### PR TITLE
League rivalry: label who did what on head-to-head stats + meetings

### DIFF
--- a/frontend/app/league/rivalry/[pair]/page.jsx
+++ b/frontend/app/league/rivalry/[pair]/page.jsx
@@ -175,9 +175,37 @@ export default async function RivalryPage({ params }) {
                     : undefined
             }
           />
-          <Stat label="Points" value={`${fmtPoints(detail.pointsA)} / ${fmtPoints(detail.pointsB)}`} />
-          <Stat label="Close (≤5 pts)" value={detail.gamesDecidedByFive} />
-          <Stat label="Close (≤10 pts)" value={detail.gamesDecidedByTen} />
+          <Stat
+            label="Points"
+            value={`${fmtPoints(detail.pointsA)} / ${fmtPoints(detail.pointsB)}`}
+            sub={
+              detail.pointsA > detail.pointsB
+                ? `${nameFor(managers, idA)} +${fmtPoints(detail.pointsA - detail.pointsB)}`
+                : detail.pointsB > detail.pointsA
+                  ? `${nameFor(managers, idB)} +${fmtPoints(detail.pointsB - detail.pointsA)}`
+                  : detail.totalMeetings > 0
+                    ? "Even"
+                    : undefined
+            }
+          />
+          <Stat
+            label="Close (≤5 pts)"
+            value={detail.gamesDecidedByFive}
+            sub={
+              detail.gamesDecidedByFive === 0 && detail.totalMeetings > 0
+                ? "No nail-biters"
+                : undefined
+            }
+          />
+          <Stat
+            label="Close (≤10 pts)"
+            value={detail.gamesDecidedByTen}
+            sub={
+              detail.gamesDecidedByTen === 0 && detail.totalMeetings > 0
+                ? "No close games"
+                : undefined
+            }
+          />
         </div>
 
         <div style={{ fontWeight: 600, marginBottom: 6 }}>Memorable meetings</div>
@@ -188,9 +216,24 @@ export default async function RivalryPage({ params }) {
             gap: 10,
           }}
         >
-          <MeetingCard label="Closest" meeting={detail.closestGame} />
-          <MeetingCard label="Biggest blowout" meeting={detail.biggestBlowout} />
-          <MeetingCard label="Last meeting" meeting={detail.lastMeeting} />
+          <MeetingCard
+            label="Closest"
+            meeting={detail.closestGame}
+            nameA={nameFor(managers, idA)}
+            nameB={nameFor(managers, idB)}
+          />
+          <MeetingCard
+            label="Biggest blowout"
+            meeting={detail.biggestBlowout}
+            nameA={nameFor(managers, idA)}
+            nameB={nameFor(managers, idB)}
+          />
+          <MeetingCard
+            label="Last meeting"
+            meeting={detail.lastMeeting}
+            nameA={nameFor(managers, idA)}
+            nameB={nameFor(managers, idB)}
+          />
         </div>
 
         {detail.seasonSplits && Object.keys(detail.seasonSplits).length > 0 && (

--- a/frontend/app/league/sections/rivalries.jsx
+++ b/frontend/app/league/sections/rivalries.jsx
@@ -65,17 +65,72 @@ function RivalriesSection({ managers, data, onNavigate }) {
         >
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10, marginBottom: 14 }}>
             <Stat label="Meetings" value={detail.totalMeetings} sub={`${detail.regularSeasonMeetings} reg · ${detail.playoffMeetings} playoff`} />
-            <Stat label="Series" value={`${detail.winsA}–${detail.winsB}${detail.ties ? `–${detail.ties}` : ""}`} />
-            <Stat label="Points" value={`${fmtPoints(detail.pointsA)} / ${fmtPoints(detail.pointsB)}`} />
-            <Stat label="Close (≤5 pts)" value={detail.gamesDecidedByFive} sub="most decisive closeness band" />
-            <Stat label="Close (≤10 pts)" value={detail.gamesDecidedByTen} />
+            <Stat
+              label="Series"
+              value={`${detail.winsA}–${detail.winsB}${detail.ties ? `–${detail.ties}` : ""}`}
+              sub={
+                detail.winsA > detail.winsB
+                  ? `${nameFor(managers, detail.ownerIds[0])} leads`
+                  : detail.winsB > detail.winsA
+                    ? `${nameFor(managers, detail.ownerIds[1])} leads`
+                    : detail.totalMeetings > 0
+                      ? "Tied"
+                      : undefined
+              }
+            />
+            <Stat
+              label="Points"
+              value={`${fmtPoints(detail.pointsA)} / ${fmtPoints(detail.pointsB)}`}
+              sub={
+                detail.pointsA > detail.pointsB
+                  ? `${nameFor(managers, detail.ownerIds[0])} +${fmtPoints(detail.pointsA - detail.pointsB)}`
+                  : detail.pointsB > detail.pointsA
+                    ? `${nameFor(managers, detail.ownerIds[1])} +${fmtPoints(detail.pointsB - detail.pointsA)}`
+                    : detail.totalMeetings > 0
+                      ? "Even"
+                      : undefined
+              }
+            />
+            <Stat
+              label="Close (≤5 pts)"
+              value={detail.gamesDecidedByFive}
+              sub={
+                detail.gamesDecidedByFive === 0 && detail.totalMeetings > 0
+                  ? "No nail-biters"
+                  : "most decisive closeness band"
+              }
+            />
+            <Stat
+              label="Close (≤10 pts)"
+              value={detail.gamesDecidedByTen}
+              sub={
+                detail.gamesDecidedByTen === 0 && detail.totalMeetings > 0
+                  ? "No close games"
+                  : undefined
+              }
+            />
           </div>
 
           <div style={{ fontWeight: 600, marginBottom: 6 }}>Memorable meetings</div>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 10 }}>
-            <MeetingCard label="Closest" meeting={detail.closestGame} />
-            <MeetingCard label="Biggest blowout" meeting={detail.biggestBlowout} />
-            <MeetingCard label="Last meeting" meeting={detail.lastMeeting} />
+            <MeetingCard
+              label="Closest"
+              meeting={detail.closestGame}
+              nameA={nameFor(managers, detail.ownerIds[0])}
+              nameB={nameFor(managers, detail.ownerIds[1])}
+            />
+            <MeetingCard
+              label="Biggest blowout"
+              meeting={detail.biggestBlowout}
+              nameA={nameFor(managers, detail.ownerIds[0])}
+              nameB={nameFor(managers, detail.ownerIds[1])}
+            />
+            <MeetingCard
+              label="Last meeting"
+              meeting={detail.lastMeeting}
+              nameA={nameFor(managers, detail.ownerIds[0])}
+              nameB={nameFor(managers, detail.ownerIds[1])}
+            />
           </div>
 
           {detail.seasonSplits && Object.keys(detail.seasonSplits).length > 0 && (

--- a/frontend/app/league/shared-server.jsx
+++ b/frontend/app/league/shared-server.jsx
@@ -120,7 +120,7 @@ export function Stat({ label, value, sub }) {
   );
 }
 
-export function MeetingCard({ label, meeting }) {
+export function MeetingCard({ label, meeting, nameA, nameB }) {
   if (!meeting) return null;
   // Multi-week championship (e.g. 2-week final spanning wk16+17) —
   // render as "Wk 16-17" so users see the combined scope instead of
@@ -128,15 +128,47 @@ export function MeetingCard({ label, meeting }) {
   const weekLabel = Array.isArray(meeting.combinedWeeks) && meeting.combinedWeeks.length > 1
     ? `Wk ${meeting.combinedWeeks[0]}-${meeting.combinedWeeks[meeting.combinedWeeks.length - 1]}`
     : `Wk ${meeting.week}`;
+  // Who-won attribution — when the caller threads both manager
+  // names through, render "{winner} def. {loser}" so the card
+  // answers the natural "who did what" question up front.
+  let outcomeLine = null;
+  if (nameA && nameB) {
+    if (meeting.winnerSide === "A") {
+      outcomeLine = `${nameA} def. ${nameB}`;
+    } else if (meeting.winnerSide === "B") {
+      outcomeLine = `${nameB} def. ${nameA}`;
+    } else if (meeting.winnerSide === "T") {
+      outcomeLine = `${nameA} tied ${nameB}`;
+    }
+  }
+  // Points line, winner bolded when names are available.
+  const pointsLine = nameA && nameB ? (
+    <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+      <span style={{ fontWeight: meeting.winnerSide === "A" ? 700 : 400, color: meeting.winnerSide === "A" ? "var(--text)" : undefined }}>
+        {nameA} {fmtPoints(meeting.pointsA)}
+      </span>
+      {" · "}
+      <span style={{ fontWeight: meeting.winnerSide === "B" ? 700 : 400, color: meeting.winnerSide === "B" ? "var(--text)" : undefined }}>
+        {nameB} {fmtPoints(meeting.pointsB)}
+      </span>
+    </div>
+  ) : (
+    <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+      Margin {fmtPoints(meeting.margin)} · {fmtPoints(meeting.pointsA)} / {fmtPoints(meeting.pointsB)}
+    </div>
+  );
   return (
     <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
       <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase" }}>{label}</div>
       <div style={{ fontSize: "0.86rem", fontWeight: 700, marginTop: 2 }}>
         {meeting.season} · {weekLabel}{meeting.isPlayoff ? " (P)" : ""}
       </div>
-      <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
-        Margin {fmtPoints(meeting.margin)} · {fmtPoints(meeting.pointsA)} / {fmtPoints(meeting.pointsB)}
-      </div>
+      {outcomeLine && (
+        <div style={{ fontSize: "0.74rem", marginTop: 2, color: "var(--cyan)" }}>
+          {outcomeLine} by {fmtPoints(meeting.margin)}
+        </div>
+      )}
+      {pointsLine}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Head-to-head detail panel previously showed raw numbers with no attribution — "3–3", "2415.6 / 2424.0", "Margin 31.8 · 413.4 / 381.6" — leaving the reader to map which side was which name. This pass threads manager names through so the cards answer "who did what" directly:

| Stat | Before | After |
|---|---|---|
| Series | `3–3` | `3–3` · sub: "Tied" / "{leader} leads" |
| Points | `2415.6 / 2424.0` | same · sub: "MaKaylaChristy +8.4" / "Even" |
| Close (≤5/10) with 0 count | `0` · sub absent | `0` · sub: "No nail-biters" / "No close games" |
| Memorable meeting cards | `Margin 31.8 · 413.4 / 381.6` | `TyBWell def. MaKaylaChristy by 31.8` + bolded winner in points line |

Applied to both the rivalries tab card view and the dedicated rivalry detail page.

## No backend changes
All needed fields (`winnerSide`, `pointsA`, `pointsB`, `margin`) were already on each meeting entry. Manager names threaded through via the existing `nameFor(managers, ownerId)` helper.

## Test plan
- [x] `npm run build` — clean.
- [ ] Visual check on rivalry detail page after deploy: outcome line reads correctly, winner bolded, sub-labels visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)