### PR TITLE
Retire former owners (Bwalk903, SheriffB) from public league data

### DIFF
--- a/src/public_league/identity.py
+++ b/src/public_league/identity.py
@@ -21,6 +21,25 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Iterable
 
+# ── Retired owner IDs ────────────────────────────────────────────────
+# Sleeper owner_ids of former league members who have left the league
+# entirely.  Their historical aliases (team names, avatars, roster
+# slots) are filtered out at registry build time so they don't appear
+# in franchise dropdowns, manager lists, or alias tables.  Game-data
+# references to their old roster slots (matchup results, trades) that
+# exist in the Sleeper archives will simply attribute to "" and get
+# filtered out by the same orphan-roster handling that skips
+# un-assigned rosters, so no historical rewrite is required.
+#
+# Add an entry here to retire an owner:
+#     _RETIRED_OWNER_IDS: frozenset[str] = frozenset({
+#         "714976074907336704",  # Bwalk903 — left after 2024
+#     })
+_RETIRED_OWNER_IDS: frozenset[str] = frozenset({
+    "714976074907336704",  # Bwalk903 — left after 2024
+    "720849338183548928",  # SheriffB — left after 2024
+})
+
 
 @dataclass
 class TeamAlias:
@@ -133,6 +152,14 @@ def build_manager_registry(seasons: Iterable[dict[str, Any]]) -> ManagerRegistry
                 # Orphaned roster — skip; we refuse to invent a
                 # pseudo-owner.  History for this roster in this season
                 # will simply be attributed to "" and filtered out.
+                continue
+            if owner_id in _RETIRED_OWNER_IDS:
+                # Operator-maintained retirement list.  Drop every
+                # alias from this owner across every season so they
+                # don't appear in manager dropdowns or franchise
+                # pages.  Historical matchup / trade data that
+                # references their old roster slot falls through to
+                # the same "" attribution path as orphaned rosters.
                 continue
             try:
                 rid_int = int(roster.get("roster_id"))

--- a/tests/public_league/test_identity_retirement.py
+++ b/tests/public_league/test_identity_retirement.py
@@ -1,0 +1,143 @@
+"""Tests for the retired-owner filter in
+``src.public_league.identity.build_manager_registry``.
+
+The filter drops rosters whose owner_id sits in
+``_RETIRED_OWNER_IDS`` so former league members don't appear in
+the public league contract's managers list or franchise dropdowns.
+Historical matchup/trade data that references their old roster
+slot falls through to the orphaned-roster path already handled by
+the section modules.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.public_league.identity import (
+    _RETIRED_OWNER_IDS,
+    build_manager_registry,
+)
+
+
+def _season(
+    *,
+    league_id: str,
+    season: str,
+    roster_owner_pairs: list[tuple[int, str]],
+    user_names: dict[str, str],
+) -> dict:
+    return {
+        "league": {"league_id": league_id, "season": season},
+        "users": [
+            {"user_id": uid, "display_name": name}
+            for uid, name in user_names.items()
+        ],
+        "rosters": [
+            {"roster_id": rid, "owner_id": owner}
+            for rid, owner in roster_owner_pairs
+        ],
+    }
+
+
+class TestRetiredOwnerFilter(unittest.TestCase):
+    def test_retired_owners_constant_contains_known_retirees(self):
+        """If this test fails, someone broke the retirement list.
+        Update this test + the _RETIRED_OWNER_IDS constant together."""
+        self.assertIn("714976074907336704", _RETIRED_OWNER_IDS)  # Bwalk903
+        self.assertIn("720849338183548928", _RETIRED_OWNER_IDS)  # SheriffB
+
+    def test_retired_owner_not_in_registry(self):
+        """A retired owner with a 2024 alias should NOT appear in the
+        manager registry even though Sleeper's archive has their
+        roster."""
+        seasons = [
+            _season(
+                league_id="2026lg",
+                season="2026",
+                roster_owner_pairs=[(1, "active_owner")],
+                user_names={"active_owner": "Jason"},
+            ),
+            _season(
+                league_id="2024lg",
+                season="2024",
+                roster_owner_pairs=[
+                    (1, "active_owner"),
+                    (5, "714976074907336704"),  # Bwalk903
+                    (9, "720849338183548928"),  # SheriffB
+                ],
+                user_names={
+                    "active_owner": "Jason",
+                    "714976074907336704": "Bwalk903",
+                    "720849338183548928": "SheriffB",
+                },
+            ),
+        ]
+        registry = build_manager_registry(seasons)
+        keys = set(registry.by_owner_id.keys())
+        self.assertIn("active_owner", keys)
+        self.assertNotIn("714976074907336704", keys)
+        self.assertNotIn("720849338183548928", keys)
+
+    def test_public_list_excludes_retirees(self):
+        """``to_public_list`` should also exclude them — same code
+        path — but we pin it explicitly in case a future
+        refactor diverges the two."""
+        seasons = [
+            _season(
+                league_id="2024lg",
+                season="2024",
+                roster_owner_pairs=[
+                    (1, "active_owner"),
+                    (2, "714976074907336704"),
+                ],
+                user_names={
+                    "active_owner": "Jason",
+                    "714976074907336704": "Bwalk903",
+                },
+            ),
+        ]
+        registry = build_manager_registry(seasons)
+        names = [m["displayName"] for m in registry.to_public_list()]
+        self.assertIn("Jason", names)
+        self.assertNotIn("Bwalk903", names)
+
+    def test_retired_owner_roster_to_owner_mapping_is_orphaned(self):
+        """The retiree's historical roster slot should NOT be in the
+        ``roster_to_owner`` lookup — which means any section module
+        that tries to attribute a 2024 matchup to their roster will
+        see the orphan path and filter it out, consistent with how
+        un-assigned rosters are already handled."""
+        seasons = [
+            _season(
+                league_id="2024lg",
+                season="2024",
+                roster_owner_pairs=[(5, "714976074907336704")],
+                user_names={"714976074907336704": "Bwalk903"},
+            ),
+        ]
+        registry = build_manager_registry(seasons)
+        self.assertNotIn(("2024lg", 5), registry.roster_to_owner)
+
+    def test_non_retired_owners_still_build_normally(self):
+        """Sanity: the filter only affects retirees, not everyone."""
+        seasons = [
+            _season(
+                league_id="2026lg",
+                season="2026",
+                roster_owner_pairs=[
+                    (1, "owner_a"),
+                    (2, "owner_b"),
+                    (3, "owner_c"),
+                ],
+                user_names={
+                    "owner_a": "Aguilar315",
+                    "owner_b": "Brenthany",
+                    "owner_c": "Jason",
+                },
+            ),
+        ]
+        registry = build_manager_registry(seasons)
+        self.assertEqual(len(registry.by_owner_id), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Sleeper archives every owner in the league chain forever, so Bwalk903 + SheriffB (both left after 2024) still showed up in the public-league manager list, franchise dropdowns, and alias tables.

Fix: add an operator-maintained \`_RETIRED_OWNER_IDS\` frozenset in \`src/public_league/identity.py\`. Their historical aliases are filtered out at registry build time; historical matchup/trade data that references their old roster slots falls through to the orphan-roster path already handled by the section modules.

## Test plan
- [x] pytest tests/ -q — 1739 pass (5 new retirement tests)
- [ ] Post-deploy: verify \`/api/public/league\` no longer lists them, force-refresh snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)