### PR TITLE
Rename tiers to generic "Tier N" and uncap gap-based detection

### DIFF
--- a/frontend/__tests__/rankings-helpers.test.js
+++ b/frontend/__tests__/rankings-helpers.test.js
@@ -13,19 +13,16 @@ import {
 
 describe("tierLabel", () => {
   it("uses backend canonicalTierId when present", () => {
-    expect(tierLabel({ canonicalTierId: 1, rank: 5 })).toBe("Elite");
-    expect(tierLabel({ canonicalTierId: 2, rank: 20 })).toBe("Blue-Chip");
-    expect(tierLabel({ canonicalTierId: 5, rank: 150 })).toBe("Starter");
-  });
-
-  it("falls back to generic label for tier IDs > 10", () => {
+    expect(tierLabel({ canonicalTierId: 1, rank: 5 })).toBe("Tier 1");
+    expect(tierLabel({ canonicalTierId: 2, rank: 20 })).toBe("Tier 2");
+    expect(tierLabel({ canonicalTierId: 5, rank: 150 })).toBe("Tier 5");
     expect(tierLabel({ canonicalTierId: 12, rank: 700 })).toBe("Tier 12");
   });
 
   it("falls back to rank-based when canonicalTierId is null", () => {
-    expect(tierLabel({ canonicalTierId: null, rank: 1 })).toBe("Elite");
-    expect(tierLabel({ rank: 50 })).toBe("Premium Starter");
-    expect(tierLabel({ rank: 400 })).toBe("Bench Depth");
+    expect(tierLabel({ canonicalTierId: null, rank: 1 })).toBe("Tier 1");
+    expect(tierLabel({ rank: 50 })).toBe("Tier 3");
+    expect(tierLabel({ rank: 400 })).toBe("Tier 7");
   });
 
   it("returns Unranked for null/0 rank and no tierId", () => {
@@ -38,26 +35,19 @@ describe("tierLabel", () => {
 // ── rankBasedTierLabel ───────────────────────────────────────────────
 
 describe("rankBasedTierLabel", () => {
-  it("maps rank boundaries correctly", () => {
-    expect(rankBasedTierLabel(1)).toBe("Elite");
-    expect(rankBasedTierLabel(12)).toBe("Elite");
-    expect(rankBasedTierLabel(13)).toBe("Blue-Chip");
-    expect(rankBasedTierLabel(36)).toBe("Blue-Chip");
-    expect(rankBasedTierLabel(37)).toBe("Premium Starter");
-    expect(rankBasedTierLabel(72)).toBe("Premium Starter");
-    expect(rankBasedTierLabel(73)).toBe("Solid Starter");
-    expect(rankBasedTierLabel(120)).toBe("Solid Starter");
-    expect(rankBasedTierLabel(121)).toBe("Starter");
-    expect(rankBasedTierLabel(200)).toBe("Starter");
-    expect(rankBasedTierLabel(201)).toBe("Flex / Depth");
-    expect(rankBasedTierLabel(350)).toBe("Flex / Depth");
-    expect(rankBasedTierLabel(351)).toBe("Bench Depth");
-    expect(rankBasedTierLabel(500)).toBe("Bench Depth");
-    expect(rankBasedTierLabel(501)).toBe("Deep Stash");
-    expect(rankBasedTierLabel(650)).toBe("Deep Stash");
-    expect(rankBasedTierLabel(651)).toBe("Roster Fringe");
-    expect(rankBasedTierLabel(800)).toBe("Roster Fringe");
-    expect(rankBasedTierLabel(801)).toBe("Waiver Wire");
+  it("returns the numeric tier label mirroring rankBasedTierId", () => {
+    expect(rankBasedTierLabel(1)).toBe("Tier 1");
+    expect(rankBasedTierLabel(12)).toBe("Tier 1");
+    expect(rankBasedTierLabel(13)).toBe("Tier 2");
+    expect(rankBasedTierLabel(36)).toBe("Tier 2");
+    expect(rankBasedTierLabel(37)).toBe("Tier 3");
+    expect(rankBasedTierLabel(120)).toBe("Tier 4");
+    expect(rankBasedTierLabel(200)).toBe("Tier 5");
+    expect(rankBasedTierLabel(350)).toBe("Tier 6");
+    expect(rankBasedTierLabel(500)).toBe("Tier 7");
+    expect(rankBasedTierLabel(650)).toBe("Tier 8");
+    expect(rankBasedTierLabel(800)).toBe("Tier 9");
+    expect(rankBasedTierLabel(801)).toBe("Tier 10");
   });
 
   it("handles edge cases", () => {
@@ -136,18 +126,12 @@ describe("valueBand", () => {
     expect(valueBand(500).css).toBe("vb-fringe");
   });
 
-  it("never returns a label that overlaps with a tier label", () => {
-    // The bug: Starter (tier 5) and Depth (former value-band) both
-    // displayed as "Starter"/"Depth" on the same row, leading to
-    // "STARTER section header above DEPTH-labeled rows".  The new
-    // labels are short symbols that cannot collide.
-    const tierLabels = new Set([
-      "Elite", "Blue-Chip", "Premium Starter", "Solid Starter",
-      "Starter", "Flex / Depth", "Bench Depth", "Deep Stash",
-      "Roster Fringe", "Waiver Wire",
-    ]);
+  it("never returns a label that looks like a tier label", () => {
+    // Tier row headers render as "Tier N".  Value-band labels are
+    // short alpha symbols (S+/S/D+/D/F) so they cannot visually
+    // collide with the tier header on the same row.
     for (const v of [9000, 7000, 5000, 3000, 1000]) {
-      expect(tierLabels.has(valueBand(v).label)).toBe(false);
+      expect(valueBand(v).label).not.toMatch(/^Tier\s/);
     }
   });
 });

--- a/frontend/lib/rankings-helpers.js
+++ b/frontend/lib/rankings-helpers.js
@@ -7,69 +7,31 @@
 
 // ── Tier labels ──────────────────────────────────────────────────────────────
 // The backend assigns canonicalTierId (integer, 1-based) via gap-detection
-// in src/canonical/player_valuation.py.  These labels are a presentation
-// layer only — they map numeric tier IDs to human-readable names.
-//
-// When canonicalTierId is null (canonical pipeline not active), we fall back
-// to rank-based tiers derived from the unified rank position.
-
-/** Fixed tier label map for the first 10 backend-detected tiers. */
-const TIER_LABELS = {
-  1: "Elite",
-  2: "Blue-Chip",
-  3: "Premium Starter",
-  4: "Solid Starter",
-  5: "Starter",
-  6: "Flex / Depth",
-  7: "Bench Depth",
-  8: "Deep Stash",
-  9: "Roster Fringe",
-  10: "Waiver Wire",
-};
+// in src/canonical/player_valuation.py.  Tier 1 is the best; tier IDs
+// increase at each natural value cliff.  Labels are purely numeric —
+// "Tier 1", "Tier 2", … — so what the user sees matches the math.
 
 /**
  * Return a human-readable tier label for a row.
- * Prefers backend canonicalTierId; falls back to rank-based derivation.
+ * Prefers backend canonicalTierId; falls back to rank-based derivation
+ * when the canonical pipeline has not stamped the row.
  */
 export function tierLabel(row) {
   const tierId = row?.canonicalTierId;
   if (tierId != null && tierId > 0) {
-    return TIER_LABELS[tierId] || `Tier ${tierId}`;
+    return `Tier ${tierId}`;
   }
-  // Fallback: derive from rank position
   return rankBasedTierLabel(row?.rank);
 }
 
 /**
- * Derive a tier label purely from overall rank position.
- * Used when canonicalTierId is absent (canonical pipeline not active).
- *
- * Boundaries are intentionally generous — these are presentation labels,
- * not fantasy advice.  The cutoffs approximate natural dynasty value
- * clustering:
- *   1-12:   Elite (top-12 startup picks)
- *   13-36:  Blue-Chip (rounds 2-3)
- *   37-72:  Premium Starter (rounds 4-6)
- *   73-120: Solid Starter (rounds 7-10)
- *   121-200: Starter
- *   201-350: Flex / Depth
- *   351-500: Bench Depth
- *   501-650: Deep Stash
- *   651-800: Roster Fringe
- *   800+:   Waiver Wire
+ * Rank-based tier label fallback used only when canonicalTierId is
+ * absent (canonical pipeline not active).  Produces the same "Tier N"
+ * shape as the backend-stamped path.
  */
 export function rankBasedTierLabel(rank) {
-  if (rank == null || rank <= 0) return "Unranked";
-  if (rank <= 12) return "Elite";
-  if (rank <= 36) return "Blue-Chip";
-  if (rank <= 72) return "Premium Starter";
-  if (rank <= 120) return "Solid Starter";
-  if (rank <= 200) return "Starter";
-  if (rank <= 350) return "Flex / Depth";
-  if (rank <= 500) return "Bench Depth";
-  if (rank <= 650) return "Deep Stash";
-  if (rank <= 800) return "Roster Fringe";
-  return "Waiver Wire";
+  const tierId = rankBasedTierId(rank);
+  return tierId == null ? "Unranked" : `Tier ${tierId}`;
 }
 
 /**
@@ -107,14 +69,9 @@ export function effectiveTierId(row) {
 //
 // These are *descriptive* — they help users frame relative value.
 //
-// IMPORTANT: the band labels are deliberately distinct from the tier
-// labels in :data:`TIER_LABELS` above.  An older revision used the
-// strings "Starter" and "Depth" here, which clashed with the section
-// header tiers ("Starter", "Solid Starter", etc.).  A row whose tier
-// header said "Starter" could simultaneously show a value-band label
-// of "Depth", giving the appearance that the tier and badge
-// disagreed.  Using "S+" / "S" / "D+" / "D" / "F" symbols keeps the
-// two layers visually distinct so the rendering bug cannot return.
+// Short symbols ("S+" / "S" / "D+" / "D" / "F") keep the value-band
+// badge visually distinct from the numeric "Tier N" row header so the
+// two layers never look like they disagree.
 const VALUE_BANDS = [
   { min: 8000, label: "S+", css: "vb-elite",    title: "Elite value (8000+)" },
   { min: 6000, label: "S",  css: "vb-bluechip", title: "Blue-chip value (6000-7999)" },

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1131,20 +1131,16 @@ def _compute_anomaly_flags(
     return flags
 
 
-_GAP_BASED_TIER_CAP: int = 10
-
-
 def _compute_value_based_tier_ids(
     tiered_rows: list[dict[str, Any]],
-    *,
-    max_tiers: int = _GAP_BASED_TIER_CAP,
 ) -> list[int]:
     """Return gap-based tier IDs aligned with ``tiered_rows``.
 
     Runs the canonical engine's ``detect_tiers`` (rolling-median gap
     normalization, see ``src/canonical/player_valuation.py``) over the
     compacted ``rankDerivedValue`` series.  Tier 1 is the best (top of
-    board); tier IDs increase as value decreases.
+    board); tier IDs increase at each natural value cliff detected by
+    the rolling-median gap analyzer.
 
     ``detect_tiers`` expects an ascending series whose adjacent
     positive gaps correspond to "moving away from the best."  Values
@@ -1152,11 +1148,9 @@ def _compute_value_based_tier_ids(
     gaps then come out as positive value drops from row i to row i+1,
     which is exactly what the gap detector is designed for.
 
-    Caps at ``max_tiers`` to preserve the frontend's fixed tier label
-    vocabulary (Elite, Blue-Chip, …, Waiver Wire).  Gap-detected
-    tiers past the cap collapse into the final tier — the top-of-board
-    boundaries are the meaningful ones; long-tail micro-tiers just get
-    lumped into "Waiver Wire".
+    No cap is applied — every mathematically-detected tier flows
+    through verbatim, since the frontend renders them as generic
+    "Tier N" labels rather than a fixed vocabulary.
     """
     if not tiered_rows:
         return []
@@ -1166,47 +1160,39 @@ def _compute_value_based_tier_ids(
     series = [-float(r.get("rankDerivedValue") or 0) for r in tiered_rows]
     player_ids = [str(r.get("canonicalName") or "") for r in tiered_rows]
     tier_ids, _gaps, _scores, _boundaries = detect_tiers(series, player_ids)
-
-    if max_tiers > 0:
-        tier_ids = [min(t, max_tiers) for t in tier_ids]
     return tier_ids
 
 
 def _tier_id_from_rank(rank: int) -> int:
-    """Return a tier ID (1-10) from an overall rank.
+    """Return a numeric tier ID (1-10) from an overall rank.
 
     Boundaries mirror the frontend's ``rankBasedTierId()`` in
-    ``frontend/lib/rankings-helpers.js`` — kept in sync so the
-    backend-stamped ``canonicalTierId`` and the frontend's fallback
-    derivation always agree.  Since the backend now stamps this field
-    authoritatively, the frontend fallback should never fire for
-    ranked players.
-
-    Retained for the Phase 4 initial stamp and as the frontend-fallback
-    mirror.  The authoritative tier assignment for ranked rows comes
-    from ``_compute_value_based_tier_ids`` in the Phase 5 compact
-    pass; this function is overwritten for every tiered row before the
+    ``frontend/lib/rankings-helpers.js``.  Used as the Phase 4 initial
+    stamp and as the frontend-fallback mirror; the authoritative tier
+    assignment for ranked rows comes from
+    ``_compute_value_based_tier_ids`` (gap-based detection) in the
+    Phase 5 compact pass, which overwrites this value before the
     contract is returned.
     """
     if rank <= 12:
-        return 1   # Elite
+        return 1
     if rank <= 36:
-        return 2   # Blue-Chip
+        return 2
     if rank <= 72:
-        return 3   # Premium Starter
+        return 3
     if rank <= 120:
-        return 4   # Solid Starter
+        return 4
     if rank <= 200:
-        return 5   # Starter
+        return 5
     if rank <= 350:
-        return 6   # Flex / Depth
+        return 6
     if rank <= 500:
-        return 7   # Bench Depth
+        return 7
     if rank <= 650:
-        return 8   # Deep Stash
+        return 8
     if rank <= 800:
-        return 9   # Roster Fringe
-    return 10       # Waiver Wire
+        return 9
+    return 10
 
 
 def _retail_source_keys() -> frozenset[str]:
@@ -4226,15 +4212,13 @@ def _compute_unified_rankings(
             r["canonicalConsensusRank"] = new_rank
         tiered_rows.append(r)
 
-    # Gap-based tier detection on the blended value series.  Replaces
-    # the prior flat ``_tier_id_from_rank`` bucketing (1-12=Elite,
-    # 13-36=Blue-Chip, etc.) with real market-cliff detection: tiers
+    # Gap-based tier detection on the blended value series.  Tiers
     # land where the per-player value gap is unusually large relative
-    # to the local rolling-median gap.  A 400-point drop from rank
+    # to the local rolling-median gap: a 400-point drop from rank
     # 12→13 registers as a new tier boundary; a 3-point drop from
-    # 312→313 does not.  Caps at 10 tiers so the frontend's
-    # ``TIER_LABELS`` ("Elite" … "Waiver Wire") still maps cleanly;
-    # any gap-detected tiers past the cap collapse into tier 10.
+    # 312→313 does not.  The frontend renders the resulting tier IDs
+    # as generic "Tier N" labels, so every math-detected tier flows
+    # through uncapped.
     for r, tier_id in zip(
         tiered_rows, _compute_value_based_tier_ids(tiered_rows)
     ):

--- a/tests/api/test_launch_readiness.py
+++ b/tests/api/test_launch_readiness.py
@@ -209,17 +209,15 @@ class TestGate5TierAlignment(unittest.TestCase):
         missing = [r["canonicalName"] for r in ranked if r.get("canonicalTierId") is None]
         self.assertEqual(missing, [])
 
-    def test_tier_ids_bounded_and_rank1_is_tier1(self):
-        """Tier IDs land in the frontend's 1..10 vocabulary, and the
-        top-of-board row is always in tier 1.
+    def test_tier_ids_positive_and_rank1_is_tier1(self):
+        """Tier IDs are positive integers, and the top-of-board row is
+        always in tier 1.
 
-        Tier assignment is now gap-based on ``rankDerivedValue`` (see
+        Tier assignment is gap-based on ``rankDerivedValue`` (see
         ``_compute_value_based_tier_ids`` in ``src/api/data_contract.py``)
-        rather than fixed rank buckets, so we no longer pin each row to
-        ``_tier_id_from_rank(rank)`` — the whole point of the change is
-        that tier boundaries land at real market cliffs, which shift
-        run-to-run as the source blend shifts.  Monotonicity is covered
-        by ``test_tiers_non_decreasing``.
+        rather than fixed rank buckets.  The frontend renders generic
+        "Tier N" labels, so there's no upper bound on tier count;
+        monotonicity is covered by ``test_tiers_non_decreasing``.
         """
         result = _get()
         if result is None:
@@ -228,7 +226,7 @@ class TestGate5TierAlignment(unittest.TestCase):
         out_of_range = [
             f"#{r['canonicalConsensusRank']}: tier={r.get('canonicalTierId')}"
             for r in ranked
-            if not (isinstance(r.get("canonicalTierId"), int) and 1 <= r["canonicalTierId"] <= 10)
+            if not (isinstance(r.get("canonicalTierId"), int) and r["canonicalTierId"] >= 1)
         ]
         self.assertEqual(out_of_range, [])
         if ranked:

--- a/tests/api/test_ranking_coherence.py
+++ b/tests/api/test_ranking_coherence.py
@@ -168,11 +168,11 @@ class TestTierAlignment(unittest.TestCase):
 
     def test_tier_id_matches_rank_boundaries(self):
         """Verify _tier_id_from_rank matches the documented boundaries."""
-        self.assertEqual(_tier_id_from_rank(1), 1)    # Elite
-        self.assertEqual(_tier_id_from_rank(12), 1)   # Elite boundary
-        self.assertEqual(_tier_id_from_rank(13), 2)   # Blue-Chip start
-        self.assertEqual(_tier_id_from_rank(36), 2)   # Blue-Chip boundary
-        self.assertEqual(_tier_id_from_rank(37), 3)   # Premium Starter start
+        self.assertEqual(_tier_id_from_rank(1), 1)
+        self.assertEqual(_tier_id_from_rank(12), 1)
+        self.assertEqual(_tier_id_from_rank(13), 2)
+        self.assertEqual(_tier_id_from_rank(36), 2)
+        self.assertEqual(_tier_id_from_rank(37), 3)
         self.assertEqual(_tier_id_from_rank(72), 3)
         self.assertEqual(_tier_id_from_rank(73), 4)
         self.assertEqual(_tier_id_from_rank(120), 4)

--- a/tests/api/test_single_authority.py
+++ b/tests/api/test_single_authority.py
@@ -95,16 +95,14 @@ class TestSingleAuthority(unittest.TestCase):
         self.assertEqual(len(ranks), len(set(ranks)), "Duplicate ranks detected")
 
     def test_tier_bounded_and_monotonic(self):
-        """canonicalTierId lands in 1..10 and is non-decreasing with rank.
+        """canonicalTierId is a positive integer and non-decreasing with rank.
 
         Tier assignment is gap-based on ``rankDerivedValue`` (see
-        ``_compute_value_based_tier_ids``) rather than fixed rank
-        buckets, so the strict ``_tier_id_from_rank`` equality check
-        this test previously enforced no longer applies.  Instead we
-        pin the two invariants the frontend relies on: tier IDs stay in
-        the ``TIER_LABELS`` vocabulary (1..10), and higher-ranked rows
-        never land in a worse (higher-numbered) tier than lower-ranked
-        rows.
+        ``_compute_value_based_tier_ids``).  The frontend renders
+        generic "Tier N" labels, so there's no upper bound on the
+        number of math-detected tiers — we only pin that tier IDs are
+        positive integers and that higher-ranked rows never land in a
+        worse (higher-numbered) tier than lower-ranked rows.
         """
         contract = _load_live_contract()
         if contract is None:
@@ -119,12 +117,12 @@ class TestSingleAuthority(unittest.TestCase):
             for r in ranked
             if not (
                 isinstance(r.get("canonicalTierId"), int)
-                and 1 <= r["canonicalTierId"] <= 10
+                and r["canonicalTierId"] >= 1
             )
         ]
         self.assertEqual(
             out_of_range, [],
-            f"Tier IDs out of 1..10 range:\n" + "\n".join(out_of_range[:10]),
+            f"Tier IDs must be positive ints:\n" + "\n".join(out_of_range[:10]),
         )
         prev_tier = 0
         non_monotonic: list[str] = []


### PR DESCRIPTION
## Problem

Tier labels on the rankings page were misleading. The backend's gap-based tier detection (`detect_tiers` in `src/canonical/player_valuation.py`) produces numeric tier IDs from natural value cliffs, but the frontend re-labeled those IDs through a fixed dynasty-flavored vocabulary:

| tier ID | old label        |
|---------|------------------|
| 1       | Elite            |
| 2       | Blue-Chip        |
| 3       | Premium Starter  |
| 4       | Solid Starter    |
| 5       | Starter          |
| 6       | Flex / Depth     |
| 7       | Bench Depth      |
| 8       | Deep Stash       |
| 9       | Roster Fringe    |
| 10      | Waiver Wire      |

That map has no relation to roster slots or start-eligibility — it's just tier *N*. So a player at rank 31 landing in the 8th gap-detected tier rendered as "Deep Stash," and a player at rank 55 landing in the 10th tier rendered as "Waiver Wire." Neither is true in a 12-team league starting 20.

## Change

- Drop the label vocabulary. Every tier now renders as `Tier N`. What the user sees matches what the gap detector actually produced.
- Remove the `_GAP_BASED_TIER_CAP = 10` cap in `_compute_value_based_tier_ids`. The cap only existed to squeeze math-detected tiers into the 10-name vocabulary; with the vocabulary gone, every mathematically-detected tier flows through verbatim instead of collapsing into tier 10.
- Update `rankBasedTierLabel` (the fallback when `canonicalTierId` is missing) to produce the same `Tier N` shape.
- Update test expectations + remove the TIER_LABELS comments that referenced the old vocabulary.

Backend math (`detect_tiers`, `_compute_value_based_tier_ids`, `_tier_id_from_rank`) is otherwise untouched — the tier *IDs* are already derived from rolling-median gap analysis; only the presentation layer changed.

## Test plan

- [x] `python -m pytest tests/` — 1738 passed, 25 skipped (live-data conditionals)
- [x] `npm test` in `frontend/` — 418 passed across 12 files
- [ ] Load `/rankings` in a browser and confirm:
  - Tier badges and tier separator headers read `Tier 1`, `Tier 2`, …
  - Rank 1 is in Tier 1
  - Tier IDs are non-decreasing as rank increases
  - No "Elite / Blue-Chip / Deep Stash / Waiver Wire" strings anywhere on the rankings page

https://claude.ai/code/session_01S1tqwCd73MEUnVeJS45YQn