### PR TITLE
Add IDP Calibration Lab internal tool

### DIFF
--- a/docs/idp_calibration_lab.md
+++ b/docs/idp_calibration_lab.md
@@ -1,0 +1,165 @@
+# IDP Calibration Lab
+
+Internal tooling for calibrating how DL / LB / DB values are scaled in the
+live trade calculator. The lab takes two Sleeper league IDs, walks each one
+back through `previous_league_id`, rescores a common IDP player universe
+under both scoring systems for 2022-2025, and produces per-position
+per-bucket multipliers plus anchor curves. Nothing reaches production
+until you click **Promote to production**.
+
+**Location:** `/tools/idp-calibration` (auth-gated, hidden from the public).
+
+## Data sources
+
+### From Sleeper (authoritative)
+- League metadata (name, season, total rosters)
+- `scoring_settings` — normalised via `src/scoring/sleeper_ingest.py::KEY_ALIASES`
+- `roster_positions` — parsed into lineup demand by `src/idp_calibration/lineup.py`
+- `previous_league_id` — walked by `src/idp_calibration/sleeper_client.fetch_league_chain`
+- Global NFL players map (for ID -> name / position in the stats adapter)
+
+### From the historical stats adapter layer
+The lab never hardcodes a "Sleeper only" assumption for historical stats
+because Sleeper's season stats endpoint is undocumented. The adapter
+interface lives at `src/idp_calibration/stats_adapter.py`. Adapters:
+
+1. `SleeperStatsAdapter` — probes `https://api.sleeper.app/v1/stats/nfl/regular/{season}`.
+   Skipped by default unless `IDP_CALIBRATION_ALLOW_NETWORK=1` is set.
+2. `LocalCSVStatsAdapter` — reads `data/idp_calibration/stats/{season}.csv`.
+   Header must include `player_id`, `name`, `position`, and any subset of
+   the canonical IDP stat columns (`idp_tkl_solo`, `idp_tkl_ast`,
+   `idp_tkl_loss`, `idp_sack`, `idp_hit`, `idp_int`, `idp_pd`, `idp_ff`,
+   `idp_fum_rec`, `idp_def_td`), plus optional `games`.
+3. `ManualFallbackAdapter` — returns an empty list and surfaces a warning
+   so the UI can flag that no stats source was reachable.
+
+The factory `get_stats_adapter(season)` picks the first usable adapter.
+Whichever adapter is used, the **same player universe is rescored under
+both league scoring systems** so the comparison is apples to apples.
+
+## How to run an analysis
+
+1. Start backend + frontend: `python server.py` + `npm run dev -w frontend`.
+2. Sign in, then visit `/tools/idp-calibration`.
+3. Paste the test-league (market) ID and your-league ID.
+4. (Optional) Open **Advanced settings** to tweak seasons, replacement
+   mode, blend weights, year recency weights, bucket edges, or universe
+   filters. Defaults:
+   - Seasons: 2022-2025
+   - Replacement: `starter_plus_buffer` with 15% team-count buffer
+   - Blend: 75% intrinsic / 25% market
+   - Year weights: 2025=0.40, 2024=0.30, 2023=0.20, 2022=0.10
+   - Buckets: 1-6, 7-12, 13-24, 25-36, 37-60, 61-100
+5. Click **Analyze**. The run is saved to
+   `data/idp_calibration/runs/{run_id}.json` and the latest pointer is
+   written to `data/idp_calibration/latest.json`.
+6. Inspect the dashboard sections — league verification, demand, VOR by
+   season, multi-year multipliers, anchor curves, recommendation.
+7. Use the export buttons for JSON / bucket CSV / anchor CSV if you want
+   an artefact outside the app.
+
+## Promotion flow
+
+Promotion is always manual.
+
+1. Open a run you like.
+2. Pick an `active_mode` — `blended` (default), `intrinsic_only`, or
+   `market_only`.
+3. Click **Promote to production** (it's a two-click confirm).
+
+On promote:
+
+- If `config/idp_calibration.json` already exists, it is copied to
+  `config/idp_calibration.backups/{iso_timestamp}.json` first.
+- The approved calibration output (multipliers + anchors + metadata) is
+  written to `config/idp_calibration.json`.
+- The live valuation pipeline picks up the new config within one request
+  thanks to an mtime-keyed cache in `src/idp_calibration/production.py`.
+  No server restart is required.
+
+### Promoted config schema
+
+```json
+{
+  "version": 1,
+  "promoted_at": "...",
+  "source_run_id": "...",
+  "promoted_by": "...",
+  "league_ids": {"test": "...", "mine": "..."},
+  "year_coverage": [2022, 2023, 2024, 2025],
+  "blend_weights": {"intrinsic": 0.75, "market": 0.25},
+  "replacement_settings": {"mode": "starter_plus_buffer", "buffer_pct": 0.15},
+  "active_mode": "blended",
+  "bucket_edges": [[1,6],[7,12],[13,24],[25,36],[37,60],[61,100]],
+  "multipliers": {
+    "DL": {"position": "DL", "buckets": [{"label": "1-6", "intrinsic": 1.0, "market": 1.0, "final": 1.0, "count": 24}, ...]},
+    "LB": {...},
+    "DB": {...}
+  },
+  "anchors": {
+    "intrinsic": {"DL": [{"rank": 1, "value": 1.0}, ...], ...},
+    "market":    {"DL": [...], ...},
+    "final":     {"DL": [...], ...}
+  }
+}
+```
+
+## How the production calculator consumes the config
+
+1. `src/api/data_contract.py` imports
+   `src.idp_calibration.production`.
+2. After Phase 4 of `_compute_unified_rankings`, the helper
+   `_apply_idp_calibration_post_pass(players_array, players_by_name)`
+   runs.
+3. The helper calls `production.load_production_config()`. If no
+   promoted config exists, it returns immediately (strict no-op).
+4. When a config exists, IDP rows are grouped into DL/LB/DB, sorted by
+   their current `rankDerivedValue`, and each row's value is multiplied
+   by `production.get_idp_bucket_multiplier(position, pos_rank,
+   mode=active_mode)`. The new value is mirrored into the legacy
+   `players_by_name` dict so runtime views stay in sync.
+5. Offense and pick rows are untouched. Picks are renormalised later in
+   Phase 5 exactly as before.
+6. Downstream consumers (trade suggestions, finder, rankings page) read
+   the updated `rankDerivedValue` without any additional change.
+
+The promoted config is the **single** entry point. There is no parallel
+code path — if the file is deleted, every IDP multiplier is 1.0 again.
+
+## Known limitations
+
+- The Sleeper stats endpoint is undocumented. When it fails, the lab
+  defaults to `LocalCSVStatsAdapter` (see above) or loudly warns via
+  `ManualFallbackAdapter`. Populate
+  `data/idp_calibration/stats/{season}.csv` for deterministic runs.
+- The player universe is defined per season (all valid DL/LB/DB with
+  usable stats). Changing the universe between analyses changes the
+  multiplier curve shape, so compare like-for-like settings.
+- Bucket counts below `min_bucket_size` (default 3) are merged into the
+  neighbouring lower-rank bucket, and the merge is reported both in the
+  UI and in the saved run artefact. Don't over-read the multiplier when
+  the bucket is small or merged.
+- The market curve is Test League scoring only. It is treated as a
+  prior, not ground truth — bump the `blend.intrinsic` weight toward
+  1.0 if you want the promoted config to lean on your own league
+  economics more heavily.
+- Promotion has no granular RBAC beyond the existing session auth gate.
+  Any authenticated user can promote.
+- IDP rookie / veteran split from `src/canonical/calibration.py` is
+  preserved — the lab's multipliers apply on top of whichever universe
+  scale the canonical engine already picked.
+
+## Tests
+
+`pytest tests/idp_calibration/ -q`
+
+| File | Covers |
+|---|---|
+| `test_season_chain.py` | `previous_league_id` walk, missing-season warnings |
+| `test_scoring.py` | Sleeper `scoring_settings` -> canonical weight map |
+| `test_replacement.py` | Replacement-level math (strict / buffer / manual) |
+| `test_vor_buckets.py` | Common-universe invariant, bucket blended-center, merge logic |
+| `test_translation_anchors.py` | Multi-year multipliers, monotonic anchors |
+| `test_storage_promotion.py` | Run save / load, promote + backup |
+| `test_api.py` | Endpoint validation, run lookup, promote flow |
+| `test_production_integration.py` | Promoted config scales IDP rows only |

--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -14,6 +14,7 @@ const PRIMARY_NAV = [
   { href: "/edge", label: "Edge" },
   { href: "/finder", label: "Finder" },
   { href: "/league", label: "League" },
+  { href: "/tools/idp-calibration", label: "IDP Lab" },
   { href: "/settings", label: "Settings" },
   { href: "/more", label: "More" },
 ];
@@ -136,6 +137,7 @@ function MobileTopBar() {
 
   // Derive page title from current route
   const pageTitle = (() => {
+    if (pathname?.startsWith("/tools/idp-calibration")) return "IDP Lab";
     const route = pathname?.split("/")[1] || "";
     const titles = {
       "": "Home",

--- a/frontend/app/api/idp-calibration/analyze/route.js
+++ b/frontend/app/api/idp-calibration/analyze/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+  /\/api\/data\/?$/,
+  "",
+);
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  // Analysis can take several seconds across 4 seasons + network.
+  const timer = setTimeout(() => ctl.abort(), 90_000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/analyze`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify(body || {}),
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/api/idp-calibration/production/route.js
+++ b/frontend/app/api/idp-calibration/production/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+  /\/api\/data\/?$/,
+  "",
+);
+
+export async function GET(request) {
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 5000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/production`, {
+      headers: { Cookie: cookie },
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/api/idp-calibration/promote/route.js
+++ b/frontend/app/api/idp-calibration/promote/route.js
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+  /\/api\/data\/?$/,
+  "",
+);
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 10_000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/promote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify(body || {}),
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/api/idp-calibration/runs/[run_id]/route.js
+++ b/frontend/app/api/idp-calibration/runs/[run_id]/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+  /\/api\/data\/?$/,
+  "",
+);
+
+export async function GET(request, { params }) {
+  const cookie = request.headers.get("cookie") || "";
+  const awaited = await params;
+  const runId = encodeURIComponent(String(awaited?.run_id || ""));
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 8000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/runs/${runId}`, {
+      headers: { Cookie: cookie },
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/api/idp-calibration/runs/[run_id]/route.js
+++ b/frontend/app/api/idp-calibration/runs/[run_id]/route.js
@@ -28,3 +28,28 @@ export async function GET(request, { params }) {
     clearTimeout(timer);
   }
 }
+
+export async function DELETE(request, { params }) {
+  const cookie = request.headers.get("cookie") || "";
+  const awaited = await params;
+  const runId = encodeURIComponent(String(awaited?.run_id || ""));
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 8000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/runs/${runId}`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/api/idp-calibration/runs/route.js
+++ b/frontend/app/api/idp-calibration/runs/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+  /\/api\/data\/?$/,
+  "",
+);
+
+export async function GET(request) {
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 5000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/runs`, {
+      headers: { Cookie: cookie },
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/api/idp-calibration/status/route.js
+++ b/frontend/app/api/idp-calibration/status/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+  /\/api\/data\/?$/,
+  "",
+);
+
+export async function GET(request) {
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 5000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/status`, {
+      headers: { Cookie: cookie },
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2012,3 +2012,323 @@ tr:hover .sticky-name {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   IDP CALIBRATION LAB  (/tools/idp-calibration)
+   ══════════════════════════════════════════════════════════════════════════ */
+.idp-lab-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding-bottom: var(--space-xl);
+}
+
+.idp-lab-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.idp-lab-input-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-md);
+}
+
+.idp-lab-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.idp-lab-label {
+  font-size: 0.82rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.idp-lab-actions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.idp-lab-hint {
+  margin-top: var(--space-sm);
+}
+
+.idp-lab-toolbar {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.idp-lab-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.idp-lab-fieldset {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-sm) var(--space-md) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.idp-lab-fieldset legend {
+  font-size: 0.82rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0 var(--space-xs);
+}
+
+.idp-lab-bucket-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.idp-lab-bucket-row .input {
+  width: 80px;
+}
+
+.idp-lab-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.idp-lab-section h2 {
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin: 0;
+}
+
+.idp-lab-section h3 {
+  font-size: 0.95rem;
+  margin: 0 0 var(--space-sm) 0;
+}
+
+.idp-lab-subheading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+
+.idp-lab-chain-grid,
+.idp-lab-scoring-grid,
+.idp-lab-lineup-grid,
+.idp-lab-anchor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-md);
+}
+
+.idp-lab-chain-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.idp-lab-chain-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  font-size: 0.9rem;
+}
+
+.idp-lab-chain-ok {
+  color: var(--text);
+}
+
+.idp-lab-chain-miss {
+  color: var(--amber);
+}
+
+.idp-lab-chain-header {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: baseline;
+}
+
+.idp-lab-chain-id {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.idp-lab-warning-list {
+  margin: var(--space-sm) 0 0;
+  padding: 0 0 0 1.2em;
+  color: var(--amber);
+  font-size: 0.85rem;
+}
+
+.idp-lab-scoring-list {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-xs) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  font-size: 0.85rem;
+}
+
+.idp-lab-lineup-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-sm);
+  margin: 0;
+}
+
+.idp-lab-lineup-list > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.idp-lab-lineup-list dt {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.idp-lab-lineup-list dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.idp-lab-season {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  border-top: 1px dashed var(--border);
+  padding-top: var(--space-sm);
+}
+
+.idp-lab-season:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.idp-lab-season-missing {
+  color: var(--amber);
+}
+
+.idp-lab-bucket-block,
+.idp-lab-mult-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.idp-lab-bucket-table th,
+.idp-lab-mult-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.idp-lab-chart {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.idp-lab-chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.idp-lab-chart-title {
+  font-weight: 600;
+}
+
+.idp-lab-chart-legend {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.idp-lab-chart-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.idp-lab-chart-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.idp-lab-chart-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.idp-lab-chart-empty {
+  padding: var(--space-md);
+  text-align: center;
+}
+
+.idp-lab-runs-table code {
+  font-size: 0.78rem;
+}
+
+.idp-lab-row-active {
+  background: rgba(78, 201, 255, 0.08);
+}
+
+.idp-lab-warning {
+  border-left: 3px solid var(--amber);
+  background: rgba(228, 161, 46, 0.06);
+}
+
+.idp-lab-warning ul {
+  margin: var(--space-xs) 0 0;
+  padding-left: 1.2em;
+}
+
+.idp-lab-error {
+  border-left: 3px solid var(--red);
+  background: rgba(220, 70, 70, 0.06);
+}
+
+.idp-lab-error-text {
+  color: var(--red);
+  margin: var(--space-sm) 0 0;
+}
+
+.idp-lab-promote-block {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-top: var(--space-sm);
+}
+
+.idp-lab-rec-list {
+  margin: 0;
+  padding-left: 1.2em;
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2332,3 +2332,60 @@ tr:hover .sticky-name {
   margin: 0;
   padding-left: 1.2em;
 }
+
+.idp-lab-runs-actions {
+  display: flex;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.idp-lab-badge-promoted {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.4);
+  color: var(--green);
+  margin-left: var(--space-xs);
+}
+
+.idp-lab-diff {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  background: rgba(86, 214, 255, 0.04);
+}
+
+.idp-lab-diff-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.idp-lab-diff-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.idp-lab-diff-up { color: var(--green); font-weight: 600; }
+.idp-lab-diff-down { color: var(--red); font-weight: 600; }
+.idp-lab-diff-new { color: var(--cyan); font-weight: 600; }
+.idp-lab-diff-flat { color: var(--muted); }
+
+.idp-lab-diff-details {
+  margin-top: var(--space-sm);
+}
+
+.idp-lab-diff-all-table th,
+.idp-lab-diff-all-table td {
+  text-align: right;
+  font-size: 0.78rem;
+}
+
+.idp-lab-diff-all-table th:first-child,
+.idp-lab-diff-all-table td:first-child {
+  text-align: left;
+}

--- a/frontend/app/tools/idp-calibration/AdvancedSettingsDrawer.jsx
+++ b/frontend/app/tools/idp-calibration/AdvancedSettingsDrawer.jsx
@@ -48,7 +48,14 @@ export default function AdvancedSettingsDrawer({
     if (initial.year_weights) setYearWeights(initial.year_weights);
     if (initial.min_bucket_size != null) setMinBucketSize(initial.min_bucket_size);
     if (initial.min_games != null) setMinGames(initial.min_games);
-    if (initial.top_n) setTopN(String(initial.top_n));
+    // Explicit clear when incoming settings carry no top_n — otherwise a
+    // value from a prior run would stick and silently re-enable the
+    // universe filter on the next Apply.
+    if (initial.top_n == null || initial.top_n === "" || initial.top_n === 0) {
+      setTopN("");
+    } else {
+      setTopN(String(initial.top_n));
+    }
     if (Array.isArray(initial.bucket_edges)) setBucketEdges(initial.bucket_edges);
   }, [initial]);
 

--- a/frontend/app/tools/idp-calibration/AdvancedSettingsDrawer.jsx
+++ b/frontend/app/tools/idp-calibration/AdvancedSettingsDrawer.jsx
@@ -23,6 +23,7 @@ export default function AdvancedSettingsDrawer({
   const [seasons, setSeasons] = useState(DEFAULT_SEASONS);
   const [replacementMode, setReplacementMode] = useState("starter_plus_buffer");
   const [bufferPct, setBufferPct] = useState(0.15);
+  const [manualRanks, setManualRanks] = useState({ DL: "", LB: "", DB: "" });
   const [blendIntrinsic, setBlendIntrinsic] = useState(0.75);
   const [yearWeights, setYearWeights] = useState(DEFAULT_YEAR_WEIGHTS);
   const [minBucketSize, setMinBucketSize] = useState(3);
@@ -35,6 +36,14 @@ export default function AdvancedSettingsDrawer({
     if (Array.isArray(initial.seasons)) setSeasons(initial.seasons);
     if (initial.replacement?.mode) setReplacementMode(initial.replacement.mode);
     if (initial.replacement?.buffer_pct != null) setBufferPct(initial.replacement.buffer_pct);
+    if (initial.replacement?.manual && typeof initial.replacement.manual === "object") {
+      setManualRanks((prev) => ({
+        ...prev,
+        ...Object.fromEntries(
+          Object.entries(initial.replacement.manual).map(([k, v]) => [k, v == null ? "" : String(v)]),
+        ),
+      }));
+    }
     if (initial.blend?.intrinsic != null) setBlendIntrinsic(initial.blend.intrinsic);
     if (initial.year_weights) setYearWeights(initial.year_weights);
     if (initial.min_bucket_size != null) setMinBucketSize(initial.min_bucket_size);
@@ -52,11 +61,20 @@ export default function AdvancedSettingsDrawer({
   }
 
   function handleSubmit() {
+    const manualPayload =
+      replacementMode === "manual"
+        ? Object.fromEntries(
+            Object.entries(manualRanks)
+              .map(([pos, raw]) => [pos, Number(raw)])
+              .filter(([, n]) => Number.isFinite(n) && n > 0),
+          )
+        : {};
     const parsed = {
       seasons: seasons.map((s) => Number(s)).filter((n) => Number.isFinite(n)),
       replacement: {
         mode: replacementMode,
         buffer_pct: Number(bufferPct) || 0,
+        manual: manualPayload,
       },
       blend: { intrinsic: Number(blendIntrinsic) || 0 },
       year_weights: yearWeights,
@@ -67,6 +85,10 @@ export default function AdvancedSettingsDrawer({
     };
     onSave?.(parsed);
     onClose?.();
+  }
+
+  function updateManualRank(position, value) {
+    setManualRanks((prev) => ({ ...prev, [position]: value }));
   }
 
   function addBucket() {
@@ -131,6 +153,29 @@ export default function AdvancedSettingsDrawer({
                 onChange={(e) => setBufferPct(e.target.value)}
               />
             </label>
+          )}
+          {replacementMode === "manual" && (
+            <>
+              <p className="muted text-sm">
+                Set the replacement rank per position. Leave blank to fall
+                back to auto-derived cutoffs for that position.
+              </p>
+              {["DL", "LB", "DB"].map((pos) => (
+                <label className="idp-lab-field" key={pos}>
+                  <span className="idp-lab-label">
+                    {pos} manual replacement rank
+                  </span>
+                  <input
+                    className="input"
+                    type="number"
+                    min="1"
+                    placeholder="e.g. 36"
+                    value={manualRanks[pos] ?? ""}
+                    onChange={(e) => updateManualRank(pos, e.target.value)}
+                  />
+                </label>
+              ))}
+            </>
           )}
         </fieldset>
 

--- a/frontend/app/tools/idp-calibration/AdvancedSettingsDrawer.jsx
+++ b/frontend/app/tools/idp-calibration/AdvancedSettingsDrawer.jsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MobileSheet } from "@/components/ui";
+
+const DEFAULT_SEASONS = [2022, 2023, 2024, 2025];
+const DEFAULT_BUCKETS = [
+  [1, 6],
+  [7, 12],
+  [13, 24],
+  [25, 36],
+  [37, 60],
+  [61, 100],
+];
+const DEFAULT_YEAR_WEIGHTS = { 2025: 0.4, 2024: 0.3, 2023: 0.2, 2022: 0.1 };
+
+export default function AdvancedSettingsDrawer({
+  isOpen,
+  onClose,
+  initial,
+  onSave,
+}) {
+  const [seasons, setSeasons] = useState(DEFAULT_SEASONS);
+  const [replacementMode, setReplacementMode] = useState("starter_plus_buffer");
+  const [bufferPct, setBufferPct] = useState(0.15);
+  const [blendIntrinsic, setBlendIntrinsic] = useState(0.75);
+  const [yearWeights, setYearWeights] = useState(DEFAULT_YEAR_WEIGHTS);
+  const [minBucketSize, setMinBucketSize] = useState(3);
+  const [minGames, setMinGames] = useState(0);
+  const [topN, setTopN] = useState("");
+  const [bucketEdges, setBucketEdges] = useState(DEFAULT_BUCKETS);
+
+  useEffect(() => {
+    if (!initial) return;
+    if (Array.isArray(initial.seasons)) setSeasons(initial.seasons);
+    if (initial.replacement?.mode) setReplacementMode(initial.replacement.mode);
+    if (initial.replacement?.buffer_pct != null) setBufferPct(initial.replacement.buffer_pct);
+    if (initial.blend?.intrinsic != null) setBlendIntrinsic(initial.blend.intrinsic);
+    if (initial.year_weights) setYearWeights(initial.year_weights);
+    if (initial.min_bucket_size != null) setMinBucketSize(initial.min_bucket_size);
+    if (initial.min_games != null) setMinGames(initial.min_games);
+    if (initial.top_n) setTopN(String(initial.top_n));
+    if (Array.isArray(initial.bucket_edges)) setBucketEdges(initial.bucket_edges);
+  }, [initial]);
+
+  function handleYearWeight(year, value) {
+    const num = Number(value);
+    setYearWeights((prev) => ({
+      ...prev,
+      [year]: Number.isFinite(num) ? num : 0,
+    }));
+  }
+
+  function handleSubmit() {
+    const parsed = {
+      seasons: seasons.map((s) => Number(s)).filter((n) => Number.isFinite(n)),
+      replacement: {
+        mode: replacementMode,
+        buffer_pct: Number(bufferPct) || 0,
+      },
+      blend: { intrinsic: Number(blendIntrinsic) || 0 },
+      year_weights: yearWeights,
+      min_bucket_size: Number(minBucketSize) || 3,
+      min_games: Number(minGames) || 0,
+      top_n: topN ? Number(topN) : null,
+      bucket_edges: bucketEdges,
+    };
+    onSave?.(parsed);
+    onClose?.();
+  }
+
+  function addBucket() {
+    const last = bucketEdges[bucketEdges.length - 1] || [0, 0];
+    setBucketEdges([...bucketEdges, [last[1] + 1, last[1] + 10]]);
+  }
+
+  function updateBucket(idx, which, value) {
+    const copy = bucketEdges.map((edge) => [...edge]);
+    copy[idx][which] = Number(value) || 0;
+    setBucketEdges(copy);
+  }
+
+  function removeBucket(idx) {
+    setBucketEdges(bucketEdges.filter((_, i) => i !== idx));
+  }
+
+  return (
+    <MobileSheet isOpen={isOpen} onClose={onClose} title="Advanced settings">
+      <div className="idp-lab-settings">
+        <fieldset className="idp-lab-fieldset">
+          <legend>Seasons</legend>
+          <input
+            className="input"
+            value={seasons.join(", ")}
+            onChange={(e) =>
+              setSeasons(
+                e.target.value
+                  .split(/[,\s]+/)
+                  .filter(Boolean)
+                  .map((v) => Number(v))
+                  .filter((n) => Number.isFinite(n)),
+              )
+            }
+          />
+          <p className="muted text-sm">
+            Comma-separated list. Default is 2022, 2023, 2024, 2025.
+          </p>
+        </fieldset>
+
+        <fieldset className="idp-lab-fieldset">
+          <legend>Replacement mode</legend>
+          <select
+            className="input"
+            value={replacementMode}
+            onChange={(e) => setReplacementMode(e.target.value)}
+          >
+            <option value="strict_starter">Strict starter cutoff</option>
+            <option value="starter_plus_buffer">Starter plus buffer (default)</option>
+            <option value="manual">Manual per-position rank</option>
+          </select>
+          {replacementMode === "starter_plus_buffer" && (
+            <label className="idp-lab-field">
+              <span className="idp-lab-label">Buffer % of team count</span>
+              <input
+                className="input"
+                type="number"
+                step="0.05"
+                min="0"
+                max="1"
+                value={bufferPct}
+                onChange={(e) => setBufferPct(e.target.value)}
+              />
+            </label>
+          )}
+        </fieldset>
+
+        <fieldset className="idp-lab-fieldset">
+          <legend>Blend weights</legend>
+          <label className="idp-lab-field">
+            <span className="idp-lab-label">
+              Intrinsic weight ({blendIntrinsic}). Market = {(1 - blendIntrinsic).toFixed(2)}
+            </span>
+            <input
+              className="input"
+              type="range"
+              step="0.05"
+              min="0"
+              max="1"
+              value={blendIntrinsic}
+              onChange={(e) => setBlendIntrinsic(Number(e.target.value))}
+            />
+          </label>
+        </fieldset>
+
+        <fieldset className="idp-lab-fieldset">
+          <legend>Recency year weights</legend>
+          {Object.keys(yearWeights)
+            .sort()
+            .map((year) => (
+              <label className="idp-lab-field" key={year}>
+                <span className="idp-lab-label">{year}</span>
+                <input
+                  className="input"
+                  type="number"
+                  step="0.05"
+                  min="0"
+                  max="1"
+                  value={yearWeights[year]}
+                  onChange={(e) => handleYearWeight(year, e.target.value)}
+                />
+              </label>
+            ))}
+          <p className="muted text-sm">
+            Weights are renormalised across resolved seasons before aggregation.
+          </p>
+        </fieldset>
+
+        <fieldset className="idp-lab-fieldset">
+          <legend>Rank buckets</legend>
+          {bucketEdges.map((edge, idx) => (
+            <div className="idp-lab-bucket-row" key={idx}>
+              <input
+                className="input"
+                type="number"
+                value={edge[0]}
+                onChange={(e) => updateBucket(idx, 0, e.target.value)}
+              />
+              <span>to</span>
+              <input
+                className="input"
+                type="number"
+                value={edge[1]}
+                onChange={(e) => updateBucket(idx, 1, e.target.value)}
+              />
+              <button
+                type="button"
+                className="button"
+                onClick={() => removeBucket(idx)}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          <button type="button" className="button" onClick={addBucket}>
+            Add bucket
+          </button>
+        </fieldset>
+
+        <fieldset className="idp-lab-fieldset">
+          <legend>Universe filters</legend>
+          <label className="idp-lab-field">
+            <span className="idp-lab-label">Minimum games</span>
+            <input
+              className="input"
+              type="number"
+              min="0"
+              value={minGames}
+              onChange={(e) => setMinGames(e.target.value)}
+            />
+          </label>
+          <label className="idp-lab-field">
+            <span className="idp-lab-label">Top-N per position (blank = all)</span>
+            <input
+              className="input"
+              type="number"
+              min="0"
+              value={topN}
+              onChange={(e) => setTopN(e.target.value)}
+            />
+          </label>
+          <label className="idp-lab-field">
+            <span className="idp-lab-label">Min bucket size (merges below this)</span>
+            <input
+              className="input"
+              type="number"
+              min="1"
+              value={minBucketSize}
+              onChange={(e) => setMinBucketSize(e.target.value)}
+            />
+          </label>
+        </fieldset>
+
+        <div className="idp-lab-actions">
+          <button type="button" className="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="button button-primary"
+            onClick={handleSubmit}
+          >
+            Apply settings
+          </button>
+        </div>
+      </div>
+    </MobileSheet>
+  );
+}

--- a/frontend/app/tools/idp-calibration/AnchorChart.jsx
+++ b/frontend/app/tools/idp-calibration/AnchorChart.jsx
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * AnchorChart — minimal SVG line chart for a single position.
+ *
+ * Draws three monotone curves (intrinsic / market / final) over the
+ * anchor ranks. Pure SVG — no external chart library so we stay
+ * aligned with the repo's vanilla-React / vanilla-CSS convention.
+ */
+export default function AnchorChart({ position, anchors }) {
+  if (!anchors) return null;
+  const intrinsic = anchors?.intrinsic?.[position] || [];
+  const market = anchors?.market?.[position] || [];
+  const final = anchors?.final?.[position] || [];
+  const allPoints = [...intrinsic, ...market, ...final];
+  if (!allPoints.length) {
+    return (
+      <div className="card idp-lab-chart-empty muted">
+        No anchor data for {position}.
+      </div>
+    );
+  }
+  const maxRank = Math.max(1, ...allPoints.map((p) => p.rank));
+  const maxValue = Math.max(
+    1.0,
+    ...allPoints.map((p) => Number(p.value) || 0),
+  );
+  const width = 320;
+  const height = 140;
+  const padX = 32;
+  const padY = 14;
+
+  function projectX(rank) {
+    return padX + ((rank - 1) / Math.max(1, maxRank - 1)) * (width - 2 * padX);
+  }
+  function projectY(value) {
+    const v = Math.max(0, Math.min(maxValue, Number(value) || 0));
+    return height - padY - (v / maxValue) * (height - 2 * padY);
+  }
+  function toPath(points) {
+    if (!points.length) return "";
+    return points
+      .map(
+        (p, i) =>
+          `${i === 0 ? "M" : "L"} ${projectX(p.rank).toFixed(2)} ${projectY(p.value).toFixed(2)}`,
+      )
+      .join(" ");
+  }
+
+  const series = [
+    { name: "intrinsic", points: intrinsic, color: "var(--cyan, #4ec9ff)" },
+    { name: "market", points: market, color: "var(--amber, #e4a12e)" },
+    { name: "final", points: final, color: "var(--green, #7bd389)" },
+  ];
+
+  return (
+    <div className="card idp-lab-chart">
+      <div className="idp-lab-chart-header">
+        <span className="idp-lab-chart-title">{position} anchors</span>
+        <div className="idp-lab-chart-legend">
+          {series.map((s) => (
+            <span key={s.name} className="idp-lab-chart-legend-item">
+              <span
+                className="idp-lab-chart-legend-swatch"
+                style={{ background: s.color }}
+              />
+              {s.name}
+            </span>
+          ))}
+        </div>
+      </div>
+      <svg
+        role="img"
+        aria-label={`${position} anchor curves`}
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+      >
+        <line
+          x1={padX}
+          x2={width - padX}
+          y1={projectY(1)}
+          y2={projectY(1)}
+          stroke="var(--border, #333)"
+          strokeDasharray="4 4"
+        />
+        {series.map((s) => (
+          <path
+            key={s.name}
+            d={toPath(s.points)}
+            fill="none"
+            stroke={s.color}
+            strokeWidth="2"
+          />
+        ))}
+        {series.map((s) =>
+          s.points.map((p, i) => (
+            <circle
+              key={`${s.name}-${i}`}
+              cx={projectX(p.rank)}
+              cy={projectY(p.value)}
+              r="2.5"
+              fill={s.color}
+            />
+          )),
+        )}
+      </svg>
+      <div className="idp-lab-chart-axis">
+        <span>rank 1</span>
+        <span>rank {maxRank}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/tools/idp-calibration/LeagueInputForm.jsx
+++ b/frontend/app/tools/idp-calibration/LeagueInputForm.jsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+
+export default function LeagueInputForm({
+  initialTestLeagueId = "",
+  initialMyLeagueId = "",
+  onAnalyze,
+  onOpenSettings,
+  loading,
+}) {
+  const [testId, setTestId] = useState(initialTestLeagueId);
+  const [myId, setMyId] = useState(initialMyLeagueId);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (!testId.trim() || !myId.trim()) return;
+    onAnalyze?.({ testLeagueId: testId.trim(), myLeagueId: myId.trim() });
+  }
+
+  const disabled = Boolean(loading) || !testId.trim() || !myId.trim();
+
+  return (
+    <form className="card idp-lab-input" onSubmit={handleSubmit}>
+      <div className="idp-lab-input-grid">
+        <label className="idp-lab-field">
+          <span className="idp-lab-label">Test (market) league ID</span>
+          <input
+            className="input"
+            value={testId}
+            onChange={(e) => setTestId(e.target.value)}
+            placeholder="e.g. 984651234567890123"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </label>
+        <label className="idp-lab-field">
+          <span className="idp-lab-label">My league ID</span>
+          <input
+            className="input"
+            value={myId}
+            onChange={(e) => setMyId(e.target.value)}
+            placeholder="e.g. 984659876543210987"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </label>
+      </div>
+      <div className="idp-lab-actions">
+        <button
+          type="submit"
+          className="button button-primary"
+          disabled={disabled}
+        >
+          {loading ? "Analyzing…" : "Analyze"}
+        </button>
+        <button
+          type="button"
+          className="button"
+          onClick={onOpenSettings}
+          disabled={Boolean(loading)}
+        >
+          Advanced settings
+        </button>
+      </div>
+      <p className="muted text-sm idp-lab-hint">
+        Both league IDs stay private to this session. Analysis will walk
+        <code> previous_league_id </code> back through 2022–2025 and rescore
+        the same IDP universe under each scoring system.
+      </p>
+    </form>
+  );
+}

--- a/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
+++ b/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+
+const VALID_MODES = ["blended", "intrinsic_only", "market_only"];
+
+export default function ProductionConfigPanel({
+  production,
+  currentRun,
+  onPromote,
+  loading,
+  error,
+}) {
+  const [mode, setMode] = useState("blended");
+  const [confirming, setConfirming] = useState(false);
+  const promoted = production?.present ? production.config : null;
+
+  const canPromote = Boolean(currentRun?.run_id) && !loading;
+
+  function handlePromoteClick() {
+    if (!canPromote) return;
+    if (!confirming) {
+      setConfirming(true);
+      return;
+    }
+    onPromote?.({ runId: currentRun.run_id, activeMode: mode });
+    setConfirming(false);
+  }
+
+  return (
+    <div className="card idp-lab-section">
+      <h2>Production config</h2>
+      {promoted ? (
+        <div>
+          <p className="muted text-sm">
+            Promoted at <strong>{promoted.promoted_at}</strong> by{" "}
+            <strong>{promoted.promoted_by}</strong> from run{" "}
+            <code>{promoted.source_run_id}</code>. Active mode:{" "}
+            <strong>{promoted.active_mode}</strong>.
+          </p>
+          <p className="muted text-sm">
+            Year coverage: {(promoted.year_coverage || []).join(", ") || "—"} |{" "}
+            League IDs: test <code>{promoted.league_ids?.test}</code>, mine{" "}
+            <code>{promoted.league_ids?.mine}</code>.
+          </p>
+        </div>
+      ) : (
+        <p className="muted text-sm">
+          No production config promoted yet. The live trade calculator is
+          operating in identity mode (all IDP multipliers = 1.0).
+        </p>
+      )}
+
+      <div className="idp-lab-promote-block">
+        <label className="idp-lab-field">
+          <span className="idp-lab-label">Promotion mode</span>
+          <select
+            className="input"
+            value={mode}
+            onChange={(e) => setMode(e.target.value)}
+          >
+            {VALID_MODES.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          className={`button ${confirming ? "button-danger" : "button-primary"}`}
+          onClick={handlePromoteClick}
+          disabled={!canPromote}
+          title={!canPromote ? "Analyze a run first" : "Promote this run"}
+        >
+          {loading
+            ? "Promoting…"
+            : confirming
+            ? "Click again to confirm"
+            : "Promote to production"}
+        </button>
+        {confirming && (
+          <button
+            type="button"
+            className="button"
+            onClick={() => setConfirming(false)}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+      {error && (
+        <p className="idp-lab-error-text">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
+++ b/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import PromotionDiffPanel from "./PromotionDiffPanel";
 
 const VALID_MODES = ["blended", "intrinsic_only", "market_only"];
 
@@ -49,6 +50,14 @@ export default function ProductionConfigPanel({
           No production config promoted yet. The live trade calculator is
           operating in identity mode (all IDP multipliers = 1.0).
         </p>
+      )}
+
+      {currentRun && (
+        <PromotionDiffPanel
+          candidateRun={currentRun}
+          production={production}
+          activeMode={mode}
+        />
       )}
 
       <div className="idp-lab-promote-block">

--- a/frontend/app/tools/idp-calibration/PromotionDiffPanel.jsx
+++ b/frontend/app/tools/idp-calibration/PromotionDiffPanel.jsx
@@ -1,0 +1,185 @@
+"use client";
+
+/**
+ * PromotionDiffPanel — per-bucket diff between the currently loaded
+ * run and the promoted production config.
+ *
+ * Mounts inside ProductionConfigPanel just above the Promote button so
+ * the reviewer cannot promote without seeing which multipliers will
+ * move. If no production is promoted yet, shows the candidate values
+ * alone (with "—" in the production column).
+ */
+
+const POSITIONS = ["DL", "LB", "DB"];
+const KINDS = ["intrinsic", "market", "final"];
+const KIND_BY_MODE = {
+  blended: "final",
+  intrinsic_only: "intrinsic",
+  market_only: "market",
+};
+
+function fmt(value) {
+  if (value == null || !Number.isFinite(Number(value))) return "—";
+  return Number(value).toFixed(4);
+}
+
+function deltaCell(candidate, current) {
+  if (candidate == null) return { text: "—", cls: "" };
+  if (current == null) return { text: `+${fmt(candidate)}`, cls: "idp-lab-diff-new" };
+  const d = Number(candidate) - Number(current);
+  if (Math.abs(d) < 1e-4) return { text: "—", cls: "idp-lab-diff-flat" };
+  const sign = d > 0 ? "+" : "";
+  return {
+    text: `${sign}${d.toFixed(4)}`,
+    cls: d > 0 ? "idp-lab-diff-up" : "idp-lab-diff-down",
+  };
+}
+
+function bucketByLabel(positionBlock) {
+  if (!positionBlock?.buckets) return {};
+  const out = {};
+  for (const b of positionBlock.buckets) out[b.label] = b;
+  return out;
+}
+
+export default function PromotionDiffPanel({
+  candidateRun,
+  production,
+  activeMode,
+}) {
+  if (!candidateRun?.multipliers) return null;
+
+  const kind = KIND_BY_MODE[activeMode] || "final";
+  const promoted = production?.present ? production.config : null;
+  const promotedAt = promoted?.promoted_at;
+
+  return (
+    <div className="idp-lab-diff">
+      <div className="idp-lab-diff-header">
+        <strong>What would change?</strong>
+        <span className="muted text-sm">
+          candidate run <code>{candidateRun.run_id}</code>{" "}
+          {promoted ? (
+            <>vs promoted <code>{promoted.source_run_id}</code> ({promotedAt})</>
+          ) : (
+            <>vs <em>(no production config yet)</em></>
+          )}
+          {" "}· kind: <strong>{kind}</strong>
+        </span>
+      </div>
+      {POSITIONS.map((pos) => {
+        const candidateBuckets = bucketByLabel(candidateRun.multipliers[pos]);
+        const promotedBuckets = bucketByLabel(promoted?.multipliers?.[pos]);
+        const labels = Array.from(
+          new Set([
+            ...Object.keys(candidateBuckets),
+            ...Object.keys(promotedBuckets),
+          ]),
+        ).sort((a, b) => {
+          const ax = Number(a.split("-")[0]) || 0;
+          const bx = Number(b.split("-")[0]) || 0;
+          return ax - bx;
+        });
+        if (!labels.length) return null;
+        return (
+          <div key={pos} className="idp-lab-diff-block">
+            <div className="idp-lab-subheading">
+              <strong>{pos}</strong>
+              <span className="muted text-sm">per-bucket {kind}</span>
+            </div>
+            <div className="table-wrap">
+              <table className="table idp-lab-diff-table">
+                <thead>
+                  <tr>
+                    <th>Bucket</th>
+                    <th>Current production</th>
+                    <th>Candidate run</th>
+                    <th>Δ</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {labels.map((label) => {
+                    const cand = candidateBuckets[label]?.[kind];
+                    const cur = promotedBuckets[label]?.[kind];
+                    const cell = deltaCell(cand, cur);
+                    return (
+                      <tr key={label}>
+                        <td>{label}</td>
+                        <td>{fmt(cur)}</td>
+                        <td>{fmt(cand)}</td>
+                        <td className={cell.cls}>{cell.text}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })}
+      <details className="idp-lab-diff-details">
+        <summary className="muted text-sm">
+          Show all three kinds (intrinsic / market / final)
+        </summary>
+        {POSITIONS.map((pos) => {
+          const cand = bucketByLabel(candidateRun.multipliers[pos]);
+          const prom = bucketByLabel(promoted?.multipliers?.[pos]);
+          const labels = Object.keys(cand).sort((a, b) => {
+            const ax = Number(a.split("-")[0]) || 0;
+            const bx = Number(b.split("-")[0]) || 0;
+            return ax - bx;
+          });
+          if (!labels.length) return null;
+          return (
+            <div key={pos} className="idp-lab-diff-block">
+              <strong>{pos}</strong>
+              <div className="table-wrap">
+                <table className="table idp-lab-diff-all-table">
+                  <thead>
+                    <tr>
+                      <th>Bucket</th>
+                      {KINDS.map((k) => (
+                        <th key={k} colSpan={3}>{k}</th>
+                      ))}
+                    </tr>
+                    <tr>
+                      <th></th>
+                      {KINDS.map((k) => (
+                        <>
+                          <th key={`${k}-cur`}>prod</th>
+                          <th key={`${k}-cand`}>cand</th>
+                          <th key={`${k}-d`}>Δ</th>
+                        </>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {labels.map((label) => (
+                      <tr key={label}>
+                        <td>{label}</td>
+                        {KINDS.map((k) => {
+                          const c = cand[label]?.[k];
+                          const p = prom[label]?.[k];
+                          const cell = deltaCell(c, p);
+                          return (
+                            <>
+                              <td key={`${k}-p`}>{fmt(p)}</td>
+                              <td key={`${k}-c`}>{fmt(c)}</td>
+                              <td key={`${k}-d`} className={cell.cls}>
+                                {cell.text}
+                              </td>
+                            </>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          );
+        })}
+      </details>
+    </div>
+  );
+}

--- a/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
+++ b/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
@@ -272,8 +272,18 @@ function SectionRecommendation({ run }) {
 export default function ResultsDashboard({ run }) {
   if (!run) return null;
 
-  const firstSeason = Object.keys(run.per_season || {}).sort()[0];
-  const scoringEntry = run.per_season?.[firstSeason] || {};
+  // Pick the most recent *resolved* season for the scoring and lineup
+  // verification panels. Falling back to the raw-first season would
+  // hide both panels whenever the earliest season in the chain is
+  // missing (a common case when one league's chain doesn't reach the
+  // default 2022 back-stop).
+  const seasonKeysDesc = Object.keys(run.per_season || {}).sort(
+    (a, b) => Number(b) - Number(a),
+  );
+  const verificationSeason =
+    seasonKeysDesc.find((k) => run.per_season?.[k]?.resolved) ||
+    seasonKeysDesc[0];
+  const scoringEntry = run.per_season?.[verificationSeason] || {};
 
   return (
     <div className="idp-lab-dashboard">
@@ -284,10 +294,18 @@ export default function ResultsDashboard({ run }) {
           <ChainBlock label="My league" chain={run.chains?.mine} />
         </div>
         {scoringEntry?.test_scoring && (
-          <div className="idp-lab-scoring-grid">
-            <ScoringSummary label="Test scoring" summary={scoringEntry.test_scoring} />
-            <ScoringSummary label="My scoring" summary={scoringEntry.my_scoring} />
-          </div>
+          <>
+            <p className="muted text-sm">
+              Scoring and lineup summaries shown for season{" "}
+              <strong>{verificationSeason}</strong>
+              {scoringEntry.resolved === false && " (unresolved)"}
+              .
+            </p>
+            <div className="idp-lab-scoring-grid">
+              <ScoringSummary label="Test scoring" summary={scoringEntry.test_scoring} />
+              <ScoringSummary label="My scoring" summary={scoringEntry.my_scoring} />
+            </div>
+          </>
         )}
         {scoringEntry?.test_lineup && (
           <div className="idp-lab-lineup-grid">

--- a/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
+++ b/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
@@ -1,0 +1,306 @@
+"use client";
+
+import AnchorChart from "./AnchorChart";
+
+const POSITIONS = ["DL", "LB", "DB"];
+
+function n(value, digits = 3) {
+  if (value == null || !Number.isFinite(Number(value))) return "—";
+  return Number(value).toFixed(digits);
+}
+
+function ScoringSummary({ label, summary }) {
+  if (!summary) return null;
+  const active = summary.active_idp_stats || {};
+  return (
+    <div className="idp-lab-scoring">
+      <span className="badge">{label}</span>
+      <span className="muted text-sm">league {summary.league_id}</span>
+      <ul className="idp-lab-scoring-list">
+        {Object.entries(active).map(([k, v]) => (
+          <li key={k}>
+            <code>{k}</code> × {n(v, 2)}
+          </li>
+        ))}
+        {!Object.keys(active).length && <li className="muted">No IDP stats scored.</li>}
+      </ul>
+    </div>
+  );
+}
+
+function LineupSummary({ lineup, label }) {
+  if (!lineup) return null;
+  return (
+    <div className="idp-lab-lineup">
+      <span className="badge">{label}</span>
+      <span className="muted text-sm">{lineup.team_count} teams</span>
+      <dl className="idp-lab-lineup-list">
+        <div>
+          <dt>DL starters</dt>
+          <dd>{lineup.dl_starters}</dd>
+        </div>
+        <div>
+          <dt>LB starters</dt>
+          <dd>{lineup.lb_starters}</dd>
+        </div>
+        <div>
+          <dt>DB starters</dt>
+          <dd>{lineup.db_starters}</dd>
+        </div>
+        <div>
+          <dt>IDP flex</dt>
+          <dd>{lineup.idp_flex_starters}</dd>
+        </div>
+        <div>
+          <dt>Offense starters</dt>
+          <dd>{lineup.offense_starters}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function ChainBlock({ label, chain }) {
+  if (!chain) return null;
+  const seasonMap = chain.seasons || {};
+  return (
+    <div className="idp-lab-chain">
+      <div className="idp-lab-chain-header">
+        <span className="badge">{label}</span>
+        <code className="idp-lab-chain-id">{chain.input_league_id || "—"}</code>
+      </div>
+      <ul className="idp-lab-chain-list">
+        {Object.keys(seasonMap)
+          .sort((a, b) => Number(b) - Number(a))
+          .map((season) => {
+            const entry = seasonMap[season];
+            return (
+              <li
+                key={season}
+                className={entry.resolved ? "idp-lab-chain-ok" : "idp-lab-chain-miss"}
+              >
+                <span>{season}</span>
+                <span className="muted">
+                  {entry.resolved ? entry.league_name || entry.league_id : entry.reason}
+                </span>
+              </li>
+            );
+          })}
+      </ul>
+      {chain.warnings?.length ? (
+        <ul className="idp-lab-warning-list">
+          {chain.warnings.map((w, i) => (
+            <li key={i}>{w}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function SectionBuckets({ run }) {
+  const perSeason = run.per_season || {};
+  const keys = Object.keys(perSeason).sort();
+  return (
+    <section className="card idp-lab-section">
+      <h2>Season-by-season VOR</h2>
+      {keys.map((season) => {
+        const entry = perSeason[season];
+        if (!entry?.resolved) {
+          return (
+            <div key={season} className="idp-lab-season idp-lab-season-missing">
+              <h3>{season}</h3>
+              <p className="muted">{entry?.reason || "Not resolved."}</p>
+            </div>
+          );
+        }
+        return (
+          <div key={season} className="idp-lab-season">
+            <h3>
+              {season}{" "}
+              <span className="muted text-sm">
+                universe={entry.universe_size} | adapter={entry.adapter}
+              </span>
+            </h3>
+            {POSITIONS.map((pos) => {
+              const buckets = entry.buckets?.[pos] || [];
+              if (!buckets.length) return null;
+              return (
+                <div key={pos} className="idp-lab-bucket-block">
+                  <div className="idp-lab-subheading">
+                    <strong>{pos}</strong>
+                    <span className="muted">
+                      replacement test={n(entry.replacement_test?.[pos]?.replacement_points)}{" "}
+                      / mine={n(entry.replacement_mine?.[pos]?.replacement_points)}
+                    </span>
+                  </div>
+                  <div className="table-wrap">
+                    <table className="table idp-lab-bucket-table">
+                      <thead>
+                        <tr>
+                          <th>Bucket</th>
+                          <th>#</th>
+                          <th>Center (test)</th>
+                          <th>Center (mine)</th>
+                          <th>Ratio</th>
+                          <th>Merged from</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {buckets.map((b, i) => (
+                          <tr key={i}>
+                            <td>{b.label}</td>
+                            <td>{b.count}</td>
+                            <td>{n(b.center_vor_test)}</td>
+                            <td>{n(b.center_vor_mine)}</td>
+                            <td>{b.ratio_mine_over_test == null ? "—" : n(b.ratio_mine_over_test, 3)}</td>
+                            <td className="muted">{(b.merged_from || []).join(", ") || "—"}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+function SectionMultipliers({ run }) {
+  const multipliers = run.multipliers || {};
+  return (
+    <section className="card idp-lab-section">
+      <h2>Multi-year calibration summary</h2>
+      {POSITIONS.map((pos) => {
+        const posBlock = multipliers[pos];
+        if (!posBlock?.buckets?.length) {
+          return (
+            <div key={pos} className="muted">
+              No multipliers generated for {pos}.
+            </div>
+          );
+        }
+        return (
+          <div key={pos} className="idp-lab-mult-block">
+            <div className="idp-lab-subheading">
+              <strong>{pos}</strong>
+              <span className="muted">per-bucket multipliers</span>
+            </div>
+            <div className="table-wrap">
+              <table className="table idp-lab-mult-table">
+                <thead>
+                  <tr>
+                    <th>Bucket</th>
+                    <th>#</th>
+                    <th>Intrinsic</th>
+                    <th>Market</th>
+                    <th>Final</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {posBlock.buckets.map((b, i) => (
+                    <tr key={i}>
+                      <td>{b.label}</td>
+                      <td>{b.count}</td>
+                      <td>{n(b.intrinsic, 4)}</td>
+                      <td>{n(b.market, 4)}</td>
+                      <td>
+                        <strong>{n(b.final, 4)}</strong>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+function SectionAnchors({ run }) {
+  return (
+    <section className="card idp-lab-section">
+      <h2>Anchor curves</h2>
+      <div className="idp-lab-anchor-grid">
+        {POSITIONS.map((pos) => (
+          <AnchorChart key={pos} position={pos} anchors={run.anchors} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SectionRecommendation({ run }) {
+  const rec = run.recommendation || {};
+  const lines = rec.summary_lines || [];
+  const notes = rec.notes || [];
+  return (
+    <section className="card idp-lab-section">
+      <h2>Recommendation</h2>
+      {lines.length ? (
+        <ul className="idp-lab-rec-list">
+          {lines.map((line, i) => (
+            <li key={i}>{line}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="muted">No recommendation available.</p>
+      )}
+      {notes.length ? (
+        <ul className="idp-lab-warning-list">
+          {notes.map((note, i) => (
+            <li key={i}>{note}</li>
+          ))}
+        </ul>
+      ) : null}
+      {rec.recommended_mode && (
+        <p className="muted text-sm">
+          Recommended production mode:{" "}
+          <strong>{rec.recommended_mode}</strong>
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default function ResultsDashboard({ run }) {
+  if (!run) return null;
+
+  const firstSeason = Object.keys(run.per_season || {}).sort()[0];
+  const scoringEntry = run.per_season?.[firstSeason] || {};
+
+  return (
+    <div className="idp-lab-dashboard">
+      <section className="card idp-lab-section">
+        <h2>League verification</h2>
+        <div className="idp-lab-chain-grid">
+          <ChainBlock label="Test league" chain={run.chains?.test} />
+          <ChainBlock label="My league" chain={run.chains?.mine} />
+        </div>
+        {scoringEntry?.test_scoring && (
+          <div className="idp-lab-scoring-grid">
+            <ScoringSummary label="Test scoring" summary={scoringEntry.test_scoring} />
+            <ScoringSummary label="My scoring" summary={scoringEntry.my_scoring} />
+          </div>
+        )}
+        {scoringEntry?.test_lineup && (
+          <div className="idp-lab-lineup-grid">
+            <LineupSummary label="Test lineup" lineup={scoringEntry.test_lineup} />
+            <LineupSummary label="My lineup" lineup={scoringEntry.my_lineup} />
+          </div>
+        )}
+      </section>
+
+      <SectionBuckets run={run} />
+      <SectionMultipliers run={run} />
+      <SectionAnchors run={run} />
+      <SectionRecommendation run={run} />
+    </div>
+  );
+}

--- a/frontend/app/tools/idp-calibration/SavedRunsList.jsx
+++ b/frontend/app/tools/idp-calibration/SavedRunsList.jsx
@@ -1,6 +1,26 @@
 "use client";
 
-export default function SavedRunsList({ runs, currentRunId, onOpen }) {
+import { useState } from "react";
+
+export default function SavedRunsList({
+  runs,
+  currentRunId,
+  promotedRunId,
+  onOpen,
+  onDelete,
+  deleting,
+}) {
+  const [confirmRunId, setConfirmRunId] = useState(null);
+
+  function handleDeleteClick(runId) {
+    if (confirmRunId !== runId) {
+      setConfirmRunId(runId);
+      return;
+    }
+    setConfirmRunId(null);
+    onDelete?.(runId);
+  }
+
   if (!runs?.length) {
     return (
       <div className="card idp-lab-section">
@@ -26,30 +46,63 @@ export default function SavedRunsList({ runs, currentRunId, onOpen }) {
             </tr>
           </thead>
           <tbody>
-            {runs.map((run) => (
-              <tr
-                key={run.run_id}
-                className={run.run_id === currentRunId ? "idp-lab-row-active" : ""}
-              >
-                <td>
-                  <code className="text-sm">{run.run_id}</code>
-                </td>
-                <td className="muted">{run.generated_at}</td>
-                <td>
-                  <code className="text-sm">{run.test_league_id}</code>
-                </td>
-                <td>
-                  <code className="text-sm">{run.my_league_id}</code>
-                </td>
-                <td>{(run.resolved_seasons || []).join(", ") || "—"}</td>
-                <td>{run.warning_count}</td>
-                <td>
-                  <button className="button" onClick={() => onOpen?.(run.run_id)}>
-                    Open
-                  </button>
-                </td>
-              </tr>
-            ))}
+            {runs.map((run) => {
+              const isActive = run.run_id === currentRunId;
+              const isPromoted = promotedRunId && run.run_id === promotedRunId;
+              const isConfirming = confirmRunId === run.run_id;
+              return (
+                <tr
+                  key={run.run_id}
+                  className={isActive ? "idp-lab-row-active" : ""}
+                >
+                  <td>
+                    <code className="text-sm">{run.run_id}</code>
+                    {isPromoted && (
+                      <span className="badge idp-lab-badge-promoted"> promoted</span>
+                    )}
+                  </td>
+                  <td className="muted">{run.generated_at}</td>
+                  <td>
+                    <code className="text-sm">{run.test_league_id}</code>
+                  </td>
+                  <td>
+                    <code className="text-sm">{run.my_league_id}</code>
+                  </td>
+                  <td>{(run.resolved_seasons || []).join(", ") || "—"}</td>
+                  <td>{run.warning_count}</td>
+                  <td className="idp-lab-runs-actions">
+                    <button
+                      className="button"
+                      onClick={() => onOpen?.(run.run_id)}
+                      disabled={Boolean(deleting)}
+                    >
+                      Open
+                    </button>
+                    <button
+                      className={`button ${isConfirming ? "button-danger" : ""}`}
+                      onClick={() => handleDeleteClick(run.run_id)}
+                      disabled={Boolean(deleting)}
+                      title={
+                        isPromoted
+                          ? "This run is the source of the current production config. Deleting it does NOT revert production."
+                          : "Delete run"
+                      }
+                    >
+                      {isConfirming ? "Confirm" : "Delete"}
+                    </button>
+                    {isConfirming && (
+                      <button
+                        className="button"
+                        onClick={() => setConfirmRunId(null)}
+                        disabled={Boolean(deleting)}
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/frontend/app/tools/idp-calibration/SavedRunsList.jsx
+++ b/frontend/app/tools/idp-calibration/SavedRunsList.jsx
@@ -1,0 +1,58 @@
+"use client";
+
+export default function SavedRunsList({ runs, currentRunId, onOpen }) {
+  if (!runs?.length) {
+    return (
+      <div className="card idp-lab-section">
+        <h2>Saved runs</h2>
+        <p className="muted">No runs saved yet. Analyze two leagues to save one.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="card idp-lab-section">
+      <h2>Saved runs</h2>
+      <div className="table-wrap">
+        <table className="table idp-lab-runs-table">
+          <thead>
+            <tr>
+              <th>Run</th>
+              <th>Generated</th>
+              <th>Test</th>
+              <th>Mine</th>
+              <th>Seasons</th>
+              <th>Warnings</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((run) => (
+              <tr
+                key={run.run_id}
+                className={run.run_id === currentRunId ? "idp-lab-row-active" : ""}
+              >
+                <td>
+                  <code className="text-sm">{run.run_id}</code>
+                </td>
+                <td className="muted">{run.generated_at}</td>
+                <td>
+                  <code className="text-sm">{run.test_league_id}</code>
+                </td>
+                <td>
+                  <code className="text-sm">{run.my_league_id}</code>
+                </td>
+                <td>{(run.resolved_seasons || []).join(", ") || "—"}</td>
+                <td>{run.warning_count}</td>
+                <td>
+                  <button className="button" onClick={() => onOpen?.(run.run_id)}>
+                    Open
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/tools/idp-calibration/exports.js
+++ b/frontend/app/tools/idp-calibration/exports.js
@@ -1,0 +1,87 @@
+"use client";
+
+function triggerDownload(blob, filename) {
+  if (typeof window === "undefined") return;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function downloadRunJson(run) {
+  if (!run) return;
+  const blob = new Blob([JSON.stringify(run, null, 2)], {
+    type: "application/json",
+  });
+  triggerDownload(blob, `idp-calibration-${run.run_id || "run"}.json`);
+}
+
+function csvEscape(value) {
+  if (value == null) return "";
+  const s = String(value);
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export function downloadBucketCsv(run) {
+  if (!run) return;
+  const lines = [
+    [
+      "position",
+      "bucket",
+      "count",
+      "intrinsic",
+      "market",
+      "final",
+    ].join(","),
+  ];
+  const multipliers = run.multipliers || {};
+  for (const pos of ["DL", "LB", "DB"]) {
+    const posBlock = multipliers[pos];
+    if (!posBlock?.buckets) continue;
+    for (const b of posBlock.buckets) {
+      lines.push(
+        [
+          pos,
+          b.label,
+          b.count ?? 0,
+          b.intrinsic ?? 0,
+          b.market ?? 0,
+          b.final ?? 0,
+        ]
+          .map(csvEscape)
+          .join(","),
+      );
+    }
+  }
+  const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+  triggerDownload(blob, `idp-calibration-buckets-${run.run_id || "run"}.csv`);
+}
+
+export function downloadAnchorCsv(run) {
+  if (!run) return;
+  const lines = [
+    ["kind", "position", "rank", "value"].join(","),
+  ];
+  const anchors = run.anchors || {};
+  for (const kind of ["intrinsic", "market", "final"]) {
+    const kindBlock = anchors[kind] || {};
+    for (const pos of ["DL", "LB", "DB"]) {
+      const points = kindBlock[pos];
+      if (!Array.isArray(points)) continue;
+      for (const p of points) {
+        lines.push(
+          [kind, pos, p.rank, p.value].map(csvEscape).join(","),
+        );
+      }
+    }
+  }
+  const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+  triggerDownload(blob, `idp-calibration-anchors-${run.run_id || "run"}.csv`);
+}

--- a/frontend/app/tools/idp-calibration/page.jsx
+++ b/frontend/app/tools/idp-calibration/page.jsx
@@ -16,6 +16,11 @@ import {
   downloadRunJson,
 } from "./exports";
 
+// Hard-coded defaults so the two working league IDs pre-fill on load.
+// The inputs remain editable for one-off experiments.
+const DEFAULT_TEST_LEAGUE_ID = "1328545898812170240";
+const DEFAULT_MY_LEAGUE_ID = "1312006700437352448";
+
 export default function IdpCalibrationLabPage() {
   const router = useRouter();
   const { authenticated, checking } = useAuthContext();
@@ -86,6 +91,8 @@ export default function IdpCalibrationLabPage() {
       />
 
       <LeagueInputForm
+        initialTestLeagueId={DEFAULT_TEST_LEAGUE_ID}
+        initialMyLeagueId={DEFAULT_MY_LEAGUE_ID}
         onAnalyze={({ testLeagueId, myLeagueId }) =>
           analyze({ testLeagueId, myLeagueId, settings })
         }

--- a/frontend/app/tools/idp-calibration/page.jsx
+++ b/frontend/app/tools/idp-calibration/page.jsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { PageHeader } from "@/components/ui";
+import { useAuthContext } from "@/app/AppShellWrapper";
+import LeagueInputForm from "./LeagueInputForm";
+import AdvancedSettingsDrawer from "./AdvancedSettingsDrawer";
+import ResultsDashboard from "./ResultsDashboard";
+import SavedRunsList from "./SavedRunsList";
+import ProductionConfigPanel from "./ProductionConfigPanel";
+import { useCalibration } from "./useCalibration";
+import {
+  downloadAnchorCsv,
+  downloadBucketCsv,
+  downloadRunJson,
+} from "./exports";
+
+export default function IdpCalibrationLabPage() {
+  const router = useRouter();
+  const { authenticated, checking } = useAuthContext();
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settings, setSettings] = useState(null);
+
+  const {
+    status,
+    runs,
+    production,
+    currentRun,
+    loading,
+    error,
+    refreshStatus,
+    refreshRuns,
+    refreshProduction,
+    analyze,
+    loadRun,
+    promote,
+  } = useCalibration();
+
+  useEffect(() => {
+    if (checking) return;
+    if (authenticated === false) {
+      router.push("/login?next=/tools/idp-calibration");
+    }
+  }, [checking, authenticated, router]);
+
+  useEffect(() => {
+    if (authenticated) {
+      refreshStatus();
+      refreshRuns();
+      refreshProduction();
+    }
+  }, [authenticated, refreshStatus, refreshRuns, refreshProduction]);
+
+  const warnings = useMemo(() => currentRun?.warnings || [], [currentRun]);
+
+  if (checking || authenticated == null) {
+    return (
+      <div className="idp-lab-page">
+        <PageHeader title="IDP Calibration Lab" subtitle="Checking session…" />
+      </div>
+    );
+  }
+  if (authenticated === false) {
+    return null;
+  }
+
+  return (
+    <div className="idp-lab-page">
+      <PageHeader
+        title="IDP Calibration Lab"
+        subtitle="Internal tooling. Analyses are never promoted until you explicitly click Promote to production."
+        actions={
+          <div className="idp-lab-header-actions">
+            {status?.production_present && (
+              <span className="badge">production: active</span>
+            )}
+            {status?.latest_run_id && (
+              <span className="muted text-sm">
+                latest run{" "}
+                <code className="text-sm">{status.latest_run_id}</code>
+              </span>
+            )}
+          </div>
+        }
+      />
+
+      <LeagueInputForm
+        onAnalyze={({ testLeagueId, myLeagueId }) =>
+          analyze({ testLeagueId, myLeagueId, settings })
+        }
+        onOpenSettings={() => setSettingsOpen(true)}
+        loading={loading.analyze}
+      />
+
+      <AdvancedSettingsDrawer
+        isOpen={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        initial={settings || currentRun?.settings}
+        onSave={setSettings}
+      />
+
+      {(error.analyze || error.runs || error.production || error.promote) && (
+        <div className="card idp-lab-error">
+          {error.analyze && <p>Analyze: {error.analyze}</p>}
+          {error.runs && <p>Runs: {error.runs}</p>}
+          {error.production && <p>Production: {error.production}</p>}
+          {error.promote && <p>Promote: {error.promote}</p>}
+        </div>
+      )}
+
+      {warnings.length > 0 && (
+        <div className="card idp-lab-warning">
+          <strong>Warnings ({warnings.length})</strong>
+          <ul>
+            {warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {currentRun && (
+        <div className="idp-lab-toolbar">
+          <button
+            type="button"
+            className="button"
+            onClick={() => downloadRunJson(currentRun)}
+          >
+            Export run JSON
+          </button>
+          <button
+            type="button"
+            className="button"
+            onClick={() => downloadBucketCsv(currentRun)}
+          >
+            Export buckets CSV
+          </button>
+          <button
+            type="button"
+            className="button"
+            onClick={() => downloadAnchorCsv(currentRun)}
+          >
+            Export anchors CSV
+          </button>
+        </div>
+      )}
+
+      <ResultsDashboard run={currentRun} />
+
+      <ProductionConfigPanel
+        production={production}
+        currentRun={currentRun}
+        onPromote={promote}
+        loading={loading.promote}
+        error={error.promote}
+      />
+
+      <SavedRunsList
+        runs={runs}
+        currentRunId={currentRun?.run_id}
+        onOpen={(runId) => loadRun(runId)}
+      />
+    </div>
+  );
+}

--- a/frontend/app/tools/idp-calibration/page.jsx
+++ b/frontend/app/tools/idp-calibration/page.jsx
@@ -39,6 +39,7 @@ export default function IdpCalibrationLabPage() {
     refreshProduction,
     analyze,
     loadRun,
+    deleteRun,
     promote,
   } = useCalibration();
 
@@ -166,7 +167,10 @@ export default function IdpCalibrationLabPage() {
       <SavedRunsList
         runs={runs}
         currentRunId={currentRun?.run_id}
+        promotedRunId={production?.config?.source_run_id}
         onOpen={(runId) => loadRun(runId)}
+        onDelete={(runId) => deleteRun(runId)}
+        deleting={loading.deleteRun}
       />
     </div>
   );

--- a/frontend/app/tools/idp-calibration/useCalibration.js
+++ b/frontend/app/tools/idp-calibration/useCalibration.js
@@ -33,6 +33,7 @@ export function useCalibration() {
     analyze: false,
     promote: false,
     runDetail: false,
+    deleteRun: false,
   });
   const [error, setError] = useState({});
   const mountedRef = useRef(true);
@@ -131,6 +132,25 @@ export function useCalibration() {
     return data;
   }, []);
 
+  const deleteRun = useCallback(async (runId) => {
+    if (!runId) return null;
+    setFlag("deleteRun", true);
+    setErr("deleteRun", null);
+    const { status: http, data } = await jfetch(
+      `/api/idp-calibration/runs/${encodeURIComponent(runId)}`,
+      { method: "DELETE" },
+    );
+    if (!mountedRef.current) return data;
+    if (http >= 400 || data?.ok === false) {
+      setErr("deleteRun", data?.error || `HTTP ${http}`);
+    } else {
+      await refreshRuns();
+      setCurrentRun((prev) => (prev && prev.run_id === runId ? null : prev));
+    }
+    setFlag("deleteRun", false);
+    return data;
+  }, [refreshRuns]);
+
   const promote = useCallback(async ({ runId, activeMode }) => {
     setFlag("promote", true);
     setErr("promote", null);
@@ -162,6 +182,7 @@ export function useCalibration() {
     refreshProduction,
     analyze,
     loadRun,
+    deleteRun,
     promote,
   };
 }

--- a/frontend/app/tools/idp-calibration/useCalibration.js
+++ b/frontend/app/tools/idp-calibration/useCalibration.js
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+async function jfetch(url, opts = {}) {
+  const res = await fetch(url, { cache: "no-store", ...opts });
+  const text = await res.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    data = { ok: false, error: text || "Invalid response" };
+  }
+  return { status: res.status, data };
+}
+
+/**
+ * useCalibration — thin wrapper around the /api/idp-calibration proxy routes.
+ *
+ * Exposes imperative actions plus the standard { loading, error, data }
+ * state for each operation. No external data-fetching library; matches
+ * the repo convention of plain fetch + useState.
+ */
+export function useCalibration() {
+  const [status, setStatus] = useState(null);
+  const [runs, setRuns] = useState([]);
+  const [production, setProduction] = useState(null);
+  const [currentRun, setCurrentRun] = useState(null);
+  const [loading, setLoading] = useState({
+    status: false,
+    runs: false,
+    production: false,
+    analyze: false,
+    promote: false,
+    runDetail: false,
+  });
+  const [error, setError] = useState({});
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const setFlag = (key, value) =>
+    setLoading((prev) => ({ ...prev, [key]: value }));
+  const setErr = (key, value) =>
+    setError((prev) => ({ ...prev, [key]: value || null }));
+
+  const refreshStatus = useCallback(async () => {
+    setFlag("status", true);
+    setErr("status", null);
+    const { status: http, data } = await jfetch("/api/idp-calibration/status");
+    if (!mountedRef.current) return data;
+    if (http >= 400) {
+      setErr("status", data?.error || `HTTP ${http}`);
+    } else {
+      setStatus(data);
+    }
+    setFlag("status", false);
+    return data;
+  }, []);
+
+  const refreshRuns = useCallback(async () => {
+    setFlag("runs", true);
+    setErr("runs", null);
+    const { status: http, data } = await jfetch("/api/idp-calibration/runs");
+    if (!mountedRef.current) return data;
+    if (http >= 400) {
+      setErr("runs", data?.error || `HTTP ${http}`);
+    } else {
+      setRuns(Array.isArray(data?.runs) ? data.runs : []);
+    }
+    setFlag("runs", false);
+    return data;
+  }, []);
+
+  const refreshProduction = useCallback(async () => {
+    setFlag("production", true);
+    setErr("production", null);
+    const { status: http, data } = await jfetch("/api/idp-calibration/production");
+    if (!mountedRef.current) return data;
+    if (http >= 400) {
+      setErr("production", data?.error || `HTTP ${http}`);
+    } else {
+      setProduction(data);
+    }
+    setFlag("production", false);
+    return data;
+  }, []);
+
+  const analyze = useCallback(async ({ testLeagueId, myLeagueId, settings }) => {
+    setFlag("analyze", true);
+    setErr("analyze", null);
+    const { status: http, data } = await jfetch("/api/idp-calibration/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        test_league_id: testLeagueId,
+        my_league_id: myLeagueId,
+        settings: settings || {},
+      }),
+    });
+    if (!mountedRef.current) return data;
+    if (http >= 400 || data?.ok === false) {
+      setErr("analyze", data?.error || `HTTP ${http}`);
+    } else {
+      setCurrentRun(data?.run || null);
+      await refreshRuns();
+    }
+    setFlag("analyze", false);
+    return data;
+  }, [refreshRuns]);
+
+  const loadRun = useCallback(async (runId) => {
+    if (!runId) return null;
+    setFlag("runDetail", true);
+    setErr("runDetail", null);
+    const { status: http, data } = await jfetch(
+      `/api/idp-calibration/runs/${encodeURIComponent(runId)}`,
+    );
+    if (!mountedRef.current) return data;
+    if (http >= 400 || data?.ok === false) {
+      setErr("runDetail", data?.error || `HTTP ${http}`);
+    } else {
+      setCurrentRun(data?.run || null);
+    }
+    setFlag("runDetail", false);
+    return data;
+  }, []);
+
+  const promote = useCallback(async ({ runId, activeMode }) => {
+    setFlag("promote", true);
+    setErr("promote", null);
+    const { status: http, data } = await jfetch("/api/idp-calibration/promote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ run_id: runId, active_mode: activeMode || "blended" }),
+    });
+    if (!mountedRef.current) return data;
+    if (http >= 400 || data?.ok === false) {
+      setErr("promote", data?.error || `HTTP ${http}`);
+    } else {
+      await Promise.all([refreshProduction(), refreshStatus()]);
+    }
+    setFlag("promote", false);
+    return data;
+  }, [refreshProduction, refreshStatus]);
+
+  return {
+    status,
+    runs,
+    production,
+    currentRun,
+    setCurrentRun,
+    loading,
+    error,
+    refreshStatus,
+    refreshRuns,
+    refreshProduction,
+    analyze,
+    loadRun,
+    promote,
+  };
+}

--- a/server.py
+++ b/server.py
@@ -3761,6 +3761,14 @@ async def idp_calibration_run_detail(request: Request, run_id: str):
     return _idp_json(_idp_api.run_detail(str(run_id or "").strip()))
 
 
+@app.delete("/api/idp-calibration/runs/{run_id}")
+async def idp_calibration_run_delete(request: Request, run_id: str):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    return _idp_json(_idp_api.run_delete(str(run_id or "").strip()))
+
+
 @app.post("/api/idp-calibration/promote")
 async def idp_calibration_promote(request: Request):
     gate = _require_auth_json(request)

--- a/server.py
+++ b/server.py
@@ -3711,6 +3711,87 @@ async def auth_logout_redirect(request: Request):
     return response
 
 
+# ── IDP CALIBRATION LAB (INTERNAL, AUTH-GATED) ──────────────────────────
+# Internal tooling: calibrate IDP multipliers from two Sleeper leagues.
+# The live valuation pipeline only reads the promoted output at
+# config/idp_calibration.json; these endpoints never mutate it without
+# an explicit POST /api/idp-calibration/promote.
+from src.idp_calibration import api as _idp_api  # noqa: E402
+
+
+def _idp_json(handler_result) -> JSONResponse:
+    status_code, payload = handler_result
+    return JSONResponse(status_code=status_code, content=payload)
+
+
+def _require_auth_json(request: Request) -> JSONResponse | None:
+    if _is_authenticated(request):
+        return None
+    return JSONResponse(
+        status_code=401,
+        content={"ok": False, "error": "Authentication required."},
+    )
+
+
+@app.post("/api/idp-calibration/analyze")
+async def idp_calibration_analyze(request: Request):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    return _idp_json(_idp_api.analyze(body if isinstance(body, dict) else None))
+
+
+@app.get("/api/idp-calibration/runs")
+async def idp_calibration_runs_index(request: Request):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    return _idp_json(_idp_api.runs_index())
+
+
+@app.get("/api/idp-calibration/runs/{run_id}")
+async def idp_calibration_run_detail(request: Request, run_id: str):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    return _idp_json(_idp_api.run_detail(str(run_id or "").strip()))
+
+
+@app.post("/api/idp-calibration/promote")
+async def idp_calibration_promote(request: Request):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    session = _get_auth_session(request) or {}
+    if isinstance(body, dict):
+        body.setdefault("promoted_by", str(session.get("username") or "internal"))
+    return _idp_json(_idp_api.promote(body if isinstance(body, dict) else None))
+
+
+@app.get("/api/idp-calibration/production")
+async def idp_calibration_production(request: Request):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    return _idp_json(_idp_api.production())
+
+
+@app.get("/api/idp-calibration/status")
+async def idp_calibration_status(request: Request):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    return _idp_json(_idp_api.status())
+
+
 @app.api_route("/", methods=["GET", "HEAD"], response_class=HTMLResponse)
 async def serve_landing(request: Request):
     redirect = _require_auth_or_redirect(request, "/")
@@ -3819,6 +3900,14 @@ async def serve_more(request: Request):
     if redirect is not None:
         return redirect
     return await _serve_app_shell("/more")
+
+
+@app.get("/tools/idp-calibration", response_class=HTMLResponse)
+async def serve_idp_calibration(request: Request):
+    redirect = _require_auth_or_redirect(request, "/tools/idp-calibration")
+    if redirect is not None:
+        return redirect
+    return await _serve_app_shell("/tools/idp-calibration")
 
 
 @app.get("/login", response_class=HTMLResponse)

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from src.data_models.contracts import utc_now_iso
+from src.idp_calibration import production as _idp_production
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -2652,6 +2653,78 @@ def _parse_pick_tier(name: str) -> tuple[int, str, int] | None:
         return None
 
 
+def _apply_idp_calibration_post_pass(
+    players_array: list[dict[str, Any]],
+    players_by_name: dict[str, Any],
+) -> None:
+    """Apply the promoted IDP calibration multipliers, if any.
+
+    Strict no-op whenever ``config/idp_calibration.json`` is absent —
+    :func:`src.idp_calibration.production.load_production_config`
+    returns ``None`` in that case and we early-exit.
+
+    When a promoted config is present we:
+
+    1. Enumerate all rows whose position normalises to DL/LB/DB.
+    2. Sort each position by the pre-multiplier ``rankDerivedValue``
+       descending to derive a stable position-specific rank.
+    3. Multiply the row's ``rankDerivedValue`` by the per-position /
+       per-bucket multiplier (looked up from the promoted config).
+    4. Mirror the updated value into the legacy-dict players map so
+       the runtime view stays in sync.
+
+    Offense rows are never touched.
+    """
+    config = _idp_production.load_production_config()
+    if not config:
+        return
+    active_mode = str(config.get("active_mode") or "blended")
+
+    by_pos: dict[str, list[dict[str, Any]]] = {"DL": [], "LB": [], "DB": []}
+    for row in players_array:
+        pos = str(row.get("position") or "").upper()
+        if pos in ("DE", "DT", "EDGE", "NT"):
+            pos = "DL"
+        elif pos in ("ILB", "OLB", "MLB"):
+            pos = "LB"
+        elif pos in ("CB", "S", "SS", "FS"):
+            pos = "DB"
+        if pos not in by_pos:
+            continue
+        try:
+            derived = int(row.get("rankDerivedValue") or 0)
+        except (TypeError, ValueError):
+            derived = 0
+        if derived <= 0:
+            continue
+        by_pos[pos].append(row)
+
+    for pos, rows in by_pos.items():
+        rows.sort(key=lambda r: -int(r.get("rankDerivedValue") or 0))
+        for idx, row in enumerate(rows, 1):
+            try:
+                multiplier = float(
+                    _idp_production.get_idp_bucket_multiplier(
+                        pos, idx, mode=active_mode
+                    )
+                )
+            except Exception:  # noqa: BLE001 — never fail the whole board
+                multiplier = 1.0
+            if abs(multiplier - 1.0) < 1e-9:
+                continue
+            old_val = int(row.get("rankDerivedValue") or 0)
+            new_val = max(1, int(round(old_val * multiplier)))
+            row["rankDerivedValue"] = new_val
+            row["idpCalibrationMultiplier"] = round(multiplier, 4)
+            row["idpCalibrationPositionRank"] = idx
+            legacy_ref = row.get("legacyRef")
+            if legacy_ref and legacy_ref in players_by_name:
+                pdata = players_by_name[legacy_ref]
+                if isinstance(pdata, dict):
+                    pdata["rankDerivedValue"] = new_val
+                    pdata["idpCalibrationMultiplier"] = round(multiplier, 4)
+
+
 def _reassign_pick_slot_order(players_array: list[dict[str, Any]]) -> int:
     """Reorder slot-specific picks within each year so slot order is
     strictly monotonic across all rounds (1.01..1.12, 2.01..2.12, ...).
@@ -3600,6 +3673,13 @@ def _compute_unified_rankings(
                     pdata["ktcRank"] = source_ranks["ktc"]
                 if "idpTradeCalc" in source_ranks:
                     pdata["idpRank"] = source_ranks["idpTradeCalc"]
+
+    # ── Phase 4c: IDP calibration post-pass ──
+    # Apply the promoted IDP calibration config (if any) to every
+    # DL/LB/DB row. Strict no-op when config/idp_calibration.json is
+    # absent — the calibration lab's Promote step is the only way to
+    # activate this. See src/idp_calibration/production.py.
+    _apply_idp_calibration_post_pass(players_array, players_by_name)
 
     # ── Phase 5: Pick refinement passes (gated to picks) ──
     # 1) Reassign (rank, value) tuples within each (year, round) bucket

--- a/src/idp_calibration/__init__.py
+++ b/src/idp_calibration/__init__.py
@@ -1,0 +1,10 @@
+"""IDP calibration lab — internal tooling.
+
+Computes lineup-aware IDP Value-Over-Replacement across two Sleeper
+leagues and four seasons, then produces per-position per-bucket
+multipliers that can be *manually* promoted into the production
+trade calculator.
+
+See ``docs/idp_calibration_lab.md`` for product docs and the
+promoted config schema consumed by the live valuation pipeline.
+"""

--- a/src/idp_calibration/anchors.py
+++ b/src/idp_calibration/anchors.py
@@ -1,0 +1,102 @@
+"""Anchor curves and monotonic smoothing.
+
+Given per-bucket multipliers we produce three curves per position —
+intrinsic, market, final — sampled at the default anchor ranks
+``[1, 3, 6, 12, 24, 36, 48, 72, 100]``.
+
+The smoothing pass is an in-place pool-adjacent-violators (PAV) style
+sweep that enforces non-increasing anchors along with a floor so we
+never emit negative or zero-crossing values. No sklearn dep —
+implemented with plain lists.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from .translation import BucketMultipliers, PositionMultipliers
+
+DEFAULT_ANCHOR_RANKS: tuple[int, ...] = (1, 3, 6, 12, 24, 36, 48, 72, 100)
+CURVE_KINDS: tuple[str, ...] = ("intrinsic", "market", "final")
+
+
+@dataclass
+class AnchorPoint:
+    rank: int
+    value: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"rank": int(self.rank), "value": round(float(self.value), 4)}
+
+
+def _bucket_value_at_rank(buckets: list[BucketMultipliers], rank: int, kind: str) -> float:
+    """Look up the multiplier for ``rank`` in a bucket list.
+
+    Buckets are labelled ``"lo-hi"``. If ``rank`` falls inside one we
+    return its multiplier. If ``rank`` is past the last bucket we
+    return the last bucket's value. Missing/empty bucket lists return
+    ``0.0``.
+    """
+    if not buckets:
+        return 0.0
+    for b in buckets:
+        lo, _, hi = b.label.partition("-")
+        try:
+            lo_i = int(lo)
+            hi_i = int(hi)
+        except ValueError:
+            continue
+        if lo_i <= rank <= hi_i:
+            return float(getattr(b, kind))
+    # Fallback: past the last labelled bucket
+    return float(getattr(buckets[-1], kind))
+
+
+def _monotone_non_increasing(values: list[float], floor: float = 0.0) -> list[float]:
+    if not values:
+        return []
+    out = [max(float(values[0]), floor)]
+    for v in values[1:]:
+        out.append(max(min(float(v), out[-1]), floor))
+    return out
+
+
+def build_anchor_curve(
+    multipliers: PositionMultipliers,
+    *,
+    anchor_ranks: Iterable[int] = DEFAULT_ANCHOR_RANKS,
+    floor: float = 0.05,
+) -> dict[str, list[AnchorPoint]]:
+    """Return {kind: [AnchorPoint...]} for one position."""
+    out: dict[str, list[AnchorPoint]] = {}
+    for kind in CURVE_KINDS:
+        raw = [
+            _bucket_value_at_rank(multipliers.buckets, r, kind)
+            for r in anchor_ranks
+        ]
+        smoothed = _monotone_non_increasing(raw, floor=floor)
+        out[kind] = [AnchorPoint(rank=r, value=v) for r, v in zip(anchor_ranks, smoothed)]
+    return out
+
+
+def build_all_anchors(
+    multipliers_by_position: dict[str, PositionMultipliers],
+    *,
+    anchor_ranks: Iterable[int] = DEFAULT_ANCHOR_RANKS,
+    floor: float = 0.05,
+) -> dict[str, dict[str, list[AnchorPoint]]]:
+    return {
+        pos: build_anchor_curve(pm, anchor_ranks=anchor_ranks, floor=floor)
+        for pos, pm in multipliers_by_position.items()
+    }
+
+
+def anchors_to_dict(
+    anchors: dict[str, dict[str, list[AnchorPoint]]],
+) -> dict[str, Any]:
+    """Flatten for JSON: {kind: {position: [{rank, value}, ...]}}."""
+    flat: dict[str, dict[str, list[dict[str, Any]]]] = {k: {} for k in CURVE_KINDS}
+    for position, by_kind in anchors.items():
+        for kind, points in by_kind.items():
+            flat.setdefault(kind, {})[position] = [p.to_dict() for p in points]
+    return flat

--- a/src/idp_calibration/api.py
+++ b/src/idp_calibration/api.py
@@ -14,7 +14,7 @@ from typing import Any
 from .engine import AnalysisSettings, run_analysis
 from .promotion import VALID_MODES, load_production, promote_run
 from .production import is_promoted
-from .storage import get_latest, list_runs, load_run, save_run
+from .storage import delete_run, get_latest, list_runs, load_run, save_run
 
 
 def _error(status: int, message: str, **extra: Any) -> tuple[int, dict[str, Any]]:
@@ -60,6 +60,15 @@ def run_detail(run_id: str, *, base: Path | None = None) -> tuple[int, dict[str,
     if not data:
         return _error(404, f"Run {run_id!r} not found.")
     return 200, {"ok": True, "run": data}
+
+
+def run_delete(run_id: str, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    if not run_id:
+        return _error(422, "run_id is required.")
+    removed = delete_run(run_id, base=base)
+    if not removed:
+        return _error(404, f"Run {run_id!r} not found.")
+    return 200, {"ok": True, "run_id": run_id, "deleted": True}
 
 
 def promote(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:

--- a/src/idp_calibration/api.py
+++ b/src/idp_calibration/api.py
@@ -1,0 +1,103 @@
+"""HTTP handlers for the IDP calibration lab.
+
+Pure-function handlers exposed to server.py so route registration
+matches the existing ``@app.get/post`` convention without dragging a
+FastAPI dependency into this package. Every handler returns a
+``(status, payload)`` tuple — server.py wraps them in ``JSONResponse``
+and applies the standard auth gate.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .engine import AnalysisSettings, run_analysis
+from .promotion import VALID_MODES, load_production, promote_run
+from .production import is_promoted
+from .storage import get_latest, list_runs, load_run, save_run
+
+
+def _error(status: int, message: str, **extra: Any) -> tuple[int, dict[str, Any]]:
+    payload: dict[str, Any] = {"ok": False, "error": message}
+    payload.update(extra)
+    return status, payload
+
+
+def analyze(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    body = body or {}
+    test_id = str(body.get("test_league_id") or "").strip()
+    my_id = str(body.get("my_league_id") or "").strip()
+    if not test_id or not my_id:
+        return _error(
+            422,
+            "Both test_league_id and my_league_id are required.",
+        )
+    settings = AnalysisSettings.from_payload(body.get("settings"))
+    try:
+        artifact = run_analysis(test_id, my_id, settings)
+    except Exception as exc:  # noqa: BLE001 — surface as user-friendly 500
+        return _error(500, f"Analysis failed: {exc}")
+    try:
+        save_run(artifact, base=base)
+    except Exception as exc:  # noqa: BLE001
+        artifact.setdefault("warnings", []).append(f"Failed to persist run: {exc}")
+    return 200, {"ok": True, "run": artifact}
+
+
+def runs_index(*, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    latest = get_latest(base=base)
+    return 200, {
+        "ok": True,
+        "runs": list_runs(base=base),
+        "latest_run_id": (latest or {}).get("run_id"),
+    }
+
+
+def run_detail(run_id: str, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    if not run_id:
+        return _error(422, "run_id is required.")
+    data = load_run(run_id, base=base)
+    if not data:
+        return _error(404, f"Run {run_id!r} not found.")
+    return 200, {"ok": True, "run": data}
+
+
+def promote(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    body = body or {}
+    run_id = str(body.get("run_id") or "").strip()
+    active_mode = str(body.get("active_mode") or "blended").strip()
+    promoted_by = str(body.get("promoted_by") or "internal").strip() or "internal"
+    if not run_id:
+        return _error(422, "run_id is required.")
+    if active_mode not in VALID_MODES:
+        return _error(
+            422,
+            f"active_mode must be one of {list(VALID_MODES)}, got {active_mode!r}.",
+        )
+    try:
+        result = promote_run(
+            run_id, active_mode=active_mode, promoted_by=promoted_by, base=base
+        )
+    except FileNotFoundError as exc:
+        return _error(404, str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return _error(500, f"Promotion failed: {exc}")
+    return 200, result
+
+
+def production(*, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    cfg = load_production(base)
+    if not cfg:
+        return 200, {"ok": True, "present": False, "config": None}
+    return 200, {"ok": True, "present": True, "config": cfg}
+
+
+def status(*, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    latest = get_latest(base=base)
+    return 200, {
+        "ok": True,
+        "latest_run_id": (latest or {}).get("run_id"),
+        "latest_generated_at": (latest or {}).get("generated_at"),
+        "production_present": is_promoted(base=base),
+        "valid_modes": list(VALID_MODES),
+    }

--- a/src/idp_calibration/api.py
+++ b/src/idp_calibration/api.py
@@ -23,8 +23,9 @@ def _error(status: int, message: str, **extra: Any) -> tuple[int, dict[str, Any]
     return status, payload
 
 
-def analyze(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:
-    body = body or {}
+def analyze(body: Any, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    if not isinstance(body, dict):
+        body = {}
     test_id = str(body.get("test_league_id") or "").strip()
     my_id = str(body.get("my_league_id") or "").strip()
     if not test_id or not my_id:
@@ -32,8 +33,12 @@ def analyze(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[i
             422,
             "Both test_league_id and my_league_id are required.",
         )
-    settings = AnalysisSettings.from_payload(body.get("settings"))
     try:
+        # Pulled inside the try block as belt-and-braces: from_payload
+        # funnels every sub-field through _as_dict / _as_list and numeric
+        # helpers, but if a future caller invents a new shape we still
+        # want a structured error, not a 500.
+        settings = AnalysisSettings.from_payload(body.get("settings"))
         artifact = run_analysis(test_id, my_id, settings)
     except Exception as exc:  # noqa: BLE001 — surface as user-friendly 500
         return _error(500, f"Analysis failed: {exc}")

--- a/src/idp_calibration/api.py
+++ b/src/idp_calibration/api.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .engine import AnalysisSettings, run_analysis
-from .promotion import VALID_MODES, load_production, promote_run
+from .promotion import EmptyCalibrationError, VALID_MODES, load_production, promote_run
 from .production import is_promoted
 from .storage import delete_run, get_latest, list_runs, load_run, save_run
 
@@ -89,6 +89,8 @@ def promote(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[i
         )
     except FileNotFoundError as exc:
         return _error(404, str(exc))
+    except EmptyCalibrationError as exc:
+        return _error(422, str(exc))
     except Exception as exc:  # noqa: BLE001
         return _error(500, f"Promotion failed: {exc}")
     return 200, result

--- a/src/idp_calibration/buckets.py
+++ b/src/idp_calibration/buckets.py
@@ -1,0 +1,163 @@
+"""Per-position rank-bucket aggregation.
+
+Given :class:`~src.idp_calibration.vor.VorRow` data, bucket the
+players into rank ranges (by ``rank_mine``), and compute the per
+bucket ``(mean + median) / 2`` blended center under both scoring
+systems.
+
+If a bucket has fewer than ``min_bucket_size`` members it is merged
+into the neighbouring (lower-rank) bucket and the merge is recorded
+in the output so the UI can flag it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import fmean, median
+from typing import Any, Iterable
+
+from .vor import VorRow
+
+DEFAULT_BUCKETS: tuple[tuple[int, int], ...] = (
+    (1, 6),
+    (7, 12),
+    (13, 24),
+    (25, 36),
+    (37, 60),
+    (61, 100),
+)
+
+
+@dataclass
+class BucketResult:
+    label: str  # "1-6"
+    lo: int
+    hi: int
+    count: int
+    mean_vor_test: float
+    median_vor_test: float
+    center_vor_test: float
+    mean_vor_mine: float
+    median_vor_mine: float
+    center_vor_mine: float
+    ratio_mine_over_test: float | None
+    merged_from: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "lo": self.lo,
+            "hi": self.hi,
+            "count": self.count,
+            "mean_vor_test": self.mean_vor_test,
+            "median_vor_test": self.median_vor_test,
+            "center_vor_test": self.center_vor_test,
+            "mean_vor_mine": self.mean_vor_mine,
+            "median_vor_mine": self.median_vor_mine,
+            "center_vor_mine": self.center_vor_mine,
+            "ratio_mine_over_test": self.ratio_mine_over_test,
+            "merged_from": list(self.merged_from),
+        }
+
+
+def _aggregate(values_test: list[float], values_mine: list[float]) -> tuple[float, float, float, float, float, float]:
+    if not values_test or not values_mine:
+        return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    mean_t = float(fmean(values_test))
+    med_t = float(median(values_test))
+    center_t = (mean_t + med_t) / 2.0
+    mean_m = float(fmean(values_mine))
+    med_m = float(median(values_mine))
+    center_m = (mean_m + med_m) / 2.0
+    return (mean_t, med_t, center_t, mean_m, med_m, center_m)
+
+
+def bucketize(
+    rows: Iterable[VorRow],
+    position: str,
+    *,
+    buckets: Iterable[tuple[int, int]] = DEFAULT_BUCKETS,
+    min_bucket_size: int = 3,
+) -> list[BucketResult]:
+    """Bucket rows by their *my-league* rank and compute centers.
+
+    The ranking used for bucketing is ``rank_mine`` because the
+    buckets represent "my-league DL1-DL6", "my-league DL7-DL12" etc.
+    The centers aggregate VOR from both scoring systems so the caller
+    can compute market vs intrinsic multipliers downstream.
+    """
+    position = position.upper()
+    by_bucket: list[dict[str, Any]] = [
+        {"label": f"{lo}-{hi}", "lo": lo, "hi": hi, "rows": [], "merged": []}
+        for lo, hi in buckets
+    ]
+    for row in rows:
+        if row.position.upper() != position:
+            continue
+        rank = int(row.rank_mine)
+        for bucket in by_bucket:
+            if bucket["lo"] <= rank <= bucket["hi"]:
+                bucket["rows"].append(row)
+                break
+
+    # Merge small buckets into the nearest lower-rank neighbour. We
+    # walk high->low so merges propagate from the tail upward.
+    for idx in range(len(by_bucket) - 1, 0, -1):
+        bucket = by_bucket[idx]
+        if len(bucket["rows"]) < min_bucket_size:
+            prev = by_bucket[idx - 1]
+            prev["rows"].extend(bucket["rows"])
+            prev["merged"].append(bucket["label"])
+            bucket["rows"] = []
+            bucket["merged_into_next"] = True
+
+    results: list[BucketResult] = []
+    for bucket in by_bucket:
+        if not bucket["rows"] and not bucket.get("merged_into_next"):
+            # Empty bucket that wasn't merged into a prior one — keep
+            # it as a zero-count placeholder so the UI shows the gap.
+            results.append(
+                BucketResult(
+                    label=bucket["label"],
+                    lo=bucket["lo"],
+                    hi=bucket["hi"],
+                    count=0,
+                    mean_vor_test=0.0,
+                    median_vor_test=0.0,
+                    center_vor_test=0.0,
+                    mean_vor_mine=0.0,
+                    median_vor_mine=0.0,
+                    center_vor_mine=0.0,
+                    ratio_mine_over_test=None,
+                    merged_from=[],
+                )
+            )
+            continue
+        if bucket.get("merged_into_next"):
+            continue
+        vs_t = [r.vor_test for r in bucket["rows"]]
+        vs_m = [r.vor_mine for r in bucket["rows"]]
+        mean_t, med_t, center_t, mean_m, med_m, center_m = _aggregate(vs_t, vs_m)
+        ratio = None
+        if abs(center_t) > 1e-6:
+            ratio = center_m / center_t
+        results.append(
+            BucketResult(
+                label=bucket["label"],
+                lo=bucket["lo"],
+                hi=bucket["hi"],
+                count=len(bucket["rows"]),
+                mean_vor_test=round(mean_t, 4),
+                median_vor_test=round(med_t, 4),
+                center_vor_test=round(center_t, 4),
+                mean_vor_mine=round(mean_m, 4),
+                median_vor_mine=round(med_m, 4),
+                center_vor_mine=round(center_m, 4),
+                ratio_mine_over_test=round(ratio, 4) if ratio is not None else None,
+                merged_from=list(bucket.get("merged") or []),
+            )
+        )
+    return results
+
+
+def buckets_to_dict(results: list[BucketResult]) -> list[dict[str, Any]]:
+    return [r.to_dict() for r in results]

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -39,6 +39,7 @@ from .vor import (
     build_universe,
     compute_vor,
     score_universe,
+    trim_to_top_n_per_position,
     vor_rows_to_dict,
 )
 
@@ -182,7 +183,7 @@ def _build_universe_for_season(
     except AdapterUnavailable as exc:
         warnings.append(f"{season}: {exc}")
         raw = []
-    universe = build_universe(raw, top_n=settings.top_n, min_games=settings.min_games)
+    universe = build_universe(raw, min_games=settings.min_games)
     return universe, warnings, adapter_name
 
 
@@ -251,6 +252,8 @@ def run_analysis(
             continue
 
         scored = score_universe(universe, test_scoring.idp_weights, my_scoring.idp_weights)
+        if settings.top_n:
+            scored = trim_to_top_n_per_position(scored, settings.top_n)
         repl_test_levels = compute_replacement_levels(
             ({"position": p.position, "points": p.points_test} for p in scored),
             test_lineup,

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -10,6 +10,7 @@ directly.
 from __future__ import annotations
 
 import hashlib
+import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -49,29 +50,51 @@ POSITIONS: tuple[str, ...] = ("DL", "LB", "DB")
 def _safe_int(value: Any, default: int) -> int:
     """Coerce ``value`` to int; return ``default`` on any parse error.
 
-    Keeps malformed client payloads (e.g. ``"min_games": "abc"``) from
-    bubbling a ``ValueError`` out of :meth:`AnalysisSettings.from_payload`
-    as a 500 response. Callers should combine this with a value-level
-    clamp where a negative or zero fallback is not safe.
+    Guards against the full set of numeric-coercion failures:
+
+    * ``TypeError`` / ``ValueError`` — ``"abc"`` or ``None``.
+    * ``OverflowError`` — ``"1e309"`` turns into ``float("inf")`` which
+      then raises ``OverflowError`` on ``int(inf)``.
+    * Non-finite intermediates — ``"nan"`` parses to ``float("nan")``
+      which ``int()`` would happily accept but produces garbage values
+      and breaks every downstream math step.
     """
     if value is None or value == "":
         return default
     try:
         return int(value)
     except (TypeError, ValueError):
-        try:
-            return int(float(value))
-        except (TypeError, ValueError):
-            return default
+        pass
+    except OverflowError:
+        return default
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(as_float):
+        return default
+    try:
+        return int(as_float)
+    except (TypeError, ValueError, OverflowError):
+        return default
 
 
 def _safe_float(value: Any, default: float) -> float:
+    """Coerce ``value`` to a finite float; return ``default`` otherwise.
+
+    Rejects ``inf`` / ``-inf`` / ``nan`` — these are not JSON-compliant
+    and propagate as NaN through the multiplier math and the response
+    encoder, which surfaces as a 500 downstream.
+    """
     if value is None or value == "":
         return default
     try:
-        return float(value)
+        result = float(value)
     except (TypeError, ValueError):
         return default
+    if not math.isfinite(result):
+        return default
+    return result
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -152,9 +175,20 @@ class AnalysisSettings:
         year_weights: dict[int, float] = {}
         for k, v in year_weights_raw.items():
             try:
-                year_weights[int(k)] = float(v)
+                key = int(k)
             except (TypeError, ValueError):
                 continue
+            try:
+                parsed = float(v)
+            except (TypeError, ValueError):
+                continue
+            # Reject inf / nan so they don't silently propagate into
+            # normalise_year_weights and make the response path fail
+            # JSON encoding. Negative weights break the normalisation
+            # step, so drop those too.
+            if not math.isfinite(parsed) or parsed < 0:
+                continue
+            year_weights[key] = parsed
         if not year_weights:
             year_weights = dict(DEFAULT_YEAR_WEIGHTS)
         anchors = _as_list(payload.get("anchor_ranks")) or list(DEFAULT_ANCHOR_RANKS)

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -1,0 +1,384 @@
+"""Top-level orchestrator for the IDP calibration lab.
+
+``run_analysis`` takes two Sleeper league IDs plus optional advanced
+settings and returns a fully populated run artifact dict that matches
+the schema documented in ``docs/idp_calibration_lab.md``. The
+artifact is self-contained — no shared mutable state — so the
+storage layer can persist it as JSON and the frontend can render it
+directly.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .anchors import DEFAULT_ANCHOR_RANKS, anchors_to_dict, build_all_anchors
+from .buckets import DEFAULT_BUCKETS, BucketResult, bucketize, buckets_to_dict
+from .lineup import LineupDemand, parse_lineup
+from .replacement import ReplacementSettings, compute_replacement_levels, replacement_to_dict
+from .scoring import LeagueScoring, parse_scoring
+from .season_chain import DEFAULT_SEASONS, LeagueChain, resolve_seasons
+from .stats_adapter import (
+    AdapterUnavailable,
+    HistoricalStatsAdapter,
+    PlayerSeason,
+    get_stats_adapter,
+)
+from .translation import (
+    DEFAULT_BLEND,
+    DEFAULT_YEAR_WEIGHTS,
+    build_multi_year_multipliers,
+    multipliers_to_dict,
+    normalise_year_weights,
+)
+from .vor import (
+    ScoredPlayer,
+    VorRow,
+    build_universe,
+    compute_vor,
+    score_universe,
+    vor_rows_to_dict,
+)
+
+POSITIONS: tuple[str, ...] = ("DL", "LB", "DB")
+
+
+@dataclass
+class AnalysisSettings:
+    seasons: list[int] = field(default_factory=lambda: list(DEFAULT_SEASONS))
+    replacement: ReplacementSettings = field(default_factory=ReplacementSettings)
+    bucket_edges: list[list[int]] = field(
+        default_factory=lambda: [list(edge) for edge in DEFAULT_BUCKETS]
+    )
+    min_bucket_size: int = 3
+    blend: dict[str, float] = field(default_factory=lambda: dict(DEFAULT_BLEND))
+    year_weights: dict[int, float] = field(
+        default_factory=lambda: dict(DEFAULT_YEAR_WEIGHTS)
+    )
+    anchor_ranks: list[int] = field(default_factory=lambda: list(DEFAULT_ANCHOR_RANKS))
+    anchor_floor: float = 0.05
+    min_games: int = 0
+    top_n: int | None = None
+
+    @staticmethod
+    def from_payload(payload: dict[str, Any] | None) -> "AnalysisSettings":
+        payload = payload or {}
+        seasons_raw = payload.get("seasons") or DEFAULT_SEASONS
+        try:
+            seasons = [int(s) for s in seasons_raw]
+        except (TypeError, ValueError):
+            seasons = list(DEFAULT_SEASONS)
+        replacement_raw = payload.get("replacement") or {}
+        replacement = ReplacementSettings(
+            mode=str(replacement_raw.get("mode") or "starter_plus_buffer"),
+            buffer_pct=float(replacement_raw.get("buffer_pct") or 0.15),
+            manual={k: int(v) for k, v in (replacement_raw.get("manual") or {}).items()},
+        )
+        bucket_edges_raw = payload.get("bucket_edges") or [list(e) for e in DEFAULT_BUCKETS]
+        bucket_edges: list[list[int]] = []
+        for edge in bucket_edges_raw:
+            try:
+                lo, hi = int(edge[0]), int(edge[1])
+                if lo <= hi:
+                    bucket_edges.append([lo, hi])
+            except (TypeError, ValueError, IndexError):
+                continue
+        if not bucket_edges:
+            bucket_edges = [list(e) for e in DEFAULT_BUCKETS]
+        blend_raw = payload.get("blend") or DEFAULT_BLEND
+        blend = {
+            "intrinsic": max(0.0, min(1.0, float(blend_raw.get("intrinsic", 0.75)))),
+            "market": 0.0,
+        }
+        blend["market"] = round(1.0 - blend["intrinsic"], 6)
+        year_weights_raw = payload.get("year_weights") or DEFAULT_YEAR_WEIGHTS
+        year_weights: dict[int, float] = {}
+        for k, v in year_weights_raw.items():
+            try:
+                year_weights[int(k)] = float(v)
+            except (TypeError, ValueError):
+                continue
+        if not year_weights:
+            year_weights = dict(DEFAULT_YEAR_WEIGHTS)
+        anchors = payload.get("anchor_ranks") or DEFAULT_ANCHOR_RANKS
+        try:
+            anchor_ranks = sorted({int(a) for a in anchors})
+        except (TypeError, ValueError):
+            anchor_ranks = list(DEFAULT_ANCHOR_RANKS)
+        min_games = int(payload.get("min_games") or 0)
+        top_n_raw = payload.get("top_n")
+        top_n = None
+        try:
+            if top_n_raw is not None and int(top_n_raw) > 0:
+                top_n = int(top_n_raw)
+        except (TypeError, ValueError):
+            top_n = None
+        return AnalysisSettings(
+            seasons=seasons,
+            replacement=replacement,
+            bucket_edges=bucket_edges,
+            min_bucket_size=int(payload.get("min_bucket_size") or 3),
+            blend=blend,
+            year_weights=year_weights,
+            anchor_ranks=anchor_ranks,
+            anchor_floor=float(payload.get("anchor_floor") or 0.05),
+            min_games=min_games,
+            top_n=top_n,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "seasons": list(self.seasons),
+            "replacement": {
+                "mode": self.replacement.mode,
+                "buffer_pct": self.replacement.buffer_pct,
+                "manual": dict(self.replacement.manual),
+            },
+            "bucket_edges": [list(e) for e in self.bucket_edges],
+            "min_bucket_size": self.min_bucket_size,
+            "blend": dict(self.blend),
+            "year_weights": {str(k): v for k, v in self.year_weights.items()},
+            "anchor_ranks": list(self.anchor_ranks),
+            "anchor_floor": self.anchor_floor,
+            "min_games": self.min_games,
+            "top_n": self.top_n,
+        }
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _make_run_id(test_id: str, my_id: str, seasons: list[int]) -> str:
+    basis = f"{test_id}|{my_id}|{','.join(str(s) for s in seasons)}|{_utc_now_iso()}"
+    short = hashlib.sha1(basis.encode("utf-8")).hexdigest()[:6]
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{ts}_{short}"
+
+
+def _build_universe_for_season(
+    season: int,
+    *,
+    adapter: HistoricalStatsAdapter | None = None,
+    settings: AnalysisSettings,
+) -> tuple[list[PlayerSeason], list[str], str]:
+    """Return (universe, warnings, adapter_name) for a single season."""
+    warnings: list[str] = []
+    adapter_name = "none"
+    if adapter is None:
+        adapter, attempts = get_stats_adapter(season)
+        adapter_name = adapter.name
+        if adapter_name == "manual_fallback":
+            warnings.append(
+                f"{season}: stats unavailable via any adapter. Attempts: "
+                + "; ".join(attempts)
+            )
+    else:
+        adapter_name = adapter.name
+    try:
+        raw = adapter.fetch(season)
+    except AdapterUnavailable as exc:
+        warnings.append(f"{season}: {exc}")
+        raw = []
+    universe = build_universe(raw, top_n=settings.top_n, min_games=settings.min_games)
+    return universe, warnings, adapter_name
+
+
+def run_analysis(
+    test_league_id: str,
+    my_league_id: str,
+    settings: AnalysisSettings | None = None,
+    *,
+    stats_adapter_factory=None,
+) -> dict[str, Any]:
+    """Execute the full calibration analysis and return a run artifact.
+
+    ``stats_adapter_factory`` is an optional ``(season) -> adapter`` hook
+    used by tests to inject deterministic stats without hitting the
+    network. When omitted, :func:`get_stats_adapter` picks the best
+    adapter per season.
+    """
+    settings = settings or AnalysisSettings()
+    settings_dict = settings.to_dict()
+    warnings: list[str] = []
+
+    test_chain = resolve_seasons(test_league_id, seasons=settings.seasons)
+    my_chain = resolve_seasons(my_league_id, seasons=settings.seasons)
+    warnings.extend(test_chain.warnings)
+    warnings.extend(my_chain.warnings)
+
+    per_season_payload: dict[int, dict[str, Any]] = {}
+    per_season_per_position_buckets: dict[str, dict[int, list[BucketResult]]] = {
+        pos: {} for pos in POSITIONS
+    }
+    resolved_seasons: list[int] = []
+
+    for season in sorted({int(s) for s in settings.seasons}):
+        test_res = test_chain.seasons.get(season)
+        my_res = my_chain.seasons.get(season)
+        if not (test_res and test_res.resolved and my_res and my_res.resolved):
+            per_season_payload[season] = {
+                "season": season,
+                "resolved": False,
+                "reason": (
+                    (test_res.reason if test_res else "")
+                    + " | "
+                    + (my_res.reason if my_res else "")
+                ).strip(" |"),
+            }
+            continue
+
+        test_scoring = parse_scoring(test_res.league)
+        my_scoring = parse_scoring(my_res.league)
+        test_lineup = parse_lineup(test_res.league)
+        my_lineup = parse_lineup(my_res.league)
+
+        adapter = stats_adapter_factory(season) if stats_adapter_factory else None
+        universe, stats_warnings, adapter_name = _build_universe_for_season(
+            season, adapter=adapter, settings=settings
+        )
+        warnings.extend(stats_warnings)
+
+        if not universe:
+            per_season_payload[season] = {
+                "season": season,
+                "resolved": False,
+                "reason": f"No usable stats for {season} (adapter={adapter_name}).",
+                "adapter": adapter_name,
+            }
+            continue
+
+        scored = score_universe(universe, test_scoring.idp_weights, my_scoring.idp_weights)
+        repl_test_levels = compute_replacement_levels(
+            ({"position": p.position, "points": p.points_test} for p in scored),
+            test_lineup,
+            settings.replacement,
+        )
+        repl_mine_levels = compute_replacement_levels(
+            ({"position": p.position, "points": p.points_mine} for p in scored),
+            my_lineup,
+            settings.replacement,
+        )
+        replacement_test = {
+            pos: lv.replacement_points for pos, lv in repl_test_levels.items()
+        }
+        replacement_mine = {
+            pos: lv.replacement_points for pos, lv in repl_mine_levels.items()
+        }
+        vor_rows = compute_vor(scored, replacement_test, replacement_mine)
+
+        position_buckets: dict[str, list[BucketResult]] = {}
+        for pos in POSITIONS:
+            buckets = bucketize(
+                vor_rows,
+                pos,
+                buckets=[tuple(edge) for edge in settings.bucket_edges],
+                min_bucket_size=settings.min_bucket_size,
+            )
+            position_buckets[pos] = buckets
+            per_season_per_position_buckets[pos][season] = buckets
+
+        per_season_payload[season] = {
+            "season": season,
+            "resolved": True,
+            "adapter": adapter_name,
+            "universe_size": len(universe),
+            "test_scoring": test_scoring.summary(),
+            "my_scoring": my_scoring.summary(),
+            "test_lineup": test_lineup.to_dict(),
+            "my_lineup": my_lineup.to_dict(),
+            "replacement_test": replacement_to_dict(repl_test_levels),
+            "replacement_mine": replacement_to_dict(repl_mine_levels),
+            "buckets": {pos: buckets_to_dict(b) for pos, b in position_buckets.items()},
+            "sample_vor_rows": vor_rows_to_dict(vor_rows)[:120],
+        }
+        resolved_seasons.append(season)
+
+    normalised_weights = normalise_year_weights(
+        settings.year_weights, seasons=resolved_seasons
+    )
+    multipliers = build_multi_year_multipliers(
+        per_season_per_position_buckets,
+        year_weights=normalised_weights,
+        blend=settings.blend,
+    )
+    anchors = build_all_anchors(
+        multipliers,
+        anchor_ranks=settings.anchor_ranks,
+        floor=settings.anchor_floor,
+    )
+
+    recommendation = _build_recommendation(multipliers, warnings)
+
+    run_id = _make_run_id(test_league_id, my_league_id, settings.seasons)
+
+    artifact: dict[str, Any] = {
+        "run_id": run_id,
+        "generated_at": _utc_now_iso(),
+        "schema_version": 1,
+        "inputs": {
+            "test_league_id": str(test_league_id or ""),
+            "my_league_id": str(my_league_id or ""),
+        },
+        "settings": settings_dict,
+        "normalised_year_weights": {str(k): v for k, v in normalised_weights.items()},
+        "resolved_seasons": resolved_seasons,
+        "chains": {
+            "test": test_chain.to_dict(),
+            "mine": my_chain.to_dict(),
+        },
+        "per_season": {str(k): v for k, v in per_season_payload.items()},
+        "multipliers": multipliers_to_dict(multipliers),
+        "anchors": anchors_to_dict(anchors),
+        "recommendation": recommendation,
+        "warnings": warnings,
+    }
+    return artifact
+
+
+def _build_recommendation(
+    multipliers: dict[str, Any], warnings: list[str]
+) -> dict[str, Any]:
+    """Produce a plain-language summary block for the UI."""
+    lines: list[str] = []
+    notes: list[str] = []
+    per_position: dict[str, dict[str, Any]] = {}
+    for pos, pm in multipliers.items():
+        if not pm.buckets:
+            notes.append(f"No multiplier data available for {pos}.")
+            continue
+        # Compare the mid-tier (3rd bucket if available, otherwise last)
+        idx = min(2, len(pm.buckets) - 1)
+        mid = pm.buckets[idx]
+        direction = "neutral"
+        if mid.intrinsic > mid.market * 1.03:
+            direction = "undervalued-by-market"
+            lines.append(
+                f"{pos}: my-league intrinsic value exceeds test-league market "
+                f"at bucket {mid.label} by {((mid.intrinsic / max(mid.market, 1e-6)) - 1) * 100:.1f}%."
+            )
+        elif mid.market > mid.intrinsic * 1.03:
+            direction = "overvalued-by-market"
+            lines.append(
+                f"{pos}: test-league market values bucket {mid.label} "
+                f"{((mid.market / max(mid.intrinsic, 1e-6)) - 1) * 100:.1f}% higher than my-league intrinsic."
+            )
+        else:
+            lines.append(f"{pos}: intrinsic and market align within 3% at {mid.label}.")
+        per_position[pos] = {
+            "direction": direction,
+            "mid_bucket": mid.label,
+            "intrinsic": mid.intrinsic,
+            "market": mid.market,
+            "final": mid.final,
+        }
+    if warnings:
+        notes.append(f"{len(warnings)} warning(s) during analysis — review before promoting.")
+    return {
+        "summary_lines": lines,
+        "notes": notes,
+        "per_position": per_position,
+        "recommended_mode": "blended",
+    }

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -46,6 +46,34 @@ from .vor import (
 POSITIONS: tuple[str, ...] = ("DL", "LB", "DB")
 
 
+def _safe_int(value: Any, default: int) -> int:
+    """Coerce ``value`` to int; return ``default`` on any parse error.
+
+    Keeps malformed client payloads (e.g. ``"min_games": "abc"``) from
+    bubbling a ``ValueError`` out of :meth:`AnalysisSettings.from_payload`
+    as a 500 response. Callers should combine this with a value-level
+    clamp where a negative or zero fallback is not safe.
+    """
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return default
+
+
+def _safe_float(value: Any, default: float) -> float:
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 @dataclass
 class AnalysisSettings:
     seasons: list[int] = field(default_factory=lambda: list(DEFAULT_SEASONS))
@@ -72,10 +100,17 @@ class AnalysisSettings:
         except (TypeError, ValueError):
             seasons = list(DEFAULT_SEASONS)
         replacement_raw = payload.get("replacement") or {}
+        manual_raw = (replacement_raw or {}).get("manual") or {}
+        manual_safe: dict[str, int] = {}
+        if isinstance(manual_raw, dict):
+            for k, v in manual_raw.items():
+                parsed = _safe_int(v, 0)
+                if parsed > 0:
+                    manual_safe[str(k)] = parsed
         replacement = ReplacementSettings(
             mode=str(replacement_raw.get("mode") or "starter_plus_buffer"),
-            buffer_pct=float(replacement_raw.get("buffer_pct") or 0.15),
-            manual={k: int(v) for k, v in (replacement_raw.get("manual") or {}).items()},
+            buffer_pct=_safe_float(replacement_raw.get("buffer_pct"), 0.15),
+            manual=manual_safe,
         )
         bucket_edges_raw = payload.get("bucket_edges") or [list(e) for e in DEFAULT_BUCKETS]
         bucket_edges: list[list[int]] = []
@@ -90,7 +125,7 @@ class AnalysisSettings:
             bucket_edges = [list(e) for e in DEFAULT_BUCKETS]
         blend_raw = payload.get("blend") or DEFAULT_BLEND
         blend = {
-            "intrinsic": max(0.0, min(1.0, float(blend_raw.get("intrinsic", 0.75)))),
+            "intrinsic": max(0.0, min(1.0, _safe_float(blend_raw.get("intrinsic"), 0.75))),
             "market": 0.0,
         }
         blend["market"] = round(1.0 - blend["intrinsic"], 6)
@@ -108,23 +143,20 @@ class AnalysisSettings:
             anchor_ranks = sorted({int(a) for a in anchors})
         except (TypeError, ValueError):
             anchor_ranks = list(DEFAULT_ANCHOR_RANKS)
-        min_games = int(payload.get("min_games") or 0)
-        top_n_raw = payload.get("top_n")
-        top_n = None
-        try:
-            if top_n_raw is not None and int(top_n_raw) > 0:
-                top_n = int(top_n_raw)
-        except (TypeError, ValueError):
-            top_n = None
+        min_games = max(0, _safe_int(payload.get("min_games"), 0))
+        top_n_raw = _safe_int(payload.get("top_n"), 0)
+        top_n = top_n_raw if top_n_raw > 0 else None
+        anchor_floor = max(0.0, min(1.0, _safe_float(payload.get("anchor_floor"), 0.05)))
+        min_bucket_size = max(1, _safe_int(payload.get("min_bucket_size"), 3))
         return AnalysisSettings(
             seasons=seasons,
             replacement=replacement,
             bucket_edges=bucket_edges,
-            min_bucket_size=int(payload.get("min_bucket_size") or 3),
+            min_bucket_size=min_bucket_size,
             blend=blend,
             year_weights=year_weights,
             anchor_ranks=anchor_ranks,
-            anchor_floor=float(payload.get("anchor_floor") or 0.05),
+            anchor_floor=anchor_floor,
             min_games=min_games,
             top_n=top_n,
         )

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -74,6 +74,21 @@ def _safe_float(value: Any, default: float) -> float:
         return default
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Return ``value`` if it is a dict, otherwise an empty dict.
+
+    Clients can send malformed shapes like ``"settings": "oops"`` or
+    ``"settings": [1,2,3]`` which would otherwise raise ``AttributeError``
+    when :meth:`AnalysisSettings.from_payload` calls ``.get()``. We funnel
+    every sub-field through this so the handler never 500s on type drift.
+    """
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
 @dataclass
 class AnalysisSettings:
     seasons: list[int] = field(default_factory=lambda: list(DEFAULT_SEASONS))
@@ -92,27 +107,29 @@ class AnalysisSettings:
     top_n: int | None = None
 
     @staticmethod
-    def from_payload(payload: dict[str, Any] | None) -> "AnalysisSettings":
-        payload = payload or {}
-        seasons_raw = payload.get("seasons") or DEFAULT_SEASONS
+    def from_payload(payload: Any) -> "AnalysisSettings":
+        # Tolerate any non-dict payload (string, list, None, scalar).
+        payload = _as_dict(payload)
+        seasons_raw = _as_list(payload.get("seasons")) or list(DEFAULT_SEASONS)
         try:
             seasons = [int(s) for s in seasons_raw]
         except (TypeError, ValueError):
             seasons = list(DEFAULT_SEASONS)
-        replacement_raw = payload.get("replacement") or {}
-        manual_raw = (replacement_raw or {}).get("manual") or {}
+        replacement_raw = _as_dict(payload.get("replacement"))
+        manual_raw = _as_dict(replacement_raw.get("manual"))
         manual_safe: dict[str, int] = {}
-        if isinstance(manual_raw, dict):
-            for k, v in manual_raw.items():
-                parsed = _safe_int(v, 0)
-                if parsed > 0:
-                    manual_safe[str(k)] = parsed
+        for k, v in manual_raw.items():
+            parsed = _safe_int(v, 0)
+            if parsed > 0:
+                manual_safe[str(k)] = parsed
         replacement = ReplacementSettings(
             mode=str(replacement_raw.get("mode") or "starter_plus_buffer"),
             buffer_pct=_safe_float(replacement_raw.get("buffer_pct"), 0.15),
             manual=manual_safe,
         )
-        bucket_edges_raw = payload.get("bucket_edges") or [list(e) for e in DEFAULT_BUCKETS]
+        bucket_edges_raw = _as_list(payload.get("bucket_edges")) or [
+            list(e) for e in DEFAULT_BUCKETS
+        ]
         bucket_edges: list[list[int]] = []
         for edge in bucket_edges_raw:
             try:
@@ -123,13 +140,15 @@ class AnalysisSettings:
                 continue
         if not bucket_edges:
             bucket_edges = [list(e) for e in DEFAULT_BUCKETS]
-        blend_raw = payload.get("blend") or DEFAULT_BLEND
+        blend_raw = _as_dict(payload.get("blend")) or dict(DEFAULT_BLEND)
         blend = {
             "intrinsic": max(0.0, min(1.0, _safe_float(blend_raw.get("intrinsic"), 0.75))),
             "market": 0.0,
         }
         blend["market"] = round(1.0 - blend["intrinsic"], 6)
-        year_weights_raw = payload.get("year_weights") or DEFAULT_YEAR_WEIGHTS
+        year_weights_raw = _as_dict(payload.get("year_weights"))
+        if not year_weights_raw:
+            year_weights_raw = dict(DEFAULT_YEAR_WEIGHTS)
         year_weights: dict[int, float] = {}
         for k, v in year_weights_raw.items():
             try:
@@ -138,7 +157,7 @@ class AnalysisSettings:
                 continue
         if not year_weights:
             year_weights = dict(DEFAULT_YEAR_WEIGHTS)
-        anchors = payload.get("anchor_ranks") or DEFAULT_ANCHOR_RANKS
+        anchors = _as_list(payload.get("anchor_ranks")) or list(DEFAULT_ANCHOR_RANKS)
         try:
             anchor_ranks = sorted({int(a) for a in anchors})
         except (TypeError, ValueError):

--- a/src/idp_calibration/lineup.py
+++ b/src/idp_calibration/lineup.py
@@ -1,0 +1,147 @@
+"""Parse a Sleeper league's roster_positions into lineup demand.
+
+The calibration lab uses this to compute effective replacement ranks
+for DL/LB/DB and to report an offense-vs-IDP demand summary so the
+reviewer can see how much of the league's starting XI is defense.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+# Sleeper slot tokens we recognise. Anything else lands in "other".
+OFFENSE_SLOTS = {"QB", "RB", "WR", "TE", "FLEX", "WRRB_FLEX", "REC_FLEX", "SUPER_FLEX"}
+IDP_DIRECT_SLOTS = {"DL", "LB", "DB"}
+IDP_FLEX_SLOTS = {"IDP_FLEX", "DB_LB", "DL_LB", "DL_DB", "DEF_FLEX", "IDP"}
+BENCH_SLOTS = {"BN", "BENCH", "IR", "TAXI"}
+SKIP_SLOTS = {"K", "DEF", "P"}
+
+
+@dataclass
+class LineupDemand:
+    league_id: str
+    season: int | None
+    team_count: int
+    starter_slots: dict[str, int] = field(default_factory=dict)
+    dl_starters: int = 0
+    lb_starters: int = 0
+    db_starters: int = 0
+    idp_flex_starters: int = 0
+    offense_starters: int = 0
+    bench_slots: int = 0
+
+    @property
+    def total_dl_demand(self) -> float:
+        return float(self.dl_starters) + self.idp_flex_starters / 3.0
+
+    @property
+    def total_lb_demand(self) -> float:
+        return float(self.lb_starters) + self.idp_flex_starters / 3.0
+
+    @property
+    def total_db_demand(self) -> float:
+        return float(self.db_starters) + self.idp_flex_starters / 3.0
+
+    def replacement_rank(self, position: str, mode: str, buffer_pct: float, manual: int | None) -> int:
+        """Return the rank index just past the last startable player.
+
+        * ``strict_starter``: team_count * positional demand, rounded up.
+        * ``starter_plus_buffer``: adds ``ceil(team_count * buffer_pct)``
+          to account for bye-week and injury depth.
+        * ``manual``: uses ``manual`` directly, coerced to ``>= 1``.
+        """
+        if mode == "manual" and manual is not None:
+            try:
+                return max(1, int(manual))
+            except (TypeError, ValueError):
+                pass
+
+        demand_lookup = {
+            "DL": self.total_dl_demand,
+            "LB": self.total_lb_demand,
+            "DB": self.total_db_demand,
+        }
+        demand = demand_lookup.get(position.upper(), 0.0)
+        base = int(round(self.team_count * demand))
+        base = max(base, 1)
+        if mode == "strict_starter":
+            return base
+        # starter_plus_buffer (default)
+        buf = max(1, int(round(self.team_count * max(0.0, buffer_pct))))
+        return base + buf
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "league_id": self.league_id,
+            "season": self.season,
+            "team_count": self.team_count,
+            "starter_slots": dict(self.starter_slots),
+            "dl_starters": self.dl_starters,
+            "lb_starters": self.lb_starters,
+            "db_starters": self.db_starters,
+            "idp_flex_starters": self.idp_flex_starters,
+            "offense_starters": self.offense_starters,
+            "bench_slots": self.bench_slots,
+            "total_dl_demand": self.total_dl_demand,
+            "total_lb_demand": self.total_lb_demand,
+            "total_db_demand": self.total_db_demand,
+        }
+
+
+def _count_teams(league: dict[str, Any]) -> int:
+    for key in ("total_rosters", "num_teams", "team_count"):
+        value = league.get(key)
+        try:
+            iv = int(value)
+            if iv > 0:
+                return iv
+        except (TypeError, ValueError):
+            continue
+    return 12  # Sleeper default; reported via warnings if we fall back.
+
+
+def parse_lineup(league: dict[str, Any] | None) -> LineupDemand:
+    if not isinstance(league, dict):
+        return LineupDemand(league_id="", season=None, team_count=0)
+    team_count = _count_teams(league)
+    season = None
+    try:
+        season = int(str(league.get("season") or "").strip())
+    except (TypeError, ValueError):
+        season = None
+
+    slots: Iterable[str] = league.get("roster_positions") or []
+    counts: dict[str, int] = {}
+    dl = lb = db = flex = offense = bench = 0
+    for raw in slots:
+        slot = str(raw or "").strip().upper()
+        if not slot:
+            continue
+        counts[slot] = counts.get(slot, 0) + 1
+        if slot in BENCH_SLOTS:
+            bench += 1
+            continue
+        if slot in SKIP_SLOTS:
+            continue
+        if slot == "DL":
+            dl += 1
+        elif slot == "LB":
+            lb += 1
+        elif slot == "DB":
+            db += 1
+        elif slot in IDP_FLEX_SLOTS:
+            flex += 1
+        elif slot in OFFENSE_SLOTS:
+            offense += 1
+    return LineupDemand(
+        league_id=str(league.get("league_id") or ""),
+        season=season,
+        team_count=team_count,
+        starter_slots=counts,
+        dl_starters=dl,
+        lb_starters=lb,
+        db_starters=db,
+        idp_flex_starters=flex,
+        offense_starters=offense,
+        bench_slots=bench,
+    )

--- a/src/idp_calibration/lineup.py
+++ b/src/idp_calibration/lineup.py
@@ -6,6 +6,7 @@ reviewer can see how much of the league's starting XI is defense.
 """
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Any, Iterable
 
@@ -62,12 +63,17 @@ class LineupDemand:
             "DB": self.total_db_demand,
         }
         demand = demand_lookup.get(position.upper(), 0.0)
-        base = int(round(self.team_count * demand))
+        # Ceiling, not round — a fractional IDP-flex demand like 13.33 must
+        # produce 14 so the replacement player sits *past* every possible
+        # starter slot. Rounding down would understate the starter pool and
+        # inflate VOR (and downstream multipliers) in leagues where
+        # team_count * demand isn't integer.
+        base = int(math.ceil(self.team_count * demand))
         base = max(base, 1)
         if mode == "strict_starter":
             return base
-        # starter_plus_buffer (default)
-        buf = max(1, int(round(self.team_count * max(0.0, buffer_pct))))
+        # starter_plus_buffer (default) — buffer also ceils for symmetry.
+        buf = max(1, int(math.ceil(self.team_count * max(0.0, buffer_pct))))
         return base + buf
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -52,12 +52,41 @@ def load_production_config(base: Path | None = None) -> dict[str, Any] | None:
     return _load_if_stale(base)
 
 
+def _position_has_real_data(position_block: Any) -> bool:
+    """Bucket data is "real" only when at least one bucket has count > 0.
+
+    A buckets list of only zero-count entries is produced by a run that
+    failed to resolve any seasons — treating it as valid would cause the
+    anchor-floor fallback to fire for every rank. Guard at read time so
+    even an accidentally-promoted empty config is a strict no-op instead
+    of a silent 95% value cut.
+    """
+    if not isinstance(position_block, dict):
+        return False
+    buckets = position_block.get("buckets")
+    if isinstance(buckets, list):
+        for bucket in buckets:
+            try:
+                if int(bucket.get("count") or 0) > 0:
+                    return True
+            except (TypeError, ValueError):
+                continue
+        return False
+    # Flat {label: value} shape carries no count, so trust its presence.
+    return any(isinstance(k, str) and "-" in k for k in position_block.keys())
+
+
 def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: str) -> float:
     """Pick the right multiplier from the promoted config.
 
     Handles both of the shapes the storage layer emits: flat
     ``multipliers[position] = {label: value}`` and the richer
     ``multipliers[kind][position] = {...}``.
+
+    Returns ``1.0`` (identity) whenever the promoted config has no real
+    per-bucket data for ``position`` — this is the safety net that
+    prevents an empty-calibration promotion from cutting every IDP
+    value through the anchor floor.
     """
     position = position.upper()
     if position not in {"DL", "LB", "DB"}:
@@ -76,8 +105,13 @@ def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: s
     else:
         position_block = multipliers.get(position)
     if not isinstance(position_block, dict):
-        # Some shapes embed {"buckets": [...]}. Fall through to anchor lookup.
         position_block = None
+
+    if not _position_has_real_data(position_block):
+        # No real bucket data for this position ⇒ identity multiplier.
+        # Do NOT fall through to anchors — empty runs produce anchor
+        # curves floored at 0.05 which would silently cut IDP values.
+        return 1.0
 
     if isinstance(position_block, dict):
         buckets = position_block.get("buckets") if "buckets" in position_block else None
@@ -101,7 +135,9 @@ def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: s
             except (TypeError, ValueError):
                 continue
 
-    # Fall back to anchors if multipliers lookup failed.
+    # Past the last labelled bucket — use the anchor curve as a smooth
+    # tail now that we've confirmed real bucket data exists for this
+    # position upstream.
     anchors_block = (config.get("anchors") or {}).get(kind, {}).get(position)
     if isinstance(anchors_block, list):
         best_val = 1.0

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -1,0 +1,152 @@
+"""Read path for the promoted IDP calibration config.
+
+Exposes a single entry point — :func:`get_idp_bucket_multiplier` —
+used by the live valuation pipeline. Results are cached by file
+mtime so operational edits to ``config/idp_calibration.json`` take
+effect on the next request without a server restart.
+
+If no promoted config exists, every call returns ``1.0`` (identity
+multiplier) so the presence of this module is a strict no-op until
+an explicit promotion has occurred.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+from src.utils.config_loader import load_json
+
+from .promotion import production_config_path
+
+_lock = threading.Lock()
+_cache: dict[str, Any] = {"mtime": None, "config": None}
+
+
+def _load_if_stale(base: Path | None = None) -> dict[str, Any] | None:
+    path = production_config_path(base)
+    if not path.exists():
+        with _lock:
+            _cache["mtime"] = None
+            _cache["config"] = None
+        return None
+    mtime = path.stat().st_mtime
+    with _lock:
+        if _cache["mtime"] == mtime and _cache["config"] is not None:
+            return _cache["config"]
+        data = load_json(path)
+        _cache["mtime"] = mtime
+        _cache["config"] = data if isinstance(data, dict) else None
+        return _cache["config"]
+
+
+def reset_cache() -> None:
+    """Test hook — drop the in-memory cache."""
+    with _lock:
+        _cache["mtime"] = None
+        _cache["config"] = None
+
+
+def load_production_config(base: Path | None = None) -> dict[str, Any] | None:
+    """Public read: current promoted config, or ``None`` if absent."""
+    return _load_if_stale(base)
+
+
+def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: str) -> float:
+    """Pick the right multiplier from the promoted config.
+
+    Handles both of the shapes the storage layer emits: flat
+    ``multipliers[position] = {label: value}`` and the richer
+    ``multipliers[kind][position] = {...}``.
+    """
+    position = position.upper()
+    if position not in {"DL", "LB", "DB"}:
+        return 1.0
+    multipliers = config.get("multipliers") or {}
+
+    kind = {
+        "intrinsic_only": "intrinsic",
+        "market_only": "market",
+        "blended": "final",
+    }.get(mode, "final")
+
+    # Shape A: kind-first — multipliers[kind][position] = {label: value}
+    if kind in multipliers and isinstance(multipliers[kind], dict):
+        position_block = multipliers[kind].get(position)
+    else:
+        position_block = multipliers.get(position)
+    if not isinstance(position_block, dict):
+        # Some shapes embed {"buckets": [...]}. Fall through to anchor lookup.
+        position_block = None
+
+    if isinstance(position_block, dict):
+        buckets = position_block.get("buckets") if "buckets" in position_block else None
+        if isinstance(buckets, list):
+            for bucket in buckets:
+                try:
+                    lo, _, hi = str(bucket.get("label") or "").partition("-")
+                    if int(lo) <= int(rank) <= int(hi):
+                        val = bucket.get(kind)
+                        if val is None:
+                            val = bucket.get("final")
+                        return float(val) if val is not None else 1.0
+                except (TypeError, ValueError):
+                    continue
+        # flat { "1-6": 1.05, ... }
+        for label, value in position_block.items():
+            try:
+                lo, _, hi = str(label).partition("-")
+                if int(lo) <= int(rank) <= int(hi):
+                    return float(value)
+            except (TypeError, ValueError):
+                continue
+
+    # Fall back to anchors if multipliers lookup failed.
+    anchors_block = (config.get("anchors") or {}).get(kind, {}).get(position)
+    if isinstance(anchors_block, list):
+        best_val = 1.0
+        best_rank = -1
+        for point in anchors_block:
+            try:
+                ar = int(point.get("rank"))
+                if ar <= int(rank) and ar > best_rank:
+                    best_rank = ar
+                    best_val = float(point.get("value"))
+            except (TypeError, ValueError):
+                continue
+        return best_val
+    return 1.0
+
+
+def get_idp_bucket_multiplier(
+    position: str,
+    rank: int,
+    *,
+    mode: str | None = None,
+    base: Path | None = None,
+) -> float:
+    """Return the multiplier to apply to an IDP row.
+
+    * ``position`` must be ``DL``, ``LB``, or ``DB``. Anything else
+      returns 1.0.
+    * ``rank`` is the player's position-specific rank (1 = DL1 etc.).
+    * ``mode`` overrides the config's ``active_mode``. When ``None``
+      the config's own ``active_mode`` is used (default ``"blended"``).
+
+    Returns ``1.0`` whenever no promoted config exists so this is a
+    strict no-op for a freshly-cloned repo.
+    """
+    config = _load_if_stale(base)
+    if not config:
+        return 1.0
+    effective_mode = mode or str(config.get("active_mode") or "blended")
+    if effective_mode not in {"intrinsic_only", "market_only", "blended"}:
+        effective_mode = "blended"
+    try:
+        return float(_bucket_lookup_for(position, int(rank), config, effective_mode))
+    except Exception:
+        return 1.0
+
+
+def is_promoted(base: Path | None = None) -> bool:
+    return _load_if_stale(base) is not None

--- a/src/idp_calibration/promotion.py
+++ b/src/idp_calibration/promotion.py
@@ -1,0 +1,114 @@
+"""Manual promotion flow.
+
+Writes the approved calibration output from a saved run into
+``config/idp_calibration.json``. The prior production file (if any)
+is moved to ``config/idp_calibration.backups/{promoted_at}.json``
+before the new file is written, so promotion is always reversible.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.utils.config_loader import load_json, repo_root, save_json
+
+from .storage import load_run
+
+CONFIG_FILENAME = "idp_calibration.json"
+BACKUPS_DIR = "idp_calibration.backups"
+
+VALID_MODES: tuple[str, ...] = ("intrinsic_only", "market_only", "blended")
+
+
+def production_config_path(base: Path | None = None) -> Path:
+    return (base or repo_root()) / "config" / CONFIG_FILENAME
+
+
+def backups_dir(base: Path | None = None) -> Path:
+    return (base or repo_root()) / "config" / BACKUPS_DIR
+
+
+def _sanitize_ts(value: str) -> str:
+    return re.sub(r"[^0-9A-Za-z_-]", "_", value)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def build_production_config(
+    artifact: dict[str, Any],
+    *,
+    active_mode: str = "blended",
+    promoted_by: str = "internal",
+) -> dict[str, Any]:
+    """Shape a saved run artifact into the production config schema."""
+    if active_mode not in VALID_MODES:
+        raise ValueError(f"active_mode must be one of {VALID_MODES}, got {active_mode!r}")
+    settings = artifact.get("settings") or {}
+    inputs = artifact.get("inputs") or {}
+    return {
+        "version": 1,
+        "promoted_at": _utc_now_iso(),
+        "source_run_id": str(artifact.get("run_id") or ""),
+        "promoted_by": str(promoted_by or "internal"),
+        "league_ids": {
+            "test": inputs.get("test_league_id"),
+            "mine": inputs.get("my_league_id"),
+        },
+        "year_coverage": list(artifact.get("resolved_seasons") or []),
+        "blend_weights": dict(settings.get("blend") or {}),
+        "replacement_settings": dict(settings.get("replacement") or {}),
+        "active_mode": active_mode,
+        "bucket_edges": list(settings.get("bucket_edges") or []),
+        "multipliers": dict(artifact.get("multipliers") or {}),
+        "anchors": dict(artifact.get("anchors") or {}),
+    }
+
+
+def promote_run(
+    run_id: str,
+    *,
+    active_mode: str = "blended",
+    promoted_by: str = "internal",
+    base: Path | None = None,
+) -> dict[str, Any]:
+    """Promote ``run_id`` to production.
+
+    Returns a dict with ``{ok, promoted_at, config_path, backup_path}``.
+    Raises :class:`FileNotFoundError` when the run does not exist.
+    """
+    artifact = load_run(run_id, base=base)
+    if not artifact:
+        raise FileNotFoundError(f"Run {run_id!r} not found.")
+    cfg_path = production_config_path(base)
+    backup_path: str | None = None
+    if cfg_path.exists():
+        backup_dir = backups_dir(base)
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        ts = _sanitize_ts(_utc_now_iso())
+        backup_target = backup_dir / f"{ts}.json"
+        prior = load_json(cfg_path)
+        if prior is not None:
+            save_json(backup_target, prior)
+            backup_path = str(backup_target)
+    production = build_production_config(
+        artifact, active_mode=active_mode, promoted_by=promoted_by
+    )
+    save_json(cfg_path, production)
+    return {
+        "ok": True,
+        "promoted_at": production["promoted_at"],
+        "config_path": str(cfg_path),
+        "backup_path": backup_path,
+        "source_run_id": production["source_run_id"],
+        "active_mode": production["active_mode"],
+    }
+
+
+def load_production(base: Path | None = None) -> dict[str, Any] | None:
+    """Return the current production config or ``None`` if unset."""
+    data = load_json(production_config_path(base))
+    return data if isinstance(data, dict) else None

--- a/src/idp_calibration/promotion.py
+++ b/src/idp_calibration/promotion.py
@@ -22,6 +22,17 @@ BACKUPS_DIR = "idp_calibration.backups"
 VALID_MODES: tuple[str, ...] = ("intrinsic_only", "market_only", "blended")
 
 
+class EmptyCalibrationError(ValueError):
+    """Raised when a run has no usable per-bucket multiplier data.
+
+    Promoting such a run would make :func:`production.get_idp_bucket_multiplier`
+    fall through to the anchor curve, which is floored at ``anchor_floor``
+    (default ``0.05``) and would silently cut every IDP value in the live
+    calculator by ~95%. The calibration lab must reject these promotions
+    at the gate rather than ship a quiet regression.
+    """
+
+
 def production_config_path(base: Path | None = None) -> Path:
     return (base or repo_root()) / "config" / CONFIG_FILENAME
 
@@ -38,6 +49,26 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _has_usable_bucket_data(artifact: dict[str, Any]) -> bool:
+    """Return ``True`` when at least one DL/LB/DB bucket has ``count > 0``.
+
+    Anchor curves alone are not enough — they can be produced from empty
+    bucket tables and default to the anchor floor, which is a dangerous
+    no-op. Bucket counts are the ground truth that real players backed
+    the multiplier.
+    """
+    multipliers = (artifact or {}).get("multipliers") or {}
+    for pos in ("DL", "LB", "DB"):
+        buckets = (multipliers.get(pos) or {}).get("buckets") or []
+        for bucket in buckets:
+            try:
+                if int(bucket.get("count") or 0) > 0:
+                    return True
+            except (TypeError, ValueError):
+                continue
+    return False
+
+
 def build_production_config(
     artifact: dict[str, Any],
     *,
@@ -47,6 +78,12 @@ def build_production_config(
     """Shape a saved run artifact into the production config schema."""
     if active_mode not in VALID_MODES:
         raise ValueError(f"active_mode must be one of {VALID_MODES}, got {active_mode!r}")
+    if not _has_usable_bucket_data(artifact):
+        raise EmptyCalibrationError(
+            "Run has no resolved seasons with per-bucket IDP data; refusing "
+            "to promote because the live pipeline would fall through to the "
+            "anchor floor and cut every IDP value by ~95%.",
+        )
     settings = artifact.get("settings") or {}
     inputs = artifact.get("inputs") or {}
     return {

--- a/src/idp_calibration/replacement.py
+++ b/src/idp_calibration/replacement.py
@@ -1,0 +1,108 @@
+"""Replacement-level calculations for the IDP calibration lab.
+
+Given a :class:`~src.idp_calibration.lineup.LineupDemand` and the
+already-scored players for a league/season, this module derives the
+effective replacement *rank* per position and interpolates the
+replacement *points* from the scored-player list.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from .lineup import LineupDemand
+
+POSITIONS: tuple[str, ...] = ("DL", "LB", "DB")
+
+MODES: tuple[str, ...] = ("strict_starter", "starter_plus_buffer", "manual")
+
+
+@dataclass
+class ReplacementSettings:
+    mode: str = "starter_plus_buffer"
+    buffer_pct: float = 0.15
+    manual: dict[str, int] = field(default_factory=dict)
+
+    def normalized(self) -> "ReplacementSettings":
+        mode = self.mode if self.mode in MODES else "starter_plus_buffer"
+        buf = max(0.0, min(1.0, float(self.buffer_pct or 0.0)))
+        manual = {str(k).upper(): int(v) for k, v in (self.manual or {}).items() if v}
+        return ReplacementSettings(mode=mode, buffer_pct=buf, manual=manual)
+
+
+@dataclass
+class ReplacementLevel:
+    position: str
+    replacement_rank: int
+    replacement_points: float
+    cohort_size: int
+    note: str = ""
+
+
+def compute_replacement_levels(
+    scored: Iterable[dict[str, Any]],
+    demand: LineupDemand,
+    settings: ReplacementSettings,
+) -> dict[str, ReplacementLevel]:
+    """Compute per-position replacement rank + points.
+
+    ``scored`` is an iterable of dicts with at least
+    ``{position, points}``. Within each position the list is sorted
+    descending by points, and the replacement point is taken as the
+    points at ``replacement_rank`` (1-indexed). If the cohort is
+    smaller than ``replacement_rank`` the last available player's
+    points are used and the ``note`` field reports the fallback.
+    """
+    settings = settings.normalized()
+    by_position: dict[str, list[float]] = {pos: [] for pos in POSITIONS}
+    for row in scored:
+        pos = str(row.get("position") or "").upper()
+        if pos not in by_position:
+            continue
+        try:
+            pts = float(row.get("points") or 0.0)
+        except (TypeError, ValueError):
+            pts = 0.0
+        by_position[pos].append(pts)
+    out: dict[str, ReplacementLevel] = {}
+    for pos in POSITIONS:
+        points_desc = sorted(by_position[pos], reverse=True)
+        rank = demand.replacement_rank(
+            pos,
+            settings.mode,
+            settings.buffer_pct,
+            settings.manual.get(pos),
+        )
+        cohort = len(points_desc)
+        note = ""
+        if cohort == 0:
+            repl_pts = 0.0
+            note = f"No scored {pos} players in this season; replacement = 0."
+        elif rank <= cohort:
+            repl_pts = points_desc[rank - 1]
+        else:
+            repl_pts = points_desc[-1]
+            note = (
+                f"Replacement rank {rank} exceeds cohort size {cohort}; "
+                f"falling back to the last-ranked player's points."
+            )
+        out[pos] = ReplacementLevel(
+            position=pos,
+            replacement_rank=rank,
+            replacement_points=float(repl_pts),
+            cohort_size=cohort,
+            note=note,
+        )
+    return out
+
+
+def replacement_to_dict(levels: dict[str, ReplacementLevel]) -> dict[str, Any]:
+    return {
+        pos: {
+            "replacement_rank": lv.replacement_rank,
+            "replacement_points": round(lv.replacement_points, 3),
+            "cohort_size": lv.cohort_size,
+            "note": lv.note,
+        }
+        for pos, lv in levels.items()
+    }

--- a/src/idp_calibration/scoring.py
+++ b/src/idp_calibration/scoring.py
@@ -1,0 +1,110 @@
+"""Extract and normalize a Sleeper league's scoring settings.
+
+Uses ``src.scoring.sleeper_ingest.KEY_ALIASES`` for the canonical
+stat-key mapping. The calibration math only cares about the IDP stat
+weights, but we preserve offensive weights too so a future offense
+calibration can share the same parsing path.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.scoring.sleeper_ingest import KEY_ALIASES
+
+# Canonical IDP stat keys the VOR engine knows how to score.
+IDP_STAT_KEYS: tuple[str, ...] = (
+    "idp_tkl_solo",
+    "idp_tkl_ast",
+    "idp_tkl_loss",
+    "idp_sack",
+    "idp_hit",
+    "idp_int",
+    "idp_pd",
+    "idp_ff",
+    "idp_fum_rec",
+    "idp_def_td",
+)
+
+
+@dataclass
+class LeagueScoring:
+    league_id: str
+    season: int | None
+    scoring_map: dict[str, float] = field(default_factory=dict)
+    idp_weights: dict[str, float] = field(default_factory=dict)
+    unknown_keys: dict[str, float] = field(default_factory=dict)
+
+    def summary(self) -> dict[str, Any]:
+        present_idp = {k: v for k, v in self.idp_weights.items() if abs(v) > 0.0}
+        return {
+            "league_id": self.league_id,
+            "season": self.season,
+            "active_idp_stats": present_idp,
+            "inactive_idp_stats": sorted(
+                k for k in IDP_STAT_KEYS if abs(self.idp_weights.get(k, 0.0)) < 1e-9
+            ),
+            "unknown_key_count": len(self.unknown_keys),
+        }
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_scoring(league: dict[str, Any] | None) -> LeagueScoring:
+    if not isinstance(league, dict):
+        return LeagueScoring(league_id="", season=None)
+    raw = league.get("scoring_settings") or {}
+    scoring_map: dict[str, float] = {}
+    unknown: dict[str, float] = {}
+    if isinstance(raw, dict):
+        for key, val in raw.items():
+            fv = _to_float(val)
+            if fv is None:
+                continue
+            canonical = KEY_ALIASES.get(str(key).strip())
+            if canonical:
+                # Keep the strongest non-zero weight if duplicates resolve to the
+                # same canonical key (e.g. ``idp_solo`` vs ``idp_tkl_solo``).
+                prior = scoring_map.get(canonical, 0.0)
+                if abs(fv) >= abs(prior):
+                    scoring_map[canonical] = fv
+            else:
+                unknown[str(key).strip()] = fv
+    season = None
+    try:
+        season = int(str(league.get("season") or "").strip())
+    except (TypeError, ValueError):
+        season = None
+    idp_weights = {k: float(scoring_map.get(k, 0.0)) for k in IDP_STAT_KEYS}
+    return LeagueScoring(
+        league_id=str(league.get("league_id") or ""),
+        season=season,
+        scoring_map=scoring_map,
+        idp_weights=idp_weights,
+        unknown_keys=unknown,
+    )
+
+
+def score_line(stat_line: dict[str, Any], weights: dict[str, float]) -> float:
+    """Dot-product a normalized stat line against IDP weights.
+
+    ``stat_line`` is expected to be keyed by canonical stat names (same
+    alias set as ``KEY_ALIASES`` values). Missing keys contribute 0.
+    """
+    total = 0.0
+    if not stat_line or not weights:
+        return 0.0
+    for key, weight in weights.items():
+        raw = stat_line.get(key)
+        if raw is None:
+            continue
+        try:
+            total += float(raw) * float(weight)
+        except (TypeError, ValueError):
+            continue
+    return total

--- a/src/idp_calibration/season_chain.py
+++ b/src/idp_calibration/season_chain.py
@@ -1,0 +1,130 @@
+"""Resolve each input league to a per-season league object.
+
+Target seasons default to ``[2022, 2023, 2024, 2025]``. Every season
+that cannot be resolved is reported as a warning — the tool must
+never silently substitute the wrong year.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable
+
+from .sleeper_client import fetch_league_chain
+
+DEFAULT_SEASONS: tuple[int, ...] = (2022, 2023, 2024, 2025)
+
+
+@dataclass
+class SeasonResolution:
+    season: int
+    league_id: str | None
+    league: dict[str, Any] | None
+    resolved: bool
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "season": self.season,
+            "league_id": self.league_id,
+            "league_name": (self.league or {}).get("name") if self.league else None,
+            "resolved": self.resolved,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class LeagueChain:
+    input_league_id: str
+    walk: list[dict[str, Any]] = field(default_factory=list)
+    seasons: dict[int, SeasonResolution] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "input_league_id": self.input_league_id,
+            "chain": [
+                {
+                    "league_id": node.get("league_id"),
+                    "season": _coerce_season(node.get("season")),
+                    "name": node.get("name"),
+                    "previous_league_id": node.get("previous_league_id"),
+                }
+                for node in self.walk
+            ],
+            "seasons": {str(s): res.to_dict() for s, res in self.seasons.items()},
+            "warnings": list(self.warnings),
+        }
+
+
+def _coerce_season(value: Any) -> int | None:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve_seasons(
+    league_id: str,
+    *,
+    seasons: Iterable[int] = DEFAULT_SEASONS,
+    max_hops: int = 10,
+    chain_fetcher: Callable[[str, int], list[dict[str, Any]]] | None = None,
+) -> LeagueChain:
+    """Walk a Sleeper league back through ``previous_league_id``.
+
+    Each target season is matched against the league ``season`` field
+    emitted by Sleeper. A season with no matching league is recorded
+    with ``resolved=False`` and a user-visible reason.
+    """
+    fetcher = chain_fetcher or fetch_league_chain
+    chain = LeagueChain(input_league_id=str(league_id or "").strip())
+    if not chain.input_league_id:
+        chain.warnings.append("Empty league ID supplied.")
+        for season in seasons:
+            chain.seasons[int(season)] = SeasonResolution(
+                season=int(season),
+                league_id=None,
+                league=None,
+                resolved=False,
+                reason="No league ID supplied.",
+            )
+        return chain
+
+    walk = fetcher(chain.input_league_id, max_hops)
+    chain.walk = list(walk)
+    if not walk:
+        chain.warnings.append(
+            f"Could not fetch league {chain.input_league_id} from Sleeper."
+        )
+
+    by_season: dict[int, dict[str, Any]] = {}
+    for node in walk:
+        season = _coerce_season(node.get("season"))
+        if season is None:
+            continue
+        by_season.setdefault(season, node)
+
+    for season in sorted({int(s) for s in seasons}):
+        node = by_season.get(season)
+        if node is None:
+            chain.seasons[season] = SeasonResolution(
+                season=season,
+                league_id=None,
+                league=None,
+                resolved=False,
+                reason=(
+                    f"Season {season} not found in previous_league_id chain for "
+                    f"{chain.input_league_id}."
+                ),
+            )
+            chain.warnings.append(
+                f"Missing season {season} for league {chain.input_league_id}."
+            )
+            continue
+        chain.seasons[season] = SeasonResolution(
+            season=season,
+            league_id=str(node.get("league_id") or ""),
+            league=node,
+            resolved=True,
+        )
+    return chain

--- a/src/idp_calibration/sleeper_client.py
+++ b/src/idp_calibration/sleeper_client.py
@@ -1,0 +1,54 @@
+"""Sleeper HTTP helpers for the IDP calibration lab.
+
+Wraps the existing public-pipeline client at
+``src/public_league/sleeper_client.py`` so we reuse its pooled session,
+graceful-degradation behaviour, and cached NFL player map. The
+calibration lab needs a deeper history than the public snapshot (4
+seasons vs 3), so ``fetch_league_chain`` exposes a configurable cap.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from src.public_league.sleeper_client import (
+    fetch_league,
+    fetch_nfl_players,
+    fetch_rosters,
+    fetch_users,
+)
+
+__all__ = [
+    "fetch_league",
+    "fetch_nfl_players",
+    "fetch_rosters",
+    "fetch_users",
+    "fetch_league_chain",
+]
+
+
+def fetch_league_chain(
+    start_league_id: str, max_seasons: int = 8
+) -> list[dict[str, Any]]:
+    """Walk ``previous_league_id`` links starting from ``start_league_id``.
+
+    Unlike ``src.public_league.sleeper_client.walk_league_chain`` this
+    variant allows a deeper horizon so the calibration lab can reach
+    the 2022 season even when the public-pipeline horizon is shorter.
+    Returns league objects ordered newest -> oldest. Stops on the
+    first missing league (no silent year substitution). Safe against
+    circular ``previous_league_id`` references.
+    """
+    if max_seasons <= 0:
+        return []
+    chain: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    cur = str(start_league_id or "").strip()
+    while cur and cur not in seen and len(chain) < max_seasons:
+        seen.add(cur)
+        league = fetch_league(cur)
+        if not league:
+            break
+        chain.append(league)
+        nxt = league.get("previous_league_id") or league.get("previous_league") or ""
+        cur = str(nxt or "").strip()
+    return chain

--- a/src/idp_calibration/stats_adapter.py
+++ b/src/idp_calibration/stats_adapter.py
@@ -1,0 +1,328 @@
+"""Historical stats adapter layer for the IDP calibration lab.
+
+The lab must remain working even if Sleeper's historical stats
+endpoints are inconsistent. The adapter interface accepts a season
+and returns ``list[PlayerSeason]`` — raw, un-scored stat lines keyed
+by canonical stat names. The rest of the math layer depends on this
+shape only.
+
+Adapters:
+
+* :class:`SleeperStatsAdapter` — probes
+  ``https://api.sleeper.app/v1/stats/nfl/regular/{season}``. Raises
+  :class:`AdapterUnavailable` on any HTTP/parse failure.
+* :class:`LocalCSVStatsAdapter` — reads
+  ``data/idp_calibration/stats/{season}.csv`` if present. The CSV is
+  expected to have a header with ``player_id``, ``name``, ``position``,
+  ``games``, and one column per canonical IDP stat.
+* :class:`ManualFallbackAdapter` — returns an empty list and attaches
+  a ``reason`` explaining that no stats source was reachable. The
+  engine surfaces this loudly.
+
+:func:`get_stats_adapter` picks the first adapter that can serve a
+given season, preferring network -> local -> manual. The caller may
+override the preference order by passing ``order=[...]``.
+"""
+from __future__ import annotations
+
+import csv
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from src.utils.config_loader import repo_root
+
+log = logging.getLogger(__name__)
+
+
+class AdapterUnavailable(RuntimeError):
+    """Raised when an adapter cannot serve a given season."""
+
+
+@dataclass
+class PlayerSeason:
+    player_id: str
+    name: str
+    position: str  # Canonical DL/LB/DB/OFF
+    games: int = 0
+    stats: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "player_id": self.player_id,
+            "name": self.name,
+            "position": self.position,
+            "games": self.games,
+            "stats": dict(self.stats),
+        }
+
+
+class HistoricalStatsAdapter:
+    """Abstract interface."""
+
+    name = "abstract"
+
+    def fetch(self, season: int) -> list[PlayerSeason]:
+        raise NotImplementedError
+
+    def available(self, season: int) -> bool:
+        try:
+            self.fetch(season)
+            return True
+        except AdapterUnavailable:
+            return False
+
+
+class SleeperStatsAdapter(HistoricalStatsAdapter):
+    """Probe Sleeper's historical stats endpoint.
+
+    Sleeper publishes (undocumented) season aggregates at
+    ``/v1/stats/nfl/regular/{season}``. When the endpoint is
+    reachable the payload is a dict keyed by player_id with per-stat
+    counts under names that closely match our canonical set (e.g.
+    ``idp_tkl_solo``, ``idp_sack``). We only consume IDP stats.
+    """
+
+    name = "sleeper"
+    base_url = "https://api.sleeper.app/v1/stats/nfl/regular"
+
+    def __init__(self, players_map: dict[str, Any] | None = None) -> None:
+        self._players_map = players_map
+
+    def _resolve_players_map(self) -> dict[str, Any]:
+        if self._players_map is not None:
+            return self._players_map
+        try:
+            from .sleeper_client import fetch_nfl_players
+
+            self._players_map = fetch_nfl_players() or {}
+        except Exception as exc:  # noqa: BLE001
+            log.warning("SleeperStatsAdapter: player map unavailable: %s", exc)
+            self._players_map = {}
+        return self._players_map
+
+    def fetch(self, season: int) -> list[PlayerSeason]:
+        try:
+            import requests
+        except ImportError as exc:
+            raise AdapterUnavailable(f"requests library not available: {exc}")
+        url = f"{self.base_url}/{int(season)}"
+        try:
+            resp = requests.get(url, timeout=10)
+        except Exception as exc:  # noqa: BLE001
+            raise AdapterUnavailable(f"Sleeper stats HTTP failure for {season}: {exc}")
+        if resp.status_code != 200:
+            raise AdapterUnavailable(
+                f"Sleeper stats returned HTTP {resp.status_code} for {season}"
+            )
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise AdapterUnavailable(f"Sleeper stats payload parse failed for {season}: {exc}")
+        if not isinstance(payload, dict) or not payload:
+            raise AdapterUnavailable(
+                f"Sleeper stats payload empty or unexpected shape for {season}"
+            )
+        players_map = self._resolve_players_map()
+        out: list[PlayerSeason] = []
+        for pid, stats in payload.items():
+            if not isinstance(stats, dict):
+                continue
+            meta = players_map.get(str(pid)) or {}
+            pos_raw = str(meta.get("position") or "").upper()
+            canonical = _canonical_position(pos_raw)
+            if canonical not in {"DL", "LB", "DB"}:
+                continue
+            games = _coerce_int(stats.get("gp") or stats.get("games") or 0)
+            scored: dict[str, float] = {}
+            for key in (
+                "idp_tkl_solo",
+                "idp_tkl_ast",
+                "idp_tkl_loss",
+                "idp_sack",
+                "idp_hit",
+                "idp_int",
+                "idp_pd",
+                "idp_ff",
+                "idp_fum_rec",
+                "idp_def_td",
+            ):
+                val = _coerce_float(stats.get(key))
+                if val is not None:
+                    scored[key] = val
+            out.append(
+                PlayerSeason(
+                    player_id=str(pid),
+                    name=str(meta.get("full_name") or meta.get("first_name") or pid),
+                    position=canonical,
+                    games=games,
+                    stats=scored,
+                )
+            )
+        if not out:
+            raise AdapterUnavailable(
+                f"Sleeper stats for {season} contained zero IDP rows."
+            )
+        return out
+
+
+class LocalCSVStatsAdapter(HistoricalStatsAdapter):
+    """Read season stats from ``data/idp_calibration/stats/{season}.csv``.
+
+    The CSV header must include ``player_id``, ``name``, ``position`` and
+    any subset of the canonical IDP stat columns. Extra columns are
+    ignored. ``games`` is optional.
+    """
+
+    name = "local_csv"
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base_dir = base_dir or (
+            repo_root() / "data" / "idp_calibration" / "stats"
+        )
+
+    def _path(self, season: int) -> Path:
+        return self._base_dir / f"{int(season)}.csv"
+
+    def fetch(self, season: int) -> list[PlayerSeason]:
+        path = self._path(season)
+        if not path.exists():
+            raise AdapterUnavailable(f"No local stats CSV at {path}")
+        out: list[PlayerSeason] = []
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                reader = csv.DictReader(handle)
+                for row in reader:
+                    pid = str(row.get("player_id") or "").strip()
+                    if not pid:
+                        continue
+                    pos = _canonical_position(str(row.get("position") or "").upper())
+                    if pos not in {"DL", "LB", "DB"}:
+                        continue
+                    stats: dict[str, float] = {}
+                    for key in (
+                        "idp_tkl_solo",
+                        "idp_tkl_ast",
+                        "idp_tkl_loss",
+                        "idp_sack",
+                        "idp_hit",
+                        "idp_int",
+                        "idp_pd",
+                        "idp_ff",
+                        "idp_fum_rec",
+                        "idp_def_td",
+                    ):
+                        val = _coerce_float(row.get(key))
+                        if val is not None:
+                            stats[key] = val
+                    out.append(
+                        PlayerSeason(
+                            player_id=pid,
+                            name=str(row.get("name") or pid),
+                            position=pos,
+                            games=_coerce_int(row.get("games") or 0),
+                            stats=stats,
+                        )
+                    )
+        except OSError as exc:
+            raise AdapterUnavailable(f"Failed reading {path}: {exc}") from exc
+        if not out:
+            raise AdapterUnavailable(f"Local CSV at {path} contained no IDP rows.")
+        return out
+
+
+class ManualFallbackAdapter(HistoricalStatsAdapter):
+    """No-op adapter that exposes a clear reason.
+
+    Returned by :func:`get_stats_adapter` only when no real adapter
+    can serve the season. The engine surfaces this loudly in the
+    ``warnings`` block so the reviewer cannot miss it.
+    """
+
+    name = "manual_fallback"
+
+    def __init__(self, reason: str = "No stats adapter available.") -> None:
+        self.reason = reason
+
+    def fetch(self, season: int) -> list[PlayerSeason]:
+        return []
+
+    def available(self, season: int) -> bool:
+        return True
+
+
+_ADAPTER_ORDER = ("sleeper", "local_csv", "manual_fallback")
+
+
+def get_stats_adapter(
+    season: int,
+    *,
+    order: Iterable[str] | None = None,
+    allow_network: bool | None = None,
+) -> tuple[HistoricalStatsAdapter, list[str]]:
+    """Return the first available adapter for ``season``.
+
+    ``allow_network`` defaults to the ``IDP_CALIBRATION_ALLOW_NETWORK``
+    environment variable (``"1"`` / ``"true"`` enables; anything else
+    disables). In test and CI environments network access is disabled
+    by default so ``SleeperStatsAdapter`` is skipped unless explicitly
+    allowed.
+    """
+    if allow_network is None:
+        env_val = str(os.getenv("IDP_CALIBRATION_ALLOW_NETWORK", "")).strip().lower()
+        allow_network = env_val in {"1", "true", "yes", "on"}
+    attempted: list[str] = []
+    for name in order or _ADAPTER_ORDER:
+        if name == "sleeper":
+            if not allow_network:
+                attempted.append("sleeper:skipped (network disabled)")
+                continue
+            adapter = SleeperStatsAdapter()
+        elif name == "local_csv":
+            adapter = LocalCSVStatsAdapter()
+        elif name == "manual_fallback":
+            adapter = ManualFallbackAdapter()
+        else:
+            continue
+        try:
+            if adapter.available(season):
+                attempted.append(f"{name}:ok")
+                return adapter, attempted
+            attempted.append(f"{name}:unavailable")
+        except AdapterUnavailable as exc:
+            attempted.append(f"{name}:{exc}")
+    return (
+        ManualFallbackAdapter(
+            reason=f"All adapters unavailable for {season}. Tried: {attempted}"
+        ),
+        attempted,
+    )
+
+
+def _canonical_position(pos: str) -> str:
+    pos = (pos or "").strip().upper()
+    if pos in {"DE", "DT", "EDGE", "NT", "DL"}:
+        return "DL"
+    if pos in {"ILB", "OLB", "MLB", "LB"}:
+        return "LB"
+    if pos in {"CB", "S", "SS", "FS", "DB"}:
+        return "DB"
+    return pos
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0

--- a/src/idp_calibration/stats_adapter.py
+++ b/src/idp_calibration/stats_adapter.py
@@ -60,11 +60,31 @@ class PlayerSeason:
 
 
 class HistoricalStatsAdapter:
-    """Abstract interface."""
+    """Abstract interface.
+
+    Subclasses override :meth:`_fetch_impl`. :meth:`fetch` wraps it
+    with a per-season memo so the adapter-selection probe
+    (:func:`get_stats_adapter` calls :meth:`available` which calls
+    :meth:`fetch`) does not cause a second full fetch when
+    :func:`run_analysis` later asks for the same season's data. For
+    a 4-season default run against ``SleeperStatsAdapter`` that's
+    4 network calls instead of 8.
+    """
 
     name = "abstract"
 
+    def __init__(self) -> None:
+        self._cache: dict[int, list[PlayerSeason]] = {}
+
     def fetch(self, season: int) -> list[PlayerSeason]:
+        key = int(season)
+        if key in self._cache:
+            return self._cache[key]
+        rows = self._fetch_impl(key)
+        self._cache[key] = rows
+        return rows
+
+    def _fetch_impl(self, season: int) -> list[PlayerSeason]:
         raise NotImplementedError
 
     def available(self, season: int) -> bool:
@@ -89,6 +109,7 @@ class SleeperStatsAdapter(HistoricalStatsAdapter):
     base_url = "https://api.sleeper.app/v1/stats/nfl/regular"
 
     def __init__(self, players_map: dict[str, Any] | None = None) -> None:
+        super().__init__()
         self._players_map = players_map
 
     def _resolve_players_map(self) -> dict[str, Any]:
@@ -103,7 +124,7 @@ class SleeperStatsAdapter(HistoricalStatsAdapter):
             self._players_map = {}
         return self._players_map
 
-    def fetch(self, season: int) -> list[PlayerSeason]:
+    def _fetch_impl(self, season: int) -> list[PlayerSeason]:
         try:
             import requests
         except ImportError as exc:
@@ -179,6 +200,7 @@ class LocalCSVStatsAdapter(HistoricalStatsAdapter):
     name = "local_csv"
 
     def __init__(self, base_dir: Path | None = None) -> None:
+        super().__init__()
         self._base_dir = base_dir or (
             repo_root() / "data" / "idp_calibration" / "stats"
         )
@@ -186,7 +208,7 @@ class LocalCSVStatsAdapter(HistoricalStatsAdapter):
     def _path(self, season: int) -> Path:
         return self._base_dir / f"{int(season)}.csv"
 
-    def fetch(self, season: int) -> list[PlayerSeason]:
+    def _fetch_impl(self, season: int) -> list[PlayerSeason]:
         path = self._path(season)
         if not path.exists():
             raise AdapterUnavailable(f"No local stats CSV at {path}")
@@ -244,9 +266,10 @@ class ManualFallbackAdapter(HistoricalStatsAdapter):
     name = "manual_fallback"
 
     def __init__(self, reason: str = "No stats adapter available.") -> None:
+        super().__init__()
         self.reason = reason
 
-    def fetch(self, season: int) -> list[PlayerSeason]:
+    def _fetch_impl(self, season: int) -> list[PlayerSeason]:
         return []
 
     def available(self, season: int) -> bool:

--- a/src/idp_calibration/storage.py
+++ b/src/idp_calibration/storage.py
@@ -77,3 +77,42 @@ def get_latest(*, base: Path | None = None) -> dict[str, Any] | None:
     if not run_id:
         return None
     return load_run(run_id, base=base)
+
+
+def delete_run(run_id: str, *, base: Path | None = None) -> bool:
+    """Delete a saved run by id.
+
+    Returns ``True`` if a file was removed, ``False`` if none existed.
+    If the deleted run was the current ``latest.json`` target the
+    pointer is rewritten to reference the next most-recent surviving
+    run (or cleared if nothing else remains). The promoted production
+    config is never touched — deletion of a run that has already been
+    promoted leaves ``config/idp_calibration.json`` in place.
+    """
+    run_id = str(run_id or "").strip()
+    if not run_id:
+        return False
+    runs_dir = _runs_dir(base)
+    target = runs_dir / f"{run_id}.json"
+    if not target.exists():
+        return False
+    target.unlink()
+
+    latest_pointer = load_json(_latest_path(base))
+    if (
+        isinstance(latest_pointer, dict)
+        and str(latest_pointer.get("run_id") or "").strip() == run_id
+    ):
+        surviving = sorted(runs_dir.glob("*.json"), reverse=True)
+        if surviving:
+            new_latest = load_json(surviving[0]) or {}
+            save_json(
+                _latest_path(base),
+                {
+                    "run_id": new_latest.get("run_id"),
+                    "path": str(surviving[0]),
+                },
+            )
+        else:
+            _latest_path(base).unlink(missing_ok=True)
+    return True

--- a/src/idp_calibration/storage.py
+++ b/src/idp_calibration/storage.py
@@ -1,0 +1,79 @@
+"""Persistence of calibration runs.
+
+Runs live under ``data/idp_calibration/runs/{run_id}.json`` and a
+``latest.json`` pointer sits alongside. Uses the shared
+``src.utils.config_loader`` helpers so filesystem behaviour matches
+the rest of the repo.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.utils.config_loader import load_json, repo_root, save_json
+
+
+def _runs_dir(base: Path | None = None) -> Path:
+    root = base or repo_root()
+    return root / "data" / "idp_calibration" / "runs"
+
+
+def _latest_path(base: Path | None = None) -> Path:
+    root = base or repo_root()
+    return root / "data" / "idp_calibration" / "latest.json"
+
+
+def save_run(artifact: dict[str, Any], *, base: Path | None = None) -> str:
+    """Persist ``artifact`` and update the ``latest.json`` pointer.
+
+    Returns the saved run's ``run_id``.
+    """
+    run_id = str(artifact.get("run_id") or "").strip()
+    if not run_id:
+        raise ValueError("Artifact is missing run_id")
+    runs_dir = _runs_dir(base)
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    target = runs_dir / f"{run_id}.json"
+    save_json(target, artifact)
+    save_json(_latest_path(base), {"run_id": run_id, "path": str(target)})
+    return run_id
+
+
+def load_run(run_id: str, *, base: Path | None = None) -> dict[str, Any] | None:
+    runs_dir = _runs_dir(base)
+    target = runs_dir / f"{run_id}.json"
+    if not target.exists():
+        return None
+    return load_json(target)
+
+
+def list_runs(*, base: Path | None = None, limit: int = 50) -> list[dict[str, Any]]:
+    runs_dir = _runs_dir(base)
+    if not runs_dir.exists():
+        return []
+    files = sorted(runs_dir.glob("*.json"), reverse=True)
+    summaries: list[dict[str, Any]] = []
+    for path in files[:limit]:
+        data = load_json(path) or {}
+        summaries.append(
+            {
+                "run_id": data.get("run_id"),
+                "generated_at": data.get("generated_at"),
+                "test_league_id": (data.get("inputs") or {}).get("test_league_id"),
+                "my_league_id": (data.get("inputs") or {}).get("my_league_id"),
+                "resolved_seasons": data.get("resolved_seasons") or [],
+                "warning_count": len(data.get("warnings") or []),
+                "path": str(path),
+            }
+        )
+    return summaries
+
+
+def get_latest(*, base: Path | None = None) -> dict[str, Any] | None:
+    pointer = load_json(_latest_path(base))
+    if not isinstance(pointer, dict):
+        return None
+    run_id = str(pointer.get("run_id") or "").strip()
+    if not run_id:
+        return None
+    return load_run(run_id, base=base)

--- a/src/idp_calibration/translation.py
+++ b/src/idp_calibration/translation.py
@@ -234,11 +234,21 @@ def normalise_year_weights(
     Used by the engine before calling into :func:`compute_position_multipliers`
     so a season that failed to resolve doesn't silently inflate the
     other years.
+
+    If every supplied season has zero/missing weight (e.g. the user
+    selected seasons outside the default weight keys like 2021 / 2020),
+    fall back to **uniform** weights across the supplied seasons. An
+    all-zero return here would collapse every bucket center to zero and
+    produce a silent no-op calibration — uniform is the honest choice.
     """
     if not weights:
         weights = DEFAULT_YEAR_WEIGHTS
     filt = {int(s): float(weights.get(int(s), 0.0)) for s in seasons}
+    if not filt:
+        return {}
     total = sum(v for v in filt.values() if v > 0)
     if total <= 0:
-        return {s: 0.0 for s in filt}
+        n = len(filt)
+        uniform = 1.0 / n
+        return {s: uniform for s in filt}
     return {s: w / total for s, w in filt.items()}

--- a/src/idp_calibration/translation.py
+++ b/src/idp_calibration/translation.py
@@ -1,0 +1,229 @@
+"""Intrinsic / market / final multiplier math.
+
+Converts per-season bucket centers into per-bucket multipliers:
+
+* **Intrinsic** — "what my-league scoring + my-league lineup economics
+  say this bucket is worth". Normalised against the top bucket so
+  the top bucket in each position has multiplier 1.0.
+* **Market** — same recipe but using the test-league centers. This
+  is treated as a prior, not ground truth.
+* **Final** — convex blend ``alpha * intrinsic + (1 - alpha) * market``.
+
+Multi-year weighting folds per-season buckets into a single table by
+applying recency weights and skipping missing seasons.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from .buckets import BucketResult
+
+DEFAULT_YEAR_WEIGHTS: dict[int, float] = {
+    2025: 0.40,
+    2024: 0.30,
+    2023: 0.20,
+    2022: 0.10,
+}
+
+DEFAULT_BLEND: dict[str, float] = {"intrinsic": 0.75, "market": 0.25}
+
+
+@dataclass
+class BucketMultipliers:
+    label: str
+    intrinsic: float
+    market: float
+    final: float
+    count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "intrinsic": round(self.intrinsic, 4),
+            "market": round(self.market, 4),
+            "final": round(self.final, 4),
+            "count": int(self.count),
+        }
+
+
+@dataclass
+class PositionMultipliers:
+    position: str
+    buckets: list[BucketMultipliers] = field(default_factory=list)
+
+    def by_label(self, kind: str = "final") -> dict[str, float]:
+        return {b.label: getattr(b, kind) for b in self.buckets}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "buckets": [b.to_dict() for b in self.buckets],
+        }
+
+
+def _weighted_center(
+    year_to_center: dict[int, float],
+    year_weights: dict[int, float],
+) -> tuple[float, float]:
+    """Return (weighted_value, sum_of_weights_used).
+
+    Only seasons present in ``year_to_center`` contribute weight. If
+    all weights are zero the function returns (0.0, 0.0).
+    """
+    total_val = 0.0
+    total_w = 0.0
+    for year, center in year_to_center.items():
+        w = float(year_weights.get(int(year), 0.0))
+        if w <= 0:
+            continue
+        total_val += float(center) * w
+        total_w += w
+    if total_w <= 0:
+        return 0.0, 0.0
+    return total_val / total_w, total_w
+
+
+def _normalise(values: list[float]) -> list[float]:
+    """Normalise so the top (first) bucket equals 1.0.
+
+    If the top bucket is zero we fall back to the max abs value; if
+    everything is zero we return 1.0s so downstream code doesn't get
+    divide-by-zero.
+    """
+    if not values:
+        return []
+    anchor = values[0]
+    if abs(anchor) < 1e-9:
+        anchor = max((abs(v) for v in values), default=0.0)
+    if abs(anchor) < 1e-9:
+        return [1.0 for _ in values]
+    return [v / anchor for v in values]
+
+
+def _collect_year_centers(
+    per_season: dict[int, list[BucketResult]],
+    label: str,
+    field_name: str,
+) -> dict[int, float]:
+    out: dict[int, float] = {}
+    for year, buckets in per_season.items():
+        for bucket in buckets:
+            if bucket.label == label:
+                out[int(year)] = float(getattr(bucket, field_name))
+                break
+    return out
+
+
+def _bucket_labels(per_season: dict[int, list[BucketResult]]) -> list[str]:
+    for buckets in per_season.values():
+        return [b.label for b in buckets]
+    return []
+
+
+def compute_position_multipliers(
+    per_season: dict[int, list[BucketResult]],
+    *,
+    year_weights: dict[int, float] | None = None,
+    blend: dict[str, float] | None = None,
+) -> PositionMultipliers:
+    """Combine per-season bucket tables into per-bucket multipliers."""
+    year_weights = year_weights or DEFAULT_YEAR_WEIGHTS
+    blend = blend or DEFAULT_BLEND
+    labels = _bucket_labels(per_season)
+    intrinsic_raw: list[float] = []
+    market_raw: list[float] = []
+    counts: list[int] = []
+    for label in labels:
+        mine_centers = _collect_year_centers(per_season, label, "center_vor_mine")
+        test_centers = _collect_year_centers(per_season, label, "center_vor_test")
+        mine_val, _ = _weighted_center(mine_centers, year_weights)
+        test_val, _ = _weighted_center(test_centers, year_weights)
+        intrinsic_raw.append(mine_val)
+        market_raw.append(test_val)
+        total_count = 0
+        for buckets in per_season.values():
+            for b in buckets:
+                if b.label == label:
+                    total_count += int(b.count)
+                    break
+        counts.append(total_count)
+    intrinsic_norm = _enforce_descending(_normalise(intrinsic_raw))
+    market_norm = _enforce_descending(_normalise(market_raw))
+    alpha = float(blend.get("intrinsic", 0.75))
+    beta = 1.0 - alpha
+    final_norm = _enforce_descending(
+        [alpha * i + beta * m for i, m in zip(intrinsic_norm, market_norm)]
+    )
+    buckets = [
+        BucketMultipliers(
+            label=lbl,
+            intrinsic=intrinsic_norm[i],
+            market=market_norm[i],
+            final=final_norm[i],
+            count=counts[i],
+        )
+        for i, lbl in enumerate(labels)
+    ]
+    return PositionMultipliers(position="", buckets=buckets)
+
+
+def _enforce_descending(values: list[float]) -> list[float]:
+    """Clamp a list so each element is <= the previous one.
+
+    This prevents calibration noise from producing a bucket that is
+    worth *more* than a higher-ranked bucket. We only enforce a soft
+    non-increasing pass — equal values are allowed so small genuine
+    plateaus (e.g. mid-tier depth) survive.
+    """
+    out: list[float] = []
+    for i, v in enumerate(values):
+        if i == 0:
+            out.append(v)
+            continue
+        prev = out[-1]
+        out.append(min(v, prev))
+    return out
+
+
+def build_multi_year_multipliers(
+    per_season_per_position: dict[str, dict[int, list[BucketResult]]],
+    *,
+    year_weights: dict[int, float] | None = None,
+    blend: dict[str, float] | None = None,
+) -> dict[str, PositionMultipliers]:
+    """Produce intrinsic/market/final multiplier tables for DL/LB/DB."""
+    out: dict[str, PositionMultipliers] = {}
+    for position, per_season in per_season_per_position.items():
+        result = compute_position_multipliers(
+            per_season, year_weights=year_weights, blend=blend
+        )
+        result.position = position
+        out[position] = result
+    return out
+
+
+def multipliers_to_dict(
+    multipliers: dict[str, PositionMultipliers],
+) -> dict[str, Any]:
+    return {pos: pm.to_dict() for pos, pm in multipliers.items()}
+
+
+def normalise_year_weights(
+    weights: dict[int, float] | None,
+    *,
+    seasons: Iterable[int],
+) -> dict[int, float]:
+    """Restrict weights to the supplied seasons and renormalise.
+
+    Used by the engine before calling into :func:`compute_position_multipliers`
+    so a season that failed to resolve doesn't silently inflate the
+    other years.
+    """
+    if not weights:
+        weights = DEFAULT_YEAR_WEIGHTS
+    filt = {int(s): float(weights.get(int(s), 0.0)) for s in seasons}
+    total = sum(v for v in filt.values() if v > 0)
+    if total <= 0:
+        return {s: 0.0 for s in filt}
+    return {s: w / total for s, w in filt.items()}

--- a/src/idp_calibration/translation.py
+++ b/src/idp_calibration/translation.py
@@ -116,9 +116,24 @@ def _collect_year_centers(
 
 
 def _bucket_labels(per_season: dict[int, list[BucketResult]]) -> list[str]:
+    """Return the union of bucket labels across every season.
+
+    Seasons can disagree on the label set when small buckets merge into
+    neighbours in one year but survive in another. Using only the first
+    season's labels (the previous behaviour) silently dropped valid
+    data. We now collect every label we've seen and sort by the
+    numeric low bound so the multiplier tables stay in rank order.
+    """
+    labels_with_lo: dict[str, int] = {}
     for buckets in per_season.values():
-        return [b.label for b in buckets]
-    return []
+        for b in buckets:
+            if b.label in labels_with_lo:
+                continue
+            try:
+                labels_with_lo[b.label] = int(b.label.split("-")[0])
+            except (TypeError, ValueError):
+                labels_with_lo[b.label] = 10**9
+    return sorted(labels_with_lo.keys(), key=lambda lbl: labels_with_lo[lbl])
 
 
 def compute_position_multipliers(

--- a/src/idp_calibration/vor.py
+++ b/src/idp_calibration/vor.py
@@ -27,14 +27,15 @@ class ScoredPlayer:
 def build_universe(
     players: Iterable[PlayerSeason],
     *,
-    top_n: int | None = None,
     min_games: int = 0,
 ) -> list[PlayerSeason]:
     """Filter the raw season list into the calibration universe.
 
-    Default (``top_n=None, min_games=0``) keeps every valid DL/LB/DB
-    with a non-empty stat line. The advanced settings surface these
-    as optional knobs.
+    Default (``min_games=0``) keeps every valid DL/LB/DB with a
+    non-empty stat line. ``min_games`` is the advanced filter exposed
+    in the UI. Top-N per position cannot be applied here because we
+    don't yet know each player's fantasy points — that selection is
+    done in :func:`trim_to_top_n_per_position` after scoring.
     """
     valid: list[PlayerSeason] = []
     for p in players:
@@ -45,11 +46,36 @@ def build_universe(
         if min_games and p.games < int(min_games):
             continue
         valid.append(p)
-    if top_n:
-        # Top-N is applied later once we know scores. Here we just
-        # preserve insertion order and return everything valid.
-        return valid
     return valid
+
+
+def trim_to_top_n_per_position(
+    scored: list["ScoredPlayer"], top_n: int | None
+) -> list["ScoredPlayer"]:
+    """Keep only the top ``top_n`` scored players per position.
+
+    Selection criterion is ``max(points_test, points_mine)`` so a
+    player who scores high in either league survives the cut — this
+    preserves the apples-to-apples rescoring invariant (both leagues
+    see the same surviving universe).
+
+    Returns the input unchanged when ``top_n`` is falsy.
+    """
+    if not top_n or top_n <= 0:
+        return list(scored)
+    by_pos: dict[str, list[ScoredPlayer]] = {"DL": [], "LB": [], "DB": []}
+    for s in scored:
+        if s.position in by_pos:
+            by_pos[s.position].append(s)
+    keep_ids: set[str] = set()
+    for cohort in by_pos.values():
+        cohort.sort(
+            key=lambda x: max(x.points_test, x.points_mine),
+            reverse=True,
+        )
+        for s in cohort[: int(top_n)]:
+            keep_ids.add(s.player_id)
+    return [s for s in scored if s.player_id in keep_ids]
 
 
 def score_universe(

--- a/src/idp_calibration/vor.py
+++ b/src/idp_calibration/vor.py
@@ -1,0 +1,154 @@
+"""Value-Over-Replacement engine for the IDP calibration lab.
+
+Rescores a *single* season player universe under two different
+league scoring systems so the downstream math can compare apples to
+apples. Enforces that the player universe (the set of player_ids) is
+identical across both leagues — this is the core invariant.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from .scoring import score_line
+from .stats_adapter import PlayerSeason
+
+
+@dataclass
+class ScoredPlayer:
+    player_id: str
+    name: str
+    position: str
+    games: int
+    points_test: float
+    points_mine: float
+
+
+def build_universe(
+    players: Iterable[PlayerSeason],
+    *,
+    top_n: int | None = None,
+    min_games: int = 0,
+) -> list[PlayerSeason]:
+    """Filter the raw season list into the calibration universe.
+
+    Default (``top_n=None, min_games=0``) keeps every valid DL/LB/DB
+    with a non-empty stat line. The advanced settings surface these
+    as optional knobs.
+    """
+    valid: list[PlayerSeason] = []
+    for p in players:
+        if p.position not in {"DL", "LB", "DB"}:
+            continue
+        if not p.stats:
+            continue
+        if min_games and p.games < int(min_games):
+            continue
+        valid.append(p)
+    if top_n:
+        # Top-N is applied later once we know scores. Here we just
+        # preserve insertion order and return everything valid.
+        return valid
+    return valid
+
+
+def score_universe(
+    universe: list[PlayerSeason],
+    test_weights: dict[str, float],
+    my_weights: dict[str, float],
+) -> list[ScoredPlayer]:
+    """Rescore the same universe under both scoring systems."""
+    out: list[ScoredPlayer] = []
+    for p in universe:
+        pts_test = score_line(p.stats, test_weights)
+        pts_mine = score_line(p.stats, my_weights)
+        out.append(
+            ScoredPlayer(
+                player_id=p.player_id,
+                name=p.name,
+                position=p.position,
+                games=p.games,
+                points_test=pts_test,
+                points_mine=pts_mine,
+            )
+        )
+    return out
+
+
+@dataclass
+class VorRow:
+    player_id: str
+    name: str
+    position: str
+    games: int
+    points_test: float
+    points_mine: float
+    vor_test: float
+    vor_mine: float
+    rank_test: int  # 1-indexed within position
+    rank_mine: int
+
+
+def compute_vor(
+    scored: list[ScoredPlayer],
+    replacement_test: dict[str, float],
+    replacement_mine: dict[str, float],
+) -> list[VorRow]:
+    """Compute VOR under both scoring systems and assign position ranks.
+
+    Each player is ranked twice — once by their points under the test
+    league scoring and once by their points under the my-league
+    scoring — because a player's rank inside the DL cohort may differ
+    between the two systems (that delta is the whole point of the
+    calibration).
+    """
+    by_pos: dict[str, list[ScoredPlayer]] = {"DL": [], "LB": [], "DB": []}
+    for s in scored:
+        if s.position in by_pos:
+            by_pos[s.position].append(s)
+
+    rank_test: dict[str, int] = {}
+    rank_mine: dict[str, int] = {}
+    for pos, cohort in by_pos.items():
+        for i, p in enumerate(sorted(cohort, key=lambda x: x.points_test, reverse=True), 1):
+            rank_test[f"{pos}:{p.player_id}"] = i
+        for i, p in enumerate(sorted(cohort, key=lambda x: x.points_mine, reverse=True), 1):
+            rank_mine[f"{pos}:{p.player_id}"] = i
+
+    rows: list[VorRow] = []
+    for s in scored:
+        repl_t = float(replacement_test.get(s.position, 0.0))
+        repl_m = float(replacement_mine.get(s.position, 0.0))
+        rows.append(
+            VorRow(
+                player_id=s.player_id,
+                name=s.name,
+                position=s.position,
+                games=s.games,
+                points_test=round(s.points_test, 3),
+                points_mine=round(s.points_mine, 3),
+                vor_test=round(s.points_test - repl_t, 3),
+                vor_mine=round(s.points_mine - repl_m, 3),
+                rank_test=rank_test.get(f"{s.position}:{s.player_id}", 9999),
+                rank_mine=rank_mine.get(f"{s.position}:{s.player_id}", 9999),
+            )
+        )
+    return rows
+
+
+def vor_rows_to_dict(rows: list[VorRow]) -> list[dict[str, Any]]:
+    return [
+        {
+            "player_id": r.player_id,
+            "name": r.name,
+            "position": r.position,
+            "games": r.games,
+            "points_test": r.points_test,
+            "points_mine": r.points_mine,
+            "vor_test": r.vor_test,
+            "vor_mine": r.vor_mine,
+            "rank_test": r.rank_test,
+            "rank_mine": r.rank_mine,
+        }
+        for r in rows
+    ]

--- a/tests/idp_calibration/test_api.py
+++ b/tests/idp_calibration/test_api.py
@@ -108,6 +108,24 @@ def test_promote_and_production_flow(tmp_base):
     assert prod["config"]["source_run_id"] == run_id
 
 
+def test_run_delete_happy_and_missing(tmp_base):
+    _, payload = api.analyze(
+        {"test_league_id": "A", "my_league_id": "B"}, base=tmp_base
+    )
+    run_id = payload["run"]["run_id"]
+    status, resp = api.run_delete(run_id, base=tmp_base)
+    assert status == 200
+    assert resp["deleted"] is True
+    # Second delete returns 404.
+    status, resp = api.run_delete(run_id, base=tmp_base)
+    assert status == 404
+
+
+def test_run_delete_requires_id(tmp_base):
+    status, _ = api.run_delete("", base=tmp_base)
+    assert status == 422
+
+
 def test_status_reports_presence(tmp_base):
     status, payload = api.status(base=tmp_base)
     assert status == 200

--- a/tests/idp_calibration/test_api.py
+++ b/tests/idp_calibration/test_api.py
@@ -126,6 +126,35 @@ def test_run_delete_requires_id(tmp_base):
     assert status == 422
 
 
+def test_promote_empty_run_returns_422(tmp_base):
+    # Save an artifact with zero bucket counts by hand so we can attempt
+    # a deliberately-unsafe promotion.
+    from src.idp_calibration import storage
+
+    empty = {
+        "run_id": "empty_api",
+        "generated_at": "2026-04-18T00:00:00Z",
+        "settings": {"blend": {"intrinsic": 0.75, "market": 0.25}},
+        "resolved_seasons": [],
+        "multipliers": {
+            "DL": {"position": "DL", "buckets": []},
+            "LB": {"position": "LB", "buckets": []},
+            "DB": {"position": "DB", "buckets": []},
+        },
+        "anchors": {},
+    }
+    storage.save_run(empty, base=tmp_base)
+    status, payload = api.promote(
+        {"run_id": "empty_api", "active_mode": "blended"}, base=tmp_base
+    )
+    assert status == 422
+    assert payload["ok"] is False
+    # And no production file was written.
+    from src.idp_calibration.promotion import production_config_path
+
+    assert not production_config_path(tmp_base).exists()
+
+
 def test_status_reports_presence(tmp_base):
     status, payload = api.status(base=tmp_base)
     assert status == 200

--- a/tests/idp_calibration/test_api.py
+++ b/tests/idp_calibration/test_api.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pytest
+
+from src.idp_calibration import api, engine, production, season_chain, storage
+from src.idp_calibration.stats_adapter import HistoricalStatsAdapter, PlayerSeason
+
+
+class _StubAdapter(HistoricalStatsAdapter):
+    name = "stub"
+
+    def fetch(self, season):
+        rows = []
+        for i in range(40):
+            pos = "DL" if i % 3 == 0 else ("LB" if i % 3 == 1 else "DB")
+            rows.append(
+                PlayerSeason(
+                    player_id=f"p{season}_{i}",
+                    name=f"Player {i}",
+                    position=pos,
+                    games=16,
+                    stats={"idp_tkl_solo": 40 - i, "idp_sack": max(0, 5 - i / 6)},
+                )
+            )
+        return rows
+
+
+def _fake_chain(seasons):
+    def _builder(league_id, max_hops):
+        return [
+            {
+                "league_id": f"{league_id}_{s}",
+                "season": s,
+                "previous_league_id": f"{league_id}_{s - 1}" if i < len(seasons) - 1 else "",
+                "scoring_settings": {"idp_tkl_solo": 1.0, "idp_sack": 3.0},
+                "roster_positions": ["QB", "RB", "WR", "DL", "LB", "LB", "DB", "BN"],
+                "total_rosters": 10,
+            }
+            for i, s in enumerate(seasons)
+        ]
+
+    return _builder
+
+
+@pytest.fixture
+def tmp_base(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        season_chain, "fetch_league_chain", _fake_chain([2025, 2024, 2023, 2022])
+    )
+    # Force stats adapter to our stub so the API path doesn't touch the network.
+    monkeypatch.setattr(
+        engine, "get_stats_adapter", lambda season: (_StubAdapter(), ["stub:ok"])
+    )
+    production.reset_cache()
+    yield tmp_path
+    production.reset_cache()
+
+
+def test_analyze_validates_league_ids(tmp_base):
+    status, payload = api.analyze({"test_league_id": "", "my_league_id": ""}, base=tmp_base)
+    assert status == 422
+    assert payload["ok"] is False
+
+
+def test_analyze_round_trip_and_run_detail(tmp_base):
+    status, payload = api.analyze(
+        {"test_league_id": "A", "my_league_id": "B"}, base=tmp_base
+    )
+    assert status == 200
+    run_id = payload["run"]["run_id"]
+    status, listing = api.runs_index(base=tmp_base)
+    assert status == 200
+    assert any(r["run_id"] == run_id for r in listing["runs"])
+    status, detail = api.run_detail(run_id, base=tmp_base)
+    assert status == 200
+    assert detail["run"]["run_id"] == run_id
+
+
+def test_run_detail_missing_returns_404(tmp_base):
+    status, payload = api.run_detail("no-such-run", base=tmp_base)
+    assert status == 404
+    assert payload["ok"] is False
+
+
+def test_promote_requires_run_id_and_mode(tmp_base):
+    status, payload = api.promote({"run_id": ""}, base=tmp_base)
+    assert status == 422
+    status, payload = api.promote(
+        {"run_id": "anything", "active_mode": "bogus"}, base=tmp_base
+    )
+    assert status == 422
+
+
+def test_promote_and_production_flow(tmp_base):
+    _, payload = api.analyze(
+        {"test_league_id": "A", "my_league_id": "B"}, base=tmp_base
+    )
+    run_id = payload["run"]["run_id"]
+    status, prod = api.production(base=tmp_base)
+    assert status == 200 and prod["present"] is False
+    status, result = api.promote(
+        {"run_id": run_id, "active_mode": "blended"}, base=tmp_base
+    )
+    assert status == 200
+    assert result["ok"] is True
+    status, prod = api.production(base=tmp_base)
+    assert prod["present"] is True
+    assert prod["config"]["source_run_id"] == run_id
+
+
+def test_status_reports_presence(tmp_base):
+    status, payload = api.status(base=tmp_base)
+    assert status == 200
+    assert payload["production_present"] is False
+    api.analyze({"test_league_id": "A", "my_league_id": "B"}, base=tmp_base)
+    status, payload = api.status(base=tmp_base)
+    assert payload["latest_run_id"] is not None

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -1,0 +1,86 @@
+"""Verify the promoted config flows into the live valuation pipeline.
+
+Tests the integration point in ``src/api/data_contract.py``:
+``_apply_idp_calibration_post_pass`` is called after Phase 4 and
+multiplies ``rankDerivedValue`` for IDP rows only.
+"""
+from __future__ import annotations
+
+from src.api.data_contract import _apply_idp_calibration_post_pass
+from src.idp_calibration import production
+from src.idp_calibration.promotion import production_config_path
+from src.utils.config_loader import save_json
+
+
+def _rows():
+    return [
+        {"position": "QB", "rankDerivedValue": 9000},
+        {"position": "DL", "rankDerivedValue": 5000},
+        {"position": "DL", "rankDerivedValue": 3000},
+        {"position": "LB", "rankDerivedValue": 4000},
+        {"position": "DB", "rankDerivedValue": 2000},
+    ]
+
+
+def test_no_config_is_strict_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: tmp_path / "config/idp_calibration.json")
+    monkeypatch.setattr(
+        "src.api.data_contract._idp_production.production_config_path",
+        lambda base=None: tmp_path / "config/idp_calibration.json",
+        raising=False,
+    )
+    production.reset_cache()
+    rows = _rows()
+    before = [r["rankDerivedValue"] for r in rows]
+    _apply_idp_calibration_post_pass(rows, {})
+    after = [r["rankDerivedValue"] for r in rows]
+    assert before == after
+
+
+def test_promoted_multipliers_scale_only_idp(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    config = {
+        "version": 1,
+        "active_mode": "blended",
+        "multipliers": {
+            "final": {
+                "DL": {"1-6": 0.5, "7-12": 0.5, "13-24": 0.5},
+                "LB": {"1-6": 1.5},
+                "DB": {"1-6": 2.0},
+            }
+        },
+        "anchors": {},
+    }
+    save_json(cfg_path, config)
+    # Point the production loader at our temp config.
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+
+    rows = _rows()
+    _apply_idp_calibration_post_pass(rows, {})
+    # QB untouched
+    assert rows[0]["rankDerivedValue"] == 9000
+    # DL rank 1 and rank 2 both in bucket 1-6 => 0.5x
+    dl_rows = [r for r in rows if r["position"] == "DL"]
+    assert dl_rows[0]["rankDerivedValue"] == 2500  # 5000 * 0.5
+    assert dl_rows[1]["rankDerivedValue"] == 1500  # 3000 * 0.5
+    # LB scaled up
+    lb = next(r for r in rows if r["position"] == "LB")
+    assert lb["rankDerivedValue"] == 6000
+    # DB scaled up
+    db = next(r for r in rows if r["position"] == "DB")
+    assert db["rankDerivedValue"] == 4000
+
+
+def test_position_alias_collapses_to_canonical(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    config = {
+        "active_mode": "blended",
+        "multipliers": {"final": {"DL": {"1-6": 0.5}}},
+    }
+    save_json(cfg_path, config)
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+    rows = [{"position": "EDGE", "rankDerivedValue": 4000}]
+    _apply_idp_calibration_post_pass(rows, {})
+    assert rows[0]["rankDerivedValue"] == 2000  # EDGE -> DL -> 0.5x

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -72,6 +72,32 @@ def test_promoted_multipliers_scale_only_idp(tmp_path, monkeypatch):
     assert db["rankDerivedValue"] == 4000
 
 
+def test_empty_bucket_config_is_identity_not_anchor_floor(tmp_path, monkeypatch):
+    """A promoted config with no real bucket data must be a no-op, NOT a
+    ~95% value cut via the anchor floor."""
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    # Count = 0 on every bucket; anchors look convincing but are all 0.05.
+    config = {
+        "active_mode": "blended",
+        "multipliers": {
+            "DL": {"position": "DL", "buckets": [
+                {"label": "1-6", "intrinsic": 0.05, "market": 0.05, "final": 0.05, "count": 0},
+            ]},
+        },
+        "anchors": {
+            "final": {
+                "DL": [{"rank": 1, "value": 0.05}, {"rank": 100, "value": 0.05}],
+            },
+        },
+    }
+    save_json(cfg_path, config)
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+    # Must return identity, not 0.05.
+    assert production.get_idp_bucket_multiplier("DL", 1) == 1.0
+    assert production.get_idp_bucket_multiplier("DL", 50) == 1.0
+
+
 def test_position_alias_collapses_to_canonical(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {

--- a/tests/idp_calibration/test_replacement.py
+++ b/tests/idp_calibration/test_replacement.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from src.idp_calibration.lineup import parse_lineup
+from src.idp_calibration.replacement import (
+    ReplacementSettings,
+    compute_replacement_levels,
+)
+
+LEAGUE = {
+    "league_id": "L",
+    "season": 2024,
+    "total_rosters": 12,
+    "roster_positions": [
+        "QB", "RB", "RB", "WR", "WR", "TE", "FLEX",
+        "DL", "DL", "LB", "LB", "LB", "DB", "DB",
+        "IDP_FLEX",
+        "BN", "BN", "BN", "BN",
+    ],
+}
+
+
+def _scored(points):
+    return [{"position": "DL", "points": p} for p in points]
+
+
+def test_strict_starter_mode_uses_exact_demand():
+    demand = parse_lineup(LEAGUE)
+    settings = ReplacementSettings(mode="strict_starter", buffer_pct=0.5)
+    # 2 DL + 1 IDP_FLEX/3 = 2.33, * 12 teams ≈ 28
+    pts = list(range(40, 0, -1))
+    levels = compute_replacement_levels(_scored(pts), demand, settings)
+    assert levels["DL"].replacement_rank == 28
+    # Replacement rank 28 => points[27]
+    assert levels["DL"].replacement_points == pts[27]
+
+
+def test_buffer_mode_adds_team_count_fraction():
+    demand = parse_lineup(LEAGUE)
+    settings = ReplacementSettings(mode="starter_plus_buffer", buffer_pct=0.25)
+    pts = list(range(50, 0, -1))
+    levels = compute_replacement_levels(_scored(pts), demand, settings)
+    # Base 28 + ceil(12 * 0.25) = 28 + 3 = 31
+    assert levels["DL"].replacement_rank == 31
+
+
+def test_manual_mode_overrides_with_explicit_rank():
+    demand = parse_lineup(LEAGUE)
+    settings = ReplacementSettings(mode="manual", manual={"DL": 10})
+    pts = list(range(20, 0, -1))
+    levels = compute_replacement_levels(_scored(pts), demand, settings)
+    assert levels["DL"].replacement_rank == 10
+    assert levels["DL"].replacement_points == pts[9]
+
+
+def test_shortfall_falls_back_to_last_player_with_note():
+    demand = parse_lineup(LEAGUE)
+    settings = ReplacementSettings(mode="manual", manual={"DL": 99})
+    pts = [10.0, 7.0, 3.0]
+    levels = compute_replacement_levels(_scored(pts), demand, settings)
+    assert levels["DL"].replacement_rank == 99
+    assert levels["DL"].replacement_points == 3.0
+    assert "exceeds cohort size" in levels["DL"].note

--- a/tests/idp_calibration/test_replacement.py
+++ b/tests/idp_calibration/test_replacement.py
@@ -52,6 +52,18 @@ def test_manual_mode_overrides_with_explicit_rank():
     assert levels["DL"].replacement_points == pts[9]
 
 
+def test_non_integer_demand_ceils_instead_of_rounding_down():
+    league = dict(LEAGUE)
+    league["total_rosters"] = 10  # 10 * 2.33 = 23.33 -> 24 after ceil
+    demand = parse_lineup(league)
+    settings = ReplacementSettings(mode="strict_starter")
+    pts = list(range(40, 0, -1))
+    levels = compute_replacement_levels(_scored(pts), demand, settings)
+    # Previously this path used round() which would have produced 23 and
+    # picked too-strong a replacement. Ceil keeps us honest.
+    assert levels["DL"].replacement_rank == 24
+
+
 def test_shortfall_falls_back_to_last_player_with_note():
     demand = parse_lineup(LEAGUE)
     settings = ReplacementSettings(mode="manual", manual={"DL": 99})

--- a/tests/idp_calibration/test_scoring.py
+++ b/tests/idp_calibration/test_scoring.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from src.idp_calibration.scoring import IDP_STAT_KEYS, parse_scoring, score_line
+
+
+def test_parse_scoring_aliases_idp_keys():
+    league = {
+        "league_id": "abc",
+        "season": 2024,
+        "scoring_settings": {
+            "idp_solo": 1.5,           # alias for idp_tkl_solo
+            "idp_ast": 0.75,           # alias for idp_tkl_ast
+            "idp_sack": 4.0,
+            "idp_int": 3.0,
+            "unknown_stat": 2.0,
+        },
+    }
+    scoring = parse_scoring(league)
+    assert scoring.league_id == "abc"
+    assert scoring.season == 2024
+    assert scoring.idp_weights["idp_tkl_solo"] == 1.5
+    assert scoring.idp_weights["idp_tkl_ast"] == 0.75
+    assert scoring.idp_weights["idp_sack"] == 4.0
+    assert "unknown_stat" in scoring.unknown_keys
+    # Inactive keys default to zero and stay accessible.
+    for key in IDP_STAT_KEYS:
+        assert key in scoring.idp_weights
+
+
+def test_score_line_dots_weights_and_stats():
+    weights = {"idp_tkl_solo": 1.0, "idp_sack": 4.0, "idp_int": 3.0}
+    stats = {"idp_tkl_solo": 5, "idp_sack": 2, "idp_int": 1}
+    assert score_line(stats, weights) == 5 * 1.0 + 2 * 4.0 + 1 * 3.0
+
+
+def test_score_line_ignores_missing_stats():
+    weights = {"idp_tkl_solo": 1.0, "idp_sack": 4.0}
+    stats = {"idp_tkl_solo": 10}
+    assert score_line(stats, weights) == 10.0

--- a/tests/idp_calibration/test_season_chain.py
+++ b/tests/idp_calibration/test_season_chain.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from src.idp_calibration.season_chain import DEFAULT_SEASONS, resolve_seasons
+
+
+def _fake_chain_builder(seasons):
+    def _builder(league_id, max_hops):
+        out = []
+        for i, s in enumerate(seasons):
+            out.append(
+                {
+                    "league_id": f"{league_id}_{s}",
+                    "season": s,
+                    "name": f"{league_id} {s}",
+                    "previous_league_id": f"{league_id}_{s - 1}" if i < len(seasons) - 1 else "",
+                }
+            )
+        return out
+
+    return _builder
+
+
+def test_resolves_all_default_seasons():
+    chain = resolve_seasons(
+        "L1",
+        chain_fetcher=_fake_chain_builder([2025, 2024, 2023, 2022]),
+    )
+    assert chain.input_league_id == "L1"
+    for season in DEFAULT_SEASONS:
+        res = chain.seasons[season]
+        assert res.resolved
+        assert res.league_id == f"L1_{season}"
+    assert chain.warnings == []
+
+
+def test_flags_missing_season_without_substitution():
+    # 2022 not present in chain.
+    chain = resolve_seasons(
+        "L2",
+        chain_fetcher=_fake_chain_builder([2025, 2024, 2023]),
+    )
+    assert chain.seasons[2022].resolved is False
+    assert chain.seasons[2023].resolved is True
+    # Ensure 2022 was never silently mapped to 2023.
+    assert chain.seasons[2022].league_id is None
+    assert any("2022" in w for w in chain.warnings)
+
+
+def test_empty_league_id_returns_warning():
+    chain = resolve_seasons("", chain_fetcher=_fake_chain_builder([]))
+    assert chain.warnings
+    for season in DEFAULT_SEASONS:
+        assert chain.seasons[season].resolved is False

--- a/tests/idp_calibration/test_settings_coercion.py
+++ b/tests/idp_calibration/test_settings_coercion.py
@@ -1,0 +1,58 @@
+"""AnalysisSettings.from_payload must never raise on garbage client input.
+
+Malformed numeric settings would otherwise bubble out of
+``api.analyze`` as a 500 because ``from_payload`` is called outside
+the handler's try/except guard.
+"""
+from __future__ import annotations
+
+from src.idp_calibration import api
+from src.idp_calibration.engine import AnalysisSettings
+
+
+def test_malformed_numeric_fields_fall_back_to_defaults():
+    payload = {
+        "min_games": "abc",
+        "min_bucket_size": None,
+        "top_n": "not a number",
+        "anchor_floor": "bad",
+        "blend": {"intrinsic": "lots"},
+        "replacement": {"mode": "starter_plus_buffer", "buffer_pct": "15%"},
+        "year_weights": {"2025": "heavy", "2024": 0.3},
+        "bucket_edges": [["x", "y"], [1, 6]],
+    }
+    settings = AnalysisSettings.from_payload(payload)
+    # Defaults restored silently — no exception.
+    assert settings.min_games == 0
+    assert settings.min_bucket_size == 3
+    assert settings.top_n is None
+    assert abs(settings.anchor_floor - 0.05) < 1e-6
+    assert abs(settings.blend["intrinsic"] - 0.75) < 1e-6
+    assert abs(settings.replacement.buffer_pct - 0.15) < 1e-6
+    # Year weights: the malformed 2025 entry is dropped; 2024 survives.
+    assert 2024 in settings.year_weights
+    # Bucket edges: the malformed ["x","y"] pair is rejected; [1,6] survives.
+    assert [1, 6] in settings.bucket_edges
+
+
+def test_analyze_handler_returns_422_on_empty_league_ids_not_500():
+    # Even with a malformed settings block, the handler should surface a
+    # structured validation error, not a 500.
+    status, payload = api.analyze(
+        {"test_league_id": "", "my_league_id": "", "settings": {"min_games": "oops"}},
+    )
+    assert status == 422
+    assert payload["ok"] is False
+
+
+def test_manual_rank_garbage_drops_entry_silently():
+    payload = {
+        "replacement": {
+            "mode": "manual",
+            "manual": {"DL": "abc", "LB": "-5", "DB": "12"},
+        },
+    }
+    settings = AnalysisSettings.from_payload(payload)
+    assert "DL" not in settings.replacement.manual
+    assert "LB" not in settings.replacement.manual  # <=0 rejected
+    assert settings.replacement.manual["DB"] == 12

--- a/tests/idp_calibration/test_settings_coercion.py
+++ b/tests/idp_calibration/test_settings_coercion.py
@@ -89,6 +89,54 @@ def test_from_payload_tolerates_non_dict_sub_fields():
     assert settings.seasons  # default seasons restored
 
 
+def test_overflow_and_non_finite_numeric_inputs_fall_back_to_defaults():
+    # "1e309" → float("inf") → int(inf) raises OverflowError. Previously
+    # escaped as a 500. Now falls back to the default.
+    settings = AnalysisSettings.from_payload({"min_games": "1e309"})
+    assert settings.min_games == 0
+
+    # "nan" and "inf" on anchor_floor / top_n / min_bucket_size must all
+    # fall back to defaults rather than propagate NaN through the math.
+    settings = AnalysisSettings.from_payload(
+        {
+            "anchor_floor": "nan",
+            "top_n": "inf",
+            "min_bucket_size": "-inf",
+        },
+    )
+    assert abs(settings.anchor_floor - 0.05) < 1e-9
+    assert settings.top_n is None
+    assert settings.min_bucket_size == 3
+
+
+def test_year_weights_reject_inf_nan_and_negative():
+    payload = {
+        "year_weights": {
+            "2025": "1e309",   # inf — reject
+            "2024": "nan",      # nan — reject
+            "2023": -0.5,       # negative — reject
+            "2022": 0.4,        # valid — keep
+        },
+    }
+    settings = AnalysisSettings.from_payload(payload)
+    assert 2025 not in settings.year_weights
+    assert 2024 not in settings.year_weights
+    assert 2023 not in settings.year_weights
+    assert settings.year_weights[2022] == 0.4
+
+
+def test_analyze_handler_survives_overflow_numeric_inputs():
+    # Previously a 500 via OverflowError in _safe_int.
+    status, _ = api.analyze(
+        {
+            "test_league_id": "A",
+            "my_league_id": "B",
+            "settings": {"min_games": "1e309", "anchor_floor": "nan"},
+        },
+    )
+    assert status != 500
+
+
 def test_analyze_handler_survives_malformed_settings_shape():
     # Was previously a 500 via AttributeError in from_payload.
     status, payload = api.analyze(

--- a/tests/idp_calibration/test_settings_coercion.py
+++ b/tests/idp_calibration/test_settings_coercion.py
@@ -56,3 +56,46 @@ def test_manual_rank_garbage_drops_entry_silently():
     assert "DL" not in settings.replacement.manual
     assert "LB" not in settings.replacement.manual  # <=0 rejected
     assert settings.replacement.manual["DB"] == 12
+
+
+def test_from_payload_tolerates_non_dict_top_level():
+    # Strings, lists, ints, None — none of these should raise.
+    for bad in ["oops", [1, 2, 3], 42, None, True, 3.14]:
+        settings = AnalysisSettings.from_payload(bad)
+        # Defaults all round-trip.
+        assert settings.min_games == 0
+        assert settings.min_bucket_size == 3
+        assert settings.top_n is None
+
+
+def test_from_payload_tolerates_non_dict_sub_fields():
+    # Each sub-field that was previously assumed to be a dict.
+    settings = AnalysisSettings.from_payload(
+        {
+            "replacement": "not a dict",
+            "blend": [1, 2, 3],
+            "year_weights": "bogus",
+            "anchor_ranks": "1,2,3",  # string is iterable but ints() will fail
+            "bucket_edges": "oops",
+            "seasons": "oops",
+        },
+    )
+    # All defaults preserved — no AttributeError raised.
+    assert settings.replacement.mode == "starter_plus_buffer"
+    assert abs(settings.blend["intrinsic"] - 0.75) < 1e-6
+    assert 2025 in settings.year_weights  # default weights
+    assert settings.anchor_ranks  # default anchors restored
+    assert settings.bucket_edges  # default buckets restored
+    assert settings.seasons  # default seasons restored
+
+
+def test_analyze_handler_survives_malformed_settings_shape():
+    # Was previously a 500 via AttributeError in from_payload.
+    status, payload = api.analyze(
+        {"test_league_id": "A", "my_league_id": "B", "settings": "oops"},
+    )
+    # Since we pass real league IDs but stub adapter isn't available,
+    # this will proceed through analysis using default settings.
+    # The important invariant is: we do NOT get a 500 from type drift.
+    assert status != 500
+    assert isinstance(payload, dict)

--- a/tests/idp_calibration/test_stats_adapter_cache.py
+++ b/tests/idp_calibration/test_stats_adapter_cache.py
@@ -1,0 +1,45 @@
+"""The `HistoricalStatsAdapter` base class memoizes per-season results
+so the adapter-selection probe (`available()` calls `fetch()`) does not
+force a duplicate fetch during `run_analysis`.
+"""
+from __future__ import annotations
+
+from src.idp_calibration.stats_adapter import HistoricalStatsAdapter, PlayerSeason
+
+
+class _CountingAdapter(HistoricalStatsAdapter):
+    name = "counting"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def _fetch_impl(self, season: int):
+        self.calls += 1
+        return [
+            PlayerSeason(
+                player_id=f"p{season}",
+                name="X",
+                position="DL",
+                games=16,
+                stats={"idp_tkl_solo": 10},
+            )
+        ]
+
+
+def test_available_then_fetch_hits_backend_once_per_season():
+    adapter = _CountingAdapter()
+    # The plain old subclass pattern: one call to available() then fetch().
+    assert adapter.available(2024) is True
+    first = adapter.fetch(2024)
+    second = adapter.fetch(2024)
+    assert first == second
+    assert adapter.calls == 1  # One impl call, not three.
+
+
+def test_cache_is_per_season():
+    adapter = _CountingAdapter()
+    adapter.fetch(2024)
+    adapter.fetch(2025)
+    adapter.fetch(2024)
+    assert adapter.calls == 2  # 2024 and 2025 each hit the impl exactly once.

--- a/tests/idp_calibration/test_storage_promotion.py
+++ b/tests/idp_calibration/test_storage_promotion.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.idp_calibration import engine, promotion, production, season_chain, storage
+from src.idp_calibration.stats_adapter import HistoricalStatsAdapter, PlayerSeason
+
+
+class _StubAdapter(HistoricalStatsAdapter):
+    name = "stub"
+
+    def fetch(self, season):
+        rows = []
+        for i in range(60):
+            pos = "DL" if i % 3 == 0 else ("LB" if i % 3 == 1 else "DB")
+            rows.append(
+                PlayerSeason(
+                    player_id=f"p{season}_{i}",
+                    name=f"Player {i}",
+                    position=pos,
+                    games=16,
+                    stats={
+                        "idp_tkl_solo": 100 - i,
+                        "idp_sack": max(0, 12 - i / 3),
+                        "idp_int": 2,
+                    },
+                )
+            )
+        return rows
+
+
+def _fake_chain(seasons):
+    def _builder(league_id, max_hops):
+        return [
+            {
+                "league_id": f"{league_id}_{s}",
+                "season": s,
+                "name": f"{league_id} {s}",
+                "previous_league_id": f"{league_id}_{s - 1}" if i < len(seasons) - 1 else "",
+                "scoring_settings": {"idp_tkl_solo": 1.0, "idp_sack": 4.0, "idp_int": 3.0},
+                "roster_positions": [
+                    "QB", "RB", "RB", "WR", "WR", "TE", "FLEX",
+                    "DL", "DL", "LB", "LB", "LB", "DB", "DB",
+                    "BN", "BN", "BN",
+                ],
+                "total_rosters": 12,
+            }
+            for i, s in enumerate(seasons)
+        ]
+
+    return _builder
+
+
+@pytest.fixture
+def tmp_base(tmp_path, monkeypatch):
+    # Keep engine's default chain fetcher deterministic.
+    monkeypatch.setattr(
+        season_chain,
+        "fetch_league_chain",
+        _fake_chain([2025, 2024, 2023, 2022]),
+    )
+    production.reset_cache()
+    yield tmp_path
+    production.reset_cache()
+
+
+def test_save_and_load_run_round_trip(tmp_base):
+    settings = engine.AnalysisSettings()
+    artifact = engine.run_analysis(
+        "A", "B", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    run_id = storage.save_run(artifact, base=tmp_base)
+    assert run_id == artifact["run_id"]
+    loaded = storage.load_run(run_id, base=tmp_base)
+    assert loaded is not None
+    assert loaded["run_id"] == run_id
+    # list_runs must surface it.
+    summaries = storage.list_runs(base=tmp_base)
+    assert any(s["run_id"] == run_id for s in summaries)
+    latest = storage.get_latest(base=tmp_base)
+    assert latest["run_id"] == run_id
+
+
+def test_promote_writes_config_and_backs_up_prior(tmp_base):
+    settings = engine.AnalysisSettings()
+    art1 = engine.run_analysis(
+        "A", "B", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    storage.save_run(art1, base=tmp_base)
+    result1 = promotion.promote_run(
+        art1["run_id"], active_mode="blended", promoted_by="tester", base=tmp_base
+    )
+    assert result1["ok"] is True
+    cfg_path = promotion.production_config_path(tmp_base)
+    cfg = json.loads(cfg_path.read_text())
+    assert cfg["source_run_id"] == art1["run_id"]
+    assert cfg["active_mode"] == "blended"
+    assert result1["backup_path"] is None
+
+    # Second promote should move the prior config into backups dir.
+    art2 = engine.run_analysis(
+        "X", "Y", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    storage.save_run(art2, base=tmp_base)
+    result2 = promotion.promote_run(
+        art2["run_id"], active_mode="intrinsic_only", base=tmp_base
+    )
+    assert result2["backup_path"] is not None
+    assert Path(result2["backup_path"]).exists()
+    refreshed = json.loads(cfg_path.read_text())
+    assert refreshed["active_mode"] == "intrinsic_only"
+    assert refreshed["source_run_id"] == art2["run_id"]
+
+
+def test_promote_unknown_run_raises(tmp_base):
+    with pytest.raises(FileNotFoundError):
+        promotion.promote_run("does-not-exist", base=tmp_base)
+
+
+def test_production_lookup_returns_multiplier_when_promoted(tmp_base):
+    settings = engine.AnalysisSettings()
+    art = engine.run_analysis(
+        "A", "B", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    storage.save_run(art, base=tmp_base)
+    promotion.promote_run(art["run_id"], active_mode="blended", base=tmp_base)
+    production.reset_cache()
+    val = production.get_idp_bucket_multiplier("DL", 1, base=tmp_base)
+    # Top bucket must be 1.0 by construction.
+    assert val == 1.0
+    # A very late rank falls back to anchor floor (0.05 by default).
+    assert production.get_idp_bucket_multiplier("DL", 500, base=tmp_base) >= 0.0

--- a/tests/idp_calibration/test_storage_promotion.py
+++ b/tests/idp_calibration/test_storage_promotion.py
@@ -160,6 +160,32 @@ def test_promote_unknown_run_raises(tmp_base):
         promotion.promote_run("does-not-exist", base=tmp_base)
 
 
+def test_promote_refuses_run_with_no_bucket_data(tmp_base):
+    # Build an artifact whose multipliers contain only zero-count buckets
+    # (the exact shape produced by a run where every season failed to
+    # resolve). Promoting would otherwise let the anchor floor (0.05)
+    # reach production and cut every IDP value by ~95%.
+    empty_artifact = {
+        "run_id": "empty_run",
+        "generated_at": "2026-04-18T00:00:00Z",
+        "settings": {"blend": {"intrinsic": 0.75, "market": 0.25}},
+        "resolved_seasons": [],
+        "multipliers": {
+            "DL": {"position": "DL", "buckets": [
+                {"label": "1-6", "intrinsic": 1.0, "market": 1.0, "final": 1.0, "count": 0},
+            ]},
+            "LB": {"position": "LB", "buckets": []},
+            "DB": {"position": "DB", "buckets": []},
+        },
+        "anchors": {},
+    }
+    storage.save_run(empty_artifact, base=tmp_base)
+    with pytest.raises(promotion.EmptyCalibrationError):
+        promotion.promote_run("empty_run", base=tmp_base)
+    # No config file should have been written.
+    assert not promotion.production_config_path(tmp_base).exists()
+
+
 def test_production_lookup_returns_multiplier_when_promoted(tmp_base):
     settings = engine.AnalysisSettings()
     art = engine.run_analysis(

--- a/tests/idp_calibration/test_storage_promotion.py
+++ b/tests/idp_calibration/test_storage_promotion.py
@@ -115,6 +115,46 @@ def test_promote_writes_config_and_backs_up_prior(tmp_base):
     assert refreshed["source_run_id"] == art2["run_id"]
 
 
+def test_delete_run_removes_file_and_updates_latest(tmp_base):
+    settings = engine.AnalysisSettings()
+    art1 = engine.run_analysis(
+        "A", "B", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    storage.save_run(art1, base=tmp_base)
+    art2 = engine.run_analysis(
+        "C", "D", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    storage.save_run(art2, base=tmp_base)
+    # latest should be art2 (the most recently saved).
+    assert storage.get_latest(base=tmp_base)["run_id"] == art2["run_id"]
+
+    # Deleting the latest must rewrite the pointer to the surviving run.
+    assert storage.delete_run(art2["run_id"], base=tmp_base) is True
+    assert storage.load_run(art2["run_id"], base=tmp_base) is None
+    assert storage.get_latest(base=tmp_base)["run_id"] == art1["run_id"]
+
+    # Deleting the last remaining run must clear the pointer.
+    assert storage.delete_run(art1["run_id"], base=tmp_base) is True
+    assert storage.get_latest(base=tmp_base) is None
+
+    # Deleting an already-gone run is a no-op that returns False.
+    assert storage.delete_run(art1["run_id"], base=tmp_base) is False
+
+
+def test_delete_run_does_not_touch_promoted_config(tmp_base):
+    settings = engine.AnalysisSettings()
+    art = engine.run_analysis(
+        "A", "B", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    storage.save_run(art, base=tmp_base)
+    promotion.promote_run(art["run_id"], active_mode="blended", base=tmp_base)
+    assert promotion.production_config_path(tmp_base).exists()
+    storage.delete_run(art["run_id"], base=tmp_base)
+    # Production stays. Deleting a run never reverts prod automatically —
+    # that's an explicit action (delete the file on disk).
+    assert promotion.production_config_path(tmp_base).exists()
+
+
 def test_promote_unknown_run_raises(tmp_base):
     with pytest.raises(FileNotFoundError):
         promotion.promote_run("does-not-exist", base=tmp_base)

--- a/tests/idp_calibration/test_translation_anchors.py
+++ b/tests/idp_calibration/test_translation_anchors.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from src.idp_calibration.anchors import build_all_anchors
+from src.idp_calibration.buckets import BucketResult
+from src.idp_calibration.translation import (
+    DEFAULT_BLEND,
+    DEFAULT_YEAR_WEIGHTS,
+    build_multi_year_multipliers,
+    normalise_year_weights,
+)
+
+
+def _bucket(label, lo, hi, test_val, mine_val, count=20):
+    return BucketResult(
+        label=label,
+        lo=lo,
+        hi=hi,
+        count=count,
+        mean_vor_test=test_val,
+        median_vor_test=test_val,
+        center_vor_test=test_val,
+        mean_vor_mine=mine_val,
+        median_vor_mine=mine_val,
+        center_vor_mine=mine_val,
+        ratio_mine_over_test=mine_val / test_val if test_val else None,
+    )
+
+
+def _three_bucket_series(test_seed, mine_seed):
+    return [
+        _bucket("1-6", 1, 6, test_seed, mine_seed),
+        _bucket("7-12", 7, 12, test_seed * 0.6, mine_seed * 0.65),
+        _bucket("13-24", 13, 24, test_seed * 0.3, mine_seed * 0.28),
+    ]
+
+
+def test_build_multi_year_multipliers_produces_normalised_curves():
+    per_position = {
+        "DL": {
+            2025: _three_bucket_series(100, 120),
+            2024: _three_bucket_series(95, 115),
+            2023: _three_bucket_series(90, 110),
+            2022: _three_bucket_series(85, 100),
+        }
+    }
+    year_weights = normalise_year_weights(DEFAULT_YEAR_WEIGHTS, seasons=[2022, 2023, 2024, 2025])
+    multipliers = build_multi_year_multipliers(
+        per_position, year_weights=year_weights, blend=DEFAULT_BLEND
+    )
+    dl = multipliers["DL"].buckets
+    assert dl[0].intrinsic == 1.0  # Top bucket normalised to 1.0
+    assert dl[1].intrinsic < dl[0].intrinsic
+    assert dl[2].intrinsic < dl[1].intrinsic
+    # Final blend must sit between intrinsic and market at each bucket.
+    for b in dl:
+        lo = min(b.intrinsic, b.market)
+        hi = max(b.intrinsic, b.market)
+        assert lo - 1e-6 <= b.final <= hi + 1e-6
+
+
+def test_anchors_are_non_increasing():
+    per_position = {
+        "LB": {
+            2025: _three_bucket_series(100, 120),
+            2024: _three_bucket_series(90, 110),
+        }
+    }
+    multipliers = build_multi_year_multipliers(
+        per_position,
+        year_weights={2025: 0.6, 2024: 0.4},
+        blend=DEFAULT_BLEND,
+    )
+    anchors = build_all_anchors(multipliers)
+    for kind in ("intrinsic", "market", "final"):
+        points = anchors["LB"][kind]
+        for a, b in zip(points, points[1:]):
+            assert b.value <= a.value + 1e-9, f"{kind} violates monotonicity"
+
+
+def test_normalise_year_weights_handles_missing_seasons():
+    weights = normalise_year_weights(DEFAULT_YEAR_WEIGHTS, seasons=[2023, 2024])
+    assert 2022 not in weights
+    assert abs(sum(weights.values()) - 1.0) < 1e-6

--- a/tests/idp_calibration/test_translation_anchors.py
+++ b/tests/idp_calibration/test_translation_anchors.py
@@ -77,6 +77,25 @@ def test_anchors_are_non_increasing():
             assert b.value <= a.value + 1e-9, f"{kind} violates monotonicity"
 
 
+def test_bucket_labels_aggregate_across_seasons_not_just_first():
+    # Season A merged 13-24 away; season B kept it. The multiplier table
+    # must still include the 13-24 bucket in the aggregate.
+    season_a = [_bucket("1-6", 1, 6, 100, 110), _bucket("7-12", 7, 12, 60, 65)]
+    season_b = _three_bucket_series(100, 115)  # includes 13-24
+    per_position = {"DL": {2025: season_a, 2024: season_b}}
+    multipliers = build_multi_year_multipliers(
+        per_position,
+        year_weights={2025: 0.6, 2024: 0.4},
+        blend=DEFAULT_BLEND,
+    )
+    labels = [b.label for b in multipliers["DL"].buckets]
+    assert "1-6" in labels
+    assert "7-12" in labels
+    assert "13-24" in labels  # Previously silently dropped.
+    # Ordering must be by numeric low bound — 1-6 before 7-12 before 13-24.
+    assert labels.index("1-6") < labels.index("7-12") < labels.index("13-24")
+
+
 def test_normalise_year_weights_handles_missing_seasons():
     weights = normalise_year_weights(DEFAULT_YEAR_WEIGHTS, seasons=[2023, 2024])
     assert 2022 not in weights

--- a/tests/idp_calibration/test_translation_anchors.py
+++ b/tests/idp_calibration/test_translation_anchors.py
@@ -100,3 +100,23 @@ def test_normalise_year_weights_handles_missing_seasons():
     weights = normalise_year_weights(DEFAULT_YEAR_WEIGHTS, seasons=[2023, 2024])
     assert 2022 not in weights
     assert abs(sum(weights.values()) - 1.0) < 1e-6
+
+
+def test_normalise_year_weights_uniform_fallback_for_custom_seasons():
+    # User picks seasons outside the default weight keys. Every year
+    # has weight 0 in the defaults. We must NOT return all zeros —
+    # that silently produces a no-op calibration downstream.
+    weights = normalise_year_weights(
+        DEFAULT_YEAR_WEIGHTS, seasons=[2021, 2020, 2019]
+    )
+    # Uniform fallback: each season gets 1/3.
+    assert set(weights.keys()) == {2021, 2020, 2019}
+    for v in weights.values():
+        assert abs(v - 1.0 / 3.0) < 1e-9
+    assert abs(sum(weights.values()) - 1.0) < 1e-6
+
+
+def test_normalise_year_weights_empty_seasons_returns_empty():
+    # Edge case — protect against ZeroDivisionError in the uniform
+    # branch when nothing is selected.
+    assert normalise_year_weights(DEFAULT_YEAR_WEIGHTS, seasons=[]) == {}

--- a/tests/idp_calibration/test_vor_buckets.py
+++ b/tests/idp_calibration/test_vor_buckets.py
@@ -6,6 +6,7 @@ from src.idp_calibration.vor import (
     build_universe,
     compute_vor,
     score_universe,
+    trim_to_top_n_per_position,
 )
 
 
@@ -56,6 +57,45 @@ def test_bucketize_merges_small_buckets_and_reports_merge():
     merged_labels = [m for b in buckets for m in b.merged_from]
     # With 15 DLs and default buckets, later buckets should merge into earlier ones.
     assert any(merged_labels), "Expected at least one merge"
+
+
+def test_trim_to_top_n_keeps_only_top_n_per_position():
+    # Mix of DL/LB/DB so the per-position slice is non-trivial.
+    universe = []
+    for i in range(20):
+        universe.append(
+            PlayerSeason(
+                player_id=f"p{i}",
+                name=f"P{i}",
+                position=["DL", "LB", "DB"][i % 3],
+                games=16,
+                stats={"idp_tkl_solo": 50 - i},
+            )
+        )
+    weights = {"idp_tkl_solo": 1.0}
+    scored = score_universe(universe, weights, weights)
+    trimmed = trim_to_top_n_per_position(scored, 2)
+    # Each position should now have at most 2 survivors.
+    by_pos = {"DL": 0, "LB": 0, "DB": 0}
+    for s in trimmed:
+        by_pos[s.position] += 1
+    assert all(n <= 2 for n in by_pos.values())
+    # Survivors are the highest-scoring per position, not the tail.
+    for pos in ("DL", "LB", "DB"):
+        pos_scored = [s for s in scored if s.position == pos]
+        pos_trim = [s for s in trimmed if s.position == pos]
+        pos_scored.sort(key=lambda x: x.points_test, reverse=True)
+        assert {s.player_id for s in pos_trim} <= {
+            s.player_id for s in pos_scored[:2]
+        }
+
+
+def test_trim_to_top_n_is_noop_when_falsy():
+    universe = _universe()[:5]
+    weights = {"idp_tkl_solo": 1.0}
+    scored = score_universe(universe, weights, weights)
+    assert len(trim_to_top_n_per_position(scored, None)) == len(scored)
+    assert len(trim_to_top_n_per_position(scored, 0)) == len(scored)
 
 
 def test_bucketize_blended_center_equals_mean_plus_median_over_2():

--- a/tests/idp_calibration/test_vor_buckets.py
+++ b/tests/idp_calibration/test_vor_buckets.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from src.idp_calibration.buckets import DEFAULT_BUCKETS, bucketize
+from src.idp_calibration.stats_adapter import PlayerSeason
+from src.idp_calibration.vor import (
+    build_universe,
+    compute_vor,
+    score_universe,
+)
+
+
+def _universe():
+    out = []
+    for i in range(40):
+        out.append(
+            PlayerSeason(
+                player_id=f"p{i}",
+                name=f"Player {i}",
+                position="DL",
+                games=16,
+                stats={"idp_tkl_solo": 40 - i, "idp_sack": max(0, 8 - i / 5)},
+            )
+        )
+    return out
+
+
+def test_same_universe_rescored_by_both_weight_sets():
+    universe = _universe()
+    weights_a = {"idp_tkl_solo": 1.0, "idp_sack": 4.0}
+    weights_b = {"idp_tkl_solo": 2.0, "idp_sack": 2.0}
+    scored = score_universe(universe, weights_a, weights_b)
+    # Invariant: every input player appears exactly once under both scorings.
+    assert {s.player_id for s in scored} == {p.player_id for p in universe}
+    assert len(scored) == len(universe)
+    top = max(scored, key=lambda s: s.points_test)
+    assert top.points_test != top.points_mine
+
+
+def test_compute_vor_yields_position_ranks():
+    universe = _universe()
+    weights_a = {"idp_tkl_solo": 1.0, "idp_sack": 4.0}
+    weights_b = {"idp_tkl_solo": 2.0, "idp_sack": 2.0}
+    scored = score_universe(universe, weights_a, weights_b)
+    rows = compute_vor(scored, {"DL": 10.0}, {"DL": 14.0})
+    ranks = sorted({r.rank_test for r in rows})
+    assert ranks[0] == 1
+    assert ranks[-1] == len(universe)
+
+
+def test_bucketize_merges_small_buckets_and_reports_merge():
+    universe = _universe()[:15]  # only 15 players — tail buckets will be small
+    weights = {"idp_tkl_solo": 1.0}
+    scored = score_universe(universe, weights, weights)
+    rows = compute_vor(scored, {"DL": 5.0}, {"DL": 5.0})
+    buckets = bucketize(rows, "DL", buckets=DEFAULT_BUCKETS, min_bucket_size=3)
+    merged_labels = [m for b in buckets for m in b.merged_from]
+    # With 15 DLs and default buckets, later buckets should merge into earlier ones.
+    assert any(merged_labels), "Expected at least one merge"
+
+
+def test_bucketize_blended_center_equals_mean_plus_median_over_2():
+    rows = []
+    for i in range(10):
+        rows.append(
+            type(
+                "VorRow",
+                (),
+                dict(
+                    player_id=str(i),
+                    name=str(i),
+                    position="LB",
+                    games=16,
+                    points_test=0.0,
+                    points_mine=0.0,
+                    vor_test=float(i),
+                    vor_mine=float(i) + 5,
+                    rank_test=i + 1,
+                    rank_mine=i + 1,
+                ),
+            )(),
+        )
+    buckets = bucketize(rows, "LB", buckets=[(1, 10)], min_bucket_size=3)
+    assert len(buckets) == 1
+    # mean of 0..9 = 4.5, median = 4.5, blended = 4.5 for vor_test
+    assert buckets[0].center_vor_test == 4.5
+    assert buckets[0].center_vor_mine == 9.5


### PR DESCRIPTION
## Summary

Private, auth-gated internal workspace at **`/tools/idp-calibration`** that calibrates IDP (DL / LB / DB) multipliers from two Sleeper league IDs across the 2022-2025 seasons and lets you **manually** promote the approved output into the live trade calculator.

- Takes a test/market league ID + your league ID, walks `previous_league_id` back to resolve 2022-2025, rescores a common IDP player universe under both scoring systems each season, and computes lineup-aware VOR.
- Per-position per-bucket intrinsic / market / final (blended) multipliers + monotonic anchor curves for DL / LB / DB.
- Every run persists to `data/idp_calibration/runs/{run_id}.json`. Promotion writes `config/idp_calibration.json` and backs up the prior file — **no run ever auto-promotes**.
- Live pipeline reads the promoted config via `src/idp_calibration/production.py` from a new post-pass helper in `src/api/data_contract.py` (strict no-op when no config is promoted).

## Architecture highlights

**Backend** (`src/idp_calibration/`):
- `sleeper_client.py` — reuses the public-pipeline pooled session; adds a deeper `fetch_league_chain`.
- `season_chain.py` — resolves 2022-2025 without silently substituting the wrong year.
- `stats_adapter.py` — abstract historical stats interface (SleeperStats probe, LocalCSV fallback, ManualFallback with loud warnings). Network access opt-in via `IDP_CALIBRATION_ALLOW_NETWORK=1`.
- `scoring.py` / `lineup.py` / `replacement.py` / `vor.py` / `buckets.py` / `translation.py` / `anchors.py` — the math pipeline. Blended center = (mean + median) / 2. Neighbour-merge on small buckets. Monotonic non-increasing anchor smoothing.
- `engine.py` — orchestrator. `storage.py` — versioned artefacts. `promotion.py` — manual promote with config backup. `production.py` — single read path used by the live valuation pipeline.

**Endpoints** (all auth-gated):
- `POST /api/idp-calibration/analyze`
- `GET  /api/idp-calibration/runs`
- `GET  /api/idp-calibration/runs/{run_id}`
- `POST /api/idp-calibration/promote`
- `GET  /api/idp-calibration/production`
- `GET  /api/idp-calibration/status`

**Frontend** (`frontend/app/tools/idp-calibration/`):
- Matches the existing vanilla-CSS / vanilla-React convention — no new dependencies.
- League input form, advanced settings drawer, results dashboard (league verification, IDP demand, season VOR, multi-year summary, anchor charts, recommendation), saved runs list, production config panel, JSON/CSV export buttons.
- 6 proxy routes under `frontend/app/api/idp-calibration/*` forwarding cookies for auth.
- Nav entry added to `AppShellWrapper.jsx` (`IDP Lab`).

**Live-pipeline integration**: `src/api/data_contract.py::_apply_idp_calibration_post_pass` runs after Phase 4, groups IDP rows by canonical position, ranks them, multiplies `rankDerivedValue` by the promoted per-bucket multiplier for the active mode (blended / intrinsic_only / market_only), and mirrors into the legacy dict. Offense and picks are untouched.

See `docs/idp_calibration_lab.md` for data sources, promoted-config schema, consumer read-path, and known limitations.

## Test plan

- [x] `python -m pytest tests/idp_calibration/ -q` — 30 new tests pass
- [x] `python -m pytest tests/ -q --ignore=tests/e2e --ignore=tests/api/test_draft_capital.py` — 1494 passed, 26 skipped (no regressions; `test_draft_capital` failures are pre-existing, environment missing `fastapi`).
- [ ] Manual UI smoke with real Sleeper league IDs in a dev stack (`python server.py` + `npm run dev -w frontend`).
- [ ] Promote a run → confirm `config/idp_calibration.json` is written, prior file moved to `config/idp_calibration.backups/`, and IDP rows on `/rankings` shift per the promoted multipliers while offense rows stay unchanged.
- [ ] Revert by deleting the promoted config → IDP rows return to identity valuation.

https://claude.ai/code/session_01Ub9Z6e914gMMdC4goBME8V