### PR TITLE
Fix scrape failure: create data/CSVs/ defensively

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -3533,7 +3533,16 @@ async def run(progress_callback=None):
 
     # ── Save CSV (all players with composites) ──
     # Keep spreadsheet outputs stable so each run overwrites the previous file.
+    #
+    # When the server invokes us with ``SCRIPT_DIR=DATA_DIR`` (server.py
+    # overrides SCRIPT_DIR to route outputs into ``data/``), the implicit
+    # ``CSVs/`` child directory may not exist yet.  Create it defensively
+    # so the first scrape after a clean checkout doesn't crash the whole
+    # pipeline on a missing directory.  April-2026 regression: scrapes
+    # failed at the ``health_report`` phase because ``data/CSVs/`` was
+    # never created on new server deploys, blocking every scrape run.
     fname = os.path.join(SCRIPT_DIR, "CSVs", "dynasty_values.csv")
+    os.makedirs(os.path.dirname(fname), exist_ok=True)
     with open(fname, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["Player"] + active_sites)
@@ -6233,6 +6242,7 @@ async def run(progress_callback=None):
 
     # ── Save FULL CSV (all players with per-site values and composite) ──
     full_csv_fname = os.path.join(SCRIPT_DIR, "CSVs", "dynasty_full.csv")
+    os.makedirs(os.path.dirname(full_csv_fname), exist_ok=True)
     try:
         site_keys = [site_key_map.get(s, s) for s in active_sites if s in site_key_map]
         with open(full_csv_fname, "w", newline="", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Scheduled scrapes have been failing at the \`health_report\` phase since 2026-04-16 with \`FileNotFoundError\` on \`data/CSVs/dynasty_values.csv\`.
- Root cause: server overrides \`scraper.SCRIPT_DIR = str(DATA_DIR)\` (server.py:1057) so scraper outputs route into \`data/\`, but the \`data/CSVs/\` child directory is never created and the scraper's \`open()\` crashes.
- Fix: add \`os.makedirs(dirname, exist_ok=True)\` right before the two CSV writes. Self-heals on first run.

## Impact
Live data has been stale since Apr 16 (five days) because of this one bug. This is a production hotfix.

## Test plan
- [x] \`data/CSVs/\` directory now exists on the live server (created manually pre-merge)
- [ ] Post-deploy: wait for next scheduled scrape (2h cadence) and verify /api/status reports success
- [ ] Verify data timestamp advances past 2026-04-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)