### PR TITLE
Blended rank with decimals, sortable columns, unified values

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -349,6 +349,14 @@ jobs:
             fi
           fi
 
+          # Always refresh deploy.sh from the target ref before running it.
+          # This prevents stale deploy scripts on the production server from
+          # blocking deployments that include deploy-script fixes.
+          git -C "\${APP_DIR}" fetch --prune origin 2>/dev/null || true
+          if git -C "\${APP_DIR}" rev-parse --verify --quiet "\${DEPLOY_REF}^{commit}" >/dev/null 2>&1; then
+            git -C "\${APP_DIR}" show "\${DEPLOY_REF}:deploy/deploy.sh" > "\${APP_DIR}/deploy/deploy.sh" 2>/dev/null || true
+          fi
+
           [[ -f "\${APP_DIR}/deploy/deploy.sh" ]] || { echo "[remote] Missing deploy script after bootstrap: \${APP_DIR}/deploy/deploy.sh" >&2; exit 23; }
           bash "\${APP_DIR}/deploy/deploy.sh"
           EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -352,9 +352,16 @@ jobs:
           # Always refresh deploy.sh from the target ref before running it.
           # This prevents stale deploy scripts on the production server from
           # blocking deployments that include deploy-script fixes.
+          # Write to a temp file first so a failed git-show does not truncate
+          # the existing script to zero bytes.
           git -C "\${APP_DIR}" fetch --prune origin 2>/dev/null || true
           if git -C "\${APP_DIR}" rev-parse --verify --quiet "\${DEPLOY_REF}^{commit}" >/dev/null 2>&1; then
-            git -C "\${APP_DIR}" show "\${DEPLOY_REF}:deploy/deploy.sh" > "\${APP_DIR}/deploy/deploy.sh" 2>/dev/null || true
+            _tmp_deploy="\${APP_DIR}/deploy/.deploy.sh.tmp"
+            if git -C "\${APP_DIR}" show "\${DEPLOY_REF}:deploy/deploy.sh" > "\${_tmp_deploy}" 2>/dev/null && [[ -s "\${_tmp_deploy}" ]]; then
+              mv -f "\${_tmp_deploy}" "\${APP_DIR}/deploy/deploy.sh"
+            else
+              rm -f "\${_tmp_deploy}"
+            fi
           fi
 
           [[ -f "\${APP_DIR}/deploy/deploy.sh" ]] || { echo "[remote] Missing deploy script after bootstrap: \${APP_DIR}/deploy/deploy.sh" >&2; exit 23; }

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -456,6 +456,51 @@ def similarity(a, b):
     return base + adjustment
 
 
+# ── Position-family normalization for cross-source matching ──────────────
+_POS_FAMILY_MAP = {
+    "DE": "DL", "DT": "DL", "EDGE": "DL", "NT": "DL", "DL": "DL",
+    "CB": "DB", "S": "DB", "FS": "DB", "SS": "DB", "DB": "DB",
+    "OLB": "LB", "ILB": "LB", "MLB": "LB", "LB": "LB",
+    "QB": "QB", "RB": "RB", "WR": "WR", "TE": "TE", "K": "K",
+}
+
+def _pos_family(pos_raw):
+    """Normalize a position to its family (DL, DB, LB, QB, RB, WR, TE)."""
+    if not pos_raw:
+        return ""
+    return _POS_FAMILY_MAP.get(pos_raw.strip().upper(), pos_raw.strip().upper())
+
+def _get_sleeper_pos(name):
+    """Look up a player's position from SLEEPER_ROSTER_DATA (if available)."""
+    pos_map = SLEEPER_ROSTER_DATA.get("positions", {})
+    if not pos_map:
+        return ""
+    # Exact match
+    pos = pos_map.get(name, "")
+    if pos:
+        return _pos_family(pos)
+    # Case-insensitive fallback
+    nl = name.lower()
+    for k, v in pos_map.items():
+        if k.lower() == nl:
+            return _pos_family(v)
+    return ""
+
+def _positions_compatible(name_a, name_b):
+    """Check whether two player names have compatible positions.
+
+    Returns True if:
+    - either player has no known position (can't reject)
+    - both have the same position family
+    Returns False if both have known but different position families.
+    """
+    pos_a = _get_sleeper_pos(name_a)
+    pos_b = _get_sleeper_pos(name_b)
+    if not pos_a or not pos_b:
+        return True  # Can't reject without position data
+    return pos_a == pos_b
+
+
 def best_match(target, candidates, threshold=0.78, match_guard=None):
     """Find the best fuzzy match for target among candidates.
 
@@ -493,7 +538,16 @@ def _first_name_compatible(a_first, b_first):
 
 
 def _is_safe_name_merge(src_name, dst_name):
-    """Guard fuzzy canonicalization so unrelated players are not merged."""
+    """Guard fuzzy canonicalization so unrelated players are not merged.
+
+    Checks both name structure AND position compatibility. Two players
+    with known but different position families (e.g. WR vs DB) are never
+    merged, even if their names are similar.
+    """
+    # Position gate: reject if both players have known incompatible positions
+    if not _positions_compatible(src_name, dst_name):
+        return False
+
     src = _name_tokens(src_name)
     dst = _name_tokens(dst_name)
     if len(src) < 2 or len(dst) < 2:
@@ -579,10 +633,11 @@ def match_all(players, name_map, results, site_key=None):
             ikey = (p_initial, p_remaining)
             if ikey in initial_index:
                 orig_key = initial_index[ikey]
-                results[player] = name_map[orig_key]
-                if DEBUG:
-                    print(f"    ✓ '{player}' → initial match '{orig_key}' ({name_map[orig_key]})")
-                continue
+                if _positions_compatible(player, orig_key):
+                    results[player] = name_map[orig_key]
+                    if DEBUG:
+                        print(f"    ✓ '{player}' → initial match '{orig_key}' ({name_map[orig_key]})")
+                    continue
             # Looser initial+last fallback for names with middle tokens.
             ikey_last = (p_initial, p_parts[-1])
             if ikey_last in initial_last_index:

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -70,8 +70,8 @@ export default function RankingsPage() {
       let va, vb;
       switch (sortCol) {
         case "rank":
-          va = resolvedRank(a);
-          vb = resolvedRank(b);
+          va = a.blendedSourceRank ?? Infinity;
+          vb = b.blendedSourceRank ?? Infinity;
           return (va - vb) * dir;
         case "name":
           return a.name.localeCompare(b.name) * dir;
@@ -197,7 +197,7 @@ export default function RankingsPage() {
                 {ranked.map((row) => (
                   <tr key={row.name}>
                     <td style={{ textAlign: "center", fontWeight: 700, color: "var(--cyan)", fontFamily: "var(--mono, monospace)" }}>
-                      {row.rank}
+                      {row.blendedSourceRank != null ? row.blendedSourceRank.toFixed(1) : row.rank}
                     </td>
                     <td style={{ fontWeight: 600, cursor: "pointer" }} onClick={() => openPlayerPopup?.(row)}>{row.name}</td>
                     <td><span className="badge">{row.pos}</span></td>

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -58,6 +58,8 @@ export default function TradePage() {
   const { settings } = useSettings();
   const { openPlayerPopup, registerAddToTrade } = useApp();
   const [valueMode, setValueMode] = useState("full");
+  const [pickerSortCol, setPickerSortCol] = useState("rank");
+  const [pickerSortAsc, setPickerSortAsc] = useState(true);
   const [sideA, setSideA] = useState([]);
   const [sideB, setSideB] = useState([]);
   const [activeSide, setActiveSide] = useState("A");
@@ -160,8 +162,34 @@ export default function TradePage() {
     let list = rows.filter((r) => !isInTrade.has(r.name));
     if (pickerFilter !== "all") list = list.filter((r) => r.assetClass === pickerFilter);
     if (q) list = list.filter((r) => r.name.toLowerCase().includes(q));
-    return list.slice(0, 80);
-  }, [rows, sideA, sideB, pickerQuery, pickerFilter]);
+    // Sort by selected column
+    const dir = pickerSortAsc ? 1 : -1;
+    list = [...list].sort((a, b) => {
+      let va, vb;
+      switch (pickerSortCol) {
+        case "rank":
+          va = a.blendedSourceRank ?? Infinity; vb = b.blendedSourceRank ?? Infinity;
+          return (va - vb) * dir;
+        case "name":
+          return a.name.localeCompare(b.name) * dir;
+        case "pos":
+          return (a.pos || "").localeCompare(b.pos || "") * dir;
+        case "value":
+          va = a.rankDerivedValue || a.values?.full || 0; vb = b.rankDerivedValue || b.values?.full || 0;
+          return (va - vb) * dir;
+        case "ktc":
+          va = Number(a.canonicalSites?.ktc) || 0; vb = Number(b.canonicalSites?.ktc) || 0;
+          return (va - vb) * dir;
+        case "idpTradeCalc":
+          va = Number(a.canonicalSites?.idpTradeCalc) || 0; vb = Number(b.canonicalSites?.idpTradeCalc) || 0;
+          return (va - vb) * dir;
+        default:
+          va = a.blendedSourceRank ?? Infinity; vb = b.blendedSourceRank ?? Infinity;
+          return (va - vb) * dir;
+      }
+    });
+    return list.slice(0, 100);
+  }, [rows, sideA, sideB, pickerQuery, pickerFilter, pickerSortCol, pickerSortAsc]);
 
   const recentRows = useMemo(() => recentNames.map((n) => rowByName.get(n)).filter(Boolean), [recentNames, rowByName]);
 
@@ -335,7 +363,7 @@ export default function TradePage() {
                             </span>
                           )}
                         </div>
-                        <div className="asset-meta">{r.pos} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
+                        <div className="asset-meta">{r.pos} · Rank {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
                       </div>
                       <button className="button" onClick={() => removeFromSide(r.name, "A")}>Remove</button>
                     </div>
@@ -385,7 +413,7 @@ export default function TradePage() {
                             </span>
                           )}
                         </div>
-                        <div className="asset-meta">{r.pos} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
+                        <div className="asset-meta">{r.pos} · Rank {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
                       </div>
                       <button className="button" onClick={() => removeFromSide(r.name, "B")}>Remove</button>
                     </div>
@@ -747,7 +775,7 @@ export default function TradePage() {
                         <button key={`recent-${r.name}`} className="asset-row button-reset" onClick={() => addToActiveSide(r)}>
                           <div>
                             <div className="asset-name">{r.name}</div>
-                            <div className="asset-meta">{r.pos} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
+                            <div className="asset-meta">{r.pos} · Rank {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
                           </div>
                           <span className="badge">Add</span>
                         </button>
@@ -755,17 +783,52 @@ export default function TradePage() {
                     </div>
                   </div>
                 )}
-                <div className="list" style={{ marginTop: 10, maxHeight: "52vh", overflow: "auto", paddingRight: 4 }}>
-                  {pickerRows.map((r) => (
-                    <button key={`pick-${r.name}`} className="asset-row button-reset" onClick={() => addToActiveSide(r)}>
-                      <div>
-                        <div className="asset-name">{r.name}</div>
-                        <div className="asset-meta">{r.pos} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
-                      </div>
-                      <span className="badge">Add</span>
-                    </button>
-                  ))}
-                  {pickerRows.length === 0 && <div className="muted">No assets match.</div>}
+                <div className="table-wrap" style={{ marginTop: 10, maxHeight: "52vh", overflow: "auto" }}>
+                  <table style={{ width: "100%", fontSize: "0.78rem" }}>
+                    <thead>
+                      <tr>
+                        {[
+                          { col: "rank", label: "Our Rank", style: { width: 70, textAlign: "center" } },
+                          { col: "name", label: "Player" },
+                          { col: "pos", label: "Pos", style: { width: 50 } },
+                          { col: "value", label: "Our Value", style: { width: 80, textAlign: "right" } },
+                          { col: "ktc", label: "KTC", style: { width: 65, textAlign: "right" } },
+                          { col: "idpTradeCalc", label: "IDPTC", style: { width: 65, textAlign: "right" } },
+                        ].map(({ col, label, style }) => (
+                          <th key={col} style={{ cursor: "pointer", userSelect: "none", whiteSpace: "nowrap", ...style }}
+                            onClick={() => {
+                              if (pickerSortCol === col) setPickerSortAsc((p) => !p);
+                              else { setPickerSortCol(col); setPickerSortAsc(["rank", "name", "pos"].includes(col)); }
+                            }}>
+                            {label}{pickerSortCol === col ? (pickerSortAsc ? " ▲" : " ▼") : ""}
+                          </th>
+                        ))}
+                        <th style={{ width: 40 }}></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pickerRows.map((r) => (
+                        <tr key={`pick-${r.name}`} style={{ cursor: "pointer" }} onClick={() => addToActiveSide(r)}>
+                          <td style={{ textAlign: "center", fontFamily: "var(--mono, monospace)", fontWeight: 600, color: "var(--cyan)" }}>
+                            {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"}
+                          </td>
+                          <td style={{ fontWeight: 600 }}>{r.name}</td>
+                          <td><span className="badge">{r.pos}</span></td>
+                          <td style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontWeight: 600 }}>
+                            {Math.round(r.rankDerivedValue || r.values?.full || 0).toLocaleString()}
+                          </td>
+                          <td style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.74rem" }}>
+                            {r.canonicalSites?.ktc != null ? Math.round(Number(r.canonicalSites.ktc)).toLocaleString() : "—"}
+                          </td>
+                          <td style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.74rem" }}>
+                            {r.canonicalSites?.idpTradeCalc != null ? Math.round(Number(r.canonicalSites.idpTradeCalc)).toLocaleString() : "—"}
+                          </td>
+                          <td><span className="badge" style={{ fontSize: "0.6rem" }}>Add</span></td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {pickerRows.length === 0 && <div className="muted" style={{ padding: 8 }}>No assets match.</div>}
                 </div>
               </div>
             </div>

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -129,11 +129,17 @@ function computeUnifiedRanks(rows) {
     const backendRank = Number(r.raw?.canonicalConsensusRank || r.canonicalConsensusRank);
     const backendValue = Number(r.raw?.rankDerivedValue);
 
+    // Blended source rank: mean of the per-source ordinal ranks (with decimals)
+    const sourceRankValues = Object.values(entry.ranks);
+    const blendedSourceRank = sourceRankValues.reduce((s, v) => s + v, 0) / sourceRankValues.length;
+
     r.canonicalConsensusRank = (Number.isInteger(backendRank) && backendRank > 0)
       ? backendRank : (i + 1);
     r.rankDerivedValue = (Number.isFinite(backendValue) && backendValue > 0)
       ? backendValue : Math.round(entry.blended);
     r.sourceRanks = entry.ranks;
+    r.blendedSourceRank = blendedSourceRank;
+    r.sourceCount = sourceRankValues.length;
 
     // Backward compat
     if (entry.ranks.ktc) r.ktcRank = entry.ranks.ktc;

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -476,6 +476,19 @@ def build_api_data_contract(
     # This is the single source of truth for canonicalConsensusRank / rankDerivedValue.
     _compute_unified_rankings(players_array, players_by_name)
 
+    # Stamp rankDerivedValue into the values bundle so every page uses the
+    # same number.  The legacy composite (values.overall / values.finalAdjusted)
+    # comes from the old multi-source scraper and may differ.  The unified
+    # ranking model's rankDerivedValue is the authoritative display value.
+    for row in players_array:
+        rdv = row.get("rankDerivedValue")
+        if rdv is not None and rdv > 0:
+            vals = row.get("values")
+            if isinstance(vals, dict):
+                vals["overall"] = rdv
+                vals["finalAdjusted"] = rdv
+                vals["displayValue"] = rdv
+
     data_source = data_source or {}
     contract_payload: dict[str, Any] = {
         **base,


### PR DESCRIPTION
## Summary

- Blended source rank with decimals (mean of per-source ordinal ranks)
- Sortable columns on rankings page and trade calculator picker
- Unified player values: rankDerivedValue is now the single display value everywhere
- Position-family guard on cross-source player matching (prevents James Williams / Jameson Williams merge)

## Changes

- **Rankings page**: Our Rank shows blendedSourceRank with 1 decimal place, all columns sortable asc/desc
- **Trade calculator**: Picker is now a sortable table with Our Rank, Player, Pos, Our Value, KTC, IDPTC columns
- **Backend**: values.overall/finalAdjusted/displayValue all set to rankDerivedValue after unified ranking
- **Scraper**: Position-family guard in fuzzy matching (DE/DT/EDGE→DL, CB/S→DB)

## Test plan

- [x] 812 tests pass
- [ ] Verify rankings page shows decimal ranks and sortable columns after deploy

https://claude.ai/code/session_01FWq9HruGSis9qi9Z3CkSgu