### PR TITLE
Mirror KTC's Value Adjustment in the Trade Calculator

### DIFF
--- a/frontend/__tests__/trade-logic.test.js
+++ b/frontend/__tests__/trade-logic.test.js
@@ -10,9 +10,13 @@ import {
   verdictFromGap,
   colorFromGap,
   sideTotal,
-  tradeGap,
-  linearGap,
-  powerWeightedTotal,
+  computeValueAdjustment,
+  adjustedSideTotals,
+  tradeGapAdjusted,
+  VA_SCARCITY_SLOPE,
+  VA_SCARCITY_INTERCEPT,
+  VA_SCARCITY_CAP,
+  VA_POSITION_DECAY,
   effectiveValue,
   pickYearDiscount,
   addAssetToSide,
@@ -148,32 +152,153 @@ describe("sideTotal", () => {
   });
 });
 
-// ── tradeGap ─────────────────────────────────────────────────────────
+// ── tradeGapAdjusted ─────────────────────────────────────────────────
 
-describe("tradeGap (power-weighted)", () => {
-  it("single-asset sides equal linear gap", () => {
-    // With one asset per side, power-weighted = linear
-    expect(tradeGap([ALLEN], [CHASE], "full")).toBe(500);
-    expect(tradeGap([CHASE], [ALLEN], "full")).toBe(-500);
+describe("tradeGapAdjusted (KTC-style)", () => {
+  it("single vs single equals linear gap (no VA)", () => {
+    expect(tradeGapAdjusted([ALLEN], [CHASE], "full")).toBe(500);
+    expect(tradeGapAdjusted([CHASE], [ALLEN], "full")).toBe(-500);
   });
 
-  it("multi-asset sides are power-weighted (less than linear sum)", () => {
-    const gap = tradeGap([ALLEN], [CHASE, PICK_2026], "full");
-    const linGapVal = linearGap([ALLEN], [CHASE, PICK_2026], "full");
-    // Power-weighted sum of B < linear sum, so gap magnitude is smaller
-    expect(linGapVal).toBe(9000 - (8500 + 7000));
-    expect(Math.abs(gap)).toBeLessThan(Math.abs(linGapVal));
-    expect(gap).toBeLessThan(0); // B still wins
+  it("1-vs-2 with dominant single asset closes the linear gap", () => {
+    // Stud (9999) vs Mid (6000) + Pick (5000) — gapRatio is big enough to
+    // trigger a meaningful VA that narrows the raw gap.
+    const stud = mockRow(9999);
+    const mid = mockRow(6000);
+    const pick = mockRow(5000);
+    const rawGap = 9999 - (6000 + 5000);
+    const gap = tradeGapAdjusted([stud], [mid, pick], "full");
+    expect(rawGap).toBe(-1001);
+    expect(gap).toBeGreaterThan(rawGap); // VA added to single side → less negative
+  });
+
+  it("1-vs-2 with near-matching top assets produces no VA (clamped scarcity)", () => {
+    // When the small side's top is only marginally better than the multi's
+    // top, scarcity clamps to 0 and the adjusted gap equals the raw gap.
+    const gap = tradeGapAdjusted([ALLEN], [CHASE, PICK_2026], "full");
+    const rawGap = 9000 - (8500 + 7000);
+    expect(gap).toBe(rawGap);
   });
 
   it("returns 0 for empty vs empty", () => {
-    expect(tradeGap([], [], "full")).toBe(0);
+    expect(tradeGapAdjusted([], [], "full")).toBe(0);
   });
 });
 
-describe("linearGap", () => {
-  it("computes simple difference", () => {
-    expect(linearGap([ALLEN], [CHASE, PICK_2026], "full")).toBe(9000 - (8500 + 7000));
+// ── computeValueAdjustment ───────────────────────────────────────────
+
+function mockRow(value) {
+  return { name: `P${value}`, pos: "QB", assetClass: "offense", values: { full: value, raw: value } };
+}
+
+describe("computeValueAdjustment", () => {
+  it("returns zero adjustment when piece counts match", () => {
+    const result = computeValueAdjustment([ALLEN], [CHASE], "full");
+    expect(result).toEqual({ adjustment: 0, recipientIdx: null });
+    const result2 = computeValueAdjustment([ALLEN, CHASE], [MAHOMES, PICK_2026], "full");
+    expect(result2).toEqual({ adjustment: 0, recipientIdx: null });
+  });
+
+  it("returns zero when either side is empty", () => {
+    const r = computeValueAdjustment([], [CHASE, PICK_2026], "full");
+    expect(r).toEqual({ adjustment: 0, recipientIdx: null });
+  });
+
+  it("recipientIdx points at the smaller-piece side", () => {
+    const r1 = computeValueAdjustment([ALLEN], [CHASE, PICK_2026], "full");
+    expect(r1.recipientIdx).toBe(0);
+    const r2 = computeValueAdjustment([CHASE, PICK_2026], [ALLEN], "full");
+    expect(r2.recipientIdx).toBe(1);
+  });
+
+  it("applies zero VA when multi side has the better top asset", () => {
+    // single=CHASE (8500) vs multi=[ALLEN (9000), PICK_2026 (7000)]
+    // gapRatio = max(0, (8500-9000)/8500) = 0
+    // scarcity = max(0, slope*0 - intercept) = 0 → no VA
+    const r = computeValueAdjustment([CHASE], [ALLEN, PICK_2026], "full");
+    expect(r.adjustment).toBe(0);
+    expect(r.recipientIdx).toBe(0);
+  });
+
+  it("applies depth decay for multiple extra pieces", () => {
+    // single=9999 vs [7000, 5000, 3000] (2 extras: 5000 at p=0, 3000 at p=1)
+    const single = [mockRow(9999)];
+    const multi = [mockRow(7000), mockRow(5000), mockRow(3000)];
+    const r = computeValueAdjustment(single, multi, "full");
+    const gapRatio = (9999 - 7000) / 9999;
+    const scarcity = Math.min(
+      VA_SCARCITY_CAP,
+      Math.max(0, VA_SCARCITY_SLOPE * gapRatio - VA_SCARCITY_INTERCEPT),
+    );
+    const expected =
+      5000 * scarcity * Math.pow(VA_POSITION_DECAY, 0) +
+      3000 * scarcity * Math.pow(VA_POSITION_DECAY, 1);
+    expect(r.adjustment).toBeCloseTo(expected, 5);
+    expect(r.recipientIdx).toBe(0);
+  });
+
+  // Pinned KTC-observed data points — regression anchors for the fitted
+  // coefficients.  Tolerance is ±5% (or ±100, whichever is larger) to
+  // allow for small coefficient refinements without breaking every test.
+  describe("KTC-observed cases", () => {
+    const KTC_TOLERANCE = (ktcVA) => Math.max(100, Math.abs(ktcVA) * 0.05);
+
+    it("9999 vs 7846+5717 → ~3712", () => {
+      const r = computeValueAdjustment(
+        [mockRow(9999)],
+        [mockRow(7846), mockRow(5717)],
+        "full",
+      );
+      expect(r.recipientIdx).toBe(0);
+      expect(Math.abs(r.adjustment - 3712)).toBeLessThanOrEqual(KTC_TOLERANCE(3712));
+    });
+
+    it("7846 vs 5717+4829 → ~3034", () => {
+      const r = computeValueAdjustment(
+        [mockRow(7846)],
+        [mockRow(5717), mockRow(4829)],
+        "full",
+      );
+      expect(r.recipientIdx).toBe(0);
+      expect(Math.abs(r.adjustment - 3034)).toBeLessThanOrEqual(KTC_TOLERANCE(3034));
+    });
+
+    it("7846 vs 6949+5717 → ~1166 (small premium when top assets are close)", () => {
+      const r = computeValueAdjustment(
+        [mockRow(7846)],
+        [mockRow(6949), mockRow(5717)],
+        "full",
+      );
+      expect(r.recipientIdx).toBe(0);
+      expect(Math.abs(r.adjustment - 1166)).toBeLessThanOrEqual(KTC_TOLERANCE(1166));
+    });
+  });
+});
+
+// ── adjustedSideTotals ───────────────────────────────────────────────
+
+describe("adjustedSideTotals", () => {
+  it("both sides have raw/adjustment/adjusted with matching invariants", () => {
+    // Use a big enough concentration gap so the smaller side gets a VA.
+    const stud = mockRow(9999);
+    const mid = mockRow(6000);
+    const pick = mockRow(5000);
+    const [a, b] = adjustedSideTotals([stud], [mid, pick], "full");
+    expect(a.raw).toBe(9999);
+    expect(b.raw).toBe(6000 + 5000);
+    expect(a.adjusted).toBe(a.raw + a.adjustment);
+    expect(b.adjusted).toBe(b.raw + b.adjustment);
+    // Only the smaller side gets a bonus
+    expect(b.adjustment).toBe(0);
+    expect(a.adjustment).toBeGreaterThan(0);
+  });
+
+  it("equal piece counts produce zero adjustments on both sides", () => {
+    const [a, b] = adjustedSideTotals([ALLEN, CHASE], [MAHOMES, PICK_2026], "full");
+    expect(a.adjustment).toBe(0);
+    expect(b.adjustment).toBe(0);
+    expect(a.adjusted).toBe(a.raw);
+    expect(b.adjusted).toBe(b.raw);
   });
 });
 
@@ -400,29 +525,32 @@ describe("full trade scenario", () => {
     // Compute
     const totalA = sideTotal(sideA, "full"); // 9000 + 8500 = 17500
     const totalB = sideTotal(sideB, "full"); // 8800 + 7000 = 15800
-    const gap = tradeGap(sideA, sideB, "full"); // power-weighted
+    const gap = tradeGapAdjusted(sideA, sideB, "full");
 
     expect(totalA).toBe(17500);
     expect(totalB).toBe(15800);
-    // Power-weighted gap is smaller than linear (1700) due to diminishing returns
-    expect(gap).toBeGreaterThan(0); // A still wins
-    expect(gap).toBeLessThan(1700); // But less than linear
+    // Equal piece counts → no VA, gap equals linear difference (1700).
+    expect(gap).toBe(1700);
     expect(verdictFromGap(gap)).toBe("Strong lean");
     expect(colorFromGap(gap)).toBe("green"); // Side A wins
 
     // Swap sides
     const [newA, newB] = [sideB, sideA];
-    const swappedGap = tradeGap(newA, newB, "full");
-    expect(swappedGap).toBeLessThan(0);
+    const swappedGap = tradeGapAdjusted(newA, newB, "full");
+    expect(swappedGap).toBe(-1700);
     expect(verdictFromGap(swappedGap)).toBe("Strong lean");
     expect(colorFromGap(swappedGap)).toBe("red"); // Now Side B wins
 
-    // Remove an asset
+    // Remove an asset — newA now has 2 pieces (8800+7000), trimmedB has 1 (9000)
     const trimmedB = removeAssetFromSide(newB, "Ja'Marr Chase");
-    const newGap = tradeGap(newA, trimmedB, "full");
-    // Power-weighted: B (8800+7000) vs A (9000). Gap is positive (B side wins after swap)
-    expect(newGap).toBeGreaterThan(0);
-    expect(newGap).toBeLessThan(15800 - 9000); // less than linear 6800
+    const newGap = tradeGapAdjusted(newA, trimmedB, "full");
+    // trimmedB's top (9000) is only 2.2% better than newA's top (8800), so
+    // gapRatio is below the scarcity intercept and VA clamps to 0 — the
+    // adjusted gap equals the raw gap here.  The near-matching-tops test
+    // above pins this behavior explicitly.
+    const rawNewGap = (8800 + 7000) - 9000;
+    expect(rawNewGap).toBe(6800);
+    expect(newGap).toBe(rawNewGap);
 
     // Serialize and restore
     const serialized = serializeWorkspace(newA, trimmedB, "full", "A");
@@ -435,26 +563,7 @@ describe("full trade scenario", () => {
     const restored = deserializeWorkspace(serialized, rowByName);
     expect(restored.sideA.length).toBe(2);
     expect(restored.sideB.length).toBe(1);
-    expect(tradeGap(restored.sideA, restored.sideB, "full")).toBe(newGap);
-  });
-});
-
-// ── New features: power-weighted, edge, pick parsing ──
-
-describe("powerWeightedTotal", () => {
-  it("single asset approximately equals its value", () => {
-    expect(powerWeightedTotal([ALLEN], "full")).toBeCloseTo(9000, 0);
-  });
-
-  it("multiple assets yield less than linear sum", () => {
-    const pw = powerWeightedTotal([ALLEN, CHASE], "full");
-    const linear = 9000 + 8500;
-    expect(pw).toBeLessThan(linear);
-    expect(pw).toBeGreaterThan(9000); // more than single best
-  });
-
-  it("empty array returns 0", () => {
-    expect(powerWeightedTotal([], "full")).toBe(0);
+    expect(tradeGapAdjusted(restored.sideA, restored.sideB, "full")).toBe(newGap);
   });
 });
 
@@ -699,14 +808,6 @@ describe("effectiveValue", () => {
   it("returns raw value with settings (no adjustment)", () => {
     const settings = { leagueFormat: "superflex" };
     expect(effectiveValue(ALLEN, "full", settings)).toBe(9000);
-  });
-});
-
-describe("settings-aware powerWeightedTotal", () => {
-  it("settings=null behaves like no settings", () => {
-    const a = powerWeightedTotal([ALLEN, CHASE], "full");
-    const b = powerWeightedTotal([ALLEN, CHASE], "full", undefined, null);
-    expect(a).toBe(b);
   });
 });
 
@@ -1067,13 +1168,6 @@ describe("deserializeWorkspaceMulti", () => {
 // ── Multi-team total calculations ──────────────────────────────────────
 
 describe("multi-team total calculations", () => {
-  it("powerWeightedTotal works for any side array", () => {
-    const sideAssets = [ALLEN, CHASE, PARSONS];
-    const total = powerWeightedTotal(sideAssets, "full");
-    expect(total).toBeGreaterThan(0);
-    expect(total).toBeLessThan(9000 + 8500 + 5000); // less than linear
-  });
-
   it("sideTotal works for 3+ sides independently", () => {
     const totals = [
       sideTotal([ALLEN], "full"),

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -10,7 +10,8 @@ import {
   verdictFromGap,
   colorFromGap,
   verdictBarPosition,
-  powerWeightedTotal,
+  adjustedSideTotals,
+  tradeGapAdjusted,
   sideTotal,
   effectiveValue,
   getPlayerEdge,
@@ -76,8 +77,8 @@ function TradeMeter({ sides, sideTotals, valueMode, settings }) {
 }
 
 function TradeMeterTwoTeam({ sides, sideTotals }) {
-  const pwA = sideTotals[0]?.pw || 0;
-  const pwB = sideTotals[1]?.pw || 0;
+  const pwA = sideTotals[0]?.adjusted || 0;
+  const pwB = sideTotals[1]?.adjusted || 0;
   const gap = pwA - pwB;
   const absGap = Math.abs(gap);
   const pctGap = percentageGap(pwA, pwB);
@@ -136,7 +137,7 @@ function TradeMeterTwoTeam({ sides, sideTotals }) {
 }
 
 function TradeMeterMultiTeam({ sides, sideTotals }) {
-  const totals = sideTotals.map((t) => t.pw);
+  const totals = sideTotals.map((t) => t.adjusted);
   const analysis = multiTeamAnalysis(totals);
   const grandTotal = totals.reduce((a, b) => a + b, 0);
 
@@ -299,18 +300,25 @@ export default function TradePage() {
   }, [pickerOpen]);
 
   // ── Computed totals for all sides ────────────────────────────────────
+  // 2-team mode uses KTC-style Value Adjustment: the side with fewer pieces
+  // gets a consolidation premium (see trade-logic.js).  3+ teams fall back
+  // to raw linear totals until we design a multi-team VA extension.
   const sideTotals = useMemo(() => {
-    return sides.map((s) => ({
-      pw: powerWeightedTotal(s.assets, valueMode, undefined, settings),
-      lin: sideTotal(s.assets, valueMode, settings),
-    }));
+    if (sides.length === 2) {
+      const [a, b] = adjustedSideTotals(sides[0].assets, sides[1].assets, valueMode, settings);
+      return [a, b];
+    }
+    return sides.map((s) => {
+      const raw = sideTotal(s.assets, valueMode, settings);
+      return { raw, adjustment: 0, adjusted: raw };
+    });
   }, [sides, valueMode, settings]);
 
   // Legacy 2-team gap computations (for sticky tray + 2-team balancers)
-  const pwTotalA = sideTotals[0]?.pw || 0;
-  const pwTotalB = sideTotals[1]?.pw || 0;
-  const linTotalA = sideTotals[0]?.lin || 0;
-  const linTotalB = sideTotals[1]?.lin || 0;
+  const pwTotalA = sideTotals[0]?.adjusted || 0;
+  const pwTotalB = sideTotals[1]?.adjusted || 0;
+  const linTotalA = sideTotals[0]?.raw || 0;
+  const linTotalB = sideTotals[1]?.raw || 0;
   const pwGap = pwTotalA - pwTotalB;
   const pctGap = Math.max(pwTotalA, pwTotalB) > 0 ? Math.round(Math.abs(pwGap) / Math.max(pwTotalA, pwTotalB) * 100) : 0;
 
@@ -326,7 +334,7 @@ export default function TradePage() {
   // For 3+ teams, find balancers for the team overpaying
   const multiBalancers = useMemo(() => {
     if (sides.length <= 2) return null;
-    const totals = sideTotals.map((t) => t.pw);
+    const totals = sideTotals.map((t) => t.adjusted);
     const maxIdx = totals.indexOf(Math.max(...totals));
     const minIdx = totals.indexOf(Math.min(...totals));
     const gap = totals[maxIdx] - totals[minIdx];
@@ -586,7 +594,7 @@ export default function TradePage() {
           {/* ── Side Cards ──────────────────────────────────────── */}
           <div className={sidesGridClass} style={{ paddingBottom: 78 }}>
             {sides.map((side, sideIdx) => {
-              const total = sideTotals[sideIdx] || { pw: 0, lin: 0 };
+              const total = sideTotals[sideIdx] || { raw: 0, adjustment: 0, adjusted: 0 };
               const isOverpaying = sides.length === 2
                 ? (sideIdx === 0 ? pwGap > 350 : pwGap < -350)
                 : false;
@@ -611,9 +619,19 @@ export default function TradePage() {
                       )}
                     </div>
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                      <div>
-                        <div className="value">{Math.round(total.pw).toLocaleString()}</div>
-                        <div className="muted" style={{ fontSize: "0.64rem" }}>Linear: {Math.round(total.lin).toLocaleString()}</div>
+                      <div style={{ textAlign: "right" }}>
+                        <div className="value">{Math.round(total.adjusted).toLocaleString()}</div>
+                        {total.adjustment > 0 ? (
+                          <div
+                            className="muted"
+                            style={{ fontSize: "0.64rem", color: "var(--cyan)" }}
+                            title="Consolidation / roster-spot premium: the side with fewer pieces frees up a roster spot, so KTC-style math adds this bonus on top of the raw total."
+                          >
+                            Raw {Math.round(total.raw).toLocaleString()} + VA {Math.round(total.adjustment).toLocaleString()}
+                          </div>
+                        ) : (
+                          <div className="muted" style={{ fontSize: "0.64rem" }}>Raw: {Math.round(total.raw).toLocaleString()}</div>
+                        )}
                       </div>
                       <button className="button trade-add-btn" onClick={() => openPickerFor(sideIdx)}>+ Add</button>
                     </div>

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -3,7 +3,7 @@
  * Pure functions, no React dependencies.
  */
 
-import { effectiveValue, powerWeightedTotal, TRADE_ALPHA, parsePickToken, getPlayerEdge, resolvePickRow } from "@/lib/trade-logic";
+import { effectiveValue, TRADE_ALPHA, parsePickToken, getPlayerEdge, resolvePickRow } from "@/lib/trade-logic";
 import { normalizePos } from "@/lib/dynasty-data";
 
 // ── Position Group Helpers ──────────────────────────────────────────────

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -22,10 +22,30 @@ const VERDICT_NEAR_EVEN = 350;
 const VERDICT_LEAN = 900;
 const VERDICT_STRONG_LEAN = 1800;
 
-// ── Power-Weighted Calculation ───────────────────────────────────────────
-// Alpha exponent concentrates value at the top — a star + role player is
-// worth more than two mid-tier pieces.  Matches static calculator exactly.
+// ── Legacy Power-Weighted Alpha (trade history only) ─────────────────────
+// The Trade Calculator no longer uses this; it has moved to the KTC-style
+// Value Adjustment model below.  `TRADE_ALPHA` is kept as a retrospective
+// grading exponent for past trades on the `/trades` history page, where a
+// consolidation premium can't be attributed after the fact.
 export const TRADE_ALPHA = 1.65;
+
+// ── KTC-Style Value Adjustment ───────────────────────────────────────────
+// Mirrors KeepTradeCut's "Value Adjustment" row: the side with fewer pieces
+// gets a consolidation / roster-spot bonus that scales with (1) how much
+// its top asset outclasses the multi-side's top asset and (2) the raw
+// value of the "extra" pieces on the multi side.  Coefficients were fit
+// to three observed KTC data points (predictions within ~3% of actuals):
+//
+//   single=9999 vs 7846+5717 → KTC VA 3712 (model 3613)
+//   single=7846 vs 5717+4829 → KTC VA 3034 (model 3091)
+//   single=7846 vs 6949+5717 → KTC VA 1166 (model 1143)
+//
+// Formula: scarcity = clamp(SLOPE · gapRatio − INTERCEPT, 0, CAP)
+//          VA = Σ extraᵢ · scarcity · POSITION_DECAYⁱ
+export const VA_SCARCITY_SLOPE = 4.27;
+export const VA_SCARCITY_INTERCEPT = 0.288;
+export const VA_SCARCITY_CAP = 0.64;
+export const VA_POSITION_DECAY = 0.70;
 
 // ── Pick Year Discount ──────────────────────────────────────────────────
 // Future-year picks are worth less than current-year picks.
@@ -80,37 +100,94 @@ export function effectiveValue(row, valueMode, settings) {
   return val;
 }
 
-/**
- * Power-weighted side total.
- * Each asset's value is raised to `alpha`, summed, then root-alpha'd back.
- * This penalizes quantity over quality.
- * @param {object[]} side - Array of player rows
- * @param {string} valueMode - Value mode key
- * @param {number} [alpha] - Power exponent
- * @param {object} [settings] - User settings (from useSettings)
- */
-export function powerWeightedTotal(side, valueMode, alpha = TRADE_ALPHA, settings = null) {
-  if (!side.length) return 0;
-  const sum = side.reduce((acc, r) => {
-    const v = effectiveValue(r, valueMode, settings);
-    return acc + Math.pow(Math.max(v, 0), alpha);
-  }, 0);
-  return Math.pow(sum, 1 / alpha);
-}
-
 /** Simple linear total (sum of values). */
 export function sideTotal(side, valueMode, settings = null) {
   return side.reduce((sum, r) => sum + effectiveValue(r, valueMode, settings), 0);
 }
 
-/** Gap = Side A power-weighted total − Side B power-weighted total. */
-export function tradeGap(sideA, sideB, valueMode) {
-  return powerWeightedTotal(sideA, valueMode) - powerWeightedTotal(sideB, valueMode);
+/** Descending-sorted effective values for a side. */
+function sortedSideValues(side, valueMode, settings) {
+  return side
+    .map((r) => Math.max(0, effectiveValue(r, valueMode, settings)))
+    .sort((a, b) => b - a);
 }
 
-/** Linear gap (for display alongside power-weighted). */
-export function linearGap(sideA, sideB, valueMode) {
-  return sideTotal(sideA, valueMode) - sideTotal(sideB, valueMode);
+/**
+ * Compute the KTC-style Value Adjustment between two sides.
+ *
+ * The side with fewer pieces receives a bonus representing the
+ * consolidation / roster-spot premium.  The bonus scales with:
+ *   (a) how much the smaller side's top asset outclasses the larger
+ *       side's top asset (gapRatio), and
+ *   (b) the raw value of each "extra" piece on the larger side
+ *       beyond parity, decayed by POSITION_DECAY per additional slot.
+ *
+ * Returns { adjustment, recipientIdx } where:
+ *   - adjustment: ≥ 0 bonus to apply to the receiving side's total
+ *   - recipientIdx: 0 for sideA, 1 for sideB, or null when counts tie
+ *
+ * @param {object[]} sideA
+ * @param {object[]} sideB
+ * @param {string} valueMode
+ * @param {object} [settings]
+ */
+export function computeValueAdjustment(sideA, sideB, valueMode, settings = null) {
+  const aValues = sortedSideValues(sideA, valueMode, settings);
+  const bValues = sortedSideValues(sideB, valueMode, settings);
+
+  if (aValues.length === bValues.length) {
+    return { adjustment: 0, recipientIdx: null };
+  }
+
+  const recipientIdx = aValues.length < bValues.length ? 0 : 1;
+  const small = recipientIdx === 0 ? aValues : bValues;
+  const large = recipientIdx === 0 ? bValues : aValues;
+
+  if (small.length === 0 || small[0] <= 0) {
+    return { adjustment: 0, recipientIdx: null };
+  }
+
+  const topSmall = small[0];
+  const topLarge = large[0] || 0;
+  const gapRatio = Math.max(0, (topSmall - topLarge) / topSmall);
+
+  const rawScarcity = VA_SCARCITY_SLOPE * gapRatio - VA_SCARCITY_INTERCEPT;
+  const scarcity = Math.max(0, Math.min(VA_SCARCITY_CAP, rawScarcity));
+
+  if (scarcity === 0) {
+    return { adjustment: 0, recipientIdx };
+  }
+
+  const extras = large.slice(small.length);
+  let adjustment = 0;
+  for (let p = 0; p < extras.length; p++) {
+    adjustment += extras[p] * scarcity * Math.pow(VA_POSITION_DECAY, p);
+  }
+
+  return { adjustment, recipientIdx };
+}
+
+/**
+ * Adjusted per-side totals for 2-team trade display.
+ * Each entry is { raw, adjustment, adjusted } where `adjusted = raw + adjustment`
+ * and only the recipient side has a non-zero adjustment.
+ */
+export function adjustedSideTotals(sideA, sideB, valueMode, settings = null) {
+  const rawA = sideTotal(sideA, valueMode, settings);
+  const rawB = sideTotal(sideB, valueMode, settings);
+  const { adjustment, recipientIdx } = computeValueAdjustment(sideA, sideB, valueMode, settings);
+  const adjA = recipientIdx === 0 ? adjustment : 0;
+  const adjB = recipientIdx === 1 ? adjustment : 0;
+  return [
+    { raw: rawA, adjustment: adjA, adjusted: rawA + adjA },
+    { raw: rawB, adjustment: adjB, adjusted: rawB + adjB },
+  ];
+}
+
+/** Gap = Side A adjusted total − Side B adjusted total (KTC-style). */
+export function tradeGapAdjusted(sideA, sideB, valueMode, settings = null) {
+  const totals = adjustedSideTotals(sideA, sideB, valueMode, settings);
+  return totals[0].adjusted - totals[1].adjusted;
 }
 
 // ── Verdict ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Scraps the Trade Calculator's stud exponent (α=1.65 power-weighted total) and replaces it with a KTC-style **Value Adjustment**: each side shows its raw linear total, and the side with fewer pieces gets a visible consolidation / roster-spot bonus that matches the pattern shown in the KeepTradeCut screenshots.

## Formula

```
gapRatio = clamp((topSmall − topLarge) / topSmall, 0, ∞)
scarcity = clamp(4.27 · gapRatio − 0.288, 0, 0.64)
VA       = Σ extra_i · scarcity · 0.70^i     (shown on the side with fewer pieces)
```

Two effects fall out naturally:
- **Consolidation premium** — bigger concentration gap → bigger bonus.
- **Depth decay** — each additional extra piece on the larger side is worth 70% of the prior one.

Coefficients were fit to three observed KTC data points (all predictions within ~3% of KTC's actual Value Adjustment):

| Single | Multi | KTC VA | Model VA |
|--------|-------|--------|----------|
| 9999 | 7846 + 5717 | 3,712 | 3,613 |
| 7846 | 5717 + 4829 | 3,034 | 3,091 |
| 7846 | 6949 + 5717 | 1,166 | 1,143 |

When the multi side's top asset is as good as or better than the single side's, scarcity clamps to 0 and no VA is applied — no hollow bonus for trading down.

## Changes

- `frontend/lib/trade-logic.js` — removed `powerWeightedTotal`, `tradeGap`, `linearGap`. Added `computeValueAdjustment`, `adjustedSideTotals`, `tradeGapAdjusted`, plus tunable `VA_SCARCITY_SLOPE` / `VA_SCARCITY_INTERCEPT` / `VA_SCARCITY_CAP` / `VA_POSITION_DECAY` constants. `TRADE_ALPHA` retained (still used by the separate `/trades` history page for retrospective grading).
- `frontend/app/trade/page.jsx` — `sideTotals` now returns `{ raw, adjustment, adjusted }`; the side-card header renders a `Raw X + VA Y` row (with tooltip) on whichever side receives the bonus, mirroring KTC's layout. Verdict, balancers, and the 2-team meter all consume the adjusted totals.
- `frontend/lib/league-analysis.js` — dropped the now-unused `powerWeightedTotal` import.
- `frontend/__tests__/trade-logic.test.js` — rewrote power-weighted tests against the new VA functions; pinned the three observed KTC cases as regression anchors; updated the full-scenario test.

3+ team mode falls back to linear sums for now — a multi-team VA extension can land in a follow-up.

## Test plan

- [x] `npx vitest run` — all 389 frontend tests pass (including 3 pinned KTC cases)
- [ ] Manual UI check: reproduce each KTC scenario on `/trade` and confirm the side-card `Raw + VA` row and verdict match KTC
- [ ] Playwright regression: `npm run regression`

https://claude.ai/code/session_014AsNVayPnQ1CQbg5twDrwS