### PR TITLE
Fix deploy curl: --globoff for Next.js [dynamic-route] chunk URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -391,7 +391,11 @@ jobs:
             local expect_code="${2:-200}"
             local full_url="${URL}${path}"
             local code
-            code=$(curl --silent --show-error --output /dev/null \
+            # --globoff stops curl from treating literal [ and ] in URLs
+            # as glob ranges — required for Next.js dynamic-route chunk
+            # filenames like "app/api/public/league/[section]/route-*.js"
+            # which preserve the brackets on disk.
+            code=$(curl --silent --show-error --globoff --output /dev/null \
               --write-out '%{http_code}' --max-time 15 "${full_url}" || echo "000")
             if [[ "${code}" == "${expect_code}" ]]; then
               echo "PASS: ${path} -> ${code}"
@@ -409,6 +413,8 @@ jobs:
           check_endpoint "/api/status" 200
           check_endpoint "/api/data" 200
           check_endpoint "/" 200
+          check_endpoint "/league" 200
+          check_endpoint "/api/public/league" 200
 
           # Extract EVERY /_next/static/* reference from the landing
           # page HTML (and a sample of other key routes) and verify
@@ -425,11 +431,11 @@ jobs:
           # (like 448-*.js) silently shipped.  This implementation
           # probes every distinct reference and fails the deploy if
           # any single one returns non-200.
-          HTML_ROUTES=( "/" "/rankings" "/trade" "/edge" "/finder" )
+          HTML_ROUTES=( "/" "/rankings" "/trade" "/edge" "/finder" "/league" )
           declare -A SEEN_ASSETS=()
           for route in "${HTML_ROUTES[@]}"; do
             body_file="$(mktemp)"
-            if ! curl --silent --show-error --max-time 15 --output "${body_file}" "${URL}${route}"; then
+            if ! curl --silent --show-error --globoff --max-time 15 --output "${body_file}" "${URL}${route}"; then
               echo "WARN: unable to fetch ${route} HTML for _next asset extraction"
               rm -f "${body_file}"
               continue

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -585,8 +585,13 @@ PY
     url="http://${FRONTEND_HOST}:${FRONTEND_PORT}/_next/${asset}"
     attempts=0
     code=""
+    # --globoff prevents curl from interpreting literal [ and ] in
+    # the URL as glob/range syntax.  Next.js dynamic routes produce
+    # chunk filenames like "app/api/public/league/[section]/route-*.js"
+    # with the square brackets preserved on disk — without --globoff,
+    # curl errors out with "bad range in URL" for every such asset.
     while (( attempts < FRONTEND_PROBE_MAX_ATTEMPTS )); do
-      code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time 10 "${url}" || echo 000)"
+      code="$(curl --silent --show-error --globoff --output /dev/null --write-out '%{http_code}' --max-time 10 "${url}" || echo 000)"
       if [[ "${code}" == "200" ]]; then
         log "Frontend _next probe OK: ${asset}"
         break

--- a/deploy/verify-deploy.sh
+++ b/deploy/verify-deploy.sh
@@ -166,7 +166,9 @@ PY
     [[ -z "${asset}" ]] && continue
     total=$((total + 1))
     url="http://${FRONTEND_HOST}:${FRONTEND_PORT}/_next/${asset}"
-    code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time "${VERIFY_CURL_TIMEOUT}" "${url}" || echo 000)"
+    # --globoff: literal [ and ] in Next.js dynamic-route chunk names
+    # must not be interpreted as curl glob/range syntax.
+    code="$(curl --silent --show-error --globoff --output /dev/null --write-out '%{http_code}' --max-time "${VERIFY_CURL_TIMEOUT}" "${url}" || echo 000)"
     if [[ "${code}" != "200" ]]; then
       error "Frontend _next asset probe failed: ${url} -> HTTP ${code}"
       return 1
@@ -187,7 +189,7 @@ probe_with_retries() {
   local n=1
 
   while (( n <= attempts )); do
-    code="$(curl --silent --show-error --output "${body_file}" --write-out '%{http_code}' --max-time "${timeout_seconds}" "${url}" || true)"
+    code="$(curl --silent --show-error --globoff --output "${body_file}" --write-out '%{http_code}' --max-time "${timeout_seconds}" "${url}" || true)"
     if [[ "${code}" == "200" ]]; then
       return 0
     fi


### PR DESCRIPTION
## Summary
- PR #71's deploy run failed the post-swap `_next` asset probe because Next.js dynamic-route chunk filenames contain literal square brackets (`app/api/public/league/[section]/route-*.js`). `curl` treated those as glob/range syntax and errored out with HTTP 000.
- Adds `--globoff` to every probe call in `deploy/deploy.sh`, `deploy/verify-deploy.sh`, and the post-deploy smoke test in `.github/workflows/deploy.yml`.
- Extends the smoke test to cover `/league` and `/api/public/league`, and adds `/league` to the HTML-asset-scrape list so dynamic-route chunks are probed every deploy.

## Context
Prod is actually live on commit 9073f45 — the atomic swap landed before the probe failure. This PR only fixes the CI orchestration so future deploys (including any rollback) don't false-fail.

## Test plan
- [x] `bash -n deploy/deploy.sh && bash -n deploy/verify-deploy.sh`
- [x] Verified `curl --globoff` does not interpret `[` / `]` as range syntax
- [x] Production endpoints confirmed live on current prod: `/league`, `/api/public/league` (v2), `/league/franchise/<owner>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)