### PR TITLE
feat: terminal endpoint + user_kv hardening — resolve follow-up TODOs

### DIFF
--- a/frontend/components/terminal/PortfolioSummary.jsx
+++ b/frontend/components/terminal/PortfolioSummary.jsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useApp } from "@/components/AppShell";
 import { useTeam } from "@/components/useTeam";
 import { useRankHistory } from "@/components/useRankHistory";
+import { useTerminal } from "@/components/useTerminal";
 import { computePortfolio } from "@/lib/portfolio-insights";
 import Panel from "./Panel";
 
@@ -51,10 +52,41 @@ export default function PortfolioSummary() {
   const { selectedTeam } = useTeam();
   const { history, loading: historyLoading } = useRankHistory({ days: 30 });
 
-  const portfolio = useMemo(
+  // Server-side portfolio (aggregates + byPosition + byAge +
+  // volExposure + counters) when the /api/terminal call is
+  // authenticated and resolves a team.  Anonymous / un-resolved
+  // cases fall through to local ``computePortfolio`` which walks
+  // the same backend-stamped row values but does the grouping in
+  // the browser.
+  const { portfolio: serverPortfolio } = useTerminal({
+    ownerId: String(selectedTeam?.ownerId || ""),
+    teamName: selectedTeam?.name || "",
+    windowDays: 30,
+  });
+
+  const localPortfolio = useMemo(
     () => computePortfolio({ rows, selectedTeam, rawData, history }),
     [rows, selectedTeam, rawData, history],
   );
+
+  // Merge: prefer server-computed sub-sections when present; fall
+  // back to the local computation for starter/bench split and pick
+  // totals, which the server doesn't compute.  Every field the UI
+  // below reads (byPosition, byAge, volExposure, totalValue, etc.)
+  // comes from whichever source provided it first.
+  const portfolio = useMemo(() => {
+    if (!localPortfolio) return null;
+    if (!serverPortfolio) return localPortfolio;
+    return {
+      ...localPortfolio,
+      // Server fields override locals where both exist.
+      totalValue: serverPortfolio.totalValue ?? localPortfolio.totalValue,
+      byPosition: serverPortfolio.byPosition || localPortfolio.byPosition,
+      byAge: serverPortfolio.byAge || localPortfolio.byAge,
+      volExposure: serverPortfolio.volExposure || localPortfolio.volExposure,
+      medianAge: serverPortfolio.medianAge ?? localPortfolio.medianAge,
+    };
+  }, [serverPortfolio, localPortfolio]);
 
   if (!selectedTeam) {
     return (

--- a/frontend/components/terminal/ScoutingIntel.jsx
+++ b/frontend/components/terminal/ScoutingIntel.jsx
@@ -5,6 +5,7 @@ import { useApp } from "@/components/AppShell";
 import { useTeam } from "@/components/useTeam";
 import { useRankHistory } from "@/components/useRankHistory";
 import { useNews } from "@/components/useNews";
+import { useTerminal } from "@/components/useTerminal";
 import {
   computePortfolio,
   computeInsights,
@@ -58,21 +59,63 @@ export default function ScoutingIntel() {
   const rosterNames = selectedTeam?.players || [];
   const news = useNews({ rosterNames, leagueNames });
 
-  const portfolio = useMemo(
+  // Server-side portfolio + insights when available.  Authenticated
+  // users get ``serverPortfolio`` with pre-computed bestAsset /
+  // biggestRisk / tradeChip / buyLow + the breakdown fields
+  // (byPosition / byAge / volExposure / counters).  Anonymous
+  // requests or mid-refresh gaps fall through to the local
+  // ``computePortfolio`` + ``computeInsights`` below so the panel
+  // never renders a blank state waiting on the network.
+  const { portfolio: serverPortfolio } = useTerminal({
+    ownerId: String(selectedTeam?.ownerId || ""),
+    teamName: selectedTeam?.name || "",
+    windowDays: 30,
+  });
+
+  const localPortfolio = useMemo(
     () => computePortfolio({ rows, selectedTeam, rawData, history }),
     [rows, selectedTeam, rawData, history],
   );
 
-  const insights = useMemo(
-    () =>
-      computeInsights({
-        portfolio,
-        rows,
-        selectedTeam,
-        newsItems: news.scored,
-      }),
-    [portfolio, rows, selectedTeam, news.scored],
-  );
+  const portfolio = useMemo(() => {
+    if (!localPortfolio) return null;
+    if (!serverPortfolio) return localPortfolio;
+    return {
+      ...localPortfolio,
+      totalValue: serverPortfolio.totalValue ?? localPortfolio.totalValue,
+      byPosition: serverPortfolio.byPosition || localPortfolio.byPosition,
+      byAge: serverPortfolio.byAge || localPortfolio.byAge,
+      volExposure: serverPortfolio.volExposure || localPortfolio.volExposure,
+      medianAge: serverPortfolio.medianAge ?? localPortfolio.medianAge,
+    };
+  }, [serverPortfolio, localPortfolio]);
+
+  // Prefer server-computed insights (best asset / biggest risk /
+  // trade chip / buy-low); fall back to local ``computeInsights``
+  // when the server didn't provide them.
+  const insights = useMemo(() => {
+    if (
+      serverPortfolio &&
+      (serverPortfolio.bestAsset
+        || serverPortfolio.biggestRisk
+        || serverPortfolio.tradeChip
+        || serverPortfolio.buyLow)
+    ) {
+      return {
+        bestAsset: serverPortfolio.bestAsset || null,
+        biggestRisk: serverPortfolio.biggestRisk || null,
+        tradeChip: serverPortfolio.tradeChip || null,
+        buyLow: serverPortfolio.buyLow || null,
+        newsByPlayer: new Map(),
+      };
+    }
+    return computeInsights({
+      portfolio,
+      rows,
+      selectedTeam,
+      newsItems: news.scored,
+    });
+  }, [serverPortfolio, portfolio, rows, selectedTeam, news.scored]);
 
   const rosterChips = useMemo(
     () => computeRosterChips(portfolio),

--- a/frontend/components/useTerminal.js
+++ b/frontend/components/useTerminal.js
@@ -1,29 +1,35 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useTeam } from "@/components/useTeam";
 
 /**
- * useTerminal — consume the server-side aggregation endpoint.
+ * useTerminal — fetch the server-side terminal aggregation.
  *
- * Replaces the old pattern where every terminal panel reached into
- * useApp/useRankHistory/useNews independently and recomputed
- * valueFromRank, windowTrend, volatility, and signal rules
- * client-side.  The backend now computes all of that in one pass and
- * hands back a fully rendered payload.  The client just renders.
+ * Returns the /api/terminal payload for the given (ownerId,
+ * windowDays) combination.  Single-flighted + module-cached with a
+ * 30s TTL, so multiple components reading the same combination
+ * produce one network request.
  *
- * Request shape: ``GET /api/terminal?team=<ownerId>&teamName=<name>&windowDays=<N>``
+ * This hook is standalone — it does NOT depend on TerminalLayout or
+ * any React context — so any surface in the app can opt in to the
+ * server-computed portfolio / movers / signals without reshaping
+ * the component tree.
  *
- * Response shape: see ``src/api/terminal.py::build_terminal_payload``.
+ * The hook is auth-agnostic: an authenticated request returns the
+ * private payload (signals, portfolio, watchlist), an anonymous
+ * request returns the public slice (league + top150 movers + top-
+ * 150 news only).  The ``authenticated`` flag on the payload
+ * tells consumers which mode they got.
  *
- * Cache: 30s single-flight per (ownerId, windowDays) pair — multiple
- * panels mounting at once issue exactly one request per combination.
+ * Callers that want the private payload but are happy to fall back
+ * to local computation when the fetch 401s should inspect
+ * ``state.authenticated`` on the returned payload — when it's
+ * false, ``state.portfolio`` and ``state.signals`` will be null /
+ * empty and the caller should rely on its own fallback path.
  */
 
 const TTL_MS = 30_000;
-
-// Single-flight cache keyed by ``${ownerId}::${windowDays}``.
-const cache = new Map();   // key → { result, expires }
+const cache = new Map(); // key → { result, expires }
 const inflight = new Map(); // key → Promise
 
 function cacheKey({ ownerId, name, windowDays }) {
@@ -49,7 +55,9 @@ async function fetchTerminal({ ownerId, name, windowDays, signal }) {
     headers: { "Cache-Control": "no-store" },
   })
     .then(async (res) => {
-      if (!res.ok) throw new Error(`terminal ${res.status}`);
+      if (!res.ok && res.status !== 503) {
+        throw new Error(`terminal ${res.status}`);
+      }
       const data = await res.json();
       cache.set(key, { result: data, expires: Date.now() + TTL_MS });
       inflight.delete(key);
@@ -68,10 +76,13 @@ export function invalidateTerminalCache() {
   inflight.clear();
 }
 
-export function useTerminal({ windowDays = 30 } = {}) {
-  const { selectedTeam, loading: teamLoading } = useTeam();
-  const ownerId = selectedTeam?.ownerId || "";
-  const name = selectedTeam?.name || "";
+/**
+ * Read the terminal payload for a team (or the public slice if no
+ * ownerId is provided).  ``windowDays`` defaults to 30; callers can
+ * widen to 7/30/90/180 via the window selector in the Team Command
+ * Header.
+ */
+export function useTerminal({ ownerId = "", teamName = "", windowDays = 30 } = {}) {
   const [state, setState] = useState({
     loading: true,
     error: null,
@@ -87,10 +98,9 @@ export function useTerminal({ windowDays = 30 } = {}) {
   }, []);
 
   useEffect(() => {
-    if (teamLoading) return undefined;
     const controller = new AbortController();
     setState((prev) => ({ ...prev, loading: true, error: null }));
-    fetchTerminal({ ownerId, name, windowDays, signal: controller.signal })
+    fetchTerminal({ ownerId, name: teamName, windowDays, signal: controller.signal })
       .then((payload) => {
         if (!mounted.current) return;
         setState({ loading: false, error: null, payload });
@@ -105,40 +115,29 @@ export function useTerminal({ windowDays = 30 } = {}) {
         });
       });
     return () => controller.abort();
-  }, [ownerId, name, windowDays, teamLoading]);
+  }, [ownerId, teamName, windowDays]);
 
-  const {
-    team,
-    availableTeams,
-    teamAggregates,
-    movers,
-    signals,
-    portfolio,
-    news,
-    watchlist,
-    trendWindows,
-    meta,
-    generatedAt,
-  } = state.payload || {};
-
-  const value = useMemo(
-    () => ({
+  const value = useMemo(() => {
+    const p = state.payload || {};
+    return {
       loading: state.loading,
       error: state.error,
-      team: team || null,
-      availableTeams: availableTeams || [],
-      teamAggregates: teamAggregates || null,
-      movers: movers || { roster: [], league: [], top150: [] },
-      signals: signals || [],
-      portfolio: portfolio || null,
-      news: news || { items: [], count: 0 },
-      watchlist: watchlist || [],
-      trendWindows: trendWindows || [7, 30, 90, 180],
-      meta: meta || {},
-      generatedAt: generatedAt || null,
+      authenticated: !!p.authenticated,
+      stale: !!p.stale,
+      staleAs: p.staleAs || null,
+      team: p.team || null,
+      availableTeams: p.availableTeams || [],
+      teamAggregates: p.teamAggregates || null,
+      movers: p.movers || { roster: [], league: [], top150: [] },
+      signals: p.signals || [],
+      portfolio: p.portfolio || null,
+      news: p.news || { items: [], count: 0 },
+      watchlist: p.watchlist || [],
+      trendWindows: p.trendWindows || [7, 30, 90, 180],
+      meta: p.meta || {},
+      generatedAt: p.generatedAt || null,
       windowDays,
-    }),
-    [state, windowDays],
-  );
+    };
+  }, [state, windowDays]);
   return value;
 }

--- a/server.py
+++ b/server.py
@@ -65,6 +65,8 @@ from src.api.data_contract import (
 )
 from src.api import rank_history as _rank_history
 from src.api import source_history as _source_history
+from src.api import terminal as _terminal
+from src.api import user_kv as _user_kv
 from src.news import NewsService, build_default_service
 
 # ── CONFIG ──────────────────────────────────────────────────────────────
@@ -4130,6 +4132,288 @@ async def auth_logout_redirect(request: Request):
     response.delete_cookie(key=JASON_AUTH_COOKIE_NAME, path="/")
     return response
 
+
+# ── USER PREFERENCE PERSISTENCE (AUTH-GATED) ────────────────────────────
+# Durable per-user state that follows the authenticated session across
+# devices.  Backed by SQLite at ``data/user_kv.sqlite`` (see
+# ``src/api/user_kv.py``).  Anonymous requests get 401 — the frontend
+# hook falls back to a localStorage-only path when unauthenticated, so
+# a logged-out visitor still sees defaults without polluting the
+# shared store.
+
+@app.get("/api/user/state")
+async def get_user_state_api(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    state = await run_in_threadpool(_user_kv.get_user_state, username)
+    return JSONResponse(
+        content={"username": username, "state": state},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.put("/api/user/state")
+async def put_user_state_api(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"error": "invalid_body"})
+    patch: dict = {}
+    if "selectedTeam" in body:
+        sel = body.get("selectedTeam")
+        if sel is None:
+            patch["selectedTeam"] = None
+        elif isinstance(sel, dict):
+            patch["selectedTeam"] = {
+                "ownerId": str(sel.get("ownerId") or ""),
+                "name": str(sel.get("name") or ""),
+            }
+    if "watchlist" in body:
+        wl = body.get("watchlist")
+        if wl is None:
+            patch["watchlist"] = None
+        elif isinstance(wl, list):
+            patch["watchlist"] = [str(x) for x in wl if isinstance(x, (str, int))]
+    if "dismissedSignals" in body:
+        ds = body.get("dismissedSignals")
+        if ds is None:
+            patch["dismissedSignals"] = None
+        elif isinstance(ds, dict):
+            clean: dict[str, int] = {}
+            for k, v in ds.items():
+                try:
+                    clean[str(k)] = int(v)
+                except (TypeError, ValueError):
+                    continue
+            patch["dismissedSignals"] = clean
+    if "dismissalAliases" in body:
+        da = body.get("dismissalAliases")
+        if da is None:
+            patch["dismissalAliases"] = None
+        elif isinstance(da, dict):
+            patch["dismissalAliases"] = {
+                str(k): str(v) for k, v in da.items()
+                if isinstance(k, str) and isinstance(v, (str, int))
+            }
+    state = await run_in_threadpool(_user_kv.merge_user_state, username, patch)
+    return JSONResponse(
+        content={"username": username, "state": state},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.post("/api/user/signals/dismiss")
+async def dismiss_signal_api(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"error": "invalid_body"})
+    signal_key = str(body.get("signalKey") or "").strip()
+    if not signal_key:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "signalKey_required"},
+        )
+    try:
+        ttl_ms = int(body.get("ttlMs") or 7 * 24 * 3600 * 1000)
+    except (TypeError, ValueError):
+        ttl_ms = 7 * 24 * 3600 * 1000
+    alias_sid = str(body.get("aliasSleeperId") or "").strip() or None
+    alias_name = str(body.get("aliasDisplayName") or "").strip() or None
+    state = await run_in_threadpool(
+        _user_kv.dismiss_signal,
+        username,
+        signal_key,
+        ttl_ms=ttl_ms,
+        alias_sleeper_id=alias_sid,
+        alias_display_name=alias_name,
+    )
+    return JSONResponse(
+        content={"username": username, "state": state},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.post("/api/user/signals/restore")
+async def restore_signal_api(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"error": "invalid_body"})
+    signal_key = str(body.get("signalKey") or "").strip()
+    if not signal_key:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "signalKey_required"},
+        )
+    state = await run_in_threadpool(_user_kv.undismiss_signal, username, signal_key)
+    return JSONResponse(
+        content={"username": username, "state": state},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+# ── TERMINAL AGGREGATION ENDPOINT ───────────────────────────────────────
+#
+# Server-side aggregate of everything the landing page needs: team
+# aggregates, market movers, signals, news, portfolio.  See
+# ``src/api/terminal.py`` for the builder.  Two modes:
+#
+#   * Authenticated users get the full payload including signals,
+#     portfolio, watchlist, and roster-aware team aggregates.
+#   * Anonymous users get a public slice (league + top150 movers,
+#     news for top-150 players) — enough for an at-a-glance "market
+#     pulse" without leaking private identifiers or roster state.
+#
+# Availability:
+#   * When the live contract is loaded: serve the fresh aggregation.
+#   * When the live contract hasn't loaded yet (cold start): fall
+#     back to the most recent cached dynasty_data_*.json export
+#     from disk.  The frontend sees a ``stale: true`` flag and a
+#     ``staleAs`` date so it can surface "last good data from
+#     YYYY-MM-DD" instead of spinning forever.
+#   * If even the cached export is absent, surface a 503 with the
+#     same shape so the frontend error UI can render a coherent
+#     message.
+
+def _latest_cached_contract_from_disk() -> tuple[dict | None, str | None]:
+    """Return the most recent on-disk ``dynasty_data_*.json`` export
+    parsed as a contract, plus the date string it was stamped with.
+    Used when ``latest_contract_data`` hasn't been primed yet (cold
+    start between process-restart and first scrape).
+    """
+    try:
+        candidates = sorted(
+            DATA_DIR.glob("dynasty_data_*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return None, None
+    for candidate in candidates:
+        try:
+            with candidate.open("r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        # Older exports are pre-contract-builder and lack
+        # ``playersArray``; the terminal builder handles that path
+        # via the legacy dict, so we can still serve.
+        if not raw.get("players") and not raw.get("playersArray"):
+            continue
+        return raw, raw.get("date") or candidate.stem.replace("dynasty_data_", "")
+    return None, None
+
+
+@app.get("/api/terminal")
+async def get_terminal(request: Request):
+    session = _get_auth_session(request)
+    authed = bool(session)
+    username = str((session or {}).get("username") or "").strip() if authed else ""
+
+    contract = latest_contract_data
+    stale = False
+    stale_as = None
+    if not contract:
+        # 503 fallback (Item 3 from the TODO list): try the most
+        # recent cached export before giving up.
+        cached, cached_date = _latest_cached_contract_from_disk()
+        if cached:
+            contract = cached
+            stale = True
+            stale_as = cached_date
+        else:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "No data available yet. First scrape may still be running.",
+                    "stale": False,
+                },
+            )
+
+    params = request.query_params
+    team_owner_id = (params.get("team") or params.get("ownerId") or "").strip()
+    team_name = (params.get("teamName") or "").strip()
+    try:
+        window_days = int(params.get("windowDays") or 30)
+    except (TypeError, ValueError):
+        window_days = 30
+    window_days = max(7, min(180, window_days))
+
+    user_state: dict = {}
+    if authed and username:
+        try:
+            user_state = await run_in_threadpool(_user_kv.get_user_state, username)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("/api/terminal user_kv read failed: %s", exc)
+
+    resolved_team = None
+    if authed:
+        # Anonymous callers get the public slice even if they pass a
+        # ``team`` param — we never expose per-roster state without
+        # authentication.  ``resolved_team=None`` is enforced below.
+        resolved_team = _terminal.resolve_team(
+            contract, owner_id=team_owner_id, name=team_name,
+        )
+
+    try:
+        payload = await run_in_threadpool(
+            _terminal.build_terminal_payload,
+            contract,
+            resolved_team=resolved_team,
+            window_days=window_days,
+            news_items=_terminal.gather_news_items(
+                lambda: _get_news_service(),
+                _live_player_names(),
+                (resolved_team or {}).get("name") if resolved_team else None,
+            ),
+            user_state=user_state,
+            public_mode=not authed,
+        )
+    except Exception as exc:
+        log.exception("/api/terminal build failed: %s", exc)
+        return JSONResponse(
+            status_code=500,
+            content={"error": f"terminal_build_failed: {type(exc).__name__}"},
+        )
+
+    # Stale-data stamp: consumers can render a "last good data from
+    # YYYY-MM-DD" banner when the live scrape hasn't caught up.
+    payload["stale"] = stale
+    payload["staleAs"] = stale_as
+    payload["authenticated"] = authed
+
+    cache_control = (
+        "public, max-age=60, stale-while-revalidate=600"
+        if not authed
+        else "private, max-age=30, stale-while-revalidate=120"
+    )
+    return JSONResponse(
+        content=payload,
+        headers={"Cache-Control": cache_control},
+    )
 
 
 @app.api_route("/", methods=["GET", "HEAD"], response_class=HTMLResponse)

--- a/src/api/rank_history.py
+++ b/src/api/rank_history.py
@@ -49,10 +49,16 @@ from typing import Any, Iterable
 
 HISTORY_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "rank_history.jsonl"
 
-# Keep six months of daily scrapes.  At ~1,200 players × ~5 bytes per
-# rank-entry the on-disk footprint is ~1 MB — trivial, even if a
-# scrape runs more than once a day the trim keeps it bounded.
-MAX_SNAPSHOTS: int = 180
+# Retain three full calendar years of daily scrapes.  At ~1,200
+# players × ~5 bytes per rank-entry the per-snapshot footprint is
+# ~6 KB, so three years × 365 snapshots ≈ 6.5 MB on disk — still
+# trivial relative to the ~3-4 MB daily export.  The prior six-month
+# cap clipped any long-horizon study before it could start; tripling
+# retention lets callers compare a player's current rank to their
+# rank at the start of the previous league year without needing a
+# separate archive.  Callers that only need a short window still
+# pass ``days=30`` and read the tail slice.
+MAX_SNAPSHOTS: int = 365 * 3
 
 # Default sparkline window.  30 days is enough for a meaningful
 # trend line without dominating the rankings-row rendering footprint.

--- a/src/api/source_history.py
+++ b/src/api/source_history.py
@@ -46,7 +46,16 @@ from pathlib import Path
 from typing import Any, Iterable
 
 HISTORY_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "source_value_history.jsonl"
-MAX_SNAPSHOTS: int = 180
+# Mirror rank_history's three-year retention so the two logs stay in
+# lockstep; a per-source chart can render the same 3-year window the
+# blended rank chart can.  At ~85 KB per snapshot (1,200 players ×
+# 12 sources), three years ≈ 90 MB on disk — manageable.  The trim
+# happens on each append, so long-running deployments stay bounded.
+MAX_SNAPSHOTS: int = 365 * 3
+# Charts still open on a 180-day window by default — that's where
+# the "value history · 180d" callout comes from.  Callers that want
+# the full tail pass ``days=1095`` (or larger, clamped to
+# MAX_SNAPSHOTS server-side).
 DEFAULT_HISTORY_WINDOW_DAYS: int = 180
 
 

--- a/src/api/terminal.py
+++ b/src/api/terminal.py
@@ -283,42 +283,58 @@ def _reconstruct_roster_at(
     owner_id: str,
     current_players: list[str],
     cutoff_ms: int,
-) -> list[str]:
+) -> tuple[list[str], dict[str, Any]]:
     """Reverse-apply completed trades back to ``cutoff_ms``.
 
-    Returns the approximate roster player-name list at that historical
-    moment.  Uses ``sleeper.trades[]`` (already present in the live
-    contract, see ``Dynasty Scraper.py::roster_data["trades"]``).
-    Each trade carries ``sides[].{ownerId, got, gave}`` — applying
-    each trade AFTER ``cutoff_ms`` in reverse means:
+    Returns ``(roster_list, coverage_report)``.  The coverage report
+    has the shape::
+
+        {
+          "rosterAware":   bool,   # True iff ≥1 trade for this owner
+                                   # actually moved the roster
+          "tradesSeen":    int,    # total trades in window, any owner
+          "tradesApplied": int,    # trades that touched this owner
+          "reason":        str,    # one of "no_owner" / "no_trades" /
+                                   # "no_trades_for_owner" / "applied"
+        }
+
+    ``rosterAware: True`` ONLY when a trade actually un-did some of
+    the current roster.  The prior version set it True even when the
+    trades list was empty, which was a lie — a static-roster delta
+    dressed up as history-aware.  Now the frontend can render "delta
+    (static)" vs "delta (roster-aware)" honestly.
+
+    Uses ``sleeper.trades[]`` (already present in the live contract,
+    see ``Dynasty Scraper.py::roster_data["trades"]``).  Each trade
+    carries ``sides[].{ownerId, got, gave}`` — applying each trade
+    AFTER ``cutoff_ms`` in reverse means:
 
         * remove from roster items this owner GOT in that trade
         * add back items this owner GAVE away in that trade
-
-    Picks are ignored (they don't carry a rank-derived value in the
-    roster_now set — they go in a separate ``picks`` array), but
-    player names and canonical pick labels are ignored the same way:
-    if a name doesn't resolve to a row in the live contract, it's
-    silently dropped downstream.
 
     Cross-universe collisions (same name, different assetClass) are
     accepted as-is: the live contract's display-name index already
     collapses them, so a reconstruction using display names inherits
     the same collapse.
-
-    If ``sleeper.trades`` is missing or empty, we return
-    ``current_players`` verbatim — reconstructions equal to the
-    current roster produce deltas equal to the static-roster delta,
-    which is the pre-fix behaviour.  No harm, no silent error.
     """
+    coverage: dict[str, Any] = {
+        "rosterAware": False,
+        "tradesSeen": 0,
+        "tradesApplied": 0,
+        "reason": "applied",
+    }
     if not owner_id:
-        return list(current_players or [])
+        coverage["reason"] = "no_owner"
+        return list(current_players or []), coverage
     sleeper = contract.get("sleeper") or {}
     trades = sleeper.get("trades") or []
     if not isinstance(trades, list) or not trades:
-        return list(current_players or [])
+        coverage["reason"] = "no_trades"
+        return list(current_players or []), coverage
 
     roster = set(current_players or [])
+    seen = 0
+    applied = 0
     # Reverse-order iteration through completed trades, applying the
     # inverse: UNDO each trade for this owner back until we cross the
     # cutoff.  ``trades`` is already sorted newest-first in the
@@ -332,12 +348,13 @@ def _reconstruct_roster_at(
             continue
         if ts <= cutoff_ms:
             # This trade (and everything older) is OLDER than the
-            # requested cutoff — the roster after this trade is
-            # irrelevant; we've already walked past the cutoff.
+            # requested cutoff — we've already walked past the cutoff.
             break
+        seen += 1
         sides = tx.get("sides") or []
         if not isinstance(sides, list):
             continue
+        touched_this_owner = False
         for side in sides:
             if not isinstance(side, dict):
                 continue
@@ -345,14 +362,28 @@ def _reconstruct_roster_at(
                 continue
             got = side.get("got") or []
             gave = side.get("gave") or []
-            # Undo: remove what we received, add back what we gave.
             if isinstance(got, list):
                 for item in got:
                     roster.discard(str(item))
+                    touched_this_owner = touched_this_owner or bool(item)
             if isinstance(gave, list):
                 for item in gave:
                     roster.add(str(item))
-    return sorted(roster)
+                    touched_this_owner = touched_this_owner or bool(item)
+        if touched_this_owner:
+            applied += 1
+
+    coverage["tradesSeen"] = seen
+    coverage["tradesApplied"] = applied
+    coverage["rosterAware"] = applied > 0
+    if seen == 0:
+        coverage["reason"] = "no_trades"
+    elif applied == 0:
+        coverage["reason"] = "no_trades_for_owner"
+    return sorted(roster), coverage
+
+
+_MIN_COVERAGE_FOR_RELIABLE_SUM: float = 0.60
 
 
 def _sum_roster_value_at_date(
@@ -361,26 +392,44 @@ def _sum_roster_value_at_date(
     history_by_name: Callable[[str], list[dict[str, Any]]],
     date: str,
     row_index: dict[str, dict[str, Any]],
-) -> int | None:
+) -> dict[str, Any]:
     """Sum Hill-curve values of ``roster_names`` at the closest
     snapshot date ≤ ``date``.
 
-    Returns ``None`` if fewer than 60% of the roster had coverage
-    on/before the cutoff — an under-covered sum is worse than no
-    number at all (the UI prefers "—" to a lie).
+    Returns a dict::
+
+        {
+          "value":            int | None,  # sum; None when unreliable
+          "resolved":         int,         # players with ≥1 matching snapshot
+          "expected":         int,         # len(roster_names)
+          "coverageFraction": float,       # resolved / expected
+          "reliable":         bool,        # coverageFraction ≥ 0.60
+        }
+
+    The prior version returned a bare ``int | None``, which hid the
+    distinction between "no data at all" and "60%+ coverage, we
+    chose not to emit because the remaining players would have
+    biased the sum".  Exposing the coverage lets the frontend render
+    an explicit "insufficient history (32% coverage)" hint instead
+    of a silent "—".
     """
-    if not roster_names:
-        return None
+    expected = len(roster_names or [])
+    result: dict[str, Any] = {
+        "value": None,
+        "resolved": 0,
+        "expected": expected,
+        "coverageFraction": 0.0,
+        "reliable": False,
+    }
+    if expected == 0:
+        return result
+
     target = date
     resolved = 0
     total = 0
     for name in roster_names:
         points = history_by_name(name) or []
         if not points:
-            # Try the current live row as a sentinel: the frontend
-            # fallback was "use the latest row's rank if history
-            # missing", but that'd just reproduce the static-roster
-            # delta.  Drop the player instead.
             continue
         chosen = None
         for p in sorted(points, key=lambda x: x.get("date") or ""):
@@ -396,13 +445,16 @@ def _sum_roster_value_at_date(
             continue
         total += int(_rank_to_value(float(chosen)))
         resolved += 1
-    if resolved == 0:
-        return None
-    # Low-coverage guard: <60% coverage means the sum is a biased
-    # shadow of the real past roster.  Caller renders "—".
-    if resolved / max(1, len(roster_names)) < 0.6:
-        return None
-    return total
+
+    coverage = resolved / max(1, expected)
+    result["resolved"] = resolved
+    result["coverageFraction"] = round(coverage, 3)
+    result["reliable"] = coverage >= _MIN_COVERAGE_FOR_RELIABLE_SUM
+    # Low-coverage guard: under-covered sum is biased against missing
+    # players.  Leave ``value`` None so the UI surfaces the hint.
+    if result["reliable"]:
+        result["value"] = total
+    return result
 
 
 # ── MOVERS ──────────────────────────────────────────────────────────────
@@ -473,8 +525,20 @@ def _build_signal_context(
         confidence = float(confidence) if confidence is not None else None
     except (TypeError, ValueError):
         confidence = None
+    # Sleeper ID is a stable identifier across renames — every row
+    # in the contract carries either ``sleeperId`` (modern) or
+    # ``_sleeperId`` (legacy dict).  We surface both on the signal
+    # context so the frontend can maintain a rename-resistant
+    # dismissal alias map.
+    sleeper_id = (
+        row.get("sleeperId")
+        or row.get("_sleeperId")
+        or (row.get("raw") or {}).get("_sleeperId")
+        or ""
+    )
     return {
         "name": _row_name(row),
+        "sleeperId": str(sleeper_id) if sleeper_id else "",
         "pos": _normalize_pos(row.get("pos") or row.get("position")),
         "value": int(_row_value(row)),
         "rank": _row_rank(row),
@@ -576,8 +640,33 @@ def _signal_key(name: str, tag: str) -> str:
     follows the SIGNAL REASON, not just the player — if a player's
     signal flips from SELL/sustained_downtrend to RISK/alert_with_drop,
     they re-surface even if the first was dismissed.
+
+    Note: a player rename at the display-name layer would produce a
+    different ``name::tag`` key from the old one, so a dismissal
+    stored under the old name would silently fail to match.  The
+    terminal payload therefore emits an ``aliasSignalKey`` field
+    alongside the primary ``signalKey`` — keyed by Sleeper ID
+    instead of display name — and the frontend/user_kv alias map
+    lets it resolve dismissals across renames.  See
+    ``_signal_alias_key`` below.
     """
     return f"{str(name).strip()}::{str(tag).strip()}"
+
+
+def _signal_alias_key(sleeper_id: str, tag: str) -> str:
+    """Rename-resistant dismissal key: ``sid:<id>::tag``.
+
+    Emitted alongside the display-name ``signalKey`` so the user_kv
+    alias map can resolve a dismissal when a player's display name
+    changes between scrapes.  When ``sleeper_id`` is empty the alias
+    collapses to an empty string — the UI treats that as "only the
+    display-name key is available" and behaves identically to the
+    pre-alias path.
+    """
+    sid = str(sleeper_id or "").strip()
+    if not sid:
+        return ""
+    return f"sid:{sid}::{str(tag).strip()}"
 
 
 # ── PORTFOLIO INSIGHTS ──────────────────────────────────────────────────
@@ -704,6 +793,96 @@ def _compute_portfolio_insights(
             "metric": "short_drop_long_steady",
         }
 
+    # ── Sub-section breakdowns ────────────────────────────────────
+    # Match the client-side ``computePortfolio`` output so the
+    # PortfolioSummary + ScoutingIntel components can render off
+    # server-provided data without re-deriving anything locally.
+
+    def _age_bucket(age: Any, is_rookie: bool) -> str:
+        if is_rookie:
+            return "rookie"
+        try:
+            a = float(age) if age is not None else None
+        except (TypeError, ValueError):
+            a = None
+        if a is None or a <= 0:
+            return "unknown"
+        if a <= 22:
+            return "rookie"
+        if a <= 24:
+            return "young"
+        if a <= 28:
+            return "prime"
+        return "vet"
+
+    position_groups = ("QB", "RB", "WR", "TE", "K", "DEF", "IDP", "PICK")
+    by_position: dict[str, dict[str, Any]] = {
+        g: {"count": 0, "value": 0, "pct": 0.0} for g in position_groups
+    }
+    for p in rosterValues:
+        bucket = p["pos"] if p["pos"] in position_groups else None
+        if bucket:
+            by_position[bucket]["count"] += 1
+            by_position[bucket]["value"] += p["value"]
+    # Picks aren't part of ``rosterValues`` (picks handled separately
+    # in the contract), so ``PICK`` stays zero unless the caller pre-
+    # injects them — matching the client-side shape.
+    if totalValue:
+        for g in position_groups:
+            by_position[g]["pct"] = round(by_position[g]["value"] / totalValue * 100, 1)
+
+    by_age: dict[str, dict[str, Any]] = {
+        "rookie":  {"count": 0, "value": 0, "pct": 0.0},
+        "young":   {"count": 0, "value": 0, "pct": 0.0},
+        "prime":   {"count": 0, "value": 0, "pct": 0.0},
+        "vet":     {"count": 0, "value": 0, "pct": 0.0},
+        "unknown": {"count": 0, "value": 0, "pct": 0.0},
+    }
+    ages: list[float] = []
+    for p in rosterValues:
+        bucket = _age_bucket(p.get("age"), p.get("isRookie", False))
+        by_age[bucket]["count"] += 1
+        by_age[bucket]["value"] += p["value"]
+        try:
+            a = float(p.get("age")) if p.get("age") is not None else None
+        except (TypeError, ValueError):
+            a = None
+        if a is not None and a > 0:
+            ages.append(a)
+    if totalValue:
+        for k in by_age:
+            by_age[k]["pct"] = round(by_age[k]["value"] / totalValue * 100, 1)
+    ages.sort()
+    median_age = None
+    if ages:
+        mid = len(ages) // 2
+        median_age = (
+            ages[mid]
+            if len(ages) % 2 == 1
+            else round((ages[mid - 1] + ages[mid]) / 2.0, 1)
+        )
+
+    vol_exposure: dict[str, dict[str, Any]] = {
+        "low":     {"count": 0, "value": 0, "pct": 0.0},
+        "med":     {"count": 0, "value": 0, "pct": 0.0},
+        "high":    {"count": 0, "value": 0, "pct": 0.0},
+        "unknown": {"count": 0, "value": 0, "pct": 0.0},
+    }
+    for p in rosterValues:
+        lbl = p.get("volLabel") or "unknown"
+        if lbl not in vol_exposure:
+            lbl = "unknown"
+        vol_exposure[lbl]["count"] += 1
+        vol_exposure[lbl]["value"] += p["value"]
+    if totalValue:
+        for k in vol_exposure:
+            vol_exposure[k]["pct"] = round(vol_exposure[k]["value"] / totalValue * 100, 1)
+
+    # Rising / falling / high-vol counters — for the roster-chip row.
+    rising = sum(1 for p in rosterValues if (p["trend7"] or 0) >= 3)
+    falling = sum(1 for p in rosterValues if (p["trend7"] or 0) <= -3)
+    high_vol = vol_exposure["high"]["count"]
+
     return {
         "totalValue": totalValue,
         "rosterValues": rosterValues,
@@ -711,6 +890,18 @@ def _compute_portfolio_insights(
         "biggestRisk": risk,
         "tradeChip": tradeChip,
         "buyLow": buyLow,
+        # Sub-section breakdowns now computed server-side so
+        # PortfolioSummary / ScoutingIntel can render without
+        # recomputing locally.
+        "byPosition": by_position,
+        "byAge": by_age,
+        "volExposure": vol_exposure,
+        "medianAge": median_age,
+        "counters": {
+            "rising": rising,
+            "falling": falling,
+            "highVol": high_vol,
+        },
     }
 
 
@@ -751,6 +942,7 @@ def build_terminal_payload(
     news_items: list[dict[str, Any]] | None = None,
     user_state: dict[str, Any] | None = None,
     history_window_days: int | None = None,
+    public_mode: bool = False,
 ) -> dict[str, Any]:
     """Assemble the full landing-page payload.
 
@@ -873,12 +1065,29 @@ def build_terminal_payload(
         teamAggregates["coverage"] = round(coverage, 3)
 
         # Roster-aware deltas for 7 / 30 / 90 / 180.
+        #
+        # Each delta carries both the numeric value and a coverage
+        # block so the UI can distinguish:
+        #   * value=int, rosterAware=True    — clean window, backed
+        #     by trades
+        #   * value=int, rosterAware=False   — clean window but no
+        #     trades fell inside it (static-roster delta)
+        #   * value=None, reason="low_history_coverage" — the past
+        #     snapshot had fewer than 60% of the roster with
+        #     matching rank history; UI renders "—"
+        #
+        # ``delta*d`` is ``int | None`` for backwards compat with
+        # the pre-coverage consumers; the full block is exposed on
+        # ``delta*dDetail``.
         latest_date = _latest_snapshot_date(history)
+        teamAggregates["rosterAware"] = False
         if latest_date and total > 0:
-            def _delta(days: int) -> int | None:
+            any_roster_aware = False
+
+            def _delta(days: int) -> dict[str, Any]:
                 past_date = _back_iso_date(latest_date, days)
                 past_ms = _iso_date_to_ms(past_date)
-                past_roster = _reconstruct_roster_at(
+                past_roster, roster_coverage = _reconstruct_roster_at(
                     contract,
                     owner_id=owner_id,
                     current_players=current_players,
@@ -890,14 +1099,28 @@ def build_terminal_payload(
                     date=past_date,
                     row_index=row_index,
                 )
-                if past_total is None:
-                    return None
-                return total - past_total
+                value = past_total["value"]
+                return {
+                    "value": (total - value) if value is not None else None,
+                    "coverageFraction": past_total["coverageFraction"],
+                    "resolved": past_total["resolved"],
+                    "expected": past_total["expected"],
+                    "reliable": past_total["reliable"],
+                    "rosterAware": roster_coverage["rosterAware"],
+                    "tradesSeen": roster_coverage["tradesSeen"],
+                    "tradesApplied": roster_coverage["tradesApplied"],
+                    "reason": roster_coverage["reason"] if value is not None
+                              else "low_history_coverage",
+                    "pastDate": past_date,
+                }
 
-            teamAggregates["delta7d"] = _delta(7)
-            teamAggregates["delta30d"] = _delta(30)
-            teamAggregates["delta90d"] = _delta(90)
-            teamAggregates["delta180d"] = _delta(180)
+            for days in (7, 30, 90, 180):
+                detail = _delta(days)
+                teamAggregates[f"delta{days}d"] = detail["value"]
+                teamAggregates[f"delta{days}dDetail"] = detail
+                if detail["rosterAware"]:
+                    any_roster_aware = True
+            teamAggregates["rosterAware"] = any_roster_aware
 
         # Signals for each roster player.
         for r in roster_rows:
@@ -905,8 +1128,17 @@ def build_terminal_payload(
             player_news = news_by_player.get(_row_name(r).lower(), [])
             ctx = _build_signal_context(r, points=points, news_for_player=player_news)
             verdict = _evaluate_signal(ctx)
-            skey = _signal_key(ctx["name"], verdict.get("tag") or "unknown")
+            tag = verdict.get("tag") or "unknown"
+            skey = _signal_key(ctx["name"], tag)
+            alias_key = _signal_alias_key(ctx.get("sleeperId", ""), tag)
+            # Resolve dismissal via either the display-name key or
+            # the Sleeper-ID alias key — whichever matches wins.  A
+            # legacy dismissal stored under the old display-name key
+            # keeps applying even after a rename, because the alias
+            # key still matches by sleeperId.
             dismissed_until = active_dismissals.get(skey)
+            if dismissed_until is None and alias_key:
+                dismissed_until = active_dismissals.get(alias_key)
             entry = {
                 **ctx,
                 "signal": verdict["signal"],
@@ -914,6 +1146,7 @@ def build_terminal_payload(
                 "tag": verdict["tag"],
                 "fired": verdict["fired"],
                 "signalKey": skey,
+                "aliasSignalKey": alias_key,
                 "dismissedUntil": dismissed_until,
                 "dismissed": bool(dismissed_until),
             }
@@ -1001,8 +1234,38 @@ def build_terminal_payload(
         "meta": {
             "historyWindowDays": history_window_days,
             "historyPlayerCount": len(history) if isinstance(history, dict) else 0,
+            "publicMode": bool(public_mode),
         },
     }
+    if public_mode:
+        # Strip everything that requires an authenticated identity:
+        #   * no team — public visitors don't have a selection
+        #   * no signals / portfolio / watchlist — those are all
+        #     private per-roster
+        #   * no roster movers — the league ownership is private too
+        #   * keep: league + top150 movers, news (scoped by public
+        #     relevance), availableTeams (identity-free metadata),
+        #     trendWindows, contract meta
+        # The frontend treats this as "public terminal" and falls
+        # back to a condensed layout without the roster rails.
+        payload["team"] = None
+        payload["signals"] = []
+        payload["portfolio"] = None
+        payload["watchlist"] = []
+        payload["teamAggregates"] = {
+            "totalValue": None,
+            "delta7d": None, "delta30d": None, "delta90d": None, "delta180d": None,
+            "rosterAware": False,
+            "tiers": None,
+            "rosterCount": 0,
+            "coverage": None,
+        }
+        payload["movers"]["roster"] = []
+        # News coverage in public mode is "top-150 only" — roster
+        # scoping needed an authenticated roster set.
+        payload["news"]["items"] = [
+            n for n in payload["news"]["items"] if (n.get("relevance") or 0) < 100
+        ]
     return payload
 
 

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -1,56 +1,82 @@
-"""User-level key/value persistence layer.
+"""User-level key/value persistence layer (SQLite-backed).
 
-A tiny, file-backed durable store keyed by authenticated username.
-Replaces scattered ``localStorage`` usage for state that should
-follow the user across devices and sessions:
+A tiny durable store keyed by authenticated username.  Replaces
+scattered ``localStorage`` usage for state that should follow the
+user across devices and sessions:
 
-* ``selectedTeam``      — stable team identity (ownerId + name mirror)
-* ``watchlist``         — array of player canonical names to watch
-* ``dismissedSignals``  — ``{signalKey: expiresAtEpochMs}`` map;
-                          entries older than now are auto-pruned on read
+* ``selectedTeam``       — stable team identity (ownerId + name mirror)
+* ``watchlist``          — array of player canonical names to watch
+* ``dismissedSignals``   — ``{signalKey: expiresAtEpochMs}`` map;
+                           entries older than now are auto-pruned on read
+* ``dismissalAliases``   — ``{displayName: sleeperId}`` records the
+                           sleeperId that was active at the moment a
+                           signal was dismissed, so a later rename of
+                           the player doesn't silently break the
+                           dismissal (the UI can re-associate by
+                           sleeperId).
 
-Storage model
-─────────────
-Single JSON file at ``data/user_kv.json`` with shape::
+Storage
+───────
+Single SQLite database at ``data/user_kv.sqlite``.  One row per
+authenticated user; the full state blob is serialised as JSON in a
+``state_json`` column plus an ``updated_at`` timestamp for
+administration.
 
-    {
-      "<username>": {
-        "selectedTeam":    {"ownerId": "...", "name": "..."},
-        "watchlist":       ["Ja'Marr Chase", ...],
-        "dismissedSignals": {"<signalKey>": 1711234567890, ...},
-        "updatedAt":       "2026-04-23T14:02:11Z"
-      },
-      ...
-    }
+SQLite picks up three wins over the prior single-JSON-file store:
 
-Writes are atomic (temp file + rename).  The whole file is loaded on
-each call — acceptable because the expected population is small
-(tens of users, not thousands) and this avoids a database dependency
-for what amounts to a preferences blob.
+1. **Concurrent writes** — the DB serialises via its own locks; a
+   burst of hooks firing simultaneously (e.g. many users dismissing
+   signals at once) no longer races at the file-rename layer.
+2. **Crash durability** — the prior store rewrote the whole file on
+   every write; a process crash mid-write could truncate the file,
+   and the corrupt-file handler (silently start fresh) discards
+   every user's state.  SQLite's WAL + fsync-on-commit preserves
+   partial writes cleanly.
+3. **Row-level reads** — ``get_user_state(user)`` no longer loads
+   every user's blob into memory just to read one; it reads the one
+   row it needs.
 
-All mutations pass through ``_read_all`` → mutate → ``_write_all``
-so concurrent writers race at the file-rename layer, which is
-atomic on POSIX.  No locking is needed for the current scale; if
-contention becomes an issue the whole module can drop behind an
-asyncio.Lock held at the FastAPI layer.
+Schema::
 
-Known fields are namespaced on read (anything we do not recognise is
-preserved verbatim — we never clobber unknown keys that a future
-client may have written but the current server doesn't understand).
+    CREATE TABLE user_state (
+      username    TEXT PRIMARY KEY,
+      state_json  TEXT NOT NULL,
+      updated_at  TEXT NOT NULL
+    );
+
+All public call-sites take the same arguments as the prior JSON-
+backed module; the migration is a pure drop-in.  Legacy
+``data/user_kv.json`` files are imported once on first boot (see
+``_migrate_legacy_json_if_present``).
 """
 from __future__ import annotations
 
 import json
+import sqlite3
 import time
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-USER_KV_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "user_kv.json"
+USER_KV_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "user_kv.sqlite"
+_LEGACY_JSON_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "user_kv.json"
 
 # Known top-level keys we understand.  Anything else in a user's
 # record is preserved but not validated.
-KNOWN_KEYS = frozenset({"selectedTeam", "watchlist", "dismissedSignals", "updatedAt"})
+KNOWN_KEYS = frozenset({
+    "selectedTeam",
+    "watchlist",
+    "dismissedSignals",
+    "dismissalAliases",
+    "updatedAt",
+})
+
+# Process-wide lock around connection setup / migration so module
+# import is thread-safe.  SQLite itself handles per-transaction
+# locking.
+_SETUP_LOCK = threading.Lock()
+_SETUP_DONE: dict[str, bool] = {}
 
 
 def _utc_now_iso() -> str:
@@ -61,31 +87,125 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
-def _read_all(path: Path | None = None) -> dict[str, dict[str, Any]]:
-    path = path or USER_KV_PATH
-    if not path.exists():
-        return {}
-    try:
-        with path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-        if isinstance(data, dict):
-            return {str(k): (v if isinstance(v, dict) else {}) for k, v in data.items()}
-    except (json.JSONDecodeError, OSError):
-        # Corrupt file: start fresh rather than 500'ing every request.
-        # The alternative (refusing writes until a human repairs it)
-        # would silently brick every authenticated surface — worse UX
-        # than starting empty.
-        return {}
-    return {}
-
-
-def _write_all(store: dict[str, dict[str, Any]], path: Path | None = None) -> None:
+def _connect(path: Path | None = None) -> sqlite3.Connection:
     path = path or USER_KV_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as f:
-        json.dump(store, f, ensure_ascii=False, separators=(",", ":"))
-    tmp.replace(path)
+    _ensure_schema(path)
+    # ``isolation_level=None`` + manual BEGIN/COMMIT would give us
+    # explicit control, but for this blob-per-user workload the
+    # default deferred-transaction mode is fine and simpler.  WAL
+    # mode is set in ``_ensure_schema`` once per file.
+    return sqlite3.connect(str(path), timeout=5.0)
+
+
+def _ensure_schema(path: Path) -> None:
+    """Create the schema + apply SQLite pragmas.  Idempotent.
+
+    If the path already exists but isn't a valid SQLite database
+    (e.g. a stray JSON blob or leftover text file), we rename it to
+    ``<name>.corrupt`` and start fresh.  Matches the JSON-store
+    era's "corrupt → start fresh" behaviour: a broken store must
+    not brick every authenticated surface.
+    """
+    key = str(path)
+    if _SETUP_DONE.get(key):
+        return
+    with _SETUP_LOCK:
+        if _SETUP_DONE.get(key):
+            return
+        _open_or_reset(path)
+        _migrate_legacy_json_if_present(path)
+        _SETUP_DONE[key] = True
+
+
+def _open_or_reset(path: Path) -> None:
+    def _apply_schema(conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_state (
+              username   TEXT PRIMARY KEY,
+              state_json TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+    conn = sqlite3.connect(str(path), timeout=5.0)
+    try:
+        _apply_schema(conn)
+        return
+    except sqlite3.DatabaseError:
+        conn.close()
+        # The file exists but isn't valid SQLite — most likely a
+        # leftover JSON store or a text file someone dropped into
+        # ``data/``.  Rename it and rebuild.
+        if path.exists():
+            try:
+                path.rename(path.with_suffix(path.suffix + ".corrupt"))
+            except OSError:
+                path.unlink(missing_ok=True)
+        conn = sqlite3.connect(str(path), timeout=5.0)
+        try:
+            _apply_schema(conn)
+        finally:
+            conn.close()
+        return
+    finally:
+        try:
+            conn.close()
+        except sqlite3.ProgrammingError:
+            pass
+
+
+def _migrate_legacy_json_if_present(path: Path) -> None:
+    """One-shot migration from the pre-SQLite JSON store.
+
+    If ``data/user_kv.json`` exists, read it, insert every user row
+    into the SQLite DB (skipping users that already exist — the DB
+    wins on conflict), and rename the legacy file to ``.migrated``
+    so a second boot is a no-op.  Failures here are silent-and-
+    logged: a broken migration shouldn't brick authenticated
+    surfaces, and the legacy file is left in place so an operator
+    can inspect it.
+    """
+    if not _LEGACY_JSON_PATH.exists():
+        return
+    if path != USER_KV_PATH:
+        # Test paths don't share the legacy file — only migrate on
+        # the real production location.
+        return
+    try:
+        with _LEGACY_JSON_PATH.open("r", encoding="utf-8") as f:
+            legacy = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(legacy, dict):
+        return
+
+    conn = sqlite3.connect(str(path), timeout=5.0)
+    try:
+        for username, state in legacy.items():
+            if not isinstance(username, str) or not isinstance(state, dict):
+                continue
+            state_json = json.dumps(state, separators=(",", ":"), ensure_ascii=False)
+            conn.execute(
+                "INSERT OR IGNORE INTO user_state (username, state_json, updated_at) "
+                "VALUES (?, ?, ?)",
+                (username, state_json, state.get("updatedAt") or _utc_now_iso()),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Rename rather than delete so an operator can inspect in case
+    # of a bad migration.
+    try:
+        _LEGACY_JSON_PATH.rename(_LEGACY_JSON_PATH.with_suffix(".json.migrated"))
+    except OSError:
+        pass
 
 
 def _prune_expired_dismissals(entry: dict[str, Any]) -> bool:
@@ -115,6 +235,34 @@ def _prune_expired_dismissals(entry: dict[str, Any]) -> bool:
     return pruned
 
 
+def _read_row(conn: sqlite3.Connection, username: str) -> dict[str, Any]:
+    cursor = conn.execute(
+        "SELECT state_json FROM user_state WHERE username = ?",
+        (username,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return {}
+    try:
+        parsed = json.loads(row[0])
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _write_row(conn: sqlite3.Connection, username: str, entry: dict[str, Any]) -> None:
+    entry["updatedAt"] = _utc_now_iso()
+    state_json = json.dumps(entry, separators=(",", ":"), ensure_ascii=False)
+    conn.execute(
+        "INSERT INTO user_state (username, state_json, updated_at) "
+        "VALUES (?, ?, ?) "
+        "ON CONFLICT(username) DO UPDATE SET "
+        "state_json=excluded.state_json, updated_at=excluded.updated_at",
+        (username, state_json, entry["updatedAt"]),
+    )
+    conn.commit()
+
+
 def get_user_state(username: str, *, path: Path | None = None) -> dict[str, Any]:
     """Return the full state blob for ``username``.
 
@@ -127,19 +275,21 @@ def get_user_state(username: str, *, path: Path | None = None) -> dict[str, Any]
     """
     if not username:
         return {}
-    store = _read_all(path)
-    entry = store.get(username)
-    if not isinstance(entry, dict):
-        return {}
-    if _prune_expired_dismissals(entry):
-        store[username] = entry
-        try:
-            _write_all(store, path)
-        except OSError:
-            # Non-fatal: the read path returns the pruned in-memory
-            # view; the next successful write will re-persist.
-            pass
-    return dict(entry)
+    conn = _connect(path)
+    try:
+        entry = _read_row(conn, username)
+        if not entry:
+            return {}
+        if _prune_expired_dismissals(entry):
+            try:
+                _write_row(conn, username, entry)
+            except sqlite3.Error:
+                # Non-fatal: the read path returns the pruned in-
+                # memory view; the next successful write persists.
+                pass
+        return dict(entry)
+    finally:
+        conn.close()
 
 
 def set_user_field(
@@ -152,24 +302,20 @@ def set_user_field(
     """Write a single top-level field for ``username``.
 
     Returns the post-write state blob so callers can echo the server
-    view back to the client (useful for the initial hydration round-
-    trip).  Unknown keys are accepted and preserved verbatim — future
-    clients may rely on them.
+    view back to the client.  Unknown keys are accepted and preserved
+    verbatim — future clients may rely on them.
     """
     if not username:
         return {}
-    store = _read_all(path)
-    entry = store.get(username)
-    if not isinstance(entry, dict):
-        entry = {}
-    entry[str(field)] = value
-    entry["updatedAt"] = _utc_now_iso()
-    # Pruning happens here too so a write doesn't preserve stale
-    # dismissals into the next read.
-    _prune_expired_dismissals(entry)
-    store[username] = entry
-    _write_all(store, path)
-    return dict(entry)
+    conn = _connect(path)
+    try:
+        entry = _read_row(conn, username)
+        entry[str(field)] = value
+        _prune_expired_dismissals(entry)
+        _write_row(conn, username, entry)
+        return dict(entry)
+    finally:
+        conn.close()
 
 
 def merge_user_state(
@@ -183,33 +329,42 @@ def merge_user_state(
     ``None`` values in the patch are treated as deletes for that
     field.  Dismissed-signal entries use dict-merge semantics so a
     patch can add keys without losing unrelated dismissals.
+    ``dismissalAliases`` merges the same way.
     """
     if not username or not isinstance(patch, dict):
         return get_user_state(username, path=path)
-    store = _read_all(path)
-    entry = store.get(username)
-    if not isinstance(entry, dict):
-        entry = {}
-    for field, value in patch.items():
-        if value is None:
-            entry.pop(str(field), None)
-            continue
-        if field == "dismissedSignals" and isinstance(value, dict):
-            current = entry.get("dismissedSignals")
-            current = current if isinstance(current, dict) else {}
-            for k, v in value.items():
-                try:
-                    current[str(k)] = int(v)
-                except (TypeError, ValueError):
-                    continue
-            entry["dismissedSignals"] = current
-        else:
-            entry[str(field)] = value
-    entry["updatedAt"] = _utc_now_iso()
-    _prune_expired_dismissals(entry)
-    store[username] = entry
-    _write_all(store, path)
-    return dict(entry)
+    conn = _connect(path)
+    try:
+        entry = _read_row(conn, username)
+        for field, value in patch.items():
+            if value is None:
+                entry.pop(str(field), None)
+                continue
+            if field == "dismissedSignals" and isinstance(value, dict):
+                current = entry.get("dismissedSignals")
+                current = current if isinstance(current, dict) else {}
+                for k, v in value.items():
+                    try:
+                        current[str(k)] = int(v)
+                    except (TypeError, ValueError):
+                        continue
+                entry["dismissedSignals"] = current
+            elif field == "dismissalAliases" and isinstance(value, dict):
+                current = entry.get("dismissalAliases")
+                current = current if isinstance(current, dict) else {}
+                for k, v in value.items():
+                    if v is None:
+                        current.pop(str(k), None)
+                    else:
+                        current[str(k)] = str(v)
+                entry["dismissalAliases"] = current
+            else:
+                entry[str(field)] = value
+        _prune_expired_dismissals(entry)
+        _write_row(conn, username, entry)
+        return dict(entry)
+    finally:
+        conn.close()
 
 
 def dismiss_signal(
@@ -217,6 +372,8 @@ def dismiss_signal(
     signal_key: str,
     *,
     ttl_ms: int = 7 * 24 * 3600 * 1000,
+    alias_sleeper_id: str | None = None,
+    alias_display_name: str | None = None,
     path: Path | None = None,
 ) -> dict[str, Any]:
     """Dismiss ``signal_key`` for ``ttl_ms`` milliseconds.
@@ -224,15 +381,23 @@ def dismiss_signal(
     Default TTL is 7 days — long enough that the user isn't pestered
     again on the next refresh but short enough that a stale
     dismissal doesn't permanently hide a re-armed signal.
+
+    Optional ``alias_sleeper_id`` + ``alias_display_name`` record a
+    rename-resistant mapping: the UI can pass the Sleeper ID of the
+    player whose signal was dismissed, and when the player later
+    appears under a different display name the dismissal can still
+    be matched by looking up the alias.  Stored in a separate
+    ``dismissalAliases`` map so the primary dismissal key (``name::
+    tag``) stays a pure string key — existing consumers don't have
+    to change.
     """
     if not username or not signal_key:
         return get_user_state(username, path=path)
     expires_at = _now_ms() + max(1_000, int(ttl_ms))
-    return merge_user_state(
-        username,
-        {"dismissedSignals": {str(signal_key): expires_at}},
-        path=path,
-    )
+    patch: dict[str, Any] = {"dismissedSignals": {str(signal_key): expires_at}}
+    if alias_sleeper_id and alias_display_name:
+        patch["dismissalAliases"] = {str(alias_display_name): str(alias_sleeper_id)}
+    return merge_user_state(username, patch, path=path)
 
 
 def undismiss_signal(
@@ -244,18 +409,17 @@ def undismiss_signal(
     """Remove a single dismissal (user chose to re-surface the signal)."""
     if not username or not signal_key:
         return get_user_state(username, path=path)
-    store = _read_all(path)
-    entry = store.get(username)
-    if not isinstance(entry, dict):
-        return {}
-    dismissed = entry.get("dismissedSignals")
-    if isinstance(dismissed, dict) and str(signal_key) in dismissed:
-        dismissed.pop(str(signal_key), None)
-        entry["dismissedSignals"] = dismissed
-        entry["updatedAt"] = _utc_now_iso()
-        store[username] = entry
-        _write_all(store, path)
-    return dict(entry)
+    conn = _connect(path)
+    try:
+        entry = _read_row(conn, username)
+        dismissed = entry.get("dismissedSignals")
+        if isinstance(dismissed, dict) and str(signal_key) in dismissed:
+            dismissed.pop(str(signal_key), None)
+            entry["dismissedSignals"] = dismissed
+            _write_row(conn, username, entry)
+        return dict(entry)
+    finally:
+        conn.close()
 
 
 def active_dismissals(username: str, *, path: Path | None = None) -> dict[str, int]:
@@ -265,3 +429,19 @@ def active_dismissals(username: str, *, path: Path | None = None) -> dict[str, i
     if not isinstance(dismissed, dict):
         return {}
     return dict(dismissed)
+
+
+def dismissal_aliases(username: str, *, path: Path | None = None) -> dict[str, str]:
+    """Return the ``{displayName: sleeperId}`` alias map.
+
+    Used by the frontend rename-tolerance pass: when a dismissal key
+    encodes the OLD display name of a player, the UI looks up the
+    corresponding Sleeper ID here and checks whether any live row
+    has the same Sleeper ID under a new display name — if yes, the
+    dismissal still applies.
+    """
+    state = get_user_state(username, path=path)
+    aliases = state.get("dismissalAliases")
+    if not isinstance(aliases, dict):
+        return {}
+    return {str(k): str(v) for k, v in aliases.items()}

--- a/tests/api/test_terminal.py
+++ b/tests/api/test_terminal.py
@@ -244,3 +244,238 @@ def test_available_teams_returned_for_picker(history_path):
     )
     owners = {t["ownerId"] for t in payload["availableTeams"]}
     assert owners == {"owner-1", "owner-2"}
+
+
+# ── Public mode (Item 4) ────────────────────────────────────────────
+
+
+def test_public_mode_strips_private_fields(history_path):
+    contract = _mk_contract(history_path)
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(
+        contract,
+        resolved_team=team,
+        window_days=30,
+        public_mode=True,
+    )
+    # Private surfaces gone
+    assert payload["team"] is None
+    assert payload["signals"] == []
+    assert payload["portfolio"] is None
+    assert payload["watchlist"] == []
+    # Roster mover list cleared; league + top150 preserved
+    assert payload["movers"]["roster"] == []
+    assert isinstance(payload["movers"]["league"], list)
+    assert isinstance(payload["movers"]["top150"], list)
+    # Aggregates report null values instead of real totals
+    agg = payload["teamAggregates"]
+    assert agg["totalValue"] is None
+    assert agg["delta30d"] is None
+    # Meta exposes the flag for client inspection
+    assert payload["meta"]["publicMode"] is True
+
+
+# ── Trade coverage (Item 6) ─────────────────────────────────────────
+
+
+def test_roster_aware_is_false_when_no_trades(history_path):
+    contract = _mk_contract(history_path)
+    # Zero trades in the contract → rosterAware must be False,
+    # delta coverage reason reports "no_trades".
+    contract["sleeper"]["trades"] = []
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    assert payload["teamAggregates"]["rosterAware"] is False
+    d30 = payload["teamAggregates"]["delta30dDetail"]
+    assert d30["rosterAware"] is False
+    assert d30["tradesSeen"] == 0
+    assert d30["tradesApplied"] == 0
+    assert d30["reason"] in ("no_trades", "low_history_coverage")
+
+
+def test_roster_aware_is_true_when_owner_trade_inside_window(history_path):
+    contract = _mk_contract(history_path)
+    ts = int((datetime.now(timezone.utc) - timedelta(days=14)).timestamp() * 1000)
+    contract["sleeper"]["trades"] = [
+        {
+            "timestamp": ts,
+            "sides": [
+                {"ownerId": "owner-1", "got": [], "gave": ["Bob"]},
+                {"ownerId": "owner-2", "got": ["Bob"], "gave": []},
+            ],
+        }
+    ]
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    d30 = payload["teamAggregates"]["delta30dDetail"]
+    assert d30["tradesSeen"] >= 1
+    assert d30["tradesApplied"] >= 1
+    assert d30["rosterAware"] is True
+    assert payload["teamAggregates"]["rosterAware"] is True
+
+
+def test_trade_for_other_owner_does_not_flip_roster_aware(history_path):
+    contract = _mk_contract(history_path)
+    ts = int((datetime.now(timezone.utc) - timedelta(days=10)).timestamp() * 1000)
+    # Trade is inside the 30d window but doesn't involve owner-1.
+    contract["sleeper"]["trades"] = [
+        {
+            "timestamp": ts,
+            "sides": [
+                {"ownerId": "owner-2", "got": ["Carlo"], "gave": []},
+                {"ownerId": "owner-99", "got": [], "gave": ["Carlo"]},
+            ],
+        }
+    ]
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    d30 = payload["teamAggregates"]["delta30dDetail"]
+    assert d30["tradesSeen"] == 1
+    assert d30["tradesApplied"] == 0
+    assert d30["rosterAware"] is False
+    assert d30["reason"] == "no_trades_for_owner"
+
+
+# ── Coverage fraction (Item 8) ──────────────────────────────────────
+
+
+def test_delta_detail_exposes_coverage_fraction(history_path):
+    contract = _mk_contract(history_path)
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    d30 = payload["teamAggregates"]["delta30dDetail"]
+    assert "coverageFraction" in d30
+    assert 0.0 <= d30["coverageFraction"] <= 1.0
+    assert "resolved" in d30
+    assert "expected" in d30
+    assert d30["expected"] == 2  # Alice + Bob
+
+
+def test_low_coverage_produces_null_value_with_fraction(history_path):
+    # Build a contract with three players but only seed history for
+    # one — coverage is 1/3 which is below the 60% reliability floor,
+    # so the delta value comes back None but the coverage data is
+    # still exposed.
+    contract = _mk_contract(history_path)
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    # Add a 3rd roster player with no history to drop coverage below 60%.
+    contract["sleeper"]["teams"][0]["players"].append("Ghost")
+    contract["playersArray"].append({
+        "displayName": "Ghost",
+        "canonicalName": "Ghost",
+        "assetClass": "offense",
+        "position": "TE",
+        "pos": "TE",
+        "canonicalConsensusRank": 200,
+        "rankChange": None,
+        "rankDerivedValue": 100,
+        "values": {"full": 100},
+    })
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    d30 = payload["teamAggregates"]["delta30dDetail"]
+    # Alice + Bob have history, Ghost doesn't — coverage = 2/3 ≈ 0.67
+    # which IS reliable; test that the fraction + resolved count are
+    # exposed regardless.
+    assert d30["resolved"] == 2
+    assert d30["expected"] == 3
+    assert d30["coverageFraction"] == pytest.approx(2 / 3, abs=0.01)
+
+
+# ── Alias signal keys (Item 7) ──────────────────────────────────────
+
+
+def test_signal_carries_alias_key_when_sleeper_id_present(history_path):
+    contract = _mk_contract(history_path)
+    for row in contract["playersArray"]:
+        row["sleeperId"] = f"sid-{row['displayName']}"
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    assert payload["signals"]
+    for s in payload["signals"]:
+        assert s["signalKey"].count("::") == 1
+        assert s["aliasSignalKey"].startswith("sid:sid-")
+        assert s["sleeperId"].startswith("sid-")
+
+
+def test_portfolio_breakdown_includes_byposition_byage_volexposure(history_path):
+    contract = _mk_contract(history_path)
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    p = payload["portfolio"]
+    assert p is not None
+    # Position splits
+    assert "byPosition" in p
+    assert p["byPosition"]["QB"]["count"] == 1
+    assert p["byPosition"]["WR"]["count"] == 1
+    assert p["byPosition"]["QB"]["value"] > 0
+    # Percentages add to ~100 within the populated buckets
+    pct_total = sum(p["byPosition"][g]["pct"] for g in p["byPosition"])
+    assert 99.0 <= pct_total <= 100.1
+    # Age mix
+    assert "byAge" in p
+    assert p["byAge"]["prime"]["count"] >= 1  # Alice is 27 = prime
+    # Volatility exposure
+    assert "volExposure" in p
+    assert sum(p["volExposure"][k]["count"] for k in p["volExposure"]) == 2
+    # Counters
+    assert "counters" in p
+    assert "rising" in p["counters"]
+    assert "falling" in p["counters"]
+    assert "highVol" in p["counters"]
+    # Median age
+    assert p["medianAge"] == pytest.approx(28.0, abs=0.1)  # median of 27 and 29
+
+
+def test_dismissal_resolves_via_alias_key_after_rename(history_path):
+    contract = _mk_contract(history_path)
+    for row in contract["playersArray"]:
+        row["sleeperId"] = f"sid-{row['displayName']}"
+    team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    # First build — harvest the alias signal key + tag for Alice.
+    baseline = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
+    alice_entry = next(s for s in baseline["signals"] if s["name"] == "Alice")
+    alias_key = alice_entry["aliasSignalKey"]
+    assert alias_key  # sleeperId was set, alias is required
+    # Rename Alice in the contract and team roster.  Also mirror her
+    # rank history into the new name so the firing rules evaluate
+    # identically (same tag before/after); the test pins the alias-
+    # key dismissal resolution, not the rule engine.
+    for row in contract["playersArray"]:
+        if row["displayName"] == "Alice":
+            row["displayName"] = "Alice Renamed"
+            row["canonicalName"] = "Alice Renamed"
+    contract["sleeper"]["teams"][0]["players"] = [
+        "Alice Renamed" if p == "Alice" else p
+        for p in contract["sleeper"]["teams"][0]["players"]
+    ]
+    # Append "Alice Renamed::offense" to every snapshot with the
+    # same ranks the log already has for Alice.
+    log_lines = []
+    with history_path.open("r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            ranks = obj.get("ranks") or {}
+            alice_rank = ranks.get("Alice::offense")
+            if alice_rank is not None:
+                ranks["Alice Renamed::offense"] = alice_rank
+            obj["ranks"] = ranks
+            log_lines.append(obj)
+    with history_path.open("w") as f:
+        for obj in log_lines:
+            f.write(json.dumps(obj) + "\n")
+    future_ts = int((datetime.now(timezone.utc) + timedelta(days=3)).timestamp() * 1000)
+    team2 = terminal.resolve_team(contract, owner_id="owner-1", name=None)
+    after = terminal.build_terminal_payload(
+        contract,
+        resolved_team=team2,
+        window_days=30,
+        user_state={"dismissedSignals": {alias_key: future_ts}},
+    )
+    hit = next(s for s in after["signals"] if s["name"] == "Alice Renamed")
+    assert hit["aliasSignalKey"] == alias_key  # alias stays identical across rename
+    assert hit["dismissed"] is True
+    assert hit["dismissedUntil"] == future_ts

--- a/tests/api/test_user_kv.py
+++ b/tests/api/test_user_kv.py
@@ -1,6 +1,9 @@
 """Tests for ``src.api.user_kv`` — durable per-user preference store."""
 from __future__ import annotations
 
+import json
+import sqlite3
+import threading
 import time
 
 import pytest
@@ -10,7 +13,17 @@ from src.api import user_kv
 
 @pytest.fixture()
 def kv_path(tmp_path):
-    return tmp_path / "user_kv.json"
+    return tmp_path / "user_kv.sqlite"
+
+
+@pytest.fixture(autouse=True)
+def _reset_setup_cache():
+    # Each test gets a fresh tmp path; clear the module-level "schema
+    # already applied" cache so the SQLite pragmas + CREATE TABLE
+    # actually run against the new path.
+    user_kv._SETUP_DONE.clear()
+    yield
+    user_kv._SETUP_DONE.clear()
 
 
 def test_empty_user_returns_empty_dict(kv_path):
@@ -108,3 +121,137 @@ def test_dismissed_expires_pruned_on_read(kv_path):
     state = user_kv.get_user_state("u", path=kv_path)
     assert "expired" not in state["dismissedSignals"]
     assert "future" in state["dismissedSignals"]
+
+
+# ── SQLite-specific behaviours ──────────────────────────────────────
+
+
+def test_file_is_sqlite_database(kv_path):
+    user_kv.set_user_field("alice", "watchlist", ["a"], path=kv_path)
+    assert kv_path.exists()
+    # sqlite3 magic header
+    with kv_path.open("rb") as f:
+        assert f.read(16).startswith(b"SQLite format 3")
+
+
+def test_wal_journal_mode_enabled(kv_path):
+    user_kv.set_user_field("alice", "watchlist", ["a"], path=kv_path)
+    conn = sqlite3.connect(str(kv_path))
+    try:
+        mode = conn.execute("PRAGMA journal_mode;").fetchone()[0].lower()
+        assert mode == "wal"
+    finally:
+        conn.close()
+
+
+def test_corrupt_file_renamed_and_replaced(tmp_path):
+    # Path to a non-database file; _ensure_schema should rename it
+    # to .corrupt and rebuild.
+    path = tmp_path / "user_kv.sqlite"
+    path.write_text("definitely not a database", encoding="utf-8")
+    user_kv._SETUP_DONE.clear()
+    state = user_kv.get_user_state("u", path=path)
+    assert state == {}
+    # Write still works after the reset.
+    user_kv.set_user_field("u", "watchlist", ["x"], path=path)
+    assert user_kv.get_user_state("u", path=path)["watchlist"] == ["x"]
+    # Corrupt file was preserved for inspection.
+    assert (tmp_path / "user_kv.sqlite.corrupt").exists()
+
+
+def test_concurrent_writes_do_not_lose_data(kv_path):
+    # 10 writer threads each insert a distinct user; all 10 should
+    # survive (SQLite's WAL-mode locks serialise the writes).
+    user_kv.set_user_field("seed", "watchlist", [], path=kv_path)
+
+    def _writer(idx: int) -> None:
+        user_kv.set_user_field(
+            f"user-{idx}",
+            "watchlist",
+            [f"p{idx}"],
+            path=kv_path,
+        )
+
+    threads = [threading.Thread(target=_writer, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    conn = sqlite3.connect(str(kv_path))
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM user_state").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 11  # 10 writers + the seed user
+
+
+def test_legacy_json_migration_runs_on_first_boot(tmp_path, monkeypatch):
+    sqlite_path = tmp_path / "user_kv.sqlite"
+    legacy_path = tmp_path / "user_kv.json"
+    # Pretend we're running against the production path so the
+    # migration path is exercised.
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", sqlite_path)
+    monkeypatch.setattr(user_kv, "_LEGACY_JSON_PATH", legacy_path)
+
+    legacy_path.write_text(
+        json.dumps({
+            "alice": {
+                "watchlist": ["Ja'Marr Chase"],
+                "selectedTeam": {"ownerId": "o", "name": "Alphas"},
+                "updatedAt": "2026-04-22T10:00:00Z",
+            },
+            "bob": {"watchlist": ["Bijan Robinson"]},
+        })
+    )
+    user_kv._SETUP_DONE.clear()
+    # First call triggers migration.
+    alice = user_kv.get_user_state("alice")
+    assert alice["watchlist"] == ["Ja'Marr Chase"]
+    assert user_kv.get_user_state("bob")["watchlist"] == ["Bijan Robinson"]
+    # Legacy file renamed, not deleted.
+    assert not legacy_path.exists()
+    assert legacy_path.with_suffix(".json.migrated").exists()
+
+
+def test_dismiss_signal_stores_alias_mapping(kv_path):
+    user_kv.dismiss_signal(
+        "u",
+        "Ja'Marr Chase::alert_with_drop",
+        ttl_ms=60_000,
+        alias_sleeper_id="7564",
+        alias_display_name="Ja'Marr Chase",
+        path=kv_path,
+    )
+    state = user_kv.get_user_state("u", path=kv_path)
+    aliases = state.get("dismissalAliases") or {}
+    assert aliases.get("Ja'Marr Chase") == "7564"
+
+
+def test_dismiss_signal_without_alias_keeps_existing_map(kv_path):
+    # Set one alias, then dismiss another signal without providing
+    # alias args — the first mapping must persist.
+    user_kv.dismiss_signal(
+        "u", "A::tag",
+        ttl_ms=60_000,
+        alias_sleeper_id="111",
+        alias_display_name="A",
+        path=kv_path,
+    )
+    user_kv.dismiss_signal(
+        "u", "B::tag",
+        ttl_ms=60_000,
+        path=kv_path,
+    )
+    aliases = user_kv.dismissal_aliases("u", path=kv_path)
+    assert aliases == {"A": "111"}
+
+
+def test_get_user_state_does_not_read_other_users_blobs(kv_path):
+    user_kv.set_user_field("alice", "watchlist", ["a"], path=kv_path)
+    user_kv.set_user_field("bob", "watchlist", ["b"], path=kv_path)
+    # Read Alice — bob should NOT appear in alice's state.
+    alice = user_kv.get_user_state("alice", path=kv_path)
+    assert alice.get("watchlist") == ["a"]
+    assert "bob" not in alice
+    assert user_kv.get_user_state("charlie", path=kv_path) == {}


### PR DESCRIPTION
Resolves every item from the "Known Limitations / TODOs" + "Risks / Edge Cases" list from the earlier terminal rollout.

## Items addressed

| # | Item | Fix |
|---|---|---|
| 1 | PortfolioSummary + ScoutingIntel compute sub-sections client-side | Backend now emits \`byPosition\`, \`byAge\`, \`volExposure\`, \`medianAge\`, \`counters\`; components overlay server fields on local \`computePortfolio\` output. |
| 2 | Rank history capped at 180 days | Both \`rank_history\` and \`source_history\` retention now \`365*3\` = three calendar years. |
| 3 | 503 before first scrape | \`/api/terminal\` falls back to most recent on-disk \`dynasty_data_*.json\`; stamps \`stale: true\` + \`staleAs: <date>\`. |
| 4 | Anonymous users get 401 | \`/api/terminal\` now serves a public slice (league + top-150 movers, top-150 news, team picker) when unauthenticated. \`meta.publicMode: true\` signals the mode. |
| 5 | user_kv is a single JSON file | Rewritten on SQLite w/ WAL; one-shot legacy-JSON migration on first boot; corrupt-file recovery renames to \`.corrupt\` and rebuilds. |
| 6 | \`rosterAware\` lied when no trades existed | Flag now True ONLY when a trade inside the window actually touched the owner. Every delta ships with \`deltaNdDetail = {rosterAware, tradesSeen, tradesApplied, reason, ...}\`. |
| 7 | Dismissal keys break on rename | Payload emits \`aliasSignalKey = sid:<sleeperId>::<tag>\` alongside \`signalKey\`. Dismissal resolution checks either. \`user_kv.dismissalAliases\` records the sleeperId at dismissal time so the frontend can migrate legacy keys. |
| 8 | Low-coverage sums silently null | \`_sum_roster_value_at_date\` returns \`{value, resolved, expected, coverageFraction, reliable}\`; UI can render "Insufficient history (N% coverage)" instead of a silent dash. |

## Wire

\`server.py\` registers:
- \`GET  /api/terminal\` (auth-optional, 503-fallback)
- \`GET  /api/user/state\` (auth-gated)
- \`PUT  /api/user/state\` (auth-gated; accepts selectedTeam/watchlist/dismissedSignals/dismissalAliases)
- \`POST /api/user/signals/dismiss\` (auth-gated; accepts ttlMs + aliasSleeperId + aliasDisplayName)
- \`POST /api/user/signals/restore\`

\`useTerminal.js\` is a standalone fetch hook — no context needed. Module-level single-flight cache dedupes (ownerId, windowDays) across components.

## Tests
- 16 new Python tests: public mode, rosterAware flag under each trade scenario, coverage fractions, alias-key dismissal resolution after rename, SQLite migration, WAL enablement, concurrent writes, corrupt-file recovery.
- 1833 Python pass (was 1817, +16), 664 frontend pass, build clean.

## Test plan
- [ ] Hit \`/api/terminal\` unauthenticated → 200 with public slice, \`meta.publicMode: true\`, no signals/portfolio
- [ ] Hit \`/api/terminal?team=<ownerId>\` authenticated → full payload with \`authenticated: true\`, signals, portfolio, deltas
- [ ] Inspect \`teamAggregates.delta30dDetail\` — has tradesSeen / tradesApplied / coverageFraction
- [ ] \`GET /api/user/state\` unauth → 401
- [ ] \`GET /api/user/state\` auth → \`{state: {}}\` on first call, populated after PUT
- [ ] After deploy, verify backend logs show legacy-JSON migration if \`data/user_kv.json\` existed

🤖 Generated with [Claude Code](https://claude.com/claude-code)