### PR TITLE
Improve trade calculator UX for mobile and desktop

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -563,10 +563,27 @@ tr:hover .sticky-name {
   padding: var(--space-sm);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
+  min-width: 0;
+}
+.asset-row > div:first-child {
+  min-width: 0;
+  flex: 1;
 }
 
-.asset-name { font-weight: 600; font-size: 0.85rem; }
-.asset-meta { color: var(--muted); font-size: 0.73rem; }
+.asset-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.asset-meta {
+  color: var(--muted);
+  font-size: 0.73rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 .tier-label {
   display: inline-flex;
@@ -607,20 +624,84 @@ tr:hover .sticky-name {
 .picker-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: rgba(0, 0, 0, 0.5);
   z-index: 42;
   display: flex;
   justify-content: center;
-  align-items: flex-end;
-  padding: 10px;
+  align-items: center;
+  padding: 16px;
 }
 
 .picker-sheet {
-  width: min(940px, 100%);
+  width: min(660px, 100%);
+  max-height: 80vh;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: linear-gradient(180deg, rgba(20, 39, 79, 0.97) 0%, rgba(13, 29, 63, 0.98) 100%);
-  padding: 12px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.picker-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.picker-subtitle {
+  margin: 2px 0 0 0;
+  font-size: 0.72rem;
+}
+
+.picker-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 19, 44, 0.7);
+  color: var(--text);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 0.12s;
+}
+.picker-close:hover { border-color: var(--cyan); }
+
+.picker-search-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  flex-shrink: 0;
+}
+
+.picker-recent {
+  margin-top: 10px;
+  flex-shrink: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.picker-table-wrap {
+  margin-top: 10px;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.picker-row {
+  cursor: pointer;
+}
+.picker-row:active {
+  background: rgba(86, 214, 255, 0.08);
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
@@ -834,12 +915,51 @@ tr:hover .sticky-name {
 
   .trade-tray-main .value { font-size: 0.9rem; }
 
-  .picker-overlay { padding: 0; }
+  .picker-overlay {
+    padding: 0;
+    align-items: flex-end;
+  }
   .picker-sheet {
-    max-height: 85vh;
+    width: 100%;
+    max-height: 75vh;
     border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    padding: 12px 10px;
+  }
+  .picker-subtitle { display: none; }
+  .picker-search-row { margin-top: 8px; }
+  .picker-recent { margin-top: 8px; max-height: 150px; }
+  .picker-table-wrap { margin-top: 8px; }
+
+  /* Hide source columns and rank column in picker on mobile —
+     the picker is for quick selection, not detailed analysis.
+     Player name, position, and value are sufficient. */
+  .picker-source-col { display: none !important; }
+  .picker-rank-col { display: none !important; }
+  .picker-add-col { display: none !important; }
+
+  /* Picker table rows: bigger touch targets */
+  .picker-row td { padding: 10px 8px; }
+
+  /* Trade card buttons: prevent truncation */
+  .trade-remove-btn {
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-size: 0.72rem;
+    padding: 6px 8px;
+  }
+  .trade-add-btn {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  /* Trade controls: compact on mobile */
+  .trade-controls {
+    gap: 6px !important;
+  }
+  .trade-controls .button,
+  .trade-controls .select {
+    font-size: 0.74rem;
+    padding: 6px 8px;
   }
 
   .login-shell { min-height: auto; padding: var(--space-sm); }
@@ -987,6 +1107,19 @@ tr:hover .sticky-name {
   /* Compact tables: reduce padding further */
   th, td { padding: 4px 6px; font-size: 0.7rem; }
   .sticky-name { min-width: 110px; }
+
+  /* Picker: tighter on small phones */
+  .picker-sheet { padding: 10px 8px; max-height: 70vh; }
+  .picker-header h3 { font-size: 0.92rem; }
+  .picker-search-row { gap: 6px; }
+  .picker-recent { max-height: 120px; }
+
+  /* Trade cards: compact side header */
+  .trade-remove-btn {
+    font-size: 0.66rem;
+    padding: 4px 6px;
+    min-height: unset;
+  }
 
   /* Tighten the mobile source strip so chips fit on 320w viewports
      (iPhone SE / older devices).  Narrower strip + smaller chip

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -565,7 +565,7 @@ export default function TradePage() {
 
       {!loading && !error && (
         <>
-          <div className="row" style={{ marginBottom: 10, flexWrap: "wrap" }}>
+          <div className="row trade-controls" style={{ marginBottom: 10, flexWrap: "wrap", gap: 8 }}>
             <select className="select" value={valueMode} onChange={(e) => setValueMode(e.target.value)}>
               {VALUE_MODES.map((m) => (<option key={m.key} value={m.key}>{m.label}</option>))}
             </select>
@@ -615,7 +615,7 @@ export default function TradePage() {
                         <div className="value">{Math.round(total.pw).toLocaleString()}</div>
                         <div className="muted" style={{ fontSize: "0.64rem" }}>Linear: {Math.round(total.lin).toLocaleString()}</div>
                       </div>
-                      <button className="button" onClick={() => openPickerFor(sideIdx)}>+ Add</button>
+                      <button className="button trade-add-btn" onClick={() => openPickerFor(sideIdx)}>+ Add</button>
                     </div>
                   </div>
                   <div className="list" style={{ marginTop: 10 }}>
@@ -636,7 +636,7 @@ export default function TradePage() {
                             </div>
                             <div className="asset-meta">{r.pos} · Consensus {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
                           </div>
-                          <button className="button" onClick={() => removeFromSide(r.name, sideIdx)}>Remove</button>
+                          <button className="button trade-remove-btn" onClick={() => removeFromSide(r.name, sideIdx)}>Remove</button>
                         </div>
                       );
                     })}
@@ -983,18 +983,18 @@ export default function TradePage() {
           {pickerOpen && (
             <div className="picker-overlay" onClick={() => setPickerOpen(false)}>
               <div className="picker-sheet" onClick={(e) => e.stopPropagation()}>
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10 }}>
-                  <div>
-                    <h3 style={{ margin: 0 }}>Add Asset to Side {sides[activeSide]?.label || "?"}</h3>
-                    <p className="muted" style={{ margin: "4px 0 0 0", fontSize: "0.76rem" }}>Tap a player/pick to add instantly.</p>
+                <div className="picker-header">
+                  <div style={{ minWidth: 0 }}>
+                    <h3 style={{ margin: 0 }}>Add to Side {sides[activeSide]?.label || "?"}</h3>
+                    <p className="muted picker-subtitle">Tap a player/pick to add instantly.</p>
                   </div>
-                  <button className="button" onClick={() => setPickerOpen(false)}>Close</button>
+                  <button className="picker-close" onClick={() => setPickerOpen(false)} aria-label="Close picker">&times;</button>
                 </div>
-                <div className="row" style={{ marginTop: 10 }}>
+                <div className="picker-search-row">
                   <input
                     ref={pickerInputRef}
                     className="input"
-                    placeholder="Search player or pick"
+                    placeholder="Search player or pick..."
                     value={pickerQuery}
                     onChange={(e) => setPickerQuery(e.target.value)}
                     style={{ flex: 1 }}
@@ -1007,14 +1007,14 @@ export default function TradePage() {
                   </select>
                 </div>
                 {!pickerQuery && recentRows.length > 0 && (
-                  <div style={{ marginTop: 10 }}>
+                  <div className="picker-recent">
                     <div className="label" style={{ marginBottom: 6 }}>Recent</div>
                     <div className="list">
                       {recentRows.slice(0, 8).map((r) => (
                         <button key={`recent-${r.name}`} className="asset-row button-reset" onClick={() => addToActiveSide(r)}>
                           <div>
                             <div className="asset-name">{r.name}</div>
-                            <div className="asset-meta">{r.pos} · Consensus {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
+                            <div className="asset-meta">{r.pos} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
                           </div>
                           <span className="badge">Add</span>
                         </button>
@@ -1022,37 +1022,38 @@ export default function TradePage() {
                     </div>
                   </div>
                 )}
-                <div className="table-wrap" style={{ marginTop: 10, maxHeight: "52vh", overflow: "auto" }}>
+                <div className="picker-table-wrap">
                   <table style={{ width: "100%", fontSize: "0.78rem" }}>
                     <thead>
                       <tr>
                         {[
-                          { col: "rank", label: "Our Rank", style: { width: 70, textAlign: "center" } },
+                          { col: "rank", label: "Rank", className: "picker-rank-col", style: { width: 55, textAlign: "center" } },
                           { col: "name", label: "Player" },
-                          { col: "pos", label: "Pos", style: { width: 50 } },
-                          { col: "value", label: "Our Value", style: { width: 80, textAlign: "right" } },
+                          { col: "pos", label: "Pos", style: { width: 46 } },
+                          { col: "value", label: "Value", style: { width: 70, textAlign: "right" } },
                           ...RANKING_SOURCES.map((src) => ({
                             col: `src:${src.key}`,
                             label: src.columnLabel,
+                            className: "picker-source-col",
                             style: { width: 65, textAlign: "right" },
                           })),
-                        ].map(({ col, label, style }) => (
-                          <th key={col} style={{ cursor: "pointer", userSelect: "none", whiteSpace: "nowrap", ...style }}
+                        ].map(({ col, label, style, className }) => (
+                          <th key={col} className={className || undefined} style={{ cursor: "pointer", userSelect: "none", whiteSpace: "nowrap", ...style }}
                             onClick={() => {
                               if (pickerSortCol === col) setPickerSortAsc((p) => !p);
                               else { setPickerSortCol(col); setPickerSortAsc(["rank", "name", "pos"].includes(col)); }
                             }}>
-                            {label}{pickerSortCol === col ? (pickerSortAsc ? " ▲" : " ▼") : ""}
+                            {label}{pickerSortCol === col ? (pickerSortAsc ? " \u25B2" : " \u25BC") : ""}
                           </th>
                         ))}
-                        <th style={{ width: 40 }}></th>
+                        <th className="picker-add-col" style={{ width: 40 }}></th>
                       </tr>
                     </thead>
                     <tbody>
                       {pickerRows.map((r) => (
-                        <tr key={`pick-${r.name}`} style={{ cursor: "pointer" }} onClick={() => addToActiveSide(r)}>
-                          <td style={{ textAlign: "center", fontFamily: "var(--mono, monospace)", fontWeight: 600, color: "var(--cyan)" }}>
-                            {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"}
+                        <tr key={`pick-${r.name}`} className="picker-row" onClick={() => addToActiveSide(r)}>
+                          <td className="picker-rank-col" style={{ textAlign: "center", fontFamily: "var(--mono, monospace)", fontWeight: 600, color: "var(--cyan)" }}>
+                            {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "\u2014"}
                           </td>
                           <td style={{ fontWeight: 600 }}>{r.name}</td>
                           <td><span className={posBadgeClass(r)}>{r.pos}</span></td>
@@ -1063,12 +1064,12 @@ export default function TradePage() {
                             const raw = r.canonicalSites?.[src.key];
                             const hasVal = raw != null && Number.isFinite(Number(raw));
                             return (
-                              <td key={src.key} style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.74rem" }}>
-                                {hasVal ? Math.round(Number(raw)).toLocaleString() : "—"}
+                              <td key={src.key} className="picker-source-col" style={{ textAlign: "right", fontFamily: "var(--mono, monospace)", fontSize: "0.74rem" }}>
+                                {hasVal ? Math.round(Number(raw)).toLocaleString() : "\u2014"}
                               </td>
                             );
                           })}
-                          <td><span className="badge" style={{ fontSize: "0.6rem" }}>Add</span></td>
+                          <td className="picker-add-col"><span className="badge" style={{ fontSize: "0.6rem" }}>Add</span></td>
                         </tr>
                       ))}
                     </tbody>


### PR DESCRIPTION
## Summary

- **Picker modal redesigned** — flex-based layout with `max-height: 80vh` on desktop (centered) and `75vh` on mobile (bottom-sheet). Eliminates the old unbounded height that made the modal too large to see entirely.
- **Source/rank columns hidden on mobile** — the 7 ranking-source columns and rank column are hidden via `.picker-source-col` / `.picker-rank-col` CSS classes at ≤768px, eliminating horizontal scroll in the picker. Player name, position, and value are sufficient for quick selection.
- **Touch targets improved** — picker table rows get `10px` vertical padding on mobile; the close button is a dedicated `36×36px` × button instead of a text "Close" button; row tap highlights on `:active`.
- **Trade card buttons no longer truncate** — "Remove" and "+ Add" buttons get `flex-shrink: 0; white-space: nowrap` so they don't get squeezed to "Rem..." on narrow screens.
- **Asset name/meta overflow handled** — `text-overflow: ellipsis` on `.asset-name` and `.asset-meta` prevents long player names from causing horizontal scroll on trade cards.
- **Trade controls compact on mobile** — smaller font/padding for the value-mode selector, Swap/Clear/Add Team buttons at ≤768px.

## Test plan

- [ ] Open trade calculator on mobile (or Chrome DevTools responsive mode at 375px, 420px widths)
- [ ] Tap "+ Add" on a trade side — picker should appear as a compact bottom sheet with no horizontal scroll
- [ ] Search for a player, verify results show Player/Pos/Value columns only (no source columns on mobile)
- [ ] Tap a row to add a player — verify it adds and the row highlights on tap
- [ ] Verify "Remove" button text is fully visible (not truncated) on trade cards
- [ ] On desktop, verify the picker is centered vertically with max-height constraint
- [ ] Verify source columns still appear in the picker on desktop (≥769px)

https://claude.ai/code/session_01HpBkX4hxgsfZAH7mLH3z5n