### PR TITLE
IDP Lab: floor bucket multipliers at anchor_floor (prevent negatives)

### DIFF
--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -504,6 +504,7 @@ def run_analysis(
         per_season_per_position_buckets,
         year_weights=normalised_weights,
         blend=settings.blend,
+        multiplier_floor=settings.anchor_floor,
     )
     anchors = build_all_anchors(
         multipliers,

--- a/src/idp_calibration/translation.py
+++ b/src/idp_calibration/translation.py
@@ -141,8 +141,21 @@ def compute_position_multipliers(
     *,
     year_weights: dict[int, float] | None = None,
     blend: dict[str, float] | None = None,
+    multiplier_floor: float = 0.05,
 ) -> PositionMultipliers:
-    """Combine per-season bucket tables into per-bucket multipliers."""
+    """Combine per-season bucket tables into per-bucket multipliers.
+
+    ``multiplier_floor`` (default ``0.05``) clamps every emitted
+    multiplier to a positive minimum. Without it, sub-replacement
+    buckets produce **negative** multipliers: VOR goes negative for
+    players below replacement, normalisation against the positive
+    top bucket yields a negative ratio, and the live pipeline would
+    multiply ``rankDerivedValue`` by a negative number — flipping a
+    player's value sign, which is nonsense (a bench depth player
+    still has positive trade value, just a small one). Flooring at
+    5% matches the anchor-curve floor so bucket and anchor lookups
+    don't disagree.
+    """
     year_weights = year_weights or DEFAULT_YEAR_WEIGHTS
     blend = blend or DEFAULT_BLEND
     labels = _bucket_labels(per_season)
@@ -163,12 +176,19 @@ def compute_position_multipliers(
                     total_count += int(b.count)
                     break
         counts.append(total_count)
-    intrinsic_norm = _enforce_descending(_normalise(intrinsic_raw))
-    market_norm = _enforce_descending(_normalise(market_raw))
+    intrinsic_norm = _clamp_series(
+        _enforce_descending(_normalise(intrinsic_raw)), multiplier_floor
+    )
+    market_norm = _clamp_series(
+        _enforce_descending(_normalise(market_raw)), multiplier_floor
+    )
     alpha = float(blend.get("intrinsic", 0.75))
     beta = 1.0 - alpha
-    final_norm = _enforce_descending(
-        [alpha * i + beta * m for i, m in zip(intrinsic_norm, market_norm)]
+    final_norm = _clamp_series(
+        _enforce_descending(
+            [alpha * i + beta * m for i, m in zip(intrinsic_norm, market_norm)]
+        ),
+        multiplier_floor,
     )
     buckets = [
         BucketMultipliers(
@@ -201,17 +221,44 @@ def _enforce_descending(values: list[float]) -> list[float]:
     return out
 
 
+def _clamp_series(values: list[float], floor: float) -> list[float]:
+    """Clamp every value into ``[floor, 1.0]`` while preserving non-increasing order.
+
+    Without this, ``_normalise`` divides every VOR center by the top
+    bucket's positive value — sub-replacement buckets (negative VOR)
+    therefore emit *negative* multipliers. Applied to a positive
+    ``rankDerivedValue`` in the live pipeline, a negative multiplier
+    would flip the player's value sign. We instead floor at
+    ``floor`` (default 5%) so sub-replacement buckets collapse to
+    the minimum positive multiplier and cap at 1.0 so calibration
+    noise can't inflate a deep bucket past the top bucket.
+    """
+    floor = max(0.0, float(floor))
+    return [max(floor, min(1.0, float(v))) for v in values]
+
+
 def build_multi_year_multipliers(
     per_season_per_position: dict[str, dict[int, list[BucketResult]]],
     *,
     year_weights: dict[int, float] | None = None,
     blend: dict[str, float] | None = None,
+    multiplier_floor: float = 0.05,
 ) -> dict[str, PositionMultipliers]:
-    """Produce intrinsic/market/final multiplier tables for DL/LB/DB."""
+    """Produce intrinsic/market/final multiplier tables for DL/LB/DB.
+
+    ``multiplier_floor`` flows through to
+    :func:`compute_position_multipliers` so every emitted multiplier
+    sits inside ``[floor, 1.0]``. See the per-position helper's
+    docstring for the rationale (sub-replacement VOR would otherwise
+    yield negative multipliers).
+    """
     out: dict[str, PositionMultipliers] = {}
     for position, per_season in per_season_per_position.items():
         result = compute_position_multipliers(
-            per_season, year_weights=year_weights, blend=blend
+            per_season,
+            year_weights=year_weights,
+            blend=blend,
+            multiplier_floor=multiplier_floor,
         )
         result.position = position
         out[position] = result

--- a/tests/idp_calibration/test_translation_anchors.py
+++ b/tests/idp_calibration/test_translation_anchors.py
@@ -120,3 +120,67 @@ def test_normalise_year_weights_empty_seasons_returns_empty():
     # Edge case — protect against ZeroDivisionError in the uniform
     # branch when nothing is selected.
     assert normalise_year_weights(DEFAULT_YEAR_WEIGHTS, seasons=[]) == {}
+
+
+def _series(*pairs, count=10):
+    """Build a single-season bucket series where each tuple is
+    (label, lo, hi, test_val, mine_val)."""
+    return [_bucket(lbl, lo, hi, tv, mv, count=count) for lbl, lo, hi, tv, mv in pairs]
+
+
+def test_sub_replacement_buckets_are_floored_not_negative():
+    # Reproduces the real-run case the user showed: DL buckets 37-60
+    # and 61-100 have negative VOR centers, which under raw
+    # normalisation produce negative multipliers. The clamp must
+    # floor each of intrinsic/market/final at 0.05 so the live
+    # pipeline never multiplies a positive rankDerivedValue by a
+    # negative number.
+    series = _series(
+        ("1-6", 1, 6, 100.0, 120.0),
+        ("7-12", 7, 12, 50.0, 60.0),
+        ("13-24", 13, 24, 20.0, 25.0),
+        ("25-36", 25, 36, 0.0, 5.0),
+        ("37-60", 37, 60, -30.0, -20.0),       # sub-replacement
+        ("61-100", 61, 100, -55.0, -45.0),     # deep sub-replacement
+    )
+    per_position = {"DL": {2025: series}}
+    multipliers = build_multi_year_multipliers(
+        per_position,
+        year_weights={2025: 1.0},
+        blend=DEFAULT_BLEND,
+    )
+    dl = multipliers["DL"].buckets
+    # Every emitted multiplier must be in [0.05, 1.0] on every
+    # channel (intrinsic, market, final). Previously 37-60 and
+    # 61-100 were negative on all three.
+    for b in dl:
+        for channel in ("intrinsic", "market", "final"):
+            val = getattr(b, channel)
+            assert 0.05 - 1e-9 <= val <= 1.0 + 1e-9, (
+                f"{b.label} {channel}={val} outside [0.05, 1.0]"
+            )
+    # Top bucket still equals 1.0 (normalisation anchor).
+    assert abs(dl[0].intrinsic - 1.0) < 1e-6
+    assert abs(dl[0].market - 1.0) < 1e-6
+    assert abs(dl[0].final - 1.0) < 1e-6
+    # Sub-replacement buckets are floored, not 0 and not negative.
+    for bucket in dl[-2:]:
+        assert abs(bucket.intrinsic - 0.05) < 1e-9
+        assert abs(bucket.market - 0.05) < 1e-9
+        assert abs(bucket.final - 0.05) < 1e-9
+
+
+def test_custom_multiplier_floor_propagates():
+    # If a caller raises the floor (say 0.10) the clamp applies at
+    # that level end-to-end.
+    series = _series(
+        ("1-6", 1, 6, 100.0, 120.0),
+        ("7-12", 7, 12, -50.0, -40.0),  # immediately sub-replacement
+    )
+    multipliers = build_multi_year_multipliers(
+        {"DL": {2025: series}},
+        year_weights={2025: 1.0},
+        blend=DEFAULT_BLEND,
+        multiplier_floor=0.10,
+    )
+    assert abs(multipliers["DL"].buckets[1].final - 0.10) < 1e-9


### PR DESCRIPTION
## Summary

Real-data run exposed a math bug that would have corrupted production if promoted. Sub-replacement buckets (VOR centers below zero) produced **negative** per-bucket multipliers — e.g. `DL 61-100 = -0.4549`, `LB 61-100 = -1.3138`. Applied to a positive `rankDerivedValue` in the live pipeline, a negative multiplier would flip the player's value sign. Nonsense — a bench-depth player has low positive trade value, not negative.

## Root cause

`_normalise()` divides every weighted VOR center by the top bucket's positive value. When a center is negative the ratio is negative. The anchor curve already floored at 0.05 via `_monotone_non_increasing(values, floor=floor)`, but bucket normalisation had no analogous clamp. And bucket lookup is the primary read path in `production.py::_bucket_lookup_for` — anchors are only the fallback — so the floor wasn't reaching the numbers that actually matter.

## Fix

- New `_clamp_series(values, floor)` helper squeezes each series into `[floor, 1.0]` while preserving non-increasing order.
- `compute_position_multipliers` now accepts a `multiplier_floor` kwarg (default 0.05) and applies it to intrinsic / market / final before emitting buckets.
- `build_multi_year_multipliers` threads it through so the engine can pass `settings.anchor_floor` (already plumbed from `AnalysisSettings`).
- `engine.run_analysis` passes `settings.anchor_floor` so floor and anchor smoothing stay in lockstep.

## Tests

- `test_sub_replacement_buckets_are_floored_not_negative` — reproduces the user's real run (buckets with negative centers) and asserts every emitted multiplier stays in `[0.05, 1.0]` across intrinsic / market / final.
- `test_custom_multiplier_floor_propagates` — confirms the knob.

Full pytest suite: **1611 passed, 26 skipped**.

## Test plan

- [x] `pytest tests/ -q --ignore=tests/e2e --ignore=tests/api/test_draft_capital.py`
- [ ] After deploy: re-run the IDP Lab against the two real league IDs. Multi-year calibration summary should show every bucket multiplier ≥ 0.05 and ≤ 1.0 across DL / LB / DB / intrinsic / market / final. **Now safe to promote.**

https://claude.ai/code/session_01Ub9Z6e914gMMdC4goBME8V