### PR TITLE
KTC VA calibration scraper + equal-count candidate formulas

### DIFF
--- a/scripts/calibrate_va_formula.py
+++ b/scripts/calibrate_va_formula.py
@@ -79,16 +79,22 @@ def load_observations(path: Path = DEFAULT_OBSERVATIONS) -> list[DataPoint]:
     ``valueAdjustmentTeam2 == 0``) are still loaded with ktc_va=0 so
     the fit can honor the "no adjustment" signal.
     """
+    # "File doesn't exist" is a legitimate state (no observations
+    # captured yet); fall through quietly and let main() print a
+    # baseline-only message.  Anything else — bad JSON, wrong shape,
+    # IO error — is a real failure that would silently mask stale or
+    # corrupt data and produce a misleading calibration if swallowed,
+    # so we let it propagate.
     if not path.exists():
         return []
-    try:
-        with path.open("r", encoding="utf-8") as f:
-            payload = json.load(f)
-    except Exception:
-        return []
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
     observations = payload.get("observations") if isinstance(payload, dict) else payload
     if not isinstance(observations, list):
-        return []
+        raise ValueError(
+            f"{path}: expected an 'observations' list (or top-level array); "
+            f"got {type(observations).__name__}"
+        )
     points: list[DataPoint] = []
     for obs in observations:
         if not isinstance(obs, dict):

--- a/scripts/calibrate_va_formula.py
+++ b/scripts/calibrate_va_formula.py
@@ -294,11 +294,25 @@ def predict_v7_full_loop(pt: DataPoint, p: dict) -> float:
 
 # ── Scoring + grid search ───────────────────────────────────────────────
 
+# Floor for the relative-error divisor.  Dividing by pt.ktc_va is
+# ideal when KTC reports a nonzero VA (gives a true percentage), but
+# breaks on observations where KTC reports 0 — those are meaningful
+# calibration signal ("formula should predict near-0 here") rather
+# than noise, so skipping them is wrong.  Using max(|target|, floor)
+# scales all errors to a common magnitude: zero-target points still
+# penalize nonzero predictions proportionally, and nonzero-target
+# points behave identically to the original pure-relative metric as
+# long as |target| ≥ floor (which is true for every one of the 13
+# baseline anchors — smallest is 1166).
+_ERROR_FLOOR = 500.0
+
+
 def errors(predict_fn, params: dict) -> list[tuple[str, float, float, float, str]]:
     rows = []
     for pt in DATA:
         pred = predict_fn(pt, params)
-        err = (pred - pt.ktc_va) / pt.ktc_va
+        denom = max(abs(pt.ktc_va), _ERROR_FLOOR)
+        err = (pred - pt.ktc_va) / denom
         rows.append((pt.label, pred, pt.ktc_va, err, pt.topology))
     return rows
 

--- a/scripts/calibrate_va_formula.py
+++ b/scripts/calibrate_va_formula.py
@@ -26,7 +26,12 @@ update the pinned regression tests in
 from __future__ import annotations
 
 import itertools
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OBSERVATIONS = REPO_ROOT / "scripts" / "ktc_va_observations.json"
 
 
 @dataclass(frozen=True)
@@ -62,6 +67,60 @@ class DataPoint:
 
     def small_top(self) -> float:
         return self.sorted_small()[0] if self.small else 0.0
+
+
+def load_observations(path: Path = DEFAULT_OBSERVATIONS) -> list[DataPoint]:
+    """Load observations from ``data/ktc_va_observations.json``.
+
+    Each observation is converted to a DataPoint.  The ``small`` side is
+    the one with fewer pieces (unequal) or higher top asset (equal) —
+    matching the convention the frontend uses.  Observations without a
+    reportable VA (``valueAdjustmentTeam1 == 0`` AND
+    ``valueAdjustmentTeam2 == 0``) are still loaded with ktc_va=0 so
+    the fit can honor the "no adjustment" signal.
+    """
+    if not path.exists():
+        return []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except Exception:
+        return []
+    observations = payload.get("observations") if isinstance(payload, dict) else payload
+    if not isinstance(observations, list):
+        return []
+    points: list[DataPoint] = []
+    for obs in observations:
+        if not isinstance(obs, dict):
+            continue
+        team1 = [v for v in (obs.get("team1Values") or []) if v]
+        team2 = [v for v in (obs.get("team2Values") or []) if v]
+        va1 = obs.get("valueAdjustmentTeam1", 0) or 0
+        va2 = obs.get("valueAdjustmentTeam2", 0) or 0
+        label = obs.get("label") or "?"
+        topo = obs.get("topology") or f"{len(team1)}v{len(team2)}"
+        if not team1 or not team2:
+            continue
+
+        # Pick which side is "small" (VA recipient).
+        #   - Unequal counts: smaller-count side.
+        #   - Equal counts: side reporting VA > 0, else side with
+        #     higher top asset (default to team1 if tied).
+        if len(team1) != len(team2):
+            small_is_team1 = len(team1) < len(team2)
+        else:
+            if va1 > 0 and va2 == 0:
+                small_is_team1 = True
+            elif va2 > 0 and va1 == 0:
+                small_is_team1 = False
+            else:
+                small_is_team1 = max(team1) >= max(team2)
+
+        small = tuple(sorted(team1 if small_is_team1 else team2, reverse=True))
+        large = tuple(sorted(team2 if small_is_team1 else team1, reverse=True))
+        ktc_va = va1 if small_is_team1 else va2
+        points.append(DataPoint(label, small, large, float(ktc_va), topo))
+    return points
 
 
 DATA: list[DataPoint] = [
@@ -183,6 +242,56 @@ def predict_v5_additive_with_roster(pt: DataPoint, p: dict) -> float:
     return total
 
 
+def predict_v6_equal_count(pt: DataPoint, p: dict) -> float:
+    """V6: V3_hybrid + explicit equal-count branch.
+
+    When small.length < large.length, identical to V3_hybrid (the
+    current production formula).  When small.length == large.length,
+    the extras loop has nothing to iterate, so we apply a single
+    elite-premium term: ``top_small · top_scarcity · equal_factor``.
+    """
+    small_top = pt.small_top()
+    top_gap = pt.top_gap()
+    top_scarcity = max(0.0, min(p["cap"], p["slope"] * top_gap - p["intercept"]))
+    sorted_small = pt.sorted_small()
+    sorted_large = pt.sorted_large()
+    if len(sorted_small) == len(sorted_large):
+        return small_top * top_scarcity * p["equal_factor"]
+    if len(sorted_small) > len(sorted_large):
+        return 0.0
+    total = 0.0
+    for i, extra in enumerate(pt.extras()):
+        extra_gap = max(0.0, (small_top - extra) / small_top) if small_top else 0.0
+        effective = top_scarcity + p["boost"] * max(0.0, extra_gap - top_gap)
+        effective = max(0.0, min(p["effective_cap"], effective))
+        total += extra * effective * (p["decay"] ** i)
+    return total
+
+
+def predict_v7_full_loop(pt: DataPoint, p: dict) -> float:
+    """V7: loop over every piece of the large side with positional decay.
+
+    V3_hybrid only iterates extras beyond the matched pair; V7 treats
+    all large-side pieces as contributing to the VA, which makes the
+    formula graceful at equal counts (no separate branch).  The first
+    matched piece is at p=0 with full weight; deeper pieces decay.
+    """
+    small_top = pt.small_top()
+    top_gap = pt.top_gap()
+    top_scarcity = max(0.0, min(p["cap"], p["slope"] * top_gap - p["intercept"]))
+    sorted_small = pt.sorted_small()
+    sorted_large = pt.sorted_large()
+    if len(sorted_small) > len(sorted_large):
+        return 0.0
+    total = 0.0
+    for i, piece in enumerate(sorted_large):
+        extra_gap = max(0.0, (small_top - piece) / small_top) if small_top else 0.0
+        effective = top_scarcity + p["boost"] * max(0.0, extra_gap - top_gap)
+        effective = max(0.0, min(p["effective_cap"], effective))
+        total += piece * effective * (p["decay"] ** i)
+    return total
+
+
 # ── Scoring + grid search ───────────────────────────────────────────────
 
 def errors(predict_fn, params: dict) -> list[tuple[str, float, float, float, str]]:
@@ -246,6 +355,20 @@ def _linspace(lo, hi, n):
 
 # ── Main ────────────────────────────────────────────────────────────────
 def main() -> None:
+    # Extend DATA with any observations collected via
+    # ``scripts/collect_ktc_va.py``.  The baseline 13 anchors stay
+    # in-source so the calibration always pins against the same
+    # reference set.
+    extra_points = load_observations()
+    if extra_points:
+        print(f"Loaded {len(extra_points)} observations from {DEFAULT_OBSERVATIONS}")
+        DATA.extend(extra_points)
+    else:
+        print(
+            f"No observations file at {DEFAULT_OBSERVATIONS} — calibrating "
+            f"against the {len(DATA)} in-source anchors only."
+        )
+
     # V1 — CURRENT PRODUCTION FORMULA.
     v1_prod = {"slope": 4.27, "intercept": 0.288, "cap": 0.64, "decay": 0.70}
     report(predict_v1_current, v1_prod, "V1 (current production)")
@@ -325,7 +448,41 @@ def main() -> None:
     )
     report(predict_v5_additive_with_roster, v5_best["params"], "V5 additive + roster floor (RMS)")
 
+    # V6 — V3 with equal-count elite-premium branch.
+    print("\n--- V6 grid refit ---")
+    v6_best = grid_search(
+        predict_v6_equal_count,
+        {
+            "slope": _linspace(3.0, 6.0, 7),
+            "intercept": _linspace(0.10, 0.50, 5),
+            "cap": _linspace(0.45, 1.10, 10),
+            "decay": _linspace(0.30, 0.90, 7),
+            "boost": _linspace(0.8, 2.0, 7),
+            "effective_cap": _linspace(0.80, 1.40, 7),
+            "equal_factor": _linspace(0.0, 1.20, 13),
+        },
+        metric="rms",
+    )
+    report(predict_v6_equal_count, v6_best["params"], "V6 equal-count extended (RMS)")
+
+    # V7 — full-loop over all large pieces (no separate extras slice).
+    print("\n--- V7 grid refit ---")
+    v7_best = grid_search(
+        predict_v7_full_loop,
+        {
+            "slope": _linspace(2.5, 5.5, 7),
+            "intercept": _linspace(0.10, 0.50, 5),
+            "cap": _linspace(0.35, 0.90, 8),
+            "decay": _linspace(0.20, 0.65, 7),
+            "boost": _linspace(0.4, 1.8, 8),
+            "effective_cap": _linspace(0.80, 1.40, 7),
+        },
+        metric="rms",
+    )
+    report(predict_v7_full_loop, v7_best["params"], "V7 full-loop (RMS)")
+
     # Summary ranking.
+    total_points = len(DATA)
     print("\n=== CANDIDATE RANKING (by RMS) ===")
     candidates = [
         ("V1 prod", predict_v1_current, v1_prod),
@@ -334,6 +491,8 @@ def main() -> None:
         ("V3", predict_v3_hybrid, v3_best["params"]),
         ("V4", predict_v4_additive, v4_best["params"]),
         ("V5", predict_v5_additive_with_roster, v5_best["params"]),
+        ("V6", predict_v6_equal_count, v6_best["params"]),
+        ("V7", predict_v7_full_loop, v7_best["params"]),
     ]
     for name, fn, params in candidates:
         errs = [abs(r[3]) for r in errors(fn, params)]
@@ -343,7 +502,7 @@ def main() -> None:
         over_10 = sum(1 for e in errs if e > 0.10)
         over_20 = sum(1 for e in errs if e > 0.20)
         print(f"  {name:<10}  rms={rms:5.2f}%  mean={mean:5.2f}%  max={mx:5.2f}%  "
-              f">10%: {over_10}/13  >20%: {over_20}/13")
+              f">10%: {over_10}/{total_points}  >20%: {over_20}/{total_points}")
 
 
 if __name__ == "__main__":

--- a/scripts/collect_ktc_va.py
+++ b/scripts/collect_ktc_va.py
@@ -81,16 +81,21 @@ def load_fixture(path: Path) -> list[dict]:
 
 
 def load_existing(path: Path) -> dict[str, dict]:
+    # File-doesn't-exist is the legitimate "fresh run" state — return
+    # an empty dict quietly.  Anything else (bad JSON, wrong shape,
+    # IO error) is real corruption: surface it so the run aborts
+    # before the next save_observations() overwrites the file with a
+    # tiny new dataset and permanently loses prior captures.
     if not path.exists():
         return {}
-    try:
-        with path.open("r", encoding="utf-8") as f:
-            payload = json.load(f)
-    except Exception:
-        return {}
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
     observations = payload.get("observations") if isinstance(payload, dict) else payload
     if not isinstance(observations, list):
-        return {}
+        raise ValueError(
+            f"{path}: expected an 'observations' list (or top-level array); "
+            f"got {type(observations).__name__}"
+        )
     return {o.get("label"): o for o in observations if isinstance(o, dict) and o.get("label")}
 
 
@@ -237,7 +242,13 @@ async def run(args: argparse.Namespace) -> int:
             print(f"No fixture entries match --only={args.only}")
             return 2
 
-    existing = {} if args.refresh else load_existing(Path(args.output))
+    # Always load prior observations — even on --refresh.  The
+    # refresh flag controls *which fixture entries get re-captured*,
+    # not whether to discard everything we've already saved.  Combined
+    # with --only the previous behaviour rewrote the file from scratch
+    # with only the filtered subset, silently deleting every other
+    # label.
+    existing = load_existing(Path(args.output))
     pending = [e for e in fixture if args.refresh or e["label"] not in existing]
     print(f"Fixture: {len(fixture)} trades  |  already captured: {len(fixture) - len(pending)}")
 
@@ -251,6 +262,7 @@ async def run(args: argparse.Namespace) -> int:
         print("FAIL: playwright not installed.  Run: pip install playwright && playwright install chromium")
         return 1
 
+    failures: list[tuple[str, str]] = []
     async with async_playwright() as pw:
         browser = await pw.chromium.launch(headless=not args.headed)
         context = await browser.new_context(
@@ -269,7 +281,9 @@ async def run(args: argparse.Namespace) -> int:
             try:
                 obs = await capture_trade(page, entry)
             except Exception as e:
-                print(f"    FAIL: {type(e).__name__}: {str(e)[:160]}")
+                msg = f"{type(e).__name__}: {str(e)[:160]}"
+                print(f"    FAIL: {msg}")
+                failures.append((label, msg))
                 continue
 
             t1 = sum(obs["team1Values"])
@@ -288,6 +302,14 @@ async def run(args: argparse.Namespace) -> int:
         await browser.close()
 
     print(f"\nWrote {len(existing)} observations to {args.output}")
+    if failures:
+        print(f"\n{len(failures)} of {len(pending)} captures FAILED:")
+        for label, msg in failures:
+            print(f"  - {label}: {msg}")
+        # Surface a nonzero exit code so shell scripts / CI / pre-commit
+        # hooks don't treat a partial run as success and let an
+        # incomplete observation set propagate into calibration.
+        return 1
     return 0
 
 

--- a/scripts/collect_ktc_va.py
+++ b/scripts/collect_ktc_va.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Collect KTC trade Value Adjustment observations for formula calibration.
+
+Reads trade shapes from ``scripts/ktc_va_fixture.json`` and writes
+observations to ``scripts/ktc_va_observations.json``.  Each observation
+captures the raw piece values (as KTC currently stamps them) and the
+``Value Adjustment`` KTC itself reports — so the ratios stay
+internally consistent even if KTC's absolute values drift later.
+
+**Must be run locally**, not from the Claude Code sandbox — the
+sandbox's egress proxy cannot negotiate TLS with keeptradecut.com
+(see ``scripts/check_ktc_health.py`` for the known failure mode).
+
+Typical workflow:
+    pip install playwright
+    playwright install chromium
+
+    # Collect observations (idempotent — re-run to pick up new
+    # fixture entries without recapturing already-captured trades).
+    python scripts/collect_ktc_va.py
+
+    # Commit the generated observations so the calibration script
+    # running in CI / in the sandbox can see them.
+    git add scripts/ktc_va_observations.json
+    git commit -m "data: refresh KTC VA observations"
+
+    # Refit the formula against the baseline 13 anchors + new
+    # observations.  Pick the winning V6/V7 params and port into
+    # frontend/lib/trade-logic.js.
+    python scripts/calibrate_va_formula.py
+
+Options:
+    --fixture PATH     alternative fixture JSON
+    --output PATH      alternative output JSON
+    --headed           run with visible browser (debugging)
+    --throttle-ms N    delay between trades (default 2500)
+    --only LABEL[,...] restrict to specific fixture labels
+    --refresh          recompute trades even if already captured
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FIXTURE = REPO_ROOT / "scripts" / "ktc_va_fixture.json"
+# Output lives alongside the fixture (inside ``scripts/``) instead of
+# the gitignored ``data/`` dir so the captured observations can be
+# committed and used by ``calibrate_va_formula.py``.
+DEFAULT_OUTPUT = REPO_ROOT / "scripts" / "ktc_va_observations.json"
+
+KTC_URL = "https://keeptradecut.com/trade-calculator"
+
+# ── DOM selectors ──────────────────────────────────────────────────────
+# These target the 2026-era KTC trade calculator layout.  If KTC
+# redesigns, adjust these four and the rest of the script keeps working.
+SEL_SEARCH_INPUT = 'input[placeholder="Search for a player"]'
+SEL_PLAYER_ROW = 'div.single-player-result, li.player-result, .trade-calc-player'
+SEL_VALUE_CELL = '.playerValue, .player-value, [class*="Value"]'
+SEL_VA_ROW = 'text=Value Adjustment'
+# The VA amount is typically in the same row — use a relative query.
+
+
+def load_fixture(path: Path) -> list[dict]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"Fixture at {path} must be a JSON array")
+    for i, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Fixture entry {i} is not an object")
+        for key in ("label", "team1", "team2"):
+            if key not in entry:
+                raise ValueError(f"Fixture entry {i} missing '{key}'")
+    return data
+
+
+def load_existing(path: Path) -> dict[str, dict]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except Exception:
+        return {}
+    observations = payload.get("observations") if isinstance(payload, dict) else payload
+    if not isinstance(observations, list):
+        return {}
+    return {o.get("label"): o for o in observations if isinstance(o, dict) and o.get("label")}
+
+
+def save_observations(path: Path, observations: dict[str, dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "capturedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "source": "https://keeptradecut.com/trade-calculator",
+        "observations": sorted(observations.values(), key=lambda o: o.get("label", "")),
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+    tmp.replace(path)
+
+
+def _parse_int(text: str) -> int | None:
+    if text is None:
+        return None
+    m = re.search(r"-?\d[\d,]*", text)
+    if not m:
+        return None
+    try:
+        return int(m.group(0).replace(",", ""))
+    except ValueError:
+        return None
+
+
+async def _add_player(page, team_idx: int, player_name: str, *, timeout: int = 15000) -> None:
+    """Add a single player to team_idx (0 or 1) via the search input."""
+    inputs = page.locator(SEL_SEARCH_INPUT)
+    count = await inputs.count()
+    if count <= team_idx:
+        raise RuntimeError(
+            f"KTC page shows {count} search inputs; expected at least {team_idx + 1}"
+        )
+    box = inputs.nth(team_idx)
+    await box.click()
+    await box.fill("")
+    await box.type(player_name, delay=40)
+    # KTC shows an autocomplete dropdown.  Prefer an exact-text match on
+    # the dropdown item to avoid picking the wrong autocomplete hit.
+    option = page.locator(
+        f'xpath=//*[self::li or self::div or self::button]'
+        f'[contains(@class, "result") or contains(@class, "option") or contains(@class, "suggest")]'
+        f'[.//text()[contains(., "{player_name}")] or normalize-space()="{player_name}"]'
+    ).first
+    await option.wait_for(state="visible", timeout=timeout)
+    await option.click()
+    # Give KTC a moment to stamp the row and recompute VA.
+    await page.wait_for_timeout(600)
+
+
+async def _clear_team(page, team_idx: int) -> None:
+    """Remove every player currently in team_idx's list."""
+    # KTC uses an 'x' button per row.  We look inside the section for
+    # team_idx and click remove buttons until no rows remain.
+    for _ in range(20):  # safety cap
+        close_buttons = page.locator(
+            f'xpath=(//*[contains(@class, "trade-calc-team") or contains(@class, "team-section")])[{team_idx + 1}]'
+            f'//button[contains(@class, "close") or contains(@class, "remove") or @aria-label="Remove"]'
+        )
+        remaining = await close_buttons.count()
+        if remaining == 0:
+            return
+        await close_buttons.first.click()
+        await page.wait_for_timeout(200)
+
+
+async def _read_trade_state(page) -> dict:
+    """Extract per-side player values and the KTC-reported VA."""
+    # Grab every player's displayed value, split by team section.
+    teams = page.locator(
+        'xpath=//*[contains(@class, "trade-calc-team") or contains(@class, "team-section")]'
+    )
+    team_count = await teams.count()
+    if team_count < 2:
+        raise RuntimeError(f"Expected 2 team sections, found {team_count}")
+
+    side_values: list[list[int]] = [[], []]
+    for i in range(min(2, team_count)):
+        cells = teams.nth(i).locator(SEL_VALUE_CELL)
+        n = await cells.count()
+        for j in range(n):
+            txt = (await cells.nth(j).inner_text()).strip()
+            v = _parse_int(txt)
+            if v is not None and v > 0:
+                side_values[i].append(v)
+
+    # VA is usually displayed in a row labeled "Value Adjustment" on the
+    # side receiving it.  Grab all text with that label and parse the
+    # sibling cell for a signed integer.
+    va_by_side: list[int] = [0, 0]
+    for i in range(2):
+        row = teams.nth(i).locator('xpath=.//*[contains(text(), "Value Adjustment")]/..')
+        if await row.count() == 0:
+            continue
+        va_text = await row.first.inner_text()
+        v = _parse_int(va_text)
+        if v is not None:
+            va_by_side[i] = v
+
+    return {"sideValues": side_values, "valueAdjustments": va_by_side}
+
+
+async def capture_trade(page, entry: dict) -> dict:
+    """Navigate fresh, add both teams, capture the VA observation."""
+    await page.goto(KTC_URL, wait_until="domcontentloaded", timeout=30000)
+    # Let any blocking modals/banners dismiss on their own.
+    await page.wait_for_timeout(800)
+    # KTC sometimes retains prior state — do a belt-and-suspenders clear.
+    await _clear_team(page, 0)
+    await _clear_team(page, 1)
+
+    for name in entry.get("team1", []):
+        await _add_player(page, 0, name)
+    for name in entry.get("team2", []):
+        await _add_player(page, 1, name)
+
+    # Settle for VA recompute.
+    await page.wait_for_timeout(900)
+    state = await _read_trade_state(page)
+
+    return {
+        "label": entry["label"],
+        "topology": entry.get("topology", ""),
+        "notes": entry.get("notes", ""),
+        "team1Names": entry.get("team1", []),
+        "team2Names": entry.get("team2", []),
+        "team1Values": state["sideValues"][0],
+        "team2Values": state["sideValues"][1],
+        "valueAdjustmentTeam1": state["valueAdjustments"][0],
+        "valueAdjustmentTeam2": state["valueAdjustments"][1],
+        "capturedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+async def run(args: argparse.Namespace) -> int:
+    fixture = load_fixture(Path(args.fixture))
+    if args.only:
+        whitelist = {s.strip() for s in args.only.split(",")}
+        fixture = [e for e in fixture if e["label"] in whitelist]
+        if not fixture:
+            print(f"No fixture entries match --only={args.only}")
+            return 2
+
+    existing = {} if args.refresh else load_existing(Path(args.output))
+    pending = [e for e in fixture if args.refresh or e["label"] not in existing]
+    print(f"Fixture: {len(fixture)} trades  |  already captured: {len(fixture) - len(pending)}")
+
+    if not pending:
+        print("Nothing to do.  Use --refresh to recapture.")
+        return 0
+
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError:
+        print("FAIL: playwright not installed.  Run: pip install playwright && playwright install chromium")
+        return 1
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=not args.headed)
+        context = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/122.0.0.0 Safari/537.36"
+            ),
+            viewport={"width": 1280, "height": 900},
+        )
+        page = await context.new_page()
+
+        for idx, entry in enumerate(pending):
+            label = entry["label"]
+            print(f"[{idx + 1}/{len(pending)}] {label} ({entry.get('topology', '?')})")
+            try:
+                obs = await capture_trade(page, entry)
+            except Exception as e:
+                print(f"    FAIL: {type(e).__name__}: {str(e)[:160]}")
+                continue
+
+            t1 = sum(obs["team1Values"])
+            t2 = sum(obs["team2Values"])
+            va1 = obs["valueAdjustmentTeam1"]
+            va2 = obs["valueAdjustmentTeam2"]
+            print(
+                f"    team1={obs['team1Values']} (Σ={t1})  "
+                f"team2={obs['team2Values']} (Σ={t2})  "
+                f"VA=[{va1}, {va2}]"
+            )
+            existing[label] = obs
+            save_observations(Path(args.output), existing)
+            await page.wait_for_timeout(args.throttle_ms)
+
+        await browser.close()
+
+    print(f"\nWrote {len(existing)} observations to {args.output}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--fixture", default=str(DEFAULT_FIXTURE))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--headed", action="store_true", help="run with visible browser")
+    parser.add_argument("--throttle-ms", type=int, default=2500, help="delay between trades")
+    parser.add_argument("--only", default="", help="comma-separated labels to capture (default: all)")
+    parser.add_argument("--refresh", action="store_true", help="recompute even if observation exists")
+    args = parser.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ktc_va_fixture.json
+++ b/scripts/ktc_va_fixture.json
@@ -1,0 +1,117 @@
+[
+  {
+    "label": "EQ_1v1_low",
+    "topology": "1v1",
+    "notes": "Top-gap ~6%. Expect VA=0 on KTC — scarcity below threshold.",
+    "team1": ["Josh Allen"],
+    "team2": ["Ja'Marr Chase"]
+  },
+  {
+    "label": "EQ_1v1_mid",
+    "topology": "1v1",
+    "notes": "Top-gap ~25%. Mid elite vs second-tier elite.",
+    "team1": ["Ja'Marr Chase"],
+    "team2": ["Justin Jefferson"]
+  },
+  {
+    "label": "EQ_1v1_high",
+    "topology": "1v1",
+    "notes": "Top-gap ~60%. Super-elite vs midtier.",
+    "team1": ["Ja'Marr Chase"],
+    "team2": ["T.J. Hockenson"]
+  },
+
+  {
+    "label": "EQ_2v2_jefferson_mckee_vs_pick_hockenson",
+    "topology": "2v2",
+    "notes": "Anchor point — KTC observed 2026-04 as VA=+3610 on team1.",
+    "team1": ["Justin Jefferson", "Tanner McKee"],
+    "team2": ["2026 Pick 1.09", "T.J. Hockenson"]
+  },
+  {
+    "label": "EQ_2v2_matched_depth",
+    "topology": "2v2",
+    "notes": "Similar topGap to anchor but matched depth (no throw-in).",
+    "team1": ["Justin Jefferson", "T.J. Hockenson"],
+    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09"]
+  },
+  {
+    "label": "EQ_2v2_small_gap",
+    "topology": "2v2",
+    "notes": "Near-matched tops, slight depth edge.",
+    "team1": ["Ja'Marr Chase", "T.J. Hockenson"],
+    "team2": ["Justin Jefferson", "Brian Thomas Jr."]
+  },
+  {
+    "label": "EQ_2v2_throw_in",
+    "topology": "2v2",
+    "notes": "Elite + deep junk vs two solid midtier.",
+    "team1": ["Ja'Marr Chase", "Tanner McKee"],
+    "team2": ["T.J. Hockenson", "Brian Thomas Jr."]
+  },
+
+  {
+    "label": "EQ_3v3_elite_vs_depth",
+    "topology": "3v3",
+    "notes": "Elite top + weak depth vs three balanced midtier.",
+    "team1": ["Justin Jefferson", "T.J. Hockenson", "Tanner McKee"],
+    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09", "T.J. Hockenson"]
+  },
+  {
+    "label": "EQ_3v3_matched",
+    "topology": "3v3",
+    "notes": "Three-for-three with roughly matched pieces.",
+    "team1": ["Justin Jefferson", "Ja'Marr Chase", "Josh Allen"],
+    "team2": ["Patrick Mahomes", "CeeDee Lamb", "Puka Nacua"]
+  },
+
+  {
+    "label": "UNEQ_1v2_high_gap",
+    "topology": "1v2",
+    "notes": "topGap ~50%. Tests cap-bound regime unequal.",
+    "team1": ["Ja'Marr Chase"],
+    "team2": ["T.J. Hockenson", "2026 Pick 1.09"]
+  },
+  {
+    "label": "UNEQ_1v2_matched_pair",
+    "topology": "1v2",
+    "notes": "Elite vs two near-matching mids — extras loop baseline.",
+    "team1": ["Justin Jefferson"],
+    "team2": ["Brian Thomas Jr.", "T.J. Hockenson"]
+  },
+  {
+    "label": "UNEQ_1v3_extreme",
+    "topology": "1v3",
+    "notes": "One elite vs three midtier, all extras should boost.",
+    "team1": ["Ja'Marr Chase"],
+    "team2": ["T.J. Hockenson", "2026 Pick 1.09", "Brian Thomas Jr."]
+  },
+  {
+    "label": "UNEQ_2v3_jefferson_mckee_vs_triple",
+    "topology": "2v3",
+    "notes": "Anchor — KTC observed 2026-04 as VA=+4187 on team1.",
+    "team1": ["Justin Jefferson", "Tanner McKee"],
+    "team2": ["2026 Pick 1.09", "T.J. Hockenson", "Brian Thomas Jr."]
+  },
+  {
+    "label": "UNEQ_2v3_balanced",
+    "topology": "2v3",
+    "notes": "Two near-matched elites vs three mids — tests topGap at cap.",
+    "team1": ["Justin Jefferson", "Ja'Marr Chase"],
+    "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "2026 Pick 1.09"]
+  },
+  {
+    "label": "UNEQ_2v4_throw_ins",
+    "topology": "2v4",
+    "notes": "Two-for-four with deep extras — decay should bite.",
+    "team1": ["Justin Jefferson", "T.J. Hockenson"],
+    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09", "Tanner McKee", "2026 Pick 2.01"]
+  },
+  {
+    "label": "UNEQ_1v4_decay",
+    "topology": "1v4",
+    "notes": "One superelite vs four mids — tests decay term sharply.",
+    "team1": ["Ja'Marr Chase"],
+    "team2": ["T.J. Hockenson", "2026 Pick 1.09", "Brian Thomas Jr.", "Tanner McKee"]
+  }
+]

--- a/scripts/ktc_va_fixture.json
+++ b/scripts/ktc_va_fixture.json
@@ -55,7 +55,7 @@
     "topology": "3v3",
     "notes": "Elite top + weak depth vs three balanced midtier.",
     "team1": ["Justin Jefferson", "T.J. Hockenson", "Tanner McKee"],
-    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09", "T.J. Hockenson"]
+    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09", "Sam LaPorta"]
   },
   {
     "label": "EQ_3v3_matched",


### PR DESCRIPTION
## Why
The current V2 VA formula in `trade-logic.js` was calibrated against 13 KTC data points that skew toward moderate top-gaps (`topGap ≤ 0.25`). Two recent KTC observations disagree materially:

| Case | Our V2 | KTC | Error |
|---|---|---|---|
| 2v2 `[7778,1305]` vs `[3844,3242]` | 0 | 3610 | −100% |
| 2v3 `[7778,1305]` vs `[4899,3844,3242]` | 2,751 | 4187 | −34% |

The 2v3 miss is in the *existing* unequal-count path — our `topScarcity` cap of 0.55 is clipping legitimate signal whenever top-gap ≥ 0.27. Fixing this requires more observations than are practical to gather by hand.

## What's in this PR
No production code changes. Three new pieces of calibration tooling:

1. **`scripts/collect_ktc_va.py`** — Playwright scraper that reads a fixture, drives KTC's trade calculator, and writes `{sideValues, valueAdjustment}` observations to `scripts/ktc_va_observations.json`. Idempotent and resumable.
2. **`scripts/ktc_va_fixture.json`** — 16 trades targeting the extreme-top regime (equal-count 1v1/2v2/3v3, unequal 1v2/1v3/2v3/2v4/1v4 with elite tops). Includes the two anchor points already seen in KTC screenshots.
3. **`scripts/calibrate_va_formula.py`** — extended with an observation loader + two new candidate families:
   - **V6**: V3_hybrid + explicit equal-count elite-premium branch.
   - **V7**: full-loop over every large-side piece with positional decay (handles equal counts without a separate branch).

## Why the scraper has to run locally
The sandbox's egress proxy cannot negotiate TLS with `keeptradecut.com` — it's a known failure mode already documented in `scripts/check_ktc_health.py`. Both curl and a headless Chromium hit the same proxy, so this can't be worked around here.

## Workflow
```bash
pip install playwright && playwright install chromium
python scripts/collect_ktc_va.py               # writes ktc_va_observations.json
git add scripts/ktc_va_observations.json
git commit -m "data: refresh KTC VA observations"
python scripts/calibrate_va_formula.py          # refits against baseline + new data
# → port the winning V6/V7 params into frontend/lib/trade-logic.js (separate PR)
```

## Caveats I want to flag
- DOM selectors are best-effort since I couldn't inspect live KTC from the sandbox. The four `SEL_*` constants at the top of `collect_ktc_va.py` are the first place to tweak if the autocomplete/row detection misfires.
- KTC's values drift over time. Observations capture both the input piece values and the reported VA together, so the ratios stay internally consistent even if KTC rebalances.

## Test plan
- [ ] `python scripts/collect_ktc_va.py --only EQ_2v2_jefferson_mckee_vs_pick_hockenson --headed` — confirms the DOM automation works against one known-anchor trade and returns VA=3610.
- [ ] Run the full fixture, commit the resulting JSON.
- [ ] `python scripts/calibrate_va_formula.py` — V1–V7 regression reports print, V6/V7 rank by RMS.
- [ ] Existing 13 anchors don't regress under the new candidate formulas (RMS within a few percent of the baseline).

https://claude.ai/code/session_01CUWaetCTP3Bo8Nh94ByoLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUWaetCTP3Bo8Nh94ByoLh)_