### PR TITLE
Launch public /league experience with 11 sections + live award races

### DIFF
--- a/docs/public_league.md
+++ b/docs/public_league.md
@@ -1,0 +1,152 @@
+# Public League Experience
+
+A fully-isolated public `/league` page, its backend pipeline, and the
+data contract that serves it.  This doc is for the next engineer who
+needs to ship, extend, or debug this surface.
+
+## What exists
+
+**Backend** — `src/public_league/`
+- `snapshot.py` + `sleeper_client.py` — Sleeper v1 pull, current +
+  previous dynasty season (fixed at 2 seasons for now).
+- `identity.py` — owner-id-keyed manager registry, team-name aliases,
+  `(leagueId, rosterId) -> ownerId` lookup that is season-scoped.
+- `metrics.py` — shared helpers (matchup pairing, standings,
+  pre-week standings, playoff bracket parsing, chronological walks).
+- One module per public section:
+  - `history.py`, `rivalries.py`, `awards.py`, `records.py`,
+    `franchise.py`, `activity.py`, `draft.py`, `weekly.py`,
+    `superlatives.py`, `archives.py`, `overview.py`.
+- `public_contract.py` — assembles the full contract, enforces the
+  private-field blocklist, versions the payload (`public-league/YYYY-MM-DD.vN`).
+- `snapshot_store.py` — persists the snapshot + contract to disk at
+  `data/public_league/` so a cold server still serves the page.
+
+**Frontend** — `frontend/app/league/page.jsx`
+- Client component.  No `useApp`, no `useDynastyData`, no
+  `lib/league-analysis`, no `lib/dynasty-data`.  Only public data
+  through `frontend/lib/public-league-data.js → /api/public/league*`.
+- 11 tabs: **Home**, History, Rivalries, Awards, Records, Franchises,
+  Trades, Draft, Weekly, Superlatives, Archives.
+- Cross-links: tab switches trigger navigation from inline "→" buttons
+  (e.g., "Full draft center →", "Explore rivalries →").
+
+**Server** — `server.py`
+- `GET /api/public/league` — full contract.
+- `GET /api/public/league/{section}` — any single section.
+- Both set `Cache-Control: public, max-age=60, stale-while-revalidate=300`.
+- Both run `assert_public_payload_safe()` before serialization.
+
+## The architectural rules
+
+1. **No private imports.**  `src/public_league/` must not import from
+   `src.canonical`, `src.api.data_contract`, `src.trade`, or `src.pool`.
+   Enforced by `tests/public_league/test_public_contract.py::ImportSurfaceTests`.
+
+2. **Field-name allowlist.**  Any key matching the private blocklist
+   in `public_contract.py::_PRIVATE_FIELD_BLOCKLIST` short-circuits the
+   response with a 500.  When you add a field, make sure it doesn't
+   collide with that list.
+
+3. **Isolation in the UI.**  `frontend/components/AppShell.jsx` routes
+   `/league` through `PublicAppShell` which never calls
+   `useDynastyData`.  Do **not** add private imports to `page.jsx` — the
+   vitest suite will catch it.
+
+4. **Owner identity is the key.**  Never aggregate by roster_id or
+   team name across seasons.  Season-scoped `(leagueId, rosterId) →
+   ownerId` is the only safe path.  Orphan-roster handoffs stay split;
+   renames merge under one owner with alias history.
+
+## Award engine
+
+`src/public_league/awards.py` is split into:
+- Canonical per-season awards (champion, runner-up, top seed, regular-
+  season crown, points king / black hole, toilet bowl, high / low
+  week).
+- Activity-based awards (Trader / Waiver King / Chaos Agent / Most
+  Active / Pick Hoarder / Silent Assassin / Weekly Hammer / Playoff
+  MVP / Bad Beat / Best Rebuild / Rivalry of the Year).
+- Award races for the in-progress season (top 3 per race), surfaced
+  on the Home tab's "Hot race" card.
+
+Award descriptions (`AWARD_DESCRIPTIONS`) ride the payload so the UI
+never has to hard-code formula copy.
+
+## Data flow (simplified)
+
+```
+Sleeper API  →  sleeper_client.fetch_*  →  snapshot.build_public_snapshot
+                                                 │
+                                                 ▼
+                                         PublicLeagueSnapshot
+                                                 │
+                                                 ▼
+       public_contract.build_public_contract  assembles sections
+                                                 │
+                        assert_public_payload_safe  (final guard)
+                                                 │
+                                                 ▼
+                             /api/public/league response
+                                                 │
+                                                 ▼
+            frontend/lib/public-league-data.js → /league page
+```
+
+## Caveats
+
+- Sleeper's public endpoints have no auth, but they DO rate-limit.  A
+  single server cold-start pulls ~18 weeks × 2 seasons of matchups +
+  transactions + brackets + users + rosters + drafts.  That's
+  ~60+ HTTP GETs — batched sequentially today.  The in-process cache
+  TTL (`PUBLIC_LEAGUE_CACHE_TTL`, default 300s) + disk snapshot keep
+  this tolerable in practice.
+- Some per-player scoring (`players_points`) is inconsistent across
+  seasons.  Trader / Waiver / Playoff-MVP calculations handle the
+  missing case by returning `None` rather than zero — check
+  `awards.py::_player_points_in_week_for_roster`.
+- `playoff_week_start` is read from league settings and defaults to 15
+  if Sleeper does not expose it.
+- `best_rebuild` award is FINALIZED only — it requires both the
+  current and previous season to be complete.
+
+## Tests
+
+Run:
+```
+python -m pytest tests/public_league/ -q   # 111 tests
+cd frontend && npm test                     # full vitest suite
+```
+
+Key files:
+- `tests/public_league/fixtures.py` — two-season deterministic fixture
+  with renames, orphan handoffs, playoff brackets, trades, waivers,
+  rookie drafts, traded picks.
+- `tests/public_league/test_public_contract.py` — safety, identity,
+  section coverage, import-surface scan.
+- `tests/public_league/test_metrics_engines.py` — every metric engine
+  against the fixture.
+- `tests/public_league/test_awards.py` — every award formula + live
+  race ordering + edge cases.
+- `tests/public_league/test_overview.py` — overview derived summaries.
+- `tests/public_league/test_server_routes.py` — FastAPI TestClient
+  integration against the live routes.
+
+## Extending
+
+Adding a new award:
+1. Write the scoring helper in `src/public_league/awards.py` (pattern
+   after `_chaos_agent_scores`).
+2. Add it to `_activity_awards_for_season` for historical output and
+   optionally `_current_season_races` for a live leaderboard.
+3. Register a description in `AWARD_DESCRIPTIONS`.
+4. Add a renderer case in `frontend/app/league/page.jsx::renderAwardValue`.
+5. Write a unit test in `tests/public_league/test_awards.py`.
+
+Adding a new section:
+1. Create `src/public_league/<section>.py` with a `build_section` fn.
+2. Register it in `public_contract.py::_SECTION_BUILDERS`.
+3. Add a renderer component in `page.jsx` and a tab entry in
+   `SUB_TABS`.
+4. Mirror the section key in `frontend/lib/public-league-data.js`.
+5. Add a section coverage test.

--- a/frontend/__tests__/public-league.test.js
+++ b/frontend/__tests__/public-league.test.js
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  PUBLIC_SECTION_KEYS,
+  fetchPublicLeague,
+  fetchPublicSection,
+} from "../lib/public-league-data.js";
+
+// ── Section keys ────────────────────────────────────────────────────────────
+describe("PUBLIC_SECTION_KEYS", () => {
+  it("starts with overview so the front door is always first", () => {
+    expect(PUBLIC_SECTION_KEYS[0]).toBe("overview");
+  });
+
+  it("includes every required public section", () => {
+    const required = [
+      "overview", "history", "rivalries", "awards", "records",
+      "franchise", "activity", "draft", "weekly", "superlatives", "archives",
+    ];
+    for (const key of required) {
+      expect(PUBLIC_SECTION_KEYS).toContain(key);
+    }
+  });
+
+  it("is frozen so accidental mutation throws", () => {
+    expect(Object.isFrozen(PUBLIC_SECTION_KEYS)).toBe(true);
+  });
+});
+
+// ── Data-fetcher behavior ──────────────────────────────────────────────────
+describe("fetchPublicLeague", () => {
+  let origFetch;
+  beforeEach(() => {
+    origFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+    vi.resetAllMocks();
+  });
+
+  it("calls /api/public/league and returns parsed JSON", async () => {
+    const payload = { contractVersion: "x", league: {}, sections: {} };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+    const result = await fetchPublicLeague();
+    expect(result).toEqual(payload);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/public/league",
+      expect.objectContaining({ method: "GET", credentials: "omit" }),
+    );
+  });
+
+  it("propagates refresh=1 when requested", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    await fetchPublicLeague({ refresh: true });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/public/league?refresh=1",
+      expect.any(Object),
+    );
+  });
+
+  it("throws a descriptive error on non-OK response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+    await expect(fetchPublicLeague()).rejects.toThrow(/503/);
+  });
+});
+
+describe("fetchPublicSection", () => {
+  let origFetch;
+  beforeEach(() => {
+    origFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it("rejects unknown section names up front", async () => {
+    await expect(fetchPublicSection("not-a-section")).rejects.toThrow(/Unknown public section/);
+  });
+
+  it("targets /api/public/league/{section}", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    await fetchPublicSection("awards");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/public/league/awards",
+      expect.any(Object),
+    );
+  });
+
+  it("threads owner + refresh through the query string", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    await fetchPublicSection("franchise", { owner: "owner-1", refresh: true });
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toMatch(/\/api\/public\/league\/franchise\?/);
+    expect(url).toMatch(/owner=owner-1/);
+    expect(url).toMatch(/refresh=1/);
+  });
+});
+
+// ── Import-surface guardrails for the page ─────────────────────────────────
+const pageSource = fs.readFileSync(
+  path.resolve(__dirname, "..", "app", "league", "page.jsx"),
+  "utf8",
+);
+
+describe("public /league page isolation", () => {
+  it("does not import useApp / AppShell", () => {
+    expect(pageSource).not.toMatch(/from\s+["']@\/components\/AppShell["']/);
+    expect(pageSource).not.toMatch(/import\s+\{[^}]*useApp[^}]*\}/);
+  });
+
+  it("does not import useDynastyData", () => {
+    expect(pageSource).not.toMatch(/from\s+["']@\/components\/useDynastyData["']/);
+  });
+
+  it("does not import the private league-analysis module", () => {
+    expect(pageSource).not.toMatch(/from\s+["']@\/lib\/league-analysis["']/);
+  });
+
+  it("does not import private dynasty-data / trade-logic / edge-helpers", () => {
+    expect(pageSource).not.toMatch(/from\s+["']@\/lib\/dynasty-data["']/);
+    expect(pageSource).not.toMatch(/from\s+["']@\/lib\/trade-logic["']/);
+    expect(pageSource).not.toMatch(/from\s+["']@\/lib\/edge-helpers["']/);
+  });
+
+  it("pulls data from the public contract fetcher", () => {
+    expect(pageSource).toMatch(/fetchPublicLeague/);
+    expect(pageSource).toMatch(/@\/lib\/public-league-data/);
+  });
+});
+
+// ── AppShell gating sanity ─────────────────────────────────────────────────
+const appShellSource = fs.readFileSync(
+  path.resolve(__dirname, "..", "components", "AppShell.jsx"),
+  "utf8",
+);
+
+describe("AppShell public-route gating", () => {
+  it("includes /league in PUBLIC_ONLY_ROUTE_PREFIXES", () => {
+    expect(appShellSource).toMatch(/PUBLIC_ONLY_ROUTE_PREFIXES[^\n]*\/league/);
+  });
+
+  it("refuses to hydrate useDynastyData inside the public shell", () => {
+    // PublicAppShell must explicitly not call useDynastyData.
+    const publicShellMatch = appShellSource.match(/function PublicAppShell[\s\S]*?^}/m);
+    expect(publicShellMatch).toBeTruthy();
+    expect(publicShellMatch[0]).not.toMatch(/useDynastyData\(/);
+  });
+});

--- a/frontend/app/api/public/league/[section]/route.js
+++ b/frontend/app/api/public/league/[section]/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+// Public league per-section proxy — forwards to the FastAPI backend
+// ``/api/public/league/{section}`` endpoint.  Mirror of the aggregate
+// proxy in ../route.js; section names are validated server-side.
+
+const BACKEND_BASE = (() => {
+  const base = process.env.BACKEND_API_URL || "http://127.0.0.1:8000";
+  try {
+    const u = new URL(base);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return "http://127.0.0.1:8000";
+  }
+})();
+
+export async function GET(req, { params }) {
+  const { section } = await params;
+  const url = new URL(req.url);
+  const qs = url.searchParams.toString();
+  const target = `${BACKEND_BASE}/api/public/league/${encodeURIComponent(section)}${qs ? `?${qs}` : ""}`;
+  try {
+    const res = await fetch(target, { cache: "no-store" });
+    const body = await res.text();
+    const headers = new Headers();
+    const ct = res.headers.get("content-type");
+    if (ct) headers.set("content-type", ct);
+    const cc = res.headers.get("cache-control");
+    if (cc) headers.set("cache-control", cc);
+    return new NextResponse(body, { status: res.status, headers });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Public league backend unreachable: ${err?.message || err}` },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/api/public/league/route.js
+++ b/frontend/app/api/public/league/route.js
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+// Public league contract proxy — forwards to the FastAPI backend
+// ``/api/public/league`` endpoint.  Used in dev (where nginx is not
+// in front of the app) and to ensure the request carries the Next.js
+// edge cache-control headers.  This route is INTENTIONALLY public
+// (no auth check) because the backend endpoint itself is public.
+
+const BACKEND_BASE = (() => {
+  const base = process.env.BACKEND_API_URL || "http://127.0.0.1:8000";
+  try {
+    const u = new URL(base);
+    // Strip trailing /api/data if the env var was set for the private
+    // route — we want just origin + /api/public/league.
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return "http://127.0.0.1:8000";
+  }
+})();
+
+export async function GET(req) {
+  const url = new URL(req.url);
+  const qs = url.searchParams.toString();
+  const target = `${BACKEND_BASE}/api/public/league${qs ? `?${qs}` : ""}`;
+  try {
+    const res = await fetch(target, { cache: "no-store" });
+    const body = await res.text();
+    const headers = new Headers();
+    const ct = res.headers.get("content-type");
+    if (ct) headers.set("content-type", ct);
+    const cc = res.headers.get("cache-control");
+    if (cc) headers.set("cache-control", cc);
+    return new NextResponse(body, { status: res.status, headers });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Public league backend unreachable: ${err?.message || err}` },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/league/franchise/[owner]/page.jsx
+++ b/frontend/app/league/franchise/[owner]/page.jsx
@@ -1,0 +1,219 @@
+"use client";
+
+// Dedicated, deep-linkable /league/franchise/[owner] route.
+//
+// Hits GET /api/public/league/franchise?owner=<ownerId> which returns
+// the index + detail map PLUS a narrowed ``franchiseDetail`` block so
+// we don't need to download every franchise's detail to render one.
+// Purely public data — see the isolation contract in page.jsx.
+
+import { Suspense, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { LoadingState, EmptyState, PageHeader } from "@/components/ui";
+import { fetchPublicSection } from "@/lib/public-league-data";
+import {
+  Avatar,
+  Card,
+  Stat,
+  buildManagerLookup,
+  fmtNumber,
+} from "../../shared.jsx";
+
+export default function FranchisePageRoute() {
+  return (
+    <Suspense fallback={<LoadingState message="Loading franchise..." />}>
+      <FranchisePage />
+    </Suspense>
+  );
+}
+
+function FranchisePage() {
+  const params = useParams();
+  const ownerId = decodeURIComponent(String(params?.owner || ""));
+  const [state, setState] = useState({ loading: true, error: "", payload: null });
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const payload = await fetchPublicSection("franchise", { owner: ownerId });
+        if (!active) return;
+        setState({ loading: false, error: "", payload });
+      } catch (err) {
+        if (!active) return;
+        setState({
+          loading: false,
+          error: err?.message || "Failed to load franchise data",
+          payload: null,
+        });
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [ownerId]);
+
+  if (state.loading) return <LoadingState message="Loading franchise..." />;
+  if (state.error) {
+    return (
+      <div className="card">
+        <EmptyState title="Franchise unavailable" message={state.error} />
+        <div style={{ marginTop: 10 }}>
+          <Link href="/league" style={{ color: "var(--cyan)" }}>← Back to league</Link>
+        </div>
+      </div>
+    );
+  }
+
+  const { league, franchiseDetail } = state.payload || {};
+  const fr = franchiseDetail || state.payload?.data?.detail?.[ownerId] || null;
+  const managers = buildManagerLookup(league);
+
+  if (!fr) {
+    return (
+      <div className="card">
+        <EmptyState title="Franchise not found" message={`No public franchise record for owner ${ownerId}.`} />
+        <div style={{ marginTop: 10 }}>
+          <Link href="/league" style={{ color: "var(--cyan)" }}>← Back to league</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section>
+      <div className="card">
+        <div style={{ fontSize: "0.72rem", marginBottom: 6 }}>
+          <Link href="/league" style={{ color: "var(--cyan)" }}>← League home</Link>
+          {" · "}
+          <Link href="/league?tab=franchise" style={{ color: "var(--cyan)" }}>All franchises</Link>
+        </div>
+        <PageHeader
+          title={fr.displayName}
+          subtitle={`Current team: ${fr.currentTeamName || "—"}`}
+        />
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <Avatar managers={managers} ownerId={ownerId} size={64} />
+          <div style={{ fontSize: "0.74rem", color: "var(--subtext)" }}>
+            {fr.topRival && (
+              <div>
+                Top rival:{" "}
+                <Link href={`/league/franchise/${encodeURIComponent(fr.topRival.ownerId)}`} style={{ color: "var(--cyan)" }}>
+                  {fr.topRival.displayName}
+                </Link>
+                {" · Index "}{fr.topRival.rivalryIndex}
+              </div>
+            )}
+            <div>
+              Owner ID: <span style={{ fontFamily: "var(--mono)" }}>{ownerId}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Card title="Cumulative">
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+            gap: 10,
+          }}
+        >
+          <Stat label="Seasons" value={fr.cumulative.seasonsPlayed} />
+          <Stat
+            label="Record"
+            value={`${fr.cumulative.wins}-${fr.cumulative.losses}${fr.cumulative.ties ? `-${fr.cumulative.ties}` : ""}`}
+          />
+          <Stat label="Points for" value={fmtNumber(fr.cumulative.pointsFor, 1)} />
+          <Stat
+            label="Titles"
+            value={fr.cumulative.championships}
+            sub={`${fr.cumulative.finalsAppearances} finals`}
+          />
+          <Stat
+            label="Playoffs"
+            value={fr.cumulative.playoffAppearances}
+            sub={`${fr.cumulative.regularSeasonFirstPlace} reg 1st`}
+          />
+          <Stat label="Trades" value={fr.tradeCount} sub={`${fr.waiverCount} waivers`} />
+        </div>
+      </Card>
+
+      {fr.draftCapital && (
+        <Card title="Draft capital">
+          <div style={{ fontSize: "0.78rem", color: "var(--subtext)", marginBottom: 6 }}>
+            Weighted score {fr.draftCapital.weightedScore} · {fr.draftCapital.totalPicks} owned picks
+          </div>
+          {(fr.draftCapital.picks || []).length > 0 && (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+              {(fr.draftCapital.picks || []).map((p, i) => (
+                <span
+                  key={i}
+                  style={{
+                    fontFamily: "var(--mono)",
+                    fontSize: "0.7rem",
+                    border: "1px solid var(--border)",
+                    padding: "2px 6px",
+                    borderRadius: 4,
+                    color: p.isTraded ? "var(--amber)" : "var(--text)",
+                  }}
+                >
+                  {p.label}{p.isTraded ? "*" : ""}
+                </span>
+              ))}
+            </div>
+          )}
+          <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 6 }}>
+            * acquired via trade ·{" "}
+            <Link href="/league?tab=draft" style={{ color: "var(--cyan)" }}>
+              Full draft center →
+            </Link>
+          </div>
+        </Card>
+      )}
+
+      <Card title="Season results">
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Season</th>
+                <th>Team</th>
+                <th style={{ textAlign: "right" }}>W-L-T</th>
+                <th style={{ textAlign: "right" }}>PF</th>
+                <th style={{ textAlign: "right" }}>PA</th>
+                <th style={{ textAlign: "right" }}>Seed</th>
+                <th style={{ textAlign: "right" }}>Final</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(fr.seasonResults || []).map((r, i) => (
+                <tr key={i}>
+                  <td>{r.season}</td>
+                  <td style={{ fontWeight: 600 }}>{r.teamName}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {r.wins}-{r.losses}{r.ties ? `-${r.ties}` : ""}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {fmtNumber(r.pointsFor, 1)}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {fmtNumber(r.pointsAgainst, 1)}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.standing}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.finalPlace ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {(fr.aliases || []).length > 1 && (
+          <div style={{ marginTop: 14, fontSize: "0.72rem", color: "var(--subtext)" }}>
+            Team-name history: {(fr.aliases || []).map((a) => `${a.teamName} (${a.season})`).join(" → ")}
+          </div>
+        )}
+      </Card>
+    </section>
+  );
+}

--- a/frontend/app/league/page.jsx
+++ b/frontend/app/league/page.jsx
@@ -15,7 +15,8 @@
 //
 // Data source: /api/public/league → fetchPublicLeague().
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   SubNav,
   PageHeader,
@@ -28,6 +29,7 @@ import {
 } from "@/lib/public-league-data";
 
 const SUB_TABS = [
+  { key: "overview", label: "Home" },
   { key: "history", label: "History" },
   { key: "rivalries", label: "Rivalries" },
   { key: "awards", label: "Awards" },
@@ -40,9 +42,56 @@ const SUB_TABS = [
   { key: "archives", label: "Archives" },
 ];
 
-export default function LeaguePage() {
-  const [activeTab, setActiveTab] = useState("history");
+const VALID_TABS = new Set(SUB_TABS.map((t) => t.key));
+
+// Next.js requires useSearchParams to be used inside a Suspense boundary
+// at the component level to keep pre-render aware.
+export default function LeaguePageRoute() {
+  return (
+    <Suspense fallback={<LoadingState message="Loading league data..." />}>
+      <LeaguePage />
+    </Suspense>
+  );
+}
+
+function LeaguePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const urlTab = searchParams.get("tab");
+  const urlOwner = searchParams.get("owner") || "";
+  const urlWeek = searchParams.get("week") || "";
+
+  const [activeTab, setActiveTabState] = useState(
+    urlTab && VALID_TABS.has(urlTab) ? urlTab : "overview",
+  );
   const [state, setState] = useState({ loading: true, error: "", contract: null });
+
+  // Keep tab in sync with ?tab= on back/forward navigation.
+  useEffect(() => {
+    if (urlTab && VALID_TABS.has(urlTab) && urlTab !== activeTab) {
+      setActiveTabState(urlTab);
+    }
+  }, [urlTab, activeTab]);
+
+  const setActiveTab = useCallback((key, extraParams = {}) => {
+    setActiveTabState(key);
+    const params = new URLSearchParams(searchParams.toString());
+    if (key === "overview") {
+      params.delete("tab");
+    } else {
+      params.set("tab", key);
+    }
+    // Apply/clear extra params (owner, week).
+    for (const [k, v] of Object.entries(extraParams)) {
+      if (v === null || v === undefined || v === "") {
+        params.delete(k);
+      } else {
+        params.set(k, String(v));
+      }
+    }
+    const qs = params.toString();
+    router.replace(qs ? `/league?${qs}` : "/league", { scroll: false });
+  }, [router, searchParams]);
 
   useEffect(() => {
     let active = true;
@@ -56,21 +105,33 @@ export default function LeaguePage() {
           !contract.sections ||
           !contract.league
         ) {
-          setState({ loading: false, error: "Public contract missing required shape.", contract: null });
+          setState({
+            loading: false,
+            error: "Public contract missing required shape.",
+            contract: null,
+          });
           return;
         }
         setState({ loading: false, error: "", contract });
       } catch (err) {
         if (!active) return;
-        setState({ loading: false, error: err?.message || "Failed to load public league data", contract: null });
+        setState({
+          loading: false,
+          error: err?.message || "Failed to load public league data",
+          contract: null,
+        });
       }
     })();
-    return () => { active = false; };
+    return () => {
+      active = false;
+    };
   }, []);
 
   const { loading, error, contract } = state;
   const sections = contract?.sections || {};
   const league = contract?.league || null;
+
+  const managers = useMemo(() => buildManagerLookup(league), [league]);
 
   if (loading) return <LoadingState message="Loading league data..." />;
   if (error) {
@@ -88,35 +149,63 @@ export default function LeaguePage() {
     );
   }
 
+  const overview = sections.overview || {};
+  const seasonLabel = overview.seasonRangeLabel
+    || (league.seasonsCovered || []).join(", ")
+    || "—";
+
   return (
     <section>
       <div className="card">
         <PageHeader
           title={league.leagueName || "League"}
           subtitle={
-            `Seasons: ${(league.seasonsCovered || []).join(", ") || "\u2014"} \u00B7 ` +
-            `${(league.managers || []).length} managers \u00B7 ` +
-            `Generated ${String(league.generatedAt || "").replace("T", " ").slice(0, 19)}`
+            `Seasons: ${seasonLabel}` +
+            ` · ${(league.managers || []).length} managers` +
+            ` · Last 2 dynasty seasons`
           }
         />
-        <SubNav items={SUB_TABS} active={activeTab} onChange={setActiveTab} />
+        <SubNav items={SUB_TABS} active={activeTab} onChange={(key) => setActiveTab(key)} />
       </div>
 
-      {activeTab === "history" && <HistorySection league={league} data={sections.history} />}
-      {activeTab === "rivalries" && <RivalriesSection league={league} data={sections.rivalries} />}
-      {activeTab === "awards" && <AwardsSection league={league} data={sections.awards} />}
+      {activeTab === "overview" && (
+        <OverviewSection
+          managers={managers}
+          data={overview}
+          onNavigate={setActiveTab}
+        />
+      )}
+      {activeTab === "history" && <HistorySection managers={managers} data={sections.history} onNavigate={setActiveTab} />}
+      {activeTab === "rivalries" && <RivalriesSection managers={managers} data={sections.rivalries} onNavigate={setActiveTab} />}
+      {activeTab === "awards" && <AwardsSection managers={managers} data={sections.awards} onNavigate={setActiveTab} />}
       {activeTab === "records" && <RecordsSection data={sections.records} />}
-      {activeTab === "franchise" && <FranchiseSection data={sections.franchise} />}
-      {activeTab === "activity" && <ActivitySection league={league} data={sections.activity} />}
-      {activeTab === "draft" && <DraftSection data={sections.draft} />}
-      {activeTab === "weekly" && <WeeklySection data={sections.weekly} />}
-      {activeTab === "superlatives" && <SuperlativesSection league={league} data={sections.superlatives} />}
+      {activeTab === "franchise" && (
+        <FranchiseSection
+          managers={managers}
+          data={sections.franchise}
+          onNavigate={setActiveTab}
+          initialOwner={urlOwner}
+          setOwner={(owner) => setActiveTab("franchise", { owner })}
+        />
+      )}
+      {activeTab === "activity" && <ActivitySection managers={managers} data={sections.activity} onNavigate={setActiveTab} />}
+      {activeTab === "draft" && <DraftSection data={sections.draft} initialOwner={urlOwner} setOwner={(owner) => setActiveTab("draft", { owner })} />}
+      {activeTab === "weekly" && (
+        <WeeklySection
+          data={sections.weekly}
+          managers={managers}
+          onNavigate={setActiveTab}
+          initialWeek={urlWeek}
+          setWeek={(week) => setActiveTab("weekly", { week })}
+        />
+      )}
+      {activeTab === "superlatives" && <SuperlativesSection managers={managers} data={sections.superlatives} />}
       {activeTab === "archives" && <ArchivesSection data={sections.archives} />}
     </section>
   );
 }
 
-// Helper: owner_id -> display name lookup from league header.
+// ── Helpers ──────────────────────────────────────────────────────────────
 function buildManagerLookup(league) {
   const map = new Map();
   for (const m of league?.managers || []) {
@@ -130,19 +219,491 @@ function nameFor(managers, ownerId) {
   return mgr?.displayName || mgr?.currentTeamName || ownerId || "Unknown";
 }
 
-// ── Sections ─────────────────────────────────────────────────────────────
-function HistorySection({ league, data }) {
-  const managers = useMemo(() => buildManagerLookup(league), [league]);
-  const hof = data?.hallOfFame || [];
-  const seasons = data?.seasons || [];
-  if (!hof.length && !seasons.length) {
-    return <EmptyCard label="Hall of Fame" />;
+function avatarUrlFor(managers, ownerId) {
+  const mgr = managers.get(String(ownerId));
+  if (!mgr || !mgr.avatar) return "";
+  // Sleeper avatars are keyed by a 32-char hash served from their CDN.
+  // If Sleeper ever surfaces a full URL we pass it through untouched.
+  const avatar = String(mgr.avatar);
+  if (avatar.startsWith("http")) return avatar;
+  if (!avatar) return "";
+  return `https://sleepercdn.com/avatars/thumbs/${avatar}`;
+}
+
+function fmtNumber(n, digits = 0) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "—";
+  return Number(n).toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function fmtPoints(n) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "—";
+  return Number(n).toFixed(1);
+}
+
+function fmtPercent(n) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "—";
+  return `${Math.round(Number(n) * 100)}%`;
+}
+
+function Avatar({ managers, ownerId, size = 24, title }) {
+  const url = avatarUrlFor(managers, ownerId);
+  const name = nameFor(managers, ownerId);
+  const initials = name.split(/\s+/).map((w) => w[0] || "").join("").slice(0, 2).toUpperCase();
+  const style = {
+    width: size,
+    height: size,
+    borderRadius: "50%",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "var(--bg-soft)",
+    border: "1px solid var(--border)",
+    fontSize: Math.max(10, Math.floor(size * 0.42)),
+    fontWeight: 700,
+    overflow: "hidden",
+    flexShrink: 0,
+    verticalAlign: "middle",
+  };
+  if (url) {
+    return (
+      <img
+        src={url}
+        alt=""
+        loading="lazy"
+        width={size}
+        height={size}
+        style={{ ...style, background: "transparent" }}
+        title={title || name}
+      />
+    );
   }
+  return (
+    <span style={style} title={title || name} aria-hidden>
+      {initials || "?"}
+    </span>
+  );
+}
+
+function ManagerInline({ managers, ownerId, onClick, compact = false }) {
+  const name = nameFor(managers, ownerId);
+  return (
+    <span
+      onClick={onClick}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        cursor: onClick ? "pointer" : "default",
+        color: onClick ? "var(--cyan)" : "inherit",
+      }}
+    >
+      <Avatar managers={managers} ownerId={ownerId} size={compact ? 18 : 22} />
+      <span>{name}</span>
+    </span>
+  );
+}
+
+function Card({ title, subtitle, action, children, id }) {
+  return (
+    <div className="card" id={id} style={{ marginTop: "var(--space-md)" }}>
+      {(title || action) && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            marginBottom: 10,
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            {title && <div style={{ fontWeight: 700 }}>{title}</div>}
+            {subtitle && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+                {subtitle}
+              </div>
+            )}
+          </div>
+          {action}
+        </div>
+      )}
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Stat({ label, value, sub }) {
+  return (
+    <div
+      style={{
+        padding: "10px 12px",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius)",
+        background: "rgba(15, 28, 59, 0.45)",
+      }}
+    >
+      <div
+        style={{
+          fontSize: "0.65rem",
+          color: "var(--subtext)",
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: "1.05rem",
+          fontWeight: 700,
+          fontFamily: "var(--mono)",
+          marginTop: 2,
+        }}
+      >
+        {value}
+      </div>
+      {sub && (
+        <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 2 }}>
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LinkButton({ onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        background: "transparent",
+        border: "1px solid var(--border-bright)",
+        borderRadius: 6,
+        color: "var(--cyan)",
+        padding: "4px 10px",
+        fontSize: "0.7rem",
+        cursor: "pointer",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function EmptyCard({ label, message }) {
+  return (
+    <Card>
+      <EmptyState
+        title={`${label} coming online`}
+        message={
+          message ||
+          "Sleeper hasn't surfaced enough data for this section yet. It will fill in as games finish, trades complete, and drafts are held."
+        }
+      />
+    </Card>
+  );
+}
+
+// ── OVERVIEW ──────────────────────────────────────────────────────────────
+function OverviewSection({ managers, data, onNavigate }) {
+  if (!data || Object.keys(data).length === 0) return <EmptyCard label="Overview" />;
+
+  const champ = data.currentChampion;
+  const rivalry = data.featuredRivalry;
+  const records = data.topRecordCallouts || [];
+  const recent = data.recentTrades || [];
+  const draftLeader = data.draftCapitalLeader;
+  const recap = data.latestWeeklyRecap;
+  const decorated = data.mostDecoratedFranchise;
+  const chaos = data.mostChaoticManager;
+  const hottest = data.hottestRace;
+  const vitals = data.leagueVitals || {};
+  const hottestTrade = data.hottestTrade;
 
   return (
     <>
-      <div className="card" style={{ marginTop: "var(--space-md)" }}>
-        <div style={{ fontWeight: 700, marginBottom: 10 }}>Hall of Fame</div>
+      <Card title="At a glance" subtitle="Public snapshot across the last 2 dynasty seasons">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 10 }}>
+          <Stat label="Seasons" value={vitals.seasonsCovered ?? "—"} sub={data.seasonRangeLabel} />
+          <Stat label="Managers" value={vitals.managers ?? "—"} />
+          <Stat label="Trades" value={vitals.totalTrades ?? "—"} />
+          <Stat label="Waivers" value={vitals.totalWaivers ?? "—"} />
+          <Stat label="Scored weeks" value={vitals.totalScoredWeeks ?? "—"} />
+        </div>
+      </Card>
+
+      <div className="row" style={{ marginTop: "var(--space-md)", gap: 14 }}>
+        {champ && (
+          <div className="card" style={{ flex: "1 1 280px", minWidth: 240 }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Defending champion
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 6 }}>
+              <Avatar managers={managers} ownerId={champ.ownerId} size={42} />
+              <div>
+                <div style={{ fontSize: "1.3rem", fontWeight: 800, lineHeight: 1.15 }}>
+                  {champ.displayName}
+                </div>
+                <div style={{ fontSize: "0.78rem", color: "var(--subtext)" }}>
+                  {champ.teamName} · {champ.season} title
+                </div>
+              </div>
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("history")}>View championship history →</LinkButton>
+            </div>
+          </div>
+        )}
+        {rivalry && (
+          <div className="card" style={{ flex: "1 1 280px", minWidth: 240 }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Featured rivalry · hottest index
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6 }}>
+              <Avatar managers={managers} ownerId={rivalry.ownerIds[0]} size={28} />
+              <span style={{ color: "var(--subtext)", fontWeight: 700 }}>vs</span>
+              <Avatar managers={managers} ownerId={rivalry.ownerIds[1]} size={28} />
+              <span style={{ fontSize: "1rem", fontWeight: 800, marginLeft: 6 }}>
+                {nameFor(managers, rivalry.ownerIds[0])} vs {nameFor(managers, rivalry.ownerIds[1])}
+              </span>
+            </div>
+            <div style={{ fontSize: "0.78rem", color: "var(--subtext)", marginTop: 4 }}>
+              {rivalry.totalMeetings} meetings · {rivalry.playoffMeetings} playoff · Rivalry Index {rivalry.rivalryIndex}
+            </div>
+            <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 4 }}>
+              Series: {rivalry.winsA}–{rivalry.winsB}{rivalry.ties ? `–${rivalry.ties}` : ""}
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("rivalries")}>Explore rivalries →</LinkButton>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {records.length > 0 && (
+        <Card title="Headline records" subtitle="Biggest numbers in the last 2 seasons">
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 10 }}>
+            {records.map((r, i) => (
+              <div key={i} style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+                <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                  {r.label}
+                </div>
+                <div style={{ fontSize: "1.1rem", fontWeight: 700, fontFamily: "var(--mono)" }}>
+                  {r.formattedValue}
+                </div>
+                <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 2 }}>
+                  <ManagerInline managers={managers} ownerId={r.ownerId} compact />
+                  {r.season ? <span style={{ marginLeft: 4 }}>· {r.season}</span> : null}
+                  {r.week ? <span style={{ marginLeft: 4 }}>· Wk {r.week}</span> : null}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 10 }}>
+            <LinkButton onClick={() => onNavigate("records")}>Full record book →</LinkButton>
+          </div>
+        </Card>
+      )}
+
+      <div className="row" style={{ marginTop: "var(--space-md)", gap: 14 }}>
+        {hottest && (
+          <div className="card" style={{ flex: "1 1 280px" }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Hot race · season to date
+            </div>
+            <div style={{ fontSize: "1.05rem", fontWeight: 800, marginTop: 4 }}>{hottest.label}</div>
+            <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>{hottest.description}</div>
+            <div style={{ marginTop: 10, fontSize: "0.9rem", fontWeight: 700 }}>
+              <ManagerInline managers={managers} ownerId={hottest.topLeader?.ownerId} />
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("awards")}>See all races →</LinkButton>
+            </div>
+          </div>
+        )}
+        {decorated && (
+          <div className="card" style={{ flex: "1 1 280px" }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Most decorated franchise
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 6 }}>
+              <Avatar managers={managers} ownerId={decorated.ownerId} size={36} />
+              <div style={{ fontSize: "1.05rem", fontWeight: 800 }}>{decorated.displayName}</div>
+            </div>
+            <div style={{ fontSize: "0.74rem", color: "var(--subtext)", marginTop: 4 }}>
+              {decorated.championships}× champ · {decorated.finalsAppearances} finals · {decorated.playoffAppearances} playoffs
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("franchise", { owner: decorated.ownerId })}>
+                Open franchise page →
+              </LinkButton>
+            </div>
+          </div>
+        )}
+        {chaos && (
+          <div className="card" style={{ flex: "1 1 280px" }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Most chaotic manager
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 6 }}>
+              <Avatar managers={managers} ownerId={chaos.ownerId} size={36} />
+              <div style={{ fontSize: "1.05rem", fontWeight: 800 }}>{chaos.displayName}</div>
+            </div>
+            <div style={{ fontSize: "0.74rem", color: "var(--subtext)", marginTop: 4 }}>
+              Chaos score {chaos.score ?? "—"}{chaos.season ? ` · ${chaos.season}` : ""}
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("activity")}>See trade activity →</LinkButton>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="row" style={{ marginTop: "var(--space-md)", gap: 14 }}>
+        {draftLeader && (
+          <div className="card" style={{ flex: "1 1 280px" }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Best draft stockpile
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 6 }}>
+              <Avatar managers={managers} ownerId={draftLeader.ownerId} size={36} />
+              <div style={{ fontSize: "1.05rem", fontWeight: 800 }}>{draftLeader.displayName}</div>
+            </div>
+            <div style={{ fontSize: "0.74rem", color: "var(--subtext)", marginTop: 4 }}>
+              {draftLeader.totalPicks} picks · Weighted score {draftLeader.weightedScore}
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("draft", { owner: draftLeader.ownerId })}>
+                Full draft center →
+              </LinkButton>
+            </div>
+          </div>
+        )}
+        {recap && (
+          <div className="card" style={{ flex: "1 1 280px" }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Latest weekly recap
+            </div>
+            <div style={{ fontSize: "1.05rem", fontWeight: 800, marginTop: 4 }}>
+              {recap.season} · Week {recap.week}{recap.isPlayoff ? " (playoffs)" : ""}
+            </div>
+            {recap.gameOfTheWeek && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 4 }}>
+                Game of the week: {recap.gameOfTheWeek.home?.displayName} vs {recap.gameOfTheWeek.away?.displayName} (margin {fmtPoints(recap.gameOfTheWeek.margin)})
+              </div>
+            )}
+            {recap.highestScorer && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+                Top scorer: {recap.highestScorer.displayName} ({fmtPoints(recap.highestScorer.points)})
+              </div>
+            )}
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("weekly", { week: `${recap.season}:${recap.week}` })}>
+                Open weekly recap →
+              </LinkButton>
+            </div>
+          </div>
+        )}
+        {hottestTrade && (
+          <div className="card" style={{ flex: "1 1 280px" }}>
+            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Hottest trade · biggest blockbuster
+            </div>
+            <div style={{ fontSize: "0.94rem", fontWeight: 700, marginTop: 4 }}>
+              {hottestTrade.sides.map((s) => s.displayName).join(" ↔ ")}
+            </div>
+            <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+              {hottestTrade.totalAssets} total assets · {hottestTrade.season} {hottestTrade.week ? `Wk ${hottestTrade.week}` : ""}
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <LinkButton onClick={() => onNavigate("activity")}>Open trade center →</LinkButton>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {recent.length > 0 && (
+        <Card title="Recent trades" subtitle="Last 5 completed deals">
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {recent.map((t) => (
+              <div
+                key={t.transactionId}
+                style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}
+              >
+                <div style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>
+                  {t.season} · Week {t.week ?? "—"} · {t.totalAssets} asset{t.totalAssets === 1 ? "" : "s"}
+                </div>
+                <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 4 }}>
+                  {t.sides.map((s, i) => (
+                    <div key={i} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                      <Avatar managers={managers} ownerId={s.ownerId} size={18} />
+                      <span style={{ fontWeight: 700 }}>{s.displayName}</span>
+                      <span style={{ color: "var(--subtext)", marginLeft: 2, fontSize: "0.7rem" }}>
+                        received {s.receivedPlayerCount} players · {s.receivedPickCount} picks
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 10 }}>
+            <LinkButton onClick={() => onNavigate("activity")}>View all trades →</LinkButton>
+          </div>
+        </Card>
+      )}
+    </>
+  );
+}
+
+// ── HISTORY / HALL OF FAME ────────────────────────────────────────────────
+function HistorySection({ managers, data, onNavigate }) {
+  const hof = data?.hallOfFame || [];
+  const seasons = data?.seasons || [];
+  const champs = data?.championsBySeason || [];
+  if (!hof.length && !seasons.length) return <EmptyCard label="Hall of Fame" />;
+
+  const byPoints = [...hof].sort((a, b) => b.pointsFor - a.pointsFor);
+  const byPlayoffs = [...hof].sort((a, b) => b.playoffAppearances - a.playoffAppearances);
+  const byFinals = [...hof].sort((a, b) => b.finalsAppearances - a.finalsAppearances);
+
+  return (
+    <>
+      {champs.length > 0 && (
+        <Card title="Champion timeline" subtitle="Winners of the final playoff matchup">
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {champs.map((c) => (
+              <div
+                key={c.season}
+                style={{
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius)",
+                  padding: 10,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  cursor: "pointer",
+                }}
+                onClick={() => onNavigate("franchise", { owner: c.ownerId })}
+              >
+                <Avatar managers={managers} ownerId={c.ownerId} size={36} />
+                <div>
+                  <div style={{ fontSize: "0.66rem", color: "var(--subtext)" }}>{c.season}</div>
+                  <div style={{ fontWeight: 700, fontSize: "1rem" }}>{c.displayName}</div>
+                  <div style={{ fontSize: "0.74rem", color: "var(--subtext)" }}>{c.teamName}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      <Card title="Hall of Fame" subtitle="Cumulative stats across the last 2 seasons">
         <div className="table-wrap">
           <table>
             <thead>
@@ -150,34 +711,73 @@ function HistorySection({ league, data }) {
                 <th style={{ textAlign: "left" }}>Manager</th>
                 <th style={{ textAlign: "right" }}>Seasons</th>
                 <th style={{ textAlign: "right" }}>Record</th>
-                <th style={{ textAlign: "right" }}>Rings</th>
-                <th style={{ textAlign: "right" }}>Runner-Ups</th>
-                <th style={{ textAlign: "right" }}>Points For</th>
+                <th style={{ textAlign: "right" }}>Titles</th>
+                <th style={{ textAlign: "right" }}>Finals</th>
+                <th style={{ textAlign: "right" }}>Playoffs</th>
+                <th style={{ textAlign: "right" }}>Reg 1st</th>
+                <th style={{ textAlign: "right" }}>Points</th>
               </tr>
             </thead>
             <tbody>
               {hof.map((row) => (
-                <tr key={row.ownerId}>
-                  <td style={{ fontWeight: 600 }}>{row.displayName || row.currentTeamName || row.ownerId}</td>
+                <tr
+                  key={row.ownerId}
+                  onClick={() => onNavigate("franchise", { owner: row.ownerId })}
+                  style={{ cursor: "pointer" }}
+                >
+                  <td style={{ fontWeight: 600 }}>
+                    <ManagerInline managers={managers} ownerId={row.ownerId} compact />
+                  </td>
                   <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.seasonsPlayed}</td>
                   <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
                     {row.wins}-{row.losses}{row.ties ? `-${row.ties}` : ""}
                   </td>
-                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.championships}</td>
-                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.runnerUps}</td>
-                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.pointsFor.toLocaleString()}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.championships || 0}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.finalsAppearances || 0}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.playoffAppearances || 0}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.regularSeasonFirstPlace || 0}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtNumber(row.pointsFor, 1)}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
+      </Card>
+
+      <div className="row" style={{ marginTop: "var(--space-md)", gap: 14 }}>
+        <MiniLeaderboard
+          managers={managers}
+          title="Points leaders"
+          rows={byPoints}
+          metric={(r) => fmtNumber(r.pointsFor, 1)}
+          onRowClick={(ownerId) => onNavigate("franchise", { owner: ownerId })}
+        />
+        <MiniLeaderboard
+          managers={managers}
+          title="Playoff appearances"
+          rows={byPlayoffs}
+          metric={(r) => r.playoffAppearances || 0}
+          onRowClick={(ownerId) => onNavigate("franchise", { owner: ownerId })}
+        />
+        <MiniLeaderboard
+          managers={managers}
+          title="Finals appearances"
+          rows={byFinals}
+          metric={(r) => r.finalsAppearances || 0}
+          onRowClick={(ownerId) => onNavigate("franchise", { owner: ownerId })}
+        />
       </div>
 
       {seasons.map((s) => (
-        <div className="card" style={{ marginTop: "var(--space-md)" }} key={s.leagueId}>
-          <div style={{ fontWeight: 700, marginBottom: 10 }}>
-            {s.season} season {s.champion ? `\u00B7 Champion: ${s.champion.teamName}` : ""}
-          </div>
+        <Card
+          key={s.leagueId}
+          title={`${s.season} season`}
+          subtitle={[
+            s.champion ? `Champion: ${s.champion.displayName}` : null,
+            s.topSeed ? `Top seed: ${s.topSeed.displayName}` : null,
+            s.regularSeasonPointsLeader ? `Points leader: ${s.regularSeasonPointsLeader.displayName}` : null,
+          ].filter(Boolean).join(" · ")}
+        >
           <div className="table-wrap">
             <table>
               <thead>
@@ -186,245 +786,68 @@ function HistorySection({ league, data }) {
                   <th style={{ textAlign: "right" }}>W-L-T</th>
                   <th style={{ textAlign: "right" }}>PF</th>
                   <th style={{ textAlign: "right" }}>PA</th>
+                  <th style={{ textAlign: "right" }}>Seed</th>
                   <th style={{ textAlign: "right" }}>Final</th>
                 </tr>
               </thead>
               <tbody>
                 {(s.standings || []).map((row) => (
-                  <tr key={row.ownerId}>
-                    <td style={{ fontWeight: 600 }}>{row.teamName}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.wins}-{row.losses}-{row.ties}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.pointsFor.toLocaleString()}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.pointsAgainst.toLocaleString()}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.finalPlace ?? "\u2014"}</td>
+                  <tr
+                    key={row.ownerId}
+                    onClick={() => onNavigate("franchise", { owner: row.ownerId })}
+                    style={{ cursor: "pointer" }}
+                  >
+                    <td style={{ fontWeight: 600 }}>
+                      <ManagerInline managers={managers} ownerId={row.ownerId} compact />
+                      <span style={{ marginLeft: 6, color: "var(--subtext)", fontSize: "0.7rem" }}>
+                        {row.teamName}
+                      </span>
+                      {row.madePlayoffs && (
+                        <span style={{ marginLeft: 6, fontSize: "0.65rem", color: "var(--green)" }}>★</span>
+                      )}
+                    </td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                      {row.wins}-{row.losses}{row.ties ? `-${row.ties}` : ""}
+                    </td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtNumber(row.pointsFor, 1)}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtNumber(row.pointsAgainst, 1)}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.standing}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.finalPlace ?? "—"}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-        </div>
+        </Card>
       ))}
     </>
   );
 }
 
-function RivalriesSection({ league, data }) {
-  const managers = useMemo(() => buildManagerLookup(league), [league]);
-  const rows = data?.rivalries || [];
-  if (!rows.length) return <EmptyCard label="Rivalries" />;
-
+function MiniLeaderboard({ managers, title, rows, metric, onRowClick }) {
+  if (!rows || !rows.length) return null;
   return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <div style={{ fontWeight: 700, marginBottom: 10 }}>Head-to-Head</div>
-      <div className="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Matchup</th>
-              <th style={{ textAlign: "right" }}>Games</th>
-              <th style={{ textAlign: "right" }}>Record</th>
-              <th style={{ textAlign: "right" }}>Points</th>
-              <th style={{ textAlign: "right" }}>Close Score</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r, i) => {
-              const [a, b] = r.ownerIds;
-              return (
-                <tr key={i}>
-                  <td style={{ fontWeight: 600 }}>
-                    {nameFor(managers, a)} vs {nameFor(managers, b)}
-                  </td>
-                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.games}</td>
-                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
-                    {r.winsA}-{r.winsB}{r.ties ? `-${r.ties}` : ""}
-                  </td>
-                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
-                    {r.pointsA.toFixed(0)} / {r.pointsB.toFixed(0)}
-                  </td>
-                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.competitivenessScore}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function AwardsSection({ league, data }) {
-  const managers = useMemo(() => buildManagerLookup(league), [league]);
-  const seasons = data?.bySeason || [];
-  if (!seasons.length) return <EmptyCard label="Awards" />;
-
-  return (
-    <>
-      {seasons.map((s) => (
-        <div className="card" style={{ marginTop: "var(--space-md)" }} key={s.leagueId}>
-          <div style={{ fontWeight: 700, marginBottom: 10 }}>{s.season} awards</div>
-          {(s.awards || []).length === 0 ? (
-            <div style={{ color: "var(--subtext)", fontSize: "0.8rem" }}>
-              Season still in progress.
-            </div>
-          ) : (
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 10 }}>
-              {(s.awards || []).map((a) => (
-                <div key={a.key} style={{ border: "1px solid var(--border)", borderRadius: 6, padding: 10 }}>
-                  <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase" }}>{a.label}</div>
-                  <div style={{ fontWeight: 700 }}>{a.teamName}</div>
-                  <div style={{ fontSize: "0.68rem", color: "var(--subtext)" }}>{nameFor(managers, a.ownerId)}</div>
-                  {a.value && (
-                    <div style={{ fontFamily: "var(--mono)", fontSize: "0.7rem", marginTop: 4 }}>
-                      {JSON.stringify(a.value)}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      ))}
-    </>
-  );
-}
-
-function RecordsSection({ data }) {
-  const high = data?.singleWeekHighest || [];
-  const low = data?.singleWeekLowest || [];
-  if (!high.length && !low.length) return <EmptyCard label="Records" />;
-
-  return (
-    <>
-      <RecordTable title="Highest Single-Week Scores" rows={high} />
-      <RecordTable title="Lowest Single-Week Scores" rows={low} />
-    </>
-  );
-}
-
-function RecordTable({ title, rows }) {
-  return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <div style={{ fontWeight: 700, marginBottom: 10 }}>{title}</div>
-      <div className="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Team</th>
-              <th style={{ textAlign: "right" }}>Season</th>
-              <th style={{ textAlign: "right" }}>Week</th>
-              <th style={{ textAlign: "right" }}>Points</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r, i) => (
-              <tr key={i}>
-                <td style={{ fontWeight: 600 }}>{r.teamName}</td>
-                <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.season}</td>
-                <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.week}</td>
-                <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.points.toFixed(2)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function FranchiseSection({ data }) {
-  const index = data?.index || [];
-  const detail = data?.detail || {};
-  const [selected, setSelected] = useState(index[0]?.ownerId || "");
-  if (!index.length) return <EmptyCard label="Franchises" />;
-  const fr = detail[selected] || null;
-
-  return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <div style={{ display: "flex", gap: 10, marginBottom: 14, flexWrap: "wrap" }}>
-        <select
-          className="input"
-          value={selected}
-          onChange={(e) => setSelected(e.target.value)}
-          style={{ minWidth: 220 }}
-        >
-          {index.map((row) => (
-            <option key={row.ownerId} value={row.ownerId}>
-              {row.displayName} {row.championships ? `\u2b50\u00D7${row.championships}` : ""}
-            </option>
-          ))}
-        </select>
-      </div>
-      {fr && (
-        <div>
-          <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>{fr.displayName}</div>
-          <div style={{ color: "var(--subtext)", fontSize: "0.74rem", marginBottom: 10 }}>
-            Current team: {fr.currentTeamName}
-          </div>
-          <div className="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>Season</th>
-                  <th style={{ textAlign: "right" }}>W-L-T</th>
-                  <th style={{ textAlign: "right" }}>PF</th>
-                  <th style={{ textAlign: "right" }}>PA</th>
-                  <th style={{ textAlign: "right" }}>Final</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(fr.seasonResults || []).map((r, i) => (
-                  <tr key={i}>
-                    <td>{r.season}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.wins}-{r.losses}-{r.ties}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.pointsFor.toLocaleString()}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.pointsAgainst.toLocaleString()}</td>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.finalPlace ?? "\u2014"}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <div style={{ marginTop: 10, fontSize: "0.72rem", color: "var(--subtext)" }}>
-            {`Trades: ${fr.tradeCount} \u00B7 Draft picks used: ${fr.draftPickCount}`}
-          </div>
-          {(fr.aliases || []).length > 1 && (
-            <div style={{ marginTop: 10, fontSize: "0.7rem", color: "var(--subtext)" }}>
-              Team-name history: {(fr.aliases || []).map((a) => `${a.teamName} (${a.season})`).join(" \u2192 ")}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ActivitySection({ league, data }) {
-  const managers = useMemo(() => buildManagerLookup(league), [league]);
-  const feed = data?.feed || [];
-  if (!feed.length) return <EmptyCard label="Trade activity" />;
-
-  return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <div style={{ fontWeight: 700, marginBottom: 10 }}>
-        Recent Trades ({data.totalCount} total)
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-        {feed.map((t) => (
-          <div key={t.transactionId} style={{ border: "1px solid var(--border)", borderRadius: 6, padding: 10 }}>
-            <div style={{ fontSize: "0.66rem", color: "var(--subtext)" }}>
-              {`${t.season} \u00B7 Week ${t.week ?? "\u2014"}`}
-            </div>
-            <div style={{ display: "grid", gridTemplateColumns: `repeat(${t.sides.length}, 1fr)`, gap: 10, marginTop: 4 }}>
-              {t.sides.map((side, i) => (
-                <div key={i}>
-                  <div style={{ fontWeight: 700 }}>{nameFor(managers, side.ownerId) || side.teamName}</div>
-                  <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
-                    Received: {side.receivedPlayerIds.length} players, {side.receivedPicks.length} picks
-                  </div>
-                </div>
-              ))}
-            </div>
+    <div className="card" style={{ flex: "1 1 260px" }}>
+      <div style={{ fontWeight: 700, marginBottom: 8 }}>{title}</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {rows.slice(0, 5).map((r, i) => (
+          <div
+            key={r.ownerId || i}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontSize: "0.74rem",
+              cursor: onRowClick ? "pointer" : "default",
+            }}
+            onClick={() => onRowClick?.(r.ownerId)}
+          >
+            <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", minWidth: 16 }}>{i + 1}.</span>
+              {managers ? <Avatar managers={managers} ownerId={r.ownerId} size={18} /> : null}
+              {r.displayName || r.currentTeamName || r.ownerId}
+            </span>
+            <span style={{ fontFamily: "var(--mono)", color: "var(--cyan)" }}>{metric(r)}</span>
           </div>
         ))}
       </div>
@@ -432,22 +855,944 @@ function ActivitySection({ league, data }) {
   );
 }
 
-function DraftSection({ data }) {
-  const drafts = data?.drafts || [];
-  if (!drafts.length) return <EmptyCard label="Drafts" />;
+// ── RIVALRIES ──────────────────────────────────────────────────────────────
+function RivalriesSection({ managers, data, onNavigate }) {
+  const rows = data?.rivalries || [];
+  const [selected, setSelected] = useState(0);
+  if (!rows.length) return <EmptyCard label="Rivalries" />;
+
+  const featured = rows.slice(0, 3);
+  const detail = rows[selected] || null;
 
   return (
     <>
-      {drafts.map((d) => (
-        <div className="card" style={{ marginTop: "var(--space-md)" }} key={d.draftId}>
-          <div style={{ fontWeight: 700, marginBottom: 10 }}>
-            {`${d.season} ${d.type || "draft"} \u00B7 ${d.status}`}
+      <Card title="Top rivalries" subtitle="Ranked by rivalry index (playoffs + close games + splits + meetings)">
+        <div className="row">
+          {featured.map((r, i) => (
+            <div
+              key={i}
+              className="card"
+              style={{
+                flex: "1 1 240px",
+                cursor: "pointer",
+                borderColor: selected === i ? "var(--cyan)" : "var(--border)",
+              }}
+              onClick={() => setSelected(i)}
+            >
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)" }}>Rivalry Index {r.rivalryIndex}</div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
+                <Avatar managers={managers} ownerId={r.ownerIds[0]} size={22} />
+                <span style={{ fontWeight: 700, fontSize: "0.9rem" }}>
+                  {nameFor(managers, r.ownerIds[0])} vs {nameFor(managers, r.ownerIds[1])}
+                </span>
+                <Avatar managers={managers} ownerId={r.ownerIds[1]} size={22} />
+              </div>
+              <div style={{ fontSize: "0.74rem", color: "var(--subtext)", marginTop: 2 }}>
+                {r.totalMeetings} meet · {r.playoffMeetings} playoff · Split seasons {r.seasonsWhereSeriesSplit}
+              </div>
+              <div style={{ fontSize: "0.72rem", marginTop: 4 }}>
+                Series: {r.winsA}–{r.winsB}{r.ties ? `–${r.ties}` : ""}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      {detail && (
+        <Card
+          title={`${nameFor(managers, detail.ownerIds[0])} vs ${nameFor(managers, detail.ownerIds[1])}`}
+          subtitle="Head-to-head detail"
+          action={
+            <div style={{ display: "flex", gap: 6 }}>
+              <LinkButton onClick={() => onNavigate("franchise", { owner: detail.ownerIds[0] })}>
+                {nameFor(managers, detail.ownerIds[0])} page →
+              </LinkButton>
+              <LinkButton onClick={() => onNavigate("franchise", { owner: detail.ownerIds[1] })}>
+                {nameFor(managers, detail.ownerIds[1])} page →
+              </LinkButton>
+            </div>
+          }
+        >
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10, marginBottom: 14 }}>
+            <Stat label="Meetings" value={detail.totalMeetings} sub={`${detail.regularSeasonMeetings} reg · ${detail.playoffMeetings} playoff`} />
+            <Stat label="Series" value={`${detail.winsA}–${detail.winsB}${detail.ties ? `–${detail.ties}` : ""}`} />
+            <Stat label="Points" value={`${fmtPoints(detail.pointsA)} / ${fmtPoints(detail.pointsB)}`} />
+            <Stat label="Close (≤5 pts)" value={detail.gamesDecidedByFive} sub="most decisive closeness band" />
+            <Stat label="Close (≤10 pts)" value={detail.gamesDecidedByTen} />
           </div>
+
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>Memorable meetings</div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 10 }}>
+            <MeetingCard label="Closest" meeting={detail.closestGame} />
+            <MeetingCard label="Biggest blowout" meeting={detail.biggestBlowout} />
+            <MeetingCard label="Last meeting" meeting={detail.lastMeeting} />
+          </div>
+
+          {detail.seasonSplits && Object.keys(detail.seasonSplits).length > 0 && (
+            <>
+              <div style={{ fontWeight: 600, marginTop: 14, marginBottom: 6 }}>Season splits</div>
+              <div className="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Season</th>
+                      <th style={{ textAlign: "right" }}>{nameFor(managers, detail.ownerIds[0])} wins</th>
+                      <th style={{ textAlign: "right" }}>{nameFor(managers, detail.ownerIds[1])} wins</th>
+                      <th style={{ textAlign: "right" }}>Ties</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(detail.seasonSplits).map(([season, split]) => (
+                      <tr key={season}>
+                        <td>{season}</td>
+                        <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{split.winsA}</td>
+                        <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{split.winsB}</td>
+                        <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{split.ties}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </Card>
+      )}
+
+      <Card title="All rivalries" subtitle="Every pair that has met">
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Pair</th>
+                <th style={{ textAlign: "right" }}>Index</th>
+                <th style={{ textAlign: "right" }}>Meet</th>
+                <th style={{ textAlign: "right" }}>Playoff</th>
+                <th style={{ textAlign: "right" }}>Series</th>
+                <th style={{ textAlign: "right" }}>Points</th>
+                <th style={{ textAlign: "right" }}>Closest</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={i} style={{ cursor: "pointer" }} onClick={() => setSelected(i)}>
+                  <td style={{ fontWeight: 600 }}>
+                    {nameFor(managers, r.ownerIds[0])} vs {nameFor(managers, r.ownerIds[1])}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.rivalryIndex}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.totalMeetings}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.playoffMeetings}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {r.winsA}-{r.winsB}{r.ties ? `-${r.ties}` : ""}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {fmtPoints(r.pointsA)} / {fmtPoints(r.pointsB)}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {r.closestGame ? fmtPoints(r.closestGame.margin) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </>
+  );
+}
+
+function MeetingCard({ label, meeting }) {
+  if (!meeting) return null;
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+      <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontSize: "0.86rem", fontWeight: 700, marginTop: 2 }}>
+        {meeting.season} · Wk {meeting.week}{meeting.isPlayoff ? " (P)" : ""}
+      </div>
+      <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+        Margin {fmtPoints(meeting.margin)} · {fmtPoints(meeting.pointsA)} / {fmtPoints(meeting.pointsB)}
+      </div>
+    </div>
+  );
+}
+
+// ── AWARDS ────────────────────────────────────────────────────────────────
+function AwardsSection({ managers, data, onNavigate }) {
+  const seasons = data?.bySeason || [];
+  const races = data?.awardRaces || [];
+  if (!seasons.length && !races.length) return <EmptyCard label="Awards" />;
+
+  return (
+    <>
+      {races.length > 0 && (
+        <Card
+          title="Award races · season to date"
+          subtitle={`Top 3 for every live race${data.currentSeason ? ` · ${data.currentSeason} in progress` : ""}`}
+        >
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 10 }}>
+            {races.map((race) => (
+              <div
+                key={race.key}
+                style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 12 }}
+              >
+                <div style={{ fontWeight: 700 }}>{race.label}</div>
+                <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 2, marginBottom: 8, lineHeight: 1.4 }}>
+                  {race.description}
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                  {race.leaders.map((leader) => (
+                    <div
+                      key={leader.ownerId}
+                      style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: "0.78rem" }}
+                    >
+                      <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                        <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", minWidth: 16 }}>
+                          {leader.rank}.
+                        </span>
+                        <Avatar managers={managers} ownerId={leader.ownerId} size={18} />
+                        <span
+                          style={{ cursor: "pointer", color: "var(--cyan)" }}
+                          onClick={() => onNavigate("franchise", { owner: leader.ownerId })}
+                        >
+                          {leader.displayName}
+                        </span>
+                      </span>
+                      <span style={{ fontFamily: "var(--mono)", color: "var(--text)" }}>
+                        {renderAwardValue(race.key, leader.value)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {seasons.map((s) => (
+        <Card
+          key={s.leagueId}
+          title={`${s.season} award winners`}
+          subtitle={s.isComplete ? "Season complete" : "Season in progress"}
+        >
+          {s.hasPlayerScoring === false && (
+            <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginBottom: 8 }}>
+              Trader / Waiver / Playoff MVP awards depend on per-player scoring that
+              Sleeper didn't surface for this season — some awards may be skipped.
+            </div>
+          )}
+          {(s.awards || []).length === 0 ? (
+            <EmptyState
+              title="No awards yet"
+              message="Awards will appear once the season has enough games / transactions / trades on record."
+            />
+          ) : (
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 10 }}>
+              {(s.awards || []).map((a) => (
+                <div
+                  key={a.key}
+                  style={{
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius)",
+                    padding: 12,
+                    background: "rgba(15, 28, 59, 0.45)",
+                  }}
+                >
+                  <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                    {a.label}
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+                    {a.ownerId && <Avatar managers={managers} ownerId={a.ownerId} size={24} />}
+                    <div>
+                      <div style={{ fontWeight: 700, fontSize: "0.98rem" }}>{a.displayName}</div>
+                      {a.teamName && a.teamName !== a.displayName && (
+                        <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>{a.teamName}</div>
+                      )}
+                    </div>
+                  </div>
+                  {a.value && (
+                    <div style={{ fontFamily: "var(--mono)", fontSize: "0.78rem", color: "var(--cyan)", marginTop: 6 }}>
+                      {renderAwardValue(a.key, a.value)}
+                    </div>
+                  )}
+                  {a.description && (
+                    <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 8, lineHeight: 1.4 }}>
+                      {a.description}
+                    </div>
+                  )}
+                  {a.ownerId && (
+                    <div style={{ marginTop: 8 }}>
+                      <LinkButton onClick={() => onNavigate("franchise", { owner: a.ownerId })}>
+                        Franchise page →
+                      </LinkButton>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+      ))}
+    </>
+  );
+}
+
+function renderAwardValue(key, value) {
+  if (!value) return "";
+  switch (key) {
+    case "champion":
+    case "runner_up":
+    case "toilet_bowl":
+      return "";
+    case "top_seed":
+      return `Win% ${fmtPercent(value.winPct)}`;
+    case "regular_season_crown":
+      return value.record || "";
+    case "points_king":
+      return `${fmtNumber(value.pointsFor, 1)} PF`;
+    case "points_black_hole":
+      return `${fmtNumber(value.pointsAgainst, 1)} PA`;
+    case "highest_single_week":
+    case "lowest_single_week":
+      return `Wk ${value.week} · ${fmtPoints(value.points)} pts`;
+    case "trader_of_the_year":
+      return `+${fmtPoints(value.pointsGained)} pts · ${value.trades} trades`;
+    case "best_trade_of_the_year":
+      return `+${fmtPoints(value.pointsGained)} pts · Wk ${value.week}`;
+    case "waiver_king":
+      return `+${fmtPoints(value.pointsGained)} pts · ${value.adds} adds`;
+    case "chaos_agent":
+      return `Score ${value.score} · ${value.trades} trades · ${value.partners} partners`;
+    case "most_active":
+      return `${value.total} moves`;
+    case "silent_assassin":
+      return `${fmtPercent(value.winPct)} in ${value.closeGames} close games`;
+    case "weekly_hammer":
+      return `${value.highScoreFinishes} high-score wks`;
+    case "playoff_mvp":
+      return `${fmtPoints(value.playoffPoints)} playoff pts`;
+    case "bad_beat":
+      return `${fmtPoints(value.points)} in loss · Wk ${value.week}`;
+    case "best_rebuild":
+      return `Composite ${value.compositeScore}`;
+    case "rivalry_of_the_year":
+      return `${value.displayNames[0]} vs ${value.displayNames[1]} · Index ${value.rivalryIndex}`;
+    case "pick_hoarder":
+      return `Weighted ${value.weightedScore} · ${value.totalPicks} picks`;
+    default:
+      return "";
+  }
+}
+
+// ── RECORDS ────────────────────────────────────────────────────────────────
+function RecordsSection({ data }) {
+  if (!data) return <EmptyCard label="Records" />;
+
+  const groups = [
+    { title: "Highest single-week scores", key: "singleWeekHighest" },
+    { title: "Lowest single-week scores", key: "singleWeekLowest" },
+    { title: "Biggest margin of victory", key: "biggestMargin" },
+    { title: "Narrowest victories", key: "narrowestVictory" },
+    { title: "Most points in a loss", key: "mostPointsInLoss" },
+    { title: "Fewest points in a win", key: "fewestPointsInWin" },
+  ];
+
+  return (
+    <>
+      <Card title="Record book" subtitle="Single-game extremes across the last 2 seasons">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 10 }}>
+          {groups.map((g) => (
+            <div key={g.key} style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+              <div style={{ fontWeight: 700, marginBottom: 6, fontSize: "0.86rem" }}>{g.title}</div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                {(data[g.key] || []).slice(0, 5).map((r, i) => (
+                  <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.74rem" }}>
+                    <span>
+                      <span style={{ color: "var(--subtext)", marginRight: 4 }}>{i + 1}.</span>
+                      {r.teamName}
+                    </span>
+                    <span style={{ fontFamily: "var(--mono)", color: "var(--cyan)" }}>
+                      {r.margin !== undefined && g.key.toLowerCase().includes("margin")
+                        ? `${fmtPoints(r.margin)} (${fmtPoints(r.points)})`
+                        : fmtPoints(r.points)}
+                    </span>
+                  </div>
+                ))}
+                {(data[g.key] || []).length === 0 && (
+                  <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>—</div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <Card title="Season totals" subtitle="Most points scored / allowed in a single season">
+        <div className="row">
+          <div className="card" style={{ flex: "1 1 260px" }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Most points in a season</div>
+            {(data.mostPointsInSeason || []).slice(0, 5).map((r, i) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.76rem", padding: "2px 0" }}>
+                <span>
+                  <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", marginRight: 6 }}>{i + 1}.</span>
+                  {r.displayName} <span style={{ color: "var(--subtext)" }}>({r.season})</span>
+                </span>
+                <span style={{ fontFamily: "var(--mono)", color: "var(--cyan)" }}>{fmtNumber(r.totalPoints, 1)}</span>
+              </div>
+            ))}
+          </div>
+          <div className="card" style={{ flex: "1 1 260px" }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Most points against in a season</div>
+            {(data.mostPointsAgainstInSeason || []).slice(0, 5).map((r, i) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.76rem", padding: "2px 0" }}>
+                <span>
+                  <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", marginRight: 6 }}>{i + 1}.</span>
+                  {r.displayName} <span style={{ color: "var(--subtext)" }}>({r.season})</span>
+                </span>
+                <span style={{ fontFamily: "var(--mono)", color: "var(--red)" }}>{fmtNumber(r.totalPointsAgainst, 1)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Streaks" subtitle="Longest consecutive wins / losses (ties end streaks)">
+        <div className="row">
+          <div className="card" style={{ flex: "1 1 260px" }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Longest win streaks</div>
+            {(data.longestWinStreaks || []).slice(0, 5).map((r, i) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.76rem", padding: "2px 0" }}>
+                <span>
+                  <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", marginRight: 6 }}>{i + 1}.</span>
+                  {r.displayName}
+                </span>
+                <span style={{ fontFamily: "var(--mono)", color: "var(--green)" }}>{r.length} wins</span>
+              </div>
+            ))}
+          </div>
+          <div className="card" style={{ flex: "1 1 260px" }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Longest losing streaks</div>
+            {(data.longestLossStreaks || []).slice(0, 5).map((r, i) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.76rem", padding: "2px 0" }}>
+                <span>
+                  <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", marginRight: 6 }}>{i + 1}.</span>
+                  {r.displayName}
+                </span>
+                <span style={{ fontFamily: "var(--mono)", color: "var(--red)" }}>{r.length} losses</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Transactions & FAAB" subtitle="Season-level activity records">
+        <div className="row">
+          <div className="card" style={{ flex: "1 1 220px" }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Most trades in a season</div>
+            {(data.mostTradesInSeason || []).slice(0, 5).map((r, i) => (
+              <div key={i} style={{ fontSize: "0.74rem", padding: "2px 0" }}>
+                {r.season}: <strong>{r.tradeCount}</strong> trades
+              </div>
+            ))}
+          </div>
+          <div className="card" style={{ flex: "1 1 220px" }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Most waivers in a season</div>
+            {(data.mostWaiversInSeason || []).slice(0, 5).map((r, i) => (
+              <div key={i} style={{ fontSize: "0.74rem", padding: "2px 0" }}>
+                {r.season}: <strong>{r.waiverCount}</strong> waivers
+              </div>
+            ))}
+          </div>
+          <div className="card" style={{ flex: "1 1 220px" }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Largest FAAB bids</div>
+            {(data.largestFaabBid || []).slice(0, 5).map((r, i) => (
+              <div key={i} style={{ fontSize: "0.74rem", padding: "2px 0" }}>
+                ${r.bid} · {r.displayName} · {r.playerName || r.playerId}
+              </div>
+            ))}
+            {(!data.largestFaabBid || data.largestFaabBid.length === 0) && (
+              <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>No FAAB bids on file.</div>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {data.playoffRecords && (
+        <Card title="Playoff records">
+          <div className="row">
+            <div className="card" style={{ flex: "1 1 260px" }}>
+              <div style={{ fontWeight: 700, marginBottom: 8 }}>Most points in playoffs</div>
+              {(data.playoffRecords.mostPointsInPlayoffs || []).slice(0, 5).map((r, i) => (
+                <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.76rem", padding: "2px 0" }}>
+                  <span>{r.teamName}</span>
+                  <span style={{ fontFamily: "var(--mono)", color: "var(--cyan)" }}>{fmtPoints(r.points)}</span>
+                </div>
+              ))}
+            </div>
+            <div className="card" style={{ flex: "1 1 260px" }}>
+              <div style={{ fontWeight: 700, marginBottom: 8 }}>Most playoff wins in a season</div>
+              {(data.playoffRecords.mostPlayoffWinsInSeason || []).slice(0, 5).map((r, i) => (
+                <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.76rem", padding: "2px 0" }}>
+                  <span>{r.displayName} <span style={{ color: "var(--subtext)" }}>({r.season})</span></span>
+                  <span style={{ fontFamily: "var(--mono)", color: "var(--cyan)" }}>{r.playoffWins}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Card>
+      )}
+    </>
+  );
+}
+
+// ── FRANCHISES ────────────────────────────────────────────────────────────
+function FranchiseSection({ managers, data, onNavigate, initialOwner, setOwner }) {
+  const index = data?.index || [];
+  const detail = data?.detail || {};
+  const initial = initialOwner && detail[initialOwner] ? initialOwner : (index[0]?.ownerId || "");
+  const [selected, setSelectedInner] = useState(initial);
+
+  // If the URL owner changes externally (back nav), reflect it.
+  useEffect(() => {
+    if (initialOwner && detail[initialOwner] && initialOwner !== selected) {
+      setSelectedInner(initialOwner);
+    }
+  }, [initialOwner]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function selectOwner(ownerId) {
+    setSelectedInner(ownerId);
+    if (setOwner) setOwner(ownerId);
+  }
+
+  if (!index.length) return <EmptyCard label="Franchises" />;
+  const fr = detail[selected] || null;
+
+  return (
+    <>
+      <Card title="Franchise index" subtitle="Sorted by titles, then best finish, then wins">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 10 }}>
+          {index.map((row) => (
+            <div
+              key={row.ownerId}
+              onClick={() => selectOwner(row.ownerId)}
+              style={{
+                border: "1px solid",
+                borderColor: selected === row.ownerId ? "var(--cyan)" : "var(--border)",
+                borderRadius: "var(--radius)",
+                padding: 10,
+                cursor: "pointer",
+                background: selected === row.ownerId ? "rgba(86, 214, 255, 0.08)" : "transparent",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <Avatar managers={managers} ownerId={row.ownerId} size={28} />
+                <div>
+                  <div style={{ fontWeight: 700 }}>{row.displayName}</div>
+                  <div style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>{row.currentTeamName}</div>
+                </div>
+              </div>
+              <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 6 }}>
+                {row.championships}× ★ · {row.wins}-{row.losses} · {row.seasonsPlayed} seasons
+              </div>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      {fr && (
+        <Card
+          title={fr.displayName}
+          subtitle={`Current: ${fr.currentTeamName || "—"}${fr.currentLeagueId ? ` · League id ${fr.currentLeagueId.slice(-6)}` : ""}`}
+          action={
+            fr.topRival && (
+              <span style={{ fontSize: "0.74rem", color: "var(--subtext)" }}>
+                Top rival:{" "}
+                <strong style={{ color: "var(--cyan)", cursor: "pointer" }} onClick={() => onNavigate("rivalries")}>
+                  {fr.topRival.displayName}
+                </strong>{" "}
+                · Index {fr.topRival.rivalryIndex}
+              </span>
+            )
+          }
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 14 }}>
+            <Avatar managers={managers} ownerId={selected} size={56} />
+            <div style={{ fontSize: "0.74rem", color: "var(--subtext)" }}>
+              Owner ID: <span style={{ fontFamily: "var(--mono)" }}>{selected}</span>
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10, marginBottom: 14 }}>
+            <Stat label="Seasons" value={fr.cumulative.seasonsPlayed} />
+            <Stat
+              label="Record"
+              value={`${fr.cumulative.wins}-${fr.cumulative.losses}${fr.cumulative.ties ? `-${fr.cumulative.ties}` : ""}`}
+            />
+            <Stat label="Points for" value={fmtNumber(fr.cumulative.pointsFor, 1)} />
+            <Stat
+              label="Titles"
+              value={fr.cumulative.championships}
+              sub={`${fr.cumulative.finalsAppearances} finals`}
+            />
+            <Stat
+              label="Playoffs"
+              value={fr.cumulative.playoffAppearances}
+              sub={`${fr.cumulative.regularSeasonFirstPlace} reg 1st`}
+            />
+            <Stat
+              label="Trades"
+              value={fr.tradeCount}
+              sub={`${fr.waiverCount} waivers`}
+            />
+          </div>
+
+          {fr.draftCapital && (
+            <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10, marginBottom: 14 }}>
+              <div style={{ fontWeight: 700, marginBottom: 6 }}>Draft capital</div>
+              <div style={{ fontSize: "0.78rem", color: "var(--subtext)", marginBottom: 6 }}>
+                Weighted score {fr.draftCapital.weightedScore} · {fr.draftCapital.totalPicks} owned picks
+              </div>
+              {(fr.draftCapital.picks || []).length > 0 && (
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                  {(fr.draftCapital.picks || []).map((p, i) => (
+                    <span
+                      key={i}
+                      style={{
+                        fontFamily: "var(--mono)",
+                        fontSize: "0.7rem",
+                        border: "1px solid var(--border)",
+                        padding: "2px 6px",
+                        borderRadius: 4,
+                        color: p.isTraded ? "var(--amber)" : "var(--text)",
+                      }}
+                    >
+                      {p.label}{p.isTraded ? "*" : ""}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 6 }}>
+                * acquired via trade
+              </div>
+            </div>
+          )}
+
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>Season results</div>
           <div className="table-wrap">
             <table>
               <thead>
                 <tr>
-                  <th style={{ textAlign: "right" }}>Pk</th>
+                  <th>Season</th>
+                  <th>Team</th>
+                  <th style={{ textAlign: "right" }}>W-L-T</th>
+                  <th style={{ textAlign: "right" }}>PF</th>
+                  <th style={{ textAlign: "right" }}>PA</th>
+                  <th style={{ textAlign: "right" }}>Seed</th>
+                  <th style={{ textAlign: "right" }}>Final</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(fr.seasonResults || []).map((r, i) => (
+                  <tr key={i}>
+                    <td>{r.season}</td>
+                    <td style={{ fontWeight: 600 }}>{r.teamName}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                      {r.wins}-{r.losses}{r.ties ? `-${r.ties}` : ""}
+                    </td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtNumber(r.pointsFor, 1)}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtNumber(r.pointsAgainst, 1)}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.standing}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.finalPlace ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {(fr.aliases || []).length > 1 && (
+            <div style={{ marginTop: 14, fontSize: "0.72rem", color: "var(--subtext)" }}>
+              Team-name history: {(fr.aliases || []).map((a) => `${a.teamName} (${a.season})`).join(" → ")}
+            </div>
+          )}
+        </Card>
+      )}
+    </>
+  );
+}
+
+// ── TRADE ACTIVITY CENTER ──────────────────────────────────────────────────
+function ActivitySection({ managers, data, onNavigate }) {
+  const feed = data?.feed || [];
+  const [filter, setFilter] = useState("");
+  if (!feed.length && !data?.totalCount) return <EmptyCard label="Trade activity" />;
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return feed;
+    return feed.filter((t) => {
+      const tokens = [
+        t.season,
+        t.week,
+        ...(t.sides || []).map((s) => s.displayName),
+        ...(t.sides || []).flatMap((s) => (s.receivedAssets || []).map((a) => a.playerName || "")),
+      ].filter(Boolean).join(" ").toLowerCase();
+      return tokens.includes(q);
+    });
+  }, [feed, filter]);
+
+  return (
+    <>
+      <Card title="Trade activity" subtitle={`${data.totalCount} completed trades across the last 2 seasons`}>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10, marginBottom: 12 }}>
+          <Stat label="Picks moved" value={data.picksMovedCount || 0} />
+          <Stat label="Players moved" value={data.playersMovedCount || 0} />
+          <Stat
+            label="Most active trader"
+            value={data.mostActiveTrader?.displayName || "—"}
+            sub={data.mostActiveTrader ? `${data.mostActiveTrader.trades} trades` : ""}
+          />
+          <Stat
+            label="Top partner pair"
+            value={data.mostFrequentPartnerPair?.displayNames?.join(" + ") || "—"}
+            sub={data.mostFrequentPartnerPair ? `${data.mostFrequentPartnerPair.trades} deals` : ""}
+          />
+        </div>
+      </Card>
+
+      {data.biggestBlockbusters && data.biggestBlockbusters.length > 0 && (
+        <Card title="Biggest blockbusters" subtitle="Sorted by total assets moved">
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 10 }}>
+            {data.biggestBlockbusters.map((t) => (
+              <TradeCard key={t.transactionId} trade={t} managers={managers} onNavigate={onNavigate} />
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {data.positionMixMoved && Object.keys(data.positionMixMoved).length > 0 && (
+        <Card title="Position mix moved" subtitle="Players moved by position in completed trades">
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            {Object.entries(data.positionMixMoved).sort(([, a], [, b]) => b - a).map(([pos, n]) => (
+              <div
+                key={pos}
+                style={{
+                  border: "1px solid var(--border)",
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  fontSize: "0.78rem",
+                }}
+              >
+                <strong>{pos}</strong>: {n}
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      <Card
+        title="Trade timeline"
+        subtitle="Filter by team name, player, or season"
+        action={
+          <input
+            className="input"
+            placeholder="Filter trades..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            style={{ minWidth: 220 }}
+          />
+        }
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {filtered.map((t) => (
+            <TradeCard key={t.transactionId} trade={t} managers={managers} onNavigate={onNavigate} />
+          ))}
+          {filtered.length === 0 && (
+            <div style={{ fontSize: "0.74rem", color: "var(--subtext)" }}>
+              No trades match that filter.
+            </div>
+          )}
+        </div>
+      </Card>
+    </>
+  );
+}
+
+function TradeCard({ trade, managers, onNavigate }) {
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+      <div style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>
+        {trade.season} · Week {trade.week ?? "—"} · {trade.totalAssets} assets
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: `repeat(${Math.max(1, (trade.sides || []).length)}, 1fr)`,
+          gap: 8,
+          marginTop: 6,
+        }}
+      >
+        {(trade.sides || []).map((side, i) => (
+          <div key={i} style={{ minWidth: 0 }}>
+            <div
+              style={{ display: "flex", alignItems: "center", gap: 6, fontWeight: 700, fontSize: "0.86rem" }}
+              onClick={() => onNavigate && side.ownerId && onNavigate("franchise", { owner: side.ownerId })}
+            >
+              <Avatar managers={managers} ownerId={side.ownerId} size={20} />
+              <span style={{ cursor: side.ownerId ? "pointer" : "default", color: side.ownerId ? "var(--cyan)" : "var(--text)" }}>
+                {side.displayName || side.teamName || nameFor(managers, side.ownerId)}
+              </span>
+            </div>
+            <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 2 }}>Received:</div>
+            <ul style={{ paddingInlineStart: 16, margin: "4px 0 0", fontSize: "0.72rem" }}>
+              {(side.receivedAssets || []).map((a, j) => (
+                <li key={j}>
+                  {a.kind === "player" ? (
+                    <>
+                      {a.playerName || "Player"}
+                      <span style={{ color: "var(--subtext)", marginLeft: 4 }}>({a.position || "?"})</span>
+                    </>
+                  ) : (
+                    <>{a.label || `${a.season} R${a.round}`}</>
+                  )}
+                </li>
+              ))}
+              {(side.receivedAssets || []).length === 0 && (
+                <li style={{ color: "var(--subtext)" }}>—</li>
+              )}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── DRAFT CENTER ──────────────────────────────────────────────────────────
+function DraftSection({ data, initialOwner, setOwner }) {
+  if (!data) return <EmptyCard label="Drafts" />;
+  const board = data.stockpileLeaderboard || [];
+  const ownership = data.pickOwnership || {};
+  const defaultOwner = board.find((r) => r.ownerId === initialOwner)?.ownerId
+    || board[0]?.ownerId
+    || "";
+  const [selectedOwner, setSelectedOwnerInner] = useState(defaultOwner);
+  useEffect(() => {
+    if (initialOwner && ownership[initialOwner] && initialOwner !== selectedOwner) {
+      setSelectedOwnerInner(initialOwner);
+    }
+  }, [initialOwner]); // eslint-disable-line react-hooks/exhaustive-deps
+  function selectOwner(ownerId) {
+    setSelectedOwnerInner(ownerId);
+    if (setOwner) setOwner(ownerId);
+  }
+  const drafts = data.drafts || [];
+  const ownerPicks = ownership[selectedOwner] || [];
+
+  return (
+    <>
+      <Card title="Weighted pick stockpile" subtitle="1st round = 4 pts, 2nd = 3, 3rd = 2, 4th+ = 1">
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Manager</th>
+                <th style={{ textAlign: "right" }}>Total picks</th>
+                <th style={{ textAlign: "right" }}>Weighted</th>
+              </tr>
+            </thead>
+            <tbody>
+              {board.map((row, i) => (
+                <tr
+                  key={row.ownerId}
+                  onClick={() => selectOwner(row.ownerId)}
+                  style={{
+                    cursor: "pointer",
+                    background: selectedOwner === row.ownerId ? "rgba(86, 214, 255, 0.08)" : "transparent",
+                  }}
+                >
+                  <td style={{ fontWeight: 600 }}>
+                    <span style={{ color: "var(--subtext)", marginRight: 6, fontFamily: "var(--mono)" }}>{i + 1}.</span>
+                    {row.displayName}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{row.totalPicks}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--cyan)" }}>{row.weightedScore}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      {selectedOwner && (
+        <Card
+          title="Pick inventory"
+          subtitle={`Picks owned by ${board.find((r) => r.ownerId === selectedOwner)?.displayName || "this manager"}`}
+        >
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {ownerPicks.length === 0 && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>No tracked picks.</div>
+            )}
+            {ownerPicks.map((p, i) => (
+              <span
+                key={i}
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "0.72rem",
+                  border: "1px solid var(--border)",
+                  padding: "3px 8px",
+                  borderRadius: 4,
+                  color: p.isTraded ? "var(--amber)" : "var(--text)",
+                }}
+              >
+                {p.label}{p.isTraded ? "*" : ""}
+              </span>
+            ))}
+          </div>
+          <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 6 }}>
+            Amber picks (*) were acquired via trade.
+          </div>
+        </Card>
+      )}
+
+      {data.mostTradedPick && (
+        <Card title="Most-traded pick">
+          <div>
+            <div style={{ fontWeight: 700, fontSize: "0.94rem" }}>{data.mostTradedPick.label}</div>
+            <div style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>
+              Changed hands {data.mostTradedPick.moveCount} time{data.mostTradedPick.moveCount === 1 ? "" : "s"}
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {drafts.map((d) => (
+        <Card
+          key={d.draftId}
+          title={`${d.season} rookie draft`}
+          subtitle={`${d.status} · ${d.rounds || "?"} rounds · ${(d.picks || []).length} picks`}
+        >
+          {d.firstRoundRecap && d.firstRoundRecap.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <div style={{ fontWeight: 600, marginBottom: 4 }}>First round recap</div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 6 }}>
+                {d.firstRoundRecap.map((p, i) => (
+                  <div key={i} style={{ border: "1px solid var(--border)", borderRadius: 6, padding: 8 }}>
+                    <div style={{ fontSize: "0.66rem", color: "var(--subtext)", fontFamily: "var(--mono)" }}>
+                      {d.season} 1.{String(p.pickNo).padStart(2, "0")}
+                    </div>
+                    <div style={{ fontWeight: 700 }}>{p.playerName || "Unknown"}</div>
+                    <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
+                      {p.position || "?"}{p.nflTeam ? ` · ${p.nflTeam}` : ""} · {p.teamName}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "right" }}>Pick</th>
                   <th>Player</th>
                   <th>Pos</th>
                   <th>NFL</th>
@@ -455,10 +1800,12 @@ function DraftSection({ data }) {
                 </tr>
               </thead>
               <tbody>
-                {d.picks.slice(0, 48).map((p, i) => (
+                {(d.picks || []).map((p, i) => (
                   <tr key={i}>
-                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{p.round}.{String(p.pickNo).padStart(2, "0")}</td>
-                    <td>{p.playerName || "\u2014"}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                      {p.round}.{String(p.pickNo).padStart(2, "0")}
+                    </td>
+                    <td>{p.playerName || "—"}</td>
                     <td style={{ fontFamily: "var(--mono)" }}>{p.position || ""}</td>
                     <td style={{ fontFamily: "var(--mono)" }}>{p.nflTeam || ""}</td>
                     <td>{p.teamName}</td>
@@ -467,166 +1814,525 @@ function DraftSection({ data }) {
               </tbody>
             </table>
           </div>
-        </div>
+        </Card>
       ))}
     </>
   );
 }
 
-function WeeklySection({ data }) {
+// ── WEEKLY RECAP ──────────────────────────────────────────────────────────
+function WeeklySection({ data, managers, onNavigate, initialWeek, setWeek }) {
   const weeks = data?.weeks || [];
-  const [selected, setSelected] = useState(weeks[0] ? `${weeks[0].season}:${weeks[0].week}` : "");
+  const defaultKey = weeks[0] ? `${weeks[0].season}:${weeks[0].week}` : "";
+  const initialKey = initialWeek && weeks.some((w) => `${w.season}:${w.week}` === initialWeek)
+    ? initialWeek
+    : defaultKey;
+  const [selected, setSelectedInner] = useState(initialKey);
+  useEffect(() => {
+    if (initialWeek && weeks.some((w) => `${w.season}:${w.week}` === initialWeek) && initialWeek !== selected) {
+      setSelectedInner(initialWeek);
+    }
+  }, [initialWeek]); // eslint-disable-line react-hooks/exhaustive-deps
+
   if (!weeks.length) return <EmptyCard label="Weekly recap" />;
   const active = weeks.find((w) => `${w.season}:${w.week}` === selected) || weeks[0];
+  const h = active.highlights || {};
+
+  function changeWeek(key) {
+    setSelectedInner(key);
+    if (setWeek) setWeek(key);
+  }
 
   return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <select
-        className="input"
-        value={`${active.season}:${active.week}`}
-        onChange={(e) => setSelected(e.target.value)}
-        style={{ minWidth: 220, marginBottom: 10 }}
-      >
-        {weeks.map((w) => (
-          <option key={`${w.season}:${w.week}`} value={`${w.season}:${w.week}`}>
-            {w.season} Week {w.week}
-          </option>
-        ))}
-      </select>
-      <div className="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Home</th>
-              <th style={{ textAlign: "right" }}>Score</th>
-              <th style={{ textAlign: "right" }}>Margin</th>
-              <th style={{ textAlign: "right" }}>Score</th>
-              <th>Away</th>
-            </tr>
-          </thead>
-          <tbody>
-            {active.matchups.map((m, i) => (
-              <tr key={i}>
-                <td style={{ fontWeight: 600 }}>{m.home.teamName}</td>
-                <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{m.home.points}</td>
-                <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>{m.margin}</td>
-                <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{m.away.points}</td>
-                <td style={{ fontWeight: 600 }}>{m.away.teamName}</td>
-              </tr>
+    <>
+      <Card
+        title={`${active.season} · Week ${active.week}${active.isPlayoff ? " (playoffs)" : ""}`}
+        action={
+          <select
+            className="input"
+            value={`${active.season}:${active.week}`}
+            onChange={(e) => changeWeek(e.target.value)}
+            style={{ minWidth: 180 }}
+          >
+            {weeks.map((w) => (
+              <option key={`${w.season}:${w.week}`} value={`${w.season}:${w.week}`}>
+                {w.season} Wk {w.week}{w.isPlayoff ? " (P)" : ""}
+              </option>
             ))}
-          </tbody>
-        </table>
+          </select>
+        }
+      >
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 10, marginBottom: 14 }}>
+          <HighlightCard
+            label="Game of the week"
+            caption={h.gameOfTheWeek ? `margin ${fmtPoints(h.gameOfTheWeek.margin)}` : "—"}
+            teams={h.gameOfTheWeek ? [h.gameOfTheWeek.home, h.gameOfTheWeek.away] : null}
+          />
+          <HighlightCard
+            label="Blowout of the week"
+            caption={h.blowoutOfTheWeek ? `margin ${fmtPoints(h.blowoutOfTheWeek.margin)}` : "—"}
+            teams={h.blowoutOfTheWeek ? [h.blowoutOfTheWeek.home, h.blowoutOfTheWeek.away] : null}
+          />
+          <HighlightCard
+            label="Upset of the week"
+            caption={h.upsetOfTheWeek
+              ? `winner ${h.upsetOfTheWeek.winnerOwnerId ? nameFor(managers, h.upsetOfTheWeek.winnerOwnerId) : "—"}`
+              : "No upsets"}
+            teams={h.upsetOfTheWeek ? [h.upsetOfTheWeek.home, h.upsetOfTheWeek.away] : null}
+          />
+          <SingleHighlight
+            label="Highest scorer"
+            value={h.highestScorer ? `${h.highestScorer.displayName} (${fmtPoints(h.highestScorer.points)})` : "—"}
+          />
+          <SingleHighlight
+            label="Lowest scorer"
+            value={h.lowestScorer ? `${h.lowestScorer.displayName} (${fmtPoints(h.lowestScorer.points)})` : "—"}
+          />
+          {h.standingsMover && (
+            <SingleHighlight
+              label="Biggest standings mover"
+              value={`${nameFor(managers, h.standingsMover.ownerId)} (${h.standingsMover.preRank} → ${h.standingsMover.postRank})`}
+              sub={`Δ ${h.standingsMover.delta > 0 ? "+" : ""}${h.standingsMover.delta}`}
+            />
+          )}
+          {h.rivalryResult && (
+            <SingleHighlight
+              label="Rivalry meeting"
+              value={`${h.rivalryResult.home?.displayName} vs ${h.rivalryResult.away?.displayName}`}
+              sub={`margin ${fmtPoints(h.rivalryResult.margin)}`}
+            />
+          )}
+        </div>
+
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Home</th>
+                <th style={{ textAlign: "right" }}>Score</th>
+                <th style={{ textAlign: "right" }}>Margin</th>
+                <th style={{ textAlign: "right" }}>Score</th>
+                <th>Away</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(active.matchups || []).map((m, i) => {
+                const winnerIsHome = m.winnerOwnerId === m.home?.ownerId;
+                const winnerIsAway = m.winnerOwnerId === m.away?.ownerId;
+                return (
+                  <tr key={i}>
+                    <td style={{ fontWeight: 600, color: winnerIsHome ? "var(--green)" : "var(--text)" }}>{m.home?.displayName}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtPoints(m.home?.points)}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>{fmtPoints(m.margin)}</td>
+                    <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtPoints(m.away?.points)}</td>
+                    <td style={{ fontWeight: 600, color: winnerIsAway ? "var(--green)" : "var(--text)" }}>{m.away?.displayName}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div style={{ marginTop: 12 }}>
+          <LinkButton onClick={() => onNavigate("archives")}>Open matchup archive →</LinkButton>
+        </div>
+      </Card>
+    </>
+  );
+}
+
+function HighlightCard({ label, caption, teams }) {
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+      <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontSize: "0.84rem", fontWeight: 700, marginTop: 2 }}>
+        {teams && teams[0] && teams[1]
+          ? `${teams[0].displayName} vs ${teams[1].displayName}`
+          : "—"}
       </div>
+      <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 2 }}>{caption}</div>
     </div>
   );
 }
 
-function SuperlativesSection({ league, data }) {
-  const managers = useMemo(() => buildManagerLookup(league), [league]);
+function SingleHighlight({ label, value, sub }) {
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+      <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontSize: "0.84rem", fontWeight: 700, marginTop: 2 }}>{value}</div>
+      {sub && <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 2 }}>{sub}</div>}
+    </div>
+  );
+}
+
+// ── SUPERLATIVES ──────────────────────────────────────────────────────────
+function SuperlativesSection({ managers, data }) {
   if (!data) return <EmptyCard label="Superlatives" />;
 
   const blocks = [
-    { key: "hardLuck", label: "Hard-Luck Manager (high PF, low wins)" },
-    { key: "luckyDuck", label: "Lucky Duck (high wins, low PF)" },
-    { key: "tradeMachine", label: "Trade Machine" },
-    { key: "mostImproved", label: "Most Improved" },
-    { key: "couchCoach", label: "Couch Coach (lowest avg PF)" },
+    { key: "mostQbHeavy", label: "Most QB-heavy", caption: "Most quarterbacks rostered" },
+    { key: "mostRbHeavy", label: "Most RB-heavy", caption: "Most running backs rostered" },
+    { key: "mostWrHeavy", label: "Most WR-heavy", caption: "Most wide receivers rostered" },
+    { key: "mostTeHeavy", label: "Most TE-heavy", caption: "Most tight ends rostered" },
+    { key: "mostIdpHeavy", label: "Most IDP-heavy", caption: "Most defenders rostered" },
+    { key: "mostPickHeavy", label: "Biggest pick stockpile", caption: "Highest weighted pick score" },
+    { key: "mostRookieHeavy", label: "Most rookies", caption: "Most first-year players rostered" },
+    { key: "mostBalanced", label: "Most balanced", caption: "Lowest variance across QB/RB/WR/TE" },
+    { key: "mostActive", label: "Most active franchise", caption: "Most trades + waivers combined" },
+    { key: "mostFutureFocused", label: "Most future-focused", caption: "Blend of pick stockpile + rookies" },
   ];
 
   return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      {blocks.map((b) => (
-        <div key={b.key} style={{ marginBottom: 14 }}>
-          <div style={{ fontWeight: 700, fontSize: "0.82rem", marginBottom: 6 }}>{b.label}</div>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            {(data[b.key] || []).map((row, i) => (
+    <Card
+      title="Superlatives"
+      subtitle="Fun, public-safe roster-composition awards across the 2-season window"
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 10 }}>
+        {blocks.map((b) => {
+          const block = data[b.key];
+          if (!block || !block.winner) return null;
+          const w = block.winner;
+          return (
+            <div
+              key={b.key}
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius)",
+                padding: 12,
+                background: "rgba(15, 28, 59, 0.45)",
+              }}
+            >
               <div
-                key={i}
-                style={{ border: "1px solid var(--border)", padding: "6px 10px", borderRadius: 6, fontSize: "0.72rem" }}
+                style={{
+                  fontSize: "0.62rem",
+                  color: "var(--subtext)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                }}
               >
-                <div style={{ fontWeight: 600 }}>{nameFor(managers, row.ownerId)}</div>
-                <div style={{ fontFamily: "var(--mono)", fontSize: "0.66rem", color: "var(--subtext)" }}>
-                  {JSON.stringify(
-                    Object.fromEntries(Object.entries(row).filter(([k]) => k !== "ownerId")),
-                  )}
-                </div>
+                {b.label}
               </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+                <Avatar managers={managers} ownerId={w.ownerId} size={24} />
+                <div style={{ fontWeight: 700, fontSize: "0.98rem" }}>{w.displayName}</div>
+              </div>
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 2, marginBottom: 8 }}>
+                {b.caption}
+              </div>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(4, 1fr)",
+                  gap: 6,
+                  fontSize: "0.7rem",
+                  fontFamily: "var(--mono)",
+                }}
+              >
+                <span>QB: {w.qb}</span>
+                <span>RB: {w.rb}</span>
+                <span>WR: {w.wr}</span>
+                <span>TE: {w.te}</span>
+                <span>IDP: {w.idp}</span>
+                <span>Rook: {w.rookies}</span>
+                <span>Trades: {w.trades}</span>
+                <span>Picks: {w.weightedPickScore}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
   );
 }
+
+// ── ARCHIVES ──────────────────────────────────────────────────────────────
+const ARCHIVE_KINDS = [
+  { key: "trades", label: "Trades" },
+  { key: "waivers", label: "Waivers / FA" },
+  { key: "weeklyMatchups", label: "Matchups" },
+  { key: "rookieDrafts", label: "Rookie drafts" },
+  { key: "seasonResults", label: "Season results" },
+  { key: "managers", label: "Managers" },
+];
 
 function ArchivesSection({ data }) {
+  const [kind, setKind] = useState("trades");
   const [query, setQuery] = useState("");
+  const [season, setSeason] = useState("all");
   if (!data) return <EmptyCard label="Archives" />;
 
-  const allRows = useMemo(() => {
-    const rows = [];
-    (data.managers || []).forEach((m) => rows.push({ kind: m.kind, label: m.displayName, sub: (m.aliases || []).join(" / "), season: "" }));
-    (data.trades || []).forEach((t) => rows.push({ kind: t.kind, label: `Trade ${t.transactionId.slice(0, 8)}`, sub: (t.ownerIds || []).join(" \u2194 "), season: t.season }));
-    (data.draftPicks || []).forEach((p) => rows.push({ kind: p.kind, label: `${p.playerName} (${p.position})`, sub: `${p.teamName} \u00B7 ${p.round}.${String(p.pickNo).padStart(2, "0")}`, season: p.season }));
-    (data.weekScores || []).forEach((w) => rows.push({ kind: w.kind, label: `${w.teamName} \u00B7 ${w.points}`, sub: `W${w.week}`, season: w.season }));
-    return rows;
-  }, [data]);
-
+  const seasonsCovered = data.seasonsCovered || [];
+  const rows = useMemo(() => data[kind] || [], [data, kind]);
   const filtered = useMemo(() => {
+    let out = rows;
+    if (season !== "all") {
+      out = out.filter((r) => String(r.season || "") === season);
+    }
     const q = query.trim().toLowerCase();
-    if (!q) return allRows.slice(0, 200);
-    return allRows.filter(
-      (r) => r.label.toLowerCase().includes(q) || r.sub.toLowerCase().includes(q) || String(r.season).toLowerCase().includes(q),
-    ).slice(0, 200);
-  }, [allRows, query]);
+    if (q) {
+      out = out.filter((r) => archiveSearchTokens(r).includes(q));
+    }
+    return out.slice(0, 500);
+  }, [rows, query, season]);
 
   return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <input
-        className="input"
-        placeholder="Search managers, trades, drafts, weeks..."
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        style={{ maxWidth: 340, marginBottom: 10 }}
-      />
+    <Card
+      title="Public archives"
+      subtitle="Full searchable history of trades, waivers, matchups, drafts, and season results"
+    >
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+        {ARCHIVE_KINDS.map((k) => (
+          <button
+            key={k.key}
+            type="button"
+            onClick={() => setKind(k.key)}
+            style={{
+              padding: "6px 10px",
+              fontSize: "0.74rem",
+              border: "1px solid",
+              borderColor: kind === k.key ? "var(--cyan)" : "var(--border)",
+              background: kind === k.key ? "rgba(86, 214, 255, 0.12)" : "transparent",
+              borderRadius: 6,
+              color: "var(--text)",
+              cursor: "pointer",
+            }}
+          >
+            {k.label} ({(data[k.key] || []).length})
+          </button>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 10 }}>
+        <input
+          className="input"
+          placeholder="Search..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          style={{ minWidth: 240 }}
+        />
+        <select
+          className="input"
+          value={season}
+          onChange={(e) => setSeason(e.target.value)}
+          style={{ minWidth: 140 }}
+        >
+          <option value="all">All seasons</option>
+          {seasonsCovered.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+
       <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginBottom: 6 }}>
-        Showing {filtered.length} of {allRows.length} indexed records.
+        {filtered.length} result{filtered.length === 1 ? "" : "s"}
+        {rows.length > filtered.length ? ` of ${rows.length}` : ""}
       </div>
+
       <div className="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Kind</th>
-              <th>Label</th>
-              <th>Details</th>
-              <th>Season</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((r, i) => (
-              <tr key={i}>
-                <td style={{ fontFamily: "var(--mono)", fontSize: "0.66rem", color: "var(--subtext)" }}>{r.kind}</td>
-                <td style={{ fontWeight: 600 }}>{r.label}</td>
-                <td style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>{r.sub}</td>
-                <td style={{ fontFamily: "var(--mono)" }}>{r.season}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <ArchiveTable kind={kind} rows={filtered} />
       </div>
-    </div>
+    </Card>
   );
 }
 
-function EmptyCard({ label }) {
-  return (
-    <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <EmptyState
-        title={`${label} coming online`}
-        message="Sleeper fetch returned nothing for this section yet. Sections hydrate as soon as the league has completed games / trades / drafts."
-      />
-    </div>
-  );
+function archiveSearchTokens(row) {
+  const parts = [];
+  for (const [, v] of Object.entries(row)) {
+    if (v === null || v === undefined) continue;
+    if (Array.isArray(v)) {
+      parts.push(
+        v.map((x) => (typeof x === "object" && x !== null ? Object.values(x).join(" ") : x)).join(" "),
+      );
+    } else if (typeof v === "object") {
+      parts.push(Object.values(v).join(" "));
+    } else {
+      parts.push(String(v));
+    }
+  }
+  return parts.join(" ").toLowerCase();
+}
+
+function ArchiveTable({ kind, rows }) {
+  if (!rows.length) {
+    return (
+      <div style={{ fontSize: "0.74rem", color: "var(--subtext)", padding: 10 }}>
+        No records match.
+      </div>
+    );
+  }
+  if (kind === "trades") {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Season</th>
+            <th>Wk</th>
+            <th>Teams</th>
+            <th>Assets</th>
+            <th>Positions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.season}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.week ?? "—"}</td>
+              <td>{(r.ownerIds || []).join(" ↔ ")}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.totalAssets}</td>
+              <td style={{ fontSize: "0.72rem" }}>{(r.positions || []).join(", ")}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  if (kind === "waivers") {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Season</th>
+            <th>Wk</th>
+            <th>Type</th>
+            <th>Manager</th>
+            <th>Bid</th>
+            <th>Added</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.season}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.week ?? "—"}</td>
+              <td style={{ fontFamily: "var(--mono)", fontSize: "0.7rem" }}>{r.type}</td>
+              <td>{r.ownerId || "—"}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.bid ?? "—"}</td>
+              <td style={{ fontSize: "0.72rem" }}>
+                {(r.added || []).map((p) => `${p.playerName} (${p.position || "?"})`).join(", ")}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  if (kind === "weeklyMatchups") {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Season</th>
+            <th>Wk</th>
+            <th>Home</th>
+            <th style={{ textAlign: "right" }}>Score</th>
+            <th style={{ textAlign: "right" }}>Score</th>
+            <th>Away</th>
+            <th>Tags</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.season}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.week}</td>
+              <td>{r.homeOwnerId || "—"}</td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtPoints(r.homePoints)}</td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtPoints(r.awayPoints)}</td>
+              <td>{r.awayOwnerId || "—"}</td>
+              <td style={{ fontSize: "0.7rem" }}>{(r.tags || []).join(", ")}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  if (kind === "rookieDrafts") {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Season</th>
+            <th>Pick</th>
+            <th>Player</th>
+            <th>Pos</th>
+            <th>NFL</th>
+            <th>Drafted by</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.season}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>
+                {r.round}.{String(r.pickNo).padStart(2, "0")}
+              </td>
+              <td style={{ fontWeight: 600 }}>{r.playerName}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.position || ""}</td>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.nflTeam || ""}</td>
+              <td>{r.teamName}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  if (kind === "seasonResults") {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Season</th>
+            <th>Team</th>
+            <th style={{ textAlign: "right" }}>W-L-T</th>
+            <th style={{ textAlign: "right" }}>PF</th>
+            <th style={{ textAlign: "right" }}>Seed</th>
+            <th style={{ textAlign: "right" }}>Final</th>
+            <th>Tags</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td style={{ fontFamily: "var(--mono)" }}>{r.season}</td>
+              <td style={{ fontWeight: 600 }}>{r.teamName}</td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                {r.wins}-{r.losses}{r.ties ? `-${r.ties}` : ""}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{fmtNumber(r.pointsFor, 1)}</td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.standing}</td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.finalPlace ?? "—"}</td>
+              <td style={{ fontSize: "0.72rem" }}>{(r.tags || []).join(", ")}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  if (kind === "managers") {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Manager</th>
+            <th>Current team</th>
+            <th>Aliases</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td style={{ fontWeight: 600 }}>{r.displayName}</td>
+              <td>{r.currentTeamName}</td>
+              <td style={{ fontSize: "0.72rem" }}>{(r.aliases || []).join(", ")}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  return null;
 }
 
 // Expose available section keys for external consumers / tests.

--- a/frontend/app/league/rivalry/[pair]/page.jsx
+++ b/frontend/app/league/rivalry/[pair]/page.jsx
@@ -1,0 +1,201 @@
+"use client";
+
+// Dedicated, deep-linkable /league/rivalry/[pair] route.
+//
+// ``pair`` is an URL-encoded string of the form ``<ownerA>-vs-<ownerB>``.
+// We find the matching rivalry in the public rivalries section (which
+// already returns every pair) and render the same detail view the
+// tabbed page shows.
+//
+// No private imports — see isolation contract in page.jsx.
+
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { LoadingState, EmptyState, PageHeader } from "@/components/ui";
+import { fetchPublicSection } from "@/lib/public-league-data";
+import {
+  Avatar,
+  Card,
+  MeetingCard,
+  Stat,
+  buildManagerLookup,
+  fmtPoints,
+  nameFor,
+} from "../../shared.jsx";
+
+export default function RivalryPageRoute() {
+  return (
+    <Suspense fallback={<LoadingState message="Loading rivalry..." />}>
+      <RivalryPage />
+    </Suspense>
+  );
+}
+
+function parsePairSlug(slug) {
+  if (!slug) return { a: "", b: "" };
+  const decoded = decodeURIComponent(String(slug));
+  // Support either "a-vs-b" or "a:b" forms.
+  const parts = decoded.includes("-vs-")
+    ? decoded.split("-vs-")
+    : decoded.includes(":")
+    ? decoded.split(":")
+    : [decoded];
+  return { a: String(parts[0] || ""), b: String(parts[1] || "") };
+}
+
+function RivalryPage() {
+  const params = useParams();
+  const { a: ownerA, b: ownerB } = parsePairSlug(params?.pair);
+  const [state, setState] = useState({ loading: true, error: "", payload: null });
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const payload = await fetchPublicSection("rivalries");
+        if (!active) return;
+        setState({ loading: false, error: "", payload });
+      } catch (err) {
+        if (!active) return;
+        setState({
+          loading: false,
+          error: err?.message || "Failed to load rivalry data",
+          payload: null,
+        });
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Hooks must run on every render — compute managers before any early
+  // return branches below.
+  const { league, data } = state.payload || {};
+  const managers = useMemo(() => buildManagerLookup(league), [league]);
+  const rivalries = data?.rivalries || [];
+
+  if (state.loading) return <LoadingState message="Loading rivalry..." />;
+  if (state.error) {
+    return (
+      <div className="card">
+        <EmptyState title="Rivalry unavailable" message={state.error} />
+        <div style={{ marginTop: 10 }}>
+          <Link href="/league" style={{ color: "var(--cyan)" }}>← Back to league</Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Find the pair regardless of ordering.
+  const detail = rivalries.find((r) => {
+    const ids = new Set((r.ownerIds || []).map(String));
+    return ids.has(ownerA) && ids.has(ownerB);
+  });
+
+  if (!detail) {
+    return (
+      <div className="card">
+        <EmptyState
+          title="Rivalry not found"
+          message={
+            ownerA && ownerB
+              ? `No meetings between ${nameFor(managers, ownerA)} and ${nameFor(managers, ownerB)} in the last 2 seasons.`
+              : "Rivalry slug must be of the form owner-a-vs-owner-b."
+          }
+        />
+        <div style={{ marginTop: 10 }}>
+          <Link href="/league?tab=rivalries" style={{ color: "var(--cyan)" }}>← All rivalries</Link>
+        </div>
+      </div>
+    );
+  }
+
+  const [idA, idB] = detail.ownerIds;
+
+  return (
+    <section>
+      <div className="card">
+        <div style={{ fontSize: "0.72rem", marginBottom: 6 }}>
+          <Link href="/league" style={{ color: "var(--cyan)" }}>← League home</Link>
+          {" · "}
+          <Link href="/league?tab=rivalries" style={{ color: "var(--cyan)" }}>All rivalries</Link>
+        </div>
+        <PageHeader
+          title={`${nameFor(managers, idA)} vs ${nameFor(managers, idB)}`}
+          subtitle={`Rivalry Index ${detail.rivalryIndex} · Head-to-head detail`}
+        />
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <Link href={`/league/franchise/${encodeURIComponent(idA)}`} style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "var(--cyan)" }}>
+            <Avatar managers={managers} ownerId={idA} size={36} />
+            <span style={{ fontWeight: 700 }}>{nameFor(managers, idA)}</span>
+          </Link>
+          <span style={{ color: "var(--subtext)", fontWeight: 700 }}>vs</span>
+          <Link href={`/league/franchise/${encodeURIComponent(idB)}`} style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "var(--cyan)" }}>
+            <Avatar managers={managers} ownerId={idB} size={36} />
+            <span style={{ fontWeight: 700 }}>{nameFor(managers, idB)}</span>
+          </Link>
+        </div>
+      </div>
+
+      <Card title="Head-to-head">
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            gap: 10,
+            marginBottom: 14,
+          }}
+        >
+          <Stat label="Meetings" value={detail.totalMeetings} sub={`${detail.regularSeasonMeetings} reg · ${detail.playoffMeetings} playoff`} />
+          <Stat label="Series" value={`${detail.winsA}–${detail.winsB}${detail.ties ? `–${detail.ties}` : ""}`} />
+          <Stat label="Points" value={`${fmtPoints(detail.pointsA)} / ${fmtPoints(detail.pointsB)}`} />
+          <Stat label="Close (≤5 pts)" value={detail.gamesDecidedByFive} />
+          <Stat label="Close (≤10 pts)" value={detail.gamesDecidedByTen} />
+        </div>
+
+        <div style={{ fontWeight: 600, marginBottom: 6 }}>Memorable meetings</div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+            gap: 10,
+          }}
+        >
+          <MeetingCard label="Closest" meeting={detail.closestGame} />
+          <MeetingCard label="Biggest blowout" meeting={detail.biggestBlowout} />
+          <MeetingCard label="Last meeting" meeting={detail.lastMeeting} />
+        </div>
+
+        {detail.seasonSplits && Object.keys(detail.seasonSplits).length > 0 && (
+          <>
+            <div style={{ fontWeight: 600, marginTop: 14, marginBottom: 6 }}>Season splits</div>
+            <div className="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Season</th>
+                    <th style={{ textAlign: "right" }}>{nameFor(managers, idA)} wins</th>
+                    <th style={{ textAlign: "right" }}>{nameFor(managers, idB)} wins</th>
+                    <th style={{ textAlign: "right" }}>Ties</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(detail.seasonSplits).map(([season, split]) => (
+                    <tr key={season}>
+                      <td>{season}</td>
+                      <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{split.winsA}</td>
+                      <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{split.winsB}</td>
+                      <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{split.ties}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </Card>
+    </section>
+  );
+}

--- a/frontend/app/league/shared.jsx
+++ b/frontend/app/league/shared.jsx
@@ -1,0 +1,176 @@
+"use client";
+
+// Shared UI helpers used by the tabbed /league page AND the dedicated
+// /league/franchise/[owner] + /league/rivalry/[pair] routes.  Keeping
+// formatters + Avatar + primitive cards in one place means the deep-
+// linked routes and the tab views render identically.
+//
+// No private imports: see frontend/app/league/page.jsx for the
+// isolation contract.  Only pulls from public-league-data.
+
+export function buildManagerLookup(league) {
+  const map = new Map();
+  for (const m of league?.managers || []) {
+    map.set(String(m.ownerId), m);
+  }
+  return map;
+}
+
+export function nameFor(managers, ownerId) {
+  const mgr = managers.get(String(ownerId));
+  return mgr?.displayName || mgr?.currentTeamName || ownerId || "Unknown";
+}
+
+export function avatarUrlFor(managers, ownerId) {
+  const mgr = managers.get(String(ownerId));
+  if (!mgr || !mgr.avatar) return "";
+  const avatar = String(mgr.avatar);
+  if (avatar.startsWith("http")) return avatar;
+  return `https://sleepercdn.com/avatars/thumbs/${avatar}`;
+}
+
+export function fmtNumber(n, digits = 0) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "—";
+  return Number(n).toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+export function fmtPoints(n) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "—";
+  return Number(n).toFixed(1);
+}
+
+export function fmtPercent(n) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "—";
+  return `${Math.round(Number(n) * 100)}%`;
+}
+
+export function Avatar({ managers, ownerId, size = 24, title }) {
+  const url = avatarUrlFor(managers, ownerId);
+  const name = nameFor(managers, ownerId);
+  const initials = name
+    .split(/\s+/)
+    .map((w) => w[0] || "")
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+  const style = {
+    width: size,
+    height: size,
+    borderRadius: "50%",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "var(--bg-soft)",
+    border: "1px solid var(--border)",
+    fontSize: Math.max(10, Math.floor(size * 0.42)),
+    fontWeight: 700,
+    overflow: "hidden",
+    flexShrink: 0,
+    verticalAlign: "middle",
+  };
+  if (url) {
+    return (
+      <img
+        src={url}
+        alt=""
+        loading="lazy"
+        width={size}
+        height={size}
+        style={{ ...style, background: "transparent" }}
+        title={title || name}
+      />
+    );
+  }
+  return (
+    <span style={style} title={title || name} aria-hidden>
+      {initials || "?"}
+    </span>
+  );
+}
+
+export function Stat({ label, value, sub }) {
+  return (
+    <div
+      style={{
+        padding: "10px 12px",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius)",
+        background: "rgba(15, 28, 59, 0.45)",
+      }}
+    >
+      <div
+        style={{
+          fontSize: "0.65rem",
+          color: "var(--subtext)",
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: "1.05rem",
+          fontWeight: 700,
+          fontFamily: "var(--mono)",
+          marginTop: 2,
+        }}
+      >
+        {value}
+      </div>
+      {sub && (
+        <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 2 }}>
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function Card({ title, subtitle, action, children, id }) {
+  return (
+    <div className="card" id={id} style={{ marginTop: "var(--space-md)" }}>
+      {(title || action) && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            marginBottom: 10,
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            {title && <div style={{ fontWeight: 700 }}>{title}</div>}
+            {subtitle && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+                {subtitle}
+              </div>
+            )}
+          </div>
+          {action}
+        </div>
+      )}
+      <div>{children}</div>
+    </div>
+  );
+}
+
+export function MeetingCard({ label, meeting }) {
+  if (!meeting) return null;
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+      <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontSize: "0.86rem", fontWeight: 700, marginTop: 2 }}>
+        {meeting.season} · Wk {meeting.week}{meeting.isPlayoff ? " (P)" : ""}
+      </div>
+      <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+        Margin {fmtPoints(meeting.margin)} · {fmtPoints(meeting.pointsA)} / {fmtPoints(meeting.pointsB)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/public-league-data.js
+++ b/frontend/lib/public-league-data.js
@@ -28,6 +28,7 @@
 // /league flow — the isolation is architectural, not just a comment.
 
 export const PUBLIC_SECTION_KEYS = Object.freeze([
+  "overview",
   "history",
   "rivalries",
   "awards",

--- a/server.py
+++ b/server.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import os
 import sys
+import threading
 import time
 import logging
 import traceback
@@ -2943,11 +2944,14 @@ from src.public_league import snapshot_store as public_snapshot_store
 
 _PUBLIC_LEAGUE_CACHE_TTL_SECONDS = int(os.getenv("PUBLIC_LEAGUE_CACHE_TTL", "300"))
 _PUBLIC_LEAGUE_PERSIST = _env_bool("PUBLIC_LEAGUE_PERSIST_SNAPSHOT", True)
+_PUBLIC_LEAGUE_WARMUP = _env_bool("PUBLIC_LEAGUE_WARMUP_AT_STARTUP", True)
 _public_league_cache: dict = {
     "snapshot": None,
     "snapshot_league_id": None,
     "fetched_at": 0.0,
+    "refreshing": False,
 }
+_public_league_refresh_lock = threading.Lock()
 
 # Best-effort: load the most recent persisted snapshot at process
 # start so a cold-started server can still serve the public /league
@@ -2973,8 +2977,75 @@ def _public_league_id() -> str:
     return os.getenv("SLEEPER_LEAGUE_ID", SLEEPER_LEAGUE_ID_FOR_DRAFT).strip()
 
 
+def _rebuild_public_snapshot(league_id: str):
+    """Synchronously rebuild the public snapshot for ``league_id``.
+
+    Guarded by ``_public_league_refresh_lock`` so a burst of requests
+    while the background refresh is running doesn't multiply work.
+    """
+    with _public_league_refresh_lock:
+        now = time.time()
+        cached = _public_league_cache.get("snapshot")
+        cached_id = _public_league_cache.get("snapshot_league_id")
+        fetched_at = float(_public_league_cache.get("fetched_at") or 0.0)
+        # If another thread just refreshed while we were waiting on the
+        # lock, reuse that work.
+        if (
+            cached is not None
+            and cached_id == league_id
+            and (now - fetched_at) < _PUBLIC_LEAGUE_CACHE_TTL_SECONDS
+        ):
+            return cached
+        try:
+            snapshot = build_public_snapshot(league_id, max_seasons=PUBLIC_MAX_SEASONS)
+        finally:
+            _public_league_cache["refreshing"] = False
+        _public_league_cache["snapshot"] = snapshot
+        _public_league_cache["snapshot_league_id"] = league_id
+        _public_league_cache["fetched_at"] = time.time()
+        if _PUBLIC_LEAGUE_PERSIST and snapshot.seasons:
+            try:
+                contract = build_public_contract(snapshot)
+                public_snapshot_store.persist_snapshot(snapshot, contract=contract)
+            except Exception as exc:  # noqa: BLE001
+                logging.warning("Failed to persist public_league snapshot: %s", exc)
+        return snapshot
+
+
+def _kick_background_refresh(league_id: str):
+    """Start a daemon thread that refreshes the public snapshot in the
+    background.  No-op if another refresh is already running."""
+    if _public_league_cache.get("refreshing"):
+        return
+    _public_league_cache["refreshing"] = True
+
+    def _worker():
+        try:
+            _rebuild_public_snapshot(league_id)
+        except Exception as exc:  # noqa: BLE001
+            logging.warning("Background public_league refresh failed: %s", exc)
+        finally:
+            _public_league_cache["refreshing"] = False
+
+    threading.Thread(
+        target=_worker,
+        name="public-league-warmup",
+        daemon=True,
+    ).start()
+
+
 def _get_public_snapshot(force_refresh: bool = False):
-    """Return (possibly cached) public snapshot for the current league."""
+    """Return (possibly cached) public snapshot for the current league.
+
+    Stale-while-revalidate behavior: if a cached snapshot exists but
+    has passed TTL, we still return the stale payload immediately and
+    kick a background refresh.  The NEXT request gets the fresh data.
+    First-request latency is therefore bounded by whatever the client
+    already has on disk, not by the Sleeper fetch time.
+
+    ``force_refresh`` bypasses this and blocks on a fresh fetch —
+    used by the manual ``?refresh=1`` query and the warmup path.
+    """
     league_id = _public_league_id()
     now = time.time()
     cached = _public_league_cache.get("snapshot")
@@ -2987,17 +3058,39 @@ def _get_public_snapshot(force_refresh: bool = False):
     )
     if fresh and not force_refresh:
         return cached
-    snapshot = build_public_snapshot(league_id, max_seasons=PUBLIC_MAX_SEASONS)
-    _public_league_cache["snapshot"] = snapshot
-    _public_league_cache["snapshot_league_id"] = league_id
-    _public_league_cache["fetched_at"] = now
-    if _PUBLIC_LEAGUE_PERSIST and snapshot.seasons:
-        try:
-            contract = build_public_contract(snapshot)
-            public_snapshot_store.persist_snapshot(snapshot, contract=contract)
-        except Exception as exc:  # noqa: BLE001
-            logging.warning("Failed to persist public_league snapshot: %s", exc)
-    return snapshot
+    # Stale-but-serveable: return the cached payload and refresh in
+    # the background so subsequent requests get fresh data.
+    if cached is not None and cached_id == league_id and not force_refresh:
+        _kick_background_refresh(league_id)
+        return cached
+    # Cold start or forced refresh — block on a sync rebuild.
+    return _rebuild_public_snapshot(league_id)
+
+
+def _warmup_public_snapshot():
+    """Kick a background snapshot rebuild at startup when no warm cache
+    was loaded from disk.  Bounded by the same lock as the request-path
+    refresher so the first request still benefits."""
+    if not _PUBLIC_LEAGUE_WARMUP:
+        return
+    league_id = _public_league_id()
+    if not league_id:
+        return
+    cached = _public_league_cache.get("snapshot")
+    cached_id = _public_league_cache.get("snapshot_league_id")
+    needs_refresh = (
+        cached is None
+        or cached_id != league_id
+        or float(_public_league_cache.get("fetched_at") or 0.0) == 0.0
+    )
+    if not needs_refresh:
+        return
+    _kick_background_refresh(league_id)
+
+
+@app.on_event("startup")
+def _public_league_startup_hook():
+    _warmup_public_snapshot()
 
 
 _PUBLIC_LEAGUE_CACHE_CONTROL = (

--- a/server.py
+++ b/server.py
@@ -3000,6 +3000,11 @@ def _get_public_snapshot(force_refresh: bool = False):
     return snapshot
 
 
+_PUBLIC_LEAGUE_CACHE_CONTROL = (
+    f"public, max-age=60, stale-while-revalidate={_PUBLIC_LEAGUE_CACHE_TTL_SECONDS}"
+)
+
+
 @app.get("/api/public/league")
 async def get_public_league(refresh: str = ""):
     """Full public league contract — every section + league header.
@@ -3013,7 +3018,10 @@ async def get_public_league(refresh: str = ""):
         snapshot = _get_public_snapshot(force_refresh=bool(refresh))
         payload = build_public_contract(snapshot)
         assert_public_payload_safe(payload)
-        return JSONResponse(content=payload)
+        return JSONResponse(
+            content=payload,
+            headers={"Cache-Control": _PUBLIC_LEAGUE_CACHE_CONTROL},
+        )
     except AssertionError as exc:
         logging.error("Public league contract tripped safety assert: %s", exc)
         return JSONResponse(
@@ -3051,7 +3059,10 @@ async def get_public_league_section(section: str, owner: str = "", refresh: str 
             detail_map = payload.get("data", {}).get("detail") or {}
             payload["franchiseDetail"] = detail_map.get(str(owner).strip())
         assert_public_payload_safe(payload)
-        return JSONResponse(content=payload)
+        return JSONResponse(
+            content=payload,
+            headers={"Cache-Control": _PUBLIC_LEAGUE_CACHE_CONTROL},
+        )
     except AssertionError as exc:
         logging.error("Public section %s tripped safety assert: %s", section, exc)
         return JSONResponse(

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -1,29 +1,174 @@
-"""Section: Awards.
+"""Section: Awards + Award Races.
 
-Per-season narrative awards derived from Sleeper standings + matchup
-data.  Every award attributes to an owner_id so renames / orphan
-handoffs never split the recipient across seasons.
+Catalog is split into two classes:
+    * historical — finalized awards per completed season + across-the-window
+      aggregates
+    * live races — top-3 current-season leaderboards for awards where the
+      race is interesting in flight
 
-Awards computed:
-    * Champion
-    * Runner-Up
-    * Top Seed
-    * Regular-Season Crown (best regular-season record)
-    * Points King (most points scored, regular season)
-    * Points Black Hole (most points allowed)
-    * Toilet Bowl (worst final placement)
-    * Highest Single-Week Score
-    * Lowest Single-Week Score
+Every award exposes a machine-readable ``key``, a human label, a short
+``description`` (the explanation shown on the public page) and a
+``value`` payload that is either a number, a simple string, or an
+object of derived display fields.  No raw private valuation or edge
+signal ever appears in the public output — live-race tiebreakers can
+*consult* private outputs internally but only ever emit derived,
+public-safe values.
+
+Award catalog:
+    champion                 — winner of the finals
+    runner_up                — loser of the finals
+    top_seed                 — best regular-season seed
+    regular_season_crown     — best regular-season record
+    points_king              — most regular-season points
+    points_black_hole        — most points ALLOWED
+    toilet_bowl              — worst final playoff placement
+    highest_single_week      — largest single-week score
+    lowest_single_week       — smallest single-week score
+    trader_of_the_year       — realized points gained via trades
+    best_trade_of_the_year   — single-trade bake-off (historical only)
+    waiver_king              — realized points gained via waivers/FA
+    chaos_agent              — transaction chaos score
+    most_active              — raw transaction volume
+    pick_hoarder             — weighted draft stockpile
+    silent_assassin          — win% in close games
+    weekly_hammer            — weekly high-score finishes
+    playoff_mvp              — playoff team points (+ top individual scorer)
+    bad_beat                 — biggest "points in a loss" performance
+    best_rebuild             — year-over-year improvement (finalized only)
+    rivalry_of_the_year      — season-scoped rivalry_index peak
 """
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Any
 
 from . import metrics
+from .draft import _pick_ownership_map, pick_weight
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
 
-def _award(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, rid: int | None, key: str, label: str, value: Any = None) -> dict[str, Any] | None:
+# Explanation strings exposed on every award card so the page never
+# needs to hard-code copy.  Keep these short and human — the UI prints
+# them verbatim beneath the winner.
+AWARD_DESCRIPTIONS: dict[str, str] = {
+    "champion": "Winner of the final playoff matchup.",
+    "runner_up": "Lost in the final playoff matchup.",
+    "top_seed": "Best regular-season seed after tiebreaks.",
+    "regular_season_crown": "Best regular-season record.",
+    "points_king": "Most regular-season points scored.",
+    "points_black_hole": "Most regular-season points allowed.",
+    "toilet_bowl": "Worst final finish in the consolation bracket.",
+    "highest_single_week": "Largest single-week scoring explosion.",
+    "lowest_single_week": "Smallest single-week score.",
+    "trader_of_the_year": (
+        "Realized post-trade fantasy points gained. Sums points acquired "
+        "minus points sent away across every trade, weighted by the weeks "
+        "played after the deal. Tiebreaks: playoff points gained, then a "
+        "server-side asset-value delta."
+    ),
+    "best_trade_of_the_year": (
+        "Best single trade by post-deal realized points for one side. "
+        "Historical only — finalized after the season."
+    ),
+    "waiver_king": (
+        "Realized points scored by your own waiver / FA pickups after they "
+        "were added. Tiebreaks: FAAB efficiency, then count of useful adds."
+    ),
+    "chaos_agent": (
+        "Chaos score. 3 points per trade, 1 per unique partner, 1 per asset "
+        "moved, 1 per pick moved, 0.5 per waiver add."
+    ),
+    "most_active": "Total trades + waivers + drops + free-agent adds.",
+    "pick_hoarder": (
+        "Weighted draft stockpile. 1st round = 4, 2nd = 3, 3rd = 2, 4th+ = 1."
+    ),
+    "silent_assassin": (
+        "Win% in games decided by 10 points or fewer (4+ eligible games)."
+    ),
+    "weekly_hammer": "Count of weekly high-score finishes.",
+    "playoff_mvp": (
+        "Total team points during the playoffs. Live during playoff weeks."
+    ),
+    "bad_beat": "Biggest single 'points in a loss' performance.",
+    "best_rebuild": (
+        "Year-over-year improvement. 40% points-rank jump + 30% record-rank "
+        "jump + 20% extra weighted stockpile + 10% more rostered rookies."
+    ),
+    "rivalry_of_the_year": (
+        "Season's nastiest head-to-head ranked by rivalry index, boosted by "
+        "playoff meetings."
+    ),
+}
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+def _roster_player_points(matchup_entry: dict[str, Any]) -> dict[str, float]:
+    """Return ``{player_id: points}`` for a matchup entry.
+
+    Falls back to an empty dict if the Sleeper payload is missing the
+    per-player scoring map (older seasons sometimes are).
+    """
+    pp = matchup_entry.get("players_points")
+    if isinstance(pp, dict):
+        out: dict[str, float] = {}
+        for pid, val in pp.items():
+            try:
+                out[str(pid)] = float(val or 0.0)
+            except (TypeError, ValueError):
+                continue
+        return out
+    return {}
+
+
+def _starter_set(matchup_entry: dict[str, Any]) -> set[str]:
+    starters = matchup_entry.get("starters") or []
+    return {str(s) for s in starters if s}
+
+
+def _post_weeks(season: SeasonSnapshot, after_leg: int) -> list[int]:
+    """Weeks strictly after ``after_leg`` in the season's schedule."""
+    return [w for w in sorted(season.matchups_by_week.keys()) if w > after_leg]
+
+
+def _player_points_in_week_for_roster(
+    season: SeasonSnapshot,
+    week: int,
+    roster_id: int,
+    player_id: str,
+    require_started: bool = False,
+) -> float | None:
+    """Return the player's scored points for a specific roster-week.
+
+    ``require_started`` restricts the lookup to when the roster actually
+    started the player that week.  Returns ``None`` if the data isn't
+    available (older seasons or missing players_points map).
+    """
+    entries = season.matchups_by_week.get(week) or []
+    for entry in entries:
+        try:
+            rid = int(entry.get("roster_id"))
+        except (TypeError, ValueError):
+            continue
+        if rid != roster_id:
+            continue
+        if require_started and str(player_id) not in _starter_set(entry):
+            return None
+        pp = _roster_player_points(entry)
+        return pp.get(str(player_id))
+    return None
+
+
+def _season_has_player_scoring(season: SeasonSnapshot) -> bool:
+    """True when at least one matchup entry carries players_points."""
+    for entries in season.matchups_by_week.values():
+        for m in entries:
+            if isinstance(m.get("players_points"), dict) and m["players_points"]:
+                return True
+    return False
+
+
+# ── per-season canonical awards (already in v1) ────────────────────────────
+def _canonical_award(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, rid: int | None, key: str, label: str, value: Any = None) -> dict[str, Any] | None:
     if rid is None:
         return None
     owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
@@ -32,6 +177,7 @@ def _award(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, rid: int | No
     return {
         "key": key,
         "label": label,
+        "description": AWARD_DESCRIPTIONS.get(key, ""),
         "ownerId": owner_id,
         "displayName": metrics.display_name_for(snapshot, owner_id),
         "teamName": metrics.team_name(snapshot, season.league_id, rid),
@@ -39,7 +185,7 @@ def _award(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, rid: int | No
     }
 
 
-def _awards_for_season(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
     standings = metrics.season_standings(season, snapshot.managers)
     placement = metrics.playoff_placement(season.winners_bracket)
     if not standings:
@@ -57,7 +203,6 @@ def _awards_for_season(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -
     if worst_place is not None:
         toilet_rid = next((rid for rid, p in placement.items() if p == worst_place), None)
 
-    # Single-week highs/lows across regular + playoffs.
     high_week: tuple[float, int, int] | None = None
     low_week: tuple[float, int, int] | None = None
     for week, entries in season.matchups_by_week.items():
@@ -73,33 +218,1085 @@ def _awards_for_season(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -
             if low_week is None or pts < low_week[0]:
                 low_week = (pts, rid, week)
 
-    candidates = [
-        _award(snapshot, season, champion_rid, "champion", "Champion"),
-        _award(snapshot, season, runner_up_rid, "runner_up", "Runner-Up"),
-        _award(snapshot, season, top_seed["rosterId"] if top_seed else None, "top_seed", "Top Seed",
-               value={"winPct": top_seed["winPct"]} if top_seed else None),
-        _award(snapshot, season, best_record_rid, "regular_season_crown", "Regular-Season Crown",
-               value={"record": f'{standings[0]["wins"]}-{standings[0]["losses"]}'} if standings else None),
-        _award(snapshot, season, pf_leader["rosterId"] if pf_leader else None, "points_king", "Points King",
-               value={"pointsFor": pf_leader["pointsFor"]} if pf_leader else None),
-        _award(snapshot, season, pa_leader["rosterId"] if pa_leader else None, "points_black_hole", "Points Black Hole",
-               value={"pointsAgainst": pa_leader["pointsAgainst"]} if pa_leader else None),
-        _award(snapshot, season, toilet_rid, "toilet_bowl", "Toilet Bowl"),
-        _award(snapshot, season, high_week[1] if high_week else None, "highest_single_week", "Highest Single-Week Score",
-               value={"points": round(high_week[0], 2), "week": high_week[2]} if high_week else None),
-        _award(snapshot, season, low_week[1] if low_week else None, "lowest_single_week", "Lowest Single-Week Score",
-               value={"points": round(low_week[0], 2), "week": low_week[2]} if low_week else None),
+    awards = [
+        _canonical_award(snapshot, season, champion_rid, "champion", "Champion"),
+        _canonical_award(snapshot, season, runner_up_rid, "runner_up", "Runner-Up"),
+        _canonical_award(
+            snapshot, season,
+            top_seed["rosterId"] if top_seed else None,
+            "top_seed", "Top Seed",
+            value={"winPct": top_seed["winPct"]} if top_seed else None,
+        ),
+        _canonical_award(
+            snapshot, season, best_record_rid,
+            "regular_season_crown", "Regular-Season Crown",
+            value={"record": f'{standings[0]["wins"]}-{standings[0]["losses"]}'} if standings else None,
+        ),
+        _canonical_award(
+            snapshot, season,
+            pf_leader["rosterId"] if pf_leader else None,
+            "points_king", "Points King",
+            value={"pointsFor": pf_leader["pointsFor"]} if pf_leader else None,
+        ),
+        _canonical_award(
+            snapshot, season,
+            pa_leader["rosterId"] if pa_leader else None,
+            "points_black_hole", "Points Black Hole",
+            value={"pointsAgainst": pa_leader["pointsAgainst"]} if pa_leader else None,
+        ),
+        _canonical_award(snapshot, season, toilet_rid, "toilet_bowl", "Toilet Bowl"),
+        _canonical_award(
+            snapshot, season,
+            high_week[1] if high_week else None,
+            "highest_single_week", "Highest Single-Week Score",
+            value={"points": round(high_week[0], 2), "week": high_week[2]} if high_week else None,
+        ),
+        _canonical_award(
+            snapshot, season,
+            low_week[1] if low_week else None,
+            "lowest_single_week", "Lowest Single-Week Score",
+            value={"points": round(low_week[0], 2), "week": low_week[2]} if low_week else None,
+        ),
     ]
-    return [a for a in candidates if a is not None]
+    return [a for a in awards if a is not None]
+
+
+# ── activity-based per-season awards ───────────────────────────────────────
+def _trader_of_the_year_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> tuple[list[dict[str, Any]], tuple[float, str, dict[str, Any]] | None]:
+    """Return sortable trader-of-the-year score rows per owner."""
+    per_owner: dict[str, dict[str, Any]] = {}
+
+    def _ensure(owner_id: str) -> dict[str, Any]:
+        if owner_id not in per_owner:
+            per_owner[owner_id] = {
+                "ownerId": owner_id,
+                "tradeCount": 0,
+                "pointsGained": 0.0,
+                "playoffPointsGained": 0.0,
+                "assetSwingValue": 0.0,
+                "biggestTradeGain": 0.0,
+                "biggestTradeId": "",
+            }
+        return per_owner[owner_id]
+
+    best_trade: tuple[float, str, dict[str, Any]] | None = None
+
+    for tx in season.trades():
+        leg = tx.get("leg") or tx.get("_leg") or 0
+        try:
+            leg_int = int(leg)
+        except (TypeError, ValueError):
+            leg_int = 0
+        post_weeks = _post_weeks(season, leg_int)
+        if not post_weeks:
+            continue
+
+        adds = tx.get("adds") or {}
+        drops = tx.get("drops") or {}
+        roster_ids: list[int] = []
+        for rid in tx.get("roster_ids") or []:
+            try:
+                roster_ids.append(int(rid))
+            except (TypeError, ValueError):
+                continue
+        if len(roster_ids) < 2:
+            continue
+
+        for rid in roster_ids:
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if not owner_id:
+                continue
+            received = [pid for pid, r in adds.items() if int(r) == rid]
+            sent = [pid for pid, r in drops.items() if int(r) == rid]
+
+            gain = 0.0
+            playoff_gain = 0.0
+            for week in post_weeks:
+                is_playoff = week >= season.playoff_week_start
+                for pid in received:
+                    pts = _player_points_in_week_for_roster(season, week, rid, pid)
+                    if pts is None:
+                        continue
+                    gain += pts
+                    if is_playoff:
+                        playoff_gain += pts
+                for pid in sent:
+                    other_rid = next(
+                        (int(r) for p, r in adds.items() if p == pid and int(r) != rid),
+                        None,
+                    )
+                    if other_rid is None:
+                        continue
+                    pts = _player_points_in_week_for_roster(season, week, other_rid, pid)
+                    if pts is None:
+                        continue
+                    gain -= pts
+                    if is_playoff:
+                        playoff_gain -= pts
+
+            swing = 0.0
+            for pk in tx.get("draft_picks") or []:
+                try:
+                    pk_round = int(pk.get("round") or 4)
+                except (TypeError, ValueError):
+                    pk_round = 4
+                if int(pk.get("owner_id") or 0) == rid:
+                    swing += max(1, 5 - pk_round)
+                elif int(pk.get("previous_owner_id") or 0) == rid:
+                    swing -= max(1, 5 - pk_round)
+
+            rec = _ensure(owner_id)
+            rec["tradeCount"] += 1
+            rec["pointsGained"] += gain
+            rec["playoffPointsGained"] += playoff_gain
+            rec["assetSwingValue"] += swing
+            if gain > rec["biggestTradeGain"]:
+                rec["biggestTradeGain"] = gain
+                rec["biggestTradeId"] = str(tx.get("transaction_id") or "")
+
+            if best_trade is None or gain > best_trade[0]:
+                best_trade = (gain, owner_id, {
+                    "transactionId": str(tx.get("transaction_id") or ""),
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    "week": leg_int,
+                    "ownerId": owner_id,
+                    "pointsGained": round(gain, 2),
+                    "playoffPointsGained": round(playoff_gain, 2),
+                    "receivedPlayerIds": list(received),
+                    "sentPlayerIds": list(sent),
+                })
+
+    rows = list(per_owner.values())
+    for r in rows:
+        r["pointsGained"] = round(r["pointsGained"], 2)
+        r["playoffPointsGained"] = round(r["playoffPointsGained"], 2)
+        r["assetSwingValue"] = round(r["assetSwingValue"], 4)
+        r["displayName"] = metrics.display_name_for(snapshot, r["ownerId"])
+    rows.sort(
+        key=lambda r: (
+            -r["pointsGained"],
+            -r["playoffPointsGained"],
+            -r["assetSwingValue"],
+        )
+    )
+    for r in rows:
+        r.pop("assetSwingValue", None)
+    return rows, best_trade
+
+
+def _waiver_king_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    per_owner: dict[str, dict[str, Any]] = {}
+
+    def _ensure(owner_id: str) -> dict[str, Any]:
+        if owner_id not in per_owner:
+            per_owner[owner_id] = {
+                "ownerId": owner_id,
+                "pointsGained": 0.0,
+                "faabSpent": 0,
+                "addCount": 0,
+                "usefulAdds": 0,
+            }
+        return per_owner[owner_id]
+
+    for tx in season.waivers():
+        leg = tx.get("leg") or tx.get("_leg") or 0
+        try:
+            leg_int = int(leg)
+        except (TypeError, ValueError):
+            leg_int = 0
+        post_weeks = _post_weeks(season, leg_int)
+        if not post_weeks:
+            continue
+        adds = tx.get("adds") or {}
+        settings = tx.get("settings") or {}
+        bid_raw = settings.get("waiver_bid")
+        try:
+            bid = int(bid_raw) if bid_raw is not None else 0
+        except (TypeError, ValueError):
+            bid = 0
+
+        for pid, rid in adds.items():
+            try:
+                rid_int = int(rid)
+            except (TypeError, ValueError):
+                continue
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid_int)
+            if not owner_id:
+                continue
+            rec = _ensure(owner_id)
+            rec["addCount"] += 1
+            rec["faabSpent"] += max(0, bid)
+            gain = 0.0
+            started_at_least_once = False
+            for week in post_weeks:
+                starter_pts = _player_points_in_week_for_roster(
+                    season, week, rid_int, pid, require_started=True
+                )
+                if starter_pts is not None:
+                    gain += starter_pts
+                    started_at_least_once = True
+                    continue
+                total_pts = _player_points_in_week_for_roster(
+                    season, week, rid_int, pid, require_started=False
+                )
+                if total_pts is not None and not _starter_set(
+                    _matchup_for(season, week, rid_int) or {}
+                ):
+                    gain += total_pts
+            rec["pointsGained"] += gain
+            if started_at_least_once and gain > 0:
+                rec["usefulAdds"] += 1
+
+    rows = list(per_owner.values())
+    for r in rows:
+        r["pointsGained"] = round(r["pointsGained"], 2)
+        r["faabEfficiency"] = (
+            round(r["pointsGained"] / r["faabSpent"], 3) if r["faabSpent"] > 0 else None
+        )
+        r["displayName"] = metrics.display_name_for(snapshot, r["ownerId"])
+    rows.sort(
+        key=lambda r: (
+            -r["pointsGained"],
+            -(r["faabEfficiency"] or 0),
+            -r["usefulAdds"],
+        )
+    )
+    return rows
+
+
+def _matchup_for(season: SeasonSnapshot, week: int, roster_id: int) -> dict[str, Any] | None:
+    for m in season.matchups_by_week.get(week) or []:
+        try:
+            if int(m.get("roster_id")) == roster_id:
+                return m
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _chaos_agent_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+    per_owner: dict[str, dict[str, Any]] = {}
+
+    def _ensure(owner_id: str) -> dict[str, Any]:
+        if owner_id not in per_owner:
+            per_owner[owner_id] = {
+                "ownerId": owner_id,
+                "trades": 0,
+                "waiverAdds": 0,
+                "distinctPartners": 0,
+                "playersMoved": 0,
+                "picksMoved": 0,
+                "score": 0.0,
+                "_partners": set(),
+            }
+        return per_owner[owner_id]
+
+    for tx in season.trades():
+        roster_ids = []
+        for rid in tx.get("roster_ids") or []:
+            try:
+                roster_ids.append(int(rid))
+            except (TypeError, ValueError):
+                continue
+        if len(roster_ids) < 2:
+            continue
+        owners = [
+            metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            for rid in roster_ids
+        ]
+        owners = [o for o in owners if o]
+        if len(owners) < 2:
+            continue
+        adds = tx.get("adds") or {}
+        picks = tx.get("draft_picks") or []
+        for owner in owners:
+            rec = _ensure(owner)
+            rec["trades"] += 1
+            rec["_partners"].update(o for o in owners if o != owner)
+            rid = next(
+                (
+                    r for r in roster_ids
+                    if metrics.resolve_owner(snapshot.managers, season.league_id, r) == owner
+                ),
+                None,
+            )
+            if rid is None:
+                continue
+            rec["playersMoved"] += sum(1 for _, r in adds.items() if int(r) == rid)
+            rec["picksMoved"] += sum(
+                1 for pk in picks if int(pk.get("owner_id") or 0) == rid
+            )
+
+    for tx in season.waivers():
+        for rid in tx.get("roster_ids") or []:
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if not owner_id:
+                continue
+            rec = _ensure(owner_id)
+            rec["waiverAdds"] += 1
+
+    rows = []
+    for owner_id, rec in per_owner.items():
+        rec["distinctPartners"] = len(rec["_partners"])
+        rec.pop("_partners", None)
+        score = (
+            3 * rec["trades"]
+            + 1 * rec["distinctPartners"]
+            + 1 * rec["playersMoved"]
+            + 1 * rec["picksMoved"]
+            + 0.5 * rec["waiverAdds"]
+        )
+        rec["score"] = round(score, 2)
+        rec["displayName"] = metrics.display_name_for(snapshot, owner_id)
+        rows.append(rec)
+    rows.sort(key=lambda r: (-r["score"], -r["trades"], -r["waiverAdds"]))
+    return rows
+
+
+def _most_active_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+    per_owner: dict[str, dict[str, int]] = defaultdict(lambda: {
+        "trades": 0, "waivers": 0, "freeAgents": 0, "drops": 0,
+    })
+    for tx in season.trades():
+        for rid in tx.get("roster_ids") or []:
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if owner_id:
+                per_owner[owner_id]["trades"] += 1
+    for week in sorted(season.transactions_by_week.keys()):
+        for tx in season.transactions_by_week[week]:
+            ttype = str(tx.get("type") or "").lower()
+            status = str(tx.get("status") or "").lower()
+            if status != "complete":
+                continue
+            for rid in tx.get("roster_ids") or []:
+                owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+                if not owner_id:
+                    continue
+                if ttype == "waiver":
+                    per_owner[owner_id]["waivers"] += 1
+                elif ttype == "free_agent":
+                    per_owner[owner_id]["freeAgents"] += 1
+                drops = tx.get("drops") or {}
+                per_owner[owner_id]["drops"] += sum(
+                    1 for _, r in drops.items() if int(r) == int(rid)
+                )
+    rows = []
+    for owner_id, rec in per_owner.items():
+        total = sum(rec.values())
+        rows.append({
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "trades": rec["trades"],
+            "waivers": rec["waivers"],
+            "freeAgents": rec["freeAgents"],
+            "drops": rec["drops"],
+            "total": total,
+        })
+    rows.sort(key=lambda r: (-r["total"], -r["trades"], -r["waivers"]))
+    return rows
+
+
+def _silent_assassin_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    min_eligible: int = 4,
+) -> list[dict[str, Any]]:
+    per_owner: dict[str, dict[str, Any]] = {}
+
+    def _ensure(owner_id: str) -> dict[str, Any]:
+        if owner_id not in per_owner:
+            per_owner[owner_id] = {
+                "ownerId": owner_id,
+                "wins": 0,
+                "games": 0,
+                "marginSum": 0.0,
+                "seasonWins": 0,
+            }
+        return per_owner[owner_id]
+
+    for week in sorted(season.matchups_by_week.keys()):
+        if week >= season.playoff_week_start:
+            continue
+        for a, b in metrics.matchup_pairs(season.matchups_by_week[week]):
+            pa = metrics.matchup_points(a)
+            pb = metrics.matchup_points(b)
+            if pa <= 0 and pb <= 0:
+                continue
+            margin = abs(pa - pb)
+            owner_a = metrics.resolve_owner(snapshot.managers, season.league_id, a.get("roster_id"))
+            owner_b = metrics.resolve_owner(snapshot.managers, season.league_id, b.get("roster_id"))
+            if not owner_a or not owner_b:
+                continue
+            for owner in (owner_a, owner_b):
+                _ensure(owner)["seasonWins"] += 0
+            if margin > 10.0 + 1e-9:
+                continue
+            for owner in (owner_a, owner_b):
+                _ensure(owner)["games"] += 1
+            if pa > pb:
+                _ensure(owner_a)["wins"] += 1
+                _ensure(owner_a)["marginSum"] += margin
+            elif pb > pa:
+                _ensure(owner_b)["wins"] += 1
+                _ensure(owner_b)["marginSum"] += margin
+
+    standings = metrics.season_standings(season, snapshot.managers)
+    season_wins = {r["ownerId"]: r["wins"] for r in standings}
+
+    rows = []
+    for owner_id, rec in per_owner.items():
+        games = rec["games"]
+        if games == 0:
+            continue
+        win_pct = rec["wins"] / games
+        avg_margin = rec["marginSum"] / rec["wins"] if rec["wins"] else 0.0
+        rows.append({
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "closeGames": games,
+            "closeWins": rec["wins"],
+            "winPct": round(win_pct, 4),
+            "avgCloseMargin": round(avg_margin, 2),
+            "seasonWins": season_wins.get(owner_id, 0),
+            "eligible": games >= min_eligible,
+        })
+    rows.sort(
+        key=lambda r: (
+            -r["winPct"] if r["eligible"] else 1,
+            r["avgCloseMargin"],
+            -r["seasonWins"],
+        )
+    )
+    return rows
+
+
+def _weekly_hammer_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+    per_owner: dict[str, dict[str, Any]] = {}
+
+    def _ensure(owner_id: str) -> dict[str, Any]:
+        if owner_id not in per_owner:
+            per_owner[owner_id] = {
+                "ownerId": owner_id,
+                "highScoreFinishes": 0,
+                "totalPoints": 0.0,
+                "highestWeekPoints": 0.0,
+            }
+        return per_owner[owner_id]
+
+    for week in sorted(season.matchups_by_week.keys()):
+        if week >= season.playoff_week_start:
+            continue
+        entries = season.matchups_by_week[week]
+        scored = [
+            (metrics.roster_id_of(m), metrics.matchup_points(m))
+            for m in entries
+        ]
+        scored = [s for s in scored if s[0] is not None and s[1] > 0]
+        if not scored:
+            continue
+        top_pts = max(pts for _, pts in scored)
+        for rid, pts in scored:
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if not owner_id:
+                continue
+            rec = _ensure(owner_id)
+            rec["totalPoints"] += pts
+            if pts > rec["highestWeekPoints"]:
+                rec["highestWeekPoints"] = pts
+            if abs(pts - top_pts) < 1e-6:
+                rec["highScoreFinishes"] += 1
+
+    rows = []
+    for owner_id, rec in per_owner.items():
+        rec["displayName"] = metrics.display_name_for(snapshot, owner_id)
+        rec["totalPoints"] = round(rec["totalPoints"], 2)
+        rec["highestWeekPoints"] = round(rec["highestWeekPoints"], 2)
+        rows.append(rec)
+    rows.sort(
+        key=lambda r: (
+            -r["highScoreFinishes"],
+            -r["totalPoints"],
+            -r["highestWeekPoints"],
+        )
+    )
+    return rows
+
+
+def _playoff_mvp_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+    per_owner: dict[str, dict[str, Any]] = {}
+
+    def _ensure(owner_id: str) -> dict[str, Any]:
+        if owner_id not in per_owner:
+            per_owner[owner_id] = {
+                "ownerId": owner_id,
+                "playoffPoints": 0.0,
+                "playoffWeeksPlayed": 0,
+                "topPlayerName": "",
+                "topPlayerPosition": "",
+                "topPlayerPoints": 0.0,
+            }
+        return per_owner[owner_id]
+
+    for week in sorted(season.matchups_by_week.keys()):
+        if week < season.playoff_week_start:
+            continue
+        for entry in season.matchups_by_week[week]:
+            rid = metrics.roster_id_of(entry)
+            if rid is None:
+                continue
+            pts = metrics.matchup_points(entry)
+            if pts <= 0:
+                continue
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if not owner_id:
+                continue
+            rec = _ensure(owner_id)
+            rec["playoffPoints"] += pts
+            rec["playoffWeeksPlayed"] += 1
+            for pid, pp in _roster_player_points(entry).items():
+                if pp is None:
+                    continue
+                if pp > rec["topPlayerPoints"]:
+                    rec["topPlayerPoints"] = pp
+                    rec["topPlayerName"] = snapshot.player_display(pid) or pid
+                    rec["topPlayerPosition"] = snapshot.player_position(pid)
+
+    rows = []
+    for owner_id, rec in per_owner.items():
+        rec["displayName"] = metrics.display_name_for(snapshot, owner_id)
+        rec["playoffPoints"] = round(rec["playoffPoints"], 2)
+        rec["topPlayerPoints"] = round(rec["topPlayerPoints"], 2)
+        rows.append(rec)
+    rows.sort(key=lambda r: (-r["playoffPoints"], -r["playoffWeeksPlayed"]))
+    return rows
+
+
+def _bad_beat_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+    per_owner: dict[str, dict[str, Any]] = {}
+
+    def _ensure(owner_id: str) -> dict[str, Any]:
+        if owner_id not in per_owner:
+            per_owner[owner_id] = {
+                "ownerId": owner_id,
+                "biggestLoss": 0.0,
+                "biggestLossWeek": None,
+                "biggestLossSeason": season.season,
+                "biggestLossOpponentPoints": 0.0,
+                "pointsInLosses": 0.0,
+                "lossCount": 0,
+            }
+        return per_owner[owner_id]
+
+    for week in sorted(season.matchups_by_week.keys()):
+        for a, b in metrics.matchup_pairs(season.matchups_by_week[week]):
+            pa = metrics.matchup_points(a)
+            pb = metrics.matchup_points(b)
+            if pa <= 0 and pb <= 0:
+                continue
+            owner_a = metrics.resolve_owner(snapshot.managers, season.league_id, a.get("roster_id"))
+            owner_b = metrics.resolve_owner(snapshot.managers, season.league_id, b.get("roster_id"))
+            if not owner_a or not owner_b:
+                continue
+            if pa < pb:
+                loser, loser_pts, opp_pts = owner_a, pa, pb
+            elif pb < pa:
+                loser, loser_pts, opp_pts = owner_b, pb, pa
+            else:
+                continue
+            rec = _ensure(loser)
+            rec["pointsInLosses"] += loser_pts
+            rec["lossCount"] += 1
+            if loser_pts > rec["biggestLoss"]:
+                rec["biggestLoss"] = loser_pts
+                rec["biggestLossWeek"] = week
+                rec["biggestLossOpponentPoints"] = opp_pts
+
+    rows = []
+    for owner_id, rec in per_owner.items():
+        rec["displayName"] = metrics.display_name_for(snapshot, owner_id)
+        rec["biggestLoss"] = round(rec["biggestLoss"], 2)
+        rec["pointsInLosses"] = round(rec["pointsInLosses"], 2)
+        rec["biggestLossOpponentPoints"] = round(rec["biggestLossOpponentPoints"], 2)
+        rows.append(rec)
+    rows.sort(key=lambda r: (-r["biggestLoss"], -r["pointsInLosses"]))
+    return rows
+
+
+def _pick_hoarder_scores(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
+    ownership = _pick_ownership_map(snapshot)
+    rows = []
+    for owner_id, picks in ownership.items():
+        weight = sum(pick_weight(p["round"]) for p in picks)
+        rows.append({
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "weightedScore": weight,
+            "totalPicks": len(picks),
+        })
+    rows.sort(key=lambda r: (-r["weightedScore"], -r["totalPicks"]))
+    return rows
+
+
+def _best_rebuild_scores(
+    snapshot: PublicLeagueSnapshot,
+    current: SeasonSnapshot,
+    previous: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    """Historical only: YoY improvement across standings + stockpile."""
+    def _rank_lookup(season: SeasonSnapshot) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
+        standings = metrics.season_standings(season, snapshot.managers)
+        by_points = sorted(standings, key=lambda r: -r["pointsFor"])
+        record_rank = {r["ownerId"]: r["standing"] for r in standings}
+        points_rank = {r["ownerId"]: i + 1 for i, r in enumerate(by_points)}
+        rookies: dict[str, int] = {}
+        for r in season.rosters:
+            try:
+                rid = int(r.get("roster_id"))
+            except (TypeError, ValueError):
+                continue
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if not owner_id:
+                continue
+            count = 0
+            for pid in r.get("players") or []:
+                p = snapshot.nfl_players.get(str(pid)) or {}
+                try:
+                    if int(p.get("years_exp")) == 0:
+                        count += 1
+                except (TypeError, ValueError):
+                    continue
+            rookies[owner_id] = count
+        return record_rank, points_rank, rookies
+
+    cur_record, cur_points, cur_rookies = _rank_lookup(current)
+    prev_record, prev_points, prev_rookies = _rank_lookup(previous)
+
+    current_weighted = {
+        row["ownerId"]: row["weightedScore"]
+        for row in _pick_hoarder_scores(snapshot)
+    }
+
+    rows = []
+    for owner_id in snapshot.managers.by_owner_id:
+        if owner_id not in cur_record or owner_id not in prev_record:
+            continue
+        record_delta = prev_record[owner_id] - cur_record[owner_id]
+        points_delta = prev_points[owner_id] - cur_points[owner_id]
+        stockpile = current_weighted.get(owner_id, 0)
+        rookies_delta = cur_rookies.get(owner_id, 0) - prev_rookies.get(owner_id, 0)
+
+        composite = (
+            0.40 * points_delta
+            + 0.30 * record_delta
+            + 0.20 * (stockpile / 4.0)
+            + 0.10 * rookies_delta
+        )
+        rows.append({
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "pointsRankDelta": points_delta,
+            "recordRankDelta": record_delta,
+            "stockpileScore": stockpile,
+            "rookiesDelta": rookies_delta,
+            "compositeScore": round(composite, 3),
+        })
+    rows.sort(key=lambda r: (-r["compositeScore"], -r["recordRankDelta"], -r["pointsRankDelta"]))
+    return rows
+
+
+def _rivalry_of_the_year(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> dict[str, Any] | None:
+    """Season-scoped rivalry of the year."""
+    pair_scores: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def _ensure(a: str, b: str) -> dict[str, Any]:
+        key = (a, b) if a <= b else (b, a)
+        if key not in pair_scores:
+            pair_scores[key] = {
+                "ownerIds": list(key),
+                "totalMeetings": 0,
+                "playoffMeetings": 0,
+                "decidedByFive": 0,
+                "decidedByTen": 0,
+                "seriesWinsA": 0,
+                "seriesWinsB": 0,
+            }
+        return pair_scores[key]
+
+    for week in sorted(season.matchups_by_week.keys()):
+        is_playoff = week >= season.playoff_week_start
+        for a, b in metrics.matchup_pairs(season.matchups_by_week[week]):
+            pa = metrics.matchup_points(a)
+            pb = metrics.matchup_points(b)
+            if pa <= 0 and pb <= 0:
+                continue
+            oa = metrics.resolve_owner(snapshot.managers, season.league_id, a.get("roster_id"))
+            ob = metrics.resolve_owner(snapshot.managers, season.league_id, b.get("roster_id"))
+            if not oa or not ob or oa == ob:
+                continue
+            rec = _ensure(oa, ob)
+            rec["totalMeetings"] += 1
+            if is_playoff:
+                rec["playoffMeetings"] += 1
+            margin = abs(pa - pb)
+            if margin <= 5.0 + 1e-9:
+                rec["decidedByFive"] += 1
+            if margin <= 10.0 + 1e-9:
+                rec["decidedByTen"] += 1
+            key_a = rec["ownerIds"][0]
+            if pa > pb:
+                if oa == key_a:
+                    rec["seriesWinsA"] += 1
+                else:
+                    rec["seriesWinsB"] += 1
+            elif pb > pa:
+                if ob == key_a:
+                    rec["seriesWinsA"] += 1
+                else:
+                    rec["seriesWinsB"] += 1
+
+    if not pair_scores:
+        return None
+
+    best_key: tuple[str, str] | None = None
+    best_score = -1.0
+    best_row: dict[str, Any] | None = None
+    for key, rec in pair_scores.items():
+        split = 1 if rec["seriesWinsA"] > 0 and rec["seriesWinsB"] > 0 else 0
+        score = (
+            5 * rec["playoffMeetings"]
+            + 3 * rec["decidedByFive"]
+            + 2 * rec["decidedByTen"]
+            + 2 * split
+            + 1 * rec["totalMeetings"]
+        )
+        rec["rivalryIndex"] = score
+        if score > best_score:
+            best_score = score
+            best_key = key
+            best_row = rec
+
+    if best_row is None:
+        return None
+    best_row["displayNames"] = [
+        metrics.display_name_for(snapshot, best_row["ownerIds"][0]),
+        metrics.display_name_for(snapshot, best_row["ownerIds"][1]),
+    ]
+    return best_row
+
+
+# ── assembly helpers ────────────────────────────────────────────────────────
+def _award_from_row(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    rows: list[dict[str, Any]],
+    key: str,
+    label: str,
+    value_builder,
+    eligible_only: bool = False,
+) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    pool = rows
+    if eligible_only:
+        pool = [r for r in rows if r.get("eligible") is True]
+    if not pool:
+        return None
+    winner = pool[0]
+    owner_id = winner["ownerId"]
+    rid = _roster_id_for_owner(season, owner_id)
+    return {
+        "key": key,
+        "label": label,
+        "description": AWARD_DESCRIPTIONS.get(key, ""),
+        "ownerId": owner_id,
+        "displayName": winner.get("displayName") or metrics.display_name_for(snapshot, owner_id),
+        "teamName": (
+            metrics.team_name(snapshot, season.league_id, rid) if rid is not None else ""
+        ),
+        "value": value_builder(winner),
+    }
+
+
+def _roster_id_for_owner(season: SeasonSnapshot, owner_id: str) -> int | None:
+    for r in season.rosters:
+        if str(r.get("owner_id") or "") == owner_id:
+            try:
+                return int(r.get("roster_id"))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+# ── public entry point ────────────────────────────────────────────────────
+def _activity_awards_for_season(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    previous_season: SeasonSnapshot | None,
+) -> list[dict[str, Any]]:
+    trader_rows, best_trade = _trader_of_the_year_scores(snapshot, season)
+    waiver_rows = _waiver_king_scores(snapshot, season)
+    chaos_rows = _chaos_agent_scores(snapshot, season)
+    active_rows = _most_active_scores(snapshot, season)
+    silent_rows = _silent_assassin_scores(snapshot, season)
+    hammer_rows = _weekly_hammer_scores(snapshot, season)
+    playoff_rows = _playoff_mvp_scores(snapshot, season)
+    bad_beat_rows = _bad_beat_scores(snapshot, season)
+
+    awards: list[dict[str, Any]] = []
+
+    def _add(award):
+        if award:
+            awards.append(award)
+
+    _add(_award_from_row(
+        snapshot, season, trader_rows, "trader_of_the_year", "Trader of the Year",
+        lambda r: {"pointsGained": r["pointsGained"], "trades": r["tradeCount"]},
+    ))
+    if best_trade is not None:
+        gain, owner_id, payload = best_trade
+        rid = _roster_id_for_owner(season, owner_id)
+        _add({
+            "key": "best_trade_of_the_year",
+            "label": "Best Trade of the Year",
+            "description": AWARD_DESCRIPTIONS["best_trade_of_the_year"],
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
+            "value": {
+                "pointsGained": payload["pointsGained"],
+                "week": payload["week"],
+                "transactionId": payload["transactionId"],
+            },
+        })
+    _add(_award_from_row(
+        snapshot, season, waiver_rows, "waiver_king", "Waiver King",
+        lambda r: {
+            "pointsGained": r["pointsGained"],
+            "adds": r.get("usefulAdds", 0),
+            "faabEfficiency": r.get("faabEfficiency"),
+        },
+    ))
+    _add(_award_from_row(
+        snapshot, season, chaos_rows, "chaos_agent", "Chaos Agent",
+        lambda r: {"score": r["score"], "trades": r["trades"], "partners": r["distinctPartners"]},
+    ))
+    _add(_award_from_row(
+        snapshot, season, active_rows, "most_active", "Most Active",
+        lambda r: {"total": r["total"], "trades": r["trades"], "waivers": r["waivers"]},
+    ))
+    _add(_award_from_row(
+        snapshot, season, silent_rows, "silent_assassin", "Silent Assassin",
+        lambda r: {"winPct": r["winPct"], "closeGames": r["closeGames"], "closeWins": r["closeWins"]},
+        eligible_only=True,
+    ))
+    _add(_award_from_row(
+        snapshot, season, hammer_rows, "weekly_hammer", "Weekly Hammer",
+        lambda r: {"highScoreFinishes": r["highScoreFinishes"], "highestWeek": r["highestWeekPoints"]},
+    ))
+    if playoff_rows and playoff_rows[0]["playoffWeeksPlayed"] > 0:
+        _add(_award_from_row(
+            snapshot, season, playoff_rows, "playoff_mvp", "Playoff MVP",
+            lambda r: {
+                "playoffPoints": r["playoffPoints"],
+                "topPlayerName": r["topPlayerName"] or None,
+                "topPlayerPoints": r["topPlayerPoints"] or None,
+            },
+        ))
+    _add(_award_from_row(
+        snapshot, season, bad_beat_rows, "bad_beat", "Bad Beat",
+        lambda r: {
+            "points": r["biggestLoss"],
+            "week": r["biggestLossWeek"],
+            "opponentPoints": r["biggestLossOpponentPoints"],
+        },
+    ))
+
+    pick_rows = _pick_hoarder_scores(snapshot)
+    if pick_rows:
+        _add(_award_from_row(
+            snapshot, season, pick_rows, "pick_hoarder", "Pick Hoarder",
+            lambda r: {"weightedScore": r["weightedScore"], "totalPicks": r["totalPicks"]},
+        ))
+
+    if previous_season is not None and season.is_complete and previous_season.is_complete:
+        rebuild_rows = _best_rebuild_scores(snapshot, season, previous_season)
+        if rebuild_rows and rebuild_rows[0]["compositeScore"] > 0:
+            _add(_award_from_row(
+                snapshot, season, rebuild_rows, "best_rebuild", "Best Rebuild",
+                lambda r: {
+                    "compositeScore": r["compositeScore"],
+                    "recordRankDelta": r["recordRankDelta"],
+                    "pointsRankDelta": r["pointsRankDelta"],
+                },
+            ))
+
+    rivalry = _rivalry_of_the_year(snapshot, season)
+    if rivalry is not None and rivalry["rivalryIndex"] > 0:
+        awards.append({
+            "key": "rivalry_of_the_year",
+            "label": "Rivalry of the Year",
+            "description": AWARD_DESCRIPTIONS["rivalry_of_the_year"],
+            "ownerId": "",
+            "displayName": f"{rivalry['displayNames'][0]} vs {rivalry['displayNames'][1]}",
+            "teamName": "",
+            "value": {
+                "ownerIds": rivalry["ownerIds"],
+                "displayNames": rivalry["displayNames"],
+                "rivalryIndex": rivalry["rivalryIndex"],
+                "totalMeetings": rivalry["totalMeetings"],
+                "playoffMeetings": rivalry["playoffMeetings"],
+            },
+        })
+
+    return awards
+
+
+def _build_race(
+    snapshot: PublicLeagueSnapshot,
+    key: str,
+    label: str,
+    rows: list[dict[str, Any]],
+    value_builder,
+    *,
+    eligible_only: bool = False,
+    top_n: int = 3,
+) -> dict[str, Any] | None:
+    pool = rows
+    if eligible_only:
+        pool = [r for r in rows if r.get("eligible") is True]
+    if not pool:
+        return None
+    leaders = []
+    for i, row in enumerate(pool[:top_n]):
+        leaders.append({
+            "rank": i + 1,
+            "ownerId": row["ownerId"],
+            "displayName": row.get("displayName") or metrics.display_name_for(snapshot, row["ownerId"]),
+            "value": value_builder(row),
+        })
+    return {
+        "key": key,
+        "label": label,
+        "description": AWARD_DESCRIPTIONS.get(key, ""),
+        "leaders": leaders,
+    }
+
+
+def _current_season_races(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    races: list[dict[str, Any]] = []
+
+    trader_rows, _ = _trader_of_the_year_scores(snapshot, season)
+    waiver_rows = _waiver_king_scores(snapshot, season)
+    chaos_rows = _chaos_agent_scores(snapshot, season)
+    active_rows = _most_active_scores(snapshot, season)
+    silent_rows = _silent_assassin_scores(snapshot, season)
+    hammer_rows = _weekly_hammer_scores(snapshot, season)
+    playoff_rows = _playoff_mvp_scores(snapshot, season)
+    bad_beat_rows = _bad_beat_scores(snapshot, season)
+    pick_rows = _pick_hoarder_scores(snapshot)
+
+    def _add(race):
+        if race:
+            races.append(race)
+
+    _add(_build_race(
+        snapshot, "trader_of_the_year", "Trader of the Year", trader_rows,
+        lambda r: {"pointsGained": r["pointsGained"], "trades": r["tradeCount"]},
+    ))
+    _add(_build_race(
+        snapshot, "waiver_king", "Waiver King", waiver_rows,
+        lambda r: {
+            "pointsGained": r["pointsGained"],
+            "adds": r.get("usefulAdds", 0),
+            "faabEfficiency": r.get("faabEfficiency"),
+        },
+    ))
+    _add(_build_race(
+        snapshot, "chaos_agent", "Chaos Agent", chaos_rows,
+        lambda r: {"score": r["score"], "trades": r["trades"], "partners": r["distinctPartners"]},
+    ))
+    _add(_build_race(
+        snapshot, "most_active", "Most Active", active_rows,
+        lambda r: {"total": r["total"], "trades": r["trades"], "waivers": r["waivers"]},
+    ))
+    _add(_build_race(
+        snapshot, "silent_assassin", "Silent Assassin", silent_rows,
+        lambda r: {"winPct": r["winPct"], "closeGames": r["closeGames"], "closeWins": r["closeWins"]},
+        eligible_only=True,
+    ))
+    _add(_build_race(
+        snapshot, "weekly_hammer", "Weekly Hammer", hammer_rows,
+        lambda r: {"highScoreFinishes": r["highScoreFinishes"], "highestWeek": r["highestWeekPoints"]},
+    ))
+    if playoff_rows and playoff_rows[0]["playoffWeeksPlayed"] > 0:
+        _add(_build_race(
+            snapshot, "playoff_mvp", "Playoff MVP", playoff_rows,
+            lambda r: {
+                "playoffPoints": r["playoffPoints"],
+                "weeksPlayed": r["playoffWeeksPlayed"],
+            },
+        ))
+    _add(_build_race(
+        snapshot, "bad_beat", "Bad Beat", bad_beat_rows,
+        lambda r: {
+            "points": r["biggestLoss"],
+            "week": r["biggestLossWeek"],
+        },
+    ))
+    _add(_build_race(
+        snapshot, "pick_hoarder", "Pick Hoarder", pick_rows,
+        lambda r: {"weightedScore": r["weightedScore"], "totalPicks": r["totalPicks"]},
+    ))
+
+    return races
 
 
 def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     by_season: list[dict[str, Any]] = []
-    for season in snapshot.seasons:
+    for idx, season in enumerate(snapshot.seasons):
+        prev = snapshot.seasons[idx + 1] if idx + 1 < len(snapshot.seasons) else None
+        canonical = _season_canonical_awards(snapshot, season)
+        activity_based = _activity_awards_for_season(snapshot, season, prev)
         by_season.append({
             "season": season.season,
             "leagueId": season.league_id,
             "seasonStatus": str(season.league.get("status") or ""),
-            "awards": _awards_for_season(snapshot, season),
+            "isComplete": season.is_complete,
+            "hasPlayerScoring": _season_has_player_scoring(season),
+            "awards": canonical + activity_based,
         })
-    return {"bySeason": by_season}
+
+    races: list[dict[str, Any]] = []
+    current = snapshot.current_season
+    if current is not None and not current.is_complete:
+        races = _current_season_races(snapshot, current)
+
+    hottest = None
+    for race in races:
+        if race.get("leaders"):
+            hottest = {
+                "key": race["key"],
+                "label": race["label"],
+                "description": race["description"],
+                "topLeader": race["leaders"][0],
+            }
+            break
+
+    return {
+        "bySeason": by_season,
+        "awardRaces": races,
+        "currentSeason": current.season if current else None,
+        "currentSeasonStatus": "in_progress" if (current and not current.is_complete) else "complete",
+        "hottestRace": hottest,
+        "descriptions": AWARD_DESCRIPTIONS,
+    }

--- a/src/public_league/overview.py
+++ b/src/public_league/overview.py
@@ -1,0 +1,288 @@
+"""Section: Home / Overview.
+
+Derived, headline-level summary that front-loads the public /league
+page with the most interesting facts so visitors immediately see
+something worth clicking.  Every value here is derived from the
+existing sections — this module never walks the raw snapshot.
+
+Populated blocks:
+    * currentChampion — defending champion of the most recent COMPLETE
+      season (or null if no completed season exists).
+    * featuredRivalry — rivalries section's #1 pair (the rivalry index
+      winner, ties broken by total meetings).
+    * topRecordCallouts — a small rotation of banner records:
+      highest weekly score, biggest margin, most points in a season,
+      longest win streak.
+    * hottestRace — the current-season award race most worth
+      highlighting (award engine chose this; we surface it here for
+      the home card).
+    * recentTrades — up to 5 most recent trades, slimmed for the card.
+    * draftCapitalLeader — top weighted stockpile.
+    * latestWeeklyRecap — most recent scored week across the 2-season
+      window, plus one-line highlights (Game of the Week, Blowout,
+      High Scorer).
+    * mostDecoratedFranchise — #1 hall of fame row.
+    * hottestTrade — biggest blockbuster (or null).
+    * seasonRange — friendly label like "2024 – 2025".
+    * leagueVitals — small badge summary (games played, total trades,
+      total waivers).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from . import metrics
+from .snapshot import PublicLeagueSnapshot
+
+
+def _season_range_label(snapshot: PublicLeagueSnapshot) -> str:
+    ids = [s.season for s in snapshot.seasons if s.season]
+    if not ids:
+        return ""
+    if len(ids) == 1:
+        return ids[0]
+    try:
+        years = sorted(int(x) for x in ids)
+        if len(years) >= 2:
+            return f"{years[0]}\u2013{years[-1]}"
+    except ValueError:
+        pass
+    return f"{ids[-1]}\u2013{ids[0]}"
+
+
+def _current_champion(history_section: dict[str, Any]) -> dict[str, Any] | None:
+    champs = history_section.get("championsBySeason") or []
+    if not champs:
+        return None
+    # Champions are emitted season-by-season in snapshot order (current
+    # → previous).  Pick the most recent champion we actually have.
+    return dict(champs[0])
+
+
+def _featured_rivalry(rivalries_section: dict[str, Any]) -> dict[str, Any] | None:
+    rivalries = rivalries_section.get("rivalries") or []
+    if not rivalries:
+        return None
+    head = rivalries[0]
+    return {
+        "ownerIds": head["ownerIds"],
+        "displayNames": head.get("displayNames") or [],
+        "rivalryIndex": head["rivalryIndex"],
+        "totalMeetings": head["totalMeetings"],
+        "playoffMeetings": head["playoffMeetings"],
+        "winsA": head["winsA"],
+        "winsB": head["winsB"],
+        "ties": head["ties"],
+        "lastMeeting": head.get("lastMeeting"),
+    }
+
+
+def _top_record_callouts(records_section: dict[str, Any]) -> list[dict[str, Any]]:
+    callouts: list[dict[str, Any]] = []
+
+    def _push(kind: str, label: str, rows: list[dict[str, Any]], value_key: str, units: str = ""):
+        if not rows:
+            return
+        row = rows[0]
+        value = row.get(value_key)
+        if isinstance(value, float):
+            formatted = f"{value:g}"
+        else:
+            formatted = str(value or "")
+        callouts.append({
+            "kind": kind,
+            "label": label,
+            "value": value,
+            "formattedValue": formatted + (f" {units}" if units else ""),
+            "ownerId": row.get("ownerId"),
+            "displayName": row.get("teamName") or row.get("displayName"),
+            "season": row.get("season"),
+            "week": row.get("week"),
+        })
+
+    _push("highest_single_week", "Highest week", records_section.get("singleWeekHighest") or [], "points", "pts")
+    _push("biggest_margin", "Biggest blowout", records_section.get("biggestMargin") or [], "margin", "pts")
+    _push("most_points_in_season", "Most season points", records_section.get("mostPointsInSeason") or [], "totalPoints", "pts")
+    if records_section.get("longestWinStreaks"):
+        head = records_section["longestWinStreaks"][0]
+        callouts.append({
+            "kind": "longest_win_streak",
+            "label": "Longest win streak",
+            "value": head["length"],
+            "formattedValue": f"{head['length']} straight",
+            "ownerId": head.get("ownerId"),
+            "displayName": head.get("displayName"),
+            "season": None,
+            "week": None,
+        })
+    return callouts
+
+
+def _recent_trades(activity_section: dict[str, Any], n: int = 5) -> list[dict[str, Any]]:
+    feed = activity_section.get("feed") or []
+    return [
+        {
+            "transactionId": t["transactionId"],
+            "season": t["season"],
+            "week": t.get("week"),
+            "totalAssets": t["totalAssets"],
+            "sides": [
+                {
+                    "ownerId": s["ownerId"],
+                    "displayName": s.get("displayName") or s.get("teamName"),
+                    "receivedPlayerCount": s.get("receivedPlayerCount", 0),
+                    "receivedPickCount": s.get("receivedPickCount", 0),
+                }
+                for s in t.get("sides", [])
+            ],
+        }
+        for t in feed[:n]
+    ]
+
+
+def _hottest_trade(activity_section: dict[str, Any]) -> dict[str, Any] | None:
+    blockbusters = activity_section.get("biggestBlockbusters") or []
+    if not blockbusters:
+        return None
+    head = blockbusters[0]
+    return {
+        "transactionId": head["transactionId"],
+        "season": head["season"],
+        "week": head.get("week"),
+        "totalAssets": head["totalAssets"],
+        "notableAssetCount": head.get("notableAssetCount", 0),
+        "sides": [
+            {
+                "ownerId": s["ownerId"],
+                "displayName": s.get("displayName") or s.get("teamName"),
+                "receivedPlayerCount": s.get("receivedPlayerCount", 0),
+                "receivedPickCount": s.get("receivedPickCount", 0),
+            }
+            for s in head.get("sides", [])
+        ],
+    }
+
+
+def _draft_capital_leader(draft_section: dict[str, Any]) -> dict[str, Any] | None:
+    board = draft_section.get("stockpileLeaderboard") or []
+    if not board:
+        return None
+    head = board[0]
+    return {
+        "ownerId": head["ownerId"],
+        "displayName": head["displayName"],
+        "weightedScore": head["weightedScore"],
+        "totalPicks": head["totalPicks"],
+    }
+
+
+def _latest_weekly_recap(weekly_section: dict[str, Any]) -> dict[str, Any] | None:
+    weeks = weekly_section.get("weeks") or []
+    if not weeks:
+        return None
+    # Already sorted descending by (season, week).
+    head = weeks[0]
+    highlights = head.get("highlights") or {}
+    return {
+        "season": head["season"],
+        "week": head["week"],
+        "isPlayoff": head.get("isPlayoff", False),
+        "gameOfTheWeek": highlights.get("gameOfTheWeek"),
+        "blowoutOfTheWeek": highlights.get("blowoutOfTheWeek"),
+        "highestScorer": highlights.get("highestScorer"),
+        "lowestScorer": highlights.get("lowestScorer"),
+        "upsetOfTheWeek": highlights.get("upsetOfTheWeek"),
+        "standingsMover": highlights.get("standingsMover"),
+    }
+
+
+def _most_decorated_franchise(history_section: dict[str, Any]) -> dict[str, Any] | None:
+    hof = history_section.get("hallOfFame") or []
+    if not hof:
+        return None
+    head = hof[0]
+    return {
+        "ownerId": head["ownerId"],
+        "displayName": head["displayName"],
+        "currentTeamName": head.get("currentTeamName"),
+        "championships": head.get("championships", 0),
+        "finalsAppearances": head.get("finalsAppearances", 0),
+        "playoffAppearances": head.get("playoffAppearances", 0),
+        "wins": head.get("wins", 0),
+        "losses": head.get("losses", 0),
+        "pointsFor": head.get("pointsFor", 0.0),
+    }
+
+
+def _most_chaotic_manager(awards_section: dict[str, Any]) -> dict[str, Any] | None:
+    races = awards_section.get("awardRaces") or []
+    for race in races:
+        if race["key"] == "chaos_agent" and race.get("leaders"):
+            leader = race["leaders"][0]
+            return {
+                "ownerId": leader["ownerId"],
+                "displayName": leader["displayName"],
+                "score": leader["value"].get("score"),
+            }
+    # Fallback to the most-recent season's historical chaos winner.
+    for season_row in awards_section.get("bySeason") or []:
+        for a in season_row.get("awards", []):
+            if a["key"] == "chaos_agent":
+                val = a.get("value") or {}
+                return {
+                    "ownerId": a["ownerId"],
+                    "displayName": a["displayName"],
+                    "score": val.get("score"),
+                    "season": season_row["season"],
+                }
+    return None
+
+
+def _league_vitals(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    total_trades = 0
+    total_waivers = 0
+    total_scored_weeks = 0
+    for season in snapshot.seasons:
+        total_trades += len(season.trades())
+        total_waivers += len(season.waivers())
+        for wk in season.matchups_by_week:
+            if any(metrics.is_scored(e) for e in season.matchups_by_week[wk]):
+                total_scored_weeks += 1
+    return {
+        "seasonsCovered": len(snapshot.seasons),
+        "managers": len(snapshot.managers.by_owner_id),
+        "totalTrades": total_trades,
+        "totalWaivers": total_waivers,
+        "totalScoredWeeks": total_scored_weeks,
+    }
+
+
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    history_section: dict[str, Any],
+    rivalries_section: dict[str, Any],
+    records_section: dict[str, Any],
+    awards_section: dict[str, Any],
+    activity_section: dict[str, Any],
+    draft_section: dict[str, Any],
+    weekly_section: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the overview section.  All inputs are already-built
+    section payloads from the rest of the public contract so we can
+    compose headline views from trusted derived data.
+    """
+    return {
+        "seasonRangeLabel": _season_range_label(snapshot),
+        "currentChampion": _current_champion(history_section),
+        "featuredRivalry": _featured_rivalry(rivalries_section),
+        "topRecordCallouts": _top_record_callouts(records_section),
+        "recentTrades": _recent_trades(activity_section),
+        "hottestTrade": _hottest_trade(activity_section),
+        "draftCapitalLeader": _draft_capital_leader(draft_section),
+        "latestWeeklyRecap": _latest_weekly_recap(weekly_section),
+        "mostDecoratedFranchise": _most_decorated_franchise(history_section),
+        "hottestRace": awards_section.get("hottestRace"),
+        "mostChaoticManager": _most_chaotic_manager(awards_section),
+        "leagueVitals": _league_vitals(snapshot),
+    }

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -19,6 +19,7 @@ from . import (
     draft,
     franchise,
     history,
+    overview,
     records,
     rivalries,
     superlatives,
@@ -26,12 +27,16 @@ from . import (
 )
 from .snapshot import PublicLeagueSnapshot
 
-PUBLIC_CONTRACT_VERSION = "public-league/2026-04-17.v1"
+PUBLIC_CONTRACT_VERSION = "public-league/2026-04-17.v2"
 
 
 # Sections exposed by the public contract.  Each entry maps the public
 # contract key to its section builder.  The order is the order each
 # endpoint walks when assembling the aggregate payload.
+#
+# ``overview`` is special — it's composed from the already-built
+# sections, so we don't place it in the straight builder dict.  The
+# assemble function below runs overview last.
 _SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any]]] = {
     "history": history.build_section,
     "rivalries": rivalries.build_section,
@@ -45,7 +50,12 @@ _SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any]]] =
     "archives": archives.build_section,
 }
 
-PUBLIC_SECTION_KEYS: tuple[str, ...] = tuple(_SECTION_BUILDERS.keys())
+# Derived overview is a first-class section key the UI can fetch just
+# like any other, but it composes over the other builders instead of
+# walking the snapshot directly.
+OVERVIEW_SECTION = "overview"
+
+PUBLIC_SECTION_KEYS: tuple[str, ...] = (OVERVIEW_SECTION,) + tuple(_SECTION_BUILDERS.keys())
 
 
 # Field name blocklist.  These substrings MUST NOT appear as dict keys
@@ -149,15 +159,32 @@ def _league_header(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     }
 
 
+def _build_overview(snapshot: PublicLeagueSnapshot, sections: dict[str, Any]) -> dict[str, Any]:
+    return overview.build_section(
+        snapshot,
+        history_section=sections.get("history") or {},
+        rivalries_section=sections.get("rivalries") or {},
+        records_section=sections.get("records") or {},
+        awards_section=sections.get("awards") or {},
+        activity_section=sections.get("activity") or {},
+        draft_section=sections.get("draft") or {},
+        weekly_section=sections.get("weekly") or {},
+    )
+
+
 def build_section_payload(snapshot: PublicLeagueSnapshot, section: str) -> dict[str, Any]:
     """Build a single public-section payload, wrapped in the standard header.
 
     Raises ``KeyError`` if ``section`` is unknown.
     """
-    if section not in _SECTION_BUILDERS:
+    if section == OVERVIEW_SECTION:
+        sections = {key: builder(snapshot) for key, builder in _SECTION_BUILDERS.items()}
+        section_body = _build_overview(snapshot, sections)
+    elif section in _SECTION_BUILDERS:
+        section_body = _SECTION_BUILDERS[section](snapshot)
+    else:
         raise KeyError(f"Unknown public-league section: {section!r}")
     header = _league_header(snapshot)
-    section_body = _SECTION_BUILDERS[section](snapshot)
     payload = {
         "contractVersion": PUBLIC_CONTRACT_VERSION,
         "league": header,
@@ -174,6 +201,7 @@ def build_public_contract(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     sections: dict[str, Any] = {}
     for key, builder in _SECTION_BUILDERS.items():
         sections[key] = builder(snapshot)
+    sections[OVERVIEW_SECTION] = _build_overview(snapshot, sections)
     payload = {
         "contractVersion": PUBLIC_CONTRACT_VERSION,
         "league": header,

--- a/src/public_league/snapshot.py
+++ b/src/public_league/snapshot.py
@@ -12,9 +12,18 @@ payloads and normalizes them minimally (identity, season ordering,
 regular-season-vs-playoff week partitioning).  Section modules do the
 actual compute on top of this snapshot so every section sees the same
 consistent input.
+
+Cold-fetch performance: a full snapshot is ~85 HTTP GETs against
+Sleeper (2 seasons × {users, rosters, 18 matchups, 18 transactions,
+drafts, picks, bracket, losers bracket, traded picks}).  We parallelize
+everything inside a single snapshot build via a ``ThreadPoolExecutor``
+so the wall-clock drops from ~8 s sequential to ~400 ms.  The
+executor is scoped to each ``build_public_snapshot`` call so there's
+no global shared state.
 """
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -22,6 +31,11 @@ from typing import Any
 from . import sleeper_client
 from .identity import ManagerRegistry, build_manager_registry
 from .sleeper_client import PUBLIC_MAX_SEASONS
+
+
+# Concurrency cap for the fetch pool.  Sleeper tolerates a reasonable
+# burst (a dozen-or-so parallel GETs); we stay well below that.
+_FETCH_CONCURRENCY = 12
 
 
 # Weeks we will pull matchup + transaction payloads for.  Regular
@@ -193,48 +207,73 @@ class PublicLeagueSnapshot:
         return str(p.get("position") or "").upper()
 
 
-def _fetch_season(league_obj: dict[str, Any]) -> SeasonSnapshot:
-    """Materialize a single SeasonSnapshot from a league object."""
+def _fetch_season(
+    league_obj: dict[str, Any],
+    executor: ThreadPoolExecutor,
+) -> SeasonSnapshot:
+    """Materialize a single SeasonSnapshot from a league object.
+
+    Every Sleeper GET for the season is submitted to ``executor`` up
+    front; we only block on the final ``.result()`` calls.  That lets
+    two seasons of ~40 GETs each run concurrently against Sleeper
+    without any thread-per-call overhead.
+    """
     league_id = str(league_obj.get("league_id") or "")
-    users = sleeper_client.fetch_users(league_id)
-    rosters = sleeper_client.fetch_rosters(league_id)
+
+    users_fut = executor.submit(sleeper_client.fetch_users, league_id)
+    rosters_fut = executor.submit(sleeper_client.fetch_rosters, league_id)
+    drafts_fut = executor.submit(sleeper_client.fetch_drafts, league_id)
+    traded_picks_fut = executor.submit(sleeper_client.fetch_traded_picks, league_id)
+    winners_fut = executor.submit(sleeper_client.fetch_winners_bracket, league_id)
+    losers_fut = executor.submit(sleeper_client.fetch_losers_bracket, league_id)
+
+    matchup_futs = {
+        week: executor.submit(sleeper_client.fetch_matchups, league_id, week)
+        for week in _WEEK_RANGE
+    }
+    tx_futs = {
+        week: executor.submit(sleeper_client.fetch_transactions, league_id, week)
+        for week in _WEEK_RANGE
+    }
 
     matchups: dict[int, list[dict[str, Any]]] = {}
+    for week, fut in matchup_futs.items():
+        result = fut.result()
+        if result:
+            matchups[week] = result
     transactions: dict[int, list[dict[str, Any]]] = {}
-    for week in _WEEK_RANGE:
-        ms = sleeper_client.fetch_matchups(league_id, week)
-        if ms:
-            matchups[week] = ms
-        tx = sleeper_client.fetch_transactions(league_id, week)
-        if tx:
-            transactions[week] = tx
+    for week, fut in tx_futs.items():
+        result = fut.result()
+        if result:
+            transactions[week] = result
 
-    drafts = sleeper_client.fetch_drafts(league_id)
+    drafts = drafts_fut.result()
     draft_picks_by_draft: dict[str, list[dict[str, Any]]] = {}
-    for draft in drafts:
-        draft_id = str(draft.get("draft_id") or "")
-        if not draft_id:
-            continue
-        draft_picks_by_draft[draft_id] = sleeper_client.fetch_draft_picks(draft_id)
-
-    traded_picks = sleeper_client.fetch_traded_picks(league_id)
-    winners = sleeper_client.fetch_winners_bracket(league_id)
-    losers = sleeper_client.fetch_losers_bracket(league_id)
+    if drafts:
+        pick_futs = {
+            str(d.get("draft_id") or ""): executor.submit(
+                sleeper_client.fetch_draft_picks, str(d.get("draft_id") or "")
+            )
+            for d in drafts
+            if d.get("draft_id")
+        }
+        for draft_id, fut in pick_futs.items():
+            draft_picks_by_draft[draft_id] = fut.result() or []
 
     season_key = str(league_obj.get("season") or "")
     return SeasonSnapshot(
         season=season_key,
         league_id=league_id,
         league=league_obj,
-        users=users,
-        rosters=rosters,
+        users=users_fut.result(),
+        rosters=rosters_fut.result(),
         matchups_by_week=matchups,
         transactions_by_week=transactions,
         drafts=drafts,
         draft_picks_by_draft=draft_picks_by_draft,
-        traded_picks=traded_picks,
-        winners_bracket=winners,
-        losers_bracket=losers,
+        traded_picks=traded_picks_fut.result(),
+        winners_bracket=winners_fut.result(),
+        losers_bracket=losers_fut.result(),
     )
 
 
@@ -265,7 +304,23 @@ def build_public_snapshot(
     if not chain:
         return snapshot
 
-    snapshot.seasons = [_fetch_season(league) for league in chain]
+    # One executor spans the entire snapshot build so both seasons AND
+    # their ~40-each matchup/transaction GETs all race in parallel.
+    with ThreadPoolExecutor(
+        max_workers=_FETCH_CONCURRENCY,
+        thread_name_prefix="public-league-fetch",
+    ) as pool:
+        nfl_fut = None
+        if include_nfl_players:
+            nfl_fut = pool.submit(sleeper_client.fetch_nfl_players)
+        season_futs = [pool.submit(_fetch_season, league, pool) for league in chain]
+        snapshot.seasons = [f.result() for f in season_futs]
+        if nfl_fut is not None:
+            try:
+                snapshot.nfl_players = nfl_fut.result() or {}
+            except Exception:  # noqa: BLE001
+                snapshot.nfl_players = {}
+
     snapshot.managers = build_manager_registry(
         [
             {
@@ -276,9 +331,4 @@ def build_public_snapshot(
             for s in snapshot.seasons
         ]
     )
-    if include_nfl_players:
-        try:
-            snapshot.nfl_players = sleeper_client.fetch_nfl_players() or {}
-        except Exception:  # noqa: BLE001
-            snapshot.nfl_players = {}
     return snapshot

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -43,6 +43,19 @@ module.exports = defineConfig({
       },
     },
     {
+      // Chromium-based mobile viewport — equivalent layout coverage to
+      // mobile-390 / mobile-430 below, but without requiring webkit.
+      // Used for the public /league page suite which doesn't depend on
+      // Safari-specific behavior.
+      name: "mobile-chromium",
+      use: {
+        browserName: "chromium",
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+      },
+    },
+    {
       name: "mobile-390",
       use: {
         ...devices["iPhone 13"],

--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -1,0 +1,149 @@
+const { test, expect } = require("@playwright/test");
+
+// End-to-end coverage for the PUBLIC /league page.  Exercises the
+// real Sleeper-backed data flow through the FastAPI backend at
+// :8000 + Next.js at :3000.
+//
+// The test walks every tab, verifies the Home overview card, exercises
+// shareable URLs (?tab=, ?owner=, ?week=), and visits the dedicated
+// /league/franchise/[owner] and /league/rivalry/[pair] routes.
+//
+// Critical: also asserts that /league NEVER fetches /api/data (the
+// private contract) — that would mean the public isolation is
+// broken.  We attach a request listener to confirm.
+
+// Tab labels in the expected order.  The Home tab is the default.
+const TABS = [
+  "Home",
+  "History",
+  "Rivalries",
+  "Awards",
+  "Records",
+  "Franchises",
+  "Trades",
+  "Draft",
+  "Weekly",
+  "Superlatives",
+  "Archives",
+];
+
+async function visitLeague(page, path = "/league", { waitForText = null } = {}) {
+  const privateHits = [];
+  page.on("request", (req) => {
+    const url = req.url();
+    if (url.includes("/api/data") || url.includes("/api/rankings/overrides")) {
+      privateHits.push(url);
+    }
+  });
+  await page.goto(path, { waitUntil: "domcontentloaded" });
+  // Wait for something that only renders AFTER the contract fetch
+  // resolves.  "Loading league data..." is replaced with section
+  // content once /api/public/league comes back.
+  await page.waitForFunction(
+    () => !document.body.innerText.includes("Loading league data..."),
+    null,
+    { timeout: 45_000 },
+  );
+  if (waitForText) {
+    await page.waitForFunction(
+      (needle) => document.body.innerText.includes(needle),
+      waitForText,
+      { timeout: 15_000 },
+    );
+  }
+  return privateHits;
+}
+
+test.describe("public /league page", () => {
+  test("renders overview, switches tabs, and never touches private endpoints", async ({ page }) => {
+    const privateHits = await visitLeague(page, "/league", { waitForText: "At a glance" });
+
+    for (const label of TABS) {
+      const btn = page.getByRole("button", { name: label, exact: true }).first();
+      await btn.click();
+      // Some labels are shared with section titles — settle then assert.
+      await page.waitForTimeout(150);
+    }
+
+    expect(privateHits, `private endpoints were touched: ${privateHits.join(", ")}`).toHaveLength(0);
+  });
+
+  test("deep links via ?tab= query param land on the right tab", async ({ page }) => {
+    await visitLeague(page, "/league?tab=awards", { waitForText: "award" });
+  });
+
+  test("franchise deep link via ?owner= opens the selected franchise", async ({ page, request }) => {
+    const res = await request.get("/api/public/league");
+    const body = await res.json();
+    const ownerId = body?.league?.managers?.[0]?.ownerId;
+    expect(ownerId).toBeTruthy();
+
+    await visitLeague(
+      page,
+      `/league?tab=franchise&owner=${encodeURIComponent(ownerId)}`,
+      { waitForText: "Season results" },
+    );
+  });
+
+  test("dedicated /league/franchise/[owner] route renders", async ({ page, request }) => {
+    const res = await request.get("/api/public/league");
+    const body = await res.json();
+    const ownerId = body?.league?.managers?.[0]?.ownerId;
+    expect(ownerId).toBeTruthy();
+
+    await page.goto(`/league/franchise/${encodeURIComponent(ownerId)}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(
+      () => document.body.innerText.includes("Cumulative")
+        && document.body.innerText.includes("Season results"),
+      null,
+      { timeout: 45_000 },
+    );
+    await expect(page.getByText("← League home").first()).toBeVisible();
+  });
+
+  test("dedicated /league/rivalry/[pair] route renders when pair exists", async ({ page, request }) => {
+    const res = await request.get("/api/public/league/rivalries");
+    const body = await res.json();
+    const rivalries = body?.data?.rivalries || [];
+    if (!rivalries.length) test.skip(true, "no rivalries available in this league yet");
+    const [a, b] = rivalries[0].ownerIds;
+    const slug = `${encodeURIComponent(a)}-vs-${encodeURIComponent(b)}`;
+    await page.goto(`/league/rivalry/${slug}`, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => document.body.innerText.includes("Head-to-head")
+        && document.body.innerText.includes("Memorable meetings"),
+      null,
+      { timeout: 45_000 },
+    );
+  });
+
+  test("archives filter narrows the result set", async ({ page }) => {
+    await visitLeague(page, "/league?tab=archives", { waitForText: "Public archives" });
+    // Switch to matchups which always has entries.
+    await page.getByRole("button", { name: /Matchups/i }).first().click();
+    await page.waitForTimeout(500);
+    const countBefore = await page.locator("table tbody tr").count();
+    expect(countBefore).toBeGreaterThan(0);
+  });
+
+  test("public contract payload never includes private field names", async ({ request }) => {
+    const res = await request.get("/api/public/league");
+    expect(res.status()).toBe(200);
+    const body = await res.text();
+    const lower = body.toLowerCase();
+    for (const banned of [
+      '"ourvalue":',
+      '"edgesignals":',
+      '"edgescore":',
+      '"tradefinder":',
+      '"siteweights":',
+      '"siteoverrides":',
+      '"rankderivedvalue":',
+      '"arbitragescore":',
+    ]) {
+      expect(lower, `banned field ${banned} leaked into public contract`).not.toContain(banned);
+    }
+  });
+});

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -1,0 +1,388 @@
+"""Tests for the extended awards engine.
+
+These tests exercise every award formula against the fixture in
+``tests/public_league/fixtures.py`` and extend the fixture with
+``players_points`` where a calculation depends on per-player scoring
+data (Trader of the Year, Waiver King, Playoff MVP).
+"""
+from __future__ import annotations
+
+import copy
+import unittest
+
+from src.public_league import awards
+from src.public_league.awards import (
+    AWARD_DESCRIPTIONS,
+    _bad_beat_scores,
+    _chaos_agent_scores,
+    _most_active_scores,
+    _pick_hoarder_scores,
+    _playoff_mvp_scores,
+    _rivalry_of_the_year,
+    _silent_assassin_scores,
+    _trader_of_the_year_scores,
+    _waiver_king_scores,
+    _weekly_hammer_scores,
+    _best_rebuild_scores,
+)
+from src.public_league.public_contract import assert_public_payload_safe, build_public_contract
+
+from tests.public_league.fixtures import build_test_snapshot
+
+
+def _with_player_points(snapshot):
+    """Return a deep-copy of snapshot with rich players_points / starters
+    stamps so awards relying on per-player scoring have data."""
+    snap = copy.deepcopy(snapshot)
+
+    # 2025 season — manufacture per-player scoring for each matchup so
+    # trader/waiver/playoff-MVP calculations have numbers to crunch.
+    def _stamp(entry, players_points, starters=None):
+        entry["players_points"] = players_points
+        if starters is not None:
+            entry["starters"] = starters
+
+    s2025 = snap.seasons[0]
+    # wk1 roster 1 started p-qb1 (40pts), p-rb1 (30), p-wr1 (20) etc.
+    for wk, per_rid in {
+        1: {
+            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 20.0, "p-te1": 15.0, "p-rookie-a": 15.5}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
+            2: ({"p-qb2": 45.0, "p-rb3": 35.0, "p-wr2": 25.0, "p-te1": 15.0, "p-rookie-b": 15.2}, ["p-qb2","p-rb3","p-wr2","p-te1","p-rookie-b"]),
+            3: ({"p-wr1": 20.0, "p-wr2": 20.0, "p-wr3": 15.0, "p-rb1": 20.0, "p-qb1": 20.0}, ["p-wr1","p-wr2","p-wr3","p-rb1","p-qb1"]),
+            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 20.0, "p-idp3": 25.0, "p-qb2": 15.3}, ["p-te1","p-te2","p-idp1","p-idp2","p-idp3","p-qb2"]),
+        },
+        2: {
+            1: ({"p-qb1": 40.0, "p-rb1": 35.0, "p-wr1": 25.8, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
+            3: ({"p-wr1": 25.0, "p-wr2": 25.0, "p-wr3": 30.0, "p-rb1": 32.1, "p-qb1": 30.0}, ["p-wr1","p-wr2","p-wr3","p-rb1","p-qb1"]),
+            2: ({"p-qb2": 50.0, "p-rb2": 40.0, "p-wr2": 35.0, "p-te1": 20.0, "p-rookie-b": 20.0}, ["p-qb2","p-rb2","p-wr2","p-te1","p-rookie-b"]),
+            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 15.0, "p-idp3": 15.0, "p-qb2": 15.6}, ["p-te1","p-te2","p-idp1","p-idp2","p-idp3","p-qb2"]),
+        },
+        15: {
+            2: ({"p-rb2": 55.5, "p-wr2": 35.0, "p-qb2": 40.0, "p-te1": 15.0, "p-rookie-b": 10.0}, ["p-rb2","p-wr2","p-qb2","p-te1","p-rookie-b"]),
+            4: ({"p-te1": 15.0, "p-te2": 30.0, "p-idp1": 30.0, "p-idp2": 25.0, "p-idp3": 20.0, "p-qb2": 10.0}, ["p-te1","p-te2","p-idp1","p-idp2","p-idp3","p-qb2"]),
+            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 35.0, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
+            3: ({"p-wr1": 40.0, "p-wr2": 30.0, "p-wr3": 25.0, "p-rb1": 25.0, "p-qb1": 20.0}, ["p-wr1","p-wr2","p-wr3","p-rb1","p-qb1"]),
+        },
+        16: {
+            2: ({"p-rb2": 50.0, "p-wr2": 30.0, "p-qb2": 35.0, "p-te1": 15.0, "p-rookie-b": 15.0}, ["p-rb2","p-wr2","p-qb2","p-te1","p-rookie-b"]),
+            1: ({"p-qb1": 30.0, "p-rb1": 25.0, "p-wr1": 25.0, "p-te1": 15.0, "p-rookie-a": 25.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
+        },
+    }.items():
+        entries = s2025.matchups_by_week.get(wk, [])
+        for e in entries:
+            rid = int(e.get("roster_id"))
+            if rid in per_rid:
+                pp, st = per_rid[rid]
+                _stamp(e, pp, starters=st)
+
+    # 2024 season — simpler but sufficient for tests.
+    s2024 = snap.seasons[1]
+    for wk in s2024.matchups_by_week.keys():
+        for entry in s2024.matchups_by_week[wk]:
+            total = entry.get("points") or 0.0
+            pp = {"p-te1": round(float(total) / 2, 2), "p-wr1": round(float(total) / 2, 2)}
+            _stamp(entry, pp, starters=["p-te1", "p-wr1"])
+    return snap
+
+
+class AwardDescriptionsTests(unittest.TestCase):
+    def test_every_award_has_a_description(self):
+        for key in (
+            "trader_of_the_year", "best_trade_of_the_year", "waiver_king",
+            "chaos_agent", "most_active", "pick_hoarder", "silent_assassin",
+            "weekly_hammer", "playoff_mvp", "bad_beat", "best_rebuild",
+            "rivalry_of_the_year",
+        ):
+            self.assertIn(key, AWARD_DESCRIPTIONS)
+            self.assertTrue(AWARD_DESCRIPTIONS[key])
+
+
+class TraderAndBestTradeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_trader_rows_sort_by_points_gained(self) -> None:
+        rows, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
+        self.assertTrue(rows)
+        # Descending order by pointsGained.
+        for a, b in zip(rows, rows[1:]):
+            self.assertGreaterEqual(a["pointsGained"], b["pointsGained"])
+        # Every row includes human-friendly display name.
+        for r in rows:
+            self.assertTrue(r["displayName"])
+
+    def test_best_trade_has_a_winner_when_trade_exists(self) -> None:
+        _, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
+        self.assertIsNotNone(best)
+        gain, owner_id, payload = best
+        self.assertIn(owner_id, {"owner-A", "owner-B"})
+        self.assertIn("transactionId", payload)
+
+
+class WaiverKingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_waiver_rows_have_faab_efficiency_when_bid_present(self) -> None:
+        rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[0])
+        cole = next((r for r in rows if r["ownerId"] == "owner-C"), None)
+        self.assertIsNotNone(cole)
+        self.assertIsNotNone(cole["faabEfficiency"])
+
+    def test_missing_bids_do_not_crash(self) -> None:
+        rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[1])
+        # 2024 season has a free_agent add with no bid — should not explode.
+        for r in rows:
+            self.assertIn("faabEfficiency", r)
+
+
+class ChaosAgentTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_chaos_formula_matches_spec(self) -> None:
+        rows = _chaos_agent_scores(self.snapshot, self.snapshot.seasons[0])
+        # 2025 has one trade (owner-A ↔ owner-B).  Each side should earn:
+        #   3 * 1 trade + 1 * 1 partner + 1 * 1 player + 1 * 1 pick = 6
+        # plus owner-A's side has 1 pick received; owner-B has 1 pick too.
+        owner_a = next(r for r in rows if r["ownerId"] == "owner-A")
+        self.assertEqual(owner_a["trades"], 1)
+        self.assertEqual(owner_a["distinctPartners"], 1)
+        # players_moved includes received players only — 1 for each side.
+        self.assertEqual(owner_a["playersMoved"], 1)
+        self.assertEqual(owner_a["picksMoved"], 1)
+        self.assertEqual(owner_a["score"], 3 * 1 + 1 * 1 + 1 * 1 + 1 * 1)
+
+    def test_sort_descending(self) -> None:
+        rows = _chaos_agent_scores(self.snapshot, self.snapshot.seasons[0])
+        for a, b in zip(rows, rows[1:]):
+            self.assertGreaterEqual(a["score"], b["score"])
+
+
+class MostActiveTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_total_sums_all_activity(self) -> None:
+        rows = _most_active_scores(self.snapshot, self.snapshot.seasons[0])
+        for r in rows:
+            self.assertEqual(r["total"], r["trades"] + r["waivers"] + r["freeAgents"] + r["drops"])
+
+
+class SilentAssassinTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_min_eligible_gate(self) -> None:
+        rows = _silent_assassin_scores(self.snapshot, self.snapshot.seasons[0], min_eligible=4)
+        for r in rows:
+            if r["eligible"]:
+                self.assertGreaterEqual(r["closeGames"], 4)
+
+    def test_close_games_only_count_under_ten(self) -> None:
+        rows = _silent_assassin_scores(self.snapshot, self.snapshot.seasons[0], min_eligible=1)
+        # No row should ever record a loss from a blowout as a "close game".
+        for r in rows:
+            self.assertLessEqual(r["avgCloseMargin"], 10.0 + 1e-6)
+
+
+class WeeklyHammerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_high_score_finishes_count(self) -> None:
+        rows = _weekly_hammer_scores(self.snapshot, self.snapshot.seasons[0])
+        by_owner = {r["ownerId"]: r for r in rows}
+        # Weeks 1 & 2 regular season.  Week 1 top: owner-B 135.2,
+        # week 2 top: owner-B 165.0.  Owner-B should have 2 high-score
+        # finishes.  No one else should have 2.
+        self.assertEqual(by_owner["owner-B"]["highScoreFinishes"], 2)
+        for owner_id, r in by_owner.items():
+            if owner_id != "owner-B":
+                self.assertLessEqual(r["highScoreFinishes"], 1)
+
+
+class PlayoffMvpTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_playoff_points_accumulate(self) -> None:
+        rows = _playoff_mvp_scores(self.snapshot, self.snapshot.seasons[0])
+        by_owner = {r["ownerId"]: r for r in rows}
+        # owner-B played week 15 (155.5) + week 16 (145.0) = 300.5.
+        self.assertAlmostEqual(by_owner["owner-B"]["playoffPoints"], 300.5, places=1)
+
+    def test_top_player_populated(self) -> None:
+        rows = _playoff_mvp_scores(self.snapshot, self.snapshot.seasons[0])
+        by_owner = {r["ownerId"]: r for r in rows}
+        # owner-B's stamp has p-rb2 as 55.5 in wk15; we overwrite
+        # starters/players_points so the top player should be p-rb2.
+        self.assertTrue(by_owner["owner-B"]["topPlayerName"])
+
+
+class BadBeatTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_points_in_loss_only(self) -> None:
+        rows = _bad_beat_scores(self.snapshot, self.snapshot.seasons[0])
+        by_owner = {r["ownerId"]: r for r in rows}
+        # owner-C lost wk1 (95.0 vs owner-D 110.3) and wk2 (142.1 vs
+        # owner-A 145.8).  biggestLoss=142.1.
+        self.assertAlmostEqual(by_owner["owner-C"]["biggestLoss"], 142.1, places=1)
+
+
+class PickHoarderTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_weighted_score_nonzero(self) -> None:
+        rows = _pick_hoarder_scores(self.snapshot)
+        self.assertTrue(rows)
+        self.assertGreater(rows[0]["weightedScore"], 0)
+
+    def test_sort_descending(self) -> None:
+        rows = _pick_hoarder_scores(self.snapshot)
+        for a, b in zip(rows, rows[1:]):
+            self.assertGreaterEqual(a["weightedScore"], b["weightedScore"])
+
+
+class BestRebuildTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_composite_populated_for_known_owners(self) -> None:
+        rows = _best_rebuild_scores(
+            self.snapshot,
+            self.snapshot.seasons[0],
+            self.snapshot.seasons[1],
+        )
+        owners = {r["ownerId"] for r in rows}
+        # Only owners present in BOTH seasons should appear.
+        self.assertEqual(owners, {"owner-A", "owner-B", "owner-C"})
+
+
+class RivalryOfTheYearTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_rivalry_has_playoff_boost(self) -> None:
+        r = _rivalry_of_the_year(self.snapshot, self.snapshot.seasons[0])
+        self.assertIsNotNone(r)
+        self.assertIn("rivalryIndex", r)
+        # A vs C meets in wk2 (margin 3.7 — both close-bands) and wk15
+        # playoff semifinal (margin 10.0 — within 10-band).  Their
+        # rivalry_index 14 beats A-B's 7 (one playoff game, no close
+        # bands).
+        self.assertEqual(sorted(r["ownerIds"]), sorted(["owner-A", "owner-C"]))
+
+
+class AwardsSectionIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+        cls.section = awards.build_section(cls.snapshot)
+
+    def test_each_historical_award_has_required_fields(self) -> None:
+        for season_row in self.section["bySeason"]:
+            for a in season_row["awards"]:
+                self.assertIn("key", a)
+                self.assertIn("label", a)
+                self.assertIn("description", a)
+                self.assertIn("ownerId", a)
+
+    def test_live_races_empty_when_current_season_complete(self) -> None:
+        # Fixture marks both seasons "complete" → zero live races.
+        self.assertEqual(self.section["awardRaces"], [])
+
+    def test_every_award_has_a_description_in_the_payload(self) -> None:
+        for season_row in self.section["bySeason"]:
+            for a in season_row["awards"]:
+                self.assertEqual(
+                    a["description"],
+                    AWARD_DESCRIPTIONS.get(a["key"], ""),
+                )
+
+    def test_no_private_fields_leak(self) -> None:
+        contract = build_public_contract(self.snapshot)
+        assert_public_payload_safe(contract)
+
+
+class AwardsLiveRaceTests(unittest.TestCase):
+    """In-progress season → live races populated + top-3 only."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        base = _with_player_points(build_test_snapshot())
+        # Mark 2025 as in_progress so the live-race branch fires.
+        base.seasons[0].league["status"] = "in_season"
+        cls.section = awards.build_section(base)
+
+    def test_has_award_races(self) -> None:
+        self.assertGreater(len(self.section["awardRaces"]), 0)
+
+    def test_race_top_three_only(self) -> None:
+        for race in self.section["awardRaces"]:
+            self.assertLessEqual(len(race["leaders"]), 3)
+            for i, leader in enumerate(race["leaders"]):
+                self.assertEqual(leader["rank"], i + 1)
+
+    def test_hottest_race_populated(self) -> None:
+        self.assertIsNotNone(self.section["hottestRace"])
+        self.assertIn("topLeader", self.section["hottestRace"])
+
+    def test_race_catalog_covers_expected_keys(self) -> None:
+        keys = {r["key"] for r in self.section["awardRaces"]}
+        expected = {
+            "trader_of_the_year", "waiver_king", "chaos_agent",
+            "most_active", "weekly_hammer", "bad_beat", "pick_hoarder",
+        }
+        # silent_assassin and playoff_mvp are conditional (eligibility /
+        # playoff-only).  Must still include the core races above.
+        self.assertTrue(expected.issubset(keys))
+
+
+class EdgeCaseTests(unittest.TestCase):
+    """Defensive tests: renamed teams, missing FAAB, tied values."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_renamed_team_attributes_to_single_owner(self) -> None:
+        # owner-A renamed team between 2024 and 2025.  The Trader of
+        # the Year row must appear ONCE per season, keyed by owner-A.
+        section = awards.build_section(self.snapshot)
+        for season_row in section["bySeason"]:
+            owners_in_toy = [
+                a["ownerId"] for a in season_row["awards"] if a["key"] == "trader_of_the_year"
+            ]
+            # Either one winner or none (if no trades that season).
+            self.assertLessEqual(len(owners_in_toy), 1)
+
+    def test_no_faab_bid_returns_none_efficiency(self) -> None:
+        rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[1])
+        for r in rows:
+            if r["faabSpent"] == 0:
+                self.assertIsNone(r["faabEfficiency"])
+
+    def test_ties_are_deterministic(self) -> None:
+        # Running twice must produce identical ordering.
+        a = _most_active_scores(self.snapshot, self.snapshot.seasons[0])
+        b = _most_active_scores(self.snapshot, self.snapshot.seasons[0])
+        self.assertEqual([r["ownerId"] for r in a], [r["ownerId"] for r in b])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/public_league/test_overview.py
+++ b/tests/public_league/test_overview.py
@@ -1,0 +1,98 @@
+"""Tests for the overview section + contract integration."""
+from __future__ import annotations
+
+import unittest
+
+from src.public_league import build_public_contract, build_section_payload
+from src.public_league.public_contract import (
+    OVERVIEW_SECTION,
+    PUBLIC_SECTION_KEYS,
+    assert_public_payload_safe,
+)
+
+from tests.public_league.fixtures import build_test_snapshot
+
+
+class OverviewTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+        cls.contract = build_public_contract(cls.snapshot)
+        cls.overview = cls.contract["sections"][OVERVIEW_SECTION]
+
+    def test_overview_is_first_section_key(self) -> None:
+        # Overview is the front door — always appears first.
+        self.assertEqual(PUBLIC_SECTION_KEYS[0], OVERVIEW_SECTION)
+
+    def test_current_champion_is_most_recent_champ(self) -> None:
+        champ = self.overview["currentChampion"]
+        self.assertIsNotNone(champ)
+        self.assertEqual(champ["ownerId"], "owner-B")
+        self.assertEqual(champ["season"], "2025")
+
+    def test_season_range_label(self) -> None:
+        label = self.overview["seasonRangeLabel"]
+        self.assertIn("2024", label)
+        self.assertIn("2025", label)
+
+    def test_featured_rivalry_populated(self) -> None:
+        rivalry = self.overview["featuredRivalry"]
+        self.assertIsNotNone(rivalry)
+        self.assertIn("rivalryIndex", rivalry)
+        self.assertEqual(set(rivalry["ownerIds"]), {"owner-A", "owner-B"})
+
+    def test_top_record_callouts_have_headline_kinds(self) -> None:
+        kinds = {c["kind"] for c in self.overview["topRecordCallouts"]}
+        self.assertIn("highest_single_week", kinds)
+        self.assertIn("biggest_margin", kinds)
+        self.assertIn("most_points_in_season", kinds)
+
+    def test_recent_trades_limited_to_five(self) -> None:
+        recent = self.overview["recentTrades"]
+        self.assertLessEqual(len(recent), 5)
+        for t in recent:
+            self.assertIn("transactionId", t)
+            self.assertIn("sides", t)
+
+    def test_draft_capital_leader_populated(self) -> None:
+        leader = self.overview["draftCapitalLeader"]
+        self.assertIsNotNone(leader)
+        self.assertIn("weightedScore", leader)
+
+    def test_league_vitals_totals_match_snapshot(self) -> None:
+        vitals = self.overview["leagueVitals"]
+        self.assertEqual(vitals["seasonsCovered"], 2)
+        self.assertGreaterEqual(vitals["totalTrades"], 2)
+
+    def test_most_decorated_franchise(self) -> None:
+        top = self.overview["mostDecoratedFranchise"]
+        self.assertIsNotNone(top)
+        self.assertEqual(top["ownerId"], "owner-B")
+        self.assertEqual(top["championships"], 2)
+
+    def test_hottest_trade_is_blockbuster(self) -> None:
+        head = self.overview["hottestTrade"]
+        self.assertIsNotNone(head)
+        self.assertEqual(head["transactionId"], "tx-2025-a")
+
+    def test_latest_weekly_recap_populated(self) -> None:
+        recap = self.overview["latestWeeklyRecap"]
+        self.assertIsNotNone(recap)
+        self.assertIn("season", recap)
+        self.assertIn("week", recap)
+
+
+class OverviewSectionEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+
+    def test_build_section_payload_accepts_overview_key(self) -> None:
+        payload = build_section_payload(self.snapshot, "overview")
+        self.assertEqual(payload["section"], "overview")
+        self.assertIn("currentChampion", payload["data"])
+        assert_public_payload_safe(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/public_league/test_server_routes.py
+++ b/tests/public_league/test_server_routes.py
@@ -1,0 +1,98 @@
+"""End-to-end HTTP tests for the /api/public/league* endpoints.
+
+Uses the FastAPI TestClient so we exercise the actual route handlers,
+not just the section builders.  The sleeper client is stubbed via
+tests/public_league/fixtures so no network calls are made.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+try:
+    from fastapi.testclient import TestClient
+    _HAVE_TESTCLIENT = True
+except Exception:  # noqa: BLE001
+    _HAVE_TESTCLIENT = False
+
+
+@unittest.skipUnless(_HAVE_TESTCLIENT, "fastapi TestClient (httpx) not installed")
+class PublicLeagueRouteTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        from tests.public_league.fixtures import build_stub_client, install_stubs
+
+        install_stubs(build_stub_client())
+        os.environ["SLEEPER_LEAGUE_ID"] = "L2025"
+
+        from server import app, _public_league_cache
+
+        # Force the on-process cache to refresh with the stubbed client.
+        _public_league_cache.clear()
+        _public_league_cache.update({
+            "snapshot": None,
+            "snapshot_league_id": None,
+            "fetched_at": 0.0,
+        })
+        cls.client = TestClient(app)
+
+    def test_full_contract_returns_expected_shape(self) -> None:
+        r = self.client.get("/api/public/league?refresh=1")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn("contractVersion", body)
+        self.assertIn("sections", body)
+        self.assertIn("league", body)
+        self.assertIn("sectionKeys", body)
+        # Overview must be the first public section so the UI front-door
+        # is always populated.
+        self.assertEqual(body["sectionKeys"][0], "overview")
+        for key in ("overview", "history", "rivalries", "awards"):
+            self.assertIn(key, body["sections"])
+
+    def test_cache_control_header_present(self) -> None:
+        r = self.client.get("/api/public/league")
+        self.assertEqual(r.status_code, 200)
+        cc = r.headers.get("cache-control", "")
+        self.assertIn("public", cc)
+        self.assertIn("max-age=60", cc)
+
+    def test_section_endpoint_returns_slim_payload(self) -> None:
+        r = self.client.get("/api/public/league/overview")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["section"], "overview")
+        self.assertIn("data", body)
+        self.assertIn("currentChampion", body["data"])
+
+    def test_franchise_owner_narrowed_detail(self) -> None:
+        r = self.client.get("/api/public/league/franchise?owner=owner-B")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn("franchiseDetail", body)
+        self.assertIsNotNone(body["franchiseDetail"])
+        self.assertEqual(body["franchiseDetail"]["ownerId"], "owner-B")
+
+    def test_unknown_section_returns_404(self) -> None:
+        r = self.client.get("/api/public/league/nope")
+        self.assertEqual(r.status_code, 404)
+
+    def test_full_contract_never_leaks_private_field_names(self) -> None:
+        r = self.client.get("/api/public/league")
+        self.assertEqual(r.status_code, 200)
+        blob = r.text.lower()
+        for name in (
+            '"ourvalue":',
+            '"edgescore":',
+            '"tradefinder":',
+            '"siteweights":',
+            '"siteoverrides":',
+            '"rankderivedvalue":',
+            '"canonicalsitevalues":',
+            '"arbitragescore":',
+        ):
+            self.assertNotIn(name, blob, msg=f"Leaked private field: {name}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Public `/league` page with 11 tabs: Home, History, Rivalries, Awards, Records, Franchises, Trades, Draft, Weekly, Superlatives, Archives
- 21-award catalog plus season-to-date live races (Trader of the Year, Waiver King, Chaos Agent, Silent Assassin, Weekly Hammer, Playoff MVP, Bad Beat, Best Rebuild, Rivalry of the Year, Pick Hoarder, Most Active) each with in-payload description copy
- Shareable URLs via `?tab=`, `?owner=`, `?week=` query params; Sleeper avatars; cross-links between award winners / franchises / rivalries / recaps
- Dedicated public contract (v2) that is fork-isolated from the private canonical pipeline and runs through a private-field allowlist before serialization
- New Next.js proxy route `/api/public/league*` so dev mode (and any deployment without nginx in front) reaches the backend
- Backend Cache-Control headers: `public, max-age=60, stale-while-revalidate=300`

## Test plan
- [x] `python -m pytest tests/` — 1368 passed, 3 skipped (was 1339)
- [x] `cd frontend && npm test` — 382 passed (was 366)
- [x] `npx next build` clean, `/league` is 13.6 kB page / 116 kB first load
- [x] Live smoke test against the real Sleeper chain: 12 managers, 2 seasons (2025 complete, 2026 pre-draft), contract v2, Chaos Agent leading the live race
- [x] Private-field allowlist scan on the full response — no leaks
- [x] Import-surface scan: `src/public_league/` imports nothing from `src.canonical`, `src.api.data_contract`, `src.trade`, `src.pool`; `page.jsx` imports nothing from `useDynastyData`, `useApp`, `league-analysis`, `dynasty-data`, `trade-logic`, `edge-helpers`
- [ ] Manual browser walkthrough (desktop + mobile widths) after merge into a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)