### PR TITLE
fix(trade): stamp canonical val on rank-history points

### DIFF
--- a/frontend/__tests__/trade-retro-value.test.js
+++ b/frontend/__tests__/trade-retro-value.test.js
@@ -7,7 +7,32 @@ function makeLookup(map) {
 }
 
 describe("valueSideAtTime", () => {
-  it("uses rankHistory rank-at-time to compute value", () => {
+  it("prefers the server-stamped val over re-deriving from rank", () => {
+    // The backend now stamps ``val`` (canonical pipeline value) on
+    // every history point so retro grading lines up with the live
+    // ``/api/data`` value scale rather than a frozen client-side
+    // Hill curve.  When ``val`` is present, ``valueFromRank`` is
+    // bypassed entirely.
+    const lookup = makeLookup({
+      "player a": [
+        { date: "2025-01-01", rank: 30, val: 4321 },
+        { date: "2025-06-01", rank: 10, val: 7777 },
+      ],
+    });
+    const asOf = Date.parse("2025-03-01");
+    const out = valueSideAtTime(
+      [{ name: "Player A", val: 9999, isPick: false }],
+      lookup,
+      asOf,
+    );
+    expect(out.total).toBe(4321);
+    expect(out.items[0].source).toBe("rankHistory");
+  });
+
+  it("falls back to the local Hill curve when val is missing on the point", () => {
+    // Defensive path: if a snapshot ever ships without ``val`` (older
+    // on-disk entry the backend forgot to back-fill), we still derive
+    // a value rather than dropping the player.
     const lookup = makeLookup({
       "player a": [
         { date: "2025-01-01", rank: 30 },
@@ -68,44 +93,50 @@ describe("valueSideAtTime", () => {
 });
 
 describe("gradeRetro", () => {
+  // Server-stamped val: 100 → small, 5 → large.  Numbers don't have
+  // to match a specific curve any more — the backend pre-computes
+  // them from the canonical pipeline.
   const lookup = makeLookup({
-    "got player": [{ date: "2025-01-01", rank: 100 }], // value-at-trade ≈ small
-    "gave player": [{ date: "2025-01-01", rank: 5 }],  // value-at-trade ≈ large
+    "got player": [{ date: "2025-01-01", rank: 100, val: 1500 }],
+    "gave player": [{ date: "2025-01-01", rank: 5, val: 8800 }],
   });
   const asOf = Date.parse("2025-02-01");
 
   it("flags 'aged_well' when current net beats at-trade net by >200", () => {
     const side = {
-      got: [{ name: "Got Player", val: valueFromRank(20), isPick: false }],
-      gave: [{ name: "Gave Player", val: valueFromRank(30), isPick: false }],
+      got: [{ name: "Got Player", val: 5000, isPick: false }],
+      gave: [{ name: "Gave Player", val: 4500, isPick: false }],
     };
-    // currentNet ≈ value(20) - value(30) ≈ positive
-    const currentNet = valueFromRank(20) - valueFromRank(30);
+    const currentNet = 5000 - 4500; // +500 today
     const out = gradeRetro({ side, currentNet, asOfMs: asOf, historyLookup: lookup });
-    expect(out.atTradeNet).toBe(valueFromRank(100) - valueFromRank(5));
+    // At-trade net was 1500 - 8800 = -7300 (a brutal initial loss);
+    // verdictDelta = 500 - (-7300) = 7800 → strongly aged_well.
+    expect(out.atTradeNet).toBe(1500 - 8800);
     expect(out.verdictDelta).toBeGreaterThan(200);
     expect(out.verdict).toBe("aged_well");
   });
 
   it("flags 'aged_poorly' when current net is much worse", () => {
     const side = {
-      got: [{ name: "Got Player", val: valueFromRank(200), isPick: false }],
-      gave: [{ name: "Gave Player", val: valueFromRank(2), isPick: false }],
+      got: [{ name: "Got Player", val: 1200, isPick: false }],
+      gave: [{ name: "Gave Player", val: 9500, isPick: false }],
     };
-    const currentNet = valueFromRank(200) - valueFromRank(2); // very negative
+    const currentNet = 1200 - 9500; // -8300 today
     const out = gradeRetro({ side, currentNet, asOfMs: asOf, historyLookup: lookup });
+    // At-trade net was 1500 - 8800 = -7300; today is -8300 →
+    // verdictDelta -1000 → aged_poorly.
     expect(out.verdictDelta).toBeLessThan(-200);
     expect(out.verdict).toBe("aged_poorly");
   });
 
   it("flags 'stable' when delta is small", () => {
     const lookup2 = makeLookup({
-      "got": [{ date: "2025-01-01", rank: 30 }],
-      "gave": [{ date: "2025-01-01", rank: 30 }],
+      "got": [{ date: "2025-01-01", rank: 30, val: 4000 }],
+      "gave": [{ date: "2025-01-01", rank: 30, val: 4000 }],
     });
     const side = {
-      got: [{ name: "Got", val: valueFromRank(30) + 50, isPick: false }],
-      gave: [{ name: "Gave", val: valueFromRank(30), isPick: false }],
+      got: [{ name: "Got", val: 4050, isPick: false }],
+      gave: [{ name: "Gave", val: 4000, isPick: false }],
     };
     const currentNet = 50;
     const out = gradeRetro({ side, currentNet, asOfMs: asOf, historyLookup: lookup2 });

--- a/frontend/lib/trade-retro-value.js
+++ b/frontend/lib/trade-retro-value.js
@@ -29,24 +29,43 @@
  */
 import { valueFromRank } from "@/lib/value-history";
 
-function rankAt(history, asOfMs) {
+/**
+ * Find the rank-history point closest-before ``asOfMs``, or — when
+ * the trade predates all coverage — the earliest available sample.
+ * Returns the whole point so callers can read both ``rank`` and the
+ * server-stamped ``val`` (canonical pipeline value at that snapshot).
+ */
+function pointAt(history, asOfMs) {
   if (!Array.isArray(history) || history.length === 0) return null;
   let best = null;
+  let earliest = null;
   for (const point of history) {
     const t = Date.parse(point?.date);
     if (!Number.isFinite(t)) continue;
     const rank = Number(point?.rank);
     if (!Number.isFinite(rank) || rank <= 0) continue;
+    if (!earliest || t < earliest.t) earliest = { t, point };
     if (t <= asOfMs) {
-      if (!best || t > best.t) best = { t, rank };
-    } else if (!best) {
-      // No earlier point — first sample after the trade is the best
-      // available proxy.  Better than null when the player was ranked
-      // shortly after the trade.
-      best = { t, rank };
+      if (!best || t > best.t) best = { t, point };
     }
   }
-  return best ? best.rank : null;
+  // Prefer closest-before; fall back to earliest sample for trades
+  // that predate the rank-history window (better than null when the
+  // player's coverage starts shortly after the trade).
+  return (best || earliest)?.point || null;
+}
+
+function valueFromPoint(point) {
+  if (!point) return null;
+  const stamped = Number(point.val);
+  if (Number.isFinite(stamped) && stamped > 0) return stamped;
+  // Defensive: if the server didn't stamp ``val`` for this point
+  // (shouldn't happen with the new schema), fall back to the local
+  // Hill-curve approximation.  Documented mismatch with backend
+  // canonical curves — see value-history.js::valueFromRank.
+  const r = Number(point.rank);
+  if (!Number.isFinite(r) || r <= 0) return null;
+  return valueFromRank(r);
 }
 
 export function valueSideAtTime(items, historyLookup, asOfMs) {
@@ -66,11 +85,11 @@ export function valueSideAtTime(items, historyLookup, asOfMs) {
       continue;
     }
     const history = historyLookup ? historyLookup(it.name) : null;
-    const rankAtTrade = rankAt(history, asOfMs);
-    if (rankAtTrade != null) {
-      const v = valueFromRank(rankAtTrade);
-      out.push({ name: it.name, val: v, isPick: false, source: "rankHistory" });
-      total += v;
+    const pointAtTrade = pointAt(history, asOfMs);
+    const stamped = valueFromPoint(pointAtTrade);
+    if (stamped != null) {
+      out.push({ name: it.name, val: stamped, isPick: false, source: "rankHistory" });
+      total += stamped;
     } else {
       const v = Number(it.val) || 0;
       out.push({ name: it.name, val: v, isPick: false, source: "current_fallback" });

--- a/src/api/rank_history.py
+++ b/src/api/rank_history.py
@@ -1,10 +1,14 @@
 """Per-player rank history persistence.
 
 On every contract rebuild we append a compact snapshot of
-``{canonicalName: canonicalConsensusRank}`` to ``data/rank_history.jsonl``.
-Later reads reconstruct a per-player time series so the frontend
-``RankChangeGlyph`` (which accepts a ``history`` prop and degrades to
-a delta arrow when absent) can render an actual sparkline.
+``{canonicalName: canonicalConsensusRank}`` plus ``rankDerivedValue``
+to ``data/rank_history.jsonl``.  Later reads reconstruct a per-player
+time series carrying both the rank and the canonical pipeline value
+at that rank, so the frontend ``RankChangeGlyph`` can render a
+sparkline AND consumers like trade-retro-grading can value each side
+of a historical trade against the same value scale the live UI uses
+today (rather than re-deriving from rank with a frozen client-side
+Hill curve that drifts from the backend).
 
 JSONL is chosen deliberately:
 
@@ -47,6 +51,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from src.canonical.player_valuation import (
+    HILL_MIDPOINT,
+    HILL_SLOPE,
+    IDP_HILL_MIDPOINT,
+    IDP_HILL_SLOPE,
+    rank_to_value,
+)
+
 HISTORY_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "rank_history.jsonl"
 
 # Retain three full calendar years of daily scrapes.  At ~1,200
@@ -69,8 +81,16 @@ def _today_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
 
+def _players_array(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    arr = contract.get("playersArray")
+    if not isinstance(arr, list):
+        data = contract.get("data") or {}
+        arr = data.get("playersArray") if isinstance(data, dict) else None
+    return arr if isinstance(arr, list) else []
+
+
 def _extract_ranks(contract: dict[str, Any]) -> dict[str, int]:
-    """Flatten a live contract into ``{canonicalName: rank}``.
+    """Flatten a live contract into ``{canonicalName::assetClass: rank}``.
 
     Accepts either the top-level contract shape or the ``data``-
     wrapped API envelope.  Skips rows without a ranked stamp; we
@@ -82,15 +102,8 @@ def _extract_ranks(contract: dict[str, Any]) -> dict[str, int]:
     identity-validation code) get distinct history series instead of
     silently overwriting each other in the snapshot dict.
     """
-    arr = contract.get("playersArray")
-    if not isinstance(arr, list):
-        data = contract.get("data") or {}
-        arr = data.get("playersArray") if isinstance(data, dict) else None
-    if not isinstance(arr, list):
-        return {}
-
     out: dict[str, int] = {}
-    for row in arr:
+    for row in _players_array(contract):
         if not isinstance(row, dict):
             continue
         key = _player_key(row)
@@ -99,6 +112,49 @@ def _extract_ranks(contract: dict[str, Any]) -> dict[str, int]:
             continue
         out[key] = int(rank)
     return out
+
+
+def _extract_values(contract: dict[str, Any]) -> dict[str, int]:
+    """Flatten a live contract into ``{canonicalName::assetClass: rankDerivedValue}``.
+
+    Mirrors ``_extract_ranks`` but captures the canonical pipeline
+    value (``rankDerivedValue``) so retro consumers can compare a
+    trade's at-trade net to its current net on the same value scale
+    that ``/api/data`` emits today — rather than re-deriving from
+    rank with a frozen client-side Hill curve.
+
+    Skipping rules match ``_extract_ranks``: only rows with a valid
+    rank are captured (a row without a rank can't contribute to a
+    meaningful history series anyway).
+    """
+    out: dict[str, int] = {}
+    for row in _players_array(contract):
+        if not isinstance(row, dict):
+            continue
+        key = _player_key(row)
+        rank = row.get("canonicalConsensusRank")
+        if not key or not isinstance(rank, int) or rank <= 0:
+            continue
+        try:
+            val = int(round(float(row.get("rankDerivedValue") or 0)))
+        except (TypeError, ValueError):
+            continue
+        if val <= 0:
+            continue
+        out[key] = val
+    return out
+
+
+def _value_from_rank(rank: int, scope: str) -> int:
+    """Backfill a value for an old log entry that has rank but no val.
+
+    Uses the canonical Hill curve constants (offense vs IDP).  Picks
+    fall through to the offense curve — picks logged before this
+    schema bump are rare and the discrepancy is bounded.
+    """
+    midpoint = IDP_HILL_MIDPOINT if scope == "idp" else HILL_MIDPOINT
+    slope = IDP_HILL_SLOPE if scope == "idp" else HILL_SLOPE
+    return int(rank_to_value(float(rank), midpoint=midpoint, slope=slope))
 
 
 _OFFENSE_POSITIONS = frozenset({"QB", "RB", "WR", "TE"})
@@ -225,14 +281,23 @@ def append_snapshot(
 
     Idempotent per date — if an entry for ``date`` already exists
     it's overwritten, not duplicated.
+
+    Each entry carries both ``ranks`` and ``values`` keyed by the
+    same composite ``name::assetClass``.  Older readers ignore
+    ``values``; newer readers prefer it over the rank-derived
+    fallback so retro grading lands on the canonical pipeline scale.
     """
     path = path or HISTORY_PATH
     ranks = _extract_ranks(contract)
     if not ranks:
         return False
 
+    values = _extract_values(contract)
+
     date = date or _today_utc()
-    entry = {"date": date, "ranks": ranks}
+    entry: dict[str, Any] = {"date": date, "ranks": ranks}
+    if values:
+        entry["values"] = values
 
     path.parent.mkdir(parents=True, exist_ok=True)
     existing = _read_lines(path)
@@ -265,13 +330,20 @@ def load_history(
     Output shape::
 
         {
-          "Ja'Marr Chase": [
-            {"date": "2026-03-25", "rank": 2},
-            {"date": "2026-03-26", "rank": 2},
+          "Ja'Marr Chase::offense": [
+            {"date": "2026-03-25", "rank": 2, "val": 9719},
+            {"date": "2026-03-26", "rank": 2, "val": 9712},
             ...
           ],
           ...
         }
+
+    ``val`` is the canonical pipeline value at the time of the
+    snapshot (``rankDerivedValue`` from the live contract).  For
+    legacy entries written before this schema bump (no ``values``
+    block on disk), ``val`` is back-filled from rank using the
+    asset-class-aware Hill curve so the consumer never has to
+    re-derive client-side.
 
     Players who don't appear in every snapshot get gaps.  The
     frontend sparkline path handles gaps; no imputation here.
@@ -287,6 +359,7 @@ def load_history(
     for e in windowed:
         date = e.get("date")
         ranks = e.get("ranks") or {}
+        values = e.get("values") if isinstance(e.get("values"), dict) else {}
         if not isinstance(date, str) or not isinstance(ranks, dict):
             continue
         for name, rank in ranks.items():
@@ -295,7 +368,24 @@ def load_history(
                     rank = int(rank)
                 except (TypeError, ValueError):
                     continue
-            per_player.setdefault(str(name), []).append({"date": date, "rank": rank})
+            stored_val = values.get(name) if values else None
+            if stored_val is None:
+                # Legacy entry — derive from rank using the canonical
+                # Hill curve.  Asset class is encoded in the key suffix
+                # ("::idp" / "::offense" / "::pick").
+                idx = str(name).rfind("::")
+                scope = str(name)[idx + 2:].lower() if idx >= 0 else ""
+                val = _value_from_rank(rank, scope)
+            else:
+                try:
+                    val = int(stored_val)
+                except (TypeError, ValueError):
+                    idx = str(name).rfind("::")
+                    scope = str(name)[idx + 2:].lower() if idx >= 0 else ""
+                    val = _value_from_rank(rank, scope)
+            per_player.setdefault(str(name), []).append(
+                {"date": date, "rank": rank, "val": val}
+            )
     return per_player
 
 

--- a/tests/api/test_rank_history.py
+++ b/tests/api/test_rank_history.py
@@ -17,17 +17,23 @@ from tempfile import TemporaryDirectory
 from src.api import rank_history
 
 
-def _contract_with(rank_by_name: dict[str, int], asset_class: str = "offense") -> dict:
-    return {
-        "playersArray": [
-            {
-                "canonicalName": name,
-                "canonicalConsensusRank": rank,
-                "assetClass": asset_class,
-            }
-            for name, rank in rank_by_name.items()
-        ]
-    }
+def _contract_with(
+    rank_by_name: dict[str, int],
+    asset_class: str = "offense",
+    *,
+    value_by_name: dict[str, int] | None = None,
+) -> dict:
+    rows = []
+    for name, rank in rank_by_name.items():
+        row = {
+            "canonicalName": name,
+            "canonicalConsensusRank": rank,
+            "assetClass": asset_class,
+        }
+        if value_by_name is not None and name in value_by_name:
+            row["rankDerivedValue"] = value_by_name[name]
+        rows.append(row)
+    return {"playersArray": rows}
 
 
 def _key(name: str, asset_class: str = "offense") -> str:
@@ -170,14 +176,18 @@ class LoadHistory(unittest.TestCase):
             )
             series = rank_history.load_history(days=30, path=path)
             self.assertIn(_key("A"), series)
-            self.assertEqual(
-                series[_key("A")],
-                [
-                    {"date": "2026-04-18", "rank": 3},
-                    {"date": "2026-04-19", "rank": 2},
-                    {"date": "2026-04-20", "rank": 1},
-                ],
-            )
+            self.assertEqual(len(series[_key("A")]), 3)
+            ranks = [p["rank"] for p in series[_key("A")]]
+            self.assertEqual(ranks, [3, 2, 1])
+            dates = [p["date"] for p in series[_key("A")]]
+            self.assertEqual(dates, ["2026-04-18", "2026-04-19", "2026-04-20"])
+            # Each point carries a ``val`` — derived from rank when no
+            # ``rankDerivedValue`` was stamped on the snapshot rows.
+            self.assertTrue(all("val" in p and p["val"] > 0 for p in series[_key("A")]))
+            # Rank 1 should map to the curve's top (close to 9999).
+            top = series[_key("A")][-1]
+            self.assertEqual(top["rank"], 1)
+            self.assertGreater(top["val"], 9500)
             self.assertEqual(series[_key("B")][-1]["rank"], 4)
 
     def test_days_window_truncates_oldest(self) -> None:
@@ -192,6 +202,58 @@ class LoadHistory(unittest.TestCase):
             series = rank_history.load_history(days=2, path=path)
             self.assertEqual(len(series[_key("A")]), 2)
             self.assertEqual(series[_key("A")][0]["date"], "2026-03-04")
+
+    def test_stamps_canonical_value_when_rank_derived_value_present(self) -> None:
+        # New schema: snapshot rows that carry ``rankDerivedValue``
+        # write a ``values`` block alongside ``ranks``.  Reading back
+        # surfaces the stamped value verbatim — no Hill-curve re-
+        # derivation, so the trade-retro grade lines up with the live
+        # ``/api/data`` value scale.
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rank_history.jsonl"
+            rank_history.append_snapshot(
+                _contract_with(
+                    {"Stud": 1},
+                    value_by_name={"Stud": 9712},
+                ),
+                date="2026-04-20",
+                path=path,
+            )
+            entries = [json.loads(line) for line in path.read_text().splitlines()]
+            self.assertEqual(entries[0]["values"], {_key("Stud"): 9712})
+            series = rank_history.load_history(days=30, path=path)
+            self.assertEqual(series[_key("Stud")][-1]["val"], 9712)
+
+    def test_back_fills_value_for_legacy_entries_without_values_block(self) -> None:
+        # Older log entries (written before the schema bump) only have
+        # ``ranks``.  Reading must back-fill ``val`` from the rank
+        # using the asset-class-aware Hill curve so consumers always
+        # see the same shape.
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rank_history.jsonl"
+            with path.open("w") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "date": "2026-01-01",
+                            "ranks": {
+                                _key("Off Rookie", "offense"): 50,
+                                _key("Idp Rookie", "idp"): 50,
+                            },
+                        }
+                    )
+                    + "\n"
+                )
+            series = rank_history.load_history(days=30, path=path)
+            off_val = series[_key("Off Rookie", "offense")][-1]["val"]
+            idp_val = series[_key("Idp Rookie", "idp")][-1]["val"]
+            self.assertGreater(off_val, 0)
+            self.assertGreater(idp_val, 0)
+            # IDP curve decays slower at rank 50 than offense — so an
+            # IDP player at rank 50 should outvalue an offense player
+            # at the same rank.  (Sanity check that the asset class
+            # actually gates which curve fills in the gap.)
+            self.assertGreater(idp_val, off_val)
 
     def test_corrupt_line_is_skipped(self) -> None:
         # A half-written final line must not break the reader.  We


### PR DESCRIPTION
## Summary

Fixes the "Aged well / Aged poorly" pill on `/trades` showing a near-constant `±X` across unrelated trades. Root cause: `currentNet` and `atTradeNet` were computed on different value scales, so the verdict delta mostly measured curve drift instead of aging.

- `currentNet` = `side.netValue`, built from the contract's `rankDerivedValue` (backend percentile→value pipeline).
- `atTradeNet` was built client-side via `valueFromRank` in `frontend/lib/value-history.js` using **frozen** constants (`K=45`, `EXP=1.10`) that had drifted out of sync with the backend (`HILL_MIDPOINT=48.44`, `HILL_SLOPE=1.149`) — and the live pipeline actually uses a different percentile→value curve on top.

The result was a systematic per-player offset that, summed across a side, landed on similar numbers for any two trades with similar shapes (e.g. the user observed `±620` repeating).

### Fix (option B)

Stamp the canonical value on every rank-history point at snapshot time and have the frontend consume it directly.

- `src/api/rank_history.py`
  - `_extract_values` captures `rankDerivedValue` per player at snapshot time.
  - `append_snapshot` writes a new `values` block alongside `ranks`. Older readers ignore it; newer readers prefer it.
  - `load_history` emits `{date, rank, val}` per point. Legacy entries (no `values` block on disk) are back-filled from rank using the asset-class-aware Hill curve (`HILL_MIDPOINT/SLOPE` for offense, `IDP_HILL_MIDPOINT/SLOPE` for IDP) so the consumer always sees the same shape.
- `frontend/lib/trade-retro-value.js`
  - `rankAt` → `pointAt` returns the whole history point.
  - `valueSideAtTime` consumes server-stamped `point.val` directly. Local `valueFromRank` remains as a defensive fallback only.

## Test plan

- [x] `python -m unittest tests.api.test_rank_history` — all 26 pass, including two new tests:
  - `test_stamps_canonical_value_when_rank_derived_value_present` — pins the new `values` block + round-trip.
  - `test_back_fills_value_for_legacy_entries_without_values_block` — verifies legacy entries surface a Hill-curve val and IDP/offense gate the right curve.
- [x] `tests.scripts.test_backfill_rank_history`, `tests.canonical.test_rank_history_band` — still green.
- [x] `frontend/__tests__/trade-retro-value.test.js` — updated fixtures to include `val`; added a server-stamped path case and kept the legacy fallback case. Syntax-checked (vitest not installed in this env).
- [ ] Spot-check on the live `/trades` page after deploy: two unrelated trades should now show different `±X` values reflecting actual rank movement.

## Notes

- Schema change is purely additive on disk (`values` is optional). Old log lines remain readable; new lines carry both blocks.
- `rankHistory` consumers that only read `rank` (sparkline, movers, team-value series via `normalizePoints`) are unaffected — `normalizePoints` strips everything except `date`/`t`/`rank` already.
- After deploy, the frontend's `valueFromRank` becomes a defensive fallback. The bigger follow-up — pulling the Hill-curve constants from `meta.methodology` so rank-only consumers stay aligned with the backend — can wait; this PR removes the trade-aging miscalibration which was the user-visible bug.

https://claude.ai/code/session_01STEuGaMG6tAL78ekEyT9B5

---
_Generated by [Claude Code](https://claude.ai/code/session_01STEuGaMG6tAL78ekEyT9B5)_