### PR TITLE
Install dynasty-frontend systemd unit and hard-fail on missing unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,11 @@ __pycache__/
 node_modules/
 frontend/node_modules/
 .next/
+.next.new/
+.next.old/
 frontend/.next/
+frontend/.next.new/
+frontend/.next.old/
 tests/e2e/playwright-report/
 tests/e2e/test-results/
 tests/e2e/tests/

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -380,11 +380,29 @@ deploy_frontend_atomic() {
   fi
 
   local frontend_name="${SERVICE_NAME}-frontend"
-  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
-    log "Stopping frontend service for atomic swap: ${frontend_name}"
-    sudo -n "${SYSTEMCTL_BIN}" stop "${frontend_name}" || true
-  else
-    warn "Frontend systemd unit ${frontend_name} not installed; swap will only touch disk."
+  # HARD FAIL: the frontend MUST be managed by systemd.  The previous
+  # WARN-and-continue branch is exactly the silent-failure path that
+  # shipped the ChunkLoadError outage — we swapped .next/ on disk but
+  # the unmanaged Next.js process (pm2/nohup/tmux) kept serving stale
+  # chunks because nothing restarted it.  ensure_systemd_service must
+  # install the unit before we reach this point.
+  if ! sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    error "Frontend systemd unit ${frontend_name} is not installed."
+    error "ensure_systemd_service should have installed it before this point."
+    exit 1
+  fi
+
+  log "Stopping frontend service for atomic swap: ${frontend_name}"
+  sudo -n "${SYSTEMCTL_BIN}" stop "${frontend_name}" || true
+
+  # Best-effort cleanup of any legacy process still holding the port.
+  # One-shot migration step: on a box that was previously running
+  # Next.js via pm2 / nohup / tmux (outside systemd), `systemctl stop`
+  # is a no-op.  We need to kill the unmanaged process or the next
+  # `systemctl start` below will fail with EADDRINUSE on port 3000.
+  if ! ensure_port_free "${FRONTEND_PORT}"; then
+    error "Could not free port ${FRONTEND_PORT} before frontend swap."
+    exit 1
   fi
 
   # Clear any leftover .next.old from a previous interrupted deploy.
@@ -398,29 +416,84 @@ deploy_frontend_atomic() {
   mv "${staging_dir}" "${live_dir}"
   log "Frontend build swapped into place: ${live_dir}"
 
-  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
-    log "Starting frontend service after swap: ${frontend_name}"
-    sudo -n "${SYSTEMCTL_BIN}" start "${frontend_name}"
-    sleep 2
-    if ! sudo -n "${SYSTEMCTL_BIN}" is-active --quiet "${frontend_name}"; then
-      error "Frontend service ${frontend_name} failed to start after swap."
-      sudo -n "${JOURNALCTL_BIN}" -u "${frontend_name}" -n 80 --no-pager || true
-      exit 1
-    fi
-    log "Frontend service ${frontend_name} is active."
+  log "Starting frontend service after swap: ${frontend_name}"
+  sudo -n "${SYSTEMCTL_BIN}" start "${frontend_name}"
+  sleep 2
+  if ! sudo -n "${SYSTEMCTL_BIN}" is-active --quiet "${frontend_name}"; then
+    error "Frontend service ${frontend_name} failed to start after swap."
+    sudo -n "${JOURNALCTL_BIN}" -u "${frontend_name}" -n 80 --no-pager || true
+    exit 1
+  fi
+  log "Frontend service ${frontend_name} is active."
 
-    if ! probe_frontend_next_assets "${live_dir}"; then
-      error "Post-swap /_next/static/* asset probe failed; aborting deploy."
-      exit 1
-    fi
-  else
-    log "Skipping post-swap _next probe (frontend service not managed by systemd)."
+  if ! probe_frontend_next_assets "${live_dir}"; then
+    error "Post-swap /_next/static/* asset probe failed; aborting deploy."
+    exit 1
   fi
 
   # Background-delete the old build so the critical path stays short.
   if [[ -d "${old_dir}" ]]; then
     ( rm -rf "${old_dir}" ) >/dev/null 2>&1 &
   fi
+}
+
+# Return 0 if the TCP port is currently accepting connections (in use),
+# 1 if it is free.  Uses bash's built-in /dev/tcp virtual filesystem so
+# no extra tools are required.
+port_in_use() {
+  local port="$1"
+  if (: < "/dev/tcp/127.0.0.1/${port}") >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+# Best-effort: kill any process holding the given TCP port and wait for
+# the port to become free.  Returns 0 if the port is free within the
+# timeout, 1 otherwise.  Used to migrate off an unmanaged Next.js
+# process before handing control to the dynasty-frontend systemd unit.
+ensure_port_free() {
+  local port="$1"
+  local max_wait_seconds="${ENSURE_PORT_FREE_TIMEOUT:-15}"
+  local waited=0
+
+  if ! port_in_use "${port}"; then
+    return 0
+  fi
+
+  log "Port ${port} is still in use after systemctl stop; killing legacy listener(s)."
+
+  # Prefer fuser (kills by TCP port, respects ownership).
+  if command -v fuser >/dev/null 2>&1; then
+    fuser -k -n tcp "${port}" 2>/dev/null || true
+  fi
+
+  # Fall back to lsof + kill for anything fuser didn't catch.
+  if command -v lsof >/dev/null 2>&1; then
+    local pids
+    pids="$(lsof -ti:"${port}" 2>/dev/null || true)"
+    if [[ -n "${pids}" ]]; then
+      log "Killing pids holding port ${port}: ${pids}"
+      # shellcheck disable=SC2086
+      kill -9 ${pids} 2>/dev/null || true
+    fi
+  fi
+
+  # Final fallback: pkill any next start / next-server for current user.
+  pkill -9 -u "$(id -u)" -f 'next start' 2>/dev/null || true
+  pkill -9 -u "$(id -u)" -f 'next-server' 2>/dev/null || true
+
+  while (( waited < max_wait_seconds )); do
+    if ! port_in_use "${port}"; then
+      log "Port ${port} is free after ${waited}s."
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  error "Port ${port} is still in use after ${max_wait_seconds}s cleanup."
+  return 1
 }
 
 # Probe every /_next/static/* asset referenced by both the build
@@ -532,13 +605,24 @@ PY
 
 ensure_systemd_service() {
   require_command systemctl
+  local frontend_name="${SERVICE_NAME}-frontend"
+  local backend_present=false
+  local frontend_present=false
+
   if sudo -n "${SYSTEMCTL_BIN}" cat "${SERVICE_NAME}" >/dev/null 2>&1; then
+    backend_present=true
+  fi
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    frontend_present=true
+  fi
+
+  if [[ "${backend_present}" == "true" && "${frontend_present}" == "true" ]]; then
     return 0
   fi
 
   local installer_script
   installer_script="${APP_DIR}/deploy/install-systemd-service.sh"
-  warn "Systemd service ${SERVICE_NAME} not found. Attempting bootstrap install."
+  warn "Systemd units missing (backend=${backend_present}, frontend=${frontend_present}). Running bootstrap installer."
   if [[ ! -f "${installer_script}" ]]; then
     error "Missing bootstrap installer script: ${installer_script}"
     exit 1
@@ -551,7 +635,12 @@ ensure_systemd_service() {
   bash "${installer_script}"
 
   if ! sudo -n "${SYSTEMCTL_BIN}" cat "${SERVICE_NAME}" >/dev/null 2>&1; then
-    error "Systemd service ${SERVICE_NAME} is still unavailable after bootstrap install."
+    error "Backend systemd unit ${SERVICE_NAME} is still unavailable after bootstrap install."
+    exit 1
+  fi
+  if ! sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    error "Frontend systemd unit ${frontend_name} is still unavailable after bootstrap install."
+    error "deploy_frontend_atomic requires the frontend unit to be installed before the swap."
     exit 1
   fi
 }

--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -67,7 +67,10 @@ escape_sed_replacement() {
 }
 
 main() {
-  local force_install unit_path tmp_unit
+  local force_install force_install_on unit_path tmp_unit
+  local frontend_template frontend_name frontend_unit_path tmp_frontend
+  local backend_needs_install=false
+  local frontend_needs_install=false
 
   require_command sudo
   require_command install
@@ -83,36 +86,71 @@ main() {
   [[ -f "${SERVICE_TEMPLATE_PATH}" ]] || { error "Service template not found: ${SERVICE_TEMPLATE_PATH}"; exit 1; }
 
   force_install="$(lower "${FORCE_SERVICE_INSTALL}")"
-  unit_path="/etc/systemd/system/${SERVICE_NAME}.service"
-  if sudo -n "${SYSTEMCTL_BIN}" cat "${SERVICE_NAME}" >/dev/null 2>&1; then
-    if [[ "${force_install}" != "true" && "${force_install}" != "1" && "${force_install}" != "yes" ]]; then
-      log "Service ${SERVICE_NAME} already exists; skipping bootstrap install."
-      exit 0
-    fi
-    log "FORCE_SERVICE_INSTALL enabled; rewriting ${unit_path}."
-  else
-    log "Installing missing systemd unit ${unit_path}."
+  force_install_on=false
+  if [[ "${force_install}" == "true" || "${force_install}" == "1" || "${force_install}" == "yes" ]]; then
+    force_install_on=true
   fi
 
-  tmp_unit="$(mktemp)"
-  trap 'rm -f "${tmp_unit}"' EXIT
-  sed \
-    -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
-    -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
-    -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
-    -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
-    "${SERVICE_TEMPLATE_PATH}" > "${tmp_unit}"
+  tmp_unit=""
+  tmp_frontend=""
+  trap 'rm -f "${tmp_unit:-}" "${tmp_frontend:-}"' EXIT
 
-  sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_unit}" "${unit_path}"
-  log "Installed ${SERVICE_NAME}.service"
+  # ── Backend service (FastAPI) ───────────────────────────────────────────
+  # Deliberately do NOT `exit 0` early when the backend unit already
+  # exists: we still need to check whether the frontend unit is
+  # installed.  A previous version of this script exited here, which
+  # meant production (where the backend was already installed) never
+  # got the frontend systemd unit and silently ran Next.js under some
+  # unmanaged process manager, so deploy.sh could not restart it.
+  unit_path="/etc/systemd/system/${SERVICE_NAME}.service"
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${SERVICE_NAME}" >/dev/null 2>&1; then
+    if [[ "${force_install_on}" == "true" ]]; then
+      log "FORCE_SERVICE_INSTALL enabled; rewriting ${unit_path}."
+      backend_needs_install=true
+    else
+      log "Backend service ${SERVICE_NAME} already installed; skipping."
+    fi
+  else
+    log "Installing missing backend systemd unit ${unit_path}."
+    backend_needs_install=true
+  fi
+
+  if [[ "${backend_needs_install}" == "true" ]]; then
+    tmp_unit="$(mktemp)"
+    sed \
+      -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+      -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+      -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+      -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+      "${SERVICE_TEMPLATE_PATH}" > "${tmp_unit}"
+    sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_unit}" "${unit_path}"
+    log "Installed ${SERVICE_NAME}.service"
+  fi
 
   # ── Frontend service (Next.js) ──────────────────────────────────────────
-  local frontend_template="${APP_DIR}/deploy/systemd/dynasty-frontend.service.template"
-  local frontend_name="${SERVICE_NAME}-frontend"
-  local frontend_unit_path="/etc/systemd/system/${frontend_name}.service"
+  frontend_template="${APP_DIR}/deploy/systemd/dynasty-frontend.service.template"
+  frontend_name="${SERVICE_NAME}-frontend"
+  frontend_unit_path="/etc/systemd/system/${frontend_name}.service"
 
-  if [[ -f "${frontend_template}" ]]; then
-    local tmp_frontend
+  if [[ ! -f "${frontend_template}" ]]; then
+    error "Frontend service template not found at ${frontend_template}."
+    error "The Next.js process must be managed by systemd; aborting bootstrap."
+    exit 1
+  fi
+
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
+    if [[ "${force_install_on}" == "true" ]]; then
+      log "FORCE_SERVICE_INSTALL enabled; rewriting ${frontend_unit_path}."
+      frontend_needs_install=true
+    else
+      log "Frontend service ${frontend_name} already installed; skipping."
+    fi
+  else
+    log "Installing missing frontend systemd unit ${frontend_unit_path}."
+    frontend_needs_install=true
+  fi
+
+  if [[ "${frontend_needs_install}" == "true" ]]; then
     tmp_frontend="$(mktemp)"
     sed \
       -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
@@ -121,18 +159,23 @@ main() {
       -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
       "${frontend_template}" > "${tmp_frontend}"
     sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_frontend}" "${frontend_unit_path}"
-    rm -f "${tmp_frontend}"
     log "Installed ${frontend_name}.service"
-  else
-    log "Frontend service template not found; skipping ${frontend_name}.service"
   fi
 
-  sudo -n "${SYSTEMCTL_BIN}" daemon-reload
-  sudo -n "${SYSTEMCTL_BIN}" enable "${SERVICE_NAME}"
-  if [[ -f "${frontend_template}" ]]; then
-    sudo -n "${SYSTEMCTL_BIN}" enable "${frontend_name}"
+  # ── daemon-reload and enable ────────────────────────────────────────────
+  if [[ "${backend_needs_install}" == "true" || "${frontend_needs_install}" == "true" ]]; then
+    sudo -n "${SYSTEMCTL_BIN}" daemon-reload
+    log "Reloaded systemd unit files."
   fi
-  log "Enabled ${SERVICE_NAME}.service (and frontend if available)"
+
+  if [[ "${backend_needs_install}" == "true" ]]; then
+    sudo -n "${SYSTEMCTL_BIN}" enable "${SERVICE_NAME}"
+    log "Enabled ${SERVICE_NAME}.service"
+  fi
+  if [[ "${frontend_needs_install}" == "true" ]]; then
+    sudo -n "${SYSTEMCTL_BIN}" enable "${frontend_name}"
+    log "Enabled ${frontend_name}.service"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
## Root Cause

Deploy #382 confirmed the real cause of the ChunkLoadError outage: `dynasty-frontend.service` was **never installed** on production. The Next.js process at port 3000 was running under an unmanaged process manager (pm2 / nohup / tmux), so `deploy.sh` had no way to restart it. Every atomic `.next/` swap stayed invisible to the running process, and production kept serving stale chunks.

The bug was in `install-systemd-service.sh`: it exited early when the backend unit existed, so production (where the backend was installed long ago) never received the frontend unit — even though the frontend template has existed in the tree all along.

Deploy #382 actually caught this cleanly: the new verify-deploy probe detected that `/_next/static/$BUILD_ID/_buildManifest.js` on the running process did not match the on-disk build, the deploy failed, and auto-rollback restored `9c1ce5e`. So the guardrail landed correctly in PR #45 — this PR fixes the underlying mismatch.

## Changes

### `deploy/install-systemd-service.sh`
- Backend and frontend unit installs are now independent — the script no longer exits early when the backend unit already exists.
- Missing frontend template is now a hard error, not a log line.
- `daemon-reload` and `enable` only run for the units that actually got (re)installed.

### `deploy/deploy.sh`
- `ensure_systemd_service` now checks for BOTH units and fails loudly if either is still missing after bootstrap.
- `deploy_frontend_atomic` changes the "frontend unit not installed" branch from `WARN` to hard `ERROR`. This was the last remaining silent-skip path in the deploy pipeline.
- New `ensure_port_free` + `port_in_use` helpers: best-effort kill any legacy process still holding port 3000 after `systemctl stop`, using `fuser` → `lsof` → `pkill` fallbacks, and confirm the port is actually free (via bash `/dev/tcp` probe) before starting the systemd unit. This is the one-shot migration step for taking over a box whose Next.js was previously running outside systemd.

## Expected Deploy Flow

1. `ensure_systemd_service` detects frontend unit missing → runs bootstrap installer.
2. `install-systemd-service.sh` skips backend (already installed), installs `dynasty-frontend.service`, runs `daemon-reload`, enables it.
3. `deploy_frontend_atomic` tries `systemctl stop dynasty-frontend` (no-op, never was started).
4. `ensure_port_free 3000` kills the unmanaged legacy Next.js process and waits for the port to drain.
5. Atomic `.next/` swap.
6. `systemctl start dynasty-frontend` — now owns port 3000.
7. `probe_frontend_next_assets` verifies every HTML-referenced `/_next/static/*` chunk responds 200 from the running process.
8. `verify-deploy.sh` repeats the probe as a double-check.

After this deploy lands, every subsequent deploy will have a clean stop → swap → start cycle under systemd, and the ChunkLoadError failure mode becomes structurally impossible.

## Test plan

- [ ] Deploy workflow runs `ensure_systemd_service` and installs `dynasty-frontend.service` (look for `[systemd-bootstrap] Installed dynasty-frontend.service` in the log)
- [ ] `deploy_frontend_atomic` reports `Port 3000 is still in use after systemctl stop; killing legacy listener(s)` the first time, and `Port 3000 is free after Ns` afterwards
- [ ] `systemctl start dynasty-frontend` succeeds without EADDRINUSE
- [ ] Post-swap `probe_frontend_next_assets` returns OK for every HTML-referenced chunk
- [ ] `verify-deploy.sh` HTML-walk probe returns OK
- [ ] Production `/`, `/rankings`, `/trade`, `/edge`, `/finder` all load without ChunkLoadError
- [ ] `curl -I https://riskittogetthebrisket.org/_next/static/chunks/*.js` returns 200 for every chunk referenced by the live HTML

https://claude.ai/code/session_01BQJFkDva1WrqP2D8YRenje