### PR TITLE
Remove blockbusters card; align public grading with private floor-1

### DIFF
--- a/frontend/app/league/sections/activity.jsx
+++ b/frontend/app/league/sections/activity.jsx
@@ -44,16 +44,6 @@ function ActivitySection({ managers, data, onNavigate }) {
         </div>
       </Card>
 
-      {data.biggestBlockbusters && data.biggestBlockbusters.length > 0 && (
-        <Card title="Biggest blockbusters" subtitle="Sorted by total assets moved">
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 10 }}>
-            {data.biggestBlockbusters.map((t) => (
-              <TradeCard key={t.transactionId} trade={t} managers={managers} onNavigate={onNavigate} />
-            ))}
-          </div>
-        </Card>
-      )}
-
       {data.positionMixMoved && Object.keys(data.positionMixMoved).length > 0 && (
         <Card title="Position mix moved" subtitle="Players moved by position in completed trades">
           <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>

--- a/src/public_league/activity.py
+++ b/src/public_league/activity.py
@@ -96,8 +96,15 @@ def _apply_trade_grades(
                     val = float(valuation(asset) or 0.0)
                 except (TypeError, ValueError):
                     val = 0.0
-                if val > 0:
-                    total += pow(max(val, 1.0), _GRADE_ALPHA)
+                # Floor each asset at 1 before raising to alpha so
+                # unranked / unknown assets still contribute the same
+                # ``1**alpha`` floor as the private ``/trades`` grading
+                # path (``analyzeSleeperTradeHistory`` in
+                # ``frontend/lib/league-analysis.js``).  Without this
+                # floor, public grading diverges from private on any
+                # trade containing assets the canonical pipeline can
+                # not value (older seasons, dropped players, etc).
+                total += pow(max(val, 1.0), _GRADE_ALPHA)
             weighted.append(total)
         max_w = max(weighted)
         min_w = min(weighted)

--- a/src/public_league/activity.py
+++ b/src/public_league/activity.py
@@ -23,6 +23,7 @@ Blockbuster tiebreaks (prompt spec):
 """
 from __future__ import annotations
 
+import math
 from collections import Counter, defaultdict
 from typing import Any, Callable
 
@@ -95,6 +96,15 @@ def _apply_trade_grades(
                 try:
                     val = float(valuation(asset) or 0.0)
                 except (TypeError, ValueError):
+                    val = 0.0
+                # Sanitize NaN / inf before exponentiation so a
+                # caller that returns ``float('nan')`` for missing
+                # values (common with dataframe-derived numbers)
+                # cannot poison the per-side total — a NaN here
+                # would propagate through ``max_w``/``min_w``/``pct``
+                # and force every comparison branch to grade
+                # incorrect extremes.
+                if not math.isfinite(val):
                     val = 0.0
                 # Floor each asset at 1 before raising to alpha so
                 # unranked / unknown assets still contribute the same

--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -309,6 +309,40 @@ class ActivityGradingTests(unittest.TestCase):
             self.assertEqual(side["grade"]["grade"], "A")
             self.assertEqual(side["grade"]["label"], "Fair trade")
 
+    def test_activity_grades_sanitize_non_finite_valuation(self) -> None:
+        # A valuation that returns NaN for some assets must not
+        # poison the per-side total — without sanitization NaN
+        # propagates through max/min/pct and grades land on the
+        # extreme winner/loser badges instead of the intended
+        # floor-1 fair behavior.
+        from src.public_league.activity import _apply_trade_grades
+
+        trade = {
+            "transactionId": "synthetic-nan",
+            "sides": [
+                {"receivedAssets": [
+                    {"kind": "player", "playerId": "a"},
+                    {"kind": "player", "playerId": "nan-1"},
+                ]},
+                {"receivedAssets": [
+                    {"kind": "player", "playerId": "b"},
+                    {"kind": "player", "playerId": "nan-2"},
+                ]},
+            ],
+        }
+
+        def _valuation(asset):
+            pid = str(asset.get("playerId") or "")
+            if pid in {"a", "b"}:
+                return 1000.0
+            return float("nan")
+
+        _apply_trade_grades([trade], _valuation)
+        grades = [s["grade"]["grade"] for s in trade["sides"]]
+        labels = [s["grade"]["label"] for s in trade["sides"]]
+        self.assertEqual(grades, ["A", "A"])
+        self.assertEqual(labels, ["Fair trade", "Fair trade"])
+
     def test_activity_grades_mark_only_top_and_bottom_in_multi_team(self) -> None:
         # Simulate a 3-team lopsided trade by valuing the winner's
         # received assets high, the loser's low, and the middle

--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -289,11 +289,14 @@ class ActivityGradingTests(unittest.TestCase):
 
     def test_activity_grades_all_sides_fair_when_every_value_is_zero(self) -> None:
         # When the private contract has no value for any asset in the
-        # trade, grading must still emit a neutral "Fair trade" badge
-        # on every side.  Silently dropping grade blocks here would
-        # inconsistently hide badges on trades full of unranked
-        # assets — the private /trades page treats zero-gap trades
-        # as fair, so this path mirrors that behavior.
+        # trade, grading must still emit badges on every side.  With
+        # the floor-1 contribution that mirrors private grading, a
+        # symmetric trade (both sides got the same asset count) ends
+        # up with identical floor totals → "Fair trade" on every
+        # side.  We pin against the 2025 fixture trade which is
+        # symmetric (1 player + 1 pick per side); the 2024 fixture
+        # is asymmetric and legitimately grades lopsided when the
+        # loser side received nothing.
         def _valuation(_asset):
             return 0.0
 
@@ -301,11 +304,10 @@ class ActivityGradingTests(unittest.TestCase):
             self.snapshot, activity_valuation=_valuation,
         )
         feed = contract["sections"]["activity"]["feed"]
-        self.assertGreater(len(feed), 0)
-        for trade in feed:
-            for side in trade.get("sides") or []:
-                self.assertEqual(side["grade"]["grade"], "A")
-                self.assertEqual(side["grade"]["label"], "Fair trade")
+        trade_2025 = next(t for t in feed if t["transactionId"] == "tx-2025-a")
+        for side in trade_2025["sides"]:
+            self.assertEqual(side["grade"]["grade"], "A")
+            self.assertEqual(side["grade"]["label"], "Fair trade")
 
     def test_activity_grades_mark_only_top_and_bottom_in_multi_team(self) -> None:
         # Simulate a 3-team lopsided trade by valuing the winner's


### PR DESCRIPTION
## Summary

Follow-up to #77.

- **Removes the "Biggest blockbusters" card** from the `/league` Trades tab. Backend still computes `biggestBlockbusters` because the Overview tab's "Hottest trade" derives from it — only the visible card in `frontend/app/league/sections/activity.jsx` was removed.
- **Aligns public grading with private floor-1 contribution.** The private `/trades` page (`analyzeSleeperTradeHistory` in `frontend/lib/league-analysis.js`) raises every asset to `pow(max(safeVal, 1), alpha)`, so unranked / unknown assets contribute a `1**alpha` floor instead of being dropped. The public path now does the same, so the same trade lands in the same bucket on both pages.

## Note on the user-reported "no grades visible"

The screenshot likely shows pre-deploy / SSR-cached content. The `/league/activity` rendering reads `side.grade` directly from the public contract, and `/api/public/league` does build grades when `latest_contract_data` is populated (verified in tests). Worth a hard refresh after this deploys; if the page still shows no badges after cache expiry (~5 min `stale-while-revalidate`), the next investigation is whether `latest_contract_data` is `None` on the production server.

## Test plan

- [x] `python -m pytest tests/public_league/` — 137 passed, 22 skipped
- [ ] Manual verify on `/league` → Trades after deploy: blockbusters card gone, grade badges (A / A- / A+ / B+ / B / C / D / F + label) visible next to team names

https://claude.ai/code/session_01WpaaTseqwkp2sb227UE5E7