### PR TITLE
Pick tethering: cover all 72 current-year slot picks via tail rookies

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3867,33 +3867,46 @@ def _anchor_current_year_picks_to_rookies(
     so each pick inherits the value of its corresponding rookie.
 
     Rookie ordering is a merged list of offense + IDP rookies sorted by
-    ``rankDerivedValue`` descending.  Pick (round, slot) maps 1-indexed to
-    rookie position = ``(round - 1) * N + slot`` where ``N`` is the
-    operator's Sleeper league roster count (resolved via
+    value descending.  Pick (round, slot) maps 1-indexed to rookie
+    position = ``(round - 1) * N + slot`` where ``N`` is the operator's
+    Sleeper league roster count (resolved via
     :func:`_resolve_league_roster_count`; falls back to 12 when the
-    league configuration isn't available).  Prior to that fix the
-    league size was hardcoded to 12, silently mis-anchoring picks on
-    10-team or 14-team leagues.
+    league configuration isn't available).
+
+    To cover all ``_ROOKIE_ANCHOR_ROUNDS * N`` picks (e.g. 72 for a
+    12-team league × 6 rounds), the pool includes rookies BEYOND the
+    top-``OVERALL_RANK_LIMIT`` cut — they're sourced from
+    ``_blendedValueUncapped`` when ``rankDerivedValue`` is zero.  This
+    covers deep rookies whose values the Hill blend computed but who
+    didn't survive the board cap; without it rounds 5 and 6 of the
+    current-year pick board would run out of tether targets around slot
+    53 and stamp ``rankDerivedValue=0`` on picks 5.06-6.12.
 
     Returns the number of picks anchored.  Callers are responsible for
     re-sorting the board by ``rankDerivedValue`` afterward so rank/value
     monotonicity (``assert_ranking_coherence``) is preserved.
     """
     league_size = _resolve_league_roster_count()
+
+    def _rookie_pool_value(row: dict[str, Any]) -> int:
+        primary = int(row.get("rankDerivedValue") or 0)
+        if primary > 0:
+            return primary
+        return int(row.get("_blendedValueUncapped") or 0)
+
     rookies = [
         r
         for r in players_array
         if r.get("assetClass") != "pick"
         and bool(r.get("rookie"))
-        and r.get("canonicalConsensusRank")
-        and (r.get("rankDerivedValue") or 0) > 0
+        and _rookie_pool_value(r) > 0
     ]
     if not rookies:
         return 0
     rookies.sort(
         key=lambda r: (
-            -int(r.get("rankDerivedValue") or 0),
-            int(r.get("canonicalConsensusRank") or 0),
+            -_rookie_pool_value(r),
+            int(r.get("canonicalConsensusRank") or 99999),
         )
     )
 
@@ -3915,7 +3928,7 @@ def _anchor_current_year_picks_to_rookies(
         if idx >= len(rookies):
             continue
         anchor = rookies[idx]
-        anchor_val = int(anchor.get("rankDerivedValue") or 0)
+        anchor_val = _rookie_pool_value(anchor)
         if anchor_val <= 0:
             continue
         # Anchor regardless of whether the pick itself survived the
@@ -4708,6 +4721,18 @@ def _compute_unified_rankings(
             mad_penalty = 0.0
 
         blended_value = max(0.0, center_value - mad_penalty)
+
+        # Stamp the uncapped blended value on every row.  ``rankDerivedValue``
+        # is only set for rows that survive the top-``OVERALL_RANK_LIMIT``
+        # sort; deep rookies (e.g. 2026 rookie class beyond the DLF top-60)
+        # fall out of that cap and lose their ``rankDerivedValue``.  Pick
+        # tethering needs them back — all 72 of a given year's slot picks
+        # must tether to a distinct rookie — so we keep the pre-cap blend
+        # value on every row in a separate field that's read only by the
+        # rookie-anchor pass.
+        players_array[row_idx]["_blendedValueUncapped"] = (
+            int(round(blended_value)) if blended_value > 0 else 0
+        )
 
         hill_value_spread = (
             statistics.stdev(all_values) if len(all_values) >= 2 else None

--- a/tests/api/test_pick_rookie_anchor.py
+++ b/tests/api/test_pick_rookie_anchor.py
@@ -184,6 +184,39 @@ class TestAnchorPassCore(unittest.TestCase):
         self.assertEqual(pick_601["rankDerivedValue"], 2000)
         self.assertNotIn("pickRookieAnchor", pick_601)
 
+    def test_tail_rookies_with_only_blended_value_included(self) -> None:
+        """Deep rookies whose Hill-blend output survived beyond the
+        top-``OVERALL_RANK_LIMIT`` cap (so they carry
+        ``_blendedValueUncapped`` instead of ``rankDerivedValue``) must
+        still participate in the tether pool.  Without this, rounds 5
+        and 6 of the current-year pick board run out of tether targets
+        around slot 53 and stamp ``rankDerivedValue=0`` on deep picks.
+        """
+        # 40 top-800 offense rookies + 35 tail rookies (only uncapped value).
+        top_rookies = [_make_rookie(f"Top{i}", i, 9000 - i * 50) for i in range(1, 41)]
+        tail_rookies: list[dict[str, Any]] = []
+        for i in range(1, 36):
+            r = _make_rookie(f"Tail{i}", 0, 0)
+            r["canonicalConsensusRank"] = None
+            r["_blendedValueUncapped"] = 1500 - i * 5  # strictly decreasing
+            tail_rookies.append(r)
+        picks = [
+            _make_pick(f"2026 Pick {rnd}.{slot:02d}", 100 + rnd * 12 + slot, 100)
+            for rnd in range(1, 7)
+            for slot in range(1, 13)
+        ]
+        players_array = top_rookies + tail_rookies + picks
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        # 40 top + 35 tail = 75 rookies → all 72 picks should tether.
+        self.assertEqual(anchored, 72)
+        # Slot 6.12 should be tethered (index 71); without tail rookies
+        # it would be skipped.
+        pick_612 = next(p for p in picks if p["canonicalName"] == "2026 Pick 6.12")
+        self.assertIn("pickRookieAnchor", pick_612)
+        self.assertGreater(int(pick_612["rankDerivedValue"]), 0)
+
 
 class TestAnchorEndToEnd(unittest.TestCase):
     """Verify the anchor flows end-to-end through the real contract
@@ -280,6 +313,34 @@ class TestAnchorEndToEnd(unittest.TestCase):
             offenders, [],
             f"2026 slot picks still hold ranks: "
             f"{[r.get('canonicalName') for r in offenders[:3]]}",
+        )
+
+    def test_all_72_current_year_picks_tethered(self) -> None:
+        """Every 2026 slot-specific pick (6 rounds × 12 slots = 72)
+        must be anchored to a distinct rookie via
+        ``_anchor_current_year_picks_to_rookies``.  The tether pool
+        draws from BOTH offense and IDP rookies, including tail
+        rookies that fell off the Phase 4 cap.
+        """
+        rows = self.contract["playersArray"]
+        picks = [
+            r for r in rows
+            if r.get("assetClass") == "pick"
+            and isinstance(r.get("canonicalName"), str)
+            and r["canonicalName"].startswith("2026 Pick ")
+        ]
+        if len(picks) < 72:
+            self.skipTest(f"Only {len(picks)} 2026 slot picks in contract")
+        untethered = [
+            p.get("canonicalName") for p in picks
+            if not p.get("pickRookieAnchor")
+        ]
+        self.assertEqual(
+            untethered, [],
+            f"2026 slot picks still untethered: {untethered[:5]}.  "
+            f"The combined offense+IDP rookie pool (including tail "
+            f"rookies with _blendedValueUncapped) should cover all "
+            f"72 picks.",
         )
 
     def test_coherence_preserved_after_anchor(self) -> None:


### PR DESCRIPTION
## Summary

Extend the current-year pick-tether pool so every one of the 72 slot picks (6 rounds × 12 slots) gets a distinct rookie anchor. Previously ~19 picks (5.06–6.12 on the current snapshot) came out untethered with ``rankDerivedValue=0`` because the pool filtered on fields (``canonicalConsensusRank``, ``rankDerivedValue > 0``) that are only stamped inside the ``OVERALL_RANK_LIMIT=800`` cap.

## Root cause

The rookie-anchor pool required ``canonicalConsensusRank`` + ``rankDerivedValue > 0``, which drops any rookie whose blend value fell below the top-800 cap. On the current snapshot the combined offense + IDP rookie pool with both fields stamped is ~53 rookies — enough for rounds 1-4 plus part of round 5. Meanwhile another ~44 rookies had real ``anchorValue`` + ``subgroupBlendValue`` stamps but no surviving ``rankDerivedValue``.

## Fix

1. **Stamp an uncapped pre-sort value on every row.** The Phase 2-3 blend loop now writes ``_blendedValueUncapped`` = ``max(0, center_value − mad_penalty)`` on every row, before the top-800 cut. Uses the leading underscore to keep it as a private field (not surfaced to the frontend).
2. **Widen the tether pool.** ``_anchor_current_year_picks_to_rookies`` now falls back to ``_blendedValueUncapped`` when a rookie's ``rankDerivedValue`` is zero. Same sort key (value desc), same slot math — just more rookies in the pool.

## Verification

| Round | Before     | After      |
| ----- | ---------- | ---------- |
| 1     | 12/12 ✓    | 12/12 ✓    |
| 2     | 12/12 ✓    | 12/12 ✓    |
| 3     | 12/12 ✓    | 12/12 ✓    |
| 4     | 12/12 ✓    | 12/12 ✓    |
| 5     | 5/12       | 12/12 ✓    |
| 6     | 0/12       | 12/12 ✓    |
| **Total** | **53/72** | **72/72 ✓** |

Sample tail anchors (post-change):
- 2026 Pick 5.06 → Tanner Koziol (v=1206)
- 2026 Pick 5.12 → Reggie Virgil (v=1180)
- 2026 Pick 6.01 → Josh Cuevas (v=1177)
- 2026 Pick 6.12 → Cade Klubnik (v=1146)

## Test plan

- [x] `python3 -m pytest tests/ -q`: **1824 passed, 3 skipped** (2 new tests).
- [x] `TestAnchorPassCore::test_tail_rookies_with_only_blended_value_included` — synthetic pool of 40 top + 35 tail rookies verifies the tail is walked once the top runs out.
- [x] `TestAnchorEndToEnd::test_all_72_current_year_picks_tethered` — live-contract invariant that every 2026 slot pick carries a ``pickRookieAnchor``.
- [ ] Post-merge: verify ``/api/data`` on prod shows a positive ``rankDerivedValue`` on every 2026 slot pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)