### PR TITLE
fix(draft): sync from /api/data on values.overall, not values.full

### DIFF
--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3132,12 +3132,33 @@ export default function DraftDashboardPage() {
       // discrepancies (the gap drives the "good to nominate" list —
       // biggest overrates first).  KTC for offense, IDPTradeCalc for
       // IDP, on the same 0-9999 scale.
+      // The raw contract stamps the blended value as ``values.overall``
+      // and ``rankDerivedValue``; the synthetic ``values.full`` is only
+      // added downstream by ``buildRows`` in dynasty-data.js, so the
+      // sync (which reads /api/data directly) must consult the real
+      // contract fields.  Falling back through the chain
+      // values.overall → rankDerivedValue → values.displayValue keeps
+      // the sync resilient to either field renames or sparse rows.
+      const readBlendedValue = (p) => {
+        const candidates = [
+          p?.values?.overall,
+          p?.rankDerivedValue,
+          p?.values?.displayValue,
+          p?.values?.finalAdjusted,
+          p?.values?.full,
+        ];
+        for (const v of candidates) {
+          const n = Number(v);
+          if (Number.isFinite(n) && n > 0) return n;
+        }
+        return 0;
+      };
       const rookies = pa
         .filter((p) => p?.rookie === true)
         .filter((p) => p?.assetClass === "offense" || p?.assetClass === "idp")
         .map((p) => ({
           name: p.displayName || p.canonicalName || "",
-          rawValue: Number(p?.values?.full) || 0,
+          rawValue: readBlendedValue(p),
           ktcRawValue: typeof p?.canonicalSiteValues?.ktc === "number"
             ? p.canonicalSiteValues.ktc : null,
           idpTradeCalcRawValue:


### PR DESCRIPTION
## Root cause

PRs #338 / #339 chased wrong hypotheses (PWA cache, fallback to `players` dict). The actual bug: **`fetchSyncPreview` reads `/api/data` directly and filters rookies on `values.full`, which doesn't exist in the raw contract.**

`values.full` is a synthetic field that `buildRows` (in `dynasty-data.js`) adds after merging the delta. The raw contract stamps `values.overall` + `rankDerivedValue` instead.

## Evidence from live snapshot

`exports/latest/dynasty_data_2026-04-27.json`:

| Field | Count |
|---|---|
| players in `playersArray` | 1,072 |
| `rookie === true && assetClass in {offense, idp}` | 135 |
| `values.full > 0` | **0** |
| `values.overall > 0` | 135 |

So the sync filter rejected every rookie, threw "No rookies found in API data", and the workspace never got `ktcDollar` / `idpTradeCalcDollar` populated — which is what `nominationCandidates` requires to surface vendor overrates.

## Fix

Read `values.overall` first, fall back through `rankDerivedValue → displayValue → finalAdjusted → full` so sync survives any single-key absence.

## Test plan

- [x] `npx vitest run` — 791 passed
- [x] `npm run build` — clean
- [ ] Post-deploy: hard-reload `/draft`, click "Sync from live contract", confirm preview modal shows ~135 rookies with KTC/IDPTC dollar values, then "Good to nominate" populates with the largest vendor-vs-our-board overrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)