### PR TITLE
Mobile responsiveness round 2: landscape zoom, safe-area, touch targets, overlay dvh

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -576,6 +576,31 @@ tr:hover .sticky-name {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   TRADE DESTINATION SELECT
+   Appears inside each trade asset row ("→ Side A / Side B / ...").
+   Desktop wants a very compact pill; mobile gets the standard 16px
+   from the global input rule so iOS does not zoom when the select is
+   tapped.
+   ══════════════════════════════════════════════════════════════════════════ */
+.select.trade-dest-select {
+  font-size: 0.7rem;
+}
+@media (max-width: 768px) {
+  .select.trade-dest-select {
+    font-size: 16px;
+  }
+}
+
+.roster-textarea {
+  font-size: 0.82rem;
+}
+@media (max-width: 768px) {
+  .roster-textarea {
+    font-size: 16px;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    SETTINGS — SOURCES TABLE
    Render the full 6-column table on desktop.  On mobile (≤768px) the
    six-column layout overflows the viewport (~680px at 0.76rem) even
@@ -1234,6 +1259,39 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   iOS INPUT ZOOM DEFENSE (orientation-independent)
+   iOS Safari auto-zooms any focused input whose computed font-size is
+   below 16px.  The ≤768px media query below catches portrait phone
+   viewports; landscape iPhones come in at 844px wide and miss that
+   query even though the device is still phone-size.  `pointer: coarse
+   + hover: none` keys off the input device rather than viewport
+   dimensions, so rotated phones and tablets also lock 16px.
+   ══════════════════════════════════════════════════════════════════════════ */
+@media (hover: none) and (pointer: coarse) {
+  .input,
+  .select,
+  textarea,
+  input[type="text"],
+  input[type="search"],
+  input[type="email"],
+  input[type="password"],
+  input[type="number"],
+  input[type="tel"],
+  input[type="url"] {
+    font-size: 16px;
+  }
+  .angle-field select, .angle-field input {
+    font-size: 16px;
+    padding: 8px 10px;
+  }
+  .select.trade-dest-select,
+  .roster-textarea,
+  .input.weight-input {
+    font-size: 16px;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    MOBILE BREAKPOINT (≤ 768px)
    ══════════════════════════════════════════════════════════════════════════ */
 @media (max-width: 768px) {
@@ -1248,12 +1306,9 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   nav.mobile-only { display: flex !important; }
   header.mobile-only { display: flex !important; }
 
-  /* iOS Safari auto-zooms any input whose computed font-size is
-     smaller than 16px.  Our form controls are 0.82rem (~13px) for
-     desktop density, which triggers a disorienting zoom-in whenever a
-     user taps a field on iOS.  Force 16px on touch-size viewports so
-     tapping a search/filter/picker input does not warp the viewport.
-     Visual density is preserved via the padding/min-height below. */
+  /* See the coarse-pointer rule below — this duplicate ensures the
+     ≤768px portrait path also gets 16px even on browsers / devices
+     that don't surface `pointer: coarse` correctly. */
   .input,
   .select,
   textarea,
@@ -2855,6 +2910,16 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   background: var(--surface-elevated);
   color: var(--text-primary);
   font-size: 0.9rem;
+}
+@media (max-width: 768px) {
+  /* `.angle-field select/input` doesn't use the `.input`/`.select`
+     class, so the generic mobile 16px rule doesn't match and iOS
+     zooms when these are tapped.  Lift the font-size inside the
+     mobile breakpoint. */
+  .angle-field select, .angle-field input {
+    font-size: 16px;
+    padding: 8px 10px;
+  }
 }
 /* Explicit option styling — Chromium on dark OS themes inherits a
    translucent default and dropdown options become unreadable. */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1693,10 +1693,22 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   font-weight: 600;
   cursor: pointer;
   transition: color 0.1s;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
-.rankings-player-name:hover {
+.rankings-player-name:hover,
+.rankings-player-name:active {
   color: var(--cyan);
+}
+
+@media (max-width: 768px) {
+  /* Extend the tappable area vertically on touch so a thumb reliably
+     hits the popup trigger.  Desktop row density unchanged. */
+  .rankings-player-name {
+    display: inline-block;
+    padding: 6px 0;
+  }
 }
 
 .rankings-player-meta {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -554,6 +554,28 @@ tr:hover .sticky-name {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   RANKINGS — COLUMNS POPOVER
+   Inline styles on the popover pin it to the button's right edge via
+   `right: 0`.  When the Columns button wraps onto a new row (narrow
+   viewports) the popover extends 260px left from that anchor, which
+   overflows the viewport on phones.  On ≤520px pin the popover to
+   both edges of the page-header card instead.
+   ══════════════════════════════════════════════════════════════════════════ */
+@media (max-width: 520px) {
+  .rankings-columns-popover {
+    /* Override the inline `right: 0` with a fixed-width anchored to
+       the left edge of the viewport so the 260px menu cannot escape
+       off-screen.  Inline styles win on specificity; bump ours with
+       !important (the popover only renders inside this narrow query,
+       so !important scope stays tight). */
+    left: 8px !important;
+    right: 8px !important;
+    min-width: 0 !important;
+    max-width: calc(100vw - 16px);
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    SETTINGS — SOURCES TABLE
    Render the full 6-column table on desktop.  On mobile (≤768px) the
    six-column layout overflows the viewport (~680px at 0.76rem) even

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -536,6 +536,45 @@ tr:hover .sticky-name {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   POSITION FILTER CHIPS (rosters page, reusable)
+   ══════════════════════════════════════════════════════════════════════════ */
+/* Segmented toggle.  Inline ``color``/``background``/``borderColor`` on
+   each chip paints the per-position accent; this rule only owns shape,
+   typography and the mobile tap-target minimum. */
+.pos-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.12s ease, color 0.12s ease, transform 0.08s ease;
+}
+.pos-chip:active { transform: translateY(1px); }
+
+/* Dim the idle (non-active) chip so the active fill reads first. */
+.pos-chip:not(.pos-chip-active) { background: rgba(255, 255, 255, 0.02); }
+
+@media (max-width: 768px) {
+  .pos-chip {
+    /* 44x44 Apple HIG minimum tap target on touch devices. */
+    min-height: 44px;
+    padding: 6px 14px;
+    font-size: 0.84rem;
+  }
+  .roster-pos-filter { gap: 6px; flex-wrap: wrap; }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    BADGES
    ══════════════════════════════════════════════════════════════════════════ */
 .badge {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -563,15 +563,27 @@ tr:hover .sticky-name {
    ══════════════════════════════════════════════════════════════════════════ */
 @media (max-width: 520px) {
   .rankings-columns-popover {
-    /* Override the inline `right: 0` with a fixed-width anchored to
-       the left edge of the viewport so the 260px menu cannot escape
-       off-screen.  Inline styles win on specificity; bump ours with
-       !important (the popover only renders inside this narrow query,
-       so !important scope stays tight). */
+    /* The popover is absolutely-positioned under an inline-block
+       wrapper (the Columns button's parent <div>) — using
+       left/right: 8px on an absolute child would shrink the popover
+       to "button width − 16px", not viewport width.  Switch to
+       `position: fixed` on narrow viewports so left/right anchor to
+       the viewport itself; the button-relative layout is only
+       meaningful on desktop where the menu fits naturally. */
+    position: fixed !important;
+    top: auto !important;
+    bottom: auto !important;
     left: 8px !important;
     right: 8px !important;
     min-width: 0 !important;
     max-width: calc(100vw - 16px);
+    /* Pin just below the mobile topbar + safe area; the button
+       itself is typically scrolled within the main-shell card
+       header, so a fixed near-top layout feels natural and keeps the
+       full source checklist readable without interacting with the
+       source button's in-flow position. */
+    top: calc(var(--mobile-topbar-h) + env(safe-area-inset-top, 0px) + 8px) !important;
+    max-height: calc(100dvh - var(--mobile-topbar-h) - var(--mobile-nav-h) - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 16px);
   }
 }
 
@@ -1568,7 +1580,13 @@ input[type="range"]:focus-visible::-moz-range-thumb {
    SMALL MOBILE (≤ 420px)
    ══════════════════════════════════════════════════════════════════════════ */
 @media (max-width: 420px) {
-  .main-shell { padding: 6px 6px calc(var(--mobile-nav-h) + 10px); }
+  /* Keep the safe-area-inset addition from the ≤768px rule — without
+     it, the last row of content lands behind the home indicator on
+     iPhones whose viewport is 390px wide (14 Pro / 14) and activates
+     this narrower override in cascade. */
+  .main-shell {
+    padding: 6px 6px calc(var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px) + 10px);
+  }
   .card { padding: var(--space-sm); }
   .page-title { font-size: 0.95rem; }
   .filter-bar .input,

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -201,9 +201,15 @@ a { color: inherit; text-decoration: none; }
   color: var(--muted);
   font-family: var(--mono);
   font-size: 0.78rem;
+  /* 44x44 minimum touch target — the previous ~24x24 glyph was a
+     frequent miss on iOS. */
+  min-width: 44px;
+  min-height: 40px;
   padding: 4px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .mobile-topbar-actions {
@@ -218,9 +224,12 @@ a { color: inherit; text-decoration: none; }
   color: var(--muted);
   font-size: 0.72rem;
   font-weight: 600;
-  padding: 4px 8px;
+  min-height: 40px;
+  padding: 6px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
@@ -533,6 +542,83 @@ thead .sticky-name {
 
 tr:hover .sticky-name {
   background: #3d1e6e;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   GLOBAL SEARCH
+   ══════════════════════════════════════════════════════════════════════════ */
+/* The input row carries the visible border + focus-ring so the bare
+   input can keep `border: none` (design goal: minimal chrome) without
+   losing keyboard-accessibility focus feedback. */
+.global-search-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 19, 44, 0.5);
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.global-search-input-row:focus-within {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 3px rgba(255, 198, 47, 0.15);
+}
+.global-search-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 8px 2px;
+  /* 16px locked — iOS would zoom on focus otherwise.  The previous
+     inline `fontSize: "1rem"` resolved to 16px but the mobile global
+     rule now covers it explicitly via `input[type="text"]`. */
+  font-size: 1rem;
+}
+.global-search-close {
+  font-size: 0.76rem;
+  min-height: 40px;
+  padding: 6px 12px;
+  letter-spacing: 0.05em;
+  touch-action: manipulation;
+}
+@media (max-width: 768px) {
+  .global-search-close {
+    min-width: 56px;
+    min-height: 44px;
+    font-size: 0.82rem;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PLAYER POPUP HEADER ACTIONS (Add to Trade / close X)
+   ══════════════════════════════════════════════════════════════════════════ */
+.player-popup-action {
+  font-size: 0.78rem;
+  padding: 6px 12px;
+}
+/* Square close button — keeps visual parity with the .picker-close
+   button used on the player picker.  Font-size drives the glyph; the
+   min-width/min-height lock the tap target. */
+.player-popup-close {
+  min-width: 36px;
+  min-height: 36px;
+  padding: 0 10px;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+@media (max-width: 768px) {
+  .player-popup-action {
+    min-height: 44px;
+    padding: 8px 14px;
+    font-size: 0.88rem;
+  }
+  .player-popup-close {
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 1.3rem;
+  }
 }
 
 /* ══════════════════════════════════════════════════════════════════════════

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -241,7 +241,12 @@ a { color: inherit; text-decoration: none; }
   left: 0;
   right: 0;
   z-index: 40;
-  height: var(--mobile-nav-h);
+  /* Grow the nav by the home-indicator safe area inset so the icons
+     still fit in the original 56px content zone above the indicator.
+     With the previous `height: 56px; padding-bottom: env(...)` +
+     box-sizing: border-box the padding ate the content area and
+     squashed icons into ~22px on iPhones with a home indicator. */
+  height: calc(var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px));
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -1110,7 +1115,7 @@ tr:hover .sticky-name {
   }
 
   .main-shell {
-    padding: var(--space-sm) var(--space-sm) calc(var(--mobile-nav-h) + var(--space-md));
+    padding: var(--space-sm) var(--space-sm) calc(var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px) + var(--space-md));
     /* Subtract the full top-bar including its safe-area inset so the
        minimum height still reflects the space actually available
        between the (taller, notch-aware) top bar and the bottom nav. */
@@ -1135,7 +1140,9 @@ tr:hover .sticky-name {
   th, td { padding: 6px 8px; }
 
   .trade-sticky-tray {
-    bottom: var(--mobile-nav-h);
+    /* Sit above the bottom nav AND the iOS home indicator, matching
+       the nav's taller total height (var + env). */
+    bottom: calc(var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px));
   }
 
   .trade-tray-main {
@@ -2915,7 +2922,9 @@ tr:hover .sticky-name {
 .chat-fab {
   position: fixed;
   right: 16px;
-  bottom: calc(var(--mobile-nav-h) + 16px);
+  /* Stack above both the bottom nav and the iOS home-indicator safe
+     area so the FAB is always reachable with one thumb. */
+  bottom: calc(var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px) + 16px);
   z-index: 900;
   display: inline-flex;
   align-items: center;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1403,13 +1403,18 @@ input[type="range"]:focus-visible::-moz-range-thumb {
     flex-shrink: 0;
   }
 
-  /* Trade controls: compact on mobile */
+  /* Trade controls: compact on mobile.  Keep the padding tight but
+     leave the generic `.input/.select` 16px rule in charge so iOS
+     does not zoom when the "Value mode" or Add-team selects are
+     tapped (the earlier 0.74rem font-size undercut 16px). */
   .trade-controls {
     gap: 6px !important;
   }
-  .trade-controls .button,
-  .trade-controls .select {
+  .trade-controls .button {
     font-size: 0.74rem;
+    padding: 6px 8px;
+  }
+  .trade-controls .select {
     padding: 6px 8px;
   }
 
@@ -2916,6 +2921,16 @@ input[type="range"]:focus-visible::-moz-range-thumb {
      class, so the generic mobile 16px rule doesn't match and iOS
      zooms when these are tapped.  Lift the font-size inside the
      mobile breakpoint. */
+  .angle-field select, .angle-field input {
+    font-size: 16px;
+    padding: 8px 10px;
+  }
+}
+/* Landscape phone / tablet defense — `pointer: coarse + hover: none`
+   keys off the input device so rotating an iPhone to landscape (viewport
+   width 844 > 768) still matches.  Declared AFTER `.angle-field` so the
+   cascade picks this rule up regardless of specificity tie-breakers. */
+@media (hover: none) and (pointer: coarse) {
   .angle-field select, .angle-field input {
     font-size: 16px;
     padding: 8px 10px;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -702,7 +702,11 @@ tr:hover .sticky-name {
 
 .picker-sheet {
   width: min(660px, 100%);
-  max-height: 80vh;
+  /* dvh = dynamic viewport height.  When the iOS soft keyboard is open
+     this shrinks the sheet above the keyboard instead of clipping its
+     results/controls underneath.  Desktop browsers treat dvh the same
+     as vh, so this is a pure mobile win with no desktop regression. */
+  max-height: 80dvh;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: linear-gradient(180deg, rgba(20, 39, 79, 0.97) 0%, rgba(13, 29, 63, 0.98) 100%);
@@ -788,7 +792,9 @@ tr:hover .sticky-name {
 .sheet {
   width: 100%;
   max-width: 600px;
-  max-height: 85vh;
+  /* dvh so the sheet shrinks with the iOS keyboard instead of
+     disappearing behind it. */
+  max-height: 85dvh;
   overflow-y: auto;
   background: linear-gradient(180deg, rgba(42, 21, 80, 0.98) 0%, rgba(26, 15, 46, 0.99) 100%);
   border: 1px solid var(--border);
@@ -908,7 +914,10 @@ tr:hover .sticky-name {
    LOGIN PAGE
    ══════════════════════════════════════════════════════════════════════════ */
 .login-shell {
-  min-height: calc(100vh - 120px);
+  /* dvh — the keyboard opens when tapping the password field; vh
+     anchored the shell to the pre-keyboard viewport and pushed the
+     submit button behind the keyboard. */
+  min-height: calc(100dvh - 120px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2839,8 +2848,11 @@ tr:hover .sticky-name {
   right: 0;
   left: 0;
   bottom: 0;
-  max-height: 90vh;
-  height: 90vh;
+  /* dvh so the drawer shrinks with the iOS soft keyboard.  With vh
+     the chat input was pushed below the keyboard and the user
+     couldn't see what they were typing. */
+  max-height: 90dvh;
+  height: 90dvh;
   display: flex;
   flex-direction: column;
   background: linear-gradient(180deg, rgba(42, 21, 80, 0.98) 0%, rgba(26, 15, 46, 0.99) 100%);

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -550,6 +550,77 @@ tr:hover .sticky-name {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   RANGE SLIDERS (settings TE-premium, trade-history window, etc.)
+   ══════════════════════════════════════════════════════════════════════════ */
+/* The native <input type="range"> thumb is ~12px on iOS Safari which
+   is nearly impossible to drag with a finger.  Enlarge to 22px with a
+   hit padding that hit-tests beyond the visible thumb, and tighten the
+   track height so the slider still reads compact. */
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 28px; /* overall control height drives the tap surface */
+  background: transparent;
+  touch-action: manipulation;
+}
+input[type="range"]:focus { outline: none; }
+
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border);
+}
+input[type="range"]::-moz-range-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border);
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 22px;
+  height: 22px;
+  margin-top: -9px; /* centre the thumb vertically on the 4px track */
+  border-radius: 50%;
+  background: var(--cyan);
+  border: 2px solid rgba(15, 10, 26, 0.9);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  cursor: grab;
+}
+input[type="range"]::-moz-range-thumb {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--cyan);
+  border: 2px solid rgba(15, 10, 26, 0.9);
+  cursor: grab;
+}
+
+input[type="range"]:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 4px rgba(255, 198, 47, 0.25),
+              0 2px 6px rgba(0, 0, 0, 0.35);
+}
+input[type="range"]:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 4px rgba(255, 198, 47, 0.25),
+              0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+@media (max-width: 768px) {
+  input[type="range"] { height: 34px; }
+  input[type="range"]::-webkit-slider-thumb {
+    width: 26px;
+    height: 26px;
+    margin-top: -11px;
+  }
+  input[type="range"]::-moz-range-thumb {
+    width: 26px;
+    height: 26px;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    GLOBAL SEARCH
    ══════════════════════════════════════════════════════════════════════════ */
 /* The input row carries the visible border + focus-ring so the bare

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -446,6 +446,10 @@ a { color: inherit; text-decoration: none; }
   font-weight: 600;
   cursor: pointer;
   transition: border-color 0.12s;
+  /* Kill the 300ms double-tap delay + the default grey tap-flash on
+     iOS; :active + :hover below still provide tap feedback. */
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .button:hover {
@@ -887,6 +891,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   min-width: 0;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 .asset-row > div:first-child {
   min-width: 0;
@@ -1830,7 +1836,14 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 /* ── Source audit panel (expandable row) ─────────────────────────── */
-.rankings-row-clickable { cursor: pointer; }
+.rankings-row-clickable {
+  cursor: pointer;
+  /* `transparent` suppresses the default grey flash iOS paints over
+     every tap target.  Hover + active styles below replace it with a
+     themed highlight, so the UI still gives visual feedback. */
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
 .rankings-row-clickable:hover td { background: rgba(96, 165, 250, 0.04); }
 .rankings-row-expanded td { background: rgba(96, 165, 250, 0.06); border-bottom: none; }
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -400,6 +400,21 @@ a { color: inherit; text-decoration: none; }
   font-size: 0.82rem;
 }
 
+/* Compact numeric inputs (eg. per-source weight in settings).  Uses
+   a narrow fixed width on desktop for the tight 6-column table layout;
+   on mobile the generic 16px rule applies so iOS Safari does not
+   zoom when the input is focused. */
+.input.weight-input {
+  width: 64px;
+  font-size: 0.76rem;
+}
+@media (max-width: 768px) {
+  .input.weight-input {
+    width: 80px;
+    font-size: 16px;
+  }
+}
+
 .input:focus,
 .select:focus {
   outline: none;
@@ -976,8 +991,10 @@ tr:hover .sticky-name {
   .filter-bar { gap: 6px; }
   .filter-bar .input,
   .filter-bar .select {
-    font-size: 0.76rem;
-    padding: 6px 8px;
+    /* Keep the general mobile 16px rule so iOS Safari does not zoom
+       on focus.  Density stays tight via padding; bigger type is
+       the correct tradeoff for touch inputs. */
+    padding: 8px 10px;
   }
 
   table { font-size: 0.74rem; }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -550,6 +550,60 @@ tr:hover .sticky-name {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   SETTINGS — SOURCES TABLE
+   Render the full 6-column table on desktop.  On mobile (≤768px) the
+   six-column layout overflows the viewport (~680px at 0.76rem) even
+   inside the horizontal-scroll `.table-wrap`, which makes the toggle
+   and weight inputs annoying to reach.  Collapse Role / Covered /
+   Status into the Source cell as inline badges + a status dot + a
+   "covered" inline count, leaving Source / On / Weight as the three
+   visible columns.  Desktop layout untouched.
+   ══════════════════════════════════════════════════════════════════════════ */
+.settings-sources-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.76rem;
+}
+.settings-src-status-mobile {
+  display: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.settings-src-role-mobile,
+.settings-src-covered-mobile {
+  display: none;
+}
+.settings-src-toggle {
+  /* Desktop keeps native density; mobile gets a bigger scale below. */
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .settings-src-col-role,
+  .settings-src-col-covered,
+  .settings-src-col-status {
+    display: none !important;
+  }
+  .settings-src-status-mobile { display: inline-block; }
+  .settings-src-role-mobile { display: inline-flex; }
+  .settings-src-covered-mobile { display: inline; }
+  .settings-sources-table { font-size: 0.82rem; }
+  .settings-sources-table th,
+  .settings-sources-table td {
+    padding: 10px 6px;
+    white-space: normal;
+  }
+  /* Scale the toggle up to ~22px for reliable one-thumb tap. */
+  .settings-src-toggle {
+    width: 22px;
+    height: 22px;
+    transform: scale(1.1);
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    RANGE SLIDERS (settings TE-premium, trade-history window, etc.)
    ══════════════════════════════════════════════════════════════════════════ */
 /* The native <input type="range"> thumb is ~12px on iOS Safari which

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -871,9 +871,14 @@ export default function RankingsPage() {
             </button>
             {colsMenuOpen && (
               <div
+                className="rankings-columns-popover"
                 style={{
                   position: "absolute",
                   top: "calc(100% + 4px)",
+                  /* Keep the popover anchored to the button's right
+                     edge on desktop; the narrow-viewport override in
+                     globals.css flips anchoring so the popover cannot
+                     overflow off-screen on mobile. */
                   right: 0,
                   minWidth: 260,
                   maxHeight: 400,

--- a/frontend/app/rosters/page.jsx
+++ b/frontend/app/rosters/page.jsx
@@ -130,20 +130,47 @@ export default function RostersPage() {
           }
         />
 
-        {/* Position filter */}
-        <div className="filter-bar" style={{ marginBottom: 12 }}>
-          <span style={{ fontWeight: 600, fontSize: "0.72rem", color: "var(--subtext)" }}>Positions:</span>
-          {POS_GROUPS.map((g) => (
-            <label key={g} style={{ display: "flex", alignItems: "center", gap: 3, fontSize: "0.68rem", cursor: "pointer" }}>
-              <input
-                type="checkbox"
-                checked={activeGroups.has(g)}
-                onChange={() => toggleGroup(g)}
-                style={{ width: 13, height: 13, accentColor: POS_GROUP_COLORS[g] }}
-              />
-              <span style={{ color: POS_GROUP_COLORS[g], fontWeight: 700 }}>{g}</span>
-            </label>
-          ))}
+        {/* Position filter — toggle chips.  The previous 13x13 native
+            checkbox + 11px label was impossible to tap on mobile.
+            Render each position as a segmented toggle button so the
+            entire chip is the tap target (meets 44px HIG minimum on
+            mobile) and still fits on a single row on phones. */}
+        <div
+          className="filter-bar roster-pos-filter"
+          style={{ marginBottom: 12 }}
+          role="group"
+          aria-label="Filter by position"
+        >
+          <span
+            style={{
+              fontWeight: 600,
+              fontSize: "0.72rem",
+              color: "var(--subtext)",
+            }}
+          >
+            Positions:
+          </span>
+          {POS_GROUPS.map((g) => {
+            const active = activeGroups.has(g);
+            const color = POS_GROUP_COLORS[g];
+            return (
+              <button
+                key={g}
+                type="button"
+                className={`pos-chip${active ? " pos-chip-active" : ""}`}
+                onClick={() => toggleGroup(g)}
+                aria-pressed={active}
+                title={`Toggle ${g}`}
+                style={{
+                  color: active ? "#fff" : color,
+                  background: active ? color : "transparent",
+                  borderColor: color,
+                }}
+              >
+                {g}
+              </button>
+            );
+          })}
         </div>
 
         {/* Legend */}

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -437,12 +437,10 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                         if (Number.isFinite(v) && v >= 0) onWeight?.(src.key, v);
                       }}
                       disabled={!enabled}
-                      className="input"
+                      className="input weight-input"
                       style={{
-                        width: 60,
                         textAlign: "right",
                         fontFamily: "var(--mono)",
-                        fontSize: "0.76rem",
                       }}
                       aria-label={`${src.displayName} weight`}
                     />

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -342,22 +342,16 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
       <div style={{ fontWeight: 600, fontSize: "0.78rem", marginBottom: 6 }}>
         {title}
       </div>
-      <div className="table-wrap">
-        <table
-          style={{
-            width: "100%",
-            borderCollapse: "collapse",
-            fontSize: "0.76rem",
-          }}
-        >
+      <div className="table-wrap settings-sources-wrap">
+        <table className="settings-sources-table">
           <thead>
             <tr style={{ borderBottom: "1px solid var(--border)" }}>
               <th style={{ textAlign: "left", padding: "6px 8px" }}>Source</th>
-              <th style={{ textAlign: "left", padding: "6px 8px" }}>Role</th>
+              <th className="settings-src-col-role" style={{ textAlign: "left", padding: "6px 8px" }}>Role</th>
               <th style={{ textAlign: "center", padding: "6px 8px" }} title="Include this source in rank blending">On</th>
               <th style={{ textAlign: "right", padding: "6px 8px" }} title="Weight applied to this source in the blend. Default 1.0">Weight</th>
-              <th style={{ textAlign: "right", padding: "6px 8px" }}>Covered</th>
-              <th style={{ textAlign: "center", padding: "6px 8px" }}>Status</th>
+              <th className="settings-src-col-covered" style={{ textAlign: "right", padding: "6px 8px" }}>Covered</th>
+              <th className="settings-src-col-status" style={{ textAlign: "center", padding: "6px 8px" }}>Status</th>
             </tr>
           </thead>
           <tbody>
@@ -379,8 +373,25 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                   }}
                 >
                   <td style={{ padding: "6px 8px" }}>
-                    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
                       <span style={{ fontWeight: 600 }}>{src.displayName}</span>
+                      {/* Role badge — visible only on mobile where the
+                          dedicated Role column is hidden to save horizontal
+                          space. */}
+                      <span
+                        className="badge settings-src-role-mobile"
+                        style={{ fontSize: "0.58rem", padding: "1px 5px" }}
+                      >
+                        {role}
+                      </span>
+                      {/* Status dot — visible only on mobile; mirrors the
+                          dedicated Status column. */}
+                      <span
+                        className="settings-src-status-mobile"
+                        aria-label={statusLabel}
+                        title={statusLabel}
+                        style={{ background: statusColor }}
+                      />
                       {src.isTepPremium && (
                         <span
                           className="badge"
@@ -405,9 +416,13 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                       style={{ fontSize: "0.64rem", fontFamily: "var(--mono)" }}
                     >
                       {src.columnLabel} · {src.key}
+                      <span className="settings-src-covered-mobile">
+                        {" · "}
+                        {src.covered} covered
+                      </span>
                     </div>
                   </td>
-                  <td style={{ padding: "6px 8px", fontSize: "0.72rem" }}>
+                  <td className="settings-src-col-role" style={{ padding: "6px 8px", fontSize: "0.72rem" }}>
                     {role}
                   </td>
                   <td style={{ padding: "6px 8px", textAlign: "center" }}>
@@ -416,6 +431,7 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                       checked={enabled}
                       onChange={(e) => onToggle?.(src.key, e.target.checked)}
                       aria-label={`Include ${src.displayName} in blend`}
+                      className="settings-src-toggle"
                       style={{ cursor: "pointer" }}
                     />
                   </td>
@@ -446,6 +462,7 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                     />
                   </td>
                   <td
+                    className="settings-src-col-covered"
                     style={{
                       padding: "6px 8px",
                       textAlign: "right",
@@ -456,6 +473,7 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                     {src.covered}
                   </td>
                   <td
+                    className="settings-src-col-status"
                     style={{
                       padding: "6px 8px",
                       textAlign: "center",

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -1423,11 +1423,10 @@ export default function TradePage() {
                               >
                                 <span className="muted" style={{ fontSize: "0.66rem" }}>→</span>
                                 <select
-                                  className="select"
+                                  className="select trade-dest-select"
                                   value={currentDest}
                                   onChange={(e) => setAssetDestination(sideIdx, r.name, e.target.value)}
                                   style={{
-                                    fontSize: "0.7rem",
                                     padding: "2px 4px",
                                     minHeight: "unset",
                                     height: "auto",
@@ -1582,12 +1581,12 @@ export default function TradePage() {
             )}
 
             <textarea
-              className="input"
+              className="input roster-textarea"
               placeholder="Enter roster (comma or newline separated): Josh Allen, Bijan Robinson, Ja'Marr Chase, ..."
               value={rosterInput}
               onChange={(e) => { setRosterInput(e.target.value); setSelectedTeamIdx(-1); setLeagueRosters(null); }}
               rows={3}
-              style={{ width: "100%", resize: "vertical", fontFamily: "inherit", fontSize: "0.82rem" }}
+              style={{ width: "100%", resize: "vertical", fontFamily: "inherit" }}
             />
 
             <div className="row" style={{ marginTop: 8, alignItems: "center" }}>

--- a/frontend/components/GlobalSearch.jsx
+++ b/frontend/components/GlobalSearch.jsx
@@ -80,7 +80,7 @@ export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect }) {
       <div
         className="picker-sheet"
         onClick={(e) => e.stopPropagation()}
-        style={{ maxWidth: 500, width: "92vw", maxHeight: "70vh", display: "flex", flexDirection: "column" }}
+        style={{ maxWidth: 500, width: "92vw", maxHeight: "70dvh", display: "flex", flexDirection: "column" }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <span style={{ fontSize: "1.1rem", opacity: 0.4 }}>/</span>

--- a/frontend/components/GlobalSearch.jsx
+++ b/frontend/components/GlobalSearch.jsx
@@ -82,20 +82,30 @@ export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect }) {
         onClick={(e) => e.stopPropagation()}
         style={{ maxWidth: 500, width: "92vw", maxHeight: "70dvh", display: "flex", flexDirection: "column" }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <span style={{ fontSize: "1.1rem", opacity: 0.4 }}>/</span>
+        <div className="global-search-input-row">
+          <span
+            style={{ fontSize: "1.1rem", opacity: 0.4 }}
+            aria-hidden="true"
+          >
+            /
+          </span>
           <input
             ref={inputRef}
-            className="input"
+            className="input global-search-input"
             type="text"
             placeholder="Search players and picks..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onKeyDown}
-            style={{ flex: 1, fontSize: "1rem", border: "none", outline: "none", background: "transparent" }}
             autoComplete="off"
+            aria-label="Search players and picks"
           />
-          <button className="button" onClick={onClose} style={{ padding: "4px 10px", fontSize: "0.76rem" }}>
+          <button
+            className="button global-search-close"
+            onClick={onClose}
+            aria-label="Close search"
+            title="Close search (ESC)"
+          >
             ESC
           </button>
         </div>

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -268,12 +268,20 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
           </div>
           <div style={{ display: "flex", gap: 6 }}>
             {onAddToTrade && (
-              <button className="button" style={{ fontSize: "0.72rem", padding: "4px 8px" }}
-                onClick={() => { onAddToTrade(row); onClose?.(); }}>
+              <button
+                className="button player-popup-action"
+                onClick={() => { onAddToTrade(row); onClose?.(); }}
+                aria-label={`Add ${row.name} to trade`}
+              >
                 Add to Trade
               </button>
             )}
-            <button className="button" onClick={onClose} style={{ fontSize: "0.82rem", padding: "4px 10px" }}>
+            <button
+              className="button player-popup-close"
+              onClick={onClose}
+              aria-label="Close player details"
+              title="Close"
+            >
               &times;
             </button>
           </div>

--- a/frontend/components/graphs/ConfidenceValueScatter.jsx
+++ b/frontend/components/graphs/ConfidenceValueScatter.jsx
@@ -144,24 +144,41 @@ export default function ConfidenceValueScatter({
           source spread (%)
         </text>
 
-        {/* Points */}
+        {/* Points.  The visible dot is r=3.5 for the desktop density
+            this chart was designed for.  Stacked on top is an invisible
+            r=10 tap-target circle so finger taps near a dot still hit
+            it — on a phone an r=3.5 (7px) circle is essentially
+            impossible to land on accurately. */}
         {points.map((p, i) => (
-          <circle
+          <g
             key={i}
-            cx={x(p.x)}
-            cy={y(p.y)}
-            r={3.5}
-            fill={CHART_COLORS.confidence[p.bucket] || CHART_COLORS.confidence.none}
-            fillOpacity={0.8}
-            stroke={CHART_COLORS.bg}
-            strokeWidth={0.5}
             style={onPointClick ? { cursor: "pointer" } : undefined}
             onClick={onPointClick ? () => onPointClick(p.raw) : undefined}
           >
-            <title>
-              #{p.rank} {p.name} — value {formatNumber(p.x)}, spread {formatNumber(p.y * 100, 1)}%, {p.bucket}
-            </title>
-          </circle>
+            {onPointClick && (
+              <circle
+                cx={x(p.x)}
+                cy={y(p.y)}
+                r={10}
+                fill="transparent"
+                pointerEvents="all"
+              />
+            )}
+            <circle
+              cx={x(p.x)}
+              cy={y(p.y)}
+              r={3.5}
+              fill={CHART_COLORS.confidence[p.bucket] || CHART_COLORS.confidence.none}
+              fillOpacity={0.8}
+              stroke={CHART_COLORS.bg}
+              strokeWidth={0.5}
+              pointerEvents="none"
+            >
+              <title>
+                #{p.rank} {p.name} — value {formatNumber(p.x)}, spread {formatNumber(p.y * 100, 1)}%, {p.bucket}
+              </title>
+            </circle>
+          </g>
         ))}
       </g>
     </svg>

--- a/frontend/components/graphs/HillCurveExplorer.jsx
+++ b/frontend/components/graphs/HillCurveExplorer.jsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 // ── Chart 6: Hill curve explorer ─────────────────────────────────────
 // Renders the four scope-level master Hill curves that map percentile
 // → value (see ``src/canonical/player_valuation.py`` constants
@@ -115,7 +117,34 @@ export default function HillCurveExplorer({
   samplePoints = 200,
   onPointClick = null,
 }) {
-  const box = chartBox({ width, height, margin: { left: 52, right: 100, top: 16, bottom: 40 } });
+  // SVG renders responsive via viewBox.  The right margin on desktop
+  // leaves room for the in-SVG legend; on narrow viewports we cut the
+  // margin to zero and render a regular HTML legend below the chart
+  // instead, so the plot area uses the whole width and the legend
+  // text stays readable (the in-SVG text scaled down to ~4-5px on
+  // iPhone SE).
+  //
+  // State-driven so SSR renders the desktop layout consistently and
+  // the first client paint after hydration flips narrow viewports to
+  // the stacked layout without a hydration mismatch.
+  const [isNarrow, setIsNarrow] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 520px)");
+    const update = () => setIsNarrow(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  const box = chartBox({
+    width,
+    height,
+    margin: {
+      left: 44,
+      right: isNarrow ? 12 : 100,
+      top: 16,
+      bottom: 40,
+    },
+  });
 
   // Determine the x-domain (rank) from the live board so the curve
   // sample and scatter share a scale.
@@ -164,7 +193,7 @@ export default function HillCurveExplorer({
   const xTicks = ticks(1, xMax, 6);
   const yTicks = ticks(0, 9999, 6);
 
-  return (
+  const svg = (
     <svg
       viewBox={box.viewBox}
       width="100%"
@@ -263,39 +292,103 @@ export default function HillCurveExplorer({
         </text>
 
         {/* Legend — curves + position groups.  Always shown because
-            the group split is the actual payload of this chart. */}
-        <g transform={`translate(${box.innerWidth + 10}, 0)`}>
-          {curvePaths.map((c, i) => (
-            <g key={`curve-${c.key}`} transform={`translate(0, ${i * 14})`}>
-              <line x1={0} x2={18} y1={6} y2={6} stroke={c.color} strokeWidth={2} />
-              <text
-                x={24}
-                y={6}
-                dominantBaseline="middle"
-                fontSize={10}
-                fill={CHART_COLORS.axisLabel}
-              >
-                {c.label}
-              </text>
-            </g>
-          ))}
-          {groupKeys.map((g, i) => (
-            <g key={`grp-${g}`} transform={`translate(0, ${curvePaths.length * 14 + 6 + i * 14})`}>
-              <circle cx={9} cy={6} r={3.25} fill={GROUP_COLORS[g] || CHART_COLORS.axisLabel} fillOpacity={0.85} />
-              <text
-                x={24}
-                y={6}
-                dominantBaseline="middle"
-                fontSize={10}
-                fill={CHART_COLORS.axisLabel}
-              >
-                {g} ({groupedScatter[g].length})
-              </text>
-            </g>
-          ))}
-        </g>
+            the group split is the actual payload of this chart.
+            Suppressed on narrow viewports; the HTML legend below
+            renders instead (see return() wrapper). */}
+        {!isNarrow && (
+          <g transform={`translate(${box.innerWidth + 10}, 0)`}>
+            {curvePaths.map((c, i) => (
+              <g key={`curve-${c.key}`} transform={`translate(0, ${i * 14})`}>
+                <line x1={0} x2={18} y1={6} y2={6} stroke={c.color} strokeWidth={2} />
+                <text
+                  x={24}
+                  y={6}
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fill={CHART_COLORS.axisLabel}
+                >
+                  {c.label}
+                </text>
+              </g>
+            ))}
+            {groupKeys.map((g, i) => (
+              <g key={`grp-${g}`} transform={`translate(0, ${curvePaths.length * 14 + 6 + i * 14})`}>
+                <circle cx={9} cy={6} r={3.25} fill={GROUP_COLORS[g] || CHART_COLORS.axisLabel} fillOpacity={0.85} />
+                <text
+                  x={24}
+                  y={6}
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fill={CHART_COLORS.axisLabel}
+                >
+                  {g} ({groupedScatter[g].length})
+                </text>
+              </g>
+            ))}
+          </g>
+        )}
       </g>
     </svg>
+  );
+
+  if (!isNarrow) return svg;
+
+  // Narrow viewport — render the chart full-width and the legend as a
+  // wrapping chip row below.  Keeps labels readable instead of
+  // scaling them down with the SVG viewBox.
+  return (
+    <div>
+      {svg}
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "6px 10px",
+          marginTop: 6,
+          fontSize: "0.68rem",
+          color: CHART_COLORS.axisLabel,
+        }}
+      >
+        {curvePaths.map((c) => (
+          <span
+            key={`lg-c-${c.key}`}
+            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                display: "inline-block",
+                width: 14,
+                height: 2,
+                background: c.color,
+                borderRadius: 1,
+              }}
+            />
+            {c.label}
+          </span>
+        ))}
+        {groupKeys.map((g) => (
+          <span
+            key={`lg-g-${g}`}
+            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                display: "inline-block",
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background:
+                  GROUP_COLORS[g] || CHART_COLORS.axisLabel,
+                opacity: 0.85,
+              }}
+            />
+            {g} ({groupedScatter[g].length})
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Second-pass mobile audit driven by a Playwright sweep across four viewports (iPhone SE 320×568, iPhone 14 Pro 390×844, iPhone 14 Pro Max 430×932, iPhone landscape 844×390, DPR 3, `is_mobile=true + has_touch=true`, mobile Safari UA).  Round 1 (#224) killed the big iOS zoom + topbar + picker-keyboard regressions.  This pass chases everything that round missed or left shallow.

Each logical fix lands as its own commit — 14 total, in the order they were found.

### Sweep script

`/tmp/mobile-sweep-2.py` hits 20 routes (including variants that open the search overlay, player popup, columns popover, trade picker, 3-team mode, KTC import, chat drawer) per viewport, captures full-page screenshots, and writes `/tmp/mobile-shots-2/report.json` with per-route overflow offenders (ignoring intentional `.table-wrap` scroll), sub-44px tap targets, input font-size <16px (iOS zoom triggers), and console errors.

## Ranked issue list

### P0 — breaks flow on touch

| # | Page | Viewport | Root cause | Fix (commit) |
|---|---|---|---|---|
| 1 | All | landscape 844×390 | `@media (max-width: 768px)` does NOT match landscape phones, so the 16px-input rule disarms and every focused input zoom-warps | `@media (hover: none) and (pointer: coarse)` defense — keys off touch device, not viewport width (`fbeba25`, `737e8c5`) |
| 2 | `/settings` | all mobile | Weight `<input type="number">` had inline `fontSize: "0.76rem"` — inline wins specificity so the 16px mobile rule never matched; every tap on a weight field zoomed | Moved density to `.weight-input` class, mobile breakpoint pins it to 16px (`284af55`) |
| 3 | `/rankings`, `/finder`, `/rosters` etc. | all mobile | `.filter-bar .input/.select { font-size: 0.76rem }` inside the same mobile query at higher specificity than `input[type="text"]` → the search + position-filter inputs zoomed on focus | Drop the override, keep density via padding (`284af55`) |
| 4 | All | iPhones with home indicator | `.mobile-bottom-nav { height: 56px; padding-bottom: env(safe-area-inset-bottom) }` with `box-sizing: border-box` → padding ate the icon zone, icons squished into top 22px.  Trade sticky tray + ChatFab + main-shell bottom padding all under-counted by the 34px indicator | Nav height becomes `calc(var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px))`; three neighbours updated to match (`4615e8f`) |
| 5 | `/settings` | 320–430 portrait | 6-column Sources table was 679px — scrolled inside `.table-wrap` but the On toggle / Weight input were usually off-screen mid-interaction | Fold Role / Status / Covered into the Source cell on mobile (badge + dot + inline "N covered"); keep Source / On / Weight as the three visible columns.  Desktop untouched (`43d50c7`) |

### P1 — feels bad

| # | Page | Viewport | Root cause | Fix (commit) |
|---|---|---|---|---|
| 6 | `/rosters` | all mobile | Position filter was 8× native 13×13 checkboxes — unusable thumb target | Segmented chip toggles with 44px min-height on mobile, `aria-pressed` for accessibility (`bf3b56d`) |
| 7 | PlayerPopup | all mobile | Close `×` 21×18, Add-to-Trade 4px padding | 44×44 tap targets, explicit aria-labels (`8f353fb`) |
| 8 | GlobalSearch | all | Input had `border:none; outline:none` — no focus indicator; ESC button 24×24 | Focus ring lifted onto wrapping row (`:focus-within`), ESC button 44+ min-height, aria-label (`8f353fb`) |
| 9 | Mobile topbar | all mobile | `/` search button + Sign-out button both ~24×24 | Min-width 44 / min-height 40 with `touch-action: manipulation` (`8f353fb`) |
| 10 | `/settings`, `/angle` | all mobile | Native `<input type="range">` thumb defaults to ~12px on iOS Safari — un-draggable by thumb | Styled track + 22/26px thumb on desktop/mobile; focus ring; `touch-action: manipulation` (`5aa2caa`) |
| 11 | Picker / sheet / login / ChatDrawer / GlobalSearch | iPhones with soft keyboard | Remaining `vh` in max-height / height / min-height pushed content behind keyboard | Convert to `dvh` (`2825339`) |
| 12 | `/rankings` Columns popover | narrow widths | `right: 0; minWidth: 260` — if the Columns button wraps near the left edge, popover overflows off-screen left | `@media (max-width: 520px)` anchors popover to `left/right: 8px` (`1ad7b98`) |
| 13 | `/rankings` player name | all mobile | Tap zone = text line-height (~20px), regularly missed — or caught the parent row's expand handler | `display: inline-block` + 6px vertical padding on mobile (`5e69d9e`) |
| 14 | Rankings methodology Hill curve | 320–520 | In-SVG legend ate 100px of a ~320px wide chart; scatter collapsed to ~180px; legend text scaled to 4-5px | Mobile: full-width chart + HTML chip legend below.  State-driven via matchMedia to avoid SSR hydration mismatch (`7e3f988`) |
| 15 | Edge scatter dots | all mobile | `r=3.5` circles (7px) — near-impossible to tap accurately | Invisible `r=10` sibling catches taps; visible dot `pointerEvents="none"` (`b0b1022`) |

### P2 — polish

| # | Page | Root cause | Fix (commit) |
|---|---|---|---|
| 16 | Buttons / rows / asset rows | iOS default grey tap-flash + 300ms click delay | `-webkit-tap-highlight-color: transparent; touch-action: manipulation` (`d99dabc`) |

## Non-regressions verified

Ran a targeted Playwright pass at 390×844 (portrait) and 844×390 (landscape) after the final commit:
- rankings search input font-size = 16px ✓
- mobile-topbar display: flex (no "BrisketTrade" regression) ✓
- mobile-bottom-nav height = 56px (safe-area inset still additive elsewhere) ✓
- 0 iOS zoom triggers across /rankings, /trade, /settings, /angle, /edge, /rosters, /finder, /tools/idp-calibration — both orientations ✓

## Out of scope (deliberately)

- Finder row hover tooltips are still hover-only; retrofitting tap-to-reveal is a bigger lift and wasn't blocking. Flagging for a follow-up.
- Trade sides destination → arrow dismiss × button is still ~21×18 but a low-traffic action; left alone.
- ChatDrawer `.chat-mini-button` ✕ is 32×24; mobile rule `input[type="text"]` already wins for the chat input itself so the drawer's main pain point (zoom-on-focus) is gone.  Close button is a P2.
- Scraper / canonical pipeline / `/api/data` contract untouched, as required.

## Test plan

- [ ] Cold-load `/rankings` on an iPhone SE, iPhone 14 Pro, iPhone 14 Pro Max — no auto-zoom on tapping the player search or position filter.
- [ ] Same three devices in landscape — still no auto-zoom.
- [ ] On a device with a home indicator: the bottom nav icons are vertically centred (not squashed against the top); the trade sticky tray sits *above* the indicator; the ChatFab is reachable without overlapping the nav.
- [ ] `/settings` on a 320px viewport: Sources table fits horizontally without scroll; the "On" checkbox and Weight input are directly tappable.
- [ ] `/rosters`: position filter chips are easy to hit; each toggles the position group.
- [ ] `/rankings` → Columns popover: opens and stays inside the viewport on every iPhone width.
- [ ] `/rankings` → "How this works" → Hill curve chart legend reads clearly on iPhone SE (wraps below the chart, not scaled-down SVG text).
- [ ] Player popup open → Close `×` and Add-to-Trade are easy thumb targets.
- [ ] Opening the AI chat drawer on an iPhone: start typing → input stays above the keyboard (no vh anchoring).
- [ ] Pipeline regression: backend `/api/data` unchanged; `npm test` passes the same 486 tests that passed before this branch.

https://claude.ai/code/session_01E3pgzQETu96M4X1ciprwnp