### PR TITLE
feat: terminal is league-aware

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4625,6 +4625,18 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   text-transform: uppercase;
   color: var(--muted);
 }
+.tc-header-eyebrow-sep {
+  color: var(--border);
+  /* Dim the middot so the league label reads as secondary info
+     rather than a peer of "My Team" — subtle by design. */
+  opacity: 0.55;
+}
+.tc-header-eyebrow-league {
+  color: var(--cyan);
+  /* Same size as "My Team" eyebrow but de-emphasized via color
+     only — reads as "you're on THIS league" without competing
+     with the team name below. */
+}
 .tc-header-team {
   margin: 2px 0 0;
   font-size: 1.4rem;

--- a/frontend/components/terminal/PortfolioSummary.jsx
+++ b/frontend/components/terminal/PortfolioSummary.jsx
@@ -49,7 +49,17 @@ function formatPct(v) {
  */
 export default function PortfolioSummary() {
   const { rows, rawData, openPlayerPopup } = useApp();
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, idpEnabled } = useTeam();
+  // IDP gating: skip the IDP positional bucket (and any IDP rows in
+  // the positional stack) for leagues that don't support IDP.  The
+  // portfolio computation still runs globally on the contract; we
+  // just don't surface an "IDP: 0" row or any stray IDP entries
+  // that might have sneaked in via a shared contract.  Matches the
+  // rankings-page IDP-tab gating.
+  const posOrder = useMemo(
+    () => (idpEnabled ? POS_ORDER : POS_ORDER.filter((p) => p !== "IDP")),
+    [idpEnabled],
+  );
   const { history, loading: historyLoading } = useRankHistory({ days: 30 });
 
   // Server-side portfolio (aggregates + byPosition + byAge +
@@ -177,7 +187,7 @@ export default function PortfolioSummary() {
       <section className="portfolio-section">
         <h3 className="portfolio-section-title">Positional allocation</h3>
         <div className="portfolio-stack">
-          {POS_ORDER.map((pos) => {
+          {posOrder.map((pos) => {
             const entry = byPosition[pos];
             if (!entry || entry.count === 0) return null;
             return (

--- a/frontend/components/terminal/TeamCommandHeader.jsx
+++ b/frontend/components/terminal/TeamCommandHeader.jsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useApp } from "@/components/AppShell";
 import { useTeam } from "@/components/useTeam";
+import { useLeague } from "@/components/useLeague";
 import { useRankHistory } from "@/components/useRankHistory";
 import { useTerminal } from "@/components/useTerminal";
 import {
@@ -85,7 +86,18 @@ function formatDeltaTooltip(detail) {
  */
 export default function TeamCommandHeader() {
   const { rows } = useApp();
-  const { selectedTeam, needsSelection, loading: teamLoading, privateDataEnabled } = useTeam();
+  const {
+    selectedTeam,
+    needsSelection,
+    loading: teamLoading,
+    privateDataEnabled,
+    leagueMismatch,
+  } = useTeam();
+  // League context for the header eyebrow: shows the active league
+  // name so the user always knows which league these aggregates
+  // belong to.  Hidden when only one league exists — at that point
+  // it'd be visual clutter, not information.
+  const { selectedLeague, leagues } = useLeague();
   const { history, loading: historyLoading } = useRankHistory({ days: 30 });
   const {
     teamAggregates: serverAggregates,
@@ -98,7 +110,14 @@ export default function TeamCommandHeader() {
 
   let teamName;
   let nameVariant = "ready";
-  if (needsSelection) {
+  if (leagueMismatch) {
+    // The user switched to a league whose roster data isn't loaded
+    // yet (single-instance deployments).  Rankings still work; the
+    // team widget just shows a clear "waiting for data" state so
+    // the page isn't rendering stale/wrong team info.
+    teamName = "Roster data not ready for this league";
+    nameVariant = "needs";
+  } else if (needsSelection) {
     teamName = "Pick your team";
     nameVariant = "needs";
   } else if (selectedTeam?.name) {
@@ -113,6 +132,14 @@ export default function TeamCommandHeader() {
     teamName = "No team data";
     nameVariant = "error";
   }
+
+  // League chip: show ONLY when more than one league is configured.
+  // For the single-league dev era (today), showing the league name
+  // above every team is redundant — there's only one league.  Once
+  // a second league is activated in the registry this flips on
+  // automatically.
+  const showLeagueEyebrow = Array.isArray(leagues) && leagues.length >= 2;
+  const leagueLabel = selectedLeague?.displayName || selectedLeague?.key || "";
 
   const rowByName = useMemo(() => {
     const m = new Map();
@@ -202,7 +229,17 @@ export default function TeamCommandHeader() {
     <header className="tc-header panel panel--bare">
       <div className="tc-header-row">
         <div className="tc-header-identity">
-          <span className="tc-header-eyebrow">My Team</span>
+          <span className="tc-header-eyebrow">
+            My Team
+            {showLeagueEyebrow && leagueLabel && (
+              <>
+                <span className="tc-header-eyebrow-sep" aria-hidden="true"> · </span>
+                <span className="tc-header-eyebrow-league" title={`Active league: ${leagueLabel}`}>
+                  {leagueLabel}
+                </span>
+              </>
+            )}
+          </span>
           <h1 className={`tc-header-team tc-header-team--${nameVariant}`}>{teamName}</h1>
         </div>
         <div className="tc-header-stats" aria-label="Team aggregates">


### PR DESCRIPTION
## Summary

Signed-in terminal now clearly shows which league the aggregates belong to, gates IDP content for non-IDP leagues, and degrades cleanly when switching to a league whose roster data isn't loaded yet.

### TeamCommandHeader
- **League eyebrow** — "My Team · <League Name>" appears when more than one active league exists. Hidden for single-league deployments so it's not clutter. Auto-appears when second league is activated.
- **Data-not-ready state** — when `useTeam().leagueMismatch` is true, the team name shows "Roster data not ready for this league" instead of wrong-league teams.

### PortfolioSummary
- IDP positional bucket filtered out when `idpEnabled` is false. Defense-in-depth — no stray "IDP: 0" row in the non-IDP league.

### Why no new data calls
`useTerminal` already passes `leagueKey` (PR #262) and invalidates on `league:changed` (PR #261). The refetch pipeline is in place — this PR just makes the output coherent.

## Test plan
- [x] pytest: 1916 passed, 3 skipped
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [ ] Manual: verify eyebrow hidden with one league, appears with two
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)