### PR TITLE
fix(ros-power): show all 12 rosters with preseason-only inputs going into 2026

### DIFF
--- a/frontend/app/league/sections/ros-power.jsx
+++ b/frontend/app/league/sections/ros-power.jsx
@@ -137,9 +137,24 @@ export default function RosPowerSection() {
     );
   }
 
-  const weights = data.weights || {};
+  const specWeights = data.weights || {};
+  const effectiveWeights = data.effectiveWeights || specWeights;
   const missing = data.missingInputs || [];
   const rosAvailable = !!data.rosTeamStrengthAvailable;
+  const preseason = !!data.preseason;
+
+  // Render the formula description from whichever weights are actually
+  // applied so the UI doesn't claim "season PPG (18%)" when we're going
+  // into a fresh year and that component has been routed through
+  // ``missingInputs``.  Order by weight descending so the dominant
+  // contributors lead the line.
+  const formulaParts = Object.entries(effectiveWeights)
+    .filter(([, w]) => Number(w) > 0)
+    .sort((a, b) => Number(b[1]) - Number(a[1]))
+    .map(
+      ([key, w]) =>
+        `${COMPONENT_LABELS[key] || key} (${Math.round(Number(w) * 100)}%)`,
+    );
 
   return (
     <div className="card" style={{ marginTop: "var(--space-md)" }}>
@@ -147,15 +162,20 @@ export default function RosPowerSection() {
         ROS Power Rankings
       </div>
       <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginBottom: 10 }}>
-        ROS roster strength (38%) + season PPG (18%) + recent form (12%) + W/L
-        (10%) + all-play (8%) + streak (5%) + schedule-adjusted (4%) + roster
-        health (3%) + luck regression (2%).{" "}
-        {!rosAvailable && (
-          <span style={{ color: "var(--amber)" }}>
-            ROS roster strength not available yet — using actual-results-only blend.
+        {preseason && (
+          <span style={{ color: "var(--cyan)" }}>
+            Going into the new season — only forward-looking inputs are used.{" "}
           </span>
         )}
-        {missing.length > 0 && (
+        {formulaParts.join(" + ")}
+        {formulaParts.length > 0 && "."}
+        {!rosAvailable && (
+          <span style={{ color: "var(--amber)" }}>
+            {" "}
+            ROS roster strength not available yet.
+          </span>
+        )}
+        {!preseason && missing.length > 0 && (
           <span>
             {" "}
             Missing inputs: {missing.join(", ")}.
@@ -182,7 +202,7 @@ export default function RosPowerSection() {
             <RankingRow
               key={row.ownerId || i}
               row={row}
-              weights={weights}
+              weights={row.weightsApplied || effectiveWeights}
               expanded={expanded === i}
               onToggle={() => setExpanded(expanded === i ? null : i)}
             />

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -1,6 +1,6 @@
 """ROS-driven power rankings (v2).
 
-Spec formula:
+Spec formula (in-season):
 
     power_score =
         0.38 * team_ros_strength_percentile
@@ -21,13 +21,24 @@ Inputs come from two places:
       ``power.py``.  Provides PPG, recent form, W/L, all-play, streak,
       and luck-regression inputs.
 
-PR2 leaves ``schedule_adjusted_performance`` and ``roster_health_score``
-at 0 (well-documented config-gated TODOs) — the spec calls these out as
-"implement what is reasonable and leave clean TODOs/config flags for the
-rest" because they need data this app doesn't currently surface
-(opponent-strength SOS + injury-aware roster scoring).  The current
-formula renormalises the populated weights so missing terms don't
-deflate the result against teams with full coverage.
+The owner list spans every team that owns a roster in the current
+league, sourced from the team-strength snapshot (live Sleeper rosters)
+unioned with the snapshot's current-season rosters.  Owners who joined
+the league for the upcoming year and have no prior-season record still
+appear with their ROS-based score — without this union the table
+silently drops to the count of owners with historical participation.
+
+Preseason / between-seasons handling: when no scored regular-season
+matchups exist for the snapshot's current season (either because the
+year hasn't kicked off yet or the prior year is complete and the new
+schedule isn't loaded), the historical-results components — PPG,
+recent form, W/L, all-play, streak, and luck regression — describe a
+season that is over and don't project the upcoming year.  Those
+components are routed through ``missing_inputs`` so the formula
+renormalises onto the forward-looking metrics (team ROS strength,
+roster health, and 2026 schedule SOS when available).  The same
+``missing_inputs`` machinery that protects against an absent
+team-strength file already handles renormalisation cleanly.
 
 Render-side, this section is gated by ``settings.useRosPowerRankings``:
 when False, the existing ``power.py`` v1 still drives /league → Power.
@@ -41,7 +52,7 @@ import logging
 import math
 import statistics
 from collections import defaultdict
-from typing import Any
+from typing import Any, Iterable
 
 from src.ros import ROS_DATA_DIR
 from src.public_league import luck, metrics as _metrics
@@ -64,6 +75,25 @@ WEIGHTS: dict[str, float] = {
 }
 
 _RECENT_WINDOW = 3  # matches power.py
+
+# Components driven entirely by the most-recent-loaded season's results.
+# Routed through ``missing_inputs`` when no scored games exist in the
+# current season — see module docstring.
+_HISTORICAL_RESULTS_COMPONENTS: tuple[str, ...] = (
+    "ppg",
+    "recent",
+    "wl_record",
+    "all_play",
+    "streak",
+    "luck_regression",
+)
+
+_EMPTY_CAREER: dict[str, float | int] = {
+    "points": 0.0,
+    "games": 0,
+    "wins": 0.0,
+    "losses": 0.0,
+}
 
 
 def _percentile(values: list[float], target: float) -> float:
@@ -162,6 +192,88 @@ def _schedule_adjusted_scores(
     return out
 
 
+def _is_preseason(snapshot: PublicLeagueSnapshot) -> bool:
+    """True when no in-progress regular season exists for the snapshot.
+
+    Two conditions count as "going into a new season":
+      * no current season at all (empty snapshot);
+      * the snapshot's current season has zero scored regular-season
+        matchups — covers both "Sleeper has the new year live but no
+        games have been played yet" and "the prior year is complete
+        and we're between seasons".
+
+    In this state the historical-results components describe a finished
+    season and don't project the upcoming year.  The build pipeline
+    drops them via ``missing_inputs`` so the score reflects only
+    forward-looking inputs (ROS strength, roster health, SOS).
+    """
+    current = snapshot.current_season
+    if current is None:
+        return True
+    if current.is_complete:
+        return True
+    for wk in current.regular_season_weeks:
+        for entry in current.matchups_by_week.get(wk) or []:
+            pts = entry.get("points")
+            try:
+                if pts is not None and float(pts) > 0:
+                    return False
+            except (TypeError, ValueError):
+                continue
+    return True
+
+
+def _enumerate_owner_ids(
+    snapshot: PublicLeagueSnapshot,
+    team_strength_rows: list[dict[str, Any]],
+    historical_owner_ids: Iterable[str],
+) -> list[str]:
+    """Canonical owner list for the rankings table.
+
+    Order of precedence (first match wins on display order — though
+    rows are re-sorted by power score before render):
+
+      1. Owners present in the live team-strength snapshot.  This is
+         the source of truth for "who is on a roster right now",
+         which is what the going-into-2026 table needs to show.
+      2. Owners on the snapshot's current Sleeper season — covers the
+         case where the team-strength file is temporarily empty.
+      3. Owners with prior-season career history that the manager
+         registry still lists as active — defensive fallback so an
+         old participant who exists in history but not in either of
+         the live sources still appears.
+    """
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def _add(oid: str | None) -> None:
+        if not oid:
+            return
+        oid = str(oid).strip()
+        if not oid or oid in seen:
+            return
+        seen.add(oid)
+        ordered.append(oid)
+
+    for row in team_strength_rows:
+        _add(row.get("ownerId"))
+
+    current = snapshot.current_season
+    if current is not None:
+        for roster in current.rosters or []:
+            _add(roster.get("owner_id"))
+
+    registry_ids = snapshot.managers.by_owner_id
+    for oid in historical_owner_ids:
+        # Only include historical owners who are still registered —
+        # retired managers are filtered out at registry build time, so
+        # falling through to ``by_owner_id`` keeps them out here too.
+        if oid in registry_ids:
+            _add(oid)
+
+    return ordered
+
+
 def _streak_score_from_outcomes(outcomes: list[float]) -> float:
     """Convert a chronological list of W/L outcomes (1.0 = W, 0.0 = L,
     0.5 = T) into a 0-1 streak score.  Reads the trailing run only;
@@ -203,7 +315,12 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     """
     registry = snapshot.managers
     seasons_sorted = sorted(snapshot.seasons, key=luck._season_sort_key)
-    if not seasons_sorted:
+    team_strength_rows = _load_team_strength_rows()
+    preseason = _is_preseason(snapshot)
+    if not seasons_sorted and not team_strength_rows and (
+        snapshot.current_season is None
+        or not (snapshot.current_season.rosters or [])
+    ):
         return {
             "currentRanking": [],
             "weights": dict(WEIGHTS),
@@ -252,16 +369,17 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                 ap = all_play.get(oid) or {}
                 last_season_allplay_share[oid] = float(ap.get("expectedShare", 0.0))
 
-    owner_ids = sorted(career_state.keys())
+    owner_ids = _enumerate_owner_ids(
+        snapshot, team_strength_rows, sorted(career_state.keys())
+    )
     if not owner_ids:
         return {
             "currentRanking": [],
             "weights": dict(WEIGHTS),
-            "missingInputs": ["no owners played"],
+            "missingInputs": ["no owners found"],
             "rosTeamStrengthAvailable": False,
         }
 
-    team_strength_rows = _load_team_strength_rows()
     ros_pct = _load_team_strength_percentiles()
     ros_available = bool(ros_pct)
     roster_health_by_owner = _load_roster_health_scores(team_strength_rows)
@@ -269,10 +387,14 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     schedule_available = bool(schedule_by_owner)
     health_available = bool(roster_health_by_owner)
 
-    # Compute per-owner inputs.
+    # Compute per-owner inputs.  ``career_state`` is a defaultdict but
+    # we read via ``.get`` to avoid mutating it for owners (e.g. new
+    # league members for the upcoming season) who never appeared in
+    # historical play.  Their historical components default to zero;
+    # in preseason mode those weights are renormalised away anyway.
     inputs: dict[str, dict[str, float]] = {}
     for oid in owner_ids:
-        s = career_state[oid]
+        s = career_state.get(oid, _EMPTY_CAREER)
         ppg = s["points"] / s["games"] if s["games"] else 0.0
         rb = last_season_recent.get(oid, [])
         recent = sum(rb) / len(rb) if rb else 0.0
@@ -284,7 +406,6 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         # Luck regression: a team whose actualWins lag expectedWins
         # gets a small boost (regression toward expected).  Clamp to
         # [-0.5, 0.5] then map to [0, 1].
-        career_row = career_state[oid]
         # Re-walk the seasons to compute expectedWins (luck.py exposes
         # this via build_section but at PR-2 budget we'd rather not
         # invoke the whole section).  Re-use the same all_play share
@@ -319,7 +440,9 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
 
     # Renormalise weights when missing inputs are present so the score
     # stays in [0, 100] instead of being deflated by the unfilled
-    # 0.04 + 0.03 = 0.07 budget.
+    # weight budget.  Preseason / between-seasons drops the historical
+    # results components — they describe a finished year and don't
+    # project the upcoming one (see ``_is_preseason``).
     missing_inputs: list[str] = []
     if not ros_available:
         missing_inputs.append("team_ros_strength")
@@ -327,6 +450,10 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         missing_inputs.append("schedule_adjusted")
     if not health_available:
         missing_inputs.append("roster_health")
+    if preseason:
+        for component in _HISTORICAL_RESULTS_COMPONENTS:
+            if component not in missing_inputs:
+                missing_inputs.append(component)
     active_weights = {
         k: v for k, v in WEIGHTS.items() if k not in missing_inputs
     }
@@ -387,6 +514,8 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     return {
         "currentRanking": rankings,
         "weights": dict(WEIGHTS),
+        "effectiveWeights": dict(active_weights),
         "missingInputs": sorted(missing_inputs),
         "rosTeamStrengthAvailable": ros_available,
+        "preseason": preseason,
     }

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -230,44 +230,46 @@ def _enumerate_owner_ids(
 ) -> list[str]:
     """Canonical owner list for the rankings table.
 
-    Order of precedence (first match wins on display order — though
-    rows are re-sorted by power score before render):
+    Every source is filtered through ``snapshot.managers.by_owner_id``,
+    which is the authoritative active-owner registry: it's built from
+    the rosters the snapshot actually fetched and excludes the
+    operator-maintained retirement list.  The registry gate matters at
+    every step because each upstream source can carry a stale owner
+    around the season-transition window:
 
-      1. Owners present in the live team-strength snapshot AND still
-         in the manager registry.  The registry gate is essential: the
-         team-strength file is written by a scheduled scrape that may
-         lag the live Sleeper rosters (e.g. an owner left mid-week
-         and the team-strength file still names them).  Without this
-         filter a stale snapshot would push the table to 13+ rows in
-         a 12-team league.  The registry is built from the rosters
-         the snapshot actually fetched plus the operator-maintained
-         retirement list, so it's the authoritative "who's in the
-         league right now" answer.
-      2. Owners on the snapshot's current Sleeper season — covers the
-         case where the team-strength file is temporarily empty.
-      3. Owners with prior-season career history that the manager
-         registry still lists as active — defensive fallback so an
-         old participant who exists in history but not in either of
-         the live sources still appears.
+      * the team-strength snapshot is written by a scheduled scrape
+        and lags live rosters by a refresh cycle;
+      * Sleeper itself sometimes leaves a departed owner attached to
+        a roster slot until a new owner claims it, so even
+        ``snapshot.current_season.rosters`` can still carry them;
+      * historical participants who left the league have rows in past
+        ``career_state`` keys but should not appear in current rankings.
+
+    Order of precedence (for the dedup walk — rows are re-sorted by
+    power score before render):
+
+      1. Owners present in the live team-strength snapshot.
+      2. Owners on the snapshot's current Sleeper season — fallback
+         for an empty team-strength file.
+      3. Owners from prior-season career history — defensive fallback
+         so a registered manager who exists in history but is missing
+         from both live sources (e.g. mid-rejoin) still appears.
     """
     ordered: list[str] = []
     seen: set[str] = set()
+    registry_ids = snapshot.managers.by_owner_id
 
     def _add(oid: str | None) -> None:
         if not oid:
             return
         oid = str(oid).strip()
-        if not oid or oid in seen:
+        if not oid or oid in seen or oid not in registry_ids:
             return
         seen.add(oid)
         ordered.append(oid)
 
-    registry_ids = snapshot.managers.by_owner_id
-
     for row in team_strength_rows:
-        oid = str(row.get("ownerId") or "").strip()
-        if oid and oid in registry_ids:
-            _add(oid)
+        _add(row.get("ownerId"))
 
     current = snapshot.current_season
     if current is not None:
@@ -275,11 +277,7 @@ def _enumerate_owner_ids(
             _add(roster.get("owner_id"))
 
     for oid in historical_owner_ids:
-        # Only include historical owners who are still registered —
-        # retired managers are filtered out at registry build time, so
-        # falling through to ``by_owner_id`` keeps them out here too.
-        if oid in registry_ids:
-            _add(oid)
+        _add(oid)
 
     return ordered
 

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -233,9 +233,16 @@ def _enumerate_owner_ids(
     Order of precedence (first match wins on display order — though
     rows are re-sorted by power score before render):
 
-      1. Owners present in the live team-strength snapshot.  This is
-         the source of truth for "who is on a roster right now",
-         which is what the going-into-2026 table needs to show.
+      1. Owners present in the live team-strength snapshot AND still
+         in the manager registry.  The registry gate is essential: the
+         team-strength file is written by a scheduled scrape that may
+         lag the live Sleeper rosters (e.g. an owner left mid-week
+         and the team-strength file still names them).  Without this
+         filter a stale snapshot would push the table to 13+ rows in
+         a 12-team league.  The registry is built from the rosters
+         the snapshot actually fetched plus the operator-maintained
+         retirement list, so it's the authoritative "who's in the
+         league right now" answer.
       2. Owners on the snapshot's current Sleeper season — covers the
          case where the team-strength file is temporarily empty.
       3. Owners with prior-season career history that the manager
@@ -255,15 +262,18 @@ def _enumerate_owner_ids(
         seen.add(oid)
         ordered.append(oid)
 
+    registry_ids = snapshot.managers.by_owner_id
+
     for row in team_strength_rows:
-        _add(row.get("ownerId"))
+        oid = str(row.get("ownerId") or "").strip()
+        if oid and oid in registry_ids:
+            _add(oid)
 
     current = snapshot.current_season
     if current is not None:
         for roster in current.rosters or []:
             _add(roster.get("owner_id"))
 
-    registry_ids = snapshot.managers.by_owner_id
     for oid in historical_owner_ids:
         # Only include historical owners who are still registered —
         # retired managers are filtered out at registry build time, so

--- a/tests/ros/test_power_v2.py
+++ b/tests/ros/test_power_v2.py
@@ -325,6 +325,26 @@ class TestEnumerateOwnerIds(unittest.TestCase):
         ids = power_v2._enumerate_owner_ids(snapshot, [], ["retired"])
         self.assertNotIn("retired", ids)
 
+    def test_stale_team_strength_owner_filtered_against_registry(self):
+        # The team-strength file is written by a scheduled scrape and
+        # can lag the live snapshot.  If a manager leaves the league
+        # between scrapes, their ownerId stays in
+        # ``team_strength/latest.json`` until the next refresh — but
+        # they're already gone from the snapshot's current season and
+        # have been pruned from ``by_owner_id``.  Without this filter
+        # the rankings table would render an extra row past league
+        # size during the season-transition window.
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+        )
+        ts_rows = [
+            {"ownerId": "alpha"},      # registered, keep
+            {"ownerId": "departed"},   # stale entry, drop
+        ]
+        ids = power_v2._enumerate_owner_ids(snapshot, ts_rows, [])
+        self.assertIn("alpha", ids)
+        self.assertNotIn("departed", ids)
+
 
 class TestBuildSectionPreseason(unittest.TestCase):
     """End-to-end build for a going-into-2026 fixture.

--- a/tests/ros/test_power_v2.py
+++ b/tests/ros/test_power_v2.py
@@ -325,6 +325,27 @@ class TestEnumerateOwnerIds(unittest.TestCase):
         ids = power_v2._enumerate_owner_ids(snapshot, [], ["retired"])
         self.assertNotIn("retired", ids)
 
+    def test_unregistered_current_season_roster_owner_filtered(self):
+        # The current-season fallback also runs through the registry
+        # gate.  Sleeper sometimes leaves a departed owner attached to
+        # a roster slot through the transition window, and the
+        # registry's ``_RETIRED_OWNER_IDS`` filter is the canonical
+        # place to express "this owner_id has left the league".
+        # ``_enumerate_owner_ids`` must respect that — otherwise
+        # retired managers would re-surface in ROS rankings even after
+        # the operator added them to the retirement list.
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+        )
+        # Simulate a retired-but-still-on-roster owner: the snapshot
+        # has them on a roster but the registry build dropped them.
+        snapshot.current_season.rosters.append(
+            {"owner_id": "retired-but-rostered", "roster_id": 99}
+        )
+        ids = power_v2._enumerate_owner_ids(snapshot, [], [])
+        self.assertIn("alpha", ids)
+        self.assertNotIn("retired-but-rostered", ids)
+
     def test_stale_team_strength_owner_filtered_against_registry(self):
         # The team-strength file is written by a scheduled scrape and
         # can lag the live snapshot.  If a manager leaves the league

--- a/tests/ros/test_power_v2.py
+++ b/tests/ros/test_power_v2.py
@@ -6,10 +6,13 @@ graceful degradation when ROS team-strength snapshot is absent.
 from __future__ import annotations
 
 import json
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from src.public_league.identity import Manager, ManagerRegistry
+from src.public_league.snapshot import PublicLeagueSnapshot, SeasonSnapshot
 from src.ros import power_v2
 
 
@@ -168,6 +171,253 @@ class TestDisplayNameResolution(unittest.TestCase):
             "update power_v2.py to call it directly and remove this "
             "test — the bug it pins becomes irrelevant.",
         )
+
+
+def _make_season(
+    year: str,
+    league_id: str,
+    rosters: list[dict],
+    matchups_by_week: dict[int, list[dict]] | None = None,
+    *,
+    is_complete: bool = False,
+) -> SeasonSnapshot:
+    """Build a minimally-populated SeasonSnapshot for build_section tests."""
+    league = {
+        "league_id": league_id,
+        "season": year,
+        "season_type": "regular",
+        "settings": {"playoff_week_start": 15},
+        "total_rosters": len(rosters),
+    }
+    if is_complete:
+        league["status"] = "complete"
+    return SeasonSnapshot(
+        season=year,
+        league_id=league_id,
+        league=league,
+        users=[],
+        rosters=rosters,
+        matchups_by_week=matchups_by_week or {},
+        transactions_by_week={},
+        drafts=[],
+        draft_picks_by_draft={},
+        traded_picks=[],
+        winners_bracket=[],
+        losers_bracket=[],
+    )
+
+
+def _make_snapshot(
+    rosters: list[dict],
+    matchups_by_week: dict[int, list[dict]] | None = None,
+    *,
+    is_complete: bool = False,
+    season_year: str = "2026",
+) -> PublicLeagueSnapshot:
+    """Build a minimal snapshot whose ManagerRegistry is consistent with
+    the supplied rosters.  Each roster's owner_id is registered as an
+    active manager so ``_enumerate_owner_ids`` includes them.
+    """
+    registry = ManagerRegistry()
+    for r in rosters:
+        oid = str(r.get("owner_id") or "")
+        if not oid:
+            continue
+        registry.by_owner_id[oid] = Manager(owner_id=oid, display_name=oid)
+    season = _make_season(
+        season_year,
+        f"L{season_year}",
+        rosters,
+        matchups_by_week,
+        is_complete=is_complete,
+    )
+    return PublicLeagueSnapshot(
+        root_league_id=f"L{season_year}",
+        generated_at="2026-04-30T00:00:00Z",
+        seasons=[season],
+        managers=registry,
+    )
+
+
+class TestIsPreseason(unittest.TestCase):
+    def test_no_current_season_is_preseason(self):
+        snapshot = PublicLeagueSnapshot(
+            root_league_id="L1",
+            generated_at="2026-04-30T00:00:00Z",
+            seasons=[],
+            managers=ManagerRegistry(),
+        )
+        self.assertTrue(power_v2._is_preseason(snapshot))
+
+    def test_no_scored_matchups_is_preseason(self):
+        # A current season exists but no week has any scored matchups —
+        # going-into-the-new-year before any games kick off.
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+            matchups_by_week={1: [{"roster_id": 1, "points": 0}]},
+        )
+        self.assertTrue(power_v2._is_preseason(snapshot))
+
+    def test_completed_season_is_preseason(self):
+        # Last year is in the snapshot and marked complete — we're
+        # between seasons.  Even with prior scored games, this counts as
+        # going into the new year.
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+            matchups_by_week={1: [{"roster_id": 1, "points": 100}]},
+            is_complete=True,
+            season_year="2025",
+        )
+        self.assertTrue(power_v2._is_preseason(snapshot))
+
+    def test_in_progress_season_is_not_preseason(self):
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+            matchups_by_week={1: [{"roster_id": 1, "points": 110.4}]},
+        )
+        self.assertFalse(power_v2._is_preseason(snapshot))
+
+
+class TestEnumerateOwnerIds(unittest.TestCase):
+    def test_team_strength_takes_precedence(self):
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+        )
+        ts_rows = [
+            {"ownerId": "alpha"},
+            {"ownerId": "bravo"},
+        ]
+        snapshot.managers.by_owner_id["bravo"] = Manager(
+            owner_id="bravo", display_name="Bravo"
+        )
+        ids = power_v2._enumerate_owner_ids(snapshot, ts_rows, [])
+        self.assertEqual(ids, ["alpha", "bravo"])
+
+    def test_falls_through_to_current_season_rosters(self):
+        # Two new owners on the current Sleeper league; team_strength
+        # snapshot empty (e.g. ROS scrape hasn't run yet).
+        snapshot = _make_snapshot(
+            rosters=[
+                {"owner_id": "new1", "roster_id": 1},
+                {"owner_id": "new2", "roster_id": 2},
+            ],
+        )
+        ids = power_v2._enumerate_owner_ids(snapshot, [], [])
+        self.assertEqual(set(ids), {"new1", "new2"})
+
+    def test_includes_historical_owners_still_registered(self):
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+        )
+        snapshot.managers.by_owner_id["legacy"] = Manager(
+            owner_id="legacy", display_name="Legacy"
+        )
+        ids = power_v2._enumerate_owner_ids(snapshot, [], ["legacy"])
+        self.assertIn("legacy", ids)
+
+    def test_drops_unregistered_historical_owners(self):
+        # Retired owners are filtered out at registry build time, so
+        # historical-only owners that aren't in by_owner_id should not
+        # leak into the table.
+        snapshot = _make_snapshot(
+            rosters=[{"owner_id": "alpha", "roster_id": 1}],
+        )
+        ids = power_v2._enumerate_owner_ids(snapshot, [], ["retired"])
+        self.assertNotIn("retired", ids)
+
+
+class TestBuildSectionPreseason(unittest.TestCase):
+    """End-to-end build for a going-into-2026 fixture.
+
+    Twelve rosters in the current Sleeper league, two of them new owners
+    with no historical participation.  The team-strength snapshot lists
+    all twelve.  No regular-season matchups are scored.  Expected
+    behaviour:
+
+      * ``currentRanking`` returns 12 rows — every roster appears,
+        including the two newcomers.
+      * ``preseason`` is True.
+      * Historical-results components (PPG, recent, W/L, all-play, streak,
+        luck regression) all appear in ``missingInputs`` so they're
+        excluded from the score weighting.
+      * ``effectiveWeights`` only contains the forward-looking
+        components: team_ros_strength, roster_health, schedule_adjusted
+        (when available).
+    """
+
+    def test_twelve_owners_preseason(self):
+        rosters = [
+            {"owner_id": f"owner-{i:02d}", "roster_id": i}
+            for i in range(1, 13)
+        ]
+        # Two of the twelve are brand new — keep them out of the
+        # historical-careers walk by virtue of empty matchups.
+        snapshot = _make_snapshot(rosters=rosters)
+        ts_rows = [
+            {
+                "ownerId": f"owner-{i:02d}",
+                "teamRosStrength": 100 - i * 5,
+                "healthAvailabilityScore": 100,
+            }
+            for i in range(1, 13)
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            target = tmp_root / "team_strength" / "latest.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(ts_rows))
+            with patch.object(power_v2, "ROS_DATA_DIR", tmp_root):
+                section = power_v2.build_section(snapshot)
+
+        self.assertEqual(len(section["currentRanking"]), 12)
+        self.assertTrue(section["preseason"])
+        for component in power_v2._HISTORICAL_RESULTS_COMPONENTS:
+            self.assertIn(
+                component,
+                section["missingInputs"],
+                f"preseason should drop {component} from active weights",
+            )
+        # Forward-looking only in effectiveWeights.
+        eff = section["effectiveWeights"]
+        for component in power_v2._HISTORICAL_RESULTS_COMPONENTS:
+            self.assertNotIn(component, eff)
+        self.assertIn("team_ros_strength", eff)
+        self.assertIn("roster_health", eff)
+        # Each row carries a non-empty score (renormalised onto the
+        # forward-looking inputs, not deflated by the dropped weights).
+        scores = [row["powerScore"] for row in section["currentRanking"]]
+        self.assertTrue(all(s >= 0 for s in scores))
+        self.assertTrue(any(s > 0 for s in scores))
+
+    def test_in_progress_season_keeps_historical_components(self):
+        # Sanity check that the preseason gate doesn't always fire.
+        rosters = [{"owner_id": f"o{i}", "roster_id": i} for i in range(1, 4)]
+        matchups = {
+            1: [
+                {"roster_id": 1, "points": 110.0},
+                {"roster_id": 2, "points": 90.0},
+                {"roster_id": 3, "points": 85.0},
+            ],
+        }
+        snapshot = _make_snapshot(rosters=rosters, matchups_by_week=matchups)
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            target = tmp_root / "team_strength" / "latest.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps([
+                    {"ownerId": f"o{i}", "teamRosStrength": 50.0,
+                     "healthAvailabilityScore": 100}
+                    for i in range(1, 4)
+                ])
+            )
+            with patch.object(power_v2, "ROS_DATA_DIR", tmp_root):
+                section = power_v2.build_section(snapshot)
+        self.assertFalse(section["preseason"])
+        # Historical components should NOT have been auto-flagged
+        # missing in an active season.
+        for component in power_v2._HISTORICAL_RESULTS_COMPONENTS:
+            self.assertNotIn(component, section["missingInputs"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `/league` Power Rankings table going into the 2026 season had two problems visible in the screenshot:

1. **Only 10 of 12 owners appeared.** Owner enumeration came from `career_state.keys()` — the set of owners with past Sleeper match history. The two new managers replacing retired owners for 2026 had no career rows, so they silently dropped out.
2. **78% of the score was past-season results.** ROS roster strength was 38% of the formula; the other 62% came from 2025 PPG / W/L / recent form / all-play / streak / luck regression. None of those describe the 2026 season.

### Changes

**`src/ros/power_v2.py`**
- New `_enumerate_owner_ids` helper unions the team-strength snapshot (live Sleeper rosters), the current-season rosters, and historical-but-still-registered owners — guaranteeing every current roster appears.
- New `_is_preseason` helper detects "going into the new year" via either `current_season.is_complete` or zero scored regular-season matchups.
- In preseason mode, the historical-results components (`ppg`, `recent`, `wl_record`, `all_play`, `streak`, `luck_regression`) are routed through the existing `missing_inputs` path so the weight budget renormalises onto the forward-looking inputs (ROS strength, roster health, 2026 SOS when the schedule is loaded).
- Response now stamps `preseason: bool` and `effectiveWeights: dict[str, float]` so callers can tell what was actually applied.
- `career_state[oid]` access switched to `.get(oid, _EMPTY_CAREER)` to avoid the defaultdict mutating for owners with no history.

**`frontend/app/league/sections/ros-power.jsx`**
- Formula description in the header is now built dynamically from `effectiveWeights` (sorted by weight desc) instead of a hard-coded list — no more `"season PPG (18%)"` claim sitting next to a `Missing inputs: ppg` footer.
- Adds a "Going into the new season — only forward-looking inputs are used." banner when `preseason: true`.
- Per-row component bars use `row.weightsApplied || effectiveWeights` so dropped components don't render zero-width bars.

**`tests/ros/test_power_v2.py`**
- `TestIsPreseason` — covers empty snapshot, no-scored-matchups, completed-season, and in-progress paths.
- `TestEnumerateOwnerIds` — pins the team-strength → current-season-rosters → historical fallback order, plus the "retired-but-not-replaced owner is excluded" invariant.
- `TestBuildSectionPreseason` — end-to-end build for a 12-roster snapshot in preseason confirms 12 rows, `preseason: true`, every historical component in `missingInputs`, and `effectiveWeights` containing only forward-looking keys. Companion test verifies an in-progress season keeps the historical components.

## Test plan

- [x] `python3 -m pytest tests/ros/test_power_v2.py -q` — 25 passed
- [x] `python3 -m pytest tests/ros/ tests/public_league/ -q` — 343 passed, 22 skipped (no regressions)
- [ ] Manual: load `/league` → Power tab on the production snapshot, confirm all 12 rosters render and the description reads "Going into the new season — only forward-looking inputs are used. ROS roster strength (38%) + roster health (3%) + ..."
- [ ] Manual: confirm the two newly-added owners (replacing retired managers) show with their team-strength-derived score

https://claude.ai/code/session_016pDoMfPT5bmFzrTFHJT1fL

---
_Generated by [Claude Code](https://claude.ai/code/session_016pDoMfPT5bmFzrTFHJT1fL)_