### PR TITLE
feat: per-source value history + multi-line PlayerPopup chart

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -6600,11 +6600,11 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   opacity: 0.6;
 }
 
-/* ── Player rank-history chart (PlayerPopup) ─────────────────────── */
+/* ── Player value-history chart (PlayerPopup) ───────────────────── */
 .player-rank-chart {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   padding: 10px 12px;
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid var(--border);
@@ -6632,6 +6632,12 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   text-transform: uppercase;
   font-size: 0.68rem;
 }
+.player-rank-chart-asterisk {
+  color: var(--cyan);
+  font-weight: 700;
+  margin-left: 2px;
+  cursor: help;
+}
 .player-rank-chart-delta {
   font-weight: 700;
   font-variant-numeric: tabular-nums;
@@ -6641,19 +6647,83 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .player-rank-chart-delta--flat { color: var(--muted); }
 .player-rank-chart-svg {
   width: 100%;
-  height: 140px;
+  height: 180px;
   display: block;
 }
+
+/* Legend: grid of small chips, one per series.  Blended chip is
+   highlighted and occupies the full first column. */
 .player-rank-chart-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  font-size: 0.68rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 4px 10px;
+  font-size: 0.66rem;
   color: var(--subtext);
   font-variant-numeric: tabular-nums;
 }
-.player-rank-chart-legend strong {
+.player-rank-chart-legend-blended {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 4px;
+  font-size: 0.72rem;
+}
+.player-rank-chart-legend-blended strong {
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.player-rank-chart-legend-source {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.player-rank-chart-legend-source > span:nth-child(2) {
+  color: var(--text);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  flex-grow: 0;
+  min-width: 0;
+}
+.player-rank-chart-legend-range {
+  color: var(--muted);
+  font-size: 0.62rem;
+  margin-left: auto;
+  padding-left: 6px;
+  white-space: nowrap;
+}
+.player-rank-chart-swatch {
+  display: inline-block;
+  width: 12px;
+  min-width: 12px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.player-rank-chart-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  padding-top: 6px;
+  margin-top: 2px;
+  border-top: 1px solid var(--border);
+  font-size: 0.62rem;
+  color: var(--subtext);
+}
+.player-rank-chart-footer strong {
   color: var(--muted);
   font-weight: 600;
   margin-right: 2px;
+}
+.player-rank-chart-note {
+  color: var(--cyan);
+  font-style: italic;
+  margin-left: auto;
 }

--- a/frontend/components/PlayerRankHistoryChart.jsx
+++ b/frontend/components/PlayerRankHistoryChart.jsx
@@ -1,85 +1,134 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { RANKING_SOURCES } from "@/lib/dynasty-data";
 
 /**
- * PlayerRankHistoryChart — 180-day rank-history line chart.
+ * PlayerRankHistoryChart — 180-day per-source + blended value chart.
  *
- * Reads ``row.rankHistory`` when the contract stamped it (the
- * default) and falls back to ``/api/data/rank-history?days=180`` with
- * a case-insensitive name match when it didn't (e.g. runtime-view
- * payloads that strip ``playersArray``).
+ * Renders one thin line per ranking source (the value each source
+ * cast into the blend on each scrape date) plus one thicker, bolder
+ * line for OUR blended value.  A shared Y axis (1–9999 value scale)
+ * lets the viewer see at a glance which sources disagree, which
+ * have drifted, and where the blended line lands relative to the
+ * extremes.
  *
- * Y-axis is rank (inverted — lower rank = up = visually better).
- * X-axis is date.  We render three windows worth of reference tags
- * (30d / 90d / 180d lines) so a viewer can eyeball "how much has he
- * moved in the last month vs the last six months".
+ * Data source: ``GET /api/data/player-source-history?name=...`` which
+ * reads ``data/source_value_history.jsonl`` on the backend.  A
+ * backfill mined the existing ``data/dynasty_data_*.json`` daily
+ * exports so the chart has ~28 days of per-source history on day
+ * one; new snapshots are appended on every scrape.
  *
- * No external chart library — SVG path primitives only.  Under 150
- * lines, renders sub-millisecond for a 180-point series.
+ * The blended line may be marked ``derived`` for historical dates
+ * that pre-date the contract-builder pipeline — in that case we
+ * show the median-of-sources approximation and note it in the
+ * legend.
+ *
+ * No external chart library — pure SVG.  ~200 lines, renders <1ms
+ * for a 28-point × 10-source series.
  */
 
 const CACHE = new Map(); // { [nameLower]: { result, expires } }
 const CACHE_TTL_MS = 120_000;
 
-async function fetchAllHistory(signal) {
+async function fetchPlayerHistory(name, signal) {
+  const key = String(name).toLowerCase().trim();
+  if (!key) return { dates: [], blended: [], sources: {} };
   const now = Date.now();
-  const cached = CACHE.get("__all__");
+  const cached = CACHE.get(key);
   if (cached && cached.expires > now) return cached.result;
-  const res = await fetch("/api/data/rank-history?days=180", {
-    credentials: "same-origin",
-    signal,
-  });
-  if (!res.ok) throw new Error(`rank-history ${res.status}`);
+  const url = `/api/data/player-source-history?name=${encodeURIComponent(name)}&days=180`;
+  const res = await fetch(url, { credentials: "same-origin", signal });
+  if (!res.ok) throw new Error(`player-source-history ${res.status}`);
   const body = await res.json();
-  const history = body?.history && typeof body.history === "object" ? body.history : {};
-  // The backend stores entries with composite keys like ``Ja'Marr
-  // Chase::offense``.  Flatten to lower-cased display names so the
-  // chart can look up by row.name alone.
-  const flat = {};
-  for (const key of Object.keys(history)) {
-    const series = history[key];
-    if (!Array.isArray(series)) continue;
-    const [namePart] = String(key).split("::");
-    const norm = String(namePart || key).toLowerCase().trim();
-    if (!norm) continue;
-    // If two asset classes share a name, keep whichever has more
-    // points — the common case is picks vs offense colliding on
-    // generic names; rank-relevant series will have more coverage.
-    const prev = flat[norm];
-    if (!prev || series.length > prev.length) {
-      flat[norm] = series;
-    }
-  }
-  const result = flat;
-  CACHE.set("__all__", { result, expires: Date.now() + CACHE_TTL_MS });
+  const result = {
+    dates: Array.isArray(body?.dates) ? body.dates : [],
+    blended: Array.isArray(body?.blended) ? body.blended : [],
+    sources: body?.sources && typeof body.sources === "object" ? body.sources : {},
+  };
+  CACHE.set(key, { result, expires: Date.now() + CACHE_TTL_MS });
   return result;
 }
 
-function normalizePoints(raw) {
-  if (!Array.isArray(raw)) return [];
-  const out = [];
-  for (const p of raw) {
-    if (!p || typeof p !== "object") continue;
-    const rank = Number(p.rank);
-    if (!Number.isFinite(rank) || rank <= 0) continue;
-    const t = Date.parse(p.date);
-    if (!Number.isFinite(t)) continue;
-    out.push({ date: p.date, t, rank });
+function parseMs(date) {
+  const t = Date.parse(date);
+  return Number.isFinite(t) ? t : null;
+}
+
+// Palette for source lines.  Non-saturated so the bold blended line
+// remains the visual focal point.  Colors are repeated in a stable
+// order so the same source gets the same color across re-renders.
+const SOURCE_PALETTE = [
+  "#60a5fa", // blue
+  "#a78bfa", // violet
+  "#f472b6", // pink
+  "#fbbf24", // amber
+  "#34d399", // emerald (dupe of blended; intentional — not used first)
+  "#fb923c", // orange
+  "#22d3ee", // cyan
+  "#a3e635", // lime
+  "#f87171", // red
+  "#818cf8", // indigo
+  "#fde047", // yellow
+  "#4ade80", // green
+];
+
+function colorForSource(key, index) {
+  return SOURCE_PALETTE[index % SOURCE_PALETTE.length];
+}
+
+// Source label lookup: prefer the display label from the registry,
+// fall back to the raw key.  Keeps the legend readable.
+const SOURCE_LABELS = (() => {
+  const map = {};
+  for (const s of RANKING_SOURCES) {
+    map[s.key] = s.columnLabel || s.displayName || s.key;
   }
-  out.sort((a, b) => a.t - b.t);
-  return out;
+  // Legacy keys from pre-contract-builder exports (camelCase).
+  map.fantasyCalc = "FantasyCalc";
+  map.dlfSf = "DLF SF";
+  map.dynastyDaddy = "Dynasty Daddy";
+  map.draftSharks = "Draft Sharks";
+  map.draftSharksIdp = "Draft Sharks IDP";
+  map.fantasyPros = "FantasyPros";
+  map.idpTradeCalc = "IDPTC";
+  map.yahoo = "Yahoo";
+  map.ktc = "KTC";
+  return map;
+})();
+
+function labelForSource(key) {
+  return SOURCE_LABELS[key] || key;
+}
+
+function buildPath({ points, toX, toY }) {
+  const parts = [];
+  let open = false;
+  for (const p of points) {
+    if (!Number.isFinite(p.value) || p.value <= 0) {
+      open = false;
+      continue;
+    }
+    const x = toX(p.t).toFixed(1);
+    const y = toY(p.value).toFixed(1);
+    parts.push(`${open ? "L" : "M"}${x},${y}`);
+    open = true;
+  }
+  return parts.join(" ");
 }
 
 export default function PlayerRankHistoryChart({
   row,
   width = 520,
-  height = 140,
+  height = 180,
 }) {
-  const stamped = Array.isArray(row?.rankHistory) ? row.rankHistory : null;
-  const [remote, setRemote] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [state, setState] = useState({
+    loading: true,
+    error: null,
+    dates: [],
+    blended: [],
+    sources: {},
+  });
   const mounted = useRef(true);
 
   useEffect(() => {
@@ -90,134 +139,134 @@ export default function PlayerRankHistoryChart({
   }, []);
 
   useEffect(() => {
-    // Only fall back to the network when the row didn't carry a
-    // stamped series.  This keeps the popup fast in the common case
-    // (full contract view) and correct in the fallback case (runtime
-    // view / the occasional unstamped row).
-    if (stamped && stamped.length > 0) return undefined;
     if (!row?.name) return undefined;
     const controller = new AbortController();
-    setLoading(true);
-    setError(null);
-    fetchAllHistory(controller.signal)
-      .then((all) => {
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    fetchPlayerHistory(row.name, controller.signal)
+      .then((res) => {
         if (!mounted.current) return;
-        const key = String(row.name).toLowerCase().trim();
-        setRemote(all[key] || []);
-        setLoading(false);
+        setState({ loading: false, error: null, ...res });
       })
       .catch((err) => {
         if (err?.name === "AbortError") return;
         if (!mounted.current) return;
-        setError(err?.message || "rank-history fetch failed");
-        setLoading(false);
+        setState({
+          loading: false,
+          error: err?.message || "fetch failed",
+          dates: [],
+          blended: [],
+          sources: {},
+        });
       });
     return () => controller.abort();
-  }, [stamped, row?.name]);
-
-  const points = useMemo(() => normalizePoints(stamped || remote), [stamped, remote]);
+  }, [row?.name]);
 
   const geometry = useMemo(() => {
-    if (points.length < 2) return null;
+    const blended = (state.blended || [])
+      .map((p) => ({ t: parseMs(p.date), value: Number(p.value), derived: !!p.derived }))
+      .filter((p) => p.t != null);
+    const sources = {};
+    for (const [key, series] of Object.entries(state.sources || {})) {
+      if (!Array.isArray(series)) continue;
+      sources[key] = series
+        .map((p) => ({ t: parseMs(p.date), value: Number(p.value) }))
+        .filter((p) => p.t != null);
+    }
+    // Collect all points for Y-axis domain.
+    const allValues = [];
+    for (const p of blended) if (Number.isFinite(p.value) && p.value > 0) allValues.push(p.value);
+    for (const key of Object.keys(sources)) {
+      for (const p of sources[key]) if (Number.isFinite(p.value) && p.value > 0) allValues.push(p.value);
+    }
+    if (allValues.length < 2) return null;
+
+    const allTimes = [];
+    for (const p of blended) allTimes.push(p.t);
+    for (const key of Object.keys(sources)) for (const p of sources[key]) allTimes.push(p.t);
+    const tMin = Math.min(...allTimes);
+    const tMax = Math.max(...allTimes);
+    const tSpan = tMax - tMin || 1;
+
+    let vMin = Math.min(...allValues);
+    let vMax = Math.max(...allValues);
+    // Pad the Y domain 5% either side so lines at the extremes
+    // don't sit right on the frame.
+    const vPad = Math.max(50, Math.round((vMax - vMin) * 0.05));
+    vMin = Math.max(0, vMin - vPad);
+    vMax += vPad;
+    const vSpan = vMax - vMin || 1;
+
     const padX = 8;
-    const padY = 10;
+    const padY = 12;
     const usableW = width - padX * 2;
     const usableH = height - padY * 2;
+    const toX = (t) => padX + ((t - tMin) / tSpan) * usableW;
+    const toY = (v) => padY + (1 - (v - vMin) / vSpan) * usableH;
 
-    const tFirst = points[0].t;
-    const tLast = points[points.length - 1].t;
-    const tSpan = tLast - tFirst || 1;
+    const sourcePaths = [];
+    const sourceKeys = Object.keys(sources).sort();
+    sourceKeys.forEach((key, index) => {
+      sourcePaths.push({
+        key,
+        label: labelForSource(key),
+        color: colorForSource(key, index),
+        path: buildPath({ points: sources[key], toX, toY }),
+        first: sources[key][0]?.value ?? null,
+        last: sources[key][sources[key].length - 1]?.value ?? null,
+      });
+    });
 
-    let rMin = Infinity;
-    let rMax = -Infinity;
-    for (const p of points) {
-      if (p.rank < rMin) rMin = p.rank;
-      if (p.rank > rMax) rMax = p.rank;
-    }
-    // Give the plot 1 rank of headroom either side so a flat series
-    // doesn't collapse to a single horizontal line at the edge.
-    const rPad = Math.max(1, Math.round((rMax - rMin) * 0.1));
-    rMin = Math.max(1, rMin - rPad);
-    rMax += rPad;
-    const rSpan = rMax - rMin || 1;
-
-    const toX = (t) => padX + ((t - tFirst) / tSpan) * usableW;
-    // Invert Y: lower rank (better) renders at TOP of plot.
-    const toY = (r) => padY + ((r - rMin) / rSpan) * usableH;
-
-    const parts = points.map((p, i) => `${i === 0 ? "M" : "L"}${toX(p.t).toFixed(1)},${toY(p.rank).toFixed(1)}`);
-    const pathD = parts.join(" ");
-    const areaD = `${pathD} L${toX(tLast).toFixed(1)},${(height - padY).toFixed(1)} L${toX(tFirst).toFixed(1)},${(height - padY).toFixed(1)} Z`;
-
-    // Axis reference: the baseline (oldest) vs latest rank and the
-    // 30d / 90d midpoints.  We return the concrete (date, rank) pairs
-    // so the caller can show small tick labels next to them.
-    const latest = points[points.length - 1];
-    const pickBack = (days) => {
-      const cutoff = latest.t - days * 86_400_000;
-      let chosen = null;
-      for (const p of points) {
-        if (p.t >= cutoff) {
-          chosen = p;
-          break;
-        }
-      }
-      return chosen || points[0];
-    };
-    const back30 = pickBack(30);
-    const back90 = pickBack(90);
-    const back180 = points[0];
-    const delta30 = back30.rank - latest.rank;
-    const delta90 = back90.rank - latest.rank;
-    const delta180 = back180.rank - latest.rank;
+    const blendedPath = buildPath({ points: blended, toX, toY });
+    const blendedFirst = blended.find((p) => Number.isFinite(p.value) && p.value > 0);
+    const blendedLast = [...blended].reverse().find((p) => Number.isFinite(p.value) && p.value > 0);
+    const blendedDelta =
+      blendedFirst && blendedLast ? blendedLast.value - blendedFirst.value : 0;
+    const anyDerived = blended.some((p) => p.derived);
 
     return {
-      pathD,
-      areaD,
-      firstRank: points[0].rank,
-      lastRank: latest.rank,
-      minRank: rMin,
-      maxRank: rMax,
-      deltas: { d30: delta30, d90: delta90, d180: delta180 },
-      firstDate: points[0].date,
-      lastDate: latest.date,
+      blendedPath,
+      blendedDelta,
+      blendedFirst,
+      blendedLast,
+      anyDerived,
+      sourcePaths,
+      firstDate: state.dates[0] || null,
+      lastDate: state.dates[state.dates.length - 1] || null,
     };
-  }, [points, width, height]);
+  }, [state, width, height]);
 
   if (!row) return null;
 
-  if (loading && !geometry) {
-    return (
-      <div className="player-rank-chart player-rank-chart--loading" aria-busy="true">
-        Loading rank history…
-      </div>
-    );
+  if (state.loading && !geometry) {
+    return <div className="player-rank-chart player-rank-chart--loading">Loading value history…</div>;
   }
-  if (error) {
-    return (
-      <div className="player-rank-chart player-rank-chart--error" role="status">
-        Rank history unavailable.
-      </div>
-    );
+  if (state.error) {
+    return <div className="player-rank-chart player-rank-chart--error">Value history unavailable.</div>;
   }
   if (!geometry) {
     return (
-      <div className="player-rank-chart player-rank-chart--empty" role="status">
-        Not enough rank history yet (need at least two snapshots).
+      <div className="player-rank-chart player-rank-chart--empty">
+        Not enough value history yet (need at least two snapshots).
       </div>
     );
   }
 
-  const { pathD, areaD, firstRank, lastRank, deltas, firstDate, lastDate } = geometry;
-  const trend180 = deltas.d180; // positive = improved rank
-  const trendTone = trend180 > 0 ? "up" : trend180 < 0 ? "down" : "flat";
+  const { blendedPath, blendedDelta, blendedFirst, blendedLast, anyDerived, sourcePaths, firstDate, lastDate } = geometry;
+  const trendTone = blendedDelta > 0 ? "up" : blendedDelta < 0 ? "down" : "flat";
 
   return (
-    <div className="player-rank-chart" role="group" aria-label="Rank history over the last 180 days">
+    <div className="player-rank-chart" role="group" aria-label="Per-source value history over the last 180 days">
       <div className="player-rank-chart-head">
-        <span className="player-rank-chart-label">Rank history · 180d</span>
+        <span className="player-rank-chart-label">
+          Value history · 180d
+          {anyDerived && <span className="player-rank-chart-asterisk" title="Historical blended line is the median of per-source values — true blend started persisting on 2026-04-23"> *</span>}
+        </span>
         <span className={`player-rank-chart-delta player-rank-chart-delta--${trendTone}`}>
-          {trend180 === 0 ? "No change" : trend180 > 0 ? `▲ ${trend180} ranks better` : `▼ ${Math.abs(trend180)} ranks worse`}
+          {blendedDelta === 0
+            ? "No change"
+            : blendedDelta > 0
+            ? `▲ ${blendedDelta.toLocaleString()} value`
+            : `▼ ${Math.abs(blendedDelta).toLocaleString()} value`}
         </span>
       </div>
       <svg
@@ -229,32 +278,77 @@ export default function PlayerRankHistoryChart({
         focusable="false"
         preserveAspectRatio="none"
       >
-        <path d={areaD} fill={trend180 >= 0 ? "rgba(52, 211, 153, 0.15)" : "rgba(248, 113, 113, 0.15)"} />
-        <path
-          d={pathD}
-          fill="none"
-          stroke={trend180 >= 0 ? "var(--green)" : "var(--red)"}
-          strokeWidth={1.5}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
+        {/* Thin per-source lines first so the blended line overlays */}
+        {sourcePaths.map((s) => (
+          <path
+            key={s.key}
+            d={s.path}
+            fill="none"
+            stroke={s.color}
+            strokeWidth={1}
+            strokeOpacity={0.55}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ))}
+        {/* Bold blended line on top */}
+        {blendedPath && (
+          <path
+            d={blendedPath}
+            fill="none"
+            stroke={blendedDelta >= 0 ? "var(--green)" : "var(--red)"}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
       </svg>
       <div className="player-rank-chart-legend">
+        <span className="player-rank-chart-legend-blended">
+          <span
+            className="player-rank-chart-swatch"
+            style={{
+              background: blendedDelta >= 0 ? "var(--green)" : "var(--red)",
+              height: 3,
+            }}
+            aria-hidden="true"
+          />
+          <strong>Our blend</strong>
+          {blendedFirst && blendedLast && (
+            <span className="player-rank-chart-legend-range">
+              {blendedFirst.value.toLocaleString()} → {blendedLast.value.toLocaleString()}
+            </span>
+          )}
+        </span>
+        {sourcePaths.map((s) => (
+          <span key={s.key} className="player-rank-chart-legend-source">
+            <span
+              className="player-rank-chart-swatch"
+              style={{ background: s.color, opacity: 0.55 }}
+              aria-hidden="true"
+            />
+            <span>{s.label}</span>
+            {Number.isFinite(s.first) && Number.isFinite(s.last) && (
+              <span className="player-rank-chart-legend-range">
+                {s.first?.toLocaleString?.() ?? s.first} → {s.last?.toLocaleString?.() ?? s.last}
+              </span>
+            )}
+          </span>
+        ))}
+      </div>
+      <div className="player-rank-chart-footer">
         <span>
-          <strong>Then</strong> #{firstRank} ({firstDate})
+          <strong>Then</strong> {firstDate}
         </span>
         <span>
-          <strong>Now</strong> #{lastRank} ({lastDate})
+          <strong>Now</strong> {lastDate}
         </span>
-        <span>
-          30d {fmtSigned(deltas.d30)} · 90d {fmtSigned(deltas.d90)} · 180d {fmtSigned(deltas.d180)}
-        </span>
+        {anyDerived && (
+          <span className="player-rank-chart-note">
+            * Historical blend approximated from per-source median
+          </span>
+        )}
       </div>
     </div>
   );
-}
-
-function fmtSigned(v) {
-  if (!Number.isFinite(v) || v === 0) return "·";
-  return v > 0 ? `+${v}` : `${v}`;
 }

--- a/scripts/backfill_source_history.py
+++ b/scripts/backfill_source_history.py
@@ -1,0 +1,74 @@
+"""One-shot backfill for ``data/source_value_history.jsonl``.
+
+Mines every historical ``data/dynasty_data_*.json`` export and writes
+a per-source value snapshot per date.  Idempotent — re-running won't
+duplicate entries, and existing snapshots (from the live scrape loop)
+are preserved when newer than the export.
+
+Run:
+    python3 scripts/backfill_source_history.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.api import source_history  # noqa: E402
+
+DEFAULT_EXPORT_GLOB = "dynasty_data_*.json"
+DEFAULT_EXPORT_DIR = REPO_ROOT / "data"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dir",
+        default=str(DEFAULT_EXPORT_DIR),
+        help="Directory to scan for dynasty_data_*.json exports (default: data/).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Override output JSONL path.  Defaults to "
+            "src.api.source_history.HISTORY_PATH."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover and parse files but don't write the output.",
+    )
+    args = parser.parse_args()
+
+    export_dir = Path(args.dir)
+    if not export_dir.is_dir():
+        print(f"[backfill] {export_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    paths = sorted(export_dir.glob(DEFAULT_EXPORT_GLOB))
+    if not paths:
+        print(f"[backfill] no files matching {DEFAULT_EXPORT_GLOB} in {export_dir}")
+        return 1
+
+    print(f"[backfill] scanning {len(paths)} export files in {export_dir}")
+    if args.dry_run:
+        for p in paths:
+            print(f"  would ingest {p.name}")
+        return 0
+
+    output_path = Path(args.output) if args.output else None
+    written = source_history.backfill_from_exports(paths, path=output_path)
+    target = output_path or source_history.HISTORY_PATH
+    print(f"[backfill] wrote {written} snapshots into {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.py
+++ b/server.py
@@ -64,6 +64,7 @@ from src.api.data_contract import (
     validate_api_data_contract,
 )
 from src.api import rank_history as _rank_history
+from src.api import source_history as _source_history
 from src.news import NewsService, build_default_service
 
 # ── CONFIG ──────────────────────────────────────────────────────────────
@@ -995,6 +996,18 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         try:
             if is_fresh_scrape:
                 _rank_history.append_snapshot(contract_payload)
+                # Sister snapshot: per-source value history.  Stored in
+                # a separate JSONL so the rank-history log stays small
+                # and readable while the popup chart can stream a
+                # richer per-source series on demand.  Failures are
+                # isolated so a source-history write error doesn't
+                # nuke the rank-history append we just did.
+                try:
+                    _source_history.append_snapshot(contract_payload)
+                except Exception as inner_exc:  # noqa: BLE001
+                    log.warning(
+                        "source_history: append failed: %s", inner_exc,
+                    )
             stamped = _rank_history.stamp_contract_with_history(contract_payload)
             if stamped:
                 log.info("rank_history: stamped %d rows with history series", stamped)
@@ -1678,6 +1691,25 @@ async def lifespan(app: FastAPI):
     except Exception as exc:  # noqa: BLE001
         log.warning("public_league warmup failed at startup: %s", exc)
 
+    # Per-source value history backfill — if the snapshot log is
+    # missing or empty, mine the historical ``data/dynasty_data_*.json``
+    # exports so the PlayerPopup chart has ~28 days of per-source
+    # history on day one.  Skipped when the log already has entries
+    # (idempotent, safe to re-run).  Runs sync at boot because it's
+    # fast (<2s) and the data is needed before the first
+    # /api/data/player-source-history request lands.
+    try:
+        history_path = _source_history.HISTORY_PATH
+        needs_backfill = not history_path.exists() or history_path.stat().st_size == 0
+        if needs_backfill:
+            exports = sorted((DATA_DIR).glob("dynasty_data_*.json"))
+            if exports:
+                written = _source_history.backfill_from_exports(exports)
+                log.info("source_history: backfilled %d snapshots from %d exports",
+                         written, len(exports))
+    except Exception as exc:  # noqa: BLE001
+        log.warning("source_history: startup backfill failed: %s", exc)
+
     log.info(f"Server started — scraping every {SCRAPE_INTERVAL_HOURS}h")
     log.info("Frontend: Next.js at %s", FRONTEND_URL)
     log.info(f"Dashboard: http://localhost:{PORT}")
@@ -1826,6 +1858,48 @@ async def get_rank_history(request: Request):
     return JSONResponse(
         content={"days": days, "history": history},
         headers={"Cache-Control": "public, max-age=60, stale-while-revalidate=300"},
+    )
+
+
+@app.get("/api/data/player-source-history")
+async def get_player_source_history(request: Request):
+    """Per-source value history for a single player.
+
+    Returns the per-source and blended value timeline the PlayerPopup
+    chart renders as multiple overlaid lines — one thin line per
+    ranking source and one bold line for our blend.
+
+    Query params:
+      * ``name``        — player display name (required, case-insensitive)
+      * ``days``        — window in days (default 180, max 180)
+      * ``assetClass``  — optional disambiguator ("offense" / "idp" /
+                          "pick") for cross-universe name collisions
+    """
+    name = (request.query_params.get("name") or "").strip()
+    if not name:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "Missing required 'name' query param."},
+        )
+    try:
+        requested = int(request.query_params.get("days", _source_history.DEFAULT_HISTORY_WINDOW_DAYS))
+    except (TypeError, ValueError):
+        requested = _source_history.DEFAULT_HISTORY_WINDOW_DAYS
+    days = max(1, min(_source_history.MAX_SNAPSHOTS, requested))
+    asset_class = (request.query_params.get("assetClass") or "").strip() or None
+    history = _source_history.load_player_history(
+        name,
+        days=days,
+        asset_class=asset_class,
+    )
+    return JSONResponse(
+        content={
+            "name": name,
+            "days": days,
+            "assetClass": asset_class,
+            **history,
+        },
+        headers={"Cache-Control": "public, max-age=120, stale-while-revalidate=600"},
     )
 
 

--- a/src/api/source_history.py
+++ b/src/api/source_history.py
@@ -1,0 +1,440 @@
+"""Per-source value history persistence.
+
+Sister of ``src/api/rank_history.py``.  Where ``rank_history`` stores
+only the final blended consensus rank per player per day, this module
+stores **per-source values** so the frontend can render "how each
+source has valued this player over time" alongside "how the blend has
+moved".
+
+On-disk shape (``data/source_value_history.jsonl``)::
+
+    {
+      "date": "2026-04-23",
+      "players": {
+        "Malik Nabers::offense": {
+          "blended":     8154,
+          "blendedRank": 17,
+          "sources": {
+            "ktc":        7844,
+            "fp_sf":      8580,
+            "dynasty_nerds_sf_tep": 8632,
+            ...
+          }
+        },
+        ...
+      }
+    }
+
+Every source value is on the normalized 1-9999 scale (the
+``valueContribution`` field from ``sourceRankMeta`` when the blended
+contract is available, else ``canonicalSiteValues`` from the raw
+scrape).  Keeping sources on the same scale as the blended line lets
+the chart overlay them with a shared Y axis.
+
+Retention: mirrors ``rank_history`` at 180 daily snapshots.  One
+JSONL line per date, trimmed + deduped on append.
+
+Storage cost: ~12 sources × 1200 players × ~6 bytes ≈ 85 KB per
+snapshot.  180 days ≈ 15 MB on disk — trivial relative to the daily
+``dynasty_data_*.json`` exports at ~3-4 MB each.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+HISTORY_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "source_value_history.jsonl"
+MAX_SNAPSHOTS: int = 180
+DEFAULT_HISTORY_WINDOW_DAYS: int = 180
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+_OFFENSE_POSITIONS = frozenset({"QB", "RB", "WR", "TE"})
+_IDP_POSITIONS = frozenset(
+    {"DL", "DE", "DT", "EDGE", "NT", "LB", "OLB", "ILB", "MLB",
+     "DB", "CB", "S", "FS", "SS"}
+)
+
+
+def _infer_asset_class(row: dict[str, Any]) -> str:
+    """Mirror of ``rank_history._infer_asset_class`` — keep in sync so
+    player keys hash identically across both snapshot files and the
+    two histories can be joined by the same composite key.
+    """
+    asset = str(row.get("assetClass") or "").strip().lower()
+    if asset in ("offense", "idp", "pick"):
+        return asset
+    pos = str(row.get("position") or row.get("pos") or "").strip().upper()
+    if pos == "PICK":
+        return "pick"
+    if pos in _OFFENSE_POSITIONS:
+        return "offense"
+    if pos in _IDP_POSITIONS:
+        return "idp"
+    return "unknown"
+
+
+def _player_key(row: dict[str, Any]) -> str | None:
+    name = row.get("canonicalName") or row.get("displayName") or row.get("name")
+    if not name:
+        return None
+    return f"{name}::{_infer_asset_class(row)}"
+
+
+def _extract_player_entry(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull the per-player (blended, blendedRank, sources) triple.
+
+    Prefers ``sourceRankMeta[key].valueContribution`` (the normalized
+    1-9999 vote each source cast into the blend) because it's the
+    same number rendered as the chip bars in PlayerPopup.  Falls back
+    to ``canonicalSiteValues`` for legacy rows — the raw source scale
+    isn't normalized but it's the best we have.
+    """
+    if not isinstance(row, dict):
+        return None
+
+    blended = row.get("rankDerivedValue")
+    blended_rank = row.get("canonicalConsensusRank")
+
+    # Coerce numerics; the contract normally has them as ints but
+    # tolerate floats from legacy rows.
+    try:
+        blended_val = int(blended) if blended is not None else None
+    except (TypeError, ValueError):
+        blended_val = None
+    try:
+        blended_rank_val = int(blended_rank) if blended_rank is not None else None
+    except (TypeError, ValueError):
+        blended_rank_val = None
+
+    sources: dict[str, int] = {}
+    meta = row.get("sourceRankMeta")
+    if isinstance(meta, dict):
+        for key, entry in meta.items():
+            if not isinstance(entry, dict):
+                continue
+            contribution = entry.get("valueContribution")
+            try:
+                v = int(contribution) if contribution is not None else None
+            except (TypeError, ValueError):
+                v = None
+            if v is not None and v > 0:
+                sources[str(key)] = v
+    # Fallback: legacy ``canonicalSiteValues`` (raw per-source values).
+    # Not normalized but still useful for pre-contract-builder rows.
+    if not sources:
+        canonical = row.get("canonicalSiteValues") or row.get("_canonicalSiteValues")
+        if isinstance(canonical, dict):
+            for key, value in canonical.items():
+                try:
+                    v = int(value) if value is not None else None
+                except (TypeError, ValueError):
+                    v = None
+                if v is not None and v > 0:
+                    sources[str(key)] = v
+
+    if blended_val is None and blended_rank_val is None and not sources:
+        return None
+
+    entry: dict[str, Any] = {"sources": sources}
+    if blended_val is not None:
+        entry["blended"] = blended_val
+    if blended_rank_val is not None:
+        entry["blendedRank"] = blended_rank_val
+    return entry
+
+
+def _extract_all(contract: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return ``{playerKey: {blended, blendedRank, sources}}`` for every
+    row in the contract that has at least one source value stamped.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    arr = contract.get("playersArray")
+    if not isinstance(arr, list):
+        data = contract.get("data") or {}
+        arr = data.get("playersArray") if isinstance(data, dict) else None
+
+    if isinstance(arr, list):
+        for row in arr:
+            if not isinstance(row, dict):
+                continue
+            key = _player_key(row)
+            entry = _extract_player_entry(row)
+            if not key or not entry:
+                continue
+            out[key] = entry
+
+    # Also try the legacy ``players`` dict, keyed by display name —
+    # this is the path that backfill needs, since pre-contract-builder
+    # exports only have the dict.
+    if not out:
+        players = contract.get("players")
+        if isinstance(players, dict):
+            for name, row in players.items():
+                if not isinstance(row, dict):
+                    continue
+                scoped = {"displayName": name, **row}
+                key = _player_key(scoped)
+                entry = _extract_player_entry(scoped)
+                if not key or not entry:
+                    continue
+                out[key] = entry
+    return out
+
+
+def _read_lines(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for raw in f:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                entry = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(entry, dict):
+                out.append(entry)
+    return out
+
+
+def append_snapshot(
+    contract: dict[str, Any],
+    *,
+    date: str | None = None,
+    path: Path | None = None,
+    max_snapshots: int = MAX_SNAPSHOTS,
+) -> bool:
+    """Write today's per-source value snapshot, deduped per UTC date.
+
+    Returns True when a line was written, False when the contract
+    had no stampable rows.
+    """
+    path = path or HISTORY_PATH
+    players = _extract_all(contract)
+    if not players:
+        return False
+
+    date = date or _today_utc()
+    entry = {"date": date, "players": players}
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _read_lines(path)
+    existing = [e for e in existing if e.get("date") != date]
+    existing.append(entry)
+    existing.sort(key=lambda e: e.get("date") or "")
+    if len(existing) > max_snapshots:
+        existing = existing[-max_snapshots:]
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        for e in existing:
+            f.write(json.dumps(e, separators=(",", ":")) + "\n")
+    tmp.replace(path)
+    return True
+
+
+def _norm_name_key(raw_key: str) -> tuple[str, str]:
+    """``"Malik Nabers::offense"`` → ("malik nabers", "offense"). Split
+    is permissive — keys without ``::`` resolve to asset ``""``.
+    """
+    if "::" in raw_key:
+        name, asset = raw_key.split("::", 1)
+    else:
+        name, asset = raw_key, ""
+    return name.strip().lower(), asset.strip().lower()
+
+
+def _median(values: list[int | float]) -> float | None:
+    """Plain median — no numpy dep."""
+    xs = sorted(v for v in values if isinstance(v, (int, float)))
+    n = len(xs)
+    if n == 0:
+        return None
+    if n % 2 == 1:
+        return float(xs[n // 2])
+    return (xs[n // 2 - 1] + xs[n // 2]) / 2.0
+
+
+def load_player_history(
+    name: str,
+    *,
+    days: int = DEFAULT_HISTORY_WINDOW_DAYS,
+    asset_class: str | None = None,
+    path: Path | None = None,
+) -> dict[str, Any]:
+    """Return ``{dates, blended: [{date, value, rank, derived?}],
+    sources: {key: [{date, value}, ...]}}`` for a single player.
+
+    ``blended[].derived`` is ``True`` when the entry's ``value`` was
+    reconstructed from the median of per-source values (i.e. the
+    historical export pre-dated the contract-builder pipeline so no
+    true blended value was persisted).  The chart renders derived and
+    recorded points with the same stroke but lets the legend note the
+    reconstruction.
+
+    Case-insensitive name match.  When a name collides across asset
+    classes (rare — the scraper collapses offense/IDP same-names
+    upstream), pass ``asset_class`` to disambiguate.
+    """
+    path = path or HISTORY_PATH
+    entries = _read_lines(path)
+    if not entries:
+        return {"dates": [], "blended": [], "sources": {}}
+    entries.sort(key=lambda e: e.get("date") or "")
+    windowed = entries[-max(1, int(days)):]
+
+    needle = name.strip().lower()
+    asset = (asset_class or "").strip().lower()
+
+    dates: list[str] = []
+    blended: list[dict[str, Any]] = []
+    sources_accum: dict[str, list[dict[str, Any]]] = {}
+
+    for snap in windowed:
+        date = snap.get("date")
+        if not isinstance(date, str):
+            continue
+        players = snap.get("players") or {}
+        if not isinstance(players, dict):
+            continue
+        hit_key: str | None = None
+        for raw_key in players.keys():
+            n, a = _norm_name_key(raw_key)
+            if n != needle:
+                continue
+            if asset and a != asset:
+                continue
+            hit_key = raw_key
+            # Prefer an explicit asset-class match over asset="".
+            if asset:
+                break
+        if hit_key is None:
+            continue
+        entry = players.get(hit_key)
+        if not isinstance(entry, dict):
+            continue
+        dates.append(date)
+        bv = entry.get("blended")
+        br = entry.get("blendedRank")
+        sources = entry.get("sources") or {}
+
+        # If the snapshot is pre-contract-builder (no blended value
+        # persisted) derive an approximate blend from the median of
+        # per-source values.  The real pipeline uses a trimmed mean-
+        # median + MAD penalty + shrinkage — median alone is within
+        # ~5% for most players and tracks the right trend.
+        derived = False
+        value_out: int | None = None
+        if isinstance(bv, (int, float)):
+            value_out = int(bv)
+        elif isinstance(sources, dict) and sources:
+            numeric = [v for v in sources.values() if isinstance(v, (int, float)) and v > 0]
+            med = _median(numeric)
+            if med is not None:
+                value_out = int(round(med))
+                derived = True
+
+        blended.append({
+            "date": date,
+            "value": value_out,
+            "rank": int(br) if isinstance(br, (int, float)) else None,
+            "derived": derived,
+        })
+        if isinstance(sources, dict):
+            for key, value in sources.items():
+                try:
+                    v = int(value)
+                except (TypeError, ValueError):
+                    continue
+                sources_accum.setdefault(str(key), []).append({"date": date, "value": v})
+
+    return {"dates": dates, "blended": blended, "sources": sources_accum}
+
+
+def load_all_player_names(
+    *,
+    path: Path | None = None,
+    days: int = DEFAULT_HISTORY_WINDOW_DAYS,
+) -> list[str]:
+    """Return every distinct display name seen in the last ``days``
+    snapshots.  Useful for admin endpoints; not currently wired.
+    """
+    path = path or HISTORY_PATH
+    entries = _read_lines(path)[-max(1, int(days)):]
+    names: set[str] = set()
+    for snap in entries:
+        players = snap.get("players") or {}
+        if not isinstance(players, dict):
+            continue
+        for raw_key in players.keys():
+            n, _ = _norm_name_key(raw_key)
+            if n:
+                names.add(n)
+    return sorted(names)
+
+
+def backfill_from_exports(
+    export_paths: Iterable[Path],
+    *,
+    path: Path | None = None,
+    max_snapshots: int = MAX_SNAPSHOTS,
+) -> int:
+    """Rebuild the snapshot log from a set of ``dynasty_data_*.json``
+    exports.  Returns the number of snapshots written.
+
+    Each export file is expected to have a ``date`` field at the top
+    level (set by the scraper).  Duplicate dates are deduped; newest
+    export wins.
+    """
+    path = path or HISTORY_PATH
+    snapshots: dict[str, dict[str, Any]] = {}
+    for export_path in export_paths:
+        try:
+            with Path(export_path).open("r", encoding="utf-8") as f:
+                contract = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        date = contract.get("date")
+        if not isinstance(date, str):
+            # Fall back to parsing the filename stem: dynasty_data_YYYY-MM-DD.
+            stem = Path(export_path).stem
+            for token in stem.split("_"):
+                if len(token) == 10 and token[4] == "-" and token[7] == "-":
+                    date = token
+                    break
+        if not isinstance(date, str):
+            continue
+        players = _extract_all(contract)
+        if not players:
+            continue
+        snapshots[date] = {"date": date, "players": players}
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Merge with any existing lines so a partial backfill doesn't
+    # clobber days we've already persisted.
+    existing = _read_lines(path)
+    merged: dict[str, dict[str, Any]] = {}
+    for snap in existing:
+        d = snap.get("date")
+        if isinstance(d, str):
+            merged[d] = snap
+    for d, snap in snapshots.items():
+        merged[d] = snap
+    sorted_snaps = [merged[d] for d in sorted(merged.keys())]
+    if len(sorted_snaps) > max_snapshots:
+        sorted_snaps = sorted_snaps[-max_snapshots:]
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        for snap in sorted_snaps:
+            f.write(json.dumps(snap, separators=(",", ":")) + "\n")
+    tmp.replace(path)
+    return len(snapshots)

--- a/tests/api/test_source_history.py
+++ b/tests/api/test_source_history.py
@@ -1,0 +1,228 @@
+"""Tests for per-source value history persistence + backfill."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.api import source_history
+
+
+@pytest.fixture()
+def path(tmp_path):
+    return tmp_path / "source_value_history.jsonl"
+
+
+def _make_contract(players, *, date="2026-04-23"):
+    """Build a minimal contract with ``playersArray`` rows.  Each
+    player is given both ``sourceRankMeta.valueContribution`` and a
+    ``canonicalSiteValues`` fallback so tests cover both code paths.
+    """
+    arr = []
+    for entry in players:
+        row = {
+            "displayName": entry["name"],
+            "canonicalName": entry["name"],
+            "position": entry.get("pos", "WR"),
+            "assetClass": entry.get("assetClass", "offense"),
+            "rankDerivedValue": entry.get("blended"),
+            "canonicalConsensusRank": entry.get("rank"),
+        }
+        if "sources" in entry:
+            row["sourceRankMeta"] = {
+                k: {"valueContribution": v} for k, v in entry["sources"].items()
+            }
+        if "canonicalSites" in entry:
+            row["canonicalSiteValues"] = entry["canonicalSites"]
+        arr.append(row)
+    return {"date": date, "playersArray": arr}
+
+
+def test_append_then_load(path):
+    contract = _make_contract(
+        [
+            {
+                "name": "Malik Nabers",
+                "blended": 8154,
+                "rank": 17,
+                "sources": {"ktc": 7844, "fp_sf": 8580, "dlf_sf": 9720},
+            },
+        ],
+        date="2026-04-23",
+    )
+    assert source_history.append_snapshot(contract, path=path) is True
+
+    hist = source_history.load_player_history("Malik Nabers", path=path)
+    assert hist["dates"] == ["2026-04-23"]
+    assert hist["blended"][0]["value"] == 8154
+    assert hist["blended"][0]["rank"] == 17
+    assert hist["blended"][0]["derived"] is False
+    assert hist["sources"]["ktc"][0]["value"] == 7844
+    assert hist["sources"]["fp_sf"][0]["value"] == 8580
+
+
+def test_dedupe_same_date(path):
+    # Two writes on the same date — the second wins.
+    source_history.append_snapshot(
+        _make_contract([{"name": "A", "blended": 1000, "sources": {"ktc": 900}}], date="2026-04-23"),
+        path=path,
+    )
+    source_history.append_snapshot(
+        _make_contract([{"name": "A", "blended": 1200, "sources": {"ktc": 1100}}], date="2026-04-23"),
+        path=path,
+    )
+    hist = source_history.load_player_history("A", path=path)
+    assert len(hist["blended"]) == 1
+    assert hist["blended"][0]["value"] == 1200
+    assert hist["sources"]["ktc"][0]["value"] == 1100
+
+
+def test_multiple_dates_sorted(path):
+    # NOTE: ``append_snapshot`` uses ``_today_utc()`` when no ``date=``
+    # kwarg is passed (it never reads ``contract['date']`` — server.py
+    # relies on the wall clock).  Tests must pass ``date=`` explicitly
+    # to simulate historical writes.
+    source_history.append_snapshot(
+        _make_contract([{"name": "A", "blended": 1000, "sources": {"ktc": 900}}]),
+        date="2026-04-22",
+        path=path,
+    )
+    source_history.append_snapshot(
+        _make_contract([{"name": "A", "blended": 1050, "sources": {"ktc": 950}}]),
+        date="2026-04-23",
+        path=path,
+    )
+    source_history.append_snapshot(
+        _make_contract([{"name": "A", "blended": 1100, "sources": {"ktc": 1000}}]),
+        date="2026-04-24",
+        path=path,
+    )
+    hist = source_history.load_player_history("A", path=path)
+    assert hist["dates"] == ["2026-04-22", "2026-04-23", "2026-04-24"]
+    assert [e["value"] for e in hist["blended"]] == [1000, 1050, 1100]
+
+
+def test_retention_trims_to_max_snapshots(path):
+    # Simulate 200 DISTINCT dates, retention = 180.  Use a deterministic
+    # iteration that avoids the Jan/Feb modulo collision an earlier
+    # version of this test had.
+    from datetime import date as _date, timedelta
+    base = _date(2026, 1, 1)
+    for i in range(200):
+        d = (base + timedelta(days=i)).isoformat()
+        source_history.append_snapshot(
+            _make_contract([{"name": "A", "blended": 1000 + i, "sources": {"ktc": 900 + i}}]),
+            date=d,
+            path=path,
+            max_snapshots=180,
+        )
+    with path.open("r", encoding="utf-8") as f:
+        lines = [json.loads(l) for l in f if l.strip()]
+    assert len(lines) == 180
+
+
+def test_case_insensitive_name_lookup(path):
+    source_history.append_snapshot(
+        _make_contract([{"name": "Ja'Marr Chase", "blended": 9999, "sources": {"ktc": 9900}}], date="2026-04-23"),
+        path=path,
+    )
+    hist = source_history.load_player_history("ja'marr chase", path=path)
+    assert hist["blended"][0]["value"] == 9999
+    assert hist["sources"]["ktc"][0]["value"] == 9900
+
+
+def test_derived_blend_from_median_when_blended_missing(path):
+    # No ``rankDerivedValue`` on the row — loader should synthesize a
+    # blended entry from the per-source median.
+    contract = _make_contract(
+        [{"name": "X", "sources": {"ktc": 7000, "fp_sf": 7500, "dlf_sf": 8000}}],
+        date="2026-04-23",
+    )
+    # Strip the blended stamp.
+    for row in contract["playersArray"]:
+        row.pop("rankDerivedValue", None)
+    source_history.append_snapshot(contract, path=path)
+    hist = source_history.load_player_history("X", path=path)
+    assert hist["blended"][0]["derived"] is True
+    # Median of 7000/7500/8000 is 7500.
+    assert hist["blended"][0]["value"] == 7500
+
+
+def test_canonical_sites_fallback(path):
+    # Row has no sourceRankMeta, only canonicalSiteValues — the
+    # legacy export shape.
+    contract = _make_contract(
+        [{"name": "L", "canonicalSites": {"ktc": 8100, "fp_sf": 8400}}],
+        date="2026-04-23",
+    )
+    source_history.append_snapshot(contract, path=path)
+    hist = source_history.load_player_history("L", path=path)
+    assert hist["sources"]["ktc"][0]["value"] == 8100
+    assert hist["sources"]["fp_sf"][0]["value"] == 8400
+
+
+def test_asset_class_disambiguation(path):
+    # Two players with the same name, different asset classes — the
+    # composite key prevents collision.  ``asset_class`` param picks
+    # the one the caller wants.
+    contract = _make_contract(
+        [
+            {
+                "name": "James Williams",
+                "blended": 5000,
+                "assetClass": "offense",
+                "sources": {"ktc": 5200},
+            },
+            {
+                "name": "James Williams",
+                "blended": 3000,
+                "assetClass": "idp",
+                "sources": {"ktc": 3100},
+            },
+        ],
+        date="2026-04-23",
+    )
+    source_history.append_snapshot(contract, path=path)
+    off = source_history.load_player_history("James Williams", asset_class="offense", path=path)
+    idp = source_history.load_player_history("James Williams", asset_class="idp", path=path)
+    assert off["blended"][0]["value"] == 5000
+    assert idp["blended"][0]["value"] == 3000
+
+
+def test_missing_player_returns_empty(path):
+    source_history.append_snapshot(
+        _make_contract([{"name": "A", "blended": 1000, "sources": {"ktc": 900}}]),
+        path=path,
+    )
+    hist = source_history.load_player_history("Unknown", path=path)
+    assert hist["dates"] == []
+    assert hist["blended"] == []
+    assert hist["sources"] == {}
+
+
+def test_backfill_from_exports_merges_with_existing(tmp_path, path):
+    # Seed an existing snapshot for 2026-04-23 via the live path.
+    source_history.append_snapshot(
+        _make_contract([{"name": "A", "blended": 9999, "sources": {"ktc": 9000}}], date="2026-04-23"),
+        path=path,
+    )
+    # Now point backfill at a historical export dated earlier.
+    export = tmp_path / "dynasty_data_2026-04-20.json"
+    export.write_text(json.dumps({
+        "date": "2026-04-20",
+        "players": {"A": {"ktc": 8000, "dlfSf": 8500, "_canonicalSiteValues": {"ktc": 8000, "dlfSf": 8500}}},
+    }))
+
+    written = source_history.backfill_from_exports([export], path=path)
+    assert written == 1
+    hist = source_history.load_player_history("A", path=path)
+    dates = [b["date"] for b in hist["blended"]]
+    assert "2026-04-20" in dates
+    # Newer snapshot preserved verbatim.
+    latest = [b for b in hist["blended"] if b["date"] == "2026-04-23"][0]
+    assert latest["value"] == 9999
+
+
+def test_append_returns_false_for_empty_contract(path):
+    assert source_history.append_snapshot({"date": "2026-04-23", "playersArray": []}, path=path) is False
+    assert not path.exists() or path.read_text() == ""


### PR DESCRIPTION
## Summary

The PlayerPopup chart now shows how **every ranking source** has valued a player over the last 180 days — one thin colored line per source, with our **blended consensus** overlaid as a bold green/red line.

## Backend

- **New module** `src/api/source_history.py` — persists per-player `{blended, blendedRank, sources}` daily to `data/source_value_history.jsonl` (mirrors the existing `rank_history.jsonl` retention: 180 entries, atomic rename, deduped per date).
- **Wired into the scrape loop** — every fresh scrape now writes both logs. Source-history failures don't break rank-history.
- **Backfill script** `scripts/backfill_source_history.py` mines existing `dynasty_data_*.json` exports (28 days back to 2026-03-23) and seeds the log. `server.py` lifespan runs the backfill automatically at startup when the log is empty — idempotent, runs in ~1-2s, no manual step on deploy.
- **Historical blend synthesis** — dates that pre-date the contract-builder pipeline don't have `rankDerivedValue` stamped, so `load_player_history` fills the blended line from the per-source median and flags each entry with `derived: true`. The chart surfaces this with an asterisk + legend note.
- **New endpoint** `GET /api/data/player-source-history?name=...&days=180` — returns `{dates, blended:[{date,value,rank,derived}], sources:{key:[{date,value}]}}`. Cached 120s public, 600s SWR.

## Frontend

`PlayerRankHistoryChart` rewritten as a multi-series chart:
- One thin semi-transparent line per source (12-color palette, stable per-source assignment)
- Bold blended line on top, colored green/red by net delta
- Grid legend with each source's first → last value
- 120s cache per player name so re-opening a popup doesn't re-fetch

## Tests

- **11 new backend tests** in `tests/api/test_source_history.py` — append dedupe, retention trimming, case-insensitive lookup, asset-class disambiguation, `canonicalSites` fallback, median-derived blend, backfill merges with existing.
- **1942 Python tests pass** (was 1931), **664 frontend tests pass**, **build clean**.

## Test plan
- [ ] Open any player popup — see ~28 days of multi-source value lines with the blended line bold and prominent
- [ ] Verify the asterisk + "approximated from median" note appears for the chart (since historical blend is derived)
- [ ] After next scrape (~2h), confirm the blended line extends with a true (non-derived) point at today's date
- [ ] Restart backend after deploy, watch logs for `source_history: backfilled N snapshots from N exports`
- [ ] Hit `/api/data/player-source-history?name=Malik%20Nabers` directly and inspect the JSON shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)