### PR TITLE
Draft Tier 3: sparkline, MDV heatmap, nominations, triage mode

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -1393,3 +1393,203 @@ describe("nextBestTargets", () => {
     expect(nextBestTargets(null)).toEqual([]);
   });
 });
+
+// ── Tier 3 ──────────────────────────────────────────────────────────────
+
+import {
+  computeHistorySeries,
+  nominationCandidates,
+} from "@/lib/draft-logic";
+
+describe("teamStats — Tier 3 per-team signals", () => {
+  it("mdv = remaining / slotsRemaining; 0 when no slots left", () => {
+    const ws = createDefaultWorkspace();
+    const stats = computeDraftStats(ws);
+    const mine = stats.teamStats[0];
+    // Russini: 417 / 6 ≈ 69.5
+    expect(mine.mdv).toBeCloseTo(417 / 6, 4);
+  });
+
+  it("overpayIndex is null before any picks", () => {
+    const ws = createDefaultWorkspace();
+    const stats = computeDraftStats(ws);
+    for (const t of stats.teamStats) {
+      expect(t.overpayIndex).toBeNull();
+      expect(t.preDraftSum).toBe(0);
+    }
+  });
+
+  it("overpayIndex > 0 when a team pays over PreDraft", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 5,
+      amount: 200, // $65 over fair
+    });
+    const stats = computeDraftStats(withPick);
+    const overpayer = stats.teamStats[5];
+    expect(overpayer.overpayIndex).toBeCloseTo((200 - 135) / 135, 4);
+  });
+
+  it("overpayIndex < 0 for a value hunter", () => {
+    const ws = createDefaultWorkspace();
+    const mendoza = ws.players.find((p) => p.name === "Fernando Mendoza");
+    const withPick = recordPick(ws, {
+      playerId: mendoza.id,
+      teamIdx: 4,
+      amount: 50, // $52 under fair
+    });
+    const stats = computeDraftStats(withPick);
+    const hunter = stats.teamStats[4];
+    expect(hunter.overpayIndex).toBeCloseTo((50 - 102) / 102, 4);
+    expect(hunter.overpayIndex).toBeLessThan(0);
+  });
+
+  it("overpayIndex aggregates across multiple picks", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const mendoza = ws.players.find((p) => p.name === "Fernando Mendoza");
+    let next = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 5,
+      amount: 200,
+    });
+    next = recordPick(next, {
+      playerId: mendoza.id,
+      teamIdx: 5,
+      amount: 120,
+    });
+    const stats = computeDraftStats(next);
+    const t = stats.teamStats[5];
+    // Paid 320, preDraft 237 → overpayIndex = (320 - 237) / 237
+    expect(t.preDraftSum).toBe(135 + 102);
+    expect(t.overpayIndex).toBeCloseTo((320 - 237) / 237, 4);
+    expect(t.picksCount).toBe(2);
+  });
+});
+
+describe("nominationCandidates", () => {
+  it("returns empty when stats is null or missing", () => {
+    expect(nominationCandidates(null)).toEqual([]);
+    expect(nominationCandidates({})).toEqual([]);
+  });
+
+  it("excludes drafted players", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 0,
+      amount: 120,
+    });
+    const stats = computeDraftStats(withPick);
+    const list = nominationCandidates(stats, { limit: 72 });
+    expect(list.find((n) => n.player.name === "Jeremiyah Love")).toBeUndefined();
+  });
+
+  it("excludes target-tagged players (never nominate my own targets)", () => {
+    let ws = createDefaultWorkspace();
+    ws = setPlayerTag(ws, "jeremiyah-love", TAG_TARGET);
+    const stats = computeDraftStats(ws);
+    const list = nominationCandidates(stats, { limit: 72 });
+    expect(list.find((n) => n.player.name === "Jeremiyah Love")).toBeUndefined();
+  });
+
+  it("AVOID-tagged players get a ~1.8× score boost", () => {
+    let ws = createDefaultWorkspace();
+    // Tag Lemon (preDraft 90) as avoid; Tate (preDraft 83) stays
+    // neutral.  Both are S tier with similar expected drain.  The
+    // avoid tag should pull Lemon ahead of Tate in the ranking.
+    ws = setPlayerTag(ws, "makai-lemon", TAG_AVOID);
+    const stats = computeDraftStats(ws);
+    const list = nominationCandidates(stats, { limit: 10 });
+    const lemonIdx = list.findIndex(
+      (n) => n.player.name === "Makai Lemon",
+    );
+    const tateIdx = list.findIndex(
+      (n) => n.player.name === "Carnell Tate",
+    );
+    expect(lemonIdx).toBeGreaterThanOrEqual(0);
+    expect(tateIdx).toBeGreaterThanOrEqual(0);
+    expect(lemonIdx).toBeLessThan(tateIdx);
+  });
+
+  it("score is capped by top competitor affordability (drain floor)", () => {
+    // Strip all other teams' budgets so drain potential = 0.
+    const ws = createDefaultWorkspace();
+    const bankrupt = {
+      ...ws,
+      teams: ws.teams.map((t, i) =>
+        i === 0 ? t : { ...t, initialBudget: 0 },
+      ),
+    };
+    const stats = computeDraftStats(bankrupt);
+    expect(stats.topCompetitorMax).toBe(0);
+    // drain < 1 → player skipped entirely
+    const list = nominationCandidates(stats, { limit: 72 });
+    expect(list.length).toBe(0);
+  });
+
+  it("carries a rationale on every entry", () => {
+    const stats = computeDraftStats(createDefaultWorkspace());
+    const list = nominationCandidates(stats, { limit: 3 });
+    for (const entry of list) {
+      expect(typeof entry.rationale).toBe("string");
+      expect(entry.rationale.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("computeHistorySeries", () => {
+  it("returns baseline + one entry per pick in ts order", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    const mendoza = ws.players.find((p) => p.name === "Fernando Mendoza");
+    const p1 = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 5,
+      amount: 135,
+    });
+    // Mutate the second pick's ts so it's strictly later (recordPick
+    // uses Date.now(), which may collide within a single tick).
+    const p2 = recordPick(p1, {
+      playerId: mendoza.id,
+      teamIdx: 4,
+      amount: 102,
+    });
+    p2.picks[1].ts = p2.picks[0].ts + 1000;
+
+    const series = computeHistorySeries(p2);
+    expect(series.length).toBe(3); // baseline + 2 picks
+    expect(series[0].picksCount).toBe(0);
+    expect(series[1].picksCount).toBe(1);
+    expect(series[2].picksCount).toBe(2);
+    expect(series[0].inflation).toBeCloseTo(1.0, 4);
+  });
+
+  it("reflects inflation shifts as picks accumulate", () => {
+    const ws = createDefaultWorkspace();
+    const love = ws.players.find((p) => p.name === "Jeremiyah Love");
+    // Massive overpay → inflation drops.
+    const withPick = recordPick(ws, {
+      playerId: love.id,
+      teamIdx: 5,
+      amount: 300,
+    });
+    const series = computeHistorySeries(withPick);
+    expect(series[0].inflation).toBeCloseTo(1.0, 4);
+    expect(series[1].inflation).toBeLessThan(series[0].inflation);
+  });
+
+  it("empty workspace yields just the baseline entry", () => {
+    const series = computeHistorySeries(createDefaultWorkspace());
+    expect(series.length).toBe(1);
+    expect(series[0].picksCount).toBe(0);
+  });
+
+  it("handles null input gracefully", () => {
+    const series = computeHistorySeries(null);
+    expect(series.length).toBe(1);
+  });
+});

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/app/AppShellWrapper";
 import {
@@ -13,11 +13,13 @@ import {
   addPlayer,
   bidStatus,
   computeDraftStats,
+  computeHistorySeries,
   createDefaultWorkspace,
   cycleTag,
   hydrateWorkspace,
   mergeDraftCapitalTeams,
   nextBestTargets,
+  nominationCandidates,
   playerRecommendation,
   playerSlug,
   recordPick,
@@ -66,14 +68,15 @@ function fmtMultiplier(n) {
 
 /* ── Inflation stats strip ────────────────────────────────────────── */
 
-function StatsStrip({ stats }) {
-  const stat = (label, value, title, extraClass = "") => (
+function StatsStrip({ stats, historySeries }) {
+  const stat = (label, value, title, extraClass = "", extra = null) => (
     <div
       className={`draft-stat ${extraClass}`.trim()}
       title={title || undefined}
     >
       <div className="draft-stat-label">{label}</div>
       <div className="draft-stat-value">{value}</div>
+      {extra}
     </div>
   );
 
@@ -105,8 +108,9 @@ function StatsStrip({ stats }) {
       {stat(
         "Inflation",
         fmtMultiplier(stats.inflation),
-        "RemainingLeague$ / (TotalAuction$ − Σ soldPreDraft). >1.00 means the remaining market is cheaper than projected; <1.00 means the remaining market got hot.",
+        "RemainingLeague$ / (TotalAuction$ − Σ soldPreDraft). >1.00 means the remaining market is cheaper than projected; <1.00 means the remaining market got hot.  Sparkline shows trajectory over picks.",
         inflationClass,
+        <InflationSparkline series={historySeries} width={138} height={28} />,
       )}
       {stat(
         "My remaining",
@@ -240,10 +244,44 @@ function TeamPanel({
           >
             Eff $
           </span>
+          <span
+            title="Marginal Dollar Value = remaining $ / slots remaining.  Higher = more $ per pick = buying power.  Shaded by pressure tier."
+          >
+            MDV
+          </span>
+          <span
+            title="Overpay index = (Σ paid − Σ preDraft at pick time) / Σ preDraft. >0 overpayer, <0 value hunter, ~0 market-rational."
+          >
+            Over%
+          </span>
         </div>
         {stats.teamStats.map((t) => {
           const effLow = t.effectiveBudget < 5;
           const slotsEmpty = t.slotsRemaining <= 0;
+          // MDV heatmap: compare each team's MDV to the median across
+          // non-bankrupt teams.  Red = meaningfully below median
+          // (pressed for $); green = meaningfully above (flush).
+          // Gray = near median.
+          const mdvClass =
+            slotsEmpty
+              ? "draft-mdv-empty"
+              : t.mdv >= 40
+                ? "draft-mdv-high"
+                : t.mdv >= 15
+                  ? "draft-mdv-mid"
+                  : "draft-mdv-low";
+          const overpayClass =
+            t.overpayIndex == null
+              ? "muted"
+              : t.overpayIndex > 0.1
+                ? "draft-money-overpay"
+                : t.overpayIndex < -0.1
+                  ? "draft-money-value"
+                  : "draft-money";
+          const overpayText =
+            t.overpayIndex == null
+              ? "—"
+              : `${t.overpayIndex > 0 ? "+" : ""}${(t.overpayIndex * 100).toFixed(0)}%`;
           return (
             <div
               key={t.idx}
@@ -293,6 +331,27 @@ function TeamPanel({
                 title="Slot-adjusted effective $: what this team can actually bid on a single player while reserving $1 each for their remaining slots."
               >
                 {fmt$(t.effectiveBudget)}
+              </span>
+              <span
+                className={`draft-money draft-mdv ${mdvClass}`}
+                title={`Marginal $/slot: ${fmt$(t.mdv)} over ${t.slotsRemaining} slot${t.slotsRemaining === 1 ? "" : "s"}`}
+              >
+                {slotsEmpty ? "—" : fmt$(t.mdv)}
+              </span>
+              <span
+                className={overpayClass}
+                style={{
+                  fontFamily: "var(--mono, monospace)",
+                  textAlign: "right",
+                  fontSize: "0.76rem",
+                }}
+                title={
+                  t.overpayIndex == null
+                    ? "No picks yet"
+                    : `Paid ${fmt$(t.spent)} vs expected ${fmt$(t.preDraftSum)}`
+                }
+              >
+                {overpayText}
               </span>
             </div>
           );
@@ -721,6 +780,7 @@ function RookieBoard({
   onEditPreDraft,
   onRemovePlayer,
   onCycleTag,
+  searchInputRef,
   showDrafted,
   onShowDraftedChange,
   query,
@@ -840,11 +900,12 @@ function RookieBoard({
         <h3 style={{ margin: 0 }}>Rookie board</h3>
         <div className="draft-board-controls">
           <input
+            ref={searchInputRef}
             className="input"
-            placeholder="Search player…"
+            placeholder="Search player… (press / )"
             value={query}
             onChange={(e) => onQueryChange(e.target.value)}
-            style={{ width: 180 }}
+            style={{ width: 200 }}
           />
           <label className="draft-check">
             <input
@@ -1122,6 +1183,182 @@ function RookieBoard({
  * or re-sort.  Clicking a row opens the draft modal pre-loaded with
  * that player; clicking the star cycles the tag.
  */
+/* ── Inflation sparkline ──────────────────────────────────────────── */
+
+/**
+ * Tiny SVG sparkline of inflation (y-axis) over picks (x-axis).
+ * Renders inline in the stats strip so the user can see "inflation
+ * has been climbing 3 picks straight" at a glance without scrolling
+ * back through the pick log.
+ *
+ * Draws a horizontal reference line at 1.00×; the main path is a
+ * polyline over the ``series``, color-coded by the most recent
+ * direction (green = above 1.0, red = below, muted when flat).
+ */
+function InflationSparkline({ series, width = 140, height = 36 }) {
+  if (!Array.isArray(series) || series.length < 2) {
+    return (
+      <span className="muted" style={{ fontSize: "0.68rem" }}>
+        (sparkline populates after first pick)
+      </span>
+    );
+  }
+  const values = series.map((s) => s.inflation);
+  const minV = Math.min(0.7, ...values);
+  const maxV = Math.max(1.3, ...values);
+  const range = Math.max(0.01, maxV - minV);
+  const padX = 2;
+  const padY = 2;
+  const w = width - padX * 2;
+  const h = height - padY * 2;
+
+  const pts = values.map((v, i) => {
+    const x = padX + (i / Math.max(1, series.length - 1)) * w;
+    const y = padY + h - ((v - minV) / range) * h;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  // Reference line at 1.00×.
+  const refY = padY + h - ((1 - minV) / range) * h;
+
+  const last = values[values.length - 1];
+  const color =
+    last > 1.03
+      ? "var(--green)"
+      : last < 0.97
+        ? "var(--red)"
+        : "var(--muted)";
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="draft-sparkline"
+      role="img"
+      aria-label={`Inflation trajectory, currently ${last.toFixed(2)}×`}
+    >
+      <line
+        x1={padX}
+        y1={refY}
+        x2={width - padX}
+        y2={refY}
+        stroke="rgba(153,166,200,0.3)"
+        strokeWidth="0.5"
+        strokeDasharray="2 2"
+      />
+      <polyline
+        points={pts.join(" ")}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx={padX + w}
+        cy={refY - ((last - 1) / range) * h}
+        r="2"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+/* ── Nomination optimizer sidebar ─────────────────────────────────── */
+
+/**
+ * "Good to nominate" list.  Players I don't want (or am happy
+ * without) whose expected clearing price is high enough to drain
+ * rival budgets.  Companion to ``NextBestTargets``; both live just
+ * above the rookie board so decisions are in peripheral vision.
+ */
+function NominationCandidates({ stats, onDraft, onCycleTag }) {
+  const list = useMemo(
+    () => nominationCandidates(stats, { limit: 5 }),
+    [stats],
+  );
+
+  if (list.length === 0) {
+    return (
+      <div className="card draft-nbt">
+        <h3 style={{ margin: "0 0 4px" }}>Good to nominate</h3>
+        <div className="muted" style={{ fontSize: "0.72rem" }}>
+          No drain candidates — rivals are too tight or everyone is
+          already tagged as target.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card draft-nbt">
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+        }}
+      >
+        <h3 style={{ margin: 0 }}>Good to nominate</h3>
+        <span className="muted" style={{ fontSize: "0.68rem" }}>
+          Drain rival $ without risking a target
+        </span>
+      </div>
+      <div className="draft-nbt-list">
+        {list.map(({ player, score, drain, rationale }, i) => (
+          <div
+            key={player.id}
+            className={`draft-nbt-row${player.userTag === TAG_AVOID ? " draft-nbt-avoid" : ""}`}
+            title={rationale}
+          >
+            <span className="draft-nbt-rank">#{i + 1}</span>
+            <button
+              type="button"
+              className={`draft-tag-chip${
+                player.userTag ? ` draft-tag-${player.userTag}` : ""
+              }`}
+              onClick={() => onCycleTag(player.id)}
+              title="Cycle tag"
+            >
+              {player.userTag === TAG_TARGET
+                ? "★"
+                : player.userTag === TAG_AVOID
+                  ? "⊘"
+                  : "+"}
+            </button>
+            <span
+              className={`draft-tier-chip draft-tier-${player.tier}`}
+              title={`${TIER_LABELS[player.tier] || player.tier} tier`}
+            >
+              {player.tier}
+            </span>
+            <span className="draft-nbt-name" onClick={() => onDraft(player)}>
+              {player.name}
+            </span>
+            <span className="draft-money">fair {fmt$(player.inflatedFair)}</span>
+            <span className="muted" style={{ fontSize: "0.68rem" }}>
+              drain {fmt$(drain)}
+            </span>
+            <span
+              className={`draft-rec-chip ${
+                player.userTag === TAG_AVOID
+                  ? "draft-rec-avoid"
+                  : "draft-rec-neutral"
+              }`}
+            >
+              {player.userTag === TAG_AVOID ? "AVOID" : "DRAIN"}
+            </span>
+            <span className="muted" style={{ fontSize: "0.66rem" }}>
+              S {Math.round(score)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function NextBestTargets({ stats, onDraft, onCycleTag, workspace }) {
   const top = useMemo(
     () => nextBestTargets(stats, { limit: 5 }),
@@ -1260,6 +1497,13 @@ export default function DraftDashboardPage() {
   const [showDrafted, setShowDrafted] = useState(false);
   const [query, setQuery] = useState("");
   const [tagFilter, setTagFilter] = useState("all"); // all | target | avoid | untagged
+  // Late-draft triage mode: when my slotPressure crosses 0.7, auto-
+  // flip the board filter to "Targets" so I see only the players I
+  // still want.  Tracked so a user who manually changes the filter
+  // AFTER auto-switch isn't fought by the effect every re-render.
+  const [triageApplied, setTriageApplied] = useState(false);
+  const [triageDismissed, setTriageDismissed] = useState(false);
+  const searchInputRef = useRef(null);
   const [capitalStatus, setCapitalStatus] = useState({
     loading: false,
     error: "",
@@ -1300,6 +1544,42 @@ export default function DraftDashboardPage() {
   }, [workspace, hydrated]);
 
   const stats = useMemo(() => computeDraftStats(workspace), [workspace]);
+  // Retrospective inflation trajectory — O(N²) in pick count, but
+  // N caps at ~72 so negligible.  Feeds the sparkline in the stats
+  // strip and any future "how did we get here" retrospectives.
+  const historySeries = useMemo(
+    () => computeHistorySeries(workspace),
+    [workspace],
+  );
+
+  // Late-draft triage: when my slot pressure crosses 0.7, auto-flip
+  // the tag filter to "target" so only players I still want appear
+  // on the board.  Only fires ONCE (via triageApplied) so a user
+  // who manually changes the filter after the flip isn't fought by
+  // the effect.  triageDismissed lets the user opt out explicitly.
+  const LATE_DRAFT_THRESHOLD = 0.7;
+  useEffect(() => {
+    if (triageApplied || triageDismissed) return;
+    if ((stats.slotPressure || 0) >= LATE_DRAFT_THRESHOLD) {
+      setTagFilter("target");
+      setTriageApplied(true);
+    }
+  }, [stats.slotPressure, triageApplied, triageDismissed]);
+
+  // "/" focuses the search input (skip when already typing).
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key !== "/") return;
+      const tag = (e.target?.tagName || "").toLowerCase();
+      const editable =
+        tag === "input" || tag === "textarea" || tag === "select";
+      if (editable) return;
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   // Pull per-team auction $ budgets from /api/draft-capital.  The
   // dashboard needs this to mirror real carry-over balances without
@@ -1495,7 +1775,7 @@ export default function DraftDashboardPage() {
         </div>
       </div>
 
-      <StatsStrip stats={stats} />
+      <StatsStrip stats={stats} historySeries={historySeries} />
 
       <div className="draft-top-grid">
         <TeamPanel
@@ -1509,12 +1789,55 @@ export default function DraftDashboardPage() {
         <BidKnobs settings={workspace.settings || {}} onSettings={onSettings} />
       </div>
 
-      <NextBestTargets
-        stats={stats}
-        onDraft={(p) => setModalPlayer(p)}
-        onCycleTag={onCycleTag}
-        workspace={workspace}
-      />
+      {/* Late-draft triage banner — visible once the auto-filter
+          fires.  Tells the user what just happened and offers an
+          "escape hatch" back to the full view.  Dismiss persists
+          within the session; reload resets to auto-behavior. */}
+      {triageApplied && !triageDismissed && (
+        <div className="draft-triage-banner">
+          <strong>LATE-DRAFT TRIAGE</strong>
+          <span>
+            Slot pressure {Math.round((stats.slotPressure || 0) * 100)}% —
+            auto-filtered to your Targets so you only see players you
+            still want.
+          </span>
+          <div style={{ display: "flex", gap: 6, marginLeft: "auto" }}>
+            <button
+              className="button"
+              style={{ fontSize: "0.7rem", padding: "2px 8px" }}
+              onClick={() => {
+                setTagFilter("all");
+                setTriageDismissed(true);
+              }}
+              title="Go back to the full board"
+            >
+              Show all
+            </button>
+            <button
+              className="button"
+              style={{ fontSize: "0.7rem", padding: "2px 8px" }}
+              onClick={() => setTriageDismissed(true)}
+              title="Keep the filter but dismiss this banner"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="draft-sidebar-grid">
+        <NextBestTargets
+          stats={stats}
+          onDraft={(p) => setModalPlayer(p)}
+          onCycleTag={onCycleTag}
+          workspace={workspace}
+        />
+        <NominationCandidates
+          stats={stats}
+          onDraft={(p) => setModalPlayer(p)}
+          onCycleTag={onCycleTag}
+        />
+      </div>
 
       <RookieBoard
         stats={stats}
@@ -1523,6 +1846,7 @@ export default function DraftDashboardPage() {
         onEditPreDraft={onEditPreDraft}
         onRemovePlayer={onRemovePlayer}
         onCycleTag={onCycleTag}
+        searchInputRef={searchInputRef}
         showDrafted={showDrafted}
         onShowDraftedChange={setShowDrafted}
         query={query}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3664,8 +3664,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .draft-team-row {
   display: grid;
-  grid-template-columns: 32px 1fr 72px 60px 72px 56px 62px;
-  gap: 6px;
+  grid-template-columns: 30px 1fr 62px 52px 64px 52px 56px 56px 46px;
+  gap: 5px;
   align-items: center;
   padding: 4px 0;
 }
@@ -4253,3 +4253,86 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .draft-sim-delta-up { color: var(--green); }
 .draft-sim-delta-down { color: var(--red); }
 .draft-sim-delta-muted { color: var(--muted); }
+
+/* ── Tier 3: sparkline, MDV heatmap, overpay colors, nomination
+      sidebar, triage banner ──────────────────────────────────── */
+
+.draft-sparkline {
+  display: block;
+  margin-top: 4px;
+}
+
+/* MDV heatmap cell backgrounds */
+.draft-mdv {
+  border-radius: 4px;
+  padding: 0 4px;
+  line-height: 1.3;
+}
+.draft-mdv-high {
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--green);
+}
+.draft-mdv-mid {
+  background: rgba(153, 166, 200, 0.08);
+  color: var(--muted);
+}
+.draft-mdv-low {
+  background: rgba(248, 113, 113, 0.1);
+  color: var(--red);
+}
+.draft-mdv-empty {
+  color: var(--subtext);
+  opacity: 0.6;
+}
+
+/* Overpay index text coloring */
+.draft-money-overpay {
+  color: var(--red);
+  font-weight: 600;
+}
+.draft-money-value {
+  color: var(--green);
+  font-weight: 600;
+}
+
+/* Sidebar grid holding NextBestTargets + NominationCandidates */
+.draft-sidebar-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+@media (max-width: 980px) {
+  .draft-sidebar-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.draft-nbt-avoid {
+  background: rgba(248, 113, 113, 0.05);
+}
+
+/* Triage banner */
+.draft-triage-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  background: rgba(255, 198, 47, 0.08);
+  border: 1px solid var(--cyan);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  flex-wrap: wrap;
+}
+.draft-triage-banner strong {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  border: 1px solid var(--cyan);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+.draft-triage-banner span {
+  color: var(--text);
+}

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -568,14 +568,35 @@ export function computeDraftStats(workspace) {
   const tagMap = (ws.tags && typeof ws.tags === "object") ? ws.tags : {};
 
   // Per-team stats (name, initial, spent, remaining, slots, eff$).
+  //
+  // Tier 3 additions per team:
+  //   mdv           — marginal dollar value (remaining / slots left).
+  //                   Used in the budget-pressure heatmap.
+  //   overpayIndex  — (Σ paid − Σ preDraftAtPick) / Σ preDraftAtPick
+  //                   across all picks.  Null when no picks yet.
+  //                   > 0: overpayer.  < 0: value hunter.  ~0: rational.
+  //                   Surfaces in the Teams panel so "who's running hot
+  //                   and will likely overpay again" is visible at a
+  //                   glance.
   const teamStats = teams.map((t, idx) => {
-    const spent = picksByTeam[idx].reduce(
+    const teamPicks = picksByTeam[idx];
+    const spent = teamPicks.reduce(
       (s, p) => s + (Number(p.amount) || 0),
       0,
     );
     const initial = Number(t.initialBudget) || 0;
     const remaining = remainingByIdx[idx];
-    const picksCount = picksByTeam[idx].length;
+    const picksCount = teamPicks.length;
+    const preDraftSum = teamPicks.reduce((s, pk) => {
+      const snap = Number.isFinite(Number(pk.preDraftAtPick))
+        ? Math.max(0, Number(pk.preDraftAtPick))
+        : playerPreDraftById.get(pk.playerId) || 0;
+      return s + snap;
+    }, 0);
+    const overpayIndex =
+      preDraftSum > 0 ? (spent - preDraftSum) / preDraftSum : null;
+    const slotsLeft = slotsRemainingByIdx[idx];
+    const mdv = slotsLeft > 0 ? remaining / slotsLeft : 0;
     return {
       idx,
       name: t.name || `Team ${idx + 1}`,
@@ -586,8 +607,11 @@ export function computeDraftStats(workspace) {
       isMine: idx === myTeamIdx,
       initialSlots: initialSlotsByIdx[idx],
       slotsDrafted: slotsDraftedByIdx[idx],
-      slotsRemaining: slotsRemainingByIdx[idx],
+      slotsRemaining: slotsLeft,
       effectiveBudget: effectiveBudgetByIdx[idx],
+      mdv,
+      preDraftSum,
+      overpayIndex,
     };
   });
 
@@ -1245,6 +1269,132 @@ export function nextBestTargets(stats, { limit = 5 } = {}) {
   });
 
   return candidates.slice(0, limit);
+}
+
+// ── Nomination optimizer ───────────────────────────────────────────────
+/**
+ * Rank undrafted players by "good nomination" score.  A good
+ * nomination is a player the user DOESN'T want, whose expected
+ * clearing price is high enough to drain rival budgets, without
+ * creating significant risk of the user being stuck with them.
+ *
+ * Score model:
+ *
+ *   expected_price(p) = p.inflatedFair
+ *   affordable(p)     = min(expected_price, topCompetitorMax)
+ *     — rivals can't pay more than their effective ceiling; a
+ *       player with fair $50 facing $20-max rivals drains at most $20.
+ *   tag_weight(p):
+ *     avoid    → 1.8    // I actively want them off the board
+ *     neutral  → 1.0
+ *     target   → 0      // never nominate my own targets
+ *   risk_of_winning(p) = if my_winning_bid exceeds expected_price by
+ *     a wide margin, I might accidentally win them.  For neutrals we
+ *     dampen the score by this risk factor; avoid-tagged players are
+ *     assumed acceptable to win (user chose the tag).
+ *
+ *   score(p) = affordable × tag_weight × (1 − risk_factor)
+ *
+ * Excludes drafted players and my targets.  Returns top ``limit``
+ * candidates sorted descending by score.
+ */
+export function nominationCandidates(stats, { limit = 5 } = {}) {
+  if (!stats || !Array.isArray(stats.enrichedPlayers)) return [];
+  const out = [];
+  const topCompetitor = Math.max(0, stats.topCompetitorMax || 0);
+  for (const p of stats.enrichedPlayers) {
+    if (p.drafted) continue;
+    if (p.userTag === TAG_TARGET) continue;
+
+    const expectedPrice = Math.max(0, p.inflatedFair || 0);
+    if (expectedPrice <= 0) continue;
+
+    // Cap drain potential by rival affordability.  A $50 fair player
+    // with no rivals over $20 only drains $20 from the pool no matter
+    // how much the nomination theoretically costs.
+    const drain = Math.min(expectedPrice, topCompetitor);
+    if (drain < 1) continue;
+
+    const tagWeight = p.userTag === TAG_AVOID ? 1.8 : 1.0;
+
+    // Risk of accidentally winning: only meaningful for neutrals.  If
+    // I could win by beating the competitor ceiling cheaply, there's
+    // a nontrivial chance nobody else bids much and I end up stuck.
+    // Avoid-tagged players: user opted in, risk_factor = 0.
+    let riskFactor = 0;
+    if (p.userTag !== TAG_AVOID) {
+      const myExcess = Math.max(0, p.myWinningBid - expectedPrice);
+      // Normalize roughly to 0..1 — excess of $30+ over expected
+      // price is a strong "you might actually win this" signal.
+      riskFactor = Math.min(1, myExcess / 30);
+    }
+
+    const score = drain * tagWeight * (1 - riskFactor);
+    if (score <= 0) continue;
+
+    out.push({
+      player: p,
+      score,
+      drain,
+      expectedPrice,
+      rationale:
+        p.userTag === TAG_AVOID
+          ? `Avoid-tagged · clears ~$${Math.round(drain)} from rivals`
+          : `Drains ~$${Math.round(drain)} from rivals at fair price`,
+    });
+  }
+
+  out.sort((a, b) => b.score - a.score);
+  return out.slice(0, limit);
+}
+
+// ── Inflation history series ───────────────────────────────────────────
+/**
+ * Re-simulate the draft pick-by-pick to produce a time series of
+ * ``{picksCount, timestamp, inflation, topCompetitorMax, leagueSpentPct,
+ * budgetAdvantage}`` snapshots — one per pick plus the draft-start
+ * zeroed baseline.
+ *
+ * Used for the inflation sparkline and any other "how did we get
+ * here?" retrospective UI.  Runs ``computeDraftStats`` N+1 times
+ * (N = number of picks) so O(N²) relative to the pick list, but N
+ * caps at 72 in our league and each computeDraftStats call is
+ * cheap, so total cost is negligible even mid-draft.
+ *
+ * Picks are sorted by ``ts`` ascending so the series reflects
+ * actual draft order regardless of any edit-then-re-record churn.
+ */
+export function computeHistorySeries(workspace) {
+  const ws = workspace || createDefaultWorkspace();
+  const picks = Array.isArray(ws.picks) ? [...ws.picks] : [];
+  picks.sort((a, b) => (a.ts || 0) - (b.ts || 0));
+
+  const series = [];
+  // Baseline (no picks).
+  const base = computeDraftStats({ ...ws, picks: [] });
+  series.push({
+    picksCount: 0,
+    timestamp: null,
+    inflation: base.inflation,
+    topCompetitorMax: base.topCompetitorMax,
+    leagueSpentPct: base.leagueSpentPct,
+    budgetAdvantage: base.budgetAdvantage,
+  });
+
+  for (let i = 0; i < picks.length; i++) {
+    const cumulative = picks.slice(0, i + 1);
+    const s = computeDraftStats({ ...ws, picks: cumulative });
+    series.push({
+      picksCount: i + 1,
+      timestamp: picks[i].ts || null,
+      inflation: s.inflation,
+      topCompetitorMax: s.topCompetitorMax,
+      leagueSpentPct: s.leagueSpentPct,
+      budgetAdvantage: s.budgetAdvantage,
+    });
+  }
+
+  return series;
 }
 
 /**


### PR DESCRIPTION
## Summary
Final tier of the draft dashboard roadmap. Five advanced features:

1. **Inflation trajectory sparkline** — SVG polyline in the stats strip showing inflation over picks; direction-colored dot on the current value
2. **MDV + Overpay Index per team** — new Teams-panel columns with heatmap coloring so you can see at a glance who's running tight and who's chasing
3. **Nomination optimizer sidebar** — "Good to nominate" top-5 scored by rival drain × tag boost × inverse-risk; excludes targets
4. **Late-draft triage mode** — auto-filters board to Targets when slotPressure ≥ 0.7, with a dismissible banner
5. **``/`` keyboard shortcut** — focuses the search box, skipping when already typing in another input

## Math (new)

```
MDV(team)           = remaining $ / slots left
OverpayIndex(team)  = (Σ paid − Σ preDraftAtPick) / Σ preDraftAtPick
NominationScore(p)  = min(fair, topCompetitorMax) × tagWeight × (1 − riskOfWinning)
                      where tagWeight = 1.8 for AVOID, 1.0 for neutral, 0 for target
```

## Test plan
- [x] ``npx vitest run __tests__/draft-logic.test.js`` — 123/123 pass (15 new)
- [x] Full frontend suite — 609/611 (2 pre-existing ``dynasty-data.test.js/rankHistory`` failures unrelated)
- [x] ``npm run build`` — clean; /draft at 15.2 kB

## Rollout notes
- No schema bump (teamStats fields are additive)
- Sparkline gracefully shows placeholder text until first pick recorded
- Triage banner fires only once per session via ``triageApplied`` flag; dismiss persists through re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)