### PR TITLE
feat: KTC TE+ sub-board (ktcSfTep) for per-source winner row

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -1633,13 +1633,59 @@ async def page_dump(page, label, limit=2500):
 # ─────────────────────────────────────────
 # FantasyCalc — JSON API, TEP + SF
 # ─────────────────────────────────────────
+# KTC's per-player API response carries every TE-premium variant
+# alongside the base SF value (e.g. ``superflexValues.tep`` for TE+
+# level 1 / "TE Premium").  We pluck the level-1 value into a parallel
+# map so the canonical pipeline can register a separate ``ktcSfTep``
+# sub-board.  The field-name list is intentionally generous — KTC has
+# rotated naming a few times and the cost of an extra .get() lookup
+# is negligible against the cost of silently writing an empty CSV.
+_KTC_TEP_FIELD_KEYS = (
+    "tep", "tepValue", "tep_value",
+    "tep1", "tep1Value", "tep1_value",
+    "tepLevel1", "tepValueLevel1",
+)
+_KTC_TEP_TOPLEVEL_KEYS = (
+    "sfTepValue", "sf_tep_value", "value_sftep",
+    "tepValue", "tep_value",
+)
+
+
+def _ktc_extract_tep(item):
+    """Return the TE+ (level 1) superflex value from a KTC API item, or None."""
+    if not isinstance(item, dict):
+        return None
+    if SUPERFLEX:
+        sf_vals = item.get("superflexValues")
+        if isinstance(sf_vals, dict):
+            for k in _KTC_TEP_FIELD_KEYS:
+                v = sf_vals.get(k)
+                if v is not None:
+                    return v
+        sf_vals2 = item.get("superflexValue")
+        if isinstance(sf_vals2, dict):
+            for k in _KTC_TEP_FIELD_KEYS:
+                v = sf_vals2.get(k)
+                if v is not None:
+                    return v
+    for k in _KTC_TEP_TOPLEVEL_KEYS:
+        v = item.get(k)
+        if v is not None:
+            return v
+    return None
+
+
 @retry(max_attempts=3, delay=2, exceptions=(requests.RequestException,))
 async def scrape_ktc(page, players):
     results = {p: None for p in players}
     cached = get_cached("KTC")
     if cached:
         match_all(players, cached, results, site_key="KTC")
+        cached_tep = get_cached("KTC_TEP")
+        if cached_tep:
+            FULL_DATA["KTC_TEP"] = dict(cached_tep)
         return results
+    tep_name_map = {}
     try:
         sf  = "true" if SUPERFLEX else "false"
         url = f"https://keeptradecut.com/dynasty-rankings?sf={sf}&tep=2&filters=QB|WR|RB|TE|RDP"
@@ -1740,9 +1786,17 @@ async def scrape_ktc(page, players):
                             name_map[clean_name(pname)] = int(float(val))
                         except (ValueError, TypeError):
                             pass
+                    tep_val = _ktc_extract_tep(item)
+                    if tep_val is not None:
+                        try:
+                            tep_name_map[clean_name(pname)] = int(float(tep_val))
+                        except (ValueError, TypeError):
+                            pass
                 if name_map and DEBUG:
                     sf_label = "SF API" if SUPERFLEX else "1QB API"
                     print(f"  [KTC] Parsed {len(name_map)} players from API ({sf_label}): {api_url[:60]}")
+                    if tep_name_map:
+                        print(f"  [KTC] TE+ values present for {len(tep_name_map)} players")
                     # Show first item structure for debugging
                     if body and isinstance(body, list) and len(body) > 0:
                         sample = body[0]
@@ -1758,16 +1812,28 @@ async def scrape_ktc(page, players):
             if DEBUG:
                 print("  [KTC] No API data — trying DOM scrape of rendered values")
 
-            # KTC renders values in the DOM after client JS runs
+            # KTC renders values in the DOM after client JS runs.  The
+            # JS payload returns ``{name: {value, tep}}`` so the Python
+            # side can split base SF and TE+ into separate maps.
             dom_data = await page.evaluate("""() => {
                 const results = {};
+                const tepKeys = ['tep','tepValue','tep_value','tep1','tep1Value','tep1_value','tepLevel1','tepValueLevel1'];
+                const grabTep = (obj) => {
+                    if (!obj) return null;
+                    for (const k of tepKeys) {
+                        const v = obj[k];
+                        if (v !== undefined && v !== null) return parseInt(v);
+                    }
+                    return null;
+                };
                 // Try reading from inline playersArray (current KTC format as of 2026-03)
                 if (typeof playersArray !== 'undefined' && Array.isArray(playersArray)) {
                     for (const p of playersArray) {
                         const name = p.playerName || p.name;
                         const sfVals = p.superflexValues;
                         const val = (sfVals && sfVals.value) || p.superflexValue || p.value;
-                        if (name && val) results[name] = parseInt(val);
+                        const tep = grabTep(sfVals) || grabTep(p);
+                        if (name && val) results[name] = { value: parseInt(val), tep };
                     }
                 }
                 if (Object.keys(results).length > 10) return results;
@@ -1782,12 +1848,13 @@ async def scrape_ktc(page, players):
                                 const name = p.playerName || p.name;
                                 const sfVals = p.superflexValues;
                                 const val = (sfVals && sfVals.value) || p.superflexValue || p.value;
-                                if (name && val) results[name] = parseInt(val);
+                                const tep = grabTep(sfVals) || grabTep(p);
+                                if (name && val) results[name] = { value: parseInt(val), tep };
                             }
                         }
                     } catch(e) {}
                 }
-                // Fallback: read from visible DOM elements
+                // Fallback: read from visible DOM elements (no TE+ available in raw DOM)
                 if (Object.keys(results).length === 0) {
                     const rows = document.querySelectorAll('.one-player, [class*="rankings-page--item"], [class*="player-row"]');
                     for (const row of rows) {
@@ -1796,7 +1863,7 @@ async def scrape_ktc(page, players):
                         if (nameEl && valEl) {
                             const name = nameEl.textContent.trim();
                             const val = parseInt(valEl.textContent.trim().replace(/,/g, ''));
-                            if (name && !isNaN(val)) results[name] = val;
+                            if (name && !isNaN(val)) results[name] = { value: val, tep: null };
                         }
                     }
                 }
@@ -1804,10 +1871,22 @@ async def scrape_ktc(page, players):
             }""")
 
             if dom_data and len(dom_data) > 10:
-                for nm, val in dom_data.items():
-                    name_map[clean_name(nm)] = int(val)
+                for nm, payload in dom_data.items():
+                    if isinstance(payload, dict):
+                        v = payload.get("value")
+                        t = payload.get("tep")
+                    else:
+                        v = payload
+                        t = None
+                    if v is not None:
+                        name_map[clean_name(nm)] = int(v)
+                    if t is not None:
+                        try:
+                            tep_name_map[clean_name(nm)] = int(t)
+                        except (ValueError, TypeError):
+                            pass
                 if DEBUG:
-                    print(f"  [KTC] DOM scrape found {len(name_map)} players")
+                    print(f"  [KTC] DOM scrape found {len(name_map)} players ({len(tep_name_map)} with TE+)")
 
         # ── Strategy 3: Full page source parsing ──
         if not name_map:
@@ -1840,8 +1919,14 @@ async def scrape_ktc(page, players):
                             val = item.get("value")
                         if val is not None:
                             name_map[clean_name(pname)] = int(float(val))
+                        tep_val = _ktc_extract_tep(item)
+                        if tep_val is not None:
+                            try:
+                                tep_name_map[clean_name(pname)] = int(float(tep_val))
+                            except (ValueError, TypeError):
+                                pass
                     if name_map and DEBUG:
-                        print(f"  [KTC] playersArray parsed {len(name_map)} players")
+                        print(f"  [KTC] playersArray parsed {len(name_map)} players ({len(tep_name_map)} with TE+)")
                 except Exception as e:
                     if DEBUG:
                         print(f"  [KTC] playersArray parse error: {e}")
@@ -1866,8 +1951,14 @@ async def scrape_ktc(page, players):
                             val = item.get("value")
                         if val is not None:
                             name_map[clean_name(pname)] = int(val)
+                        tep_val = _ktc_extract_tep(item)
+                        if tep_val is not None:
+                            try:
+                                tep_name_map[clean_name(pname)] = int(float(tep_val))
+                            except (ValueError, TypeError):
+                                pass
                     if name_map and DEBUG:
-                        print(f"  [KTC] __NEXT_DATA__ parsed {len(name_map)} players")
+                        print(f"  [KTC] __NEXT_DATA__ parsed {len(name_map)} players ({len(tep_name_map)} with TE+)")
                 except Exception as e:
                     if DEBUG:
                         print(f"  [KTC] __NEXT_DATA__ parse error: {e}")
@@ -1967,6 +2058,21 @@ async def scrape_ktc(page, players):
 
         set_cache("KTC", name_map)
         match_all(players, name_map, results, site_key="KTC")
+        # TE+ (level 1) sub-board: only stash if at least a handful of
+        # players carried the field, so the per-source winner row can
+        # tell "TE+ scrape genuinely succeeded" from "the API stopped
+        # exposing TE+ values".  The 25-player floor is well below the
+        # ~150 TEs+top WRs that materially benefit from TE Premium and
+        # well above any noise threshold.
+        if tep_name_map and len(tep_name_map) >= 25:
+            FULL_DATA["KTC_TEP"] = dict(tep_name_map)
+            set_cache("KTC_TEP", tep_name_map)
+            if DEBUG:
+                la = tep_name_map.get("Sam LaPorta") or tep_name_map.get("sam laporta")
+                bo = tep_name_map.get("Brock Bowers") or tep_name_map.get("brock bowers")
+                print(f"  [KTC] TE+ map stored: {len(tep_name_map)} players (LaPorta={la}, Bowers={bo})")
+        elif DEBUG:
+            print(f"  [KTC] TE+ map skipped — only {len(tep_name_map)} players carried TE+ fields (need ≥25)")
 
         # ── Always build playerID → name mapping for trade/waiver database ──
         global KTC_ID_TO_NAME
@@ -3597,6 +3703,7 @@ async def run(progress_callback=None):
     # ── Save JSON for dashboard ──
     site_key_map = {
         "KTC":          "ktc",
+        "KTC_TEP":      "ktcSfTep",
         "IDPTradeCalc": "idpTradeCalc",
     }
 
@@ -3612,7 +3719,7 @@ async def run(progress_callback=None):
             print(f"  [Max] {scraper_name} → {max_values[dash_key]}")
 
     # ── Trim sites to top N players before building JSON ──
-    _OFFENSIVE_SITES = {"KTC", "FantasyCalc", "DynastyDaddy", "FantasyPros",
+    _OFFENSIVE_SITES = {"KTC", "KTC_TEP", "FantasyCalc", "DynastyDaddy", "FantasyPros",
                         "DraftSharks", "Yahoo", "DynastyNerds", "DLF_SF"}
     _DEFENSIVE_SITES = {"PFF_IDP", "FantasyPros_IDP", "DLF_IDP"}
     _ROOKIE_ONLY_DLF_SITES = {"DLF_RSF", "DLF_RIDP"}

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -470,13 +470,20 @@ function TradeSourceBreakdown({ sides, settings }) {
       vendorSubs.get(vendor).push(src);
     }
 
+    // KTC and its TE+ sibling are the only vendors with native 0-9999
+    // pick values, and the only ones whose per-source winner row uses
+    // the raw KTC values directly so the V13 Value Adjustment formula
+    // (calibrated against KTC's raw scale) reproduces what
+    // keeptradecut.com displays.  Centralised so includePicks and
+    // useRawNative stay in lockstep.
+    const KTC_RAW_NATIVE_VENDORS = new Set(["ktc", "ktcSfTep"]);
     return vendorOrder
       .map((vendor) => {
         const subs = vendorSubs.get(vendor);
-        // Picks are included only for KTC — it's the canonical pick-
-        // valuation board.  Every other vendor leaves picks uncovered
-        // and would skew the piece-count math if we counted them.
-        const includePicks = vendor === "ktc";
+        // Picks are included only for KTC (and its TE+ sibling, sourced
+        // from the same scrape).  Every other vendor leaves picks
+        // uncovered and would skew the piece-count math if we counted them.
+        const includePicks = KTC_RAW_NATIVE_VENDORS.has(vendor);
         // Sub-board priority rule: main boards win over rookie-
         // specialty boards.  Once a rookie is promoted onto a
         // vendor's main SF/IDP board (typically post-NFL-draft), the
@@ -493,8 +500,8 @@ function TradeSourceBreakdown({ sides, settings }) {
         const rookieSubs = subs.filter((s) => s.needsRookieTranslation);
         // Per-source value resolution.
         //
-        // For KTC specifically, the V13 Value Adjustment formula and
-        // its empirical suppression thresholds (V13_SUPPRESS_RAW_DIFF,
+        // For KTC and its TE+ sibling, the V13 Value Adjustment formula
+        // and its empirical suppression thresholds (V13_SUPPRESS_RAW_DIFF,
         // V13_SUPPRESS_SAME_SIDE_RAW_DIFF) were calibrated against
         // KTC's raw 0-9999 piece values.  Feeding the formula the
         // canonical Hill-blended ``valueContribution`` instead would
@@ -502,15 +509,15 @@ function TradeSourceBreakdown({ sides, settings }) {
         // inventing one — and the per-source KTC row would disagree
         // with what keeptradecut.com displays for the same trade.
         // We therefore use the raw KTC value from
-        // ``row.canonicalSites['ktc']`` as the formula input for the
-        // KTC vendor row.
+        // ``row.canonicalSites['ktc']`` (or ``['ktcSfTep']`` for the
+        // TE+ row) as the formula input.
         //
         // For every other vendor we keep the Hill-normalized
         // ``valueContribution``: rank-only sources don't have a raw
         // native value, and cross-market rank sources stash a
         // synthetic 100,000+ rank-encoded number in ``canonicalSites``
         // that would break the V13 formula's 0-9999-scaled ratios.
-        const useRawNative = vendor === "ktc";
+        const useRawNative = KTC_RAW_NATIVE_VENDORS.has(vendor);
         const sourceValueForRow = (row, sub) => {
           if (useRawNative) {
             const native = Number(row.canonicalSites?.[sub.key]);

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -233,6 +233,28 @@ export const RANKING_SOURCES = [
     isTepPremium: false,
   },
   {
+    // KeepTradeCut Superflex + TE Premium sub-board.  Sourced from
+    // the same scrape as `ktc` — KTC's per-player API response
+    // carries `superflexValues.tep` (level 1, "TE+") alongside the
+    // base `superflexValues.value`, so one Dynasty Scraper run
+    // produces both CSVs.  Registered as its own source so the
+    // per-source winner row in the trade page can show "KTC TE+"
+    // next to "KTC" — users on TE Premium scoring get a row that
+    // matches keeptradecut.com's TE+ display directly instead of the
+    // standard-SF row that disagrees with their league setup.  Mirrors
+    // the backend `_RANKING_SOURCES` entry in src/api/data_contract.py.
+    key: "ktcSfTep",
+    displayName: "KeepTradeCut SF-TEP",
+    columnLabel: "KTC TE+",
+    scope: "overall_offense",
+    positionGroup: null,
+    depth: null,
+    weight: 1.0,
+    isBackbone: false,
+    isRetail: false,
+    isTepPremium: true,
+  },
+  {
     // IDP Trade Calculator's value pool covers both offense (via the
     // site's autocomplete) and IDP in the same 0-9999 scale.  Register
     // under overall_idp (as the IDP backbone) AND overall_offense (as a

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -210,6 +210,13 @@ _QUARANTINE_FLAGS = {
 #     sort in _compute_unified_rankings produces the correct ordinal)
 _SOURCE_CSV_PATHS: dict[str, Any] = {
     "ktc": "CSVs/site_raw/ktc.csv",
+    # KeepTradeCut Superflex + TE Premium (level 1 / "TE+") sub-board.
+    # Sourced from the same scrape as ``ktc`` — the per-player API
+    # response carries ``superflexValues.tep`` alongside the base SF
+    # value, so a single Dynasty Scraper run produces both CSVs.
+    # Standard ``name,value`` shape on the same 0-9999 scale; signal
+    # defaults to "value".
+    "ktcSfTep": "CSVs/site_raw/ktcSfTep.csv",
     "idpTradeCalc": "CSVs/site_raw/idpTradeCalc.csv",
     "dlfIdp": {
         "path": "CSVs/site_raw/dlfIdp.csv",
@@ -440,6 +447,9 @@ _RANK_TO_SYNTHETIC_VALUE_OFFSET = 10000
 # by hand.
 _SOURCE_MAX_AGE_HOURS: dict[str, int] = {
     "ktc": 6,
+    # KTC TE+ (level 1) sub-board is sourced from the same scrape as
+    # ``ktc``, so it shares the 6-hour staleness budget.
+    "ktcSfTep": 6,
     "idpTradeCalc": 6,
     "dynastyNerdsSfTep": 6,
     "fantasyProsIdp": 6,
@@ -824,6 +834,29 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # on the blended board.  See frontend/lib/dynasty-data.js for
         # the mirrored flag.
         "is_tep_premium": False,
+    },
+    {
+        # KeepTradeCut Superflex + TE Premium sub-board.  Sourced from
+        # the same scrape as ``ktc`` — KTC's per-player API response
+        # carries ``superflexValues.tep`` (level 1, "TE+") alongside
+        # the base ``superflexValues.value``, so one Dynasty Scraper
+        # run produces both CSVs.  Registered as its own source so the
+        # per-source winner row in the trade page can show "KTC TE+"
+        # next to "KTC" — users on TE Premium scoring get a row that
+        # matches keeptradecut.com's TE+ display directly instead of
+        # the standard-SF row that disagrees with their league setup.
+        # `is_retail: False` because the retail signal is already
+        # carried by the base ``ktc`` entry — flagging both as retail
+        # would double-count the market-gap calculation.
+        "key": "ktcSfTep",
+        "display_name": "KeepTradeCut SF-TEP",
+        "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
+        "position_group": None,
+        "depth": None,
+        "weight": 1.0,
+        "is_backbone": False,
+        "is_retail": False,
+        "is_tep_premium": True,
     },
     {
         # IDP Trade Calculator's public value pool covers both offense
@@ -4218,6 +4251,10 @@ _DS_COMBINED_RANK_KEYS: frozenset[str] = frozenset(
 
 _VALUE_BASED_SOURCES: frozenset[str] = frozenset({
     "ktc",
+    # ``ktcSfTep`` is sourced from the same KTC scrape as ``ktc`` and
+    # carries native 0-9999 values (the per-player API response
+    # includes ``superflexValues.tep`` for the TE+ variant).
+    "ktcSfTep",
     "idpTradeCalc",
     # ``dynastyDaddySf``, ``yahooBoone``, and ``fantasyProsFitzmaurice``
     # were moved to the rank-signal path 2026-04-22 after the Hampel


### PR DESCRIPTION
## Summary

- KTC's per-player API response carries `superflexValues.tep` (TE Premium level 1) alongside the base SF value, but the scraper was extracting only `value`. TE Premium leagues saw a per-source winner row that disagreed with keeptradecut.com's TE+ display — Sam LaPorta scraped at 4506 (standard SF) while KTC.com TE+ shows 5049, exactly matching the user-reported gap.
- Adds `ktcSfTep` as a sibling sub-board sourced from the same scrape (no extra HTTP fetch). A 25-player floor in the scraper guards against KTC silently dropping the TE+ field.
- Trade page's per-source winner table now shows "KTC" and "KTC TE+" as two rows, both feeding raw 0-9999 KTC values into the V13 Value Adjustment formula. Users on TE Premium scoring get a row that matches keeptradecut.com directly.

## Test plan

- [x] `pytest tests/api/test_source_registry_parity.py` — Python and frontend registries stay in lockstep
- [x] `pytest tests/api/test_source_overrides.py tests/api/test_per_source_freshness.py tests/api/test_source_health_alerts.py tests/api/test_source_monitoring.py tests/api/test_single_source_resolution.py` — 109 passed; one pre-existing failure on main (player quarantine count, unrelated)
- [x] `npx vitest run __tests__/trade-logic.test.js __tests__/ktc-pick-import.test.js` — 162 passed
- [x] `npm run build` — clean, all bundle budgets ok
- [ ] After merge + scrape: confirm `CSVs/site_raw/ktcSfTep.csv` is written with TE values diverging from `ktc.csv`
- [ ] After deploy: verify per-source winner table shows separate "KTC" + "KTC TE+" rows on a TE-heavy trade

🤖 Generated with [Claude Code](https://claude.com/claude-code)