### PR TITLE
3-team trade: show per-side Receiving list

### DIFF
--- a/frontend/__tests__/trade-logic.test.js
+++ b/frontend/__tests__/trade-logic.test.js
@@ -42,6 +42,7 @@ import {
   createSide,
   defaultDestination,
   computeSideFlows,
+  computeSideFlowAssets,
   serializeWorkspaceMulti,
   deserializeWorkspaceMulti,
   SIDE_LABELS,
@@ -1433,6 +1434,71 @@ describe("computeSideFlows", () => {
     const flows = computeSideFlows(sides, "full");
     const totalNet = flows.reduce((s, f) => s + f.net, 0);
     expect(totalNet).toBe(0);
+  });
+});
+
+// ── computeSideFlowAssets ───────────────────────────────────────────────
+
+describe("computeSideFlowAssets", () => {
+  it("2-team trade: every outgoing asset has a mirror incoming entry", () => {
+    const sides = [
+      { id: 0, label: "A", assets: [ALLEN], destinations: {} },
+      { id: 1, label: "B", assets: [CHASE], destinations: {} },
+    ];
+    const flow = computeSideFlowAssets(sides);
+    expect(flow[0].outgoing).toEqual([{ asset: ALLEN, toSideIdx: 1 }]);
+    expect(flow[0].incoming).toEqual([{ asset: CHASE, fromSideIdx: 1 }]);
+    expect(flow[1].outgoing).toEqual([{ asset: CHASE, toSideIdx: 0 }]);
+    expect(flow[1].incoming).toEqual([{ asset: ALLEN, fromSideIdx: 0 }]);
+  });
+
+  it("3-team trade: routes per the destinations map", () => {
+    const sides = [
+      { id: 0, label: "A", assets: [ALLEN], destinations: { "Josh Allen": 2 } },
+      { id: 1, label: "B", assets: [CHASE], destinations: { "Ja'Marr Chase": 0 } },
+      { id: 2, label: "C", assets: [PARSONS], destinations: { "Micah Parsons": 1 } },
+    ];
+    const flow = computeSideFlowAssets(sides);
+    expect(flow[0].outgoing).toEqual([{ asset: ALLEN, toSideIdx: 2 }]);
+    expect(flow[0].incoming).toEqual([{ asset: CHASE, fromSideIdx: 1 }]);
+    expect(flow[1].outgoing).toEqual([{ asset: CHASE, toSideIdx: 0 }]);
+    expect(flow[1].incoming).toEqual([{ asset: PARSONS, fromSideIdx: 2 }]);
+    expect(flow[2].outgoing).toEqual([{ asset: PARSONS, toSideIdx: 1 }]);
+    expect(flow[2].incoming).toEqual([{ asset: ALLEN, fromSideIdx: 0 }]);
+  });
+
+  it("empty side with no incoming: receives nothing", () => {
+    const sides = [
+      { id: 0, label: "A", assets: [ALLEN], destinations: { "Josh Allen": 1 } },
+      { id: 1, label: "B", assets: [], destinations: {} },
+      { id: 2, label: "C", assets: [], destinations: {} },
+    ];
+    const flow = computeSideFlowAssets(sides);
+    expect(flow[0].outgoing.length).toBe(1);
+    expect(flow[0].incoming.length).toBe(0);
+    expect(flow[1].incoming.length).toBe(1);
+    expect(flow[2].incoming.length).toBe(0);
+  });
+
+  it("every outgoing has a matching incoming (bijection)", () => {
+    const sides = [
+      { id: 0, label: "A", assets: [ALLEN, MAHOMES], destinations: { "Josh Allen": 1, "Patrick Mahomes": 2 } },
+      { id: 1, label: "B", assets: [CHASE], destinations: { "Ja'Marr Chase": 2 } },
+      { id: 2, label: "C", assets: [PARSONS, PICK_2026], destinations: { "Micah Parsons": 0, "2026 Early 1st": 1 } },
+    ];
+    const flow = computeSideFlowAssets(sides);
+    const totalOutgoing = flow.reduce((s, f) => s + f.outgoing.length, 0);
+    const totalIncoming = flow.reduce((s, f) => s + f.incoming.length, 0);
+    expect(totalOutgoing).toBe(5);
+    expect(totalIncoming).toBe(5);
+    expect(totalOutgoing).toBe(totalIncoming);
+  });
+
+  it("empty / single-side inputs return empty-shaped results", () => {
+    expect(computeSideFlowAssets([])).toEqual([]);
+    expect(computeSideFlowAssets([{ assets: [ALLEN] }])).toEqual([
+      { outgoing: [], incoming: [] },
+    ]);
   });
 });
 

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -30,6 +30,7 @@ import {
   valueAdjustmentFromSideArrays,
   defaultDestination,
   computeSideFlows,
+  computeSideFlowAssets,
   SIDE_LABELS,
   MAX_SIDES,
   MIN_SIDES,
@@ -661,6 +662,16 @@ export default function TradePage() {
   const sideFlows = useMemo(
     () => computeSideFlows(sides, valueMode, settings),
     [sides, valueMode, settings],
+  );
+
+  // Per-side incoming / outgoing asset lists.  This is the
+  // "who's getting what" view — for each side we know exactly which
+  // assets (and from whom) are arriving.  Rendered as a "Receiving"
+  // section in 3+-team mode so the user doesn't have to mentally
+  // reverse-lookup destinations across three separate side cards.
+  const sideFlowAssets = useMemo(
+    () => computeSideFlowAssets(sides),
+    [sides],
   );
 
   // Legacy 2-team gap computations (for sticky tray + 2-team balancers)
@@ -1323,7 +1334,20 @@ export default function TradePage() {
                       <button className="button trade-add-btn" onClick={() => openPickerFor(sideIdx)}>+ Add</button>
                     </div>
                   </div>
-                  <div className="list" style={{ marginTop: 10 }}>
+                  {sides.length > 2 && (
+                    <div
+                      className="label"
+                      style={{
+                        marginTop: 10,
+                        fontSize: "0.68rem",
+                        color: "var(--red)",
+                        letterSpacing: "0.05em",
+                      }}
+                    >
+                      GIVING
+                    </div>
+                  )}
+                  <div className="list" style={{ marginTop: sides.length > 2 ? 4 : 10 }}>
                     {side.assets.map((r) => {
                       const edge = getPlayerEdge(r);
                       // In 3+-team trades, each asset has an explicit
@@ -1395,6 +1419,72 @@ export default function TradePage() {
                     })}
                     {side.assets.length === 0 && <div className="muted">No assets yet.</div>}
                   </div>
+                  {/* Receiving section — 3+-team mode only.  Shows the
+                      assets that other sides have routed to THIS side,
+                      so each card answers both "what am I giving up?"
+                      and "what am I getting back?" in the same place. */}
+                  {sides.length > 2 && (
+                    <>
+                      <div
+                        className="label"
+                        style={{
+                          marginTop: 10,
+                          fontSize: "0.68rem",
+                          color: "var(--green)",
+                          letterSpacing: "0.05em",
+                        }}
+                      >
+                        RECEIVING
+                      </div>
+                      <div className="list" style={{ marginTop: 4 }}>
+                        {(sideFlowAssets[sideIdx]?.incoming || []).length > 0 ? (
+                          sideFlowAssets[sideIdx].incoming.map(({ asset, fromSideIdx }) => {
+                            const edge = getPlayerEdge(asset);
+                            return (
+                              <div
+                                className="asset-row"
+                                key={`recv-${side.label}-${asset.name}`}
+                                style={{ borderLeft: "2px solid var(--green)", paddingLeft: 6 }}
+                              >
+                                <div>
+                                  <div className="asset-name">
+                                    <span
+                                      style={{ cursor: "pointer", textDecoration: "underline dotted" }}
+                                      onClick={() => openPlayerPopup?.(asset)}
+                                    >
+                                      {asset.name}
+                                    </span>
+                                    {edge.signal && (
+                                      <span
+                                        className="badge"
+                                        style={{
+                                          marginLeft: 6,
+                                          fontSize: "0.6rem",
+                                          padding: "1px 4px",
+                                          color: edge.signal === "BUY" ? "var(--green)" : "var(--red)",
+                                          borderColor: edge.signal === "BUY" ? "var(--green)" : "var(--red)",
+                                        }}
+                                      >
+                                        {edge.signal} {edge.edgePct}%
+                                      </span>
+                                    )}
+                                  </div>
+                                  <div className="asset-meta">
+                                    {asset.pos} · from Side {sides[fromSideIdx]?.label || "?"} ·{" "}
+                                    {Math.round(effectiveValue(asset, valueMode, settings)).toLocaleString()}
+                                  </div>
+                                </div>
+                              </div>
+                            );
+                          })
+                        ) : (
+                          <div className="muted" style={{ fontSize: "0.72rem" }}>
+                            Nothing incoming. Assign a destination on another side to route here.
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
                   {/* Balancers (2-team mode only) */}
                   {sides.length === 2 && isUnderpaying && balancers.length > 0 && (
                     <div style={{ marginTop: 8, padding: "6px 8px", background: "rgba(255,198,47,0.06)", borderRadius: 6 }}>

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -690,6 +690,59 @@ export function defaultDestination(sideIdx, sideCount) {
 }
 
 /**
+ * Compute, for each side, the lists of incoming / outgoing asset
+ * references with their counterparty side index.  This is the
+ * "who's getting what" view of a multi-team trade — the companion
+ * to ``computeSideFlows`` which only returns totals.
+ *
+ * Returns an array of ``{ outgoing, incoming }`` per side.  Each
+ * entry in ``outgoing`` is ``{ asset, toSideIdx }`` and each entry
+ * in ``incoming`` is ``{ asset, fromSideIdx }``.
+ *
+ * In 2-team trades the mapping is implicit (every asset flows to
+ * the other side).  In 3+-team trades the destinations map drives
+ * routing, with the same default-destination fallback used in
+ * ``computeSideFlows``.
+ *
+ * @param {object[]} sides
+ * @returns {{outgoing: {asset: object, toSideIdx: number}[], incoming: {asset: object, fromSideIdx: number}[]}[]}
+ */
+export function computeSideFlowAssets(sides) {
+  const n = Array.isArray(sides) ? sides.length : 0;
+  const result = [];
+  for (let i = 0; i < n; i++) result.push({ outgoing: [], incoming: [] });
+  if (n < 2) return result;
+
+  for (let i = 0; i < n; i++) {
+    const side = sides[i];
+    const assets = Array.isArray(side?.assets) ? side.assets : [];
+    const destinations = side?.destinations || {};
+    for (const asset of assets) {
+      let dest;
+      if (n === 2) {
+        dest = 1 - i;
+      } else {
+        const raw = destinations[asset.name];
+        const parsed = Number(raw);
+        if (
+          Number.isInteger(parsed) &&
+          parsed >= 0 &&
+          parsed < n &&
+          parsed !== i
+        ) {
+          dest = parsed;
+        } else {
+          dest = defaultDestination(i, n);
+        }
+      }
+      result[i].outgoing.push({ asset, toSideIdx: dest });
+      result[dest].incoming.push({ asset, fromSideIdx: i });
+    }
+  }
+  return result;
+}
+
+/**
  * Compute per-side flow for a multi-team trade with explicit destinations.
  *
  * Returns an array of ``{ given, received, net }`` per side in the same


### PR DESCRIPTION
## Summary
Each side card in a 3+-team trade now has two sections: **GIVING** (the assets this side is handing over, unchanged) and **RECEIVING** (read-only list of assets routed TO this side from other sides, labeled with their source).

Follow-on to PR #209 — destination routing was shipped, but the pieces-level "who's getting what" view was missing. You had to reverse-lookup every other side's destination dropdown to figure out what each team walked away with. The NET bar only gave totals.

## Behavior
- 2-team trades: unchanged. GIVING / RECEIVING headers don't render.
- 3+-team trades: each card renders both sections. Incoming rows are read-only — the asset's source-of-truth is on the giving side, and you edit (or Remove) it there.
- Incoming row includes a green left-border accent + "from Side X" label + the asset value.

## Test plan
- [x] `npx vitest run` — 445 tests pass (5 new for `computeSideFlowAssets`)
- [x] `npm run build` — clean production build
- [ ] Smoke: 3-team trade with mixed routing shows correct incoming lists per side
- [ ] Smoke: 2-team trade unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)