### PR TITLE
feat(league-comparison): positional scoring-balance tool vs standard baseline

### DIFF
--- a/config/league_comparison.json
+++ b/config/league_comparison.json
@@ -1,0 +1,20 @@
+{
+  "version": "v1.0",
+  "my_league": {
+    "id": "1312736351547850752",
+    "label": "My League"
+  },
+  "baseline_league": {
+    "id": "1328545898812170240",
+    "label": "Standard Baseline"
+  },
+  "seasons": [2022, 2023, 2024, 2025],
+  "sample_sizes": {
+    "QB": 24,
+    "RB": 24,
+    "WR": 36,
+    "TE": 12,
+    "FLEX": 96,
+    "IDP_TOTAL": 96
+  }
+}

--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -50,6 +50,7 @@ const PRIMARY_NAV = [
   { href: "/draft", label: "Draft", hint: "Rookie draft prep + ADP" },
   { href: "/waivers", label: "Waivers", hint: "Add/drop analysis vs your roster" },
   { href: "/edge", label: "Edge", hint: "Where sources disagree most", groupBreak: true },
+  { href: "/league-comparison", label: "League Comp", hint: "Compare your league scoring vs a standard baseline" },
   {
     href: "/league",
     label: "League",

--- a/frontend/app/api/league-comparison/route.js
+++ b/frontend/app/api/league-comparison/route.js
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+/**
+ * Proxy GET /api/league-comparison to the FastAPI backend.
+ *
+ * The backend may need to fetch ~4 seasons × thousands of stat rows on
+ * a cold cache hit, so we use a generous 60s timeout instead of the
+ * default 5s.  Subsequent calls hit the 7-day disk cache and return
+ * immediately.
+ *
+ * Forwards the optional ``refresh`` query param so the user-facing
+ * "Recalculate" button can bypass the cache.
+ */
+export async function GET(request) {
+  try {
+    const url = new URL(request.url);
+    const refresh = url.searchParams.get("refresh");
+    const searchParams = refresh ? { refresh } : undefined;
+    const { data, status } = await proxyGet("/api/league-comparison", {
+      timeoutMs: 60000,
+      searchParams,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "League comparison service unavailable",
+        detail: err?.message || String(err),
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/league-comparison/page.jsx
+++ b/frontend/app/league-comparison/page.jsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import PageHeader from "@/components/ui/PageHeader";
+import SubNav from "@/components/ui/SubNav";
+import HeaderCard from "./sections/HeaderCard";
+import SummaryCards from "./sections/SummaryCards";
+import PositionalTable from "./sections/PositionalTable";
+import FlexComparison from "./sections/FlexComparison";
+import ComparisonCharts from "./sections/Charts";
+import YearByYear from "./sections/YearByYear";
+import Methodology from "./sections/Methodology";
+
+const TABS = [
+  { key: "summary", label: "Summary" },
+  { key: "positional", label: "Positional" },
+  { key: "flex", label: "Flex" },
+  { key: "yearly", label: "Year-by-Year" },
+  { key: "methodology", label: "Methodology" },
+];
+
+export default function LeagueComparisonPage() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [tab, setTab] = useState("summary");
+  const [method, setMethod] = useState("improved"); // "improved" | "legacy"
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async (refresh = false) => {
+    if (refresh) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      const url = refresh
+        ? "/api/league-comparison?refresh=1"
+        : "/api/league-comparison";
+      const res = await fetch(url, { cache: "no-store" });
+      const body = await res.json();
+      if (!res.ok) {
+        throw new Error(body?.detail || body?.error || `HTTP ${res.status}`);
+      }
+      setData(body);
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  const subtitle =
+    "Compares your custom league scoring against a standard baseline league " +
+    "to detect whether positional value gets accidentally distorted.";
+
+  return (
+    <section>
+      <PageHeader
+        title="League Comparison"
+        subtitle={subtitle}
+        actions={
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => load(true)}
+            disabled={loading || refreshing}
+            title="Bypass the cache and rebuild the comparison from scratch"
+          >
+            {refreshing ? "Recalculating…" : "Recalculate"}
+          </button>
+        }
+      />
+
+      {loading && (
+        <div className="card loading-state">
+          <div className="loading-spinner" />
+          <span className="muted text-sm">
+            Loading comparison data&hellip; (first hit may take 30+ seconds
+            while historical NFL stats download)
+          </span>
+        </div>
+      )}
+
+      {error && !loading && (
+        <div className="card">
+          <p className="text-red" style={{ fontWeight: 600 }}>
+            League comparison unavailable
+          </p>
+          <p className="muted text-sm" style={{ marginTop: 6 }}>{error}</p>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            style={{ marginTop: 12 }}
+            onClick={() => load(false)}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {data && !loading && (
+        <>
+          <HeaderCard data={data} />
+
+          {(data.warnings || []).length > 0 && (
+            <div className="card" style={{ borderColor: "var(--amber)" }}>
+              <p className="text-amber" style={{ fontWeight: 600 }}>
+                Notes &amp; warnings
+              </p>
+              <ul style={{ marginTop: 6, paddingLeft: 18 }}>
+                {data.warnings.map((w, i) => (
+                  <li key={i} className="muted text-sm" style={{ marginBottom: 4 }}>
+                    {w}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="card" style={{ paddingTop: "var(--space-sm)", paddingBottom: "var(--space-sm)" }}>
+            <SubNav items={TABS} active={tab} onChange={setTab} />
+          </div>
+
+          {tab === "summary" && (
+            <>
+              <SummaryCards data={data} method={method} setMethod={setMethod} />
+              <ComparisonCharts data={data} method={method} />
+            </>
+          )}
+
+          {tab === "positional" && (
+            <PositionalTable data={data} method={method} setMethod={setMethod} />
+          )}
+
+          {tab === "flex" && <FlexComparison data={data} />}
+
+          {tab === "yearly" && <YearByYear data={data} method={method} />}
+
+          {tab === "methodology" && <Methodology data={data} />}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/league-comparison/sections/Charts.jsx
+++ b/frontend/app/league-comparison/sections/Charts.jsx
@@ -1,0 +1,244 @@
+"use client";
+
+import {
+  CHART_COLORS,
+  chartBox,
+  formatNumber,
+  linearScale,
+} from "@/lib/chart-primitives";
+
+/**
+ * ComparisonCharts — pure-SVG charts for the summary tab.
+ *
+ * Three charts:
+ *   1. Grouped bar — standard vs my for QB/RB/WR/TE blended scores.
+ *   2. Stacked bar — positional share % per league.
+ *   3. Diff bar    — signed share differences by position.
+ */
+const POSITIONS = ["QB", "RB", "WR", "TE"];
+
+export default function ComparisonCharts({ data, method }) {
+  const positions = data?.positions || {};
+
+  const scoreSeries = POSITIONS.map((pos) => {
+    const c = positions[pos];
+    if (!c) return { pos, mine: 0, base: 0 };
+    return {
+      pos,
+      mine: method === "legacy" ? c.my?.legacyScore || 0 : c.my?.improvedScore || 0,
+      base: method === "legacy" ? c.baseline?.legacyScore || 0 : c.baseline?.improvedScore || 0,
+    };
+  });
+
+  const shareSeries = POSITIONS.map((pos) => {
+    const c = positions[pos];
+    if (!c) return { pos, mine: 0, base: 0 };
+    return {
+      pos,
+      mine: method === "legacy" ? c.my?.shareLegacy || 0 : c.my?.shareImproved || 0,
+      base: method === "legacy" ? c.baseline?.shareLegacy || 0 : c.baseline?.shareImproved || 0,
+    };
+  });
+
+  const diffSeries = POSITIONS.map((pos) => {
+    const c = positions[pos];
+    if (!c) return { pos, diff: 0 };
+    return {
+      pos,
+      diff: method === "legacy" ? c.diffPpLegacy || 0 : c.diffPpImproved || 0,
+    };
+  });
+
+  return (
+    <div className="card">
+      <h2 className="section-title">Charts</h2>
+      <div style={{ display: "grid", gap: "var(--space-md)", gridTemplateColumns: "1fr 1fr", marginTop: "var(--space-sm)" }}>
+        <ChartPanel title="Blended Score by Position">
+          <GroupedBarChart
+            rows={scoreSeries}
+            mineLabel="My League"
+            baseLabel="Standard"
+            valueFmt={(v) => formatNumber(v, 0)}
+          />
+        </ChartPanel>
+        <ChartPanel title="Positional Share (%)">
+          <GroupedBarChart
+            rows={shareSeries}
+            mineLabel="My League"
+            baseLabel="Standard"
+            valueFmt={(v) => `${formatNumber(v, 1)}%`}
+          />
+        </ChartPanel>
+        <ChartPanel title="Share Difference (pp)" wide>
+          <DiffBarChart rows={diffSeries} />
+        </ChartPanel>
+      </div>
+    </div>
+  );
+}
+
+function ChartPanel({ title, children, wide }) {
+  return (
+    <div style={{ gridColumn: wide ? "1 / -1" : "auto" }}>
+      <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5, marginBottom: 6 }}>
+        {title}
+      </div>
+      <div style={{ background: "rgba(0,0,0,0.15)", borderRadius: 6, padding: 8 }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ── Grouped bar chart ──────────────────────────────────────────────
+function GroupedBarChart({ rows, mineLabel = "Mine", baseLabel = "Base", valueFmt }) {
+  const width = 480;
+  const height = 220;
+  const { margin, innerWidth, innerHeight, viewBox, plotTransform } = chartBox({
+    width, height, margin: { top: 16, right: 16, bottom: 36, left: 44 },
+  });
+
+  const maxVal = Math.max(
+    ...rows.flatMap((r) => [r.mine, r.base]),
+    1,
+  );
+  const yScale = linearScale(0, maxVal, innerHeight, 0);
+  const groupW = innerWidth / Math.max(rows.length, 1);
+  const barW = (groupW - 12) / 2;
+
+  return (
+    <svg viewBox={viewBox} role="img" aria-label="Grouped bar chart" style={{ width: "100%", height: "auto" }}>
+      <g transform={plotTransform}>
+        {/* Y-axis */}
+        <line x1={0} x2={0} y1={0} y2={innerHeight} stroke={CHART_COLORS.axis} />
+        <line x1={0} x2={innerWidth} y1={innerHeight} y2={innerHeight} stroke={CHART_COLORS.axis} />
+        {[0, 0.25, 0.5, 0.75, 1].map((t, i) => {
+          const v = maxVal * t;
+          const y = yScale(v);
+          return (
+            <g key={i}>
+              <line x1={0} x2={innerWidth} y1={y} y2={y} stroke={CHART_COLORS.grid} strokeOpacity={0.5} />
+              <text x={-6} y={y + 3} textAnchor="end" fontSize={10} fill={CHART_COLORS.axisLabel}>
+                {valueFmt ? valueFmt(v) : formatNumber(v, 0)}
+              </text>
+            </g>
+          );
+        })}
+        {rows.map((r, i) => {
+          const cx = i * groupW + 6;
+          return (
+            <g key={r.pos}>
+              <rect
+                x={cx}
+                y={yScale(r.base)}
+                width={barW}
+                height={Math.max(0, innerHeight - yScale(r.base))}
+                fill={CHART_COLORS.accentMuted}
+              >
+                <title>{`${baseLabel} ${r.pos}: ${valueFmt ? valueFmt(r.base) : formatNumber(r.base, 1)}`}</title>
+              </rect>
+              <rect
+                x={cx + barW + 4}
+                y={yScale(r.mine)}
+                width={barW}
+                height={Math.max(0, innerHeight - yScale(r.mine))}
+                fill={CHART_COLORS.accent}
+              >
+                <title>{`${mineLabel} ${r.pos}: ${valueFmt ? valueFmt(r.mine) : formatNumber(r.mine, 1)}`}</title>
+              </rect>
+              <text
+                x={cx + barW + 2}
+                y={innerHeight + 14}
+                textAnchor="middle"
+                fontSize={11}
+                fill={CHART_COLORS.axisLabel}
+                fontWeight={600}
+              >
+                {r.pos}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+      {/* Legend */}
+      <g transform={`translate(${margin.left}, ${height - 8})`}>
+        <rect x={0} y={-8} width={10} height={10} fill={CHART_COLORS.accentMuted} />
+        <text x={14} y={1} fontSize={10} fill={CHART_COLORS.axisLabel}>{baseLabel}</text>
+        <rect x={70} y={-8} width={10} height={10} fill={CHART_COLORS.accent} />
+        <text x={84} y={1} fontSize={10} fill={CHART_COLORS.axisLabel}>{mineLabel}</text>
+      </g>
+    </svg>
+  );
+}
+
+// ── Signed difference bar chart ─────────────────────────────────────
+function DiffBarChart({ rows }) {
+  const width = 720;
+  const height = 200;
+  const { innerWidth, innerHeight, viewBox, plotTransform } = chartBox({
+    width, height, margin: { top: 12, right: 20, bottom: 36, left: 50 },
+  });
+
+  const maxAbs = Math.max(1, ...rows.map((r) => Math.abs(r.diff || 0)));
+  const xMid = innerHeight / 2;
+  const yScale = linearScale(-maxAbs, maxAbs, innerHeight, 0);
+  const barW = innerWidth / Math.max(rows.length, 1) - 16;
+
+  return (
+    <svg viewBox={viewBox} role="img" aria-label="Difference bar chart" style={{ width: "100%", height: "auto" }}>
+      <g transform={plotTransform}>
+        <line x1={0} x2={innerWidth} y1={xMid} y2={xMid} stroke={CHART_COLORS.axis} />
+        {rows.map((r, i) => {
+          const cx = i * (innerWidth / rows.length) + 8;
+          const y0 = yScale(0);
+          const y1 = yScale(r.diff);
+          const top = Math.min(y0, y1);
+          const h = Math.max(1, Math.abs(y1 - y0));
+          const color = Math.abs(r.diff) <= 0.5 ? CHART_COLORS.success
+                      : Math.abs(r.diff) <= 1.5 ? CHART_COLORS.accent
+                      : Math.abs(r.diff) <= 3   ? CHART_COLORS.warn
+                      :                            CHART_COLORS.danger;
+          return (
+            <g key={r.pos}>
+              <rect x={cx} y={top} width={barW} height={h} fill={color}>
+                <title>{`${r.pos}: ${r.diff >= 0 ? "+" : ""}${formatNumber(r.diff, 2)} pp`}</title>
+              </rect>
+              <text
+                x={cx + barW / 2}
+                y={innerHeight + 14}
+                textAnchor="middle"
+                fontSize={11}
+                fill={CHART_COLORS.axisLabel}
+                fontWeight={600}
+              >
+                {r.pos}
+              </text>
+              <text
+                x={cx + barW / 2}
+                y={r.diff >= 0 ? top - 3 : top + h + 11}
+                textAnchor="middle"
+                fontSize={10}
+                fill={color}
+              >
+                {(r.diff >= 0 ? "+" : "") + formatNumber(r.diff, 2)}
+              </text>
+            </g>
+          );
+        })}
+        {/* y-axis ticks */}
+        {[-maxAbs, -maxAbs / 2, 0, maxAbs / 2, maxAbs].map((v, i) => (
+          <text
+            key={i}
+            x={-8}
+            y={yScale(v) + 3}
+            textAnchor="end"
+            fontSize={10}
+            fill={CHART_COLORS.axisLabel}
+          >
+            {(v >= 0 ? "+" : "") + formatNumber(v, 1)}
+          </text>
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/frontend/app/league-comparison/sections/FlexComparison.jsx
+++ b/frontend/app/league-comparison/sections/FlexComparison.jsx
@@ -1,0 +1,92 @@
+"use client";
+
+/**
+ * FlexComparison — side-by-side detail for the Top-96 offensive flex
+ * pool (RB ∪ WR ∪ TE, QB excluded).  This tells you whether the broad
+ * flex value pool is balanced, which matters for lineup-construction
+ * value beyond the per-position tables.
+ */
+export default function FlexComparison({ data }) {
+  const flex = data?.flex;
+  if (!flex || !flex.my) {
+    return (
+      <div className="card">
+        <p className="muted">Flex comparison unavailable.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="card">
+      <h2 className="section-title">Top-96 Offensive Flex</h2>
+      <p className="muted text-sm" style={{ marginTop: 6, lineHeight: 1.5 }}>
+        Top-96 of the RB / WR / TE pool (QBs excluded), under each
+        league's actual scoring settings.  This is the broad "starter
+        pool" for lineup decisions — if your custom league inflates or
+        deflates this pool relative to a standard league, lineup value
+        construction shifts in ways that aren't visible from per-position
+        cards alone.
+      </p>
+
+      <div style={{ display: "grid", gap: "var(--space-md)", gridTemplateColumns: "1fr 1fr", marginTop: "var(--space-md)" }}>
+        <FlexBlock title="My League" flex={flex.my} accent="cyan" />
+        <FlexBlock title="Standard Baseline" flex={flex.baseline} accent="gold" />
+      </div>
+
+      <div className="card" style={{ marginTop: "var(--space-md)", background: "rgba(255,255,255,0.04)" }}>
+        <div className="text-sm" style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
+          <Stat label="Diff (Improved)" value={fmtSigned(flex.diffImproved)} />
+          <Stat label="Rel Diff" value={`${fmtSigned(flex.relDiffPct)}%`} />
+          <Stat label="Diff (Legacy)" value={fmtSigned(flex.diffLegacy)} />
+        </div>
+        <p className="text-sm" style={{ marginTop: 10 }}>{flex.interpretation}</p>
+      </div>
+    </div>
+  );
+}
+
+function FlexBlock({ title, flex, accent }) {
+  const color = accent === "gold" ? "var(--gold, #FFC704)" : "var(--cyan)";
+  const m = flex.metrics || {};
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-sm, 6px)", padding: "var(--space-sm)" }}>
+      <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5 }}>{title}</div>
+      <div style={{ fontSize: "1.4rem", fontWeight: 700, color, marginTop: 4 }}>
+        {fmt(flex.improvedScore)}
+        <span className="muted text-xs" style={{ marginLeft: 8, fontWeight: 400 }}>improved</span>
+      </div>
+      <div className="text-sm muted">
+        Legacy: <strong>{fmt(flex.legacyScore)}</strong>
+      </div>
+      <div className="text-xs" style={{ marginTop: 8, lineHeight: 1.7 }}>
+        <Stat inline label="Avg" value={fmt(m.average)} />
+        <Stat inline label="Med" value={fmt(m.median)} />
+        <Stat inline label="P25" value={fmt(m.p25)} />
+        <Stat inline label="P75" value={fmt(m.p75)} />
+        <Stat inline label="Repl" value={fmt(m.replacementLevel)} />
+        <Stat inline label="Elite" value={fmt(m.elite)} />
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, inline }) {
+  if (inline) {
+    return (
+      <span style={{ marginRight: 12 }}>
+        <span className="muted">{label}:</span> <strong style={{ fontFamily: "var(--mono)" }}>{value}</strong>
+      </span>
+    );
+  }
+  return (
+    <span>
+      <span className="muted">{label}:</span> <strong>{value}</strong>
+    </span>
+  );
+}
+
+function fmt(v) { return v == null ? "—" : Number(v).toFixed(1); }
+function fmtSigned(v) {
+  if (v == null) return "—";
+  const n = Number(v);
+  return `${n >= 0 ? "+" : ""}${n.toFixed(1)}`;
+}

--- a/frontend/app/league-comparison/sections/HeaderCard.jsx
+++ b/frontend/app/league-comparison/sections/HeaderCard.jsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * HeaderCard — top-of-page metadata block.
+ *
+ * Shows both league names + IDs (truncated for paranoid users), the
+ * seasons that were included vs unavailable, the version, and the
+ * generated-at timestamp.
+ */
+export default function HeaderCard({ data }) {
+  const meta = data?.meta || {};
+  const my = meta.myLeague || {};
+  const base = meta.baselineLeague || {};
+  const available = meta.seasonsAvailable || [];
+  const unavailable = meta.seasonsUnavailable || [];
+  const generatedAt = meta.generatedAt
+    ? new Date(meta.generatedAt).toLocaleString()
+    : "—";
+
+  return (
+    <div className="card">
+      <div style={{ display: "grid", gap: "var(--space-md)", gridTemplateColumns: "1fr 1fr" }}>
+        <LeagueBlock title="My League" league={my} accent="cyan" />
+        <LeagueBlock title="Standard Baseline" league={base} accent="gold" />
+      </div>
+
+      <div
+        style={{
+          marginTop: "var(--space-md)",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "var(--space-sm)",
+          fontSize: "0.85rem",
+        }}
+      >
+        <Tag label="Seasons included">
+          {available.length > 0 ? available.join(", ") : "—"}
+        </Tag>
+        {unavailable.length > 0 && (
+          <Tag label="Unavailable" tone="amber">
+            {unavailable.join(", ")}
+          </Tag>
+        )}
+        <Tag label="Version">{meta.version || "—"}</Tag>
+        <Tag label="Generated">{generatedAt}</Tag>
+        {meta.cacheHit && <Tag tone="muted">Cached</Tag>}
+        {!meta.cacheHit && meta.computeMs != null && (
+          <Tag tone="muted">Computed in {meta.computeMs} ms</Tag>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LeagueBlock({ title, league, accent }) {
+  const accentColor = accent === "gold" ? "var(--gold, #FFC704)" : "var(--cyan, #38bdf8)";
+  const id = league?.id || "";
+  const idTrunc = id ? `${id.slice(0, 6)}…${id.slice(-4)}` : "—";
+  return (
+    <div>
+      <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5 }}>
+        {title}
+      </div>
+      <div style={{ fontSize: "1.1rem", fontWeight: 700, color: accentColor, marginTop: 2 }}>
+        {league?.name || "(unnamed)"}
+      </div>
+      <div className="muted text-xs" style={{ marginTop: 2, fontFamily: "var(--mono)" }} title={id}>
+        {league?.label || ""} · ID {idTrunc} · hash {league?.scoringHash || "—"}
+      </div>
+    </div>
+  );
+}
+
+function Tag({ label, children, tone }) {
+  const color = tone === "amber" ? "var(--amber, #facc15)" : tone === "muted" ? "var(--muted)" : "var(--text)";
+  return (
+    <span
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm, 4px)",
+        padding: "4px 8px",
+        color,
+      }}
+    >
+      {label && <span className="muted" style={{ marginRight: 4 }}>{label}:</span>}
+      <strong>{children}</strong>
+    </span>
+  );
+}

--- a/frontend/app/league-comparison/sections/Methodology.jsx
+++ b/frontend/app/league-comparison/sections/Methodology.jsx
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * Methodology — explains the formulas and limitations to anyone
+ * inspecting the numbers.  Static text, but pulls live config values
+ * (sample sizes, seasons) from the data payload so the explanation
+ * always matches what was actually computed.
+ */
+export default function Methodology({ data }) {
+  const meta = data?.meta || {};
+  const samples = meta.sampleSizes || {};
+  const seasonsAvail = (meta.seasonsAvailable || []).join(", ") || "—";
+  const seasonsReq = (meta.seasonsRequested || []).join(", ") || "—";
+  const idp = data?.idp || {};
+
+  return (
+    <div className="card">
+      <h2 className="section-title">Methodology</h2>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>What this page does</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        For each league, we fetch its actual <code>scoring_settings</code>
+        directly from Sleeper, then apply those settings to historical NFL
+        weekly stats from nflverse to compute fantasy points <em>under that
+        league's own rules</em>.  We then sample the top performers per
+        position, summarize the distribution, and compare the two leagues
+        to see whether your custom scoring keeps positional value reasonably
+        aligned with a standard baseline.
+      </p>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Sample sizes</h3>
+      <ul className="text-sm" style={{ paddingLeft: 20, lineHeight: 1.6 }}>
+        <li>Top {samples.QB || 24} QBs</li>
+        <li>Top {samples.RB || 24} RBs</li>
+        <li>Top {samples.WR || 36} WRs</li>
+        <li>Top {samples.TE || 12} TEs</li>
+        <li>Top {samples.FLEX || 96} offensive flex (RB ∪ WR ∪ TE, QBs excluded)</li>
+      </ul>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Seasons</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        Requested: <strong>{seasonsReq}</strong>. Available: <strong>{seasonsAvail}</strong>.
+        Each available season is weighted <strong>equally</strong> in the
+        combined result — no recency weighting.  If a season is missing
+        from the upstream data source, the remaining seasons each absorb
+        its weight proportionally (e.g. 3 seasons → each counts 1/3).
+      </p>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Position metrics (per top-N sample)</h3>
+      <ul className="text-sm" style={{ paddingLeft: 20, lineHeight: 1.6 }}>
+        <li><strong>Average</strong> — mean fantasy points</li>
+        <li><strong>Median</strong> — 50th-percentile fantasy points</li>
+        <li><strong>P25 / P75</strong> — 25th / 75th percentile</li>
+        <li><strong>Replacement level</strong> — the Nth player's points (e.g. QB24)</li>
+        <li><strong>Elite</strong> — mean of the top 3</li>
+        <li><strong>Replacement-adjusted</strong> — average minus replacement level (separation between starters and the bottom of the pool)</li>
+      </ul>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Blended scores — two methods</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        Both are computed and shown side-by-side:
+      </p>
+      <ul className="text-sm" style={{ paddingLeft: 20, lineHeight: 1.6 }}>
+        <li>
+          <strong>Legacy / Simple:</strong> <code>(average + median) / 2</code> —
+          the original heuristic, preserved as a reference.
+        </li>
+        <li>
+          <strong>Improved:</strong>{" "}
+          <code>0.35·median + 0.25·average + 0.20·P75 + 0.10·P25 + 0.10·replacement_adj</code>{" "}
+          — more robust because the median anchors central tendency, the
+          percentiles capture distribution shape, and the replacement-adjusted
+          term rewards positions whose starters are well-separated from the
+          replacement-level player.
+        </li>
+      </ul>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Positional shares</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        For each league, every position's blended score is divided by the
+        total of all four positions to get a percentage share.  We then
+        compare your share against the baseline share — both as an absolute
+        difference (in percentage points) and as a relative percentage.
+      </p>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Status labels</h3>
+      <ul className="text-sm" style={{ paddingLeft: 20, lineHeight: 1.6 }}>
+        <li>≤ 0.5 pp difference — <strong>Excellent match</strong></li>
+        <li>≤ 1.5 pp — <strong>Good match</strong></li>
+        <li>≤ 3.0 pp — <strong>Slightly high / Slightly low</strong></li>
+        <li>≤ 5.0 pp — <strong>High / Low</strong></li>
+        <li>&gt; 5.0 pp — <strong>Too high / Too low</strong></li>
+      </ul>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Similarity score (0..100)</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        Total share deviation across QB/RB/WR/TE (sum of absolute differences
+        in percentage points), plus 0.4× the relative flex-pool deviation,
+        mapped through these bands:
+      </p>
+      <ul className="text-sm" style={{ paddingLeft: 20, lineHeight: 1.6 }}>
+        <li>≤ 2 → <strong>95–100</strong> · Extremely close · distortion: Low</li>
+        <li>≤ 5 → <strong>85–94</strong> · Very close · distortion: Low</li>
+        <li>≤ 10 → <strong>75–84</strong> · Some noticeable differences · distortion: Moderate</li>
+        <li>≤ 20 → <strong>60–74</strong> · Meaningfully different · distortion: High</li>
+        <li>&gt; 20 → <strong>&lt; 60</strong> · Very distorted · distortion: Severe</li>
+      </ul>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>IDP comparison</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        IDP is <strong>scaffolded but not yet enabled</strong>. {idp.message}
+      </p>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Known limitations</h3>
+      <ul className="text-sm" style={{ paddingLeft: 20, lineHeight: 1.6 }}>
+        <li>Compares fantasy <em>points</em> only — not usage, opportunity, or roster construction.</li>
+        <li>Kickers and team defenses are excluded — out of scope for positional balance.</li>
+        <li>Sleeper scoring keys not modeled by the engine (rare custom bonuses) are zeroed; these are listed in the warnings panel above when present and non-zero.</li>
+        <li>2025 season availability depends on nflverse publishing — the page degrades gracefully when a season is missing.</li>
+        <li>Recommendations are heuristic culprit-hints, not prescriptive — they never auto-modify scoring settings.</li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/app/league-comparison/sections/PositionalTable.jsx
+++ b/frontend/app/league-comparison/sections/PositionalTable.jsx
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * PositionalTable — main comparison grid.
+ *
+ * Columns: Position, Standard score, My score, Standard share, My share,
+ * Diff (pp), Rel diff (%), Status, Recommendation.  Method toggle
+ * controls whether legacy or improved values populate each row.
+ */
+const POSITIONS = ["QB", "RB", "WR", "TE"];
+
+export default function PositionalTable({ data, method, setMethod }) {
+  const positions = data?.positions || {};
+
+  return (
+    <div className="card">
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 8 }}>
+        <h2 className="section-title" style={{ margin: 0 }}>Positional Comparison</h2>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button
+            type="button"
+            className={`btn btn-secondary ${method === "improved" ? "active" : ""}`}
+            onClick={() => setMethod("improved")}
+            style={method === "improved" ? { borderColor: "var(--cyan)", color: "var(--cyan)" } : {}}
+          >
+            Improved
+          </button>
+          <button
+            type="button"
+            className={`btn btn-secondary ${method === "legacy" ? "active" : ""}`}
+            onClick={() => setMethod("legacy")}
+            style={method === "legacy" ? { borderColor: "var(--cyan)", color: "var(--cyan)" } : {}}
+          >
+            Legacy
+          </button>
+        </div>
+      </div>
+
+      <div className="table-wrap" style={{ marginTop: "var(--space-sm)" }}>
+        <table>
+          <thead>
+            <tr>
+              <th>Pos</th>
+              <th style={{ textAlign: "right" }}>Standard Score</th>
+              <th style={{ textAlign: "right" }}>My Score</th>
+              <th style={{ textAlign: "right" }}>Standard Share</th>
+              <th style={{ textAlign: "right" }}>My Share</th>
+              <th style={{ textAlign: "right" }}>Diff (pp)</th>
+              <th style={{ textAlign: "right" }}>Rel %</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {POSITIONS.map((pos) => {
+              const c = positions[pos];
+              if (!c) {
+                return (
+                  <tr key={pos}>
+                    <td>{pos}</td>
+                    <td colSpan={7} className="muted">—</td>
+                  </tr>
+                );
+              }
+              const myScore = method === "legacy" ? c.my?.legacyScore : c.my?.improvedScore;
+              const baseScore = method === "legacy" ? c.baseline?.legacyScore : c.baseline?.improvedScore;
+              const myShare = method === "legacy" ? c.my?.shareLegacy : c.my?.shareImproved;
+              const baseShare = method === "legacy" ? c.baseline?.shareLegacy : c.baseline?.shareImproved;
+              const diff = method === "legacy" ? c.diffPpLegacy : c.diffPpImproved;
+              const tone = diffTone(diff);
+              return (
+                <tr key={pos}>
+                  <td style={{ fontWeight: 700 }}>{pos}</td>
+                  <td style={mono()}>{fmt(baseScore)}</td>
+                  <td style={mono()}>{fmt(myScore)}</td>
+                  <td style={mono()}>{fmtPct(baseShare)}</td>
+                  <td style={mono()}>{fmtPct(myShare)}</td>
+                  <td style={{ ...mono(), color: tone }}>{fmtSigned(diff)}</td>
+                  <td style={{ ...mono(), color: tone }}>{fmtSigned(c.relDiffPct)}%</td>
+                  <td style={{ color: tone }}>{c.status}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ marginTop: "var(--space-md)" }}>
+        <h3 className="section-title" style={{ fontSize: "1rem" }}>Recommendations</h3>
+        <ul style={{ marginTop: 6, paddingLeft: 18 }}>
+          {POSITIONS.map((pos) => {
+            const c = positions[pos];
+            if (!c) return null;
+            return (
+              <li key={pos} className="text-sm" style={{ marginBottom: 6 }}>
+                {c.recommendation}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function diffTone(diff) {
+  const d = Math.abs(Number(diff) || 0);
+  if (d <= 0.5) return "var(--green, #22c55e)";
+  if (d <= 1.5) return "var(--cyan)";
+  if (d <= 3) return "var(--amber)";
+  return "var(--red, #ef4444)";
+}
+
+function fmt(v) { return v == null ? "—" : Number(v).toFixed(1); }
+function fmtPct(v) { return v == null ? "—" : `${Number(v).toFixed(1)}%`; }
+function fmtSigned(v) {
+  if (v == null) return "—";
+  const n = Number(v);
+  return `${n >= 0 ? "+" : ""}${n.toFixed(1)}`;
+}
+function mono() { return { textAlign: "right", fontFamily: "var(--mono)" }; }

--- a/frontend/app/league-comparison/sections/SummaryCards.jsx
+++ b/frontend/app/league-comparison/sections/SummaryCards.jsx
@@ -1,0 +1,208 @@
+"use client";
+
+/**
+ * SummaryCards — high-density at-a-glance scorecard.
+ *
+ * Renders:
+ *   • Similarity Score (big number 0..100 + label + distortion tag)
+ *   • Per-position match cards (QB / RB / WR / TE / Flex)
+ *   • Biggest Difference + Closest Match callouts
+ *
+ * Method toggle (improved vs legacy) lives at the top so the user
+ * can see how the two formulas compare without leaving the page.
+ */
+export default function SummaryCards({ data, method, setMethod }) {
+  const sim = data?.similarity || {};
+  const summary = data?.summary || {};
+  const positions = data?.positions || {};
+  const flex = data?.flex || {};
+
+  const score = sim.score ?? 0;
+  const scoreColor =
+    score >= 95 ? "var(--green, #22c55e)" :
+    score >= 85 ? "var(--green, #22c55e)" :
+    score >= 75 ? "var(--amber, #facc15)" :
+    score >= 60 ? "var(--orange, #f97316)" :
+                  "var(--red, #ef4444)";
+
+  return (
+    <>
+      <div className="card" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5 }}>Method</div>
+          <div style={{ display: "flex", gap: 6, marginTop: 6 }}>
+            <button
+              type="button"
+              className={`btn btn-secondary ${method === "improved" ? "active" : ""}`}
+              onClick={() => setMethod("improved")}
+              style={method === "improved" ? { borderColor: "var(--cyan)", color: "var(--cyan)" } : {}}
+            >
+              Improved
+            </button>
+            <button
+              type="button"
+              className={`btn btn-secondary ${method === "legacy" ? "active" : ""}`}
+              onClick={() => setMethod("legacy")}
+              style={method === "legacy" ? { borderColor: "var(--cyan)", color: "var(--cyan)" } : {}}
+            >
+              Legacy (avg+median)/2
+            </button>
+          </div>
+        </div>
+        <div className="muted text-xs" style={{ maxWidth: 360, lineHeight: 1.5 }}>
+          {method === "improved"
+            ? "Multi-signal blend of median, average, percentiles, and replacement-adjusted value."
+            : "Original simple formula — average and median averaged together. Useful as a sanity-check reference."}
+        </div>
+      </div>
+
+      <div className="card" style={{ display: "grid", gap: "var(--space-md)", gridTemplateColumns: "minmax(180px, 1fr) 2fr" }}>
+        <div style={{ textAlign: "center", padding: "var(--space-md) 0" }}>
+          <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5 }}>
+            Similarity Score
+          </div>
+          <div style={{ fontSize: "3.5rem", fontWeight: 800, color: scoreColor, lineHeight: 1, marginTop: 6 }}>
+            {score}
+          </div>
+          <div style={{ fontSize: "0.95rem", marginTop: 4 }}>{sim.label || "—"}</div>
+          <div className="muted text-xs" style={{ marginTop: 4 }}>
+            Distortion: <strong>{sim.distortionLabel || "—"}</strong>
+          </div>
+        </div>
+
+        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))" }}>
+          <PositionMatchCard pos="QB" comp={positions.QB} method={method} />
+          <PositionMatchCard pos="RB" comp={positions.RB} method={method} />
+          <PositionMatchCard pos="WR" comp={positions.WR} method={method} />
+          <PositionMatchCard pos="TE" comp={positions.TE} method={method} />
+          <FlexMatchCard flex={flex} />
+        </div>
+      </div>
+
+      <div className="card" style={{ display: "grid", gap: "var(--space-md)", gridTemplateColumns: "1fr 1fr" }}>
+        <Callout
+          label="Biggest Difference"
+          value={summary.biggestDiffPosition || "—"}
+          tone="amber"
+          detail={
+            summary.biggestDiffPosition
+              ? `Status: ${positions[summary.biggestDiffPosition]?.status}`
+              : "All positions are aligned"
+          }
+        />
+        <Callout
+          label="Closest Match"
+          value={summary.closestMatchPosition || "—"}
+          tone="green"
+          detail={
+            summary.closestMatchPosition
+              ? `Status: ${positions[summary.closestMatchPosition]?.status}`
+              : ""
+          }
+        />
+      </div>
+    </>
+  );
+}
+
+function PositionMatchCard({ pos, comp, method }) {
+  if (!comp) {
+    return (
+      <div style={cardBoxStyle()}>
+        <div className="muted text-xs">{pos}</div>
+        <div className="muted">—</div>
+      </div>
+    );
+  }
+  const diff = method === "legacy" ? comp.diffPpLegacy : comp.diffPpImproved;
+  const myShare = method === "legacy" ? comp.my?.shareLegacy : comp.my?.shareImproved;
+  const baseShare = method === "legacy" ? comp.baseline?.shareLegacy : comp.baseline?.shareImproved;
+  const tone = absDiffTone(diff);
+  return (
+    <div style={cardBoxStyle()}>
+      <div className="muted text-xs" style={{ textTransform: "uppercase" }}>{pos}</div>
+      <div style={{ fontSize: "0.95rem", color: tone, marginTop: 4 }}>
+        {comp.status}
+      </div>
+      <div className="text-xs muted" style={{ marginTop: 6 }}>
+        Mine: {fmtPct(myShare)} &nbsp;·&nbsp; Base: {fmtPct(baseShare)}
+      </div>
+      <div className="text-xs" style={{ color: tone, marginTop: 2 }}>
+        Δ {fmtSigned(diff)} pp
+      </div>
+    </div>
+  );
+}
+
+function FlexMatchCard({ flex }) {
+  if (!flex || !flex.my) {
+    return (
+      <div style={cardBoxStyle()}>
+        <div className="muted text-xs">FLEX</div>
+        <div className="muted">—</div>
+      </div>
+    );
+  }
+  const tone = absDiffTone(flex.relDiffPct, { lo: 1, mid: 5 });
+  return (
+    <div style={cardBoxStyle()}>
+      <div className="muted text-xs" style={{ textTransform: "uppercase" }}>Top-96 Flex</div>
+      <div className="text-xs" style={{ marginTop: 6 }}>
+        Mine: {fmtNum(flex.my.improvedScore)}
+      </div>
+      <div className="text-xs" style={{ marginTop: 2 }}>
+        Base: {fmtNum(flex.baseline.improvedScore)}
+      </div>
+      <div className="text-xs" style={{ color: tone, marginTop: 2 }}>
+        Δ {fmtSigned(flex.relDiffPct)}%
+      </div>
+    </div>
+  );
+}
+
+function Callout({ label, value, tone, detail }) {
+  const color = tone === "amber" ? "var(--amber)" : tone === "green" ? "var(--green, #22c55e)" : "var(--text)";
+  return (
+    <div style={cardBoxStyle()}>
+      <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5 }}>
+        {label}
+      </div>
+      <div style={{ fontSize: "1.6rem", fontWeight: 700, color, marginTop: 4 }}>
+        {value}
+      </div>
+      {detail && <div className="muted text-xs" style={{ marginTop: 4 }}>{detail}</div>}
+    </div>
+  );
+}
+
+function cardBoxStyle() {
+  return {
+    background: "rgba(255,255,255,0.03)",
+    border: "1px solid var(--border)",
+    borderRadius: "var(--radius-sm, 6px)",
+    padding: "var(--space-sm)",
+  };
+}
+
+function absDiffTone(diff, bands) {
+  const b = bands || { lo: 0.5, mid: 1.5, hi: 3 };
+  const d = Math.abs(Number(diff) || 0);
+  if (d <= b.lo) return "var(--green, #22c55e)";
+  if (d <= b.mid) return "var(--cyan)";
+  if (d <= (b.hi || 3)) return "var(--amber)";
+  return "var(--red, #ef4444)";
+}
+
+function fmtPct(v) {
+  if (v == null) return "—";
+  return `${Number(v).toFixed(1)}%`;
+}
+function fmtNum(v) {
+  if (v == null) return "—";
+  return Number(v).toFixed(1);
+}
+function fmtSigned(v) {
+  if (v == null) return "—";
+  const n = Number(v);
+  return `${n >= 0 ? "+" : ""}${n.toFixed(1)}`;
+}

--- a/frontend/app/league-comparison/sections/YearByYear.jsx
+++ b/frontend/app/league-comparison/sections/YearByYear.jsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * YearByYear — collapsible per-season detail.  For each available
+ * season, shows a per-position comparison table plus a flex line.
+ */
+const POSITIONS = ["QB", "RB", "WR", "TE"];
+
+export default function YearByYear({ data }) {
+  const bySeason = data?.bySeason || {};
+  const seasons = Object.keys(bySeason).sort().reverse(); // newest first
+  const [openSeason, setOpenSeason] = useState(seasons[0] || null);
+
+  if (seasons.length === 0) {
+    return (
+      <div className="card">
+        <p className="muted">No per-season data available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card">
+      <h2 className="section-title">Year-by-Year Detail</h2>
+      <p className="muted text-sm" style={{ marginTop: 6 }}>
+        Each season is computed independently and then equally averaged for the
+        combined view.  Click a season to expand its detailed breakdown.
+      </p>
+      <div style={{ marginTop: "var(--space-sm)", display: "flex", flexDirection: "column", gap: 8 }}>
+        {seasons.map((season) => (
+          <SeasonRow
+            key={season}
+            season={season}
+            block={bySeason[season]}
+            open={openSeason === season}
+            onToggle={() => setOpenSeason(openSeason === season ? null : season)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SeasonRow({ season, block, open, onToggle }) {
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: 6, overflow: "hidden" }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "10px 14px",
+          background: "rgba(255,255,255,0.04)",
+          border: "none",
+          color: "var(--text)",
+          cursor: "pointer",
+          fontSize: "1rem",
+          fontWeight: 700,
+        }}
+      >
+        <span>Season {season}</span>
+        <span className="muted">{open ? "▼" : "▸"}</span>
+      </button>
+      {open && (
+        <div style={{ padding: "var(--space-sm)" }}>
+          <SeasonTables block={block} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SeasonTables({ block }) {
+  if (!block) return <p className="muted">No data for this season.</p>;
+  const my = block.my || {};
+  const base = block.baseline || {};
+  return (
+    <div style={{ display: "grid", gap: "var(--space-md)", gridTemplateColumns: "1fr 1fr" }}>
+      <SeasonSide title="My League" data={my} accent="cyan" />
+      <SeasonSide title="Standard Baseline" data={base} accent="gold" />
+    </div>
+  );
+}
+
+function SeasonSide({ title, data, accent }) {
+  const color = accent === "gold" ? "var(--gold, #FFC704)" : "var(--cyan)";
+  const positions = data.positions || {};
+  const flex = data.flex || {};
+  const top = (data.topPlayers || []).slice(0, 8);
+  return (
+    <div>
+      <div style={{ fontWeight: 700, color, marginBottom: 6 }}>{title}</div>
+      <div className="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Pos</th>
+              <th style={{ textAlign: "right" }}>Avg</th>
+              <th style={{ textAlign: "right" }}>Med</th>
+              <th style={{ textAlign: "right" }}>P25</th>
+              <th style={{ textAlign: "right" }}>P75</th>
+              <th style={{ textAlign: "right" }}>Repl</th>
+              <th style={{ textAlign: "right" }}>n</th>
+            </tr>
+          </thead>
+          <tbody>
+            {POSITIONS.map((pos) => {
+              const m = positions[pos];
+              if (!m) return null;
+              return (
+                <tr key={pos}>
+                  <td style={{ fontWeight: 600 }}>{pos}</td>
+                  <td style={mono()}>{fmt(m.average)}</td>
+                  <td style={mono()}>{fmt(m.median)}</td>
+                  <td style={mono()}>{fmt(m.p25)}</td>
+                  <td style={mono()}>{fmt(m.p75)}</td>
+                  <td style={mono()}>{fmt(m.replacementLevel)}</td>
+                  <td style={mono()}>{m.sampleSize}</td>
+                </tr>
+              );
+            })}
+            <tr>
+              <td style={{ fontWeight: 600 }}>FLEX</td>
+              <td style={mono()}>{fmt(flex.average)}</td>
+              <td style={mono()}>{fmt(flex.median)}</td>
+              <td style={mono()}>{fmt(flex.p25)}</td>
+              <td style={mono()}>{fmt(flex.p75)}</td>
+              <td style={mono()}>{fmt(flex.replacementLevel)}</td>
+              <td style={mono()}>{flex.sampleSize || 0}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {top.length > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5 }}>
+            Top players (this league's scoring)
+          </div>
+          <ol className="text-xs" style={{ marginTop: 4, paddingLeft: 20, lineHeight: 1.7 }}>
+            {top.map((p) => (
+              <li key={p.playerId}>
+                <strong>{p.name}</strong>{" "}
+                <span className="muted">({p.position})</span>{" "}
+                <span style={{ fontFamily: "var(--mono)" }}>{fmt(p.totalPoints)} pts</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function fmt(v) { return v == null ? "—" : Number(v).toFixed(1); }
+function mono() { return { textAlign: "right", fontFamily: "var(--mono)" }; }

--- a/server.py
+++ b/server.py
@@ -2930,6 +2930,73 @@ async def get_leagues(request: Request):
     return JSONResponse(content=body, headers={"Cache-Control": "no-store"})
 
 
+# ── League Comparison ─────────────────────────────────────────────────
+# Compares one custom-scoring Sleeper league against a "standard"
+# baseline league across multiple historical NFL seasons.  Read-only
+# analysis tool — does NOT route through the league registry; the two
+# league IDs come from config/league_comparison.json server-side, the
+# UI never sends raw Sleeper IDs in requests.  See
+# src/league_comparison/service.py for the full pipeline.
+@app.get("/api/league-comparison")
+async def get_league_comparison(request: Request):
+    """Build the positional-balance comparison between the two
+    configured leagues across the configured seasons.
+
+    Query params:
+      * ``refresh`` — if "1"/"true", bypass the 7-day disk cache and
+        recompute (also bypasses the 1h scoring-settings cache so a
+        commissioner edit propagates immediately).
+
+    Errors:
+      * 503 — Sleeper unreachable or scoring_settings missing for one
+        of the configured leagues.
+      * 500 — internal failure during computation.
+    """
+    refresh_raw = (request.query_params.get("refresh") or "").strip().lower()
+    refresh = refresh_raw in ("1", "true", "yes", "on")
+    try:
+        from src.league_comparison import service as _lc_service
+        payload = await run_in_threadpool(
+            _lc_service.build_comparison, refresh=refresh,
+        )
+    except FileNotFoundError as exc:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "league_comparison_misconfigured",
+                "detail": str(exc),
+            },
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError) as exc:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "sleeper_unreachable",
+                "detail": str(exc),
+            },
+        )
+    except ValueError as exc:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "league_data_unavailable",
+                "detail": str(exc),
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger(__name__).exception("league_comparison_failed")
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "league_comparison_failed",
+                "detail": str(exc),
+            },
+        )
+    return JSONResponse(
+        content=payload,
+        headers={"Cache-Control": "public, max-age=300, stale-while-revalidate=3600"},
+    )
+
 
 @app.get("/api/status")
 async def get_status():

--- a/src/league_comparison/__init__.py
+++ b/src/league_comparison/__init__.py
@@ -1,0 +1,42 @@
+"""League Comparison — positional scoring-balance calibration tool.
+
+Compares the user's custom Sleeper league scoring against a "standard"
+baseline league across multiple historical NFL seasons.  The goal is
+to detect whether custom scoring rules accidentally distort positional
+value relative to a normal fantasy environment.
+
+Public entry point: :func:`src.league_comparison.service.build_comparison`
+which returns a fully-built ComparisonResult dict ready to be returned
+by ``GET /api/league-comparison``.
+
+Architecture
+------------
+* ``sleeper_scoring`` — fetches ``scoring_settings`` for arbitrary
+  Sleeper league IDs (bypasses the registry — this tool deliberately
+  decouples from multi-league routing).
+* ``historical_stats`` — wraps ``src.nfl_data.ingest`` to load weekly
+  stat rows season-by-season with graceful unavailability handling.
+* ``scoring_engine`` — applies a Sleeper scoring dict to weekly stat
+  rows using the existing ``compute_weekly_points`` engine and rolls
+  up to season totals per player.
+* ``metrics`` — pure stat math: average / median / percentiles /
+  blended scores (legacy + improved) / positional shares /
+  similarity score / status labels.
+* ``idp`` — placeholder hooks for IDP comparison (Top-96 IDP vs
+  Top-96 offensive flex); inert until real IDP data is verified.
+* ``service`` — orchestrator that ties everything together with a
+  7-day disk cache keyed on league IDs + scoring hashes + version.
+
+Why this is decoupled from the league registry
+----------------------------------------------
+The two leagues being compared are NOT the user's active league
+(rosters, draft capital, etc).  They're two *scoring profiles*
+to compare for calibration purposes only.  Pushing them through
+``src.api.league_registry`` would force them to be added to
+``config/leagues/registry.json`` even though this feature never
+needs rosters, teams, or any other registry-bound data.
+
+The endpoint returns league IDs only in its response metadata block;
+the request body never carries them — IDs come from
+``config/league_comparison.json`` server-side.
+"""

--- a/src/league_comparison/historical_stats.py
+++ b/src/league_comparison/historical_stats.py
@@ -1,0 +1,57 @@
+"""Load historical NFL weekly stat rows for the seasons we want to
+compare.
+
+Wraps :func:`src.nfl_data.ingest.fetch_weekly_stats` season-by-season
+so we get clean per-season availability information — if 2025 hasn't
+been published yet by nflverse, we want to gracefully degrade to the
+three available seasons rather than corrupting the comparison.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.nfl_data import ingest as _ingest
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def load_season_rows(season: int) -> list[dict[str, Any]] | None:
+    """Return weekly stat rows for ``season``, or ``None`` if unavailable.
+
+    A season is considered unavailable when the upstream fetcher returns
+    an empty list — this happens when nflverse hasn't published the
+    season yet, or when the feature flag is off.  We return None (not
+    an empty list) so callers can distinguish "no data" from "zero
+    players scored anything", which matters for the seasons-included
+    metadata block.
+    """
+    try:
+        rows = _ingest.fetch_weekly_stats([int(season)])
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("league_compare.season_fetch_failed season=%s err=%r", season, exc)
+        return None
+    if not rows:
+        _LOGGER.info("league_compare.season_unavailable season=%s", season)
+        return None
+    return rows
+
+
+def load_all_seasons(seasons: list[int]) -> dict[int, list[dict[str, Any]] | None]:
+    """Fan out to load every requested season; preserve order.
+
+    Returns a dict ``{season: rows | None}`` so the orchestrator can
+    report which seasons were included and which were unavailable.
+    """
+    out: dict[int, list[dict[str, Any]] | None] = {}
+    for season in sorted({int(s) for s in seasons}):
+        out[season] = load_season_rows(season)
+    return out
+
+
+def summarize_availability(seasons_map: dict[int, Any]) -> dict[str, list[int]]:
+    """Split a seasons_map into available/unavailable lists for the
+    response metadata block."""
+    available = sorted(s for s, rows in seasons_map.items() if rows)
+    unavailable = sorted(s for s, rows in seasons_map.items() if not rows)
+    return {"available": available, "unavailable": unavailable}

--- a/src/league_comparison/idp.py
+++ b/src/league_comparison/idp.py
@@ -1,0 +1,49 @@
+"""IDP comparison hooks — placeholder for future activation.
+
+The first release of League Comparison focuses on offense (QB / RB /
+WR / TE / Top-96 flex).  IDP is *scaffolded but inert* so the UI can
+render an "IDP coming soon" panel without special-casing later, and so
+flipping IDP on requires changing only this file plus the service
+orchestrator's call site — no UI rewrite.
+
+When ready to activate:
+
+1. Verify that ``src.nfl_data.ingest.fetch_weekly_defensive_stats`` is
+   producing usable rows for the configured seasons.
+2. Verify that ``src.nfl_data.realized_points`` IDP scoring matches a
+   known-good reference (e.g. another popular IDP scoring engine).
+3. Replace the body of :func:`compute_idp_block` to call into the
+   real metrics pipeline (mirror what offense does in
+   ``service._build_offense_block``), fanning out across DL / LB / DB
+   plus a Top-96 IDP pool.
+4. Compare Top-96 IDP score against Top-96 offensive flex (computed
+   by the offense pipeline) and emit the same shape as the offense
+   block.
+
+Until then the function returns a placeholder block so the UI can
+render an "IDP coming soon" badge consistently.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def compute_idp_block() -> dict[str, Any]:
+    """Return a placeholder IDP block matching the offense block shape.
+
+    Today: ``available=False, status="placeholder"`` plus an empty
+    positions dict.  Once the data is verified, replace with real
+    per-position metrics (DL / LB / DB) and a Top-96 IDP-vs-flex
+    deviation that feeds the similarity score.
+    """
+    return {
+        "available": False,
+        "status": "placeholder",
+        "message": (
+            "IDP comparison is scaffolded but not yet enabled.  Future "
+            "release will compare Top-96 IDP scoring against Top-96 "
+            "offensive flex scoring over the same multi-year sample."
+        ),
+        "positions": {},
+        "top96Idp": None,
+    }

--- a/src/league_comparison/metrics.py
+++ b/src/league_comparison/metrics.py
@@ -1,0 +1,470 @@
+"""Pure stat math for league comparison.
+
+Every function here is deterministic and side-effect-free so the test
+suite can exhaustively pin behaviour without standing up any I/O.
+
+Two scoring methods are computed in parallel and reported side-by-side:
+
+* **Legacy / Simple**:  ``(average + median) / 2``
+  The user's original heuristic, preserved so they can sanity-check
+  the new method against an established reference.
+
+* **Improved**:  ``0.35*median + 0.25*avg + 0.20*p75 + 0.10*p25
+                 + 0.10*replacement_adj``
+  More robust than legacy: median anchors the central tendency,
+  average captures the mean shift, p75 picks up elite-end skew, p25
+  picks up replacement-end compression, and the replacement-adjusted
+  value rewards positions whose starters are well-separated from the
+  bottom of the startable pool.
+
+Multi-season combination uses **equal weighting** by design (no recency
+weighting).  Each available season counts as 1/N of the combined value,
+where N is the number of available seasons.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import mean, median, quantiles
+from typing import Iterable, Sequence
+
+from .scoring_engine import PlayerSeasonScore
+
+
+# ── Constants ─────────────────────────────────────────────────────────
+
+OFFENSE_POSITIONS: tuple[str, ...] = ("QB", "RB", "WR", "TE")
+FLEX_POSITIONS: tuple[str, ...] = ("RB", "WR", "TE")  # excludes QB
+
+# Improved-method coefficients.  Documented in the user-facing
+# methodology section so changes here flow into the UI explanation.
+IMPROVED_WEIGHT_MEDIAN: float = 0.35
+IMPROVED_WEIGHT_AVERAGE: float = 0.25
+IMPROVED_WEIGHT_P75: float = 0.20
+IMPROVED_WEIGHT_P25: float = 0.10
+IMPROVED_WEIGHT_REPL_ADJ: float = 0.10
+
+
+# ── Sampling ──────────────────────────────────────────────────────────
+
+def top_n_by_position(
+    scores: Iterable[PlayerSeasonScore], position: str, n: int,
+) -> list[PlayerSeasonScore]:
+    """Return the top-N season scores for ``position``, sorted DESC.
+
+    Ties on ``total_points`` are broken by ``player_id`` for stable
+    output across runs (so tests pin reliably).
+    """
+    pool = [s for s in scores if s.position == position]
+    pool.sort(key=lambda s: (-s.total_points, s.player_id))
+    return pool[: max(0, int(n))]
+
+
+def flex_top_n(
+    scores: Iterable[PlayerSeasonScore], n: int = 96,
+) -> list[PlayerSeasonScore]:
+    """Top-N RB/WR/TE pool, QB excluded.
+
+    Used for the offensive flex comparison.  Same tie-break as
+    :func:`top_n_by_position`.
+    """
+    pool = [s for s in scores if s.position in FLEX_POSITIONS]
+    pool.sort(key=lambda s: (-s.total_points, s.player_id))
+    return pool[: max(0, int(n))]
+
+
+# ── Per-position metrics ──────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class PositionMetrics:
+    average: float
+    median: float
+    p25: float
+    p75: float
+    replacement_level: float    # the Nth player's points (e.g. QB24)
+    elite: float                # mean of top 3
+    replacement_adj: float      # average - replacement_level
+    sample_size: int
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "average": round(self.average, 2),
+            "median": round(self.median, 2),
+            "p25": round(self.p25, 2),
+            "p75": round(self.p75, 2),
+            "replacementLevel": round(self.replacement_level, 2),
+            "elite": round(self.elite, 2),
+            "replacementAdj": round(self.replacement_adj, 2),
+            "sampleSize": self.sample_size,
+        }
+
+
+_EMPTY_METRICS = PositionMetrics(
+    average=0.0, median=0.0, p25=0.0, p75=0.0,
+    replacement_level=0.0, elite=0.0, replacement_adj=0.0,
+    sample_size=0,
+)
+
+
+def _percentile(sorted_desc: Sequence[float], pct: float) -> float:
+    """Compute the ``pct`` percentile from a DESC-sorted list of floats.
+
+    Uses Python's ``statistics.quantiles`` with method='exclusive' for
+    n=100, indexed at ``pct - 1`` (0-based).  For tiny samples (<2) we
+    return the single value or 0.
+    """
+    n = len(sorted_desc)
+    if n == 0:
+        return 0.0
+    if n == 1:
+        return float(sorted_desc[0])
+    asc = sorted(sorted_desc)
+    try:
+        qs = quantiles(asc, n=100, method="exclusive")
+    except Exception:  # noqa: BLE001
+        return float(asc[int(round((pct / 100) * (n - 1)))])
+    idx = int(round(pct)) - 1
+    idx = max(0, min(idx, len(qs) - 1))
+    return float(qs[idx])
+
+
+def position_metrics(samples: Sequence[PlayerSeasonScore]) -> PositionMetrics:
+    """Compute the per-position summary stats for a top-N sample.
+
+    Empty samples return zeroed metrics with ``sample_size=0`` rather
+    than raising — the orchestrator surfaces that via warnings instead.
+    """
+    if not samples:
+        return _EMPTY_METRICS
+    pts = [float(s.total_points) for s in samples]
+    pts_desc = sorted(pts, reverse=True)
+    avg = mean(pts)
+    med = float(median(pts))
+    p25 = _percentile(pts_desc, 25)
+    p75 = _percentile(pts_desc, 75)
+    repl = float(pts_desc[-1])  # the Nth (last in top-N == replacement-level)
+    top3 = pts_desc[:3]
+    elite = float(mean(top3)) if top3 else 0.0
+    return PositionMetrics(
+        average=float(avg),
+        median=med,
+        p25=p25,
+        p75=p75,
+        replacement_level=repl,
+        elite=elite,
+        replacement_adj=float(avg) - repl,
+        sample_size=len(samples),
+    )
+
+
+# ── Blended scores (the two methods) ──────────────────────────────────
+
+def legacy_blended(m: PositionMetrics) -> float:
+    """The user's original ``(average + median) / 2`` formula."""
+    return (m.average + m.median) / 2.0
+
+
+def improved_blended(m: PositionMetrics) -> float:
+    """Multi-signal weighted blend; coefficients defined as module
+    constants and documented in the UI methodology section."""
+    return (
+        IMPROVED_WEIGHT_MEDIAN * m.median
+        + IMPROVED_WEIGHT_AVERAGE * m.average
+        + IMPROVED_WEIGHT_P75 * m.p75
+        + IMPROVED_WEIGHT_P25 * m.p25
+        + IMPROVED_WEIGHT_REPL_ADJ * m.replacement_adj
+    )
+
+
+# ── Positional shares ─────────────────────────────────────────────────
+
+def position_shares(blended_by_pos: dict[str, float]) -> dict[str, float]:
+    """Return each position's share of the total positional scoring pool.
+
+    Empty / all-zero input returns 0 shares for everything (rather than
+    NaN / division-by-zero).  Shares are returned as percentages
+    (0..100), not 0..1.
+    """
+    total = sum(max(0.0, v) for v in blended_by_pos.values())
+    if total <= 0:
+        return {pos: 0.0 for pos in blended_by_pos}
+    return {pos: (max(0.0, v) / total) * 100.0 for pos, v in blended_by_pos.items()}
+
+
+# ── Multi-season combine (equal-weight) ───────────────────────────────
+
+def combine_seasons_equal_weight(values: Sequence[float]) -> float:
+    """Average a list of per-season values with equal weight per season.
+
+    None values are dropped (used for "missing season" passthrough).
+    Empty input returns 0.0 — caller is responsible for emitting a
+    "no data" warning before calling.
+    """
+    finite = [float(v) for v in values if v is not None]
+    if not finite:
+        return 0.0
+    return sum(finite) / len(finite)
+
+
+def combine_metrics_equal_weight(
+    metrics_by_season: dict[int, PositionMetrics | None],
+) -> PositionMetrics:
+    """Combine per-season metrics into one combined PositionMetrics.
+
+    Each available season weighted equally; missing seasons skipped.
+    Uses the average of the per-season computed values, NOT a re-pool
+    of all top-N samples (that would over-weight high-volume seasons).
+    """
+    available = [m for m in metrics_by_season.values() if m and m.sample_size > 0]
+    if not available:
+        return _EMPTY_METRICS
+    n = len(available)
+    avg = sum(m.average for m in available) / n
+    med = sum(m.median for m in available) / n
+    p25 = sum(m.p25 for m in available) / n
+    p75 = sum(m.p75 for m in available) / n
+    repl = sum(m.replacement_level for m in available) / n
+    elite = sum(m.elite for m in available) / n
+    repl_adj = sum(m.replacement_adj for m in available) / n
+    sample = int(round(sum(m.sample_size for m in available) / n))
+    return PositionMetrics(
+        average=avg, median=med, p25=p25, p75=p75,
+        replacement_level=repl, elite=elite, replacement_adj=repl_adj,
+        sample_size=sample,
+    )
+
+
+# ── Status labels ─────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class StatusBands:
+    """Thresholds (in absolute pp difference) for status labels.
+
+    These are deliberately tunable in one place so the frontend
+    methodology section can reference the exact same numbers.
+    """
+    excellent: float = 0.5
+    good: float = 1.5
+    slight: float = 3.0
+    over: float = 5.0  # above this -> "Too high/low"
+
+
+_BANDS = StatusBands()
+
+
+def status_label(diff_pp: float, *, bands: StatusBands = _BANDS) -> str:
+    """Map a positional-share difference (in percentage points) to a
+    status label.  Sign of ``diff_pp`` determines high vs low.
+    """
+    abs_d = abs(diff_pp)
+    if abs_d <= bands.excellent:
+        return "Excellent match"
+    if abs_d <= bands.good:
+        return "Good match"
+    if abs_d <= bands.slight:
+        return "Slightly high" if diff_pp > 0 else "Slightly low"
+    if abs_d <= bands.over:
+        # Mid-band noun stays "high/low"; severity escalates after ``over``.
+        return "High" if diff_pp > 0 else "Low"
+    return "Too high" if diff_pp > 0 else "Too low"
+
+
+# ── Similarity score ──────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class SimilarityResult:
+    score: int                   # 0..100
+    label: str                   # human descriptor
+    distortion_label: str        # "Low" / "Moderate" / "High" / "Severe"
+    total_share_dev_pp: float    # sum of |share diffs| in pp
+    flex_dev_pct: float          # |my_flex - baseline_flex| / baseline_flex * 100
+
+
+def similarity_score(
+    my_shares: dict[str, float],
+    baseline_shares: dict[str, float],
+    my_flex: float,
+    baseline_flex: float,
+) -> SimilarityResult:
+    """Convert positional-share differences + flex difference to a
+    0..100 similarity score.
+
+    Approach:
+
+    1. Sum |my_share - baseline_share| in percentage points across the
+       four offensive positions.  This is the "share deviation" signal
+       — already a normalized number that doesn't depend on the
+       absolute scale of fantasy points.
+    2. Compute the flex-pool blended-score relative deviation as a
+       percentage.
+    3. Combined deviation = total_share_dev_pp + 0.4 * flex_dev_pct.
+       The flex weighting is intentionally less than the share signal
+       because the flex score is correlated with the per-position
+       scores (it's not fully independent).
+    4. Map combined deviation through a piecewise-linear curve to 0..100
+       using the bands documented in the methodology section.
+
+    Banding:
+
+    | Combined deviation | Score range | Label                  |
+    |--------------------|-------------|------------------------|
+    | <= 2               | 95–100      | Extremely close        |
+    | 2 – 5              | 85–94       | Very close             |
+    | 5 – 10             | 75–84       | Some noticeable diffs  |
+    | 10 – 20            | 60–74       | Meaningfully different |
+    | > 20               | < 60        | Very distorted         |
+    """
+    pos_dev = sum(
+        abs(my_shares.get(p, 0.0) - baseline_shares.get(p, 0.0))
+        for p in OFFENSE_POSITIONS
+    )
+    if baseline_flex > 0:
+        flex_dev = abs(my_flex - baseline_flex) / baseline_flex * 100.0
+    else:
+        flex_dev = 0.0
+    combined = pos_dev + 0.4 * flex_dev
+
+    # Piecewise-linear: lower deviation -> higher score.
+    if combined <= 2:
+        score = 95 + (2 - combined) / 2 * 5             # 95..100
+        label = "Extremely close to standard"
+        distortion = "Low"
+    elif combined <= 5:
+        score = 85 + (5 - combined) / 3 * 9             # 85..94
+        label = "Very close"
+        distortion = "Low"
+    elif combined <= 10:
+        score = 75 + (10 - combined) / 5 * 9            # 75..84
+        label = "Some noticeable differences"
+        distortion = "Moderate"
+    elif combined <= 20:
+        score = 60 + (20 - combined) / 10 * 14          # 60..74
+        label = "Meaningfully different"
+        distortion = "High"
+    else:
+        # Below 60.  Floor at 0; decay rapidly past 20.
+        score = max(0.0, 60 - (combined - 20) * 2)
+        label = "Very distorted"
+        distortion = "Severe"
+
+    return SimilarityResult(
+        score=int(round(max(0, min(100, score)))),
+        label=label,
+        distortion_label=distortion,
+        total_share_dev_pp=round(pos_dev, 2),
+        flex_dev_pct=round(flex_dev, 2),
+    )
+
+
+# ── Recommendations ───────────────────────────────────────────────────
+
+# Heuristic culprit hints by position.  Plain English + rough cause —
+# never prescriptive, never auto-applied.  The UI surfaces these
+# verbatim under each position row.
+_CULPRIT_HINTS: dict[str, list[str]] = {
+    "QB": [
+        "passing TD value (4-pt vs 6-pt swings QB share most)",
+        "passing yard rate (e.g. 1/25 vs 1/40)",
+        "interception penalty",
+        "passing-yard threshold bonuses (300/400)",
+        "rushing scoring (mobile QBs benefit)",
+    ],
+    "RB": [
+        "PPR amount (full PPR pushes WR/TE up at RB's expense)",
+        "rushing yard rate (e.g. 0.1 vs 0.05)",
+        "rushing TD value",
+        "rushing-yard threshold bonuses (100/200)",
+        "first-down bonuses (if applied unequally)",
+    ],
+    "WR": [
+        "PPR amount",
+        "receiving yard rate",
+        "100/200-yard receiving bonuses",
+        "TE premium (a higher TEP eats into WR share)",
+    ],
+    "TE": [
+        "TE premium (bonus_rec_te)",
+        "PPR amount (TEs gain disproportionately at full PPR)",
+        "receiving yard rate",
+    ],
+}
+
+
+def recommendation(
+    position: str,
+    diff_pp: float,
+    my_share: float,
+    baseline_share: float,
+) -> str:
+    """Build a plain-English recommendation string.
+
+    Always non-prescriptive — surfaces the gap and a list of likely
+    scoring-setting culprits, never auto-changes anything.
+    """
+    direction = "higher" if diff_pp > 0 else "lower"
+    abs_d = abs(diff_pp)
+    if abs_d <= 0.5:
+        return (
+            f"{position} scoring is essentially aligned with the "
+            f"baseline ({my_share:.1f}% vs {baseline_share:.1f}%). "
+            f"No adjustment recommended."
+        )
+    severity = (
+        "slightly" if abs_d <= 1.5 else
+        "noticeably" if abs_d <= 3.0 else
+        "meaningfully" if abs_d <= 5.0 else
+        "substantially"
+    )
+    hints = _CULPRIT_HINTS.get(position, [])
+    hint_text = ""
+    if hints and abs_d > 1.5:
+        hint_text = " Likely scoring-setting drivers: " + "; ".join(hints[:3]) + "."
+    return (
+        f"{position} scoring is {severity} {direction} than the "
+        f"baseline ({my_share:.1f}% vs {baseline_share:.1f}%, "
+        f"{diff_pp:+.1f} pp).{hint_text}"
+    )
+
+
+# ── Convenience aggregator (used by service.py) ───────────────────────
+
+@dataclass(frozen=True)
+class PositionComparison:
+    position: str
+    my_metrics: PositionMetrics
+    baseline_metrics: PositionMetrics
+    my_legacy_score: float
+    baseline_legacy_score: float
+    my_improved_score: float
+    baseline_improved_score: float
+
+    def to_dict(self, my_share_legacy: float, my_share_improved: float,
+                base_share_legacy: float, base_share_improved: float,
+                recommendation_text: str) -> dict[str, object]:
+        diff_legacy = my_share_legacy - base_share_legacy
+        diff_improved = my_share_improved - base_share_improved
+        rel = (
+            (diff_improved / base_share_improved * 100.0)
+            if base_share_improved > 0 else 0.0
+        )
+        return {
+            "position": self.position,
+            "my": {
+                "metrics": self.my_metrics.to_dict(),
+                "legacyScore": round(self.my_legacy_score, 2),
+                "improvedScore": round(self.my_improved_score, 2),
+                "shareLegacy": round(my_share_legacy, 2),
+                "shareImproved": round(my_share_improved, 2),
+            },
+            "baseline": {
+                "metrics": self.baseline_metrics.to_dict(),
+                "legacyScore": round(self.baseline_legacy_score, 2),
+                "improvedScore": round(self.baseline_improved_score, 2),
+                "shareLegacy": round(base_share_legacy, 2),
+                "shareImproved": round(base_share_improved, 2),
+            },
+            "diffPpLegacy": round(diff_legacy, 2),
+            "diffPpImproved": round(diff_improved, 2),
+            "relDiffPct": round(rel, 2),
+            "status": status_label(diff_improved),
+            "recommendation": recommendation_text,
+        }

--- a/src/league_comparison/scoring_engine.py
+++ b/src/league_comparison/scoring_engine.py
@@ -1,0 +1,149 @@
+"""Apply a Sleeper ``scoring_settings`` dict to weekly NFL stat rows
+and aggregate to per-player season totals.
+
+This module is a thin orchestrator around the existing
+:func:`src.nfl_data.realized_points.compute_weekly_points` — which is
+already the single source of truth for Sleeper-format fantasy scoring.
+
+Output: a list of :class:`PlayerSeasonScore` records, one per
+``(player_id_gsis, position, season)`` triple, that downstream metrics
+code can sort/filter/sample.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from src.nfl_data import realized_points as _rp
+from src.utils.name_clean import POSITION_ALIASES
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Positions we report on (offense + IDP).  Anything else (kickers,
+# team defenses, OL/HC/etc) is dropped — out of scope for a positional
+# scoring-balance comparison.
+_OFFENSE_POSITIONS = frozenset({"QB", "RB", "WR", "TE"})
+_IDP_POSITIONS = frozenset({"DL", "LB", "DB"})
+_TRACKED_POSITIONS = _OFFENSE_POSITIONS | _IDP_POSITIONS
+
+
+@dataclass(frozen=True)
+class PlayerSeasonScore:
+    player_id: str
+    player_name: str
+    position: str          # canonicalised: QB / RB / WR / TE / DL / LB / DB
+    raw_position: str      # what nflverse reported (DT, EDGE, OLB, etc.)
+    season: int
+    total_points: float
+    games_played: int
+
+
+def _canonical_position(raw_pos: str | None) -> str | None:
+    """Map a raw nflverse position to one of our tracked groups, or None.
+
+    Uses ``POSITION_ALIASES`` from ``src.utils.name_clean`` for the
+    standard offense aliases, and an explicit IDP collapse table since
+    nflverse uses fine-grained labels (DT/DE/EDGE → DL, ILB/OLB/MLB →
+    LB, CB/S/FS/SS → DB).
+    """
+    if not raw_pos:
+        return None
+    raw = str(raw_pos).strip().upper()
+    if not raw:
+        return None
+    aliased = POSITION_ALIASES.get(raw, raw)
+    if aliased in _OFFENSE_POSITIONS:
+        return aliased
+    # IDP collapse — keep this local to scoring_engine; not all callers
+    # of POSITION_ALIASES want this collapse.
+    if aliased in {"DL", "DT", "DE", "EDGE", "NT"}:
+        return "DL"
+    if aliased in {"LB", "ILB", "OLB", "MLB"}:
+        return "LB"
+    if aliased in {"DB", "CB", "S", "FS", "SS"}:
+        return "DB"
+    return None
+
+
+def compute_player_season_scores(
+    rows: Iterable[dict[str, Any]],
+    scoring_settings: dict[str, Any],
+    *,
+    season: int | None = None,
+) -> list[PlayerSeasonScore]:
+    """Aggregate weekly rows to season totals under one league's scoring.
+
+    ``rows`` is the output of ``fetch_weekly_stats`` — already a list of
+    plain dicts.  ``scoring_settings`` is the Sleeper dict from
+    ``LeagueScoringInfo.scoring_settings``.
+
+    ``season`` is informational; if None we infer it from the rows.
+    """
+    if not scoring_settings:
+        return []
+
+    # Group by (player_id, season) so a multi-team year stays unified
+    # (player traded mid-season — rows from both teams roll into one
+    # season total).
+    bucket: dict[tuple[str, int], dict[str, Any]] = defaultdict(
+        lambda: {
+            "name": "",
+            "raw_position": "",
+            "canonical": None,
+            "total": 0.0,
+            "games": 0,
+        }
+    )
+
+    for row in rows or []:
+        pid = str(row.get("player_id") or row.get("player_id_gsis") or "").strip()
+        if not pid:
+            continue
+        raw_pos = str(row.get("position") or "").strip().upper()
+        canonical = _canonical_position(raw_pos)
+        if canonical not in _TRACKED_POSITIONS:
+            continue
+        try:
+            row_season = int(row.get("season") or season or 0)
+        except (TypeError, ValueError):
+            continue
+        if row_season <= 0:
+            continue
+
+        rp = _rp.compute_weekly_points(row, scoring_settings, position=canonical)
+        if rp is None:
+            continue
+        pts = float(rp.fantasy_points)
+
+        key = (pid, row_season)
+        b = bucket[key]
+        if not b["name"]:
+            b["name"] = str(row.get("player_display_name") or row.get("player_name") or pid)
+        if not b["raw_position"]:
+            b["raw_position"] = raw_pos
+        b["canonical"] = canonical
+        b["total"] += pts
+        # Count any game where the player had a stat row, regardless
+        # of whether they scored — matches the "games played" intuition
+        # for sample sizes.
+        b["games"] += 1
+
+    out: list[PlayerSeasonScore] = []
+    for (pid, yr), b in bucket.items():
+        if b["canonical"] is None:
+            continue
+        out.append(
+            PlayerSeasonScore(
+                player_id=pid,
+                player_name=b["name"],
+                position=b["canonical"],
+                raw_position=b["raw_position"],
+                season=yr,
+                total_points=round(float(b["total"]), 2),
+                games_played=int(b["games"]),
+            )
+        )
+    return out

--- a/src/league_comparison/service.py
+++ b/src/league_comparison/service.py
@@ -1,0 +1,507 @@
+"""Service orchestrator for the League Comparison endpoint.
+
+Single public entry point: :func:`build_comparison`.  Everything else
+in this module is a private helper.
+
+Flow
+----
+1. Load ``config/league_comparison.json``.
+2. Fetch ``scoring_settings`` for both leagues from Sleeper
+   (:mod:`.sleeper_scoring`).
+3. Compute a cache key from league IDs + scoring hashes + seasons +
+   version.
+4. If a fresh cached result exists and ``refresh=False``, return it
+   directly (cache TTL: 7 days).
+5. Otherwise: load weekly NFL stats per season
+   (:mod:`.historical_stats`).  Track which seasons are
+   available vs unavailable.
+6. For each league × available season:
+     * Compute per-player season totals under that league's scoring.
+     * Sample top-N per position (sample sizes from config).
+     * Compute :class:`PositionMetrics` per position.
+     * Compute Top-96 flex metrics (RB ∪ WR ∪ TE).
+7. Combine seasons equally across the available seasons.
+8. Compute legacy + improved blended scores per position.
+9. Compute positional shares per league.
+10. Compute :class:`SimilarityResult`.
+11. Build per-position recommendations.
+12. Persist to disk cache and return.
+
+Output shape
+------------
+Documented in :func:`build_comparison`'s docstring and pinned by
+``tests/league_comparison/test_service.py``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from src.nfl_data import cache as _nfl_cache
+
+from . import historical_stats as _stats
+from . import idp as _idp
+from . import metrics as _m
+from . import sleeper_scoring as _sleeper
+from .scoring_engine import PlayerSeasonScore, compute_player_season_scores
+
+_LOGGER = logging.getLogger(__name__)
+
+_CACHE_TTL_SEC = 7 * 24 * 3600
+_CACHE_SUBDIR = "league_comparison_cache"
+
+
+# ── Config loading ────────────────────────────────────────────────────
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _config_path() -> Path:
+    return _repo_root() / "config" / "league_comparison.json"
+
+
+def _load_config() -> dict[str, Any]:
+    path = _config_path()
+    if not path.exists():
+        raise FileNotFoundError(f"missing config: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ── Cache layer (disk) ────────────────────────────────────────────────
+
+def _cache_dir() -> Path:
+    return _repo_root() / "data" / _CACHE_SUBDIR
+
+
+def _cache_key(
+    *,
+    my_id: str, baseline_id: str,
+    my_hash: str, baseline_hash: str,
+    seasons: Iterable[int], version: str,
+) -> str:
+    parts = [
+        version,
+        my_id, my_hash,
+        baseline_id, baseline_hash,
+        ",".join(str(s) for s in sorted(seasons)),
+    ]
+    return "league_compare:" + hashlib.sha1(":".join(parts).encode("utf-8")).hexdigest()
+
+
+# ── Per-position pipeline ─────────────────────────────────────────────
+
+def _per_season_metrics_for_league(
+    rows: list[dict[str, Any]],
+    scoring: dict[str, float],
+    sample_sizes: dict[str, int],
+    season: int,
+) -> tuple[dict[str, _m.PositionMetrics], _m.PositionMetrics, list[PlayerSeasonScore]]:
+    """For one league × one season, compute per-position metrics + flex
+    metrics.  Returns ``(per_pos, flex_metrics, top_player_pool)``.
+
+    The third return is the union of all top-N samples (offense only)
+    so callers can build a "top players used" breakdown for the
+    year-by-year UI section without recomputing.
+    """
+    scores = compute_player_season_scores(rows, scoring, season=season)
+    per_pos: dict[str, _m.PositionMetrics] = {}
+    sample_union: list[PlayerSeasonScore] = []
+    for pos in _m.OFFENSE_POSITIONS:
+        n = int(sample_sizes.get(pos, 0))
+        sample = _m.top_n_by_position(scores, pos, n)
+        per_pos[pos] = _m.position_metrics(sample)
+        sample_union.extend(sample)
+    flex_n = int(sample_sizes.get("FLEX", 96))
+    flex_sample = _m.flex_top_n(scores, n=flex_n)
+    flex_metrics = _m.position_metrics(flex_sample)
+    return per_pos, flex_metrics, sample_union
+
+
+def _build_league_block(
+    league_info: _sleeper.LeagueScoringInfo,
+    seasons_map: dict[int, list[dict[str, Any]] | None],
+    sample_sizes: dict[str, int],
+) -> dict[str, Any]:
+    """Compute per-season per-position metrics for one league across
+    every available season.
+
+    Returns a structured block:
+    ``{"perSeason": {season: {"positions":{...}, "flex":{...},
+        "topPlayers":[...]}},
+       "combined": {"positions":{...}, "flex":{...}}}``
+    """
+    per_season: dict[int, dict[str, Any]] = {}
+    for season, rows in seasons_map.items():
+        if not rows:
+            per_season[season] = {
+                "positions": {pos: _m.PositionMetrics(0, 0, 0, 0, 0, 0, 0, 0).to_dict()
+                              for pos in _m.OFFENSE_POSITIONS},
+                "flex": _m.PositionMetrics(0, 0, 0, 0, 0, 0, 0, 0).to_dict(),
+                "topPlayers": [],
+                "available": False,
+            }
+            continue
+        per_pos, flex_metrics, sample_union = _per_season_metrics_for_league(
+            rows, league_info.scoring_settings, sample_sizes, season,
+        )
+        # Top players sample for the UI year-by-year detail panel —
+        # cap at 25 to keep payload light.
+        top_players = sorted(
+            sample_union, key=lambda s: -s.total_points,
+        )[:25]
+        per_season[season] = {
+            "positions": {pos: m.to_dict() for pos, m in per_pos.items()},
+            "flex": flex_metrics.to_dict(),
+            "topPlayers": [
+                {
+                    "playerId": s.player_id,
+                    "name": s.player_name,
+                    "position": s.position,
+                    "rawPosition": s.raw_position,
+                    "season": s.season,
+                    "totalPoints": s.total_points,
+                    "gamesPlayed": s.games_played,
+                }
+                for s in top_players
+            ],
+            "available": True,
+        }
+
+    # Build combined metrics by averaging available-season metrics
+    # equally per position.
+    combined_positions: dict[str, _m.PositionMetrics] = {}
+    for pos in _m.OFFENSE_POSITIONS:
+        per_year = {}
+        for season, block in per_season.items():
+            if not block.get("available"):
+                continue
+            d = block["positions"][pos]
+            per_year[season] = _m.PositionMetrics(
+                average=d["average"], median=d["median"],
+                p25=d["p25"], p75=d["p75"],
+                replacement_level=d["replacementLevel"],
+                elite=d["elite"],
+                replacement_adj=d["replacementAdj"],
+                sample_size=d["sampleSize"],
+            )
+        combined_positions[pos] = _m.combine_metrics_equal_weight(per_year)
+    flex_per_year = {}
+    for season, block in per_season.items():
+        if not block.get("available"):
+            continue
+        d = block["flex"]
+        flex_per_year[season] = _m.PositionMetrics(
+            average=d["average"], median=d["median"],
+            p25=d["p25"], p75=d["p75"],
+            replacement_level=d["replacementLevel"],
+            elite=d["elite"],
+            replacement_adj=d["replacementAdj"],
+            sample_size=d["sampleSize"],
+        )
+    combined_flex = _m.combine_metrics_equal_weight(flex_per_year)
+
+    return {
+        "perSeason": {str(yr): block for yr, block in per_season.items()},
+        "combined": {
+            "positions": {pos: m.to_dict() for pos, m in combined_positions.items()},
+            "flex": combined_flex.to_dict(),
+        },
+        "_combinedPositions": combined_positions,   # internal handle
+        "_combinedFlex": combined_flex,             # internal handle
+    }
+
+
+def _build_position_comparisons(
+    my_block: dict[str, Any],
+    base_block: dict[str, Any],
+) -> tuple[dict[str, dict[str, Any]], dict[str, float], dict[str, float], dict[str, float], dict[str, float]]:
+    """Compute per-position comparisons and the four share dicts (legacy
+    + improved × my + baseline)."""
+    my_pos: dict[str, _m.PositionMetrics] = my_block["_combinedPositions"]
+    base_pos: dict[str, _m.PositionMetrics] = base_block["_combinedPositions"]
+
+    my_legacy = {pos: _m.legacy_blended(m) for pos, m in my_pos.items()}
+    my_improved = {pos: _m.improved_blended(m) for pos, m in my_pos.items()}
+    base_legacy = {pos: _m.legacy_blended(m) for pos, m in base_pos.items()}
+    base_improved = {pos: _m.improved_blended(m) for pos, m in base_pos.items()}
+
+    my_share_legacy = _m.position_shares(my_legacy)
+    my_share_improved = _m.position_shares(my_improved)
+    base_share_legacy = _m.position_shares(base_legacy)
+    base_share_improved = _m.position_shares(base_improved)
+
+    out: dict[str, dict[str, Any]] = {}
+    for pos in _m.OFFENSE_POSITIONS:
+        diff_pp_improved = my_share_improved[pos] - base_share_improved[pos]
+        rec_text = _m.recommendation(
+            pos, diff_pp_improved,
+            my_share_improved[pos], base_share_improved[pos],
+        )
+        comp = _m.PositionComparison(
+            position=pos,
+            my_metrics=my_pos[pos],
+            baseline_metrics=base_pos[pos],
+            my_legacy_score=my_legacy[pos],
+            baseline_legacy_score=base_legacy[pos],
+            my_improved_score=my_improved[pos],
+            baseline_improved_score=base_improved[pos],
+        )
+        out[pos] = comp.to_dict(
+            my_share_legacy=my_share_legacy[pos],
+            my_share_improved=my_share_improved[pos],
+            base_share_legacy=base_share_legacy[pos],
+            base_share_improved=base_share_improved[pos],
+            recommendation_text=rec_text,
+        )
+    return out, my_share_legacy, my_share_improved, base_share_legacy, base_share_improved
+
+
+def _flex_block(
+    my_block: dict[str, Any],
+    base_block: dict[str, Any],
+) -> dict[str, Any]:
+    my_flex: _m.PositionMetrics = my_block["_combinedFlex"]
+    base_flex: _m.PositionMetrics = base_block["_combinedFlex"]
+    my_legacy = _m.legacy_blended(my_flex)
+    base_legacy = _m.legacy_blended(base_flex)
+    my_improved = _m.improved_blended(my_flex)
+    base_improved = _m.improved_blended(base_flex)
+    diff = my_improved - base_improved
+    rel = (diff / base_improved * 100.0) if base_improved > 0 else 0.0
+    if abs(rel) <= 1:
+        interp = "Top-96 flex value is essentially aligned with the baseline league."
+    elif abs(rel) <= 5:
+        interp = (
+            f"Top-96 flex value is slightly "
+            f"{'higher' if rel > 0 else 'lower'} than baseline ({rel:+.1f}%) — "
+            f"minor adjustment may be worth considering."
+        )
+    else:
+        interp = (
+            f"Top-96 flex value is meaningfully "
+            f"{'higher' if rel > 0 else 'lower'} than baseline ({rel:+.1f}%); "
+            f"this can shift overall lineup-construction value relative to a normal league."
+        )
+    return {
+        "my": {
+            "metrics": my_flex.to_dict(),
+            "legacyScore": round(my_legacy, 2),
+            "improvedScore": round(my_improved, 2),
+        },
+        "baseline": {
+            "metrics": base_flex.to_dict(),
+            "legacyScore": round(base_legacy, 2),
+            "improvedScore": round(base_improved, 2),
+        },
+        "diffLegacy": round(my_legacy - base_legacy, 2),
+        "diffImproved": round(diff, 2),
+        "relDiffPct": round(rel, 2),
+        "interpretation": interp,
+    }
+
+
+def _summary_block(
+    positions: dict[str, dict[str, Any]],
+    flex: dict[str, Any],
+    similarity: _m.SimilarityResult,
+) -> dict[str, Any]:
+    """Compute biggest-difference + closest-match for the summary cards."""
+    diffs = [
+        (pos, abs(comp["diffPpImproved"]))
+        for pos, comp in positions.items()
+    ]
+    diffs.sort(key=lambda x: -x[1])
+    biggest = diffs[0][0] if diffs else None
+    closest = diffs[-1][0] if diffs else None
+    return {
+        "score": similarity.score,
+        "label": similarity.label,
+        "distortionLabel": similarity.distortion_label,
+        "totalShareDevPp": similarity.total_share_dev_pp,
+        "flexDevPct": similarity.flex_dev_pct,
+        "biggestDiffPosition": biggest,
+        "closestMatchPosition": closest,
+        "qbStatus": positions.get("QB", {}).get("status"),
+        "rbStatus": positions.get("RB", {}).get("status"),
+        "wrStatus": positions.get("WR", {}).get("status"),
+        "teStatus": positions.get("TE", {}).get("status"),
+        "flexInterpretation": flex.get("interpretation"),
+    }
+
+
+# ── Top-level entry ───────────────────────────────────────────────────
+
+def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
+    """Build the full comparison payload (or load it from cache).
+
+    Returns a dict ready to be JSON-serialized as the response body for
+    ``GET /api/league-comparison``.
+
+    Network failures fetching scoring settings raise — the API layer
+    catches and returns 503.  Missing seasons degrade gracefully.
+    """
+    config = _load_config()
+    version = str(config.get("version") or "v1.0")
+    seasons_requested: list[int] = sorted({int(s) for s in config.get("seasons") or []})
+    sample_sizes: dict[str, int] = {
+        k: int(v) for k, v in (config.get("sample_sizes") or {}).items()
+    }
+
+    my_cfg = config["my_league"]
+    base_cfg = config["baseline_league"]
+
+    my_info = _sleeper.fetch_league_scoring(my_cfg["id"], refresh=refresh)
+    base_info = _sleeper.fetch_league_scoring(base_cfg["id"], refresh=refresh)
+
+    cache_key = _cache_key(
+        my_id=my_info.league_id, baseline_id=base_info.league_id,
+        my_hash=my_info.scoring_hash, baseline_hash=base_info.scoring_hash,
+        seasons=seasons_requested, version=version,
+    )
+    cache_dir = _cache_dir()
+    if not refresh:
+        cached = _nfl_cache.get(cache_key, ttl_seconds=_CACHE_TTL_SEC, cache_dir=cache_dir)
+        if cached is not None:
+            cached["meta"]["cacheHit"] = True
+            return cached
+
+    t_start = time.time()
+    seasons_map = _stats.load_all_seasons(seasons_requested)
+    avail = _stats.summarize_availability(seasons_map)
+
+    warnings: list[str] = []
+    if avail["unavailable"]:
+        missing = ", ".join(str(s) for s in avail["unavailable"])
+        warnings.append(
+            f"Seasons unavailable from upstream NFL stats source: {missing}. "
+            f"Combined results use only the available seasons, equally weighted."
+        )
+    if len(avail["available"]) == 1:
+        warnings.append(
+            "Only one season of data is available — comparison is based on a "
+            "limited sample and may be less reliable."
+        )
+    elif len(avail["available"]) == 0:
+        warnings.append(
+            "No NFL stats are available for any requested season.  "
+            "Comparison cannot be computed."
+        )
+
+    # Pre-flag any scoring keys present in either league but not handled
+    # by the scoring engine — surfaces in the methodology / warnings UI.
+    from src.nfl_data.realized_points import _SIMPLE_KEYS, _IDP_KEYS  # noqa: PLC0415
+    handled = set(_SIMPLE_KEYS.keys()) | set(_IDP_KEYS.keys()) | {
+        "bonus_rec_te",
+        "bonus_pass_yd_300", "bonus_pass_yd_400",
+        "bonus_rush_yd_100", "bonus_rush_yd_200",
+        "bonus_rec_yd_100", "bonus_rec_yd_200",
+        "pass_2pt", "rush_2pt", "rec_2pt",
+        "idp_tkl_5p", "idp_tkl_10p",
+    }
+    unsupported_my = sorted(set(my_info.scoring_settings.keys()) - handled)
+    unsupported_base = sorted(set(base_info.scoring_settings.keys()) - handled)
+    if unsupported_my or unsupported_base:
+        keys = sorted(set(unsupported_my) | set(unsupported_base))
+        # Only warn about keys with non-zero values — many leagues
+        # have dozens of zeroed keys for unused categories.
+        nonzero = [
+            k for k in keys
+            if my_info.scoring_settings.get(k, 0) or base_info.scoring_settings.get(k, 0)
+        ]
+        if nonzero:
+            warnings.append(
+                "Some scoring categories are present but not modeled by the engine "
+                f"(zeroed in calculations): {', '.join(nonzero)}."
+            )
+
+    my_block = _build_league_block(my_info, seasons_map, sample_sizes)
+    base_block = _build_league_block(base_info, seasons_map, sample_sizes)
+
+    positions, my_sl, my_si, base_sl, base_si = _build_position_comparisons(
+        my_block, base_block,
+    )
+    flex = _flex_block(my_block, base_block)
+
+    similarity = _m.similarity_score(
+        my_shares=my_si,
+        baseline_shares=base_si,
+        my_flex=flex["my"]["improvedScore"],
+        baseline_flex=flex["baseline"]["improvedScore"],
+    )
+
+    summary = _summary_block(positions, flex, similarity)
+    idp_block = _idp.compute_idp_block()
+
+    by_season: dict[str, Any] = {}
+    for season in avail["available"]:
+        by_season[str(season)] = {
+            "my": {
+                "positions": my_block["perSeason"][str(season)]["positions"],
+                "flex": my_block["perSeason"][str(season)]["flex"],
+                "topPlayers": my_block["perSeason"][str(season)]["topPlayers"],
+            },
+            "baseline": {
+                "positions": base_block["perSeason"][str(season)]["positions"],
+                "flex": base_block["perSeason"][str(season)]["flex"],
+                "topPlayers": base_block["perSeason"][str(season)]["topPlayers"],
+            },
+        }
+
+    payload: dict[str, Any] = {
+        "meta": {
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "version": version,
+            "myLeague": {
+                "id": my_info.league_id,
+                "label": my_cfg.get("label"),
+                "name": my_info.name,
+                "scoringHash": my_info.scoring_hash,
+            },
+            "baselineLeague": {
+                "id": base_info.league_id,
+                "label": base_cfg.get("label"),
+                "name": base_info.name,
+                "scoringHash": base_info.scoring_hash,
+            },
+            "seasonsRequested": seasons_requested,
+            "seasonsAvailable": avail["available"],
+            "seasonsUnavailable": avail["unavailable"],
+            "sampleSizes": sample_sizes,
+            "computeMs": int((time.time() - t_start) * 1000),
+            "cacheHit": False,
+        },
+        "summary": summary,
+        "similarity": {
+            "score": similarity.score,
+            "label": similarity.label,
+            "distortionLabel": similarity.distortion_label,
+            "totalShareDevPp": similarity.total_share_dev_pp,
+            "flexDevPct": similarity.flex_dev_pct,
+        },
+        "positions": positions,
+        "flex": flex,
+        "bySeason": by_season,
+        "idp": idp_block,
+        "warnings": warnings,
+    }
+
+    # Persist to disk cache (only if we successfully got at least one
+    # season — don't poison the cache with an all-empty result).
+    if avail["available"]:
+        try:
+            _nfl_cache.put(cache_key, payload, cache_dir=cache_dir)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("league_compare.cache_put_failed err=%r", exc)
+
+    _LOGGER.info(
+        "league_compare.built my=%s baseline=%s seasons=%s ms=%d",
+        my_info.league_id, base_info.league_id,
+        avail["available"], payload["meta"]["computeMs"],
+    )
+    return payload

--- a/src/league_comparison/sleeper_scoring.py
+++ b/src/league_comparison/sleeper_scoring.py
@@ -1,0 +1,137 @@
+"""Fetch ``scoring_settings`` for arbitrary Sleeper league IDs.
+
+This module deliberately bypasses ``src.api.league_registry`` because
+the league-comparison feature only needs scoring rules — never rosters,
+teams, or any other registry-bound data.  Adding leagues to the registry
+just to compare their scoring would be unnecessary coupling.
+
+Cache strategy: 1-hour in-memory per league_id.  Scoring settings change
+rarely (commissioner edits) — a 1h TTL means a refresh after a settings
+change picks up the next hit, while normal traffic doesn't repeatedly
+hit Sleeper.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+_SLEEPER_API_ROOT = "https://api.sleeper.app/v1"
+_CACHE_TTL_SEC = 3600
+_HTTP_TIMEOUT = 8.0
+
+_cache: dict[str, tuple[float, "LeagueScoringInfo"]] = {}
+_cache_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class LeagueScoringInfo:
+    league_id: str
+    name: str
+    season: str
+    season_type: str
+    scoring_settings: dict[str, float]
+    scoring_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "leagueId": self.league_id,
+            "name": self.name,
+            "season": self.season,
+            "seasonType": self.season_type,
+            "scoringSettings": dict(self.scoring_settings),
+            "scoringHash": self.scoring_hash,
+        }
+
+
+def _scoring_hash(scoring: dict[str, Any]) -> str:
+    payload = json.dumps(scoring, sort_keys=True, default=str)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def _fetch_raw(league_id: str) -> dict[str, Any]:
+    url = f"{_SLEEPER_API_ROOT}/league/{league_id}"
+    req = urllib.request.Request(url, headers={"User-Agent": "riskit-league-compare/1.0"})
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310
+        body = resp.read()
+    return json.loads(body)
+
+
+def fetch_league_scoring(league_id: str, *, refresh: bool = False) -> LeagueScoringInfo:
+    """Fetch scoring settings for a Sleeper league.
+
+    Raises ``ValueError`` if the league_id is missing or the API
+    response is malformed (no ``scoring_settings`` key).  Network errors
+    propagate as ``urllib.error.URLError``; the orchestrator catches and
+    converts them to a 503 in the API layer.
+    """
+    league_id = (league_id or "").strip()
+    if not league_id:
+        raise ValueError("league_id is required")
+
+    if not refresh:
+        with _cache_lock:
+            cached = _cache.get(league_id)
+            if cached:
+                fetched_at, info = cached
+                if (time.time() - fetched_at) < _CACHE_TTL_SEC:
+                    return info
+
+    try:
+        raw = _fetch_raw(league_id)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise ValueError(f"Sleeper league {league_id!r} not found") from exc
+        raise
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Sleeper returned non-dict for {league_id!r}")
+
+    if "scoring_settings" not in raw:
+        raise ValueError(f"Sleeper {league_id!r} has no scoring_settings")
+    scoring_raw = raw.get("scoring_settings")
+    if not isinstance(scoring_raw, dict):
+        raise ValueError(f"Sleeper {league_id!r} scoring_settings is not a dict")
+
+    # Coerce all values to float; Sleeper sometimes mixes ints and floats.
+    scoring: dict[str, float] = {}
+    for k, v in scoring_raw.items():
+        try:
+            scoring[str(k)] = float(v)
+        except (TypeError, ValueError):
+            continue
+
+    info = LeagueScoringInfo(
+        league_id=league_id,
+        name=str(raw.get("name") or "(unnamed)"),
+        season=str(raw.get("season") or ""),
+        season_type=str(raw.get("season_type") or ""),
+        scoring_settings=scoring,
+        scoring_hash=_scoring_hash(scoring),
+    )
+
+    with _cache_lock:
+        _cache[league_id] = (time.time(), info)
+
+    _LOGGER.info(
+        "league_compare.scoring_fetched league_id=%s name=%s keys=%d hash=%s",
+        league_id, info.name, len(scoring), info.scoring_hash,
+    )
+    return info
+
+
+def evict(league_id: str | None = None) -> None:
+    """Clear the cache for one league_id, or all if None."""
+    with _cache_lock:
+        if league_id is None:
+            _cache.clear()
+        else:
+            _cache.pop(league_id, None)

--- a/tests/league_comparison/test_combine_seasons.py
+++ b/tests/league_comparison/test_combine_seasons.py
@@ -1,0 +1,76 @@
+"""Test equal-weight season combination + missing-season behavior."""
+from __future__ import annotations
+
+import pytest
+
+from src.league_comparison import metrics as m
+
+
+def _pm(avg: float, med: float, sample: int = 24) -> m.PositionMetrics:
+    return m.PositionMetrics(
+        average=avg, median=med, p25=med * 0.7, p75=med * 1.3,
+        replacement_level=med * 0.5, elite=med * 1.5,
+        replacement_adj=avg - med * 0.5, sample_size=sample,
+    )
+
+
+def test_combine_seasons_equal_weight_averages_finite_values():
+    out = m.combine_seasons_equal_weight([100, 110, 120, 130])
+    assert out == pytest.approx(115.0)
+
+
+def test_combine_seasons_skips_none_values():
+    # 3 of 4 seasons available; the missing one drops out and the
+    # remaining three each effectively count 1/3 (the equal-weight rule)
+    out = m.combine_seasons_equal_weight([100, None, 120, 130])
+    assert out == pytest.approx((100 + 120 + 130) / 3)
+
+
+def test_combine_seasons_all_none_returns_zero():
+    assert m.combine_seasons_equal_weight([None, None, None]) == 0.0
+
+
+def test_combine_seasons_single_season_returns_that_season():
+    assert m.combine_seasons_equal_weight([42.5, None, None, None]) == 42.5
+
+
+def test_combine_metrics_equal_weight_averages_per_year():
+    per_year = {
+        2022: _pm(avg=200, med=180),
+        2023: _pm(avg=220, med=200),
+        2024: _pm(avg=210, med=190),
+    }
+    out = m.combine_metrics_equal_weight(per_year)
+    assert out.average == pytest.approx(210)
+    assert out.median == pytest.approx(190)
+    assert out.sample_size == 24
+
+
+def test_combine_metrics_equal_weight_skips_missing_seasons():
+    per_year = {
+        2022: _pm(avg=200, med=180),
+        2023: None,
+        2024: _pm(avg=220, med=200),
+    }
+    out = m.combine_metrics_equal_weight(per_year)
+    assert out.average == pytest.approx(210)  # average of (200, 220)
+    assert out.median == pytest.approx(190)
+
+
+def test_combine_metrics_equal_weight_all_empty_returns_zero():
+    out = m.combine_metrics_equal_weight({2022: None, 2023: None})
+    assert out.sample_size == 0
+    assert out.average == 0
+
+
+def test_combine_metrics_skips_zero_sample_size_seasons():
+    """A season that exists but produced an empty sample should still be
+    skipped — same effect as None — so the combined value reflects only
+    seasons with real data."""
+    per_year = {
+        2022: _pm(avg=200, med=180),
+        2023: m.PositionMetrics(0, 0, 0, 0, 0, 0, 0, 0),
+    }
+    out = m.combine_metrics_equal_weight(per_year)
+    # only 2022 contributes
+    assert out.average == pytest.approx(200)

--- a/tests/league_comparison/test_metrics.py
+++ b/tests/league_comparison/test_metrics.py
@@ -1,0 +1,230 @@
+"""Unit tests for src.league_comparison.metrics — the pure stat math."""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.league_comparison import metrics as m
+from src.league_comparison.scoring_engine import PlayerSeasonScore
+
+
+def _score(pts: float, pos: str = "QB", pid: str | None = None) -> PlayerSeasonScore:
+    return PlayerSeasonScore(
+        player_id=pid or f"p{int(pts*100)}",
+        player_name=f"Player {pts}",
+        position=pos,
+        raw_position=pos,
+        season=2024,
+        total_points=pts,
+        games_played=17,
+    )
+
+
+# ── top_n_by_position / flex_top_n ────────────────────────────────────
+
+def test_top_n_filters_by_position_and_sorts_desc():
+    pool = [
+        _score(100, "QB"), _score(200, "RB"), _score(300, "QB"),
+        _score(150, "QB"), _score(50, "QB"),
+    ]
+    out = m.top_n_by_position(pool, "QB", 3)
+    assert [s.total_points for s in out] == [300, 150, 100]
+
+
+def test_top_n_breaks_ties_with_player_id():
+    pool = [
+        _score(100, "QB", pid="b"),
+        _score(100, "QB", pid="a"),
+        _score(100, "QB", pid="c"),
+    ]
+    out = m.top_n_by_position(pool, "QB", 3)
+    assert [s.player_id for s in out] == ["a", "b", "c"]
+
+
+def test_top_n_handles_oversized_request():
+    pool = [_score(100, "QB"), _score(50, "QB")]
+    out = m.top_n_by_position(pool, "QB", 10)
+    assert len(out) == 2
+
+
+def test_flex_excludes_qb():
+    pool = [
+        _score(500, "QB"),    # would be #1 by points but excluded
+        _score(200, "RB"),
+        _score(150, "WR"),
+        _score(100, "TE"),
+    ]
+    out = m.flex_top_n(pool, n=10)
+    positions = {s.position for s in out}
+    assert "QB" not in positions
+    assert positions == {"RB", "WR", "TE"}
+    assert [s.total_points for s in out] == [200, 150, 100]
+
+
+def test_flex_top_n_with_size_limit():
+    pool = [_score(p, "WR") for p in [100, 95, 90, 85, 80]]
+    out = m.flex_top_n(pool, n=3)
+    assert [s.total_points for s in out] == [100, 95, 90]
+
+
+# ── position_metrics ─────────────────────────────────────────────────
+
+def test_position_metrics_basic():
+    pts = [300, 250, 200, 150, 100]
+    samples = [_score(p, "QB") for p in pts]
+    out = m.position_metrics(samples)
+    assert out.sample_size == 5
+    assert out.average == pytest.approx(200.0)
+    assert out.median == pytest.approx(200.0)
+    assert out.replacement_level == 100.0  # the Nth (last) player
+    assert out.elite == pytest.approx(250.0)  # mean of top 3 = (300+250+200)/3
+    assert out.replacement_adj == pytest.approx(100.0)
+
+
+def test_position_metrics_empty():
+    out = m.position_metrics([])
+    assert out.sample_size == 0
+    assert out.average == 0
+    assert out.median == 0
+
+
+def test_position_metrics_single_value():
+    out = m.position_metrics([_score(50, "TE")])
+    assert out.sample_size == 1
+    assert out.average == 50
+    assert out.median == 50
+    assert out.replacement_level == 50
+    assert out.replacement_adj == 0
+    assert out.elite == 50
+
+
+# ── blended scores ───────────────────────────────────────────────────
+
+def test_legacy_blended_is_avg_median_average():
+    metrics = m.PositionMetrics(
+        average=200, median=180, p25=150, p75=250,
+        replacement_level=100, elite=300, replacement_adj=100, sample_size=5,
+    )
+    assert m.legacy_blended(metrics) == pytest.approx(190.0)
+
+
+def test_improved_blended_uses_documented_weights():
+    metrics = m.PositionMetrics(
+        average=200, median=180, p25=120, p75=240,
+        replacement_level=100, elite=300, replacement_adj=100, sample_size=5,
+    )
+    expected = (
+        0.35 * 180 + 0.25 * 200 + 0.20 * 240 + 0.10 * 120 + 0.10 * 100
+    )
+    assert m.improved_blended(metrics) == pytest.approx(expected)
+
+
+# ── shares ───────────────────────────────────────────────────────────
+
+def test_position_shares_sum_to_100():
+    inp = {"QB": 100, "RB": 200, "WR": 300, "TE": 400}
+    shares = m.position_shares(inp)
+    assert sum(shares.values()) == pytest.approx(100.0)
+    assert shares["QB"] == pytest.approx(10.0)
+    assert shares["TE"] == pytest.approx(40.0)
+
+
+def test_position_shares_handles_zero_total():
+    shares = m.position_shares({"QB": 0, "RB": 0})
+    assert all(v == 0 for v in shares.values())
+
+
+def test_position_shares_treats_negative_as_zero():
+    shares = m.position_shares({"QB": -50, "RB": 100, "WR": 100, "TE": 100})
+    # Negative QB drops to zero in the total; RB/WR/TE split 100% three ways
+    assert shares["QB"] == 0
+    assert shares["RB"] == pytest.approx(100/3)
+
+
+# ── status_label ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "diff,expected",
+    [
+        (0.3, "Excellent match"),
+        (-0.4, "Excellent match"),
+        (1.0, "Good match"),
+        (-1.4, "Good match"),
+        (2.5, "Slightly high"),
+        (-2.5, "Slightly low"),
+        (4.5, "High"),
+        (-4.5, "Low"),
+        (8.0, "Too high"),
+        (-9.0, "Too low"),
+    ],
+)
+def test_status_label_bands(diff, expected):
+    assert m.status_label(diff) == expected
+
+
+# ── similarity score ─────────────────────────────────────────────────
+
+def test_similarity_score_perfect_match_is_100():
+    shares = {"QB": 25, "RB": 25, "WR": 30, "TE": 20}
+    out = m.similarity_score(shares, dict(shares), my_flex=200, baseline_flex=200)
+    assert out.score == 100
+    assert out.distortion_label == "Low"
+    assert "Extremely close" in out.label
+
+
+def test_similarity_score_small_difference_high():
+    my = {"QB": 26, "RB": 24, "WR": 30, "TE": 20}
+    base = {"QB": 25, "RB": 25, "WR": 30, "TE": 20}
+    # Combined = 2.0 pp diff + 0 flex dev → at 2 boundary, score 95
+    out = m.similarity_score(my, base, my_flex=200, baseline_flex=200)
+    assert out.score >= 95
+
+
+def test_similarity_score_meaningful_difference_drops():
+    my = {"QB": 35, "RB": 20, "WR": 25, "TE": 20}
+    base = {"QB": 25, "RB": 25, "WR": 30, "TE": 20}
+    # share dev = 10 + 5 + 5 + 0 = 20 pp -> straddles "Meaningfully different"
+    out = m.similarity_score(my, base, my_flex=200, baseline_flex=200)
+    assert 60 <= out.score <= 74
+    assert out.distortion_label == "High"
+
+
+def test_similarity_score_severe_distortion():
+    my = {"QB": 50, "RB": 20, "WR": 20, "TE": 10}
+    base = {"QB": 25, "RB": 25, "WR": 30, "TE": 20}
+    out = m.similarity_score(my, base, my_flex=300, baseline_flex=200)
+    assert out.score < 60
+    assert out.distortion_label == "Severe"
+
+
+def test_similarity_score_handles_zero_baseline_flex():
+    out = m.similarity_score(
+        {"QB": 25, "RB": 25, "WR": 30, "TE": 20},
+        {"QB": 25, "RB": 25, "WR": 30, "TE": 20},
+        my_flex=200, baseline_flex=0,
+    )
+    # No NaN, no crash; flex deviation simply zero
+    assert math.isfinite(out.score)
+    assert out.flex_dev_pct == 0
+
+
+# ── recommendations ──────────────────────────────────────────────────
+
+def test_recommendation_aligned_says_no_adjustment():
+    text = m.recommendation("QB", 0.3, my_share=25.0, baseline_share=24.7)
+    assert "essentially aligned" in text
+    assert "No adjustment" in text
+
+
+def test_recommendation_includes_culprit_hints_for_meaningful_diff():
+    text = m.recommendation("TE", 4.0, my_share=20.0, baseline_share=16.0)
+    assert "TE" in text
+    assert "+4.0" in text
+    assert "TE premium" in text or "PPR" in text  # one of the culprit hints
+
+
+def test_recommendation_lower_direction():
+    text = m.recommendation("WR", -3.0, my_share=27.0, baseline_share=30.0)
+    assert "lower" in text
+    assert "-3.0" in text

--- a/tests/league_comparison/test_scoring_engine.py
+++ b/tests/league_comparison/test_scoring_engine.py
@@ -1,0 +1,128 @@
+"""Test the per-player season scoring engine."""
+from __future__ import annotations
+
+import pytest
+
+from src.league_comparison.scoring_engine import (
+    compute_player_season_scores,
+    _canonical_position,
+)
+
+
+_PPR = {
+    "pass_yd": 0.04, "pass_td": 4, "pass_int": -2,
+    "rush_yd": 0.1, "rush_td": 6,
+    "rec": 1.0, "rec_yd": 0.1, "rec_td": 6,
+    "fum_lost": -2,
+}
+
+
+def _stat(pid: str, pos: str, week: int, **stats):
+    return {
+        "player_id": pid,
+        "player_name": pid.upper(),
+        "position": pos,
+        "season": 2024,
+        "week": week,
+        "passing_yards": 0, "passing_tds": 0, "interceptions": 0,
+        "rushing_yards": 0, "rushing_tds": 0,
+        "receptions": 0, "receiving_yards": 0, "receiving_tds": 0,
+        "fumbles_lost": 0,
+        **stats,
+    }
+
+
+def test_canonical_position_offense_passthrough():
+    assert _canonical_position("QB") == "QB"
+    assert _canonical_position("RB") == "RB"
+    assert _canonical_position("WR") == "WR"
+    assert _canonical_position("TE") == "TE"
+
+
+def test_canonical_position_collapses_idp():
+    assert _canonical_position("DE") == "DL"
+    assert _canonical_position("EDGE") == "DL"
+    assert _canonical_position("OLB") == "LB"
+    assert _canonical_position("CB") == "DB"
+    assert _canonical_position("FS") == "DB"
+
+
+def test_canonical_position_filters_unknown():
+    assert _canonical_position("K") is None    # kickers excluded
+    assert _canonical_position("OL") is None
+    assert _canonical_position("") is None
+    assert _canonical_position(None) is None
+
+
+def test_player_aggregates_across_weeks():
+    rows = [
+        _stat("p1", "QB", 1, passing_yards=300, passing_tds=2, interceptions=0),
+        _stat("p1", "QB", 2, passing_yards=200, passing_tds=1),
+    ]
+    scores = compute_player_season_scores(rows, _PPR)
+    assert len(scores) == 1
+    s = scores[0]
+    assert s.player_id == "p1"
+    assert s.position == "QB"
+    # week 1: 300*0.04 + 2*4 = 12+8 = 20.  week 2: 200*0.04 + 1*4 = 8+4 = 12
+    assert s.total_points == pytest.approx(32.0)
+    assert s.games_played == 2
+
+
+def test_multiple_players_split_correctly():
+    rows = [
+        _stat("qb1", "QB", 1, passing_yards=400, passing_tds=4),
+        _stat("rb1", "RB", 1, rushing_yards=120, rushing_tds=1, receptions=4, receiving_yards=30),
+        _stat("wr1", "WR", 1, receptions=8, receiving_yards=110, receiving_tds=1),
+    ]
+    scores = compute_player_season_scores(rows, _PPR)
+    by_pos = {s.position: s for s in scores}
+    assert set(by_pos.keys()) == {"QB", "RB", "WR"}
+    # QB: 400*0.04 + 4*4 = 32
+    assert by_pos["QB"].total_points == pytest.approx(32.0)
+    # RB: 120*0.1 + 6 + 4 + 30*0.1 = 12+6+4+3 = 25
+    assert by_pos["RB"].total_points == pytest.approx(25.0)
+    # WR: 8 + 11 + 6 = 25
+    assert by_pos["WR"].total_points == pytest.approx(25.0)
+
+
+def test_te_premium_only_applies_to_te():
+    scoring = {**_PPR, "bonus_rec_te": 0.5}
+    rows = [
+        _stat("te1", "TE", 1, receptions=6, receiving_yards=70),
+        _stat("wr1", "WR", 1, receptions=6, receiving_yards=70),
+    ]
+    scores = compute_player_season_scores(rows, scoring)
+    by_pos = {s.position: s for s in scores}
+    # TE: 6 + 7 + 6*0.5 = 6+7+3 = 16
+    assert by_pos["TE"].total_points == pytest.approx(16.0)
+    # WR: 6 + 7 = 13 (no premium)
+    assert by_pos["WR"].total_points == pytest.approx(13.0)
+
+
+def test_unknown_position_filtered_out():
+    rows = [
+        _stat("k1", "K", 1, rushing_yards=10),       # kicker — drop
+        _stat("ol1", "OL", 1, fumbles_lost=1),       # offensive line — drop
+        _stat("qb1", "QB", 1, passing_yards=200),    # keep
+    ]
+    scores = compute_player_season_scores(rows, _PPR)
+    assert {s.player_id for s in scores} == {"qb1"}
+
+
+def test_missing_scoring_settings_returns_empty():
+    rows = [_stat("qb1", "QB", 1, passing_yards=300)]
+    assert compute_player_season_scores(rows, {}) == []
+    assert compute_player_season_scores(rows, None) == []  # type: ignore[arg-type]
+
+
+def test_handles_player_id_field_alias():
+    """nflverse uses player_id; some fixtures might use player_id_gsis."""
+    row = {
+        "player_id_gsis": "g1", "player_name": "G1", "position": "RB",
+        "season": 2024, "week": 1,
+        "rushing_yards": 100, "rushing_tds": 1,
+    }
+    scores = compute_player_season_scores([row], _PPR)
+    assert len(scores) == 1
+    assert scores[0].player_id == "g1"

--- a/tests/league_comparison/test_service.py
+++ b/tests/league_comparison/test_service.py
@@ -1,0 +1,263 @@
+"""End-to-end test of the orchestrator with mocked I/O.
+
+We don't hit Sleeper or nflverse here — both are stubbed at the module
+boundary so the test runs offline and pins the response shape.
+"""
+from __future__ import annotations
+
+import json
+import pytest
+
+from src.league_comparison import (
+    historical_stats as _stats_mod,
+    service as _service,
+    sleeper_scoring as _sleeper_mod,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def isolate_caches(tmp_path, monkeypatch):
+    """Redirect both the per-league scoring cache and the disk
+    comparison cache to a temp dir so tests don't bleed into each
+    other or into real cache files."""
+    _sleeper_mod.evict()
+    monkeypatch.setattr(
+        _service, "_cache_dir", lambda: tmp_path / "lc_cache",
+    )
+    yield
+    _sleeper_mod.evict()
+
+
+_MY_SCORING = {
+    "pass_yd": 0.04, "pass_td": 5, "pass_int": -2,
+    "rush_yd": 0.1, "rush_td": 6,
+    "rec": 0.75, "rec_yd": 0.1, "rec_td": 6,
+    "bonus_rec_te": 0.38, "fum_lost": -2,
+}
+_BASE_SCORING = {
+    "pass_yd": 0.04, "pass_td": 4, "pass_int": -2,
+    "rush_yd": 0.1, "rush_td": 6,
+    "rec": 1.0, "rec_yd": 0.1, "rec_td": 6,
+    "bonus_rec_te": 0.5, "fum_lost": -2,
+}
+
+
+def _load_real_league_ids():
+    """Read the same config the service reads so the stub stays in
+    lockstep with whatever IDs are configured."""
+    config = _service._load_config()
+    return config["my_league"]["id"], config["baseline_league"]["id"]
+
+
+def _stub_scoring_fetch(monkeypatch):
+    my_id, base_id = _load_real_league_ids()
+
+    def fake(league_id, *, refresh=False):
+        if league_id == my_id:
+            return _sleeper_mod.LeagueScoringInfo(
+                league_id=league_id, name="My League",
+                season="2025", season_type="regular",
+                scoring_settings=_MY_SCORING,
+                scoring_hash="hashMY",
+            )
+        return _sleeper_mod.LeagueScoringInfo(
+            league_id=league_id, name="Standard Baseline",
+            season="2025", season_type="regular",
+            scoring_settings=_BASE_SCORING,
+            scoring_hash="hashBASE",
+        )
+    monkeypatch.setattr(_sleeper_mod, "fetch_league_scoring", fake)
+
+
+def _row(pid, pos, week, season, **stats):
+    base = {
+        "player_id": pid, "player_name": pid.upper(),
+        "position": pos, "season": season, "week": week,
+        "passing_yards": 0, "passing_tds": 0, "interceptions": 0,
+        "rushing_yards": 0, "rushing_tds": 0,
+        "receptions": 0, "receiving_yards": 0, "receiving_tds": 0,
+        "fumbles_lost": 0,
+    }
+    base.update(stats)
+    return base
+
+
+def _make_season(season: int):
+    """Generate enough mock players to fill the top-N samples for one
+    season."""
+    rows: list[dict] = []
+    # 30 QBs, 30 RBs, 40 WRs, 15 TEs — enough to cover the sample sizes
+    # plus headroom.  Vary points by index so ranking is deterministic.
+    for i in range(30):
+        for week in range(1, 18):
+            rows.append(_row(
+                f"qb{i}", "QB", week, season,
+                passing_yards=200 + (29 - i) * 5,
+                passing_tds=2 if i < 12 else 1,
+            ))
+    for i in range(30):
+        for week in range(1, 18):
+            rows.append(_row(
+                f"rb{i}", "RB", week, season,
+                rushing_yards=60 + (29 - i) * 3,
+                receptions=2 + (i % 4),
+                receiving_yards=15 + (i % 5) * 4,
+            ))
+    for i in range(40):
+        for week in range(1, 18):
+            rows.append(_row(
+                f"wr{i}", "WR", week, season,
+                receptions=4 + (39 - i) // 5,
+                receiving_yards=50 + (39 - i) * 2,
+            ))
+    for i in range(15):
+        for week in range(1, 18):
+            rows.append(_row(
+                f"te{i}", "TE", week, season,
+                receptions=3 + (14 - i) // 3,
+                receiving_yards=30 + (14 - i) * 2,
+            ))
+    return rows
+
+
+def _stub_stats_fetch(monkeypatch, available_seasons):
+    def fake_load(season):
+        if season in available_seasons:
+            return _make_season(season)
+        return None
+    monkeypatch.setattr(_stats_mod, "load_season_rows", fake_load)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────
+
+def test_build_comparison_returns_full_shape(monkeypatch, tmp_path):
+    _stub_scoring_fetch(monkeypatch)
+    _stub_stats_fetch(monkeypatch, available_seasons={2022, 2023, 2024, 2025})
+    # Point at the real config (it exists in the repo).
+    out = _service.build_comparison(refresh=True)
+
+    # Top-level keys
+    for key in ("meta", "summary", "similarity", "positions", "flex", "bySeason", "idp", "warnings"):
+        assert key in out, f"missing top-level key: {key}"
+
+    # Meta block
+    meta = out["meta"]
+    my_id, base_id = _load_real_league_ids()
+    assert meta["myLeague"]["id"] == my_id
+    assert meta["baselineLeague"]["id"] == base_id
+    assert meta["seasonsRequested"] == [2022, 2023, 2024, 2025]
+    assert meta["seasonsAvailable"] == [2022, 2023, 2024, 2025]
+    assert meta["seasonsUnavailable"] == []
+
+    # Per-position block has all four offense positions
+    assert set(out["positions"].keys()) == {"QB", "RB", "WR", "TE"}
+    for pos, comp in out["positions"].items():
+        assert "my" in comp
+        assert "baseline" in comp
+        assert "diffPpImproved" in comp
+        assert "diffPpLegacy" in comp
+        assert "status" in comp
+        assert "recommendation" in comp
+        assert comp["my"]["metrics"]["sampleSize"] > 0
+        assert comp["baseline"]["metrics"]["sampleSize"] > 0
+
+    # Similarity block
+    sim = out["similarity"]
+    assert 0 <= sim["score"] <= 100
+    assert sim["distortionLabel"] in {"Low", "Moderate", "High", "Severe"}
+
+    # IDP placeholder
+    assert out["idp"]["available"] is False
+    assert out["idp"]["status"] == "placeholder"
+
+    # bySeason has all four seasons
+    assert set(out["bySeason"].keys()) == {"2022", "2023", "2024", "2025"}
+
+
+def test_missing_season_emits_warning(monkeypatch):
+    _stub_scoring_fetch(monkeypatch)
+    _stub_stats_fetch(monkeypatch, available_seasons={2022, 2023, 2024})  # 2025 missing
+    out = _service.build_comparison(refresh=True)
+    assert out["meta"]["seasonsUnavailable"] == [2025]
+    assert any("2025" in w for w in out["warnings"])
+    # Combined still uses three seasons, equally weighted
+    assert out["meta"]["seasonsAvailable"] == [2022, 2023, 2024]
+
+
+def test_single_season_emits_limited_data_warning(monkeypatch):
+    _stub_scoring_fetch(monkeypatch)
+    _stub_stats_fetch(monkeypatch, available_seasons={2024})
+    out = _service.build_comparison(refresh=True)
+    assert out["meta"]["seasonsAvailable"] == [2024]
+    assert any("limited" in w.lower() for w in out["warnings"])
+
+
+def test_cache_hit_avoids_recomputation(monkeypatch):
+    _stub_scoring_fetch(monkeypatch)
+    _stub_stats_fetch(monkeypatch, available_seasons={2022, 2023, 2024, 2025})
+
+    # Count how many times stats are loaded.
+    call_count = {"n": 0}
+    real_load = _stats_mod.load_season_rows
+
+    def counting_load(season):
+        call_count["n"] += 1
+        return real_load(season)
+
+    monkeypatch.setattr(_stats_mod, "load_season_rows", counting_load)
+
+    first = _service.build_comparison(refresh=True)
+    n_after_first = call_count["n"]
+    assert n_after_first > 0
+
+    # Second call without refresh should hit the disk cache and skip
+    # all stat loads.
+    second = _service.build_comparison(refresh=False)
+    assert call_count["n"] == n_after_first
+    assert second["meta"]["cacheHit"] is True
+    # Same shape, same positions
+    assert second["positions"]["QB"]["my"]["improvedScore"] == first["positions"]["QB"]["my"]["improvedScore"]
+
+
+def test_refresh_bypasses_cache(monkeypatch):
+    _stub_scoring_fetch(monkeypatch)
+    _stub_stats_fetch(monkeypatch, available_seasons={2024})
+
+    call_count = {"n": 0}
+    real_load = _stats_mod.load_season_rows
+
+    def counting_load(season):
+        call_count["n"] += 1
+        return real_load(season)
+
+    monkeypatch.setattr(_stats_mod, "load_season_rows", counting_load)
+
+    _service.build_comparison(refresh=True)
+    after_first = call_count["n"]
+    _service.build_comparison(refresh=True)
+    # refresh=True must reload every season again
+    assert call_count["n"] == 2 * after_first
+
+
+def test_baseline_my_have_different_scoring_produces_meaningful_diff(monkeypatch):
+    """Sanity: a high-PPR / TEP baseline vs a 0.75 PPR / lower-TEP my
+    league should produce non-zero share differences when applied to
+    the same stat rows."""
+    _stub_scoring_fetch(monkeypatch)
+    _stub_stats_fetch(monkeypatch, available_seasons={2024})
+    out = _service.build_comparison(refresh=True)
+
+    diffs = [abs(out["positions"][p]["diffPpImproved"]) for p in ("QB", "RB", "WR", "TE")]
+    # At least one position should have a non-trivial difference given
+    # the divergent scoring setups.
+    assert max(diffs) > 0.1
+
+
+def test_payload_is_json_serializable(monkeypatch):
+    _stub_scoring_fetch(monkeypatch)
+    _stub_stats_fetch(monkeypatch, available_seasons={2024})
+    out = _service.build_comparison(refresh=True)
+    # Will raise if anything in the payload is non-serializable
+    json.dumps(out)

--- a/tests/league_comparison/test_sleeper_scoring.py
+++ b/tests/league_comparison/test_sleeper_scoring.py
@@ -1,0 +1,119 @@
+"""Tests for the Sleeper scoring fetcher's caching + parsing behavior."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.league_comparison import sleeper_scoring as ss
+
+
+_RESPONSE = {
+    "league_id": "L1",
+    "name": "Test League",
+    "season": "2025",
+    "season_type": "regular",
+    "scoring_settings": {
+        "pass_yd": 0.04,
+        "pass_td": 5,
+        "rec": 0.75,
+        "bonus_rec_te": 0.38,
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def clean_cache():
+    ss.evict()
+    yield
+    ss.evict()
+
+
+def test_fetch_parses_scoring_settings(monkeypatch):
+    monkeypatch.setattr(ss, "_fetch_raw", lambda lid: _RESPONSE)
+    info = ss.fetch_league_scoring("L1")
+    assert info.league_id == "L1"
+    assert info.name == "Test League"
+    assert info.season == "2025"
+    assert info.scoring_settings == {
+        "pass_yd": 0.04, "pass_td": 5.0, "rec": 0.75, "bonus_rec_te": 0.38,
+    }
+    assert len(info.scoring_hash) == 12
+
+
+def test_fetch_caches_within_ttl(monkeypatch):
+    calls = {"n": 0}
+
+    def counting(lid):
+        calls["n"] += 1
+        return _RESPONSE
+
+    monkeypatch.setattr(ss, "_fetch_raw", counting)
+    ss.fetch_league_scoring("L1")
+    ss.fetch_league_scoring("L1")
+    ss.fetch_league_scoring("L1")
+    assert calls["n"] == 1
+
+
+def test_refresh_bypasses_cache(monkeypatch):
+    calls = {"n": 0}
+
+    def counting(lid):
+        calls["n"] += 1
+        return _RESPONSE
+
+    monkeypatch.setattr(ss, "_fetch_raw", counting)
+    ss.fetch_league_scoring("L1")
+    ss.fetch_league_scoring("L1", refresh=True)
+    assert calls["n"] == 2
+
+
+def test_two_leagues_cached_separately(monkeypatch):
+    calls = {"n": 0}
+
+    def counting(lid):
+        calls["n"] += 1
+        return {**_RESPONSE, "league_id": lid, "name": f"League {lid}"}
+
+    monkeypatch.setattr(ss, "_fetch_raw", counting)
+    a = ss.fetch_league_scoring("A")
+    b = ss.fetch_league_scoring("B")
+    assert a.name == "League A"
+    assert b.name == "League B"
+    # Repeat A → should hit cache, not re-fetch
+    ss.fetch_league_scoring("A")
+    assert calls["n"] == 2
+
+
+def test_missing_league_id_raises():
+    with pytest.raises(ValueError):
+        ss.fetch_league_scoring("")
+
+
+def test_malformed_response_raises(monkeypatch):
+    monkeypatch.setattr(ss, "_fetch_raw", lambda lid: {"name": "no scoring"})
+    with pytest.raises(ValueError):
+        ss.fetch_league_scoring("L1")
+
+
+def test_scoring_hash_stable_across_key_order(monkeypatch):
+    """Two equivalent dicts with different key insertion orders must
+    produce the same scoring_hash so cache keys are stable."""
+    monkeypatch.setattr(ss, "_fetch_raw", lambda lid: _RESPONSE)
+    info_a = ss.fetch_league_scoring("L1")
+    ss.evict()
+
+    reordered = {
+        "name": "Test League",
+        "season": "2025",
+        "season_type": "regular",
+        "scoring_settings": {
+            "rec": 0.75,
+            "pass_td": 5,
+            "bonus_rec_te": 0.38,
+            "pass_yd": 0.04,
+        },
+    }
+    monkeypatch.setattr(ss, "_fetch_raw", lambda lid: reordered)
+    info_b = ss.fetch_league_scoring("L1")
+    assert info_a.scoring_hash == info_b.scoring_hash


### PR DESCRIPTION
## Summary

New **League Comparison** page that compares your custom Sleeper league scoring (`1312736351547850752`) against a standard baseline league (`1328545898812170240`) across 2022–2025 NFL seasons. Answers: *does my custom scoring preserve roughly normal positional value, or does it accidentally over- or under-value certain positions?*

## What it does

For each league, fetches `scoring_settings` directly from Sleeper, applies them to historical nflverse weekly stats to compute fantasy points **under each league's actual rules**, then samples top performers per position and compares the distributions.

- **Sample sizes**: top 24 QB / 24 RB / 36 WR / 12 TE / 96 offensive flex (RB ∪ WR ∪ TE, QB excluded)
- **Seasons**: 2022, 2023, 2024, 2025 — **equal weighted** (no recency weighting). Missing seasons drop out cleanly with warnings.
- **Two methods, both shown**:
  - **Legacy/Simple**: `(average + median) / 2` — your original heuristic, preserved as a reference.
  - **Improved**: `0.35·median + 0.25·avg + 0.20·p75 + 0.10·p25 + 0.10·replacement_adj` — multi-signal weighted blend.
- **Outputs**: positional shares, status labels (Excellent/Good/Slightly High/Low/Too High/Too Low), 0–100 similarity score with distortion banding, plain-English per-position recommendations, top-96 flex comparison, year-by-year expandable detail, methodology section.
- **IDP** is scaffolded but inert — flipping `available=True` in `idp.py` is the only change needed to enable it later.

## Architecture highlights

- Reuses the existing `src/nfl_data/realized_points.py::compute_weekly_points` engine (already the source of truth for Sleeper-format scoring).
- Reuses `src/nfl_data/ingest.py::fetch_weekly_stats` (24h disk cache + nflverse_direct fallback).
- New 7-day disk cache for the comparison result, keyed on league IDs + scoring hashes + season set + version.
- **Deliberately bypasses the league registry** — this is a calibration tool that only needs `scoring_settings`, never rosters/teams/draft. League IDs live in `config/league_comparison.json`; the UI never sends raw Sleeper IDs in requests.
- Pure SVG charts via the existing `frontend/lib/chart-primitives.js` — no new chart dep.

## Files

**New backend** — `src/league_comparison/` (7 files): `sleeper_scoring`, `historical_stats`, `scoring_engine`, `metrics`, `idp`, `service`, `__init__`. New endpoint `GET /api/league-comparison?refresh=` in `server.py`. Config at `config/league_comparison.json`.

**New frontend** — `frontend/app/league-comparison/page.jsx` + 7 section components + Next.js proxy route. Nav entry added to `AppShellWrapper.jsx::PRIMARY_NAV`.

**New tests** — 62 new unit tests under `tests/league_comparison/` covering metrics, season combine, scoring engine, sleeper fetcher, and end-to-end orchestration with mocked I/O.

## Test plan

- [x] `pytest tests/league_comparison/` — 62/62 passing
- [x] `pytest tests/league_comparison/ tests/nfl_data/ tests/utils/ tests/identity/` — 357/357 passing
- [x] `python -c "import server"` — server.py parses + imports cleanly
- [x] All league_comparison Python modules import cleanly
- [x] Config file deserializes and exposes the expected league IDs / sample sizes
- [ ] Manual: hit `GET /api/league-comparison` with backend running, inspect JSON
- [ ] Manual: navigate to `/league-comparison` in the running app, verify all 5 tabs render and the Recalculate button bypasses cache
- [ ] Manual: 375px viewport renders without horizontal scroll
- [ ] Manual: smoke-check `/rankings`, `/trade`, `/league` still load normally

## Notes

- Pre-existing collection errors in `tests/api/`, `tests/public_league/`, `tests/scripts/`, `tests/scoring/`, `tests/ros/` are unrelated to this PR — they're caused by missing third-party deps (`requests`, `fastapi`) in the dev container, not by anything this branch changed.
- 2025 season availability depends on nflverse publishing; the page degrades gracefully and surfaces unavailable seasons in the warnings panel.

https://claude.ai/code/session_019A8G4VhqRnafzFQBeaGkqc


---
_Generated by [Claude Code](https://claude.ai/code/session_019A8G4VhqRnafzFQBeaGkqc)_