### PR TITLE
Fix 4 findings from 14-PR post-deploy production audit

### DIFF
--- a/frontend/components/graphs/PlayoffOddsChart.jsx
+++ b/frontend/components/graphs/PlayoffOddsChart.jsx
@@ -35,6 +35,7 @@ function certaintyLabel(kind) {
   if (kind === "partial") return { text: "Partial schedule (round-robin for un-posted weeks)", color: CHART_COLORS.warn };
   if (kind === "inferred") return { text: "Inferred round-robin schedule", color: CHART_COLORS.warn };
   if (kind === "final") return { text: "Season complete", color: CHART_COLORS.axisLabel };
+  if (kind === "preseason") return { text: "Preseason — odds not yet simulated", color: CHART_COLORS.axisLabel };
   return { text: "Unknown schedule source", color: CHART_COLORS.axisLabel };
 }
 
@@ -48,6 +49,41 @@ export default function PlayoffOddsChart({
     return (
       <div className="chart-empty" style={{ padding: 12, color: CHART_COLORS.axisLabel }}>
         No playoff-odds data — season may not have started yet.
+      </div>
+    );
+  }
+
+  // Preseason short-circuit: when the backend reports we're before
+  // Week 1 (``scheduleCertainty === "preseason"``) the simulator
+  // deliberately returns ``playoffProbability: null`` for every owner
+  // and ``numSims: 0``.  Rendering the bar chart with 12 rows of
+  // empty placeholder tracks plus "—" dashes looked broken ("every
+  // row shows nothing") even though it was working as designed.
+  // Replace that visualisation with an explicit preseason panel that
+  // names the state, so it's unambiguously "not yet computable" vs.
+  // "something is wrong."
+  const isPreseason =
+    data?.scheduleCertainty === "preseason" ||
+    (owners.length > 0 && owners.every((o) => o?.playoffProbability == null));
+  if (isPreseason) {
+    return (
+      <div
+        className="chart-empty"
+        style={{
+          padding: "16px 12px",
+          color: CHART_COLORS.axisLabel,
+          textAlign: "center",
+          lineHeight: 1.5,
+        }}
+      >
+        <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>
+          Preseason — odds not yet simulated
+        </div>
+        <div style={{ fontSize: 11 }}>
+          Playoff probabilities populate once Sleeper posts a schedule and Week 1 begins.
+          {" "}
+          {owners.length} owners · top {data?.playoffSpots ?? "?"} make playoffs.
+        </div>
       </div>
     );
   }

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -494,14 +494,14 @@ export const RANKING_SOURCES = [
     // position we pick the league-appropriate value column (SF Value
     // for QB, TEP Value for TE, Trade Value for RB/WR) — so
     // Fitzmaurice's Superflex + TE-Premium native numbers align
-    // with our league scoring.  Value-signal on this branch: the
-    // blend rescales Fitzmaurice's top player (typically a QB at
-    // ~101) to 9999 via the value-direct path.  PR #216 converts
-    // this source to rank-signal with a matching CSV rank column;
-    // the ``isRankSignal`` flag stays ``false`` here to keep
-    // frontend and backend in lockstep on THIS branch — flipping
-    // without the matching backend change would have the audit UI
-    // render ``#—`` where real values should appear.
+    // with our league scoring.  Rank-signal (restored 2026-04-22):
+    // the 0-101 value scale caps hard at the top with the top dozen
+    // players bunched between 80 and 101, which the value-direct
+    // branch collapsed into a narrow top band that the Hampel filter
+    // correctly rejected (19% drop rate).  Routing through the rank
+    // path instead feeds Fitzmaurice's global 1-indexed rank into
+    // the shared Hill curve.  Mirrors the backend
+    // ``_SOURCE_CSV_PATHS["fantasyProsFitzmaurice"].signal = "rank"``.
     key: "fantasyProsFitzmaurice",
     displayName: "FantasyPros / Pat Fitzmaurice SF-TEP",
     columnLabel: "Fitzmaurice",
@@ -512,7 +512,7 @@ export const RANKING_SOURCES = [
     weight: 1.0,
     isBackbone: false,
     isRetail: false,
-    isRankSignal: false,
+    isRankSignal: true,
     isTepPremium: true,
     needsSharedMarketTranslation: false,
     excludesRookies: false,

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -365,16 +365,22 @@ _SOURCE_CSV_PATHS: dict[str, Any] = {
     # ``scripts/fetch_fantasypros_fitzmaurice.py`` which resolves
     # the date-rotating article URL, parses the four embedded
     # Datawrapper iframes (QB/RB/WR/TE), and writes per-position
-    # values on a 0-~101 scale.  For each position we pick the
-    # league-appropriate column: ``SF Value`` for QB (Superflex),
-    # ``Trade Value`` for RB/WR (no league-scoring split), and
-    # ``TEP Value`` for TE (TE-Premium) — matching the yahooBoone
-    # pattern.  Signal=value so the blend's value-direct branch
-    # rescales Fitzmaurice's top player (typically a QB at 101)
-    # to 9999 and every other player scales linearly.
+    # values on a 0-~101 scale plus a global 1-indexed rank.
+    #
+    # Signal=rank (2026-04-22, restored): Fitzmaurice's value scale
+    # hits its ceiling hard — the top dozen+ players cluster between
+    # 80 and 101 with many ties, which the ``value-direct`` path
+    # collapsed into a narrow top band and the Hampel filter then
+    # correctly rejected against differentiated sources like KTC.
+    # PR #216 originally moved this to rank-signal (19% → 1.7% drop
+    # rate); the subsequent PR #218 merge silently reverted the flag
+    # back to ``value`` while leaving the rest of the scaffolding
+    # intact.  The live audit re-caught the 19% drop rate and this
+    # restores the PR #216 state.  Same template as dynastyDaddySf
+    # and yahooBoone above.
     "fantasyProsFitzmaurice": {
         "path": "CSVs/site_raw/fantasyProsFitzmaurice.csv",
-        "signal": "value",
+        "signal": "rank",
     },
     # DLF Dynasty Rookie Superflex rankings — 6-expert consensus of the
     # current rookie class only (no veterans).  Raw CSV exported from
@@ -2579,6 +2585,13 @@ _TRUST_MIRROR_FIELDS = (
     "sourceAudit",
     "sourceOriginalRanks",
     "canonicalTierId",
+    # ``rankChange`` is stamped by ``_stamp_rank_changes`` at the end
+    # of ``_compute_unified_rankings`` but only onto the playersArray.
+    # Without mirroring, the runtime ``view=app`` (which strips
+    # playersArray) ships a legacy dict with zero rankChange fields,
+    # which is why ``RankChangeGlyph`` had nothing to render on the
+    # default /rankings path for every row (2026-04-22 audit).
+    "rankChange",
 )
 
 
@@ -4222,20 +4235,16 @@ _MAD_PENALTY_LAMBDA: float = 0.0
 _VALUE_BASED_SOURCES: frozenset[str] = frozenset({
     "ktc",
     "idpTradeCalc",
-    # ``dynastyDaddySf`` and ``yahooBoone`` were moved to the rank-signal
-    # path 2026-04-22 after the Hampel audit flagged 61% and 47% drop
-    # rates — both have compressed top-of-curve value distributions
-    # (DynastyDaddy's 10,200 cap with top 3 tied; Boone's 141 top with
-    # seven players ≥110) that the value-direct rescaling preserved
-    # unfaithfully.  See their ``_SOURCE_CSV_PATHS`` entries above for
-    # the full rationale.
-    #
-    # FantasyPros / Pat Fitzmaurice Dynasty Trade Value Chart.
-    # Published monthly; Datawrapper CSV exposes SF Value (QB),
-    # Trade Value (RB/WR), TEP Value (TE) columns.  Top player
-    # sits at 101 (SF-adjusted QB) so the value-direct rescaling
-    # maps Fitzmaurice's top → 9999.  Added 2026-04-21.
-    "fantasyProsFitzmaurice",
+    # ``dynastyDaddySf``, ``yahooBoone``, and ``fantasyProsFitzmaurice``
+    # were moved to the rank-signal path 2026-04-22 after the Hampel
+    # audit flagged 61% / 47% / 19% drop rates respectively — all three
+    # have compressed top-of-curve value distributions (DynastyDaddy's
+    # 10,200 cap with top 3 tied; Boone's 141 top with seven players
+    # ≥110; Fitzmaurice's 0-101 scale with the top dozen bunched
+    # 80-101) that the value-direct rescaling preserved unfaithfully.
+    # See their ``_SOURCE_CSV_PATHS`` entries above for the full
+    # rationale.  Fitzmaurice was reverted by an accidental PR #218
+    # merge and restored here.
 })
 
 

--- a/src/api/rank_history.py
+++ b/src/api/rank_history.py
@@ -348,6 +348,30 @@ def stamp_contract_with_history(
     if not isinstance(players_dict, dict):
         data = contract.get("data") or {}
         players_dict = data.get("players") if isinstance(data, dict) else None
+
+    # Build a ``displayName → assetClass`` map from the modern
+    # playersArray so we can classify legacy-dict rows that carry
+    # neither ``assetClass`` nor ``position`` — which is the common
+    # case: offense/IDP rows in the legacy dict only have source
+    # value columns plus underscored internals.  Without this map,
+    # ``_infer_asset_class`` returns ``"unknown"`` for every non-pick
+    # regular player, and ``history.get(f"{name}::unknown")`` misses
+    # (snapshots were written as ``::offense`` / ``::idp``).  Picks
+    # worked via the name-pattern fallback, so the pre-fix behaviour
+    # stamped only picks — regular players never lit up on
+    # ``/rankings`` regardless of how much history accumulated.
+    name_to_asset: dict[str, str] = {}
+    if isinstance(arr, list):
+        for row in arr:
+            if not isinstance(row, dict):
+                continue
+            display = row.get("displayName") or row.get("canonicalName")
+            if not display:
+                continue
+            asset = str(row.get("assetClass") or "").strip().lower()
+            if asset in ("offense", "idp", "pick"):
+                name_to_asset[str(display)] = asset
+
     if isinstance(players_dict, dict):
         for display_name, row in players_dict.items():
             if not isinstance(row, dict):
@@ -357,6 +381,15 @@ def stamp_contract_with_history(
             scoped = dict(row)
             scoped.setdefault("canonicalName", display_name)
             scoped.setdefault("displayName", display_name)
+            # Borrow the assetClass from the playersArray mirror
+            # when the legacy row doesn't carry one itself; this is
+            # what makes history lookups hit for regular offense/IDP
+            # players (pick rows already worked via the name-pattern
+            # fallback in ``_infer_asset_class``).
+            if "assetClass" not in scoped:
+                asset_from_array = name_to_asset.get(str(display_name))
+                if asset_from_array:
+                    scoped["assetClass"] = asset_from_array
             key = _player_key(scoped)
             if not key:
                 continue

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -299,6 +299,29 @@ class TestCanonicalConsensusRank(unittest.TestCase):
         self.assertEqual(len(ranked), OVERALL_RANK_LIMIT)
 
 
+class TestRankChangeMirror(unittest.TestCase):
+    """``rankChange`` stamped by ``_stamp_rank_changes`` onto playersArray
+    must survive the runtime view that strips playersArray — i.e. it
+    must mirror into the legacy ``players`` dict via
+    ``_TRUST_MIRROR_FIELDS``.  Regression for the 2026-04-22 audit
+    which found rankChange missing from every legacy-dict row.
+    """
+
+    def test_rank_change_mirrors_to_legacy_dict(self):
+        from src.api.data_contract import _mirror_trust_to_legacy
+        players_array = [
+            {"legacyRef": "Josh Allen", "rankChange": 3, "confidenceBucket": "high"},
+            {"legacyRef": "Puka Nacua", "rankChange": None, "confidenceBucket": "high"},
+        ]
+        legacy = {
+            "Josh Allen": {"ktc": 9000},
+            "Puka Nacua": {"ktc": 8800},
+        }
+        _mirror_trust_to_legacy(players_array, legacy)
+        self.assertEqual(legacy["Josh Allen"]["rankChange"], 3)
+        self.assertIsNone(legacy["Puka Nacua"]["rankChange"])
+
+
 class TestIdpIntegrityGuardrails(unittest.TestCase):
     def test_prefers_explicit_player_offense_position_over_conflicting_sleeper_idp_map(self):
         raw = {

--- a/tests/api/test_rank_history.py
+++ b/tests/api/test_rank_history.py
@@ -424,3 +424,36 @@ class StampContract(unittest.TestCase):
             stamped = rank_history.stamp_contract_with_history(contract, path=path)
             self.assertEqual(stamped, 0)
             self.assertNotIn("rankHistory", contract["playersArray"][0])
+
+    def test_legacy_dict_borrows_asset_class_from_players_array(self) -> None:
+        # Regression for the 2026-04-22 production audit: the runtime
+        # ``/api/data?view=app`` legacy ``players`` dict ships without
+        # ``assetClass`` or ``position`` on offense/IDP rows, so the
+        # pre-fix stamp only landed on picks (which matched via the
+        # name-pattern fallback).  Borrowing ``assetClass`` from the
+        # playersArray mirror makes regular players stamp too.
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rank_history.jsonl"
+            rank_history.append_snapshot(
+                {
+                    "playersArray": [
+                        {"canonicalName": "Bare Legacy", "canonicalConsensusRank": 42, "assetClass": "offense"},
+                    ],
+                },
+                date="2026-04-22",
+                path=path,
+            )
+            contract = {
+                "playersArray": [
+                    {"canonicalName": "Bare Legacy", "canonicalConsensusRank": 42, "assetClass": "offense", "displayName": "Bare Legacy"},
+                ],
+                "players": {
+                    # Mimic the production shape: no assetClass, no position.
+                    "Bare Legacy": {"ktc": 4200, "_composite": 4200},
+                },
+            }
+            rank_history.stamp_contract_with_history(contract, path=path)
+            self.assertIn("rankHistory", contract["players"]["Bare Legacy"])
+            self.assertEqual(
+                contract["players"]["Bare Legacy"]["rankHistory"][-1]["rank"], 42
+            )


### PR DESCRIPTION
## Summary

Post-deploy validation of the last 14 PRs surfaced 4 real issues on production (`https://riskittogetthebrisket.org`). All fixed in this branch; Hampel audit + rank-history + rankChange + playoff-odds preseason UX.

Also documents a 5th item (rank-history log growth) as "soft-watch" — structurally correct, nothing to fix.

## Fix 1 — `fantasyProsFitzmaurice` rank-signal conversion restored

PR #216 moved this source from `signal=value` to `signal=rank`, reporting the Hampel drop rate dropping 19% → 1.7%. PR #218 merged ~7 minutes later and its diff silently reverted the flag back to `value` (the rest of the scaffolding — rank column in the CSV, comment block, `_VALUE_BASED_SOURCES` entry — stayed consistent with the value-signal state, so it's a clean revert not a partial one). The live 2026-04-22 audit caught the 19% drop rate re-appearing.

Restored:
- `src/api/data_contract.py::_SOURCE_CSV_PATHS["fantasyProsFitzmaurice"].signal = "rank"`
- Removed from `_VALUE_BASED_SOURCES`
- Frontend mirror `frontend/lib/dynasty-data.js::RANKING_SOURCES` flipped to `isRankSignal: true`
- Comment rewrites noting the revert+restore

Re-run audit against the freshly-built contract: **3.4%** drop rate (down from 19.0%).

## Fix 2 — `rankHistory` stamping on legacy `players` dict

Live `/api/data?view=app` showed **22/1085** rows with `rankHistory` stamped, all pick rows. Regular offense/IDP players had no stamp despite the log containing their ranks.

Root cause: `stamp_contract_with_history` walks the legacy dict and calls `_infer_asset_class(row)`, but legacy-dict entries carry no `position` or `assetClass` — so the classifier returns `"unknown"` and `history.get("A.J. Brown::unknown")` misses (snapshots write keys as `::offense`/`::idp`). Pick rows worked only because `_looks_like_pick_name` name-pattern fallback caught them.

Fix: build a `displayName → assetClass` map from the modern `playersArray` mirror, and borrow the classification when the legacy row lacks it. Regression test added.

## Fix 3 — `rankChange` mirror to legacy dict

Live `/api/data?view=app` showed **0/1085** rows with a `rankChange` field. `_stamp_rank_changes` writes it onto `playersArray` rows only, and runtime view=app strips `playersArray` — so the field never reaches the frontend's default /rankings path.

Fix: add `"rankChange"` to `_TRUST_MIRROR_FIELDS` so `_mirror_trust_to_legacy` (already called after stamping) carries it across. Regression test added.

## Fix 4 — Rank-history log growth (soft-watch, no code change)

The production log currently has 1 date because PR #217 deployed ~24 hours ago and only one UTC day has elapsed. The `append_snapshot` dedup-per-date is intentional: N scrapes/day → 1 entry/day. Existing `test_idempotent_per_date` locks this invariant. Nothing to fix.

## Fix 5 — PlayoffOddsChart preseason empty-state

In April, `scheduleCertainty === "preseason"` and every owner has `playoffProbability: null`, which previously rendered 12 rows of empty placeholder tracks plus "—" dashes. Works as designed but reads as "broken" to a user.

Fix: preseason short-circuit renders an explicit "Preseason — odds not yet simulated" panel. Also added `"preseason"` to `certaintyLabel` so the header badge reads as a named state instead of "Unknown schedule source."

## Test plan

- [x] `python3 -m pytest tests/ --ignore=tests/e2e -q` → **1802 passed, 25 skipped**
- [x] `tests/api/test_source_registry_parity.py` → **4 passed** (frontend/backend registry lockstep)
- [x] Rebuilt `/api/data` contract locally against `exports/latest/dynasty_data_2026-04-22.json`, re-ran `scripts/audit_dropped_sources.py` → Fitzmaurice 3.4% drop rate
- [x] End-to-end simulation with 2-day mock history log → regular offense rows (A.J. Brown, Ja'Marr Chase) now stamp `rankHistory` on legacy dict
- [x] Seeded fake snapshot → `rankChange` mirrors correctly onto legacy dict
- [ ] Manual browser verification of `/league?tab=power` preseason panel once deployed
- [ ] Visual regression of `/rankings` sparklines once the rank-history log accumulates ≥2 UTC days post-deploy

https://claude.ai/code/session_01VTzgRjb72DQzVTXqY4WXVY