### PR TITLE
Value-sites vote directly; retire λ·MAD overlap

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3352,7 +3352,35 @@ _ALPHA_SHRINKAGE: float = 0.10
 # λ=0.10 is preferred because it imposes slightly more penalty on
 # high-disagreement players (the whole point of the MAD step)
 # without measurable stability cost.
-_MAD_PENALTY_LAMBDA: float = 0.10
+# **Retired 2026-04-20 (Final Framework override):** the count-aware
+# mean-median blend (drop max+min at n≥5, untrimmed at n=3-4) is
+# already a disagreement-damping mechanism on offense rows, and the
+# anchor + α-shrinkage hierarchical blend is already damping on IDP /
+# pick rows.  Keeping λ·MAD on top stacks two penalties on the same
+# signal (spread between sources) and hides the real movement when a
+# board shifts.  Setting λ=0 keeps the ``sourceMAD`` diagnostic stamp
+# (useful on the frontend value-chain panel) but applies zero penalty
+# to ``rankDerivedValue``.  If a new non-duplicative conservatism
+# layer is ever needed, reinstate it here with a fresh backtest.
+_MAD_PENALTY_LAMBDA: float = 0.0
+
+# Registry of sources whose raw per-player CSV value should be used
+# as a **direct normalized vote** in the Phase 2-3 blend, instead of
+# being re-modelled through the Hill/scope-master curve.  The user's
+# Final Framework override (2026-04-20) is: value-based sites feed
+# their real dollar-equivalent values straight into the aggregation;
+# rank-only sites continue through rank → percentile → Hill.  Sources
+# here correspond to the entries in ``_SOURCE_CSV_PATHS`` that carry
+# ``signal: value`` (explicit or default).  For a source's vote we
+# take ``canonicalSiteValues[key] / site_max × 9999`` so every site's
+# top player contributes 9999 and relative shape is preserved.
+_VALUE_BASED_SOURCES: frozenset[str] = frozenset({
+    "ktc",
+    "idpTradeCalc",
+    "dynastyDaddySf",
+    "draftSharks",
+    "draftSharksIdp",
+})
 
 # Final Framework step 9: soft fallback for unranked players.
 #
@@ -4430,6 +4458,29 @@ def _compute_unified_rankings(
             anchor_key = str(s.get("key") or "")
             break
 
+    # Final Framework override (2026-04-20): value-based sources vote
+    # with their raw site values, normalized so each site's top player
+    # contributes 9999.  Pre-compute each source's max observed value
+    # from ``canonicalSiteValues`` across the full player set so a
+    # single pass handles every row in the blend loop below.  We walk
+    # ``canonicalSiteValues`` (not ``maxValues``) because the top-level
+    # ``maxValues`` dict only tracks ktc + idpTradeCalc today; the other
+    # value-based sources (dynastyDaddySf, draftSharks, draftSharksIdp)
+    # carry their real values only inside the per-player dict.
+    value_source_max: dict[str, float] = {}
+    for row in players_array:
+        canonical_site_values = row.get("canonicalSiteValues") or {}
+        if not isinstance(canonical_site_values, dict):
+            continue
+        for key in _VALUE_BASED_SOURCES:
+            raw = canonical_site_values.get(key)
+            try:
+                raw_f = float(raw) if raw is not None else 0.0
+            except (TypeError, ValueError):
+                continue
+            if raw_f > value_source_max.get(key, 0.0):
+                value_source_max[key] = raw_f
+
     _trimmed_mean_median = count_aware_mean_median_blend
 
     row_normalized: list[tuple[float, int]] = []  # (blended_value, row_idx)
@@ -4455,25 +4506,58 @@ def _compute_unified_rankings(
         subgroup_values: list[float] = []
         all_values: list[float] = []  # full set for MAD
 
+        canonical_site_values = (
+            players_array[row_idx].get("canonicalSiteValues") or {}
+        )
+        if not isinstance(canonical_site_values, dict):
+            canonical_site_values = {}
+
         for source_key, eff_rank in source_ranks.items():
             src_def = src_by_key.get(source_key, {})
-            # Pick the SOURCE's scope master curve (not the row's
-            # position).  This is the updated-framework change —
-            # IDPTC's contribution to an offense player uses the
-            # GLOBAL master (IDPTC's native curve shape), not the
-            # OFFENSE master.
+            # Branch on source type:
+            #   - value-based sources (KTC, IDPTC, DD-SF, DraftSharks):
+            #     use the raw site value directly, normalized so that
+            #     each site's top player contributes 9999.  This is the
+            #     Final Framework override (2026-04-20) — real dollar-
+            #     equivalent values bypass the Hill curve entirely.
+            #   - rank-only sources: keep the rank → percentile → Hill
+            #     pipeline using the source's scope-master curve
+            #     (GLOBAL for the anchor, OFFENSE / IDP / ROOKIE for the
+            #     others; see ``_curve_for_source``).
+            #
+            # Hill + percentile fields in the per-source meta are still
+            # computed for diagnostic completeness even on the value-
+            # based branch.  ``valueContribution`` always reflects the
+            # value that actually enters aggregation.
             hill_c, hill_s = _curve_for_source(src_def)
-            # Percentile denominator picks by source:
-            #   rookie sources → native pool size N_j (framework #2)
-            #   everything else → _PERCENTILE_REFERENCE_N (combined
-            #                     pool coordinate, post-ladder)
             denom = _percentile_denom_for_source(src_def, source_key)
             if denom >= 2:
                 p = (float(eff_rank) - 1.0) / float(denom - 1)
             else:
                 p = 0.0
             p = max(0.0, min(1.0, p))
-            value = float(percentile_to_value(p, midpoint=hill_c, slope=hill_s))
+
+            if source_key in _VALUE_BASED_SOURCES:
+                raw_v = canonical_site_values.get(source_key)
+                try:
+                    raw_f = float(raw_v) if raw_v is not None else 0.0
+                except (TypeError, ValueError):
+                    raw_f = 0.0
+                site_max = value_source_max.get(source_key, 0.0)
+                if raw_f > 0.0 and site_max > 0.0:
+                    value = raw_f / site_max * 9999.0
+                else:
+                    # Fall back to the Hill path if the raw value is
+                    # missing/invalid — should be rare, but protects
+                    # against malformed site data dropping a source's
+                    # vote to zero silently.
+                    value = float(
+                        percentile_to_value(p, midpoint=hill_c, slope=hill_s)
+                    )
+            else:
+                value = float(
+                    percentile_to_value(p, midpoint=hill_c, slope=hill_s)
+                )
             tep_applied = False
             tep_native_corrected = False
             if apply_tep and source_key in tep_boosted_source_keys:
@@ -4496,6 +4580,11 @@ def _compute_unified_rankings(
             effective_weight = coverage_weight(declared_weight, src_def.get("depth"))
             meta["percentile"] = round(p, 6)
             meta["valueContribution"] = int(round(value))
+            meta["valueContributionPath"] = (
+                "value_direct"
+                if source_key in _VALUE_BASED_SOURCES and value_source_max.get(source_key, 0.0) > 0.0
+                else "rank_hill"
+            )
             meta["effectiveWeight"] = round(effective_weight, 4)
             meta["isAnchor"] = bool(source_key == anchor_key)
             if tep_applied:

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -82,27 +82,46 @@ class TestComputeKtcRankings(unittest.TestCase):
         )
         self.assertEqual([r["canonicalName"] for r in by_rank], ["High", "Mid", "Low"])
 
-    def test_rank_derived_value_uses_hill_formula(self):
+    def test_rank_derived_value_for_solo_top_player(self):
         rows = [self._make_player_row("Solo", "QB", 9999)]
         _compute_unified_rankings(rows, {})
         self.assertEqual(rows[0]["ktcRank"], 1)
-        # Under the Final Framework's percentile-input Hill, rank 1
-        # always maps to p=0 → V=9999 regardless of the fitted
-        # constants.  The rank-based alias ``rank_to_value(1)`` also
-        # returns 9999, so either curve agrees at rank 1.
+        # KTC is a value-based source under the Final Framework
+        # override — its raw 0-9999 value is fed directly into the
+        # blend.  The top player's KTC value (9999) is also the site's
+        # max, so the normalized vote is 9999/9999 × 9999 = 9999.
         self.assertEqual(rows[0]["rankDerivedValue"], 9999)
 
-    def test_rank_50_value_matches_hill_formula(self):
+    def test_value_based_source_uses_raw_value_directly(self):
+        """KTC is on the ``_VALUE_BASED_SOURCES`` allowlist, so its
+        per-player contribution to ``rankDerivedValue`` is the raw
+        ``canonicalSiteValues[ktc]`` normalized to 0-9999, NOT the
+        Hill-converted value for the player's rank.
+
+        This test constructs a single-source KTC pool where the raw
+        values descend linearly and asserts the blended value tracks
+        the raw value (scaled by the pool's max) rather than the
+        Hill curve's output at the percentile of the player's rank.
+        """
         rows = [self._make_player_row(f"P{i}", "WR", 9999 - i * 10) for i in range(60)]
         _compute_unified_rankings(rows, {})
         rank_50_row = next(r for r in rows if r.get("ktcRank") == 50)
-        # Final Framework percentile Hill: p = (50 − 1) / (REFERENCE_N − 1)
-        # with REFERENCE_N = 500 → p ≈ 0.098, V(p) per HILL_PERCENTILE_*
-        # constants.
+        raw_v = rank_50_row["canonicalSiteValues"]["ktc"]
+        # site_max comes from the same pool → P0's value 9999.
+        site_max = 9999
+        expected_direct = int(round(raw_v / site_max * 9999.0))
+        self.assertEqual(rank_50_row["rankDerivedValue"], expected_direct)
+        # And the value is NOT the Hill output at p=49/499 ≈ 0.098,
+        # which would yield a much lower value under HILL_PERCENTILE_*.
         from src.api.data_contract import _PERCENTILE_REFERENCE_N  # noqa: PLC0415
-        p = (50 - 1) / (_PERCENTILE_REFERENCE_N - 1)
-        expected = int(percentile_to_value(p))
-        self.assertEqual(rank_50_row["rankDerivedValue"], expected)
+        hill_p = (50 - 1) / (_PERCENTILE_REFERENCE_N - 1)
+        hill_value = int(percentile_to_value(hill_p))
+        self.assertNotEqual(
+            rank_50_row["rankDerivedValue"], hill_value,
+            "Value-based source should NOT be routed through the Hill "
+            "curve — ``rankDerivedValue`` must reflect the raw normalized "
+            "site value."
+        )
 
     def test_picks_included(self):
         """Picks with source values participate in the unified ranking."""

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -727,3 +727,214 @@ class TestNoSecondHillCurve(unittest.TestCase):
             f"Rows above _DISPLAY_SCALE_MAX={_DISPLAY_SCALE_MAX}: "
             f"{offenders[:5]}",
         )
+
+
+class TestValueBasedSourceDirectVote(unittest.TestCase):
+    """Pin the Final Framework override (2026-04-20): value-based
+    sources feed their raw site values directly into the blend instead
+    of being re-modelled through the Hill / scope-master curve.
+
+    This is the implementation of requirement (A) in the overriding
+    prompt:
+
+        For sites that already provide values:
+          - normalize them into the common 0 to 9999 language
+          - preserve their relative shape as much as possible
+          - use those normalized values directly as live source votes
+          - do NOT send those live value-site votes back through the
+            Hill curve
+
+    The test walks the live contract and asserts:
+
+    1. Every row that has a ``canonicalSiteValues`` entry for a key in
+       ``_VALUE_BASED_SOURCES`` carries a ``valueContributionPath ==
+       'value_direct'`` stamp on the corresponding
+       ``sourceRankMeta`` entry.
+    2. Every row whose matched source is NOT in that set carries
+       ``valueContributionPath == 'rank_hill'`` instead.
+    3. The stamped ``valueContribution`` for a value-direct source
+       equals the raw ``canonicalSiteValues[key]`` scaled by the
+       site's max (within ±1 for integer rounding), proving no Hill
+       re-mapping occurred.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+        self.rows = _ranked_rows(self.contract)
+
+    def test_value_sources_use_value_direct_path(self) -> None:
+        from src.api.data_contract import _VALUE_BASED_SOURCES  # noqa: PLC0415
+
+        checked = 0
+        offenders: list[str] = []
+        for row in self.rows:
+            meta = row.get("sourceRankMeta") or {}
+            site_values = row.get("canonicalSiteValues") or {}
+            for src_key, m in meta.items():
+                if src_key not in _VALUE_BASED_SOURCES:
+                    continue
+                raw = site_values.get(src_key)
+                if raw is None:
+                    continue
+                path = m.get("valueContributionPath")
+                if path != "value_direct":
+                    offenders.append(
+                        f"{row.get('canonicalName')} [{src_key}]: "
+                        f"path={path!r} (raw={raw})"
+                    )
+                checked += 1
+        self.assertFalse(
+            offenders,
+            f"Value-based sources routed through the Hill curve "
+            f"(offenders first 5): {offenders[:5]}",
+        )
+        self.assertGreater(
+            checked, 100,
+            "expected many value-direct source contributions across the board",
+        )
+
+    def test_rank_only_sources_use_rank_hill_path(self) -> None:
+        from src.api.data_contract import _VALUE_BASED_SOURCES  # noqa: PLC0415
+
+        checked = 0
+        offenders: list[str] = []
+        for row in self.rows:
+            meta = row.get("sourceRankMeta") or {}
+            for src_key, m in meta.items():
+                if src_key in _VALUE_BASED_SOURCES:
+                    continue
+                path = m.get("valueContributionPath")
+                if path != "rank_hill":
+                    offenders.append(
+                        f"{row.get('canonicalName')} [{src_key}]: "
+                        f"path={path!r}"
+                    )
+                checked += 1
+        self.assertFalse(
+            offenders,
+            f"Rank-only sources NOT routed through Hill "
+            f"(offenders first 5): {offenders[:5]}",
+        )
+        self.assertGreater(checked, 100, "expected many rank-hill contributions")
+
+    def test_value_direct_contribution_matches_raw_normalized(self) -> None:
+        """For a value-direct source, ``valueContribution`` must equal
+        ``raw_value / site_max × 9999`` (within ±1 for integer rounding).
+
+        This pins that the live blend is reading the raw site value,
+        not a Hill-derived synthetic value for the player's rank.
+        """
+        from src.api.data_contract import _VALUE_BASED_SOURCES  # noqa: PLC0415
+
+        # Compute each value source's max observed raw across the
+        # live contract — same logic the blend uses.
+        site_max: dict[str, float] = {}
+        for row in self.contract.get("playersArray") or []:
+            sv = row.get("canonicalSiteValues") or {}
+            for key in _VALUE_BASED_SOURCES:
+                raw = sv.get(key)
+                try:
+                    raw_f = float(raw) if raw is not None else 0.0
+                except (TypeError, ValueError):
+                    continue
+                if raw_f > site_max.get(key, 0.0):
+                    site_max[key] = raw_f
+
+        checked = 0
+        for row in self.rows:
+            meta = row.get("sourceRankMeta") or {}
+            site_values = row.get("canonicalSiteValues") or {}
+            row_is_te = str(row.get("position") or "").upper() == "TE"
+            for src_key, m in meta.items():
+                if src_key not in _VALUE_BASED_SOURCES:
+                    continue
+                if m.get("valueContributionPath") != "value_direct":
+                    continue
+                raw = site_values.get(src_key)
+                if raw is None:
+                    continue
+                smax = site_max.get(src_key, 0.0)
+                if smax <= 0:
+                    continue
+                expected = float(raw) / smax * 9999.0
+                # TEP boost / TEP-native-correction may adjust the
+                # contribution on TE rows.  Skip those to keep this
+                # test focused on the normalization rule itself; the
+                # TEP path is covered by dedicated TEP tests.
+                if row_is_te and (
+                    m.get("tepBoostApplied") or m.get("tepNativeCorrectionApplied")
+                ):
+                    continue
+                actual = m.get("valueContribution")
+                self.assertAlmostEqual(
+                    float(actual), expected, delta=1.5,
+                    msg=(
+                        f"{row.get('canonicalName')} [{src_key}]: "
+                        f"valueContribution={actual} but raw={raw} "
+                        f"site_max={smax} → expected {expected:.1f}"
+                    ),
+                )
+                checked += 1
+        self.assertGreater(
+            checked, 50,
+            "expected many value-direct rows to cross-check against raw",
+        )
+
+
+class TestMADPenaltyNeutralized(unittest.TestCase):
+    """Pin the Final Framework override (2026-04-20): λ·MAD is no
+    longer applied to any live row.
+
+    The count-aware mean-median blend already damps offense rows via
+    trimming at n≥5.  The anchor + α-shrinkage path already damps IDP
+    + pick rows.  Adding λ·MAD on top stacked a second disagreement
+    penalty on the same signal.  λ is now pinned to 0; ``sourceMAD``
+    is still stamped as a diagnostic statistic but never deducted
+    from ``rankDerivedValue``.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _get()
+        if self.contract is None:
+            self.skipTest("No live data")
+        self.rows = _ranked_rows(self.contract)
+
+    def test_lambda_is_zero(self) -> None:
+        from src.api.data_contract import _MAD_PENALTY_LAMBDA  # noqa: PLC0415
+
+        self.assertEqual(
+            _MAD_PENALTY_LAMBDA, 0.0,
+            "λ·MAD has been retired in favour of the count-aware + "
+            "anchor damping layers.  Reinstating λ > 0 needs a fresh "
+            "backtest proving the extra penalty is non-duplicative.",
+        )
+
+    def test_no_live_row_carries_mad_penalty_applied(self) -> None:
+        offenders: list[str] = []
+        for row in self.rows:
+            penalty = row.get("madPenaltyApplied")
+            if penalty is not None and float(penalty) > 0:
+                offenders.append(
+                    f"{row.get('canonicalName')}: madPenaltyApplied={penalty}"
+                )
+        self.assertFalse(
+            offenders,
+            f"Live rows carrying madPenaltyApplied > 0 despite λ=0 "
+            f"(offenders first 5): {offenders[:5]}",
+        )
+
+    def test_source_mad_still_stamped_as_diagnostic(self) -> None:
+        """``sourceMAD`` is retained as a diagnostic even though no
+        penalty is deducted.  Frontend value-chain panel still
+        displays it.
+        """
+        multi_source = [r for r in self.rows if (r.get("sourceCount") or 0) >= 2]
+        if not multi_source:
+            self.skipTest("no multi-source rows in live data")
+        stamped = sum(1 for r in multi_source if r.get("sourceMAD") is not None)
+        self.assertGreater(
+            stamped, 0,
+            "sourceMAD diagnostic is missing on every multi-source row",
+        )


### PR DESCRIPTION
## Summary

Implements corrections **(A)** and **(C)** from the Final Framework override (2026-04-20).  Together they make the live blend honour the directive "value sites feed their normalized values directly" and "don't stack overlapping disagreement penalties".

### (A) Value-sites as direct normalized live inputs

- New ``_VALUE_BASED_SOURCES`` set covers the 5 sources whose CSVs carry real dollar-equivalent values: ``ktc``, ``idpTradeCalc``, ``dynastyDaddySf``, ``draftSharks``, ``draftSharksIdp``.
- Pre-computes each source's max observed raw from ``canonicalSiteValues`` in one pass.
- Blend loop branches: value-based → ``raw / site_max × 9999`` (preserves site shape, bypasses Hill); rank-only → unchanged rank → percentile → ``percentile_to_value``.
- New per-source meta field ``valueContributionPath`` (``"value_direct"`` vs ``"rank_hill"``) for the frontend value-chain panel.
- Malformed / missing raw values fall back to the Hill path as a safety net.

### (C) λ·MAD penalty retired

- ``_MAD_PENALTY_LAMBDA`` pinned to **0.0** (was 0.10).
- ``sourceMAD`` remains stamped as a diagnostic; never subtracted from ``rankDerivedValue`` anymore.
- Every live row is already damped by one disagreement-sensitive mechanism appropriate to its scope (count-aware trim on offense, anchor+α on IDP / picks). Adding λ·MAD on top was a second penalty on the same signal.

### Phase-1 live-value-path map (concise)

| Path component | Status |
| --- | --- |
| ``_compute_unified_rankings`` blend loop | final-framework live |
| Value-site direct-vote branch (new) | final-framework live (A) |
| Rank-only Hill branch | final-framework live |
| Offense anchor dominance | **gone** (removed PR #168, verified here) |
| λ·MAD penalty | **neutralized** (C) — diagnostic-only |
| IDP anchor + α=0.10 shrinkage | final-framework live (sole IDP damping) |
| Count-aware mean-median blend | final-framework live (sole offense damping) |
| Pick tethering (``_anchor_current_year_picks_to_rookies``) | final-framework live |
| IDP calibration post-pass (``_apply_idp_calibration_post_pass``) | final-framework live |
| Any old blend / weighting / remap / fallback | **gone** (purged PR #170, #173) |
| Stamp sites for ``rankDerivedValue`` | unchanged — one primary at line 4818 |

Nothing outside the Final Framework affects live values.

## Tests

- ``tests/api/test_single_curve_live.py::TestValueBasedSourceDirectVote`` (3 cases) — every value-based source carries ``valueContributionPath == 'value_direct'``; every rank-only source carries ``'rank_hill'``; stamped contribution matches ``raw / site_max × 9999`` within ±1 (excluding TEP-adjusted TE rows).
- ``tests/api/test_single_curve_live.py::TestMADPenaltyNeutralized`` (3 cases) — ``_MAD_PENALTY_LAMBDA == 0.0``, no row stamps ``madPenaltyApplied > 0``, ``sourceMAD`` diagnostic still present on multi-source rows.
- ``tests/api/test_data_contract.py::test_value_based_source_uses_raw_value_directly`` — unit test with a synthetic KTC-only pool; asserts KTC raw value wins over the Hill formula for the player's rank.

## Live verification

Top-10 after restart (QB-heavy retail board):

| Rank | Player | Value | Notes |
| --- | --- | --- | --- |
| 1 | Josh Allen | 9998 | — |
| 2 | Drake Maye | 9572 | Maye > Smith-Njigba preserved from PR #168 |
| 3 | Jaxon Smith-Njigba | 9278 | — |
| 4 | Bijan Robinson | 9165 | — |
| 5 | Ja'Marr Chase | 9119 | **Moved up from rank 11** — fallback-dilution fix |
| … | | | |
| 28 | Will Anderson | 6541 | IDP ordering unchanged |

- ``madPenaltyApplied`` count on ranked rows: **0 / 710**
- 2026 slot picks tethered: **72 / 72**
- `/api/trade/suggestions` still returns well-formed response.

## Suite

Full pytest: **1638 passed, 3 skipped** (was 1632, +6 new). Frontend build clean.

## Deliverables

1. **What changed**: value-based sources' votes come from their raw (normalized) CSV values; λ·MAD is retired.
2. **Why**: the directive requires value sites be direct normalized inputs rather than Hill-remapped, and forbids overlapping disagreement penalties.
3. **Live logic removed/neutralized**: λ·MAD deduction from ``rankDerivedValue`` (via λ=0); Hill re-mapping of KTC / IDPTC / DD-SF / DraftSharks votes.
4. **Tests**: 6 new focused tests + 1 rewritten unit test.
5. **Production behavior change**: YES — top-of-board values shift slightly (Chase moves up from 11 to 5 as the direct-vote fix undoes soft-fallback dilution); no rank inversions, no regressions.
6. **Legacy value code remaining**: none that affects live values. Backtest scripts (``scripts/backtest_mad_lambda.py``, ``backtest_alpha_lambda_joint.py``) are non-live research tooling per the directive's explicit carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)