### PR TITLE
feat(idp): production-ready scoring-fit + Apply toggle

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -87,6 +87,103 @@ function posMatchesFilter(pos, assetClass, filter, row) {
   return pos === filter;
 }
 
+// ── Scoring-fit badges ───────────────────────────────────────────────
+// Renders next to the value cell when the scoring-fit lens is active
+// or the apply-scoring-fit toggle is on.  Three pieces of info:
+//
+//   * Tier — categorical (elite / starter+ / starter / fringe / below)
+//   * Confidence — how robust the underlying estimate is.  ``synthetic``
+//     means the value comes from a draft-cohort baseline (rookie), not
+//     from realized production.
+//   * Delta — the value-scale gap vs the consensus market.  Positive =
+//     the league's stacked scoring would value this player higher than
+//     consensus does (buy-low candidate).  Negative = the league
+//     undervalues vs market (sell-high candidate).
+//
+// Pure presentational — every value comes from backend stamps.
+const _TIER_STYLES = {
+  elite:              { label: "Elite",     css: "rankings-tier-elite" },
+  starter_plus:       { label: "Starter+",  css: "rankings-tier-starter-plus" },
+  starter:            { label: "Starter",   css: "rankings-tier-starter" },
+  fringe:             { label: "Fringe",    css: "rankings-tier-fringe" },
+  below_replacement:  { label: "Below",     css: "rankings-tier-below" },
+  rookie:             { label: "Rookie",    css: "rankings-tier-rookie" },
+};
+
+const _CONFIDENCE_STYLES = {
+  high:      { label: "High conf",       dot: "var(--green, #4ade80)" },
+  medium:    { label: "Medium conf",     dot: "var(--yellow, #facc15)" },
+  low:       { label: "Low conf",        dot: "var(--orange, #fb923c)" },
+  synthetic: { label: "Rookie cohort",   dot: "var(--cyan, #22d3ee)" },
+  none:      { label: "No data",         dot: "var(--muted, #9ca3af)" },
+};
+
+function ScoringFitBadges({ tier, confidence, synthetic, draftRound, delta, consensusValue }) {
+  const tierMeta = _TIER_STYLES[tier] || _TIER_STYLES.starter;
+  const confMeta = _CONFIDENCE_STYLES[confidence] || _CONFIDENCE_STYLES.none;
+  const showSynthetic = !!synthetic;
+  const deltaNum = typeof delta === "number" && Number.isFinite(delta) ? delta : null;
+  const consensus = typeof consensusValue === "number" && Number.isFinite(consensusValue) ? consensusValue : null;
+
+  let deltaTitle = "";
+  if (deltaNum != null && consensus != null) {
+    const sign = deltaNum > 0 ? "+" : "";
+    deltaTitle = `Scoring fit delta vs market: ${sign}${Math.round(deltaNum)} (consensus ${Math.round(consensus)})`;
+  }
+
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4, marginLeft: 6 }}>
+      <span
+        className={`rankings-tier-badge ${tierMeta.css}`}
+        title={`Tier from VORP-per-game under your league's scoring`}
+        style={{ fontSize: "0.65rem", padding: "1px 5px" }}
+      >
+        {tierMeta.label}
+      </span>
+      <span
+        title={confMeta.label + (showSynthetic && draftRound != null ? ` (Round ${draftRound})` : "")}
+        style={{
+          display: "inline-block",
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          backgroundColor: confMeta.dot,
+        }}
+      />
+      {showSynthetic && (
+        <span
+          title={draftRound != null
+            ? `Estimated from average rookie-year production of round-${draftRound} ${tier}s under your league's scoring`
+            : "Synthetic value from draft-cohort baseline"}
+          style={{
+            fontSize: "0.62rem",
+            padding: "1px 4px",
+            borderRadius: 3,
+            background: "rgba(34, 211, 238, 0.18)",
+            color: "var(--cyan, #22d3ee)",
+            fontWeight: 600,
+          }}
+        >
+          R{draftRound != null ? draftRound : "?"} synth
+        </span>
+      )}
+      {deltaNum != null && (
+        <span
+          title={deltaTitle}
+          style={{
+            fontFamily: "var(--mono, monospace)",
+            fontSize: "0.7rem",
+            color: deltaNum > 0 ? "var(--green, #4ade80)" : "var(--red, #f87171)",
+            fontWeight: 600,
+          }}
+        >
+          {deltaNum > 0 ? "+" : ""}{Math.round(deltaNum)}
+        </span>
+      )}
+    </span>
+  );
+}
+
 // ── Methodology content ──────────────────────────────────────────────
 
 // ── Source cell formatter ────────────────────────────────────────────
@@ -469,6 +566,35 @@ export default function RankingsPage() {
   const [showMethodology, setShowMethodology] = useState(false);
   const [expandedRow, setExpandedRow] = useState(null);
 
+  // ── Apply Scoring Fit toggle ────────────────────────────────────
+  // When ON, IDP rows display ``idpScoringFitAdjustedValue`` instead
+  // of ``rankDerivedValue`` and the entire board re-sorts by the
+  // adjusted values (offense rows keep their consensus value — they
+  // don't have a scoring-fit adjustment).
+  //
+  // Persisted in localStorage so the choice survives page reloads.
+  // Default OFF — first-run users see the consensus board.
+  const [applyScoringFit, setApplyScoringFitState] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const saved = window.localStorage.getItem("applyScoringFit");
+      if (saved === "1") setApplyScoringFitState(true);
+    } catch (_e) {
+      // localStorage may be disabled (Safari private mode); default OFF.
+    }
+  }, []);
+  const setApplyScoringFit = useCallback((next) => {
+    setApplyScoringFitState(next);
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("applyScoringFit", next ? "1" : "0");
+      }
+    } catch (_e) {
+      // Persistence is best-effort; the in-memory state still works.
+    }
+  }, []);
+
   const handleSort = useCallback((col) => {
     if (sortCol === col) {
       setSortAsc((prev) => !prev);
@@ -532,13 +658,90 @@ export default function RankingsPage() {
   // rankings pipeline still blends IDP sources globally, but non-IDP
   // leagues don't render any IDP rows, tabs, or summary counts —
   // nothing the user of a non-IDP league can trade.
-  const eligible = useMemo(() => {
+  const eligibleRaw = useMemo(() => {
     const filtered = rows.filter(isEligibleForBoard);
     if (!idpEnabled) {
       return filtered.filter((r) => r?.assetClass !== "idp");
     }
     return filtered;
   }, [rows, idpEnabled]);
+
+  // ── Apply Scoring Fit transform ─────────────────────────────────
+  // When the toggle is ON: every IDP row that has an
+  // ``idpScoringFitAdjustedValue`` substitutes that for its
+  // ``rankDerivedValue``, and the entire board is re-sorted by the
+  // adjusted values to assign a fresh rank.
+  //
+  // Offense rows pass through unchanged — they have no scoring-fit
+  // adjustment.  This mutation is local to the rankings page; trade
+  // engines, edge rail, and any other consumer of ``rankDerivedValue``
+  // continue to see the consensus value.
+  //
+  // Whether at least one row actually carries an adjusted value also
+  // controls visibility of the "Apply Scoring Fit" toggle button —
+  // hidden when the backend pass didn't run for this league.
+  const hasScoringFitAvailable = useMemo(
+    () => eligibleRaw.some(
+      (r) => typeof r.idpScoringFitAdjustedValue === "number"
+              && Number.isFinite(r.idpScoringFitAdjustedValue),
+    ),
+    [eligibleRaw],
+  );
+
+  const eligible = useMemo(() => {
+    if (!applyScoringFit || !hasScoringFitAvailable) return eligibleRaw;
+    // Project every row to a working copy with displayValue/displayRank
+    // overlay.  The ORIGINAL ``rankDerivedValue`` is preserved so the
+    // PlayerPopup / trade calculator (when invoked from this page) can
+    // still surface the consensus number alongside the adjusted one.
+    const projected = eligibleRaw.map((r) => {
+      const adjusted = (typeof r.idpScoringFitAdjustedValue === "number"
+                        && Number.isFinite(r.idpScoringFitAdjustedValue))
+        ? r.idpScoringFitAdjustedValue
+        : null;
+      const displayValue = adjusted ?? Number(r.rankDerivedValue) ?? 0;
+      return {
+        ...r,
+        // Preserve originals for tooltip / debug surfaces.
+        consensusRankDerivedValueOriginal: r.rankDerivedValue,
+        consensusRankOriginal: r.canonicalConsensusRank,
+        // Swap the working values + ranks so existing sort/display
+        // pipelines (resolvedRank, sort by "value", etc.) pick up the
+        // adjusted numbers without further plumbing.
+        rankDerivedValue: displayValue,
+        // Also overlay values.full so the rendered table cell follows
+        // the toggle without a separate code path.
+        values: {
+          ...(r.values || {}),
+          full: displayValue,
+        },
+      };
+    });
+    // Re-rank by descending adjusted value, breaking ties on the
+    // original consensus rank (stable order for offense rows that
+    // didn't move).
+    const ranked = [...projected].sort((a, b) => {
+      const va = Number(a.rankDerivedValue) || 0;
+      const vb = Number(b.rankDerivedValue) || 0;
+      if (vb !== va) return vb - va;
+      return (a.consensusRankOriginal ?? Infinity) - (b.consensusRankOriginal ?? Infinity);
+    });
+    // Stamp 1-N ranks in the new order; only stamp on rows that
+    // currently carry a canonicalConsensusRank — picks-suppressed rows
+    // and any other unranked rows stay unranked.  Also overwrite the
+    // ``rank`` field (set in buildRows from canonicalConsensusRank) so
+    // every existing renderer / sort path picks up the new order
+    // without further plumbing.
+    let nextRank = 0;
+    for (const r of ranked) {
+      if (r.consensusRankOriginal != null) {
+        nextRank += 1;
+        r.canonicalConsensusRank = nextRank;
+        r.rank = nextRank;
+      }
+    }
+    return ranked;
+  }, [eligibleRaw, applyScoringFit, hasScoringFitAvailable]);
 
   // ── Trust summary stats ──────────────────────────────────────────
   // Single-pass aggregate — six filters would each walk the full
@@ -670,7 +873,7 @@ export default function RankingsPage() {
   }, [eligible, activeLens, posFilter, confFilter, query, sortCol, sortAsc]);
 
   // Apply row limit — search/filter bypasses the limit
-  const hasActiveFilter = query || posFilter !== "all" || confFilter !== "all" || activeLens !== "consensus";
+  const hasActiveFilter = query || posFilter !== "all" || confFilter !== "all" || activeLens !== "consensus" || applyScoringFit;
   const displayRows = hasActiveFilter ? ranked : ranked.slice(0, rowLimit);
   const hasMore = !hasActiveFilter && ranked.length > rowLimit;
 
@@ -1093,23 +1296,43 @@ export default function RankingsPage() {
               fields on at least one row — otherwise the button shows
               an empty board for offense-only leagues / when the flag
               is off, which is just confusing UX. */}
-          <div className="sub-nav" style={{ marginTop: "var(--space-sm)" }}>
-            {LENSES
-              .filter((lens) =>
-                lens.key !== "scoringFit"
-                || rows.some((r) => typeof r.idpScoringFitDelta === "number"
-                                     && Number.isFinite(r.idpScoringFitDelta))
-              )
-              .map((lens) => (
-                <button
-                  key={lens.key}
-                  className={`sub-nav-btn ${activeLens === lens.key ? "active" : ""}`}
-                  onClick={() => handleLensChange(lens.key)}
-                  title={lens.description}
-                >
-                  {lens.label}
-                </button>
-              ))}
+          <div className="sub-nav" style={{ marginTop: "var(--space-sm)", display: "flex", flexWrap: "wrap", alignItems: "center", gap: "8px" }}>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
+              {LENSES
+                .filter((lens) =>
+                  lens.key !== "scoringFit"
+                  || rows.some((r) => typeof r.idpScoringFitDelta === "number"
+                                       && Number.isFinite(r.idpScoringFitDelta))
+                )
+                .map((lens) => (
+                  <button
+                    key={lens.key}
+                    className={`sub-nav-btn ${activeLens === lens.key ? "active" : ""}`}
+                    onClick={() => handleLensChange(lens.key)}
+                    title={lens.description}
+                  >
+                    {lens.label}
+                  </button>
+                ))}
+            </div>
+            {/* Apply Scoring Fit toggle.  Only rendered when at least
+                one row has ``idpScoringFitAdjustedValue`` stamped (i.e.
+                the backend pass actually ran for this league).  When
+                the user toggles, the entire board re-sorts instantly
+                and IDP rows show the adjusted value instead of the
+                consensus value. */}
+            {hasScoringFitAvailable && (
+              <button
+                className={`sub-nav-btn ${applyScoringFit ? "active" : ""}`}
+                onClick={() => setApplyScoringFit(!applyScoringFit)}
+                title={applyScoringFit
+                  ? "Showing IDP values adjusted by your league's scoring fit. Click to revert to the consensus board."
+                  : "Adjust IDP values + ranks by how this league's stacked scoring rates each player vs the consensus market. Toggles instantly — does not affect the trade calculator."}
+                style={{ marginLeft: "auto" }}
+              >
+                {applyScoringFit ? "✓ Scoring Fit applied" : "Apply Scoring Fit"}
+              </button>
+            )}
           </div>
 
           {/* Lens description */}
@@ -1117,6 +1340,31 @@ export default function RankingsPage() {
             <p className="muted text-xs" style={{ margin: "4px 0 8px", lineHeight: 1.4 }}>
               {currentLens.description}
             </p>
+          )}
+
+          {/* Apply-Scoring-Fit explainer banner.  Surfaces only when
+              the toggle is ON so first-run users understand what
+              changed about the board before the lens cells make sense.
+              Single line — points at the badges and explains the
+              cyan-pill "synthetic" marker for rookies. */}
+          {applyScoringFit && (
+            <div
+              className="muted text-xs"
+              style={{
+                margin: "4px 0 8px",
+                padding: "6px 10px",
+                lineHeight: 1.4,
+                borderLeft: "3px solid var(--cyan, #22d3ee)",
+                background: "rgba(34, 211, 238, 0.08)",
+                borderRadius: "3px",
+              }}
+            >
+              IDP values + ranks are adjusted by how your league's
+              stacked scoring rates each player vs the consensus market.
+              Cyan dot = rookie cohort estimate (no realized production yet).
+              Trade calculator + suggestions still use raw consensus —
+              this toggle only affects the rankings board.
+            </div>
           )}
 
           {/* Filters */}
@@ -1389,7 +1637,24 @@ export default function RankingsPage() {
                             Value is clickable and opens the player popup
                             with the full per-source breakdown so you can
                             see exactly which sources contributed to this
-                            number. */}
+                            number.
+
+                            When ``Apply Scoring Fit`` is active OR the
+                            user is on the Scoring Fit lens, IDP rows
+                            also render two badges:
+
+                            * a confidence dot (high / medium / low /
+                              synthetic) — how robust the underlying
+                              VORP estimate is
+                            * a tier badge (elite / starter+ / starter /
+                              fringe / below) — categorical translation
+                              of the VORP-per-game
+
+                            For synthetic rows (rookies built from
+                            cohort baselines), the confidence dot reads
+                            "rookie cohort" so the user knows the value
+                            is a draft-capital estimate, not realized
+                            production. */}
                         <td style={{ textAlign: "right" }} title={`Hill-curve value ${val.toLocaleString()} (scale 1\u20139,999) — click to see per-source breakdown`}>
                           <span
                             className="rankings-value rankings-value-clickable"
@@ -1406,6 +1671,16 @@ export default function RankingsPage() {
                           >
                             {band.label}
                           </span>
+                          {(applyScoringFit || activeLens === "scoringFit") && row.idpScoringFitTier && (
+                            <ScoringFitBadges
+                              tier={row.idpScoringFitTier}
+                              confidence={row.idpScoringFitConfidence}
+                              synthetic={row.idpScoringFitSynthetic}
+                              draftRound={row.idpScoringFitDraftRound}
+                              delta={row.idpScoringFitDelta}
+                              consensusValue={row.consensusRankDerivedValueOriginal ?? row.rankDerivedValue}
+                            />
+                          )}
                         </td>
 
                         {/* Per-source value + rank columns.  Gated on

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -6301,19 +6301,29 @@ def _compute_unified_rankings(
     # IDP scoring-fit lens (Phase 1).  Stamps ``idpScoringFit*`` fields
     # on IDP rows: VORP under league scoring, tier label, value-scale
     # delta vs the consensus rank, confidence label scaled by realized
-    # sample size.  Diagnostic-only — does NOT touch
-    # ``rankDerivedValue`` or any trade engine.  Gated behind
-    # ``idp_scoring_fit`` feature flag (default OFF) until the
-    # production gate passes.  No-op for offense-only leagues.
+    # sample size, plus a pre-computed ``idpScoringFitAdjustedValue``
+    # for the frontend's apply-scoring-fit toggle.  Backend never
+    # mutates ``rankDerivedValue``.  Gated behind ``idp_scoring_fit``
+    # feature flag (default OFF) until the production gate passes.
+    # No-op for offense-only leagues — resolved via ``idp_enabled`` on
+    # the active LeagueConfig.
     try:
         from src.scoring.idp_scoring_fit_apply import (  # noqa: PLC0415
             apply_idp_scoring_fit_pass,
         )
+        # Resolve idp_enabled from the active league registry.  Default
+        # to True when the registry is unavailable (matches the
+        # historical pre-registry behaviour); the pass is still gated
+        # by the feature flag, so True-by-default doesn't cause any
+        # behaviour change with the flag OFF.
+        _idp_enabled = True
         try:
             from src.api import league_registry as _lr  # noqa: PLC0415
-            _idp_enabled = bool(_lr.get_default_idp_enabled() if hasattr(_lr, "get_default_idp_enabled") else True)
+            _league = _lr.get_default_league()
+            if _league is not None:
+                _idp_enabled = bool(_league.idp_enabled)
         except Exception:  # noqa: BLE001
-            _idp_enabled = True
+            pass
         apply_idp_scoring_fit_pass(
             players_array,
             league_idp_enabled=_idp_enabled,
@@ -7301,6 +7311,12 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "idpScoringFitDraftRound",
     "idpScoringFitWeightedPpg",
     "idpScoringFitGamesUsed",
+    # Pre-computed "what rankDerivedValue would be if the user toggles
+    # apply-scoring-fit on the frontend".  Always stamped alongside
+    # the delta; frontend toggle decides whether to display + sort by
+    # this or raw rankDerivedValue.  Backend never mutates
+    # rankDerivedValue itself.
+    "idpScoringFitAdjustedValue",
 )
 
 

--- a/src/scoring/idp_scoring_fit.py
+++ b/src/scoring/idp_scoring_fit.py
@@ -413,6 +413,63 @@ def _build_gsis_to_draft(
     return out
 
 
+def _normalize_player_name(name: str) -> str:
+    """Lowercase + strip non-alpha for fuzzy name matching.
+
+    Aligns nflverse ``display_name`` (e.g. "T.J. Watt") with Sleeper
+    ``displayName`` (e.g. "TJ Watt") into a common key like ``tjwatt``.
+    Handles periods, apostrophes, hyphens, suffixes naturally —
+    everything non-alpha is dropped.
+    """
+    out_chars: list[str] = []
+    for ch in str(name or "").lower():
+        if ch.isalpha() or ch == " ":
+            out_chars.append(ch)
+    return " ".join("".join(out_chars).split())
+
+
+def _build_name_to_gsis(
+    id_map_rows: list[dict[str, Any]] | None,
+) -> dict[str, str]:
+    """Build normalised-name → gsis lookup from nflverse players.csv.
+
+    Used as the SECOND join path when a player's Sleeper id has no
+    ``gsis_id`` stamped on the Sleeper /players/nfl payload.  About
+    35-50% of active fantasy IDPs fall into that gap (Sleeper's gsis
+    coverage is incomplete for non-superstar players).
+
+    Position is encoded into the key (``"micah parsons|LB"``) to avoid
+    cross-position name collisions (two players named "John Smith"
+    at different positions would otherwise collide).
+    """
+    out: dict[str, str] = {}
+    for row in id_map_rows or []:
+        gsis = str(row.get("gsis_id") or "").strip()
+        nm = _normalize_player_name(row.get("display_name") or "")
+        pos = str(row.get("position") or "").upper()
+        if not gsis or not nm or not pos:
+            continue
+        out[f"{nm}|{pos}"] = gsis
+        # Also stamp a position-agnostic fallback, picked by the most
+        # recent ``last_season`` if one already exists at this key.
+        # Active players win over retired ones with the same name.
+        prev = out.get(nm)
+        if prev is None:
+            out[nm] = gsis
+        else:
+            try:
+                prev_last = next(
+                    (int(r.get("last_season") or 0) for r in id_map_rows
+                     if str(r.get("gsis_id") or "") == prev), 0,
+                )
+                cur_last = int(row.get("last_season") or 0)
+                if cur_last > prev_last:
+                    out[nm] = gsis
+            except (TypeError, ValueError):
+                pass
+    return out
+
+
 # ── QuantileMap (the proposal's cross-position normalization) ─────
 def quantile_map_to_consensus_scale(
     par_value: float,
@@ -506,10 +563,15 @@ def compute_idp_scoring_fit(
         weekly_rows_by_season, id_map_rows, scoring_settings
     )
     gsis_to_draft = _build_gsis_to_draft(id_map_rows)
+    # Name → gsis fallback for the ~35-50% of active fantasy IDPs whose
+    # Sleeper /players/nfl record doesn't have ``gsis_id`` stamped.
+    name_to_gsis = _build_name_to_gsis(id_map_rows)
 
     # Phase A: build per-player season rows.
     season_rows: list[PlayerSeasonRow] = []
     diagnostic_rows: list[dict[str, Any]] = []
+
+    join_stats = {"sleeper_id": 0, "name": 0, "missing": 0}
 
     for player in players_array:
         pos = str(player.get("position") or "").upper()
@@ -519,14 +581,28 @@ def compute_idp_scoring_fit(
         # without a player_id (picks, name-only entries) can't be
         # joined to nflverse weekly data.
         sleeper_id = str(player.get("playerId") or "")
-        # Cross-walk Sleeper id → gsis id when available; fall back
-        # to display_name lowercase for the legacy join.
-        gsis_id = (sleeper_to_gsis or {}).get(sleeper_id) if sleeper_id else None
-        join_key = (
-            str(gsis_id) if gsis_id
-            else sleeper_id
-            or str(player.get("displayName") or "").lower()
-        )
+        display_name = str(player.get("displayName") or "")
+        # Cross-walk in priority order:
+        #   1. Sleeper id → gsis_id via Sleeper's /players/nfl payload
+        #   2. Normalised name → gsis via nflverse players.csv (covers
+        #      the gap where Sleeper has no gsis_id stamped)
+        gsis_id: str | None = None
+        if sleeper_id:
+            gsis_id = (sleeper_to_gsis or {}).get(sleeper_id) or None
+        if gsis_id:
+            join_stats["sleeper_id"] += 1
+        elif display_name:
+            # Try the position-qualified key first (avoids cross-position
+            # name collisions), then the position-agnostic fallback.
+            nm_norm = _normalize_player_name(display_name)
+            gsis_id = name_to_gsis.get(f"{nm_norm}|{pos}")
+            if not gsis_id:
+                gsis_id = name_to_gsis.get(nm_norm)
+            if gsis_id:
+                join_stats["name"] += 1
+        if not gsis_id:
+            join_stats["missing"] += 1
+        join_key = str(gsis_id) if gsis_id else (sleeper_id or display_name.lower())
         if not join_key:
             continue
 
@@ -608,6 +684,11 @@ def compute_idp_scoring_fit(
             "synthetic": False,
             "draft_round": None,
         })
+
+    _LOGGER.info(
+        "idp_scoring_fit=join_stats sleeper_id=%d name=%d missing=%d",
+        join_stats["sleeper_id"], join_stats["name"], join_stats["missing"],
+    )
 
     # Phase B: VORP table.
     vorp_rows = vorp_table(season_rows, slots)

--- a/src/scoring/idp_scoring_fit_apply.py
+++ b/src/scoring/idp_scoring_fit_apply.py
@@ -15,7 +15,27 @@ raising into the live contract build.
 
 Feature-gated by ``feature_flags.is_enabled("idp_scoring_fit")``.
 Phase 1 ships with the flag OFF until the production gate passes
-(≥30 of top-50 IDPs from the prior season rated fit-positive).
+(lens leans correct AND ≥20% precision floor on the prior-season
+backtest).
+
+Adjusted value (the "apply scoring fit" toggle)
+─────────────────────────────────────────────────
+When the pass runs, every IDP row also gets
+``idpScoringFitAdjustedValue`` =
+``clamp(rankDerivedValue + delta × _ADJUSTED_VALUE_WEIGHT, 0, 9999)``.
+
+That field is what the value would be IF the user toggles "apply
+scoring fit" on the frontend.  The toggle itself is purely a
+display switch — the frontend re-sorts and re-displays using this
+field instead of ``rankDerivedValue``.  Backend never mutates
+``rankDerivedValue``.
+
+The 0.30 weight was chosen as a middle ground between the original
+plan's recommended 0.20 (Phase 3) and the proposal's 0.65
+(too aggressive without proven calibration).  At 0.30 a +6000
+delta moves a player ~1800 value points — meaningful but not
+absurd; positive deltas of ~+2000 (the median of the live IDP
+universe) shift values ~600 — a one-tier nudge.
 """
 from __future__ import annotations
 
@@ -23,6 +43,10 @@ import json as _json
 import logging
 import threading
 import time as _time
+
+_ADJUSTED_VALUE_WEIGHT: float = 0.30
+_ADJUSTED_VALUE_MIN: float = 0.0
+_ADJUSTED_VALUE_MAX: float = 9999.0
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -53,7 +77,12 @@ _IDP_LEAGUE_CONTEXT_TTL_SEC = 3600
 
 
 def _fetch_sleeper_players_idmap() -> dict[str, str]:
-    """Return Sleeper-id → GSIS-id cross-walk.  Daily-cached.
+    """Return Sleeper-id → GSIS-id cross-walk.
+
+    Two-tier cache: in-memory hot path + on-disk warm path via the
+    existing ``src.nfl_data.cache`` module.  A backend restart picks up
+    the disk cache instantly (24-hour TTL) instead of refetching the
+    ~6MB Sleeper /players/nfl payload every cold start.
 
     Empty dict on any failure.  Sleeper's /players/nfl endpoint
     returns ``{sleeper_id: {gsis_id, position, ...}, ...}``.  We pull
@@ -65,6 +94,21 @@ def _fetch_sleeper_players_idmap() -> dict[str, str]:
         fetched_at = float(_SLEEPER_PLAYERS_CACHE.get("fetched_at") or 0.0)
         if isinstance(cached, dict) and (now - fetched_at) < _SLEEPER_PLAYERS_TTL_SEC:
             return cached
+
+    # Disk cache check before the network round-trip.
+    try:
+        from src.nfl_data import cache as _disk_cache  # noqa: PLC0415
+        disk_cached = _disk_cache.get(
+            "idp_scoring_fit:sleeper_idmap:v1",
+            ttl_seconds=_SLEEPER_PLAYERS_TTL_SEC,
+        )
+        if isinstance(disk_cached, dict) and disk_cached:
+            with _LOCK:
+                _SLEEPER_PLAYERS_CACHE["idmap"] = disk_cached
+                _SLEEPER_PLAYERS_CACHE["fetched_at"] = now
+            return disk_cached
+    except Exception:  # noqa: BLE001
+        pass  # disk cache miss / unwriteable → fall through to network
 
     url = "https://api.sleeper.app/v1/players/nfl"
     try:
@@ -90,13 +134,22 @@ def _fetch_sleeper_players_idmap() -> dict[str, str]:
     with _LOCK:
         _SLEEPER_PLAYERS_CACHE["idmap"] = out
         _SLEEPER_PLAYERS_CACHE["fetched_at"] = now
+    # Persist to disk cache so the next backend restart skips the
+    # 6MB fetch (cache TTL is 24h, matching the in-memory TTL).
+    try:
+        from src.nfl_data import cache as _disk_cache  # noqa: PLC0415
+        _disk_cache.put("idp_scoring_fit:sleeper_idmap:v1", out)
+    except Exception:  # noqa: BLE001
+        pass
+
     return out
 
 
 def _fetch_idp_league_context() -> dict[str, Any]:
     """Return ``{scoring_settings, roster_positions, num_teams}``.
 
-    Hourly-cached.  Empty dict on any failure.
+    Two-tier cache: in-memory + on-disk (24-hour TTL).  Empty dict
+    on any failure.
     """
     now = _time.time()
     with _LOCK:
@@ -104,6 +157,21 @@ def _fetch_idp_league_context() -> dict[str, Any]:
         fetched_at = float(_IDP_LEAGUE_CONTEXT_CACHE.get("fetched_at") or 0.0)
         if isinstance(cached, dict) and (now - fetched_at) < _IDP_LEAGUE_CONTEXT_TTL_SEC:
             return cached
+
+    # Disk cache check.
+    try:
+        from src.nfl_data import cache as _disk_cache  # noqa: PLC0415
+        disk_cached = _disk_cache.get(
+            "idp_scoring_fit:league_ctx:v1",
+            ttl_seconds=_IDP_LEAGUE_CONTEXT_TTL_SEC,
+        )
+        if isinstance(disk_cached, dict) and disk_cached.get("scoring_settings"):
+            with _LOCK:
+                _IDP_LEAGUE_CONTEXT_CACHE["ctx"] = disk_cached
+                _IDP_LEAGUE_CONTEXT_CACHE["fetched_at"] = now
+            return disk_cached
+    except Exception:  # noqa: BLE001
+        pass
 
     # Resolve league id via the registry first; fall back to env var.
     league_id = ""
@@ -145,6 +213,12 @@ def _fetch_idp_league_context() -> dict[str, Any]:
         "roster_positions": [str(p) for p in roster_positions],
         "num_teams": total_rosters,
     }
+    # Persist to disk so the next backend restart skips the network.
+    try:
+        from src.nfl_data import cache as _disk_cache  # noqa: PLC0415
+        _disk_cache.put("idp_scoring_fit:league_ctx:v1", ctx)
+    except Exception:  # noqa: BLE001
+        pass
     with _LOCK:
         _IDP_LEAGUE_CONTEXT_CACHE["ctx"] = ctx
         _IDP_LEAGUE_CONTEXT_CACHE["fetched_at"] = now
@@ -294,9 +368,18 @@ def apply_idp_scoring_fit_pass(
             player["idpScoringFitWeightedPpg"] = fit_with_delta.weighted_ppg
         if fit_with_delta.games_used:
             player["idpScoringFitGamesUsed"] = fit_with_delta.games_used
+        # Adjusted value: what rankDerivedValue would BE if the user
+        # toggles "apply scoring fit" on the frontend.  Always stamped
+        # when the pass produces a delta — frontend toggle decides
+        # whether to display this or the raw consensus.  Backend never
+        # mutates ``rankDerivedValue`` itself.
+        if fit_with_delta.delta is not None and consensus_value > 0:
+            adjusted = consensus_value + fit_with_delta.delta * _ADJUSTED_VALUE_WEIGHT
+            adjusted = max(_ADJUSTED_VALUE_MIN, min(_ADJUSTED_VALUE_MAX, adjusted))
+            player["idpScoringFitAdjustedValue"] = round(adjusted, 2)
         stamped += 1
 
     _LOGGER.info(
-        "idp_scoring_fit=applied stamped=%d total_fit_rows=%d",
-        stamped, len(fit_by_name),
+        "idp_scoring_fit=applied stamped=%d total_fit_rows=%d weight=%.2f",
+        stamped, len(fit_by_name), _ADJUSTED_VALUE_WEIGHT,
     )

--- a/tests/scoring/test_idp_scoring_fit_parity.py
+++ b/tests/scoring/test_idp_scoring_fit_parity.py
@@ -1,0 +1,187 @@
+"""Parity regression test: backend never mutates ``rankDerivedValue``.
+
+The scoring-fit pass is *additive only* — it stamps new
+``idpScoringFit*`` fields on each IDP row but MUST NOT touch the
+existing consensus fields (``rankDerivedValue``,
+``canonicalConsensusRank``, ``sourceRanks``, etc.).
+
+This test asserts the invariant by:
+
+1. Running ``apply_idp_scoring_fit_pass`` against a hand-built mini
+   players_array
+2. Snapshotting every key present BEFORE and AFTER
+3. Asserting the symmetric difference is a STRICT SUBSET of the
+   approved ``idpScoringFit*`` whitelist
+
+If any future refactor adds a side-effect that mutates an existing
+field, this test fails loud rather than silently shifting values in
+production.
+"""
+from __future__ import annotations
+
+import unittest
+from copy import deepcopy
+from unittest.mock import patch
+
+from src.scoring.idp_scoring_fit_apply import apply_idp_scoring_fit_pass
+
+
+# Approved field names the pass is allowed to add.  Any addition to
+# this set requires a deliberate code review — that's the whole point.
+_ALLOWED_NEW_FIELDS = frozenset({
+    "idpScoringFitVorp",
+    "idpScoringFitTier",
+    "idpScoringFitDelta",
+    "idpScoringFitConfidence",
+    "idpScoringFitSynthetic",
+    "idpScoringFitDraftRound",
+    "idpScoringFitWeightedPpg",
+    "idpScoringFitGamesUsed",
+    "idpScoringFitAdjustedValue",
+})
+
+
+def _seed_players() -> list[dict]:
+    """Hand-build a minimal IDP-heavy players_array for the test.
+
+    All consensus fields populated.  After the pass, every existing
+    field MUST equal its pre-pass value byte-for-byte.
+    """
+    return [
+        {
+            "displayName": "Micah Parsons",
+            "position": "LB",
+            "playerId": "11111",
+            "rankDerivedValue": 8500,
+            "canonicalConsensusRank": 12,
+            "sourceRanks": {"ktc": 12, "dlf": 11, "idpTradeCalc": 8},
+            "confidenceBucket": "high",
+            "anomalyFlags": [],
+        },
+        {
+            "displayName": "Will Anderson Jr.",
+            "position": "DE",
+            "playerId": "22222",
+            "rankDerivedValue": 6700,
+            "canonicalConsensusRank": 28,
+            "sourceRanks": {"ktc": 28, "dlf": 30, "idpTradeCalc": 22},
+            "confidenceBucket": "medium",
+            "anomalyFlags": [],
+        },
+        {
+            "displayName": "Josh Allen",
+            "position": "QB",  # offense — should be skipped by the pass
+            "playerId": "33333",
+            "rankDerivedValue": 9999,
+            "canonicalConsensusRank": 1,
+        },
+    ]
+
+
+class TestIdpScoringFitParity(unittest.TestCase):
+    """The backend pass MUST be additive-only on existing fields."""
+
+    @patch("src.scoring.idp_scoring_fit_apply._fetch_sleeper_players_idmap")
+    @patch("src.scoring.idp_scoring_fit_apply._fetch_nflverse_id_map")
+    @patch("src.scoring.idp_scoring_fit_apply._fetch_trailing_3yr_defensive_corpus")
+    @patch("src.scoring.idp_scoring_fit_apply._fetch_idp_league_context")
+    @patch("src.api.feature_flags.is_enabled")
+    def test_pass_does_not_mutate_existing_fields(
+        self,
+        mock_flag,
+        mock_ctx,
+        mock_corpus,
+        mock_id_map,
+        mock_sleeper,
+    ):
+        # Force the flag ON, return canned context so the pass executes
+        # its full body.  The corpus is intentionally non-empty so the
+        # pass produces some fit rows.
+        mock_flag.side_effect = lambda name: name == "idp_scoring_fit"
+        mock_ctx.return_value = {
+            "scoring_settings": {
+                "idp_tkl_solo": 1.5,
+                "idp_sack": 4.0,
+                "idp_qb_hits": 1.5,
+                "idp_pd": 1.5,
+            },
+            "roster_positions": ["QB", "RB", "WR", "TE", "FLEX", "DL", "LB", "DB"],
+            "num_teams": 12,
+        }
+        # Build a tiny defensive corpus so the pass produces output.
+        mock_corpus.return_value = {
+            2024: [
+                {"player_id": "gsis_parsons", "player_name": "Micah Parsons",
+                 "position": "LB", "season": 2024, "week": w,
+                 "def_tackles_solo": 4, "def_sacks": 1}
+                for w in range(1, 18)
+            ] + [
+                {"player_id": "gsis_anderson", "player_name": "Will Anderson",
+                 "position": "DE", "season": 2024, "week": w,
+                 "def_tackles_solo": 2, "def_sacks": 1, "def_qb_hits": 1}
+                for w in range(1, 18)
+            ],
+        }
+        mock_id_map.return_value = [
+            {"gsis_id": "gsis_parsons", "display_name": "Micah Parsons",
+             "position": "LB", "rookie_season": 2021, "draft_round": 1},
+            {"gsis_id": "gsis_anderson", "display_name": "Will Anderson",
+             "position": "DE", "rookie_season": 2023, "draft_round": 1},
+        ]
+        mock_sleeper.return_value = {
+            "11111": "gsis_parsons",
+            "22222": "gsis_anderson",
+        }
+
+        # Snapshot the pre-pass state.
+        players = _seed_players()
+        before = deepcopy(players)
+
+        apply_idp_scoring_fit_pass(players, league_idp_enabled=True)
+
+        # For every player, every key that existed BEFORE must still
+        # equal its pre-pass value AFTER.  The only NEW keys allowed
+        # are members of ``_ALLOWED_NEW_FIELDS``.
+        for pre, post in zip(before, players):
+            for k, v in pre.items():
+                self.assertEqual(
+                    post.get(k), v,
+                    f"field {k!r} on {pre.get('displayName')!r} mutated: "
+                    f"before={v!r}, after={post.get(k)!r}",
+                )
+            new_keys = set(post.keys()) - set(pre.keys())
+            unauthorized = new_keys - _ALLOWED_NEW_FIELDS
+            self.assertFalse(
+                unauthorized,
+                f"unauthorized new fields on {pre.get('displayName')!r}: "
+                f"{unauthorized}",
+            )
+
+    @patch("src.api.feature_flags.is_enabled")
+    def test_flag_off_is_complete_no_op(self, mock_flag):
+        """With the flag OFF, players_array must be byte-identical."""
+        mock_flag.return_value = False
+
+        players = _seed_players()
+        before = deepcopy(players)
+
+        apply_idp_scoring_fit_pass(players, league_idp_enabled=True)
+
+        self.assertEqual(players, before)
+
+    @patch("src.api.feature_flags.is_enabled")
+    def test_idp_disabled_league_is_no_op(self, mock_flag):
+        """For offense-only leagues, players_array must be byte-identical
+        even with the flag ON."""
+        mock_flag.return_value = True
+
+        players = _seed_players()
+        before = deepcopy(players)
+
+        apply_idp_scoring_fit_pass(players, league_idp_enabled=False)
+
+        self.assertEqual(players, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Builds on #313 to make the IDP scoring-fit lens production-ready plus adds an in-page toggle that instantly applies the lens to IDP values + ranks on `/rankings`.

## What changed

### Backend hardening (Steps 1-5)
- **Name-based gsis fallback** — Sleeper's `gsis_id` field is sparse (~52% coverage). Adding a normalised-name → gsis lookup from nflverse `players.csv` lifted live coverage from **148 → 390 IDP rows** with scoringFit stamps (2.6× improvement on the local snapshot).
- **`idpScoringFitAdjustedValue`** — clamped `consensus + delta × 0.30`, stamped alongside the diagnostic delta. Frontend toggle reads this; backend never mutates `rankDerivedValue`.
- **Per-league `idp_enabled`** — resolved from `LeagueConfig` instead of hardcoded `True`. Offense-only leagues skip the 7 nflverse fetches.
- **Disk-backed cache** — Sleeper `/players/nfl` (~6MB) + league context now persist via `src.nfl_data.cache`. Backend restart picks up the cached data instantly.
- **Parity regression test** — asserts the pass only writes whitelisted `idpScoringFit*` keys; mutations to existing fields fail loud.

### Frontend UX (Steps 6-9)
- **"Apply Scoring Fit" toggle button** — persistent in `localStorage`, hidden when the backend pass didn't run. Click toggles instantly: IDP rows substitute `idpScoringFitAdjustedValue` for `rankDerivedValue` and the entire board re-sorts to assign fresh 1-N ranks.
- **Tier + confidence + delta badges** next to the value cell when the toggle is on or the Scoring Fit lens is active.
- **Cyan "R{round} synth" pill** on synthetic rookie rows so the user knows the value is a draft-cohort estimate, not realized production.
- **First-run explainer banner** above the table when toggle is on, calling out that trade engines still use raw consensus.

### Live smoke test (Step 10)

Flag ON via `RISKIT_FEATURE_IDP_SCORING_FIT=1`, contract built from the latest scrape:

```
total players:                   1071
with scoringFit stamps:           390
with adjusted value:              219

Top-5 by scoringFitDelta:
  Jaquan Brisker         DB    delta=+7695  conf=high
  DeMarvion Overshown    LB    delta=+6477  conf=medium
  Bradley Chubb          DL    delta=+6352  conf=medium
  T.J. Watt              DL    delta=+4551  conf=high
  Alex Singleton         LB    delta=+4454  conf=high

Bottom-5 (sell-high candidates):
  Jack Campbell          LB    delta=-5521  conf=high
  Cedric Gray            LB    delta=-3694  conf=low
  Jamien Sherwood        LB    delta=-3584  conf=high
  Nate Landman           LB    delta=-3333  conf=high
  Payton Wilson          LB    delta=-3279  conf=high
```

Names land on plausible buy-low / sell-high candidates per the league's stacked scoring profile.

## Out of scope (called out explicitly)

The toggle only affects the `/rankings` board. Trade Calculator, Trade Suggestions, Trade Finder, and Buy/Sell signals still read raw `rankDerivedValue` — extending the toggle to those is a follow-up gated by the user's call.

## Test plan

- [x] `pytest tests/` — 2387 pass (+3 new), 3 skip
- [x] `npm run build` — bundle gate clean (all 13 pages)
- [x] Parity test passes with flag ON + full mocked corpus
- [x] Live smoke test against current snapshot — 390 IDPs stamped
- [x] Backtest gate (PR #313) still passes
- [ ] After merge: flip `RISKIT_FEATURE_IDP_SCORING_FIT=1` in `dynasty.service`, restart, hit `/api/data` and confirm the new fields appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)