### PR TITLE
Framework PR 1: drop volatility + monotonicity cap; adopt trimmed mean-median blend

### DIFF
--- a/docs/architecture/live-value-pipeline-trace.md
+++ b/docs/architecture/live-value-pipeline-trace.md
@@ -110,7 +110,7 @@ For each active source:
      IDPTC for IDP)
    - everything else → direct passthrough
 
-### Phase 3 — Hill curve + blend (L4582-4728)
+### Phase 3 — Hill curve + trimmed mean-median blend
 
 For each row with any per-source rank:
 
@@ -126,26 +126,26 @@ TEP application on TE rows only:
 - `is_tep_premium=False` sources: `value *= tep_multiplier`
 - `is_tep_premium=True` sources: `value *= tep_native_correction`
 
-Effective weight:
+Effective weight (stamped onto source meta for transparency, NOT used
+in aggregation):
 ```
 effective_weight = coverage_weight(declared_weight, depth)
 ```
 `coverage_weight` at `src/canonical/idp_backbone.py:306` linearly scales
-sources shallower than `MIN_FULL_COVERAGE_DEPTH=60`.  Only rookie
-sources (depth=50) trigger this scaling in the current registry.
+sources shallower than `MIN_FULL_COVERAGE_DEPTH=60`.
 
-Blend:
-- `weighted_mean` = ∑(value × effective_weight) / ∑ effective_weight
-- `robust`:
-  - ≥ 5 sources → drop max AND min, mean the rest
-  - 3-4 sources → drop worst (lowest) only, mean the rest
-  - 2 sources → mean
-  - 1 source → keep
-- `blended_value = 0.7 * weighted_mean + 0.3 * robust`
+Blend — **Final Framework step 5: Trimmed Mean-Median** (unweighted):
+- Sort per-source values.
+- If ≥ 3 sources: drop the highest and the lowest, compute the
+  arithmetic mean AND the median of what remains, blend =
+  `(trimmed_mean + trimmed_median) / 2`.
+- If 2 sources: mean of the two.
+- If 1 source: keep.
 
-Constants `_BLEND_MEAN_WEIGHT=0.7`, `_BLEND_ROBUST_WEIGHT=0.3`
-(see `src/api/data_contract.py:3405`; chosen via
-`scripts/backtest_blend_params.py`, PR #151).
+Weighting is reintroduced later as the hierarchical anchor / subgroup
+structure (framework steps 7–8).  The previous `0.7·weighted_mean +
+0.3·robust` convex combo has been retired — see the PR 1 commit for
+the Final Framework transition.
 
 ### Phase 3a — Pick year discount (L4739)
 
@@ -180,21 +180,15 @@ Offense calibration is **commented out** at L5021.  Regression test
 at `tests/api/test_single_curve_live.py` asserts no offense row
 carries `offenseCalibrationMultiplier`.
 
-### Phase 4d — Volatility compression (L5033)
+### Phase 4d — Volatility compression (REMOVED)
 
-`_apply_volatility_compression_post_pass`:
-- z-score of `sourceRankPercentileSpread` across all eligible rows.
-- z > 0: compress down toward floor `0.92`.
-- z < 0: boost up toward ceil `1.08`.
-- Boosts clamped by monotonicity cap:
-  `ceiling = prior_post_value - _MONOTONICITY_BASE_STEP * rank_gap`,
-  clamped to `[25, 250]` step points.
-- Picks skipped (they're anchored to rookies).
+The prior ±8% compress/boost post-pass and its 75-point monotonicity
+cap were removed as part of the Final Framework transition.  A
+principled MAD-based volatility penalty with a backtested `λ` weight
+will reappear in a later PR once the backtest is done.
 
-Constants: `_VOLATILITY_COMPRESSION_STRENGTH=0.03`,
-`_VOLATILITY_COMPRESSION_FLOOR=0.92`, `_VOLATILITY_COMPRESSION_CEIL=1.08`,
-`_MONOTONICITY_BASE_STEP=75`.  These have not been refit since they
-were migrated from the canonical engine defaults.
+Fields `preVolatilityValue` and `volatilityCompressionApplied` are no
+longer stamped.
 
 ### Phase 5 — Pick refinement + recompact (L5040-5111)
 
@@ -226,8 +220,6 @@ runtime view (`/api/data?view=app`) still has per-row data after
 - `canonicalConsensusRank` — authoritative rank (1..N)
 - `canonicalTierId` — value-gap-detected tier index
 - `rankDerivedValueUncalibrated` — pre-IDP-calibration snapshot
-- `preVolatilityValue` — post-calibration, pre-volatility snapshot
-- `volatilityCompressionApplied` — signed fraction
 - `sourceRanks`, `sourceRankMeta` — per-source transparency
 - `confidenceBucket`, `confidenceLabel` — display badge
 - `anomalyFlags` — diagnostic flags
@@ -237,12 +229,8 @@ runtime view (`/api/data?view=app`) still has per-row data after
 The chain identity (pinned in `tests/api/test_single_curve_live.py`):
 
 ```
-rankDerivedValueUncalibrated                               ← Hill + TEP + blend
-    × (idpCalibrationMultiplier × idpFamilyScale)          ← IDP only, if active
-    = preVolatilityValue
-    × (1 − volatilityCompressionApplied)   compression
-    OR                                                     ← signed fraction
-    min(× (1 + |vol|), monotonicity_cap, 9999)  boost
+rankDerivedValueUncalibrated                              ← Hill + TEP + trimmed mean-median
+    × (idpCalibrationMultiplier × idpFamilyScale)         ← IDP only, if active
     = rankDerivedValue
 ```
 
@@ -263,9 +251,11 @@ rankDerivedValueUncalibrated                               ← Hill + TEP + blen
 
 The backtest harnesses that exercise these constants:
 
-- `scripts/backtest_blend_params.py` — `_BLEND_MEAN_WEIGHT`,
-  `_VOLATILITY_COMPRESSION_*`, IDPTC weight.  Output:
-  `reports/backtest_blend_params_full.md`.
+- `scripts/backtest_blend_params.py` — IDPTC weight and (historically)
+  the old `_BLEND_MEAN_WEIGHT` / `_VOLATILITY_*` constants.  Output:
+  `reports/backtest_blend_params_full.md`.  The volatility knobs
+  referenced in older runs no longer exist; re-running the script
+  today exercises only the IDPTC weight lever.
 - `scripts/backtest_ktc_volatility.py` — empirical KTC drift bands per
   rank.  Output: `reports/ktc_volatility_backtest_full.md`.
 

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -7,21 +7,15 @@ import { resolvedRank } from "@/lib/dynasty-data";
 /**
  * Build the ordered value-chain stages from a player row.
  *
- * Pipeline order (from src/api/data_contract.py phases 4a → 5):
- *   1. Blended Hill value (weighted-mean + robust-median) → stamped
- *      as ``rankDerivedValueUncalibrated``.
+ * Pipeline order (from src/api/data_contract.py Phase 3 → 4c):
+ *   1. Blended Hill value — trimmed mean-median across per-source
+ *      Hill-curve values → stamped as ``rankDerivedValueUncalibrated``.
  *   2. IDP calibration pass (family_scale × bucket multiplier) —
- *      IDP rows only; offense rows skip this stage.
- *   3. Volatility compression / boost → stamped as
- *      ``preVolatilityValue`` capture (the value at the start of the
- *      volatility iteration) and the final ``rankDerivedValue``.
- *      Monotonicity cap can pull the boosted value BELOW the input
- *      when a higher-ranked neighbor landed at a low final value —
- *      this is why Schwesinger (rank 78) ends up at 4062 despite
- *      his calibrated pre-volatility being 6591.
- *   4. Phase-5 compact resort / pick anchoring (rare) — shows up as
- *      a catch-all delta when the final value doesn't match what
- *      the volatility stage produced.
+ *      IDP rows only; offense rows skip this stage.  Output is the
+ *      final ``rankDerivedValue``.
+ *
+ * The prior volatility-compression stage was removed along with the
+ * monotonicity cap; see docs/architecture/live-value-pipeline-trace.md.
  *
  * Only stages with a meaningful delta are emitted so offense rows
  * don't render zero-op "IDP calibration ×1.00" rows.
@@ -31,22 +25,22 @@ function computeValueChain(row) {
 
   const stages = [];
 
-  // Stage 1 — blended value (output of 60/40 weighted-mean + robust-median).
+  // Stage 1 — blended value (trimmed mean-median across Hill-curve
+  // values from every contributing source).
   const blended = Number(row.rankDerivedValueUncalibrated) || null;
   if (blended !== null && blended > 0) {
     stages.push({
       key: "blend",
       label: "Blended value",
       description:
-        "Weighted-mean + robust-median across per-source Hill-curve values",
+        "Trimmed mean-median across per-source Hill-curve values",
       value: Math.round(blended),
       delta: null,
     });
   }
 
   // Stage 2 — IDP calibration (family_scale × bucket multiplier).
-  // Offense rows lack these fields and skip this stage.  Captured
-  // BEFORE the volatility pass by the ``preVolatilityValue`` snapshot.
+  // Offense rows lack these fields and skip this stage.
   const bucket =
     typeof row.idpCalibrationMultiplier === "number"
       ? row.idpCalibrationMultiplier
@@ -57,14 +51,12 @@ function computeValueChain(row) {
     typeof row.idpCalibrationPositionRank === "number"
       ? row.idpCalibrationPositionRank
       : null;
-  const calibrated = Number(row.preVolatilityValue) || null;
-  if (family !== null && bucket !== null && calibrated !== null) {
+  const finalValue = Number(row.rankDerivedValue) || 0;
+  if (family !== null && bucket !== null && finalValue > 0) {
     const combined = family * bucket;
     const prior = stages.length ? stages[stages.length - 1].value : null;
-    const delta = prior !== null ? Math.round(calibrated) - prior : null;
-    // Skip if the calibration is a clean no-op AND there's no delta
-    // (some rows get the multiplier applied but still round-trip
-    // to the same integer).
+    const delta = prior !== null ? Math.round(finalValue) - prior : null;
+    // Skip if the calibration is a clean no-op AND there's no delta.
     if (!(Math.abs(combined - 1.0) < 1e-9 && (delta === null || delta === 0))) {
       const posLabel =
         posRank && row.pos ? ` (${row.pos}${posRank})` : "";
@@ -72,46 +64,6 @@ function computeValueChain(row) {
         key: "idp-calibration",
         label: `IDP calibration: ×${combined.toFixed(2)}`,
         description: `Family scale ×${family.toFixed(2)} × bucket multiplier ×${bucket.toFixed(2)}${posLabel}`,
-        value: Math.round(calibrated),
-        delta,
-      });
-    }
-  }
-
-  // Stage 3 — volatility compression / boost / cap.  The
-  // ``volatilityCompressionApplied`` fraction captures the raw
-  // boost/compress signal from source agreement; the actual delta
-  // can be different because the monotonicity cap may bind.
-  const volFrac =
-    typeof row.volatilityCompressionApplied === "number"
-      ? row.volatilityCompressionApplied
-      : null;
-  const finalValue = Number(row.rankDerivedValue) || 0;
-  if (finalValue > 0) {
-    const prior = stages.length ? stages[stages.length - 1].value : null;
-    const delta = prior !== null ? Math.round(finalValue) - prior : null;
-    if (delta !== null && delta !== 0) {
-      let label;
-      let description;
-      if (volFrac === null || volFrac === 0) {
-        label = "Post-volatility adjustment";
-        description =
-          "Monotonicity cap or Phase-5 compact resort produced a value shift";
-      } else if (volFrac < 0) {
-        label = `Volatility: boost ${(Math.abs(volFrac) * 100).toFixed(1)}%`;
-        description =
-          delta < 0
-            ? "High source agreement (theoretical boost), but monotonicity cap pulled the value below a higher-ranked neighbour"
-            : "High source agreement → multiplicative lift (capped by display ceiling and monotonicity step)";
-      } else {
-        label = `Volatility: compress ${(volFrac * 100).toFixed(1)}%`;
-        description =
-          "Source disagreement → value pulled toward the mean to down-weight noisy players";
-      }
-      stages.push({
-        key: "volatility",
-        label,
-        description,
         value: Math.round(finalValue),
         delta,
       });

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -794,13 +794,8 @@ function _materializePlayerArrayRow(player) {
     blendedSourceRank: backendBlendedSourceRank,
     sourceCount: backendSourceCount,
     // Value-chain audit fields — exposed so the PlayerPopup can show
-    // each pipeline stage (blend → volatility → calibration) as a
-    // transparent sequence rather than a single opaque final number.
-    preVolatilityValue: Number(player.preVolatilityValue) || null,
-    volatilityCompressionApplied:
-      typeof player.volatilityCompressionApplied === "number"
-        ? player.volatilityCompressionApplied
-        : null,
+    // each pipeline stage (blend → calibration) as a transparent
+    // sequence rather than a single opaque final number.
     idpCalibrationMultiplier:
       typeof player.idpCalibrationMultiplier === "number"
         ? player.idpCalibrationMultiplier

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3362,279 +3362,7 @@ def _apply_offense_calibration_post_pass(
                     pdata["offenseCalibrationMultiplier"] = round(multiplier, 4)
 
 
-# Volatility compression hyperparameters — mirror the canonical engine's
-# Step 5 defaults in ``src/canonical/player_valuation.py`` so the live
-# path and canonical-engine output stay conceptually aligned.  Kept
-# intentionally gentle: the floor caps worst-case compression at 8%, so
-# a high-disagreement top-tier player drops no more than 800 points on
-# the 1–9999 scale.  If this needs retuning, change it here and update
-# the matching constants in player_valuation.py.
-_VOLATILITY_COMPRESSION_STRENGTH: float = 0.03
-_VOLATILITY_COMPRESSION_FLOOR: float = 0.92
-_VOLATILITY_COMPRESSION_CEIL: float = 1.08
-
-# Final-blend mix between the weighted-mean (structural) and the
-# robust-trimmed-median (outlier-resistant) aggregation of per-source
-# Hill-curve values.  The live formula is:
-#
-#     blended_value = _BLEND_MEAN_WEIGHT * weighted_mean +
-#                     _BLEND_ROBUST_WEIGHT * robust
-#
-# The two weights MUST sum to 1.0; the pipeline treats them as a
-# convex combination and does not renormalize.
-#
-# 70/30 trusts the configured source weights heavily (the IDPTC 2.0
-# backbone weight is the dominant example) while still letting the
-# robust blend absorb single-source outliers.  Change these together
-# (not independently) — a 0.5/0.5 split weights outlier-correction
-# more, a 0.7/0.3 split trusts the configured source weights more.
-#
-# Historical note: this pair was 0.6/0.4 through 2026-04-19.  The
-# ``scripts/backtest_blend_params.py`` sweep on 25 daily snapshots
-# (2026-03-23 → 2026-04-16) showed a clean peak at 0.70 for
-# value-weighted rank stability (4.9% improvement over 0.60; spread
-# 10.7% across the {0.50 .. 0.75} grid; monotonic rise from 0.55 to
-# 0.70 with a downturn at 0.75).  See
-# ``reports/backtest_blend_params_full.md``.
-#
-# Backtests (see ``scripts/backtest_blend_params.py``) sweep these
-# against daily snapshots to verify the split is near-optimal for
-# rank stability.  Overriding at runtime is a supported pattern: the
-# backtest harness mutates the module attribute directly before each
-# ``build_api_data_contract`` call, so keep the names stable.
-_BLEND_MEAN_WEIGHT: float = 0.7
-_BLEND_ROBUST_WEIGHT: float = 0.3
-
-# Source-rank-scaled monotonicity step.  When the natural boosted
-# value overshoots ``_DISPLAY_SCALE_MAX`` (9999) for a cluster of
-# top-of-board rows, a fixed-step cap (e.g. "always 100 pts down
-# per rank") flattens the top into equal stairs — but the real
-# rank-consistency signal varies row to row:
-#   - Allen (blendedSourceRank 1.1) vs Maye (3.9) = 2.8-rank gap
-#     → Allen is far and away the consensus #1; a big visible
-#     cliff here is justified.
-#   - Chase (5.0) vs Bijan (6.3) = 1.3-rank gap → typical step.
-#   - Two adjacent players within ~0.5 source-rank of each other
-#     should collapse to a near-flat display gap; a large fixed
-#     step would fabricate separation that isn't in the source data.
-# Scaling the step by the ``blendedSourceRank`` delta between
-# consecutive rows ties the visible cliff shape directly to the
-# actual source consensus.  ``_MONOTONICITY_BASE_STEP`` is the step
-# per 1.0-rank-gap; floor/ceiling prevent zero-step collapse on
-# rank ties / inversions and runaway cliffs on huge gaps.
-_MONOTONICITY_BASE_STEP: int = 75
-_MONOTONICITY_STEP_FLOOR: int = 25
-_MONOTONICITY_STEP_CEIL: int = 250
-
 _DISPLAY_SCALE_MAX: int = 9999
-
-
-def _apply_volatility_compression_post_pass(
-    players_array: list[dict[str, Any]],
-    players_by_name: dict[str, Any],
-) -> None:
-    """Adjust ``rankDerivedValue`` symmetrically by source disagreement.
-
-    Extends Step 5 of the canonical engine
-    (``compute_volatility_adjustments`` in
-    ``src/canonical/player_valuation.py:349-391``) to be two-sided:
-    high-disagreement rows (z > 0) get compressed down to the FLOOR,
-    high-agreement rows (z < 0) get boosted up to the CEIL.  Driven
-    by the coverage-corrected ``sourceRankPercentileSpread`` stamped
-    in Phase 4 (not raw ``stdev(source_ranks)``) so heterogeneous
-    source depths (DLF IDP=185 vs FBG IDP=400) do not masquerade as
-    genuine disagreement.
-
-    Only rows with a non-None ``sourceRankPercentileSpread`` and a
-    positive ``rankDerivedValue`` participate.  Picks are skipped
-    because ``_anchor_current_year_picks_to_rookies`` overrides their
-    value from a rookie row — the pick row's own disagreement
-    signal is not a meaningful confidence signal for the anchored
-    value.
-
-    ``volatilityCompressionApplied`` is a signed fraction:
-        * positive = value compressed (high spread)
-        * negative = value boosted (high agreement)
-        * None     = no adjustment (fewer than 2 eligible, zero std,
-                     or picks/unranked rows)
-
-    Boost is clamped to ``DISPLAY_SCALE_MAX``.  The Phase 5 compact
-    resort handles monotonicity breaks from a boosted or compressed
-    value crossing a neighbor.  Mirrors the updated value into the
-    legacy ``players_by_name`` dict.
-    """
-    eligible: list[tuple[dict[str, Any], float, float]] = []
-    for row in players_array:
-        if row.get("canonicalConsensusRank") is None:
-            continue
-        if row.get("assetClass") == "pick":
-            continue
-        spread = row.get("sourceRankPercentileSpread")
-        if spread is None:
-            continue
-        try:
-            value = float(row.get("rankDerivedValue") or 0)
-        except (TypeError, ValueError):
-            continue
-        if value <= 0:
-            continue
-        eligible.append((row, value, float(spread)))
-
-    if len(eligible) < 2:
-        return
-
-    spreads = [s for _, _, s in eligible]
-    spread_mean = statistics.mean(spreads)
-    spread_std = statistics.stdev(spreads) if len(spreads) >= 2 else 0.0
-    if spread_std < 1e-9:
-        # Nothing to discriminate on — mark every eligible row as
-        # un-adjusted so delta merges clear prior state.
-        for row, _value, _spread in eligible:
-            row["volatilityCompressionApplied"] = None
-            legacy_ref = row.get("legacyRef")
-            if legacy_ref and legacy_ref in players_by_name:
-                pdata = players_by_name[legacy_ref]
-                if isinstance(pdata, dict):
-                    pdata["volatilityCompressionApplied"] = None
-        return
-
-    max_compress = 1.0 - _VOLATILITY_COMPRESSION_FLOOR
-    max_boost = _VOLATILITY_COMPRESSION_CEIL - 1.0
-    strength = _VOLATILITY_COMPRESSION_STRENGTH
-
-    # Process in canonical rank order so the monotonicity-preserving
-    # boost cap (see ``prior_post_value`` below) can reach back to
-    # the immediately-higher-ranked row.  Without this sort the raw
-    # ``eligible`` order is insertion order from the players_array
-    # walk above, which is already rank-desc for historical reasons,
-    # but making the sort explicit guards against future callers that
-    # might append rows out of order.
-    eligible.sort(
-        key=lambda triple: int(triple[0].get("canonicalConsensusRank") or 10**9)
-    )
-
-    # Tracks the post-adjustment ``rankDerivedValue`` of the row we
-    # just processed.  When a boost (``z < 0``) would raise the
-    # current row to or above ``prior_post_value``, we clamp it to
-    # ``prior_post_value - 1`` so rank 1 stays strictly above rank 2,
-    # rank 2 stays strictly above rank 3, etc.  Prevents the
-    # ``_DISPLAY_SCALE_MAX`` clamp from collapsing multiple
-    # high-agreement top players onto a single 9999 plateau (e.g.
-    # Josh Allen at rank 1 and Drake Maye at rank 2 both hitting
-    # 9999 because each raw-boosted value exceeds 9999 and clamps).
-    # Compression (``z > 0``) is NOT constrained here — any
-    # compression-induced inversion is fixed by the Phase 5 compact
-    # resort that runs after this pass.
-    prior_post_value: int | None = None
-    prior_blended_rank: float | None = None
-
-    for row, value, spread in eligible:
-        z = (spread - spread_mean) / spread_std
-        legacy_ref = row.get("legacyRef")
-        pdata = (
-            players_by_name.get(legacy_ref)
-            if legacy_ref and legacy_ref in players_by_name
-            else None
-        )
-
-        # Snapshot the pre-volatility value before any
-        # compression/boost arithmetic mutates it.  This is what the
-        # row held after the 60/40 weighted-mean / robust-median
-        # blend but BEFORE the volatility pass touched it — used by
-        # the PlayerPopup value-chain display so users can see each
-        # stage of the value derivation individually.  We also mirror
-        # into the legacy ``players_by_name`` dict so frontend rows
-        # that read from either contract shape can see it.
-        pre_vol_value = int(row.get("rankDerivedValue") or 0)
-        row["preVolatilityValue"] = pre_vol_value
-        if isinstance(pdata, dict):
-            pdata["preVolatilityValue"] = pre_vol_value
-
-        # Pull the blended source rank (mean of effective per-source
-        # ranks) stamped in Phase 4a.  Falls back to canonical rank
-        # if the row is missing a blend (single-source rows, picks).
-        bsr_raw = row.get("blendedSourceRank")
-        current_blended_rank: float | None
-        if isinstance(bsr_raw, (int, float)):
-            current_blended_rank = float(bsr_raw)
-        else:
-            ccr = row.get("canonicalConsensusRank")
-            current_blended_rank = float(ccr) if isinstance(ccr, (int, float)) else None
-
-        if z > 0:
-            frac = min(z * strength, max_compress)
-            # Compression moves values downward; no ceiling clamp
-            # needed and compression-branch values above 9999 are
-            # deliberately preserved.  The inline TEP multiplier can
-            # inflate the pre-volatility blend above the display
-            # scale (a Hill rank-1 value of 9999 × 1.15 = 11499),
-            # and a downstream Phase 5 resort is the right place to
-            # handle out-of-range display values rather than the
-            # volatility pass clamping mid-pipeline.
-            new_val = max(1, int(round(value * (1.0 - frac))))
-            signed_frac = round(frac, 4)
-        elif z < 0:
-            frac = min(abs(z) * strength, max_boost)
-            boosted = max(1, int(round(value * (1.0 + frac))))
-            # Monotonicity-preserving ceiling on boost, scaled by
-            # the source-rank gap between this row and the prior:
-            #   step = BASE * (bsr[N] − bsr[N−1])  clamped to [FLOOR, CEIL]
-            # A 2.8-rank gap (Allen 1.1 → Maye 3.9) yields a ~210-pt
-            # cliff; a 0.8-rank gap (Gibbs → Daniels) yields ~60.
-            # Rows whose natural boosted value falls below the
-            # capped ceiling use their natural value untouched, so
-            # the cap only shapes rows that would otherwise clamp
-            # at _DISPLAY_SCALE_MAX.
-            ceiling = _DISPLAY_SCALE_MAX
-            if prior_post_value is not None and prior_post_value <= _DISPLAY_SCALE_MAX:
-                if (
-                    prior_blended_rank is not None
-                    and current_blended_rank is not None
-                    and current_blended_rank > prior_blended_rank
-                ):
-                    rank_gap = current_blended_rank - prior_blended_rank
-                    raw_step = int(round(_MONOTONICITY_BASE_STEP * rank_gap))
-                else:
-                    # Rank inversion or tie (no positive gap) — fall
-                    # back to the base step so we still enforce a
-                    # minimum visible cliff between ranks.
-                    raw_step = _MONOTONICITY_BASE_STEP
-                step = max(
-                    _MONOTONICITY_STEP_FLOOR,
-                    min(_MONOTONICITY_STEP_CEIL, raw_step),
-                )
-                ceiling = min(ceiling, prior_post_value - step)
-            new_val = max(1, min(boosted, ceiling))
-            signed_frac = round(-frac, 4)
-        else:
-            new_val = int(value)
-            signed_frac = None
-
-        # Track the ``min(new_val, _DISPLAY_SCALE_MAX)`` view of
-        # this row so a compression-branch value above 9999 can't
-        # lift the next row's boost ceiling above 9999.  Any row
-        # (boost, compress, no-op) can constrain the next boost.
-        prior_post_value = min(new_val, _DISPLAY_SCALE_MAX)
-        # Track the blended rank too so the NEXT row's cliff step
-        # can be scaled against the source-consensus gap.
-        if current_blended_rank is not None:
-            prior_blended_rank = current_blended_rank
-
-        # When z is on either side but frac rounds to zero (very small
-        # |z|), skip the value mutation to avoid spurious 1-point
-        # drift but still emit an explicit None so delta merges clear
-        # prior state.
-        if signed_frac is None or abs(signed_frac) < 1e-9:
-            row["volatilityCompressionApplied"] = None
-            if isinstance(pdata, dict):
-                pdata["volatilityCompressionApplied"] = None
-            continue
-
-        row["rankDerivedValue"] = new_val
-        row["volatilityCompressionApplied"] = signed_frac
-        if isinstance(pdata, dict):
-            pdata["rankDerivedValue"] = new_val
-            pdata["volatilityCompressionApplied"] = signed_frac
 
 
 def _reassign_pick_slot_order(players_array: list[dict[str, Any]]) -> int:
@@ -4604,14 +4332,13 @@ def _compute_unified_rankings(
     for row_idx, source_ranks in row_source_ranks.items():
         # Compute the per-source value contributions and effective weights
         # in lockstep so we can apply both a weighted-mean and a
-        # robust-median blend.  The two blends are then combined: the
-        # final blended value is the average of the weighted mean and
-        # the robust median.  This downweights single-outlier sources
-        # (e.g. an IDPTC dynasty value that grossly under-prices
-        # established stars like T.J. Watt or Nick Bosa) without losing
-        # the cross-source signal entirely.
-        contributions: list[tuple[float, float]] = []  # (value, weight)
-        weight_total = 0.0
+        # trimmed mean-median aggregation (framework step 5).  The
+        # per-source ``effective_weight`` is stamped onto source meta
+        # for transparency but is NOT used in the aggregation — every
+        # source carries equal voice once trimmed.  Weighting will be
+        # reintroduced later as the hierarchical anchor / subgroup
+        # structure (framework steps 7–8).
+        contributions: list[tuple[float, float]] = []  # (value, effective_weight)
         # TE positions trigger the TEP boost.  Read once per row so
         # the per-source inner loop does not keep re-checking the
         # position string.  IDP positions (DL/LB/DB) swap in the IDP-
@@ -4660,7 +4387,6 @@ def _compute_unified_rankings(
                 value *= tep_native_correction
                 tep_native_corrected = True
             contributions.append((value, effective_weight))
-            weight_total += effective_weight
             # Stamp value contribution onto per-source meta (for debugging)
             meta = row_source_meta[row_idx].get(source_key, {})
             meta["valueContribution"] = int(round(value))
@@ -4676,46 +4402,40 @@ def _compute_unified_rankings(
             blended_value = 0.0
             hill_value_spread: float | None = None
         else:
+            # Framework step 5: Trimmed Mean-Median Blend (unweighted).
+            # For N ≥ 3 sources:
+            #   1. drop the highest and the lowest raw Hill-curve value
+            #   2. compute the arithmetic mean of the remaining values
+            #   3. compute the median of the remaining values
+            #   4. blended_value = (trimmed_mean + trimmed_median) / 2
+            # For N = 2 we mean the two; for N = 1 we pass through.
+            #
+            # This replaces the earlier 0.7·weighted_mean + 0.3·robust
+            # convex combo.  Per-source ``effective_weight`` is no longer
+            # part of the aggregation — it's still stamped onto
+            # ``sourceRankMeta[*]["effectiveWeight"]`` for transparency
+            # but the blend treats every source equally once trimmed.
+            # Weighting is reintroduced in later PRs via the
+            # hierarchical anchor / subgroup-adjustment structure (the
+            # Final Framework, steps 7–8).
             values = [v for v, _w in contributions]
-            if weight_total > 0:
-                weighted_mean = (
-                    sum(v * w for v, w in contributions) / weight_total
-                )
-            else:
-                weighted_mean = sum(values) / len(values)
-
-            # Robust blend: when 5+ sources contribute, symmetrically
-            # trim both extremes — drop the most pessimistic AND the
-            # most optimistic value so a single bullish outlier gets
-            # the same discount as a single bearish one.  Only fires
-            # at 5+ because a 2-trim on 4 sources throws away half
-            # the signal.  3-4 sources keep the prior asymmetric
-            # behavior (drop only the worst).  2 = mean; 1 = use.
             sorted_vals = sorted(values)
-            if len(sorted_vals) >= 5:
+            n = len(sorted_vals)
+            if n >= 3:
                 trimmed = sorted_vals[1:-1]
-                robust = sum(trimmed) / len(trimmed)
-            elif len(sorted_vals) >= 3:
-                trimmed = sorted_vals[1:]  # drop the worst only
-                robust = sum(trimmed) / len(trimmed)
-            elif len(sorted_vals) == 2:
-                robust = sum(sorted_vals) / 2.0
+                trimmed_mean = sum(trimmed) / len(trimmed)
+                m = len(trimmed)
+                if m % 2 == 1:
+                    trimmed_median = float(trimmed[m // 2])
+                else:
+                    trimmed_median = (
+                        trimmed[m // 2 - 1] + trimmed[m // 2]
+                    ) / 2.0
+                blended_value = (trimmed_mean + trimmed_median) / 2.0
+            elif n == 2:
+                blended_value = (sorted_vals[0] + sorted_vals[1]) / 2.0
             else:
-                robust = sorted_vals[0]
-
-            # Final blended value: ``_BLEND_MEAN_WEIGHT`` /
-            # ``_BLEND_ROBUST_WEIGHT`` convex combination of the
-            # weighted-mean (structural) and robust-trimmed-median
-            # (outlier-resistant) aggregations.  Defaults to 70/30 so
-            # the configured source weights have the dominant voice
-            # while the robust blend still absorbs obvious outliers.
-            # The split was tuned via ``scripts/backtest_blend_params.py``
-            # against 25 daily snapshots; see the constant's doc block
-            # at definition site for the reasoning and results.
-            blended_value = (
-                _BLEND_MEAN_WEIGHT * weighted_mean
-                + _BLEND_ROBUST_WEIGHT * robust
-            )
+                blended_value = sorted_vals[0]
 
             # Separation diagnostic: stdev of per-source Hill-curve values
             # before the blend.  Pairs with sourceRankPercentileSpread
@@ -5020,17 +4740,13 @@ def _compute_unified_rankings(
     # reference but they do NOT mutate rankDerivedValue.
     # _apply_offense_calibration_post_pass(players_array, players_by_name)
 
-    # ── Phase 4d: Volatility compression ──
-    # Port of Step 5 of the canonical engine
-    # (src/canonical/player_valuation.py:349-391) but driven by the
-    # coverage-corrected sourceRankPercentileSpread (stamped in
-    # Phase 4) rather than raw stdev(source_ranks).  The percentile
-    # spread normalizes for heterogeneous source depths (DLF IDP=185
-    # vs FBG IDP=400); raw stdev does not.  The compact resort in
-    # Phase 5 will naturally reshuffle any rows whose compressed
-    # value crosses a neighbor.  Runs after IDP calibration so the
-    # compression dampens the already-calibrated value.
-    _apply_volatility_compression_post_pass(players_array, players_by_name)
+    # (Phase 4d — volatility compression — intentionally removed as
+    # part of the Final Framework transition.  A principled
+    # MAD-based volatility penalty with a fitted ``λ`` weight will
+    # reappear in a later PR once backtested.  The old ±8%
+    # compress/boost + 75-pt monotonicity cap was a heuristic stack
+    # sitting on top of the Hill curve and has been removed
+    # outright — see docs/architecture/live-value-pipeline-trace.md.)
 
     # ── Phase 5: Pick refinement passes (gated to picks) ──
     # 1) Reassign (rank, value) tuples within each (year, round) bucket
@@ -5455,7 +5171,6 @@ def _derive_player_row(
         "sourceRankSpread": None,
         "sourceRankPercentileSpread": None,
         "hillValueSpread": None,
-        "volatilityCompressionApplied": None,
         "marketGapDirection": "none",
         "marketGapMagnitude": None,
         "sourceAudit": {
@@ -5975,7 +5690,6 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "sourceRankSpread",
     "sourceRankPercentileSpread",
     "hillValueSpread",
-    "volatilityCompressionApplied",
     "isSingleSource",
     "isStructurallySingleSource",
     "hasSourceDisagreement",

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -2,25 +2,20 @@
 
 Pins the structural claim that the live path
 (``src/api/data_contract.py::_compute_unified_rankings``) applies
-exactly one Hill curve, at most one calibration multiplier, and at
-most one volatility adjustment to produce ``rankDerivedValue``.  No
-hidden second curve, no accidental double-calibration, no mystery
-remap.
+exactly one Hill curve + at most one calibration multiplier to
+produce ``rankDerivedValue``.  No hidden second curve, no accidental
+double-calibration, no mystery remap.
 
-The chain, as documented in the audit dated 2026-04-20:
+The chain, as of the Final Framework transition PR 1:
 
-    rankDerivedValueUncalibrated  (snapshot after Hill blend + TEP)
+    rankDerivedValueUncalibrated  (trimmed mean-median of per-source
+                                    Hill values, post-TEP)
         × (idpCalibrationMultiplier × idpFamilyScale)   (IDP rows only)
-        = preVolatilityValue
-        × (1 − volatilityCompressionApplied)            (compression z>0)
-        OR
-        min(preVolatilityValue × (1 + |vol|),           (boost z<0,
-            monotonicity_cap, _DISPLAY_SCALE_MAX)       clamped)
         = rankDerivedValue
 
-If a second curve is ever reintroduced (e.g. offense calibration
-re-enabled without the right gate, a new post-pass remap added),
-the identities below will break and this test will fail loudly.
+The prior volatility compression + monotonicity-cap post-pass has
+been removed outright.  ``preVolatilityValue`` and
+``volatilityCompressionApplied`` are no longer stamped.
 
 These tests are invariant-band style (PR #154): they assert the
 structural chain holds for today's snapshot, not specific values.
@@ -34,8 +29,6 @@ from typing import Any
 
 from src.api.data_contract import (
     _DISPLAY_SCALE_MAX,
-    _VOLATILITY_COMPRESSION_CEIL,
-    _VOLATILITY_COMPRESSION_FLOOR,
     build_api_data_contract,
 )
 
@@ -78,9 +71,9 @@ class TestOffenseHasNoCalibrationLayer(unittest.TestCase):
 
     ``_apply_offense_calibration_post_pass`` is intentionally commented
     out at ``src/api/data_contract.py::_compute_unified_rankings``
-    (~line 5021).  Re-enabling it without a new invariant test would
-    silently restack a second curve on top of the Hill blend.  This
-    test exists to catch that regression.
+    (around line 5021).  Re-enabling it without a new invariant test
+    would silently restack a second curve on top of the Hill blend.
+    This test exists to catch that regression.
     """
 
     def setUp(self) -> None:
@@ -109,18 +102,63 @@ class TestOffenseHasNoCalibrationLayer(unittest.TestCase):
         )
 
 
-class TestPreVolatilityChain(unittest.TestCase):
-    """``preVolatilityValue`` must equal the one-time calibration fold.
+class TestVolatilityPassIsRemoved(unittest.TestCase):
+    """No row should carry the stamps the removed volatility pass left.
 
-    For offense rows (no live calibration): preVolatilityValue
-    should equal rankDerivedValueUncalibrated exactly.
+    If ``_apply_volatility_compression_post_pass`` or an analogous
+    second remap is ever re-added without a principled λ / α choice,
+    this test will catch the re-introduction of the old stamps and
+    fail loudly.
+    """
 
-    For IDP rows: preVolatilityValue should equal
-    rankDerivedValueUncalibrated × idpCalibrationMultiplier ×
-    idpFamilyScale.  Because ``get_idp_bucket_multiplier`` already
-    folds family_scale into the bucket product, the live code
-    multiplies by the combined factor EXACTLY ONCE.  If someone
-    accidentally multiplies again, this test catches it.
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+
+    def test_no_row_carries_prevolatility_stamp(self) -> None:
+        offending = [
+            r.get("canonicalName")
+            for r in _ranked_rows(self.contract)
+            if "preVolatilityValue" in r
+        ]
+        self.assertFalse(
+            offending,
+            f"{len(offending)} row(s) carry the removed "
+            f"preVolatilityValue stamp: {offending[:5]}",
+        )
+
+    def test_no_row_carries_volatility_fraction_stamp(self) -> None:
+        offending = [
+            r.get("canonicalName")
+            for r in _ranked_rows(self.contract)
+            if "volatilityCompressionApplied" in r
+        ]
+        self.assertFalse(
+            offending,
+            f"{len(offending)} row(s) carry the removed "
+            f"volatilityCompressionApplied stamp: {offending[:5]}",
+        )
+
+
+class TestValueChain(unittest.TestCase):
+    """``rankDerivedValue`` is derived from exactly one Hill blend
+    and at most one calibration multiplier.
+
+    For offense rows (no live calibration): ``rankDerivedValue`` must
+    equal ``rankDerivedValueUncalibrated`` exactly.
+
+    For IDP rows with an active promoted calibration config:
+    ``rankDerivedValue`` must equal
+    ``rankDerivedValueUncalibrated × idpCalibrationMultiplier × idpFamilyScale``
+    applied exactly once.
+
+    For IDP rows without an active config (default test env —
+    ``tests/conftest.py`` redirects the config path): same as offense,
+    strict equality.
+
+    The deeper invariant under an active config is also exercised in
+    ``tests/idp_calibration/test_family_scale_once_only.py``.
     """
 
     def setUp(self) -> None:
@@ -129,209 +167,71 @@ class TestPreVolatilityChain(unittest.TestCase):
             self.skipTest("No live data")
         self.rows = _ranked_rows(self.contract)
 
-    def test_offense_pre_vol_equals_uncalibrated(self) -> None:
+    def test_offense_final_equals_uncalibrated(self) -> None:
         checked = 0
         for row in self.rows:
             pos = str(row.get("position") or "").upper()
             if pos not in _OFFENSE_POSITIONS:
                 continue
-            pre_vol = row.get("preVolatilityValue")
             uncal = row.get("rankDerivedValueUncalibrated")
-            if pre_vol is None or uncal is None:
+            final = row.get("rankDerivedValue")
+            if uncal is None or final is None:
                 continue
             self.assertEqual(
-                int(pre_vol),
+                int(final),
                 int(uncal),
                 f"{row.get('canonicalName')} offense row has "
-                f"preVolatilityValue={pre_vol} != "
+                f"rankDerivedValue={final} != "
                 f"rankDerivedValueUncalibrated={uncal}. "
-                f"Either offense calibration was re-enabled or a new "
-                f"mystery multiplier was inserted between Hill blend "
-                f"and volatility pass.",
+                f"Either offense calibration was re-enabled, or a new "
+                f"mystery multiplier was inserted after the blend.",
             )
             checked += 1
         self.assertGreater(checked, 50, "expected many offense anchors")
 
-    def test_idp_pre_vol_chain(self) -> None:
-        """IDP pre-volatility chain.
+    def test_idp_final_is_one_time_calibration_fold(self) -> None:
+        """IDP chain.
 
-        When calibration is ACTIVE (multiplier + family_scale fields
-        stamped on the row), preVolatilityValue must equal
-        uncalibrated × (bucket × family_scale), applied exactly once.
+        When calibration is active, ``rankDerivedValue`` equals
+        ``uncalibrated × (bucket × family_scale)`` applied exactly once.
 
-        When calibration is NEUTRAL (fields absent — the default test
-        env, see ``tests/conftest.py``), preVolatilityValue must equal
-        uncalibrated exactly, same as offense.
-
-        The deeper invariant — family_scale folded-once under an
-        active promoted config — is exercised separately in
-        ``tests/idp_calibration/test_family_scale_once_only.py``.
+        When calibration is neutral (fields absent), final equals
+        uncalibrated.
         """
         checked = 0
-        calibrated = 0
-        neutral = 0
         for row in self.rows:
             pos = str(row.get("position") or "").upper()
             if pos not in _IDP_POSITIONS:
                 continue
-            pre_vol = row.get("preVolatilityValue")
             uncal = row.get("rankDerivedValueUncalibrated")
-            if pre_vol is None or uncal is None:
+            final = row.get("rankDerivedValue")
+            if uncal is None or final is None:
                 continue
             bucket = row.get("idpCalibrationMultiplier")
             family = row.get("idpFamilyScale")
             if bucket is not None and family is not None:
                 expected = int(round(float(uncal) * float(bucket) * float(family)))
                 self.assertLessEqual(
-                    abs(int(pre_vol) - expected),
+                    abs(int(final) - expected),
                     2,
-                    f"{row.get('canonicalName')} IDP row (calibrated): "
-                    f"preVolatilityValue={pre_vol} "
-                    f"!= round(uncal={uncal} × bucket={bucket} × "
-                    f"family={family}) = {expected}. "
-                    f"family_scale may have been double-applied, or a "
-                    f"new IDP multiplier was introduced.",
+                    f"{row.get('canonicalName')} IDP (calibrated): "
+                    f"rankDerivedValue={final} != round("
+                    f"uncal={uncal} × bucket={bucket} × "
+                    f"family={family}) = {expected}.  family_scale may "
+                    f"have been double-applied, or a new IDP multiplier "
+                    f"was introduced.",
                 )
-                calibrated += 1
             else:
                 self.assertEqual(
-                    int(pre_vol),
+                    int(final),
                     int(uncal),
-                    f"{row.get('canonicalName')} IDP row (no "
-                    f"calibration): preVolatilityValue={pre_vol} != "
-                    f"rankDerivedValueUncalibrated={uncal}. A new IDP "
-                    f"post-pass was added between Hill blend and "
-                    f"volatility.",
+                    f"{row.get('canonicalName')} IDP (no calibration): "
+                    f"rankDerivedValue={final} != uncalibrated={uncal}. "
+                    f"A new IDP post-pass was added between Hill blend "
+                    f"and final.",
                 )
-                neutral += 1
             checked += 1
         self.assertGreater(checked, 30, "expected many IDP anchors")
-
-
-class TestVolatilityChain(unittest.TestCase):
-    """``rankDerivedValue`` must equal ``preVolatilityValue`` ± volatility.
-
-    For compression (``volatilityCompressionApplied > 0``):
-        rankDerivedValue ≈ preVolatilityValue × (1 − vol)
-    (exact to within rounding; compression is not capped, so the
-    identity is strict.)
-
-    For boost (``volatilityCompressionApplied < 0``):
-        rankDerivedValue ≤ preVolatilityValue × (1 + |vol|) + 1
-    AND rankDerivedValue ≤ _DISPLAY_SCALE_MAX
-    (the monotonicity cap plus the 9999 ceiling can clamp boosts below
-    the natural boosted value).
-
-    For unadjusted (``volatilityCompressionApplied is None``):
-        rankDerivedValue == preVolatilityValue exactly.
-    """
-
-    def setUp(self) -> None:
-        self.contract = _get()
-        if self.contract is None:
-            self.skipTest("No live data")
-        self.rows = _ranked_rows(self.contract)
-
-    def test_compression_matches_identity(self) -> None:
-        checked = 0
-        for row in self.rows:
-            vol = row.get("volatilityCompressionApplied")
-            pre_vol = row.get("preVolatilityValue")
-            final = row.get("rankDerivedValue")
-            if vol is None or pre_vol is None or final is None:
-                continue
-            if vol <= 0:
-                continue  # compression branch only
-            expected = int(round(float(pre_vol) * (1.0 - float(vol))))
-            self.assertLessEqual(
-                abs(int(final) - expected),
-                1,
-                f"{row.get('canonicalName')} compression chain broken: "
-                f"preVol={pre_vol} × (1 − {vol}) = {expected}, "
-                f"got rankDerivedValue={final}. A new post-pass may be "
-                f"mutating the value after volatility compression.",
-            )
-            checked += 1
-        self.assertGreater(
-            checked, 20, "expected many compressed rows in the live board"
-        )
-
-    def test_boost_respects_cap_and_ceiling(self) -> None:
-        checked = 0
-        for row in self.rows:
-            vol = row.get("volatilityCompressionApplied")
-            pre_vol = row.get("preVolatilityValue")
-            final = row.get("rankDerivedValue")
-            if vol is None or pre_vol is None or final is None:
-                continue
-            if vol >= 0:
-                continue  # boost branch only
-            natural_boost = int(round(float(pre_vol) * (1.0 + abs(float(vol)))))
-            # Boost may be capped by monotonicity; final must not
-            # EXCEED the natural boost (allowing +1 for rounding).
-            self.assertLessEqual(
-                int(final),
-                natural_boost + 1,
-                f"{row.get('canonicalName')} boost exceeded natural "
-                f"ceiling: pre={pre_vol}, vol={vol}, "
-                f"natural_boost={natural_boost}, final={final}. "
-                f"The volatility pass should never produce a value "
-                f"above the natural boost.",
-            )
-            self.assertLessEqual(
-                int(final),
-                _DISPLAY_SCALE_MAX,
-                f"{row.get('canonicalName')} post-boost value {final} "
-                f"exceeds display scale {_DISPLAY_SCALE_MAX}",
-            )
-            checked += 1
-        self.assertGreater(checked, 10, "expected many boosted rows")
-
-    def test_unadjusted_rows_pass_through(self) -> None:
-        checked = 0
-        for row in self.rows:
-            vol = row.get("volatilityCompressionApplied")
-            pre_vol = row.get("preVolatilityValue")
-            final = row.get("rankDerivedValue")
-            if vol is not None:
-                continue  # only unadjusted rows
-            if pre_vol is None or final is None:
-                continue
-            self.assertEqual(
-                int(final),
-                int(pre_vol),
-                f"{row.get('canonicalName')} has vol=None but "
-                f"preVolatilityValue={pre_vol} != rankDerivedValue={final}. "
-                f"The volatility pass should be a strict no-op when "
-                f"its applied fraction is None.",
-            )
-            checked += 1
-
-    def test_volatility_fraction_stays_in_bounds(self) -> None:
-        """``volatilityCompressionApplied`` must stay within the bounds
-        derived from FLOOR/CEIL constants.  A value outside this range
-        would indicate the bounds constants drifted or the strength
-        clamp broke.
-        """
-        max_compress = 1.0 - _VOLATILITY_COMPRESSION_FLOOR
-        max_boost = _VOLATILITY_COMPRESSION_CEIL - 1.0
-        for row in self.rows:
-            vol = row.get("volatilityCompressionApplied")
-            if vol is None:
-                continue
-            name = row.get("canonicalName")
-            self.assertLessEqual(
-                float(vol),
-                max_compress + 1e-9,
-                f"{name}: compression {vol} exceeds floor-derived "
-                f"max {max_compress}",
-            )
-            self.assertGreaterEqual(
-                float(vol),
-                -max_boost - 1e-9,
-                f"{name}: boost {vol} exceeds ceil-derived "
-                f"max {max_boost}",
-            )
 
 
 class TestNoSecondHillCurve(unittest.TestCase):
@@ -363,14 +263,33 @@ class TestNoSecondHillCurve(unittest.TestCase):
         top = int(offense[0]["rankDerivedValue"])
         bottom = int(offense[-1]["rankDerivedValue"])
         spread = top - bottom
-        # Single Hill curve with our constants: rank 1 ≈ 9999,
-        # rank 50 ≈ 5000.  A second curve would compress this below
-        # ~3000.  2500 is a forgiving floor — a real second-curve
-        # regression would drop it far below that.
+        # Single Hill curve with our constants: rank 1 ≈ 9999, rank 50
+        # ≈ 5000.  A second curve would compress this below ~3000.
+        # 2500 is a forgiving floor — a real second-curve regression
+        # would drop it far below that.
         self.assertGreater(
             spread,
             2500,
             f"Top-50 offense value spread collapsed to {spread} "
             f"({top}..{bottom}). A second Hill remap may have been "
-            f"introduced; investigate calibration / volatility passes.",
+            f"introduced; investigate calibration passes.",
+        )
+
+    def test_no_value_exceeds_display_scale(self) -> None:
+        """rankDerivedValue must stay within the display scale."""
+        offenders: list[tuple[str, int]] = []
+        for row in self.rows:
+            final = row.get("rankDerivedValue")
+            if final is None:
+                continue
+            try:
+                v = int(final)
+            except (TypeError, ValueError):
+                continue
+            if v > _DISPLAY_SCALE_MAX:
+                offenders.append((str(row.get("canonicalName") or ""), v))
+        self.assertFalse(
+            offenders,
+            f"Rows above _DISPLAY_SCALE_MAX={_DISPLAY_SCALE_MAX}: "
+            f"{offenders[:5]}",
         )

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -1042,27 +1042,15 @@ class TestTepMultiplier(unittest.TestCase):
 
     def test_tep_boost_does_not_touch_non_te_values(self) -> None:
         """Non-TE players must be unaffected by tep_multiplier at the
-        per-source contribution level, but may see small display-
-        value drift from cascading monotonicity-cap effects.
+        per-source contribution level.
 
-        The volatility-compression pass includes a monotonicity-
-        preserving ceiling at the top of the board (rank 1 ≤ 9999,
-        rank 2 ≤ 9998, rank 3 ≤ 9997, ...) to prevent multiple
-        high-agreement boosted players from collapsing onto a single
-        9999 plateau.  When the TEP slider moves a TE above a QB in
-        rank, the QB's ceiling can tighten by a handful of points
-        because its rank has shifted — the player's source inputs
-        are unchanged, but the ranking neighbourhood is.
-
-        As of the TEP-native correction landing, the cascading also
-        fires in the "tep went from 1.0 to 1.15" direction even when
-        no rank shifts occur: at tep=1.0 the correction drops TEP-
-        native TE contributions by ~13%; at tep=1.15 it passes them
-        through.  The resulting TE-value shift nudges adjacent non-TE
-        rows through the volatility-compression boost term even when
-        their own rank is stable.  We therefore allow a small (≤ 200
-        pts) drift for non-rank-shift rows and the larger cap-scaled
-        drift for rows whose rank did move.
+        Under the Final Framework's simpler blend (trimmed mean-median
+        with no volatility post-pass), non-TE rows have an extremely
+        small drift envelope: rank shifts propagate into a non-TE's
+        blend only through the trim pair (drop top + drop bottom),
+        which can flip if a neighbouring TE's boosted value nudges the
+        non-TE's contributions set.  Typical drift stays under 100 pts;
+        a 150-pt budget catches runaway regressions.
         """
         boosted = build_api_data_contract(
             _fixture_raw_payload(), tep_multiplier=1.15
@@ -1074,43 +1062,13 @@ class TestTepMultiplier(unittest.TestCase):
                 continue
             base_val = int(baseline_row.get("rankDerivedValue") or 0)
             boost_val = int(boosted_by_name[name].get("rankDerivedValue") or 0)
-            base_rank = baseline_row.get("canonicalConsensusRank")
-            boost_rank = boosted_by_name[name].get("canonicalConsensusRank")
-            if base_rank != boost_rank:
-                # Rank shifted — the monotonicity cap steps the
-                # ceiling down by up to ``_MONOTONICITY_STEP_CEIL``
-                # (250) per rank, depending on the source-rank gap
-                # between adjacent rows.  A two-rank TEP shuffle can
-                # therefore drift a non-TE's display value by up to
-                # ~500 pts (two max-sized steps), though the typical
-                # case sees much less.  We still assert the drift
-                # stays bounded by the cap's max step so a runaway
-                # drift surfaces as a regression.
-                rank_delta = abs(int(base_rank or 0) - int(boost_rank or 0))
-                allowed = max(100, 275 * max(1, rank_delta))
-                self.assertAlmostEqual(
-                    base_val, boost_val, delta=allowed,
-                    msg=(
-                        f"Non-TE {name} ({pos}) drifted more than "
-                        f"{allowed} pts ({rank_delta} rank shift) "
-                        f"under TEP boost: {base_val} -> {boost_val}"
-                    ),
-                )
-            else:
-                # No rank shift — drift should be bounded by the
-                # volatility-boost envelope.  The boost term maxes
-                # around ±8% of value for a single rank-neighbor
-                # shift, and most non-TE drift seen here is <2%.
-                # A 200-pt budget is a generous cap that still
-                # catches runaway regressions.
-                self.assertAlmostEqual(
-                    base_val, boost_val, delta=200,
-                    msg=(
-                        f"Non-TE {name} ({pos}) drifted > 200 pts under "
-                        f"TEP boost with no rank shift: "
-                        f"{base_val} -> {boost_val}"
-                    ),
-                )
+            self.assertAlmostEqual(
+                base_val, boost_val, delta=150,
+                msg=(
+                    f"Non-TE {name} ({pos}) drifted > 150 pts under "
+                    f"TEP boost: {base_val} -> {boost_val}"
+                ),
+            )
 
     def test_brock_bowers_mostly_proportional_boost(self) -> None:
         """A top TE with mixed-TEP coverage gets a measurable but sub-15% boost.
@@ -1119,8 +1077,14 @@ class TestTepMultiplier(unittest.TestCase):
         (non-TEP), idpTradeCalc (non-TEP), dlfSf (non-TEP), and
         dynastyNerdsSfTep (TEP-native).  Three of four contributions
         get multiplied by 1.15 and one passes through unchanged, so
-        the final blended value should be boosted by less than the
-        full 15% but meaningfully more than 0%.
+        the final blended value should be boosted but stay within
+        the 15% raw multiplier.
+
+        Under the post-Final-Framework trimmed mean-median blend, the
+        trim can drop the unboosted native contribution entirely,
+        leaving only boosted values in the aggregate — so the boost
+        can sit right at 1.15× (±rounding) rather than strictly
+        below it.
         """
         boosted = build_api_data_contract(
             _fixture_raw_payload(), tep_multiplier=1.15
@@ -1134,9 +1098,10 @@ class TestTepMultiplier(unittest.TestCase):
         )
         self.assertGreater(base_value, 0)
         self.assertGreater(boost_value, base_value)
-        # Cap: the boost cannot exceed the raw 15% multiplier because
-        # at least one source (dynastyNerdsSfTep) passes through unchanged.
-        self.assertLess(boost_value, int(base_value * 1.15))
+        # Cap: the boost cannot exceed the raw 15% multiplier.  Allow
+        # one point of integer-rounding slack because the comparison
+        # is int-vs-int.
+        self.assertLessEqual(boost_value, int(round(base_value * 1.15)) + 1)
         # Floor: the boost must be measurable (at least 1% on a 4-source
         # blend where 3 of 4 contributions get multiplied by 1.15).
         self.assertGreater(boost_value / base_value, 1.01)
@@ -1379,83 +1344,27 @@ class TestTepMultiplier(unittest.TestCase):
         rov = contract.get("rankingsOverride") or {}
         self.assertEqual(float(rov.get("tepMultiplier") or 0), 2.0)
 
-    def test_volatility_compression_always_emitted_in_delta(self) -> None:
-        """Every ranked delta entry must carry an explicit ``volatilityCompressionApplied`` value.
-
-        Regression guard for the silent-skip bug: the compression pass
-        used to only stamp ``volatilityCompressionApplied`` when a
-        penalty was applied and silently omitted the field otherwise.
-        That broke override merges — a player compressed in the base
-        contract but uncompressed after an override would keep the
-        stale fraction because ``mergeRankingsDelta`` overwrites only
-        fields present in the delta.  Every ranked row must emit an
-        explicit value (a float fraction or ``None``) so the merge
-        path can clear stale state deterministically.
+    def test_volatility_stamps_removed_from_delta(self) -> None:
+        """Regression guard for the Final Framework PR 1: the old
+        ``volatilityCompressionApplied`` and ``preVolatilityValue``
+        fields must not reappear on any delta entry.  If they do, the
+        removed post-pass was reintroduced somewhere.
         """
         delta = build_rankings_delta_payload(
             _fixture_raw_payload(),
             source_overrides={"ktc": {"include": False}},
         )
-        missing: list[str] = []
+        offenders: list[str] = []
         for entry in delta.get("rankingsDelta", {}).get("players", []):
-            # Only rows that actually received a rank participate in
-            # the compression pass; unranked rows legitimately never
-            # have the field set explicitly, but the _derive_player_row
-            # default covers those.
-            if entry.get("canonicalConsensusRank") is None:
-                continue
-            if "volatilityCompressionApplied" not in entry:
-                missing.append(entry.get("id", "<unknown>"))
+            if (
+                "volatilityCompressionApplied" in entry
+                or "preVolatilityValue" in entry
+            ):
+                offenders.append(entry.get("id", "<unknown>"))
         self.assertEqual(
-            missing, [],
-            "Ranked rows missing explicit volatilityCompressionApplied "
-            f"in delta payload: {missing[:10]}",
-        )
-
-    def test_volatility_adjustment_is_symmetric(self) -> None:
-        """``volatilityCompressionApplied`` carries signed fractions.
-
-        Positive values indicate the row was compressed (high source
-        disagreement); negative values indicate it was boosted (high
-        source agreement).  At least one of each sign must appear on
-        a heterogeneous fixture to confirm the two-sided math works.
-        None means either fewer than 2 eligible rows or the row's
-        spread sat exactly at the population mean.
-        """
-        from src.api.data_contract import (  # noqa: PLC0415
-            _apply_volatility_compression_post_pass,
-        )
-
-        # Synthetic eligible rows spanning low to high spread.
-        rows = [
-            {
-                "canonicalConsensusRank": i + 1,
-                "rankDerivedValue": 9500 - i * 400,
-                "sourceRankPercentileSpread": spread,
-                "legacyRef": None,
-                "assetClass": "offense",
-                "canonicalName": f"row{i}",
-            }
-            for i, spread in enumerate([0.02, 0.05, 0.35, 0.10, 0.01, 0.50, 0.03])
-        ]
-        _apply_volatility_compression_post_pass(rows, {})
-        signs = [
-            r.get("volatilityCompressionApplied") for r in rows
-        ]
-        positive = [s for s in signs if s is not None and s > 0]
-        negative = [s for s in signs if s is not None and s < 0]
-        self.assertTrue(
-            positive,
-            "Expected at least one compressed row (positive signed_frac)",
-        )
-        self.assertTrue(
-            negative,
-            "Expected at least one boosted row (negative signed_frac)",
-        )
-        # All fractions are bounded by the 8% ceiling on either side.
-        self.assertTrue(
-            all(abs(s) <= 0.08 + 1e-6 for s in signs if s is not None),
-            f"signed_frac exceeded |0.08| cap: {signs}",
+            offenders, [],
+            "Delta entries carry removed volatility stamps: "
+            f"{offenders[:10]}",
         )
 
     def test_delta_payload_reflects_tep_in_summary(self) -> None:

--- a/tests/idp_calibration/test_family_scale_once_only.py
+++ b/tests/idp_calibration/test_family_scale_once_only.py
@@ -13,7 +13,7 @@ that would reintroduce the bug.
 
 This test makes the invariant executable: with an explicit promoted
 config (family_scale=1.3, DL bucket=0.5), the live pipeline must
-produce ``preVolatilityValue ≈ rankDerivedValueUncalibrated × 0.5 × 1.3``
+produce ``rankDerivedValue ≈ rankDerivedValueUncalibrated × 0.5 × 1.3``
 for DL rows — a single combined multiplication, NOT a double one.
 
 If anyone re-introduces a second application of ``family_scale`` in
@@ -86,7 +86,7 @@ def _load_latest_raw() -> dict | None:
 
 def test_family_scale_is_folded_exactly_once(tmp_path, monkeypatch):
     """Full live-pipeline exercise: under an active promoted config,
-    ``preVolatilityValue`` for DL rows must equal
+    ``rankDerivedValue`` for DL rows must equal
     ``uncalibrated × (bucket × family_scale)`` once — never twice.
     """
     raw = _load_latest_raw()
@@ -113,10 +113,10 @@ def test_family_scale_is_folded_exactly_once(tmp_path, monkeypatch):
     checked = 0
     for row in dl_rows:
         uncal = row.get("rankDerivedValueUncalibrated")
-        pre_vol = row.get("preVolatilityValue")
+        final_val = row.get("rankDerivedValue")
         bucket = row.get("idpCalibrationMultiplier")
         family = row.get("idpFamilyScale")
-        if uncal is None or pre_vol is None:
+        if uncal is None or final_val is None:
             continue
         # Stamped components match the config exactly.
         assert bucket is not None and abs(bucket - DL_BUCKET) < 1e-6, (
@@ -130,9 +130,9 @@ def test_family_scale_is_folded_exactly_once(tmp_path, monkeypatch):
         # Combined factor is applied exactly once, not twice.
         expected_once = int(round(float(uncal) * expected_combined))
         expected_twice = int(round(float(uncal) * expected_combined * FAMILY_SCALE))
-        assert abs(int(pre_vol) - expected_once) <= 2, (
+        assert abs(int(final_val) - expected_once) <= 2, (
             f"{row.get('canonicalName')}: "
-            f"preVolatilityValue={pre_vol}, "
+            f"rankDerivedValue={final_val}, "
             f"uncal={uncal}, expected_once={expected_once} "
             f"(combined={expected_combined:.4f}). "
             f"family_scale may have been double-applied — "
@@ -140,8 +140,8 @@ def test_family_scale_is_folded_exactly_once(tmp_path, monkeypatch):
         )
         # Defensive: the observed value must NOT match the
         # double-apply expectation.
-        assert abs(int(pre_vol) - expected_twice) > 2, (
-            f"{row.get('canonicalName')}: preVolatilityValue={pre_vol} "
+        assert abs(int(final_val) - expected_twice) > 2, (
+            f"{row.get('canonicalName')}: rankDerivedValue={final_val} "
             f"matches double-application of family_scale "
             f"(expected_twice={expected_twice}). family_scale is being "
             f"applied twice."


### PR DESCRIPTION
## Summary
First step of the Final Framework transition. Removes the two pieces of arbitrary math explicitly called out in the Final Framework conversation:
- the ±8% volatility compress/boost post-pass (`_VOLATILITY_COMPRESSION_*` constants, 3 of them hand-tuned)
- the 75-point monotonicity cap (`_MONOTONICITY_*` constants, 3 of them hand-tuned)

And replaces the `0.7·weighted_mean + 0.3·robust_trimmed` convex combo (`_BLEND_MEAN_WEIGHT`, `_BLEND_ROBUST_WEIGHT`) with framework step 5 exactly: unweighted trimmed mean-median.

**Eight arbitrary constants removed.** Chain becomes `uncal × (IDP cal if active) = final`.

## User-visible changes
- Top of board drops 100-400 pts (no more agreement boost at 9999 ceiling)
- High-disagreement players rise up to 8% (no more compression penalty)
- IDP ordering shifts where IDPTC's hand-picked `weight=2.0` was biasing the aggregate (blend is now consensus across all sources equally; hierarchical anchor returns in later PR)
- PlayerPopup value-chain drops the volatility stage (stages: blended → IDP calibration)

## Test plan
- [x] `pytest tests/` — 1814 passed, 3 skipped, 157 subtests
- [x] `npm run build` (frontend) — clean
- [x] All 14 KTC reconciliation tests still green (Hill curve unchanged)
- [x] `TestPlayerRankingsUnchanged` invariant bands absorb the shift without touching
- [x] Two new guards added: `TestVolatilityPassIsRemoved` + `test_volatility_stamps_removed_from_delta` catch any reintroduction

## Remaining PRs in the Final Framework arc
- PR 2: percentile-per-source + Hill refit
- PR 3: MAD volatility penalty with backtested λ
- PR 4: hierarchical anchor + backtested α
- PR 5: soft fallback for unranked players

🤖 Generated with [Claude Code](https://claude.com/claude-code)