### PR TITLE
Backend news adapter: Sleeper trending + ESPN RSS behind /api/news

### DIFF
--- a/server.py
+++ b/server.py
@@ -64,6 +64,7 @@ from src.api.data_contract import (
     validate_api_data_contract,
 )
 from src.api import rank_history as _rank_history
+from src.news import NewsService, build_default_service
 
 # ── CONFIG ──────────────────────────────────────────────────────────────
 SCRAPE_INTERVAL_HOURS = 2
@@ -227,6 +228,53 @@ contract_health: dict = {
     "contractVersion": API_DATA_CONTRACT_VERSION,
     "playerCount": 0,
 }
+# ── NEWS SERVICE ───────────────────────────────────────────────────────
+# Lazy-built singleton.  Built on first request rather than at import
+# so unit tests can monkey-patch the factory and the server can boot
+# even if a transient DNS failure would block provider construction.
+_news_service: NewsService | None = None
+_news_service_lock = threading.Lock()
+
+
+def _get_news_service() -> NewsService:
+    global _news_service
+    if _news_service is not None:
+        return _news_service
+    with _news_service_lock:
+        if _news_service is None:
+            _news_service = build_default_service()
+    return _news_service
+
+
+def _reset_news_service_for_tests(svc: NewsService | None = None) -> None:
+    """Test hook — inject a stubbed service or clear the singleton."""
+    global _news_service
+    with _news_service_lock:
+        _news_service = svc
+
+
+def _live_player_names() -> list[str]:
+    """Return every player name visible in the live contract.
+
+    ESPN's RSS provider uses this set to tag headlines with matched
+    players; returning an empty list when the contract hasn't
+    loaded yet degrades gracefully — headlines still surface,
+    they just arrive with empty ``players[]``.
+    """
+    contract = latest_contract_data or {}
+    rows = contract.get("playersArray") or []
+    names: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        for key in ("displayName", "name", "canonicalName", "fullName"):
+            v = row.get(key)
+            if isinstance(v, str) and v.strip():
+                names.append(v.strip())
+                break
+    return names
+
+
 # R-9: Lightweight metrics counters
 _metrics: dict = {
     "server_start_time": None,
@@ -2082,6 +2130,82 @@ async def get_metrics():
         "disk_ok": disk_ok,
         "scrape_running": scrape_status.get("running", False),
     })
+
+
+# ── NEWS ───────────────────────────────────────────────────────────────
+# Normalized news feed aggregating Sleeper trending + ESPN RSS.  The
+# service layer owns caching, per-provider fault isolation, and the
+# normalized NewsItem shape (see ``src/news/base.py``).  The route is
+# a thin adapter: parse query args, delegate, and surface per-provider
+# diagnostics so the frontend can distinguish "empty feed" from "all
+# providers degraded".
+@app.get("/api/news")
+async def get_news(request: Request):
+    limit_raw = request.query_params.get("limit")
+    try:
+        limit = int(limit_raw) if limit_raw else 50
+    except ValueError:
+        limit = 50
+    limit = max(1, min(limit, 100))
+
+    # Optional team-name filter.  Repeatable ?team=... or comma
+    # separated.  Items that don't mention at least one of those
+    # players are dropped from the response (client-side filtering
+    # stays available for scope="roster"/"league" already).
+    team_params = request.query_params.getlist("team") if hasattr(
+        request.query_params, "getlist"
+    ) else []
+    team_names: list[str] = []
+    for raw in team_params:
+        for part in str(raw).split(","):
+            if part.strip():
+                team_names.append(part.strip())
+
+    svc = _get_news_service()
+    try:
+        aggregated = await run_in_threadpool(
+            svc.aggregate,
+            player_names=_live_player_names(),
+            team_names=team_names or None,
+        )
+    except Exception as exc:
+        log.warning("/api/news aggregation failed: %s", exc)
+        # Signal "temporarily unavailable" — the frontend falls back
+        # to the mock fixture on 503 so the page stays functional.
+        return JSONResponse(
+            status_code=503,
+            content={
+                "items": [],
+                "providersUsed": [],
+                "providerRuns": [],
+                "error": f"{type(exc).__name__}",
+                "generatedAt": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+    payload = aggregated.to_dict()
+    payload["source"] = "backend"
+    payload["limit"] = limit
+    if len(payload.get("items", [])) > limit:
+        payload["items"] = payload["items"][:limit]
+        payload["count"] = len(payload["items"])
+
+    # Distinguish "providers worked, nothing trending" (legit 200
+    # with empty items — DEMO badge stays OFF) from "every provider
+    # errored out" (503 — frontend falls back to its mock fixture
+    # and re-shows the DEMO badge).
+    provider_runs = aggregated.provider_runs or []
+    all_failed = bool(provider_runs) and not any(r.ok for r in provider_runs)
+    if all_failed:
+        return JSONResponse(
+            status_code=503,
+            content={
+                **payload,
+                "source": "backend",
+                "error": "all_providers_failed",
+            },
+        )
+    return JSONResponse(content=payload)
 
 
 @app.get("/api/scaffold/status")

--- a/src/news/__init__.py
+++ b/src/news/__init__.py
@@ -1,0 +1,41 @@
+"""News ingestion package.
+
+Public surface:
+
+* ``NewsItem`` / ``PlayerMention`` — normalized response schema.
+* ``NewsProvider`` — abstract base for ingestion adapters.
+* ``NewsService`` / ``build_default_service`` — aggregator used
+  by the ``/api/news`` route.
+* ``available_provider_names`` / ``build_provider`` — registry
+  introspection for diagnostics.
+"""
+from __future__ import annotations
+
+from .base import NewsItem, NewsProvider, PlayerMention, stable_id, to_iso_utc
+from .providers import available_provider_names, build_provider
+from .service import (
+    AggregatedNews,
+    DEFAULT_CACHE_TTL_S,
+    DEFAULT_LIMIT_PER_PROVIDER,
+    DEFAULT_TOTAL_LIMIT,
+    NewsService,
+    ProviderRunResult,
+    build_default_service,
+)
+
+__all__ = [
+    "AggregatedNews",
+    "DEFAULT_CACHE_TTL_S",
+    "DEFAULT_LIMIT_PER_PROVIDER",
+    "DEFAULT_TOTAL_LIMIT",
+    "NewsItem",
+    "NewsProvider",
+    "NewsService",
+    "PlayerMention",
+    "ProviderRunResult",
+    "available_provider_names",
+    "build_default_service",
+    "build_provider",
+    "stable_id",
+    "to_iso_utc",
+]

--- a/src/news/base.py
+++ b/src/news/base.py
@@ -1,0 +1,168 @@
+"""News ingestion primitives.
+
+Defines the normalized ``NewsItem`` contract that every provider
+must emit, and the ``NewsProvider`` abstract base class that the
+service layer consumes.
+
+The contract is deliberately a superset of two things:
+
+1. The existing frontend ``NewsItem`` shape in
+   ``frontend/lib/news-service.js`` (``id``, ``ts``, ``provider``,
+   ``providerLabel``, ``severity``, ``kind``, ``headline``, ``body``,
+   ``players[]``, ``url``).  Preserving these fields means the
+   backend can start answering 200 without any frontend code change.
+2. The richer surface requested for future-proofing —
+   ``publishedAt`` (alias of ``ts``), ``summary`` (alias of
+   ``body``), ``impactedPlayers`` (flat name list), ``tags``,
+   ``confidence``, ``relevance``.
+
+Aliases are duplicated on every item rather than computed
+client-side so consumers of either vocabulary work identically.
+"""
+from __future__ import annotations
+
+import abc
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Literal, Optional
+
+Severity = Literal["alert", "watch", "info"]
+Impact = Literal["positive", "negative", "neutral"]
+
+
+@dataclass(frozen=True)
+class PlayerMention:
+    """Single player reference attached to a news item."""
+
+    name: str
+    impact: Impact = "neutral"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "impact": self.impact}
+
+
+@dataclass(frozen=True)
+class NewsItem:
+    """Normalized news item emitted by every provider.
+
+    ``id`` must be stable across refetches of the same underlying
+    event so the frontend's cache + dedupe logic works.  Providers
+    derive it from a content hash (see ``stable_id``) unless the
+    upstream gives a real identifier.
+    """
+
+    id: str
+    ts: str  # ISO 8601 UTC
+    provider: str
+    provider_label: str
+    severity: Severity
+    kind: str
+    headline: str
+    body: str = ""
+    players: List[PlayerMention] = field(default_factory=list)
+    url: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    confidence: Optional[float] = None
+    relevance: Optional[float] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize using both legacy and new field names.
+
+        Consumers of the old contract (``body``, ``players``,
+        ``ts``) and new contract (``summary``, ``impactedPlayers``,
+        ``publishedAt``) both see identical data.
+        """
+        players_out = [p.to_dict() for p in self.players]
+        impacted_names = [p.name for p in self.players]
+        return {
+            # ── legacy fields kept verbatim ───────────────────────
+            "id": self.id,
+            "ts": self.ts,
+            "provider": self.provider,
+            "providerLabel": self.provider_label,
+            "severity": self.severity,
+            "kind": self.kind,
+            "headline": self.headline,
+            "body": self.body,
+            "players": players_out,
+            "url": self.url,
+            # ── enriched aliases ─────────────────────────────────
+            "publishedAt": self.ts,
+            "summary": self.body,
+            "impactedPlayers": impacted_names,
+            "tags": list(self.tags),
+            "confidence": self.confidence,
+            "relevance": self.relevance,
+        }
+
+
+def stable_id(provider: str, payload: str) -> str:
+    """Build a deterministic, short id for an item.
+
+    ``payload`` should be something that uniquely identifies the
+    event — for an RSS entry the GUID + pub-date, for a Sleeper
+    trending row the player_id + rounded timestamp bucket.  Using
+    a SHA-1 prefix keeps the id URL-safe and short enough for
+    logs.
+    """
+    h = hashlib.sha1(f"{provider}:{payload}".encode("utf-8")).hexdigest()
+    return f"{provider.lower()}-{h[:12]}"
+
+
+def to_iso_utc(dt: datetime) -> str:
+    """Render a datetime as an ISO 8601 UTC string ending in ``Z``-free ``+00:00``."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+class NewsProvider(abc.ABC):
+    """Abstract contract for a news source.
+
+    A provider is expected to be cheap to construct and side-effect
+    free in ``__init__``.  All network I/O happens inside
+    ``fetch`` so the aggregator can catch and isolate failures.
+
+    Subclasses must set ``name`` and ``label`` as class attributes,
+    and implement ``fetch``.  ``fetch`` MUST return a list (not a
+    generator) and MUST NOT raise — return an empty list on any
+    upstream failure.  The service layer will log and continue.
+    """
+
+    name: str = ""
+    label: str = ""
+    # Soft timeout hint in seconds — the service uses this when
+    # dispatching providers so a single slow provider cannot block
+    # the whole response.
+    timeout_s: float = 5.0
+
+    def __init__(self, **config: Any) -> None:
+        self.config = dict(config or {})
+
+    @abc.abstractmethod
+    def fetch(
+        self,
+        *,
+        player_names: Optional[Iterable[str]] = None,
+        limit: int = 50,
+    ) -> List[NewsItem]:
+        """Return a list of normalized news items.
+
+        ``player_names`` (optional) is the union of every player
+        currently visible in the live data contract.  Providers
+        that only surface headlines (ESPN RSS) use it to tag
+        ``players`` via substring match.  Providers that already
+        emit per-player data (Sleeper trending) ignore it.
+        """
+
+
+__all__ = [
+    "Impact",
+    "NewsItem",
+    "NewsProvider",
+    "PlayerMention",
+    "Severity",
+    "stable_id",
+    "to_iso_utc",
+]

--- a/src/news/providers/__init__.py
+++ b/src/news/providers/__init__.py
@@ -6,17 +6,22 @@ individual modules so adding a provider is a one-line change in
 instance) so the service can construct them with per-deploy config
 loaded at startup.
 
-Priority ordering matches the task brief:
-    1. Sleeper trending (real-time adds/drops, always-on)
-    2. ESPN RSS (headline firehose, public feed)
-    3. Rotowire (licensing pending — stub returns empty until auth'd)
+Priority ordering (trending first, then RSS headline sources,
+then licensed sources):
+    1. Sleeper trending — real-time adds/drops, always-on, no auth
+    2. ESPN RSS — broad headline firehose, public feed
+    3. FantasyPros RSS — fantasy-flavored player news, public feed
+    4. CBS Sports RSS — NFL headlines, public feed
+    5. Rotowire — licensing pending, stub until auth'd
 """
 from __future__ import annotations
 
 from typing import Callable, Dict
 
 from ..base import NewsProvider
+from .cbs import CbsFantasyRssProvider
 from .espn import EspnRssProvider
+from .fantasypros import FantasyProsRssProvider
 from .rotowire import RotowireProvider
 from .sleeper import SleeperTrendingProvider
 
@@ -30,6 +35,8 @@ ProviderFactory = Callable[..., NewsProvider]
 _PROVIDER_FACTORIES: Dict[str, ProviderFactory] = {
     "sleeper": SleeperTrendingProvider,
     "espn": EspnRssProvider,
+    "fantasypros": FantasyProsRssProvider,
+    "cbs": CbsFantasyRssProvider,
     "rotowire": RotowireProvider,
 }
 
@@ -50,7 +57,9 @@ def build_provider(name: str, **config) -> NewsProvider:
 
 
 __all__ = [
+    "CbsFantasyRssProvider",
     "EspnRssProvider",
+    "FantasyProsRssProvider",
     "RotowireProvider",
     "SleeperTrendingProvider",
     "available_provider_names",

--- a/src/news/providers/__init__.py
+++ b/src/news/providers/__init__.py
@@ -1,0 +1,58 @@
+"""News provider registry.
+
+The service layer imports providers from here rather than from
+individual modules so adding a provider is a one-line change in
+``_PROVIDER_FACTORIES`` below.  Providers register a factory (not an
+instance) so the service can construct them with per-deploy config
+loaded at startup.
+
+Priority ordering matches the task brief:
+    1. Sleeper trending (real-time adds/drops, always-on)
+    2. ESPN RSS (headline firehose, public feed)
+    3. Rotowire (licensing pending — stub returns empty until auth'd)
+"""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from ..base import NewsProvider
+from .espn import EspnRssProvider
+from .rotowire import RotowireProvider
+from .sleeper import SleeperTrendingProvider
+
+
+ProviderFactory = Callable[..., NewsProvider]
+
+
+# Ordered dict — iteration order is the priority order providers
+# run in.  Earlier providers' items appear first in the aggregated
+# feed before sort-by-timestamp.
+_PROVIDER_FACTORIES: Dict[str, ProviderFactory] = {
+    "sleeper": SleeperTrendingProvider,
+    "espn": EspnRssProvider,
+    "rotowire": RotowireProvider,
+}
+
+
+def available_provider_names() -> list[str]:
+    """Return registered provider names in priority order."""
+    return list(_PROVIDER_FACTORIES.keys())
+
+
+def build_provider(name: str, **config) -> NewsProvider:
+    """Construct a registered provider by name.
+
+    Raises ``KeyError`` if the name is not registered.
+    """
+    key = name.lower()
+    factory = _PROVIDER_FACTORIES[key]
+    return factory(**config)
+
+
+__all__ = [
+    "EspnRssProvider",
+    "RotowireProvider",
+    "SleeperTrendingProvider",
+    "available_provider_names",
+    "build_provider",
+]

--- a/src/news/providers/__init__.py
+++ b/src/news/providers/__init__.py
@@ -2,17 +2,26 @@
 
 The service layer imports providers from here rather than from
 individual modules so adding a provider is a one-line change in
-``_PROVIDER_FACTORIES`` below.  Providers register a factory (not an
-instance) so the service can construct them with per-deploy config
-loaded at startup.
+``_PROVIDER_FACTORIES`` below.  Providers register a factory (not
+an instance) so the service can construct them with per-deploy
+config loaded at startup.
 
-Priority ordering (trending first, then RSS headline sources,
-then licensed sources):
-    1. Sleeper trending — real-time adds/drops, always-on, no auth
-    2. ESPN RSS — broad headline firehose, public feed
-    3. FantasyPros RSS — fantasy-flavored player news, public feed
-    4. CBS Sports RSS — NFL headlines, public feed
-    5. Rotowire — licensing pending, stub until auth'd
+Registered providers (ordered by priority — earliest first):
+
+1. **sleeper** — Sleeper trending adds/drops (API, not RSS).
+2. **espn** — ESPN NFL news RSS.
+3. **fantasypros** — FantasyPros player-news RSS.
+4. **cbs** — CBS Sports NFL headlines RSS.
+5. **dlf** — Dynasty League Football RSS.
+6. **dynastynerds** — Dynasty Nerds RSS.
+7. **pff** — Pro Football Focus RSS.
+8. **fftoday** — FFToday news RSS (explicit .xml endpoint).
+9. **playerprofiler** — Player Profiler analytics RSS.
+10. **razzball** — Razzball fantasy advice RSS.
+11. **rotowire** — stub, OFF until licensed.
+
+Every RSS provider inherits from ``RssNewsProvider`` (in
+``_rss.py``) — adding another source is a 6-line subclass.
 """
 from __future__ import annotations
 
@@ -20,6 +29,14 @@ from typing import Callable, Dict
 
 from ..base import NewsProvider
 from .cbs import CbsFantasyRssProvider
+from .dynasty_focused import (
+    DynastyLeagueFootballProvider,
+    DynastyNerdsProvider,
+    FfTodayProvider,
+    PffProvider,
+    PlayerProfilerProvider,
+    RazzballProvider,
+)
 from .espn import EspnRssProvider
 from .fantasypros import FantasyProsRssProvider
 from .rotowire import RotowireProvider
@@ -31,12 +48,18 @@ ProviderFactory = Callable[..., NewsProvider]
 
 # Ordered dict — iteration order is the priority order providers
 # run in.  Earlier providers' items appear first in the aggregated
-# feed before sort-by-timestamp.
+# feed before sort-by-(severity, timestamp).
 _PROVIDER_FACTORIES: Dict[str, ProviderFactory] = {
     "sleeper": SleeperTrendingProvider,
     "espn": EspnRssProvider,
     "fantasypros": FantasyProsRssProvider,
     "cbs": CbsFantasyRssProvider,
+    "dlf": DynastyLeagueFootballProvider,
+    "dynastynerds": DynastyNerdsProvider,
+    "pff": PffProvider,
+    "fftoday": FfTodayProvider,
+    "playerprofiler": PlayerProfilerProvider,
+    "razzball": RazzballProvider,
     "rotowire": RotowireProvider,
 }
 
@@ -58,8 +81,14 @@ def build_provider(name: str, **config) -> NewsProvider:
 
 __all__ = [
     "CbsFantasyRssProvider",
+    "DynastyLeagueFootballProvider",
+    "DynastyNerdsProvider",
     "EspnRssProvider",
     "FantasyProsRssProvider",
+    "FfTodayProvider",
+    "PffProvider",
+    "PlayerProfilerProvider",
+    "RazzballProvider",
     "RotowireProvider",
     "SleeperTrendingProvider",
     "available_provider_names",

--- a/src/news/providers/_rss.py
+++ b/src/news/providers/_rss.py
@@ -1,0 +1,238 @@
+"""Shared RSS parsing + classification helpers.
+
+Both the ESPN and FantasyPros providers hit the same basic shape —
+a ``<channel>`` with ``<item>`` children carrying ``<title>``,
+``<link>``, ``<guid>``, ``<pubDate>``, ``<description>`` — and
+both feed into the same keyword-based severity classifier.  This
+module holds the common bits so only the URL + provider identity
+differ between the two adapters.
+
+Nothing here issues network I/O; the default stdlib fetcher lives
+on the subclasses so tests can inject a fake fetcher.
+"""
+from __future__ import annotations
+
+import re
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Callable, Iterable, List, Optional
+
+from ..base import NewsItem, PlayerMention, stable_id, to_iso_utc
+
+# Keywords matched with word boundaries so short fragments like
+# "ir", "cut", "acl" don't trip on substrings of unrelated words
+# ("their", "document", "practice").
+_ALERT_KEYWORDS = (
+    "injury",
+    "injured",
+    "hurt",
+    "out for season",
+    "out for the season",
+    "season-ending",
+    "torn",
+    "acl",
+    "achilles",
+    "concussion",
+    "placed on ir",
+    "on the ir",
+    "to ir",
+    "questionable",
+    "doubtful",
+    "ruled out",
+    "suspended",
+    "arrest",
+)
+_WATCH_KEYWORDS = (
+    "trade",
+    "traded",
+    "signs",
+    "signed",
+    "contract",
+    "extension",
+    "restructure",
+    "promoted",
+    "starter",
+    "named starter",
+    "released",
+    "waived",
+    "claim",
+    "claimed",
+    "activated",
+)
+
+_ALERT_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(k) for k in _ALERT_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+_WATCH_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(k) for k in _WATCH_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+_TRANSACTION_RE = re.compile(
+    r"\b(?:trade|traded|signs?|signed|contract|released|waived)\b",
+    re.IGNORECASE,
+)
+
+_STRIP_HTML = re.compile(r"<[^>]+>")
+
+
+def clean_text(text: Optional[str]) -> str:
+    """Strip HTML and normalize whitespace on an RSS text field."""
+    if not text:
+        return ""
+    return _STRIP_HTML.sub("", text).strip()
+
+
+def classify(text: str) -> tuple[str, str, str]:
+    """Return ``(severity, kind, impact)`` for a headline + body.
+
+    Heuristics intentionally skew conservative — when in doubt
+    the item drops to ``info`` rather than over-alerting, since
+    the ticker's alert lane is narrow and each false positive
+    costs real estate from roster-relevant signal.
+    """
+    if _ALERT_RE.search(text):
+        return "alert", "injury", "negative"
+    if _WATCH_RE.search(text):
+        kind = "transaction" if _TRANSACTION_RE.search(text) else "performance"
+        return "watch", kind, "positive"
+    return "info", "news", "neutral"
+
+
+def parse_pub_date(raw: Optional[str]) -> datetime:
+    """Parse an RSS ``pubDate`` into an aware UTC datetime."""
+    if not raw:
+        return datetime.now(timezone.utc)
+    try:
+        dt = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return datetime.now(timezone.utc)
+    if dt is None:
+        return datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def match_players(
+    text: str,
+    *,
+    known_names: list[str],
+    impact: str,
+) -> List[PlayerMention]:
+    """Case-insensitive substring match against the known-names list.
+
+    The known-names set is already curated (only real player names
+    from the live contract), so full-word matching would be
+    overkill — the false-positive rate is bounded by the input
+    vocabulary rather than headline wording.
+    """
+    if not known_names or not text:
+        return []
+    haystack = text.lower()
+    seen: set[str] = set()
+    out: List[PlayerMention] = []
+    for name in known_names:
+        if not name:
+            continue
+        key = name.lower()
+        if key in seen:
+            continue
+        if key in haystack:
+            out.append(PlayerMention(name=name, impact=impact))
+            seen.add(key)
+    return out
+
+
+def default_http_fetcher(url: str, *, timeout: float, user_agent: str) -> bytes:
+    """Stdlib RSS fetcher used when a subclass doesn't inject one."""
+    req = urllib.request.Request(url, headers={"User-Agent": user_agent})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def fetch_rss_items(
+    *,
+    feed_url: str,
+    provider_name: str,
+    provider_label: str,
+    fetcher: Callable[[str], bytes],
+    known_names: Iterable[str] | None,
+    limit: int,
+) -> List[NewsItem]:
+    """Fetch + parse an RSS feed into normalized ``NewsItem``s.
+
+    Upstream failures (network, parse) propagate — the service
+    layer's exception handler catches them and marks the provider
+    run ``ok=False``.  That's what makes ``all_providers_failed``
+    detection work: a silent ``return []`` here would masquerade
+    as a healthy-but-quiet feed and the frontend would never
+    fall back to its DEMO fixture on a real outage.
+    """
+    raw = fetcher(feed_url)
+    root = ET.fromstring(raw)
+
+    channel = root.find("channel")
+    items_el = channel.findall("item") if channel is not None else root.findall("item")
+
+    known = [str(n) for n in (known_names or []) if n]
+    out: List[NewsItem] = []
+    for el in items_el[: max(1, int(limit))]:
+        item = _item_from_element(
+            el,
+            provider_name=provider_name,
+            provider_label=provider_label,
+            known_names=known,
+        )
+        if item is not None:
+            out.append(item)
+    return out
+
+
+def _item_from_element(
+    el: ET.Element,
+    *,
+    provider_name: str,
+    provider_label: str,
+    known_names: list[str],
+) -> Optional[NewsItem]:
+    title = clean_text((el.findtext("title") or "").strip())
+    if not title:
+        return None
+    link = (el.findtext("link") or "").strip() or None
+    description = clean_text(el.findtext("description") or "")
+    guid = (el.findtext("guid") or link or title).strip()
+    published = parse_pub_date(el.findtext("pubDate"))
+
+    severity, kind, impact = classify(f"{title}\n{description}")
+    mentions = match_players(
+        f"{title}\n{description}",
+        known_names=known_names,
+        impact=impact,
+    )
+
+    return NewsItem(
+        id=stable_id(provider_name, guid),
+        ts=to_iso_utc(published),
+        provider=provider_name,
+        provider_label=provider_label,
+        severity=severity,
+        kind=kind,
+        headline=title,
+        body=description,
+        players=mentions,
+        url=link,
+        tags=[kind],
+    )
+
+
+__all__ = [
+    "classify",
+    "clean_text",
+    "default_http_fetcher",
+    "fetch_rss_items",
+    "match_players",
+    "parse_pub_date",
+]

--- a/src/news/providers/_rss.py
+++ b/src/news/providers/_rss.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Callable, Iterable, List, Optional
 
-from ..base import NewsItem, PlayerMention, stable_id, to_iso_utc
+from ..base import NewsItem, NewsProvider, PlayerMention, stable_id, to_iso_utc
 
 # Keywords matched with word boundaries so short fragments like
 # "ir", "cut", "acl" don't trip on substrings of unrelated words
@@ -228,7 +228,55 @@ def _item_from_element(
     )
 
 
+class RssNewsProvider(NewsProvider):
+    """Base class for any public RSS news feed.
+
+    Subclasses override the class attributes ``name``, ``label``,
+    and ``feed_url``.  ``user_agent`` is optional; it defaults to
+    a generic brisket UA but per-provider UAs are nice for the
+    upstream ops team to attribute traffic.
+
+    The subclass contract is deliberately tiny — everything about
+    fetch + parse + classify + player-match lives in this module.
+    Adding a new RSS source is a ~5-line subclass:
+
+        class FootballguysRssProvider(RssNewsProvider):
+            name = "footballguys"
+            label = "Footballguys"
+            feed_url = "https://www.footballguys.com/.../rss"
+            user_agent = "brisket-news-fbg/1.0"
+    """
+
+    feed_url: str = ""
+    user_agent: str = "brisket-news/1.0"
+
+    def __init__(self, *, feed_url=None, fetcher=None):
+        super().__init__()
+        self._feed_url = feed_url or self.feed_url
+        # Tests inject a fetcher that returns the raw RSS bytes so
+        # the test stays offline.
+        self._fetcher = fetcher or self._default_fetcher
+
+    def _default_fetcher(self, url: str) -> bytes:
+        return default_http_fetcher(
+            url,
+            timeout=self.timeout_s,
+            user_agent=self.user_agent,
+        )
+
+    def fetch(self, *, player_names=None, limit: int = 50) -> List[NewsItem]:
+        return fetch_rss_items(
+            feed_url=self._feed_url,
+            provider_name=self.name,
+            provider_label=self.label,
+            fetcher=self._fetcher,
+            known_names=player_names,
+            limit=limit,
+        )
+
+
 __all__ = [
+    "RssNewsProvider",
     "classify",
     "clean_text",
     "default_http_fetcher",

--- a/src/news/providers/cbs.py
+++ b/src/news/providers/cbs.py
@@ -1,64 +1,16 @@
-"""CBS Sports Fantasy news provider.
-
-CBS Sports publishes a public NFL-fantasy headlines RSS feed.
-It's unauthenticated and follows standard RSS 2.0 shape, so
-parsing + classification + player tagging reuse the shared
-``_rss`` helpers.
-
-The CBS feed tends to carry strategy and analysis pieces more
-than injury microbursts, so most items classify as ``info``
-unless the headline explicitly names an injury or transaction.
-That's fine — the service's relevance pass handles surfacing
-on the frontend.
-"""
+"""CBS Sports NFL headlines RSS provider."""
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
-
-from ..base import NewsItem, NewsProvider
-from . import _rss
+from ._rss import RssNewsProvider
 
 DEFAULT_FEED_URL = "https://www.cbssports.com/rss/headlines/nfl/"
 
 
-class CbsFantasyRssProvider(NewsProvider):
-    """Provider backed by CBS Sports' public NFL headlines RSS feed."""
-
+class CbsFantasyRssProvider(RssNewsProvider):
     name = "cbs"
     label = "CBS Sports"
-    timeout_s = 5.0
-
-    def __init__(
-        self,
-        *,
-        feed_url: str = DEFAULT_FEED_URL,
-        fetcher=None,
-    ) -> None:
-        super().__init__(feed_url=feed_url)
-        self._feed_url = feed_url
-        self._fetcher = fetcher or self._default_fetcher
-
-    def _default_fetcher(self, url: str) -> bytes:
-        return _rss.default_http_fetcher(
-            url,
-            timeout=self.timeout_s,
-            user_agent="brisket-news-cbs/1.0",
-        )
-
-    def fetch(
-        self,
-        *,
-        player_names: Optional[Iterable[str]] = None,
-        limit: int = 50,
-    ) -> List[NewsItem]:
-        return _rss.fetch_rss_items(
-            feed_url=self._feed_url,
-            provider_name=self.name,
-            provider_label=self.label,
-            fetcher=self._fetcher,
-            known_names=player_names,
-            limit=limit,
-        )
+    feed_url = DEFAULT_FEED_URL
+    user_agent = "brisket-news-cbs/1.0"
 
 
 __all__ = ["CbsFantasyRssProvider", "DEFAULT_FEED_URL"]

--- a/src/news/providers/cbs.py
+++ b/src/news/providers/cbs.py
@@ -1,14 +1,15 @@
-"""ESPN headline-feed provider.
+"""CBS Sports Fantasy news provider.
 
-ESPN publishes a public NFL news RSS feed at
-``https://www.espn.com/espn/rss/nfl/news``.  No auth, no key.
-Each ``<item>`` becomes a ``NewsItem``; player tagging scans the
-headline + description for names visible in the live contract.
+CBS Sports publishes a public NFL-fantasy headlines RSS feed.
+It's unauthenticated and follows standard RSS 2.0 shape, so
+parsing + classification + player tagging reuse the shared
+``_rss`` helpers.
 
-The RSS parsing, severity classification, and player matching
-logic lives in ``_rss.py`` and is shared with the FantasyPros
-provider — keeping this file a thin adapter that only pins the
-feed URL + provider identity.
+The CBS feed tends to carry strategy and analysis pieces more
+than injury microbursts, so most items classify as ``info``
+unless the headline explicitly names an injury or transaction.
+That's fine — the service's relevance pass handles surfacing
+on the frontend.
 """
 from __future__ import annotations
 
@@ -17,14 +18,14 @@ from typing import Iterable, List, Optional
 from ..base import NewsItem, NewsProvider
 from . import _rss
 
-DEFAULT_FEED_URL = "https://www.espn.com/espn/rss/nfl/news"
+DEFAULT_FEED_URL = "https://www.cbssports.com/rss/headlines/nfl/"
 
 
-class EspnRssProvider(NewsProvider):
-    """Provider backed by ESPN's public NFL news RSS feed."""
+class CbsFantasyRssProvider(NewsProvider):
+    """Provider backed by CBS Sports' public NFL headlines RSS feed."""
 
-    name = "espn"
-    label = "ESPN"
+    name = "cbs"
+    label = "CBS Sports"
     timeout_s = 5.0
 
     def __init__(
@@ -35,15 +36,13 @@ class EspnRssProvider(NewsProvider):
     ) -> None:
         super().__init__(feed_url=feed_url)
         self._feed_url = feed_url
-        # Tests inject a fetcher that returns the RSS body so they
-        # don't need a live HTTP endpoint.
         self._fetcher = fetcher or self._default_fetcher
 
     def _default_fetcher(self, url: str) -> bytes:
         return _rss.default_http_fetcher(
             url,
             timeout=self.timeout_s,
-            user_agent="brisket-news-espn/1.0",
+            user_agent="brisket-news-cbs/1.0",
         )
 
     def fetch(
@@ -62,4 +61,4 @@ class EspnRssProvider(NewsProvider):
         )
 
 
-__all__ = ["DEFAULT_FEED_URL", "EspnRssProvider"]
+__all__ = ["CbsFantasyRssProvider", "DEFAULT_FEED_URL"]

--- a/src/news/providers/dynasty_focused.py
+++ b/src/news/providers/dynasty_focused.py
@@ -1,0 +1,99 @@
+"""Dynasty-focused and high-authority fantasy football RSS providers.
+
+Each entry here is a subclass of ``RssNewsProvider`` and just
+pins a name, label, and feed URL.  The base class owns fetch,
+parse, classification, and player tagging — new providers are
+~6 lines each.
+
+Sources picked from the public-RSS feed list with these criteria:
+
+* **Dynasty-relevant** — this is a dynasty valuation site, so
+  dynasty-specific sources (DLF, Dynasty Nerds) are on-brand.
+* **High authority** — PFF and FFToday have long-running feeds
+  with broad fantasy coverage.
+* **Analytics-heavy** — Player Profiler and Razzball provide a
+  different editorial voice than wire-service RSS, useful for
+  the relevance signal in the ticker.
+
+Feeds that were NOT added (kept out of the default registry):
+
+* **Footballguys** — paywalled content, RSS URL not publicly
+  documented.
+* **RotoWire** — separate provider (licensed API planned);
+  public RSS coverage is thinner than the paid feed.
+* **Walter Football / Draft sites** — scout-focused, not in-
+  season news.
+* **Small community blogs** — low volume, better left for
+  per-request additions rather than default-enabled.
+
+Any of the skipped sources can be added as a 6-line subclass
+once the feed URL is confirmed — that's the whole point of the
+base class.
+"""
+from __future__ import annotations
+
+from ._rss import RssNewsProvider
+
+
+class DynastyLeagueFootballProvider(RssNewsProvider):
+    """Dynasty League Football (DLF) — dynasty-specific rankings & analysis."""
+
+    name = "dlf"
+    label = "Dynasty League Football"
+    feed_url = "https://dynastyleaguefootball.com/feed"
+    user_agent = "brisket-news-dlf/1.0"
+
+
+class DynastyNerdsProvider(RssNewsProvider):
+    """Dynasty Nerds — dynasty rankings, rookie breakdowns, trade advice."""
+
+    name = "dynastynerds"
+    label = "Dynasty Nerds"
+    feed_url = "https://dynastynerds.com/feed"
+    user_agent = "brisket-news-nerds/1.0"
+
+
+class PffProvider(RssNewsProvider):
+    """Pro Football Focus — broad NFL analysis + fantasy grades."""
+
+    name = "pff"
+    label = "PFF"
+    feed_url = "https://www.pff.com/feed"
+    user_agent = "brisket-news-pff/1.0"
+
+
+class FfTodayProvider(RssNewsProvider):
+    """FFToday — fantasy football news + projections."""
+
+    name = "fftoday"
+    label = "FFToday"
+    feed_url = "https://www.fftoday.com/rss/news.xml"
+    user_agent = "brisket-news-fftoday/1.0"
+
+
+class PlayerProfilerProvider(RssNewsProvider):
+    """Player Profiler — advanced-metrics player analysis."""
+
+    name = "playerprofiler"
+    label = "Player Profiler"
+    feed_url = "https://www.playerprofiler.com/feed"
+    user_agent = "brisket-news-pp/1.0"
+
+
+class RazzballProvider(RssNewsProvider):
+    """Razzball — strategy, waiver-wire picks, weekly advice."""
+
+    name = "razzball"
+    label = "Razzball"
+    feed_url = "https://football.razzball.com/feed"
+    user_agent = "brisket-news-razzball/1.0"
+
+
+__all__ = [
+    "DynastyLeagueFootballProvider",
+    "DynastyNerdsProvider",
+    "FfTodayProvider",
+    "PffProvider",
+    "PlayerProfilerProvider",
+    "RazzballProvider",
+]

--- a/src/news/providers/espn.py
+++ b/src/news/providers/espn.py
@@ -1,65 +1,21 @@
-"""ESPN headline-feed provider.
+"""ESPN NFL news RSS provider.
 
-ESPN publishes a public NFL news RSS feed at
-``https://www.espn.com/espn/rss/nfl/news``.  No auth, no key.
-Each ``<item>`` becomes a ``NewsItem``; player tagging scans the
-headline + description for names visible in the live contract.
-
-The RSS parsing, severity classification, and player matching
-logic lives in ``_rss.py`` and is shared with the FantasyPros
-provider — keeping this file a thin adapter that only pins the
-feed URL + provider identity.
+Thin subclass over ``RssNewsProvider`` — ESPN publishes a public
+NFL news RSS feed with no auth.  Fetch, parse, classification,
+and player tagging all live in the base class.
 """
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
-
-from ..base import NewsItem, NewsProvider
-from . import _rss
+from ._rss import RssNewsProvider
 
 DEFAULT_FEED_URL = "https://www.espn.com/espn/rss/nfl/news"
 
 
-class EspnRssProvider(NewsProvider):
-    """Provider backed by ESPN's public NFL news RSS feed."""
-
+class EspnRssProvider(RssNewsProvider):
     name = "espn"
     label = "ESPN"
-    timeout_s = 5.0
-
-    def __init__(
-        self,
-        *,
-        feed_url: str = DEFAULT_FEED_URL,
-        fetcher=None,
-    ) -> None:
-        super().__init__(feed_url=feed_url)
-        self._feed_url = feed_url
-        # Tests inject a fetcher that returns the RSS body so they
-        # don't need a live HTTP endpoint.
-        self._fetcher = fetcher or self._default_fetcher
-
-    def _default_fetcher(self, url: str) -> bytes:
-        return _rss.default_http_fetcher(
-            url,
-            timeout=self.timeout_s,
-            user_agent="brisket-news-espn/1.0",
-        )
-
-    def fetch(
-        self,
-        *,
-        player_names: Optional[Iterable[str]] = None,
-        limit: int = 50,
-    ) -> List[NewsItem]:
-        return _rss.fetch_rss_items(
-            feed_url=self._feed_url,
-            provider_name=self.name,
-            provider_label=self.label,
-            fetcher=self._fetcher,
-            known_names=player_names,
-            limit=limit,
-        )
+    feed_url = DEFAULT_FEED_URL
+    user_agent = "brisket-news-espn/1.0"
 
 
 __all__ = ["DEFAULT_FEED_URL", "EspnRssProvider"]

--- a/src/news/providers/espn.py
+++ b/src/news/providers/espn.py
@@ -1,0 +1,267 @@
+"""ESPN headline-feed provider.
+
+ESPN publishes a public NFL news RSS feed at
+``https://www.espn.com/espn/rss/nfl/news``.  No auth, no key.
+Treats each ``<item>`` as a news item and tags players by scanning
+the headline + description for known roster names (the service
+passes the live player universe in as ``player_names``).
+
+Severity heuristic — RSS headlines carry no structured severity,
+so we infer:
+
+* keywords like "injury", "hurt", "questionable", "doubtful",
+  "out", "IR" → ``alert`` + ``impact = negative``
+* keywords like "traded", "signs", "contract", "extension",
+  "promoted" → ``watch`` + ``impact = positive``
+* everything else → ``info`` + ``impact = neutral``
+
+Heuristics are intentionally conservative — when in doubt we emit
+``info`` rather than over-alerting.  The relevance/scoring pass on
+the frontend is the real filter for what surfaces in the ticker.
+
+The RSS fetch uses stdlib only (``urllib.request`` +
+``xml.etree.ElementTree``) — no new dependencies.  A 5s network
+timeout keeps the service responsive when ESPN is slow.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Iterable, List, Optional
+
+from ..base import NewsItem, NewsProvider, PlayerMention, stable_id, to_iso_utc
+
+log = logging.getLogger(__name__)
+
+DEFAULT_FEED_URL = "https://www.espn.com/espn/rss/nfl/news"
+
+# Keyword → (severity, kind, impact) heuristics.  Order matters —
+# the first match wins, so list the most specific signals first
+# (injury beats transaction if a headline mentions both).
+# Keywords matched with word boundaries so short fragments like
+# "ir", "cut", "acl" don't trip on substrings of unrelated words
+# ("their", "document", "practice").  The compiled regex caches
+# lazily on first use.
+_ALERT_KEYWORDS = (
+    "injury",
+    "injured",
+    "hurt",
+    "out for season",
+    "out for the season",
+    "season-ending",
+    "torn",
+    "acl",
+    "achilles",
+    "concussion",
+    "placed on ir",
+    "on the ir",
+    "to ir",
+    "questionable",
+    "doubtful",
+    "ruled out",
+    "suspended",
+    "arrest",
+)
+_WATCH_KEYWORDS = (
+    "trade",
+    "traded",
+    "signs",
+    "signed",
+    "contract",
+    "extension",
+    "restructure",
+    "promoted",
+    "starter",
+    "named starter",
+    "released",
+    "waived",
+    "claim",
+    "claimed",
+    "activated",
+)
+
+_ALERT_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(k) for k in _ALERT_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+_WATCH_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(k) for k in _WATCH_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+_TRANSACTION_RE = re.compile(
+    r"\b(?:trade|traded|signs?|signed|contract|released|waived)\b",
+    re.IGNORECASE,
+)
+
+_STRIP_HTML = re.compile(r"<[^>]+>")
+
+
+def _clean(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    # RSS descriptions often contain wrapped HTML.  Strip tags and
+    # normalize whitespace — we only surface the snippet as plain
+    # text in the ticker.
+    return _STRIP_HTML.sub("", text).strip()
+
+
+def _classify(text: str) -> tuple[str, str, str]:
+    """Return (severity, kind, impact) for a headline."""
+    if _ALERT_RE.search(text):
+        return "alert", "injury", "negative"
+    if _WATCH_RE.search(text):
+        kind = "transaction" if _TRANSACTION_RE.search(text) else "performance"
+        return "watch", kind, "positive"
+    return "info", "news", "neutral"
+
+
+def _parse_pub_date(raw: Optional[str]) -> datetime:
+    if not raw:
+        return datetime.now(timezone.utc)
+    try:
+        dt = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return datetime.now(timezone.utc)
+    if dt is None:
+        return datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _match_players(
+    text: str,
+    *,
+    known_names: list[str],
+    impact: str,
+) -> List[PlayerMention]:
+    """Return PlayerMentions for every known name that appears in ``text``.
+
+    Match uses case-insensitive substring containment.  We avoid
+    full-word regex because the player-name set is already
+    curated (only real player names from the live contract) so
+    false positives are rare and cheap.
+    """
+    if not known_names or not text:
+        return []
+    haystack = text.lower()
+    seen: set[str] = set()
+    out: List[PlayerMention] = []
+    for name in known_names:
+        if not name:
+            continue
+        key = name.lower()
+        if key in seen:
+            continue
+        if key in haystack:
+            out.append(PlayerMention(name=name, impact=impact))
+            seen.add(key)
+    return out
+
+
+class EspnRssProvider(NewsProvider):
+    """Provider backed by ESPN's public NFL news RSS feed."""
+
+    name = "espn"
+    label = "ESPN"
+    timeout_s = 5.0
+
+    def __init__(
+        self,
+        *,
+        feed_url: str = DEFAULT_FEED_URL,
+        fetcher=None,
+    ) -> None:
+        super().__init__(feed_url=feed_url)
+        self._feed_url = feed_url
+        # Tests inject a ``fetcher`` that returns the RSS body as
+        # bytes/str so they don't need to stand up an HTTP server.
+        self._fetcher = fetcher or self._default_fetcher
+
+    def _default_fetcher(self, url: str) -> bytes:
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "brisket-news-espn/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+            return resp.read()
+
+    def fetch(
+        self,
+        *,
+        player_names: Optional[Iterable[str]] = None,
+        limit: int = 50,
+    ) -> List[NewsItem]:
+        try:
+            raw = self._fetcher(self._feed_url)
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            log.warning("espn rss fetch failed: %s", exc)
+            return []
+        except Exception as exc:  # pragma: no cover — last-resort
+            log.warning("espn rss fetch errored: %s", exc)
+            return []
+
+        try:
+            root = ET.fromstring(raw)
+        except ET.ParseError as exc:
+            log.warning("espn rss parse failed: %s", exc)
+            return []
+
+        channel = root.find("channel")
+        if channel is None:
+            # Some RSS variants put items at root.  Fall back.
+            items_el = root.findall("item")
+        else:
+            items_el = channel.findall("item")
+
+        known = [str(n) for n in (player_names or []) if n]
+        out: List[NewsItem] = []
+        for el in items_el[: max(1, int(limit))]:
+            item = self._item_from_element(el, known_names=known)
+            if item is not None:
+                out.append(item)
+        return out
+
+    def _item_from_element(
+        self,
+        el: ET.Element,
+        *,
+        known_names: list[str],
+    ) -> Optional[NewsItem]:
+        title = _clean((el.findtext("title") or "").strip())
+        if not title:
+            return None
+        link = (el.findtext("link") or "").strip() or None
+        description = _clean(el.findtext("description") or "")
+        guid = (el.findtext("guid") or link or title).strip()
+        pub_raw = el.findtext("pubDate")
+        published = _parse_pub_date(pub_raw)
+
+        severity, kind, impact = _classify(f"{title}\n{description}")
+        mentions = _match_players(
+            f"{title}\n{description}",
+            known_names=known_names,
+            impact=impact,
+        )
+
+        return NewsItem(
+            id=stable_id(self.name, guid),
+            ts=to_iso_utc(published),
+            provider=self.name,
+            provider_label=self.label,
+            severity=severity,
+            kind=kind,
+            headline=title,
+            body=description,
+            players=mentions,
+            url=link,
+            tags=[kind],
+        )
+
+
+__all__ = ["DEFAULT_FEED_URL", "EspnRssProvider"]

--- a/src/news/providers/fantasypros.py
+++ b/src/news/providers/fantasypros.py
@@ -1,76 +1,22 @@
-"""FantasyPros player-news provider.
+"""FantasyPros player-news RSS provider.
 
-FantasyPros publishes a public player-news RSS feed at
-``https://www.fantasypros.com/nfl/rss/player-news.php``.  The
-feed is unauthenticated and has the same RSS 2.0 structure as
-ESPN — ``<channel><item><title|link|guid|pubDate|description>``
-— so we reuse the shared RSS helper for parsing, severity
-classification, and player tagging.
-
-Why this is a separate provider and not a config knob on the
-ESPN class: FantasyPros and ESPN have meaningfully different
-editorial voice and latency (FantasyPros tends to surface
-fantasy-relevant injury + beat-writer notes faster and with
-tighter fantasy framing; ESPN skews broader league news).
-Keeping them as separate provider rows means per-source
-diagnostics (count, elapsed_ms, error) surface independently in
-``providerRuns`` — ops can see FantasyPros degrade without ESPN
-being affected.
-
-Licensing note: FantasyPros' public RSS feed is intended for
-aggregator consumption.  Their paid API has a separate licence
-and is out of scope for this provider; if we ever want the
-structured API, build a second adapter rather than flipping
-this one over.
+FantasyPros' public player-news RSS is unauthenticated and
+fantasy-flavored — items tend to surface fantasy-relevant
+analysis and beat-writer notes.  Separate from the paid
+FantasyPros API (different adapter if we ever license it).
 """
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
-
-from ..base import NewsItem, NewsProvider
-from . import _rss
+from ._rss import RssNewsProvider
 
 DEFAULT_FEED_URL = "https://www.fantasypros.com/nfl/rss/player-news.php"
 
 
-class FantasyProsRssProvider(NewsProvider):
-    """Provider backed by FantasyPros' public player-news RSS feed."""
-
+class FantasyProsRssProvider(RssNewsProvider):
     name = "fantasypros"
     label = "FantasyPros"
-    timeout_s = 5.0
-
-    def __init__(
-        self,
-        *,
-        feed_url: str = DEFAULT_FEED_URL,
-        fetcher=None,
-    ) -> None:
-        super().__init__(feed_url=feed_url)
-        self._feed_url = feed_url
-        self._fetcher = fetcher or self._default_fetcher
-
-    def _default_fetcher(self, url: str) -> bytes:
-        return _rss.default_http_fetcher(
-            url,
-            timeout=self.timeout_s,
-            user_agent="brisket-news-fantasypros/1.0",
-        )
-
-    def fetch(
-        self,
-        *,
-        player_names: Optional[Iterable[str]] = None,
-        limit: int = 50,
-    ) -> List[NewsItem]:
-        return _rss.fetch_rss_items(
-            feed_url=self._feed_url,
-            provider_name=self.name,
-            provider_label=self.label,
-            fetcher=self._fetcher,
-            known_names=player_names,
-            limit=limit,
-        )
+    feed_url = DEFAULT_FEED_URL
+    user_agent = "brisket-news-fantasypros/1.0"
 
 
 __all__ = ["DEFAULT_FEED_URL", "FantasyProsRssProvider"]

--- a/src/news/providers/fantasypros.py
+++ b/src/news/providers/fantasypros.py
@@ -1,0 +1,76 @@
+"""FantasyPros player-news provider.
+
+FantasyPros publishes a public player-news RSS feed at
+``https://www.fantasypros.com/nfl/rss/player-news.php``.  The
+feed is unauthenticated and has the same RSS 2.0 structure as
+ESPN — ``<channel><item><title|link|guid|pubDate|description>``
+— so we reuse the shared RSS helper for parsing, severity
+classification, and player tagging.
+
+Why this is a separate provider and not a config knob on the
+ESPN class: FantasyPros and ESPN have meaningfully different
+editorial voice and latency (FantasyPros tends to surface
+fantasy-relevant injury + beat-writer notes faster and with
+tighter fantasy framing; ESPN skews broader league news).
+Keeping them as separate provider rows means per-source
+diagnostics (count, elapsed_ms, error) surface independently in
+``providerRuns`` — ops can see FantasyPros degrade without ESPN
+being affected.
+
+Licensing note: FantasyPros' public RSS feed is intended for
+aggregator consumption.  Their paid API has a separate licence
+and is out of scope for this provider; if we ever want the
+structured API, build a second adapter rather than flipping
+this one over.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from ..base import NewsItem, NewsProvider
+from . import _rss
+
+DEFAULT_FEED_URL = "https://www.fantasypros.com/nfl/rss/player-news.php"
+
+
+class FantasyProsRssProvider(NewsProvider):
+    """Provider backed by FantasyPros' public player-news RSS feed."""
+
+    name = "fantasypros"
+    label = "FantasyPros"
+    timeout_s = 5.0
+
+    def __init__(
+        self,
+        *,
+        feed_url: str = DEFAULT_FEED_URL,
+        fetcher=None,
+    ) -> None:
+        super().__init__(feed_url=feed_url)
+        self._feed_url = feed_url
+        self._fetcher = fetcher or self._default_fetcher
+
+    def _default_fetcher(self, url: str) -> bytes:
+        return _rss.default_http_fetcher(
+            url,
+            timeout=self.timeout_s,
+            user_agent="brisket-news-fantasypros/1.0",
+        )
+
+    def fetch(
+        self,
+        *,
+        player_names: Optional[Iterable[str]] = None,
+        limit: int = 50,
+    ) -> List[NewsItem]:
+        return _rss.fetch_rss_items(
+            feed_url=self._feed_url,
+            provider_name=self.name,
+            provider_label=self.label,
+            fetcher=self._fetcher,
+            known_names=player_names,
+            limit=limit,
+        )
+
+
+__all__ = ["DEFAULT_FEED_URL", "FantasyProsRssProvider"]

--- a/src/news/providers/rotowire.py
+++ b/src/news/providers/rotowire.py
@@ -1,0 +1,46 @@
+"""Rotowire provider — placeholder until licensing lands.
+
+Rotowire's player-news API requires a commercial licence that we
+haven't finalized yet.  This stub exists so the registry can list
+``rotowire`` as a recognized provider name (so ops can toggle it
+in config without a code change once licensed) while the adapter
+itself returns an empty list.
+
+When the licence is in place, swap ``fetch`` for a real
+implementation that hits the licensed endpoint and maps the
+response to ``NewsItem`` — the rest of the stack (service,
+aggregator, route, frontend) will light up automatically.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Optional
+
+from ..base import NewsItem, NewsProvider
+
+log = logging.getLogger(__name__)
+
+
+class RotowireProvider(NewsProvider):
+    name = "rotowire"
+    label = "Rotowire"
+    timeout_s = 5.0
+
+    def __init__(self, *, api_key: Optional[str] = None) -> None:
+        super().__init__(api_key=api_key)
+        self._api_key = api_key
+
+    def fetch(
+        self,
+        *,
+        player_names: Optional[Iterable[str]] = None,
+        limit: int = 50,
+    ) -> List[NewsItem]:
+        # Intentional no-op.  Logged at debug so enabling the
+        # provider without a licence doesn't spam warnings.
+        if not self._api_key:
+            log.debug("rotowire provider skipped — no api_key configured")
+        return []
+
+
+__all__ = ["RotowireProvider"]

--- a/src/news/providers/sleeper.py
+++ b/src/news/providers/sleeper.py
@@ -1,0 +1,296 @@
+"""Sleeper trending-players provider.
+
+Sleeper exposes an unauthenticated, rate-limit-safe endpoint that
+lists the most-added / most-dropped players across the platform
+over a lookback window:
+
+    GET https://api.sleeper.app/v1/players/nfl/trending/add?limit=25&lookback_hours=24
+    GET https://api.sleeper.app/v1/players/nfl/trending/drop?limit=25&lookback_hours=24
+
+Responses are tiny — a list of ``{"player_id": str, "count": int}``
+rows — so we can poll this every few minutes without burning the
+Sleeper rate budget.  The player-id → full name mapping comes from
+``GET /v1/players/nfl`` which is ~5 MB; Sleeper explicitly asks
+callers to fetch it "once per day max" in their docs, so we cache
+it with a 24h TTL.
+
+Trending data maps to our news vocabulary as:
+
+* ``kind = "trending"``
+* ``severity = "watch"`` for adds, ``"info"`` for drops
+* ``impact = "positive"`` for adds, ``"negative"`` for drops
+* ``tags = ["trending", "add"|"drop"]``
+* ``confidence`` = log-scaled share of top-trending count
+
+No headline lives upstream, so we synthesize one:
+    "Jayden Reed added in 18,432 leagues (last 24h)"
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Optional
+
+import requests
+
+from ..base import NewsItem, NewsProvider, PlayerMention, stable_id, to_iso_utc
+
+log = logging.getLogger(__name__)
+
+SLEEPER_API_ROOT = "https://api.sleeper.app/v1"
+
+# Sleeper's docs: "do not call this endpoint more than once per day".
+# We cache the full player map for 24h.  24h × 3600 s = 86400.
+_PLAYER_MAP_TTL_S = 86_400
+_TRENDING_PATH_ADD = "/players/nfl/trending/add"
+_TRENDING_PATH_DROP = "/players/nfl/trending/drop"
+_PLAYERS_PATH = "/players/nfl"
+
+
+class _PlayerMapCache:
+    """Thread-safe, TTL'd cache for the Sleeper player-id → name map."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._expires_at: float = 0.0
+        self._map: dict[str, dict[str, Any]] = {}
+
+    def get(
+        self,
+        *,
+        fetcher,
+        ttl_s: float = _PLAYER_MAP_TTL_S,
+    ) -> dict[str, dict[str, Any]]:
+        now = time.time()
+        with self._lock:
+            if self._map and now < self._expires_at:
+                return self._map
+        # Fetch outside the lock so concurrent callers don't pile
+        # up on a single slow request.  Worst case we issue two
+        # fetches on a cold start — benign, the second one just
+        # overwrites the first.
+        try:
+            fresh = fetcher()
+        except Exception as exc:
+            log.warning("sleeper player-map fetch failed: %s", exc)
+            # Return whatever we have (possibly stale, possibly
+            # empty) rather than erroring out — trending data is
+            # still useful with opaque player_ids.
+            return self._map
+        if isinstance(fresh, dict) and fresh:
+            with self._lock:
+                self._map = fresh
+                self._expires_at = now + ttl_s
+        return self._map
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._map = {}
+            self._expires_at = 0.0
+
+
+# Module-level singleton — the player map is identical across every
+# SleeperTrendingProvider instance, and it's big (5 MB) so we do not
+# want one copy per instance.
+_PLAYER_MAP = _PlayerMapCache()
+
+
+def _reset_player_map_for_tests() -> None:
+    """Test hook — purge the module-level player-map cache."""
+    _PLAYER_MAP.invalidate()
+
+
+def _display_name(entry: dict[str, Any]) -> Optional[str]:
+    full = entry.get("full_name")
+    if isinstance(full, str) and full.strip():
+        return full.strip()
+    first = (entry.get("first_name") or "").strip()
+    last = (entry.get("last_name") or "").strip()
+    combined = f"{first} {last}".strip()
+    return combined or None
+
+
+class SleeperTrendingProvider(NewsProvider):
+    """Provider backed by Sleeper's trending-adds / trending-drops feeds."""
+
+    name = "sleeper"
+    label = "Sleeper"
+    timeout_s = 5.0
+
+    def __init__(
+        self,
+        *,
+        lookback_hours: int = 24,
+        limit_per_feed: int = 20,
+        session: Optional[requests.Session] = None,
+        api_root: str = SLEEPER_API_ROOT,
+    ) -> None:
+        super().__init__(
+            lookback_hours=lookback_hours,
+            limit_per_feed=limit_per_feed,
+            api_root=api_root,
+        )
+        self._session = session or requests.Session()
+        self._api_root = api_root.rstrip("/")
+        self._lookback = max(1, int(lookback_hours))
+        self._limit = max(1, int(limit_per_feed))
+
+    # ── HTTP helpers ────────────────────────────────────────────
+    def _get_json(self, path: str) -> Any:
+        url = f"{self._api_root}{path}"
+        resp = self._session.get(
+            url,
+            timeout=self.timeout_s,
+            headers={"User-Agent": "brisket-news-sleeper/1.0"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch_player_map(self) -> dict[str, dict[str, Any]]:
+        return _PLAYER_MAP.get(fetcher=lambda: self._get_json(_PLAYERS_PATH))
+
+    def _fetch_trending(self, path: str) -> List[dict[str, Any]]:
+        params = f"?lookback_hours={self._lookback}&limit={self._limit}"
+        try:
+            data = self._get_json(f"{path}{params}")
+        except Exception as exc:
+            log.warning("sleeper trending fetch (%s) failed: %s", path, exc)
+            return []
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    # ── normalization ───────────────────────────────────────────
+    def _row_to_item(
+        self,
+        row: dict[str, Any],
+        *,
+        direction: str,
+        player_map: dict[str, dict[str, Any]],
+        top_count: int,
+        now: datetime,
+    ) -> Optional[NewsItem]:
+        player_id = str(row.get("player_id") or "").strip()
+        if not player_id:
+            return None
+        count = int(row.get("count") or 0)
+        if count <= 0:
+            return None
+
+        entry = player_map.get(player_id) or {}
+        name = _display_name(entry)
+        if not name:
+            return None
+
+        position = (entry.get("position") or "").strip() or None
+        team = (entry.get("team") or "").strip() or None
+
+        impact = "positive" if direction == "add" else "negative"
+        severity = "watch" if direction == "add" else "info"
+        verb = "added in" if direction == "add" else "dropped in"
+        headline = f"{name} {verb} {count:,} leagues (last {self._lookback}h)"
+        tail_bits: list[str] = []
+        if position:
+            tail_bits.append(position)
+        if team:
+            tail_bits.append(team)
+        suffix = f" ({'/'.join(tail_bits)})" if tail_bits else ""
+        body = (
+            f"Sleeper trending {direction}s — roster churn signal{suffix}. "
+            f"Top {direction} leader this window: {top_count:,} adds."
+            if direction == "add"
+            else (
+                f"Sleeper trending {direction}s — players owners are moving off{suffix}. "
+                f"Top {direction} leader this window: {top_count:,} drops."
+            )
+        )
+
+        # Confidence = share of the top trending count this window.
+        # Log-scaled so the #1 item is ~1.0 and the tail still gets
+        # a non-trivial score (avoids a cliff between rank 1 and 2).
+        if top_count > 0:
+            share = max(0.0, min(1.0, count / top_count))
+            confidence = round(math.log1p(share * (math.e - 1)), 3)
+        else:
+            confidence = None
+
+        # Bucket the timestamp to an hour so refetches within the
+        # same window return stable ids — the frontend's cache +
+        # dedupe logic keys off ``id``.
+        bucket = now.replace(minute=0, second=0, microsecond=0)
+        ident = stable_id(self.name, f"{direction}:{player_id}:{bucket.isoformat()}")
+
+        return NewsItem(
+            id=ident,
+            ts=to_iso_utc(now),
+            provider=self.name,
+            provider_label=self.label,
+            severity=severity,
+            kind="trending",
+            headline=headline,
+            body=body,
+            players=[PlayerMention(name=name, impact=impact)],
+            url=f"https://sleeper.com/players/{player_id}",
+            tags=["trending", direction],
+            confidence=confidence,
+        )
+
+    # ── public entry point ──────────────────────────────────────
+    def fetch(
+        self,
+        *,
+        player_names: Optional[Iterable[str]] = None,
+        limit: int = 50,
+    ) -> List[NewsItem]:
+        adds = self._fetch_trending(_TRENDING_PATH_ADD)
+        drops = self._fetch_trending(_TRENDING_PATH_DROP)
+        if not adds and not drops:
+            return []
+
+        try:
+            player_map = self._fetch_player_map()
+        except Exception as exc:
+            log.warning("sleeper player map fetch failed: %s", exc)
+            player_map = {}
+
+        now = datetime.now(timezone.utc)
+        top_add = adds[0]["count"] if adds and adds[0].get("count") else 0
+        top_drop = drops[0]["count"] if drops and drops[0].get("count") else 0
+
+        out: List[NewsItem] = []
+        for row in adds:
+            item = self._row_to_item(
+                row,
+                direction="add",
+                player_map=player_map,
+                top_count=int(top_add or 0),
+                now=now,
+            )
+            if item is not None:
+                out.append(item)
+        for row in drops:
+            item = self._row_to_item(
+                row,
+                direction="drop",
+                player_map=player_map,
+                top_count=int(top_drop or 0),
+                now=now,
+            )
+            if item is not None:
+                out.append(item)
+
+        # Sort by count-derived confidence (highest first), then
+        # truncate to ``limit`` so a caller asking for 50 doesn't
+        # get 40 adds + 40 drops back.
+        out.sort(
+            key=lambda it: (it.confidence or 0.0, it.severity == "watch"),
+            reverse=True,
+        )
+        return out[: max(1, int(limit))]
+
+
+__all__ = ["SleeperTrendingProvider"]

--- a/src/news/providers/sleeper.py
+++ b/src/news/providers/sleeper.py
@@ -153,16 +153,26 @@ class SleeperTrendingProvider(NewsProvider):
     def _fetch_player_map(self) -> dict[str, dict[str, Any]]:
         return _PLAYER_MAP.get(fetcher=lambda: self._get_json(_PLAYERS_PATH))
 
-    def _fetch_trending(self, path: str) -> List[dict[str, Any]]:
+    def _fetch_trending_safe(
+        self, path: str
+    ) -> tuple[bool, List[dict[str, Any]]]:
+        """Fetch one trending endpoint, tolerating a single-endpoint outage.
+
+        Returns ``(ok, rows)``.  ``ok=False`` means the upstream
+        call failed — the caller uses that to decide whether
+        total-failure propagation is warranted (both endpoints
+        down) versus a partial-signal return (only one endpoint
+        down, still useful).
+        """
         params = f"?lookback_hours={self._lookback}&limit={self._limit}"
         try:
             data = self._get_json(f"{path}{params}")
         except Exception as exc:
             log.warning("sleeper trending fetch (%s) failed: %s", path, exc)
-            return []
+            return False, []
         if not isinstance(data, list):
-            return []
-        return [row for row in data if isinstance(row, dict)]
+            return True, []
+        return True, [row for row in data if isinstance(row, dict)]
 
     # ── normalization ───────────────────────────────────────────
     def _row_to_item(
@@ -246,8 +256,14 @@ class SleeperTrendingProvider(NewsProvider):
         player_names: Optional[Iterable[str]] = None,
         limit: int = 50,
     ) -> List[NewsItem]:
-        adds = self._fetch_trending(_TRENDING_PATH_ADD)
-        drops = self._fetch_trending(_TRENDING_PATH_DROP)
+        adds_ok, adds = self._fetch_trending_safe(_TRENDING_PATH_ADD)
+        drops_ok, drops = self._fetch_trending_safe(_TRENDING_PATH_DROP)
+        # Both endpoints down → propagate so the service marks this
+        # provider ``ok=False`` and the all-providers-failed check
+        # can trigger 503 / DEMO fallback.  Partial failure (one
+        # endpoint OK) stays silent — we still have usable signal.
+        if not adds_ok and not drops_ok:
+            raise RuntimeError("sleeper trending endpoints unavailable")
         if not adds and not drops:
             return []
 

--- a/src/news/providers/sleeper.py
+++ b/src/news/providers/sleeper.py
@@ -65,10 +65,25 @@ class _PlayerMapCache:
         fetcher,
         ttl_s: float = _PLAYER_MAP_TTL_S,
     ) -> dict[str, dict[str, Any]]:
+        """Return the cached map, fetching if stale.
+
+        Contract change (Codex P1): raises when the cache is
+        COLD (empty + no prior successful fetch) and the
+        fetcher fails.  Previously we'd log + return ``{}``, but
+        that let Sleeper emit a silently-empty feed during a real
+        outage — the service would see ``ok=True, count=0`` and
+        the all-providers-failed 503 path could never fire.
+
+        A warm-cache fetcher failure still degrades gracefully:
+        we return the stale map, since names from yesterday are
+        better than no names at all and trending data is still
+        mostly useful.
+        """
         now = time.time()
         with self._lock:
             if self._map and now < self._expires_at:
                 return self._map
+            had_cache = bool(self._map)
         # Fetch outside the lock so concurrent callers don't pile
         # up on a single slow request.  Worst case we issue two
         # fetches on a cold start — benign, the second one just
@@ -77,9 +92,8 @@ class _PlayerMapCache:
             fresh = fetcher()
         except Exception as exc:
             log.warning("sleeper player-map fetch failed: %s", exc)
-            # Return whatever we have (possibly stale, possibly
-            # empty) rather than erroring out — trending data is
-            # still useful with opaque player_ids.
+            if not had_cache:
+                raise
             return self._map
         if isinstance(fresh, dict) and fresh:
             with self._lock:
@@ -267,11 +281,10 @@ class SleeperTrendingProvider(NewsProvider):
         if not adds and not drops:
             return []
 
-        try:
-            player_map = self._fetch_player_map()
-        except Exception as exc:
-            log.warning("sleeper player map fetch failed: %s", exc)
-            player_map = {}
+        # Player-map failure bubbles up ONLY when the cache is
+        # cold.  _PlayerMapCache raises in that case (Codex P1);
+        # warm-cache failures return the stale map silently.
+        player_map = self._fetch_player_map()
 
         now = datetime.now(timezone.utc)
         top_add = adds[0]["count"] if adds and adds[0].get("count") else 0

--- a/src/news/service.py
+++ b/src/news/service.py
@@ -255,7 +255,9 @@ class NewsService:
 
 
 # ── factory helpers ─────────────────────────────────────────────
-_DEFAULT_ENABLED = ("sleeper", "espn")
+# Enabled-by-default providers.  All public, no licence required.
+# Rotowire stays registered but OFF until its paid API is wired.
+_DEFAULT_ENABLED = ("sleeper", "espn", "fantasypros", "cbs")
 
 
 def build_default_service(

--- a/src/news/service.py
+++ b/src/news/service.py
@@ -1,0 +1,301 @@
+"""News aggregation service.
+
+The service layer is the single entry point for the ``/api/news``
+route.  Responsibilities:
+
+1. Own the enabled-providers list (loaded once from config at
+   build time, or passed in explicitly for testing).
+2. Dispatch each provider with per-provider isolation — one
+   provider raising or timing out does NOT poison the response.
+3. Dedupe items by ``id`` across providers (stable ids make this
+   cheap).
+4. Cache the aggregated response for a short TTL so repeated
+   ``/api/news`` hits from the landing-page cache-warm cycle
+   don't hammer upstream feeds.
+5. Optionally filter by a team-roster name list (query param on
+   the route) so the response only contains items that mention
+   at least one of those names.
+
+No network I/O happens in this module directly — everything runs
+through the injected providers.  That keeps the cache + dedupe
+logic testable without stubbing HTTP.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Optional, Sequence
+
+from .base import NewsItem, NewsProvider
+from .providers import available_provider_names, build_provider
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CACHE_TTL_S = 180  # 3 minutes — rate-limit-safe for all providers
+DEFAULT_LIMIT_PER_PROVIDER = 25
+DEFAULT_TOTAL_LIMIT = 60
+
+
+@dataclass
+class ProviderRunResult:
+    """Per-provider diagnostics attached to the aggregated response."""
+
+    name: str
+    label: str
+    count: int = 0
+    ok: bool = True
+    error: Optional[str] = None
+    elapsed_ms: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {
+            "name": self.name,
+            "label": self.label,
+            "count": self.count,
+            "ok": self.ok,
+            "elapsedMs": self.elapsed_ms,
+        }
+        if self.error:
+            out["error"] = self.error
+        return out
+
+
+@dataclass
+class AggregatedNews:
+    """Service-layer response object — the route serializes this."""
+
+    items: List[NewsItem]
+    providers_used: List[str]
+    provider_runs: List[ProviderRunResult] = field(default_factory=list)
+    generated_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    cache_hit: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "items": [it.to_dict() for it in self.items],
+            "providersUsed": list(self.providers_used),
+            "providerRuns": [r.to_dict() for r in self.provider_runs],
+            "generatedAt": self.generated_at,
+            "cacheHit": self.cache_hit,
+            "count": len(self.items),
+        }
+
+
+def _dedupe(items: Sequence[NewsItem]) -> List[NewsItem]:
+    seen: set[str] = set()
+    out: List[NewsItem] = []
+    for it in items:
+        if it.id in seen:
+            continue
+        seen.add(it.id)
+        out.append(it)
+    return out
+
+
+def _sort_items(items: List[NewsItem]) -> List[NewsItem]:
+    """Sort by (severity rank desc, timestamp desc).
+
+    Alerts float to the top regardless of age, then watch, then
+    info — matches how the frontend ticker prioritizes.
+    """
+    severity_rank = {"alert": 3, "watch": 2, "info": 1}
+
+    def key(it: NewsItem) -> tuple[int, float]:
+        r = severity_rank.get(it.severity, 0)
+        try:
+            ts = datetime.fromisoformat(it.ts.replace("Z", "+00:00")).timestamp()
+        except (TypeError, ValueError):
+            ts = 0.0
+        return (r, ts)
+
+    return sorted(items, key=key, reverse=True)
+
+
+def _filter_by_team_names(
+    items: Sequence[NewsItem],
+    team_names: Iterable[str],
+) -> List[NewsItem]:
+    wanted = {n.strip().lower() for n in team_names if n and n.strip()}
+    if not wanted:
+        return list(items)
+    out: List[NewsItem] = []
+    for it in items:
+        names = {p.name.strip().lower() for p in it.players if p.name}
+        if names & wanted:
+            out.append(it)
+    return out
+
+
+class NewsService:
+    """Aggregator with TTL cache and per-provider fault isolation."""
+
+    def __init__(
+        self,
+        providers: Sequence[NewsProvider],
+        *,
+        cache_ttl_s: float = DEFAULT_CACHE_TTL_S,
+        limit_per_provider: int = DEFAULT_LIMIT_PER_PROVIDER,
+        total_limit: int = DEFAULT_TOTAL_LIMIT,
+        clock=time.time,
+    ) -> None:
+        self._providers = list(providers)
+        self._ttl = max(0.0, float(cache_ttl_s))
+        self._limit_per_provider = max(1, int(limit_per_provider))
+        self._total_limit = max(1, int(total_limit))
+        self._clock = clock
+        self._lock = threading.Lock()
+        # Single-entry cache keyed by the (frozenset of) player
+        # names the caller passed in — the aggregated payload is
+        # different per roster when a team filter is in play.
+        self._cache: dict[tuple, tuple[float, AggregatedNews]] = {}
+
+    @property
+    def provider_names(self) -> List[str]:
+        return [p.name for p in self._providers]
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+    # ── main entry point ────────────────────────────────────────
+    def aggregate(
+        self,
+        *,
+        player_names: Optional[Iterable[str]] = None,
+        team_names: Optional[Iterable[str]] = None,
+    ) -> AggregatedNews:
+        known_names = sorted({n for n in (player_names or []) if n})
+        team_filter = tuple(sorted({n for n in (team_names or []) if n}))
+        cache_key = (tuple(known_names), team_filter)
+
+        now = self._clock()
+        with self._lock:
+            cached = self._cache.get(cache_key)
+            if cached and (now - cached[0]) < self._ttl:
+                # Return a shallow copy with the cache flag flipped
+                # so the caller can tell live vs cached apart.
+                payload = cached[1]
+                return AggregatedNews(
+                    items=payload.items,
+                    providers_used=payload.providers_used,
+                    provider_runs=payload.provider_runs,
+                    generated_at=payload.generated_at,
+                    cache_hit=True,
+                )
+
+        items, runs = self._fetch_all(known_names)
+        items = _dedupe(items)
+        items = _sort_items(items)
+        if team_filter:
+            items = _filter_by_team_names(items, team_filter)
+        items = items[: self._total_limit]
+
+        providers_used = [r.name for r in runs if r.ok and r.count > 0]
+        result = AggregatedNews(
+            items=items,
+            providers_used=providers_used,
+            provider_runs=runs,
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            cache_hit=False,
+        )
+
+        with self._lock:
+            self._cache[cache_key] = (now, result)
+
+        return result
+
+    # ── provider dispatch ───────────────────────────────────────
+    def _fetch_all(
+        self, known_names: list[str]
+    ) -> tuple[List[NewsItem], List[ProviderRunResult]]:
+        """Run every enabled provider and collect their items.
+
+        Each provider is fully isolated — any exception is logged
+        and converted into a ``ProviderRunResult(ok=False)`` so
+        the aggregate response can still succeed on the survivors.
+
+        Run order follows registration order (priority).  We do
+        this sequentially rather than in a thread pool because
+        the worst-case total latency is small (2 providers × 5s
+        timeout = 10s cap, but realistic steady state is
+        sub-second) and keeping it sequential avoids another
+        dependency on a shared thread pool.
+        """
+        all_items: List[NewsItem] = []
+        runs: List[ProviderRunResult] = []
+        for provider in self._providers:
+            run = ProviderRunResult(name=provider.name, label=provider.label)
+            started = time.monotonic()
+            try:
+                items = provider.fetch(
+                    player_names=known_names,
+                    limit=self._limit_per_provider,
+                )
+                if not isinstance(items, list):
+                    items = list(items or [])
+                run.count = len(items)
+                all_items.extend(items)
+            except Exception as exc:  # defensive — providers
+                # shouldn't raise, but if they do we isolate the
+                # failure here rather than 500-ing the route.
+                log.warning(
+                    "news provider %s raised: %s", provider.name, exc
+                )
+                run.ok = False
+                run.error = f"{type(exc).__name__}: {exc}"
+            finally:
+                run.elapsed_ms = int((time.monotonic() - started) * 1000)
+            runs.append(run)
+        return all_items, runs
+
+
+# ── factory helpers ─────────────────────────────────────────────
+_DEFAULT_ENABLED = ("sleeper", "espn")
+
+
+def build_default_service(
+    *,
+    enabled: Optional[Sequence[str]] = None,
+    cache_ttl_s: float = DEFAULT_CACHE_TTL_S,
+    provider_config: Optional[dict[str, dict[str, Any]]] = None,
+) -> NewsService:
+    """Construct a ``NewsService`` with the production provider set.
+
+    ``enabled`` defaults to Sleeper + ESPN.  Rotowire stays
+    registered (``available_provider_names`` includes it) but is
+    OFF until explicitly enabled and licensed.
+
+    ``provider_config`` lets callers pass per-provider kwargs,
+    e.g. ``{"sleeper": {"lookback_hours": 48}}``.
+    """
+    if enabled is None:
+        enabled = _DEFAULT_ENABLED
+    cfg = provider_config or {}
+    known = set(available_provider_names())
+    instances: List[NewsProvider] = []
+    for name in enabled:
+        key = name.lower()
+        if key not in known:
+            log.warning("news provider %r not registered — skipping", name)
+            continue
+        try:
+            instances.append(build_provider(key, **cfg.get(key, {})))
+        except Exception as exc:
+            log.warning("news provider %r failed to build: %s", name, exc)
+    return NewsService(instances, cache_ttl_s=cache_ttl_s)
+
+
+__all__ = [
+    "AggregatedNews",
+    "DEFAULT_CACHE_TTL_S",
+    "DEFAULT_LIMIT_PER_PROVIDER",
+    "DEFAULT_TOTAL_LIMIT",
+    "NewsService",
+    "ProviderRunResult",
+    "build_default_service",
+]

--- a/src/news/service.py
+++ b/src/news/service.py
@@ -36,7 +36,10 @@ log = logging.getLogger(__name__)
 
 DEFAULT_CACHE_TTL_S = 180  # 3 minutes — rate-limit-safe for all providers
 DEFAULT_LIMIT_PER_PROVIDER = 25
-DEFAULT_TOTAL_LIMIT = 60
+# Matches the route's ``?limit=`` hard ceiling so the route's limit
+# contract isn't silently capped by the service before reaching the
+# slicing step (Codex P2).
+DEFAULT_TOTAL_LIMIT = 100
 
 
 @dataclass
@@ -206,6 +209,20 @@ class NewsService:
 
         with self._lock:
             self._cache[cache_key] = (now, result)
+            # Evict expired entries on every miss (Codex P2).  The
+            # cache key is ``(player_names, team_filter)`` — many
+            # distinct team combinations would otherwise accumulate
+            # full aggregated payloads forever.  Doing the sweep at
+            # write time (not on every read) keeps the hot path
+            # lock-free-ish and bounds the work by miss rate, which
+            # is itself rate-limited by the TTL.
+            expired = [
+                k
+                for k, (ts, _v) in self._cache.items()
+                if (now - ts) >= self._ttl
+            ]
+            for k in expired:
+                self._cache.pop(k, None)
 
         return result
 

--- a/tests/news/test_api_news_route.py
+++ b/tests/news/test_api_news_route.py
@@ -1,0 +1,146 @@
+"""End-to-end test for the GET /api/news FastAPI route.
+
+Uses an in-memory stub NewsService injected via
+``server._reset_news_service_for_tests`` so no real providers
+touch the network.  The route is otherwise exercised verbatim —
+query-param parsing, response shape, 503 on all-failures.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.news.base import NewsItem, PlayerMention
+from src.news.service import NewsService
+
+# Starlette's TestClient-backed lifespan conflicts with this
+# long-running app's background-thread startup.  We test the
+# route by mounting just the app without triggering lifespan.
+
+
+@pytest.fixture
+def client():
+    # Bypass lifespan — the startup hook spins up scrape threads
+    # that are unrelated to /api/news and would slow the test down.
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        yield c
+    server._reset_news_service_for_tests(None)
+
+
+class _FakeProvider:
+    name = "fake"
+    label = "Fake"
+    timeout_s = 1.0
+
+    def __init__(self, items=None, error=None):
+        self._items = items or []
+        self._error = error
+
+    def fetch(self, *, player_names=None, limit=50):
+        if self._error:
+            raise self._error
+        return self._items
+
+
+def _make_item(id_, players=None):
+    return NewsItem(
+        id=id_,
+        ts="2026-04-23T10:00:00+00:00",
+        provider="fake",
+        provider_label="Fake",
+        severity="alert",
+        kind="injury",
+        headline=f"hi {id_}",
+        body="body",
+        players=players or [],
+    )
+
+
+def test_api_news_returns_normalized_items(client):
+    svc = NewsService(
+        [_FakeProvider(items=[_make_item("a"), _make_item("b")])],
+        cache_ttl_s=0,
+    )
+    server._reset_news_service_for_tests(svc)
+
+    resp = client.get("/api/news")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source"] == "backend"
+    assert data["count"] == 2
+    assert len(data["items"]) == 2
+    first = data["items"][0]
+    # legacy + enriched fields both present
+    for key in (
+        "id",
+        "ts",
+        "providerLabel",
+        "severity",
+        "headline",
+        "publishedAt",
+        "summary",
+        "impactedPlayers",
+        "tags",
+    ):
+        assert key in first
+    assert data["providersUsed"] == ["fake"]
+
+
+def test_api_news_team_filter(client):
+    svc = NewsService(
+        [
+            _FakeProvider(
+                items=[
+                    _make_item("a", players=[PlayerMention(name="Bijan Robinson")]),
+                    _make_item("b", players=[PlayerMention(name="Random Joe")]),
+                ]
+            )
+        ],
+        cache_ttl_s=0,
+    )
+    server._reset_news_service_for_tests(svc)
+
+    resp = client.get("/api/news?team=Bijan+Robinson")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [i["id"] for i in data["items"]] == ["a"]
+
+
+def test_api_news_limit_caps_response(client):
+    items = [_make_item(f"x-{i}") for i in range(10)]
+    svc = NewsService([_FakeProvider(items=items)], cache_ttl_s=0)
+    server._reset_news_service_for_tests(svc)
+
+    resp = client.get("/api/news?limit=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["items"]) == 3
+    assert data["count"] == 3
+    assert data["limit"] == 3
+
+
+def test_api_news_returns_503_when_all_providers_fail(client):
+    svc = NewsService(
+        [_FakeProvider(error=RuntimeError("boom"))],
+        cache_ttl_s=0,
+    )
+    server._reset_news_service_for_tests(svc)
+
+    resp = client.get("/api/news")
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["items"] == []
+    assert data["error"] == "all_providers_failed"
+
+
+def test_api_news_200_with_empty_items_when_providers_return_nothing(client):
+    """Provider OK but empty → 200 (no DEMO fallback on frontend)."""
+    svc = NewsService([_FakeProvider(items=[])], cache_ttl_s=0)
+    server._reset_news_service_for_tests(svc)
+
+    resp = client.get("/api/news")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["source"] == "backend"

--- a/tests/news/test_cbs_provider.py
+++ b/tests/news/test_cbs_provider.py
@@ -1,0 +1,76 @@
+"""CBS Sports RSS provider tests.
+
+Shares the ``_rss`` helpers with ESPN / FantasyPros, so the
+surface exercised here is provider identity + the raise-on-
+failure contract.
+"""
+from __future__ import annotations
+
+import pytest
+import xml.etree.ElementTree as ET
+
+from src.news.providers.cbs import CbsFantasyRssProvider
+
+
+_SAMPLE_RSS = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>CBS Sports - NFL</title>
+    <item>
+      <title>Weekly fantasy start/sit - Week 12 overreactions</title>
+      <link>https://cbssports.com/nfl/news/a</link>
+      <guid>cbs-a</guid>
+      <pubDate>Thu, 23 Apr 2026 12:00:00 GMT</pubDate>
+      <description>Strategy piece on last week's surprises.</description>
+    </item>
+    <item>
+      <title>Breece Hall placed on IR with knee injury</title>
+      <link>https://cbssports.com/nfl/news/b</link>
+      <guid>cbs-b</guid>
+      <pubDate>Thu, 23 Apr 2026 11:00:00 GMT</pubDate>
+      <description>Jets lose their RB1.</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def _provider(rss_bytes=_SAMPLE_RSS):
+    return CbsFantasyRssProvider(fetcher=lambda _url: rss_bytes)
+
+
+def test_provider_identity():
+    items = _provider().fetch(player_names=["Breece Hall"])
+    assert len(items) == 2
+    for it in items:
+        assert it.provider == "cbs"
+        assert it.provider_label == "CBS Sports"
+
+
+def test_injury_classified_as_alert():
+    items = _provider().fetch(player_names=["Breece Hall"])
+    injury = next(i for i in items if "Breece Hall" in i.headline)
+    assert injury.severity == "alert"
+    assert injury.kind == "injury"
+    assert injury.players[0].name == "Breece Hall"
+    assert injury.players[0].impact == "negative"
+
+
+def test_strategy_piece_classified_as_info():
+    items = _provider().fetch(player_names=[])
+    strategy = next(i for i in items if "Week 12" in i.headline)
+    assert strategy.severity == "info"
+
+
+def test_fetch_error_propagates():
+    def boom(_url):
+        raise OSError("cbs down")
+
+    with pytest.raises(OSError):
+        CbsFantasyRssProvider(fetcher=boom).fetch()
+
+
+def test_malformed_rss_propagates():
+    provider = CbsFantasyRssProvider(fetcher=lambda _url: b"<bad>")
+    with pytest.raises(ET.ParseError):
+        provider.fetch()

--- a/tests/news/test_dynasty_focused_providers.py
+++ b/tests/news/test_dynasty_focused_providers.py
@@ -1,0 +1,99 @@
+"""Identity tests for the dynasty-focused RSS providers.
+
+The fetch + parse + classification behavior is fully exercised
+by the ESPN, FantasyPros, and CBS test files — every RSS
+provider inherits the same base, so re-testing the same code
+paths for six more subclasses would be redundant.
+
+What still needs pinning per-provider:
+
+1. ``name`` and ``label`` are what the frontend reads.  Typos
+   here would land a silently-mislabeled chip in the ticker.
+2. ``feed_url`` points at a concrete URL — regressing it to
+   empty or to the wrong path would make the provider silently
+   fail every fetch.
+3. The class is registered in the provider registry and
+   buildable by name.
+
+Everything below is a static contract check — no HTTP.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.news.providers import available_provider_names, build_provider
+from src.news.providers.dynasty_focused import (
+    DynastyLeagueFootballProvider,
+    DynastyNerdsProvider,
+    FfTodayProvider,
+    PffProvider,
+    PlayerProfilerProvider,
+    RazzballProvider,
+)
+
+
+@pytest.mark.parametrize(
+    "cls,name,label",
+    [
+        (DynastyLeagueFootballProvider, "dlf", "Dynasty League Football"),
+        (DynastyNerdsProvider, "dynastynerds", "Dynasty Nerds"),
+        (PffProvider, "pff", "PFF"),
+        (FfTodayProvider, "fftoday", "FFToday"),
+        (PlayerProfilerProvider, "playerprofiler", "Player Profiler"),
+        (RazzballProvider, "razzball", "Razzball"),
+    ],
+)
+def test_provider_identity(cls, name, label):
+    """Name, label, and URL must be set on each subclass."""
+    assert cls.name == name
+    assert cls.label == label
+    assert cls.feed_url, f"{name} has empty feed_url"
+    assert cls.feed_url.startswith("http")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "dlf",
+        "dynastynerds",
+        "pff",
+        "fftoday",
+        "playerprofiler",
+        "razzball",
+    ],
+)
+def test_provider_registered_and_buildable(name):
+    assert name in available_provider_names()
+    provider = build_provider(name)
+    assert provider.name == name
+    assert provider.label  # non-empty
+
+
+def test_shared_parser_produces_identity_tagged_items():
+    """All subclasses route through the shared RSS parser, so
+    a single fake feed should tag provider identity correctly."""
+    rss = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Headline X</title>
+      <link>https://example.com/a</link>
+      <guid>x-a</guid>
+      <pubDate>Thu, 23 Apr 2026 10:00:00 GMT</pubDate>
+      <description>Body</description>
+    </item>
+  </channel>
+</rss>
+"""
+    for cls in (
+        DynastyLeagueFootballProvider,
+        DynastyNerdsProvider,
+        PffProvider,
+        FfTodayProvider,
+        PlayerProfilerProvider,
+        RazzballProvider,
+    ):
+        items = cls(fetcher=lambda _url: rss).fetch()
+        assert len(items) == 1
+        assert items[0].provider == cls.name
+        assert items[0].provider_label == cls.label

--- a/tests/news/test_espn_provider.py
+++ b/tests/news/test_espn_provider.py
@@ -1,0 +1,101 @@
+"""ESPN RSS provider tests.
+
+Tests inject a fake RSS-body fetcher so no network access happens.
+"""
+from __future__ import annotations
+
+from src.news.providers.espn import EspnRssProvider
+
+
+_SAMPLE_RSS = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>ESPN.com - NFL</title>
+    <item>
+      <title>Bijan Robinson ruled out with hamstring injury</title>
+      <link>https://espn.com/nfl/story/a</link>
+      <guid>espn-a</guid>
+      <pubDate>Thu, 23 Apr 2026 10:42:00 GMT</pubDate>
+      <description><![CDATA[Falcons RB was a late scratch.]]></description>
+    </item>
+    <item>
+      <title>CeeDee Lamb signs extension with Cowboys</title>
+      <link>https://espn.com/nfl/story/b</link>
+      <guid>espn-b</guid>
+      <pubDate>Thu, 23 Apr 2026 09:00:00 GMT</pubDate>
+      <description>Dallas locks up their WR1 through 2030.</description>
+    </item>
+    <item>
+      <title>Roundup: around the league</title>
+      <link>https://espn.com/nfl/story/c</link>
+      <guid>espn-c</guid>
+      <pubDate>Thu, 23 Apr 2026 08:00:00 GMT</pubDate>
+      <description>Minor notes and rumors.</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def _provider(rss_bytes=_SAMPLE_RSS):
+    return EspnRssProvider(fetcher=lambda _url: rss_bytes)
+
+
+def test_rss_items_parse_and_classify():
+    items = _provider().fetch(player_names=["Bijan Robinson", "CeeDee Lamb"])
+    assert len(items) == 3
+    by_head = {i.headline: i for i in items}
+
+    injury = by_head["Bijan Robinson ruled out with hamstring injury"]
+    assert injury.severity == "alert"
+    assert injury.kind == "injury"
+    assert injury.players[0].name == "Bijan Robinson"
+    assert injury.players[0].impact == "negative"
+
+    extension = by_head["CeeDee Lamb signs extension with Cowboys"]
+    assert extension.severity == "watch"
+    assert extension.kind in {"transaction", "performance"}
+    assert extension.players[0].name == "CeeDee Lamb"
+    assert extension.players[0].impact == "positive"
+
+    generic = by_head["Roundup: around the league"]
+    assert generic.severity == "info"
+    assert generic.players == []
+
+
+def test_player_match_is_case_insensitive():
+    items = _provider().fetch(player_names=["bijan robinson"])
+    matches = [i for i in items if i.players]
+    assert any(p.name.lower() == "bijan robinson" for i in matches for p in i.players)
+
+
+def test_no_player_context_still_emits_items():
+    items = _provider().fetch(player_names=None)
+    # Items still render; they just have empty players[].
+    assert len(items) == 3
+    assert all(i.players == [] for i in items)
+
+
+def test_malformed_rss_returns_empty():
+    provider = EspnRssProvider(fetcher=lambda _url: b"<not-rss>")
+    assert provider.fetch() == []
+
+
+def test_fetch_error_returns_empty():
+    def boom(_url):
+        raise OSError("simulated network down")
+
+    provider = EspnRssProvider(fetcher=boom)
+    assert provider.fetch() == []
+
+
+def test_stable_ids_and_iso_timestamps():
+    items = _provider().fetch()
+    ids = [i.id for i in items]
+    assert len(set(ids)) == 3
+    for i in items:
+        # ISO 8601 UTC — parseable by datetime.fromisoformat.
+        from datetime import datetime
+
+        parsed = datetime.fromisoformat(i.ts)
+        assert parsed.tzinfo is not None

--- a/tests/news/test_espn_provider.py
+++ b/tests/news/test_espn_provider.py
@@ -76,17 +76,28 @@ def test_no_player_context_still_emits_items():
     assert all(i.players == [] for i in items)
 
 
-def test_malformed_rss_returns_empty():
+def test_malformed_rss_propagates():
+    """Malformed upstream → raise.  The service layer catches it
+    and marks the provider run ``ok=False`` so all-providers-fail
+    detection fires correctly; silently returning ``[]`` here
+    would look like a healthy-but-quiet feed (Codex P1)."""
+    import pytest
+    import xml.etree.ElementTree as ET
+
     provider = EspnRssProvider(fetcher=lambda _url: b"<not-rss>")
-    assert provider.fetch() == []
+    with pytest.raises(ET.ParseError):
+        provider.fetch()
 
 
-def test_fetch_error_returns_empty():
+def test_fetch_error_propagates():
+    import pytest
+
     def boom(_url):
         raise OSError("simulated network down")
 
     provider = EspnRssProvider(fetcher=boom)
-    assert provider.fetch() == []
+    with pytest.raises(OSError):
+        provider.fetch()
 
 
 def test_stable_ids_and_iso_timestamps():

--- a/tests/news/test_fantasypros_provider.py
+++ b/tests/news/test_fantasypros_provider.py
@@ -1,0 +1,73 @@
+"""FantasyPros RSS provider tests.
+
+FantasyPros shares the ``_rss`` parse/classify helpers with ESPN,
+so the surface tested here is mostly provider-identity + the
+raise-on-failure contract.  The full classification matrix is
+covered in ``test_espn_provider.py``.
+"""
+from __future__ import annotations
+
+import pytest
+import xml.etree.ElementTree as ET
+
+from src.news.providers.fantasypros import FantasyProsRssProvider
+
+
+_SAMPLE_RSS = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>FantasyPros Player News</title>
+    <item>
+      <title>Bijan Robinson ruled out with hamstring injury</title>
+      <link>https://fantasypros.com/nfl/news/a</link>
+      <guid>fp-a</guid>
+      <pubDate>Thu, 23 Apr 2026 11:00:00 GMT</pubDate>
+      <description><![CDATA[Report: ATL RB pulled early.]]></description>
+    </item>
+    <item>
+      <title>Jahmyr Gibbs signs rookie extension</title>
+      <link>https://fantasypros.com/nfl/news/b</link>
+      <guid>fp-b</guid>
+      <pubDate>Thu, 23 Apr 2026 10:00:00 GMT</pubDate>
+      <description>Lions lock up their lead back.</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def _provider(rss_bytes=_SAMPLE_RSS):
+    return FantasyProsRssProvider(fetcher=lambda _url: rss_bytes)
+
+
+def test_items_parse_and_tag_provider_identity():
+    items = _provider().fetch(
+        player_names=["Bijan Robinson", "Jahmyr Gibbs"]
+    )
+    assert len(items) == 2
+    for it in items:
+        assert it.provider == "fantasypros"
+        assert it.provider_label == "FantasyPros"
+
+    injury, transaction = items[0], items[1]
+    assert injury.severity == "alert"
+    assert injury.players[0].name == "Bijan Robinson"
+    assert transaction.severity == "watch"
+    assert transaction.players[0].name == "Jahmyr Gibbs"
+
+
+def test_fetch_error_propagates():
+    """Raise on upstream failure so the service marks the run
+    ``ok=False`` and all-providers-failed can trigger 503."""
+
+    def boom(_url):
+        raise OSError("fp down")
+
+    with pytest.raises(OSError):
+        FantasyProsRssProvider(fetcher=boom).fetch()
+
+
+def test_malformed_rss_propagates():
+    provider = FantasyProsRssProvider(fetcher=lambda _url: b"<nope>")
+    with pytest.raises(ET.ParseError):
+        provider.fetch()

--- a/tests/news/test_news_contract.py
+++ b/tests/news/test_news_contract.py
@@ -1,0 +1,85 @@
+"""Pin the normalized NewsItem serialization contract.
+
+Both the legacy frontend vocabulary (``ts``, ``body``, ``players``)
+and the enriched vocabulary (``publishedAt``, ``summary``,
+``impactedPlayers``, ``tags``) must survive the
+``NewsItem.to_dict`` round-trip on every item.  If either side
+breaks, every downstream consumer breaks — hence a dedicated
+contract test instead of folding it into a provider test.
+"""
+from __future__ import annotations
+
+from src.news.base import NewsItem, PlayerMention, stable_id, to_iso_utc
+from datetime import datetime, timezone
+
+
+def _sample_item() -> NewsItem:
+    return NewsItem(
+        id="espn-abc123",
+        ts="2026-04-23T10:00:00+00:00",
+        provider="espn",
+        provider_label="ESPN",
+        severity="alert",
+        kind="injury",
+        headline="Star RB exits with hamstring",
+        body="Player pulled from practice after feeling tightness.",
+        players=[PlayerMention(name="Bijan Robinson", impact="negative")],
+        url="https://example.com/news/1",
+        tags=["injury"],
+        confidence=0.72,
+    )
+
+
+def test_to_dict_preserves_legacy_fields():
+    item = _sample_item().to_dict()
+    # Every field the existing frontend reads today must be present.
+    for key in (
+        "id",
+        "ts",
+        "provider",
+        "providerLabel",
+        "severity",
+        "kind",
+        "headline",
+        "body",
+        "players",
+        "url",
+    ):
+        assert key in item, f"missing legacy field: {key}"
+    assert item["providerLabel"] == "ESPN"
+    assert item["players"] == [{"name": "Bijan Robinson", "impact": "negative"}]
+
+
+def test_to_dict_includes_enriched_aliases():
+    item = _sample_item().to_dict()
+    # Enriched fields the brief calls out: publishedAt, summary,
+    # impactedPlayers, tags, confidence, relevance.
+    assert item["publishedAt"] == item["ts"]
+    assert item["summary"] == item["body"]
+    assert item["impactedPlayers"] == ["Bijan Robinson"]
+    assert item["tags"] == ["injury"]
+    assert item["confidence"] == 0.72
+    assert "relevance" in item  # may be None
+
+
+def test_stable_id_is_deterministic():
+    a = stable_id("espn", "guid-42")
+    b = stable_id("espn", "guid-42")
+    c = stable_id("espn", "guid-43")
+    assert a == b
+    assert a != c
+    assert a.startswith("espn-")
+
+
+def test_to_iso_utc_normalizes_naive_datetime():
+    naive = datetime(2026, 4, 23, 10, 0, 0)
+    out = to_iso_utc(naive)
+    assert out.endswith("+00:00")
+    # Round-trip check.
+    assert datetime.fromisoformat(out).tzinfo is not None
+
+
+def test_to_iso_utc_preserves_aware_datetime():
+    aware = datetime(2026, 4, 23, 10, 0, 0, tzinfo=timezone.utc)
+    out = to_iso_utc(aware)
+    assert out == "2026-04-23T10:00:00+00:00"

--- a/tests/news/test_service.py
+++ b/tests/news/test_service.py
@@ -139,6 +139,47 @@ def test_sort_alerts_float_above_info():
     assert [i.id for i in out.items] == ["b-alert", "c-watch", "a-info"]
 
 
+def test_expired_entries_evicted_on_miss():
+    """Many distinct team filters must not leak full payloads
+    into the cache forever.  Eviction sweeps on every miss
+    (Codex P2)."""
+    clock = {"t": 1000.0}
+    provider = _StaticProvider(
+        items=[
+            _item("a-1", players=[PlayerMention(name="Alpha")]),
+            _item("a-2", players=[PlayerMention(name="Beta")]),
+            _item("a-3", players=[PlayerMention(name="Gamma")]),
+        ]
+    )
+    svc = NewsService([provider], cache_ttl_s=30, clock=lambda: clock["t"])
+    # Three distinct team filters → three cache entries.
+    svc.aggregate(team_names=["Alpha"])
+    svc.aggregate(team_names=["Beta"])
+    svc.aggregate(team_names=["Gamma"])
+    assert len(svc._cache) == 3
+
+    # Advance past TTL, trigger one more miss — all three prior
+    # entries should get evicted, leaving only the fresh one.
+    clock["t"] += 60
+    svc.aggregate(team_names=["Delta"])
+    assert len(svc._cache) == 1
+
+
+def test_total_limit_matches_route_cap():
+    """Service cap must not silently truncate below the route's
+    max limit (Codex P2).  Default total_limit should allow the
+    route's documented ``?limit=100`` to return 100 items."""
+    from src.news.service import DEFAULT_TOTAL_LIMIT
+
+    assert DEFAULT_TOTAL_LIMIT >= 100
+
+    many = [_item(f"x-{i}") for i in range(80)]
+    svc = NewsService([_StaticProvider(items=many)], cache_ttl_s=0)
+    out = svc.aggregate()
+    # 80 items should survive; previously capped at 60.
+    assert len(out.items) == 80
+
+
 def test_serialize_to_dict_shape():
     provider = _StaticProvider(
         items=[_item("a-1", players=[PlayerMention(name="Player X")])]

--- a/tests/news/test_service.py
+++ b/tests/news/test_service.py
@@ -1,0 +1,152 @@
+"""Service-layer tests for the news aggregator.
+
+Verifies:
+* per-provider fault isolation — a raising provider does not poison
+  the response
+* TTL caching — second call within TTL is a cache hit
+* team-name filter drops items with no matching player
+* ``providers_used`` tracks providers that actually produced items
+* priority ordering — Sleeper items appear ahead of ESPN in the
+  aggregator before the severity/time sort re-orders them
+"""
+from __future__ import annotations
+
+from src.news.base import NewsItem, NewsProvider, PlayerMention
+from src.news.service import NewsService
+
+
+class _StaticProvider(NewsProvider):
+    name = "static"
+    label = "Static"
+
+    def __init__(self, *, items=None, error=None, provider_name=None, provider_label=None):
+        super().__init__()
+        self._items = list(items or [])
+        self._error = error
+        if provider_name:
+            self.name = provider_name
+        if provider_label:
+            self.label = provider_label
+
+    def fetch(self, *, player_names=None, limit=50):
+        if self._error is not None:
+            raise self._error
+        return self._items
+
+
+def _item(id_, provider="static", severity="info", ts="2026-04-23T10:00:00+00:00", players=None):
+    return NewsItem(
+        id=id_,
+        ts=ts,
+        provider=provider,
+        provider_label=provider.title(),
+        severity=severity,
+        kind="news",
+        headline=f"headline {id_}",
+        body="",
+        players=players or [],
+    )
+
+
+def test_fault_isolation_one_provider_failing():
+    good = _StaticProvider(
+        items=[_item("a-1"), _item("a-2")],
+        provider_name="good",
+        provider_label="Good",
+    )
+    bad = _StaticProvider(
+        error=RuntimeError("boom"),
+        provider_name="bad",
+        provider_label="Bad",
+    )
+    svc = NewsService([good, bad], cache_ttl_s=0)
+    out = svc.aggregate()
+    assert len(out.items) == 2
+    assert out.providers_used == ["good"]
+    runs_by_name = {r.name: r for r in out.provider_runs}
+    assert runs_by_name["good"].ok is True
+    assert runs_by_name["bad"].ok is False
+    assert "RuntimeError" in runs_by_name["bad"].error
+
+
+def test_all_providers_failing_returns_empty_with_runs():
+    a = _StaticProvider(error=RuntimeError("x"), provider_name="a", provider_label="A")
+    b = _StaticProvider(error=RuntimeError("y"), provider_name="b", provider_label="B")
+    svc = NewsService([a, b], cache_ttl_s=0)
+    out = svc.aggregate()
+    assert out.items == []
+    assert out.providers_used == []
+    assert all(not r.ok for r in out.provider_runs)
+
+
+def test_ttl_cache_hit():
+    # Use a controllable clock so we're not racing wall time.
+    clock = {"t": 1000.0}
+    provider = _StaticProvider(items=[_item("a-1")])
+    svc = NewsService([provider], cache_ttl_s=60, clock=lambda: clock["t"])
+    first = svc.aggregate()
+    assert first.cache_hit is False
+    # Second call within TTL — should be a cache hit.
+    clock["t"] += 30
+    second = svc.aggregate()
+    assert second.cache_hit is True
+    assert [i.id for i in second.items] == [i.id for i in first.items]
+    # Past TTL — refreshes.
+    clock["t"] += 60
+    third = svc.aggregate()
+    assert third.cache_hit is False
+
+
+def test_team_name_filter_drops_non_matching_items():
+    provider = _StaticProvider(
+        items=[
+            _item("a-1", players=[PlayerMention(name="Bijan Robinson")]),
+            _item("a-2", players=[PlayerMention(name="Random Joe")]),
+            _item("a-3", players=[]),
+        ]
+    )
+    svc = NewsService([provider], cache_ttl_s=0)
+    out = svc.aggregate(team_names=["Bijan Robinson"])
+    assert [i.id for i in out.items] == ["a-1"]
+
+
+def test_dedup_by_id_across_providers():
+    a = _StaticProvider(
+        items=[_item("shared-1"), _item("only-a")],
+        provider_name="a",
+    )
+    b = _StaticProvider(
+        items=[_item("shared-1"), _item("only-b")],
+        provider_name="b",
+    )
+    svc = NewsService([a, b], cache_ttl_s=0)
+    out = svc.aggregate()
+    ids = [i.id for i in out.items]
+    assert len(ids) == 3
+    assert sorted(ids) == ["only-a", "only-b", "shared-1"]
+
+
+def test_sort_alerts_float_above_info():
+    provider = _StaticProvider(
+        items=[
+            _item("a-info", severity="info", ts="2026-04-23T12:00:00+00:00"),
+            _item("b-alert", severity="alert", ts="2026-04-23T09:00:00+00:00"),
+            _item("c-watch", severity="watch", ts="2026-04-23T10:00:00+00:00"),
+        ]
+    )
+    svc = NewsService([provider], cache_ttl_s=0)
+    out = svc.aggregate()
+    assert [i.id for i in out.items] == ["b-alert", "c-watch", "a-info"]
+
+
+def test_serialize_to_dict_shape():
+    provider = _StaticProvider(
+        items=[_item("a-1", players=[PlayerMention(name="Player X")])]
+    )
+    svc = NewsService([provider], cache_ttl_s=0)
+    payload = svc.aggregate().to_dict()
+    assert "items" in payload
+    assert "providersUsed" in payload
+    assert "providerRuns" in payload
+    assert "generatedAt" in payload
+    assert payload["items"][0]["impactedPlayers"] == ["Player X"]

--- a/tests/news/test_sleeper_provider.py
+++ b/tests/news/test_sleeper_provider.py
@@ -1,0 +1,143 @@
+"""Sleeper trending provider tests.
+
+These exercise the normalization path — upstream HTTP is stubbed
+via a fake ``requests.Session`` so the tests stay offline and
+deterministic.
+"""
+from __future__ import annotations
+
+from src.news.providers.sleeper import (
+    SleeperTrendingProvider,
+    _reset_player_map_for_tests,
+)
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+class _FakeSession:
+    """Stubs the two endpoints the provider hits.
+
+    Routes are keyed by path substring so the test reads naturally.
+    Each route can be either a static payload or a callable.
+    """
+
+    def __init__(self, routes):
+        self._routes = routes
+        self.calls = []
+
+    def get(self, url, timeout=None, headers=None):
+        self.calls.append(url)
+        for key, payload in self._routes.items():
+            if key in url:
+                resolved = payload() if callable(payload) else payload
+                return _FakeResponse(resolved)
+        raise AssertionError(f"unexpected URL: {url}")
+
+
+def _build_provider(routes):
+    _reset_player_map_for_tests()
+    session = _FakeSession(routes)
+    provider = SleeperTrendingProvider(
+        lookback_hours=24,
+        limit_per_feed=5,
+        session=session,
+    )
+    return provider, session
+
+
+def test_trending_maps_to_normalized_items():
+    routes = {
+        "/players/nfl/trending/add": [
+            {"player_id": "6797", "count": 18432},
+            {"player_id": "9999", "count": 9021},
+        ],
+        "/players/nfl/trending/drop": [
+            {"player_id": "1234", "count": 5502},
+        ],
+        "/players/nfl": {
+            "6797": {
+                "full_name": "Jayden Reed",
+                "position": "WR",
+                "team": "GB",
+            },
+            "9999": {
+                "first_name": "Rookie",
+                "last_name": "Breakout",
+                "position": "RB",
+            },
+            "1234": {
+                "full_name": "Fallen Star",
+                "position": "WR",
+            },
+        },
+    }
+    provider, _ = _build_provider(routes)
+    items = provider.fetch(limit=10)
+    assert len(items) == 3
+
+    # Spot-check the top add.
+    top = items[0]
+    assert "Jayden Reed" in top.headline
+    assert top.provider == "sleeper"
+    assert top.provider_label == "Sleeper"
+    assert top.kind == "trending"
+    assert top.severity == "watch"
+    assert top.players[0].impact == "positive"
+    assert top.url and top.url.endswith("/6797")
+    assert "trending" in top.tags and "add" in top.tags
+
+    # Dropped player should come through with negative impact.
+    drops = [i for i in items if "drop" in i.tags]
+    assert len(drops) == 1
+    assert drops[0].players[0].impact == "negative"
+    assert drops[0].severity == "info"
+
+
+def test_missing_player_map_entry_is_dropped():
+    routes = {
+        "/players/nfl/trending/add": [
+            {"player_id": "missing", "count": 100},
+        ],
+        "/players/nfl/trending/drop": [],
+        "/players/nfl": {},  # empty map → name lookup returns None
+    }
+    provider, _ = _build_provider(routes)
+    assert provider.fetch() == []
+
+
+def test_provider_swallows_network_errors():
+    """The provider must return ``[]`` not raise on upstream errors."""
+    class _ExplodingSession:
+        calls = 0
+
+        def get(self, *_a, **_kw):
+            self.__class__.calls += 1
+            raise RuntimeError("boom")
+
+    _reset_player_map_for_tests()
+    provider = SleeperTrendingProvider(session=_ExplodingSession())
+    # The public fetch method logs + returns [], never raises.
+    assert provider.fetch() == []
+
+
+def test_stable_ids_across_bucket():
+    """Two fetches in the same hour bucket should produce identical ids."""
+    routes = {
+        "/players/nfl/trending/add": [{"player_id": "6797", "count": 10}],
+        "/players/nfl/trending/drop": [],
+        "/players/nfl": {"6797": {"full_name": "Jayden Reed"}},
+    }
+    provider, _ = _build_provider(routes)
+    a = provider.fetch()
+    # Re-fetch — player map cache hit + same hour bucket → same id.
+    b = provider.fetch()
+    assert [i.id for i in a] == [i.id for i in b]

--- a/tests/news/test_sleeper_provider.py
+++ b/tests/news/test_sleeper_provider.py
@@ -114,6 +114,78 @@ def test_missing_player_map_entry_is_dropped():
     assert provider.fetch() == []
 
 
+def test_cold_player_map_failure_propagates():
+    """Player-map fetch failure on a cold cache must raise, so
+    the service can mark the provider run ``ok=False``.  A warm
+    cache (previous successful fetch) still degrades gracefully.
+    Codex P1 #2."""
+    import pytest
+
+    class _TrendingOkMapFailSession:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, timeout=None, headers=None):
+            self.calls.append(url)
+            if "trending" in url:
+                class _R:
+                    def raise_for_status(self):
+                        return None
+
+                    def json(self):
+                        return [{"player_id": "1", "count": 3}]
+
+                return _R()
+            # /players/nfl — simulate outage
+            raise RuntimeError("player-map unavailable")
+
+    _reset_player_map_for_tests()
+    provider = SleeperTrendingProvider(session=_TrendingOkMapFailSession())
+    with pytest.raises(RuntimeError):
+        provider.fetch()
+
+
+def test_warm_player_map_failure_degrades_gracefully():
+    """If a prior fetch succeeded, a later fetch outage falls
+    back to the stale map rather than raising — dynasty names
+    don't change that often, and stale-but-usable > failure."""
+    # First populate the cache via a successful fetch.
+    routes_ok = {
+        "/players/nfl/trending/add": [
+            {"player_id": "42", "count": 10},
+        ],
+        "/players/nfl/trending/drop": [],
+        "/players/nfl": {"42": {"full_name": "Cached Star"}},
+    }
+    provider_ok, _ = _build_provider(routes_ok)
+    items_ok = provider_ok.fetch()
+    assert len(items_ok) == 1
+
+    # Now simulate a player-map outage on the next fetch.  The
+    # trending endpoints still work, but /players/nfl errors out.
+    class _WarmMapOutage:
+        def get(self, url, timeout=None, headers=None):
+            if "trending" in url:
+                class _R:
+                    def raise_for_status(self):
+                        return None
+
+                    def json(self):
+                        return [{"player_id": "42", "count": 11}]
+
+                return _R()
+            raise RuntimeError("player-map down")
+
+    # Force a player-map refetch by expiring the TTL — simulate by
+    # invalidating then re-seeding trending but failing map.
+    # The existing module-level cache has the "42" entry so the
+    # warm-stale path should return it.
+    provider_warm = SleeperTrendingProvider(session=_WarmMapOutage())
+    items_warm = provider_warm.fetch()
+    assert len(items_warm) >= 1
+    assert any(p.name == "Cached Star" for i in items_warm for p in i.players)
+
+
 def test_provider_propagates_when_both_endpoints_fail():
     """Total upstream outage → raise so the service can mark the
     run ``ok=False``.  Silently returning ``[]`` would hide a real

--- a/tests/news/test_sleeper_provider.py
+++ b/tests/news/test_sleeper_provider.py
@@ -114,19 +114,60 @@ def test_missing_player_map_entry_is_dropped():
     assert provider.fetch() == []
 
 
-def test_provider_swallows_network_errors():
-    """The provider must return ``[]`` not raise on upstream errors."""
-    class _ExplodingSession:
-        calls = 0
+def test_provider_propagates_when_both_endpoints_fail():
+    """Total upstream outage → raise so the service can mark the
+    run ``ok=False``.  Silently returning ``[]`` would hide a real
+    outage from the all-providers-failed → 503 path (Codex P1)."""
+    import pytest
 
+    class _ExplodingSession:
         def get(self, *_a, **_kw):
-            self.__class__.calls += 1
             raise RuntimeError("boom")
 
     _reset_player_map_for_tests()
     provider = SleeperTrendingProvider(session=_ExplodingSession())
-    # The public fetch method logs + returns [], never raises.
-    assert provider.fetch() == []
+    with pytest.raises(RuntimeError):
+        provider.fetch()
+
+
+def test_provider_tolerates_one_endpoint_failing():
+    """Partial outage (only one of add/drop down) still returns
+    the usable items — no reason to throw away a working signal."""
+
+    class _SplitSession:
+        def __init__(self, ok_path: str):
+            self._ok_path = ok_path
+            self.calls = []
+
+        def get(self, url, timeout=None, headers=None):
+            self.calls.append(url)
+            if self._ok_path in url:
+                class _R:
+                    def raise_for_status(self):
+                        return None
+
+                    def json(self):
+                        return [{"player_id": "1", "count": 5}]
+
+                return _R()
+            if "/players/nfl" in url and "trending" not in url:
+                class _R2:
+                    def raise_for_status(self):
+                        return None
+
+                    def json(self):
+                        return {"1": {"full_name": "Only Add"}}
+
+                return _R2()
+            raise RuntimeError("drops unavailable")
+
+    _reset_player_map_for_tests()
+    provider = SleeperTrendingProvider(
+        session=_SplitSession("/trending/add")
+    )
+    items = provider.fetch()
+    assert len(items) == 1
+    assert items[0].players[0].name == "Only Add"
 
 
 def test_stable_ids_across_bucket():


### PR DESCRIPTION
## Summary

Replaces the mock-only news layer with a real backend `/api/news` feed. The existing frontend already prefers `/api/news` when it returns 200 and falls back to the bundled fixture on 404/503, so this ships **without any UI change** — the DEMO badge self-disables the moment the route starts answering.

## What changed

### New module: `src/news/`
- **`base.py`** — `NewsItem` / `PlayerMention` dataclasses, abstract `NewsProvider`. `to_dict()` emits both the legacy vocabulary (`ts`, `body`, `players`) and the enriched one (`publishedAt`, `summary`, `impactedPlayers`, `tags`, `confidence`, `relevance`) so either consumer vocabulary works identically.
- **`providers/sleeper.py`** — wraps Sleeper's `/trending/add` + `/trending/drop` endpoints. Player-id→name map is cached at module level with a 24h TTL (Sleeper docs ask callers to hit `/players/nfl` at most once per day). Trending count scales into a `confidence` score. Stable, hour-bucketed ids so refetches within the same window dedupe correctly.
- **`providers/espn.py`** — parses the public NFL RSS feed with stdlib `ElementTree` (no new deps). Word-boundary regex classifies severity/kind from injury + transaction keywords. Player tagging is substring-matched against the live `/api/data` player universe, so matches stay precise to the actual league.
- **`providers/rotowire.py`** — registered stub returning `[]` until licensing lands. Enabling it via config is a no-op today; swapping in a real impl lights up the rest of the stack automatically.
- **`service.py`** — aggregator with:
  - per-provider fault isolation (raising provider → `ProviderRunResult(ok=False)`, survivors still answer)
  - TTL cache (180 s default) keyed by `(player_names, team_filter)`
  - id-based dedup across providers
  - severity → timestamp sort (`alert` floats above `watch` above `info`)
  - optional `team_names` filter (drops items with no matching player)

### New route: `GET /api/news`

- Lazy singleton service, constructed on first request so boot stays decoupled from upstream availability.
- Query params: `?limit=N` (1–100, default 50), `?team=<name>` (repeatable or comma-separated).
- **Return codes**:
  - `200` with items — providers healthy, feed populated
  - `200` with empty `items[]` — providers healthy, no trending surface right now (frontend shows "no news yet"; DEMO badge stays off)
  - `503` — every provider failed (frontend falls back to the mock fixture and re-shows the DEMO badge)

### Response contract (normalized)

```json
{
  "source": "backend",
  "items": [{
    "id": "sleeper-abc123...",
    "ts": "2026-04-23T10:00:00+00:00",
    "publishedAt": "2026-04-23T10:00:00+00:00",
    "provider": "sleeper",
    "providerLabel": "Sleeper",
    "severity": "watch",
    "kind": "trending",
    "headline": "Jayden Reed added in 18,432 leagues (last 24h)",
    "body": "…",
    "summary": "…",
    "players": [{"name": "Jayden Reed", "impact": "positive"}],
    "impactedPlayers": ["Jayden Reed"],
    "tags": ["trending", "add"],
    "url": "https://sleeper.com/players/6797",
    "confidence": 0.83,
    "relevance": null
  }],
  "providersUsed": ["sleeper", "espn"],
  "providerRuns": [{"name": "sleeper", "ok": true, "count": 20, "elapsedMs": 210}],
  "generatedAt": "…",
  "cacheHit": false,
  "count": 20,
  "limit": 50
}
```

## How demo → live switching works now

The frontend (`frontend/lib/news-service.js`) was already coded for this transition:
1. `fetchNews()` tries `GET /api/news` first.
2. On **200**, it tags the response `source: "backend"`. `TeamNewsFeed` checks `news.source === "mock"` to decide whether to render the DEMO badge → badge hides automatically.
3. On **404 / 503** (or any network error), it returns `source: "mock"` from the bundled fixture. Badge stays visible.
4. `useNews` caches the result for 60 s at the module level, so enabling or disabling the backend route requires no client-side flag or reload logic.

No frontend files changed in this PR.

## Source priority (matches brief)

1. **Sleeper trending** — highest signal for dynasty churn, no auth, rate-limit-safe (we poll hourly, caching the player map 24h).
2. **ESPN NFL RSS** — free public feed, good headline coverage, classification is conservative (alerts only for unambiguous injury/IR keywords).
3. **Rotowire** — stub; will ship a real implementation once the commercial licence is confirmed.

## Source limitations (notes)

- **Sleeper trending** has no headline or narrative — we synthesize one from `{name} {verb} {count} leagues`. `confidence` reflects share-of-top-count, not editorial importance.
- **ESPN RSS** severity classification is heuristic. `Bijan Robinson ruled out with hamstring` → `alert`; `CeeDee Lamb signs extension` → `watch`; everything else → `info`. No upstream metadata for positive-vs-negative impact, so we infer from the same keyword buckets.
- **Player tagging** on ESPN items is substring-based against the live `/api/data` player universe. If the contract hasn't loaded yet (cold boot), items still surface with empty `players[]` rather than failing.
- **Rate limits**: aggregated response is cached 180 s, Sleeper trending is called at most ~20 times/hour per deploy, Sleeper player-map at most once per 24 h. Well inside all documented limits.

## Tests (27 new, all passing)

- `tests/news/test_news_contract.py` — pins the legacy + enriched field set on `NewsItem.to_dict()`.
- `tests/news/test_sleeper_provider.py` — injected fake session, trending mapping, missing-player-map rows dropped, network error → `[]`, stable ids across same hour.
- `tests/news/test_espn_provider.py` — fake RSS fetcher, severity/kind classification, player tag matching (case-insensitive), malformed-RSS and network-error paths.
- `tests/news/test_service.py` — fault isolation, all-providers-fail, TTL cache hit, team-name filter, cross-provider id dedup, sort order.
- `tests/news/test_api_news_route.py` — FastAPI TestClient with a stubbed service injected via `server._reset_news_service_for_tests`: happy path, team filter, limit cap, 503 on all-providers-fail, 200 with empty items.

Full existing `tests/api/` suite (602 tests) still passes.

## Test plan

- [x] `python3 -m pytest tests/news/ -v` — 27 pass
- [x] `python3 -m pytest tests/api/ -q` — 602 pass, 3 skipped
- [x] `python3 -c "import server"` — clean import (route is wired into the FastAPI app)
- [ ] Manual smoke: start the stack, hit `GET /api/news` locally, confirm real Sleeper + ESPN items flow through and the DEMO badge disappears on the landing page.
- [ ] Watch logs for per-provider warnings on first deploy to catch any upstream schema drift early.

https://claude.ai/code/session_01FXL8UMVckGXc2TNdxoNivi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXL8UMVckGXc2TNdxoNivi)_