### PR TITLE
Make canonical_build + refresh verify fail loud on silent source-pull failure

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -84,9 +84,15 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          SNAP=$(ls -t data/canonical/canonical_snapshot_*.json 2>/dev/null | head -1)
+          # `ls | head -1` is wrapped in `|| true` so the pipe's
+          # pipefail exit (from `ls` finding no matches) doesn't kill
+          # the script mid-assignment under `set -e`.  Without this,
+          # the empty-snapshot case exits with a cryptic `Process
+          # completed with exit code 2` and the ::error annotation
+          # below never gets a chance to fire.
+          SNAP=$(ls -t data/canonical/canonical_snapshot_*.json 2>/dev/null | head -1 || true)
           if [[ -z "$SNAP" ]]; then
-            echo "::error title=No canonical snapshot::Canonical rebuild produced no snapshot"
+            echo "::error title=No canonical snapshot::Canonical rebuild produced no snapshot — check the Rebuild canonical snapshot step's log for a source_pull or canonical_build error."
             exit 1
           fi
           ASSETS=$(python -c "import json; print(len(json.load(open('${SNAP}')).get('assets', [])))")

--- a/scripts/canonical_build.py
+++ b/scripts/canonical_build.py
@@ -52,11 +52,35 @@ def main() -> int:
 
     raw_file = _latest(repo / "data" / "raw_sources", "raw_source_snapshot_*.json")
     if raw_file is None:
-        print("[canonical_build] No raw source snapshot found. Run source_pull first.")
-        return 0
+        # CI used to eat this as a silent `return 0` which left the
+        # downstream "Verify canonical output" step to fail with a
+        # cryptic pipefail exit 2 from its `ls | head` call.  Fail
+        # loudly instead so the real root cause (source_pull produced
+        # nothing) shows up in the canonical-build step's log.
+        print(
+            "[canonical_build] ERROR: No raw source snapshot found in "
+            "data/raw_sources/.  Run `python scripts/source_pull.py` first "
+            "and make sure it wrote a `raw_source_snapshot_*.json` file.",
+            file=sys.stderr,
+        )
+        return 1
 
     raw_payload = load_json(raw_file, default={}) or {}
     snapshots = raw_payload.get("snapshots", [])
+
+    if not snapshots:
+        # Empty snapshots list = source_pull ran but every adapter
+        # returned zero records (scraper CSVs all missing/empty, or
+        # every adapter raised).  Surface this as a hard failure so
+        # the downstream "Verify canonical output" step reports the
+        # correct root cause instead of its generic exit-2 pipefail.
+        print(
+            f"[canonical_build] ERROR: raw source snapshot {raw_file.name} "
+            f"contains zero source snapshots.  source_pull produced no "
+            f"records — check the scraper output in exports/latest/site_raw/.",
+            file=sys.stderr,
+        )
+        return 1
 
     all_records: list[RawAssetRecord] = []
     for snap in snapshots:
@@ -91,6 +115,19 @@ def main() -> int:
                     asset_key=r.get("asset_key", ""),
                 )
             )
+
+    if not all_records:
+        # Every snapshot existed but contained no records — same
+        # silent-failure class as the empty `snapshots` list above.
+        # Report and exit 1 so the CI step blames the right component.
+        print(
+            f"[canonical_build] ERROR: raw source snapshot {raw_file.name} "
+            f"has {len(snapshots)} snapshot(s) but zero records across all "
+            f"sources.  Check scraper output — no canonical snapshot will "
+            f"be written.",
+            file=sys.stderr,
+        )
+        return 1
 
     weights_cfg = load_json(repo / "config" / "weights" / "default_weights.json", default={}) or {}
     source_weights = dict(weights_cfg.get("sources", {}))


### PR DESCRIPTION
## Summary

Scheduled data-refresh workflow has been surfacing a cryptic `Process completed with exit code 2` on the **Verify canonical output** step with no `::error` annotation.  Root cause is a chain of silent-success paths:

### Root cause chain

1. `scripts/canonical_build.py` has three non-writing code paths that all returned `0` silently:
   - No `raw_source_snapshot_*.json` in `data/raw_sources/` → printed a warning and `return 0`
   - Snapshot existed but had an empty `snapshots` list → ran calibration on nothing
   - Snapshots existed but every adapter had zero records → same
2. Downstream **Verify canonical output** step couldn't find a canonical snapshot file, and its intended error annotation never printed because the `set -Eeuo pipefail` `ls ... | head -1` pipe inherited `ls`'s exit 2 via pipefail and killed the script mid-assignment — *before* the `if [[ -z "$SNAP" ]]` check ran.
3. Operator only saw `Process completed with exit code 2` with no context.

## Changes

### `scripts/canonical_build.py`

- Missing raw snapshot → print to `stderr` and `return 1` (was `return 0`).
- Raw snapshot with zero `snapshots` list → new guard: print to `stderr`, `return 1`.
- Raw snapshot with zero records across all adapters → new guard: print to `stderr`, `return 1`.

### `.github/workflows/scheduled-refresh.yml`

- Append `|| true` to the `ls | head -1` pipe in the "Verify canonical output" step so pipefail doesn't kill the script before the `if [[ -z "$SNAP" ]]` check can print its error annotation.
- Expand the annotation title to point the operator at the upstream "Rebuild canonical snapshot" step for the real cause.

## Test plan

- [x] `python3 -m py_compile scripts/canonical_build.py` — syntax OK
- [x] Happy-path `python3 scripts/canonical_build.py --repo .` on current local data — produces `canonical_snapshot_*.json` with 1,399 assets (well above the 500-asset threshold)
- [x] Simulated **Path 1** (no raw snapshot at all): prints `ERROR: No raw source snapshot found ...`, exits 1
- [x] Simulated **Path 2** (snapshot file exists but has zero snapshots): prints `ERROR: raw source snapshot ... contains zero source snapshots`, exits 1
- [x] Simulated **Path 3** (snapshots exist but have empty records): prints `ERROR: raw source snapshot ... has N snapshot(s) but zero records`, exits 1
- [x] Simulated the updated verify step with an empty `data/canonical/` directory — now prints `::error title=No canonical snapshot::Canonical rebuild produced no snapshot — check the Rebuild canonical snapshot step's log for a source_pull or canonical_build error.` instead of dying silently at exit 2
- [x] `python3 -m pytest tests/` — 1125 passed, 4 skipped

## What this does not do

- **Does not fix the upstream scraper failure.**  If the scheduled refresh keeps failing after this lands, the next CI run will print the specific failure reason in the Rebuild canonical snapshot step's log instead of the cryptic exit 2, and we can target the real root cause from there.

https://claude.ai/code/session_014LLQ2p4PCHwVDjWAsFgjEy