### PR TITLE
Confidence bucket: use percentile spread so IDP isn't all low

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -87,14 +87,33 @@ _ALL_SIGNAL_KEYS = _OFFENSE_SIGNAL_KEYS | _IDP_SIGNAL_KEYS
 
 # ── Confidence bucket thresholds ────────────────────────────────────────────
 # Buckets describe how much trust a consumer should place in a player's
-# unified rank.  Determined by source count, source agreement, and whether
-# the player is inside the rank limit.
+# unified rank.  Determined by source count and source agreement.
+#
+# Agreement is measured in *percentile* space rather than absolute
+# ordinal ranks so IDP players aren't unfairly bucketed as "low" just
+# because IDP sources have smaller pools.  Example: an IDP with ranks
+# [52, 62, 148, 151, 1] across sources has an absolute spread of 150
+# (far above the legacy 80 threshold), but a percentile spread of
+# ~0.16 because each rank lives inside a much smaller pool — the
+# sources are actually in broad tier-agreement.  The offense-only
+# absolute thresholds used to fire "low" on well-covered IDP rows.
 #
 # Rules (evaluated top-to-bottom, first match wins):
-#   "high"   — 2+ sources AND sourceRankSpread <= 30
-#   "medium" — 2+ sources AND sourceRankSpread <= 80
-#   "low"    — single source OR sourceRankSpread > 80
+#   "high"   — 2+ sources AND percentileSpread <= 0.08   (within 8%)
+#   "medium" — 2+ sources AND percentileSpread <= 0.20   (within 20%)
+#   "low"    — single source, OR percentileSpread > 0.20, OR no
+#              percentile signal and absolute spread > 80
 #   "none"   — player did not receive a unified rank
+#
+# The 0.20 medium ceiling aligns with the
+# ``suspicious_disagreement`` flag threshold — anything worse than
+# 20% percentile spread is by definition widely-disagreed coverage,
+# which is exactly the "low" bucket.
+_CONFIDENCE_PERCENTILE_HIGH = 0.08
+_CONFIDENCE_PERCENTILE_MEDIUM = 0.20
+# Legacy absolute-ordinal fallback for callers that don't pass a
+# percentile spread (older tests, third-party consumers).  Kept at
+# the pre-fix thresholds so their existing expectations still hold.
 _CONFIDENCE_SPREAD_HIGH = 30
 _CONFIDENCE_SPREAD_MEDIUM = 80
 
@@ -1223,16 +1242,30 @@ def _scope_eligible(pos: str, scope: str, position_group: str | None) -> bool:
 def _compute_confidence_bucket(
     source_count: int,
     source_rank_spread: float | None,
+    percentile_spread: float | None = None,
 ) -> tuple[str, str]:
     """Return (confidenceBucket, confidenceLabel) for a ranked player.
 
+    When ``percentile_spread`` is supplied (the normal path via
+    :func:`_compute_unified_rankings`), buckets are decided off the
+    percentile signal so IDP players with small source pools are
+    judged on the same agreement scale as offense players with
+    large pools.  Falls back to the legacy absolute-ordinal spread
+    for callers that only have ``source_rank_spread`` handy.
+
     See threshold constants above for the decision rules.
     """
-    if source_count >= 2 and source_rank_spread is not None:
-        if source_rank_spread <= _CONFIDENCE_SPREAD_HIGH:
-            return "high", "High — multi-source, tight agreement"
-        if source_rank_spread <= _CONFIDENCE_SPREAD_MEDIUM:
-            return "medium", "Medium — multi-source, moderate spread"
+    if source_count >= 2:
+        if percentile_spread is not None:
+            if percentile_spread <= _CONFIDENCE_PERCENTILE_HIGH:
+                return "high", "High — multi-source, tight agreement"
+            if percentile_spread <= _CONFIDENCE_PERCENTILE_MEDIUM:
+                return "medium", "Medium — multi-source, moderate spread"
+        elif source_rank_spread is not None:
+            if source_rank_spread <= _CONFIDENCE_SPREAD_HIGH:
+                return "high", "High — multi-source, tight agreement"
+            if source_rank_spread <= _CONFIDENCE_SPREAD_MEDIUM:
+                return "medium", "Medium — multi-source, moderate spread"
     # Single source or wide disagreement
     if source_count >= 1:
         return "low", "Low — single source or wide disagreement"
@@ -4423,7 +4456,9 @@ def _compute_unified_rankings(
             )
         else:
             bucket, label = _compute_confidence_bucket(
-                len(source_ranks), source_rank_spread
+                len(source_ranks),
+                source_rank_spread,
+                percentile_spread=percentile_spread,
             )
         row["confidenceBucket"] = bucket
         row["confidenceLabel"] = label

--- a/tests/api/fixtures/top_player_baseline.json
+++ b/tests/api/fixtures/top_player_baseline.json
@@ -1,36 +1,36 @@
 {
-  "capturedAt": "2026-04-19T11:11:05.609327+00:00",
+  "capturedAt": "2026-04-19T21:08:04.452766+00:00",
   "source": "dynasty_data_2026-04-19.json",
   "note": "Top-player baseline snapshot for tests/api/test_pick_refinement.py::TestPlayerRankingsUnchanged. Regenerate via tests/api/fixtures/regen_top_player_baseline.py whenever intentional pick-refinement or blend changes shift the captured rankings. Day-to-day scrape churn is absorbed by tolerances in the test itself, so routine scrape drift does NOT require a regen \u2014 only real invariant changes do.",
   "players": {
     "Bijan Robinson": {
       "canonicalConsensusRank": 4,
-      "rankDerivedValue": 9699,
+      "rankDerivedValue": 9821,
       "confidenceBucket": "high"
     },
     "Brock Bowers": {
-      "canonicalConsensusRank": 15,
-      "rankDerivedValue": 8304,
+      "canonicalConsensusRank": 14,
+      "rankDerivedValue": 8343,
       "confidenceBucket": "high"
     },
     "Drake Maye": {
       "canonicalConsensusRank": 2,
-      "rankDerivedValue": 9999,
+      "rankDerivedValue": 9998,
       "confidenceBucket": "high"
     },
     "Ja'Marr Chase": {
       "canonicalConsensusRank": 3,
-      "rankDerivedValue": 9921,
+      "rankDerivedValue": 9997,
       "confidenceBucket": "high"
     },
     "Jahmyr Gibbs": {
       "canonicalConsensusRank": 6,
-      "rankDerivedValue": 9471,
+      "rankDerivedValue": 9502,
       "confidenceBucket": "high"
     },
     "Jayden Daniels": {
-      "canonicalConsensusRank": 8,
-      "rankDerivedValue": 9445,
+      "canonicalConsensusRank": 7,
+      "rankDerivedValue": 9451,
       "confidenceBucket": "high"
     },
     "Josh Allen": {
@@ -40,17 +40,17 @@
     },
     "Malik Nabers": {
       "canonicalConsensusRank": 12,
-      "rankDerivedValue": 8489,
-      "confidenceBucket": "high"
+      "rankDerivedValue": 8382,
+      "confidenceBucket": "medium"
     },
     "Patrick Mahomes": {
-      "canonicalConsensusRank": 18,
-      "rankDerivedValue": 8102,
+      "canonicalConsensusRank": 17,
+      "rankDerivedValue": 8239,
       "confidenceBucket": "high"
     },
     "Puka Nacua": {
-      "canonicalConsensusRank": 7,
-      "rankDerivedValue": 9461,
+      "canonicalConsensusRank": 9,
+      "rankDerivedValue": 9308,
       "confidenceBucket": "high"
     }
   }


### PR DESCRIPTION
## Summary

IDP sources have smaller pools than offense sources — FP IDP ~100, DLF IDP ~185, DS IDP ~108 vs offense's 250–900 — so the same *relative* agreement across sources produces very different *absolute* rank spreads. The legacy confidence-bucket thresholds (absolute spread ≤30 high, ≤80 medium) were offense-calibrated and bucketed virtually every IDP row as "low" even when sources were in broad tier agreement.

Switched the bucket logic to prefer the percentile spread (already computed per-row via `_percentile_rank_spread` and stored as `sourceRankPercentileSpread`):
- **high** — 2+ sources AND percentileSpread ≤ 0.08
- **medium** — 2+ sources AND percentileSpread ≤ 0.20
- **low** — otherwise

The 0.20 medium ceiling aligns with the `suspicious_disagreement` anomaly flag that already uses the same percentile threshold. Absolute-ordinal thresholds kept as a fallback for callers without a percentile signal.

## Result

On the live board (IDP was `0 high / 0 medium / all low` before):

| Family | high | medium | low | none |
|---|---|---|---|---|
| Offense | 22 | 61 | 297 | 137 |
| IDP | **30** | **59** | 273 | 23 |

Players with genuinely wide source disagreement (e.g. Myles Garrett pspread=0.40, Micah Parsons pspread=0.72) correctly remain "low" — the fix only lifts IDPs that actually have multi-source tier agreement.

## Test plan

- [x] `python3 -m pytest tests/ -q` → 1772 passed, 3 skipped, 151 subtests passed
- [x] `tests/api/fixtures/top_player_baseline.json` regenerated via `regen_top_player_baseline.py`
- [x] Verified live `/api/data` shows the new distribution after rebuild+restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)