### PR TITLE
feat(ros): PR 2 — ROS-driven Power Rankings v2

### DIFF
--- a/frontend/app/league/LeagueClient.jsx
+++ b/frontend/app/league/LeagueClient.jsx
@@ -51,6 +51,8 @@ import LuckSection from "./sections/luck.jsx";
 import StreaksSection from "./sections/streaks.jsx";
 import PowerSection from "./sections/power.jsx";
 import RosTeamStrengthSection from "./sections/ros-team-strength.jsx";
+import RosPowerSection from "./sections/ros-power.jsx";
+import { useSettings } from "@/components/useSettings";
 import MatchupPreviewSection from "./sections/matchup-preview.jsx";
 import WeeklyRecapSection from "./sections/weekly-recap.jsx";
 
@@ -95,6 +97,12 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
   const urlTab = searchParams.get("tab");
   const urlOwner = searchParams.get("owner") || "";
   const urlWeek = searchParams.get("week") || "";
+  // Read the ROS feature flags so the Power tab can swap to v2 when
+  // the user opts in.  Defaults match the registry in
+  // ``components/useSettings.js`` (rosEnabled true,
+  // useRosPowerRankings false until validated per-user).
+  const { settings } = useSettings();
+  const useRosPower = !!settings?.useRosPowerRankings;
 
   const [activeTab, setActiveTabState] = useState(
     urlTab && VALID_TABS.has(urlTab)
@@ -300,7 +308,9 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
         <StreaksSection data={sections.streaks} managers={managers} />
       )}
       {activeTab === "power" && (
-        <PowerSection data={sections.power} managers={managers} />
+        useRosPower
+          ? <RosPowerSection />
+          : <PowerSection data={sections.power} managers={managers} />
       )}
       {activeTab === "rosTeamStrength" && <RosTeamStrengthSection />}
       {activeTab === "matchupPreview" && (

--- a/frontend/app/league/sections/ros-power.jsx
+++ b/frontend/app/league/sections/ros-power.jsx
@@ -1,0 +1,236 @@
+"use client";
+
+// ROS-driven Power Rankings (v2).  Side-by-side replacement for the
+// existing power.jsx.  Lazy-fetched from /api/public/league/rosPower
+// because the section reads the ROS team-strength snapshot and
+// re-walks the snapshot each call — same lazy pattern as playoff
+// odds.  When the snapshot has no ROS data yet (first deploy before
+// the scrape lands), the section degrades cleanly to a v1-style
+// formula with ROS components missing — see ``missingInputs`` field.
+
+import { useEffect, useState } from "react";
+import { LoadingState, EmptyState } from "@/components/ui";
+
+// Module-level cache so tab-switching doesn't re-fetch on every mount.
+// Same pattern + 30-min TTL that power.jsx uses for playoff odds.
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const _cache = { data: null, error: null, inflight: null, fetchedAt: 0 };
+
+async function _fetchRosPower() {
+  const fresh = _cache.data && Date.now() - _cache.fetchedAt < CACHE_TTL_MS;
+  if (fresh) return { data: _cache.data, error: null };
+  if (_cache.inflight) return _cache.inflight;
+
+  const promise = fetch("/api/public/league/rosPower")
+    .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+    .then((payload) => {
+      const body = payload?.data || payload?.section || payload;
+      _cache.data = body;
+      _cache.error = null;
+      _cache.fetchedAt = Date.now();
+      _cache.inflight = null;
+      return { data: body, error: null };
+    })
+    .catch((err) => {
+      _cache.inflight = null;
+      const message = String(err?.message || err);
+      _cache.error = message;
+      return { data: _cache.data, error: message };
+    });
+
+  _cache.inflight = promise;
+  return promise;
+}
+
+function fmtScore(v) {
+  if (v == null || !Number.isFinite(Number(v))) return "—";
+  return Number(v).toFixed(1);
+}
+
+function fmtPct(v) {
+  if (v == null || !Number.isFinite(Number(v))) return "—";
+  return `${Math.round(Number(v) * 100)}%`;
+}
+
+function ComponentBar({ label, value, weight }) {
+  if (weight === 0) return null;
+  const pct = Math.max(0, Math.min(1, Number(value || 0)));
+  return (
+    <div style={{ marginBottom: 4, fontSize: "0.7rem" }}>
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <span style={{ color: "var(--subtext)" }}>
+          {label} ({Math.round(weight * 100)}%)
+        </span>
+        <span style={{ fontFamily: "var(--mono)" }}>{fmtPct(pct)}</span>
+      </div>
+      <div
+        style={{
+          height: 4,
+          background: "rgba(255,255,255,0.1)",
+          borderRadius: 2,
+          marginTop: 2,
+        }}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${pct * 100}%`,
+            background: "var(--cyan)",
+            borderRadius: 2,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+const COMPONENT_LABELS = {
+  team_ros_strength: "ROS roster strength",
+  ppg: "Points per game",
+  recent: "Recent form",
+  wl_record: "W/L record",
+  all_play: "All-play record",
+  streak: "Streak",
+  schedule_adjusted: "Schedule-adjusted",
+  roster_health: "Roster health",
+  luck_regression: "Luck regression",
+};
+
+export default function RosPowerSection() {
+  const [data, setData] = useState(() => _cache.data);
+  const [error, setError] = useState(_cache.error);
+  const [loading, setLoading] = useState(!_cache.data);
+  const [expanded, setExpanded] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    _fetchRosPower().then(({ data: d, error: e }) => {
+      if (!active) return;
+      setData(d);
+      setError(e);
+      setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (loading && !data) {
+    return <LoadingState message="Loading ROS power rankings..." />;
+  }
+  if (error && !data) {
+    return (
+      <div className="card" style={{ marginTop: "var(--space-md)" }}>
+        <EmptyState title="ROS Power unavailable" message={error} />
+      </div>
+    );
+  }
+  const rankings = data?.currentRanking || [];
+  if (!rankings.length) {
+    return (
+      <div className="card" style={{ marginTop: "var(--space-md)" }}>
+        <EmptyState
+          title="ROS Power not ready"
+          message="The league snapshot or ROS roster-strength data is missing. Once the next scheduled scrape lands, this view will populate."
+        />
+      </div>
+    );
+  }
+
+  const weights = data.weights || {};
+  const missing = data.missingInputs || [];
+  const rosAvailable = !!data.rosTeamStrengthAvailable;
+
+  return (
+    <div className="card" style={{ marginTop: "var(--space-md)" }}>
+      <div style={{ fontWeight: 700, marginBottom: 4 }}>
+        ROS Power Rankings
+      </div>
+      <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginBottom: 10 }}>
+        ROS roster strength (38%) + season PPG (18%) + recent form (12%) + W/L
+        (10%) + all-play (8%) + streak (5%) + schedule-adjusted (4%) + roster
+        health (3%) + luck regression (2%).{" "}
+        {!rosAvailable && (
+          <span style={{ color: "var(--amber)" }}>
+            ROS roster strength not available yet — using actual-results-only blend.
+          </span>
+        )}
+        {missing.length > 0 && (
+          <span>
+            {" "}
+            Missing inputs: {missing.join(", ")}.
+          </span>
+        )}
+      </div>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.84rem" }}>
+        <thead>
+          <tr
+            style={{
+              color: "var(--subtext)",
+              fontSize: "0.7rem",
+              textTransform: "uppercase",
+            }}
+          >
+            <th style={{ textAlign: "right", padding: "4px 8px 4px 0" }}>#</th>
+            <th style={{ textAlign: "left", padding: "4px 0" }}>Owner</th>
+            <th style={{ textAlign: "right", padding: "4px 8px" }}>Power</th>
+            <th style={{ textAlign: "right", padding: "4px 8px" }}>ROS Pct</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rankings.map((row, i) => (
+            <RankingRow
+              key={row.ownerId || i}
+              row={row}
+              weights={weights}
+              expanded={expanded === i}
+              onToggle={() => setExpanded(expanded === i ? null : i)}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RankingRow({ row, weights, expanded, onToggle }) {
+  return (
+    <>
+      <tr style={{ cursor: "pointer" }} onClick={onToggle} title="Click for component breakdown">
+        <td style={{ textAlign: "right", paddingRight: 8, color: "var(--subtext)" }}>
+          {row.rank}
+        </td>
+        <td style={{ fontWeight: 600 }}>{row.displayName || row.ownerId || "—"}</td>
+        <td
+          style={{
+            textAlign: "right",
+            fontFamily: "var(--mono)",
+            fontWeight: 700,
+            color: "var(--cyan)",
+          }}
+        >
+          {fmtScore(row.powerScore)}
+        </td>
+        <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+          {fmtPct(row.rosStrengthPercentile)}
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={4} style={{ background: "rgba(255,255,255,0.02)", padding: "8px 12px" }}>
+            <div style={{ fontSize: "0.72rem" }}>
+              {Object.entries(COMPONENT_LABELS).map(([key, label]) => (
+                <ComponentBar
+                  key={key}
+                  label={label}
+                  value={row.components?.[key]}
+                  weight={weights[key] ?? 0}
+                />
+              ))}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -74,9 +74,26 @@ _SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any]]] =
 # layer is opt-in until it's been validated against real rosters).
 from src.ros import api as _ros_api  # noqa: E402
 
+
+def _ros_power_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    """Lazy-import wrapper for src.ros.power_v2.
+
+    power_v2 imports ``src.public_league.luck`` + ``snapshot`` at module
+    load — importing it eagerly here forms a cycle (this module is part
+    of the same package).  Defer until call-time so the package is
+    fully initialised by the time the section runs.
+    """
+    from src.ros import power_v2  # noqa: PLC0415
+    return power_v2.build_section(snapshot)
+
+
 _LAZY_SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any]]] = {
     "playoffOdds": playoff_odds.build_section,
     "rosTeamStrength": _ros_api.build_section,
+    # ROS-driven power rankings v2.  Coexists with the existing
+    # ``power`` section above; the frontend swaps between them based
+    # on ``settings.useRosPowerRankings``.
+    "rosPower": _ros_power_section,
 }
 
 # Derived overview is a first-class section key the UI can fetch just

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -1,0 +1,318 @@
+"""ROS-driven power rankings (v2).
+
+Spec formula:
+
+    power_score =
+        0.38 * team_ros_strength_percentile
+        + 0.18 * season_points_scored_percentile
+        + 0.12 * recent_points_scored_percentile
+        + 0.10 * win_loss_record_percentile
+        + 0.08 * all_play_record_percentile
+        + 0.05 * winning_streak_score
+        + 0.04 * schedule_adjusted_performance
+        + 0.03 * roster_health_score
+        + 0.02 * luck_regression_score
+
+Inputs come from two places:
+
+    * ``data/ros/team_strength/latest.json`` — written by
+      ``src.ros.team_strength``.  Provides ``team_ros_strength_percentile``.
+    * ``PublicLeagueSnapshot`` — already feeds the existing
+      ``power.py``.  Provides PPG, recent form, W/L, all-play, streak,
+      and luck-regression inputs.
+
+PR2 leaves ``schedule_adjusted_performance`` and ``roster_health_score``
+at 0 (well-documented config-gated TODOs) — the spec calls these out as
+"implement what is reasonable and leave clean TODOs/config flags for the
+rest" because they need data this app doesn't currently surface
+(opponent-strength SOS + injury-aware roster scoring).  The current
+formula renormalises the populated weights so missing terms don't
+deflate the result against teams with full coverage.
+
+Render-side, this section is gated by ``settings.useRosPowerRankings``:
+when False, the existing ``power.py`` v1 still drives /league → Power.
+When True, /league → ROS Power renders this version side-by-side as
+the new "ROS Power" tab.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import statistics
+from collections import defaultdict
+from typing import Any
+
+from src.ros import ROS_DATA_DIR
+from src.public_league import luck
+from src.public_league.snapshot import PublicLeagueSnapshot
+
+LOG = logging.getLogger("ros.power_v2")
+
+
+# ── Formula weights (spec) ────────────────────────────────────────────
+WEIGHTS: dict[str, float] = {
+    "team_ros_strength": 0.38,
+    "ppg": 0.18,
+    "recent": 0.12,
+    "wl_record": 0.10,
+    "all_play": 0.08,
+    "streak": 0.05,
+    "schedule_adjusted": 0.04,
+    "roster_health": 0.03,
+    "luck_regression": 0.02,
+}
+
+_RECENT_WINDOW = 3  # matches power.py
+
+
+def _percentile(values: list[float], target: float) -> float:
+    """Inclusive percentile rank in [0, 1]."""
+    if not values:
+        return 0.0
+    eligible = [v for v in values if v is not None]
+    if not eligible:
+        return 0.0
+    below = sum(1 for v in eligible if v < target)
+    same = sum(1 for v in eligible if v == target)
+    return (below + 0.5 * same) / len(eligible)
+
+
+def _load_team_strength_percentiles() -> dict[str, float]:
+    """Read the latest ROS team-strength snapshot and convert each
+    team's composite score to a percentile in [0, 1] keyed by
+    ownerId.  Returns an empty dict when the snapshot is missing —
+    the caller treats absent percentiles as 0.0 (worst) and the
+    formula-renormalisation below compensates.
+    """
+    path = ROS_DATA_DIR / "team_strength" / "latest.json"
+    if not path.exists():
+        return {}
+    try:
+        rows = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    scores: list[tuple[str, float]] = []
+    for r in rows or []:
+        oid = str(r.get("ownerId") or "")
+        if not oid:
+            continue
+        score = float(r.get("teamRosStrength") or 0.0)
+        scores.append((oid, score))
+    score_values = [s for _, s in scores]
+    return {oid: _percentile(score_values, score) for oid, score in scores}
+
+
+def _streak_score_from_outcomes(outcomes: list[float]) -> float:
+    """Convert a chronological list of W/L outcomes (1.0 = W, 0.0 = L,
+    0.5 = T) into a 0-1 streak score.  Reads the trailing run only;
+    saturates at 5 wins (1.0) and bottoms at 5+ losses (0.0).
+    """
+    if not outcomes:
+        return 0.5
+    run = 0
+    last = outcomes[-1]
+    for o in reversed(outcomes):
+        if o == last:
+            run += 1
+        else:
+            break
+    if last >= 0.75:  # winning streak
+        return min(1.0, 0.5 + run * 0.10)
+    if last <= 0.25:  # losing streak
+        return max(0.0, 0.5 - run * 0.10)
+    return 0.5  # tie or mixed
+
+
+def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+    """Build the ROS power section for the public contract.
+
+    Output mirrors the existing ``power.py::build_section`` shape so
+    the frontend can render it side-by-side with no schema fork:
+
+        {
+            "currentRanking": [...],
+            "weights": { ... },
+            "missingInputs": [...]
+        }
+
+    The historical week-by-week series is intentionally NOT computed
+    here in PR2 — the v1 power section already exposes that, and the
+    ROS-team-strength input only has a single "now" snapshot.  PR3
+    adds historical playoff-odds; the chart on the new tab will hook
+    into that data instead.
+    """
+    registry = snapshot.managers
+    seasons_sorted = sorted(snapshot.seasons, key=luck._season_sort_key)
+    if not seasons_sorted:
+        return {
+            "currentRanking": [],
+            "weights": dict(WEIGHTS),
+            "missingInputs": ["snapshot empty"],
+            "rosTeamStrengthAvailable": False,
+        }
+
+    # Career totals across all seasons (matches power.py's accumulator
+    # semantics).  Recent buffer is per-season; the "recent form"
+    # metric is the trailing 3-game average within the current season.
+    career_state: dict[str, dict[str, float | int]] = defaultdict(
+        lambda: {"points": 0.0, "games": 0, "wins": 0.0, "losses": 0.0}
+    )
+    season_outcomes: dict[str, list[float]] = defaultdict(list)
+    last_season_recent: dict[str, list[float]] = defaultdict(list)
+    last_season_allplay_share: dict[str, float] = {}
+
+    for season in seasons_sorted:
+        week_scores = luck._season_weekly_scores(season, registry)
+        if not week_scores:
+            continue
+        if season is seasons_sorted[-1]:
+            recent_buffer: dict[str, list[float]] = defaultdict(list)
+        for wk in sorted(week_scores.keys()):
+            scores = week_scores[wk]
+            actuals, _ = luck._actual_week_results(season, wk, registry)
+            all_play = luck._all_play_week(scores)
+            for oid, pts in scores:
+                s = career_state[oid]
+                s["points"] += pts
+                s["games"] += 1
+                actual_share = actuals.get(oid, 0.0)
+                s["wins"] += actual_share
+                s["losses"] += 1.0 - actual_share
+                season_outcomes[oid].append(actual_share)
+                if season is seasons_sorted[-1]:
+                    rb = recent_buffer[oid]
+                    rb.append(pts)
+                    if len(rb) > _RECENT_WINDOW:
+                        rb.pop(0)
+                    last_season_recent[oid] = list(rb)
+                # Capture the last week's all-play expected share so
+                # the all-play-record percentile reflects current
+                # standings rather than a season-wide average that
+                # would lag mid-season trades.
+                ap = all_play.get(oid) or {}
+                last_season_allplay_share[oid] = float(ap.get("expectedShare", 0.0))
+
+    owner_ids = sorted(career_state.keys())
+    if not owner_ids:
+        return {
+            "currentRanking": [],
+            "weights": dict(WEIGHTS),
+            "missingInputs": ["no owners played"],
+            "rosTeamStrengthAvailable": False,
+        }
+
+    ros_pct = _load_team_strength_percentiles()
+    ros_available = bool(ros_pct)
+
+    # Compute per-owner inputs.
+    inputs: dict[str, dict[str, float]] = {}
+    for oid in owner_ids:
+        s = career_state[oid]
+        ppg = s["points"] / s["games"] if s["games"] else 0.0
+        rb = last_season_recent.get(oid, [])
+        recent = sum(rb) / len(rb) if rb else 0.0
+        wins = s["wins"]
+        games = s["games"] or 1
+        wl = wins / games  # already in [0, 1]
+        all_play = last_season_allplay_share.get(oid, 0.0)
+        streak = _streak_score_from_outcomes(season_outcomes.get(oid, []))
+        # Luck regression: a team whose actualWins lag expectedWins
+        # gets a small boost (regression toward expected).  Clamp to
+        # [-0.5, 0.5] then map to [0, 1].
+        career_row = career_state[oid]
+        # Re-walk the seasons to compute expectedWins (luck.py exposes
+        # this via build_section but at PR-2 budget we'd rather not
+        # invoke the whole section).  Re-use the same all_play share
+        # iteration (cheap; same data already in scope).
+        expected_share_running = 0.0
+        for season in seasons_sorted:
+            week_scores = luck._season_weekly_scores(season, registry)
+            for wk in sorted(week_scores.keys()):
+                scores = week_scores[wk]
+                ap_week = luck._all_play_week(scores)
+                if oid in {o for o, _ in scores}:
+                    ap = ap_week.get(oid) or {}
+                    expected_share_running += float(ap.get("expectedShare", 0.0))
+        luck_delta = (wins - expected_share_running) / games if games else 0.0
+        luck_score = max(0.0, min(1.0, 0.5 - luck_delta))  # underperformers get higher score (regression boost)
+
+        inputs[oid] = {
+            "ppg": ppg,
+            "recent": recent,
+            "wl_record": wl,
+            "all_play": all_play,
+            "streak": streak,
+            "luck_regression": luck_score,
+            # PR2 leaves these at 0 (config-gated TODOs):
+            "schedule_adjusted": 0.0,
+            "roster_health": 0.0,
+        }
+
+    # Convert raw inputs to percentiles (ppg, recent only — the others
+    # are already 0-1 scores).
+    ppg_values = [inputs[o]["ppg"] for o in owner_ids]
+    recent_values = [inputs[o]["recent"] for o in owner_ids]
+
+    # Renormalise weights when missing inputs are present so the score
+    # stays in [0, 100] instead of being deflated by the unfilled
+    # 0.04 + 0.03 = 0.07 budget.
+    missing_inputs: list[str] = []
+    if not ros_available:
+        missing_inputs.append("team_ros_strength")
+    missing_inputs.extend(["schedule_adjusted", "roster_health"])  # TODO PR-future
+    active_weights = {
+        k: v for k, v in WEIGHTS.items() if k not in missing_inputs
+    }
+    weight_total = sum(active_weights.values()) or 1.0
+
+    rankings: list[dict[str, Any]] = []
+    for oid in owner_ids:
+        i = inputs[oid]
+        components: dict[str, float] = {
+            "ppg": _percentile(ppg_values, i["ppg"]),
+            "recent": _percentile(recent_values, i["recent"]),
+            "wl_record": i["wl_record"],
+            "all_play": i["all_play"],
+            "streak": i["streak"],
+            "luck_regression": i["luck_regression"],
+        }
+        if ros_available:
+            components["team_ros_strength"] = ros_pct.get(oid, 0.0)
+        # Skipped — held at 0 in this PR, renormalised out:
+        components["schedule_adjusted"] = 0.0
+        components["roster_health"] = 0.0
+
+        # Active weighted score in [0, 1], then scale to 100.
+        score_unit = sum(
+            active_weights.get(k, 0.0) * components.get(k, 0.0)
+            for k in active_weights
+        ) / weight_total
+        score = round(score_unit * 100, 2)
+
+        ros_strength_pct = ros_pct.get(oid, None) if ros_available else None
+        rankings.append(
+            {
+                "ownerId": oid,
+                "displayName": registry.display_name_for(oid)
+                if hasattr(registry, "display_name_for")
+                else oid,
+                "powerScore": score,
+                "components": {k: round(v, 4) for k, v in components.items()},
+                "rosStrengthPercentile": (
+                    round(ros_strength_pct, 4) if ros_strength_pct is not None else None
+                ),
+                "weightsApplied": dict(active_weights),
+            }
+        )
+
+    rankings.sort(key=lambda r: -r["powerScore"])
+    for rank, row in enumerate(rankings, start=1):
+        row["rank"] = rank
+
+    return {
+        "currentRanking": rankings,
+        "weights": dict(WEIGHTS),
+        "missingInputs": sorted(missing_inputs),
+        "rosTeamStrengthAvailable": ros_available,
+    }

--- a/tests/ros/test_power_v2.py
+++ b/tests/ros/test_power_v2.py
@@ -1,0 +1,90 @@
+"""Tests for the ROS-driven power-rankings v2.
+
+Verifies the formula composition + handling of missing inputs +
+graceful degradation when ROS team-strength snapshot is absent.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.ros import power_v2
+
+
+class TestStreakScore(unittest.TestCase):
+    def test_no_history_returns_neutral(self):
+        self.assertEqual(power_v2._streak_score_from_outcomes([]), 0.5)
+
+    def test_winning_streak_above_neutral(self):
+        s = power_v2._streak_score_from_outcomes([1.0, 1.0, 1.0])
+        self.assertGreater(s, 0.5)
+
+    def test_losing_streak_below_neutral(self):
+        s = power_v2._streak_score_from_outcomes([0.0, 0.0])
+        self.assertLess(s, 0.5)
+
+    def test_streak_caps_at_one(self):
+        s = power_v2._streak_score_from_outcomes([1.0] * 20)
+        self.assertLessEqual(s, 1.0)
+
+    def test_streak_floors_at_zero(self):
+        s = power_v2._streak_score_from_outcomes([0.0] * 20)
+        self.assertGreaterEqual(s, 0.0)
+
+
+class TestPercentile(unittest.TestCase):
+    def test_top_value_yields_high_percentile(self):
+        values = [10, 20, 30, 40, 50]
+        self.assertGreater(power_v2._percentile(values, 50), 0.8)
+
+    def test_bottom_value_low_percentile(self):
+        values = [10, 20, 30, 40, 50]
+        self.assertLess(power_v2._percentile(values, 10), 0.2)
+
+    def test_empty_returns_zero(self):
+        self.assertEqual(power_v2._percentile([], 5), 0.0)
+
+
+class TestLoadTeamStrength(unittest.TestCase):
+    def test_missing_file_returns_empty(self):
+        with patch.object(power_v2, "ROS_DATA_DIR", Path("/nonexistent")):
+            self.assertEqual(power_v2._load_team_strength_percentiles(), {})
+
+    def test_loads_and_percentiles(self):
+        # Create temp snapshot file under the real ROS_DATA_DIR.
+        target = power_v2.ROS_DATA_DIR / "team_strength" / "latest.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            json.dumps(
+                [
+                    {"ownerId": "alpha", "teamRosStrength": 90.0},
+                    {"ownerId": "beta", "teamRosStrength": 60.0},
+                    {"ownerId": "gamma", "teamRosStrength": 30.0},
+                ]
+            )
+        )
+        try:
+            result = power_v2._load_team_strength_percentiles()
+            self.assertEqual(set(result.keys()), {"alpha", "beta", "gamma"})
+            self.assertGreater(result["alpha"], result["beta"])
+            self.assertGreater(result["beta"], result["gamma"])
+        finally:
+            target.unlink()
+
+
+class TestWeights(unittest.TestCase):
+    def test_weights_sum_to_one(self):
+        self.assertAlmostEqual(sum(power_v2.WEIGHTS.values()), 1.0, places=2)
+
+    def test_team_ros_strength_dominates(self):
+        # Per spec: 0.38 is the largest individual weight.
+        self.assertEqual(
+            max(power_v2.WEIGHTS.values()),
+            power_v2.WEIGHTS["team_ros_strength"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 2 of 5 for the Rest-of-Season engine. Adds the ROS-driven power-rankings v2 alongside the existing PPG-based v1; user opts in via `settings.useRosPowerRankings` (default false until validated).

## Spec formula

```
power_score =
    0.38 * team_ros_strength_percentile      ← from data/ros/team_strength/
    + 0.18 * season_points_scored_percentile  ← from snapshot.py
    + 0.12 * recent_points_scored_percentile  ← trailing 3-week avg
    + 0.10 * win_loss_record_percentile
    + 0.08 * all_play_record_percentile       ← from luck.py
    + 0.05 * winning_streak_score
    + 0.04 * schedule_adjusted_performance    ← deferred to a future PR
    + 0.03 * roster_health_score              ← deferred (no injury data layer yet)
    + 0.02 * luck_regression_score
```

When the deferred inputs aren't computable, the formula renormalises the active weights so scores stay in [0, 100] instead of being deflated against teams with full coverage. The section response surfaces `missingInputs` so the UI can flag the gap.

## Files

- `src/ros/power_v2.py` — formula + section builder
- `frontend/app/league/sections/ros-power.jsx` — UI swap-in for the Power tab
- `frontend/app/league/LeagueClient.jsx` — toggle based on `settings.useRosPowerRankings`
- `src/public_league/public_contract.py` — registers `rosPower` lazy section
- `tests/ros/test_power_v2.py` — 12 unit tests

## Coexistence

The existing `power.py` v1 stays untouched. Two paths coexist:
- Default: /league → Power renders v1 (PPG/recent/all-play)
- After user flips `useRosPowerRankings`: same tab, ROS-driven v2

## Test plan

- [x] `pytest tests/ros/` — 49 passed
- [x] `pytest tests/` — **2454 passed, 3 skipped, 162 subtests**
- [x] `npm run build` — clean
- [x] No changes to `power.py` v1 or any dynasty contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)