### PR TITLE
Pin KTC divergence and harden canonical single-curve invariant

### DIFF
--- a/src/canonical/calibration.py
+++ b/src/canonical/calibration.py
@@ -237,6 +237,13 @@ def calibrate_canonical_values(
     The knee can vary per universe (IDP uses a higher knee than offense).
     Picks are calibrated separately using the legacy pick value curve.
 
+    This function is for the LEGACY engine only.  The canonical 6-step
+    Hill-curve engine produces display-scaled values in a single pass
+    (see ``src/canonical/player_valuation.py``) and must not be
+    re-calibrated here — doing so would stack a second curve on top of
+    the Hill output.  Assets tagged by the canonical pipeline with
+    ``_pick_calibration_source == "canonical_pipeline"`` are rejected.
+
     Args:
         assets: List of canonical asset dicts.
         universe_scales: Optional override for per-universe max scales.
@@ -248,7 +255,26 @@ def calibrate_canonical_values(
 
     Returns:
         Same list with 'calibrated_value' added to each asset.
+
+    Raises:
+        RuntimeError: If any input asset was produced by the canonical
+            Hill-curve pipeline (would cause double-calibration).
     """
+    canonical_tagged = [
+        a for a in assets
+        if a.get("_pick_calibration_source") == "canonical_pipeline"
+    ]
+    if canonical_tagged:
+        sample = canonical_tagged[0].get("display_name", "<unknown>")
+        raise RuntimeError(
+            f"calibrate_canonical_values called on {len(canonical_tagged)} "
+            f"asset(s) already produced by the canonical Hill-curve pipeline "
+            f"(e.g. {sample!r}). The canonical engine emits display-scaled "
+            f"values in a single pass; re-calibrating them here would stack "
+            f"a second curve on top. Fix the caller to gate on the engine flag "
+            f"(see scripts/canonical_build.py::use_canonical_engine)."
+        )
+
     scales = universe_scales or UNIVERSE_SCALES
     knees = universe_knees or UNIVERSE_KNEES
     legacy_pick_lookup = _build_legacy_pick_lookup(legacy_path)

--- a/tests/canonical/test_canonical_single_curve.py
+++ b/tests/canonical/test_canonical_single_curve.py
@@ -1,0 +1,130 @@
+"""Pin the canonical engine's single-curve invariant.
+
+The canonical 6-step Hill-curve pipeline (``src/canonical/player_valuation.py``)
+produces display-scaled values in a single pass.  The legacy
+``calibration.py`` remap (percentile power curve + per-universe scales)
+is explicitly skipped for canonical output — see the
+``if not use_canonical_engine:`` gate in
+``scripts/canonical_build.py``.
+
+These tests pin that invariant from two directions:
+
+  1. **Emit side** — ``valuation_result_to_asset_dicts`` writes
+     ``blended_value == calibrated_value == display_value`` for every
+     canonical asset.  The three field names are retained for
+     downstream consumers that still read legacy keys, but they
+     reference the same Hill-curve value.
+
+  2. **Consume side** — ``calibrate_canonical_values`` raises
+     ``RuntimeError`` if called on a canonical-tagged asset, defending
+     against accidental double-calibration if the engine-flag gate is
+     ever bypassed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.canonical.calibration import calibrate_canonical_values
+from src.canonical.player_valuation import (
+    PlayerInput,
+    run_valuation,
+    valuation_result_to_asset_dicts,
+)
+
+
+def _make_canonical_assets(n: int = 20) -> list[dict]:
+    """Run the full canonical pipeline on a small synthetic roster."""
+    players = [
+        PlayerInput(
+            player_id=f"p{i:02d}",
+            display_name=f"Player {i:02d}",
+            source_ranks=[float(i), float(i), float(i + 1)],
+        )
+        for i in range(1, n + 1)
+    ]
+    result = run_valuation(players)
+    return valuation_result_to_asset_dicts(result, universe="offense_vet")
+
+
+class TestSingleCurveInvariant:
+    """Pin: canonical emit writes blended == calibrated == display."""
+
+    def test_three_value_fields_are_equal(self):
+        assets = _make_canonical_assets()
+        assert assets, "pipeline produced no assets"
+        for asset in assets:
+            blended = asset["blended_value"]
+            calibrated = asset["calibrated_value"]
+            display = asset["display_value"]
+            assert blended == calibrated == display, (
+                f"canonical asset {asset['display_name']!r} "
+                f"has diverging value fields: "
+                f"blended={blended}, calibrated={calibrated}, display={display}. "
+                f"The canonical engine is supposed to emit a single "
+                f"Hill-curve value across all three fields."
+            )
+
+    def test_every_canonical_asset_carries_pipeline_tag(self):
+        assets = _make_canonical_assets()
+        for asset in assets:
+            assert asset.get("_pick_calibration_source") == "canonical_pipeline", (
+                f"asset {asset['display_name']!r} missing canonical pipeline tag; "
+                f"the defensive guard in calibrate_canonical_values relies on "
+                f"this marker to detect canonical output."
+            )
+
+
+class TestCalibrationRejectsCanonical:
+    """Pin: calibrate_canonical_values refuses already-canonical assets."""
+
+    def test_raises_on_canonical_tagged_asset(self):
+        assets = _make_canonical_assets(n=5)
+        with pytest.raises(RuntimeError, match="canonical Hill-curve pipeline"):
+            calibrate_canonical_values(assets)
+
+    def test_raises_error_names_offending_asset(self):
+        assets = _make_canonical_assets(n=3)
+        with pytest.raises(RuntimeError) as exc_info:
+            calibrate_canonical_values(assets)
+        # Error message should reference the canonical pipeline and hint
+        # at the gate the caller should respect.
+        msg = str(exc_info.value)
+        assert "canonical" in msg.lower()
+        assert "use_canonical_engine" in msg
+
+    def test_raises_even_when_only_one_asset_is_canonical(self):
+        # Mixed input: most legacy, one canonical-tagged.  The guard must
+        # still fire — it's a defensive tripwire, not a majority vote.
+        legacy_assets = [
+            {
+                "display_name": "Legacy Player",
+                "universe": "offense_vet",
+                "blended_value": 5000,
+            },
+        ]
+        canonical_assets = _make_canonical_assets(n=1)
+        with pytest.raises(RuntimeError, match="canonical Hill-curve pipeline"):
+            calibrate_canonical_values(legacy_assets + canonical_assets)
+
+    def test_still_works_on_pure_legacy_assets(self):
+        # Sanity: non-canonical assets still calibrate normally.
+        legacy_assets = [
+            {
+                "display_name": f"Legacy Player {i}",
+                "universe": "offense_vet",
+                "blended_value": 9000 - i * 100,
+                "metadata": {"position": "WR"},
+            }
+            for i in range(10)
+        ]
+        result = calibrate_canonical_values(legacy_assets)
+        assert len(result) == 10
+        for asset in result:
+            assert "calibrated_value" in asset

--- a/tests/canonical/test_ktc_reconciliation.py
+++ b/tests/canonical/test_ktc_reconciliation.py
@@ -1,0 +1,194 @@
+"""KTC reconciliation regression tests.
+
+Pins the divergence between our canonical Hill-curve rank-to-value
+mapping and KeepTradeCut's live value curve, so that any drift in
+either direction surfaces as a test failure instead of silently shifting
+production rankings.
+
+The curves DO NOT match identically by design — KTC's proprietary curve
+is just one of several blended market sources in our consensus rank
+(see ``HILL_MIDPOINT`` / ``HILL_SLOPE`` in ``player_valuation.py``,
+fit as the mean across KTC, IDPTradeCalc, DynastyNerds, DynastyDaddy).
+What this test pins is the *size* of the divergence at key ranks.
+
+When deltas blow past the tolerance bands, either:
+  1. KTC drifted (rare — their curve is notoriously stable), or
+  2. We re-fit the Hill curve (via scripts/fit_hill_curve_from_market.py)
+     and need to re-baseline the pinned values below.
+
+The KTC fixture is the live offense-vet snapshot at
+``CSVs/site_raw/ktc.csv``.  Picks (rows like "2026 Early 1st") are
+filtered out so the rank index reflects player ordering only.
+"""
+from __future__ import annotations
+
+import csv
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.canonical.player_valuation import rank_to_value
+
+
+KTC_CSV = REPO / "CSVs" / "site_raw" / "ktc.csv"
+_PICK_PATTERN = re.compile(r"^\d{4}\s+(Early|Mid|Late)\s+\d", re.IGNORECASE)
+
+
+def _load_ktc_players_sorted() -> list[tuple[str, int]]:
+    """Return KTC player rows sorted by value descending.
+
+    Filters draft picks out so that rank 1 = top player by KTC value.
+    """
+    rows: list[tuple[str, int]] = []
+    with KTC_CSV.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = (row.get("name") or "").strip()
+            raw_value = (row.get("value") or "").strip()
+            if not name or not raw_value:
+                continue
+            if _PICK_PATTERN.match(name):
+                continue
+            try:
+                value = int(raw_value)
+            except ValueError:
+                continue
+            rows.append((name, value))
+    rows.sort(key=lambda r: -r[1])
+    return rows
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Pinned deltas — our Hill curve vs KTC at key ranks.
+#
+# Each entry: (rank, ktc_value, ours, pct_diff_ours_minus_ktc).
+# Baselined 2026-04-20 against CSVs/site_raw/ktc.csv.
+# Tolerance on pct_diff is ±2.0 percentage points.
+# ──────────────────────────────────────────────────────────────────────
+PINNED_DELTAS: list[tuple[int, int, int, float]] = [
+    # rank, ktc, ours, pct_diff
+    (1,   9998, 9999,   0.0),
+    (5,   9648, 9460,  -1.9),
+    (12,  7794, 8459,   8.5),
+    (24,  6757, 7017,   3.8),
+    (50,  5151, 4967,  -3.6),
+    (100, 3619, 3055, -15.6),
+    (150, 2834, 2157, -23.9),
+    (200, 2422, 1648, -32.0),
+    (300, 1629, 1100, -32.5),
+    (400, 1008,  815, -19.1),
+]
+
+# How far pct_diff is allowed to move before the pin fails.
+DELTA_TOLERANCE_PP = 2.0
+
+
+@pytest.fixture(scope="module")
+def ktc_players() -> list[tuple[str, int]]:
+    if not KTC_CSV.exists():
+        pytest.skip(f"KTC fixture missing at {KTC_CSV}")
+    players = _load_ktc_players_sorted()
+    if len(players) < 400:
+        pytest.skip(f"KTC fixture too small ({len(players)} players, need >= 400)")
+    return players
+
+
+class TestKTCReconciliation:
+    """Pin our Hill curve's divergence from KTC at key ranks."""
+
+    @pytest.mark.parametrize("rank,pinned_ktc,pinned_ours,pinned_pct", PINNED_DELTAS)
+    def test_rank_delta_within_tolerance(
+        self,
+        ktc_players: list[tuple[str, int]],
+        rank: int,
+        pinned_ktc: int,
+        pinned_ours: int,
+        pinned_pct: float,
+    ) -> None:
+        _, ktc_value = ktc_players[rank - 1]
+        ours = rank_to_value(rank)
+
+        # Pin our curve exactly — any change to HILL_MIDPOINT/HILL_SLOPE
+        # is intentional and should require re-baselining this test.
+        assert ours == pinned_ours, (
+            f"Our Hill curve at rank {rank} changed: {pinned_ours} -> {ours}. "
+            f"Re-baseline PINNED_DELTAS if this was intentional "
+            f"(e.g. re-fit via scripts/fit_hill_curve_from_market.py)."
+        )
+
+        # KTC's curve can drift with their live scrape.  Allow the KTC
+        # side to wiggle but keep the divergence within band.
+        actual_pct = 100.0 * (ours - ktc_value) / ktc_value
+        assert abs(actual_pct - pinned_pct) <= DELTA_TOLERANCE_PP, (
+            f"Divergence from KTC at rank {rank} drifted: "
+            f"pinned {pinned_pct:+.1f}% vs actual {actual_pct:+.1f}% "
+            f"(KTC={ktc_value}, ours={ours}). "
+            f"Investigate whether KTC shifted or our curve needs re-fitting."
+        )
+
+
+class TestKTCCurveShapeInvariants:
+    """Pin the qualitative shape of the KTC/ours divergence.
+
+    These invariants describe *how* our curve differs from KTC and are
+    independent of the specific pinned numbers above.  They should hold
+    until the Hill curve is re-fit.
+    """
+
+    def test_rank_one_matches_by_construction(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Both curves anchor at ~9999 at rank 1.
+        _, ktc_top = ktc_players[0]
+        ours_top = rank_to_value(1)
+        assert abs(ours_top - ktc_top) <= 5
+
+    def test_midrange_is_higher_than_ktc(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Ranks 10-15 — our curve sits above KTC (their curve dips faster
+        # through the early top-12).
+        for rank in range(10, 16):
+            _, ktc = ktc_players[rank - 1]
+            ours = rank_to_value(rank)
+            assert ours > ktc, (
+                f"Expected our curve above KTC at rank {rank}, "
+                f"got ours={ours}, ktc={ktc}"
+            )
+
+    def test_tail_is_compressed_vs_ktc(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Past rank 100, our Hill curve compresses more aggressively than
+        # KTC's — this is the primary known divergence and should remain
+        # visible until the curve is re-fit.
+        for rank in (100, 150, 200, 300):
+            _, ktc = ktc_players[rank - 1]
+            ours = rank_to_value(rank)
+            assert ours < ktc, (
+                f"Expected our curve below KTC at rank {rank}, "
+                f"got ours={ours}, ktc={ktc}"
+            )
+
+    def test_aggregate_tail_gap_is_material(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Sanity: the average tail divergence (ranks 100-300) should be
+        # at least 15% below KTC.  If this collapses, either KTC changed
+        # shape or we re-fit the curve — either way, re-baseline the test.
+        deltas: list[float] = []
+        for rank in range(100, 301, 25):
+            _, ktc = ktc_players[rank - 1]
+            ours = rank_to_value(rank)
+            deltas.append(100.0 * (ours - ktc) / ktc)
+        avg = sum(deltas) / len(deltas)
+        assert avg <= -15.0, (
+            f"Tail divergence collapsed: avg pct diff = {avg:+.1f}% "
+            f"(expected <= -15%). Re-baseline if curve was re-fit."
+        )


### PR DESCRIPTION
## Summary

Partial fix for two of the four mathematical-soundness red flags flagged during the value-accuracy review. Scoped so production values do not change.

### Red flag #3 — no KTC reconciliation test (FIXED)

`tests/canonical/test_ktc_reconciliation.py` loads the live KTC snapshot from `CSVs/site_raw/ktc.csv`, sorts players by value, and pins our Hill curve's divergence at ranks 1/5/12/24/50/100/150/200/300/400.

Current baseline (2026-04-20):

| Rank | KTC | Ours | %Δ |
|---:|---:|---:|---:|
| 1 | 9998 | 9999 | 0.0% |
| 12 | 7794 | 8459 | +8.5% |
| 50 | 5151 | 4967 | −3.6% |
| 100 | 3619 | 3055 | **−15.6%** |
| 200 | 2422 | 1648 | **−32.0%** |
| 400 | 1008 | 815 | −19.1% |

Tolerance ±2 pp on each pin. Curve-shape invariants also pinned: rank 1 matches by construction; we sit above KTC in the early mid-top; tail past rank 100 is compressed well below KTC until the curve is intentionally re-fit.

### Red flag #2 — two-curve architecture (HARDENED)

Verified the canonical Hill engine already bypasses `calibration.py` via the `if not use_canonical_engine:` gate in `scripts/canonical_build.py`, and `valuation_result_to_asset_dicts` emits `blended_value == calibrated_value == display_value`. The bypass was a single fragile boolean — now defended two ways:

- `calibrate_canonical_values` raises `RuntimeError` if handed any asset tagged `_pick_calibration_source == "canonical_pipeline"`, preventing silent double-calibration if the gate is ever bypassed.
- `tests/canonical/test_canonical_single_curve.py` pins both sides: canonical emit equality, and the guard rejecting canonical input while still accepting pure legacy assets.

### Not included

- Red flag #1 (tier cliffs + volatility adjustments excluded from `display_value`) — this is deliberate per `player_valuation.py:547-550` and is a product decision, not a bug. Changing it would shift every user-facing value and require re-fitting the Hill constants.
- Red flag #4 (joint hyperparameter optimization) — research effort, separate session.

## Test plan

- [x] `python3 -m pytest tests/canonical/ -q` → 243 passed
- [x] New tests fail loudly when `HILL_MIDPOINT` / `HILL_SLOPE` are mutated
- [x] New guard fires on canonical-tagged input; pure legacy assets still calibrate
- [x] No production value changes — legacy engine path untouched
- [ ] Re-baseline `PINNED_DELTAS` when Hill curve is intentionally re-fit via `scripts/fit_hill_curve_from_market.py`

https://claude.ai/code/session_011hat7VDYqxbR6DKNGKtdKH