### PR TITLE
Stop applying offense calibration to live values (keep lab analysis)

### DIFF
--- a/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
+++ b/frontend/app/tools/idp-calibration/ResultsDashboard.jsx
@@ -325,12 +325,15 @@ function SectionMultipliers({ run }) {
         <>
           <div className="idp-lab-family-heading">
             <strong>Offense</strong>
-            <span className="muted">within-position bucket curves (QB / RB / WR / TE)</span>
+            <span className="muted">
+              analytical view only — NOT applied to live values; offense
+              trade value stays tied to market rankings (KTC/DLF/etc.)
+            </span>
           </div>
           <PositionMultiplierBlocks
             positions={OFFENSE_POSITIONS}
             multipliers={offenseMultipliers}
-            label="per-bucket offense multipliers"
+            label="per-bucket offense VOR (reference only)"
           />
         </>
       )}

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3795,7 +3795,14 @@ def _compute_unified_rankings(
     # absent — the calibration lab's Promote step is the only way to
     # activate this. See src/idp_calibration/production.py.
     _apply_idp_calibration_post_pass(players_array, players_by_name)
-    _apply_offense_calibration_post_pass(players_array, players_by_name)
+    # Offense post-pass intentionally disabled: offense trade value
+    # should always track the market-derived rankings (KTC/DLF/
+    # FantasyCalc). VOR-based bucket multipliers override a
+    # well-calibrated market with a thin season-points-only signal and
+    # produce absurd values (e.g. QB7 Mahomes → 52% of QB1). The lab
+    # still computes offense_multipliers as an analytical reference
+    # but they are NOT applied to live values.
+    # _apply_offense_calibration_post_pass(players_array, players_by_name)
 
     # ── Phase 5: Pick refinement passes (gated to picks) ──
     # 1) Reassign (rank, value) tuples within each (year, round) bucket

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -204,3 +204,69 @@ def test_offense_post_pass_noop_when_block_absent(tmp_path, monkeypatch):
     _apply_offense_calibration_post_pass(rows, {})
     assert rows[0]["rankDerivedValue"] == 9000
     assert "rankDerivedValueUncalibrated" not in rows[0]
+
+
+def test_live_pipeline_does_not_apply_offense_calibration(tmp_path, monkeypatch):
+    """Even with a fully-populated offense_multipliers block in the
+    promoted config, the live pipeline must leave offense values
+    untouched. Offense trade value is anchored to market-derived
+    rankings; VOR-based bucket multipliers would override a well-
+    calibrated market with a thin season-points-only signal. The lab
+    still surfaces the offense analysis for reference but the post-
+    pass call site is intentionally disabled.
+    """
+    from src.api.data_contract import build_api_data_contract
+
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    config = {
+        "version": 1,
+        "active_mode": "blended",
+        "multipliers": {},  # no IDP multipliers either — isolate offense
+        "offense_multipliers": {
+            "QB": {
+                "position": "QB",
+                "buckets": [
+                    {"label": "1-6", "final": 1.0, "count": 6},
+                    {"label": "7-12", "final": 0.50, "count": 6},
+                ],
+            },
+        },
+    }
+    save_json(cfg_path, config)
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+
+    # Build a minimal valid-shape payload with 7 QBs so QB7 would be
+    # in the 7-12 bucket and get 0.50x *if* the post-pass ran.
+    players = {}
+    for i in range(1, 8):
+        name = f"Zzz QB {i:02d}"
+        players[name] = {
+            "_composite": 10000 - i * 500,
+            "_rawComposite": 10000 - i * 500,
+            "_finalAdjusted": 10000 - i * 500,
+            "_sites": 1,
+            "position": "QB",
+            "team": "TST",
+            "_canonicalSiteValues": {"ktc": 10000 - i * 500},
+        }
+    payload = {
+        "players": players,
+        "sites": [{"key": "ktc"}],
+        "maxValues": {"ktc": 9999},
+        "sleeper": {"positions": {name: "QB" for name in players}},
+    }
+    contract = build_api_data_contract(payload)
+    rows = sorted(
+        [r for r in contract["playersArray"] if r.get("position") == "QB"],
+        key=lambda r: -int(r.get("rankDerivedValue") or 0),
+    )
+    # QB7 should still be at its original rankDerivedValue range — not
+    # halved by the offense post-pass. We assert that no offense row
+    # has an ``offenseCalibrationMultiplier`` stamp (which the post-
+    # pass would set on rows it touched).
+    for row in rows:
+        assert "offenseCalibrationMultiplier" not in row, (
+            f"Offense calibration was applied to {row.get('canonicalName')!r} — "
+            "the post-pass call should be disabled."
+        )


### PR DESCRIPTION
## Summary

Reverts the runtime effect of #105. The offense calibration was a category error: VOR measures fantasy-point production above replacement; it is NOT trade value. For offense, the market sources (KTC/DLF/FantasyCalc/DynastyNerds) already price players with context VOR can't capture (age, archetype, scarcity). Overlaying VOR bucket multipliers produced absurd live values (QB7 Mahomes → 52% of QB1; TE7 LaPorta → 55% of TE1).

**Fix**: comment out the \`_apply_offense_calibration_post_pass\` call site. The function itself remains so the lab can still compute offense bucket tables as an analytical reference — they show HOW your league's scoring differs from the test league, but they don't mutate live values.

Lab UI relabels the Offense block as "analytical view only — NOT applied to live values" so there's no ambiguity about what happens at promotion.

## Test plan
- [x] New end-to-end regression: even with a fully-populated \`offense_multipliers\` config, no row receives an \`offenseCalibrationMultiplier\` stamp
- [x] Full suite 1616 passing
- [x] Frontend \`npm run build\` clean
- [ ] Post-deploy: /rankings Mahomes / CeeDee Lamb / LaPorta back to market-tied values; IDP still calibrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)