### PR TITLE
feat: retro-value badges on /trades \u2014 how each side aged

### DIFF
--- a/frontend/__tests__/trade-retro-value.test.js
+++ b/frontend/__tests__/trade-retro-value.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { valueSideAtTime, gradeRetro } from "@/lib/trade-retro-value";
+import { valueFromRank } from "@/lib/value-history";
+
+function makeLookup(map) {
+  return (name) => map[String(name).toLowerCase()] || [];
+}
+
+describe("valueSideAtTime", () => {
+  it("uses rankHistory rank-at-time to compute value", () => {
+    const lookup = makeLookup({
+      "player a": [
+        { date: "2025-01-01", rank: 30 },
+        { date: "2025-06-01", rank: 10 },
+      ],
+    });
+    const asOf = Date.parse("2025-03-01");
+    const out = valueSideAtTime(
+      [{ name: "Player A", val: 9999, isPick: false }],
+      lookup,
+      asOf,
+    );
+    expect(out.total).toBe(valueFromRank(30));
+    expect(out.items[0].source).toBe("rankHistory");
+  });
+
+  it("falls back to current val when no history found", () => {
+    const out = valueSideAtTime(
+      [{ name: "Unknown Player", val: 1234 }],
+      makeLookup({}),
+      Date.now(),
+    );
+    expect(out.items[0].source).toBe("current_fallback");
+    expect(out.total).toBe(1234);
+  });
+
+  it("uses current val for picks (no per-pick history yet)", () => {
+    const out = valueSideAtTime(
+      [{ name: "2026 1st (mid)", val: 5000, isPick: true }],
+      makeLookup({}),
+      Date.now(),
+    );
+    expect(out.items[0].source).toBe("current");
+    expect(out.total).toBe(5000);
+  });
+
+  it("returns {total: 0, items: []} for empty input", () => {
+    expect(valueSideAtTime([], () => [], Date.now())).toEqual({ total: 0, items: [] });
+    expect(valueSideAtTime(null, () => [], Date.now())).toEqual({ total: 0, items: [] });
+  });
+
+  it("uses earliest available sample when asOf is before all points", () => {
+    const lookup = makeLookup({
+      "rookie x": [
+        { date: "2025-08-01", rank: 50 },
+      ],
+    });
+    const asOf = Date.parse("2025-04-01"); // before history starts
+    const out = valueSideAtTime(
+      [{ name: "Rookie X", val: 9999, isPick: false }],
+      lookup,
+      asOf,
+    );
+    // Earliest point used as proxy.
+    expect(out.items[0].source).toBe("rankHistory");
+    expect(out.total).toBe(valueFromRank(50));
+  });
+});
+
+describe("gradeRetro", () => {
+  const lookup = makeLookup({
+    "got player": [{ date: "2025-01-01", rank: 100 }], // value-at-trade ≈ small
+    "gave player": [{ date: "2025-01-01", rank: 5 }],  // value-at-trade ≈ large
+  });
+  const asOf = Date.parse("2025-02-01");
+
+  it("flags 'aged_well' when current net beats at-trade net by >200", () => {
+    const side = {
+      got: [{ name: "Got Player", val: valueFromRank(20), isPick: false }],
+      gave: [{ name: "Gave Player", val: valueFromRank(30), isPick: false }],
+    };
+    // currentNet ≈ value(20) - value(30) ≈ positive
+    const currentNet = valueFromRank(20) - valueFromRank(30);
+    const out = gradeRetro({ side, currentNet, asOfMs: asOf, historyLookup: lookup });
+    expect(out.atTradeNet).toBe(valueFromRank(100) - valueFromRank(5));
+    expect(out.verdictDelta).toBeGreaterThan(200);
+    expect(out.verdict).toBe("aged_well");
+  });
+
+  it("flags 'aged_poorly' when current net is much worse", () => {
+    const side = {
+      got: [{ name: "Got Player", val: valueFromRank(200), isPick: false }],
+      gave: [{ name: "Gave Player", val: valueFromRank(2), isPick: false }],
+    };
+    const currentNet = valueFromRank(200) - valueFromRank(2); // very negative
+    const out = gradeRetro({ side, currentNet, asOfMs: asOf, historyLookup: lookup });
+    expect(out.verdictDelta).toBeLessThan(-200);
+    expect(out.verdict).toBe("aged_poorly");
+  });
+
+  it("flags 'stable' when delta is small", () => {
+    const lookup2 = makeLookup({
+      "got": [{ date: "2025-01-01", rank: 30 }],
+      "gave": [{ date: "2025-01-01", rank: 30 }],
+    });
+    const side = {
+      got: [{ name: "Got", val: valueFromRank(30) + 50, isPick: false }],
+      gave: [{ name: "Gave", val: valueFromRank(30), isPick: false }],
+    };
+    const currentNet = 50;
+    const out = gradeRetro({ side, currentNet, asOfMs: asOf, historyLookup: lookup2 });
+    expect(out.verdict).toBe("stable");
+  });
+
+  it("returns 'unknown' when currentNet is non-finite", () => {
+    const side = { got: [], gave: [] };
+    const out = gradeRetro({ side, currentNet: NaN, asOfMs: asOf, historyLookup: lookup });
+    expect(out.verdict).toBe("unknown");
+  });
+});

--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -12,6 +12,9 @@ import {
   POS_GROUP_COLORS,
 } from "@/lib/league-analysis";
 import { encodeTrade, SHARE_PARAM } from "@/lib/trade-share";
+import { useRankHistory } from "@/components/useRankHistory";
+import { buildHistoryLookup } from "@/lib/value-history";
+import { gradeRetro } from "@/lib/trade-retro-value";
 
 const POS_COLORS = {
   QB: "#e74c3c", RB: "#27ae60", WR: "#3498db", TE: "#e67e22",
@@ -30,6 +33,35 @@ export default function TradesPage() {
     () => analyzeSleeperTradeHistory(rawData, rows, windowDays, alpha),
     [rawData, rows, windowDays, alpha],
   );
+
+  // Pull rank history so we can value each trade at the date it
+  // happened.  ``useRankHistory`` is single-flight + cached for 60s.
+  const { history: rankHistory } = useRankHistory({ days: 365 });
+  const historyLookup = useMemo(
+    () => buildHistoryLookup(rankHistory),
+    [rankHistory],
+  );
+  // Map of (analyzed trade.id) → per-side retro grade so the renderer
+  // can stamp an "aged well / aged poorly / stable" chip on each side.
+  const retroByTrade = useMemo(() => {
+    if (!analysis?.analyzed?.length) return new Map();
+    const out = new Map();
+    for (const a of analysis.analyzed) {
+      const ts = Number(a.trade?._statusUpdatedMs)
+        || Date.parse(a.date)
+        || Date.now();
+      const perSide = (a.sides || []).map((side) =>
+        gradeRetro({
+          side,
+          currentNet: side.netValue,
+          asOfMs: ts,
+          historyLookup,
+        }),
+      );
+      out.set(a.id, perSide);
+    }
+    return out;
+  }, [analysis, historyLookup]);
 
   const teams = useMemo(() => {
     const set = new Set();
@@ -128,7 +160,11 @@ export default function TradesPage() {
       {filtered.length > 0 && (
         <div className="list" style={{ marginTop: "var(--space-md)" }}>
           {filtered.map((a, idx) => (
-            <TradeCard key={idx} analysis={a} />
+            <TradeCard
+              key={idx}
+              analysis={a}
+              retroSides={retroByTrade.get(a.id) || []}
+            />
           ))}
         </div>
       )}
@@ -291,7 +327,29 @@ function AssetRow({ label, items, total }) {
   );
 }
 
-function TradeCard({ analysis: a }) {
+const RETRO_META = {
+  aged_well: { label: "Aged well", color: "var(--green)", soft: "var(--green-soft)" },
+  aged_poorly: { label: "Aged poorly", color: "var(--red)", soft: "var(--red-soft)" },
+  stable: { label: "Stable", color: "var(--subtext)", soft: "transparent" },
+  unknown: null,
+};
+
+function fmtRetro(retro) {
+  if (!retro) return null;
+  const meta = RETRO_META[retro.verdict];
+  if (!meta) return null;
+  const delta = Number.isFinite(retro.verdictDelta) ? Math.round(retro.verdictDelta) : null;
+  const sign = delta != null && delta !== 0 ? (delta > 0 ? "+" : "") : "";
+  return {
+    ...meta,
+    label: delta != null
+      ? `${meta.label} (${sign}${delta.toLocaleString()})`
+      : meta.label,
+    title: `Value at trade: ${retro.atTradeNet > 0 ? "+" : ""}${Math.round(retro.atTradeNet).toLocaleString()} · current: ${retro.currentNet > 0 ? "+" : ""}${Math.round(retro.currentNet || 0).toLocaleString()}`,
+  };
+}
+
+function TradeCard({ analysis: a, retroSides = [] }) {
   // Headline reflects the largest grievance — winner OR loser,
   // whichever has the biggest magnitude pctGap.  If no side clears
   // ±3%, the trade reads as fair on both the card header and the
@@ -371,6 +429,7 @@ function TradeCard({ analysis: a }) {
               ? "var(--red)"
               : "var(--subtext)";
           const netSign = side.netValue >= 0 ? "+" : "−";
+          const retroChip = fmtRetro(retroSides[i]);
           return (
             <div key={i}>
               <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
@@ -405,6 +464,22 @@ function TradeCard({ analysis: a }) {
                   </span>
                 )}
               </div>
+              {retroChip && (
+                <div
+                  className="badge"
+                  title={retroChip.title}
+                  style={{
+                    fontSize: "0.6rem",
+                    fontFamily: "var(--mono)",
+                    background: retroChip.soft,
+                    color: retroChip.color,
+                    marginTop: 2,
+                    display: "inline-block",
+                  }}
+                >
+                  {retroChip.label}
+                </div>
+              )}
             </div>
           );
         })}

--- a/frontend/lib/trade-retro-value.js
+++ b/frontend/lib/trade-retro-value.js
@@ -1,0 +1,111 @@
+/**
+ * trade-retro-value — value each side of a historical trade at the
+ * date the trade went through, using rankHistory.
+ *
+ * The existing ``analyzeSleeperTradeHistory`` grades trades at
+ * *current* values.  This helper layers in the at-trade snapshot so
+ * the UI can show a trade's age — "you won this by 3,200 then; it's
+ * now a 1,800 win because Player X faded."
+ *
+ * Inputs
+ * ------
+ *   trade           — the analyzed trade record from
+ *                     analyzeSleeperTradeHistory (.sides[].items[].name)
+ *   tradeTimestamp  — epoch ms of the trade
+ *   historyLookup   — function (name) → [{date, rank}] from
+ *                     buildHistoryLookup(history)
+ *
+ * Output
+ * ------
+ *   {
+ *     atTradeBySide: [{ side: "got"|"gave", total, items: [...]}, ...],
+ *     verdict:        "winner"|"loser"|"even"|"unknown"
+ *     verdictDelta:   number — current_net - at_trade_net
+ *   }
+ *
+ * verdict logic: positive verdictDelta means the team came out ahead
+ * relative to expectations at the time of the trade.  A team that
+ * looked even at the time but is now +3,000 ahead = winner.
+ */
+import { valueFromRank } from "@/lib/value-history";
+
+function rankAt(history, asOfMs) {
+  if (!Array.isArray(history) || history.length === 0) return null;
+  let best = null;
+  for (const point of history) {
+    const t = Date.parse(point?.date);
+    if (!Number.isFinite(t)) continue;
+    const rank = Number(point?.rank);
+    if (!Number.isFinite(rank) || rank <= 0) continue;
+    if (t <= asOfMs) {
+      if (!best || t > best.t) best = { t, rank };
+    } else if (!best) {
+      // No earlier point — first sample after the trade is the best
+      // available proxy.  Better than null when the player was ranked
+      // shortly after the trade.
+      best = { t, rank };
+    }
+  }
+  return best ? best.rank : null;
+}
+
+export function valueSideAtTime(items, historyLookup, asOfMs) {
+  if (!Array.isArray(items)) return { total: 0, items: [] };
+  let total = 0;
+  const out = [];
+  for (const it of items) {
+    if (!it) continue;
+    if (it.isPick) {
+      // Picks: lean on the current value.  Pick valuation history is
+      // not stamped per-pick; using the current ``val`` is the
+      // pragmatic baseline.  Slight optimism if pick markets have
+      // moved since the trade — caller can detect this gap.
+      const v = Number(it.val) || 0;
+      out.push({ name: it.name, val: v, isPick: true, source: "current" });
+      total += v;
+      continue;
+    }
+    const history = historyLookup ? historyLookup(it.name) : null;
+    const rankAtTrade = rankAt(history, asOfMs);
+    if (rankAtTrade != null) {
+      const v = valueFromRank(rankAtTrade);
+      out.push({ name: it.name, val: v, isPick: false, source: "rankHistory" });
+      total += v;
+    } else {
+      const v = Number(it.val) || 0;
+      out.push({ name: it.name, val: v, isPick: false, source: "current_fallback" });
+      total += v;
+    }
+  }
+  return { total: Math.round(total), items: out };
+}
+
+/**
+ * Compute "got" minus "gave" deltas for both at-trade and current.
+ * Returns the verdict + the magnitudes for one side of a 2-team trade.
+ */
+export function gradeRetro({ side, currentNet, asOfMs, historyLookup }) {
+  if (!side) return null;
+  const got = side.got || side.gotItems || [];
+  const gave = side.gave || side.gaveItems || [];
+  const atTradeGot = valueSideAtTime(got, historyLookup, asOfMs);
+  const atTradeGave = valueSideAtTime(gave, historyLookup, asOfMs);
+  const atTradeNet = atTradeGot.total - atTradeGave.total;
+  const verdictDelta = Number.isFinite(currentNet)
+    ? currentNet - atTradeNet
+    : null;
+  let verdict = "unknown";
+  if (Number.isFinite(verdictDelta)) {
+    if (verdictDelta > 200) verdict = "aged_well";
+    else if (verdictDelta < -200) verdict = "aged_poorly";
+    else verdict = "stable";
+  }
+  return {
+    atTradeGot,
+    atTradeGave,
+    atTradeNet,
+    currentNet,
+    verdictDelta,
+    verdict,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a per-side "Aged well / Stable / Aged poorly" chip on every `/trades` card, computed from rank-history at the trade timestamp.
- Pure helper at `lib/trade-retro-value.js`: looks each player's rank up at the trade date, Hill-curve converts to value-at-trade, compares with current net.
- Verdict thresholds: |delta| > 200 = aged_well/aged_poorly, otherwise stable.
- Picks fall back to current value (no per-pick history yet) — flagged as `current` source for future expansion.

## Test plan
- [x] `npm test __tests__/trade-retro-value.test.js` — 9/9
- [x] `npm run build` — all pages under budget (trades 17.3/20 KB)
- [ ] Production: visit `/trades`, confirm badges render per side, hover for at-trade vs current values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)