### PR TITLE
Add IDP Calibration Lab to mobile More page

### DIFF
--- a/frontend/app/more/page.jsx
+++ b/frontend/app/more/page.jsx
@@ -27,6 +27,7 @@ const SECTIONS = [
   {
     title: "Tools",
     items: [
+      { href: "/tools/idp-calibration", label: "IDP Calibration Lab", desc: "Internal: calibrate DL/LB/DB multipliers from two Sleeper leagues across 2022–2025, then promote to production" },
       { href: "/settings", label: "Settings", desc: "Tuning controls for valuations and display" },
     ],
   },


### PR DESCRIPTION
## Summary

Adds the IDP Calibration Lab entry to the mobile **More** page (`/more`) under the Tools section. PR #91 added the lab itself and the desktop top-nav entry, but missed the hand-curated More page, so on mobile the lab was unreachable (bottom bar is Ranks / Trade / More, and More is not auto-populated).

## Test plan

- [x] Confirm entry renders under Tools on `/more`.
- [ ] Mobile smoke: open `/more`, tap **IDP Calibration Lab**, confirm navigation to `/tools/idp-calibration`.

https://claude.ai/code/session_01Ub9Z6e914gMMdC4goBME8V