### PR TITLE
feat: per-league overlay warm + pickDetails + status observability

### DIFF
--- a/server.py
+++ b/server.py
@@ -2333,7 +2333,65 @@ async def get_status():
         # R-4: Scrape success rate tracking
         "scrape_success_rate_24h": _scrape_success_rate_24h(),
         "last_n_scrapes": scrape_history[-20:],
+        "leagues": _league_status_snapshot(),
     })
+
+
+def _league_status_snapshot() -> list[dict]:
+    """Per-league data-health snapshot for /api/status.
+
+    Reports for each ACTIVE league:
+      * ``key`` / ``displayName``                — identity
+      * ``source``                                — "primary-scrape" | "overlay" | "none"
+      * ``teamCount``                             — rosters resolved
+      * ``tradeCount``                            — trades loaded
+      * ``overlayFetchedAt`` / ``overlayAgeSec``  — staleness (None when primary)
+      * ``sleeperLeagueId``                       — raw id for correlation with logs
+
+    This is the diagnostic surface for answering "does League B have
+    fresh data, or am I serving the stale overlay again?".  When the
+    source is ``none`` the UI surfaces the data-not-ready state.
+    """
+    import time as _time
+    snapshot: list[dict[str, Any]] = []
+    loaded = latest_contract_data or {}
+    loaded_meta = loaded.get("meta") or {}
+    loaded_key = loaded_meta.get("leagueKey")
+    loaded_sleeper = loaded.get("sleeper") or {}
+    for cfg in _league_registry.active_leagues():
+        entry: dict[str, Any] = {
+            "key": cfg.key,
+            "displayName": cfg.display_name,
+            "sleeperLeagueId": cfg.sleeper_league_id,
+            "idpEnabled": cfg.idp_enabled,
+            "scoringProfile": cfg.scoring_profile,
+        }
+        if cfg.key == loaded_key and isinstance(loaded_sleeper, dict):
+            entry["source"] = "primary-scrape"
+            entry["teamCount"] = len(loaded_sleeper.get("teams") or [])
+            entry["tradeCount"] = len(loaded_sleeper.get("trades") or [])
+            entry["overlayFetchedAt"] = None
+            entry["overlayAgeSec"] = None
+        else:
+            cached = _sleeper_overlay._CACHE.get(cfg.sleeper_league_id) or {}
+            payload = cached.get("payload") or {}
+            fetched_at = float(cached.get("_cached_at") or 0)
+            if payload.get("teams"):
+                entry["source"] = "overlay"
+                entry["teamCount"] = len(payload.get("teams") or [])
+                entry["tradeCount"] = len(payload.get("trades") or [])
+                entry["overlayFetchedAt"] = payload.get("overlayFetchedAt")
+                entry["overlayAgeSec"] = (
+                    round(_time.time() - fetched_at, 1) if fetched_at > 0 else None
+                )
+            else:
+                entry["source"] = "none"
+                entry["teamCount"] = 0
+                entry["tradeCount"] = 0
+                entry["overlayFetchedAt"] = None
+                entry["overlayAgeSec"] = None
+        snapshot.append(entry)
+    return snapshot
 
 
 @app.api_route("/api/health", methods=["GET", "HEAD"])
@@ -3928,11 +3986,35 @@ async def get_draft_capital(request: Request, refresh: str = ""):
     user's saved pref and then the registry default.  Unknown or
     inactive keys return 400.
 
+    The pick-value Excel workbook (``CSVs/Draft Data.xlsx``) is
+    wired to the default league's draft — per-team budgets,
+    carry-over balances, and standings all reflect that league's
+    actual data.  Non-default leagues 501 with
+    ``not_configured_for_league`` rather than serving league-A
+    numbers under league-B's team names.  Angle-finder + roster
+    picks still work across leagues via the Sleeper overlay; only
+    the workbook-sourced budget column is league-specific.
+
     Pass ``?refresh=1`` to force a fresh KTC fetch."""
     try:
         league_cfg = _resolve_league_for_request(request)
     except LeagueResolutionError as err:
         return err.json_response()
+    default_cfg = _league_registry.get_default_league()
+    if default_cfg and league_cfg.key != default_cfg.key:
+        return JSONResponse(
+            status_code=501,
+            content={
+                "error": "not_configured_for_league",
+                "message": (
+                    f"Draft-capital budgets are pinned to the default league "
+                    f"({default_cfg.key!r}).  {league_cfg.key!r} needs its own "
+                    "pick-value workbook + rookie ranks before this endpoint "
+                    "can serve it."
+                ),
+                "leagueKey": league_cfg.key,
+            },
+        )
     if refresh:
         _ktc_cache["fetched_at"] = 0  # invalidate cache
     try:
@@ -4637,27 +4719,59 @@ async def trigger_scrape(request: Request, background_tasks: BackgroundTasks):
     ``not_implemented`` because multi-league scraping isn't wired up
     yet (that's a future refactor of Dynasty Scraper.py).
     """
-    # Validate the key first.  The 501 below is a more honest
-    # response than silently scraping the default league when the
-    # caller asked for a specific one.
+    # Validate the key first.  Non-default leagues don't run the
+    # full ranking scrape (the pipeline is single-league) — instead
+    # they refresh the on-demand Sleeper overlay (rosters + trades
+    # + pick ownership) so the UI picks up new trades / roster
+    # moves without waiting for the 15-min cache to expire.  Same
+    # shape of response either way.
     try:
         league_cfg = _resolve_league_for_request(request)
     except LeagueResolutionError as err:
         return err.json_response()
     default_cfg = _league_registry.get_default_league()
     if default_cfg and league_cfg.key != default_cfg.key:
-        return JSONResponse(
-            status_code=501,
-            content={
-                "error": "multi_league_scrape_not_supported",
-                "message": (
-                    f"Only the default league ({default_cfg.key!r}) can be "
-                    "scraped at this time; multi-league scraping is a future "
-                    "refactor."
-                ),
-                "leagueKey": league_cfg.key,
-            },
+        # Invalidate + rewarm the overlay for this league.  Returns
+        # immediately with the refreshed team/trade counts so the
+        # UI can show "X trades loaded" right away.
+        loaded_sleeper = (
+            latest_contract_data.get("sleeper") or {}
+            if isinstance(latest_contract_data, dict) else {}
         )
+        id_map = loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else {}
+        _sleeper_overlay.invalidate_overlay_cache(league_cfg.sleeper_league_id)
+        try:
+            overlay = await run_in_threadpool(
+                _sleeper_overlay.fetch_sleeper_overlay,
+                sleeper_league_id=league_cfg.sleeper_league_id,
+                id_to_player=id_map if isinstance(id_map, dict) else {},
+                force_refresh=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "error": "sleeper_overlay_fetch_failed",
+                    "message": f"Sleeper overlay refresh failed: {exc}",
+                    "leagueKey": league_cfg.key,
+                },
+            )
+        if not overlay:
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "error": "sleeper_overlay_empty",
+                    "message": "Overlay fetch succeeded but returned no data.",
+                    "leagueKey": league_cfg.key,
+                },
+            )
+        return JSONResponse(content={
+            "message": f"Sleeper overlay refreshed for {league_cfg.key!r}.",
+            "leagueKey": league_cfg.key,
+            "teamCount": len(overlay.get("teams") or []),
+            "tradeCount": len(overlay.get("trades") or []),
+            "overlayFetchedAt": overlay.get("overlayFetchedAt"),
+        })
 
     status_payload = _scrape_status_payload()
     if status_payload.get("is_running") or scrape_run_lock.locked():

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -103,6 +103,98 @@ def _walk_league_chain(root_league_id: str, max_depth: int = 2) -> list[str]:
     return out
 
 
+def _round_suffix(n: int) -> str:
+    """1 → '1st', 2 → '2nd', 3 → '3rd', 4+ → 'Nth'.  Matches the
+    scraper's convention for pick labels (``2027 1st``)."""
+    if n == 1:
+        return "1st"
+    if n == 2:
+        return "2nd"
+    if n == 3:
+        return "3rd"
+    return f"{n}th"
+
+
+def _format_pick_label(season: str, round_num: int, slot: int | None = None) -> str:
+    """Build a human-readable pick asset name matching what the
+    rankings board renders: ``"2027 1.05"`` when slot is known,
+    ``"2027 1st"`` otherwise (traded-future picks usually have no
+    slot yet).  The rankings pipeline emits both shapes so the UI
+    resolves either."""
+    if slot is not None and slot > 0:
+        return f"{season} {round_num}.{str(slot).zfill(2)}"
+    return f"{season} {_round_suffix(round_num)}"
+
+
+def _build_pick_ownership(
+    sleeper_league_id: str,
+    roster_ids: list[int],
+    num_rounds: int = 6,
+    num_years: int = 3,
+) -> dict[int, list[dict[str, Any]]]:
+    """Return ``{rosterId: [pickDetail, ...]}`` — which future picks
+    each roster currently owns based on the league's
+    ``/traded_picks`` endpoint.
+
+    Default ownership: each roster owns its own pick in every round
+    of every upcoming year.  ``/traded_picks`` returns the diffs —
+    swap ``original`` → ``owner`` per entry to get current
+    ownership.  Matches the scraper's team_pick_details construction
+    in Dynasty Scraper.py (fetch_sleeper_rosters).
+
+    Returns an empty map on any fetch failure — callers degrade to
+    the data-not-ready state for draft-capital widgets.
+    """
+    import datetime as _dt
+    if not roster_ids:
+        return {}
+    current_year = _dt.datetime.now(_dt.timezone.utc).year
+    years = [str(current_year + y) for y in range(num_years)]
+
+    # Seed: every roster owns its own picks by default.
+    ownership: dict[tuple[str, int, int], int] = {}
+    for year in years:
+        for rnd in range(1, num_rounds + 1):
+            for rid in roster_ids:
+                ownership[(year, rnd, rid)] = rid
+
+    traded = _http_get_json(
+        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/traded_picks"
+    )
+    if isinstance(traded, list):
+        for tp in traded:
+            if not isinstance(tp, dict):
+                continue
+            try:
+                season = str(tp.get("season") or "")
+                rnd = int(tp.get("round") or 0)
+                original = int(tp.get("roster_id") or 0)
+                owner = int(tp.get("owner_id") or 0)
+            except (TypeError, ValueError):
+                continue
+            if not season or rnd < 1 or not original or not owner:
+                continue
+            key = (season, rnd, original)
+            if key in ownership:
+                ownership[key] = owner
+
+    # Re-pivot to {current_owner: [pickDetail...]}.
+    per_roster: dict[int, list[dict[str, Any]]] = {rid: [] for rid in roster_ids}
+    for (season, rnd, original), current_owner in ownership.items():
+        per_roster.setdefault(current_owner, []).append({
+            "season": season,
+            "round": rnd,
+            "slot": None,
+            "original_roster_id": original,
+            "owner_roster_id": current_owner,
+            "label": _format_pick_label(season, rnd),
+        })
+    # Sort each team's picks year-then-round for deterministic output.
+    for rid, plist in per_roster.items():
+        plist.sort(key=lambda p: (p.get("season", ""), p.get("round", 0)))
+    return per_roster
+
+
 def _build_teams_block(
     sleeper_league_id: str,
     id_to_player: dict[str, str] | None,
@@ -114,6 +206,12 @@ def _build_teams_block(
     safe to reuse from the primary league's contract).  When a
     roster references an ID not in the map, we fall back to the
     raw ID so the UI at least renders a row.
+
+    Also populates ``picks`` (list of pick labels) + ``pickDetails``
+    (raw {season, round, ...} dicts) per team by resolving
+    ``/traded_picks`` against each roster's default ownership.
+    This is what unblocks /api/draft-capital + angle-finder for
+    non-default leagues.
     """
     rosters = _http_get_json(
         f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters"
@@ -140,6 +238,14 @@ def _build_teams_block(
         user_map[uid] = str(name)
 
     id_map = id_to_player or {}
+    roster_ids: list[int] = []
+    for r in rosters:
+        if isinstance(r, dict) and r.get("roster_id") is not None:
+            try:
+                roster_ids.append(int(r["roster_id"]))
+            except (TypeError, ValueError):
+                continue
+    pick_ownership = _build_pick_ownership(sleeper_league_id, roster_ids)
 
     teams: list[dict[str, Any]] = []
     for r in rosters:
@@ -160,19 +266,20 @@ def _build_teams_block(
                 continue
             mapped = id_map.get(pid_str)
             names.append(mapped if mapped else pid_str)
+        try:
+            rid_int = int(roster_id) if roster_id is not None else 0
+        except (TypeError, ValueError):
+            rid_int = 0
+        pick_details = pick_ownership.get(rid_int, [])
+        pick_labels = [p["label"] for p in pick_details]
         teams.append({
             "name": user_map.get(owner_id, f"Team {roster_id}"),
             "ownerId": owner_id,
             "roster_id": roster_id,
             "players": names,
             "playerIds": [str(pid) for pid in player_ids if pid],
-            # ``picks`` + ``pickDetails`` require /traded_picks + a
-            # pick-owner resolver — out of scope for the minimal
-            # overlay.  Empty list is safe: draft-capital panels
-            # gracefully render blank, /api/draft-capital still
-            # 503s for non-loaded leagues.
-            "picks": [],
-            "pickDetails": [],
+            "picks": pick_labels,
+            "pickDetails": pick_details,
         })
     return teams
 


### PR DESCRIPTION
Collapses audit items #5, #6, #8, #9 from the multi-league plan into one PR.

### What ships
- **Post-scrape overlay warm** — every scrape completion pre-warms overlays for non-default leagues; first request after a scrape hits a warm cache
- **Pick ownership in overlay** — `/traded_picks` resolution populates `teams[].picks` + `teams[].pickDetails`, unblocking Angle finder on League B
- **`POST /api/scrape?leagueKey=X`** — now invalidates + rewarms the overlay instead of 501'ing (manual trade-refresh path)
- **`/api/status.leagues[]`** — per-league data-source + staleness surface so you can see which leagues are live vs overlay vs empty

### Still 501
- `/api/draft-capital` on non-default leagues (pick-value workbook is League-A-specific; clean 501 `not_configured_for_league` instead of serving wrong numbers)

### Live verification
- Overlay for League B resolved 10 teams, 59 trades, 20 picks on the first team

### Tests
- pytest: 1947 passed, 3 skipped
- build clean