### PR TITLE
Diagnostic: surface trade-grading readiness on metrics endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -3370,12 +3370,27 @@ async def get_public_league_metrics():
     NOTE: no private data — just aggregated counters for the cache.
     """
     snap = _public_league_metrics_snapshot()
+    # Diagnostic: is the valuation pipeline wired up right now?  This
+    # only surfaces the boolean — never any private values — and lets
+    # us answer "why are no grades showing on /league activity?" by
+    # hitting one URL.  ``valuationReady=False`` means the public
+    # activity feed will ship without grade badges (no asset value
+    # source available), which is the documented graceful degradation
+    # path; the page itself does not break.
+    valuation_ready = _build_public_activity_valuation() is not None
     return JSONResponse(
         content={
             "leagueId": _public_league_id(),
             "cacheTtlSeconds": _PUBLIC_LEAGUE_CACHE_TTL_SECONDS,
             "warmupEnabled": _PUBLIC_LEAGUE_WARMUP,
             "persistEnabled": _PUBLIC_LEAGUE_PERSIST,
+            "tradeGrading": {
+                "valuationReady": valuation_ready,
+                "privateContractLoaded": latest_contract_data is not None,
+                "privateContractPlayerCount": int(
+                    (latest_contract_data or {}).get("playerCount") or 0
+                ),
+            },
             "metrics": snap,
         },
         headers={"Cache-Control": "no-store"},


### PR DESCRIPTION
## Summary

The user reports no grade badges visible on `/league` activity timeline after #77 + #78 merged. Two likely causes are indistinguishable from outside the box:

1. The cached private contract (`latest_contract_data`) is `None` on the production server, so `_build_public_activity_valuation()` returns `None` and `activity.build_section` skips grading. (Documented graceful-degradation path.)
2. CDN / Next.js SSR / FastAPI `stale-while-revalidate=300` cache is still serving a pre-deploy contract.

This PR adds a `tradeGrading` block to `/api/public/league/metrics` so we can tell which one it is with a single curl:

```jsonc
{
  "tradeGrading": {
    "valuationReady": true|false,
    "privateContractLoaded": true|false,
    "privateContractPlayerCount": 1234
  }
}
```

No private values cross the boundary — only the readiness boolean and the player count `/api/status` already exposes.

## Test plan

- [x] `python -m pytest tests/public_league/` — 138 passed
- [ ] After deploy, hit `https://<host>/api/public/league/metrics` and check the `tradeGrading` block. If `valuationReady` is `false`, we know the issue is upstream (private contract not loaded). If `true`, the issue is cache staleness — `?refresh=1` on `/api/public/league` will force-rebuild.

https://claude.ai/code/session_01WpaaTseqwkp2sb227UE5E7