### PR TITLE
Market-anchor corridor clamp (P90 drift band)

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3425,6 +3425,167 @@ def _parse_pick_tier(name: str) -> tuple[int, str, int] | None:
         return None
 
 
+# ── Market-anchor corridor clamp ────────────────────────────────────────
+# Designated market anchor sources per asset class.  KTC and IDPTC are
+# the deepest retail value boards, so they define "market reality" for
+# each universe.  Other sources can move the final value within the
+# corridor — they just can't pull a player into a rank that contradicts
+# market at a pathological level.
+_MARKET_ANCHOR_BY_ASSET_CLASS: dict[str, str] = {
+    "offense": "ktc",
+    "idp": "idpTradeCalc",
+}
+
+# Percentile at which we declare a drift "too extreme" and clamp it.
+# 0.90 means: the worst 10% of drifts (relative to the market anchor)
+# inside each confidence bucket get pulled back to the edge of that
+# bucket's natural drift distribution.  Everything inside the top 90%
+# of natural drifts is untouched.  Chosen over an arbitrary fixed
+# percent so the band width adapts as the board's source set evolves.
+_MARKET_CORRIDOR_PERCENTILE: float = 0.90
+# Minimum sample per confidence bucket before we trust its own P90;
+# below this we fall back to the overall board P90 so a tiny bucket
+# can't get an unrepresentative band.
+_MARKET_CORRIDOR_MIN_BUCKET_N: int = 30
+
+
+def _market_anchor_value_for_row(row: dict[str, Any]) -> float | None:
+    """Return the market-anchor source value for a row, or None if
+    the row doesn't have one (e.g. rookie pre-NFL-draft without a KTC
+    value, or a pick).  Used by the corridor clamp to pick an anchor
+    per asset class."""
+    sites = row.get("canonicalSiteValues")
+    if not isinstance(sites, dict):
+        return None
+    asset_class = str(row.get("assetClass") or "")
+    source_key = _MARKET_ANCHOR_BY_ASSET_CLASS.get(asset_class)
+    if not source_key:
+        return None
+    raw = sites.get(source_key)
+    if raw is None:
+        return None
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if v <= 0:
+        return None
+    return v
+
+
+def _percentile(sorted_vals: list[float], p: float) -> float:
+    """Nearest-rank percentile on a pre-sorted list."""
+    if not sorted_vals:
+        return 0.0
+    idx = int(round((len(sorted_vals) - 1) * max(0.0, min(1.0, p))))
+    return float(sorted_vals[idx])
+
+
+def _apply_market_corridor_clamp(
+    players_array: list[dict[str, Any]],
+    players_by_name: dict[str, Any],
+) -> None:
+    """Clamp blended values that have drifted further from the market
+    anchor than the 90th percentile of natural drift within each
+    confidence bucket.
+
+    Rationale: with 19 sources, extreme disagreements (e.g. FG + DS
+    pricing an elite edge on their combined offense+IDP pool at rank
+    300, while IDPTC + DLF IDP + IDP Show + FP IDP price him top-10)
+    can pull a player's final rank hundreds of slots from where the
+    market anchor alone would place him.  The clamp leaves the blend
+    alone for players whose drift sits inside the naturally-observed
+    distribution, but pulls back the tail outliers to the edge of
+    that distribution.
+
+    Band width is empirical — P90 of ``|final - market| / market``
+    computed within each confidence bucket on THIS board build.
+    Buckets with fewer than _MARKET_CORRIDOR_MIN_BUCKET_N players
+    fall back to the overall board P90 so small-sample noise can't
+    set an unrepresentative band.
+
+    Stamps ``marketCorridorClamp`` on every clamped row so the UI
+    and audit code can see original value, clamped value, anchor,
+    direction, and which source provided the anchor.
+    """
+    # Gather drift values per confidence bucket.
+    by_bucket: dict[str, list[float]] = {}
+    overall: list[float] = []
+    drifts: list[tuple[dict[str, Any], float, float, str]] = []
+    for row in players_array:
+        if not row.get("canonicalConsensusRank"):
+            continue
+        anchor = _market_anchor_value_for_row(row)
+        if anchor is None:
+            continue
+        try:
+            value = float(row.get("rankDerivedValue") or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if value <= 0:
+            continue
+        drift = abs(value - anchor) / anchor
+        bucket = str(row.get("confidenceBucket") or "low")
+        source_key = _MARKET_ANCHOR_BY_ASSET_CLASS.get(
+            str(row.get("assetClass") or "")
+        ) or ""
+        by_bucket.setdefault(bucket, []).append(drift)
+        overall.append(drift)
+        drifts.append((row, value, anchor, source_key))
+
+    if not overall:
+        return
+
+    overall_sorted = sorted(overall)
+    overall_p90 = _percentile(overall_sorted, _MARKET_CORRIDOR_PERCENTILE)
+    bucket_bands: dict[str, float] = {}
+    for bucket, vals in by_bucket.items():
+        if len(vals) >= _MARKET_CORRIDOR_MIN_BUCKET_N:
+            bucket_bands[bucket] = _percentile(
+                sorted(vals), _MARKET_CORRIDOR_PERCENTILE
+            )
+        else:
+            bucket_bands[bucket] = overall_p90
+
+    # Apply clamps.
+    for row, value, anchor, source_key in drifts:
+        bucket = str(row.get("confidenceBucket") or "low")
+        band = bucket_bands.get(bucket, overall_p90)
+        drift = abs(value - anchor) / anchor
+        if drift <= band:
+            continue
+        # Clamp to the band edge, preserving direction.
+        if value > anchor:
+            clamped_f = anchor * (1.0 + band)
+            direction = "down"
+        else:
+            clamped_f = anchor * (1.0 - band)
+            direction = "up"
+        clamped_int = int(round(clamped_f))
+        if clamped_int <= 0:
+            continue
+        row["rankDerivedValue"] = clamped_int
+        row["marketCorridorClamp"] = {
+            "applied": True,
+            "originalValue": int(round(value)),
+            "clampedValue": clamped_int,
+            "marketAnchor": int(round(anchor)),
+            "marketSource": source_key,
+            "bandPct": round(band, 4),
+            "percentile": _MARKET_CORRIDOR_PERCENTILE,
+            "confidenceBucket": bucket,
+            "direction": direction,
+        }
+        # Mirror onto the legacy dict payload so the delta + full
+        # contract views both see the clamped value.
+        legacy_ref = row.get("legacyRef")
+        if legacy_ref and legacy_ref in players_by_name:
+            pdata = players_by_name[legacy_ref]
+            if isinstance(pdata, dict):
+                pdata["rankDerivedValue"] = clamped_int
+                pdata["marketCorridorClamp"] = dict(row["marketCorridorClamp"])
+
+
 def _apply_idp_calibration_post_pass(
     players_array: list[dict[str, Any]],
     players_by_name: dict[str, Any],
@@ -5573,6 +5734,17 @@ def _compute_unified_rankings(
                 pdata["rankDerivedValueUncalibrated"] = snapshot_val
 
     _apply_idp_calibration_post_pass(players_array, players_by_name)
+
+    # Market-anchor corridor clamp: after all value-moving passes,
+    # clamp players whose blended value has drifted further from the
+    # market anchor (KTC for offense, IDPTC for IDP) than the P90 of
+    # natural drift inside their confidence bucket.  Leaves 90% of
+    # the board untouched — only the tail outliers where one or two
+    # sources have pulled a player far from the retail-market consensus
+    # get pulled back to the band edge.  See
+    # ``_apply_market_corridor_clamp`` for the design rationale.
+    _apply_market_corridor_clamp(players_array, players_by_name)
+
     # Offense calibration is deliberately never applied to live values.
     # The offense market is already priced by the blend of KTC / DLF /
     # IDPTC / etc.  VOR bucket multipliers produced absurd artefacts

--- a/tests/api/test_market_corridor_clamp.py
+++ b/tests/api/test_market_corridor_clamp.py
@@ -1,0 +1,355 @@
+"""Tests for the market-anchor corridor clamp.
+
+The clamp pulls back players whose blended final value has drifted
+further from their market anchor (KTC for offense, IDPTC for IDP)
+than the 90th percentile of drift within their confidence bucket.
+Non-outliers are untouched.
+"""
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from src.api.data_contract import (
+    _MARKET_ANCHOR_BY_ASSET_CLASS,
+    _apply_market_corridor_clamp,
+    _market_anchor_value_for_row,
+    _percentile,
+)
+
+
+def _make_row(
+    *,
+    name: str,
+    asset_class: str,
+    value: int,
+    ktc: int | None = None,
+    idpTradeCalc: int | None = None,
+    bucket: str = "medium",
+) -> dict[str, Any]:
+    sites: dict[str, Any] = {}
+    if ktc is not None:
+        sites["ktc"] = ktc
+    if idpTradeCalc is not None:
+        sites["idpTradeCalc"] = idpTradeCalc
+    return {
+        "canonicalName": name,
+        "legacyRef": name,
+        "assetClass": asset_class,
+        "canonicalSiteValues": sites,
+        "rankDerivedValue": value,
+        "canonicalConsensusRank": 1,  # any truthy value keeps the row in the clamp scope
+        "confidenceBucket": bucket,
+    }
+
+
+class TestMarketAnchorSelection(unittest.TestCase):
+    def test_offense_uses_ktc(self):
+        self.assertEqual(_MARKET_ANCHOR_BY_ASSET_CLASS["offense"], "ktc")
+
+    def test_idp_uses_idptc(self):
+        self.assertEqual(_MARKET_ANCHOR_BY_ASSET_CLASS["idp"], "idpTradeCalc")
+
+    def test_anchor_missing_returns_none(self):
+        row = _make_row(
+            name="No Anchor", asset_class="offense", value=5000,
+            ktc=None,
+        )
+        self.assertIsNone(_market_anchor_value_for_row(row))
+
+    def test_anchor_zero_returns_none(self):
+        """Zero-value anchors can't serve as denominators for the drift
+        ratio — treat them as absent."""
+        row = _make_row(
+            name="Zero KTC", asset_class="offense", value=5000,
+            ktc=0,
+        )
+        self.assertIsNone(_market_anchor_value_for_row(row))
+
+    def test_pick_asset_class_has_no_anchor(self):
+        row = _make_row(
+            name="2026 Pick 1.01", asset_class="pick", value=8000,
+            ktc=8200,  # pick KTC values exist but picks aren't in the clamp scope
+        )
+        self.assertIsNone(_market_anchor_value_for_row(row))
+
+
+class TestPercentileHelper(unittest.TestCase):
+    def test_empty_returns_zero(self):
+        self.assertEqual(_percentile([], 0.9), 0.0)
+
+    def test_monotone(self):
+        xs = sorted([0.1, 0.2, 0.3, 0.5, 0.8])
+        self.assertLess(_percentile(xs, 0.5), _percentile(xs, 0.9))
+
+    def test_p100_is_max(self):
+        xs = sorted([0.1, 0.5, 0.9])
+        self.assertEqual(_percentile(xs, 1.0), 0.9)
+
+    def test_p0_is_min(self):
+        xs = sorted([0.1, 0.5, 0.9])
+        self.assertEqual(_percentile(xs, 0.0), 0.1)
+
+
+class TestClampFires(unittest.TestCase):
+    """The clamp must pull back rows whose drift exceeds the P90 of
+    its confidence bucket, and leave everyone else alone."""
+
+    def test_single_extreme_outlier_gets_clamped_below_market(self):
+        """A very-low-value outlier (Parsons-style) should get lifted
+        to the band edge."""
+        rows = []
+        # 39 "normal" medium-confidence rows with drifts ~0.10
+        for i in range(39):
+            rows.append(_make_row(
+                name=f"p_{i}",
+                asset_class="idp",
+                value=int(5000 * 1.10),  # 10% above market
+                idpTradeCalc=5000,
+                bucket="medium",
+            ))
+        # 1 outlier with drift ~0.70 (way below market)
+        outlier = _make_row(
+            name="outlier_low",
+            asset_class="idp",
+            value=1500,  # 70% below market 5000
+            idpTradeCalc=5000,
+            bucket="medium",
+        )
+        rows.append(outlier)
+        _apply_market_corridor_clamp(rows, players_by_name={})
+
+        # All the "normal" rows have drift 0.10 — the 90th percentile of
+        # the sample is also 0.10, so outlier's 0.70 drift exceeds it
+        # and gets clamped to the band edge: anchor * (1 - 0.10) = 4500.
+        self.assertIn("marketCorridorClamp", outlier)
+        self.assertEqual(outlier["marketCorridorClamp"]["direction"], "up")
+        self.assertEqual(outlier["marketCorridorClamp"]["originalValue"], 1500)
+        # Clamped value should land at anchor × (1 − band).
+        self.assertEqual(outlier["rankDerivedValue"], 4500)
+
+    def test_single_extreme_outlier_gets_clamped_above_market(self):
+        rows = []
+        for i in range(39):
+            rows.append(_make_row(
+                name=f"p_{i}",
+                asset_class="idp",
+                value=int(5000 * 1.10),
+                idpTradeCalc=5000,
+                bucket="medium",
+            ))
+        outlier = _make_row(
+            name="outlier_high",
+            asset_class="idp",
+            value=int(5000 * 1.80),  # 80% above market
+            idpTradeCalc=5000,
+            bucket="medium",
+        )
+        rows.append(outlier)
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        self.assertIn("marketCorridorClamp", outlier)
+        self.assertEqual(outlier["marketCorridorClamp"]["direction"], "down")
+        # Band = 0.10 (P90 of the normal rows), so clamp = 5000 × 1.10
+        self.assertEqual(outlier["rankDerivedValue"], 5500)
+
+    def test_inside_band_no_clamp(self):
+        """Rows with drifts below the bucket P90 must be untouched."""
+        rows = []
+        # 40 medium rows with uniform drift 0.20
+        for i in range(40):
+            rows.append(_make_row(
+                name=f"p_{i}",
+                asset_class="offense",
+                value=int(5000 * 1.20),
+                ktc=5000,
+                bucket="medium",
+            ))
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        for row in rows:
+            self.assertNotIn("marketCorridorClamp", row)
+            self.assertEqual(row["rankDerivedValue"], 6000)
+
+    def test_no_anchor_no_clamp(self):
+        """Rows without a market anchor value (e.g. pre-draft rookies
+        with no KTC entry) get left alone."""
+        rows = [_make_row(
+            name="rookie_no_ktc",
+            asset_class="offense",
+            value=5000,
+            ktc=None,
+            bucket="low",
+        )]
+        # Pad with anchored rows so the function has a distribution to
+        # compute a band from (otherwise it no-ops on empty).
+        for i in range(40):
+            rows.append(_make_row(
+                name=f"anchored_{i}",
+                asset_class="offense",
+                value=5500,
+                ktc=5000,
+                bucket="medium",
+            ))
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        self.assertNotIn("marketCorridorClamp", rows[0])
+        self.assertEqual(rows[0]["rankDerivedValue"], 5000)
+
+    def test_small_bucket_falls_back_to_overall_p90(self):
+        """A bucket with fewer than 30 rows borrows the overall P90.
+
+        Build a board where the 'high' bucket has 5 rows (too small)
+        and 'medium' has 50 rows with well-defined drift.  The 'high'
+        outlier should be clamped using the OVERALL P90 (derived from
+        medium + high combined), not its own 5-sample distribution.
+        """
+        rows = []
+        for i in range(50):
+            rows.append(_make_row(
+                name=f"m_{i}",
+                asset_class="offense",
+                value=int(5000 * 1.15),  # medium drift 0.15
+                ktc=5000,
+                bucket="medium",
+            ))
+        # 5 high-confidence rows, one with extreme drift
+        for i in range(4):
+            rows.append(_make_row(
+                name=f"h_{i}",
+                asset_class="offense",
+                value=int(5000 * 1.05),  # small drift 0.05
+                ktc=5000,
+                bucket="high",
+            ))
+        high_outlier = _make_row(
+            name="h_outlier",
+            asset_class="offense",
+            value=int(5000 * 2.50),  # 150% drift
+            ktc=5000,
+            bucket="high",
+        )
+        rows.append(high_outlier)
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        # The high bucket only has 5 rows, so it falls back to overall
+        # P90 which is dominated by the 50 medium-drift-0.15 rows →
+        # overall P90 ≈ 0.15.  Outlier clamps to 5000 × 1.15 = 5750.
+        self.assertIn("marketCorridorClamp", high_outlier)
+        self.assertEqual(high_outlier["rankDerivedValue"], 5750)
+
+    def test_unranked_rows_are_skipped(self):
+        rows = [_make_row(
+            name="unranked",
+            asset_class="offense",
+            value=100,
+            ktc=5000,
+            bucket="low",
+        )]
+        # Clear canonicalConsensusRank to simulate an unranked row.
+        rows[0]["canonicalConsensusRank"] = None
+        # Pad the distribution.
+        for i in range(40):
+            rows.append(_make_row(
+                name=f"p_{i}",
+                asset_class="offense",
+                value=int(5000 * 1.10),
+                ktc=5000,
+                bucket="medium",
+            ))
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        # Unranked row should NOT be touched.
+        self.assertNotIn("marketCorridorClamp", rows[0])
+        self.assertEqual(rows[0]["rankDerivedValue"], 100)
+
+
+class TestClampStamps(unittest.TestCase):
+    """When a clamp fires, the stamp must carry enough info to audit
+    the decision from the UI / logs."""
+
+    def test_stamp_fields_present(self):
+        rows = [_make_row(
+            name="outlier",
+            asset_class="idp",
+            value=100,
+            idpTradeCalc=5000,
+            bucket="low",
+        )]
+        for i in range(40):
+            rows.append(_make_row(
+                name=f"p_{i}",
+                asset_class="idp",
+                value=int(5000 * 1.10),
+                idpTradeCalc=5000,
+                bucket="medium",
+            ))
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        stamp = rows[0].get("marketCorridorClamp")
+        self.assertIsNotNone(stamp)
+        for field in (
+            "applied",
+            "originalValue",
+            "clampedValue",
+            "marketAnchor",
+            "marketSource",
+            "bandPct",
+            "percentile",
+            "confidenceBucket",
+            "direction",
+        ):
+            self.assertIn(field, stamp, f"missing {field}")
+        self.assertTrue(stamp["applied"])
+        self.assertEqual(stamp["marketSource"], "idpTradeCalc")
+        self.assertEqual(stamp["marketAnchor"], 5000)
+        self.assertEqual(stamp["originalValue"], 100)
+        self.assertEqual(stamp["direction"], "up")
+
+    def test_mirror_onto_legacy_dict(self):
+        row = _make_row(
+            name="Clamped",
+            asset_class="offense",
+            value=100,
+            ktc=5000,
+            bucket="low",
+        )
+        rows = [row]
+        for i in range(40):
+            rows.append(_make_row(
+                name=f"p_{i}",
+                asset_class="offense",
+                value=int(5000 * 1.10),
+                ktc=5000,
+                bucket="medium",
+            ))
+        legacy = {"Clamped": {"rankDerivedValue": 100}}
+        _apply_market_corridor_clamp(rows, players_by_name=legacy)
+        self.assertEqual(legacy["Clamped"]["rankDerivedValue"], row["rankDerivedValue"])
+        self.assertIn("marketCorridorClamp", legacy["Clamped"])
+
+
+class TestIdempotence(unittest.TestCase):
+    """Running the clamp twice must not compound — after one pass
+    every row's drift ≤ band, so a second pass should be a no-op."""
+
+    def test_second_pass_no_additional_clamps(self):
+        rows = [_make_row(
+            name="outlier",
+            asset_class="idp",
+            value=100,
+            idpTradeCalc=5000,
+            bucket="medium",
+        )]
+        for i in range(40):
+            rows.append(_make_row(
+                name=f"p_{i}",
+                asset_class="idp",
+                value=int(5000 * 1.10),
+                idpTradeCalc=5000,
+                bucket="medium",
+            ))
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        clamped_val = rows[0]["rankDerivedValue"]
+        _apply_market_corridor_clamp(rows, players_by_name={})
+        # Second pass mustn't shift the value — the first pass already
+        # brought every row inside the band.
+        self.assertEqual(rows[0]["rankDerivedValue"], clamped_val)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -177,6 +177,13 @@ class TestValueChain(unittest.TestCase):
             final = row.get("rankDerivedValue")
             if uncal is None or final is None:
                 continue
+            # Market-corridor clamp may have pulled this row's value
+            # toward KTC when the blend drifted past the P90 band.
+            # The invariant being tested here is that no OFFENSE
+            # CALIBRATION pass mutates the value; the clamp is a
+            # separate transform covered by its own test suite.
+            if row.get("marketCorridorClamp"):
+                continue
             self.assertEqual(
                 int(final),
                 int(uncal),
@@ -206,6 +213,12 @@ class TestValueChain(unittest.TestCase):
             uncal = row.get("rankDerivedValueUncalibrated")
             final = row.get("rankDerivedValue")
             if uncal is None or final is None:
+                continue
+            # Skip rows where the market-corridor clamp has pulled
+            # the final value away from the pure calibration fold.
+            # The calibration-folds-exactly-once invariant is what
+            # this test pins; the clamp is a separate transform.
+            if row.get("marketCorridorClamp"):
                 continue
             bucket = row.get("idpCalibrationMultiplier")
             family = row.get("idpFamilyScale")

--- a/tests/idp_calibration/test_family_scale_once_only.py
+++ b/tests/idp_calibration/test_family_scale_once_only.py
@@ -118,6 +118,14 @@ def test_family_scale_is_folded_exactly_once(tmp_path, monkeypatch):
         family = row.get("idpFamilyScale")
         if uncal is None or final_val is None:
             continue
+        # Skip rows where the market-corridor clamp has pulled the
+        # value away from the calibration-folded expectation.  The
+        # invariant we're testing is that the CALIBRATION itself
+        # folds exactly once — a subsequent clamp operating on the
+        # calibrated value is a different transform and is tested
+        # separately.
+        if row.get("marketCorridorClamp"):
+            continue
         # Stamped components match the config exactly.
         assert bucket is not None and abs(bucket - DL_BUCKET) < 1e-6, (
             f"{row.get('canonicalName')}: "


### PR DESCRIPTION
## Summary
Post-calibration clamp that pulls extreme-disagreement outliers back to the P90 of natural drift from the market anchor (KTC for offense, IDPTC for IDP).

## Why
With 19 sources, elite IDPs with genuine cross-market disagreement could land hundreds of ranks from the market consensus. The clamp catches tail cases without touching the 90% of the board already close to market.

## How
- Percentile-based bands (P90 of drift-from-anchor, computed per confidence bucket each board build). No arbitrary constants.
- Small buckets (<30 players) fall back to overall-board P90.
- Stamps \`marketCorridorClamp\` with original/clamped values, anchor, band %, direction.
- Idempotent.

## Live result
- 66/~1000 players clamped (~7%)
- 86% of clamps pull IDPs DOWN (catches the calibration-over-boosted mid-tier IDPs)
- 2 pull UP (the reverse disagreement case)
- Parsons rank 135, val 3592 (no clamp needed; recent IDP cal re-fit lifted him organically)

## Test plan
- [x] pytest tests/ -q — 1723 pass (18 new clamp tests)
- [x] Live smoke confirms expected clamp distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)