### PR TITLE
draft: cap per-team initialSlots at 6

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -1036,13 +1036,13 @@ describe("mergeDraftCapitalTeams — with picks array", () => {
     ...Array(3).fill({ currentOwner: "jstuedle" }),
   ];
 
-  it("sets initialSlots from the picks array when supplied", () => {
+  it("sets initialSlots from the picks array when supplied, capped at DEFAULT_INITIAL_SLOTS", () => {
     const ws = createDefaultWorkspace();
     const { workspace } = mergeDraftCapitalTeams(ws, teamTotals, { picks });
     const russini = workspace.teams.find((t) => t.name === "Russini Panini");
     const jstu = workspace.teams.find((t) => t.name === "jstuedle");
     const pop = workspace.teams.find((t) => t.name === "Pop Trunk");
-    expect(russini.initialSlots).toBe(8);
+    expect(russini.initialSlots).toBe(DEFAULT_INITIAL_SLOTS);
     expect(jstu.initialSlots).toBe(3);
     expect(pop.initialSlots).toBe(0);
   });

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -1212,9 +1212,9 @@ export function mergeDraftCapitalTeams(workspace, teamTotals, opts = {}) {
       : DEFAULT_INITIAL_SLOTS;
     const initialSlots = picksArray
       ? Number.isFinite(feedSlots)
-        ? feedSlots
+        ? Math.min(feedSlots, DEFAULT_INITIAL_SLOTS)
         : 0
-      : priorSlots;
+      : Math.min(priorSlots, DEFAULT_INITIAL_SLOTS);
     // In sync mode, preserve the user's typed initialBudget when it
     // diverges from the last-seen feed value.  In force mode (or when
     // no prior feedBudget exists), snap initialBudget to the new feed


### PR DESCRIPTION
## Summary
- Caps per-team `initialSlots` at `DEFAULT_INITIAL_SLOTS` (6) inside `mergeDraftCapitalTeams.buildTeam`.
- Fixes Teams & budgets panel showing raw rookie pick counts (e.g. 18 picks) instead of usable roster slots.

## Test plan
- [x] `vitest run __tests__/draft-logic.test.js` — 196 passed
- [x] `npm run build` — all bundles under budget
- [ ] Verify in prod: every team row reads `0/N` with N ≤ 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)