### PR TITLE
Fix 401 on trade history: forward session cookie through Next proxies

### DIFF
--- a/frontend/app/api/dynasty-data/route.js
+++ b/frontend/app/api/dynasty-data/route.js
@@ -16,11 +16,12 @@ const BACKEND_URL = (() => {
   }
 })();
 
-async function fetchFromBackendApi() {
+async function fetchFromBackendApi(cookie) {
   const ctl = new AbortController();
   const timer = setTimeout(() => ctl.abort(), 1500);
   try {
-    const res = await fetch(BACKEND_URL, { cache: "no-store", signal: ctl.signal });
+    const headers = cookie ? { Cookie: cookie } : undefined;
+    const res = await fetch(BACKEND_URL, { cache: "no-store", signal: ctl.signal, headers });
     if (!res.ok) return null;
     const data = await res.json();
     if (!data || typeof data !== "object") return null;
@@ -69,9 +70,10 @@ function newestFile(files) {
     .sort((a, b) => b.m - a.m)[0]?.f || null;
 }
 
-export async function GET() {
+export async function GET(request) {
   try {
-    const backendPayload = await fetchFromBackendApi();
+    const cookie = request.headers.get("cookie") || "";
+    const backendPayload = await fetchFromBackendApi(cookie);
     if (backendPayload) {
       return NextResponse.json({ ok: true, source: backendPayload.source, data: backendPayload.data });
     }

--- a/frontend/app/api/rankings/overrides/route.js
+++ b/frontend/app/api/rankings/overrides/route.js
@@ -41,9 +41,12 @@ export async function POST(request) {
   // board without clipping legitimate responses.
   const timer = setTimeout(() => ctl.abort(), 15000);
   try {
+    const cookie = request.headers.get("cookie") || "";
+    const headers = { "Content-Type": "application/json" };
+    if (cookie) headers.Cookie = cookie;
     const res = await fetch(forwardedUrl.toString(), {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(body || {}),
       signal: ctl.signal,
       cache: "no-store",


### PR DESCRIPTION
## Summary
- The Next.js API routes `frontend/app/api/dynasty-data/route.js` and `frontend/app/api/rankings/overrides/route.js` proxy to the FastAPI backend without forwarding the `jason_session` cookie.
- After the `_private_api_gate` middleware (`server.py:1836`) started gating private `/api/*` endpoints, proxied calls hit the auth gate without credentials and returned `401 auth_required`. Signed-in users saw `Failed to load dynasty data: 401 {"error":"auth_required",...}` on the trade history screen and any custom-source rankings page.
- Both proxies now extract the incoming `Cookie` header and forward it on the outbound `fetch`, matching the pattern already used in `frontend/app/api/auth/status/route.js`.
- `/api/draft-capital` is on the public allowlist (`server.py:1806`), so its proxy was intentionally left alone.

## Test plan
- [ ] Sign in and load `/trades` — dynasty data populates, no 401 banner.
- [ ] Toggle a source on `/settings` — overrides POST returns 200 and rankings update.
- [ ] Signed-out request to `/api/dynasty-data` still surfaces a 401 from the backend (proxy didn't accidentally swallow auth).
- [ ] `/api/draft-capital` (public) still works without a session.

https://claude.ai/code/session_0143WfrwVaan1YjsuK7Bva22

---
_Generated by [Claude Code](https://claude.ai/code/session_0143WfrwVaan1YjsuK7Bva22)_