### PR TITLE
Angle: cap top-N per team + value-sorted roster

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -13,6 +13,7 @@ import { useDynastyData } from "@/components/useDynastyData";
 const DEFAULT_MIN_MY = 5;
 const DEFAULT_MAX_KTC = 5;
 const DEFAULT_LIMIT = 50;
+const DEFAULT_PER_TEAM = 4;
 
 export default function AnglePage() {
   const { loading: dataLoading, error: dataError, rawData, rows } = useDynastyData();
@@ -48,6 +49,7 @@ export default function AnglePage() {
   const [minMyGainPct, setMinMyGainPct] = useState(DEFAULT_MIN_MY);
   const [maxKtcGainPct, setMaxKtcGainPct] = useState(DEFAULT_MAX_KTC);
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [perTeamLimit, setPerTeamLimit] = useState(DEFAULT_PER_TEAM);
   const [result, setResult] = useState(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
@@ -71,8 +73,13 @@ export default function AnglePage() {
           !rosterFilter.trim() ||
           name.toLowerCase().includes(rosterFilter.trim().toLowerCase()),
       )
-      .sort((a, b) => a.localeCompare(b));
-  }, [selectedTeam, rosterFilter]);
+      .sort((a, b) => {
+        const av = valueByName.get(a)?.my_value || 0;
+        const bv = valueByName.get(b)?.my_value || 0;
+        if (bv !== av) return bv - av;  // high value first
+        return a.localeCompare(b);        // ties → alphabetical
+      });
+  }, [selectedTeam, rosterFilter, valueByName]);
 
   // Reset offer whenever the team changes — an offer on the old team
   // isn't coherent with the new roster.
@@ -124,6 +131,7 @@ export default function AnglePage() {
           minMyGainPct: Number(minMyGainPct),
           maxKtcGainPct: Number(maxKtcGainPct),
           limit: Number(limit),
+          perTeamLimit: Number(perTeamLimit),
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -216,7 +224,21 @@ export default function AnglePage() {
             />
           </label>
           <label className="angle-field">
-            <span className="muted">Results limit</span>
+            <span className="muted">
+              Max per team{" "}
+              <span className="angle-field-hint">(top N from each opposing roster)</span>
+            </span>
+            <input
+              type="number"
+              value={perTeamLimit}
+              min="1"
+              max="50"
+              onChange={(e) => setPerTeamLimit(e.target.value)}
+              disabled={busy}
+            />
+          </label>
+          <label className="angle-field">
+            <span className="muted">Total results</span>
             <input
               type="number"
               value={limit}

--- a/server.py
+++ b/server.py
@@ -2328,10 +2328,11 @@ async def post_angle_packages(request: Request):
         max_ktc = float(body.get("maxKtcGainPct", 5.0))
         limit = int(body.get("limit", 50))
         pool = int(body.get("candidatePoolPerTeam", 25))
+        per_team = int(body.get("perTeamLimit", 4))
     except (TypeError, ValueError):
         return JSONResponse(
             status_code=400,
-            content={"error": "minMyGainPct, maxKtcGainPct, limit, candidatePoolPerTeam must be numeric."},
+            content={"error": "numeric params must be numeric."},
         )
 
     from src.trade.angle import find_angle_packages
@@ -2346,6 +2347,7 @@ async def post_angle_packages(request: Request):
             max_ktc_gain_pct=max_ktc,
             limit=limit,
             candidate_pool_per_team=pool,
+            per_team_limit=per_team,
         )
     except Exception as exc:  # noqa: BLE001
         log.error(f"Angle packages failed: {exc}")

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -202,6 +202,7 @@ def find_angle_packages(
     max_ktc_gain_pct: float = 5.0,
     limit: int = 50,
     candidate_pool_per_team: int = 25,
+    per_team_limit: int = 4,
 ) -> dict[str, Any]:
     """Find multi-player counter-packages for a user-built offer.
 
@@ -218,6 +219,11 @@ def find_angle_packages(
         opposing team when enumerating combinations. Caps the
         combinatorial explosion; 25 × size-5 ≈ 53k combos per team
         which completes comfortably inside a request.
+    per_team_limit
+        Max packages kept per opposing team (by arb score desc)
+        before the global ``limit`` is applied. Default 4 — keeps
+        one team from swamping the results with 50 variations of
+        the same trade. Set to a large number to disable.
 
     Returns
     -------
@@ -350,7 +356,23 @@ def find_angle_packages(
                     }
                 )
 
+    # Per-team cap first — prevents a single opposing roster from
+    # swamping the results with 50 near-identical variations of the
+    # same trade. Sort each team's candidates by arb_score desc, keep
+    # the top ``per_team_limit``, then apply the global cap across
+    # what's left.
     candidates.sort(key=lambda c: c["arb_score"], reverse=True)
+    if per_team_limit and per_team_limit > 0:
+        kept: list[dict[str, Any]] = []
+        seen_per_team: dict[str, int] = {}
+        for c in candidates:
+            owner_id = c.get("owner_id") or c.get("team") or ""
+            count = seen_per_team.get(owner_id, 0)
+            if count >= per_team_limit:
+                continue
+            kept.append(c)
+            seen_per_team[owner_id] = count + 1
+        candidates = kept
     candidates = candidates[: max(1, int(limit))]
 
     offer_players = []
@@ -379,6 +401,7 @@ def find_angle_packages(
             "max_ktc_gain_pct": max_ktc_gain_pct,
             "limit": limit,
             "candidate_pool_per_team": candidate_pool_per_team,
+            "per_team_limit": per_team_limit,
             "target_sizes": target_sizes,
         },
         "warnings": warnings,

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -266,3 +266,62 @@ def test_packages_empty_offer_returns_empty_result():
     result = find_angle_packages(_pkg_players(), [], "owner-a", _pkg_teams())
     assert result["candidates"] == []
     assert result["offer"]["size"] == 0
+
+
+def test_packages_per_team_limit_caps_results_per_team():
+    """One opposing team shouldn't fill the results with 50 slight
+    variations of the same trade. per_team_limit caps each team's
+    contribution before the global limit is applied."""
+    # Team A owns the offer. Team B has 10 good players — lots of
+    # combinations will qualify. Team C has 1 good player.
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {
+            "name": "Team B",
+            "ownerId": "owner-b",
+            "players": [f"B {i}" for i in range(10)],
+        },
+        {
+            "name": "Team C",
+            "ownerId": "owner-c",
+            "players": ["C Star"],
+        },
+    ]
+    players = [_player("Jayden Daniels", my_val=5000, ktc_val=5000)]
+    for i in range(10):
+        # Each B player is +20% my-value, -0% KTC — all qualify.
+        players.append(_player(f"B {i}", my_val=6000 + i * 10, ktc_val=5000))
+    players.append(_player("C Star", my_val=6500, ktc_val=5000))
+
+    # Default per_team_limit = 4
+    result = find_angle_packages(players, offer, "owner-a", teams)
+    # Count how many from each team.
+    counts: dict[str, int] = {}
+    for c in result["candidates"]:
+        counts[c["owner_id"]] = counts.get(c["owner_id"], 0) + 1
+    # Team B should be capped at 4 despite having many qualifying
+    # combinations. Team C has only 1 player so its size-1 count is 1.
+    assert counts.get("owner-b", 0) <= 4
+    assert counts.get("owner-c", 0) <= 4
+
+
+def test_packages_per_team_limit_disabled_by_zero_or_negative():
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {
+            "name": "Team B",
+            "ownerId": "owner-b",
+            "players": [f"B {i}" for i in range(10)],
+        },
+    ]
+    players = [_player("Jayden Daniels", my_val=5000, ktc_val=5000)]
+    for i in range(10):
+        players.append(_player(f"B {i}", my_val=6000 + i * 10, ktc_val=5000))
+    # per_team_limit=0 disables the cap — lots of Team B candidates.
+    result = find_angle_packages(
+        players, offer, "owner-a", teams, per_team_limit=0, limit=100,
+    )
+    team_b_count = sum(1 for c in result["candidates"] if c["owner_id"] == "owner-b")
+    assert team_b_count > 4


### PR DESCRIPTION
## Summary

Two refinements driven by user feedback:

1. **Per-team cap** on packages — default top 4 from each opposing roster before the global \`limit\` applies. Prevents one team's 50 near-identical variations from pushing every other team out of the results. Exposed as a **Max per team** input in the UI (0 disables).
2. **Value-sorted roster** — the selected team's checklist sorts by calibrated my-value descending (ties alphabetical) so tradable names sit at the top.

## Test plan
- [x] 2 new tests: per-team cap kicks in, per_team_limit=0 disables it
- [x] 1640 passing
- [x] Frontend \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)