### PR TITLE
feat: league selector — switch + persist across reloads and devices

### DIFF
--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/components/useAuth";
 import ChatDrawer from "@/components/ChatDrawer";
 import StaleDataBanner from "@/components/StaleDataBanner";
 import TeamSwitcher from "@/components/TeamSwitcher";
+import LeagueSwitcher from "@/components/LeagueSwitcher";
 
 // ── Route definitions ────────────────────────────────────────────────────
 // Primary destinations shown in desktop top nav
@@ -75,6 +76,7 @@ function DesktopNav() {
               </Link>
             );
           })}
+          {authenticated && <LeagueSwitcher variant="desktop" />}
           {authenticated && <TeamSwitcher variant="desktop" />}
           {authenticated && (
             <button
@@ -169,6 +171,7 @@ function MobileTopBar() {
       <Link href="/" className="mobile-brand">Brisket</Link>
       <span className="mobile-page-title">{pageTitle}</span>
       <div className="mobile-topbar-actions">
+        {authenticated && <LeagueSwitcher variant="mobile" />}
         {authenticated && <TeamSwitcher variant="mobile" />}
         {authenticated && (
           <button className="mobile-search-btn" onClick={openSearch} title="Search" aria-label="Search">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4346,6 +4346,110 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   max-width: calc(100vw - 24px);
 }
 
+/* ── League switcher ──────────────────────────────────────────────
+   Mirrors the TeamSwitcher shape so desktop + mobile nav rails
+   look consistent.  The whole widget is hidden by JS when only one
+   league is configured (registry default), so single-league
+   deployments never see it. */
+.league-switcher {
+  position: relative;
+  display: inline-block;
+}
+.league-switcher-toggle {
+  appearance: none;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: inherit;
+  transition: border-color 120ms ease, color 120ms ease;
+  min-height: 32px;
+  padding: 4px 10px;
+  font-size: 0.76rem;
+  max-width: 180px;
+}
+.league-switcher-toggle:hover,
+.league-switcher--open .league-switcher-toggle {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.league-switcher-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
+}
+.league-switcher-caret {
+  font-size: 0.6rem;
+  color: var(--muted);
+}
+.league-switcher-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-width: 220px;
+  max-height: 60vh;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  z-index: 120;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+.league-switcher-menu li {
+  list-style: none;
+  padding: 0;
+}
+.league-switcher-option {
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: inherit;
+  font-size: 0.78rem;
+  padding: 6px 10px;
+}
+.league-switcher-option:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.league-switcher-option.is-active {
+  background: rgba(94, 234, 212, 0.08);
+  color: var(--cyan);
+}
+.league-switcher-option-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.league-switcher-option-meta {
+  font-size: 0.66rem;
+  color: var(--muted);
+}
+.league-switcher--mobile .league-switcher-toggle {
+  font-size: 0.72rem;
+  padding: 4px 8px;
+  max-width: 120px;
+}
+.league-switcher--mobile .league-switcher-menu {
+  min-width: 200px;
+  max-width: calc(100vw - 24px);
+}
+
 /* ── Terminal Landing: layout + primitives ───────────────────────── */
 .terminal {
   display: flex;

--- a/frontend/components/LeagueSwitcher.jsx
+++ b/frontend/components/LeagueSwitcher.jsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLeague } from "@/components/useLeague";
+
+/**
+ * LeagueSwitcher — dropdown that picks the active dynasty league.
+ *
+ * Renders nothing when only one league is configured (the common
+ * case today) so it doesn't crowd the nav for single-league
+ * deployments.  Once the operator activates a second league in
+ * ``config/leagues/registry.json``, the switcher appears in both
+ * the desktop top-bar and the mobile action rail.
+ *
+ * We never ask the user to type a league ID — they pick from the
+ * list that the server already validated against the registry.
+ *
+ * Variants match ``TeamSwitcher`` for visual consistency.
+ */
+export default function LeagueSwitcher({ variant = "desktop" }) {
+  const { leagues, selectedLeague, selectedLeagueKey, setLeague, loading } = useLeague();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    function onDocClick(e) {
+      if (!rootRef.current) return;
+      if (rootRef.current.contains(e.target)) return;
+      setOpen(false);
+    }
+    function onKey(e) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const choose = useCallback(
+    (key) => {
+      if (key && key !== selectedLeagueKey) setLeague(key);
+      setOpen(false);
+    },
+    [setLeague, selectedLeagueKey],
+  );
+
+  // Hide when there's nothing to switch between.  Single-league
+  // deployments never see the switcher; as soon as a second league
+  // is flipped ``active: true`` in the registry the UI updates
+  // automatically on the next ``/api/leagues`` refresh.
+  if (loading) return null;
+  if (!Array.isArray(leagues) || leagues.length < 2) return null;
+
+  const label = selectedLeague?.displayName || "League";
+  const classes = [
+    "league-switcher",
+    `league-switcher--${variant}`,
+    open ? "league-switcher--open" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div ref={rootRef} className={classes}>
+      <button
+        type="button"
+        className="league-switcher-toggle"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        title={`Active league: ${label}`}
+      >
+        <span className="league-switcher-label">{label}</span>
+        <span className="league-switcher-caret" aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <ul className="league-switcher-menu" role="listbox">
+          {leagues.map((lg) => {
+            const active = lg.key === selectedLeagueKey;
+            const formatBits = [];
+            if (lg.idpEnabled) formatBits.push("IDP");
+            const roster = lg.rosterSettings || {};
+            if (roster.teamCount) formatBits.push(`${roster.teamCount} teams`);
+            return (
+              <li key={lg.key}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  className={`league-switcher-option${active ? " is-active" : ""}`}
+                  onClick={() => choose(lg.key)}
+                >
+                  <span className="league-switcher-option-name">
+                    {lg.displayName || lg.key}
+                  </span>
+                  {formatBits.length > 0 && (
+                    <span className="league-switcher-option-meta">
+                      {formatBits.join(" · ")}
+                    </span>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -45,6 +45,21 @@ export function useDynastyData() {
   const [error, setError] = useState("");
   const [source, setSource] = useState("");
   const [rawData, setRawData] = useState(null);
+  // Bumped when the active league changes so the fetch effect below
+  // re-fires.  Today's endpoints don't read leagueId (Phase 1 of the
+  // multi-league migration adds that); including the bump in the
+  // effect deps means the plumbing is ready the moment the endpoint
+  // starts routing by league.
+  const [leagueRefreshKey, setLeagueRefreshKey] = useState(0);
+
+  useEffect(() => {
+    function onLeagueChanged() {
+      setLeagueRefreshKey((v) => v + 1);
+    }
+    if (typeof window === "undefined") return undefined;
+    window.addEventListener("league:changed", onLeagueChanged);
+    return () => window.removeEventListener("league:changed", onLeagueChanged);
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -84,7 +99,7 @@ export function useDynastyData() {
       active = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [siteOverridesKey, tepMultiplier]);
+  }, [siteOverridesKey, tepMultiplier, leagueRefreshKey]);
 
   const rows = useMemo(() => {
     try {

--- a/frontend/components/useLeague.js
+++ b/frontend/components/useLeague.js
@@ -1,0 +1,259 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useUserState } from "@/components/useUserState";
+import { invalidateTerminalCache } from "@/components/useTerminal";
+import { _resetBaseContractCache } from "@/lib/dynasty-data";
+
+/**
+ * useLeague — which dynasty league is the signed-in user looking at?
+ *
+ * Composes two sources:
+ *
+ *   1. ``/api/leagues`` — the registry-backed list of available
+ *      leagues + the site-wide default key.  Fetched once per page
+ *      load (module-level cache); the registry is immutable at
+ *      runtime on the server, so a stale cache is fine.
+ *
+ *   2. ``useUserState().state.activeLeagueKey`` — the user's saved
+ *      preference.  Server-backed via ``/api/user/state`` when
+ *      authenticated, localStorage-mirrored for anon users.  Writing
+ *      via ``setLeague`` goes through the same hook so it survives
+ *      device switches.
+ *
+ * Resolution order for "which league do I show this user?":
+ *
+ *   a. ``userState.activeLeagueKey`` if it names an active league
+ *   b. registry ``userDefaultKey`` (server resolves from
+ *      ``defaultTeamMap[username]``) if present
+ *   c. registry ``defaultKey``
+ *   d. first active league
+ *   e. null (nothing configured — fresh dev box)
+ *
+ * Returns ``null``-tolerant state so the hook can render even while
+ * the leagues endpoint is still in flight.  Callers should read
+ * ``loading`` and gate side-effects until it flips false.
+ */
+
+const LOCAL_KEY = "next_active_league_v1";
+
+// Module-level cache for /api/leagues.  Same 30s TTL pattern as
+// useTerminal — one request per tab rather than per-hook-instance.
+let _leaguesCache = null; // { result, expires }
+let _leaguesInflight = null;
+const LEAGUES_TTL_MS = 60_000;
+
+async function fetchLeagues() {
+  const now = Date.now();
+  if (_leaguesCache && _leaguesCache.expires > now) return _leaguesCache.result;
+  if (_leaguesInflight) return _leaguesInflight;
+  _leaguesInflight = fetch("/api/leagues", {
+    credentials: "same-origin",
+    headers: { "Cache-Control": "no-store" },
+  })
+    .then(async (res) => {
+      if (!res.ok) throw new Error(`leagues ${res.status}`);
+      const data = await res.json();
+      _leaguesCache = { result: data, expires: Date.now() + LEAGUES_TTL_MS };
+      _leaguesInflight = null;
+      return data;
+    })
+    .catch((err) => {
+      _leaguesInflight = null;
+      throw err;
+    });
+  return _leaguesInflight;
+}
+
+export function invalidateLeaguesCache() {
+  _leaguesCache = null;
+  _leaguesInflight = null;
+}
+
+function readLocalActiveKey() {
+  if (typeof window === "undefined") return "";
+  try {
+    return localStorage.getItem(LOCAL_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeLocalActiveKey(key) {
+  if (typeof window === "undefined") return;
+  try {
+    if (key) localStorage.setItem(LOCAL_KEY, String(key));
+    else localStorage.removeItem(LOCAL_KEY);
+  } catch {
+    /* quota: ignore */
+  }
+}
+
+/**
+ * Primary hook.
+ *
+ * Returns:
+ *   leagues:            array of active LeagueConfigDto objects
+ *   selectedLeague:     the currently-active LeagueConfigDto or null
+ *   selectedLeagueKey:  current key (string) or ""
+ *   defaultLeagueKey:   registry default (used when user has no pref)
+ *   setLeague(key):     persist + broadcast a new selection
+ *   loading:            true while /api/leagues is in flight
+ *   error:              fetch error message or null
+ *   serverBacked:       true iff the user state is server-backed
+ */
+export function useLeague() {
+  const { state: userState, serverBacked, setNotifications } = useUserState();
+  // ^ setNotifications isn't used — we import it defensively so any
+  // future refactor that rolls activeLeague into setNotifications-
+  // style API surfaces in the hook still works.  Strictly unused
+  // today but harmless; hook return shape is what matters.
+  void setNotifications;
+
+  const [leaguesPayload, setLeaguesPayload] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [localKey, setLocalKey] = useState("");
+  const mounted = useRef(true);
+
+  // Initial localStorage read (client-only; SSR returns "").
+  useEffect(() => {
+    setLocalKey(readLocalActiveKey());
+  }, []);
+
+  // Fetch the registry's league list.  Single-flighted via the
+  // module cache — many hook instances share one request.
+  useEffect(() => {
+    mounted.current = true;
+    fetchLeagues()
+      .then((payload) => {
+        if (!mounted.current) return;
+        setLeaguesPayload(payload);
+        setError(null);
+      })
+      .catch((err) => {
+        if (!mounted.current) return;
+        setError(err?.message || "leagues_fetch_failed");
+      })
+      .finally(() => {
+        if (mounted.current) setLoading(false);
+      });
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const leagues = useMemo(
+    () => (Array.isArray(leaguesPayload?.leagues) ? leaguesPayload.leagues : []),
+    [leaguesPayload],
+  );
+  const defaultLeagueKey = leaguesPayload?.defaultKey || "";
+  const userDefaultKey = leaguesPayload?.userDefaultKey || "";
+
+  // Resolve the selected key using the order described in the
+  // docblock: user pref → user-default from registry → site default
+  // → first active → "".
+  const selectedLeagueKey = useMemo(() => {
+    const keysActive = new Set(leagues.map((l) => l.key));
+    const prefs = [
+      userState?.activeLeagueKey || "",
+      serverBacked ? "" : localKey, // only trust localStorage for anon users
+      userDefaultKey,
+      defaultLeagueKey,
+      leagues[0]?.key || "",
+    ];
+    for (const candidate of prefs) {
+      if (candidate && keysActive.has(candidate)) return candidate;
+    }
+    return "";
+  }, [
+    userState?.activeLeagueKey,
+    serverBacked,
+    localKey,
+    userDefaultKey,
+    defaultLeagueKey,
+    leagues,
+  ]);
+
+  const selectedLeague = useMemo(
+    () => leagues.find((l) => l.key === selectedLeagueKey) || null,
+    [leagues, selectedLeagueKey],
+  );
+
+  const setLeague = useCallback(
+    async (nextKey) => {
+      const clean = String(nextKey || "").trim();
+      if (!clean) return;
+      // Local + storage fallback fires immediately so the UI reflects
+      // the change before the network round-trip.  For authenticated
+      // users we also hit /api/user/state to persist across devices.
+      writeLocalActiveKey(clean);
+      setLocalKey(clean);
+      if (serverBacked) {
+        try {
+          await fetch("/api/user/state", {
+            method: "PUT",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ activeLeagueKey: clean }),
+          });
+        } catch {
+          /* network error — local state still wins */
+        }
+      }
+      // Purge in-flight caches so league-scoped hooks re-fetch on
+      // next render.  Today's endpoints don't actually read leagueId
+      // (that's Phase 1 of the multi-league migration), so this is
+      // currently a no-op on the wire — but the plumbing lands now
+      // so the moment endpoints start routing by leagueId, the
+      // switcher will trigger the right refreshes without another
+      // frontend change.
+      try {
+        invalidateTerminalCache();
+      } catch { /* hook not mounted yet — safe to ignore */ }
+      try {
+        _resetBaseContractCache();
+      } catch { /* dynasty-data module not initialized — ignore */ }
+
+      // Tell every other ``useUserState`` consumer that state changed.
+      // The simplest signal is a storage event; since we already wrote
+      // localStorage above, fire a synthetic event for same-tab
+      // subscribers (native 'storage' only fires cross-tab).
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("league:changed", { detail: { key: clean } }));
+      }
+    },
+    [serverBacked],
+  );
+
+  // Cross-component sync within a tab: when setLeague fires from one
+  // hook instance, other instances re-read local state.  (Across-tab
+  // sync comes for free via the browser's 'storage' event.)
+  useEffect(() => {
+    function onLeagueChange(ev) {
+      if (ev?.detail?.key) setLocalKey(ev.detail.key);
+    }
+    function onStorage(ev) {
+      if (ev?.key === LOCAL_KEY) setLocalKey(ev.newValue || "");
+    }
+    if (typeof window === "undefined") return undefined;
+    window.addEventListener("league:changed", onLeagueChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("league:changed", onLeagueChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  return {
+    leagues,
+    selectedLeague,
+    selectedLeagueKey,
+    defaultLeagueKey,
+    userDefaultKey,
+    setLeague,
+    loading,
+    error,
+    serverBacked,
+  };
+}

--- a/frontend/components/useTerminal.js
+++ b/frontend/components/useTerminal.js
@@ -88,6 +88,10 @@ export function useTerminal({ ownerId = "", teamName = "", windowDays = 30 } = {
     error: null,
     payload: null,
   });
+  // Forces a re-fetch when the active league changes — same pattern
+  // as useDynastyData.  Keeps the hook signature unchanged while
+  // wiring league-awareness for the Phase 1 migration.
+  const [leagueRefreshKey, setLeagueRefreshKey] = useState(0);
   const mounted = useRef(true);
 
   useEffect(() => {
@@ -95,6 +99,16 @@ export function useTerminal({ ownerId = "", teamName = "", windowDays = 30 } = {
     return () => {
       mounted.current = false;
     };
+  }, []);
+
+  useEffect(() => {
+    function onLeagueChanged() {
+      invalidateTerminalCache();
+      setLeagueRefreshKey((v) => v + 1);
+    }
+    if (typeof window === "undefined") return undefined;
+    window.addEventListener("league:changed", onLeagueChanged);
+    return () => window.removeEventListener("league:changed", onLeagueChanged);
   }, []);
 
   useEffect(() => {
@@ -115,7 +129,7 @@ export function useTerminal({ ownerId = "", teamName = "", windowDays = 30 } = {
         });
       });
     return () => controller.abort();
-  }, [ownerId, teamName, windowDays]);
+  }, [ownerId, teamName, windowDays, leagueRefreshKey]);
 
   const value = useMemo(() => {
     const p = state.payload || {};

--- a/server.py
+++ b/server.py
@@ -4437,6 +4437,23 @@ async def put_user_state_api(request: Request):
                 patch["notificationsEmail"] = s
     if "notificationsEnabled" in body:
         patch["notificationsEnabled"] = bool(body.get("notificationsEnabled"))
+    if "activeLeagueKey" in body:
+        # The user's preferred league from the registry.  Validate
+        # against the live registry so a stale/typo value can't
+        # silently land a user on a nonexistent league on next load.
+        # ``None`` / empty string clears the preference → callers fall
+        # back to the registry's default league on next read.
+        raw = body.get("activeLeagueKey")
+        if raw is None or raw == "":
+            patch["activeLeagueKey"] = None
+        elif isinstance(raw, str):
+            candidate = raw.strip()
+            cfg = _league_registry.get_league_by_key(candidate)
+            if cfg is not None and cfg.active:
+                patch["activeLeagueKey"] = cfg.key  # canonicalize via alias lookup
+            # Unknown or inactive league → silently drop.  The
+            # frontend will notice the server didn't echo the key back
+            # and fall through to the default.
     state = await run_in_threadpool(_user_kv.merge_user_state, username, patch)
     return JSONResponse(
         content={"username": username, "state": state},

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -70,6 +70,16 @@ KNOWN_KEYS = frozenset({
     "dismissedSignals",
     "dismissalAliases",
     "updatedAt",
+    # League preference — the user's currently-active league key from
+    # the league registry (``src/api/league_registry``).  Persists
+    # across devices so that a user who switches to the non-IDP
+    # league on mobile sees the same league on desktop.  Unvalidated
+    # here; the PUT endpoint validates against the live registry.
+    "activeLeagueKey",
+    # Notification preferences already flow through ``merge_user_state``
+    # — listed here so new readers know the schema includes them.
+    "notificationsEmail",
+    "notificationsEnabled",
 })
 
 # Process-wide lock around connection setup / migration so module

--- a/tests/api/test_league_registry.py
+++ b/tests/api/test_league_registry.py
@@ -383,6 +383,120 @@ def test_public_dict_omits_sleeper_id(tmp_path, monkeypatch):
     assert "SECRET-ID-123" not in json.dumps(payload)
 
 
+def test_put_user_state_accepts_valid_active_league_key(tmp_path, monkeypatch):
+    """PUT /api/user/state should accept an activeLeagueKey that
+    matches an active registry entry and echo it back in the response
+    state."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
+                {"key": "backup", "displayName": "Backup", "sleeperLeagueId": "2", "active": True, "rosterSettings": {}},
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    # Route the user_kv DB to a temp file so we don't touch prod data.
+    from src.api import user_kv
+    user_kv_path = tmp_path / "test_user_kv.sqlite"
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", user_kv_path)
+    user_kv._SETUP_DONE.clear()
+    # Stub auth so the endpoint accepts us as 'alice'.
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda request: {"username": "alice", "auth_method": "password"},
+    )
+
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.put("/api/user/state", json={"activeLeagueKey": "backup"})
+    assert res.status_code == 200, res.text
+    state = res.json()["state"]
+    assert state["activeLeagueKey"] == "backup"
+
+
+def test_put_user_state_drops_unknown_active_league_key(tmp_path, monkeypatch):
+    """An unknown key must be silently dropped (not persisted as-is
+    and not raise a 400) so a stale client can't poison user state."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+    user_kv_path = tmp_path / "test_user_kv.sqlite"
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", user_kv_path)
+    user_kv._SETUP_DONE.clear()
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda request: {"username": "alice", "auth_method": "password"},
+    )
+
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.put("/api/user/state", json={"activeLeagueKey": "nonexistent"})
+    assert res.status_code == 200, res.text
+    state = res.json()["state"]
+    assert state.get("activeLeagueKey") in (None, "")  # not persisted
+
+
+def test_put_user_state_canonicalizes_alias(tmp_path, monkeypatch):
+    """Submitting an alias like ``idp`` (instead of ``dynasty_main``)
+    should be stored as the canonical key so user state stays clean
+    even if aliases change later."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {
+                    "key": "dynasty_main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                    "aliases": ["idp", "main"],
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+    user_kv_path = tmp_path / "test_user_kv.sqlite"
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", user_kv_path)
+    user_kv._SETUP_DONE.clear()
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda request: {"username": "alice", "auth_method": "password"},
+    )
+
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.put("/api/user/state", json={"activeLeagueKey": "idp"})
+    assert res.status_code == 200, res.text
+    state = res.json()["state"]
+    assert state["activeLeagueKey"] == "dynasty_main"
+
+
 def test_api_leagues_endpoint_returns_active_leagues(tmp_path, monkeypatch):
     """GET /api/leagues returns the list of active leagues with no
     Sleeper IDs leaked.  Unauthenticated clients don't see


### PR DESCRIPTION
## Summary

User-visible league switching, built on top of the registry landed in #260. Flipping leagues persists to the server (for cross-device sync) with a localStorage fallback for anonymous users.

### What

- **Backend**: `PUT /api/user/state` accepts `activeLeagueKey`, validates against the registry, canonicalizes aliases. Silently drops unknown/inactive keys.
- **Frontend `useLeague` hook**: composes `/api/leagues` with server-backed user pref; resolves to sensible defaults when unset.
- **`LeagueSwitcher` dropdown** (desktop + mobile): hidden when there's only one active league (current state), appears automatically when a second league is activated in the registry.
- **Cache invalidation**: `useDynastyData` and `useTerminal` listen for `league:changed` event and refetch. Plumbing is ready for Phase 1 endpoint changes.

### Behavior today

- One active league → switcher hidden, nothing changes for existing users.
- User's pick persists via `user_kv` when signed in; localStorage (`next_active_league_v1`) otherwise.

### Behavior once second league is activated

- Switcher appears in both navs.
- User picks → write propagates to server → other devices pick it up next visit.
- `league:changed` event fires → mounted `useDynastyData` / `useTerminal` instances re-fetch.

### Not in scope

Threading `leagueId` through API endpoints, IDP gating, storage namespacing, URL reshape — all Phase 1 work, separate PR.

## Test plan

- [x] pytest: 1900 passed, 3 skipped (19 registry tests, 3 new for the activeLeagueKey endpoint paths)
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [ ] Manual smoke: switcher hidden with one league, appears on adding second
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)