### PR TITLE
Fix pick values in trade history & roster breakdown; default to 1-year trade window

### DIFF
--- a/frontend/__tests__/trade-logic.test.js
+++ b/frontend/__tests__/trade-logic.test.js
@@ -569,6 +569,43 @@ describe("resolvePickRow", () => {
     expect(row.values.full).toBe(7700);
   });
 
+  it("prefers pickAliases over a suppressed generic-tier row", () => {
+    // Backend kept the suppressed generic-tier row on the board (with
+    // stale value 1) so name search still resolves it, but pickAliases
+    // authoritatively redirects to the slot-specific row (value 7700).
+    const m = new Map();
+    m.set("2026 mid 1st", {
+      name: "2026 Mid 1st",
+      pos: "PICK",
+      values: { full: 1 },
+      raw: { pickGenericSuppressed: true },
+    });
+    m.set("2026 pick 1.06", { name: "2026 Pick 1.06", pos: "PICK", values: { full: 7700 } });
+    const aliases = { "2026 Mid 1st": "2026 Pick 1.06" };
+    const row = resolvePickRow("2026 Mid 1st (own)", m, aliases);
+    expect(row).not.toBeNull();
+    expect(row.name).toBe("2026 Pick 1.06");
+    expect(row.values.full).toBe(7700);
+  });
+
+  it("skips suppressed generic-tier rows during direct lookup fallback", () => {
+    // No pickAliases available — resolver must still skip the
+    // suppressed row and continue to the slot-specific candidate that
+    // buildPickLookupCandidates derives from the tier-centre slot.
+    const m = new Map();
+    m.set("2026 mid 1st", {
+      name: "2026 Mid 1st",
+      pos: "PICK",
+      values: { full: 1 },
+      raw: { pickGenericSuppressed: true },
+    });
+    m.set("2026 pick 1.06", { name: "2026 Pick 1.06", pos: "PICK", values: { full: 7700 } });
+    const row = resolvePickRow("2026 Mid 1st (own)", m);
+    expect(row).not.toBeNull();
+    expect(row.name).toBe("2026 Pick 1.06");
+    expect(row.values.full).toBe(7700);
+  });
+
   it("returns null when nothing matches", () => {
     const lookup = mkLookup([["2026 Pick 1.04", 9000]]);
     expect(resolvePickRow("2099 1.01", lookup)).toBeNull();

--- a/frontend/__tests__/trade-logic.test.js
+++ b/frontend/__tests__/trade-logic.test.js
@@ -606,9 +606,59 @@ describe("resolvePickRow", () => {
     expect(row.values.full).toBe(7700);
   });
 
+  it("does not apply alias redirects to derived tier candidates for slot inputs", () => {
+    // Sleeper emits a slot label.  pickAliases contains generic-tier
+    // redirects that would point derived candidates at the WRONG slot
+    // (Early→1.02, Mid→1.06, Late→1.10).  The resolver must only
+    // apply aliases to the input label itself, not to synthesized
+    // derived candidates, or slot picks get rewritten to the
+    // tier-centre slot.
+    const m = new Map();
+    m.set("2026 pick 1.04", { name: "2026 Pick 1.04", pos: "PICK", values: { full: 9200 } });
+    m.set("2026 pick 1.02", { name: "2026 Pick 1.02", pos: "PICK", values: { full: 9500 } });
+    const aliases = { "2026 Early 1st": "2026 Pick 1.02" };
+    const row = resolvePickRow("2026 1.04 (from Team X)", m, aliases);
+    expect(row).not.toBeNull();
+    expect(row.name).toBe("2026 Pick 1.04");
+    expect(row.values.full).toBe(9200);
+  });
+
+  it("resolves round 6 slot picks", () => {
+    const lookup = mkLookup([["2026 Pick 6.04", 420]]);
+    const row = resolvePickRow("2026 6.04 (own)", lookup);
+    expect(row).not.toBeNull();
+    expect(row.name).toBe("2026 Pick 6.04");
+    expect(row.values.full).toBe(420);
+  });
+
+  it("resolves round 6 tier labels", () => {
+    const lookup = mkLookup([["2027 Mid 6th", 280]]);
+    const row = resolvePickRow("2027 Mid 6th (own)", lookup);
+    expect(row).not.toBeNull();
+    expect(row.values.full).toBe(280);
+  });
+
   it("returns null when nothing matches", () => {
     const lookup = mkLookup([["2026 Pick 1.04", 9000]]);
     expect(resolvePickRow("2099 1.01", lookup)).toBeNull();
+  });
+});
+
+describe("parsePickToken round 6", () => {
+  it("parses slot format round 6", () => {
+    const p = parsePickToken("2026 6.04");
+    expect(p).not.toBeNull();
+    expect(p.year).toBe("2026");
+    expect(p.round).toBe("6th");
+    expect(p.slot).toBe(4);
+  });
+
+  it("parses tier label round 6", () => {
+    const p = parsePickToken("2027 Mid 6th");
+    expect(p).not.toBeNull();
+    expect(p.year).toBe("2027");
+    expect(p.round).toBe("6th");
+    expect(p.tier).toBe("mid");
   });
 });
 

--- a/frontend/__tests__/trade-logic.test.js
+++ b/frontend/__tests__/trade-logic.test.js
@@ -24,6 +24,8 @@ import {
   filterPickerRows,
   getPlayerEdge,
   parsePickToken,
+  buildPickLookupCandidates,
+  resolvePickRow,
   findBalancers,
   verdictBarPosition,
 } from "@/lib/trade-logic";
@@ -505,6 +507,71 @@ describe("parsePickToken", () => {
 
   it("returns null for invalid", () => {
     expect(parsePickToken("not a pick")).toBeNull();
+  });
+});
+
+describe("buildPickLookupCandidates", () => {
+  it("emits 'Pick' canonical for Sleeper slot labels with (from X)", () => {
+    const c = buildPickLookupCandidates("2026 1.04 (from Chargers Team Doctor)");
+    expect(c).toContain("2026 pick 1.04");
+    expect(c).toContain("2026 1.04");
+    // Also emits tier fallback
+    expect(c).toContain("2026 early 1st");
+  });
+
+  it("handles (own) annotation", () => {
+    const c = buildPickLookupCandidates("2026 5.04 (own)");
+    expect(c).toContain("2026 pick 5.04");
+    expect(c).toContain("2026 5.04");
+  });
+
+  it("handles tier-based labels for future years", () => {
+    const c = buildPickLookupCandidates("2027 Mid 1st (own)");
+    expect(c).toContain("2027 mid 1st");
+    // Tier-centre slot fallback for years that DO have slot rows
+    expect(c).toContain("2027 pick 1.06");
+  });
+
+  it("returns an empty list for blank input", () => {
+    expect(buildPickLookupCandidates("")).toEqual([]);
+    expect(buildPickLookupCandidates(null)).toEqual([]);
+  });
+});
+
+describe("resolvePickRow", () => {
+  function mkLookup(entries) {
+    const m = new Map();
+    for (const [name, value] of entries) {
+      m.set(name.toLowerCase(), { name, pos: "PICK", values: { full: value } });
+    }
+    return m;
+  }
+
+  it("resolves Sleeper slot label against rankings 'Pick' row", () => {
+    const lookup = mkLookup([["2026 Pick 1.04", 9123]]);
+    const row = resolvePickRow("2026 1.04 (from Rage Against The Achane)", lookup);
+    expect(row).not.toBeNull();
+    expect(row.values.full).toBe(9123);
+  });
+
+  it("resolves tier label against tier-based rankings row", () => {
+    const lookup = mkLookup([["2027 Mid 1st", 6800]]);
+    const row = resolvePickRow("2027 Mid 1st (own)", lookup);
+    expect(row).not.toBeNull();
+    expect(row.values.full).toBe(6800);
+  });
+
+  it("uses pickAliases map when direct candidates miss", () => {
+    const lookup = mkLookup([["2026 Pick 1.06", 7700]]);
+    const aliases = { "2026 Mid 1st": "2026 Pick 1.06" };
+    const row = resolvePickRow("2026 Mid 1st (own)", lookup, aliases);
+    expect(row).not.toBeNull();
+    expect(row.values.full).toBe(7700);
+  });
+
+  it("returns null when nothing matches", () => {
+    const lookup = mkLookup([["2026 Pick 1.04", 9000]]);
+    expect(resolvePickRow("2099 1.01", lookup)).toBeNull();
   });
 });
 

--- a/frontend/app/league/page.jsx
+++ b/frontend/app/league/page.jsx
@@ -70,9 +70,10 @@ export default function LeaguePage() {
 // ── Power Rankings Heatmap ──────────────────────────────────────────────
 function PowerRankingsHeatmap({ rows, rawData, sleeperTeams, settings, onSelectTeam }) {
   const playerMeta = useMemo(() => buildPlayerMetaMap(rows), [rows]);
+  const pickAliases = rawData?.pickAliases || null;
   const teams = useMemo(
-    () => buildAllTeamSummaries(sleeperTeams, playerMeta, rows, "full"),
-    [sleeperTeams, playerMeta, rows],
+    () => buildAllTeamSummaries(sleeperTeams, playerMeta, rows, "full", pickAliases),
+    [sleeperTeams, playerMeta, rows, pickAliases],
   );
   const posRanks = useMemo(() => computePositionRanks(teams), [teams]);
   const n = sleeperTeams.length;
@@ -145,9 +146,10 @@ function TeamBreakdown({ rows, rawData, sleeperTeams, settings, update }) {
   const [viewMode, setViewMode] = useState("grouped");
 
   const playerMeta = useMemo(() => buildPlayerMetaMap(rows), [rows]);
+  const pickAliases = rawData?.pickAliases || null;
   const allTeams = useMemo(
-    () => buildAllTeamSummaries(sleeperTeams, playerMeta, rows, "full"),
-    [sleeperTeams, playerMeta, rows],
+    () => buildAllTeamSummaries(sleeperTeams, playerMeta, rows, "full", pickAliases),
+    [sleeperTeams, playerMeta, rows, pickAliases],
   );
   const posRanks = useMemo(() => computePositionRanks(allTeams), [allTeams]);
 

--- a/frontend/app/rosters/page.jsx
+++ b/frontend/app/rosters/page.jsx
@@ -33,13 +33,14 @@ export default function RostersPage() {
   );
 
   const sleeperTeams = rawData?.sleeper?.teams || [];
+  const pickAliases = rawData?.pickAliases || null;
   const myTeam = settings.selectedTeam || "";
 
   const playerMeta = useMemo(() => buildPlayerMetaMap(rows), [rows]);
 
   const teams = useMemo(
-    () => buildAllTeamSummaries(sleeperTeams, playerMeta, rows, valueMode),
-    [sleeperTeams, playerMeta, rows, valueMode],
+    () => buildAllTeamSummaries(sleeperTeams, playerMeta, rows, valueMode, pickAliases),
+    [sleeperTeams, playerMeta, rows, valueMode, pickAliases],
   );
 
   // Sort by active group totals
@@ -70,8 +71,8 @@ export default function RostersPage() {
   );
 
   const teamTiers = useMemo(
-    () => scoreTeamTiers(sleeperTeams, playerMeta, rows),
-    [sleeperTeams, playerMeta, rows],
+    () => scoreTeamTiers(sleeperTeams, playerMeta, rows, pickAliases),
+    [sleeperTeams, playerMeta, rows, pickAliases],
   );
 
   function toggleGroup(g) {

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -24,7 +24,7 @@ export const SETTINGS_DEFAULTS = {
   siteWeights: {},
 
   // Trade history
-  tradeHistoryWindowDays: 120,       // rolling window for trade analysis
+  tradeHistoryWindowDays: 365,       // rolling 1-year window for trade analysis
 
   // Selected team (global)
   selectedTeam: "",                  // Sleeper team name selection

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -3,7 +3,7 @@
  * Pure functions, no React dependencies.
  */
 
-import { effectiveValue, powerWeightedTotal, TRADE_ALPHA, parsePickToken, getPlayerEdge } from "@/lib/trade-logic";
+import { effectiveValue, powerWeightedTotal, TRADE_ALPHA, parsePickToken, getPlayerEdge, resolvePickRow } from "@/lib/trade-logic";
 import { normalizePos } from "@/lib/dynasty-data";
 
 // ── Position Group Helpers ──────────────────────────────────────────────
@@ -88,25 +88,44 @@ export function buildRowLookup(rows) {
 // ── Resolve Trade Item → Row Value ──────────────────────────────────────
 /**
  * Resolve a trade item name to a value using the rows from useDynastyData.
- * Resolve a trade item name to a value using the rows from useDynastyData.
+ *
+ * Picks need a multi-candidate lookup because Sleeper labels them as
+ * "2026 1.04 (from Team X)" or "2027 Mid 1st (own)" while rankings
+ * stores canonical rows as "2026 Pick 1.04" or "2027 Mid 1st".  The
+ * `resolvePickRow` helper walks parsed candidates + backend alias map
+ * so pick values surface correctly in trade history.
  */
-export function resolveTradeItemValue(itemName, rowLookup, posMap) {
+export function resolveTradeItemValue(itemName, rowLookup, posMap, pickAliases) {
   if (!itemName) return { name: itemName, value: 0, pos: "", isPick: false };
   const name = String(itemName).trim();
   const isPick = !!parsePickToken(name);
+
+  if (isPick) {
+    const row = resolvePickRow(name, rowLookup, pickAliases);
+    if (row) {
+      return {
+        name,
+        value: row.values?.full || 0,
+        pos: "PICK",
+        isPick: true,
+      };
+    }
+    // No match — fall through to empty pick result below.
+    return { name, value: 0, pos: "PICK", isPick: true };
+  }
+
   const key = name.toLowerCase();
   const row = rowLookup.get(key);
-
   if (row) {
     return {
       name,
       value: row.values?.full || 0,
-      pos: isPick ? "PICK" : (row.pos || ""),
-      isPick,
+      pos: row.pos || "",
+      isPick: false,
     };
   }
 
-  // Try without parenthetical (e.g. "2026 1st (from Team)")
+  // Try without parenthetical (e.g. "Jameson Williams (some annotation)")
   const stripped = name.replace(/\s*\([^)]*\)\s*$/, "").trim();
   if (stripped !== name) {
     const strippedRow = rowLookup.get(stripped.toLowerCase());
@@ -114,15 +133,15 @@ export function resolveTradeItemValue(itemName, rowLookup, posMap) {
       return {
         name,
         value: strippedRow.values?.full || 0,
-        pos: isPick ? "PICK" : (strippedRow.pos || ""),
-        isPick,
+        pos: strippedRow.pos || "",
+        isPick: false,
       };
     }
   }
 
   // Fallback — check position map
-  const pos = isPick ? "PICK" : (posMap?.[name] || "");
-  return { name, value: 0, pos, isPick };
+  const pos = posMap?.[name] || "";
+  return { name, value: 0, pos, isPick: false };
 }
 
 // ── Normalize Trade Asset Label ─────────────────────────────────────────
@@ -152,6 +171,7 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
 
   const rowLookup = buildRowLookup(rows);
   const posMap = rawData?.sleeper?.positions || {};
+  const pickAliases = rawData?.pickAliases || null;
   const teamScores = {};
   const analyzed = [];
 
@@ -166,7 +186,7 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
       const items = [];
 
       for (const rawItem of getTradeSideItemLabels(side?.got)) {
-        const resolved = resolveTradeItemValue(rawItem, rowLookup, posMap);
+        const resolved = resolveTradeItemValue(rawItem, rowLookup, posMap, pickAliases);
         const safeVal = Number.isFinite(resolved.value) ? Math.max(0, resolved.value) : 0;
         linearTotal += safeVal;
         weightedTotal += Math.pow(Math.max(safeVal, 1), alpha);
@@ -249,9 +269,10 @@ function sumTopN(values, n) {
  * @param {object} playerMeta - from buildPlayerMetaMap
  * @param {object[]} rows - all rows for pick value lookup
  * @param {string} valueMode - "full" | "players" | "starters"
+ * @param {object} [pickAliases] - optional backend alias map
  * @returns {{ total, byGroup, playerDetails, pickDetails }}
  */
-export function buildTeamValueBreakdown(team, playerMeta, rows, valueMode = "full") {
+export function buildTeamValueBreakdown(team, playerMeta, rows, valueMode = "full", pickAliases = null) {
   const byGroup = {};
   POS_GROUPS.forEach((g) => { byGroup[g] = 0; });
   const playerDetails = [];
@@ -277,12 +298,14 @@ export function buildTeamValueBreakdown(team, playerMeta, rows, valueMode = "ful
     if (buckets[pm.group]) buckets[pm.group].push(pm.meta);
   }
 
-  // Resolve pick values
+  // Resolve pick values using multi-candidate lookup so Sleeper labels
+  // like "2026 1.04 (from Team X)" resolve against rankings rows stored
+  // as "2026 Pick 1.04".
   if (valueMode === "full") {
     const pickSources = teamPicks.length > 0 ? teamPicks : teamPlayers.filter((p) => parsePickToken(p));
     for (const pickName of pickSources) {
       if (!parsePickToken(pickName)) continue;
-      const row = rowLookup.get(pickName.toLowerCase());
+      const row = resolvePickRow(pickName, rowLookup, pickAliases);
       const val = row ? (row.values?.full || 0) : 0;
       pickValue += val;
       if (val > 0) {
@@ -308,9 +331,9 @@ export function buildTeamValueBreakdown(team, playerMeta, rows, valueMode = "ful
  * Build summary data for all teams in the league.
  * Returns sorted array of team objects with value breakdowns.
  */
-export function buildAllTeamSummaries(sleeperTeams, playerMeta, rows, valueMode = "full") {
+export function buildAllTeamSummaries(sleeperTeams, playerMeta, rows, valueMode = "full", pickAliases = null) {
   const teams = (sleeperTeams || []).map((team) => {
-    const breakdown = buildTeamValueBreakdown(team, playerMeta, rows, valueMode);
+    const breakdown = buildTeamValueBreakdown(team, playerMeta, rows, valueMode, pickAliases);
     return {
       name: team.name,
       roster_id: team.roster_id,
@@ -474,7 +497,21 @@ export function analyzeTradeTendencies(rawData, rows) {
 
   const rowLookup = buildRowLookup(rows);
   const posMap = rawData?.sleeper?.positions || {};
+  const pickAliases = rawData?.pickAliases || null;
   const managerStats = {};
+
+  // Shared resolver that handles both players and pick labels, so trade
+  // tendency totals include pick value rather than silently dropping
+  // picks that fail a direct rowLookup hit.
+  const resolveAssetValue = (name) => {
+    if (!name) return 0;
+    if (parsePickToken(name)) {
+      const row = resolvePickRow(name, rowLookup, pickAliases);
+      return row ? (row.values?.full || 0) : 0;
+    }
+    const row = rowLookup.get(String(name).toLowerCase());
+    return row ? (row.values?.full || 0) : 0;
+  };
 
   for (const trade of trades) {
     if (!trade.sides || trade.sides.length < 2) continue;
@@ -489,12 +526,10 @@ export function analyzeTradeTendencies(rawData, rows) {
       let gotTotal = 0;
       let gaveTotal = 0;
       for (const name of side.got || []) {
-        const row = rowLookup.get((name || "").toLowerCase());
-        if (row) gotTotal += row.values?.full || 0;
+        gotTotal += resolveAssetValue(name);
       }
       for (const name of side.gave || []) {
-        const row = rowLookup.get((name || "").toLowerCase());
-        if (row) gaveTotal += row.values?.full || 0;
+        gaveTotal += resolveAssetValue(name);
       }
       stats.totalGot += gotTotal;
       stats.totalGiven += gaveTotal;
@@ -528,7 +563,7 @@ export function analyzeTradeTendencies(rawData, rows) {
  * Depth = total minus starters, weighted 20%.
  * Pick surplus penalized at -10% (rebuild signal).
  */
-export function scoreTeamTiers(sleeperTeams, playerMeta, rows) {
+export function scoreTeamTiers(sleeperTeams, playerMeta, rows, pickAliases = null) {
   const rowLookup = buildRowLookup(rows);
 
   const scored = (sleeperTeams || []).map((team) => {
@@ -546,9 +581,10 @@ export function scoreTeamTiers(sleeperTeams, playerMeta, rows) {
       }
     }
 
-    // Picks
+    // Picks — use multi-candidate lookup so Sleeper labels resolve
+    // against canonical rankings rows.
     for (const pickName of team.picks || []) {
-      const row = rowLookup.get((pickName || "").toLowerCase());
+      const row = resolvePickRow(pickName, rowLookup, pickAliases);
       const val = row ? (row.values?.full || 0) : 0;
       totalValue += val;
       pickValue += val;

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -166,7 +166,7 @@ export function getPlayerEdge(row) {
 }
 
 // ── Pick Token Parsing ───────────────────────────────────────────────────
-const ROUND_LABELS = { "1": "1st", "2": "2nd", "3": "3rd", "4": "4th", "5": "5th" };
+const ROUND_LABELS = { "1": "1st", "2": "2nd", "3": "3rd", "4": "4th", "5": "5th", "6": "6th" };
 
 /**
  * Parse a pick token string into structured parts.
@@ -186,7 +186,7 @@ export function parsePickToken(token) {
   }
 
   // "2026 early 1st" or "2026 1st" format
-  const labelMatch = s.match(/^(\d{4})\s+(early|mid|late)?\s*(1st|2nd|3rd|4th|5th)/i);
+  const labelMatch = s.match(/^(\d{4})\s+(early|mid|late)?\s*(1st|2nd|3rd|4th|5th|6th)/i);
   if (labelMatch) {
     return { year: labelMatch[1], round: labelMatch[3].toLowerCase(), tier: (labelMatch[2] || "").toLowerCase() || null, slot: null };
   }
@@ -212,8 +212,9 @@ const TIER_CENTRE_SLOT = { early: 2, mid: 6, late: 10 };
 
 // Round numeric digit ("1") for the round label ("1st").  Kept here so
 // both slot-based and tier-based candidates can be generated without
-// re-deriving the mapping at every call site.
-const ROUND_NUM = { "1st": 1, "2nd": 2, "3rd": 3, "4th": 4, "5th": 5 };
+// re-deriving the mapping at every call site.  Mirrors the backend
+// draft_rounds range in Dynasty Scraper.py (1..6).
+const ROUND_NUM = { "1st": 1, "2nd": 2, "3rd": 3, "4th": 4, "5th": 5, "6th": 6 };
 
 /**
  * Given a raw pick label from any source (Sleeper roster, Sleeper trade
@@ -306,9 +307,14 @@ function isSuppressedGenericPickRow(row) {
  * a null return means the pick genuinely has no known value.
  *
  * Resolution order is deliberate:
- *   1. `pickAliases` lookup (authoritative for suppressed generic tiers).
- *      Without this, step 2 could return a suppressed row with stale
- *      values before the alias-to-slot redirect is ever consulted.
+ *   1. `pickAliases` lookup against the **input** label (raw or stripped
+ *      of its "(from X)" / "(own)" annotation).  The alias table only
+ *      contains entries for generic tier labels whose slot-specific
+ *      siblings exist on the board (e.g. "2026 Mid 1st" →
+ *      "2026 Pick 1.06").  Applying aliases to the input — not to the
+ *      synthesized derived candidates — prevents a slot input like
+ *      "2026 1.04" from being rewritten to the tier-centre slot via
+ *      its derived "2026 Early 1st" candidate.
  *   2. Direct `rowLookup` walk over candidate names, skipping any
  *      suppressed generic-tier row so the fallback chain continues to a
  *      valid slot-specific sibling.  This keeps the resolver robust
@@ -322,30 +328,37 @@ function isSuppressedGenericPickRow(row) {
 export function resolvePickRow(rawLabel, rowLookup, pickAliases) {
   if (!rawLabel || !rowLookup) return null;
 
-  const candidates = buildPickLookupCandidates(rawLabel);
+  const raw = String(rawLabel).trim();
+  const stripped = raw.replace(/\s*\([^)]*\)\s*$/, "").trim();
 
-  // 1) Backend alias map first.  Walk every candidate through the alias
-  //    table so annotated/stripped/tier forms all redirect to the
-  //    slot-specific canonical row when the backend has flagged the
-  //    generic tier as suppressed.
+  // 1) Backend alias map — only applied to the input label (raw or
+  //    stripped), never to synthesized derived candidates.  This is
+  //    the critical distinction: the alias table redirects generic
+  //    tier labels to slot-specific canonical rows, so applying it to
+  //    derived tier candidates (e.g. the "2026 Early 1st" that
+  //    buildPickLookupCandidates synthesizes for a "2026 1.04" input)
+  //    would systematically misroute slot picks to the tier-centre
+  //    slot.  Only trust the alias map for labels the caller actually
+  //    provided.
   if (pickAliases && typeof pickAliases === "object") {
-    const aliasLower = new Map();
+    const inputForms = new Set();
+    inputForms.add(raw.toLowerCase());
+    if (stripped) inputForms.add(stripped.toLowerCase());
     for (const [k, v] of Object.entries(pickAliases)) {
-      if (typeof k === "string" && typeof v === "string") {
-        aliasLower.set(k.toLowerCase(), v.toLowerCase());
-      }
-    }
-    for (const key of candidates) {
-      const target = aliasLower.get(key);
-      if (!target) continue;
-      const row = rowLookup.get(target);
+      if (typeof k !== "string" || typeof v !== "string") continue;
+      if (!inputForms.has(k.toLowerCase())) continue;
+      const row = rowLookup.get(v.toLowerCase());
       if (row && !isSuppressedGenericPickRow(row)) return row;
+      // Alias target matched but row is absent or suppressed — fall
+      // through to direct lookup; don't keep iterating the alias map.
+      break;
     }
   }
 
   // 2) Direct candidate lookup.  Skip suppressed generic-tier rows so a
   //    later candidate (typically the slot-specific "Pick N.NN" form)
   //    gets a chance to resolve even without a pickAliases map.
+  const candidates = buildPickLookupCandidates(raw);
   for (const key of candidates) {
     const row = rowLookup.get(key);
     if (!row) continue;

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -286,10 +286,33 @@ export function buildPickLookupCandidates(rawLabel) {
 }
 
 /**
+ * True if a row is a suppressed generic-tier pick — one that the backend
+ * kept on the legacy board for name-search purposes but cleared of
+ * ranking fields because a slot-specific sibling exists (e.g. "2026 Mid
+ * 1st" when "2026 Pick 1.06" is the authoritative row).  These rows
+ * can still carry stale values from the legacy pipeline, so callers
+ * must treat them as non-authoritative and consult `pickAliases` or
+ * slot-specific candidates instead.
+ */
+function isSuppressedGenericPickRow(row) {
+  if (!row) return false;
+  return Boolean(row.pickGenericSuppressed || row.raw?.pickGenericSuppressed);
+}
+
+/**
  * Resolve a pick label (raw or annotated) to a row using rowLookup and
  * optional backend-authored pickAliases map.  Returns null if no
  * candidate resolves.  Callers should NOT fall back to an untyped 0 —
  * a null return means the pick genuinely has no known value.
+ *
+ * Resolution order is deliberate:
+ *   1. `pickAliases` lookup (authoritative for suppressed generic tiers).
+ *      Without this, step 2 could return a suppressed row with stale
+ *      values before the alias-to-slot redirect is ever consulted.
+ *   2. Direct `rowLookup` walk over candidate names, skipping any
+ *      suppressed generic-tier row so the fallback chain continues to a
+ *      valid slot-specific sibling.  This keeps the resolver robust
+ *      even when `pickAliases` is missing (stale data, older contract).
  *
  * @param {string} rawLabel - raw pick label (any source)
  * @param {Map<string, object>} rowLookup - lowercased name → row
@@ -301,16 +324,10 @@ export function resolvePickRow(rawLabel, rowLookup, pickAliases) {
 
   const candidates = buildPickLookupCandidates(rawLabel);
 
-  // Direct candidate lookup.
-  for (const key of candidates) {
-    const row = rowLookup.get(key);
-    if (row) return row;
-  }
-
-  // Backend alias map (authoritative, case-sensitive map).  Walk each
-  // candidate through the alias and retry — covers the suppressed
-  // generic-tier case where rankings stored the row under the
-  // slot-specific canonical but kept the tier label as an alias.
+  // 1) Backend alias map first.  Walk every candidate through the alias
+  //    table so annotated/stripped/tier forms all redirect to the
+  //    slot-specific canonical row when the backend has flagged the
+  //    generic tier as suppressed.
   if (pickAliases && typeof pickAliases === "object") {
     const aliasLower = new Map();
     for (const [k, v] of Object.entries(pickAliases)) {
@@ -320,11 +337,20 @@ export function resolvePickRow(rawLabel, rowLookup, pickAliases) {
     }
     for (const key of candidates) {
       const target = aliasLower.get(key);
-      if (target) {
-        const row = rowLookup.get(target);
-        if (row) return row;
-      }
+      if (!target) continue;
+      const row = rowLookup.get(target);
+      if (row && !isSuppressedGenericPickRow(row)) return row;
     }
+  }
+
+  // 2) Direct candidate lookup.  Skip suppressed generic-tier rows so a
+  //    later candidate (typically the slot-specific "Pick N.NN" form)
+  //    gets a chance to resolve even without a pickAliases map.
+  for (const key of candidates) {
+    const row = rowLookup.get(key);
+    if (!row) continue;
+    if (isSuppressedGenericPickRow(row)) continue;
+    return row;
   }
 
   return null;

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -205,6 +205,131 @@ export function normalizePickLabel(token) {
   return `${parsed.year} ${tier} ${parsed.round}`;
 }
 
+// Tier-centre slot used to translate tier labels to slot-specific rows.
+// Matches backend _suppress_generic_pick_tiers_when_slots_exist() in
+// src/api/data_contract.py: Early=2, Mid=6, Late=10.
+const TIER_CENTRE_SLOT = { early: 2, mid: 6, late: 10 };
+
+// Round numeric digit ("1") for the round label ("1st").  Kept here so
+// both slot-based and tier-based candidates can be generated without
+// re-deriving the mapping at every call site.
+const ROUND_NUM = { "1st": 1, "2nd": 2, "3rd": 3, "4th": 4, "5th": 5 };
+
+/**
+ * Given a raw pick label from any source (Sleeper roster, Sleeper trade
+ * history, rankings row), return a de-duplicated, lowercased list of
+ * candidate canonical row names to probe against `rowLookup`.
+ *
+ * Sleeper labels arrive as "2026 1.04 (from Team X)" or "2027 Mid 1st
+ * (own)" — the rankings pipeline stores the same asset as
+ * "2026 Pick 1.04" or "2027 Mid 1st".  Without candidate expansion the
+ * slot-based Sleeper label misses the rankings row and the pick is
+ * valued at 0 in trade history + roster breakdown (while the rankings
+ * page shows the correct value).
+ *
+ * Returns lowercased strings so callers can match rowLookup (which
+ * uses `r.name.toLowerCase()` as the key).
+ */
+export function buildPickLookupCandidates(rawLabel) {
+  if (!rawLabel) return [];
+  const raw = String(rawLabel).trim();
+  const candidates = [];
+  const push = (v) => {
+    if (!v) return;
+    const key = String(v).trim().toLowerCase();
+    if (key && !candidates.includes(key)) candidates.push(key);
+  };
+
+  // 1) Raw label exactly as provided.
+  push(raw);
+
+  // 2) Strip trailing "(...)" annotation like "(from Team X)" or "(own)".
+  const stripped = raw.replace(/\s*\([^)]*\)\s*$/, "").trim();
+  if (stripped && stripped !== raw) push(stripped);
+
+  // 3) Parse into {year, round, tier, slot} and enumerate every
+  //    canonical form the rankings pipeline might have used.
+  const parsed = parsePickToken(stripped || raw);
+  if (parsed) {
+    const { year, round, tier, slot } = parsed;
+    const roundDigit = ROUND_NUM[round];
+
+    if (slot && roundDigit) {
+      // "2026 Pick 1.04" (rankings canonical, slot-specific)
+      push(`${year} Pick ${roundDigit}.${String(slot).padStart(2, "0")}`);
+      // "2026 1.04" (already pushed as stripped, but guaranteed here)
+      push(`${year} ${roundDigit}.${String(slot).padStart(2, "0")}`);
+    }
+
+    if (tier) {
+      const cap = tier.charAt(0).toUpperCase() + tier.slice(1);
+      // "2027 Early 1st" (tier canonical — used for future years)
+      push(`${year} ${cap} ${round}`);
+      // If we only know the tier, generate the tier-centre slot form
+      // so years that DO have slot-specific rows still resolve.
+      if (roundDigit) {
+        const centreSlot = TIER_CENTRE_SLOT[tier] || 6;
+        push(`${year} Pick ${roundDigit}.${String(centreSlot).padStart(2, "0")}`);
+        push(`${year} ${roundDigit}.${String(centreSlot).padStart(2, "0")}`);
+      }
+    }
+
+    // 4) If we have a slot but no tier — derive the tier from the slot
+    //    (early 1-4, mid 5-8, late 9-12) and push tier-based candidates.
+    if (slot && !tier && roundDigit) {
+      const derivedTier = slot <= 4 ? "Early" : slot <= 8 ? "Mid" : "Late";
+      push(`${year} ${derivedTier} ${round}`);
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * Resolve a pick label (raw or annotated) to a row using rowLookup and
+ * optional backend-authored pickAliases map.  Returns null if no
+ * candidate resolves.  Callers should NOT fall back to an untyped 0 —
+ * a null return means the pick genuinely has no known value.
+ *
+ * @param {string} rawLabel - raw pick label (any source)
+ * @param {Map<string, object>} rowLookup - lowercased name → row
+ * @param {object} [pickAliases] - optional backend alias map
+ *   ({ "2026 Mid 1st": "2026 Pick 1.06", ... })
+ */
+export function resolvePickRow(rawLabel, rowLookup, pickAliases) {
+  if (!rawLabel || !rowLookup) return null;
+
+  const candidates = buildPickLookupCandidates(rawLabel);
+
+  // Direct candidate lookup.
+  for (const key of candidates) {
+    const row = rowLookup.get(key);
+    if (row) return row;
+  }
+
+  // Backend alias map (authoritative, case-sensitive map).  Walk each
+  // candidate through the alias and retry — covers the suppressed
+  // generic-tier case where rankings stored the row under the
+  // slot-specific canonical but kept the tier label as an alias.
+  if (pickAliases && typeof pickAliases === "object") {
+    const aliasLower = new Map();
+    for (const [k, v] of Object.entries(pickAliases)) {
+      if (typeof k === "string" && typeof v === "string") {
+        aliasLower.set(k.toLowerCase(), v.toLowerCase());
+      }
+    }
+    for (const key of candidates) {
+      const target = aliasLower.get(key);
+      if (target) {
+        const row = rowLookup.get(target);
+        if (row) return row;
+      }
+    }
+  }
+
+  return null;
+}
+
 // ── Trade Side Helpers ───────────────────────────────────────────────────
 export function addAssetToSide(side, row) {
   if (!row) return side;


### PR DESCRIPTION
## Summary

- **Pick label mismatch fix.** Rankings stores pick rows under canonical labels like `2026 Pick 1.04` / `2027 Mid 1st`, while Sleeper emits `2026 1.04 (from Team X)` / `2027 Mid 1st (own)`. The raw `rowLookup.get(name.toLowerCase())` in trade history and roster breakdown missed this, so picks rendered as value `0` even though the rankings page showed them correctly.
- **New helpers in `frontend/lib/trade-logic.js`:** `buildPickLookupCandidates()` enumerates every canonical form the rankings pipeline might have used (slot `Pick N.NN`, tier `Early/Mid/Late Nth`, tier-centre slot fallback for mixed-year leagues), and `resolvePickRow()` walks those candidates plus the backend `pickAliases` map.
- **Wired through the live call sites:** `resolveTradeItemValue`, `buildTeamValueBreakdown`, `scoreTeamTiers`, `analyzeTradeTendencies`. `pickAliases` is threaded from `rawData` in `rosters/page.jsx` and `league/page.jsx` so the suppressed-generic-tier case resolves via the backend alias map.
- **Trade history now defaults to 1 calendar year.** `SETTINGS_DEFAULTS.tradeHistoryWindowDays` bumped `120 → 365`. The backend scraper already fetches 365 days from Sleeper, so no backend change needed.

## Root cause (verified)

Pick labels in the rankings data vs Sleeper feed:

| Source | Example label |
| --- | --- |
| Rankings row (`data.players`) | `"2026 Pick 1.04"`, `"2027 Mid 1st"` |
| `sleeper.teams[].picks` | `"2026 1.04 (from Chargers Team Doctor)"`, `"2027 Mid 1st (own)"` |
| `sleeper.trades[].sides[].got` | `"2026 1.04 (from Rage Against The Achane)"` |

`resolveTradeItemValue` previously tried the raw name, then stripped `(...)`, then gave up. For slot-based current-year picks the stripped form `"2026 1.04"` still didn't match because rankings inserts the word `"Pick"`. So the pick value was `0` for every current-year slot-specific pick in trade history, and wrong in roster breakdown totals.

## Test plan

- [x] `npx vitest run` — 308/308 frontend tests pass (including 9 new ones for `buildPickLookupCandidates` / `resolvePickRow`)
- [x] `python3 -m pytest tests/` — 1124 passed, 5 skipped
- [x] Real-data smoke test against live Sleeper labels — all 6 test cases resolve to the correct rankings row and value:
  - `2026 1.04 (from Chargers Team Doctor)` → `2026 Pick 1.04`
  - `2026 3.09 (from Rage Against The Achane )` → `2026 Pick 3.09`
  - `2026 5.04 (own)` → `2026 Pick 5.04`
  - `2027 Mid 1st (own)` → `2027 Mid 1st`
  - `2027 Early 2nd (from X)` → `2027 Early 2nd`
- [ ] Manual UI sanity check against the live dashboard: trade history pick values should now match rankings, roster breakdown totals should reflect correct PICKS contribution.

https://claude.ai/code/session_014LLQ2p4PCHwVDjWAsFgjEy