### PR TITLE
Bump stud exponent to 1.65 + fix mobile e2e tab switching

### DIFF
--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -25,7 +25,7 @@ const VERDICT_STRONG_LEAN = 1800;
 // ── Power-Weighted Calculation ───────────────────────────────────────────
 // Alpha exponent concentrates value at the top — a star + role player is
 // worth more than two mid-tier pieces.  Matches static calculator exactly.
-export const TRADE_ALPHA = 1.45;
+export const TRADE_ALPHA = 1.65;
 
 // ── Pick Year Discount ──────────────────────────────────────────────────
 // Future-year picks are worth less than current-year picks.

--- a/src/public_league/activity.py
+++ b/src/public_league/activity.py
@@ -45,7 +45,7 @@ NOTABLE_POSITIONS = OFFENSIVE_CORE | {"DL", "LB", "DB", "EDGE"}
 # ``{grade, color, label}`` object is emitted on the public
 # payload — the raw values and per-side totals NEVER leave the
 # backend.
-_GRADE_ALPHA = 1.45
+_GRADE_ALPHA = 1.65
 _GRADE_PCT_FAIR = 3.0
 _GRADE_PCT_SLIGHT = 8.0
 _GRADE_PCT_GOOD = 15.0

--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -66,9 +66,17 @@ test.describe("public /league page", () => {
       waitForText: "At a glance",
     });
 
+    // On mobile (≤768px) the tab row is hidden and sections are selected
+    // via a <select> dropdown; on desktop, each tab is a <button>.  Detect
+    // which control is currently visible and drive it accordingly.
+    const mobileSelect = page.getByLabel("Select league section");
+    const useMobile = await mobileSelect.isVisible().catch(() => false);
     for (const label of TABS) {
-      const btn = page.getByRole("button", { name: label, exact: true }).first();
-      await btn.click();
+      if (useMobile) {
+        await mobileSelect.selectOption({ label });
+      } else {
+        await page.getByRole("button", { name: label, exact: true }).first().click();
+      }
       await page.waitForTimeout(150);
     }
 


### PR DESCRIPTION
## Summary
- Bump trade alpha from 1.45 → 1.65 on both the private frontend (`frontend/lib/trade-logic.js::TRADE_ALPHA`) and the public `/league` activity grader (`src/public_league/activity.py::_GRADE_ALPHA`) — they mirror each other by design so private and public trade grades stay in the same bucket.
- Higher alpha concentrates value at the top: one stud outweighs multiple mid-tier pieces by a larger margin.
- Unbreaks the `mobile-chromium` smoke test in `tests/e2e/specs/public-league.spec.js`: `/league` renders tabs as a `<select>` on ≤768px and as `<button>`s on desktop, so the "switch every tab" loop now drives whichever control is visible instead of blindly clicking buttons that are CSS-hidden on mobile.

## Test plan
- [x] `python3 -m pytest tests/public_league/ -q` (160 passed)
- [x] Playwright `public-league` spec on both `desktop-1366` and `mobile-chromium` projects (both passing)
- [ ] CI pr-validation + smoke-test workflows green

🤖 Generated with [Claude Code](https://claude.com/claude-code)