### PR TITLE
fix: break the persistent 401 auth_required loop

### DIFF
--- a/frontend/components/useAuth.js
+++ b/frontend/components/useAuth.js
@@ -15,34 +15,53 @@ export function useAuth() {
 
   useEffect(() => {
     let active = true;
+    // sessionStorage can throw synchronously in strict privacy modes
+    // and locked-down WebViews — wrap every access so a thrown read
+    // can't abort the effect before ``setChecking(false)`` runs.
+    function readAuthCache() {
+      try {
+        return sessionStorage.getItem(AUTH_CHECK_KEY) === "true";
+      } catch {
+        return false;
+      }
+    }
+    function writeAuthCache(authed) {
+      try {
+        if (authed) sessionStorage.setItem(AUTH_CHECK_KEY, "true");
+        else sessionStorage.removeItem(AUTH_CHECK_KEY);
+      } catch {
+        // sessionStorage unavailable — accept the in-memory state.
+      }
+    }
+
     async function check() {
       // Stale-while-revalidate: paint optimistically from the cached
       // flag for fast first render, but ALWAYS re-verify against the
       // backend.  A stuck "authenticated=true" cache after the cookie
       // is gone is the entire reason this hook used to wedge users on
       // the dashboard with a 401-on-every-request loop.
-      const cached = sessionStorage.getItem(AUTH_CHECK_KEY);
-      if (cached === "true" && active) {
+      const cached = readAuthCache();
+      if (cached && active) {
         setAuthenticated(true);
         setChecking(false);
       }
       try {
         const res = await fetch("/api/auth/status", { credentials: "same-origin" });
-        if (!res.ok) {
-          sessionStorage.removeItem(AUTH_CHECK_KEY);
-          if (active) setAuthenticated(false);
-          return;
-        }
+        // /api/auth/status is public and reports unauthenticated
+        // users with 200 + {authenticated: false}, so a non-OK status
+        // here means a transient backend/proxy failure (5xx, 502
+        // during a deploy, nginx timeout).  Keep the optimistic state
+        // instead of forcing a sign-out on infra blips.
+        if (!res.ok) return;
         const data = await res.json();
         const authed = !!data.authenticated;
         if (active) setAuthenticated(authed);
-        if (authed) sessionStorage.setItem(AUTH_CHECK_KEY, "true");
-        else sessionStorage.removeItem(AUTH_CHECK_KEY);
+        writeAuthCache(authed);
       } catch {
         // Network failure: keep optimistic state if we had one,
         // otherwise fall to unauthenticated.  Don't clobber the cache
         // on transient errors.
-        if (active && cached !== "true") setAuthenticated(false);
+        if (active && !cached) setAuthenticated(false);
       } finally {
         if (active) setChecking(false);
       }

--- a/frontend/components/useAuth.js
+++ b/frontend/components/useAuth.js
@@ -16,30 +16,33 @@ export function useAuth() {
   useEffect(() => {
     let active = true;
     async function check() {
+      // Stale-while-revalidate: paint optimistically from the cached
+      // flag for fast first render, but ALWAYS re-verify against the
+      // backend.  A stuck "authenticated=true" cache after the cookie
+      // is gone is the entire reason this hook used to wedge users on
+      // the dashboard with a 401-on-every-request loop.
+      const cached = sessionStorage.getItem(AUTH_CHECK_KEY);
+      if (cached === "true" && active) {
+        setAuthenticated(true);
+        setChecking(false);
+      }
       try {
-        // Check sessionStorage first for fast re-renders
-        const cached = sessionStorage.getItem(AUTH_CHECK_KEY);
-        if (cached === "true") {
-          if (active) {
-            setAuthenticated(true);
-            setChecking(false);
-          }
-          return;
-        }
-
         const res = await fetch("/api/auth/status", { credentials: "same-origin" });
         if (!res.ok) {
+          sessionStorage.removeItem(AUTH_CHECK_KEY);
           if (active) setAuthenticated(false);
           return;
         }
         const data = await res.json();
         const authed = !!data.authenticated;
-        if (active) {
-          setAuthenticated(authed);
-          if (authed) sessionStorage.setItem(AUTH_CHECK_KEY, "true");
-        }
+        if (active) setAuthenticated(authed);
+        if (authed) sessionStorage.setItem(AUTH_CHECK_KEY, "true");
+        else sessionStorage.removeItem(AUTH_CHECK_KEY);
       } catch {
-        if (active) setAuthenticated(false);
+        // Network failure: keep optimistic state if we had one,
+        // otherwise fall to unauthenticated.  Don't clobber the cache
+        // on transient errors.
+        if (active && cached !== "true") setAuthenticated(false);
       } finally {
         if (active) setChecking(false);
       }

--- a/frontend/components/useAuth.js
+++ b/frontend/components/useAuth.js
@@ -51,8 +51,13 @@ export function useAuth() {
         // users with 200 + {authenticated: false}, so a non-OK status
         // here means a transient backend/proxy failure (5xx, 502
         // during a deploy, nginx timeout).  Keep the optimistic state
-        // instead of forcing a sign-out on infra blips.
-        if (!res.ok) return;
+        // when we had one (don't sign out a real session on infra
+        // blips); otherwise resolve to unauthenticated so callers
+        // that treat ``null`` as "still checking" don't wedge.
+        if (!res.ok) {
+          if (active && !cached) setAuthenticated(false);
+          return;
+        }
         const data = await res.json();
         const authed = !!data.authenticated;
         if (active) setAuthenticated(authed);

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -92,22 +92,26 @@ export function useDynastyData() {
         const message = err?.message || "Failed to load data";
         // A 401 here means the server-side session is gone (cookie
         // expired, deploy invalidated, allowlist rotated).  The
-        // sessionStorage auth cache in useAuth would otherwise keep
-        // the UI in a "signed-in but every fetch 401s" stuck state.
-        // Clear the cache and bounce to /login so the user can
-        // recover instead of staring at a persistent error banner.
-        // Skip the redirect when we're already on /login — otherwise
-        // a 401 from the data fetch would self-redirect into
-        // ``/login?next=%2Flogin...`` and trap the user in a loop on
-        // the login page itself.
+        // recovery is targeted at the original stuck-state bug:
+        // useAuth's sessionStorage cache says "signed-in" while
+        // every fetch 401s.  Only redirect when we have that cache
+        // flag set — otherwise we'd bounce unauthenticated visitors
+        // off PUBLIC_ROUTES (``/``, ``/draft-capital``, ``/trades``)
+        // where ``useDynastyData`` is hydrated but auth isn't
+        // required.  Also skip the redirect on /login itself to
+        // avoid a self-redirect loop on the login form.
         if (typeof window !== "undefined" && /\b401\b/.test(message)) {
+          let hadAuthCache = false;
           try {
+            hadAuthCache =
+              window.sessionStorage.getItem("next_auth_checked_v1") === "true";
             window.sessionStorage.removeItem("next_auth_checked_v1");
           } catch {
             // sessionStorage can throw in private mode — ignore.
           }
           const path = window.location.pathname || "";
-          if (path !== "/login" && !path.startsWith("/login/")) {
+          const onLogin = path === "/login" || path.startsWith("/login/");
+          if (hadAuthCache && !onLogin) {
             const next = encodeURIComponent(path + window.location.search);
             window.location.replace(`/login?next=${next}`);
             return;

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -96,17 +96,22 @@ export function useDynastyData() {
         // the UI in a "signed-in but every fetch 401s" stuck state.
         // Clear the cache and bounce to /login so the user can
         // recover instead of staring at a persistent error banner.
+        // Skip the redirect when we're already on /login — otherwise
+        // a 401 from the data fetch would self-redirect into
+        // ``/login?next=%2Flogin...`` and trap the user in a loop on
+        // the login page itself.
         if (typeof window !== "undefined" && /\b401\b/.test(message)) {
           try {
             window.sessionStorage.removeItem("next_auth_checked_v1");
           } catch {
             // sessionStorage can throw in private mode — ignore.
           }
-          const next = encodeURIComponent(
-            window.location.pathname + window.location.search,
-          );
-          window.location.replace(`/login?next=${next}`);
-          return;
+          const path = window.location.pathname || "";
+          if (path !== "/login" && !path.startsWith("/login/")) {
+            const next = encodeURIComponent(path + window.location.search);
+            window.location.replace(`/login?next=${next}`);
+            return;
+          }
         }
         setError(message);
       } finally {

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -89,7 +89,26 @@ export function useDynastyData() {
         }
       } catch (err) {
         if (!active) return;
-        setError(err?.message || "Failed to load data");
+        const message = err?.message || "Failed to load data";
+        // A 401 here means the server-side session is gone (cookie
+        // expired, deploy invalidated, allowlist rotated).  The
+        // sessionStorage auth cache in useAuth would otherwise keep
+        // the UI in a "signed-in but every fetch 401s" stuck state.
+        // Clear the cache and bounce to /login so the user can
+        // recover instead of staring at a persistent error banner.
+        if (typeof window !== "undefined" && /\b401\b/.test(message)) {
+          try {
+            window.sessionStorage.removeItem("next_auth_checked_v1");
+          } catch {
+            // sessionStorage can throw in private mode — ignore.
+          }
+          const next = encodeURIComponent(
+            window.location.pathname + window.location.search,
+          );
+          window.location.replace(`/login?next=${next}`);
+          return;
+        }
+        setError(message);
       } finally {
         if (active) setLoading(false);
       }

--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ Requirements:
 
 import asyncio
 import json
+import math
 import os
 import sys
 import threading
@@ -138,9 +139,11 @@ def _session_ttl_days_seconds(default_days: float = 30.0) -> int:
     raw = os.getenv("SESSION_TTL_DAYS", "")
     try:
         days = float(raw) if raw else default_days
-    except (TypeError, ValueError):
-        days = default_days
-    return int(days * 86400)
+        if not math.isfinite(days) or days <= 0:
+            days = default_days
+        return int(days * 86400)
+    except (TypeError, ValueError, OverflowError):
+        return int(default_days * 86400)
 
 
 JASON_AUTH_COOKIE_MAX_AGE = _session_ttl_days_seconds()
@@ -3746,7 +3749,6 @@ _ktc_cache = {"rookies": None, "fetched_at": 0}
 _KTC_CACHE_TTL = 6 * 3600  # 6 hours
 
 
-import math
 import re
 
 

--- a/server.py
+++ b/server.py
@@ -129,6 +129,10 @@ JASON_LOGIN_USERNAME = (os.getenv("JASON_LOGIN_USERNAME") or "jasonleetucker").s
 JASON_LOGIN_PASSWORD = (os.getenv("JASON_LOGIN_PASSWORD") or "Elliott21!").strip()
 JASON_AUTH_COOKIE_NAME = "jason_session"
 JASON_AUTH_COOKIE_SECURE = _env_bool("JASON_AUTH_COOKIE_SECURE", True)
+# Match the SQLite session TTL (SESSION_TTL_DAYS, default 30) so the
+# browser cookie outlives an iOS Safari tab eviction instead of dying
+# as a session cookie the first time the OS reclaims memory.
+JASON_AUTH_COOKIE_MAX_AGE = int(float(os.getenv("SESSION_TTL_DAYS", "30")) * 86400)
 
 # Private-app allowlist.  Only these Sleeper handles can sign in
 # via /api/auth/sleeper-login.  Anyone else — even with a valid
@@ -5216,6 +5220,7 @@ async def auth_login(request: Request):
         httponly=True,
         samesite="lax",
         secure=JASON_AUTH_COOKIE_SECURE,
+        max_age=JASON_AUTH_COOKIE_MAX_AGE,
     )
     return response
 
@@ -5355,6 +5360,7 @@ async def auth_sleeper_login(request: Request):
         httponly=True,
         samesite="lax",
         secure=JASON_AUTH_COOKIE_SECURE,
+        max_age=JASON_AUTH_COOKIE_MAX_AGE,
     )
     return response
 

--- a/server.py
+++ b/server.py
@@ -131,8 +131,19 @@ JASON_AUTH_COOKIE_NAME = "jason_session"
 JASON_AUTH_COOKIE_SECURE = _env_bool("JASON_AUTH_COOKIE_SECURE", True)
 # Match the SQLite session TTL (SESSION_TTL_DAYS, default 30) so the
 # browser cookie outlives an iOS Safari tab eviction instead of dying
-# as a session cookie the first time the OS reclaims memory.
-JASON_AUTH_COOKIE_MAX_AGE = int(float(os.getenv("SESSION_TTL_DAYS", "30")) * 86400)
+# as a session cookie the first time the OS reclaims memory.  Parse
+# defensively so a malformed env var (e.g. ``30d``) doesn't take the
+# whole server down at import time — fall back to the 30-day default.
+def _session_ttl_days_seconds(default_days: float = 30.0) -> int:
+    raw = os.getenv("SESSION_TTL_DAYS", "")
+    try:
+        days = float(raw) if raw else default_days
+    except (TypeError, ValueError):
+        days = default_days
+    return int(days * 86400)
+
+
+JASON_AUTH_COOKIE_MAX_AGE = _session_ttl_days_seconds()
 
 # Private-app allowlist.  Only these Sleeper handles can sign in
 # via /api/auth/sleeper-login.  Anyone else — even with a valid


### PR DESCRIPTION
## Summary

Users on iPhone Safari kept landing on the dashboard with `Failed to load dynasty data: 401 {"error":"auth_required","message":"Sign-in required."}` on every reload, even though the navbar showed them as signed in. Three compounding issues caused that wedge.

### Root cause

1. **`server.py` — auth cookie had no `max_age`.** It was a session cookie, so the first time iOS Safari evicted the tab from memory the cookie was gone — even though the SQLite-backed session row was still alive on the server.
2. **`frontend/components/useAuth.js` — short-circuit on a stale cache.** The hook returned `authenticated: true` whenever `sessionStorage["next_auth_checked_v1"]==="true"` and never re-verified against `/api/auth/status`. Once the cookie was gone, the UI stayed in a "signed-in but every fetch 401s" state forever.
3. **`frontend/components/useDynastyData.js` — no recovery on 401.** A 401 from `/api/dynasty-data` was rendered as an error string. Nothing cleared the stale cache or redirected to `/login`, so refreshing just hit the same loop.

### Fixes

- `server.py`: pin the auth cookie's `max_age` to `SESSION_TTL_DAYS` (default 30) so it survives a tab eviction and matches the persisted session TTL. Applied to both `/api/auth/login` and `/api/auth/sleeper-login` (the E2E test cookie's intentional 1h TTL is left alone).
- `useAuth`: switch to stale-while-revalidate. Paint optimistically from the cache for fast first render, but always re-check `/api/auth/status` and clear the cache when the server says we're not authenticated.
- `useDynastyData`: on a 401 from the data fetch, clear the auth cache and `window.location.replace('/login?next=<current-path>')` so the user can recover instead of staring at a persistent error banner.

## Test plan

- [ ] Sign in via Sleeper login on an iPhone, force-quit Safari, reopen the tab — confirm the session persists (cookie `max_age` set).
- [ ] Sign in, then manually clear the `jason_session` cookie in devtools and reload — confirm the UI redirects to `/login?next=...` instead of showing the 401 banner.
- [ ] Existing `tests/api/test_private_auth.py` still passes (cookie name assertion is unchanged; max_age is additive).
- [ ] Frontend `__tests__/site-overrides.test.js` exercises `fetchDynastyData` (lib function — unchanged); the hook changes are isolated.

---
_Generated by [Claude Code](https://claude.ai/code/session_014VVqsGUzohG7i9XQfRYxbV)_