### PR TITLE
Fix DJ Turner offense→IDP mismatch: run guardrail after CSV enrichment

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1981,6 +1981,49 @@ def _canonical_player_key(name: str, position: str | None) -> str:
 _NULL_CSV_ENTRY: dict[str, Any] = {}
 
 
+def _strip_mismatched_family_tags(players_array: list[dict[str, Any]]) -> None:
+    """Clear position tags set ONLY from the sleeper map when the final
+    canonicalSiteValues contradict the family.
+
+    Runs AFTER :func:`_enrich_from_source_csvs` so it sees the full set
+    of per-source signals that ended up attached to each row. Only
+    targets rows marked ``_positionFromSleeperOnly`` by
+    :func:`_derive_player_row` — rows whose position was supplied by an
+    adapter (explicit source-level tag) are left alone so the existing
+    contamination flaggers can raise ``position_source_contradiction``
+    for them. This narrow scope specifically unblocks the sleeper-map
+    name-collision case (DJ Turner WR vs DJ Turner II CB collapsing to
+    the same clean_name key) without masking real contamination.
+
+    Mutates rows in place. When a mismatch is detected, the position is
+    cleared — downstream validators treat unpositioned rows as offense,
+    which is safe for the "row has only offensive signals" case.
+    """
+    for row in players_array:
+        if not row.get("_positionFromSleeperOnly"):
+            continue
+        pos = str(row.get("position") or "").strip().upper()
+        if not pos:
+            continue
+        canonical_sites = row.get("canonicalSiteValues") or {}
+        if not isinstance(canonical_sites, dict):
+            continue
+        has_off = any(
+            _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
+            for k in _OFFENSE_SIGNAL_KEYS
+        )
+        has_idp = any(
+            _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
+            for k in _IDP_SIGNAL_KEYS
+        )
+        if pos in _IDP_POSITIONS and has_off and not has_idp:
+            row["position"] = None
+            row["assetClass"] = "offense"
+        elif pos in _OFFENSE_POSITIONS and has_idp and not has_off:
+            row["position"] = None
+            row["assetClass"] = "offense"
+
+
 def _enrich_from_source_csvs(
     players_array: list[dict[str, Any]],
     *,
@@ -3990,11 +4033,21 @@ def _derive_player_row(
     values = _player_value_bundle(p_data)
     source_count = _source_count(p_data, canonical_sites)
 
+    # Track when the final position was sourced ONLY from the sleeper map
+    # (no adapter-supplied position). This lets the post-enrichment
+    # guardrail distinguish sleeper-map name collisions (strip) from
+    # legitimate adapter-vs-signal contradictions (flag). Trimmed off
+    # the row before the contract is materialized externally.
+    position_from_sleeper_only = bool(
+        pos and not is_pick and not pos_from_player and pos_from_sleeper
+    )
+
     return {
         "playerId": str(p_data.get("_sleeperId") or "").strip() or None,
         "canonicalName": canonical_name,
         "displayName": canonical_name,
         "position": pos or None,
+        "_positionFromSleeperOnly": position_from_sleeper_only,
         "team": p_data.get("team") if isinstance(p_data.get("team"), str) else None,
         # Age: scaffolded for future use.  Populated when source data includes
         # age_raw (e.g. DLF CSV adapter).  Currently null for most players
@@ -4182,6 +4235,17 @@ def build_api_data_contract(
     csv_index = _enrich_from_source_csvs(
         players_array, parse_errors=source_parse_errors
     )
+
+    # Post-enrichment position guardrail: CSV enrichment happens AFTER
+    # _derive_player_row, so the in-row guardrail there runs against an
+    # empty canonicalSiteValues and can't detect offense/IDP mismatches
+    # driven by CSV signals. Re-check here with populated values and
+    # strip the wrong-family tag rather than letting the contract
+    # validator fail the whole rebuild. Typical case: DJ Turner (WR)
+    # inherits a DB tag from a sleeper-map name collision with DJ Turner
+    # II (CB), then the KTC/FootballGuys CSVs add offensive values to
+    # the DB-tagged row.
+    _strip_mismatched_family_tags(players_array)
 
     # Compute unified rankings: all sources, all positions, one board.
     # The CSV index lets the ranker stamp a per-row ``sourceAudit``
@@ -4400,6 +4464,10 @@ def build_api_data_contract(
         "pickAliases": pick_aliases or {},
         "sourceParseErrors": source_parse_errors,
     }
+    # Drop internal-only provenance markers before materializing the
+    # contract so they don't leak into the public payload.
+    for row in players_array:
+        row.pop("_positionFromSleeperOnly", None)
     return contract_payload
 
 

--- a/tests/api/test_identity_validation.py
+++ b/tests/api/test_identity_validation.py
@@ -721,6 +721,77 @@ class TestSleeperMapCollisionGuardrail(unittest.TestCase):
         # Sleeper tag preserved — the collision flag elsewhere handles this.
         self.assertEqual(row.get("position"), "DB")
 
+    def test_post_enrichment_strip_when_signals_arrive_via_csv(self):
+        """Regression for the live-board failure: DJ Turner has no
+        _canonicalSiteValues in the scraper payload (legacy shape), gets
+        tagged DB from the sleeper-map name collision, and then
+        _enrich_from_source_csvs injects KTC/FootballGuys values on top.
+        The in-row guardrail in _derive_player_row can't see the
+        signals at derive-time, so the post-enrichment pass has to
+        clear the tag — but ONLY when the position came from the
+        sleeper map (not when an adapter set it explicitly).
+        """
+        from src.api.data_contract import _strip_mismatched_family_tags
+
+        rows = [
+            {
+                "canonicalName": "Zzz Post Enrich DB",
+                "displayName": "Zzz Post Enrich DB",
+                "position": "DB",
+                "assetClass": "idp",
+                "_positionFromSleeperOnly": True,
+                "canonicalSiteValues": {"ktc": 3000, "footballGuysSf": 2800},
+            },
+        ]
+        _strip_mismatched_family_tags(rows)
+        self.assertIsNone(rows[0]["position"])
+        self.assertEqual(rows[0]["assetClass"], "offense")
+
+    def test_post_enrichment_preserves_correctly_tagged_row(self):
+        from src.api.data_contract import _strip_mismatched_family_tags
+
+        rows = [
+            {
+                "canonicalName": "Zzz Valid DB",
+                "displayName": "Zzz Valid DB",
+                "position": "DB",
+                "assetClass": "idp",
+                "_positionFromSleeperOnly": True,
+                "canonicalSiteValues": {"idpTradeCalc": 2500},
+            },
+            {
+                "canonicalName": "Zzz Valid WR",
+                "displayName": "Zzz Valid WR",
+                "position": "WR",
+                "assetClass": "offense",
+                "_positionFromSleeperOnly": False,
+                "canonicalSiteValues": {"ktc": 4500},
+            },
+        ]
+        _strip_mismatched_family_tags(rows)
+        self.assertEqual(rows[0]["position"], "DB")
+        self.assertEqual(rows[1]["position"], "WR")
+
+    def test_post_enrichment_skips_adapter_sourced_position(self):
+        """Adapter-sourced position tags are NOT stripped even when the
+        site values contradict — those are legitimate contamination
+        signals for the downstream ``position_source_contradiction``
+        flagger to raise."""
+        from src.api.data_contract import _strip_mismatched_family_tags
+
+        rows = [
+            {
+                "canonicalName": "Zzz Adapter WR",
+                "displayName": "Zzz Adapter WR",
+                "position": "WR",
+                "assetClass": "offense",
+                "_positionFromSleeperOnly": False,
+                "canonicalSiteValues": {"idpTradeCalc": 5000},
+            },
+        ]
+        _strip_mismatched_family_tags(rows)
+        self.assertEqual(rows[0]["position"], "WR")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #101. That PR added a signal-based guardrail inside \`_derive_player_row\` but live-board rebuilds kept failing with the same \`DJ Turner tagged DB with offensive-only source signal(s)\` error.

## Why #101 didn't stick

The legacy scraper payload's \`p_data\` shape does NOT populate \`_canonicalSiteValues\`. \`_derive_player_row\` runs BEFORE \`_enrich_from_source_csvs\`, so at derive-time the canonicalSites dict is empty and the signal-based check in #101 can't fire. CSV enrichment then attaches KTC/FootballGuys values to the already-DB-tagged row → validator error.

## Fix

Three changes:

1. \`_derive_player_row\` stamps an internal \`_positionFromSleeperOnly\` marker on rows whose final position came from the sleeper pos_map (no adapter-supplied position).
2. New \`_strip_mismatched_family_tags\` post-enrichment pass clears the family tag on rows carrying that marker whose final canonicalSiteValues contradict the tag. Rows with adapter-sourced positions are left alone so the existing \`position_source_contradiction\` flagger can still raise legitimate contamination.
3. Internal marker stripped from rows before the contract is returned so it doesn't leak into the public payload.

## Verification

End-to-end against actual live data (\`data/dynasty_data_2026-04-16.json\`):
- Before: DJ Turner tagged DB + footballGuysSf=946700 → validator error
- After: DJ Turner position=None, assetClass=offense, no error

## Test plan
- [x] 3 new regression tests covering sleeper-only-strip, adapter-sourced-skip, correctly-tagged preserved
- [x] The 4 pre-existing contamination tests that broke in my local iteration all pass again (marker-gated strip leaves adapter-sourced contamination for the flaggers)
- [x] Full suite: 1612 passing (3 pre-existing unrelated failures)
- [ ] Post-deploy: Refresh live board now should succeed, IDP calibration applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)