### PR TITLE
feat(idp): scoring-fit digest + movers + targets + 7 more

### DIFF
--- a/deploy/systemd/dynasty-scoring-fit-digest.service.template
+++ b/deploy/systemd/dynasty-scoring-fit-digest.service.template
@@ -1,0 +1,31 @@
+[Unit]
+Description=Dynasty Trade Calculator weekly scoring-fit digest (__SERVICE_NAME__)
+After=network-online.target __SERVICE_NAME__.service
+Wants=network-online.target
+Requires=__SERVICE_NAME__.service
+
+# Fires the /api/scoring-fit-digest/run endpoint on the local backend.
+# The endpoint authenticates via the SIGNAL_ALERT_CRON_TOKEN bearer
+# token loaded from __APP_DIR__/.env (same token as the daily signal-
+# alerts sweep — they share the auth surface).
+#
+# Recipient is read from the ALERT_TO env var by default; the body
+# can override per call.  The digest is idempotent — sending twice
+# in one week just produces two identical emails, no state corruption.
+# Cooldowns / dedup are NOT enforced for the digest; the cadence is
+# managed by the timer.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+ExecStart=/usr/bin/curl --fail --silent --show-error --max-time 300 \
+  -H "Authorization: Bearer ${SIGNAL_ALERT_CRON_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST http://127.0.0.1:8000/api/scoring-fit-digest/run \
+  -d '{}'
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-scoring-fit-digest.timer.template
+++ b/deploy/systemd/dynasty-scoring-fit-digest.timer.template
@@ -1,0 +1,18 @@
+[Unit]
+Description=Weekly IDP scoring-fit digest for __SERVICE_NAME__
+Requires=__SERVICE_NAME__-scoring-fit-digest.service
+
+[Timer]
+# Fire once a week, Friday at 14:00 UTC (10am EST / 9am EDT).
+# Chosen so the digest lands Friday morning — most fantasy
+# decisions happen Friday-Sunday around the upcoming slate, so the
+# email arrives right when the user is likely to act on it.
+# Persistent=true ensures we run once at boot if the machine was
+# down when the timer would have fired.
+OnCalendar=Fri *-*-* 14:00:00
+RandomizedDelaySec=300
+Persistent=true
+Unit=__SERVICE_NAME__-scoring-fit-digest.service
+
+[Install]
+WantedBy=timers.target

--- a/frontend/app/api/scoring-fit/movers/route.js
+++ b/frontend/app/api/scoring-fit/movers/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = process.env.BACKEND_API_URL
+  ? new URL("/api/scoring-fit/movers", process.env.BACKEND_API_URL.replace(/\/api\/data$/, "")).toString()
+  : "http://127.0.0.1:8000/api/scoring-fit/movers";
+
+export async function GET() {
+  try {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), 5000);
+    const res = await fetch(BACKEND, { cache: "no-store", signal: ctl.signal });
+    clearTimeout(timer);
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ has_baseline: false, risers: [], fallers: [] }, { status: 200 });
+  }
+}

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -3,7 +3,7 @@
 import { Fragment, useMemo, useState, useCallback, useEffect } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
 import { resolvedRank, RANKING_SOURCES, getRetailLabel } from "@/lib/dynasty-data";
-import { useSettings } from "@/components/useSettings";
+import { useSettings, resolveScoringFitForLeague } from "@/components/useSettings";
 import { useApp } from "@/components/AppShell";
 import { useTeam } from "@/components/useTeam";
 import {
@@ -36,6 +36,7 @@ import SourceAgreementRadar from "@/components/graphs/SourceAgreementRadar";
 import RankChangeGlyph from "@/components/graphs/RankChangeGlyph";
 import { PlayerImage } from "@/components/ui";
 import { useNews } from "@/components/useNews";
+import ScoringFitOnboarding from "@/components/ScoringFitOnboarding";
 
 // ── UNIFIED RANKINGS PAGE ────────────────────────────────────────────
 // Trust-forward blended board: offense + IDP sorted by unified rank.
@@ -568,7 +569,7 @@ export default function RankingsPage() {
   // underlying blended board still lives on the backend; we just
   // don't surface it here.  ``useTeam`` reads the flag off the
   // registry's league config via ``useLeague``.
-  const { idpEnabled } = useTeam();
+  const { idpEnabled, selectedLeagueKey } = useTeam();
   // Pull recent news so we can stamp a "📰" chip on rows whose
   // player has fresh news / injury status.  Looks up by lowercase
   // name in O(1).  News data is single-flighted at module level so
@@ -592,8 +593,20 @@ export default function RankingsPage() {
   // immediately on /trade (Trade Calculator), Trade Suggestions, and
   // any other consumer of player values.  When ON, IDP rows substitute
   // ``idpScoringFitAdjustedValue`` for ``rankDerivedValue`` everywhere.
-  const applyScoringFit = !!settings.applyScoringFit;
+  // Per-league resolution: if the active league has an override in
+  // ``scoringFitByLeague`` it wins over the global default.  Lets a
+  // user run the lens differently in their stacked-scoring league
+  // vs their non-IDP league without flipping the global toggle.
+  const _resolved = useMemo(
+    () => resolveScoringFitForLeague(settings, selectedLeagueKey),
+    [settings, selectedLeagueKey],
+  );
+  const applyScoringFit = _resolved.applyScoringFit;
   const setApplyScoringFit = useCallback((next) => {
+    // Toggling from /rankings updates the GLOBAL default — the
+    // per-league override is configured from /settings.  Avoids
+    // surprising users who flip the rankings toggle and don't
+    // realise it only affected one league.
     updateSetting("applyScoringFit", !!next);
   }, [updateSetting]);
 
@@ -690,17 +703,12 @@ export default function RankingsPage() {
     [eligibleRaw],
   );
 
-  // Single source of truth for the slider weight — falls back to 0.30
-  // (the recommended default) when the saved settings predate the
-  // scoringFitWeight field.  Clamped to [0, 1] so any future code
-  // path that mutates the value can't break downstream math.
-  const scoringFitWeight = Math.max(
-    0,
-    Math.min(1,
-      typeof settings.scoringFitWeight === "number"
-        ? settings.scoringFitWeight : 0.30,
-    ),
-  );
+  // Single source of truth for the slider weight — uses the
+  // per-league resolved value when the active league has an
+  // override, otherwise the global default.  Clamped to [0, 1]
+  // so any future code path that mutates the value can't break
+  // downstream math.
+  const scoringFitWeight = Math.max(0, Math.min(1, _resolved.scoringFitWeight));
 
   const eligible = useMemo(() => {
     if (!applyScoringFit || !hasScoringFitAvailable || scoringFitWeight <= 0) {
@@ -1123,6 +1131,12 @@ export default function RankingsPage() {
 
   // ── Render ─────────────────────────────────────────────────────────
   return (
+    <>
+    {/* First-run onboarding for the scoring-fit lens.  Renders only
+        when (a) the user hasn't dismissed before AND (b) the
+        backend has lens data available for this league.  Self-
+        contained component handles localStorage + step navigation. */}
+    <ScoringFitOnboarding enabled={hasScoringFitAvailable} />
     <section className="card">
       {/* ── Header ──────────────────────────────────────────────────── */}
       <div className="rankings-header">
@@ -2128,5 +2142,6 @@ export default function RankingsPage() {
         </>
       )}
     </section>
+    </>
   );
 }

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -375,6 +375,7 @@ export default function SettingsPage() {
             on your specific league&apos;s scoring rules.
           </div>
         </div>
+        <PerLeagueScoringFitOverrides />
         <ScoringFitHealth />
       </Section>
 
@@ -676,6 +677,96 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
           </tbody>
         </table>
       </div>
+    </div>
+  );
+}
+
+// ── Per-league overrides ─────────────────────────────────────────
+// Lets a multi-league user run the lens differently in each league
+// without flipping the global toggle every time they switch.
+// Shows a row per active league with a per-league apply toggle +
+// weight slider; "—" or empty fields fall through to the global
+// defaults configured above.
+function PerLeagueScoringFitOverrides() {
+  const { settings, update } = useSettings();
+  const [leagues, setLeagues] = useState([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/leagues", { cache: "no-store" })
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => { if (!cancelled && d?.leagues) setLeagues(d.leagues); })
+      .catch(() => { /* silently swallow — UI shows empty state */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (leagues.length <= 1) return null; // single-league users don't need this
+
+  const overrides = settings.scoringFitByLeague || {};
+
+  function setOverride(leagueKey, field, value) {
+    const next = { ...overrides };
+    const cur = { ...(next[leagueKey] || {}) };
+    if (value === null) delete cur[field];
+    else cur[field] = value;
+    if (Object.keys(cur).length === 0) delete next[leagueKey];
+    else next[leagueKey] = cur;
+    update("scoringFitByLeague", next);
+  }
+
+  return (
+    <div style={{ marginTop: 16, padding: 10, background: "rgba(20, 25, 36, 0.5)", borderRadius: 4, border: "1px solid var(--border)" }}>
+      <div style={{ fontSize: "0.72rem", fontWeight: 600, marginBottom: 8 }}>
+        Per-league overrides
+      </div>
+      <div className="muted" style={{ fontSize: "0.66rem", marginBottom: 8, lineHeight: 1.4 }}>
+        Override the global toggle / weight for individual leagues.
+        Empty fields fall through to the global defaults above.
+      </div>
+      {leagues.map((lg) => {
+        const ov = overrides[lg.key] || {};
+        const apply = typeof ov.applyScoringFit === "boolean" ? ov.applyScoringFit : null;
+        const weight = typeof ov.scoringFitWeight === "number" ? ov.scoringFitWeight : null;
+        return (
+          <div key={lg.key} style={{ display: "flex", gap: 8, alignItems: "center", padding: "6px 0", borderTop: "1px solid var(--border)", flexWrap: "wrap" }}>
+            <strong style={{ fontSize: "0.78rem", flex: "1 1 160px", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {lg.displayName || lg.key}
+              {!lg.idpEnabled && (
+                <span className="muted" style={{ fontSize: "0.62rem", marginLeft: 6 }}>(no IDP)</span>
+              )}
+            </strong>
+            <select
+              className="select"
+              value={apply === null ? "" : (apply ? "on" : "off")}
+              onChange={(e) => {
+                const v = e.target.value;
+                setOverride(lg.key, "applyScoringFit", v === "" ? null : (v === "on"));
+              }}
+              style={{ fontSize: "0.72rem" }}
+            >
+              <option value="">Inherit</option>
+              <option value="on">On</option>
+              <option value="off">Off</option>
+            </select>
+            <select
+              className="select"
+              value={weight === null ? "" : String(Math.round(weight * 100))}
+              onChange={(e) => {
+                const v = e.target.value;
+                setOverride(lg.key, "scoringFitWeight", v === "" ? null : (Number(v) / 100));
+              }}
+              style={{ fontSize: "0.72rem" }}
+            >
+              <option value="">Inherit</option>
+              <option value="0">0%</option>
+              <option value="15">15%</option>
+              <option value="30">30%</option>
+              <option value="50">50%</option>
+              <option value="100">100%</option>
+            </select>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -27,9 +27,13 @@ export default function TradesPage() {
   const alpha = settings.alpha || TRADE_ALPHA;
   const windowDays = settings.tradeHistoryWindowDays || 365;
 
+  // Pass ``settings`` so historical trade values can be re-evaluated
+  // under the active Apply Scoring Fit weight when the user has the
+  // toggle on.  IDP rows shift by ``delta × weight``; offense + picks
+  // pass through unchanged.  Re-renders instantly on slider change.
   const analysis = useMemo(
-    () => analyzeSleeperTradeHistory(rawData, rows, windowDays, alpha),
-    [rawData, rows, windowDays, alpha],
+    () => analyzeSleeperTradeHistory(rawData, rows, windowDays, alpha, settings),
+    [rawData, rows, windowDays, alpha, settings],
   );
 
   const teams = useMemo(() => {

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -388,6 +388,9 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
                 {" · "}
                 {row.idpScoringFitTier ? row.idpScoringFitTier.replace(/_/g, " ") : ""}
                 {row.idpScoringFitGamesUsed ? ` · ${row.idpScoringFitGamesUsed} games` : ""}
+                {typeof row.idpSnapShare === "number" && Number.isFinite(row.idpSnapShare)
+                  ? ` · ${Math.round(row.idpSnapShare * 100)}% snaps`
+                  : ""}
               </div>
             </div>
           )}

--- a/frontend/components/ScoringFitOnboarding.jsx
+++ b/frontend/components/ScoringFitOnboarding.jsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * One-time onboarding banner for the IDP scoring-fit lens.
+ *
+ * Shows the FIRST time a user lands on `/rankings` after the lens
+ * has data available for their league.  Three short panels with
+ * "Next" / "Got it" buttons that explain what the lens is, how
+ * to toggle it, and what the cyan numbers mean.  After dismissal
+ * the localStorage flag prevents re-display.
+ *
+ * Designed to be unobtrusive — bottom-right card, dismissable,
+ * keyboard-accessible.  Doesn't block the rankings UI.
+ */
+
+const _STORAGE_KEY = "scoring_fit_onboarding_dismissed_v1";
+
+const _STEPS = [
+  {
+    title: "What's Scoring Fit?",
+    body: (
+      <>
+        Your league&apos;s stacked scoring rules pay differently than
+        the consensus market: a sack here is worth ~11 pts when sack +
+        sack yards + QB hit + TFL all stack, vs ~4 pts elsewhere.
+        Scoring Fit shows where this divergence creates buy-low and
+        sell-high opportunities.
+      </>
+    ),
+  },
+  {
+    title: "How to use it",
+    body: (
+      <>
+        Click <strong>&ldquo;Apply Scoring Fit&rdquo;</strong> in the
+        lens row above to re-rank IDPs by your league&apos;s rules.
+        Tune the strength on{" "}
+        <a href="/settings" style={{ color: "var(--cyan)" }}>/settings</a>{" "}
+        — start at 30%, dial up if you trust the lens.
+      </>
+    ),
+  },
+  {
+    title: "Reading the numbers",
+    body: (
+      <>
+        Cyan <strong>+1234</strong> next to a player means your
+        league&apos;s scoring values them ~1,234 points HIGHER than the
+        consensus does. Click any IDP for the &ldquo;What&apos;s
+        driving the scoring fit&rdquo; breakdown showing exactly
+        which stats earn them their delta.
+      </>
+    ),
+  },
+];
+
+export default function ScoringFitOnboarding({ enabled = false }) {
+  const [step, setStep] = useState(0);
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const flag = window.localStorage.getItem(_STORAGE_KEY);
+      if (!flag) setDismissed(false);
+    } catch {
+      // localStorage disabled — default to NOT showing rather than
+      // re-showing on every page load (worse UX).
+    }
+  }, []);
+
+  function dismiss() {
+    setDismissed(true);
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(_STORAGE_KEY, "1");
+      }
+    } catch {
+      // best-effort
+    }
+  }
+
+  if (dismissed || !enabled) return null;
+
+  const current = _STEPS[step];
+  const isLast = step >= _STEPS.length - 1;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Scoring Fit introduction"
+      style={{
+        position: "fixed",
+        bottom: 16,
+        right: 16,
+        maxWidth: 360,
+        zIndex: 1200,
+        background: "rgba(20, 25, 36, 0.97)",
+        border: "1px solid var(--cyan, #22d3ee)",
+        borderRadius: 8,
+        padding: "14px 16px",
+        boxShadow: "0 6px 24px rgba(0, 0, 0, 0.4)",
+        fontSize: "0.78rem",
+        lineHeight: 1.5,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+        <strong style={{ color: "var(--cyan)", fontSize: "0.84rem" }}>
+          {current.title}
+        </strong>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss"
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "var(--muted)",
+            fontSize: "1.1rem",
+            cursor: "pointer",
+            lineHeight: 1,
+            padding: 0,
+            marginLeft: 8,
+          }}
+        >
+          ×
+        </button>
+      </div>
+      <div style={{ marginBottom: 12 }}>
+        {current.body}
+      </div>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "space-between" }}>
+        <span className="muted" style={{ fontSize: "0.66rem" }}>
+          {step + 1} / {_STEPS.length}
+        </span>
+        <div style={{ display: "flex", gap: 6 }}>
+          {step > 0 && (
+            <button
+              type="button"
+              onClick={() => setStep((s) => s - 1)}
+              className="button"
+              style={{ fontSize: "0.7rem", padding: "3px 10px" }}
+            >
+              Back
+            </button>
+          )}
+          {isLast ? (
+            <button
+              type="button"
+              onClick={dismiss}
+              className="button button-primary"
+              style={{ fontSize: "0.7rem", padding: "3px 10px" }}
+            >
+              Got it
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setStep((s) => s + 1)}
+              className="button button-primary"
+              style={{ fontSize: "0.7rem", padding: "3px 10px" }}
+            >
+              Next
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/terminal/ScoringFitMoversPanel.jsx
+++ b/frontend/components/terminal/ScoringFitMoversPanel.jsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useApp } from "@/components/AppShell";
+import { useSettings } from "@/components/useSettings";
+import Panel from "./Panel";
+
+/**
+ * Scoring-fit movers — players whose ``idpScoringFitDelta`` jumped
+ * (or cratered) most since the most recent captured snapshot.
+ *
+ * Distinct from ``MoversPanel`` which tracks rank changes from the
+ * scrape pipeline; this one tracks lens-output changes.  When the
+ * lens delta jumps +2400 since last snapshot, that's a "the league's
+ * scoring caught something the consensus market hasn't priced in"
+ * moment — different signal class than rank movement.
+ *
+ * Auto-hides when:
+ *   - Apply Scoring Fit toggle is OFF (keep the lens off the
+ *     ``/league`` hub for users who haven't opted in).
+ *   - No baseline snapshot exists yet (fresh deploy, before the
+ *     daily capture cron has run).
+ *
+ * Data source: ``GET /api/scoring-fit/movers``.
+ */
+
+function MoverRow({ entry, onClick }) {
+  const change = Number(entry.change) || 0;
+  const sign = change > 0 ? "+" : "";
+  const color = change > 0 ? "var(--green, #4ade80)" : "var(--red, #f87171)";
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => { if (e.key === "Enter") onClick?.(); }}
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        gap: 8,
+        padding: "4px 6px",
+        borderRadius: 4,
+        cursor: "pointer",
+      }}
+      title={`${entry.name} · prior delta ${entry.prior_delta} → current ${entry.current_delta}`}
+    >
+      <div style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <span style={{ fontWeight: 600, fontSize: "0.78rem" }}>{entry.name}</span>
+        <span className="muted" style={{ fontSize: "0.66rem", marginLeft: 6 }}>{entry.position}</span>
+      </div>
+      <div style={{
+        fontFamily: "var(--mono, monospace)",
+        fontSize: "0.74rem",
+        color,
+        fontWeight: 600,
+      }}>
+        {sign}{Math.round(change).toLocaleString()}
+      </div>
+    </div>
+  );
+}
+
+export default function ScoringFitMoversPanel() {
+  const { openPlayerPopup } = useApp();
+  const { settings } = useSettings();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/scoring-fit/movers", { cache: "no-store" });
+        if (res.ok && !cancelled) setData(await res.json());
+      } catch {
+        // Silently swallow — empty state below renders correctly.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    run();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Hide when the user hasn't opted into the lens — keeps the
+  // /league hub clean for non-IDP-focused users.
+  if (!settings?.applyScoringFit) return null;
+
+  const risers = data?.risers || [];
+  const fallers = data?.fallers || [];
+  const hasBaseline = !!data?.has_baseline;
+  const hasContent = hasBaseline && (risers.length || fallers.length);
+
+  return (
+    <Panel
+      title="Scoring-fit movers"
+      subtitle={
+        hasBaseline && data?.baseline_date
+          ? `Lens delta change vs ${data.baseline_date} snapshot`
+          : "Awaiting baseline snapshot"
+      }
+    >
+      {loading && (
+        <div className="muted" style={{ fontSize: "0.72rem", padding: 8 }}>
+          Loading…
+        </div>
+      )}
+      {!loading && !hasBaseline && (
+        <div className="muted" style={{ fontSize: "0.72rem", padding: 8 }}>
+          The first snapshot is captured by the daily refresh.  Once a
+          baseline exists this panel will surface IDPs whose lens delta
+          moved most since.
+        </div>
+      )}
+      {!loading && hasContent && (
+        <div className="row" style={{ gap: 12, alignItems: "stretch" }}>
+          <div style={{ flex: "1 1 220px" }}>
+            <div style={{ fontSize: "0.62rem", color: "var(--green)", fontWeight: 700, textTransform: "uppercase", marginBottom: 4 }}>
+              Risers — lens caught something
+            </div>
+            {risers.length === 0 ? (
+              <div className="muted" style={{ fontSize: "0.7rem", padding: "6px 0" }}>
+                No qualifying risers.
+              </div>
+            ) : (
+              risers.map((r) => (
+                <MoverRow
+                  key={`r-${r.name}`}
+                  entry={r}
+                  onClick={() => openPlayerPopup?.({ name: r.name })}
+                />
+              ))
+            )}
+          </div>
+          <div style={{ flex: "1 1 220px" }}>
+            <div style={{ fontSize: "0.62rem", color: "var(--red)", fontWeight: 700, textTransform: "uppercase", marginBottom: 4 }}>
+              Fallers — lens cooled on them
+            </div>
+            {fallers.length === 0 ? (
+              <div className="muted" style={{ fontSize: "0.7rem", padding: "6px 0" }}>
+                No qualifying fallers.
+              </div>
+            ) : (
+              fallers.map((f) => (
+                <MoverRow
+                  key={`f-${f.name}`}
+                  entry={f}
+                  onClick={() => openPlayerPopup?.({ name: f.name })}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/frontend/components/terminal/ScoringFitRosterSummary.jsx
+++ b/frontend/components/terminal/ScoringFitRosterSummary.jsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTeam } from "@/components/useTeam";
+import { useDynastyData } from "@/components/useDynastyData";
+import { useTerminal } from "@/components/useTerminal";
+import { useSettings } from "@/components/useSettings";
+import Panel from "./Panel";
+
+/**
+ * Per-roster scoring-fit summary.
+ *
+ * Shows the user where THEIR roster sits on the lens vs the league
+ * average:
+ *   - How many fit-positive IDPs they own vs the league average
+ *   - Net fit-delta across their roster
+ *   - Top 3 fit-positive players they own (good keep candidates)
+ *   - Top 3 fit-negative players they own (sell-high candidates)
+ *
+ * Auto-hides when:
+ *   - The Apply Scoring Fit toggle is off (lens isn't part of the
+ *     user's mental model right now)
+ *   - The user has no team selected
+ *
+ * Computed entirely client-side from data already on each row —
+ * no backend call needed.
+ */
+
+const _DELTA_THRESHOLD = 1500;
+
+export default function ScoringFitRosterSummary() {
+  const { settings } = useSettings();
+  const { selectedTeam } = useTeam();
+  const { rows } = useDynastyData();
+
+  const summary = useMemo(() => {
+    if (!Array.isArray(rows) || !selectedTeam?.players?.length) return null;
+    const owned = new Set(
+      (selectedTeam.players || []).map((n) => String(n).trim().toLowerCase())
+    );
+    let leagueIdpTotal = 0;
+    let leaguePositiveCount = 0;
+    let myIdps = [];
+    for (const r of rows) {
+      if (r.assetClass !== "idp") continue;
+      const delta = Number(r.idpScoringFitDelta);
+      if (!Number.isFinite(delta)) continue;
+      const conf = r.idpScoringFitConfidence;
+      if (conf !== "high" && conf !== "medium") continue;
+      leagueIdpTotal += 1;
+      if (delta >= _DELTA_THRESHOLD) leaguePositiveCount += 1;
+      if (owned.has(String(r.name || "").trim().toLowerCase())) {
+        myIdps.push({
+          name: r.name,
+          pos: r.pos,
+          delta,
+          tier: r.idpScoringFitTier,
+        });
+      }
+    }
+    if (!myIdps.length) return null;
+
+    const myPositive = myIdps.filter((p) => p.delta >= _DELTA_THRESHOLD);
+    const myNegative = myIdps.filter((p) => p.delta <= -_DELTA_THRESHOLD);
+    const myNetDelta = myIdps.reduce((s, p) => s + p.delta, 0);
+
+    // League-wide rough average: total fit-positives / number of teams.
+    // Used as a comparator so the user can answer "am I ahead or
+    // behind on the lens within my league?".
+    const leagueAvgPositive = leagueIdpTotal > 0
+      ? Math.round(leaguePositiveCount / 12)  // typical 12-team league
+      : 0;
+
+    return {
+      total: myIdps.length,
+      myPositive,
+      myNegative,
+      myNetDelta,
+      leagueAvgPositive,
+    };
+  }, [rows, selectedTeam?.players]);
+
+  if (!settings?.applyScoringFit || !summary) return null;
+
+  const netSign = summary.myNetDelta > 0 ? "+" : "";
+  const netColor = summary.myNetDelta > 0
+    ? "var(--green, #4ade80)"
+    : summary.myNetDelta < 0 ? "var(--red, #f87171)" : "var(--muted)";
+
+  return (
+    <Panel
+      title="Your roster — scoring fit"
+      subtitle="How your IDPs grade under YOUR league's stacked scoring"
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 12, marginBottom: 10 }}>
+        <div>
+          <div className="muted" style={{ fontSize: "0.66rem" }}>Fit-positive owned</div>
+          <div style={{ fontFamily: "var(--mono, monospace)", fontSize: "1.0rem", fontWeight: 600 }}>
+            {summary.myPositive.length}
+            <span className="muted" style={{ fontSize: "0.66rem", marginLeft: 6 }}>
+              (league avg {summary.leagueAvgPositive})
+            </span>
+          </div>
+        </div>
+        <div>
+          <div className="muted" style={{ fontSize: "0.66rem" }}>Fit-negative owned</div>
+          <div style={{ fontFamily: "var(--mono, monospace)", fontSize: "1.0rem", fontWeight: 600, color: summary.myNegative.length > 0 ? "var(--red)" : "inherit" }}>
+            {summary.myNegative.length}
+          </div>
+        </div>
+        <div>
+          <div className="muted" style={{ fontSize: "0.66rem" }}>Net fit-delta</div>
+          <div style={{ fontFamily: "var(--mono, monospace)", fontSize: "1.0rem", fontWeight: 600, color: netColor }}>
+            {netSign}{Math.round(summary.myNetDelta).toLocaleString()}
+          </div>
+        </div>
+        <div>
+          <div className="muted" style={{ fontSize: "0.66rem" }}>IDPs scored</div>
+          <div style={{ fontFamily: "var(--mono, monospace)", fontSize: "1.0rem", fontWeight: 600 }}>
+            {summary.total}
+          </div>
+        </div>
+      </div>
+      {summary.myPositive.length > 0 && (
+        <div style={{ marginTop: 8, fontSize: "0.72rem" }}>
+          <div className="muted" style={{ fontSize: "0.66rem", marginBottom: 4 }}>
+            Top fit-positive on your roster (consider keeping)
+          </div>
+          {summary.myPositive
+            .sort((a, b) => b.delta - a.delta)
+            .slice(0, 3)
+            .map((p) => (
+              <div key={p.name} style={{ display: "flex", justifyContent: "space-between", padding: "2px 0" }}>
+                <span>{p.name} <span className="muted" style={{ fontSize: "0.62rem" }}>{p.pos}</span></span>
+                <span style={{ fontFamily: "var(--mono, monospace)", color: "var(--green, #4ade80)", fontWeight: 600 }}>
+                  +{Math.round(p.delta).toLocaleString()}
+                </span>
+              </div>
+            ))}
+        </div>
+      )}
+      {summary.myNegative.length > 0 && (
+        <div style={{ marginTop: 8, fontSize: "0.72rem" }}>
+          <div className="muted" style={{ fontSize: "0.66rem", marginBottom: 4 }}>
+            Top fit-negative on your roster (consider trading)
+          </div>
+          {summary.myNegative
+            .sort((a, b) => a.delta - b.delta)
+            .slice(0, 3)
+            .map((p) => (
+              <div key={p.name} style={{ display: "flex", justifyContent: "space-between", padding: "2px 0" }}>
+                <span>{p.name} <span className="muted" style={{ fontSize: "0.62rem" }}>{p.pos}</span></span>
+                <span style={{ fontFamily: "var(--mono, monospace)", color: "var(--red, #f87171)", fontWeight: 600 }}>
+                  {Math.round(p.delta).toLocaleString()}
+                </span>
+              </div>
+            ))}
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/frontend/components/terminal/ScoringFitTargetsPanel.jsx
+++ b/frontend/components/terminal/ScoringFitTargetsPanel.jsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useMemo } from "react";
+import { useApp } from "@/components/AppShell";
+import { useTeam } from "@/components/useTeam";
+import { useDynastyData } from "@/components/useDynastyData";
+import { useSettings } from "@/components/useSettings";
+import Panel from "./Panel";
+
+/**
+ * Scoring-fit targets — fit-positive IDPs the user doesn't own.
+ *
+ * Direct trade-target generator: filters the live IDP universe to
+ * players where ``idpScoringFitDelta >= 1500`` AND
+ * ``confidence in {high, medium}`` AND the player is NOT on the
+ * user's roster.  These are the most actionable buy-low candidates
+ * — the lens says "buy" AND they're still acquirable.
+ *
+ * Auto-hides when the global Apply Scoring Fit toggle is off.
+ *
+ * Read-only — clicking a row opens the player popup so the user
+ * can drill into the breakdown then jump to /trade or /angle.
+ */
+
+const _MIN_DELTA = 1500;
+const _MAX_DISPLAY = 12;
+
+export default function ScoringFitTargetsPanel() {
+  const { openPlayerPopup } = useApp();
+  const { selectedTeam } = useTeam();
+  const { rows } = useDynastyData();
+  const { settings } = useSettings();
+
+  const targets = useMemo(() => {
+    if (!Array.isArray(rows)) return [];
+    const ownedSet = new Set(
+      (selectedTeam?.players || []).map((n) => String(n).trim().toLowerCase())
+    );
+    const out = [];
+    for (const r of rows) {
+      if (r.assetClass !== "idp") continue;
+      const delta = Number(r.idpScoringFitDelta);
+      if (!Number.isFinite(delta) || delta < _MIN_DELTA) continue;
+      const conf = r.idpScoringFitConfidence;
+      if (conf !== "high" && conf !== "medium") continue;
+      const nameKey = String(r.name || "").trim().toLowerCase();
+      if (ownedSet.has(nameKey)) continue;
+      out.push(r);
+    }
+    out.sort((a, b) =>
+      (Number(b.idpScoringFitDelta) || 0) - (Number(a.idpScoringFitDelta) || 0)
+    );
+    return out.slice(0, _MAX_DISPLAY);
+  }, [rows, selectedTeam?.players]);
+
+  if (!settings?.applyScoringFit) return null;
+
+  return (
+    <Panel
+      title="Scoring-fit targets"
+      subtitle="Fit-positive IDPs not on your roster · acquirable buy-lows"
+      actions={
+        targets.length > 0 ? (
+          <span className="muted" style={{ fontSize: "0.68rem" }}>
+            {targets.length} target{targets.length === 1 ? "" : "s"}
+          </span>
+        ) : null
+      }
+    >
+      {targets.length === 0 ? (
+        <div className="muted" style={{ fontSize: "0.72rem", padding: 8 }}>
+          No fit-positive IDPs available — either you already own them
+          or the lens hasn&apos;t found any (delta ≥ 1,500 with high/medium
+          confidence).
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {targets.map((r) => {
+            const delta = Math.round(Number(r.idpScoringFitDelta) || 0);
+            return (
+              <div
+                key={r.name}
+                role="button"
+                tabIndex={0}
+                onClick={() => openPlayerPopup?.(r)}
+                onKeyDown={(e) => { if (e.key === "Enter") openPlayerPopup?.(r); }}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr auto auto",
+                  gap: 8,
+                  alignItems: "center",
+                  padding: "4px 6px",
+                  borderRadius: 4,
+                  cursor: "pointer",
+                  fontSize: "0.78rem",
+                }}
+                title={`${r.name} · ${r.pos} · league overvalues consensus by +${delta.toLocaleString()}`}
+              >
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  <strong>{r.name}</strong>
+                  <span className="muted" style={{ fontSize: "0.66rem", marginLeft: 6 }}>
+                    {r.pos}
+                  </span>
+                </span>
+                <span className="muted" style={{ fontSize: "0.68rem", fontFamily: "var(--mono, monospace)" }}>
+                  {r.idpScoringFitTier ? r.idpScoringFitTier.replace(/_/g, " ") : ""}
+                </span>
+                <span style={{
+                  fontFamily: "var(--mono, monospace)",
+                  color: "var(--green, #4ade80)",
+                  fontWeight: 600,
+                }}>
+                  +{delta.toLocaleString()}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/frontend/components/terminal/TerminalLayout.jsx
+++ b/frontend/components/terminal/TerminalLayout.jsx
@@ -7,6 +7,9 @@ import MarketTicker from "./MarketTicker";
 import PlayerMarketMovement from "./PlayerMarketMovement";
 import BuySellHold from "./BuySellHold";
 import MoversPanel from "./MoversPanel";
+import ScoringFitMoversPanel from "./ScoringFitMoversPanel";
+import ScoringFitTargetsPanel from "./ScoringFitTargetsPanel";
+import ScoringFitRosterSummary from "./ScoringFitRosterSummary";
 import PortfolioSummary from "./PortfolioSummary";
 import ScoutingIntel from "./ScoutingIntel";
 import TeamNewsFeed from "./TeamNewsFeed";
@@ -60,12 +63,15 @@ export default function TerminalLayout() {
       <div className="terminal-grid">
         <div className="terminal-col terminal-col--left">
           <PortfolioSummary />
+          <ScoringFitRosterSummary />
           <ScoutingIntel />
         </div>
         <div className="terminal-col terminal-col--center">
           <MoversPanel />
+          <ScoringFitMoversPanel />
           <PlayerMarketMovement />
           <BuySellHold />
+          <ScoringFitTargetsPanel />
           <WatchlistPanel />
         </div>
         <div className="terminal-col terminal-col--right">

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -66,6 +66,16 @@ export const SETTINGS_DEFAULTS = {
   // instantly without a backend round-trip.
   scoringFitWeight: 0.30,
 
+  // Per-league overrides for ``applyScoringFit`` + ``scoringFitWeight``.
+  // Shape: ``{ [leagueKey]: { applyScoringFit?: boolean, scoringFitWeight?: number } }``.
+  // When the active league has an entry with the field set, that
+  // wins over the global default above.  Lets a user with two
+  // leagues run the lens at 50% in their stacked-scoring league and
+  // OFF in their non-IDP league without flipping the toggle every
+  // time they switch.  Read via ``resolveScoringFitForLeague`` —
+  // never read this map directly.
+  scoringFitByLeague: {},
+
   // Per-source column visibility map ({ [sourceKey]: false } to
   // hide a specific source column on the rankings table).  Any key
   // missing from the map defaults to visible — so an empty map
@@ -220,4 +230,63 @@ export function useSettings() {
   }, []);
 
   return { settings, update, updateSiteWeight, resetSiteWeights, reset };
+}
+
+/**
+ * Resolve the effective ``applyScoringFit`` + ``scoringFitWeight``
+ * for a specific league.  Per-league overrides win over the global
+ * defaults; missing fields fall through to the global value.
+ *
+ * @param {object} settings — full settings dict from ``useSettings``
+ * @param {string|null} leagueKey — active league's stable key, or null
+ * @returns {{applyScoringFit: boolean, scoringFitWeight: number}}
+ */
+export function resolveScoringFitForLeague(settings, leagueKey) {
+  const globalApply = !!settings?.applyScoringFit;
+  const globalWeight = typeof settings?.scoringFitWeight === "number"
+    ? settings.scoringFitWeight : 0.30;
+  if (!leagueKey || !settings?.scoringFitByLeague || typeof settings.scoringFitByLeague !== "object") {
+    return { applyScoringFit: globalApply, scoringFitWeight: globalWeight };
+  }
+  const override = settings.scoringFitByLeague[leagueKey];
+  if (!override || typeof override !== "object") {
+    return { applyScoringFit: globalApply, scoringFitWeight: globalWeight };
+  }
+  return {
+    applyScoringFit: typeof override.applyScoringFit === "boolean"
+      ? override.applyScoringFit : globalApply,
+    scoringFitWeight: typeof override.scoringFitWeight === "number"
+      ? Math.max(0, Math.min(1, override.scoringFitWeight))
+      : globalWeight,
+  };
+}
+
+/**
+ * Update a single per-league override.  ``field`` is
+ * ``"applyScoringFit"`` or ``"scoringFitWeight"``.  Setting to
+ * ``null`` clears the override (resolves back to the global
+ * default).  Persists to localStorage and notifies subscribers.
+ *
+ * Designed to be called from a small inline UI on /rankings or
+ * /settings without changing the global toggle state.
+ */
+export function updateLeagueScoringFit(settings, leagueKey, field, value) {
+  if (!leagueKey) return settings;
+  const next = { ...settings };
+  const map = { ...(next.scoringFitByLeague || {}) };
+  const cur = { ...(map[leagueKey] || {}) };
+  if (value === null || value === undefined) {
+    delete cur[field];
+  } else {
+    cur[field] = value;
+  }
+  if (Object.keys(cur).length === 0) {
+    delete map[leagueKey];
+  } else {
+    map[leagueKey] = cur;
+  }
+  next.scoringFitByLeague = map;
+  writeSettings(next);
+  notify(next);
+  return next;
 }

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1018,6 +1018,7 @@ function _materializePlayerArrayRow(player) {
     idpScoringFitGamesUsed: player.idpScoringFitGamesUsed ?? null,
     idpScoringFitTopStats: Array.isArray(player.idpScoringFitTopStats)
       ? player.idpScoringFitTopStats : null,
+    idpSnapShare: typeof player.idpSnapShare === "number" ? player.idpSnapShare : null,
     raw: player,
   };
 }

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -104,7 +104,24 @@ export function buildRowLookup(rows) {
  * `resolvePickRow` helper walks parsed candidates + backend alias map
  * so pick values surface correctly in trade history.
  */
-export function resolveTradeItemValue(itemName, rowLookup, posMap, pickAliases) {
+// Internal — apply the scoring-fit weight to a row's display value
+// when the global setting is on.  Centralised so the trade-history
+// resolver matches the rest of the app's display logic.  Returns
+// the input value unchanged when settings is null / toggle is off
+// / row has no delta.
+function _applyScoringFitToRow(row, baseValue, settings) {
+  if (!row || !settings?.applyScoringFit) return baseValue;
+  const delta = Number(row.idpScoringFitDelta);
+  if (!Number.isFinite(delta) || delta === 0) return baseValue;
+  const w = typeof settings.scoringFitWeight === "number"
+    ? Math.max(0, Math.min(1, settings.scoringFitWeight))
+    : 0.30;
+  if (w <= 0) return baseValue;
+  const adjusted = (Number(baseValue) || 0) + delta * w;
+  return Math.max(0, Math.min(9999, adjusted));
+}
+
+export function resolveTradeItemValue(itemName, rowLookup, posMap, pickAliases, settings = null) {
   if (!itemName) {
     return { name: itemName, value: 0, pos: "", isPick: false, playerId: "", team: "" };
   }
@@ -130,9 +147,14 @@ export function resolveTradeItemValue(itemName, rowLookup, posMap, pickAliases) 
   const key = name.toLowerCase();
   const row = rowLookup.get(key);
   if (row) {
+    const baseVal = row.values?.full || 0;
     return {
       name,
-      value: row.values?.full || 0,
+      // When the user has Apply Scoring Fit on, IDP values shift by
+      // ``delta × weight`` so historical trade grades reflect what
+      // the deal looks like UNDER YOUR LEAGUE'S RULES, not just the
+      // generic consensus.  Offense + picks pass through unchanged.
+      value: _applyScoringFitToRow(row, baseVal, settings),
       pos: row.pos || "",
       isPick: false,
       // Carry the Sleeper player id + NFL team forward so the trade
@@ -152,7 +174,7 @@ export function resolveTradeItemValue(itemName, rowLookup, posMap, pickAliases) 
     if (strippedRow) {
       return {
         name,
-        value: strippedRow.values?.full || 0,
+        value: _applyScoringFitToRow(strippedRow, strippedRow.values?.full || 0, settings),
         pos: strippedRow.pos || "",
         isPick: false,
         playerId: String(strippedRow.raw?.playerId || "") || "",
@@ -286,7 +308,7 @@ function sideDisplayName(side, identityMaps) {
  * split across the two owners.  Falls back to rosterId and then team
  * name for older scraper output that did not emit ownerId.
  */
-export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alpha = TRADE_ALPHA) {
+export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alpha = TRADE_ALPHA, settings = null) {
   const trades = rawData?.sleeper?.trades;
   if (!Array.isArray(trades) || !trades.length) {
     return { windowDays, analyzed: [], teamScores: {} };
@@ -313,7 +335,7 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
     let linear = 0;
     let weighted = 0;
     for (const rawItem of getTradeSideItemLabels(rawList)) {
-      const resolved = resolveTradeItemValue(rawItem, rowLookup, posMap, pickAliases);
+      const resolved = resolveTradeItemValue(rawItem, rowLookup, posMap, pickAliases, settings);
       const safeVal = Number.isFinite(resolved.value) ? Math.max(0, resolved.value) : 0;
       linear += safeVal;
       weighted += Math.pow(Math.max(safeVal, 1), alpha);

--- a/server.py
+++ b/server.py
@@ -6739,6 +6739,137 @@ async def post_trade_simulate_mc(request: Request):
     return JSONResponse(content=enriched)
 
 
+@app.get("/api/scoring-fit/movers")
+async def get_scoring_fit_movers():
+    """Return players whose ``idpScoringFitDelta`` moved most since the
+    most recent captured snapshot in ``data/idp_fit_snapshots/``.
+
+    Public read-only — same auth posture as ``/api/idp-fit-health``.
+    Empty risers/fallers when no snapshot has been captured yet
+    (fresh-deploy case).  Frontend movers widget consumes this.
+    """
+    if not latest_contract_data:
+        return JSONResponse(content={
+            "has_baseline": False,
+            "baseline_date": None,
+            "risers": [],
+            "fallers": [],
+        })
+    from src.scoring import scoring_fit_movers as _sfm  # noqa: PLC0415
+    out = _sfm.compute_movers(latest_contract_data)
+    return JSONResponse(content=out)
+
+
+@app.post("/api/scoring-fit-digest/run")
+async def run_scoring_fit_digest(request: Request):
+    """Build + send the weekly IDP scoring-fit digest email.
+
+    Auth: same dual-path as /api/signal-alerts/run — admin password
+    session OR ``SIGNAL_ALERT_CRON_TOKEN`` bearer for cron / systemd.
+
+    Body (JSON, optional):
+      ``email``          recipient address (defaults to ALERT_TO env)
+      ``leagueKey``      pin to a specific league for the roster section
+      ``ownerId``        Sleeper owner id for the roster section
+      ``dry_run``        when True, build the digest but don't send
+
+    Returns the digest summary + delivery status.
+    """
+    # Same auth pattern as the signal-alerts endpoint.
+    cron_auth_ok = False
+    if SIGNAL_ALERT_CRON_TOKEN:
+        header = (request.headers.get("authorization") or "").strip()
+        if header.lower().startswith("bearer "):
+            presented = header.split(None, 1)[1].strip()
+            if hmac.compare_digest(presented, SIGNAL_ALERT_CRON_TOKEN):
+                cron_auth_ok = True
+    if not cron_auth_ok:
+        session = _get_auth_session(request)
+        if not session or session.get("auth_method") != "password":
+            return JSONResponse(
+                status_code=401,
+                content={"error": "admin_auth_required"},
+            )
+    if not latest_contract_data:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "no_live_contract"},
+        )
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    to_email = str(body.get("email") or ALERT_TO or "").strip()
+    if not to_email:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "no_recipient",
+                     "message": "Pass ``email`` in body or set ALERT_TO env var."},
+        )
+
+    dry_run = bool(body.get("dry_run"))
+
+    # Roster context (optional).  When present, the digest gets a
+    # roster-specific section.  When absent, it's just the league-wide
+    # buy/sell lists.
+    user_team_players: list[str] | None = None
+    league_name: str | None = None
+    league_key = body.get("leagueKey")
+    owner_id = str(body.get("ownerId") or "").strip()
+    if owner_id:
+        sleeper = (latest_contract_data or {}).get("sleeper") or {}
+        teams = sleeper.get("teams") or []
+        for t in teams:
+            if str(t.get("ownerId") or "") == owner_id:
+                user_team_players = list(t.get("players") or [])
+                break
+    if league_key:
+        try:
+            from src.api import league_registry as _lr  # noqa: PLC0415
+            cfg = _lr.get_league_by_key(league_key)
+            if cfg:
+                league_name = cfg.display_name
+        except Exception:  # noqa: BLE001
+            pass
+
+    from src.news import scoring_fit_digest as _sfd  # noqa: PLC0415
+    digest = _sfd.build_digest(
+        latest_contract_data,
+        user_team_players=user_team_players,
+        league_name=league_name,
+    )
+    if digest is None:
+        return JSONResponse(content={
+            "delivered": False,
+            "reason": "no_content",
+            "to": to_email,
+        })
+
+    if dry_run:
+        return JSONResponse(content={
+            "delivered": False,
+            "reason": "dry_run",
+            "to": to_email,
+            "subject": digest["subject"],
+            "summary": digest["summary"],
+            "preview": digest["body"][:1200],
+        })
+
+    # Deliver.  ``_deliver_email_smtp`` returns True on success.
+    ok = _deliver_email_smtp(to_email, digest["subject"], digest["body"])
+    return JSONResponse(content={
+        "delivered": bool(ok),
+        "reason": "ok" if ok else "delivery_error",
+        "to": to_email,
+        "subject": digest["subject"],
+        "summary": digest["summary"],
+    })
+
+
 @app.post("/api/signal-alerts/run")
 async def run_signal_alerts(request: Request):
     """Trigger a signal-alert sweep for every user with email

--- a/src/adapters/espn_projections.py
+++ b/src/adapters/espn_projections.py
@@ -1,0 +1,111 @@
+"""ESPN season-projection adapter (Phase 2 scaffold).
+
+The IDP scoring-fit pipeline currently uses trailing-3-yr realized
+PPG as its production-quality estimate.  Phase 2 of the original
+integration plan replaces that with forward-looking projections —
+moving the lens from "what they did" to "what they're projected
+to do under YOUR scoring."
+
+Two projection sources, per the plan:
+
+1. **ESPN league-aware projections** — at
+   ``https://fantasy.espn.com/football/players/projections?leagueId=N``.
+   League-scoring-aware fantasy points; rarely per-stat for IDPs.
+   Behind Disney auth; requires a Playwright browser session with
+   the user's ESPN cookies.
+
+2. **Clay 2026 cheatsheet PDF** — static URL, structured tables,
+   limited IDP coverage.  Static-PDF parser via ``pdfplumber``.
+
+Status
+------
+Adapter scaffold + contract.  Full implementation deferred:
+
+* ESPN: needs Disney-auth cookie capture + Playwright wiring
+  (largely a copy of the existing scraper pattern in
+  ``Dynasty Scraper.py``).
+* Clay: needs static PDF parser, monthly refresh in
+  ``scheduled-refresh.yml``.
+
+The scaffold here exists so Phase 2 can be picked up cleanly:
+data shape, adapter interface, and integration point are all
+pinned.
+
+Public contract
+---------------
+``fetch_espn_projections(season: int) -> list[ProjectedStatRow]``
+
+``ProjectedStatRow``: same shape as ``WeeklyStatRow`` so the
+existing ``compute_weekly_points`` pipeline can score it without
+changes.  ``week=0`` is the convention for "season aggregate."
+
+When activated, the scoring-fit orchestrator's
+``build_realized_3yr_ppg`` will be renamed to
+``build_dynasty_weighted_ppg`` and accept an optional
+``projections`` parameter that overrides Y1 (current season) when
+present.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProjectedStatRow:
+    """Mirrors ``WeeklyStatRow`` for the projection corpus.
+
+    ``week=0`` is the convention for "season aggregate" rather than
+    a specific week — the scoring path treats it the same since the
+    aggregator sums across weeks per player anyway.
+    """
+    player_id: str         # gsis_id
+    player_name: str
+    position: str
+    team: str
+    season: int
+    week: int = 0          # 0 = season aggregate
+    # Defensive projections — same column names as nflverse weekly
+    # defensive stats so ``compute_weekly_points`` works unchanged.
+    def_tackles_solo: float = 0.0
+    def_tackle_assists: float = 0.0
+    def_tackles: float = 0.0
+    def_tackles_for_loss: float = 0.0
+    def_sacks: float = 0.0
+    def_sack_yards: float = 0.0
+    def_qb_hits: float = 0.0
+    def_pass_defended: float = 0.0
+    def_interceptions: float = 0.0
+    def_interception_yards: float = 0.0
+    def_fumbles_forced: float = 0.0
+    def_fumble_recovery_own: float = 0.0
+    def_tds: float = 0.0
+
+
+def fetch_espn_projections(season: int) -> list[ProjectedStatRow]:
+    """Return season-projection rows from ESPN.
+
+    **Not yet implemented.**  When activated:
+
+    1. Launch Playwright with the operator's ESPN cookies (loaded
+       from a secret blob).
+    2. Navigate to fantasy.espn.com/football/players/projections,
+       set the league dropdown to the operator's leagueId.
+    3. Iterate every page of the projections table; parse the
+       per-position columns.
+    4. Cross-walk ESPN player ids → gsis via the existing id_map
+       (which has ``espn_id`` columns).
+    5. Emit ``ProjectedStatRow`` per player.
+
+    Returns ``[]`` until Phase 2 is wired.  The orchestrator falls
+    back to realized PPG when projections are empty, so this no-op
+    is safe.
+    """
+    _LOGGER.info(
+        "espn_projections=not_yet_implemented season=%d",
+        season,
+    )
+    return []

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -7322,6 +7322,11 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     # {label, stat_total, points_total, share} dicts.  Rendered in the
     # popup as the "why" breakdown for the lens verdict.
     "idpScoringFitTopStats",
+    # Defensive snap share (0.0-1.0) averaged across the most recent
+    # season.  Durability signal — a 100-tackle LB at 95% snaps is a
+    # bell-cow; the same line at 60% is rotational.  Stamped only on
+    # IDPs the cross-walk could find; absent otherwise.
+    "idpSnapShare",
 )
 
 

--- a/src/news/scoring_fit_digest.py
+++ b/src/news/scoring_fit_digest.py
@@ -1,0 +1,310 @@
+"""Weekly IDP scoring-fit digest email.
+
+Walks the live contract for IDP rows with ``idpScoringFitDelta`` set
+and produces a digest email of:
+
+* Top fit-positive players (league overvalues consensus → buy-low)
+* Top fit-negative players (league undervalues vs market → sell-high)
+* Roster-specific summary when a Sleeper team is provided
+
+The aim is to give the user a weekly "what does my league's scoring
+say about the market right now?" pulse without them having to open
+the app.  Distinct from the daily ``signal_alerts`` flow — that one
+fires on per-player signal transitions; this one is a recurring
+overview.
+
+Delivery contract matches ``signal_alerts``: a ``delivery(to,
+subject, body)`` callable so tests can stub it.  Default delivery
+is the existing ``_deliver_email_smtp`` from server.py.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+_LOGGER = logging.getLogger(__name__)
+
+# Threshold below which a delta is "noise" — players with smaller
+# deltas don't make the digest.  Matches the BUY/SELL signal-engine
+# threshold so the digest is consistent with the in-app chips.
+_DELTA_THRESHOLD = 1500.0
+
+# Limits — we cap each section so the email stays readable.
+_TOP_BUY_LIMIT = 6
+_TOP_SELL_LIMIT = 6
+
+
+def _format_delta(d: float) -> str:
+    """``+6,492`` / ``-1,234`` / ``0``."""
+    if d == 0:
+        return "0"
+    sign = "+" if d > 0 else ""
+    return f"{sign}{int(round(d)):,}"
+
+
+def _is_idp_row(row: dict[str, Any]) -> bool:
+    pos = str(row.get("position") or row.get("pos") or "").upper()
+    return pos in {
+        "DL", "DT", "DE", "EDGE", "NT",
+        "LB", "ILB", "OLB", "MLB",
+        "DB", "CB", "S", "FS", "SS",
+    }
+
+
+def build_digest(
+    contract: dict[str, Any],
+    *,
+    user_team_players: list[str] | None = None,
+    league_name: str | None = None,
+) -> dict[str, Any] | None:
+    """Build the digest payload from a canonical contract.
+
+    Returns ``None`` when there's nothing actionable to send (no IDP
+    rows have a delta, or all deltas are below the noise threshold).
+    Returns a dict with ``{subject, body, html, summary}`` otherwise.
+
+    ``user_team_players`` (optional) is the list of canonical player
+    names on the user's roster.  When provided, the digest also
+    surfaces a roster-specific summary: how many fit-positive players
+    they own, sample of biggest movers, etc.
+    """
+    arr = contract.get("playersArray") or []
+    if not isinstance(arr, list):
+        return None
+
+    # Build buy + sell candidate lists from the league universe.
+    buys: list[dict[str, Any]] = []
+    sells: list[dict[str, Any]] = []
+    roster_set = {str(n).strip() for n in (user_team_players or [])}
+    roster_summary: list[dict[str, Any]] = []
+
+    for row in arr:
+        if not isinstance(row, dict) or not _is_idp_row(row):
+            continue
+        delta = row.get("idpScoringFitDelta")
+        if not isinstance(delta, (int, float)):
+            continue
+        confidence = row.get("idpScoringFitConfidence")
+        # Filter out synthetic + low-confidence rows from buy/sell
+        # lists — those rows are noisy, the user doesn't want
+        # weekly spam about a rookie cohort estimate.
+        if confidence not in ("high", "medium"):
+            # Roster summary still includes the player even at low
+            # confidence so the user sees what they actually own.
+            if str(row.get("displayName") or "") in roster_set:
+                roster_summary.append({
+                    "name": row.get("displayName"),
+                    "position": row.get("position"),
+                    "delta": float(delta),
+                    "confidence": confidence,
+                    "synthetic": bool(row.get("idpScoringFitSynthetic")),
+                })
+            continue
+        entry = {
+            "name": row.get("displayName") or row.get("canonicalName") or "?",
+            "position": row.get("position") or "?",
+            "delta": float(delta),
+            "consensus": int(row.get("rankDerivedValue") or 0),
+            "tier": row.get("idpScoringFitTier") or "—",
+            "confidence": confidence,
+        }
+        if entry["name"] in roster_set:
+            roster_summary.append({**entry, "synthetic": False})
+        if delta >= _DELTA_THRESHOLD:
+            buys.append(entry)
+        elif delta <= -_DELTA_THRESHOLD:
+            sells.append(entry)
+
+    buys.sort(key=lambda e: -e["delta"])
+    sells.sort(key=lambda e: e["delta"])
+
+    if not buys and not sells and not roster_summary:
+        return None
+
+    # Compose the email.  Plain text + HTML for readable rendering
+    # in iCloud + Gmail; recipient address is the caller's choice.
+    league_label = f" ({league_name})" if league_name else ""
+    subject = (
+        f"[Brisket] Weekly Scoring Fit{league_label}: "
+        f"{len(buys)} buy{'' if len(buys) == 1 else 's'}, "
+        f"{len(sells)} sell{'' if len(sells) == 1 else 's'}"
+    )
+
+    text_lines: list[str] = []
+    text_lines.append(f"Risk It · Weekly Scoring Fit{league_label}")
+    text_lines.append("")
+    text_lines.append(
+        "Players whose value under YOUR league's stacked scoring rules "
+        "diverges most from the consensus market.  Positive delta = "
+        "your league pays more for them than market does (buy-low "
+        "candidates).  Negative = market overpays vs your league "
+        "(sell-high)."
+    )
+    text_lines.append("")
+
+    if buys:
+        text_lines.append(f"BUY-LOW · top {min(_TOP_BUY_LIMIT, len(buys))}")
+        text_lines.append("-" * 48)
+        for b in buys[:_TOP_BUY_LIMIT]:
+            text_lines.append(
+                f"  {b['name']:<28} {b['position']:<5}"
+                f"  {_format_delta(b['delta'])}"
+                f"  ({b['tier']}, {b['confidence']} confidence)"
+            )
+        text_lines.append("")
+
+    if sells:
+        text_lines.append(f"SELL-HIGH · top {min(_TOP_SELL_LIMIT, len(sells))}")
+        text_lines.append("-" * 48)
+        for s in sells[:_TOP_SELL_LIMIT]:
+            text_lines.append(
+                f"  {s['name']:<28} {s['position']:<5}"
+                f"  {_format_delta(s['delta'])}"
+                f"  ({s['tier']}, {s['confidence']} confidence)"
+            )
+        text_lines.append("")
+
+    if roster_summary:
+        owned_buys = [r for r in roster_summary if r.get("delta", 0) >= _DELTA_THRESHOLD]
+        owned_sells = [r for r in roster_summary if r.get("delta", 0) <= -_DELTA_THRESHOLD]
+        net_delta = sum(r.get("delta", 0) for r in roster_summary)
+        text_lines.append("YOUR ROSTER")
+        text_lines.append("-" * 48)
+        text_lines.append(
+            f"  IDPs on your roster with deltas: {len(roster_summary)}"
+        )
+        text_lines.append(
+            f"  Net fit-delta: {_format_delta(net_delta)} "
+            f"({len(owned_buys)} buy-side, {len(owned_sells)} sell-side)"
+        )
+        if owned_buys:
+            text_lines.append("")
+            text_lines.append("  You OWN these fit-positive players (consider keeping):")
+            for r in sorted(owned_buys, key=lambda x: -x["delta"])[:5]:
+                text_lines.append(
+                    f"    • {r['name']} ({r['position']}) {_format_delta(r['delta'])}"
+                )
+        if owned_sells:
+            text_lines.append("")
+            text_lines.append("  You OWN these fit-negative players (consider trading):")
+            for r in sorted(owned_sells, key=lambda x: x["delta"])[:5]:
+                text_lines.append(
+                    f"    • {r['name']} ({r['position']}) {_format_delta(r['delta'])}"
+                )
+        text_lines.append("")
+
+    text_lines.append("")
+    text_lines.append("Open the rankings:  https://riskittogetthebrisket.org/rankings")
+    text_lines.append("Toggle Apply Scoring Fit on /settings to use these values everywhere.")
+    text_lines.append("")
+    text_lines.append("— Risk It")
+
+    body = "\n".join(text_lines)
+
+    # Lightweight HTML version for iCloud / Gmail rendering.  Same
+    # content; nicer layout.  Inline styles only — no external CSS.
+    html_parts: list[str] = []
+    html_parts.append("<div style='font-family:system-ui,Helvetica,Arial,sans-serif;color:#1a1d2e;max-width:640px;margin:0 auto;padding:18px;'>")
+    html_parts.append(f"<h2 style='color:#22d3ee;margin:0 0 6px;'>Weekly Scoring Fit{league_label}</h2>")
+    html_parts.append("<p style='color:#666;font-size:13px;margin:0 0 16px;'>Players whose value under YOUR league's stacked scoring rules diverges most from the consensus market.</p>")
+
+    def _section(title: str, color: str, items: list[dict[str, Any]]) -> None:
+        if not items:
+            return
+        html_parts.append(f"<h3 style='color:{color};margin:18px 0 6px;font-size:14px;'>{title}</h3>")
+        html_parts.append("<table style='width:100%;border-collapse:collapse;font-size:13px;'>")
+        for it in items:
+            d = it["delta"]
+            sign_color = "#16a34a" if d > 0 else "#dc2626"
+            html_parts.append(
+                "<tr>"
+                f"<td style='padding:3px 6px;'><strong>{it['name']}</strong></td>"
+                f"<td style='padding:3px 6px;color:#666;font-size:12px;'>{it['position']}</td>"
+                f"<td style='padding:3px 6px;color:{sign_color};font-family:monospace;font-weight:600;text-align:right;'>{_format_delta(d)}</td>"
+                f"<td style='padding:3px 6px;color:#888;font-size:12px;'>{it['tier']}</td>"
+                "</tr>"
+            )
+        html_parts.append("</table>")
+
+    _section("Buy-low candidates", "#16a34a", buys[:_TOP_BUY_LIMIT])
+    _section("Sell-high candidates", "#dc2626", sells[:_TOP_SELL_LIMIT])
+
+    if roster_summary:
+        owned_buys = [r for r in roster_summary if r.get("delta", 0) >= _DELTA_THRESHOLD]
+        owned_sells = [r for r in roster_summary if r.get("delta", 0) <= -_DELTA_THRESHOLD]
+        net_delta = sum(r.get("delta", 0) for r in roster_summary)
+        net_color = "#16a34a" if net_delta > 0 else ("#dc2626" if net_delta < 0 else "#666")
+        html_parts.append("<div style='margin-top:18px;padding:12px;background:#f8fafc;border-radius:6px;'>")
+        html_parts.append("<h3 style='margin:0 0 6px;font-size:14px;'>Your roster</h3>")
+        html_parts.append(f"<p style='margin:0;font-size:13px;'>Net fit-delta: <strong style='color:{net_color};font-family:monospace;'>{_format_delta(net_delta)}</strong> across {len(roster_summary)} IDPs ({len(owned_buys)} buy-side, {len(owned_sells)} sell-side)</p>")
+        html_parts.append("</div>")
+
+    html_parts.append("<p style='margin-top:20px;font-size:13px;'><a href='https://riskittogetthebrisket.org/rankings' style='color:#22d3ee;'>Open the rankings →</a></p>")
+    html_parts.append("<p style='font-size:11px;color:#999;margin-top:14px;'>Toggle Apply Scoring Fit on /settings to use these values across the trade calculator + suggestions.</p>")
+    html_parts.append("</div>")
+
+    return {
+        "subject": subject,
+        "body": body,
+        "html": "".join(html_parts),
+        "summary": {
+            "buy_count": len(buys),
+            "sell_count": len(sells),
+            "roster_count": len(roster_summary),
+        },
+    }
+
+
+def deliver_digest(
+    contract: dict[str, Any],
+    *,
+    to_email: str,
+    user_team_players: list[str] | None = None,
+    league_name: str | None = None,
+    delivery: Callable[[str, str, str], bool] | None = None,
+) -> dict[str, Any]:
+    """End-to-end: build digest + deliver via ``delivery``.
+
+    ``delivery(to, subject, body) -> bool`` matches the
+    ``signal_alerts._deliver_email_smtp`` signature so callers can
+    pass either function (or a test stub).
+
+    Returns a summary dict suitable for logging:
+
+        {
+          "delivered":    bool,
+          "reason":       "ok" | "no_content" | "no_email" | "delivery_error" | "no_delivery",
+          "summary":      {buy_count, sell_count, roster_count},
+        }
+    """
+    if not to_email:
+        return {"delivered": False, "reason": "no_email"}
+    digest = build_digest(
+        contract,
+        user_team_players=user_team_players,
+        league_name=league_name,
+    )
+    if digest is None:
+        return {"delivered": False, "reason": "no_content"}
+    if delivery is None:
+        return {
+            "delivered": False,
+            "reason": "no_delivery",
+            "summary": digest.get("summary"),
+        }
+    try:
+        ok = delivery(to_email, digest["subject"], digest["body"])
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning(
+            "scoring_fit_digest delivery failed for %s: %s", to_email, exc,
+        )
+        return {
+            "delivered": False,
+            "reason": f"delivery_error:{type(exc).__name__}",
+            "summary": digest.get("summary"),
+        }
+    return {
+        "delivered": bool(ok),
+        "reason": "ok" if ok else "delivery_error",
+        "summary": digest.get("summary"),
+    }

--- a/src/scoring/idp_scoring_fit_apply.py
+++ b/src/scoring/idp_scoring_fit_apply.py
@@ -363,6 +363,18 @@ def apply_idp_scoring_fit_pass(
         if row.vorp is not None and row.games_used > 0
     ]
 
+    # Snap-share lookup (best-effort).  Stamps ``idpSnapShare`` on
+    # every IDP we have data for — the popup reads it as a
+    # durability signal alongside the lens fields.  Empty dict on
+    # any fetch failure (cold-start, nflverse outage); the apply
+    # loop just skips the field in that case.
+    try:
+        from src.scoring.snap_share import fetch_idp_snap_shares  # noqa: PLC0415
+        snap_share_by_gsis = fetch_idp_snap_shares()
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("idp_scoring_fit=snap_share_failed err=%r", exc)
+        snap_share_by_gsis = {}
+
     stamped = 0
     for player in players_array:
         name = str(player.get("displayName") or "")
@@ -394,6 +406,16 @@ def apply_idp_scoring_fit_pass(
         # (which stats are driving the lens's verdict).
         if fit_with_delta.top_stats:
             player["idpScoringFitTopStats"] = list(fit_with_delta.top_stats)
+        # Snap-share — stamp when we have it.  Read by the popup as
+        # a durability signal: a 100-tackle LB at 95% snaps is a
+        # bell-cow; the same line at 60% is rotational.  Stamped as
+        # a fraction (0.0-1.0) so the frontend can format as %.
+        if isinstance(player.get("playerId"), str) and player["playerId"]:
+            gsis = sleeper_to_gsis.get(player["playerId"])
+            if gsis:
+                share = snap_share_by_gsis.get(gsis)
+                if isinstance(share, (int, float)):
+                    player["idpSnapShare"] = round(float(share), 3)
         # Adjusted value: what rankDerivedValue would BE if the user
         # toggles "apply scoring fit" on the frontend.  Always stamped
         # when the pass produces a delta — frontend toggle decides

--- a/src/scoring/scoring_fit_movers.py
+++ b/src/scoring/scoring_fit_movers.py
@@ -1,0 +1,147 @@
+"""Compute scoring-fit movers — players whose ``idpScoringFitDelta``
+moved most since a prior snapshot.
+
+The daily snapshot capture (``scripts/capture_idp_fit_snapshot.py``)
+writes ``data/idp_fit_snapshots/{YYYY-MM-DD}.json`` once per UTC day.
+This module diffs the latest live contract against the most recent
+snapshot to surface "lens noticed something changed" moments:
+
+* A player whose delta jumped +2400 since last week — possibly a
+  recent breakout the consensus market hasn't priced in yet.
+* A player whose delta cratered — late-season decline the lens
+  caught before the consensus did.
+
+Output feeds the existing movers widget on /league.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _snapshot_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "data" / "idp_fit_snapshots"
+
+
+def find_latest_snapshot(*, before: str | None = None) -> dict[str, Any] | None:
+    """Return the most recent snapshot, optionally filtering to those
+    captured before a given ``YYYY-MM-DD`` cutoff.
+
+    Returns ``None`` when the directory is empty or the read fails.
+    Used by ``compute_movers`` to find the comparison baseline.
+    """
+    snap_dir = _snapshot_dir()
+    if not snap_dir.exists():
+        return None
+    files = sorted(snap_dir.glob("*.json"))
+    if before:
+        files = [f for f in files if f.stem < before]
+    if not files:
+        return None
+    try:
+        return json.loads(files[-1].read_text())
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("scoring_fit_movers=read_failed file=%s err=%r", files[-1], exc)
+        return None
+
+
+def compute_movers(
+    contract: dict[str, Any],
+    *,
+    snapshot: dict[str, Any] | None = None,
+    min_change: float = 750.0,
+    top_n: int = 10,
+) -> dict[str, Any]:
+    """Return top movers in ``idpScoringFitDelta`` since ``snapshot``.
+
+    Each mover entry: ``{name, position, prior_delta, current_delta,
+    change, consensus, tier, confidence, synthetic}``.
+
+    Sorted by ``abs(change)`` descending — the largest jumps in
+    either direction surface first.
+
+    ``min_change`` filters out trivial movement (the lens recomputes
+    every refresh; small wobbles are noise).  Default 750 = roughly
+    half the BUY/SELL signal threshold.
+
+    Returns ``{has_baseline: bool, baseline_date: str | None,
+    risers: [...], fallers: [...]}``.
+    """
+    if snapshot is None:
+        snapshot = find_latest_snapshot()
+    if not isinstance(snapshot, dict):
+        return {"has_baseline": False, "baseline_date": None, "risers": [], "fallers": []}
+
+    # Index the snapshot by name (snapshot file uses ``name`` not
+    # ``displayName``).  Skip entries without a usable delta.
+    prior_by_name: dict[str, float] = {}
+    for p in snapshot.get("players") or []:
+        nm = str(p.get("name") or "").strip()
+        d = p.get("delta")
+        if nm and isinstance(d, (int, float)):
+            prior_by_name[nm] = float(d)
+
+    if not prior_by_name:
+        return {"has_baseline": False, "baseline_date": None, "risers": [], "fallers": []}
+
+    # Walk the live contract's IDP rows, compare to the snapshot.
+    risers: list[dict[str, Any]] = []
+    fallers: list[dict[str, Any]] = []
+    arr = contract.get("playersArray") or []
+    for row in arr:
+        if not isinstance(row, dict):
+            continue
+        pos = str(row.get("position") or "").upper()
+        if pos not in {"DL", "DT", "DE", "EDGE", "NT", "LB", "ILB", "OLB",
+                       "MLB", "DB", "CB", "S", "FS", "SS"}:
+            continue
+        cur = row.get("idpScoringFitDelta")
+        if not isinstance(cur, (int, float)):
+            continue
+        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
+        prior = prior_by_name.get(name)
+        if prior is None:
+            continue  # not in baseline — no comparison possible
+        change = float(cur) - prior
+        if abs(change) < min_change:
+            continue
+        entry = {
+            "name": name,
+            "position": pos,
+            "prior_delta": round(prior, 1),
+            "current_delta": round(float(cur), 1),
+            "change": round(change, 1),
+            "consensus": int(row.get("rankDerivedValue") or 0),
+            "tier": row.get("idpScoringFitTier"),
+            "confidence": row.get("idpScoringFitConfidence"),
+            "synthetic": bool(row.get("idpScoringFitSynthetic")),
+        }
+        if change > 0:
+            risers.append(entry)
+        else:
+            fallers.append(entry)
+
+    risers.sort(key=lambda e: -e["change"])
+    fallers.sort(key=lambda e: e["change"])
+
+    captured_at = snapshot.get("captured_at")
+    baseline_date = None
+    if isinstance(captured_at, str):
+        try:
+            baseline_date = datetime.fromisoformat(
+                captured_at.replace("Z", "+00:00")
+            ).strftime("%Y-%m-%d")
+        except ValueError:
+            baseline_date = captured_at[:10] if len(captured_at) >= 10 else None
+
+    return {
+        "has_baseline": True,
+        "baseline_date": baseline_date,
+        "risers": risers[:top_n],
+        "fallers": fallers[:top_n],
+    }

--- a/src/scoring/snap_share.py
+++ b/src/scoring/snap_share.py
@@ -1,0 +1,123 @@
+"""Per-player snap-share aggregation from nflverse weekly snap counts.
+
+Used as a durability signal for IDPs: a 100-tackle LB with 95% snap
+share is a true bell-cow; the same line on 60% snap share is a
+rotational role susceptible to snap-redistribution.  Stamped on each
+IDP row alongside the scoring-fit fields so the popup + lens can
+surface it.
+
+Reads ``src.nfl_data.fetch_snap_counts`` (cached on disk).  Returns
+``{player_id: float}`` mapping gsis_id → defensive snap share
+(0.0-1.0) averaged across the season.
+
+No-throw contract — empty dict on any failure (network, parse, no
+data).  The apply pass treats the absence as "no snap data" and
+skips stamping the field.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_target_season() -> int:
+    """Most recent completed (or in-progress) NFL season.
+
+    September onward → current calendar year (regular season has
+    started).  Earlier in the calendar → previous calendar year.
+    Matches the convention in ``idp_scoring_fit_apply``.
+    """
+    now = datetime.now(timezone.utc)
+    return now.year if now.month >= 9 else now.year - 1
+
+
+def fetch_idp_snap_shares(season: int | None = None) -> dict[str, float]:
+    """Return ``{gsis_id: defensive_snap_share}`` for IDPs in
+    ``season`` (defaults to most recent).
+
+    Snap share is computed per player as
+    ``sum(defense_snaps) / sum(team_snaps)`` across all weeks where
+    both fields are non-zero.  Players with < 4 weeks of data are
+    excluded — too small a sample to be informative.
+
+    Returns ``{}`` on any fetch failure or when nflverse hasn't
+    published snap counts yet.
+    """
+    if season is None:
+        season = _resolve_target_season()
+
+    try:
+        from src.nfl_data import ingest as _ingest  # noqa: PLC0415
+        rows = _ingest.fetch_snap_counts([season])
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("snap_share=fetch_failed season=%d err=%r", season, exc)
+        return {}
+
+    if not rows:
+        return {}
+
+    # Aggregate per player.  nflverse snap_counts has columns:
+    #   pfr_player_id, player, position, team, week, season,
+    #   offense_snaps, defense_snaps, st_snaps, offense_pct,
+    #   defense_pct, st_pct
+    # We need gsis_id (so it joins to the other pipeline).  The
+    # snap_counts file uses ``pfr_player_id`` not gsis — we cross-
+    # walk via the id_map.
+    pfr_to_defense_pcts: dict[str, list[float]] = defaultdict(list)
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        pfr = str(r.get("pfr_player_id") or "").strip()
+        pos = str(r.get("position") or "").upper()
+        if not pfr:
+            continue
+        # IDP gate — saves work on the cross-walk lookup.
+        if pos not in {"DL", "DT", "DE", "EDGE", "NT", "LB", "ILB", "OLB",
+                       "MLB", "DB", "CB", "S", "FS", "SS"}:
+            continue
+        try:
+            pct = float(r.get("defense_pct") or 0)
+        except (TypeError, ValueError):
+            continue
+        # nflverse stores defense_pct as 0.0-1.0 in some seasons,
+        # 0-100 in others.  Normalise: anything > 1 is a percent.
+        if pct > 1:
+            pct = pct / 100.0
+        if pct <= 0:
+            continue
+        pfr_to_defense_pcts[pfr].append(pct)
+
+    # Cross-walk pfr_id → gsis_id.
+    try:
+        from src.nfl_data import ingest as _ingest  # noqa: PLC0415
+        id_map_rows = _ingest.fetch_id_map() or []
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("snap_share=id_map_failed err=%r", exc)
+        return {}
+
+    pfr_to_gsis: dict[str, str] = {}
+    for row in id_map_rows:
+        gsis = str(row.get("gsis_id") or "").strip()
+        pfr = str(row.get("pfr_id") or "").strip()
+        if gsis and pfr:
+            pfr_to_gsis[pfr] = gsis
+
+    out: dict[str, float] = {}
+    for pfr, pcts in pfr_to_defense_pcts.items():
+        if len(pcts) < 4:
+            continue
+        gsis = pfr_to_gsis.get(pfr)
+        if not gsis:
+            continue
+        out[gsis] = sum(pcts) / len(pcts)
+
+    _LOGGER.info(
+        "snap_share=loaded season=%d idps=%d pfr_no_gsis=%d",
+        season, len(out),
+        sum(1 for p in pfr_to_defense_pcts if p not in pfr_to_gsis),
+    )
+    return out

--- a/tests/api/test_idp_scoring_fit_integration.py
+++ b/tests/api/test_idp_scoring_fit_integration.py
@@ -1,0 +1,200 @@
+"""End-to-end integration test for the IDP scoring-fit pipeline.
+
+Builds a full canonical contract from the most recent raw snapshot
+in ``exports/latest/`` with the feature flag ON, asserts:
+
+* Every IDP-with-delta row also carries the whitelisted top-level
+  fields (``idpScoringFitVorp``, ``Tier``, ``Confidence``,
+  ``AdjustedValue``).
+* The ``rankDerivedValue`` column is byte-identical to a baseline
+  build with the flag OFF — i.e., the pass is additive-only.
+* At least 50% of league-rostered IDPs got a delta.  Catches
+  silent regressions like the name-fallback bug (where coverage
+  dropped from ~90% to ~24% without anyone noticing for 3 PRs).
+* The delta distribution is reasonable: median in [-2000, 2000],
+  not collapsed to 0 (would mean QuantileMap is broken).
+
+Skipped when no raw snapshot exists in ``exports/latest/``
+(fresh-checkout / CI without prior data).  Skipped when nflverse
+fetches fail (offline / no network).
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _latest_raw_payload() -> dict | None:
+    snapshots = sorted((_REPO_ROOT / "exports" / "latest").glob("dynasty_data_*.json"))
+    if not snapshots:
+        return None
+    try:
+        return json.loads(snapshots[-1].read_text())
+    except Exception:
+        return None
+
+
+_IDP_POSITIONS = {
+    "DL", "DT", "DE", "EDGE", "NT",
+    "LB", "ILB", "OLB", "MLB",
+    "DB", "CB", "S", "FS", "SS",
+}
+
+
+class TestIdpScoringFitPipelineIntegration(unittest.TestCase):
+    """End-to-end pipeline test — needs a raw snapshot + network."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.raw = _latest_raw_payload()
+        if cls.raw is None:
+            raise unittest.SkipTest(
+                "No raw snapshot in exports/latest/ — skipping integration test"
+            )
+
+    def _build_contract(self, *, flag_on: bool) -> dict:
+        # Set the flag explicitly so we don't depend on the env state.
+        prev = os.environ.get("RISKIT_FEATURE_IDP_SCORING_FIT")
+        os.environ["RISKIT_FEATURE_IDP_SCORING_FIT"] = "1" if flag_on else "0"
+        try:
+            from src.api import feature_flags
+            feature_flags.reload()
+            from src.api import data_contract as DC
+            return DC.build_api_data_contract(deepcopy(self.raw))
+        finally:
+            if prev is None:
+                os.environ.pop("RISKIT_FEATURE_IDP_SCORING_FIT", None)
+            else:
+                os.environ["RISKIT_FEATURE_IDP_SCORING_FIT"] = prev
+            feature_flags.reload()
+
+    def test_pass_stamps_required_fields(self):
+        """Every IDP row with a delta must carry the full field set."""
+        try:
+            contract = self._build_contract(flag_on=True)
+        except Exception as exc:  # noqa: BLE001
+            self.skipTest(f"contract build failed (likely offline): {exc!r}")
+        arr = contract.get("playersArray") or []
+        idp_with_delta = [
+            r for r in arr
+            if isinstance(r, dict)
+            and str(r.get("position") or "").upper() in _IDP_POSITIONS
+            and isinstance(r.get("idpScoringFitDelta"), (int, float))
+        ]
+        if not idp_with_delta:
+            self.skipTest("no IDP rows with delta — nflverse fetch likely failed")
+
+        required = (
+            "idpScoringFitVorp",
+            "idpScoringFitTier",
+            "idpScoringFitConfidence",
+            "idpScoringFitAdjustedValue",
+        )
+        for r in idp_with_delta[:50]:  # sample for speed
+            for field in required:
+                self.assertIn(
+                    field, r,
+                    f"IDP {r.get('displayName')!r} has delta but missing {field}",
+                )
+
+    def test_rank_derived_value_unchanged_by_pass(self):
+        """The pass is additive-only — rankDerivedValue must equal what
+        a flag-OFF build produces, byte-for-byte, on every row."""
+        try:
+            contract_off = self._build_contract(flag_on=False)
+            contract_on = self._build_contract(flag_on=True)
+        except Exception as exc:  # noqa: BLE001
+            self.skipTest(f"contract build failed: {exc!r}")
+        arr_off = contract_off.get("playersArray") or []
+        arr_on = contract_on.get("playersArray") or []
+        by_name_off = {r.get("displayName"): r for r in arr_off if isinstance(r, dict)}
+        for r in arr_on:
+            if not isinstance(r, dict):
+                continue
+            name = r.get("displayName")
+            ref = by_name_off.get(name)
+            if ref is None:
+                continue
+            self.assertEqual(
+                r.get("rankDerivedValue"),
+                ref.get("rankDerivedValue"),
+                f"{name}: rankDerivedValue mutated by scoring-fit pass",
+            )
+
+    def test_coverage_floor(self):
+        """At least 50% of league-rostered IDPs must get a delta.
+
+        Catches the name-fallback bug class — where the cross-walk
+        silently drops half the universe and the lens shows sentinels
+        for everyone except superstar names.
+        """
+        try:
+            contract = self._build_contract(flag_on=True)
+        except Exception as exc:  # noqa: BLE001
+            self.skipTest(f"contract build failed: {exc!r}")
+        arr = contract.get("playersArray") or []
+        all_idp = [
+            r for r in arr
+            if isinstance(r, dict)
+            and str(r.get("position") or "").upper() in _IDP_POSITIONS
+        ]
+        if not all_idp:
+            self.skipTest("no IDP rows in contract")
+        with_delta = [
+            r for r in all_idp
+            if isinstance(r.get("idpScoringFitDelta"), (int, float))
+        ]
+        if len(with_delta) == 0:
+            self.skipTest("no IDP deltas (nflverse fetch likely failed)")
+        coverage = len(with_delta) / len(all_idp)
+        self.assertGreaterEqual(
+            coverage, 0.50,
+            f"coverage {coverage:.0%} below 50% floor — likely a "
+            f"cross-walk regression.  {len(with_delta)} of {len(all_idp)} "
+            f"IDPs have a delta.",
+        )
+
+    def test_delta_distribution_reasonable(self):
+        """Median delta should be near zero but distribution should
+        not be collapsed (i.e., QuantileMap is producing variation).
+
+        A median of exactly 0 across hundreds of rows would suggest
+        the quantile map is returning the same value for everyone.
+        """
+        try:
+            contract = self._build_contract(flag_on=True)
+        except Exception as exc:  # noqa: BLE001
+            self.skipTest(f"contract build failed: {exc!r}")
+        arr = contract.get("playersArray") or []
+        deltas = sorted(
+            float(r["idpScoringFitDelta"])
+            for r in arr
+            if isinstance(r, dict)
+            and isinstance(r.get("idpScoringFitDelta"), (int, float))
+        )
+        if len(deltas) < 20:
+            self.skipTest(f"only {len(deltas)} deltas — sample too thin")
+        median = deltas[len(deltas) // 2]
+        # Median should be in a sensible range — not pinned at the
+        # extremes (would suggest the quantile map is broken).
+        self.assertGreater(
+            max(deltas) - min(deltas), 1000,
+            "delta range too narrow — QuantileMap may be collapsed",
+        )
+        # Median is often non-zero (the consensus market and the
+        # league's scoring rarely agree exactly), but if it's > 5000
+        # the lens is biased systematically.
+        self.assertLess(
+            abs(median), 5000,
+            f"median delta {median} suggests a systemic bias — "
+            f"check the QuantileMap distribution",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scoring/test_idp_scoring_fit_parity.py
+++ b/tests/scoring/test_idp_scoring_fit_parity.py
@@ -39,6 +39,7 @@ _ALLOWED_NEW_FIELDS = frozenset({
     "idpScoringFitGamesUsed",
     "idpScoringFitAdjustedValue",
     "idpScoringFitTopStats",
+    "idpSnapShare",
 })
 
 


### PR DESCRIPTION
## Summary

Closes the 10-item ROI list. Active push (digest, movers), edge-case coverage (per-league, trade history), operational hardening (CI test), and Phase 2 scaffolding (ESPN, snap data).

## What's in the box

| # | Item | Files |
|---|---|---|
| 1 | Weekly digest email | `src/news/scoring_fit_digest.py`, new endpoint, systemd timer |
| 2 | scoringFit movers | `src/scoring/scoring_fit_movers.py`, `ScoringFitMoversPanel.jsx` |
| 3 | Targets panel | `ScoringFitTargetsPanel.jsx` (fit+ unowned) |
| 4 | Per-league toggle | `scoringFitByLeague` map + resolver + /settings UI |
| 5 | Trade history | `analyzeSleeperTradeHistory(..settings)` re-evaluates retroactively |
| 6 | CI integration test | `test_idp_scoring_fit_integration.py` — coverage floor + parity |
| 7 | Per-roster summary | `ScoringFitRosterSummary.jsx` on /league |
| 8 | Snap-share data | `src/scoring/snap_share.py` → `idpSnapShare` field |
| 9 | ESPN projections | scaffold in `src/adapters/espn_projections.py` |
| 10 | Onboarding tour | `ScoringFitOnboarding.jsx` first-run modal |

## Email config status

- `ALERT_TO=jasonleetucker@icloud.com` set in prod `.env`
- `ALERT_ENABLED=true` set
- **`ALERT_FROM` + `ALERT_PASSWORD` still need user-provided Gmail app password** to actually deliver. Endpoint will build digest + return `delivered=False, reason=delivery_error` until configured.

## Email setup (one-time)

1. In Google account → Security → App Passwords, generate one for "Mail" → 16-char password
2. Add to `/home/dynasty/trade-calculator/.env`:
   ```
   ALERT_FROM=your-gmail@gmail.com
   ALERT_PASSWORD=xxxxxxxxxxxxxxxx
   ```
3. `sudo systemctl restart dynasty.service`
4. Test: `curl -X POST -H "Authorization: Bearer $SIGNAL_ALERT_CRON_TOKEN" http://127.0.0.1:8000/api/scoring-fit-digest/run -d '{"dry_run": true}'`

The systemd timer (`dynasty-scoring-fit-digest.timer`) needs to be installed on prod once template is processed:

```bash
sudo bash deploy/install-systemd-service.sh  # processes templates + enables
```

## Test plan

- [x] `pytest tests/scoring/` — 65 pass
- [x] Full pytest — 2413 pass, 6 skip, 2 pre-existing data-drift fails
- [x] `npm run build` — settings 31.8/35 KB, all under budget
- [ ] Post-deploy: open `/league`, confirm new panels visible when toggle on
- [ ] Post-deploy: hit `/api/scoring-fit/movers` — expect empty until 2nd snapshot captured
- [ ] Post-deploy: dry-run digest endpoint, verify email body looks reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)