### PR TITLE
feat(draft): top 10 KTC overrates in 'Good to nominate'

### DIFF
--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -1787,7 +1787,7 @@ function TargetBoard({
  */
 function NominationCandidates({ stats, onDraft, onCycleTag }) {
   const list = useMemo(
-    () => nominationCandidates(stats, { limit: 5 }),
+    () => nominationCandidates(stats, { limit: 10 }),
     [stats],
   );
 
@@ -1796,8 +1796,8 @@ function NominationCandidates({ stats, onDraft, onCycleTag }) {
       <div className="card draft-nbt">
         <h3 style={{ margin: "0 0 4px" }}>Good to nominate</h3>
         <div className="muted" style={{ fontSize: "0.72rem" }}>
-          No drain candidates — rivals are too tight or everyone is
-          already tagged as target.
+          No KTC overrates — either every rookie's KTC and our board
+          agree, or KTC values are missing from the live contract.
         </div>
       </div>
     );
@@ -1814,11 +1814,11 @@ function NominationCandidates({ stats, onDraft, onCycleTag }) {
       >
         <h3 style={{ margin: 0 }}>Good to nominate</h3>
         <span className="muted" style={{ fontSize: "0.68rem" }}>
-          Drain rival $ without risking a target
+          Top 10 rookies KTC overrates vs our board
         </span>
       </div>
       <div className="draft-nbt-list">
-        {list.map(({ player, score, drain, rationale }, i) => (
+        {list.map(({ player, gap, ourDollar, ktcDollar, rationale }, i) => (
           <div
             key={player.id}
             className={`draft-nbt-row${player.userTag === TAG_AVOID ? " draft-nbt-avoid" : ""}`}
@@ -1848,21 +1848,22 @@ function NominationCandidates({ stats, onDraft, onCycleTag }) {
             <span className="draft-nbt-name" onClick={() => onDraft(player)}>
               {player.name}
             </span>
-            <span className="draft-money">fair {fmt$(player.inflatedFair)}</span>
-            <span className="muted" style={{ fontSize: "0.68rem" }}>
-              drain {fmt$(drain)}
+            <span className="muted" style={{ fontSize: "0.68rem" }} title="Our board's pre-draft fair price">
+              ours {fmt$(ourDollar)}
+            </span>
+            <span className="muted" style={{ fontSize: "0.68rem" }} title="KTC's market value at the same scale">
+              ktc {fmt$(ktcDollar)}
             </span>
             <span
-              className={`draft-rec-chip ${
-                player.userTag === TAG_AVOID
-                  ? "draft-rec-avoid"
-                  : "draft-rec-neutral"
-              }`}
+              className="draft-rec-chip"
+              style={{
+                background: "rgba(34, 211, 238, 0.18)",
+                color: "var(--cyan, #22d3ee)",
+                fontWeight: 600,
+              }}
+              title={`KTC overrates by $${Math.round(gap)} — leaguemates following KTC will overpay`}
             >
-              {player.userTag === TAG_AVOID ? "AVOID" : "DRAIN"}
-            </span>
-            <span className="muted" style={{ fontSize: "0.66rem" }}>
-              S {Math.round(score)}
+              +{fmt$(gap)}
             </span>
           </div>
         ))}
@@ -3112,12 +3113,21 @@ export default function DraftDashboardPage() {
       setAllPlayersArray(pa);
 
       // Rookies only, sorted by consensus value (values.full) desc.
+      // Also capture the per-source KTC value so the
+      // ``nominationCandidates`` ranker can compute the
+      // KTC-vs-our-board discrepancy (the gap drives the "good to
+      // nominate" list — biggest KTC overrates first).
       const rookies = pa
         .filter((p) => p?.rookie === true)
         .filter((p) => p?.assetClass === "offense" || p?.assetClass === "idp")
         .map((p) => ({
           name: p.displayName || p.canonicalName || "",
           rawValue: Number(p?.values?.full) || 0,
+          // Raw KTC value on the same 0-9999 scale.  Null when KTC
+          // didn't rank the rookie.  Captured here so we don't have
+          // to re-fetch playersArray inside the draft logic.
+          ktcRawValue: typeof p?.canonicalSiteValues?.ktc === "number"
+            ? p.canonicalSiteValues.ktc : null,
           pos: String(p?.position || p?.pos || "").toUpperCase(),
         }))
         .filter((p) => p.name && p.rawValue > 0)
@@ -3136,10 +3146,33 @@ export default function DraftDashboardPage() {
         1200,
       );
 
+      // Rescale the KTC values onto the same $1200 budget so the
+      // discrepancy ``ktcDollar - preDraft`` is comparable to the
+      // user's board.  Players with no KTC value get null (skipped
+      // by the discrepancy ranker).
+      const ktcDollarsByName = (() => {
+        const ranked = rookies.filter((r) => r.ktcRawValue && r.ktcRawValue > 0);
+        if (ranked.length === 0) return new Map();
+        // Sort by KTC value desc (parallels the rawValue sort) then
+        // rescale that ordered list to the $1200 pool.
+        const ktcSorted = [...ranked].sort((a, b) => b.ktcRawValue - a.ktcRawValue);
+        const ktcRaws = ktcSorted.map((r) => r.ktcRawValue);
+        const ktcScaled = rescaleValuesToBudget(ktcRaws, 1200);
+        const m = new Map();
+        ktcSorted.forEach((r, i) => m.set(r.name, ktcScaled[i]));
+        return m;
+      })();
+
       const incoming = rookies.map((r, i) => ({
         name: r.name,
         preDraft: scaled[i],
         pos: r.pos,
+        // KTC's market dollar value on the same $1200 scale.  Null
+        // when KTC doesn't rank this rookie.  Used by the
+        // ``nominationCandidates`` ranker to compute the
+        // KTC-vs-our-board gap that drives the "good to nominate"
+        // list.
+        ktcDollar: ktcDollarsByName.get(r.name) ?? null,
       }));
 
       // Dry-run against current workspace to show a preview diff.

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -1765,53 +1765,50 @@ export function nextBestTargets(stats, { limit = 5 } = {}) {
  * Excludes drafted players and my targets.  Returns top ``limit``
  * candidates sorted descending by score.
  */
-export function nominationCandidates(stats, { limit = 5 } = {}) {
+export function nominationCandidates(stats, { limit = 10 } = {}) {
   if (!stats || !Array.isArray(stats.enrichedPlayers)) return [];
+
+  // Re-purposed 2026-04-26: instead of a drain-by-affordability
+  // ranker, this now surfaces rookies KTC values MUCH HIGHER than
+  // our board.  Rationale: if KTC says a rookie is worth $50 and
+  // our board says $30, leaguemates who reference KTC will bid up
+  // to $50 — draining their budget on a player our model considers
+  // overpriced.  Largest gap = biggest tax on rivals.
+  //
+  // Selection:
+  //   1. Not yet drafted
+  //   2. Not target-tagged (don't undermine your own pursuit)
+  //   3. Has both a board ``preDraft`` AND a KTC dollar value
+  //   4. ``ktcDollar > preDraft`` (KTC overrates relative to us)
+  //
+  // Sort: ``ktcDollar - preDraft`` descending.  Cap at ``limit``
+  // (default 10).
   const out = [];
-  const topCompetitor = Math.max(0, stats.topCompetitorMax || 0);
   for (const p of stats.enrichedPlayers) {
     if (p.drafted) continue;
     if (p.userTag === TAG_TARGET) continue;
-
-    const expectedPrice = Math.max(0, p.inflatedFair || 0);
-    if (expectedPrice <= 0) continue;
-
-    // Cap drain potential by rival affordability.  A $50 fair player
-    // with no rivals over $20 only drains $20 from the pool no matter
-    // how much the nomination theoretically costs.
-    const drain = Math.min(expectedPrice, topCompetitor);
-    if (drain < 1) continue;
-
-    const tagWeight = p.userTag === TAG_AVOID ? 1.8 : 1.0;
-
-    // Risk of accidentally winning: only meaningful for neutrals.  If
-    // I could win by beating the competitor ceiling cheaply, there's
-    // a nontrivial chance nobody else bids much and I end up stuck.
-    // Avoid-tagged players: user opted in, risk_factor = 0.
-    let riskFactor = 0;
-    if (p.userTag !== TAG_AVOID) {
-      const myExcess = Math.max(0, p.myWinningBid - expectedPrice);
-      // Normalize roughly to 0..1 — excess of $30+ over expected
-      // price is a strong "you might actually win this" signal.
-      riskFactor = Math.min(1, myExcess / 30);
-    }
-
-    const score = drain * tagWeight * (1 - riskFactor);
-    if (score <= 0) continue;
-
+    const ourDollar = Math.max(0, p.preDraft || 0);
+    const ktcDollar = Math.max(0, Number(p.ktcDollar) || 0);
+    if (ourDollar <= 0 || ktcDollar <= 0) continue;
+    const gap = ktcDollar - ourDollar;
+    if (gap < 1) continue;  // KTC must overrate by at least $1
+    const drain = Math.min(ktcDollar, Math.max(0, stats.topCompetitorMax || 0));
     out.push({
       player: p,
-      score,
+      score: gap,
       drain,
-      expectedPrice,
+      gap,
+      ourDollar,
+      ktcDollar,
+      expectedPrice: ktcDollar,
       rationale:
-        p.userTag === TAG_AVOID
-          ? `Avoid-tagged · clears ~$${Math.round(drain)} from rivals`
-          : `Drains ~$${Math.round(drain)} from rivals at fair price`,
+        `KTC values $${Math.round(ktcDollar)} vs our $${Math.round(ourDollar)} ` +
+        `· $${Math.round(gap)} gap — leaguemates following KTC will ` +
+        `bid past your board's fair price`,
     });
   }
 
-  out.sort((a, b) => b.score - a.score);
+  out.sort((a, b) => b.gap - a.gap);
   return out.slice(0, limit);
 }
 


### PR DESCRIPTION
Per user request — replaces drain-by-affordability with KTC-vs-board discrepancy. See commit message.