### PR TITLE
Smooth IDP calibration + disable offense

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3812,7 +3812,13 @@ def _compute_unified_rankings(
         row["rankDerivedValueUncalibrated"] = int(row.get("rankDerivedValue") or 0)
 
     _apply_idp_calibration_post_pass(players_array, players_by_name)
-    _apply_offense_calibration_post_pass(players_array, players_by_name)
+    # Offense calibration deliberately not applied to live values.
+    # Offense trade value tracks the market-derived rankings (KTC/DLF/
+    # FantasyCalc/etc.); VOR bucket multipliers produced absurd
+    # artefacts (QB bucket cliffs, Mahomes-at-half-value-of-QB1). The
+    # lab still computes offense_multipliers as an analytical
+    # reference but they do NOT mutate rankDerivedValue.
+    # _apply_offense_calibration_post_pass(players_array, players_by_name)
 
     # ── Phase 5: Pick refinement passes (gated to picks) ──
     # 1) Reassign (rank, value) tuples within each (year, round) bucket

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -76,17 +76,61 @@ def _position_has_real_data(position_block: Any) -> bool:
     return any(isinstance(k, str) and "-" in k for k in position_block.keys())
 
 
+def _interpolate_anchor_curve(anchors_block: list[Any], rank: int) -> float | None:
+    """Piecewise-linear interpolation between anchor points.
+
+    Returns ``None`` when the anchor list is empty or malformed. Falls
+    below the first anchor ⇒ returns the first anchor's value. Past
+    the last ⇒ returns the last anchor's value. This smooths the
+    step-function cliffs that per-bucket lookups produce at bucket
+    boundaries.
+    """
+    if not isinstance(anchors_block, list) or not anchors_block:
+        return None
+    points: list[tuple[int, float]] = []
+    for point in anchors_block:
+        try:
+            r = int(point.get("rank"))
+            v = float(point.get("value"))
+            points.append((r, v))
+        except (TypeError, ValueError, AttributeError):
+            continue
+    if not points:
+        return None
+    points.sort(key=lambda p: p[0])
+    r_target = int(rank)
+    if r_target <= points[0][0]:
+        return points[0][1]
+    if r_target >= points[-1][0]:
+        return points[-1][1]
+    # Find the two adjacent anchors that bracket the target rank.
+    for i in range(len(points) - 1):
+        r0, v0 = points[i]
+        r1, v1 = points[i + 1]
+        if r0 <= r_target <= r1:
+            if r1 == r0:
+                return v0
+            t = (r_target - r0) / (r1 - r0)
+            return v0 + t * (v1 - v0)
+    return points[-1][1]
+
+
 def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: str) -> float:
-    """Pick the right multiplier from the promoted config.
+    """Smooth multiplier lookup for an IDP rank.
 
-    Handles both of the shapes the storage layer emits: flat
-    ``multipliers[position] = {label: value}`` and the richer
-    ``multipliers[kind][position] = {...}``.
+    Strategy: use the anchor curve as the PRIMARY source with
+    piecewise-linear interpolation between anchor ranks. This replaces
+    the old step-function bucket lookup so consecutive ranks never
+    face the ~90% cliffs that the bucket edges produced (e.g. DL12 →
+    DL13 jumping from 0.67 to 0.05). Buckets are still how the engine
+    *computes* robust centers; the anchor curve is how we *apply*
+    them smoothly.
 
-    Returns ``1.0`` (identity) whenever the promoted config has no real
-    per-bucket data for ``position`` — this is the safety net that
-    prevents an empty-calibration promotion from cutting every IDP
-    value through the anchor floor.
+    Falls back to bucket lookup if no anchor data is present (older
+    promoted configs). Returns ``1.0`` (identity) when the promoted
+    config has no real per-bucket data for the position — safety net
+    that prevents an empty-calibration promotion from cutting every
+    IDP value through the anchor floor.
     """
     position = position.upper()
     if position not in {"DL", "LB", "DB"}:
@@ -99,7 +143,6 @@ def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: s
         "blended": "final",
     }.get(mode, "final")
 
-    # Shape A: kind-first — multipliers[kind][position] = {label: value}
     if kind in multipliers and isinstance(multipliers[kind], dict):
         position_block = multipliers[kind].get(position)
     else:
@@ -107,12 +150,20 @@ def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: s
     if not isinstance(position_block, dict):
         position_block = None
 
+    # Safety: empty buckets ⇒ identity, never let the anchor floor
+    # silently cut every IDP value.
     if not _position_has_real_data(position_block):
-        # No real bucket data for this position ⇒ identity multiplier.
-        # Do NOT fall through to anchors — empty runs produce anchor
-        # curves floored at 0.05 which would silently cut IDP values.
         return 1.0
 
+    # PRIMARY: smooth anchor-curve interpolation.
+    anchors_block = (config.get("anchors") or {}).get(kind, {}).get(position)
+    anchor_value = _interpolate_anchor_curve(anchors_block, int(rank))
+    if anchor_value is not None:
+        return float(anchor_value)
+
+    # FALLBACK: bucket-lookup (legacy step-function behaviour) when a
+    # promoted config lacks anchor data. New runs always include
+    # anchors so this path only exercises against pre-anchor configs.
     if isinstance(position_block, dict):
         buckets = position_block.get("buckets") if "buckets" in position_block else None
         if isinstance(buckets, list):
@@ -126,7 +177,6 @@ def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: s
                         return float(val) if val is not None else 1.0
                 except (TypeError, ValueError):
                     continue
-        # flat { "1-6": 1.05, ... }
         for label, value in position_block.items():
             try:
                 lo, _, hi = str(label).partition("-")
@@ -134,23 +184,6 @@ def _bucket_lookup_for(position: str, rank: int, config: dict[str, Any], mode: s
                     return float(value)
             except (TypeError, ValueError):
                 continue
-
-    # Past the last labelled bucket — use the anchor curve as a smooth
-    # tail now that we've confirmed real bucket data exists for this
-    # position upstream.
-    anchors_block = (config.get("anchors") or {}).get(kind, {}).get(position)
-    if isinstance(anchors_block, list):
-        best_val = 1.0
-        best_rank = -1
-        for point in anchors_block:
-            try:
-                ar = int(point.get("rank"))
-                if ar <= int(rank) and ar > best_rank:
-                    best_rank = ar
-                    best_val = float(point.get("value"))
-            except (TypeError, ValueError):
-                continue
-        return best_val
     return 1.0
 
 

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -257,15 +257,84 @@ def test_offense_post_pass_noop_when_block_absent(tmp_path, monkeypatch):
     assert rows[0]["rankDerivedValue"] == 9000
 
 
-def test_live_pipeline_rank_shift_keeps_value_on_hill_curve_offense(tmp_path, monkeypatch):
-    """Offense calibration is applied as a rank SHIFT: the multiplier
-    nudges rankDerivedValue pre-re-sort so the row lands at a new
-    merged rank, then Phase 5b snaps the value back onto the Hill
-    curve at the landed rank. The final value is always coherent with
-    the rank on the 1-9999 scale — no orphan multiplied numbers.
+def test_idp_lookup_interpolates_anchor_curve_no_cliffs(tmp_path, monkeypatch):
+    """Consecutive ranks must never produce a cliff greater than the
+    neighbouring anchor-to-anchor slope. Pinning this guards against
+    someone accidentally re-introducing step-function bucket lookup
+    in production.py — the old behaviour produced 48-90% cliffs at
+    bucket boundaries (e.g. LB6 ≠ LB7 by 0.67).
+    """
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    # Realistic-shape config with bucket-derived multipliers AND an
+    # anchor curve between them. Live runs always include both.
+    config = {
+        "version": 1,
+        "active_mode": "blended",
+        "multipliers": {
+            "LB": {
+                "position": "LB",
+                "buckets": [
+                    {"label": "1-6",   "final": 1.00, "count": 6},
+                    {"label": "7-12",  "final": 0.67, "count": 6},
+                    {"label": "13-24", "final": 0.40, "count": 12},
+                    {"label": "25-36", "final": 0.07, "count": 12},
+                    {"label": "37-60", "final": 0.05, "count": 24},
+                ],
+            },
+        },
+        "anchors": {
+            "final": {
+                "LB": [
+                    {"rank": 1, "value": 1.00},
+                    {"rank": 3, "value": 1.00},
+                    {"rank": 6, "value": 1.00},
+                    {"rank": 12, "value": 0.67},
+                    {"rank": 24, "value": 0.40},
+                    {"rank": 36, "value": 0.07},
+                    {"rank": 48, "value": 0.05},
+                    {"rank": 72, "value": 0.05},
+                    {"rank": 100, "value": 0.05},
+                ],
+            },
+        },
+    }
+    save_json(cfg_path, config)
+    monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
+    production.reset_cache()
+
+    # Sample every rank from 1..48 and verify no adjacent cliff > 8%.
+    # 8% is a generous ceiling — piecewise-linear interpolation
+    # between anchor points should hold each step to the local anchor
+    # slope, which is at most a few percent per rank on this curve.
+    prev = production.get_idp_bucket_multiplier("LB", 1)
+    max_adjacent_drop = 0.0
+    for r in range(2, 49):
+        curr = production.get_idp_bucket_multiplier("LB", r)
+        drop = prev - curr
+        if drop > max_adjacent_drop:
+            max_adjacent_drop = drop
+        prev = curr
+    assert max_adjacent_drop < 0.08, (
+        f"Adjacent-rank cliff of {max_adjacent_drop:.3f} exceeds smoothness "
+        "budget — production.py probably regressed to step-function bucket lookup."
+    )
+    # Spot-check interpolation: rank 9 sits halfway between anchor 6
+    # (value 1.00) and anchor 12 (value 0.67), so interpolated value
+    # should be ~0.835 (halfway).
+    mid = production.get_idp_bucket_multiplier("LB", 9)
+    assert 0.82 < mid < 0.85, f"rank 9 interpolation off — got {mid}"
+
+
+def test_live_pipeline_does_not_apply_offense_calibration(tmp_path, monkeypatch):
+    """Offense calibration is deliberately NOT applied to live values
+    even when a promoted config has offense_multipliers populated. The
+    lab still computes the analysis, but offense trade value should
+    stay anchored to the market-derived rankings — VOR bucket
+    multipliers produce artefacts (QB cliffs, Mahomes-at-half-of-QB1)
+    that don't survive user review. Re-promoting offense from the lab
+    is a no-op on the live board.
     """
     from src.api.data_contract import build_api_data_contract
-    from src.canonical.player_valuation import rank_to_value
 
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
@@ -282,9 +351,6 @@ def test_live_pipeline_rank_shift_keeps_value_on_hill_curve_offense(tmp_path, mo
     monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
     production.reset_cache()
 
-    # 7 QBs — QB7 falls in 7-12 and gets 0.5x, which drops him down the
-    # merged board. His landed rank's Hill-curve value is what he ends
-    # up with.
     players = {}
     for i in range(1, 8):
         name = f"Zzz QB {i:02d}"
@@ -304,18 +370,9 @@ def test_live_pipeline_rank_shift_keeps_value_on_hill_curve_offense(tmp_path, mo
         "sleeper": {"positions": {name: "QB" for name in players}},
     }
     contract = build_api_data_contract(payload)
-    ranked = [r for r in contract["playersArray"] if r.get("canonicalConsensusRank")]
-    # Every ranked row's rankDerivedValue == rank_to_value(rank).
-    for row in ranked:
-        expected = int(rank_to_value(int(row["canonicalConsensusRank"])))
-        assert row["rankDerivedValue"] == expected
-    # QB7 carries the offense calibration stamp from the post-pass.
-    qb7 = next(
-        r for r in ranked
-        if r.get("canonicalName") == "Zzz QB 07"
-    )
-    assert qb7.get("offenseCalibrationMultiplier") == 0.5
-    # QB7's uncalibrated snapshot lets the toggle reconstruct the
-    # pre-calibration view instantly.
-    assert qb7.get("canonicalConsensusRankUncalibrated") is not None
-    assert qb7.get("rankDerivedValueUncalibrated") is not None
+    qbs = [r for r in contract["playersArray"] if r.get("position") == "QB"]
+    for row in qbs:
+        assert "offenseCalibrationMultiplier" not in row, (
+            f"Offense calibration was applied to {row.get('canonicalName')!r} — "
+            "post-pass should be disabled."
+        )


### PR DESCRIPTION
## Summary

Two related fixes for the user-observed weirdness on /rankings:

1. **Disable offense calibration post-pass.** Offense trade value tracks the market rankings (KTC/DLF/FantasyCalc); the VOR-derived bucket cliffs dropped Mahomes out of the top-12 and put a 157-rank gap between Bo Nix and Brock Purdy at the QB12→QB13 bucket boundary. Lab still computes offense_multipliers as an analytical reference, they just don't mutate live values.

2. **Smooth the IDP multiplier lookup.** \`production.py\` now uses the anchor curve (ranks 1/3/6/12/24/36/48/72/100) as the PRIMARY source with piecewise-linear interpolation between points. Bucket lookup becomes a fallback for old configs without anchor data.

## Why buckets were wrong for application

Buckets are great for *computing* VOR — 6 players in a bucket produces a robust center with noise reduction. But applying a constant multiplier across an entire bucket creates step-function cliffs at the boundaries (LB6 → LB7 dropped 33% in a single rank step). The anchor curve is derived from the same bucket centers but supports smooth interpolation between them, so LB7 now gets ~0.945 (halfway between 1.0 and 0.67) instead of 0.67.

## Test plan
- [x] Smoothness regression: samples every rank 1..48 for LB, asserts no adjacent-rank cliff exceeds 8%
- [x] Interpolation sanity: LB rank 9 ≈ 0.84 (midpoint of LB6=1.0 and LB12=0.67)
- [x] Offense calibration disabled end-to-end
- [x] Full suite 1617 passing
- [x] Frontend \`npm run build\` clean
- [ ] Post-deploy: Mahomes returns to market-derived rank; Bo Nix / Brock Purdy no longer have 157-rank gap; IDP curves are smooth across consecutive ranks

🤖 Generated with [Claude Code](https://claude.com/claude-code)