### PR TITLE
Add audit_dropped_sources.py — diagnose Hampel filter firing rate

### DIFF
--- a/scripts/audit_dropped_sources.py
+++ b/scripts/audit_dropped_sources.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Audit per-player Hampel outlier rejections in the live contract.
+
+The per-player Hampel filter in ``src/api/data_contract.py`` drops
+source values that sit more than ``_HAMPEL_K`` MADs from the median of
+a player's other source values (with a 500 Hill-point absolute floor).
+Each affected row stamps ``droppedSources: [...]``.
+
+This script surveys those stamps across the whole board and answers
+three diagnostic questions:
+
+  1. How often does Hampel fire at all? (total affected rows,
+     distribution of dropped-count per row)
+  2. Which sources get dropped most? A source that's dropped on >10%
+     of the rows it *could* rank is a candidate for re-ingestion rules,
+     a global weight reduction, or adapter-level investigation — its
+     disagreement isn't random, it's systemic.
+  3. Which individual players carry the largest dropped-source sets?
+     Those are the worthwhile spot-check cases: either genuine outlier
+     rejections we can verify, or surprise rejections that indicate a
+     join-hygiene problem we haven't caught yet.
+
+Run this after a scrape (or any time after the contract has been
+rebuilt) to see whether the filter is doing useful work or whether K
+/ min_threshold should be retuned.
+
+Usage:
+    python scripts/audit_dropped_sources.py [--json-path PATH]
+                                            [--top N]
+                                            [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_payload(json_path: str | None) -> dict:
+    """Locate and load the latest contract payload.
+
+    Mirrors ``scripts/audit_identity.py::_load_payload`` — prefer an
+    explicit ``--json-path`` override, otherwise fall back to the
+    standard latest-build locations.
+    """
+    if json_path:
+        p = Path(json_path)
+    else:
+        candidates = [
+            REPO / "data" / "latest.json",
+            REPO / "exports" / "latest" / "dynasty_data.json",
+            REPO / "data" / "dynasty_data.json",
+        ]
+        p = None
+        for c in candidates:
+            if c.exists():
+                p = c
+                break
+        if p is None:
+            print(
+                "ERROR: No data file found. Pass --json-path explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    print(f"Loading: {p}")
+    with p.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _players_array(payload: dict) -> list[dict[str, Any]]:
+    """Find the players array inside the contract payload.
+
+    The API response wraps the contract under ``data``; the exports
+    build writes it at the top level.
+    """
+    if isinstance(payload.get("data"), dict):
+        arr = payload["data"].get("playersArray")
+        if isinstance(arr, list):
+            return arr
+    arr = payload.get("playersArray")
+    return arr if isinstance(arr, list) else []
+
+
+def _eligible_rows_per_source(
+    players: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Count how many rows each source actually ranked.
+
+    The denominator for "how often is this source Hampel-dropped?"
+    must be the set of rows where the source contributed in the first
+    place — not the whole board — otherwise a source that covers only
+    IDPs looks artificially stable relative to one that covers the
+    full offense pool.
+    """
+    counts: Counter[str] = Counter()
+    for row in players:
+        ranks = row.get("sourceRanks") or {}
+        if isinstance(ranks, dict):
+            for key in ranks.keys():
+                counts[str(key)] += 1
+    return dict(counts)
+
+
+def _summarise(players: list[dict[str, Any]]) -> dict[str, Any]:
+    eligible = _eligible_rows_per_source(players)
+
+    total_rows = len(players)
+    rows_with_drops = 0
+    drop_count_histogram: Counter[int] = Counter()
+    dropped_by_source: Counter[str] = Counter()
+    dropped_by_position: Counter[str] = Counter()
+    biggest_offenders: list[dict[str, Any]] = []
+
+    for row in players:
+        dropped = row.get("droppedSources") or []
+        if not isinstance(dropped, list) or not dropped:
+            continue
+        rows_with_drops += 1
+        drop_count_histogram[len(dropped)] += 1
+        for sk in dropped:
+            dropped_by_source[str(sk)] += 1
+        pos = str(row.get("position") or "?").upper()
+        dropped_by_position[pos] += 1
+        biggest_offenders.append(
+            {
+                "rank": row.get("canonicalConsensusRank"),
+                "name": row.get("displayName") or row.get("canonicalName") or "?",
+                "position": pos,
+                "dropped": list(dropped),
+                "sourceCount": row.get("sourceCount") or 0,
+                "spread": row.get("sourceRankPercentileSpread"),
+            }
+        )
+
+    biggest_offenders.sort(
+        key=lambda o: (-len(o["dropped"]), o["rank"] or 1_000_000)
+    )
+
+    return {
+        "total_rows": total_rows,
+        "rows_with_drops": rows_with_drops,
+        "drop_count_histogram": dict(sorted(drop_count_histogram.items())),
+        "dropped_by_source": dict(
+            sorted(dropped_by_source.items(), key=lambda kv: -kv[1])
+        ),
+        "eligible_rows_per_source": eligible,
+        "dropped_by_position": dict(
+            sorted(dropped_by_position.items(), key=lambda kv: -kv[1])
+        ),
+        "biggest_offenders": biggest_offenders,
+    }
+
+
+def _print_report(summary: dict[str, Any], *, top: int) -> None:
+    total = summary["total_rows"]
+    hit = summary["rows_with_drops"]
+    pct = (100.0 * hit / total) if total else 0.0
+    print(f"\n{'=' * 70}")
+    print(f"  Hampel drop summary ({total} rows)")
+    print(f"{'=' * 70}")
+    print(f"Rows with >=1 dropped source: {hit} ({pct:.1f}%)")
+
+    hist = summary["drop_count_histogram"]
+    if hist:
+        print("\nDrops-per-row distribution:")
+        for k in sorted(hist.keys()):
+            print(f"  {k} dropped: {hist[k]:>4d} rows")
+
+    print(f"\n{'=' * 70}")
+    print("  Drop rate per source")
+    print(f"{'=' * 70}")
+    print("(dropped / eligible = percentage of this source's rows that were rejected)")
+    print()
+    src_drops = summary["dropped_by_source"]
+    eligible = summary["eligible_rows_per_source"]
+    keys = sorted(
+        set(src_drops) | set(eligible),
+        key=lambda k: (-src_drops.get(k, 0), k),
+    )
+    print(f"  {'source':<28s} {'dropped':>8s} {'eligible':>10s} {'rate':>8s}")
+    for key in keys:
+        d = src_drops.get(key, 0)
+        e = eligible.get(key, 0)
+        rate = (100.0 * d / e) if e else 0.0
+        flag = "  <-- elevated" if rate >= 10.0 and e >= 20 else ""
+        print(f"  {key:<28s} {d:>8d} {e:>10d} {rate:>7.1f}%{flag}")
+
+    pos_drops = summary["dropped_by_position"]
+    if pos_drops:
+        print(f"\n{'=' * 70}")
+        print("  Drops by position")
+        print(f"{'=' * 70}")
+        for pos, n in pos_drops.items():
+            print(f"  {pos:<5s} {n:>4d}")
+
+    offenders = summary["biggest_offenders"][:top]
+    if offenders:
+        print(f"\n{'=' * 70}")
+        print(f"  Top {len(offenders)} rows by dropped-source count")
+        print(f"{'=' * 70}")
+        print(
+            f"  {'rank':>5s}  {'name':<30s} {'pos':<5s} "
+            f"{'#drop':>6s} {'#src':>5s} {'spread':>8s}  dropped"
+        )
+        for o in offenders:
+            rank = str(o["rank"]) if o["rank"] is not None else "-"
+            spread = (
+                f"{o['spread']:.3f}" if isinstance(o["spread"], (int, float)) else "-"
+            )
+            dropped = ", ".join(o["dropped"])
+            print(
+                f"  {rank:>5s}  {o['name']:<30s} {o['position']:<5s} "
+                f"{len(o['dropped']):>6d} {o['sourceCount']:>5d} {spread:>8s}  {dropped}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json-path",
+        default=None,
+        help="Explicit path to a contract JSON snapshot (overrides autodiscovery).",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=20,
+        help="Number of biggest-offender rows to list (default 20).",
+    )
+    parser.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit the summary as JSON on stdout instead of a text report.",
+    )
+    args = parser.parse_args()
+
+    payload = _load_payload(args.json_path)
+    players = _players_array(payload)
+    if not players:
+        print("ERROR: no playersArray found in the payload.", file=sys.stderr)
+        return 1
+
+    summary = _summarise(players)
+
+    if args.emit_json:
+        print(json.dumps(summary, indent=2, default=str))
+    else:
+        _print_report(summary, top=args.top)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_dropped_sources.py
+++ b/scripts/audit_dropped_sources.py
@@ -102,13 +102,26 @@ def _eligible_rows_per_source(
     place — not the whole board — otherwise a source that covers only
     IDPs looks artificially stable relative to one that covers the
     full offense pool.
+
+    Union of ``sourceRanks.keys()`` and ``droppedSources`` per row: the
+    current backend keeps dropped keys in ``sourceRanks`` so the union
+    is a no-op, but if a future change strips Hampel-rejected keys out
+    of ``sourceRanks`` entirely the dropped occurrences would vanish
+    from the denominator and a chronically-dropped source would show
+    as ``0 / 0`` instead of ``N / N`` — inverting the elevated-source
+    diagnosis.  Union-ing is cheap insurance against that.
     """
     counts: Counter[str] = Counter()
     for row in players:
+        keys: set[str] = set()
         ranks = row.get("sourceRanks") or {}
         if isinstance(ranks, dict):
-            for key in ranks.keys():
-                counts[str(key)] += 1
+            keys.update(str(k) for k in ranks.keys())
+        dropped = row.get("droppedSources") or []
+        if isinstance(dropped, list):
+            keys.update(str(k) for k in dropped)
+        for key in keys:
+            counts[key] += 1
     return dict(counts)
 
 

--- a/scripts/audit_dropped_sources.py
+++ b/scripts/audit_dropped_sources.py
@@ -70,7 +70,10 @@ def _load_payload(json_path: str | None) -> dict:
             )
             sys.exit(1)
 
-    print(f"Loading: {p}")
+    # Print the load status to stderr so ``--json`` output on stdout
+    # stays valid JSON that can be piped straight into ``jq`` without
+    # having to strip a leading progress line.
+    print(f"Loading: {p}", file=sys.stderr)
     with p.open("r", encoding="utf-8") as f:
         return json.load(f)
 

--- a/tests/scripts/test_audit_dropped_sources.py
+++ b/tests/scripts/test_audit_dropped_sources.py
@@ -1,0 +1,158 @@
+"""Unit tests for ``scripts/audit_dropped_sources.py``.
+
+The script is a diagnostic surface for the per-player Hampel filter.
+These tests pin the shape of its summary output so a future refactor
+can't silently break the histogram / per-source / biggest-offender
+sections consumers rely on.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "audit_dropped_sources.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "audit_dropped_sources", SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+_summarise = _mod._summarise
+_eligible_rows_per_source = _mod._eligible_rows_per_source
+_players_array = _mod._players_array
+
+
+def _row(
+    name,
+    pos,
+    rank,
+    source_ranks,
+    dropped=(),
+    source_count=None,
+    spread=None,
+):
+    return {
+        "displayName": name,
+        "position": pos,
+        "canonicalConsensusRank": rank,
+        "sourceRanks": dict(source_ranks),
+        "droppedSources": list(dropped),
+        "sourceCount": source_count if source_count is not None else len(source_ranks),
+        "sourceRankPercentileSpread": spread,
+    }
+
+
+class TestPlayersArrayExtraction:
+    def test_reads_top_level_players_array(self):
+        payload = {"playersArray": [{"displayName": "X"}]}
+        assert len(_players_array(payload)) == 1
+
+    def test_reads_nested_data_players_array(self):
+        payload = {"data": {"playersArray": [{"displayName": "Y"}]}}
+        assert len(_players_array(payload)) == 1
+
+    def test_returns_empty_list_on_missing(self):
+        assert _players_array({}) == []
+
+
+class TestEligibleRowsPerSource:
+    def test_counts_each_source_once_per_row(self):
+        players = [
+            _row("A", "WR", 1, {"ktc": 1, "dlfSf": 1}),
+            _row("B", "WR", 2, {"ktc": 2}),
+        ]
+        eligible = _eligible_rows_per_source(players)
+        assert eligible == {"ktc": 2, "dlfSf": 1}
+
+    def test_handles_missing_source_ranks(self):
+        players = [{"displayName": "Z"}]
+        assert _eligible_rows_per_source(players) == {}
+
+
+class TestSummariseShape:
+    def test_no_drops_anywhere_produces_zero_summary(self):
+        players = [
+            _row("A", "WR", 1, {"ktc": 1, "dlfSf": 1}),
+            _row("B", "WR", 2, {"ktc": 2}),
+        ]
+        s = _summarise(players)
+        assert s["total_rows"] == 2
+        assert s["rows_with_drops"] == 0
+        assert s["drop_count_histogram"] == {}
+        assert s["dropped_by_source"] == {}
+        assert s["biggest_offenders"] == []
+
+    def test_drops_surface_in_every_facet(self):
+        players = [
+            _row(
+                "A", "WR", 1,
+                {"ktc": 1, "dlfSf": 1, "dynastyNerdsSfTep": 300},
+                dropped=["dynastyNerdsSfTep"],
+            ),
+            _row(
+                "B", "LB", 50,
+                {"idpTradeCalc": 50, "dlfIdp": 50, "footballGuysIdp": 400},
+                dropped=["footballGuysIdp"],
+                spread=0.25,
+            ),
+            _row("C", "QB", 10, {"ktc": 10, "dlfSf": 12}),
+        ]
+        s = _summarise(players)
+        assert s["total_rows"] == 3
+        assert s["rows_with_drops"] == 2
+        assert s["drop_count_histogram"] == {1: 2}
+        assert s["dropped_by_source"] == {
+            "dynastyNerdsSfTep": 1,
+            "footballGuysIdp": 1,
+        }
+        assert s["dropped_by_position"] == {"WR": 1, "LB": 1}
+        # The LB row has a percentile spread stamp; it must round-trip.
+        offenders_by_name = {o["name"]: o for o in s["biggest_offenders"]}
+        assert offenders_by_name["B"]["spread"] == 0.25
+        assert offenders_by_name["A"]["dropped"] == ["dynastyNerdsSfTep"]
+
+    def test_biggest_offenders_sorted_by_drop_count_then_rank(self):
+        players = [
+            _row("One-drop late", "WR", 100, {"ktc": 100, "a": 1}, dropped=["a"]),
+            _row("Two-drop early", "WR", 5, {"ktc": 5, "a": 1, "b": 2}, dropped=["a", "b"]),
+            _row("One-drop early", "WR", 20, {"ktc": 20, "c": 1}, dropped=["c"]),
+        ]
+        s = _summarise(players)
+        names = [o["name"] for o in s["biggest_offenders"]]
+        # Two-drop row wins on count; among the 1-drop rows, the
+        # earlier-ranked one comes first.
+        assert names == ["Two-drop early", "One-drop early", "One-drop late"]
+
+    def test_eligibility_denominator_counts_all_matches(self):
+        # A source that covered 10 rows but only got dropped on 1 has
+        # a 10% drop rate.  The script flags >=10% with eligible>=20 as
+        # "elevated"; below the denominator threshold the flag must
+        # not fire.
+        players = []
+        # 21 rows where 'footballGuysIdp' ranked all of them; 3 dropped.
+        for i in range(21):
+            dropped = ["footballGuysIdp"] if i < 3 else []
+            players.append(
+                _row(
+                    f"P{i}", "LB", i + 1,
+                    {"idpTradeCalc": i + 1, "dlfIdp": i + 1, "footballGuysIdp": i + 1},
+                    dropped=dropped,
+                )
+            )
+        s = _summarise(players)
+        assert s["eligible_rows_per_source"]["footballGuysIdp"] == 21
+        assert s["dropped_by_source"]["footballGuysIdp"] == 3
+        # Rate ≈ 14.3%; denominator ≥ 20; should meet the elevated-flag
+        # threshold when the text report renders.
+        rate = 100.0 * 3 / 21
+        assert rate >= 10.0

--- a/tests/scripts/test_audit_dropped_sources.py
+++ b/tests/scripts/test_audit_dropped_sources.py
@@ -8,6 +8,8 @@ sections consumers rely on.
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -156,3 +158,50 @@ class TestSummariseShape:
         # threshold when the text report renders.
         rate = 100.0 * 3 / 21
         assert rate >= 10.0
+
+
+class TestCliJsonMode:
+    """End-to-end check that ``--json`` produces parseable stdout.
+
+    The ``Loading: ...`` status line must be on stderr so downstream
+    consumers can pipe stdout straight into ``jq`` without a prefix-
+    stripping hack.  Regression for Codex PR #212 review.
+    """
+
+    def test_json_mode_stdout_is_clean_json(self, tmp_path):
+        snapshot = tmp_path / "snapshot.json"
+        snapshot.write_text(
+            json.dumps(
+                {
+                    "playersArray": [
+                        {
+                            "displayName": "A",
+                            "position": "WR",
+                            "canonicalConsensusRank": 1,
+                            "sourceRanks": {"ktc": 1, "dlfSf": 1, "bad": 300},
+                            "droppedSources": ["bad"],
+                            "sourceCount": 3,
+                        }
+                    ]
+                }
+            )
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--json-path",
+                str(snapshot),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # stdout must parse as JSON on its own — no status chatter.
+        summary = json.loads(result.stdout)
+        assert summary["rows_with_drops"] == 1
+        assert summary["dropped_by_source"] == {"bad": 1}
+        # Status line must still be visible for interactive runs —
+        # just not on stdout.
+        assert "Loading:" in result.stderr

--- a/tests/scripts/test_audit_dropped_sources.py
+++ b/tests/scripts/test_audit_dropped_sources.py
@@ -80,6 +80,30 @@ class TestEligibleRowsPerSource:
         players = [{"displayName": "Z"}]
         assert _eligible_rows_per_source(players) == {}
 
+    def test_counts_dropped_even_when_absent_from_sourceRanks(self):
+        # Regression for Codex PR #212 review: the elevated-source
+        # diagnosis compares ``dropped_by_source[k] / eligible[k]``.
+        # If the backend ever strips Hampel-dropped keys out of
+        # ``sourceRanks`` (currently it keeps them, but defensive
+        # robustness matters because a chronically-dropped source is
+        # *exactly* the case the script exists to surface), the
+        # denominator must still reflect the rejected occurrences.
+        # Otherwise a source dropped on every row it covered would
+        # land at ``0 / 0`` and never trip the ``>=10%`` flag.
+        players = [
+            # Dropped — absent from sourceRanks on this row.
+            _row("A", "WR", 1, {"ktc": 1, "dlfSf": 1}, dropped=["badSource"]),
+            _row("B", "WR", 2, {"ktc": 2, "dlfSf": 2}, dropped=["badSource"]),
+            # Matched — present in sourceRanks on this row.
+            _row("C", "WR", 3, {"ktc": 3, "badSource": 99, "dlfSf": 3}),
+        ]
+        eligible = _eligible_rows_per_source(players)
+        assert eligible["badSource"] == 3
+        # Summary must report the same denominator.
+        s = _summarise(players)
+        assert s["eligible_rows_per_source"]["badSource"] == 3
+        assert s["dropped_by_source"]["badSource"] == 2
+
 
 class TestSummariseShape:
     def test_no_drops_anywhere_produces_zero_summary(self):


### PR DESCRIPTION
## Summary

Diagnostic script that surveys `droppedSources` stamps across the live contract and reports where the per-player Hampel outlier filter (from PR #211) is actually firing.

Three diagnostic facets:

- **Drops-per-row histogram**: how often the filter fires at all, and how many sources it typically rejects per affected row.
- **Per-source drop rate** (`dropped / eligible`): normalizes by the number of rows each source actually ranked, so a narrow-scope source isn't compared against the whole board. Sources >=10% drop rate with >=20 eligible rows get an `<-- elevated` marker — those are candidates for adapter-level investigation or a global weight reduction.
- **Biggest-offender list**: top N rows by dropped-source count, sorted by count then rank, for spot-checking genuine outlier rejections vs. surprise rejections that hint at a join-hygiene regression.

## Usage

```
python scripts/audit_dropped_sources.py                # autodetect latest snapshot
python scripts/audit_dropped_sources.py --top 30       # more offenders
python scripts/audit_dropped_sources.py --json         # machine-readable output
python scripts/audit_dropped_sources.py --json-path data/prod_snapshot.json
```

## Test plan

- [x] 9 unit tests in `tests/scripts/test_audit_dropped_sources.py` pin summariser shape, source-eligibility denominator counting, and offender sort order
- [x] Smoke test: bails cleanly with `ERROR: no playersArray found` on legacy-only snapshots (expected — these predate `playersArray`)
- [ ] Run against the first post-deploy `/api/data` snapshot to validate against real Hampel output

https://claude.ai/code/session_01DETWzv42R1VgwpgWp9RXC7