### PR TITLE
Fix DJ Turner / DJ Turner II name collision breaking contract health

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -766,6 +766,7 @@ def fetch_sleeper_rosters(league_id):
 
     all_names = []
     position_map = {}
+    position_collisions: dict[str, set[str]] = {}
     player_id_map = {}
     id_to_player = {}
     teams = []
@@ -981,7 +982,17 @@ def fetch_sleeper_rosters(league_id):
                 if pos and cn:
                     # Multi-positional IDP rule: prefer non-LB for dual-position players
                     # Sleeper stores a single position; we override known edge cases
-                    position_map[cn] = pos
+                    existing = position_map.get(cn)
+                    if existing and existing != pos:
+                        # Name collision across universes (e.g. DJ Turner WR vs
+                        # DJ Turner II CB both clean to "DJ Turner"). Drop the
+                        # entry entirely — having no position is safer than
+                        # tagging the row with the wrong family, which breaks
+                        # the offense→IDP validator downstream.
+                        position_map.pop(cn, None)
+                        position_collisions.setdefault(cn, set()).update({existing, pos})
+                    elif cn not in position_collisions:
+                        position_map[cn] = pos
 
         teams.append({
             "name": team_name,
@@ -1014,6 +1025,15 @@ def fetch_sleeper_rosters(league_id):
         cn = clean_name(name)
         if cn in position_map:
             position_map[cn] = override_pos
+
+    if position_collisions:
+        preview = ", ".join(
+            f"{k} ({'/'.join(sorted(v))})"
+            for k, v in list(position_collisions.items())[:5]
+        )
+        print(
+            f"  [Sleeper] Dropped {len(position_collisions)} colliding position entries: {preview}"
+        )
 
 
     teams.sort(key=lambda t: t["name"])

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3958,6 +3958,20 @@ def _derive_player_row(
             pos = pos_from_player
         elif player_is_idp and sleeper_is_off and has_idp_signal and not has_off_signal:
             pos = pos_from_player
+    elif not pos_from_player and pos_from_sleeper:
+        # Signal-based guardrail: when the player's adapter data has no position
+        # but the sleeper map contradicts the source signals, drop the
+        # sleeper-supplied position. This catches name collisions across
+        # universes (e.g. DJ Turner WR vs DJ Turner II CB both clean to the
+        # same key) where the sleeper map overwrote one with the other's
+        # position. Tagging the row with the wrong family would break the
+        # offense→IDP validator downstream.
+        sleeper_is_off = pos_from_sleeper in _OFFENSE_POSITIONS
+        sleeper_is_idp = pos_from_sleeper in _IDP_POSITIONS
+        if sleeper_is_idp and has_off_signal and not has_idp_signal:
+            pos = ""
+        elif sleeper_is_off and has_idp_signal and not has_off_signal:
+            pos = ""
 
     is_pick = _is_pick_name(canonical_name)
     if is_pick:

--- a/tests/api/test_identity_validation.py
+++ b/tests/api/test_identity_validation.py
@@ -649,5 +649,78 @@ class TestAgeFieldScaffolding(unittest.TestCase):
         self.assertEqual(row["age"], 26)
 
 
+# ── Name collision guardrail: sleeper map tagging conflicts source signals ──
+
+class TestSleeperMapCollisionGuardrail(unittest.TestCase):
+    """When the sleeper positions map is contaminated by a name collision
+    (e.g. DJ Turner WR and DJ Turner II CB clean to the same key), the
+    row's adapter data may have no position but the sleeper map tags it
+    with the wrong family. _derive_player_row must use source signals to
+    refuse the mismatched tag rather than silently emitting it.
+    """
+
+    def _build_row(self, *, sleeper_pos, sites):
+        """Build a payload with sleeper map saying sleeper_pos but player
+        row having position=None and canonical site values = sites."""
+        player_data = {
+            "_composite": max(sites.values()),
+            "_rawComposite": max(sites.values()),
+            "_finalAdjusted": max(sites.values()),
+            "_sites": len(sites),
+            "position": None,
+            "team": None,
+            "_canonicalSiteValues": dict(sites),
+        }
+        payload = {
+            "players": {"Zzz Name Collide": player_data},
+            "sites": [{"key": k} for k in sites],
+            "maxValues": {k: 9999 for k in sites},
+            "sleeper": {"positions": {"Zzz Name Collide": sleeper_pos}},
+        }
+        contract = build_api_data_contract(payload)
+        for row in contract["playersArray"]:
+            if row["canonicalName"] == "Zzz Name Collide":
+                return row, contract
+        return None, contract
+
+    def test_offense_signals_reject_sleeper_idp_tag(self):
+        """The DJ Turner case: sleeper map says DB (from II collision),
+        player row has only offensive source signals. Row must NOT come
+        out tagged DB."""
+        row, contract = self._build_row(
+            sleeper_pos="DB",
+            sites={"ktc": 3000},
+        )
+        self.assertIsNotNone(row)
+        self.assertNotIn(row.get("position"), {"DB", "DL", "LB"})
+        # And the contract validator must not flag the offense→IDP mismatch.
+        status = (contract.get("_meta") or {}).get("contract_status")
+        if status is None:
+            status = (contract.get("meta") or {}).get("contract_status")
+        self.assertNotEqual(status, "error")
+
+    def test_idp_signals_reject_sleeper_offense_tag(self):
+        """Symmetric: sleeper says WR (from an offensive collision) but
+        the row has only IDP source signals."""
+        row, _ = self._build_row(
+            sleeper_pos="WR",
+            sites={"idpTradeCalc": 3000},
+        )
+        self.assertIsNotNone(row)
+        self.assertNotIn(row.get("position"), {"QB", "RB", "WR", "TE"})
+
+    def test_signals_on_both_sides_keep_sleeper_position(self):
+        """When both offense AND IDP signals are present, we cannot tell
+        which is the real player — don't override; keep sleeper's tag so
+        downstream collision flagging fires correctly."""
+        row, _ = self._build_row(
+            sleeper_pos="DB",
+            sites={"ktc": 3000, "idpTradeCalc": 3000},
+        )
+        self.assertIsNotNone(row)
+        # Sleeper tag preserved — the collision flag elsewhere handles this.
+        self.assertEqual(row.get("position"), "DB")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes the `playersArray offense→IDP mismatch: DJ Turner tagged DB with offensive-only source signal(s)` contract health error that blocked the IDP calibration from reaching the live board after promotion.

## Root cause

Two issues conspired:

1. **Dynasty Scraper.py** built the sleeper positions map with `clean_name(full)` as the key. `clean_name` strips generational suffixes (`II`, `III`, ...) so DJ Turner (WR, Bengals) and DJ Turner II (CB, Bengals) both resolved to the same key. Whichever roster was processed last silently overwrote the other's position.

2. **`_derive_player_row` guardrail** against sleeper/adapter position conflicts only fired when BOTH `pos_from_player` AND `pos_from_sleeper` were present. In the legacy scraper payload most rows have no adapter position, so the guardrail was a no-op and the contaminated sleeper tag flowed through.

Combined: DJ Turner came out `position=DB` with offensive-only source values → validator correctly flagged offense→IDP mismatch → refresh-board endpoint's health gate refused to swap the cache → calibration never applied live.

## Fix

- **Dynasty Scraper.py**: detect same-key different-position collisions while building `position_map`. Drop the entry entirely when detected (safer to have no position than the wrong family) and log a preview.
- **data_contract.py**: add a signal-based guardrail for the `pos_from_player=None` case. When sleeper says IDP but site values are offense-only (or vice versa), refuse the sleeper tag. Row ends up `position=None` and falls back to `offense` assetClass.

## Test plan
- [x] New regression tests in `tests/api/test_identity_validation.py::TestSleeperMapCollisionGuardrail` cover both directions of the new guardrail plus the "signals on both sides" case
- [x] Full backend suite passes (1609 tests, 3 pre-existing unrelated failures)
- [ ] On deploy: retry Refresh live board now — rebuild should succeed and IDP calibration reach /rankings

🤖 Generated with [Claude Code](https://claude.com/claude-code)