### PR TITLE
Reorder source registry to group cousin columns

### DIFF
--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -259,6 +259,57 @@ export const RANKING_SOURCES = [
     isTepPremium: false,
   },
   {
+    // DLF Dynasty Superflex rankings — offense expert consensus.
+    // Curated 6-expert board with Rank / Avg / Pos / Name columns.
+    // Includes rookies (unlike DLF IDP).  Mirrors the backend entry
+    // in src/api/data_contract.py::_RANKING_SOURCES.
+    //
+    // Rank-signal: CSV has an explicit Rank column.  The backend
+    // converts ranks to synthetic monotonic values for sort purposes;
+    // the UI must render sourceOriginalRanks.dlfSf, never the synthetic.
+    key: "dlfSf",
+    displayName: "Dynasty League Football Superflex",
+    columnLabel: "DLF SF",
+    scope: "overall_offense",
+    positionGroup: null,
+    depth: 280,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: true,
+    // DLF's dynasty Superflex board is a standard SF consensus — no
+    // TE premium.  The CSV columns (Rank / Avg / Pos / Name / 6 expert
+    // columns) contain no TEP indicator.  Raw source:
+    // dynastyleaguefootball.com/dynasty-rankings/superflex.  The
+    // tepMultiplier applies to DLF SF's contribution on the blended
+    // board.
+    isTepPremium: false,
+  },
+  {
+    // DLF Dynasty Rookie Superflex — 6-expert consensus covering the
+    // current rookie class only (QB/RB/WR/TE prospects).  The raw
+    // rookie-only rank is crosswalked at blend time through a rookie
+    // ladder built from KTC's current ranks on offensive rookies, so
+    // DLF's #1 rookie inherits KTC's rank-for-top-rookie scale while
+    // DLF's ORDERING remains intact.  Synthetic "2026 Pick R.SS" rows
+    // appended during CSV enrichment also nudge rookie pick values.
+    key: "dlfRookieSf",
+    displayName: "Dynasty League Football Rookie SF",
+    columnLabel: "DLF RK",
+    scope: "overall_offense",
+    extraScopes: [],
+    positionGroup: null,
+    depth: 50,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: true,
+    isTepPremium: false,
+    needsSharedMarketTranslation: false,
+    needsRookieTranslation: true,
+    excludesRookies: false,
+  },
+  {
     // DLF (Dynasty League Football) full-board IDP rankings.  Mirrors
     // the backend `_RANKING_SOURCES` entry in src/api/data_contract.py.
     // 185-player expert consensus; overall_idp scope; not a backbone.
@@ -287,6 +338,28 @@ export const RANKING_SOURCES = [
     isRankSignal: true,
   },
   {
+    // DLF Dynasty Rookie IDP — rookie-only DL/LB/DB prospects.
+    // Translated against IDPTC's rookie ladder.  Does NOT stamp onto
+    // picks because rookie IDP ranks are not a strong signal for
+    // pick-slot value (most rookie drafts prioritize offensive
+    // prospects at the top).
+    key: "dlfRookieIdp",
+    displayName: "Dynasty League Football Rookie IDP",
+    columnLabel: "DLF RK-IDP",
+    scope: "overall_idp",
+    extraScopes: [],
+    positionGroup: null,
+    depth: 50,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: true,
+    isTepPremium: false,
+    needsSharedMarketTranslation: false,
+    needsRookieTranslation: true,
+    excludesRookies: false,
+  },
+  {
     // The IDP Show (Adamidp) — Substack-hosted full-universe IDP
     // rankings board.  Includes rookies, edge/interior split.
     // Data loaded by scripts/fetch_idpshow.py from a Datawrapper
@@ -307,33 +380,6 @@ export const RANKING_SOURCES = [
     needsSharedMarketTranslation: true,
     excludesRookies: false,
     isRankSignal: true,
-  },
-  {
-    // DLF Dynasty Superflex rankings — offense expert consensus.
-    // Curated 6-expert board with Rank / Avg / Pos / Name columns.
-    // Includes rookies (unlike DLF IDP).  Mirrors the backend entry
-    // in src/api/data_contract.py::_RANKING_SOURCES.
-    //
-    // Rank-signal: CSV has an explicit Rank column.  The backend
-    // converts ranks to synthetic monotonic values for sort purposes;
-    // the UI must render sourceOriginalRanks.dlfSf, never the synthetic.
-    key: "dlfSf",
-    displayName: "Dynasty League Football Superflex",
-    columnLabel: "DLF SF",
-    scope: "overall_offense",
-    positionGroup: null,
-    depth: 280,
-    weight: 1.0,
-    isBackbone: false,
-    isRetail: false,
-    isRankSignal: true,
-    // DLF's dynasty Superflex board is a standard SF consensus — no
-    // TE premium.  The CSV columns (Rank / Avg / Pos / Name / 6 expert
-    // columns) contain no TEP indicator.  Raw source:
-    // dynastyleaguefootball.com/dynasty-rankings/superflex.  The
-    // tepMultiplier applies to DLF SF's contribution on the blended
-    // board.
-    isTepPremium: false,
   },
   {
     // Dynasty Nerds Superflex + TE Premium rankings — scraped inline
@@ -360,28 +406,6 @@ export const RANKING_SOURCES = [
     // UI can show users that this source does not need the
     // tepMultiplier boost on top of its contribution.
     isTepPremium: true,
-  },
-  {
-    // FantasyPros Dynasty Superflex rankings — offense expert consensus
-    // scraped from fantasypros.com/nfl/rankings/dynasty-superflex.php
-    // via scripts/fetch_fantasypros_offense.py.  Single flat board
-    // covering QB/RB/WR/TE.  Mirrors the backend `_RANKING_SOURCES`
-    // entry in src/api/data_contract.py.
-    //
-    // FantasyPros' dynasty superflex board is a standard SF consensus —
-    // no TE premium baked in.  The frontend `settings.tepMultiplier`
-    // boost applies to its blended contribution.
-    key: "fantasyProsSf",
-    displayName: "FantasyPros Dynasty Superflex",
-    columnLabel: "FP SF",
-    scope: "overall_offense",
-    positionGroup: null,
-    depth: 250,
-    weight: 1.0,
-    isBackbone: false,
-    isRetail: false,
-    isRankSignal: true,
-    isTepPremium: false,
   },
   {
     // Dynasty Daddy Superflex trade values — crowd-sourced community
@@ -411,6 +435,28 @@ export const RANKING_SOURCES = [
     excludesRookies: false,
   },
   {
+    // FantasyPros Dynasty Superflex rankings — offense expert consensus
+    // scraped from fantasypros.com/nfl/rankings/dynasty-superflex.php
+    // via scripts/fetch_fantasypros_offense.py.  Single flat board
+    // covering QB/RB/WR/TE.  Mirrors the backend `_RANKING_SOURCES`
+    // entry in src/api/data_contract.py.
+    //
+    // FantasyPros' dynasty superflex board is a standard SF consensus —
+    // no TE premium baked in.  The frontend `settings.tepMultiplier`
+    // boost applies to its blended contribution.
+    key: "fantasyProsSf",
+    displayName: "FantasyPros Dynasty Superflex",
+    columnLabel: "FP SF",
+    scope: "overall_offense",
+    positionGroup: null,
+    depth: 250,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: true,
+    isTepPremium: false,
+  },
+  {
     // FantasyPros Dynasty IDP expert consensus.  Combined IDP page
     // (dynasty-idp.php) is authoritative for cross-position ordering;
     // individual DL/LB/DB pages are used only as depth extension via
@@ -434,6 +480,32 @@ export const RANKING_SOURCES = [
     excludesRookies: true,
   },
   {
+    // FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart —
+    // monthly offense board covering QB/RB/WR/TE.  Fetched by
+    // scripts/fetch_fantasypros_fitzmaurice.py, which resolves the
+    // date-rotating article URL, extracts four Datawrapper iframes
+    // (one per position), and grabs each chart's dataset.csv.  Per
+    // position we pick the league-appropriate value column (SF Value
+    // for QB, TEP Value for TE, Trade Value for RB/WR) — so
+    // Fitzmaurice's Superflex + TE-Premium native numbers align
+    // with our league scoring.  Value-signal: the blend rescales
+    // Fitzmaurice's top player (typically a QB at ~101) to 9999.
+    key: "fantasyProsFitzmaurice",
+    displayName: "FantasyPros / Pat Fitzmaurice SF-TEP",
+    columnLabel: "Fitzmaurice",
+    scope: "overall_offense",
+    extraScopes: [],
+    positionGroup: null,
+    depth: 350,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: false,
+    isTepPremium: true,
+    needsSharedMarketTranslation: false,
+    excludesRookies: false,
+  },
+  {
     // Flock Fantasy Dynasty Superflex rankings — expert consensus.
     // Standard SF — no TE premium.  tepMultiplier boost applies.
     key: "flockFantasySf",
@@ -449,6 +521,30 @@ export const RANKING_SOURCES = [
     isRankSignal: true,
     isTepPremium: false,
     needsSharedMarketTranslation: false,
+    excludesRookies: false,
+  },
+  {
+    // Flock Fantasy Dynasty Superflex ROOKIE rankings — multi-expert
+    // averaged ranks of the current incoming rookie class only
+    // (~95 QB/RB/WR/TE prospects).  Same translation behaviour as
+    // dlfRookieSf — the within-class rank is crosswalked through KTC's
+    // offense rookie ladder so Flock's #1 rookie inherits KTC's
+    // scale-for-top-rookie.  Pick nudging is not wired for this source;
+    // dlfRookieSf already stamps synthetic "2026 Pick R.SS" rows.
+    key: "flockFantasySfRookies",
+    displayName: "Flock Fantasy Rookie SF",
+    columnLabel: "Flock RK",
+    scope: "overall_offense",
+    extraScopes: [],
+    positionGroup: null,
+    depth: 50,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isRankSignal: true,
+    isTepPremium: false,
+    needsSharedMarketTranslation: false,
+    needsRookieTranslation: true,
     excludesRookies: false,
   },
   {
@@ -523,102 +619,6 @@ export const RANKING_SOURCES = [
     isRankSignal: false,
     isTepPremium: true,
     needsSharedMarketTranslation: false,
-    excludesRookies: false,
-  },
-  {
-    // FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart —
-    // monthly offense board covering QB/RB/WR/TE.  Fetched by
-    // scripts/fetch_fantasypros_fitzmaurice.py, which resolves the
-    // date-rotating article URL, extracts four Datawrapper iframes
-    // (one per position), and grabs each chart's dataset.csv.  Per
-    // position we pick the league-appropriate value column (SF Value
-    // for QB, TEP Value for TE, Trade Value for RB/WR) — so
-    // Fitzmaurice's Superflex + TE-Premium native numbers align
-    // with our league scoring.  Value-signal: the blend rescales
-    // Fitzmaurice's top player (typically a QB at ~101) to 9999.
-    key: "fantasyProsFitzmaurice",
-    displayName: "FantasyPros / Pat Fitzmaurice SF-TEP",
-    columnLabel: "Fitzmaurice",
-    scope: "overall_offense",
-    extraScopes: [],
-    positionGroup: null,
-    depth: 350,
-    weight: 1.0,
-    isBackbone: false,
-    isRetail: false,
-    isRankSignal: false,
-    isTepPremium: true,
-    needsSharedMarketTranslation: false,
-    excludesRookies: false,
-  },
-  {
-    // DLF Dynasty Rookie Superflex — 6-expert consensus covering the
-    // current rookie class only (QB/RB/WR/TE prospects).  The raw
-    // rookie-only rank is crosswalked at blend time through a rookie
-    // ladder built from KTC's current ranks on offensive rookies, so
-    // DLF's #1 rookie inherits KTC's rank-for-top-rookie scale while
-    // DLF's ORDERING remains intact.  Synthetic "2026 Pick R.SS" rows
-    // appended during CSV enrichment also nudge rookie pick values.
-    key: "dlfRookieSf",
-    displayName: "Dynasty League Football Rookie SF",
-    columnLabel: "DLF RK",
-    scope: "overall_offense",
-    extraScopes: [],
-    positionGroup: null,
-    depth: 50,
-    weight: 1.0,
-    isBackbone: false,
-    isRetail: false,
-    isRankSignal: true,
-    isTepPremium: false,
-    needsSharedMarketTranslation: false,
-    needsRookieTranslation: true,
-    excludesRookies: false,
-  },
-  {
-    // Flock Fantasy Dynasty Superflex ROOKIE rankings — multi-expert
-    // averaged ranks of the current incoming rookie class only
-    // (~95 QB/RB/WR/TE prospects).  Same translation behaviour as
-    // dlfRookieSf — the within-class rank is crosswalked through KTC's
-    // offense rookie ladder so Flock's #1 rookie inherits KTC's
-    // scale-for-top-rookie.  Pick nudging is not wired for this source;
-    // dlfRookieSf already stamps synthetic "2026 Pick R.SS" rows.
-    key: "flockFantasySfRookies",
-    displayName: "Flock Fantasy Rookie SF",
-    columnLabel: "Flock RK",
-    scope: "overall_offense",
-    extraScopes: [],
-    positionGroup: null,
-    depth: 50,
-    weight: 1.0,
-    isBackbone: false,
-    isRetail: false,
-    isRankSignal: true,
-    isTepPremium: false,
-    needsSharedMarketTranslation: false,
-    needsRookieTranslation: true,
-    excludesRookies: false,
-  },
-  {
-    // DLF Dynasty Rookie IDP — rookie-only DL/LB/DB prospects.
-    // Translated against IDPTC's rookie ladder.  Does NOT stamp onto
-    // picks because rookie IDP ranks are not a strong signal for
-    // pick-slot value (most rookie drafts prioritize offensive
-    // prospects at the top).
-    key: "dlfRookieIdp",
-    displayName: "Dynasty League Football Rookie IDP",
-    columnLabel: "DLF RK-IDP",
-    scope: "overall_idp",
-    extraScopes: [],
-    positionGroup: null,
-    depth: 50,
-    weight: 1.0,
-    isBackbone: false,
-    isRetail: false,
-    isRankSignal: true,
-    isTepPremium: false,
-    needsSharedMarketTranslation: false,
-    needsRookieTranslation: true,
     excludesRookies: false,
   },
   {

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -807,6 +807,76 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_tep_premium": False,
     },
     {
+        # DLF Dynasty Superflex rankings — the offense counterpart of
+        # DLF IDP.  Curated 6-expert consensus board with explicit
+        # ``Rank`` and ``Avg`` columns.  Includes rookies and picks'
+        # equivalents, spans 279 players, and is scoped purely to
+        # offense (QB/RB/WR/TE).
+        #
+        # Weight normalized to 1.0 — see the registry note at the
+        # top of this list.  depth=280 still tells
+        # ``_expected_sources_for_position`` not to expect this
+        # source for players ranked deeper than ~350 (depth * 1.25),
+        # preventing false 1-src flags on fringe offense players
+        # that DLF SF was never going to list.
+        "key": "dlfSf",
+        "display_name": "Dynasty League Football Superflex",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": 280,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        # Not a shared-market translation source — dlfSf is purely
+        # offense, so its effective rank IS the offense ordinal.  No
+        # IDP backbone crosswalk needed.
+        #
+        # DLF Superflex is a standard SF expert consensus board, not
+        # TE-premium.  The raw CSV columns (Rank / Avg / Pos / Name /
+        # 6 expert columns) carry no TEP indicator.  The frontend
+        # ``settings.tepMultiplier`` boost applies to its blended
+        # contribution.  Mirrored in frontend/lib/dynasty-data.js.
+        "is_tep_premium": False,
+    },
+    {
+        # DLF Dynasty Rookie Superflex — rookies-only offensive board
+        # (QB/RB/WR/TE).  DLF expert consensus ranks the current
+        # incoming class; ~50 prospects per export.  Declared as an
+        # ``overall_offense`` source but with
+        # ``needs_rookie_translation=True`` so the within-source rank
+        # is crosswalked through a *rookie ladder* before the Hill
+        # curve.  The ladder is built from KTC's current ranks on
+        # offense rookie rows: ladder[k] = KTC's rank for the (k+1)th
+        # rookie in KTC's order.  This means DLF rookie #1 gets the
+        # Hill-value KTC would give to its own top rookie, preserving
+        # DLF's ORDER while inheriting KTC's SCALE.  Pre-NFL-draft
+        # prospects not in KTC fall past the ladder's tail and
+        # extrapolate via the translation helper.
+        #
+        # depth=50 reflects the typical rookie-class size; coverage
+        # weight scales contribution down so the rookie board never
+        # overwhelms the veteran-rich retail/expert blend.
+        "key": "dlfRookieSf",
+        "display_name": "Dynasty League Football Rookie SF",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": 50,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "is_tep_premium": False,
+        "needs_shared_market_translation": False,
+        "needs_rookie_translation": True,
+        # Rookie source BY DEFINITION contains only rookies, so
+        # ``excludes_rookies=False`` is correct — but even more:
+        # veteran rows will never match this source's CSV, so the
+        # source stamp is effectively rookie+pick-only.  The pick
+        # nudge is wired via synthetic "2026 Pick R.SS" rows that
+        # the conversion step appends to the CSV so the source's
+        # Hill value flows into pick rankDerivedValue directly.
+        "excludes_rookies": False,
+    },
+    {
         # DLF (Dynasty League Football) full-board IDP rankings.  The raw
         # export (`dlf_idp.csv` → `CSVs/site_raw/dlfIdp.csv`) is
         # a 185-player expert consensus covering DL/LB/DB together, so it
@@ -851,6 +921,23 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "excludes_rookies": True,
     },
     {
+        # DLF Dynasty Rookie IDP — rookie-only defensive board
+        # (DE/DT/EDGE/LB/CB/S).  Analogous to dlfRookieSf but
+        # translated against IDPTC's ladder.  depth=50 matches the
+        # typical export size.
+        "key": "dlfRookieIdp",
+        "display_name": "Dynasty League Football Rookie IDP",
+        "scope": SOURCE_SCOPE_OVERALL_IDP,
+        "position_group": None,
+        "depth": 50,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "needs_shared_market_translation": False,
+        "needs_rookie_translation": True,
+        "excludes_rookies": False,
+    },
+    {
         # The IDP Show (Adamidp) — Substack-hosted full IDP rankings
         # board published at theidpshow.com/p/idp-dynasty-rankings.
         # Data is served from an embedded Datawrapper iframe whose
@@ -874,38 +961,6 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_backbone": False,
         "needs_shared_market_translation": True,
         "excludes_rookies": False,
-    },
-    {
-        # DLF Dynasty Superflex rankings — the offense counterpart of
-        # DLF IDP.  Curated 6-expert consensus board with explicit
-        # ``Rank`` and ``Avg`` columns.  Includes rookies and picks'
-        # equivalents, spans 279 players, and is scoped purely to
-        # offense (QB/RB/WR/TE).
-        #
-        # Weight normalized to 1.0 — see the registry note at the
-        # top of this list.  depth=280 still tells
-        # ``_expected_sources_for_position`` not to expect this
-        # source for players ranked deeper than ~350 (depth * 1.25),
-        # preventing false 1-src flags on fringe offense players
-        # that DLF SF was never going to list.
-        "key": "dlfSf",
-        "display_name": "Dynasty League Football Superflex",
-        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
-        "position_group": None,
-        "depth": 280,
-        "weight": 1.0,
-        "is_backbone": False,
-        "is_retail": False,
-        # Not a shared-market translation source — dlfSf is purely
-        # offense, so its effective rank IS the offense ordinal.  No
-        # IDP backbone crosswalk needed.
-        #
-        # DLF Superflex is a standard SF expert consensus board, not
-        # TE-premium.  The raw CSV columns (Rank / Avg / Pos / Name /
-        # 6 expert columns) carry no TEP indicator.  The frontend
-        # ``settings.tepMultiplier`` boost applies to its blended
-        # contribution.  Mirrored in frontend/lib/dynasty-data.js.
-        "is_tep_premium": False,
     },
     {
         # Dynasty Nerds Superflex + TE Premium board — scraped inline
@@ -943,6 +998,35 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_tep_premium": True,
     },
     {
+        # Dynasty Daddy Superflex trade values — crowd-sourced community
+        # values fetched from the public JSON API at
+        # https://dynasty-daddy.com/api/v1/player/all/today?market=14
+        # via ``scripts/fetch_dynasty_daddy.py``.  Market 14 is the SF/
+        # dynasty format.  The API returns ~641 players; after filtering
+        # to offensive positions (QB/RB/WR/TE) ~400+ remain.
+        #
+        # Weight normalized to 1.0 — see the registry note at the top
+        # of this list.  depth=320 reflects the typical offensive-only
+        # count (~323 players with positive sf_trade_value);
+        # ``_expected_sources_for_position`` multiplies this by 1.25 so
+        # DD SF is not expected for players ranked deeper than ~400.
+        #
+        # Dynasty Daddy's SF trade values are standard SF scoring — no
+        # TE premium baked in.  The frontend ``settings.tepMultiplier``
+        # boost applies to its blended contribution.
+        "key": "dynastyDaddySf",
+        "display_name": "Dynasty Daddy Superflex",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": 320,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "is_tep_premium": False,
+        "needs_shared_market_translation": False,
+        "excludes_rookies": False,
+    },
+    {
         # FantasyPros Dynasty Superflex rankings — offense expert
         # consensus scraped from
         # https://www.fantasypros.com/nfl/rankings/dynasty-superflex.php
@@ -971,35 +1055,6 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_backbone": False,
         "is_retail": False,
         "is_tep_premium": False,
-    },
-    {
-        # Dynasty Daddy Superflex trade values — crowd-sourced community
-        # values fetched from the public JSON API at
-        # https://dynasty-daddy.com/api/v1/player/all/today?market=14
-        # via ``scripts/fetch_dynasty_daddy.py``.  Market 14 is the SF/
-        # dynasty format.  The API returns ~641 players; after filtering
-        # to offensive positions (QB/RB/WR/TE) ~400+ remain.
-        #
-        # Weight normalized to 1.0 — see the registry note at the top
-        # of this list.  depth=320 reflects the typical offensive-only
-        # count (~323 players with positive sf_trade_value);
-        # ``_expected_sources_for_position`` multiplies this by 1.25 so
-        # DD SF is not expected for players ranked deeper than ~400.
-        #
-        # Dynasty Daddy's SF trade values are standard SF scoring — no
-        # TE premium baked in.  The frontend ``settings.tepMultiplier``
-        # boost applies to its blended contribution.
-        "key": "dynastyDaddySf",
-        "display_name": "Dynasty Daddy Superflex",
-        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
-        "position_group": None,
-        "depth": 320,
-        "weight": 1.0,
-        "is_backbone": False,
-        "is_retail": False,
-        "is_tep_premium": False,
-        "needs_shared_market_translation": False,
-        "excludes_rookies": False,
     },
     {
         # FantasyPros Dynasty IDP expert consensus.  Scraped from
@@ -1037,6 +1092,42 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "excludes_rookies": True,
     },
     {
+        # FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart —
+        # monthly offense board covering QB/RB/WR/TE.  Fetched by
+        # ``scripts/fetch_fantasypros_fitzmaurice.py`` which:
+        #   1. resolves the month-rotating article URL (falls back
+        #      3 months if the current-month update isn't published yet),
+        #   2. parses the four embedded Datawrapper iframes for
+        #      QB / RB / WR / TE,
+        #   3. fetches each chart's dataset.csv and picks the league-
+        #      appropriate value column: ``SF Value`` for QB (Superflex),
+        #      ``Trade Value`` for RB/WR, ``TEP Value`` for TE (TE-Premium).
+        # Result: ~300 combined rows with a top-of-pool value of ~101
+        # (SF-adjusted QB).  Signal=value so the blend's value-direct
+        # branch scales Fitzmaurice's top to 9999 and every other row
+        # linearly.  Cross-position separation is preserved (e.g. top
+        # QB at SF value 101 beats top WR at 88, scaling to 9999 vs
+        # 8712 on the 9999 scale).
+        #
+        # depth=350 reflects the published row count; coverage_weight
+        # keeps full weight for rows within depth and degrades past.
+        # Like yahooBoone, this is a TEP-native source: it applies the
+        # TE premium directly via the TEP Value column, so the global
+        # TEP multiplier MUST NOT compound.
+        "key": "fantasyProsFitzmaurice",
+        "display_name": "FantasyPros / Pat Fitzmaurice SF-TEP",
+        "column_label": "Fitzmaurice",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": 350,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "is_tep_premium": True,
+        "needs_shared_market_translation": False,
+        "excludes_rookies": False,
+    },
+    {
         # Flock Fantasy Dynasty Superflex rankings — expert consensus
         # from https://flockfantasy.com.  Multi-expert averaged ranks.
         # Standard SF — no TE premium baked in.  The frontend
@@ -1052,6 +1143,36 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_retail": False,
         "is_tep_premium": False,
         "needs_shared_market_translation": False,
+        "excludes_rookies": False,
+    },
+    {
+        # Flock Fantasy Dynasty Superflex Rookie/Prospect rankings —
+        # multi-expert averaged ranks of the current incoming rookie
+        # class only (~95 QB/RB/WR/TE prospects).  Fetched from the
+        # PROSPECTS_SF endpoint by ``scripts/fetch_flock_fantasy_rookies.py``.
+        # Same shape and translation behaviour as ``dlfRookieSf``: the
+        # within-class rank is crosswalked through KTC's offense rookie
+        # ladder so Flock's #1 rookie inherits KTC's scale-for-top-rookie
+        # rather than being mapped to overall #1 = 9999.
+        #
+        # depth=50 mirrors ``dlfRookieSf``; coverage weight scales the
+        # rookie board's contribution down so it never overwhelms the
+        # veteran-rich blend.  Pick nudging is intentionally NOT wired
+        # for this source — ``dlfRookieSf`` already stamps synthetic
+        # "2026 Pick R.SS" rows to drive pick values, and the cross-
+        # rookie pick tethering pass (Phase 11) blends Flock's rookie
+        # values into picks via the merged rookie pool.
+        "key": "flockFantasySfRookies",
+        "display_name": "Flock Fantasy Rookie SF",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": 50,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "is_tep_premium": False,
+        "needs_shared_market_translation": False,
+        "needs_rookie_translation": True,
         "excludes_rookies": False,
     },
     {
@@ -1143,127 +1264,6 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_retail": False,
         "is_tep_premium": True,
         "needs_shared_market_translation": False,
-        "excludes_rookies": False,
-    },
-    {
-        # FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart —
-        # monthly offense board covering QB/RB/WR/TE.  Fetched by
-        # ``scripts/fetch_fantasypros_fitzmaurice.py`` which:
-        #   1. resolves the month-rotating article URL (falls back
-        #      3 months if the current-month update isn't published yet),
-        #   2. parses the four embedded Datawrapper iframes for
-        #      QB / RB / WR / TE,
-        #   3. fetches each chart's dataset.csv and picks the league-
-        #      appropriate value column: ``SF Value`` for QB (Superflex),
-        #      ``Trade Value`` for RB/WR, ``TEP Value`` for TE (TE-Premium).
-        # Result: ~300 combined rows with a top-of-pool value of ~101
-        # (SF-adjusted QB).  Signal=value so the blend's value-direct
-        # branch scales Fitzmaurice's top to 9999 and every other row
-        # linearly.  Cross-position separation is preserved (e.g. top
-        # QB at SF value 101 beats top WR at 88, scaling to 9999 vs
-        # 8712 on the 9999 scale).
-        #
-        # depth=350 reflects the published row count; coverage_weight
-        # keeps full weight for rows within depth and degrades past.
-        # Like yahooBoone, this is a TEP-native source: it applies the
-        # TE premium directly via the TEP Value column, so the global
-        # TEP multiplier MUST NOT compound.
-        "key": "fantasyProsFitzmaurice",
-        "display_name": "FantasyPros / Pat Fitzmaurice SF-TEP",
-        "column_label": "Fitzmaurice",
-        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
-        "position_group": None,
-        "depth": 350,
-        "weight": 1.0,
-        "is_backbone": False,
-        "is_retail": False,
-        "is_tep_premium": True,
-        "needs_shared_market_translation": False,
-        "excludes_rookies": False,
-    },
-    {
-        # DLF Dynasty Rookie Superflex — rookies-only offensive board
-        # (QB/RB/WR/TE).  DLF expert consensus ranks the current
-        # incoming class; ~50 prospects per export.  Declared as an
-        # ``overall_offense`` source but with
-        # ``needs_rookie_translation=True`` so the within-source rank
-        # is crosswalked through a *rookie ladder* before the Hill
-        # curve.  The ladder is built from KTC's current ranks on
-        # offense rookie rows: ladder[k] = KTC's rank for the (k+1)th
-        # rookie in KTC's order.  This means DLF rookie #1 gets the
-        # Hill-value KTC would give to its own top rookie, preserving
-        # DLF's ORDER while inheriting KTC's SCALE.  Pre-NFL-draft
-        # prospects not in KTC fall past the ladder's tail and
-        # extrapolate via the translation helper.
-        #
-        # depth=50 reflects the typical rookie-class size; coverage
-        # weight scales contribution down so the rookie board never
-        # overwhelms the veteran-rich retail/expert blend.
-        "key": "dlfRookieSf",
-        "display_name": "Dynasty League Football Rookie SF",
-        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
-        "position_group": None,
-        "depth": 50,
-        "weight": 1.0,
-        "is_backbone": False,
-        "is_retail": False,
-        "is_tep_premium": False,
-        "needs_shared_market_translation": False,
-        "needs_rookie_translation": True,
-        # Rookie source BY DEFINITION contains only rookies, so
-        # ``excludes_rookies=False`` is correct — but even more:
-        # veteran rows will never match this source's CSV, so the
-        # source stamp is effectively rookie+pick-only.  The pick
-        # nudge is wired via synthetic "2026 Pick R.SS" rows that
-        # the conversion step appends to the CSV so the source's
-        # Hill value flows into pick rankDerivedValue directly.
-        "excludes_rookies": False,
-    },
-    {
-        # Flock Fantasy Dynasty Superflex Rookie/Prospect rankings —
-        # multi-expert averaged ranks of the current incoming rookie
-        # class only (~95 QB/RB/WR/TE prospects).  Fetched from the
-        # PROSPECTS_SF endpoint by ``scripts/fetch_flock_fantasy_rookies.py``.
-        # Same shape and translation behaviour as ``dlfRookieSf``: the
-        # within-class rank is crosswalked through KTC's offense rookie
-        # ladder so Flock's #1 rookie inherits KTC's scale-for-top-rookie
-        # rather than being mapped to overall #1 = 9999.
-        #
-        # depth=50 mirrors ``dlfRookieSf``; coverage weight scales the
-        # rookie board's contribution down so it never overwhelms the
-        # veteran-rich blend.  Pick nudging is intentionally NOT wired
-        # for this source — ``dlfRookieSf`` already stamps synthetic
-        # "2026 Pick R.SS" rows to drive pick values, and the cross-
-        # rookie pick tethering pass (Phase 11) blends Flock's rookie
-        # values into picks via the merged rookie pool.
-        "key": "flockFantasySfRookies",
-        "display_name": "Flock Fantasy Rookie SF",
-        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
-        "position_group": None,
-        "depth": 50,
-        "weight": 1.0,
-        "is_backbone": False,
-        "is_retail": False,
-        "is_tep_premium": False,
-        "needs_shared_market_translation": False,
-        "needs_rookie_translation": True,
-        "excludes_rookies": False,
-    },
-    {
-        # DLF Dynasty Rookie IDP — rookie-only defensive board
-        # (DE/DT/EDGE/LB/CB/S).  Analogous to dlfRookieSf but
-        # translated against IDPTC's ladder.  depth=50 matches the
-        # typical export size.
-        "key": "dlfRookieIdp",
-        "display_name": "Dynasty League Football Rookie IDP",
-        "scope": SOURCE_SCOPE_OVERALL_IDP,
-        "position_group": None,
-        "depth": 50,
-        "weight": 1.0,
-        "is_backbone": False,
-        "is_retail": False,
-        "needs_shared_market_translation": False,
-        "needs_rookie_translation": True,
         "excludes_rookies": False,
     },
     {


### PR DESCRIPTION
## Summary
Veteran + rookie + IDP cousins from the same family now sit next to each other on the rankings table. Rookie columns (Flock RK, DLF RK, DLF RK IDP) used to live at the right edge past FBG SF — now they follow their vet siblings.

No math changes. Parity test holds.

## After
\`\`\`
KTC | IDPTC | DLF SF | DLF RK | DLF IDP | DLF RK IDP | IDP SHOW | DN | DD | FP SF | FP IDP | Fitz | Flock | Flock RK | FBG SF | FBG IDP | Boone | DS | DS IDP
\`\`\`

## Test plan
- [x] pytest tests/ -q — 1734 pass
- [x] npm run build — green