### PR TITLE
Resolve npm at install time for dynasty-frontend systemd unit

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -608,30 +608,57 @@ ensure_systemd_service() {
   local frontend_name="${SERVICE_NAME}-frontend"
   local backend_present=false
   local frontend_present=false
+  local frontend_execstart=""
+  local frontend_exec_bin=""
+  local force_reinstall=false
 
   if sudo -n "${SYSTEMCTL_BIN}" cat "${SERVICE_NAME}" >/dev/null 2>&1; then
     backend_present=true
   fi
   if sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" >/dev/null 2>&1; then
     frontend_present=true
+    # Validate the existing frontend unit's ExecStart actually points
+    # at an executable file.  An earlier version of the template
+    # hardcoded /usr/bin/npm, which does not exist on nvm-based boxes,
+    # so the unit got installed but systemctl start would never
+    # succeed.  Detect that case and force a reinstall.
+    frontend_execstart="$(sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" 2>/dev/null \
+      | awk -F= '/^ExecStart=/ {sub(/^ExecStart=/, ""); print; exit}')"
+    if [[ -n "${frontend_execstart}" ]]; then
+      frontend_exec_bin="${frontend_execstart%% *}"
+      if [[ -n "${frontend_exec_bin}" && ! -x "${frontend_exec_bin}" ]]; then
+        warn "Frontend unit ExecStart binary is not executable: ${frontend_exec_bin}. Forcing reinstall."
+        force_reinstall=true
+      fi
+    fi
   fi
 
-  if [[ "${backend_present}" == "true" && "${frontend_present}" == "true" ]]; then
+  if [[ "${backend_present}" == "true" && "${frontend_present}" == "true" && "${force_reinstall}" != "true" ]]; then
     return 0
   fi
 
   local installer_script
   installer_script="${APP_DIR}/deploy/install-systemd-service.sh"
-  warn "Systemd units missing (backend=${backend_present}, frontend=${frontend_present}). Running bootstrap installer."
+  if [[ "${force_reinstall}" == "true" ]]; then
+    warn "Reinstalling frontend systemd unit because its ExecStart binary (${frontend_exec_bin}) is not runnable."
+  else
+    warn "Systemd units missing (backend=${backend_present}, frontend=${frontend_present}). Running bootstrap installer."
+  fi
   if [[ ! -f "${installer_script}" ]]; then
     error "Missing bootstrap installer script: ${installer_script}"
     exit 1
+  fi
+
+  local force_install_value="${FORCE_SERVICE_INSTALL:-false}"
+  if [[ "${force_reinstall}" == "true" ]]; then
+    force_install_value=true
   fi
 
   APP_DIR="${APP_DIR}" \
   APP_USER="${APP_USER}" \
   VENV_DIR="${VENV_DIR}" \
   SERVICE_NAME="${SERVICE_NAME}" \
+  FORCE_SERVICE_INSTALL="${force_install_value}" \
   bash "${installer_script}"
 
   if ! sudo -n "${SYSTEMCTL_BIN}" cat "${SERVICE_NAME}" >/dev/null 2>&1; then
@@ -643,6 +670,16 @@ ensure_systemd_service() {
     error "deploy_frontend_atomic requires the frontend unit to be installed before the swap."
     exit 1
   fi
+
+  # Re-verify the reinstalled frontend unit's ExecStart is now runnable.
+  frontend_execstart="$(sudo -n "${SYSTEMCTL_BIN}" cat "${frontend_name}" 2>/dev/null \
+    | awk -F= '/^ExecStart=/ {sub(/^ExecStart=/, ""); print; exit}')"
+  frontend_exec_bin="${frontend_execstart%% *}"
+  if [[ -z "${frontend_exec_bin}" || ! -x "${frontend_exec_bin}" ]]; then
+    error "Frontend unit ExecStart binary is still not executable after reinstall: '${frontend_exec_bin}'"
+    exit 1
+  fi
+  log "Frontend systemd unit ExecStart binary resolved to: ${frontend_exec_bin}"
 }
 
 restart_service() {

--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -62,6 +62,77 @@ resolve_and_validate_sudo_binaries() {
   INSTALL_BIN="$(resolve_sudo_nopasswd_binary "install" /usr/bin/install /bin/install)"
 }
 
+# Locate an absolute path to the `npm` binary that the dynasty-frontend
+# systemd unit can use as ExecStart.  This mirrors deploy.sh's
+# resolve_node_toolchain but returns paths instead of relying on PATH
+# side-effects, because systemd runs with a minimal environment and
+# will not source nvm.sh on its own.
+#
+# Writes two values to NPM_BIN_PATH and NODE_BIN_DIR on success.
+# Returns 1 and logs an error if npm cannot be located.
+NPM_BIN_PATH=""
+NODE_BIN_DIR=""
+
+resolve_npm_bin_for_systemd() {
+  NPM_BIN_PATH=""
+  NODE_BIN_DIR=""
+
+  local candidate
+  # 1. System-wide install (Debian/Ubuntu package).
+  for candidate in /usr/bin/npm /usr/local/bin/npm; do
+    if [[ -x "${candidate}" ]]; then
+      NPM_BIN_PATH="${candidate}"
+      NODE_BIN_DIR="$(dirname "${candidate}")"
+      return 0
+    fi
+  done
+
+  # 2. Anything already on PATH (e.g. from operator shell profile).
+  if command -v npm >/dev/null 2>&1; then
+    NPM_BIN_PATH="$(command -v npm)"
+    NODE_BIN_DIR="$(dirname "${NPM_BIN_PATH}")"
+    return 0
+  fi
+
+  # 3. nvm-installed node under the service user's home dir.  This is
+  # the production case — the Hetzner VPS manages node via nvm and
+  # /usr/bin/npm does not exist.
+  local home_candidates=(
+    "/home/${APP_USER}"
+    "${HOME:-}"
+  )
+  local home_dir=""
+  for candidate in "${home_candidates[@]}"; do
+    if [[ -n "${candidate}" && -d "${candidate}" ]]; then
+      home_dir="${candidate}"
+      break
+    fi
+  done
+
+  local nvm_dir=""
+  if [[ -n "${home_dir}" && -d "${home_dir}/.nvm" ]]; then
+    nvm_dir="${home_dir}/.nvm"
+  fi
+
+  if [[ -n "${nvm_dir}" && -d "${nvm_dir}/versions/node" ]]; then
+    local node_bin
+    node_bin="$(
+      find "${nvm_dir}/versions/node" -mindepth 2 -maxdepth 2 -type d -name bin 2>/dev/null \
+      | sort -V \
+      | tail -n 1
+    )"
+    if [[ -n "${node_bin}" && -x "${node_bin}/npm" ]]; then
+      NPM_BIN_PATH="${node_bin}/npm"
+      NODE_BIN_DIR="${node_bin}"
+      return 0
+    fi
+  fi
+
+  error "Could not locate npm for dynasty-frontend systemd unit."
+  error "Checked: /usr/bin/npm, /usr/local/bin/npm, PATH, and ${nvm_dir:-<no nvm dir>}/versions/node/*/bin/npm"
+  return 1
+}
+
 escape_sed_replacement() {
   printf '%s' "$1" | sed -e 's/[\\/&]/\\&/g'
 }
@@ -151,12 +222,24 @@ main() {
   fi
 
   if [[ "${frontend_needs_install}" == "true" ]]; then
+    # Resolve npm absolute path now so the rendered unit file uses a
+    # path that actually exists under the service user's runtime.
+    # Systemd does NOT source ~/.bashrc or nvm.sh, so relying on PATH
+    # alone will fail on nvm-based production boxes.
+    if ! resolve_npm_bin_for_systemd; then
+      error "Cannot render dynasty-frontend unit without an absolute npm path."
+      exit 1
+    fi
+    log "Resolved npm for frontend unit: ${NPM_BIN_PATH} (PATH dir: ${NODE_BIN_DIR})"
+
     tmp_frontend="$(mktemp)"
     sed \
       -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
       -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
       -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
       -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+      -e "s/__NPM_BIN__/$(escape_sed_replacement "${NPM_BIN_PATH}")/g" \
+      -e "s/__NODE_BIN_DIR__/$(escape_sed_replacement "${NODE_BIN_DIR}")/g" \
       "${frontend_template}" > "${tmp_frontend}"
     sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_frontend}" "${frontend_unit_path}"
     log "Installed ${frontend_name}.service"

--- a/deploy/systemd/dynasty-frontend.service.template
+++ b/deploy/systemd/dynasty-frontend.service.template
@@ -7,11 +7,17 @@ Type=simple
 User=__APP_USER__
 Group=__APP_USER__
 WorkingDirectory=__APP_DIR__/frontend
-ExecStart=/usr/bin/npm start
+# __NPM_BIN__ and __NODE_BIN_DIR__ are resolved at install time by
+# deploy/install-systemd-service.sh, which locates npm under nvm if
+# /usr/bin/npm does not exist.  This avoids the outage where a
+# hardcoded /usr/bin/npm path caused systemctl start to fail on an
+# nvm-based production box.
+ExecStart=__NPM_BIN__ start
 Restart=always
 RestartSec=5
 Environment=NODE_ENV=production
 Environment=PORT=3000
+Environment=PATH=__NODE_BIN_DIR__:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 EnvironmentFile=-__APP_DIR__/.env
 
 [Install]

--- a/tests/api/test_frontend_migration.py
+++ b/tests/api/test_frontend_migration.py
@@ -206,7 +206,13 @@ class TestDeployConfig(unittest.TestCase):
     def test_frontend_service_runs_npm_start(self):
         template = REPO_ROOT / "deploy" / "systemd" / "dynasty-frontend.service.template"
         text = template.read_text()
-        self.assertIn("npm start", text)
+        # ExecStart must invoke `npm start` via the __NPM_BIN__
+        # placeholder, which install-systemd-service.sh substitutes at
+        # install time with an absolute path to npm (system-wide or
+        # nvm-managed).  See deploy/install-systemd-service.sh
+        # resolve_npm_bin_for_systemd().
+        self.assertIn("ExecStart=__NPM_BIN__ start", text)
+        self.assertIn("__NODE_BIN_DIR__", text)
         self.assertIn("PORT=3000", text)
 
     def test_backend_service_depends_on_frontend(self):


### PR DESCRIPTION
## Summary

PR #46 successfully installed the `dynasty-frontend.service` unit, but
the template hardcoded `ExecStart=/usr/bin/npm start`. Production runs
node via nvm, so `/usr/bin/npm` does not exist on the box, and
`systemctl start dynasty-frontend` silently failed after the install
— which tripped `deploy_frontend_atomic`'s `is-active --quiet` check
and aborted the deploy with exit 1 even though the frontend bundle
had already been swapped into place and the serving process had been
restarted by the pre-existing unmanaged runner.

This PR makes the frontend unit nvm-compatible and self-healing:

- `deploy/install-systemd-service.sh` resolves an absolute npm path
  at install time. Order: `/usr/bin/npm`, `/usr/local/bin/npm`, then
  whatever is on `PATH`, then `~/.nvm/versions/node/<latest>/bin/npm`
  under the service user.
- `deploy/systemd/dynasty-frontend.service.template` now uses
  `ExecStart=__NPM_BIN__ start` plus
  `Environment=PATH=__NODE_BIN_DIR__:...` so child processes spawned
  by `next start` can find `node` too.
- `deploy/deploy.sh` `ensure_systemd_service` now inspects the
  already-installed frontend unit's `ExecStart` binary. If the path
  is not executable (exactly the PR-#46 /usr/bin/npm failure mode),
  it forces a reinstall via `FORCE_SERVICE_INSTALL=true`, then
  re-verifies the resulting unit before handing off to
  `deploy_frontend_atomic`.

## Why this matters

Without this fix, every future deploy on a production box that has
the PR #46 unit already installed would continue to exit 1 at the
`systemctl start dynasty-frontend` step, keeping the deploy
workflow red even though production is already serving the right
chunks.

## Test plan

- [x] `bash -n deploy/deploy.sh` — syntax OK
- [x] `bash -n deploy/install-systemd-service.sh` — syntax OK
- [x] awk `ExecStart=` extraction validated against a synthetic unit file
- [ ] Deploy workflow runs green against the merged main
- [ ] `/` + `/rankings` + `/trade` + `/edge` + `/finder` return 200 with all referenced `/_next/static/*` assets returning 200
- [ ] `systemctl cat dynasty-frontend` on production shows a real absolute nvm path in `ExecStart`

https://claude.ai/code/session_01BQJFkDva1WrqP2D8YRenje