### PR TITLE
feat: centralized league registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,19 @@
 # Frontend URL — Next.js is the sole frontend (Static removed).
 FRONTEND_URL=http://127.0.0.1:3000
 
-# Canonical Sleeper league IDs used by Dynasty Scraper.py.
-# Backend is the source of truth; frontend reads from backend payload.
+# Canonical Sleeper league IDs.
+#
+# League configuration now lives in config/leagues/registry.json,
+# which is the authoritative source once present.  The env vars
+# below are the single-league back-compat fallback — when the
+# registry file is missing (fresh dev checkout, CI without config),
+# code reads SLEEPER_LEAGUE_ID from here to synthesise a one-league
+# registry.  Once a registry.json exists, these env vars are
+# ignored for league-ID resolution.  See config/leagues/README.md
+# for how to add leagues.
+#
+# Point the code at a non-default registry file with:
+#   LEAGUE_REGISTRY_PATH=/absolute/path/to/your/registry.json
 SLEEPER_LEAGUE_ID=1312006700437352448
 BASELINE_LEAGUE_ID=1328545898812170240
 

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -230,8 +230,23 @@ def retry(max_attempts=3, delay=2, backoff=2, exceptions=(Exception,)):
 # ─────────────────────────────────────────
 # SLEEPER LEAGUE — pulls rostered players automatically
 # ─────────────────────────────────────────
+# The Sleeper league ID comes from the league registry
+# (``config/leagues/registry.json``) when present, otherwise from
+# the ``SLEEPER_LEAGUE_ID`` env var.  The hardcoded fallback at the
+# bottom is a last-resort for a fresh dev box with no registry AND
+# no env var — it preserves the scraper's ability to run standalone
+# without any config.  Multi-league scrape is a future refactor;
+# for now we still scrape exactly one league per run.
+try:
+    from src.api import league_registry as _league_registry  # noqa: E402
+    _registry_league_id = _league_registry.get_sleeper_league_id()
+except Exception:  # noqa: BLE001 — registry is optional at scrape time
+    _registry_league_id = None
 DEFAULT_SLEEPER_LEAGUE_ID = "1312006700437352448"
-SLEEPER_LEAGUE_ID = _env_str("SLEEPER_LEAGUE_ID", DEFAULT_SLEEPER_LEAGUE_ID)
+SLEEPER_LEAGUE_ID = _env_str(
+    "SLEEPER_LEAGUE_ID",
+    _registry_league_id or DEFAULT_SLEEPER_LEAGUE_ID,
+)
 
 # ─────────────────────────────────────────
 # TRADE MOVEMENT ALERTS — email when your roster players move 5%+

--- a/config/leagues/README.md
+++ b/config/leagues/README.md
@@ -1,0 +1,153 @@
+# League registry
+
+Source of truth for every dynasty league the app knows about.
+
+The app was originally built around one Sleeper league (the ID lived in
+`SLEEPER_LEAGUE_ID` env var). That env var still works — if
+`registry.json` is missing or empty, the code falls back to reading
+the env var and synthesising a one-league registry. Once you drop a
+`registry.json` in this directory, the env var is ignored.
+
+## Files
+
+- `registry.json` — the active registry. Edited by operators,
+  loaded at process start. Schema: `{ schemaVersion, defaultLeagueKey,
+  leagues: [...] }`.
+- `default_superflex_idp.template.json` — legacy roster-settings
+  template kept around for reference; not loaded at runtime.
+
+## Schema
+
+```jsonc
+{
+  "schemaVersion": 1,                   // bump if the shape changes
+  "defaultLeagueKey": "dynasty_main",   // which league unauthenticated
+                                        // users see on landing
+  "leagues": [
+    {
+      "key": "dynasty_main",            // stable internal id — NEVER
+                                        // reuse once assigned, even
+                                        // if the league is deleted.
+                                        // Used in URLs + storage paths.
+      "displayName": "Dynasty Main (Superflex + TEP + IDP)",
+      "sleeperLeagueId": "1312006700437352448",
+      "scoringProfile": "superflex_tep15_ppr1",  // marker; actual
+                                        // scoring still lives in
+                                        // data_contract.py. Shared
+                                        // between leagues when the
+                                        // scoring matches.
+      "idpEnabled": true,               // gates the IDP tab + IDP
+                                        // sources for this league
+      "active": true,                   // false hides from switcher
+                                        // but lookups still work
+      "aliases": ["main", "idp"],       // alternate keys accepted by
+                                        // get_league_by_key() —
+                                        // useful for URL shortforms
+      "rosterSettings": {               // free-form dict; callers
+                                        // pull the fields they care
+                                        // about. No schema enforcement.
+        "teamCount": 12,
+        "rosterSize": 30,
+        "starters": { "QB": 1, "RB": 2, "WR": 3, "TE": 1, ... }
+      },
+      "defaultTeamMap": {               // username → default team
+                                        // lookup for auto-selection
+                                        // on fresh devices
+        "jasonleetucker": {
+          "ownerId": "",                // optional Sleeper user_id
+          "teamName": "Rossini Panini"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Adding a third league
+
+1. Get the Sleeper league ID from the URL:
+   `https://sleeper.com/leagues/<this-is-the-id>/...`
+
+2. Edit `config/leagues/registry.json` and add an entry:
+
+   ```json
+   {
+     "key": "dynasty_bestball",
+     "displayName": "Best-ball Dynasty",
+     "sleeperLeagueId": "9876543210",
+     "scoringProfile": "bestball_ppr1",
+     "idpEnabled": false,
+     "active": true,
+     "aliases": ["bestball"],
+     "rosterSettings": {
+       "teamCount": 10,
+       "rosterSize": 20,
+       "starters": { "QB": 1, "RB": 2, "WR": 3, "TE": 1, "FLEX": 2, "SFLEX": 1 }
+     },
+     "defaultTeamMap": {}
+   }
+   ```
+
+3. Restart the backend (or call the admin reload endpoint if added):
+
+   ```
+   sudo systemctl restart dynasty
+   ```
+
+4. Verify it loaded:
+
+   ```
+   curl -s http://127.0.0.1:8000/api/leagues | jq
+   ```
+
+## Rules for `key`
+
+- Lowercase snake_case: `dynasty_main`, `best_ball_12`, etc.
+- **Never reuse a key.** If you delete a league, the key is retired
+  forever — storage paths, URL bookmarks, and user state are all
+  keyed on it.
+- **Never change a key** for a live league. If you must rename,
+  leave the old key as an alias and introduce a new canonical key:
+
+  ```json
+  "key": "dynasty_main_v2",
+  "aliases": ["dynasty_main", "main", "idp"]
+  ```
+
+## What changes when you flip `idpEnabled: false`
+
+Today: the registry stores the flag but callers haven't been wired
+up to consume it yet. That's deliberate — this first refactor adds
+the registry as the source of truth without changing ranking
+behavior. Once Phase 1 of the multi-league plan ships, callers will:
+
+- gate IDP-source registration on `idpEnabled`
+- hide the IDP rankings tab in the UI
+- skip the IDP backbone build in the ranking pipeline
+- drop the "IDP" bucket from portfolio summaries
+
+Until then, `idpEnabled` is advisory — the IDP pipeline runs for all
+leagues regardless. Document-only until the downstream wiring lands.
+
+## What `scoringProfile` does
+
+Today: marker string; no behavior hangs off it yet. The plan is to
+add `config/scoring/<profile>.json` files defining PPR / TEP /
+superflex / etc. and have the ranking pipeline pick up the profile
+matching the league being rendered. Two leagues that share scoring
+can point at the same profile — which is why scoring lives on the
+league, not the scoring profile.
+
+## Testing your changes
+
+Run the registry unit tests:
+
+```
+python3 -m pytest tests/api/test_league_registry.py -v
+```
+
+And the full suite to make sure nothing downstream blew up:
+
+```
+python3 -m pytest tests/ -q
+```

--- a/config/leagues/registry.json
+++ b/config/leagues/registry.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 1,
+  "defaultLeagueKey": "dynasty_main",
+  "leagues": [
+    {
+      "key": "dynasty_main",
+      "displayName": "Dynasty Main (Superflex + TEP + IDP)",
+      "sleeperLeagueId": "1312006700437352448",
+      "scoringProfile": "superflex_tep15_ppr1",
+      "idpEnabled": true,
+      "active": true,
+      "aliases": ["main", "idp", "primary"],
+      "rosterSettings": {
+        "teamCount": 12,
+        "rosterSize": 30,
+        "taxiSize": 5,
+        "starters": {
+          "QB": 1,
+          "RB": 2,
+          "WR": 3,
+          "TE": 1,
+          "FLEX": 2,
+          "SFLEX": 1,
+          "DL": 2,
+          "LB": 2,
+          "DB": 2,
+          "IDP_FLEX": 2
+        },
+        "flexEligible": ["RB", "WR", "TE"],
+        "sflexEligible": ["QB", "RB", "WR", "TE"],
+        "idpFlexEligible": ["DL", "LB", "DB"]
+      },
+      "defaultTeamMap": {
+        "jasonleetucker": {
+          "ownerId": "",
+          "teamName": "Rossini Panini"
+        }
+      }
+    },
+    {
+      "key": "dynasty_new",
+      "displayName": "Dynasty New (Superflex + TEP, no IDP)",
+      "sleeperLeagueId": "REPLACE_WITH_NEW_SLEEPER_ID",
+      "scoringProfile": "superflex_tep15_ppr1",
+      "idpEnabled": false,
+      "active": false,
+      "aliases": ["new", "non-idp"],
+      "rosterSettings": {
+        "teamCount": 12,
+        "rosterSize": 24,
+        "taxiSize": 5,
+        "starters": {
+          "QB": 1,
+          "RB": 2,
+          "WR": 3,
+          "TE": 1,
+          "FLEX": 2,
+          "SFLEX": 1
+        },
+        "flexEligible": ["RB", "WR", "TE"],
+        "sflexEligible": ["QB", "RB", "WR", "TE"]
+      },
+      "defaultTeamMap": {}
+    }
+  ]
+}

--- a/server.py
+++ b/server.py
@@ -70,6 +70,7 @@ from src.api import signal_alerts as _signal_alerts
 from src.api import terminal as _terminal
 from src.api import trade_simulator as _trade_simulator
 from src.api import user_kv as _user_kv
+from src.api import league_registry as _league_registry
 from src.news import NewsService, build_default_service
 
 # ── CONFIG ──────────────────────────────────────────────────────────────
@@ -1918,6 +1919,34 @@ async def post_rankings_overrides(request: Request):
     return JSONResponse(content=contract_payload, headers=headers)
 
 
+@app.get("/api/leagues")
+async def get_leagues(request: Request):
+    """List every configured league.
+
+    Public endpoint — the response contains no secrets (no Sleeper
+    league IDs, no auth tokens).  The ``key`` is the stable identifier
+    callers thread through the rest of the API when we eventually
+    add ``?leagueId=`` parameters to league-scoped endpoints.
+
+    Two views:
+      * Anonymous:     active leagues only.
+      * Authenticated: active leagues + the user's resolved default
+                       (``userDefaultKey``), which the UI uses to
+                       pre-select the right league on cold start.
+    """
+    session = _get_auth_session(request)
+    leagues = [cfg.public_dict() for cfg in _league_registry.active_leagues()]
+    body: dict[str, Any] = {
+        "leagues": leagues,
+        "defaultKey": _league_registry.default_league_key(),
+    }
+    if session:
+        username = session.get("username") or ""
+        user_default = _league_registry.get_user_default_league(username)
+        body["userDefaultKey"] = user_default.key if user_default else None
+    return JSONResponse(content=body, headers={"Cache-Control": "no-store"})
+
+
 @app.get("/api/status")
 async def get_status():
     """Return scraper status info."""
@@ -2777,7 +2806,21 @@ async def get_scaffold_report():
 # Uses a decay curve to fill/extrapolate KTC values to all 72 picks.
 DRAFT_DATA_XLSX = Path(__file__).parent / "CSVs" / "Draft Data.xlsx"
 DRAFT_DATA_CSV = Path(__file__).parent / "CSVs" / "draft_data.csv"
-SLEEPER_LEAGUE_ID_FOR_DRAFT = os.getenv("SLEEPER_LEAGUE_ID", "1312006700437352448")
+
+
+def _sleeper_league_id_for_draft() -> str:
+    """Resolve the Sleeper league ID for draft endpoints via the
+    league registry.  Previously a module-level constant read from
+    ``SLEEPER_LEAGUE_ID`` env var; now routes through
+    ``league_registry.get_sleeper_league_id()`` which itself falls
+    back to the env var when no registry.json is configured.
+
+    Returns empty string when no league is configured at all so
+    callers can short-circuit instead of making a Sleeper call to
+    ``/league/``.
+    """
+    sid = _league_registry.get_sleeper_league_id()
+    return sid or ""
 _KTC_TOTAL_PICKS = 72  # fill rookie data for all 6 rounds (12 teams × 6 rounds)
 DRAFT_TOTAL_BUDGET = 1200  # $100 × 12 teams
 
@@ -3214,13 +3257,19 @@ def _fetch_draft_capital():
     first_name_to_team: dict[str, str] = {}
     all_team_names: list[str] = []
     try:
+        _league_id_for_draft = _sleeper_league_id_for_draft()
+        if not _league_id_for_draft:
+            # No league configured at all — skip the Sleeper joins and
+            # leave the mapping empty; downstream code renders draft
+            # capital without a team-name column.
+            raise RuntimeError("no_sleeper_league_configured")
         rosters_resp = urllib.request.urlopen(
-            f"https://api.sleeper.app/v1/league/{SLEEPER_LEAGUE_ID_FOR_DRAFT}/rosters", timeout=15
+            f"https://api.sleeper.app/v1/league/{_league_id_for_draft}/rosters", timeout=15
         )
         rosters = json.loads(rosters_resp.read())
 
         users_resp = urllib.request.urlopen(
-            f"https://api.sleeper.app/v1/league/{SLEEPER_LEAGUE_ID_FOR_DRAFT}/users", timeout=15
+            f"https://api.sleeper.app/v1/league/{_league_id_for_draft}/users", timeout=15
         )
         user_map: dict[str, str] = {}
         for u in json.loads(users_resp.read()):
@@ -3243,7 +3292,7 @@ def _fetch_draft_capital():
         all_team_names = list(roster_name_by_id.values())
 
         drafts_resp = urllib.request.urlopen(
-            f"https://api.sleeper.app/v1/league/{SLEEPER_LEAGUE_ID_FOR_DRAFT}/drafts", timeout=15
+            f"https://api.sleeper.app/v1/league/{_league_id_for_draft}/drafts", timeout=15
         )
         slot_to_roster: dict[int, int] = {}
         for draft in json.loads(drafts_resp.read()):
@@ -3525,9 +3574,17 @@ except Exception as _exc:  # noqa: BLE001
 
 
 def _public_league_id() -> str:
-    """Return the current public-facing league id.  Falls back to the
-    same env default used by the private draft-capital route."""
-    return os.getenv("SLEEPER_LEAGUE_ID", SLEEPER_LEAGUE_ID_FOR_DRAFT).strip()
+    """Return the current public-facing league id.
+
+    Routes through the league registry (``league_registry``) so that
+    the ID comes from ``config/leagues/registry.json`` when present
+    and from ``SLEEPER_LEAGUE_ID`` env var as a back-compat fallback.
+    Returns empty string when no league is configured — callers that
+    immediately hit Sleeper should treat that as "no snapshot
+    available" rather than calling ``/league/`` with an empty path.
+    """
+    sid = _league_registry.get_sleeper_league_id()
+    return (sid or "").strip()
 
 
 def _rebuild_public_snapshot(league_id: str, *, trigger: str = "sync"):

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4583,7 +4583,17 @@ def _resolve_league_context(
         "fetched_from_sleeper": False,
     }
 
-    league_id = os.getenv("SLEEPER_LEAGUE_ID", "").strip()
+    # Resolve via the league registry first (reads registry.json when
+    # present, falls back to the SLEEPER_LEAGUE_ID env var).  The
+    # env-var fallback is what keeps existing deployments working
+    # without touching config files.
+    try:
+        from src.api import league_registry as _league_registry  # local import avoids a cycle
+        league_id = (_league_registry.get_sleeper_league_id() or "").strip()
+    except Exception:  # noqa: BLE001 — if the registry module is broken, fall back to env var
+        league_id = ""
+    if not league_id:
+        league_id = os.getenv("SLEEPER_LEAGUE_ID", "").strip()
     if not league_id:
         # No league configured — return the fallback without populating
         # the cache so a later SLEEPER_LEAGUE_ID env change takes

--- a/src/api/league_registry.py
+++ b/src/api/league_registry.py
@@ -1,0 +1,459 @@
+"""League registry — single source of truth for every configured league.
+
+Why this module exists
+──────────────────────
+The app was originally built around one Sleeper dynasty league whose ID
+lived in ``SLEEPER_LEAGUE_ID`` env var and was read at module load from
+a dozen different places.  Adding a second league (different Sleeper
+ID, different roster rules, no IDP) meant either (a) duplicating every
+read-site or (b) routing every call through a central registry.  This
+module is (b).
+
+Design
+──────
+* A **stable internal key** (``"dynasty_main"``, ``"dynasty_new"``)
+  identifies each league.  Keys are opaque strings — never show the
+  Sleeper league ID in URLs or storage paths; use the key.
+* The registry is loaded from ``config/leagues/registry.json`` on
+  first use and cached for the process lifetime.  Reload is explicit
+  via ``reload_registry()`` — callers in tests use this.
+* If the registry file doesn't exist, we **synthesise a single-league
+  registry from env vars** (``SLEEPER_LEAGUE_ID``).  This keeps every
+  existing deployment working without a config-file migration step.
+* The registry is **immutable at runtime** — no endpoint writes to it.
+  Operators edit the JSON and restart (or call ``reload_registry()``
+  from an admin endpoint).
+
+Not in scope for v1
+───────────────────
+* Per-league scoring profiles (the ``scoring_profile`` field is a
+  string marker for now; when two leagues need different scoring,
+  wire ``config/scoring/<profile>.json`` off this key).
+* Per-league rank engine branching (IDP gating, TEP override).  The
+  registry holds the *data*; wiring it into ``data_contract.py`` is a
+  separate refactor.
+* Multi-user default-team mapping beyond a static map.  A user's
+  chosen team comes from ``user_kv`` in practice; the registry's
+  ``default_team_map`` is for unauthenticated cold-starts only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Default registry location.  Override with ``LEAGUE_REGISTRY_PATH``
+# env var (useful in tests and for staging boxes that need to point
+# at a non-default file).
+_DEFAULT_REGISTRY_PATH: Path = (
+    Path(__file__).resolve().parents[2] / "config" / "leagues" / "registry.json"
+)
+
+
+@dataclass(frozen=True)
+class LeagueConfig:
+    """Immutable snapshot of one league's configuration.
+
+    ``key`` is the internal identifier — this is what endpoints and
+    URLs use.  ``sleeper_league_id`` is an implementation detail we
+    want to hide from the rest of the app.
+
+    ``default_team_map`` maps a username to a ``{"ownerId", "teamName"}``
+    dict so we can auto-select a team for a signed-in user on a fresh
+    device without round-tripping to Sleeper.  Keys are lower-cased on
+    read to be case-insensitive.
+    """
+
+    key: str
+    display_name: str
+    sleeper_league_id: str
+    scoring_profile: str
+    roster_settings: dict[str, Any]
+    idp_enabled: bool
+    default_team_map: dict[str, dict[str, str]] = field(default_factory=dict)
+    active: bool = True
+    # Aliases let operators reference a league by an old env-var name
+    # or a friendly URL slug.  Matched case-insensitively by
+    # ``get_league_by_key``.
+    aliases: tuple[str, ...] = field(default_factory=tuple)
+
+    def public_dict(self) -> dict[str, Any]:
+        """Safe payload for /api/leagues — no Sleeper ID leakage.
+
+        The Sleeper league ID is technically public (anyone can fetch
+        /v1/league/<id>), but the registry hides it behind the opaque
+        key so we don't bake a league-identifier choice into URL
+        formats and then struggle to swap leagues later.
+        """
+        return {
+            "key": self.key,
+            "displayName": self.display_name,
+            "scoringProfile": self.scoring_profile,
+            "idpEnabled": self.idp_enabled,
+            "rosterSettings": dict(self.roster_settings),
+            "active": self.active,
+        }
+
+
+# ── Internal state ────────────────────────────────────────────────
+# Two caches:
+#   * ``_FILE_LOADED`` / ``_FILE_DEFAULT_KEY`` — state read from a
+#     ``registry.json`` on disk.  Cached for the process lifetime
+#     because the file doesn't change without an explicit
+#     ``reload_registry()``.
+#   * No cache for the env-var fallback path — ``SLEEPER_LEAGUE_ID``
+#     gets re-read on every call so tests that set it in
+#     ``setUpClass`` see their change take effect immediately.  The
+#     registry file "wins" over the env var when both are present,
+#     matching the documented precedence in config/leagues/README.md.
+_LOCK = threading.Lock()
+_FILE_LOADED: dict[str, LeagueConfig] | None = None
+_FILE_DEFAULT_KEY: str | None = None
+_FILE_CHECKED: bool = False  # sentinel: True once we've tried the file
+
+
+def _parse_league_entry(entry: dict[str, Any]) -> LeagueConfig:
+    """Turn one JSON blob into a frozen ``LeagueConfig``.
+
+    Validates required fields and normalizes the default-team map.
+    Raises ``ValueError`` on a malformed entry — malformed registries
+    should fail loud, not silently drop leagues.
+    """
+    key = str(entry.get("key") or "").strip()
+    if not key:
+        raise ValueError("league entry missing 'key'")
+    sleeper_id = str(entry.get("sleeperLeagueId") or "").strip()
+    if not sleeper_id:
+        raise ValueError(f"league '{key}' missing sleeperLeagueId")
+    display_name = str(entry.get("displayName") or key).strip()
+    scoring_profile = str(entry.get("scoringProfile") or "default").strip()
+    idp_enabled = bool(entry.get("idpEnabled", False))
+    roster_settings = entry.get("rosterSettings") or {}
+    if not isinstance(roster_settings, dict):
+        raise ValueError(f"league '{key}' rosterSettings must be a dict")
+    active = entry.get("active", True)
+    if not isinstance(active, bool):
+        active = str(active).lower() not in ("false", "0", "no", "")
+
+    # Default team map: {"username": {"ownerId": "...", "teamName": "..."}}.
+    # Usernames are lower-cased on storage so lookups are
+    # case-insensitive without touching the caller.
+    raw_map = entry.get("defaultTeamMap") or {}
+    team_map: dict[str, dict[str, str]] = {}
+    if isinstance(raw_map, dict):
+        for username, spec in raw_map.items():
+            if not isinstance(username, str) or not isinstance(spec, dict):
+                continue
+            owner_id = str(spec.get("ownerId") or "").strip()
+            team_name = str(spec.get("teamName") or "").strip()
+            if owner_id or team_name:
+                team_map[username.lower()] = {
+                    "ownerId": owner_id,
+                    "teamName": team_name,
+                }
+
+    aliases_raw = entry.get("aliases") or []
+    aliases = tuple(
+        str(a).strip() for a in aliases_raw
+        if isinstance(a, str) and a.strip()
+    )
+
+    return LeagueConfig(
+        key=key,
+        display_name=display_name,
+        sleeper_league_id=sleeper_id,
+        scoring_profile=scoring_profile,
+        roster_settings=dict(roster_settings),
+        idp_enabled=idp_enabled,
+        default_team_map=team_map,
+        active=active,
+        aliases=aliases,
+    )
+
+
+def _synthesise_from_env() -> tuple[dict[str, LeagueConfig], str | None]:
+    """Build a single-league registry from env vars.
+
+    Backward-compat path: when no registry file exists, fall back to
+    the legacy ``SLEEPER_LEAGUE_ID`` env var and pretend it's a
+    one-league registry.  Keeps existing deployments working after
+    this refactor with zero config changes.
+
+    Returns an empty registry if no env var is set either — callers
+    should handle the empty case gracefully (e.g.,
+    ``get_default_league()`` returns None).
+    """
+    sleeper_id = os.getenv("SLEEPER_LEAGUE_ID", "").strip()
+    if not sleeper_id:
+        return {}, None
+
+    entry = LeagueConfig(
+        key="default",
+        display_name=os.getenv("SLEEPER_LEAGUE_NAME", "Dynasty League").strip() or "Dynasty League",
+        sleeper_league_id=sleeper_id,
+        scoring_profile="default",
+        roster_settings={},
+        idp_enabled=_env_bool("SLEEPER_LEAGUE_IDP_ENABLED", True),
+        default_team_map={},
+        active=True,
+        aliases=("main",),
+    )
+    return {"default": entry}, "default"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _load_from_file(path: Path) -> tuple[dict[str, LeagueConfig], str | None]:
+    """Parse the registry JSON and return ``({key: cfg}, default_key)``.
+
+    ``default_key`` honours ``defaultLeagueKey`` in the file; if absent,
+    uses the first active league; if still none, returns None.  The
+    file format is documented in ``config/leagues/README.md``.
+    """
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, None
+    except json.JSONDecodeError as exc:
+        log.error("league registry %s is not valid JSON: %s", path, exc)
+        return {}, None
+
+    entries = raw.get("leagues") or []
+    if not isinstance(entries, list):
+        log.error("league registry %s: 'leagues' must be a list", path)
+        return {}, None
+
+    registry: dict[str, LeagueConfig] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            cfg = _parse_league_entry(entry)
+        except ValueError as exc:
+            log.error("league registry %s: skipping malformed entry: %s", path, exc)
+            continue
+        if cfg.key in registry:
+            log.error(
+                "league registry %s: duplicate key %r, keeping first",
+                path,
+                cfg.key,
+            )
+            continue
+        registry[cfg.key] = cfg
+
+    default_key_raw = str(raw.get("defaultLeagueKey") or "").strip()
+    default_key: str | None = None
+    if default_key_raw and default_key_raw in registry:
+        default_key = default_key_raw
+    else:
+        # Fall back to first active league; if nothing's active, first
+        # listed.  Keeps the "default league" concept well-defined
+        # even when operators forget to set it explicitly.
+        for cfg in registry.values():
+            if cfg.active:
+                default_key = cfg.key
+                break
+        if default_key is None and registry:
+            default_key = next(iter(registry.keys()))
+
+    return registry, default_key
+
+
+def _ensure_file_loaded() -> None:
+    """Cache the file-sourced registry on first access.
+
+    This is the ONLY long-lived cache.  The env-var fallback is
+    re-evaluated on every public call — see ``_resolve_registry()``
+    — because tests (and operators) set ``SLEEPER_LEAGUE_ID`` at
+    runtime and expect the change to take effect immediately.
+    """
+    global _FILE_LOADED, _FILE_DEFAULT_KEY, _FILE_CHECKED
+    if _FILE_CHECKED:
+        return
+    with _LOCK:
+        if _FILE_CHECKED:
+            return
+        override = os.getenv("LEAGUE_REGISTRY_PATH", "").strip()
+        path = Path(override) if override else _DEFAULT_REGISTRY_PATH
+        registry, default_key = _load_from_file(path)
+        _FILE_LOADED = registry
+        _FILE_DEFAULT_KEY = default_key
+        _FILE_CHECKED = True
+
+
+def _resolve_registry() -> tuple[dict[str, LeagueConfig], str | None]:
+    """Return the effective registry + default key right now.
+
+    Precedence:
+      1. ``registry.json`` file (cached after first read)
+      2. ``SLEEPER_LEAGUE_ID`` env var (re-read every call)
+      3. empty
+
+    This hot-reads the env var on every call so tests that mutate
+    ``SLEEPER_LEAGUE_ID`` in ``setUpClass`` (e.g. the public-league
+    route tests) see the change without calling ``reload_registry()``.
+    """
+    _ensure_file_loaded()
+    if _FILE_LOADED:
+        return _FILE_LOADED, _FILE_DEFAULT_KEY
+    # File wasn't found / was empty — synthesise from env var live.
+    return _synthesise_from_env()
+
+
+# ══ Public API ══════════════════════════════════════════════════════
+
+
+def reload_registry() -> None:
+    """Drop the cache and re-read the registry on next access.
+
+    Called from tests to point the registry at a fixture file, and
+    from any future admin endpoint that rewrites the registry.json on
+    disk.  Safe to call from any thread.
+    """
+    global _FILE_LOADED, _FILE_DEFAULT_KEY, _FILE_CHECKED
+    with _LOCK:
+        _FILE_LOADED = None
+        _FILE_DEFAULT_KEY = None
+        _FILE_CHECKED = False
+
+
+def all_leagues() -> list[LeagueConfig]:
+    """Return every registered league (active + inactive).
+
+    Order is registry-file order — the first entry in the JSON comes
+    first here too.  Don't sort; operators may rely on ordering for
+    UI display.
+    """
+    registry, _ = _resolve_registry()
+    return list(registry.values())
+
+
+def active_leagues() -> list[LeagueConfig]:
+    """Return only leagues with ``active: true``.
+
+    Use this for endpoints that drive user-visible switchers — an
+    ``active: false`` entry is typically a league the operator is
+    wiring up but doesn't want users to land on yet.
+    """
+    return [cfg for cfg in all_leagues() if cfg.active]
+
+
+def get_league_by_key(key: str | None) -> LeagueConfig | None:
+    """Look up a league by its stable key or any alias.
+
+    Returns None for an unknown key (no exception) so callers can
+    defensively check + fall back to the default league.  Matching is
+    case-insensitive on both the key and the aliases.
+    """
+    if not key:
+        return None
+    needle = str(key).strip().lower()
+    if not needle:
+        return None
+    registry, _ = _resolve_registry()
+    for cfg in registry.values():
+        if cfg.key.lower() == needle:
+            return cfg
+        if any(alias.lower() == needle for alias in cfg.aliases):
+            return cfg
+    return None
+
+
+def get_default_league() -> LeagueConfig | None:
+    """Return the primary league — what unauthenticated / cold-start
+    callers should use.
+
+    Resolves in this order:
+      1. ``defaultLeagueKey`` in the registry JSON (if set + active)
+      2. First active league in the registry
+      3. First league in the registry (even if inactive)
+      4. None (no leagues configured at all)
+
+    The last case means no ``config/leagues/registry.json`` and no
+    ``SLEEPER_LEAGUE_ID`` env var — a fresh developer machine with no
+    setup.  Callers should treat this as "no Sleeper data available".
+    """
+    registry, default_key = _resolve_registry()
+    if default_key and default_key in registry:
+        return registry[default_key]
+    for cfg in registry.values():
+        if cfg.active:
+            return cfg
+    return next(iter(registry.values()), None)
+
+
+def get_user_default_league(username: str | None) -> LeagueConfig | None:
+    """Pick the right league to land a signed-in user on.
+
+    Resolution order:
+      1. Any active league whose ``default_team_map`` contains the
+         user's username — this is the operator saying "Jason's team
+         is in League A". Gives us a deterministic landing page on
+         fresh devices without reading user_kv.
+      2. ``get_default_league()`` fallback.
+
+    A user's *last chosen* league (stored in ``user_kv``) is a
+    different, higher-priority signal — it lives in user state, not in
+    the registry.  Callers should check user_kv first and fall through
+    to this function when no explicit choice is recorded.
+    """
+    if username:
+        needle = str(username).strip().lower()
+        for cfg in all_leagues():
+            if not cfg.active:
+                continue
+            if needle in cfg.default_team_map:
+                return cfg
+    return get_default_league()
+
+
+def get_league_roster_settings(key: str | None) -> dict[str, Any]:
+    """Return the roster-settings dict for a league, or ``{}``.
+
+    Shape is operator-defined in the JSON — the registry doesn't
+    enforce a schema on ``rosterSettings`` beyond "it's a dict".  This
+    is deliberate: some leagues care about IDP slots, some don't;
+    some surface taxi/IR, some don't.  Callers should pull the fields
+    they care about and ignore the rest.
+    """
+    cfg = get_league_by_key(key)
+    if cfg is None:
+        return {}
+    # Return a shallow copy so callers can't mutate the cached dict.
+    return dict(cfg.roster_settings)
+
+
+def get_sleeper_league_id(key: str | None = None) -> str | None:
+    """Return the Sleeper league ID for a given key, or the default's.
+
+    ``key=None`` returns the default league's Sleeper ID — this is the
+    back-compat drop-in replacement for
+    ``os.getenv("SLEEPER_LEAGUE_ID")``.  Returns None only when no
+    league is configured at all (fresh dev machine).
+
+    Use this EVERYWHERE you previously read the env var directly.
+    That way a future multi-league rollout can thread ``key`` through
+    the callers without touching this helper.
+    """
+    if key is None:
+        cfg = get_default_league()
+    else:
+        cfg = get_league_by_key(key)
+    return cfg.sleeper_league_id if cfg else None
+
+
+def default_league_key() -> str | None:
+    """Return the default league's key, or None if none configured."""
+    cfg = get_default_league()
+    return cfg.key if cfg else None

--- a/tests/api/test_league_registry.py
+++ b/tests/api/test_league_registry.py
@@ -1,0 +1,461 @@
+"""Tests for ``src.api.league_registry``.
+
+The registry is the single source of truth for every configured
+league.  These tests pin down:
+
+* JSON parsing (valid + malformed entries)
+* Fallback to ``SLEEPER_LEAGUE_ID`` env var when no file exists
+* Helper lookups (by key, by alias, default league, user default)
+* Roster settings accessor
+* ``LEAGUE_REGISTRY_PATH`` env override resolution
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.api import league_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry(monkeypatch):
+    """Clear module-level cache and env overrides before each test.
+
+    Without this, tests that load a fixture file would leak the
+    cached state into the next test.  We also null out the env vars
+    the registry consults so tests have a clean starting point —
+    each test opts in explicitly.
+    """
+    monkeypatch.delenv("SLEEPER_LEAGUE_ID", raising=False)
+    monkeypatch.delenv("SLEEPER_LEAGUE_NAME", raising=False)
+    monkeypatch.delenv("SLEEPER_LEAGUE_IDP_ENABLED", raising=False)
+    monkeypatch.delenv("LEAGUE_REGISTRY_PATH", raising=False)
+    league_registry.reload_registry()
+    yield
+    league_registry.reload_registry()
+
+
+def _write_registry(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "registry.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ── Basic parsing + lookups ───────────────────────────────────────
+
+
+def test_load_from_file_returns_configured_leagues(tmp_path, monkeypatch):
+    path = _write_registry(
+        tmp_path,
+        {
+            "schemaVersion": 1,
+            "defaultLeagueKey": "main",
+            "leagues": [
+                {
+                    "key": "main",
+                    "displayName": "Main League",
+                    "sleeperLeagueId": "12345",
+                    "scoringProfile": "superflex_tep15",
+                    "idpEnabled": True,
+                    "active": True,
+                    "rosterSettings": {"teamCount": 12},
+                },
+                {
+                    "key": "secondary",
+                    "displayName": "Secondary League",
+                    "sleeperLeagueId": "67890",
+                    "scoringProfile": "superflex_tep15",
+                    "idpEnabled": False,
+                    "active": True,
+                    "rosterSettings": {"teamCount": 10},
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    leagues = league_registry.all_leagues()
+    assert [c.key for c in leagues] == ["main", "secondary"]
+    assert league_registry.get_default_league().key == "main"
+    assert league_registry.get_sleeper_league_id() == "12345"
+    assert league_registry.get_sleeper_league_id("secondary") == "67890"
+
+
+def test_get_league_by_key_matches_alias(tmp_path, monkeypatch):
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {
+                    "key": "dynasty_main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "12345",
+                    "aliases": ["main", "idp"],
+                    "rosterSettings": {},
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    assert league_registry.get_league_by_key("dynasty_main").key == "dynasty_main"
+    assert league_registry.get_league_by_key("main").key == "dynasty_main"
+    assert league_registry.get_league_by_key("IDP").key == "dynasty_main"  # case-insensitive
+    assert league_registry.get_league_by_key("unknown") is None
+    assert league_registry.get_league_by_key(None) is None
+    assert league_registry.get_league_by_key("") is None
+
+
+def test_default_league_falls_back_to_first_active(tmp_path, monkeypatch):
+    """When defaultLeagueKey is missing, the first *active* league wins
+    — not just the first listed.  Inactive leagues are skipped."""
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {
+                    "key": "inactive_one",
+                    "displayName": "Off",
+                    "sleeperLeagueId": "1",
+                    "active": False,
+                    "rosterSettings": {},
+                },
+                {
+                    "key": "active_one",
+                    "displayName": "On",
+                    "sleeperLeagueId": "2",
+                    "active": True,
+                    "rosterSettings": {},
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    assert league_registry.get_default_league().key == "active_one"
+
+
+def test_active_leagues_excludes_inactive(tmp_path, monkeypatch):
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {"key": "a", "displayName": "A", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
+                {"key": "b", "displayName": "B", "sleeperLeagueId": "2", "active": False, "rosterSettings": {}},
+                {"key": "c", "displayName": "C", "sleeperLeagueId": "3", "active": True, "rosterSettings": {}},
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    active = [c.key for c in league_registry.active_leagues()]
+    assert active == ["a", "c"]
+    # all_leagues still returns everything
+    assert len(league_registry.all_leagues()) == 3
+
+
+def test_get_user_default_league_uses_team_map(tmp_path, monkeypatch):
+    """A user whose username appears in any active league's
+    default_team_map lands on THAT league, not the global default."""
+    path = _write_registry(
+        tmp_path,
+        {
+            "defaultLeagueKey": "primary",
+            "leagues": [
+                {
+                    "key": "primary",
+                    "displayName": "Primary",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                    "defaultTeamMap": {},
+                },
+                {
+                    "key": "secondary",
+                    "displayName": "Secondary",
+                    "sleeperLeagueId": "2",
+                    "active": True,
+                    "rosterSettings": {},
+                    "defaultTeamMap": {
+                        "alice": {"ownerId": "", "teamName": "Alice's Team"},
+                    },
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    assert league_registry.get_user_default_league("alice").key == "secondary"
+    assert league_registry.get_user_default_league("ALICE").key == "secondary"  # case-insensitive
+    assert league_registry.get_user_default_league("bob").key == "primary"  # fallback
+    assert league_registry.get_user_default_league(None).key == "primary"
+    assert league_registry.get_user_default_league("").key == "primary"
+
+
+def test_get_user_default_skips_inactive_team_map_match(tmp_path, monkeypatch):
+    """If the only league that lists a user is inactive, we fall back
+    to the default league rather than steering the user onto a
+    disabled league."""
+    path = _write_registry(
+        tmp_path,
+        {
+            "defaultLeagueKey": "main",
+            "leagues": [
+                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
+                {
+                    "key": "disabled",
+                    "displayName": "Off",
+                    "sleeperLeagueId": "2",
+                    "active": False,
+                    "rosterSettings": {},
+                    "defaultTeamMap": {"alice": {"ownerId": "x", "teamName": "A"}},
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    assert league_registry.get_user_default_league("alice").key == "main"
+
+
+def test_get_league_roster_settings_returns_copy(tmp_path, monkeypatch):
+    """Caller mutations must not leak into the registry cache."""
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {"teamCount": 12, "starters": {"QB": 1}},
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    settings = league_registry.get_league_roster_settings("main")
+    assert settings["teamCount"] == 12
+    settings["teamCount"] = 99  # mutate the copy
+    fresh = league_registry.get_league_roster_settings("main")
+    assert fresh["teamCount"] == 12, "registry should hand out fresh copies"
+
+
+def test_get_league_roster_settings_unknown_key_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLEEPER_LEAGUE_ID", "12345")
+    league_registry.reload_registry()
+    assert league_registry.get_league_roster_settings("nonexistent") == {}
+
+
+# ── Env-var fallback path ─────────────────────────────────────────
+
+
+def test_falls_back_to_env_var_when_no_registry_file(monkeypatch, tmp_path):
+    """Existing single-league deployments without a registry.json
+    file must keep working via the SLEEPER_LEAGUE_ID env var."""
+    nonexistent = tmp_path / "missing.json"
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(nonexistent))
+    monkeypatch.setenv("SLEEPER_LEAGUE_ID", "99999")
+    league_registry.reload_registry()
+
+    default = league_registry.get_default_league()
+    assert default is not None
+    assert default.key == "default"
+    assert default.sleeper_league_id == "99999"
+    assert default.active is True
+    # Should also match by the synthesized "main" alias.
+    assert league_registry.get_league_by_key("main").sleeper_league_id == "99999"
+
+
+def test_no_registry_and_no_env_var_returns_none(monkeypatch, tmp_path):
+    """Fresh developer box with no config + no env: everything works
+    but returns None/empty.  Callers must handle this gracefully."""
+    nonexistent = tmp_path / "missing.json"
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(nonexistent))
+    # SLEEPER_LEAGUE_ID already cleared by the fixture
+    league_registry.reload_registry()
+
+    assert league_registry.get_default_league() is None
+    assert league_registry.all_leagues() == []
+    assert league_registry.active_leagues() == []
+    assert league_registry.get_sleeper_league_id() is None
+    assert league_registry.default_league_key() is None
+
+
+# ── Malformed input ───────────────────────────────────────────────
+
+
+def test_skips_malformed_entries_keeps_good_ones(tmp_path, monkeypatch, caplog):
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {"displayName": "Missing Key"},  # no key → skipped
+                {"key": "missing_id", "displayName": "Missing ID"},  # no sleeperLeagueId
+                {"key": "ok", "displayName": "OK", "sleeperLeagueId": "5", "rosterSettings": {}},
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    keys = [c.key for c in league_registry.all_leagues()]
+    assert keys == ["ok"], "bad entries should be skipped, good one kept"
+
+
+def test_duplicate_keys_keep_first(tmp_path, monkeypatch):
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {"key": "dup", "displayName": "First", "sleeperLeagueId": "1", "rosterSettings": {}},
+                {"key": "dup", "displayName": "Second", "sleeperLeagueId": "2", "rosterSettings": {}},
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    cfg = league_registry.get_league_by_key("dup")
+    assert cfg.display_name == "First"
+    assert cfg.sleeper_league_id == "1"
+    # Only one entry total.
+    assert len(league_registry.all_leagues()) == 1
+
+
+def test_invalid_json_returns_empty_then_env_fallback(tmp_path, monkeypatch):
+    """A corrupt registry file shouldn't brick the server — log the
+    error and fall through to the env-var fallback."""
+    path = tmp_path / "registry.json"
+    path.write_text("{ not valid json", encoding="utf-8")
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    monkeypatch.setenv("SLEEPER_LEAGUE_ID", "77777")
+    league_registry.reload_registry()
+
+    # Falls back to env var; a single league synthesized from it.
+    assert league_registry.get_default_league().sleeper_league_id == "77777"
+
+
+# ── public_dict() API response shape ──────────────────────────────
+
+
+def test_public_dict_omits_sleeper_id(tmp_path, monkeypatch):
+    """The /api/leagues response must not include the Sleeper ID —
+    the registry key is the public identifier."""
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "SECRET-ID-123",
+                    "scoringProfile": "ppr1",
+                    "idpEnabled": True,
+                    "active": True,
+                    "rosterSettings": {"teamCount": 12},
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    payload = league_registry.get_league_by_key("main").public_dict()
+    assert payload["key"] == "main"
+    assert payload["displayName"] == "Main"
+    assert payload["idpEnabled"] is True
+    assert payload["scoringProfile"] == "ppr1"
+    assert payload["rosterSettings"] == {"teamCount": 12}
+    assert payload["active"] is True
+    assert "sleeperLeagueId" not in payload
+    assert "SECRET-ID-123" not in json.dumps(payload)
+
+
+def test_api_leagues_endpoint_returns_active_leagues(tmp_path, monkeypatch):
+    """GET /api/leagues returns the list of active leagues with no
+    Sleeper IDs leaked.  Unauthenticated clients don't see
+    userDefaultKey."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "defaultLeagueKey": "main",
+            "leagues": [
+                {
+                    "key": "main",
+                    "displayName": "Main League",
+                    "sleeperLeagueId": "SECRET-111",
+                    "idpEnabled": True,
+                    "active": True,
+                    "rosterSettings": {"teamCount": 12},
+                },
+                {
+                    "key": "off",
+                    "displayName": "Off League",
+                    "sleeperLeagueId": "SECRET-222",
+                    "idpEnabled": False,
+                    "active": False,
+                    "rosterSettings": {},
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/leagues")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["defaultKey"] == "main"
+    # Only active leagues listed.
+    assert [lg["key"] for lg in body["leagues"]] == ["main"]
+    assert body["leagues"][0]["displayName"] == "Main League"
+    # No Sleeper ID anywhere in the response.
+    assert "SECRET-111" not in res.text
+    assert "SECRET-222" not in res.text
+    # Anonymous callers don't get userDefaultKey.
+    assert "userDefaultKey" not in body
+
+
+def test_default_team_map_lowercase_keys(tmp_path, monkeypatch):
+    """Usernames are lower-cased on read so lookups are
+    case-insensitive without touching the caller."""
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                    "defaultTeamMap": {
+                        "JasonLeeTucker": {"ownerId": "abc", "teamName": "T1"},
+                    },
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    cfg = league_registry.get_league_by_key("main")
+    assert "jasonleetucker" in cfg.default_team_map
+    assert cfg.default_team_map["jasonleetucker"] == {"ownerId": "abc", "teamName": "T1"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,20 @@ import os
 # ``_derive_tep_multiplier_from_league``.
 os.environ.pop("SLEEPER_LEAGUE_ID", None)
 
+# The league registry (``src/api/league_registry``) is the new source
+# of truth for Sleeper league IDs — ``_resolve_league_context`` now
+# reads from it first, falling back to the env var.  For tests we
+# point the registry at a non-existent file so its env-var fallback
+# path kicks in, and because we've cleared SLEEPER_LEAGUE_ID above,
+# the registry returns None.  Net effect: no live Sleeper fetches,
+# same as before the registry existed.
+os.environ["LEAGUE_REGISTRY_PATH"] = "/nonexistent/path/for/tests.json"
+try:
+    from src.api import league_registry as _league_registry
+    _league_registry.reload_registry()
+except Exception:  # noqa: BLE001 — conftest must never block collection
+    pass
+
 # The cache is keyed by the env var, but some tests import
 # data_contract before pytest runs this conftest (in which case the
 # cache may already carry a live Sleeper snapshot from a prior dev


### PR DESCRIPTION
## Summary

Adds `src/api/league_registry.py` as the single source of truth for every Sleeper league the app knows about. Loaded from `config/leagues/registry.json` on first use; falls back to the `SLEEPER_LEAGUE_ID` env var when no file exists so every existing deployment keeps working without config changes.

Phase 0 of the multi-league plan — wires the registry into the places that hardcoded the single league ID without changing any user-visible behavior yet.

### What

- `LeagueConfig` dataclass with: `key`, `displayName`, `sleeperLeagueId`, `scoringProfile`, `rosterSettings`, `idpEnabled`, `defaultTeamMap`, `active`, `aliases`
- `config/leagues/registry.json` — both leagues declared; second league (`dynasty_new`, no IDP) sits with `active: false` + placeholder ID for now
- `config/leagues/README.md` — operator docs for adding leagues
- Public helpers: `get_league_by_key`, `get_default_league`, `get_user_default_league`, `get_league_roster_settings`, `get_sleeper_league_id`, `all_leagues`, `active_leagues`, `reload_registry`
- `GET /api/leagues` endpoint — returns active leagues, no Sleeper IDs leaked
- Refactored `server.py`, `Dynasty Scraper.py`, `data_contract.py` to route through the registry

### Cache behavior

File-loaded state is cached for the process lifetime. The env-var fallback path is re-read live on every call so tests that set `SLEEPER_LEAGUE_ID` in `setUpClass` still work.

### Back-compat

- `SLEEPER_LEAGUE_ID` env var still works as a one-league fallback
- No endpoint URL / response-shape changes
- No data migration needed
- Every prior test still passes

### Not in scope

- Threading `leagueId` through league-scoped endpoints (still serves the default)
- IDP gating on `idpEnabled`
- TEP derivation from `scoringProfile`
- Frontend league switcher
- Per-league storage paths

## Test plan

- [x] 16 new registry unit tests (`tests/api/test_league_registry.py`)
- [x] Full pytest: 1897 passed, 3 skipped
- [x] Frontend build: clean
- [x] Manual smoke: `GET /api/leagues` returns the registry shape
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)