### PR TITLE
feat: private-app auth gate + activate League B

### DIFF
--- a/config/leagues/registry.json
+++ b/config/leagues/registry.json
@@ -40,10 +40,10 @@
     {
       "key": "dynasty_new",
       "displayName": "Dynasty New (Superflex + TEP, no IDP)",
-      "sleeperLeagueId": "REPLACE_WITH_NEW_SLEEPER_ID",
+      "sleeperLeagueId": "1320092771247222784",
       "scoringProfile": "superflex_tep15_ppr1",
       "idpEnabled": false,
-      "active": false,
+      "active": true,
       "aliases": ["new", "non-idp"],
       "rosterSettings": {
         "teamCount": 12,

--- a/server.py
+++ b/server.py
@@ -129,6 +129,17 @@ JASON_LOGIN_PASSWORD = (os.getenv("JASON_LOGIN_PASSWORD") or "Elliott21!").strip
 JASON_AUTH_COOKIE_NAME = "jason_session"
 JASON_AUTH_COOKIE_SECURE = _env_bool("JASON_AUTH_COOKIE_SECURE", True)
 
+# Private-app allowlist.  Only these Sleeper handles can sign in
+# via /api/auth/sleeper-login.  Anyone else — even with a valid
+# Sleeper account — gets 403.  Password auth (JASON_LOGIN_*) is
+# the operator fallback and isn't constrained by this list.
+# Env var is comma-separated, lowercase-normalised at load time.
+PRIVATE_APP_ALLOWED_USERNAMES = frozenset(
+    u.strip().lower()
+    for u in (os.getenv("PRIVATE_APP_ALLOWED_USERNAMES") or "jasonleetucker").split(",")
+    if u.strip()
+)
+
 # Rate limit: max 1 email per hour to avoid spam on repeated failures
 _last_alert_time = 0
 ALERT_COOLDOWN_SEC = 3600
@@ -1675,6 +1686,63 @@ app.add_middleware(GZipMiddleware, minimum_size=1024)
 async def _count_requests(request: Request, call_next):
     """R-9: Count all HTTP requests for metrics."""
     _metrics["request_count"] = _metrics.get("request_count", 0) + 1
+    return await call_next(request)
+
+
+# Paths under /api/* that do NOT require an authenticated session.
+# Anything else gets 401'd by ``_private_api_gate`` below.  Closes
+# the scrape risk: without this gate, ``curl /api/data`` from a
+# stranger returns the full private rankings contract.
+_PUBLIC_API_EXACT = frozenset({
+    "/api/health",
+    "/api/status",
+    "/api/uptime",
+    "/api/metrics",
+    "/api/leagues",
+    "/api/rankings/sources",
+    "/api/auth/status",
+    "/api/auth/login",
+    "/api/auth/logout",
+    "/api/auth/sleeper-login",
+    "/api/scaffold/status",
+})
+# Endpoints that handle their own auth (bearer token, etc.) — the
+# session-cookie middleware must skip them so the endpoint's own
+# check runs.
+_SELF_AUTHED_API_EXACT = frozenset({
+    "/api/signal-alerts/run",
+})
+_PUBLIC_API_PREFIXES = (
+    "/api/public/league",
+)
+
+
+def _is_public_api_path(path: str) -> bool:
+    if path in _PUBLIC_API_EXACT:
+        return True
+    if path in _SELF_AUTHED_API_EXACT:
+        return True
+    for prefix in _PUBLIC_API_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False
+
+
+@app.middleware("http")
+async def _private_api_gate(request: Request, call_next):
+    """401 any /api/* call without a session, except the public
+    allowlist.  Page routes still redirect via
+    ``_require_auth_or_redirect``; static/_next assets aren't
+    touched.
+    """
+    path = request.url.path or ""
+    if path.startswith("/api/") and not _is_public_api_path(path):
+        if not _is_authenticated(request):
+            return JSONResponse(
+                status_code=401,
+                content={"error": "auth_required", "message": "Sign-in required."},
+                headers={"Cache-Control": "no-store"},
+            )
     return await call_next(request)
 
 def _proxy_next(path: str) -> tuple[Response | None, str | None]:
@@ -4664,6 +4732,23 @@ async def auth_sleeper_login(request: Request):
             content={
                 "ok": False,
                 "error": "No Sleeper user with that username.  Double-check spelling.",
+            },
+        )
+
+    # Private-app allowlist.  A valid Sleeper handle is necessary but
+    # NOT sufficient — the app is a single-user dashboard.  Anyone
+    # whose username isn't in PRIVATE_APP_ALLOWED_USERNAMES (default:
+    # ``jasonleetucker`` only) gets 403.  Password auth remains the
+    # operator fallback.
+    if username not in PRIVATE_APP_ALLOWED_USERNAMES:
+        log.warning(
+            "sleeper-login rejected for non-allowlisted user %r", username,
+        )
+        return JSONResponse(
+            status_code=403,
+            content={
+                "ok": False,
+                "error": "This app is private.  Contact the operator for access.",
             },
         )
 

--- a/tests/api/test_league_routing.py
+++ b/tests/api/test_league_routing.py
@@ -74,6 +74,13 @@ def two_league_registry(tmp_path, monkeypatch):
     monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
     user_kv._SETUP_DONE.clear()
 
+    # Bypass the ``_private_api_gate`` middleware: these tests
+    # exercise league-routing logic under authenticated conditions.
+    # The gate is covered separately in ``test_private_auth.py``.
+    # Stub ``_is_authenticated`` to always pass so we don't have to
+    # seed a real session for every request.
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+
     yield
 
     # Reset the registry AFTER the test so later tests (especially
@@ -296,6 +303,10 @@ def shared_scoring_registry(tmp_path, monkeypatch):
     )
     monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
     league_registry.reload_registry()
+    # Bypass the private-api middleware — separately tested in
+    # test_private_auth.py.  Without this, /api/data + /api/terminal
+    # 401 before the scoring-profile logic can run.
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
     yield
     league_registry.reload_registry()
 

--- a/tests/api/test_private_auth.py
+++ b/tests/api/test_private_auth.py
@@ -1,0 +1,192 @@
+"""Tests for the private-app auth gate.
+
+The app is a single-user private tool.  Two gates enforce that:
+
+  1. ``PRIVATE_APP_ALLOWED_USERNAMES`` — only whitelisted Sleeper
+     usernames can create a Sleeper-auth session.  Anyone else
+     with a valid Sleeper handle gets 403.
+  2. ``_private_api_gate`` middleware — every ``/api/*`` path
+     except an explicit public allowlist returns 401 when there
+     is no authenticated session.  ``curl /api/data`` from a
+     stranger must not leak the rankings contract.
+
+These tests pin both gates.  They're the core privacy guarantee
+for this deployment.
+"""
+from __future__ import annotations
+
+import io
+import json as _json
+import urllib.error
+import urllib.request
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+
+
+# ── Middleware gate: unauthenticated /api/* is 401 ─────────────────
+
+
+PRIVATE_API_PATHS = [
+    "/api/data",
+    "/api/data/rank-history",
+    "/api/data/player-source-history",
+    "/api/terminal",
+    "/api/trade/suggestions",
+    "/api/trade/finder",
+    "/api/trade/simulate",
+    "/api/angle/find",
+    "/api/angle/packages",
+    "/api/draft-capital",
+    "/api/scaffold/raw",
+    "/api/scaffold/league",
+    "/api/scaffold/identity",
+    "/api/scaffold/validation",
+    "/api/scaffold/report",
+    "/api/user/state",
+]
+PRIVATE_POST_PATHS = {
+    "/api/trade/suggestions", "/api/trade/finder", "/api/trade/simulate",
+    "/api/angle/find", "/api/angle/packages", "/api/rankings/overrides",
+}
+
+
+@pytest.mark.parametrize("path", PRIVATE_API_PATHS)
+def test_private_api_paths_require_auth(path):
+    """Every private endpoint must 401 without a session cookie.
+    Single biggest anti-scrape guarantee."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        if path in PRIVATE_POST_PATHS:
+            res = c.post(path, json={})
+        else:
+            res = c.get(path)
+    assert res.status_code == 401, (
+        f"{path} leaked without auth: {res.status_code} {res.text[:200]}"
+    )
+    body = res.json()
+    assert body.get("error") == "auth_required"
+
+
+def test_api_rankings_overrides_requires_auth():
+    """POST endpoint covered separately because it's on the list
+    but needs a non-empty body to reach the actual handler logic.
+    Middleware 401 fires before body validation."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/rankings/overrides", json={})
+    assert res.status_code == 401
+    assert res.json().get("error") == "auth_required"
+
+
+PUBLIC_API_PATHS = [
+    "/api/health",
+    "/api/leagues",
+    "/api/rankings/sources",
+    "/api/auth/status",
+]
+
+
+@pytest.mark.parametrize("path", PUBLIC_API_PATHS)
+def test_public_api_paths_pass_without_auth(path):
+    """The public allowlist must stay reachable for monitoring +
+    the login flow + the public-league pipeline."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get(path)
+    assert res.status_code != 401, (
+        f"{path} requires auth unexpectedly: {res.status_code} {res.text[:200]}"
+    )
+
+
+def test_public_league_prefix_passes_without_auth():
+    """The /api/public/league/* prefix serves the isolated public
+    pipeline and must never 401."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/public/league/metrics")
+    # 200 or 503 are both fine — we just don't want the gate's 401.
+    assert res.status_code != 401
+
+
+def test_signal_alerts_run_bypasses_middleware(monkeypatch):
+    """The cron endpoint handles its own auth via a bearer token.
+    Middleware must let it through so the endpoint's own check
+    runs.  Without a valid token the endpoint returns its own
+    401 with error ``admin_auth_required`` (distinct from the
+    middleware's ``auth_required``)."""
+    monkeypatch.setattr(server, "latest_contract_data", None)
+    monkeypatch.setattr(server, "SIGNAL_ALERT_CRON_TOKEN", "")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/signal-alerts/run")
+    assert res.status_code == 401
+    # Error code proves the ENDPOINT's check fired, not middleware.
+    assert res.json().get("error") == "admin_auth_required"
+
+
+# ── Sleeper-login allowlist ────────────────────────────────────────
+
+
+def _stub_urlopen_for_sleeper(monkeypatch, username: str, user_id: str):
+    """Patch urllib to return the stub Sleeper user for one handle.
+    Other handles → 404.  League-members lookups → empty list."""
+    real = urllib.request.urlopen
+
+    def fake_urlopen(req, timeout=5.0):
+        url = getattr(req, "full_url", "") or str(req)
+        if f"/v1/user/{username}" in url:
+            body = _json.dumps({
+                "user_id": user_id,
+                "username": username,
+                "display_name": username,
+            }).encode()
+            return io.BytesIO(body)
+        if "/v1/user/" in url:
+            raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+        if "/v1/league/" in url and "/users" in url:
+            return io.BytesIO(b"[]")
+        return real(req, timeout=timeout)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+
+def test_sleeper_login_rejects_non_allowlisted_user(monkeypatch):
+    """Non-allowlisted Sleeper handle → 403 even though the user
+    exists on Sleeper.  The core gate against rando sign-ups."""
+    monkeypatch.setattr(
+        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"jasonleetucker"}),
+    )
+    _stub_urlopen_for_sleeper(monkeypatch, "randomuser99", "99999999")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/auth/sleeper-login", json={"username": "randomuser99"})
+    assert res.status_code == 403, res.text
+    body = res.json()
+    assert body.get("ok") is False
+    assert "private" in body.get("error", "").lower()
+
+
+def test_sleeper_login_accepts_allowlisted_user(monkeypatch):
+    """Allowlisted username → 200 + session cookie."""
+    monkeypatch.setattr(
+        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"allowed_user"}),
+    )
+    _stub_urlopen_for_sleeper(monkeypatch, "allowed_user", "12345678")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/auth/sleeper-login", json={"username": "allowed_user"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body.get("ok") is True
+    assert body.get("sleeperUserId") == "12345678"
+    # Cookie set.
+    set_cookies = res.headers.get_list("set-cookie")
+    assert any(server.JASON_AUTH_COOKIE_NAME in ck for ck in set_cookies)
+
+
+def test_allowlist_reads_env_var_lowercased():
+    """Module-level parse must lowercase + split comma-separated
+    entries in the env var."""
+    import os
+    expected = frozenset(
+        u.strip().lower()
+        for u in "JasonLeeTucker, AnotherUser".split(",")
+        if u.strip()
+    )
+    assert expected == {"jasonleetucker", "anotheruser"}

--- a/tests/news/test_api_news_route.py
+++ b/tests/news/test_api_news_route.py
@@ -20,9 +20,13 @@ from src.news.service import NewsService
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
     # Bypass lifespan — the startup hook spins up scrape threads
     # that are unrelated to /api/news and would slow the test down.
+    # Also bypass the ``_private_api_gate`` middleware since the
+    # news endpoint is private by default; the gate itself is
+    # tested separately in tests/api/test_private_auth.py.
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
     with TestClient(server.app, raise_server_exceptions=True) as c:
         yield c
     server._reset_news_service_for_tests(None)


### PR DESCRIPTION
## Summary

Two gates lock the private dashboard to a single user, and League B (\`dynasty_new\`) flips to active with its real Sleeper ID.

### Gate 1: Sleeper-login allowlist

\`PRIVATE_APP_ALLOWED_USERNAMES\` (default: \`jasonleetucker\`) — only allowlisted Sleeper handles can create a session. Anyone else → 403.

### Gate 2: \`/api/*\` middleware

Every \`/api/*\` path except an explicit public allowlist returns 401 without auth. Closes the \`curl /api/data\` leak.

**Public allowlist:** \`/api/health\`, \`/api/status\`, \`/api/uptime\`, \`/api/metrics\`, \`/api/leagues\`, \`/api/rankings/sources\`, \`/api/auth/*\`, \`/api/scaffold/status\`, \`/api/public/league/*\`

**Self-authed (handles its own auth):** \`/api/signal-alerts/run\` (bearer-token cron)

### League B activation

\`dynasty_new.active: true\` + real Sleeper ID (\`1320092771247222784\`). Shared scoring profile → rankings serve without a separate scrape. Team/trade/terminal surfaces show data-not-ready banner until the scraper is extended.

## Test plan

- [x] pytest: 1942 passed, 3 skipped (26 new auth tests)
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [x] Every private \`/api/*\` path verified to 401 without auth (parametrized test)
- [x] Every public \`/api/*\` path verified to stay reachable (parametrized test)
- [x] Sleeper login rejects non-allowlisted users (stubbed Sleeper API)
- [x] Sleeper login accepts allowlisted users + sets session cookie
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)