### PR TITLE
Angle: multi-player offers + dropdown visibility fix

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -4,17 +4,18 @@ import { useEffect, useMemo, useState } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
 
 // ── Angle ───────────────────────────────────────────────────────────
-// Player-specific trade-target arbitrage.
-// Pick a team → pick a player on that team → surface players on other
-// teams where your league's calibrated rankings say win but KTC sees
-// the trade as fair or better for the counterparty.
+// Multi-player trade-target arbitrage.
+// Pick your team → check off any players you'd offer → get counter-
+// packages from other teams, sized within ±1 of your offer, where
+// your league's calibrated rankings say win but KTC sees fair-or-
+// better for the counterparty.
 
 const DEFAULT_MIN_MY = 5;
 const DEFAULT_MAX_KTC = 5;
 const DEFAULT_LIMIT = 50;
 
 export default function AnglePage() {
-  const { loading: dataLoading, error: dataError, rawData } = useDynastyData();
+  const { loading: dataLoading, error: dataError, rawData, rows } = useDynastyData();
 
   const teams = useMemo(() => {
     const list = rawData?.sleeper?.teams || [];
@@ -23,8 +24,27 @@ export default function AnglePage() {
     );
   }, [rawData]);
 
+  // Quick lookup: canonical name → { my_value, ktc_value, position }.
+  // Used to show per-player totals in the checklist and offer bar.
+  const valueByName = useMemo(() => {
+    const m = new Map();
+    for (const r of rows || []) {
+      const name = r?.name || r?.canonicalName;
+      if (!name) continue;
+      const my_v = Number(r?.rankDerivedValue) || 0;
+      const ktc_v = Number(r?.canonicalSites?.ktc) || 0;
+      m.set(name, {
+        my_value: my_v,
+        ktc_value: ktc_v,
+        position: r?.pos || r?.position || "",
+      });
+    }
+    return m;
+  }, [rows]);
+
   const [ownerId, setOwnerId] = useState("");
-  const [playerName, setPlayerName] = useState("");
+  const [rosterFilter, setRosterFilter] = useState("");
+  const [offer, setOffer] = useState(() => new Set());
   const [minMyGainPct, setMinMyGainPct] = useState(DEFAULT_MIN_MY);
   const [maxKtcGainPct, setMaxKtcGainPct] = useState(DEFAULT_MAX_KTC);
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
@@ -32,7 +52,6 @@ export default function AnglePage() {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
 
-  // Default to the first team the moment the data loads.
   useEffect(() => {
     if (!ownerId && teams.length > 0) {
       setOwnerId(String(teams[0].ownerId || ""));
@@ -46,34 +65,62 @@ export default function AnglePage() {
 
   const roster = useMemo(() => {
     if (!selectedTeam) return [];
-    return [...(selectedTeam.players || [])].sort((a, b) => a.localeCompare(b));
-  }, [selectedTeam]);
+    return [...(selectedTeam.players || [])]
+      .filter(
+        (name) =>
+          !rosterFilter.trim() ||
+          name.toLowerCase().includes(rosterFilter.trim().toLowerCase()),
+      )
+      .sort((a, b) => a.localeCompare(b));
+  }, [selectedTeam, rosterFilter]);
 
+  // Reset offer whenever the team changes — an offer on the old team
+  // isn't coherent with the new roster.
   useEffect(() => {
-    // Reset the player picker whenever the team changes so we never
-    // POST a player who isn't on the currently-selected roster.
-    if (roster.length > 0 && !roster.includes(playerName)) {
-      setPlayerName(roster[0]);
-    } else if (roster.length === 0) {
-      setPlayerName("");
+    setOffer(new Set());
+    setResult(null);
+    setErr(null);
+  }, [ownerId]);
+
+  const offerList = useMemo(() => Array.from(offer), [offer]);
+
+  const offerTotals = useMemo(() => {
+    let my = 0;
+    let ktc = 0;
+    for (const name of offerList) {
+      const info = valueByName.get(name);
+      if (info) {
+        my += info.my_value || 0;
+        ktc += info.ktc_value || 0;
+      }
     }
-  }, [roster, playerName]);
+    return { my, ktc };
+  }, [offerList, valueByName]);
+
+  function toggleOffer(name) {
+    setOffer((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }
 
   async function findAngles() {
-    if (!ownerId || !playerName) {
-      setErr("Pick a team and a player.");
+    if (!ownerId || offerList.length === 0) {
+      setErr("Pick a team and check at least one player.");
       return;
     }
     setBusy(true);
     setErr(null);
     try {
-      const res = await fetch("/api/angle/find", {
+      const res = await fetch("/api/angle/packages", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         cache: "no-store",
         body: JSON.stringify({
           ownerId,
-          playerName,
+          playerNames: offerList,
           minMyGainPct: Number(minMyGainPct),
           maxKtcGainPct: Number(maxKtcGainPct),
           limit: Number(limit),
@@ -115,8 +162,8 @@ export default function AnglePage() {
         <div>
           <h1 className="page-title">Angle</h1>
           <p className="page-subtitle muted" style={{ marginTop: 4 }}>
-            Find trades that win on your rankings but look fair or losing on
-            KTC — easy to pitch to your leaguemates.
+            Build an offer from your roster; get counter-packages
+            (±1 in size) that win on your rankings but look fair-or-better on KTC.
           </p>
         </div>
       </div>
@@ -124,7 +171,7 @@ export default function AnglePage() {
       <section className="card angle-controls">
         <div className="angle-controls-row">
           <label className="angle-field">
-            <span className="muted">Team</span>
+            <span className="muted">Your team</span>
             <select
               value={ownerId}
               onChange={(e) => setOwnerId(e.target.value)}
@@ -142,27 +189,9 @@ export default function AnglePage() {
             </select>
           </label>
           <label className="angle-field">
-            <span className="muted">Player on that team</span>
-            <select
-              value={playerName}
-              onChange={(e) => setPlayerName(e.target.value)}
-              disabled={busy || roster.length === 0}
-            >
-              {roster.length === 0 ? (
-                <option value="">No roster loaded</option>
-              ) : (
-                roster.map((name) => (
-                  <option key={name} value={name}>
-                    {name}
-                  </option>
-                ))
-              )}
-            </select>
-          </label>
-          <label className="angle-field">
             <span className="muted">
               Min my-value gain %{" "}
-              <span className="angle-field-hint">(target beats selected by ≥)</span>
+              <span className="angle-field-hint">(counter beats offer by ≥)</span>
             </span>
             <input
               type="number"
@@ -176,7 +205,7 @@ export default function AnglePage() {
           <label className="angle-field">
             <span className="muted">
               Max KTC gap %{" "}
-              <span className="angle-field-hint">(KTC sees target ≤ this above)</span>
+              <span className="angle-field-hint">(counter KTC ≤ this above)</span>
             </span>
             <input
               type="number"
@@ -201,12 +230,103 @@ export default function AnglePage() {
             type="button"
             className="button button-primary angle-go"
             onClick={findAngles}
-            disabled={busy || !ownerId || !playerName}
+            disabled={busy || !ownerId || offerList.length === 0}
           >
-            {busy ? "Searching…" : "Find angles"}
+            {busy ? "Searching…" : `Find counter-packages (${offerList.length})`}
           </button>
         </div>
-        {err && <p className="err-text" style={{ marginTop: 8 }}>{err}</p>}
+        {err && (
+          <p className="err-text" style={{ marginTop: 8 }}>
+            {err}
+          </p>
+        )}
+      </section>
+
+      <section className="card angle-offer-bar">
+        <div className="angle-offer-head">
+          <strong>Your offer ({offerList.length} player{offerList.length === 1 ? "" : "s"})</strong>
+          <div className="angle-offer-totals">
+            <span>
+              My total <strong>{offerTotals.my.toLocaleString()}</strong>
+            </span>
+            <span>
+              KTC total <strong>{offerTotals.ktc.toLocaleString()}</strong>
+            </span>
+            {offerList.length > 0 && (
+              <button
+                className="button"
+                onClick={() => setOffer(new Set())}
+                disabled={busy}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+        {offerList.length > 0 && (
+          <div className="angle-offer-chips">
+            {offerList.map((name) => {
+              const info = valueByName.get(name);
+              return (
+                <button
+                  key={name}
+                  className="angle-offer-chip"
+                  onClick={() => toggleOffer(name)}
+                  title="Remove from offer"
+                >
+                  <strong>{name}</strong>
+                  {info && (
+                    <span className="muted">
+                      {info.position} · my {info.my_value.toLocaleString()} / ktc{" "}
+                      {info.ktc_value.toLocaleString()}
+                    </span>
+                  )}
+                  <span className="angle-chip-x">×</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+        <div className="angle-search">
+          <input
+            type="text"
+            placeholder="Filter your roster…"
+            value={rosterFilter}
+            onChange={(e) => setRosterFilter(e.target.value)}
+            disabled={busy || !selectedTeam}
+          />
+        </div>
+        <div className="angle-roster-grid">
+          {roster.length === 0 ? (
+            <p className="muted">No players match.</p>
+          ) : (
+            roster.map((name) => {
+              const info = valueByName.get(name);
+              const checked = offer.has(name);
+              return (
+                <label
+                  key={name}
+                  className={`angle-roster-row ${checked ? "angle-roster-checked" : ""}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleOffer(name)}
+                    disabled={busy}
+                  />
+                  <span className="angle-roster-name">{name}</span>
+                  {info && (
+                    <span className="muted angle-roster-meta">
+                      {info.position || "—"} · my{" "}
+                      {info.my_value.toLocaleString()} / ktc{" "}
+                      {info.ktc_value.toLocaleString()}
+                    </span>
+                  )}
+                </label>
+              );
+            })
+          )}
+        </div>
       </section>
 
       {result?.warnings?.length ? (
@@ -220,102 +340,72 @@ export default function AnglePage() {
         </section>
       ) : null}
 
-      {result?.selected ? (
-        <section className="card angle-selected">
-          <div className="angle-selected-grid">
-            <div>
-              <div className="muted">You're offering</div>
-              <div className="angle-player-head">
-                <strong>{result.selected.name}</strong>
-                <span className="muted">
-                  {result.selected.position} ·{" "}
-                  {result.selected.team || "(your team)"}
-                </span>
-              </div>
-            </div>
-            <div>
-              <div className="muted">Your value</div>
-              <div>
-                <strong>{result.selected.my_value?.toLocaleString()}</strong>
-              </div>
-            </div>
-            <div>
-              <div className="muted">KTC value</div>
-              <div>
-                <strong>{result.selected.ktc_value?.toLocaleString()}</strong>
-              </div>
-            </div>
-          </div>
-        </section>
-      ) : null}
-
       {result?.candidates?.length ? (
         <section className="card angle-results">
           <div className="angle-section-head">
-            <h2>Candidates ({result.candidates.length})</h2>
+            <h2>Counter-packages ({result.candidates.length})</h2>
             <span className="muted">
-              Sorted by arbitrage score (my gain % − KTC gap %)
+              Sorted by arbitrage score (my gain % − KTC gap %). Sizes allowed:{" "}
+              {(result.thresholds?.target_sizes || []).join(", ")}.
             </span>
           </div>
-          <div className="table-wrap">
-            <table className="table angle-table">
-              <thead>
-                <tr>
-                  <th>#</th>
-                  <th>Target</th>
-                  <th>Pos</th>
-                  <th>Owned by</th>
-                  <th title="Your rankings value">My</th>
-                  <th title="KeepTradeCut value">KTC</th>
-                  <th title="Target my-value minus selected my-value, as %">
-                    My Δ
-                  </th>
-                  <th title="Target KTC value minus selected KTC value, as %. 0 or negative = fair-or-better for counterparty.">
-                    KTC Δ
-                  </th>
-                  <th title="my_gain% − ktc_gap%; bigger = better pitch">
-                    Arb
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {result.candidates.map((c, i) => (
-                  <tr key={`${c.name}-${i}`}>
-                    <td>{i + 1}</td>
-                    <td>
-                      <strong>{c.name}</strong>
-                    </td>
-                    <td>{c.position}</td>
-                    <td>{c.team}</td>
-                    <td>{c.my_value.toLocaleString()}</td>
-                    <td>{c.ktc_value.toLocaleString()}</td>
-                    <td className="angle-delta-pos">
+          <div className="angle-package-grid">
+            {result.candidates.map((c, i) => (
+              <div key={i} className="angle-package">
+                <div className="angle-package-head">
+                  <div>
+                    <strong>#{i + 1}</strong>{" "}
+                    <span className="muted">
+                      {c.team} · {c.size}-for-{result.offer?.size || "?"}
+                    </span>
+                  </div>
+                  <div className="angle-package-scores">
+                    <span className="angle-delta-pos" title="my-value gain %">
                       +{c.my_gain_pct.toFixed(1)}%
-                    </td>
-                    <td
+                    </span>
+                    <span
                       className={
                         c.ktc_gain_pct <= 0
                           ? "angle-delta-pos"
                           : "angle-delta-neutral"
                       }
+                      title="KTC gap %"
                     >
                       {c.ktc_gain_pct > 0 ? "+" : ""}
-                      {c.ktc_gain_pct.toFixed(1)}%
-                    </td>
-                    <td>
+                      {c.ktc_gain_pct.toFixed(1)}% ktc
+                    </span>
+                    <span title="Arbitrage score">
                       <strong>+{c.arb_score.toFixed(1)}</strong>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                    </span>
+                  </div>
+                </div>
+                <ul className="angle-package-players">
+                  {c.players.map((p, j) => (
+                    <li key={j}>
+                      <strong>{p.name}</strong>{" "}
+                      <span className="muted">{p.position}</span>{" "}
+                      <span className="muted">
+                        my {p.my_value.toLocaleString()} / ktc{" "}
+                        {p.ktc_value.toLocaleString()}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="angle-package-totals muted">
+                  my total <strong>{c.my_total.toLocaleString()}</strong>{" "}
+                  · ktc total <strong>{c.ktc_total.toLocaleString()}</strong>
+                </div>
+              </div>
+            ))}
           </div>
         </section>
       ) : result && !busy ? (
         <section className="card">
           <p className="muted">
-            No candidates match. Loosen the thresholds (lower "Min my-value
-            gain %" or raise "Max KTC gap %") or pick a different player.
+            No counter-packages match. Loosen the thresholds (lower
+            "Min my-value gain %" or raise "Max KTC gap %"), pick
+            different offer players, or widen the candidate pool on
+            the backend.
           </p>
         </section>
       ) : null}

--- a/frontend/app/api/angle/packages/route.js
+++ b/frontend/app/api/angle/packages/route.js
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+const PACKAGES_URL = (() => {
+  const base = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+    /\/api\/data\/?$/,
+    "",
+  );
+  return `${base}/api/angle/packages`;
+})();
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const cookie = request.headers.get("cookie") || "";
+  // Combinations can take a couple seconds on a full 12-team league
+  // when the user offers 4+ players. Give the search headroom.
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 20_000);
+  try {
+    const res = await fetch(PACKAGES_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify(body),
+      signal: ctl.signal,
+      cache: "no-store",
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Angle packages service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2439,6 +2439,17 @@ tr:hover .sticky-name {
   color: var(--text-primary);
   font-size: 0.9rem;
 }
+/* Explicit option styling — Chromium on dark OS themes inherits a
+   translucent default and dropdown options become unreadable. */
+.angle-field select option {
+  background: #11182a;
+  color: var(--text-primary);
+}
+.angle-field select option:checked,
+.angle-field select option:hover {
+  background: var(--accent, #2563eb);
+  color: #fff;
+}
 .angle-field-hint { font-size: 0.72rem; opacity: 0.8; }
 .angle-go { align-self: end; white-space: nowrap; }
 .angle-selected-grid {
@@ -2468,3 +2479,108 @@ tr:hover .sticky-name {
   margin-bottom: var(--space-xs);
 }
 .idp-lab-runs-bulk { display: flex; gap: var(--space-xs); }
+
+/* Angle: multi-select offer bar + roster grid + package cards */
+.angle-offer-bar { display: flex; flex-direction: column; gap: var(--space-sm); }
+.angle-offer-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+.angle-offer-totals {
+  display: flex;
+  gap: var(--space-md);
+  align-items: baseline;
+  font-size: 0.9rem;
+}
+.angle-offer-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.angle-offer-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.angle-offer-chip:hover { background: var(--surface-hover, #1e293b); }
+.angle-chip-x { color: var(--text-muted); font-size: 1rem; line-height: 1; }
+.angle-search input {
+  width: 100%;
+  max-width: 360px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+}
+.angle-roster-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 6px 12px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  background: var(--surface-base, rgba(0, 0, 0, 0.1));
+}
+.angle-roster-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.angle-roster-row:hover { background: var(--surface-hover, rgba(255, 255, 255, 0.04)); }
+.angle-roster-checked { background: rgba(37, 99, 235, 0.15); }
+.angle-roster-name { font-weight: 500; }
+.angle-roster-meta { font-size: 0.75rem; text-align: right; white-space: nowrap; }
+.angle-package-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: var(--space-sm);
+}
+.angle-package {
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: var(--surface-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.angle-package-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+.angle-package-scores {
+  display: flex;
+  gap: 10px;
+  font-size: 0.85rem;
+}
+.angle-package-players {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.85rem;
+}
+.angle-package-players li { display: flex; gap: 6px; flex-wrap: wrap; }
+.angle-package-totals { font-size: 0.8rem; }

--- a/server.py
+++ b/server.py
@@ -2279,6 +2279,83 @@ async def post_angle_find(request: Request):
     return JSONResponse(content=result)
 
 
+@app.post("/api/angle/packages")
+async def post_angle_packages(request: Request):
+    """Multi-player variant of Angle. Offer a list of your players,
+    get back counter-packages from other teams sized within ±1 of
+    your offer that still lean your way on my-value but look fair-or-
+    better to the counterparty on KTC.
+
+    Body:
+        {
+          "ownerId": "472206636534984704",
+          "playerNames": ["Jayden Daniels", "CeeDee Lamb", ...],
+          "minMyGainPct": 5.0,
+          "maxKtcGainPct": 5.0,
+          "limit": 50,
+          "candidatePoolPerTeam": 25
+        }
+    """
+    if latest_contract_data is None:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "No data loaded. Angle requires live player data."},
+        )
+    players_array = (latest_contract_data or {}).get("playersArray")
+    sleeper = latest_contract_data.get("sleeper") or {}
+    sleeper_teams = sleeper.get("teams") or []
+    if not players_array or not sleeper_teams:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Player data or Sleeper rosters not available."},
+        )
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
+
+    owner_id = str(body.get("ownerId") or "").strip()
+    names = body.get("playerNames") or []
+    if not owner_id or not isinstance(names, list) or not names:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "Request body must include 'ownerId' and a non-empty 'playerNames' list."},
+        )
+    player_names = [str(n).strip() for n in names if str(n).strip()]
+
+    try:
+        min_my = float(body.get("minMyGainPct", 5.0))
+        max_ktc = float(body.get("maxKtcGainPct", 5.0))
+        limit = int(body.get("limit", 50))
+        pool = int(body.get("candidatePoolPerTeam", 25))
+    except (TypeError, ValueError):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "minMyGainPct, maxKtcGainPct, limit, candidatePoolPerTeam must be numeric."},
+        )
+
+    from src.trade.angle import find_angle_packages
+
+    try:
+        result = find_angle_packages(
+            players_array,
+            player_names,
+            owner_id,
+            sleeper_teams,
+            min_my_gain_pct=min_my,
+            max_ktc_gain_pct=max_ktc,
+            limit=limit,
+            candidate_pool_per_team=pool,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.error(f"Angle packages failed: {exc}")
+        return JSONResponse(
+            status_code=500,
+            content={"error": f"Angle packages failed: {exc}"},
+        )
+    return JSONResponse(content=result)
+
+
 @app.get("/api/scaffold/validation")
 async def get_scaffold_validation():
     ingest_file = _latest_file(DATA_DIR / "validation", "ingest_validation_*.json")

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -1,17 +1,23 @@
 """Angle finder — player-specific trade-target arbitrage.
 
-Given a user-owned player, find players on other teams where the trade
-leans in the user's favour under their own league's rankings but looks
-fair-or-worse to the counterparty on KTC. Lets the user pitch trades
-that their leaguemates will accept ("KTC says it's even") while
-actually gaining value in their league-specific calibrated board.
+Given a user-owned player (or package of players), find players or
+player-packages on other teams where the trade leans in the user's
+favour under their own league's rankings but looks fair-or-worse to
+the counterparty on KTC. Lets the user pitch trades that their
+leaguemates will accept ("KTC says it's even") while actually gaining
+value in their league-specific calibrated board.
 
-The user_value vs market_value comparison is the same mechanic the
-Finder arbitrage engine surfaces board-wide; Angle narrows it to a
-specific pivot player so a single trade proposal is easy to generate.
+``find_angles`` handles the single-player pivot. ``find_angle_packages``
+extends to multi-player offers: give it a list of your players and it
+returns multi-player counter-packages whose size is within ±1 of your
+offer (e.g. offering 4 players → returns 3-, 4-, and 5-player
+counter-offers). Same arbitrage math; combinations are evaluated per
+opposing team with the candidate pool clamped to each team's top-N
+players by your calibrated value so the search stays fast.
 """
 from __future__ import annotations
 
+from itertools import combinations
 from typing import Any
 
 
@@ -181,6 +187,199 @@ def find_angles(
             "min_my_gain_pct": min_my_gain_pct,
             "max_ktc_gain_pct": max_ktc_gain_pct,
             "limit": limit,
+        },
+        "warnings": warnings,
+    }
+
+
+def find_angle_packages(
+    players_array: list[dict[str, Any]],
+    selected_player_names: list[str],
+    selected_team_owner_id: str,
+    sleeper_teams: list[dict[str, Any]],
+    *,
+    min_my_gain_pct: float = 5.0,
+    max_ktc_gain_pct: float = 5.0,
+    limit: int = 50,
+    candidate_pool_per_team: int = 25,
+) -> dict[str, Any]:
+    """Find multi-player counter-packages for a user-built offer.
+
+    Parameters
+    ----------
+    selected_player_names
+        List of canonical player names on the user's roster that
+        constitute the OFFER side of the trade.
+    selected_team_owner_id
+        Sleeper ``ownerId`` identifying the user's team (excluded
+        from candidate pool).
+    candidate_pool_per_team
+        Top-N players (by ``rankDerivedValue``) considered per
+        opposing team when enumerating combinations. Caps the
+        combinatorial explosion; 25 × size-5 ≈ 53k combos per team
+        which completes comfortably inside a request.
+
+    Returns
+    -------
+    dict
+        ``{offer, candidates, thresholds, warnings}`` where
+        ``candidates`` is a list of package dicts, each with
+        ``{team, size, players, my_total, ktc_total, my_gain_pct,
+        ktc_gain_pct, arb_score}``. Sorted by ``arb_score`` desc.
+
+    The counter-package size is constrained to ``{N-1, N, N+1}``
+    where ``N`` is the offered-player count. Size ``0`` is skipped
+    when ``N == 1`` (that's what :func:`find_angles` is for).
+    """
+    warnings: list[str] = []
+
+    by_name: dict[str, dict[str, Any]] = {}
+    for row in players_array:
+        name = str(row.get("canonicalName") or row.get("displayName") or "")
+        if name and name not in by_name:
+            by_name[name] = row
+
+    # Resolve offer-side rows; drop any with missing values and warn.
+    offer_rows: list[dict[str, Any]] = []
+    missing: list[str] = []
+    for name in selected_player_names:
+        row = by_name.get(name)
+        if not row:
+            missing.append(name)
+            continue
+        pair = _value_pair(row)
+        if pair is None:
+            missing.append(name)
+            continue
+        offer_rows.append(row)
+    if missing:
+        warnings.append(
+            f"Dropped {len(missing)} player(s) from the offer that have no "
+            f"my-value or KTC value: {', '.join(missing[:5])}"
+            + (" …" if len(missing) > 5 else "")
+        )
+    if not offer_rows:
+        return {
+            "offer": {"players": [], "size": 0, "my_total": 0, "ktc_total": 0},
+            "candidates": [],
+            "warnings": warnings or ["No valid offer-side players."],
+        }
+
+    offer_my_total = sum(
+        _value_pair(r)[0] for r in offer_rows  # type: ignore[index]
+    )
+    offer_ktc_total = sum(
+        _value_pair(r)[1] for r in offer_rows  # type: ignore[index]
+    )
+    offer_size = len(offer_rows)
+
+    # Target sizes: N-1, N, N+1 — never less than 1.
+    target_sizes = sorted({max(1, offer_size - 1), offer_size, offer_size + 1})
+
+    # Build per-team candidate pool, filtered + capped.
+    my_team_name: str | None = None
+    teams_pool: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+    offer_name_set = {str(r.get("canonicalName") or "") for r in offer_rows}
+    for team in sleeper_teams:
+        owner = str(team.get("ownerId") or "")
+        if owner == selected_team_owner_id:
+            my_team_name = team.get("name")
+            continue
+        pool: list[dict[str, Any]] = []
+        for pname in team.get("players") or []:
+            pname = str(pname)
+            if pname in offer_name_set:
+                continue  # never suggest trading for your own player
+            row = by_name.get(pname)
+            if not row:
+                continue
+            pair = _value_pair(row)
+            if pair is None:
+                continue
+            my_v, ktc_v = pair
+            pool.append(
+                {
+                    "name": pname,
+                    "position": str(row.get("position") or ""),
+                    "my_value": my_v,
+                    "ktc_value": ktc_v,
+                }
+            )
+        pool.sort(key=lambda p: -p["my_value"])
+        pool = pool[:candidate_pool_per_team]
+        teams_pool.append((team, pool))
+
+    # Pre-compute numeric thresholds in absolute-value terms so the
+    # inner loop uses only arithmetic, no division.
+    min_my_total = offer_my_total * (1.0 + min_my_gain_pct / 100.0)
+    max_ktc_total = offer_ktc_total * (1.0 + max_ktc_gain_pct / 100.0)
+
+    candidates: list[dict[str, Any]] = []
+    for team, pool in teams_pool:
+        for size in target_sizes:
+            if len(pool) < size:
+                continue
+            for combo in combinations(pool, size):
+                my_sum = sum(p["my_value"] for p in combo)
+                if my_sum < min_my_total:
+                    continue
+                ktc_sum = sum(p["ktc_value"] for p in combo)
+                if ktc_sum > max_ktc_total:
+                    continue
+                my_gain_pct = 100.0 * (my_sum - offer_my_total) / offer_my_total
+                ktc_gain_pct = 100.0 * (ktc_sum - offer_ktc_total) / offer_ktc_total
+                candidates.append(
+                    {
+                        "team": team.get("name"),
+                        "owner_id": str(team.get("ownerId") or ""),
+                        "size": size,
+                        "players": [
+                            {
+                                "name": p["name"],
+                                "position": p["position"],
+                                "my_value": int(p["my_value"]),
+                                "ktc_value": int(p["ktc_value"]),
+                            }
+                            for p in combo
+                        ],
+                        "my_total": int(round(my_sum)),
+                        "ktc_total": int(round(ktc_sum)),
+                        "my_gain_pct": round(my_gain_pct, 2),
+                        "ktc_gain_pct": round(ktc_gain_pct, 2),
+                        "arb_score": round(my_gain_pct - ktc_gain_pct, 2),
+                    }
+                )
+
+    candidates.sort(key=lambda c: c["arb_score"], reverse=True)
+    candidates = candidates[: max(1, int(limit))]
+
+    offer_players = []
+    for r in offer_rows:
+        pair = _value_pair(r)
+        offer_players.append(
+            {
+                "name": str(r.get("canonicalName") or ""),
+                "position": str(r.get("position") or ""),
+                "my_value": int(pair[0]) if pair else 0,
+                "ktc_value": int(pair[1]) if pair else 0,
+            }
+        )
+
+    return {
+        "offer": {
+            "team": my_team_name,
+            "size": offer_size,
+            "players": offer_players,
+            "my_total": int(round(offer_my_total)),
+            "ktc_total": int(round(offer_ktc_total)),
+        },
+        "candidates": candidates,
+        "thresholds": {
+            "min_my_gain_pct": min_my_gain_pct,
+            "max_ktc_gain_pct": max_ktc_gain_pct,
+            "limit": limit,
+            "candidate_pool_per_team": candidate_pool_per_team,
+            "target_sizes": target_sizes,
         },
         "warnings": warnings,
     }

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -1,9 +1,9 @@
-"""Unit tests for src.trade.angle.find_angles."""
+"""Unit tests for src.trade.angle.find_angles / find_angle_packages."""
 from __future__ import annotations
 
 import pytest
 
-from src.trade.angle import find_angles
+from src.trade.angle import find_angle_packages, find_angles
 
 
 def _player(name, my_val, ktc_val, *, position="QB"):
@@ -141,3 +141,128 @@ def test_limit_caps_results():
         players.append(_player(f"Target {i}", 6000 + i, 5000))
     result = find_angles(players, "Jayden Daniels", "owner-a", teams, limit=5)
     assert len(result["candidates"]) == 5
+
+
+# ─── find_angle_packages ─────────────────────────────────────────────
+
+
+def _pkg_teams():
+    return [
+        {
+            "name": "Team A",
+            "ownerId": "owner-a",
+            "players": ["Jayden Daniels", "CeeDee Lamb", "Bench Guy"],
+        },
+        {
+            "name": "Team B",
+            "ownerId": "owner-b",
+            "players": [
+                "B Star",
+                "B Mid 1",
+                "B Mid 2",
+                "B Filler",
+            ],
+        },
+        {
+            "name": "Team C",
+            "ownerId": "owner-c",
+            "players": ["C Overpriced", "C Filler 1", "C Filler 2"],
+        },
+    ]
+
+
+def _pkg_players():
+    return [
+        _player("Jayden Daniels", my_val=5000, ktc_val=5000),
+        _player("CeeDee Lamb", my_val=5000, ktc_val=5000),
+        _player("Bench Guy", my_val=200, ktc_val=200),
+        # Team B: B Star is great, Mids are good. A 2-star package
+        # (Star + Mid1) should beat the Daniels + Lamb offer.
+        _player("B Star", my_val=6000, ktc_val=5100),
+        _player("B Mid 1", my_val=5500, ktc_val=4900),
+        _player("B Mid 2", my_val=5400, ktc_val=4800),
+        _player("B Filler", my_val=100, ktc_val=100),
+        # Team C: only overpriced targets on KTC — should be filtered.
+        _player("C Overpriced", my_val=6500, ktc_val=7500),
+        _player("C Filler 1", my_val=200, ktc_val=200),
+        _player("C Filler 2", my_val=100, ktc_val=100),
+    ]
+
+
+def test_packages_returns_counter_offers_sized_within_plus_minus_one():
+    offer = ["Jayden Daniels", "CeeDee Lamb"]  # N = 2
+    result = find_angle_packages(
+        _pkg_players(), offer, "owner-a", _pkg_teams(),
+    )
+    # Target sizes must be {1, 2, 3} — no 4 or higher.
+    target_sizes = set(result["thresholds"]["target_sizes"])
+    assert target_sizes == {1, 2, 3}
+    for c in result["candidates"]:
+        assert c["size"] in target_sizes
+
+
+def test_packages_offer_of_one_allows_sizes_one_and_two():
+    offer = ["Jayden Daniels"]  # N = 1 — size 0 collapses to 1
+    result = find_angle_packages(
+        _pkg_players(), offer, "owner-a", _pkg_teams(),
+    )
+    assert set(result["thresholds"]["target_sizes"]) == {1, 2}
+
+
+def test_packages_excludes_same_team_players_from_candidates():
+    offer = ["Jayden Daniels"]
+    result = find_angle_packages(
+        _pkg_players(), offer, "owner-a", _pkg_teams(),
+    )
+    owners = {c["owner_id"] for c in result["candidates"]}
+    assert "owner-a" not in owners  # never trade with yourself
+
+
+def test_packages_filters_on_ktc_gap_threshold():
+    offer = ["Jayden Daniels", "CeeDee Lamb"]
+    # Default max_ktc_gain_pct = 5. Team B's Star+Mid1 is KTC 10000
+    # (fair). Team C's Overpriced is KTC 7500 alone which is -25%
+    # versus offer's 10000 ktc — passes; good single-player counter.
+    result = find_angle_packages(
+        _pkg_players(), offer, "owner-a", _pkg_teams(),
+    )
+    # Every candidate satisfies KTC gap constraint.
+    offer_ktc = 10000
+    for c in result["candidates"]:
+        assert (c["ktc_total"] - offer_ktc) / offer_ktc * 100.0 <= 5.001
+
+
+def test_packages_sorts_by_arb_score_desc():
+    offer = ["Jayden Daniels", "CeeDee Lamb"]
+    result = find_angle_packages(
+        _pkg_players(), offer, "owner-a", _pkg_teams(),
+    )
+    scores = [c["arb_score"] for c in result["candidates"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_packages_offer_totals_are_correct():
+    offer = ["Jayden Daniels", "CeeDee Lamb"]
+    result = find_angle_packages(
+        _pkg_players(), offer, "owner-a", _pkg_teams(),
+    )
+    assert result["offer"]["my_total"] == 10000
+    assert result["offer"]["ktc_total"] == 10000
+    assert result["offer"]["size"] == 2
+
+
+def test_packages_unknown_offer_players_dropped_with_warning():
+    result = find_angle_packages(
+        _pkg_players(),
+        ["Jayden Daniels", "Ghost Player"],
+        "owner-a",
+        _pkg_teams(),
+    )
+    assert result["offer"]["size"] == 1
+    assert any("Ghost Player" in w for w in result["warnings"])
+
+
+def test_packages_empty_offer_returns_empty_result():
+    result = find_angle_packages(_pkg_players(), [], "owner-a", _pkg_teams())
+    assert result["candidates"] == []
+    assert result["offer"]["size"] == 0


### PR DESCRIPTION
## Summary

1. **Dropdown visibility**: team and roster picker options were rendering as near-invisible dark-on-dark text in Chromium on dark OS themes. Explicit option styling added.

2. **Multi-player offers**: \`/angle\` now supports building a trade from multiple of your players. Counter-packages come back sized within **±1 of your offer size** — offer 4 players, get 3-/4-/5-player counter-offers that win on your rankings and still fit KTC.

## How it works

- **Frontend**: team dropdown stays; player picker becomes a searchable checkbox grid with per-row values and a live "Your offer" bar showing running my-value + KTC totals. Results render as cards, one per package, showing each bundle's players, totals, and arb score.
- **Backend**: \`find_angle_packages()\` enumerates combinations of size {N-1, N, N+1} from each opposing team's top-25 players (by my-value), filters by min-my-gain% and max-KTC-gap% thresholds, and sorts by arbitrage score. POST /api/angle/packages endpoint + proxy route with 20s timeout for the larger searches.

## Test plan
- [x] 8 new tests covering size gating (±1), same-team exclusion, KTC filter, sort order, offer math, warnings, empty-offer handling
- [x] 1638 passing
- [x] Frontend \`npm run build\` clean
- [ ] Post-deploy: team dropdown readable; offering e.g. CeeDee Lamb + Mahomes surfaces 1-/2-/3-player counter packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)