### PR TITLE
Draft Tier 1: tiers, slots, competitor ceiling, phase multiplier

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -8,19 +8,26 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_AGGRESSION,
   DEFAULT_ENFORCE_PCT,
+  DEFAULT_INITIAL_SLOTS,
   DEFAULT_TEAMS,
   DEFAULT_ROOKIES,
   DRAFT_STORAGE_KEY,
+  PHASE_LATE_BOOST,
+  TIER_DEFS,
+  TIER_CONFIDENCE_MIN_SAMPLES,
   addPlayer,
   bidStatus,
   computeDraftStats,
   createDefaultWorkspace,
+  effectiveBudgetFor,
   hydrateWorkspace,
   mergeDraftCapitalTeams,
   playerSlug,
   recordPick,
   removePick,
   removePlayer,
+  slotsByTeamFromPicks,
+  tierForPreDraft,
   undoLastPick,
   updatePlayerPreDraft,
   updateSettings,
@@ -389,17 +396,45 @@ describe("bidStatus", () => {
     expect(bidStatus(love, 0).level).toBe("idle");
   });
 
-  it("push when bid is below enforce floor", () => {
+  it("push when bid is below enforce floor AND below ceiling", () => {
+    // Opening Love: enforce=108, winningBid=68 (top competitor is
+    // Joel at 68 effective).  Bid of $50 is below both → push.
     expect(bidStatus(love, 50).level).toBe("push");
   });
 
-  it("target (sweet spot) when between enforce and max", () => {
-    // enforce=108, max=193 → 150 should be target.
-    expect(bidStatus(love, 150).level).toBe("target");
+  it("pass when bid exceeds winning bid (pass-beats-push)", () => {
+    // Opening Love winning bid ≈ 68.  Bid of $100 is below the
+    // enforce cap (108) but above the ceiling — overpay territory.
+    // Pre-Tier-1 this was "target"; post-Tier-1 the competitor
+    // ceiling rules.
+    expect(bidStatus(love, 100).level).toBe("pass");
   });
 
-  it("pass when bid exceeds max", () => {
+  it("pass when bid far above ceiling", () => {
     expect(bidStatus(love, 250).level).toBe("pass");
+  });
+
+  it("target when bid between enforce and ceiling (mid-draft, rich rivals)", () => {
+    // Force a scenario with a rich rival so ceiling > enforce and
+    // "sweet spot" actually has space.  Simulate it by giving every
+    // other team the same budget as Russini Panini so competitor
+    // ceiling ≈ my own wealth.
+    const richWs = createDefaultWorkspace();
+    const evenWs = {
+      ...richWs,
+      teams: richWs.teams.map((t, i) =>
+        i === 0 ? t : { ...t, initialBudget: 400 },
+      ),
+    };
+    const evenStats = computeDraftStats(evenWs);
+    const loveRich = evenStats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    // With 11 teams at $400 each, ceiling high → enforce=108 and
+    // winning ≈ 400+1 competitor reality.  A bid of $120 sits
+    // between enforce and ceiling → "target".
+    expect(loveRich.myWinningBid).toBeGreaterThan(loveRich.enforceUpTo);
+    expect(bidStatus(loveRich, 120).level).toBe("target");
   });
 
   it("mine/gone labels when already drafted", () => {
@@ -630,5 +665,394 @@ describe("workspaceIsPristine", () => {
   it("gracefully handles null / undefined input", () => {
     expect(workspaceIsPristine(null)).toBe(false);
     expect(workspaceIsPristine(undefined)).toBe(false);
+  });
+});
+
+// ── Tier 1 upgrades ─────────────────────────────────────────────────────
+
+describe("tierForPreDraft", () => {
+  it("classifies by PreDraft $ thresholds", () => {
+    expect(tierForPreDraft(135)).toBe("S");
+    expect(tierForPreDraft(60)).toBe("S");
+    expect(tierForPreDraft(59)).toBe("A");
+    expect(tierForPreDraft(25)).toBe("A");
+    expect(tierForPreDraft(24)).toBe("B");
+    expect(tierForPreDraft(8)).toBe("B");
+    expect(tierForPreDraft(7)).toBe("C");
+    expect(tierForPreDraft(3)).toBe("C");
+    expect(tierForPreDraft(2)).toBe("D");
+    expect(tierForPreDraft(1)).toBe("D");
+    expect(tierForPreDraft(0)).toBe("D");
+  });
+
+  it("coerces bad input to D", () => {
+    expect(tierForPreDraft(null)).toBe("D");
+    expect(tierForPreDraft(undefined)).toBe("D");
+    expect(tierForPreDraft("garbage")).toBe("D");
+    expect(tierForPreDraft(-5)).toBe("D");
+  });
+
+  it("TIER_DEFS exports 5 tiers in descending price order", () => {
+    expect(TIER_DEFS.map((t) => t.key)).toEqual(["S", "A", "B", "C", "D"]);
+    for (let i = 1; i < TIER_DEFS.length; i++) {
+      expect(TIER_DEFS[i].min).toBeLessThan(TIER_DEFS[i - 1].min);
+    }
+  });
+});
+
+describe("effectiveBudgetFor", () => {
+  it("reserves $1 per remaining slot beyond the current bid", () => {
+    expect(effectiveBudgetFor(100, 3)).toBe(98); // $1 × 2 reserved
+    expect(effectiveBudgetFor(100, 1)).toBe(100); // last slot: full budget
+    expect(effectiveBudgetFor(5, 5)).toBe(1); // $1 × 4 reserved
+  });
+
+  it("returns 0 when slots are 0 (team has no roster space)", () => {
+    expect(effectiveBudgetFor(50, 0)).toBe(0);
+  });
+
+  it("returns 0 when team is over-committed (more slots than $)", () => {
+    expect(effectiveBudgetFor(10, 11)).toBe(0);
+  });
+
+  it("handles bad input gracefully", () => {
+    expect(effectiveBudgetFor(null, 3)).toBe(0);
+    expect(effectiveBudgetFor(100, null)).toBe(0);
+    expect(effectiveBudgetFor(-5, 3)).toBe(0);
+  });
+});
+
+describe("slotsByTeamFromPicks", () => {
+  it("counts picks per currentOwner (case-insensitive)", () => {
+    const picks = [
+      { currentOwner: "Russini Panini" },
+      { currentOwner: "Russini Panini" },
+      { currentOwner: "jstuedle" },
+      { currentOwner: "RUSSINI PANINI" }, // different casing
+    ];
+    const counts = slotsByTeamFromPicks(picks);
+    expect(counts.get("russini panini")).toBe(3);
+    expect(counts.get("jstuedle")).toBe(1);
+  });
+
+  it("handles null / non-array input", () => {
+    expect(slotsByTeamFromPicks(null).size).toBe(0);
+    expect(slotsByTeamFromPicks(undefined).size).toBe(0);
+    expect(slotsByTeamFromPicks("bad").size).toBe(0);
+  });
+
+  it("ignores picks with missing owner", () => {
+    const picks = [
+      { currentOwner: "Russini Panini" },
+      { currentOwner: "" },
+      { currentOwner: null },
+      {},
+    ];
+    expect(slotsByTeamFromPicks(picks).get("russini panini")).toBe(1);
+  });
+});
+
+// ── computeDraftStats: Tier 1 derivations ───────────────────────────────
+
+describe("computeDraftStats — Tier 1 new fields", () => {
+  const ws = createDefaultWorkspace();
+  const stats = computeDraftStats(ws);
+
+  it("exposes initialSlots / slotsRemaining / effectiveBudget per team", () => {
+    for (const t of stats.teamStats) {
+      expect(t.initialSlots).toBe(DEFAULT_INITIAL_SLOTS);
+      expect(t.slotsDrafted).toBe(0);
+      expect(t.slotsRemaining).toBe(DEFAULT_INITIAL_SLOTS);
+      // effectiveBudget = max(0, remaining − (slots − 1))
+      expect(t.effectiveBudget).toBe(
+        Math.max(0, t.remaining - (DEFAULT_INITIAL_SLOTS - 1)),
+      );
+    }
+  });
+
+  it("slotPressure is 0 at draft start", () => {
+    expect(stats.slotPressure).toBe(0);
+    expect(stats.phaseMultiplier).toBe(1);
+  });
+
+  it("topCompetitorMax is the max OTHER slot-adjusted budget", () => {
+    // Teams 1-10 have $71, Joel has $73.  All with 6 slots.
+    // Effective: 71-5=66, 73-5=68.  Top competitor = 68 (Joel).
+    expect(stats.topCompetitorMax).toBe(68);
+  });
+
+  it("enrichedPlayers carry tier + myWinningBid", () => {
+    const love = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    expect(love.tier).toBe("S");
+    // Love's theoretical max at opening is 193; competitor ceiling
+    // caps winning bid at 68+1=69.
+    expect(love.theoreticalMaxBid).toBe(193);
+    expect(love.myWinningBid).toBe(69);
+  });
+
+  it("myWinningBid ≤ theoreticalMaxBid for every undrafted player", () => {
+    for (const p of stats.enrichedPlayers) {
+      if (p.drafted) continue;
+      expect(p.myWinningBid).toBeLessThanOrEqual(p.theoreticalMaxBid);
+    }
+  });
+
+  it("tier heat is null at draft start (no samples)", () => {
+    for (const key of ["S", "A", "B", "C", "D"]) {
+      expect(stats.tierHeat[key]).toBeNull();
+      expect(stats.tierConfidence[key]).toBe(0);
+      expect(stats.tierSampleCount[key]).toBe(0);
+    }
+  });
+});
+
+describe("computeDraftStats — preDraftAtPick snapshot", () => {
+  it("recordPick stores the current preDraft at the moment of the pick", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const next = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 0,
+      amount: 120,
+    });
+    expect(next.picks[0].preDraftAtPick).toBe(135);
+  });
+
+  it("retroactive preDraft edit does NOT change tier heat (snapshot wins)", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 5,
+      amount: 200,
+    });
+    const before = computeDraftStats(withPick);
+    // Now the user decides Love is actually worth 80 (retroactive).
+    const withEdit = updatePlayerPreDraft(withPick, love.id, 80);
+    const after = computeDraftStats(withEdit);
+    // tierHeat for S should be unchanged because preDraftAtPick
+    // snapshot is what's used, not the current player.preDraft.
+    expect(after.tierHeat.S).toBeCloseTo(before.tierHeat.S, 4);
+    // And the inflation denominator is the same (also uses snapshot).
+    expect(after.inflation).toBeCloseTo(before.inflation, 4);
+  });
+});
+
+describe("computeDraftStats — tier heat / inflation blend", () => {
+  it("one S-tier overpay pushes tier heat > 1 with low confidence", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const stats = computeDraftStats(
+      recordPick(ws, { playerId: love.id, teamIdx: 5, amount: 200 }),
+    );
+    expect(stats.tierHeat.S).toBeCloseTo(200 / 135, 4);
+    // 1 sample / 3-sample min = 0.333 confidence
+    expect(stats.tierConfidence.S).toBeCloseTo(1 / 3, 4);
+    expect(stats.tierSampleCount.S).toBe(1);
+  });
+
+  it("three S-tier picks hits full confidence", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const mendoza = ws.players.find(
+      (p) => p.name === "Fernando Mendoza",
+    );
+    const lemon = ws.players.find((p) => p.name === "Makai Lemon");
+    let next = recordPick(ws, { playerId: love.id, teamIdx: 5, amount: 135 });
+    next = recordPick(next, { playerId: mendoza.id, teamIdx: 4, amount: 102 });
+    next = recordPick(next, { playerId: lemon.id, teamIdx: 3, amount: 90 });
+    const stats = computeDraftStats(next);
+    expect(stats.tierSampleCount.S).toBe(3);
+    expect(stats.tierConfidence.S).toBe(1);
+    // Paid exactly fair each time → heat = 1.0
+    expect(stats.tierHeat.S).toBeCloseTo(1.0, 4);
+  });
+
+  it("tier heat is unaffected by picks in other tiers", () => {
+    const ws = createDefaultWorkspace();
+    // Draft a $1 D-tier player at $10 (massive overpay, but for D).
+    const caleb = ws.players.find((p) => p.name === "Caleb Douglas");
+    const next = recordPick(ws, {
+      playerId: caleb.id,
+      teamIdx: 3,
+      amount: 10,
+    });
+    const stats = computeDraftStats(next);
+    expect(stats.tierHeat.D).toBeGreaterThan(1);
+    expect(stats.tierHeat.S).toBeNull();
+    expect(stats.tierHeat.A).toBeNull();
+    expect(stats.tierHeat.B).toBeNull();
+    expect(stats.tierHeat.C).toBeNull();
+  });
+});
+
+describe("computeDraftStats — phase multiplier (slot pressure)", () => {
+  it("ramps up as my slots drain", () => {
+    // Simulate me (team 0) drafting 5 of 6 picks at $1 each so we
+    // move slotPressure from 0 → 5/6 without blowing the budget
+    // (and without disturbing tier S heat).
+    const ws = createDefaultWorkspace();
+    const picks = [
+      "Caleb Douglas",
+      "De'Zhaun Stribling",
+      "Drew Allar",
+      "Roman Hemby",
+      "Jeff Caldwell",
+    ];
+    let next = ws;
+    for (const name of picks) {
+      const p = next.players.find((pl) => pl.name === name);
+      next = recordPick(next, {
+        playerId: p.id,
+        teamIdx: 0,
+        amount: 1,
+      });
+    }
+    const stats = computeDraftStats(next);
+    expect(stats.mySlotsRemaining).toBe(1);
+    expect(stats.slotPressure).toBeCloseTo(5 / 6, 4);
+    // phaseMultiplier = 1 + (5/6) × 0.5 ≈ 1.417
+    expect(stats.phaseMultiplier).toBeCloseTo(1 + (5 / 6) * PHASE_LATE_BOOST, 4);
+  });
+
+  it("phase multiplier stays at 1 when no slots drafted", () => {
+    const stats = computeDraftStats(createDefaultWorkspace());
+    expect(stats.phaseMultiplier).toBe(1);
+  });
+});
+
+describe("computeDraftStats — top competitor ceiling capping", () => {
+  it("winning bid collapses to 1 when every other team is bankrupt", () => {
+    const ws = createDefaultWorkspace();
+    // Zero every other team's budget.
+    const bankruptWs = {
+      ...ws,
+      teams: ws.teams.map((t, i) =>
+        i === 0 ? t : { ...t, initialBudget: 0 },
+      ),
+    };
+    const stats = computeDraftStats(bankruptWs);
+    expect(stats.topCompetitorMax).toBe(0);
+    const love = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    // myWinningBid = max(1, 0+1) = 1 — I lock any player for $1.
+    expect(love.myWinningBid).toBe(1);
+  });
+
+  it("winning bid uncapped (up to theoretical max) with wealthy rivals", () => {
+    const ws = createDefaultWorkspace();
+    // Set every rival to my budget so competitor ceiling is high.
+    const evenWs = {
+      ...ws,
+      teams: ws.teams.map((t, i) =>
+        i === 0 ? t : { ...t, initialBudget: 417 },
+      ),
+    };
+    const stats = computeDraftStats(evenWs);
+    expect(stats.topCompetitorMax).toBeGreaterThan(400);
+    const love = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    // Budget advantage ≈ 1.0 now, so theoretical max ≈ preDraft ×
+    // (1 + 0.09 × 0) = preDraft.  Winning bid doesn't cap below it.
+    expect(love.myWinningBid).toBeCloseTo(love.theoreticalMaxBid, 0);
+  });
+});
+
+describe("mergeDraftCapitalTeams — with picks array", () => {
+  const teamTotals = [
+    { team: "Russini Panini", auctionDollars: 418 },
+    { team: "jstuedle", auctionDollars: 171 },
+    { team: "Pop Trunk", auctionDollars: 0 },
+  ];
+  const picks = [
+    // Russini owns 8 picks, jstuedle 3, Pop Trunk 0
+    ...Array(8).fill({ currentOwner: "Russini Panini" }),
+    ...Array(3).fill({ currentOwner: "jstuedle" }),
+  ];
+
+  it("sets initialSlots from the picks array when supplied", () => {
+    const ws = createDefaultWorkspace();
+    const { workspace } = mergeDraftCapitalTeams(ws, teamTotals, { picks });
+    const russini = workspace.teams.find((t) => t.name === "Russini Panini");
+    const jstu = workspace.teams.find((t) => t.name === "jstuedle");
+    const pop = workspace.teams.find((t) => t.name === "Pop Trunk");
+    expect(russini.initialSlots).toBe(8);
+    expect(jstu.initialSlots).toBe(3);
+    expect(pop.initialSlots).toBe(0);
+  });
+
+  it("without picks array, initialSlots falls back to DEFAULT_INITIAL_SLOTS", () => {
+    const ws = createDefaultWorkspace();
+    const { workspace } = mergeDraftCapitalTeams(ws, teamTotals);
+    const russini = workspace.teams.find((t) => t.name === "Russini Panini");
+    expect(russini.initialSlots).toBe(DEFAULT_INITIAL_SLOTS);
+  });
+});
+
+describe("hydrateWorkspace — Tier 1 field backfill", () => {
+  it("backfills preDraftAtPick from current player when missing", () => {
+    const parsed = {
+      version: 1,
+      settings: { myTeamIdx: 0 },
+      teams: DEFAULT_TEAMS,
+      players: DEFAULT_ROOKIES.map((p) => ({
+        id: playerSlug(p.name),
+        rank: p.rank,
+        name: p.name,
+        preDraft: p.preDraft,
+      })),
+      picks: [
+        // Old-format pick: no preDraftAtPick field
+        {
+          playerId: playerSlug("Jeremiyah Love"),
+          teamIdx: 0,
+          amount: 120,
+          ts: 1000,
+        },
+      ],
+    };
+    const ws = hydrateWorkspace(parsed);
+    expect(ws.picks[0].preDraftAtPick).toBe(135); // from player.preDraft
+  });
+
+  it("preserves preDraftAtPick when present (no retroactive rewrite)", () => {
+    const parsed = {
+      version: 1,
+      settings: { myTeamIdx: 0 },
+      teams: DEFAULT_TEAMS,
+      players: DEFAULT_ROOKIES.map((p) => ({
+        id: playerSlug(p.name),
+        rank: p.rank,
+        name: p.name,
+        preDraft: p.preDraft,
+      })),
+      picks: [
+        {
+          playerId: playerSlug("Jeremiyah Love"),
+          teamIdx: 0,
+          amount: 120,
+          preDraftAtPick: 999, // user edited preDraft after pick
+          ts: 1000,
+        },
+      ],
+    };
+    const ws = hydrateWorkspace(parsed);
+    expect(ws.picks[0].preDraftAtPick).toBe(999);
+  });
+
+  it("backfills initialSlots to DEFAULT_INITIAL_SLOTS when missing", () => {
+    const parsed = {
+      version: 1,
+      settings: { myTeamIdx: 0 },
+      teams: [{ name: "A", initialBudget: 100 }], // no initialSlots
+      players: [],
+      picks: [],
+    };
+    const ws = hydrateWorkspace(parsed);
+    expect(ws.teams[0].initialSlots).toBe(DEFAULT_INITIAL_SLOTS);
   });
 });

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -7,6 +7,7 @@ import {
   DRAFT_STORAGE_KEY,
   DEFAULT_AGGRESSION,
   DEFAULT_ENFORCE_PCT,
+  TIER_DEFS,
   addPlayer,
   bidStatus,
   computeDraftStats,
@@ -23,6 +24,8 @@ import {
   updateTeam,
   workspaceIsPristine,
 } from "@/lib/draft-logic";
+
+const TIER_LABELS = Object.fromEntries(TIER_DEFS.map((t) => [t.key, t.label]));
 
 /* ── Utility formatters ───────────────────────────────────────────── */
 
@@ -45,33 +48,67 @@ function fmtMultiplier(n) {
 /* ── Inflation stats strip ────────────────────────────────────────── */
 
 function StatsStrip({ stats }) {
-  const stat = (label, value, title) => (
-    <div className="draft-stat" title={title || undefined}>
+  const stat = (label, value, title, extraClass = "") => (
+    <div
+      className={`draft-stat ${extraClass}`.trim()}
+      title={title || undefined}
+    >
       <div className="draft-stat-label">{label}</div>
       <div className="draft-stat-value">{value}</div>
     </div>
   );
+
+  const inflationClass =
+    stats.inflation > 1.05
+      ? "draft-stat-green"
+      : stats.inflation < 0.95
+        ? "draft-stat-red"
+        : "";
+
+  // Phase: 0 at draft start, →1 as my last pick approaches.  Shown as
+  // "N of M slots left · P% pressure" so both the absolute slot count
+  // and the pressure % are visible at a glance.
+  const slotsPart = `${stats.mySlotsRemaining} of ${stats.myInitialSlots} slots`;
+  const pressurePart = `${Math.round((stats.slotPressure || 0) * 100)}% pressure`;
+
+  // Top rival ceiling — the real competitor cap driving myWinningBid.
+  // Surfacing it in the strip teaches the user "this is the number to
+  // beat, not some hypothetical".
+  const rivalClass =
+    stats.topCompetitorMax < 10
+      ? "draft-stat-green" // rivals broke, I can steal anything
+      : stats.topCompetitorMax > 150
+        ? "draft-stat-red"
+        : "";
+
   return (
     <div className="draft-stats">
       {stat(
         "Inflation",
         fmtMultiplier(stats.inflation),
-        "Remaining league $ divided by undrafted PreDraft $. >1.00 means the market got cheaper than projected; <1.00 means the market is running hot.",
+        "RemainingLeague$ / (TotalAuction$ − Σ soldPreDraft). >1.00 means the remaining market is cheaper than projected; <1.00 means the remaining market got hot.",
+        inflationClass,
       )}
       {stat(
         "My remaining",
         fmt$(stats.myRemaining),
-        `Starting ${fmt$(stats.myStarting)} − spent ${fmt$(stats.mySpent)}`,
+        `Starting ${fmt$(stats.myStarting)} − spent ${fmt$(stats.mySpent)} · ${slotsPart} left`,
       )}
       {stat(
         "Budget advantage",
         fmtMultiplier(stats.budgetAdvantage),
-        `My remaining / avg per other team (${fmt$(stats.avgPerOtherTeam)}).  Above 1.0 = I can afford to outbid the field.`,
+        `My remaining / avg per other team (${fmt$(stats.avgPerOtherTeam)}). Above 1.0 = I can afford to outbid the field average.`,
       )}
       {stat(
-        "League spent",
-        fmtPct(stats.leagueSpentPct),
-        `${fmt$(stats.totalSpent)} of ${fmt$(stats.totalBudget)} total`,
+        "Top rival ceiling",
+        fmt$(stats.topCompetitorMax),
+        `The richest OTHER team can bid up to this much (slot-adjusted). Bid $1 above this to lock a player — anything more is overpay.`,
+        rivalClass,
+      )}
+      {stat(
+        "Phase",
+        `${slotsPart}`,
+        `${pressurePart}. MaxBid scales by phaseMultiplier ${fmtMultiplier(stats.phaseMultiplier)} to prevent unused $ at end of draft.`,
       )}
       {stat(
         "League $ left",
@@ -178,49 +215,69 @@ function TeamPanel({
           <span>Initial</span>
           <span>Spent</span>
           <span>Remaining</span>
-          <span>Picks</span>
-        </div>
-        {stats.teamStats.map((t) => (
-          <div
-            key={t.idx}
-            className={`draft-team-row${t.isMine ? " draft-team-mine" : ""}`}
+          <span title="Slots drafted / initial slots owned">Slots</span>
+          <span
+            title="Slot-adjusted effective $ — max single-bid this team can actually afford while still filling their other slots at $1 each."
           >
-            <label className="draft-radio">
-              <input
-                type="radio"
-                name="myTeam"
-                checked={t.isMine}
-                onChange={() => onSettings({ myTeamIdx: t.idx })}
-              />
-            </label>
-            <input
-              className="draft-inline-input"
-              value={workspace.teams[t.idx]?.name ?? ""}
-              onChange={(e) => onTeam(t.idx, { name: e.target.value })}
-              placeholder={`Team ${t.idx + 1}`}
-            />
-            <input
-              className="draft-inline-input draft-money-input"
-              type="number"
-              min="0"
-              value={workspace.teams[t.idx]?.initialBudget ?? 0}
-              onChange={(e) =>
-                onTeam(t.idx, {
-                  initialBudget: Math.max(0, Number(e.target.value) || 0),
-                })
-              }
-            />
-            <span className="draft-money">{fmt$(t.spent)}</span>
-            <span
-              className={`draft-money${
-                t.remaining < t.initialBudget * 0.25 ? " draft-money-low" : ""
-              }`}
+            Eff $
+          </span>
+        </div>
+        {stats.teamStats.map((t) => {
+          const effLow = t.effectiveBudget < 5;
+          const slotsEmpty = t.slotsRemaining <= 0;
+          return (
+            <div
+              key={t.idx}
+              className={`draft-team-row${t.isMine ? " draft-team-mine" : ""}`}
             >
-              {fmt$(t.remaining)}
-            </span>
-            <span className="draft-money">{t.picksCount}</span>
-          </div>
-        ))}
+              <label className="draft-radio">
+                <input
+                  type="radio"
+                  name="myTeam"
+                  checked={t.isMine}
+                  onChange={() => onSettings({ myTeamIdx: t.idx })}
+                />
+              </label>
+              <input
+                className="draft-inline-input"
+                value={workspace.teams[t.idx]?.name ?? ""}
+                onChange={(e) => onTeam(t.idx, { name: e.target.value })}
+                placeholder={`Team ${t.idx + 1}`}
+              />
+              <input
+                className="draft-inline-input draft-money-input"
+                type="number"
+                min="0"
+                value={workspace.teams[t.idx]?.initialBudget ?? 0}
+                onChange={(e) =>
+                  onTeam(t.idx, {
+                    initialBudget: Math.max(0, Number(e.target.value) || 0),
+                  })
+                }
+              />
+              <span className="draft-money">{fmt$(t.spent)}</span>
+              <span
+                className={`draft-money${
+                  t.remaining < t.initialBudget * 0.25 ? " draft-money-low" : ""
+                }`}
+              >
+                {fmt$(t.remaining)}
+              </span>
+              <span
+                className={`draft-money${slotsEmpty ? " draft-money-low" : ""}`}
+                title={`${t.slotsDrafted} drafted of ${t.initialSlots} owned`}
+              >
+                {t.slotsDrafted}/{t.initialSlots}
+              </span>
+              <span
+                className={`draft-money${effLow ? " draft-money-low" : ""}`}
+                title="Slot-adjusted effective $: what this team can actually bid on a single player while reserving $1 each for their remaining slots."
+              >
+                {fmt$(t.effectiveBudget)}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -365,20 +422,40 @@ function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
         <div className="draft-modal-body">
           <div className="draft-modal-refs">
             <div>
-              <span className="muted">PreDraft $</span>
-              <span className="draft-money">{fmt$(player.preDraft)}</span>
+              <span className="muted">Tier · PreDraft $</span>
+              <span className="draft-money">
+                <span
+                  className={`draft-tier-chip draft-tier-${player.tier}`}
+                  style={{ marginRight: 6 }}
+                >
+                  {player.tier}
+                </span>
+                {fmt$(player.preDraft)}
+              </span>
             </div>
             <div>
               <span className="muted">Inflated fair</span>
               <span className="draft-money">{fmt$(player.inflatedFair)}</span>
             </div>
             <div>
-              <span className="muted">My max bid</span>
+              <span className="muted">Win at</span>
+              <span className="draft-money draft-money-win">
+                {fmt$(player.myWinningBid)}
+              </span>
+            </div>
+            <div>
+              <span className="muted">My max bid (theoretical)</span>
               <span className="draft-money">{fmt$(player.myMaxBid)}</span>
             </div>
             <div>
               <span className="muted">Enforce up to</span>
               <span className="draft-money">{fmt$(player.enforceUpTo)}</span>
+            </div>
+            <div>
+              <span className="muted">Top rival ceiling</span>
+              <span className="draft-money">
+                {fmt$(stats.topCompetitorMax)}
+              </span>
             </div>
           </div>
 
@@ -410,6 +487,29 @@ function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
               placeholder="e.g. 120"
             />
           </label>
+
+          {(() => {
+            // Overpay warning: red banner when the amount is going on
+            // MY team AND exceeds myWinningBid.  No warning when
+            // recording picks on rival teams (they overpaid, not me).
+            const amt = Math.max(0, Number(amount) || 0);
+            const isMine = Number(teamIdx) === workspace.settings?.myTeamIdx;
+            const myCeiling = Number.isFinite(player.myWinningBid)
+              ? player.myWinningBid
+              : player.myMaxBid;
+            if (amt > 0 && isMine && amt > myCeiling) {
+              const diff = amt - myCeiling;
+              return (
+                <div className="draft-modal-warn">
+                  <strong>Overpay.</strong> ${amt} is ${diff} above your
+                  winning bid (${myCeiling}). The top rival can only
+                  bid ${fmt$(stats.topCompetitorMax)} — you don't need
+                  to pay more than ${myCeiling} to lock this player.
+                </div>
+              );
+            }
+            return null;
+          })()}
 
           <div className="draft-modal-live">
             <div className="muted" style={{ fontSize: "0.72rem" }}>
@@ -445,13 +545,35 @@ function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
           <button type="button" className="button" onClick={onClose}>
             Cancel
           </button>
-          <button
-            type="submit"
-            className="button"
-            style={{ borderColor: "var(--cyan)", color: "var(--cyan)" }}
-          >
-            {existingPick ? "Save" : "Record pick"}
-          </button>
+          {(() => {
+            const amt = Math.max(0, Number(amount) || 0);
+            const isMine = Number(teamIdx) === workspace.settings?.myTeamIdx;
+            const myCeiling = Number.isFinite(player.myWinningBid)
+              ? player.myWinningBid
+              : player.myMaxBid;
+            const danger = amt > 0 && isMine && amt > myCeiling;
+            return (
+              <button
+                type="submit"
+                className="button"
+                style={{
+                  borderColor: danger ? "var(--red)" : "var(--cyan)",
+                  color: danger ? "var(--red)" : "var(--cyan)",
+                }}
+                title={
+                  danger
+                    ? "You're about to overpay — double-check before committing."
+                    : ""
+                }
+              >
+                {existingPick
+                  ? "Save"
+                  : danger
+                    ? "Record (overpay!)"
+                    : "Record pick"}
+              </button>
+            );
+          })()}
         </div>
       </form>
     </div>
@@ -552,18 +674,24 @@ function RookieBoard({
           <thead>
             <tr>
               {th("#", "rank", 40)}
+              <th style={{ width: 44 }} title="Tier by PreDraft $: S=$60+, A=$25-59, B=$8-24, C=$3-7, D=$1-2">
+                Tier
+              </th>
               {th("Player", "name")}
-              {th("PreDraft", "preDraft", 90)}
-              {th("Fair", "inflatedFair", 80)}
-              {th("Enforce", "enforceUpTo", 80)}
-              {th("Max Bid", "myMaxBid", 90)}
+              {th("PreDraft", "preDraft", 82)}
+              {th("Fair", "inflatedFair", 70)}
+              {th("Enforce", "enforceUpTo", 70)}
+              {th("Win at", "myWinningBid", 80)}
+              {th("Max Bid", "myMaxBid", 80)}
               {th("Final", "final", 100)}
               <th style={{ width: 180 }}>Drafted to</th>
               <th style={{ width: 110 }}></th>
             </tr>
           </thead>
           <tbody>
-            {filtered.map((p) => (
+            {filtered.map((p) => {
+              const capped = p.myWinningBid < p.theoreticalMaxBid;
+              return (
               <tr
                 key={p.id}
                 className={`draft-row${p.drafted ? " draft-row-drafted" : ""}${
@@ -571,6 +699,14 @@ function RookieBoard({
                 }`}
               >
                 <td className="draft-money">{p.rank}</td>
+                <td>
+                  <span
+                    className={`draft-tier-chip draft-tier-${p.tier}`}
+                    title={`${TIER_LABELS[p.tier] || p.tier} tier`}
+                  >
+                    {p.tier}
+                  </span>
+                </td>
                 <td>{p.name}</td>
                 <td>
                   <input
@@ -586,7 +722,34 @@ function RookieBoard({
                 </td>
                 <td className="draft-money">{fmt$(p.inflatedFair)}</td>
                 <td className="draft-money">{fmt$(p.enforceUpTo)}</td>
-                <td className="draft-money draft-money-max">
+                <td
+                  className="draft-money draft-money-win"
+                  title={
+                    capped
+                      ? `Capped by top rival ceiling (${fmt$(
+                          stats.topCompetitorMax,
+                        )} + $1). Theoretical max was ${fmt$(
+                          p.theoreticalMaxBid,
+                        )}.`
+                      : `Limited by my theoretical max (${fmt$(
+                          p.theoreticalMaxBid,
+                        )})`
+                  }
+                >
+                  {fmt$(p.myWinningBid)}
+                  {capped && (
+                    <span
+                      style={{
+                        marginLeft: 4,
+                        fontSize: "0.64rem",
+                        color: "var(--green)",
+                      }}
+                    >
+                      ✓
+                    </span>
+                  )}
+                </td>
+                <td className="draft-money draft-money-max" title="Theoretical max bid if forced all the way to the ceiling.">
                   {fmt$(p.myMaxBid)}
                 </td>
                 <td className="draft-money">
@@ -650,11 +813,12 @@ function RookieBoard({
                   </div>
                 </td>
               </tr>
-            ))}
+              );
+            })}
             {filtered.length === 0 && (
               <tr>
                 <td
-                  colSpan={9}
+                  colSpan={11}
                   className="muted"
                   style={{ padding: 14, textAlign: "center" }}
                 >
@@ -777,6 +941,11 @@ export default function DraftDashboardPage() {
         if (teamTotals.length === 0) {
           throw new Error("Draft capital feed had no team totals.");
         }
+        // Raw picks array — used to derive per-team initial slot
+        // counts (how many rookie picks each team currently owns).
+        // Feeds into the slot-adjusted effectiveBudget calculation
+        // so MaxBid / WinningBid reflect real opponent bidding power.
+        const picksArray = Array.isArray(data?.picks) ? data.picks : [];
 
         setWorkspace((ws) => {
           // Non-force fetches are gated: if the user has already
@@ -785,13 +954,14 @@ export default function DraftDashboardPage() {
           const { workspace: next, matched, added } = mergeDraftCapitalTeams(
             ws,
             teamTotals,
+            { picks: picksArray },
           );
           if (!quiet) {
             setCapitalStatus((s) => ({
               ...s,
-              info: `Loaded ${matched} team budgets from Draft Capital${
+              info: `Loaded ${matched} team budgets${
                 added > 0 ? ` (${added} new)` : ""
-              }.`,
+              }${picksArray.length > 0 ? ` · ${picksArray.length} picks tracked` : ""}.`,
             }));
           }
           return next;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3664,8 +3664,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .draft-team-row {
   display: grid;
-  grid-template-columns: 32px 1fr 80px 70px 90px 50px;
-  gap: 8px;
+  grid-template-columns: 32px 1fr 72px 60px 72px 56px 62px;
+  gap: 6px;
   align-items: center;
   padding: 4px 0;
 }
@@ -3959,4 +3959,67 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   gap: 8px;
   padding: 12px 14px;
   border-top: 1px solid var(--border);
+}
+
+/* ── Tier 1: tier chips, winning-bid emphasis, overpay warning ─── */
+
+.draft-tier-chip {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-align: center;
+  min-width: 18px;
+  border: 1px solid var(--border);
+  font-family: var(--mono, monospace);
+}
+.draft-tier-S {
+  background: rgba(255, 198, 47, 0.15);
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.draft-tier-A {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: var(--green);
+  color: var(--green);
+}
+.draft-tier-B {
+  background: rgba(167, 139, 250, 0.12);
+  border-color: #a78bfa;
+  color: #c4b5fd;
+}
+.draft-tier-C {
+  background: rgba(153, 166, 200, 0.1);
+  color: var(--muted);
+}
+.draft-tier-D {
+  background: rgba(153, 166, 200, 0.05);
+  color: var(--subtext);
+}
+
+.draft-money-win {
+  color: var(--green);
+  font-weight: 700;
+}
+
+.draft-stat-green .draft-stat-value { color: var(--green); }
+.draft-stat-red .draft-stat-value { color: var(--red); }
+
+.draft-modal-warn {
+  margin-top: 4px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--red);
+  background: rgba(248, 113, 113, 0.08);
+  color: var(--red);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+.draft-modal-warn strong {
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  margin-right: 4px;
 }

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -2,18 +2,34 @@
  * Draft-board logic — pure inflation math + state helpers for the
  * live auction dashboard at ``/draft``.
  *
- * Ported from Jason's "Inflation" Google Sheet
- * (https://docs.google.com/spreadsheets/d/17wa6qdZ1Y8ckb4TIVZ4_C71g0skvtk9UZy43zSFzRlA).
- * Every number matches a cell in that sheet; every formula has a
- * comment pointing at the column it came from.
+ * Originally ported from Jason's "Inflation" Google Sheet
+ * (https://docs.google.com/spreadsheets/d/17wa6qdZ1Y8ckb4TIVZ4_C71g0skvtk9UZy43zSFzRlA);
+ * Tier 1 upgrades (2026-04) extend it past the sheet in four ways:
  *
- * Formulas:
+ *   1. ``preDraftAtPick`` snapshot on every pick so retroactive
+ *      PreDraft edits don't corrupt historical inflation tracking.
+ *   2. Per-team ``initialSlots`` accounting (from the live
+ *      ``/api/draft-capital`` picks array) so "slots remaining"
+ *      drives every budget calculation.
+ *   3. Slot-adjusted ``effectiveBudget`` per team + per-player
+ *      ``topCompetitorMax`` so MaxBid is capped by the richest
+ *      rival that can still actually bid, not the mean.
+ *   4. Phase multiplier (``slotPressure``) that ramps aggression
+ *      as my roster nears full, plus tier-specific inflation
+ *      (S / A / B / C / D buckets by PreDraft $) blended with
+ *      global inflation under a confidence weight.
  *
- *   Inflation          = Remaining League $ / Undrafted PreDraft $
- *   Inflated Fair      = PreDraft $ × Inflation
- *   Budget Advantage   = My Remaining / Avg $ per Other Team
- *   My Max Bid         = PreDraft × (1 + Aggression × (Advantage − 1)) × Inflation
- *   Enforce Up To      = Inflated Fair × Enforce %
+ * Core formulas (post-upgrade):
+ *
+ *   Inflation            = RemainingLeague$ / (TotalAuction$ − Σ soldPreDraft)
+ *   Tier heat(T)         = Σ paid in T / Σ preDraftAtPick in T
+ *   Tier inflation(T)    = inflation × (conf × tier_heat + (1−conf) × 1)
+ *   Budget Advantage(p)  = My Effective$ / (avg other effective$; min 1)
+ *   Slot pressure        = 1 − myPicksRemaining / myInitialSlots
+ *   Phase multiplier     = 1 + slotPressure × PHASE_LATE_BOOST
+ *   Theoretical Max(p)   = PreDraft × (1 + Aggression × (BA−1)) × tierInflation(p) × phaseMultiplier
+ *   Winning bid(p)       = min(Theoretical Max, topCompetitorMax + 1)
+ *   Enforce Up To(p)     = Inflated Fair × Enforce %
  *
  * No React dependencies — fully testable.
  */
@@ -26,6 +42,52 @@ export const DEFAULT_TOTAL_BUDGET = 1200;
 export const DEFAULT_TEAM_COUNT = 12;
 export const DEFAULT_AGGRESSION = 0.09;
 export const DEFAULT_ENFORCE_PCT = 0.8;
+/**
+ * Default number of rookie picks per team before any trades.  The
+ * actual per-team count is pulled from ``/api/draft-capital``'s
+ * ``picks`` array on first load; this default only applies to a
+ * pristine workspace before the fetch completes.
+ */
+export const DEFAULT_INITIAL_SLOTS = 6;
+/**
+ * How much slot pressure converts into MaxBid ramp-up.  At
+ * ``slotPressure=1`` (my last pick) MaxBid scales by
+ * ``1 + PHASE_LATE_BOOST`` (1.5× at the default).  Prevents the
+ * "I have $300 and 2 slots left, unused $ is wasted" failure mode.
+ */
+export const PHASE_LATE_BOOST = 0.5;
+/**
+ * Minimum number of tier samples needed before tier inflation is
+ * trusted at full weight.  With fewer samples, tier inflation is
+ * confidence-blended toward 1.0 (no tier adjustment beyond global).
+ */
+export const TIER_CONFIDENCE_MIN_SAMPLES = 3;
+
+// ── Tier partitioning ──────────────────────────────────────────────────
+// PreDraft $ cutoffs for the 5-tier classification.  Tier inflation is
+// computed independently per tier so "elite tier hot" (S-heavy overpays)
+// is surfaced separately from "cheap tier clearing" (D-heavy $1 picks).
+// Ordered from most expensive to least; a player's tier is the first
+// bucket whose ``min`` they meet.
+export const TIER_DEFS = [
+  { key: "S", label: "Elite", min: 60 },
+  { key: "A", label: "Starter", min: 25 },
+  { key: "B", label: "Depth", min: 8 },
+  { key: "C", label: "Dart", min: 3 },
+  { key: "D", label: "Min", min: 0 },
+];
+
+/**
+ * Classify a PreDraft $ value into one of the 5 tiers.
+ * Returns the tier key (``"S"``, ``"A"``, ..., ``"D"``).
+ */
+export function tierForPreDraft(preDraft) {
+  const v = Math.max(0, Number(preDraft) || 0);
+  for (const t of TIER_DEFS) {
+    if (v >= t.min) return t.key;
+  }
+  return "D";
+}
 
 // ── Default team roster ─────────────────────────────────────────────────
 // Total league pool is $1200 (the sum of DEFAULT_ROOKIES.preDraft).  The
@@ -36,18 +98,18 @@ export const DEFAULT_ENFORCE_PCT = 0.8;
 // carry-over balances, but defaulting to the sheet's anchor keeps the
 // opening inflation math matching the sheet cell-for-cell.
 export const DEFAULT_TEAMS = [
-  { name: "Russini Panini", initialBudget: 417 },
-  { name: "Ed", initialBudget: 71 },
-  { name: "Brent", initialBudget: 71 },
-  { name: "Joey", initialBudget: 71 },
-  { name: "MaKayla", initialBudget: 71 },
-  { name: "Ty", initialBudget: 71 },
-  { name: "Kich", initialBudget: 71 },
-  { name: "Eric", initialBudget: 71 },
-  { name: "Collin", initialBudget: 71 },
-  { name: "Roy", initialBudget: 71 },
-  { name: "Blaine", initialBudget: 71 },
-  { name: "Joel", initialBudget: 73 },
+  { name: "Russini Panini", initialBudget: 417, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Ed", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Brent", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Joey", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "MaKayla", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Ty", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Kich", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Eric", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Collin", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Roy", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Blaine", initialBudget: 71, initialSlots: DEFAULT_INITIAL_SLOTS },
+  { name: "Joel", initialBudget: 73, initialSlots: DEFAULT_INITIAL_SLOTS },
 ];
 
 // ── Seed rookie pool ────────────────────────────────────────────────────
@@ -129,6 +191,52 @@ export const DEFAULT_ROOKIES = [
   { rank: 72, name: "Aaron Anderson", preDraft: 1 },
 ];
 
+/**
+ * Count per-team rookie pick ownership from the raw ``picks`` array
+ * returned by ``/api/draft-capital``.  Each pick's ``currentOwner``
+ * (a team display name) contributes +1 to that team's slot count.
+ *
+ * Returns a ``Map<teamNameLowerCase, count>``.  Callers should resolve
+ * the map against their own team list by lowercased name.
+ */
+export function slotsByTeamFromPicks(picksArray) {
+  const out = new Map();
+  if (!Array.isArray(picksArray)) return out;
+  for (const pk of picksArray) {
+    const owner = String(pk?.currentOwner || "").trim().toLowerCase();
+    if (!owner) continue;
+    out.set(owner, (out.get(owner) || 0) + 1);
+  }
+  return out;
+}
+
+/**
+ * Slot-adjusted effective budget — the maximum $ a team can actually
+ * bid on a single player right now, reserving $1 per OTHER remaining
+ * slot so they can still fill their roster.  This is the number that
+ * belongs in ``topCompetitorMax`` — the mean or even max of raw
+ * remaining $ overstates real bidding power for teams with many
+ * slots to fill.
+ *
+ *   effectiveBudget = 0 if slotsRemaining <= 0
+ *                   = max(0, remaining − max(0, slotsRemaining − 1))
+ *
+ * Examples:
+ *   (remaining 100, slots 3) → bid up to $98, reserve $1 × 2
+ *   (remaining 5, slots 5)  → bid up to $1, reserve $1 × 4
+ *   (remaining 50, slots 0) → 0 (team has no roster space left)
+ *   (remaining 0, slots 1)  → 0 (team can only bid $1 min, but
+ *                             the conventional "0 means can't
+ *                             bid more than $1" is noise; explicit
+ *                             0 in the UI is clearer)
+ */
+export function effectiveBudgetFor(remaining, slotsRemaining) {
+  const rem = Math.max(0, Number(remaining) || 0);
+  const slots = Math.max(0, Number(slotsRemaining) || 0);
+  if (slots <= 0) return 0;
+  return Math.max(0, rem - Math.max(0, slots - 1));
+}
+
 // ── Player ID slug ──────────────────────────────────────────────────────
 /**
  * Produce a stable slug from a player name.  Used as the key on picks
@@ -163,30 +271,36 @@ export function createDefaultWorkspace() {
       name: p.name,
       preDraft: p.preDraft,
     })),
-    picks: [], // { playerId, teamIdx, amount, ts }
+    // picks: { playerId, teamIdx, amount, preDraftAtPick, ts }
+    //   - preDraftAtPick: snapshot of the PreDraft $ at the moment the
+    //     pick was recorded.  Used for historical tier inflation so a
+    //     retroactive edit to ``players[n].preDraft`` doesn't corrupt
+    //     the paid/expected ratios of already-drafted players.
+    picks: [],
   };
 }
 
 // ── Derived stats ───────────────────────────────────────────────────────
 /**
- * Compute every derived value the UI renders from a workspace.  All
- * money values are rounded to the nearest whole dollar; the sheet
- * rounds in the same places so the display matches.
+ * Compute every derived value the UI renders from a workspace.
  *
- * Returns:
- *   totalBudget, totalSpent, remainingLeague, myTeamName,
- *   myStarting, mySpent, myRemaining, otherTeamsRemaining,
- *   avgPerOtherTeam, budgetAdvantage, undraftedPreDraft, inflation,
- *   leagueSpentPct, teamStats[], enrichedPlayers[]
+ * Tier 1 return shape adds (beyond the sheet-port baseline):
  *
- * ``enrichedPlayers`` carries, per row:
- *   id, rank, name, preDraft, pick (|| null), drafted (bool),
- *   mine (bool), inflatedFair, myMaxBid, enforceUpTo, valueVsFair
+ *   slotPressure          0..1 — how far through my own draft I am
+ *   phaseMultiplier       1 + slotPressure × PHASE_LATE_BOOST
+ *   topCompetitorMax      slot-adjusted max effective $ of any OTHER team
+ *   tierHeat              { S/A/B/C/D: paidSum/preDraftSum or null }
+ *   tierConfidence        { S/A/B/C/D: 0..1 } — sample-size weight
+ *   teamStats[i]          + initialSlots, slotsDrafted, slotsRemaining,
+ *                           effectiveBudget
+ *   enrichedPlayers[p]    + tier, tierInflation, theoreticalMaxBid,
+ *                           myWinningBid, exceedsMyCeiling
  *
- * Undrafted rows get live inflation + max-bid; drafted rows get
- * ``valueVsFair`` = InflatedFairAtDraftTime − pick.amount (approx; we
- * use current inflation as the fair-price proxy since the sheet does
- * the same when its history snapshot is current).
+ *   myMaxBid now carries the THEORETICAL ceiling (what you'd be
+ *   willing to pay if the competitor set demanded it).  Actual
+ *   bid-to-win is ``myWinningBid`` = min(myMaxBid, topCompetitorMax+1).
+ *   The UI should surface myWinningBid as the headline figure and
+ *   myMaxBid as the tooltip explainer.
  */
 export function computeDraftStats(workspace) {
   const ws = workspace || createDefaultWorkspace();
@@ -204,9 +318,7 @@ export function computeDraftStats(workspace) {
     ? settings.enforcePct
     : DEFAULT_ENFORCE_PCT;
 
-  // League-wide money accounting.  ``initialBudget`` is the PER-TEAM
-  // entrance budget — for carry-over leagues this varies by team, so
-  // we sum to get ``totalBudget`` rather than assuming uniform split.
+  // League-wide money accounting.
   const totalBudget = teams.reduce(
     (s, t) => s + (Number(t.initialBudget) || 0),
     0,
@@ -218,21 +330,80 @@ export function computeDraftStats(workspace) {
   const remainingLeague = Math.max(0, totalBudget - totalSpent);
 
   // My team's money.
-  const myTeam = teams[myTeamIdx] || { name: "", initialBudget: 0 };
+  const myTeam = teams[myTeamIdx] || {
+    name: "",
+    initialBudget: 0,
+    initialSlots: DEFAULT_INITIAL_SLOTS,
+  };
   const myStarting = Number(myTeam.initialBudget) || 0;
   const mySpent = picks
     .filter((p) => p.teamIdx === myTeamIdx)
     .reduce((s, p) => s + (Number(p.amount) || 0), 0);
   const myRemaining = Math.max(0, myStarting - mySpent);
 
-  // Other teams' money (aggregate).  Used for the budget-advantage
-  // factor — the sheet divides the aggregate by (teams − 1) rather
-  // than weighting per-team, which is what we mirror here.
+  // ── Slot accounting ────────────────────────────────────────────────
+  // Per-team slots drafted + remaining.  ``initialSlots`` is set on
+  // the team when ``/api/draft-capital`` merges; absent that, we
+  // fall back to the 6-round default so pre-merge state still works.
+  const picksByTeam = teams.map(() => []);
+  for (const pk of picks) {
+    if (
+      Number.isInteger(pk.teamIdx) &&
+      pk.teamIdx >= 0 &&
+      pk.teamIdx < teams.length
+    ) {
+      picksByTeam[pk.teamIdx].push(pk);
+    }
+  }
+  const initialSlotsByIdx = teams.map((t) =>
+    Number.isFinite(Number(t?.initialSlots))
+      ? Math.max(0, Number(t.initialSlots))
+      : DEFAULT_INITIAL_SLOTS,
+  );
+  const slotsDraftedByIdx = picksByTeam.map((pks) => pks.length);
+  const slotsRemainingByIdx = teams.map((_, i) =>
+    Math.max(0, initialSlotsByIdx[i] - slotsDraftedByIdx[i]),
+  );
+  const remainingByIdx = teams.map((t, i) => {
+    const spent = picksByTeam[i].reduce(
+      (s, p) => s + (Number(p.amount) || 0),
+      0,
+    );
+    return Math.max(0, (Number(t.initialBudget) || 0) - spent);
+  });
+  const effectiveBudgetByIdx = teams.map((_, i) =>
+    effectiveBudgetFor(remainingByIdx[i], slotsRemainingByIdx[i]),
+  );
+
+  // My slot pressure drives the phase multiplier: at the start
+  // pressure=0 and MaxBid is unchanged; at my final pick pressure=1
+  // and MaxBid scales up by (1 + PHASE_LATE_BOOST).  This prevents
+  // the "unused $ is wasted $" failure mode when I'm wealthy but
+  // only have one roster slot left.
+  const myInitialSlots = initialSlotsByIdx[myTeamIdx] || 0;
+  const mySlotsRemaining = slotsRemainingByIdx[myTeamIdx] || 0;
+  const slotPressure =
+    myInitialSlots > 0
+      ? Math.max(0, Math.min(1, 1 - mySlotsRemaining / myInitialSlots))
+      : 0;
+  const phaseMultiplier = 1 + slotPressure * PHASE_LATE_BOOST;
+
+  // Top competitor ceiling: the single richest OTHER team, after
+  // slot adjustment.  This is the real "ceiling I need to clear" on
+  // any given player — bidding 1 above it wins.  Without this cap,
+  // MaxBid hallucinates opponents that can't actually outbid me.
+  let topCompetitorMax = 0;
+  for (let i = 0; i < effectiveBudgetByIdx.length; i++) {
+    if (i === myTeamIdx) continue;
+    if (effectiveBudgetByIdx[i] > topCompetitorMax) {
+      topCompetitorMax = effectiveBudgetByIdx[i];
+    }
+  }
+
+  // Other teams' money (aggregate).
   const otherTeamsRemaining = Math.max(0, remainingLeague - myRemaining);
   const otherTeamCount = Math.max(1, teams.length - 1);
   const avgPerOtherTeam = otherTeamsRemaining / otherTeamCount;
-  // Guard: divide-by-zero when every other team is tapped.  Fall back
-  // to "no advantage" (1.0) so MyMaxBid stays at PreDraft × Inflation.
   const rawBudgetAdvantage =
     avgPerOtherTeam > 0 ? myRemaining / avgPerOtherTeam : 1;
   // The sheet displays BAF at 2dp (e.g. 5.85) and uses THAT truncated
@@ -242,42 +413,92 @@ export function computeDraftStats(workspace) {
   // cell-for-cell.
   const budgetAdvantage = Math.floor(rawBudgetAdvantage * 100) / 100;
 
-  // Inflation denominator: the sheet uses ``TotalAuction$ − Σ (sold
-  // players' preDraft $)`` rather than the dynamic sum of undrafted
-  // preDraft values.  The difference matters when the preDraft column
-  // doesn't sum to exactly ``totalBudget`` — which is the common case,
-  // because users tune preDraft values for *relative* player worth and
-  // those don't have to land on the budget total.  Using ``totalBudget``
-  // as the baseline keeps the opening inflation pinned at 1.0 so Fair
-  // Price == PreDraft$ at the start regardless of column-sum drift,
-  // matching the sheet cell-for-cell.
+  // ── Global inflation (sheet-compatible) ────────────────────────────
+  // inflation = remainingLeague / (totalBudget − soldPreDraft).
+  // soldPreDraft uses the SNAPSHOTTED preDraftAtPick on each pick so a
+  // retroactive edit to player.preDraft doesn't rewrite history.
   const pickedPlayerIds = new Set(picks.map((p) => p.playerId));
   const playerPreDraftById = new Map(
     players.map((p) => [p.id, Number(p.preDraft) || 0]),
   );
-  const soldPreDraft = picks.reduce(
-    (s, pk) => s + (playerPreDraftById.get(pk.playerId) || 0),
-    0,
-  );
+  const soldPreDraft = picks.reduce((s, pk) => {
+    const snap = Number.isFinite(Number(pk.preDraftAtPick))
+      ? Math.max(0, Number(pk.preDraftAtPick))
+      : playerPreDraftById.get(pk.playerId) || 0;
+    return s + snap;
+  }, 0);
   const expectedPoolRemaining = Math.max(1, totalBudget - soldPreDraft);
   const inflation = remainingLeague / expectedPoolRemaining;
 
-  // Kept for the "Board $ left" display card.  This is the literal sum
-  // of still-on-the-board preDraft values — different from the
-  // inflation denominator above when the column doesn't sum to budget.
+  // Kept for the "Board $ left" display card.
   const undraftedPreDraft = players
     .filter((p) => !pickedPlayerIds.has(p.id))
     .reduce((s, p) => s + (Number(p.preDraft) || 0), 0);
   const leagueSpentPct = totalBudget > 0 ? totalSpent / totalBudget : 0;
 
-  // Per-team stats (name, initial, spent, remaining).
+  // ── Per-tier inflation (heat) ─────────────────────────────────────
+  // tier_heat(T) = Σ paid / Σ preDraftAtPick within tier T.
+  // Above 1.0 → tier was overpaid; remaining T players should mark up.
+  // Below 1.0 → tier bargains; remaining T players mark down.
+  //
+  // Blended with 1.0 via a confidence weight based on sample count,
+  // then multiplied on top of global inflation to produce
+  // ``tierInflation`` (the actual modifier applied to fair/max bids).
+  const tierHeat = {};
+  const tierConfidence = {};
+  const tierSampleCount = {};
+  for (const def of TIER_DEFS) {
+    const tierPicks = picks.filter((pk) => {
+      const snap = Number.isFinite(Number(pk.preDraftAtPick))
+        ? Math.max(0, Number(pk.preDraftAtPick))
+        : playerPreDraftById.get(pk.playerId) || 0;
+      return tierForPreDraft(snap) === def.key;
+    });
+    tierSampleCount[def.key] = tierPicks.length;
+    if (tierPicks.length === 0) {
+      tierHeat[def.key] = null;
+      tierConfidence[def.key] = 0;
+      continue;
+    }
+    const paidSum = tierPicks.reduce(
+      (s, pk) => s + (Number(pk.amount) || 0),
+      0,
+    );
+    const preSum = tierPicks.reduce((s, pk) => {
+      const snap = Number.isFinite(Number(pk.preDraftAtPick))
+        ? Math.max(0, Number(pk.preDraftAtPick))
+        : playerPreDraftById.get(pk.playerId) || 0;
+      return s + snap;
+    }, 0);
+    tierHeat[def.key] = preSum > 0 ? paidSum / preSum : 1;
+    tierConfidence[def.key] = Math.min(
+      1,
+      tierPicks.length / TIER_CONFIDENCE_MIN_SAMPLES,
+    );
+  }
+
+  // Resolve the effective tier multiplier for any PreDraft $.
+  // At full confidence, this is tier_heat.  At zero confidence
+  // (no tier picks yet), this is 1.0 (no tier adjustment beyond
+  // global inflation).  The final per-player inflation applied to
+  // fair price and max bid is ``inflation × effectiveTierMult``.
+  function effectiveTierMultFor(preDraft) {
+    const tier = tierForPreDraft(preDraft);
+    const heat = tierHeat[tier];
+    const conf = tierConfidence[tier];
+    if (heat == null || conf <= 0) return 1;
+    return conf * heat + (1 - conf) * 1;
+  }
+
+  // Per-team stats (name, initial, spent, remaining, slots, eff$).
   const teamStats = teams.map((t, idx) => {
-    const spent = picks
-      .filter((p) => p.teamIdx === idx)
-      .reduce((s, p) => s + (Number(p.amount) || 0), 0);
+    const spent = picksByTeam[idx].reduce(
+      (s, p) => s + (Number(p.amount) || 0),
+      0,
+    );
     const initial = Number(t.initialBudget) || 0;
-    const remaining = Math.max(0, initial - spent);
-    const picksCount = picks.filter((p) => p.teamIdx === idx).length;
+    const remaining = remainingByIdx[idx];
+    const picksCount = picksByTeam[idx].length;
     return {
       idx,
       name: t.name || `Team ${idx + 1}`,
@@ -286,6 +507,10 @@ export function computeDraftStats(workspace) {
       remaining,
       picksCount,
       isMine: idx === myTeamIdx,
+      initialSlots: initialSlotsByIdx[idx],
+      slotsDrafted: slotsDraftedByIdx[idx],
+      slotsRemaining: slotsRemainingByIdx[idx],
+      effectiveBudget: effectiveBudgetByIdx[idx],
     };
   });
 
@@ -296,14 +521,28 @@ export function computeDraftStats(workspace) {
   const enrichedPlayers = players.map((p) => {
     const pick = pickByPlayer.get(p.id) || null;
     const preDraft = Math.max(0, Number(p.preDraft) || 0);
-    // The sheet truncates (FLOOR) these derived dollar values rather
-    // than rounding — matching that is the difference between
-    // "MaxBid 193" (sheet) vs "MaxBid 194" (round).  Keeping the UI
-    // cell-for-cell identical to the sheet means the user can trust
-    // that the two views agree.
-    const inflatedFair = Math.floor(preDraft * inflation);
-    const myMaxBid = Math.floor(
-      preDraft * (1 + aggression * (budgetAdvantage - 1)) * inflation,
+    const tier = tierForPreDraft(preDraft);
+    const tierMult = effectiveTierMultFor(preDraft);
+    const combinedInflation = inflation * tierMult;
+
+    // The sheet truncates (FLOOR) these derived dollar values.
+    // We keep FLOOR for parity so numbers match the user's manual
+    // sheet when both are in view.
+    const inflatedFair = Math.floor(preDraft * combinedInflation);
+    const theoreticalMaxBid = Math.floor(
+      preDraft *
+        (1 + aggression * (budgetAdvantage - 1)) *
+        combinedInflation *
+        phaseMultiplier,
+    );
+    // My winning bid = cap theoretical max at "what I need to beat"
+    // (top competitor's slot-adjusted budget + 1).  If no one else
+    // can bid (everyone bankrupt), winning bid collapses to 1.
+    const competitorCeiling = Math.max(0, topCompetitorMax);
+    const winByCompetitor = Math.max(1, competitorCeiling + 1);
+    const myWinningBid = Math.max(
+      0,
+      Math.min(theoreticalMaxBid, winByCompetitor),
     );
     const enforceUpTo = Math.floor(inflatedFair * enforcePct);
     const drafted = !!pick;
@@ -315,11 +554,15 @@ export function computeDraftStats(workspace) {
     return {
       ...p,
       preDraft,
+      tier,
+      tierInflation: combinedInflation,
       pick,
       drafted,
       mine,
       inflatedFair: Math.max(0, inflatedFair),
-      myMaxBid: Math.max(0, myMaxBid),
+      myMaxBid: Math.max(0, theoreticalMaxBid),
+      theoreticalMaxBid: Math.max(0, theoreticalMaxBid),
+      myWinningBid,
       enforceUpTo: Math.max(0, enforceUpTo),
       valueVsFair,
     };
@@ -333,12 +576,20 @@ export function computeDraftStats(workspace) {
     myStarting,
     mySpent,
     myRemaining,
+    myInitialSlots,
+    mySlotsRemaining,
+    slotPressure,
+    phaseMultiplier,
+    topCompetitorMax,
     otherTeamsRemaining,
     avgPerOtherTeam,
     budgetAdvantage,
     undraftedPreDraft,
     inflation,
     leagueSpentPct,
+    tierHeat,
+    tierConfidence,
+    tierSampleCount,
     teamStats,
     enrichedPlayers,
   };
@@ -347,14 +598,30 @@ export function computeDraftStats(workspace) {
 // ── State mutators (pure) ───────────────────────────────────────────────
 /**
  * Record a draft pick.  Returns a new workspace; does not mutate.
- * If the player is already drafted, the pick is replaced (so an edit
- * is a no-op record-the-same-pick call).
+ *
+ * Snapshots ``preDraftAtPick`` at record time so historical tier
+ * inflation remains accurate even if the user later edits the
+ * player's PreDraft $ inline.  Without the snapshot, a retroactive
+ * PreDraft edit would silently rewrite what the market "looked
+ * like" when the pick landed — corrupting every downstream
+ * paid-vs-expected diagnostic.
+ *
+ * If the player is already drafted, the pick is REPLACED (edit
+ * flow) and the snapshot refreshes to the current PreDraft value.
  */
 export function recordPick(workspace, { playerId, teamIdx, amount }) {
   if (!playerId || !Number.isInteger(teamIdx)) return workspace;
   const amt = Math.max(0, Number(amount) || 0);
   const picks = (workspace.picks || []).filter((p) => p.playerId !== playerId);
-  picks.push({ playerId, teamIdx, amount: amt, ts: Date.now() });
+  const player = (workspace.players || []).find((p) => p.id === playerId);
+  const preDraftAtPick = Math.max(0, Number(player?.preDraft) || 0);
+  picks.push({
+    playerId,
+    teamIdx,
+    amount: amt,
+    preDraftAtPick,
+    ts: Date.now(),
+  });
   return { ...workspace, picks };
 }
 
@@ -444,6 +711,16 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
   const ws = workspace || createDefaultWorkspace();
   const existing = Array.isArray(ws.teams) ? ws.teams : [];
   const feed = Array.isArray(teamTotals) ? teamTotals : [];
+  // Optional: raw ``picks`` array from the /api/draft-capital
+  // response.  When provided, per-team rookie pick counts are set
+  // as ``initialSlots`` on every matched/appended team so the
+  // effective-budget math downstream is accurate.  Absent this
+  // (e.g. teamTotals passed alone), teams keep their existing
+  // ``initialSlots`` or fall back to the DEFAULT_INITIAL_SLOTS.
+  const picksArray = Array.isArray(opts.picks) ? opts.picks : null;
+  const slotsByKey = picksArray
+    ? slotsByTeamFromPicks(picksArray)
+    : new Map();
 
   // Build a case-insensitive lookup from the feed.
   const feedByKey = new Map();
@@ -483,6 +760,28 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
     ]),
   );
 
+  // Build a team row with feed-aware ``initialSlots``.  When the
+  // picks array is present, the slot count is authoritative.  When
+  // it's not (no picks opts passed), we keep whatever ``initialSlots``
+  // the existing team carried, falling back to the default.
+  const buildTeam = (nameOut, budget, prior) => {
+    const slotKey = String(nameOut || "").toLowerCase();
+    const feedSlots = slotsByKey.get(slotKey);
+    const priorSlots = Number.isFinite(Number(prior?.initialSlots))
+      ? Math.max(0, Number(prior.initialSlots))
+      : DEFAULT_INITIAL_SLOTS;
+    const initialSlots = picksArray
+      ? Number.isFinite(feedSlots)
+        ? feedSlots
+        : 0
+      : priorSlots;
+    return {
+      name: nameOut,
+      initialBudget: budget,
+      initialSlots,
+    };
+  };
+
   const usedFeedKeys = new Set();
   const zeroed = [];
   const merged = [];
@@ -491,10 +790,8 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
     const hit = feedByKey.get(key);
     if (hit) {
       usedFeedKeys.add(key);
-      merged.push({
-        name: preserveNames && t.name ? t.name : hit.name,
-        initialBudget: hit.auctionDollars,
-      });
+      const nameOut = preserveNames && t.name ? t.name : hit.name;
+      merged.push(buildTeam(nameOut, hit.auctionDollars, t));
       continue;
     }
     // Drop unmatched default placeholders; zero out unmatched user-
@@ -506,7 +803,7 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
       continue;
     }
     zeroed.push(t.name);
-    merged.push({ name: t.name || "", initialBudget: 0 });
+    merged.push(buildTeam(t.name || "", 0, t));
   }
 
   // Append any feed teams not already on the board.  These are the
@@ -515,7 +812,7 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
   const missing = [];
   for (const [key, hit] of feedByKey.entries()) {
     if (usedFeedKeys.has(key)) continue;
-    merged.push({ name: hit.name, initialBudget: hit.auctionDollars });
+    merged.push(buildTeam(hit.name, hit.auctionDollars, null));
     missing.push(hit.name);
   }
 
@@ -609,30 +906,73 @@ export function hydrateWorkspace(parsed) {
       ? parsed.teams.map((t, i) => ({
           name: String(t?.name || `Team ${i + 1}`),
           initialBudget: Math.max(0, Number(t?.initialBudget) || 0),
+          initialSlots: Number.isFinite(Number(t?.initialSlots))
+            ? Math.max(0, Number(t.initialSlots))
+            : DEFAULT_INITIAL_SLOTS,
         }))
       : def.teams,
-    players: Array.isArray(parsed.players) && parsed.players.length > 0
-      ? parsed.players.map((p, i) => ({
-          id: String(p?.id || playerSlug(p?.name) || `player-${i}`),
-          rank: Number(p?.rank) || i + 1,
-          name: String(p?.name || ""),
-          preDraft: Math.max(0, Number(p?.preDraft) || 0),
-        }))
-      : def.players,
+    players: (() => {
+      const src =
+        Array.isArray(parsed.players) && parsed.players.length > 0
+          ? parsed.players
+          : null;
+      if (!src) return def.players;
+      return src.map((p, i) => ({
+        id: String(p?.id || playerSlug(p?.name) || `player-${i}`),
+        rank: Number(p?.rank) || i + 1,
+        name: String(p?.name || ""),
+        preDraft: Math.max(0, Number(p?.preDraft) || 0),
+      }));
+    })(),
     picks: Array.isArray(parsed.picks)
-      ? parsed.picks
-          .map((p) => ({
-            playerId: String(p?.playerId || ""),
-            teamIdx: Number.isInteger(p?.teamIdx) ? p.teamIdx : -1,
-            amount: Math.max(0, Number(p?.amount) || 0),
-            ts: Number(p?.ts) || Date.now(),
-          }))
-          .filter((p) => p.playerId && p.teamIdx >= 0)
+      ? (() => {
+          // Build a playerId → current preDraft fallback map so old
+          // localStorage state (pre-Tier-1, no preDraftAtPick snapshot)
+          // hydrates with SOMETHING reasonable rather than 0.  Preference
+          // order: stored snapshot → current player preDraft → 0.
+          const playerSrc =
+            Array.isArray(parsed.players) && parsed.players.length > 0
+              ? parsed.players
+              : def.players;
+          const preDraftById = new Map();
+          for (const p of playerSrc) {
+            const id = String(p?.id || playerSlug(p?.name) || "");
+            if (!id) continue;
+            preDraftById.set(
+              id,
+              Math.max(0, Number(p?.preDraft) || 0),
+            );
+          }
+          return parsed.picks
+            .map((p) => {
+              const pid = String(p?.playerId || "");
+              const storedSnap = Number.isFinite(Number(p?.preDraftAtPick))
+                ? Math.max(0, Number(p.preDraftAtPick))
+                : null;
+              const fallback = preDraftById.get(pid) ?? 0;
+              return {
+                playerId: pid,
+                teamIdx: Number.isInteger(p?.teamIdx) ? p.teamIdx : -1,
+                amount: Math.max(0, Number(p?.amount) || 0),
+                preDraftAtPick: storedSnap != null ? storedSnap : fallback,
+                ts: Number(p?.ts) || Date.now(),
+              };
+            })
+            .filter((p) => p.playerId && p.teamIdx >= 0);
+        })()
       : [],
   };
 }
 
-/** Bid-status classification for UI color coding. */
+/**
+ * Bid-status classification for UI color coding.
+ *
+ * Uses ``myWinningBid`` (the competitor-ceiling-capped value) as the
+ * PASS threshold.  Bidding above that is strictly wasteful because
+ * no rival could match — any $1 above top competitor locks the
+ * player.  Falls back to ``myMaxBid`` when winningBid isn't present
+ * (old enriched-player shapes without Tier 1 fields).
+ */
 export function bidStatus(enrichedPlayer, currentBid) {
   if (!enrichedPlayer) return { level: "unknown", label: "" };
   if (enrichedPlayer.drafted) {
@@ -641,7 +981,16 @@ export function bidStatus(enrichedPlayer, currentBid) {
   }
   const bid = Math.max(0, Number(currentBid) || 0);
   if (bid <= 0) return { level: "idle", label: "Watching" };
+  const ceiling = Number.isFinite(enrichedPlayer.myWinningBid)
+    ? enrichedPlayer.myWinningBid
+    : enrichedPlayer.myMaxBid;
+  // Check ceiling FIRST: if the bid would win by more than $1 against
+  // the true competitor ceiling, it's overpay territory regardless of
+  // where the enforce threshold sits.  This matters when poor
+  // competitors push ``myWinningBid`` well below ``enforceUpTo``
+  // (rich-vs-bankrupt scenario) — pushing to enforce would
+  // overpay by $ you don't need to spend.
+  if (bid > ceiling) return { level: "pass", label: "Pass" };
   if (bid <= enrichedPlayer.enforceUpTo) return { level: "push", label: "Push up" };
-  if (bid <= enrichedPlayer.myMaxBid) return { level: "target", label: "Sweet spot" };
-  return { level: "pass", label: "Pass" };
+  return { level: "target", label: "Sweet spot" };
 }


### PR DESCRIPTION
## Summary
Tier 1 of the draft dashboard audit — five quant fixes that take /draft from a spreadsheet clone to a decision engine. Pre-Tier-1 the board overpaid in three scenarios (bankrupt rivals, late-draft surplus budget, stars-only market) and reported aggregate inflation everywhere regardless of which tier was hot. This ships the math + the UI to see it.

## What changed

| Fix | Impact |
|---|---|
| **Top competitor ceiling** (slot-adjusted) → ``myWinningBid = min(theoreticalMax, topCompetitorMax + 1)`` | Stops the "bankrupt opponent overpay" failure. When rivals are maxed at $5, the board tells you to pay $6, not $150. |
| **Slot accounting** from ``/api/draft-capital``'s picks array → ``initialSlots`` per team | Effective budgets now reserve $1 per remaining slot. A $200 team with 10 slots can only bid $191, not $200. |
| **Phase multiplier** = 1 + slotPressure × 0.5 | MaxBid ramps from 1.0× at draft start to 1.5× at my last pick. Unused $ at end-of-draft stops being wasted $. |
| **Per-tier inflation** (S/A/B/C/D buckets) with confidence blending | Elite-tier overpays mark UP remaining S-tier prices independently; cheap-tier bargain action doesn't pollute top-tier projections. |
| **``preDraftAtPick`` snapshots** on every pick | Retroactive PreDraft edits only affect undrafted rows. Tier heat + global inflation stay historically accurate. |

## UI surfacing
- Stats strip gains **Top rival ceiling** and **Phase** cards; inflation + rival ceiling color-code on thresholds
- Teams panel gains **Slots (drafted/initial)** and **Eff $** columns
- Rookie board gains **Tier** chip and **Win at** column (vs. theoretical Max Bid)
- Draft modal shows overpay warning + red Record button when recording a pick on MY team above ``myWinningBid``
- ``bidStatus``: pass-beats-push semantics so "bid above ceiling" always reads PASS

## Tests
- [x] ``npx vitest run __tests__/draft-logic.test.js`` — 86/86 pass (30 new cases)
- [x] Full frontend suite — 572/574 pass (2 pre-existing ``dynasty-data.test.js/rankHistory`` failures unrelated, verified via git stash)
- [x] ``npm run build`` — clean production build

## Failure modes fixed
- Bankrupt-rival overpay: winning bid collapses to $1 when every rival is out of effective $
- Late-draft budget waste: phase multiplier forces aggression as slots drain
- Tier signal blindness: S-tier heat no longer hidden inside aggregate inflation
- Retroactive PreDraft edits corrupting history: snapshots lock in tier heat at pick time

## Rollout notes
- Old localStorage states still load; ``preDraftAtPick`` backfills from current player value on hydrate, ``initialSlots`` defaults to 6
- Schema version stays at 1 (additive fields only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)