### PR TITLE
Draft: Target Board, Bayesian nomination inference, keyboard shortcuts

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -1593,3 +1593,428 @@ describe("computeHistorySeries", () => {
     expect(series.length).toBe(1);
   });
 });
+
+// ── Target Board + Nominations + Bayesian ceiling (post-Tier-3 follow-on) ──
+
+import {
+  NOMINATION_DECAY,
+  TARGET_BOARD_MAX,
+  TIER_INTEREST_MIN,
+  addToTargetBoard,
+  clearTargetBoard,
+  moveTargetInBoard,
+  recordNomination,
+  removeFromTargetBoard,
+  removeNomination,
+  undoLastNomination,
+} from "@/lib/draft-logic";
+
+describe("addToTargetBoard", () => {
+  it("appends player and auto-applies target tag", () => {
+    const ws = createDefaultWorkspace();
+    const next = addToTargetBoard(ws, "jeremiyah-love");
+    expect(next.targetBoard).toEqual(["jeremiyah-love"]);
+    expect(next.tags["jeremiyah-love"]).toBe(TAG_TARGET);
+  });
+
+  it("no-op if already on the board", () => {
+    const ws = addToTargetBoard(
+      createDefaultWorkspace(),
+      "jeremiyah-love",
+    );
+    const again = addToTargetBoard(ws, "jeremiyah-love");
+    expect(again.targetBoard.length).toBe(1);
+  });
+
+  it("capped at TARGET_BOARD_MAX (6)", () => {
+    let ws = createDefaultWorkspace();
+    for (let i = 0; i < 8; i++) {
+      ws = addToTargetBoard(ws, ws.players[i].id);
+    }
+    expect(ws.targetBoard.length).toBe(TARGET_BOARD_MAX);
+    expect(TARGET_BOARD_MAX).toBe(6);
+  });
+
+  it("preserves order in the board array", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToTargetBoard(ws, "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    ws = addToTargetBoard(ws, "carnell-tate");
+    expect(ws.targetBoard).toEqual([
+      "jeremiyah-love",
+      "makai-lemon",
+      "carnell-tate",
+    ]);
+  });
+
+  it("empty playerId is a no-op", () => {
+    const ws = createDefaultWorkspace();
+    expect(addToTargetBoard(ws, "").targetBoard).toEqual([]);
+  });
+});
+
+describe("removeFromTargetBoard", () => {
+  it("removes the player but keeps the target tag", () => {
+    let ws = addToTargetBoard(createDefaultWorkspace(), "jeremiyah-love");
+    const next = removeFromTargetBoard(ws, "jeremiyah-love");
+    expect(next.targetBoard).toEqual([]);
+    // Tag stays — the two concepts are independent.
+    expect(next.tags["jeremiyah-love"]).toBe(TAG_TARGET);
+  });
+});
+
+describe("clearTargetBoard", () => {
+  it("empties the board but leaves tags alone", () => {
+    let ws = addToTargetBoard(createDefaultWorkspace(), "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    const cleared = clearTargetBoard(ws);
+    expect(cleared.targetBoard).toEqual([]);
+    expect(cleared.tags["jeremiyah-love"]).toBe(TAG_TARGET);
+    expect(cleared.tags["makai-lemon"]).toBe(TAG_TARGET);
+  });
+});
+
+describe("moveTargetInBoard", () => {
+  const build = () => {
+    let ws = createDefaultWorkspace();
+    ws = addToTargetBoard(ws, "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    ws = addToTargetBoard(ws, "carnell-tate");
+    return ws;
+  };
+
+  it("moves a slot up", () => {
+    const ws = build();
+    const next = moveTargetInBoard(ws, "carnell-tate", "up");
+    expect(next.targetBoard).toEqual([
+      "jeremiyah-love",
+      "carnell-tate",
+      "makai-lemon",
+    ]);
+  });
+
+  it("moves a slot down", () => {
+    const ws = build();
+    const next = moveTargetInBoard(ws, "jeremiyah-love", "down");
+    expect(next.targetBoard).toEqual([
+      "makai-lemon",
+      "jeremiyah-love",
+      "carnell-tate",
+    ]);
+  });
+
+  it("no-op at boundaries", () => {
+    const ws = build();
+    expect(moveTargetInBoard(ws, "jeremiyah-love", "up")).toBe(ws);
+    expect(moveTargetInBoard(ws, "carnell-tate", "down")).toBe(ws);
+  });
+
+  it("no-op for unknown player", () => {
+    const ws = build();
+    expect(moveTargetInBoard(ws, "ghost", "up")).toBe(ws);
+  });
+});
+
+describe("computeDraftStats — targetBoardStats", () => {
+  it("empty board yields empty totals + idle status", () => {
+    const stats = computeDraftStats(createDefaultWorkspace());
+    expect(stats.targetBoardStats.slots).toEqual([]);
+    expect(stats.targetBoardStats.portfolioStatus).toBe("idle");
+  });
+
+  it("sums fair + winBid across undrafted targets", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToTargetBoard(ws, "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    const stats = computeDraftStats(ws);
+    const tb = stats.targetBoardStats;
+    expect(tb.slots.length).toBe(2);
+    // At opening: Love fair 135, Lemon fair 90
+    expect(tb.totals.fairSum).toBe(225);
+    expect(tb.totals.remainingCount).toBe(2);
+  });
+
+  it("paid sum only counts targets drafted to me", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToTargetBoard(ws, "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    // I grab Love at $60; rival grabs Lemon at $50.
+    ws = recordPick(ws, {
+      playerId: "jeremiyah-love",
+      teamIdx: 0,
+      amount: 60,
+    });
+    ws = recordPick(ws, {
+      playerId: "makai-lemon",
+      teamIdx: 4,
+      amount: 50,
+    });
+    const stats = computeDraftStats(ws);
+    const tb = stats.targetBoardStats;
+    expect(tb.totals.mineCount).toBe(1);
+    expect(tb.totals.otherCount).toBe(1);
+    expect(tb.totals.paidSum).toBe(60);
+    expect(tb.totals.remainingCount).toBe(0);
+  });
+
+  it("portfolioBuffer = myRemaining − remainingWinBid − nonTargetSlotsLeft × $1", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToTargetBoard(ws, "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    const stats = computeDraftStats(ws);
+    const tb = stats.targetBoardStats;
+    // myRemaining=417, slotsRemaining=6, target count=2, so
+    // nonTargetSlotsLeft = 4.  winBids capped by competitor ceiling
+    // ~$68 each → winBidSum ~ 2×69 = 138.  Buffer ≈ 417 − ~138 − 4.
+    const expected = 417 - tb.totals.remainingWinBid - 4;
+    expect(tb.portfolioBuffer).toBe(expected);
+    expect(tb.portfolioStatus).toBe("on_track");
+  });
+
+  it("flags 'short' when remaining targets exceed remaining $", () => {
+    let ws = createDefaultWorkspace();
+    // Make myRemaining tiny by starting the user with a $20 budget.
+    ws = updateTeam(ws, 0, { initialBudget: 20 });
+    ws = addToTargetBoard(ws, "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    const stats = computeDraftStats(ws);
+    expect(stats.targetBoardStats.portfolioStatus).toBe("short");
+    expect(stats.targetBoardStats.portfolioBuffer).toBeLessThan(0);
+  });
+});
+
+// ── Nominations ─────────────────────────────────────────────────────────
+
+describe("recordNomination", () => {
+  it("stores playerId + team + snapshot preDraft", () => {
+    const ws = createDefaultWorkspace();
+    const next = recordNomination(ws, {
+      playerId: "jeremiyah-love",
+      nominatingTeamIdx: 4,
+    });
+    expect(next.nominations.length).toBe(1);
+    const n = next.nominations[0];
+    expect(n.playerId).toBe("jeremiyah-love");
+    expect(n.nominatingTeamIdx).toBe(4);
+    expect(n.preDraftAtNomination).toBe(135);
+    expect(typeof n.ts).toBe("number");
+  });
+
+  it("replaces an existing nomination for the same player", () => {
+    let ws = recordNomination(createDefaultWorkspace(), {
+      playerId: "jeremiyah-love",
+      nominatingTeamIdx: 4,
+    });
+    ws = recordNomination(ws, {
+      playerId: "jeremiyah-love",
+      nominatingTeamIdx: 5,
+    });
+    expect(ws.nominations.length).toBe(1);
+    expect(ws.nominations[0].nominatingTeamIdx).toBe(5);
+  });
+
+  it("no-op with invalid inputs", () => {
+    const ws = createDefaultWorkspace();
+    expect(
+      recordNomination(ws, { playerId: "", nominatingTeamIdx: 0 }).nominations,
+    ).toEqual([]);
+    expect(
+      recordNomination(ws, {
+        playerId: "jeremiyah-love",
+        nominatingTeamIdx: "bad",
+      }).nominations,
+    ).toEqual([]);
+  });
+});
+
+describe("removeNomination / undoLastNomination", () => {
+  it("removes a specific logged nomination", () => {
+    let ws = recordNomination(createDefaultWorkspace(), {
+      playerId: "jeremiyah-love",
+      nominatingTeamIdx: 4,
+    });
+    ws = removeNomination(ws, "jeremiyah-love");
+    expect(ws.nominations).toEqual([]);
+  });
+
+  it("undoLastNomination pops the newest by ts", async () => {
+    let ws = recordNomination(createDefaultWorkspace(), {
+      playerId: "jeremiyah-love",
+      nominatingTeamIdx: 4,
+    });
+    await new Promise((r) => setTimeout(r, 2));
+    ws = recordNomination(ws, {
+      playerId: "makai-lemon",
+      nominatingTeamIdx: 5,
+    });
+    expect(ws.nominations.length).toBe(2);
+    const undone = undoLastNomination(ws);
+    expect(undone.nominations.length).toBe(1);
+    expect(undone.nominations[0].playerId).toBe("jeremiyah-love");
+  });
+});
+
+describe("computeDraftStats — Bayesian tier interest", () => {
+  it("no nominations → every team tierInterest is 1.0 on every tier", () => {
+    const stats = computeDraftStats(createDefaultWorkspace());
+    for (const t of stats.teamStats) {
+      for (const def of TIER_DEFS) {
+        expect(t.tierInterest[def.key]).toBe(1);
+      }
+      expect(t.nominationsLogged).toBe(0);
+    }
+  });
+
+  it("one S nomination decays the nominator's S-tier interest once", () => {
+    const ws = recordNomination(createDefaultWorkspace(), {
+      playerId: "jeremiyah-love", // tier S
+      nominatingTeamIdx: 4,
+    });
+    const stats = computeDraftStats(ws);
+    expect(stats.teamStats[4].tierInterest.S).toBeCloseTo(
+      NOMINATION_DECAY,
+      4,
+    );
+    // Other tiers untouched.
+    expect(stats.teamStats[4].tierInterest.A).toBe(1);
+    // Other teams untouched.
+    expect(stats.teamStats[5].tierInterest.S).toBe(1);
+    expect(stats.teamStats[4].nominationsLogged).toBe(1);
+  });
+
+  it("multiple nominations stack multiplicatively", () => {
+    let ws = createDefaultWorkspace();
+    // 3 S-tier noms from team 4: 0.8^3 ≈ 0.512.
+    const sPlayers = ws.players.filter((p) => p.preDraft >= 60);
+    for (const p of sPlayers.slice(0, 3)) {
+      ws = recordNomination(ws, {
+        playerId: p.id,
+        nominatingTeamIdx: 4,
+      });
+    }
+    const stats = computeDraftStats(ws);
+    expect(stats.teamStats[4].tierInterest.S).toBeCloseTo(
+      Math.pow(NOMINATION_DECAY, 3),
+      4,
+    );
+  });
+
+  it("tierInterest is floored at TIER_INTEREST_MIN with enough noms", () => {
+    // D tier has 28+ players; 0.8^28 ≈ 0.002 which would dip well
+    // below the floor without clamping.
+    let ws = createDefaultWorkspace();
+    const dPlayers = ws.players.filter((p) => p.preDraft <= 2);
+    expect(dPlayers.length).toBeGreaterThan(20);
+    for (const p of dPlayers) {
+      ws = recordNomination(ws, {
+        playerId: p.id,
+        nominatingTeamIdx: 4,
+      });
+    }
+    const stats = computeDraftStats(ws);
+    expect(stats.teamStats[4].tierInterest.D).toBe(TIER_INTEREST_MIN);
+  });
+
+  it("bayesianTopCompetitor per player reflects tierInterest", () => {
+    // Only ONE rival is wealthy (team 1); the rest are broke.  That
+    // makes team 1 the exclusive ceiling-setter, so their decayed
+    // tier interest directly drops the Bayesian ceiling.
+    let ws = createDefaultWorkspace();
+    ws = {
+      ...ws,
+      teams: ws.teams.map((t, i) => {
+        if (i === 0) return t;
+        if (i === 1) return { ...t, initialBudget: 400 };
+        return { ...t, initialBudget: 0 };
+      }),
+    };
+    ws = recordNomination(ws, {
+      playerId: "jeremiyah-love",
+      nominatingTeamIdx: 1,
+    });
+    ws = recordNomination(ws, {
+      playerId: "fernando-mendoza",
+      nominatingTeamIdx: 1,
+    });
+    const stats = computeDraftStats(ws);
+    const makai = stats.enrichedPlayers.find(
+      (p) => p.name === "Makai Lemon",
+    );
+    expect(stats.topCompetitorMax).toBeGreaterThan(300);
+    // Team 1 nominated 2 S players → S interest ≈ 0.64 → Bayesian
+    // ceiling ≈ 0.64 × topCompetitorMax.
+    expect(makai.bayesianTopCompetitor).toBeLessThan(
+      stats.topCompetitorMax,
+    );
+    expect(makai.bayesianTopCompetitor).toBeCloseTo(
+      Math.floor(stats.topCompetitorMax * NOMINATION_DECAY * NOMINATION_DECAY),
+      0,
+    );
+  });
+
+  it("bayesianWinningBid ≤ myWinningBid (tighter ceiling)", () => {
+    const ws = recordNomination(createDefaultWorkspace(), {
+      playerId: "jeremiyah-love",
+      nominatingTeamIdx: 4,
+    });
+    const stats = computeDraftStats(ws);
+    for (const p of stats.enrichedPlayers) {
+      if (p.drafted) continue;
+      expect(p.bayesianWinningBid).toBeLessThanOrEqual(p.myWinningBid);
+    }
+  });
+});
+
+describe("hydrateWorkspace — targetBoard + nominations roundtrip", () => {
+  it("preserves targetBoard order", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToTargetBoard(ws, "jeremiyah-love");
+    ws = addToTargetBoard(ws, "makai-lemon");
+    const round = hydrateWorkspace(JSON.parse(JSON.stringify(ws)));
+    expect(round.targetBoard).toEqual(["jeremiyah-love", "makai-lemon"]);
+  });
+
+  it("truncates targetBoard to TARGET_BOARD_MAX", () => {
+    const parsed = {
+      version: 1,
+      settings: {},
+      teams: DEFAULT_TEAMS,
+      players: DEFAULT_ROOKIES.map((p) => ({
+        id: playerSlug(p.name),
+        rank: p.rank,
+        name: p.name,
+        preDraft: p.preDraft,
+      })),
+      picks: [],
+      targetBoard: [
+        "a", "b", "c", "d", "e", "f", "g", "h", // 8 > 6
+      ],
+    };
+    expect(hydrateWorkspace(parsed).targetBoard.length).toBe(
+      TARGET_BOARD_MAX,
+    );
+  });
+
+  it("preserves valid nominations and drops malformed ones", () => {
+    const parsed = {
+      version: 1,
+      settings: {},
+      teams: DEFAULT_TEAMS,
+      players: DEFAULT_ROOKIES.map((p) => ({
+        id: playerSlug(p.name),
+        rank: p.rank,
+        name: p.name,
+        preDraft: p.preDraft,
+      })),
+      picks: [],
+      nominations: [
+        { playerId: "jeremiyah-love", nominatingTeamIdx: 4, ts: 1 },
+        { playerId: "", nominatingTeamIdx: 4 }, // drop: empty id
+        { playerId: "makai-lemon", nominatingTeamIdx: "bad" }, // drop
+      ],
+    };
+    const ws = hydrateWorkspace(parsed);
+    expect(ws.nominations.length).toBe(1);
+    expect(ws.nominations[0].playerId).toBe("jeremiyah-love");
+  });
+});

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -9,23 +9,31 @@ import {
   DEFAULT_ENFORCE_PCT,
   TAG_AVOID,
   TAG_TARGET,
+  TARGET_BOARD_MAX,
   TIER_DEFS,
   addPlayer,
+  addToTargetBoard,
   bidStatus,
+  clearTargetBoard,
   computeDraftStats,
   computeHistorySeries,
   createDefaultWorkspace,
   cycleTag,
   hydrateWorkspace,
   mergeDraftCapitalTeams,
+  moveTargetInBoard,
   nextBestTargets,
   nominationCandidates,
   playerRecommendation,
   playerSlug,
+  recordNomination,
   recordPick,
+  removeFromTargetBoard,
+  removeNomination,
   removePick,
   removePlayer,
   setPlayerTag,
+  undoLastNomination,
   undoLastPick,
   updatePlayerPreDraft,
   updateSettings,
@@ -720,6 +728,82 @@ function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
               </span>
             </div>
           </div>
+
+          {/* Nomination logger — record that a rival nominated this
+              player (without recording a pick).  Drives the Bayesian
+              tier-interest priors.  ``nominatedBy`` shows the current
+              logged nominator, if any, with an undo option. */}
+          {!player.drafted && (
+            <div className="draft-modal-nom">
+              <div
+                className="muted"
+                style={{ fontSize: "0.72rem", marginBottom: 4 }}
+              >
+                Who nominated this player?
+                {(() => {
+                  const existing = (workspace.nominations || []).find(
+                    (n) => n.playerId === player.id,
+                  );
+                  if (!existing) return null;
+                  const teamName =
+                    workspace.teams[existing.nominatingTeamIdx]?.name ||
+                    `Team ${existing.nominatingTeamIdx + 1}`;
+                  return (
+                    <span
+                      style={{
+                        marginLeft: 6,
+                        color: "var(--cyan)",
+                        fontSize: "0.7rem",
+                      }}
+                    >
+                      · logged: {teamName}
+                    </span>
+                  );
+                })()}
+              </div>
+              <div className="draft-live-row">
+                <select
+                  className="select"
+                  defaultValue=""
+                  onChange={(e) => {
+                    const idx = Number(e.target.value);
+                    if (!Number.isInteger(idx)) return;
+                    onSubmit({ _nominate: true, playerId: player.id, teamIdx: idx });
+                    e.target.value = "";
+                  }}
+                >
+                  <option value="" disabled>
+                    Select nominator…
+                  </option>
+                  {workspace.teams.map((t, i) =>
+                    i === workspace.settings?.myTeamIdx ? null : (
+                      <option key={i} value={i}>
+                        {t.name || `Team ${i + 1}`}
+                      </option>
+                    ),
+                  )}
+                </select>
+                {(workspace.nominations || []).some(
+                  (n) => n.playerId === player.id,
+                ) && (
+                  <button
+                    type="button"
+                    className="button"
+                    style={{ fontSize: "0.7rem", padding: "2px 8px" }}
+                    onClick={() =>
+                      onSubmit({
+                        _removeNomination: true,
+                        playerId: player.id,
+                      })
+                    }
+                    title="Clear the logged nomination"
+                  >
+                    Clear nom
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
         </div>
         <div className="draft-modal-footer">
           {existingPick && (
@@ -781,6 +865,8 @@ function RookieBoard({
   onRemovePlayer,
   onCycleTag,
   searchInputRef,
+  selectedPlayerId,
+  onSelectRow,
   showDrafted,
   onShowDraftedChange,
   query,
@@ -999,11 +1085,12 @@ function RookieBoard({
                 rendered.push(
               <tr
                 key={p.id}
+                onClick={() => onSelectRow?.(p.id)}
                 className={`draft-row${p.drafted ? " draft-row-drafted" : ""}${
                   p.mine ? " draft-row-mine" : ""
                 }${p.userTag === TAG_TARGET ? " draft-row-target" : ""}${
                   p.userTag === TAG_AVOID ? " draft-row-avoid" : ""
-                }`}
+                }${p.id === selectedPlayerId ? " draft-row-selected" : ""}`}
               >
                 <td className="draft-money">{p.rank}</td>
                 <td>
@@ -1265,6 +1352,289 @@ function InflationSparkline({ series, width = 140, height = 36 }) {
   );
 }
 
+/* ── Target Board — my explicit short-list ───────────────────────── */
+
+/**
+ * The user's committed "these are my 6" board.  Shows each slot with
+ * live predraft / fair / winning bid / paid numbers, plus an
+ * aggregate footer with the portfolio cost vs my remaining $.
+ *
+ * Headlines:
+ *   - Portfolio cost now  = Σ winning bids of remaining targets
+ *                             + Σ paid on targets already won
+ *   - Buffer              = my remaining $ − cost of remaining
+ *                             − $1 reserve per additional roster slot
+ *
+ * Negative buffer renders red with "SHORT $N — trim a target".
+ */
+function TargetBoard({
+  stats,
+  workspace,
+  onAdd,
+  onRemove,
+  onMove,
+  onClear,
+  onDraft,
+}) {
+  const [search, setSearch] = useState("");
+  const tbStats = stats.targetBoardStats;
+  const slots = tbStats.slots;
+  const undraftedCandidates = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return [];
+    const boardIds = new Set(slots.map((s) => s.id));
+    return stats.enrichedPlayers
+      .filter(
+        (p) =>
+          !p.drafted &&
+          !boardIds.has(p.id) &&
+          p.name.toLowerCase().includes(q),
+      )
+      .slice(0, 8);
+  }, [search, stats.enrichedPlayers, slots]);
+
+  const statusClass =
+    tbStats.portfolioStatus === "short"
+      ? "draft-tb-status-short"
+      : tbStats.portfolioStatus === "tight"
+        ? "draft-tb-status-tight"
+        : tbStats.portfolioStatus === "on_track"
+          ? "draft-tb-status-ok"
+          : "draft-tb-status-idle";
+
+  return (
+    <div className="card draft-target-board">
+      <div className="draft-tb-head">
+        <div>
+          <h3 style={{ margin: "0 0 2px" }}>
+            Target Board{" "}
+            <span className="muted" style={{ fontSize: "0.72rem" }}>
+              ({slots.length} of {TARGET_BOARD_MAX})
+            </span>
+          </h3>
+          <div className="muted" style={{ fontSize: "0.7rem" }}>
+            Live fair + win bid · paid if won · buffer vs my budget
+          </div>
+        </div>
+        <div className="draft-tb-actions">
+          {slots.length > 0 && (
+            <button
+              className="button"
+              style={{ fontSize: "0.7rem", padding: "3px 8px" }}
+              onClick={() => {
+                if (
+                  typeof window !== "undefined" &&
+                  window.confirm("Clear all Target Board slots?")
+                ) {
+                  onClear();
+                }
+              }}
+              title="Clear every target on the board"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {slots.length === 0 && (
+        <div
+          className="muted"
+          style={{ fontSize: "0.76rem", padding: "6px 0 4px" }}
+        >
+          Pick up to {TARGET_BOARD_MAX} rookies to track closely.  The
+          board will show what each costs now, what you paid (if won),
+          and how the full portfolio fits your remaining budget.
+        </div>
+      )}
+
+      {slots.length > 0 && (
+        <div className="draft-tb-grid">
+          <div className="draft-tb-row draft-tb-row-head">
+            <span>#</span>
+            <span>Player</span>
+            <span>PD</span>
+            <span>Fair</span>
+            <span>Win</span>
+            <span>Paid</span>
+            <span>Status</span>
+            <span></span>
+          </div>
+          {slots.map((p, idx) => {
+            const isFirst = idx === 0;
+            const isLast = idx === slots.length - 1;
+            const status = p.drafted
+              ? p.mine
+                ? {
+                    label: `Won $${p.pick.amount}`,
+                    cls: "draft-tb-status-won",
+                  }
+                : { label: "Lost", cls: "draft-tb-status-lost" }
+              : {
+                  label: `Win at $${p.myWinningBid}`,
+                  cls: "draft-tb-status-open",
+                };
+            const paidDelta =
+              p.drafted && p.mine && Number.isFinite(p.valueVsFair)
+                ? p.valueVsFair
+                : null;
+            return (
+              <div
+                key={p.id}
+                className={`draft-tb-row${p.drafted ? " draft-tb-row-drafted" : ""}${p.mine ? " draft-tb-row-mine" : ""}`}
+              >
+                <span className="draft-tb-idx">#{idx + 1}</span>
+                <span className="draft-tb-name-cell">
+                  <span
+                    className={`draft-tier-chip draft-tier-${p.tier}`}
+                    style={{ marginRight: 4 }}
+                  >
+                    {p.tier}
+                  </span>
+                  <span
+                    className="draft-nbt-name"
+                    onClick={() => onDraft(p)}
+                    title="Open draft modal"
+                  >
+                    {p.name}
+                  </span>
+                </span>
+                <span className="draft-money">{fmt$(p.preDraft)}</span>
+                <span className="draft-money">{fmt$(p.inflatedFair)}</span>
+                <span className="draft-money draft-money-win">
+                  {fmt$(p.myWinningBid)}
+                </span>
+                <span className="draft-money">
+                  {p.drafted && p.mine ? fmt$(p.pick.amount) : "—"}
+                  {paidDelta != null && (
+                    <span
+                      className={
+                        paidDelta > 0
+                          ? "draft-vs-fair-win"
+                          : paidDelta < 0
+                            ? "draft-vs-fair-lose"
+                            : ""
+                      }
+                      style={{
+                        marginLeft: 4,
+                        fontSize: "0.66rem",
+                        fontWeight: 600,
+                      }}
+                      title={`Inflated fair ${fmt$(
+                        p.inflatedFair,
+                      )} − paid ${fmt$(p.pick.amount)}`}
+                    >
+                      {paidDelta > 0 ? "+" : ""}
+                      {fmt$(paidDelta)}
+                    </span>
+                  )}
+                </span>
+                <span className={`draft-tb-status ${status.cls}`}>
+                  {status.label}
+                </span>
+                <span className="draft-tb-controls">
+                  <button
+                    className="button-reset draft-tb-ctrl"
+                    onClick={() => onMove(p.id, "up")}
+                    disabled={isFirst}
+                    title="Move up"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    className="button-reset draft-tb-ctrl"
+                    onClick={() => onMove(p.id, "down")}
+                    disabled={isLast}
+                    title="Move down"
+                  >
+                    ▼
+                  </button>
+                  <button
+                    className="button-reset draft-tb-ctrl draft-tb-ctrl-remove"
+                    onClick={() => onRemove(p.id)}
+                    title="Remove from board"
+                  >
+                    ×
+                  </button>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className={`draft-tb-summary ${statusClass}`}>
+        <div className="draft-tb-summary-line">
+          <span className="muted">PreDraft Σ</span>
+          <span className="draft-money">{fmt$(tbStats.totals.preDraftSum)}</span>
+          <span className="muted">Fair Σ</span>
+          <span className="draft-money">{fmt$(tbStats.totals.fairSum)}</span>
+          <span className="muted">Win Σ (open)</span>
+          <span className="draft-money">{fmt$(tbStats.totals.remainingWinBid)}</span>
+          <span className="muted">Paid Σ (won)</span>
+          <span className="draft-money">{fmt$(tbStats.totals.paidSum)}</span>
+        </div>
+        <div className="draft-tb-summary-line">
+          <span className="muted">My remaining</span>
+          <span className="draft-money">{fmt$(stats.myRemaining)}</span>
+          <span className="muted">− buys at win</span>
+          <span className="draft-money">
+            {fmt$(tbStats.totals.remainingWinBid)}
+          </span>
+          <span className="muted">− other slots</span>
+          <span className="draft-money">
+            {fmt$(tbStats.nonTargetSlotsLeft)}
+          </span>
+          <strong>=</strong>
+          <span className="draft-money draft-tb-buffer">
+            {fmt$(tbStats.portfolioBuffer)}
+          </span>
+        </div>
+        <div className="draft-tb-status-line">
+          {tbStats.portfolioStatusLabel}
+        </div>
+      </div>
+
+      {slots.length < TARGET_BOARD_MAX && (
+        <div className="draft-tb-add">
+          <input
+            type="text"
+            className="input"
+            placeholder="Add target (type a name)…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{ flex: 1, maxWidth: 260 }}
+          />
+          {undraftedCandidates.length > 0 && (
+            <div className="draft-tb-suggest">
+              {undraftedCandidates.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  className="button draft-tb-suggest-btn"
+                  onClick={() => {
+                    onAdd(p.id);
+                    setSearch("");
+                  }}
+                  style={{ fontSize: "0.72rem", padding: "3px 8px" }}
+                >
+                  <span
+                    className={`draft-tier-chip draft-tier-${p.tier}`}
+                    style={{ marginRight: 4 }}
+                  >
+                    {p.tier}
+                  </span>
+                  {p.name} ({fmt$(p.inflatedFair)})
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ── Nomination optimizer sidebar ─────────────────────────────────── */
 
 /**
@@ -1504,6 +1874,8 @@ export default function DraftDashboardPage() {
   const [triageApplied, setTriageApplied] = useState(false);
   const [triageDismissed, setTriageDismissed] = useState(false);
   const searchInputRef = useRef(null);
+  const [selectedPlayerId, setSelectedPlayerId] = useState(null);
+  const [helpOpen, setHelpOpen] = useState(false);
   const [capitalStatus, setCapitalStatus] = useState({
     loading: false,
     error: "",
@@ -1566,20 +1938,99 @@ export default function DraftDashboardPage() {
     }
   }, [stats.slotPressure, triageApplied, triageDismissed]);
 
-  // "/" focuses the search input (skip when already typing).
+  // Global keyboard shortcuts.  Skipped entirely when focus is in an
+  // input/textarea/select so typing a player name or budget doesn't
+  // hijack the shortcuts.  Covers:
+  //   /      — focus search
+  //   ?      — toggle help modal
+  //   Esc    — close modal / help (handled where relevant)
+  //   j/↓    — select next undrafted row
+  //   k/↑    — select prev undrafted row
+  //   D      — open draft modal for selected
+  //   N      — cycle tag on selected
+  //   T      — toggle target tag (neutral ↔ target) on selected
+  //   B      — add selected to Target Board
   useEffect(() => {
     function onKey(e) {
-      if (e.key !== "/") return;
       const tag = (e.target?.tagName || "").toLowerCase();
       const editable =
         tag === "input" || tag === "textarea" || tag === "select";
       if (editable) return;
-      e.preventDefault();
-      searchInputRef.current?.focus();
+
+      if (e.key === "/") {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        return;
+      }
+      if (e.key === "?") {
+        e.preventDefault();
+        setHelpOpen((o) => !o);
+        return;
+      }
+      if (e.key === "Escape") {
+        if (helpOpen) setHelpOpen(false);
+        // Draft modal handles its own Escape via the backdrop click.
+        return;
+      }
+
+      // Row navigation + per-row shortcuts.  Need the current undrafted
+      // list to walk through.  Skip when there's nothing to navigate.
+      const undrafted = stats.enrichedPlayers.filter((p) => !p.drafted);
+      if (undrafted.length === 0) return;
+
+      const idx = selectedPlayerId
+        ? undrafted.findIndex((p) => p.id === selectedPlayerId)
+        : -1;
+
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = undrafted[Math.min(idx + 1, undrafted.length - 1)] || undrafted[0];
+        setSelectedPlayerId(next.id);
+        return;
+      }
+      if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const next = undrafted[Math.max(idx - 1, 0)] || undrafted[0];
+        setSelectedPlayerId(next.id);
+        return;
+      }
+
+      // Shortcuts below require a selection.
+      if (!selectedPlayerId) return;
+      const selected = undrafted.find((p) => p.id === selectedPlayerId);
+      if (!selected) return;
+
+      if (e.key === "d" || e.key === "D") {
+        e.preventDefault();
+        setModalPlayer(selected);
+        return;
+      }
+      if (e.key === "n" || e.key === "N") {
+        e.preventDefault();
+        onCycleTag(selected.id);
+        return;
+      }
+      if (e.key === "t" || e.key === "T") {
+        e.preventDefault();
+        onToggleTarget(selected.id);
+        return;
+      }
+      if (e.key === "b" || e.key === "B") {
+        e.preventDefault();
+        onAddToBoard(selected.id);
+        return;
+      }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [
+    helpOpen,
+    selectedPlayerId,
+    stats.enrichedPlayers,
+    onCycleTag,
+    onToggleTarget,
+    onAddToBoard,
+  ]);
 
   // Pull per-team auction $ budgets from /api/draft-capital.  The
   // dashboard needs this to mirror real carry-over balances without
@@ -1682,11 +2133,73 @@ export default function DraftDashboardPage() {
       }),
     [],
   );
+  const onToggleTarget = useCallback(
+    (id) =>
+      setWorkspace((ws) => {
+        const current = ws.tags?.[id] || null;
+        // Toggle: target ↔ neutral (never flips to avoid via T key).
+        return setPlayerTag(
+          ws,
+          id,
+          current === TAG_TARGET ? null : TAG_TARGET,
+        );
+      }),
+    [],
+  );
+  const onAddToBoard = useCallback(
+    (id) => setWorkspace((ws) => addToTargetBoard(ws, id)),
+    [],
+  );
+  const onRemoveFromBoard = useCallback(
+    (id) => setWorkspace((ws) => removeFromTargetBoard(ws, id)),
+    [],
+  );
+  const onMoveInBoard = useCallback(
+    (id, direction) =>
+      setWorkspace((ws) => moveTargetInBoard(ws, id, direction)),
+    [],
+  );
+  const onClearBoard = useCallback(
+    () => setWorkspace((ws) => clearTargetBoard(ws)),
+    [],
+  );
+  const onRecordNomination = useCallback(
+    (playerId, nominatingTeamIdx) =>
+      setWorkspace((ws) =>
+        recordNomination(ws, {
+          playerId,
+          nominatingTeamIdx: Number(nominatingTeamIdx),
+        }),
+      ),
+    [],
+  );
+  const onRemoveNomination = useCallback(
+    (playerId) => setWorkspace((ws) => removeNomination(ws, playerId)),
+    [],
+  );
+  const onUndoLastNomination = useCallback(
+    () => setWorkspace((ws) => undoLastNomination(ws)),
+    [],
+  );
 
   const handleModalSubmit = useCallback(
     (payload) => {
       if (payload?._remove) {
         setWorkspace((ws) => removePick(ws, payload.playerId));
+      } else if (payload?._nominate) {
+        // Nomination logger — record + keep modal open so the user
+        // can continue setting up (e.g. still intends to bid on
+        // this player themselves).  No ``setModalPlayer(null)``.
+        setWorkspace((ws) =>
+          recordNomination(ws, {
+            playerId: payload.playerId,
+            nominatingTeamIdx: payload.teamIdx,
+          }),
+        );
+        return;
+      } else if (payload?._removeNomination) {
+        setWorkspace((ws) => removeNomination(ws, payload.playerId));
+        return;
       } else {
         setWorkspace((ws) => recordPick(ws, payload));
       }
@@ -1736,6 +2249,13 @@ export default function DraftDashboardPage() {
           </p>
         </div>
         <div className="draft-page-actions">
+          <button
+            className="button"
+            onClick={() => setHelpOpen(true)}
+            title="Keyboard shortcuts (?)"
+          >
+            ?
+          </button>
           <button
             className="button"
             onClick={() => setWorkspace((ws) => undoLastPick(ws))}
@@ -1825,6 +2345,16 @@ export default function DraftDashboardPage() {
         </div>
       )}
 
+      <TargetBoard
+        stats={stats}
+        workspace={workspace}
+        onAdd={onAddToBoard}
+        onRemove={onRemoveFromBoard}
+        onMove={onMoveInBoard}
+        onClear={onClearBoard}
+        onDraft={(p) => setModalPlayer(p)}
+      />
+
       <div className="draft-sidebar-grid">
         <NextBestTargets
           stats={stats}
@@ -1847,6 +2377,8 @@ export default function DraftDashboardPage() {
         onRemovePlayer={onRemovePlayer}
         onCycleTag={onCycleTag}
         searchInputRef={searchInputRef}
+        selectedPlayerId={selectedPlayerId}
+        onSelectRow={setSelectedPlayerId}
         showDrafted={showDrafted}
         onShowDraftedChange={setShowDrafted}
         query={query}
@@ -1864,6 +2396,110 @@ export default function DraftDashboardPage() {
           onClose={() => setModalPlayer(null)}
           onSubmit={handleModalSubmit}
         />
+      )}
+
+      {helpOpen && (
+        <div
+          className="draft-modal-backdrop"
+          onClick={() => setHelpOpen(false)}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="draft-modal card"
+            onClick={(e) => e.stopPropagation()}
+            style={{ width: "min(520px, 100%)" }}
+          >
+            <div className="draft-modal-header">
+              <h3>Keyboard shortcuts</h3>
+              <button
+                type="button"
+                className="button-reset draft-modal-close"
+                onClick={() => setHelpOpen(false)}
+              >
+                ×
+              </button>
+            </div>
+            <div className="draft-modal-body">
+              <table className="draft-help-table">
+                <tbody>
+                  <tr>
+                    <td>
+                      <kbd>/</kbd>
+                    </td>
+                    <td>Focus search</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>?</kbd>
+                    </td>
+                    <td>Open this help</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>Esc</kbd>
+                    </td>
+                    <td>Close modal / help</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>j</kbd> / <kbd>↓</kbd>
+                    </td>
+                    <td>Select next undrafted player</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>k</kbd> / <kbd>↑</kbd>
+                    </td>
+                    <td>Select previous undrafted player</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>D</kbd>
+                    </td>
+                    <td>Open Draft modal for selected</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>N</kbd>
+                    </td>
+                    <td>Cycle tag (neutral → target → avoid) on selected</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>T</kbd>
+                    </td>
+                    <td>Toggle target tag (neutral ↔ target) on selected</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>B</kbd>
+                    </td>
+                    <td>Add selected to Target Board</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                className="muted"
+                style={{ fontSize: "0.72rem", marginTop: 8 }}
+              >
+                Shortcuts are inactive while typing in any input,
+                textarea, or select.  Click a row on the Rookie Board
+                to select it (keyboard shortcuts target the selected
+                row).
+              </div>
+            </div>
+            <div className="draft-modal-footer">
+              <button
+                type="button"
+                className="button"
+                onClick={() => setHelpOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </section>
   );

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4336,3 +4336,212 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .draft-triage-banner span {
   color: var(--text);
 }
+
+/* ── Target Board + Bayesian nom + help modal + row selection ─── */
+
+.draft-target-board {
+  margin-bottom: 14px;
+}
+.draft-tb-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.draft-tb-grid {
+  display: grid;
+  gap: 4px;
+  margin-top: 4px;
+}
+.draft-tb-row {
+  display: grid;
+  grid-template-columns: 34px 1fr 56px 56px 58px 66px 120px 74px;
+  gap: 6px;
+  align-items: center;
+  font-size: 0.78rem;
+  padding: 4px 6px;
+  border-radius: 4px;
+  background: rgba(153, 166, 200, 0.04);
+}
+.draft-tb-row:hover {
+  background: rgba(255, 198, 47, 0.05);
+}
+.draft-tb-row-mine {
+  background: rgba(52, 211, 153, 0.08);
+  border-left: 2px solid var(--green);
+  padding-left: 4px;
+}
+.draft-tb-row-drafted:not(.draft-tb-row-mine) {
+  opacity: 0.5;
+}
+.draft-tb-row-head {
+  color: var(--muted);
+  font-size: 0.64rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: transparent !important;
+  padding: 2px 6px;
+}
+.draft-tb-idx {
+  font-family: var(--mono, monospace);
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+.draft-tb-name-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.draft-tb-status {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.draft-tb-status-won {
+  color: var(--green);
+}
+.draft-tb-status-lost {
+  color: var(--red);
+}
+.draft-tb-status-open {
+  color: var(--cyan);
+}
+.draft-tb-controls {
+  display: inline-flex;
+  gap: 2px;
+  justify-content: flex-end;
+}
+.draft-tb-ctrl {
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0;
+}
+.draft-tb-ctrl:hover:not(:disabled) {
+  color: var(--cyan);
+  border-color: var(--cyan);
+}
+.draft-tb-ctrl:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+.draft-tb-ctrl-remove:hover {
+  color: var(--red);
+  border-color: var(--red);
+}
+
+.draft-tb-summary {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(153, 166, 200, 0.05);
+  border: 1px solid var(--border);
+}
+.draft-tb-summary-line {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.76rem;
+  margin-bottom: 2px;
+  flex-wrap: wrap;
+}
+.draft-tb-summary-line .muted {
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.draft-tb-buffer {
+  font-weight: 700;
+  font-size: 0.88rem;
+}
+.draft-tb-status-line {
+  margin-top: 6px;
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+.draft-tb-status-short {
+  border-color: var(--red);
+  background: rgba(248, 113, 113, 0.08);
+}
+.draft-tb-status-short .draft-tb-status-line {
+  color: var(--red);
+}
+.draft-tb-status-short .draft-tb-buffer {
+  color: var(--red);
+}
+.draft-tb-status-tight {
+  border-color: var(--cyan);
+  background: rgba(255, 198, 47, 0.06);
+}
+.draft-tb-status-tight .draft-tb-status-line {
+  color: var(--cyan);
+}
+.draft-tb-status-ok {
+  border-color: rgba(52, 211, 153, 0.4);
+  background: rgba(52, 211, 153, 0.05);
+}
+.draft-tb-status-ok .draft-tb-status-line {
+  color: var(--green);
+}
+.draft-tb-status-idle .draft-tb-status-line {
+  color: var(--muted);
+}
+
+.draft-tb-add {
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+.draft-tb-suggest {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+/* Nomination logger in draft modal */
+.draft-modal-nom {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+/* Help modal */
+.draft-help-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+.draft-help-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid rgba(38, 58, 105, 0.3);
+}
+.draft-help-table td:first-child {
+  width: 110px;
+  white-space: nowrap;
+}
+.draft-help-table kbd {
+  background: rgba(153, 166, 200, 0.08);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 6px;
+  font-family: var(--mono, monospace);
+  font-size: 0.78rem;
+  color: var(--cyan);
+}
+
+/* Row selection highlight */
+.draft-row-selected {
+  outline: 2px solid var(--cyan);
+  outline-offset: -2px;
+  background: rgba(255, 198, 47, 0.08) !important;
+}

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -129,6 +129,25 @@ export const SPEND_UP_PRESSURE_MIN = 0.6;
  */
 export const SPEND_UP_MDV_FLOOR = 10;
 
+/** Max slots on the user's explicit Target Board. */
+export const TARGET_BOARD_MAX = 6;
+
+/**
+ * Per-nomination decay on a rival's tier-interest prior.  0.8 means
+ * every nomination a team makes in tier T reduces their prior on
+ * wanting ANOTHER player in that tier by 20% (multiplicative).  Tuned
+ * to: 1 nom → 0.80, 2 noms → 0.64, 3 noms → 0.51, 4 noms → 0.41.
+ * Floored at ``TIER_INTEREST_MIN`` so a team is never fully excluded.
+ */
+export const NOMINATION_DECAY = 0.8;
+/**
+ * Minimum tier-interest prior a team can have after nominations.
+ * Keeps the Bayesian competitor ceiling from collapsing to zero for
+ * a rival that has nominated many in a single tier — they MIGHT
+ * still want another one, just less likely.
+ */
+export const TIER_INTEREST_MIN = 0.2;
+
 // ── Default team roster ─────────────────────────────────────────────────
 // Total league pool is $1200 (the sum of DEFAULT_ROOKIES.preDraft).  The
 // sheet reports Russini Panini (Jason) at $417 and "Other Teams
@@ -319,6 +338,17 @@ export function createDefaultWorkspace() {
     picks: [],
     // tags: { [playerId]: "target" | "avoid" }  — neutral = absent
     tags: {},
+    // targetBoard: ordered array of playerId slots (up to TARGET_BOARD_MAX).
+    //   The user's explicit "these are my 6" short-list.  Independent of
+    //   the general target tag system so the user can keep a wide target
+    //   list (20+) but still focus the board on 6 specific picks.  A
+    //   player can be on both (common) or one or the other.
+    targetBoard: [],
+    // nominations: chronological log of who nominated whom.  Drives the
+    // Bayesian per-team tier-interest priors that refine the competitor
+    // ceiling on any given undrafted player.
+    //   { playerId, nominatingTeamIdx, preDraftAtNomination, ts }
+    nominations: [],
   };
 }
 
@@ -440,6 +470,42 @@ export function computeDraftStats(workspace) {
     if (effectiveBudgetByIdx[i] > topCompetitorMax) {
       topCompetitorMax = effectiveBudgetByIdx[i];
     }
+  }
+
+  // ── Bayesian tier-interest priors per team ─────────────────────────
+  // Nominations are a negative signal: teams typically nominate
+  // players they DON'T want (to drain rivals or price-anchor).  Decay
+  // each team's "wants a player of tier T" prior by NOMINATION_DECAY
+  // per nomination they've made in tier T, floored at
+  // TIER_INTEREST_MIN so they're never fully excluded.  No
+  // nominations logged → priors stay 1.0 and Bayesian ceiling
+  // collapses to the naive topCompetitorMax.
+  const nominations = Array.isArray(ws.nominations) ? ws.nominations : [];
+  // tierInterest[teamIdx][tierKey] ∈ [TIER_INTEREST_MIN, 1]
+  const tierInterestByTeam = teams.map(() => {
+    const m = {};
+    for (const def of TIER_DEFS) m[def.key] = 1;
+    return m;
+  });
+  // Build a quick playerId → current preDraft map for the fallback
+  // when a nomination predates the preDraftAtNomination snapshot
+  // (old localStorage data).  Fresh nominations always snapshot, so
+  // the fallback is rare.
+  const nominationPreDraftFallback = new Map(
+    players.map((p) => [p.id, Math.max(0, Number(p.preDraft) || 0)]),
+  );
+  for (const n of nominations) {
+    const idx = n?.nominatingTeamIdx;
+    if (!Number.isInteger(idx) || idx < 0 || idx >= teams.length) continue;
+    const snap = Number.isFinite(Number(n?.preDraftAtNomination))
+      ? Math.max(0, Number(n.preDraftAtNomination))
+      : nominationPreDraftFallback.get(n?.playerId) || 0;
+    const tierKey = tierForPreDraft(snap);
+    const cur = tierInterestByTeam[idx][tierKey] ?? 1;
+    tierInterestByTeam[idx][tierKey] = Math.max(
+      TIER_INTEREST_MIN,
+      cur * NOMINATION_DECAY,
+    );
   }
 
   // Other teams' money (aggregate).
@@ -597,6 +663,10 @@ export function computeDraftStats(workspace) {
       preDraftSum > 0 ? (spent - preDraftSum) / preDraftSum : null;
     const slotsLeft = slotsRemainingByIdx[idx];
     const mdv = slotsLeft > 0 ? remaining / slotsLeft : 0;
+    // Count this team's logged nominations for the UI badge.
+    const nominationsLogged = nominations.filter(
+      (n) => n.nominatingTeamIdx === idx,
+    ).length;
     return {
       idx,
       name: t.name || `Team ${idx + 1}`,
@@ -612,6 +682,8 @@ export function computeDraftStats(workspace) {
       mdv,
       preDraftSum,
       overpayIndex,
+      tierInterest: tierInterestByTeam[idx],
+      nominationsLogged,
     };
   });
 
@@ -645,6 +717,27 @@ export function computeDraftStats(workspace) {
       0,
       Math.min(theoreticalMaxBid, winByCompetitor),
     );
+    // Bayesian competitor ceiling: reweight each rival's effective
+    // budget by their tierInterest for THIS player's tier.  Less
+    // interest (more nominations in this tier) → lower effective
+    // ceiling for this player → lower bayesianWinningBid → I might
+    // pay less than the naive topCompetitorMax suggests.  Only
+    // diverges from topCompetitorMax once at least one nomination
+    // has been logged; otherwise every tier-interest is 1.0 and the
+    // numbers match.
+    let bayesianTopCompetitor = 0;
+    for (let i = 0; i < effectiveBudgetByIdx.length; i++) {
+      if (i === myTeamIdx) continue;
+      const interest = tierInterestByTeam[i]?.[tier] ?? 1;
+      const weighted = effectiveBudgetByIdx[i] * interest;
+      if (weighted > bayesianTopCompetitor) {
+        bayesianTopCompetitor = weighted;
+      }
+    }
+    const bayesianWinningBid = Math.max(
+      0,
+      Math.min(theoreticalMaxBid, Math.max(1, Math.floor(bayesianTopCompetitor) + 1)),
+    );
     const enforceUpTo = Math.floor(inflatedFair * enforcePct);
     const drafted = !!pick;
     const mine = drafted && pick.teamIdx === myTeamIdx;
@@ -666,6 +759,8 @@ export function computeDraftStats(workspace) {
       myMaxBid: Math.max(0, theoreticalMaxBid),
       theoreticalMaxBid: Math.max(0, theoreticalMaxBid),
       myWinningBid,
+      bayesianTopCompetitor: Math.max(0, Math.floor(bayesianTopCompetitor)),
+      bayesianWinningBid,
       enforceUpTo: Math.max(0, enforceUpTo),
       valueVsFair,
     };
@@ -678,6 +773,109 @@ export function computeDraftStats(workspace) {
   const totalPicksMade = picks.length;
   const draftProgress =
     totalInitialSlots > 0 ? totalPicksMade / totalInitialSlots : 0;
+
+  // ── Target Board rollup ─────────────────────────────────────────────
+  // Aggregated view of the user's explicit short-list.  Each slot
+  // carries a reference to the enriched player row so the UI can
+  // render live "fair now" / "win now" numbers that update as other
+  // picks land.  Totals handle three states per slot:
+  //
+  //   drafted to me:    +paid           (green; locked in)
+  //   drafted to other: NOT in totals   (greyed out on the UI)
+  //   undrafted:        +myWinningBid   (the realistic buy price)
+  //
+  // ``portfolioCost`` is what it would cost to get every remaining
+  // target at current winning-bid prices, plus what I already spent
+  // on targets.  ``portfolioBuffer`` = my remaining $ − cost of
+  // remaining targets, i.e. what's left if I hit everything I still
+  // want at today's prices.  Negative buffer means I can't afford
+  // all six — the UI surfaces this as a red warning.
+  const enrichedPlayerById = new Map(
+    enrichedPlayers.map((p) => [p.id, p]),
+  );
+  const boardIds = Array.isArray(ws.targetBoard) ? ws.targetBoard : [];
+  const targetBoardSlots = boardIds
+    .map((id) => enrichedPlayerById.get(id))
+    .filter(Boolean);
+  const tbTotals = {
+    preDraftSum: 0,
+    fairSum: 0,
+    winBidSum: 0,
+    paidSum: 0,
+    mineCount: 0,
+    otherCount: 0,
+    remainingCount: 0,
+    remainingFair: 0,
+    remainingWinBid: 0,
+  };
+  for (const p of targetBoardSlots) {
+    tbTotals.preDraftSum += p.preDraft || 0;
+    tbTotals.fairSum += p.inflatedFair || 0;
+    tbTotals.winBidSum += p.myWinningBid || 0;
+    if (p.drafted) {
+      if (p.mine) {
+        tbTotals.mineCount += 1;
+        tbTotals.paidSum += p.pick?.amount || 0;
+      } else {
+        tbTotals.otherCount += 1;
+      }
+    } else {
+      tbTotals.remainingCount += 1;
+      tbTotals.remainingFair += p.inflatedFair || 0;
+      tbTotals.remainingWinBid += p.myWinningBid || 0;
+    }
+  }
+  // Buffer: what's left of my budget after buying every remaining
+  // target at winning-bid prices, reserving $1 per additional slot
+  // beyond the targets.  If I have 6 slots but only 4 targets, I
+  // need $1 each for the other 2 so I can still fill my roster.
+  const nonTargetSlotsLeft = Math.max(
+    0,
+    mySlotsRemaining - tbTotals.remainingCount,
+  );
+  const portfolioBuffer =
+    myRemaining - tbTotals.remainingWinBid - nonTargetSlotsLeft;
+  let portfolioStatus = "idle";
+  let portfolioStatusLabel = "Add targets to your board";
+  if (targetBoardSlots.length > 0) {
+    if (portfolioBuffer < 0) {
+      portfolioStatus = "short";
+      portfolioStatusLabel = `Short $${Math.abs(Math.round(portfolioBuffer))} — trim a target or lower your ceiling`;
+    } else if (portfolioBuffer < 10) {
+      portfolioStatus = "tight";
+      portfolioStatusLabel = `Tight — $${Math.round(portfolioBuffer)} of slack`;
+    } else {
+      portfolioStatus = "on_track";
+      portfolioStatusLabel = `On track — $${Math.round(portfolioBuffer)} of headroom`;
+    }
+  }
+  const targetBoardStats = {
+    slots: targetBoardSlots,
+    totals: tbTotals,
+    portfolioBuffer,
+    portfolioStatus,
+    portfolioStatusLabel,
+    nonTargetSlotsLeft,
+  };
+
+  // ── Nominations summary ────────────────────────────────────────────
+  // Surface the raw nominations plus a per-tier count so the UI can
+  // show "Joel has logged 3 S-tier noms" as a quick-read signal.
+  const nominationsEnriched = nominations.map((n) => ({
+    ...n,
+    player: enrichedPlayerById.get(n.playerId) || null,
+    nominatingTeamName:
+      teams[n.nominatingTeamIdx]?.name || `Team ${n.nominatingTeamIdx + 1}`,
+  }));
+  const nominationsByTier = {};
+  for (const def of TIER_DEFS) nominationsByTier[def.key] = 0;
+  for (const n of nominations) {
+    const snap = Number.isFinite(Number(n.preDraftAtNomination))
+      ? n.preDraftAtNomination
+      : nominationPreDraftFallback.get(n.playerId) || 0;
+    const k = tierForPreDraft(snap);
+    nominationsByTier[k] = (nominationsByTier[k] || 0) + 1;
+  }
 
   return {
     totalBudget,
@@ -707,6 +905,10 @@ export function computeDraftStats(workspace) {
     draftProgress,
     teamStats,
     enrichedPlayers,
+    targetBoardStats,
+    nominationsCount: nominations.length,
+    nominationsByTier,
+    nominationsEnriched,
   };
 }
 
@@ -786,6 +988,103 @@ export function setPlayerTag(workspace, playerId, tag) {
     delete next[playerId];
   }
   return { ...workspace, tags: next };
+}
+
+// ── Target Board mutators ──────────────────────────────────────────────
+/**
+ * Append a player to the explicit Target Board if there's a free slot
+ * and they're not already on it.  Cap at ``TARGET_BOARD_MAX``.  Also
+ * auto-applies the ``target`` tag so the rec engine picks them up.
+ */
+export function addToTargetBoard(workspace, playerId) {
+  if (!playerId) return workspace;
+  const board = Array.isArray(workspace.targetBoard)
+    ? workspace.targetBoard
+    : [];
+  if (board.includes(playerId)) return workspace;
+  if (board.length >= TARGET_BOARD_MAX) return workspace;
+  const next = setPlayerTag(workspace, playerId, TAG_TARGET);
+  return { ...next, targetBoard: [...board, playerId] };
+}
+
+/**
+ * Remove a player from the Target Board.  Does NOT clear their
+ * target tag — the tag is a broader concept than board membership,
+ * so a user who removes from the board while keeping the tag is
+ * signalling "still interested, just not top-6 focus."
+ */
+export function removeFromTargetBoard(workspace, playerId) {
+  const board = (workspace.targetBoard || []).filter(
+    (id) => id !== playerId,
+  );
+  return { ...workspace, targetBoard: board };
+}
+
+/** Reset the Target Board to empty.  Tags are untouched. */
+export function clearTargetBoard(workspace) {
+  return { ...workspace, targetBoard: [] };
+}
+
+/**
+ * Reorder the Target Board by moving one player one slot up or down.
+ * Used for the row-reorder buttons on the Target Board UI.  No-op if
+ * the player is missing, or already at the boundary.
+ */
+export function moveTargetInBoard(workspace, playerId, direction) {
+  const board = [...(workspace.targetBoard || [])];
+  const idx = board.indexOf(playerId);
+  if (idx < 0) return workspace;
+  const to = direction === "up" ? idx - 1 : idx + 1;
+  if (to < 0 || to >= board.length) return workspace;
+  const [moved] = board.splice(idx, 1);
+  board.splice(to, 0, moved);
+  return { ...workspace, targetBoard: board };
+}
+
+// ── Nomination mutators ────────────────────────────────────────────────
+/**
+ * Log a rival nomination.  Nominations are one per player (re-logging
+ * replaces the prior entry so a miscue can be corrected in place).
+ * ``preDraftAtNomination`` snapshots the PreDraft $ at log time, same
+ * as ``preDraftAtPick`` on picks — retroactive edits can't corrupt
+ * tier-interest decay.
+ */
+export function recordNomination(workspace, { playerId, nominatingTeamIdx }) {
+  if (!playerId || !Number.isInteger(nominatingTeamIdx)) return workspace;
+  const nominations = (workspace.nominations || []).filter(
+    (n) => n.playerId !== playerId,
+  );
+  const player = (workspace.players || []).find((p) => p.id === playerId);
+  const preDraftAtNomination = Math.max(0, Number(player?.preDraft) || 0);
+  nominations.push({
+    playerId,
+    nominatingTeamIdx,
+    preDraftAtNomination,
+    ts: Date.now(),
+  });
+  return { ...workspace, nominations };
+}
+
+/** Remove a single logged nomination (undo a mis-click). */
+export function removeNomination(workspace, playerId) {
+  return {
+    ...workspace,
+    nominations: (workspace.nominations || []).filter(
+      (n) => n.playerId !== playerId,
+    ),
+  };
+}
+
+/** Undo the most recent nomination log entry (by ts). */
+export function undoLastNomination(workspace) {
+  const noms = workspace.nominations || [];
+  if (noms.length === 0) return workspace;
+  const sorted = [...noms].sort((a, b) => (b.ts || 0) - (a.ts || 0));
+  const toRemove = sorted[0];
+  return {
+    ...workspace,
+    nominations: noms.filter((n) => n !== toRemove),
+  };
 }
 
 /** Update a team's name or initial budget. */
@@ -1105,6 +1404,26 @@ export function hydrateWorkspace(parsed) {
       }
       return out;
     })(),
+    targetBoard: Array.isArray(parsed.targetBoard)
+      ? parsed.targetBoard
+          .filter((id) => typeof id === "string" && id.length > 0)
+          .slice(0, TARGET_BOARD_MAX)
+      : [],
+    nominations: Array.isArray(parsed.nominations)
+      ? parsed.nominations
+          .map((n) => ({
+            playerId: String(n?.playerId || ""),
+            nominatingTeamIdx: Number.isInteger(n?.nominatingTeamIdx)
+              ? n.nominatingTeamIdx
+              : -1,
+            preDraftAtNomination: Math.max(
+              0,
+              Number(n?.preDraftAtNomination) || 0,
+            ),
+            ts: Number(n?.ts) || Date.now(),
+          }))
+          .filter((n) => n.playerId && n.nominatingTeamIdx >= 0)
+      : [],
   };
 }
 


### PR DESCRIPTION
## Summary
Three features on top of the Tier 1-3 draft dashboard:

1. **Target Board** — explicit 6-slot short-list with live fair/win-bid/paid math and a portfolio-buffer footer that flips red when you can't afford your own list
2. **Bayesian nomination inference** — log who nominates whom, and per-player competitor ceilings reweight by rival tier-interest priors (nominating S players → less likely to chase another S)
3. **Keyboard shortcuts + help modal** — `/` focus search, `?` help, `j`/`k` nav, `D`/`N`/`T`/`B` act on selected row

## Target Board math

```
portfolioBuffer = myRemaining
                − Σ winningBid over undrafted targets
                − $1 × other roster slots (non-target slots you still need)

portfolioStatus:
  short    if buffer < 0    → "Short $N — trim a target or lower your ceiling"
  tight    if buffer < $10  → "Tight — $N of slack"
  on_track if buffer ≥ $10  → "On track — $N of headroom"
```

Fair values update live as the draft progresses (tier-inflation math is already plumbed through `enrichedPlayers.inflatedFair`).

## Bayesian model

```
tierInterest(team, T) starts at 1.0
each nomination in tier T by team → × NOMINATION_DECAY (0.8)
                                   → floored at TIER_INTEREST_MIN (0.2)

bayesianTopCompetitor(p) = max over rivals j of
                            effectiveBudget(j) × tierInterest(j, tier(p))
bayesianWinningBid(p)    = min(theoreticalMax, bayesianTopCompetitor + 1)
```

Always ≤ naive `myWinningBid`. Collapses to the naive ceiling when no nominations logged, so the feature is opt-in via the modal dropdown.

## Keyboard shortcuts

| Key | Action |
|---|---|
| `/` | Focus search |
| `?` | Toggle help modal |
| `Esc` | Close help |
| `j` / `↓` | Next undrafted row |
| `k` / `↑` | Previous undrafted row |
| `D` | Open Draft modal for selected |
| `N` | Cycle tag (neutral → target → avoid) |
| `T` | Toggle target (never flips to avoid) |
| `B` | Add selected to Target Board |

Suppressed when typing in any input/textarea/select.

## Test plan
- [x] `npx vitest run __tests__/draft-logic.test.js` — 153/153 (30 new)
- [x] Full frontend suite — 639/641 (2 pre-existing `dynasty-data.test.js/rankHistory` failures unrelated)
- [x] `npm run build` — clean; /draft at 18.5 kB

🤖 Generated with [Claude Code](https://claude.com/claude-code)