### PR TITLE
Expand KTC VA fixture from 16 to 100 trades

### DIFF
--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -165,6 +165,19 @@ function sortedSideValues(side, valueMode, settings) {
  */
 function _vaFromSortedSides(small, large) {
   if (small.length === 0 || small[0] <= 0) return 0;
+  // KNOWN GAP — equal-count trades return 0 here.  V2 was fit
+  // against 13 KTC observations all of which were unequal-count
+  // (1v2, 1v3, 2v3, 3v5).  KTC's actual behavior on equal-count
+  // trades (e.g. the user-reported 2v2 Jefferson+McKee vs Pick
+  // 1.09+Hockenson where KTC awards +3,610) was not in the
+  // training set.
+  //
+  // The fix lives in scripts/ — once the 100-trade scrape lands
+  // and the V8 (stud-factor + full-loop) candidate from
+  // calibrate_va_formula.py wins the grid search, this gate is
+  // replaced with the V8 formula which is smooth across the
+  // count boundary by construction.  See PR #283 + the V8 docstring
+  // in scripts/calibrate_va_formula.py.
   if (small.length >= large.length) return 0;
 
   const topSmall = small[0];

--- a/scripts/calibrate_va_formula.py
+++ b/scripts/calibrate_va_formula.py
@@ -345,6 +345,48 @@ def predict_v7_full_loop(pt: DataPoint, p: dict) -> float:
     return total
 
 
+def predict_v8_stud_factor(pt: DataPoint, p: dict) -> float:
+    """V8: V7 full-loop + an explicit ``stud factor`` magnitude term.
+
+    Motivation — KTC's own FAQ for Value Adjustment names ``"stud
+    factor"`` as a distinct input alongside value-difference and
+    lesser-piece-count.  V7's per-piece weight is purely ratio-based
+    (``top_gap`` is a percentage), so a 9000-vs-5000 trade and a
+    4500-vs-2500 trade get identical per-piece weights even though
+    the first one involves a true stud.  V8 amplifies the per-piece
+    weight when the small side's top piece is elite in absolute
+    terms::
+
+        stud_excess = max(0, top_small - stud_threshold) / 10000
+        stud_mult   = 1 + stud_coeff · stud_excess
+
+    When ``stud_coeff = 0`` V8 collapses to V7 exactly — so the grid
+    search will tell us if the stud factor adds real signal or is
+    just absorbed by the existing terms.  Threshold defaults to
+    7000 (loosely "top-50 dynasty value" on the 0-9999 canonical
+    scale) but is also a grid-searched parameter.
+    """
+    small_top = pt.small_top()
+    top_gap = pt.top_gap()
+    top_scarcity = max(0.0, min(p["cap"], p["slope"] * top_gap - p["intercept"]))
+    sorted_small = pt.sorted_small()
+    sorted_large = pt.sorted_large()
+    if len(sorted_small) > len(sorted_large):
+        return 0.0
+
+    stud_threshold = p.get("stud_threshold", 7000.0)
+    stud_excess = max(0.0, small_top - stud_threshold) / 10000.0
+    stud_mult = 1.0 + p["stud_coeff"] * stud_excess
+
+    total = 0.0
+    for i, piece in enumerate(sorted_large):
+        extra_gap = max(0.0, (small_top - piece) / small_top) if small_top else 0.0
+        effective = top_scarcity + p["boost"] * max(0.0, extra_gap - top_gap)
+        effective = max(0.0, min(p["effective_cap"], effective))
+        total += piece * effective * (p["decay"] ** i) * stud_mult
+    return total
+
+
 # ── Scoring + grid search ───────────────────────────────────────────────
 
 # Floor for the relative-error divisor.  Dividing by pt.ktc_va is
@@ -548,6 +590,34 @@ def main() -> None:
     )
     report(predict_v7_full_loop, v7_best["params"], "V7 full-loop (RMS)")
 
+    # V8 — V7 + stud-factor magnitude term.
+    # KTC's FAQ explicitly names "stud factor" as a distinct input.
+    # V7's per-piece weight is purely ratio-based (top_gap is a
+    # percentage), so V8 adds a multiplier that amplifies elite-top-
+    # piece trades.  When stud_coeff=0 V8 collapses to V7 exactly,
+    # so the grid search can decide whether the stud term improves
+    # the fit or is just absorbed by other parameters.
+    #
+    # Grid is intentionally wider on stud_coeff (0.0 to 1.5) so the
+    # search can choose to NOT apply it (coeff=0).  Threshold range
+    # 5000-8500 spans "top-100 dynasty" through "top-25 elite-only".
+    print("\n--- V8 grid refit ---")
+    v8_best = grid_search(
+        predict_v8_stud_factor,
+        {
+            "slope": _linspace(2.5, 5.5, 6),
+            "intercept": _linspace(0.10, 0.50, 4),
+            "cap": _linspace(0.35, 0.90, 6),
+            "decay": _linspace(0.20, 0.65, 5),
+            "boost": _linspace(0.4, 1.8, 6),
+            "effective_cap": _linspace(0.80, 1.40, 5),
+            "stud_coeff": _linspace(0.0, 1.5, 7),
+            "stud_threshold": [5000.0, 6500.0, 7000.0, 7500.0, 8500.0],
+        },
+        metric="rms",
+    )
+    report(predict_v8_stud_factor, v8_best["params"], "V8 stud-factor (RMS)")
+
     # Summary ranking.
     total_points = len(DATA)
     print("\n=== CANDIDATE RANKING (by RMS) ===")
@@ -560,6 +630,7 @@ def main() -> None:
         ("V5", predict_v5_additive_with_roster, v5_best["params"]),
         ("V6", predict_v6_equal_count, v6_best["params"]),
         ("V7", predict_v7_full_loop, v7_best["params"]),
+        ("V8", predict_v8_stud_factor, v8_best["params"]),
     ]
     for name, fn, params in candidates:
         errs = [abs(r[3]) for r in errors(fn, params)]

--- a/scripts/calibrate_va_formula.py
+++ b/scripts/calibrate_va_formula.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_OBSERVATIONS = REPO_ROOT / "scripts" / "ktc_va_observations.json"
+DEFAULT_FIXTURE = REPO_ROOT / "scripts" / "ktc_va_fixture.json"
 
 
 @dataclass(frozen=True)
@@ -69,8 +70,33 @@ class DataPoint:
         return self.sorted_small()[0] if self.small else 0.0
 
 
-def load_observations(path: Path = DEFAULT_OBSERVATIONS) -> list[DataPoint]:
-    """Load observations from ``data/ktc_va_observations.json``.
+def _load_fixture_labels(fixture_path: Path) -> set[str] | None:
+    """Return the set of labels currently in the fixture, or None when
+    the fixture is missing or unreadable (in which case we skip the
+    orphan-filter step rather than fail).  The fixture itself is
+    committed and should always be present in normal usage; this is
+    purely defensive."""
+    if not fixture_path.exists():
+        return None
+    try:
+        with fixture_path.open("r", encoding="utf-8") as f:
+            entries = json.load(f)
+    except Exception:
+        return None
+    if not isinstance(entries, list):
+        return None
+    labels: set[str] = set()
+    for e in entries:
+        if isinstance(e, dict) and isinstance(e.get("label"), str):
+            labels.add(e["label"])
+    return labels or None
+
+
+def load_observations(
+    path: Path = DEFAULT_OBSERVATIONS,
+    fixture_path: Path = DEFAULT_FIXTURE,
+) -> list[DataPoint]:
+    """Load observations from ``scripts/ktc_va_observations.json``.
 
     Each observation is converted to a DataPoint.  The ``small`` side is
     the one with fewer pieces (unequal) or higher top asset (equal) —
@@ -78,6 +104,14 @@ def load_observations(path: Path = DEFAULT_OBSERVATIONS) -> list[DataPoint]:
     reportable VA (``valueAdjustmentTeam1 == 0`` AND
     ``valueAdjustmentTeam2 == 0``) are still loaded with ktc_va=0 so
     the fit can honor the "no adjustment" signal.
+
+    Observations whose label is no longer present in the current fixture
+    are silently skipped (with a warning printed so the orphan count is
+    visible).  This prevents stale carryover when the fixture is
+    renamed or trimmed: ``collect_ktc_va.py`` doesn't prune stale
+    captures from the JSON, so without this filter a renamed fixture
+    would mix old + new datasets and quietly bias the fit toward
+    whichever local capture history a developer happens to have.
     """
     # "File doesn't exist" is a legitimate state (no observations
     # captured yet); fall through quietly and let main() print a
@@ -126,6 +160,19 @@ def load_observations(path: Path = DEFAULT_OBSERVATIONS) -> list[DataPoint]:
         large = tuple(sorted(team2 if small_is_team1 else team1, reverse=True))
         ktc_va = va1 if small_is_team1 else va2
         points.append(DataPoint(label, small, large, float(ktc_va), topo))
+
+    fixture_labels = _load_fixture_labels(fixture_path)
+    if fixture_labels is not None:
+        kept = [p for p in points if p.label in fixture_labels]
+        orphans = [p.label for p in points if p.label not in fixture_labels]
+        if orphans:
+            preview = ", ".join(orphans[:5])
+            suffix = f", … (+{len(orphans) - 5} more)" if len(orphans) > 5 else ""
+            print(
+                f"WARNING: {len(orphans)} observation(s) have labels not in "
+                f"current fixture {fixture_path.name}; skipping: {preview}{suffix}"
+            )
+        return kept
     return points
 
 

--- a/scripts/ktc_va_fixture.json
+++ b/scripts/ktc_va_fixture.json
@@ -9,7 +9,7 @@
   { "label": "UNEQ_1v2_a", "topology": "1v2", "notes": "Stud WR vs two midtiers (matched depth).", "team1": ["Ja'Marr Chase"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson"] },
   { "label": "UNEQ_1v2_b", "topology": "1v2", "notes": "Stud WR vs midtier + pick.", "team1": ["Ja'Marr Chase"], "team2": ["Brian Thomas Jr.", "2026 Pick 1.09"] },
   { "label": "UNEQ_1v2_c", "topology": "1v2", "notes": "Elite WR vs solid + throw-in.", "team1": ["Justin Jefferson"], "team2": ["DeVonta Smith", "Tanner McKee"] },
-  { "label": "UNEQ_1v2_d", "topology": "1v2", "notes": "Elite QB vs two midtier WRs.", "team1": ["Josh Allen"], "team2": ["DJ Moore", "George Pickens"] },
+  { "label": "UNEQ_1v2_d", "topology": "1v2", "notes": "Elite QB vs two midtier WRs.", "team1": ["Josh Allen"], "team2": ["D.J. Moore", "George Pickens"] },
   { "label": "UNEQ_1v2_e", "topology": "1v2", "notes": "Elite RB vs two depth pieces.", "team1": ["Bijan Robinson"], "team2": ["Mark Andrews", "Bo Nix"] },
   { "label": "UNEQ_1v2_f", "topology": "1v2", "notes": "Stud WR vs two near-matching elites — small topGap.", "team1": ["Ja'Marr Chase"], "team2": ["Patrick Mahomes", "Drake London"] },
   { "label": "UNEQ_1v2_g", "topology": "1v2", "notes": "Mid WR + pick vs another mid WR + pick.", "team1": ["Brian Thomas Jr."], "team2": ["DeVonta Smith", "2026 Pick 2.01"] },
@@ -59,7 +59,7 @@
   { "label": "UNEQ_2v4_a", "topology": "2v4", "notes": "Two elites vs four mids — decay sweep.", "team1": ["Ja'Marr Chase", "Justin Jefferson"], "team2": ["T.J. Hockenson", "Brian Thomas Jr.", "Mark Andrews", "2026 Pick 1.09"] },
   { "label": "UNEQ_2v4_b", "topology": "2v4", "notes": "Elite + mid vs four throw-ins.", "team1": ["Justin Jefferson", "T.J. Hockenson"], "team2": ["Bo Nix", "Mark Andrews", "Geno Smith", "Tanner McKee"] },
   { "label": "UNEQ_2v4_c", "topology": "2v4", "notes": "Elite + pick vs four picks.", "team1": ["Ja'Marr Chase", "2026 Pick 1.09"], "team2": ["2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st", "2028 1st"] },
-  { "label": "UNEQ_2v4_d", "topology": "2v4", "notes": "Two QBs vs four mid skills.", "team1": ["Patrick Mahomes", "Josh Allen"], "team2": ["DeVonta Smith", "T.J. Hockenson", "DJ Moore", "George Pickens"] },
+  { "label": "UNEQ_2v4_d", "topology": "2v4", "notes": "Two QBs vs four mid skills.", "team1": ["Patrick Mahomes", "Josh Allen"], "team2": ["DeVonta Smith", "T.J. Hockenson", "D.J. Moore", "George Pickens"] },
   { "label": "UNEQ_2v4_e", "topology": "2v4", "notes": "Two elites vs four mids (matched depth).", "team1": ["Bijan Robinson", "Jahmyr Gibbs"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson", "Sam LaPorta"] },
   { "label": "UNEQ_2v4_f", "topology": "2v4", "notes": "Mid stud + junk vs four mids.", "team1": ["Brian Thomas Jr.", "Tanner McKee"], "team2": ["T.J. Hockenson", "Mark Andrews", "George Pickens", "Bo Nix"] },
 

--- a/scripts/ktc_va_fixture.json
+++ b/scripts/ktc_va_fixture.json
@@ -58,7 +58,7 @@
 
   { "label": "UNEQ_2v4_a", "topology": "2v4", "notes": "Two elites vs four mids — decay sweep.", "team1": ["Ja'Marr Chase", "Justin Jefferson"], "team2": ["T.J. Hockenson", "Brian Thomas Jr.", "Mark Andrews", "2026 Pick 1.09"] },
   { "label": "UNEQ_2v4_b", "topology": "2v4", "notes": "Elite + mid vs four throw-ins.", "team1": ["Justin Jefferson", "T.J. Hockenson"], "team2": ["Bo Nix", "Mark Andrews", "Geno Smith", "Tanner McKee"] },
-  { "label": "UNEQ_2v4_c", "topology": "2v4", "notes": "Elite + pick vs four picks.", "team1": ["Ja'Marr Chase", "2026 Pick 1.09"], "team2": ["2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st", "2028 1st"] },
+  { "label": "UNEQ_2v4_c", "topology": "2v4", "notes": "Elite + pick vs four picks.", "team1": ["Ja'Marr Chase", "2026 Pick 1.09"], "team2": ["2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st", "2028 Mid 1st"] },
   { "label": "UNEQ_2v4_d", "topology": "2v4", "notes": "Two QBs vs four mid skills.", "team1": ["Patrick Mahomes", "Josh Allen"], "team2": ["DeVonta Smith", "T.J. Hockenson", "D.J. Moore", "George Pickens"] },
   { "label": "UNEQ_2v4_e", "topology": "2v4", "notes": "Two elites vs four mids (matched depth).", "team1": ["Bijan Robinson", "Jahmyr Gibbs"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson", "Sam LaPorta"] },
   { "label": "UNEQ_2v4_f", "topology": "2v4", "notes": "Mid stud + junk vs four mids.", "team1": ["Brian Thomas Jr.", "Tanner McKee"], "team2": ["T.J. Hockenson", "Mark Andrews", "George Pickens", "Bo Nix"] },
@@ -79,7 +79,7 @@
   { "label": "EQ_3v3_j", "topology": "3v3", "notes": "Two elites + pick vs elite + two mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "2026 Pick 1.09"], "team2": ["Bijan Robinson", "Drake London", "T.J. Hockenson"] },
   { "label": "EQ_3v3_k", "topology": "3v3", "notes": "Three matched throw-ins per side.", "team1": ["Tanner McKee", "Bo Nix", "Geno Smith"], "team2": ["Mark Andrews", "Aaron Rodgers", "Kirk Cousins"] },
   { "label": "EQ_3v3_l", "topology": "3v3", "notes": "Elite WR + two picks vs three solid players.", "team1": ["Justin Jefferson", "2026 Pick 1.09", "2026 Pick 2.01"], "team2": ["Brian Thomas Jr.", "DeVonta Smith", "T.J. Hockenson"] },
-  { "label": "EQ_3v3_m", "topology": "3v3", "notes": "Pick-heavy mirror — three picks each.", "team1": ["2026 Pick 1.09", "2027 Mid 1st", "2026 Pick 3.01"], "team2": ["2026 Pick 2.01", "2027 Late 1st", "2028 1st"] },
+  { "label": "EQ_3v3_m", "topology": "3v3", "notes": "Pick-heavy mirror — three picks each.", "team1": ["2026 Pick 1.09", "2027 Mid 1st", "2026 Pick 3.01"], "team2": ["2026 Pick 2.01", "2027 Late 1st", "2028 Mid 1st"] },
   { "label": "EQ_3v3_n", "topology": "3v3", "notes": "Stud + junk + junk vs balanced.", "team1": ["Ja'Marr Chase", "Tanner McKee", "Geno Smith"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Mark Andrews"] },
 
   { "label": "UNEQ_3v4_a", "topology": "3v4", "notes": "Three elites vs four mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Patrick Mahomes"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Drake London", "Mark Andrews"] },
@@ -93,7 +93,7 @@
   { "label": "UNEQ_3v5_a", "topology": "3v5", "notes": "Three elites vs five mids — heavy decay.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Bijan Robinson"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Drake London", "Mark Andrews", "2026 Pick 1.09"] },
   { "label": "UNEQ_3v5_b", "topology": "3v5", "notes": "Elite + two solid vs five spread.", "team1": ["Justin Jefferson", "Brian Thomas Jr.", "T.J. Hockenson"], "team2": ["DeVonta Smith", "Drake London", "Sam LaPorta", "Mark Andrews", "Tanner McKee"] },
   { "label": "UNEQ_3v5_c", "topology": "3v5", "notes": "Stud + two mids vs five throw-ins.", "team1": ["Ja'Marr Chase", "Brian Thomas Jr.", "T.J. Hockenson"], "team2": ["Mark Andrews", "Bo Nix", "George Pickens", "Geno Smith", "Tanner McKee"] },
-  { "label": "UNEQ_3v5_d", "topology": "3v5", "notes": "Pick-heavy receiving side.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Patrick Mahomes"], "team2": ["2026 Pick 1.09", "2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st", "2028 1st"] },
+  { "label": "UNEQ_3v5_d", "topology": "3v5", "notes": "Pick-heavy receiving side.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Patrick Mahomes"], "team2": ["2026 Pick 1.09", "2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st", "2028 Mid 1st"] },
   { "label": "UNEQ_3v5_e", "topology": "3v5", "notes": "Three RBs vs five mid skills.", "team1": ["Bijan Robinson", "Jahmyr Gibbs", "Kyren Williams"], "team2": ["Drake London", "DeVonta Smith", "T.J. Hockenson", "Sam LaPorta", "Mark Andrews"] },
 
   { "label": "EQ_4v4_a", "topology": "4v4", "notes": "Four elites vs four mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Bijan Robinson", "Patrick Mahomes"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson", "DeVonta Smith"] },

--- a/scripts/ktc_va_fixture.json
+++ b/scripts/ktc_va_fixture.json
@@ -1,117 +1,116 @@
 [
-  {
-    "label": "EQ_1v1_low",
-    "topology": "1v1",
-    "notes": "Top-gap ~6%. Expect VA=0 on KTC — scarcity below threshold.",
-    "team1": ["Josh Allen"],
-    "team2": ["Ja'Marr Chase"]
-  },
-  {
-    "label": "EQ_1v1_mid",
-    "topology": "1v1",
-    "notes": "Top-gap ~25%. Mid elite vs second-tier elite.",
-    "team1": ["Ja'Marr Chase"],
-    "team2": ["Justin Jefferson"]
-  },
-  {
-    "label": "EQ_1v1_high",
-    "topology": "1v1",
-    "notes": "Top-gap ~60%. Super-elite vs midtier.",
-    "team1": ["Ja'Marr Chase"],
-    "team2": ["T.J. Hockenson"]
-  },
+  { "label": "EQ_1v1_a", "topology": "1v1", "notes": "Two top-tier WRs — minimal topGap.", "team1": ["Ja'Marr Chase"], "team2": ["Justin Jefferson"] },
+  { "label": "EQ_1v1_b", "topology": "1v1", "notes": "Top WR vs second-tier elite WR.", "team1": ["Ja'Marr Chase"], "team2": ["CeeDee Lamb"] },
+  { "label": "EQ_1v1_c", "topology": "1v1", "notes": "Elite WR vs midtier TE — ~50% topGap.", "team1": ["Justin Jefferson"], "team2": ["T.J. Hockenson"] },
+  { "label": "EQ_1v1_d", "topology": "1v1", "notes": "Elite RB vs depth piece.", "team1": ["Bijan Robinson"], "team2": ["George Pickens"] },
+  { "label": "EQ_1v1_e", "topology": "1v1", "notes": "Elite WR vs deep throw-in — extreme topGap.", "team1": ["Ja'Marr Chase"], "team2": ["Tanner McKee"] },
+  { "label": "EQ_1v1_f", "topology": "1v1", "notes": "Mid-elite QB vs mid-tier WR.", "team1": ["Patrick Mahomes"], "team2": ["DeVonta Smith"] },
 
-  {
-    "label": "EQ_2v2_jefferson_mckee_vs_pick_hockenson",
-    "topology": "2v2",
-    "notes": "Anchor point — KTC observed 2026-04 as VA=+3610 on team1.",
-    "team1": ["Justin Jefferson", "Tanner McKee"],
-    "team2": ["2026 Pick 1.09", "T.J. Hockenson"]
-  },
-  {
-    "label": "EQ_2v2_matched_depth",
-    "topology": "2v2",
-    "notes": "Similar topGap to anchor but matched depth (no throw-in).",
-    "team1": ["Justin Jefferson", "T.J. Hockenson"],
-    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09"]
-  },
-  {
-    "label": "EQ_2v2_small_gap",
-    "topology": "2v2",
-    "notes": "Near-matched tops, slight depth edge.",
-    "team1": ["Ja'Marr Chase", "T.J. Hockenson"],
-    "team2": ["Justin Jefferson", "Brian Thomas Jr."]
-  },
-  {
-    "label": "EQ_2v2_throw_in",
-    "topology": "2v2",
-    "notes": "Elite + deep junk vs two solid midtier.",
-    "team1": ["Ja'Marr Chase", "Tanner McKee"],
-    "team2": ["T.J. Hockenson", "Brian Thomas Jr."]
-  },
+  { "label": "UNEQ_1v2_a", "topology": "1v2", "notes": "Stud WR vs two midtiers (matched depth).", "team1": ["Ja'Marr Chase"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson"] },
+  { "label": "UNEQ_1v2_b", "topology": "1v2", "notes": "Stud WR vs midtier + pick.", "team1": ["Ja'Marr Chase"], "team2": ["Brian Thomas Jr.", "2026 Pick 1.09"] },
+  { "label": "UNEQ_1v2_c", "topology": "1v2", "notes": "Elite WR vs solid + throw-in.", "team1": ["Justin Jefferson"], "team2": ["DeVonta Smith", "Tanner McKee"] },
+  { "label": "UNEQ_1v2_d", "topology": "1v2", "notes": "Elite QB vs two midtier WRs.", "team1": ["Josh Allen"], "team2": ["DJ Moore", "George Pickens"] },
+  { "label": "UNEQ_1v2_e", "topology": "1v2", "notes": "Elite RB vs two depth pieces.", "team1": ["Bijan Robinson"], "team2": ["Mark Andrews", "Bo Nix"] },
+  { "label": "UNEQ_1v2_f", "topology": "1v2", "notes": "Stud WR vs two near-matching elites — small topGap.", "team1": ["Ja'Marr Chase"], "team2": ["Patrick Mahomes", "Drake London"] },
+  { "label": "UNEQ_1v2_g", "topology": "1v2", "notes": "Mid WR + pick vs another mid WR + pick.", "team1": ["Brian Thomas Jr."], "team2": ["DeVonta Smith", "2026 Pick 2.01"] },
+  { "label": "UNEQ_1v2_h", "topology": "1v2", "notes": "Top RB vs WR + pick consolidation.", "team1": ["Jahmyr Gibbs"], "team2": ["Garrett Wilson", "2026 Pick 1.09"] },
 
-  {
-    "label": "EQ_3v3_elite_vs_depth",
-    "topology": "3v3",
-    "notes": "Elite top + weak depth vs three balanced midtier.",
-    "team1": ["Justin Jefferson", "T.J. Hockenson", "Tanner McKee"],
-    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09", "Sam LaPorta"]
-  },
-  {
-    "label": "EQ_3v3_matched",
-    "topology": "3v3",
-    "notes": "Three-for-three with roughly matched pieces.",
-    "team1": ["Justin Jefferson", "Ja'Marr Chase", "Josh Allen"],
-    "team2": ["Patrick Mahomes", "CeeDee Lamb", "Puka Nacua"]
-  },
+  { "label": "UNEQ_1v3_a", "topology": "1v3", "notes": "Stud vs 3 midtiers — extras decay test.", "team1": ["Ja'Marr Chase"], "team2": ["T.J. Hockenson", "Brian Thomas Jr.", "2026 Pick 1.09"] },
+  { "label": "UNEQ_1v3_b", "topology": "1v3", "notes": "Elite vs 3 throw-ins.", "team1": ["Justin Jefferson"], "team2": ["Bo Nix", "Mark Andrews", "Tanner McKee"] },
+  { "label": "UNEQ_1v3_c", "topology": "1v3", "notes": "Top RB vs 3 mids — decay across positions.", "team1": ["Bijan Robinson"], "team2": ["Drake London", "T.J. Hockenson", "2026 Pick 2.01"] },
+  { "label": "UNEQ_1v3_d", "topology": "1v3", "notes": "QB vs 3 lower mids.", "team1": ["Patrick Mahomes"], "team2": ["George Pickens", "Mark Andrews", "Tanner McKee"] },
+  { "label": "UNEQ_1v3_e", "topology": "1v3", "notes": "Elite WR vs 3 picks (pick valuation).", "team1": ["Ja'Marr Chase"], "team2": ["2026 Pick 1.09", "2026 Pick 2.01", "2027 Mid 1st"] },
+  { "label": "UNEQ_1v3_f", "topology": "1v3", "notes": "Mid WR vs 3 deep throw-ins.", "team1": ["Brian Thomas Jr."], "team2": ["Mark Andrews", "Bo Nix", "Tanner McKee"] },
 
-  {
-    "label": "UNEQ_1v2_high_gap",
-    "topology": "1v2",
-    "notes": "topGap ~50%. Tests cap-bound regime unequal.",
-    "team1": ["Ja'Marr Chase"],
-    "team2": ["T.J. Hockenson", "2026 Pick 1.09"]
-  },
-  {
-    "label": "UNEQ_1v2_matched_pair",
-    "topology": "1v2",
-    "notes": "Elite vs two near-matching mids — extras loop baseline.",
-    "team1": ["Justin Jefferson"],
-    "team2": ["Brian Thomas Jr.", "T.J. Hockenson"]
-  },
-  {
-    "label": "UNEQ_1v3_extreme",
-    "topology": "1v3",
-    "notes": "One elite vs three midtier, all extras should boost.",
-    "team1": ["Ja'Marr Chase"],
-    "team2": ["T.J. Hockenson", "2026 Pick 1.09", "Brian Thomas Jr."]
-  },
-  {
-    "label": "UNEQ_2v3_jefferson_mckee_vs_triple",
-    "topology": "2v3",
-    "notes": "Anchor — KTC observed 2026-04 as VA=+4187 on team1.",
-    "team1": ["Justin Jefferson", "Tanner McKee"],
-    "team2": ["2026 Pick 1.09", "T.J. Hockenson", "Brian Thomas Jr."]
-  },
-  {
-    "label": "UNEQ_2v3_balanced",
-    "topology": "2v3",
-    "notes": "Two near-matched elites vs three mids — tests topGap at cap.",
-    "team1": ["Justin Jefferson", "Ja'Marr Chase"],
-    "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "2026 Pick 1.09"]
-  },
-  {
-    "label": "UNEQ_2v4_throw_ins",
-    "topology": "2v4",
-    "notes": "Two-for-four with deep extras — decay should bite.",
-    "team1": ["Justin Jefferson", "T.J. Hockenson"],
-    "team2": ["Brian Thomas Jr.", "2026 Pick 1.09", "Tanner McKee", "2026 Pick 2.01"]
-  },
-  {
-    "label": "UNEQ_1v4_decay",
-    "topology": "1v4",
-    "notes": "One superelite vs four mids — tests decay term sharply.",
-    "team1": ["Ja'Marr Chase"],
-    "team2": ["T.J. Hockenson", "2026 Pick 1.09", "Brian Thomas Jr.", "Tanner McKee"]
-  }
+  { "label": "UNEQ_1v4_a", "topology": "1v4", "notes": "Stud vs 4 mids — deep decay regime.", "team1": ["Ja'Marr Chase"], "team2": ["T.J. Hockenson", "Brian Thomas Jr.", "Mark Andrews", "Tanner McKee"] },
+  { "label": "UNEQ_1v4_b", "topology": "1v4", "notes": "Elite RB vs 4 throw-ins.", "team1": ["Bijan Robinson"], "team2": ["George Pickens", "Bo Nix", "Mark Andrews", "Tanner McKee"] },
+  { "label": "UNEQ_1v4_c", "topology": "1v4", "notes": "Elite WR vs 4 picks.", "team1": ["Justin Jefferson"], "team2": ["2026 Pick 1.09", "2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st"] },
+  { "label": "UNEQ_1v4_d", "topology": "1v4", "notes": "Mid QB vs 4 deep mids.", "team1": ["Justin Herbert"], "team2": ["Bo Nix", "Mark Andrews", "Geno Smith", "Tanner McKee"] },
+
+  { "label": "UNEQ_1v5_a", "topology": "1v5", "notes": "Stud vs 5 throw-ins — extreme decay test.", "team1": ["Ja'Marr Chase"], "team2": ["T.J. Hockenson", "Mark Andrews", "Bo Nix", "Geno Smith", "Tanner McKee"] },
+  { "label": "UNEQ_1v5_b", "topology": "1v5", "notes": "Elite WR vs 5 mid pieces.", "team1": ["Justin Jefferson"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "2026 Pick 1.09", "2026 Pick 2.01", "Tanner McKee"] },
+
+  { "label": "EQ_2v2_a", "topology": "2v2", "notes": "Anchor — KTC observed 2026-04 as VA=+3610.", "team1": ["Justin Jefferson", "Tanner McKee"], "team2": ["2026 Pick 1.09", "T.J. Hockenson"] },
+  { "label": "EQ_2v2_b", "topology": "2v2", "notes": "Two elites vs two solid mids.", "team1": ["Ja'Marr Chase", "Patrick Mahomes"], "team2": ["Brian Thomas Jr.", "Drake London"] },
+  { "label": "EQ_2v2_c", "topology": "2v2", "notes": "Elite + throw-in vs two midtiers.", "team1": ["Ja'Marr Chase", "Tanner McKee"], "team2": ["T.J. Hockenson", "Brian Thomas Jr."] },
+  { "label": "EQ_2v2_d", "topology": "2v2", "notes": "Matched-depth (no throw-in).", "team1": ["Justin Jefferson", "T.J. Hockenson"], "team2": ["Brian Thomas Jr.", "2026 Pick 1.09"] },
+  { "label": "EQ_2v2_e", "topology": "2v2", "notes": "Near-equal tops, slight depth edge.", "team1": ["Ja'Marr Chase", "T.J. Hockenson"], "team2": ["Justin Jefferson", "Brian Thomas Jr."] },
+  { "label": "EQ_2v2_f", "topology": "2v2", "notes": "Two RBs vs two WRs (similar tier).", "team1": ["Bijan Robinson", "Jahmyr Gibbs"], "team2": ["Puka Nacua", "Drake London"] },
+  { "label": "EQ_2v2_g", "topology": "2v2", "notes": "Elite + pick vs two mids.", "team1": ["Justin Jefferson", "2026 Pick 1.09"], "team2": ["DeVonta Smith", "Brian Thomas Jr."] },
+  { "label": "EQ_2v2_h", "topology": "2v2", "notes": "Matched throw-in case (mirror of c).", "team1": ["T.J. Hockenson", "Brian Thomas Jr."], "team2": ["Ja'Marr Chase", "Tanner McKee"] },
+  { "label": "EQ_2v2_i", "topology": "2v2", "notes": "Two QBs vs two WRs.", "team1": ["Patrick Mahomes", "Josh Allen"], "team2": ["Puka Nacua", "Garrett Wilson"] },
+  { "label": "EQ_2v2_j", "topology": "2v2", "notes": "Mid + low vs mid + low (low topGap).", "team1": ["Brian Thomas Jr.", "Tanner McKee"], "team2": ["DeVonta Smith", "Mark Andrews"] },
+  { "label": "EQ_2v2_k", "topology": "2v2", "notes": "Stud + junk vs two near-equals.", "team1": ["Ja'Marr Chase", "Geno Smith"], "team2": ["Drake London", "Brian Thomas Jr."] },
+  { "label": "EQ_2v2_l", "topology": "2v2", "notes": "Pick-heavy 2v2.", "team1": ["2026 Pick 1.09", "2027 Mid 1st"], "team2": ["T.J. Hockenson", "Mark Andrews"] },
+  { "label": "EQ_2v2_m", "topology": "2v2", "notes": "Two elites vs elite + pick.", "team1": ["Ja'Marr Chase", "Bijan Robinson"], "team2": ["Justin Jefferson", "2026 Pick 1.09"] },
+  { "label": "EQ_2v2_n", "topology": "2v2", "notes": "Tier C vs Tier D.", "team1": ["Sam LaPorta", "Justin Herbert"], "team2": ["Mark Andrews", "Bo Nix"] },
+
+  { "label": "UNEQ_2v3_a", "topology": "2v3", "notes": "Anchor — KTC observed 2026-04 as VA=+4187.", "team1": ["Justin Jefferson", "Tanner McKee"], "team2": ["2026 Pick 1.09", "T.J. Hockenson", "Brian Thomas Jr."] },
+  { "label": "UNEQ_2v3_b", "topology": "2v3", "notes": "Two elites vs three mids.", "team1": ["Justin Jefferson", "Ja'Marr Chase"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "2026 Pick 1.09"] },
+  { "label": "UNEQ_2v3_c", "topology": "2v3", "notes": "Elite + pick vs three balanced.", "team1": ["Ja'Marr Chase", "2026 Pick 1.09"], "team2": ["Drake London", "T.J. Hockenson", "Mark Andrews"] },
+  { "label": "UNEQ_2v3_d", "topology": "2v3", "notes": "Two mids vs three lower mids.", "team1": ["Brian Thomas Jr.", "DeVonta Smith"], "team2": ["T.J. Hockenson", "Mark Andrews", "George Pickens"] },
+  { "label": "UNEQ_2v3_e", "topology": "2v3", "notes": "Stud + throw-in vs three solid.", "team1": ["Ja'Marr Chase", "Tanner McKee"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "2026 Pick 1.09"] },
+  { "label": "UNEQ_2v3_f", "topology": "2v3", "notes": "Elite RB + WR vs three picks.", "team1": ["Bijan Robinson", "Garrett Wilson"], "team2": ["2026 Pick 1.09", "2026 Pick 2.01", "2027 Mid 1st"] },
+  { "label": "UNEQ_2v3_g", "topology": "2v3", "notes": "Two QBs vs three skill players.", "team1": ["Patrick Mahomes", "Josh Allen"], "team2": ["DeVonta Smith", "T.J. Hockenson", "George Pickens"] },
+  { "label": "UNEQ_2v3_h", "topology": "2v3", "notes": "Matched-tier 2v3 with depth.", "team1": ["Justin Jefferson", "Drake London"], "team2": ["Brian Thomas Jr.", "DeVonta Smith", "Sam LaPorta"] },
+  { "label": "UNEQ_2v3_i", "topology": "2v3", "notes": "Mid + throw-in vs three balanced.", "team1": ["Brian Thomas Jr.", "Tanner McKee"], "team2": ["Mark Andrews", "Bo Nix", "Geno Smith"] },
+  { "label": "UNEQ_2v3_j", "topology": "2v3", "notes": "Pick-heavy small side.", "team1": ["2026 Pick 1.09", "2026 Pick 2.01"], "team2": ["T.J. Hockenson", "Mark Andrews", "Tanner McKee"] },
+
+  { "label": "UNEQ_2v4_a", "topology": "2v4", "notes": "Two elites vs four mids — decay sweep.", "team1": ["Ja'Marr Chase", "Justin Jefferson"], "team2": ["T.J. Hockenson", "Brian Thomas Jr.", "Mark Andrews", "2026 Pick 1.09"] },
+  { "label": "UNEQ_2v4_b", "topology": "2v4", "notes": "Elite + mid vs four throw-ins.", "team1": ["Justin Jefferson", "T.J. Hockenson"], "team2": ["Bo Nix", "Mark Andrews", "Geno Smith", "Tanner McKee"] },
+  { "label": "UNEQ_2v4_c", "topology": "2v4", "notes": "Elite + pick vs four picks.", "team1": ["Ja'Marr Chase", "2026 Pick 1.09"], "team2": ["2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st", "2028 1st"] },
+  { "label": "UNEQ_2v4_d", "topology": "2v4", "notes": "Two QBs vs four mid skills.", "team1": ["Patrick Mahomes", "Josh Allen"], "team2": ["DeVonta Smith", "T.J. Hockenson", "DJ Moore", "George Pickens"] },
+  { "label": "UNEQ_2v4_e", "topology": "2v4", "notes": "Two elites vs four mids (matched depth).", "team1": ["Bijan Robinson", "Jahmyr Gibbs"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson", "Sam LaPorta"] },
+  { "label": "UNEQ_2v4_f", "topology": "2v4", "notes": "Mid stud + junk vs four mids.", "team1": ["Brian Thomas Jr.", "Tanner McKee"], "team2": ["T.J. Hockenson", "Mark Andrews", "George Pickens", "Bo Nix"] },
+
+  { "label": "UNEQ_2v5_a", "topology": "2v5", "notes": "Two elites vs five throw-ins.", "team1": ["Ja'Marr Chase", "Patrick Mahomes"], "team2": ["T.J. Hockenson", "Mark Andrews", "Bo Nix", "Geno Smith", "Tanner McKee"] },
+  { "label": "UNEQ_2v5_b", "topology": "2v5", "notes": "Elite + mid vs five spread.", "team1": ["Justin Jefferson", "Brian Thomas Jr."], "team2": ["DeVonta Smith", "T.J. Hockenson", "Mark Andrews", "Bo Nix", "2026 Pick 2.01"] },
+  { "label": "UNEQ_2v5_c", "topology": "2v5", "notes": "Stud + throw-in vs five mid pieces.", "team1": ["Ja'Marr Chase", "Tanner McKee"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Mark Andrews", "2026 Pick 1.09", "2026 Pick 2.01"] },
+
+  { "label": "EQ_3v3_a", "topology": "3v3", "notes": "Three elites vs three mids — tests aggregate.", "team1": ["Justin Jefferson", "Ja'Marr Chase", "Bijan Robinson"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson"] },
+  { "label": "EQ_3v3_b", "topology": "3v3", "notes": "Elite + mid + throw-in vs three balanced mids.", "team1": ["Justin Jefferson", "T.J. Hockenson", "Tanner McKee"], "team2": ["Brian Thomas Jr.", "DeVonta Smith", "2026 Pick 1.09"] },
+  { "label": "EQ_3v3_c", "topology": "3v3", "notes": "Three RBs vs three WRs.", "team1": ["Bijan Robinson", "Jahmyr Gibbs", "Kyren Williams"], "team2": ["Puka Nacua", "Drake London", "Garrett Wilson"] },
+  { "label": "EQ_3v3_d", "topology": "3v3", "notes": "Stud + two throw-ins vs three matched mids.", "team1": ["Ja'Marr Chase", "Bo Nix", "Tanner McKee"], "team2": ["T.J. Hockenson", "Brian Thomas Jr.", "Mark Andrews"] },
+  { "label": "EQ_3v3_e", "topology": "3v3", "notes": "Elite + two mids vs three near-equal mids.", "team1": ["Justin Jefferson", "T.J. Hockenson", "Brian Thomas Jr."], "team2": ["DeVonta Smith", "Drake London", "Sam LaPorta"] },
+  { "label": "EQ_3v3_f", "topology": "3v3", "notes": "Two QBs + WR vs three skill players.", "team1": ["Patrick Mahomes", "Josh Allen", "Drake London"], "team2": ["Puka Nacua", "T.J. Hockenson", "Brian Thomas Jr."] },
+  { "label": "EQ_3v3_g", "topology": "3v3", "notes": "Three picks vs three players.", "team1": ["2026 Pick 1.09", "2026 Pick 2.01", "2027 Mid 1st"], "team2": ["T.J. Hockenson", "Mark Andrews", "George Pickens"] },
+  { "label": "EQ_3v3_h", "topology": "3v3", "notes": "Three near-equal mids on each side.", "team1": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson"], "team2": ["DeVonta Smith", "Sam LaPorta", "Mark Andrews"] },
+  { "label": "EQ_3v3_i", "topology": "3v3", "notes": "Stud + two mids vs three throw-ins.", "team1": ["Ja'Marr Chase", "T.J. Hockenson", "Brian Thomas Jr."], "team2": ["Mark Andrews", "Bo Nix", "Tanner McKee"] },
+  { "label": "EQ_3v3_j", "topology": "3v3", "notes": "Two elites + pick vs elite + two mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "2026 Pick 1.09"], "team2": ["Bijan Robinson", "Drake London", "T.J. Hockenson"] },
+  { "label": "EQ_3v3_k", "topology": "3v3", "notes": "Three matched throw-ins per side.", "team1": ["Tanner McKee", "Bo Nix", "Geno Smith"], "team2": ["Mark Andrews", "Aaron Rodgers", "Kirk Cousins"] },
+  { "label": "EQ_3v3_l", "topology": "3v3", "notes": "Elite WR + two picks vs three solid players.", "team1": ["Justin Jefferson", "2026 Pick 1.09", "2026 Pick 2.01"], "team2": ["Brian Thomas Jr.", "DeVonta Smith", "T.J. Hockenson"] },
+  { "label": "EQ_3v3_m", "topology": "3v3", "notes": "Pick-heavy mirror — three picks each.", "team1": ["2026 Pick 1.09", "2027 Mid 1st", "2026 Pick 3.01"], "team2": ["2026 Pick 2.01", "2027 Late 1st", "2028 1st"] },
+  { "label": "EQ_3v3_n", "topology": "3v3", "notes": "Stud + junk + junk vs balanced.", "team1": ["Ja'Marr Chase", "Tanner McKee", "Geno Smith"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Mark Andrews"] },
+
+  { "label": "UNEQ_3v4_a", "topology": "3v4", "notes": "Three elites vs four mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Patrick Mahomes"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Drake London", "Mark Andrews"] },
+  { "label": "UNEQ_3v4_b", "topology": "3v4", "notes": "Elite + two mids vs four balanced.", "team1": ["Justin Jefferson", "Brian Thomas Jr.", "T.J. Hockenson"], "team2": ["DeVonta Smith", "Drake London", "Mark Andrews", "2026 Pick 1.09"] },
+  { "label": "UNEQ_3v4_c", "topology": "3v4", "notes": "Three RBs vs four WRs.", "team1": ["Bijan Robinson", "Jahmyr Gibbs", "Kyren Williams"], "team2": ["Drake London", "Garrett Wilson", "Puka Nacua", "DeVonta Smith"] },
+  { "label": "UNEQ_3v4_d", "topology": "3v4", "notes": "Three solid + junk extra on the four side.", "team1": ["Ja'Marr Chase", "T.J. Hockenson", "Brian Thomas Jr."], "team2": ["Drake London", "DeVonta Smith", "Mark Andrews", "Tanner McKee"] },
+  { "label": "UNEQ_3v4_e", "topology": "3v4", "notes": "Mid-tier WRs and picks.", "team1": ["DeVonta Smith", "Brian Thomas Jr.", "2026 Pick 1.09"], "team2": ["Drake London", "T.J. Hockenson", "Mark Andrews", "2026 Pick 2.01"] },
+  { "label": "UNEQ_3v4_f", "topology": "3v4", "notes": "Stud + two throw-ins vs four mids.", "team1": ["Ja'Marr Chase", "Bo Nix", "Tanner McKee"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Mark Andrews", "George Pickens"] },
+  { "label": "UNEQ_3v4_g", "topology": "3v4", "notes": "Two elites + pick vs four mids.", "team1": ["Justin Jefferson", "Patrick Mahomes", "2026 Pick 1.09"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Sam LaPorta", "Drake London"] },
+
+  { "label": "UNEQ_3v5_a", "topology": "3v5", "notes": "Three elites vs five mids — heavy decay.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Bijan Robinson"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Drake London", "Mark Andrews", "2026 Pick 1.09"] },
+  { "label": "UNEQ_3v5_b", "topology": "3v5", "notes": "Elite + two solid vs five spread.", "team1": ["Justin Jefferson", "Brian Thomas Jr.", "T.J. Hockenson"], "team2": ["DeVonta Smith", "Drake London", "Sam LaPorta", "Mark Andrews", "Tanner McKee"] },
+  { "label": "UNEQ_3v5_c", "topology": "3v5", "notes": "Stud + two mids vs five throw-ins.", "team1": ["Ja'Marr Chase", "Brian Thomas Jr.", "T.J. Hockenson"], "team2": ["Mark Andrews", "Bo Nix", "George Pickens", "Geno Smith", "Tanner McKee"] },
+  { "label": "UNEQ_3v5_d", "topology": "3v5", "notes": "Pick-heavy receiving side.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Patrick Mahomes"], "team2": ["2026 Pick 1.09", "2026 Pick 2.01", "2027 Mid 1st", "2027 Late 1st", "2028 1st"] },
+  { "label": "UNEQ_3v5_e", "topology": "3v5", "notes": "Three RBs vs five mid skills.", "team1": ["Bijan Robinson", "Jahmyr Gibbs", "Kyren Williams"], "team2": ["Drake London", "DeVonta Smith", "T.J. Hockenson", "Sam LaPorta", "Mark Andrews"] },
+
+  { "label": "EQ_4v4_a", "topology": "4v4", "notes": "Four elites vs four mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Bijan Robinson", "Patrick Mahomes"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson", "DeVonta Smith"] },
+  { "label": "EQ_4v4_b", "topology": "4v4", "notes": "Elite + three mids vs four balanced mids.", "team1": ["Justin Jefferson", "Brian Thomas Jr.", "T.J. Hockenson", "DeVonta Smith"], "team2": ["Drake London", "Sam LaPorta", "Mark Andrews", "Garrett Wilson"] },
+  { "label": "EQ_4v4_c", "topology": "4v4", "notes": "Stud + three throw-ins vs four mids.", "team1": ["Ja'Marr Chase", "Mark Andrews", "Bo Nix", "Tanner McKee"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "DeVonta Smith", "Sam LaPorta"] },
+  { "label": "EQ_4v4_d", "topology": "4v4", "notes": "Four near-matched on each side.", "team1": ["Justin Jefferson", "T.J. Hockenson", "Mark Andrews", "Tanner McKee"], "team2": ["Brian Thomas Jr.", "DeVonta Smith", "Bo Nix", "Geno Smith"] },
+  { "label": "EQ_4v4_e", "topology": "4v4", "notes": "Two QBs + two WRs each side.", "team1": ["Patrick Mahomes", "Josh Allen", "Puka Nacua", "Drake London"], "team2": ["Lamar Jackson", "Jayden Daniels", "Garrett Wilson", "Brian Thomas Jr."] },
+  { "label": "EQ_4v4_f", "topology": "4v4", "notes": "Pick-heavy 4v4.", "team1": ["2026 Pick 1.09", "2026 Pick 2.01", "T.J. Hockenson", "Mark Andrews"], "team2": ["2027 Mid 1st", "2027 Late 1st", "Brian Thomas Jr.", "DeVonta Smith"] },
+  { "label": "EQ_4v4_g", "topology": "4v4", "notes": "Two elites + two throw-ins per side.", "team1": ["Ja'Marr Chase", "Bijan Robinson", "Tanner McKee", "Geno Smith"], "team2": ["Justin Jefferson", "Patrick Mahomes", "Bo Nix", "Mark Andrews"] },
+  { "label": "EQ_4v4_h", "topology": "4v4", "notes": "Three solid + pick vs four solid.", "team1": ["Brian Thomas Jr.", "T.J. Hockenson", "Drake London", "2026 Pick 1.09"], "team2": ["DeVonta Smith", "Sam LaPorta", "Garrett Wilson", "Mark Andrews"] },
+
+  { "label": "UNEQ_4v5_a", "topology": "4v5", "notes": "Four elites vs five mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Patrick Mahomes", "Bijan Robinson"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson", "Mark Andrews", "2026 Pick 1.09"] },
+  { "label": "UNEQ_4v5_b", "topology": "4v5", "notes": "Elite + three mids vs five spread.", "team1": ["Justin Jefferson", "Brian Thomas Jr.", "T.J. Hockenson", "Sam LaPorta"], "team2": ["DeVonta Smith", "Drake London", "Mark Andrews", "Bo Nix", "George Pickens"] },
+  { "label": "UNEQ_4v5_c", "topology": "4v5", "notes": "Stud + three throw-ins vs five mids.", "team1": ["Ja'Marr Chase", "Mark Andrews", "Bo Nix", "Tanner McKee"], "team2": ["Brian Thomas Jr.", "T.J. Hockenson", "Drake London", "Sam LaPorta", "DeVonta Smith"] },
+
+  { "label": "EQ_5v5_a", "topology": "5v5", "notes": "Five elites vs five mids.", "team1": ["Ja'Marr Chase", "Justin Jefferson", "Bijan Robinson", "Patrick Mahomes", "Josh Allen"], "team2": ["Brian Thomas Jr.", "Drake London", "T.J. Hockenson", "DeVonta Smith", "Sam LaPorta"] },
+  { "label": "EQ_5v5_b", "topology": "5v5", "notes": "Top + four mids vs five solid.", "team1": ["Ja'Marr Chase", "T.J. Hockenson", "Brian Thomas Jr.", "Mark Andrews", "Tanner McKee"], "team2": ["Justin Jefferson", "Drake London", "DeVonta Smith", "Sam LaPorta", "George Pickens"] },
+  { "label": "EQ_5v5_c", "topology": "5v5", "notes": "Five matched mids per side.", "team1": ["Brian Thomas Jr.", "T.J. Hockenson", "Mark Andrews", "Bo Nix", "Tanner McKee"], "team2": ["DeVonta Smith", "Sam LaPorta", "George Pickens", "Geno Smith", "Aaron Rodgers"] },
+  { "label": "EQ_5v5_d", "topology": "5v5", "notes": "Pick-heavy 5v5.", "team1": ["Ja'Marr Chase", "2026 Pick 1.09", "2026 Pick 2.01", "T.J. Hockenson", "Tanner McKee"], "team2": ["Justin Jefferson", "2027 Mid 1st", "2027 Late 1st", "Mark Andrews", "Brian Thomas Jr."] }
 ]

--- a/tests/scripts/test_calibrate_va_formula.py
+++ b/tests/scripts/test_calibrate_va_formula.py
@@ -1,0 +1,139 @@
+"""Smoke + math tests for ``scripts/calibrate_va_formula.py``.
+
+Pins the V7 → V8 collapse property: with ``stud_coeff = 0`` and
+matching base params, V8 must produce identical predictions to V7.
+That's the safety property — the grid search can't pick a
+"stud factor that hurts" because the stud-coeff=0 variant is
+strictly equivalent to V7 and will be in the search space.
+
+Also verifies the predict_v8 monotonicity: increasing
+``stud_coeff`` increases the prediction for elite-top trades and
+leaves sub-threshold trades unchanged.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "calibrate_va_formula.py"
+
+
+@pytest.fixture(scope="module")
+def cal():
+    """Import the calibration script as a module so its predict_*
+    functions + DataPoint class are reachable from tests without
+    a __init__.py in scripts/."""
+    spec = importlib.util.spec_from_file_location("calibrate_va", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["calibrate_va"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _point(cal, *, small, large, label="test"):
+    return cal.DataPoint(
+        label=label,
+        small=tuple(sorted(small, reverse=True)),
+        large=tuple(sorted(large, reverse=True)),
+        ktc_va=0.0,  # not used by predict_*
+        topology=f"{len(small)}v{len(large)}",
+    )
+
+
+def _v7_params():
+    return {
+        "slope": 4.0, "intercept": 0.30, "cap": 0.60,
+        "decay": 0.50, "boost": 1.0, "effective_cap": 1.10,
+    }
+
+
+def _v8_params(stud_coeff=0.0, stud_threshold=7000.0):
+    return {**_v7_params(), "stud_coeff": stud_coeff, "stud_threshold": stud_threshold}
+
+
+def test_v8_collapses_to_v7_when_stud_coeff_zero(cal):
+    """Critical safety property: V8 with stud_coeff=0 == V7 exactly.
+    Means the grid search can never pick a 'V8 worse than V7' —
+    the V7 result is in V8's parameter space."""
+    pt = _point(cal, small=[8500], large=[6800, 4200])
+    v7_pred = cal.predict_v7_full_loop(pt, _v7_params())
+    v8_pred = cal.predict_v8_stud_factor(pt, _v8_params(stud_coeff=0.0))
+    assert abs(v7_pred - v8_pred) < 1e-6, (
+        f"V8 with stud_coeff=0 must equal V7: v7={v7_pred} v8={v8_pred}"
+    )
+
+
+def test_v8_collapses_when_top_below_threshold(cal):
+    """Stud factor only kicks in above stud_threshold.  A trade with
+    top_small < threshold gets no stud bonus regardless of coeff."""
+    pt = _point(cal, small=[5000], large=[4500, 3000])
+    v7_pred = cal.predict_v7_full_loop(pt, _v7_params())
+    v8_pred = cal.predict_v8_stud_factor(
+        pt, _v8_params(stud_coeff=1.5, stud_threshold=7000.0),
+    )
+    # top_small (5000) < threshold (7000) → stud_excess = 0 → mult = 1
+    assert abs(v7_pred - v8_pred) < 1e-6
+
+
+def test_v8_amplifies_for_elite_top(cal):
+    """Elite top-piece trades get amplified relative to V7."""
+    pt = _point(cal, small=[9500], large=[7500, 5000])
+    v7_pred = cal.predict_v7_full_loop(pt, _v7_params())
+    v8_pred = cal.predict_v8_stud_factor(
+        pt, _v8_params(stud_coeff=1.0, stud_threshold=7000.0),
+    )
+    assert v8_pred > v7_pred, (
+        f"V8 should amplify elite trades: v7={v7_pred} v8={v8_pred}"
+    )
+
+
+def test_v8_returns_zero_when_small_larger(cal):
+    """Inverted shape (small.length > large.length) returns 0
+    same as V7."""
+    pt = _point(cal, small=[5000, 4000, 3000], large=[8000])
+    v8_pred = cal.predict_v8_stud_factor(
+        pt, _v8_params(stud_coeff=0.5),
+    )
+    assert v8_pred == 0.0
+
+
+def test_v8_handles_equal_count_smoothly(cal):
+    """V8's full-loop structure handles equal-count trades — no
+    discontinuity at the count boundary (which is the whole point
+    of moving to V7/V8 from V3)."""
+    pt_2v2 = _point(cal, small=[8500, 4000], large=[7800, 5200])
+    pt_2v3 = _point(cal, small=[8500, 4000], large=[7800, 5200, 1500])
+    v8_2v2 = cal.predict_v8_stud_factor(pt_2v2, _v8_params(stud_coeff=0.5))
+    v8_2v3 = cal.predict_v8_stud_factor(pt_2v3, _v8_params(stud_coeff=0.5))
+    # Both should be > 0; 2v3 should be larger (extra piece adds VA).
+    assert v8_2v2 > 0
+    assert v8_2v3 > v8_2v2
+
+
+def test_v8_monotonic_in_stud_coeff(cal):
+    """For an elite-top trade, prediction is monotonically
+    non-decreasing in stud_coeff."""
+    pt = _point(cal, small=[9000], large=[7500, 4500])
+    base = _v8_params(stud_coeff=0.0)
+    coeffs = [0.0, 0.25, 0.5, 1.0, 1.5]
+    preds = [
+        cal.predict_v8_stud_factor(pt, {**base, "stud_coeff": c})
+        for c in coeffs
+    ]
+    for i in range(len(preds) - 1):
+        assert preds[i + 1] >= preds[i], (
+            f"V8 must be monotonic in stud_coeff: {preds}"
+        )
+
+
+def test_v8_in_main_candidates_list(cal):
+    """V8 must be wired into main()'s candidate list so the ranking
+    summary includes it.  We don't run main() (it's a 2-min grid
+    search) — just verify the source contains the registration."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "predict_v8_stud_factor" in src
+    assert '("V8"' in src or "'V8'" in src


### PR DESCRIPTION
## What's in this PR
Replaces the 16-trade VA calibration probe with a 100-trade sweep that covers the full regime our current V2 formula misfits.

**Topology distribution (15 distinct shapes):**

| | 1v_ | 2v_ | 3v_ | 4v_ | 5v_ |
|---|---|---|---|---|---|
| 1 | 6 | — | — | — | — |
| 2 | 8 | 14 | — | — | — |
| 3 | 6 | 10 | 14 | — | — |
| 4 | 4 | 6 | 7 | 8 | — |
| 5 | 2 | 3 | 5 | 3 | 4 |

**Equal-count trades (1v1 / 2v2 / 3v3 / 4v4 / 5v5) take 46 of the 100 slots** because KTC's own FAQ on Value Adjustment ("difference in value of the players involved, how much of a 'stud' the players are, the number of players of lesser value included") confirms VA fires on stud-factor and value-difference — both of which trigger at equal counts and are exactly what our existing V2 formula misses (it only iterates over extras when `small.length < large.length`).

Within each topology the trades vary along three axes:
- top-asset gap (near-matched ⟶ 60%+ stud-vs-junk)
- depth profile (matched / throw-in / lopsided / picks-only)
- piece type mix (WR / RB / QB / TE / pick combinations)

The two anchor labels (`EQ_2v2_a`, `UNEQ_2v3_a`) preserve the trades already validated against KTC screenshots (`VA=3610` and `VA=4187` respectively) so the refit is anchored to known-good observations.

## How to use it
```bash
pip install playwright && playwright install chromium
python scripts/collect_ktc_va.py        # ~10-15 min, run with --headed first time
git add scripts/ktc_va_observations.json
git commit -m "data: KTC VA observations" && git push
```

Once that observations JSON lands on main, I'll run `python scripts/calibrate_va_formula.py` from the sandbox to grid-search V6/V7 candidates against the 100 new + 13 baseline anchors and propose the winning formula in a follow-up PR.

## Test plan
- [x] `python -c 'import json; assert len(json.load(open("scripts/ktc_va_fixture.json"))) == 100'` — passes locally.
- [ ] First scraper run completes in headed mode against 5–10 anchor trades to validate selectors.
- [ ] Full 100-trade run completes with ≥95% success rate (a few name misses are expected and recoverable).

https://claude.ai/code/session_01CUWaetCTP3Bo8Nh94ByoLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUWaetCTP3Bo8Nh94ByoLh)_