### PR TITLE
fix: restore player names in terminal market-movement panel

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -5396,8 +5396,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   gap: 4px;
   font-variant-numeric: tabular-nums;
 }
-.pmm-head,
-.pmm-row {
+.pmm-head {
   display: grid;
   grid-template-columns: minmax(0, 2fr) 40px 64px 52px minmax(0, 1fr) 40px;
   gap: var(--space-sm);
@@ -5423,7 +5422,21 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   flex-direction: column;
   gap: 4px;
 }
+/*
+ * ``.pmm-row`` is a plain block container — the grid columns live on
+ * the inner ``.pmm-row-trigger`` button (see rule further down).
+ * A prior rule set the LI to ``display: grid`` with the same 6-track
+ * template, which caused the LI to reserve full-width tracks for
+ * children that didn't exist (the LI only has one child — the
+ * button).  The button was placed in the FIRST track (``minmax(0,
+ * 2fr)``) and its own grid tried to fit ``2.2fr + 276px`` of
+ * columns inside roughly two-thirds of the LI's width.  Once the
+ * panel got narrower than ~610 px, the inner name column collapsed
+ * to zero and names stopped rendering — values, positions, etc.
+ * stayed visible because they have fixed track widths.
+ */
 .pmm-row {
+  display: block;
   background: rgba(255, 255, 255, 0.02);
 }
 .pmm-col { min-width: 0; }


### PR DESCRIPTION
## Summary
- Names in the Player Market Movement table were rendering as blank, showing only position + value + delta.
- The LI row had `display: grid` inherited from a shared rule with the header, but its only child (the row-trigger button) has its own inner grid — so the outer grid reserved ~200 px of empty column tracks.
- Below ~610 px of panel width, the inner `minmax(0, 2.2fr)` name column collapsed to zero while the fixed-width columns (pos/value/delta/spark/vol) stayed visible.

## Fix
Split the shared `.pmm-head, .pmm-row` rule so only `.pmm-head` gets the grid layout (its 6 spans are direct children), and pin `.pmm-row` to `display: block` so the inner `.pmm-row-trigger` button has the full row width for its own grid.

## Test plan
- [ ] Reload the signed-in terminal and confirm player names render in the Player Market Movement panel
- [ ] Verify the mobile card layout (<600 px) still stacks name above meta
- [ ] Confirm roster-dot indicator still precedes the name on roster rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)