### PR TITLE
Dual-scope IDPTradeCalc + dynamic rankings source columns

### DIFF
--- a/docs/trust-edge-handoff.md
+++ b/docs/trust-edge-handoff.md
@@ -25,7 +25,7 @@ Frontend consumer: `frontend/lib/dynasty-data.js` (`buildRows` + `computeUnified
 | `hasSourceDisagreement` | boolean | Sources diverge by >80 ordinal ranks |
 | `sourceRankSpread` | number \| null | Max minus min source rank (null if 1 source) |
 | `blendedSourceRank` | number \| null | Mean of per-source ordinal ranks |
-| `marketGapDirection` | `"ktc_premium"` \| `"consensus_premium"` \| `"none"` | KTC (retail) vs mean rank of other sources (expert consensus) |
+| `marketGapDirection` | `"retail_premium"` \| `"consensus_premium"` \| `"none"` | Retail (sources flagged `is_retail` in the registry — today just KTC) vs mean rank of non-retail sources (expert consensus). Adding a second retail source is a pure registry change. |
 | `marketGapMagnitude` | number \| null | Absolute ordinal rank difference between KTC and consensus mean |
 | `identityConfidence` | float 0.0-1.0 | How confident we are this is the right entity |
 | `identityMethod` | string | Method used: `canonical_id`, `position_source_aligned`, `partial_evidence`, `name_only` |
@@ -85,8 +85,8 @@ Any flag in `_QUARANTINE_FLAGS` set triggers `quarantined = true` and degrades `
 Source agreement dashboard. 6 sections in a 2-column grid:
 1. Consensus Assets — high confidence, multi-source, tight agreement
 2. Biggest Disagreements — highest source rank spread
-3. KTC Premium — players KTC (retail market) values much higher than the expert consensus
-4. Consensus Premium — players the expert consensus values much higher than KTC
+3. Retail Premium (today shown as "KTC Premium") — players the retail market values much higher than the expert consensus. Section title is resolved dynamically from `getRetailLabel()` in `frontend/lib/dynasty-data.js`; adding a second `isRetail` source flips the title to "Retail Premium" automatically.
+4. Consensus Premium — players the expert consensus values much higher than the retail market (inverse of #3)
 5. Flagged Anomalies — data quality flags in top 300
 6. Single-Source Players — valued by only one source
 

--- a/docs/trust-edge-handoff.md
+++ b/docs/trust-edge-handoff.md
@@ -25,8 +25,8 @@ Frontend consumer: `frontend/lib/dynasty-data.js` (`buildRows` + `computeUnified
 | `hasSourceDisagreement` | boolean | Sources diverge by >80 ordinal ranks |
 | `sourceRankSpread` | number \| null | Max minus min source rank (null if 1 source) |
 | `blendedSourceRank` | number \| null | Mean of per-source ordinal ranks |
-| `marketGapDirection` | `"ktc_higher"` \| `"idptc_higher"` \| `"none"` | Which source ranks the player higher |
-| `marketGapMagnitude` | number \| null | Absolute ordinal rank difference |
+| `marketGapDirection` | `"ktc_premium"` \| `"consensus_premium"` \| `"none"` | KTC (retail) vs mean rank of other sources (expert consensus) |
+| `marketGapMagnitude` | number \| null | Absolute ordinal rank difference between KTC and consensus mean |
 | `identityConfidence` | float 0.0-1.0 | How confident we are this is the right entity |
 | `identityMethod` | string | Method used: `canonical_id`, `position_source_aligned`, `partial_evidence`, `name_only` |
 | `quarantined` | boolean | Row flagged by identity/data-quality validation |
@@ -74,7 +74,7 @@ Any flag in `_QUARANTINE_FLAGS` set triggers `quarantined = true` and degrades `
 
 - **Trust bar**: aggregate stats (high/medium/low confidence, multi-source count, quarantine count)
 - **Lens system**: 5 views (Consensus, Disagreements, Inefficiencies, Safest, Fragile)
-- **Edge rail**: collapsible summary with top KTC/IDPTC premiums, consensus assets, flagged players
+- **Edge rail**: collapsible summary with top KTC/Consensus premiums, consensus assets, flagged players
 - **Signal column**: per-row action labels (Market premium, Consensus asset) and stackable caution labels
 - **Tier grouping**: backend canonical tiers with rank-based fallback
 - **Fast-scan chips**: R (rookie), 1-src, ! (flagged), ~ (disagreement)
@@ -85,8 +85,8 @@ Any flag in `_QUARANTINE_FLAGS` set triggers `quarantined = true` and degrades `
 Source agreement dashboard. 6 sections in a 2-column grid:
 1. Consensus Assets — high confidence, multi-source, tight agreement
 2. Biggest Disagreements — highest source rank spread
-3. KTC Premium — players KTC values much higher
-4. IDPTC Premium — players IDPTC values much higher
+3. KTC Premium — players KTC (retail market) values much higher than the expert consensus
+4. Consensus Premium — players the expert consensus values much higher than KTC
 5. Flagged Anomalies — data quality flags in top 300
 6. Single-Source Players — valued by only one source
 
@@ -181,7 +181,7 @@ for p in data.get('playersArray', []):
 
 - **All IDP players are single-source / low confidence** — expected since only one IDP source (IDPTradeCalc) currently feeds the pipeline. Will self-correct when a second IDP source is added.
 - **Will Anderson (DL, rank ~38)** — single-source IDP with high value. Correct behavior: ranked from IDPTC, low confidence since only one source.
-- **Travis Hunter (WR, rank ~52)** — spread=69, medium confidence, IDPTC ranks higher. Correct behavior: shows "Market premium: IDPTC" signal. Market gap label is accurate.
+- **Travis Hunter (WR, rank ~52)** — spread=69, medium confidence, expert consensus ranks higher than KTC. Correct behavior: shows "Market premium: Consensus" signal. Market gap label is accurate.
 - **~36 empty-position rows** — players with no position string. Not in any rankable set, receive no unified rank, invisible on all frontend surfaces (Rankings, Edge, Finder). Harmless.
 - **126 picks** — all clean, no anomaly flags. Correctly excluded from ranking board (PICK not in `_RANKABLE_POSITIONS`) but present in data for trade calculator.
 

--- a/frontend/__tests__/display-helpers.test.js
+++ b/frontend/__tests__/display-helpers.test.js
@@ -54,16 +54,27 @@ describe("confBadgeLabel", () => {
 });
 
 describe("marketGapLabel", () => {
-  it("returns KTC label when KTC ranks higher", () => {
+  it("returns KTC label when KTC ranks higher than consensus mean", () => {
+    // KTC 5 vs mean(IDPTC 50) = 50 → KTC premium 45
     expect(marketGapLabel({ sourceRanks: { ktc: 5, idpTradeCalc: 50 } })).toBe("KTC +45");
   });
-  it("returns IDPTC label when IDPTC ranks higher", () => {
-    expect(marketGapLabel({ sourceRanks: { ktc: 80, idpTradeCalc: 10 } })).toBe("IDPTC +70");
+  it("returns Consensus label when consensus mean ranks higher than KTC", () => {
+    // KTC 80 vs mean(IDPTC 10) = 10 → Consensus premium 70
+    expect(marketGapLabel({ sourceRanks: { ktc: 80, idpTradeCalc: 10 } })).toBe("Consensus +70");
+  });
+  it("averages multiple consensus sources", () => {
+    // KTC 10 vs mean(IDPTC 50, DLF 70) = 60 → KTC premium 50
+    expect(
+      marketGapLabel({ sourceRanks: { ktc: 10, idpTradeCalc: 50, dlfIdp: 70 } })
+    ).toBe("KTC +50");
   });
   it("returns null for small differences", () => {
     expect(marketGapLabel({ sourceRanks: { ktc: 10, idpTradeCalc: 15 } })).toBeNull();
   });
-  it("returns null when missing sources", () => {
+  it("returns null when KTC is missing", () => {
+    expect(marketGapLabel({ sourceRanks: { idpTradeCalc: 20, dlfIdp: 30 } })).toBeNull();
+  });
+  it("returns null when only KTC is present", () => {
     expect(marketGapLabel({ sourceRanks: { ktc: 10 } })).toBeNull();
   });
   it("returns null for no sourceRanks", () => {

--- a/frontend/__tests__/edge-helpers.test.js
+++ b/frontend/__tests__/edge-helpers.test.js
@@ -5,7 +5,7 @@ import {
   LENSES,
   getLens,
   applyLens,
-  topKtcPremium,
+  topRetailPremium,
   topConsensusPremium,
   topFlaggedCautions,
   topConsensusAssets,
@@ -38,12 +38,14 @@ describe("actionLabel", () => {
     expect(actionLabel(makeRow({ quarantined: true }))).toBeNull();
   });
 
-  it("returns market premium when KTC ranks higher with large spread", () => {
+  it("returns market premium when retail ranks higher with large spread", () => {
     const label = actionLabel(makeRow({
-      marketGapDirection: "ktc_premium",
+      marketGapDirection: "retail_premium",
       sourceRankSpread: 45,
     }));
     expect(label).not.toBeNull();
+    // Retail label is resolved from the registry via getRetailLabel();
+    // today the only retail source is KTC so the label ends in "KTC".
     expect(label.label).toBe("Market premium: KTC");
     expect(label.css).toBe("action-premium");
   });
@@ -73,7 +75,7 @@ describe("actionLabel", () => {
       confidenceBucket: "high",
       sourceCount: 2,
       sourceRankSpread: 40,
-      marketGapDirection: "ktc_premium",
+      marketGapDirection: "retail_premium",
     }));
     expect(label.label).toBe("Market premium: KTC");
   });
@@ -211,25 +213,26 @@ describe("applyLens", () => {
 
 // ── Edge summary functions ───────────────────────────────────────────
 
-describe("topKtcPremium", () => {
-  it("returns rows sorted by spread where KTC ranks higher", () => {
+describe("topRetailPremium", () => {
+  it("returns rows sorted by spread where retail ranks higher", () => {
     const rows = [
-      makeRow({ name: "A", marketGapDirection: "ktc_premium", sourceRankSpread: 50, rank: 10 }),
-      makeRow({ name: "B", marketGapDirection: "ktc_premium", sourceRankSpread: 80, rank: 20 }),
+      makeRow({ name: "A", marketGapDirection: "retail_premium", sourceRankSpread: 50, rank: 10 }),
+      makeRow({ name: "B", marketGapDirection: "retail_premium", sourceRankSpread: 80, rank: 20 }),
       makeRow({ name: "C", marketGapDirection: "consensus_premium", sourceRankSpread: 90, rank: 5 }),
-      makeRow({ name: "D", marketGapDirection: "ktc_premium", sourceRankSpread: 10, rank: 30 }), // below 20 threshold
+      makeRow({ name: "D", marketGapDirection: "retail_premium", sourceRankSpread: 10, rank: 30 }), // below 20 threshold
     ];
-    const result = topKtcPremium(rows, 3);
+    const result = topRetailPremium(rows, 3);
     expect(result).toHaveLength(2); // A and B (D is below threshold)
     expect(result[0].name).toBe("B"); // 80 > 50
+    // Retail label is dynamic — today "KTC" since KTC is the only retail source.
     expect(result[0].detail).toBe("KTC +80 ranks");
   });
 
   it("excludes quarantined rows", () => {
     const rows = [
-      makeRow({ name: "Q", marketGapDirection: "ktc_premium", sourceRankSpread: 60, quarantined: true }),
+      makeRow({ name: "Q", marketGapDirection: "retail_premium", sourceRankSpread: 60, quarantined: true }),
     ];
-    expect(topKtcPremium(rows)).toHaveLength(0);
+    expect(topRetailPremium(rows)).toHaveLength(0);
   });
 });
 
@@ -278,7 +281,7 @@ describe("computeEdgeSummary", () => {
       makeRow({ name: "P1", pos: "QB", rank: 1, confidenceBucket: "high", sourceCount: 2 }),
     ];
     const summary = computeEdgeSummary(rows);
-    expect(summary).toHaveProperty("ktcPremium");
+    expect(summary).toHaveProperty("retailPremium");
     expect(summary).toHaveProperty("consensusPremium");
     expect(summary).toHaveProperty("flaggedCautions");
     expect(summary).toHaveProperty("consensusAssets");

--- a/frontend/__tests__/edge-helpers.test.js
+++ b/frontend/__tests__/edge-helpers.test.js
@@ -6,7 +6,7 @@ import {
   getLens,
   applyLens,
   topKtcPremium,
-  topIdptcPremium,
+  topConsensusPremium,
   topFlaggedCautions,
   topConsensusAssets,
   computeEdgeSummary,
@@ -40,7 +40,7 @@ describe("actionLabel", () => {
 
   it("returns market premium when KTC ranks higher with large spread", () => {
     const label = actionLabel(makeRow({
-      marketGapDirection: "ktc_higher",
+      marketGapDirection: "ktc_premium",
       sourceRankSpread: 45,
     }));
     expect(label).not.toBeNull();
@@ -48,12 +48,12 @@ describe("actionLabel", () => {
     expect(label.css).toBe("action-premium");
   });
 
-  it("returns market premium for IDPTC direction", () => {
+  it("returns market premium for consensus direction", () => {
     const label = actionLabel(makeRow({
-      marketGapDirection: "idptc_higher",
+      marketGapDirection: "consensus_premium",
       sourceRankSpread: 50,
     }));
-    expect(label.label).toBe("Market premium: IDPTC");
+    expect(label.label).toBe("Market premium: Consensus");
   });
 
   it("returns consensus asset for high-confidence tight agreement", () => {
@@ -73,7 +73,7 @@ describe("actionLabel", () => {
       confidenceBucket: "high",
       sourceCount: 2,
       sourceRankSpread: 40,
-      marketGapDirection: "ktc_higher",
+      marketGapDirection: "ktc_premium",
     }));
     expect(label.label).toBe("Market premium: KTC");
   });
@@ -214,10 +214,10 @@ describe("applyLens", () => {
 describe("topKtcPremium", () => {
   it("returns rows sorted by spread where KTC ranks higher", () => {
     const rows = [
-      makeRow({ name: "A", marketGapDirection: "ktc_higher", sourceRankSpread: 50, rank: 10 }),
-      makeRow({ name: "B", marketGapDirection: "ktc_higher", sourceRankSpread: 80, rank: 20 }),
-      makeRow({ name: "C", marketGapDirection: "idptc_higher", sourceRankSpread: 90, rank: 5 }),
-      makeRow({ name: "D", marketGapDirection: "ktc_higher", sourceRankSpread: 10, rank: 30 }), // below 20 threshold
+      makeRow({ name: "A", marketGapDirection: "ktc_premium", sourceRankSpread: 50, rank: 10 }),
+      makeRow({ name: "B", marketGapDirection: "ktc_premium", sourceRankSpread: 80, rank: 20 }),
+      makeRow({ name: "C", marketGapDirection: "consensus_premium", sourceRankSpread: 90, rank: 5 }),
+      makeRow({ name: "D", marketGapDirection: "ktc_premium", sourceRankSpread: 10, rank: 30 }), // below 20 threshold
     ];
     const result = topKtcPremium(rows, 3);
     expect(result).toHaveLength(2); // A and B (D is below threshold)
@@ -227,20 +227,20 @@ describe("topKtcPremium", () => {
 
   it("excludes quarantined rows", () => {
     const rows = [
-      makeRow({ name: "Q", marketGapDirection: "ktc_higher", sourceRankSpread: 60, quarantined: true }),
+      makeRow({ name: "Q", marketGapDirection: "ktc_premium", sourceRankSpread: 60, quarantined: true }),
     ];
     expect(topKtcPremium(rows)).toHaveLength(0);
   });
 });
 
-describe("topIdptcPremium", () => {
-  it("returns rows where IDPTC ranks higher", () => {
+describe("topConsensusPremium", () => {
+  it("returns rows where consensus ranks higher than KTC", () => {
     const rows = [
-      makeRow({ name: "X", marketGapDirection: "idptc_higher", sourceRankSpread: 40, rank: 15 }),
+      makeRow({ name: "X", marketGapDirection: "consensus_premium", sourceRankSpread: 40, rank: 15 }),
     ];
-    const result = topIdptcPremium(rows);
+    const result = topConsensusPremium(rows);
     expect(result).toHaveLength(1);
-    expect(result[0].detail).toBe("IDPTC +40 ranks");
+    expect(result[0].detail).toBe("Consensus +40 ranks");
   });
 });
 
@@ -279,7 +279,7 @@ describe("computeEdgeSummary", () => {
     ];
     const summary = computeEdgeSummary(rows);
     expect(summary).toHaveProperty("ktcPremium");
-    expect(summary).toHaveProperty("idptcPremium");
+    expect(summary).toHaveProperty("consensusPremium");
     expect(summary).toHaveProperty("flaggedCautions");
     expect(summary).toHaveProperty("consensusAssets");
   });

--- a/frontend/__tests__/scope-aware-rankings.test.js
+++ b/frontend/__tests__/scope-aware-rankings.test.js
@@ -191,6 +191,75 @@ describe("F. Edge cases", () => {
   });
 });
 
+// ── Dual-scope IDPTradeCalc parity ──────────────────────────────────
+// IDPTradeCalc registers under BOTH overall_idp (as the backbone) and
+// overall_offense (as a second opinion alongside KTC).  Mirrors the
+// backend TestGDualScopeIdpTradeCalc cases in
+// tests/api/test_scope_aware_rankings.py.
+describe("Dual-scope IDPTradeCalc: offense + IDP contribution", () => {
+  it("ranks offense players through both KTC and IDPTradeCalc", () => {
+    const rows = buildRows({
+      playersArray: [
+        row("qb1", "QB", { ktc: 9500, idp: 9600 }),
+        row("wr1", "WR", { ktc: 9000, idp: 9200 }),
+        row("rb1", "RB", { ktc: 8500, idp: 8400 }),
+      ],
+    });
+    const qb = rows.find((r) => r.name === "qb1");
+    const wr = rows.find((r) => r.name === "wr1");
+    const rb = rows.find((r) => r.name === "rb1");
+
+    for (const r of [qb, wr, rb]) {
+      expect(r.sourceRanks.ktc).toBeDefined();
+      expect(r.sourceRanks.idpTradeCalc).toBeDefined();
+      // Offense players receive the idpTradeCalc rank under the
+      // overall_offense scope, not overall_idp.
+      expect(r.sourceRankMeta.idpTradeCalc.scope).toBe("overall_offense");
+      expect(r.isSingleSource).toBe(false);
+      expect(r.sourceCount).toBe(2);
+    }
+
+    // KTC ordering: qb > wr > rb
+    expect(qb.sourceRanks.ktc).toBe(1);
+    expect(wr.sourceRanks.ktc).toBe(2);
+    expect(rb.sourceRanks.ktc).toBe(3);
+    // IDPTC ordering: qb > wr > rb (9600 > 9200 > 8400)
+    expect(qb.sourceRanks.idpTradeCalc).toBe(1);
+    expect(wr.sourceRanks.idpTradeCalc).toBe(2);
+    expect(rb.sourceRanks.idpTradeCalc).toBe(3);
+  });
+
+  it("captures per-source spread when KTC and IDPTC disagree", () => {
+    const rows = buildRows({
+      playersArray: [
+        row("wr1", "WR", { ktc: 9500, idp: 8000 }),
+        row("wr2", "WR", { ktc: 9000, idp: 9500 }),
+      ],
+    });
+    const wr1 = rows.find((r) => r.name === "wr1");
+    const wr2 = rows.find((r) => r.name === "wr2");
+    expect(wr1.sourceRanks.ktc).toBe(1);
+    expect(wr1.sourceRanks.idpTradeCalc).toBe(2);
+    expect(wr2.sourceRanks.ktc).toBe(2);
+    expect(wr2.sourceRanks.idpTradeCalc).toBe(1);
+    expect(wr1.sourceRankSpread).toBe(1);
+    expect(wr2.sourceRankSpread).toBe(1);
+  });
+
+  it("does not leak offense scope onto IDP rows", () => {
+    const rows = buildRows({
+      playersArray: [
+        row("dl1", "DL", { idp: 900 }),
+        row("lb1", "LB", { idp: 800 }),
+      ],
+    });
+    for (const r of rows) {
+      expect(r.sourceRanks.ktc).toBeUndefined();
+      expect(r.sourceRankMeta.idpTradeCalc.scope).toBe("overall_idp");
+    }
+  });
+});
+
 // ── G. DLF (Dynasty League Football) IDP source parity ──────────────
 // DLF is registered as a second overall_idp source alongside the
 // IDPTradeCalc backbone.  Both are full-board (no depth penalty), both

--- a/frontend/__tests__/thresholds.test.js
+++ b/frontend/__tests__/thresholds.test.js
@@ -97,7 +97,7 @@ describe("threshold consistency with helpers", () => {
     const { actionLabel } = await import("@/lib/edge-helpers");
     const row = {
       sourceRankSpread: MARKET_PREMIUM_SPREAD,
-      marketGapDirection: "ktc_premium",
+      marketGapDirection: "retail_premium",
       quarantined: false,
     };
     const result = actionLabel(row);
@@ -109,7 +109,7 @@ describe("threshold consistency with helpers", () => {
     const { actionLabel } = await import("@/lib/edge-helpers");
     const row = {
       sourceRankSpread: MARKET_PREMIUM_SPREAD - 1,
-      marketGapDirection: "ktc_premium",
+      marketGapDirection: "retail_premium",
       quarantined: false,
     };
     const result = actionLabel(row);

--- a/frontend/__tests__/thresholds.test.js
+++ b/frontend/__tests__/thresholds.test.js
@@ -97,7 +97,7 @@ describe("threshold consistency with helpers", () => {
     const { actionLabel } = await import("@/lib/edge-helpers");
     const row = {
       sourceRankSpread: MARKET_PREMIUM_SPREAD,
-      marketGapDirection: "ktc_higher",
+      marketGapDirection: "ktc_premium",
       quarantined: false,
     };
     const result = actionLabel(row);
@@ -109,7 +109,7 @@ describe("threshold consistency with helpers", () => {
     const { actionLabel } = await import("@/lib/edge-helpers");
     const row = {
       sourceRankSpread: MARKET_PREMIUM_SPREAD - 1,
-      marketGapDirection: "ktc_higher",
+      marketGapDirection: "ktc_premium",
       quarantined: false,
     };
     const result = actionLabel(row);

--- a/frontend/__tests__/trust-fields.test.js
+++ b/frontend/__tests__/trust-fields.test.js
@@ -87,8 +87,8 @@ describe("trust fields from playersArray", () => {
   });
 
   it("preserves marketGapDirection", () => {
-    const row = buildSingle({ marketGapDirection: "ktc_higher" });
-    expect(row.marketGapDirection).toBe("ktc_higher");
+    const row = buildSingle({ marketGapDirection: "ktc_premium" });
+    expect(row.marketGapDirection).toBe("ktc_premium");
   });
 
   it("preserves marketGapMagnitude", () => {
@@ -284,7 +284,7 @@ describe("legacy path picks up mirrored trust fields", () => {
           hasSourceDisagreement: false,
           blendedSourceRank: 5.0,
           sourceRankSpread: 10,
-          marketGapDirection: "ktc_higher",
+          marketGapDirection: "ktc_premium",
           marketGapMagnitude: 25,
           identityConfidence: 0.95,
           identityMethod: "canonical_id",
@@ -306,7 +306,7 @@ describe("legacy path picks up mirrored trust fields", () => {
     expect(row.isSingleSource).toBe(false);
     expect(row.hasSourceDisagreement).toBe(false);
     expect(row.sourceRankSpread).toBe(10);
-    expect(row.marketGapDirection).toBe("ktc_higher");
+    expect(row.marketGapDirection).toBe("ktc_premium");
     expect(row.marketGapMagnitude).toBe(25);
     expect(row.identityConfidence).toBe(0.95);
     expect(row.identityMethod).toBe("canonical_id");

--- a/frontend/__tests__/trust-fields.test.js
+++ b/frontend/__tests__/trust-fields.test.js
@@ -87,8 +87,8 @@ describe("trust fields from playersArray", () => {
   });
 
   it("preserves marketGapDirection", () => {
-    const row = buildSingle({ marketGapDirection: "ktc_premium" });
-    expect(row.marketGapDirection).toBe("ktc_premium");
+    const row = buildSingle({ marketGapDirection: "retail_premium" });
+    expect(row.marketGapDirection).toBe("retail_premium");
   });
 
   it("preserves marketGapMagnitude", () => {
@@ -284,7 +284,7 @@ describe("legacy path picks up mirrored trust fields", () => {
           hasSourceDisagreement: false,
           blendedSourceRank: 5.0,
           sourceRankSpread: 10,
-          marketGapDirection: "ktc_premium",
+          marketGapDirection: "retail_premium",
           marketGapMagnitude: 25,
           identityConfidence: 0.95,
           identityMethod: "canonical_id",
@@ -306,7 +306,7 @@ describe("legacy path picks up mirrored trust fields", () => {
     expect(row.isSingleSource).toBe(false);
     expect(row.hasSourceDisagreement).toBe(false);
     expect(row.sourceRankSpread).toBe(10);
-    expect(row.marketGapDirection).toBe("ktc_premium");
+    expect(row.marketGapDirection).toBe("retail_premium");
     expect(row.marketGapMagnitude).toBe(25);
     expect(row.identityConfidence).toBe(0.95);
     expect(row.identityMethod).toBe("canonical_id");

--- a/frontend/app/edge/page.jsx
+++ b/frontend/app/edge/page.jsx
@@ -6,6 +6,7 @@ import { useApp } from "@/components/AppShell";
 import { actionLabel, cautionLabels } from "@/lib/edge-helpers";
 import { posBadgeClass, confBadgeClass, confBadgeLabel as confLabel, isEligibleForAnalysis } from "@/lib/display-helpers";
 import { EDGE_SECTION_LIMIT, EDGE_PREMIUM_LIMIT, EDGE_CAUTION_RANK_LIMIT, PREMIUM_SUMMARY_SPREAD } from "@/lib/thresholds";
+import { getRetailLabel } from "@/lib/dynasty-data";
 
 // ── Edge Page ─────────────────────────────────────────────────────────────
 // Source-agreement analysis dashboard. Every signal on this page traces to
@@ -131,7 +132,7 @@ const COL_GAP_DIR = {
   thStyle: { width: 70 },
   tdStyle: { fontSize: "0.78rem" },
   render: (r) => {
-    if (r.marketGapDirection === "ktc_premium") return <span className="text-cyan">KTC</span>;
+    if (r.marketGapDirection === "retail_premium") return <span className="text-cyan">{getRetailLabel()}</span>;
     if (r.marketGapDirection === "consensus_premium") return <span className="text-amber">Consensus</span>;
     return <span className="muted">\u2014</span>;
   },
@@ -205,10 +206,10 @@ export default function EdgePage() {
     [eligible],
   );
 
-  const ktcPremium = useMemo(
+  const retailPremium = useMemo(
     () =>
       eligible
-        .filter((r) => r.marketGapDirection === "ktc_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
+        .filter((r) => r.marketGapDirection === "retail_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
         .sort((a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0))
         .slice(0, EDGE_PREMIUM_LIMIT),
     [eligible],
@@ -343,17 +344,17 @@ export default function EdgePage() {
               />
             </EdgeSection>
 
-            {/* KTC Premium */}
+            {/* Retail Premium (today: KTC) */}
             <EdgeSection
-              title="KTC Premium"
-              description="Players KTC (retail market) values much higher than the expert consensus. Potential sells to KTC-first trade partners."
-              count={`${ktcPremium.length} shown`}
+              title={`${getRetailLabel()} Premium`}
+              description={`Players the retail market (${getRetailLabel()}) values much higher than the expert consensus. Potential sells to retail-first trade partners.`}
+              count={`${retailPremium.length} shown`}
               accent="cyan"
             >
               <SectionTable
-                rows={ktcPremium}
+                rows={retailPremium}
                 onPlayerClick={openPlayerPopup}
-                emptyText="No significant KTC premiums."
+                emptyText={`No significant ${getRetailLabel()} premiums.`}
                 columns={[COL_RANK, COL_PLAYER, COL_POS, COL_SPREAD, COL_VALUE]}
               />
             </EdgeSection>
@@ -361,7 +362,7 @@ export default function EdgePage() {
             {/* Consensus Premium */}
             <EdgeSection
               title="Consensus Premium"
-              description="Players the expert consensus values much higher than KTC. Potential buys from KTC-first trade partners."
+              description={`Players the expert consensus values much higher than ${getRetailLabel()}. Potential buys from retail-first trade partners.`}
               count={`${consensusPremium.length} shown`}
               accent="cyan"
             >

--- a/frontend/app/edge/page.jsx
+++ b/frontend/app/edge/page.jsx
@@ -131,8 +131,8 @@ const COL_GAP_DIR = {
   thStyle: { width: 70 },
   tdStyle: { fontSize: "0.78rem" },
   render: (r) => {
-    if (r.marketGapDirection === "ktc_higher") return <span className="text-cyan">KTC</span>;
-    if (r.marketGapDirection === "idptc_higher") return <span className="text-amber">IDPTC</span>;
+    if (r.marketGapDirection === "ktc_premium") return <span className="text-cyan">KTC</span>;
+    if (r.marketGapDirection === "consensus_premium") return <span className="text-amber">Consensus</span>;
     return <span className="muted">\u2014</span>;
   },
 };
@@ -208,16 +208,16 @@ export default function EdgePage() {
   const ktcPremium = useMemo(
     () =>
       eligible
-        .filter((r) => r.marketGapDirection === "ktc_higher" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
+        .filter((r) => r.marketGapDirection === "ktc_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
         .sort((a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0))
         .slice(0, EDGE_PREMIUM_LIMIT),
     [eligible],
   );
 
-  const idptcPremium = useMemo(
+  const consensusPremium = useMemo(
     () =>
       eligible
-        .filter((r) => r.marketGapDirection === "idptc_higher" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
+        .filter((r) => r.marketGapDirection === "consensus_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
         .sort((a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0))
         .slice(0, EDGE_PREMIUM_LIMIT),
     [eligible],
@@ -346,7 +346,7 @@ export default function EdgePage() {
             {/* KTC Premium */}
             <EdgeSection
               title="KTC Premium"
-              description="Players KTC values much higher than IDP Trade Calculator. The offense market sees value the IDP market doesn't."
+              description="Players KTC (retail market) values much higher than the expert consensus. Potential sells to KTC-first trade partners."
               count={`${ktcPremium.length} shown`}
               accent="cyan"
             >
@@ -358,17 +358,17 @@ export default function EdgePage() {
               />
             </EdgeSection>
 
-            {/* IDPTC Premium */}
+            {/* Consensus Premium */}
             <EdgeSection
-              title="IDPTC Premium"
-              description="Players IDP Trade Calculator values much higher than KTC. The IDP market sees value the offense market doesn't."
-              count={`${idptcPremium.length} shown`}
+              title="Consensus Premium"
+              description="Players the expert consensus values much higher than KTC. Potential buys from KTC-first trade partners."
+              count={`${consensusPremium.length} shown`}
               accent="cyan"
             >
               <SectionTable
-                rows={idptcPremium}
+                rows={consensusPremium}
                 onPlayerClick={openPlayerPopup}
-                emptyText="No significant IDPTC premiums."
+                emptyText="No significant consensus premiums."
                 columns={[COL_RANK, COL_PLAYER, COL_POS, COL_SPREAD, COL_VALUE]}
               />
             </EdgeSection>

--- a/frontend/app/finder/page.jsx
+++ b/frontend/app/finder/page.jsx
@@ -7,6 +7,7 @@ import { actionLabel, cautionLabels } from "@/lib/edge-helpers";
 import { posBadgeClass, confBadgeClass, confBadgeLabel as confLabel, isEligibleForAnalysis } from "@/lib/display-helpers";
 import { rowChips } from "@/lib/rankings-helpers";
 import { FINDER_ROW_LIMIT, CONFIDENCE_SPREAD_HIGH } from "@/lib/thresholds";
+import { getRetailLabel } from "@/lib/dynasty-data";
 
 // ── Finder Page ────────────────────────────────────────────────────────────
 // Filter-driven player discovery tool. Each workflow surfaces a specific type
@@ -303,8 +304,8 @@ export default function FinderPage() {
                           )}
                           {workflow.showGap && (
                             <td style={{ fontSize: "0.78rem" }}>
-                              {row.marketGapDirection === "ktc_premium" ? (
-                                <span className="text-cyan">KTC</span>
+                              {row.marketGapDirection === "retail_premium" ? (
+                                <span className="text-cyan">{getRetailLabel()}</span>
                               ) : row.marketGapDirection === "consensus_premium" ? (
                                 <span className="text-amber">Consensus</span>
                               ) : (

--- a/frontend/app/finder/page.jsx
+++ b/frontend/app/finder/page.jsx
@@ -303,10 +303,10 @@ export default function FinderPage() {
                           )}
                           {workflow.showGap && (
                             <td style={{ fontSize: "0.78rem" }}>
-                              {row.marketGapDirection === "ktc_higher" ? (
+                              {row.marketGapDirection === "ktc_premium" ? (
                                 <span className="text-cyan">KTC</span>
-                              ) : row.marketGapDirection === "idptc_higher" ? (
-                                <span className="text-amber">IDPTC</span>
+                              ) : row.marketGapDirection === "consensus_premium" ? (
+                                <span className="text-amber">Consensus</span>
                               ) : (
                                 <span className="muted">\u2014</span>
                               )}

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -124,7 +124,7 @@ function EdgeRailSection({ label, items, emptyText, onPlayerClick }) {
 function EdgeRail({ summary, onPlayerClick }) {
   const hasSomething =
     summary.ktcPremium.length > 0 ||
-    summary.idptcPremium.length > 0 ||
+    summary.consensusPremium.length > 0 ||
     summary.flaggedCautions.length > 0 ||
     summary.consensusAssets.length > 0;
 
@@ -144,9 +144,9 @@ function EdgeRail({ summary, onPlayerClick }) {
           onPlayerClick={onPlayerClick}
         />
         <EdgeRailSection
-          label="IDPTC Premium"
-          items={summary.idptcPremium}
-          emptyText="No significant IDPTC premiums"
+          label="Consensus Premium"
+          items={summary.consensusPremium}
+          emptyText="No significant consensus premiums"
           onPlayerClick={onPlayerClick}
         />
         <EdgeRailSection

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useMemo, useState, useCallback } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
-import { resolvedRank, RANKING_SOURCES } from "@/lib/dynasty-data";
+import { resolvedRank, RANKING_SOURCES, getRetailLabel } from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
 import { useApp } from "@/components/AppShell";
 import {
@@ -123,12 +123,14 @@ function EdgeRailSection({ label, items, emptyText, onPlayerClick }) {
 
 function EdgeRail({ summary, onPlayerClick }) {
   const hasSomething =
-    summary.ktcPremium.length > 0 ||
+    summary.retailPremium.length > 0 ||
     summary.consensusPremium.length > 0 ||
     summary.flaggedCautions.length > 0 ||
     summary.consensusAssets.length > 0;
 
   if (!hasSomething) return null;
+
+  const retailLabel = getRetailLabel();
 
   return (
     <div className="edge-rail">
@@ -138,9 +140,9 @@ function EdgeRail({ summary, onPlayerClick }) {
       </div>
       <div className="edge-rail-grid">
         <EdgeRailSection
-          label="KTC Premium"
-          items={summary.ktcPremium}
-          emptyText="No significant KTC premiums"
+          label={`${retailLabel} Premium`}
+          items={summary.retailPremium}
+          emptyText={`No significant ${retailLabel} premiums`}
           onPlayerClick={onPlayerClick}
         />
         <EdgeRailSection

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useMemo, useState, useCallback } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
-import { resolvedRank } from "@/lib/dynasty-data";
+import { resolvedRank, RANKING_SOURCES } from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
 import { useApp } from "@/components/AppShell";
 import {
@@ -72,11 +72,12 @@ function posMatchesFilter(pos, assetClass, filter) {
 // ── Methodology content ──────────────────────────────────────────────
 
 function MethodologySection() {
+  const sourceNames = RANKING_SOURCES.map((s) => s.displayName).join(", ");
   return (
     <div className="rankings-methodology-body">
       <h3 style={{ margin: "0 0 8px", fontSize: "0.88rem" }}>How rankings work</h3>
       <ol style={{ margin: 0, paddingLeft: 18, fontSize: "0.78rem", lineHeight: 1.7, color: "var(--subtext)" }}>
-        <li><strong>Source ingestion</strong> — Raw values from Keep Trade Cut (offense) and IDP Trade Calculator (IDP).</li>
+        <li><strong>Source ingestion</strong> — Raw values from {sourceNames}.</li>
         <li><strong>Per-source ranking</strong> — Each player ranked within each source by raw value (highest = rank 1).</li>
         <li><strong>Rank normalization</strong> — Per-source ranks converted to 1–9,999 values via Hill-curve formula so sources are comparable.</li>
         <li><strong>Blended ranking</strong> — Multi-source players get averaged normalized values. Single-source players keep their one value.</li>
@@ -276,22 +277,25 @@ export default function RankingsPage() {
           va = a.rankDerivedValue || a.values?.full || 0;
           vb = b.rankDerivedValue || b.values?.full || 0;
           return (va - vb) * dir;
-        case "ktc":
-          va = Number(a.canonicalSites?.ktc) || 0;
-          vb = Number(b.canonicalSites?.ktc) || 0;
-          return (va - vb) * dir;
-        case "idp":
-          va = Number(a.canonicalSites?.idpTradeCalc) || 0;
-          vb = Number(b.canonicalSites?.idpTradeCalc) || 0;
-          return (va - vb) * dir;
         case "confidence": {
           const order = { high: 0, medium: 1, low: 2, none: 3 };
           va = order[a.confidenceBucket] ?? 3;
           vb = order[b.confidenceBucket] ?? 3;
           return (va - vb) * dir;
         }
-        default:
+        default: {
+          // Dynamic source-column sort: col === `src:${sourceKey}`.
+          // Keeps the rankings table self-describing so any source
+          // registered in RANKING_SOURCES gets a sortable column
+          // automatically.
+          if (typeof sortCol === "string" && sortCol.startsWith("src:")) {
+            const key = sortCol.slice(4);
+            va = Number(a.canonicalSites?.[key]) || 0;
+            vb = Number(b.canonicalSites?.[key]) || 0;
+            return (va - vb) * dir;
+          }
           return resolvedRank(a) - resolvedRank(b);
+        }
       }
     });
     return sorted;
@@ -319,20 +323,39 @@ export default function RankingsPage() {
 
   // ── Copy/Export ────────────────────────────────────────────────────
   async function copyValues() {
-    const lines = ["Rank\tPlayer\tPos\tTeam\tTier\tValue\tValue Band\tConfidence\tAction\tSources\tKTC\tKTC Rank\tIDPTC\tIDPTC Rank"];
+    // Header: fixed columns, then one pair (value + rank) per registered source.
+    const sourceHeaders = RANKING_SOURCES.flatMap((src) => [
+      src.columnLabel,
+      `${src.columnLabel} Rank`,
+    ]);
+    const lines = [
+      [
+        "Rank", "Player", "Pos", "Team", "Tier", "Value", "Value Band",
+        "Confidence", "Action", "Sources",
+        ...sourceHeaders,
+      ].join("\t"),
+    ];
     displayRows.forEach((row) => {
-      const ktcVal = row.canonicalSites?.ktc != null ? Math.round(Number(row.canonicalSites.ktc)) : "";
-      const idpVal = row.canonicalSites?.idpTradeCalc != null ? Math.round(Number(row.canonicalSites.idpTradeCalc)) : "";
       const val = Math.round(row.rankDerivedValue || row.values?.full || 0);
       const band = valueBand(val);
       const action = actionLabel(row);
       const cautions = cautionLabels(row);
       const actionStr = [action?.label, ...cautions.map((c) => c.label)].filter(Boolean).join("; ");
+      const sourceCells = RANKING_SOURCES.flatMap((src) => {
+        const raw = row.canonicalSites?.[src.key];
+        const valCell = raw != null && Number.isFinite(Number(raw))
+          ? Math.round(Number(raw))
+          : "";
+        const rankCell = row.sourceRanks?.[src.key] ?? "";
+        return [valCell, rankCell];
+      });
       lines.push(
-        `${row.rank}\t${row.name}\t${row.pos}\t${row.team || ""}\t` +
-        `${tierLabel(row)}\t${val}\t${band.label}\t` +
-        `${row.confidenceBucket || ""}\t${actionStr}\t${row.sourceCount || 0}\t` +
-        `${ktcVal}\t${row.ktcRank || ""}\t${idpVal}\t${row.idpRank || ""}`
+        [
+          row.rank, row.name, row.pos, row.team || "",
+          tierLabel(row), val, band.label,
+          row.confidenceBucket || "", actionStr, row.sourceCount || 0,
+          ...sourceCells,
+        ].join("\t")
       );
     });
     try {
@@ -515,8 +538,16 @@ export default function RankingsPage() {
                   <SortHeader col="name">Player</SortHeader>
                   <SortHeader col="pos" style={{ width: 54 }}>Pos</SortHeader>
                   <SortHeader col="value" style={{ textAlign: "right" }}>Value</SortHeader>
-                  <SortHeader col="ktc" style={{ textAlign: "right", width: 80 }} className="hide-mobile">KTC</SortHeader>
-                  <SortHeader col="idp" style={{ textAlign: "right", width: 80 }} className="hide-mobile">IDPTC</SortHeader>
+                  {RANKING_SOURCES.map((src) => (
+                    <SortHeader
+                      key={src.key}
+                      col={`src:${src.key}`}
+                      style={{ textAlign: "right", width: 80 }}
+                      className="hide-mobile"
+                    >
+                      {src.columnLabel}
+                    </SortHeader>
+                  ))}
                   <SortHeader col="confidence" style={{ textAlign: "center" }} className="hide-mobile">Conf</SortHeader>
                   <th className="hide-mobile" style={{ textAlign: "center", width: 90 }}>Gap</th>
                   <th className="hide-mobile" style={{ width: 170 }}>Signal</th>
@@ -542,7 +573,7 @@ export default function RankingsPage() {
                     <Fragment key={row.name}>
                       {showTierBreak && (
                         <tr className="rankings-tier-separator">
-                          <td colSpan={10}>
+                          <td colSpan={8 + RANKING_SOURCES.length}>
                             <span className="rankings-tier-separator-label">{tier}</span>
                           </td>
                         </tr>
@@ -595,33 +626,30 @@ export default function RankingsPage() {
                           <span className={`rankings-value-band ${band.css}`}>{band.label}</span>
                         </td>
 
-                        {/* KTC source value + rank */}
-                        <td className="hide-mobile" style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.78rem" }}>
-                          {row.canonicalSites?.ktc != null ? (
-                            <>
-                              <div>{Math.round(Number(row.canonicalSites.ktc)).toLocaleString()}</div>
-                              {row.ktcRank != null && (
-                                <div className="muted" style={{ fontSize: "0.68rem" }}>#{row.ktcRank}</div>
+                        {/* Per-source value + rank columns (enumerated from RANKING_SOURCES) */}
+                        {RANKING_SOURCES.map((src) => {
+                          const rawVal = row.canonicalSites?.[src.key];
+                          const hasVal = rawVal != null && Number.isFinite(Number(rawVal));
+                          const rank = row.sourceRanks?.[src.key];
+                          return (
+                            <td
+                              key={src.key}
+                              className="hide-mobile"
+                              style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.78rem" }}
+                            >
+                              {hasVal ? (
+                                <>
+                                  <div>{Math.round(Number(rawVal)).toLocaleString()}</div>
+                                  {rank != null && (
+                                    <div className="muted" style={{ fontSize: "0.68rem" }}>#{rank}</div>
+                                  )}
+                                </>
+                              ) : (
+                                <span className="muted">&mdash;</span>
                               )}
-                            </>
-                          ) : (
-                            <span className="muted">&mdash;</span>
-                          )}
-                        </td>
-
-                        {/* IDPTradeCalc source value + rank */}
-                        <td className="hide-mobile" style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.78rem" }}>
-                          {row.canonicalSites?.idpTradeCalc != null ? (
-                            <>
-                              <div>{Math.round(Number(row.canonicalSites.idpTradeCalc)).toLocaleString()}</div>
-                              {row.idpRank != null && (
-                                <div className="muted" style={{ fontSize: "0.68rem" }}>#{row.idpRank}</div>
-                              )}
-                            </>
-                          ) : (
-                            <span className="muted">&mdash;</span>
-                          )}
-                        </td>
+                            </td>
+                          );
+                        })}
 
                         {/* Confidence */}
                         <td className="hide-mobile" style={{ textAlign: "center" }}>

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
+import { RANKING_SOURCES } from "@/lib/dynasty-data";
 import {
   VALUE_MODES,
   STORAGE_KEY,
@@ -177,15 +178,19 @@ export default function TradePage() {
         case "value":
           va = a.rankDerivedValue || a.values?.full || 0; vb = b.rankDerivedValue || b.values?.full || 0;
           return (va - vb) * dir;
-        case "ktc":
-          va = Number(a.canonicalSites?.ktc) || 0; vb = Number(b.canonicalSites?.ktc) || 0;
-          return (va - vb) * dir;
-        case "idpTradeCalc":
-          va = Number(a.canonicalSites?.idpTradeCalc) || 0; vb = Number(b.canonicalSites?.idpTradeCalc) || 0;
-          return (va - vb) * dir;
-        default:
+        default: {
+          // Dynamic per-source sort column: "src:<sourceKey>".  Keeps
+          // the picker column set self-describing so newly registered
+          // sources appear automatically.
+          if (typeof pickerSortCol === "string" && pickerSortCol.startsWith("src:")) {
+            const key = pickerSortCol.slice(4);
+            va = Number(a.canonicalSites?.[key]) || 0;
+            vb = Number(b.canonicalSites?.[key]) || 0;
+            return (va - vb) * dir;
+          }
           va = a.blendedSourceRank ?? Infinity; vb = b.blendedSourceRank ?? Infinity;
           return (va - vb) * dir;
+        }
       }
     });
     return list.slice(0, 100);
@@ -792,8 +797,15 @@ export default function TradePage() {
                           { col: "name", label: "Player" },
                           { col: "pos", label: "Pos", style: { width: 50 } },
                           { col: "value", label: "Our Value", style: { width: 80, textAlign: "right" } },
-                          { col: "ktc", label: "KTC", style: { width: 65, textAlign: "right" } },
-                          { col: "idpTradeCalc", label: "IDPTC", style: { width: 65, textAlign: "right" } },
+                          // One sortable column per registered ranking source,
+                          // enumerated from the shared RANKING_SOURCES registry
+                          // so newly-added sources (DLF, etc.) surface here
+                          // without touching this component.
+                          ...RANKING_SOURCES.map((src) => ({
+                            col: `src:${src.key}`,
+                            label: src.columnLabel,
+                            style: { width: 65, textAlign: "right" },
+                          })),
                         ].map(({ col, label, style }) => (
                           <th key={col} style={{ cursor: "pointer", userSelect: "none", whiteSpace: "nowrap", ...style }}
                             onClick={() => {
@@ -817,12 +829,15 @@ export default function TradePage() {
                           <td style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontWeight: 600 }}>
                             {Math.round(r.rankDerivedValue || r.values?.full || 0).toLocaleString()}
                           </td>
-                          <td style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.74rem" }}>
-                            {r.canonicalSites?.ktc != null ? Math.round(Number(r.canonicalSites.ktc)).toLocaleString() : "—"}
-                          </td>
-                          <td style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.74rem" }}>
-                            {r.canonicalSites?.idpTradeCalc != null ? Math.round(Number(r.canonicalSites.idpTradeCalc)).toLocaleString() : "—"}
-                          </td>
+                          {RANKING_SOURCES.map((src) => {
+                            const raw = r.canonicalSites?.[src.key];
+                            const hasVal = raw != null && Number.isFinite(Number(raw));
+                            return (
+                              <td key={src.key} style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.74rem" }}>
+                                {hasVal ? Math.round(Number(raw)).toLocaleString() : "—"}
+                              </td>
+                            );
+                          })}
                           <td><span className="badge" style={{ fontSize: "0.6rem" }}>Add</span></td>
                         </tr>
                       ))}

--- a/frontend/lib/display-helpers.js
+++ b/frontend/lib/display-helpers.js
@@ -6,6 +6,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { MARKET_GAP_MIN_DIFF } from "./thresholds.js";
+import { getRetailSourceKeys, getRetailLabel } from "./dynasty-data.js";
 
 /**
  * Return the CSS class for a position badge based on asset class.
@@ -56,26 +57,39 @@ export function isEligibleForAnalysis(row) {
 /**
  * Return a short market-gap label string, or null if insignificant.
  *
- * "Market gap" is KTC (the retail offense market) vs the mean rank of
- * every other registered ranking source (the expert consensus — IDPTC,
- * DLF, etc.).  A KTC premium means the offense market values the
- * player more than the consensus does; a consensus premium is the
- * opposite.
+ * "Market gap" frames the retail market (sources flagged `isRetail` in
+ * the registry — today just KTC) against every other registered
+ * source (the expert consensus — IDPTC, DLF, etc.).  Both sides are
+ * averaged and the label shows the side that ranks the player higher
+ * and by how many ordinal ranks.  A "KTC +N" label means retail values
+ * the player more than the consensus does; a "Consensus +N" label is
+ * the reverse.
+ *
+ * The retail side label is resolved dynamically from the registry via
+ * `getRetailLabel()`, so adding a second retail source flips the label
+ * to the generic "Retail" with no code edits here.
  */
 export function marketGapLabel(row) {
   if (!row?.sourceRanks) return null;
-  const ktcRank = row.sourceRanks.ktc;
-  if (!ktcRank) return null;
+  const retailKeys = new Set(getRetailSourceKeys());
 
-  const otherRanks = Object.entries(row.sourceRanks)
-    .filter(([key, rank]) => key !== "ktc" && rank != null)
+  const retailRanks = Object.entries(row.sourceRanks)
+    .filter(([key, rank]) => retailKeys.has(key) && rank != null)
     .map(([, rank]) => Number(rank))
     .filter((n) => Number.isFinite(n));
-  if (otherRanks.length === 0) return null;
+  if (retailRanks.length === 0) return null;
 
-  const consensusRank = otherRanks.reduce((s, v) => s + v, 0) / otherRanks.length;
-  const diff = Math.round(Math.abs(consensusRank - ktcRank));
+  const consensusRanks = Object.entries(row.sourceRanks)
+    .filter(([key, rank]) => !retailKeys.has(key) && rank != null)
+    .map(([, rank]) => Number(rank))
+    .filter((n) => Number.isFinite(n));
+  if (consensusRanks.length === 0) return null;
+
+  const retailMean = retailRanks.reduce((s, v) => s + v, 0) / retailRanks.length;
+  const consensusMean =
+    consensusRanks.reduce((s, v) => s + v, 0) / consensusRanks.length;
+  const diff = Math.round(Math.abs(consensusMean - retailMean));
   if (diff < MARKET_GAP_MIN_DIFF) return null;
-  const higher = ktcRank < consensusRank ? "KTC" : "Consensus";
+  const higher = retailMean < consensusMean ? getRetailLabel() : "Consensus";
   return `${higher} +${diff}`;
 }

--- a/frontend/lib/display-helpers.js
+++ b/frontend/lib/display-helpers.js
@@ -55,16 +55,27 @@ export function isEligibleForAnalysis(row) {
 
 /**
  * Return a short market-gap label string, or null if insignificant.
+ *
+ * "Market gap" is KTC (the retail offense market) vs the mean rank of
+ * every other registered ranking source (the expert consensus — IDPTC,
+ * DLF, etc.).  A KTC premium means the offense market values the
+ * player more than the consensus does; a consensus premium is the
+ * opposite.
  */
 export function marketGapLabel(row) {
   if (!row?.sourceRanks) return null;
   const ktcRank = row.sourceRanks.ktc;
-  const idpRank = row.sourceRanks.idpTradeCalc;
-  if (ktcRank && idpRank) {
-    const diff = Math.abs(ktcRank - idpRank);
-    if (diff < MARKET_GAP_MIN_DIFF) return null;
-    const higher = ktcRank < idpRank ? "KTC" : "IDPTC";
-    return `${higher} +${diff}`;
-  }
-  return null;
+  if (!ktcRank) return null;
+
+  const otherRanks = Object.entries(row.sourceRanks)
+    .filter(([key, rank]) => key !== "ktc" && rank != null)
+    .map(([, rank]) => Number(rank))
+    .filter((n) => Number.isFinite(n));
+  if (otherRanks.length === 0) return null;
+
+  const consensusRank = otherRanks.reduce((s, v) => s + v, 0) / otherRanks.length;
+  const diff = Math.round(Math.abs(consensusRank - ktcRank));
+  if (diff < MARKET_GAP_MIN_DIFF) return null;
+  const higher = ktcRank < consensusRank ? "KTC" : "Consensus";
+  return `${higher} +${diff}`;
 }

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -232,10 +232,11 @@ export function rankToValue(rank) {
 // src/api/data_contract.py.  Adding a new position-only source is a
 // purely declarative change (add an entry here and on the backend).
 const OVERALL_RANK_LIMIT = 800;
-const RANKING_SOURCES = [
+export const RANKING_SOURCES = [
   {
     key: "ktc",
     displayName: "KeepTradeCut",
+    columnLabel: "KTC",
     scope: SOURCE_SCOPE_OVERALL_OFFENSE,
     positionGroup: null,
     depth: null,
@@ -243,9 +244,18 @@ const RANKING_SOURCES = [
     isBackbone: false,
   },
   {
+    // IDP Trade Calculator's value pool covers both offense (via the
+    // site's autocomplete) and IDP in the same 0-9999 scale.  Register
+    // under overall_idp (as the IDP backbone) AND overall_offense (as a
+    // second opinion for offensive players) — mirrors the backend
+    // _RANKING_SOURCES entry in src/api/data_contract.py.  The two
+    // scope passes act on disjoint row sets so sourceRanks never
+    // collides for the same source key.
     key: "idpTradeCalc",
     displayName: "IDP Trade Calculator",
+    columnLabel: "IDPTC",
     scope: SOURCE_SCOPE_OVERALL_IDP,
+    extraScopes: [SOURCE_SCOPE_OVERALL_OFFENSE],
     positionGroup: null,
     depth: null,
     weight: 1.0,
@@ -257,6 +267,7 @@ const RANKING_SOURCES = [
     // 185-player expert consensus; overall_idp scope; not a backbone.
     key: "dlfIdp",
     displayName: "Dynasty League Football IDP",
+    columnLabel: "DLF",
     scope: SOURCE_SCOPE_OVERALL_IDP,
     positionGroup: null,
     depth: null,
@@ -283,46 +294,54 @@ function computeUnifiedRanks(rows) {
   const sourceMetaByRow = new Map();  // row idx -> { sourceKey: metaDict }
 
   for (const src of RANKING_SOURCES) {
-    const eligible = [];
-    rows.forEach((r, idx) => {
-      if (!RANKABLE.has(r.pos)) return;
-      if (!scopeEligible(r.pos, src.scope, src.positionGroup)) return;
-      const val = Number(r.canonicalSites?.[src.key]);
-      if (!Number.isFinite(val) || val <= 0) return;
-      eligible.push({ idx, val });
-    });
-    eligible.sort((a, b) => b.val - a.val);
+    // A source may contribute to multiple scopes (e.g. IDPTradeCalc
+    // lists both offense and IDP players in one value pool).  Each
+    // scope runs an independent eligibility + ordinal ranking pass.
+    // Offense and IDP position sets are disjoint, so sourceRanks[src.key]
+    // is written at most once per row across the passes.
+    const scopesToRank = [src.scope, ...(src.extraScopes || [])];
+    for (const scope of scopesToRank) {
+      const eligible = [];
+      rows.forEach((r, idx) => {
+        if (!RANKABLE.has(r.pos)) return;
+        if (!scopeEligible(r.pos, scope, src.positionGroup)) return;
+        const val = Number(r.canonicalSites?.[src.key]);
+        if (!Number.isFinite(val) || val <= 0) return;
+        eligible.push({ idx, val });
+      });
+      eligible.sort((a, b) => b.val - a.val);
 
-    eligible.forEach((e, rank) => {
-      const rawRank = rank + 1;
-      let effectiveRank = rawRank;
-      let method = TRANSLATION_DIRECT;
+      eligible.forEach((e, rank) => {
+        const rawRank = rank + 1;
+        let effectiveRank = rawRank;
+        let method = TRANSLATION_DIRECT;
 
-      if (src.scope === SOURCE_SCOPE_POSITION_IDP && src.positionGroup) {
-        const ladder = backbone.ladders[String(src.positionGroup).toUpperCase()] || [];
-        const translated = translatePositionRank(rawRank, ladder);
-        effectiveRank = translated.rank;
-        method = translated.method;
-      }
+        if (scope === SOURCE_SCOPE_POSITION_IDP && src.positionGroup) {
+          const ladder = backbone.ladders[String(src.positionGroup).toUpperCase()] || [];
+          const translated = translatePositionRank(rawRank, ladder);
+          effectiveRank = translated.rank;
+          method = translated.method;
+        }
 
-      if (!sourceRanksByRow.has(e.idx)) sourceRanksByRow.set(e.idx, {});
-      if (!sourceMetaByRow.has(e.idx)) sourceMetaByRow.set(e.idx, {});
-      sourceRanksByRow.get(e.idx)[src.key] = effectiveRank;
-      sourceMetaByRow.get(e.idx)[src.key] = {
-        scope: src.scope,
-        positionGroup: src.positionGroup || null,
-        rawRank,
-        effectiveRank,
-        method,
-        ladderDepth:
-          src.scope === SOURCE_SCOPE_POSITION_IDP && src.positionGroup
-            ? (backbone.ladders[String(src.positionGroup).toUpperCase()] || []).length
-            : null,
-        backboneDepth: src.scope === SOURCE_SCOPE_POSITION_IDP ? backbone.depth : null,
-        depth: src.depth ?? null,
-        weight: Number(src.weight) || 0,
-      };
-    });
+        if (!sourceRanksByRow.has(e.idx)) sourceRanksByRow.set(e.idx, {});
+        if (!sourceMetaByRow.has(e.idx)) sourceMetaByRow.set(e.idx, {});
+        sourceRanksByRow.get(e.idx)[src.key] = effectiveRank;
+        sourceMetaByRow.get(e.idx)[src.key] = {
+          scope,
+          positionGroup: src.positionGroup || null,
+          rawRank,
+          effectiveRank,
+          method,
+          ladderDepth:
+            scope === SOURCE_SCOPE_POSITION_IDP && src.positionGroup
+              ? (backbone.ladders[String(src.positionGroup).toUpperCase()] || []).length
+              : null,
+          backboneDepth: scope === SOURCE_SCOPE_POSITION_IDP ? backbone.depth : null,
+          depth: src.depth ?? null,
+          weight: Number(src.weight) || 0,
+        };
+      });
+    }
   }
 
   // ── Phase 2-3: Coverage-aware weighted Hill-curve blend ──

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -234,6 +234,12 @@ export function rankToValue(rank) {
 const OVERALL_RANK_LIMIT = 800;
 export const RANKING_SOURCES = [
   {
+    // KeepTradeCut is the retail offense market — community trade values
+    // scraped from a public-facing trade calculator.  This is what casual
+    // trade partners see and anchor on, so it's flagged `isRetail: true`
+    // and fed into the market-gap signal as the "retail" side against
+    // every other (expert) source.  Mirrors the `is_retail: True` flag
+    // on the backend `_RANKING_SOURCES` entry in src/api/data_contract.py.
     key: "ktc",
     displayName: "KeepTradeCut",
     columnLabel: "KTC",
@@ -242,6 +248,7 @@ export const RANKING_SOURCES = [
     depth: null,
     weight: 1.0,
     isBackbone: false,
+    isRetail: true,
   },
   {
     // IDP Trade Calculator's value pool covers both offense (via the
@@ -279,6 +286,37 @@ export const RANKING_SOURCES = [
 // Legacy export retained for any consumer that previously imported
 // the flat source-key list.  New callers should use RANKING_SOURCES.
 const SOURCE_KEYS = RANKING_SOURCES.map((s) => s.key);
+
+// ── Retail source registry helpers ───────────────────────────────────
+// Mirrors `_retail_source_keys()` on the backend.  "Retail" sources are
+// flagged in the registry with `isRetail: true` and represent the
+// casual/market side of the market-gap signal (today just KTC).  Every
+// non-retail registered source forms the "consensus" side.  Adding a
+// second retail source (e.g. a future Sleeper trade-values feed) is a
+// pure registry change — gap-label rendering, edge-summary filters,
+// and page-level display all read from these helpers, so no call sites
+// need to be edited when a new retail source is registered.
+
+/**
+ * Return an array of ranking source keys flagged as retail.
+ * Derived from RANKING_SOURCES on every call so tests that mutate the
+ * registry (or future runtime config reloads) see updated membership.
+ */
+export function getRetailSourceKeys() {
+  return RANKING_SOURCES.filter((s) => s.isRetail).map((s) => s.key);
+}
+
+/**
+ * Return the label to use for the retail side of the market-gap signal.
+ * When exactly one source is flagged retail, its column label is used
+ * directly (today: "KTC").  When multiple sources are flagged retail,
+ * the generic label "Retail" is used instead.
+ */
+export function getRetailLabel() {
+  const retail = RANKING_SOURCES.filter((s) => s.isRetail);
+  if (retail.length === 1) return retail[0].columnLabel;
+  return "Retail";
+}
 
 function computeUnifiedRanks(rows) {
   // ── Phase 0: Build the IDP backbone from the designated source ──

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -24,6 +24,7 @@ import {
   EDGE_CAUTION_RANK_LIMIT,
 } from "./thresholds.js";
 import { isEligibleForAnalysis } from "./display-helpers.js";
+import { getRetailLabel } from "./dynasty-data.js";
 
 // ── Action-frame labels ──────────────────────────────────────────────────────
 // Each row gets at most one primary action label + optional caution labels.
@@ -42,14 +43,17 @@ import { isEligibleForAnalysis } from "./display-helpers.js";
 export function actionLabel(row) {
   if (!row || row.quarantined) return null;
 
-  // Market premium: KTC (retail) disagrees materially with expert
-  // consensus (IDPTC + DLF + any other non-KTC source averaged).
-  // "KTC premium" = retail values the player more than consensus does;
-  // "Consensus premium" = the reverse.
+  // Market premium: the retail market (sources flagged isRetail in the
+  // registry — today just KTC) disagrees materially with the expert
+  // consensus (every non-retail source averaged).  "Retail premium" =
+  // retail values the player more than consensus does; "Consensus
+  // premium" = the reverse.  The retail side label is resolved from the
+  // registry via getRetailLabel() so a second retail source flips the
+  // label to "Retail" automatically.
   const spread = row.sourceRankSpread;
   const dir = row.marketGapDirection;
   if (spread != null && spread >= MARKET_PREMIUM_SPREAD && dir && dir !== "none") {
-    const side = dir === "ktc_premium" ? "KTC" : "Consensus";
+    const side = dir === "retail_premium" ? getRetailLabel() : "Consensus";
     return {
       label: `Market premium: ${side}`,
       css: "action-premium",
@@ -183,29 +187,36 @@ export function applyLens(rows, lensKey) {
 // capped at `limit` entries.
 
 /**
- * Top players where KTC (retail offense market) ranks them much higher
- * than the expert consensus (IDPTC + DLF + any other non-KTC source).
- * These are players the retail market values more than the experts do.
+ * Top players where the retail market (sources flagged `isRetail` in
+ * the registry — today just KTC) ranks them much higher than the
+ * expert consensus (every non-retail source averaged).  These are
+ * players the retail market values more than the experts do.
+ *
+ * The detail label is resolved dynamically from the registry via
+ * `getRetailLabel()`, so today it reads "KTC +N ranks" and a future
+ * two-retail-source world would read "Retail +N ranks" with no code
+ * edits here.
  */
-export function topKtcPremium(rows, limit = 5) {
+export function topRetailPremium(rows, limit = 5) {
+  const retailLabel = getRetailLabel();
   return rows
-    .filter((r) => r.marketGapDirection === "ktc_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
+    .filter((r) => r.marketGapDirection === "retail_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
     .sort((a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0))
     .slice(0, limit)
     .map((r) => ({
       name: r.name,
       pos: r.pos,
       rank: r.rank,
-      detail: `KTC +${r.sourceRankSpread} ranks`,
+      detail: `${retailLabel} +${r.sourceRankSpread} ranks`,
       row: r,
     }));
 }
 
 /**
- * Top players where the expert consensus ranks them much higher than
- * KTC.  These are players the experts value more than the retail
- * offense market does — potential "buy low" targets from KTC-first
- * trade partners.
+ * Top players where the expert consensus (every non-retail source
+ * averaged) ranks them much higher than the retail market.  These are
+ * players the experts value more than retail does — potential "buy
+ * low" targets from retail-first trade partners.
  */
 export function topConsensusPremium(rows, limit = 5) {
   return rows
@@ -263,7 +274,7 @@ export function computeEdgeSummary(rows) {
   // Pre-filter to ranked non-pick players
   const eligible = rows.filter(isEligibleForAnalysis);
   return {
-    ktcPremium: topKtcPremium(eligible),
+    retailPremium: topRetailPremium(eligible),
     consensusPremium: topConsensusPremium(eligible),
     flaggedCautions: topFlaggedCautions(eligible),
     consensusAssets: topConsensusAssets(eligible),

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -42,15 +42,18 @@ import { isEligibleForAnalysis } from "./display-helpers.js";
 export function actionLabel(row) {
   if (!row || row.quarantined) return null;
 
-  // Market premium: one source ranks the player much higher than the other
+  // Market premium: KTC (retail) disagrees materially with expert
+  // consensus (IDPTC + DLF + any other non-KTC source averaged).
+  // "KTC premium" = retail values the player more than consensus does;
+  // "Consensus premium" = the reverse.
   const spread = row.sourceRankSpread;
   const dir = row.marketGapDirection;
   if (spread != null && spread >= MARKET_PREMIUM_SPREAD && dir && dir !== "none") {
-    const source = dir === "ktc_higher" ? "KTC" : "IDPTC";
+    const side = dir === "ktc_premium" ? "KTC" : "Consensus";
     return {
-      label: `Market premium: ${source}`,
+      label: `Market premium: ${side}`,
       css: "action-premium",
-      title: `${source} ranks this player ${spread} positions higher than the other source`,
+      title: `${side} ranks this player ${spread} positions higher than the other side of the market`,
     };
   }
 
@@ -180,12 +183,13 @@ export function applyLens(rows, lensKey) {
 // capped at `limit` entries.
 
 /**
- * Top players where KTC ranks them much higher than IDPTC.
- * These are players the offense market values more than the IDP market.
+ * Top players where KTC (retail offense market) ranks them much higher
+ * than the expert consensus (IDPTC + DLF + any other non-KTC source).
+ * These are players the retail market values more than the experts do.
  */
 export function topKtcPremium(rows, limit = 5) {
   return rows
-    .filter((r) => r.marketGapDirection === "ktc_higher" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
+    .filter((r) => r.marketGapDirection === "ktc_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
     .sort((a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0))
     .slice(0, limit)
     .map((r) => ({
@@ -198,18 +202,21 @@ export function topKtcPremium(rows, limit = 5) {
 }
 
 /**
- * Top players where IDPTC ranks them much higher than KTC.
+ * Top players where the expert consensus ranks them much higher than
+ * KTC.  These are players the experts value more than the retail
+ * offense market does — potential "buy low" targets from KTC-first
+ * trade partners.
  */
-export function topIdptcPremium(rows, limit = 5) {
+export function topConsensusPremium(rows, limit = 5) {
   return rows
-    .filter((r) => r.marketGapDirection === "idptc_higher" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
+    .filter((r) => r.marketGapDirection === "consensus_premium" && (r.sourceRankSpread ?? 0) >= PREMIUM_SUMMARY_SPREAD && !r.quarantined)
     .sort((a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0))
     .slice(0, limit)
     .map((r) => ({
       name: r.name,
       pos: r.pos,
       rank: r.rank,
-      detail: `IDPTC +${r.sourceRankSpread} ranks`,
+      detail: `Consensus +${r.sourceRankSpread} ranks`,
       row: r,
     }));
 }
@@ -257,7 +264,7 @@ export function computeEdgeSummary(rows) {
   const eligible = rows.filter(isEligibleForAnalysis);
   return {
     ktcPremium: topKtcPremium(eligible),
-    idptcPremium: topIdptcPremium(eligible),
+    consensusPremium: topConsensusPremium(eligible),
     flaggedCautions: topFlaggedCautions(eligible),
     consensusAssets: topConsensusAssets(eligible),
   };

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -167,6 +167,15 @@ _RANK_TO_SYNTHETIC_VALUE_OFFSET = 10000
 #   is_backbone   — the first enabled overall_idp source with this flag is
 #                   used to build the translation backbone.  Backbone
 #                   status is determined by the *primary* scope only.
+#   is_retail     — marks a source as a retail/market signal (what casual
+#                   trade partners anchor on) rather than an expert board.
+#                   Used by `_compute_market_gap` to compute the "Retail
+#                   vs Consensus" mispricing signal: retail sources are
+#                   averaged on one side, every other (non-retail) source
+#                   on the other, and the gap between the two sides is
+#                   the marketGapMagnitude.  Adding a second retail
+#                   source (e.g. Sleeper's public trade values) is a
+#                   pure registry change — the gap logic generalizes.
 from src.canonical.idp_backbone import (
     SOURCE_SCOPE_OVERALL_IDP,
     SOURCE_SCOPE_OVERALL_OFFENSE,
@@ -181,6 +190,11 @@ from src.canonical.idp_backbone import (
 
 _RANKING_SOURCES: list[dict[str, Any]] = [
     {
+        # KeepTradeCut is the retail offense market — community trade
+        # values scraped from a public-facing trade calculator.  This
+        # is what casual trade partners see and anchor on, so it's
+        # flagged `is_retail` and fed into the market-gap signal as
+        # the "retail" side against every other (expert) source.
         "key": "ktc",
         "display_name": "KeepTradeCut",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
@@ -188,6 +202,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "depth": None,
         "weight": 1.0,
         "is_backbone": False,
+        "is_retail": True,
     },
     {
         # IDP Trade Calculator's public value pool covers both offense
@@ -322,45 +337,67 @@ def _compute_anomaly_flags(
     return flags
 
 
+def _retail_source_keys() -> frozenset[str]:
+    """Return the set of ranking source keys marked `is_retail` in the registry.
+
+    Derived from `_RANKING_SOURCES` on every call so tests (or future
+    config reloads) that mutate the registry see updated membership
+    without a module reimport.
+    """
+    return frozenset(s["key"] for s in _RANKING_SOURCES if s.get("is_retail"))
+
+
 def _compute_market_gap(
     source_ranks: dict[str, int],
+    retail_keys: set[str] | frozenset[str] | None = None,
 ) -> tuple[str, float | None]:
-    """Quantify the disagreement between KTC and the expert consensus.
+    """Quantify the disagreement between retail and expert consensus.
 
-    "Market gap" frames KTC (the retail offense market) against the mean
-    rank of every other registered source (IDPTC + DLF + any future
-    expert source).  A positive diff means KTC ranks the player higher
-    than consensus (a "KTC premium"); a negative diff means consensus
-    ranks the player higher than KTC (a "consensus premium").
+    "Market gap" frames the retail market (sources flagged `is_retail`
+    in the registry — today just KTC) against every other registered
+    source (the expert consensus — IDPTC, DLF, and any future non-retail
+    source).  Both sides are averaged, and the gap is the ordinal rank
+    difference between the two means.
+
+    A retail premium means retail ranks the player higher (lower rank
+    number) than consensus — i.e. the retail market is pricing the
+    player above where the experts have them.  A consensus premium is
+    the reverse: the experts value the player more than retail does,
+    making them a potential "buy low" from a retail-first trade partner.
 
     Returns (direction, magnitude) where direction is one of:
-      "ktc_premium"        — KTC rank is lower number (better) than consensus mean
-      "consensus_premium"  — consensus mean rank is lower number than KTC
-      "none"               — tie, or KTC has no rank, or no consensus sources
+      "retail_premium"     — retail mean rank is lower number than consensus mean
+      "consensus_premium"  — consensus mean rank is lower number than retail mean
+      "none"               — tie, or either side has zero sources present
 
-    magnitude is the absolute ordinal rank difference as a float, or
-    None when the comparison cannot be made (KTC missing or no consensus
-    sources present).  Magnitude is 0.0 on a tie.
+    magnitude is the absolute ordinal rank difference between the two
+    means as a float, or None when the comparison cannot be made (one
+    side has no source ranks on this row).  Magnitude is 0.0 on a tie.
+
+    `retail_keys` is an optional override for tests; when None the set is
+    derived from `_RANKING_SOURCES` via `_retail_source_keys()`.
     """
-    ktc_rank = source_ranks.get("ktc")
-    if ktc_rank is None:
-        return "none", None
+    if retail_keys is None:
+        retail_keys = _retail_source_keys()
 
-    # Consensus = mean of every source rank other than KTC that is
-    # actually present on this row.  Using a mean (not median) keeps the
-    # signal smooth when only one non-KTC source covers the player.
-    other_ranks = [
+    retail_ranks = [
         rank
         for key, rank in source_ranks.items()
-        if key != "ktc" and rank is not None
+        if key in retail_keys and rank is not None
     ]
-    if not other_ranks:
+    consensus_ranks = [
+        rank
+        for key, rank in source_ranks.items()
+        if key not in retail_keys and rank is not None
+    ]
+    if not retail_ranks or not consensus_ranks:
         return "none", None
 
-    consensus_rank = sum(other_ranks) / len(other_ranks)
-    diff = consensus_rank - ktc_rank  # positive → KTC ranks higher (lower number)
+    retail_mean = sum(retail_ranks) / len(retail_ranks)
+    consensus_mean = sum(consensus_ranks) / len(consensus_ranks)
+    diff = consensus_mean - retail_mean  # positive → retail ranks higher
     if diff > 0:
-        return "ktc_premium", float(abs(diff))
+        return "retail_premium", float(abs(diff))
     if diff < 0:
         return "consensus_premium", float(abs(diff))
     return "none", 0.0
@@ -1415,6 +1452,7 @@ def build_api_data_contract(
                 "depth": src.get("depth"),
                 "weight": src.get("weight"),
                 "isBackbone": bool(src.get("is_backbone")),
+                "isRetail": bool(src.get("is_retail")),
                 "covers": " + ".join(
                     (
                         "Offense (QB, RB, WR, TE) + draft picks"

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -325,22 +325,45 @@ def _compute_anomaly_flags(
 def _compute_market_gap(
     source_ranks: dict[str, int],
 ) -> tuple[str, float | None]:
-    """Determine which source ranks a player higher and by how much.
+    """Quantify the disagreement between KTC and the expert consensus.
+
+    "Market gap" frames KTC (the retail offense market) against the mean
+    rank of every other registered source (IDPTC + DLF + any future
+    expert source).  A positive diff means KTC ranks the player higher
+    than consensus (a "KTC premium"); a negative diff means consensus
+    ranks the player higher than KTC (a "consensus premium").
 
     Returns (direction, magnitude) where direction is one of:
-      "ktc_higher", "idptc_higher", "none"
-    and magnitude is the absolute ordinal rank difference (None if < 2 sources).
+      "ktc_premium"        — KTC rank is lower number (better) than consensus mean
+      "consensus_premium"  — consensus mean rank is lower number than KTC
+      "none"               — tie, or KTC has no rank, or no consensus sources
+
+    magnitude is the absolute ordinal rank difference as a float, or
+    None when the comparison cannot be made (KTC missing or no consensus
+    sources present).  Magnitude is 0.0 on a tie.
     """
     ktc_rank = source_ranks.get("ktc")
-    idp_rank = source_ranks.get("idpTradeCalc")
-    if ktc_rank is not None and idp_rank is not None:
-        diff = idp_rank - ktc_rank  # positive means KTC ranks higher (lower number)
-        if diff > 0:
-            return "ktc_higher", float(abs(diff))
-        elif diff < 0:
-            return "idptc_higher", float(abs(diff))
-        return "none", 0.0
-    return "none", None
+    if ktc_rank is None:
+        return "none", None
+
+    # Consensus = mean of every source rank other than KTC that is
+    # actually present on this row.  Using a mean (not median) keeps the
+    # signal smooth when only one non-KTC source covers the player.
+    other_ranks = [
+        rank
+        for key, rank in source_ranks.items()
+        if key != "ktc" and rank is not None
+    ]
+    if not other_ranks:
+        return "none", None
+
+    consensus_rank = sum(other_ranks) / len(other_ranks)
+    diff = consensus_rank - ktc_rank  # positive → KTC ranks higher (lower number)
+    if diff > 0:
+        return "ktc_premium", float(abs(diff))
+    if diff < 0:
+        return "consensus_premium", float(abs(diff))
+    return "none", 0.0
 
 
 def _normalize_for_collision(name: str) -> str:

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -145,10 +145,19 @@ _RANK_TO_SYNTHETIC_VALUE_OFFSET = 10000
 # Fields:
 #   key           — the contract-side source key used in canonicalSiteValues
 #   display_name  — human label for methodology docs
-#   scope         — one of:
+#   scope         — the *primary* scope for this source, one of:
 #                     SOURCE_SCOPE_OVERALL_OFFENSE: ranks offense + picks
 #                     SOURCE_SCOPE_OVERALL_IDP:     ranks DL/LB/DB together
 #                     SOURCE_SCOPE_POSITION_IDP:    ranks a single IDP family
+#   extra_scopes  — optional list of additional scopes this source also
+#                   contributes to.  Used when a single market source
+#                   (e.g. IDP Trade Calculator) lists BOTH offense and IDP
+#                   players in the same value pool, and we want it to
+#                   feed the offense blend as a second opinion as well as
+#                   serving as the IDP backbone.  Because offense and IDP
+#                   position sets are disjoint, each row only ever lands
+#                   in one scope's eligible list, so sourceRanks never
+#                   collides across scopes for the same source key.
 #   position_group — for position_idp: "DL" | "LB" | "DB" (None otherwise)
 #   depth         — declared list depth (None means "full board").  Used to
 #                   scale the blend weight for shallow lists.
@@ -156,7 +165,8 @@ _RANK_TO_SYNTHETIC_VALUE_OFFSET = 10000
 #                   config/weights file can override this, but equal
 #                   weights is the current project default.
 #   is_backbone   — the first enabled overall_idp source with this flag is
-#                   used to build the translation backbone.
+#                   used to build the translation backbone.  Backbone
+#                   status is determined by the *primary* scope only.
 from src.canonical.idp_backbone import (
     SOURCE_SCOPE_OVERALL_IDP,
     SOURCE_SCOPE_OVERALL_OFFENSE,
@@ -180,9 +190,18 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_backbone": False,
     },
     {
+        # IDP Trade Calculator's public value pool covers both offense
+        # players (via autocomplete, same 0-9999 scale) and the full IDP
+        # board.  Register it under the overall_idp scope as the IDP
+        # backbone *and* under overall_offense as a secondary offense
+        # source so offensive players get blended ranks from KTC and
+        # IDPTradeCalc together.  The two scope passes act on disjoint
+        # row sets (offense vs IDP positions), so sourceRanks["idpTradeCalc"]
+        # is written exactly once per row.
         "key": "idpTradeCalc",
         "display_name": "IDP Trade Calculator",
         "scope": SOURCE_SCOPE_OVERALL_IDP,
+        "extra_scopes": [SOURCE_SCOPE_OVERALL_OFFENSE],
         "position_group": None,
         "depth": None,
         "weight": 1.0,
@@ -792,58 +811,66 @@ def _compute_unified_rankings(
 
     for src in _RANKING_SOURCES:
         source_key: str = src["key"]
-        scope: str = src["scope"]
         position_group: str | None = src.get("position_group")
+        # A source may contribute to multiple scopes (e.g. IDPTradeCalc
+        # lists both offense and IDP players in one value pool).  Each
+        # scope runs its own eligibility + ordinal ranking pass.  Offense
+        # and IDP position sets are disjoint, so sourceRanks[source_key]
+        # is written at most once per row across the passes.
+        scopes_to_rank: list[str] = [src["scope"]] + list(
+            src.get("extra_scopes") or []
+        )
+        for scope in scopes_to_rank:
 
-        # Gather eligible (value, row_idx) tuples under this source's scope.
-        eligible: list[tuple[float, int]] = []
-        for idx, row in enumerate(players_array):
-            pos = str(row.get("position") or "").strip().upper()
-            if pos not in _RANKABLE_POSITIONS:
-                continue
-            if not _scope_eligible(pos, scope, position_group):
-                continue
-            sites = row.get("canonicalSiteValues") or {}
-            val = _safe_num(sites.get(source_key))
-            if val is None or val <= 0:
-                continue
-            eligible.append((val, idx))
+            # Gather eligible (value, row_idx) tuples under this source's scope.
+            eligible: list[tuple[float, int]] = []
+            for idx, row in enumerate(players_array):
+                pos = str(row.get("position") or "").strip().upper()
+                if pos not in _RANKABLE_POSITIONS:
+                    continue
+                if not _scope_eligible(pos, scope, position_group):
+                    continue
+                sites = row.get("canonicalSiteValues") or {}
+                val = _safe_num(sites.get(source_key))
+                if val is None or val <= 0:
+                    continue
+                eligible.append((val, idx))
 
-        eligible.sort(key=lambda t: -t[0])
+            eligible.sort(key=lambda t: -t[0])
 
-        for rank_idx, (_, row_idx) in enumerate(eligible):
-            raw_rank = rank_idx + 1
+            for rank_idx, (_, row_idx) in enumerate(eligible):
+                raw_rank = rank_idx + 1
 
-            # Translate to effective overall-style rank based on scope.
-            if scope == SOURCE_SCOPE_POSITION_IDP and position_group:
-                ladder = backbone.ladder_for(position_group)
-                effective_rank, method = translate_position_rank(
-                    raw_rank, ladder
-                )
-            else:
-                effective_rank = raw_rank
-                method = TRANSLATION_DIRECT
+                # Translate to effective overall-style rank based on scope.
+                if scope == SOURCE_SCOPE_POSITION_IDP and position_group:
+                    ladder = backbone.ladder_for(position_group)
+                    effective_rank, method = translate_position_rank(
+                        raw_rank, ladder
+                    )
+                else:
+                    effective_rank = raw_rank
+                    method = TRANSLATION_DIRECT
 
-            row_source_ranks.setdefault(row_idx, {})[source_key] = effective_rank
-            row_source_meta.setdefault(row_idx, {})[source_key] = {
-                "scope": scope,
-                "positionGroup": position_group,
-                "rawRank": raw_rank,
-                "effectiveRank": effective_rank,
-                "method": method,
-                "ladderDepth": (
-                    len(backbone.ladder_for(position_group))
-                    if scope == SOURCE_SCOPE_POSITION_IDP and position_group
-                    else None
-                ),
-                "backboneDepth": (
-                    backbone_depth
-                    if scope == SOURCE_SCOPE_POSITION_IDP
-                    else None
-                ),
-                "depth": src.get("depth"),
-                "weight": float(src.get("weight") or 0.0),
-            }
+                row_source_ranks.setdefault(row_idx, {})[source_key] = effective_rank
+                row_source_meta.setdefault(row_idx, {})[source_key] = {
+                    "scope": scope,
+                    "positionGroup": position_group,
+                    "rawRank": raw_rank,
+                    "effectiveRank": effective_rank,
+                    "method": method,
+                    "ladderDepth": (
+                        len(backbone.ladder_for(position_group))
+                        if scope == SOURCE_SCOPE_POSITION_IDP and position_group
+                        else None
+                    ),
+                    "backboneDepth": (
+                        backbone_depth
+                        if scope == SOURCE_SCOPE_POSITION_IDP
+                        else None
+                    ),
+                    "depth": src.get("depth"),
+                    "weight": float(src.get("weight") or 0.0),
+                }
 
     # ── Phase 2-3: Normalized value (Hill curve) + coverage-aware blend ──
     # Look up each source's weight / depth once.
@@ -1360,16 +1387,20 @@ def build_api_data_contract(
                 "key": src["key"],
                 "name": src["display_name"],
                 "scope": src["scope"],
+                "extraScopes": list(src.get("extra_scopes") or []),
                 "positionGroup": src.get("position_group"),
                 "depth": src.get("depth"),
                 "weight": src.get("weight"),
                 "isBackbone": bool(src.get("is_backbone")),
-                "covers": (
-                    "Offense (QB, RB, WR, TE) + draft picks"
-                    if src["scope"] == SOURCE_SCOPE_OVERALL_OFFENSE
-                    else "IDP full board (DL, LB, DB)"
-                    if src["scope"] == SOURCE_SCOPE_OVERALL_IDP
-                    else f"IDP position group: {src.get('position_group')}"
+                "covers": " + ".join(
+                    (
+                        "Offense (QB, RB, WR, TE) + draft picks"
+                        if s == SOURCE_SCOPE_OVERALL_OFFENSE
+                        else "IDP full board (DL, LB, DB)"
+                        if s == SOURCE_SCOPE_OVERALL_IDP
+                        else f"IDP position group: {src.get('position_group')}"
+                    )
+                    for s in ([src["scope"]] + list(src.get("extra_scopes") or []))
                 ),
             }
             for src in _RANKING_SOURCES

--- a/tests/api/test_scope_aware_rankings.py
+++ b/tests/api/test_scope_aware_rankings.py
@@ -28,6 +28,7 @@ from src.api.data_contract import (
 )
 from src.canonical.idp_backbone import (
     SOURCE_SCOPE_OVERALL_IDP,
+    SOURCE_SCOPE_OVERALL_OFFENSE,
     SOURCE_SCOPE_POSITION_IDP,
     TRANSLATION_DIRECT,
     TRANSLATION_EXACT,
@@ -380,6 +381,122 @@ class TestETransparencyFields(unittest.TestCase):
         dl = next(r for r in rows if r["canonicalName"] == "dl1")
         self.assertEqual(qb["ktcRank"], qb["sourceRanks"]["ktc"])
         self.assertEqual(dl["idpRank"], dl["sourceRanks"]["idpTradeCalc"])
+
+
+class TestGDualScopeIdpTradeCalc(unittest.TestCase):
+    """G. IDP Trade Calculator registers under two scopes.
+
+    IDPTradeCalc's public value pool covers both offensive and IDP
+    players on the same 0-9999 scale, so the source contributes to the
+    overall_offense blend (alongside KTC) AND to the overall_idp blend
+    (as the backbone).  These tests lock that behaviour so nobody
+    accidentally re-narrows it to IDP-only.
+    """
+
+    def test_registry_declares_extra_offense_scope(self):
+        idptc = next(s for s in _RANKING_SOURCES if s["key"] == "idpTradeCalc")
+        self.assertEqual(idptc["scope"], SOURCE_SCOPE_OVERALL_IDP)
+        self.assertIn(SOURCE_SCOPE_OVERALL_OFFENSE, idptc.get("extra_scopes") or [])
+        # Backbone status is determined by the primary scope only.
+        self.assertTrue(idptc["is_backbone"])
+
+    def test_offense_players_get_ktc_and_idptc_ranks(self):
+        rows = [
+            _row("qb1", "QB", ktc=9500, idp=9600),
+            _row("wr1", "WR", ktc=9000, idp=9200),
+            _row("rb1", "RB", ktc=8500, idp=8400),
+        ]
+        _compute_unified_rankings(rows, {})
+
+        qb1 = next(r for r in rows if r["canonicalName"] == "qb1")
+        wr1 = next(r for r in rows if r["canonicalName"] == "wr1")
+        rb1 = next(r for r in rows if r["canonicalName"] == "rb1")
+
+        # Both sources stamp an offense rank on every row.
+        for r in (qb1, wr1, rb1):
+            self.assertIn("ktc", r["sourceRanks"])
+            self.assertIn("idpTradeCalc", r["sourceRanks"])
+            # IDPTradeCalc's meta for this row is tagged overall_offense,
+            # not overall_idp — they're being ranked in the offense pool.
+            self.assertEqual(
+                r["sourceRankMeta"]["idpTradeCalc"]["scope"],
+                SOURCE_SCOPE_OVERALL_OFFENSE,
+            )
+
+        # KTC order: qb1(9500) > wr1(9000) > rb1(8500)
+        self.assertEqual(qb1["sourceRanks"]["ktc"], 1)
+        self.assertEqual(wr1["sourceRanks"]["ktc"], 2)
+        self.assertEqual(rb1["sourceRanks"]["ktc"], 3)
+        # IDPTC order: wr1(9200) > qb1(9600 wait that's higher) — recompute
+        # idp values:  qb1=9600, wr1=9200, rb1=8400  →  qb1 > wr1 > rb1
+        self.assertEqual(qb1["sourceRanks"]["idpTradeCalc"], 1)
+        self.assertEqual(wr1["sourceRanks"]["idpTradeCalc"], 2)
+        self.assertEqual(rb1["sourceRanks"]["idpTradeCalc"], 3)
+
+        # Offense players are no longer single-source.
+        self.assertFalse(qb1["isSingleSource"])
+        self.assertEqual(qb1["sourceCount"], 2)
+
+    def test_offense_idptc_rank_fed_into_blend(self):
+        """When KTC and IDPTradeCalc disagree on an offense player, the
+        blended rankDerivedValue sits between the two per-source Hill
+        values instead of equalling either one.
+        """
+        rows = [
+            # Identical KTC order for wr1 > wr2 but IDPTC flips them.
+            _row("wr1", "WR", ktc=9500, idp=8000),
+            _row("wr2", "WR", ktc=9000, idp=9500),
+        ]
+        _compute_unified_rankings(rows, {})
+
+        wr1 = next(r for r in rows if r["canonicalName"] == "wr1")
+        wr2 = next(r for r in rows if r["canonicalName"] == "wr2")
+
+        # KTC: wr1=1, wr2=2.  IDPTC: wr2=1, wr1=2.
+        self.assertEqual(wr1["sourceRanks"]["ktc"], 1)
+        self.assertEqual(wr1["sourceRanks"]["idpTradeCalc"], 2)
+        self.assertEqual(wr2["sourceRanks"]["ktc"], 2)
+        self.assertEqual(wr2["sourceRanks"]["idpTradeCalc"], 1)
+        # Each carries a spread of 1 between the two sources.
+        self.assertEqual(wr1["sourceRankSpread"], 1.0)
+        self.assertEqual(wr2["sourceRankSpread"], 1.0)
+
+    def test_idp_players_unaffected_by_extra_offense_scope(self):
+        """Adding overall_offense as an extra IDPTC scope must NOT change
+        how IDP players are ranked — they still only flow through the
+        overall_idp pass.
+        """
+        rows = [
+            _row("dl1", "DL", idp=900),
+            _row("lb1", "LB", idp=800),
+            _row("db1", "DB", idp=700),
+        ]
+        _compute_unified_rankings(rows, {})
+        for r in rows:
+            meta = r["sourceRankMeta"]["idpTradeCalc"]
+            self.assertEqual(meta["scope"], SOURCE_SCOPE_OVERALL_IDP)
+            # Offense scope didn't leak onto IDP rows (they have no 'ktc'
+            # entry because they're not eligible under overall_offense).
+            self.assertNotIn("ktc", r["sourceRanks"])
+        self.assertEqual(rows[0]["sourceRanks"]["idpTradeCalc"], 1)
+        self.assertEqual(rows[1]["sourceRanks"]["idpTradeCalc"], 2)
+        self.assertEqual(rows[2]["sourceRanks"]["idpTradeCalc"], 3)
+
+    def test_offense_player_without_idptc_value_still_ranks_via_ktc(self):
+        """Regression guard: an offense player with only a KTC value must
+        still land on the unified board even though IDPTradeCalc is now
+        a registered overall_offense source."""
+        rows = [
+            _row("qb_solo", "QB", ktc=8000),  # no IDPTC value
+            _row("qb_both", "QB", ktc=9000, idp=9000),
+        ]
+        _compute_unified_rankings(rows, {})
+        solo = next(r for r in rows if r["canonicalName"] == "qb_solo")
+        both = next(r for r in rows if r["canonicalName"] == "qb_both")
+        self.assertEqual(solo["sourceRanks"], {"ktc": 2})
+        self.assertTrue(solo["isSingleSource"])
+        self.assertEqual(both["sourceRanks"]["ktc"], 1)
+        self.assertEqual(both["sourceRanks"]["idpTradeCalc"], 1)
 
 
 class TestFEdgeCases(unittest.TestCase):

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -287,11 +287,12 @@ class TestAnomalyFlags(unittest.TestCase):
 
 class TestMarketGap(unittest.TestCase):
 
-    def test_ktc_premium_vs_single_consensus_source(self):
-        # KTC rank 10, IDPTC rank 50 → consensus mean = 50 →
-        # KTC ranks the player 40 positions higher → ktc_premium.
+    def test_retail_premium_vs_single_consensus_source(self):
+        # KTC (retail) rank 10, IDPTC (consensus) rank 50 → retail mean 10
+        # vs consensus mean 50 → retail ranks the player 40 positions
+        # higher → retail_premium.
         direction, magnitude = _compute_market_gap({"ktc": 10, "idpTradeCalc": 50})
-        self.assertEqual(direction, "ktc_premium")
+        self.assertEqual(direction, "retail_premium")
         self.assertEqual(magnitude, 40.0)
 
     def test_consensus_premium_vs_single_consensus_source(self):
@@ -304,24 +305,25 @@ class TestMarketGap(unittest.TestCase):
         self.assertEqual(direction, "none")
         self.assertEqual(magnitude, 0.0)
 
-    def test_ktc_alone_returns_none(self):
-        # No consensus sources present → cannot compute a gap.
+    def test_retail_alone_returns_none(self):
+        # Retail side has a rank, consensus side is empty → no gap.
         direction, magnitude = _compute_market_gap({"ktc": 10})
         self.assertEqual(direction, "none")
         self.assertIsNone(magnitude)
 
-    def test_no_ktc_returns_none(self):
-        # KTC absent → IDP-only players cannot have a KTC-vs-consensus gap.
+    def test_no_retail_returns_none(self):
+        # IDP-only players have no retail rank (KTC is offense-only) →
+        # retail side is empty → no gap.
         direction, magnitude = _compute_market_gap({"idpTradeCalc": 10, "dlfIdp": 20})
         self.assertEqual(direction, "none")
         self.assertIsNone(magnitude)
 
-    def test_ktc_vs_averaged_multi_source_consensus(self):
-        # KTC 10 vs mean(IDPTC 50, DLF 70) = 60 → ktc_premium of 50.
+    def test_retail_vs_averaged_multi_source_consensus(self):
+        # KTC 10 vs mean(IDPTC 50, DLF 70) = 60 → retail_premium of 50.
         direction, magnitude = _compute_market_gap(
             {"ktc": 10, "idpTradeCalc": 50, "dlfIdp": 70}
         )
-        self.assertEqual(direction, "ktc_premium")
+        self.assertEqual(direction, "retail_premium")
         self.assertEqual(magnitude, 50.0)
 
     def test_consensus_premium_with_multi_source_consensus(self):
@@ -331,6 +333,29 @@ class TestMarketGap(unittest.TestCase):
         )
         self.assertEqual(direction, "consensus_premium")
         self.assertEqual(magnitude, 65.0)
+
+    def test_multi_retail_sources_are_averaged(self):
+        # Hypothetical two-retail-source world (e.g. KTC + Sleeper trade
+        # values both flagged is_retail).  Retail mean = (10 + 30)/2 = 20;
+        # consensus mean = 60.  Retail ranks the player 40 higher →
+        # retail_premium.  Verified via explicit retail_keys override so
+        # we don't need to mutate the real registry.
+        direction, magnitude = _compute_market_gap(
+            {"ktc": 10, "sleeperTrade": 30, "idpTradeCalc": 50, "dlfIdp": 70},
+            retail_keys=frozenset({"ktc", "sleeperTrade"}),
+        )
+        self.assertEqual(direction, "retail_premium")
+        self.assertEqual(magnitude, 40.0)
+
+    def test_multi_retail_consensus_premium(self):
+        # Symmetric two-retail test: retail mean = (80+90)/2 = 85;
+        # consensus mean = (20+40)/2 = 30; consensus ranks 55 higher.
+        direction, magnitude = _compute_market_gap(
+            {"ktc": 80, "sleeperTrade": 90, "idpTradeCalc": 20, "dlfIdp": 40},
+            retail_keys=frozenset({"ktc", "sleeperTrade"}),
+        )
+        self.assertEqual(direction, "consensus_premium")
+        self.assertEqual(magnitude, 55.0)
 
 
 # ── Integration: single-source player row ────────────────────────────────────

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -287,14 +287,16 @@ class TestAnomalyFlags(unittest.TestCase):
 
 class TestMarketGap(unittest.TestCase):
 
-    def test_ktc_higher(self):
+    def test_ktc_premium_vs_single_consensus_source(self):
+        # KTC rank 10, IDPTC rank 50 → consensus mean = 50 →
+        # KTC ranks the player 40 positions higher → ktc_premium.
         direction, magnitude = _compute_market_gap({"ktc": 10, "idpTradeCalc": 50})
-        self.assertEqual(direction, "ktc_higher")
+        self.assertEqual(direction, "ktc_premium")
         self.assertEqual(magnitude, 40.0)
 
-    def test_idptc_higher(self):
+    def test_consensus_premium_vs_single_consensus_source(self):
         direction, magnitude = _compute_market_gap({"ktc": 80, "idpTradeCalc": 20})
-        self.assertEqual(direction, "idptc_higher")
+        self.assertEqual(direction, "consensus_premium")
         self.assertEqual(magnitude, 60.0)
 
     def test_equal_ranks(self):
@@ -302,10 +304,33 @@ class TestMarketGap(unittest.TestCase):
         self.assertEqual(direction, "none")
         self.assertEqual(magnitude, 0.0)
 
-    def test_single_source_none(self):
+    def test_ktc_alone_returns_none(self):
+        # No consensus sources present → cannot compute a gap.
         direction, magnitude = _compute_market_gap({"ktc": 10})
         self.assertEqual(direction, "none")
         self.assertIsNone(magnitude)
+
+    def test_no_ktc_returns_none(self):
+        # KTC absent → IDP-only players cannot have a KTC-vs-consensus gap.
+        direction, magnitude = _compute_market_gap({"idpTradeCalc": 10, "dlfIdp": 20})
+        self.assertEqual(direction, "none")
+        self.assertIsNone(magnitude)
+
+    def test_ktc_vs_averaged_multi_source_consensus(self):
+        # KTC 10 vs mean(IDPTC 50, DLF 70) = 60 → ktc_premium of 50.
+        direction, magnitude = _compute_market_gap(
+            {"ktc": 10, "idpTradeCalc": 50, "dlfIdp": 70}
+        )
+        self.assertEqual(direction, "ktc_premium")
+        self.assertEqual(magnitude, 50.0)
+
+    def test_consensus_premium_with_multi_source_consensus(self):
+        # KTC 100 vs mean(IDPTC 30, DLF 40) = 35 → consensus_premium of 65.
+        direction, magnitude = _compute_market_gap(
+            {"ktc": 100, "idpTradeCalc": 30, "dlfIdp": 40}
+        )
+        self.assertEqual(direction, "consensus_premium")
+        self.assertEqual(magnitude, 65.0)
 
 
 # ── Integration: single-source player row ────────────────────────────────────

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -545,15 +545,27 @@ class TestMultiFlagScenarios(unittest.TestCase):
 
     def test_suspicious_disagreement_with_high_spread(self):
         """Two sources > 150 ranks apart triggers suspicious_disagreement."""
-        # Create many players so ranks can actually spread
+        # Create many players so ranks can actually spread.  IDPTradeCalc
+        # now contributes to both the offense and IDP scopes, so the
+        # filler QBs carry IDPTC values too (mirroring production where
+        # IDPTC's autocomplete covers every offense star).  Without a
+        # full offense IDPTC pool the test player would be the only QB
+        # ranked by IDPTC and the spread would collapse to zero.
         players = {}
         for i in range(200):
-            p = _make_player(f"Filler Off {i}", "QB", ktc=9000 - i * 40)
+            p = _make_player(
+                f"Filler Off {i}",
+                "QB",
+                ktc=9000 - i * 40,
+                idp=9000 - i * 40,
+            )
             players.update(p)
         for i in range(200):
             p = _make_player(f"Filler IDP {i}", "DL", idp=9000 - i * 40)
             players.update(p)
-        # Add test player with both sources at wildly different ranks
+        # Add test player with both sources at wildly different ranks.
+        # ktc=9000 puts him near the top of the KTC offense ladder, while
+        # idp=100 puts him near the bottom of the IDPTC offense ladder.
         test_p = _make_player("Spread Guy", "QB", ktc=9000, idp=100)
         players.update(test_p)
         payload = {


### PR DESCRIPTION
IDPTradeCalc now contributes ranks to both overall_offense and
overall_idp via an additive `extra_scopes` field on the source
registry.  Offense players get blended KTC + IDPTC ranks again,
closing a regression introduced when scope-aware IDP ranking
landed.  Offense and IDP position sets are disjoint so sourceRanks
is still written at most once per row per source.

The rankings page table now enumerates source columns from
RANKING_SOURCES instead of hardcoding KTC/IDPTC, so DLF (and any
future source) appears automatically with a sortable header, value
+ rank cells, tab-copy export coverage, and methodology text.