### PR TITLE
Add mobile sign-out button to top bar

### DIFF
--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -127,6 +127,7 @@ function MobileNav() {
 function MobileTopBar() {
   const pathname = usePathname();
   const { openSearch } = useApp();
+  const { authenticated, logout } = useContext(AuthContext);
 
   // Derive page title from current route
   const pageTitle = (() => {
@@ -152,9 +153,21 @@ function MobileTopBar() {
     <header className="mobile-topbar mobile-only">
       <Link href="/" className="mobile-brand">Brisket</Link>
       <span className="mobile-page-title">{pageTitle}</span>
-      <button className="mobile-search-btn" onClick={openSearch} title="Search" aria-label="Search">
-        /
-      </button>
+      <div className="mobile-topbar-actions">
+        <button className="mobile-search-btn" onClick={openSearch} title="Search" aria-label="Search">
+          /
+        </button>
+        {authenticated && (
+          <button
+            className="mobile-signout-btn"
+            onClick={logout}
+            title="Sign out"
+            aria-label="Sign out"
+          >
+            Sign out
+          </button>
+        )}
+      </div>
     </header>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -177,6 +177,23 @@ a { color: inherit; text-decoration: none; }
   cursor: pointer;
 }
 
+.mobile-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mobile-signout-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
 /* ══════════════════════════════════════════════════════════════════════════
    MOBILE BOTTOM NAV
    ══════════════════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Summary
- Adds a "Sign out" button to the right side of the mobile top bar (next to the search `/` control) so authenticated users can log out without first navigating to `/more`.
- Wires `MobileTopBar` into the existing `AuthContext` so the button only renders when `authenticated === true` and reuses the same `logout` handler as the desktop nav and `/more` page.
- Wraps the right-side controls in a new `.mobile-topbar-actions` flex container and adds a `.mobile-signout-btn` style that mirrors the existing search button styling.

## Test plan
- [ ] Load the site on mobile viewport while signed in — confirm "Sign out" appears in the top bar next to `/`.
- [ ] Tap "Sign out" — confirm it logs the user out (same behavior as the `/more` page button).
- [ ] Load the site on mobile viewport while signed out — confirm the "Sign out" button is hidden.
- [ ] Confirm desktop top bar is unchanged.