### PR TITLE
fix(blend): exclude picks from rookie-source ranking + raise Hampel floor

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -3346,6 +3346,19 @@ def _expected_sources_for_position(
         # Exclude veteran-only sources for rookie players.
         if is_rookie and src.get("excludes_rookies"):
             continue
+        # Rookie-translation sources rank the current rookie class
+        # only, so they are never structurally expected to carry pick
+        # rows.  ``dlfRookieSf`` does stamp synthetic ``2026 Pick R.SS``
+        # entries into ``canonicalSiteValues`` for display, but the
+        # Phase 1 ordinal pass deliberately excludes picks (see the
+        # ``needs_rookie_xlate and assetClass == 'pick'`` skip in
+        # ``_compute_unified_rankings``) — picks get their final value
+        # from the Phase 11 anchor pass, not from a per-source rookie
+        # rank.  Keeping these sources out of the expected set here
+        # mirrors that exclusion in the audit so picks don't show up
+        # as "missing dlfRookieSf" in ``unmatchedSources``.
+        if pos_up == "PICK" and src.get("needs_rookie_translation"):
+            continue
         # Exclude shallow-depth sources for players ranked deeper than
         # their cutoff (with a 25% headroom so the rule doesn't
         # over-prune at the boundary).
@@ -5894,6 +5907,14 @@ def _compute_unified_rankings(
         for src in active_sources:
             skey = str(src.get("key") or "")
             if skey in source_ranks:
+                continue
+            # Rookie-translation sources are deliberately excluded from
+            # picks in the Phase 1 ordinal pass (see the matching skip
+            # earlier in this function and ``_expected_sources_for_position``).
+            # Counting them as a soft fallback for picks would inflate
+            # ``softFallbackCount`` with a coverage gap that was
+            # intentional, not a real matching failure.
+            if row_is_pick and src.get("needs_rookie_translation"):
                 continue
             src_scopes: list[str] = [src["scope"]] + list(
                 src.get("extra_scopes") or []

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -157,12 +157,24 @@ _SUSPICIOUS_DISAGREEMENT_THRESHOLD = 150
 # units (the 0–9999 scale on which all per-source contributions live).  Without
 # it, a tight cluster like [4950, 5000, 5025, 5050, 5100] (MAD=25, K·MAD=68.75)
 # would call values ±75 from the median "outliers" — nonsense at this scale.
-# 500 is roughly 5% of the full Hill range; a source value within 500 Hill
-# points of the rest of the field is in genuine consensus, never an outlier
-# regardless of how tight the bulk happens to be.
+#
+# 1000 is roughly 10% of the full Hill range.  The previous 500-point floor
+# (5%) was empirically too tight: with KTC + ktcSfTep + IDPTC + dynastyDaddySf
+# all riding the value-direct path from a shared market, the four typically
+# cluster within 50–150 Hill points on most rows (MAD ≪ 200), pulling the
+# median onto that cluster and making the K·MAD term collapse to the floor.
+# The rank-Hill sources (whose curve produces a ~2000-point spread between
+# adjacent rank decades at the steep top of the Hill) then sit outside the
+# 500-point floor on routine disagreements and get dropped.  The 2026-04-27
+# weekly audit caught this as 18% / 25% / 25% drop rates on dlfSf /
+# dlfRookieSf / flockFantasySfRookies — none of which is a broken source,
+# all of which the prior PR #215/216 regressions (dynastyDaddySf 61%,
+# yahooBoone 47%, fantasyProsFitzmaurice 19%) cleared at the bigger floor.
+# A source within 1000 Hill points of the rest of the field is in genuine
+# consensus regardless of how tight the value-direct bulk happens to be.
 _HAMPEL_K = 2.75
 _HAMPEL_MIN_N = 4
-_HAMPEL_MIN_THRESHOLD = 500.0
+_HAMPEL_MIN_THRESHOLD = 1000.0
 
 _RETIRED_INVALID_PATTERNS = re.compile(
     r"(?i)\b(retired|invalid|test|unknown|placeholder)\b"
@@ -5285,6 +5297,26 @@ def _compute_unified_rankings(
         for idx, row in enumerate(players_array):
             pos = str(row.get("position") or "").strip().upper()
             if pos not in _RANKABLE_POSITIONS:
+                continue
+            # Rookie-only sources (dlfRookieSf) stamp synthetic
+            # ``2026 Pick R.SS`` rows at CSV enrichment time so each
+            # pick slot inherits the matched rookie's value (see the
+            # ``Rookie source → synthetic pick-slot stamps`` block in
+            # ``_enrich_from_source_csvs``).  Including those picks in
+            # this Phase 1 ordinal sort interleaves them with the
+            # rookies they tether to — each (rookie, pick) pair shares
+            # a synthetic value, so dense-skip ranking gives them the
+            # same rawRank.  That doubles every rookie's within-source
+            # rank (rookie at CSV row k ⇒ rawRank 2k-1 instead of k),
+            # which the Phase 1d rookie-ladder translation then maps
+            # to a far deeper combined-pool rank than intended,
+            # collapsing the rookie's Hill contribution and tripping
+            # the per-player Hampel filter (audit caught dlfRookieSf
+            # at 25% drop rate, 2026-04-27).  Picks get their final
+            # value from the Phase 11 pick-anchor pass which reads the
+            # rookie's blended ``rankDerivedValue`` directly, so
+            # excluding them here costs nothing downstream.
+            if needs_rookie_xlate and row.get("assetClass") == "pick":
                 continue
             row_scope: str | None = None
             for s in all_scopes:

--- a/tests/api/test_hampel_filter.py
+++ b/tests/api/test_hampel_filter.py
@@ -34,9 +34,15 @@ class TestSafetyGuards:
         # Sanity: this test exists to make accidental K changes loud.
         assert _HAMPEL_K == 2.75
 
-    def test_min_threshold_floor_is_500(self):
+    def test_min_threshold_floor_is_1000(self):
         # Sanity: this test exists to make accidental floor changes loud.
-        assert _HAMPEL_MIN_THRESHOLD == 500.0
+        # Raised from 500 → 1000 (2026-04-27) after the weekly Hampel
+        # audit caught dlfSf / dlfRookieSf / flockFantasySfRookies at
+        # 18% / 25% / 25% drop rates — symptoms of the floor binding
+        # whenever the value-direct sources (KTC, ktcSfTep, IDPTC,
+        # dynastyDaddySf) cluster within ~150 Hill points and pull the
+        # MAD below 200.
+        assert _HAMPEL_MIN_THRESHOLD == 1000.0
 
     def test_perfect_agreement_drops_nothing(self):
         # All identical → all deviations are zero → nothing exceeds the
@@ -169,13 +175,13 @@ class TestOutlierRejection:
 
 
 class TestAbsoluteThresholdFloor:
-    """The 500-Hill-point floor protects tight clusters from
+    """The 1000-Hill-point floor protects tight clusters from
     over-aggressive filtering when MAD is small relative to scale."""
 
     def test_tight_cluster_no_drops_under_floor(self):
-        # MAD here is 25 → K*MAD = 68.75, well under the 500 floor.
+        # MAD here is 25 → K*MAD = 68.75, well under the 1000 floor.
         # Without the floor, values ±75 from median would be dropped;
-        # with the floor, threshold = 500 so all five are kept.
+        # with the floor, threshold = 1000 so all five are kept.
         pairs = [
             ("a", 5000.0),
             ("b", 5050.0),
@@ -188,28 +194,28 @@ class TestAbsoluteThresholdFloor:
         assert len(kept) == 5
 
     def test_tight_cluster_with_far_outlier_drops_only_outlier(self):
-        # MAD=25 again; floor=500.  A source 600 Hill points from the
+        # MAD=25 again; floor=1000.  A source >1000 Hill points from the
         # median exceeds the floor and is dropped.
         pairs = [
             ("a", 5000.0),
             ("b", 5050.0),
             ("c", 5100.0),
             ("d", 4950.0),
-            ("e", 5700.0),  # 675 from median → dropped (>500 floor)
+            ("e", 6250.0),  # 1200 from median → dropped (>1000 floor)
         ]
         kept, dropped = _hampel_filter_per_player(pairs)
         assert dropped == ["e"]
         assert len(kept) == 4
 
     def test_value_within_floor_distance_kept_even_when_above_kmad(self):
-        # K*MAD = 68.75 ; floor = 500.  A value 400 from median exceeds
+        # K*MAD = 68.75 ; floor = 1000.  A value 800 from median exceeds
         # K*MAD but sits inside the floor → kept (floor wins).
         pairs = [
             ("a", 5000.0),
             ("b", 5050.0),
             ("c", 5100.0),
             ("d", 4950.0),
-            ("e", 5400.0),  # 350 from median (5050) → kept under floor
+            ("e", 5850.0),  # 800 from median (5050) → kept under floor
         ]
         kept, dropped = _hampel_filter_per_player(pairs)
         assert dropped == []


### PR DESCRIPTION
## Summary

The 2026-04-27 weekly Hampel audit (`Audit Hampel Dropped Sources` workflow) failed with three sources over the 15% elevated-source threshold:

| source | rate | dropped / eligible |
|---|---|---|
| `dlfSf` | 19.0% | 52 / 274 |
| `dlfRookieSf` | 25.0% | 30 / 120 |
| `flockFantasySfRookies` | 25.4% | 18 / 71 |

Two narrow fixes here, each addressing a distinct mechanism:

### 1. Exclude picks from Phase 1 ranking for `needs_rookie_translation` sources

`dlfRookieSf` stamps synthetic `2026 Pick R.SS` rows on each pick's `canonicalSiteValues` at CSV enrichment time so each pick slot inherits the matched rookie's value. Including those picks in the within-source dense-skip ordinal pass interleaved them with the rookies they tether to — each (rookie, pick) pair shared a synthetic value, so dense ranking gave them the same rawRank.

That doubled every rookie's within-source rank (rookie at CSV row k → rawRank `2k-1` instead of `k`), which the Phase 1d rookie-ladder translation then mapped to a far deeper combined-pool rank than intended, collapsing the rookie's Hill contribution by ~700-1500 points and tripping the Hampel filter on 25% of rookie rows.

Picks still get their final value from the Phase 11 anchor pass (`_anchor_current_year_picks_to_rookies`), which reads the rookie's blended `rankDerivedValue` directly — excluding them from Phase 1 costs nothing downstream.

### 2. Raise `_HAMPEL_MIN_THRESHOLD` from 500 → 1000

With four value-direct sources (KTC, ktcSfTep, IDPTC, dynastyDaddySf) all riding a shared market, they typically cluster within 50-150 Hill points on most rows, dragging the median onto that cluster and collapsing `K·MAD` to the floor. The rank-Hill sources — whose curve produces ~2000-point spreads between adjacent rank decades at the steep top of the curve — then sit outside the 500-point floor on routine disagreements and get dropped on 18-25% of their rows.

None of those sources is a regression. At 1000 (10% of the Hill range) the floor still catches the regressions PR #215/216 fixed (dynastyDaddySf 61%, yahooBoone 47%, fantasyProsFitzmaurice 19%) — those sources disagreed by thousands of Hill points, not hundreds.

### Post-fix audit

| source | before | after |
|---|---|---|
| `dlfSf` | 18.6% | 7.7% |
| `dlfRookieSf` | 22.8% | 4.9% |
| `flockFantasySfRookies` | 26.7% | 5.3% |
| total rows with drops | 321 (30%) | 140 (13%) |

All sources now land below the 15% threshold; the audit workflow is green.

## Test plan

- [x] `tests/api/test_hampel_filter.py` — 18/18 pass (updated the floor sentinel from 500 → 1000 and the `test_tight_cluster_with_far_outlier` value to exercise the new floor)
- [x] `tests/api/test_pick_rookie_anchor.py` — 15/15 pass (Phase 11 anchoring is unaffected)
- [x] `tests/api/test_source_overrides.py`, `test_source_registry_parity.py` — 60/60 pass
- [x] Full pytest suite (1962 tests excluding e2e + modules with optional deps) — all green
- [x] Re-ran the audit workflow's threshold check locally against the latest snapshot — all sources below 15%

https://claude.ai/code/session_01XjsbhbNFgJQ5JcoG4Mki11

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjsbhbNFgJQ5JcoG4Mki11)_