### PR TITLE
P3: Blend ratio 60/40 → 70/30 (backtest-validated stability win)

### DIFF
--- a/reports/backtest_blend_params_full.md
+++ b/reports/backtest_blend_params_full.md
@@ -1,0 +1,61 @@
+# Blend Parameter Backtest
+
+Snapshot count: **25**
+Runtime: **330.2s**
+
+Stability metric: mean absolute change in ``canonicalConsensusRank`` across consecutive-day pairs for top-200 players present in both days.  Value-weighted variant weights each delta by the day-T rank-derived value.
+
+Lower = more stable = probably better-calibrated.  The *relative* ordering across parameter values is the signal; absolute numbers depend on the specific date range and do not imply calibration error.
+
+## _BLEND_MEAN_WEIGHT
+
+| value | extra | mean abs rank change | value-weighted rank change |
+|------:|:------|---------------------:|---------------------------:|
+| 0.5 | _BLEND_ROBUST_WEIGHT=0.5 | 19.583 | 13.438 |
+| 0.55 | _BLEND_ROBUST_WEIGHT=0.45 | 19.636 | 13.526 ← least stable |
+| 0.6 | _BLEND_ROBUST_WEIGHT=0.4 | 18.593 | 12.849 |
+| 0.65 | _BLEND_ROBUST_WEIGHT=0.35 | 18.475 | 12.635 |
+| 0.7 | _BLEND_ROBUST_WEIGHT=0.3 | 17.541 | 12.218 **← most stable** |
+| 0.75 | _BLEND_ROBUST_WEIGHT=0.25 | 18.057 | 12.570 |
+
+Spread (worst − best): **1.307** (relative: 10.7%)
+
+## _VOLATILITY_COMPRESSION_FLOOR
+
+| value | extra | mean abs rank change | value-weighted rank change |
+|------:|:------|---------------------:|---------------------------:|
+| 0.86 |  | 18.583 | 12.843 **← most stable** |
+| 0.88 |  | 18.583 | 12.843 |
+| 0.9 |  | 18.583 | 12.843 |
+| 0.92 |  | 18.593 | 12.849 |
+| 0.94 |  | 18.586 | 12.866 |
+| 0.96 |  | 18.694 | 12.942 ← least stable |
+
+Spread (worst − best): **0.099** (relative: 0.8%)
+
+## _VOLATILITY_COMPRESSION_CEIL
+
+| value | extra | mean abs rank change | value-weighted rank change |
+|------:|:------|---------------------:|---------------------------:|
+| 1.02 |  | 18.698 | 13.059 ← least stable |
+| 1.04 |  | 18.594 | 12.865 |
+| 1.06 |  | 18.593 | 12.849 **← most stable** |
+| 1.08 |  | 18.593 | 12.849 |
+| 1.1 |  | 18.593 | 12.849 |
+| 1.12 |  | 18.593 | 12.849 |
+| 1.14 |  | 18.593 | 12.849 |
+
+Spread (worst − best): **0.209** (relative: 1.6%)
+
+## RANKING_SOURCES[idpTradeCalc].weight
+
+| value | extra | mean abs rank change | value-weighted rank change |
+|------:|:------|---------------------:|---------------------------:|
+| 1.0 |  | 19.686 | 14.060 ← least stable |
+| 1.5 |  | 19.225 | 13.495 |
+| 2.0 |  | 18.593 | 12.849 |
+| 2.5 |  | 18.867 | 12.736 |
+| 3.0 |  | 17.598 | 12.115 **← most stable** |
+
+Spread (worst − best): **1.945** (relative: 16.1%)
+

--- a/scripts/backtest_blend_params.py
+++ b/scripts/backtest_blend_params.py
@@ -1,0 +1,401 @@
+"""Empirical backtest for the canonical blend parameters.
+
+Sweeps each tunable in ``src/api/data_contract.py`` against the
+operator's daily snapshot archive and reports how much each
+parameter value affects rank stability across time.
+
+Parameters under test:
+    * ``_BLEND_MEAN_WEIGHT`` / ``_BLEND_ROBUST_WEIGHT`` — the convex
+      combination of weighted-mean and robust-trimmed-median.
+      Swept at {0.50, 0.55, 0.60, 0.65, 0.70} for the mean weight
+      with robust = 1 - mean so the pair stays a convex combination.
+    * ``_VOLATILITY_COMPRESSION_FLOOR`` — minimum compression factor
+      applied to high-disagreement rows.  Swept at {0.88, 0.90,
+      0.92, 0.94}.
+    * ``_VOLATILITY_COMPRESSION_CEIL`` — maximum boost factor applied
+      to unanimous rows.  Swept at {1.04, 1.06, 1.08, 1.10, 1.12}.
+    * IDPTC weight in ``_RANKING_SOURCES`` — Swept at {1.0, 1.5, 2.0,
+      2.5, 3.0}.  The registry entry is mutated in place for each
+      trial and restored on teardown.
+
+Each parameter is swept independently with the others held at their
+live defaults.  This is cheaper than a full Cartesian grid
+(500 combos × N snapshots) and still exposes whether any single
+value is wildly mis-calibrated.  A follow-up grid can probe
+interactions if a single-dim sweep reveals a promising corner.
+
+Stability metric:
+    For each consecutive snapshot pair (T, T+1), compute the mean
+    absolute change in ``canonicalConsensusRank`` across the
+    top-200 players present on both days.  Lower = more stable.
+
+    Also reports the value-weighted variant where each player's
+    rank change is weighted by their rank-derived value on day T,
+    so moves among the top 12 matter more than moves at rank 180.
+
+Usage:
+    python3 scripts/backtest_blend_params.py
+    python3 scripts/backtest_blend_params.py --snapshots 5
+    python3 scripts/backtest_blend_params.py --out reports/backtest.md
+
+Runtime: ~2 minutes on 10 snapshots × ~20 parameter variations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from statistics import mean, median, stdev
+
+# Allow running from the repo root without an install step.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Isolate Sleeper calls during the backtest — derivation uses the
+# fallback context so TEP lands at 1.0, identical across every trial
+# snapshot.  (The live service uses the operator's league; the
+# backtest purposely normalizes this out so we're measuring blend
+# behavior, not TEP drift.)
+os.environ.pop("SLEEPER_LEAGUE_ID", None)
+
+from src.api import data_contract  # noqa: E402
+
+
+def load_snapshots(limit: int | None) -> list[tuple[str, dict]]:
+    """Load the N most recent dynasty_data_YYYY-MM-DD.json snapshots."""
+    data_dir = _REPO_ROOT / "data"
+    paths = sorted(data_dir.glob("dynasty_data_*.json"))
+    if limit is not None and limit > 0:
+        paths = paths[-limit:]
+    loaded: list[tuple[str, dict]] = []
+    for path in paths:
+        date = path.stem.replace("dynasty_data_", "")
+        with path.open() as fh:
+            loaded.append((date, json.load(fh)))
+    return loaded
+
+
+def build_board(raw: dict) -> dict[str, dict]:
+    """Run the canonical pipeline and return {displayName: row} for the
+    ranked board (rows that received a ``canonicalConsensusRank``).
+    """
+    contract = data_contract.build_api_data_contract(raw, tep_multiplier=1.0)
+    out: dict[str, dict] = {}
+    for row in contract.get("playersArray") or []:
+        rank = row.get("canonicalConsensusRank")
+        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
+        if not name or not rank:
+            continue
+        out[name] = {
+            "rank": int(rank),
+            "value": float(row.get("rankDerivedValue") or 0),
+        }
+    return out
+
+
+def stability_metric(
+    boards: list[dict[str, dict]],
+    *,
+    top_n: int = 200,
+) -> dict[str, float]:
+    """Mean absolute rank change across consecutive day-pairs.
+
+    Returns both unweighted and value-weighted variants.  The
+    value-weighted variant weights each player's rank change by the
+    day-T rank-derived value so top-12 moves dominate rank-180
+    noise.
+
+    A lower metric = more stable board = probably better-calibrated
+    blend.  Cross-snapshot changes that reflect REAL source updates
+    still register; the metric only claims to rank parameter choices
+    relative to each other, not to reveal "true" values.
+    """
+    if len(boards) < 2:
+        return {"mean_abs_rank_change": 0.0, "value_weighted_rank_change": 0.0}
+
+    unweighted_changes: list[float] = []
+    weighted_numer: float = 0.0
+    weighted_denom: float = 0.0
+    for prev, curr in zip(boards, boards[1:]):
+        # Restrict to top_n on the PRIOR day so rank-200→rank-201
+        # boundary thrashing doesn't dominate.  Consider only players
+        # present in both snapshots (new rookies / removed players
+        # are rank-change artifacts, not parameter signal).
+        prev_top = [
+            (name, info)
+            for name, info in prev.items()
+            if info["rank"] <= top_n
+        ]
+        for name, prev_info in prev_top:
+            curr_info = curr.get(name)
+            if curr_info is None:
+                continue
+            delta = abs(curr_info["rank"] - prev_info["rank"])
+            unweighted_changes.append(delta)
+            weight = prev_info["value"]
+            weighted_numer += delta * weight
+            weighted_denom += weight
+
+    return {
+        "mean_abs_rank_change": (
+            mean(unweighted_changes) if unweighted_changes else 0.0
+        ),
+        "value_weighted_rank_change": (
+            weighted_numer / weighted_denom if weighted_denom > 0 else 0.0
+        ),
+    }
+
+
+def sweep_blend_ratio(
+    snapshots: list[tuple[str, dict]],
+) -> list[dict]:
+    """Sweep ``_BLEND_MEAN_WEIGHT`` (robust = 1 - mean)."""
+    grid = [0.50, 0.55, 0.60, 0.65, 0.70, 0.75]
+    original_mean = data_contract._BLEND_MEAN_WEIGHT
+    original_rob = data_contract._BLEND_ROBUST_WEIGHT
+    results: list[dict] = []
+    try:
+        for mean_w in grid:
+            data_contract._BLEND_MEAN_WEIGHT = mean_w
+            data_contract._BLEND_ROBUST_WEIGHT = round(1.0 - mean_w, 4)
+            boards = [build_board(raw) for _date, raw in snapshots]
+            m = stability_metric(boards)
+            results.append(
+                {
+                    "param": "_BLEND_MEAN_WEIGHT",
+                    "value": mean_w,
+                    "paired_with": (
+                        f"_BLEND_ROBUST_WEIGHT={round(1.0 - mean_w, 4)}"
+                    ),
+                    **m,
+                }
+            )
+    finally:
+        data_contract._BLEND_MEAN_WEIGHT = original_mean
+        data_contract._BLEND_ROBUST_WEIGHT = original_rob
+    return results
+
+
+def sweep_volatility_floor(
+    snapshots: list[tuple[str, dict]],
+) -> list[dict]:
+    """Sweep ``_VOLATILITY_COMPRESSION_FLOOR`` (compression limit)."""
+    grid = [0.86, 0.88, 0.90, 0.92, 0.94, 0.96]
+    original = data_contract._VOLATILITY_COMPRESSION_FLOOR
+    results: list[dict] = []
+    try:
+        for v in grid:
+            data_contract._VOLATILITY_COMPRESSION_FLOOR = v
+            boards = [build_board(raw) for _date, raw in snapshots]
+            m = stability_metric(boards)
+            results.append(
+                {
+                    "param": "_VOLATILITY_COMPRESSION_FLOOR",
+                    "value": v,
+                    **m,
+                }
+            )
+    finally:
+        data_contract._VOLATILITY_COMPRESSION_FLOOR = original
+    return results
+
+
+def sweep_volatility_ceil(
+    snapshots: list[tuple[str, dict]],
+) -> list[dict]:
+    """Sweep ``_VOLATILITY_COMPRESSION_CEIL`` (boost limit)."""
+    grid = [1.02, 1.04, 1.06, 1.08, 1.10, 1.12, 1.14]
+    original = data_contract._VOLATILITY_COMPRESSION_CEIL
+    results: list[dict] = []
+    try:
+        for v in grid:
+            data_contract._VOLATILITY_COMPRESSION_CEIL = v
+            boards = [build_board(raw) for _date, raw in snapshots]
+            m = stability_metric(boards)
+            results.append(
+                {
+                    "param": "_VOLATILITY_COMPRESSION_CEIL",
+                    "value": v,
+                    **m,
+                }
+            )
+    finally:
+        data_contract._VOLATILITY_COMPRESSION_CEIL = original
+    return results
+
+
+def sweep_idptc_weight(
+    snapshots: list[tuple[str, dict]],
+) -> list[dict]:
+    """Sweep the IDP Trade Calculator declared weight."""
+    grid = [1.0, 1.5, 2.0, 2.5, 3.0]
+    # Mutate the registry entry in place and restore after.
+    target_key = "idpTradeCalc"
+    target = next(
+        (s for s in data_contract._RANKING_SOURCES if s.get("key") == target_key),
+        None,
+    )
+    if target is None:
+        return []
+    original_weight = target.get("weight")
+    results: list[dict] = []
+    try:
+        for w in grid:
+            target["weight"] = float(w)
+            boards = [build_board(raw) for _date, raw in snapshots]
+            m = stability_metric(boards)
+            results.append(
+                {
+                    "param": f"RANKING_SOURCES[{target_key}].weight",
+                    "value": w,
+                    **m,
+                }
+            )
+    finally:
+        target["weight"] = original_weight
+    return results
+
+
+def format_report(
+    all_results: list[list[dict]],
+    *,
+    snapshot_count: int,
+    runtime_seconds: float,
+) -> str:
+    """Emit a Markdown summary with the best-/worst- parameter rows
+    highlighted per sweep.
+
+    Ranks the runs within each sweep by the value-weighted stability
+    metric (the one the mission cares about — moves at the top of
+    the board count more than moves in the bottom).
+    """
+    lines: list[str] = []
+    lines.append("# Blend Parameter Backtest")
+    lines.append("")
+    lines.append(f"Snapshot count: **{snapshot_count}**")
+    lines.append(f"Runtime: **{runtime_seconds:.1f}s**")
+    lines.append("")
+    lines.append(
+        "Stability metric: mean absolute change in "
+        "``canonicalConsensusRank`` across consecutive-day pairs for "
+        "top-200 players present in both days.  Value-weighted "
+        "variant weights each delta by the day-T rank-derived value."
+    )
+    lines.append("")
+    lines.append(
+        "Lower = more stable = probably better-calibrated.  The *relative* "
+        "ordering across parameter values is the signal; absolute numbers "
+        "depend on the specific date range and do not imply calibration error."
+    )
+    lines.append("")
+
+    for sweep in all_results:
+        if not sweep:
+            continue
+        param = sweep[0]["param"]
+        lines.append(f"## {param}")
+        lines.append("")
+        lines.append(
+            "| value | extra | mean abs rank change | value-weighted rank change |"
+        )
+        lines.append("|------:|:------|---------------------:|---------------------------:|")
+        # Sort by value-weighted metric ascending (most stable first)
+        # for the summary, but render the grid in natural value order
+        # so readers can scan a monotonic curve.
+        natural = sorted(sweep, key=lambda r: r["value"])
+        best = min(sweep, key=lambda r: r["value_weighted_rank_change"])
+        worst = max(sweep, key=lambda r: r["value_weighted_rank_change"])
+        for r in natural:
+            marker = ""
+            if r is best:
+                marker = " **← most stable**"
+            elif r is worst:
+                marker = " ← least stable"
+            extra = r.get("paired_with", "")
+            lines.append(
+                f"| {r['value']} | {extra} | "
+                f"{r['mean_abs_rank_change']:.3f} | "
+                f"{r['value_weighted_rank_change']:.3f}{marker} |"
+            )
+        spread = worst["value_weighted_rank_change"] - best["value_weighted_rank_change"]
+        lines.append("")
+        lines.append(
+            f"Spread (worst − best): **{spread:.3f}** "
+            f"(relative: {100 * spread / max(best['value_weighted_rank_change'], 1e-6):.1f}%)"
+        )
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument(
+        "--snapshots",
+        type=int,
+        default=10,
+        help="How many most-recent snapshots to use (default: 10).",
+    )
+    parser.add_argument(
+        "--out",
+        type=str,
+        default="reports/backtest_blend_params.md",
+        help="Output path for the Markdown report (default: reports/backtest_blend_params.md).",
+    )
+    args = parser.parse_args()
+
+    start = time.time()
+    snapshots = load_snapshots(args.snapshots)
+    if len(snapshots) < 2:
+        print(
+            f"ERROR: need at least 2 snapshots to measure stability; "
+            f"found {len(snapshots)}.  Run the daily scrape a couple of "
+            f"days first."
+        )
+        return 1
+
+    print(
+        f"Loaded {len(snapshots)} snapshots "
+        f"({snapshots[0][0]} → {snapshots[-1][0]})"
+    )
+    print()
+
+    all_results: list[list[dict]] = []
+
+    print("Sweeping _BLEND_MEAN_WEIGHT...")
+    all_results.append(sweep_blend_ratio(snapshots))
+
+    print("Sweeping _VOLATILITY_COMPRESSION_FLOOR...")
+    all_results.append(sweep_volatility_floor(snapshots))
+
+    print("Sweeping _VOLATILITY_COMPRESSION_CEIL...")
+    all_results.append(sweep_volatility_ceil(snapshots))
+
+    print("Sweeping RANKING_SOURCES[idpTradeCalc].weight...")
+    all_results.append(sweep_idptc_weight(snapshots))
+
+    runtime = time.time() - start
+    report = format_report(
+        all_results, snapshot_count=len(snapshots), runtime_seconds=runtime
+    )
+
+    out_path = _REPO_ROOT / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(report, encoding="utf-8")
+
+    print()
+    print(f"✓ Report written to {out_path.relative_to(_REPO_ROOT)}")
+    print(f"  ({runtime:.1f}s total)")
+    print()
+    # Also echo to stdout for quick inspection.
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3362,6 +3362,38 @@ _VOLATILITY_COMPRESSION_STRENGTH: float = 0.03
 _VOLATILITY_COMPRESSION_FLOOR: float = 0.92
 _VOLATILITY_COMPRESSION_CEIL: float = 1.08
 
+# Final-blend mix between the weighted-mean (structural) and the
+# robust-trimmed-median (outlier-resistant) aggregation of per-source
+# Hill-curve values.  The live formula is:
+#
+#     blended_value = _BLEND_MEAN_WEIGHT * weighted_mean +
+#                     _BLEND_ROBUST_WEIGHT * robust
+#
+# The two weights MUST sum to 1.0; the pipeline treats them as a
+# convex combination and does not renormalize.
+#
+# 70/30 trusts the configured source weights heavily (the IDPTC 2.0
+# backbone weight is the dominant example) while still letting the
+# robust blend absorb single-source outliers.  Change these together
+# (not independently) — a 0.5/0.5 split weights outlier-correction
+# more, a 0.7/0.3 split trusts the configured source weights more.
+#
+# Historical note: this pair was 0.6/0.4 through 2026-04-19.  The
+# ``scripts/backtest_blend_params.py`` sweep on 25 daily snapshots
+# (2026-03-23 → 2026-04-16) showed a clean peak at 0.70 for
+# value-weighted rank stability (4.9% improvement over 0.60; spread
+# 10.7% across the {0.50 .. 0.75} grid; monotonic rise from 0.55 to
+# 0.70 with a downturn at 0.75).  See
+# ``reports/backtest_blend_params_full.md``.
+#
+# Backtests (see ``scripts/backtest_blend_params.py``) sweep these
+# against daily snapshots to verify the split is near-optimal for
+# rank stability.  Overriding at runtime is a supported pattern: the
+# backtest harness mutates the module attribute directly before each
+# ``build_api_data_contract`` call, so keep the names stable.
+_BLEND_MEAN_WEIGHT: float = 0.7
+_BLEND_ROBUST_WEIGHT: float = 0.3
+
 # Source-rank-scaled monotonicity step.  When the natural boosted
 # value overshoots ``_DISPLAY_SCALE_MAX`` (9999) for a cluster of
 # top-of-board rows, a fixed-step cap (e.g. "always 100 pts down
@@ -4582,10 +4614,19 @@ def _compute_unified_rankings(
             else:
                 robust = sorted_vals[0]
 
-            # Final blended value: 60/40 weighted mean / robust to give
-            # the structural source weights the dominant voice while
-            # still letting the robust blend correct obvious outliers.
-            blended_value = 0.6 * weighted_mean + 0.4 * robust
+            # Final blended value: ``_BLEND_MEAN_WEIGHT`` /
+            # ``_BLEND_ROBUST_WEIGHT`` convex combination of the
+            # weighted-mean (structural) and robust-trimmed-median
+            # (outlier-resistant) aggregations.  Defaults to 70/30 so
+            # the configured source weights have the dominant voice
+            # while the robust blend still absorbs obvious outliers.
+            # The split was tuned via ``scripts/backtest_blend_params.py``
+            # against 25 daily snapshots; see the constant's doc block
+            # at definition site for the reasoning and results.
+            blended_value = (
+                _BLEND_MEAN_WEIGHT * weighted_mean
+                + _BLEND_ROBUST_WEIGHT * robust
+            )
 
             # Separation diagnostic: stdev of per-source Hill-curve values
             # before the blend.  Pairs with sourceRankPercentileSpread


### PR DESCRIPTION
## Summary
Ran a parameter sweep across 25 daily snapshots to empirically validate the blend constants. Found that bumping the weighted-mean/robust-median split from 60/40 to 70/30 produces a **4.9% improvement in rank stability** across the 25-day window — a clean peak at 0.70 with monotonic rise from 0.55.

Kept volatility floor (0.92), volatility ceil (1.08), and IDPTC weight (2.0) unchanged — the sweep showed no actionable signal for the volatility constants (all values within noise) and the IDPTC weight had a real improvement at 3.0 but at the cost of concentrating one source at ~30% of the blend, contradicting the mission to ""combine multiple sources.""

## Why bother
The blend ratio was picked by intuition, not data. P3 of the audit flagged all three tunables (blend ratio, volatility bounds, IDPTC weight) as ""undocumented fitting procedure."" This PR introduces the harness to backtest them and commits the one change the data clearly supports.

## Findings (25-snapshot sweep)

### _BLEND_MEAN_WEIGHT — clean peak at 0.70
| value | score (lower = more stable) | delta vs 0.60 |
|------:|---------------------------:|---------------:|
| 0.50 | 13.438 | +4.6% worse |
| 0.55 | 13.526 | +5.3% worse (worst) |
| **0.60** | **12.849** | **(was current)** |
| 0.65 | 12.635 | −1.7% better |
| **0.70** | **12.218** | **−4.9% better (new default)** |
| 0.75 | 12.570 | −2.2% better |

### Kept unchanged (with receipts)
- **_VOLATILITY_COMPRESSION_FLOOR (0.92)**: sweep from 0.86 to 0.96 spans just 0.8% — no signal.
- **_VOLATILITY_COMPRESSION_CEIL (1.08)**: values 1.04–1.14 are all functionally identical; current sits safely in the flat region.
- **IDPTC weight (2.0)**: 3.0 would improve stability another 5.7% but pushes IDPTC to ~30% of the blend vs ~22% at weight 2.0. The mean-weight bump implicitly amplifies IDPTC's 2.0 weight anyway, capturing some benefit without the concentration risk.

Full sweep data in `reports/backtest_blend_params_full.md`.

## Changes
- `src/api/data_contract.py`: `_BLEND_MEAN_WEIGHT` 0.6 → 0.7, `_BLEND_ROBUST_WEIGHT` 0.4 → 0.3. Doc block updated with backtest rationale.
- `scripts/backtest_blend_params.py`: NEW. Reproducible harness — loads N most-recent `dynasty_data_*.json` snapshots, sweeps each of the four tunables independently, writes a Markdown report. ~5 min runtime on 25 snapshots.
- `reports/backtest_blend_params_full.md`: frozen 2026-04-20 results.

## Test plan
- [x] `pytest tests/` — 1783 passed, 3 skipped
- [x] `npm test -- --run` — 418 passed
- [x] `npm run build` — clean
- [ ] Post-deploy smoke: check `/api/data` top-3 values unchanged in rough shape (tier cliffs may shift slightly but top 3 should remain Josh Allen / Drake Maye / Ja'Marr Chase)
- [ ] Re-run backtest next month when we have ~40 snapshots; re-verify 0.70 is still the peak

🤖 Generated with [Claude Code](https://claude.com/claude-code)