### PR TITLE
trades: keep headline as %, keep per-side Net as number+VA chip

### DIFF
--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -332,11 +332,11 @@ function TradeCard({ analysis: a }) {
           <span className="badge" style={{ background: badgeBg, color: badgeColor }}>
             {a.headlineSide.team}{" "}
             {a.headlineDirection === "overpaid" ? "overpaid by" : "won by"}{" "}
-            {/* Show the absolute V13-adjusted point gap.  Numbers
-                read more directly than percentages ("won by 1,820"
-                tells you the magnitude immediately; "won by 6.7%"
-                requires mental math against trade size). */}
-            {(a.headlineNet ?? 0).toLocaleString()}
+            {/* Headline pct is V13-aware (driven by netAdjusted, see
+                league-analysis.js).  Per-side Net renders the
+                absolute V13 number + VA chip below — headline keeps
+                the percentage for at-a-glance scale-aware feedback. */}
+            {a.pctGap.toFixed(1)}%
           </span>
         ) : (
           <span className="badge" style={{ background: "var(--green-soft)", color: "var(--green)" }}>


### PR DESCRIPTION
## Summary
Per user feedback after #296: revert just the headline badge back to a percentage (gives scale-aware "how lopsided was this" feedback at a glance), but **keep** the per-side Net line showing the absolute V13-adjusted number with the VA contribution as a chip.

## Final layout
- **Headline:** "Russini Panini won by 5.9%" (V13-aware percentage)
- **Per side:** "Net: +1,644 (+860 VA)" (absolute number + VA chip)

Both driven by V13 netAdjusted under the hood — only the rendering differs.