### PR TITLE
Port canonical-engine tier + volatility signals into live blend, add hillValueSpread diagnostic

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2954,6 +2954,94 @@ def _apply_offense_calibration_post_pass(
                     pdata["offenseCalibrationMultiplier"] = round(multiplier, 4)
 
 
+# Volatility compression hyperparameters — mirror the canonical engine's
+# Step 5 defaults in ``src/canonical/player_valuation.py`` so the live
+# path and canonical-engine output stay conceptually aligned.  Kept
+# intentionally gentle: the floor caps worst-case compression at 8%, so
+# a high-disagreement top-tier player drops no more than 800 points on
+# the 1–9999 scale.  If this needs retuning, change it here and update
+# the matching constants in player_valuation.py.
+_VOLATILITY_COMPRESSION_STRENGTH: float = 0.03
+_VOLATILITY_COMPRESSION_FLOOR: float = 0.92
+
+
+def _apply_volatility_compression_post_pass(
+    players_array: list[dict[str, Any]],
+    players_by_name: dict[str, Any],
+) -> None:
+    """Dampen ``rankDerivedValue`` for high-disagreement players.
+
+    Mirrors Step 5 of the canonical engine (``compute_volatility_adjustments``
+    in ``src/canonical/player_valuation.py:349-391``) but feeds the
+    population-relative z-score with ``sourceRankPercentileSpread``
+    (stamped in Phase 4) rather than raw ``stdev(source_ranks)``.  The
+    percentile spread is coverage-corrected — it normalizes each
+    source's raw ordinal by that source's actual pool size — so a 50-
+    rank spread between DLF (pool 185) and FBG (pool 400) does not
+    masquerade as genuine disagreement.
+
+    Only rows with a non-None ``sourceRankPercentileSpread`` and a
+    positive ``rankDerivedValue`` participate.  Picks are skipped
+    because their post-``_anchor_current_year_picks_to_rookies`` value
+    is inherited from a rookie row and should reflect that rookie's
+    confidence, not the pick row's own source disagreement signal.
+    The Phase 5 compact resort handles any monotonicity breaks caused
+    by a compressed value crossing a neighbor.
+
+    Mirrors the updated value into the legacy ``players_by_name`` dict
+    so the runtime view stays in sync, matching the pattern in
+    ``_apply_idp_calibration_post_pass``.
+    """
+    from src.canonical.player_valuation import (  # noqa: PLC0415
+        compute_volatility_adjustments,
+    )
+
+    eligible: list[tuple[dict[str, Any], float, float]] = []
+    for row in players_array:
+        if row.get("canonicalConsensusRank") is None:
+            continue
+        if row.get("assetClass") == "pick":
+            continue
+        spread = row.get("sourceRankPercentileSpread")
+        if spread is None:
+            continue
+        try:
+            value = float(row.get("rankDerivedValue") or 0)
+        except (TypeError, ValueError):
+            continue
+        if value <= 0:
+            continue
+        eligible.append((row, value, float(spread)))
+
+    if len(eligible) < 2:
+        return
+
+    values = [v for _, v, _ in eligible]
+    spreads = [s for _, _, s in eligible]
+    adjustments = compute_volatility_adjustments(
+        values,
+        spreads,
+        strength=_VOLATILITY_COMPRESSION_STRENGTH,
+        floor=_VOLATILITY_COMPRESSION_FLOOR,
+    )
+
+    for (row, value, _spread), adj in zip(eligible, adjustments):
+        if adj >= 0.0:
+            continue
+        compression_frac = abs(adj) / value if value > 0 else 0.0
+        new_val = max(1, int(round(value + adj)))
+        row["rankDerivedValue"] = new_val
+        row["volatilityCompressionApplied"] = round(compression_frac, 4)
+        legacy_ref = row.get("legacyRef")
+        if legacy_ref and legacy_ref in players_by_name:
+            pdata = players_by_name[legacy_ref]
+            if isinstance(pdata, dict):
+                pdata["rankDerivedValue"] = new_val
+                pdata["volatilityCompressionApplied"] = round(
+                    compression_frac, 4
+                )
+
+
 def _reassign_pick_slot_order(players_array: list[dict[str, Any]]) -> int:
     """Reorder slot-specific picks within each year so slot order is
     strictly monotonic across all rounds (1.01..1.12, 2.01..2.12, ...).
@@ -3945,6 +4033,18 @@ def _compute_unified_rankings(
     # reference but they do NOT mutate rankDerivedValue.
     # _apply_offense_calibration_post_pass(players_array, players_by_name)
 
+    # ── Phase 4d: Volatility compression ──
+    # Port of Step 5 of the canonical engine
+    # (src/canonical/player_valuation.py:349-391) but driven by the
+    # coverage-corrected sourceRankPercentileSpread (stamped in
+    # Phase 4) rather than raw stdev(source_ranks).  The percentile
+    # spread normalizes for heterogeneous source depths (DLF IDP=185
+    # vs FBG IDP=400); raw stdev does not.  The compact resort in
+    # Phase 5 will naturally reshuffle any rows whose compressed
+    # value crosses a neighbor.  Runs after IDP calibration so the
+    # compression dampens the already-calibrated value.
+    _apply_volatility_compression_post_pass(players_array, players_by_name)
+
     # ── Phase 5: Pick refinement passes (gated to picks) ──
     # 1) Reassign (rank, value) tuples within each (year, round) bucket
     #    so slot-specific picks 1.01..1.12 are strictly monotonic in
@@ -4798,6 +4898,7 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "sourceRankSpread",
     "sourceRankPercentileSpread",
     "hillValueSpread",
+    "volatilityCompressionApplied",
     "isSingleSource",
     "isStructurallySingleSource",
     "hasSourceDisagreement",

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -6,6 +6,7 @@ import logging
 import math
 import os
 import re
+import statistics
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -3578,6 +3579,7 @@ def _compute_unified_rankings(
 
         if not contributions:
             blended_value = 0.0
+            hill_value_spread: float | None = None
         else:
             values = [v for v, _w in contributions]
             if weight_total > 0:
@@ -3605,6 +3607,20 @@ def _compute_unified_rankings(
             # the structural source weights the dominant voice while
             # still letting the robust blend correct obvious outliers.
             blended_value = 0.6 * weighted_mean + 0.4 * robust
+
+            # Separation diagnostic: stdev of per-source Hill-curve values
+            # before the blend.  Pairs with sourceRankPercentileSpread
+            # (agreement in rank space) to describe "how large is the
+            # value gap the sources are implying?".  None when fewer than
+            # two sources contributed — matches the percentile-spread
+            # convention.
+            hill_value_spread = (
+                statistics.stdev(values) if len(values) >= 2 else None
+            )
+
+        players_array[row_idx]["hillValueSpread"] = (
+            round(hill_value_spread, 2) if hill_value_spread is not None else None
+        )
         row_normalized.append((blended_value, row_idx))
 
     # ── Phase 3a: Pick year discount (gated to picks) ──
@@ -4268,6 +4284,7 @@ def _derive_player_row(
         "blendedSourceRank": None,
         "sourceRankSpread": None,
         "sourceRankPercentileSpread": None,
+        "hillValueSpread": None,
         "marketGapDirection": "none",
         "marketGapMagnitude": None,
         "sourceAudit": {
@@ -4713,6 +4730,7 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "sourceCount",
     "sourceRankSpread",
     "sourceRankPercentileSpread",
+    "hillValueSpread",
     "isSingleSource",
     "isStructurallySingleSource",
     "hasSourceDisagreement",

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1080,6 +1080,47 @@ def _compute_anomaly_flags(
     return flags
 
 
+_GAP_BASED_TIER_CAP: int = 10
+
+
+def _compute_value_based_tier_ids(
+    tiered_rows: list[dict[str, Any]],
+    *,
+    max_tiers: int = _GAP_BASED_TIER_CAP,
+) -> list[int]:
+    """Return gap-based tier IDs aligned with ``tiered_rows``.
+
+    Runs the canonical engine's ``detect_tiers`` (rolling-median gap
+    normalization, see ``src/canonical/player_valuation.py``) over the
+    compacted ``rankDerivedValue`` series.  Tier 1 is the best (top of
+    board); tier IDs increase as value decreases.
+
+    ``detect_tiers`` expects an ascending series whose adjacent
+    positive gaps correspond to "moving away from the best."  Values
+    are descending (best first), so we feed ``-value`` as the series;
+    gaps then come out as positive value drops from row i to row i+1,
+    which is exactly what the gap detector is designed for.
+
+    Caps at ``max_tiers`` to preserve the frontend's fixed tier label
+    vocabulary (Elite, Blue-Chip, …, Waiver Wire).  Gap-detected
+    tiers past the cap collapse into the final tier — the top-of-board
+    boundaries are the meaningful ones; long-tail micro-tiers just get
+    lumped into "Waiver Wire".
+    """
+    if not tiered_rows:
+        return []
+
+    from src.canonical.player_valuation import detect_tiers  # noqa: PLC0415
+
+    series = [-float(r.get("rankDerivedValue") or 0) for r in tiered_rows]
+    player_ids = [str(r.get("canonicalName") or "") for r in tiered_rows]
+    tier_ids, _gaps, _scores, _boundaries = detect_tiers(series, player_ids)
+
+    if max_tiers > 0:
+        tier_ids = [min(t, max_tiers) for t in tier_ids]
+    return tier_ids
+
+
 def _tier_id_from_rank(rank: int) -> int:
     """Return a tier ID (1-10) from an overall rank.
 
@@ -1089,6 +1130,12 @@ def _tier_id_from_rank(rank: int) -> int:
     derivation always agree.  Since the backend now stamps this field
     authoritatively, the frontend fallback should never fire for
     ranked players.
+
+    Retained for the Phase 4 initial stamp and as the frontend-fallback
+    mirror.  The authoritative tier assignment for ranked rows comes
+    from ``_compute_value_based_tier_ids`` in the Phase 5 compact
+    pass; this function is overwritten for every tiered row before the
+    contract is returned.
     """
     if rank <= 12:
         return 1   # Elite
@@ -3922,7 +3969,8 @@ def _compute_unified_rankings(
     #     neighborhood of their rookie target; fall back to the existing
     #     canonicalConsensusRank to preserve the prior Phase-4 ordering
     #     for all rows whose values were not mutated.  Tier IDs are
-    #     re-derived from the new ranks.
+    #     re-derived after compaction via gap-based detection on the
+    #     blended ``rankDerivedValue`` series (see below).
     ranked_rows = sorted(
         [r for r in players_array if r.get("canonicalConsensusRank")],
         key=lambda r: (
@@ -3938,6 +3986,11 @@ def _compute_unified_rankings(
     # down one rank. Only applies to slot-specific current-year picks
     # (e.g. "2026 Pick 1.06"); tier-generic picks ("2026 Early 1st")
     # still take ordinary rank slots.
+    #
+    # Collect the ranked rows that actually receive a tier ID so the
+    # gap-detection pass below sees only the compacted board (no
+    # None-ranked anchor slot picks in the middle of its gap series).
+    tiered_rows: list[dict[str, Any]] = []
     new_rank = 0
     for r in ranked_rows:
         is_anchor_slot_pick = False
@@ -3953,7 +4006,21 @@ def _compute_unified_rankings(
         old_rank = r.get("canonicalConsensusRank")
         if old_rank != new_rank:
             r["canonicalConsensusRank"] = new_rank
-        r["canonicalTierId"] = _tier_id_from_rank(new_rank)
+        tiered_rows.append(r)
+
+    # Gap-based tier detection on the blended value series.  Replaces
+    # the prior flat ``_tier_id_from_rank`` bucketing (1-12=Elite,
+    # 13-36=Blue-Chip, etc.) with real market-cliff detection: tiers
+    # land where the per-player value gap is unusually large relative
+    # to the local rolling-median gap.  A 400-point drop from rank
+    # 12→13 registers as a new tier boundary; a 3-point drop from
+    # 312→313 does not.  Caps at 10 tiers so the frontend's
+    # ``TIER_LABELS`` ("Elite" … "Waiver Wire") still maps cleanly;
+    # any gap-detected tiers past the cap collapse into tier 10.
+    for r, tier_id in zip(
+        tiered_rows, _compute_value_based_tier_ids(tiered_rows)
+    ):
+        r["canonicalTierId"] = tier_id
 
     # (Phase 5b — value re-flattening — intentionally removed.) The
     # pre-sort ``rankDerivedValue`` is a weighted blend of per-source

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3026,20 +3026,33 @@ def _apply_volatility_compression_post_pass(
     )
 
     for (row, value, _spread), adj in zip(eligible, adjustments):
+        legacy_ref = row.get("legacyRef")
+        pdata = (
+            players_by_name.get(legacy_ref)
+            if legacy_ref and legacy_ref in players_by_name
+            else None
+        )
         if adj >= 0.0:
+            # Emit an explicit ``None`` so the rankings-override delta
+            # entry always carries the current compression state. The
+            # frontend's ``mergeRankingsDelta`` overwrites only fields
+            # present in the delta; if we silently skip uncompressed
+            # rows, a player that was compressed in the base contract
+            # but uncompressed after an override keeps the stale
+            # fraction.
+            row["volatilityCompressionApplied"] = None
+            if isinstance(pdata, dict):
+                pdata["volatilityCompressionApplied"] = None
             continue
         compression_frac = abs(adj) / value if value > 0 else 0.0
         new_val = max(1, int(round(value + adj)))
         row["rankDerivedValue"] = new_val
         row["volatilityCompressionApplied"] = round(compression_frac, 4)
-        legacy_ref = row.get("legacyRef")
-        if legacy_ref and legacy_ref in players_by_name:
-            pdata = players_by_name[legacy_ref]
-            if isinstance(pdata, dict):
-                pdata["rankDerivedValue"] = new_val
-                pdata["volatilityCompressionApplied"] = round(
-                    compression_frac, 4
-                )
+        if isinstance(pdata, dict):
+            pdata["rankDerivedValue"] = new_val
+            pdata["volatilityCompressionApplied"] = round(
+                compression_frac, 4
+            )
 
 
 def _reassign_pick_slot_order(players_array: list[dict[str, Any]]) -> int:
@@ -4452,6 +4465,7 @@ def _derive_player_row(
         "sourceRankSpread": None,
         "sourceRankPercentileSpread": None,
         "hillValueSpread": None,
+        "volatilityCompressionApplied": None,
         "marketGapDirection": "none",
         "marketGapMagnitude": None,
         "sourceAudit": {

--- a/tests/api/test_launch_readiness.py
+++ b/tests/api/test_launch_readiness.py
@@ -209,17 +209,34 @@ class TestGate5TierAlignment(unittest.TestCase):
         missing = [r["canonicalName"] for r in ranked if r.get("canonicalTierId") is None]
         self.assertEqual(missing, [])
 
-    def test_tier_matches_rank_boundaries(self):
+    def test_tier_ids_bounded_and_rank1_is_tier1(self):
+        """Tier IDs land in the frontend's 1..10 vocabulary, and the
+        top-of-board row is always in tier 1.
+
+        Tier assignment is now gap-based on ``rankDerivedValue`` (see
+        ``_compute_value_based_tier_ids`` in ``src/api/data_contract.py``)
+        rather than fixed rank buckets, so we no longer pin each row to
+        ``_tier_id_from_rank(rank)`` — the whole point of the change is
+        that tier boundaries land at real market cliffs, which shift
+        run-to-run as the source blend shifts.  Monotonicity is covered
+        by ``test_tiers_non_decreasing``.
+        """
         result = _get()
         if result is None:
             self.skipTest("No live data")
         _, ranked, _ = result
-        bad = []
-        for r in ranked:
-            expected = _tier_id_from_rank(r["canonicalConsensusRank"])
-            if r.get("canonicalTierId") != expected:
-                bad.append(f"#{r['canonicalConsensusRank']}: tier={r['canonicalTierId']}, expected={expected}")
-        self.assertEqual(bad, [])
+        out_of_range = [
+            f"#{r['canonicalConsensusRank']}: tier={r.get('canonicalTierId')}"
+            for r in ranked
+            if not (isinstance(r.get("canonicalTierId"), int) and 1 <= r["canonicalTierId"] <= 10)
+        ]
+        self.assertEqual(out_of_range, [])
+        if ranked:
+            top = ranked[0]
+            self.assertEqual(
+                top.get("canonicalTierId"), 1,
+                f"Top-ranked row must be in tier 1, got {top.get('canonicalTierId')}",
+            )
 
     def test_tiers_non_decreasing(self):
         result = _get()

--- a/tests/api/test_single_authority.py
+++ b/tests/api/test_single_authority.py
@@ -94,23 +94,52 @@ class TestSingleAuthority(unittest.TestCase):
         ranks = [r["canonicalConsensusRank"] for r in pa if r.get("canonicalConsensusRank")]
         self.assertEqual(len(ranks), len(set(ranks)), "Duplicate ranks detected")
 
-    def test_tier_matches_rank(self):
-        """canonicalTierId must be consistent with rank boundaries."""
-        from src.api.data_contract import _tier_id_from_rank
+    def test_tier_bounded_and_monotonic(self):
+        """canonicalTierId lands in 1..10 and is non-decreasing with rank.
+
+        Tier assignment is gap-based on ``rankDerivedValue`` (see
+        ``_compute_value_based_tier_ids``) rather than fixed rank
+        buckets, so the strict ``_tier_id_from_rank`` equality check
+        this test previously enforced no longer applies.  Instead we
+        pin the two invariants the frontend relies on: tier IDs stay in
+        the ``TIER_LABELS`` vocabulary (1..10), and higher-ranked rows
+        never land in a worse (higher-numbered) tier than lower-ranked
+        rows.
+        """
         contract = _load_live_contract()
         if contract is None:
             self.skipTest("No live data")
         pa = contract.get("playersArray", [])
-        mismatches = []
-        for r in pa:
-            rank = r.get("canonicalConsensusRank")
-            tier = r.get("canonicalTierId")
-            if rank is None or tier is None:
-                continue
-            expected = _tier_id_from_rank(rank)
-            if tier != expected:
-                mismatches.append(f"#{rank}: tier={tier}, expected={expected}")
-        self.assertEqual(mismatches, [], f"Tier mismatches:\n" + "\n".join(mismatches[:10]))
+        ranked = sorted(
+            [r for r in pa if r.get("canonicalConsensusRank") is not None],
+            key=lambda r: int(r["canonicalConsensusRank"]),
+        )
+        out_of_range = [
+            f"#{r['canonicalConsensusRank']}: tier={r.get('canonicalTierId')}"
+            for r in ranked
+            if not (
+                isinstance(r.get("canonicalTierId"), int)
+                and 1 <= r["canonicalTierId"] <= 10
+            )
+        ]
+        self.assertEqual(
+            out_of_range, [],
+            f"Tier IDs out of 1..10 range:\n" + "\n".join(out_of_range[:10]),
+        )
+        prev_tier = 0
+        non_monotonic: list[str] = []
+        for r in ranked:
+            t = r.get("canonicalTierId") or 0
+            if t < prev_tier:
+                non_monotonic.append(
+                    f"#{r['canonicalConsensusRank']}: tier {t} after tier {prev_tier}"
+                )
+            prev_tier = t
+        self.assertEqual(
+            non_monotonic, [],
+            f"Tier IDs must be non-decreasing with rank:\n"
+            + "\n".join(non_monotonic[:10]),
+        )
 
 
 class TestOverlayRemoved(unittest.TestCase):

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -1057,6 +1057,39 @@ class TestTepMultiplier(unittest.TestCase):
         rov = contract.get("rankingsOverride") or {}
         self.assertEqual(float(rov.get("tepMultiplier") or 0), 2.0)
 
+    def test_volatility_compression_always_emitted_in_delta(self) -> None:
+        """Every ranked delta entry must carry an explicit ``volatilityCompressionApplied`` value.
+
+        Regression guard for the silent-skip bug: the compression pass
+        used to only stamp ``volatilityCompressionApplied`` when a
+        penalty was applied and silently omitted the field otherwise.
+        That broke override merges — a player compressed in the base
+        contract but uncompressed after an override would keep the
+        stale fraction because ``mergeRankingsDelta`` overwrites only
+        fields present in the delta.  Every ranked row must emit an
+        explicit value (a float fraction or ``None``) so the merge
+        path can clear stale state deterministically.
+        """
+        delta = build_rankings_delta_payload(
+            _fixture_raw_payload(),
+            source_overrides={"ktc": {"include": False}},
+        )
+        missing: list[str] = []
+        for entry in delta.get("rankingsDelta", {}).get("players", []):
+            # Only rows that actually received a rank participate in
+            # the compression pass; unranked rows legitimately never
+            # have the field set explicitly, but the _derive_player_row
+            # default covers those.
+            if entry.get("canonicalConsensusRank") is None:
+                continue
+            if "volatilityCompressionApplied" not in entry:
+                missing.append(entry.get("id", "<unknown>"))
+        self.assertEqual(
+            missing, [],
+            "Ranked rows missing explicit volatilityCompressionApplied "
+            f"in delta payload: {missing[:10]}",
+        )
+
     def test_delta_payload_reflects_tep_in_summary(self) -> None:
         """build_rankings_delta_payload must carry tepMultiplier through."""
         delta = build_rankings_delta_payload(


### PR DESCRIPTION
## Summary

Three incremental changes to `_compute_unified_rankings` in `src/api/data_contract.py`, each landed as its own commit for clean review and bisect.  Driven by the z-score analysis thread — after tracing the live path end-to-end, we concluded that z-scoring ordinal rank data would double-count signal already captured by the Hill curve, but two canonical-engine features (gap-based tier detection and volatility compression) carry real signal the live path was throwing away, and a value-spread diagnostic is strictly additive.

### 1. `hillValueSpread` market-separation diagnostic (commit `fe2c45b`)
Stamp `stdev(per_source_hill_values)` in the Phase 2-3 blend at `data_contract.py:3560-3608`, before the weighted-mean/robust combine.  Pairs with the existing `sourceRankPercentileSpread` (agreement in rank space) to describe "how large is the value gap the sources are implying?" — the separation signal a z-score layer would try to capture, computed in the space where the Hill curve already lives.  Pure diagnostic; does not mutate any ranking field.  Added to `_DELTA_PLAYER_FIELDS` so the override endpoint round-trips it.

### 2. Gap-based tier detection on `rankDerivedValue` (commit `08ff07a`)
Replaces the flat `_tier_id_from_rank` bucketing (1-12=Elite, 13-36=Blue-Chip, …) in the Phase 5 compact pass with `_compute_value_based_tier_ids`, which feeds the blended value series into the canonical engine's `detect_tiers` (rolling-median gap normalization, `src/canonical/player_valuation.py:179-254`).  Tier boundaries now land at real market cliffs rather than fixed rank buckets: a 400-point drop from rank 12→13 registers as a new tier; a 3-point blip at rank 312→313 does not.  Capped at 10 tiers so the frontend's `TIER_LABELS` vocabulary (Elite … Waiver Wire) still maps cleanly.  Two launch-readiness tests that pinned the old exact-bucket equality were replaced with the weaker invariants the new contract promises (tier IDs in 1..10, non-decreasing with rank, rank 1 is tier 1).

### 3. Volatility compression via `sourceRankPercentileSpread` (commit `ada70e3`)
Port of Step 5 of the canonical engine (`compute_volatility_adjustments`, `src/canonical/player_valuation.py:349-391`) as a Phase 4d post-pass, but driven by the coverage-corrected `sourceRankPercentileSpread` rather than raw `stdev(source_ranks)`.  Percentile spread normalizes for heterogeneous source depths (DLF IDP=185 vs FBG IDP=400), so a 50-rank spread across those sources does not masquerade as disagreement.  Rows whose spread z-score exceeds 0 get multiplicative compression up to 8% (`VOL_FLOOR=0.92`, `STRENGTH=0.03`, matching canonical-engine defaults).  Picks are skipped because `_anchor_current_year_picks_to_rookies` subsequently overrides their value from a rookie row.  The Phase 5 compact resort handles any monotonicity breaks caused by a compressed value crossing a neighbor.

## Test plan

- [x] `python -m pytest tests/` — 1694 passed, 26 skipped (pre-existing `test_draft_capital.py` failures are unrelated; reproduce on `main`)
- [x] Launch-readiness Gate 5 (`test_tier_ids_bounded_and_rank1_is_tier1`) and single-authority tier tests updated to match new gap-based semantics
- [x] Delta-payload regression (`tests/api/test_source_overrides.py`) still passes with the two new `_DELTA_PLAYER_FIELDS` entries
- [x] Synthetic smoke test on `_compute_value_based_tier_ids` — clean value cliffs produce clean tier boundaries, long-tail collapses into tier 10
- [x] Synthetic smoke test on `_apply_volatility_compression_post_pass` — low-spread players unchanged, high-spread players compressed 3-5%, capped below 8%
- [ ] Eyeball tier boundaries on the live `/api/data` board against the previous release for a sanity pass before merge
- [ ] Backtest: compare hit-rate on pre-existing trade suggestions with/without compression to confirm it improves signal rather than just shifting values

https://claude.ai/code/session_01PW4Euq62Cp6RuQLTY8y5gk