### PR TITLE
Fix home page crash: use client-side redirect

### DIFF
--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -1,5 +1,12 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function HomePage() {
-  redirect("/rankings");
+  const router = useRouter();
+  useEffect(() => {
+    router.replace("/rankings");
+  }, [router]);
+  return null;
 }


### PR DESCRIPTION
## Summary

Fix client-side exception on home page. The server-side `redirect()` crashed in production. Switch to `useRouter().replace("/rankings")` which works in all Next.js modes.

**This is urgent — the site is currently showing an error page.**

https://claude.ai/code/session_01FWq9HruGSis9qi9Z3CkSgu