### PR TITLE
Trade suggestions: source asset pool from the live contract

### DIFF
--- a/server.py
+++ b/server.py
@@ -2159,10 +2159,15 @@ async def post_trade_suggestions(request: Request):
     and categorized trade suggestions with market-edge signals
     and optional opponent-fit labels.
     """
-    if canonical_data is None:
+    # The suggestion engine now reads the live contract
+    # (``playersArray``) directly — no offline canonical snapshot
+    # required.  We only 503 if the live contract itself hasn't
+    # loaded, which indicates a server-bootstrap problem rather than
+    # a missing canonical build.
+    if not latest_contract_data or not latest_contract_data.get("playersArray"):
         return JSONResponse(
             status_code=503,
-            content={"error": "Canonical data not loaded. Trade suggestions require canonical values."},
+            content={"error": "Live contract not loaded yet. Retry in a moment."},
         )
     try:
         body = await request.json()
@@ -2176,45 +2181,28 @@ async def post_trade_suggestions(request: Request):
             content={"error": "Request body must include 'roster' as a non-empty array of player names."},
         )
 
-    from src.trade.suggestions import generate_suggestions
+    from src.trade.suggestions import (
+        build_asset_pool_from_contract,
+        generate_suggestions_from_pool,
+    )
 
     league_rosters = body.get("league_rosters")
     if league_rosters is not None and not isinstance(league_rosters, list):
         league_rosters = None
 
-    # Overlay live calibrated values on top of the static canonical
-    # snapshot before handing it to the suggestion engine. The
-    # canonical snapshot is built offline by
-    # scripts/canonical_build.py; the IDP calibration post-pass that
-    # runs inside build_api_data_contract does NOT mutate that
-    # snapshot, so by default trade suggestions would be computed on
-    # pre-calibration values. Walk the live playersArray, grab each
-    # ranked row's rankDerivedValue (calibrated), and override both
-    # display_value and calibrated_value on the matching asset so
-    # the suggestion engine sorts + fairness-checks on calibrated
-    # numbers.
-    live_by_name = _live_by_name_from_contract(latest_contract_data)
-
-    if live_by_name:
-        patched_assets = []
-        for asset in (canonical_data.get("assets") or []):
-            asset_name = str(asset.get("display_name") or "").strip()
-            live_val = live_by_name.get(asset_name)
-            if live_val is None:
-                patched_assets.append(asset)
-                continue
-            patched = dict(asset)
-            patched["display_value"] = live_val
-            patched["calibrated_value"] = live_val
-            patched_assets.append(patched)
-        canonical_data_for_suggestions = {**canonical_data, "assets": patched_assets}
-    else:
-        canonical_data_for_suggestions = canonical_data
+    # Build the asset pool directly from the live contract.  Every
+    # field the suggestion engine needs already lives on the
+    # ``playersArray`` rows (see ``build_asset_pool_from_contract``
+    # docstring for the field map).  This replaces the old two-step
+    # flow of (a) loading the offline canonical snapshot and
+    # (b) overlaying live values on top — with the contract-native
+    # path there's only one source of truth.
+    pool = build_asset_pool_from_contract(latest_contract_data)
 
     try:
-        result = generate_suggestions(
+        result = generate_suggestions_from_pool(
             roster_names=roster,
-            canonical_snapshot=canonical_data_for_suggestions,
+            pool=pool,
             league_rosters=league_rosters,
         )
     except Exception as e:

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -268,6 +268,131 @@ def build_asset_pool(
     return pool
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Contract-native asset pool
+# ──────────────────────────────────────────────────────────────────────
+
+def _universe_from_row(row: dict[str, Any]) -> str:
+    """Derive the asset's universe label from the live contract row.
+
+    Matches the labels the legacy canonical snapshot used so downstream
+    consumers (roster analysis, suggestion categories) see the same
+    universe strings.
+    """
+    if row.get("assetClass") == "pick":
+        return "picks"
+    pos = _norm_pos(str(row.get("position") or ""))
+    is_rookie = bool(row.get("rookie"))
+    if pos in {"DL", "LB", "DB"}:
+        return "idp_rookie" if is_rookie else "idp_vet"
+    return "offense_rookie" if is_rookie else "offense_vet"
+
+
+def build_asset_pool_from_contract(
+    contract: dict[str, Any],
+    *,
+    ktc_top_n: int = KTC_TOP_N_FILTER,
+) -> list[PlayerAsset]:
+    """Contract-native replacement for :func:`build_asset_pool`.
+
+    Reads the live ``playersArray`` directly instead of the offline
+    canonical snapshot, so ``/api/trade/suggestions`` can run without
+    requiring ``scripts/canonical_build.py`` to have produced a
+    snapshot.  Emits the same ``PlayerAsset`` shape as the snapshot
+    path so every downstream consumer (roster analysis, sell/buy
+    categories, balancer search) is unchanged.
+
+    Mapping:
+
+    =========================   ==================================================
+    ``PlayerAsset`` field       Source in ``contract``
+    =========================   ==================================================
+    ``name``                    ``row["canonicalName"]``
+    ``position``                ``row["position"]`` (normalised)
+    ``display_value``           ``row["rankDerivedValue"]``
+    ``calibrated_value``        same (live values are already calibrated)
+    ``source_count``            ``len(row["canonicalSiteValues"])`` (values > 0)
+    ``team``                    ``row["team"]``
+    ``rookie``                  ``row["rookie"]``
+    ``years_exp``               ``contract["players"][legacyRef]["_yearsExp"]``
+    ``universe``                derived from ``assetClass`` + position + rookie
+    ``dispersion_cv``           CV of ``canonicalSiteValues`` (values > 0)
+    =========================   ==================================================
+
+    Only rows with a positive ``rankDerivedValue`` are included; rows
+    that fell off the Phase 4 ``OVERALL_RANK_LIMIT`` cap or that have
+    no calibrated value are filtered out, matching the canonical-
+    snapshot filter that required ``calibrated_value`` to be present.
+    """
+    players_array = contract.get("playersArray") or []
+    legacy_players = contract.get("players") or {}
+
+    pool: list[PlayerAsset] = []
+    for row in players_array:
+        name = str(row.get("canonicalName") or row.get("displayName") or "").strip()
+        if not name:
+            continue
+        cv = row.get("rankDerivedValue")
+        if cv is None:
+            continue
+        try:
+            cv_int = int(cv)
+        except (TypeError, ValueError):
+            continue
+        if cv_int <= 0:
+            continue
+
+        pos = _norm_pos(str(row.get("position") or ""))
+        team = str(row.get("team") or "")
+
+        # Source values for dispersion CV + source_count.
+        site_values = row.get("canonicalSiteValues") or {}
+        sv_list: list[float] = []
+        if isinstance(site_values, dict):
+            for v in site_values.values():
+                try:
+                    f = float(v) if v is not None else 0.0
+                except (TypeError, ValueError):
+                    continue
+                if f > 0:
+                    sv_list.append(f)
+        dispersion = _compute_cv(sv_list)
+
+        # years_exp lives on the legacy players dict, not on the
+        # playersArray row.  Look it up via the row's legacyRef.
+        years_exp: int | None = None
+        legacy_ref = row.get("legacyRef") or name
+        legacy_entry = legacy_players.get(legacy_ref)
+        if isinstance(legacy_entry, dict):
+            raw_yrs = legacy_entry.get("_yearsExp")
+            if raw_yrs is not None:
+                try:
+                    years_exp = int(raw_yrs)
+                except (TypeError, ValueError):
+                    years_exp = None
+
+        pool.append(PlayerAsset(
+            name=name,
+            position=pos,
+            display_value=cv_int,
+            calibrated_value=cv_int,
+            source_count=len(sv_list),
+            team=team,
+            rookie=bool(row.get("rookie")),
+            years_exp=years_exp,
+            universe=_universe_from_row(row),
+            dispersion_cv=round(dispersion, 4) if dispersion is not None else None,
+        ))
+    pool.sort(key=lambda x: -x.display_value)
+
+    # ── Compute KTC rank and apply top-N filter ────────────────────
+    pool = _assign_ktc_ranks(pool)
+    if ktc_top_n > 0:
+        pool = _apply_ktc_top_n_filter(pool, ktc_top_n)
+
+    return pool
+
+
 def _assign_ktc_ranks(pool: list[PlayerAsset]) -> list[PlayerAsset]:
     """Assign 1-based KTC rank to each player based on KTC source value.
 
@@ -1024,31 +1149,30 @@ def _apply_quality_filters(
 
 # ── Main entry point ─────────────────────────────────────────────────
 
-def generate_suggestions(
+def generate_suggestions_from_pool(
     roster_names: list[str],
-    canonical_snapshot: dict[str, Any],
+    pool: list[PlayerAsset],
     *,
     starter_needs: dict[str, int] | None = None,
     max_per_type: int = MAX_SUGGESTIONS_PER_TYPE,
     league_rosters: list[dict[str, Any]] | None = None,
     ktc_top_n: int = KTC_TOP_N_FILTER,
 ) -> dict[str, Any]:
-    """Generate trade suggestions for a given roster.
+    """Generate trade suggestions against a pre-built asset pool.
 
-    Args:
-        roster_names: List of player names on the user's team.
-        canonical_snapshot: Full canonical snapshot with assets.
-        starter_needs: Override positional starter needs.
-        max_per_type: Max suggestions per category.
-        league_rosters: Optional list of opponent rosters for bilateral fit.
-            Each entry: {"team_name": "...", "players": ["name1", "name2", ...]}
-        ktc_top_n: Only suggest trades involving players in the KTC top N.
-            Set to 0 to disable.
+    This is the pool-native entry point — it skips asset-pool
+    construction so the caller controls where the pool comes from.
+    Used by ``/api/trade/suggestions`` in ``server.py`` to source the
+    pool directly from the live contract via
+    :func:`build_asset_pool_from_contract`, removing the need for an
+    offline canonical snapshot.
 
-    Returns:
-        Dict with suggestion categories, roster analysis, and metadata.
+    Args match :func:`generate_suggestions` except ``pool`` replaces
+    ``canonical_snapshot``.  ``ktc_top_n`` is informational-only here
+    (reported in metadata) — the pool is expected to have already had
+    the top-N filter applied by the caller.  Leaving the kwarg in the
+    signature avoids breaking existing consumers that pass it.
     """
-    pool = build_asset_pool(canonical_snapshot, ktc_top_n=ktc_top_n)
     roster = analyze_roster(roster_names, pool, starter_needs)
     roster_set = {n.lower().strip() for n in roster_names}
 
@@ -1127,6 +1251,34 @@ def generate_suggestions(
             "opponentRostersAnalyzed": len(opponent_analyses),
         },
     }
+
+
+def generate_suggestions(
+    roster_names: list[str],
+    canonical_snapshot: dict[str, Any],
+    *,
+    starter_needs: dict[str, int] | None = None,
+    max_per_type: int = MAX_SUGGESTIONS_PER_TYPE,
+    league_rosters: list[dict[str, Any]] | None = None,
+    ktc_top_n: int = KTC_TOP_N_FILTER,
+) -> dict[str, Any]:
+    """Canonical-snapshot entry point (legacy).
+
+    Preserved for tests and tooling that still pass the offline
+    canonical snapshot.  Production ``/api/trade/suggestions`` now
+    uses :func:`generate_suggestions_from_pool` with a pool built
+    directly from the live contract via
+    :func:`build_asset_pool_from_contract`.
+    """
+    pool = build_asset_pool(canonical_snapshot, ktc_top_n=ktc_top_n)
+    return generate_suggestions_from_pool(
+        roster_names=roster_names,
+        pool=pool,
+        starter_needs=starter_needs,
+        max_per_type=max_per_type,
+        league_rosters=league_rosters,
+        ktc_top_n=ktc_top_n,
+    )
 
 
 # ── Serializers ──────────────────────────────────────────────────────

--- a/tests/test_trade_suggestions.py
+++ b/tests/test_trade_suggestions.py
@@ -1608,3 +1608,181 @@ class TestKtcTopNFilter:
         for c in candidates:
             assert c.ktc_rank is not None
             assert c.ktc_rank <= 50
+
+
+class TestBuildAssetPoolFromContract:
+    """The contract-native asset pool builder is the migration target
+    for ``/api/trade/suggestions`` — it removes the requirement that
+    ``scripts/canonical_build.py`` has produced an offline snapshot
+    before the suggestion engine can run.
+
+    These tests pin the field-mapping from ``playersArray`` rows to
+    ``PlayerAsset`` objects.  The suggestion engine is unchanged; as
+    long as the pool shape matches, every downstream assertion that
+    worked against the canonical snapshot continues to hold.
+    """
+
+    def _contract(self, rows, players_dict=None):
+        return {
+            "playersArray": rows,
+            "players": players_dict or {},
+        }
+
+    def _row(
+        self,
+        name,
+        pos,
+        value,
+        *,
+        rookie=False,
+        team="",
+        site_values=None,
+        asset_class="player",
+        legacy_ref=None,
+    ):
+        return {
+            "canonicalName": name,
+            "displayName": name,
+            "position": pos,
+            "team": team,
+            "rookie": rookie,
+            "assetClass": asset_class,
+            "rankDerivedValue": value,
+            "canonicalSiteValues": site_values or {"ktc": value, "idpTradeCalc": value - 50},
+            "legacyRef": legacy_ref or name,
+        }
+
+    def test_builds_expected_player_fields(self):
+        from src.trade.suggestions import build_asset_pool_from_contract
+        rows = [
+            self._row("Josh Allen", "QB", 9997, team="BUF"),
+            self._row("Bijan Robinson", "RB", 9604, team="ATL"),
+        ]
+        # Legacy dict carries the years-of-experience the suggestion
+        # engine uses for prime-age boosts.
+        players_dict = {
+            "Josh Allen": {"_yearsExp": 7},
+            "Bijan Robinson": {"_yearsExp": 2},
+        }
+        pool = build_asset_pool_from_contract(
+            self._contract(rows, players_dict), ktc_top_n=0
+        )
+        assert len(pool) == 2
+        allen = next(p for p in pool if p.name == "Josh Allen")
+        bijan = next(p for p in pool if p.name == "Bijan Robinson")
+        assert allen.position == "QB"
+        assert allen.calibrated_value == 9997
+        assert allen.display_value == 9997
+        assert allen.team == "BUF"
+        assert allen.years_exp == 7
+        assert allen.universe == "offense_vet"
+        assert bijan.universe == "offense_vet"
+        assert bijan.years_exp == 2
+        # source_count == number of site values > 0.
+        assert allen.source_count == 2
+
+    def test_universe_labels(self):
+        from src.trade.suggestions import build_asset_pool_from_contract
+        rows = [
+            self._row("Josh Allen", "QB", 9000),                     # offense_vet
+            self._row("Jeremiyah Love", "RB", 7000, rookie=True),    # offense_rookie
+            self._row("Will Anderson", "DL", 7000),                  # idp_vet
+            self._row("Arvell Reese", "LB", 5000, rookie=True),      # idp_rookie
+            self._row("2026 Pick 1.01", "PICK", 9000,
+                      asset_class="pick", site_values={"ktc": 9000}),
+        ]
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
+        universes = {p.name: p.universe for p in pool}
+        assert universes["Josh Allen"] == "offense_vet"
+        assert universes["Jeremiyah Love"] == "offense_rookie"
+        assert universes["Will Anderson"] == "idp_vet"
+        assert universes["Arvell Reese"] == "idp_rookie"
+        assert universes["2026 Pick 1.01"] == "picks"
+
+    def test_skips_rows_without_value(self):
+        from src.trade.suggestions import build_asset_pool_from_contract
+        rows = [
+            self._row("Josh Allen", "QB", 9997),
+            # rankDerivedValue=0 → pool skip (mirrors canonical-snapshot
+            # filter that required calibrated_value to be present).
+            self._row("No Value Player", "WR", 0),
+            # rankDerivedValue=None → pool skip.
+            {**self._row("Missing Value", "WR", 1), "rankDerivedValue": None},
+        ]
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
+        names = {p.name for p in pool}
+        assert names == {"Josh Allen"}
+
+    def test_dispersion_cv_uses_canonical_site_values(self):
+        from src.trade.suggestions import build_asset_pool_from_contract
+        # Site values with meaningful spread → dispersion_cv > 0.
+        rows = [
+            self._row("Spread Player", "WR", 8000,
+                      site_values={"ktc": 9000, "idpTradeCalc": 7000, "dlfSf": 8000}),
+            # Identical site values → dispersion_cv == 0.
+            self._row("Consensus Player", "WR", 8000,
+                      site_values={"ktc": 8000, "idpTradeCalc": 8000, "dlfSf": 8000}),
+        ]
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
+        spread = next(p for p in pool if p.name == "Spread Player")
+        consensus = next(p for p in pool if p.name == "Consensus Player")
+        assert spread.dispersion_cv is not None and spread.dispersion_cv > 0
+        assert consensus.dispersion_cv == 0 or consensus.dispersion_cv is None
+
+    def test_pool_sorted_by_display_value_desc(self):
+        from src.trade.suggestions import build_asset_pool_from_contract
+        rows = [
+            self._row("Low Value", "WR", 3000),
+            self._row("High Value", "WR", 9000),
+            self._row("Mid Value", "WR", 6000),
+        ]
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
+        assert [p.name for p in pool] == ["High Value", "Mid Value", "Low Value"]
+
+    def test_ktc_top_n_filter_applies(self):
+        from src.trade.suggestions import build_asset_pool_from_contract, KTC_TOP_N_FILTER
+        rows = [
+            self._row(f"Player {i:03d}", "WR", 9999 - i)
+            for i in range(KTC_TOP_N_FILTER + 50)
+        ]
+        pool = build_asset_pool_from_contract(self._contract(rows))
+        # Every asset in the pool must have a ktc_rank within the filter.
+        assert len(pool) <= KTC_TOP_N_FILTER
+        for p in pool:
+            assert p.ktc_rank is not None and p.ktc_rank <= KTC_TOP_N_FILTER
+
+    def test_suggestion_engine_accepts_contract_pool(self):
+        """End-to-end: a pool built from a synthetic contract feeds
+        ``generate_suggestions_from_pool`` without errors and produces
+        a well-formed response with the expected top-level keys.
+        """
+        from src.trade.suggestions import (
+            build_asset_pool_from_contract,
+            generate_suggestions_from_pool,
+        )
+        rows = []
+        # Enough players to survive the starter-needs check + KTC filter.
+        positions = [("QB", 10), ("RB", 12), ("WR", 15), ("TE", 8)]
+        value = 9500
+        for pos, n in positions:
+            for i in range(n):
+                rows.append(
+                    self._row(f"{pos}{i:02d}", pos, value, team="X")
+                )
+                value -= 25
+        pool = build_asset_pool_from_contract(
+            self._contract(rows), ktc_top_n=0
+        )
+        roster_names = ["QB00", "RB00", "WR00", "WR01", "TE00"]
+        result = generate_suggestions_from_pool(
+            roster_names=roster_names,
+            pool=pool,
+        )
+        # Response shape matches the canonical-snapshot path.
+        assert "rosterAnalysis" in result
+        assert "sellHigh" in result
+        assert "buyLow" in result
+        assert "consolidation" in result
+        assert "positionalUpgrades" in result
+        assert "metadata" in result
+        assert result["metadata"]["assetPoolSize"] == len(pool)


### PR DESCRIPTION
## Summary

Step 1 of 2 on the canonical-pipeline purge.  Moves ``POST /api/trade/suggestions`` off the offline canonical snapshot (``data/canonical/canonical_snapshot_*.json``) and onto the live ``/api/data`` contract.  The canonical-pipeline scripts / modules / CI steps stay in place for this PR — they come out in a follow-up purge once the migration has baked.

### Why

Before this PR, ``/api/trade/suggestions`` returned 503 when the offline canonical snapshot wasn't loaded, and its response was always patched with live values overlaid on top of the snapshot anyway (server.py:2196-2212).  The overlay existed because the live pipeline's IDP calibration post-pass mutates ``rankDerivedValue`` but leaves the canonical snapshot untouched.

The live contract already carries every field the suggestion engine consumes:

| ``PlayerAsset`` field  | Source on ``playersArray`` row       |
| ---------------------- | ------------------------------------ |
| ``name``               | ``canonicalName``                    |
| ``position``           | ``position`` (normalised)            |
| ``calibrated_value``   | ``rankDerivedValue``                 |
| ``display_value``      | same                                 |
| ``team``               | ``team``                             |
| ``rookie``             | ``rookie``                           |
| ``years_exp``          | ``contract.players[legacyRef]._yearsExp`` |
| ``universe``           | derived from ``assetClass`` + position + rookie |
| ``source_count``       | ``canonicalSiteValues`` count ( > 0) |
| ``dispersion_cv``      | CV of ``canonicalSiteValues``        |

Reading the contract directly removes the two-step overlay *and* the hard dependency on ``scripts/canonical_build.py``.

### Changes

**``src/trade/suggestions.py``**
- New ``build_asset_pool_from_contract(contract, *, ktc_top_n=...)`` — contract-native replacement for ``build_asset_pool``.
- New ``generate_suggestions_from_pool(roster_names, pool, ...)`` — pool-native entry point so callers control where the pool comes from.
- Existing ``generate_suggestions(roster_names, canonical_snapshot, ...)`` preserved as a thin wrapper for back-compat with tests + tooling.

**``server.py``**
- ``POST /api/trade/suggestions`` builds the pool from ``latest_contract_data`` and calls the new pool-native entry point.
- 503 gate swapped from ``canonical_data is None`` → ``live contract not loaded``.
- Drops the 15-line live-value overlay block.

**``tests/test_trade_suggestions.py``**
- New ``TestBuildAssetPoolFromContract`` — 7 cases covering: field mapping, universe labels (offense/idp × rookie/vet + picks), value-filtering (``rankDerivedValue ≤ 0`` skipped), dispersion CV, display-value desc sort, KTC top-N filter, and end-to-end pool → ``generate_suggestions_from_pool`` handoff.

## Test plan

- [x] ``python3 -m pytest tests/ -q``: **1829 passed, 3 skipped** (was 1822, +7 new).
- [x] Live smoke: ``/api/trade/suggestions`` with a QB-heavy roster returns real sell-high suggestions (Mahomes → Nabers etc.) — identical response shape.
- [x] Existing ``generate_suggestions(canonical_snapshot=...)`` tests still pass unchanged (legacy wrapper still builds the pool the same way).

## What's next (separate PR)

Once this bakes in production, the follow-up purge can remove ~2000 lines:

- ``scripts/canonical_build.py``, ``scripts/source_pull.py``, ``scripts/run_comparison_batch.py``, ``scripts/league_refresh.py``
- ``src/canonical/transform.py``, ``src/canonical/pipeline.py`` (non-live; their only LIVE-reachable consumer was the suggestion endpoint migrated here)
- ``_load_canonical_snapshot`` / ``CANONICAL_DATA_MODE`` branches in ``server.py``
- 5 CI steps across ``deploy.yml`` / ``pr-validation.yml`` / ``smoke-test.yml`` / ``scheduled-refresh.yml``
- ~4 tests that exercise the canonical build path

🤖 Generated with [Claude Code](https://claude.com/claude-code)