### PR TITLE
feat(league-comparison): blended volume+pace score; weeks 1-17 only

### DIFF
--- a/config/league_comparison.json
+++ b/config/league_comparison.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1",
+  "version": "v1.2",
   "my_league": {
     "id": "1312736351547850752",
     "label": "My League"

--- a/frontend/app/league-comparison/sections/Methodology.jsx
+++ b/frontend/app/league-comparison/sections/Methodology.jsx
@@ -49,6 +49,46 @@ export default function Methodology({ data }) {
         <li>Top {samples.FLEX || 96} offensive flex (RB ∪ WR ∪ TE, QBs excluded)</li>
       </ul>
 
+      <h3 style={{ marginTop: "var(--space-md)" }}>Week range</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        Each season uses regular-season <strong>weeks 1–17 only</strong>.
+        Week 18 is dropped because most playoff-bound teams rest starters,
+        which would distort top-of-the-board scoring.  Postseason rows are
+        also excluded — they're already filtered out by the same gate.
+      </p>
+
+      <h3 style={{ marginTop: "var(--space-md)" }}>Player ranking — blended score</h3>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        Every player's season is reduced to a single <strong>blended
+        score</strong> that mixes total fantasy points (volume — what they
+        actually scored) with their per-game pace extrapolated to a full
+        17-week season (pace — what they'd have scored at full
+        availability).  This rewards a player who missed weeks at an
+        elite pace without erasing the volume signal a workhorse 17-game
+        starter brings.
+      </p>
+      <ul className="text-sm" style={{ paddingLeft: 20, lineHeight: 1.6 }}>
+        <li>
+          Formula: <code>0.5 × total_points + 0.5 × (ppg × 17)</code>
+          when <em>games_played ≥ 8</em>; otherwise just total points.
+        </li>
+        <li>
+          The 8-game minimum prevents a tiny-sample outlier (e.g. one
+          30-point week) from inflating PPG.  Below 8 games, the player
+          is ranked on volume alone.
+        </li>
+        <li>
+          A 17-game starter has ppg×17 == total, so blended == total.
+          Players who missed weeks slot between their actual total and
+          their full-season-equivalent total.
+        </li>
+      </ul>
+      <p className="text-sm" style={{ lineHeight: 1.6 }}>
+        Top-N samples and all per-position metrics (average, median, P25,
+        P75, replacement, elite, replacement-adj) are computed from
+        blended scores, not raw totals.
+      </p>
+
       <h3 style={{ marginTop: "var(--space-md)" }}>Seasons</h3>
       <p className="text-sm" style={{ lineHeight: 1.6 }}>
         Requested: <strong>{seasonsReq}</strong>. Available: <strong>{seasonsAvail}</strong>.

--- a/frontend/app/league-comparison/sections/YearByYear.jsx
+++ b/frontend/app/league-comparison/sections/YearByYear.jsx
@@ -309,14 +309,18 @@ function SeasonSide({ title, data, accent }) {
       {top.length > 0 && (
         <div style={{ marginTop: 8 }}>
           <div className="muted text-xs" style={{ textTransform: "uppercase", letterSpacing: 0.5 }}>
-            Top players (this league's scoring)
+            Top players — blended score (volume + pace)
           </div>
           <ol className="text-xs" style={{ marginTop: 4, paddingLeft: 20, lineHeight: 1.7 }}>
             {top.map((p) => (
               <li key={p.playerId}>
                 <strong>{p.name}</strong>{" "}
                 <span className="muted">({p.position})</span>{" "}
-                <span style={{ fontFamily: "var(--mono)" }}>{fmt(p.totalPoints)} pts</span>
+                <span style={{ fontFamily: "var(--mono)" }}>{fmt(p.blendedScore)}</span>
+                <span className="muted" style={{ marginLeft: 6 }}>
+                  · {fmt(p.totalPoints)} pts in {p.gamesPlayed} g{" "}
+                  ({fmt(p.pointsPerGame)} ppg)
+                </span>
               </li>
             ))}
           </ol>

--- a/src/league_comparison/historical_stats.py
+++ b/src/league_comparison/historical_stats.py
@@ -6,6 +6,10 @@ which wraps nflverse.  When nflverse hasn't published a season yet
 (typical for the most recent season), we fall back to Sleeper via
 :mod:`.sleeper_stats`.  Both sources emit nflverse-shaped rows so the
 downstream scoring engine doesn't care which fed it.
+
+Both sources are filtered to **regular-season weeks 1-17 only**
+before they leave this module — week 18 is the starter-rest week for
+most playoff-bound teams and would distort the multi-year sample.
 """
 from __future__ import annotations
 
@@ -17,6 +21,13 @@ from src.nfl_data import ingest as _ingest
 from . import sleeper_stats as _sleeper_stats
 
 _LOGGER = logging.getLogger(__name__)
+
+# Inclusive upper bound on regular-season week.  The 2021+ NFL season
+# is 18 weeks, but we drop week 18 to align with pre-2021 17-game
+# seasons and to skip the starter-rest distortion at the top of the
+# rankings.  nflverse postseason rows (week >= 19) are also excluded
+# by this filter as a side benefit.
+_MAX_REGULAR_WEEK = 17
 
 # Which source produced each season's rows in the most recent call.
 # Surfaces through :func:`summarize_availability` so the API meta
@@ -30,6 +41,29 @@ def _set_source(season: int, source: str) -> None:
 
 def get_source_for(season: int) -> str | None:
     return _LAST_SOURCE.get(int(season))
+
+
+def _filter_to_regular_season(
+    rows: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Drop rows past week 17 (and any malformed-week row).
+
+    Applied to BOTH nflverse and Sleeper output so the comparison
+    samples a consistent week range regardless of source.  Postseason
+    rows (week >= 19 in nflverse) and week 18 starter-rest games drop
+    cleanly; rows with a missing/non-numeric week field also drop.
+    """
+    if not rows:
+        return []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            week = int(row.get("week") or 0)
+        except (TypeError, ValueError):
+            continue
+        if 1 <= week <= _MAX_REGULAR_WEEK:
+            out.append(row)
+    return out
 
 
 def load_season_rows(season: int) -> list[dict[str, Any]] | None:
@@ -57,6 +91,7 @@ def load_season_rows(season: int) -> list[dict[str, Any]] | None:
             season, exc,
         )
         rows = []
+    rows = _filter_to_regular_season(rows)
     if rows:
         _set_source(season, "nflverse")
         return rows
@@ -74,6 +109,7 @@ def load_season_rows(season: int) -> list[dict[str, Any]] | None:
             season, exc,
         )
         sleeper_rows = []
+    sleeper_rows = _filter_to_regular_season(sleeper_rows)
     if sleeper_rows:
         _set_source(season, "sleeper")
         return sleeper_rows

--- a/src/league_comparison/metrics.py
+++ b/src/league_comparison/metrics.py
@@ -45,30 +45,36 @@ IMPROVED_WEIGHT_REPL_ADJ: float = 0.10
 
 
 # ── Sampling ──────────────────────────────────────────────────────────
+#
+# Ranking is by ``blended_score`` (the volume+pace composite from
+# :func:`src.league_comparison.scoring_engine.compute_blended_score`),
+# not raw ``total_points``.  Players who missed weeks at an elite pace
+# get partial credit; full-season starters score the same as before
+# (blended == total when games_played == 17).
 
 def top_n_by_position(
     scores: Iterable[PlayerSeasonScore], position: str, n: int,
 ) -> list[PlayerSeasonScore]:
-    """Return the top-N season scores for ``position``, sorted DESC.
+    """Return the top-N season scores for ``position``, sorted DESC by
+    blended score.
 
-    Ties on ``total_points`` are broken by ``player_id`` for stable
-    output across runs (so tests pin reliably).
+    Ties are broken by ``player_id`` for stable output across runs
+    (so tests pin reliably).
     """
     pool = [s for s in scores if s.position == position]
-    pool.sort(key=lambda s: (-s.total_points, s.player_id))
+    pool.sort(key=lambda s: (-s.blended_score, s.player_id))
     return pool[: max(0, int(n))]
 
 
 def flex_top_n(
     scores: Iterable[PlayerSeasonScore], n: int = 96,
 ) -> list[PlayerSeasonScore]:
-    """Top-N RB/WR/TE pool, QB excluded.
+    """Top-N RB/WR/TE pool, QB excluded, ranked by blended score.
 
-    Used for the offensive flex comparison.  Same tie-break as
-    :func:`top_n_by_position`.
+    Same tie-break and ranking signal as :func:`top_n_by_position`.
     """
     pool = [s for s in scores if s.position in FLEX_POSITIONS]
-    pool.sort(key=lambda s: (-s.total_points, s.player_id))
+    pool.sort(key=lambda s: (-s.blended_score, s.player_id))
     return pool[: max(0, int(n))]
 
 
@@ -130,12 +136,15 @@ def _percentile(sorted_desc: Sequence[float], pct: float) -> float:
 def position_metrics(samples: Sequence[PlayerSeasonScore]) -> PositionMetrics:
     """Compute the per-position summary stats for a top-N sample.
 
-    Empty samples return zeroed metrics with ``sample_size=0`` rather
-    than raising — the orchestrator surfaces that via warnings instead.
+    Operates on each player's ``blended_score`` (volume+pace composite)
+    so a position whose elite tier missed games-but-played-fast is
+    fairly represented.  Empty samples return zeroed metrics with
+    ``sample_size=0`` rather than raising — the orchestrator surfaces
+    that via warnings instead.
     """
     if not samples:
         return _EMPTY_METRICS
-    pts = [float(s.total_points) for s in samples]
+    pts = [float(s.blended_score) for s in samples]
     pts_desc = sorted(pts, reverse=True)
     avg = mean(pts)
     med = float(median(pts))

--- a/src/league_comparison/scoring_engine.py
+++ b/src/league_comparison/scoring_engine.py
@@ -30,6 +30,53 @@ _IDP_POSITIONS = frozenset({"DL", "LB", "DB"})
 _TRACKED_POSITIONS = _OFFENSE_POSITIONS | _IDP_POSITIONS
 
 
+# ── Blended score (volume + pace) ─────────────────────────────────────
+#
+# Every player's season is reduced to one number that mixes total
+# fantasy points (volume — what they actually scored) with their
+# per-game pace extrapolated to a 17-week season (pace — what they'd
+# have done at full availability).  The blend rewards a player who
+# missed a few weeks at an elite pace without erasing the volume signal
+# that a workhorse 17-game starter brings.
+#
+# Formula: ``0.5 * total + 0.5 * (ppg * 17)`` when games_played >=
+# ``MIN_GAMES_FOR_PPG``; otherwise total only.  The min-games gate
+# prevents a 1-game outlier from dominating PPG.
+#
+# At games_played == 17 the two halves agree exactly: ppg*17 == total,
+# so blended == total.  Tests that construct full-season fixtures
+# don't need to know about the blend — they get back the same numbers.
+
+#: Minimum games required for the PPG component to count.  Below this
+#: the blended score equals total points, so a 2-game elite outlier
+#: doesn't get extrapolated to a full-season equivalent.
+MIN_GAMES_FOR_PPG: int = 8
+
+#: Number of weeks we extrapolate per-game pace across.  Matches the
+#: regular-season window from :mod:`historical_stats`.
+FULL_SEASON_WEEKS: int = 17
+
+#: Weight on total points vs ppg-extrapolated.  0.5/0.5 keeps both
+#: signals equally important; tweaking this is a simple knob if the
+#: balance ever needs to lean one way.
+_TOTAL_WEIGHT: float = 0.5
+_PACE_WEIGHT: float = 0.5
+
+
+def compute_blended_score(total_points: float, games_played: int) -> float:
+    """Mix total fantasy points and per-game pace into one number.
+
+    See module docstring for the rationale.  Pure function — exposed at
+    module scope so tests can pin the formula independent of any
+    PlayerSeasonScore instance.
+    """
+    if games_played >= MIN_GAMES_FOR_PPG and games_played > 0:
+        ppg = float(total_points) / float(games_played)
+        extrapolated = ppg * FULL_SEASON_WEEKS
+        return _TOTAL_WEIGHT * float(total_points) + _PACE_WEIGHT * extrapolated
+    return float(total_points)
+
+
 @dataclass(frozen=True)
 class PlayerSeasonScore:
     player_id: str
@@ -39,6 +86,18 @@ class PlayerSeasonScore:
     season: int
     total_points: float
     games_played: int
+
+    @property
+    def blended_score(self) -> float:
+        """The volume+pace composite used for ranking and metrics."""
+        return compute_blended_score(self.total_points, self.games_played)
+
+    @property
+    def points_per_game(self) -> float:
+        """Per-game pace; 0.0 if no games (avoids div-by-zero)."""
+        if not self.games_played:
+            return 0.0
+        return float(self.total_points) / float(self.games_played)
 
 
 def _canonical_position(raw_pos: str | None) -> str | None:

--- a/src/league_comparison/service.py
+++ b/src/league_comparison/service.py
@@ -151,9 +151,10 @@ def _build_league_block(
             rows, league_info.scoring_settings, sample_sizes, season,
         )
         # Top players sample for the UI year-by-year detail panel —
-        # cap at 25 to keep payload light.
+        # cap at 25 to keep payload light.  Sort by blended_score so
+        # the displayed top matches what the ranking math actually used.
         top_players = sorted(
-            sample_union, key=lambda s: -s.total_points,
+            sample_union, key=lambda s: -s.blended_score,
         )[:25]
         per_season[season] = {
             "positions": {pos: m.to_dict() for pos, m in per_pos.items()},
@@ -165,8 +166,10 @@ def _build_league_block(
                     "position": s.position,
                     "rawPosition": s.raw_position,
                     "season": s.season,
-                    "totalPoints": s.total_points,
+                    "totalPoints": round(s.total_points, 2),
                     "gamesPlayed": s.games_played,
+                    "pointsPerGame": round(s.points_per_game, 2),
+                    "blendedScore": round(s.blended_score, 2),
                 }
                 for s in top_players
             ],

--- a/src/league_comparison/sleeper_stats.py
+++ b/src/league_comparison/sleeper_stats.py
@@ -43,10 +43,12 @@ _HTTP_TIMEOUT = 15.0
 _PLAYER_INDEX_TTL = 7 * 24 * 3600   # 7 days
 _WEEKLY_STATS_TTL = 7 * 24 * 3600   # 7 days
 
-# Modern NFL regular season is 18 weeks (since 2021).  We fetch each
-# week independently so a single 404 (e.g. a future week of an
-# in-progress season) doesn't kill the whole pull.
-_REGULAR_WEEK_RANGE = range(1, 19)
+# League-comparison samples weeks 1-17 only.  Modern NFL regular
+# seasons run 18 weeks (since 2021), but week 18 is starter-rest
+# territory for most playoff-bound teams; trimming it makes the
+# multi-year sample more apples-to-apples and shaves one HTTP fetch
+# per season.
+_REGULAR_WEEK_RANGE = range(1, 18)
 
 # Sleeper short stat key → nflverse long key.  Mirrors the inverse of
 # ``src.nfl_data.realized_points._SIMPLE_KEYS`` plus IDP and 2-pt keys

--- a/tests/league_comparison/test_historical_stats.py
+++ b/tests/league_comparison/test_historical_stats.py
@@ -14,17 +14,23 @@ def _reset_source_map():
     _hs._LAST_SOURCE.clear()
 
 
+def _row(season, week, **extras):
+    """Build a stat-row stub with a real week so the regular-season
+    filter doesn't drop it."""
+    return {"player_id": "x", "season": season, "week": week, **extras}
+
+
 def test_uses_nflverse_when_available(monkeypatch):
     """If nflverse returns rows, Sleeper must not be called and
     sources['<season>'] must be 'nflverse'."""
     sleeper_calls = {"n": 0}
 
     def fake_nflverse(years):
-        return [{"player_id": "x", "season": years[0], "week": 1}]
+        return [_row(years[0], 1)]
 
     def fake_sleeper(season):
         sleeper_calls["n"] += 1
-        return [{"sleeper_only": True}]
+        return [_row(season, 1, sleeper_only=True)]
 
     monkeypatch.setattr(_hs._ingest, "fetch_weekly_stats", fake_nflverse)
     monkeypatch.setattr(_hs._sleeper_stats, "fetch_sleeper_weekly_stats", fake_sleeper)
@@ -42,7 +48,7 @@ def test_falls_back_to_sleeper_when_nflverse_empty(monkeypatch):
     monkeypatch.setattr(_hs._ingest, "fetch_weekly_stats", lambda yrs: [])
     monkeypatch.setattr(
         _hs._sleeper_stats, "fetch_sleeper_weekly_stats",
-        lambda s: [{"player_id": "y", "season": s, "week": 1}],
+        lambda s: [_row(s, 1, player_id="y")],
     )
     rows = _hs.load_season_rows(2025)
     assert rows is not None
@@ -60,7 +66,7 @@ def test_falls_back_to_sleeper_when_nflverse_raises(monkeypatch):
     monkeypatch.setattr(_hs._ingest, "fetch_weekly_stats", fake_nflverse_raises)
     monkeypatch.setattr(
         _hs._sleeper_stats, "fetch_sleeper_weekly_stats",
-        lambda s: [{"player_id": "z", "season": s, "week": 1}],
+        lambda s: [_row(s, 1, player_id="z")],
     )
     rows = _hs.load_season_rows(2025)
     assert rows is not None
@@ -82,14 +88,52 @@ def test_summarize_availability_includes_sources(monkeypatch):
     available season so the API meta block can show provenance."""
     monkeypatch.setattr(
         _hs._ingest, "fetch_weekly_stats",
-        lambda yrs: [{"x": 1}] if yrs[0] != 2025 else [],
+        lambda yrs: [_row(yrs[0], 1)] if yrs[0] != 2025 else [],
     )
     monkeypatch.setattr(
         _hs._sleeper_stats, "fetch_sleeper_weekly_stats",
-        lambda s: [{"x": 1}] if s == 2025 else [],
+        lambda s: [_row(s, 1)] if s == 2025 else [],
     )
     seasons_map = _hs.load_all_seasons([2023, 2024, 2025])
     avail = _hs.summarize_availability(seasons_map)
     assert avail["available"] == [2023, 2024, 2025]
     assert avail["unavailable"] == []
     assert avail["sources"] == {2023: "nflverse", 2024: "nflverse", 2025: "sleeper"}
+
+
+# ── Regular-season week filter ───────────────────────────────────────
+
+def test_filter_drops_week_18_and_postseason(monkeypatch):
+    """Both nflverse and Sleeper should be cut to weeks 1-17 inclusive."""
+    monkeypatch.setattr(
+        _hs._ingest, "fetch_weekly_stats",
+        lambda yrs: [
+            _row(yrs[0], 1, player_id="w1"),
+            _row(yrs[0], 17, player_id="w17"),
+            _row(yrs[0], 18, player_id="w18"),     # starter-rest week
+            _row(yrs[0], 19, player_id="wpost"),   # nflverse postseason
+        ],
+    )
+    monkeypatch.setattr(_hs._sleeper_stats, "fetch_sleeper_weekly_stats", lambda s: [])
+
+    rows = _hs.load_season_rows(2024)
+    assert rows is not None
+    weeks = {r["week"] for r in rows}
+    assert weeks == {1, 17}
+
+
+def test_filter_drops_rows_with_missing_week(monkeypatch):
+    """Defensive: a row missing the week field shouldn't crash the
+    filter — just drop quietly."""
+    monkeypatch.setattr(
+        _hs._ingest, "fetch_weekly_stats",
+        lambda yrs: [
+            {"player_id": "good", "season": yrs[0], "week": 5},
+            {"player_id": "bad", "season": yrs[0]},        # no week
+            {"player_id": "string", "season": yrs[0], "week": "wat"},
+        ],
+    )
+    monkeypatch.setattr(_hs._sleeper_stats, "fetch_sleeper_weekly_stats", lambda s: [])
+    rows = _hs.load_season_rows(2024)
+    assert rows is not None
+    assert {r["player_id"] for r in rows} == {"good"}

--- a/tests/league_comparison/test_scoring_engine.py
+++ b/tests/league_comparison/test_scoring_engine.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 import pytest
 
 from src.league_comparison.scoring_engine import (
+    PlayerSeasonScore,
+    compute_blended_score,
     compute_player_season_scores,
     _canonical_position,
+    MIN_GAMES_FOR_PPG,
+    FULL_SEASON_WEEKS,
 )
 
 
@@ -126,3 +130,54 @@ def test_handles_player_id_field_alias():
     scores = compute_player_season_scores([row], _PPR)
     assert len(scores) == 1
     assert scores[0].player_id == "g1"
+
+
+# ── Blended score (volume + pace) ────────────────────────────────────
+
+def test_blended_full_season_equals_total():
+    """A 17-game player has blended == total: ppg×17 collapses to total."""
+    assert compute_blended_score(total_points=300.0, games_played=17) == pytest.approx(300.0)
+    assert compute_blended_score(total_points=120.0, games_played=17) == pytest.approx(120.0)
+
+
+def test_blended_partial_season_rewards_pace():
+    """A player with 12 games at high pace should land between actual
+    total and full-season-extrapolated total."""
+    # 12 games at 22 ppg → total=264, ppg×17=374, blended=0.5×264 + 0.5×374 = 319
+    assert compute_blended_score(total_points=264.0, games_played=12) == pytest.approx(319.0)
+
+
+def test_blended_below_min_games_uses_total_only():
+    """Less than MIN_GAMES_FOR_PPG → no PPG bonus, blended == total.
+    Prevents a 1-game outlier from inflating the ranking."""
+    assert MIN_GAMES_FOR_PPG == 8        # pin the threshold
+    # 7 games at 30 ppg = 210 raw — should NOT extrapolate to 510.
+    assert compute_blended_score(total_points=210.0, games_played=7) == pytest.approx(210.0)
+    assert compute_blended_score(total_points=30.0, games_played=1) == pytest.approx(30.0)
+
+
+def test_blended_zero_games_does_not_div_by_zero():
+    """Defensive: a 0-game player must not raise ZeroDivisionError."""
+    assert compute_blended_score(total_points=0.0, games_played=0) == 0.0
+
+
+def test_blended_at_min_games_threshold_includes_pace():
+    """Exactly MIN_GAMES_FOR_PPG = 8 should activate the PPG component."""
+    # 8 games × 20 ppg = 160 total; full-season = 20×17 = 340; blended = 250
+    assert compute_blended_score(total_points=160.0, games_played=8) == pytest.approx(250.0)
+
+
+def test_player_season_score_blended_property_matches_function():
+    """The dataclass property delegates to compute_blended_score."""
+    s = PlayerSeasonScore(
+        player_id="p", player_name="P", position="QB", raw_position="QB",
+        season=2024, total_points=200.0, games_played=10,
+    )
+    assert s.blended_score == compute_blended_score(200.0, 10)
+    assert s.points_per_game == pytest.approx(20.0)
+
+
+def test_full_season_weeks_constant_pinned():
+    """If anyone changes FULL_SEASON_WEEKS, this test is the canary —
+    update Methodology and the historical_stats week filter together."""
+    assert FULL_SEASON_WEEKS == 17


### PR DESCRIPTION
## Summary

Two related changes to how players are scored and which weeks count, both per user request.

### Blended score replaces total points as the ranking signal

Every player's season is reduced to **one number** that mixes total fantasy points (volume — what they scored) with their per-game pace extrapolated to a 17-week season (pace — what they'd have scored at full availability):

```
blended = 0.5 * total + 0.5 * (ppg * 17)        when games_played >= 8
blended = total                                  otherwise
```

- **8-game minimum** prevents a tiny-sample outlier (one 30-pt week) from inflating PPG.
- **17-game starter** has ppg×17 == total, so blended == total. Full-season players score identically to before; only partial-season players slot between actual total and full-season-equivalent.
- Top-N selection and all per-position metrics (avg, median, P25, P75, replacement, elite, replacement-adj) are now computed off blended scores.

### Weeks 1-17 only

Modern NFL regular season is 18 weeks (since 2021), but week 18 is starter-rest week for most playoff-bound teams and would distort top-of-the-board scoring. Filter applied in `historical_stats.load_season_rows()` so it covers both nflverse and Sleeper uniformly.

## Files

- `src/league_comparison/scoring_engine.py` — `compute_blended_score()` helper + `blended_score`/`points_per_game` properties on `PlayerSeasonScore`. `MIN_GAMES_FOR_PPG = 8`, `FULL_SEASON_WEEKS = 17`.
- `src/league_comparison/metrics.py` — `top_n_by_position`, `flex_top_n`, `position_metrics` now read `blended_score`.
- `src/league_comparison/historical_stats.py` — `_filter_to_regular_season` helper applied to both sources.
- `src/league_comparison/sleeper_stats.py` — `_REGULAR_WEEK_RANGE` trimmed to 1-17.
- `src/league_comparison/service.py` — `topPlayers` payload now includes `blendedScore`, `pointsPerGame`, `gamesPlayed`; sorted by blended.
- `frontend/.../YearByYear.jsx` — top-player list shows blended prominently with games/ppg breakdown.
- `frontend/.../Methodology.jsx` — new "Week range" + "Player ranking — blended score" subsections.
- `config/league_comparison.json` — version `v1.1` → `v1.2` to invalidate old-shape caches.

## End-to-end verification (refresh=True, local)

```
seasonsAvailable: [2022, 2023, 2024, 2025] (2025 from Sleeper)
2025 top players (my league, blended desc):
  Stafford  blend=344.5 | 334.1 pts in 16 g (20.9 ppg)
  Allen     blend=334.3 | 324.2 pts in 16 g (20.3 ppg)
  McCaffrey blend=326.5 | 316.6 pts in 16 g (19.8 ppg)
Similarity: 67/100 (Meaningfully different)
```

## Test plan

- [x] 9 new unit tests; full suite **85 passing** in 0.74s
- [x] `npm run build` clean, all bundles under budget
- [x] Local end-to-end with refresh=True (numbers above)
- [ ] Post-merge: load `/league-comparison`, confirm "Top players — blended score" header in Year-by-Year and updated Methodology section

🤖 Generated with [Claude Code](https://claude.com/claude-code)