### PR TITLE
mobile: show Per-source winner; auth: drop Sleeper-username login

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3167,19 +3167,10 @@ input[type="range"]:focus-visible::-moz-range-thumb {
    VA-adjusted totals, winner + margin.
    ══════════════════════════════════════════════════════════════════════════ */
 .source-breakdown-card .source-breakdown-header {
-  background: none;
-  border: 0;
-  padding: 0;
   margin: 0 0 6px 0;
-  width: 100%;
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
   gap: 8px;
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: default;
 }
 .source-breakdown-card .source-breakdown-header-text {
   display: flex;
@@ -3187,46 +3178,6 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   gap: 8px;
   flex-wrap: wrap;
   min-width: 0;
-}
-.source-breakdown-card .source-breakdown-chevron {
-  display: none;
-}
-@media (max-width: 768px) {
-  .source-breakdown-card .source-breakdown-header {
-    cursor: pointer;
-    align-items: center;
-  }
-  .source-breakdown-card .source-breakdown-header-text {
-    align-items: center;
-  }
-  .source-breakdown-card .source-breakdown-subtitle {
-    display: none;
-  }
-  .source-breakdown-card.is-expanded .source-breakdown-subtitle {
-    display: block;
-    flex-basis: 100%;
-    margin-top: 4px;
-  }
-  .source-breakdown-card:not(.is-expanded) .source-breakdown-header {
-    margin-bottom: 0;
-  }
-  .source-breakdown-card:not(.is-expanded) .source-breakdown-body {
-    display: none;
-  }
-  .source-breakdown-card .source-breakdown-chevron {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    width: 28px;
-    height: 28px;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    color: var(--subtext);
-    font-family: var(--mono);
-    font-size: 1.05rem;
-    line-height: 1;
-  }
 }
 .source-breakdown-table {
   width: 100%;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1401,24 +1401,6 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 .login-badge { color: var(--cyan); border-color: rgba(255, 199, 4, 0.35); background: rgba(255, 199, 4, 0.08); }
-.login-mode-tab {
-  padding: 8px 14px;
-  background: transparent;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  color: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 600;
-  cursor: pointer;
-  margin-bottom: -1px;
-}
-.login-mode-tab.is-active {
-  color: var(--cyan);
-  border-bottom-color: var(--cyan);
-}
-.login-mode-tab:hover:not(.is-active) {
-  color: var(--text);
-}
 .login-form { margin-top: var(--space-md); display: grid; gap: 10px; }
 .login-label { font-size: 0.78rem; font-weight: 700; color: var(--muted); }
 .login-input { width: 100%; }

--- a/frontend/app/login/page.jsx
+++ b/frontend/app/login/page.jsx
@@ -5,28 +5,9 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAuthContext } from "@/app/AppShellWrapper";
 
-/**
- * Login page — two sign-in paths:
- *
- * 1. Sleeper username (primary, multi-user) — user types their
- *    Sleeper handle, we look them up via the public Sleeper API.
- *    Session is keyed on their Sleeper user_id so user_kv
- *    (watchlist, dismissals, selectedTeam) partitions per-person.
- *    No password, no account creation; trust-on-first-use for a
- *    league-scoped tool.
- *
- * 2. Admin password (legacy, single-operator) — the hardcoded
- *    ``JASON_LOGIN_USERNAME`` + ``JASON_LOGIN_PASSWORD`` pair the
- *    site used to have as its only sign-in.  Kept for operator
- *    access to scrape controls and for cases where the Sleeper
- *    API is unreachable.
- *
- * Tab between them via the toggle at the top of the card.
- */
 export default function LoginPage() {
   const router = useRouter();
   const { onLoginSuccess } = useAuthContext();
-  const [mode, setMode] = useState("sleeper"); // "sleeper" | "admin"
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -38,35 +19,6 @@ export default function LoginPage() {
     const next = params.get("next") || "/rankings";
     setRedirectPath(next.startsWith("/") ? next : "/rankings");
   }, []);
-
-  async function handleSleeperSubmit(event) {
-    event.preventDefault();
-    const trimmedUser = username.trim();
-    if (!trimmedUser) {
-      setError("Enter your Sleeper username.");
-      return;
-    }
-    setError("");
-    setSubmitting(true);
-    try {
-      const res = await fetch("/api/auth/sleeper-login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username: trimmedUser, next: redirectPath }),
-      });
-      const data = await res.json();
-      if (res.ok && data.ok) {
-        onLoginSuccess?.();
-        router.push(data.redirect || redirectPath);
-      } else {
-        setError(data.error || "Login failed.");
-        setSubmitting(false);
-      }
-    } catch {
-      setError("Login request failed. Please try again.");
-      setSubmitting(false);
-    }
-  }
 
   async function handleAdminSubmit(event) {
     event.preventDefault();
@@ -101,12 +53,6 @@ export default function LoginPage() {
     }
   }
 
-  function switchMode(next) {
-    setMode(next);
-    setError("");
-    setPassword("");
-  }
-
   return (
     <section className="card login-shell">
       <div className="login-panel">
@@ -116,97 +62,39 @@ export default function LoginPage() {
           Continue to your dynasty rankings and trade workspace.
         </p>
 
-        <div
-          role="tablist"
-          aria-label="Sign-in method"
-          style={{
-            display: "flex",
-            gap: 6,
-            marginTop: 16,
-            borderBottom: "1px solid var(--border)",
-          }}
-        >
-          <button
-            type="button"
-            role="tab"
-            aria-selected={mode === "sleeper"}
-            className={`login-mode-tab${mode === "sleeper" ? " is-active" : ""}`}
-            onClick={() => switchMode("sleeper")}
-          >
-            Sleeper username
+        <form className="login-form" onSubmit={handleAdminSubmit}>
+          <label className="login-label" htmlFor="admin-username">
+            Username
+          </label>
+          <input
+            id="admin-username"
+            className="input login-input"
+            type="text"
+            autoComplete="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Enter username"
+          />
+
+          <label className="login-label" htmlFor="admin-password">
+            Password
+          </label>
+          <input
+            id="admin-password"
+            className="input login-input"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Enter password"
+          />
+
+          {error ? <p className="login-error">{error}</p> : null}
+
+          <button className="button login-button" type="submit" disabled={submitting}>
+            {submitting ? "Signing in..." : "Sign in"}
           </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={mode === "admin"}
-            className={`login-mode-tab${mode === "admin" ? " is-active" : ""}`}
-            onClick={() => switchMode("admin")}
-          >
-            Admin
-          </button>
-        </div>
-
-        {mode === "sleeper" ? (
-          <form className="login-form" onSubmit={handleSleeperSubmit}>
-            <label className="login-label" htmlFor="sleeper-username">
-              Sleeper username
-            </label>
-            <input
-              id="sleeper-username"
-              className="input login-input"
-              type="text"
-              autoComplete="username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="e.g. joeschmo"
-            />
-            <p className="muted" style={{ fontSize: "0.7rem", marginTop: 4, marginBottom: 0 }}>
-              We look up your user id on Sleeper and use that to
-              find your team in this league.  No password — this is
-              a lightweight "who are you" sign-in for league-mates.
-            </p>
-
-            {error ? <p className="login-error">{error}</p> : null}
-
-            <button className="button login-button" type="submit" disabled={submitting}>
-              {submitting ? "Checking Sleeper…" : "Sign in with Sleeper"}
-            </button>
-          </form>
-        ) : (
-          <form className="login-form" onSubmit={handleAdminSubmit}>
-            <label className="login-label" htmlFor="admin-username">
-              Username
-            </label>
-            <input
-              id="admin-username"
-              className="input login-input"
-              type="text"
-              autoComplete="username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="Enter username"
-            />
-
-            <label className="login-label" htmlFor="admin-password">
-              Password
-            </label>
-            <input
-              id="admin-password"
-              className="input login-input"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Enter password"
-            />
-
-            {error ? <p className="login-error">{error}</p> : null}
-
-            <button className="button login-button" type="submit" disabled={submitting}>
-              {submitting ? "Signing in..." : "Sign in"}
-            </button>
-          </form>
-        )}
+        </form>
 
         <p className="muted" style={{ marginBottom: 0, fontSize: "0.76rem" }}>
           Need help? <Link href="/">Go to Home</Link>

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -426,31 +426,6 @@ function TradeMeterMultiTeam({ sides, sideTotals, flows }) {
  * though their total scales aren't identical.
  */
 function TradeSourceBreakdown({ sides, settings }) {
-  const [mobileExpanded, setMobileExpanded] = useState(false);
-  // Mirror the CSS breakpoint so aria-expanded reflects what's
-  // actually rendered: on desktop the body is always visible, on
-  // mobile it follows mobileExpanded. State-driven so SSR renders a
-  // consistent "desktop = expanded" view and the first client paint
-  // after hydration flips narrow viewports to the collapsed state
-  // without a hydration mismatch.
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return undefined;
-    const mq = window.matchMedia("(max-width: 768px)");
-    const update = () => setIsMobile(mq.matches);
-    update();
-    // iOS Safari < 14 only exposes addListener/removeListener on
-    // MediaQueryList; modern browsers support the standard
-    // EventTarget API.  Prefer the modern API and fall back for
-    // older WebViews that would otherwise throw.
-    if (typeof mq.addEventListener === "function") {
-      mq.addEventListener("change", update);
-      return () => mq.removeEventListener("change", update);
-    }
-    mq.addListener(update);
-    return () => mq.removeListener(update);
-  }, []);
-  const effectiveExpanded = isMobile ? mobileExpanded : true;
   const rows = useMemo(() => {
     const assetsBySide = sides.map((s) => s.assets || []);
     const hasAny = assetsBySide.some((a) => a.length > 0);
@@ -610,19 +585,10 @@ function TradeSourceBreakdown({ sides, settings }) {
 
   return (
     <div
-      className={`card source-breakdown-card${mobileExpanded ? " is-expanded" : ""}`}
+      className="card source-breakdown-card"
       style={{ marginTop: 14 }}
     >
-      <button
-        type="button"
-        className="source-breakdown-header"
-        aria-expanded={effectiveExpanded}
-        aria-controls="source-breakdown-body"
-        tabIndex={isMobile ? 0 : -1}
-        onClick={() => {
-          if (isMobile) setMobileExpanded((v) => !v);
-        }}
-      >
+      <div className="source-breakdown-header">
         <span className="source-breakdown-header-text">
           <span
             className="source-breakdown-title"
@@ -634,10 +600,7 @@ function TradeSourceBreakdown({ sides, settings }) {
             VA-adjusted totals on the 0-9999 value scale, summed per vendor. Sub-boards (e.g. DLF SF + DLF RK) roll up into one row; margin shows winner's edge as a percent.
           </span>
         </span>
-        <span className="source-breakdown-chevron" aria-hidden="true">
-          {mobileExpanded ? "−" : "+"}
-        </span>
-      </button>
+      </div>
       <div
         id="source-breakdown-body"
         className="source-breakdown-body"

--- a/server.py
+++ b/server.py
@@ -150,11 +150,9 @@ def _session_ttl_days_seconds(default_days: float = 30.0) -> int:
 
 JASON_AUTH_COOKIE_MAX_AGE = _session_ttl_days_seconds()
 
-# Private-app allowlist.  Only these Sleeper handles can sign in
-# via /api/auth/sleeper-login.  Anyone else — even with a valid
-# Sleeper account — gets 403.  Password auth (JASON_LOGIN_*) is
-# the operator fallback and isn't constrained by this list.
-# Env var is comma-separated, lowercase-normalised at load time.
+# Private-app allowlist.  Gates admin-only endpoints to operator
+# usernames.  Env var is comma-separated, lowercase-normalised at
+# load time.
 PRIVATE_APP_ALLOWED_USERNAMES = frozenset(
     u.strip().lower()
     for u in (os.getenv("PRIVATE_APP_ALLOWED_USERNAMES") or "jasonleetucker").split(",")
@@ -448,13 +446,11 @@ def _create_auth_session(
 ) -> str:
     """Create an in-memory session for ``username``.
 
-    ``sleeper_user_id`` / ``display_name`` / ``avatar`` are populated
-    when the session was created via the Sleeper username sign-in
-    flow (see ``POST /api/auth/sleeper-login``) so downstream
-    handlers can resolve the user's Sleeper team by ownerId without
-    another round-trip.  ``auth_method`` tags sessions as either
-    ``password`` (admin login) or ``sleeper`` (username lookup)
-    so logs and audit tooling can tell them apart.
+    ``sleeper_user_id`` / ``display_name`` / ``avatar`` are optional
+    and consumed by downstream handlers that resolve the user's
+    Sleeper team by ownerId (populated today only by the E2E test
+    login path).  ``auth_method`` tags the session for logs and
+    audit tooling.
     """
     session_id = uuid.uuid4().hex
     payload = {
@@ -1862,7 +1858,6 @@ _PUBLIC_API_EXACT = frozenset({
     "/api/auth/status",
     "/api/auth/login",
     "/api/auth/logout",
-    "/api/auth/sleeper-login",
     "/api/scaffold/status",
     # /league page is a public view — its draft-capital tab reads
     # this endpoint.  Payload is public Sleeper data (team names,
@@ -5524,146 +5519,6 @@ async def auth_login(request: Request):
 
     session_id = _create_auth_session(username, auth_method="password")
     response = JSONResponse(content={"ok": True, "redirect": next_path})
-    response.set_cookie(
-        key=JASON_AUTH_COOKIE_NAME,
-        value=session_id,
-        path="/",
-        httponly=True,
-        samesite="lax",
-        secure=JASON_AUTH_COOKIE_SECURE,
-        max_age=JASON_AUTH_COOKIE_MAX_AGE,
-    )
-    return response
-
-
-@app.post("/api/auth/sleeper-login")
-async def auth_sleeper_login(request: Request):
-    """Sign in as any user known to the Sleeper API.
-
-    Flow:
-      1. Client POSTs ``{"username": "<sleeper-handle>"}``.
-      2. We call https://api.sleeper.app/v1/user/<username> which
-         returns ``{user_id, username, display_name, avatar}`` on
-         success or 404 for unknown users.
-      3. On success, create a session keyed on the Sleeper
-         ``user_id`` so the user_kv store partitions per-person
-         (not per-handle — Sleeper usernames CAN be changed, IDs
-         cannot).
-      4. ``useUserState``'s first ``GET /api/user/state`` after
-         login hydrates the returned ``username`` → the Sleeper
-         handle, and any roster team in the configured league
-         whose ``ownerId`` matches ``sleeper_user_id`` becomes the
-         default selection on the terminal.
-
-    Security note: this is a trust-on-first-use sign-in — anyone
-    who knows a valid Sleeper username can sign in as that user.
-    That's fine for a league-scoped tool (your leaguemates know
-    if someone claims their identity) but NOT suitable for
-    anything with financial or account-recovery exposure.  The
-    hardcoded-password admin path at ``/api/auth/login`` stays
-    available for operator access.
-    """
-    payload: dict = {}
-    try:
-        raw = await request.json()
-        if isinstance(raw, dict):
-            payload = raw
-    except Exception:
-        payload = {}
-
-    username = str(payload.get("username") or "").strip().lower()
-    next_path = _sanitize_next_path(payload.get("next"), "/app")
-
-    if not username or len(username) > 64:
-        return JSONResponse(
-            status_code=400,
-            content={"ok": False, "error": "Invalid username."},
-        )
-    if not all(c.isalnum() or c in "_-." for c in username):
-        return JSONResponse(
-            status_code=400,
-            content={"ok": False, "error": "Invalid username."},
-        )
-
-    # Fetch the Sleeper user record.  Run in a threadpool because
-    # urllib is sync and we don't want to block the event loop.
-    def _fetch() -> dict | None:
-        url = f"https://api.sleeper.app/v1/user/{username}"
-        req = urllib.request.Request(url, headers={"User-Agent": "brisket-sleeper-login/1.0"})
-        try:
-            with urllib.request.urlopen(req, timeout=5.0) as resp:
-                body = resp.read()
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                return None
-            raise
-        except (urllib.error.URLError, TimeoutError):
-            return None
-        try:
-            parsed = json.loads(body)
-        except (json.JSONDecodeError, ValueError):
-            return None
-        if not isinstance(parsed, dict):
-            return None
-        return parsed
-
-    try:
-        user_record = await run_in_threadpool(_fetch)
-    except Exception as exc:  # noqa: BLE001
-        log.warning("sleeper-login fetch error for %s: %s", username, exc)
-        return JSONResponse(
-            status_code=502,
-            content={"ok": False, "error": "Sleeper API unreachable; try again shortly."},
-        )
-
-    if not user_record or not user_record.get("user_id"):
-        return JSONResponse(
-            status_code=404,
-            content={
-                "ok": False,
-                "error": "No Sleeper user with that username.  Double-check spelling.",
-            },
-        )
-
-    # Private-app allowlist.  A valid Sleeper handle is necessary but
-    # NOT sufficient — the app is a single-user dashboard.  Anyone
-    # whose username isn't in PRIVATE_APP_ALLOWED_USERNAMES (default:
-    # ``jasonleetucker`` only) gets 403.  Password auth remains the
-    # operator fallback.
-    if username not in PRIVATE_APP_ALLOWED_USERNAMES:
-        log.warning(
-            "sleeper-login rejected for non-allowlisted user %r", username,
-        )
-        return JSONResponse(
-            status_code=403,
-            content={
-                "ok": False,
-                "error": "This app is private.  Contact the operator for access.",
-            },
-        )
-
-    sleeper_user_id = str(user_record.get("user_id") or "")
-    display_name = str(user_record.get("display_name") or user_record.get("username") or username)
-    avatar = str(user_record.get("avatar") or "")
-
-    # Use the Sleeper username as the session ``username`` so
-    # user_kv rows partition per-handle.  Sleeper handles are
-    # globally unique and stable-enough for this scope.
-    session_id = _create_auth_session(
-        username,
-        sleeper_user_id=sleeper_user_id,
-        display_name=display_name,
-        avatar=avatar,
-        auth_method="sleeper",
-    )
-    response = JSONResponse(content={
-        "ok": True,
-        "redirect": next_path,
-        "username": username,
-        "displayName": display_name,
-        "sleeperUserId": sleeper_user_id,
-        "avatar": avatar,
-    })
     response.set_cookie(
         key=JASON_AUTH_COOKIE_NAME,
         value=session_id,

--- a/tests/api/test_private_auth.py
+++ b/tests/api/test_private_auth.py
@@ -1,24 +1,15 @@
 """Tests for the private-app auth gate.
 
-The app is a single-user private tool.  Two gates enforce that:
+The app is a single-user private tool gated by the
+``_private_api_gate`` middleware: every ``/api/*`` path except an
+explicit public allowlist returns 401 when there is no authenticated
+session.  ``curl /api/data`` from a stranger must not leak the
+rankings contract.
 
-  1. ``PRIVATE_APP_ALLOWED_USERNAMES`` — only whitelisted Sleeper
-     usernames can create a Sleeper-auth session.  Anyone else
-     with a valid Sleeper handle gets 403.
-  2. ``_private_api_gate`` middleware — every ``/api/*`` path
-     except an explicit public allowlist returns 401 when there
-     is no authenticated session.  ``curl /api/data`` from a
-     stranger must not leak the rankings contract.
-
-These tests pin both gates.  They're the core privacy guarantee
-for this deployment.
+These tests pin that gate.  It's the core privacy guarantee for
+this deployment.
 """
 from __future__ import annotations
-
-import io
-import json as _json
-import urllib.error
-import urllib.request
 
 import pytest
 from fastapi.testclient import TestClient
@@ -133,64 +124,6 @@ def test_signal_alerts_run_bypasses_middleware(monkeypatch):
     assert res.status_code == 401
     # Error code proves the ENDPOINT's check fired, not middleware.
     assert res.json().get("error") == "admin_auth_required"
-
-
-# ── Sleeper-login allowlist ────────────────────────────────────────
-
-
-def _stub_urlopen_for_sleeper(monkeypatch, username: str, user_id: str):
-    """Patch urllib to return the stub Sleeper user for one handle.
-    Other handles → 404.  League-members lookups → empty list."""
-    real = urllib.request.urlopen
-
-    def fake_urlopen(req, timeout=5.0):
-        url = getattr(req, "full_url", "") or str(req)
-        if f"/v1/user/{username}" in url:
-            body = _json.dumps({
-                "user_id": user_id,
-                "username": username,
-                "display_name": username,
-            }).encode()
-            return io.BytesIO(body)
-        if "/v1/user/" in url:
-            raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
-        if "/v1/league/" in url and "/users" in url:
-            return io.BytesIO(b"[]")
-        return real(req, timeout=timeout)
-
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
-
-
-def test_sleeper_login_rejects_non_allowlisted_user(monkeypatch):
-    """Non-allowlisted Sleeper handle → 403 even though the user
-    exists on Sleeper.  The core gate against rando sign-ups."""
-    monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"jasonleetucker"}),
-    )
-    _stub_urlopen_for_sleeper(monkeypatch, "randomuser99", "99999999")
-    with TestClient(server.app, raise_server_exceptions=True) as c:
-        res = c.post("/api/auth/sleeper-login", json={"username": "randomuser99"})
-    assert res.status_code == 403, res.text
-    body = res.json()
-    assert body.get("ok") is False
-    assert "private" in body.get("error", "").lower()
-
-
-def test_sleeper_login_accepts_allowlisted_user(monkeypatch):
-    """Allowlisted username → 200 + session cookie."""
-    monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"allowed_user"}),
-    )
-    _stub_urlopen_for_sleeper(monkeypatch, "allowed_user", "12345678")
-    with TestClient(server.app, raise_server_exceptions=True) as c:
-        res = c.post("/api/auth/sleeper-login", json={"username": "allowed_user"})
-    assert res.status_code == 200, res.text
-    body = res.json()
-    assert body.get("ok") is True
-    assert body.get("sleeperUserId") == "12345678"
-    # Cookie set.
-    set_cookies = res.headers.get_list("set-cookie")
-    assert any(server.JASON_AUTH_COOKIE_NAME in ck for ck in set_cookies)
 
 
 def test_allowlist_reads_env_var_lowercased():


### PR DESCRIPTION
Two related cleanup commits on this branch:

## 1. mobile: always show Per-source winner on /trade
- Per-source winner card was collapsed-by-default on mobile (PR #277) behind a tap-to-expand `+` chevron. The toggle isn't discoverable, so users perceive the calculator as missing.
- Drop the mobile collapse entirely. Body keeps `overflowX: auto` so it scrolls horizontally on narrow viewports, same as every other wide table on the site.
- Removes the `matchMedia` hook, `mobileExpanded` state, the `<button>` wrapper, the chevron span, and the `@media (max-width: 768px)` `display: none` rule.

## 2. auth: remove Sleeper-username login, keep admin/password only
- The login page had a "Sleeper username" tab that signed users in via a public Sleeper API lookup, gated only by `PRIVATE_APP_ALLOWED_USERNAMES`.
- Removes:
  - `/api/auth/sleeper-login` route handler (~140 lines) and its entry in `_PUBLIC_API_EXACT`.
  - The mode toggle, sleeper form, and `handleSleeperSubmit` from `frontend/app/login/page.jsx`.
  - The two sleeper-login tests (and the urllib stub helper) from `tests/api/test_private_auth.py`.
  - The unused `.login-mode-tab` styles.
- Keeps:
  - The session-store schema (`sleeper_user_id`, `auth_method` columns) and the E2E test login path that populates them — no migration needed.
  - `PRIVATE_APP_ALLOWED_USERNAMES` (still gates admin endpoints; docstring updated).

## Test plan
- [x] `python3 -m pytest tests/api/ -q` → 919 passed, 3 skipped
- [ ] Load `/trade` on a phone-width viewport (≤768px) and confirm the "Per-source winner" table is visible by default with horizontal scroll
- [ ] Load `/trade` on desktop and confirm the card looks identical to before (header + table, no chevron)
- [ ] Load `/login` and confirm only the admin username/password form is shown — no Sleeper tab
- [ ] Sign in with admin credentials and confirm the existing flow still works

https://claude.ai/code/session_01CSRFU