### PR TITLE
Add instant IDP calibration toggle to /rankings

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -348,6 +348,7 @@ export default function RankingsPage() {
   const [activeLens, setActiveLens] = useState("consensus");
   const [showTiers, setShowTiers] = useState(true);
   const [showEdgeRail, setShowEdgeRail] = useState(true);
+  const [showIdpUncalibrated, setShowIdpUncalibrated] = useState(false);
   const [rowLimit, setRowLimit] = useState(DEFAULT_ROW_LIMIT);
   const [sortCol, setSortCol] = useState("rank");
   const [sortAsc, setSortAsc] = useState(true);
@@ -384,10 +385,47 @@ export default function RankingsPage() {
     }
   }, []);
 
+  // ── IDP calibration toggle ──────────────────────────────────────
+  // When on, swap each IDP row's rankDerivedValue with its
+  // pre-calibration snapshot and re-sort the full board by value so
+  // canonicalConsensusRank reflects the identity-mode ordering. This
+  // is a pure client-side view toggle — the promoted config stays
+  // live, rankings elsewhere in the app are unaffected.
+  const displayRows = useMemo(() => {
+    if (!showIdpUncalibrated) return rows;
+    const swapped = rows.map((r) => {
+      const uncal = Number(r.rankDerivedValueUncalibrated) || null;
+      if (!uncal || uncal === r.rankDerivedValue) return r;
+      return {
+        ...r,
+        rankDerivedValue: uncal,
+        values: { ...(r.values || {}), full: uncal },
+      };
+    });
+    const ranked = [...swapped]
+      .filter((r) => r.canonicalConsensusRank)
+      .sort(
+        (a, b) =>
+          (Number(b.rankDerivedValue) || 0) -
+            (Number(a.rankDerivedValue) || 0) ||
+          (Number(a.canonicalConsensusRank) || 0) -
+            (Number(b.canonicalConsensusRank) || 0),
+      );
+    const reranked = new Map();
+    ranked.forEach((r, idx) => {
+      reranked.set(r, idx + 1);
+    });
+    return swapped.map((r) =>
+      reranked.has(r)
+        ? { ...r, canonicalConsensusRank: reranked.get(r) }
+        : r,
+    );
+  }, [rows, showIdpUncalibrated]);
+
   // ── Base eligible list ──────────────────────────────────────────
   const eligible = useMemo(() => {
-    return rows.filter(isEligibleForBoard);
-  }, [rows]);
+    return displayRows.filter(isEligibleForBoard);
+  }, [displayRows]);
 
   // ── Trust summary stats ──────────────────────────────────────────
   const trustStats = useMemo(() => {
@@ -573,6 +611,13 @@ export default function RankingsPage() {
             onClick={() => setShowEdgeRail((v) => !v)}
           >
             {showEdgeRail ? "Hide edge" : "Show edge"}
+          </button>
+          <button
+            className={`button ${showIdpUncalibrated ? "button-primary" : ""}`}
+            onClick={() => setShowIdpUncalibrated((v) => !v)}
+            title="Toggle IDP calibration display. Swaps each IDP row to its pre-calibration value and re-sorts."
+          >
+            {showIdpUncalibrated ? "IDP: uncalibrated" : "IDP: calibrated"}
           </button>
           <button
             className={`button ${showMethodology ? "button-primary" : ""}`}

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -644,6 +644,8 @@ function _materializePlayerArrayRow(player) {
     canonicalSites,
     canonicalConsensusRank: backendRank,
     rankDerivedValue: backendValue,
+    rankDerivedValueUncalibrated:
+      Number(player.rankDerivedValueUncalibrated) || null,
     canonicalTierId: Number(player.canonicalTierId) || null,
     sourceRanks: backendSourceRanks,
     sourceRankMeta: backendSourceRankMeta,
@@ -699,6 +701,8 @@ function _materializeLegacyDictRow(name, player, posMap) {
     canonicalSites,
     canonicalConsensusRank: backendRank,
     rankDerivedValue: backendValue,
+    rankDerivedValueUncalibrated:
+      Number(player.rankDerivedValueUncalibrated) || null,
     canonicalTierId: Number(player._canonicalTierId) || null,
     sourceRanks: player.sourceRanks && typeof player.sourceRanks === "object" ? player.sourceRanks : {},
     sourceRankMeta: player.sourceRankMeta && typeof player.sourceRankMeta === "object" ? player.sourceRankMeta : {},

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2745,6 +2745,11 @@ def _apply_idp_calibration_post_pass(
     for pos, rows in by_pos.items():
         rows.sort(key=lambda r: -int(r.get("rankDerivedValue") or 0))
         for idx, row in enumerate(rows, 1):
+            # Snapshot the pre-calibration value on every IDP row so the
+            # frontend can swap back to "identity" display instantly
+            # without a refetch. Populated even when multiplier == 1.0
+            # so the toggle UX is uniform across rows.
+            row["rankDerivedValueUncalibrated"] = int(row.get("rankDerivedValue") or 0)
             try:
                 multiplier = float(
                     _idp_production.get_idp_bucket_multiplier(

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -58,18 +58,25 @@ def test_promoted_multipliers_scale_only_idp(tmp_path, monkeypatch):
 
     rows = _rows()
     _apply_idp_calibration_post_pass(rows, {})
-    # QB untouched
+    # QB untouched (no snapshot either — offense rows are never touched)
     assert rows[0]["rankDerivedValue"] == 9000
+    assert "rankDerivedValueUncalibrated" not in rows[0]
     # DL rank 1 and rank 2 both in bucket 1-6 => 0.5x
     dl_rows = [r for r in rows if r["position"] == "DL"]
     assert dl_rows[0]["rankDerivedValue"] == 2500  # 5000 * 0.5
     assert dl_rows[1]["rankDerivedValue"] == 1500  # 3000 * 0.5
+    # Pre-calibration snapshots preserved so the frontend toggle can
+    # swap the display instantly without refetching.
+    assert dl_rows[0]["rankDerivedValueUncalibrated"] == 5000
+    assert dl_rows[1]["rankDerivedValueUncalibrated"] == 3000
     # LB scaled up
     lb = next(r for r in rows if r["position"] == "LB")
     assert lb["rankDerivedValue"] == 6000
+    assert lb["rankDerivedValueUncalibrated"] == 4000
     # DB scaled up
     db = next(r for r in rows if r["position"] == "DB")
     assert db["rankDerivedValue"] == 4000
+    assert db["rankDerivedValueUncalibrated"] == 2000
 
 
 def test_empty_bucket_config_is_identity_not_anchor_floor(tmp_path, monkeypatch):
@@ -110,3 +117,22 @@ def test_position_alias_collapses_to_canonical(tmp_path, monkeypatch):
     rows = [{"position": "EDGE", "rankDerivedValue": 4000}]
     _apply_idp_calibration_post_pass(rows, {})
     assert rows[0]["rankDerivedValue"] == 2000  # EDGE -> DL -> 0.5x
+    assert rows[0]["rankDerivedValueUncalibrated"] == 4000
+
+
+def test_snapshot_populated_even_when_multiplier_is_identity(tmp_path, monkeypatch):
+    """IDP rows that happen to land in a 1.0 bucket still get a
+    pre-calibration snapshot so the frontend toggle works uniformly
+    across every IDP row regardless of bucket position."""
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    config = {
+        "active_mode": "blended",
+        "multipliers": {"final": {"DL": {"1-6": 1.0}}},
+    }
+    save_json(cfg_path, config)
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+    rows = [{"position": "DL", "rankDerivedValue": 4000}]
+    _apply_idp_calibration_post_pass(rows, {})
+    assert rows[0]["rankDerivedValue"] == 4000
+    assert rows[0]["rankDerivedValueUncalibrated"] == 4000


### PR DESCRIPTION
## Summary

Adds a client-side toggle button in the /rankings header so you can instantly compare "calibrated" vs "uncalibrated" IDP rankings without touching the promoted production config.

## How it works

1. Backend post-pass now stamps \`rankDerivedValueUncalibrated\` on every IDP row (even when multiplier == 1.0) as a snapshot of the pre-calibration value.
2. Frontend materializers thread the field through.
3. \`/rankings\` has a new **IDP: calibrated / uncalibrated** button. When toggled, a client-side useMemo:
   - Swaps \`rankDerivedValue\` with the uncalibrated snapshot on each IDP row
   - Re-sorts the full board by value
   - Re-numbers \`canonicalConsensusRank\` to reflect identity-mode ordering
4. Zero additional network I/O — pure local state. Sub-100ms flip.

Offense rows and picks untouched either way. Promoted config stays live — other pages (trade, edge, finder) still use the calibrated values.

## Test plan
- [x] Regression test confirms snapshot populated under scaled AND 1.0 buckets
- [x] Regression test confirms offense rows never receive a snapshot
- [x] Full suite 1613 passing
- [ ] Post-deploy: /rankings button flips IDP values + ranks instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)