### PR TITLE
feat: league-aware backend routes via registry key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,50 @@ npm run regression                   # Full pipeline: preflight + tests
 | `/api/scaffold/identity` | GET | Identity mappings |
 | `/api/trade/suggestions` | POST | Roster-aware trade suggestions (reads live contract) |
 | `/api/trade/finder` | POST | KTC arbitrage finder |
+| `/api/leagues` | GET | Active league registry (stable `key` → `displayName` + roster settings; **no Sleeper IDs leaked**) |
+
+### League-aware routing
+
+League-scoped endpoints accept an optional `leagueKey` parameter
+(query string for GET, body field for POST).  The resolver lives in
+`server.py::_resolve_league_for_request` and picks the target
+league in this order:
+
+1. explicit `leagueKey` in the request
+2. the authenticated user's `activeLeagueKey` from `user_kv`
+3. the registry's default league
+
+**Validation rules** (returned as clean JSON errors):
+
+| Condition | HTTP | Error code |
+|---|---|---|
+| unknown `leagueKey` | 400 | `unknown_league` |
+| `leagueKey` is inactive | 400 | `inactive_league` |
+| valid key but contract for it not loaded | 503 | `data_not_ready` |
+| no leagues configured at all | 404 | `no_leagues_configured` |
+
+Aliases (`"main"` → `"dynasty_main"`) are accepted and canonicalised
+server-side.  Frontend callers should use the stable `key` from
+`/api/leagues`, not raw Sleeper league IDs — no endpoint exposes
+raw Sleeper IDs to the UI.
+
+League-aware endpoints (all stamp `leagueKey` on their response):
+
+- `GET /api/data` — full canonical contract
+- `POST /api/rankings/overrides` — override-sensitive delta
+- `GET /api/terminal` — team aggregates, movers, signals
+- `POST /api/trade/simulate`
+- `POST /api/trade/suggestions`
+- `POST /api/trade/finder`
+- `POST /api/angle/find`, `POST /api/angle/packages`
+- `GET /api/draft-capital`
+- `POST /api/scrape` (non-default leagueKey returns 501 today; multi-league scrape is future work)
+- `GET /api/public/league/*` (routes through `_public_league_id()` which reads the registry)
+
+Backend map the frontend relies on: `leagueKey` → `sleeperLeagueId`
++ `rosterSettings` + `idpEnabled`.  Lookups go through
+`src/api/league_registry.py`; never read `os.getenv("SLEEPER_LEAGUE_ID")`
+in new code.
 
 ## Architecture Concepts
 

--- a/frontend/components/useTerminal.js
+++ b/frontend/components/useTerminal.js
@@ -31,13 +31,29 @@ import { useEffect, useMemo, useRef, useState } from "react";
 const TTL_MS = 30_000;
 const cache = new Map(); // key → { result, expires }
 const inflight = new Map(); // key → Promise
+const LEAGUE_LOCAL_KEY = "next_active_league_v1";
 
-function cacheKey({ ownerId, name, windowDays }) {
-  return `${ownerId || "_"}::${name || "_"}::${windowDays || 30}`;
+// Read the active league key from localStorage.  ``useLeague`` writes
+// here on every switch and server-side user state mirrors it, so this
+// is a fast + sync read.  We can't ``useLeague`` inside this module
+// because useLeague already imports ``invalidateTerminalCache`` from
+// us — that cycle would blow up at import time.
+function readActiveLeagueKey() {
+  if (typeof window === "undefined") return "";
+  try {
+    return localStorage.getItem(LEAGUE_LOCAL_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function cacheKey({ ownerId, name, windowDays, leagueKey }) {
+  return `${leagueKey || "_"}::${ownerId || "_"}::${name || "_"}::${windowDays || 30}`;
 }
 
 async function fetchTerminal({ ownerId, name, windowDays, signal }) {
-  const key = cacheKey({ ownerId, name, windowDays });
+  const leagueKey = readActiveLeagueKey();
+  const key = cacheKey({ ownerId, name, windowDays, leagueKey });
   const now = Date.now();
   const cached = cache.get(key);
   if (cached && cached.expires > now) return cached.result;
@@ -47,6 +63,7 @@ async function fetchTerminal({ ownerId, name, windowDays, signal }) {
   if (ownerId) params.set("team", ownerId);
   if (name) params.set("teamName", name);
   if (windowDays) params.set("windowDays", String(windowDays));
+  if (leagueKey) params.set("leagueKey", leagueKey);
   const url = `/api/terminal?${params.toString()}`;
 
   const promise = fetch(url, {

--- a/frontend/components/useTradeSimulator.js
+++ b/frontend/components/useTradeSimulator.js
@@ -27,11 +27,23 @@ export function useTradeSimulator() {
   const simulate = useCallback(async (body) => {
     setState((prev) => ({ ...prev, loading: true, error: null }));
     try {
+      // Attach the active league key if the caller didn't supply
+      // one.  The backend validates it against the registry and
+      // returns 503 ``data_not_ready`` when the loaded contract is
+      // for a different league — that's a nicer failure mode than
+      // simulating the wrong league silently.
+      const payload = { ...(body || {}) };
+      if (!payload.leagueKey && typeof window !== "undefined") {
+        try {
+          const k = localStorage.getItem("next_active_league_v1") || "";
+          if (k) payload.leagueKey = k;
+        } catch { /* ignore */ }
+      }
       const res = await fetch("/api/trade/simulate", {
         method: "POST",
         credentials: "same-origin",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body || {}),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) {
         let msg = `HTTP ${res.status}`;

--- a/server.py
+++ b/server.py
@@ -1053,6 +1053,19 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
             # contract response.  The glyph degrades gracefully when
             # rankHistory is absent.
             log.warning("rank_history: append/stamp failed: %s", exc)
+        # Tag the contract with the league it was built for so
+        # ``_resolve_league_for_request()`` can reject requests
+        # asking for a different league (503 "data_not_ready").
+        # Today only one league runs the scraper, so this is always
+        # the registry's default.  When multi-league scraping lands,
+        # this annotation is the link between a request's leagueKey
+        # and the correct in-memory contract.
+        try:
+            _default_cfg = _league_registry.get_default_league()
+            if _default_cfg and isinstance(contract_payload, dict):
+                contract_payload.setdefault("meta", {})["leagueKey"] = _default_cfg.key
+        except Exception:  # noqa: BLE001
+            pass
         latest_contract_data = contract_payload
         contract_health = contract_report
 
@@ -1693,8 +1706,41 @@ def _proxy_next(path: str) -> tuple[Response | None, str | None]:
 # ── API ROUTES ──────────────────────────────────────────────────────────
 @app.get("/api/data")
 async def get_data(request: Request):
-    """Return latest normalized/validated data contract JSON."""
+    """Return latest normalized/validated data contract JSON.
+
+    Optional ``?leagueKey=...`` validates against the league registry
+    and 503s if the loaded contract is for a different league.
+    Without the param we fall through to the user's saved
+    ``activeLeagueKey`` and finally the registry default — matching
+    ``/api/terminal``'s resolution behavior.
+    """
+    # League validation comes first so a stale leagueKey returns 400
+    # before we bother assembling the payload.  Skip the loaded-
+    # contract check here and enforce below so the 503 path can
+    # include the resolved league key in the response.
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
     if latest_contract_data:
+        # Validate that the loaded contract matches the resolved league.
+        # When it doesn't (non-default league requested, scraper hasn't
+        # caught up), surface a clean 503 with the key so the client
+        # knows to wait or switch back.
+        loaded_league = (
+            (latest_contract_data.get("meta") or {}).get("leagueKey")
+            if isinstance(latest_contract_data, dict) else None
+        )
+        if loaded_league and loaded_league != league_cfg.key:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "data_not_ready",
+                    "message": f"No data loaded for league {league_cfg.key!r} yet",
+                    "leagueKey": league_cfg.key,
+                },
+            )
         view = (request.query_params.get("view") or "").strip().lower()
         startup_view = view in {"startup", "boot", "initial"}
         runtime_view = view in {"app", "runtime", "lite", "slim"}
@@ -1878,6 +1924,20 @@ async def post_rankings_overrides(request: Request):
     except Exception:
         body = None
 
+    # Validate leagueKey (body or query).  The override pipeline
+    # always runs against the currently-loaded scrape data
+    # (``latest_data``), so a mismatched league key gets 503 with a
+    # clean error rather than rebuilding a contract whose
+    # ``sleeper`` block is wrong.
+    try:
+        league_cfg = _resolve_league_for_request(
+            request,
+            body=body if isinstance(body, dict) else None,
+            require_loaded_contract=True,
+        )
+    except LeagueResolutionError as err:
+        return err.json_response()
+
     overrides, warnings = normalize_source_overrides(body)
     tep_multiplier = normalize_tep_multiplier(body)
 
@@ -1911,6 +1971,12 @@ async def post_rankings_overrides(request: Request):
 
     if warnings:
         contract_payload.setdefault("warnings", []).extend(warnings)
+
+    # Stamp the resolved league key on the override response so the
+    # frontend can assert "this is the right league's data" after
+    # merging the delta onto its base contract.
+    if isinstance(contract_payload, dict):
+        contract_payload.setdefault("meta", {})["leagueKey"] = league_cfg.key
 
     headers = {
         "Cache-Control": "no-store",
@@ -2348,6 +2414,14 @@ async def post_trade_suggestions(request: Request):
     except Exception:
         return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
 
+    # Validate leagueKey (body or query) against the registry.
+    try:
+        league_cfg = _resolve_league_for_request(
+            request, body=body, require_loaded_contract=True,
+        )
+    except LeagueResolutionError as err:
+        return err.json_response()
+
     roster = body.get("roster")
     if not isinstance(roster, list) or not roster:
         return JSONResponse(
@@ -2383,6 +2457,8 @@ async def post_trade_suggestions(request: Request):
         log.error(f"Trade suggestion generation failed: {e}")
         return JSONResponse(status_code=500, content={"error": f"Suggestion generation failed: {e}"})
 
+    if isinstance(result, dict):
+        result["leagueKey"] = league_cfg.key
     return JSONResponse(content=result)
 
 
@@ -2418,6 +2494,14 @@ async def post_trade_finder(request: Request):
     except Exception:
         return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
 
+    # Validate leagueKey (body or query).
+    try:
+        league_cfg = _resolve_league_for_request(
+            request, body=body, require_loaded_contract=True,
+        )
+    except LeagueResolutionError as err:
+        return err.json_response()
+
     my_team = body.get("myTeam")
     if not my_team or not isinstance(my_team, str):
         return JSONResponse(
@@ -2447,6 +2531,8 @@ async def post_trade_finder(request: Request):
         log.error(f"Trade Finder failed: {e}")
         return JSONResponse(status_code=500, content={"error": f"Trade Finder failed: {e}"})
 
+    if isinstance(result, dict):
+        result["leagueKey"] = league_cfg.key
     return JSONResponse(content=result)
 
 
@@ -2546,6 +2632,16 @@ async def post_angle_find(request: Request):
     except Exception:
         return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
 
+    # League routing: accept leagueKey in body or query, reject
+    # unknown/inactive, 503 when the loaded contract is for a
+    # different league.
+    try:
+        league_cfg = _resolve_league_for_request(
+            request, body=body, require_loaded_contract=True,
+        )
+    except LeagueResolutionError as err:
+        return err.json_response()
+
     owner_id = str(body.get("ownerId") or "").strip()
     player_name = str(body.get("playerName") or "").strip()
     if not owner_id or not player_name:
@@ -2586,6 +2682,8 @@ async def post_angle_find(request: Request):
             status_code=500,
             content={"error": f"Angle find failed: {exc}"},
         )
+    if isinstance(result, dict):
+        result["leagueKey"] = league_cfg.key
     return JSONResponse(content=result)
 
 
@@ -2645,6 +2743,14 @@ async def post_angle_packages(request: Request):
         body = await request.json()
     except Exception:
         return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
+
+    # League routing (same pattern as /api/angle/find).
+    try:
+        league_cfg = _resolve_league_for_request(
+            request, body=body, require_loaded_contract=True,
+        )
+    except LeagueResolutionError as err:
+        return err.json_response()
 
     owner_id = str(body.get("ownerId") or "").strip()
     mode = str(body.get("mode") or "offer").strip().lower()
@@ -2734,7 +2840,7 @@ async def post_angle_packages(request: Request):
                 status_code=500,
                 content={"error": f"Angle acquire failed: {exc}"},
             )
-        result = {"mode": "acquire", **result}
+        result = {"mode": "acquire", **result, "leagueKey": league_cfg.key}
         return JSONResponse(content=result)
 
     target_teams_req = body.get("targetTeamOwnerIds") or []
@@ -2773,7 +2879,7 @@ async def post_angle_packages(request: Request):
             status_code=500,
             content={"error": f"Angle packages failed: {exc}"},
         )
-    result = {"mode": "offer", **result}
+    result = {"mode": "offer", **result, "leagueKey": league_cfg.key}
     return JSONResponse(content=result)
 
 
@@ -2808,19 +2914,130 @@ DRAFT_DATA_XLSX = Path(__file__).parent / "CSVs" / "Draft Data.xlsx"
 DRAFT_DATA_CSV = Path(__file__).parent / "CSVs" / "draft_data.csv"
 
 
-def _sleeper_league_id_for_draft() -> str:
+def _sleeper_league_id_for_draft(league_key: str | None = None) -> str:
     """Resolve the Sleeper league ID for draft endpoints via the
     league registry.  Previously a module-level constant read from
     ``SLEEPER_LEAGUE_ID`` env var; now routes through
     ``league_registry.get_sleeper_league_id()`` which itself falls
     back to the env var when no registry.json is configured.
 
+    If ``league_key`` is provided, that specific league's Sleeper ID
+    is returned (after validation).  ``None`` resolves to the
+    default league — the existing single-league behavior.
+
     Returns empty string when no league is configured at all so
     callers can short-circuit instead of making a Sleeper call to
     ``/league/``.
     """
-    sid = _league_registry.get_sleeper_league_id()
+    sid = _league_registry.get_sleeper_league_id(league_key)
     return sid or ""
+
+
+class LeagueResolutionError(Exception):
+    """Raised when a request references a league the server can't
+    serve.  Carries an HTTP status + body so route handlers can
+    ``except`` once and return a uniform error response.
+
+    Status codes:
+      * 400 — ``leagueKey`` is present but unknown or inactive
+      * 503 — requested league is valid but no contract is loaded
+              for it yet (single-league instance, or scrape in progress)
+      * 404 — no leagues configured at all (fresh dev machine)
+    """
+
+    def __init__(self, status: int, code: str, message: str):
+        self.status = status
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+    def json_response(self) -> "JSONResponse":
+        return JSONResponse(
+            status_code=self.status,
+            content={"error": self.code, "message": self.message},
+        )
+
+
+def _resolve_league_for_request(
+    request: "Request",
+    *,
+    body: dict | None = None,
+    require_loaded_contract: bool = False,
+) -> "_league_registry.LeagueConfig":
+    """Pick the right league for this request.
+
+    Resolution order:
+      1. Explicit ``leagueKey`` in the query string
+      2. Explicit ``leagueKey`` in the request body (when provided)
+      3. The authenticated user's ``activeLeagueKey`` (from user_kv)
+      4. The registry's default league
+
+    Passes 1 + 2 go through ``get_league_by_key`` which also accepts
+    aliases.  Passes 3 + 4 always resolve to a canonical key.  An
+    inactive league at passes 1–2 raises 400 so a stale frontend
+    can't accidentally keep hitting a retired league.
+
+    When ``require_loaded_contract=True`` and the resolved league
+    doesn't match the league that built ``latest_contract_data``,
+    raises 503 ``data_not_ready``.  This is the guard that keeps
+    single-instance deployments from returning garbage for a league
+    they haven't scraped yet.
+    """
+    # 1 + 2: explicit leagueKey in query or body.
+    explicit = (request.query_params.get("leagueKey") or "").strip()
+    if not explicit and isinstance(body, dict):
+        explicit = str(body.get("leagueKey") or "").strip()
+    if explicit:
+        cfg = _league_registry.get_league_by_key(explicit)
+        if cfg is None:
+            raise LeagueResolutionError(
+                400, "unknown_league",
+                f"Unknown leagueKey {explicit!r}",
+            )
+        if not cfg.active:
+            raise LeagueResolutionError(
+                400, "inactive_league",
+                f"League {cfg.key!r} is not active",
+            )
+    else:
+        # 3: user's saved preference.
+        cfg = None
+        session = _get_auth_session(request)
+        if session:
+            username = str(session.get("username") or "").strip()
+            if username:
+                try:
+                    state = _user_kv.get_user_state(username) or {}
+                    saved = (state.get("activeLeagueKey") or "").strip()
+                    if saved:
+                        candidate = _league_registry.get_league_by_key(saved)
+                        if candidate is not None and candidate.active:
+                            cfg = candidate
+                except Exception:  # noqa: BLE001
+                    cfg = None
+        # 4: registry default.
+        if cfg is None:
+            cfg = _league_registry.get_default_league()
+        if cfg is None:
+            raise LeagueResolutionError(
+                404, "no_leagues_configured",
+                "No leagues configured on this server",
+            )
+
+    if require_loaded_contract:
+        loaded_key = None
+        try:
+            loaded_key = (
+                (latest_contract_data or {}).get("meta", {}).get("leagueKey")
+            )
+        except Exception:  # noqa: BLE001
+            loaded_key = None
+        if loaded_key and loaded_key != cfg.key:
+            raise LeagueResolutionError(
+                503, "data_not_ready",
+                f"No data loaded for league {cfg.key!r} yet",
+            )
+    return cfg
 _KTC_TOTAL_PICKS = 72  # fill rookie data for all 6 rounds (12 teams × 6 rounds)
 DRAFT_TOTAL_BUDGET = 1200  # $100 × 12 teams
 
@@ -3225,7 +3442,7 @@ def _round_to_budget(values: list[float], budget: int = 1200) -> list[int]:
     return floors
 
 
-def _fetch_draft_capital():
+def _fetch_draft_capital(league_key: str | None = None):
     """Compute draft capital per team.
 
     The Draft Data workbook is the authoritative source for BOTH pick
@@ -3240,6 +3457,9 @@ def _fetch_draft_capital():
     by joining the sheet's standings on Sleeper's draft
     ``slot_to_roster_id``.  If Sleeper is unavailable we fall back to
     showing first names directly.
+
+    ``league_key`` selects which league's Sleeper IDs to use for the
+    team-name join.  None resolves to the registry default.
     """
     pick_dollars, workbook_picks, slot_to_original, wb_team_totals, rookies = _parse_draft_data()
     if not workbook_picks:
@@ -3257,7 +3477,7 @@ def _fetch_draft_capital():
     first_name_to_team: dict[str, str] = {}
     all_team_names: list[str] = []
     try:
-        _league_id_for_draft = _sleeper_league_id_for_draft()
+        _league_id_for_draft = _sleeper_league_id_for_draft(league_key)
         if not _league_id_for_draft:
             # No league configured at all — skip the Sleeper joins and
             # leave the mapping empty; downstream code renders draft
@@ -3422,14 +3642,26 @@ def _fetch_draft_capital():
 
 
 @app.get("/api/draft-capital")
-async def get_draft_capital(refresh: str = ""):
+async def get_draft_capital(request: Request, refresh: str = ""):
     """Return draft capital breakdown per team using Sleeper pick ownership
     and the pick value curve from the draft data spreadsheet.
-    Pass ?refresh=1 to force a fresh KTC fetch."""
+
+    Accepts ``?leagueKey=...`` to scope the Sleeper roster + users +
+    drafts calls to a specific league; absent, falls through to the
+    user's saved pref and then the registry default.  Unknown or
+    inactive keys return 400.
+
+    Pass ``?refresh=1`` to force a fresh KTC fetch."""
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
     if refresh:
         _ktc_cache["fetched_at"] = 0  # invalidate cache
     try:
-        result = _fetch_draft_capital()
+        result = _fetch_draft_capital(league_cfg.key)
+        if isinstance(result, dict):
+            result["leagueKey"] = league_cfg.key
         return JSONResponse(content=result)
     except Exception as e:
         logging.error(f"Draft capital computation failed: {e}")
@@ -4118,8 +4350,38 @@ async def get_public_league_section(section: str, owner: str = "", refresh: str 
 
 
 @app.post("/api/scrape")
-async def trigger_scrape(background_tasks: BackgroundTasks):
-    """Manually trigger a scrape. Returns immediately; scrape runs in background."""
+async def trigger_scrape(request: Request, background_tasks: BackgroundTasks):
+    """Manually trigger a scrape. Returns immediately; scrape runs in background.
+
+    Accepts optional ``?leagueKey=...`` — today the scraper runs the
+    registry's default league regardless, but we still validate the
+    key so a multi-league-aware frontend can't accidentally ask for a
+    retired league.  A non-default key currently returns 501
+    ``not_implemented`` because multi-league scraping isn't wired up
+    yet (that's a future refactor of Dynasty Scraper.py).
+    """
+    # Validate the key first.  The 501 below is a more honest
+    # response than silently scraping the default league when the
+    # caller asked for a specific one.
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+    default_cfg = _league_registry.get_default_league()
+    if default_cfg and league_cfg.key != default_cfg.key:
+        return JSONResponse(
+            status_code=501,
+            content={
+                "error": "multi_league_scrape_not_supported",
+                "message": (
+                    f"Only the default league ({default_cfg.key!r}) can be "
+                    "scraped at this time; multi-league scraping is a future "
+                    "refactor."
+                ),
+                "leagueKey": league_cfg.key,
+            },
+        )
+
     status_payload = _scrape_status_payload()
     if status_payload.get("is_running") or scrape_run_lock.locked():
         _record_scrape_event(
@@ -4584,25 +4846,53 @@ async def get_terminal(request: Request):
     authed = bool(session)
     username = str((session or {}).get("username") or "").strip() if authed else ""
 
+    # League routing — validate the key, but DON'T require a loaded
+    # contract yet (we want to fall through to the disk cache below
+    # for the default league).  The loaded-contract check fires
+    # after the in-memory contract is available.
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
     contract = latest_contract_data
     stale = False
     stale_as = None
     if not contract:
         # 503 fallback (Item 3 from the TODO list): try the most
-        # recent cached export before giving up.
-        cached, cached_date = _latest_cached_contract_from_disk()
-        if cached:
-            contract = cached
-            stale = True
-            stale_as = cached_date
-        else:
+        # recent cached export before giving up.  Disk cache is for
+        # the default league only — if a non-default league is
+        # requested we skip the cache and return 503 cleanly.
+        default_cfg = _league_registry.get_default_league()
+        if default_cfg and league_cfg.key == default_cfg.key:
+            cached, cached_date = _latest_cached_contract_from_disk()
+            if cached:
+                contract = cached
+                stale = True
+                stale_as = cached_date
+        if not contract:
             return JSONResponse(
                 status_code=503,
                 content={
                     "error": "No data available yet. First scrape may still be running.",
                     "stale": False,
+                    "leagueKey": league_cfg.key,
                 },
             )
+
+    # Guard: the loaded contract was built for a different league
+    # than the one requested.  Today this only trips for non-default
+    # leagues because the scraper only runs the default league.
+    loaded_league = (contract.get("meta") or {}).get("leagueKey") if isinstance(contract, dict) else None
+    if loaded_league and loaded_league != league_cfg.key:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": f"No data loaded for league {league_cfg.key!r} yet",
+                "leagueKey": league_cfg.key,
+            },
+        )
 
     params = request.query_params
     team_owner_id = (params.get("team") or params.get("ownerId") or "").strip()
@@ -4713,6 +5003,15 @@ async def post_trade_simulate(request: Request):
     if not isinstance(body, dict):
         return JSONResponse(status_code=400, content={"error": "invalid_body"})
 
+    # Validate leagueKey (body or query).  The contract in memory
+    # must match the resolved league — if not, 503.
+    try:
+        league_cfg = _resolve_league_for_request(
+            request, body=body, require_loaded_contract=True,
+        )
+    except LeagueResolutionError as err:
+        return err.json_response()
+
     team_owner_id = str(body.get("team") or "").strip()
     team_name = str(body.get("teamName") or "").strip()
 
@@ -4727,7 +5026,7 @@ async def post_trade_simulate(request: Request):
     if resolved_team is None:
         return JSONResponse(
             status_code=404,
-            content={"error": "team_not_found"},
+            content={"error": "team_not_found", "leagueKey": league_cfg.key},
         )
 
     def _str_list(key):
@@ -4745,6 +5044,7 @@ async def post_trade_simulate(request: Request):
         picks_in=_str_list("picksIn"),
         picks_out=_str_list("picksOut"),
     )
+    result["leagueKey"] = league_cfg.key
     return JSONResponse(
         content=result,
         headers={"Cache-Control": "no-store"},

--- a/tests/api/test_league_routing.py
+++ b/tests/api/test_league_routing.py
@@ -1,0 +1,236 @@
+"""Tests for league-aware routing on backend endpoints.
+
+These pin down the contract around ``?leagueKey=`` on the routes
+that read from the live contract:
+
+* Unknown or inactive keys return 400 with a ``unknown_league`` /
+  ``inactive_league`` code.
+* A valid key that doesn't match the loaded contract returns 503
+  ``data_not_ready`` (so single-league instances don't silently
+  serve the wrong league's data when the switcher points at a
+  league that hasn't been scraped yet).
+* No key means "use the session's activeLeagueKey, else the
+  registry default" — backward-compat for existing callers.
+
+The fixture path builds an in-memory contract stamped with the
+test league's key so ``_resolve_league_for_request`` has something
+to match against.  We stub out Sleeper-hitting endpoints where we
+can to keep the tests local.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import league_registry
+
+
+@pytest.fixture
+def two_league_registry(tmp_path, monkeypatch):
+    """A registry with two active leagues (main + side) and a test
+    user_kv DB so state writes don't bleed between tests."""
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "L-MAIN",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                        "aliases": ["primary"],
+                    },
+                    {
+                        "key": "side",
+                        "displayName": "Side",
+                        "sleeperLeagueId": "L-SIDE",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 10},
+                    },
+                    {
+                        "key": "retired",
+                        "displayName": "Retired",
+                        "sleeperLeagueId": "L-RET",
+                        "active": False,
+                        "rosterSettings": {},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    # Isolate user_kv to a temp file so the PUT paths don't leak.
+    from src.api import user_kv
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
+    user_kv._SETUP_DONE.clear()
+
+    yield
+
+    # Reset the registry AFTER the test so later tests (especially
+    # public_league tests that set SLEEPER_LEAGUE_ID directly) see
+    # the env-var-fallback state, not this test's fixture leagues.
+    # Without this, module-level _FILE_LOADED retains {"main",
+    # "side", "retired"} — which makes get_default_league() return
+    # "main" with sleeper_league_id "L-MAIN", breaking
+    # _public_league_id() for downstream tests.
+    league_registry.reload_registry()
+
+
+def _install_contract_for_league(monkeypatch, league_key: str):
+    """Put a stub contract in ``latest_contract_data`` stamped for
+    ``league_key``.  Minimal enough to pass the initial guards on
+    routes like /api/trade/simulate that bail on missing
+    ``playersArray``."""
+    stub = {
+        "meta": {"leagueKey": league_key},
+        "players": {"stub": {"name": "Stub"}},
+        "playersArray": [{"name": "Stub"}],
+        "sleeper": {"teams": [{"ownerId": "oA", "name": "Team A", "players": []}]},
+    }
+    monkeypatch.setattr(server, "latest_contract_data", stub)
+    return stub
+
+
+# ── Unknown / inactive keys ──────────────────────────────────────
+
+
+def test_unknown_league_key_returns_400(two_league_registry, monkeypatch):
+    _install_contract_for_league(monkeypatch, "main")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/terminal?leagueKey=ghost")
+    assert res.status_code == 400
+    assert res.json()["error"] == "unknown_league"
+
+
+def test_inactive_league_key_returns_400(two_league_registry, monkeypatch):
+    _install_contract_for_league(monkeypatch, "main")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/terminal?leagueKey=retired")
+    assert res.status_code == 400
+    assert res.json()["error"] == "inactive_league"
+
+
+def test_data_not_ready_for_non_loaded_league(two_league_registry, monkeypatch):
+    """The loaded contract is for 'main' — asking for 'side' must
+    return 503 ``data_not_ready`` with the league key echoed back."""
+    _install_contract_for_league(monkeypatch, "main")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/terminal?leagueKey=side")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert body["leagueKey"] == "side"
+
+
+def test_alias_resolves_to_canonical_key(two_league_registry, monkeypatch):
+    """Passing ``primary`` (an alias for ``main``) should work —
+    same as passing ``main`` directly."""
+    _install_contract_for_league(monkeypatch, "main")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/terminal?leagueKey=primary")
+    # 200 means validation accepted the alias.
+    assert res.status_code == 200, res.text
+
+
+# ── Default fallback ─────────────────────────────────────────────
+
+
+def test_no_league_key_falls_back_to_default(two_league_registry, monkeypatch):
+    """Omitting ``leagueKey`` must continue to work — backward-compat
+    for every existing caller that predates multi-league."""
+    _install_contract_for_league(monkeypatch, "main")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/terminal")
+    assert res.status_code == 200, res.text
+
+
+# ── /api/data ────────────────────────────────────────────────────
+
+
+def test_api_data_rejects_unknown_league(two_league_registry, monkeypatch):
+    _install_contract_for_league(monkeypatch, "main")
+    # latest_data_bytes is referenced by the response path; make it
+    # non-None so we hit the league validation first.
+    monkeypatch.setattr(server, "latest_data_bytes", None)
+    monkeypatch.setattr(server, "latest_data_gzip_bytes", None)
+    monkeypatch.setattr(server, "latest_data_etag", None)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/data?leagueKey=ghost")
+    assert res.status_code == 400
+    assert res.json()["error"] == "unknown_league"
+
+
+def test_api_data_returns_503_for_non_loaded_league(two_league_registry, monkeypatch):
+    _install_contract_for_league(monkeypatch, "main")
+    monkeypatch.setattr(server, "latest_data_bytes", None)
+    monkeypatch.setattr(server, "latest_data_gzip_bytes", None)
+    monkeypatch.setattr(server, "latest_data_etag", None)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/data?leagueKey=side")
+    assert res.status_code == 503
+    assert res.json()["error"] == "data_not_ready"
+    assert res.json()["leagueKey"] == "side"
+
+
+# ── /api/trade/simulate ──────────────────────────────────────────
+
+
+def test_trade_simulate_accepts_league_key_in_body(two_league_registry, monkeypatch):
+    """Valid leagueKey passes validation — the downstream
+    ``team_not_found`` surfaces because the stub sleeper block is
+    minimal, which is fine: the test asserts validation succeeded by
+    checking the 404 response still echoes the leagueKey back."""
+    _install_contract_for_league(monkeypatch, "main")
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda request: {"username": "alice", "auth_method": "sleeper", "sleeper_user_id": "oA"},
+    )
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post(
+            "/api/trade/simulate",
+            json={"leagueKey": "main", "teamName": "Nonexistent", "playersIn": [], "playersOut": []},
+        )
+    # 404 team_not_found is the NEXT validation step after league
+    # resolution — proves we got past the league check.
+    assert res.status_code == 404, res.text
+    body = res.json()
+    assert body["error"] == "team_not_found"
+    assert body["leagueKey"] == "main"
+
+
+def test_trade_simulate_rejects_wrong_league_in_body(two_league_registry, monkeypatch):
+    _install_contract_for_league(monkeypatch, "main")
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda request: {"username": "alice", "auth_method": "sleeper", "sleeper_user_id": "oA"},
+    )
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post(
+            "/api/trade/simulate",
+            json={"leagueKey": "side", "teamName": "Team A"},
+        )
+    assert res.status_code == 503
+    assert res.json()["error"] == "data_not_ready"
+
+
+# ── /api/leagues stays coherent ──────────────────────────────────
+
+
+def test_api_leagues_excludes_inactive(two_league_registry):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/leagues")
+    assert res.status_code == 200
+    keys = [lg["key"] for lg in res.json()["leagues"]]
+    assert "main" in keys
+    assert "side" in keys
+    assert "retired" not in keys


### PR DESCRIPTION
## Summary

Every league-scoped API endpoint now accepts an optional `leagueKey` parameter that resolves through `src/api/league_registry`. The UI never passes (and the server never exposes) raw Sleeper league IDs — keys are the stable public identifiers.

### Resolution order
1. Explicit `leagueKey` in query/body
2. Authenticated user's `activeLeagueKey` from `user_kv`
3. Registry default league

### Error contract
| Condition | HTTP | Code |
|---|---|---|
| Unknown key | 400 | `unknown_league` |
| Inactive key | 400 | `inactive_league` |
| Valid key, contract not loaded | 503 | `data_not_ready` |
| No leagues configured | 404 | `no_leagues_configured` |

### Updated endpoints
`/api/data`, `/api/rankings/overrides`, `/api/terminal`, `/api/trade/{simulate,suggestions,finder}`, `/api/angle/{find,packages}`, `/api/draft-capital`, `/api/scrape` (non-default → 501 until multi-league scrape lands).

All league-aware responses echo `leagueKey` so the frontend can assert contract-to-league match after delta merges.

### Frontend
- `useTerminal` passes `?leagueKey=` and keys its cache by league
- `useTradeSimulator` attaches the saved key to the POST body
- Other callers lean on the backend's fallback-to-user-pref behavior

### Backward compat
Every new param is optional. Existing callers that don't pass `leagueKey` behave identically to pre-registry.

## Test plan
- [x] pytest: 1910 passed, 3 skipped (10 new in `test_league_routing.py`)
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)