### PR TITLE
5 public-league features: Luck, Power, Streaks, This-Week, Recaps

### DIFF
--- a/frontend/app/league/LeagueClient.jsx
+++ b/frontend/app/league/LeagueClient.jsx
@@ -47,6 +47,11 @@ import DraftSection from "./sections/draft.jsx";
 import WeeklySection from "./sections/weekly.jsx";
 import SuperlativesSection from "./sections/superlatives.jsx";
 import ArchivesSection from "./sections/archives.jsx";
+import LuckSection from "./sections/luck.jsx";
+import StreaksSection from "./sections/streaks.jsx";
+import PowerSection from "./sections/power.jsx";
+import MatchupPreviewSection from "./sections/matchup-preview.jsx";
+import WeeklyRecapSection from "./sections/weekly-recap.jsx";
 
 // Tab order + labels for the /league section nav.
 // "Draft Capital" is first so it's the default landing on mobile,
@@ -54,6 +59,11 @@ import ArchivesSection from "./sections/archives.jsx";
 const SUB_TABS = [
   { key: "draft-capital", label: "Draft Capital" },
   { key: "overview", label: "Home" },
+  { key: "matchupPreview", label: "This Week" },
+  { key: "power", label: "Power" },
+  { key: "luck", label: "Luck" },
+  { key: "streaks", label: "Streaks" },
+  { key: "weeklyRecap", label: "Recaps" },
   { key: "history", label: "History" },
   { key: "rivalries", label: "Rivalries" },
   { key: "awards", label: "Awards" },
@@ -281,6 +291,28 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
         <SuperlativesSection managers={managers} data={sections.superlatives} />
       )}
       {activeTab === "archives" && <ArchivesSection data={sections.archives} />}
+      {activeTab === "luck" && (
+        <LuckSection data={sections.luck} managers={managers} />
+      )}
+      {activeTab === "streaks" && (
+        <StreaksSection data={sections.streaks} managers={managers} />
+      )}
+      {activeTab === "power" && (
+        <PowerSection data={sections.power} managers={managers} />
+      )}
+      {activeTab === "matchupPreview" && (
+        <MatchupPreviewSection
+          data={sections.matchupPreview}
+          managers={managers}
+          onNavigate={setActiveTab}
+        />
+      )}
+      {activeTab === "weeklyRecap" && (
+        <WeeklyRecapSection
+          data={sections.weeklyRecap}
+          managers={managers}
+        />
+      )}
     </section>
   );
 }

--- a/frontend/app/league/sections/luck.jsx
+++ b/frontend/app/league/sections/luck.jsx
@@ -1,0 +1,409 @@
+"use client";
+
+// LuckSection — "Luck Score" tab on /league.
+//
+// Reads the ``luck`` section of the public contract and renders:
+//   * Luckiest / unluckiest headline cards (current season + career).
+//   * A per-season sortable table with actual vs expected wins, luck
+//     delta, and all-play win%.
+//   * A cumulative luck-delta sparkline chart overlaying every owner
+//     across the full snapshot history.
+//
+// All math lives in ``src/public_league/luck.py``; this component is a
+// pure materializer.
+
+import { useMemo, useState } from "react";
+import {
+  Avatar,
+  Card,
+  EmptyCard,
+  SingleHighlight,
+  fmtNumber,
+  fmtPercent,
+  nameFor,
+} from "../shared.jsx";
+
+// ── Shared helpers ───────────────────────────────────────────────────────
+function fmtDelta(n) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "—";
+  const v = Number(n);
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${v.toFixed(2)}`;
+}
+
+function luckColor(delta) {
+  if (delta === null || delta === undefined) return "var(--subtext)";
+  if (delta > 0.5) return "#2ecc71";
+  if (delta > 0.1) return "#7bdfb3";
+  if (delta < -0.5) return "#ff6b6b";
+  if (delta < -0.1) return "#ffab6b";
+  return "var(--subtext)";
+}
+
+function luckLabel(delta) {
+  if (delta === null || delta === undefined) return "—";
+  if (delta > 1.0) return "Blessed";
+  if (delta > 0.3) return "Lucky";
+  if (delta > -0.3) return "Deserved";
+  if (delta > -1.0) return "Unlucky";
+  return "Cursed";
+}
+
+// ── Trail sparkline (inline SVG) ─────────────────────────────────────────
+// Plots cumulative luck delta over game index, one line per owner.
+// Hover state is cheap CSS so we don't pay for a tooltip system.
+function LuckTrailChart({ trail, managers }) {
+  const { lines, xMax, yMin, yMax } = useMemo(() => {
+    const grouped = new Map();
+    for (const t of trail) {
+      if (!grouped.has(t.ownerId)) grouped.set(t.ownerId, []);
+      grouped.get(t.ownerId).push(t);
+    }
+    let xMax = 0;
+    let yMin = 0;
+    let yMax = 0;
+    const lines = [];
+    for (const [ownerId, rows] of grouped) {
+      const sorted = rows.slice().sort((a, b) => a.cumGames - b.cumGames);
+      const points = sorted.map((r) => ({ x: r.cumGames, y: r.cumLuckDelta }));
+      for (const p of points) {
+        if (p.x > xMax) xMax = p.x;
+        if (p.y < yMin) yMin = p.y;
+        if (p.y > yMax) yMax = p.y;
+      }
+      lines.push({ ownerId, points });
+    }
+    // Enforce a minimum symmetric y-range so a "flat" chart doesn't
+    // look like random noise.
+    const yAbs = Math.max(1.0, Math.max(Math.abs(yMin), Math.abs(yMax)));
+    return { lines, xMax, yMin: -yAbs, yMax: yAbs };
+  }, [trail]);
+
+  if (!lines.length || xMax < 2) return null;
+
+  const W = 620;
+  const H = 220;
+  const padL = 32;
+  const padR = 12;
+  const padT = 12;
+  const padB = 22;
+  const plotW = W - padL - padR;
+  const plotH = H - padT - padB;
+
+  function px(x) {
+    return padL + (x / xMax) * plotW;
+  }
+  function py(y) {
+    return padT + (1 - (y - yMin) / (yMax - yMin)) * plotH;
+  }
+
+  // Generate a deterministic color per owner.
+  function colorFor(ownerId) {
+    const palette = [
+      "#4fc3f7",
+      "#ffa726",
+      "#66bb6a",
+      "#ef5350",
+      "#ab47bc",
+      "#26c6da",
+      "#ffee58",
+      "#8d6e63",
+      "#ec407a",
+      "#7e57c2",
+      "#9ccc65",
+      "#ff7043",
+    ];
+    let h = 0;
+    for (let i = 0; i < ownerId.length; i++) {
+      h = (h * 31 + ownerId.charCodeAt(i)) & 0xffff;
+    }
+    return palette[h % palette.length];
+  }
+
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        height={H}
+        style={{ maxWidth: W, display: "block", margin: "0 auto" }}
+        aria-label="Cumulative luck delta over time per manager"
+      >
+        {/* Gridlines at −2, −1, 0, 1, 2 when in range. */}
+        {[-2, -1, 0, 1, 2].filter((v) => v >= yMin && v <= yMax).map((v) => (
+          <g key={v}>
+            <line
+              x1={padL}
+              x2={W - padR}
+              y1={py(v)}
+              y2={py(v)}
+              stroke={v === 0 ? "var(--border-bright)" : "var(--border)"}
+              strokeDasharray={v === 0 ? "" : "3 3"}
+              opacity={v === 0 ? 0.9 : 0.5}
+            />
+            <text
+              x={padL - 6}
+              y={py(v) + 3}
+              fontSize={9}
+              textAnchor="end"
+              fill="var(--subtext)"
+              fontFamily="var(--mono)"
+            >
+              {v > 0 ? `+${v}` : v}
+            </text>
+          </g>
+        ))}
+        {/* X axis label. */}
+        <text
+          x={padL + plotW / 2}
+          y={H - 4}
+          fontSize={9}
+          textAnchor="middle"
+          fill="var(--subtext)"
+        >
+          Regular-season games played
+        </text>
+        {/* Lines. */}
+        {lines.map((line) => {
+          const d = line.points
+            .map((p, i) => `${i === 0 ? "M" : "L"} ${px(p.x)} ${py(p.y)}`)
+            .join(" ");
+          return (
+            <g key={line.ownerId}>
+              <path
+                d={d}
+                fill="none"
+                stroke={colorFor(line.ownerId)}
+                strokeWidth={1.5}
+                opacity={0.9}
+              />
+              {/* End marker + name */}
+              {line.points.length > 0 && (() => {
+                const last = line.points[line.points.length - 1];
+                return (
+                  <>
+                    <circle
+                      cx={px(last.x)}
+                      cy={py(last.y)}
+                      r={3}
+                      fill={colorFor(line.ownerId)}
+                    />
+                    <text
+                      x={px(last.x) + 6}
+                      y={py(last.y) + 3}
+                      fontSize={9}
+                      fill={colorFor(line.ownerId)}
+                      fontFamily="var(--mono)"
+                    >
+                      {nameFor(managers, line.ownerId).slice(0, 10)}
+                    </text>
+                  </>
+                );
+              })()}
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+// ── Table ────────────────────────────────────────────────────────────────
+function LuckTable({ rows, managers, showSeason = false }) {
+  if (!rows || !rows.length) return <EmptyCard label="Luck scores" />;
+  return (
+    <div className="table-wrap" style={{ overflowX: "auto" }}>
+      <table className="table">
+        <thead>
+          <tr>
+            <th style={{ width: 32 }}>#</th>
+            <th>Manager</th>
+            {showSeason && <th>Season</th>}
+            <th style={{ textAlign: "right" }}>GP</th>
+            <th style={{ textAlign: "right" }}>Actual W</th>
+            <th style={{ textAlign: "right" }}>Expected W</th>
+            <th style={{ textAlign: "right" }}>Luck Δ</th>
+            <th style={{ textAlign: "right" }}>All-Play %</th>
+            <th style={{ textAlign: "right", width: 96 }}>Verdict</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={`${r.ownerId}-${r.season || "career"}`}>
+              <td style={{ fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+                {i + 1}
+              </td>
+              <td>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                  <Avatar managers={managers} ownerId={r.ownerId} size={20} />
+                  <span>
+                    <div style={{ fontWeight: 600, lineHeight: 1.1 }}>
+                      {nameFor(managers, r.ownerId)}
+                    </div>
+                    <div style={{ fontSize: "0.65rem", color: "var(--subtext)" }}>
+                      {r.teamName}
+                    </div>
+                  </span>
+                </span>
+              </td>
+              {showSeason && (
+                <td style={{ fontFamily: "var(--mono)" }}>{r.season}</td>
+              )}
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                {r.gamesPlayed}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                {fmtNumber(r.actualWins, 1)}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+                {fmtNumber(r.expectedWins, 1)}
+              </td>
+              <td
+                style={{
+                  textAlign: "right",
+                  fontFamily: "var(--mono)",
+                  color: luckColor(r.luckDelta),
+                  fontWeight: 700,
+                }}
+              >
+                {fmtDelta(r.luckDelta)}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                {fmtPercent(r.allPlayWinPct)}
+              </td>
+              <td style={{ textAlign: "right", color: luckColor(r.luckDelta), fontSize: "0.72rem" }}>
+                {luckLabel(r.luckDelta)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Top-level section ────────────────────────────────────────────────────
+export default function LuckSection({ data, managers }) {
+  const [scope, setScope] = useState(
+    data?.currentSeasonRanked?.length ? "current" : "career",
+  );
+
+  if (!data || (!data.byOwnerCareer?.length && !data.byOwnerSeason?.length)) {
+    return <EmptyCard label="Luck Score" />;
+  }
+
+  const career = data.byOwnerCareer || [];
+  const seasonRows = data.byOwnerSeason || [];
+  const currentSeasonRows = data.currentSeasonRanked || [];
+  const currentYear = data.currentSeason;
+
+  const tableRows = scope === "career"
+    ? career
+    : scope === "current"
+      ? currentSeasonRows
+      : seasonRows.filter((r) => r.season === scope);
+
+  const seasonOptions = Array.from(
+    new Set(seasonRows.map((r) => r.season))
+  ).sort((a, b) => Number(b) - Number(a));
+
+  return (
+    <section>
+      {/* Headline cards */}
+      <div
+        className="card"
+        style={{ marginTop: "var(--space-md)" }}
+      >
+        <div style={{ fontWeight: 700, marginBottom: 4 }}>Luck Score</div>
+        <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginBottom: 10 }}>
+          Actual wins vs expected wins from weekly all-play record. Regular season only.
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: 10,
+          }}
+        >
+          {data.luckiestCurrent && (
+            <SingleHighlight
+              label={`${currentYear} · Most blessed`}
+              value={`${nameFor(managers, data.luckiestCurrent.ownerId)} (${fmtDelta(data.luckiestCurrent.luckDelta)})`}
+              sub={`${fmtNumber(data.luckiestCurrent.actualWins, 1)} actual vs ${fmtNumber(data.luckiestCurrent.expectedWins, 1)} expected`}
+            />
+          )}
+          {data.unluckiestCurrent && (
+            <SingleHighlight
+              label={`${currentYear} · Most cursed`}
+              value={`${nameFor(managers, data.unluckiestCurrent.ownerId)} (${fmtDelta(data.unluckiestCurrent.luckDelta)})`}
+              sub={`${fmtNumber(data.unluckiestCurrent.actualWins, 1)} actual vs ${fmtNumber(data.unluckiestCurrent.expectedWins, 1)} expected`}
+            />
+          )}
+          {data.luckiestCareer && (
+            <SingleHighlight
+              label="Career · Most blessed"
+              value={`${nameFor(managers, data.luckiestCareer.ownerId)} (${fmtDelta(data.luckiestCareer.luckDelta)})`}
+              sub={`${data.luckiestCareer.gamesPlayed} games, all-play ${fmtPercent(data.luckiestCareer.allPlayWinPct)}`}
+            />
+          )}
+          {data.unluckiestCareer && (
+            <SingleHighlight
+              label="Career · Most cursed"
+              value={`${nameFor(managers, data.unluckiestCareer.ownerId)} (${fmtDelta(data.unluckiestCareer.luckDelta)})`}
+              sub={`${data.unluckiestCareer.gamesPlayed} games, all-play ${fmtPercent(data.unluckiestCareer.allPlayWinPct)}`}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Trail chart */}
+      <Card
+        title="Cumulative luck delta over time"
+        action={
+          <span style={{ fontSize: "0.65rem", color: "var(--subtext)" }}>
+            Above zero = lucky; below = unlucky
+          </span>
+        }
+      >
+        <LuckTrailChart trail={data.weeklyTrail || []} managers={managers} />
+      </Card>
+
+      {/* Ranked table */}
+      <Card
+        title="Manager ranking"
+        action={
+          <select
+            className="input"
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            style={{ minWidth: 140 }}
+          >
+            <option value="career">Career</option>
+            {currentYear && (
+              <option value="current">{currentYear} (current)</option>
+            )}
+            {seasonOptions
+              .filter((s) => s !== currentYear)
+              .map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+          </select>
+        }
+      >
+        <LuckTable rows={tableRows} managers={managers} showSeason={scope !== "career" && scope !== "current"} />
+      </Card>
+
+      {/* Methodology */}
+      <Card title="How this is computed">
+        <p style={{ fontSize: "0.78rem", lineHeight: 1.5, color: "var(--subtext)" }}>
+          Each week, every manager's score is compared against every other manager's score that same week.
+          If your score beats <em>k</em> of the other <em>n−1</em> teams, your <strong>expected win share</strong> for that
+          week is <code style={{ color: "var(--cyan)" }}>(k + ties·0.5) / (n−1)</code>.
+          Add those shares up across the season and you get <strong>expected wins</strong>. Your actual
+          wins are what the schedule-luck lottery assigned you. <strong>Luck Δ = actual − expected.</strong>
+          Playoffs are excluded — bracket seeding is already a function of regular-season luck.
+        </p>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/app/league/sections/matchup-preview.jsx
+++ b/frontend/app/league/sections/matchup-preview.jsx
@@ -1,0 +1,291 @@
+"use client";
+
+// MatchupPreviewSection — "This Week" tab on /league.
+//
+// Renders the head-to-head matchup preview for the current (or most
+// recently completed) week.  Each card shows both teams, all-time H2H
+// summary, the last 5 meetings, and each side's recent-form capsule.
+
+import { Avatar, Card, EmptyCard, fmtNumber, nameFor } from "../shared.jsx";
+
+function FormCapsule({ label, form, managers, ownerId }) {
+  if (!form) return null;
+  const games = form.games || [];
+  return (
+    <div style={{ flex: 1, padding: 8, borderRadius: "var(--radius)", background: "var(--bg-subtle)" }}>
+      <div style={{ fontSize: "0.6rem", color: "var(--subtext)", textTransform: "uppercase" }}>
+        {label}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
+        <Avatar managers={managers} ownerId={ownerId} size={18} />
+        <span style={{ fontSize: "0.78rem", fontWeight: 700 }}>
+          {nameFor(managers, ownerId)}
+        </span>
+      </div>
+      <div style={{ display: "flex", gap: 12, marginTop: 6, fontSize: "0.7rem" }}>
+        <div>
+          <div style={{ color: "var(--subtext)", fontSize: "0.6rem" }}>Last 3</div>
+          <div style={{ fontFamily: "var(--mono)" }}>{form.record || "—"}</div>
+        </div>
+        <div>
+          <div style={{ color: "var(--subtext)", fontSize: "0.6rem" }}>Avg pts</div>
+          <div style={{ fontFamily: "var(--mono)" }}>{fmtNumber(form.avgPoints, 1)}</div>
+        </div>
+      </div>
+      {games.length > 0 && (
+        <div style={{ display: "flex", gap: 4, marginTop: 6 }}>
+          {games.map((g, i) => (
+            <span
+              key={i}
+              title={`${g.season} wk ${g.week} · ${g.points} vs ${g.opponentPoints}`}
+              style={{
+                display: "inline-block",
+                width: 14,
+                height: 14,
+                borderRadius: 2,
+                background:
+                  g.result === "W"
+                    ? "#2ecc71"
+                    : g.result === "L"
+                      ? "#ff6b6b"
+                      : "var(--subtext)",
+                color: "white",
+                fontSize: 9,
+                textAlign: "center",
+                lineHeight: "14px",
+                fontWeight: 700,
+              }}
+            >
+              {g.result}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MeetingRow({ m, sideAOwnerId, sideBOwnerId, managers }) {
+  const aligned = m.sideAOwnerId === sideAOwnerId;
+  const aPts = aligned ? m.sideAPoints : m.sideBPoints;
+  const bPts = aligned ? m.sideBPoints : m.sideAPoints;
+  const winnerAligned = m.winnerOwnerId === sideAOwnerId;
+  const winnerNeitherAligned = !m.winnerOwnerId;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "56px 1fr 1fr",
+        gap: 6,
+        padding: "4px 0",
+        borderBottom: "1px solid var(--border)",
+        fontSize: "0.72rem",
+      }}
+    >
+      <div style={{ color: "var(--subtext)", fontFamily: "var(--mono)" }}>
+        {m.season} wk{m.week}
+        {m.isPlayoff && <span style={{ color: "var(--amber)" }}> P</span>}
+      </div>
+      <div
+        style={{
+          textAlign: "right",
+          color: winnerAligned ? "#2ecc71" : winnerNeitherAligned ? "var(--subtext)" : "var(--subtext)",
+          fontWeight: winnerAligned ? 700 : 400,
+          fontFamily: "var(--mono)",
+        }}
+      >
+        {nameFor(managers, sideAOwnerId)} {fmtNumber(aPts, 1)}
+      </div>
+      <div
+        style={{
+          color: !winnerAligned && !winnerNeitherAligned ? "#2ecc71" : winnerNeitherAligned ? "var(--subtext)" : "var(--subtext)",
+          fontWeight: !winnerAligned && !winnerNeitherAligned ? 700 : 400,
+          fontFamily: "var(--mono)",
+        }}
+      >
+        {fmtNumber(bPts, 1)} {nameFor(managers, sideBOwnerId)}
+      </div>
+    </div>
+  );
+}
+
+function MatchupCard({ m, managers, mode }) {
+  const { home, away, h2h, form } = m;
+  const isRecap = mode === "recap";
+  const winnerSide =
+    isRecap && home.points != null && away.points != null
+      ? home.points > away.points
+        ? "home"
+        : away.points > home.points
+          ? "away"
+          : null
+      : null;
+
+  return (
+    <div className="card" style={{ padding: 14 }}>
+      {/* Matchup header */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 60px 1fr",
+          alignItems: "center",
+          gap: 12,
+        }}
+      >
+        <TeamSide side={home} managers={managers} isWinner={winnerSide === "home"} isRecap={isRecap} align="right" />
+        <div style={{ textAlign: "center", fontWeight: 700, color: "var(--subtext)" }}>
+          {isRecap ? "vs" : "@"}
+        </div>
+        <TeamSide side={away} managers={managers} isWinner={winnerSide === "away"} isRecap={isRecap} align="left" />
+      </div>
+
+      {/* H2H narrative */}
+      <div
+        style={{
+          marginTop: 10,
+          padding: "6px 10px",
+          background: "var(--bg-subtle)",
+          borderRadius: 6,
+          fontSize: "0.72rem",
+          color: "var(--subtext)",
+        }}
+      >
+        {h2h?.narrative}
+      </div>
+
+      {/* H2H summary row + form */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 10,
+          marginTop: 10,
+        }}
+      >
+        <div>
+          <div style={{ fontSize: "0.6rem", color: "var(--subtext)", textTransform: "uppercase" }}>
+            Series
+          </div>
+          <div style={{ fontSize: "0.85rem", fontWeight: 700, marginTop: 2 }}>
+            {h2h.homeWins}-{h2h.awayWins}
+            {h2h.ties > 0 && `-${h2h.ties}`}
+          </div>
+          <div style={{ fontSize: "0.64rem", color: "var(--subtext)", marginTop: 2 }}>
+            {h2h.totalMeetings} meeting{h2h.totalMeetings === 1 ? "" : "s"}
+            {h2h.playoffMeetings > 0 && ` · ${h2h.playoffMeetings} playoff`}
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: "0.6rem", color: "var(--subtext)", textTransform: "uppercase" }}>
+            Avg margin
+          </div>
+          <div style={{ fontSize: "0.85rem", fontWeight: 700, marginTop: 2 }}>
+            {fmtNumber(h2h.avgMargin, 1)} pts
+          </div>
+          <div style={{ fontSize: "0.64rem", color: "var(--subtext)", marginTop: 2 }}>
+            biggest {fmtNumber(h2h.biggestMargin, 1)}
+          </div>
+        </div>
+        <FormCapsule label="Home form" form={form.home} managers={managers} ownerId={home.ownerId} />
+        <FormCapsule label="Away form" form={form.away} managers={managers} ownerId={away.ownerId} />
+      </div>
+
+      {/* Last 5 meetings */}
+      {h2h.last5 && h2h.last5.length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div style={{ fontSize: "0.6rem", color: "var(--subtext)", textTransform: "uppercase", marginBottom: 4 }}>
+            Last {h2h.last5.length} meeting{h2h.last5.length === 1 ? "" : "s"}
+          </div>
+          <div>
+            {h2h.last5.map((meet, i) => (
+              <MeetingRow
+                key={`${meet.season}-${meet.week}-${i}`}
+                m={meet}
+                sideAOwnerId={home.ownerId}
+                sideBOwnerId={away.ownerId}
+                managers={managers}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TeamSide({ side, managers, isWinner, isRecap, align }) {
+  return (
+    <div style={{ textAlign: align }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: align === "right" ? "flex-end" : "flex-start",
+          gap: 8,
+        }}
+      >
+        {align === "left" && <Avatar managers={managers} ownerId={side.ownerId} size={28} />}
+        <div style={{ textAlign: align }}>
+          <div style={{ fontWeight: 700 }}>{nameFor(managers, side.ownerId)}</div>
+          <div style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>{side.teamName}</div>
+        </div>
+        {align === "right" && <Avatar managers={managers} ownerId={side.ownerId} size={28} />}
+      </div>
+      {isRecap && side.points != null && (
+        <div
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: "1.3rem",
+            fontWeight: 800,
+            color: isWinner ? "#2ecc71" : "var(--subtext)",
+            marginTop: 4,
+          }}
+        >
+          {fmtNumber(side.points, 1)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function MatchupPreviewSection({ data, managers, onNavigate }) {
+  if (!data || !data.matchups?.length) return <EmptyCard label="This week's matchups" />;
+  const { currentSeason, currentWeek, mode, isPlayoff, matchups } = data;
+
+  const title =
+    mode === "preview"
+      ? `${currentSeason} · Week ${currentWeek} preview`
+      : `${currentSeason} · Week ${currentWeek}${isPlayoff ? " (playoffs)" : ""} — results`;
+
+  return (
+    <section>
+      <Card
+        title={title}
+        action={
+          <span style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>
+            {mode === "preview"
+              ? "Head-to-head history + recent form for the upcoming slate"
+              : "Head-to-head context for the most recently completed week"}
+          </span>
+        }
+      >
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(340px, 1fr))",
+            gap: 12,
+          }}
+        >
+          {matchups.map((m) => (
+            <MatchupCard
+              key={`${m.home.ownerId}-${m.away.ownerId}`}
+              m={m}
+              managers={managers}
+              mode={mode}
+            />
+          ))}
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/app/league/sections/power.jsx
+++ b/frontend/app/league/sections/power.jsx
@@ -1,0 +1,346 @@
+"use client";
+
+// PowerSection — "Power" tab on /league.
+//
+// Surfaces the weekly power ranking from the ``power`` contract section:
+//   * Current-week leaderboard with components + week-over-week rank delta.
+//   * Inline SVG line chart plotting each owner's power score across
+//     every (season, week) in the snapshot.
+//   * Historical week selector for drilling into any past week.
+
+import { useMemo, useState } from "react";
+import {
+  Avatar,
+  Card,
+  EmptyCard,
+  fmtNumber,
+  fmtPercent,
+  nameFor,
+} from "../shared.jsx";
+
+function powerColor(power) {
+  if (power >= 80) return "#2ecc71";
+  if (power >= 65) return "#7bdfb3";
+  if (power >= 50) return "#4fc3f7";
+  if (power >= 35) return "#ffa726";
+  return "#ff6b6b";
+}
+
+function deltaText(delta) {
+  if (!delta) return "—";
+  const n = Number(delta);
+  if (n > 0) return `▲ ${n}`;
+  if (n < 0) return `▼ ${Math.abs(n)}`;
+  return "—";
+}
+
+function deltaColor(delta) {
+  const n = Number(delta);
+  if (n > 0) return "#2ecc71";
+  if (n < 0) return "#ff6b6b";
+  return "var(--subtext)";
+}
+
+// ── Power trail chart ────────────────────────────────────────────────────
+function PowerChart({ series, managers, highlightOwnerId = null }) {
+  const { lines, xMax } = useMemo(() => {
+    if (!series || !series.length) return { lines: [], xMax: 0 };
+    // Flatten cross-season (season, week) into a single axis index.
+    // Every owner must share the same axis so we build the master
+    // ordered list of (season, week) keys across all owners.
+    const allKeys = new Map();  // "season:week" → order
+    const sortedSeries = series.map((s) => ({
+      ...s,
+      points: [...s.points].sort((a, b) => {
+        if (a.season !== b.season) return Number(a.season) - Number(b.season);
+        return a.week - b.week;
+      }),
+    }));
+    const ordered = [];
+    for (const s of sortedSeries) {
+      for (const p of s.points) {
+        const k = `${p.season}:${p.week}`;
+        if (!allKeys.has(k)) {
+          allKeys.set(k, ordered.length);
+          ordered.push(k);
+        }
+      }
+    }
+    // Re-sort ordered keys by (season, week) explicitly; map back.
+    ordered.sort((a, b) => {
+      const [sa, wa] = a.split(":");
+      const [sb, wb] = b.split(":");
+      if (sa !== sb) return Number(sa) - Number(sb);
+      return Number(wa) - Number(wb);
+    });
+    ordered.forEach((k, i) => allKeys.set(k, i));
+
+    const lines = sortedSeries.map((s) => ({
+      ownerId: s.ownerId,
+      displayName: s.displayName,
+      points: s.points.map((p) => ({
+        x: allKeys.get(`${p.season}:${p.week}`),
+        y: p.power,
+        season: p.season,
+        week: p.week,
+        rank: p.rank,
+      })),
+    }));
+    return { lines, xMax: ordered.length - 1 };
+  }, [series]);
+
+  if (!lines.length || xMax < 1) return null;
+
+  const W = 640;
+  const H = 260;
+  const padL = 38;
+  const padR = 80;
+  const padT = 16;
+  const padB = 24;
+  const plotW = W - padL - padR;
+  const plotH = H - padT - padB;
+
+  const px = (x) => padL + (x / xMax) * plotW;
+  const py = (y) => padT + (1 - y / 100) * plotH;
+
+  function colorFor(ownerId) {
+    const palette = [
+      "#4fc3f7",
+      "#ffa726",
+      "#66bb6a",
+      "#ef5350",
+      "#ab47bc",
+      "#26c6da",
+      "#ffee58",
+      "#8d6e63",
+      "#ec407a",
+      "#7e57c2",
+      "#9ccc65",
+      "#ff7043",
+    ];
+    let h = 0;
+    for (let i = 0; i < ownerId.length; i++) {
+      h = (h * 31 + ownerId.charCodeAt(i)) & 0xffff;
+    }
+    return palette[h % palette.length];
+  }
+
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        height={H}
+        style={{ maxWidth: W, display: "block", margin: "0 auto" }}
+        aria-label="Power score across weeks per manager"
+      >
+        {/* Gridlines at 0, 25, 50, 75, 100. */}
+        {[0, 25, 50, 75, 100].map((v) => (
+          <g key={v}>
+            <line
+              x1={padL}
+              x2={W - padR}
+              y1={py(v)}
+              y2={py(v)}
+              stroke={v === 50 ? "var(--border-bright)" : "var(--border)"}
+              strokeDasharray={v === 50 ? "" : "3 3"}
+              opacity={v === 50 ? 0.8 : 0.5}
+            />
+            <text
+              x={padL - 6}
+              y={py(v) + 3}
+              fontSize={9}
+              textAnchor="end"
+              fill="var(--subtext)"
+              fontFamily="var(--mono)"
+            >
+              {v}
+            </text>
+          </g>
+        ))}
+        {/* Lines. */}
+        {lines.map((line) => {
+          const isHighlighted = highlightOwnerId && line.ownerId === highlightOwnerId;
+          const color = colorFor(line.ownerId);
+          const d = line.points
+            .map((p, i) => `${i === 0 ? "M" : "L"} ${px(p.x)} ${py(p.y)}`)
+            .join(" ");
+          return (
+            <g key={line.ownerId} opacity={highlightOwnerId && !isHighlighted ? 0.25 : 1.0}>
+              <path
+                d={d}
+                fill="none"
+                stroke={color}
+                strokeWidth={isHighlighted ? 2.4 : 1.4}
+              />
+              {line.points.length > 0 && (() => {
+                const last = line.points[line.points.length - 1];
+                return (
+                  <>
+                    <circle cx={px(last.x)} cy={py(last.y)} r={3} fill={color} />
+                    <text
+                      x={px(last.x) + 6}
+                      y={py(last.y) + 3}
+                      fontSize={9}
+                      fill={color}
+                      fontFamily="var(--mono)"
+                    >
+                      {(line.displayName || line.ownerId).slice(0, 12)}
+                    </text>
+                  </>
+                );
+              })()}
+            </g>
+          );
+        })}
+        <text
+          x={padL + plotW / 2}
+          y={H - 4}
+          fontSize={9}
+          textAnchor="middle"
+          fill="var(--subtext)"
+        >
+          Weeks played (chronological)
+        </text>
+      </svg>
+    </div>
+  );
+}
+
+// ── Leaderboard ─────────────────────────────────────────────────────────
+function PowerTable({ rankings, managers, onRowHover, hoverOwnerId }) {
+  if (!rankings || !rankings.length) return <EmptyCard label="Power rankings" />;
+  return (
+    <div className="table-wrap" style={{ overflowX: "auto" }}>
+      <table className="table">
+        <thead>
+          <tr>
+            <th style={{ width: 32 }}>#</th>
+            <th style={{ width: 44 }}>Δ</th>
+            <th>Manager</th>
+            <th style={{ textAlign: "right" }}>Power</th>
+            <th style={{ textAlign: "right" }}>PPG</th>
+            <th style={{ textAlign: "right" }}>L{"3"} avg</th>
+            <th style={{ textAlign: "right" }}>All-play</th>
+            <th style={{ textAlign: "right" }}>Record</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rankings.map((r) => (
+            <tr
+              key={r.ownerId}
+              onMouseEnter={() => onRowHover?.(r.ownerId)}
+              onMouseLeave={() => onRowHover?.(null)}
+              style={{
+                background:
+                  hoverOwnerId === r.ownerId ? "rgba(79,195,247,0.08)" : "transparent",
+                cursor: "default",
+              }}
+            >
+              <td style={{ fontFamily: "var(--mono)", fontWeight: 700, color: powerColor(r.power) }}>
+                {r.rank}
+              </td>
+              <td style={{ fontFamily: "var(--mono)", color: deltaColor(r.weekRankDelta) }}>
+                {deltaText(r.weekRankDelta)}
+              </td>
+              <td>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                  <Avatar managers={managers} ownerId={r.ownerId} size={20} />
+                  <span>
+                    <div style={{ fontWeight: 600, lineHeight: 1.1 }}>{nameFor(managers, r.ownerId)}</div>
+                    <div style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>{r.teamName}</div>
+                  </span>
+                </span>
+              </td>
+              <td
+                style={{
+                  textAlign: "right",
+                  fontFamily: "var(--mono)",
+                  color: powerColor(r.power),
+                  fontWeight: 700,
+                }}
+              >
+                {fmtNumber(r.power, 1)}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                {fmtNumber(r.components?.pointsPerGame, 1)}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                {fmtNumber(r.components?.recentAvg, 1)}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+                {fmtPercent(r.components?.allPlayWinPctThisWeek)}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>{r.record}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Section ──────────────────────────────────────────────────────────────
+export default function PowerSection({ data, managers }) {
+  const [hoverOwnerId, setHoverOwnerId] = useState(null);
+  const [selectedWeekKey, setSelectedWeekKey] = useState("__current");
+
+  if (!data || !data.weeks?.length) return <EmptyCard label="Power rankings" />;
+
+  const weeks = data.weeks;
+  const selectedWeek =
+    selectedWeekKey === "__current"
+      ? weeks[weeks.length - 1]
+      : weeks.find((w) => `${w.season}:${w.week}` === selectedWeekKey) || weeks[weeks.length - 1];
+
+  return (
+    <section>
+      <Card
+        title={`Power rankings — ${selectedWeek.season} week ${selectedWeek.week}`}
+        action={
+          <select
+            className="input"
+            value={selectedWeekKey}
+            onChange={(e) => setSelectedWeekKey(e.target.value)}
+            style={{ minWidth: 180 }}
+          >
+            <option value="__current">Most recent</option>
+            {[...weeks].reverse().map((w) => (
+              <option key={`${w.season}:${w.week}`} value={`${w.season}:${w.week}`}>
+                {w.season} Wk {w.week}
+              </option>
+            ))}
+          </select>
+        }
+      >
+        <PowerTable
+          rankings={selectedWeek.rankings}
+          managers={managers}
+          onRowHover={setHoverOwnerId}
+          hoverOwnerId={hoverOwnerId}
+        />
+      </Card>
+
+      <Card
+        title="Power score over time"
+        action={
+          <span style={{ fontSize: "0.62rem", color: "var(--subtext)" }}>
+            Hover a row in the table to highlight a manager's line
+          </span>
+        }
+      >
+        <PowerChart
+          series={data.seriesByOwner || []}
+          managers={managers}
+          highlightOwnerId={hoverOwnerId}
+        />
+      </Card>
+
+      <Card title="How this is computed">
+        <p style={{ fontSize: "0.78rem", lineHeight: 1.5, color: "var(--subtext)" }}>
+          {data.methodology}
+        </p>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/app/league/sections/streaks.jsx
+++ b/frontend/app/league/sections/streaks.jsx
@@ -1,0 +1,220 @@
+"use client";
+
+// StreaksSection — "Streaks" tab on /league.
+//
+// Three sections, top to bottom:
+//   * "Records are falling" — records-in-reach: the all-time holder
+//     plus the current-season chaser (if any), with a within-reach flag.
+//   * "Notable this week" — the most recently scored week's games that
+//     cracked the all-time top-5 in a category.
+//   * "Active streaks" — per owner, their trailing W/L/100+/120+/140+
+//     run of consecutive games.
+//
+// Reads strictly from ``sections.streaks`` of the public contract.
+
+import { Avatar, Card, EmptyCard, nameFor } from "../shared.jsx";
+
+function StreakTypeLabel(type) {
+  switch (type) {
+    case "winStreak":
+      return { label: "Win streak", color: "#2ecc71", suffix: "W" };
+    case "lossStreak":
+      return { label: "Loss streak", color: "#ff6b6b", suffix: "L" };
+    case "plus100Streak":
+      return { label: "100+ streak", color: "#7bdfb3", suffix: "G" };
+    case "plus120Streak":
+      return { label: "120+ streak", color: "#4fc3f7", suffix: "G" };
+    case "plus140Streak":
+      return { label: "140+ streak", color: "#ffa726", suffix: "G" };
+    default:
+      return { label: type, color: "var(--subtext)", suffix: "" };
+  }
+}
+
+function RecordCard({ rec, managers }) {
+  const { holder, chaser, label } = rec;
+  const inReach = chaser?.withinReach;
+  return (
+    <div
+      className="card"
+      style={{
+        borderLeft: inReach ? "3px solid var(--amber)" : "3px solid transparent",
+      }}
+    >
+      <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+        {label}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6 }}>
+        <Avatar managers={managers} ownerId={holder.ownerId} size={22} />
+        <div style={{ flex: 1 }}>
+          <div style={{ fontWeight: 700 }}>{nameFor(managers, holder.ownerId) || holder.displayName}</div>
+          <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
+            {holder.valueLabel}
+            {holder.season && ` · ${holder.season}${holder.week ? ` wk ${holder.week}` : ""}`}
+          </div>
+        </div>
+      </div>
+      {chaser && (
+        <div style={{ marginTop: 8, borderTop: "1px dashed var(--border)", paddingTop: 6 }}>
+          <div style={{ fontSize: "0.6rem", color: "var(--subtext)", textTransform: "uppercase" }}>
+            Closest chaser
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+            <Avatar managers={managers} ownerId={chaser.ownerId} size={18} />
+            <div style={{ flex: 1, fontSize: "0.78rem" }}>
+              <strong>{nameFor(managers, chaser.ownerId) || chaser.displayName}</strong>
+              <span style={{ color: inReach ? "var(--amber)" : "var(--subtext)", marginLeft: 6 }}>
+                {chaser.valueLabel}
+              </span>
+              {chaser.gap !== undefined && (
+                <span style={{ color: "var(--subtext)", marginLeft: 6 }}>
+                  ({chaser.gap > 0 ? `${chaser.gap} from record` : "tied or ahead"})
+                </span>
+              )}
+            </div>
+          </div>
+          {inReach && (
+            <div style={{ fontSize: "0.68rem", color: "var(--amber)", marginTop: 4, fontWeight: 700 }}>
+              Within striking distance
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NotableRow({ n, managers }) {
+  const cat = n.category;
+  const color =
+    cat === "highestSingleWeek" ? "#2ecc71"
+    : cat === "lowestSingleWeek" ? "#ff6b6b"
+    : cat === "biggestBlowout" ? "#4fc3f7"
+    : cat === "badBeat" ? "#ffa726"
+    : "var(--subtext)";
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 0",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      <div style={{ color, fontFamily: "var(--mono)", fontWeight: 700, minWidth: 38, textAlign: "center" }}>
+        #{n.rank}
+      </div>
+      <Avatar managers={managers} ownerId={n.ownerId} size={22} />
+      <div style={{ flex: 1, fontSize: "0.78rem" }}>
+        <strong>{nameFor(managers, n.ownerId) || n.displayName}</strong> —{" "}
+        <span style={{ color: "var(--subtext)" }}>{n.label}</span>
+      </div>
+      <div style={{ fontFamily: "var(--mono)", color, fontWeight: 700 }}>
+        {n.valueLabel}
+      </div>
+    </div>
+  );
+}
+
+function ActiveStreakRow({ s, managers }) {
+  const { label, color, suffix } = StreakTypeLabel(s.type);
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "6px 0",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      <Avatar managers={managers} ownerId={s.ownerId} size={20} />
+      <div style={{ flex: 1, fontSize: "0.78rem" }}>
+        <strong>{nameFor(managers, s.ownerId) || s.displayName}</strong>
+        <span style={{ color: "var(--subtext)", marginLeft: 8, fontSize: "0.66rem" }}>
+          since {s.start?.season} wk {s.start?.week}
+        </span>
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          color,
+          fontWeight: 700,
+          minWidth: 64,
+          textAlign: "right",
+        }}
+      >
+        {s.length}{suffix} <span style={{ color: "var(--subtext)", fontWeight: 400, fontSize: "0.66rem" }}>{label}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function StreaksSection({ data, managers }) {
+  if (!data) return <EmptyCard label="Streaks" />;
+  const { activeStreaks = [], recordsInReach = [], notableThisWeek = [], latestWeek } = data;
+
+  const hasContent = activeStreaks.length + recordsInReach.length + notableThisWeek.length > 0;
+  if (!hasContent) return <EmptyCard label="Streaks" />;
+
+  return (
+    <section>
+      {recordsInReach.length > 0 && (
+        <Card
+          title="Records are falling"
+          action={
+            <span style={{ fontSize: "0.62rem", color: "var(--subtext)" }}>
+              Gold border = chaser is within striking distance
+            </span>
+          }
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+              gap: 10,
+            }}
+          >
+            {recordsInReach.map((r) => (
+              <RecordCard key={r.category} rec={r} managers={managers} />
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {notableThisWeek.length > 0 && (
+        <Card
+          title={
+            latestWeek
+              ? `Notable from ${latestWeek.season} week ${latestWeek.week}`
+              : "Notable from the latest week"
+          }
+        >
+          <div>
+            {notableThisWeek.map((n, i) => (
+              <NotableRow key={`${n.category}-${n.ownerId}-${i}`} n={n} managers={managers} />
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {activeStreaks.length > 0 && (
+        <Card title="Active streaks">
+          <div>
+            {activeStreaks.map((s) => (
+              <ActiveStreakRow
+                key={`${s.type}-${s.ownerId}`}
+                s={s}
+                managers={managers}
+              />
+            ))}
+          </div>
+          <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 10 }}>
+            Trailing runs only — computed from each manager's most recent game, walking backwards until the streak breaks.
+          </div>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/league/sections/weekly-recap.jsx
+++ b/frontend/app/league/sections/weekly-recap.jsx
@@ -1,0 +1,188 @@
+"use client";
+
+// WeeklyRecapSection — "Recaps" tab on /league.
+//
+// Grid of per-week recap cards ordered newest first.  Each card links
+// to the full dedicated recap page at ``/league/week/[season]/[week]``.
+
+import Link from "next/link";
+import { Avatar, Card, EmptyCard, fmtNumber, nameFor } from "../shared.jsx";
+
+function RecapCard({ recap, managers }) {
+  const { season, week, isPlayoff, headline, summary, mvp, blowout, nailBiter, badBeat, matchups, trades } = recap;
+  return (
+    <Link
+      href={`/league/week/${encodeURIComponent(season)}/${encodeURIComponent(week)}`}
+      style={{
+        textDecoration: "none",
+        color: "inherit",
+        display: "block",
+      }}
+    >
+      <div
+        className="card"
+        style={{
+          cursor: "pointer",
+          transition: "border-color 0.15s",
+          height: "100%",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: 8,
+          }}
+        >
+          <div>
+            <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+              {season} · Week {week}{isPlayoff ? " · playoffs" : ""}
+            </div>
+            <div style={{ fontSize: "1.02rem", fontWeight: 700, marginTop: 2, lineHeight: 1.25 }}>
+              {headline}
+            </div>
+          </div>
+          <span
+            style={{
+              background: "var(--bg-subtle)",
+              color: "var(--cyan)",
+              padding: "3px 8px",
+              borderRadius: 10,
+              fontSize: "0.62rem",
+              whiteSpace: "nowrap",
+            }}
+          >
+            Read →
+          </span>
+        </div>
+
+        <div style={{ fontSize: "0.78rem", color: "var(--subtext)", marginTop: 8, lineHeight: 1.45 }}>
+          {summary}
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 8,
+            marginTop: 10,
+          }}
+        >
+          {mvp && (
+            <MiniStat
+              label="Weekly MVP"
+              color="#2ecc71"
+              managers={managers}
+              ownerId={mvp.ownerId}
+              value={`${fmtNumber(mvp.points, 1)} pts`}
+            />
+          )}
+          {blowout && (
+            <MiniStat
+              label="Blowout"
+              color="#ffa726"
+              managers={managers}
+              ownerId={blowout.winner.ownerId}
+              value={`+${fmtNumber(blowout.margin, 1)}`}
+            />
+          )}
+          {nailBiter && (
+            <MiniStat
+              label="Nailbiter"
+              color="#4fc3f7"
+              managers={managers}
+              ownerId={nailBiter.winner.ownerId}
+              value={`${fmtNumber(nailBiter.margin, 2)} margin`}
+            />
+          )}
+          {badBeat && (
+            <MiniStat
+              label="Bad beat"
+              color="#ff6b6b"
+              managers={managers}
+              ownerId={badBeat.ownerId}
+              value={`${fmtNumber(badBeat.points, 1)} in L`}
+            />
+          )}
+        </div>
+
+        <div
+          style={{
+            fontSize: "0.64rem",
+            color: "var(--subtext)",
+            marginTop: 8,
+            display: "flex",
+            gap: 10,
+          }}
+        >
+          <span>
+            {matchups?.length || 0} matchup{(matchups?.length || 0) === 1 ? "" : "s"}
+          </span>
+          {(trades?.length || 0) > 0 && (
+            <span style={{ color: "var(--cyan)" }}>
+              · {trades.length} trade{trades.length === 1 ? "" : "s"} on the wire
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function MiniStat({ label, color, managers, ownerId, value }) {
+  return (
+    <div
+      style={{
+        padding: 6,
+        borderLeft: `3px solid ${color}`,
+        background: "var(--bg-subtle)",
+        borderRadius: 4,
+      }}
+    >
+      <div style={{ fontSize: "0.58rem", color: "var(--subtext)", textTransform: "uppercase" }}>
+        {label}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 3 }}>
+        {ownerId && <Avatar managers={managers} ownerId={ownerId} size={18} />}
+        <span style={{ fontSize: "0.74rem" }}>
+          <strong>{nameFor(managers, ownerId)}</strong>{" "}
+          <span style={{ color, fontFamily: "var(--mono)" }}>{value}</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function WeeklyRecapSection({ data, managers }) {
+  if (!data || !data.weeks?.length) return <EmptyCard label="Weekly recaps" />;
+
+  return (
+    <section>
+      <Card
+        title="Weekly recaps"
+        action={
+          <span style={{ fontSize: "0.62rem", color: "var(--subtext)" }}>
+            Click any card to read the full recap
+          </span>
+        }
+      >
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
+            gap: 10,
+          }}
+        >
+          {data.weeks.map((recap) => (
+            <RecapCard
+              key={`${recap.season}:${recap.week}`}
+              recap={recap}
+              managers={managers}
+            />
+          ))}
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/app/league/week/[season]/[week]/page.jsx
+++ b/frontend/app/league/week/[season]/[week]/page.jsx
@@ -1,0 +1,340 @@
+// Server-rendered weekly-recap page with OG metadata.
+//
+// Fetches the full ``weeklyRecap`` section once, picks the specific
+// week by the ``byKey`` map, and renders a long-form narrative page.
+// Sharable URL pattern: ``/league/week/{season}/{week}``.
+
+import Link from "next/link";
+import { Avatar, Card } from "../../../shared-server.jsx";
+import { buildManagerLookup, fmtPoints, fmtNumber, nameFor } from "../../../shared-helpers.js";
+import { EmptyState, PageHeader } from "@/components/ui";
+import ShareButton from "../../../ShareButton.jsx";
+
+function _backend() {
+  const base = process.env.BACKEND_API_URL || "http://127.0.0.1:8000";
+  try {
+    const u = new URL(base);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return "http://127.0.0.1:8000";
+  }
+}
+
+async function fetchRecap() {
+  const url = `${_backend()}/api/public/league/weeklyRecap`;
+  try {
+    const res = await fetch(url, { next: { revalidate: 60 } });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+function findRecap(payload, season, week) {
+  const byKey = payload?.data?.byKey || {};
+  return byKey[`${season}:${week}`] || null;
+}
+
+// ── Metadata ────────────────────────────────────────────────────────────
+export async function generateMetadata({ params }) {
+  const { season, week } = await params;
+  const payload = await fetchRecap();
+  const recap = findRecap(payload, String(season), String(week));
+  if (!recap) {
+    return {
+      title: `Week ${week} · ${season} recap`,
+      description: `Weekly recap for the Brisket dynasty league, ${season} week ${week}.`,
+    };
+  }
+  const title = recap.headline || `${season} Week ${week} recap`;
+  const description = recap.summary || "";
+  return {
+    title: `${title} — ${season} Week ${week}`,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      siteName: "Risk It To Get The Brisket",
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+// ── Page ────────────────────────────────────────────────────────────────
+export default async function WeeklyRecapPage({ params }) {
+  const { season, week } = await params;
+  const payload = await fetchRecap();
+  const recap = findRecap(payload, String(season), String(week));
+  const managers = buildManagerLookup(payload?.league);
+
+  if (!recap) {
+    return (
+      <section>
+        <div className="card">
+          <EmptyState
+            title="Recap not found"
+            message={`No recap for ${season} week ${week} — the week may not be scored yet.`}
+          />
+          <div style={{ marginTop: 10 }}>
+            <Link href="/league?tab=weeklyRecap" style={{ color: "var(--cyan)" }}>
+              ← All recaps
+            </Link>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const { isPlayoff, headline, summary, matchups = [], mvp, bust, blowout, nailBiter, badBeat, trades = [] } = recap;
+
+  return (
+    <section>
+      <Card>
+        <PageHeader
+          title={headline}
+          subtitle={`${season} · Week ${week}${isPlayoff ? " (playoffs)" : ""}`}
+        />
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8, marginTop: -8 }}>
+          <Link
+            href="/league?tab=weeklyRecap"
+            style={{
+              color: "var(--cyan)",
+              fontSize: "0.74rem",
+              textDecoration: "none",
+              border: "1px solid var(--border-bright)",
+              padding: "3px 10px",
+              borderRadius: 6,
+            }}
+          >
+            ← All recaps
+          </Link>
+          <ShareButton title={headline} text={summary} />
+        </div>
+        <p style={{ fontSize: "0.96rem", lineHeight: 1.55, marginTop: 4 }}>{summary}</p>
+      </Card>
+
+      {/* Superlatives strip */}
+      <Card title="Superlatives">
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: 10,
+          }}
+        >
+          {mvp && (
+            <SuperlativeCard
+              label="Weekly MVP"
+              color="#2ecc71"
+              managers={managers}
+              ownerId={mvp.ownerId}
+              displayName={mvp.displayName}
+              teamName={mvp.teamName}
+              value={`${fmtPoints(mvp.points)} pts`}
+            />
+          )}
+          {blowout && (
+            <SuperlativeCard
+              label="Biggest blowout"
+              color="#ffa726"
+              managers={managers}
+              ownerId={blowout.winner.ownerId}
+              displayName={blowout.winner.displayName}
+              teamName={blowout.winner.teamName}
+              value={`+${fmtPoints(blowout.margin)} over ${blowout.loser.displayName}`}
+            />
+          )}
+          {nailBiter && (
+            <SuperlativeCard
+              label="Nailbiter"
+              color="#4fc3f7"
+              managers={managers}
+              ownerId={nailBiter.winner.ownerId}
+              displayName={nailBiter.winner.displayName}
+              teamName={nailBiter.winner.teamName}
+              value={`${fmtNumber(nailBiter.margin, 2)} margin over ${nailBiter.loser.displayName}`}
+            />
+          )}
+          {bust && (
+            <SuperlativeCard
+              label="Weekly bust"
+              color="#ff6b6b"
+              managers={managers}
+              ownerId={bust.ownerId}
+              displayName={bust.displayName}
+              teamName={bust.teamName}
+              value={`${fmtPoints(bust.points)} pts`}
+            />
+          )}
+          {badBeat && (
+            <SuperlativeCard
+              label="Bad beat"
+              color="#ec407a"
+              managers={managers}
+              ownerId={badBeat.ownerId}
+              displayName={badBeat.displayName}
+              teamName={badBeat.teamName}
+              value={`${fmtPoints(badBeat.points)} pts in L (by ${fmtPoints(badBeat.marginOfLoss)})`}
+            />
+          )}
+        </div>
+      </Card>
+
+      {/* Matchups */}
+      <Card title={`${matchups.length} matchup${matchups.length === 1 ? "" : "s"}`}>
+        <div>
+          {matchups.map((m, i) => {
+            const winner = m.winner;
+            return (
+              <div
+                key={i}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr auto 1fr auto",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "10px 0",
+                  borderBottom: "1px solid var(--border)",
+                }}
+              >
+                <SideBlock side={m.home} managers={managers} won={winner?.ownerId === m.home.ownerId} align="right" />
+                <div
+                  style={{
+                    textAlign: "center",
+                    fontFamily: "var(--mono)",
+                    color: "var(--subtext)",
+                    fontSize: "0.7rem",
+                  }}
+                >
+                  vs
+                </div>
+                <SideBlock side={m.away} managers={managers} won={winner?.ownerId === m.away.ownerId} align="left" />
+                <div
+                  style={{
+                    fontFamily: "var(--mono)",
+                    textAlign: "right",
+                    color: "var(--subtext)",
+                    fontSize: "0.78rem",
+                  }}
+                >
+                  margin {fmtPoints(m.margin)}
+                </div>
+                <div
+                  style={{
+                    gridColumn: "1 / -1",
+                    fontSize: "0.78rem",
+                    color: "var(--subtext)",
+                    marginTop: -2,
+                    fontStyle: "italic",
+                  }}
+                >
+                  {m.oneliner}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+
+      {trades.length > 0 && (
+        <Card title={`${trades.length} trade${trades.length === 1 ? "" : "s"} on the wire`}>
+          <div>
+            {trades.map((tx, i) => (
+              <div
+                key={tx.transactionId || i}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "8px 0",
+                  borderBottom: "1px solid var(--border)",
+                  fontSize: "0.78rem",
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  {tx.parties?.map((p, j) => (
+                    <span key={p.ownerId}>
+                      <strong>{nameFor(managers, p.ownerId) || p.displayName}</strong>
+                      {j < tx.parties.length - 1 ? " ⇄ " : ""}
+                    </span>
+                  ))}
+                </div>
+                <div style={{ color: "var(--subtext)", fontFamily: "var(--mono)", fontSize: "0.7rem" }}>
+                  {tx.assetsMoved} asset{tx.assetsMoved === 1 ? "" : "s"}
+                  {tx.picksMoved > 0 && ` · ${tx.picksMoved} pick${tx.picksMoved === 1 ? "" : "s"}`}
+                </div>
+                <Link href="/league?tab=activity" style={{ color: "var(--cyan)", fontSize: "0.7rem" }}>
+                  Details →
+                </Link>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </section>
+  );
+}
+
+function SuperlativeCard({ label, color, managers, ownerId, displayName, teamName, value }) {
+  return (
+    <div
+      style={{
+        padding: 10,
+        borderLeft: `3px solid ${color}`,
+        background: "var(--bg-subtle)",
+        borderRadius: 6,
+      }}
+    >
+      <div style={{ fontSize: "0.6rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+        {label}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+        <Avatar managers={managers} ownerId={ownerId} size={24} />
+        <div>
+          <div style={{ fontWeight: 700 }}>{nameFor(managers, ownerId) || displayName}</div>
+          <div style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>{teamName}</div>
+        </div>
+      </div>
+      <div style={{ fontFamily: "var(--mono)", color, fontWeight: 700, marginTop: 6 }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SideBlock({ side, managers, won, align }) {
+  return (
+    <div style={{ textAlign: align }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: align === "right" ? "flex-end" : "flex-start",
+          gap: 6,
+        }}
+      >
+        {align === "left" && <Avatar managers={managers} ownerId={side.ownerId} size={20} />}
+        <div style={{ textAlign: align }}>
+          <div style={{ fontWeight: won ? 800 : 500, color: won ? "#2ecc71" : "inherit" }}>
+            {nameFor(managers, side.ownerId)}
+          </div>
+          <div style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>{side.teamName}</div>
+        </div>
+        {align === "right" && <Avatar managers={managers} ownerId={side.ownerId} size={20} />}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: "1rem",
+          fontWeight: 800,
+          color: won ? "#2ecc71" : "var(--subtext)",
+          marginTop: 2,
+        }}
+      >
+        {fmtPoints(side.points)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/sitemap.js
+++ b/frontend/app/sitemap.js
@@ -46,6 +46,11 @@ export default async function sitemap() {
     "/trades",
     "/draft-capital",
     "/league",
+    "/league?tab=matchupPreview",
+    "/league?tab=power",
+    "/league?tab=luck",
+    "/league?tab=streaks",
+    "/league?tab=weeklyRecap",
     "/league?tab=history",
     "/league?tab=rivalries",
     "/league?tab=awards",
@@ -95,6 +100,22 @@ export default async function sitemap() {
     priority: 0.5,
   }));
 
+  // Weekly-recap entries — one per scored week across the snapshot.
+  // Dedupe by (season, week) since the matchup index repeats it.
+  const recapSeen = new Set();
+  const recapEntries = [];
+  for (const m of matchups) {
+    const key = `${m.season}:${m.week}`;
+    if (recapSeen.has(key)) continue;
+    recapSeen.add(key);
+    recapEntries.push({
+      url: `${origin}/league/week/${encodeURIComponent(m.season)}/${encodeURIComponent(m.week)}`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.6,
+    });
+  }
+
   // Player-journey entries — one per player with activity.  Capped at
   // 2,000 to keep the sitemap under Google's 50k-URL / 50 MB limit.
   const playersPayload = await _fetchJson("/api/public/league/players");
@@ -111,6 +132,7 @@ export default async function sitemap() {
     ...franchiseEntries,
     ...rivalryEntries,
     ...matchupEntries,
+    ...recapEntries,
     ...playerEntries,
   ];
 }

--- a/frontend/lib/public-league-data.js
+++ b/frontend/lib/public-league-data.js
@@ -39,6 +39,11 @@ export const PUBLIC_SECTION_KEYS = Object.freeze([
   "weekly",
   "superlatives",
   "archives",
+  "luck",
+  "streaks",
+  "power",
+  "matchupPreview",
+  "weeklyRecap",
 ]);
 
 async function _getJson(url) {

--- a/src/public_league/__init__.py
+++ b/src/public_league/__init__.py
@@ -18,16 +18,21 @@ assembles them and applies a field allowlist before the payload
 leaves the backend.
 
 Section modules:
-    history        — League History / Hall of Fame
-    rivalries      — Rivalries
-    awards         — Awards
-    records        — Records
-    franchise      — Franchise Pages
-    activity       — Trade Activity Center
-    draft          — Draft Center
-    weekly         — Weekly Recap
-    superlatives   — League Superlatives
-    archives       — Public searchable archives / databases
+    history          — League History / Hall of Fame
+    rivalries        — Rivalries
+    awards           — Awards
+    records          — Records
+    franchise        — Franchise Pages
+    activity         — Trade Activity Center
+    draft            — Draft Center
+    weekly           — Weekly recap (per-week tiles)
+    superlatives     — League Superlatives
+    archives         — Public searchable archives / databases
+    luck             — Luck Score (actual vs expected wins)
+    streaks          — Active streaks + records-in-reach feed
+    power            — Weekly power ranking + time-series chart
+    matchup_preview  — Head-to-head preview / recap for the current week
+    weekly_recap     — Full-page weekly recap newsletter
 
 Infrastructure modules:
     identity        — Owner-id-keyed manager identity + team aliases

--- a/src/public_league/luck.py
+++ b/src/public_league/luck.py
@@ -1,0 +1,355 @@
+"""Luck Score section: expected wins vs actual wins.
+
+For each completed regular-season week, compute each owner's "all-play"
+record — how many of the other teams they would have beaten if
+everyone played everyone that week.  Convert that to an expected win
+share, sum across the season, and compare to actual wins.
+
+    expected_wins(owner) = Σ_week (beats + ties * 0.5) / (rivals)
+    actual_wins(owner)   = Σ_week actual_w + actual_t * 0.5
+    luck_delta           = actual_wins − expected_wins
+
+A positive delta means the owner has won more than their weekly score
+profile alone would predict — lucky matchup draw or timely ceiling
+games.  A negative delta means the owner has lost more than the
+scores warrant — close losses, schedule grind, or peak weeks wasted
+on an opponent who happened to peak higher.
+
+We restrict luck accounting to **regular season** only.  Playoffs
+conflate bracket position with scoring skill and muddy the metric.
+
+Output shape
+────────────
+``byOwnerCareer``      — one row per owner aggregated across every
+                         scored regular-season week in every season.
+``byOwnerSeason``      — one row per (owner, season) pair.
+``currentSeasonRanked``— ``byOwnerSeason`` filtered to the current
+                         season, ranked luckiest → unluckiest, for a
+                         quick Home-tab card.
+``weeklyTrail``        — chronological per-owner timeline of weekly
+                         and cumulative luck deltas.  Drives the
+                         sparkline.
+``seasonsCovered``     — list of season ids included.
+``methodology``        — human-readable formula so the UI can render
+                         the "how this is computed" footnote.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from . import metrics
+from .identity import ManagerRegistry
+from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
+
+
+# ── All-play primitive ───────────────────────────────────────────────────
+def _all_play_week(
+    scores: list[tuple[str, float]],
+) -> dict[str, dict[str, float | int]]:
+    """Compute per-owner all-play stats for a single week's scored roster-weeks.
+
+    Returns ``{owner_id: {"beats": int, "ties": int, "rivals": int,
+    "expectedShare": float}}``.  ``expectedShare`` is ``(beats + ties*0.5) / rivals``.
+    """
+    n = len(scores)
+    if n < 2:
+        return {}
+    rivals = n - 1
+    out: dict[str, dict[str, float | int]] = {}
+    for i, (oid_i, pts_i) in enumerate(scores):
+        beats = 0
+        ties = 0
+        for j, (_oid_j, pts_j) in enumerate(scores):
+            if i == j:
+                continue
+            if pts_i > pts_j:
+                beats += 1
+            elif pts_i == pts_j:
+                ties += 1
+        out[oid_i] = {
+            "beats": beats,
+            "ties": ties,
+            "rivals": rivals,
+            "expectedShare": (beats + ties * 0.5) / rivals,
+        }
+    return out
+
+
+def _season_weekly_scores(
+    season: SeasonSnapshot,
+    registry: ManagerRegistry,
+) -> dict[int, list[tuple[str, float]]]:
+    """Return ``{week: [(owner_id, points), ...]}`` for every scored
+    regular-season week.  Entries that can't be resolved to an owner are skipped.
+    """
+    out: dict[int, list[tuple[str, float]]] = {}
+    for wk in season.regular_season_weeks:
+        rows: list[tuple[str, float]] = []
+        for entry in season.matchups_by_week.get(wk) or []:
+            if not metrics.is_scored(entry):
+                continue
+            owner_id = metrics.resolve_owner(registry, season.league_id, entry.get("roster_id"))
+            if not owner_id:
+                continue
+            rows.append((owner_id, metrics.matchup_points(entry)))
+        if rows:
+            out[wk] = rows
+    return out
+
+
+def _actual_week_results(
+    season: SeasonSnapshot,
+    week: int,
+    registry: ManagerRegistry,
+) -> tuple[dict[str, float], dict[str, tuple[float, float]]]:
+    """Return (actual_share, pair_points) for the given week.
+
+    * ``actual_share[owner_id]`` — 1.0 / 0.5 / 0.0 for W / T / L.
+    * ``pair_points[owner_id]`` — ``(pointsFor, pointsAgainst)`` for the
+      owner's matchup (0/0 if Sleeper didn't pair them).
+    """
+    pairs = metrics.matchup_pairs(season.matchups_by_week.get(week) or [])
+    actual: dict[str, float] = {}
+    pair_pts: dict[str, tuple[float, float]] = {}
+    for a, b in pairs:
+        if not metrics.is_scored(a) and not metrics.is_scored(b):
+            continue
+        pa, pb = metrics.matchup_points(a), metrics.matchup_points(b)
+        oa = metrics.resolve_owner(registry, season.league_id, a.get("roster_id"))
+        ob = metrics.resolve_owner(registry, season.league_id, b.get("roster_id"))
+        if oa:
+            pair_pts[oa] = (pa, pb)
+        if ob:
+            pair_pts[ob] = (pb, pa)
+        if pa > pb:
+            if oa:
+                actual[oa] = 1.0
+            if ob:
+                actual[ob] = 0.0
+        elif pb > pa:
+            if oa:
+                actual[oa] = 0.0
+            if ob:
+                actual[ob] = 1.0
+        else:
+            if oa:
+                actual[oa] = 0.5
+            if ob:
+                actual[ob] = 0.5
+    return actual, pair_pts
+
+
+def _roster_id_for_owner(
+    registry: ManagerRegistry, league_id: str, owner_id: str
+) -> int | None:
+    for (lid, rid), oid in registry.roster_to_owner.items():
+        if lid == league_id and oid == owner_id:
+            return rid
+    return None
+
+
+def _season_sort_key(season: str) -> int:
+    try:
+        return int(season)
+    except (TypeError, ValueError):
+        return 0
+
+
+# ── Build section ────────────────────────────────────────────────────────
+def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    """Assemble the luck-score section payload."""
+    registry = snapshot.managers
+
+    def _blank_career() -> dict[str, Any]:
+        return {
+            "ownerId": "",
+            "displayName": "",
+            "teamName": "",
+            "gamesPlayed": 0,
+            "actualWins": 0.0,
+            "expectedWins": 0.0,
+            "pointsFor": 0.0,
+            "pointsAgainst": 0.0,
+            "allPlayBeats": 0,
+            "allPlayTies": 0,
+            "allPlayRivals": 0,
+        }
+
+    by_owner_career: dict[str, dict[str, Any]] = defaultdict(_blank_career)
+    by_owner_season: dict[tuple[str, str], dict[str, Any]] = {}
+    weekly_trail: list[dict[str, Any]] = []
+
+    # Owner → running cumulative totals for the trail (across seasons).
+    trail_state: dict[str, dict[str, float]] = defaultdict(
+        lambda: {"expected": 0.0, "actual": 0.0, "games": 0}
+    )
+
+    current_season_year = (
+        snapshot.current_season.season if snapshot.current_season else None
+    )
+
+    # Iterate oldest → newest so ``trail_state`` cumulative counters
+    # match the final chronological sort of ``weekly_trail``.  If we
+    # walked most-recent-first (the snapshot's natural order), cumGames
+    # would decrease in the sorted output.
+    for season in sorted(snapshot.seasons, key=lambda s: _season_sort_key(s.season)):
+        week_scores = _season_weekly_scores(season, registry)
+        for wk in sorted(week_scores.keys()):
+            scores = week_scores[wk]
+            all_play = _all_play_week(scores)
+            actual, pair_pts = _actual_week_results(season, wk, registry)
+
+            for oid, ap in all_play.items():
+                pts_for, pts_against = pair_pts.get(oid, (0.0, 0.0))
+                expected_share = float(ap["expectedShare"])
+                actual_share = actual.get(oid, 0.0)
+
+                # Career aggregate.
+                career = by_owner_career[oid]
+                if not career["ownerId"]:
+                    career["ownerId"] = oid
+                    career["displayName"] = metrics.display_name_for(snapshot, oid)
+                    current = snapshot.current_season
+                    if current:
+                        rid_current = _roster_id_for_owner(registry, current.league_id, oid)
+                        career["teamName"] = metrics.team_name(snapshot, current.league_id, rid_current)
+                career["gamesPlayed"] += 1
+                career["expectedWins"] += expected_share
+                career["actualWins"] += actual_share
+                career["pointsFor"] += pts_for
+                career["pointsAgainst"] += pts_against
+                career["allPlayBeats"] += int(ap["beats"])
+                career["allPlayTies"] += int(ap["ties"])
+                career["allPlayRivals"] += int(ap["rivals"])
+
+                # Season aggregate.
+                key = (oid, season.season)
+                if key not in by_owner_season:
+                    rid = _roster_id_for_owner(registry, season.league_id, oid)
+                    by_owner_season[key] = {
+                        "ownerId": oid,
+                        "season": season.season,
+                        "leagueId": season.league_id,
+                        "displayName": metrics.display_name_for(snapshot, oid),
+                        "teamName": metrics.team_name(snapshot, season.league_id, rid),
+                        "gamesPlayed": 0,
+                        "actualWins": 0.0,
+                        "expectedWins": 0.0,
+                        "pointsFor": 0.0,
+                        "pointsAgainst": 0.0,
+                        "allPlayBeats": 0,
+                        "allPlayTies": 0,
+                        "allPlayRivals": 0,
+                    }
+                s = by_owner_season[key]
+                s["gamesPlayed"] += 1
+                s["actualWins"] += actual_share
+                s["expectedWins"] += expected_share
+                s["pointsFor"] += pts_for
+                s["pointsAgainst"] += pts_against
+                s["allPlayBeats"] += int(ap["beats"])
+                s["allPlayTies"] += int(ap["ties"])
+                s["allPlayRivals"] += int(ap["rivals"])
+
+                # Trail (owner-scoped cumulative).
+                t = trail_state[oid]
+                t["expected"] += expected_share
+                t["actual"] += actual_share
+                t["games"] += 1
+                weekly_trail.append({
+                    "ownerId": oid,
+                    "season": season.season,
+                    "week": wk,
+                    "weekExpected": round(expected_share, 4),
+                    "weekActual": round(actual_share, 4),
+                    "weekLuckDelta": round(actual_share - expected_share, 4),
+                    "weekPoints": round(pts_for, 2),
+                    "cumExpected": round(t["expected"], 4),
+                    "cumActual": round(t["actual"], 4),
+                    "cumLuckDelta": round(t["actual"] - t["expected"], 4),
+                    "cumGames": int(t["games"]),
+                })
+
+    # Finalize career rows.
+    career_rows: list[dict[str, Any]] = []
+    for oid, row in by_owner_career.items():
+        games = row["gamesPlayed"]
+        actual = row["actualWins"]
+        expected = row["expectedWins"]
+        rivals = row["allPlayRivals"]
+        career_rows.append({
+            "ownerId": oid,
+            "displayName": row["displayName"],
+            "teamName": row["teamName"],
+            "gamesPlayed": games,
+            "actualWins": round(actual, 2),
+            "expectedWins": round(expected, 2),
+            "luckDelta": round(actual - expected, 2),
+            "luckPerGame": round((actual - expected) / games, 4) if games else 0.0,
+            "actualWinPct": round(actual / games, 4) if games else 0.0,
+            "expectedWinPct": round(expected / games, 4) if games else 0.0,
+            "allPlayWinPct": round(
+                (row["allPlayBeats"] + row["allPlayTies"] * 0.5) / rivals, 4
+            ) if rivals else 0.0,
+            "allPlayBeats": row["allPlayBeats"],
+            "allPlayTies": row["allPlayTies"],
+            "allPlayLosses": rivals - row["allPlayBeats"] - row["allPlayTies"],
+            "pointsFor": round(row["pointsFor"], 2),
+            "pointsAgainst": round(row["pointsAgainst"], 2),
+        })
+    career_rows.sort(key=lambda r: -r["luckDelta"])
+
+    # Finalize season rows.
+    season_rows: list[dict[str, Any]] = []
+    for row in by_owner_season.values():
+        games = row["gamesPlayed"]
+        actual = row["actualWins"]
+        expected = row["expectedWins"]
+        rivals = row["allPlayRivals"]
+        season_rows.append({
+            "ownerId": row["ownerId"],
+            "season": row["season"],
+            "leagueId": row["leagueId"],
+            "displayName": row["displayName"],
+            "teamName": row["teamName"],
+            "gamesPlayed": games,
+            "actualWins": round(actual, 2),
+            "expectedWins": round(expected, 2),
+            "luckDelta": round(actual - expected, 2),
+            "luckPerGame": round((actual - expected) / games, 4) if games else 0.0,
+            "actualWinPct": round(actual / games, 4) if games else 0.0,
+            "expectedWinPct": round(expected / games, 4) if games else 0.0,
+            "allPlayWinPct": round(
+                (row["allPlayBeats"] + row["allPlayTies"] * 0.5) / rivals, 4
+            ) if rivals else 0.0,
+            "pointsFor": round(row["pointsFor"], 2),
+            "pointsAgainst": round(row["pointsAgainst"], 2),
+        })
+    # Most recent season first; within a season, luckiest first.
+    season_rows.sort(key=lambda r: (-_season_sort_key(r["season"]), -r["luckDelta"]))
+
+    weekly_trail.sort(
+        key=lambda t: (_season_sort_key(t["season"]), t["week"], t["ownerId"])
+    )
+
+    current_season_rows = [r for r in season_rows if r["season"] == current_season_year]
+    current_season_rows.sort(key=lambda r: -r["luckDelta"])
+
+    return {
+        "seasonsCovered": [s.season for s in snapshot.seasons],
+        "currentSeason": current_season_year,
+        "byOwnerCareer": career_rows,
+        "byOwnerSeason": season_rows,
+        "currentSeasonRanked": current_season_rows,
+        "weeklyTrail": weekly_trail,
+        "luckiestCareer": career_rows[0] if career_rows else None,
+        "unluckiestCareer": career_rows[-1] if career_rows else None,
+        "luckiestCurrent": current_season_rows[0] if current_season_rows else None,
+        "unluckiestCurrent": current_season_rows[-1] if current_season_rows else None,
+        "methodology": (
+            "Expected wins = sum of weekly all-play win share "
+            "((beats + ties*0.5) / (teams-1)). Luck delta = actual wins "
+            "minus expected wins. Regular season only."
+        ),
+    }

--- a/src/public_league/matchup_preview.py
+++ b/src/public_league/matchup_preview.py
@@ -1,0 +1,348 @@
+"""Section: Head-to-Head Matchup Preview.
+
+For each matchup on the upcoming (or most recent) week, surface:
+    * All-time head-to-head record between the two owners.
+    * Last 5 meetings with dates / scores / winner.
+    * Recent form — last 3 games per team (average points, W-L).
+
+Current-week detection:
+    1. Walk the current season's weeks in order.
+    2. The current week is the first week whose matchup rows exist
+       but have at least one unscored entry.
+    3. If no such week exists (every scheduled matchup already has a
+       score), fall back to the most recently scored week.  The UI can
+       then render the section as "This week's results" instead of a
+       preview — both modes use the same H2H context.
+
+Output shape
+────────────
+``currentSeason``    — season id of the preview / recap week.
+``currentWeek``      — int week number.
+``mode``             — ``"preview"`` (unscored) or ``"recap"`` (scored).
+``isPlayoff``        — passthrough for styling.
+``matchups``         — list of ``{home, away, h2h, form, scores}``.
+``generatedAt``      — iso timestamp for cache debugging.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from . import metrics
+from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
+
+
+def _detect_current_week(season: SeasonSnapshot) -> tuple[int, str]:
+    """Return (week, mode).  ``mode`` is ``"preview"`` if there are
+    unscored matchups in the week, else ``"recap"``.
+    """
+    for wk in season.all_weeks:
+        entries = season.matchups_by_week.get(wk) or []
+        if not entries:
+            continue
+        has_scored = any(metrics.is_scored(e) for e in entries)
+        has_unscored = any(not metrics.is_scored(e) for e in entries)
+        # A "current" week is one where Sleeper has matchup rows but
+        # not every team has posted a final score.  If every row is
+        # unscored, it's a future week; we still preview it.
+        if not has_scored:
+            return wk, "preview"
+        if has_unscored:
+            return wk, "preview"
+    # All weeks fully scored → recap the most recent one.
+    last = 0
+    for wk in season.all_weeks:
+        entries = season.matchups_by_week.get(wk) or []
+        if any(metrics.is_scored(e) for e in entries):
+            last = wk
+    return last, "recap"
+
+
+def _pair_key(a: str, b: str) -> tuple[str, str]:
+    return (a, b) if a <= b else (b, a)
+
+
+def _build_h2h_index(
+    snapshot: PublicLeagueSnapshot,
+) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    """Walk every scored matchup pair and index meetings by the canonical
+    owner-id tuple.  Meetings are ordered chronologically (oldest first).
+    """
+    idx: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for season, wk, a, b, is_playoff in metrics.walk_matchup_pairs(snapshot):
+        oa = metrics.resolve_owner(snapshot.managers, season.league_id, a.get("roster_id"))
+        ob = metrics.resolve_owner(snapshot.managers, season.league_id, b.get("roster_id"))
+        if not oa or not ob or oa == ob:
+            continue
+        pa = metrics.matchup_points(a)
+        pb = metrics.matchup_points(b)
+        if pa <= 0 and pb <= 0:
+            continue
+        key = _pair_key(oa, ob)
+        # Normalize so the key's first entry is always "sideA".
+        sideA_oid, sideB_oid = key
+        sideA_pts = pa if oa == sideA_oid else pb
+        sideB_pts = pb if oa == sideA_oid else pa
+        if sideA_pts > sideB_pts:
+            winner = sideA_oid
+        elif sideB_pts > sideA_pts:
+            winner = sideB_oid
+        else:
+            winner = None
+        idx[key].append({
+            "season": season.season,
+            "leagueId": season.league_id,
+            "week": wk,
+            "isPlayoff": is_playoff,
+            "sideAOwnerId": sideA_oid,
+            "sideBOwnerId": sideB_oid,
+            "sideAPoints": round(sideA_pts, 2),
+            "sideBPoints": round(sideB_pts, 2),
+            "winnerOwnerId": winner,
+            "margin": round(abs(sideA_pts - sideB_pts), 2),
+        })
+    for meetings in idx.values():
+        meetings.sort(
+            key=lambda m: (_season_sort(m["season"]), m["week"])
+        )
+    return idx
+
+
+def _season_sort(season: str) -> int:
+    try:
+        return int(season)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _recent_form_for_owner(
+    snapshot: PublicLeagueSnapshot,
+    owner_id: str,
+    before_season: str,
+    before_week: int,
+    n: int = 3,
+) -> dict[str, Any]:
+    """Return the owner's last ``n`` scored games STRICTLY before
+    (season, week), oldest → newest.  Includes playoffs.
+    """
+    events: list[dict[str, Any]] = []
+    for season, wk, a, b, is_playoff in metrics.walk_matchup_pairs(snapshot):
+        # Strictly-before test.
+        if _season_sort(season.season) > _season_sort(before_season):
+            continue
+        if (
+            _season_sort(season.season) == _season_sort(before_season)
+            and wk >= before_week
+        ):
+            continue
+        for me, foe in ((a, b), (b, a)):
+            rid = metrics.roster_id_of(me)
+            if rid is None:
+                continue
+            oid = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if oid != owner_id:
+                continue
+            my_pts = metrics.matchup_points(me)
+            opp_pts = metrics.matchup_points(foe)
+            if my_pts <= 0 and opp_pts <= 0:
+                continue
+            if my_pts > opp_pts:
+                result = "W"
+            elif my_pts < opp_pts:
+                result = "L"
+            else:
+                result = "T"
+            events.append({
+                "season": season.season,
+                "week": wk,
+                "points": round(my_pts, 2),
+                "opponentPoints": round(opp_pts, 2),
+                "result": result,
+            })
+    events.sort(key=lambda e: (_season_sort(e["season"]), e["week"]))
+    recent = events[-n:]
+    wins = sum(1 for e in recent if e["result"] == "W")
+    losses = sum(1 for e in recent if e["result"] == "L")
+    ties = sum(1 for e in recent if e["result"] == "T")
+    avg = round(sum(e["points"] for e in recent) / len(recent), 2) if recent else 0.0
+    return {
+        "games": recent,
+        "record": f"{wins}-{losses}" + (f"-{ties}" if ties else ""),
+        "avgPoints": avg,
+    }
+
+
+def _h2h_summary(meetings: list[dict[str, Any]], sideA_oid: str, sideB_oid: str) -> dict[str, Any]:
+    """Summarize the full series between two owners."""
+    wins_a = 0
+    wins_b = 0
+    ties = 0
+    pts_a = 0.0
+    pts_b = 0.0
+    margins = []
+    playoff_meetings = 0
+    for m in meetings:
+        aligned_a = m["sideAOwnerId"] == sideA_oid
+        a_pts = m["sideAPoints"] if aligned_a else m["sideBPoints"]
+        b_pts = m["sideBPoints"] if aligned_a else m["sideAPoints"]
+        pts_a += a_pts
+        pts_b += b_pts
+        margins.append(a_pts - b_pts)
+        if a_pts > b_pts:
+            wins_a += 1
+        elif b_pts > a_pts:
+            wins_b += 1
+        else:
+            ties += 1
+        if m.get("isPlayoff"):
+            playoff_meetings += 1
+    total = len(meetings)
+    avg_margin = round(sum(abs(m) for m in margins) / total, 2) if total else 0.0
+    biggest = max(margins, key=lambda m: abs(m)) if margins else 0.0
+    return {
+        "totalMeetings": total,
+        "sideAWins": wins_a,
+        "sideBWins": wins_b,
+        "ties": ties,
+        "sideAPointsTotal": round(pts_a, 2),
+        "sideBPointsTotal": round(pts_b, 2),
+        "avgMargin": avg_margin,
+        "biggestMargin": round(abs(biggest), 2),
+        "biggestMarginWinner": sideA_oid if biggest > 0 else (sideB_oid if biggest < 0 else None),
+        "playoffMeetings": playoff_meetings,
+    }
+
+
+def _meetings_recent(meetings: list[dict[str, Any]], n: int = 5) -> list[dict[str, Any]]:
+    return list(reversed(meetings[-n:])) if meetings else []
+
+
+def _narrative(summary: dict[str, Any], sideA_name: str, sideB_name: str, last: dict[str, Any] | None) -> str:
+    """Short 1-2 sentence summary."""
+    total = summary["totalMeetings"]
+    if total == 0:
+        return f"First ever meeting between {sideA_name} and {sideB_name}."
+    a, b = summary["sideAWins"], summary["sideBWins"]
+    lead_bit = (
+        f"{sideA_name} leads the series {a}-{b}"
+        if a > b
+        else f"{sideB_name} leads the series {b}-{a}"
+        if b > a
+        else f"series tied {a}-{a}"
+    )
+    last_bit = ""
+    if last:
+        if last["winnerOwnerId"] == summary.get("_sideA_oid"):
+            winner_name = sideA_name
+        elif last["winnerOwnerId"] == summary.get("_sideB_oid"):
+            winner_name = sideB_name
+        else:
+            winner_name = None
+        if winner_name:
+            last_bit = f"; most recent: {winner_name} by {last['margin']:.1f} in {last['season']} wk {last['week']}"
+    return f"{lead_bit}{last_bit}."
+
+
+def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    current = snapshot.current_season
+    if current is None:
+        return _empty_section()
+
+    week, mode = _detect_current_week(current)
+    if week == 0:
+        return _empty_section()
+
+    entries = current.matchups_by_week.get(week) or []
+    pairs = metrics.matchup_pairs(entries)
+    if not pairs:
+        return _empty_section()
+
+    h2h_index = _build_h2h_index(snapshot)
+
+    out_matchups: list[dict[str, Any]] = []
+    is_playoff = week >= current.playoff_week_start
+    for a, b in pairs:
+        oa = metrics.resolve_owner(snapshot.managers, current.league_id, a.get("roster_id"))
+        ob = metrics.resolve_owner(snapshot.managers, current.league_id, b.get("roster_id"))
+        if not oa or not ob:
+            continue
+        key = _pair_key(oa, ob)
+        sideA_oid, sideB_oid = key
+        meetings = h2h_index.get(key, [])
+        summary = _h2h_summary(meetings, sideA_oid, sideB_oid)
+        summary["_sideA_oid"] = sideA_oid
+        summary["_sideB_oid"] = sideB_oid
+        recent = _meetings_recent(meetings, n=5)
+        form_a = _recent_form_for_owner(
+            snapshot, sideA_oid, current.season, week, n=3
+        )
+        form_b = _recent_form_for_owner(
+            snapshot, sideB_oid, current.season, week, n=3
+        )
+
+        home_rid = metrics.roster_id_of(a) if oa == sideA_oid else metrics.roster_id_of(b)
+        away_rid = metrics.roster_id_of(b) if oa == sideA_oid else metrics.roster_id_of(a)
+
+        home_entry = a if oa == sideA_oid else b
+        away_entry = b if oa == sideA_oid else a
+
+        out_matchups.append({
+            "matchupId": a.get("matchup_id"),
+            "home": {
+                "ownerId": sideA_oid,
+                "displayName": metrics.display_name_for(snapshot, sideA_oid),
+                "teamName": metrics.team_name(snapshot, current.league_id, home_rid),
+                "rosterId": home_rid,
+                "points": round(metrics.matchup_points(home_entry), 2) if mode == "recap" else None,
+            },
+            "away": {
+                "ownerId": sideB_oid,
+                "displayName": metrics.display_name_for(snapshot, sideB_oid),
+                "teamName": metrics.team_name(snapshot, current.league_id, away_rid),
+                "rosterId": away_rid,
+                "points": round(metrics.matchup_points(away_entry), 2) if mode == "recap" else None,
+            },
+            "h2h": {
+                "totalMeetings": summary["totalMeetings"],
+                "homeWins": summary["sideAWins"],
+                "awayWins": summary["sideBWins"],
+                "ties": summary["ties"],
+                "avgMargin": summary["avgMargin"],
+                "biggestMargin": summary["biggestMargin"],
+                "biggestMarginWinnerOwnerId": summary["biggestMarginWinner"],
+                "playoffMeetings": summary["playoffMeetings"],
+                "last5": recent,
+                "lastMeeting": recent[0] if recent else None,
+                "narrative": _narrative(
+                    summary,
+                    metrics.display_name_for(snapshot, sideA_oid),
+                    metrics.display_name_for(snapshot, sideB_oid),
+                    recent[0] if recent else None,
+                ),
+            },
+            "form": {
+                "home": form_a,
+                "away": form_b,
+            },
+        })
+
+    return {
+        "currentSeason": current.season,
+        "currentWeek": week,
+        "mode": mode,
+        "isPlayoff": is_playoff,
+        "matchups": out_matchups,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _empty_section() -> dict[str, Any]:
+    return {
+        "currentSeason": None,
+        "currentWeek": None,
+        "mode": None,
+        "isPlayoff": False,
+        "matchups": [],
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+    }

--- a/src/public_league/power.py
+++ b/src/public_league/power.py
@@ -1,0 +1,219 @@
+"""Section: Weekly Power Ranking.
+
+A composite per-week power score for each owner, drawn from three
+signals:
+
+    * Points per game (PPG) — overall scoring strength, season-to-date.
+    * Recent form           — average PPG over the last 3 regular-season games.
+    * All-play win %        — strength of score distribution irrespective
+                              of schedule luck (mirrors ``luck.py``).
+
+Each signal is converted to a percentile rank within that week's set of
+owners (0 = worst in league, 1 = best), then combined into a 0-100
+power score:
+
+    power = 100 * (0.50 * PPG%ile + 0.25 * recent%ile + 0.25 * allPlayWin%)
+
+We emit a per-week ranking + a flat time-series per owner so the UI can
+render both a table and a line chart without re-computing.
+
+Output shape
+────────────
+``seasonsCovered``    — passthrough.
+``weeks``             — list of ``{season, week, rankings: [...]}`` sorted
+                        chronologically.  Each ranking row carries:
+                          - ``rank``, ``ownerId``, ``displayName``,
+                            ``teamName``, ``power``, ``components``,
+                            ``weekRankDelta`` (change vs prior week),
+                            ``record`` (season-to-date W-L).
+``seriesByOwner``     — flat time-series per owner: list of ``{season,
+                        week, power, rank}`` ordered by (season, week).
+``currentRanking``    — rankings of the most recently completed week.
+``methodology``       — human-readable formula.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from . import luck, metrics
+from .snapshot import PublicLeagueSnapshot
+
+
+# Composite weights.  These sum to 1.0.
+_W_PPG = 0.50
+_W_RECENT = 0.25
+_W_ALLPLAY = 0.25
+
+_RECENT_WINDOW = 3
+
+
+def _percentile_rank(values: list[float], target: float) -> float:
+    """Fraction of ``values`` strictly less than ``target`` + half the
+    count equal to ``target`` (midrank tiebreak).  Returns 0-1.
+    """
+    n = len(values)
+    if n <= 1:
+        return 0.5
+    below = sum(1 for v in values if v < target)
+    equal = sum(1 for v in values if v == target)
+    return (below + (equal - 1) * 0.5) / (n - 1)
+
+
+def _season_sort_key(season: str) -> int:
+    try:
+        return int(season)
+    except (TypeError, ValueError):
+        return 0
+
+
+def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    registry = snapshot.managers
+    weeks_out: list[dict[str, Any]] = []
+    # owner → list of {season, week, power, rank, pointsForThisWeek}
+    series: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    # Track per-owner running totals across the ORDERED walk.  We iterate
+    # oldest → newest so PPG accumulates chronologically.
+    seasons_sorted = sorted(
+        snapshot.seasons, key=lambda s: _season_sort_key(s.season)
+    )
+
+    # Cross-season continuous accumulators (career PPG-to-date).
+    career_state: dict[str, dict[str, float | int]] = defaultdict(
+        lambda: {"points": 0.0, "games": 0, "wins": 0.0, "losses": 0.0}
+    )
+
+    for season in seasons_sorted:
+        week_scores = luck._season_weekly_scores(season, registry)
+
+        # Per-owner rolling buffer for recent-form average.
+        recent_buffer: dict[str, list[float]] = defaultdict(list)
+
+        # Track prior-week rank per owner for delta computation.
+        prior_rank: dict[str, int] = {}
+
+        for wk in sorted(week_scores.keys()):
+            scores = week_scores[wk]
+            all_play = luck._all_play_week(scores)
+            actuals, _pair = luck._actual_week_results(season, wk, registry)
+
+            # Update running state for every owner that played.
+            for oid, pts in scores:
+                s = career_state[oid]
+                s["points"] += pts
+                s["games"] += 1
+                # Recent buffer (FIFO of _RECENT_WINDOW size).
+                rb = recent_buffer[oid]
+                rb.append(pts)
+                if len(rb) > _RECENT_WINDOW:
+                    rb.pop(0)
+                actual_share = actuals.get(oid, 0.0)
+                s["wins"] += actual_share
+                # Losses is 1.0 - actual_share per game.
+                s["losses"] += 1.0 - actual_share
+
+            # Compute this week's ranking.  Gather per-owner components.
+            owners_this_week = sorted({oid for oid, _ in scores})
+            ppg_vals: dict[str, float] = {}
+            recent_vals: dict[str, float] = {}
+            allplay_vals: dict[str, float] = {}
+            for oid in owners_this_week:
+                s = career_state[oid]
+                ppg_vals[oid] = s["points"] / s["games"] if s["games"] else 0.0
+                rb = recent_buffer[oid]
+                recent_vals[oid] = sum(rb) / len(rb) if rb else 0.0
+                ap = all_play.get(oid) or {}
+                # All-play share uses up to this week's all-play record
+                # aggregated (easier read: just use this week's share
+                # since the full-season all-play matches career PPG
+                # already).  We'd need cum state to get career all-play;
+                # simpler + still useful is current-week all-play share.
+                allplay_vals[oid] = float(ap.get("expectedShare", 0.0))
+
+            ppg_list = [ppg_vals[o] for o in owners_this_week]
+            recent_list = [recent_vals[o] for o in owners_this_week]
+
+            rankings: list[dict[str, Any]] = []
+            for oid in owners_this_week:
+                ppg_pct = _percentile_rank(ppg_list, ppg_vals[oid])
+                recent_pct = _percentile_rank(recent_list, recent_vals[oid])
+                ap_pct = allplay_vals[oid]
+                power = 100.0 * (_W_PPG * ppg_pct + _W_RECENT * recent_pct + _W_ALLPLAY * ap_pct)
+
+                s = career_state[oid]
+                wins = round(s["wins"])
+                games = s["games"]
+                losses = games - wins
+                record = f"{wins}-{losses}"
+
+                rid = luck._roster_id_for_owner(registry, season.league_id, oid)
+                rankings.append({
+                    "ownerId": oid,
+                    "displayName": metrics.display_name_for(snapshot, oid),
+                    "teamName": metrics.team_name(snapshot, season.league_id, rid),
+                    "power": round(power, 2),
+                    "components": {
+                        "pointsPerGame": round(ppg_vals[oid], 2),
+                        "pointsPerGamePct": round(ppg_pct, 4),
+                        "recentAvg": round(recent_vals[oid], 2),
+                        "recentAvgPct": round(recent_pct, 4),
+                        "allPlayWinPctThisWeek": round(ap_pct, 4),
+                    },
+                    "record": record,
+                    "games": games,
+                })
+
+            rankings.sort(key=lambda r: -r["power"])
+            for i, r in enumerate(rankings):
+                r["rank"] = i + 1
+                prior = prior_rank.get(r["ownerId"])
+                r["weekRankDelta"] = (prior - r["rank"]) if prior else 0
+
+            for r in rankings:
+                prior_rank[r["ownerId"]] = r["rank"]
+
+            weeks_out.append({
+                "season": season.season,
+                "leagueId": season.league_id,
+                "week": wk,
+                "rankings": rankings,
+            })
+
+            for r in rankings:
+                series[r["ownerId"]].append({
+                    "season": season.season,
+                    "week": wk,
+                    "power": r["power"],
+                    "rank": r["rank"],
+                    "record": r["record"],
+                })
+
+    series_out = []
+    for oid, pts in series.items():
+        series_out.append({
+            "ownerId": oid,
+            "displayName": metrics.display_name_for(snapshot, oid),
+            "points": pts,
+        })
+
+    current_ranking = weeks_out[-1]["rankings"] if weeks_out else []
+
+    return {
+        "seasonsCovered": [s.season for s in snapshot.seasons],
+        "weeks": weeks_out,
+        "seriesByOwner": series_out,
+        "currentRanking": current_ranking,
+        "methodology": (
+            f"Power = 100 × ({int(_W_PPG * 100)}% × PPG percentile "
+            f"+ {int(_W_RECENT * 100)}% × last-{_RECENT_WINDOW}-game avg percentile "
+            f"+ {int(_W_ALLPLAY * 100)}% × all-play win share). "
+            "Computed weekly; percentiles normalized within each week's active owners."
+        ),
+        "weights": {
+            "pointsPerGame": _W_PPG,
+            "recentForm": _W_RECENT,
+            "allPlayWinPct": _W_ALLPLAY,
+            "recentWindow": _RECENT_WINDOW,
+        },
+    }

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -19,15 +19,20 @@ from . import (
     draft,
     franchise,
     history,
+    luck,
+    matchup_preview,
     overview,
+    power,
     records,
     rivalries,
+    streaks,
     superlatives,
     weekly,
+    weekly_recap,
 )
 from .snapshot import PublicLeagueSnapshot
 
-PUBLIC_CONTRACT_VERSION = "public-league/2026-04-17.v2"
+PUBLIC_CONTRACT_VERSION = "public-league/2026-04-18.v1"
 
 
 # Sections exposed by the public contract.  Each entry maps the public
@@ -48,6 +53,11 @@ _SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any]]] =
     "weekly": weekly.build_section,
     "superlatives": superlatives.build_section,
     "archives": archives.build_section,
+    "luck": luck.build_section,
+    "streaks": streaks.build_section,
+    "power": power.build_section,
+    "matchupPreview": matchup_preview.build_section,
+    "weeklyRecap": weekly_recap.build_section,
 }
 
 # Derived overview is a first-class section key the UI can fetch just

--- a/src/public_league/streaks.py
+++ b/src/public_league/streaks.py
@@ -1,0 +1,522 @@
+"""Section: Active Streaks & Records-in-Reach.
+
+Distinct from ``records.py`` — that module returns the dynasty record
+book (longest-ever streak holders, top-10 single-week highs, etc.).
+This module surfaces **live, trailing streaks** and **records at risk
+this season**, so the Home tab can render a "records are falling"
+headline rail.
+
+Output shape
+────────────
+``activeStreaks``    — per owner, their current trailing run of wins,
+                       losses, 100+ point weeks, 120+ point weeks, etc.
+                       Ordered so the longest streak leads, grouped by type.
+``recordsInReach``   — per all-time record, the reigning holder and
+                       the closest active chaser (if any).
+``notableThisWeek``  — most recent scored week's entries that placed
+                       in the all-time top-N for a category (e.g.
+                       "3rd-highest score of all time").
+``seasonsCovered``   — passthrough.
+``currentSeason``    — passthrough.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from . import metrics
+from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
+
+
+# Point thresholds we track "consecutive weeks above X" for.  Picked to
+# be broad enough that most dynasty leagues hit them weekly.
+_POINT_THRESHOLDS = (100.0, 120.0, 140.0)
+
+
+# How many entries the "records in reach" list pulls for each category.
+_RECORDS_IN_REACH_TOP_N = 5
+# Only flag a record as "in reach" if the chaser is within this fraction
+# of the record holder's value (streaks use raw count diff instead).
+_NEAR_RECORD_POINTS_PCT = 0.95
+
+
+def _chron_key(event: dict[str, Any]) -> tuple[int, int]:
+    try:
+        yr = int(event["season"])
+    except (TypeError, ValueError):
+        yr = 0
+    return (yr, int(event.get("week") or 0))
+
+
+def _all_events(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
+    """Flatten every scored paired roster-week into a chronological stream."""
+    out: list[dict[str, Any]] = []
+    for season, week, a, b, is_playoff in metrics.walk_matchup_pairs(snapshot):
+        for me, foe in ((a, b), (b, a)):
+            rid = metrics.roster_id_of(me)
+            if rid is None:
+                continue
+            my_pts = metrics.matchup_points(me)
+            opp_pts = metrics.matchup_points(foe)
+            if my_pts <= 0 and opp_pts <= 0:
+                continue
+            owner_id = metrics.resolve_owner(
+                snapshot.managers, season.league_id, rid
+            )
+            if not owner_id:
+                continue
+            if my_pts > opp_pts:
+                result = "W"
+            elif my_pts < opp_pts:
+                result = "L"
+            else:
+                result = "T"
+            out.append({
+                "ownerId": owner_id,
+                "season": season.season,
+                "leagueId": season.league_id,
+                "week": week,
+                "isPlayoff": is_playoff,
+                "points": round(my_pts, 2),
+                "opponentPoints": round(opp_pts, 2),
+                "margin": round(my_pts - opp_pts, 2),
+                "result": result,
+            })
+    out.sort(key=_chron_key)
+    return out
+
+
+def _trailing_run(
+    events_reversed: list[dict[str, Any]],
+    predicate,
+) -> tuple[int, dict[str, Any] | None, dict[str, Any] | None]:
+    """Length of the trailing run where ``predicate(ev)`` is True, starting
+    from the most recent event and walking backward.  Returns
+    ``(length, start_event, end_event)`` where ``start_event`` is the
+    chronologically earliest event in the run and ``end_event`` is the
+    most recent.
+    """
+    length = 0
+    end_ev = None
+    start_ev = None
+    for ev in events_reversed:
+        if predicate(ev):
+            if length == 0:
+                end_ev = ev
+            length += 1
+            start_ev = ev
+        else:
+            break
+    return length, start_ev, end_ev
+
+
+def _active_streaks_for_owner(
+    events: list[dict[str, Any]],
+    owner_id: str,
+    display_name: str,
+) -> dict[str, dict[str, Any]]:
+    """Compute trailing streaks for one owner from their chronological events."""
+    if not events:
+        return {}
+    rev = list(reversed(events))
+
+    # Most recent result determines which of {win, loss} streak we report.
+    latest = rev[0]
+    out: dict[str, dict[str, Any]] = {}
+
+    if latest["result"] == "W":
+        length, start, end = _trailing_run(rev, lambda e: e["result"] == "W")
+        if length > 0:
+            out["winStreak"] = {
+                "type": "winStreak",
+                "ownerId": owner_id,
+                "displayName": display_name,
+                "length": length,
+                "start": start,
+                "end": end,
+            }
+    elif latest["result"] == "L":
+        length, start, end = _trailing_run(rev, lambda e: e["result"] == "L")
+        if length > 0:
+            out["lossStreak"] = {
+                "type": "lossStreak",
+                "ownerId": owner_id,
+                "displayName": display_name,
+                "length": length,
+                "start": start,
+                "end": end,
+            }
+    # A tie ends both streaks; no trailing run either way.
+
+    # Point-threshold streaks are independent of W/L and track consecutive
+    # games where the owner scored ≥ threshold.
+    for t in _POINT_THRESHOLDS:
+        length, start, end = _trailing_run(rev, lambda e, thr=t: e["points"] >= thr)
+        if length > 0:
+            key = f"plus{int(t)}Streak"
+            out[key] = {
+                "type": key,
+                "threshold": t,
+                "ownerId": owner_id,
+                "displayName": display_name,
+                "length": length,
+                "start": start,
+                "end": end,
+            }
+    return out
+
+
+def _active_streaks_all(
+    snapshot: PublicLeagueSnapshot,
+    events: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Return {type: [streak, streak, ...]} across all owners.
+
+    Streaks within each type are sorted by length descending.  Only
+    owners with a non-zero length appear.
+    """
+    by_owner: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for ev in events:
+        by_owner[ev["ownerId"]].append(ev)
+
+    collected: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for owner_id, owner_events in by_owner.items():
+        display = metrics.display_name_for(snapshot, owner_id)
+        streaks = _active_streaks_for_owner(owner_events, owner_id, display)
+        for stype, s in streaks.items():
+            collected[stype].append(s)
+
+    for stype in collected:
+        collected[stype].sort(key=lambda s: -s["length"])
+    return dict(collected)
+
+
+def _longest_ever_win_loss(
+    events: list[dict[str, Any]],
+    snapshot: PublicLeagueSnapshot,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """All-time longest win and loss streaks (chronological, ties break)."""
+    by_owner: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for ev in events:
+        by_owner[ev["ownerId"]].append(ev)
+
+    best_win = None
+    best_loss = None
+    for owner_id, owner_events in by_owner.items():
+        cur_w = 0
+        cur_l = 0
+        w_start = None
+        l_start = None
+        for ev in owner_events:
+            if ev["result"] == "W":
+                cur_l = 0
+                l_start = None
+                cur_w += 1
+                if cur_w == 1:
+                    w_start = ev
+                if best_win is None or cur_w > best_win["length"]:
+                    best_win = {
+                        "ownerId": owner_id,
+                        "displayName": metrics.display_name_for(snapshot, owner_id),
+                        "length": cur_w,
+                        "start": w_start,
+                        "end": ev,
+                    }
+            elif ev["result"] == "L":
+                cur_w = 0
+                w_start = None
+                cur_l += 1
+                if cur_l == 1:
+                    l_start = ev
+                if best_loss is None or cur_l > best_loss["length"]:
+                    best_loss = {
+                        "ownerId": owner_id,
+                        "displayName": metrics.display_name_for(snapshot, owner_id),
+                        "length": cur_l,
+                        "start": l_start,
+                        "end": ev,
+                    }
+            else:
+                cur_w = 0
+                cur_l = 0
+                w_start = None
+                l_start = None
+
+    return best_win, best_loss
+
+
+def _top_score_events(
+    events: list[dict[str, Any]],
+    highest: bool,
+    n: int = _RECORDS_IN_REACH_TOP_N,
+) -> list[dict[str, Any]]:
+    filtered = [e for e in events if e["points"] > 0]
+    filtered.sort(key=lambda e: e["points"], reverse=highest)
+    out = []
+    for e in filtered[:n]:
+        out.append({
+            "rank": len(out) + 1,
+            **e,
+            "displayName": None,  # filled in by caller
+        })
+    return out
+
+
+def _latest_scored_week(
+    snapshot: PublicLeagueSnapshot,
+) -> tuple[str, int] | None:
+    """Return the (season, week) of the most recently scored game."""
+    latest: tuple[int, int, str, int] | None = None  # (year, week, season, week)
+    for season, week, a, b, _is_playoff in metrics.walk_matchup_pairs(snapshot):
+        try:
+            yr = int(season.season)
+        except (TypeError, ValueError):
+            yr = 0
+        key = (yr, week)
+        if latest is None or key > latest[:2]:
+            latest = (yr, week, season.season, week)
+    if latest is None:
+        return None
+    return latest[2], latest[3]
+
+
+def _notable_this_week(
+    snapshot: PublicLeagueSnapshot,
+    events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Entries from the most recent scored week that crack the all-time
+    top-10 in any point-total, margin, or bad-beat category.
+    """
+    latest = _latest_scored_week(snapshot)
+    if latest is None:
+        return []
+    latest_season, latest_week = latest
+
+    # All-time sorted stacks.
+    by_points_hi = sorted(events, key=lambda e: -e["points"])
+    by_points_lo = sorted([e for e in events if e["points"] > 0], key=lambda e: e["points"])
+    by_margin_hi = sorted(events, key=lambda e: -e["margin"])
+    # Bad beats: high points in a loss (margin < 0, points high).
+    losses = [e for e in events if e["result"] == "L"]
+    by_bad_beat = sorted(losses, key=lambda e: -e["points"])
+
+    def _rank_of(target: dict[str, Any], ordered: list[dict[str, Any]]) -> int | None:
+        for i, e in enumerate(ordered):
+            if (
+                e["ownerId"] == target["ownerId"]
+                and e["season"] == target["season"]
+                and e["week"] == target["week"]
+                and e["points"] == target["points"]
+            ):
+                return i + 1
+        return None
+
+    notables: list[dict[str, Any]] = []
+    this_week_events = [
+        e for e in events
+        if e["season"] == latest_season and e["week"] == latest_week
+    ]
+    for ev in this_week_events:
+        display = metrics.display_name_for(snapshot, ev["ownerId"])
+        hi_rank = _rank_of(ev, by_points_hi)
+        if hi_rank and hi_rank <= _RECORDS_IN_REACH_TOP_N:
+            notables.append({
+                "category": "highestSingleWeek",
+                "rank": hi_rank,
+                "label": _ordinal_label(hi_rank, "highest single-week score"),
+                "ownerId": ev["ownerId"],
+                "displayName": display,
+                "season": ev["season"],
+                "week": ev["week"],
+                "value": ev["points"],
+                "valueLabel": f"{ev['points']:.1f} pts",
+            })
+        lo_rank = _rank_of(ev, by_points_lo)
+        if lo_rank and lo_rank <= _RECORDS_IN_REACH_TOP_N:
+            notables.append({
+                "category": "lowestSingleWeek",
+                "rank": lo_rank,
+                "label": _ordinal_label(lo_rank, "lowest single-week score"),
+                "ownerId": ev["ownerId"],
+                "displayName": display,
+                "season": ev["season"],
+                "week": ev["week"],
+                "value": ev["points"],
+                "valueLabel": f"{ev['points']:.1f} pts",
+            })
+        if ev["margin"] > 0:
+            m_rank = _rank_of(ev, by_margin_hi)
+            if m_rank and m_rank <= _RECORDS_IN_REACH_TOP_N:
+                notables.append({
+                    "category": "biggestBlowout",
+                    "rank": m_rank,
+                    "label": _ordinal_label(m_rank, "biggest single-week margin"),
+                    "ownerId": ev["ownerId"],
+                    "displayName": display,
+                    "season": ev["season"],
+                    "week": ev["week"],
+                    "value": ev["margin"],
+                    "valueLabel": f"+{ev['margin']:.1f}",
+                })
+        if ev["result"] == "L":
+            bb_rank = _rank_of(ev, by_bad_beat)
+            if bb_rank and bb_rank <= _RECORDS_IN_REACH_TOP_N:
+                notables.append({
+                    "category": "badBeat",
+                    "rank": bb_rank,
+                    "label": _ordinal_label(bb_rank, "highest score in a loss"),
+                    "ownerId": ev["ownerId"],
+                    "displayName": display,
+                    "season": ev["season"],
+                    "week": ev["week"],
+                    "value": ev["points"],
+                    "valueLabel": f"{ev['points']:.1f} pts in L",
+                })
+    notables.sort(key=lambda n: (n["rank"], n["category"]))
+    return notables
+
+
+def _ordinal_label(rank: int, thing: str) -> str:
+    suffixes = {1: "st", 2: "nd", 3: "rd"}
+    suffix = "th" if 10 <= rank % 100 <= 20 else suffixes.get(rank % 10, "th")
+    return f"{rank}{suffix}-{thing} all-time"
+
+
+def _records_in_reach(
+    snapshot: PublicLeagueSnapshot,
+    events: list[dict[str, Any]],
+    active_streaks: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """For each all-time record, return the holder + the closest chaser."""
+    records: list[dict[str, Any]] = []
+
+    # Highest single-week score.
+    scored = [e for e in events if e["points"] > 0]
+    if scored:
+        holder_ev = max(scored, key=lambda e: e["points"])
+        records.append({
+            "category": "highestSingleWeek",
+            "label": "Highest single-week score",
+            "holder": {
+                "ownerId": holder_ev["ownerId"],
+                "displayName": metrics.display_name_for(snapshot, holder_ev["ownerId"]),
+                "value": holder_ev["points"],
+                "valueLabel": f"{holder_ev['points']:.1f} pts",
+                "season": holder_ev["season"],
+                "week": holder_ev["week"],
+            },
+        })
+        # Current season candidates.
+        current_year = snapshot.current_season.season if snapshot.current_season else None
+        current = [e for e in scored if e["season"] == current_year]
+        if current:
+            chaser = max(current, key=lambda e: e["points"])
+            if chaser["ownerId"] != holder_ev["ownerId"] or chaser["week"] != holder_ev["week"]:
+                records[-1]["chaser"] = {
+                    "ownerId": chaser["ownerId"],
+                    "displayName": metrics.display_name_for(snapshot, chaser["ownerId"]),
+                    "value": chaser["points"],
+                    "valueLabel": f"{chaser['points']:.1f} pts",
+                    "season": chaser["season"],
+                    "week": chaser["week"],
+                    "gap": round(holder_ev["points"] - chaser["points"], 2),
+                    "withinReach": chaser["points"] >= holder_ev["points"] * _NEAR_RECORD_POINTS_PCT,
+                }
+
+    # Longest win streak.
+    best_win, best_loss = _longest_ever_win_loss(events, snapshot)
+    if best_win:
+        rec = {
+            "category": "longestWinStreak",
+            "label": "Longest win streak",
+            "holder": {
+                "ownerId": best_win["ownerId"],
+                "displayName": best_win["displayName"],
+                "value": best_win["length"],
+                "valueLabel": f"{best_win['length']} straight",
+                "season": best_win["end"]["season"] if best_win["end"] else None,
+                "week": best_win["end"]["week"] if best_win["end"] else None,
+            },
+        }
+        # Active win streak chaser.
+        active_wins = active_streaks.get("winStreak") or []
+        if active_wins:
+            top = active_wins[0]
+            if top["length"] > 0:
+                rec["chaser"] = {
+                    "ownerId": top["ownerId"],
+                    "displayName": top["displayName"],
+                    "value": top["length"],
+                    "valueLabel": f"{top['length']} active",
+                    "gap": best_win["length"] - top["length"],
+                    "withinReach": top["length"] >= best_win["length"] - 1,
+                }
+        records.append(rec)
+    if best_loss:
+        rec = {
+            "category": "longestLossStreak",
+            "label": "Longest losing streak",
+            "holder": {
+                "ownerId": best_loss["ownerId"],
+                "displayName": best_loss["displayName"],
+                "value": best_loss["length"],
+                "valueLabel": f"{best_loss['length']} straight",
+                "season": best_loss["end"]["season"] if best_loss["end"] else None,
+                "week": best_loss["end"]["week"] if best_loss["end"] else None,
+            },
+        }
+        active_losses = active_streaks.get("lossStreak") or []
+        if active_losses:
+            top = active_losses[0]
+            if top["length"] > 0:
+                rec["chaser"] = {
+                    "ownerId": top["ownerId"],
+                    "displayName": top["displayName"],
+                    "value": top["length"],
+                    "valueLabel": f"{top['length']} active",
+                    "gap": best_loss["length"] - top["length"],
+                    "withinReach": top["length"] >= best_loss["length"] - 1,
+                }
+        records.append(rec)
+
+    return records
+
+
+# ── Public builder ───────────────────────────────────────────────────────
+def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    events = _all_events(snapshot)
+    active = _active_streaks_all(snapshot, events)
+    records = _records_in_reach(snapshot, events, active)
+    notable = _notable_this_week(snapshot, events)
+    latest = _latest_scored_week(snapshot)
+
+    # Flatten active streaks into a single sorted list for rendering
+    # convenience, keeping each owner's longest only.
+    active_flat: list[dict[str, Any]] = []
+    for stype, rows in active.items():
+        for r in rows:
+            active_flat.append({**r, "type": stype})
+    # Sort longest first within type priority: win > loss > plus140 > plus120 > plus100
+    type_priority = {
+        "winStreak": 0,
+        "lossStreak": 1,
+        "plus140Streak": 2,
+        "plus120Streak": 3,
+        "plus100Streak": 4,
+    }
+    active_flat.sort(key=lambda s: (type_priority.get(s["type"], 99), -s["length"]))
+
+    return {
+        "seasonsCovered": [s.season for s in snapshot.seasons],
+        "currentSeason": snapshot.current_season.season if snapshot.current_season else None,
+        "latestWeek": (
+            {"season": latest[0], "week": latest[1]} if latest else None
+        ),
+        "activeStreaks": active_flat,
+        "activeStreaksByType": active,
+        "recordsInReach": records,
+        "notableThisWeek": notable,
+        "thresholds": {
+            "points": list(_POINT_THRESHOLDS),
+        },
+    }

--- a/src/public_league/weekly_recap.py
+++ b/src/public_league/weekly_recap.py
@@ -1,0 +1,301 @@
+"""Section: Weekly Recap Newsletter.
+
+Auto-generates a narrative-grade recap for every completed scored week
+in the snapshot:
+
+    * Headline — single sentence capturing the week's dominant story.
+    * Summary — 2-3 sentences with standings implication, star of the
+      week, and the biggest surprise.
+    * Superlatives — blowout / nailbiter / MVP / bust / bad beat.
+    * Per-matchup one-liners with winner, margin, highlight.
+    * Trades that were completed during the week's transaction leg.
+
+The recap is pre-computed in one pass per snapshot so the dynamic
+``/league/week/[season]/[week]`` route can fetch the public contract
+and pick its record out by key in O(1).
+
+Output shape
+────────────
+``seasonsCovered``  — passthrough.
+``weeks``           — list of per-week recap dicts, ordered newest first.
+``byKey``           — flat ``{"<season>:<week>": recap}`` map for
+                      O(1) lookup from the dynamic route.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from . import metrics
+from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
+
+
+def _side_entry(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, entry: dict[str, Any]) -> dict[str, Any]:
+    rid = metrics.roster_id_of(entry)
+    owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+    return {
+        "ownerId": owner_id,
+        "rosterId": rid,
+        "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+        "teamName": metrics.team_name(snapshot, season.league_id, rid),
+        "points": round(metrics.matchup_points(entry), 2),
+    }
+
+
+def _season_sort_key(season: str) -> int:
+    try:
+        return int(season)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _weekly_trades_for(
+    season: SeasonSnapshot,
+    snapshot: PublicLeagueSnapshot,
+    week: int,
+) -> list[dict[str, Any]]:
+    """Return completed trades whose transaction ``leg`` matches ``week``.
+
+    We deliberately expose only rosterIds and counts, not asset details
+    — the ``activity`` section already carries the full trade payload
+    with grades.  The recap is a pointer into that surface.
+    """
+    out: list[dict[str, Any]] = []
+    for tx in season.trades():
+        try:
+            leg = int(tx.get("_leg") or tx.get("leg") or 0)
+        except (TypeError, ValueError):
+            leg = 0
+        if leg != week:
+            continue
+        roster_ids = tx.get("roster_ids") or []
+        parties = []
+        for rid in roster_ids:
+            oid = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if oid:
+                parties.append({
+                    "ownerId": oid,
+                    "displayName": metrics.display_name_for(snapshot, oid),
+                })
+        assets_moved = sum(len(d) for d in (tx.get("adds") or {}, {}).values() if isinstance(d, dict))
+        picks_moved = len(tx.get("draft_picks") or [])
+        out.append({
+            "transactionId": tx.get("transaction_id"),
+            "parties": parties,
+            "assetsMoved": assets_moved,
+            "picksMoved": picks_moved,
+        })
+    return out
+
+
+def _matchup_oneliner(home: dict, away: dict, margin: float) -> str:
+    if home["points"] == away["points"]:
+        return f"{home['displayName']} and {away['displayName']} finished deadlocked at {home['points']:.1f}."
+    winner, loser = (home, away) if home["points"] > away["points"] else (away, home)
+    if margin < 3:
+        return f"{winner['displayName']} edged {loser['displayName']} by {margin:.1f} in a nailbiter."
+    if margin >= 50:
+        return f"{winner['displayName']} obliterated {loser['displayName']} by {margin:.1f}."
+    if margin >= 25:
+        return f"{winner['displayName']} rolled {loser['displayName']} by {margin:.1f}."
+    return f"{winner['displayName']} beat {loser['displayName']} by {margin:.1f}."
+
+
+def _headline(recap: dict[str, Any]) -> str:
+    # Prefer the blowout if it's meaningful; else the MVP; else nailbiter.
+    blowout = recap.get("blowout")
+    nailbiter = recap.get("nailBiter")
+    mvp = recap.get("mvp")
+    if blowout and blowout["margin"] >= 40:
+        return (
+            f"{blowout['winner']['displayName']} steamrolled "
+            f"{blowout['loser']['displayName']} by {blowout['margin']:.1f}"
+        )
+    if mvp and blowout and mvp["ownerId"] == blowout["winner"]["ownerId"]:
+        return (
+            f"{mvp['displayName']} dropped {mvp['points']:.1f} in a "
+            f"{blowout['margin']:.1f}-point win"
+        )
+    if nailbiter and nailbiter["margin"] < 2:
+        return (
+            f"{nailbiter['winner']['displayName']} survived "
+            f"{nailbiter['loser']['displayName']} by {nailbiter['margin']:.2f}"
+        )
+    if mvp:
+        return f"{mvp['displayName']} led the week with {mvp['points']:.1f}"
+    return "Week in review"
+
+
+def _summary(recap: dict[str, Any]) -> str:
+    parts: list[str] = []
+    mvp = recap.get("mvp")
+    bust = recap.get("bust")
+    badBeat = recap.get("badBeat")
+    blowout = recap.get("blowout")
+    nailbiter = recap.get("nailBiter")
+    trades_count = len(recap.get("trades") or [])
+
+    if mvp:
+        parts.append(
+            f"{mvp['displayName']} led the league with {mvp['points']:.1f} points."
+        )
+    if nailbiter and (not blowout or nailbiter["margin"] < blowout["margin"] / 10):
+        parts.append(
+            f"The closest game was {nailbiter['winner']['displayName']} over "
+            f"{nailbiter['loser']['displayName']} by just {nailbiter['margin']:.2f}."
+        )
+    elif blowout:
+        parts.append(
+            f"Biggest margin: {blowout['winner']['displayName']} over "
+            f"{blowout['loser']['displayName']} by {blowout['margin']:.1f}."
+        )
+    if badBeat and badBeat["points"] > (mvp["points"] if mvp else 0) - 5:
+        parts.append(
+            f"{badBeat['displayName']} took a bad beat — {badBeat['points']:.1f} "
+            f"points and still lost by {badBeat['marginOfLoss']:.1f}."
+        )
+    elif bust:
+        parts.append(
+            f"{bust['displayName']} bottomed out at {bust['points']:.1f}."
+        )
+    if trades_count:
+        parts.append(
+            f"{trades_count} trade{'s' if trades_count != 1 else ''} cleared on the wire."
+        )
+    return " ".join(parts) or "Recap unavailable."
+
+
+def _build_week_recap(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    week: int,
+) -> dict[str, Any] | None:
+    entries = season.matchups_by_week.get(week) or []
+    pairs = metrics.matchup_pairs(entries)
+    if not pairs:
+        return None
+    # Require at least one scored pair (skip fully unscored future weeks).
+    scored_pairs = [
+        (a, b) for a, b in pairs
+        if metrics.is_scored(a) or metrics.is_scored(b)
+    ]
+    if not scored_pairs:
+        return None
+
+    is_playoff = week >= season.playoff_week_start
+    matchup_rows: list[dict[str, Any]] = []
+    highest: dict[str, Any] | None = None
+    lowest: dict[str, Any] | None = None
+    biggest: dict[str, Any] | None = None
+    closest: dict[str, Any] | None = None
+    bad_beat: dict[str, Any] | None = None
+
+    for a, b in scored_pairs:
+        home = _side_entry(snapshot, season, a)
+        away = _side_entry(snapshot, season, b)
+        if home["points"] == 0 and away["points"] == 0:
+            continue
+        margin = round(abs(home["points"] - away["points"]), 2)
+        if home["points"] > away["points"]:
+            winner, loser = home, away
+        elif away["points"] > home["points"]:
+            winner, loser = away, home
+        else:
+            winner = None
+            loser = None
+
+        row = {
+            "matchupId": a.get("matchup_id"),
+            "home": home,
+            "away": away,
+            "margin": margin,
+            "winner": winner,
+            "loser": loser,
+            "oneliner": _matchup_oneliner(home, away, margin),
+        }
+        matchup_rows.append(row)
+
+        for side in (home, away):
+            if highest is None or side["points"] > highest["points"]:
+                highest = side
+            if lowest is None or side["points"] < lowest["points"]:
+                lowest = side
+        if winner and (biggest is None or margin > biggest["margin"]):
+            biggest = {
+                "winner": winner,
+                "loser": loser,
+                "margin": margin,
+                "oneliner": row["oneliner"],
+            }
+        if winner and (closest is None or margin < closest["margin"]):
+            closest = {
+                "winner": winner,
+                "loser": loser,
+                "margin": margin,
+                "oneliner": row["oneliner"],
+            }
+        # Bad beat: highest-scoring loser.
+        if loser:
+            candidate = {
+                "ownerId": loser["ownerId"],
+                "displayName": loser["displayName"],
+                "teamName": loser["teamName"],
+                "points": loser["points"],
+                "marginOfLoss": margin,
+                "winnerOwnerId": winner["ownerId"],
+                "winnerDisplayName": winner["displayName"],
+            }
+            if bad_beat is None or candidate["points"] > bad_beat["points"]:
+                bad_beat = candidate
+
+    if not matchup_rows:
+        return None
+
+    trades = _weekly_trades_for(season, snapshot, week)
+
+    recap: dict[str, Any] = {
+        "season": season.season,
+        "leagueId": season.league_id,
+        "week": week,
+        "isPlayoff": is_playoff,
+        "matchups": matchup_rows,
+        "blowout": biggest,
+        "nailBiter": closest,
+        "mvp": highest,
+        "bust": lowest,
+        "badBeat": bad_beat,
+        "trades": trades,
+    }
+    recap["headline"] = _headline(recap)
+    recap["summary"] = _summary(recap)
+    return recap
+
+
+def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    seasons_sorted = sorted(
+        snapshot.seasons, key=lambda s: _season_sort_key(s.season)
+    )
+
+    weeks_out: list[dict[str, Any]] = []
+    by_key: dict[str, dict[str, Any]] = {}
+
+    for season in seasons_sorted:
+        for wk in sorted(season.matchups_by_week.keys()):
+            recap = _build_week_recap(snapshot, season, wk)
+            if not recap:
+                continue
+            weeks_out.append(recap)
+            by_key[f"{season.season}:{wk}"] = recap
+
+    # Newest first for the list view.
+    weeks_out.sort(
+        key=lambda r: (_season_sort_key(r["season"]), r["week"]),
+        reverse=True,
+    )
+
+    return {
+        "seasonsCovered": [s.season for s in snapshot.seasons],
+        "weeks": weeks_out,
+        "byKey": by_key,
+        "latest": weeks_out[0] if weeks_out else None,
+    }

--- a/tests/public_league/test_luck.py
+++ b/tests/public_league/test_luck.py
@@ -1,0 +1,140 @@
+"""Tests for ``src/public_league/luck.py``.
+
+Walks the fixture league end-to-end and pins the expected-wins /
+actual-wins math.  The fixture has 4 owners, 2 seasons, and scored
+regular-season weeks 1+2 (2025) and 1+2+3 (2024) — enough to catch
+edge cases in the all-play computation and cross-season aggregation.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.public_league.luck import build_section, _all_play_week
+from tests.public_league.fixtures import build_test_snapshot
+
+
+class AllPlayPrimitiveTests(unittest.TestCase):
+    """Unit-level: the single-week all-play math."""
+
+    def test_strict_ordering(self) -> None:
+        scores = [("A", 100.0), ("B", 90.0), ("C", 80.0), ("D", 70.0)]
+        out = _all_play_week(scores)
+        self.assertEqual(out["A"]["beats"], 3)
+        self.assertEqual(out["A"]["ties"], 0)
+        self.assertEqual(out["A"]["rivals"], 3)
+        self.assertEqual(out["A"]["expectedShare"], 1.0)
+        self.assertEqual(out["D"]["beats"], 0)
+        self.assertEqual(out["D"]["expectedShare"], 0.0)
+
+    def test_tie_splits_half(self) -> None:
+        scores = [("A", 100.0), ("B", 100.0), ("C", 50.0)]
+        out = _all_play_week(scores)
+        # A and B tie, both beat C.
+        self.assertEqual(out["A"]["beats"], 1)
+        self.assertEqual(out["A"]["ties"], 1)
+        self.assertAlmostEqual(out["A"]["expectedShare"], (1 + 0.5) / 2, places=6)
+        self.assertEqual(out["C"]["beats"], 0)
+        self.assertEqual(out["C"]["ties"], 0)
+
+    def test_single_entry_returns_empty(self) -> None:
+        self.assertEqual(_all_play_week([("A", 120.0)]), {})
+        self.assertEqual(_all_play_week([]), {})
+
+
+class LuckSectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+        cls.data = build_section(cls.snapshot)
+
+    def test_top_level_shape(self) -> None:
+        expected_keys = {
+            "seasonsCovered",
+            "currentSeason",
+            "byOwnerCareer",
+            "byOwnerSeason",
+            "currentSeasonRanked",
+            "weeklyTrail",
+            "luckiestCareer",
+            "unluckiestCareer",
+            "luckiestCurrent",
+            "unluckiestCurrent",
+            "methodology",
+        }
+        self.assertTrue(expected_keys.issubset(set(self.data.keys())))
+
+    def test_seasons_covered(self) -> None:
+        # Fixture defines 2024 and 2025 (current).
+        self.assertEqual(set(self.data["seasonsCovered"]), {"2024", "2025"})
+        self.assertEqual(self.data["currentSeason"], "2025")
+
+    def test_career_rows_sum_to_zero(self) -> None:
+        # Expected wins and actual wins must sum to the same total across
+        # all owners (pigeon-hole).
+        total_actual = sum(r["actualWins"] for r in self.data["byOwnerCareer"])
+        total_expected = sum(r["expectedWins"] for r in self.data["byOwnerCareer"])
+        # 2025: 4 games, 2024: 6 games, total 10 games of W/L.
+        self.assertAlmostEqual(total_actual, 10.0, places=1)
+        self.assertAlmostEqual(total_expected, 10.0, places=1)
+
+    def test_luckiest_and_unluckiest_career(self) -> None:
+        career = self.data["byOwnerCareer"]
+        self.assertEqual(career[0]["ownerId"], self.data["luckiestCareer"]["ownerId"])
+        self.assertEqual(career[-1]["ownerId"], self.data["unluckiestCareer"]["ownerId"])
+        # Luckiest delta must be >= unluckiest delta.
+        self.assertGreaterEqual(career[0]["luckDelta"], career[-1]["luckDelta"])
+
+    def test_owner_d_is_lucky_in_2025(self) -> None:
+        """In the 2025 fixture, owner-D beats owner-C in wk1 despite D
+        being the 3rd-best score → expected share 0.333 but actual 1.0.
+        Net D 2025 luck should be around +0.67."""
+        rows_2025 = self.data["currentSeasonRanked"]
+        by_owner = {r["ownerId"]: r for r in rows_2025}
+        self.assertIn("owner-D", by_owner)
+        self.assertAlmostEqual(by_owner["owner-D"]["luckDelta"], 0.67, delta=0.05)
+
+    def test_weekly_trail_is_chronological_and_cumulative(self) -> None:
+        trail = self.data["weeklyTrail"]
+        self.assertGreater(len(trail), 0)
+        # Group by owner and check cumulative expected is monotonically
+        # non-decreasing and cumGames increments by 1 each step.
+        by_owner: dict[str, list] = {}
+        for t in trail:
+            by_owner.setdefault(t["ownerId"], []).append(t)
+        for oid, rows in by_owner.items():
+            last_cum_expected = -1.0
+            last_games = 0
+            for r in rows:
+                self.assertGreaterEqual(
+                    r["cumExpected"] + 1e-9,
+                    last_cum_expected,
+                    f"owner={oid} cumExpected regressed",
+                )
+                self.assertEqual(
+                    r["cumGames"], last_games + 1, f"owner={oid} cumGames non-monotonic"
+                )
+                last_cum_expected = r["cumExpected"]
+                last_games = r["cumGames"]
+
+    def test_playoffs_excluded(self) -> None:
+        """Playoff weeks must not appear in the luck trail or aggregates.
+        Fixture has weeks 15 and 16 scored in 2025 playoffs; check neither
+        bleeds into luck math."""
+        trail_weeks = {(t["season"], t["week"]) for t in self.data["weeklyTrail"]}
+        for season in ("2024", "2025"):
+            self.assertNotIn((season, 15), trail_weeks)
+            self.assertNotIn((season, 16), trail_weeks)
+
+    def test_career_winpct_fields_populated(self) -> None:
+        for row in self.data["byOwnerCareer"]:
+            self.assertIn("actualWinPct", row)
+            self.assertIn("expectedWinPct", row)
+            self.assertIn("allPlayWinPct", row)
+            self.assertGreaterEqual(row["actualWinPct"], 0.0)
+            self.assertLessEqual(row["actualWinPct"], 1.0)
+            self.assertGreaterEqual(row["expectedWinPct"], 0.0)
+            self.assertLessEqual(row["expectedWinPct"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/public_league/test_matchup_preview.py
+++ b/tests/public_league/test_matchup_preview.py
@@ -1,0 +1,94 @@
+"""Tests for ``src/public_league/matchup_preview.py``.
+
+The fixture's 2025 season is fully scored through week 16, so
+``matchup_preview`` should fall back to "recap" mode on the most
+recently scored week.  We also test the preview path by manually
+unscoring a matchup row.
+"""
+from __future__ import annotations
+
+import copy
+import unittest
+
+from src.public_league.matchup_preview import build_section, _detect_current_week, _pair_key
+from tests.public_league.fixtures import build_test_snapshot
+
+
+class PairKeyTests(unittest.TestCase):
+    def test_canonical_ordering(self) -> None:
+        self.assertEqual(_pair_key("owner-B", "owner-A"), ("owner-A", "owner-B"))
+        self.assertEqual(_pair_key("owner-A", "owner-B"), ("owner-A", "owner-B"))
+
+
+class MatchupPreviewSectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+        cls.data = build_section(cls.snapshot)
+
+    def test_top_level_shape(self) -> None:
+        for key in ("currentSeason", "currentWeek", "mode", "matchups", "generatedAt"):
+            self.assertIn(key, self.data)
+
+    def test_fully_complete_season_falls_back_to_recap(self) -> None:
+        # Fixture's 2025 is complete → mode should be "recap" and the
+        # current week should be the most recent scored one (16).
+        self.assertEqual(self.data["mode"], "recap")
+        self.assertEqual(self.data["currentWeek"], 16)
+        self.assertEqual(self.data["currentSeason"], "2025")
+
+    def test_matchups_have_h2h_and_form(self) -> None:
+        self.assertGreater(len(self.data["matchups"]), 0)
+        for m in self.data["matchups"]:
+            self.assertIn("home", m)
+            self.assertIn("away", m)
+            self.assertIn("h2h", m)
+            self.assertIn("form", m)
+            h2h = m["h2h"]
+            self.assertIn("totalMeetings", h2h)
+            self.assertIn("last5", h2h)
+            self.assertIn("narrative", h2h)
+            self.assertGreaterEqual(h2h["totalMeetings"], 0)
+            self.assertLessEqual(len(h2h["last5"]), 5)
+            self.assertIn("home", m["form"])
+            self.assertIn("away", m["form"])
+            self.assertIn("avgPoints", m["form"]["home"])
+            self.assertIn("record", m["form"]["home"])
+
+    def test_recap_points_populated(self) -> None:
+        # In recap mode, both sides must have a numeric points field.
+        for m in self.data["matchups"]:
+            self.assertIsNotNone(m["home"]["points"])
+            self.assertIsNotNone(m["away"]["points"])
+
+
+class PreviewModeTests(unittest.TestCase):
+    """Force a preview path by unscoring an existing matchup row."""
+
+    def test_unscored_week_triggers_preview(self) -> None:
+        snap = build_test_snapshot()
+        # Clone and zero-out week 16 scores in the current season.
+        current = snap.seasons[0]
+        current.matchups_by_week[16] = [
+            {**row, "points": 0} for row in current.matchups_by_week[16]
+        ]
+        # And add a brand-new unplayed week 17.
+        current.matchups_by_week[17] = [
+            {"matchup_id": 1, "roster_id": 1, "points": 0},
+            {"matchup_id": 1, "roster_id": 2, "points": 0},
+            {"matchup_id": 2, "roster_id": 3, "points": 0},
+            {"matchup_id": 2, "roster_id": 4, "points": 0},
+        ]
+        data = build_section(snap)
+        self.assertEqual(data["mode"], "preview")
+        # Preview mode should target the earliest unscored week in the
+        # season's walk; with week 16 now unscored, that's week 16.
+        self.assertIn(data["currentWeek"], (16, 17))
+        # Preview mode exposes null points, not zero.
+        for m in data["matchups"]:
+            self.assertIsNone(m["home"]["points"])
+            self.assertIsNone(m["away"]["points"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/public_league/test_power.py
+++ b/tests/public_league/test_power.py
@@ -1,0 +1,102 @@
+"""Tests for ``src/public_league/power.py``."""
+from __future__ import annotations
+
+import unittest
+
+from src.public_league.power import build_section, _percentile_rank
+from tests.public_league.fixtures import build_test_snapshot
+
+
+class PercentileTests(unittest.TestCase):
+    def test_top_scores_one(self) -> None:
+        self.assertEqual(_percentile_rank([10.0, 20.0, 30.0], 30.0), 1.0)
+
+    def test_bottom_scores_zero(self) -> None:
+        self.assertEqual(_percentile_rank([10.0, 20.0, 30.0], 10.0), 0.0)
+
+    def test_tied_gets_midrank(self) -> None:
+        # Value 20 in [10, 20, 20]: 1 below, 1 other tied → (1 + 0.5) / 2 = 0.75
+        self.assertAlmostEqual(_percentile_rank([10.0, 20.0, 20.0], 20.0), 0.75, places=3)
+
+    def test_singleton_is_midpoint(self) -> None:
+        self.assertEqual(_percentile_rank([50.0], 50.0), 0.5)
+
+
+class PowerSectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+        cls.data = build_section(cls.snapshot)
+
+    def test_top_level_shape(self) -> None:
+        expected = {
+            "seasonsCovered",
+            "weeks",
+            "seriesByOwner",
+            "currentRanking",
+            "methodology",
+            "weights",
+        }
+        self.assertTrue(expected.issubset(set(self.data.keys())))
+
+    def test_weeks_are_chronological(self) -> None:
+        last_year = 0
+        last_week = 0
+        for w in self.data["weeks"]:
+            try:
+                year = int(w["season"])
+            except (TypeError, ValueError):
+                year = 0
+            if year > last_year:
+                last_week = 0
+            self.assertTrue(
+                (year, w["week"]) >= (last_year, last_week),
+                f"weeks regress: {w['season']} wk {w['week']} before {last_year} wk {last_week}",
+            )
+            last_year = year
+            last_week = w["week"]
+
+    def test_every_week_ranks_every_owner_exactly_once(self) -> None:
+        for w in self.data["weeks"]:
+            rankings = w["rankings"]
+            owners = [r["ownerId"] for r in rankings]
+            self.assertEqual(len(owners), len(set(owners)))
+            ranks = sorted(r["rank"] for r in rankings)
+            self.assertEqual(ranks, list(range(1, len(owners) + 1)))
+
+    def test_power_is_zero_to_hundred(self) -> None:
+        for w in self.data["weeks"]:
+            for r in w["rankings"]:
+                self.assertGreaterEqual(r["power"], 0.0)
+                self.assertLessEqual(r["power"], 100.0)
+
+    def test_current_ranking_matches_last_week(self) -> None:
+        if not self.data["weeks"]:
+            return
+        last = self.data["weeks"][-1]["rankings"]
+        self.assertEqual(self.data["currentRanking"], last)
+
+    def test_series_ownerids_match_rankings(self) -> None:
+        ranked_owners = {r["ownerId"] for w in self.data["weeks"] for r in w["rankings"]}
+        series_owners = {s["ownerId"] for s in self.data["seriesByOwner"]}
+        self.assertEqual(ranked_owners, series_owners)
+
+    def test_components_and_record_fields(self) -> None:
+        for w in self.data["weeks"]:
+            for r in w["rankings"]:
+                self.assertIn("components", r)
+                c = r["components"]
+                for key in (
+                    "pointsPerGame",
+                    "pointsPerGamePct",
+                    "recentAvg",
+                    "recentAvgPct",
+                    "allPlayWinPctThisWeek",
+                ):
+                    self.assertIn(key, c)
+                self.assertIn("record", r)
+                self.assertRegex(r["record"], r"^\d+-\d+$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -219,6 +219,42 @@ class SectionCoverageTests(unittest.TestCase):
         ):
             self.assertIn(block, s)
 
+    def test_luck_section(self) -> None:
+        s = self.contract["sections"]["luck"]
+        for block in (
+            "byOwnerCareer",
+            "byOwnerSeason",
+            "currentSeasonRanked",
+            "weeklyTrail",
+            "methodology",
+        ):
+            self.assertIn(block, s)
+
+    def test_streaks_section(self) -> None:
+        s = self.contract["sections"]["streaks"]
+        for block in (
+            "activeStreaks",
+            "activeStreaksByType",
+            "recordsInReach",
+            "notableThisWeek",
+        ):
+            self.assertIn(block, s)
+
+    def test_power_section(self) -> None:
+        s = self.contract["sections"]["power"]
+        for block in ("weeks", "seriesByOwner", "currentRanking", "methodology", "weights"):
+            self.assertIn(block, s)
+
+    def test_matchup_preview_section(self) -> None:
+        s = self.contract["sections"]["matchupPreview"]
+        for block in ("currentSeason", "currentWeek", "mode", "matchups"):
+            self.assertIn(block, s)
+
+    def test_weekly_recap_section(self) -> None:
+        s = self.contract["sections"]["weeklyRecap"]
+        for block in ("weeks", "byKey", "latest", "seasonsCovered"):
+            self.assertIn(block, s)
+
 
 class ActivityGradingTests(unittest.TestCase):
     """Server-side trade grades on the public activity feed.

--- a/tests/public_league/test_streaks.py
+++ b/tests/public_league/test_streaks.py
@@ -1,0 +1,151 @@
+"""Tests for ``src/public_league/streaks.py``.
+
+The fixture gives every owner a mix of W/L results across 2 seasons of
+regular + playoff games.  We pin:
+    * Trailing W/L streaks are correctly computed from the last-played
+      game backwards.
+    * Point threshold streaks respect the threshold cutoff and do not
+      bleed across a below-threshold week.
+    * "Records in reach" carries both a holder and an optional chaser.
+    * "Notable this week" entries are keyed by the most recently scored
+      game in the snapshot.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.public_league.streaks import (
+    build_section,
+    _active_streaks_for_owner,
+    _trailing_run,
+)
+from tests.public_league.fixtures import build_test_snapshot
+
+
+class TrailingRunTests(unittest.TestCase):
+    def test_counts_consecutive_true_at_tail(self) -> None:
+        # events already chronological old → new; reversed gives new first.
+        events = [
+            {"result": "L"},
+            {"result": "W"},
+            {"result": "W"},
+            {"result": "W"},
+        ]
+        length, start, end = _trailing_run(
+            list(reversed(events)), lambda e: e["result"] == "W"
+        )
+        self.assertEqual(length, 3)
+        # end_event is the MOST recent (last chronologically).
+        self.assertIs(end, events[-1])
+        # start_event is the CHRONOLOGICALLY earliest event in the run.
+        self.assertIs(start, events[1])
+
+    def test_stops_at_first_false(self) -> None:
+        events = [
+            {"result": "W"},
+            {"result": "W"},
+            {"result": "L"},
+            {"result": "W"},
+        ]
+        length, _, _ = _trailing_run(
+            list(reversed(events)), lambda e: e["result"] == "W"
+        )
+        self.assertEqual(length, 1)
+
+    def test_zero_when_tail_is_false(self) -> None:
+        events = [{"result": "W"}, {"result": "L"}]
+        length, start, end = _trailing_run(
+            list(reversed(events)), lambda e: e["result"] == "W"
+        )
+        self.assertEqual(length, 0)
+        self.assertIsNone(start)
+        self.assertIsNone(end)
+
+
+class ActiveStreakOwnerTests(unittest.TestCase):
+    def test_ends_on_win_reports_win_streak_not_loss(self) -> None:
+        events = [
+            {"result": "L", "points": 100.0, "week": 1, "season": "2025"},
+            {"result": "W", "points": 120.0, "week": 2, "season": "2025"},
+            {"result": "W", "points": 130.0, "week": 3, "season": "2025"},
+        ]
+        out = _active_streaks_for_owner(events, "owner-A", "Ann")
+        self.assertIn("winStreak", out)
+        self.assertNotIn("lossStreak", out)
+        self.assertEqual(out["winStreak"]["length"], 2)
+
+    def test_plus100_streak_includes_games_below_100(self) -> None:
+        events = [
+            {"result": "W", "points": 130.0, "week": 1, "season": "2025"},
+            {"result": "W", "points": 90.0, "week": 2, "season": "2025"},
+            {"result": "W", "points": 125.0, "week": 3, "season": "2025"},
+            {"result": "W", "points": 140.0, "week": 4, "season": "2025"},
+        ]
+        out = _active_streaks_for_owner(events, "owner-A", "Ann")
+        # Latest game is 140 → plus100 streak starts here; goes back
+        # through the 125-point week too; stops at the 90-point week.
+        self.assertEqual(out["plus100Streak"]["length"], 2)
+
+    def test_tie_at_tail_reports_no_win_or_loss_streak(self) -> None:
+        events = [
+            {"result": "W", "points": 100.0, "week": 1, "season": "2025"},
+            {"result": "T", "points": 100.0, "week": 2, "season": "2025"},
+        ]
+        out = _active_streaks_for_owner(events, "owner-A", "Ann")
+        self.assertNotIn("winStreak", out)
+        self.assertNotIn("lossStreak", out)
+
+
+class StreaksSectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+        cls.data = build_section(cls.snapshot)
+
+    def test_top_level_shape(self) -> None:
+        expected = {
+            "seasonsCovered",
+            "currentSeason",
+            "latestWeek",
+            "activeStreaks",
+            "activeStreaksByType",
+            "recordsInReach",
+            "notableThisWeek",
+            "thresholds",
+        }
+        self.assertTrue(expected.issubset(set(self.data.keys())))
+
+    def test_latest_week_is_most_recent_scored(self) -> None:
+        # Fixture: 2025 latest scored week is 16 (playoff championship).
+        self.assertEqual(self.data["latestWeek"], {"season": "2025", "week": 16})
+
+    def test_records_in_reach_has_holder(self) -> None:
+        self.assertGreater(len(self.data["recordsInReach"]), 0)
+        for rec in self.data["recordsInReach"]:
+            self.assertIn("holder", rec)
+            self.assertIn("category", rec)
+            self.assertIn("label", rec)
+            holder = rec["holder"]
+            self.assertIn("ownerId", holder)
+            self.assertIn("displayName", holder)
+            self.assertIn("valueLabel", holder)
+
+    def test_active_streaks_are_sorted_within_type(self) -> None:
+        by_type = self.data["activeStreaksByType"]
+        for stype, rows in by_type.items():
+            for i in range(1, len(rows)):
+                self.assertGreaterEqual(
+                    rows[i - 1]["length"],
+                    rows[i]["length"],
+                    f"streak type {stype} not sorted desc by length",
+                )
+
+    def test_active_streaks_have_display_name(self) -> None:
+        for s in self.data["activeStreaks"]:
+            self.assertIn("ownerId", s)
+            self.assertIn("displayName", s)
+            self.assertGreater(s["length"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/public_league/test_weekly_recap.py
+++ b/tests/public_league/test_weekly_recap.py
@@ -1,0 +1,86 @@
+"""Tests for ``src/public_league/weekly_recap.py``."""
+from __future__ import annotations
+
+import unittest
+
+from src.public_league.weekly_recap import build_section
+from tests.public_league.fixtures import build_test_snapshot
+
+
+class WeeklyRecapSectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+        cls.data = build_section(cls.snapshot)
+
+    def test_top_level_shape(self) -> None:
+        for key in ("seasonsCovered", "weeks", "byKey", "latest"):
+            self.assertIn(key, self.data)
+
+    def test_every_recap_has_required_fields(self) -> None:
+        for recap in self.data["weeks"]:
+            for key in (
+                "season",
+                "week",
+                "isPlayoff",
+                "matchups",
+                "mvp",
+                "bust",
+                "blowout",
+                "nailBiter",
+                "badBeat",
+                "trades",
+                "headline",
+                "summary",
+            ):
+                self.assertIn(key, recap, f"missing {key} in recap {recap.get('season')}:{recap.get('week')}")
+            self.assertIsInstance(recap["headline"], str)
+            self.assertTrue(recap["headline"])
+            self.assertIsInstance(recap["summary"], str)
+            self.assertTrue(recap["summary"])
+
+    def test_week_2_of_2025_has_expected_superlatives(self) -> None:
+        # Fixture: 2025 wk2 → A 145.8 beats C 142.1 (close), B 165.0 beats D 95.6 (blowout).
+        recap = self.data["byKey"]["2025:2"]
+        self.assertIsNotNone(recap)
+        # MVP: highest scorer is owner-B at 165.0.
+        self.assertEqual(recap["mvp"]["ownerId"], "owner-B")
+        self.assertEqual(recap["mvp"]["points"], 165.0)
+        # Bust: lowest scorer is owner-D at 95.6.
+        self.assertEqual(recap["bust"]["ownerId"], "owner-D")
+        self.assertEqual(recap["bust"]["points"], 95.6)
+        # Blowout: B beats D by 69.4.
+        self.assertEqual(recap["blowout"]["margin"], 69.4)
+        self.assertEqual(recap["blowout"]["winner"]["ownerId"], "owner-B")
+        # Nailbiter: A beats C by 3.7.
+        self.assertEqual(recap["nailBiter"]["margin"], 3.7)
+        self.assertEqual(recap["nailBiter"]["winner"]["ownerId"], "owner-A")
+
+    def test_bykey_maps_every_week(self) -> None:
+        for recap in self.data["weeks"]:
+            key = f"{recap['season']}:{recap['week']}"
+            self.assertIn(key, self.data["byKey"])
+            self.assertIs(self.data["byKey"][key], recap)
+
+    def test_weeks_sorted_newest_first(self) -> None:
+        weeks = self.data["weeks"]
+        for i in range(1, len(weeks)):
+            prev = weeks[i - 1]
+            cur = weeks[i]
+            self.assertTrue(
+                (int(prev["season"]), prev["week"]) >= (int(cur["season"]), cur["week"]),
+                f"weeks not newest-first: {prev['season']}:{prev['week']} vs {cur['season']}:{cur['week']}",
+            )
+
+    def test_latest_matches_first_weeks_entry(self) -> None:
+        self.assertEqual(self.data["latest"], self.data["weeks"][0])
+
+    def test_matchup_oneliners_populated(self) -> None:
+        for recap in self.data["weeks"]:
+            for m in recap["matchups"]:
+                self.assertIsInstance(m["oneliner"], str)
+                self.assertTrue(m["oneliner"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Five new public-contract sections and tabs for the `/league` page, all running on already-ingested Sleeper data — zero new data sources, zero private-field leaks.

- **Luck Score** — actual vs expected wins from weekly all-play record. Per-owner career/season rankings + cumulative luck-delta sparkline.
- **Power Ranking** — composite weekly power score (50% PPG percentile, 25% last-3-game percentile, 25% all-play). Current-week leaderboard + time-series chart across every snapshot week.
- **Streaks** — active trailing W/L/100+/120+/140+ runs, records-in-reach with chaser highlights, all-time top-N notables from the latest scored week.
- **This Week** (H2H Preview) — per upcoming matchup: all-time H2H record, last 5 meetings, each side's recent form. Auto-switches to recap mode when the week is fully scored.
- **Weekly Recap Newsletter** — auto-generated per-week narrative at `/league/week/[season]/[week]` with OG metadata for sharing. `Recaps` tab is a grid of every week's card.

## Test plan

- [x] 50 new `tests/public_league/` tests pin math + contract shape for every new section
- [x] `ImportSurfaceTests` — no private imports leaked into `src.public_league`
- [x] `PublicContractSafetyTests` — every new section's payload passes `assert_public_payload_safe` recursively against the private-field blocklist
- [x] `SectionCoverageTests` — new assertions pin `luck`, `streaks`, `power`, `matchupPreview`, `weeklyRecap` into the contract
- [x] Full pytest suite: **1476 passed / 3 skipped** (no regressions)
- [x] Frontend vitest: **389 passed** (12 files)
- [x] `next build` completes; all 5 new `/league` tabs + `/league/week/[season]/[week]` dynamic route register correctly
- [ ] Manual smoke test in staging once this merges — verify the inline SVG charts render correctly across viewport sizes and that the recap dynamic route serves proper OG tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)