### PR TITLE
Volatility cap: scale step by blendedSourceRank gap (no artificial cliffs)

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3266,20 +3266,26 @@ _VOLATILITY_COMPRESSION_STRENGTH: float = 0.03
 _VOLATILITY_COMPRESSION_FLOOR: float = 0.92
 _VOLATILITY_COMPRESSION_CEIL: float = 1.08
 
-# Minimum step-down on the monotonicity-preserving boost clamp at
-# the top of the board.  When the natural boosted value would
-# overshoot ``_DISPLAY_SCALE_MAX`` (9999) for multiple top-of-board
-# rows in a row, enforcing "prior - 1" collapsed rank 1/2/3/4 to
-# 9999/9998/9997/9996 and erased the visible rank-consistency
-# signal the user expects (e.g. Josh Allen far and away the most
-# consistent #1 across sources).  Stepping down by 100 makes the
-# plateau legible as "each rank at the top is ~100 pts apart" —
-# a natural cliff shape even when every row's underlying boost
-# would have blown past the ceiling.  Rows whose natural boosted
-# value falls BELOW the capped ceiling use their natural value
-# (no cap applied), so mid-rank high-agreement players still get
-# their full multiplicative reward.
-_MONOTONICITY_MIN_STEP: int = 100
+# Source-rank-scaled monotonicity step.  When the natural boosted
+# value overshoots ``_DISPLAY_SCALE_MAX`` (9999) for a cluster of
+# top-of-board rows, a fixed-step cap (e.g. "always 100 pts down
+# per rank") flattens the top into equal stairs — but the real
+# rank-consistency signal varies row to row:
+#   - Allen (blendedSourceRank 1.1) vs Maye (3.9) = 2.8-rank gap
+#     → Allen is far and away the consensus #1; a big visible
+#     cliff here is justified.
+#   - Chase (5.0) vs Bijan (6.3) = 1.3-rank gap → typical step.
+#   - Two adjacent players within ~0.5 source-rank of each other
+#     should collapse to a near-flat display gap; a large fixed
+#     step would fabricate separation that isn't in the source data.
+# Scaling the step by the ``blendedSourceRank`` delta between
+# consecutive rows ties the visible cliff shape directly to the
+# actual source consensus.  ``_MONOTONICITY_BASE_STEP`` is the step
+# per 1.0-rank-gap; floor/ceiling prevent zero-step collapse on
+# rank ties / inversions and runaway cliffs on huge gaps.
+_MONOTONICITY_BASE_STEP: int = 75
+_MONOTONICITY_STEP_FLOOR: int = 25
+_MONOTONICITY_STEP_CEIL: int = 250
 
 _DISPLAY_SCALE_MAX: int = 9999
 
@@ -3381,6 +3387,7 @@ def _apply_volatility_compression_post_pass(
     # compression-induced inversion is fixed by the Phase 5 compact
     # resort that runs after this pass.
     prior_post_value: int | None = None
+    prior_blended_rank: float | None = None
 
     for row, value, spread in eligible:
         z = (spread - spread_mean) / spread_std
@@ -3390,6 +3397,17 @@ def _apply_volatility_compression_post_pass(
             if legacy_ref and legacy_ref in players_by_name
             else None
         )
+
+        # Pull the blended source rank (mean of effective per-source
+        # ranks) stamped in Phase 4a.  Falls back to canonical rank
+        # if the row is missing a blend (single-source rows, picks).
+        bsr_raw = row.get("blendedSourceRank")
+        current_blended_rank: float | None
+        if isinstance(bsr_raw, (int, float)):
+            current_blended_rank = float(bsr_raw)
+        else:
+            ccr = row.get("canonicalConsensusRank")
+            current_blended_rank = float(ccr) if isinstance(ccr, (int, float)) else None
 
         if z > 0:
             frac = min(z * strength, max_compress)
@@ -3406,24 +3424,34 @@ def _apply_volatility_compression_post_pass(
         elif z < 0:
             frac = min(abs(z) * strength, max_boost)
             boosted = max(1, int(round(value * (1.0 + frac))))
-            # Monotonicity-preserving ceiling on boost: new_val is
-            # the min of (raw-boosted, _DISPLAY_SCALE_MAX,
-            # prior_post_value - _MONOTONICITY_MIN_STEP).  The
-            # second and third terms prevent multiple high-agreement
-            # top-of-board players from collapsing onto a single
-            # 9999 plateau when their natural boosts all overshoot
-            # the display max.  The step size is 100 (not 1) so the
-            # resulting cliff shape — 9999, 9899, 9799, 9699... —
-            # reflects the rank-consistency spread the user expects
-            # at the top of the board; rows whose natural boosted
-            # value falls below the capped ceiling use their natural
-            # value and are unaffected by the cap.  The cap only
-            # tightens when the prior row itself landed at or below
-            # 9999 — a compression-branch neighbour sitting at 10694
-            # does not drag the boost ceiling above 9999.
+            # Monotonicity-preserving ceiling on boost, scaled by
+            # the source-rank gap between this row and the prior:
+            #   step = BASE * (bsr[N] − bsr[N−1])  clamped to [FLOOR, CEIL]
+            # A 2.8-rank gap (Allen 1.1 → Maye 3.9) yields a ~210-pt
+            # cliff; a 0.8-rank gap (Gibbs → Daniels) yields ~60.
+            # Rows whose natural boosted value falls below the
+            # capped ceiling use their natural value untouched, so
+            # the cap only shapes rows that would otherwise clamp
+            # at _DISPLAY_SCALE_MAX.
             ceiling = _DISPLAY_SCALE_MAX
             if prior_post_value is not None and prior_post_value <= _DISPLAY_SCALE_MAX:
-                ceiling = min(ceiling, prior_post_value - _MONOTONICITY_MIN_STEP)
+                if (
+                    prior_blended_rank is not None
+                    and current_blended_rank is not None
+                    and current_blended_rank > prior_blended_rank
+                ):
+                    rank_gap = current_blended_rank - prior_blended_rank
+                    raw_step = int(round(_MONOTONICITY_BASE_STEP * rank_gap))
+                else:
+                    # Rank inversion or tie (no positive gap) — fall
+                    # back to the base step so we still enforce a
+                    # minimum visible cliff between ranks.
+                    raw_step = _MONOTONICITY_BASE_STEP
+                step = max(
+                    _MONOTONICITY_STEP_FLOOR,
+                    min(_MONOTONICITY_STEP_CEIL, raw_step),
+                )
+                ceiling = min(ceiling, prior_post_value - step)
             new_val = max(1, min(boosted, ceiling))
             signed_frac = round(-frac, 4)
         else:
@@ -3435,6 +3463,10 @@ def _apply_volatility_compression_post_pass(
         # lift the next row's boost ceiling above 9999.  Any row
         # (boost, compress, no-op) can constrain the next boost.
         prior_post_value = min(new_val, _DISPLAY_SCALE_MAX)
+        # Track the blended rank too so the NEXT row's cliff step
+        # can be scaled against the source-consensus gap.
+        if current_blended_rank is not None:
+            prior_blended_rank = current_blended_rank
 
         # When z is on either side but frac rounds to zero (very small
         # |z|), skip the value mutation to avoid spurious 1-point

--- a/tests/api/fixtures/top_player_baseline.json
+++ b/tests/api/fixtures/top_player_baseline.json
@@ -1,36 +1,36 @@
 {
-  "capturedAt": "2026-04-19T23:18:15.097153+00:00",
+  "capturedAt": "2026-04-20T00:08:08.233994+00:00",
   "source": "dynasty_data_2026-04-19.json",
   "note": "Top-player baseline snapshot for tests/api/test_pick_refinement.py::TestPlayerRankingsUnchanged. Regenerate via tests/api/fixtures/regen_top_player_baseline.py whenever intentional pick-refinement or blend changes shift the captured rankings. Day-to-day scrape churn is absorbed by tolerances in the test itself, so routine scrape drift does NOT require a regen \u2014 only real invariant changes do.",
   "players": {
     "Bijan Robinson": {
       "canonicalConsensusRank": 4,
-      "rankDerivedValue": 9699,
+      "rankDerivedValue": 9586,
       "confidenceBucket": "high"
     },
     "Brock Bowers": {
       "canonicalConsensusRank": 14,
-      "rankDerivedValue": 8182,
+      "rankDerivedValue": 8260,
       "confidenceBucket": "high"
     },
     "Drake Maye": {
       "canonicalConsensusRank": 2,
-      "rankDerivedValue": 9899,
+      "rankDerivedValue": 9781,
       "confidenceBucket": "high"
     },
     "Ja'Marr Chase": {
       "canonicalConsensusRank": 3,
-      "rankDerivedValue": 9799,
+      "rankDerivedValue": 9707,
       "confidenceBucket": "high"
     },
     "Jahmyr Gibbs": {
       "canonicalConsensusRank": 6,
-      "rankDerivedValue": 9499,
+      "rankDerivedValue": 9443,
       "confidenceBucket": "high"
     },
     "Jayden Daniels": {
       "canonicalConsensusRank": 7,
-      "rankDerivedValue": 9399,
+      "rankDerivedValue": 9368,
       "confidenceBucket": "high"
     },
     "Josh Allen": {
@@ -45,12 +45,12 @@
     },
     "Patrick Mahomes": {
       "canonicalConsensusRank": 17,
-      "rankDerivedValue": 7882,
+      "rankDerivedValue": 8080,
       "confidenceBucket": "high"
     },
     "Puka Nacua": {
       "canonicalConsensusRank": 9,
-      "rankDerivedValue": 9199,
+      "rankDerivedValue": 9261,
       "confidenceBucket": "high"
     }
   }

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -907,14 +907,16 @@ class TestTepMultiplier(unittest.TestCase):
             boost_rank = boosted_by_name[name].get("canonicalConsensusRank")
             if base_rank != boost_rank:
                 # Rank shifted — the monotonicity cap steps the
-                # ceiling down by ``_MONOTONICITY_MIN_STEP`` (100)
-                # per rank, so a two-rank TEP shuffle can drift the
-                # display value by up to ~250 pts (two steps plus a
-                # bit of slack for rounding).  We still assert the
-                # shift is proportional to the rank change so a
-                # runaway drift surfaces as a regression.
+                # ceiling down by up to ``_MONOTONICITY_STEP_CEIL``
+                # (250) per rank, depending on the source-rank gap
+                # between adjacent rows.  A two-rank TEP shuffle can
+                # therefore drift a non-TE's display value by up to
+                # ~500 pts (two max-sized steps), though the typical
+                # case sees much less.  We still assert the drift
+                # stays bounded by the cap's max step so a runaway
+                # drift surfaces as a regression.
                 rank_delta = abs(int(base_rank or 0) - int(boost_rank or 0))
-                allowed = max(50, 120 * max(1, rank_delta))
+                allowed = max(100, 275 * max(1, rank_delta))
                 self.assertAlmostEqual(
                     base_val, boost_val, delta=allowed,
                     msg=(


### PR DESCRIPTION
## Summary

Replaces the fixed 100-pt monotonicity step with one scaled by the actual `blendedSourceRank` gap between adjacent rows. Every visible cliff now traces back to a real source-consensus jump.

## Why

Previous fix (PR #146) stepped down 100 pts per rank regardless of underlying consensus. That created an even-stair pattern that overstated some cliffs (adjacent players with near-identical source ranks) and understated others (e.g., Allen being far-and-away consensus #1 vs. Maye who has a 2.8-rank gap behind him).

Per the user's guidance: *"try not to have any huge cliffs unless it's a cliff accurately reflecting the source ranks."*

## New step formula

```
step = _MONOTONICITY_BASE_STEP × (bsr[N] − bsr[N-1])
step = clamp(step, _MONOTONICITY_STEP_FLOOR, _MONOTONICITY_STEP_CEIL)
```

- `_MONOTONICITY_BASE_STEP = 75` (pts per 1.0-rank-gap)
- `_MONOTONICITY_STEP_FLOOR = 25` (prevents zero-step on rank ties / inversions)
- `_MONOTONICITY_STEP_CEIL = 250` (caps runaway cliffs from huge rank gaps)

## Live top 10

| Rank | Player | Value | bsr | rank-gap | step |
|---:|---|---:|---:|---:|---:|
| 1 | Josh Allen | 9999 | 1.1 | — | — |
| 2 | Drake Maye | 9789 | 3.9 | +2.80 | **210** |
| 3 | Ja'Marr Chase | 9707 | 5.0 | +1.10 | 82 |
| 4 | Bijan Robinson | 9610 | 6.3 | +1.30 | 97 |
| 5 | JSN | 9520 | 7.5 | +1.20 | 90 |
| 6 | Gibbs | 9452 | 8.4 | +0.90 | 68 |
| 7 | Daniels | 9377 | 8.1 | −0.30 | 75 (inversion → base) |
| 8 | Lamar | 9352 | 8.3 | +0.20 | 25 (floor) |
| 9 | Nacua | 9270 | 9.4 | +1.10 | 82 |
| 10 | Burrow | 8912 | 11.5 | +2.10 | 358 (natural) |

The 210-pt gap between Allen and everyone else reflects his consensus-#1 dominance. The #9→#10 drop of 358 pts is natural (not a cap artifact) — it's Burrow's pre-boost value after a 2.1-rank consensus drop.

## Trade math impact

The step affects `rankDerivedValue` which feeds the trade calculator, arbitrage detection, and meter fairness. Under the new scheme:

- An Allen-for-Maye straight-up offer now correctly shows Jason gaining 210 pts (vs. old 100 or 1 pt) — reflects the real source-consensus gap.
- Adjacent ranks with near-tied consensus no longer fabricate 100-pt gaps in the meter.

## Test plan

- [x] `pytest tests/ -q` → 1772 passed, 3 skipped, 151 subtests passed
- [x] `test_tep_boost_does_not_touch_non_te_values` tolerance widened to ~275 pts per rank shift (was 120) since the cap can now step by up to the `_MONOTONICITY_STEP_CEIL` (250) in a single rank delta
- [x] `top_player_baseline.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)