### PR TITLE
Force frontend rebuild and fail deploy on skipped atomic swap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -332,6 +332,14 @@ jobs:
           export APP_PORT="${APP_PORT}"
           export STRICT_LOCAL_HEALTH="${STRICT_LOCAL_HEALTH}"
           export PUBLIC_URL="${PUBLIC_URL}"
+          # Force the frontend rebuild on every deploy.  The production
+          # server's login environment had RUN_FRONTEND_BUILD set to a
+          # non-true value, which short-circuited maybe_build_frontend
+          # and caused deploys to silently ship stale .next/ assets
+          # (the ChunkLoadError outage).  Exporting it here guarantees
+          # the remote shell inherits "true" regardless of any profile,
+          # /etc/environment, or systemd-user default.
+          export RUN_FRONTEND_BUILD="true"
 
           [[ -n "\${APP_DIR}" ]] || { echo "[remote] APP_DIR is empty" >&2; exit 20; }
           [[ -d "\${APP_DIR}/.git" ]] || { echo "[remote] APP_DIR is not a git repo: \${APP_DIR}" >&2; exit 21; }
@@ -402,32 +410,46 @@ jobs:
           check_endpoint "/api/data" 200
           check_endpoint "/" 200
 
-          # Extract a /_next/static/* reference from the landing page
-          # HTML and verify the server actually serves it.  This is the
+          # Extract EVERY /_next/static/* reference from the landing
+          # page HTML (and a sample of other key routes) and verify
+          # the server actually serves all of them.  This is the
           # guardrail for the ChunkLoadError failure mode: if the HTML
           # references a chunk hash the Next.js process no longer has
           # on disk (the exact symptom the prior production outage
           # showed), this check fails and the deploy is marked red
           # instead of silently shipping a broken client.
-          HTML_BODY_FILE="$(mktemp)"
-          if curl --silent --show-error --max-time 15 --output "${HTML_BODY_FILE}" "${URL}/"; then
-            # Prefer chunk files because that is the family that broke
-            # in prod.  Character class excludes the characters that
-            # could appear as attribute delimiters or whitespace.
-            NEXT_ASSET="$(grep -oE '/_next/static/chunks/[^"[:space:]<>]+\.js' "${HTML_BODY_FILE}" | head -n 1 || true)"
-            if [[ -z "${NEXT_ASSET}" ]]; then
-              NEXT_ASSET="$(grep -oE '/_next/static/[^"[:space:]<>]+\.(js|css)' "${HTML_BODY_FILE}" | head -n 1 || true)"
+          #
+          # The previous implementation probed ONLY the first match
+          # from `head -n 1`, which was always the webpack runtime
+          # chunk and always returned 200 — so a broken async chunk
+          # (like 448-*.js) silently shipped.  This implementation
+          # probes every distinct reference and fails the deploy if
+          # any single one returns non-200.
+          HTML_ROUTES=( "/" "/rankings" "/trade" "/edge" "/finder" )
+          declare -A SEEN_ASSETS=()
+          for route in "${HTML_ROUTES[@]}"; do
+            body_file="$(mktemp)"
+            if ! curl --silent --show-error --max-time 15 --output "${body_file}" "${URL}${route}"; then
+              echo "WARN: unable to fetch ${route} HTML for _next asset extraction"
+              rm -f "${body_file}"
+              continue
             fi
-            if [[ -n "${NEXT_ASSET}" ]]; then
-              check_endpoint "${NEXT_ASSET}" 200
-            else
-              echo "::warning title=No _next asset found::Could not extract a /_next/static/* reference from HTML; skipping chunk probe."
-            fi
-          else
-            echo "FAIL: unable to fetch / HTML for _next asset extraction"
+            while IFS= read -r asset; do
+              [[ -z "${asset}" ]] && continue
+              SEEN_ASSETS["${asset}"]=1
+            done < <(grep -oE '/_next/static/[^"'"'"'[:space:]<>]+\.(js|css)' "${body_file}" | sort -u)
+            rm -f "${body_file}"
+          done
+
+          if [[ "${#SEEN_ASSETS[@]}" -eq 0 ]]; then
+            echo "::error title=No _next assets found::HTML for routes ${HTML_ROUTES[*]} contained no /_next/static/* references."
             FAIL=$((FAIL + 1))
+          else
+            echo "Probing ${#SEEN_ASSETS[@]} distinct /_next/static/* references from HTML."
+            for asset in "${!SEEN_ASSETS[@]}"; do
+              check_endpoint "${asset}" 200
+            done
           fi
-          rm -f "${HTML_BODY_FILE}"
 
           echo ""
           echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -370,13 +370,20 @@ deploy_frontend_atomic() {
   run_build="$(lower "${RUN_FRONTEND_BUILD}")"
 
   if [[ "${run_build}" != "true" && "${run_build}" != "1" && "${run_build}" != "yes" ]]; then
-    log "Frontend build disabled; skipping atomic swap."
+    log "Frontend build disabled (RUN_FRONTEND_BUILD=${RUN_FRONTEND_BUILD}); skipping atomic swap."
     return 0
   fi
 
+  # HARD FAIL instead of warn/return.  If RUN_FRONTEND_BUILD is true but
+  # no staging directory exists, maybe_build_frontend did not actually
+  # build — either npm failed silently, or the build was short-circuited
+  # somewhere.  Continuing past this point would leave the live .next/
+  # in whatever state it was before, which is exactly how the
+  # ChunkLoadError failure mode hides inside a "successful" deploy.
   if [[ ! -d "${staging_dir}" ]]; then
-    warn "No staging dir at ${staging_dir}; skipping atomic swap."
-    return 0
+    error "Expected frontend staging dir missing at ${staging_dir}."
+    error "maybe_build_frontend did not produce a build output — aborting deploy."
+    exit 1
   fi
 
   local frontend_name="${SERVICE_NAME}-frontend"
@@ -423,10 +430,13 @@ deploy_frontend_atomic() {
   fi
 }
 
-# Probe a small sample of static chunks referenced by the live build
-# manifest.  Each URL must return 200 from the running Next.js process
-# on the loopback interface.  Retries a bounded number of times while
-# the server warms up.
+# Probe every /_next/static/* asset referenced by both the build
+# manifests AND the prerendered SSG HTML output in .next/server/app/
+# against the running Next.js process on loopback.  The prerendered
+# HTML scan is the critical piece: Next.js bakes <script src> tags for
+# async chunks (like the 448-*.js error chunk) that do not appear in
+# build-manifest.json, so a manifest-only walk silently missed the
+# exact failure mode that shipped the production ChunkLoadError.
 probe_frontend_next_assets() {
   local live_dir="$1"
   local manifest="${live_dir}/build-manifest.json"
@@ -436,13 +446,18 @@ probe_frontend_next_assets() {
   fi
 
   local probe_list
-  probe_list="$(python3 - "${manifest}" <<'PY'
+  probe_list="$(python3 - "${live_dir}" <<'PY'
 import json
+import os
+import re
 import sys
 
-manifest_path = sys.argv[1]
-with open(manifest_path) as fh:
-    manifest = json.load(fh)
+live_dir = sys.argv[1]
+manifests = [
+    "build-manifest.json",
+    "app-build-manifest.json",
+    "react-loadable-manifest.json",
+]
 
 assets = set()
 
@@ -459,23 +474,42 @@ def walk(obj):
             walk(value)
 
 
-walk(manifest)
-# Sample a handful of chunk assets.  Always include anything that
-# starts with static/chunks/ because that is the family the live
-# ChunkLoadError hit.
-chunks = sorted(a for a in assets if a.startswith("static/chunks/"))
-picked = []
-for asset in chunks[:2]:
-    picked.append(asset)
-if chunks:
-    picked.append(chunks[-1])
-for asset in picked:
+for name in manifests:
+    p = os.path.join(live_dir, name)
+    if not os.path.exists(p):
+        continue
+    try:
+        with open(p) as fh:
+            walk(json.load(fh))
+    except Exception:
+        pass
+
+# Also walk every prerendered HTML file under .next/server/app and
+# .next/server/pages and collect every /_next/static/* reference.  This
+# is what catches the async-chunk failure mode.
+html_asset_re = re.compile(r"/_next/(static/[^\"\s<>?]+\.(?:js|css))")
+for root in ("server/app", "server/pages"):
+    root_path = os.path.join(live_dir, root)
+    if not os.path.isdir(root_path):
+        continue
+    for dirpath, _dirnames, filenames in os.walk(root_path):
+        for fname in filenames:
+            if not fname.endswith(".html"):
+                continue
+            try:
+                with open(os.path.join(dirpath, fname), encoding="utf-8") as fh:
+                    for match in html_asset_re.finditer(fh.read()):
+                        assets.add(match.group(1))
+            except Exception:
+                pass
+
+for asset in sorted(assets):
     print(asset)
 PY
   )"
 
   if [[ -z "${probe_list}" ]]; then
-    warn "Build manifest lists no static chunks; skipping _next probe."
+    warn "Manifests and prerendered HTML list no static chunks; skipping _next probe."
     return 0
   fi
 


### PR DESCRIPTION
## Root cause of the ChunkLoadError outage

PR #43 did land the atomic-swap logic, but deploy #379 reported success in 35 seconds without ever rebuilding the frontend. Production kept serving the old prerendered HTML which referenced `448-64fe82eb7da535a5.js` — a chunk the running Next.js process no longer had on disk, so every page broke with `ChunkLoadError`.

Four compounding bugs let a "successful" deploy ship broken assets:

1. **`RUN_FRONTEND_BUILD` was being set to a non-true value on the production server's login env.** `deploy.sh`'s `"${RUN_FRONTEND_BUILD:-true}"` default only fires when the variable is _unset_, not when it's set to `"false"`, so `maybe_build_frontend` short-circuited at the top without building anything.

2. **`deploy_frontend_atomic` silently returned 0 when staging dir was missing.** When `maybe_build_frontend` skips, no `.next.new` exists, and the atomic-swap function logged a warning and exited zero. The live `.next/` kept whatever stale bundle it had before.

3. **`probe_frontend_next_assets` only walked JSON manifests.** Async/lazy chunks like `448-*.js` are baked into prerendered SSG HTML (`<script src>`) but do not appear in `build-manifest.json` / `app-build-manifest.json` / `react-loadable-manifest.json`. The probe missed the exact chunk family that was failing.

4. **Post-deploy smoke test probed only `head -n 1`.** The first `/_next/static/chunks/*.js` match in the HTML is always the webpack runtime (always 200). The broken 448 chunk never got checked.

Result: 10 of 11 chunks returned 200 from production, chunk 448 returned 400, every page broke with `ChunkLoadError`, and every layer of the deploy pipeline reported success.

## Fix

- **deploy.yml**: export `RUN_FRONTEND_BUILD="true"` inside the SSH heredoc so no server-side profile / `/etc/environment` / systemd default can override it to false.
- **deploy.sh `deploy_frontend_atomic`**: hard-fail with `exit 1` when the staging dir is missing instead of warning and returning 0. A silently skipped rebuild can no longer masquerade as success.
- **deploy.sh `probe_frontend_next_assets`**: walk every `.html` file under `.next/server/app` and `.next/server/pages` with regex `/_next/(static/[^\"\s<>?]+\.(?:js|css))` and probe every match, catching async-chunk references that no manifest lists.
- **deploy.yml smoke test**: fetch `/`, `/rankings`, `/trade`, `/edge`, `/finder` and probe _every_ distinct `/_next/static/*` reference — not just the first one.

## Verification plan

1. Merge this PR to trigger Deploy Production
2. Watch the workflow — it should take minutes, not 35 seconds (real `next build` runs)
3. Curl `/`, `/rankings`, `/trade`, `/edge`, `/finder` + each chunk they reference
4. Confirm chunk 448 is either a new hash that returns 200, or fully absent from HTML

https://claude.ai/code/session_01BQJFkDva1WrqP2D8YRenje