### PR TITLE
Scrapers: auto-login to eliminate manual cookie refresh

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -94,6 +94,15 @@ jobs:
         if: ${{ inputs.skip_scrape != true }}
         shell: bash
         timeout-minutes: 15
+        env:
+          # Feed credentials to the FG + DS scrapers, which read them
+          # via os.environ.  If a secret is missing the scraper logs
+          # a warning and fails the fetch — handled as non-fatal by
+          # the `|| echo` fallback below.
+          FOOTBALLGUYS_EMAIL: ${{ secrets.FOOTBALLGUYS_EMAIL }}
+          FOOTBALLGUYS_PASSWORD: ${{ secrets.FOOTBALLGUYS_PASSWORD }}
+          DRAFTSHARKS_EMAIL: ${{ secrets.DRAFTSHARKS_EMAIL }}
+          DRAFTSHARKS_PASSWORD: ${{ secrets.DRAFTSHARKS_PASSWORD }}
         run: |
           set -Eeuo pipefail
           echo "::group::Scraper output"
@@ -113,6 +122,18 @@ jobs:
 
           # Fetch Flock Fantasy SF rankings
           python scripts/fetch_flock_fantasy.py --mirror-data-dir 2>/dev/null || echo "::warning title=Flock Fantasy fetch failed::Non-fatal — continuing"
+
+          # Fetch FootballGuys league-synced rankings (offense + IDP)
+          # The scraper auto-logs-in via Playwright on session refresh
+          # when cached cookies are rejected; non-fatal if the site is
+          # unreachable so the rest of the pipeline keeps running.
+          python scripts/fetch_footballguys.py 2>&1 || echo "::warning title=FootballGuys fetch failed::Non-fatal — continuing with stale CSV"
+
+          # Fetch DraftSharks league-synced rankings (offense + IDP).
+          # DS requires Playwright because league scoring is applied
+          # client-side by a WebAssembly worker; auto-login is wired
+          # into the scraper itself.
+          python scripts/fetch_draftsharks.py 2>&1 || echo "::warning title=DraftSharks fetch failed::Non-fatal — continuing with stale CSV"
 
           # Verify at least KTC data was produced (primary source)
           if [[ -f "CSVs/site_raw/ktc.csv" ]]; then

--- a/scripts/fetch_draftsharks.py
+++ b/scripts/fetch_draftsharks.py
@@ -19,13 +19,16 @@ manual DS export uses:
 Authentication
 --------------
 
-Cookies are loaded from ``draftsharks_session.json`` at the repo
-root (gitignored).  To refresh:
+Reads ``DRAFTSHARKS_EMAIL`` + ``DRAFTSHARKS_PASSWORD`` from ``.env``
+at the repo root (gitignored).  On each run we try the cached
+session cookies first (``draftsharks_session.json``); if the
+rankings page comes back without the operator's league name we
+run the in-browser DS login flow to mint fresh cookies, save them
+back to the session file, and continue the scrape — no manual
+cookie refresh required.
 
-1. Log in to https://www.draftsharks.com/ in a browser.
-2. Open DevTools → Application → Cookies → ``www.draftsharks.com``.
-3. Copy the values of ``PHPSESSID`` (HttpOnly), ``_identity``
-   (HttpOnly), and ``_frontendCSRF`` into the session file.
+The session file is honoured as a pre-warmed cache so routine
+runs don't re-log-in every time.
 
 Run
 ---
@@ -40,17 +43,28 @@ import argparse
 import asyncio
 import csv
 import json
+import os
 import re
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SESSION_PATH = REPO / "draftsharks_session.json"
+ENV_PATH = REPO / ".env"
 OUT_PATH = REPO / "CSVs" / "site_raw" / "draftSharks.csv"
 
+HOME_URL = "https://www.draftsharks.com/"
+LOGIN_URL = "https://www.draftsharks.com/login"
 OFFENSE_URL = "https://www.draftsharks.com/dynasty-rankings/te-premium-superflex"
 IDP_URL = "https://www.draftsharks.com/dynasty-rankings/idp/te-premium-superflex"
 LEAGUE_ID = "995704"  # "Risk It To Get The Brisket"
+
+# Only these cookies matter for auth + league context.  Everything
+# else (analytics, consent, etc.) would bloat the session file and
+# cause needless churn on refresh.
+_AUTH_COOKIE_NAMES: frozenset[str] = frozenset(
+    {"PHPSESSID", "_identity", "_frontendCSRF", "_csrf-frontend"}
+)
 
 CSV_HEADER = [
     "Rank",
@@ -69,19 +83,35 @@ CSV_HEADER = [
 ]
 
 
+def _load_env_dotfile(path: Path) -> None:
+    """Parse ``.env`` and populate ``os.environ`` for any keys it
+    doesn't already set.  Minimal inline replacement for
+    ``python-dotenv`` so we don't add a runtime dependency."""
+    if not path.exists():
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
 def _load_cookies() -> list[dict]:
+    """Return Playwright-shaped cookie dicts from the session file.
+    Returns ``[]`` (not ``SystemExit``) when the file is missing so
+    the caller can fall through to ``_browser_login``."""
     if not SESSION_PATH.exists():
-        raise SystemExit(
-            f"Session file not found: {SESSION_PATH}\n"
-            "See this script's docstring for how to capture cookies."
-        )
-    data = json.loads(SESSION_PATH.read_text())
-    # Playwright expects: name, value, domain, path, httpOnly, secure, sameSite.
+        return []
+    try:
+        data = json.loads(SESSION_PATH.read_text())
+    except Exception:
+        return []
     out: list[dict] = []
     for c in data.get("cookies", []):
-        if not isinstance(c, dict) or c.get("name", "").startswith("_"):
-            # Skip analytics cookies that Playwright rejects.
-            pass
         if not isinstance(c, dict) or "name" not in c or "value" not in c:
             continue
         if c["name"].startswith("_comment"):
@@ -96,6 +126,87 @@ def _load_cookies() -> list[dict]:
             "sameSite": str(c.get("sameSite") or "Lax").title(),
         })
     return out
+
+
+def _save_cookies(cookies: list[dict]) -> None:
+    """Persist Playwright-captured cookies into the session file.
+    Only the auth-relevant cookies are stored — analytics cookies
+    add churn without buying anything."""
+    payload = {
+        "_comment_": (
+            "DraftSharks cookies auto-refreshed by "
+            "scripts/fetch_draftsharks.py using DRAFTSHARKS_EMAIL / "
+            "DRAFTSHARKS_PASSWORD.  Gitignored."
+        ),
+        "cookies": [
+            {
+                "name": c["name"],
+                "value": c["value"],
+                "domain": c.get("domain", "www.draftsharks.com"),
+                "path": c.get("path", "/"),
+                "httpOnly": bool(c.get("httpOnly", True)),
+                "secure": bool(c.get("secure", True)),
+                "sameSite": str(c.get("sameSite") or "Lax").title(),
+            }
+            for c in cookies
+            if isinstance(c, dict)
+            and "name" in c
+            and c.get("name") in _AUTH_COOKIE_NAMES
+        ],
+    }
+    SESSION_PATH.write_text(json.dumps(payload, indent=2) + "\n")
+    try:
+        SESSION_PATH.chmod(0o600)
+    except Exception:
+        pass
+
+
+async def _browser_login(context, page) -> None:
+    """Run the DS login flow in the current browser context and
+    persist fresh cookies.  Caller must reload any rankings page
+    after this returns."""
+    email = os.environ.get("DRAFTSHARKS_EMAIL", "").strip()
+    password = os.environ.get("DRAFTSHARKS_PASSWORD", "").strip()
+    if not email or not password:
+        raise SystemExit(
+            "DRAFTSHARKS_EMAIL / DRAFTSHARKS_PASSWORD not set in .env; "
+            "cannot auto-refresh cookies.  Either add the credentials to "
+            "the server's .env or paste fresh cookies into "
+            "draftsharks_session.json."
+        )
+
+    print("[DS] cached session rejected — logging in via Playwright …", flush=True)
+    await page.goto(LOGIN_URL, wait_until="domcontentloaded", timeout=30_000)
+    await page.wait_for_timeout(1_200)
+    await page.fill('input[name="LoginForm[email]"]', email)
+    await page.fill('input[name="LoginForm[password]"]', password)
+    await page.click('button[name="login-button"]')
+    # Wait for the server to issue ``_identity`` (the "remember-me"
+    # cookie that survives across requests).  DS's login redirects
+    # to ``/`` on success so ``_identity`` appears within a couple
+    # of seconds.
+    authenticated = False
+    for _ in range(20):
+        await page.wait_for_timeout(500)
+        current_cookies = await context.cookies("https://www.draftsharks.com")
+        if any(c.get("name") == "_identity" for c in current_cookies):
+            authenticated = True
+            break
+    if not authenticated:
+        errors = await page.evaluate(
+            "() => Array.from(document.querySelectorAll('.alert, .help-block-error, [role=alert]'))"
+            ".map(e => e.textContent.trim()).filter(Boolean).slice(0, 3)"
+        )
+        raise RuntimeError(
+            f"DS login failed — no _identity cookie issued.  Page errors: {errors}"
+        )
+    fresh_cookies = await context.cookies("https://www.draftsharks.com")
+    _save_cookies(fresh_cookies)
+    count = sum(1 for c in fresh_cookies if c.get("name") in _AUTH_COOKIE_NAMES)
+    print(
+        f"[DS] logged in; persisted {count} cookie(s) to {SESSION_PATH.name}",
+        flush=True,
+    )
 
 
 # Extraction JS — walks visible ``<tbody data-player-row>`` blocks
@@ -190,10 +301,8 @@ async def _scrape_one(
 
     html_initial = await page.content()
     if "Risk It To Get The Brisket" not in html_initial:
-        raise RuntimeError(
-            f"League 'Risk It To Get The Brisket' not in {label} page HTML — "
-            "cookies likely stale; refresh draftsharks_session.json"
-        )
+        # Sentinel string picked up by _scrape() to trigger auto-login.
+        raise RuntimeError("unauthenticated_session")
 
     print(f"[DS] ({label}) activating league {LEAGUE_ID} …", flush=True)
     try:
@@ -252,6 +361,34 @@ async def _scrape_one(
     return rows
 
 
+async def _scrape_with_autologin(
+    context,
+    page,
+    url: str,
+    *,
+    label: str,
+    mahomes_threshold: float | None,
+    allow_login: bool,
+) -> list[dict]:
+    """Wrapper around ``_scrape_one`` that catches the
+    ``unauthenticated_session`` sentinel, runs the browser login
+    once, then retries the scrape with the fresh cookies that
+    Playwright now holds in-context."""
+    try:
+        return await _scrape_one(
+            page, url, label=label, mahomes_threshold=mahomes_threshold
+        )
+    except RuntimeError as exc:
+        if str(exc) != "unauthenticated_session" or not allow_login:
+            raise
+        await _browser_login(context, page)
+        # After login the context already carries the fresh cookies,
+        # so re-navigating the URL picks up the authenticated view.
+        return await _scrape_one(
+            page, url, label=label, mahomes_threshold=mahomes_threshold
+        )
+
+
 async def _scrape(*, headless: bool) -> list[dict]:
     try:
         from playwright.async_api import async_playwright
@@ -273,28 +410,36 @@ async def _scrape(*, headless: bool) -> list[dict]:
                 ),
                 viewport={"width": 1400, "height": 1100},
             )
-            await context.add_cookies(cookies)
+            if cookies:
+                await context.add_cookies(cookies)
             page = await context.new_page()
 
             # Offense: load the default TEP-superflex page; Mahomes
             # public value is 74, league-synced ~81 in a
             # TE-premium + IDP-heavy league, so use 78 as settle
             # threshold.
-            offense_rows = await _scrape_one(
+            offense_rows = await _scrape_with_autologin(
+                context,
                 page,
                 OFFENSE_URL,
                 label="offense",
                 mahomes_threshold=78,
+                allow_login=True,
             )
 
             # IDP: load the IDP-only view.  Schwesinger public 44,
             # league-synced still around 44; use 30 as a loose
-            # "something loaded" threshold.
-            idp_rows = await _scrape_one(
+            # "something loaded" threshold.  We've already
+            # authenticated above so disallow a second login pass —
+            # an IDP-specific failure should surface instead of
+            # quietly burning another login.
+            idp_rows = await _scrape_with_autologin(
+                context,
                 page,
                 IDP_URL,
                 label="idp",
                 mahomes_threshold=30,
+                allow_login=False,
             )
 
             # Merge: offense first (higher scale values) then IDP.
@@ -358,6 +503,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    _load_env_dotfile(ENV_PATH)
     rows = asyncio.run(_scrape(headless=not args.headful))
 
     if not rows:

--- a/scripts/fetch_footballguys.py
+++ b/scripts/fetch_footballguys.py
@@ -9,27 +9,19 @@ URLs this script hits use ``leagueid=16023`` which is the operator's
 "Risk It To Get The Brisket" FBG league — the ranks returned are the
 league-synced view, not the generic public board.
 
-Replaces the prior workflow of manually downloading PDF / CSV exports
-from FBG and running ``scripts/parse_footballguys_pdf.py``.  The PDF
-parser is kept alive as a fallback when session cookies expire.
-
 Authentication
 --------------
 
-Cookies are loaded from ``footballguys_session.json`` at the repo
-root (gitignored).  To refresh:
+Reads ``FOOTBALLGUYS_EMAIL`` + ``FOOTBALLGUYS_PASSWORD`` from
+``.env`` at the repo root (gitignored).  On each run we try the
+cached session cookies first (``footballguys_session.json``); if
+the authenticated rankings response looks logged-out we launch a
+headless Playwright login to mint fresh cookies, save them back to
+the session file, and retry the HTTP scrape — no manual cookie
+refresh required.
 
-1. Log in to https://www.footballguys.com/ in a browser.
-2. Ensure the correct league is selected in the League Settings
-   dropdown on the rankings page (``leagueid=16023`` for this repo).
-3. Open DevTools → Application → Cookies → ``https://www.footballguys.com``
-   and copy the values of:
-      * ``prodwww`` (HttpOnly session cookie, the big one)
-      * ``TN_token`` (HttpOnly persistent auth)
-      * ``League_selectedid``
-      * ``FBG_LeagueSelect_Type``
-4. Paste them into ``footballguys_session.json`` (same shape as the
-   existing file).  Keep domain = ``.footballguys.com``.
+The session file is still honoured as a pre-warmed cache so
+routine runs don't need to pay the Playwright cost.
 
 Run
 ---
@@ -43,8 +35,10 @@ Writes:
 from __future__ import annotations
 
 import argparse
+import asyncio
 import csv
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -53,8 +47,16 @@ import requests
 
 REPO = Path(__file__).resolve().parents[1]
 SESSION_PATH = REPO / "footballguys_session.json"
+ENV_PATH = REPO / ".env"
 OUT_SF = REPO / "CSVs" / "site_raw" / "footballGuysSf.csv"
 OUT_IDP = REPO / "CSVs" / "site_raw" / "footballGuysIdp.csv"
+
+LOGIN_URL = "https://www.footballguys.com/login"
+# The league-select cookie is set on login but defaults to the
+# operator's primary league.  We enforce ``leagueid=16023`` via URL
+# query and via a cookie override when persisting, so the scrape is
+# always pinned to "Risk It To Get The Brisket".
+LEAGUE_ID = "16023"
 
 OFFENSE_URL = (
     "https://www.footballguys.com/rankings/duration/dynasty"
@@ -102,14 +104,163 @@ _OFFENSE_POS: frozenset[str] = frozenset({"QB", "RB", "WR", "TE"})
 _IDP_POS: frozenset[str] = frozenset({"DL", "LB", "DB"})
 
 
+def _load_env_dotfile(path: Path) -> None:
+    """Parse ``.env`` and populate ``os.environ`` for any keys it
+    doesn't already set.  Minimal inline replacement for
+    ``python-dotenv`` so we don't add a runtime dependency."""
+    if not path.exists():
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
 def _load_cookies() -> dict[str, str]:
     if not SESSION_PATH.exists():
+        return {}
+    try:
+        data = json.loads(SESSION_PATH.read_text())
+    except Exception:
+        return {}
+    return {
+        c["name"]: c["value"]
+        for c in data.get("cookies", [])
+        if isinstance(c, dict) and "name" in c and "value" in c
+    }
+
+
+def _save_cookies(cookies: list[dict]) -> None:
+    """Persist Playwright-captured cookies into the session file."""
+    payload = {
+        "_comment_": (
+            "FootballGuys cookies auto-refreshed by "
+            "scripts/fetch_footballguys.py using FOOTBALLGUYS_EMAIL / "
+            "FOOTBALLGUYS_PASSWORD.  Gitignored."
+        ),
+        "cookies": [
+            {
+                "name": c["name"],
+                "value": c["value"],
+                "domain": c.get("domain", ".footballguys.com"),
+                "path": c.get("path", "/"),
+                "httpOnly": bool(c.get("httpOnly", False)),
+                "secure": bool(c.get("secure", True)),
+                "sameSite": str(c.get("sameSite") or "Lax"),
+            }
+            for c in cookies
+            if isinstance(c, dict)
+            and "name" in c
+            and c.get("name") in {
+                "prodwww",
+                "TN_token",
+                "TN_tvid",
+                "FBG_LeagueSelect_Type",
+                "League_selectedid",
+            }
+        ],
+    }
+    SESSION_PATH.write_text(json.dumps(payload, indent=2) + "\n")
+    try:
+        SESSION_PATH.chmod(0o600)
+    except Exception:
+        pass
+
+
+def _response_is_authenticated(html: str) -> bool:
+    """FBG rankings are paywalled.  Unauthenticated responses render
+    exactly 15 "teaser" rows plus a nav "Log In" button wired to the
+    login modal via ``data-bs-target="#login_modal"``.  Authenticated
+    sessions never render that button.  The button marker is a more
+    reliable signal than row count because the teaser table still
+    carries ``data-playerid`` attributes."""
+    return 'data-bs-target="#login_modal"' not in html
+
+
+async def _playwright_login() -> list[dict]:
+    """Run the browser login flow and return Playwright cookie
+    dicts.  Invoked only when the cached cookies fail auth."""
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError as exc:
         raise SystemExit(
-            f"Session file not found: {SESSION_PATH}\n"
-            "See this script's docstring for how to capture cookies."
+            "playwright is required for FG auto-login.  "
+            "Install with: pip install playwright && playwright install chromium."
+        ) from exc
+
+    email = os.environ.get("FOOTBALLGUYS_EMAIL", "").strip()
+    password = os.environ.get("FOOTBALLGUYS_PASSWORD", "").strip()
+    if not email or not password:
+        raise SystemExit(
+            "FOOTBALLGUYS_EMAIL / FOOTBALLGUYS_PASSWORD not set in .env; "
+            "cannot auto-refresh cookies.  Either add the credentials to "
+            "the server's .env or paste fresh cookies into "
+            "footballguys_session.json."
         )
-    data = json.loads(SESSION_PATH.read_text())
-    return {c["name"]: c["value"] for c in data.get("cookies", [])}
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        try:
+            context = await browser.new_context(user_agent=_UA)
+            page = await context.new_page()
+            await page.goto(LOGIN_URL, wait_until="domcontentloaded", timeout=30_000)
+            await page.wait_for_timeout(1_200)
+            await page.fill('input[name="login"]', email)
+            await page.fill('input[name="password"]', password)
+            await page.click('button[type="submit"]')
+            await page.wait_for_timeout(6_000)
+            cookies = await context.cookies("https://www.footballguys.com")
+            if not any(c.get("name") == "TN_token" for c in cookies):
+                errors = await page.evaluate(
+                    "() => Array.from(document.querySelectorAll('.alert, .invalid-feedback, [role=alert]'))"
+                    ".map(e => e.textContent.trim()).filter(Boolean).slice(0, 3)"
+                )
+                raise RuntimeError(
+                    f"FG login failed — no TN_token issued.  Page errors: {errors}"
+                )
+            # Force the league cookie so server-side rendering is
+            # pinned to the operator's league regardless of the
+            # account's current default selection.
+            cookies.append({
+                "name": "League_selectedid",
+                "value": LEAGUE_ID,
+                "domain": ".footballguys.com",
+                "path": "/",
+                "httpOnly": False,
+                "secure": True,
+                "sameSite": "Lax",
+            })
+            cookies.append({
+                "name": "FBG_LeagueSelect_Type",
+                "value": "users",
+                "domain": ".footballguys.com",
+                "path": "/",
+                "httpOnly": False,
+                "secure": True,
+                "sameSite": "Lax",
+            })
+            return cookies
+        finally:
+            await browser.close()
+
+
+def _auto_refresh_session() -> dict[str, str]:
+    """Run the Playwright login flow and persist fresh cookies."""
+    print("[FBG] cached session rejected — logging in via Playwright …", flush=True)
+    new_cookies = asyncio.run(_playwright_login())
+    _save_cookies(new_cookies)
+    print(
+        f"[FBG] logged in; persisted {len(new_cookies)} cookie(s) to {SESSION_PATH.name}",
+        flush=True,
+    )
+    return _load_cookies()
 
 
 def _fetch(url: str, cookies: dict[str, str]) -> str:
@@ -120,12 +271,8 @@ def _fetch(url: str, cookies: dict[str, str]) -> str:
         timeout=30,
     )
     r.raise_for_status()
-    if "login_modal" in r.text and "logout" not in r.text.lower():
-        raise RuntimeError(
-            "FBG response looks unauthenticated (login_modal present, "
-            "no logout link).  Cookies likely expired — re-capture per "
-            "the docstring in this script."
-        )
+    if not _response_is_authenticated(r.text):
+        raise RuntimeError("unauthenticated_response")
     return r.text
 
 
@@ -228,6 +375,32 @@ def _write_csv(
     return len(selected)
 
 
+def _fetch_with_auto_login(
+    url: str,
+    cookies: dict[str, str],
+    *,
+    label: str,
+    allow_refresh: bool = True,
+) -> tuple[str, dict[str, str]]:
+    """Fetch ``url``; if the response looks logged-out, refresh the
+    session via Playwright and retry once.  Returns the HTML and the
+    (possibly refreshed) cookie dict so subsequent fetches reuse it.
+    """
+    try:
+        html = _fetch(url, cookies)
+        return html, cookies
+    except RuntimeError as exc:
+        if str(exc) != "unauthenticated_response" or not allow_refresh:
+            raise
+        print(
+            f"[FBG] {label}: session rejected — refreshing cookies …",
+            flush=True,
+        )
+        cookies = _auto_refresh_session()
+        html = _fetch(url, cookies)
+        return html, cookies
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -237,15 +410,23 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    _load_env_dotfile(ENV_PATH)
     cookies = _load_cookies()
 
     print("[FBG] fetching offense rankings …", flush=True)
-    off_html = _fetch(OFFENSE_URL, cookies)
+    off_html, cookies = _fetch_with_auto_login(
+        OFFENSE_URL, cookies, label="offense"
+    )
     off_rows = parse_rows(off_html)
     print(f"[FBG] offense rows parsed: {len(off_rows)}")
 
     print("[FBG] fetching IDP rankings …", flush=True)
-    idp_html = _fetch(IDP_URL, cookies)
+    # We already have a known-good session at this point — disable
+    # the second auto-refresh so a genuine IDP parse failure surfaces
+    # instead of quietly burning a second Playwright login.
+    idp_html, cookies = _fetch_with_auto_login(
+        IDP_URL, cookies, label="idp", allow_refresh=False
+    )
     # IDP page has no per-row position column — every row is an IDP
     # player; we pass default_family="IDP" so the rows get through
     # and the downstream pipeline's sleeper positions map assigns


### PR DESCRIPTION
## Summary

- FG + DS scrapers now auto-login via Playwright when cached cookies expire, reading credentials from `.env` locally and GitHub Secrets in CI.
- `scheduled-refresh.yml` now runs both scrapers under the same non-fatal wrapper as Dynasty Daddy / Flock Fantasy.
- GitHub secrets `FOOTBALLGUYS_EMAIL`, `FOOTBALLGUYS_PASSWORD`, `DRAFTSHARKS_EMAIL`, `DRAFTSHARKS_PASSWORD` already set.

## Auth-detection details

- **FG**: the rankings page is paywalled — logged-out sessions get 15 teaser rows with a "Log In" button wired to `data-bs-target="#login_modal"`. That marker is the auth check; simply looking for `data-playerid` was a false positive because the teaser table carries player rows.
- **DS**: logged-out sessions never render "Risk It To Get The Brisket" in the page; that's the sentinel that triggers browser login. Fresh cookies persist back to `draftsharks_session.json`.

Both scrapers skip Playwright login when cached cookies still authenticate (fast path).

## Test plan

- [x] FG dry-run with expired cookies → detects logged-out → Playwright logs in → retries → 1000 offense + 521 IDP rows
- [x] FG dry-run with fresh cookies → fast path, no login
- [x] DS dry-run with missing `draftsharks_session.json` → Playwright logs in → 250 offense + 389 IDP rows, values match user's browser
- [x] DS dry-run with fresh cookies → fast path, no login
- [x] FG + DS live runs write refreshed CSVs
- [x] `python3 -m pytest tests/ -q` → 1772 passed, 3 skipped, 151 subtests passed
- [ ] Scheduled-refresh workflow picks up the new scrapers on next cron tick (UTC minute 42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)