### PR TITLE
scripts/backfill_rank_history.py — populate rank history from exports/archive

### DIFF
--- a/scripts/backfill_rank_history.py
+++ b/scripts/backfill_rank_history.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Backfill ``data/rank_history.jsonl`` from ``exports/archive/`` zips.
+
+The rank-history log lands empty from deploy day (PR #217).  Until
+two scrapes have cycled the live box the ``RankChangeGlyph``
+sparklines have nothing to render — every glyph falls through to the
+delta-arrow fallback even though the scraper has months of prior
+snapshots sitting unused in ``exports/archive/``.
+
+This script replays those archive bundles through the canonical
+``build_api_data_contract`` pipeline and feeds each resulting
+contract into :func:`src.api.rank_history.append_snapshot` with the
+archived date — producing backdated entries so glyphs light up the
+moment the backfill finishes, without having to wait on the next
+production scrape.
+
+Archive shape
+─────────────
+
+Each archive is a zip named ``dynasty_export_YYYYMMDD_HHMMSS.zip``
+containing:
+
+* ``manifest.json`` with a top-level ``"date": "YYYY-MM-DD"`` field
+* ``dynasty_data_<DATE>.json`` — the raw scraper payload (same shape
+  ``build_api_data_contract`` consumes for the live endpoint)
+
+When multiple archives share a day (common — the scraper runs 4-6x
+per day) we keep the latest ``HHMMSS`` timestamp per date.  A same-
+day re-run would hit ``append_snapshot``'s per-date dedup and
+overwrite the earlier entry anyway; selecting up-front just avoids
+paying the contract-rebuild cost for snapshots that would be thrown
+away.
+
+Idempotency
+───────────
+
+``append_snapshot`` already deduplicates by date.  Re-running this
+script against the same archive directory converges on the same
+JSONL — every date is a fixed point.
+
+Retention
+─────────
+
+The retention cap (``MAX_SNAPSHOTS``, currently 180) is honoured.
+If the archive directory holds more than 180 days the oldest ones
+are trimmed away — same behaviour as the production append path.
+
+Usage
+─────
+
+    # See what would be written without touching the file.
+    python scripts/backfill_rank_history.py --dry-run
+
+    # Actually write.
+    python scripts/backfill_rank_history.py
+
+    # Only process snapshots on/after a cutoff (useful for
+    # incremental catch-up after partial backfills).
+    python scripts/backfill_rank_history.py --since 2026-03-25
+
+    # Point at a non-default archive directory / history file
+    # (used by the unit tests).
+    python scripts/backfill_rank_history.py \\
+        --archive-dir /tmp/fake_archive \\
+        --history-path /tmp/fake_history.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.api import rank_history  # noqa: E402
+from src.api.data_contract import build_api_data_contract  # noqa: E402
+
+DEFAULT_ARCHIVE_DIR: Path = REPO / "exports" / "archive"
+
+_FILENAME_RE = re.compile(r"^dynasty_export_(\d{8})_(\d{6})\.zip$")
+
+
+def _date_from_ymd(ymd: str) -> str:
+    """``20260422`` -> ``2026-04-22``."""
+    return f"{ymd[0:4]}-{ymd[4:6]}-{ymd[6:8]}"
+
+
+def _iter_candidate_zips(archive_dir: Path) -> Iterator[tuple[str, str, Path]]:
+    """Yield ``(date_str, hhmmss, zip_path)`` for every recognised archive.
+
+    Unrecognised filenames are silently skipped — the archive
+    directory has historically carried a few orphan files that don't
+    match the scraper's naming convention, and surfacing them as
+    errors would make every run noisy.
+    """
+    if not archive_dir.exists() or not archive_dir.is_dir():
+        return
+    for p in sorted(archive_dir.iterdir()):
+        if not p.is_file() or p.suffix != ".zip":
+            continue
+        m = _FILENAME_RE.match(p.name)
+        if not m:
+            continue
+        yield _date_from_ymd(m.group(1)), m.group(2), p
+
+
+def _select_latest_per_date(
+    archive_dir: Path,
+) -> list[tuple[str, Path]]:
+    """Return ``[(date_str, zip_path), ...]`` in ascending date order.
+
+    When multiple archives land on the same day we keep the latest
+    ``HHMMSS`` — that's the freshest snapshot of that day's state
+    and matches what ``append_snapshot``'s per-date dedup would
+    produce if we processed every zip blindly.
+    """
+    by_date: dict[str, tuple[str, Path]] = {}
+    for date_str, hms, path in _iter_candidate_zips(archive_dir):
+        prev = by_date.get(date_str)
+        if prev is None or hms > prev[0]:
+            by_date[date_str] = (hms, path)
+    return [(d, by_date[d][1]) for d in sorted(by_date.keys())]
+
+
+def _load_raw_from_zip(zip_path: Path) -> tuple[str | None, dict[str, Any] | None]:
+    """Return ``(manifest_date, raw_payload)`` from a single archive.
+
+    ``manifest_date`` is the value stamped by the scraper inside
+    ``manifest.json`` (the authoritative date for the bundle, used in
+    preference to the filename when they disagree).  Returns
+    ``(None, None)`` if the zip is corrupt or missing the expected
+    members — the caller logs & skips.
+    """
+    try:
+        with zipfile.ZipFile(zip_path) as z:
+            manifest_date: str | None = None
+            try:
+                with z.open("manifest.json") as mf:
+                    manifest = json.load(mf)
+                if isinstance(manifest, dict):
+                    maybe = manifest.get("date")
+                    if isinstance(maybe, str):
+                        manifest_date = maybe
+            except KeyError:
+                pass
+            except json.JSONDecodeError:
+                pass
+
+            data_name: str | None = None
+            for n in z.namelist():
+                if n.startswith("dynasty_data_") and n.endswith(".json"):
+                    data_name = n
+                    break
+            if data_name is None and "dynasty_data.json" in z.namelist():
+                data_name = "dynasty_data.json"
+            if data_name is None:
+                return manifest_date, None
+
+            with z.open(data_name) as df:
+                raw = json.load(df)
+            if not isinstance(raw, dict):
+                return manifest_date, None
+            if manifest_date is None:
+                maybe = raw.get("date")
+                if isinstance(maybe, str):
+                    manifest_date = maybe
+            return manifest_date, raw
+    except (zipfile.BadZipFile, OSError, json.JSONDecodeError):
+        return None, None
+
+
+def _count_ranked_rows(contract: dict[str, Any]) -> int:
+    """How many rows would ``append_snapshot`` record for this contract.
+
+    Mirrors the filter in ``rank_history._extract_ranks``: a row
+    counts only if it has a name AND a positive integer
+    ``canonicalConsensusRank``.  Used for the dry-run preview where
+    we want the same number that would actually land in the JSONL
+    without invoking the extraction helper's dict build.
+    """
+    arr = contract.get("playersArray")
+    if not isinstance(arr, list):
+        data = contract.get("data") or {}
+        arr = data.get("playersArray") if isinstance(data, dict) else None
+    if not isinstance(arr, list):
+        return 0
+    n = 0
+    for row in arr:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("canonicalName") or row.get("displayName")
+        rank = row.get("canonicalConsensusRank")
+        if name and isinstance(rank, int) and rank > 0:
+            n += 1
+    return n
+
+
+def backfill(
+    archive_dir: Path,
+    *,
+    history_path: Path | None = None,
+    dry_run: bool = False,
+    max_snapshots: int = rank_history.MAX_SNAPSHOTS,
+    since: str | None = None,
+    build_contract: Callable[[dict[str, Any]], dict[str, Any]] = build_api_data_contract,
+    out=None,
+) -> list[dict[str, Any]]:
+    """Replay archived snapshots into the rank-history log.
+
+    Parameters
+    ──────────
+    archive_dir
+        Directory of ``dynasty_export_*.zip`` bundles.
+    history_path
+        Target JSONL path.  Defaults to ``rank_history.HISTORY_PATH``.
+    dry_run
+        When ``True`` we print what would be written but never touch
+        the file — size-growth reporting shows a flat 0.
+    max_snapshots
+        Retention cap forwarded to ``append_snapshot``.  Defaults to
+        the module-level constant (180).
+    since
+        Optional ``YYYY-MM-DD`` floor; snapshots with ``date < since``
+        are skipped.
+    build_contract
+        Injection seam so tests can bypass the real contract builder.
+        Default is ``build_api_data_contract``.
+    out
+        Output stream for the progress report (defaults to stdout).
+
+    Returns
+    ───────
+    A list of per-snapshot result dicts suitable for programmatic
+    inspection (the unit tests use this; the CLI ignores it and
+    relies on the printed report).
+    """
+    history_path = history_path or rank_history.HISTORY_PATH
+    stream = out if out is not None else sys.stdout
+
+    def _print(msg: str = "") -> None:
+        print(msg, file=stream)
+
+    start_size = history_path.stat().st_size if history_path.exists() else 0
+
+    _print(f"Archive dir:   {archive_dir}")
+    _print(f"History path:  {history_path}")
+    _print(f"Max snapshots: {max_snapshots}")
+    if since:
+        _print(f"Since:         {since}")
+    if dry_run:
+        _print("DRY RUN — no writes will occur")
+    _print("")
+    _print(f"  {'date':<12} {'rows':>5}  {'status':<9}  archive")
+    _print("  " + "-" * 68)
+
+    results: list[dict[str, Any]] = []
+    selections = _select_latest_per_date(archive_dir)
+
+    for filename_date, zip_path in selections:
+        if since and filename_date < since:
+            continue
+
+        manifest_date, raw = _load_raw_from_zip(zip_path)
+        if raw is None:
+            _print(
+                f"  {filename_date:<12} {'?':>5}  {'unreadable':<9}  {zip_path.name}"
+            )
+            results.append(
+                {
+                    "date": manifest_date or filename_date,
+                    "zip": str(zip_path),
+                    "rows": 0,
+                    "appended": False,
+                    "dry_run": dry_run,
+                    "skipped": "unreadable",
+                }
+            )
+            continue
+
+        effective_date = manifest_date or filename_date
+
+        try:
+            contract = build_contract(raw)
+        except Exception as exc:  # noqa: BLE001
+            _print(
+                f"  {effective_date:<12} {'?':>5}  {'build-err':<9}  "
+                f"{zip_path.name}: {exc}"
+            )
+            results.append(
+                {
+                    "date": effective_date,
+                    "zip": str(zip_path),
+                    "rows": 0,
+                    "appended": False,
+                    "dry_run": dry_run,
+                    "skipped": f"build-err: {exc}",
+                }
+            )
+            continue
+
+        row_count = _count_ranked_rows(contract)
+        appended = False
+        if row_count == 0:
+            status = "empty"
+        elif dry_run:
+            status = "WOULD"
+        else:
+            appended = rank_history.append_snapshot(
+                contract,
+                date=effective_date,
+                path=history_path,
+                max_snapshots=max_snapshots,
+            )
+            status = "appended" if appended else "skipped"
+
+        _print(
+            f"  {effective_date:<12} {row_count:>5d}  {status:<9}  {zip_path.name}"
+        )
+        results.append(
+            {
+                "date": effective_date,
+                "zip": str(zip_path),
+                "rows": row_count,
+                "appended": appended and not dry_run,
+                "dry_run": dry_run,
+            }
+        )
+
+    end_size = history_path.stat().st_size if history_path.exists() else 0
+    delta = end_size - start_size
+
+    _print("")
+    _print(
+        f"Processed {len(results)} snapshot(s).  "
+        f"History file: {start_size} -> {end_size} bytes "
+        f"({'+' if delta >= 0 else ''}{delta})"
+    )
+    if dry_run and delta != 0:
+        # Defensive: a dry run should never move the file pointer.
+        # If we ever land here it's a regression in the injected
+        # build/append path, not a normal outcome.
+        _print("WARN: dry-run recorded non-zero size delta; check the injected build_contract.")
+
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill data/rank_history.jsonl from exports/archive snapshots.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--archive-dir",
+        type=Path,
+        default=DEFAULT_ARCHIVE_DIR,
+        help="Directory of dynasty_export_*.zip bundles (default: exports/archive).",
+    )
+    parser.add_argument(
+        "--history-path",
+        type=Path,
+        default=None,
+        help="Target JSONL path (default: data/rank_history.jsonl).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be appended without writing the history file.",
+    )
+    parser.add_argument(
+        "--max-snapshots",
+        type=int,
+        default=rank_history.MAX_SNAPSHOTS,
+        help=f"Retention cap (default: {rank_history.MAX_SNAPSHOTS}).",
+    )
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="Only process snapshots with date >= YYYY-MM-DD.",
+    )
+    args = parser.parse_args(argv)
+
+    backfill(
+        archive_dir=args.archive_dir,
+        history_path=args.history_path,
+        dry_run=args.dry_run,
+        max_snapshots=args.max_snapshots,
+        since=args.since,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_rank_history.py
+++ b/scripts/backfill_rank_history.py
@@ -110,22 +110,29 @@ def _iter_candidate_zips(archive_dir: Path) -> Iterator[tuple[str, str, Path]]:
         yield _date_from_ymd(m.group(1)), m.group(2), p
 
 
-def _select_latest_per_date(
+def _select_archives_by_date(
     archive_dir: Path,
-) -> list[tuple[str, Path]]:
-    """Return ``[(date_str, zip_path), ...]`` in ascending date order.
+) -> list[tuple[str, list[Path]]]:
+    """Return ``[(date_str, [zip_path, ...]), ...]`` in ascending date order.
 
-    When multiple archives land on the same day we keep the latest
-    ``HHMMSS`` — that's the freshest snapshot of that day's state
-    and matches what ``append_snapshot``'s per-date dedup would
-    produce if we processed every zip blindly.
+    Each inner list is ordered newest-HHMMSS first.  The caller walks
+    the list and picks the first candidate that loads + builds
+    cleanly — so a corrupt latest archive falls back to an earlier
+    same-day archive instead of dropping the whole day.  That matters
+    because scrape days almost always have 4-6 bundles and a single
+    truncated final upload shouldn't defeat the backfill for that
+    day.  When every bundle loads (the common case) this behaves
+    identically to a latest-wins pre-selection: the first candidate
+    succeeds and the rest are never touched.
     """
-    by_date: dict[str, tuple[str, Path]] = {}
+    by_date: dict[str, list[tuple[str, Path]]] = {}
     for date_str, hms, path in _iter_candidate_zips(archive_dir):
-        prev = by_date.get(date_str)
-        if prev is None or hms > prev[0]:
-            by_date[date_str] = (hms, path)
-    return [(d, by_date[d][1]) for d in sorted(by_date.keys())]
+        by_date.setdefault(date_str, []).append((hms, path))
+    out: list[tuple[str, list[Path]]] = []
+    for date_str in sorted(by_date.keys()):
+        candidates = sorted(by_date[date_str], key=lambda t: t[0], reverse=True)
+        out.append((date_str, [p for _, p in candidates]))
+    return out
 
 
 def _load_raw_from_zip(zip_path: Path) -> tuple[str | None, dict[str, Any] | None]:
@@ -260,49 +267,76 @@ def backfill(
     _print("  " + "-" * 68)
 
     results: list[dict[str, Any]] = []
-    selections = _select_latest_per_date(archive_dir)
+    selections = _select_archives_by_date(archive_dir)
 
-    for filename_date, zip_path in selections:
-        if since and filename_date < since:
+    for filename_date, candidates in selections:
+        # Walk newest -> oldest HHMMSS for this day.  The first
+        # candidate that loads + builds wins; older ones only come
+        # into play if the newer ones are corrupt or trip build_
+        # contract.  Without this fallback a single bad latest-of-
+        # the-day upload drops the whole date even when yesterday's
+        # scrape had 5 other valid bundles.
+        chosen: tuple[str | None, dict[str, Any], Path, dict[str, Any]] | None = None
+        attempt_failures: list[tuple[Path, str]] = []
+
+        for candidate in candidates:
+            manifest_date, raw = _load_raw_from_zip(candidate)
+            if raw is None:
+                attempt_failures.append((candidate, "unreadable"))
+                continue
+
+            effective_date = manifest_date or filename_date
+            if since and effective_date < since:
+                # ``--since`` is evaluated against the manifest-
+                # authoritative date, matching what ``append_snapshot``
+                # will actually write; filename/manifest mismatches
+                # would otherwise produce off-by-one skips at the
+                # cutoff boundary.  Skipping here still allows older
+                # same-day candidates to be tried for days whose
+                # manifest floats them over the cutoff.
+                attempt_failures.append((candidate, "before-since"))
+                continue
+
+            try:
+                contract = build_contract(raw)
+            except Exception as exc:  # noqa: BLE001
+                attempt_failures.append((candidate, f"build-err: {exc}"))
+                continue
+
+            chosen = (manifest_date, contract, candidate, {})
+            break
+
+        if chosen is None:
+            # Nothing salvageable for this day.  Only log when the
+            # reason wasn't a pure --since skip — an entirely-
+            # before-cutoff day is expected and shouldn't pollute
+            # the report.
+            non_since_failures = [
+                (p, reason) for p, reason in attempt_failures
+                if reason != "before-since"
+            ]
+            if not non_since_failures:
+                continue
+            for path, reason in non_since_failures:
+                label = "unreadable" if reason == "unreadable" else "build-err"
+                _print(
+                    f"  {filename_date:<12} {'?':>5}  {label:<9}  {path.name}"
+                    + (f": {reason[len('build-err: '):]}" if reason.startswith("build-err: ") else "")
+                )
+                results.append(
+                    {
+                        "date": filename_date,
+                        "zip": str(path),
+                        "rows": 0,
+                        "appended": False,
+                        "dry_run": dry_run,
+                        "skipped": reason,
+                    }
+                )
             continue
 
-        manifest_date, raw = _load_raw_from_zip(zip_path)
-        if raw is None:
-            _print(
-                f"  {filename_date:<12} {'?':>5}  {'unreadable':<9}  {zip_path.name}"
-            )
-            results.append(
-                {
-                    "date": manifest_date or filename_date,
-                    "zip": str(zip_path),
-                    "rows": 0,
-                    "appended": False,
-                    "dry_run": dry_run,
-                    "skipped": "unreadable",
-                }
-            )
-            continue
-
+        manifest_date, contract, zip_path, _ = chosen
         effective_date = manifest_date or filename_date
-
-        try:
-            contract = build_contract(raw)
-        except Exception as exc:  # noqa: BLE001
-            _print(
-                f"  {effective_date:<12} {'?':>5}  {'build-err':<9}  "
-                f"{zip_path.name}: {exc}"
-            )
-            results.append(
-                {
-                    "date": effective_date,
-                    "zip": str(zip_path),
-                    "rows": 0,
-                    "appended": False,
-                    "dry_run": dry_run,
-                    "skipped": f"build-err: {exc}",
-                }
-            )
-            continue
 
         row_count = _count_ranked_rows(contract)
         appended = False

--- a/tests/scripts/test_backfill_rank_history.py
+++ b/tests/scripts/test_backfill_rank_history.py
@@ -1,0 +1,341 @@
+"""Unit tests for ``scripts/backfill_rank_history.py``.
+
+We don't invoke ``build_api_data_contract`` directly here — a real
+contract build pulls the full pipeline and isn't what this script
+is responsible for.  Instead we inject a pass-through
+``build_contract`` so the test can stuff a pre-built contract into
+each synthetic zip and verify the iteration / dedup / dry-run
+plumbing around it.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import unittest
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "backfill_rank_history.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("backfill_rank_history", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def _contract(rank_by_name: dict[str, int], asset_class: str = "offense") -> dict[str, Any]:
+    return {
+        "playersArray": [
+            {
+                "canonicalName": name,
+                "displayName": name,
+                "canonicalConsensusRank": rank,
+                "assetClass": asset_class,
+            }
+            for name, rank in rank_by_name.items()
+        ]
+    }
+
+
+def _write_zip(path: Path, *, date: str, payload: dict[str, Any]) -> None:
+    """Write a synthetic archive with the same member layout the real
+    scraper produces — ``manifest.json`` plus
+    ``dynasty_data_<DATE>.json`` — so the script's zip-reader path is
+    exercised end-to-end."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(
+            "manifest.json",
+            json.dumps({"date": date, "files": [f"dynasty_data_{date}.json"]}),
+        )
+        z.writestr(f"dynasty_data_{date}.json", json.dumps(payload))
+
+
+def _passthrough(raw: dict[str, Any]) -> dict[str, Any]:
+    """Injected ``build_contract`` that returns the raw payload
+    unchanged — our synthetic raw already carries a ``playersArray``."""
+    return raw
+
+
+class TestBackfillThreeSnapshots(unittest.TestCase):
+    def test_writes_three_entries_in_date_order(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            # Three synthetic archives, intentionally created out of
+            # date order and with differing HHMMSS timestamps so the
+            # test exercises sort + filename parsing rather than
+            # relying on filesystem-iteration order.
+            _write_zip(
+                archive / "dynasty_export_20260310_120000.zip",
+                date="2026-03-10",
+                payload=_contract({"Alice": 1, "Bob": 2}),
+            )
+            _write_zip(
+                archive / "dynasty_export_20260308_090000.zip",
+                date="2026-03-08",
+                payload=_contract({"Alice": 2, "Bob": 1}),
+            )
+            _write_zip(
+                archive / "dynasty_export_20260309_110000.zip",
+                date="2026-03-09",
+                payload=_contract({"Alice": 1, "Bob": 3}),
+            )
+
+            results = _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+
+            self.assertEqual(len(results), 3)
+            self.assertTrue(all(r["appended"] for r in results))
+            self.assertEqual(
+                [r["date"] for r in results],
+                ["2026-03-08", "2026-03-09", "2026-03-10"],
+            )
+
+            # JSONL: exactly three entries, in chronological order.
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 3)
+            parsed = [json.loads(line) for line in lines]
+            self.assertEqual(
+                [e["date"] for e in parsed],
+                ["2026-03-08", "2026-03-09", "2026-03-10"],
+            )
+            # Rank maps carry the composite ``name::assetClass`` key
+            # the snapshot path actually stores — so each synthetic
+            # player lands under ``Alice::offense`` / ``Bob::offense``.
+            self.assertEqual(
+                parsed[0]["ranks"],
+                {"Alice::offense": 2, "Bob::offense": 1},
+            )
+            self.assertEqual(
+                parsed[2]["ranks"],
+                {"Alice::offense": 1, "Bob::offense": 2},
+            )
+
+    def test_is_idempotent_across_reruns(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            _write_zip(
+                archive / "dynasty_export_20260308_090000.zip",
+                date="2026-03-08",
+                payload=_contract({"Alice": 1}),
+            )
+            _write_zip(
+                archive / "dynasty_export_20260309_090000.zip",
+                date="2026-03-09",
+                payload=_contract({"Alice": 1}),
+            )
+            _write_zip(
+                archive / "dynasty_export_20260310_090000.zip",
+                date="2026-03-10",
+                payload=_contract({"Alice": 1}),
+            )
+
+            # First run lays down three entries.
+            _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+            # Second run must be a no-growth fixed point — per-date
+            # dedup inside ``append_snapshot`` rewrites the entry
+            # rather than appending a fourth.
+            _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 3)
+            self.assertEqual(
+                [json.loads(line)["date"] for line in lines],
+                ["2026-03-08", "2026-03-09", "2026-03-10"],
+            )
+
+
+class TestBackfillDrySelection(unittest.TestCase):
+    def test_dry_run_does_not_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            _write_zip(
+                archive / "dynasty_export_20260308_090000.zip",
+                date="2026-03-08",
+                payload=_contract({"Alice": 1}),
+            )
+
+            buf = io.StringIO()
+            results = _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                dry_run=True,
+                build_contract=_passthrough,
+                out=buf,
+            )
+
+            self.assertFalse(history.exists())
+            self.assertEqual(len(results), 1)
+            self.assertFalse(results[0]["appended"])
+            self.assertEqual(results[0]["rows"], 1)
+            self.assertIn("DRY RUN", buf.getvalue())
+            self.assertIn("WOULD", buf.getvalue())
+
+    def test_picks_latest_timestamp_per_date(self) -> None:
+        # Same day, two scrapes — the later one's ranks must win,
+        # matching what ``append_snapshot``'s per-date dedup would
+        # produce if we blindly processed both.
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            _write_zip(
+                archive / "dynasty_export_20260308_020000.zip",
+                date="2026-03-08",
+                payload=_contract({"Alice": 9, "Bob": 9}),
+            )
+            _write_zip(
+                archive / "dynasty_export_20260308_220000.zip",
+                date="2026-03-08",
+                payload=_contract({"Alice": 1, "Bob": 2}),
+            )
+
+            _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            entry = json.loads(lines[0])
+            self.assertEqual(entry["date"], "2026-03-08")
+            self.assertEqual(
+                entry["ranks"],
+                {"Alice::offense": 1, "Bob::offense": 2},
+            )
+
+    def test_since_filter_skips_earlier_snapshots(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            for date in ("2026-03-08", "2026-03-09", "2026-03-10"):
+                ymd = date.replace("-", "")
+                _write_zip(
+                    archive / f"dynasty_export_{ymd}_090000.zip",
+                    date=date,
+                    payload=_contract({"Alice": 1}),
+                )
+
+            _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                since="2026-03-09",
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(
+                [json.loads(line)["date"] for line in lines],
+                ["2026-03-09", "2026-03-10"],
+            )
+
+    def test_max_snapshots_cap(self) -> None:
+        # With a cap of 2 and three archives, only the two most
+        # recent dates survive the trim — same retention policy the
+        # production path enforces.
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            for date in ("2026-03-08", "2026-03-09", "2026-03-10"):
+                ymd = date.replace("-", "")
+                _write_zip(
+                    archive / f"dynasty_export_{ymd}_090000.zip",
+                    date=date,
+                    payload=_contract({"Alice": 1}),
+                )
+
+            _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                max_snapshots=2,
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(
+                [json.loads(line)["date"] for line in lines],
+                ["2026-03-09", "2026-03-10"],
+            )
+
+
+class TestArchiveZipLoader(unittest.TestCase):
+    def test_unreadable_zip_is_reported_not_fatal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            archive.mkdir()
+            history = tmpdir / "rank_history.jsonl"
+
+            # One good, one corrupt.
+            _write_zip(
+                archive / "dynasty_export_20260308_090000.zip",
+                date="2026-03-08",
+                payload=_contract({"Alice": 1}),
+            )
+            (archive / "dynasty_export_20260309_090000.zip").write_bytes(b"not a zip")
+
+            buf = io.StringIO()
+            results = _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                build_contract=_passthrough,
+                out=buf,
+            )
+
+            self.assertEqual(len(results), 2)
+            statuses = [r.get("skipped") for r in results]
+            self.assertIn("unreadable", statuses)
+            # The good snapshot still landed.
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(json.loads(lines[0])["date"], "2026-03-08")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_backfill_rank_history.py
+++ b/tests/scripts/test_backfill_rank_history.py
@@ -304,6 +304,135 @@ class TestBackfillDrySelection(unittest.TestCase):
             )
 
 
+class TestCorruptLatestFallback(unittest.TestCase):
+    """Regression coverage for Codex PR #223 round 1.
+
+    The original selector kept only the highest-HHMMSS archive per
+    date before any validation — so if that latest upload was
+    corrupt or crashed build_contract, the entire day was dropped
+    even when earlier same-day archives were fine.  The selector
+    now returns all candidates per date and the loop walks them
+    newest-first until one succeeds.
+    """
+
+    def test_corrupt_latest_falls_back_to_earlier_same_day(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            archive.mkdir()
+            history = tmpdir / "rank_history.jsonl"
+
+            # Earlier valid bundle.
+            _write_zip(
+                archive / "dynasty_export_20260308_020000.zip",
+                date="2026-03-08",
+                payload=_contract({"Alice": 1, "Bob": 2}),
+            )
+            # Latest is corrupt — pre-fix this would drop the day.
+            (archive / "dynasty_export_20260308_220000.zip").write_bytes(b"not a zip")
+
+            results = _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+
+            # The valid-earlier bundle wrote a snapshot.
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            entry = json.loads(lines[0])
+            self.assertEqual(entry["date"], "2026-03-08")
+            self.assertEqual(
+                entry["ranks"],
+                {"Alice::offense": 1, "Bob::offense": 2},
+            )
+            # The corrupt candidate should not be surfaced as a
+            # failure — we found a good one for that day.  Any
+            # results reported must be for successful appends only.
+            self.assertEqual(len(results), 1)
+            self.assertTrue(results[0]["appended"])
+
+    def test_build_error_on_latest_falls_back_to_earlier(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            _write_zip(
+                archive / "dynasty_export_20260308_020000.zip",
+                date="2026-03-08",
+                payload={"flavour": "good", "playersArray": [
+                    {"canonicalName": "Alice", "canonicalConsensusRank": 1, "assetClass": "offense"},
+                ]},
+            )
+            _write_zip(
+                archive / "dynasty_export_20260308_220000.zip",
+                date="2026-03-08",
+                payload={"flavour": "bad"},
+            )
+
+            # Builder that rejects the "bad" payload but accepts
+            # the "good" one — simulates a targeted build failure
+            # on the latest upload only.
+            def _picky_build(raw):
+                if raw.get("flavour") == "bad":
+                    raise RuntimeError("simulated build error")
+                return raw
+
+            _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                build_contract=_picky_build,
+                out=io.StringIO(),
+            )
+
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(
+                json.loads(lines[0])["ranks"],
+                {"Alice::offense": 1},
+            )
+
+
+class TestSinceAgainstManifestDate(unittest.TestCase):
+    """Regression coverage for Codex PR #223 round 1.
+
+    Pre-fix, ``--since`` was evaluated against the filename date
+    before the manifest was read — so an archive whose filename
+    said 2026-03-08 but whose manifest said 2026-03-09 was
+    incorrectly skipped by ``--since 2026-03-09``, even though the
+    manifest date is what ``append_snapshot`` actually writes.
+    """
+
+    def test_since_uses_manifest_date_not_filename_date(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            archive = tmpdir / "archive"
+            history = tmpdir / "rank_history.jsonl"
+
+            # Filename says 2026-03-08 but manifest authoritatively
+            # says 2026-03-09 — simulates a UTC-midnight-crossing
+            # scrape or a clock skew.
+            _write_zip(
+                archive / "dynasty_export_20260308_235959.zip",
+                date="2026-03-09",
+                payload=_contract({"Alice": 1}),
+            )
+
+            _mod.backfill(
+                archive_dir=archive,
+                history_path=history,
+                since="2026-03-09",
+                build_contract=_passthrough,
+                out=io.StringIO(),
+            )
+
+            lines = history.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(json.loads(lines[0])["date"], "2026-03-09")
+
+
 class TestArchiveZipLoader(unittest.TestCase):
     def test_unreadable_zip_is_reported_not_fatal(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

The rank-history log (`data/rank_history.jsonl`) lands empty on deploy day per PR #217, so the `RankChangeGlyph` sparklines fall through to the delta-arrow fallback until two production scrapes have cycled. This PR adds a script that backfills the JSONL from the `exports/archive/*.zip` bundles we've been accumulating for months, so glyphs can light up immediately instead of waiting on the next 2+ scrapes.

## What it does

- `scripts/backfill_rank_history.py` iterates `exports/archive/dynasty_export_YYYYMMDD_HHMMSS.zip` in date order, replays each raw payload through `build_api_data_contract`, and feeds the result into `rank_history.append_snapshot(contract, date=archived_date, ...)`.
- Prefers the `manifest.json` date over the filename, falling back to the filename when absent.
- When multiple archives share a day, picks the latest `HHMMSS` up front — avoids paying the contract-rebuild cost for same-day snapshots that `append_snapshot`'s per-date dedup would discard anyway.
- Per-snapshot progress report: date, ranked row count, status (`appended` / `WOULD` / `empty` / `unreadable` / `build-err`), archive filename. Summary line reports history-file size growth in bytes.
- `--dry-run` — prints what would be appended without touching the file.
- `--since YYYY-MM-DD` — incremental catch-up.
- `--archive-dir` / `--history-path` / `--max-snapshots` — overrides for tests & operator experimentation.

## Correctness properties

- **Idempotent**: `append_snapshot` dedups by date, so reruns are a fixed point.
- **Retention-honouring**: `MAX_SNAPSHOTS` (180) forwarded to the same trim path production uses.
- **Resilient**: corrupt/unreadable zips and build errors are logged per-snapshot but don't abort the run — the good snapshots still land.

## Test plan

7 unit tests in `tests/scripts/test_backfill_rank_history.py` (all passing locally):

- [x] Three synthetic archives land exactly three JSONL entries in date order (explicit acceptance criterion)
- [x] Re-running the backfill against the same archive is a no-growth fixed point
- [x] `--dry-run` never writes the file and prints the `WOULD` marker
- [x] Two archives on the same day → the later `HHMMSS` wins
- [x] `--since` filter skips earlier snapshots
- [x] `--max-snapshots=2` trims to the two newest dates
- [x] Corrupt zip is reported but doesn't abort the run

Full suite: `python -m unittest tests.api.test_rank_history tests.scripts.test_backfill_rank_history` → 31 passing.

Sanity check against the real archive:

```
$ python scripts/backfill_rank_history.py --dry-run --since 2026-04-20
  2026-04-20     740  WOULD      dynasty_export_20260420_223133.zip
  2026-04-21     740  WOULD      dynasty_export_20260421_222809.zip
  2026-04-22     740  WOULD      dynasty_export_20260422_035553.zip
Processed 3 snapshot(s).  History file: 0 -> 0 bytes (+0)
```

## Not in scope

Running the backfill in production — that's an operator task once this lands.

https://claude.ai/code/session_01XSAYXWvwPMorD1kZ1vvvc2