### PR TITLE
KTC-only rankings: integer ranks, Hill formula, sync guardrails

### DIFF
--- a/Static/js/runtime/10-rankings-and-picks.js
+++ b/Static/js/runtime/10-rankings-and-picks.js
@@ -2,6 +2,21 @@
  * Runtime Module: 10-rankings-and-picks.js
  * Rankings pipeline and pick normalization/value helpers.
  * Extracted from legacy monolithic inline runtime to keep live behavior intact.
+ *
+ * ── RANKINGS SINGLE SOURCE OF TRUTH ────────────────────────────────────────
+ * This file owns the Static-frontend copy of:
+ *   _rankToValue(rank)  — Hill-style rank-to-value formula  (see ~line 391)
+ *   KTC_LIMIT           — hard cap (500)                    (see ~line 462)
+ *   buildFullRankings() — KTC-only rank assignment          (see ~line 396)
+ *
+ * The Next.js frontend has a parallel implementation in:
+ *   frontend/lib/dynasty-data.js (rankToValue, KTC_RANK_LIMIT, computeKtcRanks)
+ *
+ * !! When changing ranking logic, formula constants, or eligibility rules !!
+ * !! you MUST update BOTH files and BOTH test suites to stay in sync.     !!
+ *   • JS tests:     frontend/__tests__/dynasty-data.test.js
+ *   • Python tests: tests/api/test_rankings_our_rank.py (cross-checks both files)
+ * ────────────────────────────────────────────────────────────────────────────
  */
 
   // ── RANKINGS TAB ──

--- a/Static/js/runtime/10-rankings-and-picks.js
+++ b/Static/js/runtime/10-rankings-and-picks.js
@@ -42,61 +42,20 @@
     const tbody = document.getElementById('rookieBody');
     if (!tbody) return;
 
-    const sortBasis = getRankingsSortBasis();
-    const showAdjCols = showRankingsLAMColumns();
-    const modeLabel = (
-      sortBasis === 'raw' ? 'Raw Market' :
-      sortBasis === 'scoring' ? 'Scoring Adjusted' :
-      sortBasis === 'scarcity' ? 'Scarcity Adjusted' :
-      'Our Value'
-    );
-    const lines = showAdjCols
-      ? ['Rank\tPlayer\tPos\tValue\tRaw\tScoring Mult\tAdjusted\tDelta']
-      : [`Rank\tPlayer\tPos\t${modeLabel}`];
-
+    // KTC-only mode: simplified 4-column copy (Our Rank, Player Name, Player Position, Our Value)
+    const lines = ['Our Rank\tPlayer Name\tPlayer Position\tOur Value'];
     let rank = 0;
     tbody.querySelectorAll('tr').forEach(row => {
       if (row.style.display === 'none' || row.classList.contains('tier-separator')) return;
       const cells = row.querySelectorAll('td');
       if (cells.length < 4) return;
       rank++;
+      const ktcRank = (row.dataset.ktcRank || row.dataset.overallModelRank || String(rank)).trim();
       const name = (cells[1]?.textContent || '').trim();
       const pos = (cells[2]?.textContent || '').trim();
+      const value = Number(row.dataset.ourValue || row.dataset.sortValue || 0);
       if (!name) return;
-
-      const raw = Number(row.dataset.rawComposite || 0);
-      const scoring = Number(row.dataset.scoringComposite || raw);
-      const adjusted = Number(row.dataset.adjustedComposite || 0);
-      const value = Number(
-        row.dataset.sortValue ||
-        (
-          sortBasis === 'raw' ? raw :
-          sortBasis === 'scoring' ? scoring :
-          sortBasis === 'scarcity' ? Number(row.dataset.scarcityComposite || scoring) :
-          adjusted
-        ) ||
-        0
-      );
-
-      if (!showAdjCols) {
-        lines.push(`${rank}\t${name}\t${pos}\t${Math.round(value)}`);
-        return;
-      }
-
-      let scoringDebug = null;
-      try { scoringDebug = JSON.parse(row.dataset.lamDebug || '{}'); } catch(_) { scoringDebug = null; }
-      const scoringMult = Number(scoringDebug?.effectiveMultiplier ?? 1);
-      const delta = Math.round(adjusted - raw);
-      lines.push([
-        rank,
-        name,
-        pos,
-        Math.round(value),
-        Math.round(raw),
-        scoringMult.toFixed(3),
-        Math.round(adjusted),
-        delta,
-      ].join('\t'));
+      lines.push(`${ktcRank}\t${name}\t${pos}\t${Math.round(value)}`);
     });
 
     const text = lines.join('\n');
@@ -425,6 +384,17 @@
     }
   }
 
+  // ── KTC-ONLY RANKINGS ──────────────────────────────────────────────────────
+  // Rank-to-value curve (mirrors src/canonical/player_valuation.py constants).
+  // A=10000, B=1.5, C=0.72, cliff_base=120. Anchored so rank-1 maps to 9999.
+  const _CURVE_A = 10000, _CURVE_B = 1.5, _CURVE_C = 0.72, _CLIFF_BASE = 120;
+  const _DISPLAY_ANCHOR = _CURVE_A / Math.pow(1 + _CURVE_B, _CURVE_C) + _CLIFF_BASE;
+  function _rankToValue(rank) {
+    if (!rank || rank <= 0) return 0;
+    const base = _CURVE_A / Math.pow(rank + _CURVE_B, _CURVE_C);
+    return Math.max(1, Math.min(9999, Math.round((base / _DISPLAY_ANCHOR) * 9999)));
+  }
+
   function buildFullRankings() {
     const tbody = document.getElementById('rookieBody');
     if (!tbody) return;
@@ -432,7 +402,7 @@
     buildRisingFallingSection();
 
     if (!loadedData || !loadedData.players) {
-      tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:var(--subtext);padding:24px;">Refresh values first to see rankings</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--subtext);padding:24px;">Refresh values first to see rankings</td></tr>';
       const mobileList = document.getElementById('rankingsMobileList');
       if (mobileList) {
         mobileList.innerHTML = '<div class="mobile-row-card"><div class="mobile-row-name">Update values first to see rankings.</div></div>';
@@ -441,14 +411,13 @@
       return;
     }
 
-    const cfg = getSiteConfig().filter(s => s.include);
     const hdr = document.getElementById('rookieHeader');
     const dataMode = getRankingsDataMode();
     const dataModeLabel = RANKINGS_DATA_MODE_LABELS[dataMode] || 'Dynasty';
     const titleEl = document.getElementById('rankingsTitle');
     if (titleEl) titleEl.textContent = `${dataModeLabel} Rankings`;
     if (dataMode !== 'dynasty') {
-      hdr.innerHTML = '<th style="width:40px">#</th><th>Player</th><th>Pos</th><th>Value</th>';
+      hdr.innerHTML = '<th style="width:40px">Our Rank</th><th>Player Name</th><th>Player Position</th><th>Our Value</th>';
       tbody.innerHTML = `<tr><td colspan="4" style="text-align:center;color:var(--subtext);padding:24px;">${dataModeLabel} mode is isolated from dynasty values. Load a dedicated ${dataModeLabel} dataset to enable these rankings.</td></tr>`;
       const mobileList = document.getElementById('rankingsMobileList');
       if (mobileList) {
@@ -458,38 +427,22 @@
       return;
     }
 
-    const sortArrow = rankingsSortAsc ? '\u2191' : '\u2193';
-    const sortBasis = getRankingsSortBasis();
-    const showAdjCols = showRankingsLAMColumns();
-    const showSourceCols = showRankingsSourceColumns();
-    const valueColLabel = (
-      sortBasis === 'raw' ? 'Raw' :
-      sortBasis === 'scoring' ? 'Scoring' :
-      sortBasis === 'scarcity' ? 'Scarcity' :
-      'Our Value'
-    );
-    hdr.innerHTML = '<th style="width:40px" title="Row number in current view">#</th><th style="width:60px" title="Decimal consensus rank aggregated from per-source ranks (stable across filters)">Our Rank</th><th title="Player or pick name">Player</th><th title="Position">Pos</th>' +
-      `<th style="min-width:85px;cursor:pointer;" title="Click to change sort mode" onclick="toggleRankingsSort()">${valueColLabel} ${sortArrow}</th>` +
-      (showAdjCols ? `
-        <th style="min-width:78px;" title="Raw market value before scoring and scarcity adjustments">Raw Market</th>
-        <th style="min-width:88px;" title="How much your league's scoring format changes this player's value (1.00 = no change)">Scoring Adj</th>
-        <th style="min-width:90px;" title="Final value after all league adjustments">Final Value</th>
-        <th style="min-width:70px;" title="How much league adjustments changed the value (Final minus Raw)">Change</th>
-      ` : '') +
-      (showSourceCols ? cfg.map(s => {
-        const site = sites.find(x => x.key === s.key);
-        const label = site ? site.label : s.key;
-        return `<th style="font-size:0.62rem;" title="Value from ${label}">${label}</th>`;
-      }).join('') : '') +
-      '<th title="Number of sources with data for this player (more sources = higher confidence)">Sources</th>';
+    // ── KTC-ONLY RANKINGS ──────────────────────────────────────────────
+    // Data source: KTC value (pdata.ktc) used to derive ordinal KTC rank.
+    // Only players with a valid KTC value AND a resolved, non-? position
+    // are eligible. No multi-source consensus blending, no fallback rank
+    // from value sort, no junk rows from other sources.
+    hdr.innerHTML =
+      '<th style="width:52px;text-align:center;" title="KTC-derived rank — 1 is best">Our Rank</th>' +
+      '<th title="Player name">Player Name</th>' +
+      '<th title="Resolved player position">Player Position</th>' +
+      '<th style="min-width:90px;" title="Our formula value derived from KTC rank (A=10000, B=1.5, C=0.72)">Our Value</th>';
 
     const posMap = loadedData.sleeper?.positions || {};
-    const canonicalCtx = getCanonicalValueContext();
     const search = (document.getElementById('rankingsSearch')?.value || '').trim().toLowerCase();
     const rookieOnly = document.getElementById('rankingsRookieToggle')?.checked;
     const myRosterOnly = document.getElementById('rankingsMyRosterToggle')?.checked;
 
-    // Get my team roster — check dropdown first, then localStorage
     let myTeamName = document.getElementById('rosterMyTeam')?.value || '';
     if (!myTeamName) myTeamName = localStorage.getItem('dynasty_my_team') || '';
     const myRosterSet = new Set();
@@ -497,108 +450,61 @@
       const myTeam = sleeperTeams.find(t => t.name === myTeamName);
       if (myTeam) myTeam.players.forEach(p => myRosterSet.add(p.toLowerCase()));
     }
-    // If checkbox is on but no team selected and no roster found, show hint
     if (myRosterOnly && myRosterSet.size === 0) {
-      const body = document.getElementById('rookieBody');
-      if (body) body.innerHTML = '<tr><td colspan="20" style="text-align:center;padding:30px;color:var(--subtext);">Select your team in the Rosters tab first, then check "My roster only".</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;padding:30px;color:var(--subtext);">Select your team in the Rosters tab first, then check "My roster only".</td></tr>';
       return;
     }
 
-    // Build once + reuse: heavy per-player canonicalization/adjustment stays cached
-    // unless data/settings/source-config changed.
-    const baseRows = getOrBuildRankingsBaseRows(cfg, canonicalCtx, posMap);
-
-    // ── Compute consensus rank from per-site values ────────────────────
-    // For each source site, convert values to ordinal ranks within that
-    // site, then aggregate via 70% median + 30% weighted mean.
-    // This produces a decimal consensus rank (e.g. 15.7) that is the
-    // primary ranking truth — NOT derived from value sorting.
-    const _SITE_WEIGHTS = {
-      ktc: 1.3, fantasyCalc: 1.0, dynastyDaddy: 1.0,
-      draftSharks: 0.9, fantasyPros: 0.8, yahoo: 0.8,
-      dynastyNerds: 0.8, idpTradeCalc: 1.0, flock: 0.8,
-      dlfSf: 0.8, dlfIdp: 0.8, dlfRsf: 0.7, dlfRidp: 0.7,
-      pffIdp: 0.7, fantasyProsIdp: 0.7, draftSharksIdp: 0.7,
-    };
-    // Rank-to-value curve (mirrors src/canonical/player_valuation.py)
-    const _CURVE_A = 10000, _CURVE_B = 1.5, _CURVE_C = 0.72, _CLIFF_BASE = 120;
-    const _DISPLAY_ANCHOR = _CURVE_A / Math.pow(1 + _CURVE_B, _CURVE_C) + _CLIFF_BASE;
-    function _rankToValue(rank) {
-      if (!rank || rank <= 0) return 0;
-      const base = _CURVE_A / Math.pow(rank + _CURVE_B, _CURVE_C);
-      return Math.max(1, Math.min(9999, Math.round((base / _DISPLAY_ANCHOR) * 9999)));
-    }
-    function _formatRank(rank) {
-      if (rank == null || !isFinite(rank)) return '—';
-      return rank % 1 !== 0 ? rank.toFixed(1) : String(Math.round(rank));
+    // ── Step 1: Build KTC-ranked player list (top 500, players only) ───
+    // Hard eligibility rules — a player must pass ALL of these to appear:
+    //   1. Not a pick token
+    //   2. Has a valid positive KTC value (pdata.ktc)
+    //   3. Has a resolved, non-empty, non-"?" position
+    //   4. Not a kicker
+    const KTC_LIMIT = 500;
+    const ktcRows = [];
+    for (const [name, pdata] of Object.entries(loadedData.players)) {
+      if (parsePickToken(name)) continue;
+      const ktcVal = Number(pdata?.ktc);
+      if (!isFinite(ktcVal) || ktcVal <= 0) continue;
+      let pos = (posMap[name] || '').toUpperCase();
+      if (!pos) pos = (getRookiePosHint(name) || '').toUpperCase();
+      // Hard guard: exclude unresolved / unknown positions
+      if (!pos || pos === '?' || pos === 'UNKNOWN') continue;
+      if (isKickerPosition(pos)) continue;
+      ktcRows.push({ name, pos, ktcVal, isRookie: isRookiePlayerName(name, pdata), pdata });
     }
 
-    // Step 1: collect site counts
-    const _siteCounts = {};
-    for (const r of baseRows) {
-      const sites = r.pData || {};
-      for (const [key, val] of Object.entries(sites)) {
-        if (key === '__canonical') continue;
-        if (isFinite(val) && val > 0) _siteCounts[key] = (_siteCounts[key] || 0) + 1;
-      }
-    }
-    const _activeSites = Object.keys(_siteCounts).filter(k => _siteCounts[k] >= 20);
+    // Sort descending by KTC value — highest value = rank 1
+    ktcRows.sort((a, b) => b.ktcVal - a.ktcVal);
 
-    // Step 2: per-site ordinal ranks
-    const _siteRanks = {};
-    for (const site of _activeSites) {
-      const withVal = baseRows
-        .filter(r => { const v = Number(r.pData?.[site]); return isFinite(v) && v > 0; })
-        .sort((a, b) => Number(b.pData[site]) - Number(a.pData[site]));
-      const rm = new Map();
-      withVal.forEach((r, i) => rm.set(r.name, i + 1));
-      _siteRanks[site] = rm;
-    }
-
-    // Step 3: consensus rank per player
-    const modelRankMap = new Map();
-    for (const r of baseRows) {
-      const ranks = [], weights = [];
-      for (const site of _activeSites) {
-        const rank = _siteRanks[site]?.get(r.name);
-        if (rank != null) { ranks.push(rank); weights.push(_SITE_WEIGHTS[site] || 0.8); }
-      }
-      if (ranks.length < 1) continue;
-      let wSum = 0, wTotal = 0;
-      for (let i = 0; i < ranks.length; i++) { wSum += ranks[i] * weights[i]; wTotal += weights[i]; }
-      const wMean = wSum / wTotal;
-      const sorted = [...ranks].sort((a, b) => a - b);
-      const mid = Math.floor(sorted.length / 2);
-      const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-      const consensus = Math.round((0.7 * median + 0.3 * wMean) * 10) / 10;
-      modelRankMap.set(r.name, consensus);
-    }
-    // Fallback for players without enough site data: assign integer rank by value
-    const _valSorted = [...baseRows].sort((a, b) => b.adjustedComposite - a.adjustedComposite);
-    _valSorted.forEach((r, i) => { if (!modelRankMap.has(r.name)) modelRankMap.set(r.name, i + 1); });
-
-    let ranked = baseRows.map(r => ({
-      ...r,
-      sortValue: getValueByRankingMode(r.adjustment, sortBasis),
-      overallModelRank: modelRankMap.get(r.name) || 0,
-      rankDerivedValue: _rankToValue(modelRankMap.get(r.name) || 0),
+    // Assign KTC rank (1-based) and compute Our Value from rank curve
+    let ranked = ktcRows.slice(0, KTC_LIMIT).map((r, i) => ({
+      name: r.name,
+      pos: r.pos,
+      ktcRank: i + 1,
+      ourValue: _rankToValue(i + 1),
+      isRookie: r.isRookie,
+      pdata: r.pdata,
+      // Compatibility fields for mobile cards and copy function
+      sortValue: _rankToValue(i + 1),
+      overallModelRank: i + 1,
     }));
-    ranked = dedupeRankingsRowsByName(ranked);
-    ranked.sort((a, b) => rankingsSortAsc ? a.sortValue - b.sortValue : b.sortValue - a.sortValue);
 
-    // Apply filters before display capping so focused views (like rookies-only)
-    // are not truncated by the global top-N list.
+    // ── Step 2: Apply filters ──────────────────────────────────────────
     if (currentRankingsFilter !== 'ALL') {
       if (currentRankingsFilter === 'OFF') {
         ranked = ranked.filter(r => OFFENSE_POSITIONS.has(r.pos));
       } else if (currentRankingsFilter === 'IDP') {
         ranked = ranked.filter(r => IDP_POSITIONS.has(r.pos));
       } else if (currentRankingsFilter === 'PICKS') {
-        ranked = ranked.filter(r => r.pos === 'PICK');
+        ranked = []; // No picks in KTC-only player rankings
       } else {
-        ranked = ranked.filter(r => r.pos === currentRankingsFilter ||
+        ranked = ranked.filter(r =>
+          r.pos === currentRankingsFilter ||
           (currentRankingsFilter === 'DL' && ['DL','DE','DT','EDGE'].includes(r.pos)) ||
-          (currentRankingsFilter === 'DB' && ['DB','CB','S'].includes(r.pos)));
+          (currentRankingsFilter === 'DB' && ['DB','CB','S'].includes(r.pos))
+        );
       }
     }
     if (rookieOnly) ranked = ranked.filter(r => r.isRookie);
@@ -608,173 +514,63 @@
     const useExtraMobileFilters = isMobileViewport();
     if (useExtraMobileFilters) {
       if (rankingsExtraFilters.picksOnly) {
-        ranked = ranked.filter(r => r.pos === 'PICK');
+        ranked = []; // No picks in KTC-only player rankings
       }
       if (rankingsExtraFilters.trendingOnly) {
         ranked = ranked.filter(r => Math.abs((window.playerTrends && window.playerTrends[r.name]) || 0) >= 2);
       }
       if (rankingsExtraFilters.ageBucket && rankingsExtraFilters.ageBucket !== 'ALL') {
         ranked = ranked.filter(r => {
-          const pdata = loadedData?.players?.[r.name] || {};
-          return getPlayerAgeBucket(r.name, pdata) === rankingsExtraFilters.ageBucket;
+          const pd = loadedData?.players?.[r.name] || {};
+          return getPlayerAgeBucket(r.name, pd) === rankingsExtraFilters.ageBucket;
         });
       }
     }
     if (search) ranked = ranked.filter(r => r.name.toLowerCase().includes(search));
 
-    const shouldApplyDisplayCap = (
-      currentRankingsFilter === 'ALL'
-      && !rookieOnly
-      && !myRosterOnly
-      && (!useExtraMobileFilters || !rankingsExtraFilters.picksOnly)
-      && (!useExtraMobileFilters || !rankingsExtraFilters.trendingOnly)
-      && (!useExtraMobileFilters || !rankingsExtraFilters.ageBucket || rankingsExtraFilters.ageBucket === 'ALL')
-      && !search
-    );
-    if (shouldApplyDisplayCap) {
-      const DISPLAY_MIN = 640;
-      const DISPLAY_CAP = 750;
-      const KTC_BASELINE_COUNT = 400;
-      const topKtcNames = getTopKtcBaselineNames(KTC_BASELINE_COUNT);
-      const rankedByName = new Map(ranked.map(r => [r.name, r]));
-      const displayRows = ranked.slice(0, Math.min(DISPLAY_MIN, ranked.length));
-      const displaySet = new Set(displayRows.map(r => r.name));
-      topKtcNames.forEach(name => {
-        if (displayRows.length >= DISPLAY_CAP) return;
-        if (!displaySet.has(name) && rankedByName.has(name)) {
-          displayRows.push(rankedByName.get(name));
-          displaySet.add(name);
-        }
-      });
-      ranked = displayRows
-        .sort((a, b) => rankingsSortAsc ? a.sortValue - b.sortValue : b.sortValue - a.sortValue)
-        .slice(0, DISPLAY_CAP);
-    }
-
-    // Safety guard: keep only one true canonical ceiling value in the active view.
-    ranked = enforceSingleCanonicalTop(ranked, sortBasis);
-
-    // Detect tier breaks using dynamic cliff detection on the active sort column.
+    // ── Step 3: Tier breaks and render ────────────────────────────────
     const tierBreaks = computeTierBreakIndexesFromOrderedValues(
-      ranked.map(r => Number(r?.sortValue))
+      ranked.map(r => Number(r.ourValue))
     );
     let tierNum = 1;
 
-    let displayRank = 0;
     ranked.forEach((r, idx) => {
       if (tierBreaks.has(idx)) {
         tierNum++;
         const sepTr = document.createElement('tr');
         sepTr.className = 'tier-separator';
-        const colSpan = (5 + (showAdjCols ? 4 : 0)) + (showSourceCols ? cfg.length : 0) + 1;
-        sepTr.innerHTML = `<td colspan="${colSpan}"><span class="tier-label">\u2500\u2500 Tier ${tierNum} \u2500\u2500</span></td>`;
+        sepTr.innerHTML = `<td colspan="4"><span class="tier-label">\u2500\u2500 Tier ${tierNum} \u2500\u2500</span></td>`;
         tbody.appendChild(sepTr);
       }
 
-      displayRank++;
       const tr = document.createElement('tr');
-      const maxDisplayValue = Math.max(1, ranked[0]?.sortValue || 1);
-      const barPct = Math.round((r.sortValue / maxDisplayValue) * 100);
-
-      const rookieBadge = r.isRookie ? '<span style="font-size:0.55rem;background:var(--amber);color:#000;padding:1px 4px;border-radius:3px;margin-left:4px;font-weight:700;">R</span>' : '';
       const posStyle = getPosStyle(r.pos);
-      const adjustment = r.adjustment || getPrecomputedAdjustmentBundle(r.sourceData, r.rawComposite, r.pos, r.name) || computeFinalAdjustedValue(r.rawComposite, r.pos, r.name);
-      const scoring = adjustment.scoring;
-      const scarcity = adjustment.scarcity;
+      const rookieBadge = r.isRookie
+        ? '<span style="font-size:0.55rem;background:var(--amber);color:#000;padding:1px 4px;border-radius:3px;margin-left:4px;font-weight:700;">R</span>'
+        : '';
+      const maxVal = Math.max(1, ranked[0]?.ourValue || 1);
+      const barPct = Math.round((r.ourValue / maxVal) * 100);
+      const escapedName = r.name.replace(/'/g, "\\'");
 
-      let cells = `
-        <td style="text-align:center;font-family:var(--mono);font-size:0.72rem;color:var(--subtext);">${displayRank}</td>
-        <td style="text-align:center;font-family:var(--mono);font-size:0.72rem;font-weight:700;color:var(--cyan);">${_formatRank(r.overallModelRank)}</td>
-        <td style="font-weight:600;font-size:0.8rem;"><a href="#" onclick="event.preventDefault();openPlayerPopup('${r.name.replace(/'/g,"\\'")}');return false;" style="color:var(--text);text-decoration:none;border-bottom:1px dotted var(--border);" onmouseover="this.style.color='var(--cyan)'" onmouseout="this.style.color='var(--text)'">${r.name}</a>${rookieBadge}</td>
-        <td><span class="ac-pos" style="${posStyle}">${r.pos || '?'}</span></td>
+      tr.innerHTML = `
+        <td style="text-align:center;font-family:var(--mono);font-size:0.82rem;font-weight:700;color:var(--cyan);">${r.ktcRank}</td>
+        <td style="font-weight:600;font-size:0.8rem;"><a href="#" onclick="event.preventDefault();openPlayerPopup('${escapedName}');return false;" style="color:var(--text);text-decoration:none;border-bottom:1px dotted var(--border);" onmouseover="this.style.color='var(--cyan)'" onmouseout="this.style.color='var(--text)'">${r.name}</a>${rookieBadge}</td>
+        <td><span class="ac-pos" style="${posStyle}">${r.pos}</span></td>
         <td style="font-family:var(--mono);font-weight:700;color:var(--cyan);position:relative;">
           <div style="position:absolute;left:0;top:0;bottom:0;width:${barPct}%;background:var(--cyan-soft);border-radius:3px;"></div>
-          <span style="position:relative;z-index:1;">${Math.round(r.sortValue).toLocaleString()}</span>
+          <span style="position:relative;z-index:1;">${r.ourValue.toLocaleString()}</span>
         </td>
       `;
-      if (showAdjCols) {
-        const diff = adjustment.valueDelta;
-        const diffColor = diff > 0 ? 'var(--green)' : diff < 0 ? 'var(--red)' : 'var(--subtext)';
-        const diffSign = diff > 0 ? '+' : '';
-        cells += `
-          <td style="font-family:var(--mono);text-align:right;">${Math.round(r.rawComposite).toLocaleString()}</td>
-          <td style="font-family:var(--mono);text-align:center;" title="raw ${Number(scoring.rawLeagueMultiplier || 1).toFixed(3)} · shrunk ${Number(scoring.shrunkLeagueMultiplier || 1).toFixed(3)} · strength ${Number(scoring.adjustmentStrength || 0).toFixed(2)}">${Number(scoring.effectiveMultiplier || 1).toFixed(3)}</td>
-          <td style="font-family:var(--mono);font-weight:700;text-align:right;color:var(--green);">${Math.round(r.adjustedComposite).toLocaleString()}</td>
-          <td style="font-family:var(--mono);text-align:right;color:${diffColor};">${diffSign}${diff.toLocaleString()}</td>
-        `;
-      }
-
-      if (showSourceCols) {
-        cfg.forEach(sc => {
-          const val = Number((r.pData || {})[sc.key]);
-          cells += `<td style="font-family:var(--mono);font-size:0.68rem;text-align:center;color:${val != null && Number.isFinite(val) ? 'var(--text)' : 'var(--border)'};">${val != null && Number.isFinite(val) ? Math.round(val).toLocaleString() : '\u2014'}</td>`;
-        });
-      }
-
-      const sc_ = Number(r.siteCount) || 0;
-      const scColor = sc_ >= 5 ? 'var(--green)' : sc_ >= 3 ? 'var(--text)' : sc_ >= 1 ? 'var(--amber)' : 'var(--subtext)';
-      const scTip = sc_ >= 5 ? 'Strong coverage' : sc_ >= 3 ? 'Good coverage' : sc_ >= 1 ? 'Limited coverage' : 'No sources';
-      cells += `<td style="text-align:center;font-family:var(--mono);font-size:0.72rem;color:${scColor};" title="${scTip}: ${sc_} source${sc_ !== 1 ? 's' : ''}">${sc_}</td>`;
-
-      tr.innerHTML = cells;
-      tr.dataset.overallModelRank = String(r.overallModelRank);
-      tr.dataset.rawComposite = String(Math.round(r.rawComposite));
-      tr.dataset.scoringComposite = String(Math.round(r.scoringComposite));
-      tr.dataset.scarcityComposite = String(Math.round(r.scarcityComposite));
-      tr.dataset.adjustedComposite = String(Math.round(r.adjustedComposite));
-      tr.dataset.sortValue = String(Math.round(r.sortValue));
-      tr.dataset.lamBucket = String(scoring.baselineBucket || '');
-      tr.dataset.lamDebug = JSON.stringify({
-        baselineBucket: scoring.baselineBucket,
-        rawCompositeValue: scoring.rawCompositeValue,
-        rawLeagueMultiplier: Number(scoring.rawLeagueMultiplier),
-        shrunkLeagueMultiplier: Number(scoring.shrunkLeagueMultiplier),
-        adjustmentStrength: Number(scoring.adjustmentStrength),
-        effectiveMultiplier: Number(scoring.effectiveMultiplier),
-        formatFitSource: scoring.formatFitSource || '',
-        formatFitConfidence: Number(scoring.formatFitConfidence ?? 0),
-        formatFitRaw: Number(scoring.formatFitRaw ?? 0),
-        formatFitShrunk: Number(scoring.formatFitShrunk ?? 0),
-        formatFitFinal: Number(scoring.formatFitFinal ?? 0),
-        formatFitPPGTest: Number(scoring.formatFitPPGTest ?? 0),
-        formatFitPPGCustom: Number(scoring.formatFitPPGCustom ?? 0),
-        formatFitProductionShare: Number(scoring.formatFitProductionShare ?? 0),
-        finalAdjustedValue: Number(adjustment.scoringAdjustedValue),
-        valueDelta: Number(adjustment.scoringAdjustedValue - adjustment.rawMarketValue),
-      });
-      tr.dataset.scarcityDebug = JSON.stringify({
-        scarcityBucket: scarcity.scarcityBucket,
-        scarcityMultiplierRaw: Number(scarcity.scarcityMultiplierRaw),
-        scarcityMultiplierEffective: Number(scarcity.scarcityMultiplierEffective),
-        scarcityStrength: Number(scarcity.scarcityStrength),
-        replacementRank: Number(scarcity.replacementRank),
-        replacementValue: Number(scarcity.replacementValue),
-        valueAboveReplacement: Number(scarcity.valueAboveReplacement),
-        finalScarcityAdjustedValue: Number(adjustment.scarcityAdjustedValue),
-        scarcityDelta: Number(adjustment.scarcityAdjustedValue - adjustment.rawMarketValue),
-      });
-      tr.dataset.adjustmentDebug = JSON.stringify({
-        rawMarketValue: Number(adjustment.rawMarketValue),
-        marketReliabilityScore: Number(adjustment.marketReliability?.score ?? 0),
-        marketReliabilityLabel: String(adjustment.marketReliability?.label || ''),
-        scoringMultiplierEffective: Number(scoring.effectiveMultiplier),
-        scoringAdjustedValue: Number(adjustment.scoringAdjustedValue),
-        scarcityAdjustedValue: Number(adjustment.scarcityAdjustedValue),
-        guardrailMin: Number(adjustment.topEndGuardrail?.minValue ?? 0),
-        guardrailMax: Number(adjustment.topEndGuardrail?.maxValue ?? 0),
-        guardrailApplied: !!adjustment.topEndGuardrail?.applied,
-        finalAdjustedValue: Number(adjustment.finalAdjustedValue),
-        valueDelta: Number(adjustment.valueDelta),
-      });
+      tr.dataset.overallModelRank = String(r.ktcRank);
+      tr.dataset.ktcRank = String(r.ktcRank);
+      tr.dataset.ourValue = String(r.ourValue);
+      tr.dataset.sortValue = String(r.ourValue);
       tbody.appendChild(tr);
     });
 
     const total = ranked.length;
-    const offCount = ranked.filter(r => OFFENSE_POSITIONS.has(r.pos)).length;
-    const idpCount = ranked.filter(r => IDP_POSITIONS.has(r.pos)).length;
-    const rookieCount = ranked.filter(r => r.isRookie).length;
     const title = document.getElementById('rankingsTitle');
-    if (title) title.textContent = `${dataModeLabel} Rankings \u2014 ${total} players (${offCount} OFF, ${idpCount} IDP, ${rookieCount} rookies) · sort=${sortBasis}`;
+    if (title) title.textContent = `${dataModeLabel} Rankings \u2014 ${total} players \u00b7 KTC-only top ${KTC_LIMIT}`;
     renderRankingsMobileCards(ranked);
     updateRankingsActiveChips();
   }
@@ -912,40 +708,21 @@
     const quickSide = getRankingsQuickTradeSide();
     const cards = top.map((r, idx) => {
       const name = r.name;
+      // pos is always resolved (unresolved rows are excluded upstream)
       const pos = r.pos || '?';
-      const val = Math.round(r.sortValue || 0);
+      // ourValue is the rank-curve value; sortValue is kept as alias
+      const val = Math.round(r.ourValue || r.sortValue || 0);
+      const ktcRank = r.ktcRank || r.overallModelRank || (idx + 1);
       const trend = (window.playerTrends && window.playerTrends[name]) || 0;
       const trendText = trend ? `${trend > 0 ? '+' : ''}${trend.toFixed(1)}%` : '—';
-      const pill = getFreshnessPillForAsset(name, r.sourceData || (loadedData?.players?.[name] || {}));
+      const pill = getFreshnessPillForAsset(name, r.pdata || r.sourceData || (loadedData?.players?.[name] || {}));
       const escaped = String(name).replace(/'/g, "\\'");
-      const rankLabel = `#${idx + 1}`;
-      const modelRankLabel = r.overallModelRank ? `Our Rank ${_formatRank(r.overallModelRank)}` : '';
-      let sourceBlock = '';
-      if (showSourceCols) {
-        const sourceCells = sourceCfg.map(sc => {
-          const raw = Number((r.pData || {})[sc.key]);
-          const hasVal = Number.isFinite(raw) && raw > 0;
-          const label = sourceLabelMap.get(sc.key) || sc.key;
-          const value = hasVal ? Math.round(raw).toLocaleString() : '—';
-          return `
-            <div class="mobile-rank-source-cell">
-              <span class="mobile-rank-source-label">${label}</span>
-              <span class="mobile-rank-source-value ${hasVal ? '' : 'empty'}">${value}</span>
-            </div>
-          `;
-        }).join('');
-        sourceBlock = `
-          <div class="mobile-rank-sources">
-            <div class="mobile-rank-source-grid">${sourceCells}</div>
-          </div>
-        `;
-      }
       return `
         <div class="mobile-row-card">
           <div class="mobile-row-head">
             <div>
               <div class="mobile-row-name">${name}</div>
-              <div class="mobile-row-sub">${rankLabel}${modelRankLabel ? ` · ${modelRankLabel}` : ''} · ${pos} · trend ${trendText}</div>
+              <div class="mobile-row-sub">Our Rank ${ktcRank} · ${pos} · trend ${trendText}</div>
             </div>
             <div class="mobile-row-value">${val > 0 ? val.toLocaleString() : '—'}</div>
           </div>
@@ -954,7 +731,6 @@
             <button class="mobile-chip-btn primary" onclick="addAssetToTrade('${quickSide}','${escaped}')">+${quickSide}</button>
             <button class="mobile-chip-btn" onclick="openPlayerPopup('${escaped}')">Open</button>
           </div>
-          ${sourceBlock}
         </div>
       `;
     }).join('');

--- a/Static/js/runtime/10-rankings-and-picks.js
+++ b/Static/js/runtime/10-rankings-and-picks.js
@@ -491,18 +491,28 @@
     // Sort descending by KTC value — highest value = rank 1
     ktcRows.sort((a, b) => b.ktcVal - a.ktcVal);
 
-    // Assign KTC rank (1-based) and compute Our Value from rank curve
-    let ranked = ktcRows.slice(0, KTC_LIMIT).map((r, i) => ({
+    // Assign KTC rank (1-based) and compute Our Value from rank curve.
+    // Prefer backend-computed ktcRank / rankDerivedValue when present in pdata
+    // (set by _compute_ktc_rankings in src/api/data_contract.py — the single
+    // source of truth for the formula).  Fall back to _rankToValue() only when
+    // the backend fields are absent (stale data, offline fallback).
+    let ranked = ktcRows.slice(0, KTC_LIMIT).map((r, i) => {
+      const backendRank  = Number(r.pdata?.ktcRank);
+      const backendValue = Number(r.pdata?.rankDerivedValue);
+      const ktcRank  = (Number.isInteger(backendRank)  && backendRank  > 0) ? backendRank  : (i + 1);
+      const ourValue = (Number.isFinite(backendValue) && backendValue > 0) ? backendValue : _rankToValue(ktcRank);
+      return {
       name: r.name,
       pos: r.pos,
-      ktcRank: i + 1,
-      ourValue: _rankToValue(i + 1),
+      ktcRank,
+      ourValue,
       isRookie: r.isRookie,
       pdata: r.pdata,
       // Compatibility fields for mobile cards and copy function
-      sortValue: _rankToValue(i + 1),
-      overallModelRank: i + 1,
-    }));
+      sortValue: ourValue,
+      overallModelRank: ktcRank,
+      }; // end return object
+    }); // end map
 
     // ── Step 2: Apply filters ──────────────────────────────────────────
     if (currentRankingsFilter !== 'ALL') {

--- a/Static/js/runtime/10-rankings-and-picks.js
+++ b/Static/js/runtime/10-rankings-and-picks.js
@@ -399,10 +399,22 @@
     }
   }
 
-  // ── KTC-ONLY RANKINGS ──────────────────────────────────────────────────────
-  // Rank-to-value curve: Hill-style, rank 1 is always exactly 9999.
-  // value = 1 + 9998 / (1 + ((rank-1)/45)^1.10)
-  // Flatter at the top, smoother decay, no post-hoc rescaling.
+  // ── KTC-ONLY RANKINGS — rank-to-value curve (OFFLINE FALLBACK ONLY) ─────────
+  // PRIMARY authority: src/api/data_contract.py (_compute_ktc_rankings) stamps
+  // ktcRank + rankDerivedValue onto the API response using rank_to_value() in
+  // src/canonical/player_valuation.py.  _rankToValue() is only invoked when
+  // the backend fields are absent (stale data, offline mode, no playersArray).
+  //
+  // MUST stay byte-for-byte identical to rankToValue() in:
+  //   frontend/lib/dynasty-data.js (~line 59)
+  //
+  // Formula: value = max(1, min(9999, round(1 + 9998 / (1 + ((rank-1)/45)^1.10))))
+  //   • rank 1  → 9999 (exact; denominator = 1)
+  //   • midpoint (rank 45) → ~5000
+  //   • Hill-style: flatter at top, longer tail than inverse-power
+  //
+  // Tests enforcing body-equality: tests/api/test_rankings_our_rank.py
+  //   TestFormulaAgreement::test_fallback_formula_bodies_are_identical
   function _rankToValue(rank) {
     if (!rank || rank <= 0) return 0;
     return Math.max(1, Math.min(9999, Math.round(1 + 9998 / (1 + Math.pow((rank - 1) / 45, 1.10)))));

--- a/Static/js/runtime/10-rankings-and-picks.js
+++ b/Static/js/runtime/10-rankings-and-picks.js
@@ -385,14 +385,12 @@
   }
 
   // ── KTC-ONLY RANKINGS ──────────────────────────────────────────────────────
-  // Rank-to-value curve (mirrors src/canonical/player_valuation.py constants).
-  // A=10000, B=1.5, C=0.72, cliff_base=120. Anchored so rank-1 maps to 9999.
-  const _CURVE_A = 10000, _CURVE_B = 1.5, _CURVE_C = 0.72, _CLIFF_BASE = 120;
-  const _DISPLAY_ANCHOR = _CURVE_A / Math.pow(1 + _CURVE_B, _CURVE_C) + _CLIFF_BASE;
+  // Rank-to-value curve: Hill-style, rank 1 is always exactly 9999.
+  // value = 1 + 9998 / (1 + ((rank-1)/45)^1.10)
+  // Flatter at the top, smoother decay, no post-hoc rescaling.
   function _rankToValue(rank) {
     if (!rank || rank <= 0) return 0;
-    const base = _CURVE_A / Math.pow(rank + _CURVE_B, _CURVE_C);
-    return Math.max(1, Math.min(9999, Math.round((base / _DISPLAY_ANCHOR) * 9999)));
+    return Math.max(1, Math.min(9999, Math.round(1 + 9998 / (1 + Math.pow((rank - 1) / 45, 1.10)))));
   }
 
   function buildFullRankings() {

--- a/frontend/__tests__/dynasty-data.test.js
+++ b/frontend/__tests__/dynasty-data.test.js
@@ -257,7 +257,8 @@ describe("buildRows", () => {
     expect(allen).toBeDefined();
     expect(allen.pos).toBe("QB");
     expect(allen.assetClass).toBe("offense");
-    expect(allen.values.full).toBe(9100);
+    // KTC-rank-first: values.full = rankDerivedValue from KTC rank (not raw finalAdjusted)
+    expect(allen.values.full).toBe(allen.rankDerivedValue > 0 ? allen.rankDerivedValue : 9100);
     expect(allen.values.raw).toBe(8500);
     expect(allen.siteCount).toBe(6);
   });
@@ -320,19 +321,20 @@ describe("buildRows", () => {
     expect(rows[0].values.full).toBe(7738);
   });
 
-  it("sorts rows by consensus rank ascending (rank-first)", () => {
-    // canonicalConsensusRank drives sort order (lower = better = first).
+  it("sorts rows by KTC rank ascending (rank-first)", () => {
+    // KTC rank is derived from canonicalSites.ktc value; higher ktc = lower rank number.
     const data = {
       playersArray: [
-        { displayName: "Low", position: "RB", canonicalConsensusRank: 30, values: { finalAdjusted: 1000, rawComposite: 1000, overall: 1000 } },
-        { displayName: "High", position: "QB", canonicalConsensusRank: 1, values: { finalAdjusted: 9000, rawComposite: 9000, overall: 9000 } },
-        { displayName: "Mid", position: "WR", canonicalConsensusRank: 15, values: { finalAdjusted: 5000, rawComposite: 5000, overall: 5000 } },
+        { displayName: "Low", position: "RB", values: { finalAdjusted: 1000, rawComposite: 1000, overall: 1000 }, canonicalSiteValues: { ktc: 1000 } },
+        { displayName: "High", position: "QB", values: { finalAdjusted: 9000, rawComposite: 9000, overall: 9000 }, canonicalSiteValues: { ktc: 9000 } },
+        { displayName: "Mid", position: "WR", values: { finalAdjusted: 5000, rawComposite: 5000, overall: 5000 }, canonicalSiteValues: { ktc: 5000 } },
       ],
     };
     const rows = buildRows(data);
-    expect(rows[0].name).toBe("High");
-    expect(rows[1].name).toBe("Mid");
-    expect(rows[2].name).toBe("Low");
+    const ranked = rows.filter((r) => r.ktcRank > 0);
+    expect(ranked[0].name).toBe("High");
+    expect(ranked[1].name).toBe("Mid");
+    expect(ranked[2].name).toBe("Low");
   });
 
   it("assigns ranks starting from 1", () => {
@@ -371,52 +373,43 @@ describe("buildRows", () => {
     expect(rows.every((r) => r.assetClass === "pick")).toBe(true);
   });
 
-  it("computes decimal consensus ranks from site values", () => {
-    // Generate 25 players with varying site values across 2 sites
+  it("computes integer KTC ranks from canonicalSites.ktc values", () => {
+    // Generate 25 players with varying KTC values
     const players = [];
     for (let i = 0; i < 25; i++) {
       players.push({
         displayName: `Player ${i}`,
         position: "QB",
         values: { finalAdjusted: 9000 - i * 100, rawComposite: 9000 - i * 100, overall: 9000 - i * 100 },
-        canonicalSiteValues: {
-          ktc: 9000 - i * 100,            // same order as full value
-          fantasyCalc: 9000 - (24 - i) * 100,  // reversed order
-        },
+        canonicalSiteValues: { ktc: 9000 - i * 100 },
       });
     }
     const rows = buildRows({ playersArray: players });
     expect(rows.length).toBe(25);
 
-    // Player 0 is rank 1 at ktc but rank 25 at fantasyCalc
+    // Player 0 has highest KTC value → should be rank 1
     const p0 = rows.find((r) => r.name === "Player 0");
-    expect(p0.computedConsensusRank).toBeDefined();
-    expect(p0.computedConsensusRank).not.toBe(1); // should NOT be clean integer 1
+    expect(p0.ktcRank).toBe(1);
+    expect(Number.isInteger(p0.ktcRank)).toBe(true); // always integer, never decimal
 
-    // Player 12 is rank 13 at both sites, so consensus should be 13
-    const p12 = rows.find((r) => r.name === "Player 12");
-    expect(p12.computedConsensusRank).toBeDefined();
-    expect(p12.computedConsensusRank).toBe(13);
+    // Player 24 has lowest KTC value → should be rank 25
+    const p24 = rows.find((r) => r.name === "Player 24");
+    expect(p24.ktcRank).toBe(25);
 
-    // At least some players should have non-integer ranks
-    const nonIntegers = rows.filter((r) => r.computedConsensusRank != null && r.computedConsensusRank % 1 !== 0);
-    expect(nonIntegers.length).toBeGreaterThan(0);
-
-    // Rank-first: values.full should be derived from consensus rank, not raw input
-    expect(p0.rankDerivedValue).toBeDefined();
-    expect(p0.rankDerivedValue).toBeGreaterThan(0);
+    // Rank-first: values.full should equal rankDerivedValue
+    expect(p0.rankDerivedValue).toBe(rankToValue(1)); // 9999
     expect(p0.values.full).toBe(p0.rankDerivedValue);
 
-    // Rows should be sorted by consensus rank ascending (rank-first)
-    for (let i = 1; i < rows.length; i++) {
-      const prev = rows[i - 1].computedConsensusRank ?? Infinity;
-      const curr = rows[i].computedConsensusRank ?? Infinity;
-      expect(prev).toBeLessThanOrEqual(curr);
+    // Rows should be sorted by ktcRank ascending
+    const rankedRows = rows.filter((r) => r.ktcRank > 0);
+    for (let i = 1; i < rankedRows.length; i++) {
+      expect(rankedRows[i].ktcRank).toBeGreaterThan(rankedRows[i - 1].ktcRank);
     }
   });
 
-  it("computes consensus ranks even when players have different site coverage", () => {
-    // 30 players across 3 sites, with some players missing from some sites
+  it("assigns KTC ranks even when players have different site coverage", () => {
+    // 30 players — KTC rank is driven solely by canonicalSites.ktc, regardless
+    // of whether other sites have data.
     const players = [];
     for (let i = 0; i < 30; i++) {
       const sites = { ktc: 9000 - i * 100 };
@@ -430,16 +423,20 @@ describe("buildRows", () => {
       });
     }
     const rows = buildRows({ playersArray: players });
-    const withRank = rows.filter((r) => r.computedConsensusRank != null);
-    expect(withRank.length).toBeGreaterThan(25);
+    const withRank = rows.filter((r) => r.ktcRank != null);
+    expect(withRank.length).toBe(30); // all 30 have ktc data
 
-    // Players with 3 sites should have more nuanced ranks than those with 1
+    // Player 0 has highest KTC value → rank 1
     const p0 = rows.find((r) => r.name === "TestPlayer 0");
+    expect(p0.ktcRank).toBe(1);
+
+    // Player 1 has next highest KTC value → rank 2
     const p1 = rows.find((r) => r.name === "TestPlayer 1");
-    expect(p0.computedConsensusRank).toBeDefined();
-    expect(p1.computedConsensusRank).toBeDefined();
-    // Different rank due to different site coverage
-    expect(p0.computedConsensusRank).not.toBe(p1.computedConsensusRank);
+    expect(p1.ktcRank).toBe(2);
+
+    // All ranks are unique integers
+    const rankSet = new Set(withRank.map((r) => r.ktcRank));
+    expect(rankSet.size).toBe(30);
   });
 
   it("returns empty array for empty data", () => {

--- a/frontend/__tests__/dynasty-data.test.js
+++ b/frontend/__tests__/dynasty-data.test.js
@@ -169,10 +169,22 @@ describe("getSiteKeys", () => {
 // ── buildRows ────────────────────────────────────────────────────────
 
 describe("rankToValue", () => {
-  it("maps rank 1 to approximately 9999", () => {
-    const v = rankToValue(1);
-    expect(v).toBeGreaterThan(9500);
-    expect(v).toBeLessThanOrEqual(9999);
+  it("maps rank 1 to exactly 9999", () => {
+    expect(rankToValue(1)).toBe(9999);
+  });
+
+  it("produces correct outputs for ranks 1–10", () => {
+    const expected = [9999, 9849, 9684, 9515, 9347, 9180, 9016, 8855, 8698, 8544];
+    expected.forEach((v, i) => expect(rankToValue(i + 1)).toBe(v));
+  });
+
+  it("produces correct checkpoint values", () => {
+    expect(rankToValue(25)).toBe(6663);
+    expect(rankToValue(50)).toBe(4766);
+    expect(rankToValue(100)).toBe(2959);
+    expect(rankToValue(200)).toBe(1632);
+    expect(rankToValue(300)).toBe(1108);
+    expect(rankToValue(500)).toBe(663);
   });
 
   it("produces monotonically decreasing values as rank increases", () => {
@@ -198,12 +210,11 @@ describe("rankToValue", () => {
     }
   });
 
-  it("uses canonical inverse-power curve (A / (rank + B)^C)", () => {
-    // Rank 50 should be meaningfully lower than rank 1 but still significant
-    const v1 = rankToValue(1);
+  it("top-50 value is meaningfully above replacement level", () => {
+    // rank-50 ≈ 4766, well above 1 and below rank-1
     const v50 = rankToValue(50);
-    expect(v50).toBeGreaterThan(v1 * 0.05);
-    expect(v50).toBeLessThan(v1 * 0.5);
+    expect(v50).toBeGreaterThan(1000);
+    expect(v50).toBeLessThan(rankToValue(1));
   });
 });
 

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -2,100 +2,29 @@
 
 import { useMemo, useState } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
-import { VALUE_MODES } from "@/lib/trade-logic";
+
+// ── KTC-ONLY RANKINGS PAGE ────────────────────────────────────────────
+// Data source: KTC trade value → ordinal KTC rank (integer, 1 = best)
+// Value:       Our rank-to-value formula applied to that exact KTC rank
+// Columns:     Our Rank | Player | Pos | Our Value  — nothing else
+// Sort:        KTC rank ascending only (no multi-source consensus, no blending)
 
 const FILTERS = [
   { key: "all", label: "All" },
   { key: "offense", label: "OFF" },
   { key: "idp", label: "IDP" },
-  { key: "pick", label: "Picks" },
 ];
 
 export default function RankingsPage() {
-  const { loading, error, source, rows, siteKeys } = useDynastyData();
+  const { loading, error, source, rows } = useDynastyData();
   const [query, setQuery] = useState("");
   const [assetFilter, setAssetFilter] = useState("all");
-  const [valueMode, setValueMode] = useState("full");
-  const [sort, setSort] = useState({ key: "ourRank", dir: "asc" });
   const [copyStatus, setCopyStatus] = useState("");
 
-  function getNumeric(v) {
-    const n = Number(v);
-    return Number.isFinite(n) ? n : null;
-  }
-
-  function getValueForSort(row, key) {
-    if (key === "name") return row.name;
-    if (key === "pos") return row.pos;
-    if (key === "ourRank") return getNumeric(modelRankMap.get(row.name));
-    if (key === "sites") return getNumeric(row.siteCount);
-    if (key === "selected") return getNumeric(row.values?.[valueMode]);
-    if (key === "raw") return getNumeric(row.values?.raw);
-    if (key === "scoring") return getNumeric(row.values?.scoring);
-    if (key === "scarcity") return getNumeric(row.values?.scarcity);
-    if (key.startsWith("site:")) {
-      const siteKey = key.slice(5);
-      return getNumeric(row.canonicalSites?.[siteKey]);
-    }
-    return null;
-  }
-
-  function isNumericSortKey(key) {
-    return key !== "name" && key !== "pos";
-  }
-
-  function compareWithEmptyLast(aVal, bVal, dir, numeric) {
-    const aEmpty = aVal == null || aVal === "";
-    const bEmpty = bVal == null || bVal === "";
-    if (aEmpty && !bEmpty) return 1;
-    if (!aEmpty && bEmpty) return -1;
-    if (aEmpty && bEmpty) return 0;
-
-    if (numeric) {
-      const cmp = Number(aVal) - Number(bVal);
-      if (cmp === 0) return 0;
-      return dir === "asc" ? cmp : -cmp;
-    }
-
-    const cmp = String(aVal).localeCompare(String(bVal), undefined, { sensitivity: "base" });
-    if (cmp === 0) return 0;
-    return dir === "asc" ? cmp : -cmp;
-  }
-
-  function nextSort(key) {
-    setSort((prev) => {
-      if (prev.key === key) {
-        return { key, dir: prev.dir === "desc" ? "asc" : "desc" };
-      }
-      const nextDir = key === "name" || key === "pos" || key === "ourRank" ? "asc" : "desc";
-      return { key, dir: nextDir };
-    });
-  }
-
-  // Stable overall model rank before any filters/sorts.
-  // Priority: canonical consensus rank (from pipeline) > computed consensus
-  // rank (decimal, from per-site rank blending in buildRows) > integer fallback.
-  const modelRankMap = useMemo(() => {
-    const map = new Map();
-
-    rows.forEach((r) => {
-      const rank = r.canonicalConsensusRank ?? r.computedConsensusRank;
-      if (rank != null && Number.isFinite(rank) && rank > 0) {
-        map.set(r.name, rank);
-      }
-    });
-
-    // Integer fallback for rows without a consensus rank
-    const sorted = [...rows].sort((a, b) => b.values.full - a.values.full);
-    sorted.forEach((r, i) => {
-      if (!map.has(r.name)) map.set(r.name, i + 1);
-    });
-    return map;
-  }, [rows]);
-
-  const filtered = useMemo(() => {
+  // Only show KTC-ranked players (ktcRank > 0, position resolved, no picks)
+  const ranked = useMemo(() => {
     const q = query.trim().toLowerCase();
-    let list = rows;
+    let list = rows.filter((r) => r.ktcRank > 0);
 
     if (assetFilter !== "all") {
       list = list.filter((r) => r.assetClass === assetFilter);
@@ -104,109 +33,23 @@ export default function RankingsPage() {
       list = list.filter((r) => r.name.toLowerCase().includes(q));
     }
 
-    return [...list].sort((a, b) => {
-      const av = getValueForSort(a, sort.key);
-      const bv = getValueForSort(b, sort.key);
-      const cmp = compareWithEmptyLast(av, bv, sort.dir, isNumericSortKey(sort.key));
-      if (cmp !== 0) return cmp;
-      return a.name.localeCompare(b.name);
-    });
-  }, [rows, assetFilter, query, sort.key, sort.dir, valueMode, modelRankMap]);
-
-  const tierStarts = useMemo(() => {
-    const starts = new Set([0]);
-    if (!filtered.length) return starts;
-    const key = sort.key;
-    const numeric = isNumericSortKey(key);
-
-    if (!numeric) {
-      const chunk = 24;
-      for (let i = chunk; i < filtered.length; i += chunk) starts.add(i);
-      return starts;
-    }
-
-    const values = filtered
-      .map((r) => getValueForSort(r, key))
-      .filter((v) => v != null)
-      .map((v) => Number(v));
-
-    if (values.length < 3) return starts;
-
-    const gaps = [];
-    for (let i = 1; i < values.length; i++) {
-      gaps.push(Math.abs(values[i - 1] - values[i]));
-    }
-    const sortedGaps = [...gaps].sort((a, b) => a - b);
-    const medianGap = sortedGaps[Math.floor(sortedGaps.length / 2)] || 0;
-    const gapTrigger = Math.max(40, medianGap * 2.2);
-    const hardTierSize = 28;
-
-    for (let i = 1; i < filtered.length; i++) {
-      const prevVal = getValueForSort(filtered[i - 1], key);
-      const curVal = getValueForSort(filtered[i], key);
-      if (prevVal == null || curVal == null) continue;
-      const gap = Math.abs(Number(prevVal) - Number(curVal));
-      if (gap >= gapTrigger || i % hardTierSize === 0) starts.add(i);
-    }
-
-    return starts;
-  }, [filtered, sort.key, sort.dir, valueMode]);
+    // Sort strictly by KTC rank ascending — no other sort basis
+    return [...list].sort((a, b) => a.ktcRank - b.ktcRank);
+  }, [rows, assetFilter, query]);
 
   async function copyValues() {
-    const headers = [
-      "#",
-      "Our Rank",
-      "Player",
-      "Pos",
-      VALUE_MODES.find((m) => m.key === valueMode)?.label || "Value",
-      "Raw",
-      "Scoring",
-      "Scarcity",
-      "Sites",
-      ...siteKeys,
-    ];
-    const lines = [headers.join(",")];
-
-    filtered.forEach((row, idx) => {
-      const ourRank = modelRankMap.get(row.name);
-      const cols = [
-        String(idx + 1),
-        ourRank != null ? (ourRank % 1 !== 0 ? ourRank.toFixed(1) : String(Math.round(ourRank))) : "",
-        `"${row.name.replace(/"/g, '""')}"`,
-        row.pos,
-        String(Math.round(Number(row.values?.[valueMode] || 0))),
-        String(Math.round(Number(row.values?.raw || 0))),
-        String(Math.round(Number(row.values?.scoring || 0))),
-        String(Math.round(Number(row.values?.scarcity || 0))),
-        String(Math.round(Number(row.siteCount || 0))),
-      ];
-      siteKeys.forEach((s) => {
-        const v = Number(row.canonicalSites?.[s]);
-        cols.push(Number.isFinite(v) && v > 0 ? String(Math.round(v)) : "");
-      });
-      lines.push(cols.join(","));
+    const lines = ["Our Rank\tPlayer\tPos\tOur Value"];
+    ranked.forEach((row) => {
+      lines.push(`${row.ktcRank}\t${row.name}\t${row.pos}\t${Math.round(row.rankDerivedValue || row.values.full)}`);
     });
-
     try {
       await navigator.clipboard.writeText(lines.join("\n"));
-      setCopyStatus(`Copied ${filtered.length.toLocaleString()} rows`);
+      setCopyStatus(`Copied ${ranked.length.toLocaleString()} rows`);
       setTimeout(() => setCopyStatus(""), 1800);
     } catch {
       setCopyStatus("Copy failed");
       setTimeout(() => setCopyStatus(""), 1800);
     }
-  }
-
-  function formatRank(rank) {
-    if (rank == null || !Number.isFinite(rank)) return "—";
-    if (rank % 1 !== 0) return rank.toFixed(1);
-    return String(Math.round(rank));
-  }
-
-  function thLabel(label, key) {
-    const active = sort.key === key;
-    const arrow = active ? (sort.dir === "desc" ? " \u2193" : " \u2191") : "";
-    return `${label}${arrow}`;
   }
 
   return (
@@ -215,7 +58,7 @@ export default function RankingsPage() {
         <div>
           <h1 style={{ margin: 0 }}>Rankings</h1>
           <p className="muted" style={{ marginTop: 4, marginBottom: 0 }}>
-            Source: {source || "unknown"} · {filtered.length.toLocaleString()} shown / {rows.length.toLocaleString()} total
+            KTC-only · {ranked.length.toLocaleString()} shown · Source: {source || "unknown"}
           </p>
         </div>
       </div>
@@ -228,7 +71,7 @@ export default function RankingsPage() {
           <div className="row" style={{ marginTop: 14 }}>
             <input
               className="input"
-              placeholder="Search player or pick"
+              placeholder="Search player"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               style={{ minWidth: 220 }}
@@ -237,12 +80,6 @@ export default function RankingsPage() {
             <select className="select" value={assetFilter} onChange={(e) => setAssetFilter(e.target.value)}>
               {FILTERS.map((f) => (
                 <option key={f.key} value={f.key}>{f.label}</option>
-              ))}
-            </select>
-
-            <select className="select" value={valueMode} onChange={(e) => setValueMode(e.target.value)}>
-              {VALUE_MODES.map((m) => (
-                <option key={m.key} value={m.key}>{m.label}</option>
               ))}
             </select>
 
@@ -256,42 +93,23 @@ export default function RankingsPage() {
             <table>
               <thead>
                 <tr>
-                  <th onClick={() => nextSort("selected")}>{thLabel("#", "selected")}</th>
-                  <th onClick={() => nextSort("ourRank")} title="Consensus rank across sources (weighted median/mean blend)">{thLabel("Our Rank", "ourRank")}</th>
-                  <th className="sticky-name" onClick={() => nextSort("name")}>{thLabel("Player", "name")}</th>
-                  <th onClick={() => nextSort("pos")}>{thLabel("Pos", "pos")}</th>
-                  <th onClick={() => nextSort("selected")}>{thLabel(VALUE_MODES.find((m) => m.key === valueMode)?.label || "Value", "selected")}</th>
-                  <th onClick={() => nextSort("raw")}>{thLabel("Raw", "raw")}</th>
-                  <th onClick={() => nextSort("scoring")}>{thLabel("Score", "scoring")}</th>
-                  <th onClick={() => nextSort("scarcity")}>{thLabel("Scarcity", "scarcity")}</th>
-                  <th onClick={() => nextSort("sites")}>{thLabel("Sites", "sites")}</th>
-                  {siteKeys.map((s) => (
-                    <th key={s} onClick={() => nextSort(`site:${s}`)}>{thLabel(s, `site:${s}`)}</th>
-                  ))}
+                  <th style={{ width: 64, textAlign: "center" }} title="KTC rank — 1 is best">Our Rank</th>
+                  <th>Player</th>
+                  <th>Pos</th>
+                  <th title="Our formula value derived from KTC rank">Our Value</th>
                 </tr>
               </thead>
               <tbody>
-                {filtered.map((row, i) => (
+                {ranked.map((row) => (
                   <tr key={row.name}>
-                    <td>{i + 1}</td>
-                    <td style={{ fontWeight: 700, color: "var(--cyan)", fontFamily: "var(--mono, monospace)", textAlign: "center" }}>{formatRank(modelRankMap.get(row.name))}</td>
-                    <td className="sticky-name">
-                      {tierStarts.has(i) ? (
-                        <div className="tier-label">Tier {Array.from(tierStarts).filter((x) => x <= i).length}</div>
-                      ) : null}
-                      <div style={{ fontWeight: 600 }}>{row.name}</div>
-                      <div className="muted" style={{ fontSize: "0.72rem" }}>{row.marketLabel || ""}</div>
+                    <td style={{ textAlign: "center", fontWeight: 700, color: "var(--cyan)", fontFamily: "var(--mono, monospace)" }}>
+                      {row.ktcRank}
                     </td>
+                    <td style={{ fontWeight: 600 }}>{row.name}</td>
                     <td><span className="badge">{row.pos}</span></td>
-                    <td style={{ fontWeight: 700, color: "var(--cyan)" }}>{row.values[valueMode]?.toLocaleString?.() ?? row.values[valueMode]}</td>
-                    <td>{row.values.raw.toLocaleString()}</td>
-                    <td>{row.values.scoring.toLocaleString()}</td>
-                    <td>{row.values.scarcity.toLocaleString()}</td>
-                    <td>{row.siteCount}</td>
-                    {siteKeys.map((s) => {
-                      const v = Number(row.canonicalSites?.[s]);
-                      return <td key={`${row.name}-${s}`}>{Number.isFinite(v) && v > 0 ? Math.round(v).toLocaleString() : "-"}</td>;
-                    })}
+                    <td style={{ fontWeight: 700, color: "var(--cyan)", fontFamily: "var(--mono, monospace)" }}>
+                      {Math.round(row.rankDerivedValue || row.values.full).toLocaleString()}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -47,24 +47,17 @@ const SITE_WEIGHTS = {
   pffIdp: 0.7, fantasyProsIdp: 0.7, draftSharksIdp: 0.7,
 };
 
-// ── Rank-to-value curve (mirrors src/canonical/player_valuation.py) ──
-// Formula: base = A / (rank + B)^C
-const CURVE_A = 10000.0;
-const CURVE_B = 1.5;
-const CURVE_C = 0.72;
-const CLIFF_BASE = 120.0;
-// Display anchor: theoretical max raw value (rank-1 base + one cliff).
-// Computed from hyperparameters only, so it's stable across data refreshes.
-const DISPLAY_ANCHOR = CURVE_A / Math.pow(1 + CURVE_B, CURVE_C) + CLIFF_BASE;
+// ── Rank-to-value curve: Hill-style, rank 1 is always exactly 9999 ──
+// value = 1 + 9998 / (1 + ((rank-1)/45)^1.10)
+// Flatter at the top than the old inverse-power curve, smoother mid-decay.
 
 /**
- * Convert a consensus rank to a display value (1–9999 scale).
- * Uses the same inverse-power curve as the canonical backend pipeline.
+ * Convert a rank to a display value (1–9999 scale).
+ * Hill-style curve: rank 1 → 9999, rank 50 → ~4766, rank 500 → ~663.
  */
 export function rankToValue(rank) {
   if (rank == null || !Number.isFinite(rank) || rank <= 0) return 0;
-  const base = CURVE_A / Math.pow(rank + CURVE_B, CURVE_C);
-  return Math.max(1, Math.min(9999, Math.round((base / DISPLAY_ANCHOR) * 9999)));
+  return Math.max(1, Math.min(9999, Math.round(1 + 9998 / (1 + Math.pow((rank - 1) / 45, 1.10)))));
 }
 
 /**

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -53,9 +53,22 @@ export function getSiteKeys(data) {
   return sites.map((s) => String(s?.key || "")).filter(Boolean);
 }
 
-// ── Rank-to-value curve ───────────────────────────────────────────────
-// Hill-style formula: rank 1 always = 9999.
-// value = max(1, min(9999, round(1 + 9998 / (1 + ((rank-1)/45)^1.10))))
+// ── Rank-to-value curve (OFFLINE FALLBACK ONLY) ───────────────────────
+// PRIMARY authority: src/api/data_contract.py (_compute_ktc_rankings) stamps
+// ktcRank + rankDerivedValue onto the API response using rank_to_value() in
+// src/canonical/player_valuation.py.  This function is only invoked when the
+// backend fields are absent (stale data, offline mode, unit tests).
+//
+// MUST stay byte-for-byte identical to _rankToValue() in:
+//   Static/js/runtime/10-rankings-and-picks.js (~line 407)
+//
+// Formula: value = max(1, min(9999, round(1 + 9998 / (1 + ((rank-1)/45)^1.10))))
+//   • rank 1  → 9999 (exact; denominator = 1)
+//   • midpoint (rank 45) → ~5000
+//   • Hill-style: flatter at top, longer tail than inverse-power
+//
+// Tests enforcing body-equality: tests/api/test_rankings_our_rank.py
+//   TestFormulaAgreement::test_fallback_formula_bodies_are_identical
 export function rankToValue(rank) {
   if (!rank || rank <= 0) return 0;
   return Math.max(1, Math.min(9999, Math.round(1 + 9998 / (1 + Math.pow((rank - 1) / 45, 1.10)))));
@@ -135,6 +148,9 @@ export function buildRows(data) {
           scarcity: Math.round(values.scarcity),
           full: Math.round(values.full),
         },
+        // siteCount: intentionally preserved — used by trade calculator and
+        // other non-rankings views.  Rankings pages hide this column, but the
+        // field must remain on the row contract.  Do NOT remove it.
         siteCount: Number(player.sourceCount || 0),
         confidence: Number(player.marketConfidence ?? 0),
         marketLabel: "",
@@ -175,6 +191,9 @@ export function buildRows(data) {
       pos: pos || "?",
       assetClass: classifyPos(pos || "?"),
       values,
+      // siteCount: intentionally preserved — used by trade calculator and
+      // other non-rankings views.  Rankings pages hide this column, but the
+      // field must remain on the row contract.  Do NOT remove it.
       siteCount: Number(player._sites || 0),
       confidence: Number(player._marketReliabilityScore ?? 0),
       marketLabel: String(player._marketReliabilityLabel || ""),

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1,3 +1,18 @@
+// ── RANKINGS SINGLE SOURCE OF TRUTH ──────────────────────────────────────────
+// This file (frontend/lib/dynasty-data.js) is the canonical home for:
+//   • rankToValue()     — Hill-style rank-to-value formula
+//   • computeKtcRanks() — KTC-only rank assignment (top 500, integer ranks)
+//   • KTC_RANK_LIMIT    — hard cap (500)
+//
+// The Static legacy frontend has a parallel implementation in:
+//   Static/js/runtime/10-rankings-and-picks.js (_rankToValue, KTC_LIMIT, buildFullRankings)
+//
+// !! When changing ranking logic, formula constants, or eligibility rules !!
+// !! you MUST update BOTH files and BOTH test suites to stay in sync.     !!
+//   • JS tests:     frontend/__tests__/dynasty-data.test.js
+//   • Python tests: tests/api/test_rankings_our_rank.py (cross-checks both files)
+// ─────────────────────────────────────────────────────────────────────────────
+
 const OFFENSE = new Set(["QB", "RB", "WR", "TE"]);
 const IDP = new Set(["DL", "DE", "DT", "LB", "DB", "CB", "S", "EDGE"]);
 
@@ -37,16 +52,6 @@ export function getSiteKeys(data) {
   const sites = Array.isArray(data?.sites) ? data.sites : [];
   return sites.map((s) => String(s?.key || "")).filter(Boolean);
 }
-
-// Site weights for consensus rank (mirrors scraper SITE_WEIGHTS).
-// Kept for reference; not used in KTC-only rankings mode.
-const _LEGACY_SITE_WEIGHTS = {
-  ktc: 1.3, fantasyCalc: 1.0, dynastyDaddy: 1.0,
-  draftSharks: 0.9, fantasyPros: 0.8, yahoo: 0.8,
-  dynastyNerds: 0.8, idpTradeCalc: 1.0, flock: 0.8,
-  dlfSf: 0.8, dlfIdp: 0.8, dlfRsf: 0.7, dlfRidp: 0.7,
-  pffIdp: 0.7, fantasyProsIdp: 0.7, draftSharksIdp: 0.7,
-};
 
 // ── Rank-to-value curve ───────────────────────────────────────────────
 // Hill-style formula: rank 1 always = 9999.

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -39,7 +39,8 @@ export function getSiteKeys(data) {
 }
 
 // Site weights for consensus rank (mirrors scraper SITE_WEIGHTS).
-const SITE_WEIGHTS = {
+// Kept for reference; not used in KTC-only rankings mode.
+const _LEGACY_SITE_WEIGHTS = {
   ktc: 1.3, fantasyCalc: 1.0, dynastyDaddy: 1.0,
   draftSharks: 0.9, fantasyPros: 0.8, yahoo: 0.8,
   dynastyNerds: 0.8, idpTradeCalc: 1.0, flock: 0.8,
@@ -47,100 +48,37 @@ const SITE_WEIGHTS = {
   pffIdp: 0.7, fantasyProsIdp: 0.7, draftSharksIdp: 0.7,
 };
 
-// ── Rank-to-value curve: Hill-style, rank 1 is always exactly 9999 ──
-// value = 1 + 9998 / (1 + ((rank-1)/45)^1.10)
-// Flatter at the top than the old inverse-power curve, smoother mid-decay.
-
-/**
- * Convert a rank to a display value (1–9999 scale).
- * Hill-style curve: rank 1 → 9999, rank 50 → ~4766, rank 500 → ~663.
- */
+// ── Rank-to-value curve ───────────────────────────────────────────────
+// Hill-style formula: rank 1 always = 9999.
+// value = max(1, min(9999, round(1 + 9998 / (1 + ((rank-1)/45)^1.10))))
 export function rankToValue(rank) {
-  if (rank == null || !Number.isFinite(rank) || rank <= 0) return 0;
+  if (!rank || rank <= 0) return 0;
   return Math.max(1, Math.min(9999, Math.round(1 + 9998 / (1 + Math.pow((rank - 1) / 45, 1.10)))));
 }
 
-/**
- * Compute a decimal consensus rank for each row from per-site values.
- *
- * Pipeline:
- *   1. For each source site, convert site values → site-internal ordinal ranks
- *   2. Aggregate per-site ranks → consensus rank (70% median + 30% weighted mean)
- *   3. Convert consensus rank → canonical value via rankToValue()
- *
- * Sets on each row:
- *   - computedConsensusRank  (decimal, e.g. 15.7)
- *   - rankSourceCount        (how many sites contributed)
- *   - rankMedian / rankMean  (diagnostic)
- *   - rankDerivedValue       (value from rank-to-value curve)
- */
-function computeConsensusRanks(rows) {
-  // Collect all site keys that have meaningful data
-  const siteCounts = {};
-  for (const row of rows) {
-    for (const [key, val] of Object.entries(row.canonicalSites || {})) {
-      if (Number.isFinite(Number(val)) && Number(val) > 0) {
-        siteCounts[key] = (siteCounts[key] || 0) + 1;
-      }
-    }
-  }
-  // Only use sites with at least 20 players to avoid sparse-data noise
-  const activeSites = Object.keys(siteCounts).filter((k) => siteCounts[k] >= 20);
-  if (activeSites.length === 0) return;
+// ── KTC-only rank assignment ──────────────────────────────────────────
+// Assigns integer ktcRank to the top KTC_RANK_LIMIT players sorted by
+// KTC trade value descending.  Only players with:
+//   • a valid positive canonicalSites.ktc value
+//   • a resolved, non-"?" position (picks excluded)
+// are eligible.  Players outside the limit get ktcRank = null.
+const KTC_RANK_LIMIT = 500;
 
-  // For each site, sort rows and assign ranks
-  const siteRanks = {}; // siteRanks[siteName] = Map<rowName, rank>
-  for (const site of activeSites) {
-    const withVal = rows
-      .filter((r) => {
-        const v = Number(r.canonicalSites?.[site]);
-        return Number.isFinite(v) && v > 0;
-      })
-      .sort((a, b) => Number(b.canonicalSites[site]) - Number(a.canonicalSites[site]));
+function computeKtcRanks(rows) {
+  const eligible = rows.filter((r) => {
+    if (!r.pos || r.pos === "?" || r.pos === "PICK") return false;
+    const ktcVal = Number(r.canonicalSites?.ktc);
+    return Number.isFinite(ktcVal) && ktcVal > 0;
+  });
 
-    const rankMap = new Map();
-    for (let i = 0; i < withVal.length; i++) {
-      rankMap.set(withVal[i].name, i + 1);
-    }
-    siteRanks[site] = rankMap;
-  }
+  // Sort by KTC value descending (highest value = rank 1)
+  eligible.sort((a, b) => Number(b.canonicalSites.ktc) - Number(a.canonicalSites.ktc));
 
-  // For each row, compute consensus rank from per-site ranks
-  for (const row of rows) {
-    const ranks = [];
-    const weights = [];
-    for (const site of activeSites) {
-      const rank = siteRanks[site]?.get(row.name);
-      if (rank != null) {
-        ranks.push(rank);
-        weights.push(SITE_WEIGHTS[site] || 0.8);
-      }
-    }
-    if (ranks.length < 1) continue;
-
-    // Weighted mean
-    let wSum = 0, wTotal = 0;
-    for (let i = 0; i < ranks.length; i++) {
-      wSum += ranks[i] * weights[i];
-      wTotal += weights[i];
-    }
-    const wMean = wSum / wTotal;
-
-    // Median
-    const sorted = [...ranks].sort((a, b) => a - b);
-    const mid = Math.floor(sorted.length / 2);
-    const median = sorted.length % 2 === 0
-      ? (sorted[mid - 1] + sorted[mid]) / 2
-      : sorted[mid];
-
-    // Blend: 70% median, 30% weighted mean
-    const consensus = Math.round((0.7 * median + 0.3 * wMean) * 10) / 10;
-    row.computedConsensusRank = consensus;
-    row.rankSourceCount = ranks.length;
-    row.rankMedian = Math.round(median * 10) / 10;
-    row.rankMean = Math.round(wMean * 10) / 10;
-    row.rankDerivedValue = rankToValue(consensus);
-  }
+  // Assign integer rank and compute our value for top N
+  eligible.slice(0, KTC_RANK_LIMIT).forEach((r, i) => {
+    r.ktcRank = i + 1;
+    r.rankDerivedValue = rankToValue(i + 1);
+  });
 }
 
 export function buildRows(data) {
@@ -196,15 +134,17 @@ export function buildRows(data) {
       });
     }
 
-    computeConsensusRanks(rows);
-    // Rank-first: override full value with rank-derived value for ranked rows.
+    computeKtcRanks(rows);
+    // KTC-rank-first: override full value with rank-derived value for ranked rows.
     for (const r of rows) {
       if (r.rankDerivedValue > 0) r.values.full = r.rankDerivedValue;
     }
+    // Sort: KTC-ranked players first (by ktcRank ascending), then unranked by value.
     rows.sort((a, b) => {
-      // Primary: consensus rank ascending (lower = better).
-      const ra = r => r.computedConsensusRank ?? r.canonicalConsensusRank ?? Infinity;
-      return ra(a) - ra(b);
+      const ra = a.ktcRank ?? Infinity;
+      const rb = b.ktcRank ?? Infinity;
+      if (ra !== rb) return ra - rb;
+      return (b.values.full || 0) - (a.values.full || 0);
     });
     rows.forEach((r, i) => { r.rank = i + 1; });
     return rows;
@@ -234,13 +174,15 @@ export function buildRows(data) {
     });
   }
 
-  computeConsensusRanks(rows);
+  computeKtcRanks(rows);
   for (const r of rows) {
     if (r.rankDerivedValue > 0) r.values.full = r.rankDerivedValue;
   }
   rows.sort((a, b) => {
-    const ra = r => r.computedConsensusRank ?? r.canonicalConsensusRank ?? Infinity;
-    return ra(a) - ra(b);
+    const ra = a.ktcRank ?? Infinity;
+    const rb = b.ktcRank ?? Infinity;
+    if (ra !== rb) return ra - rb;
+    return (b.values.full || 0) - (a.values.full || 0);
   });
   rows.forEach((r, i) => { r.rank = i + 1; });
   return rows;

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -79,10 +79,16 @@ function computeKtcRanks(rows) {
   // Sort by KTC value descending (highest value = rank 1)
   eligible.sort((a, b) => Number(b.canonicalSites.ktc) - Number(a.canonicalSites.ktc));
 
-  // Assign integer rank and compute our value for top N
+  // Assign integer rank and compute our value for top N.
+  // Prefer backend-computed ktcRank / rankDerivedValue when present in r.raw
+  // (set by _compute_ktc_rankings in src/api/data_contract.py — the single
+  // source of truth for the formula).  Fall back to rankToValue() only when
+  // the backend fields are absent (stale data, offline fallback).
   eligible.slice(0, KTC_RANK_LIMIT).forEach((r, i) => {
-    r.ktcRank = i + 1;
-    r.rankDerivedValue = rankToValue(i + 1);
+    const backendRank  = Number(r.raw?.ktcRank);
+    const backendValue = Number(r.raw?.rankDerivedValue);
+    r.ktcRank = (Number.isInteger(backendRank) && backendRank > 0) ? backendRank : (i + 1);
+    r.rankDerivedValue = (Number.isFinite(backendValue) && backendValue > 0) ? backendValue : rankToValue(r.ktcRank);
   });
 }
 

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -10,6 +10,67 @@ from src.data_models.contracts import utc_now_iso
 
 CONTRACT_VERSION = "2026-03-10.v2"
 
+# ── KTC-only rankings: single source of truth ─────────────────────────────────
+# rank_to_value() is imported from src.canonical.player_valuation — that module
+# is the ONE authoritative formula implementation.
+#
+# KTC_RANK_LIMIT is the hard player cap.  It must match both JS frontends:
+#   • frontend/lib/dynasty-data.js           → KTC_RANK_LIMIT = 500
+#   • Static/js/runtime/10-rankings-and-picks.js → KTC_LIMIT = 500
+#
+# _compute_ktc_rankings() stamps ktcRank + rankDerivedValue onto every
+# playersArray entry (and the legacy players dict) so both frontends can
+# consume pre-computed values and only fall back to client-side computation
+# when these fields are absent (e.g. stale offline data without this field).
+# ─────────────────────────────────────────────────────────────────────────────
+KTC_RANK_LIMIT: int = 500
+_KICKER_POSITIONS = {"K", "PK"}
+
+
+def _compute_ktc_rankings(
+    players_array: list[dict[str, Any]],
+    players_by_name: dict[str, Any],
+) -> None:
+    """Stamp ktcRank and rankDerivedValue onto each eligible playersArray entry.
+
+    Eligibility (matches both JS frontends exactly):
+      • position must be non-empty, not "?", not "PICK", not a kicker
+      • canonicalSiteValues.ktc must be a finite positive number
+
+    Ranks are integers 1..KTC_RANK_LIMIT (top 500 by KTC value descending).
+    rank_to_value() is the authoritative formula — no duplication here.
+
+    Also writes ktcRank / rankDerivedValue back into the legacy players dict so
+    the Static frontend can read them as pdata.ktcRank / pdata.rankDerivedValue.
+    """
+    from src.canonical.player_valuation import rank_to_value  # noqa: PLC0415
+
+    eligible: list[tuple[float, dict[str, Any]]] = []
+    for row in players_array:
+        pos = str(row.get("position") or "").strip().upper()
+        if not pos or pos in {"?", "PICK"} or pos in _KICKER_POSITIONS:
+            continue
+        ktc_raw = (row.get("canonicalSiteValues") or {}).get("ktc")
+        ktc_val = _safe_num(ktc_raw)
+        if ktc_val is None or ktc_val <= 0:
+            continue
+        eligible.append((ktc_val, row))
+
+    eligible.sort(key=lambda t: -t[0])
+
+    for i, (_, row) in enumerate(eligible[:KTC_RANK_LIMIT]):
+        rank = i + 1
+        derived = int(rank_to_value(rank))
+        row["ktcRank"] = rank
+        row["rankDerivedValue"] = derived
+        # Mirror into legacy players dict so Static runtime reads consistent values.
+        legacy_ref = row.get("legacyRef")
+        if legacy_ref and legacy_ref in players_by_name:
+            pdata = players_by_name[legacy_ref]
+            if isinstance(pdata, dict):
+                pdata["ktcRank"] = rank
+                pdata["rankDerivedValue"] = derived
+
 REQUIRED_TOP_LEVEL_KEYS = {
     "contractVersion",
     "generatedAt",
@@ -251,6 +312,11 @@ def build_api_data_contract(
         if not isinstance(p_data, dict):
             continue
         players_array.append(_derive_player_row(str(name), p_data, pos_map, site_keys))
+
+    # Compute KTC-only integer ranks and rank-derived values.
+    # This is the single source of truth for ktcRank / rankDerivedValue.
+    # Both JS frontends prefer these fields over client-side computation.
+    _compute_ktc_rankings(players_array, players_by_name)
 
     data_source = data_source or {}
     contract_payload: dict[str, Any] = {

--- a/src/canonical/player_valuation.py
+++ b/src/canonical/player_valuation.py
@@ -41,10 +41,11 @@ TIER_GAP_WINDOW: int = 7           # rolling-median window (each side)
 TIER_GAP_THRESHOLD: float = 2.0    # gap_score above this triggers a break
 TIER_MIN_SIZE: int = 3             # minimum players in a tier before allowing split
 
-# Step 3: Base value curve  —  base_value = A / (consensus_rank + B)^C
-CURVE_A: float = 10_000.0          # scale (controls max value magnitude)
-CURVE_B: float = 1.5               # shift (softens rank-1 singularity)
-CURVE_C: float = 0.72              # decay (steepness of drop-off)
+# Step 3: Base value curve — Hill-style, rank 1 always = 9999
+# value = 1 + 9998 / (1 + ((rank - 1) / 45)^1.10)
+# Mirrors the JS _rankToValue in Static/js/runtime/10-rankings-and-picks.js
+HILL_MIDPOINT: float = 45.0        # rank at which value ≈ 5000
+HILL_SLOPE: float = 1.10           # controls steepness of decay
 
 # Step 4: Tier cliff injection
 CLIFF_BASE_POINTS: float = 120.0   # base cliff size in value units
@@ -250,24 +251,37 @@ def detect_tiers(
 # STEP 3 — BASE VALUE CURVE
 # ══════════════════════════════════════════════════════════════════════
 
-def base_value_curve(
-    consensus_rank: float,
+def rank_to_value(
+    rank: float,
     *,
-    A: float = CURVE_A,
-    B: float = CURVE_B,
-    C: float = CURVE_C,
-) -> float:
-    """Map consensus rank to a base value using an inverse-power curve.
+    midpoint: float = HILL_MIDPOINT,
+    slope: float = HILL_SLOPE,
+) -> int:
+    """Convert a rank to a display value on the 1–9999 scale.
 
-    Formula:  base = A / (consensus_rank + B)^C
+    Hill-style formula: value = 1 + 9998 / (1 + ((rank - 1) / midpoint)^slope)
 
     Properties:
-        - Monotonically decreasing
-        - Very steep near rank 1 (elite premium)
-        - Moderate slope through mid-ranks (starter range)
-        - Flattened tail (replacement-level compression)
+        - Rank 1 always returns exactly 9999 (denominator = 1 when rank = 1)
+        - Flatter at the elite top than the old inverse-power curve
+        - Smoother decay through the mid-ranks
+        - Long tail preserved at low end
+        - No post-hoc anchor/scaling that could drift between runs
     """
-    return A / ((consensus_rank + B) ** C)
+    if rank is None or rank <= 0:
+        return 0
+    # Clamp to >= 1: consensus ranks below 1 map to 9999 (above "1st place").
+    # Also prevents negative base in fractional-exponent computation.
+    effective_rank = max(1.0, float(rank))
+    raw = 1.0 + 9998.0 / (1.0 + ((effective_rank - 1.0) / midpoint) ** slope)
+    return max(DISPLAY_SCALE_MIN, min(DISPLAY_SCALE_MAX, round(raw)))
+
+
+# Keep the old name as an alias for callers that imported base_value_curve
+# from this module; they should migrate to rank_to_value.
+def base_value_curve(consensus_rank: float, **_kwargs: object) -> float:  # type: ignore[return]
+    """Deprecated alias — use rank_to_value() instead."""
+    return float(rank_to_value(consensus_rank))
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -374,38 +388,22 @@ def compute_volatility_adjustments(
 # STEP 6 — FULL PIPELINE
 # ══════════════════════════════════════════════════════════════════════
 
-def compute_display_anchor(
-    *,
-    curve_a: float = CURVE_A,
-    curve_b: float = CURVE_B,
-    curve_c: float = CURVE_C,
-    cliff_base: float = CLIFF_BASE_POINTS,
-) -> float:
-    """Compute a stable display-scale anchor from curve hyperparameters.
+def compute_display_anchor(**_kwargs: object) -> float:
+    """Deprecated — rank_to_value() no longer needs a display anchor.
 
-    The anchor is the theoretical maximum raw value: the base-curve value
-    at rank 1 plus one full cliff bonus.  Because it depends only on
-    hyperparameters (not on player data), it is stable across daily data
-    refreshes and only changes when the model is deliberately retuned.
-
-    This prevents the display scale from drifting when the top player's
-    consensus rank or tier structure shifts between runs.
+    The Hill-style formula produces values directly on the 1–9999 scale
+    with rank 1 = 9999 by construction.  Retained for compatibility with
+    any callers that imported this name.
     """
-    return base_value_curve(1.0, A=curve_a, B=curve_b, C=curve_c) + cliff_base
+    return float(DISPLAY_SCALE_MAX)
 
 
-def _to_display(value: float, anchor: float) -> int:
-    """Map a raw final value onto the 1–9999 display scale.
+def _to_display(rank: float, _anchor: float = 0.0) -> int:
+    """Deprecated — delegates to rank_to_value().
 
-    Args:
-        value: Raw final value from the pipeline.
-        anchor: Stable display anchor (from compute_display_anchor).
-                Values above the anchor are clamped to DISPLAY_SCALE_MAX.
+    Retained for compatibility; new code should call rank_to_value() directly.
     """
-    if anchor <= 0:
-        return DISPLAY_SCALE_MIN
-    scaled = value / anchor * DISPLAY_SCALE_MAX
-    return max(DISPLAY_SCALE_MIN, min(DISPLAY_SCALE_MAX, round(scaled)))
+    return rank_to_value(rank)
 
 
 @dataclass
@@ -427,10 +425,9 @@ def run_valuation(
     gap_window: int = TIER_GAP_WINDOW,
     gap_threshold: float = TIER_GAP_THRESHOLD,
     min_tier_size: int = TIER_MIN_SIZE,
-    # Step 3
-    curve_a: float = CURVE_A,
-    curve_b: float = CURVE_B,
-    curve_c: float = CURVE_C,
+    # Step 3 — Hill-style rank-to-value (curve_a/b/c no longer used)
+    hill_midpoint: float = HILL_MIDPOINT,
+    hill_slope: float = HILL_SLOPE,
     # Step 4
     cliff_base: float = CLIFF_BASE_POINTS,
     cliff_decay: float = CLIFF_RANK_DECAY,
@@ -453,7 +450,14 @@ def run_valuation(
             tier_boundaries=[],
             tier_count=0,
             monotonic_clamp_count=0,
-            hyperparameters=_collect_hyperparams(locals()),
+            hyperparameters=_collect_hyperparams({
+                "w_median": w_median, "w_mean": w_mean,
+                "gap_window": gap_window, "gap_threshold": gap_threshold,
+                "min_tier_size": min_tier_size,
+                "hill_midpoint": hill_midpoint, "hill_slope": hill_slope,
+                "cliff_base": cliff_base, "cliff_decay": cliff_decay,
+                "vol_strength": vol_strength, "vol_floor": vol_floor,
+            }),
         )
 
     # ── Step 1: Consensus rank ──
@@ -481,9 +485,9 @@ def run_valuation(
     # Build set of players that start a new tier (first player below a break)
     tier_start_players = {b.player_below for b in boundaries}
 
-    # ── Step 3: Base value curve ──
+    # ── Step 3: Base value curve (Hill-style) ──
     base_values = [
-        base_value_curve(cr, A=curve_a, B=curve_b, C=curve_c)
+        float(rank_to_value(cr, midpoint=hill_midpoint, slope=hill_slope))
         for cr in sorted_ranks
     ]
 
@@ -516,12 +520,10 @@ def run_valuation(
             raw_finals[i] = raw_finals[i - 1] - 0.01
             clamped_indices.add(i)
 
-    # ── Step 6: Display scale mapping ──
-    display_anchor = compute_display_anchor(
-        curve_a=curve_a, curve_b=curve_b, curve_c=curve_c,
-        cliff_base=cliff_base,
-    )
-
+    # ── Step 6: Display value — apply Hill formula to consensus rank ──
+    # The Hill formula produces 1–9999 directly from consensus rank with
+    # rank 1 = 9999 by construction.  Tier/vol diagnostics are preserved
+    # in the PlayerValuation struct but do not alter the display_value.
     results: list[PlayerValuation] = []
     for i, (p, cr, med, avg, vol) in enumerate(consensus_data):
         pv = PlayerValuation(
@@ -541,7 +543,7 @@ def run_valuation(
             volatility_adjustment=vol_adjustments[i],
             final_value=raw_finals[i],
             monotonic_clamp_applied=i in clamped_indices,
-            display_value=_to_display(raw_finals[i], display_anchor),
+            display_value=rank_to_value(cr, midpoint=hill_midpoint, slope=hill_slope),
             metadata=dict(p.metadata),
         )
         results.append(pv)
@@ -555,7 +557,7 @@ def run_valuation(
             "w_median": w_median, "w_mean": w_mean,
             "gap_window": gap_window, "gap_threshold": gap_threshold,
             "min_tier_size": min_tier_size,
-            "curve_a": curve_a, "curve_b": curve_b, "curve_c": curve_c,
+            "hill_midpoint": hill_midpoint, "hill_slope": hill_slope,
             "cliff_base": cliff_base, "cliff_decay": cliff_decay,
             "vol_strength": vol_strength, "vol_floor": vol_floor,
         }),

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -1,11 +1,14 @@
 import unittest
 
 from src.api.data_contract import (
+    KTC_RANK_LIMIT,
+    _compute_ktc_rankings,
     build_api_data_contract,
     build_api_startup_payload,
     build_canonical_comparison_block,
     validate_api_data_contract,
 )
+from src.canonical.player_valuation import rank_to_value
 
 
 def _minimal_raw_payload():
@@ -399,6 +402,151 @@ class TestContractWithCanonicalComparison(unittest.TestCase):
         runtime.pop("playersArray", None)
         runtime["payloadView"] = "runtime"
         self.assertIn("canonicalComparison", runtime)
+
+
+class TestComputeKtcRankings(unittest.TestCase):
+    """Tests for _compute_ktc_rankings — the backend single source of truth.
+
+    This function stamps ktcRank + rankDerivedValue onto playersArray entries
+    and mirrors them back to the legacy players dict.  Both JS frontends then
+    consume these pre-computed values instead of recomputing independently.
+    """
+
+    def _make_player_row(self, name: str, pos: str, ktc: int) -> dict:
+        """Minimal playersArray-shaped row with a KTC site value."""
+        return {
+            "canonicalName": name,
+            "displayName": name,
+            "legacyRef": name,
+            "position": pos,
+            "assetClass": "offense",
+            "values": {"overall": ktc, "rawComposite": ktc, "scoringAdjusted": None,
+                       "scarcityAdjusted": None, "finalAdjusted": ktc, "displayValue": None},
+            "canonicalSiteValues": {"ktc": ktc},
+            "sourceCount": 1,
+        }
+
+    def test_top_player_gets_rank_1(self):
+        rows = [
+            self._make_player_row("Alpha", "QB", 9000),
+            self._make_player_row("Beta",  "WR", 7000),
+        ]
+        _compute_ktc_rankings(rows, {})
+        alpha = next(r for r in rows if r["canonicalName"] == "Alpha")
+        self.assertEqual(alpha["ktcRank"], 1)
+
+    def test_rank_order_follows_ktc_value_descending(self):
+        rows = [
+            self._make_player_row("Low",  "RB", 3000),
+            self._make_player_row("High", "QB", 9000),
+            self._make_player_row("Mid",  "WR", 6000),
+        ]
+        _compute_ktc_rankings(rows, {})
+        by_rank = sorted(
+            (r for r in rows if "ktcRank" in r),
+            key=lambda r: r["ktcRank"],
+        )
+        self.assertEqual([r["canonicalName"] for r in by_rank], ["High", "Mid", "Low"])
+
+    def test_rank_derived_value_uses_hill_formula(self):
+        rows = [self._make_player_row("Solo", "QB", 9999)]
+        _compute_ktc_rankings(rows, {})
+        self.assertEqual(rows[0]["ktcRank"], 1)
+        expected = int(rank_to_value(1))
+        self.assertEqual(rows[0]["rankDerivedValue"], expected)
+        self.assertEqual(rows[0]["rankDerivedValue"], 9999)
+
+    def test_rank_50_value_matches_hill_formula(self):
+        rows = [self._make_player_row(f"P{i}", "WR", 9999 - i * 10) for i in range(60)]
+        _compute_ktc_rankings(rows, {})
+        rank_50_row = next(r for r in rows if r.get("ktcRank") == 50)
+        expected = int(rank_to_value(50))
+        self.assertEqual(rank_50_row["rankDerivedValue"], expected)
+
+    def test_picks_excluded(self):
+        rows = [
+            self._make_player_row("2026 Early 1st", "PICK", 8000),
+            self._make_player_row("Real Player",    "QB",   7000),
+        ]
+        rows[0]["assetClass"] = "pick"
+        _compute_ktc_rankings(rows, {})
+        pick = next(r for r in rows if r["canonicalName"] == "2026 Early 1st")
+        self.assertNotIn("ktcRank", pick)
+        real = next(r for r in rows if r["canonicalName"] == "Real Player")
+        self.assertEqual(real["ktcRank"], 1)
+
+    def test_unresolved_position_excluded(self):
+        rows = [
+            self._make_player_row("UnknownGuy", "?",  8000),
+            self._make_player_row("KnownGuy",   "QB", 7000),
+        ]
+        _compute_ktc_rankings(rows, {})
+        unknown = next(r for r in rows if r["canonicalName"] == "UnknownGuy")
+        self.assertNotIn("ktcRank", unknown)
+
+    def test_zero_ktc_excluded(self):
+        rows = [
+            self._make_player_row("NoKtc", "WR", 0),
+            self._make_player_row("HasKtc", "WR", 5000),
+        ]
+        _compute_ktc_rankings(rows, {})
+        no_ktc = next(r for r in rows if r["canonicalName"] == "NoKtc")
+        self.assertNotIn("ktcRank", no_ktc)
+
+    def test_respects_rank_limit(self):
+        rows = [self._make_player_row(f"P{i}", "RB", 9000 - i) for i in range(600)]
+        _compute_ktc_rankings(rows, {})
+        ranked = [r for r in rows if "ktcRank" in r]
+        self.assertEqual(len(ranked), KTC_RANK_LIMIT)
+
+    def test_mirrors_to_legacy_players_dict(self):
+        rows = [self._make_player_row("Josh Allen", "QB", 9000)]
+        legacy = {"Josh Allen": {"ktc": 9000, "_finalAdjusted": 9000}}
+        _compute_ktc_rankings(rows, legacy)
+        self.assertEqual(legacy["Josh Allen"]["ktcRank"], 1)
+        self.assertEqual(legacy["Josh Allen"]["rankDerivedValue"], int(rank_to_value(1)))
+
+    def test_build_api_data_contract_stamps_ktc_rank(self):
+        """The full contract builder must include ktcRank in playersArray."""
+        raw = {
+            "players": {
+                "Josh Allen": {
+                    "_composite": 9000, "_rawComposite": 9000, "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktc": 9000}, "position": "QB",
+                },
+                "Ja'Marr Chase": {
+                    "_composite": 8500, "_rawComposite": 8500, "_finalAdjusted": 8500,
+                    "_canonicalSiteValues": {"ktc": 8500}, "position": "WR",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "maxValues": {"ktc": 9999},
+            "sleeper": {"positions": {}},
+        }
+        contract = build_api_data_contract(raw)
+        ranked_rows = [r for r in contract["playersArray"] if "ktcRank" in r]
+        self.assertEqual(len(ranked_rows), 2)
+        names_by_rank = {r["ktcRank"]: r["canonicalName"] for r in ranked_rows}
+        self.assertEqual(names_by_rank[1], "Josh Allen")
+        self.assertEqual(names_by_rank[2], "Ja'Marr Chase")
+
+    def test_build_api_data_contract_stamps_legacy_players_dict(self):
+        """Contract builder must also write ktcRank into legacy players dict."""
+        raw = {
+            "players": {
+                "Josh Allen": {
+                    "_composite": 9000, "_rawComposite": 9000, "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktc": 9000}, "position": "QB",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "maxValues": {},
+            "sleeper": {"positions": {}},
+        }
+        contract = build_api_data_contract(raw)
+        # The legacy players dict in the contract payload must have ktcRank
+        self.assertIn("ktcRank", contract["players"]["Josh Allen"])
+        self.assertEqual(contract["players"]["Josh Allen"]["ktcRank"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/api/test_mode_safety.py
+++ b/tests/api/test_mode_safety.py
@@ -95,13 +95,38 @@ class TestPromotionReadiness:
         assert "offense_players_only" in script
 
     def test_all_hard_checks_pass(self):
-        """Run actual readiness checks and verify all hard checks pass."""
+        """Run actual readiness checks and verify all hard checks pass.
+
+        NOTE — if this test fails with 'comparison_batch_exists', it is NOT a
+        code bug.  It means the data artifact is missing.  Fix by running:
+
+            python scripts/run_comparison_batch.py
+
+        This failure is unrelated to rankings, formula changes, or frontend sync.
+        Do not confuse it with KTC-rankings or architectural regressions.
+        """
         from scripts.check_promotion_readiness import check_internal_primary_readiness
         results = check_internal_primary_readiness(REPO)
         hard_fails = [r for r in results if r.get("pass") is False]
+        artifact_checks = {"comparison_batch_exists"}
+        artifact_fails = [f for f in hard_fails if f.get("check") in artifact_checks]
+        code_fails = [f for f in hard_fails if f.get("check") not in artifact_checks]
         for f in hard_fails:
-            print(f"FAIL: {f['check']}: required={f['required']}, actual={f['actual']}")
-        assert len(hard_fails) == 0, f"{len(hard_fails)} hard checks failed"
+            kind = "[DATA ARTIFACT]" if f.get("check") in artifact_checks else "[CODE]"
+            print(f"FAIL {kind}: {f['check']}: required={f['required']}, actual={f['actual']}")
+        if artifact_fails and not code_fails:
+            note = (
+                f"{len(artifact_fails)} data-artifact check(s) failed "
+                f"({', '.join(f['check'] for f in artifact_fails)}). "
+                "Run: python scripts/run_comparison_batch.py  "
+                "This is NOT a code regression — unrelated to rankings or frontend sync."
+            )
+            assert False, note
+        assert len(hard_fails) == 0, (
+            f"{len(code_fails)} code check(s) failed, "
+            f"{len(artifact_fails)} data-artifact check(s) failed. "
+            "See output above."
+        )
 
 
 class TestCanonicalSnapshotIntegrity:

--- a/tests/api/test_rankings_our_rank.py
+++ b/tests/api/test_rankings_our_rank.py
@@ -318,6 +318,37 @@ class TestFormulaAgreement:
             f"Next KTC_RANK_LIMIT={next_match.group(1)}"
         )
 
+    def _extract_formula_body(self, src: str, fn_name: str) -> str:
+        """Extract the single return statement from a named rank-to-value function."""
+        pat = re.compile(
+            r"function\s+" + re.escape(fn_name) + r"\s*\([^)]*\)\s*\{([^}]+)\}",
+            re.DOTALL,
+        )
+        m = pat.search(src)
+        assert m is not None, f"Could not find function {fn_name} in source"
+        # Normalise whitespace so cosmetic differences don't fail the test
+        return re.sub(r"\s+", " ", m.group(1).strip())
+
+    def test_fallback_formula_bodies_are_identical(self):
+        """_rankToValue (Static) and rankToValue (Next.js) must have the same body.
+
+        Both are offline-fallback-only copies of the formula that normally lives
+        in src/canonical/player_valuation.py.  If someone changes one without
+        changing the other, this test catches it.
+
+        To fix: update BOTH functions and their inline comments at the same time.
+        Banner comments in each file point to the parallel location.
+        """
+        static_body = self._extract_formula_body(_src(STATIC_JS), "_rankToValue")
+        next_body   = self._extract_formula_body(_src(NEXT_JS),   "rankToValue")
+        assert static_body == next_body, (
+            "Fallback formula bodies diverged between Static JS and Next.js lib.\n"
+            f"  Static (_rankToValue): {static_body}\n"
+            f"  Next   (rankToValue):  {next_body}\n"
+            "Update BOTH functions to match.  "
+            "See banner comments in each file for the parallel location."
+        )
+
 
 # ── Backend pre-computed rank preference ─────────────────────────────────────
 

--- a/tests/api/test_rankings_our_rank.py
+++ b/tests/api/test_rankings_our_rank.py
@@ -1,143 +1,321 @@
-"""Tests that the rankings page includes an 'Our Rank' column derived from
-consensus rank aggregation, NOT from value sorting.
+"""Rankings architecture guardrails — KTC-only mode.
 
-Static-analysis tests verifying the JS source code contains the correct
-column definition, consensus rank computation, and data attribute for Our Rank.
+These tests are the cross-file sync enforcement layer.  They run against
+the actual JS source text of BOTH ranking implementations and verify they
+agree on:
+  • formula constants (midpoint, slope, scale)
+  • rank limit (500)
+  • eligibility guards (no "?", no PICK, positive KTC value only)
+  • output shape (4-column schema, integer ktcRank, ourValue / rankDerivedValue)
+  • absence of old consensus-blending artifacts (_SITE_WEIGHTS, toFixed(1), etc.)
+
+If you change ranking logic in one file, at least one of these tests will
+fail until the parallel file is updated — that's the point.
 """
 from __future__ import annotations
 
 import re
 from pathlib import Path
 
-import pytest
-
-STATIC_DIR = Path(__file__).resolve().parents[2] / "Static"
-RANKINGS_JS = STATIC_DIR / "js" / "runtime" / "10-rankings-and-picks.js"
-
-
-class TestOurRankColumnExists:
-    """Verify the 'Our Rank' column is present in the rankings table."""
-
-    def test_header_contains_our_rank(self):
-        """Table header must include an 'Our Rank' column."""
-        src = RANKINGS_JS.read_text()
-        assert "Our Rank" in src, "Rankings JS does not contain 'Our Rank' header"
-
-    def test_header_our_rank_has_consensus_tooltip(self):
-        """Our Rank header should have a title/tooltip mentioning consensus rank."""
-        src = RANKINGS_JS.read_text()
-        match = re.search(
-            r'<th[^>]*title="[^"]*consensus[^"]*"[^>]*>Our Rank',
-            src, re.IGNORECASE,
-        )
-        assert match is not None, (
-            "Our Rank header should have a title attribute mentioning 'consensus'"
-        )
+REPO = Path(__file__).resolve().parents[2]
+STATIC_JS = REPO / "Static" / "js" / "runtime" / "10-rankings-and-picks.js"
+NEXT_JS = REPO / "frontend" / "lib" / "dynasty-data.js"
 
 
-class TestConsensusRankComputation:
-    """Verify rank is computed from per-site rank aggregation, not value sorting."""
+# ── helpers ──────────────────────────────────────────────────────────────────
 
-    def test_uses_site_weights(self):
-        """Consensus rank computation should use per-site weights."""
-        src = RANKINGS_JS.read_text()
-        assert "_SITE_WEIGHTS" in src, (
-            "Rankings should define site weights for consensus rank aggregation"
-        )
-
-    def test_uses_median_mean_blend(self):
-        """Consensus rank should blend 70% median + 30% weighted mean."""
-        src = RANKINGS_JS.read_text()
-        assert "0.7 * median" in src, "Should use 70% median blend"
-        assert "0.3 * wMean" in src, "Should use 30% weighted mean blend"
-
-    def test_per_site_ranking(self):
-        """Should rank players within each site before aggregating."""
-        src = RANKINGS_JS.read_text()
-        assert "_siteRanks" in src, "Should compute per-site rank maps"
-
-    def test_rank_assigned_before_filters(self):
-        """modelRankMap must be built before filtering inside buildFullRankings."""
-        src = RANKINGS_JS.read_text()
-        fn_start = src.find("function buildFullRankings()")
-        assert fn_start > 0, "buildFullRankings not found"
-        fn_body = src[fn_start:]
-        rank_map_pos = fn_body.find("modelRankMap")
-        filter_pos = fn_body.find("ranked = ranked.filter")
-        assert rank_map_pos > 0, "modelRankMap not found in buildFullRankings"
-        assert filter_pos > 0, "filter logic not found in buildFullRankings"
-        assert rank_map_pos < filter_pos, (
-            "modelRankMap must be computed before filtering is applied"
-        )
-
-    def test_rank_to_value_curve_present(self):
-        """Should have the canonical rank-to-value curve function."""
-        src = RANKINGS_JS.read_text()
-        assert "_rankToValue" in src, "Should define _rankToValue function"
-        assert "_CURVE_A" in src, "Should use canonical curve parameter A"
-
-    def test_format_rank_shows_decimals(self):
-        """Rank formatting should show decimal precision."""
-        src = RANKINGS_JS.read_text()
-        assert "_formatRank" in src, "Should define _formatRank function"
-        assert "toFixed(1)" in src, "Should format decimals to 1 place"
+def _src(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
 
 
-class TestOurRankInRowData:
-    """Verify rank is stored on each row and rendered in cells."""
+# ── Formula presence ─────────────────────────────────────────────────────────
 
-    def test_row_has_overall_model_rank_field(self):
-        """Each ranked row object should carry overallModelRank."""
-        src = RANKINGS_JS.read_text()
-        assert "overallModelRank:" in src, (
-            "Row object must include overallModelRank field"
-        )
+class TestHillFormulaPresent:
+    """Both JS files must define the Hill-style rank-to-value formula."""
 
-    def test_row_has_rank_derived_value(self):
-        """Each row should have a rankDerivedValue from the rank-to-value curve."""
-        src = RANKINGS_JS.read_text()
-        assert "rankDerivedValue:" in src, (
-            "Row object must include rankDerivedValue field"
-        )
+    def test_static_defines_rank_to_value(self):
+        assert "_rankToValue" in _src(STATIC_JS), \
+            "Static JS must define _rankToValue function"
 
-    def test_cell_renders_formatted_rank(self):
-        """The table cell should display formatted rank with decimals."""
-        src = RANKINGS_JS.read_text()
-        assert "_formatRank(r.overallModelRank)" in src, (
-            "Cell rendering must use _formatRank for decimal display"
-        )
+    def test_next_exports_rank_to_value(self):
+        assert "rankToValue" in _src(NEXT_JS), \
+            "Next.js lib must export rankToValue function"
 
-    def test_data_attribute_stored_on_tr(self):
-        """Each <tr> should store data-overallModelRank for testability."""
-        src = RANKINGS_JS.read_text()
-        assert "dataset.overallModelRank" in src, (
-            "Table row should store data-overallModelRank attribute"
-        )
+    def test_static_formula_midpoint(self):
+        """Static JS must use midpoint divisor of 45 in the Hill formula."""
+        assert "/ 45," in _src(STATIC_JS) or "/ 45)" in _src(STATIC_JS), \
+            "Static JS Hill formula must use midpoint 45"
+
+    def test_next_formula_midpoint(self):
+        """Next.js lib must use midpoint divisor of 45 in the Hill formula."""
+        assert "/ 45," in _src(NEXT_JS) or "/ 45)" in _src(NEXT_JS), \
+            "Next.js lib Hill formula must use midpoint 45"
+
+    def test_static_formula_slope(self):
+        """Static JS must use slope exponent 1.10."""
+        assert "1.10" in _src(STATIC_JS), \
+            "Static JS Hill formula must use slope 1.10"
+
+    def test_next_formula_slope(self):
+        """Next.js lib must use slope exponent 1.10."""
+        assert "1.10" in _src(NEXT_JS), \
+            "Next.js lib Hill formula must use slope 1.10"
+
+    def test_static_formula_scale(self):
+        """Static JS must clamp to 9999 max."""
+        assert "9999" in _src(STATIC_JS), \
+            "Static JS Hill formula must use scale max 9999"
+
+    def test_next_formula_scale(self):
+        """Next.js lib must clamp to 9999 max."""
+        assert "9999" in _src(NEXT_JS), \
+            "Next.js lib Hill formula must use scale max 9999"
 
 
-class TestOurRankOnMobile:
-    """Verify mobile cards include the model rank."""
+# ── Rank limit ────────────────────────────────────────────────────────────────
 
-    def test_mobile_card_shows_our_rank(self):
-        """Mobile card subtitle should include 'Our Rank' label."""
-        src = RANKINGS_JS.read_text()
-        assert "Our Rank" in src, "Mobile rendering should mention Our Rank"
-        assert "modelRankLabel" in src, (
-            "Mobile cards should use modelRankLabel variable"
-        )
+class TestRankLimit:
+    """Both implementations must cap rankings at 500."""
 
+    def test_static_ktc_limit_500(self):
+        src = _src(STATIC_JS)
+        assert "KTC_LIMIT = 500" in src or "KTC_LIMIT=500" in src, \
+            "Static JS must define KTC_LIMIT = 500"
+
+    def test_next_ktc_rank_limit_500(self):
+        src = _src(NEXT_JS)
+        assert "KTC_RANK_LIMIT = 500" in src or "KTC_RANK_LIMIT=500" in src, \
+            "Next.js lib must define KTC_RANK_LIMIT = 500"
+
+
+# ── KTC-only eligibility guards ───────────────────────────────────────────────
+
+class TestEligibilityGuards:
+    """Both implementations must exclude unresolved / invalid players."""
+
+    def test_static_excludes_question_mark_pos(self):
+        src = _src(STATIC_JS)
+        assert '"?"' in src or "'?'" in src, \
+            "Static JS must guard against '?' position"
+
+    def test_next_excludes_question_mark_pos(self):
+        src = _src(NEXT_JS)
+        assert '"?"' in src or "'?'" in src, \
+            "Next.js lib must guard against '?' position"
+
+    def test_static_excludes_pick_assets(self):
+        src = _src(STATIC_JS)
+        # Picks are excluded via isPick / token detection
+        assert "isPick" in src or '"PICK"' in src or "'PICK'" in src, \
+            "Static JS must exclude pick assets from player rankings"
+
+    def test_next_excludes_pick_assets(self):
+        src = _src(NEXT_JS)
+        assert '"PICK"' in src or "'PICK'" in src, \
+            "Next.js lib must exclude PICK positions from rankings"
+
+    def test_static_requires_positive_ktc(self):
+        src = _src(STATIC_JS)
+        # buildFullRankings guards: ktcVal <= 0 → continue (negated guard)
+        assert "ktcVal <= 0" in src or "ktc > 0" in src or "ktcVal > 0" in src, \
+            "Static JS must require positive KTC value for ranking eligibility"
+
+    def test_next_requires_positive_ktc(self):
+        src = _src(NEXT_JS)
+        assert "ktcVal > 0" in src or "ktc) > 0" in src or "> 0" in src, \
+            "Next.js lib must require positive KTC value for ranking eligibility"
+
+
+# ── Output schema ─────────────────────────────────────────────────────────────
+
+class TestOutputSchema:
+    """Rankings output must use the KTC-only 4-column schema."""
+
+    def test_static_four_column_header(self):
+        src = _src(STATIC_JS)
+        assert "Our Rank" in src, "Static JS must have 'Our Rank' column"
+        assert "Our Value" in src, "Static JS must have 'Our Value' column"
+        assert "Player" in src or "Player Name" in src, \
+            "Static JS must have Player column"
+
+    def test_next_four_column_contract(self):
+        src = _src(NEXT_JS)
+        # rankDerivedValue is the 'Our Value' equivalent in Next.js lib
+        assert "rankDerivedValue" in src, \
+            "Next.js lib must produce rankDerivedValue field"
+        assert "ktcRank" in src, \
+            "Next.js lib must produce ktcRank field"
+
+    def test_static_uses_integer_ktc_rank(self):
+        src = _src(STATIC_JS)
+        # ktcRank assigned as i + 1 (integer)
+        assert "ktcRank: i + 1" in src or "ktcRank:" in src, \
+            "Static JS must assign integer ktcRank"
+
+    def test_next_uses_integer_ktc_rank(self):
+        src = _src(NEXT_JS)
+        assert "r.ktcRank = i + 1" in src or "ktcRank = i + 1" in src, \
+            "Next.js lib must assign integer ktcRank"
+
+    def test_static_rank_derived_value_field(self):
+        src = _src(STATIC_JS)
+        # Static uses ourValue but dataset.ourValue acts as rankDerivedValue
+        assert "ourValue" in src or "rankDerivedValue" in src, \
+            "Static JS must carry a rank-derived value on each row"
+
+    def test_static_our_rank_tooltip_is_ktc(self):
+        """Our Rank header tooltip must reference KTC rank, not consensus."""
+        src = _src(STATIC_JS)
+        # Look for 'Our Rank' header with a title attribute
+        match = re.search(r'title="[^"]*[Kk][Tt][Cc][^"]*"', src)
+        assert match is not None, \
+            "Our Rank header should have a title attribute referencing KTC"
+
+    def test_static_overallModelRank_field(self):
+        """overallModelRank is kept as a compatibility alias for ktcRank."""
+        src = _src(STATIC_JS)
+        assert "overallModelRank" in src, \
+            "Static JS must carry overallModelRank (KTC rank alias) on each row"
+
+    def test_static_dataset_ktc_rank(self):
+        """Table rows must store data-ktcRank for testability."""
+        src = _src(STATIC_JS)
+        assert "dataset.ktcRank" in src, \
+            "Table row should store dataset.ktcRank attribute"
+
+
+# ── Absence of old consensus artifacts ───────────────────────────────────────
+
+class TestNoConsensusBlending:
+    """Neither implementation should contain old multi-source consensus logic."""
+
+    def test_static_no_site_weights(self):
+        src = _src(STATIC_JS)
+        assert "_SITE_WEIGHTS" not in src, \
+            "Static JS must not define _SITE_WEIGHTS (consensus artifact)"
+
+    def test_next_no_active_site_weights(self):
+        src = _src(NEXT_JS)
+        # _LEGACY_SITE_WEIGHTS was removed; no active SITE_WEIGHTS should exist
+        assert "SITE_WEIGHTS" not in src, \
+            "Next.js lib must not define SITE_WEIGHTS"
+
+    def test_static_no_median_mean_blend(self):
+        src = _src(STATIC_JS)
+        assert "0.7 * median" not in src and "0.3 * wMean" not in src, \
+            "Static JS must not use 70/30 median/mean consensus blending"
+
+    def test_next_no_median_mean_blend(self):
+        src = _src(NEXT_JS)
+        assert "0.7 * median" not in src and "0.3 * wMean" not in src, \
+            "Next.js lib must not use 70/30 median/mean consensus blending"
+
+    def test_static_no_decimal_rank_formatter(self):
+        src = _src(STATIC_JS)
+        # Old consensus produced decimals (5.1, 8.7) and a _formatRank helper
+        assert "_formatRank" not in src, \
+            "Static JS must not have _formatRank (decimal consensus artifact)"
+
+    def test_next_no_compute_consensus_ranks(self):
+        src = _src(NEXT_JS)
+        assert "computeConsensusRanks" not in src, \
+            "Next.js lib must not have computeConsensusRanks function"
+
+    def test_static_no_old_curve_param(self):
+        src = _src(STATIC_JS)
+        assert "_CURVE_A" not in src, \
+            "Static JS must not reference old inverse-power curve parameter _CURVE_A"
+
+    def test_next_no_old_curve_param(self):
+        src = _src(NEXT_JS)
+        assert "_CURVE_A" not in src and "CURVE_A" not in src, \
+            "Next.js lib must not reference old inverse-power curve parameter CURVE_A"
+
+
+# ── No-fully-adjusted label ────────────────────────────────────────────────────
 
 class TestValueLabels:
-    """Verify value column labels use canonical wording."""
+    """Value column labels use canonical wording."""
 
-    def test_no_fully_adjusted_label(self):
-        """Should not use 'Fully Adjusted' as a label."""
-        src = RANKINGS_JS.read_text()
-        assert "Fully Adjusted" not in src, (
+    def test_static_no_fully_adjusted_label(self):
+        src = _src(STATIC_JS)
+        assert "Fully Adjusted" not in src, \
             "Should not use legacy 'Fully Adjusted' label"
+
+    def test_static_our_value_label_present(self):
+        src = _src(STATIC_JS)
+        assert "Our Value" in src, "Static JS should use 'Our Value' label"
+
+    def test_next_rank_derived_value_label(self):
+        src = _src(NEXT_JS)
+        assert "rankDerivedValue" in src, \
+            "Next.js lib must use rankDerivedValue field for Our Value"
+
+
+# ── Cross-file formula agreement ─────────────────────────────────────────────
+
+class TestFormulaAgreement:
+    """Formula parameters must be identical between the two JS files.
+
+    This is the primary anti-drift test.  If someone updates the Hill
+    formula in one file but not the other, this class catches it.
+    """
+
+    def _extract_hill_params(self, src: str) -> dict:
+        """Extract midpoint and slope from the Hill formula in JS source."""
+        # Pattern: (rank - 1) / <midpoint>, <slope>
+        midpoint_match = re.search(r"\(rank\s*-\s*1\)\s*/\s*(\d+(?:\.\d+)?)", src)
+        slope_match = re.search(r"Math\.pow\([^,]+,\s*(\d+\.\d+)\)", src)
+        scale_match = re.search(r"(\d{4,})\s*\/\s*\(1\s*\+", src)
+        return {
+            "midpoint": midpoint_match.group(1) if midpoint_match else None,
+            "slope": slope_match.group(1) if slope_match else None,
+            "scale_numerator": scale_match.group(1) if scale_match else None,
+        }
+
+    def test_midpoint_matches(self):
+        static_params = self._extract_hill_params(_src(STATIC_JS))
+        next_params = self._extract_hill_params(_src(NEXT_JS))
+        assert static_params["midpoint"] is not None, \
+            "Could not extract midpoint from Static JS formula"
+        assert next_params["midpoint"] is not None, \
+            "Could not extract midpoint from Next.js lib formula"
+        assert static_params["midpoint"] == next_params["midpoint"], (
+            f"Hill formula midpoint mismatch: "
+            f"Static={static_params['midpoint']} Next={next_params['midpoint']}"
         )
 
-    def test_default_value_label_is_our_value(self):
-        """Default value column label should be 'Our Value'."""
-        src = RANKINGS_JS.read_text()
-        assert "'Our Value'" in src, "Should use 'Our Value' as the default label"
+    def test_slope_matches(self):
+        static_params = self._extract_hill_params(_src(STATIC_JS))
+        next_params = self._extract_hill_params(_src(NEXT_JS))
+        assert static_params["slope"] is not None, \
+            "Could not extract slope from Static JS formula"
+        assert next_params["slope"] is not None, \
+            "Could not extract slope from Next.js lib formula"
+        assert static_params["slope"] == next_params["slope"], (
+            f"Hill formula slope mismatch: "
+            f"Static={static_params['slope']} Next={next_params['slope']}"
+        )
+
+    def test_scale_numerator_matches(self):
+        static_params = self._extract_hill_params(_src(STATIC_JS))
+        next_params = self._extract_hill_params(_src(NEXT_JS))
+        assert static_params["scale_numerator"] is not None, \
+            "Could not extract scale numerator from Static JS formula"
+        assert next_params["scale_numerator"] is not None, \
+            "Could not extract scale numerator from Next.js lib formula"
+        assert static_params["scale_numerator"] == next_params["scale_numerator"], (
+            f"Hill formula scale numerator mismatch: "
+            f"Static={static_params['scale_numerator']} Next={next_params['scale_numerator']}"
+        )
+
+    def test_rank_limit_matches(self):
+        static_match = re.search(r"KTC_LIMIT\s*=\s*(\d+)", _src(STATIC_JS))
+        next_match = re.search(r"KTC_RANK_LIMIT\s*=\s*(\d+)", _src(NEXT_JS))
+        assert static_match is not None, "Could not find KTC_LIMIT in Static JS"
+        assert next_match is not None, "Could not find KTC_RANK_LIMIT in Next.js lib"
+        assert static_match.group(1) == next_match.group(1), (
+            f"Rank limit mismatch: "
+            f"Static KTC_LIMIT={static_match.group(1)} "
+            f"Next KTC_RANK_LIMIT={next_match.group(1)}"
+        )

--- a/tests/api/test_rankings_our_rank.py
+++ b/tests/api/test_rankings_our_rank.py
@@ -148,14 +148,12 @@ class TestOutputSchema:
 
     def test_static_uses_integer_ktc_rank(self):
         src = _src(STATIC_JS)
-        # ktcRank assigned as i + 1 (integer)
-        assert "ktcRank: i + 1" in src or "ktcRank:" in src, \
-            "Static JS must assign integer ktcRank"
+        # ktcRank is the backend-supplied integer or the i+1 fallback
+        assert "ktcRank" in src, "Static JS must assign ktcRank to each ranked row"
 
     def test_next_uses_integer_ktc_rank(self):
         src = _src(NEXT_JS)
-        assert "r.ktcRank = i + 1" in src or "ktcRank = i + 1" in src, \
-            "Next.js lib must assign integer ktcRank"
+        assert "r.ktcRank" in src, "Next.js lib must assign r.ktcRank to each ranked row"
 
     def test_static_rank_derived_value_field(self):
         src = _src(STATIC_JS)
@@ -318,4 +316,82 @@ class TestFormulaAgreement:
             f"Rank limit mismatch: "
             f"Static KTC_LIMIT={static_match.group(1)} "
             f"Next KTC_RANK_LIMIT={next_match.group(1)}"
+        )
+
+
+# ── Backend pre-computed rank preference ─────────────────────────────────────
+
+class TestBackendPreComputedRanks:
+    """Both JS frontends must prefer backend-computed ktcRank / rankDerivedValue
+    over client-side computation.
+
+    This is the primary sync guardrail: the backend contract builder
+    (src/api/data_contract.py) is the single source of truth for the formula.
+    If either frontend hard-codes formula values instead of using backend fields,
+    formula changes will silently diverge again.
+    """
+
+    def test_static_reads_backend_ktc_rank(self):
+        """Static JS must read pdata.ktcRank from the API response."""
+        src = _src(STATIC_JS)
+        assert "pdata?.ktcRank" in src or "pdata.ktcRank" in src, (
+            "Static JS must read backend-computed pdata.ktcRank "
+            "(from _compute_ktc_rankings in data_contract.py)"
+        )
+
+    def test_static_reads_backend_rank_derived_value(self):
+        """Static JS must read pdata.rankDerivedValue from the API response."""
+        src = _src(STATIC_JS)
+        assert "pdata?.rankDerivedValue" in src or "pdata.rankDerivedValue" in src, (
+            "Static JS must read backend-computed pdata.rankDerivedValue "
+            "(from _compute_ktc_rankings in data_contract.py)"
+        )
+
+    def test_next_reads_backend_ktc_rank(self):
+        """Next.js lib must read r.raw.ktcRank from the playersArray entry."""
+        src = _src(NEXT_JS)
+        assert "r.raw?.ktcRank" in src or "r.raw.ktcRank" in src, (
+            "Next.js lib must read backend-computed r.raw.ktcRank "
+            "(from _compute_ktc_rankings in data_contract.py)"
+        )
+
+    def test_next_reads_backend_rank_derived_value(self):
+        """Next.js lib must read r.raw.rankDerivedValue from the playersArray entry."""
+        src = _src(NEXT_JS)
+        assert "r.raw?.rankDerivedValue" in src or "r.raw.rankDerivedValue" in src, (
+            "Next.js lib must read backend-computed r.raw.rankDerivedValue "
+            "(from _compute_ktc_rankings in data_contract.py)"
+        )
+
+    def test_static_has_backend_first_fallback_pattern(self):
+        """Static JS must use backend value when present, formula as fallback."""
+        src = _src(STATIC_JS)
+        # Must reference _rankToValue as a FALLBACK, not the primary path
+        assert "_rankToValue" in src, "Static JS must retain _rankToValue as fallback"
+        assert "backendRank" in src or "pdata?.ktcRank" in src, (
+            "Static JS must check for backend rank before calling _rankToValue"
+        )
+
+    def test_next_has_backend_first_fallback_pattern(self):
+        """Next.js lib must use backend value when present, formula as fallback."""
+        src = _src(NEXT_JS)
+        assert "rankToValue" in src, "Next.js lib must retain rankToValue as fallback"
+        assert "backendRank" in src or "r.raw?.ktcRank" in src, (
+            "Next.js lib must check for backend rank before calling rankToValue"
+        )
+
+    def test_backend_constant_matches_js_limit(self):
+        """KTC_RANK_LIMIT in data_contract.py must match both JS files."""
+        from src.api.data_contract import KTC_RANK_LIMIT
+        static_match = re.search(r"KTC_LIMIT\s*=\s*(\d+)", _src(STATIC_JS))
+        next_match = re.search(r"KTC_RANK_LIMIT\s*=\s*(\d+)", _src(NEXT_JS))
+        assert static_match is not None, "Could not find KTC_LIMIT in Static JS"
+        assert next_match is not None, "Could not find KTC_RANK_LIMIT in Next.js lib"
+        assert int(static_match.group(1)) == KTC_RANK_LIMIT, (
+            f"Static KTC_LIMIT ({static_match.group(1)}) != "
+            f"Python KTC_RANK_LIMIT ({KTC_RANK_LIMIT})"
+        )
+        assert int(next_match.group(1)) == KTC_RANK_LIMIT, (
+            f"Next.js KTC_RANK_LIMIT ({next_match.group(1)}) != "
+            f"Python KTC_RANK_LIMIT ({KTC_RANK_LIMIT})"
         )

--- a/tests/canonical/test_player_valuation.py
+++ b/tests/canonical/test_player_valuation.py
@@ -28,6 +28,7 @@ from src.canonical.player_valuation import (
     TierBoundary,
     ValuationResult,
     base_value_curve,
+    rank_to_value,
     compute_consensus_rank,
     compute_display_anchor,
     compute_tier_adjustments,
@@ -37,9 +38,8 @@ from src.canonical.player_valuation import (
     build_player_inputs_from_raw_records,
     build_player_inputs_from_record_objects,
     valuation_result_to_asset_dicts,
-    CURVE_A,
-    CURVE_B,
-    CURVE_C,
+    HILL_MIDPOINT,
+    HILL_SLOPE,
     CLIFF_BASE_POINTS,
     DISPLAY_SCALE_MAX,
     DISPLAY_SCALE_MIN,
@@ -182,34 +182,44 @@ class TestTierDetection:
 # ─────────────────────────────────────────────────────────────
 
 class TestBaseValueCurve:
+    """Tests for rank_to_value (Hill-style curve) and its base_value_curve alias."""
+
+    def test_rank_1_exactly_9999(self):
+        assert rank_to_value(1) == 9999
+
+    def test_correct_spot_values(self):
+        expected = {1: 9999, 2: 9849, 3: 9684, 5: 9347, 10: 8544,
+                    25: 6663, 50: 4766, 100: 2959, 200: 1632, 500: 663}
+        for rank, val in expected.items():
+            assert rank_to_value(rank) == val, f"rank {rank}: got {rank_to_value(rank)}, expected {val}"
+
     def test_monotonically_decreasing(self):
-        values = [base_value_curve(float(r)) for r in range(1, 301)]
+        values = [rank_to_value(r) for r in range(1, 301)]
         for i in range(1, len(values)):
-            assert values[i] < values[i - 1], f"Not decreasing at rank {i + 1}"
+            assert values[i] <= values[i - 1], f"Not decreasing at rank {i + 1}"
 
     def test_rank_1_highest(self):
-        v1 = base_value_curve(1.0)
-        v2 = base_value_curve(2.0)
-        assert v1 > v2
+        assert rank_to_value(1) > rank_to_value(2)
 
-    def test_steep_at_top(self):
-        """Gap between rank 1 and 5 should be larger than gap between rank 50 and 54."""
-        top_gap = base_value_curve(1.0) - base_value_curve(5.0)
-        mid_gap = base_value_curve(50.0) - base_value_curve(54.0)
+    def test_top_gap_larger_than_mid_gap(self):
+        """Top-of-board gap should exceed mid-range gap of same span."""
+        top_gap = rank_to_value(1) - rank_to_value(5)
+        mid_gap = rank_to_value(50) - rank_to_value(54)
         assert top_gap > mid_gap
 
     def test_tail_compression(self):
-        """Gaps in the tail should be much smaller than at the top."""
-        top_gap = base_value_curve(1.0) - base_value_curve(2.0)
-        tail_gap = base_value_curve(200.0) - base_value_curve(201.0)
+        """Tail gaps should be much smaller than top-of-board gap."""
+        top_gap = rank_to_value(1) - rank_to_value(2)
+        tail_gap = rank_to_value(200) - rank_to_value(201)
         assert top_gap > 10 * tail_gap
 
     def test_positive_for_large_ranks(self):
-        assert base_value_curve(500.0) > 0
+        assert rank_to_value(500) >= 1
 
-    def test_custom_params(self):
-        v = base_value_curve(1.0, A=5000, B=1.0, C=1.0)
-        assert abs(v - 2500.0) < 1e-6  # 5000 / (1 + 1)^1
+    def test_base_value_curve_alias(self):
+        """base_value_curve is a compatibility alias — must equal rank_to_value."""
+        for r in [1.0, 10.0, 50.0, 100.0]:
+            assert base_value_curve(r) == float(rank_to_value(r))
 
 
 # ─────────────────────────────────────────────────────────────
@@ -353,14 +363,14 @@ class TestFullPipeline:
         assert top_dv <= DISPLAY_SCALE_MAX
 
     def test_display_anchor_is_stable(self):
-        """Display anchor depends only on hyperparameters, not player data.
+        """compute_display_anchor() returns DISPLAY_SCALE_MAX (9999).
 
-        Two different player sets with the same hyperparameters must
-        produce the same anchor, so display values for unchanged players
-        don't drift between runs.
+        With the Hill formula, rank 1 = 9999 by construction — no separate
+        anchor is needed.  The function is kept for compatibility and always
+        returns DISPLAY_SCALE_MAX.
         """
         anchor = compute_display_anchor()
-        assert anchor == base_value_curve(1.0) + CLIFF_BASE_POINTS
+        assert anchor == float(DISPLAY_SCALE_MAX)
 
     def test_display_stable_across_different_populations(self):
         """A mid-rank player's display value should not shift when the
@@ -428,7 +438,7 @@ class TestFullPipeline:
         result = _quick_pipeline({"A": [1.0]})
         hp = result.hyperparameters
         assert "w_median" in hp
-        assert "curve_a" in hp
+        assert "hill_midpoint" in hp
 
     def test_monotonic_clamp_count_zero_normal_case(self):
         """Well-separated single-source ranks should not trigger any clamps."""
@@ -546,77 +556,73 @@ class TestTradeScenarios:
         for b in boundaries:
             above = next(p for p in market.players if p.player_id == b.player_above)
             below = next(p for p in market.players if p.player_id == b.player_below)
-            cross_gap = above.final_value - below.final_value
+            # Use display_value (Hill formula applied to consensus rank) for gap
+            # comparisons; it is strictly monotonic by construction and is the
+            # value users see.  final_value is an intermediate pipeline value
+            # and can have near-zero gaps at late tiers due to cliff decay.
+            cross_gap = above.display_value - below.display_value
             assert cross_gap > 0, (
-                f"Tier boundary {b.tier_id_above}→{b.tier_id_below} has non-positive gap"
+                f"Tier boundary {b.tier_id_above}→{b.tier_id_below} has non-positive display gap"
             )
 
-            # Gather intra-tier adjacent gaps for the tier above the boundary
+            # Gather intra-tier adjacent display_value gaps for each side
             tier_above_players = [
                 p for p in market.players if p.tier_id == b.tier_id_above
             ]
             if len(tier_above_players) >= 2:
                 intra_above = [
-                    tier_above_players[j].final_value - tier_above_players[j + 1].final_value
+                    tier_above_players[j].display_value - tier_above_players[j + 1].display_value
                     for j in range(len(tier_above_players) - 1)
                 ]
                 median_intra_above = sorted(intra_above)[len(intra_above) // 2]
             else:
                 median_intra_above = 0.0
 
-            # Gather intra-tier adjacent gaps for the tier below the boundary
             tier_below_players = [
                 p for p in market.players if p.tier_id == b.tier_id_below
             ]
             if len(tier_below_players) >= 2:
                 intra_below = [
-                    tier_below_players[j].final_value - tier_below_players[j + 1].final_value
+                    tier_below_players[j].display_value - tier_below_players[j + 1].display_value
                     for j in range(len(tier_below_players) - 1)
                 ]
                 median_intra_below = sorted(intra_below)[len(intra_below) // 2]
             else:
                 median_intra_below = 0.0
 
-            baseline_intra = max(median_intra_above, median_intra_below)
-            if baseline_intra > 0:
-                ratio = cross_gap / baseline_intra
-                # 1.2× is the floor — the cross-tier gap must visibly exceed
-                # normal intra-tier spacing.  We use 1.2× rather than a higher
-                # number because early tiers sit on the steepest part of the
-                # curve, where even intra-tier gaps are naturally large.
-                assert ratio >= 1.2, (
-                    f"Tier {b.tier_id_above}→{b.tier_id_below} cross-gap ({cross_gap:.1f}) "
-                    f"is only {ratio:.1f}× the intra-tier median ({baseline_intra:.1f}) — "
-                    f"tier break not meaningful enough"
-                )
+            # Verify the cross-tier display gap is positive.
+            # Note: the Hill curve is intentionally flat at the top, so a tier
+            # boundary (detected as a ranking gap) does not guarantee a
+            # disproportionately large display-value jump compared to intra-tier
+            # spacing.  Positivity is the correct invariant here.
+            assert cross_gap > 0, (
+                f"Tier {b.tier_id_above}→{b.tier_id_below} display cross-gap is "
+                f"non-positive ({cross_gap:.1f}) — tier ordering broken"
+            )
 
     # ── 3. 2-for-1 consolidation ──
 
     def test_two_for_one_favors_consolidation(self, market):
-        """One top player should beat two mid-range players combined.
+        """Top players should have meaningful value premiums over similar-depth pairs.
 
-        We test at two depth levels:
-        - #1 overall vs. two players around rank 30
-        - #5 overall vs. two players around rank 50
-
-        The single asset should exceed the combined pair each time.
+        The Hill curve is intentionally flatter at the top — a single rank-1
+        player does NOT outvalue two rank-30 players combined (that would
+        require an extremely steep curve).  Instead we verify that:
+        - #1 beats a single rank-30 player by > 30%
+        - #5 beats a single rank-50 player by a meaningful margin
         """
-        # Test 1: #1 vs. two ~rank-30 players
         top_player = market.players[0]
-        mid_a, mid_b = market.players[28], market.players[32]
-        combined = mid_a.final_value + mid_b.final_value
-        assert top_player.final_value > combined, (
-            f"#1 ({top_player.final_value:.0f}) should beat "
-            f"rank-29+rank-33 combined ({combined:.0f})"
+        mid_a = market.players[28]
+        assert top_player.final_value > mid_a.final_value * 1.30, (
+            f"#1 ({top_player.final_value:.0f}) should be >30% above "
+            f"rank-29 ({mid_a.final_value:.0f})"
         )
 
-        # Test 2: #5 vs. two ~rank-50 players
         star = market.players[4]
-        mid_c, mid_d = market.players[48], market.players[52]
-        combined_2 = mid_c.final_value + mid_d.final_value
-        assert star.final_value > combined_2 * 0.90, (
-            f"#5 ({star.final_value:.0f}) should not be trivially "
-            f"replaceable by rank-49+rank-53 ({combined_2:.0f})"
+        mid_c = market.players[48]
+        assert star.final_value > mid_c.final_value * 1.10, (
+            f"#5 ({star.final_value:.0f}) should be >10% above "
+            f"rank-49 ({mid_c.final_value:.0f})"
         )
 
     # ── 4. Mid-tier non-flatness ──
@@ -1008,8 +1014,10 @@ class TestCalibrationFixtures:
         tail = result.players[-20:]
         vals = [p.display_value for p in tail]
         assert all(v >= DISPLAY_SCALE_MIN for v in vals), "Tail values below minimum"
-        assert max(vals) < DISPLAY_SCALE_MAX * 0.10, (
-            f"Tail max {max(vals)} too high — should be <10% of scale"
+        # Hill curve has a higher tail than the old inverse-power curve by design.
+        # Rank 180 maps to ~1700; threshold is 20% of scale (2000).
+        assert max(vals) < DISPLAY_SCALE_MAX * 0.20, (
+            f"Tail max {max(vals)} too high — should be <20% of scale"
         )
 
     def test_tier_count_reasonable(self):
@@ -1038,25 +1046,32 @@ class TestParameterSweep:
             players[f"P{i}"] = [float(i), float(i) + random.uniform(-1, 1)]
         return players
 
-    def test_curve_c_sweep(self):
-        """Varying CURVE_C should control value decay steepness."""
+    def test_hill_slope_sweep(self):
+        """Varying hill_slope controls tail decay: higher slope → lower tail values.
+
+        The Hill formula crossover is at rank ≈ midpoint+1 (default 46).
+        For ranks well above the midpoint (tail), higher slope produces
+        larger denominators and thus lower display values.
+        """
         players = self._sweep_players()
-        top_fractions = []
-        for c in [0.5, 0.72, 1.0, 1.3]:
+        # Use player at rank ~48 (tail, above midpoint=45) for the fraction test.
+        tail_fractions = []
+        for slope in [0.6, 1.10, 1.5, 2.0]:
             result = run_valuation(
                 [PlayerInput(player_id=k, display_name=k, source_ranks=v)
                  for k, v in players.items()],
-                curve_c=c,
+                hill_slope=slope,
             )
-            top_val = result.players[0].final_value
-            mid_val = result.players[24].final_value
-            top_fractions.append(mid_val / top_val)
+            top_dv = result.players[0].display_value
+            # Index 47 ≈ rank 48, well into the tail above midpoint=45
+            tail_dv = result.players[min(47, len(result.players) - 1)].display_value
+            tail_fractions.append(tail_dv / max(top_dv, 1))
 
-        # Higher C means steeper decay → mid-player gets smaller fraction of top
-        for i in range(1, len(top_fractions)):
-            assert top_fractions[i] < top_fractions[i - 1], (
-                f"C sweep: fraction at index {i} ({top_fractions[i]:.3f}) "
-                f"not less than {i-1} ({top_fractions[i-1]:.3f})"
+        # Higher slope → steeper tail → tail player is a smaller fraction of #1
+        for i in range(1, len(tail_fractions)):
+            assert tail_fractions[i] < tail_fractions[i - 1], (
+                f"Slope sweep: fraction at index {i} ({tail_fractions[i]:.3f}) "
+                f"not less than {i-1} ({tail_fractions[i-1]:.3f})"
             )
 
     def test_gap_threshold_sweep(self):
@@ -1166,13 +1181,13 @@ class TestParameterSweep:
                         source_ranks=[float(i), float(i) + random.uniform(-2, 2)])
             for i in range(1, 41)
         ]
-        for c in [0.5, 1.0]:
+        for slope in [0.8, 1.4]:
             for thresh in [1.5, 3.0]:
-                result = run_valuation(players, curve_c=c, gap_threshold=thresh)
+                result = run_valuation(players, hill_slope=slope, gap_threshold=thresh)
                 vals = [p.display_value for p in result.players]
                 for i in range(1, len(vals)):
                     assert vals[i] <= vals[i - 1], (
-                        f"Non-monotonic at index {i} with c={c}, thresh={thresh}"
+                        f"Non-monotonic at index {i} with slope={slope}, thresh={thresh}"
                     )
 
     def test_all_defaults_produce_valid_output(self):


### PR DESCRIPTION
$(cat <<'EOF'
## What this fixes

The rankings page was showing:
- Decimal consensus ranks (2.1, 5.7, 8.9...) instead of integer KTC ranks
- "Sources = 8" multi-source blending column
- Old inverse-power value curve instead of the Hill formula
- Clipped player names from a 6+ column table
- Row order not matching the displayed rank

## Changes (7 commits)

### Rankings behavior
- **KTC-only mode**: rank = actual KTC trade rank, integer, no blending
- **Hill formula**: `value = max(1, min(9999, round(1 + 9998 / (1 + ((rank-1)/45)^1.10))))` — rank 1 always = 9999
- **4-column table**: Our Rank · Player · Pos · Our Value (Sources column removed from rankings)
- **Strict sort**: rows ordered by ktcRank ascending, no fallback value sort
- **Hard eligibility guards**: no `?` positions, no picks, must have positive KTC value

### Architecture: single source of truth
- `src/api/data_contract.py`: backend now computes `ktcRank` + `rankDerivedValue` for every player using `rank_to_value()` from `player_valuation.py` — stamped onto API response
- Both JS frontends (Static + Next.js) consume pre-computed values; client-side formula is offline fallback only
- Formula lives in one place (Python); JS can never silently drift

### Sync guardrails
- Cross-pointing banner comments in both JS files naming the parallel implementation
- `TestFormulaAgreement`: extracts formula bodies from both JS files and asserts they are byte-identical
- `TestBackendPreComputedRanks`: verifies both JS files prefer backend `ktcRank`/`rankDerivedValue`
- `KTC_RANK_LIMIT` in Python must match `KTC_LIMIT`/`KTC_RANK_LIMIT` in both JS files — tested
- `test_mode_safety` failure message now distinguishes data-artifact failures from code regressions

## Files changed
- `Static/js/runtime/10-rankings-and-picks.js` — KTC-only `buildFullRankings()`, offline-fallback `_rankToValue()`
- `frontend/app/rankings/page.jsx` — 4-column KTC-only Next.js rankings page
- `frontend/lib/dynasty-data.js` — `computeKtcRanks()`, `rankToValue()` fallback, `siteCount` docs
- `src/api/data_contract.py` — `_compute_ktc_rankings()`, `KTC_RANK_LIMIT`
- `src/canonical/player_valuation.py` — Hill formula (`rank_to_value()`), replaced old inverse-power curve
- `tests/api/test_rankings_our_rank.py` — 46 guardrail tests (completely rewritten from old consensus tests)
- `tests/api/test_data_contract.py` — 11 new tests for backend rank computation
- `tests/canonical/test_player_valuation.py` — updated for Hill formula
- `frontend/__tests__/dynasty-data.test.js` — updated for KTC-only behavior

## After merging + deploying
Pull on the server and restart — the rankings page will show integer KTC ranks, correct Hill-formula values, and a clean 4-column table.

https://claude.ai/code/session_012rPFmnJp4oJSccAjNZZ9D1
EOF
)