### PR TITLE
Framework steps 5-6 (rookie scope): V_rookie* master + rookie-source routing

### DIFF
--- a/docs/architecture/live-value-pipeline-trace.md
+++ b/docs/architecture/live-value-pipeline-trace.md
@@ -129,13 +129,20 @@ value = percentile_to_value(p, midpoint=c, slope=s)
 ```
 **Scope-level master curves (updated framework)**: each source's
 contribution uses its SCOPE-appropriate master, not the player's
-position family.  Three masters:
+position family.  Four masters:
 
 | Scope | Routing | Constants | Fit source(s) |
 |---|---|---|---|
 | GLOBAL | anchor source (`is_anchor=True` — IDPTC) | `HILL_GLOBAL_PERCENTILE_C=0.1880`, `_S=0.780` | IDPTC's combined offense+IDP pool |
-| OFFENSE | non-anchor sources with offense scope | `HILL_PERCENTILE_C=0.1100`, `_S=1.210` | mean-of-curves from KTC + DynastyDaddy + DynastyNerds |
-| IDP | non-anchor sources with IDP scope | `IDP_HILL_PERCENTILE_C=0.1130`, `_S=0.850` | IDPTC's IDP slice |
+| OFFENSE | non-anchor, non-rookie, offense scope | `HILL_PERCENTILE_C=0.1100`, `_S=1.210` | mean-of-curves from KTC + DynastyDaddy + DynastyNerds |
+| IDP | non-anchor, non-rookie, IDP scope | `IDP_HILL_PERCENTILE_C=0.1130`, `_S=0.850` | IDPTC's IDP slice |
+| ROOKIE | sources with `needs_rookie_translation=True` (DLF Rookie SF, DLF Rookie IDP) | `HILL_ROOKIE_PERCENTILE_C=0.1650`, `_S=0.905` | mean-of-curves from KTC rookie slice + IDPTC rookie slice |
+
+**Rookie sources skip the ladder translation** and use their
+**native pool size N_j** (~40-50 rookies) as the percentile
+denominator, not `_PERCENTILE_REFERENCE_N=500`.  The ROOKIE master's
+flatter shape encodes rookie-relative value decay (rookie #1 = 9999,
+rookie ~#25 ≈ mid-pack) directly, so no crosswalk is needed.
 
 Fit methodology (see `scripts/fit_hill_curve_percentile.py`):
 1. Fit each value-based source's implied Hill curve individually.

--- a/scripts/fit_hill_curve_percentile.py
+++ b/scripts/fit_hill_curve_percentile.py
@@ -95,6 +95,41 @@ def _load_idptc_idp_values() -> list[float]:
     return vs
 
 
+def _load_rookie_values(source_key: str) -> list[float]:
+    """Rookie-only values for the given value-based source.
+
+    Filters the latest snapshot to rookies and pulls the source's
+    value from each rookie's ``_canonicalSiteValues`` dict.  Returns
+    descending-sorted values.  Used to build the ROOKIE scope master
+    curve.
+    """
+    import json
+
+    candidates = sorted(
+        (REPO / "data").glob("dynasty_data_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        return []
+    with candidates[0].open() as f:
+        raw = json.load(f)
+    vs: list[float] = []
+    for _name, p in (raw.get("players") or {}).items():
+        if not (p.get("_isRookie") or p.get("_formatFitRookie")):
+            continue
+        site_values = (p or {}).get("_canonicalSiteValues") or {}
+        v = site_values.get(source_key)
+        try:
+            vf = float(v) if v is not None else 0.0
+        except (TypeError, ValueError):
+            continue
+        if vf > 0:
+            vs.append(vf)
+    vs.sort(reverse=True)
+    return vs
+
+
 def _percentile_pairs(values: list[float]) -> list[tuple[float, float]]:
     """Return [(p, normalized_v)] where normalized_v has top = 9999."""
     if len(values) < 2:
@@ -253,11 +288,32 @@ def main() -> int:
     else:
         print("  (no IDP value source data)")
 
+    print("\nROOKIE scope (rookie slices of value-based sources):")
+    rookie_fits: list[tuple[str, float, float]] = []
+    for label, src_key in (
+        ("KTC-Rookie", "ktc"),
+        ("IDPTC-Rookie", "idpTradeCalc"),
+    ):
+        rv = _load_rookie_values(src_key)
+        if len(rv) < 10:
+            print(
+                f"  {label:18s}  (only {len(rv)} rookies with values; skipping)"
+            )
+            continue
+        pairs = _percentile_pairs(rv)
+        c, s, mse = _fit(pairs)
+        rookie_fits.append((label, c, s))
+        print(
+            f"  {label:18s}  n={len(pairs):4d}  c={c:.4f}  "
+            f"s={s:.3f}  rmse={mse ** 0.5:.1f}"
+        )
+
     print("\nScope-level master curves (trimmed mean-median across per-source fits):")
     for scope_label, fits in (
         ("GLOBAL", global_fits),
         ("OFFENSE", offense_fits),
         ("IDP", idp_fits),
+        ("ROOKIE", rookie_fits),
     ):
         result = _fit_scope_master(scope_label, fits)
         if result is None:
@@ -277,6 +333,7 @@ def main() -> int:
         ("GLOBAL", global_fits),
         ("OFFENSE", offense_fits),
         ("IDP", idp_fits),
+        ("ROOKIE", rookie_fits),
     ):
         result = _fit_scope_master(scope_label, fits)
         if result is None:
@@ -291,6 +348,7 @@ def main() -> int:
         ("GLOBAL", global_fits),
         ("OFFENSE", offense_fits),
         ("IDP", idp_fits),
+        ("ROOKIE", rookie_fits),
     ):
         result = _fit_scope_master(scope_label, fits)
         if result is None:
@@ -307,6 +365,9 @@ def main() -> int:
         elif scope_label == "IDP":
             print(f"IDP_HILL_PERCENTILE_C: float = {c:.4f}")
             print(f"IDP_HILL_PERCENTILE_S: float = {s:.3f}")
+        elif scope_label == "ROOKIE":
+            print(f"HILL_ROOKIE_PERCENTILE_C: float = {c:.4f}")
+            print(f"HILL_ROOKIE_PERCENTILE_S: float = {s:.3f}")
         else:
             print(f"HILL_GLOBAL_PERCENTILE_C: float = {c:.4f}")
             print(f"HILL_GLOBAL_PERCENTILE_S: float = {s:.3f}")

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4174,25 +4174,38 @@ def _compute_unified_rankings(
         HILL_GLOBAL_PERCENTILE_S,
         HILL_PERCENTILE_C,
         HILL_PERCENTILE_S,
+        HILL_ROOKIE_PERCENTILE_C,
+        HILL_ROOKIE_PERCENTILE_S,
         IDP_HILL_PERCENTILE_C,
         IDP_HILL_PERCENTILE_S,
         percentile_to_value,
     )
 
-    # Updated framework (step 5-6): route each source to its scope-
-    # appropriate master curve, not per-player-position.  The anchor
-    # source (IDPTC — dual-scope offense+IDP) uses the GLOBAL master;
-    # offense-only sources use the OFFENSE master; IDP-only sources
-    # use the IDP master.  Picks are treated as offense-scope (they're
-    # embedded in KTC's offense pool, and dlfRookieSf anchors them to
-    # the offense rookie ladder).
+    # Updated framework (steps 5-6): route each source to its scope-
+    # appropriate master curve, not per-player-position.
+    #   is_anchor=True                   → GLOBAL master
+    #   needs_rookie_translation=True    → ROOKIE master
+    #   scope=overall_idp                → IDP master
+    #   everything else (offense, picks) → OFFENSE master
     def _curve_for_source(src_def: dict) -> tuple[float, float]:
         if src_def.get("is_anchor"):
             return HILL_GLOBAL_PERCENTILE_C, HILL_GLOBAL_PERCENTILE_S
+        if src_def.get("needs_rookie_translation"):
+            return HILL_ROOKIE_PERCENTILE_C, HILL_ROOKIE_PERCENTILE_S
         scope = str(src_def.get("scope") or "")
         if scope == SOURCE_SCOPE_OVERALL_IDP:
             return IDP_HILL_PERCENTILE_C, IDP_HILL_PERCENTILE_S
         return HILL_PERCENTILE_C, HILL_PERCENTILE_S
+
+    # Rookie sources compute percentile against their NATIVE pool
+    # (N_j = rookie-class size), not the fixed
+    # ``_PERCENTILE_REFERENCE_N``.  The ROOKIE master's shape
+    # already encodes rookie-relative value decay directly.
+    def _percentile_denom_for_source(src_def: dict, source_key: str) -> int:
+        if src_def.get("needs_rookie_translation"):
+            native_n = source_pool_sizes.get(source_key, 0) or 0
+            return max(2, native_n)
+        return _PERCENTILE_REFERENCE_N
 
     # Clamp TEP multiplier to a sane range.  1.0 is a no-op, 2.0 is
     # a generous upper bound (the slider UI caps at 1.5 today).  The
@@ -4427,23 +4440,12 @@ def _compute_unified_rankings(
                 ladder_depth_meta = len(shared_market_ladder)
                 backbone_depth_meta = shared_market_depth
             elif needs_rookie_xlate:
-                ref_key = (
-                    "idpTradeCalc"
-                    if row_scope == SOURCE_SCOPE_OVERALL_IDP
-                    else "ktc"
-                )
-                ladder = _build_rookie_ladder(
-                    ref_key,
-                    idp=(row_scope == SOURCE_SCOPE_OVERALL_IDP),
-                )
-                if ladder:
-                    effective_rank, method = translate_position_rank(
-                        raw_rank, ladder
-                    )
-                    ladder_depth_meta = len(ladder)
-                else:
-                    effective_rank = raw_rank
-                    method = TRANSLATION_FALLBACK
+                # Updated framework: rookie sources skip the ladder.
+                # The ROOKIE master curve + native-N percentile
+                # denominator together encode rookie-relative value
+                # decay — no reference-source crosswalk needed.
+                effective_rank = raw_rank
+                method = TRANSLATION_DIRECT
             else:
                 effective_rank = raw_rank
                 method = TRANSLATION_DIRECT
@@ -4532,14 +4534,13 @@ def _compute_unified_rankings(
             # GLOBAL master (IDPTC's native curve shape), not the
             # OFFENSE master.
             hill_c, hill_s = _curve_for_source(src_def)
-            # Percentile denominator is the FIXED reference pool size
-            # (_PERCENTILE_REFERENCE_N).  Effective rank is post-ladder
-            # (combined-pool coordinate), so dividing by a fixed N
-            # keeps every source's contribution in the same value
-            # scale.  A rank beyond the reference pool is clamped to
-            # p=1 (long tail of the Hill).
-            if _PERCENTILE_REFERENCE_N >= 2:
-                p = (float(eff_rank) - 1.0) / float(_PERCENTILE_REFERENCE_N - 1)
+            # Percentile denominator picks by source:
+            #   rookie sources → native pool size N_j (framework #2)
+            #   everything else → _PERCENTILE_REFERENCE_N (combined
+            #                     pool coordinate, post-ladder)
+            denom = _percentile_denom_for_source(src_def, source_key)
+            if denom >= 2:
+                p = (float(eff_rank) - 1.0) / float(denom - 1)
             else:
                 p = 0.0
             p = max(0.0, min(1.0, p))
@@ -4606,10 +4607,14 @@ def _compute_unified_rankings(
                 fallback_rank = pool_n + int(
                     round(pool_n * _SOFT_FALLBACK_DISTANCE)
                 )
-                if _PERCENTILE_REFERENCE_N >= 2:
+                # Use the source's own denominator rule so rookie
+                # sources stay in native-N space and offense/IDP/global
+                # sources stay in the combined-pool reference.
+                fb_denom = _percentile_denom_for_source(src, skey)
+                if fb_denom >= 2:
                     p_fallback = (
                         float(fallback_rank) - 1.0
-                    ) / float(_PERCENTILE_REFERENCE_N - 1)
+                    ) / float(fb_denom - 1)
                 else:
                     p_fallback = 1.0
                 p_fallback = max(0.0, min(1.0, p_fallback))

--- a/src/canonical/player_valuation.py
+++ b/src/canonical/player_valuation.py
@@ -101,6 +101,16 @@ HILL_PERCENTILE_S: float = 1.210
 # DraftSharks IDP).
 IDP_HILL_PERCENTILE_C: float = 0.1130
 IDP_HILL_PERCENTILE_S: float = 0.850
+#
+# ROOKIE master — fit from KTC + IDPTC rookie slices of the latest
+# snapshot.  Used for every rookie-only source's contributions
+# (DLF Rookie SF, DLF Rookie IDP).  Rookie sources use their NATIVE
+# pool size N_j (~40-50 rookies) for the percentile denominator; the
+# rookie master's flatter shape captures rookie-relative value decay
+# (rookie #1 = 9999, rookie ~#25 ≈ mid-pack) directly, so the prior
+# rookie-ladder translation via reference source is no longer needed.
+HILL_ROOKIE_PERCENTILE_C: float = 0.1650
+HILL_ROOKIE_PERCENTILE_S: float = 0.905
 
 # Step 4: Tier cliff injection
 CLIFF_BASE_POINTS: float = 120.0   # base cliff size in value units

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -550,6 +550,77 @@ class TestScopeMasterRouting(unittest.TestCase):
         )
 
 
+class TestRookieScopeRouting(unittest.TestCase):
+    """Framework steps 5-6 (rookie scope): rookie-only sources use
+    the ROOKIE master curve with their native pool size N_j, not a
+    ladder-translated rank against the OFFENSE / IDP master.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+        self.rows = _ranked_rows(self.contract)
+
+    def test_rookie_source_rank_one_gets_max_value(self) -> None:
+        """A rookie source's rank-1 player should have V=9999 from
+        the ROOKIE master (p=0).  Under the old ladder-translation
+        this value was the OFFENSE-master-mapped reference-source
+        rank and therefore less than 9999.
+        """
+        for row in self.rows:
+            meta = row.get("sourceRankMeta") or {}
+            for src_key in ("dlfRookieSf", "dlfRookieIdp"):
+                m = meta.get(src_key) or {}
+                if m.get("rawRank") != 1:
+                    continue
+                # Rookie rank 1 now maps to p=0 → V=9999 under ROOKIE
+                # master.  Ladder is off.
+                self.assertEqual(
+                    m.get("effectiveRank"),
+                    1,
+                    f"{src_key} rank-1 player "
+                    f"{row.get('canonicalName')} has eff_rank "
+                    f"{m.get('effectiveRank')} != 1 — rookie-ladder "
+                    f"translation should be OFF.",
+                )
+                self.assertEqual(
+                    int(m.get("valueContribution") or 0),
+                    9999,
+                    f"{src_key} rank-1 V="
+                    f"{m.get('valueContribution')} != 9999 — ROOKIE "
+                    f"master should map p=0 → 9999.",
+                )
+                return
+        self.skipTest("no rookie rank-1 player in snapshot")
+
+    def test_rookie_master_differs_from_offense_and_idp(self) -> None:
+        from src.canonical.player_valuation import (  # noqa: PLC0415
+            HILL_PERCENTILE_C,
+            HILL_PERCENTILE_S,
+            HILL_ROOKIE_PERCENTILE_C,
+            HILL_ROOKIE_PERCENTILE_S,
+            IDP_HILL_PERCENTILE_C,
+            IDP_HILL_PERCENTILE_S,
+            percentile_to_value,
+        )
+        p = 0.3
+        off_v = int(percentile_to_value(
+            p, midpoint=HILL_PERCENTILE_C, slope=HILL_PERCENTILE_S
+        ))
+        idp_v = int(percentile_to_value(
+            p, midpoint=IDP_HILL_PERCENTILE_C, slope=IDP_HILL_PERCENTILE_S
+        ))
+        rook_v = int(percentile_to_value(
+            p,
+            midpoint=HILL_ROOKIE_PERCENTILE_C,
+            slope=HILL_ROOKIE_PERCENTILE_S,
+        ))
+        # All three masters must produce distinct V at p=0.3.
+        self.assertNotEqual(rook_v, off_v)
+        self.assertNotEqual(rook_v, idp_v)
+
+
 class TestNoSecondHillCurve(unittest.TestCase):
     """No live row can carry values consistent with a second Hill remap.
 


### PR DESCRIPTION
## Summary
Closes the last literal framework gap: rookie-only sources (DLF Rookie SF, DLF Rookie IDP) now route through a dedicated ROOKIE scope master (`c=0.1650, s=0.905`), fit from KTC + IDPTC rookie slices, and compute percentile against their **native pool size** N_j (~40-50) rather than the combined-pool `_PERCENTILE_REFERENCE_N=500`.

## Changes
- **New master**: `HILL_ROOKIE_PERCENTILE_C/S` in `src/canonical/player_valuation.py`.
- **Routing** (`_curve_for_source`): `needs_rookie_translation=True` → ROOKIE master. Added BEFORE the IDP scope branch so rookie-IDP sources still hit ROOKIE.
- **Denominator** (`_percentile_denom_for_source`): rookie sources use their native pool N_j; others use the reference N.
- **Ladder dropped** for rookie sources in Phase 2 — no reference-source crosswalk needed.
- **Fit script**: new `_load_rookie_values()` + ROOKIE scope block.
- **Soft fallback**: uses the same per-source denominator rule.

## Test plan
- [x] `pytest tests/` — 1838 passed (+2 new rookie tests), 3 skipped
- [x] `npm run build` — clean
- [x] `TestRookieScopeRouting` pins: rookie rank 1 → V=9999 via ROOKIE master; ROOKIE produces distinct V from OFFENSE/IDP

## Production impact
Rookie-source contributions now follow a flatter rookie-native decay (ROOKIE c=0.165 vs OFFENSE c=0.110). Top rookies' rookie-source contribution = 9999 (up from ladder's ~9400); trimmed out at n≥5, so final values shift only modestly (α=0.10 shrinks further).

## Framework closure
All 12 steps now implemented for all four scopes (global, offense, IDP, rookie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)