### PR TITLE
feat: trending page + clickable news chips + per-source freshness

### DIFF
--- a/frontend/__tests__/movers.test.js
+++ b/frontend/__tests__/movers.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeMovers,
+  filterByFamily,
+  familyOf,
+  fmtDelta,
+  WINDOW_OPTIONS,
+} from "@/lib/movers";
+
+function row({
+  name,
+  pos = "WR",
+  rankChange = 0,
+  rankHistory = null,
+  rankDerivedValue = 5000,
+  rank = 50,
+}) {
+  return {
+    name,
+    pos,
+    rankChange,
+    rankHistory,
+    rankDerivedValue,
+    canonicalConsensusRank: rank,
+    teamAbbr: "BUF",
+  };
+}
+
+describe("familyOf", () => {
+  it("maps offense + IDP variants", () => {
+    expect(familyOf("QB")).toBe("QB");
+    expect(familyOf("FB")).toBe("RB");
+    expect(familyOf("EDGE")).toBe("DL");
+    expect(familyOf("ILB")).toBe("LB");
+    expect(familyOf("CB")).toBe("DB");
+  });
+
+  it("returns OTHER for unknown positions", () => {
+    expect(familyOf("XYZ")).toBe("OTHER");
+    expect(familyOf("")).toBe("OTHER");
+  });
+});
+
+describe("computeMovers — 1-day window uses rankChange", () => {
+  it("returns rows sorted by absolute delta desc", () => {
+    const rows = [
+      row({ name: "Small", rankChange: 1 }),
+      row({ name: "Big", rankChange: -10 }),
+      row({ name: "Mid", rankChange: 5 }),
+    ];
+    const out = computeMovers(rows, { windowDays: 1 });
+    expect(out.map((m) => m.name)).toEqual(["Big", "Mid", "Small"]);
+  });
+
+  it("filters zero/null rankChange rows", () => {
+    const rows = [
+      row({ name: "Zero", rankChange: 0 }),
+      row({ name: "Null", rankChange: null }),
+      row({ name: "Real", rankChange: 3 }),
+    ];
+    const out = computeMovers(rows, { windowDays: 1 });
+    expect(out.map((m) => m.name)).toEqual(["Real"]);
+  });
+
+  it("respects gainers/losers direction", () => {
+    const rows = [
+      row({ name: "Up", rankChange: 5 }),
+      row({ name: "Down", rankChange: -7 }),
+    ];
+    expect(computeMovers(rows, { windowDays: 1, direction: "gainers" }).map((m) => m.name))
+      .toEqual(["Up"]);
+    expect(computeMovers(rows, { windowDays: 1, direction: "losers" }).map((m) => m.name))
+      .toEqual(["Down"]);
+  });
+
+  it("breaks ties by higher value", () => {
+    const rows = [
+      row({ name: "LowVal", rankChange: 5, rankDerivedValue: 1000 }),
+      row({ name: "HighVal", rankChange: 5, rankDerivedValue: 9000 }),
+    ];
+    const out = computeMovers(rows, { windowDays: 1 });
+    expect(out[0].name).toBe("HighVal");
+  });
+
+  it("respects limit", () => {
+    const rows = Array.from({ length: 50 }, (_, i) =>
+      row({ name: `P${i}`, rankChange: i + 1 }),
+    );
+    expect(computeMovers(rows, { windowDays: 1, limit: 5 })).toHaveLength(5);
+  });
+});
+
+describe("computeMovers — multi-day window uses rankHistory", () => {
+  it("uses computeWindowTrend when windowDays > 1", () => {
+    const today = new Date();
+    const iso = (offset) => {
+      const d = new Date(today);
+      d.setDate(d.getDate() - offset);
+      return d.toISOString().slice(0, 10);
+    };
+    const rows = [
+      row({
+        name: "Climber",
+        rankChange: 1, // ignored when windowDays > 1
+        rankHistory: [
+          { date: iso(6), rank: 60 },
+          { date: iso(0), rank: 50 },
+        ],
+      }),
+    ];
+    const out = computeMovers(rows, { windowDays: 7 });
+    expect(out).toHaveLength(1);
+    expect(out[0].delta).toBe(10); // improved by 10
+  });
+});
+
+describe("filterByFamily", () => {
+  const movers = [
+    { name: "qb", family: "QB" },
+    { name: "edge", family: "DL" },
+    { name: "wr", family: "WR" },
+  ];
+  it("passes through ALL", () => {
+    expect(filterByFamily(movers, "ALL")).toHaveLength(3);
+  });
+  it("filters by family key", () => {
+    expect(filterByFamily(movers, "DL").map((m) => m.name)).toEqual(["edge"]);
+  });
+});
+
+describe("fmtDelta", () => {
+  it("formats with sign + dot for zero", () => {
+    expect(fmtDelta(5)).toBe("+5");
+    expect(fmtDelta(-7)).toBe("-7");
+    expect(fmtDelta(0)).toBe("·");
+    expect(fmtDelta(null)).toBe("—");
+    expect(fmtDelta(NaN)).toBe("—");
+  });
+});
+
+it("WINDOW_OPTIONS exposes 1d/7d/30d", () => {
+  expect(WINDOW_OPTIONS.map((w) => w.key)).toEqual(["1d", "7d", "30d"]);
+});

--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -35,6 +35,7 @@ import LeagueSwitcher from "@/components/LeagueSwitcher";
 // ``href`` (sensible default) — the dropdown surfaces the siblings.
 const PRIMARY_NAV = [
   { href: "/rankings", label: "Rankings", hint: "Player value board" },
+  { href: "/trending", label: "Trending", hint: "Biggest rank movers, last 1d/7d/30d" },
   {
     href: "/trade",
     label: "Trade",

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1332,9 +1332,26 @@ export default function RankingsPage() {
                                 ``rankChange``, or renders nothing. */}
                             {chips.length > 0 && (
                               <span className="rankings-chips">
-                                {chips.map((c) => (
-                                  <span key={c.label} className={`badge ${c.css} rankings-chip`} title={c.title}>{c.label}</span>
-                                ))}
+                                {chips.map((c) =>
+                                  c.url ? (
+                                    <a
+                                      key={c.label}
+                                      href={c.url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      onClick={(e) => e.stopPropagation()}
+                                      className={`badge ${c.css} rankings-chip`}
+                                      title={`${c.title} \u2014 click to read`}
+                                      style={{ cursor: "pointer", textDecoration: "none" }}
+                                    >
+                                      {c.label}
+                                    </a>
+                                  ) : (
+                                    <span key={c.label} className={`badge ${c.css} rankings-chip`} title={c.title}>
+                                      {c.label}
+                                    </span>
+                                  ),
+                                )}
                               </span>
                             )}
                           </div>

--- a/frontend/app/trending/page.jsx
+++ b/frontend/app/trending/page.jsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useApp } from "@/components/AppShell";
+import { PageHeader, LoadingState, EmptyState, PlayerImage } from "@/components/ui";
+import {
+  WINDOW_OPTIONS,
+  DIRECTION_OPTIONS,
+  computeMovers,
+  filterByFamily,
+  fmtDelta,
+} from "@/lib/movers";
+
+const FAMILY_OPTIONS = [
+  { key: "ALL", label: "All" },
+  { key: "QB", label: "QB" },
+  { key: "RB", label: "RB" },
+  { key: "WR", label: "WR" },
+  { key: "TE", label: "TE" },
+  { key: "DL", label: "DL" },
+  { key: "LB", label: "LB" },
+  { key: "DB", label: "DB" },
+];
+
+function FilterPills({ options, value, onChange, ariaLabel }) {
+  return (
+    <div role="tablist" aria-label={ariaLabel} style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+      {options.map((opt) => {
+        const active = opt.key === value;
+        return (
+          <button
+            key={opt.key}
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(opt.key)}
+            className={active ? "button" : "button-outline"}
+            style={{
+              fontSize: "0.74rem",
+              padding: "4px 10px",
+              minHeight: 32,
+              opacity: active ? 1 : 0.78,
+            }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function TrendingPage() {
+  const { rows, loading, error } = useApp();
+  const [windowKey, setWindowKey] = useState("7d");
+  const [direction, setDirection] = useState("all");
+  const [family, setFamily] = useState("ALL");
+
+  const movers = useMemo(() => {
+    const window = WINDOW_OPTIONS.find((w) => w.key === windowKey) || WINDOW_OPTIONS[1];
+    const all = computeMovers(rows || [], {
+      windowDays: window.days,
+      direction,
+      limit: 200,
+    });
+    return filterByFamily(all, family);
+  }, [rows, windowKey, direction, family]);
+
+  if (loading) return <LoadingState message="Loading rank history…" />;
+  if (error) {
+    return (
+      <section>
+        <PageHeader title="Trending" subtitle="Biggest value movers across the board." />
+        <div className="card">
+          <EmptyState title="Couldn't load data" message={String(error)} />
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <PageHeader
+        title="Trending"
+        subtitle="Biggest rank movers across the board — gainers and losers since the chosen window."
+      />
+
+      <div className="card" style={{ marginBottom: 10, display: "flex", flexDirection: "column", gap: 10 }}>
+        <div>
+          <div className="muted" style={{ fontSize: "0.7rem", marginBottom: 4 }}>Window</div>
+          <FilterPills
+            options={WINDOW_OPTIONS}
+            value={windowKey}
+            onChange={setWindowKey}
+            ariaLabel="Time window"
+          />
+        </div>
+        <div>
+          <div className="muted" style={{ fontSize: "0.7rem", marginBottom: 4 }}>Direction</div>
+          <FilterPills
+            options={DIRECTION_OPTIONS}
+            value={direction}
+            onChange={setDirection}
+            ariaLabel="Movement direction"
+          />
+        </div>
+        <div>
+          <div className="muted" style={{ fontSize: "0.7rem", marginBottom: 4 }}>Position family</div>
+          <FilterPills
+            options={FAMILY_OPTIONS}
+            value={family}
+            onChange={setFamily}
+            ariaLabel="Position family"
+          />
+        </div>
+      </div>
+
+      {movers.length === 0 ? (
+        <div className="card">
+          <EmptyState
+            title="No movers in this window"
+            message="Try widening the window or changing direction."
+          />
+        </div>
+      ) : (
+        <div className="card">
+          <div className="muted" style={{ fontSize: "0.7rem", marginBottom: 6 }}>
+            {movers.length} player{movers.length === 1 ? "" : "s"} · sorted by absolute rank change
+          </div>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "left" }}>Player</th>
+                  <th style={{ textAlign: "left" }}>Pos</th>
+                  <th style={{ textAlign: "right" }}>Rank</th>
+                  <th style={{ textAlign: "right" }}>Δ rank</th>
+                  <th style={{ textAlign: "right" }}>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {movers.map((m) => {
+                  const positive = m.delta > 0;
+                  const color = positive ? "var(--green)" : "var(--red)";
+                  return (
+                    <tr key={`${m.name}::${m.pos}`}>
+                      <td style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                        <PlayerImage name={m.name} sleeperId={m.sleeperId} size={22} />
+                        <span style={{ fontWeight: 600 }}>{m.name}</span>
+                        {m.teamAbbr && (
+                          <span className="muted" style={{ fontSize: "0.66rem" }}>
+                            {m.teamAbbr}
+                          </span>
+                        )}
+                      </td>
+                      <td>
+                        <span className="badge" style={{ fontSize: "0.68rem" }}>{m.pos}</span>
+                      </td>
+                      <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                        {m.currentRank ?? "—"}
+                      </td>
+                      <td style={{ textAlign: "right", fontFamily: "var(--mono)", color, fontWeight: 700 }}>
+                        {fmtDelta(m.delta)}
+                      </td>
+                      <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                        {Math.round(m.value).toLocaleString()}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/SourceHealthStrip.jsx
+++ b/frontend/components/SourceHealthStrip.jsx
@@ -90,12 +90,27 @@ export default function SourceHealthStrip({ variant = "inline" }) {
         : null;
     const enabled = Array.isArray(runtime.enabled_sources) ? runtime.enabled_sources : [];
     const counts = health.source_counts || {};
+    // Per-source freshness map: stamped by ``server._per_source_freshness``,
+    // shape ``{src: {lastFetched, ageHours}}``.  Lets us render a per-source
+    // age next to each row instead of one aggregate "last scrape" age.
+    const perSource = (health.sources && typeof health.sources === "object")
+      ? health.sources
+      : {};
     const entries = enabled.map((src) => {
-      const tone = toneFor(src, runtime, ageHours);
+      const meta = perSource[src] || {};
+      const srcAgeHours = Number.isFinite(meta.ageHours)
+        ? Number(meta.ageHours)
+        : ageHours;
+      // Per-source age trumps the aggregate when available — gives a
+      // truer per-source health signal.
+      const tone = toneFor(src, runtime, srcAgeHours);
+      const ageLbl = meta.lastFetched ? ageLabel(meta.lastFetched) : null;
       return {
         source: src,
         count: Number(counts[src] || counts[src.toLowerCase()] || 0),
         tone,
+        ageLabel: ageLbl,
+        ageHours: srcAgeHours,
         failedReason:
           (health.source_failures || []).find(
             (f) => f.source === src,
@@ -158,6 +173,11 @@ export default function SourceHealthStrip({ variant = "inline" }) {
               <span className="source-health-count">
                 {e.count > 0 ? `${e.count.toLocaleString()} rows` : "—"}
               </span>
+              {e.ageLabel && (
+                <span className="source-health-age" title="CSV file mtime — when this source last refreshed">
+                  {e.ageLabel} ago
+                </span>
+              )}
               {e.failedReason && (
                 <span className="source-health-reason" title={e.failedReason}>
                   {e.failedReason}

--- a/frontend/lib/movers.js
+++ b/frontend/lib/movers.js
@@ -1,0 +1,97 @@
+/**
+ * movers — pure helpers for the /trending page.
+ *
+ * Pulls per-player rank/value movement out of the canonical contract
+ * rows and computes window-bounded changes.  Matches the convention
+ * used elsewhere: positive ``rankChange`` means the player improved
+ * (moved toward rank #1), negative means they fell.
+ *
+ * No I/O — caller passes rows + rankHistory and gets sortable
+ * mover records back.  Callable in tests without a render layer.
+ */
+import { computeWindowTrend, normalizePoints } from "@/lib/value-history";
+
+export const WINDOW_OPTIONS = Object.freeze([
+  { key: "1d", label: "1 day", days: 1 },
+  { key: "7d", label: "7 days", days: 7 },
+  { key: "30d", label: "30 days", days: 30 },
+]);
+
+export const DIRECTION_OPTIONS = Object.freeze([
+  { key: "all", label: "All movers" },
+  { key: "gainers", label: "Gainers" },
+  { key: "losers", label: "Losers" },
+]);
+
+const POS_FAMILY = {
+  QB: "QB", RB: "RB", FB: "RB", WR: "WR", TE: "TE",
+  K: "K", DEF: "DEF",
+  DL: "DL", DT: "DL", DE: "DL", EDGE: "DL", NT: "DL",
+  LB: "LB", ILB: "LB", OLB: "LB", MLB: "LB",
+  DB: "DB", CB: "DB", S: "DB", FS: "DB", SS: "DB",
+};
+
+export function familyOf(pos) {
+  return POS_FAMILY[String(pos || "").toUpperCase()] || "OTHER";
+}
+
+/**
+ * Compute mover records for every row.  ``windowDays`` decides which
+ * rank-history window the trend is taken from; the 1-day case uses
+ * the contract's pre-stamped ``rankChange`` (which is the day-over-
+ * day delta the backend already computes).
+ *
+ * Returns rows sorted by absolute delta DESC, with ties broken by
+ * higher absolute value (so a top-50 player moving 5 spots ranks
+ * above a top-300 player moving the same amount).
+ */
+export function computeMovers(rows, { windowDays = 7, direction = "all", limit = 100 } = {}) {
+  if (!Array.isArray(rows)) return [];
+  const out = [];
+  for (const r of rows) {
+    if (!r || typeof r !== "object") continue;
+
+    let delta = null;
+    if (windowDays <= 1) {
+      const rc = Number(r.rankChange);
+      delta = Number.isFinite(rc) ? rc : null;
+    } else {
+      const points = normalizePoints(r.rankHistory);
+      const trend = computeWindowTrend(points, windowDays);
+      delta = Number.isFinite(trend) ? trend : null;
+    }
+    if (delta == null || delta === 0) continue;
+
+    if (direction === "gainers" && delta <= 0) continue;
+    if (direction === "losers" && delta >= 0) continue;
+
+    out.push({
+      name: r.name,
+      pos: r.pos,
+      family: familyOf(r.pos),
+      teamAbbr: r.teamAbbr || r.team || "",
+      sleeperId: r.sleeperId || null,
+      currentRank: Number(r.canonicalConsensusRank) || null,
+      delta,
+      absDelta: Math.abs(delta),
+      value: Number(r.rankDerivedValue || r.values?.full || 0),
+      rankHistory: r.rankHistory || null,
+    });
+  }
+  out.sort((a, b) => {
+    if (b.absDelta !== a.absDelta) return b.absDelta - a.absDelta;
+    return b.value - a.value;
+  });
+  return out.slice(0, limit);
+}
+
+export function filterByFamily(movers, family) {
+  if (!family || family === "ALL") return movers;
+  return movers.filter((m) => m.family === family);
+}
+
+export function fmtDelta(v) {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v === 0) return "·";
+  return v > 0 ? `+${v}` : String(v);
+}

--- a/frontend/lib/rankings-helpers.js
+++ b/frontend/lib/rankings-helpers.js
@@ -167,10 +167,14 @@ export function rowChips(row, options = {}) {
         ? "badge-amber"
         : "badge-blue";
     const headline = String(news.headline || news.summary || "Recent news").slice(0, 140);
+    const url = typeof news.url === "string" && news.url.startsWith("http")
+      ? news.url
+      : null;
     chips.push({
       label,
       css,
       title: `${headline} (${news.providerLabel || news.provider || "news"})`,
+      url,
     });
   }
   return chips;

--- a/server.py
+++ b/server.py
@@ -1023,6 +1023,14 @@ def _build_source_health_snapshot(data: dict | None) -> dict:
     if not partial_run:
         partial_run = len(failures) > 0
 
+    # Per-source freshness — the CSV mtime tells us when each source
+    # was last successfully refreshed, independent of the most recent
+    # *full-pipeline* scrape time.  Stamp this here so the staleness
+    # alert system in src.api.source_health_alerts has the
+    # ``sources[src].lastFetched`` field it expects, and the source-
+    # health page can render per-source ages.
+    sources_meta = _per_source_freshness()
+
     return {
         "total_sources": len(source_counts),
         "sources_with_data": available,
@@ -1031,7 +1039,44 @@ def _build_source_health_snapshot(data: dict | None) -> dict:
         "partial_run": bool(partial_run),
         "source_runtime": source_runtime,
         "source_failures": failures,
+        "sources": sources_meta,
     }
+
+
+def _per_source_freshness() -> dict[str, dict]:
+    """Per-source ``{lastFetched, ageHours}`` derived from the CSV
+    file mtimes in ``CSVs/site_raw/``.  Source key → CSV name mapping
+    follows the convention ``CSVs/site_raw/{key}.csv`` for every
+    source registered in ``_SOURCE_CSV_PATHS``.  Sources without a
+    CSV (rare; only ones backed entirely by adapter modules) report
+    ``lastFetched: None``.
+
+    Returns ``{}`` if the CSV directory is missing or unreadable.
+    """
+    try:
+        from src.api.data_contract import _SOURCE_CSV_PATHS
+    except Exception:  # pragma: no cover
+        return {}
+    repo_root = Path(__file__).resolve().parent
+    out: dict[str, dict] = {}
+    now_epoch = time.time()
+    for src_key, entry in _SOURCE_CSV_PATHS.items():
+        csv_rel = entry if isinstance(entry, str) else (entry or {}).get("path")
+        if not csv_rel:
+            continue
+        csv_path = repo_root / csv_rel
+        try:
+            mtime = csv_path.stat().st_mtime
+        except OSError:
+            continue
+        age_hours = max(0.0, (now_epoch - mtime) / 3600.0)
+        out[src_key] = {
+            "lastFetched": datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat(
+                timespec="seconds"
+            ),
+            "ageHours": round(age_hours, 2),
+        }
+    return out
 
 
 

--- a/tests/api/test_per_source_freshness.py
+++ b/tests/api/test_per_source_freshness.py
@@ -1,0 +1,67 @@
+"""Per-source freshness snapshot tests.
+
+Covers the ``server._per_source_freshness`` helper that maps every
+registered source's CSV mtime onto a ``{lastFetched, ageHours}``
+record.  This is what feeds ``check_and_alert`` in
+``src.api.source_health_alerts`` and the per-source rows on the
+``/tools/source-health`` page.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+import server as srv
+
+
+def test_per_source_freshness_returns_dict_with_known_sources():
+    out = srv._per_source_freshness()
+    assert isinstance(out, dict)
+    # KTC always has a CSV in the live repo; this confirms the
+    # path-resolution + mtime read works end-to-end.
+    if "ktc" in out:
+        entry = out["ktc"]
+        assert "lastFetched" in entry
+        assert "ageHours" in entry
+        assert isinstance(entry["ageHours"], (int, float))
+        assert entry["ageHours"] >= 0
+        # ISO-8601 with timezone marker.
+        parsed = datetime.fromisoformat(entry["lastFetched"])
+        assert parsed.tzinfo is not None
+
+
+def test_freshness_records_have_consistent_age_window():
+    out = srv._per_source_freshness()
+    if not out:
+        pytest.skip("no CSV sources present in this checkout")
+    now = time.time()
+    for src, entry in out.items():
+        # Reverse-derive the lastFetched epoch and confirm ageHours
+        # matches it within ±2 minutes (rounded to 2 decimals).
+        last = datetime.fromisoformat(entry["lastFetched"]).astimezone(timezone.utc)
+        derived_hours = (now - last.timestamp()) / 3600.0
+        assert abs(derived_hours - entry["ageHours"]) < 2 / 60, (
+            f"{src}: derived={derived_hours:.4f}h vs reported={entry['ageHours']}h"
+        )
+
+
+def test_per_source_freshness_returns_empty_when_repo_missing(monkeypatch, tmp_path):
+    # Point the helper at a directory with no CSVs and confirm it
+    # returns {} cleanly (alert system tolerates this — no spurious
+    # alerts when sources legitimately don't exist yet).
+    bogus = tmp_path / "fake_repo_root"
+    bogus.mkdir()
+    monkeypatch.setattr(srv, "__file__", str(bogus / "server.py"))
+    out = srv._per_source_freshness()
+    assert out == {}
+
+
+def test_source_health_snapshot_includes_sources_block():
+    """``_build_source_health_snapshot`` must surface the per-source
+    freshness map under ``sources`` so ``source_health_alerts``
+    can find ``lastFetched``."""
+    snap = srv._build_source_health_snapshot({"sites": [], "settings": {}})
+    assert "sources" in snap
+    assert isinstance(snap["sources"], dict)


### PR DESCRIPTION
## Summary
Three bundled high-ROI improvements, all reusing existing infrastructure:

- **`/trending`**: new page showing biggest rank movers, with 1d/7d/30d × gainers/losers/all × position-family filters. Pure helpers reuse `rankHistory` already stamped on contract rows + `computeWindowTrend` from value-history.
- **Inline news on rankings**: chips with a URL render as `<a target="_blank">` so clicking the chip opens the source article. Existing severity-coloured tooltips remain.
- **Per-source freshness**: CSV mtimes added under `status.source_health.sources[]`. Source-Health page now shows `Xh ago` per source. The dormant `check_and_alert` staleness emailer finally has the `lastFetched` field it expects — staleness alerts will start firing.

## Test plan
- [x] `pytest tests/api/test_per_source_freshness.py` — 4/4
- [x] `npm test -- __tests__/movers.test.js` — 12/12
- [x] `npm run build` — all pages under budget
- [ ] Production: visit `/trending`, change windows + filters, verify the table moves; visit `/tools/source-health`, expand the strip, confirm per-source ages show; click a news chip on `/rankings` to verify opens article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)