### PR TITLE
Fix Angle run_in_threadpool import + add acquire-only mode

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -73,6 +73,12 @@ export default function AnglePage() {
   // Seed players keyed by ownerId — players that MUST appear in
   // every counter-package when a target team is selected.
   const [seedsByOwner, setSeedsByOwner] = useState({});
+  // "offer" (default): user picks players from their roster and we
+  // search opposing rosters for counter-packages.
+  // "acquire": user picks players on opposing rosters to acquire and
+  // we search their own roster for offer-side packages. Lets the
+  // user skip selecting their own players first.
+  const [mode, setMode] = useState("offer");
   const [result, setResult] = useState(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
@@ -111,6 +117,13 @@ export default function AnglePage() {
     setResult(null);
     setErr(null);
   }, [ownerId]);
+
+  // Clear stale results and errors when flipping modes so the page
+  // doesn't render offer-mode candidates after switching to acquire.
+  useEffect(() => {
+    setResult(null);
+    setErr(null);
+  }, [mode]);
 
   const offerList = useMemo(() => Array.from(offer), [offer]);
 
@@ -180,29 +193,53 @@ export default function AnglePage() {
   }, [activeTargetOwnerIds, seedsByOwner]);
 
   async function findAngles() {
-    if (!ownerId || offerList.length === 0) {
-      setErr("Pick a team and check at least one player.");
+    if (!ownerId) {
+      setErr("Pick your team.");
+      return;
+    }
+    if (mode === "offer" && offerList.length === 0) {
+      setErr("Check at least one player from your roster to offer.");
+      return;
+    }
+    if (mode === "acquire" && activeSeedNames.length === 0) {
+      setErr(
+        "Pick a target team and check at least one player you want to acquire.",
+      );
       return;
     }
     setBusy(true);
     setErr(null);
     try {
+      const body =
+        mode === "acquire"
+          ? {
+              mode: "acquire",
+              ownerId,
+              acquirePlayerNames: activeSeedNames,
+              minMyGainPct: Number(minMyGainPct),
+              maxMarketGainPct: Number(maxMarketGainPct),
+              limit: Number(limit),
+              minPlayerMyValue: Number(minPlayerValue),
+              positions: Array.from(positionFilters),
+            }
+          : {
+              mode: "offer",
+              ownerId,
+              playerNames: offerList,
+              minMyGainPct: Number(minMyGainPct),
+              maxMarketGainPct: Number(maxMarketGainPct),
+              limit: Number(limit),
+              perTeamLimit: Number(perTeamLimit),
+              minPlayerMyValue: Number(minPlayerValue),
+              positions: Array.from(positionFilters),
+              targetTeamOwnerIds: activeTargetOwnerIds,
+              seedPlayerNames: activeSeedNames,
+            };
       const res = await fetch("/api/angle/packages", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         cache: "no-store",
-        body: JSON.stringify({
-          ownerId,
-          playerNames: offerList,
-          minMyGainPct: Number(minMyGainPct),
-          maxMarketGainPct: Number(maxMarketGainPct),
-          limit: Number(limit),
-          perTeamLimit: Number(perTeamLimit),
-          minPlayerMyValue: Number(minPlayerValue),
-          positions: Array.from(positionFilters),
-          targetTeamOwnerIds: activeTargetOwnerIds,
-          seedPlayerNames: activeSeedNames,
-        }),
+        body: JSON.stringify(body),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || data?.error) {
@@ -240,10 +277,30 @@ export default function AnglePage() {
         <div>
           <h1 className="page-title">Angle</h1>
           <p className="page-subtitle muted" style={{ marginTop: 4 }}>
-            Build an offer from your roster; get counter-packages
-            (±1 in size) that win on your rankings but look fair-or-better on
-            the market the counterparty consults (IDPTC for IDP, KTC otherwise).
+            {mode === "acquire"
+              ? "Pick players on another team you want to acquire; get back offer packages from your roster (±1 in size) that win on your rankings but look fair-or-better on the market the counterparty consults (IDPTC for IDP, KTC otherwise)."
+              : "Build an offer from your roster; get counter-packages (±1 in size) that win on your rankings but look fair-or-better on the market the counterparty consults (IDPTC for IDP, KTC otherwise)."}
           </p>
+          <div className="angle-pill-row" style={{ marginTop: 10 }}>
+            <button
+              type="button"
+              className={`angle-pill ${mode === "offer" ? "angle-pill-active" : ""}`}
+              onClick={() => setMode("offer")}
+              disabled={busy}
+              title="Build an offer from your roster and get counter-packages from other teams."
+            >
+              Build an offer
+            </button>
+            <button
+              type="button"
+              className={`angle-pill ${mode === "acquire" ? "angle-pill-active" : ""}`}
+              onClick={() => setMode("acquire")}
+              disabled={busy}
+              title="Pick players you want to acquire from another team; get offer packages from your roster."
+            >
+              Acquire players
+            </button>
+          </div>
         </div>
       </div>
 
@@ -294,20 +351,22 @@ export default function AnglePage() {
               disabled={busy}
             />
           </label>
-          <label className="angle-field">
-            <span className="muted">
-              Max per team{" "}
-              <span className="angle-field-hint">(top N from each opposing roster)</span>
-            </span>
-            <input
-              type="number"
-              value={perTeamLimit}
-              min="1"
-              max="50"
-              onChange={(e) => setPerTeamLimit(e.target.value)}
-              disabled={busy}
-            />
-          </label>
+          {mode === "offer" && (
+            <label className="angle-field">
+              <span className="muted">
+                Max per team{" "}
+                <span className="angle-field-hint">(top N from each opposing roster)</span>
+              </span>
+              <input
+                type="number"
+                value={perTeamLimit}
+                min="1"
+                max="50"
+                onChange={(e) => setPerTeamLimit(e.target.value)}
+                disabled={busy}
+              />
+            </label>
+          )}
           <label className="angle-field">
             <span className="muted">Total results</span>
             <input
@@ -323,9 +382,19 @@ export default function AnglePage() {
             type="button"
             className="button button-primary angle-go"
             onClick={findAngles}
-            disabled={busy || !ownerId || offerList.length === 0}
+            disabled={
+              busy ||
+              !ownerId ||
+              (mode === "offer"
+                ? offerList.length === 0
+                : activeSeedNames.length === 0)
+            }
           >
-            {busy ? "Searching…" : `Find counter-packages (${offerList.length})`}
+            {busy
+              ? "Searching…"
+              : mode === "acquire"
+                ? `Find offer packages (${activeSeedNames.length})`
+                : `Find counter-packages (${offerList.length})`}
           </button>
         </div>
         {err && (
@@ -337,9 +406,15 @@ export default function AnglePage() {
 
       <section className="card angle-filter-card">
         <div className="angle-filter-head">
-          <strong>Counter-package filters</strong>
+          <strong>
+            {mode === "acquire"
+              ? "Offer package filters"
+              : "Counter-package filters"}
+          </strong>
           <span className="muted">
-            Narrow the candidates the search considers from other teams.
+            {mode === "acquire"
+              ? "Narrow the offer-side candidates the search considers from your roster."
+              : "Narrow the candidates the search considers from other teams."}
           </span>
         </div>
         <div className="angle-filter-row">
@@ -407,12 +482,15 @@ export default function AnglePage() {
 
       <section className="card angle-targets-card">
         <div className="angle-filter-head">
-          <strong>Trade with specific teams (optional)</strong>
+          <strong>
+            {mode === "acquire"
+              ? "Players to acquire"
+              : "Trade with specific teams (optional)"}
+          </strong>
           <span className="muted">
-            Pick up to 2 opposing teams. Check off any "must-have" players
-            from their rosters and the search will build counter-packages
-            that include those seeds and fill the rest from the selected
-            teams' top players.
+            {mode === "acquire"
+              ? "Pick up to 2 opposing teams and check off the players you want to acquire. The search will build offer packages from your roster that land these players."
+              : "Pick up to 2 opposing teams. Check off any \"must-have\" players from their rosters and the search will build counter-packages that include those seeds and fill the rest from the selected teams' top players."}
           </span>
         </div>
         <div className="angle-targets-row">
@@ -502,6 +580,7 @@ export default function AnglePage() {
         </div>
       </section>
 
+      {mode === "offer" && (
       <section className="card angle-offer-bar">
         <div className="angle-offer-head">
           <strong>Your offer ({offerList.length} player{offerList.length === 1 ? "" : "s"})</strong>
@@ -592,6 +671,7 @@ export default function AnglePage() {
           )}
         </div>
       </section>
+      )}
 
       {result?.warnings?.length ? (
         <section className="card angle-warnings">
@@ -607,13 +687,30 @@ export default function AnglePage() {
       {result?.candidates?.length ? (
         <section className="card angle-results">
           <div className="angle-section-head">
-            <h2>Counter-packages ({result.candidates.length})</h2>
+            <h2>
+              {result?.mode === "acquire"
+                ? `Offer packages (${result.candidates.length})`
+                : `Counter-packages (${result.candidates.length})`}
+            </h2>
             <span className="muted">
-              Sorted by arbitrage score (my gain % − market gap %). Market is
-              IDPTC for IDP, KTC otherwise. Sizes allowed:{" "}
-              {(result.thresholds?.target_sizes || []).join(", ")}.
+              {result?.mode === "acquire"
+                ? `Sorted by arbitrage score (my gain % − market gap %). Each package is from your roster and lands the ${result.acquire?.size || "?"} player(s) above. Market is IDPTC for IDP, KTC otherwise. Sizes allowed: ${(result.thresholds?.target_sizes || []).join(", ")}.`
+                : `Sorted by arbitrage score (my gain % − market gap %). Market is IDPTC for IDP, KTC otherwise. Sizes allowed: ${(result.thresholds?.target_sizes || []).join(", ")}.`}
             </span>
           </div>
+          {result?.mode === "acquire" && result.acquire?.players?.length ? (
+            <div className="angle-acquire-summary muted" style={{ marginBottom: 12 }}>
+              <strong>Acquiring:</strong>{" "}
+              {result.acquire.players
+                .map(
+                  (p) =>
+                    `${p.name} (${p.position}, my ${Number(p.my_value).toLocaleString()} · ${marketLabelForSource(p.market_source)} ${Number(p.market_value).toLocaleString()})`,
+                )
+                .join(" + ")}{" "}
+              · my total <strong>{Number(result.acquire.my_total).toLocaleString()}</strong> · market total{" "}
+              <strong>{Number(result.acquire.market_total).toLocaleString()}</strong>
+            </div>
+          ) : null}
           <div className="angle-package-grid">
             {result.candidates.map((c, i) => (
               <div key={i} className="angle-package">
@@ -621,7 +718,9 @@ export default function AnglePage() {
                   <div>
                     <strong>#{i + 1}</strong>{" "}
                     <span className="muted">
-                      {c.team} · {c.size}-for-{result.offer?.size || "?"}
+                      {result?.mode === "acquire"
+                        ? `${result.acquire?.team || "You"} offer · ${c.size}-for-${result.acquire?.size || "?"}`
+                        : `${c.team} · ${c.size}-for-${result.offer?.size || "?"}`}
                     </span>
                   </div>
                   <div className="angle-package-scores">
@@ -669,10 +768,9 @@ export default function AnglePage() {
       ) : result && !busy ? (
         <section className="card">
           <p className="muted">
-            No counter-packages match. Loosen the thresholds (lower
-            "Min my-value gain %" or raise "Max market gap %"), pick
-            different offer players, or widen the candidate pool on
-            the backend.
+            {result?.mode === "acquire"
+              ? "No offer packages match. Loosen the thresholds (lower \"Min my-value gain %\" or raise \"Max market gap %\"), pick different acquisition targets, or raise the candidate pool cap."
+              : "No counter-packages match. Loosen the thresholds (lower \"Min my-value gain %\" or raise \"Max market gap %\"), pick different offer players, or widen the candidate pool on the backend."}
           </p>
         </section>
       ) : null}

--- a/server.py
+++ b/server.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, BackgroundTasks, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, Response, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -2357,15 +2358,33 @@ async def post_angle_find(request: Request):
 
 @app.post("/api/angle/packages")
 async def post_angle_packages(request: Request):
-    """Multi-player variant of Angle. Offer a list of your players,
-    get back counter-packages from other teams sized within ±1 of
-    your offer that still lean your way on my-value but look fair-or-
-    better to the counterparty on KTC.
+    """Multi-player variant of Angle. Two modes:
 
-    Body:
+    * ``mode: "offer"`` (default) — offer a list of your players, get
+      back counter-packages from other teams sized within ±1 of your
+      offer that lean your way on my-value but look fair-or-better to
+      the counterparty on market.
+    * ``mode: "acquire"`` — pick players on opposing rosters you want
+      to acquire; get back offer-side packages from YOUR OWN roster
+      (size within ±1 of the desired count) that satisfy the same
+      arbitrage math. Lets you skip picking your own players upfront.
+
+    Body (offer mode):
         {
+          "mode": "offer",                      // optional, default
           "ownerId": "472206636534984704",
-          "playerNames": ["Jayden Daniels", "CeeDee Lamb", ...],
+          "playerNames": ["Jayden Daniels", ...],
+          "minMyGainPct": 5.0,
+          "maxMarketGainPct": 5.0,
+          "limit": 50,
+          "candidatePoolPerTeam": 25
+        }
+
+    Body (acquire mode):
+        {
+          "mode": "acquire",
+          "ownerId": "472206636534984704",
+          "acquirePlayerNames": ["Ja'Marr Chase", "Bijan Robinson"],
           "minMyGainPct": 5.0,
           "maxMarketGainPct": 5.0,
           "limit": 50,
@@ -2395,11 +2414,33 @@ async def post_angle_packages(request: Request):
         return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
 
     owner_id = str(body.get("ownerId") or "").strip()
-    names = body.get("playerNames") or []
+    mode = str(body.get("mode") or "offer").strip().lower()
+    if mode not in ("offer", "acquire"):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "'mode' must be 'offer' or 'acquire'."},
+        )
+
+    # In offer mode the user builds an offer from their roster and the
+    # search returns counter-packages from other teams. In acquire
+    # mode the user picks players on opposing rosters they want to
+    # acquire and the search returns offer-side packages from their
+    # own roster.
+    if mode == "acquire":
+        names_key = "acquirePlayerNames"
+        names = body.get(names_key) or body.get("playerNames") or []
+    else:
+        names_key = "playerNames"
+        names = body.get(names_key) or []
     if not owner_id or not isinstance(names, list) or not names:
         return JSONResponse(
             status_code=400,
-            content={"error": "Request body must include 'ownerId' and a non-empty 'playerNames' list."},
+            content={
+                "error": (
+                    f"Request body must include 'ownerId' and a non-empty "
+                    f"{names_key!r} list."
+                )
+            },
         )
     player_names = [str(n).strip() for n in names if str(n).strip()]
 
@@ -2422,6 +2463,32 @@ async def post_angle_packages(request: Request):
     if not isinstance(positions_req, list):
         positions_req = []
     positions_req = [str(p).strip() for p in positions_req if str(p).strip()]
+
+    if mode == "acquire":
+        from src.trade.angle import find_acquisition_packages
+
+        try:
+            result = await run_in_threadpool(
+                find_acquisition_packages,
+                players_array,
+                player_names,
+                owner_id,
+                sleeper_teams,
+                min_my_gain_pct=min_my,
+                max_market_gain_pct=max_market,
+                limit=limit,
+                candidate_pool=pool,
+                positions=positions_req or None,
+                min_player_my_value=min_player,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.error(f"Angle acquire failed: {exc}")
+            return JSONResponse(
+                status_code=500,
+                content={"error": f"Angle acquire failed: {exc}"},
+            )
+        result = {"mode": "acquire", **result}
+        return JSONResponse(content=result)
 
     target_teams_req = body.get("targetTeamOwnerIds") or []
     if not isinstance(target_teams_req, list):
@@ -2458,6 +2525,7 @@ async def post_angle_packages(request: Request):
             status_code=500,
             content={"error": f"Angle packages failed: {exc}"},
         )
+    result = {"mode": "offer", **result}
     return JSONResponse(content=result)
 
 

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -604,3 +604,266 @@ def find_angle_packages(
         },
         "warnings": warnings,
     }
+
+
+def find_acquisition_packages(
+    players_array: list[dict[str, Any]],
+    desired_player_names: list[str],
+    selected_team_owner_id: str,
+    sleeper_teams: list[dict[str, Any]],
+    *,
+    min_my_gain_pct: float = 5.0,
+    max_market_gain_pct: float = 5.0,
+    limit: int = 50,
+    candidate_pool: int = 25,
+    positions: list[str] | None = None,
+    min_player_my_value: float = 0.0,
+) -> dict[str, Any]:
+    """Find offer-side packages from the user's roster that acquire a
+    fixed set of desired players from other teams.
+
+    Inverse of :func:`find_angle_packages`. The user picks players on
+    opposing rosters they want to acquire; this enumerates combinations
+    of their own roster (size within ±1 of the desired count) and
+    keeps those that (a) leave the user ahead on my-value by at least
+    ``min_my_gain_pct`` and (b) look fair-or-better to the counterparty
+    on the market the counterparty consults (IDPTC for IDP, KTC
+    otherwise), gap ≤ ``max_market_gain_pct``.
+
+    Parameters
+    ----------
+    desired_player_names
+        Canonical names of players the user wants to acquire. They
+        must each be owned by a team OTHER than ``selected_team_owner_id``.
+        Any missing or user-owned names are dropped with a warning.
+    candidate_pool
+        Top-N players (by ``rankDerivedValue``) from the user's own
+        roster to enumerate combinations from. Caps combinatorial
+        explosion.
+
+    Returns
+    -------
+    dict
+        ``{acquire: {...}, candidates: [{...}], thresholds, warnings}``
+        where each candidate is an offer-side package from the user's
+        roster satisfying the arbitrage constraints vs the fixed
+        desired package. Sorted by ``arb_score`` desc.
+    """
+    warnings: list[str] = []
+
+    by_name: dict[str, dict[str, Any]] = {}
+    for row in players_array:
+        name = str(row.get("canonicalName") or row.get("displayName") or "")
+        if name and name not in by_name:
+            by_name[name] = row
+
+    # Locate the user's team and build a reverse index so we can
+    # validate desired players are on opposing rosters.
+    my_team: dict[str, Any] | None = None
+    owner_by_player: dict[str, str] = {}
+    for team in sleeper_teams:
+        owner = str(team.get("ownerId") or "")
+        if owner == selected_team_owner_id:
+            my_team = team
+        for pname in team.get("players") or []:
+            owner_by_player[str(pname)] = owner
+
+    if my_team is None:
+        return {
+            "acquire": {
+                "players": [],
+                "size": 0,
+                "my_total": 0,
+                "market_total": 0,
+                "targets": [],
+            },
+            "candidates": [],
+            "warnings": [f"Owner {selected_team_owner_id!r} not found in sleeper rosters."],
+        }
+
+    # Resolve desired players. Drop unknowns, self-owned, and rows
+    # missing values — each with a warning.
+    desired_rows: list[dict[str, Any]] = []
+    desired_owners: dict[str, str] = {}
+    missing: list[str] = []
+    own_roster: list[str] = []
+    for name in desired_player_names:
+        name = str(name).strip()
+        if not name:
+            continue
+        row = by_name.get(name)
+        if not row:
+            missing.append(name)
+            continue
+        owner_of = owner_by_player.get(name)
+        if owner_of == selected_team_owner_id:
+            own_roster.append(name)
+            continue
+        pair = _value_pair(row)
+        if pair is None:
+            missing.append(name)
+            continue
+        desired_rows.append(row)
+        desired_owners[name] = owner_of or ""
+    if missing:
+        warnings.append(
+            f"Dropped {len(missing)} desired player(s) with missing data: "
+            f"{', '.join(missing[:5])}"
+            + (" …" if len(missing) > 5 else "")
+        )
+    if own_roster:
+        warnings.append(
+            f"Dropped {len(own_roster)} player(s) already on your roster: "
+            f"{', '.join(own_roster[:5])}"
+            + (" …" if len(own_roster) > 5 else "")
+        )
+    if not desired_rows:
+        return {
+            "acquire": {
+                "players": [],
+                "size": 0,
+                "my_total": 0,
+                "market_total": 0,
+                "targets": [],
+            },
+            "candidates": [],
+            "warnings": warnings or ["No valid desired-acquisition players."],
+        }
+
+    desired_my_total = sum(_value_pair(r)[0] for r in desired_rows)  # type: ignore[index]
+    desired_market_total = sum(_value_pair(r)[1] for r in desired_rows)  # type: ignore[index]
+    desired_size = len(desired_rows)
+
+    target_sizes = sorted({max(1, desired_size - 1), desired_size, desired_size + 1})
+
+    position_filter: set[str] | None = None
+    if positions:
+        position_filter = {str(p).strip().upper() for p in positions if str(p).strip()}
+        if not position_filter:
+            position_filter = None
+    min_my_value_floor = max(0.0, float(min_player_my_value or 0.0))
+
+    # Build offer-side pool from the user's own roster.
+    desired_name_set = {str(r.get("canonicalName") or "") for r in desired_rows}
+    pool: list[dict[str, Any]] = []
+    for pname in my_team.get("players") or []:
+        pname = str(pname)
+        if pname in desired_name_set:
+            continue  # not on user's roster anyway, but guard
+        row = by_name.get(pname)
+        if not row:
+            continue
+        pair = _value_pair(row)
+        if pair is None:
+            continue
+        my_v, market_v, market_source = pair
+        row_pos = str(row.get("position") or "").strip().upper()
+        if position_filter is not None and row_pos not in position_filter:
+            continue
+        if my_v < min_my_value_floor:
+            continue
+        pool.append(
+            {
+                "name": pname,
+                "position": str(row.get("position") or ""),
+                "my_value": my_v,
+                "market_value": market_v,
+                "market_source": market_source,
+            }
+        )
+    pool.sort(key=lambda p: -p["my_value"])
+    pool = pool[: max(1, int(candidate_pool))]
+
+    # Arbitrage math: user receives ``desired_*``, gives ``offer_*``.
+    # my_gain = (desired - offer) / offer ≥ min_my_gain_pct
+    #   → offer_my ≤ desired_my / (1 + min_my_gain_pct/100)
+    # market_gap = (desired - offer) / offer ≤ max_market_gain_pct
+    #   → offer_market ≥ desired_market / (1 + max_market_gain_pct/100)
+    max_offer_my = desired_my_total / (1.0 + min_my_gain_pct / 100.0)
+    min_offer_market = desired_market_total / (1.0 + max_market_gain_pct / 100.0)
+
+    def _make_candidate(combo: tuple[dict[str, Any], ...]) -> dict[str, Any] | None:
+        offer_my = sum(p["my_value"] for p in combo)
+        if offer_my <= 0 or offer_my > max_offer_my:
+            return None
+        offer_market = sum(p["market_value"] for p in combo)
+        if offer_market < min_offer_market:
+            return None
+        my_gain_pct = 100.0 * (desired_my_total - offer_my) / offer_my
+        market_gain_pct = 100.0 * (desired_market_total - offer_market) / offer_market
+        return {
+            "size": len(combo),
+            "players": [
+                {
+                    "name": p["name"],
+                    "position": p["position"],
+                    "my_value": int(p["my_value"]),
+                    "market_value": int(p["market_value"]),
+                    "market_source": p["market_source"],
+                }
+                for p in combo
+            ],
+            "my_total": int(round(offer_my)),
+            "market_total": int(round(offer_market)),
+            "my_gain_pct": round(my_gain_pct, 2),
+            "market_gain_pct": round(market_gain_pct, 2),
+            "arb_score": round(my_gain_pct - market_gain_pct, 2),
+        }
+
+    candidates: list[dict[str, Any]] = []
+    for size in target_sizes:
+        if len(pool) < size:
+            continue
+        for combo in combinations(pool, size):
+            cand = _make_candidate(combo)
+            if cand is not None:
+                candidates.append(cand)
+
+    candidates.sort(key=lambda c: c["arb_score"], reverse=True)
+    candidates = candidates[: max(1, int(limit))]
+
+    desired_players = []
+    for r in desired_rows:
+        pair = _value_pair(r)
+        dname = str(r.get("canonicalName") or "")
+        desired_players.append(
+            {
+                "name": dname,
+                "position": str(r.get("position") or ""),
+                "my_value": int(pair[0]) if pair else 0,
+                "market_value": int(pair[1]) if pair else 0,
+                "market_source": pair[2] if pair else _market_source_for(r.get("position")),
+                "owner_id": desired_owners.get(dname, ""),
+            }
+        )
+
+    # Deduplicated list of target teams the desired players come from.
+    targets: list[dict[str, Any]] = []
+    seen_owners: set[str] = set()
+    for team in sleeper_teams:
+        owner = str(team.get("ownerId") or "")
+        if owner in desired_owners.values() and owner not in seen_owners:
+            targets.append({"team": str(team.get("name") or ""), "owner_id": owner})
+            seen_owners.add(owner)
+
+    return {
+        "acquire": {
+            "team": my_team.get("name"),
+            "size": desired_size,
+            "players": desired_players,
+            "my_total": int(round(desired_my_total)),
+            "market_total": int(round(desired_market_total)),
+            "targets": targets,
+        },
+        "candidates": candidates,
+        "thresholds": {
+            "min_my_gain_pct": min_my_gain_pct,
+            "max_market_gain_pct": max_market_gain_pct,
+            "limit": limit,
+            "candidate_pool": candidate_pool,
+            "target_sizes": target_sizes,
+            "positions": sorted(position_filter) if position_filter else [],
+            "min_player_my_value": int(min_my_value_floor),
+        },
+        "warnings": warnings,
+    }

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import pytest
 
-from src.trade.angle import find_angle_packages, find_angles
+from src.trade.angle import (
+    find_acquisition_packages,
+    find_angle_packages,
+    find_angles,
+)
 
 
 def _player(name, my_val, ktc_val, *, position="QB"):
@@ -622,6 +626,173 @@ def test_offense_players_still_compared_on_ktc():
     )
     cand = next(c for c in result2["candidates"] if c["name"] == "Other QB")
     assert cand["market_source"] == "ktc"
+
+
+# ─── find_acquisition_packages ───────────────────────────────────────
+
+
+def _acq_teams():
+    return [
+        {
+            "name": "Team A",
+            "ownerId": "owner-a",
+            "players": ["My QB1", "My WR1", "My WR2", "My Bench"],
+        },
+        {
+            "name": "Team B",
+            "ownerId": "owner-b",
+            "players": ["Target Star", "B Filler"],
+        },
+        {
+            "name": "Team C",
+            "ownerId": "owner-c",
+            "players": ["Target Gold"],
+        },
+    ]
+
+
+def _acq_players():
+    return [
+        # My roster: a couple of good offerables + deep bench.
+        _player("My QB1", my_val=5500, ktc_val=5200),
+        _player("My WR1", my_val=4800, ktc_val=4900),
+        _player("My WR2", my_val=4500, ktc_val=4600),
+        _player("My Bench", my_val=200, ktc_val=200),
+        # Acquisition targets on other teams.
+        _player("Target Star", my_val=6500, ktc_val=5200),  # nice arb
+        _player("B Filler", my_val=300, ktc_val=300),
+        _player("Target Gold", my_val=9000, ktc_val=8500),
+    ]
+
+
+def test_acquire_returns_offer_packages_from_user_roster():
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+    )
+    assert result["acquire"]["size"] == 1
+    # Every candidate player must come from the user's roster.
+    own_roster = {"My QB1", "My WR1", "My WR2", "My Bench"}
+    for c in result["candidates"]:
+        names = {p["name"] for p in c["players"]}
+        assert names <= own_roster, f"candidate leaks non-own players: {names}"
+
+
+def test_acquire_candidate_sizes_within_plus_minus_one():
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star", "B Filler"], "owner-a", _acq_teams(),
+    )
+    # Desired N=2 → sizes {1,2,3}
+    assert set(result["thresholds"]["target_sizes"]) == {1, 2, 3}
+    for c in result["candidates"]:
+        assert c["size"] in {1, 2, 3}
+
+
+def test_acquire_my_gain_threshold_enforced():
+    # Desired my_val = 6500. Lone offer "My QB1" has my_val 5500 →
+    # (6500-5500)/5500 = 18.2% my-gain. With min_my_gain_pct=25, no
+    # single-player combo qualifies and only multi-player combos that
+    # under-shoot enough on my-value remain.
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        min_my_gain_pct=25.0,
+    )
+    for c in result["candidates"]:
+        assert c["my_gain_pct"] >= 25.0 - 1e-6
+
+
+def test_acquire_market_gap_threshold_enforced():
+    # Target Star KTC=5200. My QB1 KTC=5200 → gap 0%. With
+    # max_market_gain_pct=2, the single-player My QB1 offer is the
+    # tightest fit.
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        min_my_gain_pct=5.0, max_market_gain_pct=2.0,
+    )
+    assert result["candidates"], "expected at least one qualifying offer"
+    for c in result["candidates"]:
+        assert c["market_gain_pct"] <= 2.0 + 1e-6
+
+
+def test_acquire_rejects_own_roster_targets_with_warning():
+    # "My QB1" is on owner-a's roster — can't "acquire" from yourself.
+    result = find_acquisition_packages(
+        _acq_players(), ["My QB1"], "owner-a", _acq_teams(),
+    )
+    assert result["acquire"]["size"] == 0
+    assert result["candidates"] == []
+    assert any("already on your roster" in w for w in result["warnings"])
+
+
+def test_acquire_unknown_targets_dropped_with_warning():
+    result = find_acquisition_packages(
+        _acq_players(), ["Ghost Player", "Target Star"], "owner-a", _acq_teams(),
+    )
+    assert result["acquire"]["size"] == 1
+    assert any("Ghost Player" in w for w in result["warnings"])
+
+
+def test_acquire_sorts_by_arb_score_desc():
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+    )
+    scores = [c["arb_score"] for c in result["candidates"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_acquire_target_team_list_in_response():
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star", "Target Gold"], "owner-a", _acq_teams(),
+    )
+    owner_ids = {t["owner_id"] for t in result["acquire"]["targets"]}
+    assert owner_ids == {"owner-b", "owner-c"}
+
+
+def test_acquire_unknown_owner_returns_warning():
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star"], "owner-missing", _acq_teams(),
+    )
+    assert result["candidates"] == []
+    assert any("not found" in w for w in result["warnings"])
+
+
+def test_acquire_respects_position_filter_on_own_roster():
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        positions=["WR"],
+    )
+    for c in result["candidates"]:
+        for p in c["players"]:
+            assert p["position"] == "WR"
+
+
+def test_acquire_respects_min_player_value_on_own_roster():
+    # With floor 3000, "My Bench" (my_val=200) is excluded.
+    result = find_acquisition_packages(
+        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        min_player_my_value=3000,
+    )
+    names = {p["name"] for c in result["candidates"] for p in c["players"]}
+    assert "My Bench" not in names
+
+
+def test_acquire_idp_target_compares_on_idptc():
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My DL"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Target DL"]},
+    ]
+    # IDPTC: 5000 vs 5100 (1% gap — fair on IDPTC). KTC: 5000 vs 7000
+    # (40% gap — would reject). Per-position rule uses IDPTC for DL.
+    players = [
+        _player_with_markets("My DL", 5000, 5000, 5000, position="DL"),
+        _player_with_markets("Target DL", 6000, 7000, 5100, position="DL"),
+    ]
+    result = find_acquisition_packages(
+        players, ["Target DL"], "owner-a", teams,
+        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+    )
+    assert result["candidates"], "IDP acquire should qualify on IDPTC"
+    # market source stamped on acquire and candidate rows.
+    assert result["acquire"]["players"][0]["market_source"] == "idpTradeCalc"
 
 
 def test_packages_player_rows_expose_per_position_market_source():


### PR DESCRIPTION
## Summary
- **Bug fix**: `server.py` used `run_in_threadpool` without importing it, so every Angle (and KTC arbitrage) request 500-ed with `name 'run_in_threadpool' is not defined`. Added `from fastapi.concurrency import run_in_threadpool`.
- **New feature (acquire-only mode)**: on the Angle page you no longer have to pick your own offer players first. Toggle to **Acquire players**, select players on an opposing team you want to acquire, and the engine returns offer packages from **your** roster (±1 in size) that satisfy the same arbitrage math — my-value gain % ≥ threshold, market gap % ≤ threshold, per-position market anchor (IDPTC for DL/LB/DB, KTC otherwise).

## Changes
- `src/trade/angle.py` — add `find_acquisition_packages`, the inverse of `find_angle_packages`. Desired players are fixed, offer-side combinations enumerated from the user's own roster.
- `server.py` — `/api/angle/packages` now accepts `mode: "offer" | "acquire"` and dispatches. Response tagged with `mode`. Legacy `mode: "offer"` keeps the existing contract.
- `frontend/app/angle/page.jsx` — mode toggle pills at the top; in acquire mode the offer section is hidden, the target-teams section becomes the primary selection, filter/result labels adapt, button reads "Find offer packages (N)".
- `tests/test_trade_angle.py` — 12 new tests: size ±1, threshold enforcement, own-roster guards, per-position market anchor, position/min-value filters, sort order, warnings for missing/self-owned targets.

## Test plan
- [x] `python -m pytest tests/ -q` → 1705 passed, 25 skipped.
- [ ] Manual: open /angle, switch to "Acquire players", pick an opposing team and a couple targets, verify offer packages render correctly with "N-for-M" counts and market labels.
- [ ] Manual: confirm the original "Build an offer" flow still works (regression check).

https://claude.ai/code/session_01Ub5VxtesVQw7VGJPH4cgEC