### PR TITLE
refit workflow: install pytest for the on-drift test gate

### DIFF
--- a/.github/workflows/refit-hill-curves.yml
+++ b/.github/workflows/refit-hill-curves.yml
@@ -56,6 +56,7 @@ jobs:
           set -Eeuo pipefail
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest
 
       - name: Run auto-refit driver
         id: refit


### PR DESCRIPTION
Fixes the apply path of the refit-hill-curves workflow.  First real dispatch (threshold=5) failed at the `Run test suite on refit` step with `No module named pytest` — pytest isn't in requirements.txt.  Adds an explicit install step.