### PR TITLE
Fix public trade grades: read correct value-bundle key from contract

### DIFF
--- a/server.py
+++ b/server.py
@@ -2959,11 +2959,9 @@ _PUBLIC_LEAGUE_PERSIST = _env_bool("PUBLIC_LEAGUE_PERSIST_SNAPSHOT", True)
 _PUBLIC_LEAGUE_WARMUP = _env_bool("PUBLIC_LEAGUE_WARMUP_AT_STARTUP", True)
 
 
-# Round ordinals used when synthesizing canonical pick names from the
-# ``(season, round)`` the public activity feed carries.  Matches the
-# labels used in ``src/api/data_contract.py`` and the frontend
-# ``frontend/lib/trade-logic.js`` pick candidate builder.
-_PUBLIC_ACTIVITY_ROUND_LABELS = {1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th", 6: "6th"}
+from src.api.public_activity_valuation import (
+    build_valuation_from_contract as _build_valuation_from_contract,
+)
 
 
 def _build_public_activity_valuation():
@@ -2978,118 +2976,13 @@ def _build_public_activity_valuation():
 
     Returns ``None`` when the private contract is unavailable (fresh
     server, scraper failure).  In that case the public activity feed
-    ships without grade annotations, which is the pre-existing
-    behavior.
+    ships without grade annotations.
+
+    The actual contract parsing lives in
+    ``src.api.public_activity_valuation.build_valuation_from_contract``
+    so it can be unit-tested without pulling in FastAPI.
     """
-    contract = latest_contract_data
-    if not contract:
-        return None
-    players_array = contract.get("playersArray") or []
-    if not players_array:
-        return None
-
-    # Alias map authored by the canonical pipeline — redirects generic
-    # tier labels ("2026 Mid 1st") to slot-specific siblings
-    # ("2026 Pick 1.06") when the latter exists.  Normalized to
-    # lowercase so lookups match our tier-candidate probes.
-    raw_aliases = contract.get("pickAliases") or {}
-    pick_aliases: dict[str, str] = {}
-    if isinstance(raw_aliases, dict):
-        for k, v in raw_aliases.items():
-            if isinstance(k, str) and isinstance(v, str):
-                pick_aliases[k.lower()] = v.lower()
-
-    by_id: dict[str, float] = {}
-    by_name: dict[str, float] = {}
-    for row in players_array:
-        if not isinstance(row, dict):
-            continue
-        raw_val = (row.get("values") or {}).get("full")
-        try:
-            val = float(raw_val)
-        except (TypeError, ValueError):
-            continue
-        if val <= 0:
-            continue
-        # Suppressed generic-tier pick rows keep a stale legacy value
-        # for name-search purposes but are NOT authoritative — the
-        # canonical pipeline aliases them to slot-specific siblings.
-        # Excluding them from ``by_name`` ensures our tier probes
-        # either hit the alias redirect or fall through to the real
-        # slot row instead of returning stale tier data.
-        suppressed = bool(row.get("pickGenericSuppressed"))
-        pid = str(row.get("playerId") or "").strip()
-        if pid and not suppressed:
-            by_id[pid] = val
-        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
-        if name and not suppressed:
-            by_name[name.lower()] = val
-
-    if not by_id and not by_name:
-        return None
-
-    # Tier-center slot mapping.  Matches the canonical pipeline's
-    # generic-tier suppression centers and the frontend's
-    # ``TIER_CENTRE_SLOT`` in ``frontend/lib/trade-logic.js``:
-    # Early=2, Mid=6, Late=10.  The public trade feed carries only
-    # ``(season, round)``, so we probe the Mid (tier-center-6) slot
-    # first and fall back to Early/Late centers.
-    _TIER_CENTER_SLOTS = (("Mid", 6), ("Early", 2), ("Late", 10))
-
-    def _resolve(name: str) -> float | None:
-        key = name.lower()
-        # Apply alias redirect first so generic tier labels hop to
-        # their slot-specific siblings before hitting ``by_name``.
-        aliased = pick_aliases.get(key)
-        if aliased is not None:
-            hit = by_name.get(aliased)
-            if hit is not None:
-                return hit
-        return by_name.get(key)
-
-    def _pick_value(season, round_) -> float:
-        try:
-            round_int = int(round_)
-        except (TypeError, ValueError):
-            return 0.0
-        label = _PUBLIC_ACTIVITY_ROUND_LABELS.get(round_int)
-        season_str = str(season or "").strip()
-        if not label or not season_str:
-            return 0.0
-        # Tier labels first (redirected via pickAliases when the
-        # canonical pipeline has a slot-specific sibling), then
-        # slot-specific rows at the canonical tier centers.
-        for tier, _slot in _TIER_CENTER_SLOTS:
-            hit = _resolve(f"{season_str} {tier} {label}")
-            if hit is not None:
-                return hit
-        for _tier, slot in _TIER_CENTER_SLOTS:
-            hit = _resolve(
-                f"{season_str} Pick {round_int}.{slot:02d}"
-            )
-            if hit is not None:
-                return hit
-        return 0.0
-
-    def _valuation(asset) -> float:
-        if not isinstance(asset, dict):
-            return 0.0
-        kind = asset.get("kind")
-        if kind == "player":
-            pid = str(asset.get("playerId") or "").strip()
-            if pid:
-                v = by_id.get(pid)
-                if v is not None:
-                    return v
-            name = str(asset.get("playerName") or "").strip()
-            if name:
-                return by_name.get(name.lower(), 0.0)
-            return 0.0
-        if kind == "pick":
-            return _pick_value(asset.get("season"), asset.get("round"))
-        return 0.0
-
-    return _valuation
+    return _build_valuation_from_contract(latest_contract_data)
 _public_league_cache: dict = {
     "snapshot": None,
     "snapshot_league_id": None,

--- a/src/api/public_activity_valuation.py
+++ b/src/api/public_activity_valuation.py
@@ -1,0 +1,179 @@
+"""Bridge between the private canonical contract and the public
+``/api/public/league`` activity trade-grading pipeline.
+
+The public ``src/public_league`` package is strictly isolated from
+private rankings — it never reads ``latest_contract_data`` directly.
+Instead, ``server.py`` builds a valuation callable out of the cached
+private contract and passes it into
+``src.public_league.activity.build_section``, which uses the callable
+server-side to compute ``{grade, color, label}`` badges for each
+trade side.  The raw values that drive the grade never leave the
+backend — only the derived grade block appears on the public payload.
+
+This module hosts the parser that walks a canonical contract dict
+and returns that callable.  Keeping it outside ``server.py`` lets
+the tests import it without pulling in FastAPI, and pins the
+contract-shape dependency (``values.displayValue`` /
+``values.overall`` / ``values.finalAdjusted`` /
+``values.rawComposite``) so a future rename to the private bundle
+keys can not silently disable public grading.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+# Rounds the public activity feed can emit labels for.  Matches
+# ``_PUBLIC_ACTIVITY_ROUND_LABELS`` in ``server.py`` and the round
+# labels used by ``src/api/data_contract.py`` / the frontend pick
+# candidate builder.
+_ROUND_LABELS: dict[int, str] = {
+    1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th", 6: "6th",
+}
+
+
+# Tier-center slot mapping — matches the canonical pipeline's
+# generic-tier suppression centers and the frontend's
+# ``TIER_CENTRE_SLOT`` in ``frontend/lib/trade-logic.js``: Early=2,
+# Mid=6, Late=10.  The public activity feed only carries
+# ``(season, round)`` so we probe the Mid center first.
+_TIER_CENTER_SLOTS: tuple[tuple[str, int], ...] = (
+    ("Mid", 6),
+    ("Early", 2),
+    ("Late", 10),
+)
+
+
+def _value_from_bundle(bundle: dict[str, Any]) -> float:
+    """Mirror the frontend ``inferValueBundle`` (1-9999 preferred,
+    calibrated fallback) against the backend contract keys.
+
+    Frontend fallback chain (``frontend/lib/dynasty-data.js``):
+        _canonicalDisplayValue || _finalAdjusted || _composite || raw
+
+    Contract equivalents (``src/api/data_contract.py``):
+        values.displayValue  ← _canonicalDisplayValue
+        values.finalAdjusted ← _finalAdjusted / _composite
+        values.overall       ← values.finalAdjusted (mirror)
+        values.rawComposite  ← _rawComposite / _rawMarketValue / _composite
+
+    Returns 0.0 when no numeric value is available.
+    """
+    if not isinstance(bundle, dict):
+        return 0.0
+    for key in ("displayValue", "overall", "finalAdjusted", "rawComposite"):
+        raw = bundle.get(key)
+        try:
+            val = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if val > 0:
+            return val
+    return 0.0
+
+
+def build_valuation_from_contract(
+    contract: dict[str, Any] | None,
+) -> Callable[[dict[str, Any]], float] | None:
+    """Build a ``(asset_dict) -> float`` valuation callable from the
+    cached canonical contract.
+
+    Returns ``None`` when the contract is empty or the players array
+    has no rows carrying a positive value — ``activity.build_section``
+    treats ``None`` as the "grading disabled" signal and ships the
+    public feed without grade badges (graceful degradation path).
+
+    The callable is safe to hand to
+    ``public_league.activity.build_section(... valuation=...)``: it
+    accepts the public trade-side received-asset shape
+    (``{kind: "player"|"pick", playerId, playerName, position,
+    season, round, ...}``) and returns a numeric value.  Neither the
+    callable nor its source values is ever serialized into the
+    public payload.
+    """
+    if not contract:
+        return None
+    players_array = contract.get("playersArray") or []
+    if not players_array:
+        return None
+
+    raw_aliases = contract.get("pickAliases") or {}
+    pick_aliases: dict[str, str] = {}
+    if isinstance(raw_aliases, dict):
+        for k, v in raw_aliases.items():
+            if isinstance(k, str) and isinstance(v, str):
+                pick_aliases[k.lower()] = v.lower()
+
+    by_id: dict[str, float] = {}
+    by_name: dict[str, float] = {}
+    for row in players_array:
+        if not isinstance(row, dict):
+            continue
+        val = _value_from_bundle(row.get("values") or {})
+        if val <= 0:
+            continue
+        # Suppressed generic-tier pick rows keep a stale legacy value
+        # for name-search purposes but are NOT authoritative — the
+        # canonical pipeline aliases them to slot-specific siblings.
+        # Exclude them so our tier probes either hit the alias
+        # redirect or fall through to the real slot row.
+        suppressed = bool(row.get("pickGenericSuppressed"))
+        if suppressed:
+            continue
+        pid = str(row.get("playerId") or "").strip()
+        if pid:
+            by_id[pid] = val
+        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
+        if name:
+            by_name[name.lower()] = val
+
+    if not by_id and not by_name:
+        return None
+
+    def _resolve(name: str) -> float | None:
+        key = name.lower()
+        aliased = pick_aliases.get(key)
+        if aliased is not None:
+            hit = by_name.get(aliased)
+            if hit is not None:
+                return hit
+        return by_name.get(key)
+
+    def _pick_value(season: Any, round_: Any) -> float:
+        try:
+            round_int = int(round_)
+        except (TypeError, ValueError):
+            return 0.0
+        label = _ROUND_LABELS.get(round_int)
+        season_str = str(season or "").strip()
+        if not label or not season_str:
+            return 0.0
+        for tier, _slot in _TIER_CENTER_SLOTS:
+            hit = _resolve(f"{season_str} {tier} {label}")
+            if hit is not None:
+                return hit
+        for _tier, slot in _TIER_CENTER_SLOTS:
+            hit = _resolve(f"{season_str} Pick {round_int}.{slot:02d}")
+            if hit is not None:
+                return hit
+        return 0.0
+
+    def _valuation(asset: Any) -> float:
+        if not isinstance(asset, dict):
+            return 0.0
+        kind = asset.get("kind")
+        if kind == "player":
+            pid = str(asset.get("playerId") or "").strip()
+            if pid:
+                hit = by_id.get(pid)
+                if hit is not None:
+                    return hit
+            name = str(asset.get("playerName") or "").strip()
+            if name:
+                return by_name.get(name.lower(), 0.0)
+            return 0.0
+        if kind == "pick":
+            return _pick_value(asset.get("season"), asset.get("round"))
+        return 0.0
+
+    return _valuation

--- a/tests/api/test_public_activity_valuation.py
+++ b/tests/api/test_public_activity_valuation.py
@@ -1,0 +1,195 @@
+"""Tests for the bridge between the private canonical contract and
+the public ``/api/public/league`` activity trade-grading pipeline.
+
+Pins the contract-shape dependency — specifically that the valuation
+walks ``values.displayValue`` / ``values.overall`` /
+``values.finalAdjusted`` / ``values.rawComposite`` against the
+contract ``playersArray`` rows, and NOT a ``values.full`` key (which
+is a frontend-only rename).  An earlier version of this bridge
+assumed ``values.full`` and silently disabled public trade grading
+in production; this test would have caught that immediately.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.api.public_activity_valuation import build_valuation_from_contract
+
+
+class BuildValuationFromContractTests(unittest.TestCase):
+    def test_returns_none_when_contract_missing(self) -> None:
+        self.assertIsNone(build_valuation_from_contract(None))
+        self.assertIsNone(build_valuation_from_contract({}))
+        self.assertIsNone(build_valuation_from_contract({"playersArray": []}))
+
+    def test_returns_none_when_every_row_has_no_value(self) -> None:
+        # A contract full of rows whose value bundles are all zero /
+        # missing must degrade gracefully rather than returning a
+        # valuation that always resolves to 0.
+        contract = {
+            "playersArray": [
+                {"playerId": "p1", "displayName": "A", "values": {}},
+                {"playerId": "p2", "displayName": "B", "values": {"displayValue": 0}},
+                {"playerId": "p3", "displayName": "C", "values": {"displayValue": None}},
+            ],
+        }
+        self.assertIsNone(build_valuation_from_contract(contract))
+
+    def test_reads_display_value_preferred_over_overall(self) -> None:
+        # Regression: the backend contract's ``values`` bundle uses
+        # ``displayValue`` / ``overall`` / ``finalAdjusted`` /
+        # ``rawComposite``.  A previous bug read ``values.full`` (a
+        # frontend-only rename) and returned None for every asset,
+        # silently disabling grading in production.  Here we assert
+        # the 1–9999 ``displayValue`` is the primary source, matching
+        # the frontend ``inferValueBundle`` fallback chain.
+        contract = {
+            "playersArray": [
+                {
+                    "playerId": "sleeper-1",
+                    "displayName": "Josh Allen",
+                    "values": {
+                        "displayValue": 9500,
+                        "overall": 8200,
+                        "finalAdjusted": 8200,
+                        "rawComposite": 8100,
+                    },
+                },
+            ],
+        }
+        valuation = build_valuation_from_contract(contract)
+        self.assertIsNotNone(valuation)
+        self.assertEqual(
+            valuation({"kind": "player", "playerId": "sleeper-1"}),
+            9500.0,
+        )
+
+    def test_falls_back_through_value_bundle_keys(self) -> None:
+        # If ``displayValue`` is missing / zero, the resolver walks
+        # ``overall`` → ``finalAdjusted`` → ``rawComposite`` in the
+        # same order the frontend ``inferValueBundle`` fallback uses.
+        contract = {
+            "playersArray": [
+                {
+                    "playerId": "fallback-overall",
+                    "displayName": "A",
+                    "values": {"displayValue": 0, "overall": 4200},
+                },
+                {
+                    "playerId": "fallback-final",
+                    "displayName": "B",
+                    "values": {"finalAdjusted": 3100},
+                },
+                {
+                    "playerId": "fallback-raw",
+                    "displayName": "C",
+                    "values": {"rawComposite": 2500},
+                },
+            ],
+        }
+        valuation = build_valuation_from_contract(contract)
+        self.assertIsNotNone(valuation)
+        self.assertEqual(
+            valuation({"kind": "player", "playerId": "fallback-overall"}),
+            4200.0,
+        )
+        self.assertEqual(
+            valuation({"kind": "player", "playerId": "fallback-final"}),
+            3100.0,
+        )
+        self.assertEqual(
+            valuation({"kind": "player", "playerId": "fallback-raw"}),
+            2500.0,
+        )
+
+    def test_falls_back_to_player_name_when_id_misses(self) -> None:
+        contract = {
+            "playersArray": [
+                {
+                    "playerId": "real-id",
+                    "displayName": "Jahmyr Gibbs",
+                    "values": {"displayValue": 7500},
+                },
+            ],
+        }
+        valuation = build_valuation_from_contract(contract)
+        self.assertIsNotNone(valuation)
+        # ID miss → name fallback (case-insensitive).
+        self.assertEqual(
+            valuation({
+                "kind": "player",
+                "playerId": "unknown-id",
+                "playerName": "Jahmyr Gibbs",
+            }),
+            7500.0,
+        )
+        self.assertEqual(
+            valuation({
+                "kind": "player",
+                "playerId": "",
+                "playerName": "JAHMYR GIBBS",
+            }),
+            7500.0,
+        )
+
+    def test_pick_value_probes_tier_centers(self) -> None:
+        contract = {
+            "playersArray": [
+                {
+                    "displayName": "2026 Mid 1st",
+                    "values": {"displayValue": 6000},
+                },
+            ],
+        }
+        valuation = build_valuation_from_contract(contract)
+        self.assertIsNotNone(valuation)
+        self.assertEqual(
+            valuation({"kind": "pick", "season": "2026", "round": 1}),
+            6000.0,
+        )
+
+    def test_pick_value_honors_pick_aliases(self) -> None:
+        # Canonical-pipeline authored aliases redirect generic tier
+        # labels to slot-specific siblings — the resolver must apply
+        # the alias before hitting the name map, otherwise picks
+        # would resolve to stale suppressed-tier values (or zero).
+        contract = {
+            "pickAliases": {"2026 Mid 1st": "2026 Pick 1.06"},
+            "playersArray": [
+                {
+                    "displayName": "2026 Pick 1.06",
+                    "values": {"displayValue": 7200},
+                },
+                # Suppressed tier row is intentionally present to
+                # confirm the resolver does NOT return its stale
+                # value — it must follow the alias to the slot row.
+                {
+                    "displayName": "2026 Mid 1st",
+                    "pickGenericSuppressed": True,
+                    "values": {"displayValue": 99},
+                },
+            ],
+        }
+        valuation = build_valuation_from_contract(contract)
+        self.assertIsNotNone(valuation)
+        self.assertEqual(
+            valuation({"kind": "pick", "season": "2026", "round": 1}),
+            7200.0,
+        )
+
+    def test_unknown_asset_returns_zero(self) -> None:
+        contract = {
+            "playersArray": [
+                {"playerId": "p1", "displayName": "A", "values": {"displayValue": 100}},
+            ],
+        }
+        valuation = build_valuation_from_contract(contract)
+        self.assertIsNotNone(valuation)
+        self.assertEqual(valuation({"kind": "player", "playerId": "unknown"}), 0.0)
+        self.assertEqual(valuation({"kind": "pick", "season": "2099", "round": 1}), 0.0)
+        self.assertEqual(valuation({"kind": "other"}), 0.0)
+        self.assertEqual(valuation(None), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`/api/public/league/metrics` showed:
```json
"tradeGrading": {
  "valuationReady": false,
  "privateContractLoaded": true,
  "privateContractPlayerCount": 1083
}
```

1083 players loaded but valuation disabled. Root cause: `_build_public_activity_valuation` was reading `row.values.full`, but `values.full` is a **frontend-only** key name synthesized by `inferValueBundle` in `frontend/lib/dynasty-data.js`. The backend contract's `values` bundle (see `src/api/data_contract.py::_player_value_bundle`) uses `displayValue` / `overall` / `finalAdjusted` / `rawComposite` — no `full` key exists. Every `playersArray` row silently resolved to 0, `by_id` / `by_name` stayed empty, the valuation callable returned `None`, and `activity.build_section` skipped grading.

## The fix

- Read the correct keys: `displayValue` (1–9999 preferred) → `overall` → `finalAdjusted` → `rawComposite`, mirroring the frontend `inferValueBundle` fallback chain.
- Extracted the builder into `src/api/public_activity_valuation.py` so the contract-shape dependency is unit-testable without FastAPI. `server.py` becomes a thin wrapper over the new helper.
- Added `tests/api/test_public_activity_valuation.py` pinning the contract shape, fallback order, `playerName` fallback, pick tier-center probing, and `pickAliases` redirection. The `displayValue`-over-`overall` regression test would have caught the original bug.

## Test plan

- [x] `python -m pytest tests/api/test_public_activity_valuation.py tests/public_league/` — 146 passed, 22 skipped
- [ ] After deploy, hit `/api/public/league/metrics` and confirm `valuationReady: true`
- [ ] Hit `/league` → Trades and confirm A/A-/A+/B+/B/C/D/F badges appear next to team names

https://claude.ai/code/session_01WpaaTseqwkp2sb227UE5E7