### PR TITLE
feat: per-league Sleeper overlay (teams + trades)

### DIFF
--- a/server.py
+++ b/server.py
@@ -71,6 +71,7 @@ from src.api import terminal as _terminal
 from src.api import trade_simulator as _trade_simulator
 from src.api import user_kv as _user_kv
 from src.api import league_registry as _league_registry
+from src.api import sleeper_overlay as _sleeper_overlay
 from src.news import NewsService, build_default_service
 
 # ── CONFIG ──────────────────────────────────────────────────────────────
@@ -1871,20 +1872,69 @@ async def get_data(request: Request):
         }
 
         # Cross-league request for a same-scoring-profile league —
-        # serve the shared rankings but null the sleeper block so the
-        # UI doesn't render the loaded league's teams under the
-        # requested league's name.  Bypass the pre-serialized fast-
-        # path here; we need to hand-edit the payload.
+        # serve the shared rankings, then try to splice in a live
+        # Sleeper overlay for the requested league.  The overlay
+        # fetches rosters + trades + metadata from Sleeper on
+        # demand (cached 15 min) so the terminal, /trades page,
+        # team pickers, etc. work without running the full
+        # scraper per league.
         if not sleeper_matches:
             scrubbed = dict(payload_obj) if isinstance(payload_obj, dict) else {}
-            scrubbed["sleeper"] = None
+            # Re-use the NFL-wide Sleeper-ID → display-name map from
+            # the currently-loaded contract (League A's scrape) so
+            # we don't have to refetch /v1/players/nfl (~5MB) for
+            # every overlay.  The map is NFL-wide, not league-scoped,
+            # so it's safe across leagues.
+            loaded_sleeper = (
+                (latest_contract_data or {}).get("sleeper") or {}
+                if isinstance(latest_contract_data, dict) else {}
+            )
+            id_to_player = loaded_sleeper.get("idToPlayer") or {}
+            try:
+                overlay = await run_in_threadpool(
+                    _sleeper_overlay.fetch_sleeper_overlay,
+                    sleeper_league_id=league_cfg.sleeper_league_id,
+                    id_to_player=id_to_player if isinstance(id_to_player, dict) else {},
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "sleeper_overlay fetch failed for %s: %s",
+                    league_cfg.key, exc,
+                )
+                overlay = None
+
             meta = dict(scrubbed.get("meta") or {})
             meta["leagueKey"] = league_cfg.key
             meta["scoringProfile"] = league_cfg.scoring_profile
-            meta["sleeperDataReady"] = False
             meta["sleeperLoadedLeagueKey"] = loaded_league or None
+
+            if overlay and overlay.get("teams"):
+                # Carry forward the NFL-wide maps from the loaded
+                # contract — the overlay is lean + doesn't refetch
+                # them.  These keys power frontend lookups that
+                # aren't league-scoped (positions, IDs, etc).
+                overlay_full = {
+                    **{
+                        k: loaded_sleeper.get(k)
+                        for k in ("positions", "playerIds", "idToPlayer",
+                                  "scoringSettings", "rosterPositions",
+                                  "leagueSettings")
+                        if k in loaded_sleeper
+                    },
+                    **overlay,
+                }
+                scrubbed["sleeper"] = overlay_full
+                meta["sleeperDataReady"] = True
+                meta["sleeperSource"] = "overlay"
+                headers["X-Payload-View"] = f"{payload_view_name}-cross-league-overlay"
+            else:
+                # Overlay unavailable (Sleeper down, empty league,
+                # etc.) — null the sleeper block so the UI falls
+                # back to the data-not-ready state.
+                scrubbed["sleeper"] = None
+                meta["sleeperDataReady"] = False
+                headers["X-Payload-View"] = f"{payload_view_name}-cross-league"
             scrubbed["meta"] = meta
-            headers["X-Payload-View"] = f"{payload_view_name}-cross-league"
             return JSONResponse(content=scrubbed, headers=headers)
 
         if payload_etag:
@@ -5161,19 +5211,73 @@ async def get_terminal(request: Request):
                 },
             )
 
-    # Guard: the loaded contract was built for a different league
-    # than the one requested.  Today this only trips for non-default
-    # leagues because the scraper only runs the default league.
-    loaded_league = (contract.get("meta") or {}).get("leagueKey") if isinstance(contract, dict) else None
+    # Cross-league request: the loaded contract is for a different
+    # league than the one requested.  If the scoring profiles match,
+    # splice in a live Sleeper overlay (rosters + trades) so the
+    # terminal + team widgets actually have data to render.  Only
+    # 503 when the overlay fetch fails completely — Sleeper
+    # unreachable, invalid league ID, etc.
+    loaded_meta = (contract.get("meta") or {}) if isinstance(contract, dict) else {}
+    loaded_league = loaded_meta.get("leagueKey")
+    loaded_profile = loaded_meta.get("scoringProfile")
     if loaded_league and loaded_league != league_cfg.key:
-        return JSONResponse(
-            status_code=503,
-            content={
-                "error": "data_not_ready",
-                "message": f"No data loaded for league {league_cfg.key!r} yet",
-                "leagueKey": league_cfg.key,
+        if loaded_profile and loaded_profile != league_cfg.scoring_profile:
+            # Rankings incompatible; the /api/data 503 path already
+            # explains this shape.  Terminal can't do anything.
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "data_not_ready",
+                    "message": (
+                        f"League {league_cfg.key!r} uses scoring profile "
+                        f"{league_cfg.scoring_profile!r}, not {loaded_profile!r}."
+                    ),
+                    "leagueKey": league_cfg.key,
+                },
+            )
+        loaded_sleeper = contract.get("sleeper") or {}
+        id_map = loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else None
+        try:
+            overlay = await run_in_threadpool(
+                _sleeper_overlay.fetch_sleeper_overlay,
+                sleeper_league_id=league_cfg.sleeper_league_id,
+                id_to_player=id_map if isinstance(id_map, dict) else {},
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "terminal overlay fetch failed for %s: %s", league_cfg.key, exc,
+            )
+            overlay = None
+        if not overlay or not overlay.get("teams"):
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "data_not_ready",
+                    "message": f"Sleeper overlay for league {league_cfg.key!r} unavailable.",
+                    "leagueKey": league_cfg.key,
+                },
+            )
+        # Build a hybrid contract: global rankings + per-league
+        # sleeper.  Carry forward the NFL-wide maps so the terminal
+        # builder can resolve positions/IDs the same as for the
+        # primary league.
+        hybrid_sleeper = {
+            **{
+                k: loaded_sleeper.get(k)
+                for k in ("positions", "playerIds", "idToPlayer",
+                          "scoringSettings", "rosterPositions",
+                          "leagueSettings")
+                if isinstance(loaded_sleeper, dict) and k in loaded_sleeper
             },
-        )
+            **overlay,
+        }
+        contract = {**contract, "sleeper": hybrid_sleeper, "meta": {
+            **loaded_meta,
+            "leagueKey": league_cfg.key,
+            "sleeperDataReady": True,
+            "sleeperSource": "overlay",
+            "sleeperLoadedLeagueKey": loaded_league,
+        }}
 
     params = request.query_params
     team_owner_id = (params.get("team") or params.get("ownerId") or "").strip()

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -1,0 +1,346 @@
+"""On-demand per-league Sleeper overlay.
+
+Problem this solves
+───────────────────
+The dynasty scraper only runs once per cycle against the
+registry's *default* league (see ``Dynasty Scraper.py`` →
+``fetch_sleeper_rosters``).  The resulting contract's ``sleeper``
+block — ``teams``, ``trades``, roster_positions, league settings
+— is therefore for one league only.
+
+When the user switches to a non-default league via the UI, the
+``/api/data`` endpoint correctly refuses to render League A's
+teams under League B's name.  But the rankings + values are
+*scoring-profile-bound* (global), so the UI is left showing
+"data not ready" for every team-dependent widget — team command
+header, portfolio, trade history, team-scoped signals, etc.
+
+This module closes the gap without running the full scraper per
+league.  It fetches only the league-specific Sleeper data
+(rosters, users, league metadata, trades) — no ranking pipeline,
+no 5MB /v1/players/nfl download (we reuse the player-ID → name
+map from the already-loaded contract, since that map is NFL-wide
+and not league-specific).
+
+Out of scope
+────────────
+* Draft-capital / pick-ownership blocks (``team.pickDetails``,
+  ``tradeWindow*``).  The ``/api/draft-capital`` endpoint still
+  503s for non-loaded leagues — a separate fix.
+* Per-league scoring settings + roster positions.  Not needed by
+  the terminal or trades page; can be layered in later.
+
+Caching
+───────
+One Sleeper call = one HTTP round-trip.  Cache each league's
+overlay for 15 minutes so steady-state traffic doesn't hammer
+Sleeper.  ``invalidate_overlay_cache()`` is exposed for tests +
+a potential future admin "refresh" endpoint.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_CACHE: dict[str, dict[str, Any]] = {}
+_CACHE_LOCK = threading.Lock()
+_CACHE_TTL_SEC = 15 * 60
+_HTTP_TIMEOUT_SEC = 8.0
+_USER_AGENT = "brisket-sleeper-overlay/1.0"
+
+
+def _utc_now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _http_get_json(url: str) -> Any:
+    """Fetch a Sleeper endpoint and parse JSON.  Returns ``None`` on
+    any failure — callers treat missing data as "no overlay available"
+    and serve the data-not-ready state.
+    """
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SEC) as resp:
+            body = resp.read()
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        log.warning("sleeper_overlay: fetch %s failed: %s", url, exc)
+        return None
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        log.warning("sleeper_overlay: non-JSON response from %s", url)
+        return None
+
+
+def _walk_league_chain(root_league_id: str, max_depth: int = 2) -> list[str]:
+    """Walk backwards through previous_league_id so trade history
+    covers multiple seasons when the ``/transactions`` endpoint
+    only returns current-season trades.  Mirrors the scraper's
+    ``_league_chain_ids`` helper (Dynasty Scraper.py ~line 1109)
+    but capped at 2 levels to keep the overlay fetch fast.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    cur = str(root_league_id or "").strip()
+    while cur and cur not in seen and len(out) < max_depth:
+        seen.add(cur)
+        out.append(cur)
+        info = _http_get_json(f"https://api.sleeper.app/v1/league/{cur}")
+        if not isinstance(info, dict):
+            break
+        prev = info.get("previous_league_id") or info.get("previous_league")
+        if not prev:
+            break
+        cur = str(prev).strip()
+    return out
+
+
+def _build_teams_block(
+    sleeper_league_id: str,
+    id_to_player: dict[str, str] | None,
+) -> list[dict[str, Any]] | None:
+    """Assemble the ``sleeper.teams`` array for one league.
+
+    Returns None on any fetch failure.  The ``id_to_player`` map is
+    the NFL-wide Sleeper-ID → display-name lookup (globally unique,
+    safe to reuse from the primary league's contract).  When a
+    roster references an ID not in the map, we fall back to the
+    raw ID so the UI at least renders a row.
+    """
+    rosters = _http_get_json(
+        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters"
+    )
+    users = _http_get_json(
+        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users"
+    )
+    if not isinstance(rosters, list) or not isinstance(users, list):
+        return None
+
+    # owner_id → team-display-name.
+    user_map: dict[str, str] = {}
+    for u in users:
+        if not isinstance(u, dict):
+            continue
+        uid = str(u.get("user_id") or "")
+        if not uid:
+            continue
+        name = (
+            (u.get("metadata") or {}).get("team_name")
+            or u.get("display_name")
+            or f"Team {uid}"
+        )
+        user_map[uid] = str(name)
+
+    id_map = id_to_player or {}
+
+    teams: list[dict[str, Any]] = []
+    for r in rosters:
+        if not isinstance(r, dict):
+            continue
+        owner_id = str(r.get("owner_id") or "")
+        roster_id = r.get("roster_id")
+        player_ids = r.get("players") or []
+        if not isinstance(player_ids, list):
+            player_ids = []
+        # Convert IDs → display names via the shared NFL map.  Keep
+        # raw IDs for callers that need them (consistent with the
+        # scraper's ``playerIds`` field).
+        names: list[str] = []
+        for pid in player_ids:
+            pid_str = str(pid or "")
+            if not pid_str:
+                continue
+            mapped = id_map.get(pid_str)
+            names.append(mapped if mapped else pid_str)
+        teams.append({
+            "name": user_map.get(owner_id, f"Team {roster_id}"),
+            "ownerId": owner_id,
+            "roster_id": roster_id,
+            "players": names,
+            "playerIds": [str(pid) for pid in player_ids if pid],
+            # ``picks`` + ``pickDetails`` require /traded_picks + a
+            # pick-owner resolver — out of scope for the minimal
+            # overlay.  Empty list is safe: draft-capital panels
+            # gracefully render blank, /api/draft-capital still
+            # 503s for non-loaded leagues.
+            "picks": [],
+            "pickDetails": [],
+        })
+    return teams
+
+
+def _build_trades_block(
+    sleeper_league_id: str,
+    window_days: int = 365,
+) -> list[dict[str, Any]]:
+    """Fetch the rolling trade history for the league chain.
+
+    Sleeper's ``/v1/league/<id>/transactions/<week>`` only exposes
+    the current season.  We walk the ``previous_league_id`` chain
+    back one level so the rolling window captures inter-season
+    trades too.  Trades outside the ``window_days`` cutoff are
+    dropped so ``/trades`` doesn't show stale moves.
+    """
+    cutoff_ms = _utc_now_ms() - int(window_days) * 24 * 3600 * 1000
+    chain = _walk_league_chain(sleeper_league_id, max_depth=2)
+    if not chain:
+        return []
+
+    trades: list[dict[str, Any]] = []
+    for lid in chain:
+        # Weeks 1..18 cover the regular + postseason transaction
+        # calendar; preseason/offseason Sleeper uses weeks 0 (and
+        # sometimes -1) — 0 is cheap to include.
+        for week in range(0, 19):
+            url = (
+                f"https://api.sleeper.app/v1/league/{lid}"
+                f"/transactions/{week}"
+            )
+            txs = _http_get_json(url)
+            if not isinstance(txs, list):
+                continue
+            for tx in txs:
+                if not isinstance(tx, dict):
+                    continue
+                if tx.get("type") != "trade":
+                    continue
+                status_ts = tx.get("status_updated") or tx.get("created")
+                ts_ms = _normalize_ts_ms(status_ts)
+                if ts_ms and ts_ms < cutoff_ms:
+                    continue
+                # Pass the raw Sleeper trade shape through — the
+                # frontend's ``analyzeSleeperTradeHistory`` already
+                # handles the Sleeper schema; the scraper just
+                # de-duplicates + tags with an in-window flag.
+                trades.append({
+                    **tx,
+                    "_leagueId": lid,
+                    "_statusUpdatedMs": ts_ms or 0,
+                })
+
+    # De-dup by transaction_id across the league chain (a trade
+    # that bridged seasons can appear twice).
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for t in trades:
+        tid = str(t.get("transaction_id") or "")
+        if tid and tid in seen:
+            continue
+        if tid:
+            seen.add(tid)
+        deduped.append(t)
+    # Newest first — the /trades UI sorts by recency.
+    deduped.sort(key=lambda t: t.get("_statusUpdatedMs", 0), reverse=True)
+    return deduped
+
+
+def _normalize_ts_ms(v: Any) -> int:
+    """Coerce a Sleeper timestamp to milliseconds.  Some endpoints
+    return seconds, others milliseconds; defensively normalize."""
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return 0
+    if n <= 0:
+        return 0
+    # Values < 1e12 are seconds (≤ 2001 in ms); scale up.
+    if n < 1_000_000_000_000:
+        n *= 1000
+    return n
+
+
+def _fetch_league_name(sleeper_league_id: str) -> str | None:
+    info = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}")
+    if not isinstance(info, dict):
+        return None
+    name = info.get("name")
+    return str(name) if name else None
+
+
+def fetch_sleeper_overlay(
+    *,
+    sleeper_league_id: str,
+    id_to_player: dict[str, str] | None = None,
+    trade_window_days: int = 365,
+    force_refresh: bool = False,
+) -> dict[str, Any] | None:
+    """Return a ``sleeper`` overlay block for a non-loaded league.
+
+    Shape matches the subset of the scraper's ``sleeper`` that the
+    terminal + /trades page read:
+
+    .. code-block:: python
+
+        {
+            "leagueId":    str,
+            "leagueName":  str,
+            "teams":       [{name, ownerId, roster_id, players, playerIds, picks=[], pickDetails=[]}],
+            "trades":      [<raw sleeper trade dicts>],
+            "tradeWindowDays":  int,
+            "tradeWindowStart": iso-str,
+            "tradeWindowCutoffMs": int,
+            "overlaySource": "live",
+            "overlayFetchedAt": iso-str,
+        }
+
+    Returns None if the fetch failed end-to-end (no teams could
+    be loaded).  Partial fetches are acceptable — e.g. trades
+    empty but teams populated.
+
+    Caches per ``sleeper_league_id`` for 15 minutes.  Pass
+    ``force_refresh=True`` to bust the cache (used by tests).
+    """
+    sleeper_league_id = str(sleeper_league_id or "").strip()
+    if not sleeper_league_id:
+        return None
+
+    now = time.time()
+    if not force_refresh:
+        with _CACHE_LOCK:
+            cached = _CACHE.get(sleeper_league_id)
+            if cached and (now - float(cached.get("_cached_at") or 0)) < _CACHE_TTL_SEC:
+                return dict(cached["payload"])
+
+    teams = _build_teams_block(sleeper_league_id, id_to_player)
+    if teams is None:
+        # Hard fetch failure — nothing useful to return.
+        return None
+
+    league_name = _fetch_league_name(sleeper_league_id) or ""
+    trades = _build_trades_block(sleeper_league_id, window_days=trade_window_days)
+
+    cutoff_dt = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(
+        days=int(trade_window_days)
+    )
+    payload: dict[str, Any] = {
+        "leagueId": sleeper_league_id,
+        "leagueName": league_name,
+        "teams": teams,
+        "trades": trades,
+        "tradeWindowDays": int(trade_window_days),
+        "tradeWindowStart": cutoff_dt.isoformat(),
+        "tradeWindowCutoffMs": int(cutoff_dt.timestamp() * 1000),
+        "overlaySource": "live",
+        "overlayFetchedAt": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+
+    with _CACHE_LOCK:
+        _CACHE[sleeper_league_id] = {"payload": dict(payload), "_cached_at": now}
+    return payload
+
+
+def invalidate_overlay_cache(sleeper_league_id: str | None = None) -> None:
+    """Drop cached overlay(s).  ``None`` clears everything."""
+    with _CACHE_LOCK:
+        if sleeper_league_id is None:
+            _CACHE.clear()
+            return
+        _CACHE.pop(str(sleeper_league_id), None)


### PR DESCRIPTION
## Summary

Closes the \"Roster data not ready\" / \"No trades found\" gap for non-scraped leagues. When you switch to Blood, Sweat, and Beers, the terminal + /trades page now have real data to render — not a waiting-state banner.

### Problem

The scraper only runs for \`dynasty_main\`. Switching to \`dynasty_new\` returned 200 with \`sleeper: null\` — rankings were fine but every team-dependent widget showed empty.

### Fix

New \`src/api/sleeper_overlay.py\`:
- Fetches rosters + users + league + trades from Sleeper on demand
- Reuses the NFL-wide \`idToPlayer\` map from the loaded contract (no 5MB refetch)
- 15-min per-league cache
- Graceful degrade to data-not-ready on fetch failure

Splices into \`/api/data\` and \`/api/terminal\` responses when league doesn't match loaded contract but scoring profile does.

### Live verification

Fetched Blood, Sweat, and Beers against the real Sleeper ID:
- 10 teams resolved
- 59 trades in the last 365 days

### Still out of scope

\`/api/draft-capital\` + \`/api/angle/*\` — they need \`traded_picks\` resolution which the overlay doesn't build. Still 503 for non-loaded leagues; a follow-up when needed.

## Test plan

- [x] pytest: 1942 passed
- [x] Next.js build: clean
- [x] Live overlay fetch returns 10 teams + 59 trades for the real League B
- [ ] Terminal shows team picker + data after switching to League B
- [ ] /trades shows the 59 trades

🤖 Generated with [Claude Code](https://claude.com/claude-code)