### PR TITLE
League: rework records, streaks, awards, recaps

### DIFF
--- a/frontend/app/league/sections/records.jsx
+++ b/frontend/app/league/sections/records.jsx
@@ -5,6 +5,17 @@
 
 import { Card, EmptyCard, fmtNumber, fmtPoints } from "../shared.jsx";
 
+const POSITION_LABELS = {
+  QB: "Quarterbacks",
+  RB: "Running backs",
+  WR: "Wide receivers",
+  TE: "Tight ends",
+  K:  "Kickers",
+  DL: "Defensive linemen",
+  LB: "Linebackers",
+  DB: "Defensive backs",
+};
+
 function RecordsSection({ data }) {
   if (!data) return <EmptyCard label="Records" />;
 
@@ -17,9 +28,16 @@ function RecordsSection({ data }) {
     { title: "Fewest points in a win", key: "fewestPointsInWin" },
   ];
 
+  const playerPositions =
+    data.playerRecordPositions ||
+    Object.keys(data.playerRecords || {});
+  const playerRecordsHasContent = playerPositions.some(
+    (pos) => (data.playerRecords?.[pos] || []).length > 0,
+  );
+
   return (
     <>
-      <Card title="Record book" subtitle="Single-game extremes across the last 2 seasons">
+      <Card title="Record book" subtitle="Single-game extremes (each row is one NFL week)">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 10 }}>
           {groups.map((g) => (
             <div key={g.key} style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
@@ -30,6 +48,9 @@ function RecordsSection({ data }) {
                     <span>
                       <span style={{ color: "var(--subtext)", marginRight: 4 }}>{i + 1}.</span>
                       {r.teamName}
+                      <span style={{ color: "var(--subtext)", marginLeft: 4 }}>
+                        ({r.season} wk {r.week})
+                      </span>
                     </span>
                     <span style={{ fontFamily: "var(--mono)", color: "var(--cyan)" }}>
                       {r.margin !== undefined && g.key.toLowerCase().includes("margin")
@@ -47,7 +68,7 @@ function RecordsSection({ data }) {
         </div>
       </Card>
 
-      <Card title="Season totals" subtitle="Most points scored / allowed in a single season">
+      <Card title="Season totals" subtitle="Most points scored / allowed in a regular season (no playoffs)">
         <div className="row">
           <div className="card" style={{ flex: "1 1 260px" }}>
             <div style={{ fontWeight: 700, marginBottom: 8 }}>Most points in a season</div>
@@ -75,6 +96,43 @@ function RecordsSection({ data }) {
           </div>
         </div>
       </Card>
+
+      {playerRecordsHasContent && (
+        <Card
+          title="Player records · single-week"
+          subtitle="Top starter-only single-week scores by position (regular season)"
+        >
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 10 }}>
+            {playerPositions.map((pos) => {
+              const rows = data.playerRecords?.[pos] || [];
+              if (!rows.length) return null;
+              return (
+                <div key={pos} style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
+                  <div style={{ fontWeight: 700, marginBottom: 6, fontSize: "0.86rem" }}>
+                    {POSITION_LABELS[pos] || pos}
+                  </div>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                    {rows.slice(0, 5).map((r, i) => (
+                      <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "0.74rem" }}>
+                        <span>
+                          <span style={{ color: "var(--subtext)", marginRight: 4 }}>{i + 1}.</span>
+                          {r.playerName || r.playerId}
+                          <span style={{ color: "var(--subtext)", marginLeft: 4 }}>
+                            ({r.displayName}, {r.season} wk {r.week})
+                          </span>
+                        </span>
+                        <span style={{ fontFamily: "var(--mono)", color: "var(--cyan)" }}>
+                          {fmtPoints(r.points)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      )}
 
       <Card title="Streaks" subtitle="Longest consecutive wins / losses (ties end streaks)">
         <div className="row">

--- a/frontend/app/league/sections/streaks.jsx
+++ b/frontend/app/league/sections/streaks.jsx
@@ -2,13 +2,13 @@
 
 // StreaksSection — "Streaks" tab on /league.
 //
-// Three sections, top to bottom:
+// Sections rendered:
 //   * "Records are falling" — records-in-reach: the all-time holder
 //     plus the current-season chaser (if any), with a within-reach flag.
 //   * "Notable this week" — the most recently scored week's games that
 //     cracked the all-time top-5 in a category.
-//   * "Active streaks" — per owner, their trailing W/L/100+/120+/140+
-//     run of consecutive games.
+//   * "Longest win streaks" + "Longest losing streaks" — top-5 of each.
+//   * "Active streaks" — every manager's current trailing W/L run.
 //
 // Reads strictly from ``sections.streaks`` of the public contract.
 
@@ -20,12 +20,10 @@ function StreakTypeLabel(type) {
       return { label: "Win streak", color: "#2ecc71", suffix: "W" };
     case "lossStreak":
       return { label: "Loss streak", color: "#ff6b6b", suffix: "L" };
-    case "plus100Streak":
-      return { label: "100+ streak", color: "#7bdfb3", suffix: "G" };
-    case "plus120Streak":
-      return { label: "120+ streak", color: "#4fc3f7", suffix: "G" };
-    case "plus140Streak":
-      return { label: "140+ streak", color: "#ffa726", suffix: "G" };
+    case "tie":
+      return { label: "Tie", color: "var(--subtext)", suffix: "T" };
+    case "none":
+      return { label: "No games", color: "var(--subtext)", suffix: "" };
     default:
       return { label: type, color: "var(--subtext)", suffix: "" };
   }
@@ -117,7 +115,42 @@ function NotableRow({ n, managers }) {
   );
 }
 
-function ActiveStreakRow({ s, managers }) {
+function LongestStreakRow({ s, managers, color, suffix }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "6px 0",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      <Avatar managers={managers} ownerId={s.ownerId} size={20} />
+      <div style={{ flex: 1, fontSize: "0.78rem" }}>
+        <strong>{nameFor(managers, s.ownerId) || s.displayName}</strong>
+        {s.start && s.end && (
+          <span style={{ color: "var(--subtext)", marginLeft: 8, fontSize: "0.66rem" }}>
+            {s.start.season} wk {s.start.week} → {s.end.season} wk {s.end.week}
+          </span>
+        )}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          color,
+          fontWeight: 700,
+          minWidth: 40,
+          textAlign: "right",
+        }}
+      >
+        {s.length}{suffix}
+      </div>
+    </div>
+  );
+}
+
+function CurrentStreakRow({ s, managers }) {
   const { label, color, suffix } = StreakTypeLabel(s.type);
   return (
     <div
@@ -132,9 +165,11 @@ function ActiveStreakRow({ s, managers }) {
       <Avatar managers={managers} ownerId={s.ownerId} size={20} />
       <div style={{ flex: 1, fontSize: "0.78rem" }}>
         <strong>{nameFor(managers, s.ownerId) || s.displayName}</strong>
-        <span style={{ color: "var(--subtext)", marginLeft: 8, fontSize: "0.66rem" }}>
-          since {s.start?.season} wk {s.start?.week}
-        </span>
+        {s.start && (
+          <span style={{ color: "var(--subtext)", marginLeft: 8, fontSize: "0.66rem" }}>
+            since {s.start.season} wk {s.start.week}
+          </span>
+        )}
       </div>
       <div
         style={{
@@ -145,7 +180,8 @@ function ActiveStreakRow({ s, managers }) {
           textAlign: "right",
         }}
       >
-        {s.length}{suffix} <span style={{ color: "var(--subtext)", fontWeight: 400, fontSize: "0.66rem" }}>{label}</span>
+        {s.length > 0 ? `${s.length}${suffix}` : "—"}{" "}
+        <span style={{ color: "var(--subtext)", fontWeight: 400, fontSize: "0.66rem" }}>{label}</span>
       </div>
     </div>
   );
@@ -153,9 +189,21 @@ function ActiveStreakRow({ s, managers }) {
 
 export default function StreaksSection({ data, managers }) {
   if (!data) return <EmptyCard label="Streaks" />;
-  const { activeStreaks = [], recordsInReach = [], notableThisWeek = [], latestWeek } = data;
+  const {
+    longestWinStreaks = [],
+    longestLossStreaks = [],
+    currentStreaksByOwner = [],
+    recordsInReach = [],
+    notableThisWeek = [],
+    latestWeek,
+  } = data;
 
-  const hasContent = activeStreaks.length + recordsInReach.length + notableThisWeek.length > 0;
+  const hasContent =
+    longestWinStreaks.length +
+      longestLossStreaks.length +
+      currentStreaksByOwner.length +
+      recordsInReach.length +
+      notableThisWeek.length > 0;
   if (!hasContent) return <EmptyCard label="Streaks" />;
 
   return (
@@ -199,19 +247,58 @@ export default function StreaksSection({ data, managers }) {
         </Card>
       )}
 
-      {activeStreaks.length > 0 && (
-        <Card title="Active streaks">
+      {(longestWinStreaks.length > 0 || longestLossStreaks.length > 0) && (
+        <Card title="Longest streaks · top 5 each">
+          <div className="row">
+            <div className="card" style={{ flex: "1 1 260px" }}>
+              <div style={{ fontWeight: 700, marginBottom: 6 }}>Win streaks</div>
+              {longestWinStreaks.length === 0 ? (
+                <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>—</div>
+              ) : (
+                longestWinStreaks.map((s) => (
+                  <LongestStreakRow
+                    key={`win-${s.ownerId}`}
+                    s={s}
+                    managers={managers}
+                    color="#2ecc71"
+                    suffix="W"
+                  />
+                ))
+              )}
+            </div>
+            <div className="card" style={{ flex: "1 1 260px" }}>
+              <div style={{ fontWeight: 700, marginBottom: 6 }}>Losing streaks</div>
+              {longestLossStreaks.length === 0 ? (
+                <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>—</div>
+              ) : (
+                longestLossStreaks.map((s) => (
+                  <LongestStreakRow
+                    key={`loss-${s.ownerId}`}
+                    s={s}
+                    managers={managers}
+                    color="#ff6b6b"
+                    suffix="L"
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {currentStreaksByOwner.length > 0 && (
+        <Card title="Current streak by manager">
           <div>
-            {activeStreaks.map((s) => (
-              <ActiveStreakRow
-                key={`${s.type}-${s.ownerId}`}
+            {currentStreaksByOwner.map((s) => (
+              <CurrentStreakRow
+                key={`cur-${s.ownerId}`}
                 s={s}
                 managers={managers}
               />
             ))}
           </div>
           <div style={{ fontSize: "0.68rem", color: "var(--subtext)", marginTop: 10 }}>
-            Trailing runs only — computed from each manager's most recent game, walking backwards until the streak breaks.
+            Each manager's current trailing run from their most recent game. A tie ends both win and loss streaks.
           </div>
         </Card>
       )}

--- a/frontend/app/league/shared.jsx
+++ b/frontend/app/league/shared.jsx
@@ -176,8 +176,15 @@ export function renderAwardValue(key, value) {
       return `${fmtPercent(value.winPct)} in ${value.closeGames} close games`;
     case "weekly_hammer":
       return `${value.highScoreFinishes} high-score wks`;
-    case "playoff_mvp":
+    case "playoff_mvp": {
+      // Player-based VORP MVP (new format).  Older shape carried
+      // playoffPoints; both are tolerated here so old cached payloads
+      // still render.
+      if (value.playerName) {
+        return `${value.playerName} (${value.position}) · VORP ${fmtPoints(value.vorp)}`;
+      }
       return `${fmtPoints(value.playoffPoints)} playoff pts`;
+    }
     case "bad_beat":
       return `${fmtPoints(value.points)} in loss · Wk ${value.week}`;
     case "best_rebuild":
@@ -186,6 +193,29 @@ export function renderAwardValue(key, value) {
       return `${value.displayNames[0]} vs ${value.displayNames[1]} · Index ${value.rivalryIndex}`;
     case "pick_hoarder":
       return `Weighted ${value.weightedScore} · ${value.totalPicks} picks`;
+    // ── Manager awards ──
+    case "top_offense":
+      return `${fmtNumber(value.offensePoints, 1)} starter pts`;
+    case "top_defense":
+      return `${fmtNumber(value.defensePoints, 1)} starter pts`;
+    case "manager_of_the_year":
+      return `${value.wins}-${value.losses} · ${fmtNumber(value.pointsFor, 1)} PF · score ${fmtNumber(value.compositeScore, 3)}`;
+    // ── Player awards ──
+    case "top_qb":
+    case "top_rb":
+    case "top_wr":
+    case "top_te":
+    case "top_k":
+    case "top_dl":
+    case "top_lb":
+    case "top_db":
+      return value.playerName
+        ? `${value.playerName} · ${fmtPoints(value.starterPoints)} pts in ${value.gamesStarted} starts`
+        : `${fmtPoints(value.starterPoints)} pts`;
+    case "league_mvp":
+      return value.playerName
+        ? `${value.playerName} (${value.position}) · VORP ${fmtPoints(value.vorp)}`
+        : `VORP ${fmtPoints(value.vorp)}`;
     default:
       return "";
   }

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -87,7 +87,9 @@ AWARD_DESCRIPTIONS: dict[str, str] = {
     ),
     "weekly_hammer": "Count of weekly high-score finishes.",
     "playoff_mvp": (
-        "Total team points during the playoffs. Live during playoff weeks."
+        "Highest playoff VORP (Value Over Replacement Player) — the player "
+        "who outscored his position's playoff replacement by the most while "
+        "in a starting lineup."
     ),
     "bad_beat": "Biggest single 'points in a loss' performance.",
     "best_rebuild": (
@@ -98,7 +100,61 @@ AWARD_DESCRIPTIONS: dict[str, str] = {
         "Season's nastiest head-to-head ranked by rivalry index, boosted by "
         "playoff meetings."
     ),
+    # ── Manager awards ──
+    "top_offense": (
+        "Most regular-season points produced by offensive starters "
+        "(QB / RB / WR / TE / K) — bench points excluded."
+    ),
+    "top_defense": (
+        "Most regular-season points produced by defensive starters "
+        "(DL / LB / DB / DEF) — bench points excluded."
+    ),
+    "manager_of_the_year": (
+        "Composite manager rating: 60% regular-season win%, 40% "
+        "regular-season points scored (normalized to league high)."
+    ),
+    # ── Player awards ──
+    "top_qb": "Top QB by total starter-only points scored in the regular season.",
+    "top_rb": "Top RB by total starter-only points scored in the regular season.",
+    "top_wr": "Top WR by total starter-only points scored in the regular season.",
+    "top_te": "Top TE by total starter-only points scored in the regular season.",
+    "top_k":  "Top K by total starter-only points scored in the regular season.",
+    "top_dl": "Top DL by total starter-only points scored in the regular season.",
+    "top_lb": "Top LB by total starter-only points scored in the regular season.",
+    "top_db": "Top DB by total starter-only points scored in the regular season.",
+    "league_mvp": (
+        "Regular-season MVP: highest VORP (Value Over Replacement Player) "
+        "across all positions, computed from starter-only scoring."
+    ),
 }
+
+
+# Player-award positions in display order.
+_PLAYER_AWARD_POSITIONS = ("QB", "RB", "WR", "TE", "K", "DL", "LB", "DB")
+_PLAYER_AWARD_KEY_BY_POS = {
+    "QB": "top_qb",
+    "RB": "top_rb",
+    "WR": "top_wr",
+    "TE": "top_te",
+    "K":  "top_k",
+    "DL": "top_dl",
+    "LB": "top_lb",
+    "DB": "top_db",
+}
+_PLAYER_AWARD_LABEL_BY_POS = {
+    "QB": "Top QB",
+    "RB": "Top RB",
+    "WR": "Top WR",
+    "TE": "Top TE",
+    "K":  "Top Kicker",
+    "DL": "Top DL",
+    "LB": "Top LB",
+    "DB": "Top DB",
+}
+
+# Offensive vs defensive position families for manager awards.
+_OFFENSIVE_POSITIONS = frozenset({"QB", "RB", "WR", "TE", "K"})
+_DEFENSIVE_POSITIONS = frozenset({"DL", "LB", "DB", "DEF"})
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -911,6 +967,434 @@ def _best_rebuild_scores(
     return rows
 
 
+# ── Starter-only scoring helpers (manager + player + MVP awards) ──────────
+def _starter_scoring_walk(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    *,
+    regular_season_only: bool,
+):
+    """Yield ``(week, roster_id, owner_id, player_id, position, points, is_playoff)``
+    for every starter in every scored matchup of the season.
+
+    Skips any matchup-entry that lacks ``players_points`` or ``starters``
+    (older Sleeper seasons sometimes omit them).  Position is resolved
+    via ``snapshot.player_position`` so IDP-eligible players collapse
+    into DL/LB/DB.
+    """
+    for week in sorted(season.matchups_by_week.keys()):
+        is_playoff = week >= season.playoff_week_start
+        if regular_season_only and is_playoff:
+            continue
+        for entry in season.matchups_by_week[week]:
+            rid = metrics.roster_id_of(entry)
+            if rid is None:
+                continue
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+            if not owner_id:
+                continue
+            pp = entry.get("players_points")
+            if not isinstance(pp, dict):
+                continue
+            starters = _starter_set(entry)
+            if not starters:
+                continue
+            for pid in starters:
+                raw = pp.get(pid)
+                try:
+                    pts = float(raw or 0.0)
+                except (TypeError, ValueError):
+                    continue
+                pos = snapshot.player_position(pid)
+                yield week, rid, owner_id, pid, pos, pts, is_playoff
+
+
+def _manager_unit_points(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    *,
+    regular_season_only: bool = True,
+) -> dict[str, dict[str, float]]:
+    """Aggregate starter-only points per owner, partitioned by offense /
+    defense unit.  Returns ``{owner_id: {"offense": pts, "defense": pts}}``.
+    """
+    out: dict[str, dict[str, float]] = {}
+    for _wk, _rid, owner_id, _pid, pos, pts, _is_p in _starter_scoring_walk(
+        snapshot, season, regular_season_only=regular_season_only
+    ):
+        rec = out.setdefault(owner_id, {"offense": 0.0, "defense": 0.0})
+        if pos in _OFFENSIVE_POSITIONS or pos == "":
+            # Default unmapped positions into offense (covers DEF/ST team
+            # defenses too if they appear in an offense-style starter slot).
+            if pos in _DEFENSIVE_POSITIONS:
+                rec["defense"] += pts
+            else:
+                rec["offense"] += pts
+        elif pos in _DEFENSIVE_POSITIONS:
+            rec["defense"] += pts
+        else:
+            rec["offense"] += pts
+    return out
+
+
+def _top_offense_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    units = _manager_unit_points(snapshot, season, regular_season_only=True)
+    rows = []
+    for owner_id, totals in units.items():
+        rows.append({
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "offensePoints": round(totals["offense"], 2),
+        })
+    rows.sort(key=lambda r: -r["offensePoints"])
+    return rows
+
+
+def _top_defense_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    units = _manager_unit_points(snapshot, season, regular_season_only=True)
+    rows = []
+    for owner_id, totals in units.items():
+        rows.append({
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "defensePoints": round(totals["defense"], 2),
+        })
+    # Filter out leagues with no IDP scoring on file so we don't surface
+    # an "everyone tied at 0.0" race.
+    rows = [r for r in rows if r["defensePoints"] > 0]
+    rows.sort(key=lambda r: -r["defensePoints"])
+    return rows
+
+
+def _manager_of_the_year_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    """60% regular-season win% + 40% PF-normalized.  Both rescaled to
+    [0, 1] within the league so a perfect manager would score 1.0.
+    """
+    standings = metrics.season_standings(season, snapshot.managers)
+    if not standings:
+        return []
+    pf_max = max((r["pointsFor"] for r in standings), default=0.0) or 1.0
+    rows = []
+    for r in standings:
+        win_component = r["winPct"]
+        pf_component = r["pointsFor"] / pf_max
+        composite = 0.6 * win_component + 0.4 * pf_component
+        rows.append({
+            "ownerId": r["ownerId"],
+            "displayName": metrics.display_name_for(snapshot, r["ownerId"]),
+            "wins": r["wins"],
+            "losses": r["losses"],
+            "ties": r["ties"],
+            "winPct": round(r["winPct"], 4),
+            "pointsFor": r["pointsFor"],
+            "compositeScore": round(composite, 4),
+        })
+    rows.sort(key=lambda r: (-r["compositeScore"], -r["wins"], -r["pointsFor"]))
+    return rows
+
+
+def _player_starter_totals(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    *,
+    regular_season_only: bool = True,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate starter-only points per player across the season.
+
+    Returns ``{player_id: {points, gamesStarted, position, ownerIds}}``.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for week, _rid, owner_id, pid, pos, pts, _is_p in _starter_scoring_walk(
+        snapshot, season, regular_season_only=regular_season_only
+    ):
+        rec = out.setdefault(pid, {
+            "playerId": pid,
+            "playerName": snapshot.player_display(pid),
+            "position": pos,
+            "starterPoints": 0.0,
+            "gamesStarted": 0,
+            "ownerIds": set(),
+            "lastOwnerId": "",
+            "lastWeek": 0,
+        })
+        # Track the most-recent fantasy owner so we can attribute the
+        # award to a manager card on the page (ownership can change
+        # mid-season after a trade).
+        rec["starterPoints"] += pts
+        rec["gamesStarted"] += 1
+        rec["ownerIds"].add(owner_id)
+        if week >= rec["lastWeek"]:
+            rec["lastWeek"] = week
+            rec["lastOwnerId"] = owner_id
+        # Position can drift if a player is dual-eligible — keep the
+        # IDP-resolved one when present, otherwise overwrite.
+        if pos and not rec["position"]:
+            rec["position"] = pos
+    for rec in out.values():
+        rec["starterPoints"] = round(rec["starterPoints"], 2)
+        rec["ownerIds"] = sorted(rec["ownerIds"])
+    return out
+
+
+def _top_player_per_position_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    *,
+    regular_season_only: bool = True,
+) -> dict[str, list[dict[str, Any]]]:
+    """Top scorers grouped by position from starter-only points.
+
+    Returns ``{pos: [row, row, row]}`` where rows are sorted descending
+    by ``starterPoints``.  Up to top 3 per position.
+    """
+    totals = _player_starter_totals(
+        snapshot, season, regular_season_only=regular_season_only
+    )
+    grouped: dict[str, list[dict[str, Any]]] = {pos: [] for pos in _PLAYER_AWARD_POSITIONS}
+    for pid, rec in totals.items():
+        pos = rec["position"]
+        if pos not in grouped:
+            continue
+        owner_id = rec["lastOwnerId"]
+        grouped[pos].append({
+            "playerId": pid,
+            "playerName": rec["playerName"],
+            "position": pos,
+            "starterPoints": rec["starterPoints"],
+            "gamesStarted": rec["gamesStarted"],
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+        })
+    for pos in grouped:
+        grouped[pos].sort(key=lambda r: -r["starterPoints"])
+    return grouped
+
+
+def _replacement_per_game_for_position(
+    rows: list[dict[str, Any]],
+    starter_slots: int,
+) -> float:
+    """Replacement-level points-per-game at a position.
+
+    Computed as the average ``starterPoints / gamesStarted`` of the
+    five players ranked just below the league's starter cutoff
+    (``starter_slots`` total starting slots filled at this position
+    each week).  Falls back to the worst-tier average if the position
+    has fewer rostered players than expected.
+    """
+    if not rows:
+        return 0.0
+    # Per-game average for each player (filter out zero-game phantoms).
+    per_game = [
+        (r["starterPoints"] / r["gamesStarted"], r)
+        for r in rows
+        if r["gamesStarted"] > 0
+    ]
+    if not per_game:
+        return 0.0
+    per_game.sort(key=lambda x: -x[0])
+    cutoff = max(0, int(starter_slots))
+    band_start = cutoff
+    band_end = cutoff + 5
+    band = per_game[band_start:band_end]
+    if not band:
+        # Position is too thin to draw a replacement band — fall back to
+        # the worst player's per-game line.
+        return per_game[-1][0]
+    return sum(p for p, _ in band) / len(band)
+
+
+def _starter_slot_counts(
+    season: SeasonSnapshot,
+) -> dict[str, int]:
+    """Total starting slots per position across the entire league per week.
+
+    Reads ``league.roster_positions`` and counts both direct slots
+    (``"QB"``) and flexes (``"FLEX"``, ``"SUPER_FLEX"``, ``"REC_FLEX"``,
+    ``"IDP_FLEX"``) which contribute to multiple positions.  Multiplied
+    by ``num_teams``.
+
+    The flex contribution is split evenly across its eligible
+    positions — close enough for a VORP baseline without overfitting.
+    """
+    positions = season.league.get("roster_positions") or []
+    teams = max(1, season.num_teams)
+    counts: dict[str, float] = defaultdict(float)
+    for slot in positions:
+        slot_norm = str(slot or "").upper()
+        if slot_norm in {"BN", "TAXI", "IR", ""}:
+            continue
+        if slot_norm == "FLEX":
+            for p in ("RB", "WR", "TE"):
+                counts[p] += 1.0 / 3.0
+        elif slot_norm in {"SUPER_FLEX", "SUPERFLEX", "SFLEX", "QFLEX"}:
+            for p in ("QB", "RB", "WR", "TE"):
+                counts[p] += 1.0 / 4.0
+        elif slot_norm in {"REC_FLEX", "WRT", "WRRBTE"}:
+            for p in ("WR", "TE", "RB"):
+                counts[p] += 1.0 / 3.0
+        elif slot_norm in {"IDP_FLEX"}:
+            for p in ("DL", "LB", "DB"):
+                counts[p] += 1.0 / 3.0
+        elif slot_norm in {"DEF"}:
+            counts["DEF"] += 1.0
+        else:
+            counts[slot_norm] += 1.0
+    out: dict[str, int] = {}
+    for pos, frac in counts.items():
+        out[pos] = max(1, int(round(frac * teams)))
+    return out
+
+
+def _vorp_rows(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    *,
+    regular_season_only: bool,
+) -> list[dict[str, Any]]:
+    """Compute a VORP row per player.
+
+    Replacement-level baseline is per-position (per-game), so injured
+    starters who scored a lot per game still rate fairly against
+    healthier-but-thinner peers.
+    """
+    totals = _player_starter_totals(
+        snapshot, season, regular_season_only=regular_season_only
+    )
+    if not totals:
+        return []
+
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rec in totals.values():
+        pos = rec["position"]
+        if not pos:
+            continue
+        grouped[pos].append({
+            "playerId": rec["playerId"],
+            "playerName": rec["playerName"],
+            "position": pos,
+            "starterPoints": rec["starterPoints"],
+            "gamesStarted": rec["gamesStarted"],
+            "ownerIds": rec["ownerIds"],
+            "lastOwnerId": rec["lastOwnerId"],
+        })
+
+    starter_slots = _starter_slot_counts(season)
+    out: list[dict[str, Any]] = []
+    for pos, rows in grouped.items():
+        slots = starter_slots.get(pos, 0)
+        if slots <= 0:
+            # No dedicated slot for this position; treat as a thin
+            # baseline so a single-game cameo doesn't outshine real
+            # full-season starters.
+            slots = max(1, len(rows) // 2)
+        replacement_per_game = _replacement_per_game_for_position(rows, slots)
+        for r in rows:
+            games = r["gamesStarted"] or 1
+            replacement_total = replacement_per_game * games
+            vorp = r["starterPoints"] - replacement_total
+            owner_id = r["lastOwnerId"]
+            out.append({
+                "playerId": r["playerId"],
+                "playerName": r["playerName"],
+                "position": pos,
+                "starterPoints": r["starterPoints"],
+                "gamesStarted": r["gamesStarted"],
+                "vorp": round(vorp, 2),
+                "replacementPerGame": round(replacement_per_game, 2),
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+            })
+    out.sort(key=lambda r: -r["vorp"])
+    return out
+
+
+def _league_mvp_rows(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    """Regular-season MVP candidates ranked by VORP."""
+    return _vorp_rows(snapshot, season, regular_season_only=True)
+
+
+def _playoff_mvp_player_rows(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+) -> list[dict[str, Any]]:
+    """Playoff MVP candidates ranked by VORP across playoff weeks only."""
+    totals = _player_starter_totals(
+        snapshot, season, regular_season_only=False
+    )
+    if not totals:
+        return []
+    # Strip regular-season data: we want playoff-only.  Re-run the walk
+    # but only over playoff weeks.
+    playoff_totals: dict[str, dict[str, Any]] = {}
+    for week, _rid, owner_id, pid, pos, pts, is_playoff in _starter_scoring_walk(
+        snapshot, season, regular_season_only=False
+    ):
+        if not is_playoff:
+            continue
+        rec = playoff_totals.setdefault(pid, {
+            "playerId": pid,
+            "playerName": snapshot.player_display(pid),
+            "position": pos,
+            "starterPoints": 0.0,
+            "gamesStarted": 0,
+            "lastOwnerId": "",
+            "lastWeek": 0,
+        })
+        rec["starterPoints"] += pts
+        rec["gamesStarted"] += 1
+        if week >= rec["lastWeek"]:
+            rec["lastWeek"] = week
+            rec["lastOwnerId"] = owner_id
+        if pos and not rec["position"]:
+            rec["position"] = pos
+    if not playoff_totals:
+        return []
+
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rec in playoff_totals.values():
+        pos = rec["position"]
+        if not pos:
+            continue
+        grouped[pos].append(rec)
+
+    starter_slots = _starter_slot_counts(season)
+    out: list[dict[str, Any]] = []
+    for pos, rows in grouped.items():
+        slots = starter_slots.get(pos, 0)
+        if slots <= 0:
+            slots = max(1, len(rows) // 2)
+        replacement_per_game = _replacement_per_game_for_position(rows, slots)
+        for r in rows:
+            games = r["gamesStarted"] or 1
+            vorp = r["starterPoints"] - replacement_per_game * games
+            owner_id = r["lastOwnerId"]
+            out.append({
+                "playerId": r["playerId"],
+                "playerName": r["playerName"],
+                "position": pos,
+                "starterPoints": round(r["starterPoints"], 2),
+                "gamesStarted": r["gamesStarted"],
+                "vorp": round(vorp, 2),
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+            })
+    out.sort(key=lambda r: -r["vorp"])
+    return out
+
+
 def _rivalry_of_the_year(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> dict[str, Any] | None:
     """Season-scoped rivalry of the year."""
     pair_scores: dict[tuple[str, str], dict[str, Any]] = {}
@@ -1100,15 +1584,27 @@ def _activity_awards_for_season(
         snapshot, season, hammer_rows, "weekly_hammer", "Weekly Hammer",
         lambda r: {"highScoreFinishes": r["highScoreFinishes"], "highestWeek": r["highestWeekPoints"]},
     ))
-    if playoff_rows and playoff_rows[0]["playoffWeeksPlayed"] > 0:
-        _add(_award_from_row(
-            snapshot, season, playoff_rows, "playoff_mvp", "Playoff MVP",
-            lambda r: {
-                "playoffPoints": r["playoffPoints"],
-                "topPlayerName": r["topPlayerName"] or None,
-                "topPlayerPoints": r["topPlayerPoints"] or None,
+    # Playoff MVP — VORP-based player award (replaces the prior team-points version).
+    playoff_mvp_rows = _playoff_mvp_player_rows(snapshot, season)
+    if playoff_mvp_rows:
+        winner = playoff_mvp_rows[0]
+        rid = _roster_id_for_owner(season, winner["ownerId"])
+        awards.append({
+            "key": "playoff_mvp",
+            "label": "Playoff MVP",
+            "description": AWARD_DESCRIPTIONS["playoff_mvp"],
+            "ownerId": winner["ownerId"],
+            "displayName": winner["displayName"],
+            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
+            "value": {
+                "playerId": winner["playerId"],
+                "playerName": winner["playerName"],
+                "position": winner["position"],
+                "vorp": winner["vorp"],
+                "starterPoints": winner["starterPoints"],
+                "gamesStarted": winner["gamesStarted"],
             },
-        ))
+        })
     _add(_award_from_row(
         snapshot, season, bad_beat_rows, "bad_beat", "Bad Beat",
         lambda r: {
@@ -1117,6 +1613,80 @@ def _activity_awards_for_season(
             "opponentPoints": r["biggestLossOpponentPoints"],
         },
     ))
+
+    # ── Manager awards ─────────────────────────────────────────────
+    offense_rows = _top_offense_scores(snapshot, season)
+    _add(_award_from_row(
+        snapshot, season, offense_rows, "top_offense", "Top Offense",
+        lambda r: {"offensePoints": r["offensePoints"]},
+    ))
+    defense_rows = _top_defense_scores(snapshot, season)
+    if defense_rows:
+        _add(_award_from_row(
+            snapshot, season, defense_rows, "top_defense", "Top Defense",
+            lambda r: {"defensePoints": r["defensePoints"]},
+        ))
+    moty_rows = _manager_of_the_year_scores(snapshot, season)
+    _add(_award_from_row(
+        snapshot, season, moty_rows, "manager_of_the_year", "Manager of the Year",
+        lambda r: {
+            "compositeScore": r["compositeScore"],
+            "wins": r["wins"],
+            "losses": r["losses"],
+            "winPct": r["winPct"],
+            "pointsFor": r["pointsFor"],
+        },
+    ))
+
+    # ── Player awards (top scorer per position, regular-season starter-only) ──
+    player_rows_by_pos = _top_player_per_position_scores(
+        snapshot, season, regular_season_only=True
+    )
+    for pos in _PLAYER_AWARD_POSITIONS:
+        rows = player_rows_by_pos.get(pos) or []
+        if not rows:
+            continue
+        winner = rows[0]
+        if winner["starterPoints"] <= 0:
+            continue
+        rid = _roster_id_for_owner(season, winner["ownerId"]) if winner["ownerId"] else None
+        awards.append({
+            "key": _PLAYER_AWARD_KEY_BY_POS[pos],
+            "label": _PLAYER_AWARD_LABEL_BY_POS[pos],
+            "description": AWARD_DESCRIPTIONS[_PLAYER_AWARD_KEY_BY_POS[pos]],
+            "ownerId": winner["ownerId"],
+            "displayName": winner["displayName"],
+            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
+            "value": {
+                "playerId": winner["playerId"],
+                "playerName": winner["playerName"],
+                "position": winner["position"],
+                "starterPoints": winner["starterPoints"],
+                "gamesStarted": winner["gamesStarted"],
+            },
+        })
+
+    # ── League MVP (regular-season VORP) ───────────────────────────
+    mvp_rows = _league_mvp_rows(snapshot, season)
+    if mvp_rows:
+        winner = mvp_rows[0]
+        rid = _roster_id_for_owner(season, winner["ownerId"]) if winner["ownerId"] else None
+        awards.append({
+            "key": "league_mvp",
+            "label": "League MVP",
+            "description": AWARD_DESCRIPTIONS["league_mvp"],
+            "ownerId": winner["ownerId"],
+            "displayName": winner["displayName"],
+            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
+            "value": {
+                "playerId": winner["playerId"],
+                "playerName": winner["playerName"],
+                "position": winner["position"],
+                "vorp": winner["vorp"],
+                "starterPoints": winner["starterPoints"],
+                "gamesStarted": winner["gamesStarted"],
+            },
+        })
 
     pick_rows = _pick_hoarder_scores(snapshot)
     if pick_rows:
@@ -1238,14 +1808,29 @@ def _current_season_races(
         snapshot, "weekly_hammer", "Weekly Hammer", hammer_rows,
         lambda r: {"highScoreFinishes": r["highScoreFinishes"], "highestWeek": r["highestWeekPoints"]},
     ))
-    if playoff_rows and playoff_rows[0]["playoffWeeksPlayed"] > 0:
-        _add(_build_race(
-            snapshot, "playoff_mvp", "Playoff MVP", playoff_rows,
-            lambda r: {
-                "playoffPoints": r["playoffPoints"],
-                "weeksPlayed": r["playoffWeeksPlayed"],
-            },
-        ))
+    playoff_mvp_rows = _playoff_mvp_player_rows(snapshot, season)
+    if playoff_mvp_rows:
+        race = {
+            "key": "playoff_mvp",
+            "label": "Playoff MVP",
+            "description": AWARD_DESCRIPTIONS["playoff_mvp"],
+            "leaders": [
+                {
+                    "rank": i + 1,
+                    "ownerId": r["ownerId"],
+                    "displayName": r["displayName"],
+                    "value": {
+                        "playerId": r["playerId"],
+                        "playerName": r["playerName"],
+                        "position": r["position"],
+                        "vorp": r["vorp"],
+                        "starterPoints": r["starterPoints"],
+                    },
+                }
+                for i, r in enumerate(playoff_mvp_rows[:3])
+            ],
+        }
+        _add(race)
     _add(_build_race(
         snapshot, "bad_beat", "Bad Beat", bad_beat_rows,
         lambda r: {
@@ -1257,6 +1842,87 @@ def _current_season_races(
         snapshot, "pick_hoarder", "Pick Hoarder", pick_rows,
         lambda r: {"weightedScore": r["weightedScore"], "totalPicks": r["totalPicks"]},
     ))
+
+    # ── Manager-award races ──
+    offense_rows = _top_offense_scores(snapshot, season)
+    _add(_build_race(
+        snapshot, "top_offense", "Top Offense Race", offense_rows,
+        lambda r: {"offensePoints": r["offensePoints"]},
+    ))
+    defense_rows = _top_defense_scores(snapshot, season)
+    if defense_rows:
+        _add(_build_race(
+            snapshot, "top_defense", "Top Defense Race", defense_rows,
+            lambda r: {"defensePoints": r["defensePoints"]},
+        ))
+    moty_rows = _manager_of_the_year_scores(snapshot, season)
+    _add(_build_race(
+        snapshot, "manager_of_the_year", "Manager of the Year Race", moty_rows,
+        lambda r: {
+            "compositeScore": r["compositeScore"],
+            "wins": r["wins"],
+            "losses": r["losses"],
+            "winPct": r["winPct"],
+            "pointsFor": r["pointsFor"],
+        },
+    ))
+
+    # ── Player-award races (top 3 per position) ──
+    player_rows_by_pos = _top_player_per_position_scores(
+        snapshot, season, regular_season_only=True
+    )
+    for pos in _PLAYER_AWARD_POSITIONS:
+        rows = player_rows_by_pos.get(pos) or []
+        rows = [r for r in rows if r["starterPoints"] > 0]
+        if not rows:
+            continue
+        race = {
+            "key": _PLAYER_AWARD_KEY_BY_POS[pos],
+            "label": f"{_PLAYER_AWARD_LABEL_BY_POS[pos]} Race",
+            "description": AWARD_DESCRIPTIONS[_PLAYER_AWARD_KEY_BY_POS[pos]],
+            "leaders": [
+                {
+                    "rank": i + 1,
+                    "ownerId": r["ownerId"],
+                    "displayName": r["displayName"],
+                    "value": {
+                        "playerId": r["playerId"],
+                        "playerName": r["playerName"],
+                        "position": r["position"],
+                        "starterPoints": r["starterPoints"],
+                        "gamesStarted": r["gamesStarted"],
+                    },
+                }
+                for i, r in enumerate(rows[:3])
+            ],
+        }
+        _add(race)
+
+    # ── League MVP race ──
+    mvp_rows = _league_mvp_rows(snapshot, season)
+    if mvp_rows:
+        race = {
+            "key": "league_mvp",
+            "label": "League MVP Race",
+            "description": AWARD_DESCRIPTIONS["league_mvp"],
+            "leaders": [
+                {
+                    "rank": i + 1,
+                    "ownerId": r["ownerId"],
+                    "displayName": r["displayName"],
+                    "value": {
+                        "playerId": r["playerId"],
+                        "playerName": r["playerName"],
+                        "position": r["position"],
+                        "vorp": r["vorp"],
+                        "starterPoints": r["starterPoints"],
+                        "gamesStarted": r["gamesStarted"],
+                    },
+                }
+                for i, r in enumerate(mvp_rows[:3])
+            ],
+        }
+        _add(race)
 
     return races
 

--- a/src/public_league/records.py
+++ b/src/public_league/records.py
@@ -3,13 +3,17 @@
 Full dynasty record book — single-game highs/lows, margin records,
 most-points-in-a-loss / fewest-in-a-win, per-season scoring totals,
 longest win/loss streaks, per-season trade/waiver counts, FAAB records,
-and playoff scoring records.
+playoff scoring records, and per-position player records.
 
 Streak rules:
     * Chronological regular-season + playoff games only.
     * Ties end both win and loss streaks.
     * Byes (rows with points == 0 AND no paired matchup) are skipped,
       not counted as wins or losses.
+
+Single-week records use individual-week side rows (no combined-finals
+fusion) so the highest single-week always reflects exactly one NFL week
+of scoring.
 """
 from __future__ import annotations
 
@@ -19,8 +23,18 @@ from . import metrics
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
 
+# Positions we track player records for.  Order = display order in the UI.
+_PLAYER_RECORD_POSITIONS = ("QB", "RB", "WR", "TE", "K", "DL", "LB", "DB")
+
+
 def _weekly_side_rows(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
-    """Return every paired, scored roster-week with its opposing score."""
+    """Return every paired, scored roster-week with its opposing score.
+
+    Combined-week finals (multi-week championships) are emitted as ONE
+    row carrying both weeks' summed score — used for rivalry/meeting
+    bookkeeping.  See ``_weekly_side_rows_individual`` for un-combined
+    rows used by single-week records.
+    """
     rows: list[dict[str, Any]] = []
     for season, week, a, b, is_playoff in metrics.walk_matchup_pairs(snapshot):
         # Multi-week finals collapse to one pair; stamp the spanned
@@ -55,6 +69,53 @@ def _weekly_side_rows(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
             if combined_weeks and len(combined_weeks) > 1:
                 row["combinedWeeks"] = list(combined_weeks)
             rows.append(row)
+    return rows
+
+
+def _weekly_side_rows_individual(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
+    """Per-individual-week side rows.  Never fuses multi-week finals.
+
+    Used by single-week record categories (highest score, biggest
+    margin, narrowest victory, etc.) so a 2-week championship is
+    counted as TWO separate weeks of scoring rather than one combined
+    300-point explosion.
+    """
+    rows: list[dict[str, Any]] = []
+    for season in snapshot.seasons:
+        for week in sorted(season.matchups_by_week.keys()):
+            entries = season.matchups_by_week.get(week) or []
+            is_playoff = week >= season.playoff_week_start
+            for a, b in metrics.matchup_pairs(entries):
+                for me, foe in ((a, b), (b, a)):
+                    rid = metrics.roster_id_of(me)
+                    if rid is None:
+                        continue
+                    my_pts = metrics.matchup_points(me)
+                    opp_pts = metrics.matchup_points(foe)
+                    if my_pts <= 0:
+                        continue
+                    owner_id = metrics.resolve_owner(
+                        snapshot.managers, season.league_id, rid
+                    )
+                    if not owner_id:
+                        continue
+                    margin = my_pts - opp_pts
+                    result = "W" if margin > 0 else ("L" if margin < 0 else "T")
+                    rows.append({
+                        "season": season.season,
+                        "leagueId": season.league_id,
+                        "week": week,
+                        "isPlayoff": is_playoff,
+                        "ownerId": owner_id,
+                        "rosterId": rid,
+                        "teamName": metrics.team_name(
+                            snapshot, season.league_id, rid
+                        ),
+                        "points": round(my_pts, 2),
+                        "opponentPoints": round(opp_pts, 2),
+                        "margin": round(margin, 2),
+                        "result": result,
+                    })
     return rows
 
 
@@ -197,11 +258,25 @@ def _trade_waiver_counts(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]
     return out
 
 
-def _season_scoring_totals(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
-    """Per-owner-per-season total PF / PA / weeks."""
+def _season_scoring_totals(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    regular_season_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Per-owner-per-season total PF / PA / weeks.
+
+    When ``regular_season_only`` is True (default), playoff weeks are
+    excluded so the resulting "most points in a season" leaderboard
+    reflects regular-season scoring only.
+    """
     by_key: dict[tuple[str, str], dict[str, Any]] = {}
     for season in snapshot.seasons:
-        for wk in season.all_weeks:
+        weeks = (
+            season.regular_season_weeks
+            if regular_season_only
+            else season.all_weeks
+        )
+        for wk in weeks:
             for a, b in metrics.matchup_pairs(season.matchups_by_week.get(wk) or []):
                 for me, foe in ((a, b), (b, a)):
                     if not metrics.is_scored(me) and not metrics.is_scored(foe):
@@ -234,6 +309,71 @@ def _season_scoring_totals(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any
     return rows
 
 
+def _starter_set(entry: dict[str, Any]) -> list[str]:
+    starters = entry.get("starters") or []
+    return [str(s) for s in starters if s]
+
+
+def _player_records(snapshot: PublicLeagueSnapshot) -> dict[str, list[dict[str, Any]]]:
+    """Top single-week starter-only scorers grouped by position.
+
+    Regular season only.  Only counts a player's points when they
+    appeared in the starting lineup.  Returns ``{position: [top5...]}``
+    ordered by points descending.
+    """
+    by_position: dict[str, list[dict[str, Any]]] = {pos: [] for pos in _PLAYER_RECORD_POSITIONS}
+
+    for season in snapshot.seasons:
+        for week in season.regular_season_weeks:
+            entries = season.matchups_by_week.get(week) or []
+            for entry in entries:
+                rid = metrics.roster_id_of(entry)
+                if rid is None:
+                    continue
+                owner_id = metrics.resolve_owner(
+                    snapshot.managers, season.league_id, rid
+                )
+                if not owner_id:
+                    continue
+                pp = entry.get("players_points")
+                if not isinstance(pp, dict):
+                    continue
+                starters = _starter_set(entry)
+                if not starters:
+                    continue
+                for pid in starters:
+                    raw = pp.get(pid)
+                    try:
+                        pts = float(raw or 0.0)
+                    except (TypeError, ValueError):
+                        continue
+                    if pts <= 0:
+                        continue
+                    pos = snapshot.player_position(pid)
+                    if not pos or pos not in by_position:
+                        continue
+                    by_position[pos].append({
+                        "season": season.season,
+                        "leagueId": season.league_id,
+                        "week": week,
+                        "ownerId": owner_id,
+                        "rosterId": rid,
+                        "teamName": metrics.team_name(snapshot, season.league_id, rid),
+                        "displayName": metrics.display_name_for(snapshot, owner_id),
+                        "playerId": pid,
+                        "playerName": snapshot.player_display(pid),
+                        "position": pos,
+                        "points": round(pts, 2),
+                    })
+
+    out: dict[str, list[dict[str, Any]]] = {}
+    for pos, rows in by_position.items():
+        rows.sort(key=lambda r: -r["points"])
+        # Top 5 single-week explosions per position.
+        out[pos] = rows[:5]
+    return out
+
+
 def _playoff_records(side_rows: list[dict[str, Any]], snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     playoff_rows = [r for r in side_rows if r["isPlayoff"]]
     most_points = _top_n(playoff_rows, "points", reverse=True, n=5)
@@ -260,41 +400,44 @@ def _playoff_records(side_rows: list[dict[str, Any]], snapshot: PublicLeagueSnap
 
 
 def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    # Combined side rows preserve the multi-week-finals fusion for
+    # rivalries / playoff bookkeeping.
     side_rows = _weekly_side_rows(snapshot)
+    # Individual side rows are the truth for "single-week" record
+    # categories — never fused, so each row is exactly one NFL week.
+    individual_rows = _weekly_side_rows_individual(snapshot)
     win_streaks, loss_streaks = _streaks(snapshot)
-    season_totals = _season_scoring_totals(snapshot)
+    season_totals_regular = _season_scoring_totals(snapshot, regular_season_only=True)
     trade_waiver = _trade_waiver_counts(snapshot)
 
-    # Single-game highs / lows (regular + playoffs).
-    highest = _top_n(side_rows, "points", reverse=True, n=10)
-    lowest = _top_n(side_rows, "points", reverse=False, n=10)
+    # Single-game highs / lows from the un-combined per-week rows.
+    highest = _top_n(individual_rows, "points", reverse=True, n=10)
+    lowest = _top_n(individual_rows, "points", reverse=False, n=10)
 
-    # Margin records.
-    biggest_margin = _top_n(side_rows, "margin", reverse=True, n=10)
+    # Margin records (also single-week only).
+    biggest_margin = _top_n(individual_rows, "margin", reverse=True, n=10)
     narrowest_margin = _top_n(
-        [r for r in side_rows if r["result"] == "W"],
+        [r for r in individual_rows if r["result"] == "W"],
         "margin",
         reverse=False,
         n=10,
     )
-    # Most points in a loss (biggest points among losers).
     most_points_in_loss = _top_n(
-        [r for r in side_rows if r["result"] == "L"],
+        [r for r in individual_rows if r["result"] == "L"],
         "points",
         reverse=True,
         n=5,
     )
-    # Fewest points in a win.
     fewest_points_in_win = _top_n(
-        [r for r in side_rows if r["result"] == "W"],
+        [r for r in individual_rows if r["result"] == "W"],
         "points",
         reverse=False,
         n=5,
     )
 
-    # Season-level top lists.
-    most_points_season = sorted(season_totals, key=lambda r: -r["totalPoints"])[:10]
-    most_pa_season = sorted(season_totals, key=lambda r: -r["totalPointsAgainst"])[:10]
+    # Season-level top lists — regular season only per user request.
+    most_points_season = sorted(season_totals_regular, key=lambda r: -r["totalPoints"])[:10]
+    most_pa_season = sorted(season_totals_regular, key=lambda r: -r["totalPointsAgainst"])[:10]
 
     most_trades_season = sorted(trade_waiver, key=lambda r: -r["tradeCount"])[:3]
     most_waivers_season = sorted(trade_waiver, key=lambda r: -r["waiverCount"])[:3]
@@ -318,4 +461,6 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         "mostWaiversInSeason": most_waivers_season,
         "largestFaabBid": [r["maxFaab"] for r in largest_faab[:3]],
         "playoffRecords": _playoff_records(side_rows, snapshot),
+        "playerRecords": _player_records(snapshot),
+        "playerRecordPositions": list(_PLAYER_RECORD_POSITIONS),
     }

--- a/src/public_league/streaks.py
+++ b/src/public_league/streaks.py
@@ -8,16 +8,20 @@ headline rail.
 
 Output shape
 ────────────
-``activeStreaks``    — per owner, their current trailing run of wins,
-                       losses, 100+ point weeks, 120+ point weeks, etc.
-                       Ordered so the longest streak leads, grouped by type.
-``recordsInReach``   — per all-time record, the reigning holder and
-                       the closest active chaser (if any).
-``notableThisWeek``  — most recent scored week's entries that placed
-                       in the all-time top-N for a category (e.g.
-                       "3rd-highest score of all time").
-``seasonsCovered``   — passthrough.
-``currentSeason``    — passthrough.
+``activeStreaks``       — per owner, their current trailing run of
+                          wins or losses (whichever is active).  Each
+                          entry includes a ``length`` and start/end
+                          metadata.
+``longestWinStreaks``   — top-5 all-time win streaks across all
+                          owners (each owner's longest only).
+``longestLossStreaks``  — top-5 all-time loss streaks across all
+                          owners (each owner's longest only).
+``recordsInReach``      — per all-time record, the reigning holder
+                          and the closest active chaser (if any).
+``notableThisWeek``     — most recent scored week's entries that
+                          placed in the all-time top-N for a category.
+``seasonsCovered``      — passthrough.
+``currentSeason``       — passthrough.
 """
 from __future__ import annotations
 
@@ -26,11 +30,6 @@ from typing import Any
 
 from . import metrics
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
-
-
-# Point thresholds we track "consecutive weeks above X" for.  Picked to
-# be broad enough that most dynasty leagues hit them weekly.
-_POINT_THRESHOLDS = (100.0, 120.0, 140.0)
 
 
 # How many entries the "records in reach" list pulls for each category.
@@ -115,7 +114,9 @@ def _active_streaks_for_owner(
     owner_id: str,
     display_name: str,
 ) -> dict[str, dict[str, Any]]:
-    """Compute trailing streaks for one owner from their chronological events."""
+    """Compute the trailing W/L streak for one owner from their
+    chronological events.  Ties end both — return empty dict for ties.
+    """
     if not events:
         return {}
     rev = list(reversed(events))
@@ -147,22 +148,6 @@ def _active_streaks_for_owner(
                 "end": end,
             }
     # A tie ends both streaks; no trailing run either way.
-
-    # Point-threshold streaks are independent of W/L and track consecutive
-    # games where the owner scored ≥ threshold.
-    for t in _POINT_THRESHOLDS:
-        length, start, end = _trailing_run(rev, lambda e, thr=t: e["points"] >= thr)
-        if length > 0:
-            key = f"plus{int(t)}Streak"
-            out[key] = {
-                "type": key,
-                "threshold": t,
-                "ownerId": owner_id,
-                "displayName": display_name,
-                "length": length,
-                "start": start,
-                "end": end,
-            }
     return out
 
 
@@ -191,22 +176,32 @@ def _active_streaks_all(
     return dict(collected)
 
 
-def _longest_ever_win_loss(
+def _longest_streaks_per_owner(
     events: list[dict[str, Any]],
     snapshot: PublicLeagueSnapshot,
-) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-    """All-time longest win and loss streaks (chronological, ties break)."""
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """All-time longest win and loss streaks per owner (chronological).
+
+    Returns ``(wins, losses)`` — each a list with one row per owner who
+    had at least one streak of length >= 1, sorted descending by length.
+    A tie in either direction breaks both running streaks (matches the
+    record-book convention).
+    """
     by_owner: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for ev in events:
         by_owner[ev["ownerId"]].append(ev)
 
-    best_win = None
-    best_loss = None
+    win_rows: list[dict[str, Any]] = []
+    loss_rows: list[dict[str, Any]] = []
+
     for owner_id, owner_events in by_owner.items():
+        owner_events.sort(key=_chron_key)
         cur_w = 0
         cur_l = 0
         w_start = None
         l_start = None
+        best_w = {"length": 0, "start": None, "end": None}
+        best_l = {"length": 0, "start": None, "end": None}
         for ev in owner_events:
             if ev["result"] == "W":
                 cur_l = 0
@@ -214,52 +209,36 @@ def _longest_ever_win_loss(
                 cur_w += 1
                 if cur_w == 1:
                     w_start = ev
-                if best_win is None or cur_w > best_win["length"]:
-                    best_win = {
-                        "ownerId": owner_id,
-                        "displayName": metrics.display_name_for(snapshot, owner_id),
-                        "length": cur_w,
-                        "start": w_start,
-                        "end": ev,
-                    }
+                if cur_w > best_w["length"]:
+                    best_w = {"length": cur_w, "start": w_start, "end": ev}
             elif ev["result"] == "L":
                 cur_w = 0
                 w_start = None
                 cur_l += 1
                 if cur_l == 1:
                     l_start = ev
-                if best_loss is None or cur_l > best_loss["length"]:
-                    best_loss = {
-                        "ownerId": owner_id,
-                        "displayName": metrics.display_name_for(snapshot, owner_id),
-                        "length": cur_l,
-                        "start": l_start,
-                        "end": ev,
-                    }
+                if cur_l > best_l["length"]:
+                    best_l = {"length": cur_l, "start": l_start, "end": ev}
             else:
                 cur_w = 0
                 cur_l = 0
                 w_start = None
                 l_start = None
-
-    return best_win, best_loss
-
-
-def _top_score_events(
-    events: list[dict[str, Any]],
-    highest: bool,
-    n: int = _RECORDS_IN_REACH_TOP_N,
-) -> list[dict[str, Any]]:
-    filtered = [e for e in events if e["points"] > 0]
-    filtered.sort(key=lambda e: e["points"], reverse=highest)
-    out = []
-    for e in filtered[:n]:
-        out.append({
-            "rank": len(out) + 1,
-            **e,
-            "displayName": None,  # filled in by caller
-        })
-    return out
+        if best_w["length"] > 0:
+            win_rows.append({
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                **best_w,
+            })
+        if best_l["length"] > 0:
+            loss_rows.append({
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                **best_l,
+            })
+    win_rows.sort(key=lambda r: -r["length"])
+    loss_rows.sort(key=lambda r: -r["length"])
+    return win_rows, loss_rows
 
 
 def _latest_scored_week(
@@ -285,18 +264,16 @@ def _notable_this_week(
     events: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Entries from the most recent scored week that crack the all-time
-    top-10 in any point-total, margin, or bad-beat category.
+    top-N in any point-total, margin, or bad-beat category.
     """
     latest = _latest_scored_week(snapshot)
     if latest is None:
         return []
     latest_season, latest_week = latest
 
-    # All-time sorted stacks.
     by_points_hi = sorted(events, key=lambda e: -e["points"])
     by_points_lo = sorted([e for e in events if e["points"] > 0], key=lambda e: e["points"])
     by_margin_hi = sorted(events, key=lambda e: -e["margin"])
-    # Bad beats: high points in a loss (margin < 0, points high).
     losses = [e for e in events if e["result"] == "L"]
     by_bad_beat = sorted(losses, key=lambda e: -e["points"])
 
@@ -385,6 +362,8 @@ def _ordinal_label(rank: int, thing: str) -> str:
 def _records_in_reach(
     snapshot: PublicLeagueSnapshot,
     events: list[dict[str, Any]],
+    longest_wins: list[dict[str, Any]],
+    longest_losses: list[dict[str, Any]],
     active_streaks: dict[str, list[dict[str, Any]]],
 ) -> list[dict[str, Any]]:
     """For each all-time record, return the holder + the closest chaser."""
@@ -406,7 +385,6 @@ def _records_in_reach(
                 "week": holder_ev["week"],
             },
         })
-        # Current season candidates.
         current_year = snapshot.current_season.season if snapshot.current_season else None
         current = [e for e in scored if e["season"] == current_year]
         if current:
@@ -424,8 +402,8 @@ def _records_in_reach(
                 }
 
     # Longest win streak.
-    best_win, best_loss = _longest_ever_win_loss(events, snapshot)
-    if best_win:
+    if longest_wins:
+        best_win = longest_wins[0]
         rec = {
             "category": "longestWinStreak",
             "label": "Longest win streak",
@@ -438,7 +416,6 @@ def _records_in_reach(
                 "week": best_win["end"]["week"] if best_win["end"] else None,
             },
         }
-        # Active win streak chaser.
         active_wins = active_streaks.get("winStreak") or []
         if active_wins:
             top = active_wins[0]
@@ -452,7 +429,8 @@ def _records_in_reach(
                     "withinReach": top["length"] >= best_win["length"] - 1,
                 }
         records.append(rec)
-    if best_loss:
+    if longest_losses:
+        best_loss = longest_losses[0]
         rec = {
             "category": "longestLossStreak",
             "label": "Longest losing streak",
@@ -482,28 +460,86 @@ def _records_in_reach(
     return records
 
 
+def _current_streaks_per_owner(
+    snapshot: PublicLeagueSnapshot,
+    events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """One row per active manager describing whatever W/L run they're
+    currently riding (or "tied / no streak" when the most recent game
+    ended in a tie).  Sorted longest first, with win streaks before
+    loss streaks for ties on length.
+    """
+    by_owner: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for ev in events:
+        by_owner[ev["ownerId"]].append(ev)
+
+    rows: list[dict[str, Any]] = []
+    for owner_id in snapshot.managers.by_owner_id.keys():
+        display = metrics.display_name_for(snapshot, owner_id)
+        owner_events = by_owner.get(owner_id) or []
+        if not owner_events:
+            rows.append({
+                "ownerId": owner_id,
+                "displayName": display,
+                "type": "none",
+                "length": 0,
+                "start": None,
+                "end": None,
+            })
+            continue
+        owner_events.sort(key=_chron_key)
+        rev = list(reversed(owner_events))
+        latest = rev[0]
+        if latest["result"] == "W":
+            length, start, end = _trailing_run(rev, lambda e: e["result"] == "W")
+            rows.append({
+                "ownerId": owner_id,
+                "displayName": display,
+                "type": "winStreak",
+                "length": length,
+                "start": start,
+                "end": end,
+            })
+        elif latest["result"] == "L":
+            length, start, end = _trailing_run(rev, lambda e: e["result"] == "L")
+            rows.append({
+                "ownerId": owner_id,
+                "displayName": display,
+                "type": "lossStreak",
+                "length": length,
+                "start": start,
+                "end": end,
+            })
+        else:
+            rows.append({
+                "ownerId": owner_id,
+                "displayName": display,
+                "type": "tie",
+                "length": 0,
+                "start": None,
+                "end": latest,
+            })
+    type_priority = {"winStreak": 0, "lossStreak": 1, "tie": 2, "none": 3}
+    rows.sort(key=lambda r: (type_priority.get(r["type"], 99), -r["length"]))
+    return rows
+
+
 # ── Public builder ───────────────────────────────────────────────────────
 def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     events = _all_events(snapshot)
     active = _active_streaks_all(snapshot, events)
-    records = _records_in_reach(snapshot, events, active)
+    longest_wins, longest_losses = _longest_streaks_per_owner(events, snapshot)
+    records = _records_in_reach(snapshot, events, longest_wins, longest_losses, active)
     notable = _notable_this_week(snapshot, events)
     latest = _latest_scored_week(snapshot)
+    current_per_owner = _current_streaks_per_owner(snapshot, events)
 
-    # Flatten active streaks into a single sorted list for rendering
-    # convenience, keeping each owner's longest only.
+    # Flatten active streaks (W/L only) longest first.
     active_flat: list[dict[str, Any]] = []
-    for stype, rows in active.items():
-        for r in rows:
+    for stype in ("winStreak", "lossStreak"):
+        for r in active.get(stype) or []:
             active_flat.append({**r, "type": stype})
-    # Sort longest first within type priority: win > loss > plus140 > plus120 > plus100
-    type_priority = {
-        "winStreak": 0,
-        "lossStreak": 1,
-        "plus140Streak": 2,
-        "plus120Streak": 3,
-        "plus100Streak": 4,
-    }
+    type_priority = {"winStreak": 0, "lossStreak": 1}
     active_flat.sort(key=lambda s: (type_priority.get(s["type"], 99), -s["length"]))
 
     return {
@@ -513,10 +549,12 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             {"season": latest[0], "week": latest[1]} if latest else None
         ),
         "activeStreaks": active_flat,
-        "activeStreaksByType": active,
+        "activeStreaksByType": {
+            k: v for k, v in active.items() if k in ("winStreak", "lossStreak")
+        },
+        "currentStreaksByOwner": current_per_owner,
+        "longestWinStreaks": longest_wins[:5],
+        "longestLossStreaks": longest_losses[:5],
         "recordsInReach": records,
         "notableThisWeek": notable,
-        "thresholds": {
-            "points": list(_POINT_THRESHOLDS),
-        },
     }

--- a/src/public_league/weekly_recap.py
+++ b/src/public_league/weekly_recap.py
@@ -1,11 +1,13 @@
 """Section: Weekly Recap Newsletter.
 
-Auto-generates a narrative-grade recap for every completed scored week
-in the snapshot:
+Auto-generates an ESPN-style narrative recap for every completed
+scored week in the snapshot:
 
     * Headline — single sentence capturing the week's dominant story.
-    * Summary — 2-3 sentences with standings implication, star of the
-      week, and the biggest surprise.
+    * Summary — multi-sentence post-game analysis. Includes standings
+      context, MVP, blowout/nail-biter framing, top performers, bad
+      beats, and recent activity. Uses a varied phrase bank so two
+      consecutive weeks don't read identically.
     * Superlatives — blowout / nailbiter / MVP / bust / bad beat.
     * Per-matchup one-liners with winner, margin, highlight.
     * Trades that were completed during the week's transaction leg.
@@ -23,7 +25,7 @@ Output shape
 """
 from __future__ import annotations
 
-from collections import defaultdict
+import random
 from typing import Any
 
 from . import metrics
@@ -54,12 +56,7 @@ def _weekly_trades_for(
     snapshot: PublicLeagueSnapshot,
     week: int,
 ) -> list[dict[str, Any]]:
-    """Return completed trades whose transaction ``leg`` matches ``week``.
-
-    We deliberately expose only rosterIds and counts, not asset details
-    — the ``activity`` section already carries the full trade payload
-    with grades.  The recap is a pointer into that surface.
-    """
+    """Return completed trades whose transaction ``leg`` matches ``week``."""
     out: list[dict[str, Any]] = []
     for tx in season.trades():
         try:
@@ -89,81 +86,309 @@ def _weekly_trades_for(
     return out
 
 
-def _matchup_oneliner(home: dict, away: dict, margin: float) -> str:
+# ── Per-matchup one-liner phrase bank ─────────────────────────────────────
+_TIE_PHRASES = (
+    "{a} and {b} stalemated at {pts:.1f}, splitting the spoils.",
+    "{a} and {b} traded haymakers and stayed deadlocked at {pts:.1f}.",
+    "{a} and {b} ended in a {pts:.1f}-all draw — neither side blinked.",
+)
+_NAILBITER_PHRASES = (
+    "{w} edged {l} by {m:.1f} in a coin-flip finish.",
+    "{w} survived {l} by {m:.1f} — decided in the final minutes.",
+    "{w} held off {l} by a hair, {m:.1f}.",
+    "{w} outlasted {l} by {m:.1f} in a back-and-forth slugfest.",
+)
+_OBLITERATE_PHRASES = (
+    "{w} steamrolled {l} by {m:.1f}.",
+    "{w} buried {l} by {m:.1f}.",
+    "{w} ran the score up on {l}, {m:.1f}.",
+    "{w} dropped the hammer on {l} — {m:.1f}-point margin.",
+)
+_ROLL_PHRASES = (
+    "{w} rolled {l} by {m:.1f}.",
+    "{w} stayed in cruise control past {l} by {m:.1f}.",
+    "{w} dictated terms to {l}, {m:.1f}.",
+    "{w} put {l} away comfortably — {m:.1f}-point spread.",
+)
+_BEAT_PHRASES = (
+    "{w} beat {l} by {m:.1f}.",
+    "{w} took {l} by {m:.1f}.",
+    "{w} got past {l} by {m:.1f}.",
+    "{w} handled {l} by {m:.1f}.",
+)
+
+
+def _choose(phrases: tuple[str, ...], seed: int) -> str:
+    """Deterministically pick a phrase given an integer seed."""
+    return phrases[seed % len(phrases)]
+
+
+def _matchup_oneliner(home: dict, away: dict, margin: float, seed: int) -> str:
     if home["points"] == away["points"]:
-        return f"{home['displayName']} and {away['displayName']} finished deadlocked at {home['points']:.1f}."
+        return _choose(_TIE_PHRASES, seed).format(
+            a=home["displayName"], b=away["displayName"], pts=home["points"]
+        )
     winner, loser = (home, away) if home["points"] > away["points"] else (away, home)
     if margin < 3:
-        return f"{winner['displayName']} edged {loser['displayName']} by {margin:.1f} in a nailbiter."
-    if margin >= 50:
-        return f"{winner['displayName']} obliterated {loser['displayName']} by {margin:.1f}."
-    if margin >= 25:
-        return f"{winner['displayName']} rolled {loser['displayName']} by {margin:.1f}."
-    return f"{winner['displayName']} beat {loser['displayName']} by {margin:.1f}."
+        bank = _NAILBITER_PHRASES
+    elif margin >= 50:
+        bank = _OBLITERATE_PHRASES
+    elif margin >= 25:
+        bank = _ROLL_PHRASES
+    else:
+        bank = _BEAT_PHRASES
+    return _choose(bank, seed).format(
+        w=winner["displayName"], l=loser["displayName"], m=margin
+    )
 
 
-def _headline(recap: dict[str, Any]) -> str:
-    # Prefer the blowout if it's meaningful; else the MVP; else nailbiter.
+# ── Headline phrase banks ─────────────────────────────────────────────────
+_BLOWOUT_HEADLINES = (
+    "{w} steamrolled {l} {ws:.1f}-{ls:.1f}",
+    "{w} buried {l} by {m:.1f}",
+    "{w} dismantled {l} {ws:.1f}-{ls:.1f}",
+    "{w} ran riot on {l} — {m:.1f}-point margin",
+    "{w} torched {l} for a {m:.1f}-point win",
+)
+_BIG_WIN_HEADLINES = (
+    "{w} cruised past {l} by {m:.1f}",
+    "{w} put {l} away by {m:.1f}",
+    "{w} took control over {l} by {m:.1f}",
+)
+_NAILBITER_HEADLINES = (
+    "{w} survived {l} by {m:.2f}",
+    "{w} squeaked past {l} by {m:.2f}",
+    "{w} edged {l} in a thriller, {m:.2f}",
+    "{w} held on against {l} by {m:.2f}",
+)
+_MVP_HEADLINES = (
+    "{name} torched the league with {pts:.1f}",
+    "{name} dropped {pts:.1f} on the slate",
+    "{name} led the field at {pts:.1f}",
+    "{name} put up a league-best {pts:.1f}",
+)
+_MVP_AND_BLOWOUT_HEADLINES = (
+    "{name} dropped {pts:.1f} in a {m:.1f}-point demolition",
+    "{name} powered a {m:.1f}-point statement win, {pts:.1f}",
+    "{name}'s {pts:.1f} fueled a {m:.1f}-point rout",
+)
+_FALLBACK_HEADLINES = (
+    "Week in review",
+    "Around the league",
+    "This week in the league",
+)
+
+
+def _headline(recap: dict[str, Any], seed: int) -> str:
     blowout = recap.get("blowout")
     nailbiter = recap.get("nailBiter")
     mvp = recap.get("mvp")
-    if blowout and blowout["margin"] >= 40:
-        return (
-            f"{blowout['winner']['displayName']} steamrolled "
-            f"{blowout['loser']['displayName']} by {blowout['margin']:.1f}"
+
+    # MVP + blowout from the same manager: "stat torched in a blowout".
+    if mvp and blowout and mvp.get("ownerId") == blowout["winner"]["ownerId"] and blowout["margin"] >= 25:
+        return _choose(_MVP_AND_BLOWOUT_HEADLINES, seed).format(
+            name=mvp["displayName"], pts=mvp["points"], m=blowout["margin"]
         )
-    if mvp and blowout and mvp["ownerId"] == blowout["winner"]["ownerId"]:
-        return (
-            f"{mvp['displayName']} dropped {mvp['points']:.1f} in a "
-            f"{blowout['margin']:.1f}-point win"
+    if blowout and blowout["margin"] >= 40:
+        return _choose(_BLOWOUT_HEADLINES, seed).format(
+            w=blowout["winner"]["displayName"],
+            l=blowout["loser"]["displayName"],
+            ws=blowout["winner"]["points"],
+            ls=blowout["loser"]["points"],
+            m=blowout["margin"],
         )
     if nailbiter and nailbiter["margin"] < 2:
-        return (
-            f"{nailbiter['winner']['displayName']} survived "
-            f"{nailbiter['loser']['displayName']} by {nailbiter['margin']:.2f}"
+        return _choose(_NAILBITER_HEADLINES, seed).format(
+            w=nailbiter["winner"]["displayName"],
+            l=nailbiter["loser"]["displayName"],
+            m=nailbiter["margin"],
+        )
+    if blowout and blowout["margin"] >= 25:
+        return _choose(_BIG_WIN_HEADLINES, seed).format(
+            w=blowout["winner"]["displayName"],
+            l=blowout["loser"]["displayName"],
+            m=blowout["margin"],
         )
     if mvp:
-        return f"{mvp['displayName']} led the week with {mvp['points']:.1f}"
-    return "Week in review"
+        return _choose(_MVP_HEADLINES, seed).format(
+            name=mvp["displayName"], pts=mvp["points"]
+        )
+    return _choose(_FALLBACK_HEADLINES, seed)
 
 
-def _summary(recap: dict[str, Any]) -> str:
+# ── Summary phrase banks ──────────────────────────────────────────────────
+_OPEN_PHRASES = (
+    "Week {wk}{playoff} — {n} matchups, {scored:.1f} combined points scored.",
+    "Week {wk}{playoff} closed with {n} games on the slate and {scored:.1f} total points.",
+    "{n} games, {scored:.1f} combined points: that was the shape of week {wk}{playoff}.",
+    "The week {wk}{playoff} books shut at {scored:.1f} total points across {n} matchups.",
+)
+_MVP_LINES = (
+    "{name} led the slate with {pts:.1f} points{ctx}.",
+    "Top score went to {name} at {pts:.1f}{ctx}.",
+    "{name} paced the league at {pts:.1f}{ctx}.",
+    "Nobody touched {name}'s {pts:.1f}{ctx}.",
+)
+_BLOWOUT_LINES = (
+    "{w} ran roughshod over {l}, winning {ws:.1f}-{ls:.1f} — a {m:.1f}-point margin that was effectively over by halftime.",
+    "{w} delivered a beatdown of {l}, {ws:.1f}-{ls:.1f}, separating themselves with a {m:.1f}-point cushion.",
+    "{w}'s {ws:.1f} buried {l}'s {ls:.1f} — a {m:.1f}-point gap that flatters {l} more than the live look did.",
+    "{w} put together one of the cleaner top-to-bottom outings of the week, taking {l} by {m:.1f}.",
+)
+_LARGE_WIN_LINES = (
+    "{w} controlled {l} from the jump, winning by {m:.1f}.",
+    "{w} pulled away from {l} for a {m:.1f}-point win — never really threatened.",
+    "{w}'s {ws:.1f}-{ls:.1f} win over {l} was decided well before the final scoreboard refresh.",
+)
+_NAILBITER_LINES = (
+    "The closest game went to {w} over {l} by just {m:.2f} — every flex slot mattered.",
+    "{w} survived {l} by {m:.2f} in a game that came down to Monday-night decimals.",
+    "Tightest finish on the slate: {w} squeaked by {l} by {m:.2f}.",
+    "{w} outlasted {l} by {m:.2f} in a back-and-forth thriller.",
+)
+_TIGHT_PAIR_LINES = (
+    "Three games inside ten points underline how compressed this scoring week was.",
+    "Multiple matchups went down to the wire — a margin-tight slate top to bottom.",
+)
+_BAD_BEAT_LINES = (
+    "{name} was the bad-beat candidate of the week — {pts:.1f} points and still {ml:.1f} short of the win.",
+    "Tough luck for {name}: {pts:.1f} points isn't usually a losing number, but it was on the wrong side of {opp}'s ceiling week.",
+    "{name} dropped a {pts:.1f}-point bomb and somehow caught an L — {opp} just had more.",
+    "{name} put up {pts:.1f} and lost. That's a season-long bad beat candidate right there.",
+)
+_BUST_LINES = (
+    "{name} bottomed out at {pts:.1f}, the only sub-{floor:.0f} score on the slate.",
+    "Cellar of the week was {name} at {pts:.1f} — a get-back-on-the-horse week.",
+    "{name}'s {pts:.1f} was the floor of the league this week.",
+)
+_TRADE_LINES = (
+    "{n} {plural} cleared on the wire this week.",
+    "Activity report: {n} {plural} got done.",
+    "The trade window stayed warm — {n} {plural} processed.",
+    "{n} {plural} went through, keeping the front offices busy.",
+)
+_PLAYOFF_LINES = (
+    "Playoff stakes: every point counts toward seeding and survival.",
+    "Postseason football — knockout football — and it showed.",
+    "Playoffs heighten everything; that was visible across the slate.",
+)
+_STREAK_LINES = (
+    "{name} extended their win streak to {n} straight.",
+    "{name}'s losing streak hit {n} games — they need a course correction.",
+    "{name} stayed unbeaten over their last {n} games.",
+)
+
+
+def _summary(recap: dict[str, Any], seed: int) -> str:
+    """Compose 3-5 sentences of varied analysis."""
     parts: list[str] = []
+    rng = random.Random(seed)
+
+    matchups = recap.get("matchups") or []
+    n_games = len(matchups)
+    scored_total = sum((m["home"]["points"] + m["away"]["points"]) for m in matchups)
+    is_playoff = recap.get("isPlayoff")
+
+    parts.append(
+        _choose(_OPEN_PHRASES, seed).format(
+            wk=recap["week"],
+            n=n_games,
+            scored=scored_total,
+            playoff=" (playoffs)" if is_playoff else "",
+        )
+    )
+
     mvp = recap.get("mvp")
     bust = recap.get("bust")
-    badBeat = recap.get("badBeat")
+    bad_beat = recap.get("badBeat")
     blowout = recap.get("blowout")
     nailbiter = recap.get("nailBiter")
-    trades_count = len(recap.get("trades") or [])
 
+    # MVP narrative — anchor a context tag so it doesn't read identical
+    # week to week.
     if mvp:
+        ctx_options = [
+            "",
+            f", {mvp['points'] - (bust['points'] if bust else 0):.1f} clear of the cellar",
+        ]
+        if blowout and mvp.get("ownerId") == blowout["winner"]["ownerId"]:
+            ctx_options.append(
+                f" while leading {blowout['loser']['displayName']} by {blowout['margin']:.1f}"
+            )
+        ctx = rng.choice(ctx_options)
         parts.append(
-            f"{mvp['displayName']} led the league with {mvp['points']:.1f} points."
+            _choose(_MVP_LINES, seed + 1).format(
+                name=mvp["displayName"], pts=mvp["points"], ctx=ctx
+            )
         )
-    if nailbiter and (not blowout or nailbiter["margin"] < blowout["margin"] / 10):
+
+    # Game-shape line.  Prefer a true blowout, else a nail-biter, else a
+    # large-margin runner-up framing.
+    if blowout and blowout["margin"] >= 40:
         parts.append(
-            f"The closest game was {nailbiter['winner']['displayName']} over "
-            f"{nailbiter['loser']['displayName']} by just {nailbiter['margin']:.2f}."
+            _choose(_BLOWOUT_LINES, seed + 2).format(
+                w=blowout["winner"]["displayName"],
+                l=blowout["loser"]["displayName"],
+                ws=blowout["winner"]["points"],
+                ls=blowout["loser"]["points"],
+                m=blowout["margin"],
+            )
         )
-    elif blowout:
+    elif blowout and blowout["margin"] >= 25:
         parts.append(
-            f"Biggest margin: {blowout['winner']['displayName']} over "
-            f"{blowout['loser']['displayName']} by {blowout['margin']:.1f}."
+            _choose(_LARGE_WIN_LINES, seed + 2).format(
+                w=blowout["winner"]["displayName"],
+                l=blowout["loser"]["displayName"],
+                ws=blowout["winner"]["points"],
+                ls=blowout["loser"]["points"],
+                m=blowout["margin"],
+            )
         )
-    if badBeat and badBeat["points"] > (mvp["points"] if mvp else 0) - 5:
+    if nailbiter and nailbiter["margin"] < 5 and (
+        not blowout or nailbiter["margin"] != blowout["margin"]
+    ):
         parts.append(
-            f"{badBeat['displayName']} took a bad beat — {badBeat['points']:.1f} "
-            f"points and still lost by {badBeat['marginOfLoss']:.1f}."
+            _choose(_NAILBITER_LINES, seed + 3).format(
+                w=nailbiter["winner"]["displayName"],
+                l=nailbiter["loser"]["displayName"],
+                m=nailbiter["margin"],
+            )
         )
-    elif bust:
+
+    # Tight-slate observation when 3+ games were inside 10 points.
+    tight_count = sum(1 for m in matchups if m["margin"] <= 10.0)
+    if tight_count >= 3:
+        parts.append(_choose(_TIGHT_PAIR_LINES, seed + 4))
+
+    # Bad beat OR bust framing — never both, to keep the recap punchy.
+    if bad_beat and (not mvp or bad_beat["points"] > mvp["points"] - 10):
         parts.append(
-            f"{bust['displayName']} bottomed out at {bust['points']:.1f}."
+            _choose(_BAD_BEAT_LINES, seed + 5).format(
+                name=bad_beat["displayName"],
+                pts=bad_beat["points"],
+                ml=bad_beat["marginOfLoss"],
+                opp=bad_beat.get("winnerDisplayName") or "their opponent",
+            )
         )
+    elif bust and bust["points"] > 0:
+        floor = max(60.0, bust["points"] + 10.0)
+        parts.append(
+            _choose(_BUST_LINES, seed + 5).format(
+                name=bust["displayName"], pts=bust["points"], floor=floor
+            )
+        )
+
+    if is_playoff:
+        parts.append(_choose(_PLAYOFF_LINES, seed + 6))
+
+    trades_count = len(recap.get("trades") or [])
     if trades_count:
+        plural = "trade" if trades_count == 1 else "trades"
         parts.append(
-            f"{trades_count} trade{'s' if trades_count != 1 else ''} cleared on the wire."
+            _choose(_TRADE_LINES, seed + 7).format(n=trades_count, plural=plural)
         )
-    return " ".join(parts) or "Recap unavailable."
+
+    return " ".join(parts)
 
 
 def _build_week_recap(
@@ -175,7 +400,6 @@ def _build_week_recap(
     pairs = metrics.matchup_pairs(entries)
     if not pairs:
         return None
-    # Require at least one scored pair (skip fully unscored future weeks).
     scored_pairs = [
         (a, b) for a, b in pairs
         if metrics.is_scored(a) or metrics.is_scored(b)
@@ -191,7 +415,13 @@ def _build_week_recap(
     closest: dict[str, Any] | None = None
     bad_beat: dict[str, Any] | None = None
 
-    for a, b in scored_pairs:
+    # Per-recap deterministic seed so phrase choice varies across weeks.
+    try:
+        seed = int(season.season) * 100 + week
+    except (TypeError, ValueError):
+        seed = week
+
+    for i, (a, b) in enumerate(scored_pairs):
         home = _side_entry(snapshot, season, a)
         away = _side_entry(snapshot, season, b)
         if home["points"] == 0 and away["points"] == 0:
@@ -212,7 +442,7 @@ def _build_week_recap(
             "margin": margin,
             "winner": winner,
             "loser": loser,
-            "oneliner": _matchup_oneliner(home, away, margin),
+            "oneliner": _matchup_oneliner(home, away, margin, seed + i),
         }
         matchup_rows.append(row)
 
@@ -235,7 +465,6 @@ def _build_week_recap(
                 "margin": margin,
                 "oneliner": row["oneliner"],
             }
-        # Bad beat: highest-scoring loser.
         if loser:
             candidate = {
                 "ownerId": loser["ownerId"],
@@ -267,8 +496,8 @@ def _build_week_recap(
         "badBeat": bad_beat,
         "trades": trades,
     }
-    recap["headline"] = _headline(recap)
-    recap["summary"] = _summary(recap)
+    recap["headline"] = _headline(recap, seed)
+    recap["summary"] = _summary(recap, seed)
     return recap
 
 
@@ -288,7 +517,6 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             weeks_out.append(recap)
             by_key[f"{season.season}:{wk}"] = recap
 
-    # Newest first for the list view.
     weeks_out.sort(
         key=lambda r: (_season_sort_key(r["season"]), r["week"]),
         reverse=True,

--- a/tests/public_league/test_streaks.py
+++ b/tests/public_league/test_streaks.py
@@ -74,7 +74,9 @@ class ActiveStreakOwnerTests(unittest.TestCase):
         self.assertNotIn("lossStreak", out)
         self.assertEqual(out["winStreak"]["length"], 2)
 
-    def test_plus100_streak_includes_games_below_100(self) -> None:
+    def test_only_winloss_streaks_after_threshold_streaks_removed(self) -> None:
+        # plus100 / plus120 / plus140 streaks have been removed — only
+        # win and loss streaks remain.
         events = [
             {"result": "W", "points": 130.0, "week": 1, "season": "2025"},
             {"result": "W", "points": 90.0, "week": 2, "season": "2025"},
@@ -82,9 +84,10 @@ class ActiveStreakOwnerTests(unittest.TestCase):
             {"result": "W", "points": 140.0, "week": 4, "season": "2025"},
         ]
         out = _active_streaks_for_owner(events, "owner-A", "Ann")
-        # Latest game is 140 → plus100 streak starts here; goes back
-        # through the 125-point week too; stops at the 90-point week.
-        self.assertEqual(out["plus100Streak"]["length"], 2)
+        self.assertNotIn("plus100Streak", out)
+        self.assertNotIn("plus120Streak", out)
+        self.assertNotIn("plus140Streak", out)
+        self.assertEqual(out["winStreak"]["length"], 4)
 
     def test_tie_at_tail_reports_no_win_or_loss_streak(self) -> None:
         events = [
@@ -109,9 +112,11 @@ class StreaksSectionTests(unittest.TestCase):
             "latestWeek",
             "activeStreaks",
             "activeStreaksByType",
+            "currentStreaksByOwner",
+            "longestWinStreaks",
+            "longestLossStreaks",
             "recordsInReach",
             "notableThisWeek",
-            "thresholds",
         }
         self.assertTrue(expected.issubset(set(self.data.keys())))
 


### PR DESCRIPTION
## Summary
- **Records**: single-week records now reflect individual NFL weeks (no fused 2-week finals); "most points in a season" excludes playoffs; new top-5-per-position player records.
- **Streaks**: removed plus100/120/140 streaks; added top-5 longest W/L lists and a per-manager current-streak rail.
- **Awards**: new manager awards (Top Offense / Top Defense / Manager of the Year), per-position player awards from starter-only points, League MVP and Playoff MVP rewritten as VORP-based player awards, and live award races for all of the above. Last 2 seasons get awards retroactively.
- **Weekly recaps**: phrase-bank-driven ESPN-style descriptions — varied headline + matchup one-liners + multi-sentence post-game summary anchored by MVP / blowout / bad beat / trades / playoff stakes.

## Test plan
- [x] `pytest tests/` — 2354 passed, 3 skipped
- [x] `pytest tests/public_league/` — 270 passed
- [x] `npm run build` (frontend) — clean build
- [ ] Manual smoke: load `/league` post-deploy and verify Records, Streaks, Awards, Recaps tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)