### PR TITLE
Add trade letter grades to public /league activity timeline

### DIFF
--- a/frontend/app/league/sections/activity.jsx
+++ b/frontend/app/league/sections/activity.jsx
@@ -119,13 +119,23 @@ function TradeCard({ trade, managers, onNavigate }) {
         {(trade.sides || []).map((side, i) => (
           <div key={i} style={{ minWidth: 0 }}>
             <div
-              style={{ display: "flex", alignItems: "center", gap: 6, fontWeight: 700, fontSize: "0.86rem" }}
+              style={{ display: "flex", alignItems: "center", gap: 6, fontWeight: 700, fontSize: "0.86rem", flexWrap: "wrap" }}
               onClick={() => onNavigate && side.ownerId && onNavigate("franchise", { owner: side.ownerId })}
             >
               <Avatar managers={managers} ownerId={side.ownerId} size={20} />
               <span style={{ cursor: side.ownerId ? "pointer" : "default", color: side.ownerId ? "var(--cyan)" : "var(--text)" }}>
                 {side.displayName || side.teamName || nameFor(managers, side.ownerId)}
               </span>
+              {side.grade && (
+                <>
+                  <span style={{ fontSize: "0.78rem", fontWeight: 800, color: side.grade.color }}>
+                    {side.grade.grade}
+                  </span>
+                  <span style={{ fontSize: "0.58rem", color: "var(--subtext)", fontWeight: 500 }}>
+                    {side.grade.label}
+                  </span>
+                </>
+              )}
             </div>
             <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 2 }}>Received:</div>
             <ul style={{ paddingInlineStart: 16, margin: "4px 0 0", fontSize: "0.72rem" }}>

--- a/server.py
+++ b/server.py
@@ -2988,6 +2988,17 @@ def _build_public_activity_valuation():
     if not players_array:
         return None
 
+    # Alias map authored by the canonical pipeline — redirects generic
+    # tier labels ("2026 Mid 1st") to slot-specific siblings
+    # ("2026 Pick 1.06") when the latter exists.  Normalized to
+    # lowercase so lookups match our tier-candidate probes.
+    raw_aliases = contract.get("pickAliases") or {}
+    pick_aliases: dict[str, str] = {}
+    if isinstance(raw_aliases, dict):
+        for k, v in raw_aliases.items():
+            if isinstance(k, str) and isinstance(v, str):
+                pick_aliases[k.lower()] = v.lower()
+
     by_id: dict[str, float] = {}
     by_name: dict[str, float] = {}
     for row in players_array:
@@ -3000,15 +3011,41 @@ def _build_public_activity_valuation():
             continue
         if val <= 0:
             continue
+        # Suppressed generic-tier pick rows keep a stale legacy value
+        # for name-search purposes but are NOT authoritative — the
+        # canonical pipeline aliases them to slot-specific siblings.
+        # Excluding them from ``by_name`` ensures our tier probes
+        # either hit the alias redirect or fall through to the real
+        # slot row instead of returning stale tier data.
+        suppressed = bool(row.get("pickGenericSuppressed"))
         pid = str(row.get("playerId") or "").strip()
-        if pid:
+        if pid and not suppressed:
             by_id[pid] = val
         name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
-        if name:
+        if name and not suppressed:
             by_name[name.lower()] = val
 
     if not by_id and not by_name:
         return None
+
+    # Tier-center slot mapping.  Matches the canonical pipeline's
+    # generic-tier suppression centers and the frontend's
+    # ``TIER_CENTRE_SLOT`` in ``frontend/lib/trade-logic.js``:
+    # Early=2, Mid=6, Late=10.  The public trade feed carries only
+    # ``(season, round)``, so we probe the Mid (tier-center-6) slot
+    # first and fall back to Early/Late centers.
+    _TIER_CENTER_SLOTS = (("Mid", 6), ("Early", 2), ("Late", 10))
+
+    def _resolve(name: str) -> float | None:
+        key = name.lower()
+        # Apply alias redirect first so generic tier labels hop to
+        # their slot-specific siblings before hitting ``by_name``.
+        aliased = pick_aliases.get(key)
+        if aliased is not None:
+            hit = by_name.get(aliased)
+            if hit is not None:
+                return hit
+        return by_name.get(key)
 
     def _pick_value(season, round_) -> float:
         try:
@@ -3019,20 +3056,17 @@ def _build_public_activity_valuation():
         season_str = str(season or "").strip()
         if not label or not season_str:
             return 0.0
-        # The public feed carries only (season, round) — no slot — so
-        # we probe tier-center candidates first (Mid) and then Early
-        # / Late and finally slot-specific rows for years the
-        # canonical pipeline enumerates per-slot.
-        candidates = (
-            f"{season_str} Mid {label}",
-            f"{season_str} Early {label}",
-            f"{season_str} Late {label}",
-            f"{season_str} Pick {round_int}.06",
-            f"{season_str} Pick {round_int}.04",
-            f"{season_str} Pick {round_int}.08",
-        )
-        for cand in candidates:
-            hit = by_name.get(cand.lower())
+        # Tier labels first (redirected via pickAliases when the
+        # canonical pipeline has a slot-specific sibling), then
+        # slot-specific rows at the canonical tier centers.
+        for tier, _slot in _TIER_CENTER_SLOTS:
+            hit = _resolve(f"{season_str} {tier} {label}")
+            if hit is not None:
+                return hit
+        for _tier, slot in _TIER_CENTER_SLOTS:
+            hit = _resolve(
+                f"{season_str} Pick {round_int}.{slot:02d}"
+            )
             if hit is not None:
                 return hit
         return 0.0

--- a/server.py
+++ b/server.py
@@ -2957,6 +2957,105 @@ from src.public_league import player_journey as public_player_journey
 _PUBLIC_LEAGUE_CACHE_TTL_SECONDS = int(os.getenv("PUBLIC_LEAGUE_CACHE_TTL", "300"))
 _PUBLIC_LEAGUE_PERSIST = _env_bool("PUBLIC_LEAGUE_PERSIST_SNAPSHOT", True)
 _PUBLIC_LEAGUE_WARMUP = _env_bool("PUBLIC_LEAGUE_WARMUP_AT_STARTUP", True)
+
+
+# Round ordinals used when synthesizing canonical pick names from the
+# ``(season, round)`` the public activity feed carries.  Matches the
+# labels used in ``src/api/data_contract.py`` and the frontend
+# ``frontend/lib/trade-logic.js`` pick candidate builder.
+_PUBLIC_ACTIVITY_ROUND_LABELS = {1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th", 6: "6th"}
+
+
+def _build_public_activity_valuation():
+    """Build a valuation callable for the public activity trade feed.
+
+    Reads the cached private canonical contract (``latest_contract_data``)
+    and returns a callable ``(asset_dict) -> float``.  The public
+    activity section uses this callable server-side to compute trade
+    letter grades on the public timeline.  The raw values themselves
+    never leave the backend — only the derived ``{grade, color,
+    label}`` block is emitted on the public payload.
+
+    Returns ``None`` when the private contract is unavailable (fresh
+    server, scraper failure).  In that case the public activity feed
+    ships without grade annotations, which is the pre-existing
+    behavior.
+    """
+    contract = latest_contract_data
+    if not contract:
+        return None
+    players_array = contract.get("playersArray") or []
+    if not players_array:
+        return None
+
+    by_id: dict[str, float] = {}
+    by_name: dict[str, float] = {}
+    for row in players_array:
+        if not isinstance(row, dict):
+            continue
+        raw_val = (row.get("values") or {}).get("full")
+        try:
+            val = float(raw_val)
+        except (TypeError, ValueError):
+            continue
+        if val <= 0:
+            continue
+        pid = str(row.get("playerId") or "").strip()
+        if pid:
+            by_id[pid] = val
+        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
+        if name:
+            by_name[name.lower()] = val
+
+    if not by_id and not by_name:
+        return None
+
+    def _pick_value(season, round_) -> float:
+        try:
+            round_int = int(round_)
+        except (TypeError, ValueError):
+            return 0.0
+        label = _PUBLIC_ACTIVITY_ROUND_LABELS.get(round_int)
+        season_str = str(season or "").strip()
+        if not label or not season_str:
+            return 0.0
+        # The public feed carries only (season, round) — no slot — so
+        # we probe tier-center candidates first (Mid) and then Early
+        # / Late and finally slot-specific rows for years the
+        # canonical pipeline enumerates per-slot.
+        candidates = (
+            f"{season_str} Mid {label}",
+            f"{season_str} Early {label}",
+            f"{season_str} Late {label}",
+            f"{season_str} Pick {round_int}.06",
+            f"{season_str} Pick {round_int}.04",
+            f"{season_str} Pick {round_int}.08",
+        )
+        for cand in candidates:
+            hit = by_name.get(cand.lower())
+            if hit is not None:
+                return hit
+        return 0.0
+
+    def _valuation(asset) -> float:
+        if not isinstance(asset, dict):
+            return 0.0
+        kind = asset.get("kind")
+        if kind == "player":
+            pid = str(asset.get("playerId") or "").strip()
+            if pid:
+                v = by_id.get(pid)
+                if v is not None:
+                    return v
+            name = str(asset.get("playerName") or "").strip()
+            if name:
+                return by_name.get(name.lower(), 0.0)
+            return 0.0
+        if kind == "pick":
+            return _pick_value(asset.get("season"), asset.get("round"))
+        return 0.0
+
+    return _valuation
 _public_league_cache: dict = {
     "snapshot": None,
     "snapshot_league_id": None,
@@ -3104,7 +3203,10 @@ def _rebuild_public_snapshot(league_id: str, *, trigger: str = "sync"):
         contract_bytes = None
         if _PUBLIC_LEAGUE_PERSIST and snapshot.seasons:
             try:
-                contract = build_public_contract(snapshot)
+                contract = build_public_contract(
+                    snapshot,
+                    activity_valuation=_build_public_activity_valuation(),
+                )
                 public_snapshot_store.persist_snapshot(snapshot, contract=contract)
                 contract_bytes = len(json.dumps(contract).encode("utf-8"))
                 _public_league_metrics["last_contract_bytes"] = contract_bytes
@@ -3257,7 +3359,10 @@ async def get_public_league(refresh: str = ""):
     """
     try:
         snapshot = _get_public_snapshot(force_refresh=bool(refresh))
-        payload = build_public_contract(snapshot)
+        payload = build_public_contract(
+            snapshot,
+            activity_valuation=_build_public_activity_valuation(),
+        )
         assert_public_payload_safe(payload)
         return JSONResponse(
             content=payload,
@@ -3530,7 +3635,11 @@ async def get_public_league_section(section: str, owner: str = "", refresh: str 
         )
     try:
         snapshot = _get_public_snapshot(force_refresh=bool(refresh))
-        payload = build_section_payload(snapshot, section)
+        payload = build_section_payload(
+            snapshot,
+            section,
+            activity_valuation=_build_public_activity_valuation(),
+        )
         if section == "franchise" and owner:
             detail_map = payload.get("data", {}).get("detail") or {}
             payload["franchiseDetail"] = detail_map.get(str(owner).strip())

--- a/src/public_league/activity.py
+++ b/src/public_league/activity.py
@@ -24,7 +24,7 @@ Blockbuster tiebreaks (prompt spec):
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from typing import Any
+from typing import Any, Callable
 
 from . import metrics
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
@@ -33,6 +33,81 @@ from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 OFFENSIVE_CORE = {"QB", "RB", "WR", "TE"}
 # Any position we consider "notable" enough for the tiebreak.
 NOTABLE_POSITIONS = OFFENSIVE_CORE | {"DL", "LB", "DB", "EDGE"}
+
+# ── Trade grading ────────────────────────────────────────────────────────
+# Mirrors ``gradeTradeHistorySide`` in
+# ``frontend/lib/league-analysis.js`` and ``TRADE_ALPHA`` in
+# ``frontend/lib/trade-logic.js`` so a trade graded on the private
+# ``/trades`` page lands in the same bucket on the public
+# ``/league`` activity timeline.  The grade is computed server-side
+# from a caller-supplied valuation callable; only the resulting
+# ``{grade, color, label}`` object is emitted on the public
+# payload — the raw values and per-side totals NEVER leave the
+# backend.
+_GRADE_ALPHA = 1.45
+_GRADE_PCT_FAIR = 3.0
+_GRADE_PCT_SLIGHT = 8.0
+_GRADE_PCT_GOOD = 15.0
+_GRADE_PCT_CLEAR = 25.0
+_GRADE_PCT_ROBBERY = 40.0
+
+
+def _grade_from_pct(pct: float, is_winner: bool) -> dict[str, str]:
+    if pct < _GRADE_PCT_FAIR:
+        return {"grade": "A", "color": "var(--green)", "label": "Fair trade"}
+    if is_winner:
+        if pct < _GRADE_PCT_SLIGHT:
+            return {"grade": "A", "color": "var(--green)", "label": "Slight win"}
+        if pct < _GRADE_PCT_GOOD:
+            return {"grade": "A-", "color": "var(--green)", "label": "Good win"}
+        if pct < _GRADE_PCT_CLEAR:
+            return {"grade": "B+", "color": "#2ecc71", "label": "Clear win"}
+        return {"grade": "A+", "color": "#00ff88", "label": "Big win"}
+    if pct < _GRADE_PCT_SLIGHT:
+        return {"grade": "B+", "color": "#2ecc71", "label": "Slight overpay"}
+    if pct < _GRADE_PCT_GOOD:
+        return {"grade": "B", "color": "var(--amber)", "label": "Overpay"}
+    if pct < _GRADE_PCT_CLEAR:
+        return {"grade": "C", "color": "#e67e22", "label": "Bad deal"}
+    if pct < _GRADE_PCT_ROBBERY:
+        return {"grade": "D", "color": "var(--red)", "label": "Robbery"}
+    return {"grade": "F", "color": "#ff4444", "label": "Fleeced"}
+
+
+def _apply_trade_grades(
+    feed: list[dict[str, Any]],
+    valuation: Callable[[dict[str, Any]], float],
+) -> None:
+    """Attach a ``grade`` block to each side of every trade in ``feed``.
+
+    Mutates the trade dicts in place.  The raw per-side weighted
+    totals are intentionally discarded after grading — the public
+    payload surfaces only the grade letter, label, and color.
+    """
+    for trade in feed:
+        sides = trade.get("sides") or []
+        if len(sides) < 2:
+            continue
+        weighted: list[float] = []
+        for side in sides:
+            total = 0.0
+            for asset in side.get("receivedAssets") or []:
+                try:
+                    val = float(valuation(asset) or 0.0)
+                except (TypeError, ValueError):
+                    val = 0.0
+                if val > 0:
+                    total += pow(max(val, 1.0), _GRADE_ALPHA)
+            weighted.append(total)
+        max_w = max(weighted) if weighted else 0.0
+        if max_w <= 0:
+            continue
+        min_w = min(weighted)
+        pct = ((max_w - min_w) / max_w) * 100.0
+        fair_deal = pct < _GRADE_PCT_FAIR
+        for i, side in enumerate(sides):
+            is_winner = weighted[i] == max_w
+            side["grade"] = _grade_from_pct(pct, True if fair_deal else is_winner)
 
 
 def _pick_asset(pick: dict[str, Any], snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
@@ -215,7 +290,24 @@ def _timeline_by_week(feed: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return rows
 
 
-def build_section(snapshot: PublicLeagueSnapshot, limit: int = 200) -> dict[str, Any]:
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    limit: int = 200,
+    *,
+    valuation: Callable[[dict[str, Any]], float] | None = None,
+) -> dict[str, Any]:
+    """Build the public activity section.
+
+    ``valuation`` is an optional callable that, given a trade-side
+    received-asset dict (``{kind: "player"|"pick", ...}``), returns a
+    numeric value.  When provided, per-side grade badges are attached
+    to every trade in the returned feed — mirroring the private
+    ``/trades`` page letter grades.  The raw values themselves are
+    never written to the output; only the derived ``{grade, color,
+    label}`` object leaves the backend.  When ``valuation`` is None,
+    the feed has no grade fields (keeps older contract consumers
+    unchanged when the private valuation pipeline is offline).
+    """
     feed: list[dict[str, Any]] = []
     per_season_counts: list[dict[str, Any]] = []
     picks_moved = 0
@@ -238,6 +330,8 @@ def build_section(snapshot: PublicLeagueSnapshot, limit: int = 200) -> dict[str,
         })
 
     feed.sort(key=lambda t: -int(t.get("createdAt") or 0))
+    if valuation is not None:
+        _apply_trade_grades(feed, valuation)
     by_manager = _by_manager_counts(feed)
     partner_pairs = _partner_pairs(feed)
     blockbusters = _biggest_blockbusters(feed)

--- a/src/public_league/activity.py
+++ b/src/public_league/activity.py
@@ -99,15 +99,42 @@ def _apply_trade_grades(
                 if val > 0:
                     total += pow(max(val, 1.0), _GRADE_ALPHA)
             weighted.append(total)
-        max_w = max(weighted) if weighted else 0.0
-        if max_w <= 0:
-            continue
+        max_w = max(weighted)
         min_w = min(weighted)
+        # All-zero case (no asset on any side resolved to a value):
+        # treat as a fair trade — private grading does the same, and
+        # silently omitting badges here would inconsistently hide the
+        # grade block on trades full of unranked assets.
+        if max_w <= 0:
+            fair = _grade_from_pct(0.0, True)
+            for side in sides:
+                side["grade"] = fair
+            continue
         pct = ((max_w - min_w) / max_w) * 100.0
-        fair_deal = pct < _GRADE_PCT_FAIR
+        # Mirror the private /trades grading: only the top-weighted
+        # side can earn a "winner" grade and only the bottom-weighted
+        # side can earn a "loser" grade.  Middle sides in 3+ team
+        # trades get the neutral "Fair trade" badge so they are not
+        # mislabeled as overpayers.
+        if pct < _GRADE_PCT_FAIR:
+            fair = _grade_from_pct(pct, True)
+            for side in sides:
+                side["grade"] = fair
+            continue
+        winner_grade = _grade_from_pct(pct, True)
+        loser_grade = _grade_from_pct(pct, False)
+        fair_grade = _grade_from_pct(0.0, True)
+        winner_assigned = False
+        loser_assigned = False
         for i, side in enumerate(sides):
-            is_winner = weighted[i] == max_w
-            side["grade"] = _grade_from_pct(pct, True if fair_deal else is_winner)
+            if not winner_assigned and weighted[i] == max_w:
+                side["grade"] = winner_grade
+                winner_assigned = True
+            elif not loser_assigned and weighted[i] == min_w:
+                side["grade"] = loser_grade
+                loser_assigned = True
+            else:
+                side["grade"] = fair_grade
 
 
 def _pick_asset(pick: dict[str, Any], snapshot: PublicLeagueSnapshot) -> dict[str, Any]:

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -172,14 +172,41 @@ def _build_overview(snapshot: PublicLeagueSnapshot, sections: dict[str, Any]) ->
     )
 
 
-def build_section_payload(snapshot: PublicLeagueSnapshot, section: str) -> dict[str, Any]:
+def _build_activity_section(
+    snapshot: PublicLeagueSnapshot,
+    activity_valuation: Callable[[dict[str, Any]], float] | None,
+) -> dict[str, Any]:
+    if activity_valuation is None:
+        return activity.build_section(snapshot)
+    return activity.build_section(snapshot, valuation=activity_valuation)
+
+
+def build_section_payload(
+    snapshot: PublicLeagueSnapshot,
+    section: str,
+    *,
+    activity_valuation: Callable[[dict[str, Any]], float] | None = None,
+) -> dict[str, Any]:
     """Build a single public-section payload, wrapped in the standard header.
+
+    ``activity_valuation`` (optional) enables server-side trade-grade
+    computation on the activity feed.  When supplied it must be a
+    callable that takes a received-asset dict and returns a numeric
+    value; only the derived grade letter/label is emitted — raw
+    values never leave the backend.
 
     Raises ``KeyError`` if ``section`` is unknown.
     """
     if section == OVERVIEW_SECTION:
-        sections = {key: builder(snapshot) for key, builder in _SECTION_BUILDERS.items()}
+        sections: dict[str, Any] = {}
+        for key, builder in _SECTION_BUILDERS.items():
+            if key == "activity":
+                sections[key] = _build_activity_section(snapshot, activity_valuation)
+            else:
+                sections[key] = builder(snapshot)
         section_body = _build_overview(snapshot, sections)
+    elif section == "activity":
+        section_body = _build_activity_section(snapshot, activity_valuation)
     elif section in _SECTION_BUILDERS:
         section_body = _SECTION_BUILDERS[section](snapshot)
     else:
@@ -195,12 +222,22 @@ def build_section_payload(snapshot: PublicLeagueSnapshot, section: str) -> dict[
     return payload
 
 
-def build_public_contract(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
-    """Assemble the full public contract: every section + header."""
+def build_public_contract(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    activity_valuation: Callable[[dict[str, Any]], float] | None = None,
+) -> dict[str, Any]:
+    """Assemble the full public contract: every section + header.
+
+    See ``build_section_payload`` for the ``activity_valuation`` arg.
+    """
     header = _league_header(snapshot)
     sections: dict[str, Any] = {}
     for key, builder in _SECTION_BUILDERS.items():
-        sections[key] = builder(snapshot)
+        if key == "activity":
+            sections[key] = _build_activity_section(snapshot, activity_valuation)
+        else:
+            sections[key] = builder(snapshot)
     sections[OVERVIEW_SECTION] = _build_overview(snapshot, sections)
     payload = {
         "contractVersion": PUBLIC_CONTRACT_VERSION,

--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -220,6 +220,95 @@ class SectionCoverageTests(unittest.TestCase):
             self.assertIn(block, s)
 
 
+class ActivityGradingTests(unittest.TestCase):
+    """Server-side trade grades on the public activity feed.
+
+    Grades mirror the private ``/trades`` page letter grades but the
+    raw values used to compute them never touch the payload — the
+    contract safety assert + blocklist still hold.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        install_stubs(build_stub_client())
+        cls.snapshot = build_public_snapshot("L2025", max_seasons=2)
+
+    def test_activity_feed_has_no_grades_without_valuation(self) -> None:
+        # Regression: default callers (no valuation) keep the pre-existing
+        # contract shape — grades are strictly opt-in.
+        contract = build_public_contract(self.snapshot)
+        feed = contract["sections"]["activity"]["feed"]
+        self.assertGreater(len(feed), 0)
+        for trade in feed:
+            for side in trade.get("sides") or []:
+                self.assertNotIn("grade", side)
+
+    def test_activity_feed_gains_grades_when_valuation_supplied(self) -> None:
+        # Value every "p-rb2" higher than "p-wr2" so the two-player
+        # swap in TRADE_2025_WK3 is lopsided enough to exit the
+        # Fair-trade bucket (pct >= 3).  Picks are valued low so the
+        # pick-swap does not wash out the player edge.
+        player_values = {
+            "p-rb2": 8000.0,
+            "p-wr2": 2000.0,
+            "p-wr3": 1500.0,
+        }
+
+        def _valuation(asset):
+            if not isinstance(asset, dict):
+                return 0.0
+            if asset.get("kind") == "player":
+                return player_values.get(str(asset.get("playerId") or ""), 0.0)
+            if asset.get("kind") == "pick":
+                return 200.0
+            return 0.0
+
+        contract = build_public_contract(
+            self.snapshot, activity_valuation=_valuation,
+        )
+        feed = contract["sections"]["activity"]["feed"]
+        graded_sides = [
+            side for trade in feed for side in (trade.get("sides") or [])
+            if "grade" in side
+        ]
+        # At least the 2025 two-player swap should be graded.
+        self.assertGreater(len(graded_sides), 0)
+        for side in graded_sides:
+            grade = side["grade"]
+            self.assertIn(grade["grade"], {"A", "A-", "A+", "B+", "B", "C", "D", "F"})
+            self.assertIn("label", grade)
+            self.assertIn("color", grade)
+            # Raw values MUST NOT accompany the grade block.
+            self.assertNotIn("weighted", side)
+            self.assertNotIn("totalValue", side)
+
+        # The full contract must still pass the public safety assert
+        # even with grades present — grade/label/color field names are
+        # not on the blocklist.
+        assert_public_payload_safe(contract)
+
+    def test_activity_section_payload_threads_valuation(self) -> None:
+        # The per-section endpoint (/api/public/league/activity) also
+        # honors the optional valuation kwarg.  Uniform player values
+        # + uniform pick values → the 2025 swap is balanced and both
+        # sides land in the "Fair trade" bucket.
+        def _valuation(asset):
+            if isinstance(asset, dict) and asset.get("kind") == "player":
+                return 1000.0
+            return 100.0
+
+        payload = build_section_payload(
+            self.snapshot, "activity", activity_valuation=_valuation,
+        )
+        feed = payload["data"]["feed"]
+        self.assertGreater(len(feed), 0)
+        trade_2025 = next(t for t in feed if t["transactionId"] == "tx-2025-a")
+        grades = [side["grade"]["grade"] for side in trade_2025["sides"]]
+        self.assertEqual(grades, ["A", "A"])
+        labels = {side["grade"]["label"] for side in trade_2025["sides"]}
+        self.assertEqual(labels, {"Fair trade"})
+
+
 class ImportSurfaceTests(unittest.TestCase):
     """Enforce the public pipeline never imports private internals."""
 

--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -287,6 +287,60 @@ class ActivityGradingTests(unittest.TestCase):
         # not on the blocklist.
         assert_public_payload_safe(contract)
 
+    def test_activity_grades_all_sides_fair_when_every_value_is_zero(self) -> None:
+        # When the private contract has no value for any asset in the
+        # trade, grading must still emit a neutral "Fair trade" badge
+        # on every side.  Silently dropping grade blocks here would
+        # inconsistently hide badges on trades full of unranked
+        # assets — the private /trades page treats zero-gap trades
+        # as fair, so this path mirrors that behavior.
+        def _valuation(_asset):
+            return 0.0
+
+        contract = build_public_contract(
+            self.snapshot, activity_valuation=_valuation,
+        )
+        feed = contract["sections"]["activity"]["feed"]
+        self.assertGreater(len(feed), 0)
+        for trade in feed:
+            for side in trade.get("sides") or []:
+                self.assertEqual(side["grade"]["grade"], "A")
+                self.assertEqual(side["grade"]["label"], "Fair trade")
+
+    def test_activity_grades_mark_only_top_and_bottom_in_multi_team(self) -> None:
+        # Simulate a 3-team lopsided trade by valuing the winner's
+        # received assets high, the loser's low, and the middle
+        # side exactly at the winner's total minus a hair so it is
+        # neither max nor min.  The private /trades grading only
+        # decorates the extremes — middle sides get "Fair trade".
+        #
+        # We synthesize this directly against the internal grading
+        # helper so the test doesn't depend on the stub trade feed
+        # having a 3-side transaction.
+        from src.public_league.activity import _apply_trade_grades
+
+        trade = {
+            "transactionId": "synthetic-3way",
+            "sides": [
+                {"receivedAssets": [{"kind": "player", "playerId": "top"}]},
+                {"receivedAssets": [{"kind": "player", "playerId": "mid"}]},
+                {"receivedAssets": [{"kind": "player", "playerId": "bot"}]},
+            ],
+        }
+        values = {"top": 10000.0, "mid": 5000.0, "bot": 100.0}
+
+        def _valuation(asset):
+            return values.get(str(asset.get("playerId") or ""), 0.0)
+
+        _apply_trade_grades([trade], _valuation)
+        grades = [s["grade"]["grade"] for s in trade["sides"]]
+        labels = [s["grade"]["label"] for s in trade["sides"]]
+        # Top-weighted side earns a winner grade (A/A-/A+), bottom
+        # earns a loser grade (B/C/D/F), middle is neutral Fair.
+        self.assertIn(grades[0], {"A", "A-", "A+", "B+"})
+        self.assertEqual(labels[1], "Fair trade")
+        self.assertIn(grades[2], {"B+", "B", "C", "D", "F"})
+
     def test_activity_section_payload_threads_valuation(self) -> None:
         # The per-section endpoint (/api/public/league/activity) also
         # honors the optional valuation kwarg.  Uniform player values


### PR DESCRIPTION
## Summary

- Adds the private `/trades` page letter-grade system (A / A- / A+ / B+ / B / C / D / F with labels like "Fair trade", "Slight win", "Overpay", "Robbery", "Fleeced") to the public `/league` activity trade timeline.
- Player values are **not** exposed — only the derived `{grade, color, label}` block per trade side is emitted.
- Grades are computed server-side in `server.py::_build_public_activity_valuation()` from the cached private contract, then threaded into `build_public_contract` / `build_section_payload` via a new optional `activity_valuation` kwarg. The `src/public_league` package itself still imports no private modules — the existing isolation assertions and public-field blocklist remain intact.
- When the private contract is unavailable (fresh server, scrape failure), the public feed degrades gracefully: no `grade` fields, same shape as before.

## Test plan

- [x] `python -m pytest tests/public_league/` passes (135 passed, 22 skipped)
- [x] New `ActivityGradingTests` cover: default (no valuation) keeps legacy shape; with valuation the feed picks up grades; per-section `activity_valuation` kwarg reaches `activity.build_section`; `assert_public_payload_safe` still passes on graded contracts.
- [ ] Visually confirm A/B/C/D badges appear next to team names on `/league` → Trades tab.

https://claude.ai/code/session_01WpaaTseqwkp2sb227UE5E7