### PR TITLE
fix(sw): bump CACHE_VERSION v3 → v4 to evict stale mobile PWA assets

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -36,10 +36,16 @@
  * Versioning: bump ``CACHE_VERSION`` when the cache layout changes.
  * Old caches are deleted on ``activate``.
  */
+// v4: bump (2026-04-27) to evict stale PWA caches that pre-date the
+// per-source winner table on /trade (PR #335).  iOS PWA users reported
+// the table missing on mobile because their cached HTML referenced
+// the old chunk hashes and the SW served them from cache; an
+// activation cycle that wipes prior caches forces the next page load
+// to fetch fresh chunks containing TradeSourceBreakdown.
 // v3: push + notificationclick handlers added.  Cache layout is
 // otherwise unchanged; the bump just forces an SW activation cycle so
 // existing tabs pick up the new event listeners.
-const CACHE_VERSION = "brisket-v3";
+const CACHE_VERSION = "brisket-v4";
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 const PUBLIC_LEAGUE_CACHE = `${CACHE_VERSION}-public-league`;


### PR DESCRIPTION
## Why

iOS PWA users report the per-source winner table missing on /trade. That table was added by PR #335 (`TradeSourceBreakdown`). Their PWA cache from before the deploy holds HTML referencing the old chunk hashes; the SW serves those from cache instead of re-fetching, so the new component never paints.

## Fix

Bump `CACHE_VERSION` from `brisket-v3` to `brisket-v4`. The existing activate handler:

```js
caches.keys().then((keys) => Promise.all(
  keys.filter(k => !k.startsWith(CACHE_VERSION)).map(k => caches.delete(k))
))
```

deletes every cache that doesn't match the new version, forcing a fresh fetch of the precache list (which re-anchors the SW to the current entrypoint hashes). The next visit then loads the new chunks containing `TradeSourceBreakdown`.

## User action after deploy

- iOS PWA: close the app fully (swipe up from app switcher), reopen.
- Desktop: hard reload (Ctrl/Cmd+Shift+R).

🤖 Generated with [Claude Code](https://claude.com/claude-code)