### PR TITLE
Hide League tab from mobile bottom nav outside /league

### DIFF
--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -96,9 +96,12 @@ function MobileNav() {
   const pathname = usePathname();
   const { authenticated } = useContext(AuthContext);
 
-  const visibleItems = MOBILE_NAV.filter(
-    (item) => authenticated || PUBLIC_ROUTES.has(item.href),
-  );
+  const onLeagueRoute = pathname === "/league" || pathname?.startsWith("/league/");
+  const visibleItems = MOBILE_NAV.filter((item) => {
+    if (!(authenticated || PUBLIC_ROUTES.has(item.href))) return false;
+    if (item.href === "/league" && !onLeagueRoute) return false;
+    return true;
+  });
 
   function isActive(href) {
     if (href === "/more") {


### PR DESCRIPTION
## Summary
- The mobile bottom nav's "League" tab is now hidden unless the user is already on a `/league` route, cleaning up the landing view for unauthenticated visitors.
- Scope is limited to `MobileNav` in `frontend/app/AppShellWrapper.jsx`; desktop top nav and route access are unchanged.

## Test plan
- [ ] On mobile, load `/` (signed out): bottom nav shows Ranks / Trade / More — no League.
- [ ] Navigate to `/league`: League tab appears in the bottom nav and is marked active.
- [ ] Navigate away from `/league`: League tab disappears again.
- [ ] Signed-in users see the same behavior (League only while on `/league`).

https://claude.ai/code/session_01EqTVc8HmXcPRukXsaEa3ev