### PR TITLE
fix(ros): duck-type adapter result to survive __main__ double-import

### DIFF
--- a/src/ros/scrape.py
+++ b/src/ros/scrape.py
@@ -208,15 +208,23 @@ def _invoke_adapter(src_meta: dict[str, Any]) -> ScrapeResult:
     try:
         module = importlib.import_module(str(src_meta["scraper"]))
         result = module.scrape(src_meta=src_meta)
-        if not isinstance(result, ScrapeResult):
+        # Duck-type the result.  ``isinstance(result, ScrapeResult)``
+        # would fail when the orchestrator runs as ``__main__`` (Python
+        # loads ``src.ros.scrape`` twice — once as ``__main__`` and once
+        # as ``src.ros.scrape`` when adapters import ScrapeResult — so
+        # the two ScrapeResult classes are distinct).  Field-presence
+        # check works regardless of the loader.
+        required = {"source_key", "status", "rows", "started_at", "completed_at"}
+        missing = required - set(getattr(result, "__dict__", {}).keys())
+        if missing:
             return ScrapeResult(
                 source_key=key,
                 status="failed",
-                error="adapter returned wrong type",
+                error=f"adapter returned wrong type (missing: {sorted(missing)})",
                 started_at=started,
                 completed_at=_now(),
             )
-        return result
+        return result  # type: ignore[return-value]
     except Exception as exc:  # noqa: BLE001 — adapter MUST NOT crash the orchestrator
         LOG.warning("[ros] adapter %s crashed: %s", key, exc)
         return ScrapeResult(


### PR DESCRIPTION
## Why

Smoke-testing the orchestrator after PR #345 landed:

```
$ python -m src.ros.scrape
fantasyProsRosSf: failed — "adapter returned wrong type"
draftSharksRosSf: failed — "adapter returned wrong type"
```

Cause: `python -m src.ros.scrape` runs the file as `__main__`. Adapters do `from src.ros.scrape import ScrapeResult` to construct their results — Python loads the same file again under the name `src.ros.scrape`, creating a second distinct `ScrapeResult` dataclass. `isinstance(result, ScrapeResult)` checks the orchestrator's class (the `__main__` copy), not the adapter's class, so it always returns False.

## Fix

Field-presence check instead of `isinstance`. The orchestrator only reads a handful of attributes off the result; if those are present, it's safe to use regardless of which class it was constructed from.

## Verified end-to-end

```
$ python -m src.ros.scrape
{
  "ranSources": ["fantasyProsRosSf", "draftSharksRosSf"],
  "results": {
    "fantasyProsRosSf": { "status": "ok", "player_count": 452 },
    "draftSharksRosSf": { "status": "ok", "player_count": 851 }
  },
  "playerCount": 919
}
```

`tests/ros/` — 37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)