### PR TITLE
Perf: run per-season adapter fetches concurrently in lab analyse

### DIFF
--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import math
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -412,7 +413,33 @@ def run_analysis(
     per_season_family_scales: dict[int, FamilyScale] = {}
     resolved_seasons: list[int] = []
 
-    for season in sorted({int(s) for s in settings.seasons}):
+    # ── Prefetch per-season universes concurrently ──────────────────
+    # ``_build_universe_for_season`` makes a network call per season
+    # (adapter probe + stats pull).  Running 4 seasons serially was
+    # the single biggest chunk of lab wall-clock time; fan them out on
+    # a small thread pool so the lab analyse action finishes in ~1×
+    # fetch time instead of 4×.  A forward-borrow / unresolved season
+    # still gets a fetch here (the resolution branches inside the
+    # main loop below pick which one to actually use) but the wasted
+    # calls are bounded by the Sleeper rate limiter and don't
+    # lengthen wall time.
+    season_list = sorted({int(s) for s in settings.seasons})
+
+    def _fetch_one(season: int):
+        adapter = stats_adapter_factory(season) if stats_adapter_factory else None
+        return _build_universe_for_season(
+            season, adapter=adapter, settings=settings
+        )
+
+    universes_by_season: dict[int, tuple] = {}
+    if season_list:
+        max_workers = min(len(season_list), 4)
+        with ThreadPoolExecutor(max_workers=max_workers) as _ex:
+            universes_by_season = dict(
+                zip(season_list, _ex.map(_fetch_one, season_list))
+            )
+
+    for season in season_list:
         test_res = test_chain.seasons.get(season)
         my_res = my_chain.seasons.get(season)
         test_native = bool(test_res and test_res.resolved)
@@ -508,15 +535,12 @@ def run_analysis(
         test_lineup = parse_lineup(test_league_obj)
         my_lineup = parse_lineup(my_league_obj)
 
-        adapter = stats_adapter_factory(season) if stats_adapter_factory else None
         (
             idp_universe,
             offense_universe,
             stats_warnings,
             adapter_name,
-        ) = _build_universe_for_season(
-            season, adapter=adapter, settings=settings
-        )
+        ) = universes_by_season[season]
         warnings.extend(stats_warnings)
 
         if not idp_universe:


### PR DESCRIPTION
## Summary
IDP calibration lab's `run_analysis` walked seasons serially — each season triggered a fresh Sleeper fetch (adapter probe + stats pull) before moving on. With the default 4-season window (2022-2025), that was ~4× network latency stacked back-to-back.

Lifted the fetch into a `ThreadPoolExecutor.map` ahead of the main loop. All 4 season fetches fire concurrently (capped at 4 workers to bound Sleeper pressure); the main loop then pulls universe tuples out of a `{season -> result}` dict for CPU-bound scoring / bucket / VOR work.

## Expected impact
- Lab analyse wall-clock: ~40-60% faster on typical 4-season runs (bounded by `max(adapter_fetch)` not `sum(adapter_fetch)`).
- Feature is user-invoked from `/tools/idp-calibration` — latency visibly affects the workflow.

## Safety notes
- Adapters are stateless — each `get_stats_adapter(season)` call constructs a fresh instance, so thread-safety is not a concern.
- Forward-borrow / unresolved seasons still get fetched in the pre-pass; the resolution + skip logic in the main loop is unchanged, so skipped seasons still produce the same `per_season_payload` entry with `resolved=False`.
- `stats_adapter_factory` closure-called inside worker threads; factories supplied by tests are pure functions.

## Test plan
- [x] `pytest tests/idp_calibration/ -q` — 106 passed.
- [x] `pytest tests/ -q` — 1715 passed.
- [ ] Trigger lab analyse with default seasons in production, confirm wall-clock improves and artifact matches a pre-PR run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)