### PR TITLE
Pipeline audit P5: KTC reconciliation + single-curve guard + IDP anchors

### DIFF
--- a/src/canonical/calibration.py
+++ b/src/canonical/calibration.py
@@ -237,6 +237,13 @@ def calibrate_canonical_values(
     The knee can vary per universe (IDP uses a higher knee than offense).
     Picks are calibrated separately using the legacy pick value curve.
 
+    This function is for the LEGACY engine only.  The canonical 6-step
+    Hill-curve engine produces display-scaled values in a single pass
+    (see ``src/canonical/player_valuation.py``) and must not be
+    re-calibrated here — doing so would stack a second curve on top of
+    the Hill output.  Assets tagged by the canonical pipeline with
+    ``_pick_calibration_source == "canonical_pipeline"`` are rejected.
+
     Args:
         assets: List of canonical asset dicts.
         universe_scales: Optional override for per-universe max scales.
@@ -248,7 +255,26 @@ def calibrate_canonical_values(
 
     Returns:
         Same list with 'calibrated_value' added to each asset.
+
+    Raises:
+        RuntimeError: If any input asset was produced by the canonical
+            Hill-curve pipeline (would cause double-calibration).
     """
+    canonical_tagged = [
+        a for a in assets
+        if a.get("_pick_calibration_source") == "canonical_pipeline"
+    ]
+    if canonical_tagged:
+        sample = canonical_tagged[0].get("display_name", "<unknown>")
+        raise RuntimeError(
+            f"calibrate_canonical_values called on {len(canonical_tagged)} "
+            f"asset(s) already produced by the canonical Hill-curve pipeline "
+            f"(e.g. {sample!r}). The canonical engine emits display-scaled "
+            f"values in a single pass; re-calibrating them here would stack "
+            f"a second curve on top. Fix the caller to gate on the engine flag "
+            f"(see scripts/canonical_build.py::use_canonical_engine)."
+        )
+
     scales = universe_scales or UNIVERSE_SCALES
     knees = universe_knees or UNIVERSE_KNEES
     legacy_pick_lookup = _build_legacy_pick_lookup(legacy_path)

--- a/tests/api/test_pick_refinement.py
+++ b/tests/api/test_pick_refinement.py
@@ -312,6 +312,7 @@ class TestPlayerRankingsUnchanged(unittest.TestCase):
     """
 
     _ANCHORS: dict[str, dict[str, Any]] = {
+        # ── Offense anchors ──
         "Josh Allen":       {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
         "Drake Maye":       {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
         "Ja'Marr Chase":    {"max_rank": 15, "min_value": 7000, "allowed_buckets": ("high",)},
@@ -322,6 +323,20 @@ class TestPlayerRankingsUnchanged(unittest.TestCase):
         "Malik Nabers":     {"max_rank": 30, "min_value": 5000, "allowed_buckets": ("high", "medium")},
         "Brock Bowers":     {"max_rank": 40, "min_value": 5000, "allowed_buckets": ("high", "medium")},
         "Patrick Mahomes":  {"max_rank": 50, "min_value": 4000, "allowed_buckets": ("high", "medium")},
+        # ── IDP anchors ──
+        # IDP rows sit deeper in the unified board (smaller pool, later
+        # calibration) and their confidence buckets lean "low" because
+        # the IDP source pool is narrower.  Bands are proportionally
+        # more generous to absorb normal drift.  A regression that
+        # collapses IDP value pricing (e.g. a calibration bug, shared-
+        # market ladder breakage, IDPTC backbone failure) will trip
+        # these.
+        "Myles Garrett":    {"max_rank": 90,  "min_value": 3500, "allowed_buckets": ("low", "medium", "high")},
+        "Will Anderson":    {"max_rank": 90,  "min_value": 3500, "allowed_buckets": ("low", "medium", "high")},
+        "Micah Parsons":    {"max_rank": 90,  "min_value": 3500, "allowed_buckets": ("low", "medium", "high")},
+        "Fred Warner":      {"max_rank": 90,  "min_value": 3200, "allowed_buckets": ("low", "medium", "high")},
+        "Roquan Smith":     {"max_rank": 100, "min_value": 3000, "allowed_buckets": ("low", "medium", "high")},
+        "Kyle Hamilton":    {"max_rank": 180, "min_value": 2200, "allowed_buckets": ("low", "medium", "high")},
     }
 
     def setUp(self) -> None:

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -1,0 +1,376 @@
+"""Single-curve invariants on the live rankings pipeline.
+
+Pins the structural claim that the live path
+(``src/api/data_contract.py::_compute_unified_rankings``) applies
+exactly one Hill curve, at most one calibration multiplier, and at
+most one volatility adjustment to produce ``rankDerivedValue``.  No
+hidden second curve, no accidental double-calibration, no mystery
+remap.
+
+The chain, as documented in the audit dated 2026-04-20:
+
+    rankDerivedValueUncalibrated  (snapshot after Hill blend + TEP)
+        × (idpCalibrationMultiplier × idpFamilyScale)   (IDP rows only)
+        = preVolatilityValue
+        × (1 − volatilityCompressionApplied)            (compression z>0)
+        OR
+        min(preVolatilityValue × (1 + |vol|),           (boost z<0,
+            monotonicity_cap, _DISPLAY_SCALE_MAX)       clamped)
+        = rankDerivedValue
+
+If a second curve is ever reintroduced (e.g. offense calibration
+re-enabled without the right gate, a new post-pass remap added),
+the identities below will break and this test will fail loudly.
+
+These tests are invariant-band style (PR #154): they assert the
+structural chain holds for today's snapshot, not specific values.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from src.api.data_contract import (
+    _DISPLAY_SCALE_MAX,
+    _VOLATILITY_COMPRESSION_CEIL,
+    _VOLATILITY_COMPRESSION_FLOOR,
+    build_api_data_contract,
+)
+
+
+_REPO = Path(__file__).resolve().parents[2]
+_IDP_POSITIONS = {"DL", "LB", "DB"}
+_OFFENSE_POSITIONS = {"QB", "RB", "WR", "TE"}
+
+
+def _load_contract() -> dict[str, Any] | None:
+    data_dir = _REPO / "exports" / "latest"
+    json_files = sorted(data_dir.glob("dynasty_data_*.json"), reverse=True)
+    if not json_files:
+        return None
+    with json_files[0].open() as f:
+        raw = json.load(f)
+    return build_api_data_contract(raw)
+
+
+_CACHED: dict[str, Any] | None = None
+
+
+def _get() -> dict[str, Any] | None:
+    global _CACHED
+    if _CACHED is None:
+        _CACHED = _load_contract()
+    return _CACHED
+
+
+def _ranked_rows(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        r
+        for r in contract.get("playersArray") or []
+        if r.get("canonicalConsensusRank") and r.get("assetClass") != "pick"
+    ]
+
+
+class TestOffenseHasNoCalibrationLayer(unittest.TestCase):
+    """Live offense rows must NOT carry IDP-calibration fields.
+
+    ``_apply_offense_calibration_post_pass`` is intentionally commented
+    out at ``src/api/data_contract.py::_compute_unified_rankings``
+    (~line 5021).  Re-enabling it without a new invariant test would
+    silently restack a second curve on top of the Hill blend.  This
+    test exists to catch that regression.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+
+    def test_offense_rows_have_no_offense_calibration_multiplier(self) -> None:
+        offending: list[str] = []
+        for row in _ranked_rows(self.contract):
+            pos = str(row.get("position") or "").upper()
+            if pos not in _OFFENSE_POSITIONS:
+                continue
+            if "offenseCalibrationMultiplier" in row:
+                offending.append(
+                    f"{row.get('canonicalName')}: "
+                    f"{row['offenseCalibrationMultiplier']}"
+                )
+        self.assertFalse(
+            offending,
+            "Offense rows carry offenseCalibrationMultiplier — "
+            "_apply_offense_calibration_post_pass was re-enabled without "
+            "an accompanying invariant. If intentional, add a test pinning "
+            "the offense chain, then delete this assertion. Offenders: "
+            f"{offending[:5]}",
+        )
+
+
+class TestPreVolatilityChain(unittest.TestCase):
+    """``preVolatilityValue`` must equal the one-time calibration fold.
+
+    For offense rows (no live calibration): preVolatilityValue
+    should equal rankDerivedValueUncalibrated exactly.
+
+    For IDP rows: preVolatilityValue should equal
+    rankDerivedValueUncalibrated × idpCalibrationMultiplier ×
+    idpFamilyScale.  Because ``get_idp_bucket_multiplier`` already
+    folds family_scale into the bucket product, the live code
+    multiplies by the combined factor EXACTLY ONCE.  If someone
+    accidentally multiplies again, this test catches it.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+        self.rows = _ranked_rows(self.contract)
+
+    def test_offense_pre_vol_equals_uncalibrated(self) -> None:
+        checked = 0
+        for row in self.rows:
+            pos = str(row.get("position") or "").upper()
+            if pos not in _OFFENSE_POSITIONS:
+                continue
+            pre_vol = row.get("preVolatilityValue")
+            uncal = row.get("rankDerivedValueUncalibrated")
+            if pre_vol is None or uncal is None:
+                continue
+            self.assertEqual(
+                int(pre_vol),
+                int(uncal),
+                f"{row.get('canonicalName')} offense row has "
+                f"preVolatilityValue={pre_vol} != "
+                f"rankDerivedValueUncalibrated={uncal}. "
+                f"Either offense calibration was re-enabled or a new "
+                f"mystery multiplier was inserted between Hill blend "
+                f"and volatility pass.",
+            )
+            checked += 1
+        self.assertGreater(checked, 50, "expected many offense anchors")
+
+    def test_idp_pre_vol_chain(self) -> None:
+        """IDP pre-volatility chain.
+
+        When calibration is ACTIVE (multiplier + family_scale fields
+        stamped on the row), preVolatilityValue must equal
+        uncalibrated × (bucket × family_scale), applied exactly once.
+
+        When calibration is NEUTRAL (fields absent — the default test
+        env, see ``tests/conftest.py``), preVolatilityValue must equal
+        uncalibrated exactly, same as offense.
+
+        The deeper invariant — family_scale folded-once under an
+        active promoted config — is exercised separately in
+        ``tests/idp_calibration/test_family_scale_once_only.py``.
+        """
+        checked = 0
+        calibrated = 0
+        neutral = 0
+        for row in self.rows:
+            pos = str(row.get("position") or "").upper()
+            if pos not in _IDP_POSITIONS:
+                continue
+            pre_vol = row.get("preVolatilityValue")
+            uncal = row.get("rankDerivedValueUncalibrated")
+            if pre_vol is None or uncal is None:
+                continue
+            bucket = row.get("idpCalibrationMultiplier")
+            family = row.get("idpFamilyScale")
+            if bucket is not None and family is not None:
+                expected = int(round(float(uncal) * float(bucket) * float(family)))
+                self.assertLessEqual(
+                    abs(int(pre_vol) - expected),
+                    2,
+                    f"{row.get('canonicalName')} IDP row (calibrated): "
+                    f"preVolatilityValue={pre_vol} "
+                    f"!= round(uncal={uncal} × bucket={bucket} × "
+                    f"family={family}) = {expected}. "
+                    f"family_scale may have been double-applied, or a "
+                    f"new IDP multiplier was introduced.",
+                )
+                calibrated += 1
+            else:
+                self.assertEqual(
+                    int(pre_vol),
+                    int(uncal),
+                    f"{row.get('canonicalName')} IDP row (no "
+                    f"calibration): preVolatilityValue={pre_vol} != "
+                    f"rankDerivedValueUncalibrated={uncal}. A new IDP "
+                    f"post-pass was added between Hill blend and "
+                    f"volatility.",
+                )
+                neutral += 1
+            checked += 1
+        self.assertGreater(checked, 30, "expected many IDP anchors")
+
+
+class TestVolatilityChain(unittest.TestCase):
+    """``rankDerivedValue`` must equal ``preVolatilityValue`` ± volatility.
+
+    For compression (``volatilityCompressionApplied > 0``):
+        rankDerivedValue ≈ preVolatilityValue × (1 − vol)
+    (exact to within rounding; compression is not capped, so the
+    identity is strict.)
+
+    For boost (``volatilityCompressionApplied < 0``):
+        rankDerivedValue ≤ preVolatilityValue × (1 + |vol|) + 1
+    AND rankDerivedValue ≤ _DISPLAY_SCALE_MAX
+    (the monotonicity cap plus the 9999 ceiling can clamp boosts below
+    the natural boosted value).
+
+    For unadjusted (``volatilityCompressionApplied is None``):
+        rankDerivedValue == preVolatilityValue exactly.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+        self.rows = _ranked_rows(self.contract)
+
+    def test_compression_matches_identity(self) -> None:
+        checked = 0
+        for row in self.rows:
+            vol = row.get("volatilityCompressionApplied")
+            pre_vol = row.get("preVolatilityValue")
+            final = row.get("rankDerivedValue")
+            if vol is None or pre_vol is None or final is None:
+                continue
+            if vol <= 0:
+                continue  # compression branch only
+            expected = int(round(float(pre_vol) * (1.0 - float(vol))))
+            self.assertLessEqual(
+                abs(int(final) - expected),
+                1,
+                f"{row.get('canonicalName')} compression chain broken: "
+                f"preVol={pre_vol} × (1 − {vol}) = {expected}, "
+                f"got rankDerivedValue={final}. A new post-pass may be "
+                f"mutating the value after volatility compression.",
+            )
+            checked += 1
+        self.assertGreater(
+            checked, 20, "expected many compressed rows in the live board"
+        )
+
+    def test_boost_respects_cap_and_ceiling(self) -> None:
+        checked = 0
+        for row in self.rows:
+            vol = row.get("volatilityCompressionApplied")
+            pre_vol = row.get("preVolatilityValue")
+            final = row.get("rankDerivedValue")
+            if vol is None or pre_vol is None or final is None:
+                continue
+            if vol >= 0:
+                continue  # boost branch only
+            natural_boost = int(round(float(pre_vol) * (1.0 + abs(float(vol)))))
+            # Boost may be capped by monotonicity; final must not
+            # EXCEED the natural boost (allowing +1 for rounding).
+            self.assertLessEqual(
+                int(final),
+                natural_boost + 1,
+                f"{row.get('canonicalName')} boost exceeded natural "
+                f"ceiling: pre={pre_vol}, vol={vol}, "
+                f"natural_boost={natural_boost}, final={final}. "
+                f"The volatility pass should never produce a value "
+                f"above the natural boost.",
+            )
+            self.assertLessEqual(
+                int(final),
+                _DISPLAY_SCALE_MAX,
+                f"{row.get('canonicalName')} post-boost value {final} "
+                f"exceeds display scale {_DISPLAY_SCALE_MAX}",
+            )
+            checked += 1
+        self.assertGreater(checked, 10, "expected many boosted rows")
+
+    def test_unadjusted_rows_pass_through(self) -> None:
+        checked = 0
+        for row in self.rows:
+            vol = row.get("volatilityCompressionApplied")
+            pre_vol = row.get("preVolatilityValue")
+            final = row.get("rankDerivedValue")
+            if vol is not None:
+                continue  # only unadjusted rows
+            if pre_vol is None or final is None:
+                continue
+            self.assertEqual(
+                int(final),
+                int(pre_vol),
+                f"{row.get('canonicalName')} has vol=None but "
+                f"preVolatilityValue={pre_vol} != rankDerivedValue={final}. "
+                f"The volatility pass should be a strict no-op when "
+                f"its applied fraction is None.",
+            )
+            checked += 1
+
+    def test_volatility_fraction_stays_in_bounds(self) -> None:
+        """``volatilityCompressionApplied`` must stay within the bounds
+        derived from FLOOR/CEIL constants.  A value outside this range
+        would indicate the bounds constants drifted or the strength
+        clamp broke.
+        """
+        max_compress = 1.0 - _VOLATILITY_COMPRESSION_FLOOR
+        max_boost = _VOLATILITY_COMPRESSION_CEIL - 1.0
+        for row in self.rows:
+            vol = row.get("volatilityCompressionApplied")
+            if vol is None:
+                continue
+            name = row.get("canonicalName")
+            self.assertLessEqual(
+                float(vol),
+                max_compress + 1e-9,
+                f"{name}: compression {vol} exceeds floor-derived "
+                f"max {max_compress}",
+            )
+            self.assertGreaterEqual(
+                float(vol),
+                -max_boost - 1e-9,
+                f"{name}: boost {vol} exceeds ceil-derived "
+                f"max {max_boost}",
+            )
+
+
+class TestNoSecondHillCurve(unittest.TestCase):
+    """No live row can carry values consistent with a second Hill remap.
+
+    A second Hill application after calibration would collapse the
+    dynamic range (two compound S-curves stack into something much
+    flatter).  We sanity-check that top-of-board values are spread
+    widely enough to be inconsistent with a hidden second curve.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+        self.rows = _ranked_rows(self.contract)
+
+    def test_top_50_value_range_is_wide(self) -> None:
+        offense = sorted(
+            (
+                r
+                for r in self.rows
+                if str(r.get("position") or "").upper() in _OFFENSE_POSITIONS
+            ),
+            key=lambda r: int(r["canonicalConsensusRank"]),
+        )[:50]
+        if len(offense) < 50:
+            self.skipTest("fewer than 50 offense rows ranked")
+        top = int(offense[0]["rankDerivedValue"])
+        bottom = int(offense[-1]["rankDerivedValue"])
+        spread = top - bottom
+        # Single Hill curve with our constants: rank 1 ≈ 9999,
+        # rank 50 ≈ 5000.  A second curve would compress this below
+        # ~3000.  2500 is a forgiving floor — a real second-curve
+        # regression would drop it far below that.
+        self.assertGreater(
+            spread,
+            2500,
+            f"Top-50 offense value spread collapsed to {spread} "
+            f"({top}..{bottom}). A second Hill remap may have been "
+            f"introduced; investigate calibration / volatility passes.",
+        )

--- a/tests/canonical/test_canonical_single_curve.py
+++ b/tests/canonical/test_canonical_single_curve.py
@@ -1,0 +1,129 @@
+"""Pin the canonical engine's single-curve invariant.
+
+The canonical 6-step Hill-curve pipeline (``src/canonical/player_valuation.py``)
+produces display-scaled values in a single pass.  The legacy
+``calibration.py`` remap (percentile power curve + per-universe scales)
+is explicitly skipped for canonical output — see the
+``if not use_canonical_engine:`` gate in
+``scripts/canonical_build.py``.
+
+These tests pin that invariant from two directions:
+
+  1. **Emit side** — ``valuation_result_to_asset_dicts`` writes
+     ``blended_value == calibrated_value == display_value`` for every
+     canonical asset.  The three field names are retained for
+     downstream consumers that still read legacy keys, but they
+     reference the same Hill-curve value.
+
+  2. **Consume side** — ``calibrate_canonical_values`` raises
+     ``RuntimeError`` if called on a canonical-tagged asset, defending
+     against accidental double-calibration if the engine-flag gate is
+     ever bypassed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.canonical.calibration import calibrate_canonical_values
+from src.canonical.player_valuation import (
+    PlayerInput,
+    run_valuation,
+    valuation_result_to_asset_dicts,
+)
+
+
+def _make_canonical_assets(n: int = 20) -> list[dict]:
+    """Run the full canonical pipeline on a small synthetic roster."""
+    players = [
+        PlayerInput(
+            player_id=f"p{i:02d}",
+            display_name=f"Player {i:02d}",
+            source_ranks=[float(i), float(i), float(i + 1)],
+        )
+        for i in range(1, n + 1)
+    ]
+    result = run_valuation(players)
+    return valuation_result_to_asset_dicts(result, universe="offense_vet")
+
+
+class TestSingleCurveInvariant:
+    """Pin: canonical emit writes blended == calibrated == display."""
+
+    def test_three_value_fields_are_equal(self):
+        assets = _make_canonical_assets()
+        assert assets, "pipeline produced no assets"
+        for asset in assets:
+            blended = asset["blended_value"]
+            calibrated = asset["calibrated_value"]
+            display = asset["display_value"]
+            assert blended == calibrated == display, (
+                f"canonical asset {asset['display_name']!r} "
+                f"has diverging value fields: "
+                f"blended={blended}, calibrated={calibrated}, display={display}. "
+                f"The canonical engine is supposed to emit a single "
+                f"Hill-curve value across all three fields."
+            )
+
+    def test_every_canonical_asset_carries_pipeline_tag(self):
+        assets = _make_canonical_assets()
+        for asset in assets:
+            assert asset.get("_pick_calibration_source") == "canonical_pipeline", (
+                f"asset {asset['display_name']!r} missing canonical pipeline tag; "
+                f"the defensive guard in calibrate_canonical_values relies on "
+                f"this marker to detect canonical output."
+            )
+
+
+class TestCalibrationRejectsCanonical:
+    """Pin: calibrate_canonical_values refuses already-canonical assets."""
+
+    def test_raises_on_canonical_tagged_asset(self):
+        assets = _make_canonical_assets(n=5)
+        with pytest.raises(RuntimeError, match="canonical Hill-curve pipeline"):
+            calibrate_canonical_values(assets)
+
+    def test_raises_error_names_offending_asset(self):
+        assets = _make_canonical_assets(n=3)
+        with pytest.raises(RuntimeError) as exc_info:
+            calibrate_canonical_values(assets)
+        msg = str(exc_info.value)
+        assert "canonical" in msg.lower()
+        assert "use_canonical_engine" in msg
+
+    def test_raises_even_when_only_one_asset_is_canonical(self):
+        # Mixed input: most legacy, one canonical-tagged.  The guard
+        # must still fire — it's a defensive tripwire, not a majority
+        # vote.
+        legacy_assets = [
+            {
+                "display_name": "Legacy Player",
+                "universe": "offense_vet",
+                "blended_value": 5000,
+            },
+        ]
+        canonical_assets = _make_canonical_assets(n=1)
+        with pytest.raises(RuntimeError, match="canonical Hill-curve pipeline"):
+            calibrate_canonical_values(legacy_assets + canonical_assets)
+
+    def test_still_works_on_pure_legacy_assets(self):
+        # Sanity: non-canonical assets still calibrate normally.
+        legacy_assets = [
+            {
+                "display_name": f"Legacy Player {i}",
+                "universe": "offense_vet",
+                "blended_value": 9000 - i * 100,
+                "metadata": {"position": "WR"},
+            }
+            for i in range(10)
+        ]
+        result = calibrate_canonical_values(legacy_assets)
+        assert len(result) == 10
+        for asset in result:
+            assert "calibrated_value" in asset

--- a/tests/canonical/test_ktc_reconciliation.py
+++ b/tests/canonical/test_ktc_reconciliation.py
@@ -1,0 +1,209 @@
+"""KTC reconciliation regression tests.
+
+Pins the divergence between our canonical Hill-curve rank-to-value
+mapping and KeepTradeCut's live value curve, so that any drift in
+either direction surfaces as a test failure instead of silently shifting
+production rankings.
+
+The curves DO NOT match identically by design — KTC's proprietary curve
+is just one of several blended market sources in our consensus rank
+(see ``HILL_MIDPOINT`` / ``HILL_SLOPE`` in ``player_valuation.py``,
+fit as the mean across KTC, IDPTradeCalc, DynastyNerds, DynastyDaddy).
+What this test pins is the *size* of the divergence at key ranks, using
+invariant tolerance bands rather than exact pins so normal daily KTC
+scrape drift does not break CI — the same philosophy as PR #154 applied
+to anchor player values.
+
+When the pinned pct_diff band fails, either:
+  1. KTC drifted beyond band (rare — their curve is notoriously stable), or
+  2. We re-fit the Hill curve (via scripts/fit_hill_curve_from_market.py)
+     and need to re-baseline the pinned values below.
+
+The KTC fixture is the live offense-vet snapshot at
+``CSVs/site_raw/ktc.csv``.  Picks (rows like "2026 Early 1st") are
+filtered out so the rank index reflects player ordering only.
+"""
+from __future__ import annotations
+
+import csv
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.canonical.player_valuation import rank_to_value
+
+
+KTC_CSV = REPO / "CSVs" / "site_raw" / "ktc.csv"
+_PICK_PATTERN = re.compile(r"^\d{4}\s+(Early|Mid|Late)\s+\d", re.IGNORECASE)
+
+
+def _load_ktc_players_sorted() -> list[tuple[str, int]]:
+    """Return KTC player rows sorted by value descending.
+
+    Filters draft picks out so that rank 1 = top player by KTC value.
+    """
+    rows: list[tuple[str, int]] = []
+    with KTC_CSV.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = (row.get("name") or "").strip()
+            raw_value = (row.get("value") or "").strip()
+            if not name or not raw_value:
+                continue
+            if _PICK_PATTERN.match(name):
+                continue
+            try:
+                value = int(raw_value)
+            except ValueError:
+                continue
+            rows.append((name, value))
+    rows.sort(key=lambda r: -r[1])
+    return rows
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Pinned deltas — our Hill curve vs KTC at key ranks.
+#
+# Each entry: (rank, ours_expected, pct_diff_band_center).
+# Baselined 2026-04-20 against CSVs/site_raw/ktc.csv.
+#
+# ``ours_expected`` is the exact integer ``rank_to_value(rank)`` output.
+# Because ``rank_to_value`` is pure and deterministic in the Hill
+# constants, changing it is a deliberate act and must re-baseline here.
+#
+# ``pct_diff_band_center`` is the expected (ours − ktc) / ktc × 100
+# at that rank.  Tolerance ``DELTA_TOLERANCE_PP`` is applied symmetrically
+# around the band center — wide enough (±5pp) to absorb ordinary daily
+# KTC scrape drift, narrow enough to catch a real curve shape change.
+# ──────────────────────────────────────────────────────────────────────
+PINNED_DELTAS: list[tuple[int, int, float]] = [
+    # rank, ours (exact), pct_diff band center
+    (1,   9999,   0.0),
+    (5,   9460,  -1.8),
+    (12,  8459,   8.4),
+    (24,  7017,   3.8),
+    (50,  4967,  -3.6),
+    (100, 3055, -15.4),
+    (150, 2157, -24.0),
+    (200, 1648, -31.9),
+    (300, 1100, -32.5),
+    (400,  815, -19.2),
+]
+
+# Tolerance band around pinned pct_diff, in absolute percentage points.
+# ±5pp is wide enough to absorb normal daily KTC scrape drift (their
+# daily changes typically sit well under ±2pp at most ranks) while
+# still tight enough to catch a real curve-shape regression.
+DELTA_TOLERANCE_PP = 5.0
+
+
+@pytest.fixture(scope="module")
+def ktc_players() -> list[tuple[str, int]]:
+    if not KTC_CSV.exists():
+        pytest.skip(f"KTC fixture missing at {KTC_CSV}")
+    players = _load_ktc_players_sorted()
+    if len(players) < 400:
+        pytest.skip(f"KTC fixture too small ({len(players)} players, need >= 400)")
+    return players
+
+
+class TestKTCReconciliation:
+    """Pin our Hill curve's divergence from KTC at key ranks."""
+
+    @pytest.mark.parametrize("rank,pinned_ours,pinned_pct", PINNED_DELTAS)
+    def test_rank_delta_within_tolerance(
+        self,
+        ktc_players: list[tuple[str, int]],
+        rank: int,
+        pinned_ours: int,
+        pinned_pct: float,
+    ) -> None:
+        _, ktc_value = ktc_players[rank - 1]
+        ours = rank_to_value(rank)
+
+        # Our curve is deterministic — any change to HILL_MIDPOINT/
+        # HILL_SLOPE is intentional and should require re-baselining
+        # this test.  Pin exactly.
+        assert ours == pinned_ours, (
+            f"Our Hill curve at rank {rank} changed: {pinned_ours} -> {ours}. "
+            f"Re-baseline PINNED_DELTAS if this was intentional "
+            f"(e.g. re-fit via scripts/fit_hill_curve_from_market.py)."
+        )
+
+        # KTC's curve wiggles with their daily scrape.  Keep the
+        # divergence within ±DELTA_TOLERANCE_PP of the pinned center.
+        actual_pct = 100.0 * (ours - ktc_value) / ktc_value
+        assert abs(actual_pct - pinned_pct) <= DELTA_TOLERANCE_PP, (
+            f"Divergence from KTC at rank {rank} drifted: "
+            f"pinned {pinned_pct:+.1f}% vs actual {actual_pct:+.1f}% "
+            f"(KTC={ktc_value}, ours={ours}, band ±{DELTA_TOLERANCE_PP:.1f}pp). "
+            f"Investigate whether KTC shifted or our curve needs re-fitting."
+        )
+
+
+class TestKTCCurveShapeInvariants:
+    """Pin the qualitative shape of the KTC/ours divergence.
+
+    These invariants describe *how* our curve differs from KTC and are
+    independent of the specific pinned numbers above.  They should hold
+    until the Hill curve is re-fit.
+    """
+
+    def test_rank_one_matches_by_construction(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Both curves anchor at ~9999 at rank 1.
+        _, ktc_top = ktc_players[0]
+        ours_top = rank_to_value(1)
+        assert abs(ours_top - ktc_top) <= 5
+
+    def test_midrange_is_higher_than_ktc(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Ranks 10-15 — our curve sits above KTC (their curve dips
+        # faster through the early top-12).
+        for rank in range(10, 16):
+            _, ktc = ktc_players[rank - 1]
+            ours = rank_to_value(rank)
+            assert ours > ktc, (
+                f"Expected our curve above KTC at rank {rank}, "
+                f"got ours={ours}, ktc={ktc}"
+            )
+
+    def test_tail_is_compressed_vs_ktc(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Past rank 100, our Hill curve compresses more aggressively
+        # than KTC's — this is the primary known divergence and should
+        # remain visible until the curve is re-fit.
+        for rank in (100, 150, 200, 300):
+            _, ktc = ktc_players[rank - 1]
+            ours = rank_to_value(rank)
+            assert ours < ktc, (
+                f"Expected our curve below KTC at rank {rank}, "
+                f"got ours={ours}, ktc={ktc}"
+            )
+
+    def test_aggregate_tail_gap_is_material(
+        self, ktc_players: list[tuple[str, int]]
+    ) -> None:
+        # Sanity: the average tail divergence (ranks 100-300) should
+        # be at least 15% below KTC.  If this collapses, either KTC
+        # changed shape or we re-fit the curve — either way,
+        # re-baseline the test.
+        deltas: list[float] = []
+        for rank in range(100, 301, 25):
+            _, ktc = ktc_players[rank - 1]
+            ours = rank_to_value(rank)
+            deltas.append(100.0 * (ours - ktc) / ktc)
+        avg = sum(deltas) / len(deltas)
+        assert avg <= -15.0, (
+            f"Tail divergence collapsed: avg pct diff = {avg:+.1f}% "
+            f"(expected <= -15%). Re-baseline if curve was re-fit."
+        )

--- a/tests/idp_calibration/test_family_scale_once_only.py
+++ b/tests/idp_calibration/test_family_scale_once_only.py
@@ -1,0 +1,190 @@
+"""Pin: IDP ``family_scale`` is folded into ``rankDerivedValue`` exactly once.
+
+Audit concern R-V6 (see audit dated 2026-04-20): a prior review pass
+believed ``family_scale`` was dead code and was about to multiply it a
+second time in ``_apply_idp_calibration_post_pass``, which would have
+stacked (family × family) on top of each IDP value (≈1.58× at the
+current 1.2571 scale).  The current code is correct — ``family_scale``
+is pre-folded into the return of
+``production.get_idp_bucket_multiplier`` at
+``src/idp_calibration/production.py`` — and a load-bearing comment at
+``src/api/data_contract.py:3186-3195`` defends against future cleanup
+that would reintroduce the bug.
+
+This test makes the invariant executable: with an explicit promoted
+config (family_scale=1.3, DL bucket=0.5), the live pipeline must
+produce ``preVolatilityValue ≈ rankDerivedValueUncalibrated × 0.5 × 1.3``
+for DL rows — a single combined multiplication, NOT a double one.
+
+If anyone re-introduces a second application of ``family_scale`` in
+the post-pass, this test will fail loudly instead of silently shifting
+the entire IDP board.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.api.data_contract import build_api_data_contract
+from src.idp_calibration import production
+
+
+FAMILY_SCALE = 1.3
+DL_BUCKET = 0.5
+
+
+def _write_config(path: Path) -> None:
+    """Write a minimal promoted config with family_scale + single DL bucket."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_mode": "blended",
+                "family_scale": {
+                    "intrinsic": FAMILY_SCALE,
+                    "market": 1.0,
+                    "final": FAMILY_SCALE,
+                },
+                "multipliers": {
+                    # Single DL bucket spanning all ranks so every DL row
+                    # gets the same predictable multiplier under test.
+                    "DL": {
+                        "position": "DL",
+                        "buckets": [
+                            {
+                                "label": "1-500",
+                                "intrinsic": DL_BUCKET,
+                                "market": DL_BUCKET,
+                                "final": DL_BUCKET,
+                                "count": 500,
+                            },
+                        ],
+                    },
+                },
+                "anchors": {},
+            }
+        )
+    )
+
+
+def _load_latest_raw() -> dict | None:
+    data_dir = REPO / "exports" / "latest"
+    files = sorted(data_dir.glob("dynasty_data_*.json"), reverse=True)
+    if not files:
+        return None
+    with files[0].open() as f:
+        return json.load(f)
+
+
+def test_family_scale_is_folded_exactly_once(tmp_path, monkeypatch):
+    """Full live-pipeline exercise: under an active promoted config,
+    ``preVolatilityValue`` for DL rows must equal
+    ``uncalibrated × (bucket × family_scale)`` once — never twice.
+    """
+    raw = _load_latest_raw()
+    if raw is None:
+        pytest.skip("no latest snapshot for contract rebuild")
+
+    cfg_path = tmp_path / "idp_calibration.json"
+    _write_config(cfg_path)
+    monkeypatch.setattr(
+        production, "production_config_path", lambda base=None: cfg_path
+    )
+    production.reset_cache()
+
+    contract = build_api_data_contract(raw)
+    dl_rows = [
+        r
+        for r in contract.get("playersArray") or []
+        if r.get("canonicalConsensusRank")
+        and str(r.get("position") or "").upper() == "DL"
+    ]
+    assert dl_rows, "expected DL rows in the live board"
+
+    expected_combined = DL_BUCKET * FAMILY_SCALE  # 0.65
+    checked = 0
+    for row in dl_rows:
+        uncal = row.get("rankDerivedValueUncalibrated")
+        pre_vol = row.get("preVolatilityValue")
+        bucket = row.get("idpCalibrationMultiplier")
+        family = row.get("idpFamilyScale")
+        if uncal is None or pre_vol is None:
+            continue
+        # Stamped components match the config exactly.
+        assert bucket is not None and abs(bucket - DL_BUCKET) < 1e-6, (
+            f"{row.get('canonicalName')}: "
+            f"idpCalibrationMultiplier={bucket} != {DL_BUCKET}"
+        )
+        assert family is not None and abs(family - FAMILY_SCALE) < 1e-6, (
+            f"{row.get('canonicalName')}: "
+            f"idpFamilyScale={family} != {FAMILY_SCALE}"
+        )
+        # Combined factor is applied exactly once, not twice.
+        expected_once = int(round(float(uncal) * expected_combined))
+        expected_twice = int(round(float(uncal) * expected_combined * FAMILY_SCALE))
+        assert abs(int(pre_vol) - expected_once) <= 2, (
+            f"{row.get('canonicalName')}: "
+            f"preVolatilityValue={pre_vol}, "
+            f"uncal={uncal}, expected_once={expected_once} "
+            f"(combined={expected_combined:.4f}). "
+            f"family_scale may have been double-applied — "
+            f"double-apply expectation would yield ≈{expected_twice}."
+        )
+        # Defensive: the observed value must NOT match the
+        # double-apply expectation.
+        assert abs(int(pre_vol) - expected_twice) > 2, (
+            f"{row.get('canonicalName')}: preVolatilityValue={pre_vol} "
+            f"matches double-application of family_scale "
+            f"(expected_twice={expected_twice}). family_scale is being "
+            f"applied twice."
+        )
+        checked += 1
+
+    assert checked >= 10, (
+        f"expected to exercise many DL rows; checked only {checked}"
+    )
+
+
+def test_family_scale_zero_in_test_env(tmp_path, monkeypatch):
+    """Sanity check: with an empty config, production returns identity
+    multipliers and no IDP-calibration fields are stamped.  This pins
+    the "neutral" branch that the live single-curve invariant test
+    relies on.
+    """
+    cfg_path = tmp_path / "does_not_exist.json"
+    monkeypatch.setattr(
+        production, "production_config_path", lambda base=None: cfg_path
+    )
+    production.reset_cache()
+
+    raw = _load_latest_raw()
+    if raw is None:
+        pytest.skip("no latest snapshot for contract rebuild")
+    contract = build_api_data_contract(raw)
+
+    idp_rows = [
+        r
+        for r in contract.get("playersArray") or []
+        if r.get("canonicalConsensusRank")
+        and str(r.get("position") or "").upper() in ("DL", "LB", "DB")
+    ]
+    assert idp_rows
+
+    offenders = [
+        r.get("canonicalName")
+        for r in idp_rows
+        if r.get("idpCalibrationMultiplier") is not None
+        or r.get("idpFamilyScale") is not None
+    ]
+    assert not offenders, (
+        f"IDP calibration fields stamped despite neutral config: "
+        f"{offenders[:5]}"
+    )


### PR DESCRIPTION
## Summary
- Ports the long-abandoned KTC reconciliation + calibration double-apply guard from branch `claude/review-value-accuracy-a3CfR` (commit `5a078471`), adapted to use invariant-band tolerances (±5pp on KTC divergence) rather than the tight ±2pp pins that broke PR #154's predecessor.
- Adds a live-pipeline single-curve invariant test that catches any future second-remap between Hill blend and volatility compression on either offense or IDP rows.
- Adds a dedicated regression test for R-V6 (`family_scale` folded exactly once in `_apply_idp_calibration_post_pass`), making the load-bearing comment at `data_contract.py:3186-3195` executable.
- Extends `TestPlayerRankingsUnchanged` invariant bands (PR #154 pattern) with six IDP anchors: Myles Garrett, Will Anderson, Micah Parsons, Fred Warner, Roquan Smith, Kyle Hamilton.
- Zero production behavior changes. The calibration `RuntimeError` guard lives in the non-live canonical module and fires only if someone calls `calibrate_canonical_values` on a canonical-engine-tagged asset — the live path never does.

## What this closes from the 2026-04-20 audit
- **R-V2** — KTC alignment is unchecked. ✔ pinned at 10 ranks + 4 shape invariants.
- **R-V6** — `family_scale` double-apply regression risk. ✔ executable invariant.
- **Phase 6-E** — thin IDP regression coverage. ✔ +6 IDP anchors across DL/LB/DB.
- **Deliverable 4** items 1, 2, 3 from the audit. ✔ all landed.

## What this explicitly does NOT do
- Does not re-fit the Hill curve (R-H1 — research project).
- Does not touch `_apply_volatility_compression_post_pass` (R-V1 — research project).
- Does not change any constant (`_BLEND_MEAN_WEIGHT`, `_MONOTONICITY_BASE_STEP`, etc.).
- Does not modify the canonical engine's live-path imports.

## Test plan
- [x] `pytest tests/canonical/test_ktc_reconciliation.py -v` — 14 passed
- [x] `pytest tests/canonical/test_canonical_single_curve.py -v` — 6 passed
- [x] `pytest tests/api/test_single_curve_live.py -v` — 8 passed
- [x] `pytest tests/idp_calibration/test_family_scale_once_only.py -v` — 2 passed
- [x] `pytest tests/api/test_pick_refinement.py -v` — 16 passed, 16 subtests (10 offense + 6 IDP)
- [x] Full suite: `pytest tests/` — 1816 passed, 3 skipped, 157 subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)