### PR TITLE
feat: PWA push notifications + custom value/rank alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,23 @@ LOG_FORMAT=text
 # ALERT_FROM=sender@gmail.com
 # ALERT_PASSWORD=gmail-app-password
 
+# Web Push (PWA notifications) — set ALL THREE to enable browser
+# push.  Generate a fresh keypair with:
+#
+#     python -c "from py_vapid import Vapid; v=Vapid(); v.generate_keys(); \
+#       import base64; print('PRIV:', base64.urlsafe_b64encode(\
+#       v.private_key.private_numbers().private_value.to_bytes(32,'big')\
+#       ).decode().rstrip('=')); from cryptography.hazmat.primitives import \
+#       serialization; print('PUB:', base64.urlsafe_b64encode(\
+#       v.public_key.public_bytes(serialization.Encoding.X962,\
+#       serialization.PublicFormat.UncompressedPoint)).decode().rstrip('='))"
+#
+# VAPID_CONTACT must be a real mailto: — push providers send delivery
+# failures here.
+# VAPID_PUBLIC_KEY=
+# VAPID_PRIVATE_KEY=
+# VAPID_CONTACT=mailto:ops@example.com
+
 # ── IDP Calibration Lab ──────────────────────────────────────────────────
 # Controls network access for the historical stats adapter layer at
 # src/idp_calibration/stats_adapter.py.

--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -297,8 +297,51 @@ main() {
     log "Signal-alerts timer skipped: SIGNAL_ALERT_CRON_TOKEN not set in ${APP_DIR}/.env."
   fi
 
+  # ── Custom-alerts sweep (optional systemd timer) ───────────────────────
+  # Same pattern as signal-alerts: install only when the cron token is
+  # present.  Fires every 2 hours; the rule-engine cooldown inside
+  # ``custom_alerts.py`` keeps a single rule from re-firing within 24h.
+  local custom_alerts_service_template="${APP_DIR}/deploy/systemd/dynasty-custom-alerts.service.template"
+  local custom_alerts_timer_template="${APP_DIR}/deploy/systemd/dynasty-custom-alerts.timer.template"
+  local custom_alerts_service_name="${SERVICE_NAME}-custom-alerts"
+  local custom_alerts_service_path="/etc/systemd/system/${custom_alerts_service_name}.service"
+  local custom_alerts_timer_path="/etc/systemd/system/${custom_alerts_service_name}.timer"
+  local custom_alerts_needs_install=false
+
+  if [[ -f "${custom_alerts_service_template}" && -f "${custom_alerts_timer_template}" && "${has_cron_token}" == "true" ]]; then
+    if sudo -n "${SYSTEMCTL_BIN}" cat "${custom_alerts_service_name}.timer" >/dev/null 2>&1; then
+      if [[ "${force_install_on}" == "true" ]]; then
+        log "FORCE_SERVICE_INSTALL enabled; rewriting ${custom_alerts_service_path} + timer."
+        custom_alerts_needs_install=true
+      else
+        log "Custom-alerts timer already installed; skipping."
+      fi
+    else
+      log "Installing custom-alerts service + timer."
+      custom_alerts_needs_install=true
+    fi
+
+    if [[ "${custom_alerts_needs_install}" == "true" ]]; then
+      local tmp_custom_alerts_service tmp_custom_alerts_timer
+      tmp_custom_alerts_service="$(mktemp)"
+      tmp_custom_alerts_timer="$(mktemp)"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+        -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+        "${custom_alerts_service_template}" > "${tmp_custom_alerts_service}"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        "${custom_alerts_timer_template}" > "${tmp_custom_alerts_timer}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_custom_alerts_service}" "${custom_alerts_service_path}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_custom_alerts_timer}" "${custom_alerts_timer_path}"
+      rm -f "${tmp_custom_alerts_service}" "${tmp_custom_alerts_timer}"
+      log "Installed ${custom_alerts_service_name}.service + .timer"
+    fi
+  fi
+
   # ── daemon-reload and enable ────────────────────────────────────────────
-  if [[ "${backend_needs_install}" == "true" || "${frontend_needs_install}" == "true" || "${alerts_needs_install}" == "true" ]]; then
+  if [[ "${backend_needs_install}" == "true" || "${frontend_needs_install}" == "true" || "${alerts_needs_install}" == "true" || "${custom_alerts_needs_install}" == "true" ]]; then
     sudo -n "${SYSTEMCTL_BIN}" daemon-reload
     log "Reloaded systemd unit files."
   fi
@@ -314,6 +357,10 @@ main() {
   if [[ "${alerts_needs_install}" == "true" ]]; then
     sudo -n "${SYSTEMCTL_BIN}" enable --now "${alerts_service_name}.timer"
     log "Enabled ${alerts_service_name}.timer"
+  fi
+  if [[ "${custom_alerts_needs_install}" == "true" ]]; then
+    sudo -n "${SYSTEMCTL_BIN}" enable --now "${custom_alerts_service_name}.timer"
+    log "Enabled ${custom_alerts_service_name}.timer"
   fi
 
   # ── Backup timer + restore-test timer + logrotate (2026-04-25) ──

--- a/deploy/systemd/dynasty-custom-alerts.service.template
+++ b/deploy/systemd/dynasty-custom-alerts.service.template
@@ -1,0 +1,24 @@
+[Unit]
+Description=Dynasty Trade Calculator custom-alert sweep (__SERVICE_NAME__)
+After=network-online.target __SERVICE_NAME__.service
+Wants=network-online.target
+Requires=__SERVICE_NAME__.service
+
+# Fires the /api/custom-alerts/run endpoint, which evaluates
+# every user's custom value/rank rules and dispatches matches via
+# email and/or web push.  Same SIGNAL_ALERT_CRON_TOKEN bearer
+# auth as the signal-alerts sweep — single shared secret keeps
+# operator burden low.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+ExecStart=/usr/bin/curl --fail --silent --show-error --max-time 120 \
+  -H "Authorization: Bearer ${SIGNAL_ALERT_CRON_TOKEN}" \
+  -X POST http://127.0.0.1:8000/api/custom-alerts/run
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-custom-alerts.timer.template
+++ b/deploy/systemd/dynasty-custom-alerts.timer.template
@@ -1,0 +1,18 @@
+[Unit]
+Description=Hourly custom-alert sweep for __SERVICE_NAME__
+Requires=__SERVICE_NAME__-custom-alerts.service
+
+[Timer]
+# Fire every two hours so a value crossing or rank shift turns into
+# a notification within at most ~2h of the next scrape.  The
+# 24-hour cooldown inside ``custom_alerts.py`` prevents the same
+# rule from re-firing during a sustained crossing — a rule that
+# matches now will not match again until tomorrow even if every
+# tick of this timer hits.
+OnCalendar=*-*-* 0/2:13:00
+RandomizedDelaySec=180
+Persistent=true
+Unit=__SERVICE_NAME__-custom-alerts.service
+
+[Install]
+WantedBy=timers.target

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -10,6 +10,8 @@ import {
   detectActivePreset,
 } from "@/lib/weight-presets";
 import { RANKING_SOURCES } from "@/lib/dynasty-data";
+import PushNotificationToggle from "@/components/PushNotificationToggle";
+import CustomAlertsConfigurator from "@/components/CustomAlertsConfigurator";
 
 // The settings page enumerates the canonical ranking registry directly
 // so a newly registered source automatically shows up here without any
@@ -420,6 +422,9 @@ export default function SettingsPage() {
               roster — buy-low / sell-high opportunities, injury news, rookie or pick movement.
               We only email you when there&apos;s a change worth acting on.
             </p>
+            <div style={{ marginTop: 14, paddingTop: 12, borderTop: "1px solid var(--border)" }}>
+              <PushNotificationToggle enabled={!!serverBacked} />
+            </div>
           </>
         ) : (
           <p className="muted" style={{ fontSize: "0.78rem" }}>
@@ -427,6 +432,10 @@ export default function SettingsPage() {
             are stored on the server and apply across devices.
           </p>
         )}
+      </Section>
+
+      <Section title="Custom alerts" defaultOpen={false}>
+        <CustomAlertsConfigurator enabled={!!serverBacked} players={rows} />
       </Section>
 
       <Section title="Data & Admin" defaultOpen={false}>

--- a/frontend/components/CustomAlertsConfigurator.jsx
+++ b/frontend/components/CustomAlertsConfigurator.jsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const KIND_LABELS = {
+  value_crosses: "Value crosses threshold",
+  rank_change: "Rank moves by",
+};
+
+function genId() {
+  return `alert_${Math.random().toString(16).slice(2, 14)}`;
+}
+
+function newRule(kind = "value_crosses") {
+  if (kind === "rank_change") {
+    return {
+      id: genId(),
+      kind,
+      displayName: "",
+      params: { minDelta: 10 },
+      channels: ["email"],
+    };
+  }
+  return {
+    id: genId(),
+    kind: "value_crosses",
+    displayName: "",
+    params: { threshold: 6000, direction: "above" },
+    channels: ["email"],
+  };
+}
+
+export default function CustomAlertsConfigurator({ enabled, players }) {
+  const [rules, setRules] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [savingFor, setSavingFor] = useState(null);
+  const [status, setStatus] = useState("");
+  const [error, setError] = useState("");
+
+  const playerNames = useMemo(() => {
+    if (!Array.isArray(players)) return [];
+    return players
+      .map((p) => p?.name || p?.displayName)
+      .filter((n) => typeof n === "string" && n.length > 0)
+      .slice(0, 800);
+  }, [players]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/custom-alerts", { credentials: "include" });
+        if (!res.ok) throw new Error(`load_${res.status}`);
+        const json = await res.json();
+        if (!cancelled) {
+          setRules(Array.isArray(json?.rules) ? json.rules : []);
+        }
+      } catch (exc) {
+        if (!cancelled) setError(`Couldn't load alerts (${exc.message}).`);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  const persist = useCallback(async (next) => {
+    setError("");
+    setSavingFor("all");
+    try {
+      const res = await fetch("/api/custom-alerts", {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rules: next }),
+      });
+      if (!res.ok) {
+        let detail = "";
+        try {
+          const j = await res.json();
+          detail = j?.detail || j?.error || "";
+        } catch { /* ignore */ }
+        throw new Error(detail || `save_${res.status}`);
+      }
+      const json = await res.json();
+      setRules(Array.isArray(json?.rules) ? json.rules : []);
+      setStatus("Saved.");
+      setTimeout(() => setStatus(""), 2500);
+    } catch (exc) {
+      setError(`Couldn't save (${exc.message}).`);
+    } finally {
+      setSavingFor(null);
+    }
+  }, []);
+
+  const addRule = useCallback((kind) => {
+    setRules((prev) => [...prev, newRule(kind)]);
+  }, []);
+
+  const updateRule = useCallback((id, patch) => {
+    setRules((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  }, []);
+
+  const updateParams = useCallback((id, patch) => {
+    setRules((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, params: { ...r.params, ...patch } } : r)),
+    );
+  }, []);
+
+  const toggleChannel = useCallback((id, channel, on) => {
+    setRules((prev) =>
+      prev.map((r) => {
+        if (r.id !== id) return r;
+        const set = new Set(r.channels || ["email"]);
+        if (on) set.add(channel);
+        else set.delete(channel);
+        if (set.size === 0) set.add("email");
+        return { ...r, channels: Array.from(set) };
+      }),
+    );
+  }, []);
+
+  const removeRule = useCallback(
+    (id) => {
+      const next = rules.filter((r) => r.id !== id);
+      setRules(next);
+      persist(next);
+    },
+    [rules, persist],
+  );
+
+  const saveAll = useCallback(() => {
+    const cleaned = rules
+      .map((r) => ({ ...r, displayName: String(r.displayName || "").trim() }))
+      .filter((r) => r.displayName.length > 0);
+    persist(cleaned);
+  }, [rules, persist]);
+
+  if (!enabled) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem" }}>
+        Sign in to set up custom alerts.
+      </p>
+    );
+  }
+
+  if (loading) {
+    return <p className="muted" style={{ fontSize: "0.72rem" }}>Loading…</p>;
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <p className="muted" style={{ fontSize: "0.72rem", margin: 0 }}>
+        Watch a specific player for value crossings or rank moves. Alerts fire at most
+        once per 24 hours per (player, rule) pair, delivered via your enabled channels.
+      </p>
+
+      {rules.length === 0 ? (
+        <p className="muted" style={{ fontSize: "0.72rem", fontStyle: "italic" }}>
+          No alerts configured yet.
+        </p>
+      ) : (
+        rules.map((rule) => (
+          <div
+            key={rule.id}
+            className="card"
+            style={{
+              padding: 10,
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              border: "1px solid var(--border)",
+            }}
+          >
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+              <select
+                className="input"
+                value={rule.kind}
+                onChange={(e) => {
+                  const next = newRule(e.target.value);
+                  updateRule(rule.id, {
+                    kind: next.kind,
+                    params: next.params,
+                  });
+                }}
+                style={{ flex: "0 0 auto", fontSize: "0.78rem" }}
+              >
+                {Object.entries(KIND_LABELS).map(([k, label]) => (
+                  <option key={k} value={k}>{label}</option>
+                ))}
+              </select>
+              <input
+                className="input"
+                value={rule.displayName || ""}
+                placeholder="Player name"
+                list="brisket-custom-alerts-player-list"
+                onChange={(e) => updateRule(rule.id, { displayName: e.target.value })}
+                style={{ flex: "1 1 200px", minWidth: 160, fontSize: "0.78rem" }}
+              />
+              <button
+                className="button"
+                onClick={() => removeRule(rule.id)}
+                style={{ fontSize: "0.72rem", padding: "4px 10px" }}
+              >
+                Remove
+              </button>
+            </div>
+
+            {rule.kind === "value_crosses" && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+                <select
+                  className="input"
+                  value={rule.params?.direction || "above"}
+                  onChange={(e) => updateParams(rule.id, { direction: e.target.value })}
+                  style={{ flex: "0 0 auto", fontSize: "0.78rem" }}
+                >
+                  <option value="above">crosses above</option>
+                  <option value="below">crosses below</option>
+                </select>
+                <input
+                  type="number"
+                  className="input"
+                  value={Number(rule.params?.threshold ?? 0)}
+                  step={100}
+                  min={0}
+                  onChange={(e) =>
+                    updateParams(rule.id, { threshold: Number(e.target.value) || 0 })
+                  }
+                  style={{ flex: "0 0 110px", fontSize: "0.78rem" }}
+                />
+                <span className="muted" style={{ fontSize: "0.7rem" }}>(canonical value)</span>
+              </div>
+            )}
+
+            {rule.kind === "rank_change" && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+                <span style={{ fontSize: "0.78rem" }}>at least</span>
+                <input
+                  type="number"
+                  className="input"
+                  value={Number(rule.params?.minDelta ?? 10)}
+                  min={1}
+                  max={200}
+                  onChange={(e) =>
+                    updateParams(rule.id, { minDelta: Math.max(1, Number(e.target.value) || 1) })
+                  }
+                  style={{ flex: "0 0 80px", fontSize: "0.78rem" }}
+                />
+                <span style={{ fontSize: "0.78rem" }}>positions in either direction</span>
+              </div>
+            )}
+
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 12, alignItems: "center", fontSize: "0.78rem" }}>
+              <span className="muted" style={{ fontSize: "0.72rem" }}>Send via:</span>
+              <label style={{ display: "flex", gap: 4, alignItems: "center", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={(rule.channels || ["email"]).includes("email")}
+                  onChange={(e) => toggleChannel(rule.id, "email", e.target.checked)}
+                />
+                Email
+              </label>
+              <label style={{ display: "flex", gap: 4, alignItems: "center", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={(rule.channels || []).includes("push")}
+                  onChange={(e) => toggleChannel(rule.id, "push", e.target.checked)}
+                />
+                Push
+              </label>
+            </div>
+          </div>
+        ))
+      )}
+
+      <datalist id="brisket-custom-alerts-player-list">
+        {playerNames.map((n) => (
+          <option key={n} value={n} />
+        ))}
+      </datalist>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <button
+          className="button"
+          onClick={() => addRule("value_crosses")}
+          style={{ fontSize: "0.76rem" }}
+        >
+          + Value alert
+        </button>
+        <button
+          className="button"
+          onClick={() => addRule("rank_change")}
+          style={{ fontSize: "0.76rem" }}
+        >
+          + Rank-change alert
+        </button>
+        <button
+          className="button"
+          onClick={saveAll}
+          disabled={savingFor === "all"}
+          style={{ fontSize: "0.76rem", marginLeft: "auto" }}
+        >
+          {savingFor === "all" ? "Saving…" : "Save all"}
+        </button>
+      </div>
+
+      {status && (
+        <div className="muted" style={{ fontSize: "0.7rem", color: "var(--green)" }}>
+          {status}
+        </div>
+      )}
+      {error && (
+        <div className="muted" style={{ fontSize: "0.7rem", color: "var(--red)" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/PushNotificationToggle.jsx
+++ b/frontend/components/PushNotificationToggle.jsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  isPushSupported,
+  getCurrentSubscription,
+  subscribe,
+  unsubscribe,
+} from "@/lib/push-subscription";
+
+const SUPPORT_HINT_BY_PERMISSION = {
+  granted: "",
+  denied: "Browser denied push permission. Re-enable it in site settings to receive notifications on this device.",
+  default: "",
+};
+
+export default function PushNotificationToggle({ enabled }) {
+  const [supported, setSupported] = useState(false);
+  const [hasSub, setHasSub] = useState(false);
+  const [permission, setPermission] = useState("default");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!isPushSupported()) {
+      setSupported(false);
+      return () => {};
+    }
+    setSupported(true);
+    setPermission(typeof Notification !== "undefined" ? Notification.permission : "default");
+    (async () => {
+      try {
+        const sub = await getCurrentSubscription();
+        if (!cancelled) setHasSub(!!sub);
+      } catch {
+        if (!cancelled) setHasSub(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleEnable = useCallback(async () => {
+    setBusy(true);
+    setError("");
+    setStatus("");
+    try {
+      await subscribe();
+      setHasSub(true);
+      setPermission(Notification.permission);
+      setStatus("This device will receive push alerts.");
+      setTimeout(() => setStatus(""), 3000);
+    } catch (exc) {
+      const code = exc?.message || "unknown";
+      if (code.startsWith("permission_")) {
+        setPermission(code.replace("permission_", ""));
+        setError("Push permission was not granted.");
+      } else if (code === "public_key_unavailable_503") {
+        setError("Push isn't configured on the server yet.");
+      } else {
+        setError(`Couldn't subscribe (${code}).`);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleDisable = useCallback(async () => {
+    setBusy(true);
+    setError("");
+    setStatus("");
+    try {
+      await unsubscribe();
+      setHasSub(false);
+      setStatus("Push disabled on this device.");
+      setTimeout(() => setStatus(""), 3000);
+    } catch (exc) {
+      setError(`Couldn't unsubscribe (${exc?.message || "unknown"}).`);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  if (!supported) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem" }}>
+        This browser doesn&apos;t support web push notifications.
+      </p>
+    );
+  }
+
+  if (!enabled) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem" }}>
+        Sign in to enable push notifications.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <strong style={{ fontSize: "0.82rem" }}>Push to this device</strong>
+        {hasSub ? (
+          <button className="button" onClick={handleDisable} disabled={busy} style={{ fontSize: "0.76rem" }}>
+            {busy ? "Working…" : "Disable"}
+          </button>
+        ) : (
+          <button className="button" onClick={handleEnable} disabled={busy} style={{ fontSize: "0.76rem" }}>
+            {busy ? "Working…" : "Enable"}
+          </button>
+        )}
+      </div>
+      {status && (
+        <div className="muted" style={{ fontSize: "0.7rem", color: "var(--green)" }}>
+          {status}
+        </div>
+      )}
+      {error && (
+        <div className="muted" style={{ fontSize: "0.7rem", color: "var(--red)" }}>
+          {error}
+        </div>
+      )}
+      {SUPPORT_HINT_BY_PERMISSION[permission] && (
+        <div className="muted" style={{ fontSize: "0.68rem" }}>
+          {SUPPORT_HINT_BY_PERMISSION[permission]}
+        </div>
+      )}
+      <p className="muted" style={{ fontSize: "0.68rem", margin: 0 }}>
+        Daily digests + custom alerts arrive as system notifications. iOS requires the
+        app to be installed to your home screen; Android/desktop work in any browser tab.
+      </p>
+    </div>
+  );
+}

--- a/frontend/lib/push-subscription.js
+++ b/frontend/lib/push-subscription.js
@@ -1,0 +1,144 @@
+"use client";
+
+/**
+ * push-subscription — small client-side helper for opting into Web Push
+ *
+ * Flow when a user opts in:
+ *   1. Fetch the VAPID public key from /api/push/public-key (cached
+ *      by the SW for an hour, so this is usually a no-network call
+ *      after the first request).
+ *   2. Register the service worker if not already controlling the page.
+ *   3. Call `Notification.requestPermission()` — the browser blocks
+ *      if the user has previously denied; we surface that as an error.
+ *   4. Call `pushManager.subscribe({applicationServerKey})`.
+ *   5. POST the resulting subscription JSON to /api/push/subscribe so
+ *      the backend can target this device on the next signal alert.
+ *
+ * Opt-out is the inverse: unsubscribe locally, then POST the endpoint
+ * to /api/push/unsubscribe so we don't keep a dead record around.
+ */
+
+function urlBase64ToUint8Array(base64) {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const b64 = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(b64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) arr[i] = raw.charCodeAt(i);
+  return arr;
+}
+
+export function isPushSupported() {
+  if (typeof window === "undefined") return false;
+  return (
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+async function fetchPublicKey() {
+  const res = await fetch("/api/push/public-key", { cache: "default" });
+  if (!res.ok) throw new Error(`public_key_unavailable_${res.status}`);
+  const json = await res.json();
+  if (!json?.publicKey) throw new Error("public_key_missing");
+  return json.publicKey;
+}
+
+async function ensureRegistration() {
+  if (!("serviceWorker" in navigator)) {
+    throw new Error("service_worker_unsupported");
+  }
+  const reg =
+    (await navigator.serviceWorker.getRegistration("/")) ||
+    (await navigator.serviceWorker.register("/sw.js", { scope: "/" }));
+  await navigator.serviceWorker.ready;
+  return reg;
+}
+
+export async function getCurrentSubscription() {
+  if (!isPushSupported()) return null;
+  const reg = await navigator.serviceWorker.getRegistration("/");
+  if (!reg) return null;
+  return reg.pushManager.getSubscription();
+}
+
+export async function subscribe() {
+  if (!isPushSupported()) {
+    throw new Error("push_unsupported");
+  }
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    throw new Error(`permission_${permission}`);
+  }
+
+  const publicKey = await fetchPublicKey();
+  const reg = await ensureRegistration();
+
+  let sub = await reg.pushManager.getSubscription();
+  if (sub) {
+    const sk = sub.options?.applicationServerKey;
+    let bytes = null;
+    try {
+      bytes = sk ? new Uint8Array(sk) : null;
+    } catch {
+      bytes = null;
+    }
+    const expected = urlBase64ToUint8Array(publicKey);
+    const matches =
+      bytes &&
+      bytes.length === expected.length &&
+      bytes.every((v, i) => v === expected[i]);
+    if (!matches) {
+      try {
+        await sub.unsubscribe();
+      } catch {
+        /* ignore */
+      }
+      sub = null;
+    }
+  }
+
+  if (!sub) {
+    sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    });
+  }
+
+  const payload = sub.toJSON();
+  const ua =
+    (typeof navigator !== "undefined" && navigator.userAgent) || "";
+  const res = await fetch("/api/push/subscribe", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...payload, ua }),
+  });
+  if (!res.ok) {
+    throw new Error(`subscribe_${res.status}`);
+  }
+  return sub;
+}
+
+export async function unsubscribe() {
+  const sub = await getCurrentSubscription();
+  if (!sub) return false;
+  const endpoint = sub.endpoint;
+  try {
+    await sub.unsubscribe();
+  } catch {
+    /* ignore */
+  }
+  try {
+    await fetch("/api/push/unsubscribe", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ endpoint }),
+    });
+  } catch {
+    /* best-effort; if the network is down the server will prune on
+       its own next time the endpoint returns 404/410 */
+  }
+  return true;
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -20,9 +20,14 @@
  *     the homepage HTML ``/offline``-style shell so the user sees
  *     "You're offline" instead of Chrome's dino.
  *
+ * Push (`push` + `notificationclick`):
+ *   - On `push`, parses the JSON payload (`{title, body, url, tag}`)
+ *     and shows a notification.  Falls back to a generic title +
+ *     body if the payload is malformed (some test pushes are empty).
+ *   - On `notificationclick`, focuses an existing tab on the same
+ *     origin (the `url` field if provided) or opens a new one.
+ *
  * What this deliberately does NOT do:
- *   - Push notifications (that's a future PR once a subscription
- *     endpoint ships).
  *   - Background sync.
  *   - Cache any authenticated API endpoint.  ``/api/user/*`` and
  *     ``/api/terminal`` intentionally pass straight through so we
@@ -31,9 +36,10 @@
  * Versioning: bump ``CACHE_VERSION`` when the cache layout changes.
  * Old caches are deleted on ``activate``.
  */
-// Bumped to v2 alongside the SWR /api/public/league path so the
-// new cache layout takes effect on first re-visit.
-const CACHE_VERSION = "brisket-v2";
+// v3: push + notificationclick handlers added.  Cache layout is
+// otherwise unchanged; the bump just forces an SW activation cycle so
+// existing tabs pick up the new event listeners.
+const CACHE_VERSION = "brisket-v3";
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 const PUBLIC_LEAGUE_CACHE = `${CACHE_VERSION}-public-league`;
@@ -176,6 +182,56 @@ async function staleWhileRevalidate(request, cacheName) {
   if (fresh) return fresh;
   return offlineFallback();
 }
+
+self.addEventListener("push", (event) => {
+  let payload = {};
+  if (event.data) {
+    try {
+      payload = event.data.json();
+    } catch {
+      try {
+        payload = { title: "Brisket", body: event.data.text() };
+      } catch {
+        payload = {};
+      }
+    }
+  }
+  const title = String(payload.title || "Brisket").slice(0, 120);
+  const body = String(payload.body || "").slice(0, 300);
+  const url = typeof payload.url === "string" ? payload.url : "/";
+  const tag = typeof payload.tag === "string" ? payload.tag : undefined;
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon: "/icons/icon-192.png",
+      badge: "/icons/icon-192.png",
+      data: { url },
+      tag,
+      renotify: !!tag,
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || "/";
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+      for (const c of clients) {
+        try {
+          const u = new URL(c.url);
+          if (u.origin === self.location.origin && "focus" in c) {
+            c.navigate?.(target);
+            return c.focus();
+          }
+        } catch { /* ignore malformed client url */ }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(target);
+      }
+    }),
+  );
+});
 
 async function offlineFallback() {
   const shell = await caches.match("/");

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,13 @@ curl_cffi~=0.15.0
 # markup.
 beautifulsoup4~=4.14.0
 
+# Web Push (PWA notifications).  ``pywebpush`` handles the VAPID
+# signing + RFC8291 payload encryption; ``cryptography`` is already
+# pulled in transitively.  Used by ``src/api/push_delivery.py`` to
+# fan out the daily signal-alerts digest + custom alert hits to
+# subscribed devices.
+pywebpush~=2.0
+
 # nfl_data_py: deliberately NOT in this manifest.
 #
 # nfl_data_py 0.3.x pins pandas<2.0, which forces pandas-1.5.3 to

--- a/server.py
+++ b/server.py
@@ -67,6 +67,7 @@ from src.api.data_contract import (
 )
 from src.api import rank_history as _rank_history
 from src.api import source_history as _source_history
+from src.api import push_delivery as _push_delivery
 from src.api import signal_alerts as _signal_alerts
 from src.api import terminal as _terminal
 from src.api import trade_simulator as _trade_simulator
@@ -74,6 +75,7 @@ from src.api import user_kv as _user_kv
 from src.api import league_registry as _league_registry
 from src.api import sleeper_overlay as _sleeper_overlay
 from src.news import NewsService, build_default_service
+from src.news import custom_alerts as _custom_alerts
 
 # ── CONFIG ──────────────────────────────────────────────────────────────
 SCRAPE_INTERVAL_HOURS = 2
@@ -1831,11 +1833,14 @@ _SELF_AUTHED_API_EXACT = frozenset({
     # Same bearer-auth pattern as signal-alerts.  Bypass session
     # cookie gate so the systemd timer's curl call hits the
     # endpoint's own bearer check.
+    "/api/custom-alerts/run",
     # E2E test-session bootstrap — handles its own bearer-token auth.
     # Returns 404 unless E2E_TEST_MODE + matching bearer secret are
     # both set, so having it bypass the session gate doesn't leak
     # anything in prod (env vars aren't set there).
     "/api/test/create-session",
+    # Push public-key endpoint is read-only and stateless — no auth.
+    "/api/push/public-key",
 })
 _PUBLIC_API_PREFIXES = (
     "/api/public/league",
@@ -5784,6 +5789,254 @@ async def put_user_state_api(request: Request):
     state = await run_in_threadpool(_user_kv.merge_user_state, username, patch)
     return JSONResponse(
         content={"username": username, "state": state},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+# ── Web Push subscriptions ────────────────────────────────────────
+@app.get("/api/push/public-key")
+async def get_push_public_key():
+    """Return the VAPID public key the browser uses when calling
+    ``pushManager.subscribe({applicationServerKey})``.  Stateless,
+    no auth — the public key is, by definition, public."""
+    if not _push_delivery.is_configured():
+        return JSONResponse(
+            status_code=503,
+            content={"error": "push_not_configured"},
+            headers={"Cache-Control": "no-store"},
+        )
+    return JSONResponse(
+        content={"publicKey": _push_delivery.public_key()},
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@app.post("/api/push/subscribe")
+async def post_push_subscribe(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"error": "invalid_body"})
+    try:
+        state = await run_in_threadpool(_user_kv.get_user_state, username) or {}
+        new_subs = _push_delivery.upsert_subscription(state, body)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+    await run_in_threadpool(
+        _user_kv.set_user_field, username, "pushSubscriptions", new_subs,
+    )
+    return JSONResponse(
+        content={"ok": True, "count": len(new_subs)},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.post("/api/push/unsubscribe")
+async def post_push_unsubscribe(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    endpoint = ""
+    if isinstance(body, dict):
+        endpoint = str(body.get("endpoint") or "").strip()
+    if not endpoint:
+        return JSONResponse(status_code=400, content={"error": "endpoint_required"})
+    state = await run_in_threadpool(_user_kv.get_user_state, username) or {}
+    new_subs = _push_delivery.remove_subscription(state, endpoint)
+    await run_in_threadpool(
+        _user_kv.set_user_field, username, "pushSubscriptions", new_subs,
+    )
+    return JSONResponse(
+        content={"ok": True, "count": len(new_subs)},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+# ── Custom alerts (user-defined value/rank watchers) ──────────────
+@app.get("/api/custom-alerts")
+async def get_custom_alerts(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    state = await run_in_threadpool(_user_kv.get_user_state, username) or {}
+    rules = state.get("customAlerts") or []
+    if not isinstance(rules, list):
+        rules = []
+    return JSONResponse(
+        content={"rules": rules},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.put("/api/custom-alerts")
+async def put_custom_alerts(request: Request):
+    session = _get_auth_session(request)
+    if not session:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    username = str(session.get("username") or "").strip()
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"error": "invalid_body"})
+    raw_rules = body.get("rules")
+    if not isinstance(raw_rules, list):
+        return JSONResponse(status_code=400, content={"error": "rules_array_required"})
+    if len(raw_rules) > 50:
+        return JSONResponse(status_code=400, content={"error": "too_many_rules"})
+
+    cleaned: list[dict[str, object]] = []
+    for entry in raw_rules:
+        try:
+            cleaned.append(_custom_alerts.validate_rule(entry))
+        except ValueError as exc:
+            return JSONResponse(
+                status_code=400,
+                content={"error": "invalid_rule", "detail": str(exc)},
+            )
+
+    state = await run_in_threadpool(_user_kv.get_user_state, username) or {}
+    prior_state = state.get("customAlertsState") or {}
+    if not isinstance(prior_state, dict):
+        prior_state = {}
+    new_ids = {r["id"] for r in cleaned}
+    pruned_state = {
+        k: v for k, v in prior_state.items()
+        if isinstance(k, str) and k.split("::", 1)[0] in new_ids
+    }
+
+    await run_in_threadpool(
+        _user_kv.merge_user_state,
+        username,
+        {"customAlerts": cleaned, "customAlertsState": pruned_state},
+    )
+    return JSONResponse(
+        content={"rules": cleaned, "count": len(cleaned)},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.post("/api/custom-alerts/run")
+async def run_custom_alerts(request: Request):
+    """Cron-driven evaluator.  Walks every user's rules, fires any
+    that hit, delivers via email and/or push, updates cooldown state.
+
+    Same bearer-token auth model as ``/api/signal-alerts/run``.
+    """
+    cron_auth_ok = False
+    if SIGNAL_ALERT_CRON_TOKEN:
+        header = (request.headers.get("authorization") or "").strip()
+        if header.lower().startswith("bearer "):
+            presented = header.split(None, 1)[1].strip()
+            if hmac.compare_digest(presented, SIGNAL_ALERT_CRON_TOKEN):
+                cron_auth_ok = True
+    if not cron_auth_ok:
+        session = _get_auth_session(request)
+        if not session or session.get("auth_method") != "password":
+            return JSONResponse(
+                status_code=401, content={"error": "admin_auth_required"},
+            )
+
+    if not latest_contract_data:
+        return JSONResponse(status_code=503, content={"error": "no_live_contract"})
+    players_array = (latest_contract_data or {}).get("playersArray") or []
+
+    db = await run_in_threadpool(_user_kv.all_user_states)
+    summary: dict[str, dict[str, int]] = {}
+
+    for username, state in (db or {}).items():
+        if not isinstance(state, dict):
+            continue
+        rules = state.get("customAlerts") or []
+        if not isinstance(rules, list) or not rules:
+            continue
+        cooldown_state = state.get("customAlertsState") or {}
+        if not isinstance(cooldown_state, dict):
+            cooldown_state = {}
+
+        try:
+            hits = _custom_alerts.evaluate_alerts(
+                rules, players_array, state=cooldown_state,
+            )
+        except Exception as exc:
+            log.warning("custom-alerts evaluation failed for %s: %s", username, exc)
+            continue
+        if not hits:
+            continue
+
+        notify_email = ""
+        if isinstance(state.get("notificationsEmail"), str):
+            notify_email = state["notificationsEmail"].strip()
+
+        delivered_email = 0
+        delivered_push = 0
+        endpoints_to_prune: list[str] = []
+        new_state = dict(cooldown_state)
+
+        for hit in hits:
+            email_ok = False
+            push_ok = False
+
+            if "email" in hit.channels and notify_email:
+                try:
+                    email_ok = _deliver_email_smtp(
+                        notify_email,
+                        f"[Brisket alert] {hit.title}",
+                        f"{hit.body}\n\n— Brisket custom alert ({hit.kind})",
+                    )
+                except Exception as exc:
+                    log.warning("custom-alert email failed for %s: %s", username, exc)
+                if email_ok:
+                    delivered_email += 1
+
+            if "push" in hit.channels:
+                count, prune = _push_delivery.fanout(
+                    state,
+                    title=f"Brisket: {hit.title}",
+                    body=hit.body,
+                    url="/rankings",
+                    tag=hit.rule_id,
+                )
+                push_ok = count > 0
+                delivered_push += count
+                endpoints_to_prune.extend(prune)
+
+            if email_ok or push_ok:
+                new_state = _custom_alerts.mark_fired(new_state, hit)
+
+        patch: dict[str, object] = {}
+        if new_state != cooldown_state:
+            patch["customAlertsState"] = new_state
+        if endpoints_to_prune:
+            kept = [
+                s for s in _push_delivery.list_subscriptions(state)
+                if s.get("endpoint") not in set(endpoints_to_prune)
+            ]
+            patch["pushSubscriptions"] = kept
+        if patch:
+            await run_in_threadpool(_user_kv.merge_user_state, username, patch)
+
+        summary[username] = {
+            "hits": len(hits),
+            "email": delivered_email,
+            "push": delivered_push,
+        }
+
+    return JSONResponse(
+        content={"ok": True, "users": summary},
         headers={"Cache-Control": "no-store"},
     )
 

--- a/src/api/push_delivery.py
+++ b/src/api/push_delivery.py
@@ -1,0 +1,193 @@
+"""Web Push (PWA) delivery + per-user subscription persistence.
+
+Sits next to the existing SMTP delivery path.  A user can subscribe
+either, neither, or both — the dispatch helpers in ``server.py``
+fan out a notification through every channel a user has enabled.
+
+Storage
+───────
+Subscriptions live in ``user_kv`` under the ``pushSubscriptions`` key:
+
+    [
+      {
+        "endpoint": "https://...",
+        "keys": {"p256dh": "...", "auth": "..."},
+        "ua": "iPhone Safari",        # optional, for the UI list
+        "createdAt": "2026-04-26T..."
+      },
+      ...
+    ]
+
+A given device generates a unique ``endpoint``; we de-dup by endpoint
+on insert so re-subscribing on the same device replaces rather than
+duplicates.
+
+Sending
+───────
+``send_push(sub, title, body, url=None)`` returns True on success,
+False on transient delivery failure, and removes the subscription
+on a 404/410 (the browser explicitly told us this endpoint is dead).
+Callers walk the subscription list and prune as we go.
+
+VAPID
+─────
+Public/private keys come from the env vars ``VAPID_PUBLIC_KEY`` and
+``VAPID_PRIVATE_KEY`` (base64url-encoded raw EC P-256 keys, no PEM
+wrapping).  ``VAPID_CONTACT`` is the ``mailto:`` address browsers
+include in delivery failures.  When any of the three is missing,
+``is_configured()`` returns False and the dispatch path falls back
+to email-only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+_VAPID_PUBLIC = os.getenv("VAPID_PUBLIC_KEY", "").strip()
+_VAPID_PRIVATE = os.getenv("VAPID_PRIVATE_KEY", "").strip()
+_VAPID_CONTACT = os.getenv("VAPID_CONTACT", "").strip()
+
+
+def is_configured() -> bool:
+    return bool(_VAPID_PUBLIC and _VAPID_PRIVATE and _VAPID_CONTACT)
+
+
+def public_key() -> str:
+    return _VAPID_PUBLIC
+
+
+def _private_key_for_pywebpush() -> str:
+    """``pywebpush`` accepts the raw base64url private key string
+    directly.  We pass it through unchanged so the same value lives
+    in env, in test fixtures, and on the wire.
+    """
+    return _VAPID_PRIVATE
+
+
+_KV_KEY = "pushSubscriptions"
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def list_subscriptions(user_state: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = user_state.get(_KV_KEY)
+    if isinstance(raw, list):
+        return [s for s in raw if isinstance(s, dict) and isinstance(s.get("endpoint"), str)]
+    return []
+
+
+def upsert_subscription(
+    user_state: dict[str, Any], sub: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Add ``sub`` to the user's list, replacing any record with the
+    same endpoint.  Returns the new full list (caller persists)."""
+    endpoint = str(sub.get("endpoint") or "").strip()
+    keys = sub.get("keys") or {}
+    if not endpoint or not isinstance(keys, dict):
+        raise ValueError("subscription missing endpoint/keys")
+    if not keys.get("p256dh") or not keys.get("auth"):
+        raise ValueError("subscription keys missing p256dh/auth")
+
+    record = {
+        "endpoint": endpoint,
+        "keys": {"p256dh": str(keys["p256dh"]), "auth": str(keys["auth"])},
+        "ua": str(sub.get("ua") or "")[:120],
+        "createdAt": _utc_iso(),
+    }
+    current = list_subscriptions(user_state)
+    deduped = [s for s in current if s.get("endpoint") != endpoint]
+    deduped.append(record)
+    return deduped
+
+
+def remove_subscription(
+    user_state: dict[str, Any], endpoint: str
+) -> list[dict[str, Any]]:
+    current = list_subscriptions(user_state)
+    return [s for s in current if s.get("endpoint") != endpoint]
+
+
+_send_lock = threading.Lock()
+
+
+def send_push(
+    sub: dict[str, Any],
+    *,
+    title: str,
+    body: str,
+    url: str | None = None,
+    tag: str | None = None,
+) -> tuple[bool, bool]:
+    """Send a push notification.
+
+    Returns ``(ok, gone)``: ``ok`` is True if delivery succeeded,
+    ``gone`` is True if the browser told us the subscription is
+    permanently dead (404/410) and the caller should remove it.
+    """
+    if not is_configured():
+        return (False, False)
+    try:
+        # Lazy import: pywebpush is only loaded when push is in use.
+        from pywebpush import WebPushException, webpush
+    except Exception as exc:  # pragma: no cover
+        _LOGGER.warning("pywebpush unavailable: %s", exc)
+        return (False, False)
+
+    payload = {"title": title[:120], "body": body[:300]}
+    if url:
+        payload["url"] = url
+    if tag:
+        payload["tag"] = tag[:60]
+
+    with _send_lock:
+        try:
+            webpush(
+                subscription_info={
+                    "endpoint": sub["endpoint"],
+                    "keys": sub["keys"],
+                },
+                data=json.dumps(payload),
+                vapid_private_key=_private_key_for_pywebpush(),
+                vapid_claims={"sub": _VAPID_CONTACT},
+                ttl=60 * 60 * 24,  # 24h: align with custom-alert cooldown
+            )
+            return (True, False)
+        except WebPushException as exc:
+            status = getattr(exc.response, "status_code", 0) if exc.response else 0
+            if status in (404, 410):
+                _LOGGER.info("push subscription gone (%d) — pruning", status)
+                return (False, True)
+            _LOGGER.warning("push send failed (%s): %s", status, exc)
+            return (False, False)
+        except Exception as exc:  # pragma: no cover
+            _LOGGER.warning("push send unexpected error: %s", exc)
+            return (False, False)
+
+
+def fanout(
+    user_state: dict[str, Any],
+    *,
+    title: str,
+    body: str,
+    url: str | None = None,
+    tag: str | None = None,
+) -> tuple[int, list[str]]:
+    """Send to every subscription on this user.  Returns
+    ``(num_delivered, endpoints_to_prune)``."""
+    delivered = 0
+    to_prune: list[str] = []
+    for sub in list_subscriptions(user_state):
+        ok, gone = send_push(sub, title=title, body=body, url=url, tag=tag)
+        if ok:
+            delivered += 1
+        if gone:
+            to_prune.append(sub["endpoint"])
+    return (delivered, to_prune)

--- a/src/news/custom_alerts.py
+++ b/src/news/custom_alerts.py
@@ -1,0 +1,293 @@
+"""User-defined custom alerts.
+
+Two rule kinds are supported:
+
+* ``value_crosses`` — fires when ``rankDerivedValue`` crosses a target.
+  Direction is one of ``"above"`` or ``"below"``; the rule fires once
+  per cooldown window when the threshold is crossed in the configured
+  direction.
+* ``rank_change`` — fires when ``canonicalConsensusRank`` shifts by
+  more than N positions in either direction (``window_days`` is
+  informational only — the rank diff comes from ``rankChange`` on the
+  contract row, which the rankings pipeline already stamps).
+
+Cooldown
+────────
+Each (alertId, playerName) pair carries a ``last_fired_at`` timestamp
+in user_kv under ``customAlertsState``.  An alert that just fired
+won't fire again for ``COOLDOWN_HOURS`` (24h default), so a daily
+cron over the same payload won't send duplicates.
+
+Storage
+───────
+Rules live in user_kv under ``customAlerts``:
+
+    [
+      {
+        "id": "...",
+        "kind": "value_crosses",
+        "displayName": "Caleb Williams",
+        "params": {"threshold": 7000, "direction": "above"},
+        "channels": ["email", "push"],
+        "createdAt": "..."
+      },
+      ...
+    ]
+
+Evaluation
+──────────
+``evaluate_alerts(rules, players, now=None)`` returns ``Hit`` records
+the dispatcher should deliver.  No I/O, no email/push side effects;
+the cron handler in server.py wires those up.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+COOLDOWN_HOURS = 24
+SUPPORTED_KINDS = frozenset({"value_crosses", "rank_change"})
+SUPPORTED_CHANNELS = frozenset({"email", "push"})
+
+
+@dataclass
+class Hit:
+    rule_id: str
+    kind: str
+    display_name: str
+    title: str
+    body: str
+    state_key: str
+    channels: tuple[str, ...]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def new_rule_id() -> str:
+    return f"alert_{secrets.token_hex(6)}"
+
+
+def validate_rule(payload: Any) -> dict[str, Any]:
+    """Parse + sanitize a user-submitted rule.  Raises ValueError on
+    malformed input.  Returns the canonical rule dict ready to merge
+    into ``customAlerts``.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("rule must be an object")
+
+    kind = str(payload.get("kind") or "").strip()
+    if kind not in SUPPORTED_KINDS:
+        raise ValueError(f"unknown rule kind: {kind!r}")
+
+    name = str(payload.get("displayName") or "").strip()
+    if not name or len(name) > 80:
+        raise ValueError("displayName required (≤80 chars)")
+
+    raw_params = payload.get("params") or {}
+    if not isinstance(raw_params, dict):
+        raise ValueError("params must be an object")
+
+    if kind == "value_crosses":
+        try:
+            threshold = float(raw_params.get("threshold"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("threshold must be numeric") from exc
+        direction = str(raw_params.get("direction") or "").lower()
+        if direction not in ("above", "below"):
+            raise ValueError("direction must be 'above' or 'below'")
+        params = {"threshold": int(round(threshold)), "direction": direction}
+
+    else:  # rank_change
+        try:
+            min_delta = int(raw_params.get("minDelta") or 0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("minDelta must be an integer") from exc
+        if min_delta < 1 or min_delta > 200:
+            raise ValueError("minDelta must be between 1 and 200")
+        params = {"minDelta": min_delta}
+
+    if "channels" not in payload:
+        raw_channels = ["email"]
+    else:
+        raw_channels = payload.get("channels")
+    if isinstance(raw_channels, str):
+        raw_channels = [raw_channels]
+    if not isinstance(raw_channels, list):
+        raise ValueError("channels must be a list")
+    channels = [c for c in raw_channels if c in SUPPORTED_CHANNELS]
+    if not channels:
+        raise ValueError("at least one valid channel required (email, push)")
+
+    rule_id = str(payload.get("id") or "").strip() or new_rule_id()
+
+    return {
+        "id": rule_id,
+        "kind": kind,
+        "displayName": name,
+        "params": params,
+        "channels": channels,
+        "createdAt": payload.get("createdAt") or _iso(_utc_now()),
+    }
+
+
+def _state_key(rule_id: str, display_name: str) -> str:
+    return f"{rule_id}::{display_name.lower()}"
+
+
+def _is_cooldown(state: dict[str, Any], key: str, now: datetime) -> bool:
+    info = state.get(key) or {}
+    last = info.get("lastFiredAt")
+    if not isinstance(last, str):
+        return False
+    try:
+        last_dt = datetime.strptime(last, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc,
+        )
+    except ValueError:
+        return False
+    return now - last_dt < timedelta(hours=COOLDOWN_HOURS)
+
+
+def _row_for(players_array: list[dict[str, Any]], display_name: str) -> dict[str, Any] | None:
+    needle = display_name.strip().lower()
+    if not needle:
+        return None
+    for row in players_array:
+        if not isinstance(row, dict):
+            continue
+        candidates = (
+            row.get("displayName"),
+            row.get("canonicalName"),
+            row.get("name"),
+        )
+        for c in candidates:
+            if isinstance(c, str) and c.strip().lower() == needle:
+                return row
+    return None
+
+
+def evaluate_alerts(
+    rules: list[dict[str, Any]],
+    players_array: list[dict[str, Any]],
+    *,
+    state: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> list[Hit]:
+    """Return Hit records for every rule that fires now.
+
+    ``state`` is the user's ``customAlertsState`` map; the caller is
+    expected to update ``state[hit.state_key]["lastFiredAt"]`` after
+    a successful dispatch so the cooldown window starts.  This
+    function is pure — it does not mutate ``state``.
+    """
+    if not rules:
+        return []
+    now = now or _utc_now()
+    state = state or {}
+
+    out: list[Hit] = []
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        kind = rule.get("kind")
+        if kind not in SUPPORTED_KINDS:
+            continue
+        display_name = str(rule.get("displayName") or "").strip()
+        if not display_name:
+            continue
+        rule_id = str(rule.get("id") or "")
+        skey = _state_key(rule_id, display_name)
+        if _is_cooldown(state, skey, now):
+            continue
+
+        row = _row_for(players_array, display_name)
+        if row is None:
+            continue
+
+        params = rule.get("params") or {}
+        channels = tuple(rule.get("channels") or ["email"])
+
+        if kind == "value_crosses":
+            value = row.get("rankDerivedValue")
+            if not isinstance(value, (int, float)):
+                continue
+            threshold = int(params.get("threshold") or 0)
+            direction = str(params.get("direction") or "")
+            v = int(round(float(value)))
+            crossed = (
+                (direction == "above" and v >= threshold)
+                or (direction == "below" and v <= threshold)
+            )
+            if not crossed:
+                continue
+            arrow = "↑" if direction == "above" else "↓"
+            title = f"{display_name} {arrow} {threshold}"
+            body = f"Value is now {v:,} (threshold {threshold:,})."
+            out.append(Hit(
+                rule_id=rule_id,
+                kind=kind,
+                display_name=display_name,
+                title=title,
+                body=body,
+                state_key=skey,
+                channels=channels,
+            ))
+            continue
+
+        if kind == "rank_change":
+            change = row.get("rankChange")
+            if not isinstance(change, (int, float)):
+                continue
+            min_delta = int(params.get("minDelta") or 0)
+            if abs(int(change)) < min_delta:
+                continue
+            rank = row.get("canonicalConsensusRank")
+            arrow = "↑" if change > 0 else "↓"
+            title = f"{display_name} rank {arrow} {abs(int(change))}"
+            body_parts = [f"Rank moved {int(change):+d} positions"]
+            if isinstance(rank, int):
+                body_parts.append(f"now #{rank}")
+            out.append(Hit(
+                rule_id=rule_id,
+                kind=kind,
+                display_name=display_name,
+                title=" · ".join(body_parts[:1]),
+                body=" · ".join(body_parts) + ".",
+                state_key=skey,
+                channels=channels,
+            ))
+            continue
+
+    return out
+
+
+def mark_fired(state: dict[str, Any], hit: Hit, *, now: datetime | None = None) -> dict[str, Any]:
+    """Return a NEW state dict with ``hit.state_key`` updated to the
+    current timestamp.  Caller persists into user_kv."""
+    now = now or _utc_now()
+    new_state = dict(state)
+    new_state[hit.state_key] = {"lastFiredAt": _iso(now)}
+    return new_state
+
+
+def prune_state_for_removed_rule(
+    state: dict[str, Any], rule_id: str
+) -> dict[str, Any]:
+    """Drop cooldown entries for a deleted rule so its state_key
+    namespace doesn't accumulate forever in user_kv."""
+    return {
+        k: v for k, v in state.items()
+        if not (isinstance(k, str) and k.startswith(f"{rule_id}::"))
+    }

--- a/tests/api/test_push_delivery.py
+++ b/tests/api/test_push_delivery.py
@@ -1,0 +1,106 @@
+"""Push subscription storage + dispatch shape tests.
+
+We don't drive an actual webpush server here — we monkeypatch the
+``send_push`` function to confirm the fanout helper walks every
+subscription and forwards prune signals correctly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.api import push_delivery as pd
+
+
+def test_upsert_dedupes_by_endpoint():
+    state: dict = {}
+    sub_a = {
+        "endpoint": "https://example.com/push/a",
+        "keys": {"p256dh": "p", "auth": "a"},
+        "ua": "iPhone",
+    }
+    state["pushSubscriptions"] = pd.upsert_subscription(state, sub_a)
+    # Re-subscribing on the same endpoint should replace, not duplicate.
+    state["pushSubscriptions"] = pd.upsert_subscription(state, sub_a)
+    assert len(state["pushSubscriptions"]) == 1
+
+
+def test_upsert_appends_distinct_endpoints():
+    state: dict = {}
+    state["pushSubscriptions"] = pd.upsert_subscription(state, {
+        "endpoint": "https://example.com/push/a",
+        "keys": {"p256dh": "p1", "auth": "a1"},
+    })
+    state["pushSubscriptions"] = pd.upsert_subscription(state, {
+        "endpoint": "https://example.com/push/b",
+        "keys": {"p256dh": "p2", "auth": "a2"},
+    })
+    assert len(state["pushSubscriptions"]) == 2
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"keys": {"p256dh": "p", "auth": "a"}},                     # no endpoint
+        {"endpoint": "https://x", "keys": {}},                       # no key fields
+        {"endpoint": "https://x", "keys": {"p256dh": "p"}},          # missing auth
+        {"endpoint": "https://x"},                                    # no keys
+    ],
+)
+def test_upsert_rejects_malformed_subscription(bad):
+    with pytest.raises(ValueError):
+        pd.upsert_subscription({}, bad)
+
+
+def test_remove_subscription_filters_by_endpoint():
+    state = {"pushSubscriptions": [
+        {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
+        {"endpoint": "https://x/b", "keys": {"p256dh": "p", "auth": "a"}},
+    ]}
+    new = pd.remove_subscription(state, "https://x/a")
+    assert [s["endpoint"] for s in new] == ["https://x/b"]
+
+
+def test_list_subscriptions_filters_invalid_records():
+    state = {"pushSubscriptions": [
+        {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
+        "not-a-dict",
+        {"endpoint": None, "keys": {}},
+    ]}
+    out = pd.list_subscriptions(state)
+    assert len(out) == 1
+    assert out[0]["endpoint"] == "https://x/a"
+
+
+def test_fanout_walks_every_subscription_and_collects_prunes(monkeypatch):
+    state = {"pushSubscriptions": [
+        {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
+        {"endpoint": "https://x/b", "keys": {"p256dh": "p", "auth": "a"}},
+        {"endpoint": "https://x/c", "keys": {"p256dh": "p", "auth": "a"}},
+    ]}
+
+    def fake_send(sub, **_):
+        if sub["endpoint"].endswith("a"):
+            return (True, False)
+        if sub["endpoint"].endswith("b"):
+            return (False, True)  # gone — prune
+        return (False, False)
+
+    monkeypatch.setattr(pd, "send_push", fake_send)
+
+    delivered, prune = pd.fanout(state, title="t", body="b", url="/")
+    assert delivered == 1
+    assert prune == ["https://x/b"]
+
+
+def test_is_configured_false_when_env_missing(monkeypatch):
+    monkeypatch.setattr(pd, "_VAPID_PUBLIC", "")
+    monkeypatch.setattr(pd, "_VAPID_PRIVATE", "x")
+    monkeypatch.setattr(pd, "_VAPID_CONTACT", "mailto:x")
+    assert not pd.is_configured()
+
+
+def test_is_configured_true_when_all_three_set(monkeypatch):
+    monkeypatch.setattr(pd, "_VAPID_PUBLIC", "pub")
+    monkeypatch.setattr(pd, "_VAPID_PRIVATE", "priv")
+    monkeypatch.setattr(pd, "_VAPID_CONTACT", "mailto:test@example.com")
+    assert pd.is_configured()

--- a/tests/news/test_custom_alerts.py
+++ b/tests/news/test_custom_alerts.py
@@ -1,0 +1,190 @@
+"""Custom-alert rule validation, evaluation, and cooldown tests."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.news import custom_alerts as ca
+
+
+def test_validate_value_crosses_rule():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Caleb Williams",
+        "params": {"threshold": 7000, "direction": "above"},
+    })
+    assert rule["kind"] == "value_crosses"
+    assert rule["displayName"] == "Caleb Williams"
+    assert rule["params"] == {"threshold": 7000, "direction": "above"}
+    assert rule["channels"] == ["email"]
+    assert rule["id"].startswith("alert_")
+
+
+def test_validate_rank_change_rule():
+    rule = ca.validate_rule({
+        "kind": "rank_change",
+        "displayName": "Bo Nix",
+        "params": {"minDelta": 10},
+        "channels": ["email", "push"],
+    })
+    assert rule["params"] == {"minDelta": 10}
+    assert set(rule["channels"]) == {"email", "push"}
+
+
+@pytest.mark.parametrize(
+    "payload,detail_part",
+    [
+        ({"kind": "bogus", "displayName": "X"}, "unknown rule kind"),
+        ({"kind": "value_crosses"}, "displayName"),
+        ({"kind": "value_crosses", "displayName": "X"}, "threshold"),
+        (
+            {"kind": "value_crosses", "displayName": "X",
+             "params": {"threshold": 1, "direction": "sideways"}},
+            "direction",
+        ),
+        ({"kind": "rank_change", "displayName": "X"}, "minDelta"),
+        (
+            {"kind": "rank_change", "displayName": "X",
+             "params": {"minDelta": 10}, "channels": []},
+            "channel",
+        ),
+    ],
+)
+def test_validate_rejects_bad_input(payload, detail_part):
+    with pytest.raises(ValueError) as exc:
+        ca.validate_rule(payload)
+    assert detail_part.lower() in str(exc.value).lower()
+
+
+def _fake_player(name="Test Player", *, value=6000, rank_change=0, rank=50):
+    return {
+        "displayName": name,
+        "rankDerivedValue": value,
+        "canonicalConsensusRank": rank,
+        "rankChange": rank_change,
+    }
+
+
+def test_value_crosses_above_fires_when_value_meets_threshold():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Caleb",
+        "params": {"threshold": 5000, "direction": "above"},
+    })
+    hits = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=6000)])
+    assert len(hits) == 1
+    assert hits[0].kind == "value_crosses"
+    assert "↑" in hits[0].title
+
+
+def test_value_crosses_above_silent_when_below_threshold():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Caleb",
+        "params": {"threshold": 7000, "direction": "above"},
+    })
+    hits = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=6000)])
+    assert hits == []
+
+
+def test_value_crosses_below_fires_when_value_drops_under_threshold():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Bo",
+        "params": {"threshold": 4000, "direction": "below"},
+    })
+    hits = ca.evaluate_alerts([rule], [_fake_player("Bo", value=3500)])
+    assert len(hits) == 1
+    assert "↓" in hits[0].title
+
+
+def test_rank_change_fires_when_delta_meets_threshold():
+    rule = ca.validate_rule({
+        "kind": "rank_change",
+        "displayName": "Drake",
+        "params": {"minDelta": 5},
+    })
+    hits = ca.evaluate_alerts([rule], [_fake_player("Drake", rank_change=-7)])
+    assert len(hits) == 1
+    assert hits[0].kind == "rank_change"
+
+
+def test_rank_change_silent_when_movement_below_threshold():
+    rule = ca.validate_rule({
+        "kind": "rank_change",
+        "displayName": "Drake",
+        "params": {"minDelta": 10},
+    })
+    hits = ca.evaluate_alerts([rule], [_fake_player("Drake", rank_change=3)])
+    assert hits == []
+
+
+def test_cooldown_suppresses_recent_fire():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Caleb",
+        "params": {"threshold": 5000, "direction": "above"},
+    })
+    # 1 hour ago → still in 24h cooldown.
+    last_iso = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ",
+    )
+    skey = f"{rule['id']}::caleb"
+    state = {skey: {"lastFiredAt": last_iso}}
+    hits = ca.evaluate_alerts(
+        [rule], [_fake_player("Caleb", value=6000)], state=state,
+    )
+    assert hits == []
+
+
+def test_cooldown_lifts_after_24h():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Caleb",
+        "params": {"threshold": 5000, "direction": "above"},
+    })
+    # 25 hours ago → cooldown elapsed.
+    last_iso = (datetime.now(timezone.utc) - timedelta(hours=25)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ",
+    )
+    skey = f"{rule['id']}::caleb"
+    state = {skey: {"lastFiredAt": last_iso}}
+    hits = ca.evaluate_alerts(
+        [rule], [_fake_player("Caleb", value=6000)], state=state,
+    )
+    assert len(hits) == 1
+
+
+def test_mark_fired_records_timestamp_under_state_key():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Caleb",
+        "params": {"threshold": 5000, "direction": "above"},
+    })
+    [hit] = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=6000)])
+    new_state = ca.mark_fired({}, hit)
+    assert hit.state_key in new_state
+    assert "lastFiredAt" in new_state[hit.state_key]
+
+
+def test_prune_state_drops_only_matching_rule_id():
+    other = "alert_keepme"
+    rule_id = "alert_drop"
+    state = {
+        f"{rule_id}::caleb": {"lastFiredAt": "2026-01-01T00:00:00Z"},
+        f"{other}::bo": {"lastFiredAt": "2026-01-02T00:00:00Z"},
+    }
+    pruned = ca.prune_state_for_removed_rule(state, rule_id)
+    assert f"{other}::bo" in pruned
+    assert f"{rule_id}::caleb" not in pruned
+
+
+def test_unknown_player_does_not_fire():
+    rule = ca.validate_rule({
+        "kind": "value_crosses",
+        "displayName": "Phantom",
+        "params": {"threshold": 1, "direction": "above"},
+    })
+    hits = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=9999)])
+    assert hits == []


### PR DESCRIPTION
## Summary
- Two opt-in notification surfaces, both server-backed via `user_kv` so prefs follow the user across devices.
- **Web Push (PWA)**: `/api/push/{public-key,subscribe,unsubscribe}` + SW push/notificationclick handlers + `frontend/lib/push-subscription.js`. Backed by `pywebpush` + VAPID keypair (VAPID_PUBLIC_KEY/VAPID_PRIVATE_KEY/VAPID_CONTACT in `.env`); falls back to email-only when unset.
- **Custom alerts**: per-user rules of two kinds — `value_crosses` (rankDerivedValue ≷ threshold) and `rank_change` (|rankChange| ≥ minDelta). Email and/or push delivery, 24h cooldown per (rule, player). Configurator under `/settings`; cron evaluator at `POST /api/custom-alerts/run` (same bearer-token auth as signal-alerts) with a `dynasty-custom-alerts` systemd timer firing every 2 hours.

## Test plan
- [x] `pytest tests/news/test_custom_alerts.py tests/api/test_push_delivery.py` — 29 passed
- [x] full `pytest tests/` — 2392 passed (2 pre-existing data-quality failures: launch-readiness quarantined count 6 vs threshold 5; unrelated)
- [x] `npm run build` — settings page 34.6 KB / 35 KB budget, all pages under budget
- [ ] Production: set VAPID keys in `.env`, restart services, verify subscribe → POST `/api/push/subscribe` round-trips
- [ ] Production: configure a test alert on `/settings`, run `curl -X POST /api/custom-alerts/run` with bearer, verify delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)