### PR TITLE
feat(pwa): pull-to-refresh in standalone mode

### DIFF
--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import AppShellWrapper from "./AppShellWrapper";
 import ServiceWorkerRegistrar from "@/components/ServiceWorkerRegistrar";
+import PullToRefresh from "@/components/PullToRefresh";
 
 export const metadata = {
   title: "Dynasty Trade Calculator",
@@ -34,6 +35,7 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <body>
         <ServiceWorkerRegistrar />
+        <PullToRefresh />
         <AppShellWrapper>{children}</AppShellWrapper>
       </body>
     </html>

--- a/frontend/components/AppShell.jsx
+++ b/frontend/components/AppShell.jsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useDynastyData } from "@/components/useDynastyData";
 import PlayerPopup from "@/components/PlayerPopup";
 import GlobalSearch from "@/components/GlobalSearch";
+import PullToRefresh from "@/components/PullToRefresh";
 
 // ── App-wide context for popup and search ────────────────────────────────
 const AppContext = createContext({
@@ -185,6 +186,8 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
       }}
     >
       {children}
+
+      <PullToRefresh />
 
       {privateDataEnabled && (
         <PlayerPopup

--- a/frontend/components/AppShell.jsx
+++ b/frontend/components/AppShell.jsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import { useDynastyData } from "@/components/useDynastyData";
 import PlayerPopup from "@/components/PlayerPopup";
 import GlobalSearch from "@/components/GlobalSearch";
-import PullToRefresh from "@/components/PullToRefresh";
 
 // ── App-wide context for popup and search ────────────────────────────────
 const AppContext = createContext({
@@ -186,8 +185,6 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
       }}
     >
       {children}
-
-      <PullToRefresh />
 
       {privateDataEnabled && (
         <PlayerPopup

--- a/frontend/components/PullToRefresh.jsx
+++ b/frontend/components/PullToRefresh.jsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// iOS Safari has a native pull-to-refresh in browser chrome, but
+// when the site is launched from the home screen as a PWA the
+// gesture is gone — the rubber-band overscroll just snaps back.
+// This shim restores it for standalone mode and stays out of
+// regular Safari's way (where the native one already works).
+
+const THRESHOLD = 70;        // px past which release triggers a refresh
+const MAX_PULL = 120;        // visual ceiling so the indicator can't run off
+const ACTIVATION_SLOP = 8;   // ignore tiny finger drift before committing
+
+export default function PullToRefresh() {
+  const [pullDistance, setPullDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+
+  const pullRef = useRef(0);
+  const startYRef = useRef(null);
+  const trackingRef = useRef(false);
+  const committedRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const standalone =
+      (window.matchMedia && window.matchMedia("(display-mode: standalone)").matches) ||
+      window.navigator?.standalone === true;
+    setEnabled(Boolean(standalone));
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    function reset() {
+      trackingRef.current = false;
+      committedRef.current = false;
+      startYRef.current = null;
+      pullRef.current = 0;
+      setPullDistance(0);
+    }
+
+    function onTouchStart(e) {
+      if (refreshing) return;
+      // Only start tracking when the page is genuinely at the top.
+      if ((window.scrollY || window.pageYOffset || 0) > 0) return;
+      const t = e.touches?.[0];
+      if (!t) return;
+      startYRef.current = t.clientY;
+      trackingRef.current = true;
+      committedRef.current = false;
+    }
+
+    function onTouchMove(e) {
+      if (!trackingRef.current || refreshing) return;
+      if ((window.scrollY || window.pageYOffset || 0) > 0) {
+        reset();
+        return;
+      }
+      const t = e.touches?.[0];
+      if (!t) return;
+      const delta = t.clientY - startYRef.current;
+      if (delta <= ACTIVATION_SLOP) {
+        // Either pulling up or below the slop threshold — let the
+        // browser handle scroll normally.
+        if (committedRef.current) {
+          pullRef.current = 0;
+          setPullDistance(0);
+        }
+        return;
+      }
+      committedRef.current = true;
+      // Damped pull so the indicator slows down as the finger
+      // travels — feels closer to native PTR than a 1:1 mapping.
+      const damped = Math.min(MAX_PULL, Math.pow(delta, 0.85));
+      pullRef.current = damped;
+      setPullDistance(damped);
+      // Suppress rubber-band overscroll while we're handling the pull.
+      if (e.cancelable) e.preventDefault();
+    }
+
+    function onTouchEnd() {
+      if (!trackingRef.current || refreshing) {
+        reset();
+        return;
+      }
+      const distance = pullRef.current;
+      trackingRef.current = false;
+      committedRef.current = false;
+      startYRef.current = null;
+      if (distance >= THRESHOLD) {
+        setRefreshing(true);
+        // Brief delay so the user sees the indicator settle into the
+        // "refreshing" state before the page tears down.
+        setTimeout(() => {
+          try {
+            window.location.reload();
+          } catch {
+            window.location.assign(window.location.href);
+          }
+        }, 120);
+      } else {
+        pullRef.current = 0;
+        setPullDistance(0);
+      }
+    }
+
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+    window.addEventListener("touchend", onTouchEnd, { passive: true });
+    window.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
+    return () => {
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", onTouchEnd);
+      window.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [enabled, refreshing]);
+
+  if (!enabled) return null;
+
+  const armed = pullDistance >= THRESHOLD;
+  const visible = pullDistance > 0 || refreshing;
+  const translate = refreshing ? Math.max(pullDistance, THRESHOLD) : pullDistance;
+  const opacity = refreshing ? 1 : Math.min(1, pullDistance / THRESHOLD);
+  const rotation = refreshing ? 0 : Math.min(360, (pullDistance / THRESHOLD) * 270);
+
+  return (
+    <div
+      aria-hidden={!visible}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 0,
+        zIndex: 1000,
+        pointerEvents: "none",
+        display: "flex",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          transform: `translateY(${translate}px)`,
+          transition: refreshing || pullDistance === 0 ? "transform 180ms ease-out" : "none",
+          opacity,
+          marginTop: 8,
+          width: 36,
+          height: 36,
+          borderRadius: "50%",
+          background: "var(--bg-elevated, #1a1a24)",
+          boxShadow: "0 4px 12px rgba(0,0,0,0.35)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={armed || refreshing ? "var(--amber, #f5b342)" : "var(--text, #e7e7ee)"}
+          strokeWidth="2.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{
+            transform: `rotate(${rotation}deg)`,
+            transition: refreshing ? "none" : "transform 60ms linear",
+            animation: refreshing ? "ptr-spin 0.9s linear infinite" : "none",
+          }}
+        >
+          <path d="M21 12a9 9 0 1 1-3-6.7" />
+          <path d="M21 4v5h-5" />
+        </svg>
+      </div>
+      <style jsx global>{`
+        @keyframes ptr-spin {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(360deg); }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a pull-to-refresh gesture for the home-screen PWA. iOS Safari has a native pull-to-refresh in browser chrome, but launching the site from the home screen runs it in standalone mode — the gesture is gone, and the rubber-band overscroll just snaps back. This adds a small custom PTR that **only activates in standalone mode**, so regular Safari keeps using its native gesture.

### How it works

- `frontend/components/PullToRefresh.jsx` — fixed-position indicator + window-level touch listeners.
- Detects standalone via `matchMedia("(display-mode: standalone)")` and `navigator.standalone` (iOS).
- Tracks `touchstart` only when `scrollY === 0`, then watches `touchmove`. Below an 8px slop, the browser scrolls normally; past it, we damp the pull (`pow(delta, 0.85)`), call `preventDefault()` to suppress iOS rubber-band, and translate the indicator down.
- On release past the 70px threshold, the indicator locks into a spinning state and `window.location.reload()` fires after a 120ms delay so the user sees the gesture commit.
- Mounted globally in `AppShell` so every page (private + public) picks it up.

### Why a hard reload?

The site has plenty of client-side state (settings, popup, search) that benefits from a clean reload — and that's the gesture users expect from native PTR. Soft re-fetching `useDynastyData` would skip overrides recompute, scoring profile resolution, and any cache invalidation that happens in `_app`'s data hooks. A reload is the predictable, mobile-native behavior.

## Test plan

- [ ] Add the site to iOS home screen and launch it. Pull down on `/rankings`, `/trade`, and `/trades` — indicator should appear, arm at threshold (color shift to amber), and trigger a reload on release.
- [ ] Pull down a short distance and release before threshold — indicator should retract without reloading.
- [ ] Open the same pages in regular mobile Safari (not standalone) — Safari's native PTR should still work, custom indicator should not appear.
- [ ] Scroll partway down a long page (e.g. `/rankings`), then drag — should NOT trigger PTR (only fires when `scrollY === 0`).
- [ ] Desktop Chrome — `display-mode: standalone` is false, the component is a no-op.

## Notes

- No changes to backend or data layer.
- Component is gated behind a one-time effect that sets `enabled` based on display mode, so it adds zero overhead for non-PWA visitors.
- If the user upgrades to a different PTR pattern later (e.g. soft re-fetch via `useDynastyData`), the swap is local to this file.

https://claude.ai/code/session_01STEuGaMG6tAL78ekEyT9B5

---
_Generated by [Claude Code](https://claude.ai/code/session_01STEuGaMG6tAL78ekEyT9B5)_