### PR TITLE
trade: resolve draft picks via resolvePickRow when share-URL hydrating

### DIFF
--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -21,6 +21,7 @@ import {
   effectiveValue,
   getPlayerEdge,
   findBalancers,
+  parsePickToken,
   resolvePickRow,
   meterVerdict,
   percentageGap,
@@ -832,7 +833,21 @@ export default function TradePage() {
           const resolved = [];
           const seen = new Set();
           for (const name of incoming.players || []) {
-            const row = rowByName.get(name);
+            // Direct rowByName lookup catches every player and any
+            // pick that happens to be in canonical form
+            // ("2026 Pick 1.04").
+            let row = rowByName.get(name);
+            if (!row) {
+              // Pick fallback: trade history items round-trip through
+              // share URLs using the SLEEPER format ("2026 1.04 (from
+              // Team X)" or "2027 Mid 1st (own)"), which doesn't
+              // match the canonical rowByName key.  Re-use the same
+              // ``resolvePickRow`` walker league-analysis uses so
+              // imported trades from /trades correctly hydrate picks.
+              if (parsePickToken(name)) {
+                row = resolvePickRow(name, rowByLowerName, pickAliases);
+              }
+            }
             if (!row || seen.has(row.name)) continue;
             seen.add(row.name);
             resolved.push(row);


### PR DESCRIPTION
## Summary
Trades imported from \`/trades\` (the click-to-import flow from PR #292) drop their draft picks. Cause: share URL encodes Sleeper-format pick names (\`"2026 1.04 (from Team X)"\`) but the calculator's \`rowByName\` map is keyed on canonical names (\`"2026 Pick 1.04"\`).  Direct lookup misses, picks get silently skipped.

## Fix
Two-line fallback in the share-URL hydrator: when \`rowByName.get\` returns null AND the name parses as a pick token, run \`resolvePickRow\` against \`rowByLowerName + pickAliases\` (same walker league-analysis.js uses for trade history pick resolution).

## Test plan
- [x] All 732 frontend tests pass
- [x] Frontend build clean
- [ ] Live: click a past trade with picks on \`/trades\` → picks appear in calculator alongside players