### PR TITLE
Angle: position filters + min-player-value slider

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -14,6 +14,8 @@ const DEFAULT_MIN_MY = 5;
 const DEFAULT_MAX_KTC = 5;
 const DEFAULT_LIMIT = 50;
 const DEFAULT_PER_TEAM = 4;
+const DEFAULT_MIN_PLAYER_VALUE = 3000;
+const POSITION_FILTERS = ["QB", "RB", "WR", "TE", "DL", "LB", "DB"];
 
 export default function AnglePage() {
   const { loading: dataLoading, error: dataError, rawData, rows } = useDynastyData();
@@ -50,6 +52,8 @@ export default function AnglePage() {
   const [maxKtcGainPct, setMaxKtcGainPct] = useState(DEFAULT_MAX_KTC);
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [perTeamLimit, setPerTeamLimit] = useState(DEFAULT_PER_TEAM);
+  const [positionFilters, setPositionFilters] = useState(() => new Set());
+  const [minPlayerValue, setMinPlayerValue] = useState(DEFAULT_MIN_PLAYER_VALUE);
   const [result, setResult] = useState(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
@@ -113,6 +117,15 @@ export default function AnglePage() {
     });
   }
 
+  function togglePosition(pos) {
+    setPositionFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(pos)) next.delete(pos);
+      else next.add(pos);
+      return next;
+    });
+  }
+
   async function findAngles() {
     if (!ownerId || offerList.length === 0) {
       setErr("Pick a team and check at least one player.");
@@ -132,6 +145,8 @@ export default function AnglePage() {
           maxKtcGainPct: Number(maxKtcGainPct),
           limit: Number(limit),
           perTeamLimit: Number(perTeamLimit),
+          minPlayerMyValue: Number(minPlayerValue),
+          positions: Array.from(positionFilters),
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -262,6 +277,76 @@ export default function AnglePage() {
             {err}
           </p>
         )}
+      </section>
+
+      <section className="card angle-filter-card">
+        <div className="angle-filter-head">
+          <strong>Counter-package filters</strong>
+          <span className="muted">
+            Narrow the candidates the search considers from other teams.
+          </span>
+        </div>
+        <div className="angle-filter-row">
+          <div className="angle-filter-group">
+            <span className="muted">Positions wanted</span>
+            <div className="angle-pill-row">
+              {POSITION_FILTERS.map((pos) => {
+                const active = positionFilters.has(pos);
+                return (
+                  <button
+                    key={pos}
+                    type="button"
+                    className={`angle-pill ${active ? "angle-pill-active" : ""}`}
+                    onClick={() => togglePosition(pos)}
+                    disabled={busy}
+                    title={
+                      active
+                        ? `Only include ${pos}s in counter-packages`
+                        : `Click to require ${pos}`
+                    }
+                  >
+                    {pos}
+                  </button>
+                );
+              })}
+              {positionFilters.size > 0 && (
+                <button
+                  type="button"
+                  className="angle-pill angle-pill-clear"
+                  onClick={() => setPositionFilters(new Set())}
+                  disabled={busy}
+                  title="Clear — accept all positions"
+                >
+                  × clear
+                </button>
+              )}
+            </div>
+            <span className="angle-field-hint">
+              Leave empty to allow any position.
+            </span>
+          </div>
+          <div className="angle-filter-group">
+            <span className="muted">
+              Minimum value per target player:{" "}
+              <strong>{Number(minPlayerValue).toLocaleString()}</strong>
+            </span>
+            <input
+              type="range"
+              min="0"
+              max="9999"
+              step="100"
+              value={minPlayerValue}
+              onChange={(e) => setMinPlayerValue(Number(e.target.value))}
+              disabled={busy}
+              className="angle-slider"
+            />
+            <span className="angle-field-hint">
+              Each individual player in a counter-package must have a
+              my-value at or above this. Default 3,000 filters out
+              deep-bench filler.
+            </span>
+          </div>
+        </div>
       </section>
 
       <section className="card angle-offer-bar">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2584,3 +2584,50 @@ tr:hover .sticky-name {
 }
 .angle-package-players li { display: flex; gap: 6px; flex-wrap: wrap; }
 .angle-package-totals { font-size: 0.8rem; }
+
+/* Angle: counter-package filter card */
+.angle-filter-card { display: flex; flex-direction: column; gap: var(--space-sm); }
+.angle-filter-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+.angle-filter-row {
+  display: grid;
+  grid-template-columns: minmax(240px, 1.2fr) minmax(220px, 1fr);
+  gap: var(--space-md);
+  align-items: start;
+}
+@media (max-width: 720px) {
+  .angle-filter-row { grid-template-columns: 1fr; }
+}
+.angle-filter-group { display: flex; flex-direction: column; gap: 6px; }
+.angle-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.angle-pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  min-width: 42px;
+}
+.angle-pill:hover { background: var(--surface-hover, #1e293b); }
+.angle-pill-active {
+  background: var(--accent, #2563eb);
+  border-color: var(--accent, #2563eb);
+  color: #fff;
+}
+.angle-pill-clear { font-weight: 400; opacity: 0.8; }
+.angle-slider {
+  width: 100%;
+  max-width: 360px;
+  accent-color: var(--accent, #2563eb);
+}

--- a/server.py
+++ b/server.py
@@ -2329,11 +2329,16 @@ async def post_angle_packages(request: Request):
         limit = int(body.get("limit", 50))
         pool = int(body.get("candidatePoolPerTeam", 25))
         per_team = int(body.get("perTeamLimit", 4))
+        min_player = float(body.get("minPlayerMyValue", 0.0))
     except (TypeError, ValueError):
         return JSONResponse(
             status_code=400,
             content={"error": "numeric params must be numeric."},
         )
+    positions_req = body.get("positions") or []
+    if not isinstance(positions_req, list):
+        positions_req = []
+    positions_req = [str(p).strip() for p in positions_req if str(p).strip()]
 
     from src.trade.angle import find_angle_packages
 
@@ -2348,6 +2353,8 @@ async def post_angle_packages(request: Request):
             limit=limit,
             candidate_pool_per_team=pool,
             per_team_limit=per_team,
+            positions=positions_req or None,
+            min_player_my_value=min_player,
         )
     except Exception as exc:  # noqa: BLE001
         log.error(f"Angle packages failed: {exc}")

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -203,6 +203,8 @@ def find_angle_packages(
     limit: int = 50,
     candidate_pool_per_team: int = 25,
     per_team_limit: int = 4,
+    positions: list[str] | None = None,
+    min_player_my_value: float = 0.0,
 ) -> dict[str, Any]:
     """Find multi-player counter-packages for a user-built offer.
 
@@ -224,6 +226,14 @@ def find_angle_packages(
         before the global ``limit`` is applied. Default 4 — keeps
         one team from swamping the results with 50 variations of
         the same trade. Set to a large number to disable.
+    positions
+        When non-empty, restrict the candidate pool to players whose
+        ``position`` matches one of these tokens (case-insensitive).
+        ``None`` or empty list = any position.
+    min_player_my_value
+        Minimum ``rankDerivedValue`` a player must have to be
+        considered in the candidate pool. Caller uses this to say
+        "don't suggest filler-depth guys in my counter-package."
 
     Returns
     -------
@@ -282,6 +292,14 @@ def find_angle_packages(
     # Target sizes: N-1, N, N+1 — never less than 1.
     target_sizes = sorted({max(1, offer_size - 1), offer_size, offer_size + 1})
 
+    # Normalise position filter.
+    position_filter: set[str] | None = None
+    if positions:
+        position_filter = {str(p).strip().upper() for p in positions if str(p).strip()}
+        if not position_filter:
+            position_filter = None
+    min_my_value_floor = max(0.0, float(min_player_my_value or 0.0))
+
     # Build per-team candidate pool, filtered + capped.
     my_team_name: str | None = None
     teams_pool: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
@@ -303,6 +321,12 @@ def find_angle_packages(
             if pair is None:
                 continue
             my_v, ktc_v = pair
+            # Per-player filters: position allow-list and my-value floor.
+            row_pos = str(row.get("position") or "").strip().upper()
+            if position_filter is not None and row_pos not in position_filter:
+                continue
+            if my_v < min_my_value_floor:
+                continue
             pool.append(
                 {
                     "name": pname,
@@ -403,6 +427,8 @@ def find_angle_packages(
             "candidate_pool_per_team": candidate_pool_per_team,
             "per_team_limit": per_team_limit,
             "target_sizes": target_sizes,
+            "positions": sorted(position_filter) if position_filter else [],
+            "min_player_my_value": int(min_my_value_floor),
         },
         "warnings": warnings,
     }

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -325,3 +325,99 @@ def test_packages_per_team_limit_disabled_by_zero_or_negative():
     )
     team_b_count = sum(1 for c in result["candidates"] if c["owner_id"] == "owner-b")
     assert team_b_count > 4
+
+
+def test_packages_position_filter_restricts_candidates():
+    """When ``positions`` is given, only players at those positions
+    can appear in counter-packages."""
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {
+            "name": "Team B",
+            "ownerId": "owner-b",
+            "players": ["B WR", "B RB", "B TE"],
+        },
+    ]
+    players = [
+        _player("Jayden Daniels", my_val=5000, ktc_val=5000, position="QB"),
+        _player("B WR", my_val=6000, ktc_val=5000, position="WR"),
+        _player("B RB", my_val=6000, ktc_val=5000, position="RB"),
+        _player("B TE", my_val=6000, ktc_val=5000, position="TE"),
+    ]
+    # Only want WRs back.
+    result = find_angle_packages(
+        players, offer, "owner-a", teams, positions=["WR"],
+    )
+    pos_seen = {p["position"] for c in result["candidates"] for p in c["players"]}
+    assert pos_seen == {"WR"}
+    # Empty position filter = any position accepted.
+    result2 = find_angle_packages(
+        players, offer, "owner-a", teams, positions=[],
+    )
+    pos_seen2 = {p["position"] for c in result2["candidates"] for p in c["players"]}
+    assert pos_seen2 == {"WR", "RB", "TE"}
+
+
+def test_packages_position_filter_case_insensitive():
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["B WR"]},
+    ]
+    players = [
+        _player("Jayden Daniels", 5000, 5000, position="QB"),
+        _player("B WR", 6000, 5000, position="WR"),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams, positions=["wr"],
+    )
+    assert any(p["name"] == "B WR" for c in result["candidates"] for p in c["players"])
+
+
+def test_packages_min_player_my_value_filters_filler():
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {
+            "name": "Team B",
+            "ownerId": "owner-b",
+            "players": ["B Star", "B Filler"],
+        },
+    ]
+    players = [
+        _player("Jayden Daniels", my_val=5000, ktc_val=5000),
+        _player("B Star", my_val=6000, ktc_val=5000),
+        _player("B Filler", my_val=500, ktc_val=500),
+    ]
+    # Default 3000 floor — B Filler's my_value=500 is excluded.
+    result = find_angle_packages(
+        players, offer, "owner-a", teams, min_player_my_value=3000,
+    )
+    names = {p["name"] for c in result["candidates"] for p in c["players"]}
+    assert "B Filler" not in names
+    # Zero floor — Filler can come along.
+    result2 = find_angle_packages(
+        players, offer, "owner-a", teams, min_player_my_value=0,
+    )
+    names2 = {p["name"] for c in result2["candidates"] for p in c["players"]}
+    assert "B Star" in names2  # at minimum
+
+
+def test_packages_filters_surfaced_in_thresholds():
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["B WR"]},
+    ]
+    players = [
+        _player("Jayden Daniels", 5000, 5000, position="QB"),
+        _player("B WR", 6000, 5000, position="WR"),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        positions=["WR", "TE"], min_player_my_value=2500,
+    )
+    th = result["thresholds"]
+    assert th["positions"] == ["TE", "WR"]  # sorted
+    assert th["min_player_my_value"] == 2500


### PR DESCRIPTION
## Summary

Two filters on the counter-package search:

1. **Position pills** (QB / RB / WR / TE / DL / LB / DB) — click to restrict candidates. Leave all off for no restriction.
2. **Minimum value per target player** — slider, default **3,000**. Each individual player in a candidate package must have \`rankDerivedValue\` ≥ this floor. Filters out deep-bench filler from multi-player counter-offers.

## Test plan
- [x] 4 new tests: position filter narrows; empty list = any; case-insensitive; value floor drops filler; thresholds echoed in response
- [x] 1644 passing
- [x] Frontend \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)