### PR TITLE
Add FantasyPros / Fitzmaurice Dynasty Trade Value Chart source

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -145,6 +145,13 @@ jobs:
           # failed DLF fetch leaves the previous CSV in place.
           python scripts/fetch_dlf.py 2>&1 || echo "::warning title=DLF fetch failed::Non-fatal — continuing with stale CSV"
 
+          # Fetch FantasyPros / Pat Fitzmaurice Dynasty Trade Value
+          # Chart.  Monthly article with date-rotating URL; the
+          # fetcher auto-resolves the current month (falls back up
+          # to 3 months).  Non-fatal — if FP hasn't published the
+          # new month's update yet, the previous CSV stays in place.
+          python scripts/fetch_fantasypros_fitzmaurice.py 2>&1 || echo "::warning title=FP Fitzmaurice fetch failed::Non-fatal — continuing with stale CSV"
+
           # Verify at least KTC data was produced (primary source)
           if [[ -f "CSVs/site_raw/ktc.csv" ]]; then
             KTC_LINES=$(wc -l < "CSVs/site_raw/ktc.csv")

--- a/CSVs/site_raw/fantasyProsFitzmaurice.csv
+++ b/CSVs/site_raw/fantasyProsFitzmaurice.csv
@@ -1,0 +1,300 @@
+name,team,position,value
+Drake Maye,NE,QB,101
+Josh Allen,BUF,QB,101
+Jayden Daniels,WAS,QB,91
+Lamar Jackson,BAL,QB,91
+Ja'Marr Chase,CIN,WR,88
+Jaxon Smith-Njigba,SEA,WR,87
+Caleb Williams,CHI,QB,85
+Bijan Robinson,ATL,RB,84
+Joe Burrow,CIN,QB,82
+Justin Herbert,LAC,QB,82
+Puka Nacua,LAR,WR,82
+Brock Bowers,LV,TE,82
+Jahmyr Gibbs,DET,RB,81
+Trey McBride,ARI,TE,81
+Patrick Mahomes II,KC,QB,79
+Jaxson Dart,NYG,QB,76
+Amon-Ra St. Brown,DET,WR,75
+Jalen Hurts,PHI,QB,73
+Trevor Lawrence,JAC,QB,73
+Justin Jefferson,MIN,WR,73
+CeeDee Lamb,DAL,WR,73
+Malik Nabers,NYG,WR,73
+Drake London,ATL,WR,71
+Bo Nix,DEN,QB,70
+Tetairoa McMillan,CAR,WR,69
+Ashton Jeanty,LV,RB,68
+Jeremiyah Love,FA,RB,68
+Brock Purdy,SF,QB,67
+Jordan Love,GB,QB,67
+George Pickens,DAL,WR,67
+Colston Loveland,CHI,TE,66
+De'Von Achane,MIA,RB,65
+Omarion Hampton,LAC,RB,65
+Nico Collins,HOU,WR,65
+James Cook III,BUF,RB,63
+Jonathan Taylor,IND,RB,63
+Garrett Wilson,NYJ,WR,63
+Chris Olave,NO,WR,63
+Emeka Egbuka,TB,WR,63
+Fernando Mendoza,FA,QB,62
+Tyler Warren,IND,TE,62
+Kenneth Walker III,KC,RB,61
+Ladd McConkey,LAC,WR,60
+Harold Fannin Jr.,CLE,TE,59
+Breece Hall,NYJ,RB,58
+TreVeyon Henderson,NE,RB,58
+Carnell Tate,FA,WR,58
+Tucker Kraft,GB,TE,57
+Bucky Irving,TB,RB,56
+Luther Burden III,CHI,WR,55
+Jordyn Tyson,FA,WR,55
+Makai Lemon,FA,WR,55
+Rome Odunze,CHI,WR,55
+Christian McCaffrey,SF,RB,54
+Tee Higgins,CIN,WR,54
+Brian Thomas Jr.,JAC,WR,54
+Marvin Harrison Jr.,ARI,WR,54
+Dak Prescott,DAL,QB,53
+Quinshon Judkins,CLE,RB,53
+DeVonta Smith,PHI,WR,53
+Jaylen Waddle,DEN,WR,53
+Sam LaPorta,DET,TE,53
+Cam Ward,TEN,QB,52
+Sam Darnold,SEA,QB,52
+Chase Brown,CIN,RB,52
+Zay Flowers,BAL,WR,52
+Kyle Pitts Sr.,ATL,TE,52
+Kyren Williams,LAR,RB,51
+Jameson Williams,DET,WR,51
+A.J. Brown,PHI,WR,51
+Rashee Rice,KC,WR,51
+C.J. Stroud,HOU,QB,50
+Travis Etienne Jr.,NO,RB,50
+Saquon Barkley,PHI,RB,50
+Javonte Williams,DAL,RB,49
+Josh Jacobs,GB,RB,49
+Kenyon Sadiq,FA,TE,49
+Baker Mayfield,TB,QB,48
+Oronde Gadsden II,LAC,TE,48
+Cam Skattebo,NYG,RB,47
+Alec Pierce,IND,WR,47
+Christian Watson,GB,WR,46
+Denzel Boston,FA,WR,46
+K.C. Concepcion,FA,WR,46
+RJ Harvey,DEN,RB,44
+Bhayshul Tuten,JAC,RB,44
+Ricky Pearsall,SF,WR,44
+DK Metcalf,PIT,WR,44
+Jared Goff,DET,QB,43
+Tyler Shough,NO,QB,43
+Derrick Henry,BAL,RB,43
+Omar Cooper Jr.,FA,WR,43
+Jayden Higgins,HOU,WR,43
+Michael Wilson,ARI,WR,43
+Jordan Addison,MIN,WR,43
+Isaiah Likely,NYG,TE,42
+Malik Willis,MIA,QB,41
+Kyler Murray,MIN,QB,41
+Bryce Young,CAR,QB,41
+Terry McLaurin,WAS,WR,41
+Davante Adams,LAR,WR,41
+Kyle Monangai,CHI,RB,40
+DJ Moore,BUF,WR,40
+Wan'Dale Robinson,TEN,WR,40
+Michael Pittman Jr.,PIT,WR,40
+Matthew Stafford,LAR,QB,39
+Daniel Jones,IND,QB,39
+D'Andre Swift,CHI,RB,39
+Parker Washington,JAC,WR,39
+Xavier Worthy,KC,WR,39
+Eli Stowers,FA,TE,39
+Dalton Kincaid,BUF,TE,39
+Quentin Johnston,LAC,WR,38
+Matthew Golden,GB,WR,38
+Jake Ferguson,DAL,TE,38
+Tyler Allgeier,ARI,RB,37
+Zach Charbonnet,SEA,RB,36
+Blake Corum,LAR,RB,36
+Mike Evans,SF,WR,36
+Josh Downs,IND,WR,36
+George Kittle,SF,TE,36
+Jadarian Price,FA,RB,35
+Jaylen Warren,PIT,RB,35
+Jakobi Meyers,JAC,WR,35
+Romeo Doubs,NE,WR,35
+Ty Simpson,FA,QB,34
+Brenton Strange,JAC,TE,34
+David Montgomery,HOU,RB,33
+Mason Taylor,NYJ,TE,33
+Terrance Ferguson,LAR,TE,33
+AJ Barner,SEA,TE,33
+Michael Penix Jr.,ATL,QB,32
+Emmett Johnson,FA,RB,32
+Mike Washington Jr.,FA,RB,32
+Jonah Coleman,FA,RB,32
+Courtland Sutton,DEN,WR,32
+Jaylin Noel,HOU,WR,32
+Khalil Shakir,BUF,WR,31
+J.J. McCarthy,MIN,QB,30
+Shedeur Sanders,CLE,QB,30
+Rico Dowdle,PIT,RB,30
+Jayden Reed,GB,WR,30
+Jalen Coker,CAR,WR,30
+Dallas Goedert,PHI,TE,30
+Mac Jones,SF,QB,29
+Jacoby Brissett,ARI,QB,29
+Elijah Sarratt,FA,WR,29
+Rhamondre Stevenson,NE,RB,28
+J.K. Dobbins,DEN,RB,28
+Tre Harris,LAC,WR,28
+Rashid Shaheed,SEA,WR,28
+Elic Ayomanor,TEN,WR,28
+T.J. Hockenson,MIN,TE,28
+Kenneth Gainwell,TB,RB,27
+Jonathon Brooks,CAR,RB,27
+Chuba Hubbard,CAR,RB,27
+Kayshon Boutte,NE,WR,27
+Tua Tagovailoa,ATL,QB,26
+Woody Marks,HOU,RB,26
+Adonai Mitchell,NYJ,WR,26
+Jacory Croskey-Merritt,WAS,RB,25
+Chris Brazzell II,FA,WR,25
+Elijah Arroyo,SEA,TE,25
+Travis Kelce,KC,TE,25
+Gunnar Helm,TEN,TE,25
+Nicholas Singleton,FA,RB,24
+Dylan Sampson,CLE,RB,24
+Tyjae Spears,TEN,RB,24
+Chris Bell,FA,WR,24
+Chris Godwin Jr.,TB,WR,24
+Travis Hunter,JAC,WR,24
+Juwan Johnson,NO,TE,24
+Chig Okonkwo,WAS,TE,24
+Mark Andrews,BAL,TE,24
+Theo Johnson,NYG,TE,24
+Anthony Richardson Sr.,IND,QB,23
+Rachaad White,WAS,RB,23
+Kaytron Allen,FA,RB,23
+Tony Pollard,TEN,RB,23
+Troy Franklin,DEN,WR,23
+Jauan Jennings,FA,WR,23
+Zachariah Branch,FA,WR,23
+Malachi Fields,FA,WR,23
+Germie Bernard,FA,WR,23
+Isaac TeSlaa,DET,WR,23
+Tyrone Tracy Jr.,NYG,RB,22
+Jalen McMillan,TB,WR,22
+Kyle Williams,NE,WR,22
+Hunter Henry,NE,TE,22
+Trey Benson,ARI,RB,21
+Braelon Allen,NYJ,RB,21
+Antonio Williams,FA,WR,21
+Chimere Dike,TEN,WR,21
+Tory Horton,SEA,WR,21
+Pat Bryant,DEN,WR,21
+Justin Fields,KC,QB,20
+Garrett Nussmeier,FA,QB,20
+Jordan Mason,MIN,RB,20
+Brandon Aiyuk,SF,WR,20
+Jerry Jeudy,CLE,WR,20
+Ted Hurst,FA,WR,19
+Bryce Lance,FA,WR,19
+David Njoku,FA,TE,19
+Geno Smith,NYJ,QB,18
+Ollie Gordon II,MIA,RB,18
+Ja'Kobi Lane,FA,WR,18
+Deebo Samuel Sr.,FA,WR,18
+Dalton Schultz,HOU,TE,18
+Joe Milton III,DAL,QB,17
+Chris Rodriguez Jr.,JAC,RB,17
+Stefon Diggs,FA,WR,17
+Devin Neal,NO,RB,16
+Jack Bech,LV,WR,16
+Tre Tucker,LV,WR,16
+Cade Otton,TB,TE,16
+Carson Beck,FA,QB,15
+Kimani Vidal,LAC,RB,15
+Keaton Mitchell,LAC,RB,15
+Brian Robinson Jr.,ATL,RB,15
+Sean Tucker,TB,RB,15
+Tyreek Hill,FA,WR,15
+Max Klare,FA,TE,15
+Aaron Rodgers,FA,QB,14
+Tank Bigsby,PHI,RB,14
+Aaron Jones Sr.,MIN,RB,14
+Skyler Bell,FA,WR,14
+Kevin Coleman Jr.,FA,WR,14
+Tank Dell,HOU,WR,14
+Marvin Mims Jr.,DEN,WR,14
+Keon Coleman,BUF,WR,14
+Michael Mayer,LV,TE,14
+Kaleb Johnson,PIT,RB,13
+Jaylen Wright,MIA,RB,13
+Seth McGowan,FA,RB,13
+Adam Randall,FA,RB,13
+Reggie Virgil,FA,WR,13
+Tez Johnson,TB,WR,13
+Ryan Flournoy,DAL,WR,13
+Pat Freiermuth,PIT,TE,13
+Emanuel Wilson,SEA,RB,12
+Brashard Smith,KC,RB,12
+Dontayvion Wicks,GB,WR,12
+Greg Dulcich,MIA,TE,12
+Isiah Pacheco,DET,RB,11
+Isaiah Davis,NYJ,RB,11
+James Conner,ARI,RB,11
+Jalen Nailor,LV,WR,11
+Konata Mumpfield,LAR,WR,11
+Rashod Bateman,BAL,WR,11
+Kirk Cousins,FA,QB,10
+Marcus Mariota,WAS,QB,10
+Cole Payton,FA,QB,10
+Riley Leonard,IND,QB,10
+Quinn Ewers,MIA,QB,10
+Alvin Kamara,NO,RB,10
+Demond Claiborne,FA,RB,10
+Kendre Miller,NO,RB,10
+Eric McAlister,FA,WR,10
+Darnell Mooney,NYG,WR,10
+Christian Kirk,SF,WR,10
+Jeff Caldwell,FA,WR,10
+Cedric Tillman,CLE,WR,10
+Cole Kmet,CHI,TE,10
+Colby Parkinson,LAR,TE,10
+Ben Sinnott,WAS,TE,10
+Ray Davis,BUF,RB,9
+Kaelon Black,FA,RB,9
+Roman Hemby,FA,RB,9
+Harrison Wallace III,FA,WR,9
+Romello Brinson,FA,WR,9
+Xavier Legette,CAR,WR,9
+Jameis Winston,NYG,QB,8
+Will Howard,PIT,QB,8
+Jaydon Blue,DAL,RB,8
+J'Mari Taylor,FA,RB,8
+Le'Veon Moss,FA,RB,8
+Calvin Ridley,TEN,WR,8
+Malik Washington,MIA,WR,8
+Darnell Washington,PIT,TE,8
+Sam Roush,FA,TE,8
+Ja'Tavion Sanders,CAR,TE,8
+Najee Harris,LAC,RB,7
+Brenen Thompson,FA,WR,7
+Chris Brooks,GB,RB,6
+MarShawn Lloyd,GB,RB,6
+Jarquez Hunter,LAR,RB,6
+DJ Giddens,IND,RB,6
+Cooper Kupp,SEA,WR,6
+Justin Joly,FA,TE,6
+Michael Trigg,FA,TE,6
+Evan Engram,DEN,TE,6
+George Holani,SEA,RB,5
+LeQuint Allen Jr.,JAC,RB,5
+Jordan James,SF,RB,5
+Devontez Walker,BAL,WR,5
+Zach Ertz,FA,TE,5
+Diego Pavia,FA,QB,4
+Will Levis,TEN,QB,4
+Tyren Montgomery,FA,WR,4

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -504,6 +504,32 @@ export const RANKING_SOURCES = [
     excludesRookies: false,
   },
   {
+    // FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart —
+    // monthly offense board covering QB/RB/WR/TE.  Fetched by
+    // scripts/fetch_fantasypros_fitzmaurice.py, which resolves the
+    // date-rotating article URL, extracts four Datawrapper iframes
+    // (one per position), and grabs each chart's dataset.csv.  Per
+    // position we pick the league-appropriate value column (SF Value
+    // for QB, TEP Value for TE, Trade Value for RB/WR) — so
+    // Fitzmaurice's Superflex + TE-Premium native numbers align
+    // with our league scoring.  Value-signal: the blend rescales
+    // Fitzmaurice's top player (typically a QB at ~101) to 9999.
+    key: "fantasyProsFitzmaurice",
+    displayName: "FantasyPros / Pat Fitzmaurice SF-TEP",
+    columnLabel: "Fitzmaurice",
+    scope: "overall_offense",
+    extraScopes: [],
+    positionGroup: null,
+    depth: 350,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: false,
+    isTepPremium: true,
+    needsSharedMarketTranslation: false,
+    excludesRookies: false,
+  },
+  {
     // DLF Dynasty Rookie Superflex — 6-expert consensus covering the
     // current rookie class only (QB/RB/WR/TE prospects).  The raw
     // rookie-only rank is crosswalked at blend time through a rookie

--- a/scripts/fetch_fantasypros_fitzmaurice.py
+++ b/scripts/fetch_fantasypros_fitzmaurice.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Fetch FantasyPros Dynasty Trade Value Chart (Fitzmaurice column).
+
+FantasyPros publishes Pat Fitzmaurice's monthly Dynasty Trade Value
+Chart as an article with a date-rotating URL.  Each monthly update
+embeds four Datawrapper iframes (one per position), and Datawrapper
+exposes the underlying table as a tab-separated CSV we can fetch
+directly — no HTML scraping of the article body required.
+
+URL pattern
+-----------
+
+The article slug rotates monthly::
+
+    https://www.fantasypros.com/{YYYY}/{MM}/
+        fantasy-football-rankings-dynasty-trade-value-chart-
+        {month-name}-{YYYY}-update/
+
+We start from the current month, fall back through up to 3 previous
+months when the current URL 404s (FP usually publishes within the
+first week, but a fresh-of-the-month run may hit a window where the
+new article hasn't landed yet).
+
+League scoring
+--------------
+
+Our league is Superflex + TE Premium, so per-position column pick:
+
+* QB  → ``SF Value``         (e.g. Josh Allen 101, not 1QB 51)
+* RB  → ``Trade Value``      (position has no league-scoring split)
+* WR  → ``Trade Value``
+* TE  → ``TEP Value``        (e.g. Brock Bowers 82, not baseline 69)
+
+This matches the yahooBoone source pattern (2QB + TE-Prem columns).
+
+Output
+------
+
+    CSVs/site_raw/fantasyProsFitzmaurice.csv
+
+Columns: ``name,team,position,value``.  The ranking pipeline reads
+the ``value`` column via ``_VALUE_ALIASES`` and rescales every
+player linearly so Fitzmaurice's top player contributes 9999.
+
+Run
+---
+
+    python3 scripts/fetch_fantasypros_fitzmaurice.py
+    python3 scripts/fetch_fantasypros_fitzmaurice.py --dry-run
+    python3 scripts/fetch_fantasypros_fitzmaurice.py --url <article-url>
+"""
+from __future__ import annotations
+
+import argparse
+import calendar
+import csv
+import re
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+OUT_PATH = REPO / "CSVs" / "site_raw" / "fantasyProsFitzmaurice.csv"
+
+# Per-position column to use for our Superflex + TE-Premium league.
+# Keys are the position label we stamp onto each row; values are
+# the CSV column-name alternatives we search for in priority order
+# (the first present column wins).
+_POSITION_VALUE_COLUMNS = {
+    "QB": ("SF Value", "Superflex Value", "2QB Value", "Trade Value"),
+    "RB": ("Trade Value", "Value"),
+    "WR": ("Trade Value", "Value"),
+    "TE": ("TEP Value", "TE Premium Value", "Trade Value", "Value"),
+}
+
+# Datawrapper chart IDs sometimes appear multiple times per article;
+# we only want the four rankings tables.  Identify them by matching
+# the position label in the containing heading / caption.
+_POSITION_HEADINGS = (
+    ("QB", ("Dynasty Trade Values: Quarterbacks", "Quarterbacks")),
+    ("RB", ("Dynasty Trade Values: Running Backs", "Running Backs")),
+    ("WR", ("Dynasty Trade Values: Wide Receivers", "Wide Receivers")),
+    ("TE", ("Dynasty Trade Value Chart: Tight Ends",
+            "Dynasty Trade Values: Tight Ends", "Tight Ends")),
+)
+
+
+def _build_candidate_urls(today: date | None = None) -> list[str]:
+    """Return article URLs to try, newest month first.
+
+    Falls back up to 3 months back so a run on the 2nd of the month
+    before Fitzmaurice's update lands still finds last month's data.
+    """
+    t = today or date.today()
+    urls: list[str] = []
+    for offset in range(0, 4):
+        y = t.year
+        m = t.month - offset
+        while m <= 0:
+            m += 12
+            y -= 1
+        month_name = calendar.month_name[m].lower()
+        urls.append(
+            f"https://www.fantasypros.com/{y}/{m:02d}/"
+            f"fantasy-football-rankings-dynasty-trade-value-chart-"
+            f"{month_name}-{y}-update/"
+        )
+    return urls
+
+
+def _fetch_article_html(url: str) -> str | None:
+    """GET the FP article; return text on 200, None on 404/error."""
+    try:
+        import requests
+    except ImportError:
+        raise SystemExit(
+            "requests is not installed.  `pip install requests` first."
+        )
+    try:
+        r = requests.get(
+            url,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/131.0.0.0 Safari/537.36"
+                ),
+            },
+            timeout=30,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[fitzmaurice] GET {url} failed: {exc}", file=sys.stderr)
+        return None
+    if r.status_code != 200:
+        return None
+    return r.text
+
+
+def _extract_chart_ids_by_position(html: str) -> dict[str, str]:
+    """Find the four Datawrapper iframes and match each to its
+    position (QB/RB/WR/TE) by inspecting the nearest preceding
+    heading.  Returns ``{position: chart_id}``.
+
+    FantasyPros lays the article out as::
+
+        <h3>Dynasty Trade Values: Quarterbacks</h3>
+        <iframe ... src="https://datawrapper.dwcdn.net/yqKj2/1/" ...>
+        <h3>Dynasty Trade Values: Running Backs</h3>
+        <iframe ... src="https://datawrapper.dwcdn.net/ZVpNh/1/" ...>
+
+    We scan sequentially, keeping track of the last position heading
+    we saw, and map each iframe's chart_id to that position.
+    """
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:
+        raise SystemExit(
+            "beautifulsoup4 not installed.  `pip install beautifulsoup4`."
+        )
+    soup = BeautifulSoup(html, "html.parser")
+    # Walk the document tree in source order, tracking the most
+    # recent heading we saw for each position match.
+    out: dict[str, str] = {}
+    current_pos: str | None = None
+    # Only look in the article body (skip footer / sidebar).  FP
+    # wraps the article in <article> or <main> on most templates.
+    scope = soup.find("article") or soup.find("main") or soup
+    for node in scope.find_all(["h2", "h3", "iframe"]):
+        if node.name in ("h2", "h3"):
+            text = node.get_text(" ", strip=True)
+            for pos, needles in _POSITION_HEADINGS:
+                if any(n.lower() in text.lower() for n in needles):
+                    current_pos = pos
+                    break
+            else:
+                # Non-position heading (e.g. "Dynasty Rookie Draft Pick
+                # Values") — clear the current position so any iframe
+                # belonging to a non-player chart doesn't get stamped.
+                current_pos = None
+        elif node.name == "iframe":
+            src = node.get("src") or ""
+            m = re.search(r"datawrapper\.dwcdn\.net/([A-Za-z0-9]+)/", src)
+            if not m:
+                continue
+            chart_id = m.group(1)
+            if current_pos and current_pos not in out:
+                out[current_pos] = chart_id
+    return out
+
+
+def _fetch_chart_csv(chart_id: str) -> str | None:
+    """Fetch the Datawrapper dataset CSV (tab-separated)."""
+    try:
+        import requests
+    except ImportError:
+        raise SystemExit(
+            "requests is not installed.  `pip install requests` first."
+        )
+    url = f"https://datawrapper.dwcdn.net/{chart_id}/1/dataset.csv"
+    try:
+        r = requests.get(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) "
+                              "AppleWebKit/537.36 Chrome/131",
+                "Referer": "https://www.fantasypros.com/",
+            },
+            timeout=20,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[fitzmaurice] chart {chart_id} fetch failed: {exc}",
+              file=sys.stderr)
+        return None
+    if r.status_code != 200:
+        print(f"[fitzmaurice] chart {chart_id} status={r.status_code}",
+              file=sys.stderr)
+        return None
+    return r.text
+
+
+def _parse_chart_rows(csv_text: str, position: str) -> list[dict]:
+    """Parse one Datawrapper TSV and return ``[{name, team, value}]``.
+
+    Picks the value column per the per-position priority list.  Rows
+    whose value does not parse as a positive number (e.g. FP's
+    trailing "All Other <POS>s	1" row with value 1 — a filler bucket
+    that should not enter the blend) are dropped.
+    """
+    # Datawrapper's CSV is tab-separated despite the .csv extension.
+    rdr = csv.DictReader(csv_text.splitlines(), delimiter="\t")
+    col_choices = _POSITION_VALUE_COLUMNS.get(position, ("Trade Value",))
+    rows_out: list[dict] = []
+    for row in rdr:
+        name = (row.get("Name") or row.get("name") or "").strip()
+        if not name:
+            continue
+        # Skip FP's trailing "All Other <Position>s" bucket row.
+        if name.lower().startswith("all other "):
+            continue
+        team = (row.get("Team") or row.get("team") or "").strip()
+        raw_val: str | None = None
+        for col in col_choices:
+            if col in row and row[col] not in (None, ""):
+                raw_val = str(row[col]).strip()
+                if raw_val:
+                    break
+        if raw_val is None:
+            continue
+        try:
+            val = int(float(raw_val))
+        except (TypeError, ValueError):
+            continue
+        # Filler bucket rows sometimes carry value 1; skip them so
+        # they don't pollute the tail of the combined pool.
+        if val <= 1:
+            continue
+        rows_out.append({
+            "name": name,
+            "team": team,
+            "position": position,
+            "value": val,
+        })
+    return rows_out
+
+
+def _write_csv(path: Path, rows: list[dict]) -> int:
+    """Write the combined ``name,team,position,value`` CSV."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Sort by value desc so the top player is the first row.
+    rows_sorted = sorted(rows, key=lambda r: -int(r["value"]))
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["name", "team", "position", "value"])
+        for r in rows_sorted:
+            w.writerow([r["name"], r["team"], r["position"], r["value"]])
+    return len(rows_sorted)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Scrape but don't write the CSV.")
+    parser.add_argument(
+        "--url", metavar="ARTICLE_URL",
+        help="Skip URL discovery and use this article URL directly.",
+    )
+    args = parser.parse_args()
+
+    candidate_urls: list[str] = (
+        [args.url] if args.url else _build_candidate_urls()
+    )
+    html: str | None = None
+    used_url: str | None = None
+    for candidate in candidate_urls:
+        print(f"[fitzmaurice] trying {candidate}")
+        html = _fetch_article_html(candidate)
+        if html is not None:
+            used_url = candidate
+            print(f"[fitzmaurice] fetched article ({len(html):,} bytes)")
+            break
+    if html is None or used_url is None:
+        print(
+            "[fitzmaurice] ERROR: could not fetch any candidate "
+            "article URL.  Monthly update may not have been published "
+            "yet — retry in a day.  URLs tried:",
+            file=sys.stderr,
+        )
+        for url in candidate_urls:
+            print(f"  {url}", file=sys.stderr)
+        return 1
+
+    chart_ids = _extract_chart_ids_by_position(html)
+    print(f"[fitzmaurice] detected charts: {chart_ids}")
+    if set(chart_ids) != {"QB", "RB", "WR", "TE"}:
+        missing = sorted({"QB", "RB", "WR", "TE"} - set(chart_ids))
+        print(
+            f"[fitzmaurice] WARN: missing chart IDs for {missing} — "
+            f"FP article structure may have changed.",
+            file=sys.stderr,
+        )
+        if not chart_ids:
+            return 1
+
+    all_rows: list[dict] = []
+    for position in ("QB", "RB", "WR", "TE"):
+        chart_id = chart_ids.get(position)
+        if chart_id is None:
+            continue
+        csv_text = _fetch_chart_csv(chart_id)
+        if csv_text is None:
+            print(
+                f"[fitzmaurice] WARN: chart {chart_id} ({position}) "
+                f"fetch failed — dropping {position} from this run.",
+                file=sys.stderr,
+            )
+            continue
+        rows = _parse_chart_rows(csv_text, position)
+        print(f"[fitzmaurice] {position} ({chart_id}): parsed {len(rows)} rows")
+        all_rows.extend(rows)
+
+    if not all_rows:
+        print("[fitzmaurice] ERROR: no rows extracted from any position",
+              file=sys.stderr)
+        return 1
+
+    # Sanity floor — each position should have at least ~20 rows in
+    # a normal chart.  A big shortfall suggests FP changed the
+    # Datawrapper layout.
+    pos_counts: dict[str, int] = {}
+    for r in all_rows:
+        pos_counts[r["position"]] = pos_counts.get(r["position"], 0) + 1
+    print(f"[fitzmaurice] position counts: {pos_counts}")
+    for pos in ("QB", "RB", "WR", "TE"):
+        if pos_counts.get(pos, 0) < 10:
+            print(
+                f"[fitzmaurice] WARN: {pos} only has "
+                f"{pos_counts.get(pos, 0)} rows — expected ≥10.",
+                file=sys.stderr,
+            )
+
+    if args.dry_run:
+        print(
+            f"[fitzmaurice] dry-run: {len(all_rows)} total rows "
+            f"(top 5 by value):"
+        )
+        for r in sorted(all_rows, key=lambda r: -r["value"])[:5]:
+            print(
+                f"  {r['position']:<3} {r['name']:<25} "
+                f"{r['team']:<4} value={r['value']}"
+            )
+        return 0
+
+    count = _write_csv(OUT_PATH, all_rows)
+    print(f"[fitzmaurice] wrote {count} rows → {OUT_PATH.relative_to(REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -74,6 +74,7 @@ _OFFENSE_SIGNAL_KEYS = {
     "dynastyNerdsSfTep",
     "footballGuysSf",
     "yahooBoone",
+    "fantasyProsFitzmaurice",
 }
 _IDP_SIGNAL_KEYS = {
     "idpTradeCalc",
@@ -278,6 +279,22 @@ _SOURCE_CSV_PATHS: dict[str, Any] = {
         "path": "CSVs/site_raw/yahooBoone.csv",
         "signal": "value",
     },
+    # FantasyPros Dynasty Trade Value Chart — Pat Fitzmaurice's
+    # monthly article-based chart.  Fetched by
+    # ``scripts/fetch_fantasypros_fitzmaurice.py`` which resolves
+    # the date-rotating article URL, parses the four embedded
+    # Datawrapper iframes (QB/RB/WR/TE), and writes per-position
+    # values on a 0-~101 scale.  For each position we pick the
+    # league-appropriate column: ``SF Value`` for QB (Superflex),
+    # ``Trade Value`` for RB/WR (no league-scoring split), and
+    # ``TEP Value`` for TE (TE-Premium) — matching the yahooBoone
+    # pattern.  Signal=value so the blend's value-direct branch
+    # rescales Fitzmaurice's top player (typically a QB at 101)
+    # to 9999 and every other player scales linearly.
+    "fantasyProsFitzmaurice": {
+        "path": "CSVs/site_raw/fantasyProsFitzmaurice.csv",
+        "signal": "value",
+    },
     # DLF Dynasty Rookie Superflex rankings — 6-expert consensus of the
     # current rookie class only (no veterans).  Raw CSV exported from
     # DLF with Rank, Avg, Pos, Name, Team, Age, expert columns.  Signal=
@@ -352,6 +369,9 @@ _SOURCE_MAX_AGE_HOURS: dict[str, int] = {
     # allow a 30-day window; the fetcher also emits its own stale-
     # article warning if Yahoo's redirect chain ever stops resolving.
     "yahooBoone": 720,
+    # FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart:
+    # refreshes monthly as a new FP article.  30-day window.
+    "fantasyProsFitzmaurice": 720,
     # DraftSharks SF + IDP CSVs are written by scripts/fetch_draftsharks.py
     # on every scheduled-refresh tick (3-hour cadence), so the same
     # 6-hour freshness budget as ktc / idpTradeCalc applies.
@@ -388,6 +408,9 @@ _DEFAULT_SOURCE_ROW_FLOORS: dict[str, int] = {
     # at the April 2026 baseline.  Floor at ~80% so a scrape regression
     # trips a warning.
     "yahooBoone": 400,
+    # FantasyPros / Pat Fitzmaurice: QB (50) + RB (~88) + WR (~115) +
+    # TE (~46) ≈ 299 rows at the April 2026 baseline.  Floor at ~75%.
+    "fantasyProsFitzmaurice": 225,
     # DraftSharks: the scraper ingests 461 offense / 389 IDP rows,
     # but canonical-name matches against the Sleeper player pool
     # yield a smaller count because DS's deeper rows are prospects
@@ -1049,6 +1072,42 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "position_group": None,
         "depth": 500,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "is_tep_premium": True,
+        "needs_shared_market_translation": False,
+        "excludes_rookies": False,
+    },
+    {
+        # FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart —
+        # monthly offense board covering QB/RB/WR/TE.  Fetched by
+        # ``scripts/fetch_fantasypros_fitzmaurice.py`` which:
+        #   1. resolves the month-rotating article URL (falls back
+        #      3 months if the current-month update isn't published yet),
+        #   2. parses the four embedded Datawrapper iframes for
+        #      QB / RB / WR / TE,
+        #   3. fetches each chart's dataset.csv and picks the league-
+        #      appropriate value column: ``SF Value`` for QB (Superflex),
+        #      ``Trade Value`` for RB/WR, ``TEP Value`` for TE (TE-Premium).
+        # Result: ~300 combined rows with a top-of-pool value of ~101
+        # (SF-adjusted QB).  Signal=value so the blend's value-direct
+        # branch scales Fitzmaurice's top to 9999 and every other row
+        # linearly.  Cross-position separation is preserved (e.g. top
+        # QB at SF value 101 beats top WR at 88, scaling to 9999 vs
+        # 8712 on the 9999 scale).
+        #
+        # depth=350 reflects the published row count; coverage_weight
+        # keeps full weight for rows within depth and degrades past.
+        # Like yahooBoone, this is a TEP-native source: it applies the
+        # TE premium directly via the TEP Value column, so the global
+        # TEP multiplier MUST NOT compound.
+        "key": "fantasyProsFitzmaurice",
+        "display_name": "FantasyPros / Pat Fitzmaurice SF-TEP",
+        "column_label": "Fitzmaurice",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": 350,
         "weight": 1.0,
         "is_backbone": False,
         "is_retail": False,
@@ -3495,6 +3554,12 @@ _VALUE_BASED_SOURCES: frozenset[str] = frozenset({
     # Added 2026-04-21 to preserve Boone's native value structure
     # instead of collapsing it to rank-only ordinal information.
     "yahooBoone",
+    # FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart.
+    # Published monthly; Datawrapper CSV exposes SF Value (QB),
+    # Trade Value (RB/WR), TEP Value (TE) columns.  Top player
+    # sits at 101 (SF-adjusted QB) so the value-direct rescaling
+    # maps Fitzmaurice's top → 9999.  Added 2026-04-21.
+    "fantasyProsFitzmaurice",
 })
 
 

--- a/tests/adapters/test_fitzmaurice_scraper.py
+++ b/tests/adapters/test_fitzmaurice_scraper.py
@@ -1,0 +1,188 @@
+"""Unit tests for scripts/fetch_fantasypros_fitzmaurice.py
+
+The live fetcher hits FantasyPros + Datawrapper over HTTP, so the
+tests here exercise the offline-safe pure functions: URL candidate
+generation, chart-ID extraction from a page snippet, per-position
+column selection, and trailing-filler-row filtering.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def fz_module():
+    repo = Path(__file__).resolve().parents[2]
+    path = repo / "scripts" / "fetch_fantasypros_fitzmaurice.py"
+    spec = importlib.util.spec_from_file_location(
+        "fetch_fantasypros_fitzmaurice", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["fetch_fantasypros_fitzmaurice"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_candidate_urls_current_month_first(fz_module):
+    urls = fz_module._build_candidate_urls(date(2026, 4, 21))
+    assert urls[0].endswith("april-2026-update/")
+    assert urls[1].endswith("march-2026-update/")
+    assert urls[2].endswith("february-2026-update/")
+    assert urls[3].endswith("january-2026-update/")
+    # URL path format
+    assert "/2026/04/" in urls[0]
+    assert "/2026/03/" in urls[1]
+
+
+def test_build_candidate_urls_wraps_year_boundary(fz_module):
+    urls = fz_module._build_candidate_urls(date(2026, 2, 3))
+    assert urls[0].endswith("february-2026-update/")
+    assert urls[1].endswith("january-2026-update/")
+    assert urls[2].endswith("december-2025-update/")
+    assert urls[3].endswith("november-2025-update/")
+    assert "/2025/12/" in urls[2]
+    assert "/2025/11/" in urls[3]
+
+
+FAKE_ARTICLE_HTML = """
+<html><body>
+<article>
+  <h2>Dynasty Trade Value Chart</h2>
+  <h3>Dynasty Rookie Draft Pick Values</h3>
+  <table>
+    <tr><th>Round 1</th><th>1QB</th><th>SF</th></tr>
+    <tr><td>1.01</td><td>68</td><td>68</td></tr>
+  </table>
+
+  <h3>Dynasty Trade Values: Quarterbacks</h3>
+  <iframe src="https://datawrapper.dwcdn.net/yqKj2/1/"></iframe>
+
+  <h3>Dynasty Trade Values: Running Backs</h3>
+  <iframe src="https://datawrapper.dwcdn.net/ZVpNh/1/"></iframe>
+
+  <h3>Dynasty Trade Values: Wide Receivers</h3>
+  <iframe src="https://datawrapper.dwcdn.net/yuwfA/1/"></iframe>
+
+  <h3>Dynasty Trade Value Chart: Tight Ends</h3>
+  <iframe src="https://datawrapper.dwcdn.net/GFqDz/1/"></iframe>
+
+  <h3>About Author</h3>
+</article>
+</body></html>
+"""
+
+
+def test_extract_chart_ids_by_position(fz_module):
+    ids = fz_module._extract_chart_ids_by_position(FAKE_ARTICLE_HTML)
+    assert ids == {
+        "QB": "yqKj2",
+        "RB": "ZVpNh",
+        "WR": "yuwfA",
+        "TE": "GFqDz",
+    }
+
+
+def test_extract_chart_ids_ignores_non_position_iframes(fz_module):
+    html = """
+    <html><body><article>
+      <h3>Dynasty Trade Values: Quarterbacks</h3>
+      <iframe src="https://datawrapper.dwcdn.net/qbCHARTID/1/"></iframe>
+      <h3>About Author</h3>
+      <iframe src="https://datawrapper.dwcdn.net/shouldNotMatch/1/"></iframe>
+    </article></body></html>
+    """
+    ids = fz_module._extract_chart_ids_by_position(html)
+    assert ids == {"QB": "qbCHARTID"}
+    assert "shouldNotMatch" not in ids.values()
+
+
+QB_CSV_TSV = (
+    "Name\tTeam\tTrade Value\tSF Value\tValue Change\n"
+    "Josh Allen\tBUF\t51\t101\t- / -\n"
+    "Drake Maye\tNE\t51\t101\t- / -\n"
+    "Jayden Daniels\tWAS\t46\t91\t- / +1\n"
+    "All Other QBs\t\t1\t4\t\n"
+)
+
+RB_CSV_TSV = (
+    "Name\tTeam\tTrade Value\tValue Change\n"
+    "Bijan Robinson\tATL\t84\t+1\n"
+    "Jahmyr Gibbs\tDET\t81\t-\n"
+    "All Other RBs\t\t1\t-\n"
+)
+
+TE_CSV_TSV = (
+    "Name\tTeam\tTrade Value\tTEP Value\tValue Change\n"
+    "Brock Bowers\tLV\t69\t82\t- / -\n"
+    "Trey McBride\tARI\t67\t81\t- / -\n"
+    "All Other TEs\t\t1\t\t\n"
+)
+
+
+def test_parse_chart_rows_qb_uses_sf_value(fz_module):
+    rows = fz_module._parse_chart_rows(QB_CSV_TSV, "QB")
+    assert len(rows) == 3  # "All Other QBs" dropped
+    assert rows[0]["name"] == "Josh Allen"
+    assert rows[0]["value"] == 101  # SF Value, not 1QB Trade Value
+    assert rows[0]["position"] == "QB"
+    assert rows[0]["team"] == "BUF"
+
+
+def test_parse_chart_rows_rb_uses_trade_value(fz_module):
+    rows = fz_module._parse_chart_rows(RB_CSV_TSV, "RB")
+    assert len(rows) == 2
+    assert rows[0]["name"] == "Bijan Robinson"
+    assert rows[0]["value"] == 84
+
+
+def test_parse_chart_rows_te_uses_tep_value(fz_module):
+    rows = fz_module._parse_chart_rows(TE_CSV_TSV, "TE")
+    assert len(rows) == 2
+    assert rows[0]["name"] == "Brock Bowers"
+    assert rows[0]["value"] == 82  # TEP Value, not 69 baseline Trade Value
+    assert rows[1]["name"] == "Trey McBride"
+    assert rows[1]["value"] == 81
+
+
+def test_parse_chart_rows_drops_filler_value_1_rows(fz_module):
+    csv_text = (
+        "Name\tTeam\tTrade Value\tValue Change\n"
+        "Real Player\tSF\t50\t-\n"
+        "All Other RBs\t\t1\t-\n"
+        "Fluke Row\t\t1\t-\n"
+    )
+    rows = fz_module._parse_chart_rows(csv_text, "RB")
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Real Player"
+
+
+def test_write_csv_sorts_by_value_desc_and_preserves_position(fz_module, tmp_path: Path):
+    out = tmp_path / "fitz_test.csv"
+    rows = [
+        {"name": "WR1", "team": "A", "position": "WR", "value": 80},
+        {"name": "QB1", "team": "B", "position": "QB", "value": 101},
+        {"name": "RB1", "team": "C", "position": "RB", "value": 95},
+    ]
+    count = fz_module._write_csv(out, rows)
+    assert count == 3
+    import csv
+    with out.open() as f:
+        written = list(csv.DictReader(f))
+    # Top-value first.
+    assert written[0]["name"] == "QB1"
+    assert written[0]["value"] == "101"
+    assert written[0]["position"] == "QB"
+    assert written[-1]["name"] == "WR1"
+
+
+def test_position_value_columns_registered_for_all_four(fz_module):
+    assert set(fz_module._POSITION_VALUE_COLUMNS) == {"QB", "RB", "WR", "TE"}
+    # QB must prefer SF Value; TE must prefer TEP Value — the whole
+    # point of the per-position priority list.
+    assert fz_module._POSITION_VALUE_COLUMNS["QB"][0] == "SF Value"
+    assert fz_module._POSITION_VALUE_COLUMNS["TE"][0] == "TEP Value"

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -460,10 +460,11 @@ class TestPayloadLevelBlocks(unittest.TestCase):
         self.assertIsInstance(meth["sources"], list)
         # ktc + idpTradeCalc + dlfIdp + dlfSf + dynastyNerdsSfTep +
         # fantasyProsSf + dynastyDaddySf + fantasyProsIdp + flockFantasySf +
-        # footballGuysSf + footballGuysIdp + yahooBoone + dlfRookieSf +
-        # dlfRookieIdp + draftSharks + draftSharksIdp
-        # (sixteen registered ranking sources)
-        self.assertEqual(len(meth["sources"]), 16)
+        # footballGuysSf + footballGuysIdp + yahooBoone +
+        # fantasyProsFitzmaurice + dlfRookieSf + dlfRookieIdp +
+        # draftSharks + draftSharksIdp (seventeen sources as of 2026-04-21
+        # when FP/Fitzmaurice was added).
+        self.assertEqual(len(meth["sources"]), 17)
         keys = {s.get("key") for s in meth["sources"]}
         self.assertEqual(
             keys,
@@ -480,6 +481,7 @@ class TestPayloadLevelBlocks(unittest.TestCase):
                 "footballGuysSf",
                 "footballGuysIdp",
                 "yahooBoone",
+                "fantasyProsFitzmaurice",
                 "dlfRookieSf",
                 "dlfRookieIdp",
                 "draftSharks",


### PR DESCRIPTION
## Summary
- New source \`fantasyProsFitzmaurice\` — Pat Fitzmaurice's monthly Dynasty Trade Value Chart on FantasyPros.
- Scraper resolves the date-rotating article URL, extracts four Datawrapper iframes (QB/RB/WR/TE), picks league-appropriate value column per position (SF Value for QB, TEP Value for TE, Trade Value for RB/WR), writes a combined CSV.
- Value-based source — top player (typically QB at SF value 101) rescales to 9999 via the same value-direct branch KTC and Boone use.

## Why
Adds another expert authority for SF-TEP trade values with native TE-premium handling. Now we have two TEP-native value sources (yahooBoone + fantasyProsFitzmaurice) giving us cross-market signal on the TE-premium adjustment.

## How
- \`scripts/fetch_fantasypros_fitzmaurice.py\`: URL candidate generator (current month + up to 3 months back), Datawrapper chart ID extraction, per-position column picker, filler-row filter
- Registry: \`_SOURCE_CSV_PATHS\` + \`_VALUE_BASED_SOURCES\` + \`_RANKING_SOURCES\` + frontend mirror
- 10 new unit tests: URL generation, chart-ID extraction, per-position column preference, filler filter, CSV output
- Added to \`scheduled-refresh.yml\` with non-fatal fallback

## Smoke (against cached Apr 16 contract)
\`\`\`
Josh Allen    raw 101 → vc 9999  (value_direct)
Drake Maye    raw 101 → vc 9999
Ja'Marr Chase raw  88 → vc 8712
Brock Bowers  raw  82 → vc 8118  (TEP-native)
\`\`\`

Row counts (April 2026 update): QB 50 + RB 88 + WR 115 + TE 46 = 299 total.

## Test plan
- [x] pytest tests/ -q — 1651 passed (10 new Fitzmaurice tests)
- [x] npm run build — green
- [x] Local live fetch — all 4 charts parsed and CSV written
- [ ] Post-deploy: verify \`/rankings\` shows a Fitzmaurice column
- [ ] Next scheduled-refresh — confirm the GH Actions step writes fresh CSVs

🤖 Generated with [Claude Code](https://claude.com/claude-code)