### PR TITLE
KTC trade import: accept pipe-separated IDs

### DIFF
--- a/src/trade/ktc_import.py
+++ b/src/trade/ktc_import.py
@@ -11,7 +11,9 @@ HTML of https://keeptradecut.com/trade-calculator.  Each entry has
         &teamOne=1274&teamTwo=1555
         &format=2&isStartup=0&tep=0
 
-where ``teamOne`` and ``teamTwo`` are comma-separated KTC player IDs.
+where ``teamOne`` and ``teamTwo`` are KTC player IDs separated by
+EITHER ``,`` (KTC's legacy URL form) OR ``|`` (KTC's current URL
+form).  The parser accepts both — we split on ``[,|]``.
 This module turns that URL into two ordered lists of canonical player
 names the frontend trade page can load into its sides.
 
@@ -129,7 +131,11 @@ def parse_trade_url(url: str) -> tuple[list[int], list[int]]:
     def _parse_side(raw_values: list[str]) -> list[int]:
         ids: list[int] = []
         for raw in raw_values:
-            for token in str(raw).split(","):
+            # KTC uses BOTH ``,`` and ``|`` as ID separators depending
+            # on where/when the URL was generated.  Treating only one
+            # as valid makes pipe-form URLs (``teamOne=1934|1771``)
+            # error out with "non-integer KTC id".  Split on either.
+            for token in re.split(r"[,|]", str(raw)):
                 token = token.strip()
                 if not token:
                     continue

--- a/tests/trade/test_ktc_import_parse.py
+++ b/tests/trade/test_ktc_import_parse.py
@@ -1,0 +1,69 @@
+"""Tests for KTC trade-URL parsing in
+``src.trade.ktc_import.parse_trade_url``.
+
+KTC uses either ``,`` or ``|`` to separate multiple player IDs in
+``teamOne`` / ``teamTwo``.  The parser must accept both forms.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.trade.ktc_import import parse_trade_url
+
+
+class TestParseTradeUrl(unittest.TestCase):
+    def test_single_ids_both_sides(self):
+        url = "https://keeptradecut.com/trade-calculator?teamOne=1274&teamTwo=1555&tep=0"
+        one, two = parse_trade_url(url)
+        self.assertEqual(one, [1274])
+        self.assertEqual(two, [1555])
+
+    def test_comma_separated_multi_ids(self):
+        """Legacy KTC URL form — comma-delimited."""
+        url = (
+            "https://keeptradecut.com/trade-calculator"
+            "?teamOne=1274,542&teamTwo=1555,1751&tep=0"
+        )
+        one, two = parse_trade_url(url)
+        self.assertEqual(one, [1274, 542])
+        self.assertEqual(two, [1555, 1751])
+
+    def test_pipe_separated_multi_ids(self):
+        """Current KTC URL form — pipe-delimited.  Regression guard
+        for the ``non-integer KTC id in URL: '1934|1771'`` error
+        users hit when importing trades from the live site."""
+        url = (
+            "https://keeptradecut.com/trade-calculator"
+            "?var=5&pickVal=0&teamOne=1934|1771&teamTwo=542|1751&format=2"
+        )
+        one, two = parse_trade_url(url)
+        self.assertEqual(one, [1934, 1771])
+        self.assertEqual(two, [542, 1751])
+
+    def test_mixed_delimiters_on_same_url(self):
+        """Defensive: if KTC ever generates mixed ``,`` and ``|``, we
+        still handle it.  Not observed in the wild, but cheap to
+        support with a single regex split."""
+        url = (
+            "https://keeptradecut.com/trade-calculator"
+            "?teamOne=100,200|300&teamTwo=400|500,600"
+        )
+        one, two = parse_trade_url(url)
+        self.assertEqual(one, [100, 200, 300])
+        self.assertEqual(two, [400, 500, 600])
+
+    def test_non_integer_still_raises(self):
+        url = "https://keeptradecut.com/trade-calculator?teamOne=abc&teamTwo=1555"
+        with self.assertRaises(ValueError) as ctx:
+            parse_trade_url(url)
+        self.assertIn("non-integer KTC id", str(ctx.exception))
+
+    def test_empty_url_raises(self):
+        url = "https://keeptradecut.com/trade-calculator?foo=bar"
+        with self.assertRaises(ValueError) as ctx:
+            parse_trade_url(url)
+        self.assertIn("missing both teamOne and teamTwo", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
KTC now pipe-separates IDs in the trade URL (\`teamOne=1934|1771\`). Our parser only split on \`,\` — current KTC URLs error with \`non-integer KTC id in URL: '1934|1771'\`.

## Fix
One-line change: split on \`[,|]\` instead of just \`,\`. Both forms now parse.

## Test plan
- [x] pytest tests/ -q — 1745 pass (6 new regression cases)
- [x] Verified manually against the URL the user was importing

🤖 Generated with [Claude Code](https://claude.com/claude-code)