### PR TITLE
Hide mobile source chips until row is tapped

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1446,10 +1446,16 @@ export default function RankingsPage() {
                           horizontally and get hidden via `hide-mobile`.
                           Instead of dropping the data entirely, we
                           render a compact flex strip of source chips
-                          below each player row so mobile users see the
-                          same per-source value + rank they'd see on
-                          desktop.  Gated on `showSiteCols` so the
-                          toggle has the same effect on both surfaces.
+                          below each player row — but only when the
+                          user has tapped the row to expand it.
+                          Rendering the strip under every row by
+                          default dominated the mobile viewport and
+                          pushed the headline Value column off-screen;
+                          gating on `isExpanded` makes the source
+                          audit on-demand.  `showSiteCols` still
+                          governs the desktop column render; on mobile
+                          the "click to reveal" pattern is the
+                          default.
 
                           Uses a dedicated `.rankings-mobile-source-row`
                           class (not the global `.mobile-only` helper)
@@ -1458,7 +1464,7 @@ export default function RankingsPage() {
                           `display: initial !important`, which would
                           force the <tr> to `inline` and break the
                           table layout. */}
-                      {settings.showSiteCols && (
+                      {isExpanded && (
                         <tr className="rankings-mobile-source-row">
                           <td colSpan={totalCols}>
                             <div className="rankings-mobile-sources">

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -857,17 +857,24 @@ export default function RankingsPage() {
           <button className="button" onClick={exportCsv} title="Download the current rows as a CSV file">
             Export CSV
           </button>
-          {/* Columns toggle — opens an inline popover with one
-              checkbox per source so the user can hide clutter from
-              sources they don't care about.  Persisted across
-              sessions via ``settings.hiddenSiteCols``. */}
+          {/* Columns toggle — opens an inline popover with a master
+              on/off for the per-source columns plus one checkbox per
+              source so the user can hide clutter from sources they
+              don't care about.  Persisted across sessions via
+              ``settings.showSiteCols`` (master gate) and
+              ``settings.hiddenSiteCols`` (per-source). */}
           <div style={{ position: "relative", display: "inline-block" }}>
             <button
               className="button"
               onClick={() => setColsMenuOpen((v) => !v)}
               title="Show/hide per-source columns"
             >
-              Columns{hiddenCount > 0 ? ` (${hiddenCount} hidden)` : ""}
+              Columns
+              {!settings.showSiteCols
+                ? " (off)"
+                : hiddenCount > 0
+                  ? ` (${hiddenCount} hidden)`
+                  : ""}
             </button>
             {colsMenuOpen && (
               <div
@@ -899,12 +906,39 @@ export default function RankingsPage() {
                     onClick={showAllSiteCols}
                     style={{ fontSize: "0.7rem", padding: "2px 8px" }}
                     title="Restore all source columns"
+                    disabled={!settings.showSiteCols}
                   >
                     Show all
                   </button>
                 </div>
+                {/* Master on/off — flips the global gate that renders
+                    the per-source value columns on desktop and the
+                    per-row chip strip on mobile.  Without this toggle
+                    the per-source checkboxes below would be silent
+                    no-ops for cold-start users, since the default for
+                    ``showSiteCols`` is off. */}
+                <label
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "6px 0",
+                    borderBottom: "1px solid var(--border-dim, rgba(255,255,255,0.08))",
+                    marginBottom: 4,
+                    cursor: "pointer",
+                    fontWeight: 600,
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={Boolean(settings.showSiteCols)}
+                    onChange={(e) => updateSetting("showSiteCols", e.target.checked)}
+                  />
+                  <span>Show source columns</span>
+                </label>
                 {RANKING_SOURCES.map((src) => {
                   const hidden = Boolean(hiddenSiteCols[src.key]);
+                  const rowDisabled = !settings.showSiteCols;
                   return (
                     <label
                       key={src.key}
@@ -913,13 +947,15 @@ export default function RankingsPage() {
                         alignItems: "center",
                         gap: 8,
                         padding: "4px 0",
-                        cursor: "pointer",
+                        cursor: rowDisabled ? "not-allowed" : "pointer",
+                        opacity: rowDisabled ? 0.45 : 1,
                       }}
                     >
                       <input
                         type="checkbox"
                         checked={!hidden}
                         onChange={() => toggleSiteCol(src.key)}
+                        disabled={rowDisabled}
                       />
                       <span>{src.columnLabel}</span>
                       <span className="muted" style={{ marginLeft: "auto", fontSize: "0.72rem" }}>{src.displayName}</span>

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -30,14 +30,17 @@ export const SETTINGS_DEFAULTS = {
 
   // Rankings display
   rankingsSortBasis: "full",         // "full" | "raw"
-  // Source-site columns are on by default on mobile AND desktop.  The
-  // rankings table always renders the per-source value + rank cells;
-  // this toggle lets power users hide them to focus on the consensus
-  // value column.  Historically this defaulted to false but we never
-  // wired the toggle to the table render, so the setting was dead and
-  // mobile hid the columns via CSS regardless.  Default ON is the
-  // canonical behavior — see rankings/page.jsx for the render gate.
-  showSiteCols: true,
+  // Source-site columns are off by default.  The rankings table's
+  // headline columns (rank, player, pos, consensus, value) are what
+  // most users open the page to see; the per-source value + rank
+  // cells are power-user transparency data that dominates the
+  // viewport — especially on mobile, where they render as a wrapping
+  // chip strip below every row and push the Value column off-screen.
+  // Users who want to audit per-source contributions can flip the
+  // toggle from the Columns popover on /rankings or the Rankings
+  // Display section on /settings.  See rankings/page.jsx for the
+  // render gate.
+  showSiteCols: false,
   // Per-source column visibility map ({ [sourceKey]: false } to
   // hide a specific source column on the rankings table).  Any key
   // missing from the map defaults to visible — so an empty map


### PR DESCRIPTION
## Why this is a follow-up

#226 flipped the cold-start default for `showSiteCols` to `false`, but that only helps brand-new users. Anyone who already had `showSiteCols: true` stored in localStorage (including the user who filed the original mobile screenshot) still sees the per-row source chip strip rendered beneath every player — which dominates the mobile viewport and pushes the Value column off-screen.

## Change

Gate the mobile chip strip render on `isExpanded` instead of `settings.showSiteCols`. On mobile, the chips now only appear when you **tap a row to reveal them**, matching what the user literally asked for: "click and then be able to see the source columns."

Desktop per-source columns continue to honor `settings.showSiteCols` — behavior there is unchanged.

## Effect, by surface

- **Mobile, cold-start row**: headline columns only (# / Player / Pos / Consensus / Value). No chip strip. Value column fits without horizontal scroll.
- **Mobile, tapped row**: chip strip appears beneath the row alongside the existing source audit panel.
- **Desktop**: unchanged. Per-source columns still controlled by the `showSiteCols` master toggle (now reachable from both the Columns popover on `/rankings` and `/settings`).

## Test plan

- [ ] On mobile (≤768px), verify the chip strip is hidden under every player row on page load regardless of stored `showSiteCols` value.
- [ ] Tap a row and confirm the chip strip (and existing audit panel) render beneath it.
- [ ] Tap the row again to collapse — strip disappears.
- [ ] On desktop, verify `showSiteCols: true` still renders per-source columns inline; toggling from the Columns popover master still works.
- [ ] Confirm the Josh Allen row's Value column is fully visible on a 390px-wide viewport without scrolling.

https://claude.ai/code/session_01T1SY7WNCysDYBzzPwqpBV4