### PR TITLE
trade: resolve draft picks in KTC URL import path (companion to #298)

### DIFF
--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -1294,6 +1294,15 @@ export default function TradePage() {
           if (!row) row = lowerIndex.get(String(entry.name || "").toLowerCase());
           // 3. Normalized (punctuation / whitespace / suffix-stripped).
           if (!row) row = normIndex.get(_normalize(entry.name));
+          // 4. Pick token fallback — KTC's pick labels ("2026 1.09",
+          //    "2027 Mid 1st") use a different shape than our
+          //    canonical row names ("2026 Pick 1.09").  Walk the
+          //    same ``resolvePickRow`` resolver league-analysis +
+          //    the share-URL hydrator use so picks from KTC URLs
+          //    actually load instead of silently dropping.
+          if (!row && parsePickToken(entry.name)) {
+            row = resolvePickRow(entry.name, rowByLowerName, pickAliases);
+          }
           if (row) found.push(row);
           else missing.push(entry.name);
         }


### PR DESCRIPTION
## Summary
PR #298 fixed picks not loading from share URLs (trade history click-to-import).  The KTC URL import path (\`importKtcTradeUrl\` in \`trade/page.jsx\`) had the same bug: the backend's \`/api/trade/import-ktc\` resolver returns pick labels in KTC's UI shape ("2026 1.09" / "2026 Early 1st") but the 4-tier lookup ladder didn't include a pick-aware step, so picks silently disappeared.

## Fix
Add \`parsePickToken\` + \`resolvePickRow\` as the 4th lookup step in \`resolveBatch\` — same fix shape as PR #298, different code path.

## Test plan
- [x] All 732 frontend tests pass
- [x] Frontend build clean
- [ ] Live: paste a KTC URL with picks → picks load alongside players