### PR TITLE
feat: league activity feed + win-now/rebuild phase analyzer

### DIFF
--- a/frontend/__tests__/activity-feed.test.js
+++ b/frontend/__tests__/activity-feed.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { buildActivityEvents, filterEvents, familyOfPos } from "@/lib/activity-feed";
+
+const FAKE_TEAMS = [
+  { ownerId: "ownA", rosterId: "1", name: "Team A", players: ["Caleb Williams", "Bo Nix"] },
+  { ownerId: "ownB", rosterId: "2", name: "Team B", players: ["Drake Maye"] },
+];
+
+const FAKE_RAW = {
+  sleeper: {
+    teams: FAKE_TEAMS,
+    positions: {
+      "100": { name: "Caleb Williams" },
+      "200": { name: "Drake Maye" },
+    },
+    trades: [
+      {
+        transaction_id: "t1",
+        roster_ids: ["1", "2"],
+        adds: { "100": "2" },
+        drops: { "100": "1" },
+        status_updated: 1714000000000, // 2024-04-25
+      },
+    ],
+  },
+};
+
+const FAKE_NEWS = [
+  {
+    id: "n1",
+    headline: "Caleb Williams ankle update",
+    body: "Out 2 weeks.",
+    severity: "alert",
+    ts: "2026-04-26T14:00:00Z",
+    players: [{ name: "Caleb Williams" }],
+    url: "https://news.example/caleb",
+  },
+  {
+    id: "n2",
+    headline: "Random other story",
+    severity: "info",
+    ts: "2026-04-25T14:00:00Z",
+    players: [{ name: "Some Other Player" }],
+  },
+];
+
+describe("buildActivityEvents", () => {
+  it("merges trades + news into one chronological feed", () => {
+    const events = buildActivityEvents(FAKE_RAW, FAKE_NEWS);
+    expect(events.length).toBe(3);
+    expect(events.map((e) => e.type)).toEqual(["news", "news", "trade"]);
+    // Newest first.
+    expect(events[0].id).toBe("news::n1");
+  });
+
+  it("trade event carries team names + player names", () => {
+    const [, , trade] = buildActivityEvents(FAKE_RAW, FAKE_NEWS);
+    expect(trade.type).toBe("trade");
+    expect(trade.teamNames).toEqual(expect.arrayContaining(["Team A", "Team B"]));
+    expect(trade.playerNames).toContain("Caleb Williams");
+  });
+
+  it("returns [] when given empty inputs", () => {
+    expect(buildActivityEvents(null, null)).toEqual([]);
+    expect(buildActivityEvents({}, [])).toEqual([]);
+  });
+});
+
+describe("filterEvents", () => {
+  const events = buildActivityEvents(FAKE_RAW, FAKE_NEWS);
+
+  it("scope=roster keeps events that touch a roster player", () => {
+    const filtered = filterEvents(events, {
+      scope: "roster",
+      rosterNames: ["Caleb Williams"],
+    });
+    // News for Caleb + trade involving Caleb.  Other news is dropped.
+    expect(filtered.map((e) => e.id)).toEqual(["news::n1", "trade::t1"]);
+  });
+
+  it("scope=league keeps everything", () => {
+    expect(filterEvents(events, { scope: "league" })).toHaveLength(3);
+  });
+
+  it("type filter respects all/trade/news", () => {
+    expect(filterEvents(events, { type: "trade" })).toHaveLength(1);
+    expect(filterEvents(events, { type: "news" })).toHaveLength(2);
+    expect(filterEvents(events, { type: "all" })).toHaveLength(3);
+  });
+
+  it("scope=roster with no roster names returns []", () => {
+    expect(filterEvents(events, { scope: "roster", rosterNames: [] })).toEqual([]);
+  });
+
+  it("is case-insensitive on player names", () => {
+    const filtered = filterEvents(events, {
+      scope: "roster",
+      rosterNames: ["caleb williams"],
+    });
+    expect(filtered.length).toBeGreaterThan(0);
+  });
+});
+
+describe("familyOfPos", () => {
+  it("maps QB/RB/WR/TE", () => {
+    expect(familyOfPos("QB")).toBe("QB");
+    expect(familyOfPos("RB")).toBe("RB");
+  });
+  it("maps IDP variants", () => {
+    expect(familyOfPos("EDGE")).toBe("DL");
+    expect(familyOfPos("CB")).toBe("DB");
+  });
+});

--- a/frontend/__tests__/team-phase.test.js
+++ b/frontend/__tests__/team-phase.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { analyzeLeaguePhases, PHASES } from "@/lib/team-phase";
+
+function row({ name, value = 5000, age = 26 }) {
+  return { name, rankDerivedValue: value, age };
+}
+
+function fakeLeague(teams) {
+  return {
+    sleeper: {
+      teams: teams.map((t, i) => ({
+        ownerId: `own${i}`,
+        rosterId: String(i + 1),
+        name: t.name,
+        players: t.players,
+      })),
+    },
+  };
+}
+
+describe("analyzeLeaguePhases", () => {
+  it("classifies a young, valuable team as Win-now", () => {
+    const rows = [
+      row({ name: "young star A", value: 9000, age: 22 }),
+      row({ name: "young star B", value: 8500, age: 23 }),
+      row({ name: "veteran", value: 4000, age: 30 }),
+    ];
+    const teams = [
+      { name: "Young Squad", players: ["young star A", "young star B"] },
+      { name: "Old Squad", players: ["veteran"] },
+    ];
+    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    const young = result.teams.find((t) => t.name === "Young Squad");
+    expect(young.phase.key).toBe(PHASES.WIN_NOW.key);
+  });
+
+  it("classifies a low-value young team as Rebuild", () => {
+    const rows = [
+      row({ name: "young rookie", value: 2000, age: 21 }),
+      row({ name: "veteran star A", value: 9000, age: 30 }),
+      row({ name: "veteran star B", value: 8500, age: 31 }),
+    ];
+    const teams = [
+      { name: "Rookies", players: ["young rookie"] },
+      { name: "Veterans", players: ["veteran star A", "veteran star B"] },
+    ];
+    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    const rebuilder = result.teams.find((t) => t.name === "Rookies");
+    expect(rebuilder.phase.key).toBe(PHASES.REBUILD.key);
+    const contender = result.teams.find((t) => t.name === "Veterans");
+    expect(contender.phase.key).toBe(PHASES.CONTENDER.key);
+  });
+
+  it("returns trade partnerships pairing winners with rebuilders", () => {
+    const rows = [
+      row({ name: "young rookie", value: 2000, age: 21 }),
+      row({ name: "young star", value: 9000, age: 22 }),
+      row({ name: "young star B", value: 8800, age: 22 }),
+      row({ name: "vet", value: 8500, age: 30 }),
+      row({ name: "vet2", value: 8000, age: 31 }),
+    ];
+    const teams = [
+      { name: "Win-now", players: ["young star", "young star B"] },
+      { name: "Contender", players: ["vet", "vet2"] },
+      { name: "Rebuilder", players: ["young rookie"] },
+    ];
+    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    expect(result.partnerships.length).toBeGreaterThan(0);
+    // Winners → Rebuilders pairing.  Both Win-now and Contender pair
+    // with Rebuilder.
+    const partnerNames = new Set(
+      result.partnerships.map((p) => `${p.winnerName}→${p.rebuilderName}`),
+    );
+    expect(partnerNames.has("Win-now→Rebuilder")).toBe(true);
+  });
+
+  it("returns empty when sleeper teams missing", () => {
+    expect(analyzeLeaguePhases({}, []).teams).toEqual([]);
+    expect(analyzeLeaguePhases({ sleeper: { teams: [] } }, []).teams).toEqual([]);
+  });
+
+  it("computes league medians from per-team snapshots", () => {
+    const rows = [
+      row({ name: "a", value: 1000, age: 25 }),
+      row({ name: "b", value: 2000, age: 27 }),
+    ];
+    const teams = [
+      { name: "T1", players: ["a"] },
+      { name: "T2", players: ["b"] },
+    ];
+    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    expect(result.leagueMedians.value).toBe(1500);
+    expect(result.leagueMedians.age).toBe(26);
+  });
+});

--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -49,7 +49,17 @@ const PRIMARY_NAV = [
   },
   { href: "/draft", label: "Draft", hint: "Rookie draft prep + ADP" },
   { href: "/edge", label: "Edge", hint: "Where sources disagree most", groupBreak: true },
-  { href: "/league", label: "League", hint: "Public league hub", groupBreak: true },
+  {
+    href: "/league",
+    label: "League",
+    hint: "Public league hub",
+    groupBreak: true,
+    children: [
+      { href: "/league", label: "Hub", hint: "League overview" },
+      { href: "/league/activity", label: "Activity", hint: "Trades + news in one feed" },
+      { href: "/league/phases", label: "Win-now vs Rebuild", hint: "Per-team phase classification + trade partners" },
+    ],
+  },
   { href: "/settings", label: "Settings", hint: "Source weights, TEP, profile", groupBreak: true },
   { href: "/more", label: "More", hint: "Rosters, tools, admin" },
 ];

--- a/frontend/app/league/activity/page.jsx
+++ b/frontend/app/league/activity/page.jsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useApp } from "@/components/AppShell";
+import { useNews } from "@/components/useNews";
+import { useUserState } from "@/components/useUserState";
+import { PageHeader, LoadingState, EmptyState } from "@/components/ui";
+import { buildActivityEvents, filterEvents } from "@/lib/activity-feed";
+
+const SCOPE_OPTIONS = [
+  { key: "league", label: "League" },
+  { key: "roster", label: "My roster" },
+];
+
+const TYPE_OPTIONS = [
+  { key: "all", label: "All" },
+  { key: "trade", label: "Trades" },
+  { key: "news", label: "News" },
+];
+
+function fmtRelative(ts) {
+  if (!ts) return "—";
+  const diffMs = Date.now() - ts;
+  if (diffMs < 0) return "just now";
+  const minutes = diffMs / 60_000;
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${Math.round(minutes)}m ago`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${Math.round(hours)}h ago`;
+  const days = hours / 24;
+  if (days < 30) return `${Math.round(days)}d ago`;
+  return `${Math.round(days / 30)}mo ago`;
+}
+
+function severityChip(severity) {
+  if (severity === "alert" || severity === "high") {
+    return { label: "Alert", css: "badge-amber" };
+  }
+  if (severity === "injury") return { label: "Injury", css: "badge-red" };
+  return null;
+}
+
+function FilterPills({ options, value, onChange, ariaLabel }) {
+  return (
+    <div role="tablist" aria-label={ariaLabel} style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+      {options.map((opt) => {
+        const active = opt.key === value;
+        return (
+          <button
+            key={opt.key}
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(opt.key)}
+            className={active ? "button" : "button-outline"}
+            style={{ fontSize: "0.74rem", padding: "4px 10px", minHeight: 32 }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function ActivityPage() {
+  const { rawData, loading, error } = useApp();
+  const { state: userState } = useUserState();
+  const { items: newsItems } = useNews();
+  const [scope, setScope] = useState("league");
+  const [type, setType] = useState("all");
+
+  const myTeam = useMemo(() => {
+    const ownerId = userState?.selectedTeam?.ownerId;
+    if (!ownerId) return null;
+    return (rawData?.sleeper?.teams || []).find(
+      (t) => String(t?.ownerId) === String(ownerId),
+    ) || null;
+  }, [rawData, userState]);
+
+  const allEvents = useMemo(
+    () => buildActivityEvents(rawData, newsItems),
+    [rawData, newsItems],
+  );
+
+  const events = useMemo(
+    () => filterEvents(allEvents, {
+      scope,
+      type,
+      rosterNames: myTeam?.players || [],
+    }),
+    [allEvents, scope, type, myTeam],
+  );
+
+  if (loading) return <LoadingState message="Loading league activity…" />;
+  if (error) {
+    return (
+      <section>
+        <PageHeader title="League activity" subtitle="Trades + news in one feed." />
+        <div className="card">
+          <EmptyState title="Couldn't load data" message={String(error)} />
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <div style={{ fontSize: "0.72rem", marginBottom: 6 }}>
+        <Link href="/league" style={{ color: "var(--cyan)" }}>← League home</Link>
+      </div>
+      <PageHeader
+        title="League activity"
+        subtitle="Trades + news in one chronological feed.  Scope to your roster to see only events involving your players."
+      />
+
+      <div className="card" style={{ marginBottom: 10, display: "flex", flexDirection: "column", gap: 10 }}>
+        <div>
+          <div className="muted" style={{ fontSize: "0.7rem", marginBottom: 4 }}>Scope</div>
+          <FilterPills options={SCOPE_OPTIONS} value={scope} onChange={setScope} ariaLabel="Scope" />
+        </div>
+        <div>
+          <div className="muted" style={{ fontSize: "0.7rem", marginBottom: 4 }}>Type</div>
+          <FilterPills options={TYPE_OPTIONS} value={type} onChange={setType} ariaLabel="Event type" />
+        </div>
+        {scope === "roster" && !myTeam && (
+          <p className="muted" style={{ fontSize: "0.7rem", margin: 0, color: "var(--amber)" }}>
+            Pick your team on the league page to use the &quot;My roster&quot; scope.
+          </p>
+        )}
+      </div>
+
+      {events.length === 0 ? (
+        <div className="card">
+          <EmptyState
+            title="No activity in this view"
+            message="Try widening the scope or changing the type filter."
+          />
+        </div>
+      ) : (
+        <div className="card" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <div className="muted" style={{ fontSize: "0.7rem" }}>
+            {events.length} event{events.length === 1 ? "" : "s"} · newest first
+          </div>
+          {events.slice(0, 80).map((e) => {
+            const chip = severityChip(e.severity);
+            const teamLine = (e.teamNames || []).slice(0, 4).join(" · ");
+            const playerLine = (e.playerNames || []).slice(0, 6).join(" · ");
+            return (
+              <div
+                key={e.id}
+                style={{
+                  padding: "10px 0",
+                  borderTop: "1px solid var(--border)",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 4,
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                  <span
+                    className={`badge ${e.type === "trade" ? "badge-amber" : "badge-blue"}`}
+                    style={{ fontSize: "0.66rem" }}
+                  >
+                    {e.type === "trade" ? "TRADE" : "NEWS"}
+                  </span>
+                  {chip && (
+                    <span className={`badge ${chip.css}`} style={{ fontSize: "0.66rem" }}>
+                      {chip.label}
+                    </span>
+                  )}
+                  <span className="muted" style={{ fontSize: "0.7rem" }}>{fmtRelative(e.ts)}</span>
+                  {e.url ? (
+                    <a
+                      href={e.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        marginLeft: "auto",
+                        color: "var(--cyan)",
+                        fontSize: "0.7rem",
+                        textDecoration: "none",
+                      }}
+                    >
+                      Read source →
+                    </a>
+                  ) : null}
+                </div>
+                <div style={{ fontSize: "0.86rem", fontWeight: 600 }}>{e.title}</div>
+                {(teamLine || e.detail || playerLine) && (
+                  <div className="muted" style={{ fontSize: "0.74rem" }}>
+                    {teamLine && (
+                      <div><strong>Teams:</strong> {teamLine}</div>
+                    )}
+                    {playerLine && e.type === "trade" && (
+                      <div><strong>Players:</strong> {playerLine}</div>
+                    )}
+                    {e.detail && (
+                      <div style={{ marginTop: 4 }}>{e.detail}</div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/league/phases/page.jsx
+++ b/frontend/app/league/phases/page.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Link from "next/link";
+import { PageHeader } from "@/components/ui";
+import TeamPhasePanel from "@/components/TeamPhasePanel";
+
+export default function LeaguePhasesPage() {
+  return (
+    <section>
+      <div style={{ fontSize: "0.72rem", marginBottom: 6 }}>
+        <Link href="/league" style={{ color: "var(--cyan)" }}>← League home</Link>
+      </div>
+      <PageHeader
+        title="Win-now vs Rebuild"
+        subtitle="Each team in your league classified by top-25 roster value × median age, with natural trade-partner suggestions for your franchise."
+      />
+      <TeamPhasePanel />
+    </section>
+  );
+}

--- a/frontend/components/TeamPhasePanel.jsx
+++ b/frontend/components/TeamPhasePanel.jsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { useApp } from "@/components/AppShell";
+import { useUserState } from "@/components/useUserState";
+import { analyzeLeaguePhases } from "@/lib/team-phase";
+
+const TONE_COLOR = {
+  up: "var(--green)",
+  warn: "var(--amber)",
+  down: "var(--red)",
+};
+
+function fmtAge(a) {
+  if (a == null || !Number.isFinite(a)) return "—";
+  return a.toFixed(1);
+}
+
+function fmtValue(v) {
+  if (!Number.isFinite(v)) return "—";
+  return Math.round(v).toLocaleString();
+}
+
+export default function TeamPhasePanel() {
+  const { rows, rawData, loading } = useApp();
+  const { state: userState } = useUserState();
+
+  const myOwnerId = userState?.selectedTeam?.ownerId
+    ? String(userState.selectedTeam.ownerId)
+    : null;
+
+  const analysis = useMemo(
+    () => analyzeLeaguePhases(rawData, rows),
+    [rawData, rows],
+  );
+
+  if (loading) return null;
+  if (!analysis.teams.length) return null;
+
+  const myRow = myOwnerId
+    ? analysis.teams.find((t) => t.ownerId === myOwnerId)
+    : null;
+  const myPartnerships = myOwnerId
+    ? analysis.partnerships.filter(
+        (p) => p.winnerOwnerId === myOwnerId || p.rebuilderOwnerId === myOwnerId,
+      )
+    : [];
+
+  return (
+    <div className="card" style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 10 }}>
+      <div>
+        <h3 style={{ margin: 0, fontSize: "0.92rem" }}>Win-now vs Rebuild</h3>
+        <p className="muted" style={{ fontSize: "0.7rem", margin: "4px 0 0" }}>
+          Each team classified by top-25 roster value × median age, against the league medians
+          ({fmtValue(analysis.leagueMedians.value)} value · {fmtAge(analysis.leagueMedians.age)} age).
+        </p>
+      </div>
+
+      {myRow && (
+        <div style={{ padding: 8, borderRadius: 4, border: "1px solid var(--border)" }}>
+          <div style={{ fontSize: "0.74rem", color: "var(--subtext)" }}>You are:</div>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+            <strong style={{ fontSize: "0.96rem", color: TONE_COLOR[myRow.phase.tone] }}>
+              {myRow.phase.label}
+            </strong>
+            <span className="muted" style={{ fontSize: "0.74rem" }}>
+              · top-25 value {fmtValue(myRow.totalValue)} · median age {fmtAge(myRow.medianAge)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th style={{ textAlign: "left" }}>Team</th>
+              <th style={{ textAlign: "left" }}>Phase</th>
+              <th style={{ textAlign: "right" }}>Top-25 value</th>
+              <th style={{ textAlign: "right" }}>Median age</th>
+            </tr>
+          </thead>
+          <tbody>
+            {analysis.teams.map((t) => {
+              const isMe = myOwnerId && t.ownerId === myOwnerId;
+              return (
+                <tr key={t.ownerId || t.name}>
+                  <td style={{ fontWeight: isMe ? 700 : 500 }}>
+                    {t.ownerId ? (
+                      <Link
+                        href={`/league/franchise/${encodeURIComponent(t.ownerId)}`}
+                        style={{ color: "var(--cyan)", textDecoration: "none" }}
+                      >
+                        {t.name}
+                        {isMe && (
+                          <span className="muted" style={{ marginLeft: 6, fontSize: "0.66rem" }}>
+                            (you)
+                          </span>
+                        )}
+                      </Link>
+                    ) : (
+                      t.name
+                    )}
+                  </td>
+                  <td>
+                    <span
+                      className="badge"
+                      style={{
+                        backgroundColor: "var(--surface-2)",
+                        color: TONE_COLOR[t.phase.tone],
+                        fontSize: "0.7rem",
+                      }}
+                    >
+                      {t.phase.label}
+                    </span>
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {fmtValue(t.totalValue)}
+                  </td>
+                  <td style={{ textAlign: "right", fontFamily: "var(--mono)" }}>
+                    {fmtAge(t.medianAge)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {myPartnerships.length > 0 && (
+        <div>
+          <strong style={{ fontSize: "0.84rem" }}>Natural trade partners for you</strong>
+          <ul style={{ margin: "4px 0 0 16px", padding: 0, fontSize: "0.78rem" }}>
+            {myPartnerships.slice(0, 3).map((p) => {
+              const otherName =
+                p.winnerOwnerId === myOwnerId ? p.rebuilderName : p.winnerName;
+              const otherId =
+                p.winnerOwnerId === myOwnerId ? p.rebuilderOwnerId : p.winnerOwnerId;
+              const direction =
+                p.winnerOwnerId === myOwnerId
+                  ? "buy older star talent from"
+                  : "sell veterans to";
+              return (
+                <li key={otherId} style={{ marginBottom: 2 }}>
+                  {direction}{" "}
+                  <Link
+                    href={`/league/franchise/${encodeURIComponent(otherId)}`}
+                    style={{ color: "var(--cyan)" }}
+                  >
+                    {otherName}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/activity-feed.js
+++ b/frontend/lib/activity-feed.js
@@ -1,0 +1,140 @@
+/**
+ * activity-feed — pure helpers that combine Sleeper trades + news
+ * items + (optionally) waiver moves into a single chronological feed.
+ *
+ * No I/O — caller provides ``rawData`` (the live contract) and
+ * ``newsItems`` (from useNews); we project them into a uniform
+ * ``ActivityEvent`` shape that the feed UI renders.
+ *
+ * Filtering happens at render time: the feed page lets the user
+ * scope to "my roster" (events touching any selectedTeam player)
+ * or "league wide" (everything).
+ */
+
+const POS_FAMILY = {
+  QB: "QB", RB: "RB", FB: "RB", WR: "WR", TE: "TE",
+  DL: "DL", DT: "DL", DE: "DL", EDGE: "DL", NT: "DL",
+  LB: "LB", ILB: "LB", OLB: "LB", MLB: "LB",
+  DB: "DB", CB: "DB", S: "DB", FS: "DB", SS: "DB",
+};
+
+function familyOf(pos) {
+  return POS_FAMILY[String(pos || "").toUpperCase()] || "OTHER";
+}
+
+function tsOf(value) {
+  if (!value) return 0;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value < 1e12 ? value * 1000 : value;
+  }
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : 0;
+}
+
+function teamFromOwnerId(rawData, ownerId) {
+  const teams = rawData?.sleeper?.teams || [];
+  for (const t of teams) {
+    if (String(t?.ownerId) === String(ownerId)) return t;
+  }
+  return null;
+}
+
+function tradeToEvent(trade, rawData) {
+  const ts = tsOf(trade?._statusUpdatedMs || trade?.status_updated || trade?.created);
+  const rosterIds = Array.isArray(trade?.roster_ids) ? trade.roster_ids : [];
+  const teams = rawData?.sleeper?.teams || [];
+  const teamsInTrade = rosterIds
+    .map((rid) => teams.find((t) => String(t?.rosterId) === String(rid)))
+    .filter(Boolean);
+  const teamNames = teamsInTrade.map((t) => t?.name).filter(Boolean);
+
+  // adds: { sleeperPlayerId/pickLabel: rosterId } — roster that received
+  const adds = trade?.adds && typeof trade.adds === "object" ? trade.adds : {};
+  const drops = trade?.drops && typeof trade.drops === "object" ? trade.drops : {};
+  const playerNamesSeen = new Set();
+  const positions = rawData?.sleeper?.positions || {};
+
+  for (const pid of [...Object.keys(adds), ...Object.keys(drops)]) {
+    const meta = positions[pid];
+    const name = meta?.name || (typeof meta === "string" ? meta : null);
+    if (typeof name === "string" && name.trim()) {
+      playerNamesSeen.add(name);
+    }
+  }
+
+  const summary = teamNames.length >= 2
+    ? `${teamNames[0]} ↔ ${teamNames.slice(1).join(", ")}`
+    : `${teamNames.join(", ") || "Trade"}`;
+
+  return {
+    id: `trade::${trade?.transaction_id || trade?.id || ts}`,
+    type: "trade",
+    ts,
+    title: summary,
+    detail: playerNamesSeen.size
+      ? Array.from(playerNamesSeen).slice(0, 6).join(" · ")
+      : `Multi-asset trade between ${teamNames.length} teams`,
+    teamNames,
+    rosterIds,
+    playerNames: Array.from(playerNamesSeen),
+    url: null,
+    severity: "info",
+  };
+}
+
+function newsToEvent(item) {
+  const ts = tsOf(item?.ts || item?.publishedAt || item?.published);
+  const playerNames = Array.isArray(item?.players)
+    ? item.players.map((p) => (typeof p === "string" ? p : p?.name)).filter(Boolean)
+    : [];
+  return {
+    id: `news::${item?.id || ts || item?.headline}`,
+    type: "news",
+    ts,
+    title: String(item?.headline || item?.title || "News"),
+    detail: String(item?.body || item?.summary || "")
+      .slice(0, 300)
+      || (item?.providerLabel || item?.provider || ""),
+    teamNames: [],
+    rosterIds: [],
+    playerNames,
+    url: typeof item?.url === "string" ? item.url : null,
+    severity: String(item?.severity || "info").toLowerCase(),
+  };
+}
+
+export function buildActivityEvents(rawData, newsItems) {
+  const events = [];
+  const trades = rawData?.sleeper?.trades || [];
+  if (Array.isArray(trades)) {
+    for (const t of trades) events.push(tradeToEvent(t, rawData));
+  }
+  if (Array.isArray(newsItems)) {
+    for (const n of newsItems) events.push(newsToEvent(n));
+  }
+  events.sort((a, b) => b.ts - a.ts);
+  return events;
+}
+
+export function filterEvents(events, { scope = "league", rosterNames = [], type = "all" } = {}) {
+  if (!Array.isArray(events)) return [];
+  const lowerRoster = new Set(
+    (rosterNames || [])
+      .filter((n) => typeof n === "string" && n.length)
+      .map((n) => n.toLowerCase()),
+  );
+  return events.filter((e) => {
+    if (type !== "all" && e.type !== type) return false;
+    if (scope === "roster") {
+      if (!lowerRoster.size) return false;
+      return (e.playerNames || []).some((n) =>
+        typeof n === "string" && lowerRoster.has(n.toLowerCase()),
+      );
+    }
+    return true;
+  });
+}
+
+export function familyOfPos(pos) {
+  return familyOf(pos);
+}

--- a/frontend/lib/team-phase.js
+++ b/frontend/lib/team-phase.js
@@ -1,0 +1,144 @@
+/**
+ * team-phase — classify each team in the league as
+ * Win-now / Contender / Mixed / Rebuild based on roster age × value.
+ *
+ * Methodology
+ * -----------
+ * For every team in ``rawData.sleeper.teams``:
+ *   1. Look up rankDerivedValue + age for each rostered player.
+ *   2. Compute median age and total value (top-25 players, or all if
+ *      shorter).
+ *   3. Score along two dimensions:
+ *        - value vs the league median (above / below)
+ *        - age vs the league median (younger / older)
+ *
+ * Phase classification
+ * --------------------
+ *   high value × younger  →  Win-now    ("you're built to win now and later")
+ *   high value × older    →  Contender  ("you're built to win now")
+ *   low value × younger   →  Rebuild    ("you're young and still climbing")
+ *   low value × older     →  Mixed      ("you should probably reset")
+ *
+ * Trade-partner suggestion: a Win-now/Contender team is a natural
+ * buyer of older star talent from a Rebuild team.  We surface the
+ * three most-complementary pairs in the UI.
+ *
+ * No I/O — pure function from the live contract.
+ */
+
+const TOP_N_FOR_VALUE = 25;
+
+export const PHASES = Object.freeze({
+  WIN_NOW: { key: "win_now", label: "Win-now", tone: "up", order: 0 },
+  CONTENDER: { key: "contender", label: "Contender", tone: "up", order: 1 },
+  MIXED: { key: "mixed", label: "Mixed", tone: "warn", order: 2 },
+  REBUILD: { key: "rebuild", label: "Rebuild", tone: "down", order: 3 },
+});
+
+function median(values) {
+  const arr = (values || [])
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => a - b);
+  if (!arr.length) return null;
+  const mid = Math.floor(arr.length / 2);
+  return arr.length % 2 ? arr[mid] : (arr[mid - 1] + arr[mid]) / 2;
+}
+
+function buildIndex(rows) {
+  const ix = new Map();
+  for (const r of rows || []) {
+    if (!r?.name) continue;
+    ix.set(String(r.name).toLowerCase(), {
+      value: Number(r.rankDerivedValue || r.values?.full || 0),
+      age: Number(r.age) || null,
+    });
+  }
+  return ix;
+}
+
+function teamSnapshot(team, valueIndex) {
+  const players = Array.isArray(team?.players) ? team.players : [];
+  const lookup = players
+    .map((n) => valueIndex.get(String(n).toLowerCase()))
+    .filter((p) => p && p.value > 0);
+  // Sort by value desc, take top N for the "starter-equivalent" total.
+  const top = [...lookup].sort((a, b) => b.value - a.value).slice(0, TOP_N_FOR_VALUE);
+  const totalValue = top.reduce((s, p) => s + p.value, 0);
+  const ages = top.map((p) => p.age).filter((a) => Number.isFinite(a));
+  return {
+    name: team?.name || "Team",
+    ownerId: String(team?.ownerId || ""),
+    rosterId: String(team?.rosterId || ""),
+    totalValue: Math.round(totalValue),
+    medianAge: median(ages),
+    rosterCount: players.length,
+    valuedCount: top.length,
+  };
+}
+
+function classifyPhase(snapshot, leagueMedians) {
+  const { totalValue, medianAge } = snapshot;
+  const isHighValue = leagueMedians.value != null && totalValue > leagueMedians.value;
+  // ``younger`` is < median age (lower number = younger).  When
+  // medianAge is null (no age data), default to "older" so a team
+  // with missing data doesn't get pushed into the youth corner.
+  const isYounger =
+    medianAge != null && leagueMedians.age != null && medianAge < leagueMedians.age;
+
+  if (isHighValue && isYounger) return PHASES.WIN_NOW;
+  if (isHighValue && !isYounger) return PHASES.CONTENDER;
+  if (!isHighValue && isYounger) return PHASES.REBUILD;
+  return PHASES.MIXED;
+}
+
+export function analyzeLeaguePhases(rawData, rows) {
+  const teams = rawData?.sleeper?.teams || [];
+  if (!Array.isArray(teams) || teams.length === 0) {
+    return { teams: [], leagueMedians: { value: null, age: null }, partnerships: [] };
+  }
+  const valueIndex = buildIndex(rows);
+  const snapshots = teams.map((t) => teamSnapshot(t, valueIndex));
+
+  const leagueMedians = {
+    value: median(snapshots.map((s) => s.totalValue)),
+    age: median(snapshots.map((s) => s.medianAge).filter((a) => a != null)),
+  };
+
+  const enriched = snapshots.map((s) => {
+    const phase = classifyPhase(s, leagueMedians);
+    return { ...s, phase };
+  });
+
+  enriched.sort((a, b) => {
+    if (a.phase.order !== b.phase.order) return a.phase.order - b.phase.order;
+    return b.totalValue - a.totalValue;
+  });
+
+  const winners = enriched.filter((t) => t.phase.key === "win_now" || t.phase.key === "contender");
+  const rebuilders = enriched.filter((t) => t.phase.key === "rebuild");
+  const partnerships = [];
+  for (const w of winners) {
+    for (const r of rebuilders) {
+      // Score by complementarity: bigger value gap × bigger age gap = better fit.
+      const valueGap = w.totalValue - r.totalValue;
+      const ageGap = (r.medianAge || 0) - (w.medianAge || 0);
+      const score = Math.max(0, valueGap) * Math.max(0, ageGap || 1);
+      partnerships.push({
+        winnerOwnerId: w.ownerId,
+        winnerName: w.name,
+        rebuilderOwnerId: r.ownerId,
+        rebuilderName: r.name,
+        valueGap,
+        ageGap,
+        score,
+      });
+    }
+  }
+  partnerships.sort((a, b) => b.score - a.score);
+
+  return {
+    teams: enriched,
+    leagueMedians,
+    partnerships: partnerships.slice(0, 6),
+  };
+}


### PR DESCRIPTION
## Summary
- **`/league/activity`**: chronological feed combining Sleeper trades + news items, with scope (League / My roster) and type (All / Trades / News) filters. When scoped to "My roster", shows only events involving any player on the visitor's selectedTeam.
- **`/league/phases`**: every team classified as Win-now / Contender / Mixed / Rebuild based on top-25 roster value × median age, against the league medians. Surfaces a "natural trade partners for you" panel pairing high-value teams with rebuilders.
- Both pages added under the League nav dropdown.

## Test plan
- [x] `npm test __tests__/activity-feed.test.js` — 10/10
- [x] `npm test __tests__/team-phase.test.js` — 5/5
- [x] `npm run build` — all pages under budget
- [ ] Production: visit `/league/activity` and toggle scope to "My roster"; visit `/league/phases` and confirm each team's classification is sensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)