### PR TITLE
fix(mobile): per-source winner card — stop pruning sourceRankMeta from compact view

### DIFF
--- a/src/api/compact_view.py
+++ b/src/api/compact_view.py
@@ -8,15 +8,26 @@ Fields we prune (listed in ``_PRUNED_CONTRACT_FIELDS``):
     poolAudit, methodology, siteStats (verbose per-scrape stats)
 
 Fields we prune per-player (listed in ``_PRUNED_PLAYER_FIELDS``):
-    sourceRankMeta, canonicalSiteValues, droppedSources,
-    effectiveSourceRanks, sourceOriginalRanks, anomalyFlags,
-    confidenceLabel, pickDetails
+    droppedSources, effectiveSourceRanks, sourceOriginalRanks,
+    anomalyFlags, confidenceLabel, pickDetails
+
+Fields slimmed per-player (listed in ``_SLIM_SOURCE_RANK_META_FIELDS``):
+    sourceRankMeta entries are kept but reduced to the subset of
+    fields the mobile UI actually consumes.  Mobile drops the per-
+    source ``percentile`` / ``valueContributionPath`` / ``isAnchor``
+    / ``ladderDepth`` / TEP audit stamps, but keeps the
+    ``valueContribution`` (drives the trade per-source winner row,
+    PlayerPopup, source-contribution graphs, rankings audit cell),
+    ``effectiveWeight``, and ``method`` fields.
 
 Fields KEPT (mobile UI needs them):
     name / canonicalName / displayName / position / team / age /
     rookie / assetClass / values / sourceCount / confidence /
     marketLabel / canonicalConsensusRank / rankDerivedValue /
-    canonicalTierId / rankChange / sleeper (for team-switcher)
+    canonicalTierId / rankChange / sleeper (for team-switcher) /
+    canonicalSiteValues (KTC TE+ row in the trade per-source winner
+    reads the raw native value from this map) / sourceRankMeta
+    (slimmed — see above).
 
 Shape tests in ``tests/api/test_compact_view`` pin the
 contract so adding a field to this list either updates tests
@@ -34,8 +45,6 @@ _PRUNED_CONTRACT_FIELDS = frozenset({
 })
 
 _PRUNED_PLAYER_FIELDS = frozenset({
-    "sourceRankMeta",
-    "canonicalSiteValues",
     "droppedSources",
     "effectiveSourceRanks",
     "sourceOriginalRanks",
@@ -56,12 +65,53 @@ _PRUNED_PLAYER_FIELDS = frozenset({
     "anchorValue",
 })
 
+# Per-source meta fields kept on the compact view.  Drives the trade
+# per-source winner card (``valueContribution``), the rankings audit
+# popover (``valueContribution`` + ``effectiveWeight`` + ``method``),
+# and the PlayerPopup source-contribution graphs (``valueContribution``).
+# Audit-only stamps (percentile, isAnchor, TEP correction flags, etc.)
+# are dropped on mobile to keep the payload small.
+_SLIM_SOURCE_RANK_META_FIELDS = frozenset({
+    "valueContribution",
+    "effectiveWeight",
+    "method",
+})
+
+
+def _slim_source_rank_meta(meta: Any) -> Any:
+    """Return a per-source meta dict reduced to the mobile-consumed
+    subset.  Non-dict inputs pass through untouched."""
+    if not isinstance(meta, dict):
+        return meta
+    slim: dict[str, dict[str, Any]] = {}
+    for src_key, src_meta in meta.items():
+        if isinstance(src_meta, dict):
+            slim[src_key] = {
+                k: v for k, v in src_meta.items()
+                if k in _SLIM_SOURCE_RANK_META_FIELDS
+            }
+        else:
+            # Defensive: preserve unexpected shapes verbatim so tests
+            # that mutate fixtures (and downstream consumers that
+            # tolerate odd shapes) don't break silently.
+            slim[src_key] = src_meta
+    return slim
+
 
 def compact_player(player: dict[str, Any]) -> dict[str, Any]:
-    """Return a shallow-copied player row with pruned fields."""
+    """Return a shallow-copied player row with pruned fields and a
+    slimmed ``sourceRankMeta`` map."""
     if not isinstance(player, dict):
         return player
-    return {k: v for k, v in player.items() if k not in _PRUNED_PLAYER_FIELDS}
+    out: dict[str, Any] = {}
+    for k, v in player.items():
+        if k in _PRUNED_PLAYER_FIELDS:
+            continue
+        if k == "sourceRankMeta":
+            out[k] = _slim_source_rank_meta(v)
+            continue
+        out[k] = v
+    return out
 
 
 def compact_contract(payload: dict[str, Any]) -> dict[str, Any]:

--- a/tests/api/test_compact_view.py
+++ b/tests/api/test_compact_view.py
@@ -11,7 +11,26 @@ def _sample_contract():
                 "name": "Josh Allen",
                 "rankDerivedValue": 9200,
                 "canonicalConsensusRank": 1,
-                "sourceRankMeta": {"x": 1, "y": 2},
+                "sourceRankMeta": {
+                    "ktcSfTep": {
+                        "valueContribution": 9100,
+                        "effectiveWeight": 1.0,
+                        "method": "value_direct",
+                        "percentile": 0.0001,
+                        "valueContributionPath": "value_direct",
+                        "isAnchor": True,
+                        "tepBoostApplied": False,
+                        "ladderDepth": 320,
+                    },
+                    "dlfSf": {
+                        "valueContribution": 8800,
+                        "effectiveWeight": 1.0,
+                        "method": "rank_hill",
+                        "percentile": 0.002,
+                        "isAnchor": False,
+                        "ladderDepth": 280,
+                    },
+                },
                 "canonicalSiteValues": {"ktcSfTep": 9000},
                 "droppedSources": [],
                 "effectiveSourceRanks": {"ktcSfTep": 2},
@@ -36,7 +55,15 @@ def _sample_contract():
             {
                 "displayName": "Josh Allen",
                 "rankDerivedValue": 9200,
-                "sourceRankMeta": {"x": 1},
+                "sourceRankMeta": {
+                    "ktcSfTep": {
+                        "valueContribution": 9100,
+                        "effectiveWeight": 1.0,
+                        "method": "value_direct",
+                        "percentile": 0.0001,
+                        "isAnchor": True,
+                    },
+                },
                 "canonicalSiteValues": {"ktcSfTep": 9000},
                 "anomalyFlags": [],
             }
@@ -63,8 +90,12 @@ def test_prunes_contract_level_fields():
 def test_prunes_player_level_fields():
     out = cv.compact_contract(_sample_contract())
     player = out["players"]["Josh Allen"]
-    assert "sourceRankMeta" not in player
-    assert "canonicalSiteValues" not in player
+    # ``sourceRankMeta`` and ``canonicalSiteValues`` are kept on the
+    # compact view — the trade per-source winner card and the
+    # rankings audit popover both read them.  Other audit-only fields
+    # are still pruned.
+    assert "sourceRankMeta" in player
+    assert "canonicalSiteValues" in player
     assert "anomalyFlags" not in player
     # Kept fields.
     assert player["name"] == "Josh Allen"
@@ -75,17 +106,50 @@ def test_prunes_player_level_fields():
 def test_prunes_players_array_fields():
     out = cv.compact_contract(_sample_contract())
     arr_player = out["playersArray"][0]
-    assert "sourceRankMeta" not in arr_player
-    assert "canonicalSiteValues" not in arr_player
+    assert "sourceRankMeta" in arr_player
+    assert "canonicalSiteValues" in arr_player
+    assert "anomalyFlags" not in arr_player
     assert arr_player["rankDerivedValue"] == 9200
+
+
+def test_source_rank_meta_is_slimmed():
+    """``sourceRankMeta`` survives the compact pass but each per-source
+    entry is reduced to the fields the mobile UI actually consumes —
+    valueContribution (drives the trade per-source winner row),
+    effectiveWeight, method.  Audit-only stamps are dropped."""
+    out = cv.compact_contract(_sample_contract())
+    player = out["players"]["Josh Allen"]
+    ktc_meta = player["sourceRankMeta"]["ktcSfTep"]
+    # Kept fields.
+    assert ktc_meta["valueContribution"] == 9100
+    assert ktc_meta["effectiveWeight"] == 1.0
+    assert ktc_meta["method"] == "value_direct"
+    # Dropped audit-only fields.
+    assert "percentile" not in ktc_meta
+    assert "valueContributionPath" not in ktc_meta
+    assert "isAnchor" not in ktc_meta
+    assert "tepBoostApplied" not in ktc_meta
+    assert "ladderDepth" not in ktc_meta
+    # Same slimming applied per-source.
+    dlf_meta = player["sourceRankMeta"]["dlfSf"]
+    assert dlf_meta["valueContribution"] == 8800
+    assert "percentile" not in dlf_meta
+
+
+def test_source_rank_meta_slimming_on_players_array():
+    out = cv.compact_contract(_sample_contract())
+    arr_meta = out["playersArray"][0]["sourceRankMeta"]["ktcSfTep"]
+    assert arr_meta["valueContribution"] == 9100
+    assert "percentile" not in arr_meta
+    assert "isAnchor" not in arr_meta
 
 
 def test_non_destructive():
     orig = _sample_contract()
     _ = cv.compact_contract(orig)
-    # Input unchanged.
+    # Input unchanged: original audit fields still present.
     assert "poolAudit" in orig
-    assert "sourceRankMeta" in orig["players"]["Josh Allen"]
+    assert "percentile" in orig["players"]["Josh Allen"]["sourceRankMeta"]["ktcSfTep"]
 
 
 def test_byte_savings_reports_positive_number():


### PR DESCRIPTION
## Summary

User reported the **Per-source winner** card on `/trade` still rendering the "No vendor coverage for this trade yet" empty-state on mobile, even with both sides populated and showing real value totals (7,989 vs 7,432 in the screenshot). The diagnostic card chrome introduced in 7cfaba5 was visible — confirming this is a **data path** issue, not a stale-cache one.

## Root cause

`src/api/compact_view.py` is the response builder for `/api/data?view=compact`, which `frontend/lib/device-profile.js::preferredDataView()` selects automatically on mobile viewports / slow networks. Its `_PRUNED_PLAYER_FIELDS` set listed both `sourceRankMeta` and `canonicalSiteValues` — so every player on a mobile fetch came back with both fields stripped.

But the trade per-source winner row reads exactly these:

- `row.sourceRankMeta?.[sub.key]?.valueContribution` — the per-source 0-9999 Hill-blended value summed per vendor; drives the winner-margin column.
- `row.canonicalSites?.[sub.key]` — KTC TE+'s native raw value, used so V13 Value Adjustment reproduces what keeptradecut.com displays.

Without either field, the inner loop in `TradeSourceBreakdown` returns `0` for every (vendor, side, asset) tuple → coverage is zero across all vendors → `rows` collapses to `[]` → the empty-state path renders.

The same pruning silently broke other mobile UIs:
- Rankings audit popover (reads `meta.valueContribution` / `effectiveWeight` / `method`).
- PlayerPopup source-contribution + agreement graphs (read `meta.valueContribution`).

## Fix

1. Drop `sourceRankMeta` and `canonicalSiteValues` from `_PRUNED_PLAYER_FIELDS`. Both are needed by core mobile UX; the original prune list was too aggressive.
2. Slim each per-source `sourceRankMeta` entry down to the three fields the mobile UI consumes (`valueContribution`, `effectiveWeight`, `method`) via a new `_slim_source_rank_meta` helper. Audit-only stamps (`percentile`, `valueContributionPath`, `isAnchor`, TEP correction flags, `ladderDepth`) are still dropped on mobile, so we keep most of the original payload savings. `canonicalSiteValues` passes through unchanged — its value map is small and fully consumed by the per-source winner card + retail-vs-consensus gap fallback.

## Test plan

- [x] Updated `tests/api/test_compact_view.py` fixture to a realistic per-source nested-dict shape with the full audit payload.
- [x] Added `test_source_rank_meta_is_slimmed` — asserts the consumed subset round-trips and audit-only stamps are dropped.
- [x] Added `test_source_rank_meta_slimming_on_players_array` — same invariant on the `playersArray` shape.
- [x] Flipped two pre-existing assertions that asserted `sourceRankMeta` / `canonicalSiteValues` were ABSENT to PRESENT, matching the new contract.
- [x] All 8 compact-view tests pass; the broader 847 api tests still pass.
- [ ] On the deployed branch, confirm mobile `/trade` now renders the Per-source winner table with vendor rows once both sides have at least one player.

https://claude.ai/code/session_01BwT4AmLsG9mKGtc2K8QRZb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwT4AmLsG9mKGtc2K8QRZb)_