### PR TITLE
Trade suggestions use calibration + 2026 slot picks are pure rookie proxies

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -903,7 +903,7 @@ export default function RankingsPage() {
                             Visible on mobile. */}
                         <td
                           style={{ textAlign: "right", fontFamily: "var(--mono)", fontSize: "0.82rem", color: "var(--cyan)" }}
-                          title={row.blendedSourceRank != null ? `Mean source rank ${row.blendedSourceRank.toFixed(2)}. Final rank is #${row.rank}. Gap = blend penalty/bonus for source disagreement.` : "No sources ranked this player"}
+                          title={row.blendedSourceRank != null ? `Mean source rank ${row.blendedSourceRank.toFixed(2)}. Final rank is ${row.rank ? `#${row.rank}` : "\u2014 (unranked)"}. Gap = blend penalty/bonus for source disagreement.` : "No sources ranked this player"}
                         >
                           {row.blendedSourceRank != null
                             ? row.blendedSourceRank.toFixed(1)
@@ -1164,7 +1164,7 @@ export default function RankingsPage() {
                                   Mirrors the exact labels from the main table
                                   header so the user can match row→column. */}
                               <div className="source-audit-summary">
-                                <span><strong>Rank:</strong> #{row.rank} (final ordinal — the engine's opinion)</span>
+                                <span><strong>Rank:</strong> {row.rank ? `#${row.rank}` : "\u2014 (unranked)"} (final ordinal — the engine's opinion)</span>
                                 <span><strong>Consensus:</strong> {row.blendedSourceRank?.toFixed(1) ?? "\u2014"} (mean of per-source effective ranks — orthogonal to Rank; gaps reveal blend arbitration)</span>
                                 <span><strong>Value:</strong> {val.toLocaleString()} (Hill curve, 1\u20139,999 scale)</span>
                                 <span><strong>Confidence:</strong> {confExplain}</span>

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -783,18 +783,35 @@ export function buildRows(data) {
     return [];
   }
 
-  // Stable sort by backend canonicalConsensusRank; tied rows fall back
-  // to raw values.full descending.  Backend already orders playersArray
-  // in rank order, so this is a no-op in the common path.
+  // Sort by rankDerivedValue desc so rows that intentionally carry
+  // null canonicalConsensusRank (e.g. anchor-year slot picks — 2026
+  // picks anchored to the matching rookie by value) still interleave
+  // with players at the right position instead of collapsing to the
+  // end of the table. For ranked rows this ordering matches the
+  // integer-rank order because the backend has already made value
+  // monotonic with rank; the change only affects null-rank rows.
   rows.sort((a, b) => {
+    const va = Number(a.rankDerivedValue) || 0;
+    const vb = Number(b.rankDerivedValue) || 0;
+    if (vb !== va) return vb - va;
+    // Tie-break: integer ranks first (so ties with null-rank picks
+    // place the ranked player "above" the pick deterministically).
     const ra = a.canonicalConsensusRank ?? Infinity;
     const rb = b.canonicalConsensusRank ?? Infinity;
-    if (ra !== rb) return ra - rb;
-    return (b.values.full || 0) - (a.values.full || 0);
+    return ra - rb;
   });
   rows.forEach((r, i) => {
     r.computedConsensusRank = i + 1;
-    r.rank = r.canonicalConsensusRank ?? r.computedConsensusRank;
+    // Preserve null rank on rows the backend explicitly un-ranked
+    // (anchor-year slot picks). Players still fall back to the
+    // local computed ordinal as before; picks show no rank number.
+    if (r.canonicalConsensusRank != null) {
+      r.rank = r.canonicalConsensusRank;
+    } else if (r.assetClass === "pick") {
+      r.rank = null;
+    } else {
+      r.rank = r.computedConsensusRank;
+    }
   });
   return rows;
 }

--- a/server.py
+++ b/server.py
@@ -2131,10 +2131,54 @@ async def post_trade_suggestions(request: Request):
     if league_rosters is not None and not isinstance(league_rosters, list):
         league_rosters = None
 
+    # Overlay live calibrated values on top of the static canonical
+    # snapshot before handing it to the suggestion engine. The
+    # canonical snapshot is built offline by
+    # scripts/canonical_build.py; the IDP calibration post-pass that
+    # runs inside build_api_data_contract does NOT mutate that
+    # snapshot, so by default trade suggestions would be computed on
+    # pre-calibration values. Walk the live playersArray, grab each
+    # ranked row's rankDerivedValue (calibrated), and override both
+    # display_value and calibrated_value on the matching asset so
+    # the suggestion engine sorts + fairness-checks on calibrated
+    # numbers.
+    live_by_name: dict[str, int] = {}
+    try:
+        live_rows = (latest_contract_data or {}).get("playersArray") or []
+    except Exception:  # noqa: BLE001
+        live_rows = []
+    for row in live_rows:
+        name = str(row.get("canonicalName") or row.get("displayName") or "").strip()
+        if not name:
+            continue
+        rdv = row.get("rankDerivedValue")
+        try:
+            v = int(rdv) if rdv is not None else None
+        except (TypeError, ValueError):
+            continue
+        if v is not None and v > 0:
+            live_by_name[name] = v
+
+    if live_by_name:
+        patched_assets = []
+        for asset in (canonical_data.get("assets") or []):
+            asset_name = str(asset.get("display_name") or "").strip()
+            live_val = live_by_name.get(asset_name)
+            if live_val is None:
+                patched_assets.append(asset)
+                continue
+            patched = dict(asset)
+            patched["display_value"] = live_val
+            patched["calibrated_value"] = live_val
+            patched_assets.append(patched)
+        canonical_data_for_suggestions = {**canonical_data, "assets": patched_assets}
+    else:
+        canonical_data_for_suggestions = canonical_data
+
     try:
         result = generate_suggestions(
             roster_names=roster,
-            canonical_snapshot=canonical_data,
+            canonical_snapshot=canonical_data_for_suggestions,
             league_rosters=league_rosters,
         )
     except Exception as e:

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3854,7 +3854,26 @@ def _compute_unified_rankings(
             int(r["canonicalConsensusRank"]),
         ),
     )
-    for new_rank, r in enumerate(ranked_rows, start=1):
+    # Compact ranks, skipping current-year slot picks so picks don't
+    # consume merged-board rank slots. Picks still appear (the row is
+    # kept in the array) but their ``canonicalConsensusRank`` is
+    # cleared — they're a proxy for the corresponding rookie, so the
+    # user sees the value without the pick pushing every other player
+    # down one rank. Only applies to slot-specific current-year picks
+    # (e.g. "2026 Pick 1.06"); tier-generic picks ("2026 Early 1st")
+    # still take ordinary rank slots.
+    new_rank = 0
+    for r in ranked_rows:
+        is_anchor_slot_pick = False
+        if r.get("assetClass") == "pick":
+            parsed = _parse_pick_slot(r.get("canonicalName") or "")
+            if parsed is not None and parsed[0] == _anchor_year:
+                is_anchor_slot_pick = True
+        if is_anchor_slot_pick:
+            r["canonicalConsensusRank"] = None
+            r["canonicalTierId"] = None
+            continue
+        new_rank += 1
         old_rank = r.get("canonicalConsensusRank")
         if old_rank != new_rank:
             r["canonicalConsensusRank"] = new_rank

--- a/tests/api/test_launch_readiness.py
+++ b/tests/api/test_launch_readiness.py
@@ -324,17 +324,17 @@ class TestGate8FlagIntegrity(unittest.TestCase):
         self.assertEqual(impossible, 0)
 
     def test_confidence_distribution_reasonable(self):
-        """At least 15% high-confidence players.
+        """At least 10% high-confidence players.
 
         Relaxed historically from 20% → 18% when Dynasty Nerds was the
         5th ranking source.  Relaxed again from 18% → 15% when
-        FootballGuys SF + IDP were added as the 10th and 11th sources:
-        every additional independent opinion can widen
-        ``sourceRankSpread`` enough to push a borderline high-
-        confidence player into medium.  Confidence bucket thresholds
-        (spread <= 30 for "high") were calibrated in a 4-source world;
-        live high-confidence fraction under 11 sources stabilizes at
-        ~16%, still a reasonable floor.
+        FootballGuys SF + IDP were added as the 10th and 11th sources.
+        Relaxed again to 10% after 2026 slot picks were pulled out of
+        the ranked board (they were anchored high-confidence rows;
+        removing them drops the high-count while the medium/low
+        distribution among players is unchanged). Still a useful
+        sanity floor — if high drops below 10% something has broken
+        in the source pipeline.
         """
         result = _get()
         if result is None:
@@ -342,7 +342,7 @@ class TestGate8FlagIntegrity(unittest.TestCase):
         _, ranked, _ = result
         high = sum(1 for r in ranked if r.get("confidenceBucket") == "high")
         pct = high / len(ranked) * 100
-        self.assertGreaterEqual(pct, 15, f"High confidence {pct:.1f}% < 15%")
+        self.assertGreaterEqual(pct, 10, f"High confidence {pct:.1f}% < 10%")
 
 
 # ── GATE 9: Live-Page Verification ──────────────────────────────────────

--- a/tests/api/test_pick_rookie_anchor.py
+++ b/tests/api/test_pick_rookie_anchor.py
@@ -216,6 +216,62 @@ class TestAnchorEndToEnd(unittest.TestCase):
             pick_101.get("pickRookieAnchor"), rookies[0]["canonicalName"]
         )
 
+    def test_2026_slot_picks_have_null_canonical_rank(self) -> None:
+        """2026 slot picks are proxies for their anchor rookie; they
+        carry the rookie's rankDerivedValue but NOT a merged-board
+        rank so players aren't pushed down a slot by each pick row."""
+        rows = self.contract["playersArray"]
+        slot_picks = [
+            r for r in rows
+            if r.get("assetClass") == "pick"
+            and isinstance(r.get("canonicalName"), str)
+            and r["canonicalName"].startswith("2026 Pick ")
+        ]
+        if not slot_picks:
+            self.skipTest("No 2026 slot picks in contract")
+        for pick in slot_picks:
+            self.assertIsNone(
+                pick.get("canonicalConsensusRank"),
+                f"{pick.get('canonicalName')} still carries a rank "
+                f"(got {pick.get('canonicalConsensusRank')}) — 2026 slot picks "
+                "must be un-ranked so they don't push other rows down.",
+            )
+        # At least one pick should carry an anchored value — verifies
+        # that un-ranking happens AFTER the rookie anchor step, not
+        # instead of it. (Some deep rookie slots may have no rookie
+        # match; skipping to a pick that does is sufficient.)
+        anchored = [
+            p for p in slot_picks
+            if p.get("rankDerivedValue") and int(p.get("rankDerivedValue")) > 0
+        ]
+        self.assertTrue(
+            anchored,
+            "No 2026 slot pick carries a positive rankDerivedValue — "
+            "anchor step appears broken after the un-rank change.",
+        )
+
+    def test_no_2026_slot_pick_consumes_a_rank_slot(self) -> None:
+        """2026 slot picks should be ENTIRELY absent from the ranked
+        board — no pick like ``2026 Pick 1.01`` should hold a
+        canonicalConsensusRank. Other pick types (tier-generic
+        ``2026 Early 1st``, ``2027 Pick 1.01``) may still hold ranks
+        and are checked separately."""
+        ranked = [
+            r for r in self.contract["playersArray"]
+            if r.get("canonicalConsensusRank")
+        ]
+        offenders = [
+            r for r in ranked
+            if r.get("assetClass") == "pick"
+            and isinstance(r.get("canonicalName"), str)
+            and r["canonicalName"].startswith("2026 Pick ")
+        ]
+        self.assertEqual(
+            offenders, [],
+            f"2026 slot picks still hold ranks: "
+            f"{[r.get('canonicalName') for r in offenders[:3]]}",
+        )
+
     def test_coherence_preserved_after_anchor(self) -> None:
         ranked = sorted(
             [

--- a/tests/api/test_picks_end_to_end.py
+++ b/tests/api/test_picks_end_to_end.py
@@ -97,6 +97,19 @@ def _is_deep_future_tier(name: str) -> bool:
     return False
 
 
+def _slot_pick_round(name: str) -> int | None:
+    """Extract round number from a slot-specific pick name like
+    '2026 Pick 3.06'. Returns None for non-slot-pick names."""
+    import re
+    m = re.match(r"^\d{4}\s+Pick\s+(\d+)\.\d+$", str(name or "").strip())
+    if m:
+        try:
+            return int(m.group(1))
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
 def _pick_rows(contract: dict[str, Any]) -> list[dict[str, Any]]:
     return [
         r
@@ -147,19 +160,24 @@ class TestPicksPresentInContract(unittest.TestCase):
 
     def test_every_pick_has_rank_and_value(self) -> None:
         # Picks that pass through the pick refinement passes can be
-        # legitimately *unranked* in two cases:
+        # legitimately *unranked* in three cases:
         #   1. Generic Early/Mid/Late tier rows that were suppressed
         #      because slot-specific siblings exist for the same year
         #      (see _suppress_generic_pick_tiers_when_slots_exist).
         #   2. Deep R5/R6 future-year tier rows (e.g. 2028 Mid 6th)
         #      that fall below OVERALL_RANK_LIMIT after the future-year
         #      discount is applied.
+        #   3. 2026 slot-specific picks (e.g. "2026 Pick 1.01") — these
+        #      are anchored to the corresponding rookie by value and
+        #      intentionally un-ranked so they don't consume merged-
+        #      board rank slots.
         # Every other pick must still carry rank + value.
         picks = _pick_rows(self.contract)
         missing = [
             p["canonicalName"]
             for p in picks
             if not p.get("pickGenericSuppressed")
+            and not str(p.get("canonicalName") or "").startswith("2026 Pick ")
             and (
                 not p.get("canonicalConsensusRank")
                 or not p.get("rankDerivedValue")
@@ -177,6 +195,26 @@ class TestPicksPresentInContract(unittest.TestCase):
             [],
             f"Picks missing rank/value (excluding deep-tier dropouts): "
             f"{unexpected[:10]}",
+        )
+        # 2026 slot picks in rounds 1-4 must have VALUE (anchored to
+        # the corresponding rookie). Later-round slot picks depend on
+        # rookie universe depth; if the rookie list runs out before
+        # round 5-6, some deep picks legitimately end up without an
+        # anchored value — this mirrors the pre-change behaviour where
+        # those picks had tier-value approximations only.
+        slot_2026_early = [
+            p for p in picks
+            if str(p.get("canonicalName") or "").startswith("2026 Pick ")
+            and _slot_pick_round(p.get("canonicalName") or "") in (1, 2, 3, 4)
+        ]
+        value_missing = [
+            p["canonicalName"] for p in slot_2026_early
+            if not p.get("rankDerivedValue")
+            or p.get("rankDerivedValue", 0) <= 0
+        ]
+        self.assertEqual(
+            value_missing, [],
+            f"2026 rounds 1-4 slot picks missing anchored value: {value_missing[:5]}",
         )
 
     def test_every_pick_has_source_ranks(self) -> None:
@@ -335,6 +373,10 @@ class TestRepresentativePicks(unittest.TestCase):
         }
 
     def test_targets_have_rank_and_value(self) -> None:
+        # 2026 slot-specific picks are intentionally un-ranked — they
+        # carry the rookie-anchored value only (``rankDerivedValue``)
+        # so they don't consume merged-board rank slots. Tier-generic
+        # picks and future-year picks still hold real ranks.
         for name in self.TARGETS:
             with self.subTest(pick=name):
                 row = self.by_name.get(name)
@@ -342,10 +384,17 @@ class TestRepresentativePicks(unittest.TestCase):
                     row, f"{name} missing from pick contract output"
                 )
                 assert row is not None
-                self.assertTrue(
-                    row.get("canonicalConsensusRank"),
-                    f"{name} has no canonicalConsensusRank",
-                )
+                is_2026_slot = name.startswith("2026 Pick ")
+                if is_2026_slot:
+                    self.assertIsNone(
+                        row.get("canonicalConsensusRank"),
+                        f"{name} should be un-ranked (anchored to rookie only)",
+                    )
+                else:
+                    self.assertTrue(
+                        row.get("canonicalConsensusRank"),
+                        f"{name} has no canonicalConsensusRank",
+                    )
                 self.assertGreater(
                     int(row.get("rankDerivedValue") or 0),
                     0,
@@ -359,16 +408,13 @@ class TestRepresentativePicks(unittest.TestCase):
                     f"{name} has no sourceRanks",
                 )
 
-    def test_early_first_outranks_late_first(self) -> None:
+    def test_early_first_has_higher_value_than_late_first(self) -> None:
+        """2026 slot picks no longer carry ranks — value is the only
+        comparison signal (anchored to the corresponding rookie)."""
         early = self.by_name.get("2026 Pick 1.01")
         late = self.by_name.get("2026 Pick 1.12")
         if not early or not late:
             self.skipTest("Slot-specific 1st not in snapshot")
-        self.assertLess(
-            int(early["canonicalConsensusRank"]),
-            int(late["canonicalConsensusRank"]),
-            "Early 1st should outrank late 1st",
-        )
         self.assertGreater(
             int(early["rankDerivedValue"]),
             int(late["rankDerivedValue"]),

--- a/tests/api/test_player_identity_regression.py
+++ b/tests/api/test_player_identity_regression.py
@@ -336,6 +336,7 @@ KNOWN_TOP_BOARD_SINGLE_SOURCE_ALLOWLIST: dict[str, str] = {
     "Michael Penix":   "IDPTradeCalc upstream feed has no entry under Michael Penix / Michael Penix Jr.",
     "Omar Cooper":     "Indiana WR (current college rookie) — not yet listed in IDPTradeCalc autocomplete",
     "Devin Bush":      "Veteran depth IDP — outside DLF top-185 cut",
+    "David Bailey":    "Edge rookie IDP — only FantasyPros IDP covers him; moved into top-200 after 2026 slot picks were un-ranked",
 }
 
 


### PR DESCRIPTION
## Summary

Two user-requested fixes:

### 1. Trade suggestions respect the live calibration

The suggestion engine reads from the offline canonical snapshot, which doesn't carry the live IDP calibration post-pass. Balancer values were being computed on pre-calibration numbers. Now the \`/api/trade/suggestions\` endpoint overlays the live \`rankDerivedValue\` from \`latest_contract_data.playersArray\` onto each canonical asset before the suggester runs — so IDP multipliers and family scale flow through to trade suggestions.

### 2. 2026 slot picks are pure rookie-anchored proxies

"2026 Pick 1.01", "2026 Pick 2.06" etc. keep their rookie-anchored \`rankDerivedValue\` but are deliberately excluded from the merged-board rank numbering. The rank-compaction step skips them when renumbering, so non-pick players form a contiguous 1..N sequence without picks consuming rank slots. This addresses the user's concern that picks were pushing every subsequent player down one rank. Tier-generic picks ("2026 Early 1st") and future-year picks ("2027 Pick 1.01") still hold real ranks.

Frontend adjustments:
- \`buildRows\` sorts by \`rankDerivedValue\` desc so null-rank picks still interleave with players by value.
- Rank column renders a dash for null-rank picks instead of a fallback computed number.

## Test plan
- [x] 1651 passing; 2 new tests for null-rank slot picks; existing pick tests updated for new semantics; launch-readiness confidence floor relaxed 15% → 10% (ranked total shrinks when picks pull out); David Bailey added to 1-src allowlist (moved into top-200 with picks removed)
- [x] Frontend \`npm run build\` clean
- [ ] Post-deploy: trade suggester balancer values reflect IDP calibration; /rankings has 2026 slot picks with blank rank column but anchored values

🤖 Generated with [Claude Code](https://claude.com/claude-code)