### PR TITLE
Rename KTC/Consensus Premium to Sell/Buy Signals

### DIFF
--- a/frontend/__tests__/edge-helpers.test.js
+++ b/frontend/__tests__/edge-helpers.test.js
@@ -230,8 +230,7 @@ describe("topRetailPremium", () => {
     const result = topRetailPremium(rows, 3);
     expect(result).toHaveLength(2); // A and B (D is below threshold)
     expect(result[0].name).toBe("B"); // 80 > 50
-    // Retail label is dynamic — today "KTC" since KTC is the only retail source.
-    expect(result[0].detail).toBe("KTC +80 ranks");
+    expect(result[0].detail).toBe("Sell +80 ranks");
   });
 
   it("excludes quarantined rows", () => {
@@ -249,7 +248,7 @@ describe("topConsensusPremium", () => {
     ];
     const result = topConsensusPremium(rows);
     expect(result).toHaveLength(1);
-    expect(result[0].detail).toBe("Consensus +40 ranks");
+    expect(result[0].detail).toBe("Buy +40 ranks");
   });
 });
 
@@ -317,8 +316,8 @@ describe("getLens", () => {
 
 // ── isTopRankedForEdgePremium ────────────────────────────────────────
 //
-// The Edge page's Retail Premium / Consensus Premium sections are
-// pinned to the top 200 by consensus rank OR KTC rank so deep-bench
+// The Edge page's Sell Signals / Buy Signals sections are pinned to
+// the top 200 by consensus rank OR KTC rank so deep-bench
 // disagreements (which have no trade relevance) don't flood the
 // sections.  This block pins every eligibility branch.
 

--- a/frontend/app/edge/page.jsx
+++ b/frontend/app/edge/page.jsx
@@ -138,8 +138,8 @@ const COL_GAP_DIR = {
   thStyle: { width: 70 },
   tdStyle: { fontSize: "0.78rem" },
   render: (r) => {
-    if (r.marketGapDirection === "retail_premium") return <span className="text-cyan">{getRetailLabel()}</span>;
-    if (r.marketGapDirection === "consensus_premium") return <span className="text-amber">Consensus</span>;
+    if (r.marketGapDirection === "retail_premium") return <span className="text-cyan">Sell</span>;
+    if (r.marketGapDirection === "consensus_premium") return <span className="text-amber">Buy</span>;
     return <span className="muted">\u2014</span>;
   },
 };
@@ -362,9 +362,9 @@ export default function EdgePage() {
               />
             </EdgeSection>
 
-            {/* Retail Premium (today: KTC) */}
+            {/* Sell Signals — retail (KTC) values higher than consensus */}
             <EdgeSection
-              title={`${getRetailLabel()} Premium`}
+              title="Sell Signals"
               description={`Players the retail market (${getRetailLabel()}) values much higher than the expert consensus. Limited to players inside the top ${EDGE_PREMIUM_RANK_LIMIT} by consensus or ${getRetailLabel()} rank so only trade-relevant gaps surface. Potential sells to retail-first trade partners.`}
               count={`${retailPremium.length} shown`}
               accent="cyan"
@@ -372,14 +372,14 @@ export default function EdgePage() {
               <SectionTable
                 rows={retailPremium}
                 onPlayerClick={openPlayerPopup}
-                emptyText={`No significant ${getRetailLabel()} premiums in the top ${EDGE_PREMIUM_RANK_LIMIT}.`}
+                emptyText={`No sell signals in the top ${EDGE_PREMIUM_RANK_LIMIT}.`}
                 columns={[COL_RANK, COL_PLAYER, COL_POS, COL_SPREAD, COL_VALUE]}
               />
             </EdgeSection>
 
-            {/* Consensus Premium */}
+            {/* Buy Signals — consensus values higher than retail */}
             <EdgeSection
-              title="Consensus Premium"
+              title="Buy Signals"
               description={`Players the expert consensus values much higher than ${getRetailLabel()}. Limited to players inside the top ${EDGE_PREMIUM_RANK_LIMIT} by consensus or ${getRetailLabel()} rank so only trade-relevant gaps surface. Potential buys from retail-first trade partners.`}
               count={`${consensusPremium.length} shown`}
               accent="cyan"
@@ -387,7 +387,7 @@ export default function EdgePage() {
               <SectionTable
                 rows={consensusPremium}
                 onPlayerClick={openPlayerPopup}
-                emptyText={`No significant consensus premiums in the top ${EDGE_PREMIUM_RANK_LIMIT}.`}
+                emptyText={`No buy signals in the top ${EDGE_PREMIUM_RANK_LIMIT}.`}
                 columns={[COL_RANK, COL_PLAYER, COL_POS, COL_SPREAD, COL_VALUE]}
               />
             </EdgeSection>

--- a/frontend/app/finder/page.jsx
+++ b/frontend/app/finder/page.jsx
@@ -305,9 +305,9 @@ export default function FinderPage() {
                           {workflow.showGap && (
                             <td style={{ fontSize: "0.78rem" }}>
                               {row.marketGapDirection === "retail_premium" ? (
-                                <span className="text-cyan">{getRetailLabel()}</span>
+                                <span className="text-cyan">Sell</span>
                               ) : row.marketGapDirection === "consensus_premium" ? (
-                                <span className="text-amber">Consensus</span>
+                                <span className="text-amber">Buy</span>
                               ) : (
                                 <span className="muted">\u2014</span>
                               )}

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -208,15 +208,15 @@ function EdgeRail({ summary, onPlayerClick }) {
       </div>
       <div className="edge-rail-grid">
         <EdgeRailSection
-          label={`${retailLabel} Premium`}
+          label="Sell Signals"
           items={summary.retailPremium}
-          emptyText={`No significant ${retailLabel} premiums`}
+          emptyText="No sell signals"
           onPlayerClick={onPlayerClick}
         />
         <EdgeRailSection
-          label="Consensus Premium"
+          label="Buy Signals"
           items={summary.consensusPremium}
-          emptyText="No significant consensus premiums"
+          emptyText="No buy signals"
           onPlayerClick={onPlayerClick}
         />
         <EdgeRailSection

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -235,10 +235,8 @@ export function applyLens(rows, lensKey) {
  * expert consensus (every non-retail source averaged).  These are
  * players the retail market values more than the experts do.
  *
- * The detail label is resolved dynamically from the registry via
- * `getRetailLabel()`, so today it reads "KTC +N ranks" and a future
- * two-retail-source world would read "Retail +N ranks" with no code
- * edits here.
+ * Sell signals: players the retail market values much higher than the
+ * expert consensus — potential sells to retail-first trade partners.
  */
 export function topRetailPremium(rows, limit = 5) {
   const retailLabel = getRetailLabel();
@@ -250,16 +248,15 @@ export function topRetailPremium(rows, limit = 5) {
       name: r.name,
       pos: r.pos,
       rank: r.rank,
-      detail: `${retailLabel} +${r.sourceRankSpread} ranks`,
+      detail: `Sell +${r.sourceRankSpread} ranks`,
       row: r,
     }));
 }
 
 /**
- * Top players where the expert consensus (every non-retail source
- * averaged) ranks them much higher than the retail market.  These are
- * players the experts value more than retail does — potential "buy
- * low" targets from retail-first trade partners.
+ * Buy signals: players the expert consensus values much higher than
+ * the retail market — potential buy-low targets from retail-first
+ * trade partners.
  */
 export function topConsensusPremium(rows, limit = 5) {
   return rows
@@ -270,7 +267,7 @@ export function topConsensusPremium(rows, limit = 5) {
       name: r.name,
       pos: r.pos,
       rank: r.rank,
-      detail: `Consensus +${r.sourceRankSpread} ranks`,
+      detail: `Buy +${r.sourceRankSpread} ranks`,
       row: r,
     }));
 }

--- a/frontend/lib/thresholds.js
+++ b/frontend/lib/thresholds.js
@@ -52,11 +52,11 @@ export const EDGE_CAUTION_RANK_LIMIT = 300;
 
 /**
  * Maximum rank (by consensus OR retail/KTC) for players to appear in
- * the Edge page's Retail Premium / Consensus Premium sections.  Deep-
- * bench players can have huge source disagreements without any real
- * trade relevance, so we pin both premium sections to players inside
- * the top 200 of either scale.  A player qualifies when EITHER their
- * consensus rank is <= 200 OR their per-source KTC rank is <= 200.
+ * the Edge page's Sell Signals / Buy Signals sections.  Deep-bench
+ * players can have huge source disagreements without any real trade
+ * relevance, so we pin both sections to players inside the top 200 of
+ * either scale.  A player qualifies when EITHER their consensus rank
+ * is <= 200 OR their per-source KTC rank is <= 200.
  */
 export const EDGE_PREMIUM_RANK_LIMIT = 200;
 


### PR DESCRIPTION
## Summary\n\n- Renamed **KTC Premium** → **Sell Signals** (retail values player higher than consensus = sell opportunity)\n- Renamed **Consensus Premium** → **Buy Signals** (consensus values player higher than retail = buy opportunity)\n- Updated section titles, descriptions, empty-state text, detail strings, gap-direction column labels, comments, and test expectations across 6 files\n\n## Files changed\n\n- `frontend/app/edge/page.jsx` — section titles, descriptions, empty text, gap column labels\n- `frontend/app/rankings/page.jsx` — edge rail section labels and empty text\n- `frontend/app/finder/page.jsx` — gap direction column labels\n- `frontend/lib/edge-helpers.js` — detail strings and comments\n- `frontend/lib/thresholds.js` — comments\n- `frontend/__tests__/edge-helpers.test.js` — updated expectations and comments\n\n## Test plan\n\n- [x] Python tests pass (1198 passed)\n- [x] Frontend Vitest tests pass (366 passed)\n- [ ] Visual check: Edge page shows \"Sell Signals\" and \"Buy Signals\" section headers\n- [ ] Visual check: Rankings page edge rail shows updated labels\n- [ ] Visual check: Finder page gap column shows \"Sell\" / \"Buy\"\n\nhttps://claude.ai/code/session_016Ts4EocmbJE5kbJJv4mxgc