### PR TITLE
Sleeper schedule inference for playoff-odds simulator

### DIFF
--- a/src/public_league/playoff_odds.py
+++ b/src/public_league/playoff_odds.py
@@ -19,9 +19,13 @@ For the *current* season only:
 2. Determine the remaining schedule.  Sleeper exposes matchups only
    for weeks that have been posted (usually current + a couple of
    future weeks).  For posted-but-not-played weeks we honour the
-   exact matchup pairs.  For further-out weeks we assume a standard
-   single round-robin rotation over a week-0 reference pairing, which
-   closely matches how most Sleeper leagues schedule.
+   exact matchup pairs.  For further-out weeks we first try to infer
+   the pairings from the observed posted-week pattern — detecting the
+   cycle length by looking for pair-set repetition across posted
+   weeks and propagating forward.  Only when fewer than 2 posted
+   weeks are available (or the observed block leaves residues
+   uncovered) do we fall back to a synthetic single round-robin
+   rotation.
 
 3. Run N Monte Carlo simulations.  In each run, for every remaining
    week, sample each owner's score from their empirical distribution
@@ -185,6 +189,128 @@ def _regular_season_record_to_date(
     return out
 
 
+def _all_posted_pair_lists(
+    season: SeasonSnapshot,
+    registry,
+) -> dict[int, list[tuple[str, str]]]:
+    """Owner-id pairs for every regular-season week Sleeper has posted
+    matchup assignments for — regardless of whether the games are
+    already scored.
+
+    Differs from ``_posted_future_matchups`` in that this helper does
+    not filter out fully-scored matchups.  Cycle detection in
+    ``_infer_schedule_from_posted`` needs the authoritative pairings
+    from already-played weeks, not just the live/future un-played ones.
+    """
+    out: dict[int, list[tuple[str, str]]] = {}
+    for wk in season.regular_season_weeks:
+        entries = season.matchups_by_week.get(wk) or []
+        pairs: list[tuple[str, str]] = []
+        for a, b in metrics.matchup_pairs(entries):
+            rid_a = metrics.roster_id_of(a)
+            rid_b = metrics.roster_id_of(b)
+            if rid_a is None or rid_b is None:
+                continue
+            oa = metrics.resolve_owner(registry, season.league_id, rid_a)
+            ob = metrics.resolve_owner(registry, season.league_id, rid_b)
+            if oa and ob:
+                pairs.append((oa, ob))
+        if pairs:
+            out[wk] = pairs
+    return out
+
+
+def _detect_cycle_length(
+    posted_weeks: list[int],
+    canonical: dict[int, frozenset],
+) -> int | None:
+    """Return the smallest ``L ≥ 1`` such that every pair of posted
+    weeks sharing a residue ``(w - anchor) mod L`` has the same
+    canonical pair-set, AND at least one such overlap exists.
+
+    Returns ``None`` when no cycle can be confirmed — e.g. all posted
+    weeks carry distinct pair-sets and no ``L`` within the span lines
+    two of them up.
+    """
+    if len(posted_weeks) < 2:
+        return None
+    anchor = posted_weeks[0]
+    span = posted_weeks[-1] - anchor
+    for L in range(1, span + 1):
+        residues: dict[int, frozenset] = {}
+        has_overlap = False
+        ok = True
+        for w in posted_weeks:
+            r = (w - anchor) % L
+            if r in residues:
+                has_overlap = True
+                if residues[r] != canonical[w]:
+                    ok = False
+                    break
+            else:
+                residues[r] = canonical[w]
+        if ok and has_overlap:
+            return L
+    return None
+
+
+def _infer_schedule_from_posted(
+    season: SeasonSnapshot,
+    registry,
+) -> dict[int, list[tuple[str, str]]] | None:
+    """Infer per-week owner pairs for every regular-season week from
+    the pattern of posted weeks.
+
+    Returns a full schedule dict when inference succeeds, or ``None``
+    when fewer than 2 posted weeks are available (caller should fall
+    back to ``_round_robin_schedule``) or when at least one regular-
+    season week has no matching residue in the observed pattern.
+
+    Algorithm:
+      1. Gather all posted weeks with their canonical pair-sets.
+      2. Detect the cycle length ``L`` via pair-set repetition across
+         posted weeks.  If no cycle is confirmed, fall back to
+         ``L = span + 1`` — treats the contiguous observed block as a
+         single cycle and propagates it forward.
+      3. For each regular-season week, reuse the posted pairs from the
+         observed week with the same residue ``(wk - anchor) mod L``.
+    """
+    posted_pairs = _all_posted_pair_lists(season, registry)
+    if len(posted_pairs) < 2:
+        return None
+    posted_weeks = sorted(posted_pairs.keys())
+    canonical = {
+        w: frozenset(frozenset(p) for p in posted_pairs[w]) for w in posted_weeks
+    }
+    anchor = posted_weeks[0]
+
+    cycle_length = _detect_cycle_length(posted_weeks, canonical)
+    if cycle_length is None:
+        # No confirmed repetition — treat the posted block itself as
+        # the cycle.  Works for the common case of weeks [1..k] posted
+        # with distinct pairings: week k+1 inherits week 1's pairs.
+        cycle_length = posted_weeks[-1] - anchor + 1
+
+    residue_to_week: dict[int, int] = {}
+    for w in posted_weeks:
+        r = (w - anchor) % cycle_length
+        residue_to_week.setdefault(r, w)
+
+    schedule: dict[int, list[tuple[str, str]]] = {}
+    for wk in season.regular_season_weeks:
+        if wk in posted_pairs:
+            schedule[wk] = posted_pairs[wk]
+            continue
+        residue = (wk - anchor) % cycle_length
+        src_week = residue_to_week.get(residue)
+        if src_week is None:
+            # Posted block has a gap at this residue — inference
+            # can't cover every missing week; caller falls back.
+            return None
+        schedule[wk] = posted_pairs[src_week]
+    return schedule
+
+
 def _posted_future_matchups(
     season: SeasonSnapshot,
     registry,
@@ -317,7 +443,7 @@ def compute_playoff_odds(
           "playoffSpots": 6,
           "weeksPlayed": 8,
           "weeksRemaining": 5,
-          "scheduleCertainty": "posted" | "inferred" | "partial",
+          "scheduleCertainty": "posted" | "inferred_from_posted" | "partial" | "inferred",
           "owners": [
             {
               "ownerId": "...",
@@ -476,11 +602,31 @@ def compute_playoff_odds(
         }
 
     posted = _posted_future_matchups(season, registry)
-    schedule_certainty = "posted" if all(wk in posted for wk in remaining_weeks) else (
-        "partial" if any(wk in posted for wk in remaining_weeks) else "inferred"
-    )
     missing_weeks = [wk for wk in remaining_weeks if wk not in posted]
-    inferred = _round_robin_schedule(owners_in_league, missing_weeks)
+    # For missing future weeks, prefer inference from the observed
+    # posted-week pattern over a synthetic round-robin — the latter
+    # ignores Sleeper's actual pairings and can invent opponents the
+    # league will never face.  Fall back to round-robin only when
+    # fewer than 2 posted weeks exist (helper returns ``None``) or
+    # when the observed block has gaps that block inference.
+    inferred_full = (
+        _infer_schedule_from_posted(season, registry) if missing_weeks else None
+    )
+    if missing_weeks and inferred_full is not None:
+        inferred = {wk: inferred_full.get(wk, []) for wk in missing_weeks}
+        used_posted_inference = True
+    else:
+        inferred = _round_robin_schedule(owners_in_league, missing_weeks)
+        used_posted_inference = False
+
+    if not missing_weeks:
+        schedule_certainty = "posted"
+    elif used_posted_inference:
+        schedule_certainty = "inferred_from_posted"
+    elif any(wk in posted for wk in remaining_weeks):
+        schedule_certainty = "partial"
+    else:
+        schedule_certainty = "inferred"
     full_schedule = {**inferred, **posted}
 
     owner_pool: dict[str, list[float]] = {}

--- a/tests/public_league/test_playoff_odds.py
+++ b/tests/public_league/test_playoff_odds.py
@@ -526,3 +526,207 @@ class NumSimsGuard(_Base):
             self.snapshot, num_sims="bogus", rng=random.Random(0)  # type: ignore[arg-type]
         )
         self.assertEqual(result["numSims"], 0)
+
+
+class ScheduleInferenceFromPosted(unittest.TestCase):
+    """Regression for the round-robin fallback gap: when the league
+    has posted enough weeks to reveal the rotation pattern, subsequent
+    un-posted weeks should inherit the observed pairings rather than
+    being filled in by a synthetic circle-method round-robin.
+    """
+
+    @staticmethod
+    def _pair_row(matchup_id: int, roster_id: int, points: float = 0.0) -> dict:
+        return {"roster_id": roster_id, "matchup_id": matchup_id, "points": points}
+
+    def _make_season(
+        self,
+        entries_by_week: dict[int, list[dict]],
+        *,
+        playoff_week_start: int = 15,
+    ):
+        entries = entries_by_week
+        cutoff = playoff_week_start
+
+        class _Season:
+            league_id = "L1"
+            league = {"settings": {"playoff_week_start": cutoff}}
+            matchups_by_week = entries
+
+            @property
+            def regular_season_weeks(self):
+                return sorted(w for w in entries if w < cutoff)
+
+        return _Season()
+
+    def setUp(self) -> None:
+        self._orig_resolve = playoff_odds.metrics.resolve_owner
+        playoff_odds.metrics.resolve_owner = (  # type: ignore[attr-defined]
+            lambda reg, league_id, rid: f"owner-{rid}"
+        )
+
+    def tearDown(self) -> None:
+        playoff_odds.metrics.resolve_owner = self._orig_resolve  # type: ignore[attr-defined]
+
+    def test_detects_four_team_three_week_cycle(self) -> None:
+        # 4 teams → round-robin cycle length 3.  Weeks 1-5 posted with
+        # week 4 == week 1 and week 5 == week 2.  Un-posted week 6
+        # should inherit week 3's pairing (same residue mod 3).
+        # Week 1: (1v2, 3v4); Week 2: (1v3, 2v4); Week 3: (1v4, 2v3).
+        entries = {
+            1: [self._pair_row(10, 1, 120.0), self._pair_row(10, 2, 110.0),
+                self._pair_row(11, 3,  95.0), self._pair_row(11, 4, 105.0)],
+            2: [self._pair_row(20, 1, 130.0), self._pair_row(20, 3, 115.0),
+                self._pair_row(21, 2, 140.0), self._pair_row(21, 4,  98.0)],
+            3: [self._pair_row(30, 1, 125.0), self._pair_row(30, 4, 108.0),
+                self._pair_row(31, 2, 133.0), self._pair_row(31, 3, 112.0)],
+            4: [self._pair_row(40, 1,   0.0), self._pair_row(40, 2,   0.0),
+                self._pair_row(41, 3,   0.0), self._pair_row(41, 4,   0.0)],
+            5: [self._pair_row(50, 1,   0.0), self._pair_row(50, 3,   0.0),
+                self._pair_row(51, 2,   0.0), self._pair_row(51, 4,   0.0)],
+            # Weeks 6..14 intentionally absent — inference must fill them.
+        }
+        # Regular season weeks 1..14, playoffs week 15+.  Note the
+        # helper only inspects weeks present in ``matchups_by_week``,
+        # so expand that to include empty entries for the missing
+        # weeks so regular_season_weeks returns the full range.
+        for wk in range(6, 15):
+            entries[wk] = []
+        season = self._make_season(entries, playoff_week_start=15)
+        schedule = playoff_odds._infer_schedule_from_posted(season, None)
+        self.assertIsNotNone(schedule)
+
+        def _pair_set(week_pairs):
+            return frozenset(frozenset(p) for p in week_pairs)
+
+        # Verify cycle propagation: week 6 ≡ week 3, week 7 ≡ week 1,
+        # week 8 ≡ week 2, and so on through the rest of the season.
+        self.assertEqual(_pair_set(schedule[6]), _pair_set(schedule[3]))
+        self.assertEqual(_pair_set(schedule[7]), _pair_set(schedule[1]))
+        self.assertEqual(_pair_set(schedule[8]), _pair_set(schedule[2]))
+        self.assertEqual(_pair_set(schedule[14]), _pair_set(schedule[2]))
+        # And posted weeks survive verbatim.
+        self.assertEqual(_pair_set(schedule[1]),
+                         _pair_set([("owner-1", "owner-2"), ("owner-3", "owner-4")]))
+
+    def test_odd_team_count_league_cycle_propagates(self) -> None:
+        # 5 teams, 2 pairs posted per week (one roster sits out each
+        # week — Sleeper encodes byes by simply not listing that
+        # roster in the week's matchups).  Weeks 1-6 posted with a
+        # 5-week cycle (week 6 == week 1).  Inference must carry that
+        # pattern into weeks 7+, preserving the bye rotation.
+        weekly_pairs = {
+            1: [(1, 2), (3, 4)],              # roster 5 on bye
+            2: [(1, 3), (2, 5)],              # roster 4 on bye
+            3: [(1, 4), (3, 5)],              # roster 2 on bye
+            4: [(1, 5), (2, 4)],              # roster 3 on bye
+            5: [(2, 3), (4, 5)],              # roster 1 on bye
+        }
+        # Week 6 repeats week 1 to give the detector something to
+        # latch onto.
+        weekly_pairs[6] = list(weekly_pairs[1])
+
+        entries: dict[int, list[dict]] = {}
+        for wk, pairs in weekly_pairs.items():
+            rows: list[dict] = []
+            for idx, (a, b) in enumerate(pairs):
+                rows.append(self._pair_row(wk * 100 + idx, a, 100.0))
+                rows.append(self._pair_row(wk * 100 + idx, b,  90.0))
+            entries[wk] = rows
+        for wk in range(7, 15):
+            entries[wk] = []
+        season = self._make_season(entries, playoff_week_start=15)
+        schedule = playoff_odds._infer_schedule_from_posted(season, None)
+        self.assertIsNotNone(schedule)
+
+        def _pair_set(week_pairs):
+            return frozenset(frozenset(p) for p in week_pairs)
+
+        # Cycle length must be 5 because week 6 ≡ week 1.
+        self.assertEqual(_pair_set(schedule[7]), _pair_set(schedule[2]))
+        self.assertEqual(_pair_set(schedule[11]), _pair_set(schedule[1]))
+        # Every propagated week still has exactly 2 pairs (5 teams → 1
+        # bye per week, never 3 pairs).
+        for wk in range(7, 15):
+            self.assertEqual(len(schedule[wk]), 2)
+            # No roster sits in two games in the same week.
+            owners_this_week = [o for pair in schedule[wk] for o in pair]
+            self.assertEqual(len(owners_this_week), len(set(owners_this_week)))
+
+    def test_single_posted_week_falls_back_to_round_robin(self) -> None:
+        # Only week 1 posted — under 2 weeks means we can't detect any
+        # repetition, so the helper returns None and the simulator
+        # falls through to _round_robin_schedule.  scheduleCertainty
+        # stays "partial" (some posted + round-robin fallback) or
+        # "inferred" (no posted at all).  Either way, NOT
+        # "inferred_from_posted".
+        entries = {
+            1: [self._pair_row(10, 1, 120.0), self._pair_row(10, 2, 110.0),
+                self._pair_row(11, 3,  95.0), self._pair_row(11, 4, 105.0)],
+        }
+        for wk in range(2, 15):
+            entries[wk] = []
+        season = self._make_season(entries, playoff_week_start=15)
+        schedule = playoff_odds._infer_schedule_from_posted(season, None)
+        self.assertIsNone(schedule)
+
+    def test_zero_posted_weeks_returns_none(self) -> None:
+        season = self._make_season({wk: [] for wk in range(1, 15)}, playoff_week_start=15)
+        self.assertIsNone(playoff_odds._infer_schedule_from_posted(season, None))
+
+    def test_compute_playoff_odds_reports_inferred_from_posted(self) -> None:
+        # Integration: the new certainty value reaches the public
+        # payload when inference drives the missing-week schedule.
+        entries = {
+            1: [self._pair_row(10, 1, 120.0), self._pair_row(10, 2, 110.0),
+                self._pair_row(11, 3,  95.0), self._pair_row(11, 4, 105.0)],
+            2: [self._pair_row(20, 1, 130.0), self._pair_row(20, 3, 115.0),
+                self._pair_row(21, 2, 140.0), self._pair_row(21, 4,  98.0)],
+            3: [self._pair_row(30, 1, 125.0), self._pair_row(30, 4, 108.0),
+                self._pair_row(31, 2, 133.0), self._pair_row(31, 3, 112.0)],
+            4: [self._pair_row(40, 1, 118.0), self._pair_row(40, 2, 111.0),
+                self._pair_row(41, 3,  97.0), self._pair_row(41, 4, 101.0)],
+        }
+        for wk in range(5, 15):
+            entries[wk] = []
+
+        class _Season:
+            season = "2026"
+            league_id = "L1"
+            league = {"settings": {"playoff_week_start": 15, "playoff_teams": 2}}
+            rosters = [{"roster_id": r} for r in (1, 2, 3, 4)]
+            matchups_by_week = entries
+
+            @property
+            def regular_season_weeks(self):
+                return sorted(w for w in entries if w < 15)
+
+        class _Registry:
+            by_owner_id: dict = {}
+
+        class _Snapshot:
+            def __init__(self) -> None:
+                self._s = _Season()
+                self.managers = _Registry()
+
+            @property
+            def current_season(self):
+                return self._s
+
+        orig_display = playoff_odds.metrics.display_name_for
+        playoff_odds.metrics.display_name_for = (  # type: ignore[attr-defined]
+            lambda snapshot, owner_id: owner_id
+        )
+        try:
+            result = playoff_odds.compute_playoff_odds(
+                _Snapshot(), num_sims=50, rng=random.Random(7)
+            )
+        finally:
+            playoff_odds.metrics.display_name_for = orig_display  # type: ignore[attr-defined]
+
+        self.assertEqual(result["scheduleCertainty"], "inferred_from_posted")
+        # Every owner gets a probability (none skipped by empty
+        # schedule gaps).
+        self.assertEqual(len(result["owners"]), 4)
+        for owner in result["owners"]:
+            self.assertIsNotNone(owner["playoffProbability"])


### PR DESCRIPTION
## Summary

Close the round-robin fallback gap in `src/public_league/playoff_odds.py`.

Previously, when Sleeper hadn't posted matchups for a future regular-season week, the simulator filled the gap with a synthetic circle-method round-robin (`_round_robin_schedule`). For leagues where later weeks never get posted — or leagues with non-standard rotations — that pairing often didn't match the league's real schedule.

The new `_infer_schedule_from_posted` helper walks every posted week (past or future), builds canonical pair-sets, detects the rotation cycle length by looking for pair-set repetition across posted weeks, and propagates the observed pattern forward into the un-posted weeks. The synthetic round-robin only runs now as a last resort when fewer than two posted weeks are available, or when the observed block leaves a residue uncovered.

`scheduleCertainty` gains a new `"inferred_from_posted"` value so the frontend can tell real-pattern inference apart from the last-resort round-robin.

### Key code paths

- `src/public_league/playoff_odds.py:191` — `_all_posted_pair_lists` gathers every posted week's pair list (includes fully-scored weeks, unlike `_posted_future_matchups`).
- `src/public_league/playoff_odds.py:221` — `_detect_cycle_length` returns the smallest `L ≥ 1` with confirmed pair-set repetition, or `None`.
- `src/public_league/playoff_odds.py:253` — `_infer_schedule_from_posted` stitches it all together, returning a per-week pair list or `None` when inference can't cover every regular-season week.
- `src/public_league/playoff_odds.py:598` — `compute_playoff_odds` now prefers inference over round-robin for missing weeks.

### Not touched

- The MC loop itself.
- Standings sort / tiebreak rules.
- `_round_robin_schedule` (still the last-resort path).
- `_posted_future_matchups` (still handles the live/partial-week cases).

## Test plan

- [x] `python -m pytest tests/public_league/test_playoff_odds.py -q` — 29 passed (24 original + 5 new)
- [x] `python -m pytest tests/ -q --ignore=tests/e2e` — **1,805 passed**, 25 skipped (1,800 baseline + 5 new tests from this PR)

### New regression tests (`ScheduleInferenceFromPosted`)

- `test_detects_four_team_three_week_cycle` — 4 teams, 5 posted weeks where weeks 4-5 repeat weeks 1-2; confirms detected cycle `L=3` and that weeks 6-14 inherit the right posted pairs.
- `test_odd_team_count_league_cycle_propagates` — 5 teams with bye rotation, 6 posted weeks where week 6 ≡ week 1; confirms pattern carries into weeks 7-14 and no roster plays twice in the same week.
- `test_single_posted_week_falls_back_to_round_robin` — only week 1 posted; helper returns `None` so the simulator falls through to the existing round-robin path.
- `test_zero_posted_weeks_returns_none` — empty matchup map; helper returns `None`.
- `test_compute_playoff_odds_reports_inferred_from_posted` — end-to-end integration: posted weeks 1-4 drive inference for weeks 5-14 and the response includes `scheduleCertainty: "inferred_from_posted"`.

https://claude.ai/code/session_01QNtf8rPMbMzLhxw9J1tHp2