### PR TITLE
Angle: IDP trades compare on IDPTC, offense stays on KTC

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -7,15 +7,25 @@ import { useDynastyData } from "@/components/useDynastyData";
 // Multi-player trade-target arbitrage.
 // Pick your team → check off any players you'd offer → get counter-
 // packages from other teams, sized within ±1 of your offer, where
-// your league's calibrated rankings say win but KTC sees fair-or-
-// better for the counterparty.
+// your league's calibrated rankings say win but the market the
+// counterparty consults says fair-or-better. "Market" is per-position:
+// IDP Trade Calculator for DL/LB/DB, KTC for everyone else.
 
 const DEFAULT_MIN_MY = 5;
-const DEFAULT_MAX_KTC = 5;
+const DEFAULT_MAX_MARKET = 5;
 const DEFAULT_LIMIT = 50;
 const DEFAULT_PER_TEAM = 4;
 const DEFAULT_MIN_PLAYER_VALUE = 3000;
 const POSITION_FILTERS = ["QB", "RB", "WR", "TE", "DL", "LB", "DB"];
+const IDP_POS_RE = /^(?:DL|DE|DT|EDGE|NT|LB|ILB|OLB|MLB|DB|CB|S|SS|FS)$/i;
+
+function marketSourceForPos(position) {
+  return IDP_POS_RE.test(String(position || "").trim()) ? "idpTradeCalc" : "ktc";
+}
+
+function marketLabelForSource(source) {
+  return source === "idpTradeCalc" ? "IDPTC" : "KTC";
+}
 
 export default function AnglePage() {
   const { loading: dataLoading, error: dataError, rawData, rows } = useDynastyData();
@@ -27,19 +37,23 @@ export default function AnglePage() {
     );
   }, [rawData]);
 
-  // Quick lookup: canonical name → { my_value, ktc_value, position }.
-  // Used to show per-player totals in the checklist and offer bar.
+  // Quick lookup: canonical name → { my_value, market_value, market_source, position }.
+  // "Market" source is IDPTC for IDP positions, KTC for everyone else
+  // — matches the per-position market anchor the backend uses.
   const valueByName = useMemo(() => {
     const m = new Map();
     for (const r of rows || []) {
       const name = r?.name || r?.canonicalName;
       if (!name) continue;
+      const pos = r?.pos || r?.position || "";
+      const source = marketSourceForPos(pos);
       const my_v = Number(r?.rankDerivedValue) || 0;
-      const ktc_v = Number(r?.canonicalSites?.ktc) || 0;
+      const market_v = Number(r?.canonicalSites?.[source]) || 0;
       m.set(name, {
         my_value: my_v,
-        ktc_value: ktc_v,
-        position: r?.pos || r?.position || "",
+        market_value: market_v,
+        market_source: source,
+        position: pos,
       });
     }
     return m;
@@ -49,7 +63,7 @@ export default function AnglePage() {
   const [rosterFilter, setRosterFilter] = useState("");
   const [offer, setOffer] = useState(() => new Set());
   const [minMyGainPct, setMinMyGainPct] = useState(DEFAULT_MIN_MY);
-  const [maxKtcGainPct, setMaxKtcGainPct] = useState(DEFAULT_MAX_KTC);
+  const [maxMarketGainPct, setMaxMarketGainPct] = useState(DEFAULT_MAX_MARKET);
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [perTeamLimit, setPerTeamLimit] = useState(DEFAULT_PER_TEAM);
   const [positionFilters, setPositionFilters] = useState(() => new Set());
@@ -102,15 +116,15 @@ export default function AnglePage() {
 
   const offerTotals = useMemo(() => {
     let my = 0;
-    let ktc = 0;
+    let market = 0;
     for (const name of offerList) {
       const info = valueByName.get(name);
       if (info) {
         my += info.my_value || 0;
-        ktc += info.ktc_value || 0;
+        market += info.market_value || 0;
       }
     }
-    return { my, ktc };
+    return { my, market };
   }, [offerList, valueByName]);
 
   function toggleOffer(name) {
@@ -181,7 +195,7 @@ export default function AnglePage() {
           ownerId,
           playerNames: offerList,
           minMyGainPct: Number(minMyGainPct),
-          maxKtcGainPct: Number(maxKtcGainPct),
+          maxMarketGainPct: Number(maxMarketGainPct),
           limit: Number(limit),
           perTeamLimit: Number(perTeamLimit),
           minPlayerMyValue: Number(minPlayerValue),
@@ -227,7 +241,8 @@ export default function AnglePage() {
           <h1 className="page-title">Angle</h1>
           <p className="page-subtitle muted" style={{ marginTop: 4 }}>
             Build an offer from your roster; get counter-packages
-            (±1 in size) that win on your rankings but look fair-or-better on KTC.
+            (±1 in size) that win on your rankings but look fair-or-better on
+            the market the counterparty consults (IDPTC for IDP, KTC otherwise).
           </p>
         </div>
       </div>
@@ -268,14 +283,14 @@ export default function AnglePage() {
           </label>
           <label className="angle-field">
             <span className="muted">
-              Max KTC gap %{" "}
-              <span className="angle-field-hint">(counter KTC ≤ this above)</span>
+              Max market gap %{" "}
+              <span className="angle-field-hint">(IDPTC for IDP / KTC for offense)</span>
             </span>
             <input
               type="number"
-              value={maxKtcGainPct}
+              value={maxMarketGainPct}
               step="1"
-              onChange={(e) => setMaxKtcGainPct(e.target.value)}
+              onChange={(e) => setMaxMarketGainPct(e.target.value)}
               disabled={busy}
             />
           </label>
@@ -470,8 +485,9 @@ export default function AnglePage() {
                               {info && (
                                 <span className="muted angle-roster-meta">
                                   {info.position || "—"} · my{" "}
-                                  {info.my_value.toLocaleString()} / ktc{" "}
-                                  {info.ktc_value.toLocaleString()}
+                                  {info.my_value.toLocaleString()} ·{" "}
+                                  {marketLabelForSource(info.market_source)}{" "}
+                                  {info.market_value.toLocaleString()}
                                 </span>
                               )}
                             </label>
@@ -494,7 +510,9 @@ export default function AnglePage() {
               My total <strong>{offerTotals.my.toLocaleString()}</strong>
             </span>
             <span>
-              KTC total <strong>{offerTotals.ktc.toLocaleString()}</strong>
+              Market total{" "}
+              <strong>{offerTotals.market.toLocaleString()}</strong>
+              <span className="angle-field-hint"> (IDPTC for IDP, KTC otherwise)</span>
             </span>
             {offerList.length > 0 && (
               <button
@@ -521,8 +539,9 @@ export default function AnglePage() {
                   <strong>{name}</strong>
                   {info && (
                     <span className="muted">
-                      {info.position} · my {info.my_value.toLocaleString()} / ktc{" "}
-                      {info.ktc_value.toLocaleString()}
+                      {info.position} · my {info.my_value.toLocaleString()} ·{" "}
+                      {marketLabelForSource(info.market_source)}{" "}
+                      {info.market_value.toLocaleString()}
                     </span>
                   )}
                   <span className="angle-chip-x">×</span>
@@ -562,8 +581,9 @@ export default function AnglePage() {
                   {info && (
                     <span className="muted angle-roster-meta">
                       {info.position || "—"} · my{" "}
-                      {info.my_value.toLocaleString()} / ktc{" "}
-                      {info.ktc_value.toLocaleString()}
+                      {info.my_value.toLocaleString()} ·{" "}
+                      {marketLabelForSource(info.market_source)}{" "}
+                      {info.market_value.toLocaleString()}
                     </span>
                   )}
                 </label>
@@ -589,7 +609,8 @@ export default function AnglePage() {
           <div className="angle-section-head">
             <h2>Counter-packages ({result.candidates.length})</h2>
             <span className="muted">
-              Sorted by arbitrage score (my gain % − KTC gap %). Sizes allowed:{" "}
+              Sorted by arbitrage score (my gain % − market gap %). Market is
+              IDPTC for IDP, KTC otherwise. Sizes allowed:{" "}
               {(result.thresholds?.target_sizes || []).join(", ")}.
             </span>
           </div>
@@ -609,14 +630,14 @@ export default function AnglePage() {
                     </span>
                     <span
                       className={
-                        c.ktc_gain_pct <= 0
+                        c.market_gain_pct <= 0
                           ? "angle-delta-pos"
                           : "angle-delta-neutral"
                       }
-                      title="KTC gap %"
+                      title="Market gap % (IDPTC for IDP / KTC for offense)"
                     >
-                      {c.ktc_gain_pct > 0 ? "+" : ""}
-                      {c.ktc_gain_pct.toFixed(1)}% ktc
+                      {c.market_gain_pct > 0 ? "+" : ""}
+                      {c.market_gain_pct.toFixed(1)}% mkt
                     </span>
                     <span title="Arbitrage score">
                       <strong>+{c.arb_score.toFixed(1)}</strong>
@@ -629,15 +650,17 @@ export default function AnglePage() {
                       <strong>{p.name}</strong>{" "}
                       <span className="muted">{p.position}</span>{" "}
                       <span className="muted">
-                        my {p.my_value.toLocaleString()} / ktc{" "}
-                        {p.ktc_value.toLocaleString()}
+                        my {p.my_value.toLocaleString()} ·{" "}
+                        {marketLabelForSource(p.market_source)}{" "}
+                        {p.market_value.toLocaleString()}
                       </span>
                     </li>
                   ))}
                 </ul>
                 <div className="angle-package-totals muted">
                   my total <strong>{c.my_total.toLocaleString()}</strong>{" "}
-                  · ktc total <strong>{c.ktc_total.toLocaleString()}</strong>
+                  · market total{" "}
+                  <strong>{c.market_total.toLocaleString()}</strong>
                 </div>
               </div>
             ))}
@@ -647,7 +670,7 @@ export default function AnglePage() {
         <section className="card">
           <p className="muted">
             No counter-packages match. Loosen the thresholds (lower
-            "Min my-value gain %" or raise "Max KTC gap %"), pick
+            "Min my-value gain %" or raise "Max market gap %"), pick
             different offer players, or widen the candidate pool on
             the backend.
           </p>

--- a/server.py
+++ b/server.py
@@ -2262,9 +2262,13 @@ async def post_angle_find(request: Request):
           "ownerId": "472206636534984704",       // your sleeper ownerId
           "playerName": "Jayden Daniels",        // canonical name
           "minMyGainPct": 5.0,                    // optional, default 5
-          "maxKtcGainPct": 5.0,                   // optional, default 5
+          "maxMarketGainPct": 5.0,                // optional, default 5
           "limit": 50                             // optional, default 50
         }
+
+    Market value is per-position: IDPTradeCalc for IDP (DL/LB/DB),
+    KTC for everyone else. Legacy body key ``maxKtcGainPct`` is
+    still accepted for backward compatibility.
     """
     if latest_contract_data is None:
         return JSONResponse(
@@ -2294,12 +2298,15 @@ async def post_angle_find(request: Request):
 
     try:
         min_my = float(body.get("minMyGainPct", 5.0))
-        max_ktc = float(body.get("maxKtcGainPct", 5.0))
+        # Accept new key, fall back to legacy for pre-rename clients.
+        max_market = float(
+            body.get("maxMarketGainPct", body.get("maxKtcGainPct", 5.0))
+        )
         limit = int(body.get("limit", 50))
     except (TypeError, ValueError):
         return JSONResponse(
             status_code=400,
-            content={"error": "minMyGainPct, maxKtcGainPct, limit must be numeric."},
+            content={"error": "minMyGainPct, maxMarketGainPct, limit must be numeric."},
         )
 
     from src.trade.angle import find_angles
@@ -2311,7 +2318,7 @@ async def post_angle_find(request: Request):
             owner_id,
             sleeper_teams,
             min_my_gain_pct=min_my,
-            max_ktc_gain_pct=max_ktc,
+            max_market_gain_pct=max_market,
             limit=limit,
         )
     except Exception as exc:  # noqa: BLE001
@@ -2335,10 +2342,14 @@ async def post_angle_packages(request: Request):
           "ownerId": "472206636534984704",
           "playerNames": ["Jayden Daniels", "CeeDee Lamb", ...],
           "minMyGainPct": 5.0,
-          "maxKtcGainPct": 5.0,
+          "maxMarketGainPct": 5.0,
           "limit": 50,
           "candidatePoolPerTeam": 25
         }
+
+    Market value is per-position: IDPTradeCalc for IDP (DL/LB/DB),
+    KTC for everyone else. Legacy body key ``maxKtcGainPct`` is
+    still accepted.
     """
     if latest_contract_data is None:
         return JSONResponse(
@@ -2369,7 +2380,10 @@ async def post_angle_packages(request: Request):
 
     try:
         min_my = float(body.get("minMyGainPct", 5.0))
-        max_ktc = float(body.get("maxKtcGainPct", 5.0))
+        # Accept renamed key; fall back to legacy for pre-rename clients.
+        max_market = float(
+            body.get("maxMarketGainPct", body.get("maxKtcGainPct", 5.0))
+        )
         limit = int(body.get("limit", 50))
         pool = int(body.get("candidatePoolPerTeam", 25))
         per_team = int(body.get("perTeamLimit", 4))
@@ -2403,7 +2417,7 @@ async def post_angle_packages(request: Request):
             owner_id,
             sleeper_teams,
             min_my_gain_pct=min_my,
-            max_ktc_gain_pct=max_ktc,
+            max_market_gain_pct=max_market,
             limit=limit,
             candidate_pool_per_team=pool,
             per_team_limit=per_team,

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -2,10 +2,20 @@
 
 Given a user-owned player (or package of players), find players or
 player-packages on other teams where the trade leans in the user's
-favour under their own league's rankings but looks fair-or-worse to
-the counterparty on KTC. Lets the user pitch trades that their
-leaguemates will accept ("KTC says it's even") while actually gaining
+favour under their own league's calibrated rankings but looks
+fair-or-worse to the counterparty on the market index their position
+indexes. Lets the user pitch trades that their leaguemates will
+accept (the market they consult says "even") while actually gaining
 value in their league-specific calibrated board.
+
+Market anchor is per-position:
+  * Offense (QB/RB/WR/TE), picks, everything else → KTC
+  * IDP (DL/LB/DB) → IDP Trade Calculator
+
+IDP leaguemates evaluate IDP trades on IDPTC, not KTC. A trade
+between two DLs that looks 5% over-market on KTC is irrelevant — the
+counterparty looks at IDPTC. So each player's "market value" is
+drawn from the source their position indexes.
 
 ``find_angles`` handles the single-player pivot. ``find_angle_packages``
 extends to multi-player offers: give it a list of your players and it
@@ -20,20 +30,41 @@ from __future__ import annotations
 from itertools import combinations
 from typing import Any
 
+_IDP_POSITIONS: frozenset[str] = frozenset(
+    {"DL", "DE", "DT", "EDGE", "NT", "LB", "ILB", "OLB", "MLB", "DB", "CB", "S", "SS", "FS"}
+)
 
-def _value_pair(row: dict[str, Any]) -> tuple[float, float] | None:
-    """Return (my_value, ktc_value) for a row, or None if incomplete."""
+
+def _market_source_for(position: str | None) -> str:
+    """Return the canonicalSiteValues key the counterparty would
+    consult for this position. IDP positions compare on IDPTC;
+    everything else (offense, picks, kickers, etc.) compares on KTC.
+    """
+    pos = str(position or "").strip().upper()
+    if pos in _IDP_POSITIONS:
+        return "idpTradeCalc"
+    return "ktc"
+
+
+def _value_pair(row: dict[str, Any]) -> tuple[float, float, str] | None:
+    """Return (my_value, market_value, market_source_key) for a row.
+
+    ``market_source_key`` is the canonicalSiteValues key used —
+    ``"idpTradeCalc"`` for IDP rows, ``"ktc"`` otherwise. Returns
+    ``None`` when either value is missing or non-positive.
+    """
     my_val = row.get("rankDerivedValue")
     sites = row.get("canonicalSiteValues") or {}
-    ktc_val = sites.get("ktc") if isinstance(sites, dict) else None
+    source = _market_source_for(row.get("position"))
+    market_val = sites.get(source) if isinstance(sites, dict) else None
     try:
         my_num = float(my_val) if my_val is not None else 0.0
-        ktc_num = float(ktc_val) if ktc_val is not None else 0.0
+        market_num = float(market_val) if market_val is not None else 0.0
     except (TypeError, ValueError):
         return None
-    if my_num <= 0 or ktc_num <= 0:
+    if my_num <= 0 or market_num <= 0:
         return None
-    return my_num, ktc_num
+    return my_num, market_num, source
 
 
 def find_angles(
@@ -43,10 +74,16 @@ def find_angles(
     sleeper_teams: list[dict[str, Any]],
     *,
     min_my_gain_pct: float = 5.0,
-    max_ktc_gain_pct: float = 5.0,
+    max_market_gain_pct: float = 5.0,
     limit: int = 50,
 ) -> dict[str, Any]:
     """Find trade-target candidates that lean in the user's favour.
+
+    Each player's "market value" is drawn from the source that indexes
+    their position — IDP Trade Calculator for DL/LB/DB, KTC for
+    everyone else. The counterparty looks at the same market their
+    player is listed in, so the threshold check matches their
+    perspective.
 
     Parameters
     ----------
@@ -54,25 +91,11 @@ def find_angles(
         Canonical player rows (from build_api_data_contract's
         ``playersArray``). Each row must carry ``canonicalName``,
         ``rankDerivedValue`` (the calibrated my-league value), and
-        ``canonicalSiteValues.ktc`` (the market anchor).
-    selected_player_name
-        Canonical name of the player on the user's team to pivot on.
-    selected_team_owner_id
-        Sleeper ``ownerId`` identifying the user's roster. Used to
-        filter out same-team targets so Angle never suggests trading
-        with yourself.
-    sleeper_teams
-        List of team entries from ``sleeper.teams`` — each team has
-        ``name``, ``ownerId``, and ``players`` (canonical names).
-    min_my_gain_pct
-        Minimum my-league value gain for a target to qualify (as a
-        percentage of the selected player's my-league value). Default
-        5% — the trade has to visibly move the needle.
-    max_ktc_gain_pct
-        Maximum market (KTC) value gain on the target side for the
-        trade to still look "plausible" to the counterparty. Default
-        5% — anything beyond that and the counterparty would reject
-        purely on KTC grounds.
+        a market value at ``canonicalSiteValues.idpTradeCalc`` for
+        IDP or ``canonicalSiteValues.ktc`` for offense.
+    max_market_gain_pct
+        Maximum market value gain on the target side for the trade
+        to still look "plausible" to the counterparty. Default 5%.
     limit
         Cap on returned candidates (sorted by arbitrage score desc).
 
@@ -80,6 +103,8 @@ def find_angles(
     -------
     dict
         ``{selected: {...}, candidates: [{...}, ...], warnings: [...]}``
+        Market value is in ``market_value``; market source (``ktc``
+        vs ``idpTradeCalc``) is in ``market_source``.
     """
     warnings: list[str] = []
 
@@ -99,19 +124,21 @@ def find_angles(
 
     pair = _value_pair(selected_row)
     if pair is None:
+        sel_source = _market_source_for(selected_row.get("position"))
         return {
             "selected": {
                 "name": selected_player_name,
                 "my_value": selected_row.get("rankDerivedValue"),
-                "ktc_value": None,
+                "market_value": None,
+                "market_source": sel_source,
             },
             "candidates": [],
             "warnings": [
-                f"{selected_player_name!r} is missing a my-league or KTC value "
+                f"{selected_player_name!r} is missing a my-league or {sel_source} value "
                 "— Angle needs both to compute the arbitrage."
             ],
         }
-    my_val_selected, ktc_val_selected = pair
+    my_val_selected, market_val_selected, selected_market_source = pair
 
     # Build reverse index: canonical name -> owner's team dict.
     owner_by_player: dict[str, dict[str, Any]] = {}
@@ -143,16 +170,16 @@ def find_angles(
         target_pair = _value_pair(target_row)
         if target_pair is None:
             continue
-        my_val_target, ktc_val_target = target_pair
+        my_val_target, market_val_target, target_market_source = target_pair
 
         my_gain = my_val_target - my_val_selected
-        ktc_gain = ktc_val_target - ktc_val_selected
+        market_gain = market_val_target - market_val_selected
         my_gain_pct = 100.0 * my_gain / my_val_selected
-        ktc_gain_pct = 100.0 * ktc_gain / ktc_val_selected
+        market_gain_pct = 100.0 * market_gain / market_val_selected
 
         if my_gain_pct < min_my_gain_pct:
             continue
-        if ktc_gain_pct > max_ktc_gain_pct:
+        if market_gain_pct > max_market_gain_pct:
             continue
 
         candidates.append(
@@ -162,12 +189,13 @@ def find_angles(
                 "team": owner_team.get("name") if owner_team else "(free agent)",
                 "owner_id": str(owner_team.get("ownerId") or "") if owner_team else "",
                 "my_value": int(my_val_target),
-                "ktc_value": int(ktc_val_target),
+                "market_value": int(market_val_target),
+                "market_source": target_market_source,
                 "my_gain": int(round(my_gain)),
-                "ktc_gain": int(round(ktc_gain)),
+                "market_gain": int(round(market_gain)),
                 "my_gain_pct": round(my_gain_pct, 2),
-                "ktc_gain_pct": round(ktc_gain_pct, 2),
-                "arb_score": round(my_gain_pct - ktc_gain_pct, 2),
+                "market_gain_pct": round(market_gain_pct, 2),
+                "arb_score": round(my_gain_pct - market_gain_pct, 2),
             }
         )
 
@@ -180,12 +208,13 @@ def find_angles(
             "position": str(selected_row.get("position") or ""),
             "team": my_team_name,
             "my_value": int(my_val_selected),
-            "ktc_value": int(ktc_val_selected),
+            "market_value": int(market_val_selected),
+            "market_source": selected_market_source,
         },
         "candidates": candidates,
         "thresholds": {
             "min_my_gain_pct": min_my_gain_pct,
-            "max_ktc_gain_pct": max_ktc_gain_pct,
+            "max_market_gain_pct": max_market_gain_pct,
             "limit": limit,
         },
         "warnings": warnings,
@@ -199,7 +228,7 @@ def find_angle_packages(
     sleeper_teams: list[dict[str, Any]],
     *,
     min_my_gain_pct: float = 5.0,
-    max_ktc_gain_pct: float = 5.0,
+    max_market_gain_pct: float = 5.0,
     limit: int = 50,
     candidate_pool_per_team: int = 25,
     per_team_limit: int = 4,
@@ -242,8 +271,12 @@ def find_angle_packages(
     dict
         ``{offer, candidates, thresholds, warnings}`` where
         ``candidates`` is a list of package dicts, each with
-        ``{team, size, players, my_total, ktc_total, my_gain_pct,
-        ktc_gain_pct, arb_score}``. Sorted by ``arb_score`` desc.
+        ``{team, size, players, my_total, market_total, my_gain_pct,
+        market_gain_pct, arb_score}``. Sorted by ``arb_score`` desc.
+        Market value is per-position: IDPTC for DL/LB/DB, KTC for
+        offense/picks/other. Individual player rows carry
+        ``market_value`` and ``market_source`` so the UI can label
+        correctly.
 
     The counter-package size is constrained to ``{N-1, N, N+1}``
     where ``N`` is the offered-player count. Size ``0`` is skipped
@@ -273,12 +306,12 @@ def find_angle_packages(
     if missing:
         warnings.append(
             f"Dropped {len(missing)} player(s) from the offer that have no "
-            f"my-value or KTC value: {', '.join(missing[:5])}"
+            f"my-value or market value: {', '.join(missing[:5])}"
             + (" …" if len(missing) > 5 else "")
         )
     if not offer_rows:
         return {
-            "offer": {"players": [], "size": 0, "my_total": 0, "ktc_total": 0},
+            "offer": {"players": [], "size": 0, "my_total": 0, "market_total": 0},
             "candidates": [],
             "warnings": warnings or ["No valid offer-side players."],
         }
@@ -286,7 +319,7 @@ def find_angle_packages(
     offer_my_total = sum(
         _value_pair(r)[0] for r in offer_rows  # type: ignore[index]
     )
-    offer_ktc_total = sum(
+    offer_market_total = sum(
         _value_pair(r)[1] for r in offer_rows  # type: ignore[index]
     )
     offer_size = len(offer_rows)
@@ -322,7 +355,7 @@ def find_angle_packages(
             pair = _value_pair(row)
             if pair is None:
                 continue
-            my_v, ktc_v = pair
+            my_v, market_v, market_source = pair
             # Per-player filters: position allow-list and my-value floor.
             row_pos = str(row.get("position") or "").strip().upper()
             if position_filter is not None and row_pos not in position_filter:
@@ -334,7 +367,8 @@ def find_angle_packages(
                     "name": pname,
                     "position": str(row.get("position") or ""),
                     "my_value": my_v,
-                    "ktc_value": ktc_v,
+                    "market_value": market_v,
+                    "market_source": market_source,
                 }
             )
         pool.sort(key=lambda p: -p["my_value"])
@@ -344,7 +378,7 @@ def find_angle_packages(
     # Pre-compute numeric thresholds in absolute-value terms so the
     # inner loop uses only arithmetic, no division.
     min_my_total = offer_my_total * (1.0 + min_my_gain_pct / 100.0)
-    max_ktc_total = offer_ktc_total * (1.0 + max_ktc_gain_pct / 100.0)
+    max_market_total = offer_market_total * (1.0 + max_market_gain_pct / 100.0)
 
     # Normalise target-team + seed inputs for constructed-package mode.
     target_ids: set[str] = {
@@ -361,12 +395,13 @@ def find_angle_packages(
         pair = _value_pair(row)
         if pair is None:
             return None
-        my_v, ktc_v = pair
+        my_v, market_v, market_source = pair
         return {
             "name": str(row.get("canonicalName") or row.get("displayName") or ""),
             "position": str(row.get("position") or ""),
             "my_value": my_v,
-            "ktc_value": ktc_v,
+            "market_value": market_v,
+            "market_source": market_source,
         }
 
     def _make_candidate(
@@ -377,11 +412,11 @@ def find_angle_packages(
         my_sum = sum(p["my_value"] for p in combo)
         if my_sum < min_my_total:
             return None
-        ktc_sum = sum(p["ktc_value"] for p in combo)
-        if ktc_sum > max_ktc_total:
+        market_sum = sum(p["market_value"] for p in combo)
+        if market_sum > max_market_total:
             return None
         my_gain_pct = 100.0 * (my_sum - offer_my_total) / offer_my_total
-        ktc_gain_pct = 100.0 * (ktc_sum - offer_ktc_total) / offer_ktc_total
+        market_gain_pct = 100.0 * (market_sum - offer_market_total) / offer_market_total
         return {
             "team": team_label,
             "owner_id": owner_id_label,
@@ -391,15 +426,16 @@ def find_angle_packages(
                     "name": p["name"],
                     "position": p["position"],
                     "my_value": int(p["my_value"]),
-                    "ktc_value": int(p["ktc_value"]),
+                    "market_value": int(p["market_value"]),
+                    "market_source": p["market_source"],
                 }
                 for p in combo
             ],
             "my_total": int(round(my_sum)),
-            "ktc_total": int(round(ktc_sum)),
+            "market_total": int(round(market_sum)),
             "my_gain_pct": round(my_gain_pct, 2),
-            "ktc_gain_pct": round(ktc_gain_pct, 2),
-            "arb_score": round(my_gain_pct - ktc_gain_pct, 2),
+            "market_gain_pct": round(market_gain_pct, 2),
+            "arb_score": round(my_gain_pct - market_gain_pct, 2),
         }
 
     if target_ids:
@@ -537,7 +573,8 @@ def find_angle_packages(
                 "name": str(r.get("canonicalName") or ""),
                 "position": str(r.get("position") or ""),
                 "my_value": int(pair[0]) if pair else 0,
-                "ktc_value": int(pair[1]) if pair else 0,
+                "market_value": int(pair[1]) if pair else 0,
+                "market_source": pair[2] if pair else _market_source_for(r.get("position")),
             }
         )
 
@@ -547,12 +584,12 @@ def find_angle_packages(
             "size": offer_size,
             "players": offer_players,
             "my_total": int(round(offer_my_total)),
-            "ktc_total": int(round(offer_ktc_total)),
+            "market_total": int(round(offer_market_total)),
         },
         "candidates": candidates,
         "thresholds": {
             "min_my_gain_pct": min_my_gain_pct,
-            "max_ktc_gain_pct": max_ktc_gain_pct,
+            "max_market_gain_pct": max_market_gain_pct,
             "limit": limit,
             "candidate_pool_per_team": candidate_pool_per_team,
             "per_team_limit": per_team_limit,

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -82,12 +82,12 @@ def test_respects_min_my_gain_threshold():
     assert result["candidates"] == []
 
 
-def test_respects_max_ktc_gain_threshold():
+def test_respects_max_market_gain_threshold():
     players = [
         _player("Jayden Daniels", 5000, 5000),
-        _player("Trade Target Good", 6000, 5600),  # +20% my, +12% KTC
+        _player("Trade Target Good", 6000, 5600),  # +20% my, +12% market
     ]
-    # Default max is 5%; 12% KTC gap too much.
+    # Default max is 5%; 12% gap too much.
     result = find_angles(players, "Jayden Daniels", "owner-a", _teams())
     names = [c["name"] for c in result["candidates"]]
     assert "Trade Target Good" not in names
@@ -97,7 +97,7 @@ def test_respects_max_ktc_gain_threshold():
         "Jayden Daniels",
         "owner-a",
         _teams(),
-        max_ktc_gain_pct=20.0,
+        max_market_gain_pct=20.0,
     )
     names2 = [c["name"] for c in result2["candidates"]]
     assert "Trade Target Good" in names2
@@ -111,19 +111,20 @@ def test_missing_selected_player_returns_warning():
     assert result["warnings"]
 
 
-def test_selected_missing_ktc_value_returns_warning():
+def test_selected_missing_market_value_returns_warning():
     players = [
         {
             "canonicalName": "Jayden Daniels",
             "displayName": "Jayden Daniels",
             "position": "QB",
             "rankDerivedValue": 5000,
-            "canonicalSiteValues": {},  # no KTC
+            "canonicalSiteValues": {},  # no market value
         },
     ]
     result = find_angles(players, "Jayden Daniels", "owner-a", _teams())
     assert result["candidates"] == []
-    assert any("KTC" in w for w in result["warnings"])
+    # Warning mentions the market source that's missing (ktc for QB).
+    assert any("ktc" in w for w in result["warnings"])
 
 
 def test_limit_caps_results():
@@ -218,18 +219,17 @@ def test_packages_excludes_same_team_players_from_candidates():
     assert "owner-a" not in owners  # never trade with yourself
 
 
-def test_packages_filters_on_ktc_gap_threshold():
+def test_packages_filters_on_market_gap_threshold():
     offer = ["Jayden Daniels", "CeeDee Lamb"]
-    # Default max_ktc_gain_pct = 5. Team B's Star+Mid1 is KTC 10000
-    # (fair). Team C's Overpriced is KTC 7500 alone which is -25%
-    # versus offer's 10000 ktc — passes; good single-player counter.
+    # Default max_market_gain_pct = 5. Every candidate must satisfy
+    # the market gap constraint vs the offer's market total (which
+    # for this all-offense offer happens to equal the KTC total).
     result = find_angle_packages(
         _pkg_players(), offer, "owner-a", _pkg_teams(),
     )
-    # Every candidate satisfies KTC gap constraint.
-    offer_ktc = 10000
+    offer_market = 10000
     for c in result["candidates"]:
-        assert (c["ktc_total"] - offer_ktc) / offer_ktc * 100.0 <= 5.001
+        assert (c["market_total"] - offer_market) / offer_market * 100.0 <= 5.001
 
 
 def test_packages_sorts_by_arb_score_desc():
@@ -247,7 +247,7 @@ def test_packages_offer_totals_are_correct():
         _pkg_players(), offer, "owner-a", _pkg_teams(),
     )
     assert result["offer"]["my_total"] == 10000
-    assert result["offer"]["ktc_total"] == 10000
+    assert result["offer"]["market_total"] == 10000
     assert result["offer"]["size"] == 2
 
 
@@ -549,3 +549,104 @@ def test_packages_no_targets_uses_existing_per_team_mode():
     # Should see packages from both Team B and Team C independently.
     owners = {c["owner_id"] for c in result["candidates"]}
     assert owners == {"owner-b", "owner-c"}
+
+
+# ── Per-position market source ─────────────────────────────────────
+
+
+def _player_with_markets(name, my_val, ktc, idptc, *, position="QB"):
+    """Build a row carrying BOTH site values so the helper can pick."""
+    return {
+        "canonicalName": name,
+        "displayName": name,
+        "position": position,
+        "rankDerivedValue": my_val,
+        "canonicalSiteValues": {"ktc": ktc, "idpTradeCalc": idptc},
+    }
+
+
+def test_idp_players_compared_on_idptc_not_ktc():
+    """An IDP counter is accepted/rejected based on IDPTC, not KTC —
+    even if KTC would place it out of range."""
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My DL"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Better DL"]},
+    ]
+    # Offer: My DL with IDPTC 5000. Target: Better DL with IDPTC
+    # 5100 (+2% — fair on IDPTC) but KTC 7000 (+40% — way over on
+    # KTC). The per-position rule should compare on IDPTC and
+    # accept.
+    players = [
+        _player_with_markets("My DL", my_val=5000, ktc=5000, idptc=5000, position="DL"),
+        _player_with_markets(
+            "Better DL", my_val=6000, ktc=7000, idptc=5100, position="DL",
+        ),
+    ]
+    result = find_angles(
+        players, "My DL", "owner-a", teams,
+        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+    )
+    names = [c["name"] for c in result["candidates"]]
+    assert "Better DL" in names, (
+        "IDP counter should qualify on IDPTC (+2%) despite bad KTC (+40%) "
+        f"— got candidates {names}"
+    )
+    # And the market source stamped on the row reflects IDPTC.
+    cand = next(c for c in result["candidates"] if c["name"] == "Better DL")
+    assert cand["market_source"] == "idpTradeCalc"
+
+
+def test_offense_players_still_compared_on_ktc():
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Other QB"]},
+    ]
+    # Offense trade — should compare on KTC, not IDPTC. IDPTC fair
+    # (+1%) but KTC bad (+30%) → should reject.
+    players = [
+        _player_with_markets("My QB", my_val=5000, ktc=5000, idptc=5000, position="QB"),
+        _player_with_markets(
+            "Other QB", my_val=6000, ktc=6500, idptc=5050, position="QB",
+        ),
+    ]
+    result = find_angles(
+        players, "My QB", "owner-a", teams,
+        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+    )
+    names = [c["name"] for c in result["candidates"]]
+    assert "Other QB" not in names
+    # Raising the ceiling admits it.
+    result2 = find_angles(
+        players, "My QB", "owner-a", teams,
+        min_my_gain_pct=5.0, max_market_gain_pct=40.0,
+    )
+    cand = next(c for c in result2["candidates"] if c["name"] == "Other QB")
+    assert cand["market_source"] == "ktc"
+
+
+def test_packages_player_rows_expose_per_position_market_source():
+    offer = ["My QB"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
+        {
+            "name": "Team B", "ownerId": "owner-b",
+            "players": ["IDP Target", "Off Target"],
+        },
+    ]
+    players = [
+        _player_with_markets("My QB", 5000, 5000, 5000, position="QB"),
+        _player_with_markets("IDP Target", 6000, 7000, 5100, position="DL"),
+        _player_with_markets("Off Target", 6000, 5100, 7000, position="WR"),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+    )
+    for c in result["candidates"]:
+        for p in c["players"]:
+            if p["position"] == "DL":
+                assert p["market_source"] == "idpTradeCalc"
+                assert p["market_value"] == 5100  # IDPTC value
+            elif p["position"] == "WR":
+                assert p["market_source"] == "ktc"
+                assert p["market_value"] == 5100  # KTC value


### PR DESCRIPTION
## Summary

Arbitrage check now uses the **market anchor that matches each player's position**:

- IDP (DL/LB/DB/CB/S/…) → **IDP Trade Calculator**
- Offense, picks, everything else → **KTC**

An IDP counter that looks +40% on KTC but +2% on IDPTC is now accepted — the counterparty doesn't evaluate IDP on KTC. Offense counters still have to hold up on KTC.

## Backend
- \`_value_pair\` returns \`(my_value, market_value, market_source)\`; source is picked from the row's position.
- Each candidate player carries \`market_value\` + \`market_source\` (ktc / idpTradeCalc) so the UI can label correctly.
- Threshold kwarg renamed \`max_ktc_gain_pct\` → \`max_market_gain_pct\`. Server body shim still accepts legacy \`maxKtcGainPct\`.

## Frontend
- UI shows "IDPTC" / "KTC" badges next to per-player market values.
- Controls: "Max market gap %" replaces "Max KTC gap %".
- Results: "% mkt" instead of "% ktc".

## Tests
- 3 new tests: IDP accepts on good IDPTC despite bad KTC; offense still rejects on bad KTC; per-position \`market_source\` stamped on package player rows.
- Existing tests renamed for new field names.
- Full suite 1654 passing; frontend \`npm run build\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)