### PR TITLE
test: bump methodology source count 19 → 20 for ktcSfTep

### DIFF
--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -458,19 +458,20 @@ class TestPayloadLevelBlocks(unittest.TestCase):
         self.assertIn("confidenceBuckets", meth)
         self.assertIn("anomalyFlags", meth)
         self.assertIsInstance(meth["sources"], list)
-        # ktc + idpTradeCalc + dlfIdp + idpShow + dlfSf +
+        # ktc + ktcSfTep + idpTradeCalc + dlfIdp + idpShow + dlfSf +
         # dynastyNerdsSfTep + fantasyProsSf + dynastyDaddySf +
         # fantasyProsIdp + flockFantasySf + footballGuysSf +
         # footballGuysIdp + yahooBoone + fantasyProsFitzmaurice +
         # dlfRookieSf + flockFantasySfRookies + dlfRookieIdp +
-        # draftSharks + draftSharksIdp (nineteen sources as of
-        # 2026-04-21 when The IDP Show was added).
-        self.assertEqual(len(meth["sources"]), 19)
+        # draftSharks + draftSharksIdp (twenty sources as of
+        # 2026-04-26 when KTC TE+ sub-board was added).
+        self.assertEqual(len(meth["sources"]), 20)
         keys = {s.get("key") for s in meth["sources"]}
         self.assertEqual(
             keys,
             {
                 "ktc",
+                "ktcSfTep",
                 "idpTradeCalc",
                 "dlfIdp",
                 "idpShow",


### PR DESCRIPTION
## Summary

PR #332 added the `ktcSfTep` sub-board to `_RANKING_SOURCES`, taking the total from 19 to 20. `test_methodology_block_present` hard-codes the expected count, so it failed CI on the merged commit. Update the assertion, the expected keys set, and the comment to include `ktcSfTep`.

## Test plan

- [x] `pytest tests/api/` passes locally — 921 passed, 3 skipped, 162 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)