### PR TITLE
Refit Hill curve to market sources (KTC/IDPTC/DN/DD average)

### DIFF
--- a/scripts/fit_hill_curve_from_market.py
+++ b/scripts/fit_hill_curve_from_market.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Fit the Hill curve (midpoint, slope) to average market source values.
+
+Loads per-source value CSVs from ``CSVs/site_raw/`` — KTC, IDPTradeCalc,
+DynastyNerds (SF TEP), DynastyDaddy (SF) — normalises each source so
+its top player = 9999, grid-searches a Hill curve per source, then
+reports the simple mean + n-weighted mean of (midpoint, slope).
+
+Use the output to update ``src/canonical/player_valuation.py`` constants
+``HILL_MIDPOINT`` and ``HILL_SLOPE`` when the community's dropoff shape
+drifts from ours.
+
+Usage:
+    python3 scripts/fit_hill_curve_from_market.py
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+SOURCES: dict[str, tuple[str, str]] = {
+    "KTC":          ("CSVs/site_raw/ktc.csv",                 "value"),
+    "IDPTradeCalc": ("CSVs/site_raw/idpTradeCalc.csv",        "value"),
+    "DynastyDaddy": ("CSVs/site_raw/dynastyDaddySf.csv",      "value"),
+    "DynastyNerds": ("CSVs/site_raw/dynastyNerdsSfTep.csv",   "Value"),
+}
+
+
+def _load_values(path: Path, col: str) -> list[float]:
+    vs: list[float] = []
+    with open(path, newline="") as f:
+        for r in csv.DictReader(f):
+            raw = r.get(col)
+            try:
+                v = float(raw)
+            except (TypeError, ValueError):
+                continue
+            if v > 0:
+                vs.append(v)
+    vs.sort(reverse=True)
+    return vs
+
+
+def _hill(rank: float, midpoint: float, slope: float) -> float:
+    rank = max(1.0, float(rank))
+    return 1.0 + 9998.0 / (1.0 + ((rank - 1.0) / midpoint) ** slope)
+
+
+def _fit(normed_points: list[tuple[int, float]]) -> tuple[float, float, float]:
+    """Grid-search + refine (midpoint, slope) minimising MSE."""
+    best: tuple[float, float, float] | None = None
+    for m_i in range(20, 201, 1):
+        m = float(m_i)
+        for s_i in range(40, 251, 2):
+            s = s_i / 100.0
+            err = sum((v - _hill(r, m, s)) ** 2 for r, v in normed_points)
+            if best is None or err < best[0]:
+                best = (err, m, s)
+    assert best is not None
+    # Fine refinement
+    err0, m0, s0 = best
+    for dm in (-0.5, -0.25, 0.0, 0.25, 0.5):
+        for ds in (-0.01, -0.005, 0.0, 0.005, 0.01):
+            m = m0 + dm
+            s = s0 + ds
+            err = sum((v - _hill(r, m, s)) ** 2 for r, v in normed_points)
+            if err < best[0]:
+                best = (err, m, s)
+    return best[1], best[2], best[0] / len(normed_points)
+
+
+def main() -> int:
+    print(f"Fitting Hill curve to {len(SOURCES)} market sources …")
+    print()
+    fits: list[tuple[str, int, float, float, float]] = []
+    for label, (rel_path, col) in SOURCES.items():
+        values = _load_values(REPO / rel_path, col)
+        if not values:
+            print(f"  {label}: no values found at {rel_path}")
+            continue
+        top = values[0]
+        normed = [(i + 1, v / top * 9999.0) for i, v in enumerate(values[:300])]
+        m, s, mse = _fit(normed)
+        fits.append((label, len(values), m, s, mse))
+        print(f"  {label:14s}  n={len(values):4d}  midpoint={m:6.2f}  slope={s:5.3f}  mse/pt={mse:.1f}")
+
+    if not fits:
+        print("No sources loaded; aborting.")
+        return 1
+
+    total = sum(n for _, n, *_ in fits)
+    simple_m = sum(m for *_, _m, _s, _ in () or ()) or 0.0
+    simple_m = sum(m for _, _, m, _, _ in fits) / len(fits)
+    simple_s = sum(s for _, _, _, s, _ in fits) / len(fits)
+    weighted_m = sum(n * m for _, n, m, _, _ in fits) / total
+    weighted_s = sum(n * s for _, n, _, s, _ in fits) / total
+
+    print()
+    print(f"  {'Simple mean':14s}                   midpoint={simple_m:6.2f}  slope={simple_s:5.3f}")
+    print(f"  {'n-Weighted':14s}                   midpoint={weighted_m:6.2f}  slope={weighted_s:5.3f}")
+    print(f"  {'Current (ours)':14s}                   midpoint=45.00          slope=1.100")
+
+    print()
+    print("Value at key ranks (top=9999):")
+    ranks = (1, 5, 10, 25, 50, 75, 100, 150, 200, 300)
+    header = f"  {'rank':>4}" + "".join(f"{r:>9}" for r in ranks)
+    print(header)
+    for label, _, m, s, _ in fits:
+        row = "".join(f"{int(_hill(r, m, s)):>9}" for r in ranks)
+        print(f"  {label[:14]:<14}" + row)
+    print(f"  {'SIMPLE_AVG':<14}" + "".join(f"{int(_hill(r, simple_m, simple_s)):>9}" for r in ranks))
+    print(f"  {'N_WEIGHTED':<14}" + "".join(f"{int(_hill(r, weighted_m, weighted_s)):>9}" for r in ranks))
+    print(f"  {'CURRENT':<14}" + "".join(f"{int(_hill(r, 45, 1.1)):>9}" for r in ranks))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/canonical/player_valuation.py
+++ b/src/canonical/player_valuation.py
@@ -42,10 +42,17 @@ TIER_GAP_THRESHOLD: float = 2.0    # gap_score above this triggers a break
 TIER_MIN_SIZE: int = 3             # minimum players in a tier before allowing split
 
 # Step 3: Base value curve — Hill-style, rank 1 always = 9999
-# value = 1 + 9998 / (1 + ((rank - 1) / 45)^1.10)
-# Mirrors the JS rankToValue in frontend/lib/dynasty-data.js
-HILL_MIDPOINT: float = 45.0        # rank at which value ≈ 5000
-HILL_SLOPE: float = 1.10           # controls steepness of decay
+# value = 1 + 9998 / (1 + ((rank - 1) / midpoint)^slope)
+# Mirrors the JS rankToValue in frontend/lib/dynasty-data.js.
+#
+# Constants are the simple mean of per-source Hill-curve fits across
+# the four value-emitting market sources — KTC, IDPTradeCalc,
+# DynastyNerds (SF TEP), DynastyDaddy (SF) — each normalised so its
+# top player = 9999 before fitting. Re-run
+# ``scripts/fit_hill_curve_from_market.py`` when the community's
+# dropoff shape drifts from ours and update the constants here.
+HILL_MIDPOINT: float = 48.44       # rank at which value decay inflects
+HILL_SLOPE: float = 1.149          # controls steepness of decay
 
 # Step 4: Tier cliff injection
 CLIFF_BASE_POINTS: float = 120.0   # base cliff size in value units

--- a/tests/api/test_rankings_our_rank.py
+++ b/tests/api/test_rankings_our_rank.py
@@ -118,11 +118,19 @@ class TestBackendFormulaIntact:
     """The backend rank-to-value curve is the single source of truth."""
 
     def test_python_hill_curve_anchors(self):
-        from src.canonical.player_valuation import rank_to_value
+        from src.canonical.player_valuation import (
+            HILL_MIDPOINT,
+            rank_to_value,
+        )
         assert rank_to_value(1) == 9999, "Rank 1 must produce 9999"
         assert rank_to_value(0) == 0, "Rank 0 must produce 0"
-        mid = rank_to_value(45)
-        assert 4900 <= mid <= 5100, f"Rank 45 (midpoint) produced {mid}, expected ~5000"
+        # Rank == midpoint+1 is the Hill curve's inflection point:
+        # v = 1 + 9998/(1 + 1^slope) = 5000 regardless of slope.
+        mid_rank = int(round(HILL_MIDPOINT)) + 1
+        mid = rank_to_value(mid_rank)
+        assert 4900 <= mid <= 5100, (
+            f"Rank {mid_rank} (midpoint+1) produced {mid}, expected ~5000"
+        )
 
 
 # ── Unified rank precedence ──────────────────────────────────────────────────

--- a/tests/canonical/test_player_valuation.py
+++ b/tests/canonical/test_player_valuation.py
@@ -188,8 +188,12 @@ class TestBaseValueCurve:
         assert rank_to_value(1) == 9999
 
     def test_correct_spot_values(self):
-        expected = {1: 9999, 2: 9849, 3: 9684, 5: 9347, 10: 8544,
-                    25: 6663, 50: 4766, 100: 2959, 200: 1632, 500: 663}
+        # Hill curve fit to the simple mean of KTC / IDPTradeCalc /
+        # DynastyDaddy / DynastyNerds. Re-run
+        # ``scripts/fit_hill_curve_from_market.py`` to refresh the
+        # constants and update these expected values together.
+        expected = {1: 9999, 2: 9885, 3: 9749, 5: 9460, 10: 8736,
+                    25: 6914, 50: 4967, 100: 3055, 200: 1648, 500: 643}
         for rank, val in expected.items():
             assert rank_to_value(rank) == val, f"rank {rank}: got {rank_to_value(rank)}, expected {val}"
 
@@ -1039,12 +1043,21 @@ class TestParameterSweep:
     def test_hill_slope_sweep(self):
         """Varying hill_slope controls tail decay: higher slope → lower tail values.
 
-        The Hill formula crossover is at rank ≈ midpoint+1 (default 46).
-        For ranks well above the midpoint (tail), higher slope produces
-        larger denominators and thus lower display values.
+        The Hill formula crossover is at rank ≈ midpoint+1. For ranks
+        well above the midpoint (tail), higher slope produces larger
+        denominators and thus lower display values. We pick a rank
+        clearly past the midpoint so the direction of the relationship
+        is unambiguous regardless of small midpoint drift between
+        calibration refreshes.
         """
-        players = self._sweep_players()
-        # Use player at rank ~48 (tail, above midpoint=45) for the fraction test.
+        import random
+        random.seed(123)
+        # Generate a deeper sweep (150 players) so the tail probe lands
+        # well past the midpoint even if constants shift.
+        players = {
+            f"P{i}": [float(i), float(i) + random.uniform(-1, 1)]
+            for i in range(1, 151)
+        }
         tail_fractions = []
         for slope in [0.6, 1.10, 1.5, 2.0]:
             result = run_valuation(
@@ -1053,8 +1066,8 @@ class TestParameterSweep:
                 hill_slope=slope,
             )
             top_dv = result.players[0].display_value
-            # Index 47 ≈ rank 48, well into the tail above midpoint=45
-            tail_dv = result.players[min(47, len(result.players) - 1)].display_value
+            # Index 119 = rank 120, well past any plausible Hill midpoint.
+            tail_dv = result.players[min(119, len(result.players) - 1)].display_value
             tail_fractions.append(tail_dv / max(top_dv, 1))
 
         # Higher slope → steeper tail → tail player is a smaller fraction of #1


### PR DESCRIPTION
## Summary

User feedback: current value curve drops off too fast. Fit the Hill curve to the four value-emitting market sources, each normalised to a 1-9999 top, and take the simple mean of their per-source (midpoint, slope) fits.

**Per-source fits (each normalised to top=9999 before fitting):**
| Source | midpoint | slope |
|---|---:|---:|
| KTC | 57.50 | 0.855 |
| IDPTradeCalc | 75.00 | 0.755 |
| DynastyDaddy | 32.75 | 1.235 |
| DynastyNerds | 28.50 | 1.750 |
| **Simple mean** | **48.44** | **1.149** |

**Value deltas vs old curve (45.0, 1.10):**
| rank | old | new | Δ |
|---:|---:|---:|---|
| 5 | 9347 | 9460 | +1.2% |
| 25 | 6663 | 6914 | +3.8% |
| 50 | 4766 | 4967 | +4.2% |
| 100 | 2959 | 3055 | +3.2% |
| 200 | 1632 | 1648 | +1.0% |

\`scripts/fit_hill_curve_from_market.py\` runs the full analysis and prints the per-source breakdown so we can refresh the constants cleanly whenever the CSV snapshots update.

## Notes on normalisation

DynastyNerds caps at ~10256 and DynastyDaddy at ~10200. Every source is scaled by \`top/9999\` before the fit so the different native scales don't bias the blended midpoint/slope. KTC and IDPTradeCalc are already on the 9999 scale but get the same treatment for consistency.

## Test plan
- [x] Canonical test suite updated with new expected values
- [x] Parameter-sweep test moved to rank 120 so the probe lands well past any future midpoint
- [x] Hill-curve anchor test rooted at \`HILL_MIDPOINT + 1\` so it tracks future refits automatically
- [x] 1630 passing
- [x] Frontend \`npm run build\` clean
- [ ] Post-deploy: /rankings mid/late ranks show slightly higher values, elite top unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)