### PR TITLE
IDP Lab: &quot;Refresh live board now&quot; button in Production Config panel

### DIFF
--- a/frontend/app/api/idp-calibration/refresh-board/route.js
+++ b/frontend/app/api/idp-calibration/refresh-board/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+  /\/api\/data\/?$/,
+  "",
+);
+
+export async function POST(request) {
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  // Rebuilding the full contract is usually 1-3s but allow headroom.
+  const timer = setTimeout(() => ctl.abort(), 30_000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/refresh-board`, {
+      method: "POST",
+      headers: { Cookie: cookie },
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2328,6 +2328,18 @@ tr:hover .sticky-name {
   margin-top: var(--space-sm);
 }
 
+.idp-lab-refresh-block {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: var(--space-sm);
+}
+
+.idp-lab-refresh-hint {
+  margin-top: var(--space-xs);
+}
+
 .idp-lab-rec-list {
   margin: 0;
   padding-left: 1.2em;

--- a/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
+++ b/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
@@ -11,12 +11,25 @@ export default function ProductionConfigPanel({
   onPromote,
   loading,
   error,
+  onRefreshBoard,
+  refreshing,
+  refreshError,
 }) {
   const [mode, setMode] = useState("blended");
   const [confirming, setConfirming] = useState(false);
+  const [lastRefreshAt, setLastRefreshAt] = useState(null);
   const promoted = production?.present ? production.config : null;
 
   const canPromote = Boolean(currentRun?.run_id) && !loading;
+  const canRefresh = Boolean(promoted) && !refreshing;
+
+  async function handleRefreshClick() {
+    if (!canRefresh || !onRefreshBoard) return;
+    const result = await onRefreshBoard();
+    if (result?.ok) {
+      setLastRefreshAt(result.rebuilt_at || new Date().toISOString());
+    }
+  }
 
   function handlePromoteClick() {
     if (!canPromote) return;
@@ -43,6 +56,33 @@ export default function ProductionConfigPanel({
             Year coverage: {(promoted.year_coverage || []).join(", ") || "—"} |{" "}
             League IDs: test <code>{promoted.league_ids?.test}</code>, mine{" "}
             <code>{promoted.league_ids?.mine}</code>.
+          </p>
+          <div className="idp-lab-refresh-block">
+            <button
+              type="button"
+              className="button"
+              onClick={handleRefreshClick}
+              disabled={!canRefresh}
+              title={
+                !canRefresh
+                  ? "Nothing to refresh until a calibration is promoted"
+                  : "Force the live /rankings + /trade contracts to rebuild with the current promoted calibration"
+              }
+            >
+              {refreshing ? "Refreshing…" : "Refresh live board now"}
+            </button>
+            {lastRefreshAt && !refreshing && (
+              <span className="muted text-sm">
+                Last refresh: <code>{lastRefreshAt}</code>
+              </span>
+            )}
+            {refreshError && (
+              <span className="idp-lab-error-text">{refreshError}</span>
+            )}
+          </div>
+          <p className="muted text-sm idp-lab-refresh-hint">
+            Without clicking, the live board picks up the promoted calibration on
+            the next scheduled scrape. This button forces it to happen now.
           </p>
         </div>
       ) : (

--- a/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
+++ b/frontend/app/tools/idp-calibration/ProductionConfigPanel.jsx
@@ -21,7 +21,12 @@ export default function ProductionConfigPanel({
   const promoted = production?.present ? production.config : null;
 
   const canPromote = Boolean(currentRun?.run_id) && !loading;
-  const canRefresh = Boolean(promoted) && !refreshing;
+  // Must also gate on `loading` (the promote flag). If the user clicks
+  // Refresh while a promote is in flight, the rebuild would read the
+  // OLD config from disk (promote hasn't written yet) but still report
+  // success — leaving a misleading "Last refresh" timestamp. Block the
+  // button until promote resolves.
+  const canRefresh = Boolean(promoted) && !refreshing && !loading;
 
   async function handleRefreshClick() {
     if (!canRefresh || !onRefreshBoard) return;
@@ -64,8 +69,12 @@ export default function ProductionConfigPanel({
               onClick={handleRefreshClick}
               disabled={!canRefresh}
               title={
-                !canRefresh
+                loading
+                  ? "Promotion in flight — wait until it finishes"
+                  : !promoted
                   ? "Nothing to refresh until a calibration is promoted"
+                  : refreshing
+                  ? "Refresh already running"
                   : "Force the live /rankings + /trade contracts to rebuild with the current promoted calibration"
               }
             >

--- a/frontend/app/tools/idp-calibration/page.jsx
+++ b/frontend/app/tools/idp-calibration/page.jsx
@@ -41,6 +41,7 @@ export default function IdpCalibrationLabPage() {
     loadRun,
     deleteRun,
     promote,
+    refreshBoard,
   } = useCalibration();
 
   useEffect(() => {
@@ -162,6 +163,9 @@ export default function IdpCalibrationLabPage() {
         onPromote={promote}
         loading={loading.promote}
         error={error.promote}
+        onRefreshBoard={refreshBoard}
+        refreshing={loading.refreshBoard}
+        refreshError={error.refreshBoard}
       />
 
       <SavedRunsList

--- a/frontend/app/tools/idp-calibration/useCalibration.js
+++ b/frontend/app/tools/idp-calibration/useCalibration.js
@@ -34,6 +34,7 @@ export function useCalibration() {
     promote: false,
     runDetail: false,
     deleteRun: false,
+    refreshBoard: false,
   });
   const [error, setError] = useState({});
   const mountedRef = useRef(true);
@@ -169,6 +170,21 @@ export function useCalibration() {
     return data;
   }, [refreshProduction, refreshStatus]);
 
+  const refreshBoard = useCallback(async () => {
+    setFlag("refreshBoard", true);
+    setErr("refreshBoard", null);
+    const { status: http, data } = await jfetch(
+      "/api/idp-calibration/refresh-board",
+      { method: "POST" },
+    );
+    if (!mountedRef.current) return data;
+    if (http >= 400 || data?.ok === false) {
+      setErr("refreshBoard", data?.error || `HTTP ${http}`);
+    }
+    setFlag("refreshBoard", false);
+    return data;
+  }, []);
+
   return {
     status,
     runs,
@@ -184,5 +200,6 @@ export function useCalibration() {
     loadRun,
     deleteRun,
     promote,
+    refreshBoard,
   };
 }

--- a/frontend/app/tools/idp-calibration/useCalibration.js
+++ b/frontend/app/tools/idp-calibration/useCalibration.js
@@ -173,16 +173,33 @@ export function useCalibration() {
   const refreshBoard = useCallback(async () => {
     setFlag("refreshBoard", true);
     setErr("refreshBoard", null);
-    const { status: http, data } = await jfetch(
-      "/api/idp-calibration/refresh-board",
-      { method: "POST" },
-    );
-    if (!mountedRef.current) return data;
-    if (http >= 400 || data?.ok === false) {
-      setErr("refreshBoard", data?.error || `HTTP ${http}`);
+    try {
+      const { status: http, data } = await jfetch(
+        "/api/idp-calibration/refresh-board",
+        { method: "POST" },
+      );
+      if (!mountedRef.current) return data;
+      if (http >= 400 || data?.ok === false) {
+        setErr("refreshBoard", data?.error || `HTTP ${http}`);
+      }
+      return data;
+    } catch (err) {
+      // Network-layer rejection (browser offline, aborted navigation,
+      // backend unreachable). Without the try/finally the loading flag
+      // would stay true and the button would stick at "Refreshing…"
+      // until a full reload.
+      if (mountedRef.current) {
+        setErr(
+          "refreshBoard",
+          err?.message || "Network error. The live board may still be healthy.",
+        );
+      }
+      return { ok: false, error: err?.message || "Network error" };
+    } finally {
+      if (mountedRef.current) {
+        setFlag("refreshBoard", false);
+      }
     }
-    setFlag("refreshBoard", false);
-    return data;
   }, []);
 
   return {

--- a/server.py
+++ b/server.py
@@ -3800,6 +3800,54 @@ async def idp_calibration_status(request: Request):
     return _idp_json(_idp_api.status())
 
 
+@app.post("/api/idp-calibration/refresh-board")
+async def idp_calibration_refresh_board(request: Request):
+    """Force a rebuild of the cached live player contract.
+
+    After ``Promote to production`` writes ``config/idp_calibration.json``,
+    the live player board cached in memory (``latest_contract_data``,
+    plus its pre-serialised byte/gzip/etag variants) still reflects
+    the calibration applied at the last scrape time. This endpoint
+    re-runs ``_prime_latest_payload`` against the current raw scrape
+    (``latest_data``), which re-reads the promoted config and produces
+    a fresh contract — so the next ``/api/data`` / ``/rankings`` /
+    ``/trade`` request serves values computed under the newly-promoted
+    calibration, without waiting for the next scheduled scrape.
+
+    Returns 503 when no scrape data has been captured yet (cold start)
+    because there's nothing to rebuild from.
+    """
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    if not latest_data:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "ok": False,
+                "error": (
+                    "No scrape data available yet. Wait for the first "
+                    "scrape to complete before requesting a refresh."
+                ),
+            },
+        )
+    try:
+        _prime_latest_payload(latest_data)
+    except Exception as exc:  # noqa: BLE001 — user-facing surface
+        log.exception("idp-calibration refresh-board rebuild failed: %s", exc)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": f"Rebuild failed: {exc}"},
+        )
+    return JSONResponse(
+        content={
+            "ok": True,
+            "rebuilt_at": _utc_now_iso(),
+            "contract_ok": bool((contract_health or {}).get("ok")),
+        },
+    )
+
+
 @app.api_route("/", methods=["GET", "HEAD"], response_class=HTMLResponse)
 async def serve_landing(request: Request):
     redirect = _require_auth_or_redirect(request, "/")

--- a/server.py
+++ b/server.py
@@ -3820,6 +3820,13 @@ async def idp_calibration_refresh_board(request: Request):
     gate = _require_auth_json(request)
     if gate is not None:
         return gate
+    global latest_contract_data, latest_data_bytes, latest_data_gzip_bytes
+    global latest_data_etag, latest_runtime_data, latest_runtime_data_bytes
+    global latest_runtime_data_gzip_bytes, latest_runtime_data_etag
+    global latest_startup_data, latest_startup_data_bytes
+    global latest_startup_data_gzip_bytes, latest_startup_data_etag
+    global contract_health
+
     if not latest_data:
         return JSONResponse(
             status_code=503,
@@ -3831,23 +3838,70 @@ async def idp_calibration_refresh_board(request: Request):
                 ),
             },
         )
+
+    # Snapshot every global _prime_latest_payload mutates BEFORE calling
+    # it. The helper clears all of these to None up-front and only
+    # re-populates them on a successful build — so if the rebuild fails
+    # the live board would otherwise go dark (/api/data serves 503).
+    # A failed manual refresh must never turn a healthy board into an
+    # outage: if the rebuild ends unhealthy, we restore the snapshot so
+    # the previously-cached contract keeps serving.
+    snapshot = (
+        latest_contract_data,
+        latest_data_bytes,
+        latest_data_gzip_bytes,
+        latest_data_etag,
+        latest_runtime_data,
+        latest_runtime_data_bytes,
+        latest_runtime_data_gzip_bytes,
+        latest_runtime_data_etag,
+        latest_startup_data,
+        latest_startup_data_bytes,
+        latest_startup_data_gzip_bytes,
+        latest_startup_data_etag,
+        contract_health,
+    )
+
+    def _restore_snapshot() -> None:
+        global latest_contract_data, latest_data_bytes, latest_data_gzip_bytes
+        global latest_data_etag, latest_runtime_data, latest_runtime_data_bytes
+        global latest_runtime_data_gzip_bytes, latest_runtime_data_etag
+        global latest_startup_data, latest_startup_data_bytes
+        global latest_startup_data_gzip_bytes, latest_startup_data_etag
+        global contract_health
+        (
+            latest_contract_data,
+            latest_data_bytes,
+            latest_data_gzip_bytes,
+            latest_data_etag,
+            latest_runtime_data,
+            latest_runtime_data_bytes,
+            latest_runtime_data_gzip_bytes,
+            latest_runtime_data_etag,
+            latest_startup_data,
+            latest_startup_data_bytes,
+            latest_startup_data_gzip_bytes,
+            latest_startup_data_etag,
+            contract_health,
+        ) = snapshot
+
     try:
         _prime_latest_payload(latest_data)
-    except Exception as exc:  # noqa: BLE001 — defensive, shouldn't fire in
-        # practice because _prime_latest_payload catches internally, but we
-        # keep the outer guard in case that contract ever changes.
+    except Exception as exc:  # noqa: BLE001 — defensive net; see P1 review.
         log.exception("idp-calibration refresh-board rebuild raised: %s", exc)
+        _restore_snapshot()
         return JSONResponse(
             status_code=500,
-            content={"ok": False, "error": f"Rebuild raised: {exc}"},
+            content={
+                "ok": False,
+                "error": f"Rebuild raised: {exc}. Previous live board preserved.",
+            },
         )
     # _prime_latest_payload swallows its own exceptions and signals
-    # validation / build failures through contract_health + by leaving
-    # latest_contract_data unset. Both are necessary: contract_health can
-    # be ok=False on a validation warning while latest_contract_data is
-    # still populated, and conversely latest_contract_data can be None
-    # on a catastrophic JSON-serialise failure even though contract_health
-    # never updated. Require both to be healthy before reporting success.
+    # failures through contract_health + by leaving latest_contract_data
+    # unset. Require both to be healthy before reporting success; on
+    # failure, roll the globals back to their pre-refresh snapshot so
+    # a failed manual refresh cannot take the live board down.
     health = contract_health or {}
     if latest_contract_data is None or not health.get("ok"):
         errors = (health.get("errors") or [])[:3]
@@ -3859,13 +3913,14 @@ async def idp_calibration_refresh_board(request: Request):
         log.error(
             "idp-calibration refresh-board rebuild unhealthy: %s", detail
         )
+        _restore_snapshot()
         return JSONResponse(
             status_code=500,
             content={
                 "ok": False,
                 "error": (
-                    "Rebuild completed but the live contract is not healthy. "
-                    f"Details: {detail}"
+                    "Rebuild completed but the live contract is not healthy; "
+                    f"restored previous board. Details: {detail}"
                 ),
                 "contract_ok": bool(health.get("ok")),
                 "error_count": int(health.get("errorCount") or 0),

--- a/server.py
+++ b/server.py
@@ -3833,17 +3833,49 @@ async def idp_calibration_refresh_board(request: Request):
         )
     try:
         _prime_latest_payload(latest_data)
-    except Exception as exc:  # noqa: BLE001 — user-facing surface
-        log.exception("idp-calibration refresh-board rebuild failed: %s", exc)
+    except Exception as exc:  # noqa: BLE001 — defensive, shouldn't fire in
+        # practice because _prime_latest_payload catches internally, but we
+        # keep the outer guard in case that contract ever changes.
+        log.exception("idp-calibration refresh-board rebuild raised: %s", exc)
         return JSONResponse(
             status_code=500,
-            content={"ok": False, "error": f"Rebuild failed: {exc}"},
+            content={"ok": False, "error": f"Rebuild raised: {exc}"},
+        )
+    # _prime_latest_payload swallows its own exceptions and signals
+    # validation / build failures through contract_health + by leaving
+    # latest_contract_data unset. Both are necessary: contract_health can
+    # be ok=False on a validation warning while latest_contract_data is
+    # still populated, and conversely latest_contract_data can be None
+    # on a catastrophic JSON-serialise failure even though contract_health
+    # never updated. Require both to be healthy before reporting success.
+    health = contract_health or {}
+    if latest_contract_data is None or not health.get("ok"):
+        errors = (health.get("errors") or [])[:3]
+        detail = "; ".join(str(e) for e in errors) if errors else (
+            "latest_contract_data was not populated"
+            if latest_contract_data is None
+            else "contract validation reported errors"
+        )
+        log.error(
+            "idp-calibration refresh-board rebuild unhealthy: %s", detail
+        )
+        return JSONResponse(
+            status_code=500,
+            content={
+                "ok": False,
+                "error": (
+                    "Rebuild completed but the live contract is not healthy. "
+                    f"Details: {detail}"
+                ),
+                "contract_ok": bool(health.get("ok")),
+                "error_count": int(health.get("errorCount") or 0),
+            },
         )
     return JSONResponse(
         content={
             "ok": True,
             "rebuilt_at": _utc_now_iso(),
-            "contract_ok": bool((contract_health or {}).get("ok")),
+            "contract_ok": True,
         },
     )
 


### PR DESCRIPTION
## Summary

After **Promote to production** writes `config/idp_calibration.json`, the server's cached player-data contract (`latest_contract_data` + its pre-serialised byte/gzip/etag variants) still reflects the calibration that was applied at the last scrape — so `/rankings`, `/trade`, and `/api/data` keep serving the old values until the next scheduled scrape rebuilds them. The previous workaround was to toggle a source on `/settings`, which triggered an override rebuild as a side effect. This PR gives promotion its own explicit refresh button so the operator doesn't have to use a trick.

## Changes

**Backend** (`server.py`)
- New `POST /api/idp-calibration/refresh-board` endpoint. Auth-gated the same way the other lab endpoints are. Calls `_prime_latest_payload(latest_data)` which re-runs `build_api_data_contract` → runs the IDP calibration post-pass → reads `config/idp_calibration.json` fresh. Returns 503 when no scrape data is available yet (cold start).

**Frontend**
- `frontend/app/api/idp-calibration/refresh-board/route.js` — Next.js proxy with cookie forwarding and 30s timeout headroom for the rebuild.
- `useCalibration` hook gains `refreshBoard()`, `loading.refreshBoard`, and `error.refreshBoard`.
- `ProductionConfigPanel` renders a new **Refresh live board now** button inside the promoted-config block (disabled when no promotion yet or while refresh is in flight). Shows `Refreshing…` while rebuilding, then the `rebuilt_at` timestamp on success. Hint text explains the scrape-cycle fallback.
- `page.jsx` wires the props.
- `globals.css` adds `.idp-lab-refresh-block` and `.idp-lab-refresh-hint`.

No math or promotion semantics change — purely an ergonomics addition.

## Test plan

- [x] `pytest tests/ -q --ignore=tests/e2e --ignore=tests/api/test_draft_capital.py` — 1633 passed, 26 skipped.
- [ ] After deploy: promote any run → click **Refresh live board now** in the Production Config panel → the button shows `Refreshing…` then the rebuilt_at timestamp → reload `/rankings` and confirm IDP values reflect the new calibration without needing to trigger a scrape or toggle a source.

https://claude.ai/code/session_01Ub9Z6e914gMMdC4goBME8V