### PR TITLE
fix(ktc): extract nested TE+ value + supersede ktc when ktcSfTep covers

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -1652,26 +1652,50 @@ _KTC_TEP_TOPLEVEL_KEYS = (
 
 
 def _ktc_extract_tep(item):
-    """Return the TE+ (level 1) superflex value from a KTC API item, or None."""
+    """Return the TE+ (level 1) superflex value from a KTC API item, or None.
+
+    KTC's playersArray nests the TE+ block as a dict, not a scalar:
+
+        superflexValues: {
+          value: 8337,                # base SF
+          tep:  { value: 8337, rank: 9, ... },   # TE+ level 1
+          tepp: { value: 9113, rank: 8, ... },   # TE++ level 2
+          teppp: { ... }                          # TE+++ level 3
+        }
+
+    The earlier version of this extractor returned the entire ``tep``
+    dict, then later code crashed on ``int(float({}))`` and silently
+    skipped — leaving ktcSfTep.csv empty.  Now we handle both shapes:
+    if a candidate is a dict, pull ``.value``; if it's a scalar,
+    return it directly.
+    """
+    def _coerce_value(candidate):
+        if candidate is None:
+            return None
+        if isinstance(candidate, dict):
+            inner = candidate.get("value")
+            return inner if inner is not None else None
+        return candidate
+
     if not isinstance(item, dict):
         return None
     if SUPERFLEX:
         sf_vals = item.get("superflexValues")
         if isinstance(sf_vals, dict):
             for k in _KTC_TEP_FIELD_KEYS:
-                v = sf_vals.get(k)
-                if v is not None:
-                    return v
+                resolved = _coerce_value(sf_vals.get(k))
+                if resolved is not None:
+                    return resolved
         sf_vals2 = item.get("superflexValue")
         if isinstance(sf_vals2, dict):
             for k in _KTC_TEP_FIELD_KEYS:
-                v = sf_vals2.get(k)
-                if v is not None:
-                    return v
+                resolved = _coerce_value(sf_vals2.get(k))
+                if resolved is not None:
+                    return resolved
     for k in _KTC_TEP_TOPLEVEL_KEYS:
-        v = item.get(k)
-        if v is not None:
-            return v
+        resolved = _coerce_value(item.get(k))
+        if resolved is not None:
+            return resolved
     return None
 
 
@@ -1818,11 +1842,25 @@ async def scrape_ktc(page, players):
             dom_data = await page.evaluate("""() => {
                 const results = {};
                 const tepKeys = ['tep','tepValue','tep_value','tep1','tep1Value','tep1_value','tepLevel1','tepValueLevel1'];
+                // KTC's playersArray nests the TE+ block as a dict
+                // (e.g. superflexValues.tep = {value: 8337, rank: 9}),
+                // not a scalar.  Resolve the nested .value when the
+                // candidate is an object.
                 const grabTep = (obj) => {
                     if (!obj) return null;
                     for (const k of tepKeys) {
                         const v = obj[k];
-                        if (v !== undefined && v !== null) return parseInt(v);
+                        if (v === undefined || v === null) continue;
+                        if (typeof v === 'object') {
+                            const inner = v.value;
+                            if (inner !== undefined && inner !== null) {
+                                const n = parseInt(inner);
+                                if (Number.isFinite(n)) return n;
+                            }
+                            continue;
+                        }
+                        const n = parseInt(v);
+                        if (Number.isFinite(n)) return n;
                     }
                     return null;
                 };

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -855,8 +855,21 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "depth": None,
         "weight": 1.0,
         "is_backbone": False,
+        # Inherits is_retail from the superseded ``ktc`` source at
+        # runtime (see _supersedes_check).  Declared False here so the
+        # static registry doesn't double-count retail when both are
+        # enabled but ktcSfTep has no scrape data yet.
         "is_retail": False,
         "is_tep_premium": True,
+        # When ktcSfTep has live coverage, it replaces ``ktc`` in the
+        # blend — same scrape source, different variant, including both
+        # would double-count KTC.  ``_active_sources`` reads this and
+        # drops the superseded keys (and inherits their is_retail flag
+        # so the market-gap calculation continues to work with TE+ as
+        # the retail anchor).  When ktcSfTep has no coverage (e.g. the
+        # scraper failed to extract TE+ that day), ``ktc`` stays in the
+        # blend as the fallback.
+        "supersedes": ("ktc",),
     },
     {
         # IDP Trade Calculator's public value pool covers both offense
@@ -2217,6 +2230,90 @@ def _effective_source_weight(
     return w
 
 
+# Supersession check cache — keyed by (csv path, mtime) so the file
+# only gets re-counted when it changes.  Counting CSV rows is cheap
+# (~1 ms for 500 rows) but we'd rather not pay even that on every
+# /api/data call; a single dict.get hit is faster.
+_SUPERSEDES_COVERAGE_CACHE: dict[str, tuple[float, bool]] = {}
+_SUPERSEDES_COVERAGE_FLOOR = 25
+
+
+def _source_has_coverage(key: str) -> bool:
+    """Return True if the source's CSV exists with at least 25 data rows.
+
+    Used by ``_active_sources`` to decide whether a registered source
+    has enough live data to supersede a sibling.  The 25-row floor
+    matches the scraper-side guard in Dynasty Scraper.py so we don't
+    flip into "supersede" mode based on a partial or empty scrape.
+    """
+    from pathlib import Path
+    path_spec = _SOURCE_CSV_PATHS.get(key)
+    if not path_spec:
+        return False
+    csv_path = path_spec["path"] if isinstance(path_spec, dict) else path_spec
+    full_path = Path(__file__).resolve().parents[2] / csv_path
+    if not full_path.exists():
+        return False
+    mtime = full_path.stat().st_mtime
+    cached = _SUPERSEDES_COVERAGE_CACHE.get(key)
+    if cached and cached[0] == mtime:
+        return cached[1]
+    try:
+        with full_path.open() as f:
+            row_count = sum(1 for _ in f) - 1  # subtract header
+    except Exception:
+        row_count = 0
+    has_coverage = row_count >= _SUPERSEDES_COVERAGE_FLOOR
+    _SUPERSEDES_COVERAGE_CACHE[key] = (mtime, has_coverage)
+    return has_coverage
+
+
+def _supersedes_check(active: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Apply registry-level supersession to an enabled source list.
+
+    For every active source declaring ``supersedes: (key, ...)``, if
+    that source has live coverage (≥ 25 rows in its CSV), drop the
+    listed keys from the active list.  Inherit ``is_retail`` from the
+    dropped sources onto the superseder so the market-gap calculation
+    continues to work — e.g. when ktcSfTep supersedes ktc, the retail
+    anchor moves to ktcSfTep automatically.
+
+    No-op when:
+    - No active source declares ``supersedes``.
+    - The superseder declares it but doesn't have live coverage yet
+      (e.g. ktcSfTep registered but scraper hasn't populated the CSV).
+    """
+    drops: set[str] = set()
+    inherit_retail: set[str] = set()
+    for src in active:
+        keys = src.get("supersedes") or ()
+        if not keys:
+            continue
+        sup_key = str(src.get("key") or "")
+        if not sup_key or not _source_has_coverage(sup_key):
+            continue
+        for k in keys:
+            drops.add(str(k))
+            for other in active:
+                if str(other.get("key") or "") == str(k) and other.get("is_retail"):
+                    inherit_retail.add(sup_key)
+                    break
+    if not drops:
+        return active
+    out: list[dict[str, Any]] = []
+    for src in active:
+        key = str(src.get("key") or "")
+        if key in drops:
+            continue
+        if key in inherit_retail and not src.get("is_retail"):
+            copy = dict(src)
+            copy["is_retail"] = True
+            out.append(copy)
+        else:
+            out.append(src)
+    return out
+
+
 def _active_sources(
     source_overrides: dict[str, dict[str, Any]] | None,
 ) -> list[dict[str, Any]]:
@@ -2227,9 +2324,13 @@ def _active_sources(
     replaced.  Sources that inherit their defaults are passed through
     by reference so the hot path does not pay a copy tax when no
     overrides are in play.
+
+    After the user-override filter, ``_supersedes_check`` runs to
+    apply registry-level mutual exclusion (e.g. ktcSfTep supersedes
+    ktc when the TE+ scrape has data).
     """
     if not source_overrides:
-        return list(_RANKING_SOURCES)
+        return _supersedes_check(list(_RANKING_SOURCES))
     out: list[dict[str, Any]] = []
     for src in _RANKING_SOURCES:
         if not _source_is_enabled(src, source_overrides):
@@ -2241,7 +2342,7 @@ def _active_sources(
             out.append(copy)
         else:
             out.append(src)
-    return out
+    return _supersedes_check(out)
 
 
 def _compute_market_gap(


### PR DESCRIPTION
## Summary

User noticed KTC registered twice on /settings (KeepTradeCut + KeepTradeCut SF-TEP, both ON). Two latent bugs explained the situation:

### Bug 1 — Scraper TE+ extraction silently broken

PR #336 assumed `superflexValues.tep` was a scalar. It's actually a nested object:

```json
"superflexValues": {
  "value": 8337,
  "tep":  { "value": 8337, "rank": 9, "history": [...] },
  "tepp": { "value": 9113, ... }
}
```

The extractor returned the whole dict, `int(float({...}))` raised silently, and `tep_name_map` stayed empty. So `ktcSfTep.csv` was never written despite the scrape running — that's why `KTC SF-TEP` shows "0 covered, Idle" in the screenshot.

Now we resolve `.value` from any dict candidate before the int conversion.

### Bug 2 — No mutual exclusion at the blend level

Once TE+ extraction works, both `ktc` and `ktcSfTep` would contribute to the blend with weight 1.0 each — **double-counting KTC**. User explicitly asked: "I just want to make sure that it's only being used once and that we're using the Superflex TEP version."

Added a `supersedes` field to the registry. `ktcSfTep` declares `supersedes: ("ktc",)`. `_active_sources` runs a final pass via `_supersedes_check` that drops the listed keys when the superseder has live coverage (≥ 25 rows — same floor the scraper uses before writing). Inherits `is_retail` onto the superseder so the market-gap calc continues to work with TE+ as the retail anchor.

### Behavior matrix

| State | Active sources |
|---|---|
| ktcSfTep CSV missing or sparse (today) | both `ktc` (retail) + `ktcSfTep` registered, but ktcSfTep contributes zero values — no double-count |
| ktcSfTep CSV populated (after scrape fix) | `ktc` dropped, `ktcSfTep` becomes retail anchor |

## Test plan

- [x] `pytest tests/api/` — 919 passed
- [x] `pytest tests/api/test_source_registry_parity.py` — 60 passed (new `supersedes` field is internal-only, doesn't break parity)
- [x] `npm run build` — clean
- [x] Simulated populated `ktcSfTep.csv` (30 fake rows): active sources reduce from 20 → 19; only `ktcSfTep` remains in the KTC family with `is_retail: True`
- [x] Verified empty case (today's state): both still active, ktcSfTep contributes zero values
- [ ] Post-deploy: next scheduled scrape should populate `CSVs/site_raw/ktcSfTep.csv`. After it runs, check /settings — `KeepTradeCut SF-TEP` should show "Live" with coverage > 0; `KeepTradeCut` row will still show but won't contribute to the blend (auto-superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)