### PR TITLE
Yahoo/Boone: value-based blend on 9999 scale

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -102,7 +102,16 @@ function posMatchesFilter(pos, assetClass, filter, row) {
 // using this helper so both surfaces show `value (#rank)` consistently.
 function formatSourceCell(row, src) {
   const rawVal = row?.canonicalSites?.[src.key];
-  const hasVal = rawVal != null && Number.isFinite(Number(rawVal));
+  // valueContribution is the backend's 9999-scale normalized value
+  // (source's top player = 9999, others scale linearly).  For sources
+  // whose native value range is already 0-9999 (KTC, IDPTC, DD-SF)
+  // this is effectively rawVal; for sources like Yahoo/Boone whose
+  // native range is 0-~141, this is the rescaled value so every
+  // value column in the UI lives on the same scale.
+  const normalizedVal = row?.sourceRankMeta?.[src.key]?.valueContribution;
+  const hasVal =
+    (normalizedVal != null && Number.isFinite(Number(normalizedVal))) ||
+    (rawVal != null && Number.isFinite(Number(rawVal)));
   const effectiveRank = row?.sourceRanks?.[src.key];
   const origRank = row?.sourceOriginalRanks?.[src.key];
 
@@ -133,8 +142,13 @@ function formatSourceCell(row, src) {
     };
   }
 
-  // Value source: raw value as primary, effective rank in parens.
-  const primary = Math.round(Number(rawVal)).toLocaleString();
+  // Value source: prefer the normalized 9999-scale value contribution
+  // so sources with non-9999 native ranges (e.g. Yahoo/Boone ~141 max)
+  // render consistently with KTC/IDPTC.  Fall back to the raw site
+  // value if the backend didn't stamp a valueContribution (old payloads
+  // during rollout).
+  const displayVal = normalizedVal != null ? normalizedVal : rawVal;
+  const primary = Math.round(Number(displayVal)).toLocaleString();
   const rankLabel = effectiveRank != null ? `#${effectiveRank}` : "\u2014";
   return {
     hasVal: true,

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -481,10 +481,13 @@ export const RANKING_SOURCES = [
     // surfaces a "TEP NATIVE" badge and the global tepMultiplier
     // boost does NOT compound on this source.
     //
-    // Rank-signal: a single competition rank is computed across all
-    // four positions (ties share a rank, next rank is skipped).  The
-    // UI must render sourceOriginalRanks.yahooBoone, never the
-    // synthetic value produced by the rank-to-value inversion.
+    // Value-signal (2026-04-21): the scraper writes Boone's
+    // published trade value in ``boone_value`` (0-~141 scale) and the
+    // backend blend rescales linearly so Boone's top player
+    // contributes 9999.  The ``rank`` column is still preserved and
+    // the UI renders Boone's published rank via
+    // ``sourceOriginalRanks.yahooBoone``.  `isRankSignal` is false now
+    // because the blend no longer uses the rank column as its vote.
     key: "yahooBoone",
     displayName: "Yahoo / Justin Boone SF-TEP",
     columnLabel: "Boone",
@@ -495,7 +498,7 @@ export const RANKING_SOURCES = [
     weight: 1.0,
     isBackbone: false,
     isRetail: false,
-    isRankSignal: true,
+    isRankSignal: false,
     isTepPremium: true,
     needsSharedMarketTranslation: false,
     excludesRookies: false,

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -261,13 +261,22 @@ _SOURCE_CSV_PATHS: dict[str, Any] = {
     # Yahoo / Justin Boone dynasty trade value charts — scraped from
     # sports.yahoo.com via ``scripts/fetch_yahoo_boone.py``.  The
     # scraper combines Boone's QB (2QB column), RB, WR, and TE
-    # (TE-Prem. column) charts into one cross-positional competition
-    # rank and writes the ``rank`` column of the CSV.  Signal=rank so
-    # the ``_enrich_from_source_csvs`` reader picks up the rank column
-    # via ``_RANK_ALIASES``.
+    # (TE-Prem. column) charts into one cross-positional pool and
+    # writes BOTH a competition rank and Boone's published trade
+    # value (0-~141 scale where Boone's top player = 141) to the CSV
+    # columns ``rank`` and ``boone_value``.
+    #
+    # Signal=value (2026-04-21): blend reads ``boone_value`` directly
+    # via ``_VALUE_ALIASES``, normalising by the column's max so Boone's
+    # top player contributes 9999 and every other player scales linearly.
+    # This preserves Boone's published value structure (e.g. his QB vs
+    # WR separation) instead of collapsing to rank-only ordinal info.
+    # The ``rank`` column is still preserved into
+    # ``sourceOriginalRanks.yahooBoone`` for the UI to display Boone's
+    # published rank alongside his value.
     "yahooBoone": {
         "path": "CSVs/site_raw/yahooBoone.csv",
-        "signal": "rank",
+        "signal": "value",
     },
     # DLF Dynasty Rookie Superflex rankings — 6-expert consensus of the
     # current rookie class only (no veterans).  Raw CSV exported from
@@ -1019,11 +1028,17 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # Superflex + TEP league scoring — so the source is declared
         # ``is_tep_premium=True``.  Roughly 500 combined rows.
         #
-        # Rank signal: the scraper emits a competition rank computed
-        # across all four positions (ties share a rank, next rank is
-        # skipped).  The contract loader inverts rank to a synthetic
-        # monotonic value for the blend; the UI must render
-        # sourceOriginalRanks.yahooBoone, never the synthetic.
+        # Value signal (2026-04-21): the scraper writes Boone's
+        # published trade value in ``boone_value`` (0-~141 scale) plus a
+        # cross-position competition rank in ``rank``.  The blend reads
+        # ``boone_value`` via the value-direct branch, scaling linearly
+        # so Boone's top player contributes 9999 — preserving his
+        # published value structure (e.g. how much further QBs lead WRs)
+        # rather than collapsing to rank-only ordinal info.  The UI
+        # continues to render Boone's published rank via
+        # ``sourceOriginalRanks.yahooBoone`` (the value-signal CSV
+        # loader now also picks up the ``rank`` column so this audit
+        # stamp survives the switch).
         #
         # depth=500 mirrors the live row count; ``_expected_sources_for_position``
         # multiplies this by 1.25 so YAHOO_BOONE is not expected for
@@ -2537,9 +2552,18 @@ def _parse_source_csv_cached(
         "effectiveRank",
     )
     # ``3D Value +`` is DraftSharks' normalised 0-100 value column (top
-    # player = 100, decimals preserved).  Kept at the tail so more
-    # conventional aliases win when multiple are present.
-    _VALUE_ALIASES = ("value", "Value", "trade_value", "TradeValue", "3D Value +")
+    # player = 100, decimals preserved).  ``boone_value`` is Yahoo /
+    # Justin Boone's published trade value (0-~141 integer scale).
+    # Conventional aliases are placed first so more generic columns
+    # win when multiple are present.
+    _VALUE_ALIASES = (
+        "value",
+        "Value",
+        "trade_value",
+        "TradeValue",
+        "3D Value +",
+        "boone_value",
+    )
 
     def _pick(csvrow: dict[str, Any], aliases: tuple[str, ...]) -> str:
         for k in aliases:
@@ -2619,9 +2643,23 @@ def _parse_source_csv_cached(
                     val = _pick(csvrow, _VALUE_ALIASES)
                     if not val:
                         continue
+                    # Value-signal CSVs often carry a rank column too
+                    # (e.g. yahooBoone emits name,pos,rank,boone_value).
+                    # Preserve it so ``sourceOriginalRanks[source_key]``
+                    # stamps for the UI just like the rank-signal
+                    # branch does.  Missing/invalid → None (harmless).
+                    rank_raw = _pick(csvrow, _RANK_ALIASES)
+                    orig_rank: float | None = None
+                    if rank_raw != "":
+                        try:
+                            rv = float(str(rank_raw).strip())
+                            if rv > 0:
+                                orig_rank = rv
+                        except (TypeError, ValueError):
+                            orig_rank = None
                     try:
                         csv_lookup.setdefault(key, []).append(
-                            (name, int(float(val)), None)
+                            (name, int(float(val)), orig_rank)
                         )
                     except (ValueError, TypeError):
                         continue
@@ -3444,6 +3482,11 @@ _VALUE_BASED_SOURCES: frozenset[str] = frozenset({
     "ktc",
     "idpTradeCalc",
     "dynastyDaddySf",
+    # Yahoo / Justin Boone's published trade values (0-~141 scale) are
+    # rescaled to 0-9999 linearly by the blend's value-direct branch.
+    # Added 2026-04-21 to preserve Boone's native value structure
+    # instead of collapsing it to rank-only ordinal information.
+    "yahooBoone",
 })
 
 


### PR DESCRIPTION
## Summary
- Switches Yahoo/Justin Boone from rank-only to value-based blending.
- Boone's published trade value (~141 for top QB) now rescales linearly to 9999, matching KTC/IDPTC's native scale.
- UI shows Boone's normalized 9999 value as primary; published rank still surfaces via \`sourceOriginalRanks.yahooBoone\`.

## Why
Boone publishes actual trade values per player — signal richer than rank alone (captures QB vs WR separation). We were throwing that data away by configuring the source as \`signal=rank\`.

## How
- \`_SOURCE_CSV_PATHS[yahooBoone]\`: \`rank\` → \`value\`
- \`_VALUE_ALIASES\` adds \`boone_value\` column
- \`_VALUE_BASED_SOURCES\` adds \`yahooBoone\`
- CSV loader value branch now also picks up rank column so UI rank display still works
- Frontend cell formatter prefers \`sourceRankMeta.valueContribution\` (9999-normalized) over raw site value — no change for sources already on 0-9999 scale

## Local smoke
- Josh Allen: raw 141 → valueContribution 9999, path=value_direct. Matches KTC 9988.
- Drake Maye: raw 130 → valueContribution 9219 (130/141 × 9999).
- \`sourceOriginalRanks.yahooBoone\` still populated for rank display.

## Test plan
- [x] pytest tests/ -q — 1642 passed
- [x] npm run build — green
- [x] Local smoke against cached data: Boone contributions rescale to 9999
- [ ] Post-deploy: verify \`/rankings\` "Boone" column shows 9,999 for the top QB rather than 141

🤖 Generated with [Claude Code](https://claude.com/claude-code)