### PR TITLE
feat(ros): UI integration — Fit panel + PlayerPopup tags + /settings section

### DIFF
--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -356,6 +356,78 @@ export default function SettingsPage() {
         />
       </Section>
 
+      <Section title="Rest-of-Season Engine" defaultOpen={false}>
+        <p className="muted" style={{ fontSize: "0.72rem", marginTop: 0, marginBottom: 10 }}>
+          The ROS engine is a separate short-term contender layer.{" "}
+          <strong>It never modifies dynasty rankings or trade-calculator math.</strong>{" "}
+          These flags only control which surfaces show ROS context.
+        </p>
+        <ToggleRow
+          label="Enable ROS engine"
+          checked={settings.rosEnabled !== false}
+          onChange={(v) => update("rosEnabled", v)}
+          hint="Master switch.  Off hides every ROS-driven surface (Power v2, Championship tab, Trade-deadline dashboard, ROS Fit panel, player tags)."
+        />
+        <ToggleRow
+          label="Use ROS-driven Power Rankings"
+          checked={!!settings.useRosPowerRankings}
+          onChange={(v) => update("useRosPowerRankings", v)}
+          hint="Swap the /league Power tab from the v1 PPG/all-play formula to the ROS-driven 9-input v2.  Defaults off until you've validated v2 against a few weeks of standings."
+        />
+        <ToggleRow
+          label="Use ROS-driven Playoff Odds"
+          checked={!!settings.useRosPlayoffOdds}
+          onChange={(v) => update("useRosPlayoffOdds", v)}
+          hint="When enabled, the playoff Monte Carlo uses ROS-blended weekly score distributions instead of empirical-only.  PR-future toggle for the playoff-odds section swap; ROS Championship tab uses ROS by default."
+        />
+        <ToggleRow
+          label="Show ROS Fit panel on Trade Calculator"
+          checked={settings.showRosTradePanel !== false}
+          onChange={(v) => update("showRosTradePanel", v)}
+          hint="Adds an informational panel below the per-source winner table on /trade.  Surfaces buyer/seller direction + per-player tags.  Does NOT change trade math."
+        />
+        <ToggleRow
+          label="Show ROS context tags on player popups"
+          checked={settings.showRosTags !== false}
+          onChange={(v) => update("showRosTags", v)}
+          hint="Appends a Short-term context section to PlayerPopup with ROS value, rank, tier, and tags like Win-now target / Seller cash-out / Rebuilder hold."
+        />
+        <div style={{ display: "flex", gap: 10, alignItems: "center", marginTop: 14 }}>
+          <label style={{ fontSize: "0.82rem", minWidth: 200 }}>
+            Monte Carlo simulations
+          </label>
+          <input
+            type="number"
+            min={1000}
+            max={100000}
+            step={1000}
+            value={settings.rosSimulationCount ?? 10000}
+            onChange={(e) =>
+              update(
+                "rosSimulationCount",
+                Math.max(1000, Math.min(100000, parseInt(e.target.value) || 10000)),
+              )
+            }
+            className="input"
+            style={{ width: 100 }}
+          />
+          <span style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>
+            higher = tighter tails, slower section load
+          </span>
+        </div>
+        <p
+          className="muted"
+          style={{ fontSize: "0.7rem", marginTop: 12, marginBottom: 0 }}
+        >
+          ROS source weights and per-source enable toggles ship in a future
+          PR — for now the registry defaults are baked in.  Diagnostic page:{" "}
+          <a href="/tools/ros-data-health" style={{ color: "var(--cyan)" }}>
+            /tools/ros-data-health
+          </a>
+          .
+        </p>
+      </Section>
+
       <Section title="Pick Settings" defaultOpen={false}>
         <div style={{ display: "flex", gap: 10, alignItems: "center", marginBottom: 8 }}>
           <label style={{ fontSize: "0.82rem" }}>Current Draft Year</label>

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -40,6 +40,7 @@ import {
 } from "@/lib/trade-logic";
 import { useSettings } from "@/components/useSettings";
 import TradeDeltaHistogram from "@/components/graphs/TradeDeltaHistogram";
+import RosTradeFitPanel from "@/components/RosTradeFitPanel";
 import MultiTradeFlow from "@/components/graphs/MultiTradeFlow";
 import { useApp } from "@/components/AppShell";
 import { posBadgeClass } from "@/lib/display-helpers";
@@ -2044,6 +2045,9 @@ export default function TradePage() {
 
           {/* ── Per-source winner breakdown (below the fairness meter) ── */}
           <TradeSourceBreakdown sides={sides} settings={settings} />
+
+          {/* ── ROS Fit panel (informational; gated by settings) ──── */}
+          <RosTradeFitPanel sides={sides} settings={settings} />
 
           {/* ── Value delta histogram (graphical complement to meter) ──── */}
           {sides.length === 2 ? (

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -7,6 +7,176 @@ import PlayerRankHistoryChart from "@/components/PlayerRankHistoryChart";
 import { useTeam } from "@/components/useTeam";
 import { useTerminal } from "@/components/useTerminal";
 import { useUserState } from "@/components/useUserState";
+import { useSettings } from "@/components/useSettings";
+
+
+// ── ROS context section ──────────────────────────────────────────────
+// Read-only contender-layer labels surfaced inside PlayerPopup.  Never
+// mutates dynasty values; gated by ``settings.showRosTags``.  Caches
+// the player-values JSON at module level so opening multiple popups
+// doesn't refetch the 500-row payload each time.
+const _rosCache = { byName: null, fetchedAt: 0, inflight: null };
+const _ROS_TTL_MS = 30 * 60 * 1000;
+
+async function _loadRosValuesByName() {
+  const fresh = _rosCache.byName && Date.now() - _rosCache.fetchedAt < _ROS_TTL_MS;
+  if (fresh) return _rosCache.byName;
+  if (_rosCache.inflight) return _rosCache.inflight;
+  const promise = fetch("/api/ros/player-values?limit=2000")
+    .then((r) => (r.ok ? r.json() : null))
+    .then((payload) => {
+      const map = {};
+      for (const p of payload?.players || []) {
+        if (p.canonicalName) {
+          map[p.canonicalName] = {
+            rosValue: p.rosValue,
+            rosRank: p.rosRankOverall,
+            rosRankPosition: p.rosRankPosition,
+            confidence: p.confidence,
+            volatilityFlag: !!p.volatilityFlag,
+            staleFlag: !!p.staleFlag,
+            tier: p.tier,
+          };
+        }
+      }
+      _rosCache.byName = map;
+      _rosCache.fetchedAt = Date.now();
+      _rosCache.inflight = null;
+      return map;
+    })
+    .catch(() => {
+      _rosCache.inflight = null;
+      return _rosCache.byName || {};
+    });
+  _rosCache.inflight = promise;
+  return promise;
+}
+
+const _ROS_TAG_COLOR = {
+  "Win-now target": "var(--cyan)",
+  "Contender upgrade": "var(--cyan)",
+  "Seller cash-out": "var(--amber)",
+  "Rebuilder hold": "var(--green)",
+  "Avoid unless contending": "var(--red)",
+  "Depth spike option": "var(--subtext)",
+  "Best-ball boost": "var(--cyan)",
+  "IDP contender target": "var(--cyan)",
+  "Injury/bye cover": "var(--subtext)",
+};
+const _VET_AGE = { QB: 32, RB: 26, WR: 29, TE: 30, DL: 30, DE: 30, DT: 30, EDGE: 30, LB: 29, DB: 29, S: 29, CB: 29 };
+
+function _tagsForPlayer({ position, age, rosValue, rosRank, dynastyValue, volatilityFlag }) {
+  const tags = [];
+  if (rosValue == null || rosValue <= 0) return tags;
+  const pos = String(position || "").toUpperCase().split("/")[0];
+  const isIdp = ["DL", "DE", "DT", "EDGE", "LB", "DB", "S", "CB"].includes(pos);
+  const isStrong = rosValue >= 60;
+  const isElite = rosValue >= 80;
+  const isStarterCaliber = rosRank != null && rosRank <= 100;
+  const isTopIdp = isIdp && rosRank != null && rosRank <= 50;
+  const veteran = age != null && _VET_AGE[pos] != null && age >= _VET_AGE[pos];
+  const young = age != null && age <= 24;
+  if (veteran && isStrong) tags.push("Win-now target");
+  if (isElite && isStarterCaliber && !isIdp) tags.push("Contender upgrade");
+  if (veteran && isStrong && dynastyValue != null && dynastyValue < rosValue * 0.7) tags.push("Seller cash-out");
+  if (young && !isStrong) tags.push("Rebuilder hold");
+  if (veteran && isStrong && !isStarterCaliber) tags.push("Avoid unless contending");
+  if (!isStarterCaliber && rosValue >= 30 && rosValue < 60) tags.push("Depth spike option");
+  if (volatilityFlag && isStarterCaliber) tags.push("Best-ball boost");
+  if (isTopIdp) tags.push("IDP contender target");
+  if (!isStrong && !young) tags.push("Injury/bye cover");
+  return tags;
+}
+
+function RosContextSection({ row }) {
+  const { settings } = useSettings();
+  const enabled = settings?.showRosTags !== false;
+  const [ros, setRos] = useState(null);
+  useEffect(() => {
+    if (!enabled || !row) return;
+    let active = true;
+    _loadRosValuesByName().then((map) => {
+      if (!active) return;
+      const name = row.canonicalName || row.displayName || row.name;
+      setRos(map?.[name] ?? null);
+    });
+    return () => {
+      active = false;
+    };
+  }, [enabled, row?.canonicalName, row?.displayName]);
+
+  if (!enabled || !row) return null;
+  if (!ros || !ros.rosValue) {
+    return (
+      <div
+        className="muted"
+        style={{ fontSize: "0.7rem", paddingBottom: 6 }}
+        title="No ROS source ranked this player today."
+      >
+        ROS · no data yet
+      </div>
+    );
+  }
+  const dynastyValue = row.values?.full ?? row.rankDerivedValue ?? null;
+  const tags = _tagsForPlayer({
+    position: row.pos,
+    age: row.age,
+    rosValue: ros.rosValue,
+    rosRank: ros.rosRank,
+    dynastyValue,
+    volatilityFlag: ros.volatilityFlag,
+  });
+  return (
+    <div
+      style={{
+        marginTop: 6,
+        paddingTop: 6,
+        borderTop: "1px dashed rgba(255,255,255,0.08)",
+        fontSize: "0.72rem",
+      }}
+    >
+      <div style={{ color: "var(--subtext)", marginBottom: 4 }}>
+        Short-term context (ROS) · informational only
+      </div>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+        <span style={{ fontFamily: "var(--mono)" }}>
+          ROS value <strong style={{ color: "var(--cyan)" }}>{Math.round(ros.rosValue)}</strong>
+        </span>
+        {ros.rosRank != null && (
+          <span style={{ fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+            #{ros.rosRank} overall
+          </span>
+        )}
+        {ros.tier != null && (
+          <span style={{ color: "var(--subtext)" }}>Tier {ros.tier}</span>
+        )}
+        {ros.confidence != null && (
+          <span style={{ color: "var(--subtext)" }}>
+            confidence {Math.round(ros.confidence * 100)}%
+          </span>
+        )}
+      </div>
+      {tags.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 6 }}>
+          {tags.map((tag) => (
+            <span
+              key={tag}
+              style={{
+                fontSize: "0.62rem",
+                padding: "1px 6px",
+                borderRadius: 4,
+                border: `1px solid ${_ROS_TAG_COLOR[tag] || "var(--subtext)"}`,
+                color: _ROS_TAG_COLOR[tag] || "var(--subtext)",
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 /**
  * Build the ordered value-chain stages from a player row.
@@ -354,6 +524,11 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
               Injury news · offseason (value unchanged)
             </div>
           )}
+          {/* ── Short-term context (ROS) ──────────────────────────
+              Read-only contender-layer labels.  Never mutates the
+              dynasty value above.  Gated by ``settings.showRosTags``
+              (default true). */}
+          <RosContextSection row={row} />
         </div>
 
         {/* Scoring-fit explainer — what's driving the league-aware

--- a/frontend/components/RosTradeFitPanel.jsx
+++ b/frontend/components/RosTradeFitPanel.jsx
@@ -1,0 +1,218 @@
+"use client";
+
+// Trade-calculator ROS Fit panel.  Read-only contextual panel that
+// surfaces buyer/seller direction + per-player ROS tags for the
+// players in the trade.  NEVER mutates trade math — informational
+// only, gated by ``settings.showRosTradePanel``.
+
+import { useEffect, useState } from "react";
+
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const _cache = { data: null, fetchedAt: 0, inflight: null };
+
+async function _loadDirections() {
+  if (_cache.data && Date.now() - _cache.fetchedAt < CACHE_TTL_MS) {
+    return _cache.data;
+  }
+  if (_cache.inflight) return _cache.inflight;
+  const promise = fetch("/api/public/league/rosTradeDeadline")
+    .then((r) => (r.ok ? r.json() : null))
+    .then((payload) => {
+      const body = payload?.data || payload?.section || payload;
+      _cache.data = body || { teams: [] };
+      _cache.fetchedAt = Date.now();
+      _cache.inflight = null;
+      return _cache.data;
+    })
+    .catch(() => {
+      _cache.inflight = null;
+      return _cache.data || { teams: [] };
+    });
+  _cache.inflight = promise;
+  return promise;
+}
+
+const TAG_COLOR = {
+  "Win-now target": "var(--cyan)",
+  "Contender upgrade": "var(--cyan)",
+  "Seller cash-out": "var(--amber)",
+  "Rebuilder hold": "var(--green)",
+  "Avoid unless contending": "var(--red)",
+  "Depth spike option": "var(--subtext)",
+  "Best-ball boost": "var(--cyan)",
+  "IDP contender target": "var(--cyan)",
+  "Injury/bye cover": "var(--subtext)",
+};
+
+const LABEL_COLOR = {
+  "Strong Buyer": "var(--cyan)",
+  "Buyer": "var(--green)",
+  "Selective Buyer": "var(--green)",
+  "Hold / Evaluate": "var(--subtext)",
+  "Selective Seller": "var(--amber)",
+  "Seller": "var(--red)",
+  "Strong Seller / Rebuilder": "var(--red)",
+};
+
+// Pure tag classifier — mirrors src/ros/tags.py::tags_for_player so
+// the trade-calc can label players without a backend round-trip per
+// row.  Stays in sync via the parity test (PR-future).
+function tagsForPlayer({ position, age, rosValue, rosRank, dynastyValue, volatilityFlag }) {
+  const tags = [];
+  if (rosValue == null || rosValue <= 0) return tags;
+  const pos = String(position || "").toUpperCase().split("/")[0];
+  const isIdp = ["DL", "DE", "DT", "EDGE", "LB", "DB", "S", "CB"].includes(pos);
+  const isStrong = rosValue >= 60;
+  const isElite = rosValue >= 80;
+  const isStarterCaliber = rosRank != null && rosRank <= 100;
+  const isTopIdp = isIdp && rosRank != null && rosRank <= 50;
+  const VET_AGE = { QB: 32, RB: 26, WR: 29, TE: 30, DL: 30, DE: 30, DT: 30, EDGE: 30, LB: 29, DB: 29, S: 29, CB: 29 };
+  const veteran = age != null && VET_AGE[pos] != null && age >= VET_AGE[pos];
+  const young = age != null && age <= 24;
+  if (veteran && isStrong) tags.push("Win-now target");
+  if (isElite && isStarterCaliber && !isIdp) tags.push("Contender upgrade");
+  if (veteran && isStrong && dynastyValue != null && dynastyValue < rosValue * 0.7) tags.push("Seller cash-out");
+  if (young && !isStrong) tags.push("Rebuilder hold");
+  if (veteran && isStrong && !isStarterCaliber) tags.push("Avoid unless contending");
+  if (!isStarterCaliber && rosValue >= 30 && rosValue < 60) tags.push("Depth spike option");
+  if (volatilityFlag && isStarterCaliber) tags.push("Best-ball boost");
+  if (isTopIdp) tags.push("IDP contender target");
+  if (!isStrong && !young) tags.push("Injury/bye cover");
+  return tags;
+}
+
+export default function RosTradeFitPanel({ sides, settings }) {
+  const [directions, setDirections] = useState({ teams: [] });
+  const [valuesByName, setValuesByName] = useState({});
+
+  useEffect(() => {
+    if (settings?.showRosTradePanel === false) return;
+    let active = true;
+    _loadDirections().then((d) => {
+      if (!active || !d) return;
+      setDirections(d);
+    });
+    fetch("/api/ros/player-values?limit=2000")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((payload) => {
+        if (!active || !payload) return;
+        const map = {};
+        for (const p of payload.players || []) {
+          if (p.canonicalName) {
+            map[p.canonicalName] = {
+              rosValue: p.rosValue,
+              rosRank: p.rosRankOverall,
+              volatilityFlag: !!p.volatilityFlag,
+            };
+          }
+        }
+        setValuesByName(map);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [settings?.showRosTradePanel]);
+
+  if (settings?.showRosTradePanel === false) return null;
+  if (!sides || sides.length < 2) return null;
+
+  // Resolve incoming + outgoing players per side -> their ROS tags.
+  const enriched = sides.map((side) => {
+    const assets = side.assets || [];
+    const tagged = assets.map((row) => {
+      const name =
+        row?.canonicalName || row?.name || row?.displayName || "";
+      const ros = valuesByName[name] || {};
+      const tags = tagsForPlayer({
+        position: row?.pos,
+        age: row?.age,
+        rosValue: ros.rosValue,
+        rosRank: ros.rosRank,
+        dynastyValue: row?.values?.full ?? row?.rankDerivedValue ?? null,
+        volatilityFlag: ros.volatilityFlag,
+      });
+      return { name, position: row?.pos, age: row?.age, ros, tags };
+    });
+    return { sideLabel: side.label || "?", tagged };
+  });
+
+  // Drop the panel entirely when no asset has a ROS read AND no team
+  // direction is available — nothing useful to show.
+  const hasAnyTags = enriched.some((s) => s.tagged.some((p) => p.tags.length));
+  const hasDirections = (directions?.teams || []).length > 0;
+  if (!hasAnyTags && !hasDirections) return null;
+
+  return (
+    <div
+      className="card"
+      style={{
+        marginTop: 14,
+        padding: "10px 14px",
+        background: "rgba(255, 199, 4, 0.04)",
+        border: "1px solid rgba(255, 199, 4, 0.15)",
+      }}
+    >
+      <div style={{ fontWeight: 700, marginBottom: 4, fontSize: "0.84rem" }}>
+        ROS Fit
+      </div>
+      <div
+        style={{
+          fontSize: "0.7rem",
+          color: "var(--subtext)",
+          marginBottom: 8,
+        }}
+      >
+        Informational short-term context.  Does NOT change the trade math
+        above — your dynasty value calculation is unaffected.
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: enriched.length === 2 ? "1fr 1fr" : "1fr",
+          gap: 12,
+        }}
+      >
+        {enriched.map((side, i) => (
+          <div key={i}>
+            <div style={{ fontWeight: 600, fontSize: "0.78rem", marginBottom: 4 }}>
+              Side {side.sideLabel}
+            </div>
+            {side.tagged.length === 0 && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>
+                (No assets yet)
+              </div>
+            )}
+            {side.tagged.map((p, j) => (
+              <div key={j} style={{ marginBottom: 6, fontSize: "0.74rem" }}>
+                <div style={{ fontWeight: 500 }}>{p.name || "—"}</div>
+                {p.tags.length === 0 ? (
+                  <div style={{ color: "var(--subtext)", fontSize: "0.66rem" }}>
+                    No ROS tags · {p.ros?.rosValue ? `ROS value ${Math.round(p.ros.rosValue)}` : "no ROS read"}
+                  </div>
+                ) : (
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                    {p.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        style={{
+                          fontSize: "0.62rem",
+                          padding: "1px 6px",
+                          borderRadius: 4,
+                          border: `1px solid ${TAG_COLOR[tag] || "var(--subtext)"}`,
+                          color: TAG_COLOR[tag] || "var(--subtext)",
+                        }}
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/scripts/check-bundle-sizes.mjs
+++ b/frontend/scripts/check-bundle-sizes.mjs
@@ -54,7 +54,7 @@ const BUDGETS_KB = {
   "/league/page": 165, // public hub bundles every section together
   "/rosters/page": 30,
   "/trades/page": 20,
-  "/settings/page": 35,  // bumped from 30 for the IDP scoring-fit panel + health dashboard
+  "/settings/page": 40,  // bumped 35→40 for ROS engine section (5 toggles + sim-count input)
   "/login/page": 15,
   "/more/page": 10,
 };


### PR DESCRIPTION
Items 1-3 of the ROS top-10 follow-up. UI-only; never mutates dynasty values or trade math.

- /trade Fit panel (new `RosTradeFitPanel`) below per-source winner table
- PlayerPopup gains a Short-term context block with ROS value/rank/tier + tags
- /settings new 'Rest-of-Season Engine' section with 5 toggles + Monte Carlo count input

Tests: 82 pytest, 791 vitest, build clean (settings budget bumped 35→40 KB).