### PR TITLE
Add Delete All Runs button to IDP Calibration Lab

### DIFF
--- a/frontend/app/api/idp-calibration/runs/route.js
+++ b/frontend/app/api/idp-calibration/runs/route.js
@@ -26,3 +26,26 @@ export async function GET(request) {
     clearTimeout(timer);
   }
 }
+
+export async function DELETE(request) {
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 10_000);
+  try {
+    const res = await fetch(`${BACKEND}/api/idp-calibration/runs`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+      cache: "no-store",
+      signal: ctl.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "IDP calibration service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2459,3 +2459,12 @@ tr:hover .sticky-name {
 .angle-delta-pos { color: var(--status-positive, #4ade80); }
 .angle-delta-neutral { color: var(--text-muted); }
 .angle-warnings ul { margin: 4px 0 0 20px; padding: 0; }
+
+.idp-lab-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+.idp-lab-runs-bulk { display: flex; gap: var(--space-xs); }

--- a/frontend/app/tools/idp-calibration/SavedRunsList.jsx
+++ b/frontend/app/tools/idp-calibration/SavedRunsList.jsx
@@ -8,9 +8,11 @@ export default function SavedRunsList({
   promotedRunId,
   onOpen,
   onDelete,
+  onDeleteAll,
   deleting,
 }) {
   const [confirmRunId, setConfirmRunId] = useState(null);
+  const [confirmAll, setConfirmAll] = useState(false);
 
   function handleDeleteClick(runId) {
     if (confirmRunId !== runId) {
@@ -19,6 +21,15 @@ export default function SavedRunsList({
     }
     setConfirmRunId(null);
     onDelete?.(runId);
+  }
+
+  function handleDeleteAllClick() {
+    if (!confirmAll) {
+      setConfirmAll(true);
+      return;
+    }
+    setConfirmAll(false);
+    onDeleteAll?.();
   }
 
   if (!runs?.length) {
@@ -31,7 +42,32 @@ export default function SavedRunsList({
   }
   return (
     <div className="card idp-lab-section">
-      <h2>Saved runs</h2>
+      <div className="idp-lab-section-head">
+        <h2>Saved runs</h2>
+        {onDeleteAll && (
+          <div className="idp-lab-runs-bulk">
+            <button
+              className={`button ${confirmAll ? "button-danger" : ""}`}
+              onClick={handleDeleteAllClick}
+              disabled={Boolean(deleting)}
+              title="Delete every saved run. Promoted production config is NOT affected — the live board keeps running against the promoted values even if the source run artefact is wiped."
+            >
+              {confirmAll
+                ? `Confirm: delete all ${runs.length}`
+                : "Delete all runs"}
+            </button>
+            {confirmAll && (
+              <button
+                className="button"
+                onClick={() => setConfirmAll(false)}
+                disabled={Boolean(deleting)}
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        )}
+      </div>
       <div className="table-wrap">
         <table className="table idp-lab-runs-table">
           <thead>

--- a/frontend/app/tools/idp-calibration/page.jsx
+++ b/frontend/app/tools/idp-calibration/page.jsx
@@ -40,6 +40,7 @@ export default function IdpCalibrationLabPage() {
     analyze,
     loadRun,
     deleteRun,
+    deleteAllRuns,
     promote,
     refreshBoard,
   } = useCalibration();
@@ -174,6 +175,7 @@ export default function IdpCalibrationLabPage() {
         promotedRunId={production?.config?.source_run_id}
         onOpen={(runId) => loadRun(runId)}
         onDelete={(runId) => deleteRun(runId)}
+        onDeleteAll={() => deleteAllRuns()}
         deleting={loading.deleteRun}
       />
     </div>

--- a/frontend/app/tools/idp-calibration/useCalibration.js
+++ b/frontend/app/tools/idp-calibration/useCalibration.js
@@ -152,6 +152,23 @@ export function useCalibration() {
     return data;
   }, [refreshRuns]);
 
+  const deleteAllRuns = useCallback(async () => {
+    setFlag("deleteRun", true);
+    setErr("deleteRun", null);
+    const { status: http, data } = await jfetch("/api/idp-calibration/runs", {
+      method: "DELETE",
+    });
+    if (!mountedRef.current) return data;
+    if (http >= 400 || data?.ok === false) {
+      setErr("deleteRun", data?.error || `HTTP ${http}`);
+    } else {
+      await refreshRuns();
+      setCurrentRun(null);
+    }
+    setFlag("deleteRun", false);
+    return data;
+  }, [refreshRuns]);
+
   const promote = useCallback(async ({ runId, activeMode }) => {
     setFlag("promote", true);
     setErr("promote", null);
@@ -216,6 +233,7 @@ export function useCalibration() {
     analyze,
     loadRun,
     deleteRun,
+    deleteAllRuns,
     promote,
     refreshBoard,
   };

--- a/server.py
+++ b/server.py
@@ -3841,6 +3841,14 @@ async def idp_calibration_run_delete(request: Request, run_id: str):
     return _idp_json(_idp_api.run_delete(str(run_id or "").strip()))
 
 
+@app.delete("/api/idp-calibration/runs")
+async def idp_calibration_runs_delete_all(request: Request):
+    gate = _require_auth_json(request)
+    if gate is not None:
+        return gate
+    return _idp_json(_idp_api.runs_delete_all())
+
+
 @app.post("/api/idp-calibration/promote")
 async def idp_calibration_promote(request: Request):
     gate = _require_auth_json(request)

--- a/src/idp_calibration/api.py
+++ b/src/idp_calibration/api.py
@@ -14,7 +14,7 @@ from typing import Any
 from .engine import AnalysisSettings, run_analysis
 from .promotion import EmptyCalibrationError, VALID_MODES, load_production, promote_run
 from .production import is_promoted
-from .storage import delete_run, get_latest, list_runs, load_run, save_run
+from .storage import delete_all_runs, delete_run, get_latest, list_runs, load_run, save_run
 
 
 def _error(status: int, message: str, **extra: Any) -> tuple[int, dict[str, Any]]:
@@ -74,6 +74,17 @@ def run_delete(run_id: str, *, base: Path | None = None) -> tuple[int, dict[str,
     if not removed:
         return _error(404, f"Run {run_id!r} not found.")
     return 200, {"ok": True, "run_id": run_id, "deleted": True}
+
+
+def runs_delete_all(*, base: Path | None = None) -> tuple[int, dict[str, Any]]:
+    """Nuke every saved run and clear the latest pointer.
+
+    Promoted production config is intentionally left untouched — a
+    live calibration keeps running against its last-known inputs
+    even if its source run artefact gets wiped.
+    """
+    count = delete_all_runs(base=base)
+    return 200, {"ok": True, "deleted": count}
 
 
 def promote(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[int, dict[str, Any]]:

--- a/src/idp_calibration/storage.py
+++ b/src/idp_calibration/storage.py
@@ -116,3 +116,25 @@ def delete_run(run_id: str, *, base: Path | None = None) -> bool:
         else:
             _latest_path(base).unlink(missing_ok=True)
     return True
+
+
+def delete_all_runs(*, base: Path | None = None) -> int:
+    """Delete every saved run and clear the ``latest.json`` pointer.
+
+    Returns the number of run files that were removed. Leaves the
+    promoted production config (``config/idp_calibration.json``)
+    untouched — if the promoted source run is deleted, production
+    stays live but the "Source run" link in the UI will report the
+    run as gone.
+    """
+    runs_dir = _runs_dir(base)
+    removed = 0
+    if runs_dir.exists():
+        for path in runs_dir.glob("*.json"):
+            try:
+                path.unlink()
+                removed += 1
+            except OSError:
+                continue
+    _latest_path(base).unlink(missing_ok=True)
+    return removed

--- a/tests/idp_calibration/test_api.py
+++ b/tests/idp_calibration/test_api.py
@@ -126,6 +126,28 @@ def test_run_delete_requires_id(tmp_base):
     assert status == 422
 
 
+def test_runs_delete_all_clears_everything(tmp_base):
+    for seed in ("A", "C", "E"):
+        api.analyze(
+            {"test_league_id": seed, "my_league_id": seed + "-mine"},
+            base=tmp_base,
+        )
+    status, runs_before = api.runs_index(base=tmp_base)
+    assert status == 200
+    assert len(runs_before["runs"]) == 3
+    status, payload = api.runs_delete_all(base=tmp_base)
+    assert status == 200
+    assert payload["deleted"] == 3
+    status, runs_after = api.runs_index(base=tmp_base)
+    assert runs_after["runs"] == []
+
+
+def test_runs_delete_all_on_empty_store_returns_zero(tmp_base):
+    status, payload = api.runs_delete_all(base=tmp_base)
+    assert status == 200
+    assert payload["deleted"] == 0
+
+
 def test_promote_empty_run_returns_422(tmp_base):
     # Save an artifact with zero bucket counts by hand so we can attempt
     # a deliberately-unsafe promotion.

--- a/tests/idp_calibration/test_storage_promotion.py
+++ b/tests/idp_calibration/test_storage_promotion.py
@@ -141,6 +141,39 @@ def test_delete_run_removes_file_and_updates_latest(tmp_base):
     assert storage.delete_run(art1["run_id"], base=tmp_base) is False
 
 
+def test_delete_all_runs_clears_everything(tmp_base):
+    settings = engine.AnalysisSettings()
+    for seed in ("A", "C", "E"):
+        art = engine.run_analysis(
+            seed, seed + "-mine", settings,
+            stats_adapter_factory=lambda s: _StubAdapter(),
+        )
+        storage.save_run(art, base=tmp_base)
+    # Baseline: three runs saved plus a latest pointer.
+    assert len(storage.list_runs(base=tmp_base)) == 3
+    assert storage.get_latest(base=tmp_base) is not None
+
+    removed = storage.delete_all_runs(base=tmp_base)
+    assert removed == 3
+    assert storage.list_runs(base=tmp_base) == []
+    assert storage.get_latest(base=tmp_base) is None
+
+
+def test_delete_all_runs_on_empty_dir_is_zero(tmp_base):
+    assert storage.delete_all_runs(base=tmp_base) == 0
+
+
+def test_delete_all_runs_does_not_touch_promoted_config(tmp_base):
+    settings = engine.AnalysisSettings()
+    art = engine.run_analysis(
+        "A", "B", settings, stats_adapter_factory=lambda s: _StubAdapter()
+    )
+    storage.save_run(art, base=tmp_base)
+    promotion.promote_run(art["run_id"], active_mode="blended", base=tmp_base)
+    storage.delete_all_runs(base=tmp_base)
+    assert promotion.production_config_path(tmp_base).exists()
+
+
 def test_delete_run_does_not_touch_promoted_config(tmp_base):
     settings = engine.AnalysisSettings()
     art = engine.run_analysis(


### PR DESCRIPTION
## Summary

One-click wipe of every saved run artefact in the IDP Calibration Lab. Complements the existing per-row Delete.

**UX**: Two-click confirm — first click arms ("Confirm: delete all N"), second click fires and refreshes the list.

**Safety**: Promoted production config is intentionally **not** touched. Wiping saved runs doesn't revert the live board; that's still a separate explicit operation (remove \`config/idp_calibration.json\`).

## Changes
- \`storage.delete_all_runs()\` helper + DELETE collection-URL endpoint (\`DELETE /api/idp-calibration/runs\`, distinct from the existing single-delete \`{run_id}\` route)
- Next.js proxy route extended with a DELETE handler
- \`useCalibration\` hook exposes \`deleteAllRuns\`
- \`SavedRunsList\` renders the bulk-delete button in the section head

## Tests
- [x] \`delete_all_runs\` populated store, empty store, promoted-config survival
- [x] \`api.runs_delete_all\` end-to-end
- [x] 1630 passing
- [x] Frontend \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)