### PR TITLE
Add Flock Fantasy SF rookie rankings as a new source

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -125,6 +125,9 @@ jobs:
           # Fetch Flock Fantasy SF rankings
           python scripts/fetch_flock_fantasy.py --mirror-data-dir 2>/dev/null || echo "::warning title=Flock Fantasy fetch failed::Non-fatal — continuing"
 
+          # Fetch Flock Fantasy SF ROOKIE rankings (PROSPECTS_SF endpoint)
+          python scripts/fetch_flock_fantasy_rookies.py --mirror-data-dir 2>/dev/null || echo "::warning title=Flock Fantasy rookies fetch failed::Non-fatal — continuing"
+
           # Fetch FootballGuys league-synced rankings (offense + IDP)
           # The scraper auto-logs-in via Playwright on session refresh
           # when cached cookies are rejected; non-fatal if the site is

--- a/CSVs/site_raw/flockFantasySfRookies.csv
+++ b/CSVs/site_raw/flockFantasySfRookies.csv
@@ -1,0 +1,99 @@
+name,Rank
+Jeremiyah Love,1.0
+Makai Lemon,2.57
+Carnell Tate,2.71
+Jordyn Tyson,4.43
+Fernando Mendoza,4.43
+Kenyon Sadiq,5.86
+KC Concepcion,7.0
+Omar Cooper Jr.,8.43
+Jadarian Price,9.57
+Denzel Boston,11.57
+Jonah Coleman,11.86
+Eli Stowers,13.0
+Elijah Sarratt,13.29
+Ty Simpson,14.29
+Chris Bell,17.29
+Germie Bernard,18.57
+Nicholas Singleton,19.86
+Kaytron Allen,19.86
+Chris Brazzell II,20.29
+Ja'Kobi Lane,20.71
+Zachariah Branch,21.14
+Ted Hurst,21.33
+Mike Washington Jr.,21.43
+Emmett Johnson,22.57
+Max Klare,23.14
+Antonio Williams,25.0
+Bryce Lance,28.83
+Justin Joly,29.4
+Skyler Bell,30.5
+Eric McAlister,31.14
+Le'Veon Moss,33.17
+Drew Allar,33.86
+Demond Claiborne,34.14
+Oscar Delp,35.33
+Eli Heidenreich,36.0
+Dean Connors,36.0
+Malachi Fields,36.17
+Adam Randall,37.0
+Michael Trigg,37.33
+Eli Raridon,38.0
+J'Mari Taylor,38.25
+De'Zhaun Stribling,38.33
+Cole Payton,38.8
+Kaelon Black,39.0
+Roman Hemby,39.2
+Garrett Nussmeier,39.83
+Seth McGowan,41.0
+Deion Burks,41.33
+Desmond Reid,41.5
+Jack Endries,41.83
+Jaydn Ott,43.33
+Jeff Caldwell,45.8
+Brenen Thompson,46.0
+Zavion Thomas,46.0
+Kevin Coleman Jr.,46.75
+C.J. Daniels,47.0
+Taylen Green,47.0
+Sam Roush,47.5
+Cade Klubnik,47.6
+Terion Stewart,48.0
+Amare Thomas,48.0
+Carson Beck,49.25
+Deion Burks (Duplicate),50.0
+Jamarion (Jam) Miller,51.33
+Diego Pavia,51.5
+Tanner Koziol,51.67
+Barion Brown,62.0
+Aaron Anderson,62.0
+Reggie Virgil,62.5
+Malik Benson,63.0
+Rahsul Faison,64.0
+Josh Cameron,64.0
+Robert Henry Jr.,64.5
+Eric Rivers,65.0
+Chase Roberts,66.0
+Lewis Bond,66.5
+Noah Whittington,67.0
+John Michael Gyllenborg,69.5
+Dallen Bentley,69.5
+Caleb Douglas,71.0
+Dae'quan Wright,71.0
+Jordan Hudson,72.0
+Joe Royer,72.0
+Jalon Daniels,73.0
+Josh Cuevas,73.0
+Colbie Young,76.0
+Marlin Klein,76.5
+Jalen Walthall,78.0
+Emmanuel Henderson Jr,79.0
+Caullin Lacy,80.0
+Jamal Haynes,81.0
+CJ Donaldson,82.0
+Kentrel Bullock,83.0
+Chip Trayanum,84.0
+RJ Maryland,91.0
+Lake McRee,93.0
+J. Michael Sturdivant,94.0
+Kendrick Law,95.0

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -554,6 +554,30 @@ export const RANKING_SOURCES = [
     excludesRookies: false,
   },
   {
+    // Flock Fantasy Dynasty Superflex ROOKIE rankings — multi-expert
+    // averaged ranks of the current incoming rookie class only
+    // (~95 QB/RB/WR/TE prospects).  Same translation behaviour as
+    // dlfRookieSf — the within-class rank is crosswalked through KTC's
+    // offense rookie ladder so Flock's #1 rookie inherits KTC's
+    // scale-for-top-rookie.  Pick nudging is not wired for this source;
+    // dlfRookieSf already stamps synthetic "2026 Pick R.SS" rows.
+    key: "flockFantasySfRookies",
+    displayName: "Flock Fantasy Rookie SF",
+    columnLabel: "Flock RK",
+    scope: "overall_offense",
+    extraScopes: [],
+    positionGroup: null,
+    depth: 50,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: true,
+    isTepPremium: false,
+    needsSharedMarketTranslation: false,
+    needsRookieTranslation: true,
+    excludesRookies: false,
+  },
+  {
     // DLF Dynasty Rookie IDP — rookie-only DL/LB/DB prospects.
     // Translated against IDPTC's rookie ladder.  Does NOT stamp onto
     // picks because rookie IDP ranks are not a strong signal for

--- a/scripts/fetch_flock_fantasy_rookies.py
+++ b/scripts/fetch_flock_fantasy_rookies.py
@@ -113,14 +113,22 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
     """Extract (name, Rank) from a Flock Fantasy PROSPECTS_SF response.
 
     Only returns players whose position is in _OFFENSE_POSITIONS,
-    whose isDraftPick is false, whose isRookie is true, and whose
-    averageRank is a positive number.
+    whose isDraftPick is false, whose isRookie is explicitly true,
+    and whose averageRank is a positive number.
 
     The PROSPECTS_SF endpoint is rookie-only by name, but we filter
-    defensively on ``isRookie`` because this source is wired with
+    strictly on ``isRookie is True`` because this source is wired with
     ``needs_rookie_translation=True`` downstream — any veteran row
     that slips through would be remapped via the rookie ladder and
-    skew blended values.
+    skew blended values.  Missing/null ``isRookie`` flags are dropped
+    rather than accepted; losing a legit rookie if Flock changes their
+    schema costs us one source's contribution for that player, while
+    accepting a non-rookie distorts the ladder for every player above
+    them.
+
+    Non-dict rows in the ``data`` array (e.g. ``null`` from a partial
+    payload) are silently skipped so a single malformed element does
+    not abort the whole fetch.
     """
     if not isinstance(data, dict) or "data" not in data:
         raise FlockFantasyRookiesSchemaError(
@@ -133,9 +141,11 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
         )
     out: list[dict[str, Any]] = []
     for entry in entries:
+        if not isinstance(entry, dict):
+            continue
         if entry.get("isDraftPick"):
             continue
-        if entry.get("isRookie") is False:
+        if entry.get("isRookie") is not True:
             continue
         name = str(entry.get("playerName") or "").strip()
         if not name:

--- a/scripts/fetch_flock_fantasy_rookies.py
+++ b/scripts/fetch_flock_fantasy_rookies.py
@@ -113,8 +113,14 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
     """Extract (name, Rank) from a Flock Fantasy PROSPECTS_SF response.
 
     Only returns players whose position is in _OFFENSE_POSITIONS,
-    whose isDraftPick is false, and whose averageRank is a positive
-    number.
+    whose isDraftPick is false, whose isRookie is true, and whose
+    averageRank is a positive number.
+
+    The PROSPECTS_SF endpoint is rookie-only by name, but we filter
+    defensively on ``isRookie`` because this source is wired with
+    ``needs_rookie_translation=True`` downstream — any veteran row
+    that slips through would be remapped via the rookie ladder and
+    skew blended values.
     """
     if not isinstance(data, dict) or "data" not in data:
         raise FlockFantasyRookiesSchemaError(
@@ -128,6 +134,8 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for entry in entries:
         if entry.get("isDraftPick"):
+            continue
+        if entry.get("isRookie") is False:
             continue
         name = str(entry.get("playerName") or "").strip()
         if not name:

--- a/scripts/fetch_flock_fantasy_rookies.py
+++ b/scripts/fetch_flock_fantasy_rookies.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Fetch Flock Fantasy Superflex rookie/prospect rankings and write a source CSV.
+
+Flock Fantasy publishes a public JSON API at::
+
+    https://api.flockfantasy.com/rankings?format=PROSPECTS_SF
+
+which returns ``{ format, year, data: [...] }`` with ~98 entries — the
+current incoming rookie class only (``isRookie == true`` and
+``isDraftPick == false`` for every row, scoped to the upcoming
+``draftYear``).  Each entry carries ``playerName``, ``position``,
+``averageRank`` (float, lower is better), and ``isRookie``.  After
+filtering to offensive positions (QB/RB/WR/TE) ~95+ prospects remain.
+
+Core model
+----------
+
+This is a **rank signal** source (not value).  ``averageRank`` is a
+multi-expert averaged consensus rank of incoming rookies — lower is
+better.  Like ``dlfRookieSf``, the source is registered with
+``needs_rookie_translation=True`` so the within-class rank is
+crosswalked through KTC's offense rookie ladder before the Hill curve
+sees it; that way Flock's #1 rookie inherits KTC's scale-for-top-rookie
+rather than being mapped to overall #1 = 9999.
+
+Output CSV
+----------
+
+Written to ``CSVs/site_raw/flockFantasySfRookies.csv`` with columns:
+
+    name, Rank
+
+Read by ``_enrich_from_source_csvs`` in ``src/api/data_contract.py``
+as a rank-signal source; ``Rank`` drives the downstream blend.
+
+Run::
+
+    python3 scripts/fetch_flock_fantasy_rookies.py [--mirror-data-dir] [--dry-run]
+
+Exit codes:
+    0  - success, CSV written
+    1  - soft failure (fetch / parse error, or zero rows extracted)
+    2  - schema / shape regression:
+         * response is not a dict with a ``data`` array, or
+         * row count below :data:`_FF_ROOKIE_ROW_COUNT_FLOOR`
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import requests
+except ImportError:  # pragma: no cover
+    print(
+        "[fetch_flock_fantasy_rookies] requests is not installed",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+FF_URL = "https://api.flockfantasy.com/rankings?format=PROSPECTS_SF"
+UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"
+)
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DST = REPO_ROOT / "CSVs" / "site_raw" / "flockFantasySfRookies.csv"
+DATA_DIR_DST = (
+    REPO_ROOT
+    / "data"
+    / "exports"
+    / "latest"
+    / "site_raw"
+    / "flockFantasySfRookies.csv"
+)
+
+# Minimum row count.  The PROSPECTS_SF endpoint currently carries ~98
+# entries (one full rookie class).  Floor set at ~60 so a class shrink
+# or a scrape regression trips exit 2 rather than silently publishing a
+# degraded CSV.  Class sizes vary year-over-year — a small class is
+# normal in summers before the next college season fully enters the
+# board, so the floor is intentionally permissive.
+_FF_ROOKIE_ROW_COUNT_FLOOR: int = 60
+
+# Offensive positions we accept from Flock Fantasy rookies.  The
+# PROSPECTS_SF endpoint already excludes IDP and draft picks, but we
+# filter defensively.
+_OFFENSE_POSITIONS: frozenset[str] = frozenset({"QB", "RB", "WR", "TE"})
+
+
+class FlockFantasyRookiesSchemaError(RuntimeError):
+    """Raised when the API response shape has changed unexpectedly."""
+
+
+# ── JSON fetch / parse ─────────────────────────────────────────────────
+def _fetch_json(url: str, *, timeout: int = 30) -> Any:
+    headers = {
+        "User-Agent": UA,
+        "Accept": "application/json",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    resp = requests.get(url, headers=headers, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _parse_players(data: Any) -> list[dict[str, Any]]:
+    """Extract (name, Rank) from a Flock Fantasy PROSPECTS_SF response.
+
+    Only returns players whose position is in _OFFENSE_POSITIONS,
+    whose isDraftPick is false, and whose averageRank is a positive
+    number.
+    """
+    if not isinstance(data, dict) or "data" not in data:
+        raise FlockFantasyRookiesSchemaError(
+            f"Expected dict with 'data' key, got {type(data).__name__}"
+        )
+    entries = data["data"]
+    if not isinstance(entries, list):
+        raise FlockFantasyRookiesSchemaError(
+            f"Expected 'data' to be a list, got {type(entries).__name__}"
+        )
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        if entry.get("isDraftPick"):
+            continue
+        name = str(entry.get("playerName") or "").strip()
+        if not name:
+            continue
+        pos = str(entry.get("position") or "").strip().upper()
+        if pos not in _OFFENSE_POSITIONS:
+            continue
+        avg_rank = entry.get("averageRank")
+        if avg_rank is None:
+            continue
+        try:
+            rank_float = float(avg_rank)
+        except (TypeError, ValueError):
+            continue
+        if rank_float <= 0:
+            continue
+        out.append(
+            {
+                "name": name,
+                "Rank": rank_float,
+            }
+        )
+    out.sort(key=lambda r: r["Rank"])
+    return out
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = ["name", "Rank"]
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "name": row["name"],
+                    "Rank": row["Rank"],
+                }
+            )
+
+
+# ── CLI entry ───────────────────────────────────────────────────────────
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=DEFAULT_DST,
+        help="CSV path to write (default: CSVs/site_raw/flockFantasySfRookies.csv).",
+    )
+    parser.add_argument(
+        "--mirror-data-dir",
+        action="store_true",
+        help="Also mirror to data/exports/latest/site_raw/.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print row counts and a sample without writing the CSV.",
+    )
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read JSON from file instead of fetching (for dev / tests).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.from_file:
+            raw_text = args.from_file.read_text(encoding="utf-8")
+            data = json.loads(raw_text)
+        else:
+            data = _fetch_json(FF_URL)
+    except Exception as exc:
+        print(
+            f"[fetch_flock_fantasy_rookies] fetch failed: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        rows = _parse_players(data)
+    except FlockFantasyRookiesSchemaError as exc:
+        print(
+            f"[fetch_flock_fantasy_rookies] schema regression: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            f"[fetch_flock_fantasy_rookies] parse failed: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not rows:
+        print(
+            "[fetch_flock_fantasy_rookies] no rows extracted",
+            file=sys.stderr,
+        )
+        return 1
+
+    if len(rows) < _FF_ROOKIE_ROW_COUNT_FLOOR:
+        print(
+            f"[fetch_flock_fantasy_rookies] row count below floor: "
+            f"{len(rows)} < {_FF_ROOKIE_ROW_COUNT_FLOOR}",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"[fetch_flock_fantasy_rookies] total={len(rows)} rows with valid averageRank"
+    )
+
+    if args.dry_run:
+        print("[fetch_flock_fantasy_rookies] --dry-run; not writing CSV")
+        for r in rows[:5]:
+            print("  ", r)
+        return 0
+
+    _write_csv(args.dest, rows)
+    print(
+        f"[fetch_flock_fantasy_rookies] wrote {len(rows)} rows -> {args.dest}"
+    )
+
+    if args.mirror_data_dir:
+        try:
+            _write_csv(DATA_DIR_DST, rows)
+            print(
+                f"[fetch_flock_fantasy_rookies] mirrored -> {DATA_DIR_DST}"
+            )
+        except Exception as exc:
+            print(
+                f"[fetch_flock_fantasy_rookies] mirror failed: {exc}",
+                file=sys.stderr,
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -121,6 +121,7 @@ _SOURCE_SHORT: dict[str, str] = {
     "draftSharksIdp": "dsIdp",
     "dlfRookieSf": "dlfRookSf",
     "dlfRookieIdp": "dlfRookIdp",
+    "flockFantasySfRookies": "flockRookSf",
 }
 
 

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -244,6 +244,18 @@ _SOURCE_CSV_PATHS: dict[str, Any] = {
         "path": "CSVs/site_raw/flockFantasySf.csv",
         "signal": "rank",
     },
+    # Flock Fantasy Dynasty Superflex ROOKIE rankings — fetched from
+    # https://api.flockfantasy.com/rankings?format=PROSPECTS_SF via
+    # ``scripts/fetch_flock_fantasy_rookies.py``.  Same multi-expert
+    # averaged-rank shape as ``flockFantasySf`` but scoped to the
+    # current incoming rookie class only (~95 prospects).  Signal=rank
+    # — registered as ``needs_rookie_translation=True`` so the
+    # within-class rank is crosswalked through KTC's offense rookie
+    # ladder before the Hill curve, mirroring ``dlfRookieSf``.
+    "flockFantasySfRookies": {
+        "path": "CSVs/site_raw/flockFantasySfRookies.csv",
+        "signal": "rank",
+    },
     # FootballGuys dynasty rankings — 6-expert offense board and
     # 3-expert IDP board, exported from FootballGuys as a PDF by the
     # user and converted to CSV via
@@ -359,6 +371,9 @@ _SOURCE_MAX_AGE_HOURS: dict[str, int] = {
     "fantasyProsIdp": 6,
     "dynastyDaddySf": 6,
     "flockFantasySf": 168,
+    # Flock Fantasy rookie board updates as experts refresh ranks
+    # through the offseason; same 1-week window as the vet board.
+    "flockFantasySfRookies": 168,
     "dlfIdp": 720,
     "dlfSf": 720,
     # FootballGuys rankings are a user-managed PDF→CSV export; allow
@@ -1151,6 +1166,36 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # nudge is wired via synthetic "2026 Pick R.SS" rows that
         # the conversion step appends to the CSV so the source's
         # Hill value flows into pick rankDerivedValue directly.
+        "excludes_rookies": False,
+    },
+    {
+        # Flock Fantasy Dynasty Superflex Rookie/Prospect rankings —
+        # multi-expert averaged ranks of the current incoming rookie
+        # class only (~95 QB/RB/WR/TE prospects).  Fetched from the
+        # PROSPECTS_SF endpoint by ``scripts/fetch_flock_fantasy_rookies.py``.
+        # Same shape and translation behaviour as ``dlfRookieSf``: the
+        # within-class rank is crosswalked through KTC's offense rookie
+        # ladder so Flock's #1 rookie inherits KTC's scale-for-top-rookie
+        # rather than being mapped to overall #1 = 9999.
+        #
+        # depth=50 mirrors ``dlfRookieSf``; coverage weight scales the
+        # rookie board's contribution down so it never overwhelms the
+        # veteran-rich blend.  Pick nudging is intentionally NOT wired
+        # for this source — ``dlfRookieSf`` already stamps synthetic
+        # "2026 Pick R.SS" rows to drive pick values, and the cross-
+        # rookie pick tethering pass (Phase 11) blends Flock's rookie
+        # values into picks via the merged rookie pool.
+        "key": "flockFantasySfRookies",
+        "display_name": "Flock Fantasy Rookie SF",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": 50,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "is_tep_premium": False,
+        "needs_shared_market_translation": False,
+        "needs_rookie_translation": True,
         "excludes_rookies": False,
     },
     {
@@ -4433,7 +4478,8 @@ def _compute_unified_rankings(
 
     # ── Rookie-translation ladders (built lazily on demand) ──
     # Sources flagged ``needs_rookie_translation=True`` (dlfRookieSf /
-    # dlfRookieIdp) rank the current rookie class only.  Their raw
+    # dlfRookieIdp / flockFantasySfRookies) rank the current rookie
+    # class only.  Their raw
     # within-source rank 1 would otherwise be fed to the Hill curve
     # as if the #1 rookie were the #1 overall player — inflating every
     # rookie to value ~9999.  We crosswalk through a rookie ladder
@@ -4741,6 +4787,10 @@ def _compute_unified_rankings(
     #   * ``dlfRookieIdp`` (IDP rookies) → IDPTC ladder:
     #     DLF's #1 IDP rookie → IDPTC's top-rookie rank, etc.
     #
+    #   * ``flockFantasySfRookies`` (offense rookies) → KTC ladder:
+    #     same shape as dlfRookieSf — Flock's class-only ranks anchor
+    #     to KTC's offense rookie ladder.
+    #
     # Preserves each rookie source's within-class ORDERING while
     # calibrating the top-rookie's market value to the reference
     # source's opinion.  After this translation, the rookie source's
@@ -4805,6 +4855,7 @@ def _compute_unified_rankings(
     _rookie_ladder_pairs = (
         ("dlfRookieSf", "ktc", _OFFENSE_POSITIONS),
         ("dlfRookieIdp", "idpTradeCalc", _IDP_POSITIONS),
+        ("flockFantasySfRookies", "ktc", _OFFENSE_POSITIONS),
     )
     for rookie_key, ref_key, universe in _rookie_ladder_pairs:
         if rookie_key not in active_keys or ref_key not in active_keys:

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -461,10 +461,10 @@ class TestPayloadLevelBlocks(unittest.TestCase):
         # ktc + idpTradeCalc + dlfIdp + dlfSf + dynastyNerdsSfTep +
         # fantasyProsSf + dynastyDaddySf + fantasyProsIdp + flockFantasySf +
         # footballGuysSf + footballGuysIdp + yahooBoone +
-        # fantasyProsFitzmaurice + dlfRookieSf + dlfRookieIdp +
-        # draftSharks + draftSharksIdp (seventeen sources as of 2026-04-21
-        # when FP/Fitzmaurice was added).
-        self.assertEqual(len(meth["sources"]), 17)
+        # fantasyProsFitzmaurice + dlfRookieSf + flockFantasySfRookies +
+        # dlfRookieIdp + draftSharks + draftSharksIdp (eighteen sources
+        # as of 2026-04-21 when flockFantasySfRookies was added).
+        self.assertEqual(len(meth["sources"]), 18)
         keys = {s.get("key") for s in meth["sources"]}
         self.assertEqual(
             keys,
@@ -483,6 +483,7 @@ class TestPayloadLevelBlocks(unittest.TestCase):
                 "yahooBoone",
                 "fantasyProsFitzmaurice",
                 "dlfRookieSf",
+                "flockFantasySfRookies",
                 "dlfRookieIdp",
                 "draftSharks",
                 "draftSharksIdp",

--- a/tests/scripts/test_fetch_flock_fantasy_rookies.py
+++ b/tests/scripts/test_fetch_flock_fantasy_rookies.py
@@ -1,0 +1,326 @@
+"""Unit tests for scripts/fetch_flock_fantasy_rookies.py.
+
+Covers:
+  * JSON schema probe (non-dict / malformed response)
+  * Player parsing with position filtering (offense only)
+  * Draft pick filtering (isDraftPick == true excluded)
+  * averageRank values are present and reasonable (rank signal format)
+  * End-to-end fixture build: ``--from-file`` with a tiny JSON blob
+  * Exit-code behaviour for schema regressions and row-count floors
+  * Registry metadata: rookie translation, scope, non-TEP, non-retail
+  * Dry-run mode
+"""
+from __future__ import annotations
+
+import csv
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import fetch_flock_fantasy_rookies as ffr
+
+
+def _make_api_response(
+    *entries: tuple[str, str, float, bool],
+) -> dict:
+    """Build a Flock Fantasy PROSPECTS_SF API response shape.
+
+    entries = (playerName, position, averageRank, isDraftPick).
+    """
+    return {
+        "format": "PROSPECTS_SF",
+        "year": 2026,
+        "data": [
+            {
+                "playerName": name,
+                "position": pos,
+                "averageRank": rank,
+                "isDraftPick": is_pick,
+                "isRookie": True,
+            }
+            for name, pos, rank, is_pick in entries
+        ],
+    }
+
+
+class TestParsePlayersSchemaProbe(unittest.TestCase):
+    def test_non_dict_raises_schema_error(self):
+        with self.assertRaises(ffr.FlockFantasyRookiesSchemaError):
+            ffr._parse_players([{"playerName": "Test"}])
+
+    def test_missing_data_key_raises_schema_error(self):
+        with self.assertRaises(ffr.FlockFantasyRookiesSchemaError):
+            ffr._parse_players({"format": "PROSPECTS_SF"})
+
+    def test_data_not_list_raises_schema_error(self):
+        with self.assertRaises(ffr.FlockFantasyRookiesSchemaError):
+            ffr._parse_players({"data": "not a list"})
+
+    def test_empty_data_returns_empty(self):
+        self.assertEqual(ffr._parse_players({"data": []}), [])
+
+
+class TestParsePlayersPositionFilter(unittest.TestCase):
+    def test_only_offense_positions_kept(self):
+        data = _make_api_response(
+            ("Jeremiyah Love", "RB", 1.0, False),
+            ("Carnell Tate", "WR", 2.71, False),
+            ("Fernando Mendoza", "QB", 4.43, False),
+            ("Lake McRee", "TE", 93.0, False),
+            ("Some IDP Prospect", "DE", 50.0, False),
+            ("Another IDP Prospect", "LB", 55.0, False),
+        )
+        rows = ffr._parse_players(data)
+        self.assertEqual(len(rows), 4)
+        names = {r["name"] for r in rows}
+        self.assertEqual(
+            names,
+            {"Jeremiyah Love", "Carnell Tate", "Fernando Mendoza", "Lake McRee"},
+        )
+
+    def test_draft_picks_filtered_out(self):
+        data = _make_api_response(
+            ("Jeremiyah Love", "RB", 1.0, False),
+            ("2026 1.01", "QB", 5.0, True),
+            ("2026 1.02", "RB", 8.0, True),
+        )
+        rows = ffr._parse_players(data)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "Jeremiyah Love")
+
+    def test_none_averageRank_filtered_out(self):
+        data = {
+            "data": [
+                {
+                    "playerName": "Jeremiyah Love",
+                    "position": "RB",
+                    "averageRank": 1.0,
+                    "isDraftPick": False,
+                    "isRookie": True,
+                },
+                {
+                    "playerName": "Ghost Player",
+                    "position": "WR",
+                    "averageRank": None,
+                    "isDraftPick": False,
+                    "isRookie": True,
+                },
+            ]
+        }
+        rows = ffr._parse_players(data)
+        self.assertEqual(len(rows), 1)
+
+    def test_rows_sorted_by_rank_ascending(self):
+        data = _make_api_response(
+            ("Third", "WR", 45.0, False),
+            ("First", "RB", 1.0, False),
+            ("Second", "QB", 12.5, False),
+        )
+        rows = ffr._parse_players(data)
+        ranks = [r["Rank"] for r in rows]
+        self.assertEqual(ranks, [1.0, 12.5, 45.0])
+
+
+class TestCsvOutputShape(unittest.TestCase):
+    def test_csv_has_name_rank_columns(self):
+        """CSV columns should be name,Rank (rank signal, not value)."""
+        data = _make_api_response(
+            ("Jeremiyah Love", "RB", 1.0, False),
+            ("Carnell Tate", "WR", 2.71, False),
+            ("Fernando Mendoza", "QB", 4.43, False),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            json_path = tmp / "flock_rookies.json"
+            json_path.write_text(json.dumps(data), encoding="utf-8")
+            dest = tmp / "out.csv"
+
+            orig_floor = ffr._FF_ROOKIE_ROW_COUNT_FLOOR
+            ffr._FF_ROOKIE_ROW_COUNT_FLOOR = 1
+            try:
+                rc = ffr.main(
+                    ["--from-file", str(json_path), "--dest", str(dest)]
+                )
+            finally:
+                ffr._FF_ROOKIE_ROW_COUNT_FLOOR = orig_floor
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(dest.exists())
+
+            rows = list(csv.DictReader(dest.open(encoding="utf-8-sig")))
+            self.assertEqual(len(rows), 3)
+            self.assertIn("name", rows[0])
+            self.assertIn("Rank", rows[0])
+            self.assertNotIn("value", rows[0])
+            self.assertAlmostEqual(float(rows[0]["Rank"]), 1.0, places=2)
+
+
+class TestFromFileEndToEnd(unittest.TestCase):
+    def test_from_file_writes_csv(self):
+        data = _make_api_response(
+            ("Jeremiyah Love", "RB", 1.0, False),
+            ("Makai Lemon", "WR", 2.57, False),
+            ("Carnell Tate", "WR", 2.71, False),
+            ("Fernando Mendoza", "QB", 4.43, False),
+            ("Lake McRee", "TE", 93.0, False),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            json_path = tmp / "flock_rookies.json"
+            json_path.write_text(json.dumps(data), encoding="utf-8")
+            dest = tmp / "out.csv"
+
+            orig_floor = ffr._FF_ROOKIE_ROW_COUNT_FLOOR
+            ffr._FF_ROOKIE_ROW_COUNT_FLOOR = 1
+            try:
+                rc = ffr.main(
+                    ["--from-file", str(json_path), "--dest", str(dest)]
+                )
+            finally:
+                ffr._FF_ROOKIE_ROW_COUNT_FLOOR = orig_floor
+
+            self.assertEqual(rc, 0)
+            rows = list(csv.DictReader(dest.open(encoding="utf-8-sig")))
+            self.assertEqual(len(rows), 5)
+            names = {r["name"] for r in rows}
+            self.assertIn("Jeremiyah Love", names)
+            self.assertIn("Lake McRee", names)
+
+
+class TestMainExitCodes(unittest.TestCase):
+    def test_main_exits_2_on_non_dict_response(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            json_path = tmp / "bad.json"
+            json_path.write_text('["not", "a dict"]', encoding="utf-8")
+            dest = tmp / "out.csv"
+            rc = ffr.main(["--from-file", str(json_path), "--dest", str(dest)])
+            self.assertEqual(rc, 2)
+            self.assertFalse(dest.exists())
+
+    def test_main_exits_2_on_row_count_floor_violation(self):
+        # 2 players — below the default 60-row floor.
+        data = _make_api_response(
+            ("Jeremiyah Love", "RB", 1.0, False),
+            ("Carnell Tate", "WR", 2.71, False),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            json_path = tmp / "small.json"
+            json_path.write_text(json.dumps(data), encoding="utf-8")
+            dest = tmp / "out.csv"
+            rc = ffr.main(["--from-file", str(json_path), "--dest", str(dest)])
+            self.assertEqual(rc, 2)
+
+    def test_main_exits_1_on_empty_data_array(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            json_path = tmp / "empty.json"
+            json_path.write_text('{"data": []}', encoding="utf-8")
+            dest = tmp / "out.csv"
+            rc = ffr.main(["--from-file", str(json_path), "--dest", str(dest)])
+            self.assertEqual(rc, 1)
+
+    def test_main_exits_1_on_invalid_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            json_path = tmp / "invalid.json"
+            json_path.write_text("not json at all", encoding="utf-8")
+            dest = tmp / "out.csv"
+            rc = ffr.main(["--from-file", str(json_path), "--dest", str(dest)])
+            self.assertEqual(rc, 1)
+
+
+class TestDryRun(unittest.TestCase):
+    def test_dry_run_does_not_write_csv(self):
+        data = _make_api_response(
+            ("Jeremiyah Love", "RB", 1.0, False),
+            ("Carnell Tate", "WR", 2.71, False),
+            ("Fernando Mendoza", "QB", 4.43, False),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            json_path = tmp / "flock_rookies.json"
+            json_path.write_text(json.dumps(data), encoding="utf-8")
+            dest = tmp / "out.csv"
+
+            orig_floor = ffr._FF_ROOKIE_ROW_COUNT_FLOOR
+            ffr._FF_ROOKIE_ROW_COUNT_FLOOR = 1
+            try:
+                rc = ffr.main(
+                    [
+                        "--from-file",
+                        str(json_path),
+                        "--dest",
+                        str(dest),
+                        "--dry-run",
+                    ]
+                )
+            finally:
+                ffr._FF_ROOKIE_ROW_COUNT_FLOOR = orig_floor
+
+            self.assertEqual(rc, 0)
+            self.assertFalse(dest.exists())
+
+
+class TestRegistryMetadata(unittest.TestCase):
+    """Pin the source's registry shape: scope, rookie-translation, flags."""
+
+    def _entry(self):
+        from src.api.data_contract import get_ranking_source_registry
+
+        for src in get_ranking_source_registry():
+            if src["key"] == "flockFantasySfRookies":
+                return src
+        return None
+
+    def test_source_registered(self):
+        self.assertIsNotNone(
+            self._entry(), "flockFantasySfRookies not in registry"
+        )
+
+    def test_scope_overall_offense(self):
+        entry = self._entry()
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.get("scope"), "overall_offense")
+
+    def test_not_tep_premium(self):
+        entry = self._entry()
+        self.assertIsNotNone(entry)
+        self.assertFalse(entry.get("isTepPremium"))
+
+    def test_not_retail(self):
+        entry = self._entry()
+        self.assertIsNotNone(entry)
+        self.assertFalse(entry.get("isRetail"))
+
+    def test_scraper_export_registered(self):
+        from src.api.data_contract import _SOURCE_CSV_PATHS
+
+        self.assertIn("flockFantasySfRookies", _SOURCE_CSV_PATHS)
+        cfg = _SOURCE_CSV_PATHS["flockFantasySfRookies"]
+        self.assertEqual(cfg.get("signal"), "rank")
+        self.assertEqual(
+            cfg.get("path"), "CSVs/site_raw/flockFantasySfRookies.csv"
+        )
+
+    def test_needs_rookie_translation_flag(self):
+        from src.api.data_contract import _RANKING_SOURCES
+
+        for src in _RANKING_SOURCES:
+            if src.get("key") == "flockFantasySfRookies":
+                self.assertTrue(
+                    src.get("needs_rookie_translation"),
+                    "flockFantasySfRookies must declare needs_rookie_translation=True",
+                )
+                return
+        self.fail("flockFantasySfRookies not found in _RANKING_SOURCES")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_fetch_flock_fantasy_rookies.py
+++ b/tests/scripts/test_fetch_flock_fantasy_rookies.py
@@ -114,10 +114,10 @@ class TestParsePlayersPositionFilter(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["name"], "Jeremiyah Love")
 
-    def test_missing_isRookie_field_defaults_to_accept(self):
-        """If the endpoint omits ``isRookie``, accept the row — the
-        PROSPECTS_SF endpoint is rookie-only by contract; don't over-
-        filter on a field that might disappear."""
+    def test_missing_isRookie_field_is_rejected(self):
+        """Strict ``isRookie is True`` filter — rows lacking the flag
+        are dropped to preserve the rookie-only invariant the
+        downstream rookie ladder depends on."""
         data = {
             "data": [
                 {
@@ -125,11 +125,56 @@ class TestParsePlayersPositionFilter(unittest.TestCase):
                     "position": "RB",
                     "averageRank": 1.0,
                     "isDraftPick": False,
+                    "isRookie": True,
+                },
+                {
+                    "playerName": "No Flag Player",
+                    "position": "WR",
+                    "averageRank": 2.0,
+                    "isDraftPick": False,
+                    # isRookie deliberately omitted
+                },
+                {
+                    "playerName": "Null Flag Player",
+                    "position": "WR",
+                    "averageRank": 3.0,
+                    "isDraftPick": False,
+                    "isRookie": None,
                 },
             ]
         }
         rows = ffr._parse_players(data)
         self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "Jeremiyah Love")
+
+    def test_non_dict_entries_are_skipped(self):
+        """Malformed rows (e.g. ``null``) in the ``data`` array must
+        not abort the whole fetch — skip them and keep the valid rows."""
+        data = {
+            "data": [
+                None,
+                {
+                    "playerName": "Jeremiyah Love",
+                    "position": "RB",
+                    "averageRank": 1.0,
+                    "isDraftPick": False,
+                    "isRookie": True,
+                },
+                "string instead of dict",
+                42,
+                {
+                    "playerName": "Carnell Tate",
+                    "position": "WR",
+                    "averageRank": 2.71,
+                    "isDraftPick": False,
+                    "isRookie": True,
+                },
+            ]
+        }
+        rows = ffr._parse_players(data)
+        self.assertEqual(len(rows), 2)
+        names = {r["name"] for r in rows}
+        self.assertEqual(names, {"Jeremiyah Love", "Carnell Tate"})
 
     def test_none_averageRank_filtered_out(self):
         data = {

--- a/tests/scripts/test_fetch_flock_fantasy_rookies.py
+++ b/tests/scripts/test_fetch_flock_fantasy_rookies.py
@@ -89,6 +89,48 @@ class TestParsePlayersPositionFilter(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["name"], "Jeremiyah Love")
 
+    def test_non_rookies_filtered_out(self):
+        """Defensive ``isRookie=False`` filter — the rookie ladder
+        downstream would mis-scale any veteran row that slipped through."""
+        data = {
+            "data": [
+                {
+                    "playerName": "Jeremiyah Love",
+                    "position": "RB",
+                    "averageRank": 1.0,
+                    "isDraftPick": False,
+                    "isRookie": True,
+                },
+                {
+                    "playerName": "Some Veteran",
+                    "position": "WR",
+                    "averageRank": 5.0,
+                    "isDraftPick": False,
+                    "isRookie": False,
+                },
+            ]
+        }
+        rows = ffr._parse_players(data)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "Jeremiyah Love")
+
+    def test_missing_isRookie_field_defaults_to_accept(self):
+        """If the endpoint omits ``isRookie``, accept the row — the
+        PROSPECTS_SF endpoint is rookie-only by contract; don't over-
+        filter on a field that might disappear."""
+        data = {
+            "data": [
+                {
+                    "playerName": "Jeremiyah Love",
+                    "position": "RB",
+                    "averageRank": 1.0,
+                    "isDraftPick": False,
+                },
+            ]
+        }
+        rows = ffr._parse_players(data)
+        self.assertEqual(len(rows), 1)
+
     def test_none_averageRank_filtered_out(self):
         data = {
             "data": [


### PR DESCRIPTION
## Summary

Adds Flock Fantasy's super flex rookie rankings (https://flockfantasy.com/rankings?format=PROSPECTS_SF) as a new ranking source under the key `flockFantasySfRookies`.

The PROSPECTS_SF endpoint serves multi-expert averaged consensus ranks of the current incoming rookie class only (~95 QB/RB/WR/TE prospects, all flagged `isRookie=true`, no draft picks).

## Implementation

Modeled directly on the existing `dlfRookieSf` pattern — same scope, same depth, same KTC offense rookie ladder for translation:

- **`scripts/fetch_flock_fantasy_rookies.py`** — JSON fetcher modeled on `fetch_flock_fantasy.py`, writes `CSVs/site_raw/flockFantasySfRookies.csv` (signal=rank). Internal 60-row floor + exit-2 schema regression detection.
- **`src/api/data_contract.py`** — registered in `_SOURCE_CSV_PATHS`, `_SOURCE_MAX_AGE_HOURS`, `_RANKING_SOURCES` (with `needs_rookie_translation=True`), and added to the `_rookie_ladder_pairs` tuple to anchor against KTC.
- **`frontend/lib/dynasty-data.js`** — `RANKING_SOURCES` mirror entry with matching `needsRookieTranslation: true` and `columnLabel: "Flock RK"`.
- **`src/api/chat.py`** — short-form key (`flockRookSf`) for the chat snapshot table.
- **`.github/workflows/scheduled-refresh.yml`** — non-fatal fetch step alongside the existing `flockFantasySf` vet board.

Pick nudging is intentionally *not* wired for this source — `dlfRookieSf` already stamps synthetic `2026 Pick R.SS` rows, and the existing rookie-pick tethering pass (Phase 11) folds Flock's rookie values into picks via the merged rookie pool.

## Test plan

- [x] `tests/scripts/test_fetch_flock_fantasy_rookies.py` — schema probes (non-dict / missing keys), position filtering (offense only), draft-pick filtering, sort order, exit codes (1 for empty/invalid JSON, 2 for floor violation/schema regression), dry-run, registry metadata pinning (scope, rookie-translation flag, scraper export wiring).
- [x] `tests/api/test_source_registry_parity.py` — backend/frontend registry stays in lockstep.
- [x] `tests/api/test_trust_confidence.py::test_methodology_block_present` — bumped expected source count 17 → 18.
- [x] `tests/api/test_source_monitoring.py::TestRowCountFloors` — passes (the new source is intentionally NOT in `_DEFAULT_SOURCE_ROW_FLOORS`, matching `dlfRookieSf` / `dlfRookieIdp` so the validator doesn't error before the first scrape lands).
- [x] Smoke-tested the fetch script against the live API (98 entries, all rookies, sorted by `averageRank` ascending).

https://claude.ai/code/session_01JZFutFiAp9m3hHmZLrRppo