### PR TITLE
rankings: tap-to-reveal source chip strip on mobile

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1446,10 +1446,17 @@ export default function RankingsPage() {
                           horizontally and get hidden via `hide-mobile`.
                           Instead of dropping the data entirely, we
                           render a compact flex strip of source chips
-                          below each player row so mobile users see the
-                          same per-source value + rank they'd see on
-                          desktop.  Gated on `showSiteCols` so the
-                          toggle has the same effect on both surfaces.
+                          below each player row — but only when the
+                          user has tapped the row to expand it.
+                          Rendering the strip under every row by
+                          default dominated the mobile viewport and
+                          pushed the headline Value column off-screen
+                          for cold-start users carrying the legacy
+                          ``showSiteCols: true`` localStorage value.
+                          Gating on ``isExpanded`` makes the source
+                          audit on-demand on mobile.  ``showSiteCols``
+                          still governs the desktop per-source column
+                          render — desktop behavior is unchanged.
 
                           Uses a dedicated `.rankings-mobile-source-row`
                           class (not the global `.mobile-only` helper)
@@ -1458,7 +1465,7 @@ export default function RankingsPage() {
                           `display: initial !important`, which would
                           force the <tr> to `inline` and break the
                           table layout. */}
-                      {settings.showSiteCols && (
+                      {isExpanded && (
                         <tr className="rankings-mobile-source-row">
                           <td colSpan={totalCols}>
                             <div className="rankings-mobile-sources">


### PR DESCRIPTION
## Why

Extracts the single remaining behavior change from the now-closed #227.

#226 flipped the cold-start default for `showSiteCols` to `false` and added a master toggle to the Columns popover — both of which have already landed. But users who had `showSiteCols: true` stored in localStorage from before #226 still see the mobile chip strip rendered under every row, which dominates the viewport and pushes the headline Value column off-screen on a 390px-wide device.

## Change

Gate the mobile chip strip on `isExpanded` instead of `settings.showSiteCols`. On mobile, tapping a row reveals its per-source audit strip; collapsed rows render headline columns only. Desktop per-source columns continue to honor `settings.showSiteCols` — behavior there is unchanged.

Comment block above the gate refreshed to reflect the new semantic.

## Test plan
- [ ] On mobile (≤768px): chip strip hidden under every player row on page load, regardless of stored `showSiteCols` value.
- [ ] Tap a row → chip strip + existing audit panel render beneath it.
- [ ] Tap the row again → collapse, strip disappears.
- [ ] On desktop: `showSiteCols: true` still renders per-source columns inline; Columns popover master toggle unchanged.
- [ ] Value column fully visible on a 390px-wide viewport without scrolling.

https://claude.ai/code/session_01BpYM35qWqVMjojuN2Bw45K

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpYM35qWqVMjojuN2Bw45K)_