### PR TITLE
IDP Hill curve: refit to IDPTC's raw IDP slice (mirrors retail before calibration)

### DIFF
--- a/scripts/fit_hill_curve_from_market.py
+++ b/scripts/fit_hill_curve_from_market.py
@@ -30,15 +30,25 @@ OFFENSE_SOURCES: dict[str, tuple[str, str]] = {
     "DynastyNerds": ("CSVs/site_raw/dynastyNerdsSfTep.csv",   "Value"),
 }
 
-# IDP market sources.  FantasyPros IDP exposes a pre-normalized 1-9999
-# ``normalizedValue`` column straight from its dynasty IDP expert
-# consensus, so the fit works off published IDP pricing directly.
-# IDPTradeCalc's raw ``value`` column mixes offense + IDP + picks, but
-# the IDP entries always cluster below 7500 on its scale — cap the
-# slice at row 200 to approximate "IDP-only" without a position column.
+# IDP market sources.  IDPTradeCalc is the retail IDP authority and
+# the blend backbone — we want the IDP Hill curve to reproduce its
+# per-rank values directly, so our Hill(rank) output matches IDPTC
+# BEFORE any per-position IDP calibration multiplier is applied.
+# IDPTC's CSV is ``name,value`` for a combined offense+IDP+picks pool
+# with no position column, so the ``--universe idp`` path loads a
+# snapshot (``dynasty_data_*.json``) to filter to IDP-only rows and
+# reads their IDPTC combined-pool ranks directly.  See
+# ``_load_idptc_idp_pairs`` below.
 IDP_SOURCES: dict[str, tuple[str, str]] = {
-    "FantasyProsIDP": ("CSVs/site_raw/fantasyProsIdp.csv", "normalizedValue"),
+    "IDPTradeCalc-IDP": ("CSVs/site_raw/idpTradeCalc.csv", "value"),
 }
+
+# IDP positions recognised by the snapshot filter.  Mirrors
+# ``src.utils.name_clean`` — kept local to the script to avoid a
+# package import at fit time.
+_IDP_POSITIONS: frozenset[str] = frozenset(
+    {"DL", "DE", "DT", "EDGE", "NT", "LB", "ILB", "OLB", "MLB", "DB", "CB", "S", "SS", "FS"}
+)
 
 
 def _load_values(path: Path, col: str) -> list[float]:
@@ -54,6 +64,47 @@ def _load_values(path: Path, col: str) -> list[float]:
                 vs.append(v)
     vs.sort(reverse=True)
     return vs
+
+
+def _load_idptc_idp_pairs() -> list[tuple[int, float]]:
+    """Return (idptc_combined_pool_rank, idptc_value) for IDP players.
+
+    IDPTC's CSV has no position column, so we load the most recent
+    ``dynasty_data_*.json`` snapshot to borrow its sleeper positions
+    map.  Ranks are IDPTC's actual combined-pool positions (not
+    IDP-only ordinals) because that's what the blend feeds into the
+    Hill curve at runtime.
+    """
+    import json
+
+    snapshot_candidates = sorted(
+        REPO.glob("dynasty_data_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not snapshot_candidates:
+        return []
+    with snapshot_candidates[0].open() as f:
+        raw = json.load(f)
+    positions = (raw.get("sleeper") or {}).get("positions") or {}
+
+    all_rows: list[tuple[str, float]] = []
+    for name, p in (raw.get("players") or {}).items():
+        idptc_val = ((p or {}).get("_canonicalSiteValues") or {}).get("idpTradeCalc")
+        try:
+            v = float(idptc_val)
+        except (TypeError, ValueError):
+            continue
+        if v > 0:
+            all_rows.append((name, v))
+    all_rows.sort(key=lambda t: -t[1])
+
+    pairs: list[tuple[int, float]] = []
+    for rank, (name, v) in enumerate(all_rows, start=1):
+        pos = str(positions.get(name, "")).strip().upper()
+        if pos in _IDP_POSITIONS:
+            pairs.append((rank, v))
+    return pairs
 
 
 def _hill(rank: float, midpoint: float, slope: float) -> float:
@@ -97,6 +148,26 @@ def main() -> int:
     print()
     fits: list[tuple[str, int, float, float, float]] = []
     for label, (rel_path, col) in sources.items():
+        # IDP universe: fit against IDPTC's IDP slice using combined-
+        # pool ranks from the latest snapshot (no CSV-only position
+        # column).  Hill output then mirrors IDPTC's raw values at
+        # the same ranks the blend actually feeds in.
+        if args.universe == "idp" and label == "IDPTradeCalc-IDP":
+            pairs = _load_idptc_idp_pairs()
+            if not pairs:
+                print(f"  {label}: no snapshot found at dynasty_data_*.json")
+                continue
+            # Use raw IDPTC values (not normalised to 9999) — the top
+            # IDP in IDPTC is nowhere near 9999 by design, and the
+            # blend's Hill output should reproduce that shape.
+            normed = list(pairs)
+            m, s, mse = _fit(normed)
+            fits.append((label, len(pairs), m, s, mse))
+            print(
+                f"  {label:18s}  n={len(pairs):4d}  midpoint={m:6.2f}  "
+                f"slope={s:5.3f}  rmse={mse ** 0.5:.1f}"
+            )
+            continue
         values = _load_values(REPO / rel_path, col)
         if not values:
             print(f"  {label}: no values found at {rel_path}")

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1106,6 +1106,20 @@ SINGLE_SOURCE_ALLOWLIST: dict[str, str] = {
     # ranks as deep dynasty holds even though IDPTradeCalc and the
     # other IDP boards have dropped them.  Genuine source gaps.
     "lavonte david": "source_gap:idpTradeCalc+dlfIdp+fantasyProsIdp — 36yo FA veteran LB only ranked by FootballGuys IDP",
+    "jordan davis": "source_gap:idpTradeCalc+dlfIdp+fantasyProsIdp — DL only ranked by FootballGuys IDP",
+    # ── IDP: IDPTradeCalc-only (not listed by other IDP sources) ──
+    # Depth IDP players that only IDPTradeCalc's combined pool lists;
+    # DLF / FP / FBG expert boards haven't added them (yet).  After
+    # the 2026 IDP Hill refit to IDPTC's curve, several of these
+    # elevated into the top 400.
+    "ashton gillotte": "source_gap:dlfIdp+fantasyProsIdp+footballGuysIdp — DL only ranked by IDPTradeCalc",
+    "christian harris": "source_gap:dlfIdp+fantasyProsIdp+footballGuysIdp — LB only ranked by IDPTradeCalc",
+    "josh newton": "source_gap:dlfIdp+fantasyProsIdp+footballGuysIdp — DB only ranked by IDPTradeCalc",
+    "noah sewell": "source_gap:dlfIdp+fantasyProsIdp+footballGuysIdp — LB only ranked by IDPTradeCalc",
+    # ── IDP: DLF-Rookie-IDP-only (rookie prospects only in DLF rookie board) ──
+    # Current-class IDP rookies that only DLF Rookie IDP has
+    # evaluated.  IDPTC and FBG haven't added them yet.
+    "aj haulcy": "rookie_source_gap:idpTradeCalc+footballGuysIdp — 2026 DB rookie only ranked by DLF Rookie IDP",
 }
 
 

--- a/src/canonical/player_valuation.py
+++ b/src/canonical/player_valuation.py
@@ -60,11 +60,16 @@ HILL_SLOPE: float = 1.149          # controls steepness of decay
 # roster IDP players are more fungible than the equivalent offensive
 # skill-position players).  Fit via
 # ``scripts/fit_hill_curve_from_market.py --universe idp`` against
-# FantasyPros IDP's published normalizedValue (expert consensus IDP
-# pricing on a 1-9999 scale).  Re-run the fit and update these
-# constants when the community IDP dropoff shape drifts.
-IDP_HILL_MIDPOINT: float = 47.50
-IDP_HILL_SLOPE: float = 1.005
+# IDPTradeCalc's raw IDP slice of its combined offense+IDP pool — the
+# retail IDP authority whose per-rank values the blend should
+# reproduce at the Hill step, BEFORE any per-position IDP calibration
+# multiplier is applied.  Previous fit anchored on FantasyPros IDP
+# ``normalizedValue`` which produced values ~600-1,000 below IDPTC
+# across the top-250 IDP rows; the new fit is RMSE ~170 across 376
+# IDP rows in the live snapshot.  Re-run the fit and update these
+# constants when the IDPTC dropoff shape drifts.
+IDP_HILL_MIDPOINT: float = 69.50
+IDP_HILL_SLOPE: float = 0.945
 
 # Step 4: Tier cliff injection
 CLIFF_BASE_POINTS: float = 120.0   # base cliff size in value units

--- a/tests/api/test_player_identity_regression.py
+++ b/tests/api/test_player_identity_regression.py
@@ -337,6 +337,15 @@ KNOWN_TOP_BOARD_SINGLE_SOURCE_ALLOWLIST: dict[str, str] = {
     "Omar Cooper":     "Indiana WR (current college rookie) — not yet listed in IDPTradeCalc autocomplete",
     "Devin Bush":      "Veteran depth IDP — outside DLF top-185 cut",
     "David Bailey":    "Edge rookie IDP — only FantasyPros IDP covers him; moved into top-200 after 2026 slot picks were un-ranked",
+    # ── IDP top-board 1-src that surfaced after the IDP Hill curve
+    # was refit to IDPTC (midpoint 69.50 / slope 0.945).  The steeper
+    # top-of-curve elevation pulled these into the top 200 where they
+    # previously lived outside the allowlist's view.  All are
+    # legitimate source gaps — IDPTC and FBG haven't listed them so
+    # only one IDP board (FP or DLF Rookie) stamps a rank.
+    "Jack Gibbens":    "Veteran LB only ranked by FantasyPros IDP — IDPTC/DLF/FBG haven't picked him up",
+    "Malachi Moore":   "Veteran S only ranked by FantasyPros IDP — IDPTC/FBG haven't picked him up",
+    "Lavonte David":   "36yo FA veteran LB only ranked by FootballGuys IDP — IDPTC and others have dropped him",
 }
 
 

--- a/tests/api/test_single_source_resolution.py
+++ b/tests/api/test_single_source_resolution.py
@@ -235,7 +235,12 @@ class TestAllowlistCompleteness(unittest.TestCase):
 
     def test_all_allowlist_reasons_have_category(self):
         """Every allowlist reason must start with a recognized category."""
-        valid_prefixes = ("source_gap:", "depth_boundary:", "rookie_exclusion:")
+        valid_prefixes = (
+            "source_gap:",
+            "depth_boundary:",
+            "rookie_exclusion:",
+            "rookie_source_gap:",
+        )
         for key, reason in SINGLE_SOURCE_ALLOWLIST.items():
             self.assertTrue(
                 reason.startswith(valid_prefixes),


### PR DESCRIPTION
## Summary
The IDP Hill curve converts an effective overall rank → 1-9999 value for IDP players BEFORE the per-position IDP calibration multiplier runs. Previous fit anchored on FantasyPros IDP's `normalizedValue` and produced values 600-1,000 below IDPTC's raw per-rank pricing across the top-250 rows. Since IDPTC is also the retail IDP authority + the blend backbone, the pre-calibration Hill output should match IDPTC directly — any intentional tilt belongs in the calibration multiplier.

## New fit
Targets IDPTC's IDP slice directly. Loads the latest snapshot to get position info (IDPTC's CSV has no position column), extracts (idptc_combined_pool_rank, idptc_value) for every IDP, grid-searches (midpoint, slope) minimising RMSE.

376 IDP players → RMSE 170.8 after fit.

| | Previous (FP) | New (IDPTC) |
|---|---|---|
| Midpoint | 47.50 | **69.50** |
| Slope | 1.005 | **0.945** |

## Value-at-rank comparison on the live snapshot

| rank | IDPTC | old Hill | new Hill | old gap | new gap |
|---|---|---|---|---|---|
| 38 | 5,963 | 5,624 | 6,450 | -339 | +487 |
| 52 | 5,414 | 4,821 | 5,729 | -593 | +315 |
| 94 | 4,169 | 3,374 | 4,318 | -795 | +149 |
| 192 | 2,999 | 1,981 | 2,778 | -1,018 | -221 |
| 557 | 1,235 | 779 | 1,229 | -456 | -6 |

## Downstream
- Pushes several legitimate single-source IDPs into the top 400. Added allowlist entries in `SINGLE_SOURCE_ALLOWLIST` (a.j. haulcy, ashton gillotte, christian harris, jordan davis, josh newton, noah sewell) + `KNOWN_TOP_BOARD_SINGLE_SOURCE_ALLOWLIST` (Jack Gibbens, Malachi Moore, Lavonte David) with documented reasons.
- New `rookie_source_gap:` category prefix added for rookies only in DLF Rookie IDP.
- `scripts/fit_hill_curve_from_market.py --universe idp` now fits from IDPTC's IDP slice via `_load_idptc_idp_pairs`. Re-run when IDPTC's dropoff shape drifts.

## Test plan
- [x] `pytest tests/ -q` — 1772 passed, 3 skipped.
- [x] `npm run build` — clean.
- [ ] Post-deploy: spot-check IDP values — top IDPs should sit near IDPTC's raw values, mid-tier should be close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)