### PR TITLE
fix: switcher eyebrow shows wrong league + use real Sleeper names

### DIFF
--- a/config/leagues/registry.json
+++ b/config/leagues/registry.json
@@ -4,7 +4,7 @@
   "leagues": [
     {
       "key": "dynasty_main",
-      "displayName": "Dynasty Main (Superflex + TEP + IDP)",
+      "displayName": "Risk It To Get The Brisket",
       "sleeperLeagueId": "1312006700437352448",
       "scoringProfile": "superflex_tep15_ppr1",
       "idpEnabled": true,
@@ -39,14 +39,14 @@
     },
     {
       "key": "dynasty_new",
-      "displayName": "Dynasty New (Superflex + TEP, no IDP)",
+      "displayName": "Blood, Sweat, and Beers",
       "sleeperLeagueId": "1320092771247222784",
       "scoringProfile": "superflex_tep15_ppr1",
       "idpEnabled": false,
       "active": true,
-      "aliases": ["new", "non-idp"],
+      "aliases": ["new", "non-idp", "bsb", "beers"],
       "rosterSettings": {
-        "teamCount": 12,
+        "teamCount": 10,
         "rosterSize": 24,
         "taxiSize": 5,
         "starters": {

--- a/frontend/components/useLeague.js
+++ b/frontend/components/useLeague.js
@@ -150,14 +150,19 @@ export function useLeague() {
   const defaultLeagueKey = leaguesPayload?.defaultKey || "";
   const userDefaultKey = leaguesPayload?.userDefaultKey || "";
 
-  // Resolve the selected key using the order described in the
-  // docblock: user pref → user-default from registry → site default
-  // → first active → "".
+  // Resolve the selected key.  ``localKey`` is FIRST because it's
+  // the optimistic value written synchronously on every setLeague()
+  // call — it's the "user just clicked the switcher" signal.  If
+  // we deferred to ``userState.activeLeagueKey``, the switcher
+  // would appear to do nothing until the 30s useUserState cache
+  // TTL expires + a refetch brings back the server's copy.  Since
+  // setLeague also PUTs to /api/user/state, the two sources
+  // converge on the next refetch regardless.
   const selectedLeagueKey = useMemo(() => {
     const keysActive = new Set(leagues.map((l) => l.key));
     const prefs = [
+      localKey,
       userState?.activeLeagueKey || "",
-      serverBacked ? "" : localKey, // only trust localStorage for anon users
       userDefaultKey,
       defaultLeagueKey,
       leagues[0]?.key || "",
@@ -168,7 +173,6 @@ export function useLeague() {
     return "";
   }, [
     userState?.activeLeagueKey,
-    serverBacked,
     localKey,
     userDefaultKey,
     defaultLeagueKey,

--- a/server.py
+++ b/server.py
@@ -2134,6 +2134,46 @@ async def post_rankings_overrides(request: Request):
     return JSONResponse(content=contract_payload, headers=headers)
 
 
+# Cache of Sleeper league ``name`` fields.  Refreshed every
+# ``_SLEEPER_NAME_TTL_SEC`` so a rename in Sleeper propagates to the
+# UI without a deploy, but we don't hammer Sleeper on every
+# /api/leagues request.
+_SLEEPER_NAME_CACHE: dict[str, dict] = {}
+_SLEEPER_NAME_TTL_SEC = 300
+
+
+def _fetch_sleeper_league_name(sleeper_league_id: str) -> str | None:
+    """Return the live ``name`` from ``/v1/league/<id>`` or None on
+    any failure.  Cached per-league for 5 minutes.  Used by
+    ``/api/leagues`` to label each league with its actual Sleeper
+    name (e.g. "Risk It To Get The Brisket") instead of whatever
+    operator-edited string lives in the registry's ``displayName``.
+    """
+    import time as _time
+
+    sleeper_league_id = str(sleeper_league_id or "").strip()
+    if not sleeper_league_id:
+        return None
+    now = _time.time()
+    cached = _SLEEPER_NAME_CACHE.get(sleeper_league_id)
+    if cached and (now - float(cached.get("fetched_at") or 0)) < _SLEEPER_NAME_TTL_SEC:
+        return cached.get("name")
+
+    try:
+        url = f"https://api.sleeper.app/v1/league/{sleeper_league_id}"
+        req = urllib.request.Request(url, headers={"User-Agent": "brisket-league-name/1.0"})
+        with urllib.request.urlopen(req, timeout=5.0) as resp:
+            body = resp.read()
+        parsed = json.loads(body)
+    except Exception:  # noqa: BLE001 — transient failures cache None so we don't refetch every call
+        _SLEEPER_NAME_CACHE[sleeper_league_id] = {"name": None, "fetched_at": now}
+        return None
+
+    name = str((parsed or {}).get("name") or "").strip() or None
+    _SLEEPER_NAME_CACHE[sleeper_league_id] = {"name": name, "fetched_at": now}
+    return name
+
+
 @app.get("/api/leagues")
 async def get_leagues(request: Request):
     """List every configured league.
@@ -2142,6 +2182,12 @@ async def get_leagues(request: Request):
     league IDs, no auth tokens).  The ``key`` is the stable identifier
     callers thread through the rest of the API when we eventually
     add ``?leagueId=`` parameters to league-scoped endpoints.
+
+    ``displayName`` is pulled LIVE from Sleeper (``/v1/league/<id>``
+    ``.name``) and cached for 5 minutes.  This way a league rename
+    in Sleeper propagates to the switcher without a registry edit
+    or redeploy.  Falls back to the registry's configured
+    ``displayName`` when Sleeper is unreachable.
 
     Views:
       * Anonymous:     active leagues only.
@@ -2156,6 +2202,17 @@ async def get_leagues(request: Request):
     session = _get_auth_session(request)
     active_cfgs = _league_registry.active_leagues()
     leagues = [cfg.public_dict() for cfg in active_cfgs]
+
+    # Overlay the live Sleeper name for each league.  Run the
+    # fetches in a threadpool so we don't block the event loop on
+    # the Sleeper round-trip.  Cached 5 min so steady-state traffic
+    # doesn't hammer Sleeper.
+    def _fetch_names(cfgs):
+        return [_fetch_sleeper_league_name(c.sleeper_league_id) for c in cfgs]
+    sleeper_names = await run_in_threadpool(_fetch_names, active_cfgs)
+    for i, live_name in enumerate(sleeper_names):
+        if live_name:
+            leagues[i]["displayName"] = live_name
 
     if session:
         username = (session.get("username") or "").strip().lower()


### PR DESCRIPTION
Two bugs reported from a live screenshot:

1. **Terminal eyebrow stale after league switch.** User picked "Dynasty New" in the switcher but the terminal eyebrow still read "DYNASTY MAIN (SUPERFLEX + TEP + IDP)". Root cause in `useLeague.js`: the resolution order prioritised `userState.activeLeagueKey` over the optimistic `localKey` — so until the 30s useUserState cache TTL expired, the switcher appeared to do nothing. Swapped priorities; `localKey` wins first.

2. **Hardcoded display names replaced with live Sleeper names.** Added `_fetch_sleeper_league_name` with 5-min cache and wired it into `/api/leagues`. The switcher + terminal eyebrow now show the actual Sleeper league names ("Risk It To Get The Brisket", "Blood, Sweat, and Beers"). A rename in Sleeper propagates within 5 minutes — no redeploy needed. Falls back to registry `displayName` when Sleeper is unreachable.

**Registry fixes:**
- dynasty_new.teamCount: 12 → 10 (was wrong)
- Both leagues' `displayName` updated to match Sleeper
- dynasty_new aliases += ["bsb", "beers"]

## Test plan
- [x] pytest: 1942 passed, 3 skipped
- [x] vitest: 690 passed
- [x] Next.js build: clean
- [ ] Reload page: eyebrow reflects current switcher selection
- [ ] Reload page: switcher shows "Risk It To Get The Brisket" + "Blood, Sweat, and Beers"
- [ ] CI green