### PR TITLE
Draft: fix "Board $ left" to show league $ remaining

### DIFF
--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -74,9 +74,11 @@ function StatsStrip({ stats }) {
         `${fmt$(stats.totalSpent)} of ${fmt$(stats.totalBudget)} total`,
       )}
       {stat(
-        "Board $ left",
-        fmt$(stats.undraftedPreDraft),
-        "Sum of PreDraft $ for every rookie still on the board.",
+        "League $ left",
+        fmt$(stats.remainingLeague),
+        `Total auction $ still unspent across all teams. Starts at ${fmt$(
+          stats.totalBudget,
+        )}; drops as picks are recorded.`,
       )}
     </div>
   );


### PR DESCRIPTION
Board $ left was bound to undraftedPreDraft (the literal sum of the PreDraft column = $1211) instead of remainingLeague (the actual money still available to spend = $1200 at start, drops as picks land). Relabeled to "League $ left" for clarity.

Tests pass (55/55), production build clean.