### PR TITLE
Prevent name-based position overrides — prefer canonical positions and use stable Sleeper ID fallback

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -719,6 +719,7 @@ def fetch_sleeper_rosters(league_id):
 
     all_names = []
     position_map = {}
+    position_by_id = {}
     player_id_map = {}
     id_to_player = {}
     teams = []
@@ -935,6 +936,8 @@ def fetch_sleeper_rosters(league_id):
                     # Multi-positional IDP rule: prefer non-LB for dual-position players
                     # Sleeper stores a single position; we override known edge cases
                     position_map[cn] = pos
+                if pos and sid:
+                    position_by_id[sid] = pos
 
         teams.append({
             "name": team_name,
@@ -961,6 +964,9 @@ def fetch_sleeper_rosters(league_id):
         cn = clean_name(name)
         if cn in position_map:
             position_map[cn] = override_pos
+        sid = player_id_map.get(cn)
+        if sid and sid in position_by_id:
+            position_by_id[sid] = override_pos
 
 
     teams.sort(key=lambda t: t["name"])
@@ -970,6 +976,7 @@ def fetch_sleeper_rosters(league_id):
         "leagueName": league_name,
         "teams": teams,
         "positions": position_map,
+        "positionsById": position_by_id,
         "playerIds": player_id_map,
         "idToPlayer": id_to_player,
         "scoringSettings": scoring_settings,

--- a/frontend/__tests__/dynasty-data.test.js
+++ b/frontend/__tests__/dynasty-data.test.js
@@ -282,6 +282,71 @@ describe("buildRows", () => {
     expect(rows[0].values.raw).toBe(8500);
   });
 
+  it("does not let name-based sleeper position override canonical offense", () => {
+    const data = {
+      players: {
+        "Josh Allen": {
+          _sleeperId: "111",
+          _composite: 8500,
+          _rawComposite: 8500,
+          _finalAdjusted: 9100,
+          _sites: 6,
+          position: "QB",
+        },
+      },
+      sleeper: {
+        positions: { "Josh Allen": "LB" },
+        playerIds: { "Josh Allen": "111" },
+        positionsById: { "111": "LB" },
+      },
+    };
+    const rows = buildRows(data);
+    expect(rows.length).toBe(1);
+    expect(rows[0].pos).toBe("QB");
+    expect(rows[0].assetClass).toBe("offense");
+  });
+
+  it("requires stable sleeper id before using legacy name-based fallback", () => {
+    const data = {
+      players: {
+        "Alex Carter": {
+          _sleeperId: "OFF-1",
+          _composite: 5000,
+          _rawComposite: 5000,
+          _finalAdjusted: 5000,
+          _sites: 3,
+          position: "",
+        },
+      },
+      sleeper: {
+        positions: { "Alex Carter": "LB" },
+        playerIds: { "Alex Carter": "DEF-2" },
+        positionsById: { "DEF-2": "LB" },
+      },
+    };
+    const rows = buildRows(data);
+    expect(rows.length).toBe(1);
+    expect(rows[0].pos).toBe("?");
+    expect(rows[0].assetClass).toBe("other");
+  });
+
+  it("recomputes assetClass from normalized position in playersArray", () => {
+    const data = {
+      playersArray: [
+        {
+          displayName: "Roquan Smith",
+          position: "LB",
+          assetClass: "offense",
+          values: { finalAdjusted: 5300, rawComposite: 5300, overall: 5300 },
+          canonicalSiteValues: { ktc: 5300 },
+        },
+      ],
+    };
+    const rows = buildRows(data);
+    expect(rows.length).toBe(1);
+    expect(rows[0].assetClass).toBe("idp");
+  });
+
   it("prefers displayValue for full in contract format", () => {
     const data = {
       playersArray: [

--- a/frontend/__tests__/dynasty-data.test.js
+++ b/frontend/__tests__/dynasty-data.test.js
@@ -330,6 +330,40 @@ describe("buildRows", () => {
     expect(rows[0].assetClass).toBe("other");
   });
 
+  it("backfills missing positionsById from legacy name map when sleeper ids match", () => {
+    const data = {
+      players: {
+        "Player One": {
+          _sleeperId: "1",
+          _composite: 9000,
+          _rawComposite: 9000,
+          _finalAdjusted: 9000,
+          _sites: 3,
+          position: "",
+        },
+        "Player Two": {
+          _sleeperId: "2",
+          _composite: 8500,
+          _rawComposite: 8500,
+          _finalAdjusted: 8500,
+          _sites: 3,
+          position: "",
+        },
+      },
+      sleeper: {
+        positionsById: { "1": "QB" }, // partial map from backend
+        positions: { "Player One": "QB", "Player Two": "WR" },
+        playerIds: { "Player One": "1", "Player Two": "2" },
+      },
+    };
+    const rows = buildRows(data);
+    expect(rows.length).toBe(2);
+    const one = rows.find((r) => r.name === "Player One");
+    const two = rows.find((r) => r.name === "Player Two");
+    expect(one.pos).toBe("QB");
+    expect(two.pos).toBe("WR");
+  });
+
   it("recomputes assetClass from normalized position in playersArray", () => {
     const data = {
       playersArray: [

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -108,8 +108,30 @@ function computeKtcRanks(rows) {
 export function buildRows(data) {
   const players = data?.players || {};
   const playersArray = Array.isArray(data?.playersArray) ? data.playersArray : [];
-  const posMap = data?.sleeper?.positions || {};
+  const sleeper = data?.sleeper || {};
+  const posMap = sleeper?.positions || {};
+  const posById = sleeper?.positionsById || {};
+  const playerIds = sleeper?.playerIds || {};
   const rows = [];
+
+  function resolveLegacyPlayerPos(name, player) {
+    const canonical = normalizePos(player?.position || "");
+    if (canonical && canonical !== "?" && canonical !== "UNKNOWN") return canonical;
+
+    const sleeperId = String(player?._sleeperId || "").trim();
+    if (sleeperId) {
+      const byId = normalizePos(posById[sleeperId] || "");
+      if (byId && byId !== "?" && byId !== "UNKNOWN") return byId;
+    }
+
+    // Legacy name map fallback is allowed only when linked to a stable Sleeper ID.
+    const mappedId = String(playerIds?.[name] || "").trim();
+    if (sleeperId && mappedId && sleeperId === mappedId) {
+      const byName = normalizePos(posMap[name] || "");
+      if (byName && byName !== "?" && byName !== "UNKNOWN") return byName;
+    }
+    return canonical;
+  }
 
   if (playersArray.length) {
     for (const player of playersArray) {
@@ -141,7 +163,7 @@ export function buildRows(data) {
       rows.push({
         name,
         pos: pos || "?",
-        assetClass: String(player.assetClass || classifyPos(pos || "?")),
+        assetClass: classifyPos(pos || "?"),
         values: {
           raw: Math.round(values.raw),
           scoring: Math.round(values.scoring),
@@ -180,7 +202,7 @@ export function buildRows(data) {
   for (const [name, player] of Object.entries(players)) {
     if (!player || typeof player !== "object") continue;
     const isPick = /\b(20\d{2})\s+(early|mid|late)?\s*(1st|2nd|3rd|4th|5th|6th|round|r\d|pick)/i.test(name) || /^20\d{2}\s+pick/i.test(name);
-    const pos = isPick ? "PICK" : normalizePos(posMap[name] || player.position || "");
+    const pos = isPick ? "PICK" : resolveLegacyPlayerPos(name, player);
     if (pos === "K") continue;
 
     const values = inferValueBundle(player);

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -145,9 +145,9 @@ def _is_unknown_pos(pos: Any) -> bool:
 def _build_sleeper_positions_by_id(sleeper: dict[str, Any]) -> dict[str, str]:
     """Build a stable Sleeper-ID keyed position map.
 
-    Primary source is ``sleeper.positionsById``. Legacy fallback derives from
-    ``sleeper.positions`` + ``sleeper.playerIds`` and only keeps unambiguous ID
-    mappings.
+    Primary source is ``sleeper.positionsById`` (preferred, but may be partial).
+    Legacy fallback derives from ``sleeper.positions`` + ``sleeper.playerIds``
+    and only backfills IDs missing from explicit map.
     """
     out: dict[str, str] = {}
     explicit = sleeper.get("positionsById")
@@ -157,29 +157,30 @@ def _build_sleeper_positions_by_id(sleeper: dict[str, Any]) -> dict[str, str]:
             pos = _normalize_pos(raw_pos)
             if sid_s and not _is_unknown_pos(pos):
                 out[sid_s] = pos
-        if out:
-            return out
 
     by_name = sleeper.get("positions")
     player_ids = sleeper.get("playerIds")
     if not isinstance(by_name, dict) or not isinstance(player_ids, dict):
         return out
 
+    legacy_candidates: dict[str, str] = {}
     conflicts: set[str] = set()
     for name, sid_raw in player_ids.items():
         sid = str(sid_raw or "").strip()
-        if not sid:
+        if not sid or sid in out:
             continue
         pos = _normalize_pos(by_name.get(name))
         if _is_unknown_pos(pos):
             continue
-        if sid in out and out[sid] != pos:
+        existing = legacy_candidates.get(sid)
+        if existing and existing != pos:
             conflicts.add(sid)
             continue
-        out[sid] = pos
+        legacy_candidates[sid] = pos
 
     for sid in conflicts:
-        out.pop(sid, None)
+        legacy_candidates.pop(sid, None)
+    out.update(legacy_candidates)
     return out
 
 

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -8,7 +8,7 @@ from typing import Any
 from src.data_models.contracts import utc_now_iso
 
 
-CONTRACT_VERSION = "2026-03-10.v2"
+CONTRACT_VERSION = "2026-04-06.v1"
 
 # ── KTC-only rankings: single source of truth ─────────────────────────────────
 # rank_to_value() is imported from src.canonical.player_valuation — that module
@@ -25,6 +25,9 @@ CONTRACT_VERSION = "2026-03-10.v2"
 # ─────────────────────────────────────────────────────────────────────────────
 KTC_RANK_LIMIT: int = 500
 _KICKER_POSITIONS = {"K", "PK"}
+_OFFENSE_POSITIONS = {"QB", "RB", "WR", "TE"}
+_IDP_POSITIONS = {"DL", "DE", "DT", "LB", "DB", "CB", "S", "EDGE"}
+_UNKNOWN_POSITIONS = {"", "?", "UNKNOWN", "N/A", "NA"}
 
 
 def _compute_ktc_rankings(
@@ -135,6 +138,51 @@ def _normalize_pos(pos: Any) -> str:
     return POSITION_ALIASES.get(p, p)
 
 
+def _is_unknown_pos(pos: Any) -> bool:
+    return _normalize_pos(pos) in _UNKNOWN_POSITIONS
+
+
+def _build_sleeper_positions_by_id(sleeper: dict[str, Any]) -> dict[str, str]:
+    """Build a stable Sleeper-ID keyed position map.
+
+    Primary source is ``sleeper.positionsById``. Legacy fallback derives from
+    ``sleeper.positions`` + ``sleeper.playerIds`` and only keeps unambiguous ID
+    mappings.
+    """
+    out: dict[str, str] = {}
+    explicit = sleeper.get("positionsById")
+    if isinstance(explicit, dict):
+        for sid, raw_pos in explicit.items():
+            sid_s = str(sid or "").strip()
+            pos = _normalize_pos(raw_pos)
+            if sid_s and not _is_unknown_pos(pos):
+                out[sid_s] = pos
+        if out:
+            return out
+
+    by_name = sleeper.get("positions")
+    player_ids = sleeper.get("playerIds")
+    if not isinstance(by_name, dict) or not isinstance(player_ids, dict):
+        return out
+
+    conflicts: set[str] = set()
+    for name, sid_raw in player_ids.items():
+        sid = str(sid_raw or "").strip()
+        if not sid:
+            continue
+        pos = _normalize_pos(by_name.get(name))
+        if _is_unknown_pos(pos):
+            continue
+        if sid in out and out[sid] != pos:
+            conflicts.add(sid)
+            continue
+        out[sid] = pos
+
+    for sid in conflicts:
+        out.pop(sid, None)
+    return out
+
+
 def _is_pick_name(name: str) -> bool:
     n = str(name or "").strip()
     if not n:
@@ -200,11 +248,19 @@ def _player_value_bundle(p_data: dict[str, Any]) -> dict[str, int | None]:
 def _derive_player_row(
     name: str,
     p_data: dict[str, Any],
-    pos_map: dict[str, Any],
+    sleeper_positions_by_id: dict[str, Any],
     site_keys: list[str],
 ) -> dict[str, Any]:
     canonical_name = str(name or "").strip()
-    pos = _normalize_pos(pos_map.get(canonical_name) or p_data.get("position"))
+    player_id = str(p_data.get("_sleeperId") or "").strip() or None
+    canonical_pos = _normalize_pos(p_data.get("position"))
+    fallback_pos = _normalize_pos(sleeper_positions_by_id.get(player_id)) if player_id else ""
+    pos = canonical_pos
+    if _is_unknown_pos(pos) and not _is_unknown_pos(fallback_pos):
+        pos = fallback_pos
+    elif pos in _OFFENSE_POSITIONS and fallback_pos in _IDP_POSITIONS:
+        # Hard guard: never allow IDP fallback to overwrite canonical offense.
+        pos = canonical_pos
     is_pick = _is_pick_name(canonical_name)
     if is_pick:
         pos = "PICK"
@@ -214,7 +270,7 @@ def _derive_player_row(
     source_count = _source_count(p_data, canonical_sites)
 
     return {
-        "playerId": str(p_data.get("_sleeperId") or "").strip() or None,
+        "playerId": player_id,
         "canonicalName": canonical_name,
         "displayName": canonical_name,
         "position": pos or None,
@@ -300,10 +356,11 @@ def build_api_data_contract(
         sleeper = {}
         base["sleeper"] = sleeper
 
-    pos_map = sleeper.get("positions")
-    if not isinstance(pos_map, dict):
-        pos_map = {}
-        sleeper["positions"] = pos_map
+    if not isinstance(sleeper.get("positions"), dict):
+        sleeper["positions"] = {}
+    sleeper_positions_by_id = _build_sleeper_positions_by_id(sleeper)
+    if sleeper_positions_by_id:
+        sleeper["positionsById"] = sleeper_positions_by_id
 
     site_keys = [str(s.get("key")) for s in sites if isinstance(s, dict) and s.get("key")]
     players_array: list[dict[str, Any]] = []
@@ -311,7 +368,9 @@ def build_api_data_contract(
         p_data = players_by_name.get(name)
         if not isinstance(p_data, dict):
             continue
-        players_array.append(_derive_player_row(str(name), p_data, pos_map, site_keys))
+        players_array.append(
+            _derive_player_row(str(name), p_data, sleeper_positions_by_id, site_keys)
+        )
 
     # Compute KTC-only integer ranks and rank-derived values.
     # This is the single source of truth for ktcRank / rankDerivedValue.
@@ -741,6 +800,49 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
         warnings.append("playersArray is empty")
     if not site_keys:
         warnings.append("sites is empty or missing keys")
+
+    idp_count = 0
+    offense_misclassified: list[str] = []
+    players_lookup = players_map if isinstance(players_map, dict) else {}
+    idp_expected_from_canonical = False
+    for pdata in players_lookup.values():
+        if not isinstance(pdata, dict):
+            continue
+        if _normalize_pos(pdata.get("position")) in _IDP_POSITIONS:
+            idp_expected_from_canonical = True
+            break
+
+    sleeper = payload.get("sleeper")
+    if isinstance(sleeper, dict):
+        positions_by_id = sleeper.get("positionsById")
+        if isinstance(positions_by_id, dict):
+            for raw_pos in positions_by_id.values():
+                if _normalize_pos(raw_pos) in _IDP_POSITIONS:
+                    idp_expected_from_canonical = True
+                    break
+
+    for row in players_array:
+        if not isinstance(row, dict):
+            continue
+        row_pos = _normalize_pos(row.get("position"))
+        if row_pos in _IDP_POSITIONS:
+            idp_count += 1
+        legacy_ref = str(row.get("legacyRef") or "").strip()
+        p_data = players_lookup.get(legacy_ref)
+        canonical_pos = _normalize_pos(p_data.get("position")) if isinstance(p_data, dict) else ""
+        if canonical_pos in _OFFENSE_POSITIONS and row_pos in _IDP_POSITIONS:
+            offense_misclassified.append(legacy_ref or str(row.get("canonicalName") or ""))
+
+    if offense_misclassified:
+        sample = ", ".join(offense_misclassified[:5])
+        errors.append(
+            f"offense players emitted in IDP buckets: {sample}"
+        )
+
+    if idp_expected_from_canonical and idp_count < 8:
+        errors.append(
+            f"implausibly tiny IDP pool: {idp_count} IDP players emitted while IDP data is present"
+        )
 
     # Optional: canonicalComparison (shadow mode comparison block).
     canonical_cmp = payload.get("canonicalComparison")

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -405,6 +405,39 @@ class TestContractWithCanonicalComparison(unittest.TestCase):
 
 
 class TestPositionSafetyAndIdpIntegrity(unittest.TestCase):
+    def test_partial_positions_by_id_is_backfilled_from_legacy_id_map(self):
+        raw = {
+            "players": {
+                "Player A": {
+                    "_sleeperId": "1",
+                    "_composite": 7000,
+                    "_rawComposite": 7000,
+                    "_finalAdjusted": 7000,
+                    "_canonicalSiteValues": {"ktc": 7000},
+                    "position": "",
+                },
+                "Player B": {
+                    "_sleeperId": "2",
+                    "_composite": 6800,
+                    "_rawComposite": 6800,
+                    "_finalAdjusted": 6800,
+                    "_canonicalSiteValues": {"ktc": 6800},
+                    "position": "",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "sleeper": {
+                "positionsById": {"1": "QB"},
+                "positions": {"Player A": "QB", "Player B": "WR"},
+                "playerIds": {"Player A": "1", "Player B": "2"},
+            },
+        }
+        payload = build_api_data_contract(raw)
+        pos_by_name = {r["canonicalName"]: r["position"] for r in payload["playersArray"]}
+        self.assertEqual(pos_by_name["Player A"], "QB")  # explicit positionsById
+        self.assertEqual(pos_by_name["Player B"], "WR")  # backfilled from legacy map
+        self.assertEqual(payload["sleeper"]["positionsById"]["2"], "WR")
+
     def test_canonical_offense_position_wins_over_name_based_idp_map(self):
         raw = {
             "players": {
@@ -427,6 +460,38 @@ class TestPositionSafetyAndIdpIntegrity(unittest.TestCase):
         allen = payload["playersArray"][0]
         self.assertEqual(allen["position"], "QB")
         self.assertEqual(allen["assetClass"], "offense")
+
+    def test_rankings_pool_not_shrunk_by_partial_positions_by_id(self):
+        raw = {
+            "players": {
+                "QB One": {
+                    "_sleeperId": "11",
+                    "_composite": 9000,
+                    "_rawComposite": 9000,
+                    "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktc": 9000},
+                    "position": "",
+                },
+                "WR Two": {
+                    "_sleeperId": "22",
+                    "_composite": 8500,
+                    "_rawComposite": 8500,
+                    "_finalAdjusted": 8500,
+                    "_canonicalSiteValues": {"ktc": 8500},
+                    "position": "",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "sleeper": {
+                "positionsById": {"11": "QB"},  # partial on purpose
+                "positions": {"QB One": "QB", "WR Two": "WR"},
+                "playerIds": {"QB One": "11", "WR Two": "22"},
+            },
+        }
+        payload = build_api_data_contract(raw)
+        ranked = [r for r in payload["playersArray"] if r.get("ktcRank")]
+        self.assertEqual(len(ranked), 2)
+        self.assertEqual({r["canonicalName"] for r in ranked}, {"QB One", "WR Two"})
 
     def test_fallback_position_requires_stable_id_match(self):
         raw = {
@@ -512,6 +577,44 @@ class TestPositionSafetyAndIdpIntegrity(unittest.TestCase):
             any("offense players emitted in IDP buckets" in err for err in report["errors"]),
             report["errors"],
         )
+
+    def test_name_collision_cannot_reclassify_offense_with_backfill(self):
+        raw = {
+            "players": {
+                "Alex Smith": {
+                    "_sleeperId": "off-1",
+                    "_composite": 7000,
+                    "_rawComposite": 7000,
+                    "_finalAdjusted": 7000,
+                    "_canonicalSiteValues": {"ktc": 7000},
+                    "position": "QB",
+                },
+                "Alex Smith IDP": {
+                    "_sleeperId": "def-2",
+                    "_composite": 4200,
+                    "_rawComposite": 4200,
+                    "_finalAdjusted": 4200,
+                    "_canonicalSiteValues": {"ktc": 4200},
+                    "position": "",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "sleeper": {
+                "positionsById": {"def-2": "LB"},  # offense id intentionally missing
+                "positions": {
+                    "Alex Smith": "LB",       # unsafe name map entry (defender)
+                    "Alex Smith IDP": "LB",
+                },
+                "playerIds": {
+                    "Alex Smith": "def-2",    # points to defender ID, not offense ID
+                    "Alex Smith IDP": "def-2",
+                },
+            },
+        }
+        payload = build_api_data_contract(raw)
+        by_name = {r["canonicalName"]: r for r in payload["playersArray"]}
+        self.assertEqual(by_name["Alex Smith"]["position"], "QB")
+        self.assertEqual(by_name["Alex Smith"]["assetClass"], "offense")
 
 
 class TestComputeKtcRankings(unittest.TestCase):

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -404,6 +404,116 @@ class TestContractWithCanonicalComparison(unittest.TestCase):
         self.assertIn("canonicalComparison", runtime)
 
 
+class TestPositionSafetyAndIdpIntegrity(unittest.TestCase):
+    def test_canonical_offense_position_wins_over_name_based_idp_map(self):
+        raw = {
+            "players": {
+                "Josh Allen": {
+                    "_sleeperId": "111",
+                    "_composite": 9000,
+                    "_rawComposite": 9000,
+                    "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktc": 9000},
+                    "position": "QB",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "sleeper": {
+                "positions": {"Josh Allen": "LB"},
+                "playerIds": {"Josh Allen": "111"},
+            },
+        }
+        payload = build_api_data_contract(raw)
+        allen = payload["playersArray"][0]
+        self.assertEqual(allen["position"], "QB")
+        self.assertEqual(allen["assetClass"], "offense")
+
+    def test_fallback_position_requires_stable_id_match(self):
+        raw = {
+            "players": {
+                "Alex Carter (OFF)": {
+                    "_sleeperId": "1001",
+                    "_composite": 5000,
+                    "_rawComposite": 5000,
+                    "_finalAdjusted": 5000,
+                    "_canonicalSiteValues": {"ktc": 5000},
+                    "position": "",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "sleeper": {
+                "positions": {"Alex Carter (OFF)": "LB"},
+                "playerIds": {"Alex Carter (OFF)": "2002"},
+                "positionsById": {"2002": "LB"},
+            },
+        }
+        payload = build_api_data_contract(raw)
+        row = payload["playersArray"][0]
+        # No stable-ID match -> keep canonical unknown instead of guessing from name.
+        self.assertIsNone(row["position"])
+
+    def test_idp_pool_validation_fails_when_idp_data_present_but_output_tiny(self):
+        raw = {
+            "players": {
+                f"LB Player {i}": {
+                    "_sleeperId": str(i),
+                    "_composite": 4000 + i,
+                    "_rawComposite": 4000 + i,
+                    "_finalAdjusted": 4000 + i,
+                    "_canonicalSiteValues": {"ktc": 4000 + i},
+                    "position": "LB",
+                }
+                for i in range(4)
+            },
+            "sites": [{"key": "ktc"}],
+            "sleeper": {"positionsById": {str(i): "LB" for i in range(4)}},
+        }
+        payload = build_api_data_contract(raw)
+        report = validate_api_data_contract(payload)
+        self.assertFalse(report["ok"])
+        self.assertTrue(
+            any("implausibly tiny IDP pool" in err for err in report["errors"]),
+            report["errors"],
+        )
+
+    def test_idp_pool_validation_passes_with_plausible_defensive_pool(self):
+        players = {}
+        for i in range(10):
+            players[f"Defender {i}"] = {
+                "_sleeperId": f"d{i}",
+                "_composite": 3500 + i,
+                "_rawComposite": 3500 + i,
+                "_finalAdjusted": 3500 + i,
+                "_canonicalSiteValues": {"ktc": 3500 + i},
+                "position": "LB" if i % 2 == 0 else "DL",
+            }
+        players["Offense Anchor"] = {
+            "_sleeperId": "o1",
+            "_composite": 9000,
+            "_rawComposite": 9000,
+            "_finalAdjusted": 9000,
+            "_canonicalSiteValues": {"ktc": 9000},
+            "position": "QB",
+        }
+        payload = build_api_data_contract({
+            "players": players,
+            "sites": [{"key": "ktc"}],
+            "sleeper": {"positionsById": {f"d{i}": ("LB" if i % 2 == 0 else "DL") for i in range(10)}},
+        })
+        report = validate_api_data_contract(payload)
+        self.assertTrue(report["ok"], report["errors"])
+
+    def test_validation_fails_if_offense_player_emitted_as_idp(self):
+        payload = build_api_data_contract(_minimal_raw_payload())
+        payload["playersArray"][0]["position"] = "LB"
+        report = validate_api_data_contract(payload)
+        self.assertFalse(report["ok"])
+        self.assertTrue(
+            any("offense players emitted in IDP buckets" in err for err in report["errors"]),
+            report["errors"],
+        )
+
+
 class TestComputeKtcRankings(unittest.TestCase):
     """Tests for _compute_ktc_rankings — the backend single source of truth.
 


### PR DESCRIPTION
### Motivation
- Fix an active bug where `sleeper.positions[name]` (name-keyed) could override canonical `players[name].position` and misclassify offensive players as IDP, corrupting rankings and filters.
- Ensure canonical player metadata is the authoritative source for position assignment and avoid unsafe name-based lookups that collide across offense/defense.
- Provide fail-loud contract validation when IDP coverage looks implausible or when offense players are emitted into IDP buckets.

### Description
- Make `players[name].position` authoritative in `_derive_player_row()` and only allow fallback when tied to a stable Sleeper identifier by adding `_build_sleeper_positions_by_id()` and passing `sleeper.positionsById` into `_derive_player_row()` instead of a name-keyed map.
- Add hard guard preventing IDP fallback from overwriting canonical offense positions (`QB/RB/WR/TE`) and normalize unknown positions handling. (changes in `src/api/data_contract.py`, including a `contractVersion` bump to `2026-04-06.v1`).
- Publish an ID-keyed position map during ingestion and preserve legacy name map by updating `Dynasty Scraper.py` to emit `positionsById` alongside `positions`. (`Dynasty Scraper.py`).
- Harden frontend ingestion/row-building so `buildRows()` prefers canonical `player.position`, only uses legacy name-based fallback when a stable Sleeper ID matches, and recomputes `assetClass` from the resolved position. (`frontend/lib/dynasty-data.js`).
- Add validation and unit tests covering canonical precedence, stable-ID fallback requirement, name-collision safety, defensive-pool plausibility, and offense-in-IDP failure modes; tests added/extended in `tests/api/test_data_contract.py` and `frontend/__tests__/dynasty-data.test.js`.
- Files changed: `src/api/data_contract.py`, `Dynasty Scraper.py`, `frontend/lib/dynasty-data.js`, `tests/api/test_data_contract.py`, and `frontend/__tests__/dynasty-data.test.js`.

### Testing
- Ran Python unit tests: `python -m pytest tests/api/test_data_contract.py -q` and all tests passed (47 passed).
- Ran frontend tests: from `frontend/` run `npm test -- --run __tests__/dynasty-data.test.js` and vitest reported `1 test file` with `42 passed` tests.
- New tests explicitly assert that canonical offense positions cannot be overwritten by name-based IDP mappings, that fallback requires stable ID agreement, that tiny/implausible IDP pools trigger contract validation failures, and that normal defensive pools pass validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3dff83d70832dbd7dc86230d54c84)