### PR TITLE
P2: Derive TEP multiplier from Sleeper bonus_rec_te scoring

### DIFF
--- a/frontend/__tests__/site-overrides.test.js
+++ b/frontend/__tests__/site-overrides.test.js
@@ -765,18 +765,32 @@ describe("fetchDynastyData — routes overrides to backend endpoint", () => {
 // This block pins every step.
 
 describe("tepMultiplierIsCustomized", () => {
-  it("returns false for 1.0 and sub-default values", () => {
-    expect(tepMultiplierIsCustomized(1.0)).toBe(false);
-    expect(tepMultiplierIsCustomized(0.5)).toBe(false);
+  // The "customized" bit flips on EXPLICITNESS, not on a magic
+  // value like 1.0.  ``null`` (the new default) means "auto from
+  // league" — no override.  A finite number (including 1.0) means
+  // "user dragged the slider, honor this value verbatim".
+  //
+  // Historical note: this function used to return ``true`` only for
+  // ``n > 1.0``, which bundled the hardcoded 1.15 frontend default
+  // into every TEP-league user's cold-start payload and masked
+  // non-TEP-league users' over-boosted TEs.  The new shape lets the
+  // backend derive from Sleeper ``bonus_rec_te`` and reserves
+  // "customized" for the opt-in slider drag.
+  it("returns false for null / undefined (auto-from-league default)", () => {
     expect(tepMultiplierIsCustomized(undefined)).toBe(false);
     expect(tepMultiplierIsCustomized(null)).toBe(false);
     expect(tepMultiplierIsCustomized("not a number")).toBe(false);
+    expect(tepMultiplierIsCustomized(NaN)).toBe(false);
   });
 
-  it("returns true for values > 1.0", () => {
+  it("returns true for any finite number (explicit user override)", () => {
+    // Critically: 1.0 IS customized now — "user explicitly set TEP to 1.0"
+    // is a real override when the league derives a non-1.0 default.
+    expect(tepMultiplierIsCustomized(1.0)).toBe(true);
     expect(tepMultiplierIsCustomized(1.15)).toBe(true);
     expect(tepMultiplierIsCustomized(1.2)).toBe(true);
     expect(tepMultiplierIsCustomized(1.5)).toBe(true);
+    expect(tepMultiplierIsCustomized(0.5)).toBe(true);
   });
 });
 
@@ -849,12 +863,23 @@ describe("fetchDynastyData — tepMultiplier routes overrides to backend", () =>
     };
   }
 
-  it("does not hit override endpoint when tepMultiplier is 1.0 and no siteOverrides", async () => {
+  it("does not hit override endpoint when tepMultiplier is null/undefined (auto-from-league)", async () => {
+    // ``null`` is the new default — "let the backend derive from my
+    // Sleeper league".  No override POST; the base contract already
+    // carries the derived value baked into every rankDerivedValue.
     globalThis.fetch.mockResolvedValueOnce(baseMock());
-    await fetchDynastyData({ tepMultiplier: 1.0 });
+    await fetchDynastyData({ tepMultiplier: null });
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     const [url] = globalThis.fetch.mock.calls[0];
     expect(String(url)).toMatch(/\/api\/dynasty-data/);
+
+    // Also verify undefined behaves the same (some callers omit the prop).
+    _resetBaseContractCache();
+    globalThis.fetch.mockResolvedValueOnce(baseMock());
+    await fetchDynastyData({});
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    const [url2] = globalThis.fetch.mock.calls[1];
+    expect(String(url2)).toMatch(/\/api\/dynasty-data/);
   });
 
   it("routes to override endpoint when only tepMultiplier is customized", async () => {

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -61,13 +61,37 @@ function ToggleRow({ label, checked, onChange, hint }) {
 }
 
 export default function SettingsPage() {
-  const { loading, error, rows } = useDynastyData();
+  const { loading, error, rows, rawData } = useDynastyData();
   const { settings, update, updateSiteWeight, resetSiteWeights, reset } = useSettings();
   const [hydrated, setHydrated] = useState(true);
 
   function resetToDefaults() {
     reset();
   }
+
+  // Derived TE-premium multiplier from the backend.  Comes from
+  // ``rankingsOverride.tepMultiplierDerived`` which the backend
+  // stamps on every /api/data + override response.  The number is
+  // computed from the operator's Sleeper league ``bonus_rec_te``
+  // (0.0 → 1.0, 0.5 → 1.15, 1.0 → 1.30, ...) and represents the
+  // "auto" baseline the slider shows when the user has not
+  // explicitly overridden it.
+  const tepDerivedFromLeague = (() => {
+    const v = Number(rawData?.rankingsOverride?.tepMultiplierDerived);
+    return Number.isFinite(v) ? v : 1.0;
+  })();
+  // Effective slider value.  null/undefined in settings → show the
+  // derived value (auto); a finite number → show the user's override.
+  // Coerce any noise (strings, NaN) back to the derived baseline.
+  const tepSliderValue = (() => {
+    const raw = settings?.tepMultiplier;
+    if (raw === null || raw === undefined) return tepDerivedFromLeague;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : tepDerivedFromLeague;
+  })();
+  const tepIsAuto =
+    settings?.tepMultiplier === null ||
+    settings?.tepMultiplier === undefined;
 
   // Split the canonical registry into offense / IDP groups by the
   // declared scope field.  idpTradeCalc is listed under IDP (its
@@ -157,15 +181,43 @@ export default function SettingsPage() {
         </div>
         <SliderRow
           label="TE Premium"
-          value={settings.tepMultiplier}
+          value={tepSliderValue}
           min={1.0} max={1.5} step={0.05}
           onChange={(v) => update("tepMultiplier", v)}
-          hint="Backend TE boost — applied to non-TEP-native sources before blending"
+          hint={
+            tepIsAuto
+              ? `Auto from league (bonus_rec_te → ${tepDerivedFromLeague.toFixed(2)})`
+              : `Custom override (auto would be ${tepDerivedFromLeague.toFixed(2)})`
+          }
         />
+        {!tepIsAuto && (
+          <div style={{ marginTop: 4, marginBottom: 6 }}>
+            <button
+              type="button"
+              className="button-reset"
+              style={{
+                fontSize: "0.7rem",
+                color: "var(--accent-gold, #FFC62F)",
+                textDecoration: "underline",
+                cursor: "pointer",
+                padding: 0,
+              }}
+              onClick={() => update("tepMultiplier", null)}
+            >
+              Reset to Auto (derive from my Sleeper league)
+            </button>
+          </div>
+        )}
         <p className="muted" style={{ fontSize: "0.68rem", marginTop: 4, marginBottom: 0 }}>
-          Applied on the backend to every TE&apos;s per-source contributions from
-          rankings sources that don&apos;t already bake TE premium into their ranks.
-          Sources tagged{" "}
+          By default, this is <strong>derived from your Sleeper league&apos;s{" "}
+          <span style={{ fontFamily: "var(--mono)", fontSize: "0.64rem" }}>
+            bonus_rec_te
+          </span></strong>{" "}
+          scoring setting: 0.0 (standard) → 1.00, 0.5 (TEP-1.5) → 1.15,
+          1.0 (TEP-2.0) → 1.30.  Dragging the slider opts into a manual
+          override on top of that.  Applied on the backend to every TE&apos;s
+          per-source contributions from rankings sources that don&apos;t
+          already bake TE premium into their ranks.  Sources tagged{" "}
           <span
             style={{
               fontFamily: "var(--mono)",
@@ -181,9 +233,7 @@ export default function SettingsPage() {
           in the Ranking Sources table below pass through unchanged, so there is
           no double-boost. Changing the slider re-runs the canonical ranking
           pipeline with the new multiplier, so every page (rankings, trade
-          calculator, edge) sees the same TEP-adjusted values. Set to 1.00 to
-          disable the boost entirely, or raise it if your non-TEP sources
-          (DLF SF, KTC, etc.) are under-valuing TEs for your league.
+          calculator, edge) sees the same TEP-adjusted values.
         </p>
       </Section>
 

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -19,7 +19,19 @@ export function useDynastyData() {
   // frontend TEP multiplication either.
   const { settings } = useSettings();
   const siteOverrides = settings?.siteWeights || null;
-  const tepMultiplier = Number(settings?.tepMultiplier ?? 1.0) || 1.0;
+  // tepMultiplier: null means "auto from league" (derive on backend
+  // from Sleeper's bonus_rec_te).  A finite number means the user
+  // dragged the slider and wants that exact override.  Coercing null
+  // → 1.0 here would defeat the derivation path entirely, so we
+  // preserve the sentinel and let ``fetchDynastyData`` route
+  // accordingly (absent body key → backend derives).
+  const rawTep = settings?.tepMultiplier;
+  const tepMultiplier =
+    rawTep === null || rawTep === undefined
+      ? null
+      : Number.isFinite(Number(rawTep))
+        ? Number(rawTep)
+        : null;
   // Serialize the override map so the effect's dependency array
   // fires on semantic changes, not reference churn, without forcing
   // callers to memoize on their side.  The tepMultiplier is part of

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -11,7 +11,22 @@ export const SETTINGS_DEFAULTS = {
   leagueFormat: "superflex",         // "superflex" | "standard"
 
   // Value adjustment strengths
-  tepMultiplier: 1.15,               // 1.0..1.5 — TE premium boost for non-TEP sites
+  //
+  // tepMultiplier: null means "auto from league" — the backend derives
+  // the TE-premium multiplier from the operator's Sleeper league
+  // ``bonus_rec_te`` scoring setting and applies that value during the
+  // blend.  A standard TEP-1.5 league (bonus_rec_te=0.5) yields 1.15;
+  // a non-TEP league yields 1.0 (a no-op).  When the user drags the
+  // slider on /settings, this flips from null to a finite number,
+  // which ``fetchDynastyData`` then POSTs to the override endpoint as
+  // an explicit override on top of the derived default.  "Reset"
+  // returns it to null so the derived baseline kicks back in.
+  //
+  // Pre-2026-04 this defaulted to 1.15 — which silently applied a TE
+  // boost to every cold-start user regardless of whether their league
+  // even had a TE premium.  Moving the default to null fixes that
+  // mismatch: the board you see reflects your Sleeper league.
+  tepMultiplier: null,               // null = auto from Sleeper bonus_rec_te; 1.0..2.0 = explicit
 
   // Rankings display
   rankingsSortBasis: "full",         // "full" | "raw"

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -665,16 +665,31 @@ export function siteOverridesAreCustomized(siteOverrides) {
 }
 
 /**
- * A TE premium multiplier is "customized" when it differs from the
- * canonical backend default (1.0 = no boost).  Any value strictly
- * greater than 1.0 triggers the override fetch so the backend
- * pipeline bakes TEP into every TE's ``rankDerivedValue`` stamp.
- * Values at or below 1.0 pass through as the default blend.
+ * A TE premium multiplier is "customized" when the caller has passed
+ * an explicit finite number — i.e. the user dragged the slider on
+ * /settings and the value is no longer the ``null`` sentinel that
+ * means "auto from league".
+ *
+ * Previously this function considered 1.0 to be "default" and any
+ * value strictly > 1.0 to be customized, but that shape couldn't
+ * express "auto derived from my Sleeper league" — the frontend
+ * default of 1.15 always looked customized even when it matched the
+ * league-derived value.  The new shape uses ``null`` for "inherit
+ * from backend" and a finite number for "explicit override".  The
+ * backend's ``rankingsOverride.tepMultiplierDerived`` carries the
+ * league-derived default so the UI can render it without re-fetching
+ * the registry.
+ *
+ * Returns ``true`` when the caller has posted a finite number (they
+ * want to override the derived default).  Returns ``false`` for
+ * ``null`` / ``undefined`` / non-finite values (auto-from-league
+ * path — ``fetchDynastyData`` skips posting ``tep_multiplier`` in
+ * the body and the backend derives from Sleeper).
  */
 export function tepMultiplierIsCustomized(tepMultiplier) {
+  if (tepMultiplier === null || tepMultiplier === undefined) return false;
   const n = Number(tepMultiplier);
-  if (!Number.isFinite(n)) return false;
-  return n > 1.0;
+  return Number.isFinite(n);
 }
 
 // ── Row materialization ──────────────────────────────────────────────
@@ -1159,12 +1174,24 @@ export function mergeRankingsDelta(baseContract, delta) {
 
 export async function fetchDynastyData(opts = {}) {
   const siteOverrides = opts.siteOverrides || null;
-  const tepMultiplier = Number(opts.tepMultiplier ?? 1.0) || 1.0;
+  // Preserve ``null`` / ``undefined`` as "inherit derived default"
+  // rather than coercing to 1.0.  A finite number is treated as the
+  // explicit override the user set via the slider.
+  const rawTep = opts.tepMultiplier;
+  const tepMultiplier =
+    rawTep === null || rawTep === undefined
+      ? null
+      : Number.isFinite(Number(rawTep))
+        ? Number(rawTep)
+        : null;
   const sitesCustomized = siteOverridesAreCustomized(siteOverrides);
   const tepCustomized = tepMultiplierIsCustomized(tepMultiplier);
   const customized = sitesCustomized || tepCustomized;
 
   // Default path (no overrides): fetch + cache the base contract.
+  // The backend will derive tep_multiplier from the operator's
+  // Sleeper league ``bonus_rec_te`` and bake it into the blend for
+  // us, so the frontend doesn't need to POST anything.
   if (!customized) {
     return _fetchBaseContract();
   }
@@ -1177,11 +1204,12 @@ export async function fetchDynastyData(opts = {}) {
   const base = _cachedBaseContract || (await _fetchBaseContract());
 
   // Build the POST body: start from the siteOverrides map (legacy
-  // shape) and stamp the tep_multiplier field on top.  Both shapes
-  // the backend accepts leave extra top-level keys alone, so an
-  // empty siteOverrides map with tepMultiplier > 1.0 produces
-  // ``{tep_multiplier: 1.15}`` which the backend routes purely
-  // through normalize_tep_multiplier().
+  // shape) and stamp the tep_multiplier field on top only when the
+  // user has an explicit override.  When the slider is in "auto"
+  // (null) the body omits tep_multiplier entirely; the backend's
+  // ``normalize_tep_multiplier`` returns ``None`` for an absent key
+  // and ``build_api_data_contract`` derives from the Sleeper league
+  // context.
   const body = { ...(siteOverrides || {}) };
   if (tepCustomized) {
     body.tep_multiplier = tepMultiplier;

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1494,14 +1494,22 @@ _RESERVED_OVERRIDE_BODY_KEYS: frozenset[str] = frozenset(
 )
 
 
-def normalize_tep_multiplier(raw: Any) -> float:
+def normalize_tep_multiplier(raw: Any) -> float | None:
     """Extract + clamp a TEP multiplier from a POST override body.
 
-    Accepts a raw request body dict and returns a TEP multiplier in
-    the canonical range ``[1.0, 2.0]``.  Missing / invalid / out-of-
-    range values silently default to ``1.0`` (a no-op), matching the
-    permissive override-validation philosophy elsewhere in this
-    module.
+    Accepts a raw request body dict.  Returns:
+
+      * ``None`` when no ``tep_multiplier`` / ``tepMultiplier`` key is
+        present in the body — signals "user did not override, fall
+        back to the league-derived default".  ``build_api_data_contract``
+        and ``build_rankings_delta_payload`` both treat ``None`` as
+        "derive from Sleeper" via :func:`_derive_tep_multiplier_from_league`.
+      * A ``float`` clamped to ``[1.0, 2.0]`` when the key IS present
+        and parses as a finite number.  The clamped value is what the
+        pipeline applies verbatim (no derivation layered on top).
+      * ``None`` when the key is present but unparseable / infinite —
+        treated the same as "absent" so a garbled body falls back to
+        the league-derived default rather than silently becoming 1.0.
 
     The key lookup accepts both ``tep_multiplier`` (snake_case, the
     canonical API spelling) and ``tepMultiplier`` (camelCase, the
@@ -1510,17 +1518,17 @@ def normalize_tep_multiplier(raw: Any) -> float:
     import math
 
     if not isinstance(raw, dict):
-        return 1.0
+        return None
     for key in ("tep_multiplier", "tepMultiplier"):
         if key in raw:
             try:
                 v = float(raw[key])
             except (TypeError, ValueError):
-                return 1.0
+                return None
             if not math.isfinite(v):
-                return 1.0
+                return None
             return max(1.0, min(2.0, v))
-    return 1.0
+    return None
 
 
 def normalize_source_overrides(
@@ -1677,13 +1685,15 @@ def _summarize_source_overrides(
     source_overrides: dict[str, dict[str, Any]] | None,
     *,
     tep_multiplier: float = 1.0,
+    tep_multiplier_derived: float = 1.0,
+    tep_multiplier_source: str = "default",
 ) -> dict[str, Any]:
     """Produce the ``rankingsOverride`` contract summary block.
 
     The block carries:
       * ``isCustomized`` — True when at least one override actually
-        diverges from the registry default, OR ``tep_multiplier``
-        differs from the canonical default of 1.0.
+        diverges from the registry default, OR the effective
+        ``tep_multiplier`` diverges from the league-derived default.
       * ``enabledSources`` — ordered list of source keys that were
         enabled in the effective configuration.
       * ``weights`` — dict mapping source key → effective declared
@@ -1695,7 +1705,19 @@ def _summarize_source_overrides(
         was given, for debugging.
       * ``tepMultiplier`` — effective (clamped) TE-premium multiplier
         that was applied during the blend.
-      * ``tepMultiplierDefault`` — canonical default (``1.0``).
+      * ``tepMultiplierDefault`` — the league-derived default the
+        frontend should treat as "auto" / unchecked.  Equals
+        ``tep_multiplier_derived`` so the slider shows the right
+        baseline when the user has not overridden.
+      * ``tepMultiplierDerived`` — the raw TE-premium value derived
+        from the operator's Sleeper ``bonus_rec_te`` (redundant with
+        ``tepMultiplierDefault`` but kept as an explicit channel so
+        the frontend never confuses derivation with fallback).
+      * ``tepMultiplierSource`` — one of ``"derived"`` (came from
+        Sleeper), ``"explicit"`` (user slider override), or
+        ``"default"`` (fallback when the Sleeper fetch failed and no
+        override was sent).  The frontend uses this to label the
+        slider state ("Auto from league" vs "Custom override").
     """
     import math
 
@@ -1741,8 +1763,24 @@ def _summarize_source_overrides(
     if not math.isfinite(tep_eff):
         tep_eff = 1.0
     tep_eff = max(1.0, min(2.0, tep_eff))
-    if tep_eff != 1.0:
+
+    try:
+        tep_derived = float(tep_multiplier_derived)
+    except (TypeError, ValueError):
+        tep_derived = 1.0
+    if not math.isfinite(tep_derived):
+        tep_derived = 1.0
+    tep_derived = max(1.0, min(2.0, tep_derived))
+
+    # isCustomized flips only when the user-facing effective value
+    # diverges from the league-derived baseline.  A league with
+    # bonus_rec_te=0.5 (derived TEP=1.15) that lands on tep_eff=1.15
+    # is NOT customized — the user just accepted the auto value.
+    # Customization only fires when they explicitly drag the slider
+    # to something else.
+    if abs(tep_eff - tep_derived) > 1e-6:
         is_customized = True
+
     return {
         "isCustomized": is_customized,
         "enabledSources": enabled_sources,
@@ -1750,7 +1788,9 @@ def _summarize_source_overrides(
         "defaults": default_weights,
         "received": dict(normalized),
         "tepMultiplier": round(tep_eff, 4),
-        "tepMultiplierDefault": 1.0,
+        "tepMultiplierDefault": round(tep_derived, 4),
+        "tepMultiplierDerived": round(tep_derived, 4),
+        "tepMultiplierSource": str(tep_multiplier_source or "default"),
     }
 
 
@@ -3734,7 +3774,7 @@ def _suppress_generic_pick_tiers_when_slots_exist(
 #
 # League-size default: pick (round, slot) → rookie rank = (round-1)*N + slot,
 # where N = the operator's Sleeper league roster count.  Resolved at runtime
-# via :func:`_resolve_league_roster_count`; the constant below is the fallback
+# via :func:`_resolve_league_context`; the constant below is the fallback
 # when the Sleeper fetch is unavailable (offline, bad league id, etc.).
 # Only affects rows consumed via /api/data (rankings + trade calculator).
 # /api/draft-capital is served by a separate code path (server.py::_fetch_draft_capital)
@@ -3742,22 +3782,72 @@ def _suppress_generic_pick_tiers_when_slots_exist(
 _ROOKIE_ANCHOR_LEAGUE_SIZE_DEFAULT = 12
 _ROOKIE_ANCHOR_ROUNDS = 6
 
-# Cached Sleeper league size.  Populated on first call via the Sleeper
-# /v1/league/{id} endpoint using ``SLEEPER_LEAGUE_ID`` from the env.
+# TE-premium derivation from Sleeper ``bonus_rec_te``.
+#
+# Sleeper exposes the per-reception TE bonus as ``bonus_rec_te`` under
+# the league's ``scoring_settings``.  A "TEP 1.5" league has bonus 0.5
+# (TEs get 1.5 per reception vs the 1.0 the league awards everyone).
+#
+# The TE-premium value boost applied to non-TEP-native sources during
+# the blend is derived linearly from that bonus:
+#
+#     tep_multiplier = 1.0 + bonus_rec_te * _TEP_DERIVATION_SLOPE
+#
+# The slope 0.30 is calibrated so the standard TEP-1.5 setup
+# (bonus_rec_te == 0.5) lands at 1.15, which was the historical
+# frontend default and represents a ~15% TE value bump.  Sleeper
+# leagues without any TE bonus (bonus_rec_te == 0) derive tep == 1.0,
+# which is a no-op on the blend — the canonical "clean" board.
+#
+# The derived value is clamped to the same [1.0, 2.0] range as the
+# manual override so a misconfigured bonus (e.g. 3.0 per rec) can't
+# pump TE values off the board.  Callers who pass an explicit float
+# for ``tep_multiplier`` bypass the derivation entirely.
+_TEP_DERIVATION_SLOPE = 0.30
+_TEP_DERIVED_CLAMP_MIN = 1.0
+_TEP_DERIVED_CLAMP_MAX = 2.0
+
+# Cached Sleeper league context.  Populated on first call via the
+# Sleeper /v1/league/{id} endpoint using ``SLEEPER_LEAGUE_ID`` from
+# the env.  Stores the full resolved payload (roster count, TE-bonus,
+# scoring format hash) so every pipeline knob can reference the same
+# snapshot without a second HTTP round-trip.
 # Refresh every hour so a mid-season league expansion (rare) or a
 # switch to a different league eventually propagates without a restart.
-_LEAGUE_ROSTER_CACHE: dict[str, Any] = {"size": None, "fetched_at": 0.0}
-_LEAGUE_ROSTER_CACHE_TTL_SECONDS = 3600
+_LEAGUE_CONTEXT_CACHE: dict[str, Any] = {
+    "context": None,
+    "fetched_at": 0.0,
+}
+_LEAGUE_CONTEXT_CACHE_TTL_SECONDS = 3600
+
+# Back-compat alias — older revisions referenced the roster-only
+# cache dict by this name.  Keeping the symbol (as a view of the new
+# cache) avoids ImportError on any test helper that may patch it.
+_LEAGUE_ROSTER_CACHE: dict[str, Any] = _LEAGUE_CONTEXT_CACHE
+_LEAGUE_ROSTER_CACHE_TTL_SECONDS = _LEAGUE_CONTEXT_CACHE_TTL_SECONDS
 
 
-def _resolve_league_roster_count(default: int = _ROOKIE_ANCHOR_LEAGUE_SIZE_DEFAULT) -> int:
-    """Return the operator's Sleeper league roster count.
+def _resolve_league_context(
+    default_roster_count: int = _ROOKIE_ANCHOR_LEAGUE_SIZE_DEFAULT,
+) -> dict[str, Any]:
+    """Return the operator's Sleeper league context as a dict.
 
     Reads ``SLEEPER_LEAGUE_ID`` from the environment and fetches
-    ``total_rosters`` from Sleeper, cached for an hour.  Returns
-    ``default`` (12) if the env var is unset, the fetch fails, or
-    Sleeper returns an unusable payload — so the pipeline still
-    produces output on a cold start / offline machine.
+    ``total_rosters`` + ``scoring_settings`` from Sleeper, cached for
+    an hour.  Returns a dict with keys:
+
+      * ``roster_count`` (int) — number of rosters in the league; the
+        rookie-pick anchor uses this as N in ``(round-1)*N + slot``.
+      * ``bonus_rec_te`` (float) — Sleeper's per-reception TE bonus
+        (0.0 for leagues with no TE premium, 0.5 for standard TEP-1.5,
+        1.0 for TEP-2.0, etc.).
+      * ``fetched_from_sleeper`` (bool) — True when the dict reflects
+        a live Sleeper fetch, False when it's a fallback dict.
+
+    Returns a fallback dict (``roster_count=default``, ``bonus_rec_te=0.0``,
+    ``fetched_from_sleeper=False``) if the env var is unset, the fetch
+    fails, or Sleeper returns an unusable payload — so the pipeline
+    still produces output on a cold start / offline machine.
 
     Public helper so tests can patch it; no side effects beyond
     the cache fill.
@@ -3766,18 +3856,24 @@ def _resolve_league_roster_count(default: int = _ROOKIE_ANCHOR_LEAGUE_SIZE_DEFAU
     import urllib.request
 
     now = _time.time()
-    cached = _LEAGUE_ROSTER_CACHE.get("size")
-    fetched_at = float(_LEAGUE_ROSTER_CACHE.get("fetched_at") or 0.0)
-    if isinstance(cached, int) and cached > 0:
-        if (now - fetched_at) < _LEAGUE_ROSTER_CACHE_TTL_SECONDS:
-            return cached
+    cached = _LEAGUE_CONTEXT_CACHE.get("context")
+    fetched_at = float(_LEAGUE_CONTEXT_CACHE.get("fetched_at") or 0.0)
+    if isinstance(cached, dict) and cached.get("roster_count"):
+        if (now - fetched_at) < _LEAGUE_CONTEXT_CACHE_TTL_SECONDS:
+            return dict(cached)
+
+    fallback: dict[str, Any] = {
+        "roster_count": int(default_roster_count),
+        "bonus_rec_te": 0.0,
+        "fetched_from_sleeper": False,
+    }
 
     league_id = os.getenv("SLEEPER_LEAGUE_ID", "").strip()
     if not league_id:
-        # No league configured — return the default without populating
+        # No league configured — return the fallback without populating
         # the cache so a later SLEEPER_LEAGUE_ID env change takes
         # effect on the next call.
-        return default
+        return fallback
 
     try:
         url = f"https://api.sleeper.app/v1/league/{league_id}"
@@ -3785,13 +3881,71 @@ def _resolve_league_roster_count(default: int = _ROOKIE_ANCHOR_LEAGUE_SIZE_DEFAU
         with urllib.request.urlopen(req, timeout=5) as resp:
             data = json.load(resp)
         size = int(data.get("total_rosters") or 0)
+        scoring = data.get("scoring_settings") or {}
+        if not isinstance(scoring, dict):
+            scoring = {}
+        try:
+            bonus_rec_te = float(scoring.get("bonus_rec_te") or 0.0)
+        except (TypeError, ValueError):
+            bonus_rec_te = 0.0
+        if not math.isfinite(bonus_rec_te) or bonus_rec_te < 0:
+            bonus_rec_te = 0.0
         if size > 0:
-            _LEAGUE_ROSTER_CACHE["size"] = size
-            _LEAGUE_ROSTER_CACHE["fetched_at"] = now
-            return size
+            context = {
+                "roster_count": size,
+                "bonus_rec_te": bonus_rec_te,
+                "fetched_from_sleeper": True,
+            }
+            _LEAGUE_CONTEXT_CACHE["context"] = context
+            _LEAGUE_CONTEXT_CACHE["fetched_at"] = now
+            # Back-compat: mirror roster count under the legacy key so
+            # any caller that inspects the cache directly (tests) can
+            # still see ``cache["size"]``.
+            _LEAGUE_CONTEXT_CACHE["size"] = size
+            return dict(context)
     except Exception:  # noqa: BLE001 — any failure falls back to default
         pass
-    return default
+    return fallback
+
+
+def _resolve_league_roster_count(default: int = _ROOKIE_ANCHOR_LEAGUE_SIZE_DEFAULT) -> int:
+    """Return the operator's Sleeper league roster count.
+
+    Thin wrapper over :func:`_resolve_league_context` kept for
+    backwards-compatibility with callers that only need the roster
+    count (rookie pick anchor, DLF league-size gate).  New code
+    should prefer ``_resolve_league_context()`` directly.
+    """
+    return int(_resolve_league_context(default).get("roster_count") or default)
+
+
+def _derive_tep_multiplier_from_league(
+    context: dict[str, Any] | None = None,
+) -> float:
+    """Derive the effective TE-premium multiplier from the league context.
+
+    ``context`` is the dict returned by :func:`_resolve_league_context`;
+    when ``None`` the function resolves it itself (same 1h cache).
+
+    Formula: ``1.0 + bonus_rec_te * _TEP_DERIVATION_SLOPE``, clamped
+    to ``[_TEP_DERIVED_CLAMP_MIN, _TEP_DERIVED_CLAMP_MAX]``.
+
+    Returns ``1.0`` (a no-op on the blend) for any league with no TE
+    bonus, and also when the Sleeper fetch fails — the pipeline falls
+    back to the canonical "clean" board rather than silently
+    inheriting a boost from a prior deployment.
+    """
+    ctx = context if isinstance(context, dict) else _resolve_league_context()
+    try:
+        bonus = float(ctx.get("bonus_rec_te") or 0.0)
+    except (TypeError, ValueError):
+        bonus = 0.0
+    if not math.isfinite(bonus) or bonus < 0:
+        bonus = 0.0
+    derived = 1.0 + bonus * _TEP_DERIVATION_SLOPE
+    if not math.isfinite(derived):
+        return 1.0
+    return max(_TEP_DERIVED_CLAMP_MIN, min(_TEP_DERIVED_CLAMP_MAX, derived))
 
 
 def _anchor_current_year_picks_to_rookies(
@@ -4761,8 +4915,11 @@ def _compute_unified_rankings(
 
     # 2b) Anchor current-year slot picks to merged offense+IDP rookies.
     #     Pick (round, slot) inherits the rankDerivedValue of the rookie
-    #     at position (round-1)*12 + slot in the merged rookie list.  The
-    #     compact-ranks pass below re-sorts by value so coherence holds.
+    #     at position (round-1)*N + slot in the merged rookie list, where
+    #     N is the operator's Sleeper league roster count resolved via
+    #     ``_resolve_league_context`` (falls back to 12 when the Sleeper
+    #     fetch is unavailable).  The compact-ranks pass below re-sorts
+    #     by value so coherence holds.
     _anchor_year = int(_load_pick_year_discount().get("baselineYear") or 2026)
     _anchor_current_year_picks_to_rookies(players_array, _anchor_year)
 
@@ -5261,7 +5418,7 @@ def build_api_data_contract(
     *,
     data_source: dict[str, Any] | None = None,
     source_overrides: dict[str, dict[str, Any]] | None = None,
-    tep_multiplier: float = 1.0,
+    tep_multiplier: float | None = None,
     _for_delta: bool = False,
 ) -> dict[str, Any]:
     """Build a full API data contract payload from a raw scraper bundle.
@@ -5274,12 +5431,25 @@ def build_api_data_contract(
     consumers can tell an override response from the baseline
     response without guessing.
 
-    ``tep_multiplier`` (optional, default ``1.0``) is the league-wide
-    TE premium boost.  It is applied value-level inside the
-    canonical blend — see ``_compute_unified_rankings`` docstring.
-    Passing ``1.0`` is a no-op and byte-for-byte identical to the
-    pre-TEP pipeline; any value > 1.0 boosts TE rows whose
-    contributions came from non-TEP-native sources.
+    ``tep_multiplier`` is the league-wide TE premium boost, applied
+    value-level inside the canonical blend (see
+    ``_compute_unified_rankings`` docstring).  Two modes:
+
+      * ``None`` (default) — derive the multiplier from the operator's
+        Sleeper league context via
+        :func:`_derive_tep_multiplier_from_league`.  A standard TEP-1.5
+        league (``bonus_rec_te == 0.5``) yields ``1.15``; a non-TEP
+        league yields ``1.0`` (a no-op).  This is the production
+        cold-start path.
+      * an explicit ``float`` — use the caller's value verbatim (after
+        the same ``[1.0, 2.0]`` clamp the derivation applies).  Used by
+        the override endpoint when the user moves the TEP slider.
+
+    Previously this parameter defaulted to ``1.0``, which meant every
+    cold start produced a "clean" board regardless of league setup
+    and the frontend had to stamp its own ``tepMultiplier=1.15``
+    default on top.  That path is now symmetric: absent override →
+    league-derived, explicit override → user value.
 
     ``_for_delta`` (internal) skips work that only feeds fields the
     delta payload discards (trust-mirror into legacy players dict,
@@ -5287,6 +5457,47 @@ def build_api_data_contract(
     this to ``True`` so overrides round-trips don't pay for output
     blocks the wire shape drops.
     """
+    # ── Resolve the TE-premium multiplier ──
+    # ``None`` = caller wants the league-derived default (production
+    # cold start + any override request that omits ``tep_multiplier``).
+    # A finite float = caller passed an explicit override; we trust
+    # their value after the standard [1.0, 2.0] clamp.  The derived
+    # value is always computed (even when overridden) so the
+    # ``rankingsOverride`` summary can report both channels and the
+    # frontend slider can show the "Auto" baseline.
+    league_context = _resolve_league_context()
+    tep_multiplier_derived = _derive_tep_multiplier_from_league(league_context)
+    if tep_multiplier is None:
+        tep_multiplier_effective = tep_multiplier_derived
+        tep_multiplier_source = (
+            "derived"
+            if league_context.get("fetched_from_sleeper")
+            else "default"
+        )
+    else:
+        try:
+            tep_multiplier_effective = float(tep_multiplier)
+        except (TypeError, ValueError):
+            tep_multiplier_effective = tep_multiplier_derived
+            tep_multiplier_source = (
+                "derived"
+                if league_context.get("fetched_from_sleeper")
+                else "default"
+            )
+        else:
+            if not math.isfinite(tep_multiplier_effective):
+                tep_multiplier_effective = tep_multiplier_derived
+                tep_multiplier_source = (
+                    "derived"
+                    if league_context.get("fetched_from_sleeper")
+                    else "default"
+                )
+            else:
+                tep_multiplier_effective = max(
+                    _TEP_DERIVED_CLAMP_MIN,
+                    min(_TEP_DERIVED_CLAMP_MAX, tep_multiplier_effective),
+                )
+                tep_multiplier_source = "explicit"
     # Two-level copy of raw_payload: shallow at the top, one-deep for
     # the ``players`` dict so per-player mutations stay isolated.  Full
     # ``deepcopy`` of a 3MB payload was 70+ms per call; this lands at
@@ -5381,7 +5592,7 @@ def build_api_data_contract(
         players_by_name,
         csv_index=csv_index,
         source_overrides=source_overrides,
-        tep_multiplier=tep_multiplier,
+        tep_multiplier=tep_multiplier_effective,
     )
 
     # Stamp rankDerivedValue into the values bundle so every page uses the
@@ -5560,7 +5771,9 @@ def build_api_data_contract(
     # can hydrate a consistent shape without branching on presence.
     rankings_override = _summarize_source_overrides(
         source_overrides,
-        tep_multiplier=tep_multiplier,
+        tep_multiplier=tep_multiplier_effective,
+        tep_multiplier_derived=tep_multiplier_derived,
+        tep_multiplier_source=tep_multiplier_source,
     )
 
     contract_payload: dict[str, Any] = {
@@ -5640,7 +5853,7 @@ def build_rankings_delta_payload(
     *,
     data_source: dict[str, Any] | None = None,
     source_overrides: dict[str, dict[str, Any]] | None = None,
-    tep_multiplier: float = 1.0,
+    tep_multiplier: float | None = None,
 ) -> dict[str, Any]:
     """Build a compact delta contract for the rankings-override endpoint.
 
@@ -5648,6 +5861,10 @@ def build_rankings_delta_payload(
     extracts only the override-sensitive fields per player, keyed by
     ``displayName``.  The frontend merges each delta entry onto its
     cached base ``/api/data?view=app`` contract by that key.
+
+    ``tep_multiplier`` follows the same two-mode contract as
+    :func:`build_api_data_contract`: ``None`` derives from the Sleeper
+    league context; a ``float`` is used verbatim (after clamping).
 
     The delta drops the legacy ``players`` dict, ``sleeper``,
     ``methodology``, ``poolAudit``, and the full ``playersArray``,

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -32,7 +32,10 @@ import json
 from src.api.data_contract import (
     _DELTA_PLAYER_FIELDS,
     _RANKING_SOURCES,
+    _TEP_DERIVATION_SLOPE,
     _compute_unified_rankings,
+    _derive_tep_multiplier_from_league,
+    _resolve_league_context,
     _summarize_source_overrides,
     assert_ranking_source_registry_parity,
     build_api_data_contract,
@@ -760,18 +763,32 @@ class TestBuildRankingsDeltaPayload(unittest.TestCase):
 
 
 class TestNormalizeTepMultiplier(unittest.TestCase):
-    """Input validation + clamping for the TE-premium multiplier."""
+    """Input validation + clamping for the TE-premium multiplier.
 
-    def test_missing_field_defaults_to_one(self) -> None:
-        self.assertEqual(normalize_tep_multiplier(None), 1.0)
-        self.assertEqual(normalize_tep_multiplier({}), 1.0)
-        self.assertEqual(normalize_tep_multiplier({"ktc": {"include": False}}), 1.0)
+    Absent or invalid values return ``None`` (not ``1.0``) so the
+    pipeline can distinguish "user did not override" (→ derive from
+    Sleeper league context) from "user explicitly set 1.0" (→ use
+    1.0 verbatim).
+    """
+
+    def test_missing_field_returns_none(self) -> None:
+        self.assertIsNone(normalize_tep_multiplier(None))
+        self.assertIsNone(normalize_tep_multiplier({}))
+        self.assertIsNone(normalize_tep_multiplier({"ktc": {"include": False}}))
 
     def test_snake_case_key_is_accepted(self) -> None:
         self.assertEqual(normalize_tep_multiplier({"tep_multiplier": 1.15}), 1.15)
 
     def test_camel_case_key_is_accepted(self) -> None:
         self.assertEqual(normalize_tep_multiplier({"tepMultiplier": 1.2}), 1.2)
+
+    def test_explicit_one_is_preserved(self) -> None:
+        # Critical: posting ``{"tep_multiplier": 1.0}`` must return
+        # 1.0, NOT None.  The frontend slider explicitly set to 1.0
+        # (user wants to disable TE premium entirely) is a real
+        # override that the pipeline honors verbatim; it must not
+        # fall back to the league-derived default.
+        self.assertEqual(normalize_tep_multiplier({"tep_multiplier": 1.0}), 1.0)
 
     def test_snake_case_wins_over_camel_case(self) -> None:
         # Both forms present: snake_case is the canonical spelling and
@@ -786,27 +803,27 @@ class TestNormalizeTepMultiplier(unittest.TestCase):
         self.assertEqual(normalize_tep_multiplier({"tep_multiplier": 3.0}), 2.0)
         self.assertEqual(normalize_tep_multiplier({"tep_multiplier": -1}), 1.0)
 
-    def test_non_numeric_values_default_to_one(self) -> None:
-        self.assertEqual(normalize_tep_multiplier({"tep_multiplier": "nope"}), 1.0)
-        self.assertEqual(normalize_tep_multiplier({"tep_multiplier": None}), 1.0)
-        self.assertEqual(
-            normalize_tep_multiplier({"tep_multiplier": float("inf")}), 1.0
+    def test_non_numeric_values_return_none(self) -> None:
+        # Unparseable values fall back to "let the backend derive",
+        # not to a silent 1.0 (which would mask garbled bodies).
+        self.assertIsNone(normalize_tep_multiplier({"tep_multiplier": "nope"}))
+        self.assertIsNone(normalize_tep_multiplier({"tep_multiplier": None}))
+        self.assertIsNone(
+            normalize_tep_multiplier({"tep_multiplier": float("inf")})
         )
-        self.assertEqual(
-            normalize_tep_multiplier({"tep_multiplier": float("nan")}), 1.0
+        self.assertIsNone(
+            normalize_tep_multiplier({"tep_multiplier": float("nan")})
         )
 
-    def test_non_dict_input_returns_default(self) -> None:
-        self.assertEqual(normalize_tep_multiplier("1.15"), 1.0)
-        self.assertEqual(normalize_tep_multiplier(1.15), 1.0)
-        self.assertEqual(normalize_tep_multiplier([1.15]), 1.0)
+    def test_non_dict_input_returns_none(self) -> None:
+        self.assertIsNone(normalize_tep_multiplier("1.15"))
+        self.assertIsNone(normalize_tep_multiplier(1.15))
+        self.assertIsNone(normalize_tep_multiplier([1.15]))
 
     def test_tep_multiplier_with_source_overrides_is_accepted(self) -> None:
         """The TEP field must not reject a body that has no per-source overrides.
 
-        The frontend default is tepMultiplier=1.15 with an empty
-        siteWeights map.  Posting just ``{"tep_multiplier": 1.15}``
-        must be a valid body.
+        Posting just ``{"tep_multiplier": 1.15}`` must be a valid body.
         """
         overrides, warnings = normalize_source_overrides({"tep_multiplier": 1.15})
         # No per-source overrides were provided — the source map
@@ -823,6 +840,150 @@ class TestNormalizeTepMultiplier(unittest.TestCase):
         self.assertEqual(overrides, {"ktc": {"include": False}})
         self.assertEqual(warnings, [])
         self.assertEqual(normalize_tep_multiplier(body), 1.2)
+
+
+class TestTepMultiplierDerivation(unittest.TestCase):
+    """League-context-aware derivation of the TE-premium multiplier.
+
+    The backend derives the TEP multiplier from the operator's
+    Sleeper league ``bonus_rec_te`` scoring setting when the caller
+    passes ``tep_multiplier=None`` (production cold-start path).  This
+    suite pins the linear formula + the three "from league context"
+    entry points.
+
+    Calibration: ``tep_multiplier = 1.0 + bonus_rec_te * 0.30``,
+    clamped to ``[1.0, 2.0]``.  0.5 PPR bonus (standard TEP-1.5)
+    → 1.15, which matches the historical frontend default.
+    """
+
+    def test_derive_zero_bonus_is_identity(self) -> None:
+        """A league with no TE premium derives a no-op multiplier."""
+        result = _derive_tep_multiplier_from_league({"bonus_rec_te": 0.0})
+        self.assertEqual(result, 1.0)
+
+    def test_derive_half_bonus_matches_legacy_default(self) -> None:
+        """TEP-1.5 (bonus 0.5) derives the historical frontend default."""
+        result = _derive_tep_multiplier_from_league({"bonus_rec_te": 0.5})
+        self.assertAlmostEqual(result, 1.15, places=6)
+
+    def test_derive_full_bonus(self) -> None:
+        """TEP-2.0 (bonus 1.0) derives a 30% boost."""
+        result = _derive_tep_multiplier_from_league({"bonus_rec_te": 1.0})
+        self.assertAlmostEqual(result, 1.30, places=6)
+
+    def test_derive_clamps_extreme_values(self) -> None:
+        """Misconfigured bonuses can't pump TE values off the board."""
+        # bonus_rec_te=10 would derive 4.0 without clamping; clamp to 2.0.
+        result = _derive_tep_multiplier_from_league({"bonus_rec_te": 10.0})
+        self.assertEqual(result, 2.0)
+
+    def test_derive_floors_at_one(self) -> None:
+        """Negative / invalid bonuses floor at 1.0 (no TE discount)."""
+        self.assertEqual(
+            _derive_tep_multiplier_from_league({"bonus_rec_te": -0.5}), 1.0
+        )
+        self.assertEqual(
+            _derive_tep_multiplier_from_league({"bonus_rec_te": None}), 1.0
+        )
+        self.assertEqual(
+            _derive_tep_multiplier_from_league({"bonus_rec_te": "nope"}), 1.0
+        )
+
+    def test_derive_with_none_context_falls_back_to_default(self) -> None:
+        """No context (offline / no SLEEPER_LEAGUE_ID) → no-op."""
+        # In the test environment SLEEPER_LEAGUE_ID is cleared by
+        # conftest, so _resolve_league_context returns the fallback
+        # dict with bonus_rec_te=0.0 → derived TEP = 1.0.
+        result = _derive_tep_multiplier_from_league()
+        self.assertEqual(result, 1.0)
+
+    def test_derivation_slope_matches_constant(self) -> None:
+        """Slope constant is 0.30 (calibrated for TEP-1.5 → 1.15)."""
+        self.assertAlmostEqual(_TEP_DERIVATION_SLOPE, 0.30)
+
+
+class TestBuildContractTepDerivation(unittest.TestCase):
+    """End-to-end: build_api_data_contract uses None → derived behavior."""
+
+    def test_none_derives_from_league_context(self) -> None:
+        """Passing tep_multiplier=None derives from Sleeper."""
+        import src.api.data_contract as dc
+
+        # Override the resolver to mimic a TEP-1.5 league.
+        original = dc._resolve_league_context
+        dc._resolve_league_context = lambda default_roster_count=12: {  # type: ignore[assignment]
+            "roster_count": 12,
+            "bonus_rec_te": 0.5,
+            "fetched_from_sleeper": True,
+        }
+        try:
+            contract = build_api_data_contract(_fixture_raw_payload())
+        finally:
+            dc._resolve_league_context = original
+
+        rov = contract.get("rankingsOverride") or {}
+        # tepMultiplier reflects the derived value (1.15).
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.15)
+        # tepMultiplierDerived exposes the raw league derivation.
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplierDerived") or 0), 1.15
+        )
+        # Source is "derived" (not "explicit" / "default") — confirms
+        # the None path took the Sleeper route.
+        self.assertEqual(rov.get("tepMultiplierSource"), "derived")
+        # Not customized: derived == effective, user didn't override.
+        self.assertFalse(rov.get("isCustomized"))
+
+    def test_explicit_override_beats_derivation(self) -> None:
+        """Passing a finite float uses that value, not the derived one."""
+        import src.api.data_contract as dc
+
+        # League derives 1.15, but the caller overrides to 1.0.
+        original = dc._resolve_league_context
+        dc._resolve_league_context = lambda default_roster_count=12: {  # type: ignore[assignment]
+            "roster_count": 12,
+            "bonus_rec_te": 0.5,
+            "fetched_from_sleeper": True,
+        }
+        try:
+            contract = build_api_data_contract(
+                _fixture_raw_payload(), tep_multiplier=1.0
+            )
+        finally:
+            dc._resolve_league_context = original
+
+        rov = contract.get("rankingsOverride") or {}
+        self.assertEqual(float(rov.get("tepMultiplier") or 0), 1.0)
+        # The derived baseline is still exposed so the frontend can
+        # render "Auto would be 1.15" under the slider.
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplierDerived") or 0), 1.15
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "explicit")
+        # Effective (1.0) differs from derived (1.15) → isCustomized flips.
+        self.assertTrue(rov.get("isCustomized"))
+
+    def test_non_tep_league_derives_no_boost(self) -> None:
+        """A league without bonus_rec_te derives a no-op multiplier."""
+        import src.api.data_contract as dc
+
+        original = dc._resolve_league_context
+        dc._resolve_league_context = lambda default_roster_count=12: {  # type: ignore[assignment]
+            "roster_count": 12,
+            "bonus_rec_te": 0.0,
+            "fetched_from_sleeper": True,
+        }
+        try:
+            contract = build_api_data_contract(_fixture_raw_payload())
+        finally:
+            dc._resolve_league_context = original
+
+        rov = contract.get("rankingsOverride") or {}
+        self.assertEqual(float(rov.get("tepMultiplier") or 0), 1.0)
+        self.assertEqual(
+            float(rov.get("tepMultiplierDerived") or 0), 1.0
+        )
+        self.assertFalse(rov.get("isCustomized"))
 
 
 class TestTepMultiplier(unittest.TestCase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,34 @@ def _neutral_config_path(base: Path | None = None) -> Path:  # noqa: ARG001
 _production._original_production_config_path = _production.production_config_path
 _production.production_config_path = _neutral_config_path
 _production.reset_cache()
+
+
+# ── Sleeper league context isolation ──────────────────────────────────
+# ``src/api/data_contract.py::_resolve_league_context`` reads the
+# operator's Sleeper league to derive the roster count (rookie-pick
+# anchor) and the TE-premium multiplier (``bonus_rec_te``).  During
+# tests we must not hit the live Sleeper API — both because it's slow /
+# flaky and because the operator's league has bonus_rec_te=0.5, which
+# would silently flip the derived TEP from the 1.0 baseline the test
+# fixtures assume.
+#
+# Clearing the env var makes ``_resolve_league_context`` return its
+# fallback dict (roster_count=12, bonus_rec_te=0.0, derived TEP=1.0),
+# which matches the pre-derivation behavior of every fixture-based
+# test in this suite.  Tests that WANT to exercise derivation
+# explicitly monkeypatch ``_resolve_league_context`` or
+# ``_derive_tep_multiplier_from_league``.
+os.environ.pop("SLEEPER_LEAGUE_ID", None)
+
+# The cache is keyed by the env var, but some tests import
+# data_contract before pytest runs this conftest (in which case the
+# cache may already carry a live Sleeper snapshot from a prior dev
+# session).  Clear it defensively.
+try:
+    from src.api import data_contract as _data_contract
+
+    _data_contract._LEAGUE_CONTEXT_CACHE.clear()
+    _data_contract._LEAGUE_CONTEXT_CACHE["context"] = None
+    _data_contract._LEAGUE_CONTEXT_CACHE["fetched_at"] = 0.0
+except Exception:  # noqa: BLE001 — conftest must never block collection
+    pass


### PR DESCRIPTION
## Summary
- Backend now derives the TE-premium multiplier from the operator's Sleeper league ``bonus_rec_te`` scoring setting instead of relying on a hardcoded frontend default of 1.15. Formula: ``1.0 + bonus_rec_te * 0.30`` clamped to [1.0, 2.0].
- Frontend slider default changes from ``1.15`` → ``null`` meaning ""auto from league""; user drag becomes an explicit override. UI shows ""Auto from league"" hint with a ""Reset to Auto"" button when the user has a manual override.
- Also fixes stale ``(round-1)*12`` comment that hadn't been updated after the rookie-pick anchor went dynamic.

## Why it matters
Pre-change, every cold-start user got a silent +15% TE boost regardless of whether their league even had a TE premium. The frontend default (1.15) was ALWAYS posted to the backend on first load because ``tepMultiplierIsCustomized(1.15) === true``. This contradicts the mission statement (""based on my league setup"") — the board you saw was a synthetic TEP blend, not the canonical value for your actual league.

## Net behavior
- **Operator's league (TEP-1.5, bonus 0.5)**: zero change. Derives 1.15 — byte-identical to the old default.
- **Non-TEP league (bonus 0)**: board correctly shows no TE boost.
- **Heavy-TEP (bonus 1.0)**: derives 1.30, more accurate than the old hardcoded 1.15 ceiling.

## Changes
- ``src/api/data_contract.py``: ``_resolve_league_context`` (new), ``_derive_tep_multiplier_from_league`` (new), ``normalize_tep_multiplier`` returns ``float | None``, builder signatures accept ``tep_multiplier: float | None``, ``rankingsOverride`` exposes ``tepMultiplierDerived`` + ``tepMultiplierSource``.
- ``frontend/components/useSettings.js``: default from 1.15 → null.
- ``frontend/lib/dynasty-data.js``: ``tepMultiplierIsCustomized`` flips on any finite number; ``fetchDynastyData`` only stamps the body when explicit.
- ``frontend/app/settings/page.jsx``: slider reads derived value from ``rawData.rankingsOverride.tepMultiplierDerived``; ""Reset to Auto"" affordance.
- ``tests/conftest.py``: clears ``SLEEPER_LEAGUE_ID`` + ``_LEAGUE_CONTEXT_CACHE`` so tests never hit live Sleeper.

## Test plan
- [x] ``pytest tests/`` — 1783 passed, 3 skipped
- [x] ``npm test -- --run`` — 418 passed
- [x] ``npm run build`` — production build clean
- [ ] Verify /settings slider shows ""Auto from league (bonus_rec_te → 1.15)"" in production
- [ ] Verify /settings ""Reset to Auto"" clears a manual override back to null
- [ ] Verify the rankings board values are unchanged vs pre-deploy (since derived 1.15 == old default 1.15 for this league)

🤖 Generated with [Claude Code](https://claude.com/claude-code)