### PR TITLE
polish(league-comparison): 5 follow-ups on top of #371

### DIFF
--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -346,6 +346,7 @@ function MobileTopBar() {
       finder: "Finder",
       angle: "Angle",
       league: "League",
+      "league-comparison": "League Comp",
       rosters: "Rosters",
       trades: "Trades",
       settings: "Settings",

--- a/frontend/app/league-comparison/sections/PositionalTable.jsx
+++ b/frontend/app/league-comparison/sections/PositionalTable.jsx
@@ -48,6 +48,7 @@ export default function PositionalTable({ data, method, setMethod }) {
               <th style={{ textAlign: "right" }}>Diff (pp)</th>
               <th style={{ textAlign: "right" }}>Rel %</th>
               <th>Status</th>
+              <th style={{ minWidth: 240 }}>Recommendation</th>
             </tr>
           </thead>
           <tbody>
@@ -57,7 +58,7 @@ export default function PositionalTable({ data, method, setMethod }) {
                 return (
                   <tr key={pos}>
                     <td>{pos}</td>
-                    <td colSpan={7} className="muted">—</td>
+                    <td colSpan={8} className="muted">—</td>
                   </tr>
                 );
               }
@@ -77,26 +78,14 @@ export default function PositionalTable({ data, method, setMethod }) {
                   <td style={{ ...mono(), color: tone }}>{fmtSigned(diff)}</td>
                   <td style={{ ...mono(), color: tone }}>{fmtSigned(c.relDiffPct)}%</td>
                   <td style={{ color: tone }}>{c.status}</td>
+                  <td className="text-sm" style={{ minWidth: 240, maxWidth: 420, lineHeight: 1.4 }}>
+                    {c.recommendation}
+                  </td>
                 </tr>
               );
             })}
           </tbody>
         </table>
-      </div>
-
-      <div style={{ marginTop: "var(--space-md)" }}>
-        <h3 className="section-title" style={{ fontSize: "1rem" }}>Recommendations</h3>
-        <ul style={{ marginTop: 6, paddingLeft: 18 }}>
-          {POSITIONS.map((pos) => {
-            const c = positions[pos];
-            if (!c) return null;
-            return (
-              <li key={pos} className="text-sm" style={{ marginBottom: 6 }}>
-                {c.recommendation}
-              </li>
-            );
-          })}
-        </ul>
       </div>
     </div>
   );

--- a/frontend/app/league-comparison/sections/YearByYear.jsx
+++ b/frontend/app/league-comparison/sections/YearByYear.jsx
@@ -1,12 +1,54 @@
 "use client";
 
 import { useState } from "react";
+import {
+  CHART_COLORS,
+  categoricalColor,
+  chartBox,
+  formatNumber,
+  linearScale,
+  linePath,
+} from "@/lib/chart-primitives";
 
 /**
  * YearByYear — collapsible per-season detail.  For each available
  * season, shows a per-position comparison table plus a flex line.
+ *
+ * Also renders a per-season trend chart at the top so the user can
+ * see whether any single season looks like an outlier in the
+ * combined-view share differences.
  */
 const POSITIONS = ["QB", "RB", "WR", "TE"];
+
+// Improved-method blended-score weights — must mirror the backend
+// constants in src/league_comparison/metrics.py.  Used to derive
+// per-season positional shares client-side from the per-season
+// PositionMetrics dicts (the API doesn't pre-compute per-season
+// shares to keep payload size down).
+const W = {
+  median: 0.35, average: 0.25, p75: 0.20, p25: 0.10, replAdj: 0.10,
+};
+
+function improvedBlended(m) {
+  if (!m) return 0;
+  return (
+    W.median * (m.median || 0)
+    + W.average * (m.average || 0)
+    + W.p75 * (m.p75 || 0)
+    + W.p25 * (m.p25 || 0)
+    + W.replAdj * (m.replacementAdj || 0)
+  );
+}
+
+function positionShares(scoresByPos) {
+  const total = Object.values(scoresByPos).reduce(
+    (a, v) => a + Math.max(0, v || 0), 0,
+  );
+  if (total <= 0) return Object.fromEntries(Object.keys(scoresByPos).map((k) => [k, 0]));
+  return Object.fromEntries(
+    Object.entries(scoresByPos).map(([k, v]) => [k, (Math.max(0, v) / total) * 100]),
+  );
+}
 
 export default function YearByYear({ data }) {
   const bySeason = data?.bySeason || {};
@@ -28,6 +70,7 @@ export default function YearByYear({ data }) {
         Each season is computed independently and then equally averaged for the
         combined view.  Click a season to expand its detailed breakdown.
       </p>
+      <ShareTrendChart bySeason={bySeason} />
       <div style={{ marginTop: "var(--space-sm)", display: "flex", flexDirection: "column", gap: 8 }}>
         {seasons.map((season) => (
           <SeasonRow
@@ -38,6 +81,133 @@ export default function YearByYear({ data }) {
             onToggle={() => setOpenSeason(openSeason === season ? null : season)}
           />
         ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Trend chart: positional share diff (my − baseline) per season ──
+//
+// Useful as a sanity check on the combined view: if a single season
+// dragged the average sharply, you see it here as a spike or a
+// crossing zero line.  X-axis is seasons (oldest → newest), one line
+// per offense position, y-axis is share difference in pp.  A
+// horizontal zero line marks "perfectly aligned with baseline".
+function ShareTrendChart({ bySeason }) {
+  const seasons = Object.keys(bySeason).sort();
+  if (seasons.length < 2) {
+    // Single season → trend is not meaningful; just skip.
+    return null;
+  }
+
+  const series = POSITIONS.map((pos) => ({
+    pos,
+    points: seasons.map((season) => {
+      const block = bySeason[season] || {};
+      const myPos = block.my?.positions || {};
+      const basePos = block.baseline?.positions || {};
+      const myScores = Object.fromEntries(POSITIONS.map((p) => [p, improvedBlended(myPos[p])]));
+      const baseScores = Object.fromEntries(POSITIONS.map((p) => [p, improvedBlended(basePos[p])]));
+      const myShares = positionShares(myScores);
+      const baseShares = positionShares(baseScores);
+      return (myShares[pos] || 0) - (baseShares[pos] || 0);
+    }),
+  }));
+
+  const allDiffs = series.flatMap((s) => s.points);
+  const maxAbs = Math.max(1, ...allDiffs.map((v) => Math.abs(v)));
+  const yLo = -maxAbs;
+  const yHi = maxAbs;
+
+  const width = 640;
+  const height = 220;
+  const { innerWidth, innerHeight, viewBox, plotTransform, margin } = chartBox({
+    width, height, margin: { top: 16, right: 16, bottom: 30, left: 44 },
+  });
+
+  const xScale = linearScale(0, Math.max(1, seasons.length - 1), 0, innerWidth);
+  const yScale = linearScale(yLo, yHi, innerHeight, 0);
+
+  return (
+    <div style={{ marginTop: "var(--space-sm)" }}>
+      <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5, marginBottom: 4 }}>
+        Share difference (my − baseline) by season — improved method
+      </div>
+      <div style={{ background: "rgba(0,0,0,0.15)", borderRadius: 6, padding: 8 }}>
+        <svg
+          viewBox={viewBox}
+          role="img"
+          aria-label="Per-season positional share difference trend"
+          style={{ width: "100%", height: "auto" }}
+        >
+          <g transform={plotTransform}>
+            {/* Zero line */}
+            <line
+              x1={0} x2={innerWidth}
+              y1={yScale(0)} y2={yScale(0)}
+              stroke={CHART_COLORS.axis}
+              strokeDasharray="4 3"
+            />
+            {/* Y-axis ticks */}
+            {[yLo, yLo / 2, 0, yHi / 2, yHi].map((v, i) => (
+              <g key={i}>
+                <line
+                  x1={0} x2={innerWidth}
+                  y1={yScale(v)} y2={yScale(v)}
+                  stroke={CHART_COLORS.grid}
+                  strokeOpacity={0.4}
+                />
+                <text
+                  x={-6} y={yScale(v) + 3}
+                  textAnchor="end" fontSize={10}
+                  fill={CHART_COLORS.axisLabel}
+                >
+                  {(v >= 0 ? "+" : "") + formatNumber(v, 1)}
+                </text>
+              </g>
+            ))}
+            {/* X-axis season labels */}
+            {seasons.map((season, i) => (
+              <text
+                key={season}
+                x={xScale(i)} y={innerHeight + 16}
+                textAnchor="middle" fontSize={11}
+                fill={CHART_COLORS.axisLabel}
+              >
+                {season}
+              </text>
+            ))}
+            {/* Series lines + markers */}
+            {series.map((s, idx) => {
+              const color = categoricalColor(idx);
+              const pts = s.points.map((v, i) => [xScale(i), yScale(v)]);
+              return (
+                <g key={s.pos}>
+                  <path
+                    d={linePath(pts)}
+                    fill="none"
+                    stroke={color}
+                    strokeWidth={2}
+                  />
+                  {pts.map(([cx, cy], i) => (
+                    <circle key={i} cx={cx} cy={cy} r={3.5} fill={color}>
+                      <title>{`${s.pos} ${seasons[i]}: ${(s.points[i] >= 0 ? "+" : "") + formatNumber(s.points[i], 2)} pp`}</title>
+                    </circle>
+                  ))}
+                </g>
+              );
+            })}
+          </g>
+          {/* Legend (bottom-right of chart area) */}
+          <g transform={`translate(${margin.left}, ${height - 4})`}>
+            {series.map((s, idx) => (
+              <g key={s.pos} transform={`translate(${idx * 56}, -18)`}>
+                <rect x={0} y={-7} width={10} height={3} fill={categoricalColor(idx)} />
+                <text x={14} y={-4} fontSize={10} fill={CHART_COLORS.axisLabel}>{s.pos}</text>
+              </g>
+            ))}
+          </g>
+        </svg>
       </div>
     </div>
   );

--- a/src/league_comparison/scoring_engine.py
+++ b/src/league_comparison/scoring_engine.py
@@ -98,6 +98,8 @@ def compute_player_season_scores(
         }
     )
 
+    unknown_positions: set[str] = set()
+
     for row in rows or []:
         pid = str(row.get("player_id") or row.get("player_id_gsis") or "").strip()
         if not pid:
@@ -105,6 +107,8 @@ def compute_player_season_scores(
         raw_pos = str(row.get("position") or "").strip().upper()
         canonical = _canonical_position(raw_pos)
         if canonical not in _TRACKED_POSITIONS:
+            if raw_pos:
+                unknown_positions.add(raw_pos)
             continue
         try:
             row_season = int(row.get("season") or season or 0)
@@ -146,4 +150,11 @@ def compute_player_season_scores(
                 games_played=int(b["games"]),
             )
         )
+
+    if unknown_positions:
+        _LOGGER.warning(
+            "scoring_engine.unknown_positions_dropped season=%s positions=%s",
+            season, sorted(unknown_positions),
+        )
+
     return out

--- a/src/league_comparison/service.py
+++ b/src/league_comparison/service.py
@@ -353,6 +353,21 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
         k: int(v) for k, v in (config.get("sample_sizes") or {}).items()
     }
 
+    # Fail fast on a malformed config rather than silently producing
+    # zeroed metrics when a position key is missing or non-positive.
+    _required_sample_keys = ("QB", "RB", "WR", "TE", "FLEX")
+    _missing = [k for k in _required_sample_keys if k not in sample_sizes]
+    if _missing:
+        raise ValueError(
+            f"config/league_comparison.json missing sample_sizes keys: {_missing}"
+        )
+    _bad = [k for k in _required_sample_keys if sample_sizes[k] <= 0]
+    if _bad:
+        raise ValueError(
+            f"config/league_comparison.json sample_sizes must be positive, "
+            f"got non-positive values for: {_bad}"
+        )
+
     my_cfg = config["my_league"]
     base_cfg = config["baseline_league"]
 


### PR DESCRIPTION
## Summary

Five small follow-up polish items on top of [#371](https://github.com/jasonleetucker-code/riskittogetthebrisket/pull/371). All defensive / UX polish, no spec or contract changes.

- **Mobile page title** — add `"league-comparison": "League Comp"` to the mobile-bar title map (`AppShellWrapper.jsx`). Direct mobile loads now show "League Comp" instead of the generic "Brisket" fallback.
- **Recommendation column** — promote per-position recommendations from a bulleted list below the table to a 9th column in `PositionalTable.jsx`. Restores the spec's 9-column layout while keeping full sentences readable (240-420px cell, wraps).
- **Year-by-year trend chart** — add a per-season trend chart at the top of `YearByYear.jsx` showing positional share difference (my − baseline) by season. Pure SVG via existing `chart-primitives.js` — no new deps. Lets the user spot outlier seasons that the equally-weighted combined view smooths over.
- **Config validation** — `service.build_comparison` now validates that `config.sample_sizes` contains positive values for QB/RB/WR/TE/FLEX before running. Malformed config fails fast instead of silently zeroing the missing position.
- **Unknown-position logging** — `scoring_engine.compute_player_season_scores` tracks unique unknown raw positions encountered and logs once per season at WARNING. Helps diagnose upstream nflverse schema drift without per-row spam.

## Test plan

- [x] `pytest tests/league_comparison/` — 62 passed in 0.62s
- [x] `npm run build` — green, `/league-comparison` page 10.1 kB
- [ ] Manual smoke after merge: mobile title shows "League Comp", recommendation column visible, trend chart renders with 4 lines (QB/RB/WR/TE), zero line dashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)