### PR TITLE
KTC reconciliation: empirically-tiered tolerance bands + backtest harness

### DIFF
--- a/reports/ktc_volatility_backtest_full.md
+++ b/reports/ktc_volatility_backtest_full.md
@@ -1,0 +1,126 @@
+# KTC Volatility Backtest
+
+- Snapshot count: **25**
+- Date range: **2026-03-23 → 2026-04-16**
+- Hill constants: midpoint=48.44, slope=1.149
+- Pinned ranks: [1, 5, 12, 24, 50, 100, 150, 200, 300, 400]
+
+Measures how much KTC's curve drifts day-to-day at the ranks pinned in `tests/canonical/test_ktc_reconciliation.py`. The `pct_diff` column is `(ours − ktc) / ktc × 100`; `ours` is deterministic, so all observed spread comes from KTC scrape drift.  **The `max dod` column is the statistic the ±tolerance band must absorb** — it's the largest consecutive-day jump in pct_diff observed across the history.
+
+## Per-rank drift summary
+
+| rank | n | ktc min | ktc max | ktc stdev | pct_diff min | pct_diff max | pct_diff stdev | max dod | p95 dod |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 25 | 9991 | 9999 | 2.6 | +0.00% | +0.08% | 0.03pp | 0.08pp | 0.06pp |
+| 5 | 25 | 9568 | 9689 | 31.2 | -2.36% | -1.13% | 0.32pp | 0.36pp | 0.31pp |
+| 12 | 25 | 7693 | 7794 | 24.5 | +8.53% | +9.96% | 0.35pp | 0.55pp | 0.40pp |
+| 24 | 25 | 6743 | 6819 | 19.8 | +2.90% | +4.06% | 0.30pp | 0.64pp | 0.41pp |
+| 50 | 25 | 5370 | 5413 | 11.9 | -8.24% | -7.50% | 0.20pp | 0.43pp | 0.40pp |
+| 100 | 25 | 3873 | 3942 | 15.7 | -22.50% | -21.12% | 0.31pp | 1.04pp | 0.74pp |
+| 150 | 25 | 3069 | 3122 | 14.5 | -30.91% | -29.72% | 0.33pp | 0.92pp | 0.79pp |
+| 200 | 25 | 2632 | 2814 | 65.5 | -41.44% | -37.39% | 1.47pp | 2.30pp | 1.45pp |
+| 300 | 25 | 1867 | 2101 | 107.2 | -47.64% | -41.08% | 3.00pp | 5.98pp | 0.28pp |
+| 400 | 25 | 1231 | 1418 | 84.9 | -42.52% | -33.79% | 3.96pp | 8.36pp | 0.36pp |
+
+## Aggregate drift across all pinned ranks
+
+- Observations (day-over-day pct_diff deltas): **240**
+- Max observed: **8.36pp**
+- 99th percentile: **1.98pp**
+- 95th percentile: **0.62pp**
+- 90th percentile: **0.40pp**
+- Median: **0.10pp**
+
+## Tolerance-band sizing guidance
+
+The `pct_diff` band in `PINNED_DELTAS` is a static center + ±DELTA_TOLERANCE_PP. The tolerance must be ≥ the max day-over-day jump observed in this history or a data refresh will break CI.  Safe sizing rules:
+
+- **Strict (catches regressions earliest):** ceil(max_dod) + 1pp = 9pp
+- **Balanced (absorbs 99% of drift):** ceil(p99) + 1pp = 2pp
+- **Lax (absorbs 95% of drift, tolerates rare CI break):** ceil(p95) + 1pp = 1pp
+
+Current tolerance **±5.0pp** covers the p99 drift (1.98pp) but NOT the max observed (8.36pp).  Expect ~1% of daily refreshes to break CI unless widened to **±9pp**.
+
+## Per-rank day-over-day trace
+
+Top few largest day-over-day pct_diff jumps, per rank.  Useful for spotting the specific dates KTC methodology appears to have shifted.
+
+### rank 1
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-03-28 | 2026-03-29 | +0.08% | +0.00% | -0.08pp |
+| 2026-03-23 | 2026-03-24 | +0.07% | +0.01% | -0.06pp |
+| 2026-03-25 | 2026-03-26 | +0.00% | +0.06% | +0.06pp |
+
+### rank 5
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-14 | 2026-04-15 | -1.13% | -1.49% | -0.36pp |
+| 2026-04-11 | 2026-04-12 | -1.78% | -1.47% | +0.31pp |
+| 2026-04-12 | 2026-04-13 | -1.47% | -1.17% | +0.30pp |
+
+### rank 12
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-13 | 2026-04-14 | +9.52% | +8.97% | -0.55pp |
+| 2026-04-14 | 2026-04-15 | +8.97% | +8.53% | -0.43pp |
+| 2026-04-01 | 2026-04-02 | +9.70% | +9.46% | -0.24pp |
+
+### rank 24
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-14 | 2026-04-15 | +3.42% | +4.06% | +0.64pp |
+| 2026-04-15 | 2026-04-16 | +4.06% | +3.63% | -0.43pp |
+| 2026-04-09 | 2026-04-10 | +3.30% | +3.60% | +0.31pp |
+
+### rank 50
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-04 | 2026-04-05 | -7.76% | -8.19% | -0.43pp |
+| 2026-04-08 | 2026-04-09 | -7.92% | -7.50% | +0.41pp |
+| 2026-04-02 | 2026-04-03 | -8.12% | -7.76% | +0.36pp |
+
+### rank 100
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-13 | 2026-04-14 | -21.47% | -22.50% | -1.04pp |
+| 2026-03-24 | 2026-03-25 | -22.44% | -21.67% | +0.78pp |
+| 2026-04-11 | 2026-04-12 | -21.12% | -21.67% | -0.55pp |
+
+### rank 150
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-07 | 2026-04-08 | -30.75% | -29.83% | +0.92pp |
+| 2026-03-31 | 2026-04-01 | -29.99% | -30.82% | -0.83pp |
+| 2026-03-27 | 2026-03-28 | -30.28% | -29.72% | +0.57pp |
+
+### rank 200
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-07 | 2026-04-08 | -40.20% | -37.91% | +2.30pp |
+| 2026-03-27 | 2026-03-28 | -41.44% | -39.94% | +1.49pp |
+| 2026-03-25 | 2026-03-26 | -39.81% | -41.04% | -1.23pp |
+
+### rank 300
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-07 | 2026-04-08 | -47.32% | -41.33% | +5.98pp |
+| 2026-04-10 | 2026-04-11 | -41.36% | -41.08% | +0.28pp |
+| 2026-04-12 | 2026-04-13 | -41.18% | -41.46% | -0.28pp |
+
+### rank 400
+
+| prev date | curr date | prev pct | curr pct | Δ |
+|---|---|---:|---:|---:|
+| 2026-04-07 | 2026-04-08 | -42.16% | -33.79% | +8.36pp |
+| 2026-04-12 | 2026-04-13 | -34.06% | -34.43% | -0.37pp |
+| 2026-03-29 | 2026-03-30 | -42.48% | -42.20% | +0.29pp |

--- a/scripts/backtest_ktc_volatility.py
+++ b/scripts/backtest_ktc_volatility.py
@@ -1,0 +1,360 @@
+"""Empirical backtest for KTC day-to-day volatility.
+
+Quantifies how much KTC's curve drifts in the rank positions our
+reconciliation test (``tests/canonical/test_ktc_reconciliation.py``)
+pins.  The output decides whether the current ±5pp tolerance band
+is defensible, too loose, or too tight — and feeds directly into
+any future decision to re-fit the Hill curve (audit item R-H1).
+
+For each daily snapshot in ``data/dynasty_data_*.json`` this script:
+
+  1. Sorts players by raw ``ktc`` value descending (picks filtered).
+  2. Records KTC value at each pinned reconciliation rank.
+  3. Compares to ``rank_to_value(rank)`` (our deterministic Hill
+     curve) and records the percentage divergence.
+
+Across the full history it computes, per rank:
+
+  * observed min / max / mean / stdev of KTC value
+  * observed min / max / mean / stdev of pct_diff
+  * max and 95th-percentile day-over-day change in pct_diff
+    (consecutive-day jump, the signal that actually breaks CI)
+
+Usage:
+    python3 scripts/backtest_ktc_volatility.py
+    python3 scripts/backtest_ktc_volatility.py --out reports/ktc_volatility.md
+
+No production behavior is modified.  The output is a markdown report.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.canonical.player_valuation import (  # noqa: E402
+    HILL_MIDPOINT,
+    HILL_SLOPE,
+    rank_to_value,
+)
+
+
+_PICK_PATTERN = re.compile(r"^\d{4}\s+(Early|Mid|Late)\s+\d", re.IGNORECASE)
+
+# Ranks pinned in tests/canonical/test_ktc_reconciliation.py.  Any
+# change here should mirror in the test (and vice versa) so the
+# report and the regression test measure the same thing.
+PINNED_RANKS: list[int] = [1, 5, 12, 24, 50, 100, 150, 200, 300, 400]
+
+DATA_DIR = REPO / "data"
+
+
+def _iter_ktc_values(payload: dict[str, Any]) -> list[tuple[str, int]]:
+    """Return (player_name, ktc_value) for every non-pick player
+    with a positive KTC value.  Mirrors the filtering in
+    ``tests/canonical/test_ktc_reconciliation.py::_load_ktc_players_sorted``.
+    """
+    players = payload.get("players") or {}
+    rows: list[tuple[str, int]] = []
+    for name, pdata in players.items():
+        if _PICK_PATTERN.match(str(name)):
+            continue
+        v = (pdata or {}).get("ktc") if isinstance(pdata, dict) else None
+        if not v:
+            continue
+        try:
+            rows.append((str(name), int(v)))
+        except (TypeError, ValueError):
+            continue
+    rows.sort(key=lambda r: -r[1])
+    return rows
+
+
+def _rank_values(ktc_rows: list[tuple[str, int]]) -> dict[int, tuple[str, int]]:
+    """Return {rank: (player_name, ktc_value)} for every pinned rank
+    that falls within the available pool.
+    """
+    out: dict[int, tuple[str, int]] = {}
+    for r in PINNED_RANKS:
+        if r - 1 < len(ktc_rows):
+            out[r] = ktc_rows[r - 1]
+    return out
+
+
+def _snapshot_date(path: Path) -> str:
+    """Return the ISO date component of a dynasty_data_YYYY-MM-DD.json file."""
+    stem = path.stem  # dynasty_data_2026-04-15
+    return stem.rsplit("_", 1)[-1]
+
+
+def collect_daily_series(data_dir: Path) -> dict[int, list[dict[str, Any]]]:
+    """Build per-rank daily time series.
+
+    Returns: {rank -> [{"date": YYYY-MM-DD, "ktc": int, "player": str,
+                        "ours": int, "pct_diff": float}, ...]}
+    """
+    per_rank: dict[int, list[dict[str, Any]]] = {r: [] for r in PINNED_RANKS}
+    files = sorted(data_dir.glob("dynasty_data_*.json"))
+    if not files:
+        raise SystemExit(f"No snapshots found in {data_dir}")
+
+    for path in files:
+        date = _snapshot_date(path)
+        with path.open() as f:
+            payload = json.load(f)
+        rows = _iter_ktc_values(payload)
+        for rank, (player, ktc_val) in _rank_values(rows).items():
+            ours = rank_to_value(rank)
+            pct_diff = 100.0 * (ours - ktc_val) / ktc_val if ktc_val else 0.0
+            per_rank[rank].append(
+                {
+                    "date": date,
+                    "ktc": ktc_val,
+                    "player": player,
+                    "ours": ours,
+                    "pct_diff": pct_diff,
+                }
+            )
+    return per_rank
+
+
+def _summary_stats(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"min": 0.0, "max": 0.0, "mean": 0.0, "stdev": 0.0}
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": statistics.mean(values),
+        "stdev": statistics.stdev(values) if len(values) >= 2 else 0.0,
+    }
+
+
+def _percentile(sorted_vals: list[float], p: float) -> float:
+    """Linear-interpolated percentile (p in [0, 1]) on a sorted list."""
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    k = (len(sorted_vals) - 1) * p
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = k - lo
+    return sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac
+
+
+def _day_over_day(series: list[float]) -> dict[str, float]:
+    """Compute {max_abs_delta, p95_abs_delta} for consecutive-day deltas."""
+    if len(series) < 2:
+        return {"max_abs_delta": 0.0, "p95_abs_delta": 0.0}
+    deltas = [abs(series[i] - series[i - 1]) for i in range(1, len(series))]
+    deltas.sort()
+    return {
+        "max_abs_delta": max(deltas),
+        "p95_abs_delta": _percentile(deltas, 0.95),
+    }
+
+
+def render_report(per_rank: dict[int, list[dict[str, Any]]]) -> str:
+    lines: list[str] = []
+    sample_sizes = {r: len(v) for r, v in per_rank.items()}
+    n_snapshots = max(sample_sizes.values()) if sample_sizes else 0
+    first_date = per_rank[PINNED_RANKS[0]][0]["date"] if per_rank[PINNED_RANKS[0]] else "?"
+    last_date = per_rank[PINNED_RANKS[0]][-1]["date"] if per_rank[PINNED_RANKS[0]] else "?"
+
+    lines.append("# KTC Volatility Backtest")
+    lines.append("")
+    lines.append(f"- Snapshot count: **{n_snapshots}**")
+    lines.append(f"- Date range: **{first_date} → {last_date}**")
+    lines.append(f"- Hill constants: midpoint={HILL_MIDPOINT}, slope={HILL_SLOPE}")
+    lines.append(f"- Pinned ranks: {PINNED_RANKS}")
+    lines.append("")
+    lines.append(
+        "Measures how much KTC's curve drifts day-to-day at the ranks "
+        "pinned in `tests/canonical/test_ktc_reconciliation.py`. The "
+        "`pct_diff` column is `(ours − ktc) / ktc × 100`; `ours` is "
+        "deterministic, so all observed spread comes from KTC scrape "
+        "drift.  **The `max dod` column is the statistic the ±tolerance "
+        "band must absorb** — it's the largest consecutive-day jump in "
+        "pct_diff observed across the history."
+    )
+    lines.append("")
+
+    lines.append("## Per-rank drift summary")
+    lines.append("")
+    header = (
+        "| rank | n | ktc min | ktc max | ktc stdev | pct_diff min | "
+        "pct_diff max | pct_diff stdev | max dod | p95 dod |"
+    )
+    sep = "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
+    lines.append(header)
+    lines.append(sep)
+    for rank in PINNED_RANKS:
+        series = per_rank[rank]
+        if not series:
+            lines.append(f"| {rank} | 0 | — | — | — | — | — | — | — | — |")
+            continue
+        ktc_stats = _summary_stats([s["ktc"] for s in series])
+        pct_stats = _summary_stats([s["pct_diff"] for s in series])
+        dod = _day_over_day([s["pct_diff"] for s in series])
+        lines.append(
+            f"| {rank} | {len(series)} | "
+            f"{int(ktc_stats['min'])} | {int(ktc_stats['max'])} | "
+            f"{ktc_stats['stdev']:.1f} | "
+            f"{pct_stats['min']:+.2f}% | {pct_stats['max']:+.2f}% | "
+            f"{pct_stats['stdev']:.2f}pp | "
+            f"{dod['max_abs_delta']:.2f}pp | {dod['p95_abs_delta']:.2f}pp |"
+        )
+    lines.append("")
+
+    # Overall max day-over-day across any pinned rank
+    all_dod: list[float] = []
+    for rank in PINNED_RANKS:
+        series = per_rank[rank]
+        if len(series) >= 2:
+            pct_series = [s["pct_diff"] for s in series]
+            for i in range(1, len(pct_series)):
+                all_dod.append(abs(pct_series[i] - pct_series[i - 1]))
+    all_dod.sort()
+    lines.append("## Aggregate drift across all pinned ranks")
+    lines.append("")
+    if all_dod:
+        lines.append(f"- Observations (day-over-day pct_diff deltas): **{len(all_dod)}**")
+        lines.append(f"- Max observed: **{all_dod[-1]:.2f}pp**")
+        lines.append(f"- 99th percentile: **{_percentile(all_dod, 0.99):.2f}pp**")
+        lines.append(f"- 95th percentile: **{_percentile(all_dod, 0.95):.2f}pp**")
+        lines.append(f"- 90th percentile: **{_percentile(all_dod, 0.90):.2f}pp**")
+        lines.append(f"- Median: **{_percentile(all_dod, 0.50):.2f}pp**")
+    else:
+        lines.append("- (not enough data)")
+    lines.append("")
+
+    lines.append("## Tolerance-band sizing guidance")
+    lines.append("")
+    if all_dod:
+        p99 = _percentile(all_dod, 0.99)
+        p95 = _percentile(all_dod, 0.95)
+        max_dod = all_dod[-1]
+        lines.append(
+            "The `pct_diff` band in "
+            "`PINNED_DELTAS` is a static center + ±DELTA_TOLERANCE_PP. The "
+            "tolerance must be ≥ the max day-over-day jump observed in this "
+            "history or a data refresh will break CI.  Safe sizing rules:"
+        )
+        lines.append("")
+        lines.append(f"- **Strict (catches regressions earliest):** ceil(max_dod) + 1pp = {int(max_dod) + 1}pp")
+        lines.append(f"- **Balanced (absorbs 99% of drift):** ceil(p99) + 1pp = {int(p99) + 1}pp")
+        lines.append(f"- **Lax (absorbs 95% of drift, tolerates rare CI break):** ceil(p95) + 1pp = {int(p95) + 1}pp")
+        lines.append("")
+        current_tol = 5.0
+        if current_tol >= max_dod:
+            lines.append(
+                f"Current tolerance **±{current_tol:.1f}pp** is SAFE "
+                f"(covers max observed dod = {max_dod:.2f}pp)."
+            )
+        elif current_tol >= p99:
+            lines.append(
+                f"Current tolerance **±{current_tol:.1f}pp** covers the "
+                f"p99 drift ({p99:.2f}pp) but NOT the max observed "
+                f"({max_dod:.2f}pp).  Expect ~1% of daily refreshes to "
+                f"break CI unless widened to **±{int(max_dod) + 1}pp**."
+            )
+        else:
+            lines.append(
+                f"Current tolerance **±{current_tol:.1f}pp** is TOO TIGHT — "
+                f"p99 drift = {p99:.2f}pp, max = {max_dod:.2f}pp.  Widen "
+                f"to at least **±{int(p99) + 1}pp** to survive ordinary "
+                f"KTC drift."
+            )
+    lines.append("")
+
+    lines.append("## Per-rank day-over-day trace")
+    lines.append("")
+    lines.append(
+        "Top few largest day-over-day pct_diff jumps, per rank.  Useful "
+        "for spotting the specific dates KTC methodology appears to have "
+        "shifted."
+    )
+    lines.append("")
+    for rank in PINNED_RANKS:
+        series = per_rank[rank]
+        if len(series) < 2:
+            continue
+        jumps: list[tuple[float, str, str, float, float]] = []
+        for i in range(1, len(series)):
+            prior = series[i - 1]
+            curr = series[i]
+            jump = curr["pct_diff"] - prior["pct_diff"]
+            jumps.append((jump, prior["date"], curr["date"], prior["pct_diff"], curr["pct_diff"]))
+        jumps.sort(key=lambda t: -abs(t[0]))
+        lines.append(f"### rank {rank}")
+        lines.append("")
+        lines.append("| prev date | curr date | prev pct | curr pct | Δ |")
+        lines.append("|---|---|---:|---:|---:|")
+        for j, prev_d, curr_d, prev_p, curr_p in jumps[:3]:
+            lines.append(
+                f"| {prev_d} | {curr_d} | {prev_p:+.2f}% | {curr_p:+.2f}% | {j:+.2f}pp |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_csv(per_rank: dict[int, list[dict[str, Any]]], out_path: Path) -> None:
+    """Dump the full daily series as CSV for downstream analysis."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["date", "rank", "player", "ktc", "ours", "pct_diff"])
+        for rank in PINNED_RANKS:
+            for s in per_rank[rank]:
+                w.writerow([s["date"], rank, s["player"], s["ktc"], s["ours"], f"{s['pct_diff']:+.4f}"])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DATA_DIR,
+        help="Directory containing dynasty_data_*.json snapshots",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=REPO / "reports" / "ktc_volatility_backtest.md",
+        help="Markdown report output path",
+    )
+    ap.add_argument(
+        "--csv",
+        type=Path,
+        default=REPO / "reports" / "ktc_volatility_backtest.csv",
+        help="CSV daily-series output path",
+    )
+    args = ap.parse_args()
+
+    per_rank = collect_daily_series(args.data_dir)
+    report = render_report(per_rank)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(report)
+    write_csv(per_rank, args.csv)
+
+    # Also print the summary so a runner without a file viewer sees it.
+    print(report)
+    print(f"\nWrote report: {args.out}")
+    print(f"Wrote CSV:    {args.csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/canonical/test_ktc_reconciliation.py
+++ b/tests/canonical/test_ktc_reconciliation.py
@@ -70,7 +70,7 @@ def _load_ktc_players_sorted() -> list[tuple[str, int]]:
 # ──────────────────────────────────────────────────────────────────────
 # Pinned deltas — our Hill curve vs KTC at key ranks.
 #
-# Each entry: (rank, ours_expected, pct_diff_band_center).
+# Each entry: (rank, ours_expected, pct_diff_band_center, tolerance_pp).
 # Baselined 2026-04-20 against CSVs/site_raw/ktc.csv.
 #
 # ``ours_expected`` is the exact integer ``rank_to_value(rank)`` output.
@@ -78,29 +78,33 @@ def _load_ktc_players_sorted() -> list[tuple[str, int]]:
 # constants, changing it is a deliberate act and must re-baseline here.
 #
 # ``pct_diff_band_center`` is the expected (ours − ktc) / ktc × 100
-# at that rank.  Tolerance ``DELTA_TOLERANCE_PP`` is applied symmetrically
-# around the band center — wide enough (±5pp) to absorb ordinary daily
-# KTC scrape drift, narrow enough to catch a real curve shape change.
+# at that rank.  ``tolerance_pp`` is the symmetric band half-width.
+#
+# Tolerances are tiered per the 2026-04-20 KTC volatility backtest
+# (``scripts/backtest_ktc_volatility.py``, see
+# ``reports/ktc_volatility_backtest.md``) across 25 daily snapshots:
+#
+#   ranks 1–50  | max observed day-over-day drift = 0.64pp → ±2pp
+#   ranks 100–150 | max observed day-over-day drift = 1.04pp → ±3pp
+#   ranks 200–400 | max observed day-over-day drift = 8.36pp (driven
+#                   by the 2026-04-08 deep-tail methodology shift) → ±10pp
+#
+# A structural KTC tail shift larger than these bands is a signal, not
+# a regression — break CI, investigate, re-baseline the affected ranks.
 # ──────────────────────────────────────────────────────────────────────
-PINNED_DELTAS: list[tuple[int, int, float]] = [
-    # rank, ours (exact), pct_diff band center
-    (1,   9999,   0.0),
-    (5,   9460,  -1.8),
-    (12,  8459,   8.4),
-    (24,  7017,   3.8),
-    (50,  4967,  -3.6),
-    (100, 3055, -15.4),
-    (150, 2157, -24.0),
-    (200, 1648, -31.9),
-    (300, 1100, -32.5),
-    (400,  815, -19.2),
+PINNED_DELTAS: list[tuple[int, int, float, float]] = [
+    # rank, ours (exact), pct_diff band center, tolerance_pp
+    (1,   9999,   0.0,  2.0),
+    (5,   9460,  -1.8,  2.0),
+    (12,  8459,   8.4,  2.0),
+    (24,  7017,   3.8,  2.0),
+    (50,  4967,  -3.6,  2.0),
+    (100, 3055, -15.4,  3.0),
+    (150, 2157, -24.0,  3.0),
+    (200, 1648, -31.9, 10.0),
+    (300, 1100, -32.5, 10.0),
+    (400,  815, -19.2, 10.0),
 ]
-
-# Tolerance band around pinned pct_diff, in absolute percentage points.
-# ±5pp is wide enough to absorb normal daily KTC scrape drift (their
-# daily changes typically sit well under ±2pp at most ranks) while
-# still tight enough to catch a real curve-shape regression.
-DELTA_TOLERANCE_PP = 5.0
 
 
 @pytest.fixture(scope="module")
@@ -116,13 +120,14 @@ def ktc_players() -> list[tuple[str, int]]:
 class TestKTCReconciliation:
     """Pin our Hill curve's divergence from KTC at key ranks."""
 
-    @pytest.mark.parametrize("rank,pinned_ours,pinned_pct", PINNED_DELTAS)
+    @pytest.mark.parametrize("rank,pinned_ours,pinned_pct,tolerance_pp", PINNED_DELTAS)
     def test_rank_delta_within_tolerance(
         self,
         ktc_players: list[tuple[str, int]],
         rank: int,
         pinned_ours: int,
         pinned_pct: float,
+        tolerance_pp: float,
     ) -> None:
         _, ktc_value = ktc_players[rank - 1]
         ours = rank_to_value(rank)
@@ -136,13 +141,14 @@ class TestKTCReconciliation:
             f"(e.g. re-fit via scripts/fit_hill_curve_from_market.py)."
         )
 
-        # KTC's curve wiggles with their daily scrape.  Keep the
-        # divergence within ±DELTA_TOLERANCE_PP of the pinned center.
+        # KTC's curve wiggles with their daily scrape.  Tier-specific
+        # tolerance (see PINNED_DELTAS doc block) — tight at the stable
+        # top of board, wide at the actively-drifting deep tail.
         actual_pct = 100.0 * (ours - ktc_value) / ktc_value
-        assert abs(actual_pct - pinned_pct) <= DELTA_TOLERANCE_PP, (
+        assert abs(actual_pct - pinned_pct) <= tolerance_pp, (
             f"Divergence from KTC at rank {rank} drifted: "
             f"pinned {pinned_pct:+.1f}% vs actual {actual_pct:+.1f}% "
-            f"(KTC={ktc_value}, ours={ours}, band ±{DELTA_TOLERANCE_PP:.1f}pp). "
+            f"(KTC={ktc_value}, ours={ours}, band ±{tolerance_pp:.1f}pp). "
             f"Investigate whether KTC shifted or our curve needs re-fitting."
         )
 


### PR DESCRIPTION
## Summary
- Adds `scripts/backtest_ktc_volatility.py` — reproducible harness measuring KTC day-to-day drift at the pinned reconciliation ranks across every snapshot in `data/`.
- Adds `reports/ktc_volatility_backtest_full.md` — frozen results across 25 daily snapshots (2026-03-23 → 2026-04-16).
- Replaces the single `DELTA_TOLERANCE_PP = 5.0` constant with per-rank tiers grounded in the backtest:
  - ranks 1–50 → **±2pp** (max observed day-over-day 0.64pp — tight)
  - ranks 100–150 → **±3pp** (max observed day-over-day 1.04pp)
  - ranks 200–400 → **±10pp** (active deep-tail drift, max 8.36pp)

## Why
PR #155 landed the reconciliation test with a hand-picked ±5pp band. The follow-up KTC-volatility backtest (requested in the 2026-04-20 audit follow-up conversation) quantified actual KTC drift: the top of board is far more stable than ±5pp requires, and the deep tail is sometimes more volatile than ±5pp absorbs (the 2026-04-07 → 2026-04-08 shift was 8.36pp at rank 400). Tiered bands catch shallow-rank regressions earliest while surviving known deep-tail KTC methodology drift.

## What this does NOT do
- Does not refit the Hill curve (R-H1 — still a research project; this backtest is a prerequisite for that future work).
- Does not change any production code, any constant in the live pipeline, or any user-facing value.

## Test plan
- [x] `pytest tests/canonical/test_ktc_reconciliation.py -v` — 14 passed, parametrize IDs now show the tiered tolerance
- [x] Full suite: 1816 passed, 3 skipped, 157 subtests
- [x] `python3 scripts/backtest_ktc_volatility.py` regenerates the markdown report deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)