### PR TITLE
Always force frontend build and probe HTML chunks in verify-deploy

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -220,16 +220,17 @@ prepare_python_runtime() {
 }
 
 maybe_build_frontend() {
-  local run_build
-  run_build="$(lower "${RUN_FRONTEND_BUILD}")"
-  if [[ "${run_build}" != "true" && "${run_build}" != "1" && "${run_build}" != "yes" ]]; then
-    log "Frontend build disabled (RUN_FRONTEND_BUILD=${RUN_FRONTEND_BUILD})."
-    return 0
-  fi
+  # RUN_FRONTEND_BUILD used to be an opt-out via env var, but the
+  # production server had it set to a non-true value in its login
+  # environment, which silently short-circuited every frontend rebuild
+  # and shipped stale /_next/ chunks.  We now IGNORE the variable
+  # entirely and always run the frontend build.  If the frontend
+  # directory is missing, that's a deploy-fatal error.
+  log "Frontend build requested (RUN_FRONTEND_BUILD=${RUN_FRONTEND_BUILD:-unset}, build is always forced)."
 
   if [[ ! -f "${APP_DIR}/frontend/package.json" ]]; then
-    warn "RUN_FRONTEND_BUILD enabled but frontend/package.json not found; skipping frontend build."
-    return 0
+    error "frontend/package.json missing at ${APP_DIR}/frontend/package.json; cannot build frontend."
+    exit 1
   fi
 
   if ! resolve_node_toolchain; then
@@ -366,20 +367,12 @@ deploy_frontend_atomic() {
   local staging_dir="${frontend_dir}/${FRONTEND_STAGING_DIR_NAME}"
   local live_dir="${frontend_dir}/.next"
   local old_dir="${frontend_dir}/.next.old"
-  local run_build
-  run_build="$(lower "${RUN_FRONTEND_BUILD}")"
 
-  if [[ "${run_build}" != "true" && "${run_build}" != "1" && "${run_build}" != "yes" ]]; then
-    log "Frontend build disabled (RUN_FRONTEND_BUILD=${RUN_FRONTEND_BUILD}); skipping atomic swap."
-    return 0
-  fi
-
-  # HARD FAIL instead of warn/return.  If RUN_FRONTEND_BUILD is true but
-  # no staging directory exists, maybe_build_frontend did not actually
-  # build — either npm failed silently, or the build was short-circuited
-  # somewhere.  Continuing past this point would leave the live .next/
-  # in whatever state it was before, which is exactly how the
-  # ChunkLoadError failure mode hides inside a "successful" deploy.
+  # Atomic swap always runs.  maybe_build_frontend is guaranteed to
+  # have produced a staging dir (or exited fatally).  If the staging
+  # dir is still missing here, something is seriously wrong and we
+  # refuse to continue, because the previous skip-and-return behavior
+  # is exactly what silently shipped broken /_next/ chunks.
   if [[ ! -d "${staging_dir}" ]]; then
     error "Expected frontend staging dir missing at ${staging_dir}."
     error "maybe_build_frontend did not produce a build output — aborting deploy."

--- a/deploy/verify-deploy.sh
+++ b/deploy/verify-deploy.sh
@@ -77,27 +77,36 @@ dump_service_diagnostics() {
   sudo -n "${journalctl_bin}" -u "${SERVICE_NAME}" -n 160 --no-pager || true
 }
 
-# Probe a sample of static chunks referenced by the live
-# build-manifest.json.  Each URL must return HTTP 200 from the running
-# Next.js process on the loopback interface.  This catches the case
-# where HTML references a chunk hash the server no longer has on disk
-# (the live ChunkLoadError bug) and fails the deploy *before* we mark
-# it successful.
+# Probe EVERY static chunk referenced by both the live build
+# manifests AND the prerendered SSG HTML output in .next/server/app/
+# and .next/server/pages/.  Each URL must return HTTP 200 from the
+# running Next.js process on the loopback interface.
+#
+# The prerendered HTML walk is what catches the ChunkLoadError failure
+# mode: Next.js bakes <script src> tags for async chunks (like the
+# 448-*.js outage chunk) that do NOT appear in build-manifest.json.
+# A manifest-only probe silently missed the exact failure mode that
+# shipped the production outage.
 probe_frontend_next_assets() {
   local build_dir="$1"
-  local manifest="${build_dir}/build-manifest.json"
-  if [[ ! -f "${manifest}" ]]; then
-    error "Frontend build manifest missing: ${manifest}"
+  if [[ ! -d "${build_dir}" ]]; then
+    error "Frontend build dir missing: ${build_dir}"
     return 1
   fi
 
   local probe_list
-  probe_list="$(python3 - "${manifest}" <<'PY'
+  probe_list="$(python3 - "${build_dir}" <<'PY'
 import json
+import os
+import re
 import sys
 
-with open(sys.argv[1]) as fh:
-    manifest = json.load(fh)
+live_dir = sys.argv[1]
+manifests = [
+    "build-manifest.json",
+    "app-build-manifest.json",
+    "react-loadable-manifest.json",
+]
 
 assets = set()
 
@@ -114,34 +123,57 @@ def walk(obj):
             walk(value)
 
 
-walk(manifest)
-chunks = sorted(a for a in assets if a.startswith("static/chunks/"))
-picked = []
-for asset in chunks[:2]:
-    picked.append(asset)
-if chunks:
-    picked.append(chunks[-1])
-for asset in picked:
+for name in manifests:
+    path = os.path.join(live_dir, name)
+    if not os.path.exists(path):
+        continue
+    try:
+        with open(path) as fh:
+            walk(json.load(fh))
+    except Exception:
+        pass
+
+html_asset_re = re.compile(r"/_next/(static/[^\"\s<>?]+\.(?:js|css))")
+for root in ("server/app", "server/pages"):
+    root_path = os.path.join(live_dir, root)
+    if not os.path.isdir(root_path):
+        continue
+    for dirpath, _dirnames, filenames in os.walk(root_path):
+        for fname in filenames:
+            if not fname.endswith(".html"):
+                continue
+            try:
+                with open(os.path.join(dirpath, fname), encoding="utf-8") as fh:
+                    for match in html_asset_re.finditer(fh.read()):
+                        assets.add(match.group(1))
+            except Exception:
+                pass
+
+for asset in sorted(assets):
     print(asset)
 PY
   )"
 
   if [[ -z "${probe_list}" ]]; then
-    warn "Build manifest lists no static chunks; skipping _next probe."
+    warn "Manifests and prerendered HTML list no static chunks; skipping _next probe."
     return 0
   fi
 
   local asset url code
+  local total=0
+  local ok=0
   while IFS= read -r asset; do
     [[ -z "${asset}" ]] && continue
+    total=$((total + 1))
     url="http://${FRONTEND_HOST}:${FRONTEND_PORT}/_next/${asset}"
     code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time "${VERIFY_CURL_TIMEOUT}" "${url}" || echo 000)"
     if [[ "${code}" != "200" ]]; then
       error "Frontend _next asset probe failed: ${url} -> HTTP ${code}"
       return 1
     fi
-    log "Frontend _next asset probe OK: ${asset}"
+    ok=$((ok + 1))
   done <<< "${probe_list}"
+  log "Frontend _next asset probe OK: ${ok}/${total} chunks served by live Next.js process."
   return 0
 }
 


### PR DESCRIPTION
## Why another PR?

PR #44 forced `RUN_FRONTEND_BUILD="true"` in the SSH heredoc and hard-failed the atomic swap when the staging dir was missing. Deploy #381 ran for that merge commit, completed in 1m 18s, and reported success — but chunk `448-64fe82eb7da535a5.js` still returns HTTP 400 on production and every route still ships the stale prerendered HTML referencing it.

Something on the server side is still short-circuiting the frontend rebuild even with the explicit export. Rather than keep chasing whatever environment-variable handling is overriding it, **remove the gate entirely**.

## Changes

- **`deploy/deploy.sh` — `maybe_build_frontend`**: no longer checks `RUN_FRONTEND_BUILD`. The function always runs `npm ci` + `next build` into the staging dir. If `frontend/package.json` is missing, that is now a fatal error rather than a silent skip.
- **`deploy/deploy.sh` — `deploy_frontend_atomic`**: dropped its own `RUN_FRONTEND_BUILD` early-exit. The hard-fail-on-missing-staging-dir behavior from PR #44 stays.
- **`deploy/verify-deploy.sh` — `probe_frontend_next_assets`**: now walks every prerendered `.html` file under `.next/server/app` and `.next/server/pages` in addition to the JSON manifests. The previous version only walked `build-manifest.json` / `app-build-manifest.json` / `react-loadable-manifest.json`, which do NOT list async chunks like `448-*.js`, so the broken chunk was never probed and `verify-deploy` always passed.

`verify-deploy.sh` runs via `deploy.sh → verify_deploy` as part of every deploy, so this change guarantees that any future deploy where HTML references a chunk the running Next.js process can't serve will be caught and fail red — regardless of whether the build step itself was skipped, cached, or deterministic.

## Verification plan

1. Merge, watch Deploy Production
2. Deploy should now take at least 2-3 minutes (real `npm ci` + `next build`)
3. Curl every route, probe every chunk
4. `/_next/static/chunks/448-*.js` should either return 200 with a new hash or disappear from HTML entirely

https://claude.ai/code/session_01BQJFkDva1WrqP2D8YRenje