### PR TITLE
Rename sourceMAD → sourceSpread; refresh architecture docs

### DIFF
--- a/docs/architecture/final-framework-transition.md
+++ b/docs/architecture/final-framework-transition.md
@@ -1,10 +1,43 @@
-# Final Framework Transition — Status: COMPLETE
+# Final Framework Transition — Status: COMPLETE (superseded)
 
 Record of the four-PR transition from the pre-2026-04-20 value engine
 (accumulated hand-tuned constants) to the user-specified Final
 Framework (principled, backtested, multi-source with hierarchical
 structure).  See `docs/architecture/live-value-pipeline-trace.md` for
 the authoritative live-path description.
+
+> ## ⚠️ Post-framework overrides (2026-04-20 forward)
+>
+> Several rules from this doc have since been *overridden* by follow-up
+> directives.  The authoritative live behaviour is what
+> `_compute_unified_rankings` does today, not what this doc describes.
+> Superseded rules:
+>
+> - **Value-based sources bypass the Hill curve** (PR #174, #175).
+>   ``ktc`` / ``idpTradeCalc`` / ``dynastyDaddySf`` now vote with their
+>   raw site values normalized to 0-9999.  Rank-only sources still
+>   route through the scope-master Hill.
+> - **Offense is flat-blended** (PR #168).  The hierarchical anchor +
+>   α-shrinkage path is gated to IDP + pick rows only; offense rows
+>   use the count-aware mean-median directly.
+> - **Soft fallback no longer injects imputed values** (PR #175).  The
+>   count-aware trim was dropping only one imputed value at n≥5 and
+>   any residual fallback was silently dragging the mean.
+>   ``softFallbackCount`` is now a pure coverage diagnostic.
+> - **λ·MAD is retired** (PR #174).  ``_MAD_PENALTY_LAMBDA = 0.0``.
+>   Count-aware trim (offense) and anchor+α (IDP+picks) already damp
+>   disagreement; λ·MAD on top was duplicative.  The ``sourceSpread``
+>   field (renamed from ``sourceMAD`` in PR #176) is kept as a
+>   transparency metric only.
+> - **DraftSharks uses combined cross-market ranking** (PR #175).
+>   DS offense + IDP CSVs are merged into one rank list and routed
+>   through the GLOBAL Hill master — preserves DS's native ~56%
+>   offense-vs-IDP premium and handles its negative values (~50% of
+>   each CSV) by sorting them to the deep tail.
+>
+> The "Final pipeline identity" and "Final constant values" sections
+> below describe the state at the end of PR #161, not today.  Read
+> ``live-value-pipeline-trace.md`` Phase 3 for the current picture.
 
 ## The framework, as specified
 

--- a/docs/architecture/optimization-target.md
+++ b/docs/architecture/optimization-target.md
@@ -2,6 +2,17 @@
 
 Codified from the 2026-04-20 pipeline audit, Deliverable 3.
 
+> **Note (2026-04-20 forward).**  Several specific mechanisms cited
+> in the "What this framework looks like in production" section
+> below — λ·MAD, soft-fallback value injection, Hill re-mapping of
+> value-based sources' live votes — have since been overridden.  See
+> `docs/architecture/live-value-pipeline-trace.md` Phase 3 for the
+> authoritative live behaviour and
+> `docs/architecture/final-framework-transition.md` for the
+> "Post-framework overrides" summary.  The **optimization target**
+> ("market consensus fit" + the per-rank KTC tolerance bands) is
+> unchanged; only the machinery that pursues it has been simplified.
+
 ## The declared target
 
 **Market consensus fit.**  Our values should track KeepTradeCut and the

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -794,10 +794,13 @@ function _materializePlayerArrayRow(player) {
     blendedSourceRank: backendBlendedSourceRank,
     sourceCount: backendSourceCount,
     // Value-chain audit fields — exposed so the PlayerPopup can show
-    // each pipeline stage (anchor + subgroup → MAD → calibration) as
-    // a transparent sequence rather than a single opaque final number.
-    sourceMAD:
-      typeof player.sourceMAD === "number" ? player.sourceMAD : null,
+    // each pipeline stage (anchor + subgroup → calibration) as a
+    // transparent sequence rather than a single opaque final number.
+    // ``sourceSpread`` is a pure transparency metric (mean absolute
+    // deviation of per-source value contributions around the trimmed
+    // center); it is NOT a penalty — λ·MAD was retired 2026-04-20.
+    sourceSpread:
+      typeof player.sourceSpread === "number" ? player.sourceSpread : null,
     madPenaltyApplied:
       typeof player.madPenaltyApplied === "number"
         ? player.madPenaltyApplied

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3375,10 +3375,11 @@ _ALPHA_SHRINKAGE: float = 0.10
 # anchor + α-shrinkage hierarchical blend is already damping on IDP /
 # pick rows.  Keeping λ·MAD on top stacks two penalties on the same
 # signal (spread between sources) and hides the real movement when a
-# board shifts.  Setting λ=0 keeps the ``sourceMAD`` diagnostic stamp
-# (useful on the frontend value-chain panel) but applies zero penalty
-# to ``rankDerivedValue``.  If a new non-duplicative conservatism
-# layer is ever needed, reinstate it here with a fresh backtest.
+# board shifts.  Setting λ=0 keeps the ``sourceSpread`` diagnostic
+# stamp (useful on the frontend value-chain panel) but applies zero
+# penalty to ``rankDerivedValue``.  If a new non-duplicative
+# conservatism layer is ever needed, reinstate it here with a fresh
+# backtest.
 _MAD_PENALTY_LAMBDA: float = 0.0
 
 # Registry of sources whose raw per-player CSV value should be used
@@ -4823,9 +4824,19 @@ def _compute_unified_rankings(
             round(_ALPHA_SHRINKAGE, 4) if use_hierarchical_blend else 0.0
         )
 
-        # Stamp MAD diagnostics on the row so the value chain can
-        # surface "center value − λ·MAD = blended" transparently.
-        players_array[row_idx]["sourceMAD"] = (
+        # Stamp source-spread diagnostic on every row.  ``sourceSpread``
+        # is the mean absolute deviation of per-source value
+        # contributions around the (trimmed) center — a pure
+        # transparency metric that lets the frontend value-chain
+        # panel show how much the sources actually disagreed on this
+        # player.  It has been renamed from the old ``sourceMAD``
+        # field for clarity: with λ·MAD retired (2026-04-20) this
+        # number is a spread statistic, not a penalty input.
+        #
+        # ``madPenaltyApplied`` is kept stamped as ``None`` because
+        # frontend builds still read the key; once every frontend
+        # consumer drops the reference, this stamp can go too.
+        players_array[row_idx]["sourceSpread"] = (
             round(source_mad, 2) if source_mad is not None else None
         )
         players_array[row_idx]["madPenaltyApplied"] = (
@@ -5557,7 +5568,7 @@ def _derive_player_row(
         "sourceRankSpread": None,
         "sourceRankPercentileSpread": None,
         "hillValueSpread": None,
-        "sourceMAD": None,
+        "sourceSpread": None,
         "madPenaltyApplied": None,
         "anchorValue": None,
         "subgroupBlendValue": None,
@@ -6044,7 +6055,7 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "sourceRankSpread",
     "sourceRankPercentileSpread",
     "hillValueSpread",
-    "sourceMAD",
+    "sourceSpread",
     "madPenaltyApplied",
     "anchorValue",
     "subgroupBlendValue",

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -308,7 +308,7 @@ class TestHierarchicalAnchorChain(unittest.TestCase):
             subgroup = row.get("subgroupBlendValue")
             delta = row.get("subgroupDelta")
             uncal = row.get("rankDerivedValueUncalibrated")
-            mad = row.get("sourceMAD")
+            mad = row.get("sourceSpread")
             if (
                 anchor is None
                 or subgroup is None
@@ -375,7 +375,7 @@ class TestMADPenaltyChain(unittest.TestCase):
     """Pin the Final Framework step 6 MAD penalty chain.
 
     For every ranked non-pick row with ≥ 2 sources:
-      * ``sourceMAD`` is stamped with the trimmed-mean absolute deviation
+      * ``sourceSpread`` is stamped with the trimmed-mean absolute deviation
         of the per-source Hill-curve values.
       * When λ = _MAD_PENALTY_LAMBDA > 0, ``madPenaltyApplied`` is
         stamped with the subtracted penalty, and the penalty is
@@ -391,7 +391,7 @@ class TestMADPenaltyChain(unittest.TestCase):
             self.skipTest("No live data")
         self.rows = _ranked_rows(self.contract)
 
-    def test_nonpick_rows_carry_source_mad_when_multi_source(self) -> None:
+    def test_nonpick_rows_carry_source_spread_when_multi_source(self) -> None:
         from src.api.data_contract import _MAD_PENALTY_LAMBDA  # noqa: PLC0415
 
         checked = 0
@@ -401,15 +401,15 @@ class TestMADPenaltyChain(unittest.TestCase):
             src_ranks = row.get("sourceRanks") or {}
             if len(src_ranks) < 2:
                 continue
-            mad = row.get("sourceMAD")
+            mad = row.get("sourceSpread")
             self.assertIsNotNone(
                 mad,
                 f"{row.get('canonicalName')}: multi-source row missing "
-                f"sourceMAD stamp",
+                f"sourceSpread stamp",
             )
             self.assertGreaterEqual(
                 float(mad), 0.0,
-                f"{row.get('canonicalName')}: sourceMAD={mad} is negative",
+                f"{row.get('canonicalName')}: sourceSpread={mad} is negative",
             )
             checked += 1
         self.assertGreater(checked, 50, "expected many multi-source rows")
@@ -426,7 +426,7 @@ class TestMADPenaltyChain(unittest.TestCase):
         for row in self.rows:
             if row.get("assetClass") == "pick":
                 continue
-            mad = row.get("sourceMAD")
+            mad = row.get("sourceSpread")
             penalty = row.get("madPenaltyApplied")
             if mad is None or penalty is None:
                 continue
@@ -889,7 +889,7 @@ class TestMADPenaltyNeutralized(unittest.TestCase):
     The count-aware mean-median blend already damps offense rows via
     trimming at n≥5.  The anchor + α-shrinkage path already damps IDP
     + pick rows.  Adding λ·MAD on top stacked a second disagreement
-    penalty on the same signal.  λ is now pinned to 0; ``sourceMAD``
+    penalty on the same signal.  λ is now pinned to 0; ``sourceSpread``
     is still stamped as a diagnostic statistic but never deducted
     from ``rankDerivedValue``.
     """
@@ -924,18 +924,18 @@ class TestMADPenaltyNeutralized(unittest.TestCase):
             f"(offenders first 5): {offenders[:5]}",
         )
 
-    def test_source_mad_still_stamped_as_diagnostic(self) -> None:
-        """``sourceMAD`` is retained as a diagnostic even though no
+    def test_source_spread_still_stamped_as_diagnostic(self) -> None:
+        """``sourceSpread`` is retained as a diagnostic even though no
         penalty is deducted.  Frontend value-chain panel still
         displays it.
         """
         multi_source = [r for r in self.rows if (r.get("sourceCount") or 0) >= 2]
         if not multi_source:
             self.skipTest("no multi-source rows in live data")
-        stamped = sum(1 for r in multi_source if r.get("sourceMAD") is not None)
+        stamped = sum(1 for r in multi_source if r.get("sourceSpread") is not None)
         self.assertGreater(
             stamped, 0,
-            "sourceMAD diagnostic is missing on every multi-source row",
+            "sourceSpread diagnostic is missing on every multi-source row",
         )
 
 


### PR DESCRIPTION
## Summary

Audit pass confirmed Priority 1 (DraftSharks combined cross-market ranking) and backtest archival already landed in PR #175.  This PR closes out the remaining two items from the cleanup directive.

### Field rename

With λ·MAD retired, ``sourceMAD`` was still stamped as a pass-through stat but the name implied a penalty that no longer runs.  Renamed to ``sourceSpread`` so the data is labelled honestly — it's a transparency metric (mean absolute deviation of per-source contributions around the trimmed center), not a penalty input.

Scope: backend stamp + defaults + delta-payload field list; frontend row-mapping passthrough; test method names and assertions.  ``madPenaltyApplied`` (always ``None`` now) is retained as a stamp for frontend-build compatibility.

### Architecture doc refresh

- **``final-framework-transition.md``** — added a prominent "Post-framework overrides" callout at the top that enumerates every rule this doc described which has since been overridden (value-direct votes, offense flat-blend, λ·MAD retirement, soft-fallback non-injection, DS combined ranking).  Historical PR #158-#161 record preserved below.
- **``optimization-target.md``** — added a shorter note at the top clarifying the target is unchanged but the machinery has been simplified; points at the live-path trace.

## Verification

- `python3 -m pytest tests/ -q`: **1642 passed, 3 skipped** (unchanged).
- `cd frontend && npm run build`: clean.
- Live smoke: **695 ranked rows** carry `sourceSpread`; **0 rows** carry the old `sourceMAD` key.  Top-5 ordering unchanged (Allen / Chase / Maye / Smith-Njigba / Bijan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)