### PR TITLE
Rankings: display every source on the 1-9,999 value scale

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -520,17 +520,31 @@ export default function RankingsPage() {
             // translation re-order between their original and effective
             // rank; reading ``canonicalSites`` here would sort on the
             // pre-translation synthetic encoding and produce a ranking
-            // that disagrees with the values in the column.  Fall back
-            // to ``canonicalSites`` only when the backend didn't stamp
-            // a valueContribution (legacy payloads).
+            // that disagrees with the values in the column.
+            //
+            // Fall back to ``canonicalSites`` only for value-based
+            // sources on legacy payloads that predate the
+            // ``valueContribution`` stamp — their raw slot is on a
+            // monotonic value scale, so the sort still matches what
+            // ``formatSourceCell`` renders in that legacy branch.  For
+            // rank-signal sources the raw slot is a synthetic rank
+            // encoding the cell intentionally refuses to render, so
+            // reading it here would reorder rows whose visible cells
+            // are all "—" — sort order the user cannot interpret.
+            const src = RANKING_SOURCES.find((s) => s.key === key);
             const aMeta = Number(a.sourceRankMeta?.[key]?.valueContribution);
             const bMeta = Number(b.sourceRankMeta?.[key]?.valueContribution);
+            const allowRawFallback = !src?.isRankSignal;
             va = Number.isFinite(aMeta)
               ? aMeta
-              : Number(a.canonicalSites?.[key]) || 0;
+              : allowRawFallback
+                ? Number(a.canonicalSites?.[key]) || 0
+                : 0;
             vb = Number.isFinite(bMeta)
               ? bMeta
-              : Number(b.canonicalSites?.[key]) || 0;
+              : allowRawFallback
+                ? Number(b.canonicalSites?.[key]) || 0
+                : 0;
             return (va - vb) * dir;
           }
           return resolvedRank(a) - resolvedRank(b);

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -109,9 +109,16 @@ function formatSourceCell(row, src) {
   // native range is 0-~141, this is the rescaled value so every
   // value column in the UI lives on the same scale.
   const normalizedVal = row?.sourceRankMeta?.[src.key]?.valueContribution;
-  const hasVal =
-    (normalizedVal != null && Number.isFinite(Number(normalizedVal))) ||
-    (rawVal != null && Number.isFinite(Number(rawVal)));
+  // Rank-signal sources stamp a synthetic encoding into canonicalSites
+  // (``_RANK_TO_SYNTHETIC_VALUE_OFFSET - rank * 100`` in the backend) that
+  // the pipeline uses only for ordering — it is NOT a 1-9,999 contribution.
+  // Require a real ``valueContribution`` for those sources so a legacy
+  // payload without the stamp shows an honest "\u2014" instead of a
+  // six-digit synthetic number mislabeled as a normalized value.
+  const hasNormalized =
+    normalizedVal != null && Number.isFinite(Number(normalizedVal));
+  const hasRaw = rawVal != null && Number.isFinite(Number(rawVal));
+  const hasVal = hasNormalized || (!src.isRankSignal && hasRaw);
   const effectiveRank = row?.sourceRanks?.[src.key];
   const origRank = row?.sourceOriginalRanks?.[src.key];
 
@@ -126,9 +133,13 @@ function formatSourceCell(row, src) {
 
   // Every source renders its 9,999-scale valueContribution as the
   // primary cell label — the same number the blend averages into the
-  // final Hill value.  Fall back to the raw site value if the backend
-  // didn't stamp a valueContribution (legacy payloads during rollout).
-  const displayVal = normalizedVal != null ? normalizedVal : rawVal;
+  // final Hill value.  Value-based sources may fall back to the raw
+  // site value on legacy payloads that predate the valueContribution
+  // stamp (their raw value IS on a monotonic value scale, just not yet
+  // rescaled to 9,999); rank-signal sources intentionally do not fall
+  // back because their raw canonicalSites entry is a synthetic rank
+  // encoding, not a value.
+  const displayVal = hasNormalized ? normalizedVal : rawVal;
   const primary = Math.round(Number(displayVal)).toLocaleString();
   const rankLabel = effectiveRank != null ? `#${effectiveRank}` : "\u2014";
   const origRankSuffix =
@@ -503,8 +514,23 @@ export default function RankingsPage() {
           // automatically.
           if (typeof sortCol === "string" && sortCol.startsWith("src:")) {
             const key = sortCol.slice(4);
-            va = Number(a.canonicalSites?.[key]) || 0;
-            vb = Number(b.canonicalSites?.[key]) || 0;
+            // Sort by the same 9,999-scale ``valueContribution`` the cell
+            // renders, so the column order always matches the displayed
+            // numbers.  Rank-signal sources with shared-market / rookie
+            // translation re-order between their original and effective
+            // rank; reading ``canonicalSites`` here would sort on the
+            // pre-translation synthetic encoding and produce a ranking
+            // that disagrees with the values in the column.  Fall back
+            // to ``canonicalSites`` only when the backend didn't stamp
+            // a valueContribution (legacy payloads).
+            const aMeta = Number(a.sourceRankMeta?.[key]?.valueContribution);
+            const bMeta = Number(b.sourceRankMeta?.[key]?.valueContribution);
+            va = Number.isFinite(aMeta)
+              ? aMeta
+              : Number(a.canonicalSites?.[key]) || 0;
+            vb = Number.isFinite(bMeta)
+              ? bMeta
+              : Number(b.canonicalSites?.[key]) || 0;
             return (va - vb) * dir;
           }
           return resolvedRank(a) - resolvedRank(b);

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -84,19 +84,19 @@ function posMatchesFilter(pos, assetClass, filter, row) {
 //
 // Unified formatting for every per-source cell the rankings table
 // renders — both the desktop column cells and the mobile chip strip
-// beneath each player row.  Returns:
+// beneath each player row.  Every source (rank-signal or value-based)
+// lives on one common 1-9,999 scale in the UI: the backend stamps a
+// ``valueContribution`` for every matched source (rank sources route
+// through the Hill curve, value sources rescale linearly), and this
+// helper renders that number as the primary cell label with the
+// effective rank on the shared board shown in parentheses.  Returns:
 //
 //   hasVal    — true if the source contributed a value for this player
-//   primary   — the main label (raw value for value sources, `#rank`
-//               for rank-signal sources — per the rank-signal contract
-//               described on `RANKING_SOURCES` in dynasty-data.js,
-//               which requires UIs to render `sourceOriginalRanks`
-//               and never the synthetic value stamped for sort order).
-//   rankLabel — the effective rank on the shared board, wrapped with
-//               a `#` prefix and the `eff` prefix for rank-signal
-//               sources where "primary" is already a rank; this makes
-//               the distinction explicit in the cell output.
-//   title     — hover tooltip explaining the cell.
+//   primary   — the 9,999-scale ``valueContribution`` for the source
+//   rankLabel — the effective rank on the shared board, `#`-prefixed
+//   title     — hover tooltip explaining the cell (includes the
+//               source's original pre-translation rank when it differs
+//               from the effective rank, e.g. rookie / shared-market).
 //
 // Mirror the display format between desktop and mobile by always
 // using this helper so both surfaces show `value (#rank)` consistently.
@@ -124,39 +124,24 @@ function formatSourceCell(row, src) {
     };
   }
 
-  if (src.isRankSignal) {
-    // Rank-signal sources (DLF SF, DLF IDP, DN SF-TEP, FP IDP) expose
-    // only ordinal rank, not a trade value.  Render the original rank
-    // as primary and the effective (shared-market-translated) rank
-    // in parentheses, prefixed with `eff` to disambiguate.
-    const primary = origRank != null ? `#${origRank}` : "\u2014";
-    const rankLabel =
-      effectiveRank != null ? `eff #${effectiveRank}` : "eff \u2014";
-    return {
-      hasVal: true,
-      primary,
-      rankLabel,
-      title: `${src.displayName}: original rank ${primary}, effective rank on blended board ${
-        effectiveRank != null ? `#${effectiveRank}` : "\u2014"
-      }`,
-    };
-  }
-
-  // Value source: prefer the normalized 9999-scale value contribution
-  // so sources with non-9999 native ranges (e.g. Yahoo/Boone ~141 max)
-  // render consistently with KTC/IDPTC.  Fall back to the raw site
-  // value if the backend didn't stamp a valueContribution (old payloads
-  // during rollout).
+  // Every source renders its 9,999-scale valueContribution as the
+  // primary cell label — the same number the blend averages into the
+  // final Hill value.  Fall back to the raw site value if the backend
+  // didn't stamp a valueContribution (legacy payloads during rollout).
   const displayVal = normalizedVal != null ? normalizedVal : rawVal;
   const primary = Math.round(Number(displayVal)).toLocaleString();
   const rankLabel = effectiveRank != null ? `#${effectiveRank}` : "\u2014";
+  const origRankSuffix =
+    origRank != null && origRank !== effectiveRank
+      ? `, original rank #${origRank}`
+      : "";
   return {
     hasVal: true,
     primary,
     rankLabel,
     title: `${src.displayName}: value ${primary}${
       effectiveRank != null ? `, effective rank #${effectiveRank}` : ""
-    }`,
+    }${origRankSuffix}`,
   };
 }
 
@@ -813,11 +798,9 @@ export default function RankingsPage() {
                       col={`src:${src.key}`}
                       style={{ textAlign: "right", width: 90 }}
                       className="hide-mobile rankings-source-col"
-                      title={`${src.displayName} — ${
-                        src.isRankSignal
-                          ? "expert rank source (lower = better). Cell shows the source's original rank with its effective rank on the shared board in parentheses."
-                          : "value source. Cell shows the source's raw trade value with its effective rank on the shared board in parentheses."
-                      }`}
+                      title={`${src.displayName} — cell shows the source's 1\u20139,999 scale value (${
+                        src.isRankSignal ? "Hill curve from this source's ordinal rank" : "linear rescale of this source's native trade value"
+                      }) with its effective rank on the shared board in parentheses.`}
                     >
                       {src.columnLabel}
                     </SortHeader>
@@ -953,10 +936,11 @@ export default function RankingsPage() {
                         {/* Per-source value + rank columns.  Gated on
                             `showSiteCols` so power users can collapse the
                             source columns to focus on the Value column.
-                            Each cell shows the source's raw value (or
-                            original rank for rank-signal sources) with
-                            the effective rank on the shared board in
-                            parentheses — unified single-line format. */}
+                            Each cell shows the source's 9,999-scale
+                            valueContribution with the effective rank on
+                            the shared board in parentheses — unified
+                            single-line format so every source sits on
+                            the same value scale. */}
                         {settings.showSiteCols && RANKING_SOURCES.map((src) => {
                           const cell = formatSourceCell(row, src);
                           return (


### PR DESCRIPTION
## Summary

The rankings page's per-source chips/columns were only showing 9,999-scale values for value-based sources (KTC, IDPTC, DD, Boone, Fitzmaurice, DraftSharks). Rank-signal sources (DLF SF, DN SF-TEP, FP SF, FF, FBG SF, DLF IDP, FP IDP, FBG IDP, DLF RK, Flock RK, DLF RK-IDP) were rendering just the ordinal rank (`#1 (eff #1)`) — even though the backend already stamps a Hill-curve-derived `valueContribution` on the 0-9,999 scale for every matched source.

- Collapse the `src.isRankSignal` branch inside `formatSourceCell` in `frontend/app/rankings/page.jsx` so every source renders `sourceRankMeta[src.key].valueContribution` as the primary cell label, with the effective rank on the shared board in parentheses (`9,999 (#1)`).
- Add the source's original pre-translation rank to the hover tooltip whenever it differs from the effective rank (rookie / shared-market translation), preserving that audit detail.
- Update the column-header tooltip and the inline render comment to reflect the single-scale display contract; the matching mobile chip strip already goes through the same helper, so desktop + mobile stay aligned.

The source audit panel continues to surface both the source's native rank/raw value and the Hill Value (`valueContribution`) as separate diagnostic fields — no change there.

## Test plan

- [x] `npm test` in `frontend/` — all 428 vitest tests still pass.
- [ ] Visual check on the live rankings page: every source chip now reads `value (#rank)` on the 1-9,999 scale instead of `#rank (eff #rank)`, including DLF SF / DN SF-TEP / FP SF / FF / FBG SF / DLF IDP / FP IDP / FBG IDP / DLF RK / Flock RK / DLF RK-IDP.
- [ ] Hover a rank-translated source (e.g. Flock RK or DLF RK) and confirm the tooltip includes `original rank #N` when the effective rank differs.