### PR TITLE
fix(waivers): surface /waivers in mobile More menu

### DIFF
--- a/frontend/app/more/page.jsx
+++ b/frontend/app/more/page.jsx
@@ -26,6 +26,12 @@ const SECTIONS = [
     ],
   },
   {
+    title: "Roster",
+    items: [
+      { href: "/waivers", label: "Waivers", desc: "Add/drop analysis vs your roster" },
+    ],
+  },
+  {
     title: "Signals",
     items: [
       { href: "/edge", label: "Edge", desc: "Where ranking sources agree, disagree, and flag issues" },


### PR DESCRIPTION
## Summary
- The /waivers page added in 5e04993 was wired into the desktop top nav but missing from the mobile `/more` page's static `SECTIONS` array, so mobile users had no in-app way to discover the route.
- Adds a new "Roster" section between "Trade workflow" and "Signals" containing Waivers, mirroring desktop nav ordering (Trade ▾ → Draft → Waivers → Edge).

## Test plan
- [ ] Visit `/more` on mobile while authenticated and confirm the new "Roster" section appears with a "Waivers" entry between "Trade workflow" and "Signals".
- [ ] Tap the entry and confirm it navigates to `/waivers`.
- [ ] Confirm desktop top nav is unchanged.

https://claude.ai/code/session_01BLPCoWaYrxaciesLmWiyma

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLPCoWaYrxaciesLmWiyma)_