### PR TITLE
Collapse per-source winner table on mobile

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3001,6 +3001,68 @@ input[type="range"]:focus-visible::-moz-range-thumb {
    Rendered below the trade meter on /trade — one row per ranking source,
    VA-adjusted totals, winner + margin.
    ══════════════════════════════════════════════════════════════════════════ */
+.source-breakdown-card .source-breakdown-header {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0 0 6px 0;
+  width: 100%;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: default;
+}
+.source-breakdown-card .source-breakdown-header-text {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.source-breakdown-card .source-breakdown-chevron {
+  display: none;
+}
+@media (max-width: 768px) {
+  .source-breakdown-card .source-breakdown-header {
+    cursor: pointer;
+    align-items: center;
+  }
+  .source-breakdown-card .source-breakdown-header-text {
+    align-items: center;
+  }
+  .source-breakdown-card .source-breakdown-subtitle {
+    display: none;
+  }
+  .source-breakdown-card.is-expanded .source-breakdown-subtitle {
+    display: block;
+    flex-basis: 100%;
+    margin-top: 4px;
+  }
+  .source-breakdown-card:not(.is-expanded) .source-breakdown-header {
+    margin-bottom: 0;
+  }
+  .source-breakdown-card:not(.is-expanded) .source-breakdown-body {
+    display: none;
+  }
+  .source-breakdown-card .source-breakdown-chevron {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--subtext);
+    font-family: var(--mono);
+    font-size: 1.05rem;
+    line-height: 1;
+  }
+}
 .source-breakdown-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -343,8 +343,16 @@ function TradeSourceBreakdown({ sides, settings }) {
     const mq = window.matchMedia("(max-width: 768px)");
     const update = () => setIsMobile(mq.matches);
     update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
+    // iOS Safari < 14 only exposes addListener/removeListener on
+    // MediaQueryList; modern browsers support the standard
+    // EventTarget API.  Prefer the modern API and fall back for
+    // older WebViews that would otherwise throw.
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", update);
+      return () => mq.removeEventListener("change", update);
+    }
+    mq.addListener(update);
+    return () => mq.removeListener(update);
   }, []);
   const effectiveExpanded = isMobile ? mobileExpanded : true;
   const rows = useMemo(() => {

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -331,6 +331,22 @@ function TradeMeterMultiTeam({ sides, sideTotals, flows }) {
  */
 function TradeSourceBreakdown({ sides, settings }) {
   const [mobileExpanded, setMobileExpanded] = useState(false);
+  // Mirror the CSS breakpoint so aria-expanded reflects what's
+  // actually rendered: on desktop the body is always visible, on
+  // mobile it follows mobileExpanded. State-driven so SSR renders a
+  // consistent "desktop = expanded" view and the first client paint
+  // after hydration flips narrow viewports to the collapsed state
+  // without a hydration mismatch.
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const mq = window.matchMedia("(max-width: 768px)");
+    const update = () => setIsMobile(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  const effectiveExpanded = isMobile ? mobileExpanded : true;
   const rows = useMemo(() => {
     const assetsBySide = sides.map((s) => s.assets || []);
     const hasAny = assetsBySide.some((a) => a.length > 0);
@@ -462,9 +478,12 @@ function TradeSourceBreakdown({ sides, settings }) {
       <button
         type="button"
         className="source-breakdown-header"
-        aria-expanded={mobileExpanded}
+        aria-expanded={effectiveExpanded}
         aria-controls="source-breakdown-body"
-        onClick={() => setMobileExpanded((v) => !v)}
+        tabIndex={isMobile ? 0 : -1}
+        onClick={() => {
+          if (isMobile) setMobileExpanded((v) => !v);
+        }}
       >
         <span className="source-breakdown-header-text">
           <span

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -330,6 +330,7 @@ function TradeMeterMultiTeam({ sides, sideTotals, flows }) {
  * though their total scales aren't identical.
  */
 function TradeSourceBreakdown({ sides, settings }) {
+  const [mobileExpanded, setMobileExpanded] = useState(false);
   const rows = useMemo(() => {
     const assetsBySide = sides.map((s) => s.assets || []);
     const hasAny = assetsBySide.some((a) => a.length > 0);
@@ -454,14 +455,37 @@ function TradeSourceBreakdown({ sides, settings }) {
   const sideLabels = sides.map((s) => s.label);
 
   return (
-    <div className="card" style={{ marginTop: 14 }}>
-      <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 6 }}>
-        <h3 style={{ margin: 0, fontSize: "0.88rem" }}>Per-source winner</h3>
-        <span className="muted" style={{ fontSize: "0.72rem" }}>
-          VA-adjusted totals on the 0-9999 value scale, summed per vendor. Sub-boards (e.g. DLF SF + DLF RK) roll up into one row; margin shows winner's edge as a percent.
+    <div
+      className={`card source-breakdown-card${mobileExpanded ? " is-expanded" : ""}`}
+      style={{ marginTop: 14 }}
+    >
+      <button
+        type="button"
+        className="source-breakdown-header"
+        aria-expanded={mobileExpanded}
+        aria-controls="source-breakdown-body"
+        onClick={() => setMobileExpanded((v) => !v)}
+      >
+        <span className="source-breakdown-header-text">
+          <span
+            className="source-breakdown-title"
+            style={{ margin: 0, fontSize: "0.88rem", fontWeight: 700 }}
+          >
+            Per-source winner
+          </span>
+          <span className="muted source-breakdown-subtitle" style={{ fontSize: "0.72rem" }}>
+            VA-adjusted totals on the 0-9999 value scale, summed per vendor. Sub-boards (e.g. DLF SF + DLF RK) roll up into one row; margin shows winner's edge as a percent.
+          </span>
         </span>
-      </div>
-      <div style={{ overflowX: "auto" }}>
+        <span className="source-breakdown-chevron" aria-hidden="true">
+          {mobileExpanded ? "−" : "+"}
+        </span>
+      </button>
+      <div
+        id="source-breakdown-body"
+        className="source-breakdown-body"
+        style={{ overflowX: "auto" }}
+      >
         <table className="source-breakdown-table">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- On `/trade`, the "Per-source winner" card was a wide multi-column table that forced horizontal scrolling on phones, pushing the Winner column off-screen.
- Wrapped the card header in a tappable `<button>` with a `+ / −` chevron. On mobile (≤768px) the body is collapsed by default; tap the header to reveal the full per-source breakdown (Side totals, Winner, Margin).
- Desktop rendering is unchanged — the toggle/chevron are hidden via CSS above 768px and the body always renders.

## Test plan
- [ ] Load `/trade` on a phone (or Chrome devtools ≤768px), add assets to both sides, confirm the "Per-source winner" card shows just the title + `+` chevron with no table visible.
- [ ] Tap the header — table expands, chevron becomes `−`, and the explanatory subtitle appears.
- [ ] Tap again to collapse; subtitle hides and table is gone.
- [ ] Resize to desktop (>768px) — the table is always visible, no chevron, header is not interactive-looking.
- [ ] Check the console for React DOM-nesting warnings (should be none).
- [ ] `npm run regression` passes.

https://claude.ai/code/session_01CUWaetCTP3Bo8Nh94ByoLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUWaetCTP3Bo8Nh94ByoLh)_