### PR TITLE
Remove Phase 5b: preserve fractional-rank signal through calibration

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2755,12 +2755,15 @@ def _apply_idp_calibration_post_pass(
                 multiplier = 1.0
             if abs(multiplier - 1.0) < 1e-9:
                 continue
-            # Multiplier shifts the row's *target value* so that the
-            # subsequent global re-sort moves the row to a new rank on
-            # the merged board. After the re-sort, Phase 5b recomputes
-            # rankDerivedValue from rank_to_value(canonicalConsensusRank)
-            # so the final value is coherent with the new rank on the
-            # Hill curve — not an orphaned multiplied number.
+            # Multiplier scales the row's value (on top of the
+            # weighted Hill-curve blend already encoded in
+            # rankDerivedValue). The subsequent global re-sort places
+            # the row at its new merged rank based on the multiplied
+            # value. We deliberately keep the multiplied value as the
+            # final rankDerivedValue — the tiered fractional-rank
+            # signal from the per-source Hill blend carries through
+            # the calibration so elite players don't get snapped to
+            # the integer-rank Hill value.
             old_val = int(row.get("rankDerivedValue") or 0)
             new_val = max(1, int(round(old_val * multiplier)))
             row["rankDerivedValue"] = new_val
@@ -2827,10 +2830,9 @@ def _apply_offense_calibration_post_pass(
                 multiplier = 1.0
             if abs(multiplier - 1.0) < 1e-9:
                 continue
-            # Same rank-shift semantics as IDP: multiplier adjusts the
-            # target value so the global re-sort moves the row to a new
-            # rank; Phase 5b then anchors the value back onto the Hill
-            # curve based on the new rank.
+            # Same semantics as IDP post-pass: multiplier scales the
+            # blended rankDerivedValue; the global re-sort then places
+            # the row at its new merged rank.
             old_val = int(row.get("rankDerivedValue") or 0)
             new_val = max(1, int(round(old_val * multiplier)))
             row["rankDerivedValue"] = new_val
@@ -3858,29 +3860,15 @@ def _compute_unified_rankings(
             r["canonicalConsensusRank"] = new_rank
         r["canonicalTierId"] = _tier_id_from_rank(new_rank)
 
-    # Phase 5b — rank-to-value coherence when calibration is active.
-    # Gated: only run when a promoted calibration config exists. In the
-    # uncalibrated baseline, existing pre-sort value adjustments (TEP
-    # premium, pick anchors, per-source blends) deliberately decouple
-    # value from a strict rank_to_value() — we preserve that behaviour
-    # when there's nothing to calibrate. Once calibration is promoted,
-    # the user's mental model takes priority: every row's final value
-    # equals ``rank_to_value(canonicalConsensusRank)`` so value and rank
-    # stay coupled on the Hill curve — no orphaned post-pass products,
-    # always on the 1–9999 scale.
-    if _idp_production.load_production_config():
-        from src.canonical.player_valuation import rank_to_value as _hill_value
-        for r in ranked_rows:
-            rank = r.get("canonicalConsensusRank")
-            if rank is None or int(rank) <= 0:
-                continue
-            coherent_value = int(_hill_value(int(rank)))
-            r["rankDerivedValue"] = coherent_value
-            legacy_ref = r.get("legacyRef")
-            if legacy_ref and legacy_ref in players_by_name:
-                pdata = players_by_name[legacy_ref]
-                if isinstance(pdata, dict):
-                    pdata["rankDerivedValue"] = coherent_value
+    # (Phase 5b — value re-flattening — intentionally removed.) The
+    # pre-sort ``rankDerivedValue`` is a weighted blend of per-source
+    # Hill-curve values plus any calibration multiplier, which
+    # encodes fractional-rank consensus (e.g. Josh Allen at source
+    # ranks [1,1,1,2,1] ⇒ blended ~9976 ≈ Hill(1.2)) rather than a
+    # raw integer-rank snap. Re-flattening to ``rank_to_value(int
+    # rank)`` threw that nuance away. Sort order is still enforced
+    # by the Phase 5 re-sort above, so values are monotonic with
+    # ranks even without the Hill-curve anchor here.
 
     # 2c) Mirror the post-anchor rank back into the legacy players_by_name
     #     dict for every ranked row — not just picks.  The runtime view

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -118,22 +118,28 @@ def test_position_alias_collapses_to_canonical(tmp_path, monkeypatch):
     assert rows[0]["rankDerivedValue"] == 2000  # EDGE -> DL -> 0.5x
 
 
-def test_end_to_end_keeps_value_on_hill_curve_after_calibration(tmp_path, monkeypatch):
-    """Core invariant of the rank-shift calibration: after
-    ``build_api_data_contract`` runs, every ranked row's
-    ``rankDerivedValue`` equals ``rank_to_value(canonicalConsensusRank)``
-    — i.e. the value is always on the Hill curve at the player's final
-    rank. No orphan multiplied numbers, always on the 1-9999 scale.
+def test_end_to_end_values_are_monotonic_with_ranks_after_calibration(tmp_path, monkeypatch):
+    """With calibration active, ``rankDerivedValue`` is the weighted
+    Hill-curve blend from per-source ranks times the calibration
+    multiplier. It is NOT re-snapped to ``rank_to_value(int rank)`` —
+    that was the old Phase 5b behaviour, which threw away the
+    fractional-rank nuance (Josh Allen at source ranks [1,1,1,2,1]
+    gets a blended ~9976, not the integer-rank Hill(1)=9999).
+
+    What we lock in instead:
+      * ranks are a strict sort of ranked values (monotonic)
+      * each ranked row carries pre-calibration rank + value
+        snapshots so the /rankings toggle can swap coherently
+      * values past the offense top-tier bear the signature of
+        calibration (at least one IDP row has a non-unit multiplier
+        stamp when meaningful buckets are promoted)
     """
     from src.api.data_contract import build_api_data_contract
-    from src.canonical.player_valuation import rank_to_value
 
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
         "version": 1,
         "active_mode": "blended",
-        # Meaningful IDP calibration — DL 1-6 scaled up, DL 7-12 down.
-        # Drives real rank reshuffles so we exercise the re-sort path.
         "multipliers": {
             "final": {
                 "DL": {"1-6": 1.5, "7-12": 0.5},
@@ -144,7 +150,6 @@ def test_end_to_end_keeps_value_on_hill_curve_after_calibration(tmp_path, monkey
     monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
     production.reset_cache()
 
-    # Minimal payload with a mix of positions so re-sort is exercised.
     players = {}
     for i in range(1, 8):
         players[f"Zzz DL {i:02d}"] = {
@@ -173,22 +178,28 @@ def test_end_to_end_keeps_value_on_hill_curve_after_calibration(tmp_path, monkey
         "sleeper": {"positions": {n: v["position"] for n, v in players.items()}},
     }
     contract = build_api_data_contract(payload)
-    ranked = [r for r in contract["playersArray"] if r.get("canonicalConsensusRank")]
-    # Invariant: every row's rankDerivedValue is exactly rank_to_value
-    # of its final canonicalConsensusRank. Calibration moves rows
-    # AROUND the board, but their landed value is always on the curve.
-    for row in ranked:
-        expected = int(rank_to_value(int(row["canonicalConsensusRank"])))
-        assert row["rankDerivedValue"] == expected, (
-            f"{row.get('canonicalName')!r} at rank "
-            f"{row['canonicalConsensusRank']} has value "
-            f"{row['rankDerivedValue']} but Hill curve says {expected}"
+    ranked = sorted(
+        [r for r in contract["playersArray"] if r.get("canonicalConsensusRank")],
+        key=lambda r: int(r["canonicalConsensusRank"]),
+    )
+    # Invariant 1: values decrease (or tie) as rank increases.
+    for a, b in zip(ranked, ranked[1:]):
+        assert int(a["rankDerivedValue"]) >= int(b["rankDerivedValue"]), (
+            f"Value inversion: rank {a['canonicalConsensusRank']} "
+            f"({a['rankDerivedValue']}) < rank {b['canonicalConsensusRank']} "
+            f"({b['rankDerivedValue']})"
         )
-    # And: snapshots exist on every ranked row so the /rankings toggle
-    # has both a pre-calibration rank AND value to swap to.
+    # Invariant 2: every ranked row carries the pre-calibration
+    # snapshot so the /rankings toggle can reconstruct the
+    # uncalibrated board coherently.
     for row in ranked:
         assert "canonicalConsensusRankUncalibrated" in row
         assert "rankDerivedValueUncalibrated" in row
+    # Invariant 3: at least one DL row carries the calibration stamp
+    # — otherwise the test isn't actually exercising the multiplier
+    # path.
+    stamped = [r for r in ranked if r.get("idpCalibrationMultiplier")]
+    assert stamped, "No row was stamped with idpCalibrationMultiplier"
 
 
 def test_offense_multipliers_scale_only_offense(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Per user feedback: the per-source Hill-value blend already encodes fractional-rank consensus (Josh Allen at source ranks \`[1,1,1,2,1]\` blends to ~9976, approximating Hill(1.2) — not flattening to Hill(1)=9999). Phase 5b was throwing that signal away by re-snapping to \`rank_to_value(integer rank)\` when calibration was active.

## What changes
- After post-passes + global re-sort, \`rankDerivedValue\` is left at the blended × multiplied value. Not re-flattened.
- Sort order remains monotonic with value (re-sort step enforces this), so ranks and values stay ordered.
- Fractional-rank nuance is preserved across calibration.

## What stays
- Anchor-curve smoothing for IDP calibration multipliers (prevents the bucket cliffs you originally flagged)
- Pre-calibration snapshots for the /rankings toggle
- Sort-order enforcement so monotonicity holds

## Trade-off
A rank-40 row's value won't exactly equal \`rank_to_value(40)\`. The deviation reflects *real signal* — the calibration multiplier plus the per-source fractional-rank blend — both of which you explicitly want preserved.

## Test plan
- [x] Invariant test rewritten from "value == Hill(int rank)" to "values monotonic with ranks + snapshots present + multiplier stamps present"
- [x] Full suite 1630 passing
- [x] Frontend \`npm run build\` clean
- [ ] Post-deploy: top players show blended values (Allen ~9976 instead of exactly 9999), calibrated IDP show multiplier-adjusted values

🤖 Generated with [Claude Code](https://claude.com/claude-code)