### PR TITLE
Angle: apply KTC-style Value Adjustment + default-exclude IDP

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -17,7 +17,12 @@ const DEFAULT_LIMIT = 50;
 const DEFAULT_PER_TEAM = 4;
 const DEFAULT_MIN_PLAYER_VALUE = 3000;
 const POSITION_FILTERS = ["QB", "RB", "WR", "TE", "DL", "LB", "DB"];
+const IDP_POSITION_FILTERS = new Set(["DL", "LB", "DB"]);
 const IDP_POS_RE = /^(?:DL|DE|DT|EDGE|NT|LB|ILB|OLB|MLB|DB|CB|S|SS|FS)$/i;
+
+function isIdpPos(position) {
+  return IDP_POS_RE.test(String(position || "").trim());
+}
 
 function marketSourceForPos(position) {
   return IDP_POS_RE.test(String(position || "").trim()) ? "idpTradeCalc" : "ktc";
@@ -79,6 +84,13 @@ export default function AnglePage() {
   // we search their own roster for offer-side packages. Lets the
   // user skip selecting their own players first.
   const [mode, setMode] = useState("offer");
+  // IDP opt-in. Default OFF — most leaguemates don't value IDP the
+  // way KTC/our board do, so by default we exclude IDP from the
+  // candidate pool the search enumerates. Auto-flips to ON whenever
+  // the user picks an IDP position filter pill or explicitly selects
+  // an IDP player on the fixed side (offer in offer-mode, desired
+  // acquisition in acquire-mode).
+  const [includeIdp, setIncludeIdp] = useState(false);
   const [result, setResult] = useState(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
@@ -192,6 +204,28 @@ export default function AnglePage() {
     return out;
   }, [activeTargetOwnerIds, seedsByOwner]);
 
+  // An IDP position pill is active → user is explicitly asking for
+  // IDP in the pool. An IDP player is on the fixed side (offer in
+  // offer-mode, acquisition list in acquire-mode) → user is already
+  // trading IDP, so the search should be allowed to counter with it.
+  // Either condition forces the effective IDP gate open regardless of
+  // the manual toggle — matches the user brief: "unless I specifically
+  // add IDP players […] it won't try to build the trades using any
+  // IDP players."
+  const idpInPositionFilters = useMemo(
+    () => Array.from(positionFilters).some((p) => IDP_POSITION_FILTERS.has(p)),
+    [positionFilters],
+  );
+  const idpOnFixedSide = useMemo(() => {
+    const names = mode === "acquire" ? activeSeedNames : offerList;
+    return names.some((n) => {
+      const info = valueByName.get(n);
+      return info && isIdpPos(info.position);
+    });
+  }, [mode, activeSeedNames, offerList, valueByName]);
+  const effectiveIncludeIdp =
+    includeIdp || idpInPositionFilters || idpOnFixedSide;
+
   async function findAngles() {
     if (!ownerId) {
       setErr("Pick your team.");
@@ -221,6 +255,7 @@ export default function AnglePage() {
               limit: Number(limit),
               minPlayerMyValue: Number(minPlayerValue),
               positions: Array.from(positionFilters),
+              includeIdp: effectiveIncludeIdp,
             }
           : {
               mode: "offer",
@@ -234,6 +269,7 @@ export default function AnglePage() {
               positions: Array.from(positionFilters),
               targetTeamOwnerIds: activeTargetOwnerIds,
               seedPlayerNames: activeSeedNames,
+              includeIdp: effectiveIncludeIdp,
             };
       const res = await fetch("/api/angle/packages", {
         method: "POST",
@@ -475,6 +511,34 @@ export default function AnglePage() {
               Each individual player in a counter-package must have a
               my-value at or above this. Default 3,000 filters out
               deep-bench filler.
+            </span>
+          </div>
+          <div className="angle-filter-group">
+            <span className="muted">IDP players</span>
+            <div className="angle-pill-row">
+              <button
+                type="button"
+                className={`angle-pill ${effectiveIncludeIdp ? "angle-pill-active" : ""}`}
+                onClick={() => setIncludeIdp((v) => !v)}
+                disabled={busy || idpInPositionFilters || idpOnFixedSide}
+                title={
+                  idpOnFixedSide
+                    ? "Forced ON — you've already put an IDP player on the trade."
+                    : idpInPositionFilters
+                      ? "Forced ON — an IDP position is in the pill filter."
+                      : effectiveIncludeIdp
+                        ? "IDP players can appear in counter-packages."
+                        : "IDP players excluded from counter-packages by default (toggle on to include)."
+                }
+              >
+                {effectiveIncludeIdp ? "Include IDP" : "Exclude IDP (default)"}
+              </button>
+            </div>
+            <span className="angle-field-hint">
+              Most managers don't value IDP the way our board does, so
+              the search excludes them from counter/offer packages
+              unless you toggle this on, put an IDP position pill
+              above, or explicitly add an IDP player to the trade.
             </span>
           </div>
         </div>
@@ -757,9 +821,31 @@ export default function AnglePage() {
                   ))}
                 </ul>
                 <div className="angle-package-totals muted">
-                  my total <strong>{c.my_total.toLocaleString()}</strong>{" "}
-                  · market total{" "}
+                  my total <strong>{c.my_total.toLocaleString()}</strong>
+                  {c.my_value_adjustment > 0 ? (
+                    <>
+                      {" "}
+                      <span
+                        title="KTC-style Value Adjustment (consolidation premium) applied to the smaller side"
+                      >
+                        (+{c.my_value_adjustment.toLocaleString()} VA ={" "}
+                        <strong>{c.my_total_adjusted.toLocaleString()}</strong>)
+                      </span>
+                    </>
+                  ) : null}
+                  {" "}· market total{" "}
                   <strong>{c.market_total.toLocaleString()}</strong>
+                  {c.market_value_adjustment > 0 ? (
+                    <>
+                      {" "}
+                      <span title="KTC-style Value Adjustment on the market side">
+                        (+{c.market_value_adjustment.toLocaleString()} VA ={" "}
+                        <strong>
+                          {c.market_total_adjusted.toLocaleString()}
+                        </strong>)
+                      </span>
+                    </>
+                  ) : null}
                 </div>
               </div>
             ))}

--- a/server.py
+++ b/server.py
@@ -2466,6 +2466,16 @@ async def post_angle_packages(request: Request):
 
     include_idp_raw = body.get("includeIdp", False)
     include_idp = bool(include_idp_raw) and include_idp_raw not in ("false", "0", "")
+    # Back-compat: if the caller explicitly requested an IDP position
+    # via ``positions`` but didn't set ``includeIdp`` (e.g. legacy
+    # scripts predating the toggle), treat that as an implicit opt-in.
+    # Otherwise ``positions=["DL"]`` alone would filter the pool down
+    # to zero candidates, which silently breaks those callers.
+    from src.trade.angle import _IDP_POSITIONS as _ANGLE_IDP_POSITIONS
+    if not include_idp and any(
+        str(p).strip().upper() in _ANGLE_IDP_POSITIONS for p in positions_req
+    ):
+        include_idp = True
 
     if mode == "acquire":
         from src.trade.angle import find_acquisition_packages

--- a/server.py
+++ b/server.py
@@ -2464,6 +2464,9 @@ async def post_angle_packages(request: Request):
         positions_req = []
     positions_req = [str(p).strip() for p in positions_req if str(p).strip()]
 
+    include_idp_raw = body.get("includeIdp", False)
+    include_idp = bool(include_idp_raw) and include_idp_raw not in ("false", "0", "")
+
     if mode == "acquire":
         from src.trade.angle import find_acquisition_packages
 
@@ -2480,6 +2483,7 @@ async def post_angle_packages(request: Request):
                 candidate_pool=pool,
                 positions=positions_req or None,
                 min_player_my_value=min_player,
+                include_idp=include_idp,
             )
         except Exception as exc:  # noqa: BLE001
             log.error(f"Angle acquire failed: {exc}")
@@ -2518,6 +2522,7 @@ async def post_angle_packages(request: Request):
             min_player_my_value=min_player,
             target_team_owner_ids=target_teams_req or None,
             seed_player_names=seeds_req or None,
+            include_idp=include_idp,
         )
     except Exception as exc:  # noqa: BLE001
         log.error(f"Angle packages failed: {exc}")

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -28,11 +28,91 @@ players by your calibrated value so the search stays fast.
 from __future__ import annotations
 
 from itertools import combinations
-from typing import Any
+from typing import Any, Iterable, Sequence
 
 _IDP_POSITIONS: frozenset[str] = frozenset(
     {"DL", "DE", "DT", "EDGE", "NT", "LB", "ILB", "OLB", "MLB", "DB", "CB", "S", "SS", "FS"}
 )
+
+# KTC-style Value Adjustment (V2) — ports the frontend formula in
+# ``frontend/lib/trade-logic.js`` (``_vaFromSortedSides``) so the Angle
+# engine stops treating a package of 4 filler players as equivalent to
+# 3 studs whose raw totals happen to match. Coefficients are calibrated
+# against 13 observed KTC data points; see the JS module docstring.
+#
+# Arbitrage math was previously pure sum-of-raw-totals, which is wrong
+# for uneven sizes: 3 stars for 4 scrubs can look fair on market and a
+# big win on my-value in raw terms, yet no leaguemate would accept it.
+# VA injects the consolidation premium on the SMALLER side — so the
+# side receiving more studs sees its effective total climb, and the
+# thresholds get evaluated on the adjusted numbers.
+_VA_SCARCITY_SLOPE = 3.75
+_VA_SCARCITY_INTERCEPT = 0.45
+_VA_SCARCITY_CAP = 0.55
+_VA_PER_EXTRA_BOOST = 1.4
+_VA_EFFECTIVE_CAP = 1.0
+_VA_POSITION_DECAY = 0.35
+
+
+def _value_adjustment(small: Sequence[float], large: Sequence[float]) -> float:
+    """Compute the V2 consolidation premium the ``small`` side gets
+    when trading against the (longer) ``large`` side.
+
+    Both sequences must be sorted descending. Matches
+    ``_vaFromSortedSides`` in ``frontend/lib/trade-logic.js``. Returns
+    ``0.0`` when sizes tie (no consolidation), when small is empty, or
+    when small's top piece is not above large's top piece.
+    """
+    if not small or small[0] <= 0:
+        return 0.0
+    if len(small) >= len(large):
+        return 0.0
+
+    top_small = small[0]
+    top_large = large[0] if large else 0.0
+    top_gap = max(0.0, (top_small - top_large) / top_small)
+    if top_gap == 0.0:
+        return 0.0
+
+    raw_scarcity = _VA_SCARCITY_SLOPE * top_gap - _VA_SCARCITY_INTERCEPT
+    top_scarcity = max(0.0, min(_VA_SCARCITY_CAP, raw_scarcity))
+
+    extras = list(large[len(small):])
+    adjustment = 0.0
+    for p, extra in enumerate(extras):
+        extra_gap = max(0.0, (top_small - extra) / top_small)
+        boost_term = _VA_PER_EXTRA_BOOST * max(0.0, extra_gap - top_gap)
+        effective = max(0.0, min(_VA_EFFECTIVE_CAP, top_scarcity + boost_term))
+        adjustment += extra * effective * (_VA_POSITION_DECAY ** p)
+    return adjustment
+
+
+def _adjusted_pair_totals(
+    small_values: Iterable[float],
+    large_values: Iterable[float],
+) -> tuple[float, float, float, float]:
+    """Apply VA to the smaller of two value lists.
+
+    Returns ``(small_adjusted, large_adjusted, small_va, large_va)``.
+    The longer side never receives VA; the shorter side gets the full
+    consolidation premium. When sizes are equal or either side is
+    empty, both adjustments are zero.
+    """
+    small_sorted = sorted((float(v) for v in small_values), reverse=True)
+    large_sorted = sorted((float(v) for v in large_values), reverse=True)
+    small_sum = sum(small_sorted)
+    large_sum = sum(large_sorted)
+    if len(small_sorted) == len(large_sorted) or not small_sorted or not large_sorted:
+        return small_sum, large_sum, 0.0, 0.0
+    if len(small_sorted) < len(large_sorted):
+        va = _value_adjustment(small_sorted, large_sorted)
+        return small_sum + va, large_sum, va, 0.0
+    va = _value_adjustment(large_sorted, small_sorted)
+    return small_sum, large_sum + va, 0.0, va
+
+
+def _is_idp_position(position: Any) -> bool:
+    return str(position or "").strip().upper() in _IDP_POSITIONS
 
 
 def _market_source_for(position: str | None) -> str:
@@ -236,6 +316,7 @@ def find_angle_packages(
     min_player_my_value: float = 0.0,
     target_team_owner_ids: list[str] | None = None,
     seed_player_names: list[str] | None = None,
+    include_idp: bool = False,
 ) -> dict[str, Any]:
     """Find multi-player counter-packages for a user-built offer.
 
@@ -265,6 +346,15 @@ def find_angle_packages(
         Minimum ``rankDerivedValue`` a player must have to be
         considered in the candidate pool. Caller uses this to say
         "don't suggest filler-depth guys in my counter-package."
+    include_idp
+        When ``False`` (default) IDP positions (DL/LB/DB and their
+        sub-positions) are filtered OUT of the candidate pool entirely.
+        Most managers don't value IDP the way KTC/our-board scores
+        them, so the default keeps counter-packages offense+picks
+        only. Set ``True`` (or explicitly include an IDP player in
+        the offer / seeds) to allow IDP candidates. Offer-side and
+        user-selected seeds are never filtered — the user's explicit
+        choices always win.
 
     Returns
     -------
@@ -356,9 +446,15 @@ def find_angle_packages(
             if pair is None:
                 continue
             my_v, market_v, market_source = pair
-            # Per-player filters: position allow-list and my-value floor.
+            # Per-player filters: position allow-list, my-value floor,
+            # and the IDP gate. IDP players get filtered out of the
+            # candidate pool by default because most leaguemates don't
+            # gravitate toward them — setting include_idp=True (or an
+            # IDP position in ``positions``) re-admits them.
             row_pos = str(row.get("position") or "").strip().upper()
             if position_filter is not None and row_pos not in position_filter:
+                continue
+            if not include_idp and row_pos in _IDP_POSITIONS:
                 continue
             if my_v < min_my_value_floor:
                 continue
@@ -375,10 +471,14 @@ def find_angle_packages(
         pool = pool[:candidate_pool_per_team]
         teams_pool.append((team, pool))
 
-    # Pre-compute numeric thresholds in absolute-value terms so the
-    # inner loop uses only arithmetic, no division.
-    min_my_total = offer_my_total * (1.0 + min_my_gain_pct / 100.0)
-    max_market_total = offer_market_total * (1.0 + max_market_gain_pct / 100.0)
+    # Offer-side value lists (sorted descending) used by the VA path
+    # below. We keep raw totals available for display/back-compat.
+    offer_my_values = sorted(
+        (float(_value_pair(r)[0]) for r in offer_rows), reverse=True,  # type: ignore[index]
+    )
+    offer_market_values = sorted(
+        (float(_value_pair(r)[1]) for r in offer_rows), reverse=True,  # type: ignore[index]
+    )
 
     # Normalise target-team + seed inputs for constructed-package mode.
     target_ids: set[str] = {
@@ -409,14 +509,37 @@ def find_angle_packages(
         team_label: str,
         owner_id_label: str,
     ) -> dict[str, Any] | None:
-        my_sum = sum(p["my_value"] for p in combo)
-        if my_sum < min_my_total:
+        # Apply KTC-style Value Adjustment so consolidation packages
+        # (e.g. 3 studs vs 4 filler pieces whose raws happen to match)
+        # don't slip through the thresholds on pure sum-of-raws.
+        counter_my_values = [p["my_value"] for p in combo]
+        counter_market_values = [p["market_value"] for p in combo]
+        (
+            counter_my_adj,
+            offer_my_adj,
+            counter_my_va,
+            offer_my_va,
+        ) = _adjusted_pair_totals(counter_my_values, offer_my_values)
+        (
+            counter_market_adj,
+            offer_market_adj,
+            counter_market_va,
+            offer_market_va,
+        ) = _adjusted_pair_totals(counter_market_values, offer_market_values)
+
+        if offer_my_adj <= 0 or offer_market_adj <= 0:
             return None
-        market_sum = sum(p["market_value"] for p in combo)
-        if market_sum > max_market_total:
+        my_gain_pct = 100.0 * (counter_my_adj - offer_my_adj) / offer_my_adj
+        market_gain_pct = (
+            100.0 * (counter_market_adj - offer_market_adj) / offer_market_adj
+        )
+        if my_gain_pct < min_my_gain_pct:
             return None
-        my_gain_pct = 100.0 * (my_sum - offer_my_total) / offer_my_total
-        market_gain_pct = 100.0 * (market_sum - offer_market_total) / offer_market_total
+        if market_gain_pct > max_market_gain_pct:
+            return None
+
+        my_sum = sum(counter_my_values)
+        market_sum = sum(counter_market_values)
         return {
             "team": team_label,
             "owner_id": owner_id_label,
@@ -433,6 +556,14 @@ def find_angle_packages(
             ],
             "my_total": int(round(my_sum)),
             "market_total": int(round(market_sum)),
+            "my_total_adjusted": int(round(counter_my_adj)),
+            "market_total_adjusted": int(round(counter_market_adj)),
+            "my_value_adjustment": int(round(counter_my_va)),
+            "market_value_adjustment": int(round(counter_market_va)),
+            "offer_my_total_adjusted": int(round(offer_my_adj)),
+            "offer_market_total_adjusted": int(round(offer_market_adj)),
+            "offer_my_value_adjustment": int(round(offer_my_va)),
+            "offer_market_value_adjustment": int(round(offer_market_va)),
             "my_gain_pct": round(my_gain_pct, 2),
             "market_gain_pct": round(market_gain_pct, 2),
             "arb_score": round(my_gain_pct - market_gain_pct, 2),
@@ -601,6 +732,7 @@ def find_angle_packages(
             "min_player_my_value": int(min_my_value_floor),
             "target_team_owner_ids": sorted(target_ids) if target_ids else [],
             "seed_player_names": sorted(seed_names_set) if target_ids else [],
+            "include_idp": bool(include_idp),
         },
         "warnings": warnings,
     }
@@ -618,6 +750,7 @@ def find_acquisition_packages(
     candidate_pool: int = 25,
     positions: list[str] | None = None,
     min_player_my_value: float = 0.0,
+    include_idp: bool = False,
 ) -> dict[str, Any]:
     """Find offer-side packages from the user's roster that acquire a
     fixed set of desired players from other teams.
@@ -760,6 +893,11 @@ def find_acquisition_packages(
         row_pos = str(row.get("position") or "").strip().upper()
         if position_filter is not None and row_pos not in position_filter:
             continue
+        # IDP gate — see docstring on find_angle_packages. Fixed side
+        # (desired players) is never filtered; this only restricts the
+        # offer-side pool built from the user's own roster.
+        if not include_idp and row_pos in _IDP_POSITIONS:
+            continue
         if my_v < min_my_value_floor:
             continue
         pool.append(
@@ -774,23 +912,48 @@ def find_acquisition_packages(
     pool.sort(key=lambda p: -p["my_value"])
     pool = pool[: max(1, int(candidate_pool))]
 
-    # Arbitrage math: user receives ``desired_*``, gives ``offer_*``.
-    # my_gain = (desired - offer) / offer ≥ min_my_gain_pct
-    #   → offer_my ≤ desired_my / (1 + min_my_gain_pct/100)
-    # market_gap = (desired - offer) / offer ≤ max_market_gain_pct
-    #   → offer_market ≥ desired_market / (1 + max_market_gain_pct/100)
-    max_offer_my = desired_my_total / (1.0 + min_my_gain_pct / 100.0)
-    min_offer_market = desired_market_total / (1.0 + max_market_gain_pct / 100.0)
+    # Desired-side value lists (sorted descending) for the VA path.
+    desired_my_values = sorted(
+        (float(_value_pair(r)[0]) for r in desired_rows), reverse=True,  # type: ignore[index]
+    )
+    desired_market_values = sorted(
+        (float(_value_pair(r)[1]) for r in desired_rows), reverse=True,  # type: ignore[index]
+    )
 
     def _make_candidate(combo: tuple[dict[str, Any], ...]) -> dict[str, Any] | None:
-        offer_my = sum(p["my_value"] for p in combo)
-        if offer_my <= 0 or offer_my > max_offer_my:
+        # Arbitrage math: user receives ``desired_*``, gives up
+        # ``offer_*``. Apply KTC-style VA so consolidation (e.g. giving
+        # 4 filler to land 3 studs) isn't treated as a fair swap just
+        # because raw totals line up — the consolidated side carries a
+        # premium on both my-value and market-value.
+        offer_my_values = [p["my_value"] for p in combo]
+        offer_market_values = [p["market_value"] for p in combo]
+        (
+            desired_my_adj,
+            offer_my_adj,
+            desired_my_va,
+            offer_my_va,
+        ) = _adjusted_pair_totals(desired_my_values, offer_my_values)
+        (
+            desired_market_adj,
+            offer_market_adj,
+            desired_market_va,
+            offer_market_va,
+        ) = _adjusted_pair_totals(desired_market_values, offer_market_values)
+
+        if offer_my_adj <= 0 or offer_market_adj <= 0:
             return None
-        offer_market = sum(p["market_value"] for p in combo)
-        if offer_market < min_offer_market:
+        my_gain_pct = 100.0 * (desired_my_adj - offer_my_adj) / offer_my_adj
+        market_gain_pct = (
+            100.0 * (desired_market_adj - offer_market_adj) / offer_market_adj
+        )
+        if my_gain_pct < min_my_gain_pct:
             return None
-        my_gain_pct = 100.0 * (desired_my_total - offer_my) / offer_my
-        market_gain_pct = 100.0 * (desired_market_total - offer_market) / offer_market
+        if market_gain_pct > max_market_gain_pct:
+            return None
+
+        offer_my_sum = sum(offer_my_values)
+        offer_market_sum = sum(offer_market_values)
         return {
             "size": len(combo),
             "players": [
@@ -803,8 +966,16 @@ def find_acquisition_packages(
                 }
                 for p in combo
             ],
-            "my_total": int(round(offer_my)),
-            "market_total": int(round(offer_market)),
+            "my_total": int(round(offer_my_sum)),
+            "market_total": int(round(offer_market_sum)),
+            "my_total_adjusted": int(round(offer_my_adj)),
+            "market_total_adjusted": int(round(offer_market_adj)),
+            "my_value_adjustment": int(round(offer_my_va)),
+            "market_value_adjustment": int(round(offer_market_va)),
+            "acquire_my_total_adjusted": int(round(desired_my_adj)),
+            "acquire_market_total_adjusted": int(round(desired_market_adj)),
+            "acquire_my_value_adjustment": int(round(desired_my_va)),
+            "acquire_market_value_adjustment": int(round(desired_market_va)),
             "my_gain_pct": round(my_gain_pct, 2),
             "market_gain_pct": round(market_gain_pct, 2),
             "arb_score": round(my_gain_pct - market_gain_pct, 2),
@@ -864,6 +1035,7 @@ def find_acquisition_packages(
             "target_sizes": target_sizes,
             "positions": sorted(position_filter) if position_filter else [],
             "min_player_my_value": int(min_my_value_floor),
+            "include_idp": bool(include_idp),
         },
         "warnings": warnings,
     }

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import pytest
 
 from src.trade.angle import (
+    _value_adjustment,
     find_acquisition_packages,
     find_angle_packages,
     find_angles,
@@ -786,9 +787,13 @@ def test_acquire_idp_target_compares_on_idptc():
         _player_with_markets("My DL", 5000, 5000, 5000, position="DL"),
         _player_with_markets("Target DL", 6000, 7000, 5100, position="DL"),
     ]
+    # include_idp must be True — the offer-side "My DL" would
+    # otherwise be filtered out of the candidate pool by the default
+    # IDP gate.
     result = find_acquisition_packages(
         players, ["Target DL"], "owner-a", teams,
         min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+        include_idp=True,
     )
     assert result["candidates"], "IDP acquire should qualify on IDPTC"
     # market source stamped on acquire and candidate rows.
@@ -821,3 +826,256 @@ def test_packages_player_rows_expose_per_position_market_source():
             elif p["position"] == "WR":
                 assert p["market_source"] == "ktc"
                 assert p["market_value"] == 5100  # KTC value
+
+
+# ─── Value Adjustment (consolidation premium) ────────────────────────
+
+
+def test_value_adjustment_matches_js_calibration_point_case_a():
+    """Parity check against JS ``_vaFromSortedSides`` (Case A in the
+    trade-logic.js docstring: small=[9999], large=[7846,5717],
+    KTC-observed 3712, V2 predicted 3748). Keeps the Python port from
+    drifting away from the calibrated formula."""
+    va = _value_adjustment([9999], [7846, 5717])
+    assert round(va) == 3748
+
+
+def test_value_adjustment_zero_when_sizes_match():
+    # Same count on each side → no consolidation premium.
+    assert _value_adjustment([8000, 7000], [7500, 6800]) == 0.0
+
+
+def test_value_adjustment_positive_for_smaller_side_with_top_gap():
+    # 1v2 with a clear top-piece gap: small tops at 9999, large tops
+    # at 7846. Smaller side receives a positive VA.
+    va = _value_adjustment([9999], [7846, 5717])
+    assert va > 0.0
+
+
+def test_value_adjustment_grows_with_top_gap():
+    # A bigger gap between the consolidated star and the best piece
+    # on the longer side should produce a larger VA.
+    low_gap = _value_adjustment([8000], [7500, 5000])
+    high_gap = _value_adjustment([9999], [6000, 4000])
+    assert high_gap > low_gap
+
+
+def test_packages_consolidation_trade_is_filtered_by_va():
+    """Classic "4 filler for 1 stud" trade: raw totals match, but VA
+    should make the single stud side bigger under the adjusted math,
+    pushing the counterparty's perceived market gap past the cap."""
+    # Offer: 1 stud. Counter: 4 filler pieces whose KTC sum lines up
+    # with the stud but no single piece is close to the stud's value.
+    offer = ["Stud Star"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["Stud Star"]},
+        {
+            "name": "Team B",
+            "ownerId": "owner-b",
+            "players": ["Filler 1", "Filler 2", "Filler 3", "Filler 4"],
+        },
+    ]
+    # Stud: my=9500, ktc=9500.  Four fillers each ≈ 2400 → sum ≈ 9600.
+    # Raw math would accept this as +1% my-gain, +1% ktc-gap (both
+    # within threshold). VA on the consolidated side should flip the
+    # market gap past the 5% cap.
+    players = [
+        _player("Stud Star", 9500, 9500),
+        _player("Filler 1", 2400, 2400),
+        _player("Filler 2", 2400, 2400),
+        _player("Filler 3", 2400, 2400),
+        _player("Filler 4", 2400, 2400),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        min_my_gain_pct=0.0, max_market_gain_pct=5.0,
+    )
+    # Under raw arithmetic the 4-filler counter is within both
+    # thresholds. With VA applied to the smaller (stud) side, the
+    # market gap climbs well past 5% and the package is rejected.
+    four_filler = [c for c in result["candidates"] if c["size"] == 4]
+    assert four_filler == [], (
+        "4-filler counter should be rejected once VA is applied to the "
+        f"consolidated stud side; got {four_filler}"
+    )
+
+
+def test_packages_candidate_exposes_va_adjustment_fields():
+    """Successful candidates ship the adjusted totals so the UI can
+    show consolidation premiums."""
+    offer = ["Offer Star", "Offer Depth"]
+    teams = [
+        {
+            "name": "Team A", "ownerId": "owner-a",
+            "players": ["Offer Star", "Offer Depth"],
+        },
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Target Star"]},
+    ]
+    # 2-for-1 — the single counter piece should receive VA.
+    players = [
+        _player("Offer Star", 5000, 5000),
+        _player("Offer Depth", 3000, 3000),
+        _player("Target Star", 9000, 8200),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        min_my_gain_pct=0.0, max_market_gain_pct=50.0,  # loose so sth qualifies
+    )
+    size_one = next((c for c in result["candidates"] if c["size"] == 1), None)
+    assert size_one is not None, "expected the single-player counter to qualify"
+    assert size_one["my_value_adjustment"] > 0
+    assert size_one["market_value_adjustment"] > 0
+    assert size_one["my_total_adjusted"] > size_one["my_total"]
+
+
+# ─── IDP filter default ──────────────────────────────────────────────
+
+
+def test_packages_idp_excluded_from_pool_by_default():
+    offer = ["My QB"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
+        {
+            "name": "Team B", "ownerId": "owner-b",
+            "players": ["Opp DL", "Opp WR"],
+        },
+    ]
+    players = [
+        _player("My QB", 5000, 5000, position="QB"),
+        _player("Opp DL", 6000, 5000, position="DL"),
+        _player("Opp WR", 6000, 5000, position="WR"),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,  # include_idp default False
+    )
+    names = {p["name"] for c in result["candidates"] for p in c["players"]}
+    assert "Opp DL" not in names
+    assert "Opp WR" in names
+
+
+def _idp_player(name, my_val, idptc_val, *, position="DL"):
+    return {
+        "canonicalName": name,
+        "displayName": name,
+        "position": position,
+        "rankDerivedValue": my_val,
+        "canonicalSiteValues": {"idpTradeCalc": idptc_val},
+    }
+
+
+def test_packages_idp_included_when_flag_set():
+    offer = ["My QB"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Opp DL"]},
+    ]
+    players = [
+        _player("My QB", 5000, 5000, position="QB"),
+        _idp_player("Opp DL", 6000, 5000, position="DL"),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams, include_idp=True,
+    )
+    names = {p["name"] for c in result["candidates"] for p in c["players"]}
+    assert "Opp DL" in names
+
+
+def test_packages_idp_filter_does_not_touch_seed_players():
+    """Seed players are user-selected — the IDP gate should let them
+    through even when include_idp is False."""
+    offer = ["My QB"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
+        {
+            "name": "Team B", "ownerId": "owner-b",
+            "players": ["Opp Seed DL", "Opp WR"],
+        },
+    ]
+    players = [
+        _player("My QB", 5000, 5000, position="QB"),
+        _idp_player("Opp Seed DL", 6000, 5000, position="DL"),
+        _player("Opp WR", 6000, 5000, position="WR"),
+    ]
+    result = find_angle_packages(
+        players, offer, "owner-a", teams,
+        target_team_owner_ids=["owner-b"],
+        seed_player_names=["Opp Seed DL"],
+    )
+    # Every candidate must carry the IDP seed even though include_idp
+    # is False and the pool is otherwise IDP-stripped.
+    assert result["candidates"]
+    for c in result["candidates"]:
+        names = {p["name"] for p in c["players"]}
+        assert "Opp Seed DL" in names
+
+
+def test_acquire_idp_excluded_from_offer_pool_by_default():
+    """In acquire mode, the default IDP gate strips IDP players from
+    the user's own roster pool — so an IDP-only owner ends up with
+    zero offers."""
+    teams = [
+        {
+            "name": "Team A", "ownerId": "owner-a",
+            "players": ["My LB 1", "My LB 2"],
+        },
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Target WR"]},
+    ]
+    players = [
+        _idp_player("My LB 1", 5500, 5200, position="LB"),
+        _idp_player("My LB 2", 5400, 5100, position="LB"),
+        _player("Target WR", 6000, 5000, position="WR"),
+    ]
+    result = find_acquisition_packages(
+        players, ["Target WR"], "owner-a", teams,  # include_idp default False
+    )
+    assert result["candidates"] == []
+    # Flip include_idp on and the offer packages appear.
+    result2 = find_acquisition_packages(
+        players, ["Target WR"], "owner-a", teams,
+        include_idp=True,
+    )
+    assert result2["candidates"], "LB offers should qualify once IDP is allowed"
+
+
+def test_acquire_idp_filter_does_not_drop_desired_player():
+    """The acquire-side (fixed) set is user-selected — it should
+    survive the IDP gate even when include_idp is False."""
+    teams = [
+        {
+            "name": "Team A", "ownerId": "owner-a",
+            "players": ["My WR 1", "My WR 2"],
+        },
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Target DL"]},
+    ]
+    players = [
+        _player("My WR 1", 5500, 5500, position="WR"),
+        _player("My WR 2", 5400, 5400, position="WR"),
+        _idp_player("Target DL", 6000, 5500, position="DL"),
+    ]
+    result = find_acquisition_packages(
+        players, ["Target DL"], "owner-a", teams,  # default include_idp=False
+        min_my_gain_pct=0.0, max_market_gain_pct=50.0,
+    )
+    # Desired player survives the gate.
+    assert result["acquire"]["size"] == 1
+    assert result["acquire"]["players"][0]["name"] == "Target DL"
+    # And the offer pool (all-WR) can still produce candidates.
+    assert result["candidates"]
+
+
+def test_packages_include_idp_flag_surfaced_in_thresholds():
+    offer = ["My QB"]
+    teams = [
+        {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
+        {"name": "Team B", "ownerId": "owner-b", "players": ["Opp WR"]},
+    ]
+    players = [
+        _player("My QB", 5000, 5000, position="QB"),
+        _player("Opp WR", 6000, 5000, position="WR"),
+    ]
+    result_off = find_angle_packages(players, offer, "owner-a", teams)
+    assert result_off["thresholds"]["include_idp"] is False
+    result_on = find_angle_packages(
+        players, offer, "owner-a", teams, include_idp=True,
+    )
+    assert result_on["thresholds"]["include_idp"] is True


### PR DESCRIPTION
## Summary
Two fixes for the Angle package builder, prompted by a screenshot where "Acquire 3 studs (~20k my)" was being matched with "offer 4 filler pieces (~12k my, ~19k market)" as a +64.5% arb. That shouldn't qualify — no leaguemate takes that trade — and the screenshot also leaked IDP filler into every suggestion.

### 1. Apply the calibrated KTC-style Value Adjustment
The trade calculator already models consolidation premium via the V2 VA formula (`frontend/lib/trade-logic.js::_vaFromSortedSides`), but the Angle engine bypassed it and compared raw sums. Ported the formula to `src/trade/angle.py` and apply it in both `find_angle_packages` and `find_acquisition_packages` — the consolidated (smaller) side gets the premium on my-value **and** market-value totals before thresholds are checked. Exact numeric parity with JS (Case A: 3748 vs KTC-observed 3712 — pinned by a regression test).

### 2. Default-exclude IDP from the candidate pool
Added `include_idp: bool = False` to both finders. By default IDP positions are stripped from the pool the search enumerates. Explicit user choices (fixed-side players, seeds) always survive the gate. Frontend gets an "Include IDP" toggle (default OFF) that auto-flips ON and locks when an IDP position pill is active or an IDP player is on the fixed side — matches the brief: *"unless I specifically add IDP players … it won't try to build the trades using any IDP players."*

## Changes
- `src/trade/angle.py` — port VA formula + apply it to both engines; add `include_idp` gate.
- `server.py` — thread `includeIdp` from body through to both finders.
- `frontend/app/angle/page.jsx` — IDP toggle pill (auto-on/locked on explicit IDP intent); show raw → raw+VA inline on each package.
- `tests/test_trade_angle.py` — 12 new tests: VA parity with JS calibration point, consolidation trades rejected by VA, VA fields exposed on candidates, IDP default-off in both modes, seeds/fixed-side bypass the IDP gate, threshold surfacing.

## Test plan
- [x] `python -m pytest tests/ -q` → 1716 passed, 25 skipped.
- [ ] Manual: reproduce the screenshot case (acquire 3 studs, default settings) — the 4-piece filler packages should no longer qualify once VA is applied.
- [ ] Manual: confirm IDP players are absent from suggestions by default and re-appear when the toggle is on (or when an IDP pill/player is selected).

https://claude.ai/code/session_01Ub5VxtesVQw7VGJPH4cgEC