### PR TITLE
Rookie ladder translation + IDPTC weight unification

### DIFF
--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -240,10 +240,10 @@ export const RANKING_SOURCES = [
     // _RANKING_SOURCES entry in src/api/data_contract.py.  The two
     // scope passes act on disjoint row sets so sourceRanks never
     // collides for the same source key.
-    // Weight = 2.0 (not 1.0) because IDPTC is the retail IDP
-    // authority and the backbone source.  Keeps the IDP blend
-    // from being dragged down by DLF/FP veteran boards when they
-    // disagree strongly with IDPTC's projection-aware view.
+    // Weight = 1.0 — IDPTC was previously weighted 2.0 when it was
+    // the sole IDP anchor; now that DS SF/IDP + FG SF/IDP are also
+    // cross-market anchors, every source gets one equal vote in the
+    // live blend.
     key: "idpTradeCalc",
     displayName: "IDP Trade Calculator",
     columnLabel: "IDPTC",
@@ -251,7 +251,7 @@ export const RANKING_SOURCES = [
     extraScopes: ["overall_offense"],
     positionGroup: null,
     depth: null,
-    weight: 2.0,
+    weight: 1.0,
     isBackbone: true,
     isRetail: false,
     // IDPTradeCalc's offense board is a standard SF calculator — no

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -709,16 +709,14 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "position_group": None,
         "depth": None,
         # IDPTC is the retail IDP authority and the backbone source.
-        # Weight bumped to 2.0 so the IDP blend leans toward IDPTC
-        # whenever it disagrees strongly with veteran-focused expert
-        # boards (DLF IDP, FantasyPros IDP, FootballGuys IDP).  The
-        # original 1.0 weight let DLF IDP drag down players IDPTC
-        # likes — particularly high-draft-capital edge rushers whose
-        # pass-rush projection (IDPTC) diverges from raw tackle
-        # production (DLF).  Mirrored in
-        # frontend/lib/dynasty-data.js so the settings page shows the
-        # correct default.
-        "weight": 2.0,
+        # The old weight=2.0 dated to when IDPTC was the SOLE IDP
+        # anchor; now that DraftSharks SF+IDP and FootballGuys SF+IDP
+        # are also cross-market anchors (see ``is_cross_market``), no
+        # single source gets an explicit multiplier in the blend.
+        # The ``weight`` field is still honoured as a user-override
+        # knob on ``/settings`` but in the live blend every source
+        # contributes with one equal vote.
+        "weight": 1.0,
         "is_backbone": True,
         # Cross-market anchor source (2026-04-20): IDPTC prices both
         # offense and IDP on a single combined-pool scale, so its
@@ -4221,32 +4219,28 @@ def _compute_unified_rankings(
 
     # Updated framework (steps 5-6): route each source to its scope-
     # appropriate master curve, not per-player-position.
-    #   is_anchor=True                   → GLOBAL master
-    #   needs_rookie_translation=True    → ROOKIE master
+    #   is_cross_market=True             → GLOBAL master
     #   scope=overall_idp                → IDP master
     #   everything else (offense, picks) → OFFENSE master
+    #
+    # ``needs_rookie_translation`` flag and the ROOKIE master used to
+    # gate rookie-only sources through their own Hill curve fit
+    # against rookie slices.  Retired 2026-04-21: rookie-only sources
+    # now go through the Phase 1d ladder translation (their rank is
+    # translated to a combined-pool rank via KTC/IDPTC), so by the
+    # time they reach this function their rank is in combined-pool
+    # space and the OFFENSE/IDP master is the correct curve.
     def _curve_for_source(src_def: dict) -> tuple[float, float]:
-        # Cross-market sources (IDPTC, DraftSharks SF/IDP, FootballGuys
-        # SF/IDP) price players on ONE combined offense+IDP scale, so
-        # they all use the GLOBAL Hill master that was fit off IDPTC's
-        # native combined pool.
         if src_def.get("is_cross_market"):
             return HILL_GLOBAL_PERCENTILE_C, HILL_GLOBAL_PERCENTILE_S
-        if src_def.get("needs_rookie_translation"):
-            return HILL_ROOKIE_PERCENTILE_C, HILL_ROOKIE_PERCENTILE_S
         scope = str(src_def.get("scope") or "")
         if scope == SOURCE_SCOPE_OVERALL_IDP:
             return IDP_HILL_PERCENTILE_C, IDP_HILL_PERCENTILE_S
         return HILL_PERCENTILE_C, HILL_PERCENTILE_S
 
-    # Rookie sources compute percentile against their NATIVE pool
-    # (N_j = rookie-class size), not the fixed
-    # ``_PERCENTILE_REFERENCE_N``.  The ROOKIE master's shape
-    # already encodes rookie-relative value decay directly.
+    # All sources (including rookie-only ones after Phase 1d ladder
+    # translation) use the fixed combined-pool reference denominator.
     def _percentile_denom_for_source(src_def: dict, source_key: str) -> int:
-        if src_def.get("needs_rookie_translation"):
-            native_n = source_pool_sizes.get(source_key, 0) or 0
-            return max(2, native_n)
         return _PERCENTILE_REFERENCE_N
 
     # Clamp TEP multiplier to a sane range.  1.0 is a no-op, 2.0 is
@@ -4610,6 +4604,118 @@ def _compute_unified_rankings(
                 meta["rawRank"] = meta.get("rawRank", csv_rank)
                 meta["effectiveRank"] = csv_rank
                 meta["method"] = "csv_combined_cross_market"
+
+    # ── Phase 1d: Rookie-ladder translation ──
+    # DLF Rookie SF / DLF Rookie IDP publish rookie-only boards (~50
+    # rookies, within-class ranks 1..N).  Treated naively, DLF's #1
+    # rookie ends up at percentile 0 on the ROOKIE Hill master,
+    # producing a contribution of 9999 — i.e. "the #1 rookie is as
+    # valuable as the #1 player overall", which is wrong.  In reality
+    # the top rookie sits around overall rank 25-30 in the combined
+    # market (per KTC/IDPTC's combined boards).
+    #
+    # This pre-pass (Fix B from the 2026-04-21 audit) translates each
+    # rookie-source rank to a combined-pool rank via the reference
+    # ladder:
+    #
+    #   * ``dlfRookieSf`` (offense rookies) → KTC ladder:
+    #     DLF's #1 rookie → the rank KTC gives its #1 rookie.
+    #     DLF's #2 rookie → KTC's #2 rookie-slot rank.  Etc.
+    #
+    #   * ``dlfRookieIdp`` (IDP rookies) → IDPTC ladder:
+    #     DLF's #1 IDP rookie → IDPTC's top-rookie rank, etc.
+    #
+    # Preserves each rookie source's within-class ORDERING while
+    # calibrating the top-rookie's market value to the reference
+    # source's opinion.  After this translation, the rookie source's
+    # ``effective_rank`` is a combined-pool rank and the downstream
+    # Hill conversion uses the OFFENSE/IDP master (not a special
+    # ROOKIE master), which is what we want now that ranks are in
+    # combined-pool space.
+    #
+    # Rookies past the reference ladder's depth are extrapolated
+    # using the slope of the last ~10 ladder entries.
+    def _build_rookie_ladder(reference_source: str, universe_positions: set[str]) -> list[int]:
+        """Collect the reference source's ranks for every rookie in
+        the relevant universe, sorted ascending (best rookie first).
+        ``ladder[k - 1]`` is the combined-pool rank that the k-th
+        rookie should translate to.
+        """
+        out: list[int] = []
+        for idx, row in enumerate(players_array):
+            if not bool(row.get("rookie")):
+                continue
+            pos = str(row.get("position") or "").upper()
+            if pos not in universe_positions:
+                continue
+            ref_rank = row_source_ranks.get(idx, {}).get(reference_source)
+            if ref_rank is None:
+                continue
+            try:
+                out.append(int(ref_rank))
+            except (TypeError, ValueError):
+                continue
+        out.sort()
+        return out
+
+    def _translate_via_ladder(rookie_rank: int, ladder: list[int]) -> int:
+        """Map a within-class rookie rank k to the ladder's k-th
+        entry.  Extrapolate past the ladder's depth using the slope
+        across the last 10 entries (floor slope to 1.0 so ranks
+        strictly increase).
+        """
+        if not ladder:
+            return rookie_rank
+        if 1 <= rookie_rank <= len(ladder):
+            return ladder[rookie_rank - 1]
+        # Past the ladder — linear extrapolation using the tail slope.
+        tail_n = min(10, len(ladder))
+        if tail_n < 2:
+            slope = 1.0
+        else:
+            tail_start = ladder[len(ladder) - tail_n]
+            tail_end = ladder[-1]
+            slope = max(1.0, (tail_end - tail_start) / (tail_n - 1))
+        extrapolated = ladder[-1] + int(
+            round((rookie_rank - len(ladder)) * slope)
+        )
+        return max(1, extrapolated)
+
+    # Pair each rookie source with its reference ladder.  If the
+    # reference source isn't active or has no rookie coverage, the
+    # fallback is to leave the rookie source's rank untranslated
+    # (it'll go through the Hill path with its within-class rank,
+    # which is the pre-fix behaviour — safer than silently breaking).
+    _rookie_ladder_pairs = (
+        ("dlfRookieSf", "ktc", _OFFENSE_POSITIONS),
+        ("dlfRookieIdp", "idpTradeCalc", _IDP_POSITIONS),
+    )
+    for rookie_key, ref_key, universe in _rookie_ladder_pairs:
+        if rookie_key not in active_keys or ref_key not in active_keys:
+            continue
+        ladder = _build_rookie_ladder(ref_key, universe)
+        if len(ladder) < 3:
+            # Not enough rookie coverage on the reference source to
+            # translate reliably; skip and let the rookie source flow
+            # through the normal Hill path below.
+            continue
+        for row_idx, rk_dict in row_source_ranks.items():
+            if rookie_key not in rk_dict:
+                continue
+            orig = rk_dict[rookie_key]
+            try:
+                orig_int = int(orig)
+            except (TypeError, ValueError):
+                continue
+            translated = _translate_via_ladder(orig_int, ladder)
+            rk_dict[rookie_key] = translated
+            meta = row_source_meta.setdefault(row_idx, {}).setdefault(
+                rookie_key, {}
+            )
+            meta["effectiveRank"] = translated
+            meta["method"] = (
+                f"rookie_ladder_translation_via_{ref_key}"
+            )
 
     # ── Phase 2-3: Normalized value (Hill curve) + robust blend ──
     # Look up each source's weight / depth once.

--- a/tests/api/test_scope_aware_rankings.py
+++ b/tests/api/test_scope_aware_rankings.py
@@ -261,11 +261,13 @@ class TestCCoverageAwareBlending(unittest.TestCase):
         # Coverage weight stamped on meta
         eff_w = dl_a["sourceRankMeta"]["dlTop5"]["effectiveWeight"]
         self.assertLess(eff_w, 0.1)
-        # IDPTC's declared weight is 2.0 (IDP backbone + retail
-        # authority); coverage_weight preserves it on full-board
-        # sources (depth=None).
+        # IDPTC's declared weight is 1.0 as of 2026-04-21 — it was
+        # demoted from 2.0 when DS SF/IDP and FG SF/IDP joined the
+        # cross-market anchor set (IDPTC is no longer the sole
+        # authority).  coverage_weight still preserves the declared
+        # weight unchanged on full-board sources (depth=None).
         backbone_w = dl_a["sourceRankMeta"]["idpTradeCalc"]["effectiveWeight"]
-        self.assertEqual(backbone_w, 2.0)
+        self.assertEqual(backbone_w, 1.0)
 
         # The blended value must stay closer to rank_to_value(3) than to
         # rank_to_value(1) — the deep backbone dominates the shallow list.
@@ -278,7 +280,7 @@ class TestCCoverageAwareBlending(unittest.TestCase):
     def test_full_board_second_idp_source_preserves_declared_weights(self):
         """A second full-board overall_idp source (depth=None) should
         carry its declared weight unchanged by coverage_weight; the
-        backbone's declared 2.0 is similarly preserved."""
+        backbone's declared 1.0 is similarly preserved."""
         self._saved_registry2 = copy.deepcopy(_RANKING_SOURCES)
         _RANKING_SOURCES.append(
             {
@@ -301,8 +303,11 @@ class TestCCoverageAwareBlending(unittest.TestCase):
             bw = b["sourceRankMeta"]["secondFull"]["effectiveWeight"]
             bw_bb = b["sourceRankMeta"]["idpTradeCalc"]["effectiveWeight"]
             self.assertEqual(bw, 1.0)
-            # IDPTC's declared weight is 2.0 per the IDP-authority policy.
-            self.assertEqual(bw_bb, 2.0)
+            # IDPTC's declared weight is 1.0 as of 2026-04-21 (demoted
+            # from 2.0 when DS SF/IDP and FG SF/IDP joined the
+            # cross-market anchor set — IDPTC is no longer the sole
+            # IDP authority).
+            self.assertEqual(bw_bb, 1.0)
         finally:
             _RANKING_SOURCES.clear()
             _RANKING_SOURCES.extend(self._saved_registry2)

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -608,37 +608,70 @@ class TestRookieScopeRouting(unittest.TestCase):
             self.skipTest("No live data")
         self.rows = _ranked_rows(self.contract)
 
-    def test_rookie_source_rank_one_gets_max_value(self) -> None:
-        """A rookie source's rank-1 player should have V=9999 from
-        the ROOKIE master (p=0).  Under the old ladder-translation
-        this value was the OFFENSE-master-mapped reference-source
-        rank and therefore less than 9999.
+    def test_rookie_source_rank_one_translated_via_reference_ladder(self) -> None:
+        """Fix B (2026-04-21): a rookie source's rank-1 player has
+        its effective rank TRANSLATED to the reference ladder's top-
+        rookie rank (KTC for SF, IDPTC for IDP), NOT left at rank 1.
+
+        This is the whole point of the ladder translation — the top
+        rookie isn't "the best player overall" (value 9999); they're
+        "where KTC/IDPTC puts the top rookie on their combined
+        board" (SF rookies typically land around rank 25-40 in KTC's
+        offense-only pool; IDP rookies land around rank 100-200 in
+        IDPTC's combined offense+IDP pool where offense players sit
+        above IDPs on the shared 0-9999 scale).
         """
+        # Per-source sanity upper bounds — KTC is a pure offense
+        # ranker so rookie#1 sits shallow; IDPTC is a combined pool
+        # so top IDP rookie naturally sits deeper.
+        _SANITY_UPPER_BOUND = {
+            "dlfRookieSf": 100,
+            "dlfRookieIdp": 250,
+        }
+        hits = 0
         for row in self.rows:
             meta = row.get("sourceRankMeta") or {}
             for src_key in ("dlfRookieSf", "dlfRookieIdp"):
                 m = meta.get(src_key) or {}
                 if m.get("rawRank") != 1:
                     continue
-                # Rookie rank 1 now maps to p=0 → V=9999 under ROOKIE
-                # master.  Ladder is off.
-                self.assertEqual(
-                    m.get("effectiveRank"),
-                    1,
-                    f"{src_key} rank-1 player "
-                    f"{row.get('canonicalName')} has eff_rank "
-                    f"{m.get('effectiveRank')} != 1 — rookie-ladder "
-                    f"translation should be OFF.",
+                eff = int(m.get("effectiveRank") or 0)
+                vc = int(m.get("valueContribution") or 0)
+                # Ladder-translated rank must be much deeper than 1
+                # (if it's still 1 the translation didn't run) and
+                # the contribution must be well below the max 9999.
+                self.assertGreater(
+                    eff, 1,
+                    f"{src_key} rank-1 player {row.get('canonicalName')}"
+                    f" still at effective rank {eff} — the Phase 1d"
+                    f" rookie-ladder translation is OFF.",
                 )
-                self.assertEqual(
-                    int(m.get("valueContribution") or 0),
-                    9999,
-                    f"{src_key} rank-1 V="
-                    f"{m.get('valueContribution')} != 9999 — ROOKIE "
-                    f"master should map p=0 → 9999.",
+                self.assertLess(
+                    vc, 9999,
+                    f"{src_key} rank-1 player contribution still 9999"
+                    f" — ladder translation should cap it below that.",
                 )
-                return
-        self.skipTest("no rookie rank-1 player in snapshot")
+                # Sanity: not wildly deep either.  Bounds differ per
+                # source because the reference ladder's universe
+                # (offense-only KTC vs combined-pool IDPTC) puts the
+                # top rookie at very different ranks.
+                bound = _SANITY_UPPER_BOUND[src_key]
+                self.assertLess(
+                    eff, bound,
+                    f"{src_key} rank-1 translated to {eff} (sanity"
+                    f" bound {bound}) — reference ladder may be"
+                    f" malformed or universe filter incorrect.",
+                )
+                # And the ``method`` stamp records the translation.
+                self.assertIn(
+                    "rookie_ladder_translation",
+                    str(m.get("method") or ""),
+                    f"{src_key} rank-1 player lacks ladder-translation"
+                    f" method stamp; got {m.get('method')!r}",
+                )
+                hits += 1
+        if hits == 0:
+            self.skipTest("no rookie rank-1 player in snapshot")
 
     def test_rookie_master_differs_from_offense_and_idp(self) -> None:
         from src.canonical.player_valuation import (  # noqa: PLC0415

--- a/tests/api/test_source_registry_parity.py
+++ b/tests/api/test_source_registry_parity.py
@@ -265,14 +265,14 @@ class TestBackendFrontendRegistryParity(unittest.TestCase):
             )
 
     def test_default_weights_match_registry_policy(self) -> None:
-        # Guardrail on the "no silent weight boosts" rule — weights
-        # must match the explicit per-source policy documented in the
-        # registry comments.  The default is 1.0, but IDPTC carries
-        # 2.0 because it is the IDP backbone + retail IDP authority
-        # (see registry comment in src/api/data_contract.py).  Any
-        # other per-source override must be added here AND in the
-        # registry comment explaining why.
-        expected_weights: dict[str, float] = {"idpTradeCalc": 2.0}
+        # Guardrail on the "no silent weight boosts" rule — every
+        # source contributes with an equal weight=1.0 in the live
+        # blend as of 2026-04-21.  IDPTC previously carried 2.0 when
+        # it was the sole IDP anchor; that was demoted to 1.0 when DS
+        # SF/IDP and FG SF/IDP joined the cross-market anchor set.
+        # If a future entry requires a non-1.0 default, add it here
+        # AND document the registry comment policy.
+        expected_weights: dict[str, float] = {}
         for entry in self.py_registry:
             expected = expected_weights.get(str(entry["key"]), 1.0)
             self.assertEqual(


### PR DESCRIPTION
## Summary
- **Phase 1d**: DLF rookie sources translate within-class rookie rank to their reference source's combined-pool rank before the Hill curve. Fixes the top-rookie-scores-9999 bug.
- **IDPTC weight demotion**: 2.0 → 1.0, bringing all sources to equal weight now that IDPTC is no longer the sole cross-market IDP anchor.

## Why
Before: DLF rookie #1 (e.g. top SF rookie pick) entered the Hill curve at rank=1 → value=9999, same as the #1 overall player. Conceptually wrong — the top rookie isn't "the best player period", they're "the best rookie".

After: `dlfRookieSf` rank `k` is translated to KTC's offense-pool rank for the `k`-th rookie on KTC's ladder; `dlfRookieIdp` rank `k` translates via IDPTC's combined offense+IDP rookie ladder. Live-data smoke:
- Top SF rookie pick: eff 1 → 16, vc 9999 → 8277 (`rookie_ladder_translation_via_ktc`)
- Top IDP rookie: eff 1 → 117, vc 9999 → 3513 (`rookie_ladder_translation_via_idpTradeCalc`)

IDPTC weight drop to 1.0: the old 2.0 boost was justified when IDPTC was the lone cross-market anchor. Now DS SF/IDP and FG SF/IDP carry cross-market signal too — unifying at weight=1.0 is the cleaner policy.

## Test plan
- [x] pytest tests/ -q — 1642 passed, 3 skipped
- [x] npm run build — green
- [x] Local smoke: new rookie ladder method stamps visible on live data, IDPTC effective weight = 1.0
- [ ] Production smoke after deploy: verify top DLF rookie value drops from 9999 to ~8200 on /rankings

🤖 Generated with [Claude Code](https://claude.com/claude-code)