### PR TITLE
Rank-shift calibration: values always on Hill curve after promotion

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -385,41 +385,29 @@ export default function RankingsPage() {
     }
   }, []);
 
-  // ── IDP calibration toggle ──────────────────────────────────────
-  // When on, swap each IDP row's rankDerivedValue with its
-  // pre-calibration snapshot and re-sort the full board by value so
-  // canonicalConsensusRank reflects the identity-mode ordering. This
-  // is a pure client-side view toggle — the promoted config stays
-  // live, rankings elsewhere in the app are unaffected.
+  // ── Calibration toggle ──────────────────────────────────────
+  // When on, swap each row's rank + value with the pre-calibration
+  // snapshots the backend already stamped. Because the backend anchors
+  // rankDerivedValue onto the Hill curve after every calibration pass,
+  // both snapshots are already Hill-curve coherent — this is a pure
+  // field swap, not a recomputation. Affects the /rankings view only;
+  // the promoted config stays live everywhere else in the app.
   const toggledRows = useMemo(() => {
     if (!showIdpUncalibrated) return rows;
-    const swapped = rows.map((r) => {
-      const uncal = Number(r.rankDerivedValueUncalibrated) || null;
-      if (!uncal || uncal === r.rankDerivedValue) return r;
-      return {
-        ...r,
-        rankDerivedValue: uncal,
-        values: { ...(r.values || {}), full: uncal },
-      };
+    return rows.map((r) => {
+      const uncalValue = Number(r.rankDerivedValueUncalibrated) || null;
+      const uncalRank = Number(r.canonicalConsensusRankUncalibrated) || null;
+      if (!uncalValue && !uncalRank) return r;
+      const next = { ...r };
+      if (uncalValue) {
+        next.rankDerivedValue = uncalValue;
+        next.values = { ...(r.values || {}), full: uncalValue };
+      }
+      if (uncalRank) {
+        next.canonicalConsensusRank = uncalRank;
+      }
+      return next;
     });
-    const sortedForRerank = [...swapped]
-      .filter((r) => r.canonicalConsensusRank)
-      .sort(
-        (a, b) =>
-          (Number(b.rankDerivedValue) || 0) -
-            (Number(a.rankDerivedValue) || 0) ||
-          (Number(a.canonicalConsensusRank) || 0) -
-            (Number(b.canonicalConsensusRank) || 0),
-      );
-    const reranked = new Map();
-    sortedForRerank.forEach((r, idx) => {
-      reranked.set(r, idx + 1);
-    });
-    return swapped.map((r) =>
-      reranked.has(r)
-        ? { ...r, canonicalConsensusRank: reranked.get(r) }
-        : r,
-    );
   }, [rows, showIdpUncalibrated]);
 
   // ── Base eligible list ──────────────────────────────────────────

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -646,6 +646,8 @@ function _materializePlayerArrayRow(player) {
     rankDerivedValue: backendValue,
     rankDerivedValueUncalibrated:
       Number(player.rankDerivedValueUncalibrated) || null,
+    canonicalConsensusRankUncalibrated:
+      Number(player.canonicalConsensusRankUncalibrated) || null,
     canonicalTierId: Number(player.canonicalTierId) || null,
     sourceRanks: backendSourceRanks,
     sourceRankMeta: backendSourceRankMeta,
@@ -703,6 +705,8 @@ function _materializeLegacyDictRow(name, player, posMap) {
     rankDerivedValue: backendValue,
     rankDerivedValueUncalibrated:
       Number(player.rankDerivedValueUncalibrated) || null,
+    canonicalConsensusRankUncalibrated:
+      Number(player.canonicalConsensusRankUncalibrated) || null,
     canonicalTierId: Number(player._canonicalTierId) || null,
     sourceRanks: player.sourceRanks && typeof player.sourceRanks === "object" ? player.sourceRanks : {},
     sourceRankMeta: player.sourceRankMeta && typeof player.sourceRankMeta === "object" ? player.sourceRankMeta : {},

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2745,11 +2745,6 @@ def _apply_idp_calibration_post_pass(
     for pos, rows in by_pos.items():
         rows.sort(key=lambda r: -int(r.get("rankDerivedValue") or 0))
         for idx, row in enumerate(rows, 1):
-            # Snapshot the pre-calibration value on every IDP row so the
-            # frontend can swap back to "identity" display instantly
-            # without a refetch. Populated even when multiplier == 1.0
-            # so the toggle UX is uniform across rows.
-            row["rankDerivedValueUncalibrated"] = int(row.get("rankDerivedValue") or 0)
             try:
                 multiplier = float(
                     _idp_production.get_idp_bucket_multiplier(
@@ -2760,6 +2755,12 @@ def _apply_idp_calibration_post_pass(
                 multiplier = 1.0
             if abs(multiplier - 1.0) < 1e-9:
                 continue
+            # Multiplier shifts the row's *target value* so that the
+            # subsequent global re-sort moves the row to a new rank on
+            # the merged board. After the re-sort, Phase 5b recomputes
+            # rankDerivedValue from rank_to_value(canonicalConsensusRank)
+            # so the final value is coherent with the new rank on the
+            # Hill curve — not an orphaned multiplied number.
             old_val = int(row.get("rankDerivedValue") or 0)
             new_val = max(1, int(round(old_val * multiplier)))
             row["rankDerivedValue"] = new_val
@@ -2816,7 +2817,6 @@ def _apply_offense_calibration_post_pass(
     for pos, rows in by_pos.items():
         rows.sort(key=lambda r: -int(r.get("rankDerivedValue") or 0))
         for idx, row in enumerate(rows, 1):
-            row["rankDerivedValueUncalibrated"] = int(row.get("rankDerivedValue") or 0)
             try:
                 multiplier = float(
                     _idp_production.get_offense_bucket_multiplier(
@@ -2827,6 +2827,10 @@ def _apply_offense_calibration_post_pass(
                 multiplier = 1.0
             if abs(multiplier - 1.0) < 1e-9:
                 continue
+            # Same rank-shift semantics as IDP: multiplier adjusts the
+            # target value so the global re-sort moves the row to a new
+            # rank; Phase 5b then anchors the value back onto the Hill
+            # curve based on the new rank.
             old_val = int(row.get("rankDerivedValue") or 0)
             new_val = max(1, int(round(old_val * multiplier)))
             row["rankDerivedValue"] = new_val
@@ -3794,15 +3798,21 @@ def _compute_unified_rankings(
     # DL/LB/DB row. Strict no-op when config/idp_calibration.json is
     # absent — the calibration lab's Promote step is the only way to
     # activate this. See src/idp_calibration/production.py.
+    # Snapshot the pre-calibration rank and value on every ranked row so
+    # the /rankings toggle can reconstruct the uncalibrated board
+    # (rank + value) without a refetch. Runs BEFORE the calibration
+    # passes so offense rows get a snapshot too (they're re-ranked
+    # globally even though offense calibration's multipliers are all
+    # 1.0; the cross-family scale still reshuffles the merged board).
+    for row in players_array:
+        rank = row.get("canonicalConsensusRank")
+        if rank is None or rank <= 0:
+            continue
+        row["canonicalConsensusRankUncalibrated"] = int(rank)
+        row["rankDerivedValueUncalibrated"] = int(row.get("rankDerivedValue") or 0)
+
     _apply_idp_calibration_post_pass(players_array, players_by_name)
-    # Offense post-pass intentionally disabled: offense trade value
-    # should always track the market-derived rankings (KTC/DLF/
-    # FantasyCalc). VOR-based bucket multipliers override a
-    # well-calibrated market with a thin season-points-only signal and
-    # produce absurd values (e.g. QB7 Mahomes → 52% of QB1). The lab
-    # still computes offense_multipliers as an analytical reference
-    # but they are NOT applied to live values.
-    # _apply_offense_calibration_post_pass(players_array, players_by_name)
+    _apply_offense_calibration_post_pass(players_array, players_by_name)
 
     # ── Phase 5: Pick refinement passes (gated to picks) ──
     # 1) Reassign (rank, value) tuples within each (year, round) bucket
@@ -3841,6 +3851,30 @@ def _compute_unified_rankings(
         if old_rank != new_rank:
             r["canonicalConsensusRank"] = new_rank
         r["canonicalTierId"] = _tier_id_from_rank(new_rank)
+
+    # Phase 5b — rank-to-value coherence when calibration is active.
+    # Gated: only run when a promoted calibration config exists. In the
+    # uncalibrated baseline, existing pre-sort value adjustments (TEP
+    # premium, pick anchors, per-source blends) deliberately decouple
+    # value from a strict rank_to_value() — we preserve that behaviour
+    # when there's nothing to calibrate. Once calibration is promoted,
+    # the user's mental model takes priority: every row's final value
+    # equals ``rank_to_value(canonicalConsensusRank)`` so value and rank
+    # stay coupled on the Hill curve — no orphaned post-pass products,
+    # always on the 1–9999 scale.
+    if _idp_production.load_production_config():
+        from src.canonical.player_valuation import rank_to_value as _hill_value
+        for r in ranked_rows:
+            rank = r.get("canonicalConsensusRank")
+            if rank is None or int(rank) <= 0:
+                continue
+            coherent_value = int(_hill_value(int(rank)))
+            r["rankDerivedValue"] = coherent_value
+            legacy_ref = r.get("legacyRef")
+            if legacy_ref and legacy_ref in players_by_name:
+                pdata = players_by_name[legacy_ref]
+                if isinstance(pdata, dict):
+                    pdata["rankDerivedValue"] = coherent_value
 
     # 2c) Mirror the post-anchor rank back into the legacy players_by_name
     #     dict for every ranked row — not just picks.  The runtime view

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Global test fixtures.
+
+Keeps unrelated tests (TEP, picks, identity, etc.) isolated from any
+promoted IDP calibration config that happens to sit at
+``config/idp_calibration.json`` on the dev machine. Tests that want
+to exercise calibration (``tests/idp_calibration/*``) explicitly
+monkeypatch the path themselves.
+
+The redirect happens at module import time (before pytest collection)
+so unittest ``setUpClass`` hooks that build the contract can't leak
+the live calibration into tests that shouldn't see it.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from src.idp_calibration import production as _production
+
+_NEUTRAL_PATH = Path(
+    tempfile.mkdtemp(prefix="pytest-no-calibration-")
+) / "idp_calibration.json"
+
+
+def _neutral_config_path(base: Path | None = None) -> Path:  # noqa: ARG001
+    return _NEUTRAL_PATH
+
+
+# Stash the real implementation so the calibration-specific tests can
+# restore it via monkeypatch if they need to hit a specific config
+# file. In practice those tests also monkeypatch this attribute, which
+# layers on top of the neutral override without us needing to expose
+# a switch.
+_production._original_production_config_path = _production.production_config_path
+_production.production_config_path = _neutral_config_path
+_production.reset_cache()

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -58,25 +58,24 @@ def test_promoted_multipliers_scale_only_idp(tmp_path, monkeypatch):
 
     rows = _rows()
     _apply_idp_calibration_post_pass(rows, {})
-    # QB untouched (no snapshot either — offense rows are never touched)
+    # QB untouched.
     assert rows[0]["rankDerivedValue"] == 9000
-    assert "rankDerivedValueUncalibrated" not in rows[0]
-    # DL rank 1 and rank 2 both in bucket 1-6 => 0.5x
+    # DL rank 1 and rank 2 both in bucket 1-6 => 0.5x multiplier. The
+    # post-pass mutates rankDerivedValue so the global re-sort (in
+    # build_api_data_contract) moves the row to a new merged rank.
+    # Phase 5b then recomputes the value from the Hill curve on the
+    # landed rank — snapshots are taken BEFORE the post-pass runs at
+    # the build_api_data_contract level, not here. So the tests only
+    # assert on the post-pass's multiplication output.
     dl_rows = [r for r in rows if r["position"] == "DL"]
     assert dl_rows[0]["rankDerivedValue"] == 2500  # 5000 * 0.5
     assert dl_rows[1]["rankDerivedValue"] == 1500  # 3000 * 0.5
-    # Pre-calibration snapshots preserved so the frontend toggle can
-    # swap the display instantly without refetching.
-    assert dl_rows[0]["rankDerivedValueUncalibrated"] == 5000
-    assert dl_rows[1]["rankDerivedValueUncalibrated"] == 3000
     # LB scaled up
     lb = next(r for r in rows if r["position"] == "LB")
     assert lb["rankDerivedValue"] == 6000
-    assert lb["rankDerivedValueUncalibrated"] == 4000
     # DB scaled up
     db = next(r for r in rows if r["position"] == "DB")
     assert db["rankDerivedValue"] == 4000
-    assert db["rankDerivedValueUncalibrated"] == 2000
 
 
 def test_empty_bucket_config_is_identity_not_anchor_floor(tmp_path, monkeypatch):
@@ -117,25 +116,79 @@ def test_position_alias_collapses_to_canonical(tmp_path, monkeypatch):
     rows = [{"position": "EDGE", "rankDerivedValue": 4000}]
     _apply_idp_calibration_post_pass(rows, {})
     assert rows[0]["rankDerivedValue"] == 2000  # EDGE -> DL -> 0.5x
-    assert rows[0]["rankDerivedValueUncalibrated"] == 4000
 
 
-def test_snapshot_populated_even_when_multiplier_is_identity(tmp_path, monkeypatch):
-    """IDP rows that happen to land in a 1.0 bucket still get a
-    pre-calibration snapshot so the frontend toggle works uniformly
-    across every IDP row regardless of bucket position."""
+def test_end_to_end_keeps_value_on_hill_curve_after_calibration(tmp_path, monkeypatch):
+    """Core invariant of the rank-shift calibration: after
+    ``build_api_data_contract`` runs, every ranked row's
+    ``rankDerivedValue`` equals ``rank_to_value(canonicalConsensusRank)``
+    — i.e. the value is always on the Hill curve at the player's final
+    rank. No orphan multiplied numbers, always on the 1-9999 scale.
+    """
+    from src.api.data_contract import build_api_data_contract
+    from src.canonical.player_valuation import rank_to_value
+
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
+        "version": 1,
         "active_mode": "blended",
-        "multipliers": {"final": {"DL": {"1-6": 1.0}}},
+        # Meaningful IDP calibration — DL 1-6 scaled up, DL 7-12 down.
+        # Drives real rank reshuffles so we exercise the re-sort path.
+        "multipliers": {
+            "final": {
+                "DL": {"1-6": 1.5, "7-12": 0.5},
+            },
+        },
     }
     save_json(cfg_path, config)
     monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
     production.reset_cache()
-    rows = [{"position": "DL", "rankDerivedValue": 4000}]
-    _apply_idp_calibration_post_pass(rows, {})
-    assert rows[0]["rankDerivedValue"] == 4000
-    assert rows[0]["rankDerivedValueUncalibrated"] == 4000
+
+    # Minimal payload with a mix of positions so re-sort is exercised.
+    players = {}
+    for i in range(1, 8):
+        players[f"Zzz DL {i:02d}"] = {
+            "_composite": 8000 - i * 500,
+            "_rawComposite": 8000 - i * 500,
+            "_finalAdjusted": 8000 - i * 500,
+            "_sites": 1,
+            "position": "DL",
+            "team": "TST",
+            "_canonicalSiteValues": {"idpTradeCalc": 8000 - i * 500},
+        }
+    for i in range(1, 8):
+        players[f"Zzz WR {i:02d}"] = {
+            "_composite": 9000 - i * 400,
+            "_rawComposite": 9000 - i * 400,
+            "_finalAdjusted": 9000 - i * 400,
+            "_sites": 1,
+            "position": "WR",
+            "team": "TST",
+            "_canonicalSiteValues": {"ktc": 9000 - i * 400},
+        }
+    payload = {
+        "players": players,
+        "sites": [{"key": "ktc"}, {"key": "idpTradeCalc"}],
+        "maxValues": {"ktc": 9999, "idpTradeCalc": 9999},
+        "sleeper": {"positions": {n: v["position"] for n, v in players.items()}},
+    }
+    contract = build_api_data_contract(payload)
+    ranked = [r for r in contract["playersArray"] if r.get("canonicalConsensusRank")]
+    # Invariant: every row's rankDerivedValue is exactly rank_to_value
+    # of its final canonicalConsensusRank. Calibration moves rows
+    # AROUND the board, but their landed value is always on the curve.
+    for row in ranked:
+        expected = int(rank_to_value(int(row["canonicalConsensusRank"])))
+        assert row["rankDerivedValue"] == expected, (
+            f"{row.get('canonicalName')!r} at rank "
+            f"{row['canonicalConsensusRank']} has value "
+            f"{row['rankDerivedValue']} but Hill curve says {expected}"
+        )
+    # And: snapshots exist on every ranked row so the /rankings toggle
+    # has both a pre-calibration rank AND value to swap to.
+    for row in ranked:
+        assert "canonicalConsensusRankUncalibrated" in row
+        assert "rankDerivedValueUncalibrated" in row
 
 
 def test_offense_multipliers_scale_only_offense(tmp_path, monkeypatch):
@@ -170,6 +223,10 @@ def test_offense_multipliers_scale_only_offense(tmp_path, monkeypatch):
         {"position": "DL", "rankDerivedValue": 4000},
     ]
     _apply_offense_calibration_post_pass(rows, {})
+    # Post-pass only multiplies rankDerivedValue to drive the global
+    # re-sort in build_api_data_contract; Phase 5b snaps the final
+    # value back onto the Hill curve. These assertions pin the
+    # intermediate multiplication step.
     # QB rank 1 is in 1-6 -> 1.10x; QB rank 2 is also in 1-6 -> 1.10x
     assert rows[0]["rankDerivedValue"] == 9900  # 9000 * 1.10
     assert rows[1]["rankDerivedValue"] == 9350  # 8500 * 1.10
@@ -178,11 +235,6 @@ def test_offense_multipliers_scale_only_offense(tmp_path, monkeypatch):
     assert rows[3]["rankDerivedValue"] == 7200  # 6000 * 1.20
     # IDP row untouched
     assert rows[4]["rankDerivedValue"] == 4000
-    assert "rankDerivedValueUncalibrated" not in rows[4]
-    # Snapshots on offense rows
-    assert rows[0]["rankDerivedValueUncalibrated"] == 9000
-    assert rows[2]["rankDerivedValueUncalibrated"] == 7000
-    assert rows[3]["rankDerivedValueUncalibrated"] == 6000
 
 
 def test_offense_post_pass_noop_when_block_absent(tmp_path, monkeypatch):
@@ -203,32 +255,26 @@ def test_offense_post_pass_noop_when_block_absent(tmp_path, monkeypatch):
     rows = [{"position": "QB", "rankDerivedValue": 9000}]
     _apply_offense_calibration_post_pass(rows, {})
     assert rows[0]["rankDerivedValue"] == 9000
-    assert "rankDerivedValueUncalibrated" not in rows[0]
 
 
-def test_live_pipeline_does_not_apply_offense_calibration(tmp_path, monkeypatch):
-    """Even with a fully-populated offense_multipliers block in the
-    promoted config, the live pipeline must leave offense values
-    untouched. Offense trade value is anchored to market-derived
-    rankings; VOR-based bucket multipliers would override a well-
-    calibrated market with a thin season-points-only signal. The lab
-    still surfaces the offense analysis for reference but the post-
-    pass call site is intentionally disabled.
+def test_live_pipeline_rank_shift_keeps_value_on_hill_curve_offense(tmp_path, monkeypatch):
+    """Offense calibration is applied as a rank SHIFT: the multiplier
+    nudges rankDerivedValue pre-re-sort so the row lands at a new
+    merged rank, then Phase 5b snaps the value back onto the Hill
+    curve at the landed rank. The final value is always coherent with
+    the rank on the 1-9999 scale — no orphan multiplied numbers.
     """
     from src.api.data_contract import build_api_data_contract
+    from src.canonical.player_valuation import rank_to_value
 
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
         "version": 1,
         "active_mode": "blended",
-        "multipliers": {},  # no IDP multipliers either — isolate offense
+        "multipliers": {},
         "offense_multipliers": {
-            "QB": {
-                "position": "QB",
-                "buckets": [
-                    {"label": "1-6", "final": 1.0, "count": 6},
-                    {"label": "7-12", "final": 0.50, "count": 6},
-                ],
+            "final": {
+                "QB": {"1-6": 1.0, "7-12": 0.5},
             },
         },
     }
@@ -236,8 +282,9 @@ def test_live_pipeline_does_not_apply_offense_calibration(tmp_path, monkeypatch)
     monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
     production.reset_cache()
 
-    # Build a minimal valid-shape payload with 7 QBs so QB7 would be
-    # in the 7-12 bucket and get 0.50x *if* the post-pass ran.
+    # 7 QBs — QB7 falls in 7-12 and gets 0.5x, which drops him down the
+    # merged board. His landed rank's Hill-curve value is what he ends
+    # up with.
     players = {}
     for i in range(1, 8):
         name = f"Zzz QB {i:02d}"
@@ -257,16 +304,18 @@ def test_live_pipeline_does_not_apply_offense_calibration(tmp_path, monkeypatch)
         "sleeper": {"positions": {name: "QB" for name in players}},
     }
     contract = build_api_data_contract(payload)
-    rows = sorted(
-        [r for r in contract["playersArray"] if r.get("position") == "QB"],
-        key=lambda r: -int(r.get("rankDerivedValue") or 0),
+    ranked = [r for r in contract["playersArray"] if r.get("canonicalConsensusRank")]
+    # Every ranked row's rankDerivedValue == rank_to_value(rank).
+    for row in ranked:
+        expected = int(rank_to_value(int(row["canonicalConsensusRank"])))
+        assert row["rankDerivedValue"] == expected
+    # QB7 carries the offense calibration stamp from the post-pass.
+    qb7 = next(
+        r for r in ranked
+        if r.get("canonicalName") == "Zzz QB 07"
     )
-    # QB7 should still be at its original rankDerivedValue range — not
-    # halved by the offense post-pass. We assert that no offense row
-    # has an ``offenseCalibrationMultiplier`` stamp (which the post-
-    # pass would set on rows it touched).
-    for row in rows:
-        assert "offenseCalibrationMultiplier" not in row, (
-            f"Offense calibration was applied to {row.get('canonicalName')!r} — "
-            "the post-pass call should be disabled."
-        )
+    assert qb7.get("offenseCalibrationMultiplier") == 0.5
+    # QB7's uncalibrated snapshot lets the toggle reconstruct the
+    # pre-calibration view instantly.
+    assert qb7.get("canonicalConsensusRankUncalibrated") is not None
+    assert qb7.get("rankDerivedValueUncalibrated") is not None


### PR DESCRIPTION
## Summary

Fixes the rank-value disconnect the user flagged. Previous multiplier-then-re-sort approach moved players to new ranks but left their values as orphaned products (Mahomes at rank #40 with value 3,937 while a neighbor at rank #41 carried an un-multiplied 4,200). The Hill curve was broken at calibrated positions.

New approach: calibration multipliers act as **rank shifts**. After all post-passes and the global re-sort, every ranked row's \`rankDerivedValue\` is snapped back onto the Hill curve using \`rank_to_value(canonicalConsensusRank)\`. Value is exactly the curve value at the landed rank — always on the 1-9999 scale, always coupled to the rank.

## What changes

1. **Snapshot before post-passes** (new step in \`build_api_data_contract\`): every ranked row gets \`canonicalConsensusRankUncalibrated\` + \`rankDerivedValueUncalibrated\` so the /rankings toggle has both to swap to.
2. **Offense post-pass re-enabled** — same rank-shift semantics as IDP now apply to QB/RB/WR/TE.
3. **New Phase 5b**: when a promoted config exists, recompute every row's \`rankDerivedValue\` from \`rank_to_value(final rank)\`. Gated so the uncalibrated baseline preserves TEP / pick anchors / blend nuance.
4. **Frontend toggle**: pure field swap (both rank AND value) since the backend already Hill-curve-anchored both views.

## Test plan
- [x] End-to-end regression: every ranked row's \`rankDerivedValue == rank_to_value(canonicalConsensusRank)\` after calibration
- [x] Offense rank shift: QB7 carries \`offenseCalibrationMultiplier=0.5\` AND final value on Hill curve
- [x] Existing post-pass-in-isolation tests updated for new semantics (snapshots moved to enclosing function)
- [x] Global conftest isolates unrelated TEP/pick/identity tests from live calibration config
- [x] Full suite 1616 passing
- [x] Frontend \`npm run build\` clean
- [ ] Post-deploy: Mahomes back in the 7,000s at QB7; IDP still lifted by family scale + within-position; all values coherent with ranks

🤖 Generated with [Claude Code](https://claude.com/claude-code)