### PR TITLE
Align Vikings skin to exact 4-color palette + surface blush orange

### DIFF
--- a/frontend/app/edge/page.jsx
+++ b/frontend/app/edge/page.jsx
@@ -27,13 +27,13 @@ function EdgeSection({ title, description, count, accent, children }) {
     green: "rgba(52, 211, 153, 0.12)",
     amber: "rgba(251, 191, 36, 0.10)",
     red: "rgba(248, 113, 113, 0.10)",
-    cyan: "rgba(255, 198, 47, 0.08)",
+    cyan: "rgba(255, 199, 4, 0.08)",
   };
   const borderMap = {
     green: "rgba(52, 211, 153, 0.25)",
     amber: "rgba(251, 191, 36, 0.20)",
     red: "rgba(248, 113, 113, 0.20)",
-    cyan: "rgba(255, 198, 47, 0.18)",
+    cyan: "rgba(255, 199, 4, 0.18)",
   };
 
   return (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4,23 +4,28 @@
    ══════════════════════════════════════════════════════════════════════════ */
 
 /* ── DESIGN TOKENS ─────────────────────────────────────────────────────── */
-/* Minnesota Vikings skin.  Official brand colors are purple #4F2683 and
- * gold #FFC62F, plus white and black.  The palette below anchors on those:
- *   - Backgrounds step from near-black with a purple tint up to the Vikings
- *     primary purple (used for card hover + accent borders).
- *   - The historic ``--cyan`` variable — used throughout the codebase as
- *     "the accent color" (buttons, links, focus rings, trade-meter) — now
- *     holds Vikings gold.  136 ``var(--cyan)`` usages pick this up for free;
- *     the ~50 hardcoded ``#FFC62F`` / ``rgba(255, 198, 47, X)`` references
- *     are search-replaced to the gold equivalent.
- *   - ``--amber`` collapses to the same gold so the two accent flavors no
- *     longer diverge.  The IDP position badge separately remaps to purple
- *     so offense (gold) and IDP (purple) stay visually distinguishable.
- *   - ``--green`` / ``--red`` stay for data semantics (wins/losses, high/low
- *     confidence) — contrast vs the deep-purple bg is still AAA+.
- *   - White text on any of the background tones hits WCAG AAA.  Gold text on
- *     ``--card`` (#2a1550) is ~8:1 (AAA).  Gold on Vikings primary purple
- *     (#4F2683) is ~5.6:1 — AA for normal, AAA for large/bold.
+/* Minnesota Vikings skin — aligned to the official 4-color palette
+ * (schemecolor.com/minnesota-vikings-team-colors):
+ *     Dark Yellow  #FFC704   (primary gold)
+ *     Aesthetic P. #4F2185   (primary purple)
+ *     Full White   #FFFFFF
+ *     Blush Orange #EABF99   (warm cream accent)
+ *
+ * Semantic mapping:
+ *   - ``--cyan`` is the codebase's "accent" variable — it now holds the
+ *     exact Vikings gold.  130+ ``var(--cyan)`` usages (buttons, focus
+ *     rings, recommendation chips, Win-at column, sparkline) pick this
+ *     up automatically.
+ *   - ``--amber`` collapses to the same gold so "amber" flavors don't
+ *     drift from primary.
+ *   - ``--border`` / ``--vikings-purple`` carry the exact palette purple.
+ *   - ``--blush`` is a NEW accent for warmer tints — borders of
+ *     informational-not-critical states, secondary chip backgrounds,
+ *     decorative highlights where gold would feel too loud.
+ *   - ``--green`` / ``--red`` stay for data semantics (up/down, ok/err)
+ *     — both still hit AAA contrast on the deep-purple bg.
+ *   - Body gradient now tinted with Vikings purple instead of the
+ *     previous navy-blue highlight, so even the backdrop says "Vikings".
  */
 :root {
   --bg: #0f0a1a;
@@ -30,16 +35,19 @@
   --text: #ffffff;
   --subtext: #c7b8dc;
   --muted: #c7b8dc;
-  --cyan: #FFC62F;
+  --cyan: #FFC704;
   --green: #34d399;
   --red: #f87171;
-  --amber: #FFC62F;
-  --border: #4F2683;
-  --border-bright: #7a3fbf;
-  /* Explicit brand colors — reach for these when you want the raw Vikings
-   * hex without going through the semantic variable names. */
-  --vikings-purple: #4F2683;
-  --vikings-gold: #FFC62F;
+  --amber: #FFC704;
+  --border: #4F2185;
+  --border-bright: #6d35b3;
+  /* Explicit brand colors — reach for these when you want the raw
+   * Vikings hex without going through the semantic variable names. */
+  --vikings-purple: #4F2185;
+  --vikings-gold: #FFC704;
+  --vikings-blush: #EABF99;
+  /* Aliased for CSS usage: ``var(--blush)`` reads cleaner inline. */
+  --blush: #EABF99;
 
   /* Spacing scale */
   --space-xs: 4px;
@@ -70,7 +78,10 @@ html, body { margin: 0; padding: 0; min-height: 100%; }
 
 body {
   font-family: var(--font);
-  background: radial-gradient(circle at top right, #12264f 0%, var(--bg) 45%);
+  /* Vikings purple radial glow top-right, fading into the deep
+   * near-black base.  Replaces the pre-skin navy #12264f highlight
+   * so the backdrop matches the palette. */
+  background: radial-gradient(circle at top right, #3b186a 0%, var(--bg) 50%);
   color: var(--text);
   font-size: 14px;
   line-height: 1.5;
@@ -137,8 +148,8 @@ a { color: inherit; text-decoration: none; }
 
 .nav-link.nav-active {
   color: var(--cyan);
-  border-color: rgba(255, 198, 47, 0.25);
-  background: rgba(255, 198, 47, 0.06);
+  border-color: rgba(255, 199, 4, 0.25);
+  background: rgba(255, 199, 4, 0.06);
 }
 
 .nav-search-btn {
@@ -462,13 +473,13 @@ a { color: inherit; text-decoration: none; }
 }
 
 .button-primary {
-  background: rgba(255, 198, 47, 0.12);
-  border-color: rgba(255, 198, 47, 0.35);
+  background: rgba(255, 199, 4, 0.12);
+  border-color: rgba(255, 199, 4, 0.35);
   color: var(--cyan);
 }
 
 .button-primary:hover {
-  background: rgba(255, 198, 47, 0.18);
+  background: rgba(255, 199, 4, 0.18);
 }
 
 .button-danger {
@@ -716,11 +727,11 @@ input[type="range"]::-moz-range-thumb {
 }
 
 input[type="range"]:focus-visible::-webkit-slider-thumb {
-  box-shadow: 0 0 0 4px rgba(255, 198, 47, 0.25),
+  box-shadow: 0 0 0 4px rgba(255, 199, 4, 0.25),
               0 2px 6px rgba(0, 0, 0, 0.35);
 }
 input[type="range"]:focus-visible::-moz-range-thumb {
-  box-shadow: 0 0 0 4px rgba(255, 198, 47, 0.25),
+  box-shadow: 0 0 0 4px rgba(255, 199, 4, 0.25),
               0 2px 6px rgba(0, 0, 0, 0.35);
 }
 
@@ -755,7 +766,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .global-search-input-row:focus-within {
   border-color: var(--cyan);
-  box-shadow: 0 0 0 3px rgba(255, 198, 47, 0.15);
+  box-shadow: 0 0 0 3px rgba(255, 199, 4, 0.15);
 }
 .global-search-input {
   flex: 1;
@@ -869,8 +880,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 
 .badge-cyan {
   color: var(--cyan);
-  border-color: rgba(255, 198, 47, 0.35);
-  background: rgba(255, 198, 47, 0.08);
+  border-color: rgba(255, 199, 4, 0.35);
+  background: rgba(255, 199, 4, 0.08);
 }
 
 .badge-green {
@@ -895,7 +906,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
    * touching every consumer of the old amber label. */
   color: #c9a9ff;
   border-color: rgba(122, 63, 191, 0.45);
-  background: rgba(79, 38, 131, 0.25);
+  background: rgba(79, 33, 133, 0.25);
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
@@ -1093,7 +1104,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   cursor: pointer;
 }
 .picker-row:active {
-  background: rgba(255, 198, 47, 0.08);
+  background: rgba(255, 199, 4, 0.08);
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
@@ -1208,8 +1219,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 .toast-info {
-  background: rgba(255, 198, 47, 0.18);
-  border: 1px solid rgba(255, 198, 47, 0.35);
+  background: rgba(255, 199, 4, 0.18);
+  border: 1px solid rgba(255, 199, 4, 0.35);
   color: var(--cyan);
 }
 
@@ -1241,7 +1252,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(circle at top left, rgba(255, 198, 47, 0.08), transparent 48%);
+  background: radial-gradient(circle at top left, rgba(255, 199, 4, 0.08), transparent 48%);
 }
 
 .login-panel {
@@ -1252,7 +1263,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   padding: 18px;
 }
 
-.login-badge { color: var(--cyan); border-color: rgba(255, 198, 47, 0.35); background: rgba(255, 198, 47, 0.08); }
+.login-badge { color: var(--cyan); border-color: rgba(255, 199, 4, 0.35); background: rgba(255, 199, 4, 0.08); }
 .login-form { margin-top: var(--space-md); display: grid; gap: 10px; }
 .login-label { font-size: 0.78rem; font-weight: 700; color: var(--muted); }
 .login-input { width: 100%; }
@@ -2880,7 +2891,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   padding: var(--space-sm);
   border: 1px dashed var(--border);
   border-radius: var(--radius);
-  background: rgba(255, 198, 47, 0.04);
+  background: rgba(255, 199, 4, 0.04);
 }
 
 .idp-lab-diff-header {
@@ -3202,20 +3213,20 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   padding: 10px 16px;
   border-radius: 999px;
   border: 1px solid var(--border-bright);
-  background: linear-gradient(135deg, #4F2683 0%, #2a1550 100%);
+  background: linear-gradient(135deg, #4F2185 0%, #2a1550 100%);
   color: var(--text);
   font-family: var(--font);
   font-size: 0.82rem;
   font-weight: 600;
   letter-spacing: 0.01em;
-  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.45), 0 2px 6px rgba(255, 198, 47, 0.14);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.45), 0 2px 6px rgba(255, 199, 4, 0.14);
   cursor: pointer;
   transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
 }
 .chat-fab:hover {
   transform: translateY(-1px);
   border-color: var(--cyan);
-  box-shadow: 0 8px 26px rgba(0, 0, 0, 0.5), 0 2px 10px rgba(255, 198, 47, 0.3);
+  box-shadow: 0 8px 26px rgba(0, 0, 0, 0.5), 0 2px 10px rgba(255, 199, 4, 0.3);
 }
 .chat-fab-glyph {
   display: inline-block;
@@ -3363,7 +3374,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   gap: 8px;
   padding: 8px;
   border-radius: var(--radius);
-  background: rgba(255, 198, 47, 0.04);
+  background: rgba(255, 199, 4, 0.04);
   border: 1px dashed var(--border);
 }
 .chat-suggestions-title {
@@ -3406,7 +3417,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .chat-bubble-user {
   align-self: flex-end;
-  background: linear-gradient(135deg, #4F2683 0%, #2a1550 100%);
+  background: linear-gradient(135deg, #4F2185 0%, #2a1550 100%);
   border-color: var(--border-bright);
 }
 .chat-bubble-assistant {
@@ -3415,7 +3426,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .chat-bubble-streaming {
   border-color: var(--cyan);
-  box-shadow: 0 0 0 1px rgba(255, 198, 47, 0.25);
+  box-shadow: 0 0 0 1px rgba(255, 199, 4, 0.25);
 }
 .chat-bubble-role {
   font-size: 0.66rem;
@@ -3469,7 +3480,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .chat-bubble-body a {
   color: var(--cyan);
   text-decoration: underline;
-  text-decoration-color: rgba(255, 198, 47, 0.5);
+  text-decoration-color: rgba(255, 199, 4, 0.5);
 }
 .chat-bubble-body blockquote {
   margin: 4px 0;
@@ -3537,7 +3548,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .chat-input::placeholder { color: var(--muted); }
 .chat-input:focus {
   border-color: var(--cyan);
-  box-shadow: 0 0 0 3px rgba(255, 198, 47, 0.12);
+  box-shadow: 0 0 0 3px rgba(255, 199, 4, 0.12);
 }
 .chat-input:disabled { opacity: 0.6; }
 
@@ -3545,7 +3556,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   padding: 10px 18px;
   border: 1px solid var(--border-bright);
   border-radius: var(--radius);
-  background: linear-gradient(135deg, #4F2683 0%, #2a1550 100%);
+  background: linear-gradient(135deg, #4F2185 0%, #2a1550 100%);
   color: var(--text);
   font-family: var(--font);
   font-size: 0.82rem;
@@ -3597,7 +3608,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   border-bottom: none;
 }
 .source-breakdown-table tbody tr:hover {
-  background: rgba(255, 198, 47, 0.04);
+  background: rgba(255, 199, 4, 0.04);
 }
 
 /* ── Draft dashboard ──────────────────────────────────────────────── */
@@ -3623,8 +3634,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   margin-bottom: 14px;
 }
 .draft-stat {
-  background: rgba(255, 198, 47, 0.04);
-  border: 1px solid rgba(255, 198, 47, 0.15);
+  background: rgba(255, 199, 4, 0.04);
+  border: 1px solid rgba(255, 199, 4, 0.15);
   border-radius: 8px;
   padding: 10px 12px;
 }
@@ -3811,7 +3822,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   border-left: 2px solid var(--green);
 }
 .draft-row:hover {
-  background: rgba(255, 198, 47, 0.04);
+  background: rgba(255, 199, 4, 0.04);
 }
 
 .draft-tag {
@@ -3947,7 +3958,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   border: 1px solid var(--border);
 }
 .draft-live-idle    { color: var(--muted); }
-.draft-live-push    { color: var(--cyan); border-color: var(--cyan); background: rgba(255, 198, 47, 0.08); }
+.draft-live-push    { color: var(--cyan); border-color: var(--cyan); background: rgba(255, 199, 4, 0.08); }
 .draft-live-target  { color: var(--green); border-color: var(--green); background: rgba(52, 211, 153, 0.1); }
 .draft-live-pass    { color: var(--red); border-color: var(--red); background: rgba(248, 113, 113, 0.08); }
 .draft-live-mine    { color: var(--green); border-color: var(--green); background: rgba(52, 211, 153, 0.1); }
@@ -3976,7 +3987,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   font-family: var(--mono, monospace);
 }
 .draft-tier-S {
-  background: rgba(255, 198, 47, 0.15);
+  background: rgba(255, 199, 4, 0.15);
   border-color: var(--cyan);
   color: var(--cyan);
 }
@@ -4039,7 +4050,15 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .draft-progress-fill {
   height: 100%;
-  background: linear-gradient(to right, var(--cyan), var(--green));
+  /* Vikings palette sweep: purple → gold → blush so all three
+   * brand colors ride the progress bar.  Visual beat: the user
+   * sees the whole league palette fill in as the draft completes. */
+  background: linear-gradient(
+    to right,
+    var(--vikings-purple),
+    var(--vikings-gold) 60%,
+    var(--blush)
+  );
   transition: width 0.35s ease;
 }
 .draft-progress-labels {
@@ -4071,7 +4090,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   align-items: center;
 }
 .draft-tag-tab:hover {
-  background: rgba(255, 198, 47, 0.05);
+  background: rgba(255, 199, 4, 0.05);
 }
 .draft-tag-tab-active {
   font-weight: 600;
@@ -4099,7 +4118,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   justify-content: center;
 }
 .draft-tag-chip:hover {
-  background: rgba(255, 198, 47, 0.08);
+  background: rgba(255, 199, 4, 0.08);
 }
 .draft-tag-chip:disabled {
   opacity: 0.4;
@@ -4145,7 +4164,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   color: var(--green);
 }
 .draft-rec-steal {
-  background: rgba(255, 198, 47, 0.12);
+  background: rgba(255, 199, 4, 0.12);
   border-color: var(--cyan);
   color: var(--cyan);
 }
@@ -4160,7 +4179,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   color: var(--green);
 }
 .draft-rec-spend {
-  background: rgba(255, 198, 47, 0.1);
+  background: rgba(255, 199, 4, 0.1);
   border-color: var(--cyan);
   color: var(--cyan);
 }
@@ -4203,7 +4222,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   background: rgba(153, 166, 200, 0.04);
 }
 .draft-nbt-row:hover {
-  background: rgba(255, 198, 47, 0.05);
+  background: rgba(255, 199, 4, 0.05);
 }
 .draft-nbt-target {
   background: rgba(52, 211, 153, 0.06);
@@ -4320,7 +4339,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   padding: 8px 12px;
   margin-bottom: 12px;
   border-radius: 6px;
-  background: rgba(255, 198, 47, 0.08);
+  background: rgba(255, 199, 4, 0.08);
   border: 1px solid var(--cyan);
   color: var(--cyan);
   font-size: 0.78rem;
@@ -4365,7 +4384,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   background: rgba(153, 166, 200, 0.04);
 }
 .draft-tb-row:hover {
-  background: rgba(255, 198, 47, 0.05);
+  background: rgba(255, 199, 4, 0.05);
 }
 .draft-tb-row-mine {
   background: rgba(52, 211, 153, 0.08);
@@ -4478,7 +4497,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .draft-tb-status-tight {
   border-color: var(--cyan);
-  background: rgba(255, 198, 47, 0.06);
+  background: rgba(255, 199, 4, 0.06);
 }
 .draft-tb-status-tight .draft-tb-status-line {
   color: var(--cyan);
@@ -4543,7 +4562,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .draft-row-selected {
   outline: 2px solid var(--cyan);
   outline-offset: -2px;
-  background: rgba(255, 198, 47, 0.08) !important;
+  background: rgba(255, 199, 4, 0.08) !important;
 }
 
 /* ── Draft glossary ─────────────────────────────────────────────── */
@@ -4556,7 +4575,10 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   list-style: none;
   cursor: pointer;
   padding-bottom: 6px;
-  border-bottom: 1px solid var(--border);
+  /* Blush-orange underline — the 4th Vikings palette color.  Only
+   * used here and on the progress-bar gradient end-stop, so the
+   * color stays a "peripheral trim" accent rather than dominating. */
+  border-bottom: 2px solid var(--blush);
   margin-bottom: 10px;
 }
 .draft-gloss > details > summary::-webkit-details-marker {

--- a/frontend/app/league/franchise/[owner]/opengraph-image.js
+++ b/frontend/app/league/franchise/[owner]/opengraph-image.js
@@ -61,7 +61,7 @@ export default async function FranchiseOGImage({ params }) {
           justifyContent: "space-between",
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 16, color: "#FFC62F", fontSize: 28 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 16, color: "#FFC704", fontSize: 28 }}>
           <span style={{ letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
             Brisket League · Franchise
           </span>
@@ -78,7 +78,7 @@ export default async function FranchiseOGImage({ params }) {
           <div style={{ display: "flex", gap: 48, marginTop: 20, fontSize: 30 }}>
             <Stat label="Record" value={record || "—"} color="#eaf2ff" />
             <Stat label="Titles" value={`${titles}×`} color="#fbbf24" />
-            <Stat label="Seasons" value={`${seasons}`} color="#FFC62F" />
+            <Stat label="Seasons" value={`${seasons}`} color="#FFC704" />
             {cum.playoffAppearances ? (
               <Stat label="Playoffs" value={`${cum.playoffAppearances}`} color="#34d399" />
             ) : null}

--- a/frontend/app/league/player/[playerId]/opengraph-image.js
+++ b/frontend/app/league/player/[playerId]/opengraph-image.js
@@ -50,7 +50,7 @@ export default async function PlayerOGImage({ params }) {
           justifyContent: "space-between",
         }}
       >
-        <div style={{ display: "flex", gap: 16, color: "#FFC62F", fontSize: 28 }}>
+        <div style={{ display: "flex", gap: 16, color: "#FFC704", fontSize: 28 }}>
           <span style={{ letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
             Brisket League · Player Journey
           </span>
@@ -88,7 +88,7 @@ export default async function PlayerOGImage({ params }) {
             </div>
             <div style={{ display: "flex", gap: 40 }}>
               <Stat label="Total pts" value={`${top.pointsTotal}`} color="#34d399" />
-              <Stat label="Wks started" value={`${top.weeksStarted}`} color="#FFC62F" />
+              <Stat label="Wks started" value={`${top.weeksStarted}`} color="#FFC704" />
               <Stat label="Wks rostered" value={`${top.weeksRostered}`} color="#eaf2ff" />
             </div>
           </div>

--- a/frontend/app/league/rivalry/[pair]/opengraph-image.js
+++ b/frontend/app/league/rivalry/[pair]/opengraph-image.js
@@ -96,7 +96,7 @@ export default async function RivalryOGImage({ params }) {
         <div style={{ display: "flex", gap: 60, justifyContent: "center", fontSize: 34 }}>
           <Stat label="Rivalry Index" value={String(index)} color="#fbbf24" />
           <Stat label="Meetings" value={String(meetings)} color="#eaf2ff" />
-          <Stat label="Playoff" value={String(playoffMeetings)} color="#FFC62F" />
+          <Stat label="Playoff" value={String(playoffMeetings)} color="#FFC704" />
           <Stat label="Series" value={record} color="#34d399" />
         </div>
 

--- a/frontend/app/league/sections/archives.jsx
+++ b/frontend/app/league/sections/archives.jsx
@@ -43,7 +43,7 @@ function ArchivesSection({ data }) {
               fontSize: "0.74rem",
               border: "1px solid",
               borderColor: kind === k.key ? "var(--cyan)" : "var(--border)",
-              background: kind === k.key ? "rgba(255, 198, 47, 0.12)" : "transparent",
+              background: kind === k.key ? "rgba(255, 199, 4, 0.12)" : "transparent",
               borderRadius: 6,
               color: "var(--text)",
               cursor: "pointer",

--- a/frontend/app/league/sections/draft-capital.jsx
+++ b/frontend/app/league/sections/draft-capital.jsx
@@ -135,10 +135,10 @@ function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds
                     style={{
                       width: `${pct}%`,
                       height: "100%",
-                      background: "linear-gradient(90deg, var(--cyan), rgba(255,198,47,0.6))",
+                      background: "linear-gradient(90deg, var(--cyan), rgba(255, 199, 4,0.6))",
                       borderRadius: "var(--radius-sm)",
                       transition: "width 0.4s ease-out",
-                      boxShadow: pct > 30 ? "0 0 12px rgba(255,198,47,0.15)" : "none",
+                      boxShadow: pct > 30 ? "0 0 12px rgba(255, 199, 4,0.15)" : "none",
                     }}
                   />
                 </div>

--- a/frontend/app/league/sections/draft.jsx
+++ b/frontend/app/league/sections/draft.jsx
@@ -45,7 +45,7 @@ function DraftSection({ data, initialOwner, setOwner }) {
                   onClick={() => selectOwner(row.ownerId)}
                   style={{
                     cursor: "pointer",
-                    background: selectedOwner === row.ownerId ? "rgba(255, 198, 47, 0.08)" : "transparent",
+                    background: selectedOwner === row.ownerId ? "rgba(255, 199, 4, 0.08)" : "transparent",
                   }}
                 >
                   <td style={{ fontWeight: 600 }}>

--- a/frontend/app/league/sections/franchise.jsx
+++ b/frontend/app/league/sections/franchise.jsx
@@ -42,7 +42,7 @@ function FranchiseSection({ managers, data, onNavigate, initialOwner, setOwner }
                 borderRadius: "var(--radius)",
                 padding: 10,
                 cursor: "pointer",
-                background: selected === row.ownerId ? "rgba(255, 198, 47, 0.08)" : "transparent",
+                background: selected === row.ownerId ? "rgba(255, 199, 4, 0.08)" : "transparent",
               }}
             >
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>

--- a/frontend/app/league/weekly/[season]/[week]/[matchup]/opengraph-image.js
+++ b/frontend/app/league/weekly/[season]/[week]/[matchup]/opengraph-image.js
@@ -60,7 +60,7 @@ export default async function MatchupOGImage({ params }) {
           justifyContent: "space-between",
         }}
       >
-        <div style={{ display: "flex", color: "#FFC62F", fontSize: 28, letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
+        <div style={{ display: "flex", color: "#FFC704", fontSize: 28, letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
           {`Brisket League · ${season} Week ${week}${m?.isPlayoff ? " · Playoffs" : ""}`}
         </div>
 
@@ -98,7 +98,7 @@ function Side({ name, points, winner }) {
         gap: 12,
         padding: "24px 32px",
         borderRadius: 20,
-        border: `2px solid ${winner ? "#34d399" : "#4F2683"}`,
+        border: `2px solid ${winner ? "#34d399" : "#4F2185"}`,
         background: winner ? "rgba(52,211,153,0.08)" : "transparent",
         minWidth: 360,
       }}

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -197,7 +197,7 @@ export default function SettingsPage() {
               className="button-reset"
               style={{
                 fontSize: "0.7rem",
-                color: "var(--accent-gold, #FFC62F)",
+                color: "var(--accent-gold, #FFC704)",
                 textDecoration: "underline",
                 cursor: "pointer",
                 padding: 0,

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -64,7 +64,7 @@ function fairnessLabel(f) {
 
 function confidenceBadge(c) {
   if (c === "high") return { label: "High consensus", bg: "rgba(52,211,153,0.15)", border: "rgba(52,211,153,0.4)", color: "var(--green)" };
-  if (c === "medium") return { label: "Moderate consensus", bg: "rgba(255,198,47,0.12)", border: "rgba(255,198,47,0.35)", color: "var(--cyan)" };
+  if (c === "medium") return { label: "Moderate consensus", bg: "rgba(255, 199, 4,0.12)", border: "rgba(255, 199, 4,0.35)", color: "var(--cyan)" };
   return { label: "Low consensus", bg: "rgba(153,166,200,0.1)", border: "var(--border)", color: "var(--muted)" };
 }
 
@@ -1324,7 +1324,7 @@ export default function TradePage() {
                 marginBottom: 10,
                 padding: "10px 12px",
                 border: "1px solid var(--cyan)",
-                background: "rgba(255,198,47,0.04)",
+                background: "rgba(255, 199, 4,0.04)",
               }}
             >
               <div style={{ fontSize: "0.74rem", fontWeight: 700, letterSpacing: "0.04em", marginBottom: 6 }}>
@@ -1635,7 +1635,7 @@ export default function TradePage() {
                   )}
                   {/* Balancers (2-team mode only) */}
                   {sides.length === 2 && isUnderpaying && balancers.list.length > 0 && (
-                    <div style={{ marginTop: 8, padding: "6px 8px", background: "rgba(255,198,47,0.06)", borderRadius: 6 }}>
+                    <div style={{ marginTop: 8, padding: "6px 8px", background: "rgba(255, 199, 4,0.06)", borderRadius: 6 }}>
                       <div className="label" style={{ fontSize: "0.68rem", marginBottom: 4 }}>
                         {balancers.teamName
                           ? `Add from ${balancers.teamName}'s roster:`
@@ -1651,7 +1651,7 @@ export default function TradePage() {
                   )}
                   {/* Balancers (3+ team mode) - show on the side getting the best deal */}
                   {multiBalancers && sideIdx === multiBalancers.underpayingIdx && multiBalancers.suggestions.length > 0 && (
-                    <div style={{ marginTop: 8, padding: "6px 8px", background: "rgba(255,198,47,0.06)", borderRadius: 6 }}>
+                    <div style={{ marginTop: 8, padding: "6px 8px", background: "rgba(255, 199, 4,0.06)", borderRadius: 6 }}>
                       <div className="label" style={{ fontSize: "0.68rem", marginBottom: 4 }}>
                         {multiBalancers.teamName
                           ? `Add from ${multiBalancers.teamName}'s roster (Side ${sides[multiBalancers.overpayingIdx]?.label} loses ${Math.round(multiBalancers.gap).toLocaleString()}):`
@@ -1780,7 +1780,7 @@ export default function TradePage() {
                           padding: "5px 10px",
                           borderColor: isActive ? "var(--cyan)" : "var(--border)",
                           color: isActive ? "var(--cyan)" : isEmpty ? "var(--border)" : "var(--muted)",
-                          background: isActive ? "rgba(255,198,47,0.08)" : undefined,
+                          background: isActive ? "rgba(255, 199, 4,0.08)" : undefined,
                           opacity: isEmpty && !isActive ? 0.5 : 1,
                         }}
                       >
@@ -1803,7 +1803,7 @@ export default function TradePage() {
                         className="card"
                         style={{
                           padding: 10,
-                          borderColor: isTopPick ? "rgba(52,211,153,0.5)" : s.edge ? "rgba(255,198,47,0.3)" : undefined,
+                          borderColor: isTopPick ? "rgba(52,211,153,0.5)" : s.edge ? "rgba(255, 199, 4,0.3)" : undefined,
                           borderWidth: isTopPick ? 2 : undefined,
                         }}
                       >

--- a/frontend/components/GlobalSearch.jsx
+++ b/frontend/components/GlobalSearch.jsx
@@ -127,7 +127,7 @@ export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect }) {
                   onClick={() => { onSelect?.(r); onClose?.(); }}
                   style={{
                     width: "100%", textAlign: "left", cursor: "pointer",
-                    background: isSelected ? "rgba(255,198,47,0.08)" : undefined,
+                    background: isSelected ? "rgba(255, 199, 4,0.08)" : undefined,
                     borderLeft: isSelected ? "2px solid var(--cyan)" : "2px solid transparent",
                     paddingLeft: 8,
                   }}

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -368,7 +368,7 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
                   border: "1px solid var(--border)",
                   borderRadius: 6,
                   padding: "8px 10px",
-                  background: "rgba(79, 38, 131, 0.12)",
+                  background: "rgba(79, 33, 133, 0.12)",
                   display: "flex",
                   flexDirection: "column",
                   gap: 6,


### PR DESCRIPTION
## Summary
Site was already themed Vikings purple + gold, but the hex codes had drifted slightly from the official schemecolor.com palette (e.g. #FFC62F instead of #FFC704). This commit locks everything to the exact 4-color palette and finds visible homes for the 4th brand color (blush orange) that previously went unused.

## Palette alignment
| Before | After | Role |
|---|---|---|
| #FFC62F | #FFC704 | Dark Yellow / primary gold |
| #4F2683 | #4F2185 | Aesthetic Purple / primary purple |
| #FFFFFF | #FFFFFF | Full White / text |
| — | #EABF99 | Blush Orange / new accent |

## Where blush orange shows up
- **Draft progress bar gradient**: purple → gold → blush, so the fill paints all three brand colors as it grows
- **Draft glossary summary underline**: 2px blush trim so the 4th color surfaces once per screen

## Propagation
14 files touched. Every hardcoded hex of the old gold/purple was search-replaced across globals.css, four OpenGraph image routes, PlayerPopup, GlobalSearch, trade/edge/settings pages, and four /league section views. rgba() variants normalized to the new base hex too.

Green / red semantic colors unchanged (they mean up / down, not brand).

## Test plan
- [x] npx vitest run — 639/641 pass (2 pre-existing rankHistory failures unrelated)
- [x] npm run build — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)