### PR TITLE
fix: refetch dynasty data + user state after sign-in

### DIFF
--- a/frontend/components/useAuth.js
+++ b/frontend/components/useAuth.js
@@ -102,6 +102,17 @@ export function useAuth() {
   const onLoginSuccess = useCallback(() => {
     sessionStorage.setItem(AUTH_CHECK_KEY, "true");
     setAuthenticated(true);
+    // Notify data hooks (useDynastyData, useUserState) so any cached
+    // 401 error state from before sign-in clears immediately instead
+    // of requiring a full page reload.  Listened for in
+    // ``useDynastyData`` and ``useUserState``.
+    if (typeof window !== "undefined") {
+      try {
+        window.dispatchEvent(new Event("auth:changed"));
+      } catch {
+        /* old browsers without Event constructor — ignore */
+      }
+    }
   }, []);
 
   return { authenticated, checking, logout, onLoginSuccess };

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -53,12 +53,19 @@ export function useDynastyData() {
   const [leagueRefreshKey, setLeagueRefreshKey] = useState(0);
 
   useEffect(() => {
-    function onLeagueChanged() {
+    function bump() {
       setLeagueRefreshKey((v) => v + 1);
     }
     if (typeof window === "undefined") return undefined;
-    window.addEventListener("league:changed", onLeagueChanged);
-    return () => window.removeEventListener("league:changed", onLeagueChanged);
+    // ``auth:changed`` fires from ``useAuth.onLoginSuccess`` so a
+    // post-401 sign-in immediately re-fires the data fetch instead of
+    // leaving the page stuck on the cached "Sign-in required" error.
+    window.addEventListener("league:changed", bump);
+    window.addEventListener("auth:changed", bump);
+    return () => {
+      window.removeEventListener("league:changed", bump);
+      window.removeEventListener("auth:changed", bump);
+    };
   }, []);
 
   useEffect(() => {

--- a/frontend/components/useUserState.js
+++ b/frontend/components/useUserState.js
@@ -247,8 +247,17 @@ export function useUserState() {
     };
   }, []);
 
+  const [authBump, setAuthBump] = useState(0);
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const onAuth = () => setAuthBump((v) => v + 1);
+    window.addEventListener("auth:changed", onAuth);
+    return () => window.removeEventListener("auth:changed", onAuth);
+  }, []);
+
   useEffect(() => {
     mounted.current = true;
+    setLoading(true);
     fetchServerState()
       .then((server) => {
         if (!mounted.current) return;
@@ -288,7 +297,7 @@ export function useUserState() {
     return () => {
       mounted.current = false;
     };
-  }, []);
+  }, [authBump]);
 
   // Mutators — write-through to local + server.
   const persist = useCallback(async (nextState, serverPatch) => {


### PR DESCRIPTION
## Summary
- Fixes the bug surfaced just now where signing in on the login page doesn't clear the cached "Sign-in required" error on `/trades` (and any other page using `useDynastyData`/`useUserState`) — the effect dep array doesn't include any auth signal, so the post-401 state was sticky until a manual reload.

## Fix
- `useAuth.onLoginSuccess` now dispatches `auth:changed` on the window, mirroring the existing `league:changed` pattern.
- `useDynastyData` and `useUserState` listen for it and re-fire their fetches.

## Test plan
- [x] `npm run build` clean
- [ ] Production: visit `/trades` while signed out, confirm 401 error renders, sign in via Sleeper, confirm page recovers without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)