### PR TITLE
Hotfix: rename IDP-toggle useMemo to fix production build

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -391,7 +391,7 @@ export default function RankingsPage() {
   // canonicalConsensusRank reflects the identity-mode ordering. This
   // is a pure client-side view toggle — the promoted config stays
   // live, rankings elsewhere in the app are unaffected.
-  const displayRows = useMemo(() => {
+  const toggledRows = useMemo(() => {
     if (!showIdpUncalibrated) return rows;
     const swapped = rows.map((r) => {
       const uncal = Number(r.rankDerivedValueUncalibrated) || null;
@@ -402,7 +402,7 @@ export default function RankingsPage() {
         values: { ...(r.values || {}), full: uncal },
       };
     });
-    const ranked = [...swapped]
+    const sortedForRerank = [...swapped]
       .filter((r) => r.canonicalConsensusRank)
       .sort(
         (a, b) =>
@@ -412,7 +412,7 @@ export default function RankingsPage() {
             (Number(b.canonicalConsensusRank) || 0),
       );
     const reranked = new Map();
-    ranked.forEach((r, idx) => {
+    sortedForRerank.forEach((r, idx) => {
       reranked.set(r, idx + 1);
     });
     return swapped.map((r) =>
@@ -424,8 +424,8 @@ export default function RankingsPage() {
 
   // ── Base eligible list ──────────────────────────────────────────
   const eligible = useMemo(() => {
-    return displayRows.filter(isEligibleForBoard);
-  }, [displayRows]);
+    return toggledRows.filter(isEligibleForBoard);
+  }, [toggledRows]);
 
   // ── Trust summary stats ──────────────────────────────────────────
   const trustStats = useMemo(() => {


### PR DESCRIPTION
## Summary

Production deploy from #103 failed due to a duplicate \`displayRows\` identifier in \`frontend/app/rankings/page.jsx\`. The existing \`displayRows\` variable was ~100 lines below the new useMemo I added, both in the same component scope. Webpack rejected the build, and the auto-rollback also failed because it tried to rebuild the same broken commit.

Rename:
- New useMemo: \`displayRows\` → \`toggledRows\`
- Inner working variable (for rerank): \`ranked\` → \`sortedForRerank\`

Verified locally with \`npm run build\` this time.

## Test plan
- [x] Local \`npm run build\` succeeds
- [ ] Deploy pipeline accepts the build
- [ ] /rankings page loads, IDP toggle functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)