### PR TITLE
Atomic frontend deploy with _next asset verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -410,27 +410,14 @@ jobs:
           # showed), this check fails and the deploy is marked red
           # instead of silently shipping a broken client.
           HTML_BODY_FILE="$(mktemp)"
-          trap 'rm -f "${HTML_BODY_FILE}"' EXIT
           if curl --silent --show-error --max-time 15 --output "${HTML_BODY_FILE}" "${URL}/"; then
-            NEXT_ASSET="$(python3 - "${HTML_BODY_FILE}" <<'PY'
-import re
-import sys
-
-with open(sys.argv[1], "r", encoding="utf-8", errors="replace") as fh:
-    html = fh.read()
-
-# Prefer chunk files because that is the family that broke in prod.
-patterns = [
-    r'/_next/static/chunks/[^"\'\s<>]+?\.js',
-    r'/_next/static/[^"\'\s<>]+?\.(?:js|css)',
-]
-for pat in patterns:
-    matches = re.findall(pat, html)
-    if matches:
-        print(matches[0])
-        break
-PY
-            )"
+            # Prefer chunk files because that is the family that broke
+            # in prod.  Character class excludes the characters that
+            # could appear as attribute delimiters or whitespace.
+            NEXT_ASSET="$(grep -oE '/_next/static/chunks/[^"[:space:]<>]+\.js' "${HTML_BODY_FILE}" | head -n 1 || true)"
+            if [[ -z "${NEXT_ASSET}" ]]; then
+              NEXT_ASSET="$(grep -oE '/_next/static/[^"[:space:]<>]+\.(js|css)' "${HTML_BODY_FILE}" | head -n 1 || true)"
+            fi
             if [[ -n "${NEXT_ASSET}" ]]; then
               check_endpoint "${NEXT_ASSET}" 200
             else
@@ -440,6 +427,7 @@ PY
             echo "FAIL: unable to fetch / HTML for _next asset extraction"
             FAIL=$((FAIL + 1))
           fi
+          rm -f "${HTML_BODY_FILE}"
 
           echo ""
           echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -402,6 +402,45 @@ jobs:
           check_endpoint "/api/data" 200
           check_endpoint "/" 200
 
+          # Extract a /_next/static/* reference from the landing page
+          # HTML and verify the server actually serves it.  This is the
+          # guardrail for the ChunkLoadError failure mode: if the HTML
+          # references a chunk hash the Next.js process no longer has
+          # on disk (the exact symptom the prior production outage
+          # showed), this check fails and the deploy is marked red
+          # instead of silently shipping a broken client.
+          HTML_BODY_FILE="$(mktemp)"
+          trap 'rm -f "${HTML_BODY_FILE}"' EXIT
+          if curl --silent --show-error --max-time 15 --output "${HTML_BODY_FILE}" "${URL}/"; then
+            NEXT_ASSET="$(python3 - "${HTML_BODY_FILE}" <<'PY'
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8", errors="replace") as fh:
+    html = fh.read()
+
+# Prefer chunk files because that is the family that broke in prod.
+patterns = [
+    r'/_next/static/chunks/[^"\'\s<>]+?\.js',
+    r'/_next/static/[^"\'\s<>]+?\.(?:js|css)',
+]
+for pat in patterns:
+    matches = re.findall(pat, html)
+    if matches:
+        print(matches[0])
+        break
+PY
+            )"
+            if [[ -n "${NEXT_ASSET}" ]]; then
+              check_endpoint "${NEXT_ASSET}" 200
+            else
+              echo "::warning title=No _next asset found::Could not extract a /_next/static/* reference from HTML; skipping chunk probe."
+            fi
+          else
+            echo "FAIL: unable to fetch / HTML for _next asset extraction"
+            FAIL=$((FAIL + 1))
+          fi
+
           echo ""
           echo "Results: ${PASS} passed, ${FAIL} failed"
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -16,10 +16,18 @@ LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE="${LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE:-${DEPL
 AUTO_ROLLBACK="${AUTO_ROLLBACK:-true}"
 APP_HOST="${APP_HOST:-127.0.0.1}"
 APP_PORT="${APP_PORT:-8000}"
+FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
 PUBLIC_URL="${PUBLIC_URL:-}"
 RUN_FRONTEND_BUILD="${RUN_FRONTEND_BUILD:-true}"
 STRICT_LOCAL_HEALTH="${STRICT_LOCAL_HEALTH:-true}"
 ALLOW_DIRTY_DEPLOY="${ALLOW_DIRTY_DEPLOY:-false}"
+# Where next build stages its output before the atomic swap.  Relative
+# to frontend/ so it lives on the same filesystem as the live .next (a
+# requirement for an atomic rename).  See deploy_frontend_atomic().
+FRONTEND_STAGING_DIR_NAME="${FRONTEND_STAGING_DIR_NAME:-.next.new}"
+FRONTEND_PROBE_MAX_ATTEMPTS="${FRONTEND_PROBE_MAX_ATTEMPTS:-15}"
+FRONTEND_PROBE_SLEEP_SECONDS="${FRONTEND_PROBE_SLEEP_SECONDS:-2}"
 
 STATE_DIR=""
 PRE_DEPLOY_REV=""
@@ -232,13 +240,267 @@ maybe_build_frontend() {
 
   log "Using node=$(command -v node)"
   log "Using npm=$(command -v npm)"
-  log "Running frontend production build in ${APP_DIR}/frontend"
-  if [[ -f "${APP_DIR}/frontend/package-lock.json" ]]; then
-    npm ci --prefix "${APP_DIR}/frontend"
-  else
-    npm install --prefix "${APP_DIR}/frontend"
+
+  local frontend_dir="${APP_DIR}/frontend"
+  local staging_dir="${frontend_dir}/${FRONTEND_STAGING_DIR_NAME}"
+
+  # Remove any leftover staging dir from a prior failed deploy so we
+  # start from a known-empty state.
+  if [[ -d "${staging_dir}" ]]; then
+    log "Removing stale frontend staging dir: ${staging_dir}"
+    rm -rf "${staging_dir}"
   fi
-  npm run --prefix "${APP_DIR}/frontend" build
+
+  log "Installing frontend dependencies in ${frontend_dir}"
+  if [[ -f "${frontend_dir}/package-lock.json" ]]; then
+    npm ci --prefix "${frontend_dir}"
+  else
+    npm install --prefix "${frontend_dir}"
+  fi
+
+  # Build into the staging directory.  The next.config.mjs honors
+  # NEXT_DIST_DIR so this does not touch the live .next/ directory at
+  # all — the running dynasty-frontend process keeps serving chunks
+  # from the current build until we do the atomic swap below.
+  log "Building frontend production bundle into staging dir: ${staging_dir}"
+  (
+    cd "${frontend_dir}"
+    NEXT_DIST_DIR="${FRONTEND_STAGING_DIR_NAME}" npm run build
+  )
+
+  verify_frontend_build_manifest "${staging_dir}"
+}
+
+# Parse the Next.js build manifests in the given dist directory and
+# verify every chunk/asset they reference actually exists on disk.
+# This catches partial builds, disk-full truncation, and any case where
+# the manifest references a hash webpack has already deleted.
+verify_frontend_build_manifest() {
+  local dist_dir="$1"
+  if [[ ! -d "${dist_dir}" ]]; then
+    error "Frontend build dir does not exist: ${dist_dir}"
+    exit 1
+  fi
+
+  local build_manifest="${dist_dir}/build-manifest.json"
+  if [[ ! -f "${build_manifest}" ]]; then
+    error "Missing build-manifest.json at ${build_manifest}"
+    exit 1
+  fi
+
+  log "Verifying frontend build manifest references: ${dist_dir}"
+  python3 - "${dist_dir}" <<'PY' || {
+import json
+import os
+import sys
+
+dist_dir = sys.argv[1]
+manifests = [
+    "build-manifest.json",
+    "app-build-manifest.json",
+    "react-loadable-manifest.json",
+]
+
+missing = []
+seen = 0
+
+
+def walk(obj):
+    global seen
+    if isinstance(obj, str):
+        if obj.endswith(".js") or obj.endswith(".css"):
+            seen += 1
+            full = os.path.join(dist_dir, obj)
+            if not os.path.exists(full):
+                missing.append(obj)
+    elif isinstance(obj, list):
+        for item in obj:
+            walk(item)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            walk(value)
+
+
+for name in manifests:
+    path = os.path.join(dist_dir, name)
+    if not os.path.exists(path):
+        continue
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[verify-build] Unable to parse {name}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    walk(data)
+
+if missing:
+    print(
+        f"[verify-build] {len(missing)} referenced asset(s) missing from {dist_dir}",
+        file=sys.stderr,
+    )
+    for entry in missing[:20]:
+        print(f"  - {entry}", file=sys.stderr)
+    if len(missing) > 20:
+        print(f"  ... and {len(missing) - 20} more", file=sys.stderr)
+    sys.exit(1)
+
+print(f"[verify-build] OK: {seen} manifest-referenced asset(s) present in {dist_dir}")
+PY
+    error "Frontend build verification failed for ${dist_dir}."
+    exit 1
+  }
+}
+
+# Atomic frontend swap:
+#   1. Stop the dynasty-frontend service so no process is holding file
+#      descriptors into the old .next/.
+#   2. Move the old .next to .next.old (for emergency rollback) and
+#      rename the staging .next.new into place.
+#   3. Start the frontend service, which will read the fresh .next/.
+#   4. Probe a few /_next/static/* assets over localhost to confirm
+#      the running process actually serves the chunks referenced by
+#      the new build-manifest.json.
+#   5. Remove the .next.old archive in the background.
+deploy_frontend_atomic() {
+  local frontend_dir="${APP_DIR}/frontend"
+  local staging_dir="${frontend_dir}/${FRONTEND_STAGING_DIR_NAME}"
+  local live_dir="${frontend_dir}/.next"
+  local old_dir="${frontend_dir}/.next.old"
+  local run_build
+  run_build="$(lower "${RUN_FRONTEND_BUILD}")"
+
+  if [[ "${run_build}" != "true" && "${run_build}" != "1" && "${run_build}" != "yes" ]]; then
+    log "Frontend build disabled; skipping atomic swap."
+    return 0
+  fi
+
+  if [[ ! -d "${staging_dir}" ]]; then
+    warn "No staging dir at ${staging_dir}; skipping atomic swap."
+    return 0
+  fi
+
+  local frontend_name="${SERVICE_NAME}-frontend"
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    log "Stopping frontend service for atomic swap: ${frontend_name}"
+    sudo -n "${SYSTEMCTL_BIN}" stop "${frontend_name}" || true
+  else
+    warn "Frontend systemd unit ${frontend_name} not installed; swap will only touch disk."
+  fi
+
+  # Clear any leftover .next.old from a previous interrupted deploy.
+  if [[ -d "${old_dir}" ]]; then
+    rm -rf "${old_dir}"
+  fi
+
+  if [[ -d "${live_dir}" ]]; then
+    mv "${live_dir}" "${old_dir}"
+  fi
+  mv "${staging_dir}" "${live_dir}"
+  log "Frontend build swapped into place: ${live_dir}"
+
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    log "Starting frontend service after swap: ${frontend_name}"
+    sudo -n "${SYSTEMCTL_BIN}" start "${frontend_name}"
+    sleep 2
+    if ! sudo -n "${SYSTEMCTL_BIN}" is-active --quiet "${frontend_name}"; then
+      error "Frontend service ${frontend_name} failed to start after swap."
+      sudo -n "${JOURNALCTL_BIN}" -u "${frontend_name}" -n 80 --no-pager || true
+      exit 1
+    fi
+    log "Frontend service ${frontend_name} is active."
+
+    if ! probe_frontend_next_assets "${live_dir}"; then
+      error "Post-swap /_next/static/* asset probe failed; aborting deploy."
+      exit 1
+    fi
+  else
+    log "Skipping post-swap _next probe (frontend service not managed by systemd)."
+  fi
+
+  # Background-delete the old build so the critical path stays short.
+  if [[ -d "${old_dir}" ]]; then
+    ( rm -rf "${old_dir}" ) >/dev/null 2>&1 &
+  fi
+}
+
+# Probe a small sample of static chunks referenced by the live build
+# manifest.  Each URL must return 200 from the running Next.js process
+# on the loopback interface.  Retries a bounded number of times while
+# the server warms up.
+probe_frontend_next_assets() {
+  local live_dir="$1"
+  local manifest="${live_dir}/build-manifest.json"
+  if [[ ! -f "${manifest}" ]]; then
+    error "Missing build-manifest.json at ${manifest}; cannot probe frontend."
+    return 1
+  fi
+
+  local probe_list
+  probe_list="$(python3 - "${manifest}" <<'PY'
+import json
+import sys
+
+manifest_path = sys.argv[1]
+with open(manifest_path) as fh:
+    manifest = json.load(fh)
+
+assets = set()
+
+
+def walk(obj):
+    if isinstance(obj, str):
+        if obj.startswith("static/") and (obj.endswith(".js") or obj.endswith(".css")):
+            assets.add(obj)
+    elif isinstance(obj, list):
+        for item in obj:
+            walk(item)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            walk(value)
+
+
+walk(manifest)
+# Sample a handful of chunk assets.  Always include anything that
+# starts with static/chunks/ because that is the family the live
+# ChunkLoadError hit.
+chunks = sorted(a for a in assets if a.startswith("static/chunks/"))
+picked = []
+for asset in chunks[:2]:
+    picked.append(asset)
+if chunks:
+    picked.append(chunks[-1])
+for asset in picked:
+    print(asset)
+PY
+  )"
+
+  if [[ -z "${probe_list}" ]]; then
+    warn "Build manifest lists no static chunks; skipping _next probe."
+    return 0
+  fi
+
+  local asset url code attempts
+  while IFS= read -r asset; do
+    [[ -z "${asset}" ]] && continue
+    url="http://${FRONTEND_HOST}:${FRONTEND_PORT}/_next/${asset}"
+    attempts=0
+    code=""
+    while (( attempts < FRONTEND_PROBE_MAX_ATTEMPTS )); do
+      code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time 10 "${url}" || echo 000)"
+      if [[ "${code}" == "200" ]]; then
+        log "Frontend _next probe OK: ${asset}"
+        break
+      fi
+      attempts=$((attempts + 1))
+      log "Frontend _next probe ${asset} returned HTTP ${code} (attempt ${attempts}/${FRONTEND_PROBE_MAX_ATTEMPTS}); retrying in ${FRONTEND_PROBE_SLEEP_SECONDS}s."
+      sleep "${FRONTEND_PROBE_SLEEP_SECONDS}"
+    done
+    if [[ "${code}" != "200" ]]; then
+      error "Frontend _next probe failed after ${attempts} attempts: ${url} -> HTTP ${code}"
+      return 1
+    fi
+  done <<< "${probe_list}"
+  return 0
 }
 
 ensure_systemd_service() {
@@ -269,21 +531,11 @@ ensure_systemd_service() {
 
 restart_service() {
   require_command systemctl
-  local frontend_name="${SERVICE_NAME}-frontend"
-  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
-    log "Restarting frontend service: ${frontend_name}"
-    sudo -n "${SYSTEMCTL_BIN}" restart "${frontend_name}"
-    # Wait briefly for the process to stabilize before checking
-    sleep 2
-    if ! sudo -n "${SYSTEMCTL_BIN}" is-active --quiet "${frontend_name}"; then
-      error "Frontend service ${frontend_name} failed to become active after restart."
-      sudo -n "${JOURNALCTL_BIN}" -u "${frontend_name}" -n 60 --no-pager || true
-      exit 1
-    else
-      log "Frontend service ${frontend_name} is active."
-    fi
-  fi
-
+  # NOTE: the frontend (dynasty-frontend) is restarted by
+  # deploy_frontend_atomic() as part of the build-swap sequence, not
+  # here.  This function only touches the backend so that a frontend
+  # chunk-manifest failure short-circuits the deploy BEFORE we cycle
+  # the backend.
   log "Restarting systemd service: ${SERVICE_NAME}"
   sudo -n "${SYSTEMCTL_BIN}" restart "${SERVICE_NAME}"
   if ! sudo -n "${SYSTEMCTL_BIN}" is-active --quiet "${SERVICE_NAME}"; then
@@ -299,6 +551,10 @@ verify_deploy() {
     log "Running deploy verification script."
     APP_HOST="${APP_HOST}" \
     APP_PORT="${APP_PORT}" \
+    APP_DIR="${APP_DIR}" \
+    FRONTEND_HOST="${FRONTEND_HOST}" \
+    FRONTEND_PORT="${FRONTEND_PORT}" \
+    FRONTEND_BUILD_DIR="${APP_DIR}/frontend/.next" \
     SERVICE_NAME="${SERVICE_NAME}" \
     PUBLIC_URL="${PUBLIC_URL}" \
     STRICT_LOCAL_HEALTH="${STRICT_LOCAL_HEALTH}" \
@@ -453,6 +709,7 @@ main() {
   prepare_python_runtime
   maybe_build_frontend
   ensure_systemd_service
+  deploy_frontend_atomic
   restart_service
   verify_deploy
   record_success_state

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -13,12 +13,22 @@ DEPLOY_STATE_DIR="${DEPLOY_STATE_DIR:-${APP_DIR}/.deploy}"
 LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE="${LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE:-${DEPLOY_STATE_DIR}/${APP_NAME}.last_successful_deploy_commit}"
 APP_HOST="${APP_HOST:-127.0.0.1}"
 APP_PORT="${APP_PORT:-8000}"
+FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+FRONTEND_STAGING_DIR_NAME="${FRONTEND_STAGING_DIR_NAME:-.next.new}"
+FRONTEND_PROBE_MAX_ATTEMPTS="${FRONTEND_PROBE_MAX_ATTEMPTS:-15}"
+FRONTEND_PROBE_SLEEP_SECONDS="${FRONTEND_PROBE_SLEEP_SECONDS:-2}"
+RUN_FRONTEND_BUILD="${RUN_FRONTEND_BUILD:-true}"
 PUBLIC_URL="${PUBLIC_URL:-}"
 STRICT_LOCAL_HEALTH="${STRICT_LOCAL_HEALTH:-true}"
 ROLLBACK_REF="${1:-${ROLLBACK_REF:-}}"
 SYSTEMCTL_BIN=""
 JOURNALCTL_BIN=""
 CHOWN_BIN=""
+
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
 
 log() {
   printf '[rollback] %s\n' "$*"
@@ -116,6 +126,266 @@ PY
   fi
 }
 
+resolve_node_toolchain() {
+  if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+    return 0
+  fi
+  local home_candidates=("/home/${APP_USER}" "${HOME:-}")
+  local home_dir="" candidate=""
+  for candidate in "${home_candidates[@]}"; do
+    if [[ -n "${candidate}" && -d "${candidate}" ]]; then
+      home_dir="${candidate}"; break
+    fi
+  done
+  if [[ -z "${NVM_DIR:-}" && -n "${home_dir}" && -d "${home_dir}/.nvm" ]]; then
+    export NVM_DIR="${home_dir}/.nvm"
+  fi
+  if [[ -n "${NVM_DIR:-}" && -s "${NVM_DIR}/nvm.sh" ]]; then
+    # shellcheck disable=SC1090
+    . "${NVM_DIR}/nvm.sh"
+  fi
+  if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+    return 0
+  fi
+  local node_bin=""
+  if [[ -n "${NVM_DIR:-}" && -d "${NVM_DIR}/versions/node" ]]; then
+    node_bin="$(find "${NVM_DIR}/versions/node" -mindepth 2 -maxdepth 2 -type d -name bin 2>/dev/null | sort -V | tail -n 1)"
+    if [[ -n "${node_bin}" && -d "${node_bin}" ]]; then
+      export PATH="${node_bin}:${PATH}"
+    fi
+  fi
+  if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+# Verify every .js/.css reference in the Next.js build manifests exists
+# on disk.  Mirrors deploy.sh::verify_frontend_build_manifest — any
+# drift here reintroduces the chunk-hash mismatch bug, so keep the two
+# implementations behaviourally identical.
+verify_frontend_build_manifest() {
+  local dist_dir="$1"
+  if [[ ! -d "${dist_dir}" ]]; then
+    error "Frontend build dir does not exist: ${dist_dir}"
+    return 1
+  fi
+  local build_manifest="${dist_dir}/build-manifest.json"
+  if [[ ! -f "${build_manifest}" ]]; then
+    error "Missing build-manifest.json at ${build_manifest}"
+    return 1
+  fi
+  log "Verifying frontend build manifest references: ${dist_dir}"
+  python3 - "${dist_dir}" <<'PY' || return 1
+import json
+import os
+import sys
+
+dist_dir = sys.argv[1]
+manifests = [
+    "build-manifest.json",
+    "app-build-manifest.json",
+    "react-loadable-manifest.json",
+]
+
+missing = []
+seen = 0
+
+
+def walk(obj):
+    global seen
+    if isinstance(obj, str):
+        if obj.endswith(".js") or obj.endswith(".css"):
+            seen += 1
+            full = os.path.join(dist_dir, obj)
+            if not os.path.exists(full):
+                missing.append(obj)
+    elif isinstance(obj, list):
+        for item in obj:
+            walk(item)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            walk(value)
+
+
+for name in manifests:
+    path = os.path.join(dist_dir, name)
+    if not os.path.exists(path):
+        continue
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[verify-build] Unable to parse {name}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    walk(data)
+
+if missing:
+    print(
+        f"[verify-build] {len(missing)} referenced asset(s) missing from {dist_dir}",
+        file=sys.stderr,
+    )
+    for entry in missing[:20]:
+        print(f"  - {entry}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"[verify-build] OK: {seen} manifest-referenced asset(s) present in {dist_dir}")
+PY
+}
+
+probe_frontend_next_assets() {
+  local live_dir="$1"
+  local manifest="${live_dir}/build-manifest.json"
+  if [[ ! -f "${manifest}" ]]; then
+    error "Missing build-manifest.json at ${manifest}; cannot probe frontend."
+    return 1
+  fi
+  local probe_list
+  probe_list="$(python3 - "${manifest}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as fh:
+    manifest = json.load(fh)
+
+assets = set()
+
+
+def walk(obj):
+    if isinstance(obj, str):
+        if obj.startswith("static/") and (obj.endswith(".js") or obj.endswith(".css")):
+            assets.add(obj)
+    elif isinstance(obj, list):
+        for item in obj:
+            walk(item)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            walk(value)
+
+
+walk(manifest)
+chunks = sorted(a for a in assets if a.startswith("static/chunks/"))
+picked = []
+for asset in chunks[:2]:
+    picked.append(asset)
+if chunks:
+    picked.append(chunks[-1])
+for asset in picked:
+    print(asset)
+PY
+  )"
+  if [[ -z "${probe_list}" ]]; then
+    warn "Build manifest lists no static chunks; skipping _next probe."
+    return 0
+  fi
+  local asset url code attempts
+  while IFS= read -r asset; do
+    [[ -z "${asset}" ]] && continue
+    url="http://${FRONTEND_HOST}:${FRONTEND_PORT}/_next/${asset}"
+    attempts=0
+    code=""
+    while (( attempts < FRONTEND_PROBE_MAX_ATTEMPTS )); do
+      code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time 10 "${url}" || echo 000)"
+      if [[ "${code}" == "200" ]]; then
+        log "Frontend _next probe OK: ${asset}"
+        break
+      fi
+      attempts=$((attempts + 1))
+      log "Frontend _next probe ${asset} returned HTTP ${code} (attempt ${attempts}/${FRONTEND_PROBE_MAX_ATTEMPTS}); retrying in ${FRONTEND_PROBE_SLEEP_SECONDS}s."
+      sleep "${FRONTEND_PROBE_SLEEP_SECONDS}"
+    done
+    if [[ "${code}" != "200" ]]; then
+      error "Frontend _next probe failed after ${attempts} attempts: ${url} -> HTTP ${code}"
+      return 1
+    fi
+  done <<< "${probe_list}"
+  return 0
+}
+
+# Rebuild the rolled-back frontend into a staging dir and atomically
+# swap it into place.  Without this, a rollback would keep whatever
+# .next/ the failed forward deploy left on disk, so HTML from the old
+# (rolled-back) commit would reference chunk hashes from the new build
+# — the exact failure mode we are trying to eliminate.
+maybe_rebuild_frontend_after_rollback() {
+  local run_build
+  run_build="$(lower "${RUN_FRONTEND_BUILD}")"
+  if [[ "${run_build}" != "true" && "${run_build}" != "1" && "${run_build}" != "yes" ]]; then
+    log "Frontend build disabled (RUN_FRONTEND_BUILD=${RUN_FRONTEND_BUILD}); skipping rollback frontend rebuild."
+    return 0
+  fi
+
+  local frontend_dir="${APP_DIR}/frontend"
+  if [[ ! -f "${frontend_dir}/package.json" ]]; then
+    warn "No frontend/package.json after rollback; skipping frontend rebuild."
+    return 0
+  fi
+
+  if ! resolve_node_toolchain; then
+    error "Required command not found for rollback frontend rebuild: npm"
+    return 1
+  fi
+
+  local staging_dir="${frontend_dir}/${FRONTEND_STAGING_DIR_NAME}"
+  local live_dir="${frontend_dir}/.next"
+  local old_dir="${frontend_dir}/.next.old"
+
+  if [[ -d "${staging_dir}" ]]; then
+    log "Removing stale frontend staging dir: ${staging_dir}"
+    rm -rf "${staging_dir}"
+  fi
+
+  log "Installing frontend dependencies in ${frontend_dir} (rollback)"
+  if [[ -f "${frontend_dir}/package-lock.json" ]]; then
+    npm ci --prefix "${frontend_dir}"
+  else
+    npm install --prefix "${frontend_dir}"
+  fi
+
+  log "Rebuilding rolled-back frontend bundle into staging dir: ${staging_dir}"
+  (
+    cd "${frontend_dir}"
+    NEXT_DIST_DIR="${FRONTEND_STAGING_DIR_NAME}" npm run build
+  )
+
+  verify_frontend_build_manifest "${staging_dir}" || return 1
+
+  local frontend_name="${SERVICE_NAME}-frontend"
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    log "Stopping frontend service for rollback swap: ${frontend_name}"
+    sudo -n "${SYSTEMCTL_BIN}" stop "${frontend_name}" || true
+  fi
+
+  if [[ -d "${old_dir}" ]]; then
+    rm -rf "${old_dir}"
+  fi
+  if [[ -d "${live_dir}" ]]; then
+    mv "${live_dir}" "${old_dir}"
+  fi
+  mv "${staging_dir}" "${live_dir}"
+  log "Rolled-back frontend build swapped into place: ${live_dir}"
+
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    log "Starting frontend service after rollback swap: ${frontend_name}"
+    sudo -n "${SYSTEMCTL_BIN}" start "${frontend_name}"
+    sleep 2
+    if ! sudo -n "${SYSTEMCTL_BIN}" is-active --quiet "${frontend_name}"; then
+      error "Frontend service ${frontend_name} failed to start after rollback swap."
+      sudo -n "${JOURNALCTL_BIN}" -u "${frontend_name}" -n 80 --no-pager || true
+      return 1
+    fi
+    log "Frontend service ${frontend_name} is active after rollback swap."
+    if ! probe_frontend_next_assets "${live_dir}"; then
+      error "Post-rollback /_next/static/* asset probe failed."
+      return 1
+    fi
+  fi
+
+  if [[ -d "${old_dir}" ]]; then
+    ( rm -rf "${old_dir}" ) >/dev/null 2>&1 &
+  fi
+}
+
 prepare_python_runtime() {
   local req_file
   req_file="$(canonical_requirements_file)"
@@ -178,6 +448,14 @@ main() {
 
   prepare_python_runtime
 
+  # Rebuild the frontend from the rolled-back source tree before
+  # restarting the backend.  A failure here should still fall through
+  # to the backend restart, but we log the failure loudly so operators
+  # know the frontend is potentially inconsistent.
+  if ! maybe_rebuild_frontend_after_rollback; then
+    error "Rollback frontend rebuild failed; backend will still be restarted but frontend state is suspect."
+  fi
+
   log "Restarting service ${SERVICE_NAME} after rollback."
   sudo -n "${SYSTEMCTL_BIN}" restart "${SERVICE_NAME}"
   if ! sudo -n "${SYSTEMCTL_BIN}" is-active --quiet "${SERVICE_NAME}"; then
@@ -189,6 +467,10 @@ main() {
   if [[ -f "${APP_DIR}/deploy/verify-deploy.sh" ]]; then
     APP_HOST="${APP_HOST}" \
     APP_PORT="${APP_PORT}" \
+    APP_DIR="${APP_DIR}" \
+    FRONTEND_HOST="${FRONTEND_HOST}" \
+    FRONTEND_PORT="${FRONTEND_PORT}" \
+    FRONTEND_BUILD_DIR="${APP_DIR}/frontend/.next" \
     SERVICE_NAME="${SERVICE_NAME}" \
     PUBLIC_URL="${PUBLIC_URL}" \
     STRICT_LOCAL_HEALTH="${STRICT_LOCAL_HEALTH}" \

--- a/deploy/verify-deploy.sh
+++ b/deploy/verify-deploy.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 APP_HOST="${APP_HOST:-127.0.0.1}"
 APP_PORT="${APP_PORT:-8000}"
+APP_DIR="${APP_DIR:-${DEFAULT_APP_DIR}}"
+FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+FRONTEND_BUILD_DIR="${FRONTEND_BUILD_DIR:-${APP_DIR}/frontend/.next}"
 SERVICE_NAME="${SERVICE_NAME:-dynasty}"
 PUBLIC_URL="${PUBLIC_URL:-}"
 VERIFY_MAX_ATTEMPTS="${VERIFY_MAX_ATTEMPTS:-20}"
@@ -10,6 +17,7 @@ VERIFY_SLEEP_SECONDS="${VERIFY_SLEEP_SECONDS:-2}"
 VERIFY_CURL_TIMEOUT="${VERIFY_CURL_TIMEOUT:-8}"
 STRICT_LOCAL_HEALTH="${STRICT_LOCAL_HEALTH:-true}"
 STRICT_PUBLIC_HEALTH="${STRICT_PUBLIC_HEALTH:-false}"
+STRICT_FRONTEND_ASSETS="${STRICT_FRONTEND_ASSETS:-true}"
 
 log() {
   printf '[verify] %s\n' "$*"
@@ -67,6 +75,74 @@ dump_service_diagnostics() {
   warn "Collecting service diagnostics for ${SERVICE_NAME}"
   sudo -n "${systemctl_bin}" status "${SERVICE_NAME}" --no-pager || true
   sudo -n "${journalctl_bin}" -u "${SERVICE_NAME}" -n 160 --no-pager || true
+}
+
+# Probe a sample of static chunks referenced by the live
+# build-manifest.json.  Each URL must return HTTP 200 from the running
+# Next.js process on the loopback interface.  This catches the case
+# where HTML references a chunk hash the server no longer has on disk
+# (the live ChunkLoadError bug) and fails the deploy *before* we mark
+# it successful.
+probe_frontend_next_assets() {
+  local build_dir="$1"
+  local manifest="${build_dir}/build-manifest.json"
+  if [[ ! -f "${manifest}" ]]; then
+    error "Frontend build manifest missing: ${manifest}"
+    return 1
+  fi
+
+  local probe_list
+  probe_list="$(python3 - "${manifest}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as fh:
+    manifest = json.load(fh)
+
+assets = set()
+
+
+def walk(obj):
+    if isinstance(obj, str):
+        if obj.startswith("static/") and (obj.endswith(".js") or obj.endswith(".css")):
+            assets.add(obj)
+    elif isinstance(obj, list):
+        for item in obj:
+            walk(item)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            walk(value)
+
+
+walk(manifest)
+chunks = sorted(a for a in assets if a.startswith("static/chunks/"))
+picked = []
+for asset in chunks[:2]:
+    picked.append(asset)
+if chunks:
+    picked.append(chunks[-1])
+for asset in picked:
+    print(asset)
+PY
+  )"
+
+  if [[ -z "${probe_list}" ]]; then
+    warn "Build manifest lists no static chunks; skipping _next probe."
+    return 0
+  fi
+
+  local asset url code
+  while IFS= read -r asset; do
+    [[ -z "${asset}" ]] && continue
+    url="http://${FRONTEND_HOST}:${FRONTEND_PORT}/_next/${asset}"
+    code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time "${VERIFY_CURL_TIMEOUT}" "${url}" || echo 000)"
+    if [[ "${code}" != "200" ]]; then
+      error "Frontend _next asset probe failed: ${url} -> HTTP ${code}"
+      return 1
+    fi
+    log "Frontend _next asset probe OK: ${asset}"
+  done <<< "${probe_list}"
+  return 0
 }
 
 probe_with_retries() {
@@ -129,12 +205,35 @@ main() {
     local frontend_name="${SERVICE_NAME}-frontend"
     if sudo -n "${systemctl_bin}" cat "${frontend_name}" >/dev/null 2>&1; then
       if ! sudo -n "${systemctl_bin}" is-active --quiet "${frontend_name}"; then
+        if [[ "${STRICT_FRONTEND_ASSETS}" == "true" || "${STRICT_FRONTEND_ASSETS}" == "1" || "${STRICT_FRONTEND_ASSETS}" == "yes" ]]; then
+          error "Frontend service is not active: ${frontend_name}"
+          sudo -n "${journalctl_bin}" -u "${frontend_name}" -n 120 --no-pager || true
+          exit 1
+        fi
         warn "Frontend service is not active: ${frontend_name}"
         sudo -n "${journalctl_bin}" -u "${frontend_name}" -n 60 --no-pager || true
       else
         log "Frontend service is active: ${frontend_name}"
       fi
     fi
+  fi
+
+  # Verify the running Next.js server actually serves the /_next/static
+  # chunk hashes referenced by the live build-manifest.json on disk.
+  # This is the guardrail for the ChunkLoadError failure mode: if HTML
+  # and assets diverge, the deploy fails here instead of silently
+  # succeeding with a broken UI.
+  if [[ -d "${FRONTEND_BUILD_DIR}" ]]; then
+    if ! probe_frontend_next_assets "${FRONTEND_BUILD_DIR}"; then
+      if [[ "${STRICT_FRONTEND_ASSETS}" == "true" || "${STRICT_FRONTEND_ASSETS}" == "1" || "${STRICT_FRONTEND_ASSETS}" == "yes" ]]; then
+        dump_service_diagnostics "${systemctl_bin:-}" "${journalctl_bin:-}"
+        exit 1
+      else
+        warn "Frontend _next asset probe failed (STRICT_FRONTEND_ASSETS=${STRICT_FRONTEND_ASSETS}); continuing."
+      fi
+    fi
+  else
+    warn "Frontend build dir not found at ${FRONTEND_BUILD_DIR}; skipping _next asset probe."
   fi
 
   if ! probe_with_retries "${status_url}" "${VERIFY_MAX_ATTEMPTS}" "${VERIFY_SLEEP_SECONDS}" "${VERIFY_CURL_TIMEOUT}" "${status_body}"; then

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -3,8 +3,18 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Allow deploys to build into a staging directory (e.g. ".next.new")
+// and then atomically rename it onto ".next" after the service is
+// stopped.  This prevents the running Next.js server from observing a
+// half-rewritten .next/ directory, which is what produces the
+// ChunkLoadError / 400 Bad Request failures on /_next/static/chunks/*.
+// At serve time the systemd unit runs `next start` with no override so
+// this falls back to the standard ".next" location.
+const DIST_DIR = process.env.NEXT_DIST_DIR || ".next";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  distDir: DIST_DIR,
   turbopack: {
     root: __dirname,
   },


### PR DESCRIPTION
## Root cause

Production is serving HTML whose baked-in `<script src>` references `/_next/static/chunks/448-64fe82eb7da535a5.js`, but that exact hash is not present in the running Next.js process's on-disk `.next/` — so Next itself returns HTTP 400 for the chunk (confirmed from live curl probes showing `x-powered-by: Next.js` on the 400 response). All 5 app routes (`/`, `/rankings`, `/trade`, `/edge`, `/finder`) render 200 HTML, 10 of 11 chunks return 200, chunk 448 returns 400. Every page boots into `ChunkLoadError`.

Cause: `deploy/deploy.sh` ran `npm run build` in place over the running `dynasty-frontend` service. Webpack deletes chunk hashes it no longer needs mid-request, so HTML emitted earlier (including the prerendered SSG HTML under `.next/server/app/*.html` that Next.js serves for all 5 routes) ended up referencing hashes no longer on disk. The e0223fe `is-active` guard passed because the service started fine — it was just serving inconsistent content. Nothing in the prior deploy flow caught the mismatch: `verify-deploy.sh` only probed `/api/*` and the GHA smoke test only hit `/`, `/api/health`, `/api/status`, `/api/data`.

## Fix

Atomic frontend deploy with explicit HTML-to-asset verification.

**`frontend/next.config.mjs`**
- Honor `NEXT_DIST_DIR` so builds can stage to `.next.new` instead of overwriting the live `.next/`.

**`deploy/deploy.sh`**
- Build into `.next.new` via `NEXT_DIST_DIR=.next.new npm run build`.
- `verify_frontend_build_manifest()` — walk `build-manifest.json`, `app-build-manifest.json`, `react-loadable-manifest.json`, assert every `.js`/`.css` reference exists on disk inside `.next.new`.
- `deploy_frontend_atomic()` — stop `dynasty-frontend`, archive `.next` → `.next.old`, rename `.next.new` → `.next`, start `dynasty-frontend`, `sleep 2` stabilization, `is-active` hard-stop, `probe_frontend_next_assets()` on loopback with bounded retry, then background-delete `.next.old`.
- Preserves the e0223fe restart-failure hard stop pattern (`sleep 2` + `error` + `exit 1`) at lines 403–408; adds an additional post-swap `_next` asset probe hard-stop at lines 412–415.
- `restart_service()` now only touches the backend, so a frontend failure short-circuits before the backend gets cycled.

**`deploy/verify-deploy.sh`**
- After backend checks, walk the live `build-manifest.json` and curl a sample of chunk URLs through the Next.js process on loopback. `STRICT_FRONTEND_ASSETS=true` by default. Frontend service inactive is now strict (exits 1).

**`deploy/rollback.sh`**
- Mirror the same atomic staging build + manifest verification + atomic swap + `_next` probe for rollbacks. Without this, a rollback would leave the failed forward deploy's `.next/` in place and reintroduce the exact chunk-hash mismatch.

**`.github/workflows/deploy.yml`**
- Post-deploy smoke test fetches `/`, extracts a `/_next/static/*` reference from the HTML with `grep -oE`, and asserts it returns 200. Fails the deploy if HTML and served assets diverge. (The first iteration used a Python heredoc inside `run: |` that broke YAML parsing; `91888c7` replaces it with a pure `grep -oE` pipeline that lives entirely inside the normally-indented bash body.)

## Verification plan (post-merge)

- Watch GHA deploy workflow run to completion.
- Curl `/`, `/rankings`, `/trade`, `/edge`, `/finder` and confirm no references to `448-64fe82eb7da535a5.js` remain.
- Curl every `/_next/static/*` chunk referenced by the new HTML and assert every one returns 200.
- Hit `/api/status`, `/api/health`, `/api/data` and confirm backend is healthy.