### PR TITLE
trades: show absolute V13 point gap, drop percentages

### DIFF
--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -332,7 +332,11 @@ function TradeCard({ analysis: a }) {
           <span className="badge" style={{ background: badgeBg, color: badgeColor }}>
             {a.headlineSide.team}{" "}
             {a.headlineDirection === "overpaid" ? "overpaid by" : "won by"}{" "}
-            {a.pctGap.toFixed(1)}%
+            {/* Show the absolute V13-adjusted point gap.  Numbers
+                read more directly than percentages ("won by 1,820"
+                tells you the magnitude immediately; "won by 6.7%"
+                requires mental math against trade size). */}
+            {(a.headlineNet ?? 0).toLocaleString()}
           </span>
         ) : (
           <span className="badge" style={{ background: "var(--green-soft)", color: "var(--green)" }}>
@@ -378,19 +382,19 @@ function TradeCard({ analysis: a }) {
                 fontWeight: 600,
                 marginTop: 2,
               }}>
-                Net: {netSign}{Math.abs(Math.round(side.netValue)).toLocaleString()}
-                {/* When V13 fires a non-zero VA on this side, surface
-                    it next to the linear net so users see exactly
-                    where the stud-scarcity premium kicked in.  Sign
-                    follows the convention: +VA = team got the studs,
-                    −VA = team gave studs away. */}
+                {/* Show the V13-adjusted net (linear + VA) as a single
+                    number — that's the meaningful "did this team win
+                    or lose" quantity.  Surface the VA contribution
+                    inline so users see when the stud-scarcity rule
+                    moved the verdict. */}
+                Net: {(side.netAdjusted ?? side.netValue) >= 0 ? "+" : "−"}
+                {Math.abs(Math.round(side.netAdjusted ?? side.netValue)).toLocaleString()}
                 {side.vaNet != null && Math.abs(side.vaNet) >= 1 && (
                   <span style={{ color: "var(--subtext)", fontWeight: 400 }}>
-                    {" "}{side.vaNet >= 0 ? "+" : "−"}
-                    {Math.abs(Math.round(side.vaNet)).toLocaleString()} VA
+                    {" "}({side.vaNet >= 0 ? "+" : "−"}
+                    {Math.abs(Math.round(side.vaNet)).toLocaleString()} VA)
                   </span>
                 )}
-                {" "}({side.pctGap >= 0 ? "+" : ""}{side.pctGap.toFixed(1)}%)
               </div>
             </div>
           );

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -434,8 +434,15 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
       null,
     );
     const headlinePct = headlineSide ? Math.abs(headlineSide.pctGap) : 0;
+    // Absolute V13-adjusted point gap for the headline side.  Reads
+    // more naturally than a percent — "won by 1,820" tells you the
+    // raw stud-aware gap directly, while "won by 6.7%" requires
+    // mental arithmetic against the trade size.
+    const headlineNet = headlineSide
+      ? Math.abs(Math.round(headlineSide.netAdjusted ?? headlineSide.netValue))
+      : 0;
     // If the largest-magnitude side is a loser (negative pctGap), the
-    // UI should say "X overpaid by Y%" rather than "X won by Y%".
+    // UI should say "X overpaid by Y" rather than "X won by Y".
     const headlineDirection =
       headlineSide && headlineSide.pctGap < 0 ? "overpaid" : "won";
 
@@ -473,6 +480,7 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
       winner,
       loser,
       pctGap: headlinePct,
+      headlineNet,
       headlineSide,
       headlineDirection,
       // Legacy top-level grades kept for any caller that still reads


### PR DESCRIPTION
## Summary
Trade history cards now show the absolute V13-adjusted point gap instead of a percentage.

**Before:** "Russini Panini won by 5.9%"
**After:** "Russini Panini won by 542"

**Before (per-side Net line):** "Net: -1,537 -1,730 VA (-16.7%)"
**After (per-side Net line):** "Net: -3,267 (-1,730 VA)"

The absolute number reads more directly.  "Won by 1,820" tells you the magnitude immediately; "won by 6.7%" requires mental math against trade size, and percentages aren't comparable across trades of different sizes.

## Changes
- ``league-analysis.js`` — adds ``analyzed.headlineNet`` (abs of the headline side's V13 ``netAdjusted``)
- ``trades/page.jsx`` — headline badge renders ``headlineNet``; per-side Net renders ``netAdjusted`` as the primary number with VA chip inline; no percentage in either

The ``showBadge`` threshold still gates on ``pctGap >= 3`` (the fairness check carried over from the prior regime), only the displayed text changes.

## Test plan
- [x] All 732 frontend tests pass
- [x] Frontend build clean