### PR TITLE
Draft Tier 2: tags, recommendations, Next Best Targets, bid simulator

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -1056,3 +1056,340 @@ describe("hydrateWorkspace — Tier 1 field backfill", () => {
     expect(ws.teams[0].initialSlots).toBe(DEFAULT_INITIAL_SLOTS);
   });
 });
+
+// ── Tier 2 ──────────────────────────────────────────────────────────────
+
+import {
+  TAG_TARGET,
+  TAG_AVOID,
+  TIER_SCARCITY_URGENT,
+  cycleTag,
+  nextBestTargets,
+  playerRecommendation,
+  setPlayerTag,
+} from "@/lib/draft-logic";
+
+describe("cycleTag", () => {
+  it("cycles neutral → target → avoid → neutral", () => {
+    expect(cycleTag(null)).toBe(TAG_TARGET);
+    expect(cycleTag(undefined)).toBe(TAG_TARGET);
+    expect(cycleTag(TAG_TARGET)).toBe(TAG_AVOID);
+    expect(cycleTag(TAG_AVOID)).toBe(null);
+  });
+});
+
+describe("setPlayerTag", () => {
+  it("writes target/avoid and clears on anything else", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const tagged = setPlayerTag(ws, love.id, TAG_TARGET);
+    expect(tagged.tags[love.id]).toBe(TAG_TARGET);
+    const cleared = setPlayerTag(tagged, love.id, null);
+    expect(cleared.tags[love.id]).toBeUndefined();
+    const avoided = setPlayerTag(ws, love.id, TAG_AVOID);
+    expect(avoided.tags[love.id]).toBe(TAG_AVOID);
+  });
+
+  it("does not mutate the input workspace", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const result = setPlayerTag(ws, love.id, TAG_TARGET);
+    expect(ws.tags[love.id]).toBeUndefined();
+    expect(result.tags[love.id]).toBe(TAG_TARGET);
+  });
+
+  it("no-op when playerId is empty", () => {
+    const ws = createDefaultWorkspace();
+    expect(setPlayerTag(ws, "", TAG_TARGET)).toBe(ws);
+  });
+});
+
+describe("hydrateWorkspace — tags roundtrip", () => {
+  it("preserves valid target/avoid tags", () => {
+    const ws = createDefaultWorkspace();
+    const tagged = setPlayerTag(
+      setPlayerTag(ws, "jeremiyah-love", TAG_TARGET),
+      "drew-allar",
+      TAG_AVOID,
+    );
+    const roundtripped = hydrateWorkspace(
+      JSON.parse(JSON.stringify(tagged)),
+    );
+    expect(roundtripped.tags["jeremiyah-love"]).toBe(TAG_TARGET);
+    expect(roundtripped.tags["drew-allar"]).toBe(TAG_AVOID);
+  });
+
+  it("drops invalid tag values", () => {
+    const parsed = {
+      version: 1,
+      settings: {},
+      teams: DEFAULT_TEAMS,
+      players: DEFAULT_ROOKIES.map((p) => ({
+        id: playerSlug(p.name),
+        rank: p.rank,
+        name: p.name,
+        preDraft: p.preDraft,
+      })),
+      picks: [],
+      tags: {
+        "jeremiyah-love": "target",
+        "carnell-tate": "bogus",
+        "makai-lemon": null,
+      },
+    };
+    const ws = hydrateWorkspace(parsed);
+    expect(ws.tags["jeremiyah-love"]).toBe(TAG_TARGET);
+    expect(ws.tags["carnell-tate"]).toBeUndefined();
+    expect(ws.tags["makai-lemon"]).toBeUndefined();
+  });
+});
+
+// ── tierStats ───────────────────────────────────────────────────────────
+
+describe("computeDraftStats — tierStats", () => {
+  it("reports totals per tier at draft start", () => {
+    const stats = computeDraftStats(createDefaultWorkspace());
+    // DEFAULT_ROOKIES distribution:
+    //   S (≥60): Love(135), Mendoza(102), Lemon(90), Tate(83),
+    //            Tyson(73), Styles(66), Downs(61) → 7
+    //   A (25-59): Sadiq, McNeil-Warren, Thieneman, Bailey,
+    //              Reese, CJ Allen, Concepcion, Cooper → 8 (sanity via ≥25 && <60)
+    //   ...
+    // Just sanity-check shape + totals sum to 72.
+    const totalAcrossTiers = Object.values(stats.tierStats).reduce(
+      (s, t) => s + t.total,
+      0,
+    );
+    expect(totalAcrossTiers).toBe(72);
+    expect(stats.tierStats.S.total).toBeGreaterThan(0);
+    expect(stats.tierStats.S.remaining).toBe(stats.tierStats.S.total);
+    expect(stats.tierStats.S.remainingRatio).toBe(1);
+  });
+
+  it("tracks drafted / remaining as picks land", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 5,
+      amount: 135,
+    });
+    const stats = computeDraftStats(withPick);
+    const sBefore = computeDraftStats(ws).tierStats.S;
+    expect(stats.tierStats.S.drafted).toBe(1);
+    expect(stats.tierStats.S.remaining).toBe(sBefore.total - 1);
+    expect(stats.tierStats.S.remainingRatio).toBeCloseTo(
+      (sBefore.total - 1) / sBefore.total,
+      4,
+    );
+  });
+});
+
+describe("computeDraftStats — draftProgress", () => {
+  it("starts at 0 and climbs with picks", () => {
+    const ws = createDefaultWorkspace();
+    const s0 = computeDraftStats(ws);
+    expect(s0.draftProgress).toBe(0);
+    expect(s0.totalInitialSlots).toBe(12 * DEFAULT_INITIAL_SLOTS);
+
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 0,
+      amount: 135,
+    });
+    const s1 = computeDraftStats(withPick);
+    expect(s1.totalPicksMade).toBe(1);
+    expect(s1.draftProgress).toBeCloseTo(1 / 72, 4);
+  });
+});
+
+describe("enrichedPlayers carry userTag", () => {
+  it("reflects target/avoid/null per player", () => {
+    let ws = createDefaultWorkspace();
+    ws = setPlayerTag(ws, "jeremiyah-love", TAG_TARGET);
+    ws = setPlayerTag(ws, "drew-allar", TAG_AVOID);
+    const stats = computeDraftStats(ws);
+    const love = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    const allar = stats.enrichedPlayers.find(
+      (p) => p.name === "Drew Allar",
+    );
+    const tate = stats.enrichedPlayers.find(
+      (p) => p.name === "Carnell Tate",
+    );
+    expect(love.userTag).toBe(TAG_TARGET);
+    expect(allar.userTag).toBe(TAG_AVOID);
+    expect(tate.userTag).toBeNull();
+  });
+});
+
+// ── playerRecommendation ────────────────────────────────────────────────
+
+describe("playerRecommendation", () => {
+  it("returns null for drafted players", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 0,
+      amount: 120,
+    });
+    const stats = computeDraftStats(withPick);
+    const lovePost = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    expect(playerRecommendation(lovePost, stats)).toBeNull();
+  });
+
+  it("AVOID tag always returns level 'avoid'", () => {
+    let ws = createDefaultWorkspace();
+    ws = setPlayerTag(ws, "jeremiyah-love", TAG_AVOID);
+    const stats = computeDraftStats(ws);
+    const love = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    const rec = playerRecommendation(love, stats);
+    expect(rec.level).toBe("avoid");
+  });
+
+  it("neutral tag = no recommendation (level 'neutral')", () => {
+    const stats = computeDraftStats(createDefaultWorkspace());
+    const tate = stats.enrichedPlayers.find(
+      (p) => p.name === "Carnell Tate",
+    );
+    const rec = playerRecommendation(tate, stats);
+    expect(rec.level).toBe("neutral");
+  });
+
+  it("LOCK when rivals are bankrupt and player is a target", () => {
+    let ws = createDefaultWorkspace();
+    // Zero every rival's budget so topCompetitorMax == 0.
+    ws = {
+      ...ws,
+      teams: ws.teams.map((t, i) =>
+        i === 0 ? t : { ...t, initialBudget: 0 },
+      ),
+    };
+    ws = setPlayerTag(ws, "jeremiyah-love", TAG_TARGET);
+    const stats = computeDraftStats(ws);
+    const love = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    expect(stats.topCompetitorMax).toBe(0);
+    expect(playerRecommendation(love, stats).level).toBe("lock");
+  });
+
+  it("STEAL when rivals are bankrupt but player is untagged", () => {
+    const bankrupt = {
+      ...createDefaultWorkspace(),
+    };
+    bankrupt.teams = bankrupt.teams.map((t, i) =>
+      i === 0 ? t : { ...t, initialBudget: 0 },
+    );
+    const stats = computeDraftStats(bankrupt);
+    const tate = stats.enrichedPlayers.find(
+      (p) => p.name === "Carnell Tate",
+    );
+    expect(playerRecommendation(tate, stats).level).toBe("steal");
+  });
+
+  it("PUSH when target is in a drying-up tier", () => {
+    // Force S-tier scarcity by drafting most S players.
+    let ws = createDefaultWorkspace();
+    const sPlayers = ws.players.filter(
+      (p) => p.preDraft >= 60,
+    );
+    // Draft all but the first S-tier player.
+    for (const p of sPlayers.slice(1)) {
+      ws = recordPick(ws, {
+        playerId: p.id,
+        teamIdx: 5,
+        amount: Math.max(1, Math.floor(p.preDraft * 0.5)),
+      });
+    }
+    ws = setPlayerTag(ws, sPlayers[0].id, TAG_TARGET);
+    const stats = computeDraftStats(ws);
+    expect(stats.tierStats.S.remainingRatio).toBeLessThan(
+      TIER_SCARCITY_URGENT,
+    );
+    const p = stats.enrichedPlayers.find((pl) => pl.id === sPlayers[0].id);
+    const rec = playerRecommendation(p, stats);
+    expect(rec.level).toBe("push");
+  });
+
+  it("BUY is the default for a target in a normal market", () => {
+    // All defaults except target flag on Love.  No picks yet, so
+    // rivals still wealthy, no tier scarcity, no slot pressure.
+    let ws = createDefaultWorkspace();
+    ws = setPlayerTag(ws, "jeremiyah-love", TAG_TARGET);
+    const stats = computeDraftStats(ws);
+    const love = stats.enrichedPlayers.find(
+      (p) => p.name === "Jeremiyah Love",
+    );
+    const rec = playerRecommendation(love, stats);
+    // Opening-state competitor ceiling is $68 (Joel).  preDraft 135;
+    // collapse floor = 0.3 × 135 = 40.  68 > 40 so no lock/steal.
+    // No tier scarcity on S at opening.  Slot pressure 0 so no
+    // spend-up.  → "buy".
+    expect(rec.level).toBe("buy");
+  });
+});
+
+// ── nextBestTargets ─────────────────────────────────────────────────────
+
+describe("nextBestTargets", () => {
+  it("returns an array capped at the limit", () => {
+    const stats = computeDraftStats(createDefaultWorkspace());
+    const top = nextBestTargets(stats, { limit: 5 });
+    expect(top.length).toBeLessThanOrEqual(5);
+    for (const entry of top) {
+      expect(entry.player).toBeTruthy();
+      expect(entry.rec).toBeTruthy();
+      expect(entry.ev).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("excludes drafted players", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 0,
+      amount: 120,
+    });
+    const stats = computeDraftStats(withPick);
+    const top = nextBestTargets(stats, { limit: 10 });
+    expect(top.find((e) => e.player.name === "Jeremiyah Love")).toBeUndefined();
+  });
+
+  it("excludes AVOID-tagged players entirely", () => {
+    let ws = createDefaultWorkspace();
+    ws = setPlayerTag(ws, "jeremiyah-love", TAG_AVOID);
+    const stats = computeDraftStats(ws);
+    const top = nextBestTargets(stats, { limit: 72 });
+    expect(top.find((e) => e.player.name === "Jeremiyah Love")).toBeUndefined();
+  });
+
+  it("ranks TARGET-tagged players above untagged at similar value", () => {
+    let ws = createDefaultWorkspace();
+    // Tag Tate (PreDraft 83) as a target; Tyson (73) stays neutral.
+    ws = setPlayerTag(ws, "carnell-tate", TAG_TARGET);
+    const stats = computeDraftStats(ws);
+    const top = nextBestTargets(stats, { limit: 5 });
+    const tateIdx = top.findIndex((e) => e.player.name === "Carnell Tate");
+    const tysonIdx = top.findIndex(
+      (e) => e.player.name === "Jordyn Tyson",
+    );
+    // Tate should be at or above Tyson after the tag boost.
+    expect(tateIdx).toBeGreaterThanOrEqual(0);
+    if (tysonIdx >= 0) {
+      expect(tateIdx).toBeLessThan(tysonIdx);
+    }
+  });
+
+  it("falls back gracefully when stats is null", () => {
+    expect(nextBestTargets(null)).toEqual([]);
+  });
+});

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -7,17 +7,23 @@ import {
   DRAFT_STORAGE_KEY,
   DEFAULT_AGGRESSION,
   DEFAULT_ENFORCE_PCT,
+  TAG_AVOID,
+  TAG_TARGET,
   TIER_DEFS,
   addPlayer,
   bidStatus,
   computeDraftStats,
   createDefaultWorkspace,
+  cycleTag,
   hydrateWorkspace,
   mergeDraftCapitalTeams,
+  nextBestTargets,
+  playerRecommendation,
   playerSlug,
   recordPick,
   removePick,
   removePlayer,
+  setPlayerTag,
   undoLastPick,
   updatePlayerPreDraft,
   updateSettings,
@@ -26,6 +32,19 @@ import {
 } from "@/lib/draft-logic";
 
 const TIER_LABELS = Object.fromEntries(TIER_DEFS.map((t) => [t.key, t.label]));
+
+// Short labels + CSS classes for the recommendation chip on each row.
+// Kept in one place so the color language is consistent between the
+// board, the Next Best Target sidebar, and the draft modal.
+const REC_CHIP = {
+  lock: { text: "LOCK", cls: "draft-rec-lock" },
+  steal: { text: "STEAL", cls: "draft-rec-steal" },
+  push: { text: "PUSH", cls: "draft-rec-push" },
+  buy: { text: "BUY", cls: "draft-rec-buy" },
+  spend: { text: "SPEND", cls: "draft-rec-spend" },
+  avoid: { text: "AVOID", cls: "draft-rec-avoid" },
+  neutral: { text: "—", cls: "draft-rec-neutral" },
+};
 
 /* ── Utility formatters ───────────────────────────────────────────── */
 
@@ -367,6 +386,38 @@ function BidKnobs({ settings, onSettings }) {
 
 /* ── Draft-pick modal ─────────────────────────────────────────────── */
 
+/**
+ * One-line before → after preview for the bid simulator.  Color-
+ * codes the delta: green when the change improves my position
+ * (more $, higher BA, more slots), red when it hurts.  For
+ * inflation the sign is inverted (lower inflation means my
+ * money buys more later, so a negative delta renders green).
+ */
+function SimRow({ label, before, after, formatter, rawDelta = false }) {
+  const delta = (Number(after) || 0) - (Number(before) || 0);
+  let direction = 0;
+  if (Math.abs(delta) > 0.001) direction = delta > 0 ? 1 : -1;
+  const cls = rawDelta
+    ? "draft-sim-delta-muted"
+    : direction > 0
+      ? "draft-sim-delta-up"
+      : direction < 0
+        ? "draft-sim-delta-down"
+        : "";
+  const signPrefix = delta > 0 ? "+" : delta < 0 ? "−" : "";
+  const magnitude = formatter(Math.abs(delta));
+  const deltaText = direction === 0 ? "" : `(${signPrefix}${magnitude})`;
+  return (
+    <div className="draft-sim-row">
+      <span className="muted">{label}</span>
+      <span className="draft-money">{formatter(before)}</span>
+      <span className="draft-sim-arrow">→</span>
+      <span className="draft-money">{formatter(after)}</span>
+      <span className={`draft-sim-delta ${cls}`}>{deltaText}</span>
+    </div>
+  );
+}
+
 function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
   const existingPick = player?.pick;
   const [teamIdx, setTeamIdx] = useState(
@@ -375,6 +426,31 @@ function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
   const [amount, setAmount] = useState(existingPick?.amount ?? "");
   const [liveBid, setLiveBid] = useState("");
   const liveStatus = useMemo(() => bidStatus(player, liveBid), [player, liveBid]);
+
+  // Bid simulator: project the workspace forward with this pick
+  // applied so the user can see the downstream effect before
+  // committing.  Uses the SAME math path as the rest of the app
+  // (computeDraftStats(recordPick(...))) so numbers match the live
+  // board exactly post-commit.  Skips computation when amount is 0
+  // or the pick is just being re-recorded unchanged (existing edit
+  // that didn't move the needle).
+  const simulated = useMemo(() => {
+    const amt = Math.max(0, Number(amount) || 0);
+    if (amt <= 0 || !player) return null;
+    if (
+      existingPick &&
+      existingPick.teamIdx === Number(teamIdx) &&
+      existingPick.amount === amt
+    ) {
+      return null;
+    }
+    const nextWs = recordPick(workspace, {
+      playerId: player.id,
+      teamIdx: Number(teamIdx),
+      amount: amt,
+    });
+    return computeDraftStats(nextWs);
+  }, [workspace, player, teamIdx, amount, existingPick]);
 
   // Re-focus the amount input on open so the user can start typing.
   useEffect(() => {
@@ -511,6 +587,62 @@ function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
             return null;
           })()}
 
+          {/* Bid simulator — before/after preview of the key numbers
+              this pick would change.  Surfaces "if I commit this, my
+              BA drops from 5.85× to 3.24×" BEFORE you click Record,
+              so regrets become rare. */}
+          {simulated && (
+            <div className="draft-modal-sim">
+              <div
+                className="muted"
+                style={{ fontSize: "0.68rem", marginBottom: 4 }}
+              >
+                If recorded:
+              </div>
+              <div className="draft-sim-grid">
+                <SimRow
+                  label="League $ left"
+                  before={stats.remainingLeague}
+                  after={simulated.remainingLeague}
+                  formatter={fmt$}
+                />
+                <SimRow
+                  label="My remaining"
+                  before={stats.myRemaining}
+                  after={simulated.myRemaining}
+                  formatter={fmt$}
+                />
+                <SimRow
+                  label="My BA"
+                  before={stats.budgetAdvantage}
+                  after={simulated.budgetAdvantage}
+                  formatter={(n) => `${n.toFixed(2)}×`}
+                  rawDelta
+                />
+                <SimRow
+                  label="Inflation"
+                  before={stats.inflation}
+                  after={simulated.inflation}
+                  formatter={(n) => `${n.toFixed(2)}×`}
+                  rawDelta
+                />
+                <SimRow
+                  label="Top rival $"
+                  before={stats.topCompetitorMax}
+                  after={simulated.topCompetitorMax}
+                  formatter={fmt$}
+                />
+                <SimRow
+                  label="My slots left"
+                  before={stats.mySlotsRemaining}
+                  after={simulated.mySlotsRemaining}
+                  formatter={(n) => `${n}`}
+                  rawDelta
+                />
+              </div>
+            </div>
+          )}
+
           <div className="draft-modal-live">
             <div className="muted" style={{ fontSize: "0.72rem" }}>
               Or simulate a live bid to see the recommendation:
@@ -588,17 +720,46 @@ function RookieBoard({
   onDraft,
   onEditPreDraft,
   onRemovePlayer,
+  onCycleTag,
   showDrafted,
   onShowDraftedChange,
   query,
   onQueryChange,
+  tagFilter,
+  onTagFilterChange,
   onAdd,
 }) {
-  const [sort, setSort] = useState({ col: "myMaxBid", asc: false });
+  const [sort, setSort] = useState({ col: "myWinningBid", asc: false });
+
+  // Tag tabs — quick filter so the user can focus on targets during
+  // live drafting without scrolling past everything.
+  const tagCounts = useMemo(() => {
+    let target = 0;
+    let avoid = 0;
+    let untagged = 0;
+    for (const p of stats.enrichedPlayers) {
+      if (p.drafted) continue;
+      if (p.userTag === TAG_TARGET) target += 1;
+      else if (p.userTag === TAG_AVOID) avoid += 1;
+      else untagged += 1;
+    }
+    return { target, avoid, untagged, all: target + avoid + untagged };
+  }, [stats.enrichedPlayers]);
 
   const filtered = useMemo(() => {
     let list = stats.enrichedPlayers;
     if (!showDrafted) list = list.filter((p) => !p.drafted);
+
+    // Tag filter applies only to undrafted rows; drafted rows still
+    // surface when ``showDrafted`` is on so history stays visible.
+    if (tagFilter === "target") {
+      list = list.filter((p) => p.drafted || p.userTag === TAG_TARGET);
+    } else if (tagFilter === "avoid") {
+      list = list.filter((p) => p.drafted || p.userTag === TAG_AVOID);
+    } else if (tagFilter === "untagged") {
+      list = list.filter((p) => p.drafted || !p.userTag);
+    }
+
     const q = (query || "").trim().toLowerCase();
     if (q) list = list.filter((p) => p.name.toLowerCase().includes(q));
     const dir = sort.asc ? 1 : -1;
@@ -616,6 +777,8 @@ function RookieBoard({
           return (a.enforceUpTo - b.enforceUpTo) * dir;
         case "myMaxBid":
           return (a.myMaxBid - b.myMaxBid) * dir;
+        case "myWinningBid":
+          return (a.myWinningBid - b.myWinningBid) * dir;
         case "final":
           return (
             ((a.pick?.amount ?? -1) - (b.pick?.amount ?? -1)) * dir
@@ -624,7 +787,14 @@ function RookieBoard({
           return 0;
       }
     });
-  }, [stats.enrichedPlayers, sort, query, showDrafted]);
+  }, [stats.enrichedPlayers, sort, query, showDrafted, tagFilter]);
+
+  // Tier-separator rows — only when the current sort groups by tier
+  // naturally (rank or preDraft descending/ascending).  Scatter sorts
+  // (win bid, fair) skip the dividers to avoid noise.
+  const showTierDividers =
+    (sort.col === "rank" && sort.asc) ||
+    (sort.col === "preDraft" && !sort.asc);
 
   const teamName = (idx) =>
     workspace.teams[idx]?.name || `Team ${idx + 1}`;
@@ -645,6 +815,24 @@ function RookieBoard({
       </th>
     );
   }
+
+  const tagTab = (key, label, count, color) => {
+    const active = tagFilter === key;
+    return (
+      <button
+        type="button"
+        className={`draft-tag-tab${active ? " draft-tag-tab-active" : ""}`}
+        style={{
+          borderColor: active ? color : "var(--border)",
+          color: active ? color : "var(--muted)",
+        }}
+        onClick={() => onTagFilterChange(key)}
+      >
+        {label}
+        <span className="draft-tag-tab-count">{count}</span>
+      </button>
+    );
+  };
 
   return (
     <div className="card">
@@ -669,13 +857,31 @@ function RookieBoard({
           <AddPlayerInline onAdd={onAdd} />
         </div>
       </div>
+      <div className="draft-tag-tabs">
+        {tagTab("all", "All", tagCounts.all, "var(--cyan)")}
+        {tagTab("target", "Targets", tagCounts.target, "var(--green)")}
+        {tagTab("avoid", "Avoid", tagCounts.avoid, "var(--red)")}
+        {tagTab("untagged", "Untagged", tagCounts.untagged, "var(--muted)")}
+      </div>
       <div className="draft-table-wrap">
         <table className="draft-table">
           <thead>
             <tr>
               {th("#", "rank", 40)}
-              <th style={{ width: 44 }} title="Tier by PreDraft $: S=$60+, A=$25-59, B=$8-24, C=$3-7, D=$1-2">
+              <th
+                style={{ width: 44 }}
+                title="Tier by PreDraft $: S=$60+, A=$25-59, B=$8-24, C=$3-7, D=$1-2"
+              >
                 Tier
+              </th>
+              <th
+                style={{ width: 70 }}
+                title="Click to cycle: neutral → target → avoid → neutral"
+              >
+                Tag
+              </th>
+              <th style={{ width: 86 }} title="Draft-time recommendation">
+                Rec
               </th>
               {th("Player", "name")}
               {th("PreDraft", "preDraft", 82)}
@@ -689,13 +895,53 @@ function RookieBoard({
             </tr>
           </thead>
           <tbody>
-            {filtered.map((p) => {
-              const capped = p.myWinningBid < p.theoreticalMaxBid;
-              return (
+            {(() => {
+              const rendered = [];
+              let lastTier = null;
+              for (const p of filtered) {
+                if (showTierDividers && p.tier !== lastTier) {
+                  const info = stats.tierStats?.[p.tier];
+                  rendered.push(
+                    <tr
+                      key={`tier-${p.tier}`}
+                      className="draft-tier-divider"
+                    >
+                      <td colSpan={13}>
+                        <span
+                          className={`draft-tier-chip draft-tier-${p.tier}`}
+                          style={{ marginRight: 8 }}
+                        >
+                          {p.tier}
+                        </span>
+                        <strong>
+                          {TIER_LABELS[p.tier] || p.tier} tier
+                        </strong>
+                        {info && (
+                          <span
+                            className="muted"
+                            style={{ marginLeft: 8, fontSize: "0.72rem" }}
+                          >
+                            {info.remaining} of {info.total} left
+                            {info.heat != null &&
+                              info.confidence > 0 &&
+                              ` · heat ${info.heat.toFixed(2)}×`}
+                          </span>
+                        )}
+                      </td>
+                    </tr>,
+                  );
+                  lastTier = p.tier;
+                }
+                const capped = p.myWinningBid < p.theoreticalMaxBid;
+                const rec = playerRecommendation(p, stats);
+                const recInfo = rec ? REC_CHIP[rec.level] : null;
+                rendered.push(
               <tr
                 key={p.id}
                 className={`draft-row${p.drafted ? " draft-row-drafted" : ""}${
                   p.mine ? " draft-row-mine" : ""
+                }${p.userTag === TAG_TARGET ? " draft-row-target" : ""}${
+                  p.userTag === TAG_AVOID ? " draft-row-avoid" : ""
                 }`}
               >
                 <td className="draft-money">{p.rank}</td>
@@ -706,6 +952,39 @@ function RookieBoard({
                   >
                     {p.tier}
                   </span>
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    className={`draft-tag-chip${p.userTag ? ` draft-tag-${p.userTag}` : ""}`}
+                    onClick={() => onCycleTag(p.id)}
+                    disabled={p.drafted}
+                    title={
+                      p.userTag === TAG_TARGET
+                        ? "Target — click to cycle to avoid"
+                        : p.userTag === TAG_AVOID
+                          ? "Avoid — click to clear"
+                          : "Click to mark target"
+                    }
+                  >
+                    {p.userTag === TAG_TARGET
+                      ? "★"
+                      : p.userTag === TAG_AVOID
+                        ? "⊘"
+                        : "+"}
+                  </button>
+                </td>
+                <td>
+                  {recInfo ? (
+                    <span
+                      className={`draft-rec-chip ${recInfo.cls}`}
+                      title={rec.rationale || rec.label}
+                    >
+                      {recInfo.text}
+                    </span>
+                  ) : (
+                    <span className="muted">—</span>
+                  )}
                 </td>
                 <td>{p.name}</td>
                 <td>
@@ -812,13 +1091,15 @@ function RookieBoard({
                     )}
                   </div>
                 </td>
-              </tr>
-              );
-            })}
+              </tr>,
+                );
+              }
+              return rendered;
+            })()}
             {filtered.length === 0 && (
               <tr>
                 <td
-                  colSpan={11}
+                  colSpan={13}
                   className="muted"
                   style={{ padding: 14, textAlign: "center" }}
                 >
@@ -828,6 +1109,101 @@ function RookieBoard({
             )}
           </tbody>
         </table>
+      </div>
+    </div>
+  );
+}
+
+/* ── Next Best Target sidebar ─────────────────────────────────────── */
+
+/**
+ * Top-N EV-ranked undrafted targets, always visible.  Answers "what
+ * should I focus on right now?" without the user having to scroll
+ * or re-sort.  Clicking a row opens the draft modal pre-loaded with
+ * that player; clicking the star cycles the tag.
+ */
+function NextBestTargets({ stats, onDraft, onCycleTag, workspace }) {
+  const top = useMemo(
+    () => nextBestTargets(stats, { limit: 5 }),
+    [stats],
+  );
+
+  if (top.length === 0) {
+    return (
+      <div className="card draft-nbt">
+        <h3 style={{ margin: "0 0 4px" }}>Next Best Targets</h3>
+        <div className="muted" style={{ fontSize: "0.72rem" }}>
+          Nothing to flag yet — tag a few players as <strong>★ target</strong>{" "}
+          to seed EV ranking.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card draft-nbt">
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+        }}
+      >
+        <h3 style={{ margin: 0 }}>Next Best Targets</h3>
+        <span className="muted" style={{ fontSize: "0.68rem" }}>
+          EV = (fair − winBid) × tag weight + scarcity boost
+        </span>
+      </div>
+      <div className="draft-nbt-list">
+        {top.map(({ player, ev, rec }, i) => {
+          const recInfo = rec ? REC_CHIP[rec.level] : null;
+          return (
+            <div
+              key={player.id}
+              className={`draft-nbt-row${player.userTag === TAG_TARGET ? " draft-nbt-target" : ""}`}
+              title={rec?.rationale || rec?.label || ""}
+            >
+              <span className="draft-nbt-rank">#{i + 1}</span>
+              <button
+                type="button"
+                className={`draft-tag-chip${
+                  player.userTag ? ` draft-tag-${player.userTag}` : ""
+                }`}
+                onClick={() => onCycleTag(player.id)}
+                title="Cycle tag"
+              >
+                {player.userTag === TAG_TARGET
+                  ? "★"
+                  : player.userTag === TAG_AVOID
+                    ? "⊘"
+                    : "+"}
+              </button>
+              <span
+                className={`draft-tier-chip draft-tier-${player.tier}`}
+                title={`${TIER_LABELS[player.tier] || player.tier} tier`}
+              >
+                {player.tier}
+              </span>
+              <span className="draft-nbt-name" onClick={() => onDraft(player)}>
+                {player.name}
+              </span>
+              <span className="draft-money draft-money-win">
+                {fmt$(player.myWinningBid)}
+              </span>
+              <span className="muted" style={{ fontSize: "0.68rem" }}>
+                fair {fmt$(player.inflatedFair)}
+              </span>
+              {recInfo && (
+                <span className={`draft-rec-chip ${recInfo.cls}`}>
+                  {recInfo.text}
+                </span>
+              )}
+              <span className="muted" style={{ fontSize: "0.66rem" }}>
+                EV {ev.toFixed(0)}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -883,6 +1259,7 @@ export default function DraftDashboardPage() {
   const [modalPlayer, setModalPlayer] = useState(null);
   const [showDrafted, setShowDrafted] = useState(false);
   const [query, setQuery] = useState("");
+  const [tagFilter, setTagFilter] = useState("all"); // all | target | avoid | untagged
   const [capitalStatus, setCapitalStatus] = useState({
     loading: false,
     error: "",
@@ -1017,6 +1394,14 @@ export default function DraftDashboardPage() {
     (id) => setWorkspace((ws) => removePlayer(ws, id)),
     [],
   );
+  const onCycleTag = useCallback(
+    (id) =>
+      setWorkspace((ws) => {
+        const current = ws.tags?.[id] || null;
+        return setPlayerTag(ws, id, cycleTag(current));
+      }),
+    [],
+  );
 
   const handleModalSubmit = useCallback(
     (payload) => {
@@ -1089,6 +1474,27 @@ export default function DraftDashboardPage() {
         </div>
       </div>
 
+      {/* Draft progress bar — picks drafted vs total slots in the
+          draft (sum of initialSlots across all teams, normally 72).
+          Sits above the stats strip so the user has constant
+          peripheral awareness of "how far in are we?" — which drives
+          every late-draft decision. */}
+      <div className="draft-progress" title={`${stats.totalPicksMade} of ${stats.totalInitialSlots} picks recorded`}>
+        <div className="draft-progress-bar">
+          <div
+            className="draft-progress-fill"
+            style={{ width: `${Math.min(100, stats.draftProgress * 100)}%` }}
+          />
+        </div>
+        <div className="draft-progress-labels">
+          <span>
+            Pick <strong>{stats.totalPicksMade}</strong> of{" "}
+            <strong>{stats.totalInitialSlots}</strong>
+          </span>
+          <span>{Math.round(stats.draftProgress * 100)}% through draft</span>
+        </div>
+      </div>
+
       <StatsStrip stats={stats} />
 
       <div className="draft-top-grid">
@@ -1103,16 +1509,26 @@ export default function DraftDashboardPage() {
         <BidKnobs settings={workspace.settings || {}} onSettings={onSettings} />
       </div>
 
+      <NextBestTargets
+        stats={stats}
+        onDraft={(p) => setModalPlayer(p)}
+        onCycleTag={onCycleTag}
+        workspace={workspace}
+      />
+
       <RookieBoard
         stats={stats}
         workspace={workspace}
         onDraft={(p) => setModalPlayer(p)}
         onEditPreDraft={onEditPreDraft}
         onRemovePlayer={onRemovePlayer}
+        onCycleTag={onCycleTag}
         showDrafted={showDrafted}
         onShowDraftedChange={setShowDrafted}
         query={query}
         onQueryChange={setQuery}
+        tagFilter={tagFilter}
+        onTagFilterChange={setTagFilter}
         onAdd={onAdd}
       />
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4023,3 +4023,233 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   font-size: 0.72rem;
   margin-right: 4px;
 }
+
+/* ── Tier 2: tags, recommendations, tier dividers, progress bar,
+      next best targets, simulator ──────────────────────────── */
+
+.draft-progress {
+  margin-bottom: 10px;
+}
+.draft-progress-bar {
+  height: 6px;
+  background: rgba(153, 166, 200, 0.08);
+  border-radius: 3px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.draft-progress-fill {
+  height: 100%;
+  background: linear-gradient(to right, var(--cyan), var(--green));
+  transition: width 0.35s ease;
+}
+.draft-progress-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: var(--muted);
+  margin-top: 3px;
+}
+
+/* Tag filter tabs */
+.draft-tag-tabs {
+  display: flex;
+  gap: 6px;
+  margin: 6px 0 8px;
+  flex-wrap: wrap;
+}
+.draft-tag-tab {
+  padding: 3px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.74rem;
+  letter-spacing: 0.03em;
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+.draft-tag-tab:hover {
+  background: rgba(255, 198, 47, 0.05);
+}
+.draft-tag-tab-active {
+  font-weight: 600;
+}
+.draft-tag-tab-count {
+  font-family: var(--mono, monospace);
+  font-size: 0.68rem;
+  opacity: 0.75;
+}
+
+/* Per-row tag chips */
+.draft-tag-chip {
+  width: 26px;
+  height: 22px;
+  border-radius: 4px;
+  background: rgba(153, 166, 200, 0.05);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.draft-tag-chip:hover {
+  background: rgba(255, 198, 47, 0.08);
+}
+.draft-tag-chip:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.draft-tag-target {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: var(--green);
+  color: var(--green);
+}
+.draft-tag-avoid {
+  background: rgba(248, 113, 113, 0.1);
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.draft-row-target td:first-child {
+  border-left: 2px solid var(--green);
+}
+.draft-row-avoid td:first-child {
+  border-left: 2px solid var(--red);
+}
+.draft-row-avoid {
+  opacity: 0.6;
+}
+
+/* Recommendation chip */
+.draft-rec-chip {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--border);
+  text-align: center;
+  min-width: 48px;
+  font-family: var(--mono, monospace);
+}
+.draft-rec-lock {
+  background: rgba(52, 211, 153, 0.15);
+  border-color: var(--green);
+  color: var(--green);
+}
+.draft-rec-steal {
+  background: rgba(255, 198, 47, 0.12);
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.draft-rec-push {
+  background: rgba(167, 139, 250, 0.12);
+  border-color: #a78bfa;
+  color: #c4b5fd;
+}
+.draft-rec-buy {
+  background: rgba(52, 211, 153, 0.08);
+  border-color: rgba(52, 211, 153, 0.5);
+  color: var(--green);
+}
+.draft-rec-spend {
+  background: rgba(255, 198, 47, 0.1);
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.draft-rec-avoid {
+  background: rgba(248, 113, 113, 0.1);
+  border-color: var(--red);
+  color: var(--red);
+}
+.draft-rec-neutral {
+  color: var(--muted);
+  border-color: var(--border);
+}
+
+/* Tier divider rows on the board */
+.draft-tier-divider td {
+  padding: 6px 8px !important;
+  background: rgba(153, 166, 200, 0.04);
+  border-bottom: 1px solid rgba(38, 58, 105, 0.5) !important;
+  letter-spacing: 0.02em;
+  font-size: 0.8rem;
+}
+
+/* Next Best Targets sidebar */
+.draft-nbt {
+  margin-bottom: 14px;
+}
+.draft-nbt-list {
+  display: grid;
+  gap: 4px;
+  margin-top: 6px;
+}
+.draft-nbt-row {
+  display: grid;
+  grid-template-columns: 32px 28px 36px 1fr 80px 90px 64px 60px;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  background: rgba(153, 166, 200, 0.04);
+}
+.draft-nbt-row:hover {
+  background: rgba(255, 198, 47, 0.05);
+}
+.draft-nbt-target {
+  background: rgba(52, 211, 153, 0.06);
+}
+.draft-nbt-rank {
+  font-family: var(--mono, monospace);
+  font-weight: 700;
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+.draft-nbt-name {
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+}
+.draft-nbt-name:hover {
+  color: var(--cyan);
+}
+
+/* Bid simulator in draft modal */
+.draft-modal-sim {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(52, 211, 153, 0.04);
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+.draft-sim-grid {
+  display: grid;
+  gap: 3px;
+}
+.draft-sim-row {
+  display: grid;
+  grid-template-columns: 110px 70px 14px 70px 1fr;
+  gap: 6px;
+  align-items: center;
+  font-size: 0.74rem;
+}
+.draft-sim-arrow {
+  color: var(--muted);
+  text-align: center;
+}
+.draft-sim-delta {
+  font-family: var(--mono, monospace);
+  font-size: 0.72rem;
+}
+.draft-sim-delta-up { color: var(--green); }
+.draft-sim-delta-down { color: var(--red); }
+.draft-sim-delta-muted { color: var(--muted); }

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -89,6 +89,46 @@ export function tierForPreDraft(preDraft) {
   return "D";
 }
 
+// ── Player tags (TARGET / AVOID / neutral) ──────────────────────────────
+// Tags drive the recommendation engine.  A player defaults to neutral
+// (no entry in ``workspace.tags``); the UI cycles TARGET → AVOID →
+// neutral via clickable chips.  Stored in a separate map keyed by
+// player id so it survives player renames + is trivially JSON-
+// serializable.
+export const TAG_TARGET = "target";
+export const TAG_AVOID = "avoid";
+export const TAG_VALUES = [TAG_TARGET, TAG_AVOID];
+
+/**
+ * Cycle helper: neutral → target → avoid → neutral.  Used by the
+ * row-level "click to retag" button.
+ */
+export function cycleTag(current) {
+  if (current === TAG_TARGET) return TAG_AVOID;
+  if (current === TAG_AVOID) return null;
+  return TAG_TARGET;
+}
+
+/**
+ * Tier scarcity thresholds.  When ``remaining / initial < THRESHOLD``
+ * the tier is "drying up" and recommendations urge extra aggression.
+ */
+export const TIER_SCARCITY_URGENT = 0.3;
+
+/**
+ * Slot-pressure gate for the "Spend up" recommendation — only trigger
+ * past this fraction of the draft (i.e. late-draft mode).  At 0.6
+ * that's after ~60% of my picks are drafted.
+ */
+export const SPEND_UP_PRESSURE_MIN = 0.6;
+/**
+ * $-per-slot floor for the "Spend up" recommendation — only trigger
+ * when my remaining $ exceeds my remaining slots × this floor.
+ * Prevents the surplus-alert from firing when my per-slot budget is
+ * already normal-sized.
+ */
+export const SPEND_UP_MDV_FLOOR = 10;
+
 // ── Default team roster ─────────────────────────────────────────────────
 // Total league pool is $1200 (the sum of DEFAULT_ROOKIES.preDraft).  The
 // sheet reports Russini Panini (Jason) at $417 and "Other Teams
@@ -277,6 +317,8 @@ export function createDefaultWorkspace() {
     //     retroactive edit to ``players[n].preDraft`` doesn't corrupt
     //     the paid/expected ratios of already-drafted players.
     picks: [],
+    // tags: { [playerId]: "target" | "avoid" }  — neutral = absent
+    tags: {},
   };
 }
 
@@ -490,6 +532,41 @@ export function computeDraftStats(workspace) {
     return conf * heat + (1 - conf) * 1;
   }
 
+  // ── Per-tier scarcity stats ───────────────────────────────────────
+  // Total players in each tier at draft START vs still on the board,
+  // so the recommendation engine can flag "tier drying up" on the
+  // remaining targets.  Tier is determined from ``player.preDraft``
+  // (the current value) because scarcity is about what's LEFT, not
+  // what WAS — retroactive PreDraft edits intentionally reshape this.
+  const tierStats = {};
+  for (const def of TIER_DEFS) {
+    tierStats[def.key] = {
+      key: def.key,
+      label: def.label,
+      total: 0,
+      drafted: 0,
+      remaining: 0,
+      remainingRatio: 1,
+      heat: tierHeat[def.key],
+      confidence: tierConfidence[def.key],
+      sampleCount: tierSampleCount[def.key],
+    };
+  }
+  for (const p of players) {
+    const key = tierForPreDraft(p.preDraft);
+    if (!tierStats[key]) continue;
+    tierStats[key].total += 1;
+    if (pickedPlayerIds.has(p.id)) tierStats[key].drafted += 1;
+  }
+  for (const key of Object.keys(tierStats)) {
+    const t = tierStats[key];
+    t.remaining = Math.max(0, t.total - t.drafted);
+    t.remainingRatio = t.total > 0 ? t.remaining / t.total : 0;
+  }
+
+  // Lookup for user tags.
+  const tagMap = (ws.tags && typeof ws.tags === "object") ? ws.tags : {};
+
   // Per-team stats (name, initial, spent, remaining, slots, eff$).
   const teamStats = teams.map((t, idx) => {
     const spent = picksByTeam[idx].reduce(
@@ -551,6 +628,7 @@ export function computeDraftStats(workspace) {
       drafted && Number.isFinite(Number(pick.amount))
         ? inflatedFair - Number(pick.amount)
         : null;
+    const userTag = tagMap[p.id] || null;
     return {
       ...p,
       preDraft,
@@ -559,6 +637,7 @@ export function computeDraftStats(workspace) {
       pick,
       drafted,
       mine,
+      userTag,
       inflatedFair: Math.max(0, inflatedFair),
       myMaxBid: Math.max(0, theoreticalMaxBid),
       theoreticalMaxBid: Math.max(0, theoreticalMaxBid),
@@ -567,6 +646,14 @@ export function computeDraftStats(workspace) {
       valueVsFair,
     };
   });
+
+  // Total picks in the draft = sum of initial slots across all teams.
+  // Used for the UI progress bar; typically 72 (12 × 6) for our
+  // league but differs when teams trade picks between leagues.
+  const totalInitialSlots = initialSlotsByIdx.reduce((s, n) => s + n, 0);
+  const totalPicksMade = picks.length;
+  const draftProgress =
+    totalInitialSlots > 0 ? totalPicksMade / totalInitialSlots : 0;
 
   return {
     totalBudget,
@@ -590,6 +677,10 @@ export function computeDraftStats(workspace) {
     tierHeat,
     tierConfidence,
     tierSampleCount,
+    tierStats,
+    totalInitialSlots,
+    totalPicksMade,
+    draftProgress,
     teamStats,
     enrichedPlayers,
   };
@@ -653,6 +744,24 @@ export function updatePlayerPreDraft(workspace, playerId, newPreDraft) {
       : p,
   );
   return { ...workspace, players };
+}
+
+/**
+ * Set (or clear) the TARGET / AVOID tag on a player.
+ *
+ * Pass ``null`` / ``undefined`` / anything unrecognized to clear the
+ * tag back to neutral (i.e. remove from the tags map).  Returns a
+ * new workspace; does not mutate.
+ */
+export function setPlayerTag(workspace, playerId, tag) {
+  if (!playerId) return workspace;
+  const next = { ...(workspace.tags || {}) };
+  if (tag === TAG_TARGET || tag === TAG_AVOID) {
+    next[playerId] = tag;
+  } else {
+    delete next[playerId];
+  }
+  return { ...workspace, tags: next };
 }
 
 /** Update a team's name or initial budget. */
@@ -961,7 +1070,181 @@ export function hydrateWorkspace(parsed) {
             .filter((p) => p.playerId && p.teamIdx >= 0);
         })()
       : [],
+    tags: (() => {
+      // Tags are optional; silently drop any value that isn't
+      // exactly "target" or "avoid".  This keeps the map tight
+      // even if localStorage gets hand-edited to something weird.
+      const src = parsed.tags && typeof parsed.tags === "object" ? parsed.tags : {};
+      const out = {};
+      for (const [k, v] of Object.entries(src)) {
+        if (v === TAG_TARGET || v === TAG_AVOID) out[String(k)] = v;
+      }
+      return out;
+    })(),
   };
+}
+
+// ── Recommendation engine ──────────────────────────────────────────────
+/**
+ * Classify a single undrafted player's draft-time stance given the
+ * current workspace state.  Returns null for drafted players or
+ * missing input.  The classification is INDEPENDENT of any live bid
+ * (use ``bidStatus`` for that).  It answers: "all else equal, what
+ * should my posture be on this guy right now?"
+ *
+ * Levels (ordered by priority):
+ *
+ *   - ``avoid``   — user flagged AVOID
+ *   - ``lock``    — target AND competitor ceiling collapses
+ *                  (rivals can't afford past a modest bid)
+ *   - ``steal``   — NEUTRAL AND competitor ceiling collapses
+ *                  (opportunistic grab at fire-sale price)
+ *   - ``spend``   — target AND late-draft surplus (slot pressure
+ *                   high, remaining $ outpaces remaining slots)
+ *   - ``push``    — target AND tier drying up
+ *   - ``buy``     — target, normal market
+ *   - ``neutral`` — nothing noteworthy
+ *
+ * Every level carries a short ``label`` + ``rationale`` so the UI
+ * can render the label as a chip and the rationale as a tooltip.
+ */
+export function playerRecommendation(enrichedPlayer, stats) {
+  if (!enrichedPlayer || enrichedPlayer.drafted || !stats) return null;
+  const p = enrichedPlayer;
+  const tag = p.userTag;
+
+  // Explicit AVOID flag — user knows better than any signal.
+  if (tag === TAG_AVOID) {
+    return {
+      level: "avoid",
+      label: "Avoid",
+      rationale: "You flagged this player as avoid.",
+    };
+  }
+
+  // Competitor ceiling collapse: bid ``topCompetitorMax + 1`` wins.
+  // Floor the threshold at max(1, preDraft × 0.3) so a borderline
+  // "my rivals can afford $10 and the player's PreDraft is $30"
+  // scenario doesn't register as collapse (rivals might push to $15,
+  // still much below my ceiling).
+  const collapseFloor = Math.max(1, Math.floor(p.preDraft * 0.3));
+  if (stats.topCompetitorMax <= collapseFloor) {
+    if (tag === TAG_TARGET) {
+      return {
+        level: "lock",
+        label: "Lock now",
+        rationale: `Rivals maxed at $${stats.topCompetitorMax}; bid $${
+          stats.topCompetitorMax + 1
+        } to lock.`,
+      };
+    }
+    return {
+      level: "steal",
+      label: "Steal candidate",
+      rationale: `Rivals maxed at $${stats.topCompetitorMax}; any bid above wins.`,
+    };
+  }
+
+  // Late-draft surplus $ on a target → spend up.
+  const mdv =
+    stats.mySlotsRemaining > 0
+      ? stats.myRemaining / stats.mySlotsRemaining
+      : 0;
+  if (
+    tag === TAG_TARGET &&
+    stats.slotPressure >= SPEND_UP_PRESSURE_MIN &&
+    mdv > SPEND_UP_MDV_FLOOR
+  ) {
+    return {
+      level: "spend",
+      label: "Spend up",
+      rationale: `Late draft (${Math.round(
+        stats.slotPressure * 100,
+      )}% pressure), ~$${Math.round(mdv)}/slot surplus — don't let $ go unused.`,
+    };
+  }
+
+  // Tier scarcity on a target.
+  if (tag === TAG_TARGET) {
+    const tierInfo = stats.tierStats?.[p.tier];
+    if (
+      tierInfo &&
+      tierInfo.remainingRatio < TIER_SCARCITY_URGENT &&
+      tierInfo.remaining > 0
+    ) {
+      return {
+        level: "push",
+        label: "Push aggressively",
+        rationale: `Only ${tierInfo.remaining} of ${tierInfo.total} ${p.tier}-tier players left.`,
+      };
+    }
+    return {
+      level: "buy",
+      label: "Buy at fair",
+      rationale: `Target; bid up to $${p.myWinningBid} to win.`,
+    };
+  }
+
+  return {
+    level: "neutral",
+    label: "Neutral",
+    rationale: null,
+  };
+}
+
+/**
+ * Rank undrafted players by expected value and return the top N.
+ *
+ * EV model (per player p):
+ *
+ *   surplus(p) = max(0, inflatedFair − myWinningBid)
+ *   tagWeight(p) = 1.5 (target)  1.0 (neutral)  0 (avoid)
+ *   ev(p) = surplus × tagWeight + tierScarcityBoost(p, stats)
+ *
+ * Where ``tierScarcityBoost`` adds a small bump when the player
+ * sits in a drying-up tier, nudging those to the front.  Avoid-
+ * tagged players are forced to 0 so they never surface as
+ * recommendations.  Ties are broken by tier (S > A > B > C > D)
+ * then by ``preDraft`` descending.
+ *
+ * Returns an array of ``{ player, ev, rec }`` objects, sorted
+ * descending by ev, capped at ``limit`` entries (default 5).
+ */
+export function nextBestTargets(stats, { limit = 5 } = {}) {
+  if (!stats || !Array.isArray(stats.enrichedPlayers)) return [];
+  const tierOrder = { S: 5, A: 4, B: 3, C: 2, D: 1 };
+  const candidates = [];
+  for (const p of stats.enrichedPlayers) {
+    if (p.drafted) continue;
+    if (p.userTag === TAG_AVOID) continue;
+
+    const surplus = Math.max(0, p.inflatedFair - p.myWinningBid);
+    const tagWeight = p.userTag === TAG_TARGET ? 1.5 : 1.0;
+    const tierInfo = stats.tierStats?.[p.tier];
+    const scarcityBoost =
+      tierInfo && tierInfo.remainingRatio < TIER_SCARCITY_URGENT
+        ? Math.max(0, 10 * (TIER_SCARCITY_URGENT - tierInfo.remainingRatio))
+        : 0;
+
+    const ev = surplus * tagWeight + scarcityBoost;
+    if (ev <= 0 && p.userTag !== TAG_TARGET) continue;
+
+    candidates.push({
+      player: p,
+      ev,
+      rec: playerRecommendation(p, stats),
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (b.ev !== a.ev) return b.ev - a.ev;
+    const at = tierOrder[a.player.tier] || 0;
+    const bt = tierOrder[b.player.tier] || 0;
+    if (bt !== at) return bt - at;
+    return b.player.preDraft - a.player.preDraft;
+  });
+
+  return candidates.slice(0, limit);
 }
 
 /**


### PR DESCRIPTION
## Summary
Tier 2 of the draft dashboard roadmap (post-Tier-1, PR #233). Makes ``/draft`` actively prescriptive. Six features:

1. **TARGET / AVOID tags** — one-click per row, cycle neutral → target → avoid; filter tabs above the board (All / Targets / Avoid / Untagged) with counts
2. **Recommendation engine** — LOCK / STEAL / PUSH / BUY / SPEND / AVOID / neutral classification per undrafted player based on tag + competitor ceiling + tier scarcity + draft phase
3. **Next Best Targets sidebar** — top 5 undrafted rows ranked by EV = (fair − winBid) × tagWeight + scarcityBoost; always visible
4. **Tier dividers + tier heat on the board** — when sorted by rank or PreDraft, shows "Elite tier · 7 of 7 left · heat 1.07×" divider rows between tier bands
5. **Progress bar + pick counter** — "Pick 12 of 72 · 17% through draft" at the top of the page
6. **Bid simulator in the draft modal** — before/after preview of League $, My remaining, BA, Inflation, Top rival $, Slots left if the pick is recorded as typed

## Recommendation engine levels

| Level | Trigger | Rendered |
|---|---|---|
| LOCK | target + rivals collapse (topCompetitorMax ≤ preDraft × 0.3) | green chip |
| STEAL | neutral + rivals collapse | amber chip |
| PUSH | target + tier remaining ratio < 0.3 | purple chip |
| BUY | target, normal market | green-outline chip |
| SPEND | target + slotPressure ≥ 0.6 + surplus $/slot > $10 | amber chip |
| AVOID | user tagged AVOID | red chip |
| neutral | no strong signal | muted |

All levels carry a ``rationale`` string surfaced as a tooltip ("Rivals maxed at $5; bid $6 to lock", "Only 2 of 7 S-tier left", etc.).

## Test plan
- [x] ``npx vitest run __tests__/draft-logic.test.js`` — 108/108 pass (22 new)
- [x] Full suite — 594/596 (2 pre-existing ``dynasty-data.test.js/rankHistory`` failures unrelated, verified unchanged)
- [x] ``npm run build`` — clean; /draft at 13.2 kB

## Rollout
- Schema version stays at 1 (additive fields only: ``workspace.tags``, ``teams[i].initialSlots``)
- Old localStorage hydrates cleanly — absent tags just stay neutral
- Feature gating: every new UI element degrades gracefully when its inputs are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)