### PR TITLE
Anchor 2026 slot picks to merged offense+IDP rookie values

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2753,6 +2753,79 @@ def _suppress_generic_pick_tiers_when_slots_exist(
     return aliases
 
 
+# Rookie anchor: slot-specific picks in the current rookie-draft year are
+# pinned to the top-N merged (offense + IDP) rookies so pick values in the
+# rankings and trade calculator match the rookies they will become.
+#
+# 12-team league assumption: pick (round, slot) → rookie rank = (round-1)*12 + slot.
+# Only affects rows consumed via /api/data (rankings + trade calculator).
+# /api/draft-capital is served by a separate code path (server.py::_fetch_draft_capital)
+# that reads from the draft spreadsheet and is untouched by this pass.
+_ROOKIE_ANCHOR_LEAGUE_SIZE = 12
+_ROOKIE_ANCHOR_ROUNDS = 6
+
+
+def _anchor_current_year_picks_to_rookies(
+    players_array: list[dict[str, Any]],
+    anchor_year: int,
+) -> int:
+    """Override ``rankDerivedValue`` on slot-specific picks in ``anchor_year``
+    so each pick inherits the value of its corresponding rookie.
+
+    Rookie ordering is a merged list of offense + IDP rookies sorted by
+    ``rankDerivedValue`` descending.  Pick (round, slot) maps 1-indexed to
+    rookie position = ``(round - 1) * 12 + slot`` in the merged list.
+
+    Returns the number of picks anchored.  Callers are responsible for
+    re-sorting the board by ``rankDerivedValue`` afterward so rank/value
+    monotonicity (``assert_ranking_coherence``) is preserved.
+    """
+    rookies = [
+        r
+        for r in players_array
+        if r.get("assetClass") != "pick"
+        and bool(r.get("rookie"))
+        and r.get("canonicalConsensusRank")
+        and (r.get("rankDerivedValue") or 0) > 0
+    ]
+    if not rookies:
+        return 0
+    rookies.sort(
+        key=lambda r: (
+            -int(r.get("rankDerivedValue") or 0),
+            int(r.get("canonicalConsensusRank") or 0),
+        )
+    )
+
+    anchored = 0
+    for row in players_array:
+        if row.get("assetClass") != "pick":
+            continue
+        parsed = _parse_pick_slot(row.get("canonicalName") or "")
+        if parsed is None:
+            continue
+        year, rnd, slot = parsed
+        if year != anchor_year:
+            continue
+        if not (1 <= rnd <= _ROOKIE_ANCHOR_ROUNDS):
+            continue
+        if not (1 <= slot <= _ROOKIE_ANCHOR_LEAGUE_SIZE):
+            continue
+        idx = (rnd - 1) * _ROOKIE_ANCHOR_LEAGUE_SIZE + (slot - 1)
+        if idx >= len(rookies):
+            continue
+        anchor = rookies[idx]
+        anchor_val = int(anchor.get("rankDerivedValue") or 0)
+        if anchor_val <= 0:
+            continue
+        if not row.get("canonicalConsensusRank"):
+            continue
+        row["rankDerivedValue"] = anchor_val
+        row["pickRookieAnchor"] = anchor.get("canonicalName")
+        anchored += 1
+    return anchored
+
+
 def _compute_pick_confidence(
     canonical_sites: dict[str, Any],
     is_slot_specific: bool,
@@ -3466,15 +3539,26 @@ def _compute_unified_rankings(
     #    specific slots, returning a {generic_name: slot_alias} map.
     pick_aliases = _suppress_generic_pick_tiers_when_slots_exist(players_array)
 
-    # 2a) Compact ranks after suppression so the ranked board is still
-    #     contiguous 1..N.  This walks the surviving ranked rows in
-    #     ascending-rank order and renumbers them 1..N.  Values stay
-    #     monotonic because we are only *removing* rows from a sequence
-    #     that was already monotonic.  Tier IDs are re-derived from the
-    #     new ranks.
+    # 2b) Anchor current-year slot picks to merged offense+IDP rookies.
+    #     Pick (round, slot) inherits the rankDerivedValue of the rookie
+    #     at position (round-1)*12 + slot in the merged rookie list.  The
+    #     compact-ranks pass below re-sorts by value so coherence holds.
+    _anchor_year = int(_load_pick_year_discount().get("baselineYear") or 2026)
+    _anchor_current_year_picks_to_rookies(players_array, _anchor_year)
+
+    # 2a) Compact ranks after suppression/anchor so the ranked board is
+    #     still contiguous 1..N and value-monotonic.  Sort primarily by
+    #     rankDerivedValue desc so anchored picks naturally bubble to the
+    #     neighborhood of their rookie target; fall back to the existing
+    #     canonicalConsensusRank to preserve the prior Phase-4 ordering
+    #     for all rows whose values were not mutated.  Tier IDs are
+    #     re-derived from the new ranks.
     ranked_rows = sorted(
         [r for r in players_array if r.get("canonicalConsensusRank")],
-        key=lambda r: int(r["canonicalConsensusRank"]),
+        key=lambda r: (
+            -int(r.get("rankDerivedValue") or 0),
+            int(r["canonicalConsensusRank"]),
+        ),
     )
     for new_rank, r in enumerate(ranked_rows, start=1):
         old_rank = r.get("canonicalConsensusRank")
@@ -3515,6 +3599,8 @@ def _compute_unified_rankings(
             pdata["pickAliasFor"] = row["pickAliasFor"]
         if row.get("pickYearDiscount") is not None:
             pdata["pickYearDiscount"] = row["pickYearDiscount"]
+        if row.get("pickRookieAnchor"):
+            pdata["pickRookieAnchor"] = row["pickRookieAnchor"]
 
     return pick_aliases
 

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3566,6 +3566,31 @@ def _compute_unified_rankings(
             r["canonicalConsensusRank"] = new_rank
         r["canonicalTierId"] = _tier_id_from_rank(new_rank)
 
+    # 2c) Mirror the post-anchor rank back into the legacy players_by_name
+    #     dict for every ranked row — not just picks.  The runtime view
+    #     (/api/data?view=app) strips playersArray, so the frontend reads
+    #     ``_canonicalConsensusRank`` from the legacy dict.  When the
+    #     compact-ranks pass above re-sorts by rankDerivedValue, non-pick
+    #     rows can shift (e.g. a rookie-anchored pick bubbles up past a
+    #     bench player, pushing the bench player's rank down by one).  The
+    #     pick-only mirror below handles pick-specific flags, so keep it
+    #     focused on picks; this pass syncs the ranked-row baseline.
+    for row in players_array:
+        if row.get("assetClass") == "pick":
+            continue
+        legacy_ref = row.get("legacyRef")
+        if not legacy_ref or legacy_ref not in players_by_name:
+            continue
+        pdata = players_by_name[legacy_ref]
+        if not isinstance(pdata, dict):
+            continue
+        rk = row.get("canonicalConsensusRank")
+        if rk is not None:
+            pdata["_canonicalConsensusRank"] = rk
+        tid = row.get("canonicalTierId")
+        if tid is not None:
+            pdata["canonicalTierId"] = tid
+
     # 3) Mirror the post-refinement rank/value back into the legacy
     #    players_by_name dict so the runtime view stays in sync.
     for row in players_array:

--- a/tests/api/test_pick_rookie_anchor.py
+++ b/tests/api/test_pick_rookie_anchor.py
@@ -1,0 +1,233 @@
+"""Rookie anchor pass tests.
+
+When slot-specific 2026 picks are present alongside rookies, each pick
+should inherit the ``rankDerivedValue`` of the corresponding merged
+offense+IDP rookie (pick 1.01 <-> rookie #1, pick 1.02 <-> rookie #2,
+and so on through all 72 slots in 6 rounds * 12 slots).
+
+The pass runs inside ``_compute_unified_rankings`` after
+``_reassign_pick_slot_order`` and ``_suppress_generic_pick_tiers``.
+It only mutates ``rankDerivedValue`` (and stamps
+``pickRookieAnchor``); the compact-ranks pass that follows re-sorts
+the board by value so coherence is preserved.
+
+Run with:  python3 -m pytest tests/api/test_pick_rookie_anchor.py -v
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from src.api.data_contract import (
+    _anchor_current_year_picks_to_rookies,
+    assert_ranking_coherence,
+    build_api_data_contract,
+)
+
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+def _make_rookie(name: str, rank: int, value: int) -> dict[str, Any]:
+    return {
+        "canonicalName": name,
+        "assetClass": "player",
+        "rookie": True,
+        "canonicalConsensusRank": rank,
+        "rankDerivedValue": value,
+    }
+
+
+def _make_pick(name: str, rank: int, value: int) -> dict[str, Any]:
+    return {
+        "canonicalName": name,
+        "assetClass": "pick",
+        "rookie": False,
+        "canonicalConsensusRank": rank,
+        "rankDerivedValue": value,
+    }
+
+
+class TestAnchorPassCore(unittest.TestCase):
+    """Synthetic playersArray exercises — no live data required."""
+
+    def test_1_01_matches_top_rookie(self) -> None:
+        rookies = [_make_rookie(f"Rookie {i}", i, 10000 - i * 10) for i in range(1, 13)]
+        picks = [
+            _make_pick(f"2026 Pick 1.{slot:02d}", 80 + slot, 6000 - slot * 50)
+            for slot in range(1, 13)
+        ]
+        players_array = rookies + picks
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+        self.assertEqual(anchored, 12)
+        self.assertEqual(
+            picks[0]["rankDerivedValue"], rookies[0]["rankDerivedValue"]
+        )
+        self.assertEqual(picks[0]["pickRookieAnchor"], "Rookie 1")
+
+    def test_slot_mapping_is_monotonic(self) -> None:
+        rookies = [_make_rookie(f"R{i}", i, 20000 - i * 7) for i in range(1, 80)]
+        picks = []
+        for rnd in range(1, 7):
+            for slot in range(1, 13):
+                picks.append(
+                    _make_pick(
+                        f"2026 Pick {rnd}.{slot:02d}",
+                        100 + (rnd - 1) * 12 + slot,
+                        500 - rnd * 10 - slot,
+                    )
+                )
+        players_array = rookies + picks
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+        self.assertEqual(anchored, 72)
+
+        # Walk picks in slot order; values must strictly decrease
+        # because the rookie list is strictly decreasing.
+        prev_val: int | None = None
+        for rnd in range(1, 7):
+            for slot in range(1, 13):
+                name = f"2026 Pick {rnd}.{slot:02d}"
+                row = next(p for p in picks if p["canonicalName"] == name)
+                val = row["rankDerivedValue"]
+                if prev_val is not None:
+                    self.assertLess(val, prev_val, f"{name}: {val} >= prev {prev_val}")
+                prev_val = val
+
+    def test_offense_idp_rookies_merge(self) -> None:
+        offense = [_make_rookie(f"OffRook {i}", i, 9000 - i * 20) for i in range(1, 6)]
+        idp = [_make_rookie(f"IdpRook {i}", 30 + i, 8900 - i * 20) for i in range(1, 6)]
+        # Interleave by value: off1=8980, idp1=8880, off2=8960, idp2=8860, ...
+        picks = [_make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 100) for s in range(1, 8)]
+        players_array = offense + idp + picks
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        merged_sorted = sorted(
+            offense + idp, key=lambda r: -r["rankDerivedValue"]
+        )
+        for i, pick in enumerate(picks):
+            if i >= len(merged_sorted):
+                continue
+            self.assertEqual(
+                pick["rankDerivedValue"],
+                merged_sorted[i]["rankDerivedValue"],
+                f"pick {pick['canonicalName']} should match merged "
+                f"rookie #{i+1}",
+            )
+
+    def test_wrong_year_untouched(self) -> None:
+        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 4)]
+        pick_2027 = _make_pick("2027 Pick 1.01", 50, 4200)
+        pick_2026 = _make_pick("2026 Pick 1.01", 51, 4100)
+        players_array = rookies + [pick_2026, pick_2027]
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        self.assertEqual(pick_2027["rankDerivedValue"], 4200)  # untouched
+        self.assertEqual(pick_2026["rankDerivedValue"], 8990)  # top rookie
+
+    def test_generic_tier_rows_untouched(self) -> None:
+        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 4)]
+        tier_pick = _make_pick("2026 Early 1st", 40, 5500)
+        players_array = rookies + [tier_pick]
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        # Generic tier rows (Early/Mid/Late) don't parse as slot picks
+        # and are left alone.
+        self.assertEqual(tier_pick["rankDerivedValue"], 5500)
+        self.assertNotIn("pickRookieAnchor", tier_pick)
+
+    def test_no_rookies_is_noop(self) -> None:
+        picks = [
+            _make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 5000 - s * 10)
+            for s in range(1, 13)
+        ]
+        before = [p["rankDerivedValue"] for p in picks]
+        anchored = _anchor_current_year_picks_to_rookies(picks, 2026)
+        self.assertEqual(anchored, 0)
+        self.assertEqual([p["rankDerivedValue"] for p in picks], before)
+
+    def test_unranked_pick_skipped(self) -> None:
+        rookies = [_make_rookie("R1", 1, 9000)]
+        pick = _make_pick("2026 Pick 1.01", 0, 0)
+        pick["canonicalConsensusRank"] = None
+        players_array = rookies + [pick]
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+        self.assertEqual(anchored, 0)
+        self.assertNotIn("pickRookieAnchor", pick)
+
+    def test_beyond_72_rookies_unused(self) -> None:
+        # Only 60 rookies available; pick 6.01 (index 60) has no anchor.
+        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 61)]
+        pick_601 = _make_pick("2026 Pick 6.01", 200, 2000)
+        players_array = rookies + [pick_601]
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        # idx = 5*12 + 0 = 60 which is >= len(rookies)=60, so untouched.
+        self.assertEqual(pick_601["rankDerivedValue"], 2000)
+        self.assertNotIn("pickRookieAnchor", pick_601)
+
+
+class TestAnchorEndToEnd(unittest.TestCase):
+    """Verify the anchor flows end-to-end through the real contract
+    build when a live scraper export is available."""
+
+    def setUp(self) -> None:
+        data_dir = _REPO / "exports" / "latest"
+        json_files = sorted(data_dir.glob("dynasty_data_*.json"), reverse=True)
+        if not json_files:
+            self.skipTest("No live scraper export available")
+        with json_files[0].open() as f:
+            raw = json.load(f)
+        self.contract = build_api_data_contract(raw)
+
+    def test_2026_1_01_matches_top_rookie_value(self) -> None:
+        rows = self.contract["playersArray"]
+        rookies = sorted(
+            [
+                r
+                for r in rows
+                if r.get("assetClass") != "pick"
+                and bool(r.get("rookie"))
+                and (r.get("rankDerivedValue") or 0) > 0
+            ],
+            key=lambda r: -int(r["rankDerivedValue"]),
+        )
+        if not rookies:
+            self.skipTest("No rookies in contract")
+
+        pick_101 = next(
+            (r for r in rows if r.get("canonicalName") == "2026 Pick 1.01"),
+            None,
+        )
+        if pick_101 is None:
+            self.skipTest("No 2026 Pick 1.01 in contract")
+        self.assertEqual(
+            pick_101.get("rankDerivedValue"), rookies[0]["rankDerivedValue"]
+        )
+        self.assertEqual(
+            pick_101.get("pickRookieAnchor"), rookies[0]["canonicalName"]
+        )
+
+    def test_coherence_preserved_after_anchor(self) -> None:
+        ranked = sorted(
+            [
+                r
+                for r in self.contract["playersArray"]
+                if r.get("canonicalConsensusRank")
+            ],
+            key=lambda r: int(r["canonicalConsensusRank"]),
+        )
+        errors = assert_ranking_coherence(ranked)
+        self.assertEqual(errors, [], "\n".join(errors[:5]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_pick_rookie_anchor.py
+++ b/tests/api/test_pick_rookie_anchor.py
@@ -228,6 +228,28 @@ class TestAnchorEndToEnd(unittest.TestCase):
         errors = assert_ranking_coherence(ranked)
         self.assertEqual(errors, [], "\n".join(errors[:5]))
 
+    def test_legacy_dict_mirror_matches_players_array(self) -> None:
+        # The runtime view strips playersArray and the frontend reads
+        # ``_canonicalConsensusRank`` from the legacy players dict.  When
+        # the compact-ranks pass re-sorts by rankDerivedValue after the
+        # anchor, non-pick rows can shift — the mirror must keep up or
+        # the rankings board shows stale / duplicate ranks.
+        legacy = self.contract.get("players") or {}
+        mismatches: list[str] = []
+        for row in self.contract["playersArray"]:
+            legacy_ref = row.get("legacyRef")
+            if not legacy_ref or legacy_ref not in legacy:
+                continue
+            arr_rank = row.get("canonicalConsensusRank")
+            leg_rank = legacy[legacy_ref].get("_canonicalConsensusRank")
+            if arr_rank != leg_rank:
+                mismatches.append(
+                    f"{row.get('canonicalName')}: array={arr_rank} legacy={leg_rank}"
+                )
+                if len(mismatches) >= 5:
+                    break
+        self.assertEqual(mismatches, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Anchors every 2026 slot-specific draft pick (1.01 through 6.12, all 72) to the corresponding rookie in a merged offense + IDP rookie list. Pick 1.01 inherits the top rookie's `rankDerivedValue`, 1.02 the #2 rookie's, and so on. Only affects the rankings page and trade calculator. The `/api/draft-capital` endpoint is untouched.

Spot check against current scraper data (`exports/latest`):

| Pick | Anchored Rookie | Value |
|---|---|---|
| 2026 Pick 1.01 | Jeremiyah Love | 7263 |
| 2026 Pick 1.02 | Carnell Tate | 4737 |
| 2026 Pick 1.03 | Fernando Mendoza | 4734 |
| 2026 Pick 1.04 | Makai Lemon | 4570 |
| ... | ... | ... |
| 2026 Pick 1.12 | Eli Stowers | 2331 |

## Implementation

- New helper `_anchor_current_year_picks_to_rookies()` in `src/api/data_contract.py` runs inside `_compute_unified_rankings` after the slot-monotonization and generic-tier suppression passes.
- Anchor year is sourced from `pick_year_discount.json::baselineYear` (2026) — same concept already used for future-year pick discounts.
- The compact-ranks pass that immediately follows now sorts by `(-rankDerivedValue, canonicalConsensusRank)` so anchored picks naturally land next to their rookie targets and `assert_ranking_coherence` stays green.
- Each anchored pick gets a `pickRookieAnchor` stamp (e.g. `"Jeremiyah Love"`) for transparency, mirrored to the legacy `players` dict alongside the other pick flags.
- 12-team league assumption: pick `(round, slot)` maps to rookie index `(round - 1) * 12 + slot - 1`. Rounds 1-6, slots 1-12 = 72 picks.
- Rookies with fewer than 72 available (off-season edge case) simply leave the remaining later-round picks on the legacy round curve.
- Future-year picks (2027+) and generic tier rows (`2026 Early 1st`, etc.) are intentionally left alone.

## Scope

- Only `view=app` / rankings / trade calculator path (consumes `/api/data` -> `_compute_unified_rankings`)
- `/api/draft-capital` (served by `server.py::_fetch_draft_capital` from the draft spreadsheet) is a separate endpoint and is **not** modified. All 10 existing `test_draft_capital.py` tests still pass unchanged.

## Test plan

- [x] New unit tests cover the mapping (1.01 -> top rookie), slot monotonicity across all 72 picks, offense + IDP merge order, wrong-year pass-through, generic-tier pass-through, no-rookies no-op, unranked-pick skip, and the 72-rookie boundary (`tests/api/test_pick_rookie_anchor.py::TestAnchorPassCore`)
- [x] New end-to-end tests against a live scraper export assert that pick 1.01 == top rookie in the real contract and that `assert_ranking_coherence` returns zero errors after the anchor pass (`TestAnchorEndToEnd`)
- [x] Full suite: **1256 passed, 3 skipped** (no regressions)
- [x] `test_draft_capital.py`: all 10 tests still pass (no behavior change on the draft capital page)
- [x] `test_pick_refinement.py` slot-monotonicity tests still pass (anchor preserves slot order because rookies are rank-monotonic)
- [x] `test_picks_end_to_end.py::test_ranking_coherence_with_picks` still passes

https://claude.ai/code/session_011HfBBtPaL5pQJZUShn8XBh