### PR TITLE
fix: PlayerPopup scroll containment + body-scroll lock

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1047,6 +1047,28 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   overflow: hidden;
 }
 
+/*
+ * ``.picker-sheet--scrollable`` — opt-in scrollable body for popups
+ * whose content (charts, long source breakdowns, value chains) can
+ * exceed the 80dvh cap.  PlayerPopup uses this; GlobalSearch + the
+ * trade picker keep the default ``overflow: hidden`` because they
+ * manage their own inner scroll containers (result list, picker
+ * list).
+ *
+ * ``overscroll-behavior: contain`` stops the scroll from chaining to
+ * document.body when the user hits the top/bottom of the sheet, so a
+ * trackpad flick inside the popup can't smuggle into the page
+ * behind.  Paired with the body-scroll lock set by the popup
+ * component while it's mounted, this gives proper modal scroll
+ * isolation.
+ */
+.picker-sheet--scrollable {
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
 .picker-header {
   display: flex;
   justify-content: space-between;

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -152,12 +152,27 @@ function computeValueChain(row) {
 export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade }) {
   const [chainOpen, setChainOpen] = useState(false);
 
-  // Close on Escape
+  // Close on Escape + lock body scroll while open.
+  //
+  // Body-scroll lock: when the popup is open we set ``overflow:
+  // hidden`` on ``document.body`` so a user scrolling inside the
+  // popup doesn't accidentally drive the page behind.  On unmount
+  // (or when ``row`` flips back to null) we restore whatever was
+  // there before — reading the prior value rather than hard-coding
+  // "" avoids clobbering a parent component that might have set
+  // ``overflow: scroll`` for its own reasons.  Combined with
+  // ``overscroll-behavior: contain`` on the sheet in CSS, this
+  // fully isolates scrolling inside the popup.
   useEffect(() => {
     if (!row) return;
     function onKey(e) { if (e.key === "Escape") onClose?.(); }
     document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+    const priorOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = priorOverflow;
+    };
   }, [row, onClose]);
 
   // Reset the chain panel when switching players — the new row's
@@ -250,7 +265,7 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
   return (
     <div className="picker-overlay" onClick={onClose} style={{ zIndex: 1100 }}>
       <div
-        className="picker-sheet"
+        className="picker-sheet picker-sheet--scrollable"
         onClick={(e) => e.stopPropagation()}
         style={{ maxWidth: 520, width: "95vw" }}
       >


### PR DESCRIPTION
## Summary
When the player popup is open, scrolling inside the popup (trackpad flick, touch scroll, etc.) was driving the main page behind it instead of the popup content. And with the new 180-day chart + source breakdown, the popup content routinely overflows the 80dvh cap with no way to reach it.

## Fix
- New \`.picker-sheet--scrollable\` modifier: \`overflow-y: auto\` + \`overscroll-behavior: contain\`. PlayerPopup opts in; GlobalSearch and the trade picker keep the default (they manage their own inner scroll containers).
- PlayerPopup now pins \`document.body.style.overflow = 'hidden'\` while mounted and restores the prior value on unmount. Combined with \`overscroll-behavior: contain\`, scrolling is fully isolated inside the modal.

## Test plan
- [ ] Open any player popup, verify you can scroll the content inside the popup
- [ ] Try to scroll the background page while the popup is open — should do nothing
- [ ] Close the popup, verify page scroll is restored
- [ ] GlobalSearch + trade picker unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)