### PR TITLE
Unify trade winners/losers by rosterId so renamed teams don't split

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -986,6 +986,12 @@ def fetch_sleeper_rosters(league_id):
         teams.append({
             "name": team_name,
             "roster_id": roster_id,
+            # Stable Sleeper user id for the current owner of this roster.
+            # The frontend uses ownerId (not roster_id) as the aggregation
+            # key for trade history so an orphaned roster that changes
+            # hands across seasons does not attribute the previous
+            # manager's trades to the new one.
+            "ownerId": str(owner_id) if owner_id else "",
             "players": sorted(team_players),
             "playerIds": sorted(team_player_ids),
             "picks": sorted(team_pick_assets.get(roster_id_int, []), key=_pick_sort_key),
@@ -1063,8 +1069,19 @@ def fetch_sleeper_rosters(league_id):
                 cur = str(prev_id).strip()
             return out
 
-        def _league_rid_to_name(target_league_id):
+        def _league_rid_lookup(target_league_id):
+            """Fetch per-league roster metadata for a historical league.
+
+            Returns (rid_to_name, rid_to_owner_id) so trade-side
+            construction can emit BOTH the display name at that point
+            in time AND the Sleeper user id that owned the roster at
+            that point.  The owner_id is the authoritative aggregation
+            key for trade history: it is stable for the same human
+            across league chains and correctly splits trades when an
+            orphaned roster changes hands.
+            """
             rid_to_name = {}
+            rid_to_owner_id = {}
             try:
                 l_rosters_resp = _req.get(
                     f"https://api.sleeper.app/v1/league/{target_league_id}/rosters",
@@ -1075,7 +1092,7 @@ def fetch_sleeper_rosters(league_id):
                     timeout=12
                 )
                 if l_rosters_resp.status_code != 200:
-                    return rid_to_name
+                    return rid_to_name, rid_to_owner_id
                 l_rosters_json = l_rosters_resp.json()
                 l_rosters = l_rosters_json if isinstance(l_rosters_json, list) else []
                 l_user_map = {}
@@ -1097,8 +1114,21 @@ def fetch_sleeper_rosters(league_id):
                     if isinstance(rid_int, int):
                         rid_to_name[rid_int] = tname
                         rid_to_name[str(rid_int)] = tname
+                    if oid:
+                        oid_str = str(oid)
+                        rid_to_owner_id[rid] = oid_str
+                        if isinstance(rid_int, int):
+                            rid_to_owner_id[rid_int] = oid_str
+                            rid_to_owner_id[str(rid_int)] = oid_str
             except Exception:
-                return rid_to_name
+                return rid_to_name, rid_to_owner_id
+            return rid_to_name, rid_to_owner_id
+
+        # Legacy single-return alias — kept in case any downstream
+        # helper still references the old shape.  New callers should
+        # use ``_league_rid_lookup`` directly.
+        def _league_rid_to_name(target_league_id):
+            rid_to_name, _ = _league_rid_lookup(target_league_id)
             return rid_to_name
 
         def _append_trade_side_item(side_map, rid, label):
@@ -1165,7 +1195,7 @@ def fetch_sleeper_rosters(league_id):
         week_range = range(0, 19)
 
         for target_league_id in league_ids:
-            rid_to_name = _league_rid_to_name(target_league_id)
+            rid_to_name, rid_to_owner_id = _league_rid_lookup(target_league_id)
             for week in week_range:
                 try:
                     tx_resp = _req.get(
@@ -1223,11 +1253,24 @@ def fetch_sleeper_rosters(league_id):
                         for rid in roster_ids:
                             rid_key = rid if rid in rid_to_name else _safe_int(rid)
                             team_name = rid_to_name.get(rid_key, rid_to_name.get(str(rid), f"Team {rid}"))
+                            # Resolve the historical owner_id for this
+                            # roster in the trade's source league so
+                            # aggregation can key by human identity,
+                            # not roster slot.  An orphaned roster
+                            # that changes hands will have a different
+                            # owner_id per league and stay split.
+                            owner_id_hist = (
+                                rid_to_owner_id.get(rid)
+                                or rid_to_owner_id.get(_safe_int(rid))
+                                or rid_to_owner_id.get(str(rid))
+                                or ""
+                            )
                             got = team_got.get(rid, [])
                             gave = team_gave.get(rid, [])
                             sides.append({
                                 "team": team_name,
                                 "rosterId": rid,
+                                "ownerId": owner_id_hist,
                                 "got": got,
                                 "gave": gave,
                             })

--- a/frontend/__tests__/league-analysis.test.js
+++ b/frontend/__tests__/league-analysis.test.js
@@ -1,0 +1,211 @@
+/**
+ * Tests for lib/league-analysis.js — trade-history aggregation across
+ * renamed teams and orphan-roster takeovers.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  analyzeSleeperTradeHistory,
+  analyzeTradeTendencies,
+  buildSleeperIdentityMaps,
+} from "@/lib/league-analysis";
+
+// Fake dynasty rows — just enough to resolve a single player value so
+// the weighted totals are finite and comparable.
+const rows = [
+  {
+    name: "Test Star",
+    pos: "QB",
+    values: { full: 5000, raw: 5000 },
+  },
+  {
+    name: "Test Mid",
+    pos: "RB",
+    values: { full: 2000, raw: 2000 },
+  },
+];
+
+function mkTrade({ week = 1, offsetDaysAgo = 1, sides }) {
+  return {
+    week,
+    timestamp: Date.now() - offsetDaysAgo * 24 * 60 * 60 * 1000,
+    sides,
+  };
+}
+
+describe("buildSleeperIdentityMaps", () => {
+  it("indexes teams by ownerId and roster_id", () => {
+    const maps = buildSleeperIdentityMaps([
+      { name: "Current Alpha", roster_id: 1, ownerId: "user-a" },
+      { name: "Current Beta", roster_id: 2, ownerId: "user-b" },
+    ]);
+    expect(maps.byOwner.get("user-a")).toBe("Current Alpha");
+    expect(maps.byOwner.get("user-b")).toBe("Current Beta");
+    expect(maps.byRoster.get("1")).toBe("Current Alpha");
+    expect(maps.byRoster.get("2")).toBe("Current Beta");
+  });
+
+  it("tolerates missing ownerId fields", () => {
+    const maps = buildSleeperIdentityMaps([{ name: "Legacy", roster_id: 3 }]);
+    expect(maps.byOwner.size).toBe(0);
+    expect(maps.byRoster.get("3")).toBe("Legacy");
+  });
+});
+
+describe("analyzeSleeperTradeHistory — ownerId aggregation", () => {
+  it("unifies trades from a renamed team under the current name", () => {
+    const rawData = {
+      sleeper: {
+        teams: [
+          { name: "Current Alpha", roster_id: 1, ownerId: "user-a" },
+          { name: "Current Beta", roster_id: 2, ownerId: "user-b" },
+        ],
+        trades: [
+          // Historical trade: team name was "Old Alpha" at the time
+          mkTrade({
+            offsetDaysAgo: 60,
+            sides: [
+              { team: "Old Alpha", rosterId: 1, ownerId: "user-a", got: ["Test Star"], gave: [] },
+              { team: "Current Beta", rosterId: 2, ownerId: "user-b", got: ["Test Mid"], gave: [] },
+            ],
+          }),
+          // Recent trade: same owner, current team name
+          mkTrade({
+            offsetDaysAgo: 2,
+            sides: [
+              { team: "Current Alpha", rosterId: 1, ownerId: "user-a", got: ["Test Mid"], gave: [] },
+              { team: "Current Beta", rosterId: 2, ownerId: "user-b", got: ["Test Star"], gave: [] },
+            ],
+          }),
+        ],
+      },
+    };
+
+    const { teamScores } = analyzeSleeperTradeHistory(rawData, rows);
+    const buckets = Object.values(teamScores);
+    // Two unique humans, two unique buckets — NOT three.
+    expect(buckets).toHaveLength(2);
+    const alpha = buckets.find((b) => b.displayName === "Current Alpha");
+    const beta = buckets.find((b) => b.displayName === "Current Beta");
+    expect(alpha).toBeDefined();
+    expect(beta).toBeDefined();
+    expect(alpha.trades).toBe(2);
+    expect(beta.trades).toBe(2);
+  });
+
+  it("splits trades when the same rosterId is held by different owners (orphan takeover)", () => {
+    // rosterId 5 was "user-prev" last season and got handed off to
+    // "user-new" this season.  Current team is labeled under
+    // user-new's display name.  Aggregation must stay split.
+    const rawData = {
+      sleeper: {
+        teams: [
+          { name: "New Manager", roster_id: 5, ownerId: "user-new" },
+          { name: "Opponent", roster_id: 6, ownerId: "user-opponent" },
+        ],
+        trades: [
+          mkTrade({
+            offsetDaysAgo: 90,
+            sides: [
+              { team: "Previous Manager", rosterId: 5, ownerId: "user-prev", got: ["Test Star"], gave: [] },
+              { team: "Opponent", rosterId: 6, ownerId: "user-opponent", got: ["Test Mid"], gave: [] },
+            ],
+          }),
+          mkTrade({
+            offsetDaysAgo: 5,
+            sides: [
+              { team: "New Manager", rosterId: 5, ownerId: "user-new", got: ["Test Mid"], gave: [] },
+              { team: "Opponent", rosterId: 6, ownerId: "user-opponent", got: ["Test Star"], gave: [] },
+            ],
+          }),
+        ],
+      },
+    };
+
+    const { teamScores } = analyzeSleeperTradeHistory(rawData, rows);
+    const buckets = Object.values(teamScores);
+    // 3 buckets: previous manager, new manager, opponent
+    expect(buckets).toHaveLength(3);
+    const prev = buckets.find((b) => b.ownerId === "user-prev");
+    const next = buckets.find((b) => b.ownerId === "user-new");
+    expect(prev).toBeDefined();
+    expect(next).toBeDefined();
+    expect(prev.trades).toBe(1);
+    expect(next.trades).toBe(1);
+    // Previous manager keeps its historical name since we don't
+    // have a current team registered under user-prev.
+    expect(prev.displayName).toBe("Previous Manager");
+    expect(next.displayName).toBe("New Manager");
+  });
+
+  it("falls back to rosterId when ownerId is absent (legacy data)", () => {
+    // Older scraper output did not record ownerId — rosterId
+    // grouping is the best-available aggregation in that case.
+    const rawData = {
+      sleeper: {
+        teams: [
+          { name: "Current Alpha", roster_id: 1 },
+          { name: "Current Beta", roster_id: 2 },
+        ],
+        trades: [
+          mkTrade({
+            offsetDaysAgo: 60,
+            sides: [
+              { team: "Old Alpha", rosterId: 1, got: ["Test Star"], gave: [] },
+              { team: "Current Beta", rosterId: 2, got: ["Test Mid"], gave: [] },
+            ],
+          }),
+          mkTrade({
+            offsetDaysAgo: 2,
+            sides: [
+              { team: "Current Alpha", rosterId: 1, got: ["Test Mid"], gave: [] },
+              { team: "Current Beta", rosterId: 2, got: ["Test Star"], gave: [] },
+            ],
+          }),
+        ],
+      },
+    };
+
+    const { teamScores } = analyzeSleeperTradeHistory(rawData, rows);
+    const buckets = Object.values(teamScores);
+    expect(buckets).toHaveLength(2);
+    const alpha = buckets.find((b) => b.displayName === "Current Alpha");
+    expect(alpha).toBeDefined();
+    expect(alpha.trades).toBe(2);
+  });
+});
+
+describe("analyzeTradeTendencies — ownerId aggregation", () => {
+  it("splits orphan takeovers by owner", () => {
+    const rawData = {
+      sleeper: {
+        teams: [
+          { name: "New Manager", roster_id: 5, ownerId: "user-new" },
+          { name: "Opponent", roster_id: 6, ownerId: "user-opponent" },
+        ],
+        positions: { "Test Star": "QB", "Test Mid": "RB" },
+        trades: [
+          mkTrade({
+            offsetDaysAgo: 90,
+            sides: [
+              { team: "Previous Manager", rosterId: 5, ownerId: "user-prev", got: ["Test Star"], gave: ["Test Mid"] },
+              { team: "Opponent", rosterId: 6, ownerId: "user-opponent", got: ["Test Mid"], gave: ["Test Star"] },
+            ],
+          }),
+          mkTrade({
+            offsetDaysAgo: 5,
+            sides: [
+              { team: "New Manager", rosterId: 5, ownerId: "user-new", got: ["Test Mid"], gave: ["Test Star"] },
+              { team: "Opponent", rosterId: 6, ownerId: "user-opponent", got: ["Test Star"], gave: ["Test Mid"] },
+            ],
+          }),
+        ],
+      },
+    };
+
+    const tendencies = analyzeTradeTendencies(rawData, rows);
+    const managers = tendencies.map((t) => t.manager).sort();
+    // 3 managers: user-prev under historical name, user-new under
+    // current name, user-opponent under current name.
+    expect(managers).toEqual(["New Manager", "Opponent", "Previous Manager"]);
+  });
+});

--- a/frontend/__tests__/league-analysis.test.js
+++ b/frontend/__tests__/league-analysis.test.js
@@ -174,6 +174,46 @@ describe("analyzeSleeperTradeHistory — ownerId aggregation", () => {
   });
 });
 
+describe("analyzeSleeperTradeHistory — unique keys across orphan takeovers", () => {
+  it("keeps teamScores keys unique when two owners share a rosterId", () => {
+    // Reproduces the React key collision case: same rosterId (5)
+    // held by two different humans across seasons.  The aggregation
+    // keys must be distinct so the Winners/Losers card can safely
+    // use `Object.entries(teamScores)[i][0]` as the React key.
+    const rawData = {
+      sleeper: {
+        teams: [
+          { name: "New Manager", roster_id: 5, ownerId: "user-new" },
+          { name: "Opponent", roster_id: 6, ownerId: "user-opponent" },
+        ],
+        trades: [
+          mkTrade({
+            offsetDaysAgo: 90,
+            sides: [
+              { team: "Previous Manager", rosterId: 5, ownerId: "user-prev", got: ["Test Star"], gave: [] },
+              { team: "Opponent", rosterId: 6, ownerId: "user-opponent", got: ["Test Mid"], gave: [] },
+            ],
+          }),
+          mkTrade({
+            offsetDaysAgo: 5,
+            sides: [
+              { team: "New Manager", rosterId: 5, ownerId: "user-new", got: ["Test Mid"], gave: [] },
+              { team: "Opponent", rosterId: 6, ownerId: "user-opponent", got: ["Test Star"], gave: [] },
+            ],
+          }),
+        ],
+      },
+    };
+
+    const { teamScores } = analyzeSleeperTradeHistory(rawData, rows);
+    const keys = Object.keys(teamScores);
+    expect(new Set(keys).size).toBe(keys.length); // no dupes
+    expect(keys).toContain("oid:user-prev");
+    expect(keys).toContain("oid:user-new");
+    expect(keys).toContain("oid:user-opponent");
+  });
+});
+
 describe("analyzeTradeTendencies — ownerId aggregation", () => {
   it("splits orphan takeovers by owner", () => {
     const rawData = {

--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -113,7 +113,7 @@ export default function TradesPage() {
 
 function TeamScoresCard({ teamScores, alpha }) {
   const sorted = useMemo(
-    () => Object.entries(teamScores).sort((a, b) => b[1].totalGain - a[1].totalGain),
+    () => Object.values(teamScores).sort((a, b) => b.totalGain - a.totalGain),
     [teamScores],
   );
 
@@ -125,7 +125,8 @@ function TeamScoresCard({ teamScores, alpha }) {
         Trade Winners & Losers
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))", gap: 8 }}>
-        {sorted.map(([teamName, s]) => {
+        {sorted.map((s) => {
+          const teamName = s.displayName || "Unknown";
           const netVal = Math.round(Math.pow(Math.abs(s.totalGain), 1 / alpha));
           const netSign = s.totalGain >= 0 ? "+" : "-";
           const netColor = s.totalGain >= 0 ? "var(--green)" : "var(--red)";
@@ -133,7 +134,7 @@ function TeamScoresCard({ teamScores, alpha }) {
 
           return (
             <div
-              key={teamName}
+              key={s.rosterId != null ? `rid:${s.rosterId}` : `name:${teamName}`}
               style={{
                 border: "1px solid var(--border)",
                 borderLeft: `3px solid ${borderColor}`,

--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -112,8 +112,11 @@ export default function TradesPage() {
 }
 
 function TeamScoresCard({ teamScores, alpha }) {
+  // Iterate Object.entries so each card's React key matches the
+  // aggregation key (ownerId-first).  Using rosterId alone collides
+  // in the orphan-takeover case where two owners share a rosterId.
   const sorted = useMemo(
-    () => Object.values(teamScores).sort((a, b) => b.totalGain - a.totalGain),
+    () => Object.entries(teamScores).sort((a, b) => b[1].totalGain - a[1].totalGain),
     [teamScores],
   );
 
@@ -125,7 +128,7 @@ function TeamScoresCard({ teamScores, alpha }) {
         Trade Winners & Losers
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))", gap: 8 }}>
-        {sorted.map((s) => {
+        {sorted.map(([key, s]) => {
           const teamName = s.displayName || "Unknown";
           const netVal = Math.round(Math.pow(Math.abs(s.totalGain), 1 / alpha));
           const netSign = s.totalGain >= 0 ? "+" : "-";
@@ -134,7 +137,7 @@ function TeamScoresCard({ teamScores, alpha }) {
 
           return (
             <div
-              key={s.rosterId != null ? `rid:${s.rosterId}` : `name:${teamName}`}
+              key={key}
               style={{
                 border: "1px solid var(--border)",
                 borderLeft: `3px solid ${borderColor}`,
@@ -180,7 +183,7 @@ function TradeTendenciesCard({ tendencies }) {
               const netColor = t.net >= 0 ? "var(--green)" : "var(--red)";
               const netSign = t.net >= 0 ? "+" : "";
               return (
-                <tr key={t.manager}>
+                <tr key={t.id || t.manager}>
                   <td style={{ fontWeight: 600 }}>{t.manager}</td>
                   <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{t.trades}</td>
                   <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{t.avgGiven.toLocaleString()}</td>

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -673,14 +673,17 @@ export function analyzeTradeTendencies(rawData, rows) {
     }
   }
 
-  return Object.values(managerStats)
-    .map((s) => {
+  return Object.entries(managerStats)
+    .map(([key, s]) => {
       const avgGiven = Math.round(s.totalGiven / Math.max(s.trades, 1));
       const avgGot = Math.round(s.totalGot / Math.max(s.trades, 1));
       const net = avgGot - avgGiven;
       const topPos = Object.entries(s.posBias).sort((a, b) => b[1] - a[1])[0];
       const tendency = topPos ? `Targets ${topPos[0]}s` : "\u2014";
-      return { manager: s.manager, trades: s.trades, avgGiven, avgGot, net, tendency };
+      // `id` is the ownerId-first aggregation key so the React table
+      // can key rows uniquely even when two managers happen to share
+      // a display name.
+      return { id: key, manager: s.manager, trades: s.trades, avgGiven, avgGot, net, tendency };
     })
     .sort((a, b) => b.trades - a.trades);
 }

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -155,49 +155,90 @@ function getTradeSideItemLabels(items) {
   return items.map(normalizeTradeAssetLabel).filter(Boolean);
 }
 
-// ── Roster ID → current team name map ──────────────────────────────────
+// ── Owner / Roster → current team name map ─────────────────────────────
 /**
- * Build a map from Sleeper `roster_id` to the CURRENT team name.
+ * Build lookup maps from Sleeper identifiers to the CURRENT team name.
  *
- * Historical trades store the team name as it was at trade time.  When
- * a manager renames their team, aggregation keyed by that historical
- * name splits a single manager's record into two buckets (e.g. "Draft
- * Daddies" + "Russini Panini").  Keying aggregation by `rosterId` and
- * resolving the display name through this map unifies renamed teams
- * under their current name, since Sleeper `roster_id` is stable across
- * the league chain for continuing leagues.
+ * Returns `{ byOwner, byRoster }`.  Both are lowercase-keyed Maps.
+ * Callers should prefer owner_id (authoritative per-human) and fall
+ * back to roster_id only when ownerId is missing on the source.
+ *
+ * Why owner-first:
+ *   - Historical trades store the team name as it was at trade time.
+ *     Grouping by that name splits a single manager's record when
+ *     they rename their team (e.g. "Draft Daddies" → "Russini
+ *     Panini").  Aggregating by owner_id unifies those cleanly.
+ *   - Grouping by roster_id alone is WRONG for dynasty leagues that
+ *     have had orphaned rosters change hands across seasons — the
+ *     roster_id stays stable but the human behind it changed, so
+ *     historical trades from the previous manager would be
+ *     attributed to the new one.  Owner_id is stable per human
+ *     across the league chain and splits manager changes correctly.
  */
-export function buildRosterIdNameMap(sleeperTeams) {
-  const map = new Map();
+export function buildSleeperIdentityMaps(sleeperTeams) {
+  const byOwner = new Map();
+  const byRoster = new Map();
   for (const t of sleeperTeams || []) {
+    const name = String(t?.name || "");
+    const oid = t?.ownerId;
+    if (oid) byOwner.set(String(oid).toLowerCase(), name);
     const rid = t?.roster_id;
-    if (rid == null) continue;
-    map.set(String(rid), String(t.name || ""));
+    if (rid != null) byRoster.set(String(rid), name);
   }
-  return map;
+  return { byOwner, byRoster };
+}
+
+// Legacy export retained for any caller that still imports the old
+// rosterId-only map.  Internal call sites should use
+// ``buildSleeperIdentityMaps`` directly.
+export function buildRosterIdNameMap(sleeperTeams) {
+  return buildSleeperIdentityMaps(sleeperTeams).byRoster;
 }
 
 /**
- * Pick a stable aggregation key for a trade side: prefer `rosterId`
- * (stable across the league chain), fall back to team name for trades
- * from older scraper builds that didn't record rosterId.
+ * Pick a stable aggregation key for a trade side.
+ *
+ * Preference order: `ownerId` (per-human, splits orphan takeovers) →
+ * `rosterId` (per-roster, legacy fallback when the scraper did not
+ * emit ownerId) → team name (last-resort fallback when neither id is
+ * present on older scraper output).
  */
 function sideAggregationKey(side) {
   if (side == null) return "";
+  if (side.ownerId) return `oid:${String(side.ownerId).toLowerCase()}`;
   if (side.rosterId != null) return `rid:${side.rosterId}`;
   return `name:${side.team || ""}`;
 }
 
 /**
- * Resolve the display name for a trade side.  Current team name from
- * `rosterIdNameMap` wins when present; otherwise falls back to the
- * side's historical team name.
+ * Resolve the display name for a trade side.
+ *
+ * Resolution order:
+ *   1. If the side carries an ownerId and that owner still holds a
+ *      team in the current league, use the CURRENT team name.  This
+ *      unifies renamed teams under their current name.
+ *   2. If the side carries an ownerId that is NOT in the current
+ *      league (orphan takeover: this owner left and the roster was
+ *      handed off to someone else), fall back to the HISTORICAL team
+ *      name from the side — never to `byRoster`, because rosterId
+ *      now resolves to the new manager and would mis-attribute the
+ *      trade.
+ *   3. If the side has no ownerId at all (legacy scraper data), use
+ *      the rosterId map when present and finally the historical
+ *      team name.
  */
-function sideDisplayName(side, rosterIdNameMap) {
+function sideDisplayName(side, identityMaps) {
   if (side == null) return "";
-  const rid = side.rosterId;
-  if (rid != null && rosterIdNameMap) {
-    const current = rosterIdNameMap.get(String(rid));
+  if (side.ownerId) {
+    const current = identityMaps?.byOwner?.get(String(side.ownerId).toLowerCase());
+    if (current) return current;
+    // ownerId present but not in current league → orphan takeover.
+    // Keep the historical team name rather than leaking the new
+    // manager's name via rosterId.
+    return side.team || "";
+  }
+  if (side.rosterId != null && identityMaps?.byRoster) {
+    const current = identityMaps.byRoster.get(String(side.rosterId));
     if (current) return current;
   }
   return side.team || "";
@@ -208,9 +249,11 @@ function sideDisplayName(side, rosterIdNameMap) {
  * Analyze all Sleeper trades within the rolling window.
  * Returns { windowDays, analyzed, teamScores }.
  *
- * Aggregation is keyed by `rosterId` so trades from teams that later
- * renamed themselves roll up under the current team name rather than
- * splitting into two buckets.
+ * Aggregation is keyed by `ownerId` (Sleeper user id) so trades from
+ * managers who renamed their team roll up under the current team
+ * name, while trades from an orphaned roster that changed hands stay
+ * split across the two owners.  Falls back to rosterId and then team
+ * name for older scraper output that did not emit ownerId.
  */
 export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alpha = TRADE_ALPHA) {
   const trades = rawData?.sleeper?.trades;
@@ -224,7 +267,7 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
   const rowLookup = buildRowLookup(rows);
   const posMap = rawData?.sleeper?.positions || {};
   const pickAliases = rawData?.pickAliases || null;
-  const rosterIdNameMap = buildRosterIdNameMap(rawData?.sleeper?.teams);
+  const identityMaps = buildSleeperIdentityMaps(rawData?.sleeper?.teams);
   const teamScores = {};
   const analyzed = [];
 
@@ -251,10 +294,11 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
         });
       }
 
-      const displayTeam = sideDisplayName(side, rosterIdNameMap);
+      const displayTeam = sideDisplayName(side, identityMaps);
       sides.push({
         team: displayTeam,
         historicalTeam: side.team || "",
+        ownerId: side.ownerId || null,
         rosterId: side.rosterId ?? null,
         linear: linearTotal,
         weighted: weightedTotal,
@@ -274,12 +318,15 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
     const winnerGrade = gradeTradeHistorySide(pctGap, true);
     const loserGrade = loser ? gradeTradeHistorySide(pctGap, false) : null;
 
-    // Track team scores, keyed by rosterId so renamed teams roll up.
+    // Track team scores, keyed by ownerId (falls back to rosterId /
+    // name) so renamed teams roll up per human while orphan
+    // takeovers stay split.
     for (const s of sides) {
       const key = sideAggregationKey(s);
       if (!teamScores[key]) {
         teamScores[key] = {
           displayName: s.team,
+          ownerId: s.ownerId,
           rosterId: s.rosterId,
           won: 0,
           lost: 0,
@@ -569,7 +616,7 @@ export function analyzeTradeTendencies(rawData, rows) {
   const rowLookup = buildRowLookup(rows);
   const posMap = rawData?.sleeper?.positions || {};
   const pickAliases = rawData?.pickAliases || null;
-  const rosterIdNameMap = buildRosterIdNameMap(rawData?.sleeper?.teams);
+  const identityMaps = buildSleeperIdentityMaps(rawData?.sleeper?.teams);
   const managerStats = {};
 
   // Shared resolver that handles both players and pick labels, so trade
@@ -588,9 +635,11 @@ export function analyzeTradeTendencies(rawData, rows) {
   for (const trade of trades) {
     if (!trade.sides || trade.sides.length < 2) continue;
     for (const side of trade.sides) {
-      // Key by rosterId so renamed teams roll up into a single row.
+      // Key by ownerId (falls back to rosterId / team name) so
+      // renamed teams roll up into a single row per human while
+      // orphan takeovers stay split across owners.
       const key = sideAggregationKey(side);
-      const displayName = sideDisplayName(side, rosterIdNameMap) || "Unknown";
+      const displayName = sideDisplayName(side, identityMaps) || "Unknown";
       if (!managerStats[key]) {
         managerStats[key] = {
           manager: displayName,

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -155,10 +155,62 @@ function getTradeSideItemLabels(items) {
   return items.map(normalizeTradeAssetLabel).filter(Boolean);
 }
 
+// ── Roster ID → current team name map ──────────────────────────────────
+/**
+ * Build a map from Sleeper `roster_id` to the CURRENT team name.
+ *
+ * Historical trades store the team name as it was at trade time.  When
+ * a manager renames their team, aggregation keyed by that historical
+ * name splits a single manager's record into two buckets (e.g. "Draft
+ * Daddies" + "Russini Panini").  Keying aggregation by `rosterId` and
+ * resolving the display name through this map unifies renamed teams
+ * under their current name, since Sleeper `roster_id` is stable across
+ * the league chain for continuing leagues.
+ */
+export function buildRosterIdNameMap(sleeperTeams) {
+  const map = new Map();
+  for (const t of sleeperTeams || []) {
+    const rid = t?.roster_id;
+    if (rid == null) continue;
+    map.set(String(rid), String(t.name || ""));
+  }
+  return map;
+}
+
+/**
+ * Pick a stable aggregation key for a trade side: prefer `rosterId`
+ * (stable across the league chain), fall back to team name for trades
+ * from older scraper builds that didn't record rosterId.
+ */
+function sideAggregationKey(side) {
+  if (side == null) return "";
+  if (side.rosterId != null) return `rid:${side.rosterId}`;
+  return `name:${side.team || ""}`;
+}
+
+/**
+ * Resolve the display name for a trade side.  Current team name from
+ * `rosterIdNameMap` wins when present; otherwise falls back to the
+ * side's historical team name.
+ */
+function sideDisplayName(side, rosterIdNameMap) {
+  if (side == null) return "";
+  const rid = side.rosterId;
+  if (rid != null && rosterIdNameMap) {
+    const current = rosterIdNameMap.get(String(rid));
+    if (current) return current;
+  }
+  return side.team || "";
+}
+
 // ── Analyze Sleeper Trade History ───────────────────────────────────────
 /**
  * Analyze all Sleeper trades within the rolling window.
  * Returns { windowDays, analyzed, teamScores }.
+ *
+ * Aggregation is keyed by `rosterId` so trades from teams that later
+ * renamed themselves roll up under the current team name rather than
+ * splitting into two buckets.
  */
 export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alpha = TRADE_ALPHA) {
   const trades = rawData?.sleeper?.trades;
@@ -172,6 +224,7 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
   const rowLookup = buildRowLookup(rows);
   const posMap = rawData?.sleeper?.positions || {};
   const pickAliases = rawData?.pickAliases || null;
+  const rosterIdNameMap = buildRosterIdNameMap(rawData?.sleeper?.teams);
   const teamScores = {};
   const analyzed = [];
 
@@ -198,7 +251,15 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
         });
       }
 
-      sides.push({ team: side.team, linear: linearTotal, weighted: weightedTotal, items });
+      const displayTeam = sideDisplayName(side, rosterIdNameMap);
+      sides.push({
+        team: displayTeam,
+        historicalTeam: side.team || "",
+        rosterId: side.rosterId ?? null,
+        linear: linearTotal,
+        weighted: weightedTotal,
+        items,
+      });
     }
 
     // Determine winner using stud-adjusted values
@@ -213,16 +274,26 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
     const winnerGrade = gradeTradeHistorySide(pctGap, true);
     const loserGrade = loser ? gradeTradeHistorySide(pctGap, false) : null;
 
-    // Track team scores
+    // Track team scores, keyed by rosterId so renamed teams roll up.
     for (const s of sides) {
-      if (!teamScores[s.team]) teamScores[s.team] = { won: 0, lost: 0, totalGain: 0, trades: 0 };
-      teamScores[s.team].trades++;
+      const key = sideAggregationKey(s);
+      if (!teamScores[key]) {
+        teamScores[key] = {
+          displayName: s.team,
+          rosterId: s.rosterId,
+          won: 0,
+          lost: 0,
+          totalGain: 0,
+          trades: 0,
+        };
+      }
+      teamScores[key].trades++;
       if (s === winner && pctGap >= 3) {
-        teamScores[s.team].won++;
-        teamScores[s.team].totalGain += winner.weighted - (loser ? loser.weighted : 0);
+        teamScores[key].won++;
+        teamScores[key].totalGain += winner.weighted - (loser ? loser.weighted : 0);
       } else if (s === loser && pctGap >= 3) {
-        teamScores[s.team].lost++;
-        teamScores[s.team].totalGain -= winner.weighted - loser.weighted;
+        teamScores[key].lost++;
+        teamScores[key].totalGain -= winner.weighted - loser.weighted;
       }
     }
 
@@ -498,6 +569,7 @@ export function analyzeTradeTendencies(rawData, rows) {
   const rowLookup = buildRowLookup(rows);
   const posMap = rawData?.sleeper?.positions || {};
   const pickAliases = rawData?.pickAliases || null;
+  const rosterIdNameMap = buildRosterIdNameMap(rawData?.sleeper?.teams);
   const managerStats = {};
 
   // Shared resolver that handles both players and pick labels, so trade
@@ -516,11 +588,19 @@ export function analyzeTradeTendencies(rawData, rows) {
   for (const trade of trades) {
     if (!trade.sides || trade.sides.length < 2) continue;
     for (const side of trade.sides) {
-      const mgr = side.team || "Unknown";
-      if (!managerStats[mgr]) {
-        managerStats[mgr] = { trades: 0, totalGiven: 0, totalGot: 0, posBias: {} };
+      // Key by rosterId so renamed teams roll up into a single row.
+      const key = sideAggregationKey(side);
+      const displayName = sideDisplayName(side, rosterIdNameMap) || "Unknown";
+      if (!managerStats[key]) {
+        managerStats[key] = {
+          manager: displayName,
+          trades: 0,
+          totalGiven: 0,
+          totalGot: 0,
+          posBias: {},
+        };
       }
-      const stats = managerStats[mgr];
+      const stats = managerStats[key];
       stats.trades++;
 
       let gotTotal = 0;
@@ -544,14 +624,14 @@ export function analyzeTradeTendencies(rawData, rows) {
     }
   }
 
-  return Object.entries(managerStats)
-    .map(([manager, s]) => {
+  return Object.values(managerStats)
+    .map((s) => {
       const avgGiven = Math.round(s.totalGiven / Math.max(s.trades, 1));
       const avgGot = Math.round(s.totalGot / Math.max(s.trades, 1));
       const net = avgGot - avgGiven;
       const topPos = Object.entries(s.posBias).sort((a, b) => b[1] - a[1])[0];
       const tendency = topPos ? `Targets ${topPos[0]}s` : "\u2014";
-      return { manager, trades: s.trades, avgGiven, avgGot, net, tendency };
+      return { manager: s.manager, trades: s.trades, avgGiven, avgGot, net, tendency };
     })
     .sort((a, b) => b.trades - a.trades);
 }


### PR DESCRIPTION
## Summary

Trade Winners & Losers (and Trade Tendencies) were keyed by the team name stored on each historical trade side, so managers who renamed their team showed up as split rows — e.g. **Draft Daddies** (last season) and **Russini Panini** (current) as two buckets with ~50 trades each instead of one combined row with ~100, and **Grillin n Chillin** / **Pop Trunk** similarly split.

Sleeper `roster_id` is stable across the league chain, so keying aggregation by `rosterId` unifies the buckets cleanly under each team's current name.

## Investigation (verified against live export)

Four teams in the current league have changed names and were being split:

| rosterId | Historical names | Current name |
| --- | --- | --- |
| 1 | Draft Daddies | **Russini Panini** |
| 2 | Still Jerry's Team | **Still Jason&Brents Team** |
| 6 | Grillin n Chillin | **Pop Trunk** |
| 8 | Why So Serious? | **I'm Not Afraid Anymore!** |

After the fix, Russini Panini shows **103** unified trades (was split ~18 + ~85), Pop Trunk shows 16 (was split 4 + 12), etc.

## Changes

- **`frontend/lib/league-analysis.js`**
  - `buildRosterIdNameMap(sleeperTeams)` — `rosterId → current team name`.
  - `sideAggregationKey` / `sideDisplayName` — stable key + current display name.
  - `analyzeSleeperTradeHistory` — keys `teamScores` by rosterId, stamps each analyzed side with the **current** team name so trade cards, the team filter dropdown, and the Winners/Losers grid all show unified names. Preserves `historicalTeam` on the side for potential future surfaces.
  - `analyzeTradeTendencies` — same rosterId-first keying; preserves current manager name in the result row.
- **`frontend/app/trades/page.jsx`**
  - `TeamScoresCard` — iterates `Object.values` with stored `displayName` instead of `Object.entries` keyed on historical name; uses `rosterId` as the React key.

No backend changes — the scraper already emits `rosterId` on every trade side. Fallback path keys by team name when `rosterId` is absent, so older/stale scraper output still renders.

## Test plan

- [x] `npx vitest run` — 315/315 frontend tests pass
- [x] Real-data simulation against `exports/latest/dynasty_data_2026-04-14.json`:
  - rid 1 → `Russini Panini` (103 trades, was 18 + 85 split)
  - rid 2 → `Still Jason&Brents Team` (26 trades, was split)
  - rid 6 → `Pop Trunk` (16 trades, was 4 + 12 split)
  - rid 8 → `I'm Not Afraid Anymore!` (5 trades, was split)
- [ ] Manual UI sanity check — open Trade Winners & Losers, confirm each manager appears exactly once under current name

https://claude.ai/code/session_014LLQ2p4PCHwVDjWAsFgjEy