### PR TITLE
feat: roster comparison on /league/franchise pages

### DIFF
--- a/frontend/__tests__/roster-compare.test.js
+++ b/frontend/__tests__/roster-compare.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  POSITION_FAMILIES,
+  familyForPos,
+  buildValueIndex,
+  totalsByFamily,
+  grandTotal,
+} from "@/lib/roster-compare";
+
+describe("familyForPos", () => {
+  it("maps offense positions to their family", () => {
+    expect(familyForPos("QB")).toBe("QB");
+    expect(familyForPos("RB")).toBe("RB");
+    expect(familyForPos("FB")).toBe("RB");
+    expect(familyForPos("WR")).toBe("WR");
+    expect(familyForPos("TE")).toBe("TE");
+  });
+
+  it("maps IDP variants to their family", () => {
+    expect(familyForPos("DT")).toBe("DL");
+    expect(familyForPos("EDGE")).toBe("DL");
+    expect(familyForPos("ILB")).toBe("LB");
+    expect(familyForPos("CB")).toBe("DB");
+    expect(familyForPos("FS")).toBe("DB");
+  });
+
+  it("returns null for unknown positions", () => {
+    expect(familyForPos("K")).toBe(null);
+    expect(familyForPos("DEF")).toBe(null);
+    expect(familyForPos("")).toBe(null);
+    expect(familyForPos(null)).toBe(null);
+  });
+
+  it("is case-insensitive", () => {
+    expect(familyForPos("qb")).toBe("QB");
+    expect(familyForPos("edge")).toBe("DL");
+  });
+});
+
+describe("buildValueIndex", () => {
+  it("indexes rows by lowercase name", () => {
+    const ix = buildValueIndex([
+      { name: "Caleb Williams", pos: "QB", rankDerivedValue: 6500 },
+      { name: "Bo Nix", pos: "QB", rankDerivedValue: 4000 },
+    ]);
+    expect(ix.size).toBe(2);
+    expect(ix.get("caleb williams").value).toBe(6500);
+    expect(ix.get("bo nix").pos).toBe("QB");
+  });
+
+  it("falls back to values.full when rankDerivedValue is absent", () => {
+    const ix = buildValueIndex([
+      { name: "X", pos: "WR", values: { full: 3000 } },
+    ]);
+    expect(ix.get("x").value).toBe(3000);
+  });
+
+  it("coerces non-finite values to 0", () => {
+    const ix = buildValueIndex([
+      { name: "X", pos: "WR", rankDerivedValue: "garbage" },
+    ]);
+    expect(ix.get("x").value).toBe(0);
+  });
+
+  it("skips rows with empty names", () => {
+    const ix = buildValueIndex([
+      { name: "", pos: "QB", rankDerivedValue: 1 },
+      { name: null, pos: "QB", rankDerivedValue: 2 },
+    ]);
+    expect(ix.size).toBe(0);
+  });
+});
+
+describe("totalsByFamily", () => {
+  const ix = buildValueIndex([
+    { name: "QB1", pos: "QB", rankDerivedValue: 7000 },
+    { name: "QB2", pos: "QB", rankDerivedValue: 4500 },
+    { name: "RB1", pos: "RB", rankDerivedValue: 6000 },
+    { name: "WR1", pos: "WR", rankDerivedValue: 8000 },
+    { name: "EDGE1", pos: "EDGE", rankDerivedValue: 3000 },
+    { name: "LB1", pos: "ILB", rankDerivedValue: 2000 },
+    { name: "K1", pos: "K", rankDerivedValue: 500 },
+  ]);
+
+  it("sums values per family with counts", () => {
+    const totals = totalsByFamily(
+      ["QB1", "QB2", "RB1", "WR1", "EDGE1", "LB1"],
+      ix,
+    );
+    expect(totals.QB).toEqual({ total: 11500, count: 2 });
+    expect(totals.RB).toEqual({ total: 6000, count: 1 });
+    expect(totals.WR).toEqual({ total: 8000, count: 1 });
+    expect(totals.DL).toEqual({ total: 3000, count: 1 });
+    expect(totals.LB).toEqual({ total: 2000, count: 1 });
+  });
+
+  it("ignores positions outside the recognised families", () => {
+    const totals = totalsByFamily(["K1"], ix);
+    expect(totals.QB.count).toBe(0);
+    expect(totals.WR.count).toBe(0);
+    // K → no family, so doesn't appear anywhere
+    for (const f of Object.values(totals)) expect(f.count).toBe(0);
+  });
+
+  it("returns zeros for an empty roster", () => {
+    const totals = totalsByFamily([], ix);
+    for (const f of POSITION_FAMILIES) {
+      expect(totals[f.key]).toEqual({ total: 0, count: 0 });
+    }
+  });
+
+  it("ignores names not present in the index", () => {
+    const totals = totalsByFamily(["nobody"], ix);
+    for (const f of POSITION_FAMILIES) {
+      expect(totals[f.key].count).toBe(0);
+    }
+  });
+
+  it("is case-insensitive when matching player names", () => {
+    const totals = totalsByFamily(["qb1"], ix);
+    expect(totals.QB.count).toBe(1);
+    expect(totals.QB.total).toBe(7000);
+  });
+});
+
+describe("grandTotal", () => {
+  it("sums every family's total", () => {
+    const sum = grandTotal({
+      QB: { total: 100, count: 1 },
+      RB: { total: 200, count: 2 },
+      WR: { total: 300, count: 3 },
+    });
+    expect(sum).toBe(600);
+  });
+
+  it("handles missing or malformed families gracefully", () => {
+    expect(grandTotal({})).toBe(0);
+    expect(grandTotal(null)).toBe(0);
+    expect(grandTotal({ QB: null, RB: { total: 5 } })).toBe(5);
+  });
+});

--- a/frontend/app/league/franchise/[owner]/page.jsx
+++ b/frontend/app/league/franchise/[owner]/page.jsx
@@ -9,6 +9,7 @@ import { Avatar, Card, Stat } from "../../shared-server.jsx";
 import { buildManagerLookup, fmtNumber } from "../../shared-helpers.js";
 import { EmptyState, PageHeader } from "@/components/ui";
 import ShareButton from "../../ShareButton.jsx";
+import RosterComparePanel from "@/components/RosterComparePanel";
 
 function _backend() {
   const base = process.env.BACKEND_API_URL || "http://127.0.0.1:8000";
@@ -124,6 +125,10 @@ export default async function FranchisePage({ params }) {
           </div>
         </div>
       </div>
+
+      <Card title="Compare to my roster">
+        <RosterComparePanel ownerId={ownerId} />
+      </Card>
 
       <Card title="Cumulative">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>

--- a/frontend/components/RosterComparePanel.jsx
+++ b/frontend/components/RosterComparePanel.jsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useDynastyData } from "@/components/useDynastyData";
+import { useUserState } from "@/components/useUserState";
+import {
+  POSITION_FAMILIES,
+  buildValueIndex,
+  totalsByFamily,
+  grandTotal,
+} from "@/lib/roster-compare";
+
+function fmtValue(v) {
+  if (!Number.isFinite(v)) return "—";
+  return Math.round(v).toLocaleString();
+}
+
+function fmtDelta(v) {
+  if (!Number.isFinite(v)) return "—";
+  const n = Math.round(v);
+  if (n === 0) return "·";
+  return n > 0 ? `+${n.toLocaleString()}` : n.toLocaleString();
+}
+
+export default function RosterComparePanel({ ownerId }) {
+  const { rows, rawData, loading } = useDynastyData();
+  const { state: userState } = useUserState();
+  const [open, setOpen] = useState(false);
+
+  const myOwnerId = userState?.selectedTeam?.ownerId
+    ? String(userState.selectedTeam.ownerId)
+    : null;
+  const sameAsSelf = myOwnerId && String(ownerId) === myOwnerId;
+
+  const compare = useMemo(() => {
+    if (!rawData?.sleeper?.teams || !Array.isArray(rawData.sleeper.teams)) return null;
+    const teams = rawData.sleeper.teams;
+    const themTeam = teams.find((t) => String(t?.ownerId) === String(ownerId));
+    const meTeam = myOwnerId
+      ? teams.find((t) => String(t?.ownerId) === myOwnerId)
+      : null;
+    if (!themTeam || !meTeam) return null;
+
+    const valueIndex = buildValueIndex(rows);
+    const themTotals = totalsByFamily(themTeam.players, valueIndex);
+    const meTotals = totalsByFamily(meTeam.players, valueIndex);
+
+    const themGrand = grandTotal(themTotals);
+    const meGrand = grandTotal(meTotals);
+
+    return {
+      themName: themTeam.name || "Their team",
+      meName: meTeam.name || "Your team",
+      themTotals,
+      meTotals,
+      themGrand,
+      meGrand,
+    };
+  }, [rawData, rows, ownerId, myOwnerId]);
+
+  if (sameAsSelf) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem", margin: "8px 0" }}>
+        This is your own franchise — nothing to compare against.
+      </p>
+    );
+  }
+
+  if (loading) {
+    return <p className="muted" style={{ fontSize: "0.72rem" }}>Loading rosters…</p>;
+  }
+
+  if (!myOwnerId) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem", margin: "8px 0" }}>
+        Pick your team on the league page to compare against this franchise.
+      </p>
+    );
+  }
+
+  if (!compare) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem", margin: "8px 0" }}>
+        Roster comparison unavailable — neither team is in the active league&apos;s Sleeper data.
+      </p>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button className="button" onClick={() => setOpen(true)} style={{ fontSize: "0.78rem" }}>
+        Compare to my roster
+      </button>
+    );
+  }
+
+  const grandDelta = compare.meGrand - compare.themGrand;
+  const grandColor = grandDelta > 0 ? "var(--green)" : grandDelta < 0 ? "var(--red)" : "var(--text)";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <strong style={{ fontSize: "0.84rem" }}>Roster comparison</strong>
+        <button
+          className="button"
+          onClick={() => setOpen(false)}
+          style={{ fontSize: "0.7rem", padding: "2px 8px" }}
+        >
+          Hide
+        </button>
+        <span className="muted" style={{ fontSize: "0.7rem" }}>
+          (consensus value totals, by position family)
+        </span>
+      </div>
+
+      <div className="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Position</th>
+              <th style={{ textAlign: "right" }}>{compare.meName}</th>
+              <th style={{ textAlign: "right" }}>{compare.themName}</th>
+              <th style={{ textAlign: "right" }}>Net (you − them)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {POSITION_FAMILIES.map((f) => {
+              const me = compare.meTotals[f.key];
+              const them = compare.themTotals[f.key];
+              if (me.count === 0 && them.count === 0) return null;
+              const delta = me.total - them.total;
+              const color = delta > 0 ? "var(--green)" : delta < 0 ? "var(--red)" : "var(--text)";
+              return (
+                <tr key={f.key}>
+                  <td style={{ fontWeight: 600 }}>{f.label}</td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {fmtValue(me.total)}{" "}
+                    <span className="muted" style={{ fontSize: "0.66rem" }}>
+                      ({me.count})
+                    </span>
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {fmtValue(them.total)}{" "}
+                    <span className="muted" style={{ fontSize: "0.66rem" }}>
+                      ({them.count})
+                    </span>
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)", color }}>
+                    {fmtDelta(delta)}
+                  </td>
+                </tr>
+              );
+            })}
+            <tr style={{ borderTop: "2px solid var(--border)" }}>
+              <td style={{ fontWeight: 700 }}>Total</td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)", fontWeight: 700 }}>
+                {fmtValue(compare.meGrand)}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)", fontWeight: 700 }}>
+                {fmtValue(compare.themGrand)}
+              </td>
+              <td
+                style={{
+                  textAlign: "right",
+                  fontFamily: "var(--mono)",
+                  fontWeight: 700,
+                  color: grandColor,
+                }}
+              >
+                {fmtDelta(grandDelta)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p className="muted" style={{ fontSize: "0.66rem", margin: 0 }}>
+        Totals sum <code>rankDerivedValue</code> across each team&apos;s current Sleeper roster.
+        A positive net means your roster carries more consensus value at that position family.
+      </p>
+    </div>
+  );
+}

--- a/frontend/lib/roster-compare.js
+++ b/frontend/lib/roster-compare.js
@@ -1,0 +1,61 @@
+/**
+ * roster-compare — pure helpers for the franchise-page comparison panel.
+ *
+ * Kept in lib (not the JSX component) so the totals math can be unit-
+ * tested without rendering React.  Bucket assignment matches the
+ * backend's family map in src/trade/waiver.py — a single source of
+ * truth for "which positions roll up to which family."
+ */
+
+export const POSITION_FAMILIES = Object.freeze([
+  { key: "QB", label: "QB", positions: ["QB"] },
+  { key: "RB", label: "RB", positions: ["RB", "FB"] },
+  { key: "WR", label: "WR", positions: ["WR"] },
+  { key: "TE", label: "TE", positions: ["TE"] },
+  { key: "DL", label: "DL", positions: ["DL", "DT", "DE", "EDGE", "NT"] },
+  { key: "LB", label: "LB", positions: ["LB", "ILB", "OLB", "MLB"] },
+  { key: "DB", label: "DB", positions: ["DB", "CB", "S", "FS", "SS"] },
+]);
+
+export function familyForPos(pos) {
+  const p = String(pos || "").toUpperCase();
+  for (const f of POSITION_FAMILIES) {
+    if (f.positions.includes(p)) return f.key;
+  }
+  return null;
+}
+
+export function buildValueIndex(rows) {
+  const ix = new Map();
+  for (const r of rows || []) {
+    const name = String(r?.name || "").toLowerCase();
+    if (!name) continue;
+    const value = Number(r?.rankDerivedValue || r?.values?.full || 0);
+    const pos = String(r?.pos || "").toUpperCase();
+    ix.set(name, { value: Number.isFinite(value) ? value : 0, pos });
+  }
+  return ix;
+}
+
+export function totalsByFamily(playerNames, valueIndex) {
+  const totals = Object.fromEntries(
+    POSITION_FAMILIES.map((f) => [f.key, { total: 0, count: 0 }]),
+  );
+  for (const name of playerNames || []) {
+    const entry = valueIndex.get(String(name).toLowerCase());
+    if (!entry) continue;
+    const fam = familyForPos(entry.pos);
+    if (!fam) continue;
+    totals[fam].total += entry.value;
+    totals[fam].count += 1;
+  }
+  return totals;
+}
+
+export function grandTotal(byFamily) {
+  let sum = 0;
+  for (const fam of Object.values(byFamily || {})) {
+    sum += fam?.total || 0;
+  }
+  return sum;
+}


### PR DESCRIPTION
## Summary
- Adds a "Compare to my roster" panel to every franchise detail page (`/league/franchise/[owner]`).
- Tallies `rankDerivedValue` per position family (QB/RB/WR/TE/DL/LB/DB) for both rosters and shows a per-family + grand-total net advantage column.
- Pure helpers extracted to `frontend/lib/roster-compare.js` so the math is unit-testable; JSX wrapper handles state + render only.
- Visiting your own franchise gracefully shows "this is your own franchise" instead of a zero-delta self-compare.

## Test plan
- [x] `npm test __tests__/roster-compare.test.js` — 15 cases pass (position families, value index, totals, grand totals)
- [x] `npm run build` — all pages under budget, no new warnings
- [ ] Production: visit `/league/franchise/<other-owner>` while signed in with a selectedTeam, click "Compare to my roster", verify totals look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)