### PR TITLE
feat: league-scoped team model + IDP-aware rankings

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Fragment, useMemo, useState, useCallback } from "react";
+import { Fragment, useMemo, useState, useCallback, useEffect } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
 import { resolvedRank, RANKING_SOURCES, getRetailLabel } from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
 import { useApp } from "@/components/AppShell";
+import { useTeam } from "@/components/useTeam";
 import {
   tierLabel,
   effectiveTierId,
@@ -440,6 +441,13 @@ export default function RankingsPage() {
     updateSetting("hiddenSiteCols", {});
   }, [updateSetting]);
   const { openPlayerPopup } = useApp();
+  // IDP gating — when the active league has ``idpEnabled: false``
+  // (the new non-IDP league), we strip IDP filter tabs from the
+  // pos-filter dropdown and drop IDP rows from the list.  The
+  // underlying blended board still lives on the backend; we just
+  // don't surface it here.  ``useTeam`` reads the flag off the
+  // registry's league config via ``useLeague``.
+  const { idpEnabled } = useTeam();
   const [query, setQuery] = useState("");
   const [posFilter, setPosFilter] = useState("all");
   const [confFilter, setConfFilter] = useState("all");
@@ -462,6 +470,16 @@ export default function RankingsPage() {
     }
   }, [sortCol]);
 
+  // If the user is viewing an IDP-only filter and then switches to
+  // a league that disables IDP, snap back to "all" so the board
+  // doesn't render empty.  Runs every render but only commits a
+  // state change when the filter is actually stale.
+  useEffect(() => {
+    if (!idpEnabled && (posFilter === "idp" || posFilter === "DL" || posFilter === "LB" || posFilter === "DB")) {
+      setPosFilter("all");
+    }
+  }, [idpEnabled, posFilter]);
+
   // Switch lens: reset sort to default, expand row limit
   const handleLensChange = useCallback((key) => {
     setActiveLens(key);
@@ -483,9 +501,17 @@ export default function RankingsPage() {
   }, []);
 
   // ── Base eligible list ──────────────────────────────────────────
+  // ``idpEnabled=false`` drops every IDP row from the board.  The
+  // rankings pipeline still blends IDP sources globally, but non-IDP
+  // leagues don't render any IDP rows, tabs, or summary counts —
+  // nothing the user of a non-IDP league can trade.
   const eligible = useMemo(() => {
-    return rows.filter(isEligibleForBoard);
-  }, [rows]);
+    const filtered = rows.filter(isEligibleForBoard);
+    if (!idpEnabled) {
+      return filtered.filter((r) => r?.assetClass !== "idp");
+    }
+    return filtered;
+  }, [rows, idpEnabled]);
 
   // ── Trust summary stats ──────────────────────────────────────────
   // Single-pass aggregate — six filters would each walk the full
@@ -1068,7 +1094,7 @@ export default function RankingsPage() {
             <select className="select" value={posFilter} onChange={(e) => setPosFilter(e.target.value)}>
               <option value="all">All</option>
               <option value="offense">OFF</option>
-              <option value="idp">IDP</option>
+              {idpEnabled && <option value="idp">IDP</option>}
               <option value="pick">Picks</option>
               <optgroup label="Rookies">
                 <option value="rookie">All Rookies</option>
@@ -1082,9 +1108,9 @@ export default function RankingsPage() {
                 <option value="RB">RB</option>
                 <option value="WR">WR</option>
                 <option value="TE">TE</option>
-                <option value="DL">DL</option>
-                <option value="LB">LB</option>
-                <option value="DB">DB</option>
+                {idpEnabled && <option value="DL">DL</option>}
+                {idpEnabled && <option value="LB">LB</option>}
+                {idpEnabled && <option value="DB">DB</option>}
               </optgroup>
             </select>
             <select className="select hide-mobile" value={confFilter} onChange={(e) => setConfFilter(e.target.value)}>

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -67,7 +67,12 @@ export const SETTINGS_DEFAULTS = {
   // Trade history
   tradeHistoryWindowDays: 365,       // rolling 1-year window for trade analysis
 
-  // Selected team (global)
+  // Selected team (LEGACY, one-league era).  Kept for back-compat:
+  // if ``selectedTeamsByLeague`` has no entry for the active league
+  // but this field is set AND the active league is the registry
+  // default, ``useTeam`` treats this as the default league's pick.
+  // Writes still mirror here when on the default league so a roll-
+  // back to a pre-migration build won't flip the user's team empty.
   selectedTeam: "",                  // Sleeper team name selection
 
   // True once the user (or any surface) has written ``selectedTeam``
@@ -79,6 +84,18 @@ export const SETTINGS_DEFAULTS = {
   // TeamSwitcher, the /rosters "My team..." dropdown, and any future
   // surface) flips this to true in the same localStorage write.
   selectedTeamTouched: false,
+
+  // Per-league selected team map.  Shape:
+  //   { [leagueKey]: { ownerId, teamName, rosterId?, managerName? } }
+  // Takes precedence over ``selectedTeam`` when an entry exists for
+  // the active league.  ``useTeam`` writes to this AND mirrors to
+  // the legacy field when writing for the default league.
+  selectedTeamsByLeague: {},
+  // Per-league touched flags, same shape as ``selectedTeamTouched``
+  // but keyed by leagueKey.  Once a user picks a team in League B
+  // explicitly, auto-select never overrides their choice on that
+  // league — even if their League A pick was implicit.
+  selectedTeamTouchedByLeague: {},
 };
 
 // ── localStorage helpers ────────────────────────────────────────────────

--- a/frontend/components/useTeam.js
+++ b/frontend/components/useTeam.js
@@ -3,10 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useApp } from "@/components/AppShell";
 import { useSettings } from "@/components/useSettings";
+import { useLeague } from "@/components/useLeague";
 
-// Default team to auto-select on first load when no persisted choice
-// exists and this team is present in the league's Sleeper roster set.
-// Matched case-insensitively against ``sleeper.teams[].name``.
+// Fallback team name for the ORIGINAL league only (back-compat for
+// Jason's pre-multi-league state).  New leagues don't have a
+// hardcoded default — they rely on the registry's ``defaultTeamMap``
+// which ``/api/leagues`` exposes per user via ``userDefaultTeam``.
 export const DEFAULT_TEAM_NAME = "Rossini Panini";
 
 function normalize(s) {
@@ -15,98 +17,246 @@ function normalize(s) {
 
 /**
  * useTeam — single source of truth for "which Sleeper team is the
- * signed-in user operating as?"
+ * signed-in user operating as on the ACTIVE league?"
  *
- * Composes:
- *   - sleeper.teams[] from the live canonical contract (via AppShell's
- *     useApp context, so private/public gating is respected)
- *   - settings.selectedTeam from useSettings (localStorage-backed,
- *     synced across tabs via useSyncExternalStore)
+ * Multi-league design
+ * ───────────────────
+ * Before multi-league, ``settings.selectedTeam`` was a single string
+ * and ``availableTeams`` came from ``rawData.sleeper.teams``.  That
+ * broke once a user could own a team in multiple leagues: picking
+ * "my team" in League A would silently clobber "my team" in League
+ * B (or worse, auto-match a same-named team across leagues).
  *
- * Reactivity: any consumer re-renders when either the underlying
- * contract changes OR the persisted selection changes.  Switching
- * teams writes to settings which notifies every useSettings subscriber
- * in the app.
+ * New shape:
+ *   * ``useLeague`` decides which league is active.
+ *   * ``settings.selectedTeamsByLeague[leagueKey]`` stores the team
+ *     per league.  ``useTeam`` reads from that slot and writes to
+ *     that slot.
+ *   * For the REGISTRY DEFAULT league, the legacy
+ *     ``settings.selectedTeam`` is mirrored (on write) + consulted
+ *     (on read) as a fallback so pre-migration users don't flip
+ *     empty on first load.
+ *   * Auto-select honors the league's ``userDefaultTeam`` from
+ *     ``/api/leagues`` (per-user slice of the registry's
+ *     ``defaultTeamMap``).  When the server doesn't name a default,
+ *     the historical ``DEFAULT_TEAM_NAME`` hardcoded fallback runs
+ *     only for the registry default league — new leagues require
+ *     an explicit user choice.
  *
- * First-load behavior: if the user has no persisted selection AND
- * no explicit touched flag on this device, and the league contains a
- * team whose name matches DEFAULT_TEAM_NAME, auto-select it and
- * persist.  A persisted empty string with the touched flag set
- * counts as an explicit clear and is preserved across reloads; an
- * unresolvable persisted name (e.g. league renamed a team) is
- * likewise not silently overwritten — ``needsSelection`` flips true
- * and the UI can prompt the user.
- *
- * The guard OR's ``selectedTeamTouched`` with ``!!selectedName`` so
- * that users upgrading from a build that pre-dates the touched flag
- * (where their persisted non-empty ``selectedTeam`` carries an
- * implicit-default ``selectedTeamTouched: false``) are not clobbered
- * by auto-assignment.  A non-empty persisted name is authoritative
- * evidence of prior user intent regardless of the flag.
+ * ``availableTeams`` is sourced from ``rawData.sleeper.teams``.
+ * That block is currently stamped with one league's teams at a time
+ * (the scrape is single-league until Phase 2).  When the
+ * ``meta.leagueKey`` on the contract doesn't match the active
+ * league, ``availableTeams`` returns ``[]`` — the UI should show a
+ * "data not ready" state for that league, not another league's
+ * teams dressed up with a wrong name.
  */
 export function useTeam() {
   const { rawData, privateDataEnabled, loading: dataLoading } = useApp();
   const { settings, update } = useSettings();
-  const selectedName = settings?.selectedTeam || "";
-  const selectionTouched =
-    settings?.selectedTeamTouched === true || selectedName.length > 0;
-  const autoAssignedRef = useRef(false);
+  const { selectedLeague, selectedLeagueKey, defaultLeagueKey } = useLeague();
+  const autoAssignedRef = useRef(new Set());
+
+  // ── Contract-for-this-league guard ──────────────────────────────
+  // The contract in memory carries ``meta.leagueKey``.  When the UI
+  // asks for teams in a league the contract wasn't built for, we
+  // return an empty list — the UI then renders the data-not-ready
+  // state rather than showing League A's teams on League B.
+  const contractLeagueKey = useMemo(
+    () => rawData?.meta?.leagueKey || rawData?.leagueKey || "",
+    [rawData],
+  );
+
+  const leagueMismatch = Boolean(
+    selectedLeagueKey &&
+    contractLeagueKey &&
+    contractLeagueKey !== selectedLeagueKey,
+  );
 
   const availableTeams = useMemo(() => {
     if (!privateDataEnabled) return [];
+    if (leagueMismatch) return [];
     const teams = rawData?.sleeper?.teams;
     return Array.isArray(teams) ? teams : [];
-  }, [rawData, privateDataEnabled]);
+  }, [rawData, privateDataEnabled, leagueMismatch]);
+
+  // ── Resolve the stored selection for the active league ─────────
+  const storedEntry = useMemo(() => {
+    const byLeague = settings?.selectedTeamsByLeague || {};
+    const fromMap = selectedLeagueKey ? byLeague[selectedLeagueKey] : null;
+    if (fromMap && (fromMap.teamName || fromMap.ownerId)) return fromMap;
+    // Legacy fallback: only the default league reads ``selectedTeam``
+    // — non-default leagues have nothing to fall back to.
+    if (selectedLeagueKey && selectedLeagueKey === defaultLeagueKey) {
+      const legacyName = settings?.selectedTeam || "";
+      if (legacyName) return { ownerId: "", teamName: legacyName };
+    }
+    return null;
+  }, [settings, selectedLeagueKey, defaultLeagueKey]);
+
+  const storedName = storedEntry?.teamName || "";
+  const storedOwnerId = storedEntry?.ownerId || "";
+
+  const touchedMap = settings?.selectedTeamTouchedByLeague || {};
+  const selectionTouched = Boolean(
+    (selectedLeagueKey && touchedMap[selectedLeagueKey] === true) ||
+    // Pre-migration users might only have the legacy touched flag set.
+    // For the default league, treat the legacy flag as the touched
+    // signal; for other leagues it's meaningless.
+    (selectedLeagueKey === defaultLeagueKey &&
+      (settings?.selectedTeamTouched === true || !!storedName)),
+  );
 
   const selectedTeam = useMemo(() => {
-    if (!selectedName || availableTeams.length === 0) return null;
-    const needle = normalize(selectedName);
-    return availableTeams.find((t) => normalize(t?.name) === needle) || null;
-  }, [availableTeams, selectedName]);
+    if (!storedName && !storedOwnerId) return null;
+    if (availableTeams.length === 0) return null;
+    // Prefer owner-ID match so a Sleeper team rename doesn't orphan
+    // the selection; fall back to case-insensitive name match.
+    if (storedOwnerId) {
+      const byOwner = availableTeams.find(
+        (t) => String(t?.ownerId || "") === storedOwnerId,
+      );
+      if (byOwner) return byOwner;
+    }
+    if (storedName) {
+      const needle = normalize(storedName);
+      return availableTeams.find((t) => normalize(t?.name) === needle) || null;
+    }
+    return null;
+  }, [availableTeams, storedName, storedOwnerId]);
 
-  // Auto-assign default team when (a) the user has never written a
-  // selection on this device and (b) the default exists in this
-  // league.  ``selectionTouched`` is true if the stored flag is set
-  // (any ``update("selectedTeam", ...)`` write via useSettings flips
-  // it) OR if a non-empty name is persisted — the latter covers users
-  // upgrading from a build that pre-dates the touched flag.  A
-  // persisted-but-unresolvable name keeps ``selectionTouched`` true
-  // so we skip auto-assign in that case too and let the UI surface
-  // ``needsSelection``.
+  // ── Writers ─────────────────────────────────────────────────────
+  // Accept a team dict OR a name string.  The dict form carries
+  // ownerId + rosterId + managerName so future multi-device syncs
+  // can rename-tolerance via ownerId.  Callers that only have a
+  // name (TeamSwitcher, /rosters dropdown) pass a string.
+  const setSelectedTeam = useCallback(
+    (teamOrName) => {
+      if (!selectedLeagueKey) return;
+      let entry;
+      if (!teamOrName) {
+        entry = { ownerId: "", teamName: "" };
+      } else if (typeof teamOrName === "string") {
+        // Look up the full team in availableTeams so we can stash
+        // ownerId + rosterId + managerName alongside the name.
+        const match = availableTeams.find(
+          (t) => normalize(t?.name) === normalize(teamOrName),
+        );
+        entry = {
+          ownerId: match?.ownerId || "",
+          teamName: match?.name || String(teamOrName).trim(),
+          rosterId: match?.roster_id ? String(match.roster_id) : undefined,
+          managerName: match?.manager || undefined,
+        };
+      } else {
+        entry = {
+          ownerId: String(teamOrName.ownerId || "").trim(),
+          teamName: String(teamOrName.teamName || teamOrName.name || "").trim(),
+          rosterId: teamOrName.rosterId || (teamOrName.roster_id && String(teamOrName.roster_id)) || undefined,
+          managerName: teamOrName.managerName || teamOrName.manager || undefined,
+        };
+      }
+      // Drop undefined fields so localStorage doesn't grow a cruft
+      // suffix over time.
+      for (const k of Object.keys(entry)) {
+        if (entry[k] === undefined) delete entry[k];
+      }
+
+      const nextByLeague = {
+        ...(settings?.selectedTeamsByLeague || {}),
+        [selectedLeagueKey]: entry,
+      };
+      const nextTouched = {
+        ...(settings?.selectedTeamTouchedByLeague || {}),
+        [selectedLeagueKey]: true,
+      };
+
+      update("selectedTeamsByLeague", nextByLeague);
+      update("selectedTeamTouchedByLeague", nextTouched);
+
+      // Back-compat mirror: for the default league also write the
+      // legacy top-level field so pre-migration builds loaded in
+      // another tab still see the right team name.
+      if (selectedLeagueKey === defaultLeagueKey) {
+        update("selectedTeam", entry.teamName);
+        // update() already sets selectedTeamTouched for selectedTeam writes.
+      }
+    },
+    [selectedLeagueKey, defaultLeagueKey, availableTeams, settings, update],
+  );
+
+  const clearSelectedTeam = useCallback(() => setSelectedTeam(""), [setSelectedTeam]);
+
+  // ── Auto-assign on fresh devices ────────────────────────────────
+  // Once per (leagueKey, mount) — only if the user hasn't explicitly
+  // set a team on this league on this device.
   useEffect(() => {
-    if (autoAssignedRef.current) return;
+    if (!selectedLeagueKey) return;
+    if (autoAssignedRef.current.has(selectedLeagueKey)) return;
     if (dataLoading) return;
     if (!privateDataEnabled) return;
+    if (leagueMismatch) return;
     if (selectionTouched) return;
     if (availableTeams.length === 0) return;
 
-    const match = availableTeams.find(
-      (t) => normalize(t?.name) === normalize(DEFAULT_TEAM_NAME),
-    );
-    if (match?.name) {
-      autoAssignedRef.current = true;
-      update("selectedTeam", match.name);
+    // 1. Server-resolved default from the registry's defaultTeamMap
+    //    (shipped per-league on /api/leagues as ``userDefaultTeam``).
+    const serverDefault = selectedLeague?.userDefaultTeam;
+    let match = null;
+    if (serverDefault?.ownerId) {
+      match = availableTeams.find(
+        (t) => String(t?.ownerId || "") === String(serverDefault.ownerId),
+      ) || null;
     }
-  }, [availableTeams, selectionTouched, privateDataEnabled, dataLoading, update]);
+    if (!match && serverDefault?.teamName) {
+      const needle = normalize(serverDefault.teamName);
+      match = availableTeams.find((t) => normalize(t?.name) === needle) || null;
+    }
 
-  const setSelectedTeam = useCallback(
-    (name) => update("selectedTeam", name || ""),
-    [update],
-  );
+    // 2. Historical "Rossini Panini" fallback — only for the default
+    //    league.  New leagues don't inherit Jason's team.
+    if (!match && selectedLeagueKey === defaultLeagueKey) {
+      match = availableTeams.find(
+        (t) => normalize(t?.name) === normalize(DEFAULT_TEAM_NAME),
+      ) || null;
+    }
 
-  const clearSelectedTeam = useCallback(() => update("selectedTeam", ""), [update]);
+    if (match?.name) {
+      autoAssignedRef.current.add(selectedLeagueKey);
+      setSelectedTeam(match);
+    }
+  }, [
+    selectedLeagueKey,
+    defaultLeagueKey,
+    selectionTouched,
+    privateDataEnabled,
+    dataLoading,
+    leagueMismatch,
+    availableTeams,
+    selectedLeague,
+    setSelectedTeam,
+  ]);
 
   const needsSelection =
-    privateDataEnabled && !dataLoading && availableTeams.length > 0 && !selectedTeam;
+    privateDataEnabled &&
+    !dataLoading &&
+    !leagueMismatch &&
+    availableTeams.length > 0 &&
+    !selectedTeam;
 
   return {
     availableTeams,
     selectedTeam,
-    selectedName,
+    selectedName: selectedTeam?.name || storedName || "",
+    selectedOwnerId: selectedTeam?.ownerId || storedOwnerId || "",
+    selectedLeagueKey,
+    leagueMismatch,
     setSelectedTeam,
     clearSelectedTeam,
     needsSelection,
     loading: dataLoading,
     privateDataEnabled,
+    idpEnabled: selectedLeague?.idpEnabled !== false,
+    rosterSettings: selectedLeague?.rosterSettings || {},
   };
 }

--- a/server.py
+++ b/server.py
@@ -1994,21 +1994,42 @@ async def get_leagues(request: Request):
     callers thread through the rest of the API when we eventually
     add ``?leagueId=`` parameters to league-scoped endpoints.
 
-    Two views:
+    Views:
       * Anonymous:     active leagues only.
-      * Authenticated: active leagues + the user's resolved default
-                       (``userDefaultKey``), which the UI uses to
-                       pre-select the right league on cold start.
+      * Authenticated: active leagues + ``userDefaultKey`` (which
+                       league the UI should land this user on by
+                       default) + per-league ``userDefaultTeam``
+                       entries from each league's ``defaultTeamMap``
+                       so the frontend can auto-select the right
+                       team in each league without a second round-
+                       trip to user_kv.
     """
     session = _get_auth_session(request)
-    leagues = [cfg.public_dict() for cfg in _league_registry.active_leagues()]
+    active_cfgs = _league_registry.active_leagues()
+    leagues = [cfg.public_dict() for cfg in active_cfgs]
+
+    if session:
+        username = (session.get("username") or "").strip().lower()
+        # Stamp each league's entry with this user's default team
+        # when the registry knows about one.  Only this authed user
+        # sees their own default — we don't expose other usernames'
+        # mappings even though the registry file holds them.
+        for i, cfg in enumerate(active_cfgs):
+            default_team = cfg.default_team_map.get(username) if username else None
+            if default_team:
+                leagues[i]["userDefaultTeam"] = {
+                    "ownerId": default_team.get("ownerId", ""),
+                    "teamName": default_team.get("teamName", ""),
+                }
+
     body: dict[str, Any] = {
         "leagues": leagues,
         "defaultKey": _league_registry.default_league_key(),
     }
     if session:
-        username = session.get("username") or ""
-        user_default = _league_registry.get_user_default_league(username)
+        user_default = _league_registry.get_user_default_league(
+            session.get("username") or ""
+        )
         body["userDefaultKey"] = user_default.key if user_default else None
     return JSONResponse(content=body, headers={"Cache-Control": "no-store"})
 
@@ -4716,6 +4737,43 @@ async def put_user_state_api(request: Request):
             # Unknown or inactive league → silently drop.  The
             # frontend will notice the server didn't echo the key back
             # and fall through to the default.
+    if "selectedTeamsByLeague" in body:
+        # Per-league selected team map.  Accepts
+        #   {"leagueKey": {"ownerId": "...", "teamName": "...",
+        #                  "rosterId": <int|str>, "managerName": "..."}}
+        # Each entry's leagueKey must resolve against the registry
+        # (aliases canonicalized); unknown / inactive leagues are
+        # dropped.  Null/"" clears the entire map.
+        raw = body.get("selectedTeamsByLeague")
+        if raw is None or raw == "":
+            patch["selectedTeamsByLeague"] = None
+        elif isinstance(raw, dict):
+            clean: dict[str, dict[str, object]] = {}
+            for lkey, spec in raw.items():
+                if not isinstance(lkey, str) or not isinstance(spec, dict):
+                    continue
+                cfg = _league_registry.get_league_by_key(lkey.strip())
+                if cfg is None or not cfg.active:
+                    continue
+                owner_id = str(spec.get("ownerId") or "").strip()
+                team_name = str(spec.get("teamName") or "").strip()
+                if not owner_id and not team_name:
+                    # An empty entry clears that league's selection
+                    # (distinct from not touching the map at all).
+                    clean[cfg.key] = {"ownerId": "", "teamName": ""}
+                    continue
+                entry: dict[str, object] = {
+                    "ownerId": owner_id,
+                    "teamName": team_name,
+                }
+                roster_id = spec.get("rosterId")
+                if roster_id is not None:
+                    entry["rosterId"] = str(roster_id)
+                manager_name = str(spec.get("managerName") or "").strip()
+                if manager_name:
+                    entry["managerName"] = manager_name
+                clean[cfg.key] = entry
+            patch["selectedTeamsByLeague"] = clean
     state = await run_in_threadpool(_user_kv.merge_user_state, username, patch)
     return JSONResponse(
         content={"username": username, "state": state},

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -76,6 +76,14 @@ KNOWN_KEYS = frozenset({
     # league on mobile sees the same league on desktop.  Unvalidated
     # here; the PUT endpoint validates against the live registry.
     "activeLeagueKey",
+    # Per-league selected team.  Shape:
+    #   ``{ [leagueKey]: {ownerId, teamName, rosterId?, managerName?} }``
+    # Takes precedence over the legacy top-level ``selectedTeam`` when
+    # a per-league entry exists for the active league.  The legacy
+    # field is kept for back-compat — it's treated as the default
+    # league's entry on read, and writes mirror to both for one more
+    # release so pre-migration clients don't flip empty on first load.
+    "selectedTeamsByLeague",
     # Notification preferences already flow through ``merge_user_state``
     # — listed here so new readers know the schema includes them.
     "notificationsEmail",

--- a/tests/api/test_league_registry.py
+++ b/tests/api/test_league_registry.py
@@ -455,6 +455,114 @@ def test_put_user_state_drops_unknown_active_league_key(tmp_path, monkeypatch):
     assert state.get("activeLeagueKey") in (None, "")  # not persisted
 
 
+def test_put_user_state_accepts_selected_teams_by_league(tmp_path, monkeypatch):
+    """PUT /api/user/state accepts a per-league team map, validates
+    each key against the registry, and canonicalizes aliases.  Unknown
+    / inactive leagues are silently dropped from the map."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}, "aliases": ["primary"]},
+                {"key": "side", "displayName": "Side", "sleeperLeagueId": "2", "active": True, "rosterSettings": {}},
+                {"key": "retired", "displayName": "Off", "sleeperLeagueId": "3", "active": False, "rosterSettings": {}},
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
+    user_kv._SETUP_DONE.clear()
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda request: {"username": "alice", "auth_method": "password"},
+    )
+
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.put(
+            "/api/user/state",
+            json={
+                "selectedTeamsByLeague": {
+                    # Uses an alias — server should canonicalize to "main".
+                    "primary": {"ownerId": "o1", "teamName": "Team One", "rosterId": 5},
+                    "side": {"ownerId": "o2", "teamName": "Side Team", "managerName": "Alice"},
+                    "retired": {"ownerId": "o9", "teamName": "Legacy"},  # should drop
+                    "ghost": {"ownerId": "oX", "teamName": "Nope"},  # should drop
+                },
+            },
+        )
+    assert res.status_code == 200, res.text
+    by_league = res.json()["state"]["selectedTeamsByLeague"]
+    assert set(by_league.keys()) == {"main", "side"}  # canonical + valid only
+    assert by_league["main"]["ownerId"] == "o1"
+    assert by_league["main"]["teamName"] == "Team One"
+    assert by_league["main"]["rosterId"] == "5"
+    assert by_league["side"]["managerName"] == "Alice"
+
+
+def test_api_leagues_includes_user_default_team_when_authed(tmp_path, monkeypatch):
+    """When authenticated, each league entry in /api/leagues carries
+    a ``userDefaultTeam`` pulled from the registry's defaultTeamMap
+    so the frontend can auto-select per league without a second
+    round-trip."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "leagues": [
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                    "defaultTeamMap": {
+                        "alice": {"ownerId": "", "teamName": "Alice's Squad"},
+                    },
+                },
+                {
+                    "key": "side",
+                    "displayName": "Side",
+                    "sleeperLeagueId": "2",
+                    "active": True,
+                    "rosterSettings": {},
+                    "defaultTeamMap": {},  # alice has no default on side
+                },
+            ],
+        },
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    # Authed as alice.
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda request: {"username": "alice", "auth_method": "sleeper"},
+    )
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/leagues")
+    assert res.status_code == 200
+    leagues_by_key = {lg["key"]: lg for lg in res.json()["leagues"]}
+    assert leagues_by_key["main"].get("userDefaultTeam", {}).get("teamName") == "Alice's Squad"
+    assert "userDefaultTeam" not in leagues_by_key["side"]
+
+    # Anon callers never see userDefaultTeam.
+    monkeypatch.setattr(server, "_get_auth_session", lambda request: None)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/leagues")
+    for lg in res.json()["leagues"]:
+        assert "userDefaultTeam" not in lg
+
+
 def test_put_user_state_canonicalizes_alias(tmp_path, monkeypatch):
     """Submitting an alias like ``idp`` (instead of ``dynasty_main``)
     should be stored as the canonical key so user state stays clean


### PR DESCRIPTION
## Summary

Teams are scoped per league. A user's "my team" in League A no longer clobbers their pick in League B. Rankings UI hides IDP tabs + rows when the active league has `idpEnabled: false`.

### Backend
- `user_kv` grows `selectedTeamsByLeague: {[leagueKey]: {ownerId, teamName, rosterId?, managerName?}}`
- `PUT /api/user/state` validates each entry's league key against the registry (aliases canonicalised)
- `GET /api/leagues` returns per-league `userDefaultTeam` when authenticated (authed user's slice of `defaultTeamMap`)

### Frontend
- `useTeam` reads from the nested slot, falls back to legacy `selectedTeam` for the default league only
- Auto-select: server-supplied `userDefaultTeam` first, then `DEFAULT_TEAM_NAME = "Rossini Panini"` as a default-league-only fallback
- Writes to nested map + mirrors to legacy for backward compat
- Returns `{ownerId, rosterId, managerName, idpEnabled, rosterSettings}` from the registry
- `leagueMismatch` flag stops non-default-league UIs from rendering wrong data
- Rankings page hides IDP filter options + drops IDP rows when `idpEnabled` is false

### Default-team behavior
- Original league: Jason still lands on **Rossini Panini** (registry `defaultTeamMap[jasonleetucker]` OR the historical `DEFAULT_TEAM_NAME` fallback)
- New league: each user picks their own default (no inherited pick from League A)

## Test plan
- [x] pytest: 1912 passed, 3 skipped (2 new backend tests)
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [ ] Manual smoke: switch league → team doesn't carry over; IDP tab hidden in non-IDP league
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)