### PR TITLE
feat: per-league signal-alert cooldowns + dismissals

### DIFF
--- a/frontend/components/terminal/BuySellHold.jsx
+++ b/frontend/components/terminal/BuySellHold.jsx
@@ -39,7 +39,7 @@ const DEFAULT_FILTERS = new Set([SIGNALS.RISK, SIGNALS.SELL, SIGNALS.MONITOR, SI
 
 export default function BuySellHold() {
   const { rows, rawData, openPlayerPopup } = useApp();
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, selectedLeagueKey } = useTeam();
   const { history, loading: historyLoading } = useRankHistory({ days: 30 });
   const {
     state: userState,
@@ -98,7 +98,22 @@ export default function BuySellHold() {
     return m;
   }, [rawData]);
 
-  const dismissedMap = userState?.dismissedSignals || {};
+  // Per-league dismissals take precedence over the legacy flat map.
+  // ``useTeam().selectedLeagueKey`` tells us which league's bucket
+  // to read; for pre-migration users on the default league the flat
+  // map is used as a fallback so their existing dismissals carry
+  // over.  ``useLeague`` can't be imported here without pulling a
+  // larger context cycle — we read the active league key off the
+  // team hook which already resolves it.
+  const dismissedMap = useMemo(() => {
+    const leagueKey = selectedTeam ? selectedLeagueKey : "";
+    const byLeague = userState?.dismissedSignalsByLeague;
+    if (leagueKey && byLeague && typeof byLeague === "object") {
+      const bucket = byLeague[leagueKey];
+      if (bucket && typeof bucket === "object") return bucket;
+    }
+    return userState?.dismissedSignals || {};
+  }, [userState?.dismissedSignalsByLeague, userState?.dismissedSignals, selectedLeagueKey, selectedTeam]);
 
   const rosterNames = selectedTeam?.players || [];
   const news = useNews({ rosterNames, leagueNames });

--- a/frontend/components/useUserState.js
+++ b/frontend/components/useUserState.js
@@ -143,11 +143,31 @@ async function writeServerState(patch) {
   }
 }
 
+// Read the active league key from localStorage — same key
+// ``useLeague`` writes on every switcher change.  Can't import
+// ``useLeague`` here because this module is imported BY
+// ``useLeague`` (cycle).  localStorage is the cycle-safe bridge.
+const LEAGUE_LOCAL_KEY = "next_active_league_v1";
+function _readActiveLeagueKey() {
+  if (typeof window === "undefined") return "";
+  try {
+    return localStorage.getItem(LEAGUE_LOCAL_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
 async function dismissSignalOnServer(signalKey, ttlMs, opts) {
   try {
     const payload = { signalKey, ttlMs };
     if (opts?.aliasSleeperId) payload.aliasSleeperId = opts.aliasSleeperId;
     if (opts?.aliasDisplayName) payload.aliasDisplayName = opts.aliasDisplayName;
+    // Scope the dismissal to the active league so flipping a SELL
+    // off on league A doesn't silence the same player's alert on
+    // league B.  Backend falls through to legacy flat storage when
+    // leagueKey is absent or invalid.
+    const leagueKey = _readActiveLeagueKey();
+    if (leagueKey) payload.leagueKey = leagueKey;
     const res = await fetch("/api/user/signals/dismiss", {
       method: "POST",
       credentials: "same-origin",
@@ -167,11 +187,14 @@ async function dismissSignalOnServer(signalKey, ttlMs, opts) {
 
 async function restoreSignalOnServer(signalKey) {
   try {
+    const payload = { signalKey };
+    const leagueKey = _readActiveLeagueKey();
+    if (leagueKey) payload.leagueKey = leagueKey;
     const res = await fetch("/api/user/signals/restore", {
       method: "POST",
       credentials: "same-origin",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ signalKey }),
+      body: JSON.stringify(payload),
     });
     if (!res.ok) return null;
     const body = await res.json();

--- a/server.py
+++ b/server.py
@@ -5078,6 +5078,15 @@ async def dismiss_signal_api(request: Request):
         ttl_ms = 7 * 24 * 3600 * 1000
     alias_sid = str(body.get("aliasSleeperId") or "").strip() or None
     alias_name = str(body.get("aliasDisplayName") or "").strip() or None
+    # Scope the dismissal to the active league.  Validated against
+    # the registry; unknown/inactive keys fall through to legacy flat
+    # dismissal.  See user_kv.dismiss_signal docstring.
+    raw_league = str(body.get("leagueKey") or "").strip()
+    scoped_key: str | None = None
+    if raw_league:
+        cfg = _league_registry.get_league_by_key(raw_league)
+        if cfg is not None and cfg.active:
+            scoped_key = cfg.key
     state = await run_in_threadpool(
         _user_kv.dismiss_signal,
         username,
@@ -5085,6 +5094,7 @@ async def dismiss_signal_api(request: Request):
         ttl_ms=ttl_ms,
         alias_sleeper_id=alias_sid,
         alias_display_name=alias_name,
+        league_key=scoped_key,
     )
     return JSONResponse(
         content={"username": username, "state": state},
@@ -5110,7 +5120,15 @@ async def restore_signal_api(request: Request):
             status_code=400,
             content={"error": "signalKey_required"},
         )
-    state = await run_in_threadpool(_user_kv.undismiss_signal, username, signal_key)
+    raw_league = str(body.get("leagueKey") or "").strip()
+    scoped_key: str | None = None
+    if raw_league:
+        cfg = _league_registry.get_league_by_key(raw_league)
+        if cfg is not None and cfg.active:
+            scoped_key = cfg.key
+    state = await run_in_threadpool(
+        _user_kv.undismiss_signal, username, signal_key, league_key=scoped_key,
+    )
     return JSONResponse(
         content={"username": username, "state": state},
         headers={"Cache-Control": "no-store"},
@@ -5328,6 +5346,11 @@ async def get_terminal(request: Request):
             ),
             user_state=user_state,
             public_mode=not authed,
+            # Scope dismissals to the active league so a dismissal
+            # on league A doesn't silence the same player's signal
+            # on league B.  See terminal.build_terminal_payload +
+            # user_kv.active_dismissals docstrings.
+            league_key=league_cfg.key if league_cfg else None,
         )
     except Exception as exc:
         log.exception("/api/terminal build failed: %s", exc)
@@ -5506,10 +5529,28 @@ async def run_signal_alerts(request: Request):
             content={"error": "no_live_contract"},
         )
     # Walk every user_kv row.  No pagination — at current scale
-    # (dozens of users tops) this is fine.
+    # (dozens of users tops) this is fine.  For each user, loop
+    # over every active league: build a league-specific terminal
+    # payload (via Sleeper overlay for non-default leagues) and
+    # run the alert detector with the league_key scoped.  Cooldowns
+    # are now nested per league so a SELL in league A doesn't
+    # silently eat a SELL in league B for the same player.
     def _run_sweep() -> dict[str, object]:
         db = _user_kv.all_user_states()
         summary: list[dict] = []
+        loaded_league = (
+            (latest_contract_data or {}).get("meta", {}).get("leagueKey")
+            if isinstance(latest_contract_data, dict) else None
+        )
+        loaded_profile = (
+            (latest_contract_data or {}).get("meta", {}).get("scoringProfile")
+            if isinstance(latest_contract_data, dict) else None
+        )
+        loaded_sleeper = (
+            latest_contract_data.get("sleeper") or {}
+            if isinstance(latest_contract_data, dict) else {}
+        )
+        active_leagues = _league_registry.active_leagues()
         for username, state in db.items():
             if not isinstance(state, dict):
                 continue
@@ -5518,38 +5559,89 @@ async def run_signal_alerts(request: Request):
             email = str(state.get("notificationsEmail") or "").strip()
             if not email:
                 continue
-            # Resolve the user's team via their stored ownerId OR
-            # their session sleeper_user_id — neither may be
-            # available here, so try both.
             owner_id = str((state.get("selectedTeam") or {}).get("ownerId") or "")
-            # Try finding the user's team by matching username to
-            # sleeper_user_id of any team (user_kv key = Sleeper
-            # username for sleeper-auth users).
-            team = _terminal.resolve_team(
-                latest_contract_data,
-                owner_id=owner_id,
-                name=None,
-            )
-            try:
-                payload = _terminal.build_terminal_payload(
-                    latest_contract_data,
-                    resolved_team=team,
-                    window_days=30,
-                    user_state=state,
+            selected_teams = state.get("selectedTeamsByLeague") or {}
+            if not isinstance(selected_teams, dict):
+                selected_teams = {}
+            user_summary: list[dict] = []
+            for cfg in active_leagues:
+                # Skip leagues the user isn't in — if there's no
+                # team-map entry and the contract doesn't resolve a
+                # team, they have nothing to alert on here.
+                league_entry = selected_teams.get(cfg.key) or {}
+                league_owner_id = (
+                    str(league_entry.get("ownerId") or "").strip()
+                    or owner_id
                 )
-            except Exception as exc:  # noqa: BLE001
-                summary.append({"username": username, "ok": False,
-                                "reason": f"build_error:{type(exc).__name__}"})
-                continue
-            display_name = username
-            result = _signal_alerts.process_user_alerts(
-                username,
-                signals=payload.get("signals") or [],
-                display_name=display_name,
-                email=email,
-                delivery=_deliver_email_smtp,
-            )
-            summary.append({"username": username, **result})
+                # Build the league-specific contract.  For the
+                # loaded league this is just latest_contract_data;
+                # for other active leagues we splice in the overlay.
+                if cfg.key == loaded_league:
+                    contract = latest_contract_data
+                elif loaded_profile and loaded_profile == cfg.scoring_profile:
+                    id_map = loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else {}
+                    try:
+                        overlay = _sleeper_overlay.fetch_sleeper_overlay(
+                            sleeper_league_id=cfg.sleeper_league_id,
+                            id_to_player=id_map if isinstance(id_map, dict) else {},
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        log.warning(
+                            "signal-alerts overlay failed for %s / %s: %s",
+                            username, cfg.key, exc,
+                        )
+                        overlay = None
+                    if not overlay or not overlay.get("teams"):
+                        # No data for this league — skip, not a
+                        # failure (e.g. Sleeper transient error).
+                        continue
+                    hybrid_sleeper = {
+                        **{
+                            k: loaded_sleeper.get(k)
+                            for k in ("positions", "playerIds", "idToPlayer",
+                                      "scoringSettings", "rosterPositions",
+                                      "leagueSettings")
+                            if isinstance(loaded_sleeper, dict) and k in loaded_sleeper
+                        },
+                        **overlay,
+                    }
+                    contract = {**latest_contract_data, "sleeper": hybrid_sleeper}
+                else:
+                    # Different scoring profile — rankings aren't
+                    # comparable, skip this league for this run.
+                    continue
+
+                team = _terminal.resolve_team(
+                    contract, owner_id=league_owner_id, name=None,
+                )
+                if team is None:
+                    # User isn't in this league — nothing to alert on.
+                    continue
+                try:
+                    payload = _terminal.build_terminal_payload(
+                        contract,
+                        resolved_team=team,
+                        window_days=30,
+                        user_state=state,
+                        league_key=cfg.key,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    user_summary.append({
+                        "leagueKey": cfg.key, "ok": False,
+                        "reason": f"build_error:{type(exc).__name__}",
+                    })
+                    continue
+                result = _signal_alerts.process_user_alerts(
+                    username,
+                    signals=payload.get("signals") or [],
+                    display_name=username,
+                    email=email,
+                    delivery=_deliver_email_smtp,
+                    league_key=cfg.key,
+                )
+                user_summary.append({"leagueKey": cfg.key, **result})
+            if user_summary:
+                summary.append({"username": username, "byLeague": user_summary})
         return {
             "total_users_checked": len(db),
             "processed": len(summary),

--- a/src/api/signal_alerts.py
+++ b/src/api/signal_alerts.py
@@ -7,16 +7,27 @@ user, and queues a delivery via whatever transport is configured
 
 State model
 -----------
-For each (username, signalKey) pair we persist two facts:
+For each (username, leagueKey, signalKey) triple we persist two
+facts:
 
 * ``last_seen_signal`` — the most recent signal the user saw for
-  this player+tag.  Compared against the current signal to decide
-  whether to alert.
+  this player+tag IN THIS LEAGUE.  Compared against the current
+  signal to decide whether to alert.
 * ``last_notified_at`` — when we last fired an alert for this
-  key, so we don't spam the user if they ignore two evaluations
+  triple, so we don't spam the user if they ignore two evaluations
   in a row.
 
-Both are stored in user_kv under the ``signalAlertState`` key.
+Stored in user_kv under ``signalAlertStateByLeague[leagueKey]``.
+Legacy ``signalAlertState`` (un-nested) is read as a fallback for
+the default league only so pre-migration state keeps working —
+see ``_load_alert_state``.
+
+Why per-league — the scenario this fixes: a SELL signal fires for
+Ja'Marr Chase in league A at 10am → alert sent → same signal
+fires for the same user's league B roster at 11am.  Under the old
+single-bucket scheme the 12-hour cooldown saw "already notified"
+and silently dropped league B's alert.  Nested by league each
+cooldown is independent.
 
 Delivery is pluggable — the default ``delivery_email`` uses the
 existing ``ALERT_TO`` / ``ALERT_FROM`` / ``ALERT_PASSWORD`` SMTP
@@ -54,11 +65,54 @@ def _utc_now_ms() -> int:
     return int(time.time() * 1000)
 
 
+def _load_alert_state(
+    user_state: dict[str, Any],
+    league_key: str | None,
+) -> dict[str, Any]:
+    """Return the signalAlertState bucket for a specific league.
+
+    Resolution order (each step is also a one-time implicit
+    migration — whatever wins the read is what subsequent writes
+    use):
+
+      1. ``signalAlertStateByLeague[leagueKey]`` (new shape)
+      2. Legacy flat ``signalAlertState`` IF this is the user's
+         default-league query (empty league_key or matches
+         registry default).  Pre-migration state doesn't lose
+         its cooldowns on upgrade.
+      3. Empty dict.
+
+    We don't auto-rewrite the legacy field on read — too easy to
+    race a concurrent write.  The first write through
+    ``detect_signal_transitions`` below stores to the new shape
+    and leaves the legacy field alone; on the next read the
+    legacy bucket may drift out of date, which is fine because
+    once the new shape is populated we never read the legacy one
+    again for that league.
+    """
+    by_league = user_state.get("signalAlertStateByLeague") or {}
+    if not isinstance(by_league, dict):
+        by_league = {}
+    key = str(league_key or "").strip()
+    if key and isinstance(by_league.get(key), dict):
+        return dict(by_league[key])
+    # Legacy fallback — only for the default-league request path.
+    # We assume the caller passes "" / None only for default-league
+    # scrape runs; a new-league run passes an explicit key and
+    # correctly gets an empty state on first evaluation.
+    if not key:
+        legacy = user_state.get("signalAlertState") or {}
+        if isinstance(legacy, dict):
+            return dict(legacy)
+    return {}
+
+
 def detect_signal_transitions(
     username: str,
     signals: list[dict[str, Any]],
     *,
     path: Any = None,
+    league_key: str | None = None,
 ) -> list[dict[str, Any]]:
     """Compare the live signal list to the user's last-seen state
     and return the subset that represents a newly-actionable
@@ -68,8 +122,15 @@ def detect_signal_transitions(
       * ``signal in ACTIONABLE_SIGNALS``
       * AND either no prior signal exists OR the prior signal was
         different
-      * AND we haven't already notified on this same (key, signal)
-        within _MIN_NOTIFY_INTERVAL_HOURS
+      * AND we haven't already notified on this same
+        (leagueKey, key, signal) within _MIN_NOTIFY_INTERVAL_HOURS
+
+    ``league_key`` scopes the cooldown state.  Omitted / empty →
+    treated as the legacy single-league path (reads + writes the
+    un-nested ``signalAlertState`` for back-compat with pre-
+    multi-league deployments).  Passed explicitly for each
+    active league during the alert sweep so cooldowns don't
+    bleed.
 
     Writes the new state back to user_kv.  Returns the list of
     alerts to deliver (the caller actually sends them).
@@ -78,9 +139,7 @@ def detect_signal_transitions(
         return []
 
     user_state = _user_kv.get_user_state(username, path=path)
-    alert_state = user_state.get("signalAlertState") or {}
-    if not isinstance(alert_state, dict):
-        alert_state = {}
+    alert_state = _load_alert_state(user_state, league_key)
 
     now = _utc_now_ms()
     min_interval_ms = int(_MIN_NOTIFY_INTERVAL_HOURS * 3600 * 1000)
@@ -140,11 +199,32 @@ def detect_signal_transitions(
     # Persist the updated state even when no transitions fired —
     # we still want to remember "last seen" so the first evaluation
     # after a quiet period doesn't flood the user.
-    _user_kv.merge_user_state(
-        username,
-        {"signalAlertState": new_state},
-        path=path,
-    )
+    #
+    # Storage shape: when a league_key is present, nest under
+    # ``signalAlertStateByLeague[leagueKey]``.  When absent (legacy
+    # single-league callers) keep writing the flat field — that's
+    # what pre-migration state reads on the next run.
+    key = str(league_key or "").strip()
+    if key:
+        # Merge with whatever other leagues are already stored so
+        # we don't clobber them.  ``merge_user_state`` does shallow
+        # dict-merge at the top level, so nesting one extra level
+        # means each league's bucket updates atomically.
+        existing_by_league = user_state.get("signalAlertStateByLeague") or {}
+        if not isinstance(existing_by_league, dict):
+            existing_by_league = {}
+        next_by_league = {**existing_by_league, key: new_state}
+        _user_kv.merge_user_state(
+            username,
+            {"signalAlertStateByLeague": next_by_league},
+            path=path,
+        )
+    else:
+        _user_kv.merge_user_state(
+            username,
+            {"signalAlertState": new_state},
+            path=path,
+        )
     return transitions
 
 
@@ -188,6 +268,7 @@ def process_user_alerts(
     email: str | None = None,
     delivery: Callable[[str, str, str], bool] | None = None,
     path: Any = None,
+    league_key: str | None = None,
 ) -> dict[str, Any]:
     """End-to-end: detect transitions + deliver via ``delivery``.
 
@@ -201,8 +282,13 @@ def process_user_alerts(
 
     ``delivery`` is called as ``delivery(to, subject, body) -> bool``
     so tests can pass a stub to inspect the payload without SMTP.
+
+    ``league_key`` scopes the cooldown (see ``detect_signal_transitions``).
+    Omitted → legacy single-league behaviour.
     """
-    transitions = detect_signal_transitions(username, signals, path=path)
+    transitions = detect_signal_transitions(
+        username, signals, path=path, league_key=league_key,
+    )
     if not transitions:
         return {"transitions": 0, "delivered": False, "reason": "no_transitions"}
     if not email:

--- a/src/api/terminal.py
+++ b/src/api/terminal.py
@@ -1106,6 +1106,7 @@ def build_terminal_payload(
     user_state: dict[str, Any] | None = None,
     history_window_days: int | None = None,
     public_mode: bool = False,
+    league_key: str | None = None,
 ) -> dict[str, Any]:
     """Assemble the full landing-page payload.
 
@@ -1200,16 +1201,37 @@ def build_terminal_payload(
     watchlist_block: list[dict[str, Any]] = []
     roster_rows: list[dict[str, Any]] = []
 
-    # Dismissals applied to signals.
+    # Dismissals applied to signals.  When ``league_key`` is passed,
+    # read from ``dismissedSignalsByLeague[leagueKey]`` (nested
+    # per-league) and fall back to the flat ``dismissedSignals`` field
+    # so users who haven't written any dismissals on the new
+    # per-league schema yet (everyone pre-migration) still see their
+    # existing dismissals honored for their default league.  See
+    # ``user_kv.active_dismissals`` for the resolution rules.
     active_dismissals: dict[str, int] = {}
     if isinstance(user_state, dict):
-        ds = user_state.get("dismissedSignals")
-        if isinstance(ds, dict):
-            for k, v in ds.items():
-                try:
-                    active_dismissals[str(k)] = int(v)
-                except (TypeError, ValueError):
-                    continue
+        key = str(league_key or "").strip()
+        ds_by_league = user_state.get("dismissedSignalsByLeague")
+        if key and isinstance(ds_by_league, dict):
+            bucket = ds_by_league.get(key)
+            if isinstance(bucket, dict):
+                for k, v in bucket.items():
+                    try:
+                        active_dismissals[str(k)] = int(v)
+                    except (TypeError, ValueError):
+                        continue
+        # Legacy flat field — layer in for the default league only so
+        # dismissals made before the migration still take effect.
+        # For non-default leagues we intentionally skip the flat field
+        # because its entries belong to the default league's context.
+        if not active_dismissals:
+            ds = user_state.get("dismissedSignals")
+            if isinstance(ds, dict):
+                for k, v in ds.items():
+                    try:
+                        active_dismissals[str(k)] = int(v)
+                    except (TypeError, ValueError):
+                        continue
 
     if resolved_team and isinstance(resolved_team, dict):
         owner_id = str(resolved_team.get("ownerId") or "").strip()

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -68,7 +68,17 @@ KNOWN_KEYS = frozenset({
     "selectedTeam",
     "watchlist",
     "dismissedSignals",
+    # Per-league nested dismissals: ``{leagueKey: {signalKey: expiresAt}}``.
+    # Takes precedence over the flat field when ``active_dismissals``
+    # is called with a ``league_key``.  Dismissing a signal on league
+    # A no longer silences the same player's signal on league B.
+    "dismissedSignalsByLeague",
     "dismissalAliases",
+    # Per-league signal-alert state used by signal_alerts.py for the
+    # 12-hour cooldown: ``{leagueKey: {stateKey: {signal, notifiedAt}}}``.
+    # Prevents a SELL in league A from silently suppressing the same
+    # player's SELL notification in league B.
+    "signalAlertStateByLeague",
     "updatedAt",
     # League preference — the user's currently-active league key from
     # the league registry (``src/api/league_registry``).  Persists
@@ -385,6 +395,42 @@ def merge_user_state(
         conn.close()
 
 
+def _merge_per_league_dismissals(
+    existing_by_league: dict[str, Any] | None,
+    league_key: str,
+    add: dict[str, int] | None = None,
+    remove: set[str] | None = None,
+) -> dict[str, dict[str, int]]:
+    """Helper: layer ``add`` + ``remove`` onto
+    ``existing_by_league[league_key]`` and return the full map.
+
+    Keeps other leagues' dismissal buckets untouched — that's the
+    whole point of nesting.  Used by ``dismiss_signal`` +
+    ``undismiss_signal`` below.
+    """
+    by_league: dict[str, dict[str, int]] = {}
+    if isinstance(existing_by_league, dict):
+        for k, v in existing_by_league.items():
+            if isinstance(k, str) and isinstance(v, dict):
+                by_league[k] = {
+                    str(sk): int(sv)
+                    for sk, sv in v.items()
+                    if str(sk)
+                }
+    bucket = dict(by_league.get(league_key) or {})
+    if add:
+        for k, v in add.items():
+            try:
+                bucket[str(k)] = int(v)
+            except (TypeError, ValueError):
+                continue
+    if remove:
+        for k in remove:
+            bucket.pop(str(k), None)
+    by_league[league_key] = bucket
+    return by_league
+
+
 def dismiss_signal(
     username: str,
     signal_key: str,
@@ -392,6 +438,7 @@ def dismiss_signal(
     ttl_ms: int = 7 * 24 * 3600 * 1000,
     alias_sleeper_id: str | None = None,
     alias_display_name: str | None = None,
+    league_key: str | None = None,
     path: Path | None = None,
 ) -> dict[str, Any]:
     """Dismiss ``signal_key`` for ``ttl_ms`` milliseconds.
@@ -400,19 +447,29 @@ def dismiss_signal(
     again on the next refresh but short enough that a stale
     dismissal doesn't permanently hide a re-armed signal.
 
+    ``league_key`` (when provided) scopes the dismissal to one league.
+    Stored under ``dismissedSignalsByLeague[leagueKey][signalKey]`` so
+    dismissing a signal on league A doesn't silence the same player's
+    signal on league B.  When ``league_key`` is None or empty the
+    legacy flat ``dismissedSignals`` is written instead — back-compat
+    path for pre-migration callers + anonymous frontend usage.
+
     Optional ``alias_sleeper_id`` + ``alias_display_name`` record a
-    rename-resistant mapping: the UI can pass the Sleeper ID of the
-    player whose signal was dismissed, and when the player later
-    appears under a different display name the dismissal can still
-    be matched by looking up the alias.  Stored in a separate
-    ``dismissalAliases`` map so the primary dismissal key (``name::
-    tag``) stays a pure string key — existing consumers don't have
-    to change.
+    rename-resistant mapping (global across leagues — Sleeper IDs are
+    NFL-wide, the alias isn't league-scoped).
     """
     if not username or not signal_key:
         return get_user_state(username, path=path)
     expires_at = _now_ms() + max(1_000, int(ttl_ms))
-    patch: dict[str, Any] = {"dismissedSignals": {str(signal_key): expires_at}}
+    patch: dict[str, Any] = {}
+    key = str(league_key or "").strip()
+    if key:
+        existing = get_user_state(username, path=path).get("dismissedSignalsByLeague")
+        patch["dismissedSignalsByLeague"] = _merge_per_league_dismissals(
+            existing, key, add={str(signal_key): expires_at},
+        )
+    else:
+        patch["dismissedSignals"] = {str(signal_key): expires_at}
     if alias_sleeper_id and alias_display_name:
         patch["dismissalAliases"] = {str(alias_display_name): str(alias_sleeper_id)}
     return merge_user_state(username, patch, path=path)
@@ -422,31 +479,68 @@ def undismiss_signal(
     username: str,
     signal_key: str,
     *,
+    league_key: str | None = None,
     path: Path | None = None,
 ) -> dict[str, Any]:
-    """Remove a single dismissal (user chose to re-surface the signal)."""
+    """Remove a single dismissal (user chose to re-surface the signal).
+
+    ``league_key`` scopes the removal to one league's bucket; legacy
+    callers without a key modify the flat ``dismissedSignals`` map.
+    """
     if not username or not signal_key:
         return get_user_state(username, path=path)
     conn = _connect(path)
     try:
         entry = _read_row(conn, username)
-        dismissed = entry.get("dismissedSignals")
-        if isinstance(dismissed, dict) and str(signal_key) in dismissed:
-            dismissed.pop(str(signal_key), None)
-            entry["dismissedSignals"] = dismissed
+        changed = False
+        key = str(league_key or "").strip()
+        if key:
+            by_league = entry.get("dismissedSignalsByLeague")
+            if isinstance(by_league, dict):
+                bucket = by_league.get(key)
+                if isinstance(bucket, dict) and str(signal_key) in bucket:
+                    bucket.pop(str(signal_key), None)
+                    by_league[key] = bucket
+                    entry["dismissedSignalsByLeague"] = by_league
+                    changed = True
+        else:
+            dismissed = entry.get("dismissedSignals")
+            if isinstance(dismissed, dict) and str(signal_key) in dismissed:
+                dismissed.pop(str(signal_key), None)
+                entry["dismissedSignals"] = dismissed
+                changed = True
+        if changed:
             _write_row(conn, username, entry)
         return dict(entry)
     finally:
         conn.close()
 
 
-def active_dismissals(username: str, *, path: Path | None = None) -> dict[str, int]:
-    """Return the ``{signalKey: expiresAtMs}`` dict with expireds pruned."""
+def active_dismissals(
+    username: str,
+    *,
+    league_key: str | None = None,
+    path: Path | None = None,
+) -> dict[str, int]:
+    """Return the ``{signalKey: expiresAtMs}`` dict with expireds pruned.
+
+    ``league_key`` returns just that league's bucket (merged with the
+    legacy flat dismissals for the default league as a soft migration
+    path).  Omitted → returns the flat legacy field only (pre-migration
+    behaviour for callers that haven't adopted league scoping yet).
+    """
     state = get_user_state(username, path=path)
-    dismissed = state.get("dismissedSignals")
-    if not isinstance(dismissed, dict):
-        return {}
-    return dict(dismissed)
+    key = str(league_key or "").strip()
+    if not key:
+        dismissed = state.get("dismissedSignals")
+        return dict(dismissed) if isinstance(dismissed, dict) else {}
+    by_league = state.get("dismissedSignalsByLeague")
+    bucket = {}
+    if isinstance(by_league, dict):
+        b = by_league.get(key)
+        if isinstance(b, dict):
+            bucket = {str(k): int(v) for k, v in b.items() if isinstance(v, (int, float))}
+    return bucket
 
 
 def dismissal_aliases(username: str, *, path: Path | None = None) -> dict[str, str]:

--- a/tests/api/test_signal_alerts.py
+++ b/tests/api/test_signal_alerts.py
@@ -181,6 +181,67 @@ def test_process_user_alerts_skips_when_no_email(kv_path):
     assert result["reason"] == "no_email"
 
 
+def test_cooldown_is_scoped_per_league(kv_path):
+    """The #1 pre-refactor bleed: a SELL signal on Ja'Marr Chase
+    in league A at 10am must NOT suppress the same player's SELL
+    alert in league B at 11am.  Fresh per-league state means the
+    12-hour cooldown only looks at league B's bucket.
+    """
+    sig = _sig("Josh Allen", "elite_stable", "SELL", sid="4017")
+
+    # League A: first fire — transition emitted.
+    a1 = signal_alerts.detect_signal_transitions(
+        "alice", [sig], path=kv_path, league_key="dynasty_main",
+    )
+    assert len(a1) == 1
+
+    # Same player, same signal, league B — different bucket, so
+    # this must ALSO fire even though the cooldown in league A
+    # just set notifiedAt = now.
+    b1 = signal_alerts.detect_signal_transitions(
+        "alice", [sig], path=kv_path, league_key="dynasty_new",
+    )
+    assert len(b1) == 1, (
+        "league B fire suppressed by league A's cooldown — per-league "
+        "bucketing is broken"
+    )
+
+    # Re-fire in league A within the cooldown window: correctly
+    # suppressed (same-league flicker guard is what the cooldown is
+    # for in the first place).
+    a2 = signal_alerts.detect_signal_transitions(
+        "alice", [sig], path=kv_path, league_key="dynasty_main",
+    )
+    assert a2 == [], "league A cooldown should still guard same-league flicker"
+
+
+def test_legacy_flat_state_read_for_default_league(kv_path):
+    """Pre-migration state lives in the flat ``signalAlertState``
+    field.  The default-league code path (``league_key=None`` or
+    empty) must still read + write it so users who had cooldowns
+    before the upgrade don't re-fire everything on first run.
+    """
+    # Seed a pre-migration state blob.
+    from src.api import user_kv
+    seeded = {
+        "signalAlertState": {
+            "sid:4017::elite_stable": {
+                "signal": "SELL",
+                "notifiedAt": signal_alerts._utc_now_ms(),
+            }
+        }
+    }
+    user_kv.merge_user_state("alice", seeded, path=kv_path)
+
+    # Legacy call (no league_key) — must see prior cooldown and
+    # suppress.
+    sig = _sig("Josh Allen", "elite_stable", "SELL", sid="4017")
+    legacy = signal_alerts.detect_signal_transitions(
+        "alice", [sig], path=kv_path,  # no league_key
+    )
+    assert legacy == [], "legacy flat signalAlertState must still gate cooldowns"
+
+
 def test_process_user_alerts_honors_delivery_error(kv_path):
     def boom(to, s, b):
         raise RuntimeError("smtp unreachable")

--- a/tests/api/test_user_kv.py
+++ b/tests/api/test_user_kv.py
@@ -89,6 +89,57 @@ def test_undismiss_signal(kv_path):
     assert "foo" not in user_kv.active_dismissals("u", path=kv_path)
 
 
+def test_dismissals_scoped_per_league(kv_path):
+    """Dismissing a signal in league A must NOT hide the same
+    signal in league B — both leagues get independent buckets."""
+    user_kv.dismiss_signal(
+        "u", "Josh Allen::elite_stable", ttl_ms=60_000,
+        league_key="dynasty_main", path=kv_path,
+    )
+    # League A has it; league B does not.
+    assert "Josh Allen::elite_stable" in user_kv.active_dismissals(
+        "u", league_key="dynasty_main", path=kv_path,
+    )
+    assert user_kv.active_dismissals(
+        "u", league_key="dynasty_new", path=kv_path,
+    ) == {}
+
+
+def test_undismiss_scoped_per_league(kv_path):
+    """Un-dismissing in league A leaves league B's dismissal alone."""
+    user_kv.dismiss_signal(
+        "u", "Josh Allen::elite_stable", league_key="dynasty_main", path=kv_path,
+    )
+    user_kv.dismiss_signal(
+        "u", "Josh Allen::elite_stable", league_key="dynasty_new", path=kv_path,
+    )
+    user_kv.undismiss_signal(
+        "u", "Josh Allen::elite_stable", league_key="dynasty_main", path=kv_path,
+    )
+    # A gone, B intact.
+    assert user_kv.active_dismissals(
+        "u", league_key="dynasty_main", path=kv_path,
+    ) == {}
+    assert "Josh Allen::elite_stable" in user_kv.active_dismissals(
+        "u", league_key="dynasty_new", path=kv_path,
+    )
+
+
+def test_legacy_flat_dismissals_unchanged(kv_path):
+    """Legacy callers (no ``league_key``) continue to write the flat
+    ``dismissedSignals`` field + read from it, keeping pre-migration
+    state intact."""
+    user_kv.dismiss_signal("u", "legacy::x", ttl_ms=60_000, path=kv_path)
+    flat = user_kv.active_dismissals("u", path=kv_path)  # no league_key
+    assert "legacy::x" in flat
+    # Per-league reader on a league with no bucket returns empty —
+    # it does NOT surface the flat field (we'd be showing default-
+    # league dismissals under league B's name).
+    assert user_kv.active_dismissals(
+        "u", league_key="dynasty_new", path=kv_path,
+    ) == {}
+
+
 def test_corrupt_file_starts_fresh(kv_path):
     kv_path.write_text("not json", encoding="utf-8")
     # Should not raise


### PR DESCRIPTION
Closes the #1 bleed from the multi-league audit: a SELL at 10am for league A would silently suppress the same player's SELL at 11am for league B (12-hour cooldown was global). Same on the dismissal side.

Now nested by league: `signalAlertStateByLeague[key]` + `dismissedSignalsByLeague[key]`. Legacy flat fields kept as read-only fallbacks for default-league pre-migration state.

### Tests
- pytest: 1947 passed (5 new, including the bleed-pinned regression test)
- vitest: 690 passed
- build clean