### PR TITLE
Stop dropping negatively-valued DraftSharks rows

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3008,6 +3008,19 @@ def _enrich_from_source_csvs(
     repo = Path(__file__).resolve().parents[2]
     csv_index: dict[str, dict[str, dict[str, Any]]] = {}
 
+    # DraftSharks (offense + IDP) publish a cross-market 0-100 ``3D
+    # Value +`` scale that goes negative past ~rank 200 — the CSV
+    # rows below that threshold carry legitimate negative values
+    # (e.g. Emmanuel McNeil-Warren IDP rank 362 → -25).  Other
+    # value-signal sources (KTC, IDPTC, DynastyNerds, Boone) only
+    # emit non-negative values, so we keep the ``val > 0`` guard
+    # for them and only relax it for the DS combined-rank sources.
+    # Without this carve-out every negatively-valued DS row is
+    # silently dropped from ``canonicalSiteValues``, which means
+    # the downstream DS combined-rank pre-pass never sees those
+    # players and they show up with zero DS coverage on the board.
+    ds_combined_rank_keys = _DS_COMBINED_RANK_KEYS
+
     # Pre-compute the position-group of each player row by canonical
     # key so the position-aware fallback in stage (3) can pick the
     # right CSV entry when name-only collisions occur.
@@ -3144,7 +3157,15 @@ def _enrich_from_source_csvs(
             if not isinstance(csv_vals, dict):
                 continue
             existing = _safe_num(csv_vals.get(source_key))
-            if existing is not None and existing > 0:
+            # Skip rows that already carry a real value.  For DS
+            # combined-rank sources any non-None number counts (their
+            # scale goes negative, so "already stamped" is any
+            # finite value); for everyone else we require > 0 so a
+            # stale zero doesn't block the enrichment from re-running.
+            if existing is not None and (
+                existing > 0
+                or (source_key in ds_combined_rank_keys and existing <= 0)
+            ):
                 continue
             nm = str(row.get("canonicalName") or row.get("displayName") or "")
             if not nm:
@@ -3167,7 +3188,17 @@ def _enrich_from_source_csvs(
             if not entry:
                 continue
             val = entry.get("value")
-            if val is not None and val > 0:
+            # DS combined-rank sources accept negative values (their
+            # ``3D Value +`` scale goes negative past ~rank 200, and
+            # those rows are real — they just sort to the tail of the
+            # combined cross-market ladder); every other value-signal
+            # source requires > 0 to distinguish "ranked" from
+            # "missing/zero".
+            negatives_allowed = source_key in ds_combined_rank_keys
+            accept = val is not None and (
+                val > 0 if not negatives_allowed else True
+            )
+            if accept:
                 csv_vals[source_key] = val
                 # For rank-signal sources, preserve the original CSV rank
                 # so the frontend can display it instead of the meaningless
@@ -4288,6 +4319,22 @@ _MAD_PENALTY_LAMBDA: float = 0.0
 # ``ds_combined_rank_partner`` in the registry) and routes that
 # combined rank through the GLOBAL Hill master — the same curve
 # IDPTC's anchor contribution uses.
+# ── DraftSharks combined-rank exemption ─────────────────────────────────
+# Derived from the registry at import time.  These sources publish a
+# cross-market ``3D Value +`` scale that legitimately goes negative
+# past ~rank 200 (the CSV tail), so the enrichment + Phase 1 ordinal
+# gates relax their strict ``val > 0`` check for them.  Keeping this
+# as a module-level set (rather than recomputing it inside each gate)
+# avoids hot-path repetition and keeps the two gates in lockstep —
+# if someone adds a new negative-scale source to the registry they
+# only have to flip ``ds_combined_rank_partner``.
+_DS_COMBINED_RANK_KEYS: frozenset[str] = frozenset(
+    str(src.get("key") or "")
+    for src in _RANKING_SOURCES
+    if src.get("ds_combined_rank_partner")
+)
+
+
 _VALUE_BASED_SOURCES: frozenset[str] = frozenset({
     "ktc",
     "idpTradeCalc",
@@ -5320,7 +5367,18 @@ def _compute_unified_rankings(
                 continue
             sites = row.get("canonicalSiteValues") or {}
             val = _safe_num(sites.get(source_key))
-            if val is None or val <= 0:
+            # DS combined-rank sources publish a cross-market scale
+            # that goes negative past ~rank 200 (and can legitimately
+            # hit zero).  Let those rows through so Phase 1 ordinal
+            # sort places them at the tail of the pool — the DS
+            # combined-rank pre-pass then re-ranks them in the merged
+            # offense+IDP pool via the GLOBAL Hill master.  Every
+            # other value-signal source treats ``val <= 0`` as
+            # "unranked / missing" because their scales are strictly
+            # non-negative.
+            if val is None:
+                continue
+            if val <= 0 and source_key not in _DS_COMBINED_RANK_KEYS:
                 continue
             tiebreak_name = str(
                 row.get("canonicalName") or row.get("displayName") or ""
@@ -6076,8 +6134,21 @@ def _compute_unified_rankings(
         # then introspect every source-bearing row, ranked or not.
         row["sourceRanks"] = source_ranks
         canonical_sites = row.get("canonicalSiteValues") or {}
+        # ``sourcePresence[k]`` is True when source ``k`` covered this
+        # row.  DS combined-rank sources use a cross-market scale that
+        # goes negative past ~rank 200 (the tail of the CSV); those
+        # rows are still ranked by DS, so any non-None DS value counts
+        # as coverage.  Every other value-signal source treats ``<= 0``
+        # as "unranked / missing."  Keeping this in lockstep with the
+        # enrichment + Phase 1 gates is the whole point of
+        # ``_DS_COMBINED_RANK_KEYS``.
         row["sourcePresence"] = {
-            k: (v is not None and v > 0) for k, v in canonical_sites.items()
+            k: (
+                v is not None
+                if k in _DS_COMBINED_RANK_KEYS
+                else (v is not None and v > 0)
+            )
+            for k, v in canonical_sites.items()
         }
 
         pos = str(row.get("position") or "").strip().upper()

--- a/tests/api/test_draftsharks_negative_values.py
+++ b/tests/api/test_draftsharks_negative_values.py
@@ -1,0 +1,199 @@
+"""Regression tests for the DraftSharks negative-value carve-out.
+
+DraftSharks publishes a cross-market ``3D Value +`` column that goes
+negative past ~rank 200 — the CSV rows below that threshold carry
+legitimate negative values (e.g. Emmanuel McNeil-Warren at IDP rank
+362 → ``-25``).  Before the 2026-04-22 fix, three separate ``> 0``
+gates silently dropped every negatively-valued DS row:
+
+    1. ``_enrich_from_source_csvs`` wouldn't write the value into
+       ``canonicalSiteValues``.
+    2. ``_compute_unified_rankings`` Phase 1 ordinal pass wouldn't
+       add the row to the source's eligible pool, so
+       ``row_source_ranks`` had no DS stamp.
+    3. ``sourcePresence[draftSharks*]`` was computed as
+       ``v > 0``, so it read False even for stamped rows.
+
+The net effect was ~360 players (185 SF + 174 IDP) showing up as
+"not covered by DraftSharks" when they were actually ranked by DS.
+These tests guard all three gates simultaneously by building the
+live contract and asserting that a known tail-player (McNeil-Warren)
+receives credit for DS coverage end to end.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from src.api.data_contract import (
+    _DS_COMBINED_RANK_KEYS,
+    _RANKING_SOURCES,
+    build_api_data_contract,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DS_IDP_CSV = REPO / "CSVs" / "site_raw" / "draftSharksIdp.csv"
+DS_SF_CSV = REPO / "CSVs" / "site_raw" / "draftSharksSf.csv"
+
+
+def _load_live_contract() -> dict | None:
+    """Build the live contract from the latest exported raw payload.
+
+    Returns ``None`` when no export exists — tests that depend on the
+    live contract self-skip in that case so CI still runs against the
+    registry-shape assertions.
+    """
+    export_dir = REPO / "exports" / "latest"
+    files = sorted(export_dir.glob("dynasty_data_*.json"), reverse=True)
+    if not files:
+        return None
+    with files[0].open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+    return build_api_data_contract(raw)
+
+
+class DraftSharksNegativeValueTests(unittest.TestCase):
+    """End-to-end coverage for DS rows with negative ``3D Value +``."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = _load_live_contract()
+
+    def test_ds_combined_rank_keys_matches_registry(self) -> None:
+        """The module-level set must mirror every registry entry that
+        declares ``ds_combined_rank_partner``.  If someone adds a new
+        negative-scale source to the registry and forgets to bump
+        the set, this test fires."""
+        expected = {
+            str(src.get("key") or "")
+            for src in _RANKING_SOURCES
+            if src.get("ds_combined_rank_partner")
+        }
+        self.assertEqual(set(_DS_COMBINED_RANK_KEYS), expected)
+        # Sanity: at minimum both DS sources must be in the set.
+        self.assertIn("draftSharks", _DS_COMBINED_RANK_KEYS)
+        self.assertIn("draftSharksIdp", _DS_COMBINED_RANK_KEYS)
+
+    def test_ds_csvs_have_negative_rows(self) -> None:
+        """Guard against CSV-format regressions that would make these
+        tests vacuous — DS SHOULD carry negative-valued rows past the
+        rank-200 crossover."""
+        for csv_path in (DS_IDP_CSV, DS_SF_CSV):
+            if not csv_path.exists():
+                self.skipTest(f"CSV missing: {csv_path}")
+            text = csv_path.read_text(encoding="utf-8")
+            # Cheap substring probe — avoids pulling pandas just to
+            # confirm there's a negative number in the value column.
+            self.assertTrue(
+                any(
+                    line.rstrip().endswith(f",{sign}")
+                    or f",{sign}\n" in line
+                    or f",-{digit}" in line
+                    for line in text.splitlines()
+                    for sign in ("-1", "-5", "-10")
+                    for digit in ("1", "2", "3", "4", "5", "6", "7", "8", "9")
+                ),
+                f"{csv_path.name} has no negative ``3D Value +`` rows — "
+                "has the CSV format changed, or have the tail rows been "
+                "trimmed upstream?",
+            )
+
+    def test_negative_ds_row_gets_full_coverage(self) -> None:
+        """Emmanuel McNeil-Warren is DraftSharks IDP rank 362 with
+        ``3D Value +`` == -25.  Every gate — canonicalSiteValues,
+        sourceRanks, sourcePresence — must show DS as covering him."""
+        if not DS_IDP_CSV.exists():
+            self.skipTest("DraftSharks IDP CSV missing")
+        if self.contract is None:
+            self.skipTest("No exported raw payload to build contract from")
+
+        players = self.contract.get("playersArray") or []
+        target = next(
+            (p for p in players if p.get("displayName") == "Emmanuel McNeil-Warren"),
+            None,
+        )
+        if target is None:
+            self.skipTest(
+                "Emmanuel McNeil-Warren not in live contract — CSV may "
+                "have been regenerated without him; drop this test or "
+                "swap for another known tail player."
+            )
+
+        csv_vals = target.get("canonicalSiteValues") or {}
+        self.assertIn(
+            "draftSharksIdp",
+            csv_vals,
+            "canonicalSiteValues missing draftSharksIdp — the CSV "
+            "enrichment ``> 0`` gate still drops negative DS values.",
+        )
+        self.assertIsNotNone(csv_vals["draftSharksIdp"])
+        self.assertLess(
+            float(csv_vals["draftSharksIdp"]),
+            0,
+            "McNeil-Warren's DS IDP value should be negative; if it's "
+            "now positive, either DS changed his ranking or a prior "
+            "stage is clobbering the stamp.",
+        )
+
+        source_ranks = target.get("sourceRanks") or {}
+        self.assertIn(
+            "draftSharksIdp",
+            source_ranks,
+            "sourceRanks missing draftSharksIdp — Phase 1 ordinal "
+            "pass still filters ``val <= 0``.",
+        )
+        self.assertGreater(source_ranks["draftSharksIdp"], 0)
+
+        presence = target.get("sourcePresence") or {}
+        self.assertTrue(
+            presence.get("draftSharksIdp"),
+            "sourcePresence[draftSharksIdp] is False even though DS "
+            "ranked the player — the presence computation still "
+            "requires ``v > 0`` for DS sources.",
+        )
+
+    def test_ds_coverage_counts_include_negative_tail(self) -> None:
+        """Aggregate check: the fix should expand DS coverage by
+        hundreds of players (the negative-value tail).  Floor the
+        totals so a regression that silently re-introduces the
+        ``> 0`` gate would drop coverage below expected and fail."""
+        if not DS_IDP_CSV.exists() or not DS_SF_CSV.exists():
+            self.skipTest("DraftSharks CSVs missing")
+        if self.contract is None:
+            self.skipTest("No exported raw payload to build contract from")
+
+        players = self.contract.get("playersArray") or []
+
+        ds_idp_covered = sum(
+            1
+            for p in players
+            if (p.get("sourcePresence") or {}).get("draftSharksIdp")
+        )
+        ds_sf_covered = sum(
+            1
+            for p in players
+            if (p.get("sourcePresence") or {}).get("draftSharks")
+        )
+
+        # Floors: at time of fix, DS IDP covered 270 and DS SF covered
+        # 407.  Set the floor at 80% of those numbers so scraper churn
+        # (a dozen-row pull-forward, a depth trim) doesn't fail the
+        # test, but a regression that drops the negative-tail coverage
+        # (losing ~170 IDP / ~185 SF rows) trips immediately.
+        self.assertGreaterEqual(
+            ds_idp_covered,
+            216,
+            f"DS IDP coverage collapsed to {ds_idp_covered}; the "
+            "negative-value carve-out may have regressed.",
+        )
+        self.assertGreaterEqual(
+            ds_sf_covered,
+            326,
+            f"DS SF coverage collapsed to {ds_sf_covered}; the "
+            "negative-value carve-out may have regressed.",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes 3 separate ``> 0`` filters in the canonical pipeline that silently dropped every DraftSharks row with a negative ``3D Value +`` — which is ~half the DS CSV past rank 200. These are legitimate rankings (e.g. Emmanuel McNeil-Warren at IDP rank 362 = -25), but the value-signal gates were written assuming non-negative scales and never got the DS carve-out the registry already declared.

## User-visible impact
- **DS IDP coverage: 96 → 270 players (+174, +181%)**
- **DS SF coverage: 222 → 407 players (+185, +83%)**
- Emmanuel McNeil-Warren now appears with a DraftSharks IDP stamp end-to-end (canonicalSiteValues, sourceRanks, sourcePresence). He was flagged by the user as missing from the board even though DraftSharks clearly ranks him.
- Per-source trade breakdown + rankings board's DS column now light up for deep-bench prospects.

## What changed
- New module-level ``_DS_COMBINED_RANK_KEYS`` frozenset derived from the registry at import time (any source declaring ``ds_combined_rank_partner``).
- Three gates in ``src/api/data_contract.py`` relax their strict ``> 0`` check for sources in that set — every other value-signal source keeps the strict gate because their scales are non-negative.
- 4 new regression tests in ``tests/api/test_draftsharks_negative_values.py`` pin: the registry ↔ carve-out set parity, the presence of negative DS rows in the CSV, end-to-end coverage of a known negative-value player (McNeil-Warren), and aggregate DS coverage floors so a silent re-introduction of any ``> 0`` gate trips the suite.

## Test plan
- [x] ``python3 -m pytest tests/api/ -q`` — 604 passed, 3 skipped (up from 600, added 4)
- [x] ``python3 -m pytest tests/ -q`` — all 1853 backend tests pass
- [ ] Smoke on deployed ``/api/data``: McNeil-Warren returns with ``sourcePresence.draftSharksIdp == true``

🤖 Generated with [Claude Code](https://claude.com/claude-code)