### PR TITLE
Cleanup: stale sourceMAD wording in popup comment + pipeline-trace doc

### DIFF
--- a/docs/architecture/live-value-pipeline-trace.md
+++ b/docs/architecture/live-value-pipeline-trace.md
@@ -212,10 +212,12 @@ Count-aware blend (shared helper ``count_aware_mean_median_blend``):
 **Step 5 — λ·MAD retired.**  ``_MAD_PENALTY_LAMBDA = 0.0`` as of the
 Final Framework override 2026-04-20: count-aware trimming (offense)
 and anchor + α-shrinkage (IDP + picks) already damp disagreement;
-λ·MAD on top was a duplicate penalty on the same signal.
-``sourceMAD`` is still stamped as a diagnostic transparency field
-(the frontend value-chain panel displays it as "source spread") but
-never subtracts from ``rankDerivedValue``.
+λ·MAD on top was a duplicate penalty on the same signal.  The
+diagnostic statistic itself (mean absolute deviation of per-source
+value contributions around the trimmed center) is still stamped on
+every multi-source row as ``sourceSpread`` (renamed from
+``sourceMAD`` 2026-04-20 for clarity) and surfaced in the frontend
+value-chain panel, but it never subtracts from ``rankDerivedValue``.
 
 The result of Phase 3 is a pre-discount ``blended_value`` that then
 enters Phase 3a (pick year discount) and Phase 4 (global sort).

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -83,10 +83,11 @@ function computeValueChain(row) {
     });
   }
 
-  // MAD-penalty stage retired 2026-04-20: λ is pinned to 0, so the
-  // previous "MAD penalty" chain row never fires.  ``sourceMAD`` is
-  // still stamped as a diagnostic so it's surfaced below the chain
-  // as a pure transparency metric, labelled "source spread".
+  // λ·MAD penalty retired 2026-04-20; field renamed to
+  // ``sourceSpread`` 2026-04-20 for clarity (it was always a
+  // diagnostic statistic, never a penalty).  The stage that used to
+  // render "MAD penalty −N" is gone — ``sourceSpread`` is displayed
+  // below the chain as a pure transparency metric.
   const blended = Number(row.rankDerivedValueUncalibrated) || null;
   if (blended !== null && blended > 0 && stages.length === 0) {
     // Offense rows (no anchor/subgroup stamps) — surface the final


### PR DESCRIPTION
Two comment-only edits left over from the ``sourceMAD`` → ``sourceSpread`` rename in PR #176.  No live math changes.

## What changed

- ``frontend/components/PlayerPopup.jsx`` — inline comment next to the retired MAD-penalty stage still said "``sourceMAD`` is still stamped as a diagnostic."  The stamped field is now ``sourceSpread``; rewrote the comment to explain both the λ·MAD retirement and the rename.
- ``docs/architecture/live-value-pipeline-trace.md`` — Phase 3 Step 5 paragraph still referenced ``sourceMAD`` as the stamped field.  Now names ``sourceSpread`` with a parenthetical noting the historical name.

## Stale wording remaining

None in live-behavior-describing text.  The three ``sourceMAD`` references still in the repo are all explicit history callouts:

- ``src/api/data_contract.py:4832`` — blend-loop comment documenting the rename history.
- ``docs/architecture/final-framework-transition.md:30`` — inside the "Post-framework overrides" callout, which is itself a rename note.
- ``docs/architecture/live-value-pipeline-trace.md:219`` — this PR's own rewritten paragraph, parenthetically noting the prior name.

All four ``MAD penalty`` / ``MAD Penalty`` mentions left are either my retirement comment (popup), the "Phase 4d — Volatility compression (REMOVED)" history section of the trace doc, or the preserved-as-historical "The framework, as specified" section of ``final-framework-transition.md`` (which is gated by the override callout at the top).

## ``madPenaltyApplied`` field

Kept.  The backend still stamps it (always ``None`` now) and it's in the delta-payload allowlist.  Per instruction, only remove "if unused everywhere" — I can prove the frontend app no longer reads it (PR #175 removed the popup stage), but cannot prove zero external API consumers read ``/api/data`` and expect the key.  Safe default: leave.

## Live behavior change

None.  Comment-only diff.

## Verification

- ``python3 -m pytest tests/ -q``: **1642 passed** (unchanged).
- ``cd frontend && npm run build``: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)