### PR TITLE
feat: multi-league awareness on /draft, /angle, /finder

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
+import { useTeam } from "@/components/useTeam";
 
 // ── Angle ───────────────────────────────────────────────────────────
 // Multi-player trade-target arbitrage.
@@ -34,6 +35,10 @@ function marketLabelForSource(source) {
 
 export default function AnglePage() {
   const { loading: dataLoading, error: dataError, rawData, rows } = useDynastyData();
+  // League awareness: ``idpEnabled`` gates the IDP position filters
+  // + the "Include IDP" checkbox; ``selectedLeagueKey`` attaches to
+  // the POST body so the backend serves/rejects for the right league.
+  const { idpEnabled, selectedLeagueKey } = useTeam();
 
   const teams = useMemo(() => {
     const list = rawData?.sleeper?.teams || [];
@@ -41,6 +46,14 @@ export default function AnglePage() {
       String(a?.name || "").localeCompare(String(b?.name || "")),
     );
   }, [rawData]);
+
+  // Offensive-only position filters for non-IDP leagues — the
+  // backend still accepts ``positions`` + ``includeIdp`` but there's
+  // no reason to show IDP toggles in a league that can't use them.
+  const positionFiltersList = useMemo(
+    () => (idpEnabled ? POSITION_FILTERS : POSITION_FILTERS.filter((p) => !IDP_POSITION_FILTERS.has(p))),
+    [idpEnabled],
+  );
 
   // Quick lookup: canonical name → { my_value, market_value, market_source, position }.
   // "Market" source is IDPTC for IDP positions, KTC for everyone else
@@ -271,6 +284,11 @@ export default function AnglePage() {
               seedPlayerNames: activeSeedNames,
               includeIdp: effectiveIncludeIdp,
             };
+      // Attach leagueKey so the backend validates + scopes to the
+      // right league.  Backend falls back to the user's saved pref
+      // when absent but we pass it explicitly so switcher changes
+      // don't race user_kv writes.
+      if (selectedLeagueKey) body.leagueKey = selectedLeagueKey;
       const res = await fetch("/api/angle/packages", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -457,7 +475,7 @@ export default function AnglePage() {
           <div className="angle-filter-group">
             <span className="muted">Positions wanted</span>
             <div className="angle-pill-row">
-              {POSITION_FILTERS.map((pos) => {
+              {positionFiltersList.map((pos) => {
                 const active = positionFilters.has(pos);
                 return (
                   <button
@@ -513,6 +531,7 @@ export default function AnglePage() {
               deep-bench filler.
             </span>
           </div>
+          {idpEnabled && (
           <div className="angle-filter-group">
             <span className="muted">IDP players</span>
             <div className="angle-pill-row">
@@ -541,6 +560,7 @@ export default function AnglePage() {
               above, or explicitly add an IDP player to the trade.
             </span>
           </div>
+          )}
         </div>
       </section>
 

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/app/AppShellWrapper";
+import { useLeague } from "@/components/useLeague";
 import {
   DRAFT_STORAGE_KEY,
   DEFAULT_AGGRESSION,
@@ -2657,6 +2658,16 @@ function DraftGlossary() {
 export default function DraftDashboardPage() {
   const router = useRouter();
   const { authenticated, checking } = useAuthContext();
+  // League-scoped draft workspace — a draft-in-progress lives per
+  // league, keyed by ``DRAFT_STORAGE_KEY__<leagueKey>``.  Switching
+  // leagues mid-draft doesn't destroy the prior league's board.
+  // Falls back to the legacy unsuffixed key when no league is
+  // resolved yet (cold boot) so pre-migration state still hydrates.
+  const { selectedLeagueKey } = useLeague();
+  const draftStorageKey = useMemo(
+    () => (selectedLeagueKey ? `${DRAFT_STORAGE_KEY}__${selectedLeagueKey}` : DRAFT_STORAGE_KEY),
+    [selectedLeagueKey],
+  );
 
   const [workspace, setWorkspace] = useState(() => createDefaultWorkspace());
   const [hydrated, setHydrated] = useState(false);
@@ -2702,29 +2713,42 @@ export default function DraftDashboardPage() {
     }
   }, [checking, authenticated, router]);
 
-  // Hydrate workspace from localStorage on mount.
+  // Hydrate workspace from localStorage when the active league
+  // changes (or on mount).  Reads the league-scoped key first and
+  // falls back to the legacy unsuffixed key — migration path so
+  // pre-multi-league state carries over into the default league's
+  // slot on the first load.
   useEffect(() => {
+    setHydrated(false);
     try {
-      const raw = localStorage.getItem(DRAFT_STORAGE_KEY);
+      let raw = localStorage.getItem(draftStorageKey);
+      if (!raw && draftStorageKey !== DRAFT_STORAGE_KEY) {
+        // Legacy fallback: user had a workspace saved pre-migration
+        // under the unsuffixed key.  Adopt it as the current league's
+        // workspace.  Next persist write will land at the scoped key.
+        raw = localStorage.getItem(DRAFT_STORAGE_KEY);
+      }
       if (raw) {
         const parsed = JSON.parse(raw);
         setWorkspace(hydrateWorkspace(parsed));
+      } else {
+        setWorkspace(createDefaultWorkspace());
       }
     } catch {
       /* ignore */
     }
     setHydrated(true);
-  }, []);
+  }, [draftStorageKey]);
 
   // Persist on every change.
   useEffect(() => {
     if (!hydrated) return;
     try {
-      localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(workspace));
+      localStorage.setItem(draftStorageKey, JSON.stringify(workspace));
     } catch {
       /* ignore */
     }
-  }, [workspace, hydrated]);
+  }, [workspace, hydrated, draftStorageKey]);
 
   const stats = useMemo(() => computeDraftStats(workspace), [workspace]);
   // Retrospective inflation trajectory — O(N²) in pick count, but
@@ -2895,7 +2919,14 @@ export default function DraftDashboardPage() {
     async ({ quiet = false, force = false } = {}) => {
       setCapitalStatus((s) => ({ ...s, loading: true, error: "", info: "" }));
       try {
-        const res = await fetch("/api/draft-capital", { cache: "no-store" });
+        // Scope the draft-capital fetch to the active league so
+        // per-team auction budgets come from the right Sleeper
+        // league.  Backend validates + 503s with a clean error
+        // when the requested league's data isn't loaded.
+        const url = selectedLeagueKey
+          ? `/api/draft-capital?leagueKey=${encodeURIComponent(selectedLeagueKey)}`
+          : "/api/draft-capital";
+        const res = await fetch(url, { cache: "no-store" });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         if (data?.error) throw new Error(data.error);
@@ -2947,7 +2978,7 @@ export default function DraftDashboardPage() {
         }));
       }
     },
-    [],
+    [selectedLeagueKey],
   );
 
   // Auto-sync team budgets from the live Draft Capital feed on every
@@ -3068,7 +3099,13 @@ export default function DraftDashboardPage() {
     setSyncBusy(true);
     setSyncError("");
     try {
-      const res = await fetch("/api/data", { cache: "no-store" });
+      // Pass leagueKey so the backend serves the right league's
+      // sleeper block and 503s cleanly when the requested league
+      // isn't loaded yet.
+      const url = selectedLeagueKey
+        ? `/api/data?leagueKey=${encodeURIComponent(selectedLeagueKey)}`
+        : "/api/data";
+      const res = await fetch(url, { cache: "no-store" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       const pa = Array.isArray(data?.playersArray) ? data.playersArray : [];
@@ -3114,7 +3151,7 @@ export default function DraftDashboardPage() {
     } finally {
       setSyncBusy(false);
     }
-  }, [workspace]);
+  }, [workspace, selectedLeagueKey]);
 
   const applySyncPreview = useCallback(() => {
     if (!syncPreview) return;
@@ -3138,7 +3175,10 @@ export default function DraftDashboardPage() {
     // playersArray fetch side-effect.  Defer to the user's
     // currently selected team identity by NAME.
     try {
-      fetch("/api/data", { cache: "force-cache" })
+      const url = selectedLeagueKey
+        ? `/api/data?leagueKey=${encodeURIComponent(selectedLeagueKey)}`
+        : "/api/data";
+      fetch(url, { cache: "force-cache" })
         .then((r) => r.json())
         .then((data) => {
           const teams = data?.sleeper?.teams || [];
@@ -3153,7 +3193,7 @@ export default function DraftDashboardPage() {
     } catch {
       /* ignore */
     }
-  }, [allPlayersArray, workspace?.settings?.myTeamIdx, workspace?.teams]);
+  }, [allPlayersArray, workspace?.settings?.myTeamIdx, workspace?.teams, selectedLeagueKey]);
 
   // Global keyboard shortcuts.  Must be declared AFTER the callbacks
   // it depends on (onCycleTag / onToggleTarget / onAddToBoard) —

--- a/frontend/app/finder/page.jsx
+++ b/frontend/app/finder/page.jsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback, useEffect } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
 import { useApp } from "@/components/AppShell";
+import { useTeam } from "@/components/useTeam";
 import { actionLabel, cautionLabels } from "@/lib/edge-helpers";
 import { posBadgeClass, confBadgeClass, confBadgeLabel as confLabel, isEligibleForAnalysis } from "@/lib/display-helpers";
 import { rowChips } from "@/lib/rankings-helpers";
@@ -113,12 +114,39 @@ const ROW_LIMIT = FINDER_ROW_LIMIT;
 export default function FinderPage() {
   const { loading, error, rows } = useDynastyData();
   const { openPlayerPopup } = useApp();
+  // League gating: hide IDP workflows + filter tabs on non-IDP
+  // leagues.  ``idpEnabled`` comes from the registry via useLeague
+  // via useTeam.
+  const { idpEnabled } = useTeam();
+
+  // Filter WORKFLOWS and POS_FILTERS through the IDP gate in one
+  // place rather than N guard checks inline.
+  const visibleWorkflows = useMemo(
+    () => (idpEnabled ? WORKFLOWS : WORKFLOWS.filter((w) => w.key !== "stable-idp")),
+    [idpEnabled],
+  );
+  const visiblePosFilters = useMemo(() => {
+    if (idpEnabled) return POS_FILTERS;
+    const IDP_KEYS = new Set(["idp", "DL", "LB", "DB"]);
+    return POS_FILTERS.filter((f) => !IDP_KEYS.has(f.key));
+  }, [idpEnabled]);
 
   const [activeWorkflow, setActiveWorkflow] = useState("wr-gaps");
   const [query, setQuery] = useState("");
   const [posFilter, setPosFilter] = useState("all");
   const [confFilter, setConfFilter] = useState("all");
   const [expanded, setExpanded] = useState(false);
+
+  // Snap away from stale IDP selections when the user switches to
+  // a non-IDP league mid-session.  Runs on every relevant change;
+  // no-ops when already on a non-IDP filter.
+  useEffect(() => {
+    if (idpEnabled) return;
+    if (activeWorkflow === "stable-idp") setActiveWorkflow("wr-gaps");
+    if (posFilter === "idp" || posFilter === "DL" || posFilter === "LB" || posFilter === "DB") {
+      setPosFilter("all");
+    }
+  }, [idpEnabled, activeWorkflow, posFilter]);
 
   const handleWorkflowChange = useCallback((key) => {
     setActiveWorkflow(key);
@@ -191,7 +219,7 @@ export default function FinderPage() {
         <div className="card">
           {/* ── Workflow tabs ────────────────────────────────────────── */}
           <div className="sub-nav">
-            {WORKFLOWS.map((w) => (
+            {visibleWorkflows.map((w) => (
               <button
                 key={w.key}
                 className={`sub-nav-btn ${activeWorkflow === w.key ? "active" : ""}`}
@@ -217,7 +245,7 @@ export default function FinderPage() {
               style={{ flex: 1, minWidth: 140 }}
             />
             <select className="select" value={posFilter} onChange={(e) => setPosFilter(e.target.value)}>
-              {POS_FILTERS.map((f) => (
+              {visiblePosFilters.map((f) => (
                 <option key={f.key} value={f.key}>{f.label}</option>
               ))}
             </select>


### PR DESCRIPTION
## Summary

Final pass over the remaining league-scoped surfaces flagged in the multi-league audit. Three concrete gaps fixed, the rest verified correct by reading.

### Fixed

**`/draft`**
- `DRAFT_STORAGE_KEY` scoped per league — `next_draft_board_v1__<leagueKey>`. Legacy unsuffixed key read as migration fallback. Mid-draft league switch no longer clobbers boards.
- `/api/draft-capital` + both `/api/data` fetches get `?leagueKey=`

**`/angle`**
- POST body gets `leagueKey`
- IDP position pills + "Include IDP" filter hidden for non-IDP leagues

**`/finder`**
- "Stable IDP" workflow hidden
- IDP / DL / LB / DB pos filters hidden
- Stale IDP selection snaps to default on league switch

### Verified correct (no change)

| Surface | Why it's fine |
|---|---|
| `/rosters` | Reads `rawData.sleeper.teams` → empty on data-not-ready |
| `/edge` | Client-side signals over global rows; no team context |
| `/trades` | Client-side trade history |
| `/league` | Isolated public pipeline; single-league by design (future design gap) |
| `/tools/source-health` | Global pipeline health |
| `/tools/trade-coverage` | Uses `useTeam` which is already league-scoped |

## Test plan

- [x] pytest: 1916 passed, 3 skipped
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)