### PR TITLE
Fix: robust combine rule for multi-week finals + series leader label

### DIFF
--- a/frontend/app/league/rivalry/[pair]/page.jsx
+++ b/frontend/app/league/rivalry/[pair]/page.jsx
@@ -162,7 +162,19 @@ export default async function RivalryPage({ params }) {
             value={detail.totalMeetings}
             sub={`${detail.regularSeasonMeetings} reg · ${detail.playoffMeetings} playoff`}
           />
-          <Stat label="Series" value={`${detail.winsA}–${detail.winsB}${detail.ties ? `–${detail.ties}` : ""}`} />
+          <Stat
+            label="Series"
+            value={`${detail.winsA}–${detail.winsB}${detail.ties ? `–${detail.ties}` : ""}`}
+            sub={
+              detail.winsA > detail.winsB
+                ? `${nameFor(managers, idA)} leads`
+                : detail.winsB > detail.winsA
+                  ? `${nameFor(managers, idB)} leads`
+                  : detail.totalMeetings > 0
+                    ? "Tied"
+                    : undefined
+            }
+          />
           <Stat label="Points" value={`${fmtPoints(detail.pointsA)} / ${fmtPoints(detail.pointsB)}`} />
           <Stat label="Close (≤5 pts)" value={detail.gamesDecidedByFive} />
           <Stat label="Close (≤10 pts)" value={detail.gamesDecidedByTen} />

--- a/src/public_league/metrics.py
+++ b/src/public_league/metrics.py
@@ -373,26 +373,44 @@ def walk_matchup_pairs(
                 idx[frozenset({rid_a, rid_b})] = (a, b)
             index_by_week[wk] = idx
 
-        # Identify the single candidate week pair that can combine:
-        # only the last two contiguous playoff weeks qualify.  Semis
-        # against the final — even if the same two teams appear —
-        # stay separate.
-        playoff_weeks = [w for w in weeks_sorted if w >= season.playoff_week_start]
-        combine_from_wk: int | None = None
-        combine_to_wk: int | None = None
-        if len(playoff_weeks) >= 2:
-            last = playoff_weeks[-1]
-            prev = playoff_weeks[-2]
-            if last == prev + 1:
-                combine_from_wk = prev
-                combine_to_wk = last
+        # Build per-pair combine plan.  Sleeper snapshots frequently
+        # include trailing "week 18" roster rows with ``matchup_id ==
+        # None`` that look like playoffs by week number but carry no
+        # real pairings — so a naive "last two playoff weeks" rule
+        # misses the real championship.  Instead, for each pair that
+        # actually yields a matchup pair in the playoff window, find
+        # the *latest* run of consecutive playoff weeks it appears in.
+        # If the run has length >= 2, the last two weeks of that run
+        # are the multi-week final and should be fused.  Runs are
+        # per-pair, so a 3-week semi+final same-rosters scenario
+        # combines only the last two (championship) weeks and leaves
+        # the earlier semifinal emit intact.
+        playoff_week_start = season.playoff_week_start
+        pair_playoff_weeks: dict[frozenset[int], list[int]] = {}
+        for wk in weeks_sorted:
+            if wk < playoff_week_start:
+                continue
+            for key in index_by_week[wk].keys():
+                pair_playoff_weeks.setdefault(key, []).append(wk)
+
+        # pair -> (combine_from_wk, combine_to_wk) for 2-week finals.
+        combine_plan: dict[frozenset[int], tuple[int, int]] = {}
+        for pair_key, pwks in pair_playoff_weeks.items():
+            pwks_sorted = sorted(pwks)
+            # Walk the list and keep the latest consecutive pair.
+            latest: tuple[int, int] | None = None
+            for i in range(len(pwks_sorted) - 1):
+                if pwks_sorted[i + 1] == pwks_sorted[i] + 1:
+                    latest = (pwks_sorted[i], pwks_sorted[i + 1])
+            if latest is not None:
+                combine_plan[pair_key] = latest
 
         # Track (week, pair_key) consumed as the second half of a
         # combined matchup so we don't emit the same pair twice.
         consumed: set[tuple[int, frozenset[int]]] = set()
 
         for wk in weeks_sorted:
-            is_playoff = wk >= season.playoff_week_start
+            is_playoff = wk >= playoff_week_start
             if is_playoff and not include_playoffs:
                 continue
             for a, b in pairs_by_week[wk]:
@@ -406,14 +424,12 @@ def walk_matchup_pairs(
                     continue
 
                 emit_a, emit_b = a, b
-                # Combine only if we're on the penultimate playoff
-                # week AND the same pair appears in the final week.
-                if (
-                    wk == combine_from_wk
-                    and combine_to_wk is not None
-                    and combine_to_wk in index_by_week
-                ):
-                    next_pair = index_by_week[combine_to_wk].get(pair_key)
+                # Combine only when this week is the first half of
+                # the planned 2-week final for *this* pair.
+                plan = combine_plan.get(pair_key)
+                if plan is not None and plan[0] == wk:
+                    combine_to_wk = plan[1]
+                    next_pair = index_by_week.get(combine_to_wk, {}).get(pair_key)
                     if next_pair is not None:
                         a2, b2 = next_pair
                         rid_a2 = roster_id_of(a2)

--- a/tests/public_league/test_combined_weeks.py
+++ b/tests/public_league/test_combined_weeks.py
@@ -171,6 +171,57 @@ class CombinedWeeksIteratorTests(unittest.TestCase):
         # 2-week-final case where no semi exists.
         self.assertEqual(len(results), 1)
 
+    def test_trailing_empty_playoff_week_does_not_hide_final(self) -> None:
+        # Sleeper snapshots frequently include a trailing wk 18 with
+        # roster rows but no matchup_ids (consolation / leftover
+        # scoring).  The real 2-week championship is 16+17 and must
+        # still fuse even though 18 is technically the last "playoff
+        # week" by week number.
+        snap = _mk_snapshot(
+            {
+                14: [
+                    # Bye-ish: unpaired rows (no matchup_id).
+                    {"matchup_id": None, "roster_id": 1, "points": 100.0},
+                    {"matchup_id": None, "roster_id": 2, "points": 110.0},
+                ],
+                15: [
+                    # Semi with different bracket (rid 1 vs rid 2
+                    # happen to appear but as solo entries, no
+                    # matchup_id → not paired).
+                    {"matchup_id": None, "roster_id": 1, "points": 200.0},
+                    {"matchup_id": None, "roster_id": 2, "points": 210.0},
+                ],
+                16: [
+                    # Championship game 1.
+                    {"matchup_id": 1, "roster_id": 1, "points": 130.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 125.0},
+                ],
+                17: [
+                    # Championship game 2.
+                    {"matchup_id": 1, "roster_id": 1, "points": 115.0},
+                    {"matchup_id": 1, "roster_id": 2, "points": 140.0},
+                ],
+                18: [
+                    # Sleeper trailing empty week — roster rows
+                    # exist but no matchup_ids.
+                    {"matchup_id": None, "roster_id": 1, "points": 180.0},
+                    {"matchup_id": None, "roster_id": 2, "points": 195.0},
+                ],
+            }
+        )
+        results = list(walk_matchup_pairs(snap))
+        # Only the combined championship matchup emits (wks 14, 15,
+        # 18 have no real pairings; wks 16 + 17 fuse).
+        self.assertEqual(len(results), 1)
+        _, week, a, b, is_playoff = results[0]
+        self.assertEqual(week, 16)
+        self.assertTrue(is_playoff)
+        self.assertEqual(a["_combinedWeeks"], [16, 17])
+        # rid 1: 130 + 115 = 245; rid 2: 125 + 140 = 265.
+        pts_by_rid = {a["roster_id"]: a["points"], b["roster_id"]: b["points"]}
+        self.assertAlmostEqual(pts_by_rid[1], 245.0, places=2)
+        self.assertAlmostEqual(pts_by_rid[2], 265.0, places=2)
+
     def test_three_playoff_weeks_only_final_two_combine(self) -> None:
         # The real user scenario: wk15 semi (rosters 1 vs 2), wk16+17
         # championship between different rosters.  Set up a case


### PR DESCRIPTION
## Summary
PR #129's combine rule looked at "the last two playoff weeks of the schedule" — but Sleeper snapshots commonly include a trailing wk 18 with roster rows and no real matchup_ids (consolation scoring). That pushed the rule to evaluate (17, 18) instead of (16, 17), so the real 2-week championship never fused.

Live regression: TyBWell vs MaKaylaChristy showed 7 meetings / 3 playoffs / series 3-4.

## Fix
Per-pair rule: for each pair yielding a real matchup pair in any playoff week, find the latest run of contiguous playoff weeks it appears in. If that run has length ≥ 2, fuse its last two weeks. Sleeper's trailing-wk-18 empty rows never enter the per-pair index (matchup_id=None → no paired output), so they no longer interfere.

Semifinal + championship with the same rosters (3 contiguous weeks) still works correctly — only the last two fuse, the semi emits on its own.

## Also in this PR
Rivalry detail "Series" stat now shows who leads the all-time series (e.g. "MaKaylaChristy leads") or "Tied" under the record.

## Live-data check
TyBWell vs MaKaylaChristy after this fix:
- totalMeetings: 6 (was 7)
- playoffMeetings: 2 (was 3)
- series: 3-3 (was 3-4) — the 2024 wks 16+17 championship fuses into one combined-point W

## Test plan
- [x] `pytest tests/ -q` — 1770 passed (1 new regression test for trailing empty week).
- [x] Live API check against production snapshot confirms fused totals.
- [ ] Visual check on the rivalry page after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)