### PR TITLE
nav: full IA reorg — Trade ▾ dropdown

### DIFF
--- a/docs/ux-audit.md
+++ b/docs/ux-audit.md
@@ -246,10 +246,15 @@ remaining items below:
 
 1. **Mobile filter bar redesign for `/rankings`** (U5) — *Shipped.*
    Confidence + Tiers exposed on mobile via `hide-mobile` removal.
-2. **Discovery-surface IA pass** (U4) — *Shipped (lite).* Desktop nav
-   tooltips + visual group separators between workflow / discovery /
-   public / admin clusters.  Full IA reorg deferred — owner design
-   call.
+2. **Discovery-surface IA pass** (U4) — *Shipped (full).* The four
+   trade-related routes (/trade · /trades · /finder · /angle) used
+   to live as flat top-level peers; they now collapse into a single
+   "Trade ▾" dropdown on desktop with sub-items labelled "Calculator
+   / History / Arbitrage Finder / Counter-Pitch".  Direct URLs still
+   work — the change is nav-only.  /more page is restructured to
+   mirror the new grouping ("Trade workflow", "Signals", "League",
+   "Settings").  Original lite version (tooltips + group separators)
+   is preserved.
 3. **Parameterized mobile top-bar titles** (U3) — *Shipped.*
    `AppShellWrapper.jsx::pageTitle` walks two route segments.
 4. **Standardize on `EmptyState` everywhere** (U2) — *Closed wontfix.*

--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useCallback, createContext, useContext } from "react";
+import { useCallback, useEffect, useRef, useState, createContext, useContext } from "react";
 import AppShell, { useApp } from "@/components/AppShell";
 import { useAuth } from "@/components/useAuth";
 import ChatDrawer from "@/components/ChatDrawer";
@@ -13,32 +13,50 @@ import LeagueSwitcher from "@/components/LeagueSwitcher";
 // ── Route definitions ────────────────────────────────────────────────────
 // Primary destinations shown in desktop top nav.
 //
-// Items are grouped so the four trade-discovery tools (Trade · Edge ·
-// Finder · Angle) cluster together visually instead of reading as flat
-// peers.  ``groupBreak: true`` on an item triggers a thin vertical
-// separator before it on desktop.
+// IA structure
+// ────────────
+// The four trade-related routes (Calculator / History / Arbitrage
+// Finder / Counter-Pitch) used to live as four flat peers in the nav.
+// They now collapse into a single parent ``Trade`` entry with a
+// dropdown that lists the four sub-tools so the relationship is
+// obvious without crowding the bar.  Direct URLs (/trade, /trades,
+// /finder, /angle) all still work — the reorg is nav-only, no route
+// changes.
 //
-// Mental model:
-//   Group 1 — daily workflow: Rankings, Trade, Draft
-//   Group 2 — decision-support / discovery: Edge, Finder, Angle
+// Mental model after this reorg:
+//   Group 1 — daily workflow: Rankings, Trade ▾ (4 sub-tools), Draft
+//   Group 2 — decision-support / discovery: Edge
 //   Group 3 — public-facing: League
 //   Group 4 — admin: Settings, More
 //
-// ``hint`` populates the browser's native title tooltip on hover so a
-// user passing over "Trade" vs. "Trades" vs. "Finder" vs. "Angle" can
-// tell which one solves which problem without having to click through.
-// The /more page already shows these descriptions on mobile.
+// ``hint`` populates the browser's native title tooltip on hover.
+// ``children`` makes an item a parent that opens a dropdown of its
+// nested sub-routes.  Clicking the parent label still navigates to
+// ``href`` (sensible default) — the dropdown surfaces the siblings.
 const PRIMARY_NAV = [
   { href: "/rankings", label: "Rankings", hint: "Player value board" },
-  { href: "/trade", label: "Trade", hint: "Build and grade a trade" },
+  {
+    href: "/trade",
+    label: "Trade",
+    hint: "Trade workflow tools",
+    children: [
+      { href: "/trade", label: "Calculator", hint: "Build and grade a trade" },
+      { href: "/trades", label: "History", hint: "Analyzed history of every league trade" },
+      { href: "/finder", label: "Arbitrage Finder", hint: "Find KTC market gaps you can exploit" },
+      { href: "/angle", label: "Counter-Pitch", hint: "Generate counter-package suggestions" },
+    ],
+  },
   { href: "/draft", label: "Draft", hint: "Rookie draft prep + ADP" },
   { href: "/edge", label: "Edge", hint: "Where sources disagree most", groupBreak: true },
-  { href: "/finder", label: "Finder", hint: "Find KTC arbitrage trades" },
-  { href: "/angle", label: "Angle", hint: "Counter-package generator" },
   { href: "/league", label: "League", hint: "Public league hub", groupBreak: true },
   { href: "/settings", label: "Settings", hint: "Source weights, TEP, profile", groupBreak: true },
-  { href: "/more", label: "More", hint: "Trades history, rosters, tools" },
+  { href: "/more", label: "More", hint: "Rosters, tools, admin" },
 ];
+
+// Routes that should mark the ``Trade`` parent as active in the
+// dropdown UI.  Any pathname that starts with one of these prefixes
+// counts as "we're inside the trade workflow group".
+const TRADE_GROUP_PREFIXES = ["/trade", "/trades", "/finder", "/angle"];
 
 // Mobile bottom nav — 3-tab model.  /league is intentionally NOT in
 // this bar.  Users reach it via the More menu + desktop top nav; the
@@ -67,6 +85,86 @@ export function useAuthContext() {
   return useContext(AuthContext);
 }
 
+// ── Nav dropdown (used by the "Trade" parent in PRIMARY_NAV) ─────────────
+function NavDropdown({ item, pathname, isActive }) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef(null);
+  const closeTimer = useRef(null);
+
+  // Hover dropdown with a 120 ms delay before close so a small
+  // diagonal mouse drift between parent and a menu item doesn't snap
+  // the menu shut.  Standard nav-menu behaviour.
+  const handleEnter = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setOpen(true);
+  }, []);
+  const handleLeave = useCallback(() => {
+    closeTimer.current = setTimeout(() => setOpen(false), 120);
+  }, []);
+
+  // Close when focus leaves the wrapper (keyboard) and on Escape.
+  const handleBlur = useCallback((e) => {
+    if (!wrapRef.current) return;
+    if (!wrapRef.current.contains(e.relatedTarget)) setOpen(false);
+  }, []);
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Close the menu when the route actually changes (link click).
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  return (
+    <span
+      ref={wrapRef}
+      className="nav-dropdown"
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      onFocus={handleEnter}
+      onBlur={handleBlur}
+    >
+      <Link
+        href={item.href}
+        title={item.hint || item.label}
+        className={`nav-link nav-dropdown-trigger${isActive ? " nav-active" : ""}`}
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        {item.label}
+        <span className="nav-dropdown-caret" aria-hidden="true">▾</span>
+      </Link>
+      {open && (
+        <div role="menu" className="nav-dropdown-menu">
+          {item.children.map((child) => {
+            const childActive = pathname === child.href
+              || pathname?.startsWith(child.href + "/");
+            return (
+              <Link
+                key={child.href}
+                href={child.href}
+                role="menuitem"
+                className={`nav-dropdown-item${childActive ? " nav-active" : ""}`}
+              >
+                <span className="nav-dropdown-item-label">{child.label}</span>
+                {child.hint && (
+                  <span className="nav-dropdown-item-hint">{child.hint}</span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </span>
+  );
+}
+
 // ── Desktop top navigation bar ───────────────────────────────────────────
 function DesktopNav() {
   const pathname = usePathname();
@@ -86,7 +184,6 @@ function DesktopNav() {
             );
             const out = [];
             visible.forEach((item, idx) => {
-              const active = pathname === item.href || pathname?.startsWith(item.href + "/");
               if (item.groupBreak && idx > 0) {
                 out.push(
                   <span
@@ -96,6 +193,26 @@ function DesktopNav() {
                   />,
                 );
               }
+              if (item.children && item.children.length > 0) {
+                // Parent item with a sub-menu — the parent's "active"
+                // state fires for any path inside its child set so the
+                // user always sees a highlighted top-level entry, even
+                // on a deep child route.
+                const groupActive = TRADE_GROUP_PREFIXES.some(
+                  (prefix) =>
+                    pathname === prefix || pathname?.startsWith(prefix + "/"),
+                );
+                out.push(
+                  <NavDropdown
+                    key={item.href}
+                    item={item}
+                    pathname={pathname}
+                    isActive={groupActive}
+                  />,
+                );
+                return;
+              }
+              const active = pathname === item.href || pathname?.startsWith(item.href + "/");
               out.push(
                 <Link
                   key={item.href}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -165,9 +165,9 @@ a { color: inherit; text-decoration: none; }
 }
 
 /* Subtle vertical divider between desktop-nav groups.  The hierarchy
-   is workflow (Rankings · Trade · Draft) | discovery (Edge · Finder ·
-   Angle) | public (League) | admin (Settings · More).  The divider
-   visually separates them without taking up a full nav slot. */
+   is workflow (Rankings · Trade ▾ · Draft) | signals (Edge) | public
+   (League) | admin (Settings · More).  The divider visually separates
+   them without taking up a full nav slot. */
 .nav-group-sep {
   display: inline-block;
   width: 1px;
@@ -175,6 +175,78 @@ a { color: inherit; text-decoration: none; }
   background: var(--border);
   margin: 0 4px;
   opacity: 0.55;
+}
+
+/* ── Nav dropdown (used by the "Trade" parent in PRIMARY_NAV) ─────────────
+   The dropdown surfaces the four trade-related sub-tools (Calculator,
+   History, Arbitrage Finder, Counter-Pitch) under one nav slot
+   instead of four flat peers.  The parent itself is still a Link so
+   click-navigation goes to /trade — the menu is purely additive.
+   ──────────────────────────────────────────────────────────────────────── */
+.nav-dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.nav-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.nav-dropdown-caret {
+  font-size: 0.62rem;
+  opacity: 0.65;
+  transform: translateY(1px);
+}
+
+.nav-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 50;
+  min-width: 240px;
+  background: rgba(8, 19, 44, 0.96);
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.nav-dropdown-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: var(--text);
+  transition: background 0.1s, color 0.1s;
+}
+
+.nav-dropdown-item:hover {
+  background: rgba(255, 199, 4, 0.07);
+}
+
+.nav-dropdown-item.nav-active {
+  background: rgba(255, 199, 4, 0.12);
+  color: var(--cyan);
+}
+
+.nav-dropdown-item-label {
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.nav-dropdown-item-hint {
+  font-size: 0.66rem;
+  color: var(--subtext);
+  line-height: 1.35;
 }
 
 .nav-search-btn {

--- a/frontend/app/more/page.jsx
+++ b/frontend/app/more/page.jsx
@@ -7,26 +7,39 @@ import { useAuthContext } from "@/app/AppShellWrapper";
  * More — mobile navigation hub.
  * Provides access to all destinations not in the mobile bottom nav.
  * On desktop this page is accessible but the top nav already covers everything.
+ *
+ * Section structure mirrors the desktop nav grouping:
+ *   * Trade workflow — the four trade-related tools that live under
+ *     the "Trade ▾" dropdown on desktop
+ *   * Signals — Edge (source-disagreement)
+ *   * League — public-facing surfaces
+ *   * Other — Rosters, Settings, etc.
  */
 const SECTIONS = [
   {
-    title: "Analysis",
+    title: "Trade workflow",
     items: [
-      { href: "/edge", label: "Edge — Source Signals", desc: "Where ranking sources agree, disagree, and flag issues" },
-      { href: "/finder", label: "Finder — Player Discovery", desc: "Surface players by source signal patterns and opportunity type" },
-      { href: "/angle", label: "Angle — Trade Pitches", desc: "Pick a player on your team; get targets that win on your rankings but look fair-or-better on KTC" },
+      { href: "/trade", label: "Calculator", desc: "Build and grade a trade" },
+      { href: "/trades", label: "History", desc: "Analyzed history of every league trade" },
+      { href: "/finder", label: "Arbitrage Finder", desc: "Find KTC market gaps you can exploit" },
+      { href: "/angle", label: "Counter-Pitch", desc: "Pick a player on your team; get targets that win on your rankings but look fair-or-better on KTC" },
+    ],
+  },
+  {
+    title: "Signals",
+    items: [
+      { href: "/edge", label: "Edge", desc: "Where ranking sources agree, disagree, and flag issues" },
     ],
   },
   {
     title: "League",
     items: [
-      { href: "/trades", label: "Trade History", desc: "Grade and analyze your league's trades" },
       { href: "/rosters", label: "Roster Dashboard", desc: "Team strength rankings with position breakdowns" },
       { href: "/league", label: "League Hub", desc: "Champions, rivalries, awards, records, draft capital, weekly recaps, and more" },
     ],
   },
   {
-    title: "Tools",
+    title: "Settings",
     items: [
       { href: "/settings", label: "Settings", desc: "Tuning controls for valuations and display" },
     ],


### PR DESCRIPTION
## Summary
Closes U4 from `docs/ux-audit.md` (the discovery-surface IA pass that was originally flagged as needing a design call).

Collapses `/trade` / `/trades` / `/finder` / `/angle` from four flat top-level peers in the desktop nav into a single "Trade ▾" parent with a hover/focus dropdown listing all four sub-tools with descriptions:
- **Calculator** → `/trade` — Build and grade a trade
- **History** → `/trades` — Analyzed history of every league trade
- **Arbitrage Finder** → `/finder` — Find KTC market gaps you can exploit
- **Counter-Pitch** → `/angle` — Generate counter-package suggestions

Direct URLs unchanged. Existing bookmarks keep working. Desktop nav drops from 9 to 7 items.

The `/more` page is restructured to mirror the same grouping (Trade workflow / Signals / League / Settings).

## Test plan
- [x] `npm run build` — clean
- [ ] Manual: hover "Trade" on desktop, confirm dropdown opens; click each sub-item, confirm correct route
- [ ] Manual: keyboard tab to "Trade", confirm dropdown opens on focus; press Esc to close
- [ ] Manual: navigate to `/finder`, confirm "Trade" parent shows active highlight
- [ ] Manual: load `/more` on mobile, confirm grouping reads "Trade workflow / Signals / League / Settings"

🤖 Generated with [Claude Code](https://claude.com/claude-code)