### PR TITLE
Angle: target-team picker + seed players constructor

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -54,6 +54,11 @@ export default function AnglePage() {
   const [perTeamLimit, setPerTeamLimit] = useState(DEFAULT_PER_TEAM);
   const [positionFilters, setPositionFilters] = useState(() => new Set());
   const [minPlayerValue, setMinPlayerValue] = useState(DEFAULT_MIN_PLAYER_VALUE);
+  // Up to 2 opposing teams the user explicitly wants to trade with.
+  const [targetOwners, setTargetOwners] = useState(["", ""]);
+  // Seed players keyed by ownerId — players that MUST appear in
+  // every counter-package when a target team is selected.
+  const [seedsByOwner, setSeedsByOwner] = useState({});
   const [result, setResult] = useState(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
@@ -126,6 +131,40 @@ export default function AnglePage() {
     });
   }
 
+  function setTargetOwnerAt(slot, value) {
+    setTargetOwners((prev) => {
+      const next = [...prev];
+      next[slot] = value;
+      return next;
+    });
+  }
+
+  function toggleSeed(ownerIdKey, playerName) {
+    setSeedsByOwner((prev) => {
+      const current = new Set(prev[ownerIdKey] || []);
+      if (current.has(playerName)) current.delete(playerName);
+      else current.add(playerName);
+      return { ...prev, [ownerIdKey]: current };
+    });
+  }
+
+  const activeTargetOwnerIds = useMemo(
+    () =>
+      targetOwners
+        .filter((id) => id && id !== ownerId)
+        // Deduplicate so selecting the same team twice doesn't double-count.
+        .reduce((acc, id) => (acc.includes(id) ? acc : [...acc, id]), []),
+    [targetOwners, ownerId],
+  );
+
+  const activeSeedNames = useMemo(() => {
+    const out = [];
+    for (const id of activeTargetOwnerIds) {
+      for (const name of seedsByOwner[id] || []) out.push(name);
+    }
+    return out;
+  }, [activeTargetOwnerIds, seedsByOwner]);
+
   async function findAngles() {
     if (!ownerId || offerList.length === 0) {
       setErr("Pick a team and check at least one player.");
@@ -147,6 +186,8 @@ export default function AnglePage() {
           perTeamLimit: Number(perTeamLimit),
           minPlayerMyValue: Number(minPlayerValue),
           positions: Array.from(positionFilters),
+          targetTeamOwnerIds: activeTargetOwnerIds,
+          seedPlayerNames: activeSeedNames,
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -346,6 +387,102 @@ export default function AnglePage() {
               deep-bench filler.
             </span>
           </div>
+        </div>
+      </section>
+
+      <section className="card angle-targets-card">
+        <div className="angle-filter-head">
+          <strong>Trade with specific teams (optional)</strong>
+          <span className="muted">
+            Pick up to 2 opposing teams. Check off any "must-have" players
+            from their rosters and the search will build counter-packages
+            that include those seeds and fill the rest from the selected
+            teams' top players.
+          </span>
+        </div>
+        <div className="angle-targets-row">
+          {[0, 1].map((slot) => {
+            const selectedId = targetOwners[slot];
+            const otherId = targetOwners[1 - slot];
+            const team = teams.find(
+              (t) => String(t.ownerId || "") === selectedId,
+            );
+            const roster = team?.players || [];
+            const seedsForTeam = new Set(seedsByOwner[selectedId] || []);
+            return (
+              <div key={slot} className="angle-target-slot">
+                <label className="angle-field">
+                  <span className="muted">Team {slot + 1}</span>
+                  <select
+                    value={selectedId}
+                    onChange={(e) => setTargetOwnerAt(slot, e.target.value)}
+                    disabled={busy}
+                  >
+                    <option value="">(any team)</option>
+                    {teams
+                      .filter(
+                        (t) =>
+                          String(t.ownerId || "") !== ownerId &&
+                          String(t.ownerId || "") !== otherId,
+                      )
+                      .map((t) => (
+                        <option
+                          key={t.ownerId}
+                          value={String(t.ownerId || "")}
+                        >
+                          {t.name}
+                        </option>
+                      ))}
+                  </select>
+                </label>
+                {selectedId && (
+                  <div className="angle-target-seeds">
+                    <div className="muted">
+                      Seed players from <strong>{team?.name}</strong>{" "}
+                      <span className="angle-field-hint">
+                        (required in every counter-package)
+                      </span>
+                    </div>
+                    <div className="angle-target-seed-grid">
+                      {[...roster]
+                        .sort((a, b) => {
+                          const av = valueByName.get(a)?.my_value || 0;
+                          const bv = valueByName.get(b)?.my_value || 0;
+                          return bv - av || a.localeCompare(b);
+                        })
+                        .map((name) => {
+                          const info = valueByName.get(name);
+                          const checked = seedsForTeam.has(name);
+                          return (
+                            <label
+                              key={name}
+                              className={`angle-roster-row ${
+                                checked ? "angle-roster-checked" : ""
+                              }`}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={() => toggleSeed(selectedId, name)}
+                                disabled={busy}
+                              />
+                              <span className="angle-roster-name">{name}</span>
+                              {info && (
+                                <span className="muted angle-roster-meta">
+                                  {info.position || "—"} · my{" "}
+                                  {info.my_value.toLocaleString()} / ktc{" "}
+                                  {info.ktc_value.toLocaleString()}
+                                </span>
+                              )}
+                            </label>
+                          );
+                        })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       </section>
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2631,3 +2631,39 @@ tr:hover .sticky-name {
   max-width: 360px;
   accent-color: var(--accent, #2563eb);
 }
+
+/* Angle: target-teams + per-team seed rosters */
+.angle-targets-card { display: flex; flex-direction: column; gap: var(--space-sm); }
+.angle-targets-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-md);
+}
+.angle-target-slot { display: flex; flex-direction: column; gap: var(--space-sm); }
+.angle-target-seeds {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.angle-target-seed-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  background: var(--surface-base, rgba(0, 0, 0, 0.1));
+}
+/* Explicit option styling for the new dropdowns — same as the
+   existing team picker. */
+.angle-target-slot select option {
+  background: #11182a;
+  color: var(--text-primary);
+}
+.angle-target-slot select option:checked,
+.angle-target-slot select option:hover {
+  background: var(--accent, #2563eb);
+  color: #fff;
+}

--- a/server.py
+++ b/server.py
@@ -2340,6 +2340,16 @@ async def post_angle_packages(request: Request):
         positions_req = []
     positions_req = [str(p).strip() for p in positions_req if str(p).strip()]
 
+    target_teams_req = body.get("targetTeamOwnerIds") or []
+    if not isinstance(target_teams_req, list):
+        target_teams_req = []
+    target_teams_req = [str(t).strip() for t in target_teams_req if str(t).strip()]
+
+    seeds_req = body.get("seedPlayerNames") or []
+    if not isinstance(seeds_req, list):
+        seeds_req = []
+    seeds_req = [str(s).strip() for s in seeds_req if str(s).strip()]
+
     from src.trade.angle import find_angle_packages
 
     try:
@@ -2355,6 +2365,8 @@ async def post_angle_packages(request: Request):
             per_team_limit=per_team,
             positions=positions_req or None,
             min_player_my_value=min_player,
+            target_team_owner_ids=target_teams_req or None,
+            seed_player_names=seeds_req or None,
         )
     except Exception as exc:  # noqa: BLE001
         log.error(f"Angle packages failed: {exc}")

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -205,6 +205,8 @@ def find_angle_packages(
     per_team_limit: int = 4,
     positions: list[str] | None = None,
     min_player_my_value: float = 0.0,
+    target_team_owner_ids: list[str] | None = None,
+    seed_player_names: list[str] | None = None,
 ) -> dict[str, Any]:
     """Find multi-player counter-packages for a user-built offer.
 
@@ -344,41 +346,169 @@ def find_angle_packages(
     min_my_total = offer_my_total * (1.0 + min_my_gain_pct / 100.0)
     max_ktc_total = offer_ktc_total * (1.0 + max_ktc_gain_pct / 100.0)
 
+    # Normalise target-team + seed inputs for constructed-package mode.
+    target_ids: set[str] = {
+        str(t).strip() for t in (target_team_owner_ids or []) if str(t).strip()
+    }
+    seed_names_requested = [
+        str(n).strip() for n in (seed_player_names or []) if str(n).strip()
+    ]
+
     candidates: list[dict[str, Any]] = []
-    for team, pool in teams_pool:
-        for size in target_sizes:
-            if len(pool) < size:
+    seed_names_set: set[str] = set()
+
+    def _row_to_pool_entry(row: dict[str, Any]) -> dict[str, Any] | None:
+        pair = _value_pair(row)
+        if pair is None:
+            return None
+        my_v, ktc_v = pair
+        return {
+            "name": str(row.get("canonicalName") or row.get("displayName") or ""),
+            "position": str(row.get("position") or ""),
+            "my_value": my_v,
+            "ktc_value": ktc_v,
+        }
+
+    def _make_candidate(
+        combo: tuple[dict[str, Any], ...],
+        team_label: str,
+        owner_id_label: str,
+    ) -> dict[str, Any] | None:
+        my_sum = sum(p["my_value"] for p in combo)
+        if my_sum < min_my_total:
+            return None
+        ktc_sum = sum(p["ktc_value"] for p in combo)
+        if ktc_sum > max_ktc_total:
+            return None
+        my_gain_pct = 100.0 * (my_sum - offer_my_total) / offer_my_total
+        ktc_gain_pct = 100.0 * (ktc_sum - offer_ktc_total) / offer_ktc_total
+        return {
+            "team": team_label,
+            "owner_id": owner_id_label,
+            "size": len(combo),
+            "players": [
+                {
+                    "name": p["name"],
+                    "position": p["position"],
+                    "my_value": int(p["my_value"]),
+                    "ktc_value": int(p["ktc_value"]),
+                }
+                for p in combo
+            ],
+            "my_total": int(round(my_sum)),
+            "ktc_total": int(round(ktc_sum)),
+            "my_gain_pct": round(my_gain_pct, 2),
+            "ktc_gain_pct": round(ktc_gain_pct, 2),
+            "arb_score": round(my_gain_pct - ktc_gain_pct, 2),
+        }
+
+    if target_ids:
+        # ── Constructed-package mode ─────────────────────────────
+        # User picked 1 or 2 specific opposing teams. Pool is the
+        # union of those teams' candidates; all seed players are
+        # required in every result (seeds bypass position/value
+        # filters because the user explicitly asked for them).
+        target_teams: list[dict[str, Any]] = []
+        combined_pool_by_name: dict[str, dict[str, Any]] = {}
+        owner_by_pool_name: dict[str, str] = {}
+        target_team_names: list[str] = []
+        target_team_owners: list[str] = []
+        for team, pool in teams_pool:
+            owner = str(team.get("ownerId") or "")
+            if owner not in target_ids:
                 continue
-            for combo in combinations(pool, size):
-                my_sum = sum(p["my_value"] for p in combo)
-                if my_sum < min_my_total:
+            target_teams.append(team)
+            target_team_names.append(str(team.get("name") or ""))
+            target_team_owners.append(owner)
+            for entry in pool:
+                combined_pool_by_name[entry["name"]] = entry
+                owner_by_pool_name[entry["name"]] = owner
+
+        # Resolve seeds. Seeds must be owned by one of the target
+        # teams and bypass the filter pool — they're mandatory.
+        seed_entries: list[dict[str, Any]] = []
+        missing_seeds: list[str] = []
+        wrong_team_seeds: list[str] = []
+        for sname in seed_names_requested:
+            row = by_name.get(sname)
+            if not row:
+                missing_seeds.append(sname)
+                continue
+            # Find which team owns this seed.
+            owner_of_seed = None
+            for team in target_teams:
+                if sname in (team.get("players") or []):
+                    owner_of_seed = str(team.get("ownerId") or "")
+                    break
+            if owner_of_seed is None:
+                wrong_team_seeds.append(sname)
+                continue
+            entry = _row_to_pool_entry(row)
+            if entry is None:
+                missing_seeds.append(sname)
+                continue
+            seed_entries.append(entry)
+            # Ensure seeds are present in the combined pool so they
+            # can participate in filter-respecting combo selection
+            # (but seeds themselves bypass the filter cuts above).
+            combined_pool_by_name.setdefault(entry["name"], entry)
+            owner_by_pool_name.setdefault(entry["name"], owner_of_seed)
+        if missing_seeds:
+            warnings.append(
+                f"Dropped {len(missing_seeds)} seed player(s) with missing data: "
+                f"{', '.join(missing_seeds[:5])}"
+                + (" …" if len(missing_seeds) > 5 else "")
+            )
+        if wrong_team_seeds:
+            warnings.append(
+                f"Ignored {len(wrong_team_seeds)} seed player(s) not on any selected "
+                f"target team: {', '.join(wrong_team_seeds[:5])}"
+                + (" …" if len(wrong_team_seeds) > 5 else "")
+            )
+
+        seed_names_set = {e["name"] for e in seed_entries}
+        non_seed_pool = [
+            e for e in combined_pool_by_name.values() if e["name"] not in seed_names_set
+        ]
+        # Sort non-seed pool by my_value for deterministic order.
+        non_seed_pool.sort(key=lambda p: -p["my_value"])
+
+        team_label = " + ".join(target_team_names) or "(selected teams)"
+        owner_label = "+".join(target_team_owners) or ",".join(sorted(target_ids))
+
+        for size in target_sizes:
+            if size < len(seed_entries):
+                continue  # can't fit all required seeds
+            free_slots = size - len(seed_entries)
+            if free_slots == 0:
+                combo = tuple(seed_entries)
+                cand = _make_candidate(combo, team_label, owner_label)
+                if cand is not None:
+                    candidates.append(cand)
+                continue
+            if len(non_seed_pool) < free_slots:
+                continue
+            for fillers in combinations(non_seed_pool, free_slots):
+                combo = tuple(seed_entries) + fillers
+                cand = _make_candidate(combo, team_label, owner_label)
+                if cand is not None:
+                    candidates.append(cand)
+    else:
+        # ── Default mode: one team per candidate package ──
+        # This is the existing behaviour — each opposing team
+        # contributes its own packages independently.
+        for team, pool in teams_pool:
+            for size in target_sizes:
+                if len(pool) < size:
                     continue
-                ktc_sum = sum(p["ktc_value"] for p in combo)
-                if ktc_sum > max_ktc_total:
-                    continue
-                my_gain_pct = 100.0 * (my_sum - offer_my_total) / offer_my_total
-                ktc_gain_pct = 100.0 * (ktc_sum - offer_ktc_total) / offer_ktc_total
-                candidates.append(
-                    {
-                        "team": team.get("name"),
-                        "owner_id": str(team.get("ownerId") or ""),
-                        "size": size,
-                        "players": [
-                            {
-                                "name": p["name"],
-                                "position": p["position"],
-                                "my_value": int(p["my_value"]),
-                                "ktc_value": int(p["ktc_value"]),
-                            }
-                            for p in combo
-                        ],
-                        "my_total": int(round(my_sum)),
-                        "ktc_total": int(round(ktc_sum)),
-                        "my_gain_pct": round(my_gain_pct, 2),
-                        "ktc_gain_pct": round(ktc_gain_pct, 2),
-                        "arb_score": round(my_gain_pct - ktc_gain_pct, 2),
-                    }
-                )
+                for combo in combinations(pool, size):
+                    cand = _make_candidate(
+                        combo,
+                        str(team.get("name") or ""),
+                        str(team.get("ownerId") or ""),
+                    )
+                    if cand is not None:
+                        candidates.append(cand)
 
     # Per-team cap first — prevents a single opposing roster from
     # swamping the results with 50 near-identical variations of the
@@ -429,6 +559,8 @@ def find_angle_packages(
             "target_sizes": target_sizes,
             "positions": sorted(position_filter) if position_filter else [],
             "min_player_my_value": int(min_my_value_floor),
+            "target_team_owner_ids": sorted(target_ids) if target_ids else [],
+            "seed_player_names": sorted(seed_names_set) if target_ids else [],
         },
         "warnings": warnings,
     }

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -421,3 +421,131 @@ def test_packages_filters_surfaced_in_thresholds():
     th = result["thresholds"]
     assert th["positions"] == ["TE", "WR"]  # sorted
     assert th["min_player_my_value"] == 2500
+
+
+def test_packages_target_teams_restrict_candidates():
+    """When target_team_owner_ids is non-empty, candidates come only
+    from those teams (and the result package carries a combined
+    team label)."""
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["B Star"]},
+        {"name": "Team C", "ownerId": "owner-c", "players": ["C Star"]},
+    ]
+    players = [
+        _player("Jayden Daniels", 5000, 5000),
+        _player("B Star", 6000, 5000),
+        _player("C Star", 6000, 5000),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        target_team_owner_ids=["owner-b"],
+    )
+    # Every candidate has owner_id == "owner-b" (our single target).
+    assert all(c["owner_id"] == "owner-b" for c in result["candidates"])
+    names = {p["name"] for c in result["candidates"] for p in c["players"]}
+    assert "C Star" not in names  # Team C excluded by target filter
+
+
+def test_packages_seed_player_must_appear_in_every_candidate():
+    """Seeded players are required in every counter-package."""
+    offer = ["Jayden Daniels", "CeeDee Lamb"]  # N = 2
+    teams = [
+        {
+            "name": "Team A", "ownerId": "owner-a",
+            "players": ["Jayden Daniels", "CeeDee Lamb"],
+        },
+        {
+            "name": "Team B", "ownerId": "owner-b",
+            "players": ["B Star", "B Mid", "B Bench"],
+        },
+    ]
+    players = [
+        _player("Jayden Daniels", 5000, 5000),
+        _player("CeeDee Lamb", 5000, 5000),
+        _player("B Star", 6500, 5200),    # this is the seed
+        _player("B Mid", 5500, 4800),
+        _player("B Bench", 4500, 4500),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        target_team_owner_ids=["owner-b"],
+        seed_player_names=["B Star"],
+    )
+    assert result["candidates"], "Expected at least one candidate"
+    # Every candidate contains the seed.
+    for c in result["candidates"]:
+        names = {p["name"] for p in c["players"]}
+        assert "B Star" in names
+
+
+def test_packages_two_target_teams_draw_from_union():
+    """With 2 target teams selected, the counter-package candidate
+    pool is the union of both teams' top-N players."""
+    offer = ["Jayden Daniels", "CeeDee Lamb"]
+    teams = [
+        {
+            "name": "Team A", "ownerId": "owner-a",
+            "players": ["Jayden Daniels", "CeeDee Lamb"],
+        },
+        {"name": "Team B", "ownerId": "owner-b", "players": ["B Star"]},
+        {"name": "Team C", "ownerId": "owner-c", "players": ["C Star"]},
+    ]
+    players = [
+        _player("Jayden Daniels", 5000, 5000),
+        _player("CeeDee Lamb", 5000, 5000),
+        _player("B Star", 6000, 5000),
+        _player("C Star", 6000, 5000),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        target_team_owner_ids=["owner-b", "owner-c"],
+        seed_player_names=["B Star", "C Star"],
+    )
+    assert result["candidates"], "Expected 2-player counter with both seeds"
+    # Every candidate contains both seeds.
+    for c in result["candidates"]:
+        names = {p["name"] for p in c["players"]}
+        assert "B Star" in names and "C Star" in names
+    # Team label reflects multi-team nature.
+    assert "+" in result["candidates"][0]["team"]
+
+
+def test_packages_warning_for_seed_not_on_target_team():
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["B Star"]},
+        {"name": "Team C", "ownerId": "owner-c", "players": ["C Star"]},
+    ]
+    players = [
+        _player("Jayden Daniels", 5000, 5000),
+        _player("B Star", 6000, 5000),
+        _player("C Star", 6000, 5000),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        target_team_owner_ids=["owner-b"],
+        seed_player_names=["C Star"],  # not on Team B — should be ignored w/ warning
+    )
+    assert any("not on any selected target team" in w for w in result["warnings"])
+
+
+def test_packages_no_targets_uses_existing_per_team_mode():
+    """Existing per-team behaviour is preserved when no targets given."""
+    offer = ["Jayden Daniels"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Jayden Daniels"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["B Star"]},
+        {"name": "Team C", "ownerId": "owner-c", "players": ["C Star"]},
+    ]
+    players = [
+        _player("Jayden Daniels", 5000, 5000),
+        _player("B Star", 6000, 5000),
+        _player("C Star", 6000, 5000),
+    ]
+    result = find_angle_packages(players, offer, "owner-a", teams)
+    # Should see packages from both Team B and Team C independently.
+    owners = {c["owner_id"] for c in result["candidates"]}
+    assert owners == {"owner-b", "owner-c"}


### PR DESCRIPTION
## Summary

Lets users build 3-way or team-directed trades. Pick up to **2 opposing teams** and pin "must-have" **seed players** from each roster; the search fills in additional players from the selected teams' combined top-N pool to balance the trade.

Use case: "I want Ja'Marr Chase from Team B and Brock Purdy from Team C — what else do I need to throw in to make it work?"

## What's new

- **Backend**: \`find_angle_packages\` grows two kwargs — \`target_team_owner_ids\` (up to 2) and \`seed_player_names\`. Seeds bypass filters (user explicitly wants them) and are required in every candidate. When no targets are supplied, behaviour is identical to before.
- **Server**: \`targetTeamOwnerIds\` and \`seedPlayerNames\` threaded through \`POST /api/angle/packages\`.
- **Frontend**: new "Trade with specific teams (optional)" card with 2 team dropdowns; each selection reveals a roster checklist (sorted by my-value desc) for seed selection. Deselecting a team ignores its seeds automatically.

Labelling: multi-team packages carry a combined team name (\`Team B + Team C\`) so the per-team cap still works sensibly.

## Test plan
- [x] 5 new tests covering target-team restriction, seed presence, 2-team union, off-team-seed warning, no-targets default mode
- [x] 1649 passing
- [x] Frontend \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)