### PR TITLE
Fix IDP position misclassification, add contract guardrails, and restore full-board rankings

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -3,11 +3,11 @@
 import { useMemo, useState } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
 
-// ── KTC-ONLY RANKINGS PAGE ────────────────────────────────────────────
-// Data source: KTC trade value → ordinal KTC rank (integer, 1 = best)
-// Value:       Our rank-to-value formula applied to that exact KTC rank
-// Columns:     Our Rank | Player | Pos | Our Value  — nothing else
-// Sort:        KTC rank ascending only (no multi-source consensus, no blending)
+// ── FULL-BOARD RANKINGS PAGE ──────────────────────────────────────────
+// Data source: normalized contract rows from useDynastyData/buildRows
+// Value:       rankDerivedValue when KTC-ranked, else canonical full value
+// Columns:     Our Rank | Player | Pos | Our Value
+// Sort:        precomputed row rank (ranked KTC first, then remaining board)
 
 const FILTERS = [
   { key: "all", label: "All" },
@@ -21,10 +21,10 @@ export default function RankingsPage() {
   const [assetFilter, setAssetFilter] = useState("all");
   const [copyStatus, setCopyStatus] = useState("");
 
-  // Only show KTC-ranked players (ktcRank > 0, position resolved, no picks)
+  // Show the full board (including unranked-by-KTC IDP pools).
   const ranked = useMemo(() => {
     const q = query.trim().toLowerCase();
-    let list = rows.filter((r) => r.ktcRank > 0);
+    let list = rows.filter((r) => r.pos && r.pos !== "?" && r.pos !== "PICK");
 
     if (assetFilter !== "all") {
       list = list.filter((r) => r.assetClass === assetFilter);
@@ -33,14 +33,14 @@ export default function RankingsPage() {
       list = list.filter((r) => r.name.toLowerCase().includes(q));
     }
 
-    // Sort strictly by KTC rank ascending — no other sort basis
-    return [...list].sort((a, b) => a.ktcRank - b.ktcRank);
+    // rows are already pre-ranked in buildRows(), but keep deterministic sort.
+    return [...list].sort((a, b) => (a.rank || Number.MAX_SAFE_INTEGER) - (b.rank || Number.MAX_SAFE_INTEGER));
   }, [rows, assetFilter, query]);
 
   async function copyValues() {
     const lines = ["Our Rank\tPlayer\tPos\tOur Value"];
     ranked.forEach((row) => {
-      lines.push(`${row.ktcRank}\t${row.name}\t${row.pos}\t${Math.round(row.rankDerivedValue || row.values.full)}`);
+      lines.push(`${row.rank}\t${row.name}\t${row.pos}\t${Math.round(row.rankDerivedValue || row.values.full)}`);
     });
     try {
       await navigator.clipboard.writeText(lines.join("\n"));
@@ -58,7 +58,7 @@ export default function RankingsPage() {
         <div>
           <h1 style={{ margin: 0 }}>Rankings</h1>
           <p className="muted" style={{ marginTop: 4, marginBottom: 0 }}>
-            KTC-only · {ranked.length.toLocaleString()} shown · Source: {source || "unknown"}
+            Full board · {ranked.length.toLocaleString()} shown · Source: {source || "unknown"}
           </p>
         </div>
       </div>
@@ -93,17 +93,17 @@ export default function RankingsPage() {
             <table>
               <thead>
                 <tr>
-                  <th style={{ width: 64, textAlign: "center" }} title="KTC rank — 1 is best">Our Rank</th>
+                  <th style={{ width: 64, textAlign: "center" }} title="Overall board rank — 1 is best">Our Rank</th>
                   <th>Player</th>
                   <th>Pos</th>
-                  <th title="Our formula value derived from KTC rank">Our Value</th>
+                  <th title="Our board value (KTC-derived where available)">Our Value</th>
                 </tr>
               </thead>
               <tbody>
                 {ranked.map((row) => (
                   <tr key={row.name}>
                     <td style={{ textAlign: "center", fontWeight: 700, color: "var(--cyan)", fontFamily: "var(--mono, monospace)" }}>
-                      {row.ktcRank}
+                      {row.rank}
                     </td>
                     <td style={{ fontWeight: 600 }}>{row.name}</td>
                     <td><span className="badge">{row.pos}</span></td>

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -25,6 +25,15 @@ CONTRACT_VERSION = "2026-03-10.v2"
 # ─────────────────────────────────────────────────────────────────────────────
 KTC_RANK_LIMIT: int = 500
 _KICKER_POSITIONS = {"K", "PK"}
+_OFFENSE_POSITIONS = {"QB", "RB", "WR", "TE"}
+_IDP_POSITIONS = {"DL", "LB", "DB"}
+_OFFENSE_SIGNAL_KEYS = {
+    "ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "draftSharks",
+    "yahoo", "dynastyNerds", "dlfSf", "dlfRsf", "flock",
+}
+_IDP_SIGNAL_KEYS = {
+    "pffIdp", "fantasyProsIdp", "draftSharksIdp", "dlfIdp", "dlfRidp",
+}
 
 
 def _compute_ktc_rankings(
@@ -204,12 +213,36 @@ def _derive_player_row(
     site_keys: list[str],
 ) -> dict[str, Any]:
     canonical_name = str(name or "").strip()
-    pos = _normalize_pos(pos_map.get(canonical_name) or p_data.get("position"))
+    pos_from_player = _normalize_pos(p_data.get("position"))
+    pos_from_sleeper = _normalize_pos(pos_map.get(canonical_name))
+    canonical_sites = _canonical_site_values(p_data, site_keys)
+
+    has_off_signal = any(
+        _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
+        for k in _OFFENSE_SIGNAL_KEYS
+    )
+    has_idp_signal = any(
+        _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
+        for k in _IDP_SIGNAL_KEYS
+    )
+
+    pos = pos_from_sleeper or pos_from_player
+    # Guardrail: never let a sleeper map collision override an explicit offensive
+    # source profile into an IDP position (or vice versa).
+    if pos_from_player and pos_from_sleeper:
+        player_is_off = pos_from_player in _OFFENSE_POSITIONS
+        player_is_idp = pos_from_player in _IDP_POSITIONS
+        sleeper_is_off = pos_from_sleeper in _OFFENSE_POSITIONS
+        sleeper_is_idp = pos_from_sleeper in _IDP_POSITIONS
+        if player_is_off and sleeper_is_idp and has_off_signal and not has_idp_signal:
+            pos = pos_from_player
+        elif player_is_idp and sleeper_is_off and has_idp_signal and not has_off_signal:
+            pos = pos_from_player
+
     is_pick = _is_pick_name(canonical_name)
     if is_pick:
         pos = "PICK"
 
-    canonical_sites = _canonical_site_values(p_data, site_keys)
     values = _player_value_bundle(p_data)
     source_count = _source_count(p_data, canonical_sites)
 
@@ -736,6 +769,46 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
                 warnings.append(
                     f"playersArray[{idx}] canonicalSiteValues missing keys: {', '.join(missing_keys[:6])}"
                 )
+
+    idp_count = 0
+    normalized_pos_by_name: dict[str, set[str]] = {}
+    for row in players_array:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("canonicalName") or row.get("displayName") or "").strip()
+        pos = str(row.get("position") or "").strip().upper()
+        if pos in _IDP_POSITIONS:
+            idp_count += 1
+
+        canonical_sites = row.get("canonicalSiteValues") or {}
+        has_off_signal = isinstance(canonical_sites, dict) and any(
+            _to_int_or_none(canonical_sites.get(k)) not in (None, 0) for k in _OFFENSE_SIGNAL_KEYS
+        )
+        has_idp_signal = isinstance(canonical_sites, dict) and any(
+            _to_int_or_none(canonical_sites.get(k)) not in (None, 0) for k in _IDP_SIGNAL_KEYS
+        )
+        if pos in _IDP_POSITIONS and has_off_signal and not has_idp_signal:
+            errors.append(
+                f"playersArray offense→IDP mismatch: {name or '<unknown>'} tagged {pos} "
+                "with offensive-only source signal(s)"
+            )
+
+        if name:
+            norm = re.sub(r"[^a-z0-9]+", "", str(name).lower())
+            normalized_pos_by_name.setdefault(norm, set()).add(pos or "?")
+
+    for norm_name, poses in normalized_pos_by_name.items():
+        cleaned = {p for p in poses if p and p != "?"}
+        has_off = bool(cleaned & _OFFENSE_POSITIONS)
+        has_idp = bool(cleaned & _IDP_POSITIONS)
+        if has_off and has_idp:
+            errors.append(f"possible offense/IDP name collision detected for normalized name '{norm_name}'")
+
+    if len(players_array) >= 250 and idp_count < 25:
+        errors.append(
+            f"implausibly small IDP pool in playersArray: {idp_count}/{len(players_array)} "
+            "(expected at least 25 when full board is present)"
+        )
 
     if not players_array:
         warnings.append("playersArray is empty")

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -549,5 +549,114 @@ class TestComputeKtcRankings(unittest.TestCase):
         self.assertEqual(contract["players"]["Josh Allen"]["ktcRank"], 1)
 
 
+class TestIdpIntegrityGuardrails(unittest.TestCase):
+    def test_prefers_explicit_player_offense_position_over_conflicting_sleeper_idp_map(self):
+        raw = {
+            "players": {
+                "DJ Moore": {
+                    "_composite": 8000,
+                    "_rawComposite": 8000,
+                    "_finalAdjusted": 7900,
+                    "_canonicalSiteValues": {"ktc": 7700, "fantasyCalc": 7600},
+                    "position": "WR",
+                },
+            },
+            "sites": [{"key": "ktc"}, {"key": "fantasyCalc"}],
+            "maxValues": {"ktc": 9999},
+            "sleeper": {"positions": {"DJ Moore": "DB"}},
+        }
+        contract = build_api_data_contract(raw)
+        row = contract["playersArray"][0]
+        self.assertEqual(row["position"], "WR")
+        self.assertEqual(row["assetClass"], "offense")
+
+    def test_validation_flags_offense_signal_player_tagged_as_idp(self):
+        payload = _minimal_raw_payload()
+        payload["players"] = {
+            "Elijah Mitchell": {
+                "_composite": 5000,
+                "_rawComposite": 5000,
+                "_finalAdjusted": 5000,
+                "_canonicalSiteValues": {"ktc": 5000},
+                "position": "DB",
+            },
+        }
+        payload["sites"] = [{"key": "ktc"}]
+        contract = build_api_data_contract(payload)
+        report = validate_api_data_contract(contract)
+        self.assertFalse(report["ok"])
+        self.assertTrue(any("offense→IDP mismatch" in e for e in report["errors"]))
+
+    def test_validation_flags_implausibly_tiny_idp_pool(self):
+        players = {}
+        for i in range(300):
+            players[f"Player {i}"] = {
+                "_composite": 4000 - i,
+                "_rawComposite": 4000 - i,
+                "_finalAdjusted": 4000 - i,
+                "_canonicalSiteValues": {"ktc": 3000},
+                "position": "WR",
+            }
+        players["Bobby Brown"] = {
+            "_composite": 2500,
+            "_rawComposite": 2500,
+            "_finalAdjusted": 2500,
+            "_canonicalSiteValues": {"pffIdp": 8000},
+            "position": "DL",
+        }
+        raw = {
+            "players": players,
+            "sites": [{"key": "ktc"}, {"key": "pffIdp"}],
+            "maxValues": {"ktc": 9999},
+            "sleeper": {"positions": {}},
+        }
+        contract = build_api_data_contract(raw)
+        report = validate_api_data_contract(contract)
+        self.assertFalse(report["ok"])
+        self.assertTrue(any("implausibly small IDP pool" in e for e in report["errors"]))
+
+    def test_validation_flags_offense_idp_duplicate_name_collision(self):
+        payload = build_api_data_contract(_minimal_raw_payload())
+        payload["playersArray"].append({
+            "playerId": None,
+            "canonicalName": "DJ Moore",
+            "displayName": "DJ Moore",
+            "position": "WR",
+            "team": "CHI",
+            "rookie": False,
+            "values": {
+                "overall": 100,
+                "rawComposite": 100,
+                "scoringAdjusted": 100,
+                "scarcityAdjusted": 100,
+                "finalAdjusted": 100,
+                "displayValue": 100,
+            },
+            "canonicalSiteValues": {"ktc": 100},
+            "sourceCount": 1,
+        })
+        payload["playersArray"].append({
+            "playerId": None,
+            "canonicalName": "D.J. Moore",
+            "displayName": "D.J. Moore",
+            "position": "DB",
+            "team": "CHI",
+            "rookie": False,
+            "values": {
+                "overall": 1,
+                "rawComposite": 1,
+                "scoringAdjusted": 1,
+                "scarcityAdjusted": 1,
+                "finalAdjusted": 1,
+                "displayValue": 1,
+            },
+            "canonicalSiteValues": {"pffIdp": 1},
+            "sourceCount": 1,
+        })
+        report = validate_api_data_contract(payload)
+        self.assertFalse(report["ok"])
+        self.assertTrue(any("name collision" in e for e in report["errors"]))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Resolve an IDP data-integrity failure where offensive players were being emitted with IDP tags (DB/DL/LB) and the public rankings hid most IDP players by only showing KTC-ranked rows.

### Description
- Add position-resolution guardrail in `src/api/data_contract.py` so `players[name].position` and source signals (canonicalSiteValues) are used to prevent `sleeper.positions` map collisions from overriding explicit offensive positions. (file: `src/api/data_contract.py`)
- Add contract validation checks in `src/api/data_contract.py` that fail the contract when an offense-signaled player is emitted as IDP, when the IDP pool is implausibly small on a full board, or when normalized-name collisions show both offense and IDP positions. (file: `src/api/data_contract.py`)
- Restore full-board visibility in the UI by changing the rankings page to render all resolved players (excluding unknown/picks) instead of filtering to `ktcRank > 0`. (file: `frontend/app/rankings/page.jsx`)
- Add tests exercising the new guardrails and regression cases in `tests/api/test_data_contract.py`. (file: `tests/api/test_data_contract.py`)

### Testing
- Ran `pytest -q tests/api/test_data_contract.py` and all tests passed (46 passed). 
- Ran `pytest -q tests/api/test_rankings_our_rank.py` and all tests passed (47 passed). 
- These tests validate the guardrails: explicit-offense wins over conflicting sleeper map, offense→IDP mismatch detection, implausibly small IDP pool detection, and normalized-name offense/IDP collision detection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3dd0352e0832db782cd8ba9ed7fe8)