### PR TITLE
Perf: drop deepcopy in build_api_data_contract (two-level copy)

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4386,11 +4386,36 @@ def build_api_data_contract(
     this to ``True`` so overrides round-trips don't pay for output
     blocks the wire shape drops.
     """
-    base = deepcopy(raw_payload or {})
-    players_by_name = base.get("players")
-    if not isinstance(players_by_name, dict):
+    # Two-level copy of raw_payload: shallow at the top, one-deep for
+    # the ``players`` dict so per-player mutations stay isolated.  Full
+    # ``deepcopy`` of a 3MB payload was 70+ms per call; this lands at
+    # ~20ms because we skip the fanout into ``sites``, ``sleeper``, and
+    # every site-per-player record (none of which this function ever
+    # mutates).  Documented mutation sites are scalar assignments on
+    # the player dict and one mutation on the nested
+    # ``_canonicalSiteValues`` dict — both isolated by shallow-copying
+    # each player's nested dicts/lists.
+    src_payload = raw_payload or {}
+    base: dict[str, Any] = dict(src_payload)
+    src_players = src_payload.get("players") if isinstance(src_payload, dict) else None
+    if not isinstance(src_players, dict):
         players_by_name = {}
-        base["players"] = players_by_name
+    else:
+        players_by_name = {}
+        for _name, _pdata in src_players.items():
+            if not isinstance(_pdata, dict):
+                players_by_name[_name] = _pdata
+                continue
+            _copy: dict[str, Any] = {}
+            for _k, _v in _pdata.items():
+                if isinstance(_v, dict):
+                    _copy[_k] = dict(_v)
+                elif isinstance(_v, list):
+                    _copy[_k] = list(_v)
+                else:
+                    _copy[_k] = _v
+            players_by_name[_name] = _copy
+    base["players"] = players_by_name
 
     # Strip legacy LAM/scarcity fields before building the contract.
     _strip_legacy_lam_fields(base, players_by_name)

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -550,6 +550,37 @@ class TestComputeKtcRankings(unittest.TestCase):
         self.assertIn("ktcRank", contract["players"]["Josh Allen"])
         self.assertEqual(contract["players"]["Josh Allen"]["ktcRank"], 1)
 
+    def test_build_api_data_contract_does_not_mutate_raw_payload(self):
+        """Two-level copy guards against mutations leaking back into the
+        caller's raw_payload. Scalar fields added to player dicts by the
+        ranker (rankDerivedValue, ktcRank, etc.) must NOT appear on the
+        source payload after the build.
+        """
+        raw = {
+            "players": {
+                "Josh Allen": {
+                    "_composite": 9000, "_rawComposite": 9000, "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktc": 9000}, "position": "QB",
+                },
+            },
+            "sites": [{"key": "ktc"}],
+            "maxValues": {},
+            "sleeper": {"positions": {}},
+        }
+        orig_player_keys = set(raw["players"]["Josh Allen"].keys())
+        orig_csv_keys = set(raw["players"]["Josh Allen"]["_canonicalSiteValues"].keys())
+        build_api_data_contract(raw)
+        # Top-level keys of the source player dict must not have grown.
+        self.assertEqual(set(raw["players"]["Josh Allen"].keys()), orig_player_keys)
+        # Nested _canonicalSiteValues keys must not have grown either.
+        self.assertEqual(
+            set(raw["players"]["Josh Allen"]["_canonicalSiteValues"].keys()),
+            orig_csv_keys,
+        )
+        # Critical: the build must not stamp rankDerivedValue onto the caller's dict.
+        self.assertNotIn("rankDerivedValue", raw["players"]["Josh Allen"])
+        self.assertNotIn("ktcRank", raw["players"]["Josh Allen"])
+
 
 class TestCanonicalConsensusRank(unittest.TestCase):
     """Backend must stamp canonicalConsensusRank — the authoritative rank


### PR DESCRIPTION
## Summary
Replaced the full `deepcopy(raw_payload)` at the top of `build_api_data_contract` with a shallow top-level copy + one-deep shallow copy of each player dict.

Benchmarked on the live 3MB snapshot:

| Strategy | Per-call cost |
|---|---|
| `deepcopy` (before) | 72.8ms |
| Two-level copy (this PR) | 19.0ms |

That saves ~54ms per contract build — meaningful on every scrape prime AND every `/api/rankings/overrides` POST. Combined with the delta-mode skips from PR #119, overrides rebuilds no longer pay deepcopy cost at all.

## Safety analysis
- Grepped every mutation site inside `build_api_data_contract` and `_compute_unified_rankings`.
- Player dicts only receive scalar-field assignments (`rankDerivedValue`, `ktcRank`, `sourceRanks`, etc.), isolated by the shallow-per-player copy.
- One observed nested mutation is `legacy_csv[k] = v` at line 3851. The 2-level copy isolates it because `_canonicalSiteValues` is shallow-copied too.
- Inspected the live payload's player schema: only simple `dict[str, scalar]` fields at level 2. No lists of dicts. No level-3 mutations found.

## Test plan
- [x] `pytest tests/ -q` — 1715 passed (new mutation-guard test + 1714 existing), 3 skipped.
- [x] New regression test `test_build_api_data_contract_does_not_mutate_raw_payload` asserts the source payload stays unchanged after a build.
- [ ] Verify override requests still return correct ranks/values after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)