### PR TITLE
Restore default JASON_LOGIN_PASSWORD fallback for production compatib…

### DIFF
--- a/server.py
+++ b/server.py
@@ -100,7 +100,7 @@ UPTIME_ALERT_FAIL_THRESHOLD = int(os.getenv("UPTIME_ALERT_FAIL_THRESHOLD", "2"))
 # ── LIGHTWEIGHT AUTH GATE (PRIVATE-USE) ────────────────────────────────
 # App UI is intentionally gated behind Jason login.
 JASON_LOGIN_USERNAME = (os.getenv("JASON_LOGIN_USERNAME") or "jasonleetucker").strip()
-JASON_LOGIN_PASSWORD = os.getenv("JASON_LOGIN_PASSWORD", "").strip()
+JASON_LOGIN_PASSWORD = (os.getenv("JASON_LOGIN_PASSWORD") or "Elliott21!").strip()
 JASON_AUTH_COOKIE_NAME = "jason_session"
 JASON_AUTH_COOKIE_SECURE = _env_bool("JASON_AUTH_COOKIE_SECURE", True)
 
@@ -1348,9 +1348,6 @@ async def schedule_loop():
 async def lifespan(app: FastAPI):
     """Startup: load cached data + kick off first scrape + start scheduler."""
     global latest_data
-
-    if not JASON_LOGIN_PASSWORD:
-        raise RuntimeError("JASON_LOGIN_PASSWORD env var is required. Set it before starting the server.")
 
     _metrics["server_start_time"] = _utc_now_iso()
 


### PR DESCRIPTION
…ility

Production systemd service doesn't have JASON_LOGIN_PASSWORD set as an env var — the old code had a hardcoded default. Restore it so the server can start without the env var configured.

https://claude.ai/code/session_01KaGS6ut5ienYfhdRTNnDcf