### PR TITLE
ci: capture IDP scoring-fit snapshots daily

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -187,13 +187,47 @@ jobs:
             exit 1
           fi
 
+      # ── IDP scoring-fit snapshot (idempotent, daily) ──────────────
+      # The capture script writes to ``data/idp_fit_snapshots/{date}.json``.
+      # Skipping when today's file already exists turns the every-3-hour
+      # refresh into a daily snapshot cadence without a second cron.
+      # Each snapshot is ~50KB JSON of the lens output for every
+      # IDP-with-delta — small enough to commit inline; large enough to
+      # power historical backtests later.
+      #
+      # Snapshots accumulate forever in git; pruning is a future concern
+      # (at ~50KB × 365/yr × N years, the bottom of the iceberg is
+      # ~18MB/yr — fine until we have multiple years of history).
+      - name: Capture daily IDP scoring-fit snapshot
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          TODAY=$(date -u +%Y-%m-%d)
+          TARGET="data/idp_fit_snapshots/${TODAY}.json"
+          if [[ -f "$TARGET" ]]; then
+            echo "Snapshot for ${TODAY} already exists — skipping capture"
+            exit 0
+          fi
+          # League context resolves via config/leagues/registry.json
+          # (already in the repo) — no SLEEPER_LEAGUE_ID secret needed.
+          mkdir -p data/idp_fit_snapshots
+          # Capture script is best-effort.  Any failure (missing payload,
+          # nflverse outage, Sleeper rate-limit) logs a warning and
+          # continues the workflow rather than blocking the refresh.
+          if python3 scripts/capture_idp_fit_snapshot.py; then
+            echo "Captured snapshot: $TARGET"
+            ls -la "$TARGET" 2>/dev/null || true
+          else
+            echo "::warning title=Snapshot capture failed::see logs above"
+          fi
+
       - name: Commit updated data
         shell: bash
         run: |
           set -Eeuo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -f CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/
+          git add -f CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/ data/idp_fit_snapshots/
           if git diff --cached --quiet; then
             echo "No data changes to commit"
           else


### PR DESCRIPTION
## Summary

Automates the snapshot capture from the prior PR. The scheduled-refresh workflow already runs every 3 hours; this adds an idempotent step that runs `scripts/capture_idp_fit_snapshot.py` only when today's snapshot doesn't already exist.

Effective cadence: **one snapshot per UTC day**, no second cron needed.

## How it works

```yaml
- name: Capture daily IDP scoring-fit snapshot
  run: |
    TODAY=$(date -u +%Y-%m-%d)
    TARGET="data/idp_fit_snapshots/${TODAY}.json"
    [[ -f "$TARGET" ]] && exit 0  # already captured
    python3 scripts/capture_idp_fit_snapshot.py
```

The git commit step then force-adds `data/idp_fit_snapshots/` alongside the existing `data/canonical/` etc.

## Sizing

- ~120KB per snapshot (every IDP-with-delta + their lens output)
- 365 snapshots/yr × 120KB ≈ **44MB/year** in git
- Linear; pruning is a future concern (years 4+)

## Why this design

Considered + rejected:
- **Separate cron workflow**: would need its own checkout + Python install (~2min). Reusing scheduled-refresh's already-set-up environment is free.
- **systemd timer on prod**: would require committing back to git via SSH key on the box. CI is cleaner — runner already has `GITHUB_TOKEN`.
- **Quarterly cadence**: too coarse to track in-season lens drift.

## Local verification

```
captured 355 IDPs with deltas
wrote: data/idp_fit_snapshots/2026-04-26.json
```

51 synthetic rookies firing (up from 12 pre-#318 — the position-family aliasing kicked in).

## Test plan

- [x] Capture script runs locally → produces 117KB JSON
- [x] League context resolves via `config/leagues/registry.json` (no secret needed)
- [ ] Post-merge: next scheduled-refresh run captures the first production snapshot
- [ ] After 14 days of accumulated snapshots: try `python3 scripts/backtest_idp_scoring_fit.py --snapshot data/idp_fit_snapshots/2026-04-26.json` to validate replay works

🤖 Generated with [Claude Code](https://claude.com/claude-code)