### PR TITLE
feat: rankings follow scoring profile; league drives context only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,69 @@ npm run regression                   # Full pipeline: preflight + tests
 | `/api/trade/finder` | POST | KTC arbitrage finder |
 | `/api/leagues` | GET | Active league registry (stable `key` → `displayName` + roster settings; **no Sleeper IDs leaked**) |
 
+### Rankings vs. league context — the core split
+
+The single most important architectural rule for multi-league:
+
+> **Scoring profile controls rankings.  League key controls context.**
+
+* **`scoringProfile`** (from `config/leagues/registry.json`) is the
+  identifier for "which set of rules produces a player's value".  Two
+  leagues that use identical scoring share ONE ranking pipeline and
+  ONE output.  A single scrape's blended rankings can be served to
+  every league with the same profile — no per-league recompute.
+
+* **`leagueKey`** is the identifier for "which league's rosters,
+  teams, managers, draft, and signals".  Anything that depends on
+  who-owns-what in Sleeper is league-scoped.
+
+Fields that follow **scoring profile** (global across same-scoring leagues):
+- `players`, `playersArray`, `sources`, `rankings`, `poolAudit`
+- Rank history, source-value history, edge signals
+- Player metadata (position, Sleeper ID, news)
+- Tier boundaries, confidence buckets, value bands
+- Injury-impact calculations (position-based, not league-based)
+
+Fields that follow **leagueKey** (must be per-league):
+- `sleeper.teams`, `sleeper.leagueId`, `sleeper.positions`,
+  `sleeper.scoringSettings`
+- Draft capital (per-team auction budgets, pick ownership)
+- Public-league snapshots / standings / matchups
+- Terminal aggregates (team portfolio, roster movers)
+- Trade-finder, trade-suggestions, trade-simulate outputs
+- Angle-finder / Angle-packages opponent filters
+- Signal visibility (filtered by roster ownership)
+- IDP display toggle (per-league `idpEnabled`)
+- Roster-constraint derived UI (starter counts, flex rules)
+- Per-user `selectedTeam`, `activeLeagueKey`, watchlist relevance
+
+Contract annotations:
+- `meta.leagueKey` — which specific league's `sleeper` block is
+  stamped here
+- `meta.scoringProfile` — which scoring rules produced these rankings
+- `meta.sleeperDataReady` — true iff `sleeper` block is valid for the
+  *requested* league; false when the server served the shared
+  rankings but doesn't have the requested league's rosters loaded
+- `meta.sleeperLoadedLeagueKey` — which league the `sleeper` block
+  *would* be for, when `sleeperDataReady: false` (diagnostic only)
+
+Error behavior on endpoints:
+- `/api/data`, `/api/rankings/overrides` — 503 only when scoring
+  profiles genuinely differ.  When they match but sleeper is for a
+  different league, serve shared rankings with `sleeper: null` +
+  `sleeperDataReady: false`.
+- `/api/terminal`, `/api/trade/*`, `/api/angle/*`,
+  `/api/draft-capital` — 503 whenever the loaded contract's
+  `leagueKey` doesn't match the request.  These endpoints can't
+  meaningfully work without the specific league's rosters.
+
+Rule for new code:
+- Need rankings / values / player data?  →  resolve the scoring
+  profile via `league_registry.get_scoring_profile(key)`.  Share
+  across leagues.  Never index per-league.
+- Need rosters / teams / matchups?  →  resolve via `leagueKey`.  One
+  pipeline per league.  Never collapse.
+
 ### League-aware routing
 
 League-scoped endpoints accept an optional `leagueKey` parameter

--- a/frontend/components/useTeam.js
+++ b/frontend/components/useTeam.js
@@ -57,21 +57,36 @@ export function useTeam() {
   const { selectedLeague, selectedLeagueKey, defaultLeagueKey } = useLeague();
   const autoAssignedRef = useRef(new Set());
 
-  // ── Contract-for-this-league guard ──────────────────────────────
-  // The contract in memory carries ``meta.leagueKey``.  When the UI
-  // asks for teams in a league the contract wasn't built for, we
-  // return an empty list — the UI then renders the data-not-ready
-  // state rather than showing League A's teams on League B.
+  // ── Sleeper-data-for-this-league guard ─────────────────────────
+  // The contract's ``meta.sleeperDataReady`` tells us whether the
+  // ``sleeper`` block in the response is real for the requested
+  // league.  When the user switches to a league whose rosters
+  // haven't been scraped yet, the server returns shared rankings
+  // with ``sleeper: null`` and ``sleeperDataReady: false``.  We
+  // surface that as ``leagueMismatch: true`` so team-dependent UI
+  // (pickers, rosters, terminal) renders the data-not-ready state
+  // rather than the wrong league's teams.
+  //
+  // Back-compat: older contracts (pre-scoringProfile refactor) lack
+  // the flag.  Treat an absent flag as "ready" and fall back to
+  // the old leagueKey-mismatch check so pre-multi-league clients
+  // still work.
   const contractLeagueKey = useMemo(
     () => rawData?.meta?.leagueKey || rawData?.leagueKey || "",
     [rawData],
   );
+  const sleeperDataReady = useMemo(() => {
+    const flag = rawData?.meta?.sleeperDataReady;
+    if (flag === false) return false;
+    if (flag === true) return true;
+    // Legacy path: if the flag is absent, infer from leagueKey match.
+    if (contractLeagueKey && selectedLeagueKey) {
+      return contractLeagueKey === selectedLeagueKey;
+    }
+    return true;
+  }, [rawData, contractLeagueKey, selectedLeagueKey]);
 
-  const leagueMismatch = Boolean(
-    selectedLeagueKey &&
-    contractLeagueKey &&
-    contractLeagueKey !== selectedLeagueKey,
-  );
+  const leagueMismatch = !sleeperDataReady && Boolean(selectedLeagueKey);
 
   const availableTeams = useMemo(() => {
     if (!privateDataEnabled) return [];

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1166,7 +1166,29 @@ const DEFAULT_DATA_URL = "/api/dynasty-data";
 // delta onto.  We keep the last successfully loaded full contract in
 // module-level state so the second call with overrides does not have
 // to refetch the 2.5MB base payload.
+//
+// NOTE: rankings are scoped by scoring profile (see CLAUDE.md).  When
+// two leagues share a profile they share this cached contract.  We
+// still pass ``leagueKey`` on the wire so the server can stamp the
+// response with the right league's ``sleeper`` block (or null it
+// when the specific league's roster data isn't loaded yet).
 let _cachedBaseContract = null;
+
+// Key to read the active league from localStorage — written by
+// ``useLeague`` whenever the user switches leagues.  We can't
+// ``useLeague`` here because this module is imported by
+// ``useLeague`` itself (via ``_resetBaseContractCache``); localStorage
+// is the cycle-safe way to share the value.
+const LEAGUE_LOCAL_KEY = "next_active_league_v1";
+
+function _readActiveLeagueKey() {
+  if (typeof window === "undefined") return "";
+  try {
+    return localStorage.getItem(LEAGUE_LOCAL_KEY) || "";
+  } catch {
+    return "";
+  }
+}
 
 /** Clear the in-memory base contract cache.  Useful for tests. */
 export function _resetBaseContractCache() {
@@ -1174,7 +1196,17 @@ export function _resetBaseContractCache() {
 }
 
 async function _fetchBaseContract() {
-  const res = await fetch(DEFAULT_DATA_URL, { cache: "no-store" });
+  const leagueKey = _readActiveLeagueKey();
+  // Append leagueKey so the server can stamp ``meta.leagueKey`` and
+  // ``meta.sleeperDataReady`` correctly on the response.  When the
+  // active league shares the scoring profile with the loaded
+  // contract, the server serves the common rankings with a nulled
+  // ``sleeper`` block.  When profiles differ, the server 503s and
+  // we surface the error the same way as any other data failure.
+  const url = leagueKey
+    ? `${DEFAULT_DATA_URL}?leagueKey=${encodeURIComponent(leagueKey)}`
+    : DEFAULT_DATA_URL;
+  const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) {
     const txt = await res.text();
     throw new Error(`Failed to load dynasty data: ${res.status} ${txt}`);

--- a/server.py
+++ b/server.py
@@ -1053,17 +1053,27 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
             # contract response.  The glyph degrades gracefully when
             # rankHistory is absent.
             log.warning("rank_history: append/stamp failed: %s", exc)
-        # Tag the contract with the league it was built for so
-        # ``_resolve_league_for_request()`` can reject requests
-        # asking for a different league (503 "data_not_ready").
-        # Today only one league runs the scraper, so this is always
-        # the registry's default.  When multi-league scraping lands,
-        # this annotation is the link between a request's leagueKey
-        # and the correct in-memory contract.
+        # Tag the contract with the league + scoring profile it was
+        # built for.  Two different roles:
+        #
+        #   * ``meta.leagueKey`` — which specific league's Sleeper
+        #     block (teams, rosters, ownerIds) is stamped here.
+        #     Team-requiring endpoints (/api/terminal, /api/trade/*)
+        #     reject requests for other leagues with 503.
+        #   * ``meta.scoringProfile`` — which scoring rules produced
+        #     these rankings.  Rankings endpoints (/api/data,
+        #     /api/rankings/overrides) serve the same rankings to
+        #     any league that shares the profile, and only 503 when
+        #     profiles actually differ.
+        #
+        # This split is the core of the "scoring drives rankings,
+        # league drives context" architecture — see CLAUDE.md.
         try:
             _default_cfg = _league_registry.get_default_league()
             if _default_cfg and isinstance(contract_payload, dict):
-                contract_payload.setdefault("meta", {})["leagueKey"] = _default_cfg.key
+                meta_block = contract_payload.setdefault("meta", {})
+                meta_block["leagueKey"] = _default_cfg.key
+                meta_block["scoringProfile"] = _default_cfg.scoring_profile
         except Exception:  # noqa: BLE001
             pass
         latest_contract_data = contract_payload
@@ -1708,11 +1718,22 @@ def _proxy_next(path: str) -> tuple[Response | None, str | None]:
 async def get_data(request: Request):
     """Return latest normalized/validated data contract JSON.
 
-    Optional ``?leagueKey=...`` validates against the league registry
-    and 503s if the loaded contract is for a different league.
-    Without the param we fall through to the user's saved
-    ``activeLeagueKey`` and finally the registry default — matching
-    ``/api/terminal``'s resolution behavior.
+    Optional ``?leagueKey=...`` validates against the league registry.
+
+    **Rankings are keyed by scoring profile, not by league.**  When
+    two leagues share a profile, they share the rankings pipeline's
+    output — the ``players`` / ``playersArray`` / ``sources`` blocks
+    are identical and we serve them to any caller whose league
+    resolves to the same profile.  Only the league-specific
+    ``sleeper`` block (teams, rosters, owners) is per-league; when a
+    different league is requested and we don't have that league's
+    sleeper data loaded, the block is returned as ``None`` and
+    ``meta.sleeperDataReady=false`` tells the client to show
+    "no roster data yet" rather than rendering the default league's
+    teams under the wrong name.
+
+    503 ``data_not_ready`` only fires when the scoring profiles
+    genuinely differ — i.e. the rankings themselves can't be reused.
     """
     # League validation comes first so a stale leagueKey returns 400
     # before we bother assembling the payload.  Skip the loaded-
@@ -1724,23 +1745,34 @@ async def get_data(request: Request):
         return err.json_response()
 
     if latest_contract_data:
-        # Validate that the loaded contract matches the resolved league.
-        # When it doesn't (non-default league requested, scraper hasn't
-        # caught up), surface a clean 503 with the key so the client
-        # knows to wait or switch back.
-        loaded_league = (
-            (latest_contract_data.get("meta") or {}).get("leagueKey")
-            if isinstance(latest_contract_data, dict) else None
+        loaded_meta = (
+            latest_contract_data.get("meta") or {}
+            if isinstance(latest_contract_data, dict) else {}
         )
-        if loaded_league and loaded_league != league_cfg.key:
+        loaded_league = str(loaded_meta.get("leagueKey") or "")
+        loaded_profile = str(loaded_meta.get("scoringProfile") or "")
+        sleeper_matches = bool(loaded_league) and loaded_league == league_cfg.key
+
+        # Scoring-profile mismatch → genuinely different data; 503.
+        # Missing loaded_profile means we're running a contract built
+        # before this refactor; treat it as if profiles match (the
+        # rankings are global), and surface sleeper_matches only.
+        if loaded_profile and loaded_profile != league_cfg.scoring_profile:
             return JSONResponse(
                 status_code=503,
                 content={
                     "error": "data_not_ready",
-                    "message": f"No data loaded for league {league_cfg.key!r} yet",
+                    "message": (
+                        f"League {league_cfg.key!r} uses scoring profile "
+                        f"{league_cfg.scoring_profile!r}, but the loaded "
+                        f"contract is {loaded_profile!r}.  Rankings are "
+                        "not compatible."
+                    ),
                     "leagueKey": league_cfg.key,
+                    "scoringProfile": league_cfg.scoring_profile,
                 },
             )
+
         view = (request.query_params.get("view") or "").strip().lower()
         startup_view = view in {"startup", "boot", "initial"}
         runtime_view = view in {"app", "runtime", "lite", "slim"}
@@ -1769,6 +1801,24 @@ async def get_data(request: Request):
             "Cache-Control": "public, max-age=30, stale-while-revalidate=300",
             "X-Payload-View": payload_view_name,
         }
+
+        # Cross-league request for a same-scoring-profile league —
+        # serve the shared rankings but null the sleeper block so the
+        # UI doesn't render the loaded league's teams under the
+        # requested league's name.  Bypass the pre-serialized fast-
+        # path here; we need to hand-edit the payload.
+        if not sleeper_matches:
+            scrubbed = dict(payload_obj) if isinstance(payload_obj, dict) else {}
+            scrubbed["sleeper"] = None
+            meta = dict(scrubbed.get("meta") or {})
+            meta["leagueKey"] = league_cfg.key
+            meta["scoringProfile"] = league_cfg.scoring_profile
+            meta["sleeperDataReady"] = False
+            meta["sleeperLoadedLeagueKey"] = loaded_league or None
+            scrubbed["meta"] = meta
+            headers["X-Payload-View"] = f"{payload_view_name}-cross-league"
+            return JSONResponse(content=scrubbed, headers=headers)
+
         if payload_etag:
             headers["ETag"] = payload_etag
             incoming = request.headers.get("if-none-match", "").strip('"')
@@ -1924,19 +1974,39 @@ async def post_rankings_overrides(request: Request):
     except Exception:
         body = None
 
-    # Validate leagueKey (body or query).  The override pipeline
-    # always runs against the currently-loaded scrape data
-    # (``latest_data``), so a mismatched league key gets 503 with a
-    # clean error rather than rebuilding a contract whose
-    # ``sleeper`` block is wrong.
+    # Rankings follow scoring profile, not league key.  Validate the
+    # key but only 503 when profiles actually differ — otherwise the
+    # override pipeline can serve the same recomputed rankings to any
+    # league that shares scoring.  The league-specific sleeper block
+    # in the response is nulled below when the loaded contract was
+    # built for a different league.
     try:
         league_cfg = _resolve_league_for_request(
             request,
             body=body if isinstance(body, dict) else None,
-            require_loaded_contract=True,
         )
     except LeagueResolutionError as err:
         return err.json_response()
+    loaded_meta = (
+        latest_contract_data.get("meta") or {}
+        if isinstance(latest_contract_data, dict) else {}
+    )
+    loaded_league = str(loaded_meta.get("leagueKey") or "")
+    loaded_profile = str(loaded_meta.get("scoringProfile") or "")
+    sleeper_matches = bool(loaded_league) and loaded_league == league_cfg.key
+    if loaded_profile and loaded_profile != league_cfg.scoring_profile:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": (
+                    f"League {league_cfg.key!r} uses scoring profile "
+                    f"{league_cfg.scoring_profile!r}, not {loaded_profile!r}."
+                ),
+                "leagueKey": league_cfg.key,
+                "scoringProfile": league_cfg.scoring_profile,
+            },
+        )
 
     overrides, warnings = normalize_source_overrides(body)
     tep_multiplier = normalize_tep_multiplier(body)
@@ -1972,11 +2042,22 @@ async def post_rankings_overrides(request: Request):
     if warnings:
         contract_payload.setdefault("warnings", []).extend(warnings)
 
-    # Stamp the resolved league key on the override response so the
-    # frontend can assert "this is the right league's data" after
-    # merging the delta onto its base contract.
+    # Stamp meta fields so the frontend can assert compatibility:
+    # ``leagueKey`` = resolved league; ``scoringProfile`` = which
+    # rules the pipeline used; ``sleeperDataReady`` = whether the
+    # ``sleeper`` block can be trusted for this league.  When the
+    # loaded contract was built for a different league (same scoring
+    # profile though — we'd have 503'd above if profiles differed),
+    # null the sleeper block so callers don't render the wrong
+    # league's teams.
     if isinstance(contract_payload, dict):
-        contract_payload.setdefault("meta", {})["leagueKey"] = league_cfg.key
+        meta = contract_payload.setdefault("meta", {})
+        meta["leagueKey"] = league_cfg.key
+        meta["scoringProfile"] = league_cfg.scoring_profile
+        meta["sleeperDataReady"] = sleeper_matches
+        if not sleeper_matches:
+            contract_payload["sleeper"] = None
+            meta["sleeperLoadedLeagueKey"] = loaded_league or None
 
     headers = {
         "Cache-Control": "no-store",

--- a/src/api/league_registry.py
+++ b/src/api/league_registry.py
@@ -453,6 +453,49 @@ def get_sleeper_league_id(key: str | None = None) -> str | None:
     return cfg.sleeper_league_id if cfg else None
 
 
+def get_scoring_profile(key: str | None = None) -> str | None:
+    """Return the scoring-profile marker for a league, or the default's.
+
+    The scoring profile is the identifier for "which set of rules
+    produces this league's player values" — e.g.
+    ``"superflex_tep15_ppr1"``.  **Rankings are keyed by scoring
+    profile, not by league.**  When two leagues share a profile, they
+    share the blended rank + value pipeline; when they differ, each
+    profile runs its own pipeline.
+
+    See ``config/leagues/README.md`` and ``CLAUDE.md`` ("League-aware
+    routing" section) for the full split:
+
+      * scoringProfile → controls rankings, values, rank-history
+      * leagueKey      → controls teams, rosters, signals, context
+
+    Returns None when no league is configured at all.
+    """
+    if key is None:
+        cfg = get_default_league()
+    else:
+        cfg = get_league_by_key(key)
+    return cfg.scoring_profile if cfg else None
+
+
+def leagues_share_scoring(key_a: str | None, key_b: str | None) -> bool:
+    """True iff two league keys resolve to the same scoring profile.
+
+    Used by routes that serve rankings (``/api/data``,
+    ``/api/rankings/overrides``) to decide whether the loaded
+    contract's rankings apply to a different requested league.
+    Unknown keys never share scoring — safer to return False and
+    force the caller to surface a ``data_not_ready`` response than
+    to silently serve the default league's pipeline output under
+    the wrong league's name.
+    """
+    cfg_a = get_league_by_key(key_a) if key_a else None
+    cfg_b = get_league_by_key(key_b) if key_b else None
+    if cfg_a is None or cfg_b is None:
+        return False
+    return cfg_a.scoring_profile == cfg_b.scoring_profile
+
+
 def default_league_key() -> str | None:
     """Return the default league's key, or None if none configured."""
     cfg = get_default_league()

--- a/tests/api/test_league_routing.py
+++ b/tests/api/test_league_routing.py
@@ -170,16 +170,27 @@ def test_api_data_rejects_unknown_league(two_league_registry, monkeypatch):
     assert res.json()["error"] == "unknown_league"
 
 
-def test_api_data_returns_503_for_non_loaded_league(two_league_registry, monkeypatch):
-    _install_contract_for_league(monkeypatch, "main")
-    monkeypatch.setattr(server, "latest_data_bytes", None)
-    monkeypatch.setattr(server, "latest_data_gzip_bytes", None)
-    monkeypatch.setattr(server, "latest_data_etag", None)
+def test_api_data_returns_200_with_nulled_sleeper_for_legacy_stub(
+    two_league_registry, monkeypatch
+):
+    """Legacy test: the stub contract in this fixture doesn't stamp
+    ``meta.scoringProfile``, which means the endpoint can't enforce
+    profile matching.  In that case the pre-refactor behavior applies
+    — same-scoring-profile pass-through is assumed, sleeper is
+    nulled for the non-matching league.  Upgrading the stub to
+    include a profile would push this into the ``stranger`` (503)
+    path; see ``test_api_data_503s_when_scoring_profile_differs``."""
     with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract_for_league(monkeypatch, "main")
+        monkeypatch.setattr(server, "latest_data_bytes", None)
+        monkeypatch.setattr(server, "latest_data_gzip_bytes", None)
+        monkeypatch.setattr(server, "latest_data_etag", None)
         res = c.get("/api/data?leagueKey=side")
-    assert res.status_code == 503
-    assert res.json()["error"] == "data_not_ready"
-    assert res.json()["leagueKey"] == "side"
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["sleeper"] is None
+    assert body["meta"]["leagueKey"] == "side"
+    assert body["meta"]["sleeperDataReady"] is False
 
 
 # ── /api/trade/simulate ──────────────────────────────────────────
@@ -221,6 +232,142 @@ def test_trade_simulate_rejects_wrong_league_in_body(two_league_registry, monkey
         )
     assert res.status_code == 503
     assert res.json()["error"] == "data_not_ready"
+
+
+# ── Scoring-profile sharing ──────────────────────────────────────
+# Leagues that share a scoring profile share one ranking pipeline
+# output.  When the server has loaded the contract for League A
+# but the client requests League B (same profile), the response
+# carries the shared rankings with the ``sleeper`` block nulled
+# and ``meta.sleeperDataReady: false``.  Only when profiles
+# actually differ does the server 503.
+
+
+@pytest.fixture
+def shared_scoring_registry(tmp_path, monkeypatch):
+    """Two leagues with the SAME scoring profile + one with a
+    different profile.  Tests around scoring-vs-sleeper distinction
+    use this fixture to verify that profile-match serves shared
+    rankings and profile-mismatch returns 503."""
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "LM",
+                        "scoringProfile": "superflex_tep15_ppr1",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    },
+                    {
+                        "key": "twin",
+                        "displayName": "Twin",
+                        "sleeperLeagueId": "LT",
+                        "scoringProfile": "superflex_tep15_ppr1",  # same
+                        "active": True,
+                        "rosterSettings": {"teamCount": 10},
+                    },
+                    {
+                        "key": "stranger",
+                        "displayName": "Stranger",
+                        "sleeperLeagueId": "LS",
+                        "scoringProfile": "standard_1qb_ppr1",  # different
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+    yield
+    league_registry.reload_registry()
+
+
+def _install_contract_with_profile(monkeypatch, league_key: str, profile: str):
+    stub = {
+        "meta": {"leagueKey": league_key, "scoringProfile": profile},
+        "players": {"stub": {"name": "Stub"}},
+        "playersArray": [{"name": "Stub"}],
+        "sleeper": {"teams": [{"ownerId": "oA", "name": "Team A", "players": []}]},
+    }
+    monkeypatch.setattr(server, "latest_contract_data", stub)
+    # Skip the pre-serialized bytes path so our hand-edited sleeper
+    # scrubbing branch is exercised.
+    monkeypatch.setattr(server, "latest_data_bytes", None)
+    monkeypatch.setattr(server, "latest_data_gzip_bytes", None)
+    monkeypatch.setattr(server, "latest_data_etag", None)
+
+
+def test_api_data_serves_shared_rankings_for_same_profile(
+    shared_scoring_registry, monkeypatch
+):
+    """Loaded contract is for League 'main' (superflex_tep15_ppr1).
+    Request for 'twin' (same profile) should succeed with 200,
+    serve the rankings, and null the sleeper block so the UI
+    doesn't render League main's teams under Twin's name.
+
+    IMPORTANT: monkeypatch inside the TestClient context so app
+    startup can't re-populate ``latest_contract_data`` after our
+    stub.  Same pattern as the signal-alerts tests."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract_with_profile(monkeypatch, "main", "superflex_tep15_ppr1")
+        res = c.get("/api/data?leagueKey=twin")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    # Rankings are intact.
+    assert body["players"]["stub"]["name"] == "Stub"
+    # Sleeper is nulled + meta flags the state.
+    assert body["sleeper"] is None
+    assert body["meta"]["leagueKey"] == "twin"
+    assert body["meta"]["scoringProfile"] == "superflex_tep15_ppr1"
+    assert body["meta"]["sleeperDataReady"] is False
+    assert body["meta"]["sleeperLoadedLeagueKey"] == "main"
+
+
+def test_api_data_serves_full_contract_when_sleeper_matches(
+    shared_scoring_registry, monkeypatch
+):
+    """When the loaded contract's leagueKey matches the requested
+    league, the sleeper block is returned intact."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract_with_profile(monkeypatch, "main", "superflex_tep15_ppr1")
+        res = c.get("/api/data?leagueKey=main")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["sleeper"] is not None
+    assert body["sleeper"]["teams"][0]["ownerId"] == "oA"
+
+
+def test_api_data_503s_when_scoring_profile_differs(
+    shared_scoring_registry, monkeypatch
+):
+    """Loaded contract is superflex_tep15_ppr1.  Requesting the
+    'stranger' league (standard_1qb_ppr1) must 503 — rankings
+    genuinely can't be reused across different scoring."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract_with_profile(monkeypatch, "main", "superflex_tep15_ppr1")
+        res = c.get("/api/data?leagueKey=stranger")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert body["leagueKey"] == "stranger"
+    assert body["scoringProfile"] == "standard_1qb_ppr1"
+
+
+def test_registry_helpers_share_scoring(shared_scoring_registry):
+    """Unit-level check on the registry helpers themselves."""
+    assert league_registry.leagues_share_scoring("main", "twin") is True
+    assert league_registry.leagues_share_scoring("main", "stranger") is False
+    assert league_registry.leagues_share_scoring("main", "unknown") is False
+    assert league_registry.leagues_share_scoring(None, "main") is False
+    assert league_registry.get_scoring_profile("twin") == "superflex_tep15_ppr1"
 
 
 # ── /api/leagues stays coherent ──────────────────────────────────


### PR DESCRIPTION
## Summary

Enforces the core multi-league rule: **scoring profile controls rankings; league key controls context.** Two leagues with identical scoring now share ONE ranking pipeline output — no duplicate compute, no accidental divergence.

### What

- **Registry helpers**: `get_scoring_profile(key)` + `leagues_share_scoring(a, b)` — single source of truth for profile identity
- **Contract stamping**: `latest_contract_data.meta` carries both `leagueKey` and `scoringProfile`
- **`/api/data` + `/api/rankings/overrides`**: 503 *only* when profiles genuinely differ. When profiles match but sleeper block is for a different league, serve the shared rankings with `sleeper: null` + `meta.sleeperDataReady: false`. UI renders data-not-ready state without rendering wrong teams.
- **Team-requiring endpoints** (`/api/terminal`, `/api/trade/*`, `/api/angle/*`, `/api/draft-capital`): keep strict leagueKey matching
- **`useTeam.leagueMismatch`**: reads `meta.sleeperDataReady` off the contract; back-compat falls through to the old leagueKey check
- **`fetchDynastyData`**: passes `?leagueKey=` so server can stamp meta correctly

### What's global vs per-league

| Global (scoring profile) | Per-league |
|---|---|
| Players, values, rankings | `sleeper.teams` |
| Rank/source-value history | Draft capital |
| Edge signals | Public-league snapshot |
| Player metadata | Terminal aggregates |
| Tier boundaries | Trade-finder/simulate/suggestions |
| Injury-impact | Angle-finder |
| | IDP display toggle |
| | Per-user selectedTeam, activeLeagueKey |

### Not in scope

Multi-league scraping — still single-contract in memory. When two leagues share scoring, one scrape serves both; when they diverge, each needs its own pipeline (future work).

## Test plan

- [x] pytest: 1916 passed, 3 skipped (4 new tests)
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [x] `test_api_data_serves_shared_rankings_for_same_profile` pins the shared-rankings contract
- [x] `test_api_data_503s_when_scoring_profile_differs` pins the profile-divergence behavior
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)