### PR TITLE
Fix Trade page crash + Edge \u2014 rendering + tighten Sell/Buy to top-150

### DIFF
--- a/frontend/__tests__/edge-helpers.test.js
+++ b/frontend/__tests__/edge-helpers.test.js
@@ -317,9 +317,11 @@ describe("getLens", () => {
 // ── isTopRankedForEdgePremium ────────────────────────────────────────
 //
 // The Edge page's Sell Signals / Buy Signals sections are pinned to
-// the top 200 by consensus rank OR KTC rank so deep-bench
-// disagreements (which have no trade relevance) don't flood the
-// sections.  This block pins every eligibility branch.
+// the top 150 by OUR consensus rank only — the previous OR-on-KTC
+// path was dropped (users reported it surfaced deep players KTC
+// priced high but our blend ranked outside the top 200, defeating
+// the "only trade-relevant" intent).  This block pins the new,
+// stricter gate.
 
 describe("isTopRankedForEdgePremium", () => {
   it("returns false for null / undefined / missing row", () => {
@@ -327,60 +329,43 @@ describe("isTopRankedForEdgePremium", () => {
     expect(isTopRankedForEdgePremium(undefined)).toBe(false);
   });
 
-  it("admits rows whose consensus rank is inside the top 200", () => {
+  it("admits rows whose consensus rank is inside the top 150", () => {
     expect(isTopRankedForEdgePremium({ rank: 1 })).toBe(true);
     expect(isTopRankedForEdgePremium({ rank: 50 })).toBe(true);
-    expect(isTopRankedForEdgePremium({ rank: 199 })).toBe(true);
-    expect(isTopRankedForEdgePremium({ rank: 200 })).toBe(true);
+    expect(isTopRankedForEdgePremium({ rank: 149 })).toBe(true);
+    expect(isTopRankedForEdgePremium({ rank: 150 })).toBe(true);
   });
 
-  it("rejects rows whose consensus rank is past the top 200 with no KTC signal", () => {
-    expect(isTopRankedForEdgePremium({ rank: 201 })).toBe(false);
+  it("rejects rows past the top 150", () => {
+    expect(isTopRankedForEdgePremium({ rank: 151 })).toBe(false);
+    expect(isTopRankedForEdgePremium({ rank: 200 })).toBe(false);
     expect(isTopRankedForEdgePremium({ rank: 500 })).toBe(false);
   });
 
-  it("admits rows with KTC rank <= 200 even when consensus rank is past 200", () => {
+  it("ignores KTC rank — consensus rank is the sole gate", () => {
+    // Previously admitted on ``ktc <= 200`` even when consensus was
+    // past 200; that escape hatch is gone.  A player KTC prices top-10
+    // but OUR blend ranks #300 now DOES NOT surface in Sell/Buy.
     expect(
-      isTopRankedForEdgePremium({ rank: 500, sourceRanks: { ktc: 150 } }),
-    ).toBe(true);
-    expect(
-      isTopRankedForEdgePremium({ rank: 201, sourceRanks: { ktc: 200 } }),
-    ).toBe(true);
-  });
-
-  it("rejects rows where both ranks are past the top 200", () => {
-    expect(
-      isTopRankedForEdgePremium({ rank: 250, sourceRanks: { ktc: 300 } }),
+      isTopRankedForEdgePremium({ rank: 500, sourceRanks: { ktc: 50 } }),
     ).toBe(false);
     expect(
-      isTopRankedForEdgePremium({ rank: 500, sourceRanks: { ktc: 500 } }),
+      isTopRankedForEdgePremium({ rank: 300, sourceRanks: { ktc: 10 } }),
     ).toBe(false);
-  });
-
-  it("treats a missing consensus rank as Infinity and defers to KTC", () => {
+    // And a player inside top-150 consensus is admitted regardless
+    // of KTC rank.
     expect(
-      isTopRankedForEdgePremium({ sourceRanks: { ktc: 100 } }),
+      isTopRankedForEdgePremium({ rank: 100, sourceRanks: { ktc: 800 } }),
     ).toBe(true);
-    expect(
-      isTopRankedForEdgePremium({ sourceRanks: { ktc: 300 } }),
-    ).toBe(false);
   });
 
-  it("treats a missing sourceRanks.ktc as Infinity and defers to consensus", () => {
-    expect(isTopRankedForEdgePremium({ rank: 150 })).toBe(true);
-    expect(isTopRankedForEdgePremium({ rank: 150, sourceRanks: {} })).toBe(
-      true,
-    );
-    expect(isTopRankedForEdgePremium({ rank: 220, sourceRanks: {} })).toBe(
-      false,
-    );
-  });
-
-  it("returns false when both ranks are NaN / missing", () => {
+  it("returns false when consensus rank is missing / invalid", () => {
     expect(isTopRankedForEdgePremium({})).toBe(false);
     expect(isTopRankedForEdgePremium({ rank: null })).toBe(false);
+    expect(isTopRankedForEdgePremium({ rank: 0 })).toBe(false);
+    expect(isTopRankedForEdgePremium({ rank: -5 })).toBe(false);
     expect(
-      isTopRankedForEdgePremium({ rank: "garbage", sourceRanks: { ktc: null } }),
+      isTopRankedForEdgePremium({ rank: "garbage", sourceRanks: { ktc: 10 } }),
     ).toBe(false);
   });
 });

--- a/frontend/app/edge/page.jsx
+++ b/frontend/app/edge/page.jsx
@@ -141,7 +141,11 @@ const COL_GAP_DIR = {
   render: (r) => {
     if (r.marketGapDirection === "retail_premium") return <span className="text-cyan">Sell</span>;
     if (r.marketGapDirection === "consensus_premium") return <span className="text-amber">Buy</span>;
-    return <span className="muted">\u2014</span>;
+    // JSX text nodes don't interpret ``\uXXXX`` escapes — wrapping in
+    // a JS-string expression forces the em-dash to render correctly
+    // instead of the four literal characters ``\``, ``u``, ``2``,
+    // ``0``, ``1``, ``4`` showing up in the cell.
+    return <span className="muted">{"\u2014"}</span>;
   },
 };
 
@@ -169,7 +173,7 @@ const COL_SIGNAL = {
   render: (r) => {
     const action = actionLabel(r);
     const cautions = cautionLabels(r);
-    if (!action && cautions.length === 0) return <span className="muted">\u2014</span>;
+    if (!action && cautions.length === 0) return <span className="muted">{"\u2014"}</span>;
     return (
       <>
         {action && <span className={`action-label ${action.css}`} title={action.title}>{action.label}</span>}
@@ -407,7 +411,7 @@ export default function EdgePage() {
             {/* Sell Signals — retail (KTC) values higher than consensus */}
             <EdgeSection
               title="Sell Signals"
-              description={`Players the retail market (${getRetailLabel()}) values much higher than the expert consensus. Limited to players inside the top ${EDGE_PREMIUM_RANK_LIMIT} by consensus or ${getRetailLabel()} rank so only trade-relevant gaps surface. Potential sells to retail-first trade partners.`}
+              description={`Players the retail market (${getRetailLabel()}) values much higher than the expert consensus. Limited to players inside the top ${EDGE_PREMIUM_RANK_LIMIT} on OUR blended board so only trade-relevant gaps surface. Potential sells to retail-first trade partners.`}
               count={`${retailPremium.length} shown`}
               accent="cyan"
             >
@@ -422,7 +426,7 @@ export default function EdgePage() {
             {/* Buy Signals — consensus values higher than retail */}
             <EdgeSection
               title="Buy Signals"
-              description={`Players the expert consensus values much higher than ${getRetailLabel()}. Limited to players inside the top ${EDGE_PREMIUM_RANK_LIMIT} by consensus or ${getRetailLabel()} rank so only trade-relevant gaps surface. Potential buys from retail-first trade partners.`}
+              description={`Players the expert consensus values much higher than ${getRetailLabel()}. Limited to players inside the top ${EDGE_PREMIUM_RANK_LIMIT} on OUR blended board so only trade-relevant gaps surface. Potential buys from retail-first trade partners.`}
               count={`${consensusPremium.length} shown`}
               accent="cyan"
             >

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -15,6 +15,7 @@ import {
   colorFromGap,
   verdictBarPosition,
   adjustedSideTotals,
+  multiAdjustedSideTotals,
   tradeGapAdjusted,
   sideTotal,
   effectiveValue,

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -28,45 +28,24 @@ import { isEligibleForAnalysis } from "./display-helpers.js";
 import { getRetailLabel } from "./dynasty-data.js";
 
 /**
- * True when a row is "top-ranked" for the Edge page Premium sections.
- * A row qualifies if EITHER its consensus rank OR its per-source KTC
- * rank is inside the top ``EDGE_PREMIUM_RANK_LIMIT`` (200 today).
+ * True when a row is "top-ranked" for the Edge page Premium sections
+ * (Sell / Buy Signals).  Qualifies strictly by OUR consensus rank —
+ * inside the top ``EDGE_PREMIUM_RANK_LIMIT`` (150 today) on the
+ * blended board.
  *
- * The Premium sections on /edge are the only two that use this
- * filter — the other sections (Consensus Assets, Biggest
- * Disagreements, Flagged Anomalies, Single-Source Players) still
- * trust the backend's ``canonicalConsensusRank`` alone or a
- * different rank-based cap, because their signals are still
- * meaningful for players outside the top 200.  Premium gaps are
- * different: a deep-bench player with wildly different consensus
- * and retail ranks has no real trade relevance, so we pin both
- * Premium tables to players who actually show up near the top of
- * at least one of the two scales.
- *
- * ``row.rank`` is the resolved consensus rank stamp (see
- * ``resolvedRank`` in dynasty-data.js); ``row.sourceRanks.ktc`` is
- * the per-source KTC rank stamp produced by the canonical
- * ranking pipeline in
- * ``src/api/data_contract.py::_compute_unified_rankings``.
+ * Previously qualified on ``consensus OR ktc`` rank, which pulled in
+ * players KTC priced high but our blend ranked deep (Mac Jones,
+ * Jacoby Brissett, etc.).  That defeated the "only trade-relevant"
+ * intent — if OUR board doesn't think a player is top-150, a market
+ * gap on them isn't actionable.
  */
 export function isTopRankedForEdgePremium(row) {
   if (!row) return false;
-  // Real ranks start at 1; rank 0 or negative is a sentinel for
-  // "no rank" (e.g. Number(null) → 0) and should not count as
-  // "top-ranked".  Require a strictly positive finite rank <= cap.
   const consensusRank = Number(row.rank);
   if (
     Number.isFinite(consensusRank) &&
     consensusRank >= 1 &&
     consensusRank <= EDGE_PREMIUM_RANK_LIMIT
-  ) {
-    return true;
-  }
-  const ktcRank = Number(row?.sourceRanks?.ktc);
-  if (
-    Number.isFinite(ktcRank) &&
-    ktcRank >= 1 &&
-    ktcRank <= EDGE_PREMIUM_RANK_LIMIT
   ) {
     return true;
   }

--- a/frontend/lib/thresholds.js
+++ b/frontend/lib/thresholds.js
@@ -51,14 +51,18 @@ export const MARKET_GAP_MIN_DIFF = 10;
 export const EDGE_CAUTION_RANK_LIMIT = 300;
 
 /**
- * Maximum rank (by consensus OR retail/KTC) for players to appear in
- * the Edge page's Sell Signals / Buy Signals sections.  Deep-bench
- * players can have huge source disagreements without any real trade
- * relevance, so we pin both sections to players inside the top 200 of
- * either scale.  A player qualifies when EITHER their consensus rank
- * is <= 200 OR their per-source KTC rank is <= 200.
+ * Maximum OUR-consensus rank for players to appear in the Edge page's
+ * Sell Signals / Buy Signals sections.  Deep-bench players can have
+ * huge source disagreements without any real trade relevance, so we
+ * pin both sections to players inside the top 150 of the blended
+ * board.  Previously qualified on ``consensus <= 200 OR ktc <= 200``
+ * — the KTC-only path pulled in low-rated players KTC happened to
+ * price highly (Mac Jones, Jacoby Brissett, etc.) which defeated
+ * the "only trade-relevant" intent.  Now single-filtered on
+ * consensus rank: if the blended board doesn't think the player is
+ * top-150, no signal.
  */
-export const EDGE_PREMIUM_RANK_LIMIT = 200;
+export const EDGE_PREMIUM_RANK_LIMIT = 150;
 
 // ── Display limits ──────────────────────────────────────────────────────────
 // These are page-level UX choices, not data thresholds.


### PR DESCRIPTION
## Three fixes
1. **Trade Builder crashed** with \`multiAdjustedSideTotals is not defined\` — missing import on \`frontend/app/trade/page.jsx\`. Added it.
2. **Edge page** rendered literal \`\\u2014\` text instead of em-dashes in the Gap Direction column for rows with no retail/consensus premium. JSX text nodes don't interpret \`\\uXXXX\` escapes — wrapped in \`{"\\u2014"}\`.
3. **Sell/Buy Signals** filter changed from "consensus ≤ 200 OR ktc ≤ 200" to "OUR consensus ≤ 150" so surfaced players are always trade-relevant on our board. Mac Jones / Jacoby Brissett-type KTC-inflated names no longer appear.

## Test plan
- [x] 1745 backend tests pass
- [x] 425 frontend tests pass
- [x] Edge helper test block rewritten for new gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)