### PR TITLE
Fix 503 on /api/public/league from tuple.values() typo

### DIFF
--- a/src/public_league/weekly_recap.py
+++ b/src/public_league/weekly_recap.py
@@ -77,7 +77,8 @@ def _weekly_trades_for(
                     "ownerId": oid,
                     "displayName": metrics.display_name_for(snapshot, oid),
                 })
-        assets_moved = sum(len(d) for d in (tx.get("adds") or {}, {}).values() if isinstance(d, dict))
+        adds = tx.get("adds")
+        assets_moved = len(adds) if isinstance(adds, dict) else 0
         picks_moved = len(tx.get("draft_picks") or [])
         out.append({
             "transactionId": tx.get("transaction_id"),

--- a/tests/public_league/test_weekly_recap.py
+++ b/tests/public_league/test_weekly_recap.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import unittest
 
-from src.public_league.weekly_recap import build_section
+from src.public_league.weekly_recap import _weekly_trades_for, build_section
 from tests.public_league.fixtures import build_test_snapshot
 
 
@@ -80,6 +80,35 @@ class WeeklyRecapSectionTests(unittest.TestCase):
             for m in recap["matchups"]:
                 self.assertIsInstance(m["oneliner"], str)
                 self.assertTrue(m["oneliner"])
+
+    def test_weekly_trades_counts_assets_when_leg_matches_week(self) -> None:
+        # Regression: previously a `(adds or {}, {}).values()` typo raised
+        # AttributeError whenever a completed trade's leg matched a scored
+        # week.  The test fixture's trade legs don't overlap scored weeks,
+        # so the bug never surfaced in unit tests — only in production.
+        season = next(s for s in self.snapshot.seasons if s.season == "2025")
+        fake_tx = {
+            "transaction_id": "tx-regression",
+            "type": "trade",
+            "status": "complete",
+            "leg": 2,
+            "roster_ids": [1, 2],
+            "adds": {"p-rb2": 1, "p-wr2": 2},
+            "drops": {"p-rb2": 2, "p-wr2": 1},
+        }
+        original_trades = season.trades
+
+        def patched_trades() -> list:
+            return [*original_trades(), fake_tx]
+
+        season.trades = patched_trades  # type: ignore[method-assign]
+        try:
+            out = _weekly_trades_for(season, self.snapshot, 2)
+        finally:
+            season.trades = original_trades  # type: ignore[method-assign]
+        match = next((row for row in out if row["transactionId"] == "tx-regression"), None)
+        self.assertIsNotNone(match)
+        self.assertEqual(match["assetsMoved"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Production `/league` was returning **"League data unavailable"** because `GET /api/public/league` was throwing `AttributeError: 'tuple' object has no attribute 'values'` on every request, which the handler catches and maps to 503.

Root cause: `src/public_league/weekly_recap.py::_weekly_trades_for` computed `assets_moved` with

```python
sum(len(d) for d in (tx.get("adds") or {}, {}).values() if isinstance(d, dict))
```

The expression `(tx.get("adds") or {}, {})` is a 2-tuple of dicts, and tuples don't have `.values()`. The whole public-league contract builder fed this section, so the 503 fired as soon as any completed trade's `leg` landed on a scored week — which is essentially always in production.

The existing unit fixture coincidentally had trade legs that never intersected scored weeks (trade leg=3, matchup weeks=1,2,15,16), so this path was never exercised and CI stayed green.

## Changes

- `src/public_league/weekly_recap.py` — replace the tuple-indexing typo with a direct `len(adds)`, which is what `assetsMoved` was always meant to represent (the frontend renders `"{assetsMoved} asset{…}"`).
- `tests/public_league/test_weekly_recap.py` — add a regression test that patches the 2025 season so a trade's leg matches a scored week, asserting `_weekly_trades_for` returns the trade with `assetsMoved == 2`. Verified this test fails against the original buggy line and passes with the fix.

## Test plan

- [x] `python -m pytest tests/public_league/ -q` — 196 passed, 22 skipped
- [x] Reproduced the 503 locally against the real Sleeper league ID; confirmed `build_public_contract` now succeeds end-to-end and `assert_public_payload_safe` is satisfied
- [ ] After deploy, hit `https://riskittogetthebrisket.org/api/public/league` and verify 200 + populated `weeklyRecap.weeks`
- [ ] Reload `/league` in the browser and verify the "League data unavailable" banner is gone

https://claude.ai/code/session_01UxZ5Viw8DYsLRm6QNLPEeC