### PR TITLE
IDP calibration: cross-league relativity + Sleeper dual-position fix

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -54,6 +54,14 @@ import requests
 from playwright.async_api import async_playwright
 import sys
 
+# Reach into the shared IDP position resolver so dual-position
+# Sleeper entries (e.g. "DL,LB" for edge rushers) collapse with the
+# DL > DB > LB priority used everywhere else in the stack.
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+from src.utils.name_clean import resolve_idp_position as _resolve_idp_position  # noqa: E402
+
 try:
     from src.scoring import (
         build_default_baseline_config,
@@ -969,7 +977,25 @@ def fetch_sleeper_rosters(league_id):
                 continue
             full = (p.get("full_name")
                     or f"{p.get('first_name','')} {p.get('last_name','')}".strip())
-            pos = p.get("position", "")
+            raw_pos = p.get("position", "") or ""
+            # Sleeper exposes ``fantasy_positions`` as the list of
+            # eligible slots; ``position`` is just the primary. For
+            # dual-eligible IDPs (Micah Parsons = ["DL","LB"]) we want
+            # the non-LB family so Parsons doesn't get bucketed as an
+            # off-ball LB. Only collapse through resolve_idp_position
+            # when fantasy_positions has 2+ entries AND at least one
+            # is an IDP family — single-position rows (including plain
+            # "DE", "CB", etc.) pass through untouched so offense rows
+            # and the fine-grained IDP tokens downstream code may
+            # still read stay intact.
+            fp_list = p.get("fantasy_positions") if isinstance(
+                p.get("fantasy_positions"), list
+            ) else None
+            pos = raw_pos
+            if fp_list and len(fp_list) >= 2:
+                resolved_family = _resolve_idp_position(fp_list)
+                if resolved_family in {"DL", "DB", "LB"}:
+                    pos = resolved_family
             if pos in VALID_POSITIONS and full:
                 cn = clean_name(full)
                 team_players.append(cn)

--- a/src/idp_calibration/anchors.py
+++ b/src/idp_calibration/anchors.py
@@ -1,13 +1,15 @@
-"""Anchor curves and monotonic smoothing.
+"""Anchor curves for per-rank interpolation.
 
 Given per-bucket multipliers we produce three curves per position —
 intrinsic, market, final — sampled at the default anchor ranks
 ``[1, 3, 6, 12, 24, 36, 48, 72, 100]``.
 
-The smoothing pass is an in-place pool-adjacent-violators (PAV) style
-sweep that enforces non-increasing anchors along with a floor so we
-never emit negative or zero-crossing values. No sklearn dep —
-implemented with plain lists.
+Schema-v2 behaviour: the ``final`` curve carries cross-league
+relativity ratios, which can legitimately be non-monotone (the user's
+scoring may lift a mid-rank bucket over the top bucket in some
+positions). We therefore do **not** force monotone descent on the
+emitted anchors — we only apply a safety floor against
+near-zero/negative values that would blow up the live interpolation.
 """
 from __future__ import annotations
 
@@ -52,12 +54,25 @@ def _bucket_value_at_rank(buckets: list[BucketMultipliers], rank: int, kind: str
     return float(getattr(buckets[-1], kind))
 
 
-def _monotone_non_increasing(values: list[float], floor: float = 0.0) -> list[float]:
+def _floor_only(values: list[float], floor: float = 0.0) -> list[float]:
+    """Apply a minimum-value floor without enforcing monotone descent.
+
+    Schema v2 relativity ratios can legitimately sit above 1.0 or move
+    non-monotonically across buckets; clamping-down would discard the
+    real cross-league signal. We only guard against near-zero / NaN
+    values that would blow up the live anchor interpolation.
+    """
     if not values:
         return []
-    out = [max(float(values[0]), floor)]
-    for v in values[1:]:
-        out.append(max(min(float(v), out[-1]), floor))
+    out: list[float] = []
+    for v in values:
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            f = floor
+        if f != f:  # NaN
+            f = floor
+        out.append(max(f, floor))
     return out
 
 
@@ -74,8 +89,8 @@ def build_anchor_curve(
             _bucket_value_at_rank(multipliers.buckets, r, kind)
             for r in anchor_ranks
         ]
-        smoothed = _monotone_non_increasing(raw, floor=floor)
-        out[kind] = [AnchorPoint(rank=r, value=v) for r, v in zip(anchor_ranks, smoothed)]
+        floored = _floor_only(raw, floor=floor)
+        out[kind] = [AnchorPoint(rank=r, value=v) for r, v in zip(anchor_ranks, floored)]
     return out
 
 

--- a/src/idp_calibration/api.py
+++ b/src/idp_calibration/api.py
@@ -12,7 +12,14 @@ from pathlib import Path
 from typing import Any
 
 from .engine import AnalysisSettings, run_analysis
-from .promotion import EmptyCalibrationError, VALID_MODES, load_production, promote_run
+from .promotion import (
+    EmptyCalibrationError,
+    StaleArtifactSchemaError,
+    V2_VALID_MODES,
+    VALID_MODES,
+    load_production,
+    promote_run,
+)
 from .production import is_promoted
 from .storage import delete_all_runs, delete_run, get_latest, list_runs, load_run, save_run
 
@@ -99,6 +106,18 @@ def promote(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[i
             422,
             f"active_mode must be one of {list(VALID_MODES)}, got {active_mode!r}.",
         )
+    # Under schema v2 only ``blended`` is a valid applied mode
+    # (``intrinsic`` / ``market`` are display-only diagnostic
+    # channels — see ``promotion.V2_VALID_MODES``). Catch this at the
+    # HTTP boundary so the lab surfaces a structured 422 rather than
+    # a ``StaleArtifactSchemaError`` / ``ValueError`` 500.
+    if active_mode not in V2_VALID_MODES:
+        return _error(
+            422,
+            f"active_mode={active_mode!r} is not applicable under the "
+            f"current calibration schema. Only {list(V2_VALID_MODES)} "
+            f"produce a valid applied multiplier.",
+        )
     try:
         result = promote_run(
             run_id, active_mode=active_mode, promoted_by=promoted_by, base=base
@@ -106,6 +125,8 @@ def promote(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[i
     except FileNotFoundError as exc:
         return _error(404, str(exc))
     except EmptyCalibrationError as exc:
+        return _error(422, str(exc))
+    except StaleArtifactSchemaError as exc:
         return _error(422, str(exc))
     except Exception as exc:  # noqa: BLE001
         return _error(500, f"Promotion failed: {exc}")

--- a/src/idp_calibration/engine.py
+++ b/src/idp_calibration/engine.py
@@ -29,6 +29,7 @@ from .stats_adapter import (
     get_stats_adapter,
 )
 from .translation import (
+    CALIBRATION_SCHEMA_VERSION,
     DEFAULT_BLEND,
     DEFAULT_YEAR_WEIGHTS,
     FamilyScale,
@@ -44,6 +45,7 @@ from .vor import (
     ScoredPlayer,
     VorRow,
     build_universe,
+    compute_offense_anchor_vor,
     compute_vor,
     score_universe,
     trim_to_top_n_per_position,
@@ -411,6 +413,13 @@ def run_analysis(
         pos: {} for pos in OFFENSE_FAMILY
     }
     per_season_family_scales: dict[int, FamilyScale] = {}
+    # Schema v2 cross-league relativity anchors — mean VOR of the top-24
+    # RB+WR under each league's scoring, per season. Year-weighted and
+    # aggregated downstream into scalar anchors the translation layer
+    # uses to put ``intrinsic`` and ``market`` into the same offense-
+    # flex unit before taking their ratio.
+    per_season_offense_anchor_mine: dict[int, float] = {}
+    per_season_offense_anchor_test: dict[int, float] = {}
     resolved_seasons: list[int] = []
 
     # ── Prefetch per-season universes concurrently ──────────────────
@@ -628,6 +637,18 @@ def run_analysis(
                 offense_vor_test=offense_vor_test,
                 blend=settings.blend,
             )
+            # Offense anchor VOR (top-24 RB+WR mean under each scoring
+            # system) — the yardstick every IDP bucket's VOR gets
+            # normalised against before the cross-league ratio.
+            anchor_mine, anchor_test = compute_offense_anchor_vor(
+                offense_scored,
+                replacement_mine=offense_repl_my,
+                replacement_test=offense_repl_test,
+            )
+            if anchor_mine > 0:
+                per_season_offense_anchor_mine[season] = anchor_mine
+            if anchor_test > 0:
+                per_season_offense_anchor_test[season] = anchor_test
         else:
             warnings.append(
                 f"{season}: offense universe empty — family_scale for this "
@@ -711,10 +732,27 @@ def run_analysis(
     normalised_weights = normalise_year_weights(
         settings.year_weights, seasons=resolved_seasons
     )
+
+    def _weighted_anchor(samples: dict[int, float]) -> float:
+        total_val = 0.0
+        total_w = 0.0
+        for season, value in samples.items():
+            w = float(normalised_weights.get(int(season), 0.0))
+            if w <= 0:
+                continue
+            total_val += float(value) * w
+            total_w += w
+        return total_val / total_w if total_w > 0 else 0.0
+
+    offense_anchor_mine = _weighted_anchor(per_season_offense_anchor_mine)
+    offense_anchor_test = _weighted_anchor(per_season_offense_anchor_test)
+
     multipliers = build_multi_year_multipliers(
         per_season_per_position_buckets,
         year_weights=normalised_weights,
         blend=settings.blend,
+        offense_anchor_mine=offense_anchor_mine,
+        offense_anchor_test=offense_anchor_test,
         multiplier_floor=settings.anchor_floor,
     )
     # Same aggregation for offense — drop positions where every
@@ -730,6 +768,8 @@ def run_analysis(
         offense_buckets_present,
         year_weights=normalised_weights,
         blend=settings.blend,
+        offense_anchor_mine=offense_anchor_mine,
+        offense_anchor_test=offense_anchor_test,
         multiplier_floor=settings.anchor_floor,
     )
     family_scale = combine_family_scales(
@@ -753,7 +793,9 @@ def run_analysis(
     artifact: dict[str, Any] = {
         "run_id": run_id,
         "generated_at": _utc_now_iso(),
-        "schema_version": 1,
+        "schema_version": CALIBRATION_SCHEMA_VERSION,
+        "offense_anchor_vor_mine": round(offense_anchor_mine, 4),
+        "offense_anchor_vor_test": round(offense_anchor_test, 4),
         "inputs": {
             "test_league_id": str(test_league_id or ""),
             "my_league_id": str(my_league_id or ""),

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -290,6 +290,19 @@ def get_idp_bucket_multiplier(
     effective_mode = mode or str(config.get("active_mode") or "blended")
     if effective_mode not in {"intrinsic_only", "market_only", "blended"}:
         effective_mode = "blended"
+    # Schema v2 safety rail: the ``intrinsic`` / ``market`` channels
+    # carry offense-anchored absolute VOR magnitudes (unbounded above
+    # 1.0), not applied multipliers. The promotion factory already
+    # refuses non-blended modes under v2, but a hand-edited config
+    # could still smuggle one in — coerce to ``blended`` so
+    # ``_bucket_lookup_for`` reads the ``final`` relativity ratio
+    # regardless.
+    try:
+        cfg_version = int(config.get("version") or 0)
+    except (TypeError, ValueError):
+        cfg_version = 0
+    if cfg_version >= 2 and effective_mode != "blended":
+        effective_mode = "blended"
     try:
         bucket = float(_bucket_lookup_for(position, int(rank), config, effective_mode))
         family = _family_scale_for(config, effective_mode)

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -22,19 +22,54 @@ from .promotion import production_config_path
 _lock = threading.Lock()
 _cache: dict[str, Any] = {"mtime": None, "config": None}
 
+# Minimum config version the runtime will apply. Configs written by the
+# v1 engine encoded ``final`` as a top-bucket-normalised VOR decay
+# curve; under the v2 engine the same field carries a cross-league
+# relativity ratio. Applying a v1 config under v2 semantics would
+# mis-interpret the numbers, so we refuse to load anything older than
+# :data:`_MIN_SUPPORTED_VERSION` and leave calibration as a strict
+# no-op until the lab re-promotes on the current engine.
+_MIN_SUPPORTED_VERSION: int = 2
+
+_stale_version_warned = False
+
 
 def _load_if_stale(base: Path | None = None) -> dict[str, Any] | None:
+    global _stale_version_warned
     path = production_config_path(base)
     if not path.exists():
         with _lock:
             _cache["mtime"] = None
             _cache["config"] = None
+        _stale_version_warned = False
         return None
     mtime = path.stat().st_mtime
     with _lock:
         if _cache["mtime"] == mtime and _cache["config"] is not None:
             return _cache["config"]
         data = load_json(path)
+        if isinstance(data, dict):
+            try:
+                cfg_version = int(data.get("version") or 0)
+            except (TypeError, ValueError):
+                cfg_version = 0
+            if cfg_version < _MIN_SUPPORTED_VERSION:
+                if not _stale_version_warned:
+                    import logging
+
+                    logging.getLogger(__name__).warning(
+                        "config/idp_calibration.json is schema v%s "
+                        "(minimum supported: v%s). IDP calibration is a "
+                        "strict no-op until the lab re-promotes a run on "
+                        "the current engine.",
+                        cfg_version,
+                        _MIN_SUPPORTED_VERSION,
+                    )
+                    _stale_version_warned = True
+                _cache["mtime"] = mtime
+                _cache["config"] = None
+                return None
+            _stale_version_warned = False
         _cache["mtime"] = mtime
         _cache["config"] = data if isinstance(data, dict) else None
         return _cache["config"]
@@ -42,9 +77,11 @@ def _load_if_stale(base: Path | None = None) -> dict[str, Any] | None:
 
 def reset_cache() -> None:
     """Test hook — drop the in-memory cache."""
+    global _stale_version_warned
     with _lock:
         _cache["mtime"] = None
         _cache["config"] = None
+    _stale_version_warned = False
 
 
 def load_production_config(base: Path | None = None) -> dict[str, Any] | None:

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -19,6 +19,15 @@ from src.utils.config_loader import load_json
 
 from .promotion import production_config_path
 
+# Sentinel stored in the cache when the on-disk config has been read
+# and rejected (e.g. schema version below :data:`_MIN_SUPPORTED_VERSION`
+# or not a JSON dict).  Having a distinct value from ``None`` lets the
+# mtime fast-path short-circuit **without re-reading the file**, which
+# matters during the pre-re-promotion rollout window where a stale
+# config is present — otherwise every per-player multiplier lookup
+# would load_json() a ~200 KB file off disk on every call.
+_STALE_SENTINEL: object = object()
+
 _lock = threading.Lock()
 _cache: dict[str, Any] = {"mtime": None, "config": None}
 
@@ -45,8 +54,16 @@ def _load_if_stale(base: Path | None = None) -> dict[str, Any] | None:
         return None
     mtime = path.stat().st_mtime
     with _lock:
-        if _cache["mtime"] == mtime and _cache["config"] is not None:
-            return _cache["config"]
+        cached = _cache["config"]
+        if _cache["mtime"] == mtime:
+            # Fast path covers both outcomes:
+            #   * valid dict cached → return it
+            #   * stale-version sentinel cached → return None
+            # without re-parsing the JSON every call.
+            if cached is _STALE_SENTINEL:
+                return None
+            if cached is not None:
+                return cached
         data = load_json(path)
         if isinstance(data, dict):
             try:
@@ -67,12 +84,17 @@ def _load_if_stale(base: Path | None = None) -> dict[str, Any] | None:
                     )
                     _stale_version_warned = True
                 _cache["mtime"] = mtime
-                _cache["config"] = None
+                _cache["config"] = _STALE_SENTINEL
                 return None
             _stale_version_warned = False
+            _cache["mtime"] = mtime
+            _cache["config"] = data
+            return data
+        # Non-dict JSON (corrupt file) — treat as stale so we don't
+        # re-read and parse every call.
         _cache["mtime"] = mtime
-        _cache["config"] = data if isinstance(data, dict) else None
-        return _cache["config"]
+        _cache["config"] = _STALE_SENTINEL
+        return None
 
 
 def reset_cache() -> None:

--- a/src/idp_calibration/promotion.py
+++ b/src/idp_calibration/promotion.py
@@ -22,6 +22,29 @@ BACKUPS_DIR = "idp_calibration.backups"
 
 VALID_MODES: tuple[str, ...] = ("intrinsic_only", "market_only", "blended")
 
+# Under schema v2 the per-bucket ``final`` is the only channel that
+# carries a cross-league relativity ratio; ``intrinsic`` / ``market``
+# are offense-anchored absolute VOR magnitudes used for display only.
+# Promoting a v2 run with ``active_mode="intrinsic_only"`` or
+# ``"market_only"`` would make ``production.get_idp_bucket_multiplier``
+# read an unbounded VOR magnitude and apply it as a multiplier to
+# live values — a silent catastrophic mis-scale. The only mode that
+# produces a valid applied quantity under v2 is ``blended`` (reads
+# the ``final`` ratio), so we gate promotion on that at the factory.
+V2_VALID_MODES: tuple[str, ...] = ("blended",)
+
+
+class StaleArtifactSchemaError(ValueError):
+    """Raised when a run artifact predates the current engine schema.
+
+    Promoting a pre-v2 artifact would stamp ``"version": 2`` on a
+    config whose ``final`` field still encodes the old top-bucket-
+    normalised VOR decay, silently bypassing the loader gate in
+    :func:`production.load_production_config`. We refuse at the
+    promotion factory so stale runs can never reach production — the
+    operator must re-run the calibration on the current engine.
+    """
+
 
 class EmptyCalibrationError(ValueError):
     """Raised when a run has no usable per-bucket multiplier data.
@@ -79,6 +102,33 @@ def build_production_config(
     """Shape a saved run artifact into the production config schema."""
     if active_mode not in VALID_MODES:
         raise ValueError(f"active_mode must be one of {VALID_MODES}, got {active_mode!r}")
+    # Gate 1: refuse pre-v2 artifacts. The promoted config will be
+    # stamped with ``version = CALIBRATION_SCHEMA_VERSION`` below, so
+    # without this check a v1 run's top-bucket-normalised VOR decay
+    # values would ship under a v2 tag and be read as relativity
+    # ratios by the live loader.
+    try:
+        artifact_version = int(artifact.get("schema_version") or 0)
+    except (TypeError, ValueError):
+        artifact_version = 0
+    if artifact_version < CALIBRATION_SCHEMA_VERSION:
+        raise StaleArtifactSchemaError(
+            f"Run artifact is schema v{artifact_version}; the current engine "
+            f"produces v{CALIBRATION_SCHEMA_VERSION}. Re-run the calibration "
+            f"on the current engine before promoting — promoting a stale "
+            f"artifact would mis-interpret its multiplier field under the "
+            f"new semantics."
+        )
+    # Gate 2: under v2, only ``blended`` is a valid applied mode
+    # (``intrinsic`` / ``market`` are offense-anchored VOR magnitudes,
+    # not multipliers — see ``translation.compute_position_multipliers``).
+    if active_mode not in V2_VALID_MODES:
+        raise ValueError(
+            f"active_mode={active_mode!r} is not applicable under schema "
+            f"v{CALIBRATION_SCHEMA_VERSION}. Only {V2_VALID_MODES} produce "
+            f"a valid applied multiplier; intrinsic/market are display-only "
+            f"diagnostic channels in the v2 artifact."
+        )
     if not _has_usable_bucket_data(artifact):
         raise EmptyCalibrationError(
             "Run has no resolved seasons with per-bucket IDP data; refusing "

--- a/src/idp_calibration/promotion.py
+++ b/src/idp_calibration/promotion.py
@@ -15,6 +15,7 @@ from typing import Any
 from src.utils.config_loader import load_json, repo_root, save_json
 
 from .storage import load_run
+from .translation import CALIBRATION_SCHEMA_VERSION
 
 CONFIG_FILENAME = "idp_calibration.json"
 BACKUPS_DIR = "idp_calibration.backups"
@@ -86,8 +87,15 @@ def build_production_config(
         )
     settings = artifact.get("settings") or {}
     inputs = artifact.get("inputs") or {}
+    # Schema v2: per-bucket ``final`` already carries the offense-
+    # anchored cross-league relativity ratio, so ``family_scale`` is
+    # redundant class-wide lift and would double-count if applied on
+    # top. We keep the field in the artifact for the lab UI's display
+    # but pin the applied value to identity (1.0 / 1.0 / 1.0) in the
+    # promoted config. If a future schema needs a separate class-wide
+    # lever, bump the version and plug it back in.
     return {
-        "version": 1,
+        "version": CALIBRATION_SCHEMA_VERSION,
         "promoted_at": _utc_now_iso(),
         "source_run_id": str(artifact.get("run_id") or ""),
         "promoted_by": str(promoted_by or "internal"),
@@ -100,9 +108,16 @@ def build_production_config(
         "replacement_settings": dict(settings.get("replacement") or {}),
         "active_mode": active_mode,
         "bucket_edges": list(settings.get("bucket_edges") or []),
+        "offense_anchor_vor_mine": float(
+            artifact.get("offense_anchor_vor_mine") or 0.0
+        ),
+        "offense_anchor_vor_test": float(
+            artifact.get("offense_anchor_vor_test") or 0.0
+        ),
         "multipliers": dict(artifact.get("multipliers") or {}),
         "offense_multipliers": dict(artifact.get("offense_multipliers") or {}),
-        "family_scale": dict(artifact.get("family_scale") or {}),
+        "family_scale": {"intrinsic": 1.0, "market": 1.0, "final": 1.0},
+        "family_scale_diagnostic": dict(artifact.get("family_scale") or {}),
         "anchors": dict(artifact.get("anchors") or {}),
         "offense_anchors": dict(artifact.get("offense_anchors") or {}),
     }

--- a/src/idp_calibration/translation.py
+++ b/src/idp_calibration/translation.py
@@ -1,16 +1,32 @@
-"""Intrinsic / market / final multiplier math.
+"""Cross-league relativity multiplier math (schema v2).
 
-Converts per-season bucket centers into per-bucket multipliers:
+Converts per-season bucket centers into per-bucket multipliers that
+express **how my league values this IDP bucket relative to a test
+league, anchored to each league's own offense baseline**.
 
-* **Intrinsic** — "what my-league scoring + my-league lineup economics
-  say this bucket is worth". Normalised against the top bucket so
-  the top bucket in each position has multiplier 1.0.
-* **Market** — same recipe but using the test-league centers. This
-  is treated as a prior, not ground truth.
-* **Final** — convex blend ``alpha * intrinsic + (1 - alpha) * market``.
+Per-bucket formula::
 
-Multi-year weighting folds per-season buckets into a single table by
-applying recency weights and skipping missing seasons.
+    my_norm[i]   = center_vor_mine[i]  / offense_anchor_mine
+    test_norm[i] = center_vor_test[i]  / offense_anchor_test
+    final[i]     = my_norm[i] / test_norm[i]     # the applied multiplier
+
+Where ``offense_anchor_*`` is the mean VOR of the top-24 RB+WR under
+each league's scoring (see ``vor.compute_offense_anchor_vor``).
+
+Fields on the emitted :class:`BucketMultipliers` record:
+
+* ``intrinsic`` — ``my_norm[i]``. How much VOR my-league scoring
+  produces for this bucket expressed as a multiple of one average top-24
+  flex starter's VOR. Display-only in the final-mode production path.
+* ``market`` — ``test_norm[i]``. Same measure for the test league.
+* ``final`` — ``intrinsic / market``. The **relativity ratio** applied
+  as a multiplier to market-derived ``rankDerivedValue`` in the live
+  pipeline. 1.0 = identical weighting; > 1.0 lifts the bucket; < 1.0
+  cuts it.
+
+Multi-year weighting folds per-season buckets (and per-season offense
+anchors) into a single table by applying recency weights and skipping
+missing seasons.
 """
 from __future__ import annotations
 
@@ -27,6 +43,27 @@ DEFAULT_YEAR_WEIGHTS: dict[int, float] = {
 }
 
 DEFAULT_BLEND: dict[str, float] = {"intrinsic": 0.75, "market": 0.25}
+
+# Schema version tag written into the emitted multipliers/anchors
+# artifact. ``production.py`` refuses to apply anything older than
+# :data:`CALIBRATION_SCHEMA_VERSION` because the v1 ``final`` field
+# encoded a different quantity (top-bucket-normalised VOR decay) and
+# would be misinterpreted as a relativity ratio.
+CALIBRATION_SCHEMA_VERSION: int = 2
+
+# Cross-league relativity bounds. The engineering floor/ceiling here
+# bounds the ``final`` multiplier only — the display-side ``intrinsic``
+# and ``market`` fields are emitted without a ceiling because they're
+# in offense-anchor units and the reader does not apply them as
+# multipliers when the active mode is ``blended``/``final``.
+RELATIVITY_MIN: float = 0.25
+RELATIVITY_MAX: float = 4.0
+
+# Guard against pathological zero/near-zero offense anchors. A
+# missing-data anchor collapses the ratio to garbage; we fall back to
+# an identity multiplier (``1.0``) whenever either side can't produce
+# a real number.
+_OFFENSE_ANCHOR_EPSILON: float = 1.0  # VOR points; anything below this is noise
 
 
 @dataclass
@@ -84,21 +121,23 @@ def _weighted_center(
     return total_val / total_w, total_w
 
 
-def _normalise(values: list[float]) -> list[float]:
-    """Normalise so the top (first) bucket equals 1.0.
+def _clamp_relativity(value: float) -> float:
+    """Clamp a relativity ratio into ``[RELATIVITY_MIN, RELATIVITY_MAX]``.
 
-    If the top bucket is zero we fall back to the max abs value; if
-    everything is zero we return 1.0s so downstream code doesn't get
-    divide-by-zero.
+    Unlike the old :func:`_clamp_series`, we do not force the output to
+    sit below 1.0 — a relativity > 1.0 is the signal that "my league
+    values this bucket more than the test league." The floor keeps a
+    pathological near-zero test anchor from producing an absurd
+    deflation; the ceiling keeps a pathological near-zero my-league
+    anchor from producing an absurd inflation. Identity passes through
+    unchanged.
     """
-    if not values:
-        return []
-    anchor = values[0]
-    if abs(anchor) < 1e-9:
-        anchor = max((abs(v) for v in values), default=0.0)
-    if abs(anchor) < 1e-9:
-        return [1.0 for _ in values]
-    return [v / anchor for v in values]
+    if not isinstance(value, (int, float)):
+        return 1.0
+    v = float(value)
+    if v != v:  # NaN
+        return 1.0
+    return max(RELATIVITY_MIN, min(RELATIVITY_MAX, v))
 
 
 def _collect_year_centers(
@@ -141,100 +180,91 @@ def compute_position_multipliers(
     *,
     year_weights: dict[int, float] | None = None,
     blend: dict[str, float] | None = None,
-    multiplier_floor: float = 0.05,
+    offense_anchor_mine: float = 0.0,
+    offense_anchor_test: float = 0.0,
+    multiplier_floor: float = 0.05,  # kept for signature compat; no longer used
 ) -> PositionMultipliers:
-    """Combine per-season bucket tables into per-bucket multipliers.
+    """Combine per-season bucket tables into cross-league relativity multipliers.
 
-    ``multiplier_floor`` (default ``0.05``) clamps every emitted
-    multiplier to a positive minimum. Without it, sub-replacement
-    buckets produce **negative** multipliers: VOR goes negative for
-    players below replacement, normalisation against the positive
-    top bucket yields a negative ratio, and the live pipeline would
-    multiply ``rankDerivedValue`` by a negative number — flipping a
-    player's value sign, which is nonsense (a bench depth player
-    still has positive trade value, just a small one). Flooring at
-    5% matches the anchor-curve floor so bucket and anchor lookups
-    don't disagree.
+    For each bucket the function computes::
+
+        my_norm   = weighted_center_vor_mine / offense_anchor_mine
+        test_norm = weighted_center_vor_test / offense_anchor_test
+        final     = my_norm / test_norm          (clamped to [0.25, 4.0])
+
+    ``offense_anchor_mine`` / ``offense_anchor_test`` are the mean VOR
+    of the top-24 RB+WR under each league's scoring (see
+    :func:`src.idp_calibration.vor.compute_offense_anchor_vor`),
+    weighted-aggregated across seasons upstream. They put ``intrinsic``
+    and ``market`` into a common "offense flex starter" unit so the
+    ratio represents genuine cross-league relativity rather than raw
+    VOR point counts (which would just reflect scoring intensity).
+
+    Fallback semantics:
+
+    * Either anchor missing / ≤ ``_OFFENSE_ANCHOR_EPSILON`` → every
+      bucket emits the identity multiplier (1.0) with raw VOR still
+      exposed on ``intrinsic`` / ``market`` for audit.
+    * A single bucket with ``center_vor_mine`` ≤ 0 or
+      ``center_vor_test`` ≤ 0 → emit identity (1.0) for that bucket's
+      ``final`` — we don't have a meaningful ratio when either side is
+      at/below replacement.
+
+    ``multiplier_floor`` is accepted for call-site compat but no longer
+    used; the relativity floor/ceiling are set by
+    :data:`RELATIVITY_MIN` / :data:`RELATIVITY_MAX`.
     """
+    del multiplier_floor  # schema v1 vestige; relativity has its own bounds
     year_weights = year_weights or DEFAULT_YEAR_WEIGHTS
-    blend = blend or DEFAULT_BLEND
+    blend = blend or DEFAULT_BLEND  # kept for API compat; unused in v2 math
+    del blend
     labels = _bucket_labels(per_season)
-    intrinsic_raw: list[float] = []
-    market_raw: list[float] = []
-    counts: list[int] = []
+
+    anchors_ok = (
+        offense_anchor_mine > _OFFENSE_ANCHOR_EPSILON
+        and offense_anchor_test > _OFFENSE_ANCHOR_EPSILON
+    )
+
+    buckets: list[BucketMultipliers] = []
     for label in labels:
         mine_centers = _collect_year_centers(per_season, label, "center_vor_mine")
         test_centers = _collect_year_centers(per_season, label, "center_vor_test")
         mine_val, _ = _weighted_center(mine_centers, year_weights)
         test_val, _ = _weighted_center(test_centers, year_weights)
-        intrinsic_raw.append(mine_val)
-        market_raw.append(test_val)
         total_count = 0
-        for buckets in per_season.values():
-            for b in buckets:
+        for season_buckets in per_season.values():
+            for b in season_buckets:
                 if b.label == label:
                     total_count += int(b.count)
                     break
-        counts.append(total_count)
-    intrinsic_norm = _clamp_series(
-        _enforce_descending(_normalise(intrinsic_raw)), multiplier_floor
-    )
-    market_norm = _clamp_series(
-        _enforce_descending(_normalise(market_raw)), multiplier_floor
-    )
-    alpha = float(blend.get("intrinsic", 0.75))
-    beta = 1.0 - alpha
-    final_norm = _clamp_series(
-        _enforce_descending(
-            [alpha * i + beta * m for i, m in zip(intrinsic_norm, market_norm)]
-        ),
-        multiplier_floor,
-    )
-    buckets = [
-        BucketMultipliers(
-            label=lbl,
-            intrinsic=intrinsic_norm[i],
-            market=market_norm[i],
-            final=final_norm[i],
-            count=counts[i],
+
+        if anchors_ok:
+            my_norm = mine_val / offense_anchor_mine
+            test_norm = test_val / offense_anchor_test
+        else:
+            my_norm = 0.0
+            test_norm = 0.0
+
+        # Relativity ratio — the applied multiplier.
+        if anchors_ok and mine_val > 0 and test_val > 0:
+            final = _clamp_relativity(my_norm / test_norm)
+        else:
+            # No meaningful ratio: identity passthrough so the live
+            # pipeline leaves the market-derived value alone rather
+            # than guessing.
+            final = 1.0
+
+        buckets.append(
+            BucketMultipliers(
+                label=label,
+                intrinsic=my_norm,
+                market=test_norm,
+                final=final,
+                count=total_count,
+            )
         )
-        for i, lbl in enumerate(labels)
-    ]
+
     return PositionMultipliers(position="", buckets=buckets)
-
-
-def _enforce_descending(values: list[float]) -> list[float]:
-    """Clamp a list so each element is <= the previous one.
-
-    This prevents calibration noise from producing a bucket that is
-    worth *more* than a higher-ranked bucket. We only enforce a soft
-    non-increasing pass — equal values are allowed so small genuine
-    plateaus (e.g. mid-tier depth) survive.
-    """
-    out: list[float] = []
-    for i, v in enumerate(values):
-        if i == 0:
-            out.append(v)
-            continue
-        prev = out[-1]
-        out.append(min(v, prev))
-    return out
-
-
-def _clamp_series(values: list[float], floor: float) -> list[float]:
-    """Clamp every value into ``[floor, 1.0]`` while preserving non-increasing order.
-
-    Without this, ``_normalise`` divides every VOR center by the top
-    bucket's positive value — sub-replacement buckets (negative VOR)
-    therefore emit *negative* multipliers. Applied to a positive
-    ``rankDerivedValue`` in the live pipeline, a negative multiplier
-    would flip the player's value sign. We instead floor at
-    ``floor`` (default 5%) so sub-replacement buckets collapse to
-    the minimum positive multiplier and cap at 1.0 so calibration
-    noise can't inflate a deep bucket past the top bucket.
-    """
-    floor = max(0.0, float(floor))
-    return [max(floor, min(1.0, float(v))) for v in values]
 
 
 @dataclass
@@ -413,15 +443,18 @@ def build_multi_year_multipliers(
     *,
     year_weights: dict[int, float] | None = None,
     blend: dict[str, float] | None = None,
+    offense_anchor_mine: float = 0.0,
+    offense_anchor_test: float = 0.0,
     multiplier_floor: float = 0.05,
 ) -> dict[str, PositionMultipliers]:
-    """Produce intrinsic/market/final multiplier tables for DL/LB/DB.
+    """Produce per-bucket relativity multiplier tables for DL/LB/DB.
 
-    ``multiplier_floor`` flows through to
-    :func:`compute_position_multipliers` so every emitted multiplier
-    sits inside ``[floor, 1.0]``. See the per-position helper's
-    docstring for the rationale (sub-replacement VOR would otherwise
-    yield negative multipliers).
+    ``offense_anchor_mine`` / ``offense_anchor_test`` are the aggregate
+    (year-weighted) top-24 RB+WR mean VOR on each side; they are
+    threaded into :func:`compute_position_multipliers` so every bucket
+    is normalised into the same offense-anchored unit before the ratio.
+    Missing anchors collapse every bucket to identity (see that helper's
+    docstring).
     """
     out: dict[str, PositionMultipliers] = {}
     for position, per_season in per_season_per_position.items():
@@ -429,6 +462,8 @@ def build_multi_year_multipliers(
             per_season,
             year_weights=year_weights,
             blend=blend,
+            offense_anchor_mine=offense_anchor_mine,
+            offense_anchor_test=offense_anchor_test,
             multiplier_floor=multiplier_floor,
         )
         result.position = position

--- a/src/idp_calibration/vor.py
+++ b/src/idp_calibration/vor.py
@@ -171,6 +171,55 @@ def compute_vor(
     return rows
 
 
+_OFFENSE_ANCHOR_POSITIONS: tuple[str, ...] = ("RB", "WR")
+_OFFENSE_ANCHOR_TOP_N: int = 24
+
+
+def compute_offense_anchor_vor(
+    offense_scored: list[ScoredPlayer],
+    replacement_mine: dict[str, float],
+    replacement_test: dict[str, float],
+    *,
+    positions: Iterable[str] = _OFFENSE_ANCHOR_POSITIONS,
+    top_n: int = _OFFENSE_ANCHOR_TOP_N,
+) -> tuple[float, float]:
+    """Return ``(anchor_mine, anchor_test)`` — mean VOR of the top
+    ``top_n`` RB+WR under each scoring system.
+
+    This is the "what counts as a top flex starter" yardstick that
+    every IDP bucket's VOR is normalised against in the cross-league
+    relativity math (see :func:`compute_position_multipliers`). Top-24
+    combined RB+WR is a robust, scoring-invariant anchor: it's the
+    depth of a standard 12-team flex pool, and it's insensitive to
+    SF/non-SF (QBs are excluded) and TE-premium (TE excluded) format
+    differences.
+
+    Each side ranks independently by its own VOR column, so a player
+    who is elite under my-league scoring but mediocre under test
+    scoring is counted in my anchor but not the test anchor — that's
+    the point: we're measuring each league's own "top-24 flex" cohort.
+
+    Returns ``(0.0, 0.0)`` when there isn't enough offense data on
+    either side; the caller should treat a zero anchor as a signal
+    to skip the calibration altogether for that season.
+    """
+    allowed = {p.upper() for p in positions}
+    cohort = [s for s in offense_scored if s.position in allowed]
+    if not cohort or top_n <= 0:
+        return 0.0, 0.0
+    vor_mine_list = [
+        s.points_mine - float(replacement_mine.get(s.position, 0.0)) for s in cohort
+    ]
+    vor_test_list = [
+        s.points_test - float(replacement_test.get(s.position, 0.0)) for s in cohort
+    ]
+    top_mine = sorted(vor_mine_list, reverse=True)[:top_n]
+    top_test = sorted(vor_test_list, reverse=True)[:top_n]
+    anchor_mine = sum(top_mine) / len(top_mine) if top_mine else 0.0
+    anchor_test = sum(top_test) / len(top_test) if top_test else 0.0
+    return float(anchor_mine), float(anchor_test)
+
+
 def vor_rows_to_dict(rows: list[VorRow]) -> list[dict[str, Any]]:
     return [
         {

--- a/src/idp_calibration/vor.py
+++ b/src/idp_calibration/vor.py
@@ -202,16 +202,38 @@ def compute_offense_anchor_vor(
     Returns ``(0.0, 0.0)`` when there isn't enough offense data on
     either side; the caller should treat a zero anchor as a signal
     to skip the calibration altogether for that season.
+
+    Phantom-demand guardrail: ``replacement_mine`` / ``replacement_test``
+    come from :func:`engine._compute_offense_replacement`, which omits
+    positions with zero starter demand (a 0-RB league skips RB
+    entirely). We therefore **drop** any row whose position is missing
+    from either side's replacement map — using ``replacement.get(pos,
+    0.0)`` would silently treat zero-demand positions as "replacement
+    = 0", turning every player's raw points into pure VOR and inflating
+    the anchor. That inflation deflates ``my_norm`` / ``test_norm`` and
+    produces unjustified cuts in the final relativity ratio.
     """
     allowed = {p.upper() for p in positions}
-    cohort = [s for s in offense_scored if s.position in allowed]
-    if not cohort or top_n <= 0:
+    # Per-side cohorts: a position must have a real replacement
+    # baseline on that side to contribute. "Real" means the position
+    # key is present in the map at all — the engine strips
+    # zero-demand positions before handing the dict over, so any key
+    # here represents a genuine starter pool.
+    cohort_mine = [
+        s for s in offense_scored
+        if s.position in allowed and s.position in replacement_mine
+    ]
+    cohort_test = [
+        s for s in offense_scored
+        if s.position in allowed and s.position in replacement_test
+    ]
+    if top_n <= 0:
         return 0.0, 0.0
     vor_mine_list = [
-        s.points_mine - float(replacement_mine.get(s.position, 0.0)) for s in cohort
+        s.points_mine - float(replacement_mine[s.position]) for s in cohort_mine
     ]
     vor_test_list = [
-        s.points_test - float(replacement_test.get(s.position, 0.0)) for s in cohort
+        s.points_test - float(replacement_test[s.position]) for s in cohort_test
     ]
     top_mine = sorted(vor_mine_list, reverse=True)[:top_n]
     top_test = sorted(vor_test_list, reverse=True)[:top_n]

--- a/tests/idp_calibration/test_api.py
+++ b/tests/idp_calibration/test_api.py
@@ -156,6 +156,7 @@ def test_promote_empty_run_returns_422(tmp_base):
     empty = {
         "run_id": "empty_api",
         "generated_at": "2026-04-18T00:00:00Z",
+        "schema_version": 2,
         "settings": {"blend": {"intrinsic": 0.75, "market": 0.25}},
         "resolved_seasons": [],
         "multipliers": {

--- a/tests/idp_calibration/test_family_scale.py
+++ b/tests/idp_calibration/test_family_scale.py
@@ -246,19 +246,28 @@ def test_engine_neutral_when_leagues_are_identical(monkeypatch):
     assert abs(fs["final"] - 1.0) < 0.01
 
 
-# ── Production read path: family_scale is applied multiplicatively ──
+# ── Production read path (schema v2): family_scale is pinned to 1.0 ──
+#
+# Under schema v2 the per-bucket ``final`` field already carries the
+# offense-anchored cross-league relativity ratio. Applying a separate
+# class-wide ``family_scale`` on top would double-count the same
+# signal, so the promotion step pins ``family_scale`` to identity in
+# the promoted config regardless of what the lab computed.  The lab's
+# diagnostic number is preserved under ``family_scale_diagnostic`` for
+# UI display only.
 
 
 def _write_config(path, *, family_scale_final, dl_bucket_final):
-    """Helper: write a minimal promoted config with a family scale and
-    one DL bucket so we can verify the multiplicative combination."""
+    """Helper: write a minimal promoted v2 config with a (possibly
+    non-identity) ``family_scale`` block so we can verify that the
+    runtime ignores it and applies only the per-bucket ratio."""
     import json
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "active_mode": "blended",
                 "family_scale": {
                     "intrinsic": family_scale_final,
@@ -285,20 +294,23 @@ def _write_config(path, *, family_scale_final, dl_bucket_final):
     )
 
 
-def test_production_combines_family_scale_with_bucket(tmp_path, monkeypatch):
+def test_production_applies_bucket_ratio_without_family_scale(tmp_path, monkeypatch):
+    # Even though the config file carries a non-identity family_scale
+    # (1.1), the runtime reader folds it through its own clamp; the
+    # applied multiplier is the per-bucket ``final`` × family_scale. Under
+    # v2 the promotion step pins family_scale to 1.0, so a real promoted
+    # config would never hit this path — but a hand-edited file could,
+    # and the [0.85, 1.15] production clamp keeps the blast radius bounded.
     cfg_path = tmp_path / "config" / "idp_calibration.json"
-    # Use 1.1 — within the [0.85, 1.15] production cap.  1.3 would
-    # be clamped to 1.15 and wouldn't exercise the pure combination.
     _write_config(cfg_path, family_scale_final=1.1, dl_bucket_final=0.5)
     monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
     production.reset_cache()
-    # Expected: 1.1 (family) × 0.5 (bucket) = 0.55.
+    # 1.1 (family) × 0.5 (bucket) = 0.55.
     assert abs(production.get_idp_bucket_multiplier("DL", 1) - 0.55) < 1e-9
 
 
 def test_production_family_scale_missing_is_identity(tmp_path, monkeypatch):
-    # Pre-Family-Scale promoted configs must keep working. Absent
-    # family_scale block → family lift = 1.0 (identity).
+    # Promoted configs without a family_scale block → family lift = 1.0.
     import json
 
     cfg_path = tmp_path / "config" / "idp_calibration.json"
@@ -306,7 +318,7 @@ def test_production_family_scale_missing_is_identity(tmp_path, monkeypatch):
     cfg_path.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "active_mode": "blended",
                 "multipliers": {
                     "DL": {
@@ -332,9 +344,9 @@ def test_production_family_scale_missing_is_identity(tmp_path, monkeypatch):
 
 
 def test_production_family_scale_insane_value_clamped(tmp_path, monkeypatch):
-    # Defend against a hand-edited config with a nonsense value.
-    # Production clamp is [0.85, 1.15] (market-sensibility cap), so
-    # any hand-edited mega-value saturates at 1.15.
+    # Defend against a hand-edited config with a nonsense value. The
+    # [0.85, 1.15] production clamp caps any hand-edited mega-value
+    # at 1.15, independent of the bucket value.
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     _write_config(cfg_path, family_scale_final=100.0, dl_bucket_final=0.5)
     monkeypatch.setattr(production, "production_config_path", lambda base=None: cfg_path)
@@ -343,9 +355,11 @@ def test_production_family_scale_insane_value_clamped(tmp_path, monkeypatch):
     assert abs(production.get_idp_bucket_multiplier("DL", 1) - 0.575) < 1e-9
 
 
-def test_promotion_persists_family_scale(tmp_path, monkeypatch):
-    """End-to-end: run_analysis → storage.save_run → promotion.promote_run
-    → production config contains the family_scale block."""
+def test_promotion_pins_family_scale_to_identity_under_v2(tmp_path, monkeypatch):
+    """v2 behaviour: ``promote_run`` writes family_scale={1,1,1} even when
+    the lab's artifact computed a non-identity scale. The diagnostic
+    value is preserved under ``family_scale_diagnostic`` for UI display.
+    """
     monkeypatch.setattr(
         season_chain,
         "fetch_league_chain",
@@ -364,6 +378,8 @@ def test_promotion_persists_family_scale(tmp_path, monkeypatch):
     import json
 
     promoted = json.loads(cfg_path.read_text())
-    assert "family_scale" in promoted
-    assert promoted["family_scale"]["intrinsic"] > 1.0
-    assert promoted["family_scale"]["final"] > 1.0
+    assert promoted["version"] == 2
+    # Applied family_scale is pinned to identity.
+    assert promoted["family_scale"] == {"intrinsic": 1.0, "market": 1.0, "final": 1.0}
+    # Diagnostic preserves the computed value from the run artifact.
+    assert promoted["family_scale_diagnostic"]["intrinsic"] > 1.0

--- a/tests/idp_calibration/test_family_scale_once_only.py
+++ b/tests/idp_calibration/test_family_scale_once_only.py
@@ -46,7 +46,7 @@ def _write_config(path: Path) -> None:
     path.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "active_mode": "blended",
                 "family_scale": {
                     "intrinsic": FAMILY_SCALE,

--- a/tests/idp_calibration/test_offense_anchor.py
+++ b/tests/idp_calibration/test_offense_anchor.py
@@ -1,0 +1,106 @@
+"""Offense anchor VOR correctness — top-24 RB+WR across both scoring systems.
+
+Pins the no-phantom-demand invariant: when either side's replacement
+map omits a position (the engine strips zero-starter-demand positions
+upstream), that position must be dropped from the anchor cohort on
+that side — never treated as "replacement = 0," which would silently
+turn raw points into pure VOR and inflate the anchor.
+"""
+from __future__ import annotations
+
+from src.idp_calibration.vor import ScoredPlayer, compute_offense_anchor_vor
+
+
+def _players(*triples: tuple[str, str, float, float]) -> list[ScoredPlayer]:
+    """Build a ScoredPlayer list from (player_id, position, pts_mine, pts_test) tuples."""
+    return [
+        ScoredPlayer(
+            player_id=pid,
+            name=f"P_{pid}",
+            position=pos,
+            games=16,
+            points_mine=pm,
+            points_test=pt,
+        )
+        for pid, pos, pm, pt in triples
+    ]
+
+
+def test_standard_lineup_both_sides_contribute():
+    """Baseline: both leagues have RB+WR demand. Anchor is mean VOR
+    of the top-24 combined RB+WR on each side."""
+    # 12 RBs and 12 WRs with identical points on both sides; demand
+    # present on both. Expected VOR per player = points - replacement.
+    cohort = _players(
+        *[(f"rb{i}", "RB", 200 - i * 10, 200 - i * 10) for i in range(12)],
+        *[(f"wr{i}", "WR", 180 - i * 8, 180 - i * 8) for i in range(12)],
+    )
+    rep_mine = {"RB": 50.0, "WR": 40.0}
+    rep_test = {"RB": 50.0, "WR": 40.0}
+    am, at = compute_offense_anchor_vor(cohort, rep_mine, rep_test)
+    assert am == at
+    assert am > 0
+
+
+def test_zero_rb_demand_drops_rb_cohort_on_that_side():
+    """My league has no RB slots (replacement_mine omits RB). RBs
+    must be dropped from the mine-side anchor rather than silently
+    contributing their raw points as VOR. Test side still has RB
+    demand, so RBs DO contribute there.
+    """
+    # 12 RBs with inflated raw points + 12 WRs with modest points.
+    # Under the old ``.get(pos, 0.0)`` behaviour, RBs would get pure
+    # points as VOR on the mine side, dominating the top-24 and
+    # inflating ``anchor_mine`` far beyond the honest WR-only anchor.
+    cohort = _players(
+        *[(f"rb{i}", "RB", 500 - i * 10, 200 - i * 10) for i in range(12)],
+        *[(f"wr{i}", "WR", 180 - i * 8, 180 - i * 8) for i in range(12)],
+    )
+    rep_mine = {"WR": 40.0}  # no RB demand
+    rep_test = {"RB": 50.0, "WR": 40.0}
+    am, at = compute_offense_anchor_vor(cohort, rep_mine, rep_test)
+
+    # Mine anchor is the mean WR VOR only (12 players).
+    expected_wr_vor = [(180 - i * 8) - 40.0 for i in range(12)]
+    expected_am = sum(expected_wr_vor) / len(expected_wr_vor)
+    assert abs(am - expected_am) < 1e-9, (
+        f"anchor_mine should be WR-only mean VOR ({expected_am:.3f}); "
+        f"got {am:.3f} — phantom RB demand was not filtered"
+    )
+
+    # Test anchor includes both: top-24 of the combined 24-player
+    # cohort, so it uses every row.
+    rb_vors_test = [(200 - i * 10) - 50.0 for i in range(12)]
+    wr_vors_test = [(180 - i * 8) - 40.0 for i in range(12)]
+    combined = sorted(rb_vors_test + wr_vors_test, reverse=True)[:24]
+    expected_at = sum(combined) / len(combined)
+    assert abs(at - expected_at) < 1e-9
+
+
+def test_both_sides_missing_position_produces_zero_cohort_contribution():
+    """If neither league has RB demand, RBs don't contribute anywhere —
+    both anchors collapse to the WR-only mean VOR.
+    """
+    cohort = _players(
+        *[(f"rb{i}", "RB", 500, 500) for i in range(12)],
+        *[(f"wr{i}", "WR", 180 - i * 8, 180 - i * 8) for i in range(12)],
+    )
+    rep_mine = {"WR": 40.0}
+    rep_test = {"WR": 40.0}
+    am, at = compute_offense_anchor_vor(cohort, rep_mine, rep_test)
+    expected = sum((180 - i * 8) - 40.0 for i in range(12)) / 12
+    assert abs(am - expected) < 1e-9
+    assert abs(at - expected) < 1e-9
+
+
+def test_empty_replacement_maps_produce_zero_anchors():
+    """When neither side has ANY offense demand, both anchors are 0
+    and the upstream relativity math falls through to identity
+    (see ``translation.compute_position_multipliers`` missing-anchor
+    branch)."""
+    cohort = _players(
+        *[(f"rb{i}", "RB", 500, 500) for i in range(12)],
+    )
+    am, at = compute_offense_anchor_vor(cohort, {}, {})
+    assert am == 0.0
+    assert at == 0.0

--- a/tests/idp_calibration/test_production_integration.py
+++ b/tests/idp_calibration/test_production_integration.py
@@ -40,7 +40,7 @@ def test_no_config_is_strict_noop(tmp_path, monkeypatch):
 def test_promoted_multipliers_scale_only_idp(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
-        "version": 1,
+        "version": 2,
         "active_mode": "blended",
         "multipliers": {
             "final": {
@@ -84,6 +84,7 @@ def test_empty_bucket_config_is_identity_not_anchor_floor(tmp_path, monkeypatch)
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     # Count = 0 on every bucket; anchors look convincing but are all 0.05.
     config = {
+        "version": 2,
         "active_mode": "blended",
         "multipliers": {
             "DL": {"position": "DL", "buckets": [
@@ -107,6 +108,7 @@ def test_empty_bucket_config_is_identity_not_anchor_floor(tmp_path, monkeypatch)
 def test_position_alias_collapses_to_canonical(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
+        "version": 2,
         "active_mode": "blended",
         "multipliers": {"final": {"DL": {"1-6": 0.5}}},
     }
@@ -138,7 +140,7 @@ def test_end_to_end_values_are_monotonic_with_ranks_after_calibration(tmp_path, 
 
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
-        "version": 1,
+        "version": 2,
         "active_mode": "blended",
         "multipliers": {
             "final": {
@@ -213,7 +215,7 @@ def test_idp_lookup_interpolates_anchor_curve_no_cliffs(tmp_path, monkeypatch):
     # Realistic-shape config with bucket-derived multipliers AND an
     # anchor curve between them. Live runs always include both.
     config = {
-        "version": 1,
+        "version": 2,
         "active_mode": "blended",
         "multipliers": {
             "LB": {
@@ -283,7 +285,7 @@ def test_live_pipeline_does_not_apply_offense_calibration(tmp_path, monkeypatch)
 
     cfg_path = tmp_path / "config" / "idp_calibration.json"
     config = {
-        "version": 1,
+        "version": 2,
         "active_mode": "blended",
         "multipliers": {},
         "offense_multipliers": {

--- a/tests/idp_calibration/test_schema_version_gate.py
+++ b/tests/idp_calibration/test_schema_version_gate.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 import logging
 
+import pytest
+
 from src.idp_calibration import production
 
 
@@ -81,3 +83,115 @@ def test_v2_config_loads_cleanly(tmp_path, monkeypatch):
     # And the real bucket lookup returns the configured value (0.5),
     # NOT identity.
     assert abs(production.get_idp_bucket_multiplier("DL", 1) - 0.5) < 1e-9
+
+
+def test_promotion_refuses_pre_v2_artifact(tmp_path, monkeypatch):
+    """Gate on the write path: a saved run artifact that predates the
+    current engine must be refused by ``build_production_config``, so
+    it cannot be stamped with ``"version": 2`` and silently bypass the
+    runtime loader gate."""
+    from src.idp_calibration import promotion
+
+    v1_artifact = {
+        "run_id": "legacy_run",
+        "schema_version": 1,
+        "settings": {},
+        "resolved_seasons": [2024],
+        "multipliers": {
+            "DL": {
+                "position": "DL",
+                "buckets": [
+                    {"label": "1-6", "intrinsic": 1.0, "market": 1.0, "final": 1.0, "count": 10},
+                ],
+            },
+        },
+        "anchors": {},
+    }
+    with pytest.raises(promotion.StaleArtifactSchemaError):
+        promotion.build_production_config(v1_artifact, active_mode="blended")
+
+
+def test_promotion_refuses_artifact_with_no_schema_version(tmp_path):
+    """Legacy artifacts without a ``schema_version`` field must also
+    be rejected (parsed as 0 → below the minimum)."""
+    from src.idp_calibration import promotion
+
+    artifact = {
+        "run_id": "unversioned",
+        "settings": {},
+        "resolved_seasons": [2024],
+        "multipliers": {
+            "DL": {
+                "position": "DL",
+                "buckets": [
+                    {"label": "1-6", "intrinsic": 1.0, "market": 1.0, "final": 1.0, "count": 10},
+                ],
+            },
+        },
+    }
+    with pytest.raises(promotion.StaleArtifactSchemaError):
+        promotion.build_production_config(artifact, active_mode="blended")
+
+
+def test_promotion_refuses_non_blended_mode_under_v2(tmp_path):
+    """Schema v2 ``intrinsic`` / ``market`` are offense-anchored VOR
+    magnitudes, not multipliers. The promotion factory must refuse
+    non-blended modes so no v2 config can ship with ``active_mode``
+    pointing at a display-only channel."""
+    from src.idp_calibration import promotion
+
+    v2_artifact = {
+        "run_id": "v2_run",
+        "schema_version": 2,
+        "settings": {},
+        "resolved_seasons": [2024],
+        "multipliers": {
+            "DL": {
+                "position": "DL",
+                "buckets": [
+                    {"label": "1-6", "intrinsic": 3.5, "market": 3.0, "final": 1.17, "count": 10},
+                ],
+            },
+        },
+    }
+    for bad_mode in ("intrinsic_only", "market_only"):
+        with pytest.raises(ValueError, match="not applicable"):
+            promotion.build_production_config(v2_artifact, active_mode=bad_mode)
+    # ``blended`` is accepted.
+    cfg = promotion.build_production_config(v2_artifact, active_mode="blended")
+    assert cfg["version"] == 2
+    assert cfg["active_mode"] == "blended"
+
+
+def test_runtime_coerces_non_blended_mode_back_to_final(tmp_path, monkeypatch):
+    """Defence-in-depth: even if a hand-edited v2 config smuggles
+    ``active_mode="intrinsic_only"`` past the factory, the runtime
+    must coerce back to ``blended`` so it never reads the raw
+    offense-anchored VOR magnitude in the ``intrinsic`` channel as a
+    multiplier."""
+    cfg_path = tmp_path / "config" / "idp_calibration.json"
+    _write(
+        cfg_path,
+        {
+            "version": 2,
+            "active_mode": "intrinsic_only",  # intentionally malformed
+            "multipliers": {
+                "DL": {
+                    "position": "DL",
+                    "buckets": [
+                        {"label": "1-6", "intrinsic": 3.5, "market": 3.0, "final": 1.17, "count": 10},
+                    ],
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(
+        production, "production_config_path", lambda base=None: cfg_path
+    )
+    production.reset_cache()
+    # Reading ``intrinsic`` directly would return 3.5 (offense-anchored
+    # magnitude). Runtime coercion must instead read ``final`` → 1.17.
+    val = production.get_idp_bucket_multiplier("DL", 1)
+    assert abs(val - 1.17) < 1e-6, (
+        f"Runtime did not coerce intrinsic_only → blended; got {val}"
+    )

--- a/tests/idp_calibration/test_schema_version_gate.py
+++ b/tests/idp_calibration/test_schema_version_gate.py
@@ -1,0 +1,83 @@
+"""Production loader refuses pre-v2 configs.
+
+Schema v1 (the old engine) wrote ``final`` as a top-bucket-normalised
+VOR decay curve. Under v2 that same field carries a cross-league
+relativity ratio. Applying a v1 config under v2 semantics would
+mis-interpret the numbers, so the loader must decline to activate
+any config older than :data:`_MIN_SUPPORTED_VERSION` and the live
+post-pass must fall through to its no-op branch.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from src.idp_calibration import production
+
+
+def _write(path, blob: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(blob))
+
+
+def test_v1_config_is_refused_and_warns_once(tmp_path, monkeypatch, caplog):
+    cfg = tmp_path / "config" / "idp_calibration.json"
+    _write(
+        cfg,
+        {
+            "version": 1,
+            "active_mode": "blended",
+            "multipliers": {"final": {"DL": {"1-6": 0.5}}},
+        },
+    )
+    monkeypatch.setattr(
+        production, "production_config_path", lambda base=None: cfg
+    )
+    production.reset_cache()
+    with caplog.at_level(logging.WARNING, logger="src.idp_calibration.production"):
+        assert production.load_production_config() is None
+        # Repeated reads don't re-warn; the one-shot flag debounces noise.
+        assert production.load_production_config() is None
+    warnings = [r for r in caplog.records if "schema v1" in r.getMessage()]
+    assert len(warnings) == 1, f"expected 1 warning, got {len(warnings)}"
+    # Bucket lookup falls through to identity.
+    assert production.get_idp_bucket_multiplier("DL", 1) == 1.0
+
+
+def test_v0_missing_version_is_refused(tmp_path, monkeypatch):
+    cfg = tmp_path / "config" / "idp_calibration.json"
+    _write(
+        cfg,
+        {
+            # No version field ⇒ parsed as 0 ⇒ refused.
+            "active_mode": "blended",
+            "multipliers": {"final": {"DL": {"1-6": 0.5}}},
+        },
+    )
+    monkeypatch.setattr(
+        production, "production_config_path", lambda base=None: cfg
+    )
+    production.reset_cache()
+    assert production.load_production_config() is None
+
+
+def test_v2_config_loads_cleanly(tmp_path, monkeypatch):
+    cfg = tmp_path / "config" / "idp_calibration.json"
+    _write(
+        cfg,
+        {
+            "version": 2,
+            "active_mode": "blended",
+            "multipliers": {"final": {"DL": {"1-6": 0.5}}},
+        },
+    )
+    monkeypatch.setattr(
+        production, "production_config_path", lambda base=None: cfg
+    )
+    production.reset_cache()
+    cfg_loaded = production.load_production_config()
+    assert cfg_loaded is not None
+    assert cfg_loaded["version"] == 2
+    # And the real bucket lookup returns the configured value (0.5),
+    # NOT identity.
+    assert abs(production.get_idp_bucket_multiplier("DL", 1) - 0.5) < 1e-9

--- a/tests/idp_calibration/test_schema_version_gate.py
+++ b/tests/idp_calibration/test_schema_version_gate.py
@@ -163,6 +163,52 @@ def test_promotion_refuses_non_blended_mode_under_v2(tmp_path):
     assert cfg["active_mode"] == "blended"
 
 
+def test_stale_config_is_cached_without_reparsing(tmp_path, monkeypatch):
+    """Rollout-window performance guardrail: when the on-disk config is
+    schema-stale, the loader must cache that verdict by mtime so repeat
+    calls don't re-read and re-parse the JSON on every IDP multiplier
+    lookup. Exercised by stubbing ``load_json`` with a call counter
+    under a fixed mtime and verifying only one parse fires across many
+    multiplier calls.
+    """
+    from src.idp_calibration import production as prod_module
+
+    cfg = tmp_path / "config" / "idp_calibration.json"
+    _write(
+        cfg,
+        {
+            "version": 1,  # stale — will be rejected
+            "active_mode": "blended",
+            "multipliers": {"final": {"DL": {"1-6": 0.5}}},
+        },
+    )
+    monkeypatch.setattr(
+        production, "production_config_path", lambda base=None: cfg
+    )
+    production.reset_cache()
+
+    call_count = {"n": 0}
+    real_load_json = prod_module.load_json
+
+    def _counting_load_json(path):
+        call_count["n"] += 1
+        return real_load_json(path)
+
+    monkeypatch.setattr(prod_module, "load_json", _counting_load_json)
+
+    # Fire a bunch of lookups — all should resolve to identity (1.0)
+    # because the config is refused.
+    for _ in range(50):
+        assert production.get_idp_bucket_multiplier("DL", 1) == 1.0
+
+    # Only one disk read should have happened — the fast path must
+    # short-circuit on subsequent calls via the mtime-matched sentinel.
+    assert call_count["n"] == 1, (
+        f"Stale config re-parsed {call_count['n']}× across 50 lookups — "
+        "the stale-sentinel fast path regressed."
+    )
+
+
 def test_runtime_coerces_non_blended_mode_back_to_final(tmp_path, monkeypatch):
     """Defence-in-depth: even if a hand-edited v2 config smuggles
     ``active_mode="intrinsic_only"`` past the factory, the runtime

--- a/tests/idp_calibration/test_storage_promotion.py
+++ b/tests/idp_calibration/test_storage_promotion.py
@@ -101,17 +101,21 @@ def test_promote_writes_config_and_backs_up_prior(tmp_base):
     assert result1["backup_path"] is None
 
     # Second promote should move the prior config into backups dir.
+    # ``blended`` is the only applied mode under schema v2; the
+    # important invariant here is the backup + replace sequence, not
+    # the active_mode value. Non-blended modes would be refused at
+    # the promotion factory under v2 (see ``V2_VALID_MODES``).
     art2 = engine.run_analysis(
         "X", "Y", settings, stats_adapter_factory=lambda s: _StubAdapter()
     )
     storage.save_run(art2, base=tmp_base)
     result2 = promotion.promote_run(
-        art2["run_id"], active_mode="intrinsic_only", base=tmp_base
+        art2["run_id"], active_mode="blended", base=tmp_base
     )
     assert result2["backup_path"] is not None
     assert Path(result2["backup_path"]).exists()
     refreshed = json.loads(cfg_path.read_text())
-    assert refreshed["active_mode"] == "intrinsic_only"
+    assert refreshed["active_mode"] == "blended"
     assert refreshed["source_run_id"] == art2["run_id"]
 
 
@@ -201,6 +205,7 @@ def test_promote_refuses_run_with_no_bucket_data(tmp_base):
     empty_artifact = {
         "run_id": "empty_run",
         "generated_at": "2026-04-18T00:00:00Z",
+        "schema_version": 2,
         "settings": {"blend": {"intrinsic": 0.75, "market": 0.25}},
         "resolved_seasons": [],
         "multipliers": {

--- a/tests/idp_calibration/test_translation_anchors.py
+++ b/tests/idp_calibration/test_translation_anchors.py
@@ -34,7 +34,12 @@ def _three_bucket_series(test_seed, mine_seed):
     ]
 
 
-def test_build_multi_year_multipliers_produces_normalised_curves():
+def test_build_multi_year_multipliers_produces_offense_anchored_curves():
+    # Schema v2: ``intrinsic`` and ``market`` carry offense-anchored
+    # VOR (bucket_center / offense_anchor), and ``final`` is their
+    # cross-league ratio. Setup: both anchors set to 100 so ``intrinsic``
+    # is the bucket center expressed as a multiple of "one top-24 flex
+    # starter's VOR", and ``final`` is the mine/test VOR ratio.
     per_position = {
         "DL": {
             2025: _three_bucket_series(100, 120),
@@ -43,38 +48,83 @@ def test_build_multi_year_multipliers_produces_normalised_curves():
             2022: _three_bucket_series(85, 100),
         }
     }
-    year_weights = normalise_year_weights(DEFAULT_YEAR_WEIGHTS, seasons=[2022, 2023, 2024, 2025])
+    year_weights = normalise_year_weights(
+        DEFAULT_YEAR_WEIGHTS, seasons=[2022, 2023, 2024, 2025]
+    )
     multipliers = build_multi_year_multipliers(
-        per_position, year_weights=year_weights, blend=DEFAULT_BLEND
+        per_position,
+        year_weights=year_weights,
+        blend=DEFAULT_BLEND,
+        offense_anchor_mine=100.0,
+        offense_anchor_test=100.0,
     )
     dl = multipliers["DL"].buckets
-    assert dl[0].intrinsic == 1.0  # Top bucket normalised to 1.0
-    assert dl[1].intrinsic < dl[0].intrinsic
-    assert dl[2].intrinsic < dl[1].intrinsic
-    # Final blend must sit between intrinsic and market at each bucket.
+    # Bucket centers divided by anchor: top-bucket intrinsic =
+    # weighted-mean(mine_seed) / 100. For this fixture the bucket
+    # centers shrink with rank, so intrinsic monotonically decreases.
+    assert dl[0].intrinsic > dl[1].intrinsic > dl[2].intrinsic
+    assert dl[0].market > dl[1].market > dl[2].market
+    # Every final is the offense-anchored ratio. With both anchors ==
+    # 100 it collapses to mine_center / test_center.
     for b in dl:
-        lo = min(b.intrinsic, b.market)
-        hi = max(b.intrinsic, b.market)
-        assert lo - 1e-6 <= b.final <= hi + 1e-6
+        expected = b.intrinsic / b.market
+        assert abs(b.final - expected) < 1e-6
 
 
-def test_anchors_are_non_increasing():
+def test_final_lifts_above_one_when_my_league_values_a_bucket_more():
+    # Setup: both sides agree on the top bucket but my league scores
+    # rank 7-12 much more generously (edge-premium scoring). The
+    # relativity ratio for 7-12 must climb above 1.0 — this is the
+    # exact behaviour the schema-v1 engine could not produce.
     per_position = {
-        "LB": {
-            2025: _three_bucket_series(100, 120),
-            2024: _three_bucket_series(90, 110),
+        "DL": {
+            2025: [
+                _bucket("1-6", 1, 6, 100.0, 100.0),
+                _bucket("7-12", 7, 12, 40.0, 80.0),  # my-league doubles the bucket
+            ]
         }
     }
     multipliers = build_multi_year_multipliers(
         per_position,
-        year_weights={2025: 0.6, 2024: 0.4},
+        year_weights={2025: 1.0},
         blend=DEFAULT_BLEND,
+        offense_anchor_mine=100.0,
+        offense_anchor_test=100.0,
+    )
+    dl = multipliers["DL"].buckets
+    assert abs(dl[0].final - 1.0) < 1e-6  # agreeing top bucket → 1.0
+    assert dl[1].final > 1.5  # my-league 80 / test 40 = 2.0 → lifted
+
+
+def test_anchors_preserve_relativity_signal():
+    # The v2 anchor smoothing pass must NOT force monotone descent —
+    # otherwise a lifted mid-rank bucket (final > top) would get
+    # clamped down to the top bucket value and destroy the signal.
+    per_position = {
+        "LB": {
+            2025: [
+                _bucket("1-6", 1, 6, 100.0, 100.0),
+                _bucket("7-12", 7, 12, 40.0, 80.0),  # lifted bucket
+                _bucket("13-24", 13, 24, 25.0, 25.0),
+            ]
+        }
+    }
+    multipliers = build_multi_year_multipliers(
+        per_position,
+        year_weights={2025: 1.0},
+        blend=DEFAULT_BLEND,
+        offense_anchor_mine=100.0,
+        offense_anchor_test=100.0,
     )
     anchors = build_all_anchors(multipliers)
-    for kind in ("intrinsic", "market", "final"):
-        points = anchors["LB"][kind]
-        for a, b in zip(points, points[1:]):
-            assert b.value <= a.value + 1e-9, f"{kind} violates monotonicity"
+    # rank=12 sits inside the 7-12 bucket where final ≈ 2.0. Rank=1
+    # sits in the 1-6 bucket where final ≈ 1.0. The v1 code would have
+    # forced rank=12 <= rank=1 (≈1.0) and lost the lift signal.
+    pts = {p.rank: p.value for p in anchors["LB"]["final"]}
+    assert pts[12] > 1.5, "7-12 lift was flattened by monotone smoothing"
+    # Floor is still respected (no negative/zero values).
+    for v in pts.values():
+        assert v >= 0.05 - 1e-9
 
 
 def test_bucket_labels_aggregate_across_seasons_not_just_first():
@@ -128,59 +178,81 @@ def _series(*pairs, count=10):
     return [_bucket(lbl, lo, hi, tv, mv, count=count) for lbl, lo, hi, tv, mv in pairs]
 
 
-def test_sub_replacement_buckets_are_floored_not_negative():
-    # Reproduces the real-run case the user showed: DL buckets 37-60
-    # and 61-100 have negative VOR centers, which under raw
-    # normalisation produce negative multipliers. The clamp must
-    # floor each of intrinsic/market/final at 0.05 so the live
-    # pipeline never multiplies a positive rankDerivedValue by a
-    # negative number.
+def test_sub_replacement_buckets_fall_through_to_identity():
+    # v2 behaviour: sub-replacement buckets (center <= 0 on either side)
+    # can't produce a meaningful cross-league ratio, so they fall
+    # through to ``final=1.0`` (identity). The ``intrinsic`` /
+    # ``market`` display fields still surface the raw offense-anchored
+    # VOR, including negatives, for audit.
     series = _series(
         ("1-6", 1, 6, 100.0, 120.0),
         ("7-12", 7, 12, 50.0, 60.0),
         ("13-24", 13, 24, 20.0, 25.0),
-        ("25-36", 25, 36, 0.0, 5.0),
-        ("37-60", 37, 60, -30.0, -20.0),       # sub-replacement
-        ("61-100", 61, 100, -55.0, -45.0),     # deep sub-replacement
+        ("25-36", 25, 36, 0.0, 5.0),                # zero bucket on test side
+        ("37-60", 37, 60, -30.0, -20.0),            # sub-replacement both sides
+        ("61-100", 61, 100, -55.0, -45.0),          # deep sub-replacement
     )
     per_position = {"DL": {2025: series}}
     multipliers = build_multi_year_multipliers(
         per_position,
         year_weights={2025: 1.0},
         blend=DEFAULT_BLEND,
+        offense_anchor_mine=100.0,
+        offense_anchor_test=100.0,
     )
     dl = multipliers["DL"].buckets
-    # Every emitted multiplier must be in [0.05, 1.0] on every
-    # channel (intrinsic, market, final). Previously 37-60 and
-    # 61-100 were negative on all three.
-    for b in dl:
-        for channel in ("intrinsic", "market", "final"):
-            val = getattr(b, channel)
-            assert 0.05 - 1e-9 <= val <= 1.0 + 1e-9, (
-                f"{b.label} {channel}={val} outside [0.05, 1.0]"
-            )
-    # Top bucket still equals 1.0 (normalisation anchor).
-    assert abs(dl[0].intrinsic - 1.0) < 1e-6
-    assert abs(dl[0].market - 1.0) < 1e-6
-    assert abs(dl[0].final - 1.0) < 1e-6
-    # Sub-replacement buckets are floored, not 0 and not negative.
-    for bucket in dl[-2:]:
-        assert abs(bucket.intrinsic - 0.05) < 1e-9
-        assert abs(bucket.market - 0.05) < 1e-9
-        assert abs(bucket.final - 0.05) < 1e-9
+    # Bucket 1-6 and 7-12 and 13-24 have positive VOR on both sides
+    # → real ratio.
+    for lbl in ("1-6", "7-12", "13-24"):
+        b = next(x for x in dl if x.label == lbl)
+        assert b.final != 1.0 or abs(b.intrinsic - b.market) < 1e-9
+    # Bucket 25-36 and deeper: at least one side is ≤ 0, so ``final``
+    # falls through to 1.0 rather than producing a negative multiplier.
+    for lbl in ("25-36", "37-60", "61-100"):
+        b = next(x for x in dl if x.label == lbl)
+        assert abs(b.final - 1.0) < 1e-9, (
+            f"{lbl} final={b.final} should be identity under sub-replacement"
+        )
 
 
-def test_custom_multiplier_floor_propagates():
-    # If a caller raises the floor (say 0.10) the clamp applies at
-    # that level end-to-end.
+def test_missing_offense_anchor_falls_through_to_identity():
+    # If the engine couldn't compute a usable offense anchor on either
+    # side (e.g. offense universe was empty every season), every
+    # bucket's final must default to 1.0 so the live pipeline runs as
+    # a no-op rather than applying garbage ratios.
     series = _series(
         ("1-6", 1, 6, 100.0, 120.0),
-        ("7-12", 7, 12, -50.0, -40.0),  # immediately sub-replacement
+        ("7-12", 7, 12, 50.0, 60.0),
     )
     multipliers = build_multi_year_multipliers(
         {"DL": {2025: series}},
         year_weights={2025: 1.0},
         blend=DEFAULT_BLEND,
-        multiplier_floor=0.10,
+        offense_anchor_mine=0.0,  # missing anchor
+        offense_anchor_test=0.0,
     )
-    assert abs(multipliers["DL"].buckets[1].final - 0.10) < 1e-9
+    for b in multipliers["DL"].buckets:
+        assert abs(b.final - 1.0) < 1e-9
+
+
+def test_relativity_clamped_to_engineering_bounds():
+    # Pathologically large disparity (10× on one side) must clamp to
+    # the ``[0.25, 4.0]`` engineering band so a single weird bucket
+    # can't ship an absurd multiplier to production.
+    series = _series(
+        ("1-6", 1, 6, 100.0, 100.0),
+        ("7-12", 7, 12, 1.0, 100.0),    # test says ~nothing, mine says a lot
+        ("13-24", 13, 24, 100.0, 1.0),  # mirror case
+    )
+    multipliers = build_multi_year_multipliers(
+        {"DL": {2025: series}},
+        year_weights={2025: 1.0},
+        blend=DEFAULT_BLEND,
+        offense_anchor_mine=100.0,
+        offense_anchor_test=100.0,
+    )
+    dl = multipliers["DL"].buckets
+    lifted = next(b for b in dl if b.label == "7-12")
+    cut = next(b for b in dl if b.label == "13-24")
+    assert abs(lifted.final - 4.0) < 1e-6  # pinned at ceiling
+    assert abs(cut.final - 0.25) < 1e-6    # pinned at floor

--- a/tests/scripts/test_sleeper_dual_position.py
+++ b/tests/scripts/test_sleeper_dual_position.py
@@ -1,0 +1,73 @@
+"""Dynasty Scraper Sleeper-side dual-position resolution.
+
+Sleeper exposes ``fantasy_positions`` as a list of eligible slots;
+``position`` is just the primary. Edge rushers who also carry LB
+eligibility (Parsons, Burns, Crosby) come through Sleeper as
+``position="LB"`` with ``fantasy_positions=["DL","LB"]``. We want
+those rows collapsed to DL in the position_map so they don't
+compete in the off-ball LB bucket downstream.
+
+Single-position rows and pure-offense rows must pass through
+unchanged.
+"""
+from __future__ import annotations
+
+from src.utils.name_clean import resolve_idp_position
+
+
+def _resolve(raw_pos: str, fantasy_positions: list[str] | None) -> str:
+    """Replicate the Dynasty Scraper sleeper-ingest block.
+
+    We don't import Dynasty Scraper.py directly (it has a top-level
+    ``import playwright`` that's not available in the CI image), so
+    this helper mirrors the same condition the scraper applies.
+    """
+    fp_list = fantasy_positions if isinstance(fantasy_positions, list) else None
+    pos = raw_pos
+    if fp_list and len(fp_list) >= 2:
+        resolved_family = resolve_idp_position(fp_list)
+        if resolved_family in {"DL", "DB", "LB"}:
+            pos = resolved_family
+    return pos
+
+
+def test_dl_plus_lb_collapses_to_dl():
+    # Parsons case: Sleeper primary = "LB", fantasy_positions =
+    # ["DL","LB"]. Must resolve to DL so he gets bucketed with
+    # pass-rushers, not off-ball LBs.
+    assert _resolve("LB", ["DL", "LB"]) == "DL"
+
+
+def test_db_plus_lb_collapses_to_db():
+    # Box safety case: LB + S eligibility should fall on DB, not LB,
+    # because DB outranks LB in the shared priority ladder.
+    assert _resolve("LB", ["LB", "S"]) == "DB"
+
+
+def test_exclusive_lb_stays_lb():
+    # Pure off-ball LB — no DL/DB co-eligibility — stays LB.
+    assert _resolve("LB", ["LB"]) == "LB"
+
+
+def test_single_position_passes_through():
+    # Single-entry fantasy_positions list: we do NOT call
+    # resolve_idp_position (it would collapse "CB" → "DB" and
+    # discard the fine-grained token). Row stays as the raw position.
+    assert _resolve("CB", ["CB"]) == "CB"
+    assert _resolve("DE", ["DE"]) == "DE"
+
+
+def test_offense_dual_position_passes_through():
+    # Offense flex eligibility (e.g. "RB,WR,FLEX") must not be
+    # collapsed to an IDP family just because the list has 2+
+    # entries. ``resolve_idp_position`` returns "" for non-IDP
+    # rosters and the row stays as the primary.
+    assert _resolve("RB", ["RB", "FLEX"]) == "RB"
+    assert _resolve("WR", ["WR", "TE"]) == "WR"
+
+
+def test_missing_fantasy_positions_passes_through():
+    # Older Sleeper snapshots may not supply fantasy_positions at
+    # all. Behaviour falls back to the raw primary position.
+    assert _resolve("LB", None) == "LB"
+    assert _resolve("QB", None) == "QB"


### PR DESCRIPTION
## Why

The existing IDP calibration engine could only push IDP values **down**, never up. Every bucket multiplier is bounded to `[0.05, 1.0]` by construction: each league's VOR gets normalised against its own top bucket (so the top is always 1.0) and then the two normalised curves are convex-blended. The output is a "VOR decay shape," not the cross-league relativity the feature was pitched as.

That's why Micah Parsons was sitting at rank #453 with a `-1,576` calibration delta: the LB curve's 7-12 and 13-24 buckets cut him ~58% even though his league specifically values edge rushers more than the test league does. The current math has no way to express "this bucket is worth more in my league."

Separately, Parsons was ending up in the LB pool at all because the scraper reads Sleeper's primary `position` (`"LB"` for dual-eligible edge rushers) and ignores `fantasy_positions` (`["DL","LB"]`). Every edge rusher Sleeper tags as OLB has been competing against off-ball tackle-monster LBs in the bucket table.

## What

### Calibration math rewrite (schema v2)

Replaces `src/idp_calibration/translation.py::compute_position_multipliers` with an offense-anchored cross-league ratio:

```
my_norm   = bucket_center_mine / offense_anchor_mine
test_norm = bucket_center_test / offense_anchor_test
final     = my_norm / test_norm        # the applied multiplier
```

- `offense_anchor_*` = mean VOR of the top-24 RB+WR under each league's scoring (new helper `vor.compute_offense_anchor_vor`). Top-24 flex pool is robust across SF / non-SF and TE-premium variants.
- `final` is clamped to `[0.25, 4.0]`. No monotone-descent enforcement — lifted mid-rank buckets survive end-to-end.
- `intrinsic` / `market` display fields now carry each league's offense-anchored VOR (not top-bucket-normalised); `final` is their ratio.
- Sub-replacement buckets (center ≤ 0 on either side) fall through to `final = 1.0` instead of producing a negative multiplier.
- Missing anchors ⇒ every bucket collapses to identity so the live pipeline runs as a no-op rather than applying garbage.

### `family_scale` becomes a display-only diagnostic

The per-bucket ratio already captures class-level relativity, so multiplying by `family_scale` on top would double-count. `promotion.build_production_config` now pins `family_scale = {1.0, 1.0, 1.0}` in the promoted config; the lab's computed value is preserved under `family_scale_diagnostic` for UI display.

### Schema version gate

`production.load_production_config` refuses any config with `version < 2`. A pre-v2 config (old-semantics bucket values) would be catastrophically mis-interpreted under v2, so the loader logs a one-shot warning and leaves calibration as a strict no-op until the lab re-promotes a fresh run on the new engine. `promotion.promote_run` writes `version = 2` going forward.

### Sleeper dual-position fix (`Dynasty Scraper.py`)

The Sleeper ingest block now checks `fantasy_positions` (when it has 2+ entries) and runs it through the shared `src.utils.name_clean.resolve_idp_position` helper to collapse dual-eligible IDPs via the DL > DB > LB priority ladder. So `position=LB, fantasy_positions=["DL","LB"]` (Parsons) lands as `DL` in the position_map. Single-position rows and pure-offense rows pass through untouched.

## Test plan

- [x] `python -m pytest tests/idp_calibration/` — 108 pass (includes new coverage for v2 ratio math, sub-replacement fall-through, missing-anchor fall-through, engineering bounds, anchor non-monotonicity preservation, and the schema version gate)
- [x] `python -m pytest tests/scripts/test_sleeper_dual_position.py` — 6 pass (Parsons DL+LB → DL, DB+LB → DB, pure LB stays LB, single-position pass-through, offense pass-through, missing fantasy_positions fallback)
- [x] `python -m pytest tests/ -q` — full repo suite: 1674 pass, 25 skipped, 0 failed

## Rollout notes

- Any currently-promoted `config/idp_calibration.json` on the VPS will be refused at load (v1 → refused with warning), so IDP calibration will be a no-op until the lab re-promotes a run on the v2 engine. That's intentional: applying v1 values under v2 semantics is worse than running uncalibrated.
- Re-promotion steps: run the lab on the current engine → inspect the new relativity curves (they'll now be two-sided, sitting around 1.0 with real lifts and cuts) → promote.
- Parsons should re-appear in the DL pool on the next scraper run; his relativity multiplier should now reflect whether your league values top-pass-rusher-DLs more or less than the test league does, instead of being unconditionally cut.

https://claude.ai/code/session_019MgmMeyKczA2jFZd22Rcky