### PR TITLE
fix(mobile): resolve seven mobile UI regressions

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2797,6 +2797,36 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   .chat-fab { bottom: 20px; }
 }
 
+/* On phones the full "▲ Ask" pill ate ~110px x 40px of screen, sat
+   above the bottom nav, and reliably masked the last list item.
+   Collapse to an icon-only round button at 44x44 (the iOS HIG touch
+   target minimum) — the label still ships in the DOM for screen
+   readers, just visually hidden. */
+@media (max-width: 600px) {
+  .chat-fab {
+    padding: 0;
+    width: 44px;
+    height: 44px;
+    justify-content: center;
+    border-radius: 999px;
+    right: 12px;
+    /* Sit a notch closer to the nav so it eats less list space. */
+    bottom: calc(var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px) + 10px);
+  }
+  .chat-fab-glyph {
+    font-size: 0.95rem;
+    transform: rotate(-90deg);
+  }
+  .chat-fab-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+}
+
 /* Drawer overlay + backdrop */
 .chat-overlay {
   position: fixed;
@@ -5472,7 +5502,11 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 .portfolio-stack-row {
   display: grid;
-  grid-template-columns: 32px 1fr 48px;
+  /* Value column auto-sizes to its (variable-width) numeric content
+     instead of being clamped to 48px while the value's own
+     ``min-width: 100px`` happily overflowed past the right edge of
+     narrow phone viewports. */
+  grid-template-columns: 32px minmax(0, 1fr) auto;
   gap: var(--space-sm);
   align-items: center;
   font-variant-numeric: tabular-nums;
@@ -5581,6 +5615,12 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 /* ── Portfolio Summary (front-office dashboard) ─────────────────── */
+.portfolio-empty-inline {
+  font-size: 0.7rem;
+  color: var(--muted);
+  padding: 8px 0;
+  font-style: italic;
+}
 .portfolio-empty {
   padding: var(--space-md);
   color: var(--muted);
@@ -5677,11 +5717,22 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   color: var(--text);
   font-size: 0.76rem;
   text-align: right;
-  min-width: 100px;
+  white-space: nowrap;
 }
 .portfolio-stack-meta {
   color: var(--muted);
   font-size: 0.66rem;
+}
+@media (max-width: 480px) {
+  /* On narrow phones the inline meta ("· 28 · 45%") doubles the
+     column width — drop it under the headline number so the bar
+     keeps room to breathe. */
+  .portfolio-stack-meta {
+    display: block;
+    text-align: right;
+    font-size: 0.6rem;
+    line-height: 1.1;
+  }
 }
 .portfolio-stack-fill {
   background: linear-gradient(90deg, var(--cyan), var(--green));
@@ -6317,32 +6368,46 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .pmm-vol-pill--high { color: var(--red); border-color: rgba(248, 113, 113, 0.4); }
 .pmm-vol-pill--none { color: var(--muted); }
 
-/* Mobile: collapse table to 3 columns (name+dot, delta, spark) */
+/* Mobile: collapse table to a 2-row card layout.
+ *
+ * Each meta column (pos / value / vol) gets its own grid cell on the
+ * second row.  The previous template assigned all three to the same
+ * ``meta`` named area, which caused them to render stacked on top of
+ * each other — visible as garbled glyphs like "Q,B54" / "8VRC9" where
+ * the position pill, value, and volatility pill all painted into the
+ * same x/y. */
 @media (max-width: 600px) {
   /* Movers table → card layout */
   .pmm-head { display: none; }
   .pmm-row-trigger {
-    grid-template-columns: minmax(0, 1fr) 56px 60px;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     grid-template-areas:
-      "name delta spark"
-      "meta meta  meta";
+      "name  delta spark"
+      "pos   value vol";
+    column-gap: 8px;
     row-gap: 4px;
     min-height: 52px;
+    align-items: center;
   }
   .pmm-col--name  { grid-area: name; }
-  .pmm-col--delta { grid-area: delta; }
-  .pmm-col--spark { grid-area: spark; }
-  .pmm-col--pos,
-  .pmm-col--value,
-  .pmm-col--vol {
-    grid-area: meta;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
+  .pmm-col--delta { grid-area: delta; min-width: 40px; }
+  .pmm-col--spark { grid-area: spark; min-width: 56px; }
+  .pmm-col--pos {
+    grid-area: pos;
     justify-self: start;
-    font-size: 0.7rem;
+    font-size: 0.66rem;
   }
-  .pmm-col--value { color: var(--muted); }
+  .pmm-col--value {
+    grid-area: value;
+    justify-self: end;
+    font-size: 0.7rem;
+    color: var(--muted);
+  }
+  .pmm-col--vol {
+    grid-area: vol;
+    justify-self: end;
+    font-size: 0.66rem;
+  }
 
   /* Bump small tabs/chips so thumbs land cleanly.  44px is the iOS
      HIG minimum; we accept 36px here because every tap target sits

--- a/frontend/components/AppShell.jsx
+++ b/frontend/components/AppShell.jsx
@@ -114,12 +114,40 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
   const openPlayerPopup = useCallback((row) => {
     if (!privateDataEnabled) return;
     if (typeof row === "string") {
-      // Look up by name
-      const found = rows.find((r) => r.name === row);
+      // Look up by name (case-insensitive).  When the same display
+      // name resolves to multiple universes (rare offense/IDP
+      // collision), this picks the first row encountered — callers
+      // that care should pass ``{ name, assetClass }`` instead.
+      const lowered = row.toLowerCase();
+      const found = rows.find((r) => String(r.name).toLowerCase() === lowered);
       if (found) setPopupRow(found);
-    } else {
-      setPopupRow(row);
+      return;
     }
+    if (!row || typeof row !== "object") return;
+    // When the caller supplies ``{ name, assetClass }`` (e.g. the
+    // movers panel surfacing a scoped rank-history entry) and no
+    // contract data, resolve to the matching live row using both
+    // name + assetClass so offense/IDP collisions land on the right
+    // universe.  When the caller already has a full contract row we
+    // skip the lookup.
+    const looksLikeFullRow =
+      row.rankDerivedValue != null ||
+      row.values != null ||
+      row.canonicalConsensusRank != null;
+    if (!looksLikeFullRow && row.name) {
+      const lowered = String(row.name).toLowerCase();
+      const ac = row.assetClass != null ? String(row.assetClass).toLowerCase() : "";
+      const found = rows.find((r) => {
+        if (String(r.name).toLowerCase() !== lowered) return false;
+        if (!ac) return true;
+        return String(r.assetClass || "").toLowerCase() === ac;
+      });
+      if (found) {
+        setPopupRow(found);
+        return;
+      }
+    }
+    setPopupRow(row);
   }, [rows, privateDataEnabled]);
 
   const openSearch = useCallback(() => {

--- a/frontend/components/terminal/MoversPanel.jsx
+++ b/frontend/components/terminal/MoversPanel.jsx
@@ -127,7 +127,10 @@ function MoverRow({ row, openPlayerPopup }) {
                 e.stopPropagation();
                 // Look up the row in the live rankings + open the
                 // popup so the user gets the full per-source detail.
-                openPlayerPopup({ name: row.name });
+                // Pass ``assetClass`` so cross-universe name
+                // collisions (offense vs IDP) resolve to the right
+                // contract row downstream.
+                openPlayerPopup({ name: row.name, assetClass: row.assetClass });
               }}
               style={{
                 marginLeft: "auto",
@@ -217,7 +220,11 @@ export default function MoversPanel() {
               </div>
             ) : (
               risers.map((r) => (
-                <MoverRow key={`up-${r.name}`} row={r} openPlayerPopup={openPlayerPopup} />
+                <MoverRow
+                  key={`up-${r.name}::${r.assetClass || "x"}`}
+                  row={r}
+                  openPlayerPopup={openPlayerPopup}
+                />
               ))
             )}
           </div>
@@ -231,7 +238,11 @@ export default function MoversPanel() {
               </div>
             ) : (
               fallers.map((r) => (
-                <MoverRow key={`down-${r.name}`} row={r} openPlayerPopup={openPlayerPopup} />
+                <MoverRow
+                  key={`down-${r.name}::${r.assetClass || "x"}`}
+                  row={r}
+                  openPlayerPopup={openPlayerPopup}
+                />
               ))
             )}
           </div>

--- a/frontend/components/terminal/MoversPanel.jsx
+++ b/frontend/components/terminal/MoversPanel.jsx
@@ -24,10 +24,27 @@ const WINDOW_OPTIONS = [
   { days: 30, label: "30d" },
 ];
 
+// Asset-class label used when the contract has no NFL position stamped
+// (picks, or IDP/offense rows that have rolled off the live board).
+// Keeps the meta line readable instead of showing a bare "?".
+const ASSET_LABELS = {
+  pick: "Pick",
+  idp: "IDP",
+  offense: "OFF",
+};
+
+function describePosition(row) {
+  const pos = (row.position || "").trim().toUpperCase();
+  if (pos) return pos;
+  const ac = String(row.assetClass || "").trim().toLowerCase();
+  return ASSET_LABELS[ac] || "—";
+}
+
 function MoverRow({ row, openPlayerPopup }) {
   const [expanded, setExpanded] = useState(false);
   const tone = row.delta > 0 ? "var(--green)" : "var(--red)";
   const arrow = row.delta > 0 ? "▲" : "▼";
+  const posLabel = describePosition(row);
 
   return (
     <div
@@ -51,7 +68,7 @@ function MoverRow({ row, openPlayerPopup }) {
             {row.name}
           </div>
           <div style={{ fontSize: "0.62rem", color: "var(--subtext)" }}>
-            {row.position || "?"}
+            {posLabel}
             {row.team ? ` · ${row.team}` : ""} · #{row.rankNow}
             {row.valueNow ? ` · ${row.valueNow.toLocaleString()}` : ""}
           </div>

--- a/frontend/components/terminal/PlayerMarketMovement.jsx
+++ b/frontend/components/terminal/PlayerMarketMovement.jsx
@@ -8,6 +8,7 @@ import {
   normalizePoints,
   computeWindowTrend,
   computeVolatility,
+  buildHistoryLookup,
 } from "@/lib/value-history";
 import Panel from "./Panel";
 import Sparkline from "./Sparkline";
@@ -39,13 +40,6 @@ function toSet(names) {
   if (!Array.isArray(names)) return s;
   for (const n of names) s.add(String(n).toLowerCase());
   return s;
-}
-
-function buildHistoryLookup(history) {
-  if (!history || typeof history !== "object") return () => [];
-  const lower = new Map();
-  for (const key of Object.keys(history)) lower.set(key.toLowerCase(), history[key]);
-  return (name) => lower.get(String(name).toLowerCase()) || history[name] || [];
 }
 
 export default function PlayerMarketMovement() {
@@ -94,7 +88,9 @@ export default function PlayerMarketMovement() {
 
   const enriched = useMemo(() => {
     return scoped.map((r) => {
-      const rawPts = historyLookup(r.name);
+      // History keys are scoped ("Name::offense"); pass r.assetClass
+      // so cross-universe name collisions resolve to the right series.
+      const rawPts = historyLookup(r.name, r.assetClass);
       const points = normalizePoints(rawPts);
       const trend = computeWindowTrend(points, windowDays);
       const vol = computeVolatility(points, Math.max(30, windowDays));

--- a/frontend/components/terminal/PortfolioSummary.jsx
+++ b/frontend/components/terminal/PortfolioSummary.jsx
@@ -212,36 +212,63 @@ export default function PortfolioSummary() {
       </section>
 
       {/* ── Age mix (value-weighted) ── */}
-      <section className="portfolio-section">
-        <h3 className="portfolio-section-title">Age mix (by value)</h3>
-        <div className="portfolio-seg-bar" role="img" aria-label="Age distribution">
-          {AGE_ORDER.map((a) => {
-            const entry = byAge[a.key];
-            if (!entry || entry.pct === 0) return null;
-            return (
-              <span
-                key={a.key}
-                className={`portfolio-seg portfolio-seg--age-${a.key}`}
-                style={{ flex: entry.pct }}
-                title={`${a.label}: ${formatPct(entry.pct)} · ${entry.count} player${entry.count === 1 ? "" : "s"}`}
-              />
-            );
-          })}
-        </div>
-        <div className="portfolio-seg-legend">
-          {AGE_ORDER.map((a) => {
-            const entry = byAge[a.key];
-            if (!entry || entry.count === 0) return null;
-            return (
-              <span key={a.key} className="portfolio-seg-legend-item">
-                <span className={`portfolio-seg-swatch portfolio-seg--age-${a.key}`} aria-hidden="true" />
-                <span className="portfolio-seg-legend-label">{a.label}</span>
-                <span className="portfolio-seg-legend-value">{formatPct(entry.pct)}</span>
-              </span>
-            );
-          })}
-        </div>
-      </section>
+      {(() => {
+        // When every resolved player is in the "unknown" bucket the
+        // section adds nothing but a flat purple bar with a confused
+        // "? 100%" legend.  That happens when the contract hasn't
+        // stamped birthdates (e.g. a fresh league sync, or a Sleeper
+        // outage) — surface that state honestly instead of pretending
+        // the data is meaningful.
+        const unknownEntry = byAge?.unknown;
+        const totalAgeCount = AGE_ORDER.reduce(
+          (acc, a) => acc + (byAge?.[a.key]?.count || 0),
+          0,
+        );
+        const allUnknown =
+          totalAgeCount > 0 &&
+          unknownEntry &&
+          unknownEntry.count === totalAgeCount;
+        return (
+          <section className="portfolio-section">
+            <h3 className="portfolio-section-title">Age mix (by value)</h3>
+            {allUnknown ? (
+              <div className="portfolio-empty-inline">
+                Age data unavailable for this roster.
+              </div>
+            ) : (
+              <>
+                <div className="portfolio-seg-bar" role="img" aria-label="Age distribution">
+                  {AGE_ORDER.map((a) => {
+                    const entry = byAge[a.key];
+                    if (!entry || entry.pct === 0) return null;
+                    return (
+                      <span
+                        key={a.key}
+                        className={`portfolio-seg portfolio-seg--age-${a.key}`}
+                        style={{ flex: entry.pct }}
+                        title={`${a.label}: ${formatPct(entry.pct)} · ${entry.count} player${entry.count === 1 ? "" : "s"}`}
+                      />
+                    );
+                  })}
+                </div>
+                <div className="portfolio-seg-legend">
+                  {AGE_ORDER.map((a) => {
+                    const entry = byAge[a.key];
+                    if (!entry || entry.count === 0) return null;
+                    return (
+                      <span key={a.key} className="portfolio-seg-legend-item">
+                        <span className={`portfolio-seg-swatch portfolio-seg--age-${a.key}`} aria-hidden="true" />
+                        <span className="portfolio-seg-legend-label">{a.label}</span>
+                        <span className="portfolio-seg-legend-value">{formatPct(entry.pct)}</span>
+                      </span>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+          </section>
+        );
+      })()}
 
       {/* ── Volatility exposure ── */}
       <section className="portfolio-section">

--- a/frontend/lib/portfolio-insights.js
+++ b/frontend/lib/portfolio-insights.js
@@ -4,6 +4,7 @@ import {
   normalizePoints,
   computeWindowTrend,
   computeVolatility,
+  buildHistoryLookup,
 } from "@/lib/value-history";
 
 /**
@@ -197,6 +198,13 @@ export function computePortfolio({ rows, selectedTeam, rawData, history }) {
   const byName = new Map();
   for (const r of rows) byName.set(String(r.name).toLowerCase(), r);
 
+  // Backend rank-history keys are stamped as "{Name}::{asset_class}",
+  // so a bare ``history[name]`` lookup misses every entry — which
+  // collapsed every player into the volatility/age "unknown" bucket.
+  // ``buildHistoryLookup`` strips the suffix and supports scope-aware
+  // disambiguation via the row's assetClass.
+  const lookupHistory = buildHistoryLookup(history);
+
   // Build per-player value objects with position, age, volatility.
   const rosterValues = [];
   const unresolved = [];
@@ -208,7 +216,7 @@ export function computePortfolio({ rows, selectedTeam, rawData, history }) {
     }
     const pos = normalizePos(row.pos);
     const value = Number(row.rankDerivedValue || row.values?.full || 0);
-    const points = normalizePoints(history?.[row.name] || history?.[name] || []);
+    const points = normalizePoints(lookupHistory(row.name, row.assetClass));
     const vol = computeVolatility(points, 30);
     rosterValues.push({
       name: row.name,

--- a/frontend/lib/value-history.js
+++ b/frontend/lib/value-history.js
@@ -186,12 +186,14 @@ export function computeTeamValueSeries({ rosterNames, history, valueFromRank }) 
   if (typeof valueFromRank !== "function") return [];
 
   // Build per-player sorted point lists, keyed by lowercased name.
+  // History keys are scoped ("Name::offense"), so use the shared
+  // helper instead of bare ``history[name]`` (which misses every key).
+  const lookup = buildHistoryLookup(history);
   const byName = new Map();
   for (const name of rosterNames) {
     const key = String(name).toLowerCase();
     if (byName.has(key)) continue;
-    const raw = history[name] || history[key] || findCaseInsensitive(history, name);
-    byName.set(key, normalizePoints(raw));
+    byName.set(key, normalizePoints(lookup(name)));
   }
 
   // Find the intersection of dates across all players with coverage.
@@ -229,12 +231,52 @@ export function computeTeamValueSeries({ rosterNames, history, valueFromRank }) 
   return series;
 }
 
-function findCaseInsensitive(obj, name) {
-  const needle = String(name).toLowerCase();
-  for (const key of Object.keys(obj)) {
-    if (key.toLowerCase() === needle) return obj[key];
+/**
+ * Build a fast scope-aware lookup over a /api/data/rank-history map.
+ *
+ * Backend keys are stamped as ``"{Display Name}::{asset_class}"`` (see
+ * ``src/api/rank_history.py::_player_key``).  Frontend rows only carry
+ * the bare ``name`` (and an optional ``assetClass``), so every consumer
+ * needs to strip / split the keys to get a hit — the previous bare
+ * ``history[name]`` lookup missed every row, which is why "Top
+ * Gainers" rendered as all-dashes and the portfolio age/volatility
+ * mix collapsed into the "unknown" bucket.
+ *
+ * The returned function accepts ``(name, assetClass?)`` and returns
+ * the raw history series (or ``[]``).  When the same display name
+ * appears under multiple asset classes (rare offense/IDP collisions
+ * — e.g. "Devin Singletary" if a defender ever shared the name), the
+ * caller can disambiguate by passing ``assetClass``.
+ */
+export function buildHistoryLookup(history) {
+  if (!history || typeof history !== "object") return () => [];
+  const byName = new Map();        // lowercased clean name → series
+  const byScoped = new Map();      // "name::scope" → series
+  for (const rawKey of Object.keys(history)) {
+    const series = history[rawKey];
+    const idx = rawKey.indexOf("::");
+    const cleanName = (idx >= 0 ? rawKey.slice(0, idx) : rawKey).trim().toLowerCase();
+    const scope = (idx >= 0 ? rawKey.slice(idx + 2) : "").trim().toLowerCase();
+    if (scope) {
+      byScoped.set(`${cleanName}::${scope}`, series);
+    }
+    // First-write wins so that a scope-collision doesn't overwrite a
+    // legitimate primary entry; callers passing assetClass still get
+    // the precise scoped series via byScoped.
+    if (!byName.has(cleanName)) {
+      byName.set(cleanName, series);
+    }
   }
-  return null;
+  return (name, assetClass) => {
+    if (!name) return [];
+    const lowered = String(name).toLowerCase();
+    const ac = String(assetClass || "").toLowerCase();
+    if (ac) {
+      const scoped = byScoped.get(`${lowered}::${ac}`);
+      if (scoped) return scoped;
+    }
+    return byName.get(lowered) || [];
+  };
 }
 
 /**

--- a/frontend/lib/value-history.js
+++ b/frontend/lib/value-history.js
@@ -252,6 +252,7 @@ export function buildHistoryLookup(history) {
   if (!history || typeof history !== "object") return () => [];
   const byName = new Map();        // lowercased clean name → series
   const byScoped = new Map();      // "name::scope" → series
+  const nameVariantCount = new Map(); // lowercased name → number of distinct scopes
   for (const rawKey of Object.keys(history)) {
     const series = history[rawKey];
     const idx = rawKey.indexOf("::");
@@ -260,12 +261,13 @@ export function buildHistoryLookup(history) {
     if (scope) {
       byScoped.set(`${cleanName}::${scope}`, series);
     }
-    // First-write wins so that a scope-collision doesn't overwrite a
-    // legitimate primary entry; callers passing assetClass still get
-    // the precise scoped series via byScoped.
+    // First-write wins so that a scope-collision doesn't silently
+    // overwrite a legitimate primary entry; callers passing
+    // assetClass still get the precise scoped series via byScoped.
     if (!byName.has(cleanName)) {
       byName.set(cleanName, series);
     }
+    nameVariantCount.set(cleanName, (nameVariantCount.get(cleanName) || 0) + 1);
   }
   return (name, assetClass) => {
     if (!name) return [];
@@ -275,6 +277,11 @@ export function buildHistoryLookup(history) {
       const scoped = byScoped.get(`${lowered}::${ac}`);
       if (scoped) return scoped;
     }
+    // Bare-name path: refuse to pick arbitrarily when the same
+    // display name maps to multiple scopes (e.g. cross-universe
+    // offense/IDP collision).  Returning [] is the conservative
+    // choice — better "no chart" than "wrong chart".
+    if ((nameVariantCount.get(lowered) || 0) > 1) return [];
     return byName.get(lowered) || [];
   };
 }

--- a/server.py
+++ b/server.py
@@ -2225,19 +2225,39 @@ async def get_movers(request: Request):
     # missing from the live board.
     contract = latest_contract_data or {}
     by_name: dict[str, dict] = {}
+    by_name_lower: dict[str, dict] = {}
+    by_name_scoped: dict[str, dict] = {}
     arr = contract.get("playersArray") or []
     if isinstance(arr, list):
         for row in arr:
-            if isinstance(row, dict):
-                key = str(row.get("displayName") or row.get("canonicalName") or "")
-                if key:
-                    by_name[key] = row
+            if not isinstance(row, dict):
+                continue
+            display = str(row.get("displayName") or row.get("canonicalName") or "")
+            if not display:
+                continue
+            by_name[display] = row
+            by_name_lower[display.lower()] = row
+            asset = str(row.get("assetClass") or "").strip().lower()
+            if asset:
+                by_name_scoped[f"{display.lower()}::{asset}"] = row
 
     risers: list[dict] = []
     fallers: list[dict] = []
-    for name, series in history.items():
+    for raw_key, series in history.items():
         if not series or len(series) < 2:
             continue
+        # History keys are ``"{Display Name}::{asset_class}"`` (see
+        # ``src/api/rank_history.py::_player_key``).  Split the key so
+        # we can (a) look up the contract row by clean displayName,
+        # (b) emit a clean name to the UI, and (c) carry assetClass
+        # through to the response so the frontend can disambiguate
+        # cross-universe name collisions (offense vs IDP).
+        if "::" in raw_key:
+            clean_name, asset_class = raw_key.split("::", 1)
+        else:
+            clean_name, asset_class = raw_key, ""
+        clean_name = clean_name.strip()
+        asset_class = asset_class.strip().lower()
         # Most-recent ``rank`` and the rank from ~``window`` days ago.
         # Series is already date-sorted ascending by load_history.
         latest = series[-1]
@@ -2253,7 +2273,15 @@ async def get_movers(request: Request):
         delta = r_then - r_now
         if abs(delta) < threshold:
             continue
-        row = by_name.get(name) or {}
+        # Prefer a scope-matched contract row (handles offense/IDP
+        # name collisions), then case-insensitive name match, then
+        # exact-key fallback.
+        row = (
+            by_name_scoped.get(f"{clean_name.lower()}::{asset_class}")
+            or by_name_lower.get(clean_name.lower())
+            or by_name.get(raw_key)
+            or {}
+        )
         per_source_delta: dict[str, int] = {}
         # Per-source rank deltas — useful so the user can see
         # "this move was driven by KTC dropping them 25 spots".
@@ -2265,8 +2293,16 @@ async def get_movers(request: Request):
                     per_source_delta[str(src_key)] = int(src_rank)
                 except (TypeError, ValueError):
                     continue
+        # Prefer the contract's assetClass (most current) but fall
+        # back to the history key's parsed asset_class so picks /
+        # IDPs aren't mis-stamped as "?" when the contract has
+        # rotated them off the board.
+        resolved_asset = (
+            str(row.get("assetClass") or "").strip().lower() or asset_class or None
+        )
         entry = {
-            "name": name,
+            "name": clean_name,
+            "assetClass": resolved_asset,
             "playerId": str(row.get("playerId") or "") or None,
             "position": str(row.get("position") or "") or None,
             "team": str(row.get("team") or "") or None,


### PR DESCRIPTION
## Summary

Surfaced from a screenshot review of the iOS web app. Seven independent
issues, six tractable enough to fix, all wired through the same PR.

### `::scope` suffix leaking into Risers/Fallers names

`/api/movers` emitted the raw rank-history key (`"Reggie Virgil::offense"`)
as the response `name`, then tried to look up the contract row by that
same key against `displayName` — which fails by definition, so
`position` fell through to `"?"`. Now splits the key, looks the row up
by clean name + scope, and emits both the clean name and `assetClass`.

### Top Gainers showed `—` for every player

`PlayerMarketMovement` and `computePortfolio` were probing
`/api/data/rank-history` by bare name (`history[r.name]`), but backend
keys are scoped (`"Justin Jefferson::offense"`), so every probe missed.
Result: zero history points → null trend → `—` everywhere, and the
"Age Mix" bar collapsed into the unknown bucket. Added a shared
`buildHistoryLookup` in `lib/value-history.js` and routed
`PlayerMarketMovement`, `portfolio-insights`, and `computeTeamValueSeries`
through it.

### Garbled position pills on Top Gainers (`Q,B54`, `8VRC9`)

The mobile breakpoint stacked `pos` / `value` / `vol` into the same
named grid area (`grid-area: meta`), so the three columns rendered on
top of each other. Gave each meta column its own grid cell:

```css
grid-template-areas:
  "name  delta spark"
  "pos   value vol";
```

### Positional allocation values truncated off the right edge

`.portfolio-stack-row` clamped column 3 to `48px` while
`.portfolio-stack-value` carried `min-width: 100px`, so the cell
overflowed past the viewport on narrow phones. Switched to an `auto`
column, dropped the `min-width`, and dropped the inline meta
(`· 28 · 45%`) under the headline number on ≤480px viewports.

### Floating "Ask" pill masking the last list item

The pill was `~110×40 px`, sat above the bottom nav, and reliably
covered the bottom row of every list. Collapsed to a `44×44` icon-only
round button on mobile (the label is still in the DOM for screen
readers), and pulled it ~6px closer to the nav.

### Age mix rendered "? 100%" when ages weren't stamped

When every resolved player landed in the `unknown` bucket the section
showed a single solid purple bar with a "? 100%" legend. Now renders
an inline "Age data unavailable for this roster." message instead.

### "?" position fallback in Risers/Fallers

When the contract row has no NFL position stamped (picks, or rows that
have rolled off the live board), the metadata line falls back to an
asset-class label (`Pick` / `IDP` / `OFF`) instead of a bare `?`.

## Test plan

- [x] `pytest tests/api/test_rank_history.py tests/api/test_source_history.py` (35 passed)
- [x] `npx vitest run` — 732/732 passed
- [x] `npx next build` — clean build, all routes render
- [x] Manual exercise of `buildHistoryLookup` against scoped keys (case-insensitive + scope-aware paths)
- [ ] Eye-test the Risers/Fallers, Top Gainers, and Portfolio screens on a real iOS device once deployed

## Files touched

- `server.py` — `/api/movers` clean-name + scope split
- `frontend/lib/value-history.js` — new `buildHistoryLookup` helper, `computeTeamValueSeries` rewired
- `frontend/lib/portfolio-insights.js` — uses scope-aware history lookup
- `frontend/components/terminal/PlayerMarketMovement.jsx` — uses scope-aware history lookup
- `frontend/components/terminal/MoversPanel.jsx` — clean position fallback
- `frontend/components/terminal/PortfolioSummary.jsx` — age-mix empty state
- `frontend/app/globals.css` — mobile pmm grid, portfolio stack value, chat-fab compact, age-empty styling

https://claude.ai/code/session_01D5prsZkSgg9CyNXMdz1KJs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5prsZkSgg9CyNXMdz1KJs)_