### PR TITLE
Unescape HTML entities in FootballGuys player names (Ja'Marr Chase fix)

### DIFF
--- a/CSVs/site_raw/footballGuysIdp.csv
+++ b/CSVs/site_raw/footballGuysIdp.csv
@@ -127,7 +127,7 @@ Mike Jackson,434,CB13,CAR,29,7
 Leo Chenal,435,LB49,WAS,25,4
 Tyler Nubin,436,S26,NYG,24,2
 Jake Golday,437,LB50,FA,22,R
-L&apos;Jarius Sneed,439,CB14,FA,29,6
+L'Jarius Sneed,439,CB14,FA,29,6
 Devin White,441,LB51,FA,28,7
 Dillon Thieneman,442,S27,FA,21,R
 Anthony Hill Jr.,443,LB52,FA,21,R
@@ -225,7 +225,7 @@ Nohl Williams,543,CB44,KC,23,1
 Harold Perkins Jr.,544,LB85,FA,21,R
 Jimmy Rolder,545,LB86,FA,-,R
 Mohamoud Diabate,546,LB87,TEN,24,3
-D&apos;Marco Jackson,547,LB88,CHI,27,4
+D'Marco Jackson,547,LB88,CHI,27,4
 DaRon Bland,548,CB45,DAL,26,4
 Bryce Boettcher,549,LB89,FA,23,R
 Aiden Fisher,550,LB90,FA,22,R
@@ -316,7 +316,7 @@ Christian Barmore,760,DT37,NE,26,5
 Joey Bosa,761,DE58,FA,30,10
 Carl Granderson,762,DE59,NO,29,7
 Joseph Ossai,763,DE60,NYJ,26,5
-A&apos;Shawn Robinson,764,DT38,TB,31,10
+A'Shawn Robinson,764,DT38,TB,31,10
 Jamel Dean,765,CB61,PIT,29,7
 Grant Delpit,766,S38,CLE,27,6
 Coby Bryant,767,S39,CHI,27,4
@@ -346,8 +346,8 @@ Lathan Ransom,791,S43,CAR,23,1
 Jonas Sanker,793,S44,NO,23,1
 Charvarius Ward,794,CB66,IND,29,8
 Geno Stone,800,S45,BUF,27,6
-K&apos;Lavon Chaisson,801,DE69,WAS,26,6
-Dre&apos;Mont Jones,802,DE70,NE,29,7
+K'Lavon Chaisson,801,DE69,WAS,26,6
+Dre'Mont Jones,802,DE70,NE,29,7
 Jonah Laulu,803,DT46,LV,25,2
 Harrison Phillips,804,DT47,NYJ,30,8
 D.J. Wonnum,805,DE71,DET,28,6

--- a/CSVs/site_raw/footballGuysSf.csv
+++ b/CSVs/site_raw/footballGuysSf.csv
@@ -11,7 +11,7 @@ Patrick Mahomes II,9,QB9,KC,30,9
 Trevor Lawrence,10,QB10,JAX,26,5
 Jaxson Dart,11,QB11,NYG,22,1
 Bo Nix,12,QB12,DEN,26,2
-Ja&apos;Marr Chase,13,WR1,CIN,26,5
+Ja'Marr Chase,13,WR1,CIN,26,5
 Brock Purdy,14,QB13,SF,26,4
 Puka Nacua,15,WR2,LAR,24,3
 Fernando Mendoza,16,QB14,FA,22,R
@@ -91,10 +91,10 @@ DJ Moore,112,WR33,BUF,29,8
 Michael Penix Jr.,113,QB28,ATL,25,2
 Derrick Henry,114,RB22,BAL,32,10
 Oronde Gadsden,115,TE9,LAC,22,1
-D&apos;Andre Swift,116,RB23,CHI,27,6
+D'Andre Swift,116,RB23,CHI,27,6
 Ricky Pearsall,118,WR34,SF,25,2
 RJ Harvey,119,RB24,DEN,25,1
-Wan&apos;Dale Robinson,120,WR35,TEN,25,4
+Wan'Dale Robinson,120,WR35,TEN,25,4
 Kenyon Sadiq,121,TE10,FA,21,R
 J.J. McCarthy,122,QB29,MIN,23,2
 Courtland Sutton,123,WR36,DEN,30,8
@@ -387,7 +387,7 @@ DeeJay Dallas,657,RB151,JAX,27,6
 Dylan Devezin,658,RB152,FA,-,R
 Donovan Edwards,659,RB153,MIA,23,1
 Ezekiel Elliott,660,RB154,FA,30,10
-D&apos;Onta Foreman,661,RB155,FA,30,9
+D'Onta Foreman,661,RB155,FA,30,9
 Tyler Goodson,662,RB156,ATL,25,4
 Eric Gray,663,RB157,NYG,26,3
 C.J. Ham,664,RB158,FA,32,10
@@ -396,7 +396,7 @@ JaMycal Hasty,666,RB160,FA,29,6
 Eli Heidenreich,667,RB161,FA,22,R
 Evan Hull,668,RB162,NO,25,3
 Terrell Jennings,669,RB163,NE,25,2
-D&apos;Ernest Johnson,670,RB164,FA,30,7
+D'Ernest Johnson,670,RB164,FA,30,7
 Cashion Jones,671,RB165,FA,24,R
 Corey Kiner,672,RB166,ARI,24,1
 Barika Kpeenu,673,RB167,FA,23,R
@@ -513,7 +513,7 @@ Van Jefferson,902,WR212,WAS,29,6
 Tyler Johnson,905,WR213,FA,27,6
 Isaiah Hodgins,906,WR214,NYG,27,6
 Treylon Burks,915,WR215,WAS,26,4
-Lil&apos;Jordan Humphrey,916,WR216,DEN,28,7
+Lil'Jordan Humphrey,916,WR216,DEN,28,7
 Allen Lazard,917,WR217,FA,30,8
 Tyler Boyd,918,WR218,FA,31,10
 KhaDarel Hodge,919,WR219,FA,31,8

--- a/scripts/fetch_footballguys.py
+++ b/scripts/fetch_footballguys.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
+import html as _html
 import json
 import os
 import re
@@ -328,8 +329,14 @@ def parse_rows(html: str, *, default_family: str | None = None) -> list[dict[str
             age = trail_m.group(1).strip()
             years_exp = trail_m.group(2).strip()
             # trail_m.group(3) is bye; we don't surface it
+        # HTML-unescape names.  FBG's ``data-playername`` attribute
+        # contains HTML entities (``Ja&apos;Marr Chase``,
+        # ``D&apos;Andre Swift``) that don't match the canonical
+        # apostrophe form Sleeper uses, so without unescape the
+        # canonical-name matcher drops these players silently.
+        # Affects ~11 players across the SF + IDP CSVs.
         out.append({
-            "name": name.strip(),
+            "name": _html.unescape(name).strip(),
             "rank": str(rank),
             "position": position_display,
             "family": canonical_family,


### PR DESCRIPTION
## Summary
FBG scraper was writing HTML-encoded names like \`Ja&apos;Marr Chase\` to the CSV. Canonical-name matcher treats that as different from \`Ja'Marr Chase\` so 11 apostrophed players silently lost FBG coverage.

## Affected players
6 offense + 5 IDP. Complete list in commit message; notable: Ja'Marr Chase (WR), D'Andre Swift (RB), L'Jarius Sneed (CB).

## Fix
\`html.unescape()\` applied to names in \`parse_rows()\` before CSV write. Also patched the two checked-in CSVs in place so Chase's FBG contribution lands in the live blend immediately.

## Test plan
- [x] pytest tests/ -q — 1739 pass
- [x] Live smoke: Chase + Swift + Robinson + Sneed all now have FBG stamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)