### PR TITLE
Home tab: surface Power / Luck / Streaks / This Week / Recap cards

### DIFF
--- a/frontend/app/league/sections/overview.jsx
+++ b/frontend/app/league/sections/overview.jsx
@@ -5,6 +5,23 @@
 
 import { Avatar, Card, EmptyCard, LinkButton, ManagerInline, Stat, fmtPoints, nameFor } from "../shared.jsx";
 
+function streakTypeDescription(type, length) {
+  switch (type) {
+    case "winStreak":
+      return `${length} straight wins`;
+    case "lossStreak":
+      return `${length} straight losses`;
+    case "plus100Streak":
+      return `${length} weeks ≥ 100 pts`;
+    case "plus120Streak":
+      return `${length} weeks ≥ 120 pts`;
+    case "plus140Streak":
+      return `${length} weeks ≥ 140 pts`;
+    default:
+      return `${length} in a row`;
+  }
+}
+
 function OverviewSection({ managers, data, onNavigate }) {
   if (!data || Object.keys(data).length === 0) return <EmptyCard label="Overview" />;
 
@@ -19,6 +36,13 @@ function OverviewSection({ managers, data, onNavigate }) {
   const hottest = data.hottestRace;
   const vitals = data.leagueVitals || {};
   const hottestTrade = data.hottestTrade;
+  // v2 Home callouts (PR #87).
+  const powerLeader = data.currentPowerLeader;
+  const luckyUnlucky = data.luckyUnluckyCurrent;
+  const activeStreak = data.activeStreakHighlight;
+  const recordInReach = data.recordInReach;
+  const upcomingWeek = data.upcomingWeekPreview;
+  const latestFullRecap = data.latestFullRecap;
 
   return (
     <>
@@ -79,6 +103,165 @@ function OverviewSection({ managers, data, onNavigate }) {
           </div>
         )}
       </div>
+
+      {/* v2 Home rail: This Week + current Power + Luck + Active Streak */}
+      {(upcomingWeek || powerLeader || luckyUnlucky || activeStreak || recordInReach || latestFullRecap) && (
+        <div className="row" style={{ marginTop: "var(--space-md)", gap: 14 }}>
+          {upcomingWeek && (
+            <div className="card" style={{ flex: "1 1 300px", minWidth: 260 }}>
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                {upcomingWeek.mode === "preview"
+                  ? `This week · ${upcomingWeek.season} Wk ${upcomingWeek.week}`
+                  : `Most recent · ${upcomingWeek.season} Wk ${upcomingWeek.week}`}
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6 }}>
+                <Avatar managers={managers} ownerId={upcomingWeek.home?.ownerId} size={28} />
+                <span style={{ color: "var(--subtext)", fontWeight: 700 }}>
+                  {upcomingWeek.mode === "recap" ? "vs" : "@"}
+                </span>
+                <Avatar managers={managers} ownerId={upcomingWeek.away?.ownerId} size={28} />
+              </div>
+              <div style={{ fontSize: "0.98rem", fontWeight: 800, marginTop: 4 }}>
+                {upcomingWeek.home?.displayName} vs {upcomingWeek.away?.displayName}
+              </div>
+              {upcomingWeek.h2h?.narrative && (
+                <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 4 }}>
+                  {upcomingWeek.h2h.narrative}
+                </div>
+              )}
+              <div style={{ marginTop: 10 }}>
+                <LinkButton onClick={() => onNavigate("matchupPreview")}>Full H2H preview →</LinkButton>
+              </div>
+            </div>
+          )}
+          {powerLeader && (
+            <div className="card" style={{ flex: "1 1 240px", minWidth: 220 }}>
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Power rank #1
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 6 }}>
+                <Avatar managers={managers} ownerId={powerLeader.ownerId} size={36} />
+                <div>
+                  <div style={{ fontSize: "1.05rem", fontWeight: 800 }}>{powerLeader.displayName}</div>
+                  <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>{powerLeader.teamName}</div>
+                </div>
+              </div>
+              <div style={{ fontFamily: "var(--mono)", fontSize: "0.8rem", marginTop: 6 }}>
+                Power <strong style={{ color: "#2ecc71" }}>{fmtPoints(powerLeader.power)}</strong>
+                <span style={{ color: "var(--subtext)", marginLeft: 8 }}>{powerLeader.record}</span>
+                {powerLeader.weekRankDelta > 0 && (
+                  <span style={{ color: "#2ecc71", marginLeft: 8 }}>▲{powerLeader.weekRankDelta}</span>
+                )}
+                {powerLeader.weekRankDelta < 0 && (
+                  <span style={{ color: "#ff6b6b", marginLeft: 8 }}>▼{Math.abs(powerLeader.weekRankDelta)}</span>
+                )}
+              </div>
+              <div style={{ marginTop: 10 }}>
+                <LinkButton onClick={() => onNavigate("power")}>Power rankings →</LinkButton>
+              </div>
+            </div>
+          )}
+          {luckyUnlucky && (
+            <div className="card" style={{ flex: "1 1 240px", minWidth: 220 }}>
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Luck Δ · {luckyUnlucky.season}
+              </div>
+              {luckyUnlucky.lucky && (
+                <div style={{ marginTop: 6, display: "flex", alignItems: "center", gap: 8 }}>
+                  <Avatar managers={managers} ownerId={luckyUnlucky.lucky.ownerId} size={22} />
+                  <div style={{ flex: 1, fontSize: "0.78rem" }}>
+                    <strong>{luckyUnlucky.lucky.displayName}</strong>
+                    <span style={{ color: "#2ecc71", marginLeft: 6, fontFamily: "var(--mono)" }}>
+                      +{fmtPoints(luckyUnlucky.lucky.luckDelta)}
+                    </span>
+                  </div>
+                </div>
+              )}
+              {luckyUnlucky.unlucky && (
+                <div style={{ marginTop: 6, display: "flex", alignItems: "center", gap: 8 }}>
+                  <Avatar managers={managers} ownerId={luckyUnlucky.unlucky.ownerId} size={22} />
+                  <div style={{ flex: 1, fontSize: "0.78rem" }}>
+                    <strong>{luckyUnlucky.unlucky.displayName}</strong>
+                    <span style={{ color: "#ff6b6b", marginLeft: 6, fontFamily: "var(--mono)" }}>
+                      {fmtPoints(luckyUnlucky.unlucky.luckDelta)}
+                    </span>
+                  </div>
+                </div>
+              )}
+              <div style={{ marginTop: 10 }}>
+                <LinkButton onClick={() => onNavigate("luck")}>Luck score →</LinkButton>
+              </div>
+            </div>
+          )}
+          {activeStreak && (
+            <div className="card" style={{ flex: "1 1 240px", minWidth: 220 }}>
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Longest active streak
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 6 }}>
+                <Avatar managers={managers} ownerId={activeStreak.ownerId} size={32} />
+                <div>
+                  <div style={{ fontSize: "0.98rem", fontWeight: 800 }}>{activeStreak.displayName}</div>
+                  <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
+                    {streakTypeDescription(activeStreak.type, activeStreak.length)}
+                  </div>
+                </div>
+              </div>
+              <div style={{ marginTop: 10 }}>
+                <LinkButton onClick={() => onNavigate("streaks")}>All streaks →</LinkButton>
+              </div>
+            </div>
+          )}
+          {recordInReach && (
+            <div
+              className="card"
+              style={{
+                flex: "1 1 240px",
+                minWidth: 220,
+                borderLeft: (recordInReach.chaser?.withinReach ? "3px solid var(--amber)" : undefined),
+              }}
+            >
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                {recordInReach.chaser?.withinReach ? "Record within reach" : "Record in the hunt"}
+              </div>
+              <div style={{ fontSize: "0.86rem", fontWeight: 700, marginTop: 4 }}>
+                {recordInReach.label}
+              </div>
+              {recordInReach.holder && (
+                <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 4 }}>
+                  Holder: <strong>{nameFor(managers, recordInReach.holder.ownerId) || recordInReach.holder.displayName}</strong>{" "}
+                  ({recordInReach.holder.valueLabel})
+                </div>
+              )}
+              {recordInReach.chaser && (
+                <div style={{ fontSize: "0.72rem", color: "var(--amber)", marginTop: 2 }}>
+                  Chaser: <strong>{nameFor(managers, recordInReach.chaser.ownerId) || recordInReach.chaser.displayName}</strong>{" "}
+                  ({recordInReach.chaser.valueLabel})
+                </div>
+              )}
+              <div style={{ marginTop: 10 }}>
+                <LinkButton onClick={() => onNavigate("streaks")}>See all →</LinkButton>
+              </div>
+            </div>
+          )}
+          {latestFullRecap && (
+            <div className="card" style={{ flex: "1 1 300px", minWidth: 260 }}>
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Week in review · {latestFullRecap.season} Wk {latestFullRecap.week}
+              </div>
+              <div style={{ fontSize: "0.98rem", fontWeight: 800, marginTop: 4, lineHeight: 1.3 }}>
+                {latestFullRecap.headline}
+              </div>
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 4, lineHeight: 1.45 }}>
+                {latestFullRecap.summary}
+              </div>
+              <div style={{ marginTop: 10, display: "flex", gap: 8 }}>
+                <LinkButton onClick={() => onNavigate("weeklyRecap")}>All recaps →</LinkButton>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
 
       {records.length > 0 && (
         <Card title="Headline records" subtitle="Biggest numbers in the last 2 seasons">

--- a/src/public_league/overview.py
+++ b/src/public_league/overview.py
@@ -238,6 +238,129 @@ def _most_chaotic_manager(awards_section: dict[str, Any]) -> dict[str, Any] | No
     return None
 
 
+# ── v2 home callouts (from specialized sections) ────────────────────────
+def _current_power_leader(power_section: dict[str, Any]) -> dict[str, Any] | None:
+    ranking = power_section.get("currentRanking") or []
+    if not ranking:
+        return None
+    head = ranking[0]
+    return {
+        "ownerId": head.get("ownerId"),
+        "displayName": head.get("displayName"),
+        "teamName": head.get("teamName"),
+        "power": head.get("power"),
+        "record": head.get("record"),
+        "weekRankDelta": head.get("weekRankDelta", 0),
+    }
+
+
+def _slim_luck_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not row:
+        return None
+    return {
+        "ownerId": row.get("ownerId"),
+        "displayName": row.get("displayName"),
+        "teamName": row.get("teamName"),
+        "luckDelta": row.get("luckDelta"),
+        "actualWins": row.get("actualWins"),
+        "expectedWins": row.get("expectedWins"),
+    }
+
+
+def _lucky_unlucky_current(luck_section: dict[str, Any]) -> dict[str, Any] | None:
+    lucky = luck_section.get("luckiestCurrent")
+    unlucky = luck_section.get("unluckiestCurrent")
+    if not lucky and not unlucky:
+        return None
+    return {
+        "season": luck_section.get("currentSeason"),
+        "lucky": _slim_luck_row(lucky),
+        "unlucky": _slim_luck_row(unlucky),
+    }
+
+
+def _active_streak_highlight(streaks_section: dict[str, Any]) -> dict[str, Any] | None:
+    """The single longest ongoing streak across all managers + all types."""
+    active = streaks_section.get("activeStreaks") or []
+    if not active:
+        return None
+    head = active[0]
+    return {
+        "type": head.get("type"),
+        "length": head.get("length"),
+        "ownerId": head.get("ownerId"),
+        "displayName": head.get("displayName"),
+        "start": head.get("start"),
+        "end": head.get("end"),
+    }
+
+
+def _slim_record(rec: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "category": rec.get("category"),
+        "label": rec.get("label"),
+        "holder": rec.get("holder"),
+        "chaser": rec.get("chaser"),
+    }
+
+
+def _record_in_reach(streaks_section: dict[str, Any]) -> dict[str, Any] | None:
+    """Preferred: first record with a ``withinReach`` chaser.  Fallback:
+    first record-in-reach row with any chaser.  Final fallback: None.
+    """
+    records = streaks_section.get("recordsInReach") or []
+    in_reach = [r for r in records if (r.get("chaser") or {}).get("withinReach")]
+    if in_reach:
+        return _slim_record(in_reach[0])
+    with_chaser = [r for r in records if r.get("chaser")]
+    if with_chaser:
+        return _slim_record(with_chaser[0])
+    return None
+
+
+def _upcoming_week_preview(matchup_preview_section: dict[str, Any]) -> dict[str, Any] | None:
+    """Headline matchup for This Week.  We rank by H2H total meetings so
+    the pair with the most history leads — usually the most narrative
+    heft.  Falls back to the first matchup if none have history.
+    """
+    matchups = matchup_preview_section.get("matchups") or []
+    if not matchups:
+        return None
+    ranked = sorted(matchups, key=lambda m: -(m.get("h2h") or {}).get("totalMeetings", 0))
+    head = ranked[0]
+    return {
+        "season": matchup_preview_section.get("currentSeason"),
+        "week": matchup_preview_section.get("currentWeek"),
+        "mode": matchup_preview_section.get("mode"),
+        "home": head.get("home"),
+        "away": head.get("away"),
+        "h2h": {
+            "totalMeetings": (head.get("h2h") or {}).get("totalMeetings"),
+            "homeWins": (head.get("h2h") or {}).get("homeWins"),
+            "awayWins": (head.get("h2h") or {}).get("awayWins"),
+            "narrative": (head.get("h2h") or {}).get("narrative"),
+        },
+    }
+
+
+def _latest_full_recap(weekly_recap_section: dict[str, Any]) -> dict[str, Any] | None:
+    latest = weekly_recap_section.get("latest")
+    if not latest:
+        return None
+    return {
+        "season": latest.get("season"),
+        "week": latest.get("week"),
+        "isPlayoff": latest.get("isPlayoff", False),
+        "headline": latest.get("headline"),
+        "summary": latest.get("summary"),
+        "mvp": latest.get("mvp"),
+        "blowout": latest.get("blowout"),
+        "nailBiter": latest.get("nailBiter"),
+        "badBeat": latest.get("badBeat"),
+        "tradesCount": len(latest.get("trades") or []),
+    }
+
+
 def _league_vitals(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     total_trades = 0
     total_waivers = 0
@@ -267,11 +390,26 @@ def build_section(
     activity_section: dict[str, Any],
     draft_section: dict[str, Any],
     weekly_section: dict[str, Any],
+    luck_section: dict[str, Any] | None = None,
+    streaks_section: dict[str, Any] | None = None,
+    power_section: dict[str, Any] | None = None,
+    matchup_preview_section: dict[str, Any] | None = None,
+    weekly_recap_section: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the overview section.  All inputs are already-built
     section payloads from the rest of the public contract so we can
     compose headline views from trusted derived data.
+
+    The v2 section kwargs (luck, streaks, power, matchup_preview,
+    weekly_recap) are optional — when absent, the corresponding
+    home-tab callouts are emitted as ``None``.  Older contract
+    consumers pre-dating these sections still work.
     """
+    luck_section = luck_section or {}
+    streaks_section = streaks_section or {}
+    power_section = power_section or {}
+    matchup_preview_section = matchup_preview_section or {}
+    weekly_recap_section = weekly_recap_section or {}
     return {
         "seasonRangeLabel": _season_range_label(snapshot),
         "currentChampion": _current_champion(history_section),
@@ -285,4 +423,13 @@ def build_section(
         "hottestRace": awards_section.get("hottestRace"),
         "mostChaoticManager": _most_chaotic_manager(awards_section),
         "leagueVitals": _league_vitals(snapshot),
+        # v2 Home callouts — derived from the 5 specialized sections
+        # added in PR #83.  Each may be null when the source section
+        # has no data (e.g. no current-season games, no active streaks).
+        "currentPowerLeader": _current_power_leader(power_section),
+        "luckyUnluckyCurrent": _lucky_unlucky_current(luck_section),
+        "activeStreakHighlight": _active_streak_highlight(streaks_section),
+        "recordInReach": _record_in_reach(streaks_section),
+        "upcomingWeekPreview": _upcoming_week_preview(matchup_preview_section),
+        "latestFullRecap": _latest_full_recap(weekly_recap_section),
     }

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -179,6 +179,11 @@ def _build_overview(snapshot: PublicLeagueSnapshot, sections: dict[str, Any]) ->
         activity_section=sections.get("activity") or {},
         draft_section=sections.get("draft") or {},
         weekly_section=sections.get("weekly") or {},
+        luck_section=sections.get("luck") or {},
+        streaks_section=sections.get("streaks") or {},
+        power_section=sections.get("power") or {},
+        matchup_preview_section=sections.get("matchupPreview") or {},
+        weekly_recap_section=sections.get("weeklyRecap") or {},
     )
 
 

--- a/tests/public_league/test_overview.py
+++ b/tests/public_league/test_overview.py
@@ -81,6 +81,56 @@ class OverviewTests(unittest.TestCase):
         self.assertIn("season", recap)
         self.assertIn("week", recap)
 
+    # ── v2 Home callouts ─────────────────────────────────────────────
+    def test_current_power_leader_populated(self) -> None:
+        leader = self.overview["currentPowerLeader"]
+        self.assertIsNotNone(leader)
+        for key in ("ownerId", "displayName", "teamName", "power", "record"):
+            self.assertIn(key, leader)
+        self.assertGreaterEqual(leader["power"], 0)
+        self.assertLessEqual(leader["power"], 100)
+
+    def test_lucky_unlucky_current_populated(self) -> None:
+        lu = self.overview["luckyUnluckyCurrent"]
+        self.assertIsNotNone(lu)
+        self.assertEqual(lu["season"], "2025")
+        self.assertIsNotNone(lu["lucky"])
+        self.assertIsNotNone(lu["unlucky"])
+        # Lucky luck delta >= unlucky luck delta.
+        self.assertGreaterEqual(lu["lucky"]["luckDelta"], lu["unlucky"]["luckDelta"])
+
+    def test_active_streak_highlight_populated(self) -> None:
+        s = self.overview["activeStreakHighlight"]
+        self.assertIsNotNone(s)
+        self.assertIn("type", s)
+        self.assertIn("length", s)
+        self.assertGreater(s["length"], 0)
+
+    def test_record_in_reach_has_holder_and_maybe_chaser(self) -> None:
+        rec = self.overview["recordInReach"]
+        if rec is None:
+            # Fixture may not produce a chaser; skip.
+            return
+        self.assertIn("holder", rec)
+        self.assertIn("category", rec)
+
+    def test_upcoming_week_preview_populated(self) -> None:
+        preview = self.overview["upcomingWeekPreview"]
+        # Fixture's 2025 season is complete, so mode should be "recap".
+        self.assertIsNotNone(preview)
+        self.assertIn(preview["mode"], ("recap", "preview"))
+        self.assertIn("home", preview)
+        self.assertIn("away", preview)
+        self.assertIn("h2h", preview)
+
+    def test_latest_full_recap_populated(self) -> None:
+        recap = self.overview["latestFullRecap"]
+        self.assertIsNotNone(recap)
+        for key in ("season", "week", "headline", "summary"):
+            self.assertIn(key, recap)
+        self.assertTrue(recap["headline"])
+        self.assertTrue(recap["summary"])
+
 
 class OverviewSectionEndpointTests(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Summary

The 5 tabs added in PR #83 (This Week, Power, Luck, Streaks, Recaps) were reachable only through navigation. Home now features a headline card from each, so visitors immediately see the most interesting thing about the league without clicking around.

## New Home cards

| Card | Source | What it shows |
|---|---|---|
| **This Week** | `matchupPreview` | Headline matchup with biggest H2H history; auto-preview or recap |
| **Power #1** | `power` | Most recent week's top ranked manager + record + week-over-week delta |
| **Luck Δ** | `luck` | Current-season luckiest + unluckiest pair with luck delta |
| **Longest Active Streak** | `streaks` | Manager and streak type (win/loss/100+/120+/140+) |
| **Record in Reach** | `streaks` | All-time record with current-season chaser; gold border if "within striking distance" |
| **Week in Review** | `weeklyRecap` | Auto-generated headline + summary from newest recap |

Each card deep-links to its dedicated tab. The whole row degrades gracefully when any individual callout has no data (e.g. no games scored yet).

## Backend

- `src/public_league/overview.py`: 6 new private helpers, 5 new optional kwargs on `build_section`, 6 new keys in output dict.
- `src/public_league/public_contract.py::_build_overview` passes the 5 new sections through.
- All optional args mean older contract consumers pre-dating PR #83 still work.

## Test plan

- [x] 6 new `tests/public_league/test_overview.py` assertions pin the shape of each new callout
- [x] Full pytest: **211 passing**
- [x] Full vitest: **402 passing**  
- [x] `next build` clean
- [x] `assert_public_payload_safe` verified against the new fields (no private leaks)
- [ ] Manual spot-check in staging — verify 6-card row reflows cleanly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)