### PR TITLE
IDP blend: self-correcting rookie exclusion + IDPTC weight 2.0

### DIFF
--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -240,6 +240,10 @@ export const RANKING_SOURCES = [
     // _RANKING_SOURCES entry in src/api/data_contract.py.  The two
     // scope passes act on disjoint row sets so sourceRanks never
     // collides for the same source key.
+    // Weight = 2.0 (not 1.0) because IDPTC is the retail IDP
+    // authority and the backbone source.  Keeps the IDP blend
+    // from being dragged down by DLF/FP veteran boards when they
+    // disagree strongly with IDPTC's projection-aware view.
     key: "idpTradeCalc",
     displayName: "IDP Trade Calculator",
     columnLabel: "IDPTC",
@@ -247,7 +251,7 @@ export const RANKING_SOURCES = [
     extraScopes: ["overall_offense"],
     positionGroup: null,
     depth: null,
-    weight: 1.0,
+    weight: 2.0,
     isBackbone: true,
     isRetail: false,
     // IDPTradeCalc's offense board is a standard SF calculator — no

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -655,7 +655,17 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "extra_scopes": [SOURCE_SCOPE_OVERALL_OFFENSE],
         "position_group": None,
         "depth": None,
-        "weight": 1.0,
+        # IDPTC is the retail IDP authority and the backbone source.
+        # Weight bumped to 2.0 so the IDP blend leans toward IDPTC
+        # whenever it disagrees strongly with veteran-focused expert
+        # boards (DLF IDP, FantasyPros IDP, FootballGuys IDP).  The
+        # original 1.0 weight let DLF IDP drag down players IDPTC
+        # likes — particularly high-draft-capital edge rushers whose
+        # pass-rush projection (IDPTC) diverges from raw tackle
+        # production (DLF).  Mirrored in
+        # frontend/lib/dynasty-data.js so the settings page shows the
+        # correct default.
+        "weight": 2.0,
         "is_backbone": True,
         # IDPTradeCalc's offense autocomplete is a standard SF board,
         # not TE-premium.  The frontend TEP boost applies.
@@ -3863,6 +3873,29 @@ def _compute_unified_rankings(
             if rank_idx == 0 or val != eligible[rank_idx - 1][0]:
                 current_dense_rank = rank_idx + 1
             raw_rank = current_dense_rank
+
+            # ── Self-correcting rookie exclusion ──
+            # Sources flagged ``excludes_rookies=True`` (DLF IDP,
+            # FantasyPros IDP today) are veteran-focused boards whose
+            # rookie entries historically live at the deep tail of
+            # the pool — placeholder filler rather than real
+            # evaluations.  Stamping those placeholder ranks onto
+            # rookie rows drags the blend down even though the board
+            # doesn't really have an opinion.
+            #
+            # Rule (dynamic, not a hard flag): if the rookie's rank
+            # inside THIS source's pool is in the bottom 20% of the
+            # source's actual ranked depth, skip the contribution.
+            # If the source starts ranking the rookie in its top 80%
+            # (i.e. evaluating the player seriously), the stamp is
+            # trusted again automatically.  No code change required
+            # when DLF or FP start covering rookies properly — the
+            # gate lifts on its own.
+            row = players_array[row_idx]
+            if src.get("excludes_rookies") and bool(row.get("rookie")):
+                _pool_size = source_pool_sizes.get(source_key, 0)
+                if _pool_size > 0 and raw_rank > _pool_size * 0.80:
+                    continue
 
             # Translate to effective overall-style rank based on scope.
             # position_idp sources (shallow positional lists like DL-only)

--- a/tests/api/test_scope_aware_rankings.py
+++ b/tests/api/test_scope_aware_rankings.py
@@ -261,8 +261,11 @@ class TestCCoverageAwareBlending(unittest.TestCase):
         # Coverage weight stamped on meta
         eff_w = dl_a["sourceRankMeta"]["dlTop5"]["effectiveWeight"]
         self.assertLess(eff_w, 0.1)
+        # IDPTC's declared weight is 2.0 (IDP backbone + retail
+        # authority); coverage_weight preserves it on full-board
+        # sources (depth=None).
         backbone_w = dl_a["sourceRankMeta"]["idpTradeCalc"]["effectiveWeight"]
-        self.assertEqual(backbone_w, 1.0)
+        self.assertEqual(backbone_w, 2.0)
 
         # The blended value must stay closer to rank_to_value(3) than to
         # rank_to_value(1) — the deep backbone dominates the shallow list.
@@ -272,9 +275,10 @@ class TestCCoverageAwareBlending(unittest.TestCase):
         dist_to_rank1 = abs(dl_a["rankDerivedValue"] - v_rank1)
         self.assertLess(dist_to_rank3, dist_to_rank1)
 
-    def test_full_board_second_idp_source_carries_equal_weight(self):
+    def test_full_board_second_idp_source_preserves_declared_weights(self):
         """A second full-board overall_idp source (depth=None) should
-        blend equally with the backbone (both get coverage weight 1.0)."""
+        carry its declared weight unchanged by coverage_weight; the
+        backbone's declared 2.0 is similarly preserved."""
         self._saved_registry2 = copy.deepcopy(_RANKING_SOURCES)
         _RANKING_SOURCES.append(
             {
@@ -297,7 +301,8 @@ class TestCCoverageAwareBlending(unittest.TestCase):
             bw = b["sourceRankMeta"]["secondFull"]["effectiveWeight"]
             bw_bb = b["sourceRankMeta"]["idpTradeCalc"]["effectiveWeight"]
             self.assertEqual(bw, 1.0)
-            self.assertEqual(bw_bb, 1.0)
+            # IDPTC's declared weight is 2.0 per the IDP-authority policy.
+            self.assertEqual(bw_bb, 2.0)
         finally:
             _RANKING_SOURCES.clear()
             _RANKING_SOURCES.extend(self._saved_registry2)

--- a/tests/api/test_source_registry_parity.py
+++ b/tests/api/test_source_registry_parity.py
@@ -264,26 +264,32 @@ class TestBackendFrontendRegistryParity(unittest.TestCase):
                 f"Frontend entry {entry.get('key')} missing columnLabel",
             )
 
-    def test_every_weight_is_1_0(self) -> None:
-        # This is a guardrail on the "no silent weight boosts" rule —
-        # if a weight ever drifts off 1.0, either the user asked for
-        # it via overrides (which this test does NOT exercise) or
-        # someone forgot to update the registry comment explaining
-        # why.  Run with a weight != 1.0 to fail loudly.
+    def test_default_weights_match_registry_policy(self) -> None:
+        # Guardrail on the "no silent weight boosts" rule — weights
+        # must match the explicit per-source policy documented in the
+        # registry comments.  The default is 1.0, but IDPTC carries
+        # 2.0 because it is the IDP backbone + retail IDP authority
+        # (see registry comment in src/api/data_contract.py).  Any
+        # other per-source override must be added here AND in the
+        # registry comment explaining why.
+        expected_weights: dict[str, float] = {"idpTradeCalc": 2.0}
         for entry in self.py_registry:
+            expected = expected_weights.get(str(entry["key"]), 1.0)
             self.assertEqual(
                 entry["weight"],
-                1.0,
-                f"Python registry default weight for {entry['key']} is "
-                f"{entry['weight']}; every source must default to 1.0 "
-                "(see registry note in src/api/data_contract.py)",
+                expected,
+                f"Python registry weight for {entry['key']} is "
+                f"{entry['weight']}; expected {expected} per registry "
+                "comment policy in src/api/data_contract.py",
             )
         for entry in self.js_registry:
+            expected = expected_weights.get(str(entry.get("key")), 1.0)
             self.assertEqual(
                 entry.get("weight"),
-                1,
-                f"Frontend registry default weight for {entry.get('key')} is "
-                f"{entry.get('weight')}; every source must default to 1.0",
+                expected,
+                f"Frontend registry weight for {entry.get('key')} is "
+                f"{entry.get('weight')}; expected {expected} per "
+                "registry policy (must mirror src/api/data_contract.py)",
             )
 
 


### PR DESCRIPTION
## Summary
Two fixes for the "rookies with good IDPTC ranks have low blended values" complaint:

### 1. Self-correcting rookie exclusion at enrichment
`excludes_rookies=True` was metadata-only before (just pruned the single-source detector's expected set) — DLF IDP and FP IDP were still stamping placeholder tail-of-pool ranks onto rookies.

New rule: when a source is flagged `excludes_rookies` AND the row is a rookie, check the rookie's within-source rank. If it sits in the bottom **20%** of the source's actual ranked pool, skip the contribution. If the source starts ranking the rookie in its top 80%, the stamp is trusted again — **no code change required when DLF/FP improve rookie coverage**.

### 2. IDPTC weight 1.0 → 2.0 for its primary IDP scope
IDPTC is the retail IDP authority + backbone source. Giving it a 2× voice in the blend respects the "IDPTC is the source I trust most" stance without conditional override logic.

## Live-snapshot impact

| Player | Before | After | Δ |
|---|---|---|---|
| Caleb Downs | 2,580 | 2,757 | +177 |
| Arvell Reese | 2,201 | 2,413 | +212 |
| Sonny Styles | 1,943 | 2,132 | +189 |
| Dillon Thieneman | 1,910 | 2,002 | +92 |
| Abdul Carter | 2,710 | 3,319 | +609 |
| Brian Burns | 3,499 | 3,574 | +75 |
| Myles Garrett | 4,830 | 5,098 | +268 |
| Will Anderson | 5,628 | 5,963 | +335 |
| Jared Verse | 3,108 | 2,808 | **−300** (IDPTC is cooler on Verse; weight bump pulls him DOWN toward IDPTC's #145) |

The Verse case is the asymmetric half — if IDPTC is bearish on a player, the weight bump pulls them down. That's the intended behavior given your stated preference.

## Test plan
- [x] `pytest tests/ -q` — 1772 passed, 3 skipped.
- [x] `npm run build` — clean.
- [x] Registry parity test renamed + allows per-source weight policy (idpTradeCalc=2.0, others=1.0).
- [ ] Post-deploy: spot-check rookies and edge rushers on the rankings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)