### PR TITLE
feat(draft): add "Best value on the board" panel

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -2350,6 +2350,156 @@ describe("nominationCandidates — vendor split (offense=KTC, IDP=IDPTC)", () =>
   });
 });
 
+// ── bestValueOnBoard ───────────────────────────────────────────────────
+
+import { bestValueOnBoard } from "@/lib/draft-logic";
+
+describe("bestValueOnBoard", () => {
+  function statsWith(players) {
+    return { enrichedPlayers: players, topCompetitorMax: 100 };
+  }
+
+  it("returns empty when stats is null or missing", () => {
+    expect(bestValueOnBoard(null)).toEqual([]);
+    expect(bestValueOnBoard({})).toEqual([]);
+  });
+
+  it("offense rookie surfaces when KTC underrates vs our board", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50, ktcDollar: 30 },
+      ]),
+    );
+    expect(list.length).toBe(1);
+    expect(list[0].vendorLabel).toBe("KTC");
+    expect(list[0].vendorDollar).toBe(30);
+    expect(list[0].ourDollar).toBe(50);
+    expect(list[0].gap).toBe(20);
+  });
+
+  it("IDP rookie surfaces when IDPTradeCalc underrates vs our board", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "lb-rook", name: "LB Rook", pos: "LB", preDraft: 48, idpTradeCalcDollar: 25 },
+      ]),
+    );
+    expect(list.length).toBe(1);
+    expect(list[0].vendorLabel).toBe("IDPTC");
+    expect(list[0].vendorDollar).toBe(25);
+    expect(list[0].gap).toBe(23);
+  });
+
+  it("excludes drafted players", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50, ktcDollar: 30, drafted: true },
+        { id: "wr-rook2", name: "WR Rook 2", pos: "WR", preDraft: 50, ktcDollar: 30 },
+      ]),
+    );
+    expect(list.length).toBe(1);
+    expect(list[0].player.id).toBe("wr-rook2");
+  });
+
+  it("excludes avoid-tagged players (don't promote players we don't want)", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50, ktcDollar: 30, userTag: "avoid" },
+      ]),
+    );
+    expect(list.length).toBe(0);
+  });
+
+  it("skips when our value is at or below vendor (no edge)", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "even", name: "Even", pos: "WR", preDraft: 30, ktcDollar: 30 },
+        { id: "under", name: "Under", pos: "WR", preDraft: 20, ktcDollar: 30 },
+      ]),
+    );
+    expect(list.length).toBe(0);
+  });
+
+  it("skips when vendor dollar is missing", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50 },
+      ]),
+    );
+    expect(list.length).toBe(0);
+  });
+
+  it("offense rookie with only IDPTradeCalc dollar (no KTC) is skipped", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50, idpTradeCalcDollar: 30 },
+      ]),
+    );
+    expect(list.length).toBe(0);
+  });
+
+  it("ranks by percentage gap, not dollar gap", () => {
+    // Cheap player (50% under) should beat expensive player (25% under)
+    // even though the dollar gap is identical.
+    const list = bestValueOnBoard(
+      statsWith([
+        // $30 board / $20 vendor → 50% under, $10 gap
+        { id: "cheap", name: "Cheap", pos: "WR", preDraft: 30, ktcDollar: 20 },
+        // $50 board / $40 vendor → 25% under, $10 gap
+        { id: "pricey", name: "Pricey", pos: "WR", preDraft: 50, ktcDollar: 40 },
+      ]),
+    );
+    expect(list.map((e) => e.player.id)).toEqual(["cheap", "pricey"]);
+    expect(Math.round(list[0].gapPct * 100)).toBe(50);
+    expect(Math.round(list[1].gapPct * 100)).toBe(25);
+  });
+
+  it("uses assetClass when pos is missing (IDP rookie without a position string)", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        {
+          id: "lb-rook",
+          name: "LB Rook",
+          assetClass: "idp",
+          preDraft: 48,
+          idpTradeCalcDollar: 25,
+        },
+      ]),
+    );
+    expect(list.length).toBe(1);
+    expect(list[0].vendorLabel).toBe("IDPTC");
+  });
+
+  it("rationale references the per-row vendor label", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50, ktcDollar: 30 },
+        { id: "lb-rook", name: "LB Rook", pos: "LB", preDraft: 48, idpTradeCalcDollar: 25 },
+      ]),
+    );
+    const wr = list.find((e) => e.player.name === "WR Rook");
+    const lb = list.find((e) => e.player.name === "LB Rook");
+    expect(wr.rationale).toContain("KTC");
+    expect(lb.rationale).toContain("IDPTC");
+  });
+
+  it("respects the limit parameter", () => {
+    const rookies = Array.from({ length: 12 }, (_, i) => ({
+      id: `rook-${i}`,
+      name: `Rook ${i}`,
+      pos: "WR",
+      assetClass: "offense",
+      preDraft: 30 + i, // Largest edge first.
+      ktcDollar: 10,
+    }));
+    const list = bestValueOnBoard(
+      { enrichedPlayers: rookies },
+      { limit: 5 },
+    );
+    expect(list.length).toBe(5);
+    expect(list[0].player.id).toBe("rook-11");
+  });
+});
+
 // ── computeDraftReview / draftReviewToCsv ──────────────────────────────
 
 describe("computeDraftReview", () => {

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -15,6 +15,7 @@ import {
   TIER_DEFS,
   addPlayer,
   addToTargetBoard,
+  bestValueOnBoard,
   bidStatus,
   clearTargetBoard,
   computeDraftReview,
@@ -1869,6 +1870,105 @@ function NominationCandidates({ stats, onDraft, onCycleTag }) {
               title={`${vendorLabel} overrates by ${Math.round(gapPct * 100)}% (+$${Math.round(gap)}) — leaguemates following ${vendorLabel} will overpay`}
             >
               +{Math.round(gapPct * 100)}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * "Best value on the board" list — mirror of NominationCandidates.
+ * Surfaces undrafted rookies our board values much HIGHER than the
+ * vendor (KTC for offense, IDPTC for IDP).  Sorted by percentage gap
+ * above the vendor price so cheap discounts outrank big-dollar but
+ * proportionally smaller mismatches.
+ */
+function BestValueOnBoard({ stats, onDraft, onCycleTag }) {
+  const list = useMemo(
+    () => bestValueOnBoard(stats, { limit: 10 }),
+    [stats],
+  );
+
+  if (list.length === 0) {
+    return (
+      <div className="card draft-nbt">
+        <h3 style={{ margin: "0 0 4px" }}>Best value on the board</h3>
+        <div className="muted" style={{ fontSize: "0.72rem" }}>
+          No vendor underrates — either every rookie's vendor price and
+          our board agree, or KTC / IDPTradeCalc values are missing
+          from the live contract.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card draft-nbt">
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+        }}
+      >
+        <h3 style={{ margin: 0 }}>Best value on the board</h3>
+        <span className="muted" style={{ fontSize: "0.68rem" }}>
+          Top 10 rookies KTC / IDPTC underrates vs our board (% gap)
+        </span>
+      </div>
+      <div className="draft-nbt-list">
+        {list.map(({ player, gap, gapPct, ourDollar, vendorDollar, vendorLabel, rationale }, i) => (
+          <div
+            key={player.id}
+            className={`draft-nbt-row${player.userTag === TAG_TARGET ? " draft-nbt-target" : ""}`}
+            title={rationale}
+          >
+            <span className="draft-nbt-rank">#{i + 1}</span>
+            <button
+              type="button"
+              className={`draft-tag-chip${
+                player.userTag ? ` draft-tag-${player.userTag}` : ""
+              }`}
+              onClick={() => onCycleTag(player.id)}
+              title="Cycle tag"
+            >
+              {player.userTag === TAG_TARGET
+                ? "★"
+                : player.userTag === TAG_AVOID
+                  ? "⊘"
+                  : "+"}
+            </button>
+            <span
+              className={`draft-tier-chip draft-tier-${player.tier}`}
+              title={`${TIER_LABELS[player.tier] || player.tier} tier`}
+            >
+              {player.tier}
+            </span>
+            <span className="draft-nbt-name" onClick={() => onDraft(player)}>
+              {player.name}
+            </span>
+            <span className="muted" style={{ fontSize: "0.68rem" }} title="Our board's pre-draft fair price">
+              ours {fmt$(ourDollar)}
+            </span>
+            <span
+              className="muted"
+              style={{ fontSize: "0.68rem" }}
+              title={`${vendorLabel}'s market value at the same scale`}
+            >
+              {vendorLabel.toLowerCase()} {fmt$(vendorDollar)}
+            </span>
+            <span
+              className="draft-rec-chip"
+              style={{
+                background: "rgba(74, 222, 128, 0.18)",
+                color: "var(--green, #4ade80)",
+                fontWeight: 600,
+              }}
+              title={`${vendorLabel} underrates by ${Math.round(gapPct * 100)}% (+$${Math.round(gap)} board edge) — leaguemates following ${vendorLabel} will let this clear cheap`}
+            >
+              −{Math.round(gapPct * 100)}%
             </span>
           </div>
         ))}
@@ -3835,6 +3935,11 @@ export default function DraftDashboardPage() {
           workspace={workspace}
         />
         <NominationCandidates
+          stats={stats}
+          onDraft={(p) => setModalPlayer(p)}
+          onCycleTag={onCycleTag}
+        />
+        <BestValueOnBoard
           stats={stats}
           onDraft={(p) => setModalPlayer(p)}
           onCycleTag={onCycleTag}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3974,12 +3974,18 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   font-weight: 600;
 }
 
-/* Sidebar grid holding NextBestTargets + NominationCandidates */
+/* Sidebar grid holding NextBestTargets + NominationCandidates +
+   BestValueOnBoard */
 .draft-sidebar-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 10px;
   margin-bottom: 14px;
+}
+@media (max-width: 1300px) {
+  .draft-sidebar-grid {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 @media (max-width: 980px) {
   .draft-sidebar-grid {

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -1858,6 +1858,77 @@ export function nominationCandidates(stats, { limit = 10 } = {}) {
   return out.slice(0, limit);
 }
 
+// ── Best value still on the board ──────────────────────────────────────
+/**
+ * Mirror of ``nominationCandidates`` flipped 180°.  Surfaces undrafted
+ * rookies our board values much HIGHER than the relevant market vendor
+ * (KTC for offense, IDPTradeCalc for IDP), ranked by *percentage* gap
+ * above the vendor price.  These are the best buys still available —
+ * if a leaguemate following the vendor walks the bidding to the
+ * vendor's number, we still come out ahead at our board's price.
+ *
+ * Vendor split mirrors ``nominationCandidates``:
+ *   - Offense rookies (QB/RB/WR/TE) → KTC reference price.
+ *   - IDP rookies (DL/LB/DB/etc.)   → IDP Trade Calculator.
+ *
+ * Selection:
+ *   1. Not yet drafted
+ *   2. Not avoid-tagged (we don't want them anyway)
+ *   3. Has both a board ``preDraft`` AND the relevant vendor dollar
+ *   4. ``preDraft > vendorDollar`` (we value them higher than vendor)
+ *
+ * Sort: ``(preDraft - vendorDollar) / vendorDollar`` descending — i.e.
+ * percentage gap above the vendor's price.  Mirrors the percentage
+ * normalization used by ``nominationCandidates`` so a 50% discount on
+ * a $20 vendor price (=$10 board edge) outranks a 25% discount on a
+ * $40 vendor price (=$10 board edge).
+ *
+ * Excludes drafted players and avoid-tags.  Returns top ``limit``
+ * candidates sorted descending by percentage gap.
+ */
+export function bestValueOnBoard(stats, { limit = 10 } = {}) {
+  if (!stats || !Array.isArray(stats.enrichedPlayers)) return [];
+
+  const out = [];
+  for (const p of stats.enrichedPlayers) {
+    if (p.drafted) continue;
+    if (p.userTag === TAG_AVOID) continue;
+    const ourDollar = Math.max(0, p.preDraft || 0);
+    if (ourDollar <= 0) continue;
+    const isIdp =
+      p.assetClass === "idp"
+      || (p.assetClass !== "offense" && classifyPos(p.pos) === "idp");
+    const vendorKey = isIdp ? "idpTradeCalcDollar" : "ktcDollar";
+    const vendorLabel = isIdp ? "IDPTC" : "KTC";
+    const vendorDollar = Math.max(0, Number(p[vendorKey]) || 0);
+    if (vendorDollar <= 0) continue;
+    const gap = ourDollar - vendorDollar;
+    if (gap < 1) continue;  // we must value them at least $1 above
+    const gapPct = gap / vendorDollar;  // 0.5 → "50% under market"
+    out.push({
+      player: p,
+      score: gapPct,
+      gap,
+      gapPct,
+      ourDollar,
+      vendorDollar,
+      vendorKey,
+      vendorLabel,
+      ktcDollar: isIdp ? null : vendorDollar,
+      idpTradeCalcDollar: isIdp ? vendorDollar : null,
+      expectedPrice: vendorDollar,
+      rationale:
+        `Our board $${Math.round(ourDollar)} vs ${vendorLabel} ` +
+        `$${Math.round(vendorDollar)} · ${Math.round(gapPct * 100)}% under ` +
+        `(${gap >= 0 ? "+" : ""}$${Math.round(gap)}) — leaguemates ` +
+        `following ${vendorLabel} should let this clear at a discount`,
+    });
+  }
+
+  out.sort((a, b) => b.gapPct - a.gapPct);
+  return out.slice(0, limit);
+}
+
 // ── Inflation history series ───────────────────────────────────────────
 /**
  * Re-simulate the draft pick-by-pick to produce a time series of


### PR DESCRIPTION
## Summary

Adds a "Best value on the board" sidebar panel to `/draft` — the mirror of the existing **Good to Nominate** panel.

Where Good to Nominate surfaces undrafted rookies the **vendor overrates** vs our board (so leaguemates following KTC / IDPTC will overpay), this new panel surfaces undrafted rookies the **vendor underrates** vs our board (so leaguemates following KTC / IDPTC will let them clear cheap). These are the best buys still available.

Same vendor split:
- Offense (QB/RB/WR/TE) → KTC
- IDP (DL/LB/DB/etc.) → IDP Trade Calculator

## Mechanics

- New `bestValueOnBoard(stats, { limit })` helper in `frontend/lib/draft-logic.js`.
- Filter: `preDraft > vendorDollar` (and not drafted, not avoid-tagged, both prices present).
- Sort: `(preDraft - vendorDollar) / vendorDollar` descending — percentage gap above the vendor price.
- Sorting by % (rather than $) keeps cheap discounts visible against larger raw-dollar but proportionally smaller mismatches, exactly mirroring the percentage normalization used by `nominationCandidates`.

## UI

- New `BestValueOnBoard` React component in `frontend/app/draft/page.jsx`, structurally identical to `NominationCandidates` but with a green chip showing `−N%` (under-market discount) instead of cyan `+N%`.
- Sidebar grid expanded to 3 columns >1300px; falls back to 2 cols >980px and 1 col below — the existing breakpoints are preserved.

## Tests

- 11 new unit tests in `frontend/__tests__/draft-logic.test.js` covering: empty stats, offense/IDP routing, drafted/avoid exclusions, missing-vendor-dollar skip, % vs $ sort order, `assetClass` override, rationale labels, and the limit param.
- `npx vitest run __tests__/draft-logic.test.js` → 196 / 196 pass.

## Test plan

- [ ] Open `/draft` and confirm the new panel renders alongside Next Best Targets and Good to Nominate.
- [ ] Verify the top entry has the largest `preDraft − vendor$ / vendor$` percentage among undrafted rookies.
- [ ] Confirm at narrow widths the sidebar collapses to 2 / 1 columns as expected.
- [ ] Drafting a player removes them from the list; avoid-tagging a player removes them.

https://claude.ai/code/session_01DZK7aKdsWbtHLMPMiLt9an

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZK7aKdsWbtHLMPMiLt9an)_