### PR TITLE
Fix deploy bootstrap: refresh deploy.sh before execution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -349,6 +349,14 @@ jobs:
             fi
           fi
 
+          # Always refresh deploy.sh from the target ref before running it.
+          # This prevents stale deploy scripts on the production server from
+          # blocking deployments that include deploy-script fixes.
+          git -C "\${APP_DIR}" fetch --prune origin 2>/dev/null || true
+          if git -C "\${APP_DIR}" rev-parse --verify --quiet "\${DEPLOY_REF}^{commit}" >/dev/null 2>&1; then
+            git -C "\${APP_DIR}" show "\${DEPLOY_REF}:deploy/deploy.sh" > "\${APP_DIR}/deploy/deploy.sh" 2>/dev/null || true
+          fi
+
           [[ -f "\${APP_DIR}/deploy/deploy.sh" ]] || { echo "[remote] Missing deploy script after bootstrap: \${APP_DIR}/deploy/deploy.sh" >&2; exit 23; }
           bash "\${APP_DIR}/deploy/deploy.sh"
           EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -352,9 +352,16 @@ jobs:
           # Always refresh deploy.sh from the target ref before running it.
           # This prevents stale deploy scripts on the production server from
           # blocking deployments that include deploy-script fixes.
+          # Write to a temp file first so a failed git-show does not truncate
+          # the existing script to zero bytes.
           git -C "\${APP_DIR}" fetch --prune origin 2>/dev/null || true
           if git -C "\${APP_DIR}" rev-parse --verify --quiet "\${DEPLOY_REF}^{commit}" >/dev/null 2>&1; then
-            git -C "\${APP_DIR}" show "\${DEPLOY_REF}:deploy/deploy.sh" > "\${APP_DIR}/deploy/deploy.sh" 2>/dev/null || true
+            _tmp_deploy="\${APP_DIR}/deploy/.deploy.sh.tmp"
+            if git -C "\${APP_DIR}" show "\${DEPLOY_REF}:deploy/deploy.sh" > "\${_tmp_deploy}" 2>/dev/null && [[ -s "\${_tmp_deploy}" ]]; then
+              mv -f "\${_tmp_deploy}" "\${APP_DIR}/deploy/deploy.sh"
+            else
+              rm -f "\${_tmp_deploy}"
+            fi
           fi
 
           [[ -f "\${APP_DIR}/deploy/deploy.sh" ]] || { echo "[remote] Missing deploy script after bootstrap: \${APP_DIR}/deploy/deploy.sh" >&2; exit 23; }


### PR DESCRIPTION
## Summary

- Fix deploy chicken-and-egg: production server runs the old `deploy.sh` from its existing checkout, which crashes at the `--include-untracked=false` bug before ever fetching the fix. The workflow now does `git show DEPLOY_REF:deploy/deploy.sh` to overwrite the stale copy before running it.

## Test plan

- [x] 812 tests pass
- [ ] Re-run deploy workflow after merge — should pass the stash step

https://claude.ai/code/session_01FWq9HruGSis9qi9Z3CkSgu