### PR TITLE
IDP calibration: unify /production and /status on the schema-gated loader

### DIFF
--- a/src/idp_calibration/api.py
+++ b/src/idp_calibration/api.py
@@ -17,10 +17,9 @@ from .promotion import (
     StaleArtifactSchemaError,
     V2_VALID_MODES,
     VALID_MODES,
-    load_production,
     promote_run,
 )
-from .production import is_promoted
+from .production import promoted_state
 from .storage import delete_all_runs, delete_run, get_latest, list_runs, load_run, save_run
 
 
@@ -134,18 +133,33 @@ def promote(body: dict[str, Any] | None, *, base: Path | None = None) -> tuple[i
 
 
 def production(*, base: Path | None = None) -> tuple[int, dict[str, Any]]:
-    cfg = load_production(base)
-    if not cfg:
-        return 200, {"ok": True, "present": False, "config": None}
-    return 200, {"ok": True, "present": True, "config": cfg}
+    # Routes through the schema-aware ``promoted_state`` so this
+    # endpoint and ``/status`` never disagree about whether
+    # calibration is live. When a schema-stale config sits on disk
+    # we surface that explicitly (``stale=true``, ``stale_version=N``)
+    # so operators can see why ``present`` is ``false`` despite a
+    # file being present.
+    state = promoted_state(base)
+    return 200, {
+        "ok": True,
+        "present": state["present"],
+        "stale": state["stale"],
+        "stale_version": state["stale_version"],
+        "required_version": state["required_version"],
+        "config": state["config"],
+    }
 
 
 def status(*, base: Path | None = None) -> tuple[int, dict[str, Any]]:
     latest = get_latest(base=base)
+    state = promoted_state(base)
     return 200, {
         "ok": True,
         "latest_run_id": (latest or {}).get("run_id"),
         "latest_generated_at": (latest or {}).get("generated_at"),
-        "production_present": is_promoted(base=base),
+        "production_present": state["present"],
+        "production_stale": state["stale"],
+        "production_stale_version": state["stale_version"],
+        "required_schema_version": state["required_version"],
         "valid_modes": list(VALID_MODES),
     }

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -29,7 +29,11 @@ from .promotion import production_config_path
 _STALE_SENTINEL: object = object()
 
 _lock = threading.Lock()
-_cache: dict[str, Any] = {"mtime": None, "config": None}
+# ``stale_version`` is cached alongside the sentinel so
+# :func:`promoted_state` can surface the on-disk schema version to
+# operators without re-reading the file.  ``None`` when the config
+# is absent or actively applied.
+_cache: dict[str, Any] = {"mtime": None, "config": None, "stale_version": None}
 
 # Minimum config version the runtime will apply. Configs written by the
 # v1 engine encoded ``final`` as a top-bucket-normalised VOR decay
@@ -50,6 +54,7 @@ def _load_if_stale(base: Path | None = None) -> dict[str, Any] | None:
         with _lock:
             _cache["mtime"] = None
             _cache["config"] = None
+            _cache["stale_version"] = None
         _stale_version_warned = False
         return None
     mtime = path.stat().st_mtime
@@ -85,15 +90,18 @@ def _load_if_stale(base: Path | None = None) -> dict[str, Any] | None:
                     _stale_version_warned = True
                 _cache["mtime"] = mtime
                 _cache["config"] = _STALE_SENTINEL
+                _cache["stale_version"] = cfg_version
                 return None
             _stale_version_warned = False
             _cache["mtime"] = mtime
             _cache["config"] = data
+            _cache["stale_version"] = None
             return data
         # Non-dict JSON (corrupt file) — treat as stale so we don't
         # re-read and parse every call.
         _cache["mtime"] = mtime
         _cache["config"] = _STALE_SENTINEL
+        _cache["stale_version"] = 0
         return None
 
 
@@ -103,12 +111,69 @@ def reset_cache() -> None:
     with _lock:
         _cache["mtime"] = None
         _cache["config"] = None
+        _cache["stale_version"] = None
     _stale_version_warned = False
 
 
 def load_production_config(base: Path | None = None) -> dict[str, Any] | None:
     """Public read: current promoted config, or ``None`` if absent."""
     return _load_if_stale(base)
+
+
+def promoted_state(base: Path | None = None) -> dict[str, Any]:
+    """Structured snapshot of the promoted-config state.
+
+    Single source of truth for every operator-facing endpoint
+    (``/api/idp-calibration/production`` and ``/status``), so both
+    surfaces can't contradict each other about whether calibration
+    is live — a real concern during the rollout window where a
+    schema-stale config may sit on disk while the runtime ignores it.
+
+    Fields:
+
+    * ``present`` — the live pipeline is applying this config right
+      now. ``True`` only when the file exists **and** passes the
+      schema-version gate.
+    * ``stale`` — a file exists on disk but the loader refused it
+      (version below :data:`_MIN_SUPPORTED_VERSION` or corrupt JSON).
+      When ``stale`` is ``True``, ``present`` is ``False``.
+    * ``stale_version`` — the on-disk schema version when ``stale``
+      is ``True``; ``None`` otherwise. Helpful for operators to see
+      "you're on v1, need v2" at a glance.
+    * ``required_version`` — the minimum schema version the runtime
+      accepts. Constant per build.
+    * ``config`` — the active config dict when ``present`` is
+      ``True``; ``None`` otherwise.
+    """
+    path = production_config_path(base)
+    if not path.exists():
+        return {
+            "present": False,
+            "stale": False,
+            "stale_version": None,
+            "required_version": _MIN_SUPPORTED_VERSION,
+            "config": None,
+        }
+    cfg = _load_if_stale(base)
+    if cfg is not None:
+        return {
+            "present": True,
+            "stale": False,
+            "stale_version": None,
+            "required_version": _MIN_SUPPORTED_VERSION,
+            "config": cfg,
+        }
+    # File is on disk but was rejected. Surface the cached version
+    # so operators can see why without another read.
+    with _lock:
+        stale_version = _cache["stale_version"]
+    return {
+        "present": False,
+        "stale": True,
+        "stale_version": stale_version,
+        "required_version": _MIN_SUPPORTED_VERSION,
+        "config": None,
+    }
 
 
 def _position_has_real_data(position_block: Any) -> bool:

--- a/src/idp_calibration/production.py
+++ b/src/idp_calibration/production.py
@@ -144,17 +144,21 @@ def promoted_state(base: Path | None = None) -> dict[str, Any]:
       accepts. Constant per build.
     * ``config`` — the active config dict when ``present`` is
       ``True``; ``None`` otherwise.
+
+    Always routes through :func:`_load_if_stale` so its cache-
+    management branches (file-missing clears the cache; file-present
+    refreshes on mtime change; stale-version stamps the sentinel)
+    run on every call. A short-circuit on ``not path.exists()`` would
+    skip the reset path and leave stale cache entries alive across a
+    delete/restore cycle that preserves the original mtime.
     """
-    path = production_config_path(base)
-    if not path.exists():
-        return {
-            "present": False,
-            "stale": False,
-            "stale_version": None,
-            "required_version": _MIN_SUPPORTED_VERSION,
-            "config": None,
-        }
     cfg = _load_if_stale(base)
+    # Snapshot the cache state once under the lock so the
+    # "absent vs stale" branching below stays consistent even if a
+    # concurrent thread mutates the cache in between.
+    with _lock:
+        cached = _cache["config"]
+        stale_version = _cache["stale_version"]
     if cfg is not None:
         return {
             "present": True,
@@ -163,14 +167,22 @@ def promoted_state(base: Path | None = None) -> dict[str, Any]:
             "required_version": _MIN_SUPPORTED_VERSION,
             "config": cfg,
         }
-    # File is on disk but was rejected. Surface the cached version
-    # so operators can see why without another read.
-    with _lock:
-        stale_version = _cache["stale_version"]
+    if cached is _STALE_SENTINEL:
+        # File is on disk but the loader refused it. ``stale_version``
+        # was cached alongside the sentinel so we can surface it
+        # without a second ``load_json`` call.
+        return {
+            "present": False,
+            "stale": True,
+            "stale_version": stale_version,
+            "required_version": _MIN_SUPPORTED_VERSION,
+            "config": None,
+        }
+    # No config on disk (or the cache was reset after a delete).
     return {
         "present": False,
-        "stale": True,
-        "stale_version": stale_version,
+        "stale": False,
+        "stale_version": None,
         "required_version": _MIN_SUPPORTED_VERSION,
         "config": None,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,16 +23,24 @@ _NEUTRAL_PATH = Path(
 ) / "idp_calibration.json"
 
 
-def _neutral_config_path(base: Path | None = None) -> Path:  # noqa: ARG001
+# Stash the real implementation so calibration-specific tests can
+# opt back in by passing ``base=tmp_path`` to their API calls, and so
+# the wrapper below can delegate to it when a base is explicit.
+_production._original_production_config_path = _production.production_config_path
+
+
+def _neutral_config_path(base: Path | None = None) -> Path:
+    # Honour an explicit ``base`` so opt-in calibration tests that
+    # pass ``base=tmp_path`` (e.g. ``tests/idp_calibration/test_api.py``)
+    # still hit their own sandbox. Without an explicit base we fall
+    # through to the neutral temp file so unrelated tests never read
+    # any promoted config that happens to live at
+    # ``config/idp_calibration.json`` on the dev machine.
+    if base is not None:
+        return _production._original_production_config_path(base)
     return _NEUTRAL_PATH
 
 
-# Stash the real implementation so the calibration-specific tests can
-# restore it via monkeypatch if they need to hit a specific config
-# file. In practice those tests also monkeypatch this attribute, which
-# layers on top of the neutral override without us needing to expose
-# a switch.
-_production._original_production_config_path = _production.production_config_path
 _production.production_config_path = _neutral_config_path
 _production.reset_cache()
 

--- a/tests/idp_calibration/test_api_loader_parity.py
+++ b/tests/idp_calibration/test_api_loader_parity.py
@@ -99,6 +99,50 @@ def test_v1_config_both_endpoints_report_stale(tmp_base):
     assert stat["required_schema_version"] == 2
 
 
+def test_delete_then_restore_same_mtime_forces_reread(tmp_base):
+    """Regression: ``promoted_state`` previously short-circuited on
+    ``not path.exists()`` without resetting the cache. If the file
+    was then restored with the same mtime (preserved-timestamp
+    restore or coarse filesystem mtime), the mtime fast-path would
+    reuse the old cached config.
+
+    With the short-circuit removed, the file-missing branch inside
+    ``_load_if_stale`` clears the cache, so even a same-mtime
+    restore triggers a fresh disk read.
+    """
+    import os
+
+    cfg = tmp_base / "config" / "idp_calibration.json"
+    _write_config(cfg, version=2)
+    original_mtime = cfg.stat().st_mtime
+
+    # Prime the cache with the v2 config.
+    _, prod = api.production(base=tmp_base)
+    assert prod["present"] is True
+    assert prod["config"]["version"] == 2
+
+    # Simulate a delete/restore cycle that preserves mtime.
+    cfg.unlink()
+    _, prod_missing = api.production(base=tmp_base)
+    assert prod_missing["present"] is False
+    assert prod_missing["stale"] is False
+
+    # Restore a DIFFERENT config at the SAME mtime. If the cache
+    # still held the old config, the mtime fast-path would replay
+    # it; with the file-missing cache-reset, the loader re-reads.
+    _write_config(cfg, version=1)  # v1 → would be refused as stale
+    os.utime(cfg, (original_mtime, original_mtime))
+    assert cfg.stat().st_mtime == original_mtime
+
+    _, prod_restored = api.production(base=tmp_base)
+    assert prod_restored["present"] is False
+    assert prod_restored["stale"] is True
+    assert prod_restored["stale_version"] == 1, (
+        "Same-mtime restore reused the v2 cache entry instead of "
+        "re-reading the v1 file — cache-reset regression."
+    )
+
+
 def test_missing_version_treated_as_stale_v0(tmp_base):
     """A config with no version field (hand-edited or very old) gets
     parsed as v0 and surfaced as stale with stale_version=0."""

--- a/tests/idp_calibration/test_api_loader_parity.py
+++ b/tests/idp_calibration/test_api_loader_parity.py
@@ -1,0 +1,125 @@
+"""Pin: ``/production`` and ``/status`` report a consistent view.
+
+Before schema v2, ``api.production`` went through
+``promotion.load_production`` (raw JSON, no gate) while ``api.status``
+went through ``production.is_promoted`` (schema-gated via
+``_load_if_stale``).  During the v1→v2 rollout window a legacy
+``config/idp_calibration.json`` could sit on disk and produce
+contradictory signals — ``/production`` would report ``present: true``
+while ``/status`` reported ``production_present: false``.
+
+Both endpoints now route through ``production.promoted_state`` so
+they read the same thing, and when a file exists but fails the schema
+gate both endpoints surface an explicit ``stale`` flag for operators.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.idp_calibration import api, production
+
+
+def _write_config(path, version: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": version,
+                "active_mode": "blended",
+                "multipliers": {
+                    "DL": {
+                        "position": "DL",
+                        "buckets": [
+                            {"label": "1-6", "intrinsic": 1.0, "market": 1.0, "final": 1.0, "count": 10},
+                        ],
+                    },
+                },
+                "anchors": {},
+            }
+        )
+    )
+
+
+@pytest.fixture
+def tmp_base(tmp_path):
+    production.reset_cache()
+    yield tmp_path
+    production.reset_cache()
+
+
+def test_no_config_both_endpoints_agree(tmp_base):
+    """No config on disk → both endpoints report not-present,
+    not-stale."""
+    _, prod = api.production(base=tmp_base)
+    _, stat = api.status(base=tmp_base)
+    assert prod["present"] is False
+    assert prod["stale"] is False
+    assert stat["production_present"] is False
+    assert stat["production_stale"] is False
+
+
+def test_v2_config_both_endpoints_report_active(tmp_base):
+    """Fresh v2 config → both endpoints report present, not-stale."""
+    cfg = tmp_base / "config" / "idp_calibration.json"
+    _write_config(cfg, version=2)
+    _, prod = api.production(base=tmp_base)
+    _, stat = api.status(base=tmp_base)
+    assert prod["present"] is True
+    assert prod["stale"] is False
+    assert stat["production_present"] is True
+    assert stat["production_stale"] is False
+    # And /production returns the actual config.
+    assert prod["config"]["version"] == 2
+
+
+def test_v1_config_both_endpoints_report_stale(tmp_base):
+    """Pre-schema-v2 config on disk → /production no longer reports
+    ``present: true`` (which would contradict /status); both endpoints
+    surface an explicit ``stale`` signal with the on-disk version.
+    """
+    cfg = tmp_base / "config" / "idp_calibration.json"
+    _write_config(cfg, version=1)
+
+    _, prod = api.production(base=tmp_base)
+    _, stat = api.status(base=tmp_base)
+
+    # /production: not applied, flagged as stale, version surfaced.
+    assert prod["present"] is False
+    assert prod["stale"] is True
+    assert prod["stale_version"] == 1
+    assert prod["required_version"] == 2
+    assert prod["config"] is None
+
+    # /status: agrees.
+    assert stat["production_present"] is False
+    assert stat["production_stale"] is True
+    assert stat["production_stale_version"] == 1
+    assert stat["required_schema_version"] == 2
+
+
+def test_missing_version_treated_as_stale_v0(tmp_base):
+    """A config with no version field (hand-edited or very old) gets
+    parsed as v0 and surfaced as stale with stale_version=0."""
+    cfg = tmp_base / "config" / "idp_calibration.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        json.dumps(
+            {
+                "active_mode": "blended",
+                "multipliers": {},
+                "anchors": {},
+            }
+        )
+    )
+
+    _, prod = api.production(base=tmp_base)
+    _, stat = api.status(base=tmp_base)
+
+    assert prod["present"] is False
+    assert prod["stale"] is True
+    assert prod["stale_version"] == 0
+    assert stat["production_present"] is False
+    assert stat["production_stale"] is True
+    assert stat["production_stale_version"] == 0


### PR DESCRIPTION
## Why

Follow-up to [PR #196](https://github.com/jasonleetucker-code/riskittogetthebrisket/pull/196). Codex's final review flagged that `api.production()` was still reading the promoted config through `promotion.load_production` (raw JSON, no schema gate) while `api.status()` read through `production.is_promoted` (schema-gated via `_load_if_stale`). During the v1→v2 rollout window — which is exactly where we are right now — a legacy `config/idp_calibration.json` on disk would make `/production` report `present: true` while `/status` reports `production_present: false`. Operators get contradictory signals about whether calibration is actually live.

## What

**One source of truth.** New `production.promoted_state(base)` returns a structured snapshot every operator-facing endpoint can share:

```python
{
  "present": bool,             # live pipeline is applying this config
  "stale": bool,               # file exists on disk but loader refused it
  "stale_version": int | None, # on-disk schema version when stale (e.g. 1)
  "required_version": int,     # minimum schema version the runtime accepts
  "config": dict | None,       # the active config, else None
}
```

- `api.production()` + `api.status()` both route through it, so their views can't disagree.
- Payload gains a `stale` / `stale_version` pair so operators can see *why* `present` is `false` despite a file being present. "You have v1 on disk, need v2" at a glance, distinct from "no config at all."
- The cache stores `stale_version` alongside the stale sentinel, so `promoted_state` surfaces the on-disk version without a second `load_json` call.

**Test harness fix.** `tests/conftest.py`'s neutral-path override previously ignored the `base` argument entirely. That worked for the old `api.production` (which went through `promotion.*`, unpatched) but broke when I unified the path. The override now honours an explicit `base` so opt-in calibration tests that pass `base=tmp_path` reach their sandbox regardless of which module resolves the config path.

## Test plan

- [x] `python -m pytest tests/idp_calibration/` — 124 pass (includes new `test_api_loader_parity.py` pinning all four states: no config / fresh v2 / stale v1 / missing-version treated as v0)
- [x] `python -m pytest tests/` — 1687 pass, 25 skipped, 0 failed across the whole repo

## Rollout impact

This PR does not change the runtime multiplier path — it only tightens the operator-observability contract. With this merged + the VPS re-promoted on v2, `/production` and `/status` stay in lockstep. While the VPS still has the v1 config, both endpoints will now say `present: false, stale: true, stale_version: 1, required_version: 2` — exactly what we want to see.

https://claude.ai/code/session_019MgmMeyKczA2jFZd22Rcky