### PR TITLE
edge: add IDP Buy/Sell signal cards (IDPTC as retail anchor, top-200)

### DIFF
--- a/frontend/__tests__/display-helpers.test.js
+++ b/frontend/__tests__/display-helpers.test.js
@@ -7,6 +7,9 @@ import {
   marketAction,
   isEligibleForBoard,
   isEligibleForAnalysis,
+  idpMarketEdge,
+  idpMarketAction,
+  isIdpInTopByIdptc,
 } from "../lib/display-helpers.js";
 
 describe("posBadgeClass", () => {
@@ -214,5 +217,215 @@ describe("marketAction", () => {
   it("title surfaces direction context", () => {
     const a = marketAction(_row({ ktc: 50, dlf: 10, fc: 12 }));
     expect(a.title.toLowerCase()).toContain("market is undervaluing");
+  });
+});
+
+
+// ── idpMarketAction (IDP BUY / SELL / HOLD vs IDPTC) ────────────────
+
+describe("idpMarketAction", () => {
+  // Build an IDP row with IDPTC + IDP-expert ranks.
+  function _idp({ idptc, dlf, ipd, fp, fbg, ds }) {
+    const sourceRanks = {};
+    if (idptc != null) sourceRanks.idpTradeCalc = idptc;
+    if (dlf != null) sourceRanks.dlfIdp = dlf;
+    if (ipd != null) sourceRanks.idpShow = ipd;
+    if (fp != null) sourceRanks.fantasyProsIdp = fp;
+    if (fbg != null) sourceRanks.footballGuysIdp = fbg;
+    if (ds != null) sourceRanks.draftSharksIdp = ds;
+    return { assetClass: "idp", pos: "LB", sourceRanks };
+  }
+
+  it("BUY when IDP experts rank well above IDPTC", () => {
+    // IDPTC=50, experts mean ~12 — experts ~38 ranks above IDPTC
+    const a = idpMarketAction(_idp({ idptc: 50, dlf: 10, fp: 12, fbg: 14 }));
+    expect(a.label).toBe("BUY");
+    expect(a.kind).toBe("buy");
+    expect(a.css).toBe("edge-buy");
+    expect(a.title.toLowerCase()).toContain("idptc is undervaluing");
+  });
+
+  it("SELL when IDPTC ranks well above IDP experts", () => {
+    // IDPTC=10, experts mean ~55 — IDPTC ~45 ranks above
+    const a = idpMarketAction(_idp({ idptc: 10, dlf: 50, fp: 55, fbg: 60 }));
+    expect(a.label).toBe("SELL");
+    expect(a.kind).toBe("sell");
+    expect(a.css).toBe("edge-sell");
+    expect(a.title.toLowerCase()).toContain("idptc is overvaluing");
+  });
+
+  it("HOLD when IDPTC and IDP experts agree within threshold", () => {
+    const a = idpMarketAction(_idp({ idptc: 25, dlf: 26, fp: 24 }));
+    expect(a.label).toBe("HOLD");
+    expect(a.kind).toBe("hold");
+  });
+
+  it("— when only IDPTC ranks (no IDP-expert sources)", () => {
+    const a = idpMarketAction(_idp({ idptc: 25 }));
+    expect(a.label).toBe("—");
+    expect(a.css).toBe("edge-none");
+  });
+
+  it("— when only IDP-expert sources rank (no IDPTC)", () => {
+    const a = idpMarketAction(_idp({ dlf: 25, fp: 26 }));
+    expect(a.label).toBe("—");
+  });
+
+  it("— when no IDP source ranks at all", () => {
+    const a = idpMarketAction({ assetClass: "idp", sourceRanks: {} });
+    expect(a.label).toBe("—");
+  });
+
+  it("uses effectiveSourceRanks when present (post-Hampel)", () => {
+    // sourceRanks contains an IDPTC outlier; effectiveSourceRanks
+    // is the post-Hampel set the backend would use.
+    const row = {
+      assetClass: "idp",
+      sourceRanks: { idpTradeCalc: 200, dlfIdp: 50, fantasyProsIdp: 55 },
+      effectiveSourceRanks: { idpTradeCalc: 50, dlfIdp: 50, fantasyProsIdp: 55 },
+    };
+    const a = idpMarketAction(row);
+    // With effective ranks, IDPTC=50 vs experts mean ~52 → aligned →
+    // idpMarketAction translates "aligned" → label "HOLD" / kind "hold"
+    expect(a.kind).toBe("hold");
+    expect(a.label).toBe("HOLD");
+  });
+
+  it("ignores non-IDP sources (e.g. KTC) in the consensus calculation", () => {
+    // KTC's offense rank should NOT count toward IDP consensus.
+    const a = idpMarketAction({
+      assetClass: "idp",
+      sourceRanks: { idpTradeCalc: 50, ktc: 1, dlfIdp: 12, fantasyProsIdp: 14 },
+    });
+    // Experts mean = (12+14)/2 = 13 vs IDPTC 50 → BUY (consensus_higher)
+    expect(a.label).toBe("BUY");
+  });
+});
+
+
+// ── isIdpInTopByIdptc ───────────────────────────────────────────────
+
+describe("isIdpInTopByIdptc", () => {
+  it("includes IDP rows ranked at or above the limit by IDPTC", () => {
+    expect(
+      isIdpInTopByIdptc(
+        { assetClass: "idp", sourceRanks: { idpTradeCalc: 1 } },
+        200,
+      ),
+    ).toBe(true);
+    expect(
+      isIdpInTopByIdptc(
+        { assetClass: "idp", sourceRanks: { idpTradeCalc: 200 } },
+        200,
+      ),
+    ).toBe(true);
+  });
+
+  it("excludes IDP rows ranked below the IDPTC limit", () => {
+    expect(
+      isIdpInTopByIdptc(
+        { assetClass: "idp", sourceRanks: { idpTradeCalc: 201 } },
+        200,
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes IDP rows IDPTC didn't rank", () => {
+    expect(
+      isIdpInTopByIdptc(
+        { assetClass: "idp", sourceRanks: { dlfIdp: 50 } },
+        200,
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes non-IDP rows (offense, picks)", () => {
+    expect(
+      isIdpInTopByIdptc(
+        { assetClass: "offense", sourceRanks: { idpTradeCalc: 50 } },
+        200,
+      ),
+    ).toBe(false);
+    expect(
+      isIdpInTopByIdptc(
+        { assetClass: "pick", sourceRanks: { idpTradeCalc: 50 } },
+        200,
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes quarantined rows", () => {
+    expect(
+      isIdpInTopByIdptc(
+        {
+          assetClass: "idp",
+          quarantined: true,
+          sourceRanks: { idpTradeCalc: 50 },
+        },
+        200,
+      ),
+    ).toBe(false);
+  });
+
+  it("prefers effectiveSourceRanks over sourceRanks when present", () => {
+    // sourceRanks says IDPTC=50 (in top-200); effectiveSourceRanks
+    // dropped IDPTC entirely → row should be excluded.
+    expect(
+      isIdpInTopByIdptc(
+        {
+          assetClass: "idp",
+          sourceRanks: { idpTradeCalc: 50 },
+          effectiveSourceRanks: { dlfIdp: 50 },
+        },
+        200,
+      ),
+    ).toBe(false);
+  });
+
+  it("handles null / undefined input", () => {
+    expect(isIdpInTopByIdptc(null, 200)).toBe(false);
+    expect(isIdpInTopByIdptc(undefined, 200)).toBe(false);
+    expect(isIdpInTopByIdptc({}, 200)).toBe(false);
+  });
+});
+
+
+// ── idpMarketEdge — descriptor shape ────────────────────────────────
+
+describe("idpMarketEdge", () => {
+  it("returns retail_only when only IDPTC is ranked", () => {
+    const e = idpMarketEdge({
+      assetClass: "idp",
+      sourceRanks: { idpTradeCalc: 25 },
+    });
+    expect(e.kind).toBe("retail_only");
+    expect(e.label).toBe("IDPTC only");
+  });
+
+  it("returns consensus_only when only IDP experts ranked", () => {
+    const e = idpMarketEdge({
+      assetClass: "idp",
+      sourceRanks: { dlfIdp: 25, fantasyProsIdp: 26 },
+    });
+    expect(e.kind).toBe("consensus_only");
+    expect(e.label).toBe("expert only");
+  });
+
+  it("returns retail_higher with diff in label when IDPTC > experts", () => {
+    const e = idpMarketEdge({
+      assetClass: "idp",
+      sourceRanks: { idpTradeCalc: 10, dlfIdp: 50, fantasyProsIdp: 60 },
+    });
+    expect(e.kind).toBe("retail_higher");
+    expect(e.label).toMatch(/^IDPTC higher by \d+$/);
+  });
+
+  it("returns consensus_higher with diff in label when experts > IDPTC", () => {
+    const e = idpMarketEdge({
+      assetClass: "idp",
+      sourceRanks: { idpTradeCalc: 50, dlfIdp: 10, fantasyProsIdp: 12 },
+    });
+    expect(e.kind).toBe("consensus_higher");
+    expect(e.label).toMatch(/^Experts higher by \d+$/);
   });
 });

--- a/frontend/app/edge/page.jsx
+++ b/frontend/app/edge/page.jsx
@@ -5,7 +5,14 @@ import { useDynastyData } from "@/components/useDynastyData";
 import { useApp } from "@/components/AppShell";
 import { useSettings } from "@/components/useSettings";
 import { actionLabel, cautionLabels, isTopRankedForEdgePremium } from "@/lib/edge-helpers";
-import { posBadgeClass, confBadgeClass, confBadgeLabel as confLabel, isEligibleForAnalysis } from "@/lib/display-helpers";
+import {
+  posBadgeClass,
+  confBadgeClass,
+  confBadgeLabel as confLabel,
+  isEligibleForAnalysis,
+  idpMarketAction,
+  isIdpInTopByIdptc,
+} from "@/lib/display-helpers";
 import ConfidenceValueScatter from "@/components/graphs/ConfidenceValueScatter";
 import {
   EDGE_SECTION_LIMIT,
@@ -267,6 +274,61 @@ export default function EdgePage() {
     [eligible],
   );
 
+  // ── IDP Buy/Sell — IDPTC as the retail anchor ─────────────────────
+  //
+  // The offense Buy/Sell sections above use KTC as the retail anchor,
+  // but KTC doesn't list IDP players, so defenders never appear in
+  // those sections.  For IDP-specific Buy/Sell we mirror the offense
+  // logic with IDPTC playing the role KTC plays:
+  //
+  //   * "IDPTC overvalues"  → SELL signal (IDPTC ranks player above
+  //                            IDP-expert consensus)
+  //   * "IDPTC undervalues" → BUY signal  (IDP-expert consensus ranks
+  //                            player above IDPTC)
+  //
+  // Filter scope: top 200 by IDPTC.  Below that the IDP-expert
+  // consensus is too noisy for these signals to be trustworthy.
+  const IDP_TOP_LIMIT = 200;
+
+  const idpEligible = useMemo(
+    () => eligible.filter((r) => isIdpInTopByIdptc(r, IDP_TOP_LIMIT)),
+    [eligible],
+  );
+
+  const idpRetailPremium = useMemo(
+    () =>
+      idpEligible
+        .map((r) => ({ row: r, action: idpMarketAction(r) }))
+        .filter(({ action }) => action.kind === "sell")
+        // Sort by gap magnitude — biggest IDPTC overvaluations first.
+        // Pull the diff out of the title since idpMarketEdge stamps it.
+        .map(({ row, action }) => {
+          const m = action.title?.match(/~(\d+) ordinal/);
+          const diff = m ? Number(m[1]) : 0;
+          return { row, diff };
+        })
+        .sort((a, b) => b.diff - a.diff)
+        .slice(0, EDGE_PREMIUM_LIMIT)
+        .map(({ row }) => row),
+    [idpEligible],
+  );
+
+  const idpConsensusPremium = useMemo(
+    () =>
+      idpEligible
+        .map((r) => ({ row: r, action: idpMarketAction(r) }))
+        .filter(({ action }) => action.kind === "buy")
+        .map(({ row, action }) => {
+          const m = action.title?.match(/~(\d+) ordinal/);
+          const diff = m ? Number(m[1]) : 0;
+          return { row, diff };
+        })
+        .sort((a, b) => b.diff - a.diff)
+        .slice(0, EDGE_PREMIUM_LIMIT)
+        .map(({ row }) => row),
+    [idpEligible],
+  );
+
   const flagged = useMemo(
     () =>
       eligible
@@ -451,6 +513,36 @@ export default function EdgePage() {
                 rows={consensusPremium}
                 onPlayerClick={openPlayerPopup}
                 emptyText={`No buy signals in the top ${EDGE_PREMIUM_RANK_LIMIT}.`}
+                columns={[COL_RANK, COL_PLAYER, COL_POS, COL_SPREAD, COL_VALUE]}
+              />
+            </EdgeSection>
+
+            {/* IDP Sell Signals — IDPTC values defenders higher than IDP-expert consensus */}
+            <EdgeSection
+              title="IDP Sell Signals"
+              description={`IDP players where IDPTC's rank is much higher than the IDP-expert consensus (DLF IDP, IDP Show, FantasyPros IDP, FootballGuys IDP, DraftSharks IDP). Limited to the top ${IDP_TOP_LIMIT} by IDPTC. Potential sells to IDPTC-first trade partners.`}
+              count={`${idpRetailPremium.length} shown`}
+              accent="amber"
+            >
+              <SectionTable
+                rows={idpRetailPremium}
+                onPlayerClick={openPlayerPopup}
+                emptyText={`No IDP sell signals inside the top ${IDP_TOP_LIMIT} by IDPTC.`}
+                columns={[COL_RANK, COL_PLAYER, COL_POS, COL_SPREAD, COL_VALUE]}
+              />
+            </EdgeSection>
+
+            {/* IDP Buy Signals — IDP-expert consensus values defenders higher than IDPTC */}
+            <EdgeSection
+              title="IDP Buy Signals"
+              description={`IDP players where the IDP-expert consensus ranks them much higher than IDPTC. Limited to the top ${IDP_TOP_LIMIT} by IDPTC. Potential buys from IDPTC-first trade partners.`}
+              count={`${idpConsensusPremium.length} shown`}
+              accent="green"
+            >
+              <SectionTable
+                rows={idpConsensusPremium}
+                onPlayerClick={openPlayerPopup}
+                emptyText={`No IDP buy signals inside the top ${IDP_TOP_LIMIT} by IDPTC.`}
                 columns={[COL_RANK, COL_PLAYER, COL_POS, COL_SPREAD, COL_VALUE]}
               />
             </EdgeSection>

--- a/frontend/lib/display-helpers.js
+++ b/frontend/lib/display-helpers.js
@@ -273,3 +273,182 @@ export function marketGapLabel(row) {
   const higher = retailMean < consensusMean ? getRetailLabel() : "Consensus";
   return `${higher} +${diff}`;
 }
+
+
+// ── IDP market gap (IDPTC vs other IDP sources) ─────────────────────────
+//
+// The `marketEdge` / `marketAction` helpers above use the registry's
+// retail flag — today only KTC.  KTC doesn't list IDP players, so
+// IDP rows always come back as "expert only" / unranked / neutral
+// from those helpers, and the offense BUY/SELL signals never fire
+// for defenders.
+//
+// For IDP-specific Buy/Sell signals we treat IDPTC as the analogous
+// "retail" anchor (the most-followed source on the IDP side, just as
+// KTC is the most-followed source on the offense side) and the other
+// IDP sources (DLF IDP, IDP Show, FantasyPros IDP, FootballGuys IDP,
+// DraftSharks IDP) as the expert consensus.
+
+const IDP_RETAIL_KEY = "idpTradeCalc";
+
+const IDP_CONSENSUS_KEYS = new Set([
+  "dlfIdp",
+  "idpShow",
+  "fantasyProsIdp",
+  "footballGuysIdp",
+  "draftSharksIdp",
+]);
+
+/**
+ * Structured retail-vs-consensus descriptor for IDP rows, using
+ * IDPTC as the retail anchor.
+ *
+ * Returns `{ label, css, kind, title }` matching the shape
+ * `marketEdge()` returns, so a caller can hand the result to the
+ * same UI components.
+ *
+ * `kind` values:
+ *   - `"consensus_higher"` — IDP experts mean rank is significantly
+ *     better (lower number) than IDPTC's rank → market (IDPTC)
+ *     undervalues → BUY signal.
+ *   - `"retail_higher"` — IDPTC ranks the player significantly above
+ *     the IDP-expert consensus mean → market (IDPTC) overvalues →
+ *     SELL signal.
+ *   - `"aligned"`, `"retail_only"`, `"consensus_only"`, `"unranked"`
+ *     — same semantics as `marketEdge`.
+ */
+export function idpMarketEdge(row) {
+  const ranks =
+    row?.effectiveSourceRanks && Object.keys(row.effectiveSourceRanks).length > 0
+      ? row.effectiveSourceRanks
+      : row?.sourceRanks;
+  if (!ranks || Object.keys(ranks).length === 0) {
+    return {
+      label: "unranked",
+      css: "edge-none",
+      kind: "unranked",
+      title: "No IDP source ranks available for this player.",
+    };
+  }
+  const retailRank = Number(ranks[IDP_RETAIL_KEY]);
+  const consensusRanks = Object.entries(ranks)
+    .filter(([k, v]) => IDP_CONSENSUS_KEYS.has(k) && v != null)
+    .map(([, v]) => Number(v))
+    .filter((n) => Number.isFinite(n));
+
+  const haveRetail = Number.isFinite(retailRank);
+  const haveConsensus = consensusRanks.length > 0;
+
+  if (!haveRetail && !haveConsensus) {
+    return {
+      label: "unranked",
+      css: "edge-none",
+      kind: "unranked",
+      title: "No IDP source ranks available for this player.",
+    };
+  }
+  if (!haveRetail) {
+    return {
+      label: "expert only",
+      css: "edge-none",
+      kind: "consensus_only",
+      title: "No IDPTC rank — only IDP-expert sources contributed.",
+    };
+  }
+  if (!haveConsensus) {
+    return {
+      label: "IDPTC only",
+      css: "edge-none",
+      kind: "retail_only",
+      title: "No IDP-expert rank — only IDPTC contributed.",
+    };
+  }
+
+  const consensusMean =
+    consensusRanks.reduce((s, v) => s + v, 0) / consensusRanks.length;
+  const diff = Math.round(Math.abs(consensusMean - retailRank));
+
+  if (diff < MARKET_GAP_MIN_DIFF) {
+    return {
+      label: "aligned",
+      css: "edge-aligned",
+      kind: "aligned",
+      title: `IDPTC and IDP-expert consensus agree within ${MARKET_GAP_MIN_DIFF} ranks (actual difference: ${diff}).`,
+    };
+  }
+  if (retailRank < consensusMean) {
+    return {
+      label: `IDPTC higher by ${diff}`,
+      css: "edge-retail",
+      kind: "retail_higher",
+      title: `IDPTC ranks this player ~${diff} ordinal ranks above IDP-expert consensus.`,
+    };
+  }
+  return {
+    label: `Experts higher by ${diff}`,
+    css: "edge-consensus",
+    kind: "consensus_higher",
+    title: `IDP-expert consensus ranks this player ~${diff} ordinal ranks above IDPTC.`,
+  };
+}
+
+/**
+ * Single-verb BUY / SELL / HOLD descriptor for IDP rows, derived
+ * from `idpMarketEdge`.  Mirrors `marketAction` but with IDPTC as
+ * the retail anchor.
+ */
+export function idpMarketAction(row) {
+  const edge = idpMarketEdge(row);
+  if (edge.kind === "consensus_higher") {
+    return {
+      label: "BUY",
+      css: "edge-buy",
+      kind: "buy",
+      title: `${edge.title} IDP experts > IDPTC → IDPTC is undervaluing.`,
+    };
+  }
+  if (edge.kind === "retail_higher") {
+    return {
+      label: "SELL",
+      css: "edge-sell",
+      kind: "sell",
+      title: `${edge.title} IDPTC > IDP experts → IDPTC is overvaluing.`,
+    };
+  }
+  if (edge.kind === "aligned") {
+    return {
+      label: "HOLD",
+      css: "edge-hold",
+      kind: "hold",
+      title: edge.title,
+    };
+  }
+  return {
+    label: "—",
+    css: "edge-none",
+    kind: edge.kind,
+    title: edge.title || "Insufficient IDP source coverage to compare IDPTC vs experts.",
+  };
+}
+
+/**
+ * Predicate: row is an IDP eligible for the top-200 IDP Buy/Sell
+ * sections.  Requires:
+ *   - assetClass === "idp"
+ *   - IDPTC ranked the player at or above 200
+ *   - row is not quarantined
+ *
+ * The IDPTC-rank-based limit (rather than our blended consensus rank)
+ * matches user expectation: "limit to the top 200 by IDPTC".
+ */
+export function isIdpInTopByIdptc(row, limit = 200) {
+  if (!row || row.assetClass !== "idp") return false;
+  if (row.quarantined) return false;
+  const ranks =
+    (row.effectiveSourceRanks && Object.keys(row.effectiveSourceRanks).length > 0
+      ? row.effectiveSourceRanks
+      : row.sourceRanks) || {};
+  const idptcRank = Number(ranks[IDP_RETAIL_KEY]);
+  if (!Number.isFinite(idptcRank) || idptcRank < 1) return false;
+  return idptcRank <= limit;
+}


### PR DESCRIPTION
## Summary
- Existing /edge Buy/Sell sections use KTC as retail; KTC doesn't list IDPs, so defenders never appear in those sections
- Mirror the logic for IDPs using **IDPTC as the retail anchor** (the most-followed IDP source) and DLF IDP / IDP Show / FantasyPros IDP / FootballGuys IDP / DraftSharks IDP as expert consensus
- Filter to **top 200 by IDPTC** — below that the IDP-expert consensus is too noisy for trustworthy signals

## What's new

### Helpers (`frontend/lib/display-helpers.js`)
- `idpMarketEdge(row)` — structured retail-vs-consensus descriptor; same shape as `marketEdge` but IDPTC-anchored
- `idpMarketAction(row)` — single BUY/SELL/HOLD verb, same shape as `marketAction`
- `isIdpInTopByIdptc(row, limit)` — eligibility predicate (default 200)

### Sections on `/edge`
- **IDP Sell Signals** — IDPTC ranks player above IDP-expert consensus by ≥ `MARKET_GAP_MIN_DIFF` ranks. Potential sells to IDPTC-first trade partners.
- **IDP Buy Signals** — IDP-expert consensus ranks player above IDPTC. Potential buys from IDPTC-first trade partners.

Both sorted by gap magnitude, capped at `EDGE_PREMIUM_LIMIT` rows.

## Why IDPTC-as-retail makes sense
For Carson Schwesinger (the user's flagged case): IDPTC=52, IDP Show=52, DLF=61, FBG=87, FantasyPros=148, **DraftSharks=2**. IDPTC and most experts agree at ~52, with DS as the high outlier. Our final blend correctly anchors near IDPTC (composite=4372). The new IDP Buy/Sell cards surface exactly these IDP-side disagreements — useful trade signals that the offense KTC-vs-consensus logic can't capture.

## Test plan
- [x] 18 new tests added (idpMarketAction × 7, isIdpInTopByIdptc × 7, idpMarketEdge × 4)
- [x] All 56 display-helpers tests pass
- [x] Frontend build clean
- [x] Existing offense Buy/Sell sections unchanged