### PR TITLE
fix: pass explicit date to append_snapshot in history tests

### DIFF
--- a/tests/api/test_source_history.py
+++ b/tests/api/test_source_history.py
@@ -50,7 +50,7 @@ def test_append_then_load(path):
         ],
         date="2026-04-23",
     )
-    assert source_history.append_snapshot(contract, path=path) is True
+    assert source_history.append_snapshot(contract, date="2026-04-23", path=path) is True
 
     hist = source_history.load_player_history("Malik Nabers", path=path)
     assert hist["dates"] == ["2026-04-23"]
@@ -204,6 +204,7 @@ def test_backfill_from_exports_merges_with_existing(tmp_path, path):
     # Seed an existing snapshot for 2026-04-23 via the live path.
     source_history.append_snapshot(
         _make_contract([{"name": "A", "blended": 9999, "sources": {"ktc": 9000}}], date="2026-04-23"),
+        date="2026-04-23",
         path=path,
     )
     # Now point backfill at a historical export dated earlier.


### PR DESCRIPTION
## Summary

`source_history.append_snapshot` uses `_today_utc()` and never reads `contract["date"]` — so any test that asserts on a specific date must pass `date=` explicitly. The file's own comment at `test_multiple_dates_sorted` calls this out, but two tests forgot:

- `test_append_then_load` — asserted `hist["dates"] == ["2026-04-23"]`, failed today (2026-04-24).
- `test_backfill_from_exports_merges_with_existing` — filtered `hist["blended"]` for the date `"2026-04-23"`, which would silently return nothing once the wall clock rolled forward.

Both now pass `date="2026-04-23"` to `append_snapshot`. No production code changes.

## Test plan

- [x] `python -m pytest tests/api/test_source_history.py -v` — all 11 pass
- [ ] CI green on the full suite

https://claude.ai/code/session_018qsGkHtknmhYNokPiA6Ce6

---
_Generated by [Claude Code](https://claude.ai/code/session_018qsGkHtknmhYNokPiA6Ce6)_