### PR TITLE
IDP Lab: default stats network ON in prod, OFF under pytest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,15 +58,19 @@ LOG_FORMAT=text
 # ALERT_PASSWORD=gmail-app-password
 
 # ── IDP Calibration Lab ──────────────────────────────────────────────────
-# Opt-in network access for the historical stats adapter layer at
-# src/idp_calibration/stats_adapter.py. Off by default so unit tests and
-# local dev don't accidentally hit Sleeper's undocumented season-stats
-# endpoint on every run.
+# Controls network access for the historical stats adapter layer at
+# src/idp_calibration/stats_adapter.py.
 #
-# Set to "1" (or "true" / "yes") in production to let SleeperStatsAdapter
-# probe https://api.sleeper.app/v1/stats/nfl/regular/{season}. If that
-# endpoint is unreachable the adapter factory falls through to
-# LocalCSVStatsAdapter (data/idp_calibration/stats/{season}.csv), then
-# ManualFallbackAdapter (no-op with loud warning).
+# Default behaviour:
+#   * Production server (no pytest in sys.modules)   → network ENABLED
+#   * Unit-test / pytest run                         → network DISABLED
+#
+# Override only if you need to pin the behaviour — e.g. you want to
+# disable network on the prod host (use "0"), or force it on in a
+# local dev workflow (use "1").
+#
+# Accepted values:
+#   enable:  "1" / "true" / "yes" / "on"
+#   disable: "0" / "false" / "no" / "off"
 #
 # IDP_CALIBRATION_ALLOW_NETWORK=1

--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,17 @@ LOG_FORMAT=text
 # ALERT_TO=you@example.com
 # ALERT_FROM=sender@gmail.com
 # ALERT_PASSWORD=gmail-app-password
+
+# ── IDP Calibration Lab ──────────────────────────────────────────────────
+# Opt-in network access for the historical stats adapter layer at
+# src/idp_calibration/stats_adapter.py. Off by default so unit tests and
+# local dev don't accidentally hit Sleeper's undocumented season-stats
+# endpoint on every run.
+#
+# Set to "1" (or "true" / "yes") in production to let SleeperStatsAdapter
+# probe https://api.sleeper.app/v1/stats/nfl/regular/{season}. If that
+# endpoint is unreachable the adapter factory falls through to
+# LocalCSVStatsAdapter (data/idp_calibration/stats/{season}.csv), then
+# ManualFallbackAdapter (no-op with loud warning).
+#
+# IDP_CALIBRATION_ALLOW_NETWORK=1

--- a/docs/idp_calibration_lab.md
+++ b/docs/idp_calibration_lab.md
@@ -126,28 +126,30 @@ On promote:
 The promoted config is the **single** entry point. There is no parallel
 code path — if the file is deleted, every IDP multiplier is 1.0 again.
 
-## Enabling stats access in production
+## Stats network access
 
-By default the lab's network-probing adapter (`SleeperStatsAdapter`) is
-**disabled** — unit tests and local dev should never touch Sleeper's
-undocumented season-stats endpoint, and a fresh clone of the repo is
-intentionally a strict no-op until you opt in.
+`SleeperStatsAdapter` probes an undocumented Sleeper endpoint, so we
+keep its behaviour predictable:
 
-To let the lab actually score historical stats in production:
+* **Production server (no pytest in `sys.modules`)** → network
+  **enabled by default**. The adapter factory tries Sleeper first,
+  falls through to `LocalCSVStatsAdapter`
+  (`data/idp_calibration/stats/{season}.csv`), then
+  `ManualFallbackAdapter`.
+* **pytest** → network **disabled by default** so the unit suite never
+  touches a live endpoint.
 
-1. Add `IDP_CALIBRATION_ALLOW_NETWORK=1` to your production `.env`
-   (the systemd unit at `deploy/systemd/dynasty.service.template`
-   already loads `__APP_DIR__/.env` via `EnvironmentFile=-`).
-2. `sudo systemctl restart dynasty.service` (and `dynasty-frontend.service`
-   if a backend restart dropped the Next.js proxy).
-3. Re-run analysis. You should see `adapter=sleeper` on each resolved
-   season instead of `adapter=manual_fallback`.
+No operator setup is required on a fresh deploy. If you want to
+override the default, set `IDP_CALIBRATION_ALLOW_NETWORK` in
+`__APP_DIR__/.env` and restart the service — `"1"` / `"true"` /
+`"yes"` / `"on"` enable, `"0"` / `"false"` / `"no"` / `"off"`
+disable. Explicit caller arguments to `get_stats_adapter()` always win
+over both.
 
-If the Sleeper endpoint is unreachable from your VPS, the adapter
-factory automatically falls through to `LocalCSVStatsAdapter` — drop
-CSVs at `data/idp_calibration/stats/{season}.csv` with the header
-documented above and the lab will use them in preference order
-`sleeper → local_csv → manual_fallback`.
+If the Sleeper endpoint is unreachable from your VPS even with network
+enabled, drop CSVs at `data/idp_calibration/stats/{season}.csv` with
+the header documented above — the factory uses them in preference
+order `sleeper → local_csv → manual_fallback`.
 
 ## Known limitations
 

--- a/docs/idp_calibration_lab.md
+++ b/docs/idp_calibration_lab.md
@@ -126,6 +126,29 @@ On promote:
 The promoted config is the **single** entry point. There is no parallel
 code path — if the file is deleted, every IDP multiplier is 1.0 again.
 
+## Enabling stats access in production
+
+By default the lab's network-probing adapter (`SleeperStatsAdapter`) is
+**disabled** — unit tests and local dev should never touch Sleeper's
+undocumented season-stats endpoint, and a fresh clone of the repo is
+intentionally a strict no-op until you opt in.
+
+To let the lab actually score historical stats in production:
+
+1. Add `IDP_CALIBRATION_ALLOW_NETWORK=1` to your production `.env`
+   (the systemd unit at `deploy/systemd/dynasty.service.template`
+   already loads `__APP_DIR__/.env` via `EnvironmentFile=-`).
+2. `sudo systemctl restart dynasty.service` (and `dynasty-frontend.service`
+   if a backend restart dropped the Next.js proxy).
+3. Re-run analysis. You should see `adapter=sleeper` on each resolved
+   season instead of `adapter=manual_fallback`.
+
+If the Sleeper endpoint is unreachable from your VPS, the adapter
+factory automatically falls through to `LocalCSVStatsAdapter` — drop
+CSVs at `data/idp_calibration/stats/{season}.csv` with the header
+documented above and the lab will use them in preference order
+`sleeper → local_csv → manual_fallback`.
+
 ## Known limitations
 
 - The Sleeper stats endpoint is undocumented. When it fails, the lab

--- a/src/idp_calibration/stats_adapter.py
+++ b/src/idp_calibration/stats_adapter.py
@@ -279,6 +279,24 @@ class ManualFallbackAdapter(HistoricalStatsAdapter):
 _ADAPTER_ORDER = ("sleeper", "local_csv", "manual_fallback")
 
 
+def _detect_test_context() -> bool:
+    """Heuristic: are we running under pytest?
+
+    Checking ``sys.modules`` is the cheapest reliable signal — pytest
+    always imports itself before any test collects, and production
+    server processes never import it. We use this to default network
+    *off* under tests while keeping it *on* in production so the live
+    lab works without operator env-var plumbing.
+    """
+    import sys as _sys
+
+    if "pytest" in _sys.modules:
+        return True
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return True
+    return False
+
+
 def get_stats_adapter(
     season: int,
     *,
@@ -287,15 +305,25 @@ def get_stats_adapter(
 ) -> tuple[HistoricalStatsAdapter, list[str]]:
     """Return the first available adapter for ``season``.
 
-    ``allow_network`` defaults to the ``IDP_CALIBRATION_ALLOW_NETWORK``
-    environment variable (``"1"`` / ``"true"`` enables; anything else
-    disables). In test and CI environments network access is disabled
-    by default so ``SleeperStatsAdapter`` is skipped unless explicitly
-    allowed.
+    ``allow_network`` resolves in this order:
+
+    1. Explicit caller argument wins.
+    2. ``IDP_CALIBRATION_ALLOW_NETWORK`` env var — ``"1"`` / ``"true"``
+       / ``"yes"`` / ``"on"`` enables; ``"0"`` / ``"false"`` / ``"no"``
+       / ``"off"`` disables.
+    3. Otherwise, **default on in production, off under pytest**. This
+       lets a freshly-deployed production backend probe Sleeper without
+       requiring the operator to edit ``.env`` by hand, while keeping
+       the unit-test suite network-free by default.
     """
     if allow_network is None:
         env_val = str(os.getenv("IDP_CALIBRATION_ALLOW_NETWORK", "")).strip().lower()
-        allow_network = env_val in {"1", "true", "yes", "on"}
+        if env_val in {"1", "true", "yes", "on"}:
+            allow_network = True
+        elif env_val in {"0", "false", "no", "off"}:
+            allow_network = False
+        else:
+            allow_network = not _detect_test_context()
     attempted: list[str] = []
     for name in order or _ADAPTER_ORDER:
         if name == "sleeper":

--- a/tests/idp_calibration/test_stats_adapter_cache.py
+++ b/tests/idp_calibration/test_stats_adapter_cache.py
@@ -43,3 +43,41 @@ def test_cache_is_per_season():
     adapter.fetch(2025)
     adapter.fetch(2024)
     assert adapter.calls == 2  # 2024 and 2025 each hit the impl exactly once.
+
+
+def test_get_stats_adapter_defaults_network_off_under_pytest(monkeypatch):
+    """Because these tests import pytest, _detect_test_context() should
+    return True and the factory should skip ``SleeperStatsAdapter``
+    automatically unless the env var or explicit arg overrides."""
+    from src.idp_calibration import stats_adapter
+
+    monkeypatch.delenv("IDP_CALIBRATION_ALLOW_NETWORK", raising=False)
+    _, attempts = stats_adapter.get_stats_adapter(2025)
+    assert any("skipped (network disabled)" in a for a in attempts)
+
+
+def test_get_stats_adapter_env_var_forces_network_on(monkeypatch):
+    from src.idp_calibration import stats_adapter
+
+    monkeypatch.setenv("IDP_CALIBRATION_ALLOW_NETWORK", "1")
+    _, attempts = stats_adapter.get_stats_adapter(2025)
+    # With network opt-in the sleeper attempt is tried rather than
+    # being skipped outright. It may still return unavailable locally
+    # (no network in CI), but the marker is not "skipped".
+    assert not any("skipped (network disabled)" in a for a in attempts)
+
+
+def test_get_stats_adapter_env_var_forces_network_off(monkeypatch):
+    """Explicit "0" still overrides even if someone flipped the default."""
+    from src.idp_calibration import stats_adapter
+
+    monkeypatch.setenv("IDP_CALIBRATION_ALLOW_NETWORK", "0")
+    _, attempts = stats_adapter.get_stats_adapter(2025)
+    assert any("skipped (network disabled)" in a for a in attempts)
+
+
+def test_detect_test_context_sees_pytest():
+    # Sanity check: our detector fires inside the test process.
+    from src.idp_calibration.stats_adapter import _detect_test_context
+
+    assert _detect_test_context() is True

--- a/tests/idp_calibration/test_stats_adapter_cache.py
+++ b/tests/idp_calibration/test_stats_adapter_cache.py
@@ -59,12 +59,24 @@ def test_get_stats_adapter_defaults_network_off_under_pytest(monkeypatch):
 def test_get_stats_adapter_env_var_forces_network_on(monkeypatch):
     from src.idp_calibration import stats_adapter
 
+    # Stub _fetch_impl so the adapter-selection probe doesn't perform
+    # a real HTTP call against api.sleeper.app. The assertion only
+    # cares which branch the factory takes, not whether the sleeper
+    # endpoint is reachable from the test runner — a real call would
+    # make this test flaky on no-egress or slow CI networks.
+    def _fail(self, season):
+        raise stats_adapter.AdapterUnavailable("stubbed: no network in tests")
+
+    monkeypatch.setattr(stats_adapter.SleeperStatsAdapter, "_fetch_impl", _fail)
     monkeypatch.setenv("IDP_CALIBRATION_ALLOW_NETWORK", "1")
+
     _, attempts = stats_adapter.get_stats_adapter(2025)
-    # With network opt-in the sleeper attempt is tried rather than
-    # being skipped outright. It may still return unavailable locally
-    # (no network in CI), but the marker is not "skipped".
+    # We forced network on, so the sleeper branch must NOT have been
+    # marked as skipped — it was attempted (and failed deterministically
+    # via our stub).
     assert not any("skipped (network disabled)" in a for a in attempts)
+    # The sleeper branch entry must appear in the attempt log.
+    assert any(a.startswith("sleeper:") for a in attempts)
 
 
 def test_get_stats_adapter_env_var_forces_network_off(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the production calibration lab so it "just works" after a code deploy — **no operator VPS shell required**.

Previously the operator had to hand-edit `.env` on the prod VPS to add `IDP_CALIBRATION_ALLOW_NETWORK=1` before `SleeperStatsAdapter` would probe Sleeper. Miss that step and the lab silently degraded to `ManualFallbackAdapter` with warnings like `sleeper:skipped (network disabled)`.

New behaviour in `src/idp_calibration/stats_adapter.py::get_stats_adapter`:

- **Production server (no pytest in `sys.modules`)** → network **enabled by default**.
- **pytest** → network **disabled by default** so the unit suite never touches a live endpoint.
- `IDP_CALIBRATION_ALLOW_NETWORK` env var still overrides auto-detect either way (values: `1/true/yes/on` → on; `0/false/no/off` → off).
- Explicit caller arg to `get_stats_adapter(..., allow_network=...)` wins over everything.

Pytest detection uses `sys.modules` (always present by the time tests collect) and `PYTEST_CURRENT_TEST` — cheap and reliable.

Docs updated to reflect the new default. Existing tests all still use stub adapters, so none of them regress. Four new tests lock in the auto-detect + env-var override behaviour.

## Test plan

- [x] `python -m pytest tests/idp_calibration/ -q` — 58 passed.
- [x] `python -m pytest tests/ -q --ignore=tests/e2e --ignore=tests/api/test_draft_capital.py` — 1522 passed, 26 skipped, no regressions.
- [ ] After merge + next production deploy: re-run the IDP Lab against the two league IDs and confirm `adapter=sleeper` on resolved seasons instead of `manual_fallback`.

https://claude.ai/code/session_01Ub9Z6e914gMMdC4goBME8V