### PR TITLE
feat: six-pack — injury/watchlist UI, share/sim trade, email opt-in, cron timer

### DIFF
--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -245,8 +245,60 @@ main() {
     log "Installed ${frontend_name}.service"
   fi
 
+  # ── Signal-alerts sweep (optional systemd timer) ───────────────────────
+  # Deploys a one-shot service + daily timer that POSTs the internal
+  # /api/signal-alerts/run endpoint.  We only install these units when
+  # both templates exist AND SIGNAL_ALERT_CRON_TOKEN is set in the
+  # .env file — without the token the endpoint would reject the
+  # bearer auth, so there's no point enabling the timer yet.
+  local alerts_service_template="${APP_DIR}/deploy/systemd/dynasty-signal-alerts.service.template"
+  local alerts_timer_template="${APP_DIR}/deploy/systemd/dynasty-signal-alerts.timer.template"
+  local alerts_service_name="${SERVICE_NAME}-signal-alerts"
+  local alerts_service_path="/etc/systemd/system/${alerts_service_name}.service"
+  local alerts_timer_path="/etc/systemd/system/${alerts_service_name}.timer"
+  local alerts_needs_install=false
+  local has_cron_token=false
+
+  if [[ -f "${APP_DIR}/.env" ]] && grep -Eq '^[[:space:]]*SIGNAL_ALERT_CRON_TOKEN=.+$' "${APP_DIR}/.env"; then
+    has_cron_token=true
+  fi
+
+  if [[ -f "${alerts_service_template}" && -f "${alerts_timer_template}" && "${has_cron_token}" == "true" ]]; then
+    if sudo -n "${SYSTEMCTL_BIN}" cat "${alerts_service_name}.timer" >/dev/null 2>&1; then
+      if [[ "${force_install_on}" == "true" ]]; then
+        log "FORCE_SERVICE_INSTALL enabled; rewriting ${alerts_service_path} + timer."
+        alerts_needs_install=true
+      else
+        log "Signal-alerts timer already installed; skipping."
+      fi
+    else
+      log "Installing signal-alerts service + timer."
+      alerts_needs_install=true
+    fi
+
+    if [[ "${alerts_needs_install}" == "true" ]]; then
+      local tmp_alerts_service tmp_alerts_timer
+      tmp_alerts_service="$(mktemp)"
+      tmp_alerts_timer="$(mktemp)"
+      trap 'rm -f "${tmp_unit:-}" "${tmp_frontend:-}" "${tmp_alerts_service:-}" "${tmp_alerts_timer:-}"' EXIT
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+        -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+        "${alerts_service_template}" > "${tmp_alerts_service}"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        "${alerts_timer_template}" > "${tmp_alerts_timer}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_alerts_service}" "${alerts_service_path}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_alerts_timer}" "${alerts_timer_path}"
+      log "Installed ${alerts_service_name}.service + .timer"
+    fi
+  elif [[ -f "${alerts_service_template}" && "${has_cron_token}" != "true" ]]; then
+    log "Signal-alerts timer skipped: SIGNAL_ALERT_CRON_TOKEN not set in ${APP_DIR}/.env."
+  fi
+
   # ── daemon-reload and enable ────────────────────────────────────────────
-  if [[ "${backend_needs_install}" == "true" || "${frontend_needs_install}" == "true" ]]; then
+  if [[ "${backend_needs_install}" == "true" || "${frontend_needs_install}" == "true" || "${alerts_needs_install}" == "true" ]]; then
     sudo -n "${SYSTEMCTL_BIN}" daemon-reload
     log "Reloaded systemd unit files."
   fi
@@ -258,6 +310,10 @@ main() {
   if [[ "${frontend_needs_install}" == "true" ]]; then
     sudo -n "${SYSTEMCTL_BIN}" enable "${frontend_name}"
     log "Enabled ${frontend_name}.service"
+  fi
+  if [[ "${alerts_needs_install}" == "true" ]]; then
+    sudo -n "${SYSTEMCTL_BIN}" enable --now "${alerts_service_name}.timer"
+    log "Enabled ${alerts_service_name}.timer"
   fi
 }
 

--- a/deploy/systemd/dynasty-signal-alerts.service.template
+++ b/deploy/systemd/dynasty-signal-alerts.service.template
@@ -1,0 +1,30 @@
+[Unit]
+Description=Dynasty Trade Calculator signal-alert sweep (__SERVICE_NAME__)
+After=network-online.target __SERVICE_NAME__.service
+Wants=network-online.target
+Requires=__SERVICE_NAME__.service
+
+# Fires the /api/signal-alerts/run endpoint on the local backend.
+# The endpoint authenticates via the SIGNAL_ALERT_CRON_TOKEN bearer
+# token loaded from __APP_DIR__/.env — no password session, no
+# cookies.  Failure to send from here means either the backend is
+# down, the token is missing/wrong, or the SMTP creds are off;
+# systemd will retry on the next timer tick.  The sweep is
+# idempotent (per-signal cooldowns prevent duplicate emails) so
+# over-firing is harmless.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+# curl --fail makes systemd report the unit as failed on any non-2xx
+# response.  --show-error prints errors to the journal; --silent
+# suppresses progress output so the journal stays clean on success.
+ExecStart=/usr/bin/curl --fail --silent --show-error --max-time 300 \
+  -H "Authorization: Bearer ${SIGNAL_ALERT_CRON_TOKEN}" \
+  -X POST http://127.0.0.1:8000/api/signal-alerts/run
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-signal-alerts.timer.template
+++ b/deploy/systemd/dynasty-signal-alerts.timer.template
@@ -1,0 +1,19 @@
+[Unit]
+Description=Daily signal-alert digest sweep for __SERVICE_NAME__
+Requires=__SERVICE_NAME__-signal-alerts.service
+
+[Timer]
+# Fire once a day at 15:00 local time.  Chosen for the US Eastern
+# evening window — most people check fantasy news at night, so the
+# email arrives right before the usual look-at-your-roster moment
+# rather than buried under morning inbox noise.  Persistent=true
+# ensures we run once at boot if the machine was down when the
+# timer would have fired; RandomizedDelaySec smears the load a bit
+# so cohort bursts don't hammer the SMTP relay.
+OnCalendar=*-*-* 15:00:00
+RandomizedDelaySec=300
+Persistent=true
+Unit=__SERVICE_NAME__-signal-alerts.service
+
+[Install]
+WantedBy=timers.target

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -802,6 +802,24 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   font-size: 0.78rem;
   padding: 6px 12px;
 }
+.player-popup-watchlist {
+  min-width: 36px;
+  min-height: 36px;
+  padding: 0;
+  font-size: 1.1rem;
+  line-height: 1;
+  border-color: var(--border);
+  color: var(--muted);
+}
+.player-popup-watchlist.is-active {
+  color: var(--cyan);
+  border-color: var(--cyan);
+  background: rgba(255, 199, 4, 0.08);
+}
+.player-popup-watchlist:hover {
+  color: var(--cyan);
+  border-color: var(--cyan);
+}
 /* Square close button — keeps visual parity with the .picker-close
    button used on the player picker.  Font-size drives the glyph; the
    min-width/min-height lock the tap target. */
@@ -4927,6 +4945,45 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   font-size: 0.78rem;
   line-height: 1.4;
   color: var(--text);
+}
+.signal-card-injury {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 4px 8px;
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  border-radius: 6px;
+  font-size: 0.72rem;
+  cursor: help;
+}
+.signal-card-injury--offseason {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--border);
+  color: var(--muted);
+}
+.signal-card-injury-pct {
+  font-weight: 700;
+  color: var(--red);
+  font-variant-numeric: tabular-nums;
+}
+.signal-card-injury-severity {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+}
+.signal-card-injury-headline {
+  color: var(--subtext);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
 }
 .signal-card-chips {
   display: flex;

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
 import { useSettings, SETTINGS_DEFAULTS as DEFAULTS } from "@/components/useSettings";
+import { useUserState } from "@/components/useUserState";
 import {
   WEIGHT_PRESETS,
   presetToWeights,
@@ -68,7 +69,37 @@ function ToggleRow({ label, checked, onChange, hint }) {
 export default function SettingsPage() {
   const { loading, error, rows, rawData } = useDynastyData();
   const { settings, update, updateSiteWeight, resetSiteWeights, reset } = useSettings();
+  const { state: userState, serverBacked, setNotifications } = useUserState();
   const [hydrated, setHydrated] = useState(true);
+  const [emailDraft, setEmailDraft] = useState("");
+  const [emailStatus, setEmailStatus] = useState("");
+
+  // Keep the email input in sync with the server-backed value on
+  // hydrate.  A user who clears the field and saves empty should see
+  // the input stay empty (not snap back to the server value).
+  useEffect(() => {
+    if (userState?.notificationsEmail) {
+      setEmailDraft(String(userState.notificationsEmail));
+    }
+  }, [userState?.notificationsEmail]);
+
+  const saveEmail = useCallback(() => {
+    const clean = emailDraft.trim();
+    if (clean && (!clean.includes("@") || !clean.split("@")[1]?.includes("."))) {
+      setEmailStatus("That doesn't look like a valid email address.");
+      return;
+    }
+    setNotifications({ email: clean || null });
+    setEmailStatus(clean ? "Saved." : "Email cleared.");
+    setTimeout(() => setEmailStatus(""), 2500);
+  }, [emailDraft, setNotifications]);
+
+  const toggleEnabled = useCallback(
+    (next) => {
+      setNotifications({ enabled: next });
+    },
+    [setNotifications],
+  );
 
   function resetToDefaults() {
     reset();
@@ -337,6 +368,65 @@ export default function SettingsPage() {
           Picks from future years are automatically discounted in trade calculations:
           current year = 100%, +1 year = 85%, +2 years = 72%, +3+ years = 60%.
         </p>
+      </Section>
+
+      <Section title="Notifications" defaultOpen={false}>
+        {serverBacked ? (
+          <>
+            <ToggleRow
+              label="Email me daily signal alerts"
+              checked={!!userState?.notificationsEnabled}
+              onChange={toggleEnabled}
+              hint="Buy/sell/injury/roster digest, sent once per day when you have live signals."
+            />
+            <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8, flexWrap: "wrap" }}>
+              <label style={{ fontSize: "0.82rem", minWidth: 100 }}>Email address</label>
+              <input
+                type="email"
+                className="input"
+                value={emailDraft}
+                placeholder="you@example.com"
+                onChange={(e) => setEmailDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") saveEmail();
+                }}
+                style={{ flex: "1 1 260px", maxWidth: 360 }}
+              />
+              <button className="button" onClick={saveEmail} style={{ fontSize: "0.76rem" }}>
+                Save
+              </button>
+              {emailDraft && (
+                <button
+                  className="button"
+                  onClick={() => {
+                    setEmailDraft("");
+                    setNotifications({ email: null });
+                    setEmailStatus("Email cleared.");
+                    setTimeout(() => setEmailStatus(""), 2500);
+                  }}
+                  style={{ fontSize: "0.76rem" }}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            {emailStatus && (
+              <div className="muted" style={{ fontSize: "0.72rem", marginTop: 6, color: "var(--green)" }}>
+                {emailStatus}
+              </div>
+            )}
+            <p className="muted" style={{ fontSize: "0.7rem", marginTop: 10, marginBottom: 0 }}>
+              Alerts fire once per day when the signal engine finds something notable on your
+              roster — buy-low / sell-high opportunities, injury news, rookie or pick movement.
+              We only email you when there&apos;s a change worth acting on.
+            </p>
+          </>
+        ) : (
+          <p className="muted" style={{ fontSize: "0.78rem" }}>
+            Sign in to enable email notifications.  Your notification preferences
+            are stored on the server and apply across devices.
+          </p>
+        )}
       </Section>
 
       <Section title="Data & Admin" defaultOpen={false}>

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -40,6 +40,13 @@ import { useSettings } from "@/components/useSettings";
 import TradeDeltaHistogram from "@/components/graphs/TradeDeltaHistogram";
 import { useApp } from "@/components/AppShell";
 import { posBadgeClass } from "@/lib/display-helpers";
+import {
+  buildShareUrl,
+  parseShareParam,
+  SHARE_PARAM,
+} from "@/lib/trade-share";
+import { useTradeSimulator } from "@/components/useTradeSimulator";
+import { useTeam } from "@/components/useTeam";
 
 const ROSTER_KEY = "next_trade_roster_v1";
 const TEAM_KEY = "next_trade_team_v1";
@@ -578,6 +585,12 @@ export default function TradePage() {
   const [ktcImportError, setKtcImportError] = useState("");
   const [ktcImportStatus, setKtcImportStatus] = useState("");
 
+  // Share + simulator state.
+  const [shareStatus, setShareStatus] = useState("");
+  const [shareHydrated, setShareHydrated] = useState(false);
+  const { simulate: simulateTrade, result: simResult, loading: simLoading, error: simError, reset: resetSim } = useTradeSimulator();
+  const { selectedTeam } = useTeam();
+
   // Extract Sleeper teams from dynasty data
   const sleeperTeams = useMemo(() => {
     const teams = rawData?.sleeper?.teams;
@@ -705,6 +718,60 @@ export default function TradePage() {
     const payload = serializeWorkspaceMulti(sides, valueMode, activeSide);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
   }, [hydrated, valueMode, activeSide, sides]);
+
+  // ── Share-URL decoder ──────────────────────────────────────────────
+  // When the page loads with ``?share=<base64url>`` in the URL, decode
+  // the payload and replace the first N sides with its contents.  We
+  // wait for rows to load + localStorage hydration to finish so the
+  // decoded trade doesn't flash-then-disappear when the later effect
+  // commits the stored workspace.  Running once per page load is
+  // enforced via ``shareHydrated`` — the user can still /clear or edit
+  // the trade after, and we won't re-override from the URL.
+  useEffect(() => {
+    if (!hydrated || shareHydrated) return;
+    if (!rows.length) return;
+    if (typeof window === "undefined") return;
+    const state = parseShareParam(window.location.search);
+    if (!state || !state.sides?.length) {
+      setShareHydrated(true);
+      return;
+    }
+    try {
+      const neededSides = Math.max(2, state.sides.length);
+      const ensureSides = (prev) => {
+        let next = prev;
+        while (next.length < neededSides) next = [...next, createSide(next.length)];
+        return next;
+      };
+      setSides((prev) => {
+        const base = ensureSides(prev);
+        return base.map((side, i) => {
+          const incoming = state.sides[i];
+          if (!incoming) return { ...side, assets: [], destinations: {} };
+          const resolved = [];
+          const seen = new Set();
+          for (const name of incoming.players || []) {
+            const row = rowByName.get(name);
+            if (!row || seen.has(row.name)) continue;
+            seen.add(row.name);
+            resolved.push(row);
+          }
+          const nextDestinations = {};
+          if (base.length > 2) {
+            for (const row of resolved) {
+              nextDestinations[row.name] = defaultDestination(i, base.length);
+            }
+          }
+          return { ...side, assets: resolved, destinations: nextDestinations };
+        });
+      });
+      setShareStatus("Loaded shared trade from link.");
+    } catch {
+      setShareStatus("Share link was malformed — ignored.");
+    } finally {
+      setShareHydrated(true);
+    }
+  }, [hydrated, shareHydrated, rows, rowByName]);
 
   useEffect(() => {
     if (pickerOpen && pickerInputRef.current) pickerInputRef.current.focus();
@@ -1177,6 +1244,78 @@ export default function TradePage() {
     }
   }, [ktcImportUrl, rowByName]);
 
+  // ── Share-URL + simulator actions ─────────────────────────────────
+  // Build a share-URL from the current trade and copy to clipboard.
+  // Falls back to selecting the URL in a prompt when the clipboard
+  // API is unavailable (older Safari / non-HTTPS contexts).
+  const copyShareLink = useCallback(async () => {
+    try {
+      const payload = {
+        sides: sides.map((s) => ({
+          name: s.label ? `Side ${s.label}` : "",
+          players: (s.assets || []).map((a) => a.name),
+        })),
+      };
+      const url = buildShareUrl(payload);
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        setShareStatus("Share link copied to clipboard.");
+      } else if (typeof window !== "undefined") {
+        // Surface the URL so the user can copy it manually.
+        window.prompt("Copy this share link:", url);
+        setShareStatus("Share link ready.");
+      }
+    } catch (err) {
+      setShareStatus(err?.message || "Could not copy share link.");
+    }
+  }, [sides]);
+
+  // Pure impact-on-my-roster simulator.  2-team trades only:
+  // whichever side matches the user's selected Sleeper team is
+  // treated as "sending" (players OUT) and the other side as
+  // "receiving" (players IN).  Picks and players are sent as one
+  // payload each because the simulator backend treats them
+  // identically — both resolve through the same row-index.
+  const runSimulateTrade = useCallback(() => {
+    if (sides.length !== 2) return;
+    if (!selectedTeam) return;
+    const myRosterNames = teamRosterNames(selectedTeam);
+    // Score each side by how many of its assets the user owns.
+    // Whichever side has more matches is "my side" (I'm giving).
+    const scores = sides.map((s) => {
+      let hits = 0;
+      for (const a of s.assets || []) if (myRosterNames.has(a.name)) hits += 1;
+      return hits;
+    });
+    let mySide = scores[0] >= scores[1] ? 0 : 1;
+    if (scores[0] === 0 && scores[1] === 0) {
+      // Neither side matches — default to "I'm giving side A" so the
+      // user can flip via Swap Sides if needed.
+      mySide = 0;
+    }
+    const otherSide = mySide === 0 ? 1 : 0;
+    const isPickName = (name) => /\d{4}/.test(String(name || ""));
+    const playersOut = [];
+    const picksOut = [];
+    for (const a of sides[mySide].assets || []) {
+      if (isPickName(a.name)) picksOut.push(a.name);
+      else playersOut.push(a.name);
+    }
+    const playersIn = [];
+    const picksIn = [];
+    for (const a of sides[otherSide].assets || []) {
+      if (isPickName(a.name)) picksIn.push(a.name);
+      else playersIn.push(a.name);
+    }
+    simulateTrade({
+      teamName: selectedTeam?.name,
+      playersIn,
+      playersOut,
+      picksIn,
+      picksOut,
+    });
+  }, [sides, selectedTeam, teamRosterNames, simulateTrade]);
+
   // ── Suggestions logic ─────────────────────────────────────────────
   const parseRoster = useCallback(() => {
     return rosterInput
@@ -1315,7 +1454,166 @@ export default function TradePage() {
             >
               + Import KTC
             </button>
+            <button
+              className="button"
+              onClick={copyShareLink}
+              disabled={!sides.some((s) => (s.assets || []).length > 0)}
+              style={{ borderColor: "var(--cyan)", color: "var(--cyan)" }}
+              title="Copy a shareable link that pre-loads this trade for anyone who opens it"
+            >
+              🔗 Copy Share Link
+            </button>
+            {sides.length === 2 && selectedTeam && (
+              <button
+                className="button"
+                onClick={runSimulateTrade}
+                disabled={simLoading || !sides.some((s) => (s.assets || []).length > 0)}
+                style={{ borderColor: "var(--green)", color: "var(--green)" }}
+                title={`Apply this trade to ${selectedTeam.name} and see before/after roster value`}
+              >
+                {simLoading ? "Simulating…" : "⚙ Simulate impact"}
+              </button>
+            )}
           </div>
+
+          {shareStatus && (
+            <div
+              className="muted"
+              style={{
+                fontSize: "0.74rem",
+                marginBottom: 8,
+                paddingLeft: 2,
+              }}
+            >
+              <span style={{ color: "var(--cyan)" }}>Share:</span>{" "}
+              {shareStatus}
+              <button
+                className="button"
+                style={{
+                  marginLeft: 8,
+                  padding: "1px 8px",
+                  fontSize: "0.66rem",
+                  minHeight: "unset",
+                }}
+                onClick={() => setShareStatus("")}
+                title="Dismiss"
+              >
+                ×
+              </button>
+            </div>
+          )}
+
+          {(simResult || simError) && (
+            <div
+              className="card"
+              style={{
+                marginBottom: 10,
+                padding: "10px 12px",
+                border: "1px solid var(--green)",
+                background: "rgba(52,211,153,0.05)",
+              }}
+            >
+              <div style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: 8,
+              }}>
+                <div style={{ fontSize: "0.74rem", fontWeight: 700, letterSpacing: "0.04em" }}>
+                  IMPACT ON {simResult?.team?.name?.toUpperCase?.() || (selectedTeam?.name || "").toUpperCase()}
+                </div>
+                <button
+                  className="button"
+                  style={{ fontSize: "0.66rem", padding: "1px 8px", minHeight: "unset" }}
+                  onClick={resetSim}
+                  title="Clear simulation"
+                >
+                  ×
+                </button>
+              </div>
+              {simError && (
+                <div style={{ color: "var(--red)", fontSize: "0.78rem" }}>
+                  {simError}
+                </div>
+              )}
+              {simResult && (
+                <div>
+                  <div style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(3, minmax(0,1fr))",
+                    gap: 10,
+                    marginBottom: 8,
+                  }}>
+                    <div>
+                      <div className="muted" style={{ fontSize: "0.66rem" }}>Before</div>
+                      <div style={{ fontSize: "1.1rem", fontWeight: 700 }}>
+                        {Math.round(simResult.before?.totalValue || 0).toLocaleString()}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="muted" style={{ fontSize: "0.66rem" }}>After</div>
+                      <div style={{ fontSize: "1.1rem", fontWeight: 700 }}>
+                        {Math.round(simResult.after?.totalValue || 0).toLocaleString()}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="muted" style={{ fontSize: "0.66rem" }}>Δ Total Value</div>
+                      <div style={{
+                        fontSize: "1.1rem",
+                        fontWeight: 700,
+                        color: (simResult.delta?.totalValue || 0) >= 0 ? "var(--green)" : "var(--red)",
+                      }}>
+                        {(simResult.delta?.totalValue || 0) >= 0 ? "+" : ""}
+                        {Math.round(simResult.delta?.totalValue || 0).toLocaleString()}
+                      </div>
+                    </div>
+                  </div>
+                  <div style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(110px, 1fr))",
+                    gap: 8,
+                    fontSize: "0.72rem",
+                  }}>
+                    {["QB", "RB", "WR", "TE"].map((pos) => {
+                      const row = simResult.delta?.byPosition?.[pos];
+                      if (!row) return null;
+                      const d = row.value || 0;
+                      return (
+                        <div key={pos} style={{
+                          padding: "4px 8px",
+                          border: "1px solid var(--border)",
+                          borderRadius: 4,
+                        }}>
+                          <span className="muted">{pos}</span>{" "}
+                          <span style={{
+                            color: d === 0 ? "var(--muted)" : d > 0 ? "var(--green)" : "var(--red)",
+                            fontWeight: 600,
+                          }}>
+                            {d > 0 ? "+" : ""}{Math.round(d).toLocaleString()}
+                          </span>
+                          {row.count !== 0 && (
+                            <span className="muted" style={{ marginLeft: 4 }}>
+                              ({row.count > 0 ? "+" : ""}{row.count})
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                  {(simResult.unresolvedIn?.length > 0 || simResult.unresolvedOut?.length > 0) && (
+                    <div className="muted" style={{ fontSize: "0.7rem", marginTop: 6, color: "var(--red)" }}>
+                      Unresolved:{" "}
+                      {[...(simResult.unresolvedIn || []), ...(simResult.unresolvedOut || [])].join(", ")}
+                    </div>
+                  )}
+                  <div className="muted" style={{ fontSize: "0.68rem", marginTop: 6 }}>
+                    Equity (receiving − sending): {simResult.equity >= 0 ? "+" : ""}
+                    {Math.round(simResult.equity || 0).toLocaleString()}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
 
           {ktcImportOpen && (
             <div

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -4,6 +4,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getPlayerEdge } from "@/lib/trade-logic";
 import { resolvedRank, RANKING_SOURCES } from "@/lib/dynasty-data";
 import PlayerRankHistoryChart from "@/components/PlayerRankHistoryChart";
+import { useTeam } from "@/components/useTeam";
+import { useTerminal } from "@/components/useTerminal";
+import { useUserState } from "@/components/useUserState";
 
 /**
  * Build the ordered value-chain stages from a player row.
@@ -150,6 +153,36 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
   const edge = useMemo(() => (row ? getPlayerEdge(row) : null), [row]);
   const valueChain = useMemo(() => computeValueChain(row), [row]);
 
+  // Injury impact lookup from the server-side signals block.
+  // Only populated for roster players today — non-roster players
+  // won't have impact data, and the chip simply doesn't render.
+  const { selectedTeam } = useTeam();
+  const { signals: serverSignals } = useTerminal({
+    ownerId: String(selectedTeam?.ownerId || ""),
+    teamName: selectedTeam?.name || "",
+    windowDays: 30,
+  });
+  const injury = useMemo(() => {
+    const name = String(row?.name || "").toLowerCase();
+    if (!name) return null;
+    const hit = (serverSignals || []).find(
+      (s) => s?.name && String(s.name).toLowerCase() === name,
+    );
+    if (!hit?.injuryImpact) return null;
+    return { impact: hit.injuryImpact, adjustedValue: hit.injuryAdjustedValue };
+  }, [serverSignals, row?.name]);
+
+  // Watchlist toggle — wires the ⭐ button in the popup header to
+  // useUserState.toggleWatchlist.  ``serverBacked`` drives the
+  // tooltip so users know whether the state syncs across devices.
+  const { state: userState, toggleWatchlist, serverBacked: userStateServerBacked } = useUserState();
+  const onWatchlist = useMemo(() => {
+    const name = String(row?.name || "").toLowerCase();
+    if (!name) return false;
+    const list = userState?.watchlist || [];
+    return list.some((x) => String(x).toLowerCase() === name);
+  }, [userState?.watchlist, row?.name]);
+
   const siteDetails = useMemo(() => {
     if (!row) return [];
     // Prefer the backend's 9,999-scale ``valueContribution`` stamp —
@@ -241,6 +274,23 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
             </div>
           </div>
           <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              className={`button player-popup-watchlist${onWatchlist ? " is-active" : ""}`}
+              onClick={() => toggleWatchlist(row.name)}
+              aria-pressed={onWatchlist}
+              title={
+                onWatchlist
+                  ? userStateServerBacked
+                    ? "Remove from watchlist (synced)"
+                    : "Remove from watchlist"
+                  : userStateServerBacked
+                  ? "Add to watchlist (synced across devices)"
+                  : "Add to watchlist (local)"
+              }
+            >
+              {onWatchlist ? "★" : "☆"}
+            </button>
             {onAddToTrade && (
               <button
                 className="button player-popup-action"
@@ -269,11 +319,34 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
             for a separate reason — it subtracted a legacy composite
             from the Hill blend, which produced misleading four-digit
             "discounts" on every IDP row). */}
-        <div style={{ display: "flex", gap: 20, marginTop: 14, flexWrap: "wrap" }}>
+        <div style={{ display: "flex", gap: 20, marginTop: 14, flexWrap: "wrap", alignItems: "flex-end" }}>
           <div>
             <div className="label">Our Value</div>
             <div className="value" style={{ fontSize: "1.4rem" }}>{Math.round(values.full || 0).toLocaleString()}</div>
           </div>
+          {injury && injury.impact?.appliedDiscountPct > 0 && (
+            <div>
+              <div className="label" style={{ color: "var(--red)" }}>
+                Adjusted (injury −{Number(injury.impact.appliedDiscountPct).toFixed(
+                  injury.impact.appliedDiscountPct < 1 ? 2 : 1,
+                )}%)
+              </div>
+              <div className="value" style={{ fontSize: "1.4rem", color: "var(--red)" }}>
+                {Number.isFinite(Number(injury.adjustedValue))
+                  ? Number(injury.adjustedValue).toLocaleString()
+                  : "—"}
+              </div>
+            </div>
+          )}
+          {injury && injury.impact?.offseasonSuppressed && (
+            <div
+              className="muted"
+              style={{ fontSize: "0.72rem", fontStyle: "italic", paddingBottom: 6 }}
+              title={`Headline: ${injury.impact.headline}`}
+            >
+              Injury news · offseason (value unchanged)
+            </div>
+          )}
         </div>
 
         {/* Value chain — how we arrived at Our Value */}

--- a/frontend/components/terminal/BuySellHold.jsx
+++ b/frontend/components/terminal/BuySellHold.jsx
@@ -6,6 +6,7 @@ import { useTeam } from "@/components/useTeam";
 import { useRankHistory } from "@/components/useRankHistory";
 import { useNews } from "@/components/useNews";
 import { useUserState } from "@/components/useUserState";
+import { useTerminal } from "@/components/useTerminal";
 import {
   evaluateRoster,
   SIGNAL_META,
@@ -46,6 +47,27 @@ export default function BuySellHold() {
     restoreSignal,
     serverBacked,
   } = useUserState();
+  // Server-side signals carry ``injuryImpact`` + ``injuryAdjustedValue``
+  // fields that the client-side ``evaluateRoster`` can't produce
+  // (news rulebook lives in Python).  We merge by name into the
+  // local verdicts below so every card renders the injury chip
+  // when applicable.
+  const { signals: serverSignals } = useTerminal({
+    ownerId: String(selectedTeam?.ownerId || ""),
+    teamName: selectedTeam?.name || "",
+    windowDays: 30,
+  });
+  const injuryByName = useMemo(() => {
+    const m = new Map();
+    for (const s of serverSignals || []) {
+      if (!s?.name || !s?.injuryImpact) continue;
+      m.set(String(s.name).toLowerCase(), {
+        impact: s.injuryImpact,
+        adjustedValue: s.injuryAdjustedValue,
+      });
+    }
+    return m;
+  }, [serverSignals]);
 
   const sleeperTeams = rawData?.sleeper?.teams;
   const leagueNames = useMemo(() => {
@@ -111,6 +133,7 @@ export default function BuySellHold() {
       const primaryExp = Number(dismissedMap[primary] || 0);
       const aliasExp = alias ? Number(dismissedMap[alias] || 0) : 0;
       const expiresAt = Math.max(primaryExp, aliasExp);
+      const injury = injuryByName.get(String(name).toLowerCase()) || null;
       return {
         ...v,
         signalKey: primary,
@@ -118,6 +141,8 @@ export default function BuySellHold() {
         sleeperId: sid,
         dismissedUntil: expiresAt || null,
         dismissed: expiresAt > now,
+        injuryImpact: injury?.impact || null,
+        injuryAdjustedValue: injury?.adjustedValue ?? null,
       };
     });
   }, [rawVerdicts, dismissedMap, sleeperIdByName, now]);
@@ -265,6 +290,9 @@ function SignalCard({ entry, expanded, onToggleExpand, onOpenPlayer, onDismiss, 
         <span className={`signal-badge signal-badge--${meta.tone}`}>{meta.label}</span>
       </div>
       <div className="signal-card-rationale">{verdict.reason}</div>
+      {entry.injuryImpact && (
+        <InjuryChip impact={entry.injuryImpact} adjustedValue={entry.injuryAdjustedValue} />
+      )}
       <div className="signal-card-chips">
         <Chip label="7d" value={fmtSignedInt(context.trend7)} tone={toneOf(context.trend7)} />
         <Chip label="30d" value={fmtSignedInt(context.trend30)} tone={toneOf(context.trend30)} />
@@ -349,4 +377,60 @@ function volTone(label) {
   if (label === "high") return "down";
   if (label === "med") return "warn";
   return "flat";
+}
+
+/**
+ * InjuryChip — shows the server-side injury impact so the signal
+ * card explains WHY value dropped when news is the reason.
+ *
+ * The impact shape comes from ``src/api/injury_impact.py`` and
+ * carries ``appliedDiscountPct`` + ``severity`` + ``headline`` +
+ * ``offseasonSuppressed``.  We render:
+ *
+ *   - In-season: "⚠ -3.2% (alert) · ACL update" with a title
+ *     tooltip showing the full rulebook math
+ *   - Offseason: muted "Injury news (offseason — suppressed)"
+ *     so the user sees the news exists but knows we didn't
+ *     reprice them (dynasty-horizon rule)
+ */
+function InjuryChip({ impact, adjustedValue }) {
+  if (!impact) return null;
+  const offseason = !!impact.offseasonSuppressed;
+  const discount = Number(impact.appliedDiscountPct) || 0;
+  const severity = impact.severity || "";
+  const headline = impact.headline || "";
+
+  if (offseason) {
+    return (
+      <div
+        className="signal-card-injury signal-card-injury--offseason"
+        title={`News: ${headline}\n(Suppressed — NFL offseason; dynasty value unaffected)`}
+      >
+        <span aria-hidden="true">⚪</span>
+        <span>Injury news · offseason (no reprice)</span>
+      </div>
+    );
+  }
+  const tooltipParts = [
+    `Severity: ${severity || "unknown"}`,
+    `Applied discount: ${discount.toFixed(2)}%`,
+    `Adjusted value: ${Number.isFinite(Number(adjustedValue)) ? Number(adjustedValue).toLocaleString() : "—"}`,
+    impact.headline ? `News: ${headline}` : null,
+  ].filter(Boolean);
+  return (
+    <div
+      className="signal-card-injury"
+      title={tooltipParts.join("\n")}
+      role="note"
+    >
+      <span aria-hidden="true">⚠</span>
+      <span className="signal-card-injury-pct">-{discount.toFixed(discount < 1 ? 2 : 1)}%</span>
+      {severity && (
+        <span className="signal-card-injury-severity">{severity}</span>
+      )}
+      {headline && (
+        <span className="signal-card-injury-headline">{headline}</span>
+      )}
+    </div>
+  );
 }

--- a/frontend/components/useUserState.js
+++ b/frontend/components/useUserState.js
@@ -314,6 +314,29 @@ export function useUserState() {
     [persist, state],
   );
 
+  // Patch the notification fields (email + enabled toggle).  Each
+  // field is optional so callers can flip one without clobbering the
+  // other; a null / empty-string email clears the stored address.
+  const setNotifications = useCallback(
+    ({ email, enabled } = {}) => {
+      const curr = currentState || state;
+      const next = { ...curr };
+      const patch = {};
+      if (email !== undefined) {
+        const clean = email === null ? null : String(email).trim() || null;
+        next.notificationsEmail = clean;
+        patch.notificationsEmail = clean;
+      }
+      if (enabled !== undefined) {
+        next.notificationsEnabled = !!enabled;
+        patch.notificationsEnabled = !!enabled;
+      }
+      if (Object.keys(patch).length === 0) return;
+      persist(next, patch);
+    },
+    [persist, state],
+  );
+
   const dismissSignal = useCallback(
     (signalKey, ttlMs, opts) => {
       if (!signalKey) return;
@@ -378,6 +401,7 @@ export function useUserState() {
     setSelectedTeam,
     clearSelectedTeam,
     toggleWatchlist,
+    setNotifications,
     dismissSignal,
     restoreSignal,
   };

--- a/server.py
+++ b/server.py
@@ -24,6 +24,7 @@ import traceback
 import smtplib
 import gzip
 import hashlib
+import hmac
 import shutil
 import uuid
 import urllib.request
@@ -99,6 +100,16 @@ ALERT_ENABLED = _env_bool("ALERT_ENABLED", False)
 ALERT_TO = os.getenv("ALERT_TO", "")
 ALERT_FROM = os.getenv("ALERT_FROM", "")
 ALERT_PASSWORD = os.getenv("ALERT_PASSWORD") or os.getenv("GMAIL_APP_PASSWORD", "")
+
+# Shared secret for the systemd signal-alert timer.  When set, any
+# request to ``POST /api/signal-alerts/run`` with a matching
+# ``Authorization: Bearer <token>`` header is accepted in place of
+# the usual password-session gate.  Empty = cron auth disabled
+# (only browser-sessioned admins can trigger the sweep).  Generate
+# with e.g. ``openssl rand -hex 32`` and store in .env alongside the
+# ALERT_* creds.  Treat it like a password: leaking it lets anyone
+# force a full alert send.
+SIGNAL_ALERT_CRON_TOKEN = os.getenv("SIGNAL_ALERT_CRON_TOKEN", "").strip()
 
 # ── UPTIME WATCHDOG ────────────────────────────────────────────────────
 UPTIME_CHECK_ENABLED = _env_bool("UPTIME_CHECK_ENABLED", True)
@@ -4707,13 +4718,29 @@ async def run_signal_alerts(request: Request):
       3. Returns a summary.
 
     Wire this to a cron / systemd timer for automated daily digests.
+    Cron clients authenticate via the shared ``SIGNAL_ALERT_CRON_TOKEN``
+    as a Bearer token; browser clients still need a password session.
     """
-    session = _get_auth_session(request)
-    if not session or session.get("auth_method") != "password":
-        return JSONResponse(
-            status_code=401,
-            content={"error": "admin_auth_required"},
-        )
+    # Two auth paths: (1) a password-session admin from the browser,
+    # (2) an opaque bearer token for cron / systemd timers.  Either is
+    # sufficient on its own.  Failure mode: if no session AND no token
+    # (or token mismatch), reject.  Short-circuit the token check
+    # before touching cookies so an unset token can never authorize.
+    cron_auth_ok = False
+    if SIGNAL_ALERT_CRON_TOKEN:
+        header = (request.headers.get("authorization") or "").strip()
+        if header.lower().startswith("bearer "):
+            presented = header.split(None, 1)[1].strip()
+            # Constant-time compare to avoid timing leaks.
+            if hmac.compare_digest(presented, SIGNAL_ALERT_CRON_TOKEN):
+                cron_auth_ok = True
+    if not cron_auth_ok:
+        session = _get_auth_session(request)
+        if not session or session.get("auth_method") != "password":
+            return JSONResponse(
+                status_code=401,
+                content={"error": "admin_auth_required"},
+            )
     if not latest_contract_data:
         return JSONResponse(
             status_code=503,
@@ -4722,7 +4749,7 @@ async def run_signal_alerts(request: Request):
     # Walk every user_kv row.  No pagination — at current scale
     # (dozens of users tops) this is fine.
     def _run_sweep() -> dict[str, object]:
-        db = _user_kv._read_all()
+        db = _user_kv.all_user_states()
         summary: list[dict] = []
         for username, state in db.items():
             if not isinstance(state, dict):

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -445,3 +445,43 @@ def dismissal_aliases(username: str, *, path: Path | None = None) -> dict[str, s
     if not isinstance(aliases, dict):
         return {}
     return {str(k): str(v) for k, v in aliases.items()}
+
+
+def all_user_states(*, path: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Return every stored user's state, keyed by username.
+
+    Used by admin / background jobs (e.g. the signal-alerts timer)
+    that need to walk every user.  Expired dismissals are pruned
+    per-row on read — cheap, and keeps the returned dict honest.
+    The caller gets fresh copies so they can safely mutate without
+    writing back.
+
+    Returns an empty dict if the DB is missing or empty.
+    """
+    target = path or USER_KV_PATH
+    # If the DB file doesn't exist yet (e.g. fresh install),
+    # ``_connect`` will create it.  But if the parent dir also
+    # doesn't exist and we aren't pointed at a temp path, that's
+    # fine too — the create is idempotent.
+    try:
+        conn = _connect(target)
+    except Exception:
+        return {}
+    try:
+        rows = conn.execute("SELECT username, state_json FROM user_state").fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    finally:
+        conn.close()
+
+    out: dict[str, dict[str, Any]] = {}
+    for username, state_json in rows:
+        try:
+            state = json.loads(state_json) if state_json else {}
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(state, dict):
+            continue
+        _prune_expired_dismissals(state)
+        out[str(username)] = state
+    return out

--- a/tests/api/test_signal_alerts.py
+++ b/tests/api/test_signal_alerts.py
@@ -194,3 +194,77 @@ def test_process_user_alerts_honors_delivery_error(kv_path):
     )
     assert result["delivered"] is False
     assert "delivery_error" in result["reason"]
+
+
+# ── /api/signal-alerts/run endpoint auth tests ────────────────────
+# These exercise the auth-gating on the HTTP layer.  We stub out
+# ``latest_contract_data`` so the endpoint gets past the 503 guard
+# and can reach the auth branch.  No SMTP is touched because no
+# users in the user_kv have ``notificationsEnabled`` set.
+
+
+def test_signal_alerts_run_rejects_unauthenticated(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    import server
+
+    monkeypatch.setattr(server, "latest_contract_data", {"stub": True})
+    monkeypatch.setattr(server, "SIGNAL_ALERT_CRON_TOKEN", "")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/signal-alerts/run")
+    assert res.status_code == 401
+
+
+def test_signal_alerts_run_accepts_bearer_token(monkeypatch, tmp_path):
+    """With SIGNAL_ALERT_CRON_TOKEN set and a matching bearer header,
+    the endpoint processes the sweep (even though no users qualify)."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    monkeypatch.setattr(server, "latest_contract_data", {"players": {}})
+    monkeypatch.setattr(server, "SIGNAL_ALERT_CRON_TOKEN", "test-token-abc123")
+    # all_user_states() returns {} in a fresh temp env; stub it so
+    # we don't depend on the real user_kv.sqlite on this box.
+    monkeypatch.setattr(server._user_kv, "all_user_states", lambda: {})
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post(
+            "/api/signal-alerts/run",
+            headers={"Authorization": "Bearer test-token-abc123"},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["processed"] == 0
+
+
+def test_signal_alerts_run_rejects_wrong_bearer_token(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    import server
+
+    monkeypatch.setattr(server, "latest_contract_data", {"players": {}})
+    monkeypatch.setattr(server, "SIGNAL_ALERT_CRON_TOKEN", "real-token")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post(
+            "/api/signal-alerts/run",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+    assert res.status_code == 401
+
+
+def test_signal_alerts_run_ignores_bearer_when_token_unset(monkeypatch):
+    """Sanity check: an empty server token must never authorize an
+    arbitrary bearer header — otherwise a blank .env would make the
+    endpoint open to the internet."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    monkeypatch.setattr(server, "latest_contract_data", {"players": {}})
+    monkeypatch.setattr(server, "SIGNAL_ALERT_CRON_TOKEN", "")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post(
+            "/api/signal-alerts/run",
+            headers={"Authorization": "Bearer anything"},
+        )
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary

Wires up activation items #1–#6 from the latest "what's next" list. Every piece connects an already-built backend to a user-facing surface.

- **#4 Injury badge**: InjuryChip on BuySellHold cards + PlayerPopup, with offseason-suppressed muted note.
- **#2 Watchlist star**: ⭐ on PlayerPopup — covers PMM + rankings + every popup surface.
- **#3 Share URL**: Copy Share Link button on /trade + `?share=` decoder.  Base64url, auth-free.
- **#1 Trade simulator UI**: "Simulate impact" button → before/after/Δ panel on /trade.
- **#6 Email collection**: Notifications section on /settings with email + enable toggle.
- **#5 Cron auth + timer**: `SIGNAL_ALERT_CRON_TOKEN` bearer bypass; new `dynasty-signal-alerts.{service,timer}.template` fires daily at 15:00.

Also fixed a latent bug: `_user_kv._read_all()` didn't exist — added public `all_user_states()` instead.

## Test plan

- [x] Full pytest suite: 1881 passed, 3 skipped
- [x] Full vitest suite: 690 passed
- [x] `next build` clean — no JSX/webpack errors
- [x] New tests for cron token auth (missing/wrong/blank/valid)
- [ ] Smoke test share URL encode/decode in prod
- [ ] Smoke test simulator against a real roster
- [ ] Verify systemd timer fires after SIGNAL_ALERT_CRON_TOKEN is set in .env

🤖 Generated with [Claude Code](https://claude.com/claude-code)