### PR TITLE
League: treat a 2-week championship as one matchup for records

### DIFF
--- a/frontend/app/league/shared-server.jsx
+++ b/frontend/app/league/shared-server.jsx
@@ -122,11 +122,17 @@ export function Stat({ label, value, sub }) {
 
 export function MeetingCard({ label, meeting }) {
   if (!meeting) return null;
+  // Multi-week championship (e.g. 2-week final spanning wk16+17) —
+  // render as "Wk 16-17" so users see the combined scope instead of
+  // a misleading single week number.
+  const weekLabel = Array.isArray(meeting.combinedWeeks) && meeting.combinedWeeks.length > 1
+    ? `Wk ${meeting.combinedWeeks[0]}-${meeting.combinedWeeks[meeting.combinedWeeks.length - 1]}`
+    : `Wk ${meeting.week}`;
   return (
     <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
       <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase" }}>{label}</div>
       <div style={{ fontSize: "0.86rem", fontWeight: 700, marginTop: 2 }}>
-        {meeting.season} · Wk {meeting.week}{meeting.isPlayoff ? " (P)" : ""}
+        {meeting.season} · {weekLabel}{meeting.isPlayoff ? " (P)" : ""}
       </div>
       <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
         Margin {fmtPoints(meeting.margin)} · {fmtPoints(meeting.pointsA)} / {fmtPoints(meeting.pointsB)}

--- a/src/public_league/metrics.py
+++ b/src/public_league/metrics.py
@@ -334,16 +334,108 @@ def walk_matchup_pairs(
     snapshot: PublicLeagueSnapshot,
     include_playoffs: bool = True,
 ) -> Iterable[tuple[SeasonSnapshot, int, dict[str, Any], dict[str, Any], bool]]:
-    """Yield (season, week, a, b, is_playoff) for every scored pair."""
+    """Yield (season, week, a, b, is_playoff) for every scored pair.
+
+    Multi-week championship matchups (e.g. a 2-week final spanning
+    weeks 16 and 17) are detected and yielded as a single combined
+    entry: points are summed across both weeks, the yielded week is
+    the earlier of the two, and each side carries a
+    ``_combinedWeeks`` marker listing the spanned weeks so downstream
+    consumers can surface the combined nature in UI labels.
+
+    Detection rule, deliberately narrow to avoid fusing the semifinal
+    with the final when the same rosters happen to appear in both:
+    the *last two playoff weeks* of the season must be contiguous
+    (wk_last == wk_penultimate + 1) AND the same pair of roster_ids
+    must appear in both.  Earlier playoff weeks (semis, quarters) are
+    emitted individually even when a repeat pairing exists.
+
+    This matches how Sleeper's ``championship_week_length = 2``
+    leagues surface their final: the last two scheduled weeks carry
+    the same finalists and the winner is decided by combined score.
+    """
     for season in snapshot.seasons:
-        for wk in sorted(season.matchups_by_week.keys()):
+        weeks_sorted = sorted(season.matchups_by_week.keys())
+        # Pre-compute pairs per week so lookahead into wk+1 is cheap.
+        pairs_by_week: dict[int, list[tuple[dict[str, Any], dict[str, Any]]]] = {
+            wk: matchup_pairs(season.matchups_by_week[wk]) for wk in weeks_sorted
+        }
+        # Index each week's pairs by the frozenset of the two roster ids
+        # so the lookahead step can probe in O(1).
+        index_by_week: dict[int, dict[frozenset[int], tuple[dict[str, Any], dict[str, Any]]]] = {}
+        for wk in weeks_sorted:
+            idx: dict[frozenset[int], tuple[dict[str, Any], dict[str, Any]]] = {}
+            for a, b in pairs_by_week[wk]:
+                rid_a = roster_id_of(a)
+                rid_b = roster_id_of(b)
+                if rid_a is None or rid_b is None:
+                    continue
+                idx[frozenset({rid_a, rid_b})] = (a, b)
+            index_by_week[wk] = idx
+
+        # Identify the single candidate week pair that can combine:
+        # only the last two contiguous playoff weeks qualify.  Semis
+        # against the final — even if the same two teams appear —
+        # stay separate.
+        playoff_weeks = [w for w in weeks_sorted if w >= season.playoff_week_start]
+        combine_from_wk: int | None = None
+        combine_to_wk: int | None = None
+        if len(playoff_weeks) >= 2:
+            last = playoff_weeks[-1]
+            prev = playoff_weeks[-2]
+            if last == prev + 1:
+                combine_from_wk = prev
+                combine_to_wk = last
+
+        # Track (week, pair_key) consumed as the second half of a
+        # combined matchup so we don't emit the same pair twice.
+        consumed: set[tuple[int, frozenset[int]]] = set()
+
+        for wk in weeks_sorted:
             is_playoff = wk >= season.playoff_week_start
             if is_playoff and not include_playoffs:
                 continue
-            for a, b in matchup_pairs(season.matchups_by_week[wk]):
-                if not is_scored(a) and not is_scored(b):
+            for a, b in pairs_by_week[wk]:
+                rid_a = roster_id_of(a)
+                rid_b = roster_id_of(b)
+                if rid_a is None or rid_b is None:
                     continue
-                yield season, wk, a, b, is_playoff
+                pair_key = frozenset({rid_a, rid_b})
+
+                if (wk, pair_key) in consumed:
+                    continue
+
+                emit_a, emit_b = a, b
+                # Combine only if we're on the penultimate playoff
+                # week AND the same pair appears in the final week.
+                if (
+                    wk == combine_from_wk
+                    and combine_to_wk is not None
+                    and combine_to_wk in index_by_week
+                ):
+                    next_pair = index_by_week[combine_to_wk].get(pair_key)
+                    if next_pair is not None:
+                        a2, b2 = next_pair
+                        rid_a2 = roster_id_of(a2)
+                        # Align the two sides so emit_a tracks rid_a
+                        # and emit_b tracks rid_b across both weeks.
+                        side_a2, side_b2 = (a2, b2) if rid_a2 == rid_a else (b2, a2)
+                        combined_weeks = [wk, combine_to_wk]
+                        emit_a = {
+                            **a,
+                            "points": matchup_points(a) + matchup_points(side_a2),
+                            "_combinedWeeks": combined_weeks,
+                        }
+                        emit_b = {
+                            **b,
+                            "points": matchup_points(b) + matchup_points(side_b2),
+                            "_combinedWeeks": combined_weeks,
+                        }
+                        consumed.add((combine_to_wk, pair_key))
+
+                if not is_scored(emit_a) and not is_scored(emit_b):
+                    continue
+                yield season, wk, emit_a, emit_b, is_playoff
 
 
 # ── Shared team-name resolver ────────────────────────────────────────────

--- a/src/public_league/records.py
+++ b/src/public_league/records.py
@@ -23,6 +23,9 @@ def _weekly_side_rows(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
     """Return every paired, scored roster-week with its opposing score."""
     rows: list[dict[str, Any]] = []
     for season, week, a, b, is_playoff in metrics.walk_matchup_pairs(snapshot):
+        # Multi-week finals collapse to one pair; stamp the spanned
+        # weeks so record-book rows can label them correctly.
+        combined_weeks = a.get("_combinedWeeks") or b.get("_combinedWeeks")
         for me, foe in ((a, b), (b, a)):
             rid = metrics.roster_id_of(me)
             if rid is None:
@@ -36,7 +39,7 @@ def _weekly_side_rows(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
                 continue
             margin = my_pts - opp_pts
             result = "W" if margin > 0 else ("L" if margin < 0 else "T")
-            rows.append({
+            row: dict[str, Any] = {
                 "season": season.season,
                 "leagueId": season.league_id,
                 "week": week,
@@ -48,7 +51,10 @@ def _weekly_side_rows(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
                 "opponentPoints": round(opp_pts, 2),
                 "margin": round(margin, 2),
                 "result": result,
-            })
+            }
+            if combined_weeks and len(combined_weeks) > 1:
+                row["combinedWeeks"] = list(combined_weeks)
+            rows.append(row)
     return rows
 
 

--- a/src/public_league/rivalries.py
+++ b/src/public_league/rivalries.py
@@ -119,6 +119,12 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         if margin_abs <= 10.0 + 1e-9:
             rec["gamesDecidedByTen"] += 1
 
+        # ``walk_matchup_pairs`` collapses multi-week playoff finals
+        # (e.g. a 2-week championship) into a single pair and stamps
+        # ``_combinedWeeks`` on each side.  Surface that here so the
+        # UI can render "Weeks 16-17 (Final)" instead of two separate
+        # meeting rows — records still count it as one win.
+        combined_weeks = a.get("_combinedWeeks") or b.get("_combinedWeeks")
         meeting = {
             "season": season.season,
             "leagueId": season.league_id,
@@ -129,6 +135,8 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             "pointsA": round(pts_left, 2),
             "pointsB": round(pts_right, 2),
         }
+        if combined_weeks and len(combined_weeks) > 1:
+            meeting["combinedWeeks"] = list(combined_weeks)
         if rec["closestGame"] is None or margin_abs < rec["closestGame"]["margin"]:
             rec["closestGame"] = meeting
         if rec["biggestBlowout"] is None or margin_abs > rec["biggestBlowout"]["margin"]:

--- a/tests/public_league/test_combined_weeks.py
+++ b/tests/public_league/test_combined_weeks.py
@@ -1,0 +1,343 @@
+"""Multi-week playoff championship combine rule.
+
+Sleeper leagues can configure a 2-week championship (e.g. weeks 16 +
+17 count as a single final).  For record bookkeeping purposes the
+pipeline must treat those as ONE matchup — one W/L entry in
+rivalries, one meeting in the record book — with combined points
+deciding the winner.  Scoring math (weekly hammers) still skips
+playoff weeks entirely so weekly-high attribution is unaffected.
+
+These tests pin the combine behavior at the iterator layer
+(``walk_matchup_pairs``) and verify it propagates into the record +
+rivalry engines.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.public_league import records, rivalries
+from src.public_league.identity import Manager, ManagerRegistry, TeamAlias
+from src.public_league.metrics import walk_matchup_pairs
+from src.public_league.snapshot import PublicLeagueSnapshot, SeasonSnapshot
+
+
+def _mk_registry() -> ManagerRegistry:
+    reg = ManagerRegistry()
+    for owner, rid in (("owner-A", 1), ("owner-B", 2)):
+        mgr = Manager(
+            owner_id=owner,
+            display_name=owner.title(),
+            current_roster_id=rid,
+            current_team_name=f"Team {owner[-1]}",
+            current_league_id="L-TEST",
+            aliases=[
+                TeamAlias(
+                    season="2025",
+                    league_id="L-TEST",
+                    team_name=f"Team {owner[-1]}",
+                    display_name=owner.title(),
+                    roster_id=rid,
+                )
+            ],
+        )
+        reg.by_owner_id[owner] = mgr
+        reg.roster_to_owner[("L-TEST", rid)] = owner
+    return reg
+
+
+def _mk_snapshot(matchups_by_week: dict[int, list[dict]]) -> PublicLeagueSnapshot:
+    season = SeasonSnapshot(
+        season="2025",
+        league_id="L-TEST",
+        league={
+            "league_id": "L-TEST",
+            "season": "2025",
+            "status": "complete",
+            "total_rosters": 2,
+            "settings": {"playoff_week_start": 15},
+        },
+        users=[],
+        rosters=[
+            {"roster_id": 1, "owner_id": "owner-A", "players": [], "settings": {}},
+            {"roster_id": 2, "owner_id": "owner-B", "players": [], "settings": {}},
+        ],
+        matchups_by_week=matchups_by_week,
+        transactions_by_week={},
+        drafts=[],
+        draft_picks_by_draft={},
+        traded_picks=[],
+        winners_bracket=[],
+        losers_bracket=[],
+    )
+    return PublicLeagueSnapshot(
+        root_league_id="L-TEST",
+        generated_at="2026-04-19T00:00:00+00:00",
+        seasons=[season],
+        managers=_mk_registry(),
+        nfl_players={},
+    )
+
+
+class CombinedWeeksIteratorTests(unittest.TestCase):
+    """walk_matchup_pairs must fuse 2-week playoff finals into one pair."""
+
+    def test_two_week_championship_yields_one_combined_pair(self) -> None:
+        # Weeks 16+17 championship (A vs B with combined scoring).
+        # A wins on combined points (220 vs 210) even though B won
+        # week 17 individually.  No semifinal — we only need two
+        # contiguous playoff weeks of the same pair to trigger the
+        # combine.
+        snap = _mk_snapshot(
+            {
+                16: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+                17: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 90.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+            }
+        )
+        results = list(walk_matchup_pairs(snap))
+        # One combined championship entry only.
+        self.assertEqual(len(results), 1)
+
+        season, week, a, b, is_playoff = results[0]
+        self.assertEqual(week, 16)
+        self.assertTrue(is_playoff)
+        self.assertEqual(a["_combinedWeeks"], [16, 17])
+        self.assertEqual(b["_combinedWeeks"], [16, 17])
+        # roster_id=1 (owner-A) combined: 130 + 90 = 220.0
+        # roster_id=2 (owner-B) combined: 105 + 105 = 210.0
+        pts_by_rid = {a["roster_id"]: a["points"], b["roster_id"]: b["points"]}
+        self.assertAlmostEqual(pts_by_rid[1], 220.0, places=2)
+        self.assertAlmostEqual(pts_by_rid[2], 210.0, places=2)
+
+    def test_single_week_championship_not_combined(self) -> None:
+        # Only one playoff week exists → nothing to combine with.
+        snap = _mk_snapshot(
+            {
+                1: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 100.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+                16: [
+                    # Lone championship week — no wk17 paired with it.
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 145.0},
+                ],
+            }
+        )
+        results = list(walk_matchup_pairs(snap))
+        self.assertEqual(len(results), 2)
+        wk16 = next(r for r in results if r[1] == 16)
+        _, _, a, b, _ = wk16
+        self.assertNotIn("_combinedWeeks", a)
+        self.assertNotIn("_combinedWeeks", b)
+        self.assertAlmostEqual(a["points"] + b["points"], 275.0, places=2)
+
+    def test_semifinal_and_championship_same_pair_not_combined(self) -> None:
+        # Rule must be narrow: even if the same two rosters appear in
+        # wk15 (semi) and wk16 (championship), those stay separate.
+        # Combine only fires for the final two contiguous playoff
+        # weeks.  Here: playoff weeks are 15, 16 — the last two; they
+        # ARE contiguous; BUT the scenario simulates a semi with the
+        # same rosters as the championship (unusual but legal under
+        # our rule — we DO combine since we can't distinguish without
+        # bracket context).  See
+        # ``test_three_playoff_weeks_only_final_two_combine`` below
+        # for the real three-week scenario.
+        #
+        # This test simply documents what happens when only 2 playoff
+        # weeks exist and they share a pair.  The user's scenario has
+        # THREE playoff weeks (semi wk15 + champ wk16+17), which the
+        # next test covers.
+        snap = _mk_snapshot(
+            {
+                15: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 150.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 140.0},
+                ],
+                16: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 125.0},
+                ],
+            }
+        )
+        results = list(walk_matchup_pairs(snap))
+        # With only 2 playoff weeks, the last two contiguous + same
+        # pair → combined into one.  That's the legitimate
+        # 2-week-final case where no semi exists.
+        self.assertEqual(len(results), 1)
+
+    def test_three_playoff_weeks_only_final_two_combine(self) -> None:
+        # The real user scenario: wk15 semi (rosters 1 vs 2), wk16+17
+        # championship between different rosters.  Set up a case
+        # where the same pair appears in BOTH the semi and the final.
+        # Because we only combine the *last two* playoff weeks, the
+        # semi stays separate.
+        snap = _mk_snapshot(
+            {
+                15: [
+                    # Semi with rid 1 vs 2.
+                    {"matchup_id": 1, "roster_id": 1, "points": 150.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 140.0},
+                ],
+                16: [
+                    # Championship game 1.
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 125.0},
+                ],
+                17: [
+                    # Championship game 2.
+                    {"matchup_id": 1, "roster_id": 1, "points": 115.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 140.0},
+                ],
+            }
+        )
+        results = list(walk_matchup_pairs(snap))
+        # wk15 semi emits on its own; wk16+17 combine into one entry.
+        weeks = sorted(r[1] for r in results)
+        self.assertEqual(weeks, [15, 16])
+
+        # Semi stays uncombined.
+        wk15 = next(r for r in results if r[1] == 15)
+        _, _, a, b, _ = wk15
+        self.assertNotIn("_combinedWeeks", a)
+        self.assertNotIn("_combinedWeeks", b)
+
+        # Championship is combined.
+        wk16 = next(r for r in results if r[1] == 16)
+        _, _, a, b, _ = wk16
+        self.assertEqual(a["_combinedWeeks"], [16, 17])
+        # Combined totals: rid 1 = 130+115 = 245; rid 2 = 125+140 = 265.
+        pts_by_rid = {a["roster_id"]: a["points"], b["roster_id"]: b["points"]}
+        self.assertAlmostEqual(pts_by_rid[1], 245.0, places=2)
+        self.assertAlmostEqual(pts_by_rid[2], 265.0, places=2)
+
+    def test_regular_season_consecutive_same_pair_not_combined(self) -> None:
+        # Two reg-season meetings between same rosters in consecutive
+        # weeks must remain separate (combine rule is playoff-only).
+        snap = _mk_snapshot(
+            {
+                1: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 100.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+                2: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 110.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 115.0},
+                ],
+            }
+        )
+        results = list(walk_matchup_pairs(snap))
+        self.assertEqual(len(results), 2)
+        weeks = sorted(r[1] for r in results)
+        self.assertEqual(weeks, [1, 2])
+        # Neither week combined.
+        for _, _, a, b, _ in results:
+            self.assertNotIn("_combinedWeeks", a)
+
+
+class CombinedWeeksRivalryTests(unittest.TestCase):
+    """Rivalry engine must count a 2-week final as ONE meeting."""
+
+    def _snap_with_combined_final(self) -> PublicLeagueSnapshot:
+        return _mk_snapshot(
+            {
+                16: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+                17: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 90.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+            }
+        )
+
+    def test_one_meeting_not_two(self) -> None:
+        snap = self._snap_with_combined_final()
+        section = rivalries.build_section(snap)
+        rows = section["rivalries"]
+        self.assertEqual(len(rows), 1)
+        ab = rows[0]
+        self.assertEqual(ab["totalMeetings"], 1)
+        self.assertEqual(ab["playoffMeetings"], 1)
+        # Combined points: A = 130+90 = 220, B = 105+105 = 210. A wins on total.
+        winner = ab["winsA"] + ab["winsB"]
+        self.assertEqual(winner, 1)
+        # Last meeting surfaces combinedWeeks for frontend labelling.
+        last = ab["lastMeeting"]
+        self.assertEqual(last["combinedWeeks"], [16, 17])
+        self.assertAlmostEqual(last["margin"], 10.0, places=2)
+
+    def test_sum_points_decide_winner(self) -> None:
+        """Winner is decided by combined points across both weeks,
+        even if one week individually went to the other side."""
+        snap = _mk_snapshot(
+            {
+                16: [
+                    # Week 16: A clobbers B by 40.
+                    {"matchup_id": 1, "roster_id": 1, "points": 180.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 140.0},
+                ],
+                17: [
+                    # Week 17: B wins by 10 — but combined A still
+                    # wins by 30.  Single W for A.
+                    {"matchup_id": 1, "roster_id": 1, "points": 90.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 100.0},
+                ],
+            }
+        )
+        section = rivalries.build_section(snap)
+        ab = section["rivalries"][0]
+        # Canonical pair ordering is by tuple sort — ('owner-A','owner-B').
+        # A is in position 0 so winsA is A's total.
+        self.assertEqual(ab["winsA"], 1)
+        self.assertEqual(ab["winsB"], 0)
+
+
+class CombinedWeeksRecordsTests(unittest.TestCase):
+    """Record-book weekly rows must stamp combinedWeeks on a combined
+    final so the UI can label it 'Weeks 16-17' instead of 'Week 16'."""
+
+    def test_combined_row_carries_weeks_marker(self) -> None:
+        snap = _mk_snapshot(
+            {
+                16: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+                17: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 90.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+            }
+        )
+        rows = records._weekly_side_rows(snap)
+        # One entry per side of the combined matchup (not 4).
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertEqual(row["week"], 16)
+            self.assertEqual(row["combinedWeeks"], [16, 17])
+            self.assertTrue(row["isPlayoff"])
+
+    def test_single_week_playoff_row_has_no_combined_marker(self) -> None:
+        snap = _mk_snapshot(
+            {
+                16: [
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+                ],
+            }
+        )
+        rows = records._weekly_side_rows(snap)
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertNotIn("combinedWeeks", row)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Your league scheduled the championship across weeks 16+17 in 2024 and 2025, where the winner is decided by combined points. Prior to this PR the pipeline counted those as two independent head-to-head meetings — two entries in the rivalry series, two record-book margins, and a 1-1 split was surfaced as a "series split" instead of a single combined W/L.

This PR fuses the last two contiguous playoff weeks that share a roster pair into one matchup:

- Points sum across both weeks; `_combinedWeeks=[w1, w2]` is stamped on each side
- Rivalry meetings count it as one meeting, decide the winner by combined points
- Record-book rows carry a `combinedWeeks` marker
- Frontend `MeetingCard` renders "Wk 16-17" instead of "Wk 16"

## Narrow detection rule
Only the *final two playoff weeks* combine, and only when they share a roster pair. Earlier playoff weeks (semi, quarter) stay separate even if the same teams happen to appear. Regular-season back-to-back meetings never combine.

## Scoring math unchanged
`_weekly_hammer_scores` already skips playoff weeks entirely — "don't count as a weekly high" was already true and stays true.

## Test plan
- [x] `pytest tests/ -q` — 1769 passed (9 new combined-week tests + 1760 existing), 3 skipped.
- [x] `npm run build` — clean.
- [ ] Load a rivalry page between two managers who met in the 2024 or 2025 championship, confirm one meeting row labelled "Wk 16-17".
- [ ] Check series record reflects combined W/L, not split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)