### PR TITLE
Surface $0-budget teams on /draft

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -472,14 +472,44 @@ describe("mergeDraftCapitalTeams", () => {
       ws,
       capitalFeed,
     );
-    // One of the defaults ("Russini Panini") matches; the rest are
-    // placeholder names so they don't match the feed and stay put.
+    // One of the defaults ("Russini Panini") matches; the other 11
+    // defaults are dropped as placeholders, and the feed appends its
+    // remaining 9 teams.
     expect(matched).toBe(1);
     expect(added).toBe(capitalFeed.length - 1);
     const russini = workspace.teams.find(
       (t) => t.name === "Russini Panini",
     );
     expect(russini.initialBudget).toBe(418);
+  });
+
+  it("drops pristine placeholder defaults rather than zeroing them", () => {
+    const ws = createDefaultWorkspace();
+    const { workspace } = mergeDraftCapitalTeams(ws, capitalFeed);
+    // No "Ed" / "Brent" / "Joey" placeholders should survive a
+    // pristine merge — they get replaced entirely by the feed.
+    const names = workspace.teams.map((t) => t.name);
+    expect(names).not.toContain("Ed");
+    expect(names).not.toContain("Brent");
+    expect(names).not.toContain("Joey");
+    // Final size = matched (1) + added (9) = 10.
+    expect(workspace.teams.length).toBe(10);
+  });
+
+  it("zeroes out manually-edited rows that aren't in the feed", () => {
+    // User renamed "Ed" to "Dynasty Danglers" but left the budget
+    // alone.  The rename signals user intent, so the row stays —
+    // but zeroed, because the feed is authoritative for budgets.
+    const ws = createDefaultWorkspace();
+    const withRename = updateTeam(ws, 1, { name: "Dynasty Danglers" });
+    const { workspace, zeroed } = mergeDraftCapitalTeams(
+      withRename,
+      capitalFeed,
+    );
+    const dd = workspace.teams.find((t) => t.name === "Dynasty Danglers");
+    expect(dd).toBeTruthy();
+    expect(dd.initialBudget).toBe(0);
+    expect(zeroed).toContain("Dynasty Danglers");
   });
 
   it("appends feed teams that aren't already on the board", () => {
@@ -529,19 +559,37 @@ describe("mergeDraftCapitalTeams", () => {
     expect(workspace.teams).toEqual(ws.teams);
   });
 
-  it("merged budgets sum to the feed's total budget", () => {
+  it("merged budgets sum to exactly the feed's total budget", () => {
+    // With placeholder defaults dropped, the board should sum to
+    // exactly $1200 — no phantom default budget left over.
     const ws = createDefaultWorkspace();
     const { workspace } = mergeDraftCapitalTeams(ws, capitalFeed);
-    // Every feed team's auction$ should be reflected.  The sum of
-    // the feed (1200) should be a subset of the merged total — any
-    // ADDITIONAL default teams keep their 71/73 budgets.
     const feedTotal = capitalFeed.reduce((s, t) => s + t.auctionDollars, 0);
     expect(feedTotal).toBe(1200);
     const mergedTotal = workspace.teams.reduce(
       (s, t) => s + t.initialBudget,
       0,
     );
-    expect(mergedTotal).toBeGreaterThanOrEqual(1200);
+    expect(mergedTotal).toBe(1200);
+  });
+
+  it("a feed with a $0 team carries that $0 onto the board", () => {
+    // Backend change (2026-04-23) seeds every Sleeper roster at $0
+    // so teams that traded every rookie pick still appear in the
+    // feed.  Confirm those rows land on the board with $0.
+    const feedWithZero = [
+      ...capitalFeed,
+      { team: "Jason&Brent Future Team", auctionDollars: 0 },
+    ];
+    const { workspace } = mergeDraftCapitalTeams(
+      createDefaultWorkspace(),
+      feedWithZero,
+    );
+    const zero = workspace.teams.find(
+      (t) => t.name === "Jason&Brent Future Team",
+    );
+    expect(zero).toBeTruthy();
+    expect(zero.initialBudget).toBe(0);
   });
 });
 

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -407,23 +407,28 @@ export function updateSettings(workspace, patch) {
 /**
  * Merge per-team auction $ from ``/api/draft-capital`` onto a workspace.
  *
- * The draft-capital endpoint returns one row per team that's carrying
- * carry-over auction dollars — typically 10 of 12 teams (the two with
- * $0 budget are usually omitted from the API response because they
- * traded every rookie pick away).  We merge by case-insensitive team
- * name, preserving:
+ * The draft-capital endpoint returns one row per team in the league —
+ * teams that traded every rookie pick away show up with
+ * ``auctionDollars: 0`` rather than being omitted, so the dashboard
+ * sees the full 12-team roster after the merge.
  *
- *   - Any team the user already renamed manually (we match the
- *     original name so a manual rename doesn't block the merge).
- *   - Teams that already have picks recorded against them (we NEVER
- *     blow away budgets mid-draft; callers should only invoke this
- *     when ``workspace.picks`` is empty, or explicitly ack the reset).
+ * Merge rules:
  *
- * Any team in the capital feed that doesn't already exist on the
- * board is appended to the end.  Teams on the board but missing from
- * the feed keep their existing budget (or default to 0 if this is a
- * fresh load).  A ``myTeamIdx`` remap is also returned so the UI can
- * re-pin the user's team even if the order changes.
+ *   - Feed is authoritative.  If the feed has 12 teams, the post-
+ *     merge board has exactly 12 teams (placeholder "Ed" / "Brent"
+ *     / etc. defaults are replaced entirely).
+ *   - Existing teams are matched against the feed by
+ *     case-insensitive name.  A name match copies the feed's budget
+ *     onto the existing row (preserving the user's preferred
+ *     display name when ``preserveCustomNames`` is true).
+ *   - Teams in the feed but not on the board are appended.
+ *   - Teams ON the board that AREN'T in the feed get zeroed out —
+ *     the feed is the source of truth for budget, so anyone it
+ *     doesn't list has $0 to spend.  The user can still manually
+ *     bump a budget back up if they're tracking a side deal.
+ *
+ * ``myTeamIdx`` is remapped by name so the merge can't accidentally
+ * deselect the user's team.
  *
  * @param {object} workspace - existing workspace (mutated into a new copy)
  * @param {{team: string, auctionDollars: number}[]} teamTotals
@@ -451,25 +456,58 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
     });
   }
 
+  // Empty feed — leave the workspace untouched rather than nuking
+  // every placeholder team.  The fetch layer should already have
+  // surfaced this as an error to the user; compute-side we just
+  // act as a no-op so nothing gets lost.
+  if (feedByKey.size === 0) {
+    return { workspace: ws, matched: 0, added: 0, missing: [], zeroed: [] };
+  }
+
   const myTeamIdx = Number.isInteger(ws.settings?.myTeamIdx)
     ? ws.settings.myTeamIdx
     : 0;
   const myTeamNameBefore = existing[myTeamIdx]?.name || "";
 
-  // Walk existing teams, matching by name.  Unmatched entries keep
-  // their current budget — the UI can flag them as "missing from
-  // capital feed" if needed.
+  // Default-placeholder detector: a row whose name + initialBudget
+  // still match the DEFAULT_TEAMS seed is assumed to be a pre-load
+  // placeholder and gets DROPPED rather than zeroed on merge.  That
+  // way a fresh workspace doesn't end up with 11 orphan "Ed / Brent /
+  // ..." rows at $0 cluttering the panel next to the real feed.  A
+  // row that's been customized (either renamed or re-budgeted) is
+  // treated as a user assertion and zeroed out rather than dropped.
+  const defaultByKey = new Map(
+    DEFAULT_TEAMS.map((t) => [
+      String(t.name || "").toLowerCase(),
+      t.initialBudget,
+    ]),
+  );
+
   const usedFeedKeys = new Set();
-  const merged = existing.map((t) => {
+  const zeroed = [];
+  const merged = [];
+  for (const t of existing) {
     const key = String(t.name || "").toLowerCase();
     const hit = feedByKey.get(key);
-    if (!hit) return { ...t };
-    usedFeedKeys.add(key);
-    return {
-      name: preserveNames && t.name ? t.name : hit.name,
-      initialBudget: hit.auctionDollars,
-    };
-  });
+    if (hit) {
+      usedFeedKeys.add(key);
+      merged.push({
+        name: preserveNames && t.name ? t.name : hit.name,
+        initialBudget: hit.auctionDollars,
+      });
+      continue;
+    }
+    // Drop unmatched default placeholders; zero out unmatched user-
+    // customized rows.
+    if (
+      defaultByKey.has(key) &&
+      defaultByKey.get(key) === Number(t.initialBudget)
+    ) {
+      continue;
+    }
+    zeroed.push(t.name);
+    merged.push({ name: t.name || "", initialBudget: 0 });
+  }
 
   // Append any feed teams not already on the board.  These are the
   // rows that just showed up in the capital feed — most likely after
@@ -496,6 +534,7 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
     matched: usedFeedKeys.size,
     added: missing.length,
     missing,
+    zeroed,
   };
 }
 

--- a/server.py
+++ b/server.py
@@ -3202,6 +3202,16 @@ def _fetch_draft_capital():
     all_picks: list[dict] = []
     team_totals_decimal: dict[str, float] = {}
 
+    # Seed every known roster at $0 so teams that traded every pick
+    # away — and therefore never get a decimal-value addition below
+    # — still appear in the output.  Without this seed, the sort on
+    # ``team_totals_decimal`` drops $0 teams entirely and consumers
+    # (e.g. the /draft dashboard that pulls carry-over budgets from
+    # this endpoint) can't see the full 12-team roster.
+    for rid in roster_ids:
+        roster_name = roster_name_by_id.get(rid, f"Team {rid}")
+        team_totals_decimal.setdefault(roster_name, 0.0)
+
     if roster_ids:
         # Sleeper ownership available — pair workbook values with live owners
         for rnd in range(1, draft_rounds + 1):


### PR DESCRIPTION
## Summary
Follow-up to #230. The user called out: "if they don't have any dollars that means they have 0" — the previous behaviour either dropped those teams entirely or left them at their $71 placeholder budget, so the dashboard wasn't showing the full 12-team roster.

Two fixes:

**1. Backend:** ``/api/draft-capital`` now seeds every Sleeper roster at $0 before walking picks. Post-fix the feed returns all 12 teams:

```
Russini Panini           $418
jstuedle                 $171
Rage Against The Achane  $157
CollinFoz                $140
Chargers Team Doctor     $128
killaKich00              $64
I'm Not Afraid Anymore!  $50
TyBWell                  $49
ughb                     $18
Still Jason&Brents Team  $5
Pop Trunk                $0   ← new
Karma Cowboy             $0   ← new
                         ─────
                        $1200
```

**2. Frontend merge:** ``mergeDraftCapitalTeams`` now treats the feed as the source of truth. Teams on the board that aren't in the feed get $0 (not $71 placeholder). A placeholder-vs-user-edit check prevents ghost rows:
- Pristine defaults that don't match the feed → row dropped entirely.
- User-edited rows (renamed or re-budgeted) that don't match → zeroed but kept, so picks can still be recorded against that team.

Empty-feed calls now short-circuit to a no-op so an API hiccup can't blow away the roster.

## Test plan
- [x] ``npx vitest run`` — 55/55 draft-logic tests pass (3 new)
- [x] ``python3 -m pytest tests/api -q`` — 604 pass
- [x] ``npm run build`` — clean
- [x] Live curl of ``/api/draft-capital`` confirms 12 teams, $1200 sum, Pop Trunk + Karma Cowboy at $0

🤖 Generated with [Claude Code](https://claude.com/claude-code)