### PR TITLE
Stamp per-scope Hill curves onto /api/data contract + wire HillCurveExplorer

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -981,7 +981,11 @@ export default function RankingsPage() {
               The curve is the canonical rank-to-value shape; dots are where every
               rankable player actually lands after per-source aggregation.
             </p>
-            <HillCurveExplorer rows={rows} onPointClick={openPlayerPopup} />
+            <HillCurveExplorer
+              rows={rows}
+              curves={rawData?.hillCurves}
+              onPointClick={openPlayerPopup}
+            />
           </div>
           <div className="card" style={{ padding: "var(--space-md)" }}>
             <h3 className="section-title">Tier gap waterfall</h3>

--- a/frontend/components/graphs/HillCurveExplorer.jsx
+++ b/frontend/components/graphs/HillCurveExplorer.jsx
@@ -1,27 +1,23 @@
 "use client";
 
 // ── Chart 6: Hill curve explorer ─────────────────────────────────────
-// Renders the canonical Hill curve that maps percentile → Hill value
-// (see ``src/canonical/player_valuation.py::percentile_to_value``) with
-// the live board overlaid as a scatter.  Scatter points are coloured
-// by position group so per-scope behaviour (where rookies cluster,
-// where IDPs cluster, where picks sit relative to starters) is visible
-// even though the curve itself is a single global parameter set.
+// Renders the four scope-level master Hill curves that map percentile
+// → value (see ``src/canonical/player_valuation.py`` constants
+// ``HILL_GLOBAL_PERCENTILE_*``, ``HILL_PERCENTILE_*``,
+// ``IDP_HILL_PERCENTILE_*``, ``HILL_ROOKIE_PERCENTILE_*``) with the
+// live board overlaid as a scatter.
 //
-// Design note: the backend has exactly one Hill curve
-// (``HILL_MIDPOINT=45``, ``HILL_SLOPE=1.10``).  A previous iteration of
-// this chart spoke of "4 scope-master curves side-by-side" but those
-// don't exist in the pipeline — every source / scope / position feeds
-// the same percentile-to-value map.  Where sub-pools differ is in the
-// *distribution of ranks* that hit that curve.  Splitting the scatter
-// by position group makes that distribution visible, which is the
-// honest version of "compare scopes on the Hill curve."
+// The backend stamps the curves into the contract root as
+// ``hillCurves: { global: {midpoint, slope, ...}, offense: {...},
+// idp: {...}, rookie: {...} }``; rankings/page.jsx forwards that to
+// the ``curves`` prop here.  Each curve's ``midpoint``/``slope`` are
+// already rank-form (``midpoint = c * (referenceN − 1)``), so the
+// rank-based ``hillValue`` below renders them directly.  See
+// ``_build_hill_curves_block`` in ``src/api/data_contract.py``.
 //
-// The ``curves`` prop remains multi-curve capable — if the backend
-// ever stamps per-scope curve parameters into the contract root
-// (``hillCurves: { global: {...}, offense: {...}, idp: {...},
-// rookie: {...} }``), this component picks them up automatically and
-// renders each as a separate line.
+// Scatter points are coloured by position group so per-scope
+// behaviour (where rookies cluster, where IDPs cluster, where picks
+// sit relative to starters) is visible alongside the curves.
 // ─────────────────────────────────────────────────────────────────────
 
 import {
@@ -34,20 +30,57 @@ import {
   linePath,
 } from "../../lib/chart-primitives.js";
 
-// Mirrors the Python ``percentile_to_value`` helper.  The backend's
-// ``HILL_MIDPOINT`` is expressed in *rank* units (the rank at which
-// value ≈ 5000), so the curve plotted here is parameterised on rank
-// as well; the x-axis is labelled "rank" rather than "percentile" so
-// what you see matches what the pipeline actually does.
+// Rank-form Hill evaluator; matches the Python ``percentile_to_value``
+// after the rank→percentile conversion ``p = (r-1)/(N-1)`` and the
+// equivalence ``midpoint_rank = c * (N-1)``, ``slope = s``.  The
+// backend stamps curves in rank form so this renders directly.
 function hillValue(rank, { midpoint, slope }) {
   const r = Math.max(1, rank);
   const exponent = Math.pow((r - 1) / midpoint, slope);
   return Math.max(1, Math.min(9999, Math.round(1 + 9998 / (1 + exponent))));
 }
 
+// Fallback only — used when the contract hasn't stamped ``hillCurves``
+// (e.g. a stale cached payload).  The live path receives the full
+// four-scope object from the ``/api/data`` root.
 const DEFAULT_CURVES = [
   { key: "global", label: "Global", midpoint: 45, slope: 1.1 },
 ];
+
+// Normalize incoming curves: accept either the backend's dict shape
+// ``{global: {...}, offense: {...}, ...}`` or an already-flat array
+// ``[{key, label, midpoint, slope}, ...]``.  Entries missing a numeric
+// ``midpoint`` or ``slope`` are dropped rather than silently rendered
+// as NaN paths.
+function normalizeCurves(curves) {
+  if (Array.isArray(curves)) return curves.filter(isRenderableCurve);
+  if (curves && typeof curves === "object") {
+    const order = ["global", "offense", "idp", "rookie"];
+    const seen = new Set();
+    const flat = [];
+    for (const key of order) {
+      if (curves[key]) {
+        flat.push({ key, ...curves[key] });
+        seen.add(key);
+      }
+    }
+    for (const key of Object.keys(curves)) {
+      if (!seen.has(key) && curves[key]) flat.push({ key, ...curves[key] });
+    }
+    return flat.filter(isRenderableCurve);
+  }
+  return [];
+}
+
+function isRenderableCurve(c) {
+  return (
+    c &&
+    Number.isFinite(Number(c.midpoint)) &&
+    Number(c.midpoint) > 0 &&
+    Number.isFinite(Number(c.slope)) &&
+    Number(c.slope) > 0
+  );
+}
 
 // Colour palette per position group.  Keys match the ``assetClass`` /
 // coarse position taxonomy the frontend already uses so the Hill
@@ -99,7 +132,11 @@ export default function HillCurveExplorer({
   const x = linearScale(1, xMax, 0, box.innerWidth);
   const y = linearScale(0, 9999, box.innerHeight, 0);
 
-  const curvePaths = (curves || []).map((c, i) => {
+  const renderableCurves = (() => {
+    const normalized = normalizeCurves(curves);
+    return normalized.length > 0 ? normalized : DEFAULT_CURVES;
+  })();
+  const curvePaths = renderableCurves.map((c, i) => {
     const pts = [];
     for (let k = 0; k <= samplePoints; k++) {
       const r = 1 + (xMax - 1) * (k / samplePoints);
@@ -264,4 +301,4 @@ export default function HillCurveExplorer({
 
 // Exported so callers (tests, wiring) can stay in lockstep with the
 // component's grouping rules.
-export { groupFor, hillValue };
+export { groupFor, hillValue, normalizeCurves };

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4146,6 +4146,62 @@ _DISPLAY_SCALE_MAX: int = 9999
 # deeper ranks asymptote to the Hill's long tail.
 _PERCENTILE_REFERENCE_N: int = 500
 
+
+def _build_hill_curves_block() -> dict[str, dict[str, Any]]:
+    """Stamp the four scope-level master Hill curves onto the contract.
+
+    Mirrors the constants in ``src/canonical/player_valuation.py`` and
+    the routing in ``_curve_for_source``.  Each entry carries:
+        - ``c`` / ``s`` — raw percentile-form constants:
+            V(p) = 9999 / (1 + (p / c)^s),  p = (rank − 1) / (N − 1)
+        - ``referenceN`` — the denominator used to map rank → percentile
+          (= ``_PERCENTILE_REFERENCE_N`` for GLOBAL/OFFENSE/IDP; rookie
+          sources were historically fit against a rookie-only slice but
+          the ROOKIE master is currently fit-only and not routed — see
+          ``_curve_for_source`` — so we stamp the same reference N for
+          consistency).
+        - ``midpoint`` / ``slope`` — rank-form equivalents for callers
+          (e.g. the frontend HillCurveExplorer) that evaluate in rank
+          space: V(r) = 9999 / (1 + ((r − 1) / midpoint)^slope).
+          ``midpoint = c * (referenceN − 1)``, ``slope = s``.
+        - ``label`` — short human label for chart legends.
+        - ``routed`` — whether the live ``_curve_for_source`` routing
+          currently uses this curve.  ROOKIE is fit by the monthly
+          refit workflow but not routed today.
+    """
+    from src.canonical.player_valuation import (  # noqa: PLC0415
+        HILL_GLOBAL_PERCENTILE_C,
+        HILL_GLOBAL_PERCENTILE_S,
+        HILL_PERCENTILE_C,
+        HILL_PERCENTILE_S,
+        HILL_ROOKIE_PERCENTILE_C,
+        HILL_ROOKIE_PERCENTILE_S,
+        IDP_HILL_PERCENTILE_C,
+        IDP_HILL_PERCENTILE_S,
+    )
+
+    ref_n = _PERCENTILE_REFERENCE_N
+    denom = max(1, ref_n - 1)
+
+    def _entry(key: str, label: str, c: float, s: float, routed: bool) -> dict[str, Any]:
+        return {
+            "key": key,
+            "label": label,
+            "c": float(c),
+            "s": float(s),
+            "referenceN": ref_n,
+            "midpoint": round(float(c) * denom, 4),
+            "slope": round(float(s), 4),
+            "routed": routed,
+        }
+
+    return {
+        "global":  _entry("global",  "Global",  HILL_GLOBAL_PERCENTILE_C, HILL_GLOBAL_PERCENTILE_S, True),
+        "offense": _entry("offense", "Offense", HILL_PERCENTILE_C,        HILL_PERCENTILE_S,        True),
+        "idp":     _entry("idp",     "IDP",     IDP_HILL_PERCENTILE_C,    IDP_HILL_PERCENTILE_S,    True),
+        "rookie":  _entry("rookie",  "Rookie",  HILL_ROOKIE_PERCENTILE_C, HILL_ROOKIE_PERCENTILE_S, False),
+    }
+
 # Final Framework step 8: subgroup shrinkage factor.
 #
 #     Final = Anchor + α · (SubgroupBlend − Anchor)
@@ -7212,6 +7268,7 @@ def build_api_data_contract(
         "validationSummary": validation_summary,
         "pickAliases": pick_aliases or {},
         "sourceParseErrors": source_parse_errors,
+        "hillCurves": _build_hill_curves_block(),
     }
     # Drop internal-only provenance markers before materializing the
     # contract so they don't leak into the public payload.

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -457,5 +457,62 @@ class TestStripNameSuffix(unittest.TestCase):
         self.assertEqual(_strip_name_suffix("Patrick Mahomes"), "Patrick Mahomes")
 
 
+class TestHillCurvesStamp(unittest.TestCase):
+    """Contract carries all four scope-level master Hill curves.
+
+    The refit workflow (``.github/workflows/refit-hill-curves.yml``)
+    fits four scope masters — GLOBAL / OFFENSE / IDP / ROOKIE — via
+    ``scripts/auto_refit_hill_curves.py``, and the routing in
+    ``_curve_for_source`` consumes three of them live.  The frontend
+    HillCurveExplorer renders the set directly; this test pins the
+    stamp shape so a rename or drop doesn't silently leave the chart
+    with no curves.
+    """
+
+    def test_contract_root_has_all_four_scope_curves(self):
+        contract = build_api_data_contract(_minimal_raw_payload())
+        curves = contract.get("hillCurves")
+        self.assertIsInstance(curves, dict)
+        self.assertEqual(
+            set(curves.keys()),
+            {"global", "offense", "idp", "rookie"},
+        )
+
+    def test_each_curve_has_renderable_rank_form(self):
+        contract = build_api_data_contract(_minimal_raw_payload())
+        curves = contract["hillCurves"]
+        for scope in ("global", "offense", "idp", "rookie"):
+            entry = curves[scope]
+            for field in ("midpoint", "slope", "c", "s", "referenceN", "label", "routed"):
+                self.assertIn(field, entry, f"{scope}.{field} missing")
+            self.assertGreater(entry["midpoint"], 0.0, f"{scope} midpoint must be positive")
+            self.assertGreater(entry["slope"], 0.0, f"{scope} slope must be positive")
+            self.assertEqual(entry["slope"], round(entry["s"], 4))
+            # midpoint ≈ c * (referenceN − 1); allow small rounding.
+            expected_midpoint = entry["c"] * (entry["referenceN"] - 1)
+            self.assertAlmostEqual(entry["midpoint"], round(expected_midpoint, 4), places=3)
+
+    def test_curves_match_committed_constants(self):
+        from src.canonical.player_valuation import (
+            HILL_GLOBAL_PERCENTILE_C,
+            HILL_GLOBAL_PERCENTILE_S,
+            HILL_PERCENTILE_C,
+            HILL_PERCENTILE_S,
+            HILL_ROOKIE_PERCENTILE_C,
+            HILL_ROOKIE_PERCENTILE_S,
+            IDP_HILL_PERCENTILE_C,
+            IDP_HILL_PERCENTILE_S,
+        )
+        curves = build_api_data_contract(_minimal_raw_payload())["hillCurves"]
+        self.assertAlmostEqual(curves["global"]["c"], HILL_GLOBAL_PERCENTILE_C)
+        self.assertAlmostEqual(curves["global"]["s"], HILL_GLOBAL_PERCENTILE_S)
+        self.assertAlmostEqual(curves["offense"]["c"], HILL_PERCENTILE_C)
+        self.assertAlmostEqual(curves["offense"]["s"], HILL_PERCENTILE_S)
+        self.assertAlmostEqual(curves["idp"]["c"], IDP_HILL_PERCENTILE_C)
+        self.assertAlmostEqual(curves["idp"]["s"], IDP_HILL_PERCENTILE_S)
+        self.assertAlmostEqual(curves["rookie"]["c"], HILL_ROOKIE_PERCENTILE_C)
+        self.assertAlmostEqual(curves["rookie"]["s"], HILL_ROOKIE_PERCENTILE_S)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Investigation outcome: curves **do** exist — wired them up

The refit-workflow comment ("four scope-level master Hill curves GLOBAL/OFFENSE/IDP/ROOKIE") is correct; the prior audit that only found one pair (`HILL_MIDPOINT=45`, `HILL_SLOPE=1.10`) missed the percentile-form constants.

**Citation that settles it:** `src/canonical/player_valuation.py:87-113` — four committed pairs:

| Scope   | C constant                   | S constant                   | Lines    |
| ------- | ---------------------------- | ---------------------------- | -------- |
| GLOBAL  | `HILL_GLOBAL_PERCENTILE_C`   | `HILL_GLOBAL_PERCENTILE_S`   | 87–88    |
| OFFENSE | `HILL_PERCENTILE_C`          | `HILL_PERCENTILE_S`          | 95–96    |
| IDP     | `IDP_HILL_PERCENTILE_C`      | `IDP_HILL_PERCENTILE_S`      | 102–103  |
| ROOKIE  | `HILL_ROOKIE_PERCENTILE_C`   | `HILL_ROOKIE_PERCENTILE_S`   | 112–113  |

All four are re-fit monthly by `scripts/auto_refit_hill_curves.py:48-64` (`CONSTANT_NAMES` tuple + `SCOPE_TO_CS` map), and three are routed live by `src/api/data_contract.py:5095-5101` (`_curve_for_source`). ROOKIE is fit but currently unrouted per the 2026-04-21 retirement note at lines 5088-5094 — I stamped it with `routed: false` so downstream callers can distinguish.

The previous audit that found only `HILL_MIDPOINT=45` / `HILL_SLOPE=1.10` was looking at the **legacy rank-based** constants (lines 54-55), which are still used by `rank_to_value` for the old path but not by the scope-master pipeline.

## What this PR does

- Adds `_build_hill_curves_block()` in `src/api/data_contract.py` and stamps `hillCurves: { global, offense, idp, rookie }` at the contract root. Each entry carries both the percentile-form `c`/`s`/`referenceN` and the rank-form `midpoint`/`slope` (pre-converted via `midpoint = c * (referenceN − 1)`) so the frontend's rank-based `hillValue` helper renders directly without any math.
- Removes the stale "backend has exactly one Hill curve" block comment from `HillCurveExplorer.jsx` and updates it to reference the real per-scope stamp.
- Adds `normalizeCurves()` to the component: accepts either the backend's dict shape or a flat array, drops entries with non-numeric midpoint/slope (avoids silent NaN paths), and falls back to the single-curve `DEFAULT_CURVES` when the contract field is absent.
- Wires `rawData?.hillCurves` → `HillCurveExplorer.curves` in `frontend/app/rankings/page.jsx`.
- Adds `TestHillCurvesStamp` in `tests/api/test_data_contract.py` with three assertions: all four scopes present, rank-form fields renderable and consistent with percentile form, stamped values equal the committed `player_valuation.py` constants.

## What this PR does NOT do

- Does not refit the curves or change any constant value.
- Does not propagate `hillCurves` through the delta payload — source overrides cannot change these constants, and `mergeRankingsDelta` spreads `...base`, so the frontend's cached base contract carries them through overrides unchanged.
- Does not touch the stale `methodology.formula` block at `data_contract.py:7114-7121`, which still advertises `midpoint: 45, slope: 1.10` despite the committed legacy constants being `48.44` / `1.149`. Separate drift; would bloat this PR.

## Test plan

- [x] `python -m pytest tests/ -q --ignore=tests/regression` → 1818 passed, 25 skipped.
- [x] New `TestHillCurvesStamp` class covers shape, rank-form invariants, and constant parity.
- [ ] Manual browser check of the rankings page Hill-curve card once deployed — should show four lines (global solid/accent, offense/idp/rookie in categorical colors) with a 4-entry legend instead of a single dashed curve.

https://claude.ai/code/session_01PhVYG7xLbvTGMMjiswojdq