### PR TITLE
chore: remove last two hardcoded league IDs in active code

### DIFF
--- a/scripts/build_public_league_snapshot.py
+++ b/scripts/build_public_league_snapshot.py
@@ -16,16 +16,36 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from src.api import league_registry  # noqa: E402
 from src.public_league import build_public_contract, build_public_snapshot  # noqa: E402
 from src.public_league import snapshot_store  # noqa: E402
+
+
+def _default_league_id() -> str:
+    """Pick the default --league-id for the CLI:
+       1. ``SLEEPER_LEAGUE_ID`` env var (explicit operator override)
+       2. The registry's default league
+       3. Empty string (caller must pass --league-id)
+
+    Removes the hardcoded Sleeper ID that used to live here; the
+    registry is now the source of truth per the multi-league audit.
+    """
+    env = os.getenv("SLEEPER_LEAGUE_ID", "").strip()
+    if env:
+        return env
+    reg = league_registry.get_sleeper_league_id()
+    return reg or ""
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--league-id",
-        default=os.getenv("SLEEPER_LEAGUE_ID", "1312006700437352448"),
-        help="Sleeper league id to start the chain walk from.",
+        default=_default_league_id(),
+        help=(
+            "Sleeper league id to start the chain walk from.  Defaults "
+            "to SLEEPER_LEAGUE_ID env var → registry default → empty."
+        ),
     )
     parser.add_argument(
         "--max-seasons",

--- a/src/pool/builder.py
+++ b/src/pool/builder.py
@@ -18,7 +18,12 @@ from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any
 
-DEFAULT_SLEEPER_LEAGUE_ID = "1312006700437352448"
+# Historical note: this file used to export
+# ``DEFAULT_SLEEPER_LEAGUE_ID`` as a hardcoded fallback.  The constant
+# was never consumed outside its own module (confirmed by grep on
+# 2026-04-24) — the scraper resolves the league ID through
+# ``src/api/league_registry`` with its own env-var fallback, not via
+# this builder.  Removed during the multi-league audit.
 KTC_UNIVERSE_LIMIT = 525
 
 # Source type classification for the valuation pipeline


### PR DESCRIPTION
Found during final QA pass:

- `src/pool/builder.py` — dead `DEFAULT_SLEEPER_LEAGUE_ID` constant (never consumed outside its own file). Removed.
- `scripts/build_public_league_snapshot.py` — routed through the registry via a new `_default_league_id()` helper.

Source-code audit after this change:
- grep `1312006700437352448` in `src/` + `frontend/` + `server.py` → zero hits (only generated data snapshots + docs + .env.example)
- grep `getenv("SLEEPER_LEAGUE_ID"` in source → only in the registry's back-compat fallback path (intentional)

Tests: 1916 pytest + 690 vitest + clean build.