### PR TITLE
feat(draft): rookie predraft = consensus pick-slot dollar value

### DIFF
--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3111,9 +3111,21 @@ export default function DraftDashboardPage() {
       const url = selectedLeagueKey
         ? `/api/data?leagueKey=${encodeURIComponent(selectedLeagueKey)}`
         : "/api/data";
-      const res = await fetch(url, { cache: "no-store" });
+      // Fetch /api/data and /api/draft-capital in parallel — the
+      // draft-capital response carries per-slot dollar values from
+      // the workbook, which we use as each rookie's preDraft (the
+      // consensus 1.01 rookie inherits pick 1.01's dollar value, etc.)
+      // instead of rescaling raw blended values across the top 72.
+      const [res, capitalRes] = await Promise.all([
+        fetch(url, { cache: "no-store" }),
+        fetch("/api/draft-capital", { cache: "no-store" }).catch(() => null),
+      ]);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
+      // capitalRes can be null (network failure) or a non-ok response
+      // — fall back to the rescale path in either case so sync still
+      // works when the workbook isn't available.
+      const capitalData = capitalRes && capitalRes.ok ? await capitalRes.json() : null;
       // Prefer the contract's ``playersArray`` (full view).  Fall
       // back to the legacy ``players`` dict — the runtime view
       // (``view=app``) strips playersArray but keeps the dict, and
@@ -3192,32 +3204,54 @@ export default function DraftDashboardPage() {
         );
       }
 
-      // Rescale raw consensus values to the $1200 league pool.
-      const scaled = rescaleValuesToBudget(
-        rookies.map((r) => r.rawValue),
-        1200,
-      );
+      // Per-slot dollar values from the draft-capital workbook,
+      // ordered by overallPick.  ``originalDollarValue`` is the
+      // unaveraged per-slot price (e.g. 1.01 → $147, 1.02 → $112)
+      // — distinct from ``dollarValue`` which spreads expansion-pair
+      // picks evenly.  When the workbook isn't reachable, fall back
+      // to rescaling raw blended values so sync still works.
+      const slotDollarsByPick = (() => {
+        const picks = Array.isArray(capitalData?.picks) ? capitalData.picks : [];
+        if (picks.length === 0) return null;
+        const sorted = [...picks].sort(
+          (a, b) => (a?.overallPick || 0) - (b?.overallPick || 0),
+        );
+        return sorted
+          .map((p) => Number(p?.originalDollarValue ?? p?.dollarValue))
+          .filter((n) => Number.isFinite(n) && n > 0);
+      })();
+      const scaled = (slotDollarsByPick && slotDollarsByPick.length >= rookies.length)
+        ? rookies.map((_, i) => slotDollarsByPick[i])
+        : rescaleValuesToBudget(rookies.map((r) => r.rawValue), 1200);
 
-      // Rescale per-vendor values onto the same $1200 budget so the
-      // discrepancy ``vendorDollar - preDraft`` is comparable to the
-      // user's board.  One sorted/rescaled pass per vendor; players
-      // not ranked by that vendor stay null (skipped by the ranker).
-      const rescaleVendorByName = (rawKey) => {
+      // Per-vendor dollar values — slot-based when the workbook is
+      // available, rescaled-to-$1200 otherwise.  The vendor's #N rookie
+      // gets the dollar value of pick N: if KTC ranks Carnell Tate #2,
+      // KTC values him at pick 1.02's price ($112).  This makes the
+      // ``vendorDollar - preDraft`` gap an honest "how many more dollars
+      // would a vendor-following leaguemate spend at this slot than my
+      // board does" rather than a comparison of two different
+      // rescaling schemes.
+      const vendorDollarsByName = (rawKey) => {
         const ranked = rookies.filter(
           (r) => Number.isFinite(r[rawKey]) && r[rawKey] > 0,
         );
         if (ranked.length === 0) return new Map();
         const sorted = [...ranked].sort((a, b) => b[rawKey] - a[rawKey]);
-        const scaledVendor = rescaleValuesToBudget(
-          sorted.map((r) => r[rawKey]),
-          1200,
-        );
         const m = new Map();
-        sorted.forEach((r, i) => m.set(r.name, scaledVendor[i]));
+        if (slotDollarsByPick && slotDollarsByPick.length >= sorted.length) {
+          sorted.forEach((r, i) => m.set(r.name, slotDollarsByPick[i]));
+        } else {
+          const scaledVendor = rescaleValuesToBudget(
+            sorted.map((r) => r[rawKey]),
+            1200,
+          );
+          sorted.forEach((r, i) => m.set(r.name, scaledVendor[i]));
+        }
         return m;
       };
-      const ktcDollarsByName = rescaleVendorByName("ktcRawValue");
-      const idpTradeCalcDollarsByName = rescaleVendorByName("idpTradeCalcRawValue");
+      const ktcDollarsByName = vendorDollarsByName("ktcRawValue");
+      const idpTradeCalcDollarsByName = vendorDollarsByName("idpTradeCalcRawValue");
 
       const incoming = rookies.map((r, i) => ({
         name: r.name,

--- a/server.py
+++ b/server.py
@@ -4465,6 +4465,19 @@ def _fetch_draft_capital(league_key: str | None = None):
     draft_rounds = max(1, len(workbook_picks) // num_teams)
     raw_values = [wp["value"] for wp in workbook_picks]
     int_pick_values = _round_to_budget(raw_values, DRAFT_TOTAL_BUDGET)
+    # Original (pre-expansion-averaging) per-slot values from the
+    # workbook's P2:AA7 grid.  workbook_picks Q45:Q116 averages
+    # expansion-pair picks (e.g. 1.01 + 1.02 split equally because both
+    # belong to expansion teams in the user's league), which is correct
+    # for ownership accounting but wrong for valuing individual rookies
+    # at their actual draft slot.  This array preserves the unaveraged
+    # per-slot price so the rookie board can show e.g. 1.01 → $147 and
+    # 1.02 → $112 instead of both at the $130 average.
+    int_original_values = (
+        _round_to_budget(pick_dollars, DRAFT_TOTAL_BUDGET)
+        if pick_dollars and len(pick_dollars) >= len(workbook_picks)
+        else int_pick_values
+    )
 
     # ── First-name → Sleeper team-name mapping ──
     # Built by joining sheet standings (slot → first name) with
@@ -4583,6 +4596,10 @@ def _fetch_draft_capital(league_key: str | None = None):
         origin_team = display(origin_first)
 
         dollar = int_pick_values[overall_idx] if overall_idx < len(int_pick_values) else int(round(val))
+        original_dollar = (
+            int_original_values[overall_idx]
+            if overall_idx < len(int_original_values) else dollar
+        )
 
         all_picks.append({
             "pick": f"{rnd}.{str(slot).zfill(2)}",
@@ -4591,6 +4608,11 @@ def _fetch_draft_capital(league_key: str | None = None):
             "overallPick": overall_idx + 1,
             "dollarValue": dollar,
             "adjustedDollarValue": dollar,
+            # Unaveraged per-slot value — used by the rookie board on
+            # /draft to value each rookie at their consensus pick slot
+            # (e.g. consensus 1.01 → $147, not the $130 expansion-pair
+            # average).  Sums to 1200 across all 72 picks like dollarValue.
+            "originalDollarValue": original_dollar,
             "originalOwner": origin_team,
             "currentOwner": owner_team,
             "isTraded": str(origin_first).strip() != str(owner_first).strip(),


### PR DESCRIPTION
## Summary

Rookie predraft values previously came from rescaling each rookie's blended `values.overall` across the top 72 to sum to $1,200. That produced Jeremiyah Love at $56 — disconnected from the workbook saying pick 1.01 is worth $147.

This PR makes a rookie's predraft = the dollar value of the pick slot they're consensus-projected to:
- Consensus 1.01 → pick 1.01's price
- Consensus 1.02 → pick 1.02's price
- ...and so on

## Workbook caveat

The existing `dollarValue` averages expansion-pair picks (1.01 + 1.02 split 50/50 to $130 each). Correct for ownership accounting, wrong for individual rookie valuation. The workbook's `P2:AA7` grid carries the unaveraged per-slot price.

| Pick | dollarValue (averaged) | originalDollarValue (raw) |
|---|---|---|
| 1.01 | $130 | **$147** |
| 1.02 | $130 | **$112** |
| 1.03 | $98 | $98 |
| ... (rest unchanged) |

## Changes

- **Backend** (`server.py::_fetch_draft_capital`): expose `originalDollarValue` per pick, sourced from `P2:AA7`. Sums to 1200 like `dollarValue`.
- **Frontend** (`fetchSyncPreview`): fetch `/api/draft-capital` alongside `/api/data`; assign `preDraft = originalDollarValue[rank-1]` to each rookie. Falls back to legacy rescale if the workbook is unavailable.
- Same slot-based assignment for `ktcDollar` / `idpTradeCalcDollar` so the "Good to nominate" gap is an honest "what would a vendor-following leaguemate spend at this slot."

## Expected board after deploy + sync

```
Jeremiyah Love     PREDRAFT $147
Carnell Tate       PREDRAFT $112
Fernando Mendoza   PREDRAFT $98
Makai Lemon        PREDRAFT $89
Jordyn Tyson       PREDRAFT $80
...
```

## Test plan

- [x] `pytest tests/ -k draft` — 22 passed
- [x] `npx vitest run __tests__/draft-logic.test.js` — 182 passed
- [x] `npm run build` — clean
- [x] Verified `originalDollarValue` API output: 1.01=$147, 1.02=$112, sum=$1,200
- [ ] Post-deploy: hard-reload `/draft`, click "Sync from live contract", confirm the preview shows 1.01 → $147, 1.02 → $112

🤖 Generated with [Claude Code](https://claude.com/claude-code)