### PR TITLE
Gate player search on authenticated session

### DIFF
--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -74,13 +74,15 @@ function DesktopNav() {
               </Link>
             );
           })}
-          <button
-            className="nav-link nav-search-btn"
-            onClick={openSearch}
-            title="Search players (press /)"
-          >
-            /
-          </button>
+          {authenticated && (
+            <button
+              className="nav-link nav-search-btn"
+              onClick={openSearch}
+              title="Search players (press /)"
+            >
+              /
+            </button>
+          )}
           {authenticated && (
             <button className="nav-link nav-logout-btn" onClick={logout} title="Sign out">
               Sign out
@@ -165,9 +167,11 @@ function MobileTopBar() {
       <Link href="/" className="mobile-brand">Brisket</Link>
       <span className="mobile-page-title">{pageTitle}</span>
       <div className="mobile-topbar-actions">
-        <button className="mobile-search-btn" onClick={openSearch} title="Search" aria-label="Search">
-          /
-        </button>
+        {authenticated && (
+          <button className="mobile-search-btn" onClick={openSearch} title="Search" aria-label="Search">
+            /
+          </button>
+        )}
         {authenticated && (
           <button
             className="mobile-signout-btn"
@@ -189,7 +193,7 @@ export default function AppShellWrapper({ children }) {
 
   return (
     <AuthContext.Provider value={auth}>
-      <AppShell>
+      <AppShell authenticated={auth.authenticated === true}>
         <DesktopNav />
         <MobileTopBar />
         <StaleDataBanner />

--- a/frontend/components/AppShell.jsx
+++ b/frontend/components/AppShell.jsx
@@ -45,18 +45,18 @@ function isPublicOnlyRoute(pathname) {
  * For PUBLIC-only routes, AppShell refuses to hydrate private data.
  * See PUBLIC_ONLY_ROUTE_PREFIXES above.
  */
-export default function AppShell({ children }) {
+export default function AppShell({ children, authenticated = false }) {
   const pathname = usePathname();
   const privateDataEnabled = !isPublicOnlyRoute(pathname);
 
   return privateDataEnabled ? (
-    <PrivateAppShell>{children}</PrivateAppShell>
+    <PrivateAppShell authenticated={authenticated}>{children}</PrivateAppShell>
   ) : (
-    <PublicAppShell>{children}</PublicAppShell>
+    <PublicAppShell authenticated={authenticated}>{children}</PublicAppShell>
   );
 }
 
-function PrivateAppShell({ children }) {
+function PrivateAppShell({ children, authenticated }) {
   const { loading, error, rows, siteKeys, rawData } = useDynastyData();
   return (
     <InnerAppShell
@@ -66,13 +66,14 @@ function PrivateAppShell({ children }) {
       siteKeys={siteKeys}
       rawData={rawData}
       privateDataEnabled={true}
+      authenticated={authenticated}
     >
       {children}
     </InnerAppShell>
   );
 }
 
-function PublicAppShell({ children }) {
+function PublicAppShell({ children, authenticated }) {
   // No useDynastyData call — the public page pipeline must never
   // hydrate from /api/data.  The search + popup components render
   // against an empty rows list so they simply no-op rather than
@@ -85,13 +86,18 @@ function PublicAppShell({ children }) {
       siteKeys={[]}
       rawData={null}
       privateDataEnabled={false}
+      authenticated={authenticated}
     >
       {children}
     </InnerAppShell>
   );
 }
 
-function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEnabled, children }) {
+function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEnabled, authenticated, children }) {
+  // Player search requires an authenticated session.  Search against
+  // the private contract leaks ranking data and private identifiers
+  // to logged-out visitors on otherwise-public surfaces.
+  const searchEnabled = privateDataEnabled && authenticated;
   // Player popup state
   const [popupRow, setPopupRow] = useState(null);
 
@@ -117,13 +123,13 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
   }, [rows, privateDataEnabled]);
 
   const openSearch = useCallback(() => {
-    if (!privateDataEnabled) return;
+    if (!searchEnabled) return;
     setSearchOpen(true);
-  }, [privateDataEnabled]);
+  }, [searchEnabled]);
 
   // Global "/" keyboard shortcut for search
   useEffect(() => {
-    if (!privateDataEnabled) return undefined;
+    if (!searchEnabled) return undefined;
     function onKeyDown(e) {
       const tag = e.target?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
@@ -134,7 +140,7 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [privateDataEnabled]);
+  }, [searchEnabled]);
 
   return (
     <AppContext.Provider
@@ -153,21 +159,21 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
       {children}
 
       {privateDataEnabled && (
-        <>
-          <PlayerPopup
-            row={popupRow}
-            siteKeys={siteKeys}
-            onClose={() => setPopupRow(null)}
-            onAddToTrade={addToTradeRef.current ? handleAddToTrade : null}
-          />
+        <PlayerPopup
+          row={popupRow}
+          siteKeys={siteKeys}
+          onClose={() => setPopupRow(null)}
+          onAddToTrade={addToTradeRef.current ? handleAddToTrade : null}
+        />
+      )}
 
-          <GlobalSearch
-            rows={rows}
-            isOpen={searchOpen}
-            onClose={() => setSearchOpen(false)}
-            onSelect={(row) => openPlayerPopup(row)}
-          />
-        </>
+      {searchEnabled && (
+        <GlobalSearch
+          rows={rows}
+          isOpen={searchOpen}
+          onClose={() => setSearchOpen(false)}
+          onSelect={(row) => openPlayerPopup(row)}
+        />
       )}
     </AppContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Hide the desktop `/` search button and the mobile top-bar search button when the visitor is not logged in.
- Thread `authenticated` through `AppShell` → `InnerAppShell` and gate `openSearch`, the global "/" keyboard shortcut, and the `GlobalSearch` modal render on a new `searchEnabled = privateDataEnabled && authenticated` check.
- Logged-out visitors on public surfaces (and direct-navigation attempts to private routes) can no longer reach the private-contract player list through search.

## Test plan
- [ ] Logged out: the `/` button is absent from the desktop top bar and mobile top bar; pressing `/` on the keyboard does nothing; no search overlay renders.
- [ ] Logged in: the `/` button is visible, the `/` shortcut opens the overlay, and player selection opens `PlayerPopup` as before.
- [ ] Public `/league` route still has no search (unchanged behavior).
- [ ] `npm run regression` passes.

https://claude.ai/code/session_014S7PtPknAAB69gDPbSSqdX