### PR TITLE
fix(draft-capital): overlay Sleeper traded_picks so dollars-per-team update on every trade

### DIFF
--- a/server.py
+++ b/server.py
@@ -4524,6 +4524,11 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         return {"error": "Draft data workbook not found or empty"}
 
     current_year = datetime.now(timezone.utc).year
+    # Default to calendar year; overwritten with the actual draft
+    # season once the Sleeper drafts response is read (below).  This
+    # distinction matters around Dec→Jan when the league is still on
+    # the prior season's rookie draft.
+    league_season = current_year
     num_teams = len(slot_to_original) or 12
     draft_rounds = max(1, len(workbook_picks) // num_teams)
     raw_values = [wp["value"] for wp in workbook_picks]
@@ -4588,14 +4593,29 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         drafts_resp = urllib.request.urlopen(
             f"https://api.sleeper.app/v1/league/{_league_id_for_draft}/drafts", timeout=15
         )
+        # Resolve league season from the Sleeper drafts response — the
+        # source of truth — rather than the server's calendar year.
+        # Around December → January the calendar year ticks over while
+        # the league is still on the prior season's draft, and a naive
+        # `season != now().year` filter would silently skip every
+        # traded pick (and slot mapping) for that window.
+        all_drafts = [d for d in json.loads(drafts_resp.read()) if isinstance(d, dict)]
+        draft_seasons: list[int] = []
+        for d in all_drafts:
+            try:
+                draft_seasons.append(int(d.get("season")))
+            except (TypeError, ValueError):
+                continue
+        if draft_seasons:
+            league_season = max(draft_seasons)
         slot_to_roster: dict[int, int] = {}
-        for draft in json.loads(drafts_resp.read()):
+        for draft in all_drafts:
             try:
                 season = int(draft.get("season"))
             except (TypeError, ValueError):
                 continue
             draft_id = draft.get("draft_id")
-            if season != current_year or not draft_id:
+            if season != league_season or not draft_id:
                 continue
             try:
                 detail_resp = urllib.request.urlopen(
@@ -4665,7 +4685,7 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
                         new_rid = int(t.get("owner_id"))
                     except (TypeError, ValueError):
                         continue
-                    if season != current_year:
+                    if season != league_season:
                         continue
                     original_slot = roster_id_to_slot.get(original_rid)
                     new_first = roster_id_to_first_name.get(new_rid)
@@ -4766,7 +4786,7 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         "totalBudget": total_budget,
         "numTeams": num_teams,
         "draftRounds": draft_rounds,
-        "season": current_year,
+        "season": league_season,
         "ktcSource": ktc_source,
         "ktcRookieCount": ktc_count,
         "ktcTotalFilled": len(rookies),

--- a/server.py
+++ b/server.py
@@ -4501,24 +4501,23 @@ def _round_to_budget(values: list[float], budget: int = 1200) -> list[int]:
     return floors
 
 
-def _fetch_draft_capital(league_key: str | None = None):
+def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades: bool = True):
     """Compute draft capital per team.
 
-    The Draft Data workbook is the authoritative source for BOTH pick
-    values AND pick ownership:
+    The Draft Data workbook is the authoritative source for pick
+    VALUES (Q45:Q116) and the slot→original-owner standings
+    (O30:R42).  Pick OWNERSHIP is overlaid live from Sleeper's
+    ``/traded_picks`` endpoint when ``apply_sleeper_trades=True``
+    (default), so trades made on Sleeper between scheduled
+    refreshes are reflected immediately in per-team dollar totals.
 
-        Q45:Q116 — per-pick dollar values (decimal, sum = 1200)
-        R45:R116 — per-pick current owner (first name)
-        O30:R42  — standings: slot → original owner (first name)
-
-    Sleeper is used only to resolve the sheet's first-name owners into
-    display team names (``user.metadata.team_name`` / ``display_name``)
-    by joining the sheet's standings on Sleeper's draft
-    ``slot_to_roster_id``.  If Sleeper is unavailable we fall back to
-    showing first names directly.
+    If the Sleeper join fails or no trades are reported, the
+    workbook's R45:R116 ownership column is used verbatim.
 
     ``league_key`` selects which league's Sleeper IDs to use for the
     team-name join.  None resolves to the registry default.
+    ``apply_sleeper_trades=False`` preserves the legacy workbook-
+    only behavior (used by tests that assert sheet-derived totals).
     """
     pick_dollars, workbook_picks, slot_to_original, wb_team_totals, rookies = _parse_draft_data()
     if not workbook_picks:
@@ -4548,6 +4547,9 @@ def _fetch_draft_capital(league_key: str | None = None):
     # Sleeper's draft slot_to_roster_id (slot → roster id → team name).
     first_name_to_team: dict[str, str] = {}
     all_team_names: list[str] = []
+    # (round, slot) → new-owner first name from Sleeper traded_picks.
+    # Empty when Sleeper is unreachable or apply_sleeper_trades=False.
+    sleeper_trade_overrides: dict[tuple[int, int], str] = {}
     try:
         _league_id_for_draft = _sleeper_league_id_for_draft(league_key)
         if not _league_id_for_draft:
@@ -4628,6 +4630,49 @@ def _fetch_draft_capital(league_key: str | None = None):
             if rid is not None and first_name:
                 first_name_to_team[str(first_name).strip()] = roster_name_by_id[rid]
 
+        # roster_id → slot (inverse of slot_to_roster) and
+        # roster_id → original-owner first name.  Both bridges are
+        # needed to translate Sleeper traded_picks (keyed by
+        # roster_id) into the workbook's (round, slot, first-name)
+        # space.
+        roster_id_to_slot: dict[int, int] = {
+            int(rid): int(slot) for slot, rid in slot_to_roster.items()
+        }
+        roster_id_to_first_name: dict[int, str] = {}
+        for slot, first_name in slot_to_original.items():
+            rid = slot_to_roster.get(int(slot))
+            if rid is not None and first_name:
+                roster_id_to_first_name[int(rid)] = str(first_name).strip()
+
+        if apply_sleeper_trades:
+            try:
+                traded_resp = urllib.request.urlopen(
+                    f"https://api.sleeper.app/v1/league/{_league_id_for_draft}/traded_picks",
+                    timeout=15,
+                )
+                traded = json.loads(traded_resp.read())
+            except Exception as exc:  # noqa: BLE001
+                logging.warning(f"Sleeper traded_picks fetch failed: {exc}")
+                traded = []
+            if isinstance(traded, list):
+                for t in traded:
+                    if not isinstance(t, dict):
+                        continue
+                    try:
+                        season = int(t.get("season"))
+                        round_n = int(t.get("round"))
+                        original_rid = int(t.get("roster_id"))
+                        new_rid = int(t.get("owner_id"))
+                    except (TypeError, ValueError):
+                        continue
+                    if season != current_year:
+                        continue
+                    original_slot = roster_id_to_slot.get(original_rid)
+                    new_first = roster_id_to_first_name.get(new_rid)
+                    if original_slot is None or not new_first:
+                        continue
+                    sleeper_trade_overrides[(round_n, original_slot)] = new_first
+
     except Exception as e:
         logging.warning(f"Sleeper API failed for draft capital team-name mapping: {e}")
 
@@ -4655,6 +4700,12 @@ def _fetch_draft_capital(league_key: str | None = None):
         val = wp["value"]
         owner_first = wp["owner"]
         origin_first = slot_to_original.get(slot, owner_first)
+        # Sleeper traded_picks wins over the workbook's R45:R116
+        # column when both are available — Sleeper is the system of
+        # record for trades, the workbook is hand-edited and lags.
+        sleeper_owner = sleeper_trade_overrides.get((rnd, slot))
+        if sleeper_owner:
+            owner_first = sleeper_owner
 
         owner_team = display(owner_first)
         origin_team = display(origin_first)

--- a/server.py
+++ b/server.py
@@ -4562,6 +4562,26 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
             # leave the mapping empty; downstream code renders draft
             # capital without a team-name column.
             raise RuntimeError("no_sleeper_league_configured")
+        # League metadata first — its ``season`` is the canonical
+        # anchor for the active-pick-season window.  Filtering trades
+        # by /drafts alone breaks during the offseason gap when the
+        # league has rolled over but Sleeper hasn't yet created the
+        # new season's draft object: in that window /drafts returns
+        # only the prior season, while /league/{id}.season already
+        # reports the active one and /traded_picks contains the
+        # active-season trades that need to apply to the workbook.
+        try:
+            league_resp = urllib.request.urlopen(
+                f"https://api.sleeper.app/v1/league/{_league_id_for_draft}", timeout=15
+            )
+            league_meta = json.loads(league_resp.read())
+            league_meta_season = int(league_meta.get("season"))
+        except Exception as exc:  # noqa: BLE001
+            logging.warning(f"Sleeper league-meta fetch failed: {exc}")
+            league_meta_season = None
+        if league_meta_season:
+            league_season = league_meta_season
+
         rosters_resp = urllib.request.urlopen(
             f"https://api.sleeper.app/v1/league/{_league_id_for_draft}/rosters", timeout=15
         )
@@ -4593,12 +4613,12 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         drafts_resp = urllib.request.urlopen(
             f"https://api.sleeper.app/v1/league/{_league_id_for_draft}/drafts", timeout=15
         )
-        # Resolve league season from the Sleeper drafts response — the
-        # source of truth — rather than the server's calendar year.
-        # Around December → January the calendar year ticks over while
-        # the league is still on the prior season's draft, and a naive
-        # `season != now().year` filter would silently skip every
-        # traded pick (and slot mapping) for that window.
+        # /league/{id}.season is the primary anchor for the active
+        # season; /drafts.season is only consulted as a fallback when
+        # the league-meta call failed.  This pair handles both
+        # boundary cases: the Dec→Jan calendar-year flip AND the
+        # offseason window where the league has rolled over but its
+        # new draft object hasn't been created yet.
         all_drafts = [d for d in json.loads(drafts_resp.read()) if isinstance(d, dict)]
         draft_seasons: list[int] = []
         for d in all_drafts:
@@ -4606,8 +4626,16 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
                 draft_seasons.append(int(d.get("season")))
             except (TypeError, ValueError):
                 continue
-        if draft_seasons:
+        if not league_meta_season and draft_seasons:
             league_season = max(draft_seasons)
+        # Prefer the active-season draft for slot-to-roster mapping;
+        # fall back to the most recent prior-season draft when the
+        # active-season draft hasn't been created yet (offseason
+        # rollover gap).  Dynasty slot orders are stable enough
+        # across the gap that the prior mapping is a safe stand-in.
+        slot_mapping_season = league_season if league_season in draft_seasons else (
+            max(draft_seasons) if draft_seasons else league_season
+        )
         slot_to_roster: dict[int, int] = {}
         for draft in all_drafts:
             try:
@@ -4615,7 +4643,7 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
             except (TypeError, ValueError):
                 continue
             draft_id = draft.get("draft_id")
-            if season != league_season or not draft_id:
+            if season != slot_mapping_season or not draft_id:
                 continue
             try:
                 detail_resp = urllib.request.urlopen(

--- a/server.py
+++ b/server.py
@@ -4628,14 +4628,17 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
                 continue
         if not league_meta_season and draft_seasons:
             league_season = max(draft_seasons)
-        # Prefer the active-season draft for slot-to-roster mapping;
-        # fall back to the most recent prior-season draft when the
-        # active-season draft hasn't been created yet (offseason
-        # rollover gap).  Dynasty slot orders are stable enough
-        # across the gap that the prior mapping is a safe stand-in.
-        slot_mapping_season = league_season if league_season in draft_seasons else (
-            max(draft_seasons) if draft_seasons else league_season
-        )
+        # The slot-to-roster map MUST come from the active-season
+        # draft.  Falling back to a prior-season draft is unsafe
+        # because rookie draft slots are reverse-standings of the
+        # PRIOR season (so slot order shifts year to year), and a
+        # cross-year mapping would mis-route traded picks to the
+        # wrong workbook slot and shift dollars to the wrong team.
+        # When the active-season draft hasn't been created yet
+        # (offseason rollover gap), we leave slot_to_roster empty
+        # and let the overlay degrade to workbook ownership — the
+        # workbook is freshly hand-maintained for the new season
+        # in that window, so dollars are still defensible.
         slot_to_roster: dict[int, int] = {}
         for draft in all_drafts:
             try:
@@ -4643,7 +4646,7 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
             except (TypeError, ValueError):
                 continue
             draft_id = draft.get("draft_id")
-            if season != slot_mapping_season or not draft_id:
+            if season != league_season or not draft_id:
                 continue
             try:
                 detail_resp = urllib.request.urlopen(

--- a/server.py
+++ b/server.py
@@ -4737,8 +4737,15 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
 
     # Seed every known team at $0 so teams that own no picks still
     # show up in the output (the /draft dashboard relies on this to
-    # render the full 12-team roster).
-    if all_team_names:
+    # render the full 12-team roster).  We pre-seed with Sleeper
+    # team names ONLY when the first-name → team-name bridge is
+    # populated — otherwise ``display()`` will fall back to raw
+    # first names for the picks below, and pre-seeding Sleeper
+    # names would produce duplicate logical rows (e.g. "Russini
+    # Panini" $0 + "Jason" $XX).  In the rollover gap where the
+    # bridge is empty, seed from workbook first names instead so
+    # the seeded keys match the picks-loop keys.
+    if all_team_names and first_name_to_team:
         for t in all_team_names:
             team_totals_decimal.setdefault(t, 0.0)
     else:

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -180,23 +180,20 @@ class TestSleeperTradeOverlay(unittest.TestCase):
             raise AssertionError(f"unexpected urlopen({target})")
         return fake_urlopen
 
-    def test_traded_pick_moves_dollars_between_teams(self):
-        """When Sleeper reports the (current_year, round=1, slot=5) pick
-        was traded from its original owner to another roster, the
-        receiving team's dollar total must increase by the pick's value
-        and the original owner's must decrease by the same amount —
-        independent of whatever R45:R116 says."""
-        import server
-        from datetime import datetime, timezone
+    def _build_overlay_fixture(self, draft_season):
+        """Construct mocked Sleeper responses for a single traded pick.
 
+        Returns ``(url_map, wp, orig_first, other_first)`` where ``wp``
+        is the workbook pick chosen for the trade and the two first
+        names identify the original / receiving team buckets.
+
+        ``draft_season`` is what Sleeper reports as the league/draft
+        season — may differ from the server's calendar year (Dec→Jan
+        boundary regression)."""
         _, workbook_picks, slot_to_original, _, _ = _load()
         if not workbook_picks or not slot_to_original:
-            self.skipTest("Workbook unavailable")
+            return None
 
-        # Pick a (round, slot) that exists, has a non-zero value, and
-        # whose original-owner first name differs from at least one
-        # other slot's first name (so the trade actually moves dollars
-        # between distinct first-name buckets).
         target = None
         for wp in workbook_picks:
             if wp["value"] <= 0:
@@ -211,17 +208,11 @@ class TestSleeperTradeOverlay(unittest.TestCase):
                 target = (wp, orig, other)
                 break
         if target is None:
-            self.skipTest("No suitable workbook pick for overlay test")
+            return None
         wp, orig_first, other_first = target
 
-        # Build a Sleeper response set that reports the pick was
-        # traded from orig_first's roster to other_first's roster.
-        # Roster IDs are arbitrary; we map them via a fake
-        # slot_to_roster_id so the server resolves them back to
-        # first names through the standings.
-        rosters = []
-        users = []
-        slot_to_roster = {}
+        rosters, users = [], []
+        slot_to_roster: dict[str, int] = {}
         roster_id_for_first: dict[str, int] = {}
         for slot, first_name in slot_to_original.items():
             rid = int(slot)
@@ -235,54 +226,71 @@ class TestSleeperTradeOverlay(unittest.TestCase):
             slot_to_roster[str(slot)] = rid
             roster_id_for_first[first_name] = rid
 
-        current_year = datetime.now(timezone.utc).year
-        drafts = [{"draft_id": "D1", "season": current_year}]
+        drafts = [{"draft_id": "D1", "season": draft_season}]
         draft_detail = {"slot_to_roster_id": slot_to_roster}
         traded_picks = [{
-            "season": current_year,
+            "season": draft_season,
             "round": wp["round"],
             "roster_id": roster_id_for_first[orig_first],
             "owner_id": roster_id_for_first[other_first],
             "previous_owner_id": roster_id_for_first[orig_first],
         }]
-
         url_map = {
             "/rosters": rosters,
             "/users": users,
-            "/league/" : None,  # placeholder; specific paths below win
             "/drafts": drafts,
             "/draft/D1": draft_detail,
             "/traded_picks": traded_picks,
         }
-        # Drop the placeholder so unmatched URLs don't accidentally hit it.
-        del url_map["/league/"]
+        return url_map, wp, orig_first, other_first
 
+    def _run_overlay(self, draft_season):
+        """Drive ``_fetch_draft_capital`` with mocked Sleeper responses
+        for ``draft_season``.  Returns (with_overlay_result,
+        without_overlay_result, wp, orig_first, other_first) or None
+        if the workbook is unavailable."""
+        import server
+        fixture = self._build_overlay_fixture(draft_season)
+        if fixture is None:
+            return None
+        url_map, wp, orig_first, other_first = fixture
         with patch.object(server.urllib.request, "urlopen",
                           self._stub_urlopen(url_map)), \
              patch.object(server, "_sleeper_league_id_for_draft",
                           return_value="TEST_LEAGUE"):
             with_overlay = server._fetch_draft_capital(apply_sleeper_trades=True)
             without_overlay = server._fetch_draft_capital(apply_sleeper_trades=False)
-
         if "error" in with_overlay or "error" in without_overlay:
-            self.skipTest("Workbook returned error")
+            return None
+        return with_overlay, without_overlay, wp, orig_first, other_first
 
-        def total_for(result, team_first):
-            label = f"Team-{team_first}"
-            for row in result["teamTotals"]:
-                if row["team"] == label:
-                    return row["auctionDollars"]
-            return 0
+    @staticmethod
+    def _team_total(result, team_first):
+        label = f"Team-{team_first}"
+        for row in result["teamTotals"]:
+            if row["team"] == label:
+                return row["auctionDollars"]
+        return 0
 
-        # The receiving team must have strictly more dollars with the
-        # overlay applied; the original owner must have strictly less.
-        delta_recv = total_for(with_overlay, other_first) - total_for(without_overlay, other_first)
-        delta_orig = total_for(with_overlay, orig_first) - total_for(without_overlay, orig_first)
+    def test_traded_pick_moves_dollars_between_teams(self):
+        """When Sleeper reports a pick was traded, the receiving team's
+        dollar total must increase and the original owner's must
+        decrease — independent of whatever R45:R116 says."""
+        from datetime import datetime, timezone
+        run = self._run_overlay(datetime.now(timezone.utc).year)
+        if run is None:
+            self.skipTest("Workbook unavailable")
+        with_overlay, without_overlay, wp, orig_first, other_first = run
+
+        delta_recv = (self._team_total(with_overlay, other_first)
+                      - self._team_total(without_overlay, other_first))
+        delta_orig = (self._team_total(with_overlay, orig_first)
+                      - self._team_total(without_overlay, orig_first))
         self.assertGreater(delta_recv, 0,
                            f"Receiving team did not gain dollars: {delta_recv}")
         self.assertLess(delta_orig, 0,
                         f"Original owner did not lose dollars: {delta_orig}")
-        # And the overlaid pick must report the new currentOwner.
+
         traded_pick_label = f"{wp['round']}.{str(wp['pick']).zfill(2)}"
         overlay_pick = next(
             (p for p in with_overlay["picks"] if p["pick"] == traded_pick_label),
@@ -291,6 +299,31 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         self.assertIsNotNone(overlay_pick)
         self.assertEqual(overlay_pick["currentOwner"], f"Team-{other_first}")
         self.assertTrue(overlay_pick["isTraded"])
+
+    def test_overlay_uses_sleeper_draft_season_not_calendar_year(self):
+        """Regression for the Dec→Jan boundary: when Sleeper reports
+        the league/draft season as a year that differs from the
+        server's calendar year, the overlay must still apply and the
+        response must stamp ``season`` from Sleeper, not ``now().year``.
+        Pre-fix, this filter (``season != current_year``) silently
+        dropped every traded pick in that window."""
+        from datetime import datetime, timezone
+        wall_year = datetime.now(timezone.utc).year
+        # Simulate the boundary: Sleeper reports next year's draft.
+        sleeper_season = wall_year + 1
+        run = self._run_overlay(sleeper_season)
+        if run is None:
+            self.skipTest("Workbook unavailable")
+        with_overlay, without_overlay, wp, orig_first, other_first = run
+
+        # The overlay must still flip the dollar totals, even though
+        # the draft season differs from datetime.now().year.
+        delta_recv = (self._team_total(with_overlay, other_first)
+                      - self._team_total(without_overlay, other_first))
+        self.assertGreater(delta_recv, 0,
+                           "Trade overlay regressed under sleeper_season != calendar_year")
+        # And the response must report the actual draft season.
+        self.assertEqual(with_overlay["season"], sleeper_season)
 
 
 if __name__ == "__main__":

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -354,15 +354,24 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         self.assertEqual(overlay_pick["currentOwner"], f"Team-{other_first}")
         self.assertTrue(overlay_pick["isTraded"])
 
-    def test_overlay_anchors_on_league_meta_when_drafts_lags(self):
+    def test_overlay_degrades_safely_when_active_season_draft_missing(self):
         """Pre-rollover offseason regression (Codex P1): a dynasty
         league has rolled to season N+1 (so ``/league/{id}.season``
-        reports N+1 and Sleeper has trades for N+1 picks) but the
-        N+1 draft hasn't been created yet, so ``/drafts`` only
-        returns season N.  The overlay must anchor on
-        ``/league/{id}.season`` (N+1) — using ``max(drafts.season)``
-        would skip every N+1 trade and revert to the stale workbook
-        owner."""
+        reports N+1) but the N+1 draft hasn't been created yet, so
+        ``/drafts`` only has season N.  The overlay must NOT fall
+        back to N's slot mapping — rookie slot order is reverse-
+        standings of the PRIOR season, so it shifts year to year and
+        a cross-year mapping would mis-route trades and shift dollars
+        to the wrong teams.
+
+        Required behavior in this gap:
+          1. Response ``season`` is anchored on ``/league/{id}.season``
+             (proves league-meta — not max(drafts) — drives it).
+          2. Per-team dollar totals are identical with and without the
+             overlay (proves no unsafe cross-year mapping is applied;
+             we degrade to workbook ownership, which is freshly
+             hand-maintained for N+1 in this window).
+        """
         from datetime import datetime, timezone
         active = datetime.now(timezone.utc).year + 1   # active pick season
         prior = active - 1                              # last completed draft
@@ -374,13 +383,21 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         )
         if run is None:
             self.skipTest("Workbook unavailable")
-        with_overlay, without_overlay, _wp, orig_first, other_first = run
-        delta_recv = (self._team_total(with_overlay, other_first)
-                      - self._team_total(without_overlay, other_first))
-        self.assertGreater(delta_recv, 0,
-                           "Overlay regressed when /drafts season lags league meta season")
+        with_overlay, without_overlay, _wp, _orig_first, _other_first = run
+        # League meta drives the response season, not max(drafts).
         self.assertEqual(with_overlay["season"], active,
                          "Response season must follow league meta, not drafts max")
+        # Overlay must not apply incorrectly: per-team totals must be
+        # bit-identical between with/without when the active-season
+        # slot map is unavailable.
+        with_totals = sorted(
+            (t["team"], t["auctionDollars"]) for t in with_overlay["teamTotals"]
+        )
+        without_totals = sorted(
+            (t["team"], t["auctionDollars"]) for t in without_overlay["teamTotals"]
+        )
+        self.assertEqual(with_totals, without_totals,
+                         "Overlay shifted dollars using a cross-year slot map")
 
     def test_overlay_uses_sleeper_draft_season_not_calendar_year(self):
         """Regression for the Dec→Jan boundary: when Sleeper reports

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -167,29 +167,58 @@ class TestSleeperTradeOverlay(unittest.TestCase):
     """
 
     def _stub_urlopen(self, url_to_payload):
-        """Build a urllib.request.urlopen stub from a {url-substring: payload}
-        map.  Each payload is a dict/list that gets JSON-encoded."""
+        """Build a urllib.request.urlopen stub.  ``url_to_payload`` is
+        a {key: payload} dict where ``key`` is either a URL substring
+        match or the special sentinel ``"__LEAGUE_META__"`` for the
+        bare ``/v1/league/{id}`` endpoint (matched by checking the
+        path ends in the league id with no trailing resource).
+        """
         import io
         import json as _json
 
+        meta_payload = url_to_payload.get("__LEAGUE_META__")
+        substring_map = {k: v for k, v in url_to_payload.items()
+                         if k != "__LEAGUE_META__"}
+
         def fake_urlopen(url, *args, **kwargs):
             target = url.full_url if hasattr(url, "full_url") else str(url)
-            for key, payload in url_to_payload.items():
+            # League meta = "/v1/league/{id}" with no trailing path
+            # segment.  A normal "/v1/league/{id}/rosters" URL has at
+            # least one trailing segment, which is how we distinguish.
+            tail = target.split("/v1/league/", 1)[-1] if "/v1/league/" in target else ""
+            if meta_payload is not None and "/v1/league/" in target and "/" not in tail:
+                return io.BytesIO(_json.dumps(meta_payload).encode())
+            for key, payload in substring_map.items():
                 if key in target:
                     return io.BytesIO(_json.dumps(payload).encode())
             raise AssertionError(f"unexpected urlopen({target})")
         return fake_urlopen
 
-    def _build_overlay_fixture(self, draft_season):
+    def _build_overlay_fixture(self, draft_season, *,
+                               league_meta_season=None,
+                               drafts_seasons=None,
+                               traded_pick_season=None):
         """Construct mocked Sleeper responses for a single traded pick.
 
         Returns ``(url_map, wp, orig_first, other_first)`` where ``wp``
         is the workbook pick chosen for the trade and the two first
         names identify the original / receiving team buckets.
 
-        ``draft_season`` is what Sleeper reports as the league/draft
-        season — may differ from the server's calendar year (Dec→Jan
-        boundary regression)."""
+        ``draft_season`` — convenience default used for league meta,
+            drafts, and traded_picks when the more specific kwargs
+            are not provided.
+        ``league_meta_season`` — what ``/v1/league/{id}.season``
+            reports.  Defaults to ``draft_season``.  Pass an
+            explicit value (or ``False`` to drop the field) to
+            simulate the league meta endpoint returning a different
+            season than ``/drafts``.
+        ``drafts_seasons`` — list of seasons returned by
+            ``/v1/league/{id}/drafts``.  Defaults to
+            ``[draft_season]``.  Use ``[older_season]`` to simulate
+            the pre-rollover offseason window.
+        ``traded_pick_season`` — season stamped on the traded-pick
+            entry.  Defaults to ``draft_season``.
+        """
         _, workbook_picks, slot_to_original, _, _ = _load()
         if not workbook_picks or not slot_to_original:
             return None
@@ -226,31 +255,56 @@ class TestSleeperTradeOverlay(unittest.TestCase):
             slot_to_roster[str(slot)] = rid
             roster_id_for_first[first_name] = rid
 
-        drafts = [{"draft_id": "D1", "season": draft_season}]
+        if drafts_seasons is None:
+            drafts_seasons = [draft_season]
+        if traded_pick_season is None:
+            traded_pick_season = draft_season
+        if league_meta_season is None:
+            league_meta_season = draft_season
+
+        drafts = [
+            {"draft_id": f"D{i}", "season": s}
+            for i, s in enumerate(drafts_seasons, start=1)
+        ]
         draft_detail = {"slot_to_roster_id": slot_to_roster}
         traded_picks = [{
-            "season": draft_season,
+            "season": traded_pick_season,
             "round": wp["round"],
             "roster_id": roster_id_for_first[orig_first],
             "owner_id": roster_id_for_first[other_first],
             "previous_owner_id": roster_id_for_first[orig_first],
         }]
-        url_map = {
+        url_map: dict[str, object] = {
             "/rosters": rosters,
             "/users": users,
             "/drafts": drafts,
-            "/draft/D1": draft_detail,
             "/traded_picks": traded_picks,
         }
+        # League-meta endpoint (``/v1/league/{id}`` with no trailing
+        # path).  ``league_meta_season=False`` simulates the field
+        # being missing so the drafts-based fallback gets exercised.
+        league_meta_payload: dict[str, object] = {}
+        if league_meta_season is not False and league_meta_season is not None:
+            league_meta_payload["season"] = str(league_meta_season)
+        # Match the bare /league/{id} URL via a longer substring than
+        # the per-resource endpoints to avoid false positives.  Stub
+        # comparison happens left-to-right in dict-insertion order,
+        # so put the more-specific paths first.
+        for did in [d["draft_id"] for d in drafts]:
+            url_map[f"/draft/{did}"] = draft_detail
+        url_map["__LEAGUE_META__"] = league_meta_payload
         return url_map, wp, orig_first, other_first
 
-    def _run_overlay(self, draft_season):
+    def _run_overlay(self, draft_season, **fixture_kwargs):
         """Drive ``_fetch_draft_capital`` with mocked Sleeper responses
-        for ``draft_season``.  Returns (with_overlay_result,
-        without_overlay_result, wp, orig_first, other_first) or None
-        if the workbook is unavailable."""
+        for ``draft_season``.  Extra kwargs are forwarded to
+        ``_build_overlay_fixture`` (e.g. ``league_meta_season``,
+        ``drafts_seasons``, ``traded_pick_season``).  Returns
+        (with_overlay_result, without_overlay_result, wp,
+        orig_first, other_first) or None if the workbook is
+        unavailable."""
         import server
-        fixture = self._build_overlay_fixture(draft_season)
+        fixture = self._build_overlay_fixture(draft_season, **fixture_kwargs)
         if fixture is None:
             return None
         url_map, wp, orig_first, other_first = fixture
@@ -299,6 +353,34 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         self.assertIsNotNone(overlay_pick)
         self.assertEqual(overlay_pick["currentOwner"], f"Team-{other_first}")
         self.assertTrue(overlay_pick["isTraded"])
+
+    def test_overlay_anchors_on_league_meta_when_drafts_lags(self):
+        """Pre-rollover offseason regression (Codex P1): a dynasty
+        league has rolled to season N+1 (so ``/league/{id}.season``
+        reports N+1 and Sleeper has trades for N+1 picks) but the
+        N+1 draft hasn't been created yet, so ``/drafts`` only
+        returns season N.  The overlay must anchor on
+        ``/league/{id}.season`` (N+1) — using ``max(drafts.season)``
+        would skip every N+1 trade and revert to the stale workbook
+        owner."""
+        from datetime import datetime, timezone
+        active = datetime.now(timezone.utc).year + 1   # active pick season
+        prior = active - 1                              # last completed draft
+        run = self._run_overlay(
+            active,
+            league_meta_season=active,
+            drafts_seasons=[prior],
+            traded_pick_season=active,
+        )
+        if run is None:
+            self.skipTest("Workbook unavailable")
+        with_overlay, without_overlay, _wp, orig_first, other_first = run
+        delta_recv = (self._team_total(with_overlay, other_first)
+                      - self._team_total(without_overlay, other_first))
+        self.assertGreater(delta_recv, 0,
+                           "Overlay regressed when /drafts season lags league meta season")
+        self.assertEqual(with_overlay["season"], active,
+                         "Response season must follow league meta, not drafts max")
 
     def test_overlay_uses_sleeper_draft_season_not_calendar_year(self):
         """Regression for the Dec→Jan boundary: when Sleeper reports

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -398,6 +398,23 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         )
         self.assertEqual(with_totals, without_totals,
                          "Overlay shifted dollars using a cross-year slot map")
+        # And teamTotals must not contain duplicate logical teams
+        # (e.g. a Sleeper "Russini Panini" row at $0 plus a workbook
+        # "Jason" row at $XX).  Codex P1 round 4: when the first-name
+        # → team-name bridge is empty (no active-season draft),
+        # pre-seeding Sleeper team names while the picks loop emits
+        # raw first names produced doubled rows.  The teamTotals
+        # length must equal the unique team count from the workbook.
+        team_names = {row["team"] for row in with_overlay["teamTotals"]}
+        self.assertEqual(
+            len(with_overlay["teamTotals"]), len(team_names),
+            f"Duplicate rows in teamTotals: {with_overlay['teamTotals']}",
+        )
+        self.assertLessEqual(
+            len(with_overlay["teamTotals"]),
+            with_overlay.get("numTeams", 12),
+            f"teamTotals exploded past numTeams: {with_overlay['teamTotals']}",
+        )
 
     def test_overlay_uses_sleeper_draft_season_not_calendar_year(self):
         """Regression for the Dec→Jan boundary: when Sleeper reports

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -1,14 +1,18 @@
 """Tests for the draft capital pipeline.
 
-The Draft Data workbook is the authoritative source for BOTH pick
-values (Q45:Q116) and pick ownership (R45:R116).  Sleeper is used only
-to resolve first-name owners to display team names.
+The Draft Data workbook is the authoritative source for pick values
+(Q45:Q116) and the slot→original-owner standings (O30:R42).  Pick
+ownership is overlaid live from Sleeper's ``/traded_picks`` API; the
+workbook's R45:R116 column is the fallback when Sleeper is
+unreachable.  Tests that need to assert workbook-only behavior pass
+``apply_sleeper_trades=False``.
 """
 from __future__ import annotations
 
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 REPO = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO))
@@ -76,7 +80,7 @@ class TestApiOutput(unittest.TestCase):
 
     def test_api_values_are_integers(self):
         import server
-        result = server._fetch_draft_capital()
+        result = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
         for p in result["picks"]:
@@ -85,14 +89,14 @@ class TestApiOutput(unittest.TestCase):
 
     def test_api_total_budget_1200(self):
         import server
-        result = server._fetch_draft_capital()
+        result = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
         self.assertEqual(result["totalBudget"], 1200)
 
     def test_api_team_totals_sum_to_1200(self):
         import server
-        result = server._fetch_draft_capital()
+        result = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
         total = sum(t["auctionDollars"] for t in result["teamTotals"])
@@ -121,7 +125,13 @@ class TestTeamTotalsMirrorSheet(unittest.TestCase):
     def test_api_team_totals_match_largest_remainder_of_sheet_decimals(self):
         """Sorted API dollar totals must equal largest-remainder
         rounding of the sheet's per-owner decimals (regardless of the
-        Sleeper display-name mapping used to label each row)."""
+        Sleeper display-name mapping used to label each row).
+
+        Pinned to ``apply_sleeper_trades=False`` so the workbook's
+        R45:R116 ownership column is the sole owner-of-record; with
+        the live overlay any Sleeper trade not yet reflected in the
+        sheet would shift dollars between teams and break this
+        invariant."""
         import server
         from collections import defaultdict
         _, workbook_picks, _, _, _ = _load()
@@ -129,7 +139,7 @@ class TestTeamTotalsMirrorSheet(unittest.TestCase):
         for wp in workbook_picks:
             decimals[wp["owner"]] += wp["value"]
 
-        result = server._fetch_draft_capital()
+        result = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
 
@@ -147,6 +157,140 @@ class TestTeamTotalsMirrorSheet(unittest.TestCase):
         )
         self.assertEqual(api_totals, expected,
                          f"api={api_totals} expected={expected}")
+
+
+class TestSleeperTradeOverlay(unittest.TestCase):
+    """Ownership in the workbook (R45:R116) is hand-edited and lags
+    real-time trades.  ``_fetch_draft_capital`` overlays Sleeper's
+    ``/traded_picks`` so dollars-per-team reflect the current
+    Sleeper roster ownership without waiting for a commissioner edit.
+    """
+
+    def _stub_urlopen(self, url_to_payload):
+        """Build a urllib.request.urlopen stub from a {url-substring: payload}
+        map.  Each payload is a dict/list that gets JSON-encoded."""
+        import io
+        import json as _json
+
+        def fake_urlopen(url, *args, **kwargs):
+            target = url.full_url if hasattr(url, "full_url") else str(url)
+            for key, payload in url_to_payload.items():
+                if key in target:
+                    return io.BytesIO(_json.dumps(payload).encode())
+            raise AssertionError(f"unexpected urlopen({target})")
+        return fake_urlopen
+
+    def test_traded_pick_moves_dollars_between_teams(self):
+        """When Sleeper reports the (current_year, round=1, slot=5) pick
+        was traded from its original owner to another roster, the
+        receiving team's dollar total must increase by the pick's value
+        and the original owner's must decrease by the same amount —
+        independent of whatever R45:R116 says."""
+        import server
+        from datetime import datetime, timezone
+
+        _, workbook_picks, slot_to_original, _, _ = _load()
+        if not workbook_picks or not slot_to_original:
+            self.skipTest("Workbook unavailable")
+
+        # Pick a (round, slot) that exists, has a non-zero value, and
+        # whose original-owner first name differs from at least one
+        # other slot's first name (so the trade actually moves dollars
+        # between distinct first-name buckets).
+        target = None
+        for wp in workbook_picks:
+            if wp["value"] <= 0:
+                continue
+            orig = slot_to_original.get(wp["pick"])
+            other = next(
+                (n for s, n in slot_to_original.items()
+                 if s != wp["pick"] and n != orig),
+                None,
+            )
+            if orig and other:
+                target = (wp, orig, other)
+                break
+        if target is None:
+            self.skipTest("No suitable workbook pick for overlay test")
+        wp, orig_first, other_first = target
+
+        # Build a Sleeper response set that reports the pick was
+        # traded from orig_first's roster to other_first's roster.
+        # Roster IDs are arbitrary; we map them via a fake
+        # slot_to_roster_id so the server resolves them back to
+        # first names through the standings.
+        rosters = []
+        users = []
+        slot_to_roster = {}
+        roster_id_for_first: dict[str, int] = {}
+        for slot, first_name in slot_to_original.items():
+            rid = int(slot)
+            owner_uid = f"u{rid}"
+            rosters.append({"roster_id": rid, "owner_id": owner_uid})
+            users.append({
+                "user_id": owner_uid,
+                "display_name": f"Team-{first_name}",
+                "metadata": {},
+            })
+            slot_to_roster[str(slot)] = rid
+            roster_id_for_first[first_name] = rid
+
+        current_year = datetime.now(timezone.utc).year
+        drafts = [{"draft_id": "D1", "season": current_year}]
+        draft_detail = {"slot_to_roster_id": slot_to_roster}
+        traded_picks = [{
+            "season": current_year,
+            "round": wp["round"],
+            "roster_id": roster_id_for_first[orig_first],
+            "owner_id": roster_id_for_first[other_first],
+            "previous_owner_id": roster_id_for_first[orig_first],
+        }]
+
+        url_map = {
+            "/rosters": rosters,
+            "/users": users,
+            "/league/" : None,  # placeholder; specific paths below win
+            "/drafts": drafts,
+            "/draft/D1": draft_detail,
+            "/traded_picks": traded_picks,
+        }
+        # Drop the placeholder so unmatched URLs don't accidentally hit it.
+        del url_map["/league/"]
+
+        with patch.object(server.urllib.request, "urlopen",
+                          self._stub_urlopen(url_map)), \
+             patch.object(server, "_sleeper_league_id_for_draft",
+                          return_value="TEST_LEAGUE"):
+            with_overlay = server._fetch_draft_capital(apply_sleeper_trades=True)
+            without_overlay = server._fetch_draft_capital(apply_sleeper_trades=False)
+
+        if "error" in with_overlay or "error" in without_overlay:
+            self.skipTest("Workbook returned error")
+
+        def total_for(result, team_first):
+            label = f"Team-{team_first}"
+            for row in result["teamTotals"]:
+                if row["team"] == label:
+                    return row["auctionDollars"]
+            return 0
+
+        # The receiving team must have strictly more dollars with the
+        # overlay applied; the original owner must have strictly less.
+        delta_recv = total_for(with_overlay, other_first) - total_for(without_overlay, other_first)
+        delta_orig = total_for(with_overlay, orig_first) - total_for(without_overlay, orig_first)
+        self.assertGreater(delta_recv, 0,
+                           f"Receiving team did not gain dollars: {delta_recv}")
+        self.assertLess(delta_orig, 0,
+                        f"Original owner did not lose dollars: {delta_orig}")
+        # And the overlaid pick must report the new currentOwner.
+        traded_pick_label = f"{wp['round']}.{str(wp['pick']).zfill(2)}"
+        overlay_pick = next(
+            (p for p in with_overlay["picks"] if p["pick"] == traded_pick_label),
+            None,
+        )
+        self.assertIsNotNone(overlay_pick)
+        self.assertEqual(overlay_pick["currentOwner"], f"Team-{other_first}")
+        self.assertTrue(overlay_pick["isTraded"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The default-league draft-capital page was sourcing both pick **values** AND pick **ownership** from the hand-edited Google Sheet (R45:R116), so per-team dollar totals only refreshed when the commissioner manually edited the sheet — leaving Sleeper-tracked trades stale even though the workbook itself already refreshes every 2 hours via `scheduled-refresh.yml`.

This PR overlays Sleeper's `/traded_picks` API on top of the workbook ownership column. Pick **values** still come from the workbook (those are league-specific auction prices); pick **ownership** is now sourced live from Sleeper on every API call, matching the behavior the Sleeper-derived fallback path already uses for non-default leagues.

## Why the dollars were "wrong"

- Cron at `42 */2 * * *` UTC pulls the workbook fresh — that part already worked.
- But `_fetch_draft_capital` (`server.py:4504`) trusted `wp["owner"]` from R45:R116 verbatim.
- That column is hand-maintained, so a Sleeper trade made yesterday wouldn't shift dollar totals between teams until someone opened the sheet and re-typed first names.

## Behavior after the fix

- `/api/draft-capital` for the default league now reflects current Sleeper ownership on **every** request, not just after the commissioner edits the sheet.
- Pick values, expansion-pair averaging, $1200 budget, and largest-remainder rounding are all unchanged.
- If Sleeper is unreachable, the workbook ownership column is used as fallback (logged as a warning) — no degradation vs. prior behavior.
- New `apply_sleeper_trades=False` kwarg preserves legacy workbook-only behavior for existing tests that pin sheet-derived totals.

## Test plan

- [x] `pytest tests/api/test_draft_capital.py tests/api/test_draft_capital_fallback.py` — 20/20 pass
- [x] Full `tests/api/` suite — 916 passed, 3 skipped, 0 failed
- [x] New `TestSleeperTradeOverlay::test_traded_pick_moves_dollars_between_teams` — mocks Sleeper rosters/users/drafts/traded_picks and verifies the receiving team gains the pick's dollars and the original owner loses them.
- [x] Existing `TestTeamTotalsMirrorSheet` invariants pinned with `apply_sleeper_trades=False` so they still validate the workbook-only path.
- [ ] Manual: hit `/api/draft-capital?leagueKey=dynasty_main` in production and confirm a recently-traded pick shows the new owner.

https://claude.ai/code/session_01WKPmoNqxSBkXE2A5MYgqRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKPmoNqxSBkXE2A5MYgqRT)_