### PR TITLE
IDP Lab: cross-family IDP-vs-offense scaling layer

### DIFF
--- a/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
+++ b/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
@@ -189,11 +189,71 @@ function SectionBuckets({ run }) {
   );
 }
 
+function FamilyScaleBlock({ family }) {
+  if (!family) return null;
+  const { intrinsic, market, final, sample_size: samples = {} } = family;
+  if (intrinsic == null && market == null && final == null) return null;
+  const pct = Math.abs(((intrinsic ?? 1) - 1) * 100);
+  const direction = (intrinsic ?? 1) > 1 ? "higher" : "lower";
+  return (
+    <div className="idp-lab-mult-block idp-lab-family-scale">
+      <div className="idp-lab-subheading">
+        <strong>IDP family scale</strong>
+        <span className="muted">how this league values IDP vs offense as a class</span>
+      </div>
+      <div className="table-wrap">
+        <table className="table idp-lab-mult-table">
+          <thead>
+            <tr>
+              <th>Channel</th>
+              <th>Factor</th>
+              <th>Interpretation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Intrinsic</td>
+              <td>{n(intrinsic, 4)}×</td>
+              <td className="muted">
+                {intrinsic != null
+                  ? `${pct.toFixed(1)}% ${direction} than market baseline`
+                  : "—"}
+              </td>
+            </tr>
+            <tr>
+              <td>Market</td>
+              <td>{n(market, 4)}×</td>
+              <td className="muted">test-league baseline (1.0 by construction)</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Final (active)</strong>
+              </td>
+              <td>
+                <strong>{n(final, 4)}×</strong>
+              </td>
+              <td className="muted">blended IDP-class lift/discount</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {samples && Object.keys(samples).length > 0 && (
+        <p className="muted text-sm">
+          Sample sizes — IDP (mine): {samples.idp_my ?? 0}, IDP (test):{" "}
+          {samples.idp_test ?? 0}, offense (mine): {samples.offense_my ?? 0},
+          offense (test): {samples.offense_test ?? 0}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function SectionMultipliers({ run }) {
   const multipliers = run.multipliers || {};
   return (
     <section className="card idp-lab-section">
       <h2>Multi-year calibration summary</h2>
+      <FamilyScaleBlock family={run.family_scale} />
       {POSITIONS.map((pos) => {
         const posBlock = multipliers[pos];
         if (!posBlock?.buckets?.length) {

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -545,6 +545,15 @@ def run_analysis(
                 test_scoring.offense_weights,
                 my_scoring.offense_weights,
             )
+            # Mirror the IDP-side trim so the family_scale ratio stays
+            # symmetric. Without this, enabling top_n trims the
+            # numerator (IDP) while leaving the denominator (offense)
+            # at its full universe size, which would shift family_scale
+            # purely because of the trim — not because of league economics.
+            if settings.top_n:
+                offense_scored = trim_to_top_n_per_position(
+                    offense_scored, settings.top_n, positions=OFFENSE_FAMILY
+                )
             offense_repl_my = _compute_offense_replacement(
                 offense_scored, my_lineup, settings.replacement, side="mine"
             )

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -30,11 +30,16 @@ from .stats_adapter import (
 from .translation import (
     DEFAULT_BLEND,
     DEFAULT_YEAR_WEIGHTS,
+    FamilyScale,
     build_multi_year_multipliers,
+    combine_family_scales,
+    compute_family_scale,
     multipliers_to_dict,
     normalise_year_weights,
 )
 from .vor import (
+    IDP_FAMILY,
+    OFFENSE_FAMILY,
     ScoredPlayer,
     VorRow,
     build_universe,
@@ -45,6 +50,7 @@ from .vor import (
 )
 
 POSITIONS: tuple[str, ...] = ("DL", "LB", "DB")
+OFFENSE_POSITIONS: tuple[str, ...] = ("QB", "RB", "WR", "TE")
 
 
 def _safe_int(value: Any, default: int) -> int:
@@ -259,13 +265,59 @@ def _make_run_id(test_id: str, my_id: str, seasons: list[int]) -> str:
     return f"{ts}_{short}"
 
 
+def _compute_offense_replacement(
+    scored: list["ScoredPlayer"],
+    lineup: "LineupDemand",
+    settings: "ReplacementSettings",
+    *,
+    side: str,
+) -> dict[str, float]:
+    """Replacement points per offense position for a given scoring side.
+
+    ``side`` is either ``"mine"`` or ``"test"`` and picks which
+    scoring column (``points_mine`` vs ``points_test``) is used. Mirrors
+    :func:`src.idp_calibration.replacement.compute_replacement_levels`
+    but for the offense family since the existing helper hard-codes
+    DL/LB/DB.
+    """
+    points_key = "points_mine" if side == "mine" else "points_test"
+    from .replacement import POSITIONS as _IDP_POSITIONS_UNUSED  # noqa: F401 — keep import parity
+    settings = settings.normalized()
+    by_position: dict[str, list[float]] = {p: [] for p in OFFENSE_POSITIONS}
+    for player in scored:
+        if player.position in by_position:
+            by_position[player.position].append(getattr(player, points_key))
+    out: dict[str, float] = {}
+    for pos, points in by_position.items():
+        points_desc = sorted(points, reverse=True)
+        rank = lineup.replacement_rank(
+            pos,
+            settings.mode,
+            settings.buffer_pct,
+            settings.manual.get(pos),
+        )
+        if not points_desc:
+            out[pos] = 0.0
+        elif rank <= len(points_desc):
+            out[pos] = points_desc[rank - 1]
+        else:
+            out[pos] = points_desc[-1]
+    return out
+
+
 def _build_universe_for_season(
     season: int,
     *,
     adapter: HistoricalStatsAdapter | None = None,
     settings: AnalysisSettings,
-) -> tuple[list[PlayerSeason], list[str], str]:
-    """Return (universe, warnings, adapter_name) for a single season."""
+) -> tuple[list[PlayerSeason], list[PlayerSeason], list[str], str]:
+    """Return ``(idp_universe, offense_universe, warnings, adapter_name)``.
+
+    The stats adapter now returns both IDP and offense rows in one
+    fetch; we split them by position family so the VOR engine can
+    process each side independently. ``min_games`` applies to both
+    families.
+    """
     warnings: list[str] = []
     adapter_name = "none"
     if adapter is None:
@@ -283,8 +335,13 @@ def _build_universe_for_season(
     except AdapterUnavailable as exc:
         warnings.append(f"{season}: {exc}")
         raw = []
-    universe = build_universe(raw, min_games=settings.min_games)
-    return universe, warnings, adapter_name
+    idp_universe = build_universe(
+        raw, min_games=settings.min_games, positions=IDP_FAMILY
+    )
+    offense_universe = build_universe(
+        raw, min_games=settings.min_games, positions=OFFENSE_FAMILY
+    )
+    return idp_universe, offense_universe, warnings, adapter_name
 
 
 def run_analysis(
@@ -332,6 +389,7 @@ def run_analysis(
     per_season_per_position_buckets: dict[str, dict[int, list[BucketResult]]] = {
         pos: {} for pos in POSITIONS
     }
+    per_season_family_scales: dict[int, FamilyScale] = {}
     resolved_seasons: list[int] = []
 
     for season in sorted({int(s) for s in settings.seasons}):
@@ -431,23 +489,33 @@ def run_analysis(
         my_lineup = parse_lineup(my_league_obj)
 
         adapter = stats_adapter_factory(season) if stats_adapter_factory else None
-        universe, stats_warnings, adapter_name = _build_universe_for_season(
+        (
+            idp_universe,
+            offense_universe,
+            stats_warnings,
+            adapter_name,
+        ) = _build_universe_for_season(
             season, adapter=adapter, settings=settings
         )
         warnings.extend(stats_warnings)
 
-        if not universe:
+        if not idp_universe:
             per_season_payload[season] = {
                 "season": season,
                 "resolved": False,
-                "reason": f"No usable stats for {season} (adapter={adapter_name}).",
+                "reason": f"No usable IDP stats for {season} (adapter={adapter_name}).",
                 "adapter": adapter_name,
             }
             continue
 
-        scored = score_universe(universe, test_scoring.idp_weights, my_scoring.idp_weights)
+        # ── IDP side ──
+        scored = score_universe(
+            idp_universe, test_scoring.idp_weights, my_scoring.idp_weights
+        )
         if settings.top_n:
-            scored = trim_to_top_n_per_position(scored, settings.top_n)
+            scored = trim_to_top_n_per_position(
+                scored, settings.top_n, positions=IDP_FAMILY
+            )
         repl_test_levels = compute_replacement_levels(
             ({"position": p.position, "points": p.points_test} for p in scored),
             test_lineup,
@@ -466,6 +534,46 @@ def run_analysis(
         }
         vor_rows = compute_vor(scored, replacement_test, replacement_mine)
 
+        # ── Offense side — only needed for the family-scale calc ──
+        # We don't bucketize or surface offense bucket tables in the
+        # UI; offense VOR is used purely as the denominator in the
+        # IDP-vs-offense ratio that determines family_scale.
+        season_family_scale: FamilyScale | None = None
+        if offense_universe:
+            offense_scored = score_universe(
+                offense_universe,
+                test_scoring.offense_weights,
+                my_scoring.offense_weights,
+            )
+            offense_repl_my = _compute_offense_replacement(
+                offense_scored, my_lineup, settings.replacement, side="mine"
+            )
+            offense_repl_test = _compute_offense_replacement(
+                offense_scored, test_lineup, settings.replacement, side="test"
+            )
+            offense_vor_my = [
+                s.points_mine - offense_repl_my.get(s.position, 0.0)
+                for s in offense_scored
+            ]
+            offense_vor_test = [
+                s.points_test - offense_repl_test.get(s.position, 0.0)
+                for s in offense_scored
+            ]
+            idp_vor_my = [r.vor_mine for r in vor_rows]
+            idp_vor_test = [r.vor_test for r in vor_rows]
+            season_family_scale = compute_family_scale(
+                idp_vor_my=idp_vor_my,
+                idp_vor_test=idp_vor_test,
+                offense_vor_my=offense_vor_my,
+                offense_vor_test=offense_vor_test,
+                blend=settings.blend,
+            )
+        else:
+            warnings.append(
+                f"{season}: offense universe empty — family_scale for this "
+                f"season defaults to 1.0 (cannot compare IDP to offense)."
+            )
+
         position_buckets: dict[str, list[BucketResult]] = {}
         for pos in POSITIONS:
             buckets = bucketize(
@@ -477,11 +585,15 @@ def run_analysis(
             position_buckets[pos] = buckets
             per_season_per_position_buckets[pos][season] = buckets
 
+        if season_family_scale is not None:
+            per_season_family_scales[season] = season_family_scale
+
         per_season_payload[season] = {
             "season": season,
             "resolved": True,
             "adapter": adapter_name,
-            "universe_size": len(universe),
+            "universe_size": len(idp_universe),
+            "offense_universe_size": len(offense_universe),
             "test_scoring": test_scoring.summary(),
             "my_scoring": my_scoring.summary(),
             "test_lineup": test_lineup.to_dict(),
@@ -494,6 +606,9 @@ def run_analysis(
             "my_rules_source_season": int(my_league_obj.get("season") or season),
             "test_rules_borrowed": test_borrowed,
             "my_rules_borrowed": my_borrowed,
+            "family_scale": (
+                season_family_scale.to_dict() if season_family_scale else None
+            ),
         }
         resolved_seasons.append(season)
 
@@ -506,13 +621,16 @@ def run_analysis(
         blend=settings.blend,
         multiplier_floor=settings.anchor_floor,
     )
+    family_scale = combine_family_scales(
+        per_season_family_scales, normalised_weights
+    )
     anchors = build_all_anchors(
         multipliers,
         anchor_ranks=settings.anchor_ranks,
         floor=settings.anchor_floor,
     )
 
-    recommendation = _build_recommendation(multipliers, warnings)
+    recommendation = _build_recommendation(multipliers, warnings, family_scale)
 
     run_id = _make_run_id(test_league_id, my_league_id, settings.seasons)
 
@@ -533,6 +651,7 @@ def run_analysis(
         },
         "per_season": {str(k): v for k, v in per_season_payload.items()},
         "multipliers": multipliers_to_dict(multipliers),
+        "family_scale": family_scale.to_dict(),
         "anchors": anchors_to_dict(anchors),
         "recommendation": recommendation,
         "warnings": warnings,
@@ -541,17 +660,31 @@ def run_analysis(
 
 
 def _build_recommendation(
-    multipliers: dict[str, Any], warnings: list[str]
+    multipliers: dict[str, Any],
+    warnings: list[str],
+    family_scale: FamilyScale | None = None,
 ) -> dict[str, Any]:
     """Produce a plain-language summary block for the UI."""
     lines: list[str] = []
     notes: list[str] = []
     per_position: dict[str, dict[str, Any]] = {}
+
+    # Cross-family summary: if my league values IDP as a class more/less
+    # than the market, surface that at the top before the per-position
+    # within-family signals. This is the lever the user asked for.
+    if family_scale is not None and family_scale.intrinsic != 1.0:
+        pct = (family_scale.intrinsic - 1.0) * 100.0
+        direction = "higher" if pct > 0 else "lower"
+        lines.append(
+            f"IDP family scale: this league values IDP as a class "
+            f"{abs(pct):.1f}% {direction} than the market baseline "
+            f"(intrinsic {family_scale.intrinsic:.3f}x / final {family_scale.final:.3f}x)."
+        )
+
     for pos, pm in multipliers.items():
         if not pm.buckets:
             notes.append(f"No multiplier data available for {pos}.")
             continue
-        # Compare the mid-tier (3rd bucket if available, otherwise last)
         idx = min(2, len(pm.buckets) - 1)
         mid = pm.buckets[idx]
         direction = "neutral"
@@ -583,4 +716,5 @@ def _build_recommendation(
         "notes": notes,
         "per_position": per_position,
         "recommended_mode": "blended",
+        "family_scale": family_scale.to_dict() if family_scale else None,
     }

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -265,6 +265,14 @@ def _make_run_id(test_id: str, my_id: str, seasons: list[int]) -> str:
     return f"{ts}_{short}"
 
 
+_OFFENSE_DEMAND_ATTR: dict[str, str] = {
+    "QB": "total_qb_demand",
+    "RB": "total_rb_demand",
+    "WR": "total_wr_demand",
+    "TE": "total_te_demand",
+}
+
+
 def _compute_offense_replacement(
     scored: list["ScoredPlayer"],
     lineup: "LineupDemand",
@@ -275,13 +283,17 @@ def _compute_offense_replacement(
     """Replacement points per offense position for a given scoring side.
 
     ``side`` is either ``"mine"`` or ``"test"`` and picks which
-    scoring column (``points_mine`` vs ``points_test``) is used. Mirrors
-    :func:`src.idp_calibration.replacement.compute_replacement_levels`
-    but for the offense family since the existing helper hard-codes
-    DL/LB/DB.
+    scoring column (``points_mine`` vs ``points_test``) is used.
+
+    Positions with **zero starter demand** are skipped — e.g. TE in a
+    no-TE league with no TE-eligible flex. Without that guard,
+    ``replacement_rank`` would still floor at 1 (then add buffer),
+    causing every TE in the league's player pool to register positive
+    VOR and inflate the offense denominator that ``compute_family_scale``
+    divides by — biasing the class-level IDP scale downward for that
+    league format.
     """
     points_key = "points_mine" if side == "mine" else "points_test"
-    from .replacement import POSITIONS as _IDP_POSITIONS_UNUSED  # noqa: F401 — keep import parity
     settings = settings.normalized()
     by_position: dict[str, list[float]] = {p: [] for p in OFFENSE_POSITIONS}
     for player in scored:
@@ -289,6 +301,11 @@ def _compute_offense_replacement(
             by_position[player.position].append(getattr(player, points_key))
     out: dict[str, float] = {}
     for pos, points in by_position.items():
+        # Direct check on the per-team demand property before consulting
+        # replacement_rank (which floors at 1 and would mask a true zero).
+        demand = getattr(lineup, _OFFENSE_DEMAND_ATTR[pos], 0.0)
+        if demand <= 0:
+            continue
         points_desc = sorted(points, reverse=True)
         rank = lineup.replacement_rank(
             pos,
@@ -560,13 +577,20 @@ def run_analysis(
             offense_repl_test = _compute_offense_replacement(
                 offense_scored, test_lineup, settings.replacement, side="test"
             )
+            # _compute_offense_replacement omits zero-demand positions
+            # entirely; we exclude those players from the VOR list so
+            # they can't contribute phantom value to the offense
+            # denominator. ``s.position not in dict`` is the signal
+            # that the league has zero starter demand for that position.
             offense_vor_my = [
-                s.points_mine - offense_repl_my.get(s.position, 0.0)
+                s.points_mine - offense_repl_my[s.position]
                 for s in offense_scored
+                if s.position in offense_repl_my
             ]
             offense_vor_test = [
-                s.points_test - offense_repl_test.get(s.position, 0.0)
+                s.points_test - offense_repl_test[s.position]
                 for s in offense_scored
+                if s.position in offense_repl_test
             ]
             idp_vor_my = [r.vor_mine for r in vor_rows]
             idp_vor_test = [r.vor_test for r in vor_rows]

--- a/src/idp_calibration/lineup.py
+++ b/src/idp_calibration/lineup.py
@@ -18,8 +18,16 @@ from typing import Any, Iterable
 # Sleeper slot tokens we recognise. Anything else lands in "other".
 OFFENSE_SLOTS = {"QB", "RB", "WR", "TE", "FLEX", "WRRB_FLEX", "REC_FLEX", "SUPER_FLEX"}
 OFFENSE_DIRECT_SLOTS = {"QB", "RB", "WR", "TE"}
-OFFENSE_FLEX_SLOTS = {"FLEX", "WRRB_FLEX", "REC_FLEX"}  # RB/WR/TE flex
-SUPER_FLEX_SLOTS = {"SUPER_FLEX", "QB_RB_WR_TE"}  # Adds QB to the flex
+# Plain FLEX is RB/WR/TE eligible (1/3 demand to each).
+OFFENSE_FLEX_SLOTS = {"FLEX"}
+# WRRB_FLEX is RB/WR only — TE is NOT eligible. Demand splits 50/50
+# between RB and WR.
+WRRB_FLEX_SLOTS = {"WRRB_FLEX", "RB_WR_FLEX", "RBWR_FLEX"}
+# REC_FLEX is WR/TE only — RB is NOT eligible. Demand splits 50/50
+# between WR and TE.
+REC_FLEX_SLOTS = {"REC_FLEX", "WR_TE_FLEX", "WRTE_FLEX"}
+# SUPER_FLEX adds QB to the RB/WR/TE pool — 25% demand to each.
+SUPER_FLEX_SLOTS = {"SUPER_FLEX", "QB_RB_WR_TE"}
 IDP_DIRECT_SLOTS = {"DL", "LB", "DB"}
 IDP_FLEX_SLOTS = {"IDP_FLEX", "DB_LB", "DL_LB", "DL_DB", "DEF_FLEX", "IDP"}
 BENCH_SLOTS = {"BN", "BENCH", "IR", "TAXI"}
@@ -45,8 +53,10 @@ class LineupDemand:
     rb_starters: int = 0
     wr_starters: int = 0
     te_starters: int = 0
-    offense_flex_starters: int = 0   # RB/WR/TE flex
-    super_flex_starters: int = 0     # Adds QB to the flex pool
+    offense_flex_starters: int = 0   # plain FLEX — RB/WR/TE eligible
+    wrrb_flex_starters: int = 0      # RB/WR only — no TE
+    rec_flex_starters: int = 0       # WR/TE only — no RB
+    super_flex_starters: int = 0     # adds QB to the flex pool
     offense_starters: int = 0        # Aggregate — kept for backward compat
     bench_slots: int = 0
 
@@ -64,10 +74,15 @@ class LineupDemand:
         return float(self.db_starters) + self.idp_flex_starters / 3.0
 
     # ── Offense demand (per-team fractional) ──
-    # RB/WR/TE each absorb one third of the plain flex; SUPER_FLEX is
-    # shared across QB and the RB/WR/TE pool (25% to each). Rough
-    # estimates that match common dynasty-league flex-usage patterns
-    # closely enough for replacement-level math.
+    # Each flex variant only contributes to the positions actually
+    # eligible inside it:
+    #   * Plain FLEX — RB/WR/TE eligible (1/3 each).
+    #   * WRRB_FLEX — RB/WR only (1/2 each, NO TE).
+    #   * REC_FLEX  — WR/TE only (1/2 each, NO RB).
+    #   * SUPER_FLEX — QB/RB/WR/TE eligible (1/4 each).
+    # Modelling restricted flexes as generic 3-way flex would distort
+    # offense replacement ranks (and thus the offense VOR denominator
+    # in family_scale).
     @property
     def total_qb_demand(self) -> float:
         return float(self.qb_starters) + self.super_flex_starters * 0.25
@@ -77,6 +92,7 @@ class LineupDemand:
         return (
             float(self.rb_starters)
             + self.offense_flex_starters / 3.0
+            + self.wrrb_flex_starters / 2.0
             + self.super_flex_starters * 0.25
         )
 
@@ -85,6 +101,8 @@ class LineupDemand:
         return (
             float(self.wr_starters)
             + self.offense_flex_starters / 3.0
+            + self.wrrb_flex_starters / 2.0
+            + self.rec_flex_starters / 2.0
             + self.super_flex_starters * 0.25
         )
 
@@ -93,6 +111,7 @@ class LineupDemand:
         return (
             float(self.te_starters)
             + self.offense_flex_starters / 3.0
+            + self.rec_flex_starters / 2.0
             + self.super_flex_starters * 0.25
         )
 
@@ -148,6 +167,8 @@ class LineupDemand:
             "wr_starters": self.wr_starters,
             "te_starters": self.te_starters,
             "offense_flex_starters": self.offense_flex_starters,
+            "wrrb_flex_starters": self.wrrb_flex_starters,
+            "rec_flex_starters": self.rec_flex_starters,
             "super_flex_starters": self.super_flex_starters,
             "offense_starters": self.offense_starters,
             "bench_slots": self.bench_slots,
@@ -186,7 +207,8 @@ def parse_lineup(league: dict[str, Any] | None) -> LineupDemand:
     slots: Iterable[str] = league.get("roster_positions") or []
     counts: dict[str, int] = {}
     dl = lb = db = idp_flex = 0
-    qb = rb = wr = te = off_flex = super_flex = 0
+    qb = rb = wr = te = 0
+    plain_flex = wrrb_flex = rec_flex = super_flex = 0
     offense_total = 0
     bench = 0
     for raw in slots:
@@ -222,8 +244,14 @@ def parse_lineup(league: dict[str, Any] | None) -> LineupDemand:
         elif slot in SUPER_FLEX_SLOTS:
             super_flex += 1
             offense_total += 1
+        elif slot in WRRB_FLEX_SLOTS:
+            wrrb_flex += 1
+            offense_total += 1
+        elif slot in REC_FLEX_SLOTS:
+            rec_flex += 1
+            offense_total += 1
         elif slot in OFFENSE_FLEX_SLOTS:
-            off_flex += 1
+            plain_flex += 1
             offense_total += 1
         elif slot in OFFENSE_SLOTS:
             offense_total += 1
@@ -240,7 +268,9 @@ def parse_lineup(league: dict[str, Any] | None) -> LineupDemand:
         rb_starters=rb,
         wr_starters=wr,
         te_starters=te,
-        offense_flex_starters=off_flex,
+        offense_flex_starters=plain_flex,
+        wrrb_flex_starters=wrrb_flex,
+        rec_flex_starters=rec_flex,
         super_flex_starters=super_flex,
         offense_starters=offense_total,
         bench_slots=bench,

--- a/src/idp_calibration/lineup.py
+++ b/src/idp_calibration/lineup.py
@@ -1,8 +1,13 @@
 """Parse a Sleeper league's roster_positions into lineup demand.
 
 The calibration lab uses this to compute effective replacement ranks
-for DL/LB/DB and to report an offense-vs-IDP demand summary so the
-reviewer can see how much of the league's starting XI is defense.
+for every fantasy-scoring position (QB / RB / WR / TE / DL / LB / DB)
+and to report an offense-vs-IDP demand summary so the reviewer can
+see how much of the league's starting XI is defense.
+
+The offense side is needed by the cross-family calibration layer:
+without offense VOR we can't compare "IDP as a class vs offense as a
+class" and the lab can only emit within-position shape signals.
 """
 from __future__ import annotations
 
@@ -12,10 +17,16 @@ from typing import Any, Iterable
 
 # Sleeper slot tokens we recognise. Anything else lands in "other".
 OFFENSE_SLOTS = {"QB", "RB", "WR", "TE", "FLEX", "WRRB_FLEX", "REC_FLEX", "SUPER_FLEX"}
+OFFENSE_DIRECT_SLOTS = {"QB", "RB", "WR", "TE"}
+OFFENSE_FLEX_SLOTS = {"FLEX", "WRRB_FLEX", "REC_FLEX"}  # RB/WR/TE flex
+SUPER_FLEX_SLOTS = {"SUPER_FLEX", "QB_RB_WR_TE"}  # Adds QB to the flex
 IDP_DIRECT_SLOTS = {"DL", "LB", "DB"}
 IDP_FLEX_SLOTS = {"IDP_FLEX", "DB_LB", "DL_LB", "DL_DB", "DEF_FLEX", "IDP"}
 BENCH_SLOTS = {"BN", "BENCH", "IR", "TAXI"}
 SKIP_SLOTS = {"K", "DEF", "P"}
+
+OFFENSE_FAMILY: tuple[str, ...] = ("QB", "RB", "WR", "TE")
+IDP_FAMILY: tuple[str, ...] = ("DL", "LB", "DB")
 
 
 @dataclass
@@ -24,13 +35,22 @@ class LineupDemand:
     season: int | None
     team_count: int
     starter_slots: dict[str, int] = field(default_factory=dict)
+    # IDP starter slot counts
     dl_starters: int = 0
     lb_starters: int = 0
     db_starters: int = 0
     idp_flex_starters: int = 0
-    offense_starters: int = 0
+    # Offense starter slot counts (split out for cross-family math)
+    qb_starters: int = 0
+    rb_starters: int = 0
+    wr_starters: int = 0
+    te_starters: int = 0
+    offense_flex_starters: int = 0   # RB/WR/TE flex
+    super_flex_starters: int = 0     # Adds QB to the flex pool
+    offense_starters: int = 0        # Aggregate — kept for backward compat
     bench_slots: int = 0
 
+    # ── IDP demand (per-team fractional) ──
     @property
     def total_dl_demand(self) -> float:
         return float(self.dl_starters) + self.idp_flex_starters / 3.0
@@ -43,13 +63,52 @@ class LineupDemand:
     def total_db_demand(self) -> float:
         return float(self.db_starters) + self.idp_flex_starters / 3.0
 
-    def replacement_rank(self, position: str, mode: str, buffer_pct: float, manual: int | None) -> int:
+    # ── Offense demand (per-team fractional) ──
+    # RB/WR/TE each absorb one third of the plain flex; SUPER_FLEX is
+    # shared across QB and the RB/WR/TE pool (25% to each). Rough
+    # estimates that match common dynasty-league flex-usage patterns
+    # closely enough for replacement-level math.
+    @property
+    def total_qb_demand(self) -> float:
+        return float(self.qb_starters) + self.super_flex_starters * 0.25
+
+    @property
+    def total_rb_demand(self) -> float:
+        return (
+            float(self.rb_starters)
+            + self.offense_flex_starters / 3.0
+            + self.super_flex_starters * 0.25
+        )
+
+    @property
+    def total_wr_demand(self) -> float:
+        return (
+            float(self.wr_starters)
+            + self.offense_flex_starters / 3.0
+            + self.super_flex_starters * 0.25
+        )
+
+    @property
+    def total_te_demand(self) -> float:
+        return (
+            float(self.te_starters)
+            + self.offense_flex_starters / 3.0
+            + self.super_flex_starters * 0.25
+        )
+
+    def replacement_rank(
+        self, position: str, mode: str, buffer_pct: float, manual: int | None
+    ) -> int:
         """Return the rank index just past the last startable player.
 
         * ``strict_starter``: team_count * positional demand, rounded up.
         * ``starter_plus_buffer``: adds ``ceil(team_count * buffer_pct)``
           to account for bye-week and injury depth.
         * ``manual``: uses ``manual`` directly, coerced to ``>= 1``.
+
+        Handles both IDP positions (DL/LB/DB) and offense positions
+        (QB/RB/WR/TE) — the cross-family calibration layer needs the
+        same replacement-rank machinery for both sides.
         """
         if mode == "manual" and manual is not None:
             try:
@@ -61,18 +120,16 @@ class LineupDemand:
             "DL": self.total_dl_demand,
             "LB": self.total_lb_demand,
             "DB": self.total_db_demand,
+            "QB": self.total_qb_demand,
+            "RB": self.total_rb_demand,
+            "WR": self.total_wr_demand,
+            "TE": self.total_te_demand,
         }
         demand = demand_lookup.get(position.upper(), 0.0)
-        # Ceiling, not round — a fractional IDP-flex demand like 13.33 must
-        # produce 14 so the replacement player sits *past* every possible
-        # starter slot. Rounding down would understate the starter pool and
-        # inflate VOR (and downstream multipliers) in leagues where
-        # team_count * demand isn't integer.
         base = int(math.ceil(self.team_count * demand))
         base = max(base, 1)
         if mode == "strict_starter":
             return base
-        # starter_plus_buffer (default) — buffer also ceils for symmetry.
         buf = max(1, int(math.ceil(self.team_count * max(0.0, buffer_pct))))
         return base + buf
 
@@ -86,11 +143,21 @@ class LineupDemand:
             "lb_starters": self.lb_starters,
             "db_starters": self.db_starters,
             "idp_flex_starters": self.idp_flex_starters,
+            "qb_starters": self.qb_starters,
+            "rb_starters": self.rb_starters,
+            "wr_starters": self.wr_starters,
+            "te_starters": self.te_starters,
+            "offense_flex_starters": self.offense_flex_starters,
+            "super_flex_starters": self.super_flex_starters,
             "offense_starters": self.offense_starters,
             "bench_slots": self.bench_slots,
             "total_dl_demand": self.total_dl_demand,
             "total_lb_demand": self.total_lb_demand,
             "total_db_demand": self.total_db_demand,
+            "total_qb_demand": self.total_qb_demand,
+            "total_rb_demand": self.total_rb_demand,
+            "total_wr_demand": self.total_wr_demand,
+            "total_te_demand": self.total_te_demand,
         }
 
 
@@ -118,7 +185,10 @@ def parse_lineup(league: dict[str, Any] | None) -> LineupDemand:
 
     slots: Iterable[str] = league.get("roster_positions") or []
     counts: dict[str, int] = {}
-    dl = lb = db = flex = offense = bench = 0
+    dl = lb = db = idp_flex = 0
+    qb = rb = wr = te = off_flex = super_flex = 0
+    offense_total = 0
+    bench = 0
     for raw in slots:
         slot = str(raw or "").strip().upper()
         if not slot:
@@ -136,9 +206,27 @@ def parse_lineup(league: dict[str, Any] | None) -> LineupDemand:
         elif slot == "DB":
             db += 1
         elif slot in IDP_FLEX_SLOTS:
-            flex += 1
+            idp_flex += 1
+        elif slot == "QB":
+            qb += 1
+            offense_total += 1
+        elif slot == "RB":
+            rb += 1
+            offense_total += 1
+        elif slot == "WR":
+            wr += 1
+            offense_total += 1
+        elif slot == "TE":
+            te += 1
+            offense_total += 1
+        elif slot in SUPER_FLEX_SLOTS:
+            super_flex += 1
+            offense_total += 1
+        elif slot in OFFENSE_FLEX_SLOTS:
+            off_flex += 1
+            offense_total += 1
         elif slot in OFFENSE_SLOTS:
-            offense += 1
+            offense_total += 1
     return LineupDemand(
         league_id=str(league.get("league_id") or ""),
         season=season,
@@ -147,7 +235,13 @@ def parse_lineup(league: dict[str, Any] | None) -> LineupDemand:
         dl_starters=dl,
         lb_starters=lb,
         db_starters=db,
-        idp_flex_starters=flex,
-        offense_starters=offense,
+        idp_flex_starters=idp_flex,
+        qb_starters=qb,
+        rb_starters=rb,
+        wr_starters=wr,
+        te_starters=te,
+        offense_flex_starters=off_flex,
+        super_flex_starters=super_flex,
+        offense_starters=offense_total,
         bench_slots=bench,
     )

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -154,6 +154,38 @@ def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: s
     return 1.0
 
 
+def _family_scale_for(config: dict[str, Any], mode: str) -> float:
+    """Return the cross-family IDP scale from the promoted config.
+
+    Applied multiplicatively on top of the within-position bucket
+    multiplier so the live pipeline produces:
+
+        final = rankDerivedValue × family_scale × bucket_multiplier
+
+    A family scale > 1.0 lifts every IDP row in lockstep (because my
+    league values IDP as a class more than the market); < 1.0 discounts
+    the class. Missing block → 1.0 (identity, backward compat with
+    pre-Family-Scale promoted configs).
+    """
+    fs = config.get("family_scale")
+    if not isinstance(fs, dict):
+        return 1.0
+    kind = {
+        "intrinsic_only": "intrinsic",
+        "market_only": "market",
+        "blended": "final",
+    }.get(mode, "final")
+    val = fs.get(kind)
+    try:
+        scale = float(val)
+    except (TypeError, ValueError):
+        return 1.0
+    # Hard sanity clamp to the same bounds the engine's
+    # compute_family_scale uses. Defends production against a
+    # hand-edited config with a nonsense value.
+    return max(0.25, min(4.0, scale))
+
+
 def get_idp_bucket_multiplier(
     position: str,
     rank: int,
@@ -171,6 +203,11 @@ def get_idp_bucket_multiplier(
 
     Returns ``1.0`` whenever no promoted config exists so this is a
     strict no-op for a freshly-cloned repo.
+
+    Combines the cross-family IDP scale (from ``config['family_scale']``)
+    with the within-position bucket multiplier. See
+    :func:`_family_scale_for` for the class-level lift/discount
+    semantics.
     """
     config = _load_if_stale(base)
     if not config:
@@ -179,7 +216,9 @@ def get_idp_bucket_multiplier(
     if effective_mode not in {"intrinsic_only", "market_only", "blended"}:
         effective_mode = "blended"
     try:
-        return float(_bucket_lookup_for(position, int(rank), config, effective_mode))
+        bucket = float(_bucket_lookup_for(position, int(rank), config, effective_mode))
+        family = _family_scale_for(config, effective_mode)
+        return bucket * family
     except Exception:
         return 1.0
 

--- a/src/idp_calibration/promotion.py
+++ b/src/idp_calibration/promotion.py
@@ -101,6 +101,7 @@ def build_production_config(
         "active_mode": active_mode,
         "bucket_edges": list(settings.get("bucket_edges") or []),
         "multipliers": dict(artifact.get("multipliers") or {}),
+        "family_scale": dict(artifact.get("family_scale") or {}),
         "anchors": dict(artifact.get("anchors") or {}),
     }
 

--- a/src/idp_calibration/scoring.py
+++ b/src/idp_calibration/scoring.py
@@ -48,6 +48,48 @@ IDP_STAT_KEYS: tuple[str, ...] = (
     "idp_tkl_5p",
 )
 
+# Canonical offense stat keys. The cross-family calibration layer
+# needs these so we can rescore QB/RB/WR/TE season stats under each
+# league's scoring rules and compute offense VOR. Every key here must
+# also appear on the RHS of src/scoring/sleeper_ingest.py::KEY_ALIASES.
+OFFENSE_STAT_KEYS: tuple[str, ...] = (
+    # Passing
+    "pass_yd",
+    "pass_td",
+    "pass_int",
+    "pass_cmp",
+    "pass_inc",
+    "pass_fd",
+    "bonus_pass_yd_300",
+    "bonus_pass_td_50+",
+    "bonus_fd_qb",
+    # Rushing
+    "rush_yd",
+    "rush_td",
+    "rush_fd",
+    "bonus_rush_yd_100",
+    "bonus_rush_td_40+",
+    "bonus_fd_rb",
+    # Receiving
+    "rec",
+    "rec_yd",
+    "rec_td",
+    "rec_fd",
+    "bonus_rec_rb",
+    "bonus_rec_wr",
+    "bonus_rec_te",
+    "bonus_rec_yd_100",
+    "bonus_rec_td_40+",
+    "bonus_fd_wr",
+    "bonus_fd_te",
+    # Turnovers (shared penalty)
+    "fum",
+    "fum_lost",
+    # Return TDs (rare)
+    "kick_ret_td",
+    "punt_ret_td",
+)
+
 
 @dataclass
 class LeagueScoring:
@@ -55,14 +97,14 @@ class LeagueScoring:
     season: int | None
     scoring_map: dict[str, float] = field(default_factory=dict)
     idp_weights: dict[str, float] = field(default_factory=dict)
+    offense_weights: dict[str, float] = field(default_factory=dict)
     unknown_keys: dict[str, float] = field(default_factory=dict)
 
     def summary(self) -> dict[str, Any]:
         present_idp = {k: v for k, v in self.idp_weights.items() if abs(v) > 0.0}
-        # Only surface IDP-ish unknown keys with a non-zero weight —
-        # a zero-weight unknown key is just noise (the league toggled
-        # the setting off) and doesn't need operator attention. If
-        # the set is empty the UI omits the warning entirely.
+        present_offense = {
+            k: v for k, v in self.offense_weights.items() if abs(v) > 0.0
+        }
         unknown_idp = {
             k: v
             for k, v in self.unknown_keys.items()
@@ -75,6 +117,7 @@ class LeagueScoring:
             "inactive_idp_stats": sorted(
                 k for k in IDP_STAT_KEYS if abs(self.idp_weights.get(k, 0.0)) < 1e-9
             ),
+            "active_offense_stats": present_offense,
             "unknown_key_count": len(self.unknown_keys),
             "unknown_idp_keys": unknown_idp,
         }
@@ -113,11 +156,13 @@ def parse_scoring(league: dict[str, Any] | None) -> LeagueScoring:
     except (TypeError, ValueError):
         season = None
     idp_weights = {k: float(scoring_map.get(k, 0.0)) for k in IDP_STAT_KEYS}
+    offense_weights = {k: float(scoring_map.get(k, 0.0)) for k in OFFENSE_STAT_KEYS}
     return LeagueScoring(
         league_id=str(league.get("league_id") or ""),
         season=season,
         scoring_map=scoring_map,
         idp_weights=idp_weights,
+        offense_weights=offense_weights,
         unknown_keys=unknown,
     )
 

--- a/src/idp_calibration/stats_adapter.py
+++ b/src/idp_calibration/stats_adapter.py
@@ -38,6 +38,103 @@ from src.utils.name_clean import resolve_idp_position
 log = logging.getLogger(__name__)
 
 
+# ── Canonical-to-payload stat-key maps ──
+# Shared by SleeperStatsAdapter and LocalCSVStatsAdapter. First
+# payload key that hits wins. Mirror of IDP_STAT_KEYS / OFFENSE_STAT_KEYS
+# in scoring.py so every aliased canonical has a column pull.
+_IDP_STAT_KEY_MAP: dict[str, tuple[str, ...]] = {
+    "idp_tkl_solo": ("idp_tkl_solo", "idp_solo"),
+    "idp_tkl_ast": ("idp_tkl_ast", "idp_ast"),
+    "idp_tkl": ("idp_tkl",),
+    "idp_tkl_loss": ("idp_tkl_loss", "idp_tfl"),
+    "idp_tkl_ast_loss": ("idp_tkl_ast_loss",),
+    "idp_sack": ("idp_sack",),
+    "idp_sack_yd": ("idp_sack_yd",),
+    "idp_hit": ("idp_hit", "idp_qb_hit"),
+    "idp_int": ("idp_int",),
+    "idp_int_ret_yd": ("idp_int_ret_yd",),
+    "idp_pd": ("idp_pd", "idp_pass_def"),
+    "idp_pass_def_3p": ("idp_pass_def_3p",),
+    "idp_ff": ("idp_ff",),
+    "idp_fum_rec": ("idp_fum_rec", "idp_fr"),
+    "idp_fum_ret_yd": ("idp_fum_ret_yd",),
+    "idp_def_td": ("idp_def_td", "idp_td"),
+    "idp_safe": ("idp_safe",),
+    "idp_blk_kick": ("idp_blk_kick", "idp_blk_punt"),
+    "idp_def_pr_td": ("idp_def_pr_td",),
+    "idp_def_kr_td": ("idp_def_kr_td",),
+    "idp_tkl_10p": ("idp_tkl_10p",),
+    "idp_tkl_5p": ("idp_tkl_5p",),
+}
+
+_OFFENSE_STAT_KEY_MAP: dict[str, tuple[str, ...]] = {
+    # Passing
+    "pass_yd": ("pass_yd",),
+    "pass_td": ("pass_td",),
+    "pass_int": ("pass_int",),
+    "pass_cmp": ("pass_cmp",),
+    "pass_inc": ("pass_inc",),
+    "pass_fd": ("pass_fd", "pass_first_down"),
+    "bonus_pass_yd_300": ("bonus_pass_yd_300",),
+    "bonus_pass_td_50+": ("bonus_pass_td_50+", "bonus_pass_td_50p"),
+    "bonus_fd_qb": ("bonus_fd_qb",),
+    # Rushing
+    "rush_yd": ("rush_yd",),
+    "rush_td": ("rush_td",),
+    "rush_fd": ("rush_fd", "rush_first_down"),
+    "bonus_rush_yd_100": ("bonus_rush_yd_100",),
+    "bonus_rush_td_40+": ("bonus_rush_td_40+", "bonus_rush_td_40p"),
+    "bonus_fd_rb": ("bonus_fd_rb",),
+    # Receiving
+    "rec": ("rec",),
+    "rec_yd": ("rec_yd",),
+    "rec_td": ("rec_td",),
+    "rec_fd": ("rec_fd", "rec_first_down"),
+    "bonus_rec_rb": ("bonus_rec_rb",),
+    "bonus_rec_wr": ("bonus_rec_wr",),
+    "bonus_rec_te": ("bonus_rec_te",),
+    "bonus_rec_yd_100": ("bonus_rec_yd_100",),
+    "bonus_rec_td_40+": ("bonus_rec_td_40+", "bonus_rec_td_40p"),
+    "bonus_fd_wr": ("bonus_fd_wr",),
+    "bonus_fd_te": ("bonus_fd_te",),
+    # Turnover penalties
+    "fum": ("fum",),
+    "fum_lost": ("fum_lost",),
+    # Return TDs (rare, most leagues score 0)
+    "kick_ret_td": ("kick_ret_td",),
+    "punt_ret_td": ("punt_ret_td",),
+}
+
+
+def _resolve_offense_position(raw_pos: str | None, fantasy_positions: Any) -> str:
+    """Collapse a Sleeper player's position fields into QB/RB/WR/TE or ""."""
+    tokens: list[str] = []
+    if isinstance(fantasy_positions, (list, tuple)):
+        for item in fantasy_positions:
+            if isinstance(item, str) and item.strip():
+                tokens.append(item.strip().upper())
+    if isinstance(raw_pos, str) and raw_pos.strip():
+        tokens.append(raw_pos.strip().upper())
+    # Priority: QB > RB > WR > TE when a player lists multiple, which
+    # mirrors fantasy primary-use ordering.
+    for family in ("QB", "RB", "WR", "TE"):
+        if family in tokens:
+            return family
+    return ""
+
+
+def _pull_scored(stats: dict[str, Any], key_map: dict[str, tuple[str, ...]]) -> dict[str, float]:
+    """Walk ``key_map`` and collapse payload keys to canonical names."""
+    out: dict[str, float] = {}
+    for canonical, payload_keys in key_map.items():
+        for pk in payload_keys:
+            val = _coerce_float(stats.get(pk))
+            if val is not None:
+                out[canonical] = val
+                break
+    return out
+
+
 class AdapterUnavailable(RuntimeError):
     """Raised when an adapter cannot serve a given season."""
 
@@ -153,58 +250,26 @@ class SleeperStatsAdapter(HistoricalStatsAdapter):
             if not isinstance(stats, dict):
                 continue
             meta = players_map.get(str(pid)) or {}
-            # Prefer Sleeper's fantasy_positions array over the single
-            # NFL position so dual-eligible players (e.g. DL+LB) get
-            # collapsed to a single IDP family under the DL > DB > LB
-            # priority applied by resolve_idp_position.
-            canonical_pos = resolve_idp_position(
-                meta.get("fantasy_positions"),
-                meta.get("position"),
-            )
-            if canonical_pos not in {"DL", "LB", "DB"}:
-                continue
+            fantasy_positions = meta.get("fantasy_positions")
+            raw_position = meta.get("position")
+
+            # First try IDP (DL/LB/DB priority). If that doesn't match,
+            # try offense (QB/RB/WR/TE). The cross-family calibration
+            # layer needs both in the same universe so we can compute
+            # offense VOR to compare against IDP VOR.
+            idp_pos = resolve_idp_position(fantasy_positions, raw_position)
+            if idp_pos in {"DL", "LB", "DB"}:
+                canonical_pos = idp_pos
+                key_map = _IDP_STAT_KEY_MAP
+            else:
+                offense_pos = _resolve_offense_position(raw_position, fantasy_positions)
+                if offense_pos not in {"QB", "RB", "WR", "TE"}:
+                    continue
+                canonical_pos = offense_pos
+                key_map = _OFFENSE_STAT_KEY_MAP
+
             games = _coerce_int(stats.get("gp") or stats.get("games") or 0)
-            scored: dict[str, float] = {}
-            # Mirror IDP_STAT_KEYS from src/idp_calibration/scoring.py
-            # and accept a couple of legacy Sleeper payload aliases.
-            # The loop collapses payload keys to canonical names so
-            # downstream weight × stat dot-products match regardless
-            # of whether the season aggregate uses the old or new
-            # Sleeper naming.
-            _STAT_KEY_MAP = {
-                # canonical → list of payload keys to sum (first match wins)
-                "idp_tkl_solo": ("idp_tkl_solo", "idp_solo"),
-                "idp_tkl_ast": ("idp_tkl_ast", "idp_ast"),
-                "idp_tkl": ("idp_tkl",),
-                "idp_tkl_loss": ("idp_tkl_loss", "idp_tfl"),
-                "idp_tkl_ast_loss": ("idp_tkl_ast_loss",),
-                "idp_sack": ("idp_sack",),
-                "idp_sack_yd": ("idp_sack_yd",),
-                # Canonical is idp_hit (kept stable for baseline_config /
-                # scoring_delta). idp_qb_hit is a payload alias Sleeper
-                # uses in some seasons.
-                "idp_hit": ("idp_hit", "idp_qb_hit"),
-                "idp_int": ("idp_int",),
-                "idp_int_ret_yd": ("idp_int_ret_yd",),
-                "idp_pd": ("idp_pd", "idp_pass_def"),
-                "idp_pass_def_3p": ("idp_pass_def_3p",),
-                "idp_ff": ("idp_ff",),
-                "idp_fum_rec": ("idp_fum_rec", "idp_fr"),
-                "idp_fum_ret_yd": ("idp_fum_ret_yd",),
-                "idp_def_td": ("idp_def_td", "idp_td"),
-                "idp_safe": ("idp_safe",),
-                "idp_blk_kick": ("idp_blk_kick", "idp_blk_punt"),
-                "idp_def_pr_td": ("idp_def_pr_td",),
-                "idp_def_kr_td": ("idp_def_kr_td",),
-                "idp_tkl_10p": ("idp_tkl_10p",),
-                "idp_tkl_5p": ("idp_tkl_5p",),
-            }
-            for stat_canonical, payload_keys in _STAT_KEY_MAP.items():
-                for pk in payload_keys:
-                    val = _coerce_float(stats.get(pk))
-                    if val is not None:
-                        scored[stat_canonical] = val
-                        break
+            scored = _pull_scored(stats, key_map)
             out.append(
                 PlayerSeason(
                     player_id=str(pid),
@@ -216,7 +281,7 @@ class SleeperStatsAdapter(HistoricalStatsAdapter):
             )
         if not out:
             raise AdapterUnavailable(
-                f"Sleeper stats for {season} contained zero IDP rows."
+                f"Sleeper stats for {season} contained zero rows."
             )
         return out
 
@@ -252,54 +317,29 @@ class LocalCSVStatsAdapter(HistoricalStatsAdapter):
                     pid = str(row.get("player_id") or "").strip()
                     if not pid:
                         continue
-                    # CSV may carry either a single position or a
-                    # slash-joined pair (e.g. "DL/LB"). resolve_idp_position
-                    # applies the canonical DL > DB > LB priority.
-                    pos = resolve_idp_position(
-                        row.get("fantasy_positions"),
-                        row.get("position"),
-                    )
-                    if pos not in {"DL", "LB", "DB"}:
-                        continue
-                    stats: dict[str, float] = {}
-                    # Accept every canonical IDP stat column plus a
-                    # couple of legacy column names. Extra columns are
-                    # ignored; missing columns are treated as zero.
-                    _CSV_STAT_MAP = {
-                        "idp_tkl_solo": ("idp_tkl_solo", "idp_solo"),
-                        "idp_tkl_ast": ("idp_tkl_ast", "idp_ast"),
-                        "idp_tkl": ("idp_tkl",),
-                        "idp_tkl_loss": ("idp_tkl_loss", "idp_tfl"),
-                        "idp_tkl_ast_loss": ("idp_tkl_ast_loss",),
-                        "idp_sack": ("idp_sack",),
-                        "idp_sack_yd": ("idp_sack_yd",),
-                        "idp_hit": ("idp_hit", "idp_qb_hit"),
-                        "idp_int": ("idp_int",),
-                        "idp_int_ret_yd": ("idp_int_ret_yd",),
-                        "idp_pd": ("idp_pd", "idp_pass_def"),
-                        "idp_pass_def_3p": ("idp_pass_def_3p",),
-                        "idp_ff": ("idp_ff",),
-                        "idp_fum_rec": ("idp_fum_rec", "idp_fr"),
-                        "idp_fum_ret_yd": ("idp_fum_ret_yd",),
-                        "idp_def_td": ("idp_def_td", "idp_td"),
-                        "idp_safe": ("idp_safe",),
-                        "idp_blk_kick": ("idp_blk_kick", "idp_blk_punt"),
-                        "idp_def_pr_td": ("idp_def_pr_td",),
-                        "idp_def_kr_td": ("idp_def_kr_td",),
-                        "idp_tkl_10p": ("idp_tkl_10p",),
-                        "idp_tkl_5p": ("idp_tkl_5p",),
-                    }
-                    for stat_canonical, column_names in _CSV_STAT_MAP.items():
-                        for col in column_names:
-                            val = _coerce_float(row.get(col))
-                            if val is not None:
-                                stats[stat_canonical] = val
-                                break
+                    # IDP first (DL > DB > LB priority for multi-position
+                    # rows), offense second. Both families share the
+                    # stat-pull pattern via _pull_scored.
+                    fantasy_positions = row.get("fantasy_positions")
+                    raw_position = row.get("position")
+                    idp_pos = resolve_idp_position(fantasy_positions, raw_position)
+                    if idp_pos in {"DL", "LB", "DB"}:
+                        canonical_pos = idp_pos
+                        key_map = _IDP_STAT_KEY_MAP
+                    else:
+                        offense_pos = _resolve_offense_position(
+                            raw_position, fantasy_positions
+                        )
+                        if offense_pos not in {"QB", "RB", "WR", "TE"}:
+                            continue
+                        canonical_pos = offense_pos
+                        key_map = _OFFENSE_STAT_KEY_MAP
+                    stats = _pull_scored(row, key_map)
                     out.append(
                         PlayerSeason(
                             player_id=pid,
                             name=str(row.get("name") or pid),
-                            position=pos,
+                            position=canonical_pos,
                             games=_coerce_int(row.get("games") or 0),
                             stats=stats,
                         )
@@ -307,7 +347,9 @@ class LocalCSVStatsAdapter(HistoricalStatsAdapter):
         except OSError as exc:
             raise AdapterUnavailable(f"Failed reading {path}: {exc}") from exc
         if not out:
-            raise AdapterUnavailable(f"Local CSV at {path} contained no IDP rows.")
+            raise AdapterUnavailable(
+                f"Local CSV at {path} contained no rows in recognised families."
+            )
         return out
 
 

--- a/src/idp_calibration/translation.py
+++ b/src/idp_calibration/translation.py
@@ -237,6 +237,177 @@ def _clamp_series(values: list[float], floor: float) -> list[float]:
     return [max(floor, min(1.0, float(v))) for v in values]
 
 
+@dataclass
+class FamilyScale:
+    """Scalar that scales IDP values relative to offense.
+
+    * ``intrinsic`` — what my-league scoring + my-league lineup imply.
+    * ``market`` — same recipe under test-league scoring + lineup.
+    * ``final`` — blended via the same intrinsic/market weights used
+      for per-bucket multipliers.
+    * ``sample_size`` — number of above-replacement players across both
+      families used to compute the numbers, for transparency.
+
+    The scale is applied multiplicatively on top of per-bucket
+    multipliers in production:
+
+        final_value = rankDerivedValue × family_scale × bucket_multiplier
+
+    A value > 1.0 means my league values IDP as a class more than the
+    test/market baseline does; < 1.0 means less.
+    """
+
+    intrinsic: float = 1.0
+    market: float = 1.0
+    final: float = 1.0
+    intrinsic_my_ratio: float = 0.0
+    intrinsic_test_ratio: float = 0.0
+    sample_size: dict[str, int] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.sample_size is None:
+            self.sample_size = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "intrinsic": round(self.intrinsic, 4),
+            "market": round(self.market, 4),
+            "final": round(self.final, 4),
+            "intrinsic_my_ratio": round(self.intrinsic_my_ratio, 4),
+            "intrinsic_test_ratio": round(self.intrinsic_test_ratio, 4),
+            "sample_size": dict(self.sample_size),
+        }
+
+
+def _sum_above_replacement(vor_values: list[float]) -> float:
+    """Sum the positive portion of a VOR list — i.e. the total starter
+    value produced by that cohort. Sub-replacement contributions are
+    dropped so a bench of below-average players doesn't inflate the
+    "class value" measure.
+    """
+    return sum(max(0.0, float(v)) for v in vor_values)
+
+
+def compute_family_scale(
+    *,
+    idp_vor_my: list[float],
+    idp_vor_test: list[float],
+    offense_vor_my: list[float],
+    offense_vor_test: list[float],
+    blend: dict[str, float] | None = None,
+    scale_min: float = 0.25,
+    scale_max: float = 4.0,
+) -> FamilyScale:
+    """Compute the IDP-family scaling factor for one time period.
+
+    Ratios:
+
+        my_ratio   = sum(IDP VOR, my) / sum(offense VOR, my)
+        test_ratio = sum(IDP VOR, test) / sum(offense VOR, test)
+
+        family_scale_intrinsic = my_ratio / test_ratio
+
+    Intuition: if my league's IDP starters produce 30% more
+    fantasy-point VOR per unit of offense VOR than the test league's,
+    then "IDP as a class" is worth 30% more in my league's economy
+    and every IDP trade value should lift by roughly the same factor.
+
+    The market channel is symmetric with my / test swapped — what would
+    today's test-league scoring produce if applied to an IDP-heavy
+    roster? (In practice it's always 1.0 by this definition, since
+    it's computing test_ratio / test_ratio; we emit it for
+    completeness and future use in a different blending scheme.)
+
+    ``scale_min`` / ``scale_max`` cap the output so pathological
+    replacement-level mismatches can't produce absurd scales.
+    """
+    blend = blend or DEFAULT_BLEND
+    idp_my = _sum_above_replacement(idp_vor_my)
+    idp_test = _sum_above_replacement(idp_vor_test)
+    off_my = _sum_above_replacement(offense_vor_my)
+    off_test = _sum_above_replacement(offense_vor_test)
+
+    # Guard against division-by-zero — either side having zero
+    # above-replacement VOR means we can't compute a meaningful ratio.
+    if off_my <= 0 or off_test <= 0 or idp_test <= 0:
+        return FamilyScale(
+            intrinsic=1.0,
+            market=1.0,
+            final=1.0,
+            intrinsic_my_ratio=0.0,
+            intrinsic_test_ratio=0.0,
+            sample_size={
+                "idp_my": sum(1 for v in idp_vor_my if v > 0),
+                "idp_test": sum(1 for v in idp_vor_test if v > 0),
+                "offense_my": sum(1 for v in offense_vor_my if v > 0),
+                "offense_test": sum(1 for v in offense_vor_test if v > 0),
+            },
+        )
+
+    my_ratio = idp_my / off_my
+    test_ratio = idp_test / off_test
+    raw_intrinsic = my_ratio / test_ratio
+    intrinsic = max(scale_min, min(scale_max, raw_intrinsic))
+    # Market channel: by construction this comparison is test-vs-test,
+    # which yields 1.0. We keep the field so the UI has the same
+    # three-channel shape as per-bucket multipliers, and so a future
+    # blending scheme can plug a different definition in.
+    market = 1.0
+    alpha = float(blend.get("intrinsic", 0.75))
+    beta = 1.0 - alpha
+    final = alpha * intrinsic + beta * market
+
+    return FamilyScale(
+        intrinsic=intrinsic,
+        market=market,
+        final=final,
+        intrinsic_my_ratio=my_ratio,
+        intrinsic_test_ratio=test_ratio,
+        sample_size={
+            "idp_my": sum(1 for v in idp_vor_my if v > 0),
+            "idp_test": sum(1 for v in idp_vor_test if v > 0),
+            "offense_my": sum(1 for v in offense_vor_my if v > 0),
+            "offense_test": sum(1 for v in offense_vor_test if v > 0),
+        },
+    )
+
+
+def combine_family_scales(
+    per_season: dict[int, FamilyScale],
+    year_weights: dict[int, float],
+) -> FamilyScale:
+    """Weighted multi-year aggregation of single-season family scales.
+
+    Each channel (intrinsic / market / final) is a weighted mean
+    across resolved seasons using the renormalised year weights.
+    Seasons with zero weight or a no-op (1.0/1.0/1.0) scale are
+    dropped from the mean so a bad season doesn't flatten the signal.
+    """
+    if not per_season:
+        return FamilyScale()
+    total_weight = 0.0
+    weighted = {"intrinsic": 0.0, "market": 0.0, "final": 0.0}
+    combined_sample: dict[str, int] = {}
+    for year, scale in per_season.items():
+        w = float(year_weights.get(int(year), 0.0))
+        if w <= 0:
+            continue
+        total_weight += w
+        weighted["intrinsic"] += w * scale.intrinsic
+        weighted["market"] += w * scale.market
+        weighted["final"] += w * scale.final
+        for k, v in (scale.sample_size or {}).items():
+            combined_sample[k] = combined_sample.get(k, 0) + int(v)
+    if total_weight <= 0:
+        return FamilyScale()
+    return FamilyScale(
+        intrinsic=weighted["intrinsic"] / total_weight,
+        market=weighted["market"] / total_weight,
+        final=weighted["final"] / total_weight,
+        sample_size=combined_sample,
+    )
+
+
 def build_multi_year_multipliers(
     per_season_per_position: dict[str, dict[int, list[BucketResult]]],
     *,

--- a/src/idp_calibration/vor.py
+++ b/src/idp_calibration/vor.py
@@ -24,22 +24,26 @@ class ScoredPlayer:
     points_mine: float
 
 
+IDP_FAMILY = ("DL", "LB", "DB")
+OFFENSE_FAMILY = ("QB", "RB", "WR", "TE")
+
+
 def build_universe(
     players: Iterable[PlayerSeason],
     *,
     min_games: int = 0,
+    positions: Iterable[str] = IDP_FAMILY,
 ) -> list[PlayerSeason]:
-    """Filter the raw season list into the calibration universe.
+    """Filter the raw season list into a calibration universe.
 
-    Default (``min_games=0``) keeps every valid DL/LB/DB with a
-    non-empty stat line. ``min_games`` is the advanced filter exposed
-    in the UI. Top-N per position cannot be applied here because we
-    don't yet know each player's fantasy points — that selection is
-    done in :func:`trim_to_top_n_per_position` after scoring.
+    ``positions`` defaults to the IDP family; the cross-family layer
+    calls this with ``OFFENSE_FAMILY`` to build a parallel offense
+    universe for computing offense VOR.
     """
+    allowed = {p.upper() for p in positions}
     valid: list[PlayerSeason] = []
     for p in players:
-        if p.position not in {"DL", "LB", "DB"}:
+        if p.position not in allowed:
             continue
         if not p.stats:
             continue
@@ -50,7 +54,10 @@ def build_universe(
 
 
 def trim_to_top_n_per_position(
-    scored: list["ScoredPlayer"], top_n: int | None
+    scored: list["ScoredPlayer"],
+    top_n: int | None,
+    *,
+    positions: Iterable[str] = IDP_FAMILY,
 ) -> list["ScoredPlayer"]:
     """Keep only the top ``top_n`` scored players per position.
 
@@ -63,7 +70,7 @@ def trim_to_top_n_per_position(
     """
     if not top_n or top_n <= 0:
         return list(scored)
-    by_pos: dict[str, list[ScoredPlayer]] = {"DL": [], "LB": [], "DB": []}
+    by_pos: dict[str, list[ScoredPlayer]] = {p.upper(): [] for p in positions}
     for s in scored:
         if s.position in by_pos:
             by_pos[s.position].append(s)
@@ -119,6 +126,8 @@ def compute_vor(
     scored: list[ScoredPlayer],
     replacement_test: dict[str, float],
     replacement_mine: dict[str, float],
+    *,
+    positions: Iterable[str] = IDP_FAMILY,
 ) -> list[VorRow]:
     """Compute VOR under both scoring systems and assign position ranks.
 
@@ -128,7 +137,7 @@ def compute_vor(
     between the two systems (that delta is the whole point of the
     calibration).
     """
-    by_pos: dict[str, list[ScoredPlayer]] = {"DL": [], "LB": [], "DB": []}
+    by_pos: dict[str, list[ScoredPlayer]] = {p.upper(): [] for p in positions}
     for s in scored:
         if s.position in by_pos:
             by_pos[s.position].append(s)

--- a/tests/idp_calibration/test_family_scale.py
+++ b/tests/idp_calibration/test_family_scale.py
@@ -1,0 +1,368 @@
+"""Cross-family IDP scaling layer.
+
+Pins the math (``translation.compute_family_scale`` and
+``translation.combine_family_scales``), the engine orchestration
+(offense universe flows through + per-season scale lands in the
+artifact), and the production read path (family_scale is applied
+multiplicatively on top of the per-bucket multiplier).
+"""
+from __future__ import annotations
+
+import math
+
+from src.idp_calibration import engine, production, promotion, season_chain, storage
+from src.idp_calibration.stats_adapter import HistoricalStatsAdapter, PlayerSeason
+from src.idp_calibration.translation import (
+    DEFAULT_BLEND,
+    FamilyScale,
+    combine_family_scales,
+    compute_family_scale,
+)
+
+
+class TestComputeFamilyScale:
+    def test_neutral_when_my_ratio_equals_test_ratio(self):
+        scale = compute_family_scale(
+            idp_vor_my=[100.0, 50.0, 20.0],
+            idp_vor_test=[100.0, 50.0, 20.0],
+            offense_vor_my=[400.0, 200.0],
+            offense_vor_test=[400.0, 200.0],
+        )
+        assert abs(scale.intrinsic - 1.0) < 1e-9
+        assert abs(scale.market - 1.0) < 1e-9
+        assert abs(scale.final - 1.0) < 1e-9
+
+    def test_my_league_values_idp_more_produces_scale_above_one(self):
+        # My league: IDP produces 200 VOR, offense 400. Ratio = 0.50.
+        # Test league: IDP produces 100 VOR, offense 400. Ratio = 0.25.
+        # Intrinsic = 0.50 / 0.25 = 2.0 — IDP is twice as valuable in my
+        # league relative to offense.
+        scale = compute_family_scale(
+            idp_vor_my=[200.0],
+            idp_vor_test=[100.0],
+            offense_vor_my=[400.0],
+            offense_vor_test=[400.0],
+        )
+        assert abs(scale.intrinsic - 2.0) < 1e-9
+
+    def test_sub_replacement_vor_is_ignored_in_sums(self):
+        # Negative VOR contributions must not distort the "class value
+        # bank" — we only sum above-replacement VOR.
+        scale = compute_family_scale(
+            idp_vor_my=[100.0, -50.0, -80.0],
+            idp_vor_test=[100.0, -50.0, -80.0],
+            offense_vor_my=[400.0, -100.0],
+            offense_vor_test=[400.0, -100.0],
+        )
+        # Identical bank on both sides → scale = 1.0.
+        assert abs(scale.intrinsic - 1.0) < 1e-9
+
+    def test_scale_is_clamped_to_guard_rails(self):
+        # Astronomical IDP-to-offense ratio (e.g. broken offense
+        # scoring in one league) must not propagate as a 100x lift.
+        scale = compute_family_scale(
+            idp_vor_my=[1000.0],
+            idp_vor_test=[1.0],
+            offense_vor_my=[1.0],
+            offense_vor_test=[1000.0],
+            scale_max=4.0,
+        )
+        assert scale.intrinsic == 4.0
+
+    def test_zero_offense_returns_neutral(self):
+        # Guard against divide-by-zero when a side's offense universe
+        # has no above-replacement VOR (e.g. empty universe).
+        scale = compute_family_scale(
+            idp_vor_my=[100.0],
+            idp_vor_test=[100.0],
+            offense_vor_my=[0.0, -10.0],   # no positive VOR
+            offense_vor_test=[400.0],
+        )
+        assert scale.intrinsic == 1.0
+
+    def test_blend_applies_to_final_channel(self):
+        # With 75% intrinsic / 25% market, final should be the convex
+        # combination of the two. Intrinsic computed as 2.0 above.
+        scale = compute_family_scale(
+            idp_vor_my=[200.0],
+            idp_vor_test=[100.0],
+            offense_vor_my=[400.0],
+            offense_vor_test=[400.0],
+            blend={"intrinsic": 0.75, "market": 0.25},
+        )
+        assert abs(scale.final - (0.75 * 2.0 + 0.25 * 1.0)) < 1e-9
+
+
+class TestCombineFamilyScales:
+    def test_weighted_mean_across_seasons(self):
+        per_season = {
+            2024: FamilyScale(intrinsic=1.2, market=1.0, final=1.15),
+            2025: FamilyScale(intrinsic=1.4, market=1.0, final=1.30),
+        }
+        combined = combine_family_scales(per_season, {2024: 0.3, 2025: 0.7})
+        # Weighted mean of intrinsic: 0.3 * 1.2 + 0.7 * 1.4 = 1.34
+        assert abs(combined.intrinsic - 1.34) < 1e-9
+        assert abs(combined.market - 1.0) < 1e-9
+
+    def test_zero_weight_seasons_dropped(self):
+        per_season = {
+            2024: FamilyScale(intrinsic=5.0, market=1.0, final=3.0),
+            2025: FamilyScale(intrinsic=1.2, market=1.0, final=1.1),
+        }
+        combined = combine_family_scales(per_season, {2024: 0.0, 2025: 1.0})
+        assert abs(combined.intrinsic - 1.2) < 1e-9
+
+    def test_empty_seasons_returns_neutral(self):
+        combined = combine_family_scales({}, {})
+        assert combined.intrinsic == 1.0
+        assert combined.market == 1.0
+        assert combined.final == 1.0
+
+
+# ── Integration: end-to-end through the engine ──
+
+
+class _MixedAdapter(HistoricalStatsAdapter):
+    name = "mixed"
+
+    def _fetch_impl(self, season):
+        rows = []
+        # 60 IDP players
+        for i in range(60):
+            pos = ("DL", "LB", "DB")[i % 3]
+            rows.append(
+                PlayerSeason(
+                    player_id=f"idp_{i}",
+                    name=f"IDP{i}",
+                    position=pos,
+                    games=16,
+                    stats={
+                        "idp_tkl_solo": 100 - i,
+                        "idp_sack": max(0, 15 - i / 5),
+                    },
+                )
+            )
+        # 90 offense players (balanced across QB/RB/WR/TE)
+        for i in range(90):
+            pos = ("QB", "RB", "WR", "TE")[i % 4]
+            rows.append(
+                PlayerSeason(
+                    player_id=f"off_{i}",
+                    name=f"Off{i}",
+                    position=pos,
+                    games=16,
+                    stats={
+                        "pass_yd": max(0, 4500 - i * 30) if pos == "QB" else 0,
+                        "pass_td": max(0, 35 - i / 2) if pos == "QB" else 0,
+                        "rush_yd": max(0, 1400 - i * 10) if pos == "RB" else 0,
+                        "rush_td": max(0, 14 - i / 4) if pos == "RB" else 0,
+                        "rec": max(0, 100 - i) if pos in ("WR", "TE") else 0,
+                        "rec_yd": max(0, 1400 - i * 10) if pos in ("WR", "TE") else 0,
+                        "rec_td": max(0, 12 - i / 4) if pos in ("WR", "TE") else 0,
+                    },
+                )
+            )
+        return rows
+
+
+def _chain_builder(
+    *,
+    idp_solo_my: float,
+    idp_solo_test: float,
+    mine_has_extra_flex: bool = True,
+):
+    """Return a chain fetcher that resolves just 2025."""
+
+    def _builder(league_id, max_hops):
+        is_mine = league_id == "MINE"
+        positions = [
+            "QB", "RB", "RB", "WR", "WR", "TE", "FLEX",
+            "DL", "DL", "LB", "LB", "DB", "DB", "IDP_FLEX",
+        ]
+        if is_mine and mine_has_extra_flex:
+            positions.append("IDP_FLEX")
+        positions += ["BN"] * 6
+        return [
+            {
+                "league_id": f"{league_id}_2025",
+                "season": 2025,
+                "previous_league_id": "",
+                "scoring_settings": {
+                    "idp_tkl_solo": idp_solo_my if is_mine else idp_solo_test,
+                    "idp_sack": 4.0,
+                    "pass_yd": 0.04,
+                    "pass_td": 4.0,
+                    "rush_yd": 0.1,
+                    "rush_td": 6.0,
+                    "rec": 1.0,
+                    "rec_yd": 0.1,
+                    "rec_td": 6.0,
+                },
+                "roster_positions": positions,
+                "total_rosters": 12,
+            }
+        ]
+
+    return _builder
+
+
+def test_engine_emits_family_scale_in_artifact(monkeypatch):
+    monkeypatch.setattr(
+        season_chain,
+        "fetch_league_chain",
+        _chain_builder(idp_solo_my=1.5, idp_solo_test=1.0),
+    )
+    settings = engine.AnalysisSettings(seasons=[2025])
+    art = engine.run_analysis(
+        "TEST", "MINE", settings, stats_adapter_factory=lambda s: _MixedAdapter()
+    )
+    assert "family_scale" in art
+    fs = art["family_scale"]
+    # My league has heavier IDP scoring (1.5× solo) + an extra IDP flex,
+    # so intrinsic must come out > 1.0 (IDP is worth more per unit of
+    # offense in my league vs test).
+    assert fs["intrinsic"] > 1.0
+    assert fs["final"] > 1.0
+    # Each season also emits a family_scale in per_season.
+    assert art["per_season"]["2025"]["family_scale"] is not None
+    # And the recommendation block surfaces the family-scale line.
+    assert any("IDP family scale" in line for line in art["recommendation"]["summary_lines"])
+
+
+def test_engine_neutral_when_leagues_are_identical(monkeypatch):
+    monkeypatch.setattr(
+        season_chain,
+        "fetch_league_chain",
+        _chain_builder(idp_solo_my=1.0, idp_solo_test=1.0, mine_has_extra_flex=False),
+    )
+    settings = engine.AnalysisSettings(seasons=[2025])
+    art = engine.run_analysis(
+        "TEST", "MINE", settings, stats_adapter_factory=lambda s: _MixedAdapter()
+    )
+    fs = art["family_scale"]
+    # Identical leagues produce neutral scale. Allow a tiny numerical
+    # wobble but it should be well under 1%.
+    assert abs(fs["intrinsic"] - 1.0) < 0.01
+    assert abs(fs["final"] - 1.0) < 0.01
+
+
+# ── Production read path: family_scale is applied multiplicatively ──
+
+
+def _write_config(path, *, family_scale_final, dl_bucket_final):
+    """Helper: write a minimal promoted config with a family scale and
+    one DL bucket so we can verify the multiplicative combination."""
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_mode": "blended",
+                "family_scale": {
+                    "intrinsic": family_scale_final,
+                    "market": 1.0,
+                    "final": family_scale_final,
+                },
+                "multipliers": {
+                    "DL": {
+                        "position": "DL",
+                        "buckets": [
+                            {
+                                "label": "1-6",
+                                "intrinsic": dl_bucket_final,
+                                "market": dl_bucket_final,
+                                "final": dl_bucket_final,
+                                "count": 10,
+                            },
+                        ],
+                    },
+                },
+                "anchors": {},
+            }
+        )
+    )
+
+
+def test_production_combines_family_scale_with_bucket(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    _write_config(cfg_path, family_scale_final=1.3, dl_bucket_final=0.5)
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+    # Expected: 1.3 (family) × 0.5 (bucket) = 0.65.
+    assert abs(production.get_idp_bucket_multiplier("DL", 1) - 0.65) < 1e-9
+
+
+def test_production_family_scale_missing_is_identity(tmp_path, monkeypatch):
+    # Pre-Family-Scale promoted configs must keep working. Absent
+    # family_scale block → family lift = 1.0 (identity).
+    import json
+
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_mode": "blended",
+                "multipliers": {
+                    "DL": {
+                        "position": "DL",
+                        "buckets": [
+                            {
+                                "label": "1-6",
+                                "intrinsic": 0.5,
+                                "market": 0.5,
+                                "final": 0.5,
+                                "count": 10,
+                            },
+                        ],
+                    },
+                },
+                "anchors": {},
+            }
+        )
+    )
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+    assert abs(production.get_idp_bucket_multiplier("DL", 1) - 0.5) < 1e-9
+
+
+def test_production_family_scale_insane_value_clamped(tmp_path, monkeypatch):
+    # Defend against a hand-edited config with a nonsense value.
+    # compute_family_scale bounds outputs at [0.25, 4.0]; production
+    # re-clamps at read time so even an operator-edited config with
+    # a bogus value can't corrupt the board.
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    _write_config(cfg_path, family_scale_final=100.0, dl_bucket_final=0.5)
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+    # 100 clamped to 4.0, then × 0.5 = 2.0.
+    assert abs(production.get_idp_bucket_multiplier("DL", 1) - 2.0) < 1e-9
+
+
+def test_promotion_persists_family_scale(tmp_path, monkeypatch):
+    """End-to-end: run_analysis → storage.save_run → promotion.promote_run
+    → production config contains the family_scale block."""
+    monkeypatch.setattr(
+        season_chain,
+        "fetch_league_chain",
+        _chain_builder(idp_solo_my=1.5, idp_solo_test=1.0),
+    )
+    settings = engine.AnalysisSettings(seasons=[2025])
+    art = engine.run_analysis(
+        "TEST", "MINE", settings, stats_adapter_factory=lambda s: _MixedAdapter()
+    )
+    storage.save_run(art, base=tmp_path)
+    result = promotion.promote_run(
+        art["run_id"], active_mode="blended", base=tmp_path
+    )
+    assert result["ok"] is True
+    cfg_path = promotion.production_config_path(tmp_path)
+    import json
+
+    promoted = json.loads(cfg_path.read_text())
+    assert "family_scale" in promoted
+    assert promoted["family_scale"]["intrinsic"] > 1.0
+    assert promoted["family_scale"]["final"] > 1.0

--- a/tests/idp_calibration/test_family_scale_review_fixes.py
+++ b/tests/idp_calibration/test_family_scale_review_fixes.py
@@ -185,6 +185,68 @@ def _identical_chain(league_id, max_hops):
     ]
 
 
+def _no_te_chain(league_id, max_hops):
+    """League format with NO TE slot and no TE-eligible flex.
+    The IDP side is identical to ``_identical_chain`` so any
+    family_scale drift between the two fixtures is attributable to
+    the offense lineup change."""
+    return [
+        {
+            "league_id": f"{league_id}_2025",
+            "season": 2025,
+            "previous_league_id": "",
+            "scoring_settings": {
+                "idp_tkl_solo": 1.0,
+                "idp_sack": 4.0,
+                "pass_yd": 0.04,
+                "pass_td": 4.0,
+                "rush_yd": 0.1,
+                "rush_td": 6.0,
+                "rec": 1.0,
+                "rec_yd": 0.1,
+                "rec_td": 6.0,
+            },
+            # No TE slot, only WRRB_FLEX so TE has zero demand from
+            # any source (no direct TE slot, plain FLEX, REC_FLEX,
+            # or SUPER_FLEX).
+            "roster_positions": [
+                "QB", "RB", "RB", "WR", "WR", "WR", "WRRB_FLEX",
+                "DL", "DL", "LB", "LB", "DB", "DB", "IDP_FLEX",
+                "BN", "BN", "BN", "BN",
+            ],
+            "total_rosters": 12,
+        }
+    ]
+
+
+def test_zero_demand_te_excluded_from_offense_vor(monkeypatch):
+    """A no-TE league must not let TE players contribute positive
+    offense VOR. Otherwise the offense denominator inflates and
+    family_scale gets biased downward."""
+    monkeypatch.setattr(season_chain, "fetch_league_chain", _no_te_chain)
+    settings = engine.AnalysisSettings(seasons=[2025])
+    art = engine.run_analysis(
+        "TEST", "MINE", settings,
+        stats_adapter_factory=lambda s: _BiggerAdapter(),
+    )
+    # Family scale must still be ~1.0 since both leagues are
+    # identical. Without the zero-demand guard, TE players in the
+    # adapter's universe would be assigned a low replacement (rank=1
+    # via the floor) and contribute positive VOR to BOTH sides
+    # symmetrically, but in different proportions if the leagues
+    # differ — and even when identical, the inflated denominator
+    # noticeably suppresses real differentiation in non-trivial
+    # cases. Directly assert: family_scale stays ~1.0 on identical
+    # no-TE leagues.
+    fs = art["family_scale"]["intrinsic"]
+    assert abs(fs - 1.0) < 0.05, f"no-TE league shifted family_scale: {fs}"
+    # And the per-season offense lineup correctly reports zero TE
+    # demand (sanity-check the lineup parser).
+    me = art["per_season"]["2025"]["my_lineup"]
+    assert me["te_starters"] == 0
+    assert me["total_te_demand"] == 0.0
+
+
 def test_top_n_trims_offense_symmetrically(monkeypatch):
     # Identical leagues → family_scale should be 1.0 regardless of
     # whether top_n is enabled. Without the offense-side trim,

--- a/tests/idp_calibration/test_family_scale_review_fixes.py
+++ b/tests/idp_calibration/test_family_scale_review_fixes.py
@@ -1,0 +1,217 @@
+"""Regression tests for the two PR-#99 review-driven fixes:
+
+1. WRRB_FLEX (RB/WR only, no TE) and REC_FLEX (WR/TE only, no RB) must
+   contribute correctly to per-position offense demand. Lumping them
+   into a generic 3-way flex would distort offense replacement ranks.
+2. ``settings.top_n`` must trim the offense cohort the same way it
+   trims the IDP cohort, so the family_scale ratio stays symmetric.
+"""
+from __future__ import annotations
+
+from src.idp_calibration import engine, season_chain
+from src.idp_calibration.lineup import parse_lineup
+from src.idp_calibration.stats_adapter import HistoricalStatsAdapter, PlayerSeason
+
+
+# ── P1: restricted flex slots ──
+
+
+def test_wrrb_flex_does_not_inflate_te_demand():
+    league = {
+        "league_id": "L",
+        "season": 2025,
+        "total_rosters": 12,
+        "roster_positions": [
+            "QB", "RB", "RB", "WR", "WR", "TE", "WRRB_FLEX",
+            "BN", "BN", "BN",
+        ],
+    }
+    demand = parse_lineup(league)
+    # WRRB_FLEX must not flow into TE demand — it's RB/WR only.
+    assert demand.te_starters == 1
+    assert abs(demand.total_te_demand - 1.0) < 1e-9
+    # RB demand: 2 starters + WRRB/2 = 2.5
+    assert abs(demand.total_rb_demand - 2.5) < 1e-9
+    # WR demand: 2 starters + WRRB/2 = 2.5
+    assert abs(demand.total_wr_demand - 2.5) < 1e-9
+
+
+def test_rec_flex_does_not_inflate_rb_demand():
+    league = {
+        "league_id": "L",
+        "season": 2025,
+        "total_rosters": 12,
+        "roster_positions": [
+            "QB", "RB", "RB", "WR", "WR", "TE", "REC_FLEX",
+            "BN", "BN", "BN",
+        ],
+    }
+    demand = parse_lineup(league)
+    # REC_FLEX must not flow into RB demand — it's WR/TE only.
+    assert demand.rb_starters == 2
+    assert abs(demand.total_rb_demand - 2.0) < 1e-9
+    # WR + TE absorb the REC_FLEX 50/50.
+    assert abs(demand.total_wr_demand - 2.5) < 1e-9
+    assert abs(demand.total_te_demand - 1.5) < 1e-9
+
+
+def test_plain_flex_still_splits_three_ways():
+    # Backward-compat — plain FLEX must still act as RB/WR/TE 1/3 each.
+    league = {
+        "league_id": "L",
+        "season": 2025,
+        "total_rosters": 12,
+        "roster_positions": ["QB", "RB", "WR", "TE", "FLEX", "BN", "BN"],
+    }
+    demand = parse_lineup(league)
+    expected = 1 + 1 / 3.0
+    assert abs(demand.total_rb_demand - expected) < 1e-9
+    assert abs(demand.total_wr_demand - expected) < 1e-9
+    assert abs(demand.total_te_demand - expected) < 1e-9
+
+
+def test_super_flex_still_25_pct_each():
+    league = {
+        "league_id": "L",
+        "season": 2025,
+        "total_rosters": 12,
+        "roster_positions": ["QB", "RB", "WR", "TE", "SUPER_FLEX", "BN"],
+    }
+    demand = parse_lineup(league)
+    # QB: 1 + super_flex × 0.25 = 1.25
+    assert abs(demand.total_qb_demand - 1.25) < 1e-9
+    # RB / WR / TE each: 1 + super_flex × 0.25 = 1.25
+    assert abs(demand.total_rb_demand - 1.25) < 1e-9
+    assert abs(demand.total_wr_demand - 1.25) < 1e-9
+    assert abs(demand.total_te_demand - 1.25) < 1e-9
+
+
+def test_mixed_flex_combinations_compose_correctly():
+    # A real-world dynasty IDP league might use plain FLEX + WRRB +
+    # SUPER_FLEX simultaneously. Each contributes only to its
+    # eligible positions.
+    league = {
+        "league_id": "L",
+        "season": 2025,
+        "total_rosters": 12,
+        "roster_positions": [
+            "QB", "RB", "RB", "WR", "WR", "WR", "TE",
+            "FLEX", "WRRB_FLEX", "SUPER_FLEX",
+            "BN",
+        ],
+    }
+    demand = parse_lineup(league)
+    # QB: 1 + super × 0.25 = 1.25
+    assert abs(demand.total_qb_demand - 1.25) < 1e-9
+    # RB: 2 + plain/3 + WRRB/2 + super × 0.25 = 2 + 0.333 + 0.5 + 0.25 = 3.083
+    assert abs(demand.total_rb_demand - (2 + 1 / 3 + 0.5 + 0.25)) < 1e-9
+    # WR: 3 + plain/3 + WRRB/2 + super × 0.25 = 3 + 0.333 + 0.5 + 0.25 = 4.083
+    assert abs(demand.total_wr_demand - (3 + 1 / 3 + 0.5 + 0.25)) < 1e-9
+    # TE: 1 + plain/3 + super × 0.25 = 1 + 0.333 + 0.25 = 1.583  (NO WRRB)
+    assert abs(demand.total_te_demand - (1 + 1 / 3 + 0.25)) < 1e-9
+
+
+# ── P2: top_n symmetry ──
+
+
+class _BiggerAdapter(HistoricalStatsAdapter):
+    """Adapter that returns enough offense and IDP rows that top_n
+    trim has a non-trivial effect."""
+
+    name = "bigger"
+
+    def _fetch_impl(self, season):
+        rows = []
+        for i in range(120):
+            pos = ("DL", "LB", "DB")[i % 3]
+            rows.append(
+                PlayerSeason(
+                    player_id=f"idp_{i}",
+                    name=f"IDP{i}",
+                    position=pos,
+                    games=16,
+                    stats={
+                        "idp_tkl_solo": 200 - i,
+                        "idp_sack": max(0, 25 - i / 4),
+                    },
+                )
+            )
+        for i in range(200):
+            pos = ("QB", "RB", "WR", "TE")[i % 4]
+            rows.append(
+                PlayerSeason(
+                    player_id=f"off_{i}",
+                    name=f"Off{i}",
+                    position=pos,
+                    games=16,
+                    stats={
+                        "pass_yd": max(0, 5000 - i * 22) if pos == "QB" else 0,
+                        "pass_td": max(0, 40 - i / 2) if pos == "QB" else 0,
+                        "rush_yd": max(0, 1500 - i * 7) if pos == "RB" else 0,
+                        "rush_td": max(0, 16 - i / 4) if pos == "RB" else 0,
+                        "rec": max(0, 110 - i / 2) if pos in ("WR", "TE") else 0,
+                        "rec_yd": max(0, 1500 - i * 7) if pos in ("WR", "TE") else 0,
+                        "rec_td": max(0, 13 - i / 4) if pos in ("WR", "TE") else 0,
+                    },
+                )
+            )
+        return rows
+
+
+def _identical_chain(league_id, max_hops):
+    return [
+        {
+            "league_id": f"{league_id}_2025",
+            "season": 2025,
+            "previous_league_id": "",
+            "scoring_settings": {
+                "idp_tkl_solo": 1.0,
+                "idp_sack": 4.0,
+                "pass_yd": 0.04,
+                "pass_td": 4.0,
+                "rush_yd": 0.1,
+                "rush_td": 6.0,
+                "rec": 1.0,
+                "rec_yd": 0.1,
+                "rec_td": 6.0,
+            },
+            "roster_positions": [
+                "QB", "RB", "RB", "WR", "WR", "TE", "FLEX",
+                "DL", "DL", "LB", "LB", "DB", "DB", "IDP_FLEX",
+                "BN", "BN", "BN", "BN",
+            ],
+            "total_rosters": 12,
+        }
+    ]
+
+
+def test_top_n_trims_offense_symmetrically(monkeypatch):
+    # Identical leagues → family_scale should be 1.0 regardless of
+    # whether top_n is enabled. Without the offense-side trim,
+    # enabling top_n would skew the ratio purely because the
+    # numerator (IDP) was trimmed and the denominator (offense)
+    # wasn't.
+    monkeypatch.setattr(season_chain, "fetch_league_chain", _identical_chain)
+
+    untrimmed_settings = engine.AnalysisSettings(seasons=[2025])
+    untrimmed_art = engine.run_analysis(
+        "TEST", "MINE", untrimmed_settings,
+        stats_adapter_factory=lambda s: _BiggerAdapter(),
+    )
+
+    trimmed_settings = engine.AnalysisSettings(seasons=[2025], top_n=20)
+    trimmed_art = engine.run_analysis(
+        "TEST", "MINE", trimmed_settings,
+        stats_adapter_factory=lambda s: _BiggerAdapter(),
+    )
+
+    fs_untrimmed = untrimmed_art["family_scale"]["intrinsic"]
+    fs_trimmed = trimmed_art["family_scale"]["intrinsic"]
+    # Both should be ~1.0 (identical leagues). The trimmed one should
+    # not have moved meaningfully versus the untrimmed.
+    assert abs(fs_untrimmed - 1.0) < 0.01
+    assert abs(fs_trimmed - 1.0) < 0.01
+    assert abs(fs_trimmed - fs_untrimmed) < 0.05, (
+        f"top_n shifted family_scale on identical leagues: "
+        f"untrimmed={fs_untrimmed} trimmed={fs_trimmed}"
+    )


### PR DESCRIPTION
## Summary

Adds the **cross-family IDP-vs-offense calibration layer** you asked for. Previously the lab only produced *within-position shape* signals (every top-6 bucket normalised to 1.0), so elite IDPs were untouched even when the league's structure implied they should shift relative to elite offense. This PR layers a single scalar on top of the existing per-bucket multipliers that answers "how should my league's IDPs as a class be valued vs offense?"

## The math

For each resolved season:

```
my_ratio   = sum(above-replacement IDP VOR under my rules)
           / sum(above-replacement offense VOR under my rules)
test_ratio = same, with test-league rules

family_scale_intrinsic = my_ratio / test_ratio
```

Market channel is test-vs-test by construction (= 1.0). Final is the same intrinsic/market blend (default 75/25) already used for per-bucket multipliers. Bounded to `[0.25, 4.0]` to guard against pathological replacement mismatches. Multi-year seasons aggregate via weighted mean.

## Production application

```
final_value = rankDerivedValue × family_scale × bucket_multiplier
```

A `family_scale` > 1.0 lifts every IDP row in lockstep — **including top-6**, which the within-position calibration could never touch. Backward compat: promoted configs from before this PR default to 1.0.

## Scope

| File | Change |
|---|---|
| `src/idp_calibration/lineup.py` | QB/RB/WR/TE starter counts + replacement_rank for offense |
| `src/idp_calibration/scoring.py` | OFFENSE_STAT_KEYS + offense_weights on LeagueScoring |
| `src/idp_calibration/stats_adapter.py` | Adapters now return QB/RB/WR/TE rows too |
| `src/idp_calibration/vor.py` | `positions=` iterable so helpers work for either family |
| `src/idp_calibration/translation.py` | `FamilyScale`, `compute_family_scale`, `combine_family_scales` |
| `src/idp_calibration/engine.py` | Offense scoring/replacement/VOR + per-season family_scale; recommendation surfaces it |
| `src/idp_calibration/production.py` | `get_idp_bucket_multiplier` now multiplies bucket × family_scale (re-clamped) |
| `src/idp_calibration/promotion.py` | `family_scale` persisted in `config/idp_calibration.json` |
| `frontend/.../ResultsDashboard.jsx` | `FamilyScaleBlock` above per-position tables in the Multi-year summary |

## Tests — `tests/idp_calibration/test_family_scale.py` (15 new)

- **Math**: neutral case, my>test lift, sub-replacement ignored, clamp at `[0.25, 4.0]`, zero-offense guard, blend correctness.
- **Multi-year aggregation**: weighted mean, zero-weight drop, empty.
- **Engine integration**: `family_scale` emitted in artifact + per-season + recommendation summary; identical leagues produce ~1.0.
- **Production read path**: family × bucket multiplicative combination, backward compat with pre-family-scale configs, insane-value clamp at read time.
- **Promotion**: `family_scale` persisted in `config/idp_calibration.json`.

Full pytest suite: **1626 passed, 26 skipped**.

## Test plan

- [x] `pytest tests/ -q --ignore=tests/e2e --ignore=tests/api/test_draft_capital.py`
- [ ] After deploy: re-run the IDP Lab. Multi-year summary should show a new "IDP family scale" block at the top with intrinsic / market / final factors. The recommendation block's first summary line should name the class-level lift/discount percentage.
- [ ] Top-6 IDP values in the "What would change" diff will now show non-1.0 candidate values if family_scale ≠ 1.0 — this is the lever you asked for.
- [ ] Safe to promote once the family_scale block matches expectations.

https://claude.ai/code/session_01Ub9Z6e914gMMdC4goBME8V