### PR TITLE
Mirror Draft Data sheet in /league + auto-sync /draft budgets

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -626,6 +626,68 @@ describe("mergeDraftCapitalTeams", () => {
     expect(zero).toBeTruthy();
     expect(zero.initialBudget).toBe(0);
   });
+
+  it("sync mode updates every row when none have been manually edited", () => {
+    // First pull seeds feedBudget on every row.  A second pull with
+    // different numbers should flow through freely because no row's
+    // initialBudget has diverged from its feedBudget yet.
+    const ws = createDefaultWorkspace();
+    const { workspace: first } = mergeDraftCapitalTeams(ws, capitalFeed, {
+      mode: "sync",
+    });
+    const bumpedFeed = capitalFeed.map((e) => ({
+      ...e,
+      auctionDollars: e.auctionDollars + 1,
+    }));
+    const { workspace: second } = mergeDraftCapitalTeams(first, bumpedFeed, {
+      mode: "sync",
+    });
+    const russini = second.teams.find((t) => t.name === "Russini Panini");
+    expect(russini.initialBudget).toBe(419);
+    expect(russini.feedBudget).toBe(419);
+  });
+
+  it("sync mode preserves a user-edited row and still advances feedBudget", () => {
+    const ws = createDefaultWorkspace();
+    const { workspace: seeded } = mergeDraftCapitalTeams(ws, capitalFeed, {
+      mode: "sync",
+    });
+    // User overrides Russini Panini to 500.
+    const edited = updateTeam(
+      seeded,
+      seeded.teams.findIndex((t) => t.name === "Russini Panini"),
+      { initialBudget: 500 },
+    );
+    // Draft capital re-pulls with a new value.
+    const newFeed = capitalFeed.map((e) =>
+      e.team === "Russini Panini" ? { ...e, auctionDollars: 420 } : e,
+    );
+    const { workspace: after } = mergeDraftCapitalTeams(edited, newFeed, {
+      mode: "sync",
+    });
+    const russini = after.teams.find((t) => t.name === "Russini Panini");
+    // User's 500 is preserved; feedBudget tracks the latest feed.
+    expect(russini.initialBudget).toBe(500);
+    expect(russini.feedBudget).toBe(420);
+  });
+
+  it("force mode overwrites user edits (the Load-from-Draft-Capital button)", () => {
+    const ws = createDefaultWorkspace();
+    const { workspace: seeded } = mergeDraftCapitalTeams(ws, capitalFeed, {
+      mode: "sync",
+    });
+    const edited = updateTeam(
+      seeded,
+      seeded.teams.findIndex((t) => t.name === "Russini Panini"),
+      { initialBudget: 500 },
+    );
+    const { workspace: forced } = mergeDraftCapitalTeams(edited, capitalFeed, {
+      mode: "force",
+    });
+    const russini = forced.teams.find((t) => t.name === "Russini Panini");
+    expect(russini.initialBudget).toBe(418);
+    expect(russini.feedBudget).toBe(418);
+  });
 });
 
 // ── workspaceIsPristine ─────────────────────────────────────────────

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -44,7 +44,6 @@ import {
   updatePlayerPreDraft,
   updateSettings,
   updateTeam,
-  workspaceIsPristine,
 } from "@/lib/draft-logic";
 
 const TIER_LABELS = Object.fromEntries(TIER_DEFS.map((t) => [t.key, t.label]));
@@ -2911,13 +2910,14 @@ export default function DraftDashboardPage() {
         const picksArray = Array.isArray(data?.picks) ? data.picks : [];
 
         setWorkspace((ws) => {
-          // Non-force fetches are gated: if the user has already
-          // recorded picks or tuned team budgets, don't clobber.
-          if (!force && !workspaceIsPristine(ws)) return ws;
+          // Force = "Load from Draft Capital" button: overwrite every
+          // row unconditionally.  Sync = auto-refresh: only rewrite
+          // rows the user hasn't manually edited (feedBudget !==
+          // initialBudget flags a manual override, which we preserve).
           const { workspace: next, matched, added } = mergeDraftCapitalTeams(
             ws,
             teamTotals,
-            { picks: picksArray },
+            { picks: picksArray, mode: force ? "force" : "sync" },
           );
           if (!quiet) {
             setCapitalStatus((s) => ({
@@ -2950,12 +2950,13 @@ export default function DraftDashboardPage() {
     [],
   );
 
-  // Auto-populate on first load when the workspace is still at
-  // defaults — gives the user a pre-seeded team list without a click,
-  // but never overwrites a workspace already in progress.
+  // Auto-sync team budgets from the live Draft Capital feed on every
+  // page mount.  Runs in "sync" mode so rows the user has manually
+  // edited (initialBudget !== feedBudget) are preserved; all other
+  // rows snap to the latest feed.  "Load from Draft Capital" still
+  // exists for a hard reset that overwrites every row.
   useEffect(() => {
     if (!hydrated || authenticated !== true) return;
-    if (!workspaceIsPristine(workspace)) return;
     fetchDraftCapital({ quiet: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hydrated, authenticated]);

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -323,7 +323,7 @@ export function createDefaultWorkspace() {
       aggression: DEFAULT_AGGRESSION,
       enforcePct: DEFAULT_ENFORCE_PCT,
     },
-    teams: DEFAULT_TEAMS.map((t) => ({ ...t })),
+    teams: DEFAULT_TEAMS.map((t) => ({ ...t, feedBudget: t.initialBudget })),
     players: DEFAULT_ROOKIES.map((p) => ({
       id: playerSlug(p.name),
       rank: p.rank,
@@ -1140,6 +1140,12 @@ export function updateSettings(workspace, patch) {
  */
 export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
   const preserveNames = opts.preserveCustomNames !== false;
+  // ``mode === "sync"`` preserves user-edited budgets: a row is only
+  // rewritten when its ``initialBudget`` still equals its last-seen
+  // ``feedBudget`` (i.e. the user hasn't typed a custom value).
+  // ``mode === "force"`` (default) is the "Load from Draft Capital"
+  // semantics — overwrite everything.
+  const mode = opts.mode === "sync" ? "sync" : "force";
   const ws = workspace || createDefaultWorkspace();
   const existing = Array.isArray(ws.teams) ? ws.teams : [];
   const feed = Array.isArray(teamTotals) ? teamTotals : [];
@@ -1196,7 +1202,7 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
   // picks array is present, the slot count is authoritative.  When
   // it's not (no picks opts passed), we keep whatever ``initialSlots``
   // the existing team carried, falling back to the default.
-  const buildTeam = (nameOut, budget, prior) => {
+  const buildTeam = (nameOut, feedBudget, prior) => {
     const slotKey = String(nameOut || "").toLowerCase();
     const feedSlots = slotsByKey.get(slotKey);
     const priorSlots = Number.isFinite(Number(prior?.initialSlots))
@@ -1207,10 +1213,30 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
         ? feedSlots
         : 0
       : priorSlots;
+    // In sync mode, preserve the user's typed initialBudget when it
+    // diverges from the last-seen feed value.  In force mode (or when
+    // no prior feedBudget exists), snap initialBudget to the new feed
+    // value.  Either way, feedBudget always tracks the latest feed.
+    let initialBudget = feedBudget;
+    if (mode === "sync" && prior) {
+      const priorFeed = Number.isFinite(Number(prior.feedBudget))
+        ? Number(prior.feedBudget)
+        : null;
+      const priorInitial = Number.isFinite(Number(prior.initialBudget))
+        ? Number(prior.initialBudget)
+        : null;
+      if (priorFeed != null && priorInitial != null && priorInitial !== priorFeed) {
+        // User has edited the budget since the last feed pull —
+        // preserve their value, but still advance the feedBudget
+        // cursor so future edits re-match the user's intent.
+        initialBudget = priorInitial;
+      }
+    }
     return {
       name: nameOut,
-      initialBudget: budget,
+      initialBudget,
       initialSlots,
+      feedBudget,
     };
   };
 
@@ -1445,13 +1471,25 @@ export function hydrateWorkspace(parsed) {
         : def.settings.enforcePct,
     },
     teams: Array.isArray(parsed.teams) && parsed.teams.length > 0
-      ? parsed.teams.map((t, i) => ({
-          name: String(t?.name || `Team ${i + 1}`),
-          initialBudget: Math.max(0, Number(t?.initialBudget) || 0),
-          initialSlots: Number.isFinite(Number(t?.initialSlots))
-            ? Math.max(0, Number(t.initialSlots))
-            : DEFAULT_INITIAL_SLOTS,
-        }))
+      ? parsed.teams.map((t, i) => {
+          const initialBudget = Math.max(0, Number(t?.initialBudget) || 0);
+          // Legacy workspaces (pre-feedBudget tracking) are treated as
+          // in-sync so the next /api/draft-capital fetch freely updates
+          // them.  Once the user edits a row post-hydration, the
+          // diverging feedBudget will protect that edit on subsequent
+          // auto-syncs.
+          const feedBudget = Number.isFinite(Number(t?.feedBudget))
+            ? Math.max(0, Number(t.feedBudget))
+            : initialBudget;
+          return {
+            name: String(t?.name || `Team ${i + 1}`),
+            initialBudget,
+            initialSlots: Number.isFinite(Number(t?.initialSlots))
+              ? Math.max(0, Number(t.initialSlots))
+              : DEFAULT_INITIAL_SLOTS,
+            feedBudget,
+          };
+        })
       : def.teams,
     players: (() => {
       const src =

--- a/server.py
+++ b/server.py
@@ -3072,32 +3072,34 @@ def _round_to_budget(values: list[float], budget: int = 1200) -> list[int]:
 def _fetch_draft_capital():
     """Compute draft capital per team.
 
-    Values: workbook Q45:Q116 (rounded to integers summing to 1200).
-    Ownership: Sleeper API (live traded-pick data).
+    The Draft Data workbook is the authoritative source for BOTH pick
+    values AND pick ownership:
+
+        Q45:Q116 — per-pick dollar values (decimal, sum = 1200)
+        R45:R116 — per-pick current owner (first name)
+        O30:R42  — standings: slot → original owner (first name)
+
+    Sleeper is used only to resolve the sheet's first-name owners into
+    display team names (``user.metadata.team_name`` / ``display_name``)
+    by joining the sheet's standings on Sleeper's draft
+    ``slot_to_roster_id``.  If Sleeper is unavailable we fall back to
+    showing first names directly.
     """
     pick_dollars, workbook_picks, slot_to_original, wb_team_totals, rookies = _parse_draft_data()
-    if not pick_dollars:
-        return {"error": "Draft data CSV not found or empty"}
+    if not workbook_picks:
+        return {"error": "Draft data workbook not found or empty"}
 
     current_year = datetime.now(timezone.utc).year
-    num_teams = 12
-    draft_rounds = max(1, len(pick_dollars) // num_teams) if pick_dollars else 6
+    num_teams = len(slot_to_original) or 12
+    draft_rounds = max(1, len(workbook_picks) // num_teams)
+    raw_values = [wp["value"] for wp in workbook_picks]
+    int_pick_values = _round_to_budget(raw_values, DRAFT_TOTAL_BUDGET)
 
-    # ── Per-pick dollar values from workbook (rounded to int, sum = 1200) ──
-    if workbook_picks and len(workbook_picks) == len(pick_dollars):
-        raw_values = [wp["value"] for wp in workbook_picks]
-    else:
-        raw_values = list(pick_dollars)
-    int_values = _round_to_budget(raw_values, DRAFT_TOTAL_BUDGET)
-
-    # ── Sleeper API: get team names + pick ownership ──
-    roster_name_by_id = {}
-    roster_ids = []
-    owner_to_roster_id = {}
-    roster_id_set = set()
-    draft_slot_by_origin = {}
-    pick_owner = {}  # (round, origin_rid) -> owner_rid
-
+    # ── First-name → Sleeper team-name mapping ──
+    # Built by joining sheet standings (slot → first name) with
+    # Sleeper's draft slot_to_roster_id (slot → roster id → team name).
+    first_name_to_team: dict[str, str] = {}
+    all_team_names: list[str] = []
     try:
         rosters_resp = urllib.request.urlopen(
             f"https://api.sleeper.app/v1/league/{SLEEPER_LEAGUE_ID_FOR_DRAFT}/rosters", timeout=15
@@ -3107,30 +3109,30 @@ def _fetch_draft_capital():
         users_resp = urllib.request.urlopen(
             f"https://api.sleeper.app/v1/league/{SLEEPER_LEAGUE_ID_FOR_DRAFT}/users", timeout=15
         )
-        user_map = {}
+        user_map: dict[str, str] = {}
         for u in json.loads(users_resp.read()):
             uid = u.get("user_id")
-            name = (u.get("metadata", {}).get("team_name")
-                    or u.get("display_name")
-                    or f"Team {uid}")
-            user_map[uid] = name
+            user_map[uid] = (u.get("metadata", {}).get("team_name")
+                             or u.get("display_name")
+                             or f"Team {uid}")
 
+        roster_name_by_id: dict[int, str] = {}
+        owner_to_roster_id: dict[str, int] = {}
         for r in rosters:
             rid = r.get("roster_id")
-            if rid is not None:
-                rid = int(rid)
-                roster_ids.append(rid)
-                oid = r.get("owner_id", "")
-                if oid:
-                    owner_to_roster_id[str(oid)] = rid
-                roster_name_by_id[rid] = user_map.get(oid, f"Team {rid}")
-        roster_id_set = set(roster_ids)
-        num_teams = len(roster_ids) or 12
-        draft_rounds = len(int_values) // num_teams
+            if rid is None:
+                continue
+            rid = int(rid)
+            oid = r.get("owner_id", "")
+            if oid:
+                owner_to_roster_id[str(oid)] = rid
+            roster_name_by_id[rid] = user_map.get(oid, f"Team {rid}")
+        all_team_names = list(roster_name_by_id.values())
 
         drafts_resp = urllib.request.urlopen(
             f"https://api.sleeper.app/v1/league/{SLEEPER_LEAGUE_ID_FOR_DRAFT}/drafts", timeout=15
         )
+        slot_to_roster: dict[int, int] = {}
         for draft in json.loads(drafts_resp.read()):
             try:
                 season = int(draft.get("season"))
@@ -3146,16 +3148,16 @@ def _fetch_draft_capital():
                 draft_detail = json.loads(detail_resp.read())
             except Exception:
                 draft_detail = {}
-            slot_to_roster = draft_detail.get("slot_to_roster_id") or draft.get("slot_to_roster_id") or {}
-            if isinstance(slot_to_roster, dict):
-                for slot, rid_val in slot_to_roster.items():
+            slot_map = draft_detail.get("slot_to_roster_id") or draft.get("slot_to_roster_id") or {}
+            if isinstance(slot_map, dict):
+                for slot, rid_val in slot_map.items():
                     try:
-                        s, r = int(slot), int(rid_val)
+                        s, rv = int(slot), int(rid_val)
                     except (TypeError, ValueError):
                         continue
-                    if r in roster_id_set and s > 0:
-                        draft_slot_by_origin[r] = s
-            if not draft_slot_by_origin:
+                    if s > 0 and rv in roster_name_by_id:
+                        slot_to_roster[s] = rv
+            if not slot_to_roster:
                 draft_order = draft_detail.get("draft_order") or draft.get("draft_order") or {}
                 if isinstance(draft_order, dict):
                     for uid, slot in draft_order.items():
@@ -3164,121 +3166,67 @@ def _fetch_draft_capital():
                             s = int(slot)
                         except (TypeError, ValueError):
                             continue
-                        if rid in roster_id_set and s > 0:
-                            draft_slot_by_origin[rid] = s
+                        if rid in roster_name_by_id and s > 0:
+                            slot_to_roster[s] = rid
 
-        if not draft_slot_by_origin:
-            for i, rid in enumerate(sorted(roster_ids), 1):
-                draft_slot_by_origin[rid] = i
-
-        for rnd in range(1, draft_rounds + 1):
-            for rid in roster_ids:
-                pick_owner[(rnd, rid)] = rid
-
-        tp_resp = urllib.request.urlopen(
-            f"https://api.sleeper.app/v1/league/{SLEEPER_LEAGUE_ID_FOR_DRAFT}/traded_picks", timeout=15
-        )
-        for tp in json.loads(tp_resp.read()):
-            try:
-                season = int(tp.get("season"))
-                rnd = int(tp.get("round"))
-                origin_rid = int(tp.get("roster_id"))
-                owner_rid = int(tp.get("owner_id"))
-            except (TypeError, ValueError):
-                continue
-            if (season == current_year
-                    and 1 <= rnd <= draft_rounds
-                    and origin_rid in roster_id_set
-                    and owner_rid in roster_id_set):
-                pick_owner[(rnd, origin_rid)] = owner_rid
+        for slot, first_name in slot_to_original.items():
+            rid = slot_to_roster.get(int(slot))
+            if rid is not None and first_name:
+                first_name_to_team[str(first_name).strip()] = roster_name_by_id[rid]
 
     except Exception as e:
-        logging.warning(f"Sleeper API failed for draft capital, using workbook owners: {e}")
-        roster_ids = []
+        logging.warning(f"Sleeper API failed for draft capital team-name mapping: {e}")
 
-    # ── Build pick list ──
-    # Accumulate team totals from DECIMAL Q45:Q116 values so rounding
-    # happens at the team level (matching the workbook), not per-pick.
+    def display(first_name) -> str:
+        fn = str(first_name).strip() if first_name else ""
+        return first_name_to_team.get(fn, fn) if fn else "Unknown"
+
+    # ── Build pick list + team totals from sheet ownership ──
     all_picks: list[dict] = []
     team_totals_decimal: dict[str, float] = {}
 
-    # Seed every known roster at $0 so teams that traded every pick
-    # away — and therefore never get a decimal-value addition below
-    # — still appear in the output.  Without this seed, the sort on
-    # ``team_totals_decimal`` drops $0 teams entirely and consumers
-    # (e.g. the /draft dashboard that pulls carry-over budgets from
-    # this endpoint) can't see the full 12-team roster.
-    for rid in roster_ids:
-        roster_name = roster_name_by_id.get(rid, f"Team {rid}")
-        team_totals_decimal.setdefault(roster_name, 0.0)
-
-    if roster_ids:
-        # Sleeper ownership available — pair workbook values with live owners
-        for rnd in range(1, draft_rounds + 1):
-            round_picks = []
-            for origin_rid in roster_ids:
-                slot = draft_slot_by_origin.get(origin_rid, 99)
-                owner_rid = pick_owner.get((rnd, origin_rid), origin_rid)
-                round_picks.append({"origin_rid": origin_rid, "owner_rid": owner_rid, "slot": slot})
-            round_picks.sort(key=lambda p: p["slot"])
-
-            for pick_in_round, pi in enumerate(round_picks):
-                overall = (rnd - 1) * num_teams + pick_in_round
-                dollar = int_values[overall] if overall < len(int_values) else 1
-                origin_name = roster_name_by_id.get(pi["origin_rid"], f"Team {pi['origin_rid']}")
-                owner_name = roster_name_by_id.get(pi["owner_rid"], f"Team {pi['owner_rid']}")
-                is_traded = pi["origin_rid"] != pi["owner_rid"]
-
-                # Use the decimal value from workbook for team total accumulation
-                decimal_val = raw_values[overall] if overall < len(raw_values) else 1.0
-
-                all_picks.append({
-                    "pick": f"{rnd}.{str(pi['slot']).zfill(2)}",
-                    "round": rnd,
-                    "pickInRound": pick_in_round + 1,
-                    "overallPick": overall + 1,
-                    "dollarValue": dollar,
-                    "adjustedDollarValue": dollar,
-                    "originalOwner": origin_name,
-                    "currentOwner": owner_name,
-                    "isTraded": is_traded,
-                    "isExpansion": pick_in_round < 2,
-                    "rookieName": None,
-                    "rookiePos": None,
-                    "rookieKtcValue": None,
-                })
-                team_totals_decimal.setdefault(owner_name, 0.0)
-                team_totals_decimal[owner_name] += decimal_val
+    # Seed every known team at $0 so teams that own no picks still
+    # show up in the output (the /draft dashboard relies on this to
+    # render the full 12-team roster).
+    if all_team_names:
+        for t in all_team_names:
+            team_totals_decimal.setdefault(t, 0.0)
     else:
-        # No Sleeper data — use workbook owners as fallback
-        for i, dollar in enumerate(int_values):
-            rnd = i // num_teams + 1
-            slot = i % num_teams + 1
-            owner = workbook_picks[i]["owner"] if i < len(workbook_picks) else f"Pick {slot}"
-            orig = slot_to_original.get(slot, owner)
-            decimal_val = raw_values[i] if i < len(raw_values) else 1.0
+        for first_name in slot_to_original.values():
+            team_totals_decimal.setdefault(display(first_name), 0.0)
 
-            all_picks.append({
-                "pick": f"{rnd}.{str(slot).zfill(2)}",
-                "round": rnd,
-                "pickInRound": slot,
-                "overallPick": i + 1,
-                "dollarValue": dollar,
-                "adjustedDollarValue": dollar,
-                "originalOwner": orig,
-                "currentOwner": owner,
-                "isTraded": orig != owner,
-                "isExpansion": (i % num_teams) < 2,
-                "rookieName": None,
-                "rookiePos": None,
-                "rookieKtcValue": None,
-            })
-            team_totals_decimal.setdefault(owner, 0.0)
-            team_totals_decimal[owner] += decimal_val
+    for overall_idx, wp in enumerate(workbook_picks):
+        rnd = wp["round"]
+        slot = wp["pick"]
+        val = wp["value"]
+        owner_first = wp["owner"]
+        origin_first = slot_to_original.get(slot, owner_first)
 
-    # ── Round team totals to integers summing to 1200 ──
-    # Rounding at the team level (not per-pick) matches the workbook's
-    # SUMIF-over-decimals approach and avoids ±$1 drift.
+        owner_team = display(owner_first)
+        origin_team = display(origin_first)
+
+        dollar = int_pick_values[overall_idx] if overall_idx < len(int_pick_values) else int(round(val))
+
+        all_picks.append({
+            "pick": f"{rnd}.{str(slot).zfill(2)}",
+            "round": rnd,
+            "pickInRound": slot,
+            "overallPick": overall_idx + 1,
+            "dollarValue": dollar,
+            "adjustedDollarValue": dollar,
+            "originalOwner": origin_team,
+            "currentOwner": owner_team,
+            "isTraded": str(origin_first).strip() != str(owner_first).strip(),
+            "isExpansion": slot <= 2,
+            "rookieName": None,
+            "rookiePos": None,
+            "rookieKtcValue": None,
+        })
+        team_totals_decimal.setdefault(owner_team, 0.0)
+        team_totals_decimal[owner_team] += float(val)
+
+    # Round team totals to integers summing to exactly 1200, matching the
+    # workbook's SUMIF-over-decimals approach.
     team_names = sorted(team_totals_decimal, key=lambda t: -team_totals_decimal[t])
     team_decimal_list = [team_totals_decimal[t] for t in team_names]
     team_int_list = _round_to_budget(team_decimal_list, DRAFT_TOTAL_BUDGET)

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -1,7 +1,8 @@
 """Tests for the draft capital pipeline.
 
-Values come from the workbook (rounded to integers summing to 1200).
-Ownership comes from the Sleeper API (live traded-pick data).
+The Draft Data workbook is the authoritative source for BOTH pick
+values (Q45:Q116) and pick ownership (R45:R116).  Sleeper is used only
+to resolve first-name owners to display team names.
 """
 from __future__ import annotations
 
@@ -96,6 +97,56 @@ class TestApiOutput(unittest.TestCase):
             self.skipTest(f"Unavailable: {result['error']}")
         total = sum(t["auctionDollars"] for t in result["teamTotals"])
         self.assertEqual(total, 1200, f"Team total sum = {total}")
+
+
+class TestTeamTotalsMirrorSheet(unittest.TestCase):
+    """The pipeline must mirror the sheet: accumulating R45:R116
+    ownership against Q45:Q116 values must equal the authoritative
+    per-owner decimals in T63:U74, and the API's integer totals must
+    sum to exactly 1200 via largest-remainder rounding of those
+    decimals."""
+
+    def test_decimal_totals_match_sheet_per_owner(self):
+        from collections import defaultdict
+        _, workbook_picks, _, wb_team_totals, _ = _load()
+        computed = defaultdict(float)
+        for wp in workbook_picks:
+            computed[wp["owner"]] += wp["value"]
+        for owner, total in computed.items():
+            self.assertAlmostEqual(
+                total, wb_team_totals.get(owner, 0.0), places=2,
+                msg=f"{owner}: computed={total}, sheet={wb_team_totals.get(owner)}",
+            )
+
+    def test_api_team_totals_match_largest_remainder_of_sheet_decimals(self):
+        """Sorted API dollar totals must equal largest-remainder
+        rounding of the sheet's per-owner decimals (regardless of the
+        Sleeper display-name mapping used to label each row)."""
+        import server
+        from collections import defaultdict
+        _, workbook_picks, _, _, _ = _load()
+        decimals = defaultdict(float)
+        for wp in workbook_picks:
+            decimals[wp["owner"]] += wp["value"]
+
+        result = server._fetch_draft_capital()
+        if "error" in result:
+            self.skipTest(f"Unavailable: {result['error']}")
+
+        # Pad with zero-total rows for any teams Sleeper reports that
+        # don't appear as owners in R45:R116 (e.g. expansion franchises
+        # with no picks yet).
+        api_totals = sorted(
+            [t["auctionDollars"] for t in result["teamTotals"]], reverse=True,
+        )
+        decimal_vals = sorted(decimals.values(), reverse=True)
+        pad = max(0, len(api_totals) - len(decimal_vals))
+        decimal_vals += [0.0] * pad
+        expected = sorted(
+            server._round_to_budget(decimal_vals, 1200), reverse=True,
+        )
+        self.assertEqual(api_totals, expected,
+                         f"api={api_totals} expected={expected}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes two related issues where team budgets drifted out of sync with the Draft Data workbook:

### 1. `/league` Draft Capital didn't match the sheet
`_fetch_draft_capital` was reading pick *values* from the sheet (Q45:Q116) but pick *ownership* from Sleeper's `traded_picks` feed. Those two sources disagreed, so team totals drifted (e.g. Russini Panini showed **$417** vs the sheet's **$413**).

The workbook is now authoritative for both values AND ownership:
- Q45:Q116 → per-pick decimal values
- R45:R116 → per-pick current owner (first name)
- O30:R42 → slot → original owner (first name)

Sleeper is used **only** to resolve first-name owners into display team names, by joining the sheet's standings with Sleeper's `slot_to_roster_id`. If Sleeper is unavailable, we fall back to first names.

Output after fix — exact decimal match to sheet T63:U74:

| Team | Before | After | Sheet |
|---|---|---|---|
| Russini Panini (Jason) | $417 | **$413** | 412.75 |
| jstuedle (Joel) | $164 | **$169** | 169.00 |
| Rage Against The Achane (MaKayla) | $155 | **$159** | 158.50 |
| CollinFoz (Collin) | $139 | **$139** | 138.50 |
| Chargers Team Doctor (Roy) | $125 | **$129** | 129.50 |

(All 12 teams sum to exactly $1200 via largest-remainder rounding.)

### 2. `/draft` starting budgets were stale
`/draft` only auto-fetched `/api/draft-capital` on the very first page visit (gated by `workspaceIsPristine`). Every subsequent visit used stale localStorage values until the user manually clicked "Load from Draft Capital".

Now:
- Each team row carries a `feedBudget` cursor tracking the last-seen feed value.
- Auto-sync runs on **every** page mount.
- A row is only overwritten when `initialBudget === feedBudget` (row is still in sync with the feed). If the user has manually typed a value (`initialBudget !== feedBudget`), it's preserved.
- "Load from Draft Capital" still works as a hard reset (force mode overwrites everything).

## Test plan

- [x] `python3 -m pytest tests/api/test_draft_capital.py -v` — all 12 pass, including 2 new regression tests that pin per-owner decimal totals to T63:U74 and the final integer rollup to largest-remainder of the sheet decimals
- [x] `python3 -m pytest tests/` — 1830 pass, 4 pre-existing failures (beautifulsoup4/selenium env issues, unrelated)
- [x] `npm test` — all 174 frontend tests pass, including 3 new `mergeDraftCapitalTeams` sync-mode tests covering: (a) rows with no user edits get refreshed, (b) user-edited rows are preserved while `feedBudget` still advances, (c) force mode overwrites user edits
- [ ] Verify in browser: `/league` Draft Capital shows $413 / $169 / $159 / ... and `/draft` INITIAL column matches without requiring a manual "Load from Draft Capital" click

https://claude.ai/code/session_018zxNEUG6TsHswK6JdVkjtp

---
_Generated by [Claude Code](https://claude.ai/code/session_018zxNEUG6TsHswK6JdVkjtp)_