### PR TITLE
Fix IDP data hygiene: name join, DLF crosswalk, trust validation

### DIFF
--- a/docs/trust-edge-handoff.md
+++ b/docs/trust-edge-handoff.md
@@ -1,12 +1,22 @@
 # Trust & Edge Layer — Implementation Handoff
 
-Last updated: 2026-04-09
+Last updated: 2026-04-13
 
 ## Overview
 
 The rankings board now exposes trust diagnostics, confidence signals, anomaly detection, identity validation, and actionable edge analysis across three surfaces: Rankings, Edge, and Finder.
 
 Every signal traces to measurable properties of the ranking data. Nothing is predicted or editorialized.
+
+Two IDP sources contribute today: **IDP Trade Calculator** (the shared-market
+backbone — prices offense + IDP on one 0-9999 scale) and **Dynasty League
+Football IDP** (a 185-player expert consensus that covers DL/LB/DB in an IDP-
+only pool). The ranking pipeline treats them very differently: IDPTC pass-
+through feeds the Hill curve directly, while DLF is *crosswalked* through the
+shared-market IDP ladder before feeding the Hill curve. This prevents DLF
+rank 1 from behaving like shared-market rank 1 (and being mapped to Hill
+value 9999 as if it beat every offense player) — see "IDP Shared-Market
+Crosswalk" below.
 
 ---
 
@@ -65,6 +75,79 @@ Identity-validation flags (trigger quarantine):
 ### Quarantine
 
 Any flag in `_QUARANTINE_FLAGS` set triggers `quarantined = true` and degrades `confidenceBucket` to `"low"`. Quarantined rows remain in the dataset — they are dimmed in the UI, not removed.
+
+### `OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS`
+
+A narrow override list for verified cross-universe name collisions where
+the same display name legitimately refers to two different people across
+the offense and IDP universes (e.g. "Josh Johnson" — retired QB vs draftable
+DB prospect).
+
+**The exception is conditional**: it only suppresses
+`position_source_contradiction` on a row that has *also* tripped
+`name_collision_cross_universe` in Check 1. A false-positive contradiction
+on a non-colliding name will still fire as before — the exception list
+cannot mask genuine data-quality errors anymore. Before adding a new
+entry, verify the contradiction survives a full rebuild with the
+normalised `_canonical_match_key` join in place: historical
+contradictions were almost entirely punctuation join artefacts
+(`T.J. Watt` vs `TJ Watt`) and do not reproduce after the hygiene fix.
+
+### IDP Shared-Market Crosswalk
+
+IDPTradeCalc prices offense + IDP on a single 0-9999 scale, so its
+ordinal rank is computed over the full combined pool. Its #1 IDP might
+sit at combined-pool rank ~40 because 39 offense players out-price it
+in the backbone source. That's the correct behaviour — feeding that 40
+into the Hill curve gives the right relative value for the best IDP on
+the shared offense+IDP economy.
+
+DLF, in contrast, only ranks IDPs. Its raw board ordinal says "best IDP
+= rank 1", which — fed directly to the Hill curve — would produce value
+9999 as if the best IDP were also the best asset in the whole dynasty
+market. That's the bug the crosswalk fixes.
+
+The crosswalk is built in `src/canonical/idp_backbone.py` as a
+`shared_market_idp_ladder`: the i-th entry is the combined-pool rank of
+the i-th best IDP in the backbone source. The builder activates the
+ladder only when the caller supplies `offense_positions` to
+`build_backbone_from_rows`, which the contract builder does automatically
+when the backbone source declares `overall_offense` in its `extra_scopes`.
+
+Any source flagged `needs_shared_market_translation=True` in
+`_RANKING_SOURCES` (today: `dlfIdp`) has its raw IDP ordinal rank
+translated through this ladder via `translate_position_rank(raw_rank,
+shared_market_ladder)`. DLF rank 1 becomes the combined-pool rank of the
+best IDP in IDPTC (~44 in live data), which is what actually gets fed
+to the Hill curve.
+
+- Backbone source (`idpTradeCalc`): pass-through, `method=direct`,
+  `sharedMarketTranslated=false`.
+- DLF (`dlfIdp`): crosswalked, `method=exact` (or
+  `extrapolated` past the ladder tail), `sharedMarketTranslated=true`.
+- Frontend mirror: `buildIdpBackbone(rows, sourceKey, includeSharedMarket)`
+  and the `sharedMarketTranslated` meta field in
+  `frontend/lib/dynasty-data.js` keep the browser-side fallback in lock
+  step with the backend.
+
+### Name join normalisation
+
+All cross-source name joins go through `_canonical_match_key` which
+wraps `src/utils/name_clean.py::normalize_player_name`. The normaliser
+ASCII-folds diacritics, lowercases, strips generational suffixes
+(Jr/Sr/II-VI), collapses non-alphanumerics to whitespace, and collapses
+adjacent single-letter initials. The result is a single key that
+treats `T.J. Watt` and `TJ Watt` as the same player, `D.J. Moore` and
+`DJ Moore` as the same player, and `Marvin Harrison Jr.` and
+`Marvin Harrison` as the same player.
+
+Before this fix, `_enrich_from_source_csvs` used a suffix-strip-only
+key and silently lost every player whose spelling drifted between the
+scraper payload and the committed CSVs — T.J. Watt was the canonical
+example (present in both DLF and IDPTC, but landed on the board as a
+1-src ghost because the join failed on the period). The frontend
+mirror `normalizePlayerName` in `frontend/lib/dynasty-data.js` uses the
+same rules so offline fallbacks reproduce the backend join semantics.
 
 ---
 
@@ -169,28 +252,80 @@ for p in data.get('playersArray', []):
 
 - 2 JS test failures in `dynasty-data.test.js` (`computedConsensusRank` tests) — pre-existing before trust/edge work, related to IDP rank offset calculation in the test fixture, not in production code.
 
-## Known Data Quality Issues (current as of 2026-04-09)
+## Known Data Quality Issues (current as of 2026-04-13)
 
 ### Fixed
 
+- **T.J. Watt / T.J. Edwards / D.J. Moore / C.J. Stroud et al.** — every
+  player whose scraper payload spelling differed in punctuation from the
+  CSV exports was previously dropped by the enrichment join. T.J. Watt
+  was the headline case: he appeared in both `exports/latest/site_raw/dlfIdp.csv`
+  and `exports/latest/site_raw/idpTradeCalc.csv` as `TJ Watt`, but the
+  scraper payload key was `T.J. Watt`, so the legacy
+  `_strip_name_suffix(name).lower()` join produced `t.j. watt` vs
+  `tj watt` and the match failed silently. Fixed by routing every join
+  through `_canonical_match_key` (wrapping `normalize_player_name`),
+  which collapses periods and initials consistently with the
+  identity and adapter layers. The frontend mirror is
+  `normalizePlayerName` in `frontend/lib/dynasty-data.js`. Regression
+  tests live in `tests/api/test_name_join_hygiene.py`.
+- **DLF IDP overweighting** — DLF was registered as `overall_idp`,
+  which passed its raw IDP ordinal rank directly to the Hill curve as
+  if it were a combined offense+IDP rank. DLF rank 1 → value 9999 inflated
+  every elite IDP. Fixed by building a
+  `shared_market_idp_ladder` in `src/canonical/idp_backbone.py` from the
+  backbone source's combined offense+IDP ordering and translating any
+  source flagged `needs_shared_market_translation` (today: DLF) through
+  it via `translate_position_rank`. Top IDPs now land at consensus rank
+  ~44 and below — behind offense starters who out-price them on the
+  retail market — while still occupying the same top-tier value band they
+  deserve within the IDP pool. Regression tests:
+  `tests/canonical/test_idp_backbone.py::TestSharedMarketIdpLadder` and
+  `tests/api/test_dlf_source.py::TestDlfParticipatesInUnifiedRankings::test_dlf_rank_is_mapped_through_shared_market_when_offense_present`.
+- **Stale `sourceCount` on out-of-limit rows** — rows that used to land
+  inside the top-800 cap and carried their (enriched) sourceCount only
+  because Phase 4 stamped it. Rows past the cap retained the stale
+  pre-enrichment count from `_derive_player_row`. Fixed by splitting
+  Phase 4 into two sub-phases: 4a refreshes `sourceCount`,
+  `isSingleSource`, and `sourcePresence` for *every* ranked row (so the
+  counts always reflect post-enrichment reality), and 4b still caps the
+  `canonicalConsensusRank` / value stamping at `OVERALL_RANK_LIMIT`.
+- **`OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS` is now conditional** — the
+  set only overrides `position_source_contradiction` on rows that also
+  carry `name_collision_cross_universe` from Check 1. A false-positive
+  contradiction on a non-colliding name (the old class of join
+  artefact) will now fire as before. The set has been pruned to the
+  single verified case (Josh Johnson: QB vs S).
 - **Elijah Mitchell (DB)** — IDP DB with only KTC (offense) data. Was incorrectly excepted from `position_source_contradiction` quarantine via `OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS`. Removed from exception set so Check 2 now quarantines him correctly.
-- **Bobby Brown (DL)** — IDP DL with only KTC data. Already quarantined via `near_name_value_mismatch` (Check 3). Also in `OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS` but quarantine fires through another path.
+- **Bobby Brown (DL)** — IDP DL with only KTC data. Already quarantined via `near_name_value_mismatch` (Check 3).
 - **Unsupported positions (OL/OT/OG/C/G/T/P/LS)** — blocked from ranking pipeline via `_RANKABLE_POSITIONS` allowlist. Frontend excludes via `classifyPos("excluded")`. Players like Nick Martin (OL) and Brandon Knight (OT) are correctly quarantined and unranked.
 
 ### Accepted / Working as Intended
 
-- **All IDP players are single-source / low confidence** — expected since only one IDP source (IDPTradeCalc) currently feeds the pipeline. Will self-correct when a second IDP source is added.
-- **Will Anderson (DL, rank ~38)** — single-source IDP with high value. Correct behavior: ranked from IDPTC, low confidence since only one source.
+- **IDP players with DLF + IDPTC both present** now carry `sourceCount=2` and
+  medium/high confidence. Rows where DLF recognised a player but IDPTC did not
+  remain single-source by design.
+- **Will Anderson (DL)** and other elite IDPs sit around consensus rank 44 on
+  the unified board — behind the top offense starters but still at a high
+  Hill value (~5100). Correct behaviour: DLF rank 1 is crosswalked to the
+  combined-pool rank of the best IDP, not treated as overall rank 1.
 - **Travis Hunter (WR, rank ~52)** — spread=69, medium confidence, expert consensus ranks higher than KTC. Correct behavior: shows "Market premium: Consensus" signal. Market gap label is accurate.
 - **~36 empty-position rows** — players with no position string. Not in any rankable set, receive no unified rank, invisible on all frontend surfaces (Rankings, Edge, Finder). Harmless.
 - **126 picks** — all clean, no anomaly flags. Correctly excluded from ranking board (PICK not in `_RANKABLE_POSITIONS`) but present in data for trade calculator.
 
 ### Requires Later Data/Modeling Pass
 
-- **`OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS` set** — 4 remaining names (Bobby Brown, Cameron Young, Dwight Bentley, Josh Johnson). Only Bobby Brown exists in current data; others are phantom entries. The exception set should ideally be conditional: only apply when both universe versions of a player exist. Currently it's a static name list that may mask future contamination.
 - **Cross-universe name collisions** — when both an offense and IDP player share the same name (e.g., "James Williams"), Check 1 flags both. The scraper's name-based matching cannot distinguish them. Needs canonical player IDs (Sleeper ID, etc.) to resolve.
 - **Age field** — scaffolded in contract but null for most players. Requires scraper bridge to supply age.
-- **Single-source value stability** — single-source players have no spread/agreement signal. Their rank position is entirely determined by one market. No mitigation possible until a second source covers the same pool.
+- **Single-source IDPs outside DLF's 185-entry board** — DLF's top-185 cap
+  means any IDP deeper than DLF rank 185 is crosswalked via
+  `TRANSLATION_EXTRAPOLATED`. This is safer than the old DIRECT pass-
+  through but extrapolated ranks carry less confidence than exact-anchor
+  ranks. A deeper DLF board would tighten this.
+- **Bryan Bresee-style players with `pos=None` in the scraper** — their
+  position is currently backfilled from the Sleeper positions map. When
+  the scraper misses a row, we rely on the name-based Sleeper join
+  remaining stable across releases.
 
 ## Intentionally Deferred
 

--- a/frontend/__tests__/dynasty-data.test.js
+++ b/frontend/__tests__/dynasty-data.test.js
@@ -12,7 +12,73 @@ import {
   buildRows,
   getSiteKeys,
   fetchDynastyData,
+  normalizePlayerName,
 } from "@/lib/dynasty-data";
+
+// ── normalizePlayerName ──────────────────────────────────────────────
+//
+// Frontend mirror of src/utils/name_clean.py::normalize_player_name.
+// The canonical match key is what every name join across the app falls
+// back on when backend-authored keys drift between snapshots.  The
+// backend uses the same normaliser inside _enrich_from_source_csvs,
+// so any divergence here re-introduces the T.J. Watt class of silent
+// join-miss bugs.
+
+describe("normalizePlayerName", () => {
+  it("collapses adjacent single-letter initials across punctuation", () => {
+    expect(normalizePlayerName("T.J. Watt")).toBe("tj watt");
+    expect(normalizePlayerName("TJ Watt")).toBe("tj watt");
+    expect(normalizePlayerName("t j watt")).toBe("tj watt");
+    expect(normalizePlayerName("T.J. Watt")).toBe(normalizePlayerName("TJ Watt"));
+  });
+
+  it("handles C.J. Stroud and D.J. Moore punctuation variants", () => {
+    expect(normalizePlayerName("C.J. Stroud")).toBe(
+      normalizePlayerName("CJ Stroud")
+    );
+    expect(normalizePlayerName("D.J. Moore")).toBe(
+      normalizePlayerName("DJ Moore")
+    );
+    expect(normalizePlayerName("A.J. Brown")).toBe(
+      normalizePlayerName("AJ Brown")
+    );
+  });
+
+  it("strips generational suffixes consistently", () => {
+    expect(normalizePlayerName("Marvin Harrison Jr.")).toBe(
+      normalizePlayerName("Marvin Harrison")
+    );
+    expect(normalizePlayerName("Kenneth Walker III")).toBe(
+      normalizePlayerName("Kenneth Walker")
+    );
+    expect(normalizePlayerName("Brian Thomas Jr")).toBe(
+      normalizePlayerName("Brian Thomas")
+    );
+  });
+
+  it("folds diacritics to ASCII", () => {
+    expect(normalizePlayerName("Juanyéh Thomas")).toBe(
+      normalizePlayerName("Juanyeh Thomas")
+    );
+    // Apostrophes are collapsed to whitespace by the non-alnum rule,
+    // matching the Python normalise_player_name helper exactly.  The
+    // important parity property is that both spellings collide on the
+    // SAME key whether or not the apostrophe is present.
+    expect(normalizePlayerName("Ja'Marr Chase")).toBe(
+      normalizePlayerName("Ja Marr Chase")
+    );
+  });
+
+  it("returns empty string for empty or null input", () => {
+    expect(normalizePlayerName("")).toBe("");
+    expect(normalizePlayerName(null)).toBe("");
+    expect(normalizePlayerName(undefined)).toBe("");
+  });
+
+  it("lowercases and trims whitespace", () => {
+    expect(normalizePlayerName("  T.J.  WATT  ")).toBe("tj watt");
+  });
+});
 
 // ── normalizePos ─────────────────────────────────────────────────────
 

--- a/frontend/__tests__/scope-aware-rankings.test.js
+++ b/frontend/__tests__/scope-aware-rankings.test.js
@@ -555,13 +555,65 @@ describe("G. DLF IDP source parity", () => {
     expect(lb.sourceRanks.dlfIdp).toBe(2);
     expect(db.sourceRanks.dlfIdp).toBe(3);
 
-    // DLF's meta entry should be present, direct (overall_idp is a
-    // pass-through scope), and pin the same scope token the backend uses.
+    // DLF is an IDP-only expert board, so its raw rank is translated
+    // through the shared-market IDP ladder built from IDPTradeCalc's
+    // combined offense+IDP pool.  In this fixture there are no offense
+    // rows, so the ladder is ``[1, 2, 3]`` and the crosswalk is a
+    // no-op in terms of effective rank — but the method token flips
+    // from DIRECT to EXACT because the row lands on a ladder anchor
+    // and ``sharedMarketTranslated`` is true.
     expect(dl.sourceRankMeta.dlfIdp.scope).toBe("overall_idp");
-    expect(dl.sourceRankMeta.dlfIdp.method).toBe(TRANSLATION_DIRECT);
+    expect(dl.sourceRankMeta.dlfIdp.method).toBe(TRANSLATION_EXACT);
     expect(dl.sourceRankMeta.dlfIdp.rawRank).toBe(1);
     expect(dl.sourceRankMeta.dlfIdp.effectiveRank).toBe(1);
     expect(dl.sourceRankMeta.dlfIdp.positionGroup).toBeNull();
+    expect(dl.sourceRankMeta.dlfIdp.sharedMarketTranslated).toBe(true);
+    // IDPTradeCalc stays pass-through because it IS the backbone.
+    expect(dl.sourceRankMeta.idpTradeCalc.method).toBe(TRANSLATION_DIRECT);
+    expect(dl.sourceRankMeta.idpTradeCalc.sharedMarketTranslated).toBe(false);
+  });
+
+  it("maps DLF rank 1 through the shared market when offense dominates", () => {
+    // 10 offense rows whose IDPTradeCalc values are all higher than
+    // the best IDP.  After the crosswalk, DLF's raw IDP rank 1 must
+    // be translated to IDPTradeCalc's combined-pool rank 11, not left
+    // as rank 1.
+    const playersArray = [];
+    for (let i = 0; i < 10; i++) {
+      playersArray.push(
+        row(`off${i}`, i % 2 === 0 ? "QB" : "WR", {
+          idp: 9999 - i * 10,
+        })
+      );
+    }
+    playersArray.push(row("dl1", "DL", { idp: 5500, dlf: 9995 }));
+    playersArray.push(row("lb1", "LB", { idp: 5000, dlf: 9990 }));
+
+    const rows = buildRows({ playersArray });
+    const dl1 = rows.find((r) => r.name === "dl1");
+    const lb1 = rows.find((r) => r.name === "lb1");
+
+    // Baseline: IDPTradeCalc's combined-pool rank for the top IDP is 11.
+    expect(dl1.sourceRanks.idpTradeCalc).toBe(11);
+    expect(lb1.sourceRanks.idpTradeCalc).toBe(12);
+
+    // Crosswalk: DLF's raw rank 1 is translated to combined-pool rank 11.
+    expect(dl1.sourceRankMeta.dlfIdp.rawRank).toBe(1);
+    expect(dl1.sourceRankMeta.dlfIdp.effectiveRank).toBe(11);
+    expect(dl1.sourceRankMeta.dlfIdp.method).toBe(TRANSLATION_EXACT);
+    expect(dl1.sourceRanks.dlfIdp).toBe(11);
+
+    // And the blended value is materially lower than 9999 — the sort
+    // no longer inflates the top IDP to "as good as the top offense
+    // player".
+    expect(dl1.rankDerivedValue).toBeLessThan(9999);
+
+    // The top offense player still outranks the top IDP on the unified
+    // board.
+    const topOff = rows.find((r) => r.name === "off0");
+    expect(topOff.canonicalConsensusRank).toBeLessThan(
+      dl1.canonicalConsensusRank
+    );
   });
 
   it("picks up DLF-only players even when IDPTradeCalc has no value", () => {

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -17,6 +17,50 @@ const IDP = new Set(["DL", "DE", "DT", "LB", "DB", "CB", "S", "EDGE"]);
 // Positions that may never enter the ranked board or user-facing surfaces.
 const UNSUPPORTED = new Set(["OL", "OT", "OG", "C", "G", "T", "LS"]);
 
+// ── Canonical name join key ──────────────────────────────────────────
+// Mirrors normalize_player_name() in src/utils/name_clean.py.  Collapses
+// punctuation, diacritics, apostrophes, casing, generational suffixes
+// (Jr / Sr / II-VI), and adjacent single-letter initials so
+// "T.J. Watt", "TJ Watt", and "t.j. watt" all produce "tj watt".
+// Exported for any consumer (tests, manual enrichment, dev-tools) that
+// needs to reproduce the backend join semantics.
+const _SUFFIX_RE = /\b(jr|sr|ii|iii|iv|v|dr)\b\.?/gi;
+const _NON_ALNUM_RE = /[^a-z0-9]+/g;
+
+export function normalizePlayerName(name) {
+  if (name === null || name === undefined) return "";
+  // NFKD-style ASCII fold.
+  const folded = String(name)
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/&/g, " and ");
+  let s = folded.replace(_SUFFIX_RE, "");
+  s = s.replace(_NON_ALNUM_RE, " ").trim();
+  s = s.replace(/\s+/g, " ");
+  // Collapse adjacent single-letter initials so "t j watt" → "tj watt".
+  const parts = s.split(" ").filter(Boolean);
+  const collapsed = [];
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i].length === 1 && /[a-z]/.test(parts[i])) {
+      let initials = parts[i];
+      while (
+        i + 1 < parts.length &&
+        parts[i + 1].length === 1 &&
+        /[a-z]/.test(parts[i + 1])
+      ) {
+        i += 1;
+        initials += parts[i];
+      }
+      collapsed.push(initials);
+    } else {
+      collapsed.push(parts[i]);
+    }
+  }
+  return collapsed.join(" ");
+}
+
 export function normalizePos(pos) {
   const p = String(pos || "").toUpperCase();
   if (["DE", "DT", "EDGE", "NT"].includes(p)) return "DL";
@@ -81,18 +125,37 @@ function scopeEligible(pos, scope, positionGroup) {
 // Walks every row, keeps IDP entries with a positive value in the
 // backbone source, sorts descending, and records per-position-group
 // ladders of overall-IDP ranks.
-function buildIdpBackbone(rows, sourceKey) {
+//
+// When ``includeSharedMarket`` is true the builder also emits a
+// sharedMarketIdpLadder — combined offense+IDP ranks at which IDP
+// entries appear in the backbone source's value pool.  IDP-only
+// expert boards (DLF) crosswalk through this ladder so their raw IDP
+// rank 1 is translated into the combined-pool rank of the best IDP
+// instead of being fed to the Hill curve as shared-market rank 1.
+function buildIdpBackbone(rows, sourceKey, includeSharedMarket = false) {
   const ladders = {};
   for (const pg of IDP_POSITION_GROUPS) ladders[pg] = [];
-  if (!sourceKey) return { ladders, depth: 0 };
+  if (!sourceKey) {
+    return {
+      ladders,
+      depth: 0,
+      sharedMarketIdpLadder: [],
+      sharedMarketDepth: 0,
+    };
+  }
 
   const eligible = [];
+  const combined = [];
   rows.forEach((r) => {
     const pos = String(r?.pos || "").toUpperCase();
-    if (!IDP_POSITIONS_SET.has(pos)) return;
+    const isIdp = IDP_POSITIONS_SET.has(pos);
+    const isOffense = OFFENSE_POSITIONS.has(pos) || pos === "PICK";
+    if (!isIdp && !(includeSharedMarket && isOffense)) return;
     const val = Number(r?.canonicalSites?.[sourceKey]);
     if (!Number.isFinite(val) || val <= 0) return;
-    eligible.push({ val, pos, name: String(r?.name || "") });
+    const name = String(r?.name || "");
+    if (isIdp) eligible.push({ val, pos, name });
+    if (includeSharedMarket) combined.push({ val, pos, name, isIdp });
   });
   eligible.sort((a, b) => b.val - a.val || a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
@@ -102,7 +165,22 @@ function buildIdpBackbone(rows, sourceKey) {
     if (ladders[e.pos]) ladders[e.pos].push(overall);
     depth = overall;
   });
-  return { ladders, depth };
+
+  const sharedMarketIdpLadder = [];
+  let sharedMarketDepth = 0;
+  if (includeSharedMarket && combined.length) {
+    combined.sort(
+      (a, b) =>
+        b.val - a.val ||
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+    );
+    sharedMarketDepth = combined.length;
+    combined.forEach((e, i) => {
+      if (e.isIdp) sharedMarketIdpLadder.push(i + 1);
+    });
+  }
+
+  return { ladders, depth, sharedMarketIdpLadder, sharedMarketDepth };
 }
 
 // ── Position-rank translation ───────────────────────────────────────
@@ -272,6 +350,16 @@ export const RANKING_SOURCES = [
     // DLF (Dynasty League Football) full-board IDP rankings.  Mirrors
     // the backend `_RANKING_SOURCES` entry in src/api/data_contract.py.
     // 185-player expert consensus; overall_idp scope; not a backbone.
+    //
+    // IDP-only expert boards (needsSharedMarketTranslation=true) have
+    // their raw IDP ordinal rank translated through a *shared-market
+    // IDP ladder* built from the backbone source's combined
+    // offense+IDP value pool.  Without this translation DLF rank 1
+    // would hit the Hill curve as overall rank 1 → value 9999, as if
+    // DLF priced both offense and IDP together.  With translation, DLF
+    // rank 1 becomes the combined-pool rank of the best IDP in the
+    // backbone (typically ~30-50), correctly calibrating DLF against
+    // the retail offense market.
     key: "dlfIdp",
     displayName: "Dynasty League Football IDP",
     columnLabel: "DLF",
@@ -280,6 +368,7 @@ export const RANKING_SOURCES = [
     depth: null,
     weight: 1.0,
     isBackbone: false,
+    needsSharedMarketTranslation: true,
   },
 ];
 
@@ -320,12 +409,33 @@ export function getRetailLabel() {
 
 function computeUnifiedRanks(rows) {
   // ── Phase 0: Build the IDP backbone from the designated source ──
+  // The builder seeds the shared-market IDP ladder only when the
+  // backbone source declares overall_offense in its extraScopes (i.e.
+  // prices offense + IDP on a shared 0-9999 scale).  Non-backbone IDP
+  // sources flagged ``needsSharedMarketTranslation`` use that ladder
+  // as a crosswalk so their raw rank 1 is mapped to the combined-pool
+  // rank of the best IDP, not treated as overall rank 1.
   const backboneSrc = RANKING_SOURCES.find(
     (s) => s.scope === SOURCE_SCOPE_OVERALL_IDP && s.isBackbone
   );
+  const backboneExtraScopes = Array.isArray(backboneSrc?.extraScopes)
+    ? backboneSrc.extraScopes
+    : [];
+  const backboneHasSharedMarket = backboneExtraScopes.includes(
+    SOURCE_SCOPE_OVERALL_OFFENSE
+  );
   const backbone = backboneSrc
-    ? buildIdpBackbone(rows, backboneSrc.key)
-    : { ladders: { DL: [], LB: [], DB: [] }, depth: 0 };
+    ? buildIdpBackbone(rows, backboneSrc.key, backboneHasSharedMarket)
+    : {
+        ladders: { DL: [], LB: [], DB: [] },
+        depth: 0,
+        sharedMarketIdpLadder: [],
+        sharedMarketDepth: 0,
+      };
+  const sharedMarketLadder = Array.isArray(backbone.sharedMarketIdpLadder)
+    ? backbone.sharedMarketIdpLadder
+    : [];
+  const sharedMarketDepth = Number(backbone.sharedMarketDepth) || 0;
 
   // ── Phase 1: Combined-pass ordinal ranking per source ──
   const sourceRanksByRow = new Map(); // row idx -> { sourceKey: effectiveRank }
@@ -371,19 +481,36 @@ function computeUnifiedRanks(rows) {
       (a, b) => b.val - a.val || a.tiebreakName.localeCompare(b.tiebreakName)
     );
 
+    const needsSharedMarket =
+      Boolean(src.needsSharedMarketTranslation) && !src.isBackbone;
+
     eligible.forEach((e, rank) => {
       const rawRank = rank + 1;
       let effectiveRank = rawRank;
       let method = TRANSLATION_DIRECT;
+      let ladderDepthMeta = null;
+      let backboneDepthMeta = null;
+      let sharedMarketTranslated = false;
 
       // position_idp sources (shallow positional lists like DL-only)
       // still get backbone translation.  overall_* scopes — including
-      // the cross-universe combined pool — pass through directly.
+      // the cross-universe combined pool — pass through directly unless
+      // the source is an IDP-only expert board that opts in to the
+      // shared-market crosswalk (e.g. DLF).
       if (e.scope === SOURCE_SCOPE_POSITION_IDP && src.positionGroup) {
         const ladder = backbone.ladders[String(src.positionGroup).toUpperCase()] || [];
         const translated = translatePositionRank(rawRank, ladder);
         effectiveRank = translated.rank;
         method = translated.method;
+        ladderDepthMeta = ladder.length;
+        backboneDepthMeta = backbone.depth;
+      } else if (needsSharedMarket && e.scope === SOURCE_SCOPE_OVERALL_IDP) {
+        const translated = translatePositionRank(rawRank, sharedMarketLadder);
+        effectiveRank = translated.rank;
+        method = translated.method;
+        ladderDepthMeta = sharedMarketLadder.length;
+        backboneDepthMeta = sharedMarketDepth;
+        sharedMarketTranslated = true;
       }
 
       if (!sourceRanksByRow.has(e.idx)) sourceRanksByRow.set(e.idx, {});
@@ -395,13 +522,11 @@ function computeUnifiedRanks(rows) {
         rawRank,
         effectiveRank,
         method,
-        ladderDepth:
-          e.scope === SOURCE_SCOPE_POSITION_IDP && src.positionGroup
-            ? (backbone.ladders[String(src.positionGroup).toUpperCase()] || []).length
-            : null,
-        backboneDepth: e.scope === SOURCE_SCOPE_POSITION_IDP ? backbone.depth : null,
+        ladderDepth: ladderDepthMeta,
+        backboneDepth: backboneDepthMeta,
         depth: src.depth ?? null,
         weight: Number(src.weight) || 0,
+        sharedMarketTranslated,
       };
     });
   }

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -7,12 +7,28 @@ from typing import Any
 
 from src.data_models.contracts import utc_now_iso
 
-OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS = {
-    "Bobby Brown",
-    "Cameron Young",
-    "Dwight Bentley",
-    "Josh Johnson",
-}
+#: Verified cross-universe name collisions — players whose display name
+#: exists in both the offense market (QB/RB/WR/TE) and the IDP market
+#: (DL/LB/DB) as two genuinely different people.  The
+#: ``position_source_contradiction`` check would otherwise fire on one
+#: side of every such collision because name-based join enrichment will
+#: graft the wrong source's value onto the wrong row.
+#:
+#: This list is intentionally small.  Before adding a new entry, verify
+#: that the contradiction survives a full rebuild with the normalised
+#: name join (``_canonical_match_key``) in place — most historical
+#: contradictions were join artefacts from punctuation drift (e.g.
+#: ``T.J. Watt`` vs ``TJ Watt``) and no longer reproduce.
+#:
+#: The exceptions only apply when a row ALSO has
+#: ``name_collision_cross_universe`` already flagged on it, so a false
+#: positive on a non-colliding name cannot silently suppress a legitimate
+#: contradiction anymore.
+OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS: frozenset[str] = frozenset(
+    {
+        "Josh Johnson",  # QB (retired journeyman) vs S (draftable prospect)
+    }
+)
 
 
 CONTRACT_VERSION = "2026-03-10.v2"
@@ -230,6 +246,20 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # NOT a backbone source — IDPTradeCalc remains authoritative for
         # ladder translation — but it contributes equally-weighted signal
         # to the coverage-aware blend.
+        #
+        # IDP-only sources (``needs_shared_market_translation=True``)
+        # have their raw IDP ordinal rank translated through a
+        # *shared-market IDP ladder* before feeding the Hill curve.  The
+        # ladder is built from the backbone source's combined
+        # offense+IDP value pool (see
+        # ``src/canonical/idp_backbone.IdpBackbone.shared_market_idp_ladder``):
+        # the i-th entry holds the combined-pool rank of the i-th best
+        # IDP in the backbone.  Without this translation, DLF rank 1
+        # would be fed to the Hill curve as an overall rank 1 → value
+        # 9999, as if DLF were ranking both offense and IDP together.
+        # With translation, DLF rank 1 becomes the combined-pool rank of
+        # the best IDP in the shared market (typically ~30-50), which
+        # correctly calibrates DLF against the retail offense market.
         "key": "dlfIdp",
         "display_name": "Dynasty League Football IDP",
         "scope": SOURCE_SCOPE_OVERALL_IDP,
@@ -237,6 +267,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "depth": None,
         "weight": 1.0,
         "is_backbone": False,
+        "needs_shared_market_translation": True,
     },
 ]
 
@@ -523,6 +554,18 @@ def _validate_and_quarantine_rows(
                     row["anomalyFlags"] = flags
 
     # ── Check 2: Position-source contradiction ──
+    # A row gets flagged when the position family disagrees with the set
+    # of source keys carrying positive values on the row.  The flag is
+    # suppressed when:
+    #   (a) the row is a verified cross-universe name collision (see
+    #       OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS) AND the collision flag
+    #       has already been applied in Check 1 — in that case the
+    #       contradiction is an expected consequence of the grafted
+    #       join, and quarantining via two flags would inflate false
+    #       positives in downstream reports.
+    #   (b) the row already carries `name_collision_cross_universe`
+    #       from Check 1.  The collision flag is itself a quarantine
+    #       signal, so we don't need to pile contradictions on top.
     for idx, row in enumerate(players_array):
         pos = str(row.get("position") or "").strip().upper()
         asset_class = row.get("assetClass") or ""
@@ -537,19 +580,29 @@ def _validate_and_quarantine_rows(
             for k in _IDP_SIGNAL_KEYS
         )
 
-        # Offense position but only IDP values (and not an allowed exception)
+        current_flags = row.get("anomalyFlags") or []
+        has_collision = "name_collision_cross_universe" in current_flags
         name = row.get("canonicalName") or ""
+        is_known_collision = (
+            has_collision and name in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
+        )
+
+        # Offense position but only IDP values.
         if pos in _OFFENSE_POSITIONS and has_idp_val and not has_off_val:
-            if name not in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS:
-                flags = row.get("anomalyFlags") or []
+            if has_collision or is_known_collision:
+                pass
+            else:
+                flags = current_flags
                 if "position_source_contradiction" not in flags:
                     flags.append("position_source_contradiction")
                     row["anomalyFlags"] = flags
 
-        # IDP position but only offense values
+        # IDP position but only offense values.
         if pos in _IDP_POSITIONS and has_off_val and not has_idp_val:
-            if name not in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS:
-                flags = row.get("anomalyFlags") or []
+            if has_collision or is_known_collision:
+                pass
+            else:
+                flags = current_flags
                 if "position_source_contradiction" not in flags:
                     flags.append("position_source_contradiction")
                     row["anomalyFlags"] = flags
@@ -689,12 +742,35 @@ def _mirror_trust_to_legacy(
 
 
 def _strip_name_suffix(name: str) -> str:
-    """Strip generational suffixes (Jr, Sr, II-VI) for resilient matching."""
+    """Strip generational suffixes (Jr, Sr, II-VI) for resilient matching.
+
+    Legacy helper retained for backwards-compat with callers/tests that
+    imported it directly.  For new matching code prefer
+    ``_canonical_match_key`` below, which also normalises punctuation,
+    apostrophes, casing, and collapses initials so ``T.J. Watt`` and
+    ``TJ Watt`` collide on the same key.
+    """
     n = name.strip()
     for sfx in (" Jr.", " Jr", " Sr.", " Sr", " II", " III", " IV", " V", " VI"):
         if n.endswith(sfx):
             n = n[: -len(sfx)].strip()
     return n
+
+
+def _canonical_match_key(name: str) -> str:
+    """Return the single canonical join key for cross-source name matching.
+
+    All enrichment joins and CSV → contract lookups go through this
+    helper so punctuation, diacritics, apostrophes, initials, suffixes,
+    and casing collapse to a single ``tj watt``-style key.  The
+    underlying ``normalize_player_name`` helper in
+    ``src/utils/name_clean.py`` owns the actual rules; this wrapper
+    exists so callers (and tests) can import a single contract-level
+    symbol without dipping into ``src.utils`` every call site.
+    """
+    from src.utils.name_clean import normalize_player_name  # noqa: PLC0415
+
+    return normalize_player_name(name)
 
 
 def _enrich_from_source_csvs(players_array: list[dict[str, Any]]) -> None:
@@ -704,6 +780,15 @@ def _enrich_from_source_csvs(players_array: list[dict[str, Any]]) -> None:
     (e.g. KTC scrape failed but the CSV persists from a prior run), load
     the CSV and inject values into canonicalSiteValues so the ranking
     function can use them.
+
+    Matching uses ``_canonical_match_key`` (which itself calls the
+    shared ``normalize_player_name`` helper in ``src/utils/name_clean``)
+    so that ``T.J. Watt`` in the scraper payload joins against a
+    ``TJ Watt`` row in the CSV export without either side knowing about
+    the punctuation variant.  Before the normalisation refactor the
+    loader only stripped generational suffixes + lowered, which caused
+    silent 1-src artefacts for any player whose spelling drifted between
+    the scraper payload and the committed CSV snapshot.
 
     Supports two signal types per source:
 
@@ -744,6 +829,9 @@ def _enrich_from_source_csvs(players_array: list[dict[str, Any]]) -> None:
                     name = str(csvrow.get("name", "")).strip()
                     if not name:
                         continue
+                    key = _canonical_match_key(name)
+                    if not key:
+                        continue
                     if signal == "rank":
                         raw = csvrow.get("rank", "")
                         if raw == "" or raw is None:
@@ -767,13 +855,16 @@ def _enrich_from_source_csvs(players_array: list[dict[str, Any]]) -> None:
                         )
                         if synthetic <= 0:
                             continue
-                        csv_lookup[_strip_name_suffix(name).lower()] = synthetic
+                        # First entry wins on collision — CSV rows are
+                        # emitted best-to-worst so we prefer the stronger
+                        # anchor for a duplicated key.
+                        csv_lookup.setdefault(key, synthetic)
                     else:
                         val = csvrow.get("value", "")
                         if not val:
                             continue
                         try:
-                            csv_lookup[_strip_name_suffix(name).lower()] = int(float(val))
+                            csv_lookup.setdefault(key, int(float(val)))
                         except (ValueError, TypeError):
                             continue
         except Exception:
@@ -790,9 +881,11 @@ def _enrich_from_source_csvs(players_array: list[dict[str, Any]]) -> None:
             existing = _safe_num(csv_vals.get(source_key))
             if existing is not None and existing > 0:
                 continue
-            canon_name = _strip_name_suffix(
+            canon_name = _canonical_match_key(
                 str(row.get("canonicalName") or row.get("displayName") or "")
-            ).lower()
+            )
+            if not canon_name:
+                continue
             csv_val = csv_lookup.get(canon_name)
             if csv_val is not None and csv_val > 0:
                 csv_vals[source_key] = csv_val
@@ -847,17 +940,41 @@ def _compute_unified_rankings(
     # wins.  If no backbone source is present, position_idp sources fall
     # back to treating their raw rank as a synthetic overall rank and get
     # a caution flag on the per-source meta.
+    #
+    # The backbone also carries a *shared-market IDP ladder* — the
+    # combined offense+IDP ranks at which IDP entries appear in the
+    # backbone source's value pool.  Non-backbone overall_idp sources
+    # flagged with ``needs_shared_market_translation`` (e.g. DLF) use
+    # this ladder as a crosswalk so their IDP-only rank 1 is translated
+    # to the combined-pool rank of the best IDP, not treated as if it
+    # were the overall rank 1 of the shared offense+IDP board.
     backbone_source_key: str | None = None
     for src in _RANKING_SOURCES:
         if src["scope"] == SOURCE_SCOPE_OVERALL_IDP and src.get("is_backbone"):
             backbone_source_key = src["key"]
             break
     if backbone_source_key:
-        backbone = build_backbone_from_rows(
-            players_array,
-            source_key=backbone_source_key,
-            idp_positions=_IDP_POSITIONS,
+        # Only seed the shared-market ladder when the backbone source
+        # actually prices both offense + IDP on a shared scale; this is
+        # detected by the registry declaring offense in extra_scopes.
+        backbone_src_def = next(
+            (s for s in _RANKING_SOURCES if s["key"] == backbone_source_key),
+            {},
         )
+        backbone_extra_scopes = list(backbone_src_def.get("extra_scopes") or [])
+        if SOURCE_SCOPE_OVERALL_OFFENSE in backbone_extra_scopes:
+            backbone = build_backbone_from_rows(
+                players_array,
+                source_key=backbone_source_key,
+                idp_positions=_IDP_POSITIONS,
+                offense_positions=_OFFENSE_POSITIONS | {"PICK"},
+            )
+        else:
+            backbone = build_backbone_from_rows(
+                players_array,
+                source_key=backbone_source_key,
+                idp_positions=_IDP_POSITIONS,
+            )
     else:
         backbone = IdpBackbone()
 
@@ -868,11 +985,16 @@ def _compute_unified_rankings(
     row_source_meta: dict[int, dict[str, dict[str, Any]]] = {}
     # For backbone assertion: remember the actual ladder depth used
     backbone_depth = backbone.depth
+    shared_market_ladder = backbone.shared_idp_ladder()
+    shared_market_depth = backbone.shared_market_depth
 
     for src in _RANKING_SOURCES:
         source_key: str = src["key"]
         position_group: str | None = src.get("position_group")
         primary_scope: str = src["scope"]
+        needs_shared_market = bool(
+            src.get("needs_shared_market_translation")
+        ) and not src.get("is_backbone")
         # A source may contribute to multiple scopes (e.g. IDPTradeCalc
         # lists both offense and IDP players in one value pool on a shared
         # 0-9999 scale).  Earlier revisions ran a separate ordinal pass per
@@ -931,12 +1053,28 @@ def _compute_unified_rankings(
             # Translate to effective overall-style rank based on scope.
             # position_idp sources (shallow positional lists like DL-only)
             # still get backbone translation.  overall_* scopes — including
-            # the cross-universe combined pool — pass through directly.
+            # the cross-universe combined pool — pass through directly
+            # unless the source is an IDP-only expert board that opts in
+            # to the shared-market crosswalk (e.g. DLF).
+            ladder_depth_meta: int | None = None
+            backbone_depth_meta: int | None = None
             if row_scope == SOURCE_SCOPE_POSITION_IDP and position_group:
                 ladder = backbone.ladder_for(position_group)
                 effective_rank, method = translate_position_rank(
                     raw_rank, ladder
                 )
+                ladder_depth_meta = len(ladder)
+                backbone_depth_meta = backbone_depth
+            elif needs_shared_market and row_scope == SOURCE_SCOPE_OVERALL_IDP:
+                # Crosswalk an IDP-only expert board's raw IDP ordinal
+                # into the backbone source's combined offense+IDP rank
+                # space.  This prevents DLF rank 1 from being fed to the
+                # Hill curve as if it were shared-market rank 1.
+                effective_rank, method = translate_position_rank(
+                    raw_rank, shared_market_ladder
+                )
+                ladder_depth_meta = len(shared_market_ladder)
+                backbone_depth_meta = shared_market_depth
             else:
                 effective_rank = raw_rank
                 method = TRANSLATION_DIRECT
@@ -948,18 +1086,14 @@ def _compute_unified_rankings(
                 "rawRank": raw_rank,
                 "effectiveRank": effective_rank,
                 "method": method,
-                "ladderDepth": (
-                    len(backbone.ladder_for(position_group))
-                    if row_scope == SOURCE_SCOPE_POSITION_IDP and position_group
-                    else None
-                ),
-                "backboneDepth": (
-                    backbone_depth
-                    if row_scope == SOURCE_SCOPE_POSITION_IDP
-                    else None
-                ),
+                "ladderDepth": ladder_depth_meta,
+                "backboneDepth": backbone_depth_meta,
                 "depth": src.get("depth"),
                 "weight": float(src.get("weight") or 0.0),
+                "sharedMarketTranslated": bool(
+                    needs_shared_market
+                    and row_scope == SOURCE_SCOPE_OVERALL_IDP
+                ),
             }
 
     # ── Phase 2-3: Normalized value (Hill curve) + coverage-aware blend ──
@@ -996,6 +1130,24 @@ def _compute_unified_rankings(
     row_normalized.sort(
         key=lambda t: (-t[0], players_array[t[1]].get("canonicalName", "").lower())
     )
+
+    # ── Phase 4a: stamp sourceCount / source presence on EVERY row that
+    # produced source ranks, even rows that will later fall past the
+    # OVERALL_RANK_LIMIT and never receive canonicalConsensusRank.  This
+    # keeps sourceCount consistent with post-enrichment reality for
+    # downstream filters (trust, audits, frontend fallback) — otherwise
+    # a row stamped with stale pre-enrichment counts by _derive_player_row
+    # would carry that stale value forever if it happened to slip past
+    # the ranked board cap.
+    for row_idx, source_ranks in row_source_ranks.items():
+        row = players_array[row_idx]
+        row["sourceCount"] = len(source_ranks)
+        row["isSingleSource"] = len(source_ranks) == 1
+        # Also refresh sourcePresence so the enriched keys show up.
+        canonical_sites = row.get("canonicalSiteValues") or {}
+        row["sourcePresence"] = {
+            k: (v is not None and v > 0) for k, v in canonical_sites.items()
+        }
 
     for overall_idx, (norm_val, row_idx) in enumerate(
         row_normalized[:OVERALL_RANK_LIMIT]
@@ -2003,15 +2155,27 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
             _to_int_or_none(canonical_sites.get(k)) not in (None, 0) for k in _IDP_SIGNAL_KEYS
         )
         if pos in _IDP_POSITIONS and has_off_signal and not has_idp_signal:
-            if len(players_array) >= 250 and name in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS:
-                continue
-            errors.append(
-                f"playersArray offense→IDP mismatch: {name or '<unknown>'} tagged {pos} "
-                "with offensive-only source signal(s)"
+            # Skip the hard-fail for verified cross-universe collisions
+            # (Josh Johnson: QB ≠ S).  The exception only applies on a
+            # full-board payload so synthetic unit test fixtures still
+            # fail loudly when contamination is present.
+            current_flags = row.get("anomalyFlags") or []
+            has_collision = "name_collision_cross_universe" in current_flags
+            is_known_collision = (
+                name in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
             )
+            if len(players_array) >= 250 and (has_collision or is_known_collision):
+                pass
+            else:
+                errors.append(
+                    f"playersArray offense→IDP mismatch: {name or '<unknown>'} tagged {pos} "
+                    "with offensive-only source signal(s)"
+                )
 
         if name:
-            norm = re.sub(r"[^a-z0-9]+", "", str(name).lower())
+            norm = _canonical_match_key(name) or re.sub(
+                r"[^a-z0-9]+", "", str(name).lower()
+            )
             normalized_pos_by_name.setdefault(norm, set()).add(pos or "?")
 
     for norm_name, poses in normalized_pos_by_name.items():

--- a/src/canonical/idp_backbone.py
+++ b/src/canonical/idp_backbone.py
@@ -87,13 +87,37 @@ class IdpBackbone:
     `depth` is the total number of overall-IDP entries the backbone was
     built from.  It's retained for transparency (to label "ladderDepth"
     on translation metadata).
+
+    ``shared_market_idp_ladder`` holds the combined offense+IDP ranks at
+    which IDP entries appear in the backbone source's shared market.
+    The i-th entry is the combined-pool rank of the (i+1)-th best IDP in
+    the backbone source.  This ladder is only populated when the caller
+    supplies ``offense_positions`` to ``build_backbone_from_rows``; it
+    powers the crosswalk that keeps IDP-only expert boards (e.g. DLF)
+    from pretending their rank 1 is the overall rank 1 of the shared
+    market.
+
+    ``shared_market_depth`` is the size of the combined offense+IDP pool
+    used to build ``shared_market_idp_ladder``.  Zero when no shared
+    market was supplied.
     """
 
     ladders: dict[str, list[int]] = field(default_factory=dict)
     depth: int = 0
+    shared_market_idp_ladder: list[int] = field(default_factory=list)
+    shared_market_depth: int = 0
 
     def ladder_for(self, position_group: str) -> list[int]:
         return self.ladders.get(str(position_group).upper(), [])
+
+    def shared_idp_ladder(self) -> list[int]:
+        """Return the combined offense+IDP ladder for IDP-only sources.
+
+        Used by `translate_position_rank` to translate a non-backbone
+        overall_idp source's raw rank into a synthetic combined-market
+        rank.  Empty when no shared market was supplied at build time.
+        """
+        return list(self.shared_market_idp_ladder)
 
     def is_empty(self) -> bool:
         return self.depth == 0 or not any(self.ladders.values())
@@ -127,6 +151,7 @@ def build_backbone_from_rows(
     *,
     source_key: str,
     idp_positions: Iterable[str] = IDP_POSITION_GROUPS,
+    offense_positions: Iterable[str] | None = None,
 ) -> IdpBackbone:
     """Convenience builder used by the contract pipeline.
 
@@ -134,12 +159,25 @@ def build_backbone_from_rows(
     is an IDP family, sorts them descending by the per-source value at
     `canonicalSiteValues[source_key]`, and constructs a backbone from the
     resulting order.
+
+    When ``offense_positions`` is supplied, the builder also computes the
+    *shared-market IDP ladder* — a list of combined offense+IDP ranks at
+    which IDP players appear in the same-source value pool.  This ladder
+    is the crosswalk backbone for non-backbone IDP-only expert boards
+    (e.g. DLF): their raw IDP-only rank gets translated through it into
+    a synthetic combined-pool rank, preventing DLF rank 1 from behaving
+    like a shared-market rank 1.
     """
     idp_set = {p.upper() for p in idp_positions}
+    offense_set = {p.upper() for p in (offense_positions or ())}
+
     eligible: list[tuple[float, str, str]] = []
+    combined: list[tuple[float, str, str, bool]] = []  # (val, pos, name, is_idp)
     for row in rows:
         pos = str(row.get("position") or "").strip().upper()
-        if pos not in idp_set:
+        is_idp = pos in idp_set
+        is_offense = pos in offense_set
+        if not (is_idp or is_offense):
             continue
         sites = row.get("canonicalSiteValues") or {}
         raw = sites.get(source_key)
@@ -150,10 +188,29 @@ def build_backbone_from_rows(
         if val is None or val <= 0:
             continue
         name = str(row.get("canonicalName") or row.get("displayName") or "")
-        eligible.append((val, pos, name))
+        if is_idp:
+            eligible.append((val, pos, name))
+        if offense_set:
+            combined.append((val, pos, name, is_idp))
     # Sort descending by value; secondary tiebreaker by name for stability.
     eligible.sort(key=lambda t: (-t[0], t[2].lower()))
-    return build_backbone_from_ranked_entries((pos, name) for _, pos, name in eligible)
+    base = build_backbone_from_ranked_entries((pos, name) for _, pos, name in eligible)
+
+    shared_market_idp_ladder: list[int] = []
+    shared_market_depth = 0
+    if combined:
+        combined.sort(key=lambda t: (-t[0], t[2].lower()))
+        shared_market_depth = len(combined)
+        for combined_rank, (_, _pos, _name, is_idp) in enumerate(combined, start=1):
+            if is_idp:
+                shared_market_idp_ladder.append(combined_rank)
+
+    return IdpBackbone(
+        ladders=base.ladders,
+        depth=base.depth,
+        shared_market_idp_ladder=shared_market_idp_ladder,
+        shared_market_depth=shared_market_depth,
+    )
 
 
 # ── Position-rank translation ────────────────────────────────────────────

--- a/tests/api/test_dlf_source.py
+++ b/tests/api/test_dlf_source.py
@@ -32,6 +32,8 @@ from src.api.data_contract import (
 from src.canonical.idp_backbone import (
     SOURCE_SCOPE_OVERALL_IDP,
     TRANSLATION_DIRECT,
+    TRANSLATION_EXACT,
+    TRANSLATION_EXTRAPOLATED,
 )
 
 
@@ -277,7 +279,18 @@ class TestDlfParticipatesInUnifiedRankings(unittest.TestCase):
             self.assertIn("dlfIdp", meta)
             self.assertIn("idpTradeCalc", meta)
             self.assertEqual(meta["dlfIdp"]["scope"], SOURCE_SCOPE_OVERALL_IDP)
-            self.assertEqual(meta["dlfIdp"]["method"], TRANSLATION_DIRECT)
+            # DLF is an IDP-only expert board, so its raw rank is
+            # translated through the shared-market IDP ladder built
+            # from IDPTradeCalc's combined offense+IDP pool.  In this
+            # fixture there are no offense rows, so the ladder is
+            # ``[1, 2, 3]`` and the crosswalk becomes a no-op in terms
+            # of effective rank, but the method token flips from DIRECT
+            # to EXACT because the row lands on a ladder anchor.
+            self.assertEqual(meta["dlfIdp"]["method"], TRANSLATION_EXACT)
+            self.assertTrue(meta["dlfIdp"]["sharedMarketTranslated"])
+            # idpTradeCalc is still the backbone — no crosswalk on it.
+            self.assertEqual(meta["idpTradeCalc"]["method"], TRANSLATION_DIRECT)
+            self.assertFalse(meta["idpTradeCalc"]["sharedMarketTranslated"])
 
         # dl1 is rank 1 in both sources
         dl1 = rows[0]
@@ -287,6 +300,59 @@ class TestDlfParticipatesInUnifiedRankings(unittest.TestCase):
         db1 = rows[2]
         self.assertEqual(db1["sourceRanks"]["idpTradeCalc"], 3)
         self.assertEqual(db1["sourceRanks"]["dlfIdp"], 3)
+
+    def test_dlf_rank_is_mapped_through_shared_market_when_offense_present(self):
+        """The real regression: when offense rows dominate the backbone
+        source's combined pool, DLF's IDP rank 1 must NOT be fed to the
+        Hill curve as overall rank 1.  It should be translated through
+        the shared-market IDP ladder to the combined-pool rank of the
+        best IDP in the backbone."""
+        # 10 offense rows all price higher in IDPTradeCalc than any IDP,
+        # so the combined-pool rank of the top IDP in IDPTC is 11.
+        rows = [
+            _row(f"off{i}", "QB" if i % 2 else "WR", idp=9999 - i * 10)
+            for i in range(10)
+        ]
+        rows += [
+            _row("dl1", "DL", idp=5500, dlf=9995),
+            _row("lb1", "LB", idp=5000, dlf=9990),
+            _row("db1", "DB", idp=4500, dlf=9985),
+        ]
+        _compute_unified_rankings(rows, {})
+
+        dl1 = next(r for r in rows if r["canonicalName"] == "dl1")
+        lb1 = next(r for r in rows if r["canonicalName"] == "lb1")
+        db1 = next(r for r in rows if r["canonicalName"] == "db1")
+
+        # IDPTradeCalc combined-pool ranks: 11, 12, 13 for the three IDPs
+        # (ten offense rows precede them in value order).
+        self.assertEqual(dl1["sourceRanks"]["idpTradeCalc"], 11)
+        self.assertEqual(lb1["sourceRanks"]["idpTradeCalc"], 12)
+        self.assertEqual(db1["sourceRanks"]["idpTradeCalc"], 13)
+
+        # DLF raw rank 1 (dl1) must be translated through the
+        # shared-market ladder to combined-pool rank 11, not left as 1.
+        dl_meta = dl1["sourceRankMeta"]["dlfIdp"]
+        self.assertEqual(dl_meta["rawRank"], 1)
+        self.assertEqual(dl_meta["effectiveRank"], 11)
+        self.assertEqual(dl_meta["method"], TRANSLATION_EXACT)
+        self.assertTrue(dl_meta["sharedMarketTranslated"])
+        # And the sourceRanks entry reflects the translated value.
+        self.assertEqual(dl1["sourceRanks"]["dlfIdp"], 11)
+
+        # The key regression assertion: the blended Hill value for an
+        # elite IDP must now be materially lower than the top-of-curve
+        # 9999, because DLF is no longer injecting its rank 1 as if it
+        # were shared-market rank 1.
+        self.assertLess(dl1["rankDerivedValue"], 9999)
+        # And the unified board agrees: the best offense player still
+        # outranks the best IDP.
+        top_off = next(
+            r for r in rows if r["canonicalName"] == "off0"
+        )
+        self.assertLess(
+            top_off["canonicalConsensusRank"], dl1["canonicalConsensusRank"]
+        )
 
     def test_dlf_disagreement_with_idptradecalc_blends_not_overrides(self):
         # IDPTradeCalc says dl1 > dl2; DLF disagrees and puts dl2 first.

--- a/tests/api/test_identity_validation.py
+++ b/tests/api/test_identity_validation.py
@@ -480,10 +480,66 @@ class TestExceptionSetCoverage(unittest.TestCase):
         self.assertIn("position_source_contradiction", flags)
         self.assertTrue(row.get("quarantined"))
 
-    def test_excepted_name_not_quarantined_by_check2(self):
-        """Names in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS bypass Check 2."""
+    def test_excepted_name_bypasses_contradiction_when_collision_also_flagged(self):
+        """Names in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS only bypass
+        ``position_source_contradiction`` when they also trip the
+        upstream cross-universe collision flag.  This is the post-hygiene
+        behaviour: the exception set is a narrow override for verified
+        collisions only, not a blanket suppression of evidence errors.
+        """
         from src.api.data_contract import OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
-        # Use a name from the exception set
+        if not OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS:
+            self.skipTest("Exception set is empty")
+        exc_name = next(iter(sorted(OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS)))
+        # Two rows that share the excepted name: one offense, one IDP.
+        # Check 1 stamps both with ``name_collision_cross_universe``,
+        # after which Check 2 is suppressed on the IDP row because it
+        # is a verified exception sitting on top of a live collision.
+        rows = [
+            {
+                "canonicalName": exc_name,
+                "displayName": exc_name,
+                "position": "QB",
+                "assetClass": "offense",
+                "playerId": None,
+                "canonicalSiteValues": {"ktc": 4200},
+                "anomalyFlags": [],
+                "confidenceBucket": "low",
+                "confidenceLabel": "",
+                "rankDerivedValue": 4200,
+            },
+            {
+                "canonicalName": exc_name,
+                "displayName": exc_name,
+                "position": "DL",
+                "assetClass": "idp",
+                "playerId": None,
+                "canonicalSiteValues": {"ktc": 685},
+                "anomalyFlags": [],
+                "confidenceBucket": "low",
+                "confidenceLabel": "",
+                "rankDerivedValue": 500,
+            },
+        ]
+        _validate_and_quarantine_rows(rows)
+        flags_qb = rows[0].get("anomalyFlags") or []
+        flags_dl = rows[1].get("anomalyFlags") or []
+        # Both rows carry the collision flag from Check 1.
+        self.assertIn("name_collision_cross_universe", flags_qb)
+        self.assertIn("name_collision_cross_universe", flags_dl)
+        # And Check 2 is suppressed on both sides — the collision flag
+        # alone is enough to quarantine; double-flagging is false-positive
+        # inflation.
+        self.assertNotIn("position_source_contradiction", flags_qb)
+        self.assertNotIn("position_source_contradiction", flags_dl)
+
+    def test_excepted_name_without_collision_still_fires_contradiction(self):
+        """Without a live cross-universe collision the exception list
+        does NOT blanket-suppress the contradiction flag.  A single IDP
+        row with only offense evidence (the pre-hygiene bug) is still a
+        data-quality error and must be quarantined.
+        """
+        from src.api.data_contract import OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
         if not OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS:
             self.skipTest("Exception set is empty")
         exc_name = next(iter(sorted(OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS)))
@@ -503,8 +559,7 @@ class TestExceptionSetCoverage(unittest.TestCase):
         ]
         _validate_and_quarantine_rows(rows)
         flags = rows[0].get("anomalyFlags") or []
-        # Exception set blocks position_source_contradiction specifically
-        self.assertNotIn("position_source_contradiction", flags)
+        self.assertIn("position_source_contradiction", flags)
 
 
 # ── Age field scaffolding ──────────────────────────────────────────────────

--- a/tests/api/test_name_join_hygiene.py
+++ b/tests/api/test_name_join_hygiene.py
@@ -1,0 +1,306 @@
+"""Regression tests for the name-join hygiene layer in the contract.
+
+These tests pin the behaviour that drove the IDP data-hygiene fix: the
+backend join path between scraper payload rows and source CSV lookup
+tables was matching by a suffix-strip-only key, which silently lost
+every player whose spelling differed in punctuation between the two
+sides — most famously T.J. Watt (``TJ Watt`` in the CSVs vs
+``T.J. Watt`` in the scraper dict).
+
+After the fix, all joins go through ``_canonical_match_key`` which is a
+thin wrapper around ``normalize_player_name`` in
+``src/utils/name_clean.py``.  The normalizer already handles the
+punctuation/diacritic/suffix/initial-collapse rules consistently with
+the identity pipeline and the adapters.
+
+Test coverage:
+
+* ``_canonical_match_key`` parity with ``normalize_player_name``.
+* ``_enrich_from_source_csvs`` joins across:
+    - periods in initials (T.J. Watt ↔ TJ Watt)
+    - periods in three-part initials (C.J. Stroud ↔ CJ Stroud)
+    - periods + disambiguation (D.J. Moore ↔ DJ Moore)
+    - generational suffix drift (Will Anderson Jr ↔ Will Anderson)
+    - diacritics (Juanyeh Thomas ↔ Juanyéh Thomas)
+* Downstream effect: a pair of rows that used to produce a single-source
+  artefact now carries both sources on the canonical site map.
+"""
+from __future__ import annotations
+
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from src.api.data_contract import (
+    _canonical_match_key,
+    _compute_unified_rankings,
+    _enrich_from_source_csvs,
+)
+from src.utils.name_clean import normalize_player_name
+
+
+def _row(name: str, pos: str, *, idp=None, dlf=None, ktc=None) -> dict:
+    sites: dict = {}
+    if idp is not None:
+        sites["idpTradeCalc"] = idp
+    if dlf is not None:
+        sites["dlfIdp"] = dlf
+    if ktc is not None:
+        sites["ktc"] = ktc
+    return {
+        "canonicalName": name,
+        "displayName": name,
+        "legacyRef": name,
+        "position": pos,
+        "assetClass": "offense" if pos in {"QB", "RB", "WR", "TE"} else "idp",
+        "values": {"overall": 0, "rawComposite": 0,
+                   "finalAdjusted": 0, "displayValue": None},
+        "canonicalSiteValues": sites,
+        "sourceCount": 1,
+    }
+
+
+class TestCanonicalMatchKey(unittest.TestCase):
+    """``_canonical_match_key`` must be a pure alias for the shared
+    ``normalize_player_name`` helper.  Any drift here re-introduces the
+    class of bugs this entire fix was designed to eliminate.
+    """
+
+    def test_mirrors_normalize_player_name(self):
+        for raw in [
+            "T.J. Watt",
+            "C.J. Stroud",
+            "D.J. Moore",
+            "Ja'Marr Chase",
+            "Marvin Harrison Jr.",
+            "Kenneth Walker III",
+            "Juanyéh Thomas",
+            "  t.j.  WATT  ",
+        ]:
+            self.assertEqual(
+                _canonical_match_key(raw),
+                normalize_player_name(raw),
+            )
+
+    def test_period_initials_collide_on_a_single_key(self):
+        # The T.J. Watt regression: both spellings must yield the same key.
+        self.assertEqual(
+            _canonical_match_key("T.J. Watt"),
+            _canonical_match_key("TJ Watt"),
+        )
+        self.assertEqual(
+            _canonical_match_key("C.J. Stroud"),
+            _canonical_match_key("CJ Stroud"),
+        )
+        self.assertEqual(
+            _canonical_match_key("D.J. Moore"),
+            _canonical_match_key("DJ Moore"),
+        )
+        self.assertEqual(
+            _canonical_match_key("A.J. Brown"),
+            _canonical_match_key("AJ Brown"),
+        )
+
+    def test_generational_suffix_drift_collides(self):
+        # Marvin Harrison Jr. ↔ Marvin Harrison, Kenneth Walker III ↔
+        # Kenneth Walker, Brian Thomas Jr ↔ Brian Thomas — all three
+        # must join on the suffix-free base.
+        self.assertEqual(
+            _canonical_match_key("Marvin Harrison Jr."),
+            _canonical_match_key("Marvin Harrison"),
+        )
+        self.assertEqual(
+            _canonical_match_key("Kenneth Walker III"),
+            _canonical_match_key("Kenneth Walker"),
+        )
+        self.assertEqual(
+            _canonical_match_key("Brian Thomas Jr"),
+            _canonical_match_key("Brian Thomas"),
+        )
+
+    def test_diacritics_fold_to_ascii(self):
+        self.assertEqual(
+            _canonical_match_key("Juanyéh Thomas"),
+            _canonical_match_key("Juanyeh Thomas"),
+        )
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(_canonical_match_key(""), "")
+        self.assertEqual(_canonical_match_key(None), "")
+
+
+class TestEnrichFromSourceCsvsJoinHygiene(unittest.TestCase):
+    """``_enrich_from_source_csvs`` must honour the canonical match key
+    on both the CSV side (when building ``csv_lookup``) and the player-
+    row side (when resolving a player to a CSV value).
+    """
+
+    def _run_with_csvs(
+        self,
+        players: list[dict],
+        csvs: dict[str, list[tuple[str, float]]],
+    ) -> None:
+        """Rewrite ``_SOURCE_CSV_PATHS`` so each source in ``csvs``
+        resolves to a temporary file inside a tempdir.
+
+        Each value in ``csvs`` is a list of ``(name, rank)`` pairs;
+        dlfIdp is loaded with signal=rank, everything else with
+        signal=value (using the rank number as the raw value).
+        """
+        with tempfile.TemporaryDirectory() as td:
+            from src.api import data_contract as dc
+
+            patched = {}
+            for source_key, rows in csvs.items():
+                p = Path(td) / f"{source_key}.csv"
+                with p.open("w", encoding="utf-8", newline="") as f:
+                    w = csv.writer(f)
+                    header = ("name", "rank") if source_key == "dlfIdp" else ("name", "value")
+                    w.writerow(header)
+                    for name, n in rows:
+                        w.writerow([name, n])
+                if source_key == "dlfIdp":
+                    patched[source_key] = {
+                        "path": str(p),
+                        "signal": "rank",
+                    }
+                else:
+                    patched[source_key] = str(p)
+            with mock.patch.object(dc, "_SOURCE_CSV_PATHS", patched):
+                _enrich_from_source_csvs(players)
+
+    def test_tj_watt_joins_across_punctuation_drift(self):
+        """The regression hero: T.J. Watt in the players dict joins to
+        TJ Watt in both the DLF and IDPTradeCalc CSVs.
+        """
+        players = [_row("T.J. Watt", "DL")]
+        self._run_with_csvs(
+            players,
+            {
+                "idpTradeCalc": [("TJ Watt", 3288)],
+                "dlfIdp": [("TJ Watt", 13)],
+            },
+        )
+        sites = players[0]["canonicalSiteValues"]
+        self.assertIn("idpTradeCalc", sites)
+        self.assertIn("dlfIdp", sites)
+        self.assertGreater(sites["idpTradeCalc"], 0)
+        self.assertGreater(sites["dlfIdp"], 0)
+
+    def test_cj_stroud_joins_across_punctuation_drift(self):
+        players = [_row("C.J. Stroud", "QB", ktc=4851)]
+        self._run_with_csvs(
+            players,
+            {
+                "idpTradeCalc": [("CJ Stroud", 4794)],
+            },
+        )
+        sites = players[0]["canonicalSiteValues"]
+        self.assertIn("idpTradeCalc", sites)
+        self.assertEqual(sites["idpTradeCalc"], 4794)
+
+    def test_dj_moore_joins_across_punctuation_drift(self):
+        players = [_row("D.J. Moore", "WR", ktc=3868)]
+        self._run_with_csvs(
+            players,
+            {
+                "idpTradeCalc": [("DJ Moore", 3909)],
+            },
+        )
+        sites = players[0]["canonicalSiteValues"]
+        self.assertIn("idpTradeCalc", sites)
+        self.assertEqual(sites["idpTradeCalc"], 3909)
+
+    def test_suffix_drift_joins_correctly(self):
+        # DLF CSV emits "Will Anderson Jr"; scraper dict has the suffix-
+        # free form.  The canonical key drops the suffix on both sides.
+        players = [_row("Will Anderson", "DL")]
+        self._run_with_csvs(
+            players,
+            {
+                "dlfIdp": [("Will Anderson Jr", 2)],
+            },
+        )
+        self.assertIn("dlfIdp", players[0]["canonicalSiteValues"])
+        self.assertGreater(
+            players[0]["canonicalSiteValues"]["dlfIdp"], 0
+        )
+
+    def test_reverse_suffix_drift_joins_correctly(self):
+        # And in reverse: scraper has the suffix, CSV does not.
+        players = [_row("Marvin Harrison Jr.", "WR")]
+        self._run_with_csvs(
+            players,
+            {
+                "idpTradeCalc": [("Marvin Harrison", 7200)],
+            },
+        )
+        self.assertIn("idpTradeCalc", players[0]["canonicalSiteValues"])
+        self.assertEqual(
+            players[0]["canonicalSiteValues"]["idpTradeCalc"], 7200
+        )
+
+    def test_diacritics_drift_joins_correctly(self):
+        players = [_row("Juanyéh Thomas", "DB")]
+        self._run_with_csvs(
+            players,
+            {
+                "idpTradeCalc": [("Juanyeh Thomas", 1100)],
+            },
+        )
+        self.assertIn("idpTradeCalc", players[0]["canonicalSiteValues"])
+
+    def test_existing_source_value_still_wins(self):
+        # When the scraper already produced an idpTradeCalc value for
+        # this player, the CSV enrichment must NOT overwrite it — even
+        # if the CSV provides a different value under a punctuation
+        # variant.
+        players = [_row("T.J. Watt", "DL", idp=4000)]
+        self._run_with_csvs(
+            players,
+            {"idpTradeCalc": [("TJ Watt", 5000)]},
+        )
+        self.assertEqual(
+            players[0]["canonicalSiteValues"]["idpTradeCalc"], 4000
+        )
+
+    def test_row_becomes_multi_source_after_hygiene_fix(self):
+        # End-to-end: a T.J. Watt row that starts with zero canonical
+        # site values gets enriched from two independent CSVs, then
+        # feeds _compute_unified_rankings with both sources present.
+        # Before the fix this row was a 1-src ghost.
+        players = [_row("T.J. Watt", "DL")]
+        # Need a backbone anchor so the shared-market ladder exists and
+        # DLF's raw rank has something to translate against.
+        players.append(_row("Myles Garrett", "DL", idp=9000))
+        self._run_with_csvs(
+            players,
+            {
+                "idpTradeCalc": [
+                    ("Myles Garrett", 9000),
+                    ("TJ Watt", 3288),
+                ],
+                "dlfIdp": [
+                    ("Aidan Hutchinson", 1),
+                    ("TJ Watt", 13),
+                ],
+            },
+        )
+        _compute_unified_rankings(players, {})
+        watt = next(
+            r for r in players if r["canonicalName"] == "T.J. Watt"
+        )
+        # Both sources show up on canonicalSiteValues
+        self.assertIn("idpTradeCalc", watt["canonicalSiteValues"])
+        self.assertIn("dlfIdp", watt["canonicalSiteValues"])
+        # And both appear on sourceRanks, so the player is NOT single-source.
+        self.assertIn("idpTradeCalc", watt["sourceRanks"])
+        self.assertIn("dlfIdp", watt["sourceRanks"])
+        self.assertFalse(watt["isSingleSource"])
+        self.assertEqual(watt["sourceCount"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/canonical/test_idp_backbone.py
+++ b/tests/canonical/test_idp_backbone.py
@@ -156,6 +156,111 @@ class TestTranslatePositionRank(unittest.TestCase):
         self.assertEqual(method, TRANSLATION_EXTRAPOLATED)
 
 
+class TestSharedMarketIdpLadder(unittest.TestCase):
+    """The shared-market IDP ladder is the crosswalk that keeps
+    IDP-only expert boards (e.g. DLF) from pretending their rank 1 is
+    the overall rank 1 of the shared offense+IDP market.
+
+    The ladder is built from the backbone source's combined
+    offense+IDP value pool: the i-th entry holds the combined-pool
+    rank of the i-th best IDP in the backbone.  These tests pin the
+    builder math that ``src/api/data_contract.py`` relies on to
+    translate DLF's raw IDP rank through
+    ``translate_position_rank(raw_rank, shared_market_idp_ladder)``.
+    """
+
+    def test_empty_when_offense_positions_not_supplied(self):
+        rows = [
+            {"canonicalName": "dl1", "position": "DL",
+             "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "qb1", "position": "QB",
+             "canonicalSiteValues": {"idpTC": 95}},
+        ]
+        bb = build_backbone_from_rows(rows, source_key="idpTC")
+        self.assertEqual(bb.shared_market_idp_ladder, [])
+        self.assertEqual(bb.shared_market_depth, 0)
+        self.assertEqual(bb.shared_idp_ladder(), [])
+
+    def test_shared_ladder_reflects_combined_pool_ordering(self):
+        # IDPTC combined-pool order: qb(95) > dl1(90) > wr1(85) > lb1(80) > db1(70)
+        rows = [
+            {"canonicalName": "qb1", "position": "QB",
+             "canonicalSiteValues": {"idpTC": 95}},
+            {"canonicalName": "dl1", "position": "DL",
+             "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "wr1", "position": "WR",
+             "canonicalSiteValues": {"idpTC": 85}},
+            {"canonicalName": "lb1", "position": "LB",
+             "canonicalSiteValues": {"idpTC": 80}},
+            {"canonicalName": "db1", "position": "DB",
+             "canonicalSiteValues": {"idpTC": 70}},
+        ]
+        bb = build_backbone_from_rows(
+            rows,
+            source_key="idpTC",
+            offense_positions={"QB", "RB", "WR", "TE", "PICK"},
+        )
+        # Combined pool has 5 entries, IDPs sit at ranks 2, 4, 5.
+        self.assertEqual(bb.shared_market_depth, 5)
+        self.assertEqual(bb.shared_market_idp_ladder, [2, 4, 5])
+        # The position ladders are also rebuilt but these are built
+        # from the IDP-only sort (1..N in IDP order), unchanged.
+        self.assertEqual(bb.ladder_for("DL"), [1])
+        self.assertEqual(bb.ladder_for("LB"), [2])
+        self.assertEqual(bb.ladder_for("DB"), [3])
+        self.assertEqual(bb.depth, 3)
+
+    def test_shared_ladder_crosswalks_through_translate_position_rank(self):
+        # With the shared-market ladder = [2, 4, 5], translating DLF's
+        # raw IDP ranks 1/2/3 must yield 2/4/5 respectively.
+        rows = [
+            {"canonicalName": "qb1", "position": "QB",
+             "canonicalSiteValues": {"idpTC": 95}},
+            {"canonicalName": "dl1", "position": "DL",
+             "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "wr1", "position": "WR",
+             "canonicalSiteValues": {"idpTC": 85}},
+            {"canonicalName": "lb1", "position": "LB",
+             "canonicalSiteValues": {"idpTC": 80}},
+            {"canonicalName": "db1", "position": "DB",
+             "canonicalSiteValues": {"idpTC": 70}},
+        ]
+        bb = build_backbone_from_rows(
+            rows,
+            source_key="idpTC",
+            offense_positions={"QB", "WR"},
+        )
+        ladder = bb.shared_idp_ladder()
+        self.assertEqual(translate_position_rank(1, ladder),
+                         (2, TRANSLATION_EXACT))
+        self.assertEqual(translate_position_rank(2, ladder),
+                         (4, TRANSLATION_EXACT))
+        self.assertEqual(translate_position_rank(3, ladder),
+                         (5, TRANSLATION_EXACT))
+        # Past the ladder extrapolates monotonically.
+        syn, method = translate_position_rank(4, ladder)
+        self.assertEqual(method, TRANSLATION_EXTRAPOLATED)
+        self.assertGreater(syn, 5)
+
+    def test_shared_ladder_is_empty_without_offense_rows(self):
+        # Only IDP rows supplied, offense_positions still provided —
+        # the combined-pool collapses to the IDP pool, so the ladder
+        # is [1,2,3,...].
+        rows = [
+            {"canonicalName": "dl1", "position": "DL",
+             "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "lb1", "position": "LB",
+             "canonicalSiteValues": {"idpTC": 80}},
+        ]
+        bb = build_backbone_from_rows(
+            rows,
+            source_key="idpTC",
+            offense_positions={"QB"},
+        )
+        self.assertEqual(bb.shared_market_idp_ladder, [1, 2])
+        self.assertEqual(bb.shared_market_depth, 2)
+
+
 class TestCoverageWeight(unittest.TestCase):
     def test_none_depth_returns_declared_weight_unchanged(self):
         self.assertEqual(coverage_weight(1.0, None), 1.0)


### PR DESCRIPTION
The trust layer was producing two related classes of false signals on
the IDP board:

1. Silent join misses on punctuation drift. The enrichment path in
   `_enrich_from_source_csvs` used a suffix-strip-only key
   (`_strip_name_suffix(name).lower()`) to match scraper payload rows
   against committed CSV exports. Any player whose spelling differed
   in punctuation between the two sides was dropped on the floor —
   T.J. Watt was the headline case (stored as `T.J. Watt` in the
   scraper dict but `TJ Watt` in both `dlfIdp.csv` and
   `idpTradeCalc.csv`). He landed on the board as a 1-src ghost even
   though both feeds had him.

2. Structural DLF overweighting. DLF was registered as `overall_idp`
   and its raw IDP ordinal rank was passed directly to the Hill curve.
   Because DLF only ranks IDPs, its rank 1 was being treated as
   shared-market rank 1 → Hill value 9999, inflating every elite IDP
   to "as valuable as the best offense player on the retail market".
   IDPTradeCalc was not affected because it prices offense + IDP on a
   single 0-9999 scale, so its combined-pool rank for the best IDP
   naturally reflects the shared economy.

This commit addresses both issues:

* `_canonical_match_key` wraps `normalize_player_name` (diacritics,
  periods, suffixes, apostrophes, initials collapse) and is used for
  every cross-source name join in `_enrich_from_source_csvs` and the
  contract-level name-collision detector. `tests/api/test_name_join_hygiene.py`
  pins the join behaviour for T.J. Watt, C.J. Stroud, D.J. Moore,
  Marvin Harrison Jr, Juanyéh Thomas, and T.J. Edwards.

* `IdpBackbone` gains a `shared_market_idp_ladder` field built from the
  backbone source's combined offense+IDP value pool. Any source
  flagged `needs_shared_market_translation=True` in `_RANKING_SOURCES`
  (today just `dlfIdp`) has its raw IDP ordinal rank translated
  through the ladder via `translate_position_rank` — exactly the same
  mechanism position-only IDP lists already use for their per-position
  ladders. DLF rank 1 now maps to the combined-pool rank of the best
  IDP in IDPTC (~44 in live data), producing the right Hill-curve
  input while preserving DLF's rawRank on `sourceRankMeta` for
  transparency.

* `_compute_unified_rankings` now refreshes `sourceCount`,
  `isSingleSource`, and `sourcePresence` for every ranked row, not
  just rows inside the top-800 cap, so out-of-limit IDPs can't carry
  stale pre-enrichment counts.

* `OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS` is narrowed to a single
  verified collision (Josh Johnson) and only applies when the row
  also carries `name_collision_cross_universe` from Check 1. The
  previous behaviour was an unconditional blanket-suppression that
  could mask real evidence contradictions. New identity-validation
  tests pin both the conditional bypass and the "no-collision-still-
  fires" case.

* Frontend mirror in `frontend/lib/dynasty-data.js`:
    - `normalizePlayerName` reproduces the backend join semantics for
      offline fallbacks.
    - `buildIdpBackbone(rows, sourceKey, includeSharedMarket)` builds
      the shared-market ladder when the backbone declares overall
      offense in its extraScopes.
    - `computeUnifiedRanks` crosswalks DLF through the ladder when
      `needsSharedMarketTranslation` is set.
    - `sourceRankMeta.<source>.sharedMarketTranslated` reports whether
      the translation ran on that row.

* `docs/trust-edge-handoff.md` is updated to describe the normalised
  join key, the shared-market crosswalk, and the conditional exception
  list.

Results on the live 2026-04-13 payload:
  - T.J. Watt: 1 → 2 sources (canonicalConsensusRank 279 → 177)
  - T.J. Edwards: 1 → 2 sources (547 → 304)
  - D.J. Moore / C.J. Stroud: both now double-sourced across KTC + IDPTC
  - suspicious_disagreement flag count: 198 → 115 (-42%)
  - near_name_value_mismatch flag count: 50 → 31 (-38%)
  - Top IDP (Hutchinson) sits at consensus rank 44, not 1 — behind the
    top offense starters but still at a ~5100 Hill value; the best
    offense still outranks the best IDP on the unified board.

Test results:
  - 934 / 934 Python tests pass (13 new in test_name_join_hygiene.py,
    4 new in test_idp_backbone.py, 2 new in test_dlf_source.py,
    1 updated in test_identity_validation.py)
  - 294 / 294 frontend tests pass (6 new in dynasty-data.test.js,
    1 new in scope-aware-rankings.test.js, 1 updated G.DLF test)

https://claude.ai/code/session_01PXf4AHEopv5BobbHPBB192