### PR TITLE
fix(trade): restore missing "Recommended right now" rail on /trade

### DIFF
--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -1628,23 +1628,47 @@ export default function TradePage() {
   //   * loading completes (cold-load arrives after first paint)
   // Debounced via a ref so a rapid roster edit doesn't spam the API.
   //
-  // Important: the debounce timer must survive effect re-runs that
-  // don't change ``bodyKey`` — e.g. when ``rows`` ref churns mid-load
-  // because ``useSettings`` hydrates from localStorage and triggers
-  // a second ``useDynastyData`` fetch.  An older shape returned a
-  // cleanup that cleared the timer on every dep change; combined with
-  // the ``lastBody === bodyKey`` short-circuit, the timer would be
-  // killed and never re-armed, so ``fetchSuggestions`` never fired and
-  // the rail stayed hidden.  Today's shape lets the inner
-  // ``clearTimeout`` (line below ``setSuggestions(null)``) handle the
-  // bodyKey-changed case and uses a separate unmount-only effect to
-  // tear down a still-pending timer.
+  // Two failure modes the cancel logic has to thread:
+  //
+  //   (A) ``rows`` ref churns mid-load (``useSettings`` hydrates and
+  //       triggers a second ``useDynastyData`` fetch) but ``bodyKey``
+  //       is unchanged.  An older shape unconditionally cancelled the
+  //       timer on every dep change; combined with the ``lastBody ===
+  //       bodyKey`` short-circuit, the timer was killed and never
+  //       re-armed, so ``fetchSuggestions`` never fired and the rail
+  //       stayed hidden.
+  //
+  //   (B) The user switches leagues / clears the roster / starts a
+  //       reload, so the preconditions now fail.  An armed timer from
+  //       a prior valid render would otherwise fire ~500ms later and
+  //       dispatch ``fetchSuggestions`` with stale render state.
+  //
+  // The shape below cancels exactly when preconditions newly fail OR
+  // when ``bodyKey`` changes, and otherwise leaves the pending timer
+  // alone.  ``lastBody`` is reset on the precondition-fail branch so a
+  // fresh timer arms when the user returns to a valid state.
   const proactiveFetchRef = useRef({ lastBody: null, timer: null });
   useEffect(() => {
-    if (loading || error || leagueMismatch) return;
-    if (!rows || rows.length === 0) return;
+    const cancelPending = () => {
+      if (proactiveFetchRef.current.timer) {
+        clearTimeout(proactiveFetchRef.current.timer);
+        proactiveFetchRef.current.timer = null;
+      }
+      proactiveFetchRef.current.lastBody = null;
+    };
+    if (loading || error || leagueMismatch) {
+      cancelPending();
+      return;
+    }
+    if (!rows || rows.length === 0) {
+      cancelPending();
+      return;
+    }
     const roster = parseRoster();
-    if (roster.length < 3) return;
+    if (roster.length < 3) {
+      cancelPending();
+      return;
+    }
     const bodyKey = `${selectedLeagueKey || ""}|${roster.join("|")}`;
     if (proactiveFetchRef.current.lastBody === bodyKey) return;
     proactiveFetchRef.current.lastBody = bodyKey;
@@ -1663,9 +1687,10 @@ export default function TradePage() {
       proactiveFetchRef.current.timer = null;
       fetchSuggestions();
     }, 500);
-    // No re-run cleanup: the inner clearTimeout above already cancels
-    // the pending timer when bodyKey actually changes, and the unmount
-    // effect below tears down anything still in flight on teardown.
+    // No re-run cleanup: cancellation is handled inline above so a
+    // benign ``rows`` ref churn doesn't kill the pending fetch, and
+    // the unmount effect below tears down anything still in flight
+    // on teardown.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, error, leagueMismatch, rows, rosterInput, selectedLeagueKey]);
 

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -1627,6 +1627,18 @@ export default function TradePage() {
   //   * selected league/team changes (incl. picks regenerate)
   //   * loading completes (cold-load arrives after first paint)
   // Debounced via a ref so a rapid roster edit doesn't spam the API.
+  //
+  // Important: the debounce timer must survive effect re-runs that
+  // don't change ``bodyKey`` — e.g. when ``rows`` ref churns mid-load
+  // because ``useSettings`` hydrates from localStorage and triggers
+  // a second ``useDynastyData`` fetch.  An older shape returned a
+  // cleanup that cleared the timer on every dep change; combined with
+  // the ``lastBody === bodyKey`` short-circuit, the timer would be
+  // killed and never re-armed, so ``fetchSuggestions`` never fired and
+  // the rail stayed hidden.  Today's shape lets the inner
+  // ``clearTimeout`` (line below ``setSuggestions(null)``) handle the
+  // bodyKey-changed case and uses a separate unmount-only effect to
+  // tear down a still-pending timer.
   const proactiveFetchRef = useRef({ lastBody: null, timer: null });
   useEffect(() => {
     if (loading || error || leagueMismatch) return;
@@ -1648,15 +1660,26 @@ export default function TradePage() {
       clearTimeout(proactiveFetchRef.current.timer);
     }
     proactiveFetchRef.current.timer = setTimeout(() => {
+      proactiveFetchRef.current.timer = null;
       fetchSuggestions();
     }, 500);
+    // No re-run cleanup: the inner clearTimeout above already cancels
+    // the pending timer when bodyKey actually changes, and the unmount
+    // effect below tears down anything still in flight on teardown.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, error, leagueMismatch, rows, rosterInput, selectedLeagueKey]);
+
+  // Unmount-only cleanup for the proactive-fetch debounce timer — kept
+  // separate from the auto-fetch effect above so a dep-driven re-run
+  // doesn't cancel a pending fetch.
+  useEffect(() => {
     return () => {
       if (proactiveFetchRef.current.timer) {
         clearTimeout(proactiveFetchRef.current.timer);
+        proactiveFetchRef.current.timer = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, error, leagueMismatch, rows, rosterInput, selectedLeagueKey]);
+  }, []);
 
   async function fetchSuggestions() {
     const roster = parseRoster();


### PR DESCRIPTION
## Summary

- Restore the proactive "Recommended right now · top idea per category" rail at the top of `/trade` (Sell High / Buy Low / Consolidation / Upgrade cards). The component, the auto-fetch, and the render guard were all still in the codebase — the issue was that the auto-fetch was being silently cancelled mid-debounce on cold load.
- Drop the per-rerun cleanup from the auto-fetch effect; replace it with a single unmount-only cleanup so a dep change that doesn't move `bodyKey` no longer kills the pending 500 ms timer.
- Null out `proactiveFetchRef.current.timer` when the timer's callback fires.

## Root cause

`frontend/app/trade/page.jsx` had:

```jsx
useEffect(() => {
  ...
  if (proactiveFetchRef.current.lastBody === bodyKey) return;
  proactiveFetchRef.current.lastBody = bodyKey;
  ...
  proactiveFetchRef.current.timer = setTimeout(fetchSuggestions, 500);
  return () => clearTimeout(proactiveFetchRef.current.timer);  // ← buggy
}, [loading, error, leagueMismatch, rows, rosterInput, selectedLeagueKey]);
```

Cold-load timing on a typical session:

1. Page mounts. Loading completes. `rosterInput` is empty → effect early-returns at `roster.length < 3`.
2. localStorage hydration sets `rosterInput`. Effect re-runs, computes `bodyKey`, sets `lastBody`, arms timer T1.
3. `useSettings` hydrates from localStorage with custom `siteWeights`. `siteOverridesKey` flips → `useDynastyData` re-fetches → `rawData` updates → `rows` ref churns.
4. Auto-fetch effect re-runs because `rows` is in its deps. Cleanup fires first and clears T1. Body re-runs, `bodyKey` unchanged → returns early at the `lastBody` check. **T1 is dead, no T2 ever armed.**
5. `fetchSuggestions` never fires → `suggestions` stays `null` → render guard `suggestions && suggestions.totalSuggestions > 0` never opens → rail never appears.

## Fix

The inner `clearTimeout` (just before re-arming) already handles the `bodyKey`-changed case, so the per-rerun cleanup is redundant — and harmful when the rerun short-circuits. Removed it from the auto-fetch effect and added a separate single-mount effect that only tears down a still-pending timer on unmount.

## Test plan

- [x] `npm test` (vitest): 841/841 pass
- [x] `npm run build:nocheck`: clean production build
- [ ] Manual verification on `/trade`: load page, confirm the "RECOMMENDED RIGHT NOW · TOP IDEA PER CATEGORY" panel appears with Sell High / Buy Low / Consolidation / Upgrade cards once auto-suggestions return
- [ ] Switch teams via the topbar TeamSwitcher and confirm the rail refreshes (no stale cards from the previous team)
- [ ] Switch to a non-default league and confirm the rail correctly hides behind the existing `leagueMismatch` banner

https://claude.ai/code/session_01XcRKR7pHLMKtXf6Mj3rWfj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcRKR7pHLMKtXf6Mj3rWfj)_