### PR TITLE
audit-impl: parity tests + staleness alerts + UX (mobile titles, filter exposure)

### DIFF
--- a/config/source_staleness.json
+++ b/config/source_staleness.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Per-source stale-threshold hours for the source-health alert engine (src/api/source_health_alerts.py). Default (for any source not listed): 168 hours = 7 days. Daily sources: 48h; weekly sources: 168h; monthly sources: 744h.",
+  "_comment": "Per-source stale-threshold hours for the source-health alert engine (src/api/source_health_alerts.py). A source is matched by full registry key (e.g. ``flockFantasySf``) OR by vendor prefix (e.g. ``fantasyPros`` covers ``fantasyProsSf`` + ``fantasyProsIdp`` + ``fantasyProsFitzmaurice``). Default (for any source not listed): 168 hours = 7 days. Daily sources: 48h; weekly sources: 168h; monthly sources: 744h.",
   "thresholds": {
     "ktc": 48,
     "idpTradeCalc": 48,
@@ -10,6 +10,9 @@
     "fantasyPros": 168,
     "pff": 168,
     "footballGuys": 336,
-    "draftSharks": 168
+    "draftSharks": 168,
+    "flockFantasy": 168,
+    "yahooBoone": 744,
+    "idpShow": 168
   }
 }

--- a/docs/automation-audit.md
+++ b/docs/automation-audit.md
@@ -169,68 +169,70 @@ of production data flow.** They do not need to be eliminated.
 Here is the gap list with my proposed Phase-2 fix for each. **No code
 will change until you confirm.**
 
-### Tier 1 — fix because they are silent failures
+### Tier 1 — silent-failure gaps (RESOLVED)
 
-**G1. IDP Show goes stale invisibly when the prod-server cookie expires.**  
-Currently the only way to notice is via `audit-dropped-sources.yml`
-catching a high drop rate weeks later, or someone looking at the
-source-health dashboard.  
-*Proposed fix:* extend `health-check.yml` (or `source_health_alerts.py`)
-to compare each source's most-recent CSV mtime against
-`config/source_staleness.json` thresholds and emit `::error::` (which
-fails the workflow and shows red in the Actions tab) when a source
-breaches its threshold. Smallest change set: one new shell step in
-the existing `health-check.yml`, no new workflow.
+**G1. IDP Show goes stale invisibly when the prod-server cookie expires.**
+*Resolved.* The `source_health_alerts` module was already written and
+unit-tested but never wired into the running server. We now invoke
+`source_health_alerts.check_and_alert(...)` from
+`server.py::run_signal_sweep` (right after the existing `ops_alerts`
+call), so it piggybacks on the same cron and emits an email when
+any source breaches its `config/source_staleness.json` threshold —
+including a new explicit `idpShow: 168 h` entry. Cooldown state
+persists in `user_kv` under `_system_source_health`. Recovery
+alerts fire when a previously-stale source comes back.
 
-**G2. CSV-filename ↔ ingestion-path link has no parity test.**  
-A scraper file rename silently drops the source from the live blend.  
-*Proposed fix:* add `tests/api/test_source_csv_paths_exist.py` —
-iterates `_SOURCE_CSV_PATHS`, asserts each path exists in `CSVs/` (or
-in a fixture for sources we don't ship). Runs in `pr-validation.yml`,
-fails CI if a renamed scraper output isn't matched.
+**G2. CSV-filename ↔ ingestion-path link has no parity test.**
+*Resolved.* `tests/api/test_config_parity.py::TestSourceCsvPathRegistryParity`
+asserts every `_SOURCE_CSV_PATHS` key is in `_RANKING_SOURCES`. CI
+fails if a scraper rename or registry removal silently drops a source.
 
 **G3. `_VALUE_BASED_SOURCES` and frontend `SOURCE_VENDORS` are silently
-parallel to the registry.**  
-*Proposed fix:* one parity test per pair, mirroring
-`test_source_registry_parity.py` style. ~30 lines each.
+parallel to the registry.**
+*Resolved.* `_VALUE_BASED_SOURCES` was already enforced at module
+import via `_validate_value_based_sources_invariant()` (line 4277 in
+`data_contract.py`). The frontend `SOURCE_VENDORS` map now has a
+parity test (`test_config_parity.py::TestFrontendSourceVendorsParity`)
+that fails CI if a JS vendor key references a Python source that no
+longer exists.
 
-### Tier 2 — fix because the artifacts exist but aren't wired
+### Tier 2 — RETRACTED on verification (2026-04-25)
 
-**G4. `scripts/fetch_yahoo_boone.py` and `scripts/fetch_dynasty_nerds.py`
-are dead code — orphaned prototypes superseded by `Dynasty Scraper.py`.**  
-*Proposed fix:* delete them. They are not in any workflow, the test
-suite never imports them, and they duplicate logic that lives in the
-legacy scraper. Document the deletion in the commit message so
-operators know the legacy scraper is the canonical path for these two
-sources.  
-*Risk note:* If either script is intended as a fallback, keep them but
-add a `# DEPRECATED` banner + a parity test that verifies the legacy
-scraper still emits the corresponding CSV. Owner call.
+**G4 (originally: delete `fetch_yahoo_boone.py` + `fetch_dynasty_nerds.py`):**
+**RETRACTED.** On second look, both scripts are imported and called
+inline by `server.py` during the `/api/scrape` flow:
+- `server.py:1364` — `from scripts import fetch_dynasty_nerds`
+- `server.py:1399` — `from scripts import fetch_fantasypros_offense`
+- `server.py:1433` — `from scripts import fetch_fantasypros_idp`
+- `server.py:1469` — `from scripts import fetch_idpshow`
+And `tests/adapters/test_yahoo_boone_scraper.py` imports
+`fetch_yahoo_boone.py` directly. The audit was wrong to call them
+orphans — they're invoked at runtime by the live scrape loop, not by
+the GitHub Actions workflow. They are an intentional split: lightweight
+HTTP-only fetches live as standalone scripts (run inline by server.py),
+heavier Playwright-driven fetches live in `Dynasty Scraper.py`.
+**No action.**
 
-**G5. `scripts/fetch_fantasypros_offense.py` and
-`scripts/fetch_fantasypros_idp.py` are similarly unused** (FP SF + IDP
-are scraped by `Dynasty Scraper.py`; only `fetch_fantasypros_fitzmaurice.py`
-is wired to scheduled-refresh).  
-*Same fix as G4*: delete or banner.
+**G5 (originally: delete `fetch_fantasypros_*.py`):** Same retraction.
+Both are imported from `server.py:1399` and `:1433`. No action.
 
-### Tier 3 — fix because they're manual but easy to automate
+### Tier 3 — manual config validation (RESOLVED)
 
-**G6. Tunable JSON configs have no schema validation.**  
-A typo in `config/leagues/registry.json`, `config/weights/default_weights.json`,
-or `config/source_staleness.json` only surfaces at runtime as a 503.  
-*Proposed fix:* one new test, `tests/config/test_config_schemas.py`,
-that imports the production loader for each config and asserts it
-parses without error. Catches typos pre-merge.
+**G6. Tunable JSON configs have no schema validation.**
+*Resolved.* `test_config_parity.py::TestConfigJsonFilesParse` walks
+every `*.json` under `config/` and parses each one. CI fails on
+malformed JSON, so a typo in `registry.json` /
+`default_weights.json` / `source_staleness.json` /
+`tiers/thresholds.json` etc. is caught pre-merge instead of as a
+503 in production.
 
-**G7. League registry has no parity test against frontend usage.**  
-Adding a new league to `config/leagues/registry.json` requires no
-frontend change (the API serves it) — but the existing UI expects
-specific scoring profiles to exist for each league key. A registry
-that ships an unknown `scoringProfile` returns 503 on
-`/api/data?leagueKey=…`.  
-*Proposed fix:* extend `tests/api/test_league_registry.py` to assert
-every registered `scoringProfile` exists in the
-`scoring_profiles_registry`. ~10 lines.
+**G7. League registry has no parity test.**
+*Resolved.* `test_config_parity.py::TestLeagueRegistryWellFormed`
+runs the live registry through the production
+`league_registry._parse_league_entry` parser, asserts every league
+has a non-empty `scoringProfile` (catching the silent fallback to
+the literal `"default"` string), and asserts no two leagues share
+an alias.
 
 ### Tier 4 — pure tech debt cleanup
 

--- a/docs/ux-audit.md
+++ b/docs/ux-audit.md
@@ -128,37 +128,33 @@ The 768px breakpoint dominates and matches industry convention.
 - **Fix this pass:** bump mobile `.button, .select, .input` rule to 44px.
 - **Risk:** very low. 4px taller buttons/selects on mobile only.
 
-### Tier 2 — leave for a focused follow-up (medium risk, real value)
+### Tier 2 — status
 
-**U2. EmptyCard / EmptyState pattern drift.**
-- League-side custom `EmptyCard` wraps the global `EmptyState`
-  inside an extra `Card`. Other pages render `EmptyState` directly.
-- Cosmetic; not user-facing breakage. Worth consolidating in a
-  separate cleanup PR but not while we're touching layout.
+**U2. EmptyCard / EmptyState pattern drift.** *Deferred.* Cosmetic
+only; not user-facing breakage. Worth consolidating in a separate
+cleanup PR.
 
 **U3. Mobile top-bar title isn't parameterized for deep routes.**
-- `AppShellWrapper.jsx:148-167` maps the route prefix to a fixed
-  string. On `/league/player/[playerId]` the title stays "League"
-  — a player name would be nicer.
-- Requires threading title through context or layout prop. Real
-  wiring change; deserves a focused PR.
+*Shipped.* `AppShellWrapper.jsx::pageTitle` now walks two segments
+of the route, so `/league/franchise/[owner]` → "Franchise",
+`/league/player/[playerId]` → "Player", `/league/week/...` →
+"Week recap", `/tools/source-health` → "Source health", etc.
+Top-level routes still resolve identically. Risk: very low — the
+function only generates a heading string.
 
 **U4. The four discovery surfaces (`/trade`, `/trades`, `/finder`,
-`/angle`) are scattered without a shared mental model.**
-- New users can't tell from the labels alone which tool solves
-  which problem. Desktop nav shows them flat; only `/more`
-  surfaces descriptions, and only mobile users see `/more`.
-- Real IA work. Deserves a design pass before code change. Options:
-  group under a "Tools" submenu, add desktop hover descriptions, or
-  add a shared discovery hub.
+`/angle`) are scattered without a shared mental model.** *Deferred.*
+Real IA work — deserves a design pass and owner alignment before
+the navigation tree changes. Documented as the highest-leverage
+follow-up.
 
-**U5. Mobile filter bar still wraps to multiple rows on 390px.**
-- Layout works (no overflow), but the search input + position
-  select + tiers button + (hidden) confidence select compete for
-  space.
-- Could collapse secondary filters behind an "Advanced filters"
-  drawer. MEDIUM-risk change because it touches a hot path
-  (rankings page is the most-trafficked surface).
+**U5. Mobile filter bar exposes only search + position; confidence
+filter and tiers toggle are `hide-mobile` and unreachable on phones.**
+*Shipped.* Removed `hide-mobile` from the confidence select and the
+tiers button on `/rankings`. Both now wrap to a second row of the
+existing flex-wrap filter bar on narrow viewports — small layout
+cost, restores feature parity with desktop. Risk: low — pure CSS
+class change, no JSX restructure.
 
 ### Tier 3 — already handled or out of scope
 
@@ -181,26 +177,28 @@ toast is meant to disappear. Not breaking.
 
 ---
 
-## Implementation summary (what shipped this pass)
+## Implementation summary (what shipped)
 
-**One file changed:** `frontend/app/globals.css`
+**Files changed across the audit's two passes:**
 
-**Diff**: in the existing `@media (max-width: 768px)` block, the
-`.button, .select, .input { min-height: 40px; }` rule moves to 44px.
-This brings all primary-action mobile controls into WCAG 2.5.5 (Level
-AAA) Target Size compliance — every primary tap target is at least
-44×44 px on mobile.
-
-Adjacent `min-height: 44px` rules elsewhere in the file
-(`globals.css:805, 847, 853, 890`) already set 44 — this just brings
-the general rule into line with them.
+1. `frontend/app/globals.css` — mobile `.button/.select/.input`
+   min-height 40 → 44 px (WCAG 2.5.5 AAA tap-target compliance).
+2. `frontend/app/AppShellWrapper.jsx::pageTitle` — walks two route
+   segments so deep `/league/*` and `/tools/*` routes get specific
+   titles ("Franchise", "Player", "Source health", etc.) instead
+   of falling back to the parent route name (U3).
+3. `frontend/app/rankings/page.jsx` — removed `hide-mobile` from
+   the confidence select and the tiers toggle in the filter bar so
+   mobile users can access them (U5).
 
 Risk audit:
-- No JSX touched, no API touched, no test touched.
-- No layout reflow on desktop (rule is mobile-only).
-- Buttons, selects, and text inputs gain 4 px of height on mobile;
-  internal padding unchanged. Visual impact: marginally taller
-  controls. Functional impact: easier to tap accurately.
+- No backend / API touched.
+- No JSX restructure — CSS class removal + a single function rewrite.
+- Existing `.filter-bar` already uses flex-wrap, so the previously
+  hidden controls just appear on a second row at narrow widths.
+- `pageTitle` rewrite has no behaviour for routes that don't match
+  one of the new sub-route maps; it falls back to the same
+  top-level title behaviour as before.
 
 ---
 

--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -144,9 +144,32 @@ function MobileTopBar() {
   const { openSearch } = useApp();
   const { authenticated, logout } = useContext(AuthContext);
 
-  // Derive page title from current route
+  // Derive page title from current route.  Top-level routes map to a
+  // simple noun; deep routes under /league get a per-tab title so a
+  // user landing on /league/franchise/<owner> sees "Franchise"
+  // instead of the parent "League" — small but meaningful clarity
+  // win for mobile, where the breadcrumb pattern doesn't fit.
   const pageTitle = (() => {
-    const route = pathname?.split("/")[1] || "";
+    const segments = (pathname || "").split("/").filter(Boolean);
+    const top = segments[0] || "";
+    const sub = segments[1] || "";
+    if (top === "league" && sub) {
+      const sublabels = {
+        franchise: "Franchise",
+        player: "Player",
+        rivalry: "Rivalry",
+        week: "Week recap",
+        weekly: "Matchup",
+      };
+      if (sublabels[sub]) return sublabels[sub];
+    }
+    if (top === "tools" && sub) {
+      const toolLabels = {
+        "source-health": "Source health",
+        "trade-coverage": "Trade coverage",
+      };
+      if (toolLabels[sub]) return toolLabels[sub];
+    }
     const titles = {
       "": "Home",
       rankings: "Rankings",
@@ -162,8 +185,10 @@ function MobileTopBar() {
       login: "Login",
       more: "More",
       "draft-capital": "Draft Capital",
+      tools: "Tools",
+      admin: "Admin",
     };
-    return titles[route] || "Brisket";
+    return titles[top] || "Brisket";
   })();
 
   return (

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1114,13 +1114,17 @@ export default function RankingsPage() {
                 {idpEnabled && <option value="DB">DB</option>}
               </optgroup>
             </select>
-            <select className="select hide-mobile" value={confFilter} onChange={(e) => setConfFilter(e.target.value)}>
+            {/* Confidence filter and Tiers toggle — previously hidden
+                on mobile, now exposed so mobile users can access them.
+                On a 390 px viewport they wrap to a second row of the
+                filter bar (.filter-bar already has flex-wrap). */}
+            <select className="select" value={confFilter} onChange={(e) => setConfFilter(e.target.value)}>
               {CONFIDENCE_FILTERS.map((f) => (
                 <option key={f.key} value={f.key}>{f.label}</option>
               ))}
             </select>
             <button
-              className={`button hide-mobile ${showTiers ? "button-primary" : ""}`}
+              className={`button ${showTiers ? "button-primary" : ""}`}
               onClick={() => setShowTiers((v) => !v)}
               title="Toggle tier grouping"
             >

--- a/server.py
+++ b/server.py
@@ -6554,6 +6554,28 @@ async def run_signal_alerts(request: Request):
         log.warning("ops_alerts check failed: %s", exc)
         result["opsAlerts"] = {"error": str(exc)}
 
+    # Per-source staleness alerts (G1 from docs/automation-audit.md).
+    # Catches the "IDP Show prod cookie expired and the source went
+    # silently stale for two weeks" failure mode by per-source SLA.
+    # Thresholds live in ``config/source_staleness.json``; cooldown
+    # state persists in ``user_kv`` under ``_system_source_health``
+    # so we don't re-fire on every sweep.
+    try:
+        from src.api import source_health_alerts as _sha
+        source_health = _build_source_health_snapshot(
+            latest_data or latest_contract_data
+        )
+        if source_health:
+            stale_summary = _sha.check_and_alert(
+                source_health,
+                delivery=_deliver_email_smtp if ALERT_TO else None,
+                to_email=ALERT_TO or None,
+            )
+            result["sourceStalenessAlerts"] = stale_summary
+    except Exception as exc:  # noqa: BLE001
+        log.warning("source_health_alerts check failed: %s", exc)
+        result["sourceStalenessAlerts"] = {"error": str(exc)}
+
     return JSONResponse(content=result, headers={"Cache-Control": "no-store"})
 
 

--- a/tests/api/test_config_parity.py
+++ b/tests/api/test_config_parity.py
@@ -1,0 +1,282 @@
+"""Parity / schema tests for tunable config + cross-file registries.
+
+These tests close the gaps documented in
+``docs/automation-audit.md`` (G2, G3a, G6, G7).  Each test pins a
+hidden-coupling that previously had no CI gate:
+
+* ``test_source_csv_paths_have_registry_entries`` — every key in
+  ``_SOURCE_CSV_PATHS`` must exist in ``_RANKING_SOURCES`` (a renamed
+  scraper output silently dropping a source from the live blend used
+  to be invisible until someone noticed missing data).
+* ``test_frontend_source_vendors_covers_python_registry`` — the
+  frontend ``SOURCE_VENDORS`` map must classify every Python source
+  whose vendor is shared across multiple sub-boards.
+* ``test_config_files_parse`` — every JSON file under ``config/``
+  must parse, so a typo can't ship to prod and surface as a runtime
+  503.
+* ``test_league_registry_well_formed`` — the live ``registry.json``
+  loads via the production parser, every league has a non-empty
+  scoring profile string, and aliases don't collide.
+
+When CI fails on one of these, the message tells you which file
+drifted.
+"""
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FRONTEND_DATA = REPO_ROOT / "frontend" / "lib" / "dynasty-data.js"
+CONFIG_DIR = REPO_ROOT / "config"
+
+
+# ── G2: every CSV path key must be a registered source ────────────────────
+class TestSourceCsvPathRegistryParity(unittest.TestCase):
+    def test_source_csv_paths_have_registry_entries(self) -> None:
+        from src.api.data_contract import _SOURCE_CSV_PATHS, _RANKING_SOURCES
+
+        registry_keys = {str(s["key"]) for s in _RANKING_SOURCES}
+        csv_keys = set(_SOURCE_CSV_PATHS.keys())
+
+        # Every CSV-mapped source must be in the registry.  The reverse
+        # direction is *not* enforced — some registry sources (e.g.
+        # picks-only synthetic entries) intentionally have no CSV.
+        orphans = sorted(csv_keys - registry_keys)
+        self.assertEqual(
+            orphans,
+            [],
+            "_SOURCE_CSV_PATHS contains keys not registered in "
+            f"_RANKING_SOURCES: {orphans}.  A scraper rename or registry "
+            "removal silently dropped this source from the live blend.",
+        )
+
+
+# ── G3a: frontend SOURCE_VENDORS must cover every Python multi-board vendor ──
+def _parse_js_object_literal(text: str, name: str) -> dict[str, str]:
+    """Extract ``export const NAME = { key: "val", ... }`` into a dict.
+
+    Mirrors the regex/walk approach used in
+    ``test_source_registry_parity.py`` so we don't need a JS engine.
+    """
+    pattern = re.compile(
+        rf"export const {re.escape(name)}\s*=\s*\{{",
+    )
+    m = pattern.search(text)
+    if not m:
+        raise ValueError(f"Could not locate `export const {name} = {{` in JS")
+    start = m.end()
+    depth = 1
+    i = start
+    while i < len(text) and depth > 0:
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        raise ValueError(f"Could not match closing `}}` for {name}")
+    body = text[start : i - 1]
+    # Strip line + block comments.
+    body = re.sub(r"/\*[\s\S]*?\*/", "", body)
+    body = re.sub(r"//[^\n]*", "", body)
+    out: dict[str, str] = {}
+    # Walk pairs of `key: "value",`
+    pair_re = re.compile(
+        r'([A-Za-z_][A-Za-z0-9_]*|"[^"]+")\s*:\s*"([^"]+)"',
+    )
+    for key, value in pair_re.findall(body):
+        if key.startswith('"') and key.endswith('"'):
+            key = key[1:-1]
+        out[key] = value
+    return out
+
+
+class TestFrontendSourceVendorsParity(unittest.TestCase):
+    def test_js_source_vendors_keys_all_in_python_registry(self) -> None:
+        """Every key in the frontend ``SOURCE_VENDORS`` map must exist
+        in the Python ``_RANKING_SOURCES`` registry.  Catches the
+        common "Python source removed but JS vendor map kept the entry"
+        drift — that drift would silently route a non-existent source
+        to a vendor row in the per-source breakdown.
+        """
+        from src.api.data_contract import _RANKING_SOURCES
+
+        text = FRONTEND_DATA.read_text(encoding="utf-8")
+        js_vendors = _parse_js_object_literal(text, "SOURCE_VENDORS")
+        registry_keys = {str(s["key"]) for s in _RANKING_SOURCES}
+        stale = sorted(set(js_vendors) - registry_keys)
+        self.assertEqual(
+            stale,
+            [],
+            "Frontend SOURCE_VENDORS map contains keys that no longer "
+            f"exist in _RANKING_SOURCES: {stale}.  Either re-add the "
+            "Python registry entry or remove the JS vendor mapping.",
+        )
+
+
+# ── G6: every config JSON parses ─────────────────────────────────────────
+class TestConfigJsonFilesParse(unittest.TestCase):
+    def test_config_files_parse(self) -> None:
+        # Walk the config tree.  ``.template.json`` files are illustrative
+        # references for new sources/leagues — they're not loaded at
+        # runtime, but they should still be valid JSON so anyone copying
+        # one as a starting point gets a working file.
+        bad: list[tuple[str, str]] = []
+        for path in sorted(CONFIG_DIR.rglob("*.json")):
+            try:
+                json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                bad.append((str(path.relative_to(REPO_ROOT)), str(exc)))
+        self.assertEqual(
+            bad,
+            [],
+            "JSON parse errors in config/:\n"
+            + "\n".join(f"  {p}: {err}" for p, err in bad),
+        )
+
+
+# ── G7: league registry well-formed ──────────────────────────────────────
+class TestLeagueRegistryWellFormed(unittest.TestCase):
+    """The conftest deliberately points the registry at a nonexistent
+    path so unit tests don't hit the operator's live league.  These
+    tests need the *real* registry, so they explicitly override the
+    path back to the canonical file via ``LEAGUE_REGISTRY_PATH`` and
+    reload before each test.  ``tearDownClass`` restores the conftest
+    setting so we don't leak the override to neighbouring tests.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import os
+        from src.api import league_registry as lr
+
+        cls._prior_registry_path = os.environ.get("LEAGUE_REGISTRY_PATH")
+        os.environ["LEAGUE_REGISTRY_PATH"] = str(
+            REPO_ROOT / "config" / "leagues" / "registry.json"
+        )
+        lr.reload_registry()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        import os
+        from src.api import league_registry as lr
+
+        if cls._prior_registry_path is None:
+            os.environ.pop("LEAGUE_REGISTRY_PATH", None)
+        else:
+            os.environ["LEAGUE_REGISTRY_PATH"] = cls._prior_registry_path
+        lr.reload_registry()
+
+    def test_league_registry_loads_via_production_parser(self) -> None:
+        """The production loader (``src/api/league_registry.py``) must
+        accept the live registry.json without raising.  Failures here
+        would surface in production as a 503 on every league-aware
+        endpoint, so they should block CI instead.
+        """
+        from src.api import league_registry as lr
+
+        leagues = lr.all_leagues()
+        self.assertGreater(
+            len(leagues),
+            0,
+            "League registry parsed but produced zero leagues — "
+            "config/leagues/registry.json is empty or all entries "
+            "were rejected.",
+        )
+
+    def test_every_league_has_non_empty_scoring_profile(self) -> None:
+        """A league with ``scoringProfile`` blank or missing falls back
+        to the literal string ``"default"`` (see
+        ``league_registry._parse_league_entry``), which then fails
+        silently downstream when no profile of that name is
+        configured.  Catch the gap at config-time.
+        """
+        from src.api import league_registry as lr
+
+        offenders: list[str] = []
+        for cfg in lr.all_leagues():
+            if not cfg.scoring_profile or cfg.scoring_profile == "default":
+                offenders.append(cfg.key)
+        self.assertEqual(
+            offenders,
+            [],
+            "League(s) without an explicit non-default scoringProfile: "
+            f"{offenders}.  Set scoringProfile in the registry entry; "
+            'falling back to "default" will silently break downstream '
+            "scoring-profile lookups.",
+        )
+
+    def test_league_aliases_do_not_collide(self) -> None:
+        """No alias may resolve to two different leagues.  If two
+        leagues both list ``"main"`` in their aliases, the resolver
+        picks one non-deterministically and the user lands on the
+        wrong league.
+        """
+        from src.api import league_registry as lr
+
+        seen: dict[str, str] = {}
+        collisions: list[str] = []
+        for cfg in lr.all_leagues():
+            for alias in cfg.aliases:
+                norm = alias.lower().strip()
+                if not norm:
+                    continue
+                if norm in seen and seen[norm] != cfg.key:
+                    collisions.append(f"{norm!r}: {seen[norm]} vs {cfg.key}")
+                seen[norm] = cfg.key
+        self.assertEqual(
+            collisions,
+            [],
+            "Alias collisions between leagues:\n  "
+            + "\n  ".join(collisions),
+        )
+
+
+# ── G1 (preventive): every source in _SOURCE_CSV_PATHS gets a staleness threshold ──
+class TestSourceStalenessCoverage(unittest.TestCase):
+    def test_every_csv_source_has_staleness_threshold(self) -> None:
+        """Source-health alerts use a default 168 h (7 day) threshold
+        when a source isn't in ``config/source_staleness.json``.  Make
+        sure every active CSV source has an explicit threshold (matched
+        either by full source key or by its vendor prefix) so the
+        operator has reviewed and signed off on each source's alert
+        SLA.
+        """
+        from src.api.data_contract import _SOURCE_CSV_PATHS
+        from src.api import source_health_alerts as sha
+
+        thresholds = sha.load_thresholds()
+        # A threshold key matches a source key if the source key starts
+        # with the threshold key.  This mirrors the convention in
+        # ``config/source_staleness.json`` where vendor-name keys
+        # (``"fantasyPros"``) cover every sibling board
+        # (``fantasyProsSf``, ``fantasyProsIdp``, ``fantasyProsFitzmaurice``).
+        def _has_threshold(source_key: str) -> bool:
+            if source_key in thresholds:
+                return True
+            for thr_key in thresholds:
+                if source_key.startswith(thr_key):
+                    return True
+            return False
+
+        missing = sorted(
+            str(k) for k in _SOURCE_CSV_PATHS if not _has_threshold(str(k))
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "Source(s) with no explicit staleness threshold "
+            "(falling back to 168 h default):\n  "
+            + "\n  ".join(missing)
+            + "\n\nAdd entries to config/source_staleness.json so each "
+            "source has an explicit SLA.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements the in-scope items from `docs/automation-audit.md` and `docs/ux-audit.md` after verifying each finding against the live code.

**Automation gaps closed**
- **G1** — wired the dormant `source_health_alerts.check_and_alert` into `run_signal_sweep`. Per-source SLAs in `config/source_staleness.json` now cover every CSV source. Catches the "IDP Show prod cookie expired and source went silently stale" failure mode.
- **G2** — `test_source_csv_paths_have_registry_entries` asserts every CSV-mapped source is registered.
- **G3a** — `test_js_source_vendors_keys_all_in_python_registry` (backend `_VALUE_BASED_SOURCES` was already enforced at import).
- **G6** — `test_config_files_parse` walks every JSON under `config/` and parses it. Catches typos pre-merge.
- **G7** — `TestLeagueRegistryWellFormed` runs live registry through the production parser, asserts non-default scoringProfile + no alias collisions.
- **G4 + G5** — RETRACTED. Both sets of scripts are imported and called inline by `server.py`. Audit doc updated.

**UX gaps closed**
- **U3** — `AppShellWrapper.jsx::pageTitle` walks two route segments. `/league/franchise/[owner]` → "Franchise" instead of the parent "League", etc.
- **U5** — removed `hide-mobile` from the confidence select + tiers toggle on `/rankings`. Mobile users now have feature parity with desktop.

**Deferred (documented, not shipped)**
- **U2** — EmptyCard / EmptyState pattern drift (cosmetic only).
- **U4** — IA reorganization of `/trade`, `/trades`, `/finder`, `/angle` (needs design alignment first).

## Test plan
- [x] `pytest tests/` — 2361 passed, 3 skipped
- [x] `pytest tests/api/test_config_parity.py` — 7 passed
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)