### PR TITLE
Multi-team VA: extend V2 to 3+ team trades

### DIFF
--- a/frontend/__tests__/trade-logic.test.js
+++ b/frontend/__tests__/trade-logic.test.js
@@ -11,7 +11,9 @@ import {
   colorFromGap,
   sideTotal,
   computeValueAdjustment,
+  computeMultiSideAdjustments,
   adjustedSideTotals,
+  multiAdjustedSideTotals,
   tradeGapAdjusted,
   VA_SCARCITY_SLOPE,
   VA_SCARCITY_INTERCEPT,
@@ -457,6 +459,133 @@ describe("computeValueAdjustment", () => {
       const over20 = errs.filter((e) => e > 0.20).length;
       expect(over20).toBe(0);
     });
+  });
+});
+
+// ── computeMultiSideAdjustments (N-team trades) ──────────────────────
+//
+// Structural property tests — we don't have KTC observations for 3+
+// team trades yet, so these assert formula invariants and consistency
+// with the 2-side path rather than hitting specific KTC numbers.
+describe("computeMultiSideAdjustments", () => {
+  it("returns array matching input length", () => {
+    const out = computeMultiSideAdjustments(
+      [[mockRow(9999)], [mockRow(5000)], [mockRow(3000)]],
+      "full",
+    );
+    expect(out).toHaveLength(3);
+  });
+
+  it("reduces to 2-side behavior when called with 2 sides", () => {
+    const sideA = [mockRow(9999)];
+    const sideB = [mockRow(7846), mockRow(5717)];
+    const [adjA, adjB] = computeMultiSideAdjustments([sideA, sideB], "full");
+    const twoSide = computeValueAdjustment(sideA, sideB, "full");
+    const expectedRecipient = twoSide.adjustment;
+    const expectedOther = 0;
+    expect(adjA).toBeCloseTo(expectedRecipient, 5);
+    expect(adjB).toBeCloseTo(expectedOther, 5);
+    expect(twoSide.recipientIdx).toBe(0);
+  });
+
+  it("returns zero for every side when all have equal piece counts (2 ea)", () => {
+    const out = computeMultiSideAdjustments(
+      [
+        [mockRow(5000), mockRow(3000)],
+        [mockRow(4800), mockRow(3100)],
+        [mockRow(4900), mockRow(2900)],
+      ],
+      "full",
+    );
+    // Each side has count=2, opposition count=4 → guard passes, but
+    // small.length < large.length only because opposition is larger.
+    // However topGap is computed per side — most sides will have top
+    // ≤ merged top, so VA stays at zero.  At most the side with the
+    // strictly-highest top gets a non-zero VA.
+    const nonZero = out.filter((v) => v > 0).length;
+    expect(nonZero).toBeLessThanOrEqual(1);
+  });
+
+  it("in 3-team with one clear stud holder, that side gets the premium", () => {
+    // Side A has a single 9999 stud.  Sides B and C each have 2
+    // medium pieces.  A should earn significant VA for consolidation;
+    // B and C may earn little or none (their tops are below A's stud).
+    const out = computeMultiSideAdjustments(
+      [
+        [mockRow(9999)],
+        [mockRow(5000), mockRow(3500)],
+        [mockRow(4800), mockRow(3200)],
+      ],
+      "full",
+    );
+    expect(out[0]).toBeGreaterThan(1000);
+    // B and C: their top < merged top (includes A's 9999), so their
+    // topGap is 0 and they earn 0 VA.
+    expect(out[1]).toBe(0);
+    expect(out[2]).toBe(0);
+  });
+
+  it("never produces negative adjustments", () => {
+    const out = computeMultiSideAdjustments(
+      [
+        [mockRow(9999), mockRow(8000)],
+        [mockRow(7500)],
+        [mockRow(6000), mockRow(4000), mockRow(2000)],
+      ],
+      "full",
+    );
+    for (const v of out) expect(v).toBeGreaterThanOrEqual(0);
+  });
+
+  it("VA never exceeds the side's top asset", () => {
+    const sides = [
+      [mockRow(9999)],
+      [mockRow(5000), mockRow(3000), mockRow(2000)],
+      [mockRow(4000), mockRow(3000)],
+    ];
+    const out = computeMultiSideAdjustments(sides, "full");
+    sides.forEach((side, i) => {
+      const top = Math.max(...side.map((r) => r.values.full));
+      expect(out[i]).toBeLessThanOrEqual(top);
+    });
+  });
+
+  it("empty or single-side input returns zeros", () => {
+    expect(computeMultiSideAdjustments([], "full")).toEqual([]);
+    expect(computeMultiSideAdjustments([[mockRow(9999)]], "full")).toEqual([0]);
+  });
+});
+
+describe("multiAdjustedSideTotals", () => {
+  it("returns raw/adjustment/adjusted per side for 3 teams", () => {
+    const sides = [
+      [mockRow(9999)],
+      [mockRow(5000), mockRow(3500)],
+      [mockRow(4800), mockRow(3200)],
+    ];
+    const totals = multiAdjustedSideTotals(sides, "full");
+    expect(totals).toHaveLength(3);
+    for (const t of totals) {
+      expect(t).toHaveProperty("raw");
+      expect(t).toHaveProperty("adjustment");
+      expect(t).toHaveProperty("adjusted");
+      expect(t.adjusted).toBeCloseTo(t.raw + t.adjustment, 5);
+    }
+    // Stud side should have positive adjustment.
+    expect(totals[0].adjustment).toBeGreaterThan(0);
+  });
+
+  it("is consistent with adjustedSideTotals for 2 teams", () => {
+    const sideA = [mockRow(9999)];
+    const sideB = [mockRow(7846), mockRow(5717)];
+    const multi = multiAdjustedSideTotals([sideA, sideB], "full");
+    const [a, b] = adjustedSideTotals(sideA, sideB, "full");
+    expect(multi[0].raw).toBe(a.raw);
+    expect(multi[0].adjustment).toBeCloseTo(a.adjustment, 5);
+    expect(multi[0].adjusted).toBeCloseTo(a.adjusted, 5);
+    expect(multi[1].raw).toBe(b.raw);
+    expect(multi[1].adjustment).toBeCloseTo(b.adjustment, 5);
+    expect(multi[1].adjusted).toBeCloseTo(b.adjusted, 5);
   });
 });
 

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -300,13 +300,17 @@ export default function TradePage() {
   }, [pickerOpen]);
 
   // ── Computed totals for all sides ────────────────────────────────────
-  // 2-team mode uses KTC-style Value Adjustment: the side with fewer pieces
-  // gets a consolidation premium (see trade-logic.js).  3+ teams fall back
-  // to raw linear totals until we design a multi-team VA extension.
+  // Both 2-team and N-team trades use the KTC-style Value Adjustment.
+  // For N ≥ 3, each side's VA is computed against the merged opposition
+  // (every other side's assets flattened) — see
+  // ``computeMultiSideAdjustments`` in trade-logic.js.
   const sideTotals = useMemo(() => {
     if (sides.length === 2) {
       const [a, b] = adjustedSideTotals(sides[0].assets, sides[1].assets, valueMode, settings);
       return [a, b];
+    }
+    if (sides.length > 2) {
+      return multiAdjustedSideTotals(sides.map((s) => s.assets), valueMode, settings);
     }
     return sides.map((s) => {
       const raw = sideTotal(s.assets, valueMode, settings);

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -150,6 +150,47 @@ function sortedSideValues(side, valueMode, settings) {
 }
 
 /**
+ * Core V2 VA formula on pre-sorted value arrays.
+ *
+ * ``small`` and ``large`` must be sorted descending.  ``small`` is the
+ * side receiving the VA; ``large`` is the side with more pieces.
+ * Returns the scalar VA (always ≥ 0).  Caller is responsible for
+ * clamping when small.length ≥ large.length — this function assumes
+ * ``large`` is strictly longer than ``small``.
+ *
+ * Factored out so both the 2-side ``computeValueAdjustment`` path and
+ * the N-side ``computeMultiSideAdjustments`` path share exactly the
+ * same math — no divergence between how a 2-team trade is graded vs
+ * how the same shape is graded inside a 3-team trade.
+ */
+function _vaFromSortedSides(small, large) {
+  if (small.length === 0 || small[0] <= 0) return 0;
+  if (small.length >= large.length) return 0;
+
+  const topSmall = small[0];
+  const topLarge = large[0] || 0;
+  const topGap = Math.max(0, (topSmall - topLarge) / topSmall);
+  if (topGap === 0) return 0;
+
+  const rawScarcity = VA_SCARCITY_SLOPE * topGap - VA_SCARCITY_INTERCEPT;
+  const topScarcity = Math.max(0, Math.min(VA_SCARCITY_CAP, rawScarcity));
+
+  const extras = large.slice(small.length);
+  let adjustment = 0;
+  for (let p = 0; p < extras.length; p++) {
+    const extra = extras[p];
+    const extraGap = Math.max(0, (topSmall - extra) / topSmall);
+    const boostTerm = VA_PER_EXTRA_BOOST * Math.max(0, extraGap - topGap);
+    const effective = Math.max(
+      0,
+      Math.min(VA_EFFECTIVE_CAP, topScarcity + boostTerm),
+    );
+    adjustment += extra * effective * Math.pow(VA_POSITION_DECAY, p);
+  }
+  return adjustment;
+}
+
+/**
  * Compute the KTC-style Value Adjustment between two sides.
  *
  * The side with fewer pieces receives a bonus representing the
@@ -183,51 +224,49 @@ export function computeValueAdjustment(sideA, sideB, valueMode, settings = null)
     return { adjustment: 0, recipientIdx: null };
   }
 
-  const topSmall = small[0];
-  const topLarge = large[0] || 0;
-  const topGap = Math.max(0, (topSmall - topLarge) / topSmall);
-
-  // If the small side's top is no better than the large side's top,
-  // there's no consolidation upgrade to reward — return zero VA
-  // regardless of any throw-ins on the large side.  This preserves
-  // the V1 invariant; every KTC data point we've calibrated against
-  // has topSmall > topLarge (including case L at a 0.04 gap).
-  if (topGap === 0) {
-    return { adjustment: 0, recipientIdx };
-  }
-
-  const rawScarcity = VA_SCARCITY_SLOPE * topGap - VA_SCARCITY_INTERCEPT;
-  const topScarcity = Math.max(0, Math.min(VA_SCARCITY_CAP, rawScarcity));
-
-  const extras = large.slice(small.length);
-
-  // Per-extra effective weight with a "throw-in" boost.
-  //
-  // For each extra, compute its own gap ratio relative to the small
-  // side's top.  The further this extra's gap is below topGap, the
-  // smaller (more "filler") the extra is — and the higher its
-  // effective weight should climb (KTC rewards trading filler for
-  // consolidation).  When extra_gap ≈ topGap (the extra is as valuable
-  // as ``topLarge``), the boost goes to zero and we reduce back to the
-  // plain V1 behavior for that piece.
-  //
-  // If topScarcity is zero AND no extras beat the gap floor (only
-  // happens for near-even tops AND matched extras), VA stays zero.
-  let adjustment = 0;
-  for (let p = 0; p < extras.length; p++) {
-    const extra = extras[p];
-    const extraGap = topSmall > 0
-      ? Math.max(0, (topSmall - extra) / topSmall)
-      : 0;
-    const boostTerm = VA_PER_EXTRA_BOOST * Math.max(0, extraGap - topGap);
-    const effective = Math.max(
-      0,
-      Math.min(VA_EFFECTIVE_CAP, topScarcity + boostTerm),
-    );
-    adjustment += extra * effective * Math.pow(VA_POSITION_DECAY, p);
-  }
-
+  const adjustment = _vaFromSortedSides(small, large);
   return { adjustment, recipientIdx };
+}
+
+/**
+ * Compute per-side Value Adjustments for a multi-team trade (N ≥ 2).
+ *
+ * Each side's VA is computed as if that side is the "small" side in a
+ * 2-side trade, and the merged opposition is the flattened union of
+ * every OTHER side's received assets.  This generalization reduces to
+ * the 2-side ``computeValueAdjustment`` behavior when N = 2, and lets
+ * every side that consolidated relative to what they gave up earn an
+ * independent premium in 3+-team deals.
+ *
+ * Returns an array of numeric adjustments — one per side, in the same
+ * order as the input.  A side's adjustment is ≥ 0; sides without a
+ * piece-count advantage over the rest of the trade receive 0.
+ *
+ * Caveat: the V2 coefficients were calibrated against 2-side KTC
+ * observations.  Multi-side output is a structural extension of that
+ * calibration, NOT a separately fit formula.  If KTC's real multi-team
+ * VA diverges from this, we'll know when we have multi-team KTC data.
+ *
+ * @param {object[][]} sides  — array of asset arrays, one per side
+ * @param {string} valueMode
+ * @param {object} [settings]
+ * @returns {number[]}
+ */
+export function computeMultiSideAdjustments(sides, valueMode, settings = null) {
+  if (!Array.isArray(sides) || sides.length < 2) {
+    return (sides || []).map(() => 0);
+  }
+  const allValues = sides.map((side) =>
+    sortedSideValues(side, valueMode, settings),
+  );
+  return allValues.map((small, i) => {
+    const large = [];
+    for (let j = 0; j < allValues.length; j++) {
+      if (j !== i) large.push(...allValues[j]);
+    }
+    large.sort((a, b) => b - a);
+    return _vaFromSortedSides(small, large);
+  });
 }
 
 /**
@@ -245,6 +284,26 @@ export function adjustedSideTotals(sideA, sideB, valueMode, settings = null) {
     { raw: rawA, adjustment: adjA, adjusted: rawA + adjA },
     { raw: rawB, adjustment: adjB, adjusted: rawB + adjB },
   ];
+}
+
+/**
+ * Adjusted per-side totals for N-team trade display (N ≥ 2).
+ *
+ * Each entry is { raw, adjustment, adjusted }.  For N = 2 this matches
+ * ``adjustedSideTotals`` exactly.  For N ≥ 3 each side can earn its
+ * own consolidation premium — see ``computeMultiSideAdjustments``.
+ *
+ * @param {object[][]} sides  — array of asset arrays
+ * @param {string} valueMode
+ * @param {object} [settings]
+ */
+export function multiAdjustedSideTotals(sides, valueMode, settings = null) {
+  const adjustments = computeMultiSideAdjustments(sides, valueMode, settings);
+  return sides.map((side, i) => {
+    const raw = sideTotal(side, valueMode, settings);
+    const adjustment = adjustments[i] || 0;
+    return { raw, adjustment, adjusted: raw + adjustment };
+  });
 }
 
 /** Gap = Side A adjusted total − Side B adjusted total (KTC-style). */


### PR DESCRIPTION
## Summary

Closes PR #82's follow-up TODO. Before this PR, 3+ team trades fell back to raw linear totals (zero VA). Now each side in a multi-team trade earns an independent consolidation premium computed via V2 against the merged opposition (every other side's assets flattened).

## Design

For an N-team trade (N ≥ 2), each side's VA runs the V2 2-side formula with:
- `small` = that side's received pieces
- `large` = union of every OTHER side's received pieces

Reduces exactly to the existing 2-side behavior when N = 2. For N ≥ 3:
- Each side can earn its own VA for consolidation relative to what it gave up
- V2's `topGap` guard still fires — sides whose top asset is no better than the merged opposition earn 0, so only the stud-holder typically gets a non-trivial premium in balanced trades

**This is a structural extension, NOT a separately calibrated formula.** V2 was fit against 13 two-side KTC observations. Multi-team output is plausible and self-consistent but uncalibrated until we have KTC multi-team data.

## API

New exports in `frontend/lib/trade-logic.js`:

```js
computeMultiSideAdjustments(sides: object[][], valueMode, settings?): number[]
multiAdjustedSideTotals(sides: object[][], valueMode, settings?): {raw, adjustment, adjusted}[]
```

The 2-side math is now factored into `_vaFromSortedSides` so both paths share identical formulas.

## Frontend

`frontend/app/trade/page.jsx`'s `sideTotals` now routes `sides.length > 2` through `multiAdjustedSideTotals`. The existing UI already renders `total.adjustment` + "Raw X + VA Y" per side, so multi-team trades now display consolidation premium automatically — no rendering changes needed.

## Test plan

- [x] 9 new multi-side tests covering length invariance, 2-side consistency, balanced-tops behavior, clear-stud-holder behavior, non-negativity, bounds (VA ≤ top), empty input
- [x] All 13 existing KTC 2-side anchors still pass (refactor preserves math)
- [x] 146 trade-logic tests pass (was 137)
- [x] 411 full vitest pass (was 402)
- [x] `next build` clean
- [ ] Manual spot-check in staging with a 3-team trade shape
- [ ] Eventually: collect KTC-equivalent multi-team observations and calibrate separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)