### PR TITLE
draft: phase-blended nominations + backfill best-value to 10

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -2196,10 +2196,13 @@ describe("replacePlayerPool", () => {
 });
 
 describe("nominationCandidates — vendor split (offense=KTC, IDP=IDPTC)", () => {
-  function statsWith(players) {
-    // Minimal stats stub — nominationCandidates only reads
-    // `enrichedPlayers` and `topCompetitorMax` from stats.
-    return { enrichedPlayers: players, topCompetitorMax: 100 };
+  function statsWith(players, { leagueSpentPct = 1 } = {}) {
+    // Minimal stats stub — nominationCandidates reads
+    // `enrichedPlayers`, `topCompetitorMax`, and `leagueSpentPct`
+    // from stats.  Default to leagueSpentPct=1 (end-of-draft) so
+    // the legacy "rank by percentage gap" assertions still hold;
+    // the early-phase blend is exercised by its own test below.
+    return { enrichedPlayers: players, topCompetitorMax: 100, leagueSpentPct };
   }
 
   it("offense rookie surfaces when KTC overrates vs our board", () => {
@@ -2293,20 +2296,48 @@ describe("nominationCandidates — vendor split (offense=KTC, IDP=IDPTC)", () =>
     expect(lb.rationale).toContain("IDPTC values");
   });
 
-  it("ranks by percentage gap, not dollar gap", () => {
-    // Cheap player (50% over) should beat expensive player (25% over)
-    // even though the dollar gap is identical.
+  it("late draft ranks by percentage gap, not dollar gap", () => {
+    // leagueSpentPct=1 (end of draft) → pure % gap ordering: cheap
+    // player (50% over) beats expensive player (25% over).
     const list = nominationCandidates(
       statsWith([
         // $20 board / $30 vendor → 50% over, $10 gap
         { id: "cheap", name: "Cheap", pos: "WR", preDraft: 20, ktcDollar: 30 },
         // $40 board / $50 vendor → 25% over, $10 gap (same dollars)
         { id: "pricey", name: "Pricey", pos: "WR", preDraft: 40, ktcDollar: 50 },
-      ]),
+      ], { leagueSpentPct: 1 }),
     );
     expect(list.map((e) => e.player.id)).toEqual(["cheap", "pricey"]);
     expect(Math.round(list[0].gapPct * 100)).toBe(50);
     expect(Math.round(list[1].gapPct * 100)).toBe(25);
+  });
+
+  it("early draft ranks by absolute vendor dollar (stars first)", () => {
+    // leagueSpentPct=0 (pick #1) → pure absolute-vendor ordering.
+    // High-dollar overrate ($50) beats high-percentage overrate ($30)
+    // because at the start of the draft, leaguemates nominate
+    // expensive names first to drain rivals' wallets.
+    const list = nominationCandidates(
+      statsWith([
+        { id: "cheap-pct", name: "Cheap %", pos: "WR", preDraft: 20, ktcDollar: 30 },
+        { id: "pricey-star", name: "Pricey Star", pos: "WR", preDraft: 40, ktcDollar: 50 },
+      ], { leagueSpentPct: 0 }),
+    );
+    expect(list.map((e) => e.player.id)).toEqual(["pricey-star", "cheap-pct"]);
+  });
+
+  it("phase blend reweights toward % gap as the draft progresses", () => {
+    // Mid draft (pct=0.5): blended score = 0.5*vendor + 0.5*gapPct*100.
+    //   pricey-star: 0.5*50 + 0.5*25  = 37.5
+    //   cheap-pct:   0.5*30 + 0.5*50  = 40
+    // → cheap-pct narrowly wins on the blended score.
+    const list = nominationCandidates(
+      statsWith([
+        { id: "cheap-pct", name: "Cheap %", pos: "WR", preDraft: 20, ktcDollar: 30 },
+        { id: "pricey-star", name: "Pricey Star", pos: "WR", preDraft: 40, ktcDollar: 50 },
+      ], { leagueSpentPct: 0.5 }),
+    );
+    expect(list[0].player.id).toBe("cheap-pct");
   });
 
   it("repopulates: drafting a top-N candidate surfaces the next-best from the pool", () => {
@@ -2409,32 +2440,55 @@ describe("bestValueOnBoard", () => {
     expect(list.length).toBe(0);
   });
 
-  it("skips when our value is at or below vendor (no edge)", () => {
+  it("backfills rows without an edge so the panel always reaches limit", () => {
+    // No qualifying edges — both fall into the backfill tier and
+    // get sorted by ourDollar desc.
     const list = bestValueOnBoard(
       statsWith([
         { id: "even", name: "Even", pos: "WR", preDraft: 30, ktcDollar: 30 },
         { id: "under", name: "Under", pos: "WR", preDraft: 20, ktcDollar: 30 },
       ]),
     );
-    expect(list.length).toBe(0);
+    expect(list.map((e) => e.player.id)).toEqual(["even", "under"]);
+    expect(list.every((e) => e.gap <= 0)).toBe(true);
   });
 
-  it("skips when vendor dollar is missing", () => {
+  it("backfills rows whose vendor dollar is missing", () => {
     const list = bestValueOnBoard(
       statsWith([
         { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50 },
       ]),
     );
-    expect(list.length).toBe(0);
+    expect(list.length).toBe(1);
+    expect(list[0].player.id).toBe("wr-rook");
+    expect(list[0].vendorDollar).toBe(0);
+    expect(list[0].expectedPrice).toBe(50);
   });
 
-  it("offense rookie with only IDPTradeCalc dollar (no KTC) is skipped", () => {
+  it("offense rookie with only IDPTradeCalc dollar (no KTC) backfills", () => {
+    // Routed to KTC (offense), no KTC comp → backfill tier.
     const list = bestValueOnBoard(
       statsWith([
         { id: "wr-rook", name: "WR Rook", pos: "WR", preDraft: 50, idpTradeCalcDollar: 30 },
       ]),
     );
-    expect(list.length).toBe(0);
+    expect(list.length).toBe(1);
+    expect(list[0].player.id).toBe("wr-rook");
+    expect(list[0].vendorDollar).toBe(0);
+  });
+
+  it("qualifying rows always sort ahead of backfill rows", () => {
+    const list = bestValueOnBoard(
+      statsWith([
+        // Qualifying: $30 board / $20 vendor → 50% under, $10 gap.
+        { id: "qual", name: "Qual", pos: "WR", preDraft: 30, ktcDollar: 20 },
+        // Backfill: highest absolute fair price but no vendor edge.
+        { id: "rich", name: "Rich", pos: "WR", preDraft: 100, ktcDollar: 100 },
+      ]),
+    );
+    expect(list.map((e) => e.player.id)).toEqual(["qual", "rich"]);
+    expect(list[0].gap).toBe(10);   // qualifying
+    expect(list[1].gap).toBe(0);    // backfill
   });
 
   it("ranks by percentage gap, not dollar gap", () => {

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -1786,13 +1786,19 @@ export function nextBestTargets(stats, { limit = 5 } = {}) {
 export function nominationCandidates(stats, { limit = 10 } = {}) {
   if (!stats || !Array.isArray(stats.enrichedPlayers)) return [];
 
-  // Surfaces rookies a market vendor values much HIGHER than our
-  // board, ranked by *percentage* overrate.  A $20→$30 board-vs-vendor
-  // gap on a cheap player (50% overrate) is a bigger relative tax on
-  // rivals than a $20→$40 gap on an expensive one (only 25%).  Sorting
-  // by percentage keeps low-priced overrates from being buried under
-  // raw-dollar gaps that look big in absolute terms but barely move
-  // the rival's budget needle.
+  // Surfaces rookies a market vendor values HIGHER than our board.
+  // Sort key blends two regimes by draft progress (``leagueSpentPct``):
+  //
+  //   earlyScore = vendorDollar        — raw fair price
+  //   lateScore  = gapPct × 100        — percentage overrate vs us
+  //   score      = (1 − pct) × earlyScore + pct × lateScore
+  //
+  // At pick #1 (pct ≈ 0) we sort by absolute vendor dollar — the
+  // expensive rookies real auctions nominate first to drain rivals.
+  // By draft end (pct ≈ 1) we sort purely by percentage overrate —
+  // surfacing the small-$ inefficiencies that ratchet prices up.
+  // Both panels recompute on every workspace mutation, so the blend
+  // shifts live as picks come in.
   //
   // Vendor split by position:
   //   - Offense rookies (QB/RB/WR/TE) → KTC reference price.
@@ -1806,6 +1812,7 @@ export function nominationCandidates(stats, { limit = 10 } = {}) {
   //
   // Sort: ``(vendorDollar - preDraft) / preDraft`` descending.  Cap
   // at ``limit`` (default 10).
+  const phasePct = Math.max(0, Math.min(1, Number(stats.leagueSpentPct) || 0));
   const out = [];
   for (const p of stats.enrichedPlayers) {
     if (p.drafted) continue;
@@ -1827,12 +1834,15 @@ export function nominationCandidates(stats, { limit = 10 } = {}) {
     const gap = vendorDollar - ourDollar;
     if (gap < 1) continue;  // vendor must overrate by at least $1
     const gapPct = gap / ourDollar;  // 0.5 → "50% over"
+    const earlyScore = vendorDollar;
+    const lateScore = gapPct * 100;
+    const score = (1 - phasePct) * earlyScore + phasePct * lateScore;
     const drain = Math.min(
       vendorDollar, Math.max(0, stats.topCompetitorMax || 0),
     );
     out.push({
       player: p,
-      score: gapPct,
+      score,
       drain,
       gap,
       gapPct,
@@ -1854,7 +1864,7 @@ export function nominationCandidates(stats, { limit = 10 } = {}) {
     });
   }
 
-  out.sort((a, b) => b.gapPct - a.gapPct);
+  out.sort((a, b) => b.score - a.score);
   return out.slice(0, limit);
 }
 
@@ -1889,7 +1899,16 @@ export function nominationCandidates(stats, { limit = 10 } = {}) {
 export function bestValueOnBoard(stats, { limit = 10 } = {}) {
   if (!stats || !Array.isArray(stats.enrichedPlayers)) return [];
 
-  const out = [];
+  // Two passes:
+  //   1. Qualifying rows — undrafted rookies where our board > vendor by
+  //      at least $1.  Sorted by % gap descending (best edges first).
+  //   2. Backfill — if fewer than ``limit`` qualified, fill the rest
+  //      with the highest-fair-price undrafted rookies regardless of
+  //      vendor gap.  Ensures the panel always shows ``limit`` rows so
+  //      the user can see what's still on the board even if we don't
+  //      strictly outrate the market on every name.
+  const seen = new Set();
+  const qualified = [];
   for (const p of stats.enrichedPlayers) {
     if (p.drafted) continue;
     if (p.userTag === TAG_AVOID) continue;
@@ -1905,7 +1924,8 @@ export function bestValueOnBoard(stats, { limit = 10 } = {}) {
     const gap = ourDollar - vendorDollar;
     if (gap < 1) continue;  // we must value them at least $1 above
     const gapPct = gap / vendorDollar;  // 0.5 → "50% under market"
-    out.push({
+    seen.add(p.id);
+    qualified.push({
       player: p,
       score: gapPct,
       gap,
@@ -1924,9 +1944,49 @@ export function bestValueOnBoard(stats, { limit = 10 } = {}) {
         `following ${vendorLabel} should let this clear at a discount`,
     });
   }
+  qualified.sort((a, b) => b.gapPct - a.gapPct);
 
-  out.sort((a, b) => b.gapPct - a.gapPct);
-  return out.slice(0, limit);
+  if (qualified.length >= limit) return qualified.slice(0, limit);
+
+  // Backfill with highest-fair-price undrafted rookies the qualifying
+  // pass didn't cover.
+  const backfill = [];
+  for (const p of stats.enrichedPlayers) {
+    if (p.drafted) continue;
+    if (p.userTag === TAG_AVOID) continue;
+    if (seen.has(p.id)) continue;
+    const ourDollar = Math.max(0, p.preDraft || 0);
+    if (ourDollar <= 0) continue;
+    const isIdp =
+      p.assetClass === "idp"
+      || (p.assetClass !== "offense" && classifyPos(p.pos) === "idp");
+    const vendorKey = isIdp ? "idpTradeCalcDollar" : "ktcDollar";
+    const vendorLabel = isIdp ? "IDPTC" : "KTC";
+    const vendorDollar = Math.max(0, Number(p[vendorKey]) || 0);
+    const gap = ourDollar - vendorDollar;
+    const gapPct = vendorDollar > 0 ? gap / vendorDollar : 0;
+    backfill.push({
+      player: p,
+      score: ourDollar,  // sort key for the backfill tier only
+      gap,
+      gapPct,
+      ourDollar,
+      vendorDollar,
+      vendorKey,
+      vendorLabel,
+      ktcDollar: isIdp ? null : (vendorDollar || null),
+      idpTradeCalcDollar: isIdp ? (vendorDollar || null) : null,
+      expectedPrice: vendorDollar || ourDollar,
+      rationale:
+        vendorDollar > 0
+          ? `Our board $${Math.round(ourDollar)} vs ${vendorLabel} ` +
+            `$${Math.round(vendorDollar)} — top remaining fair price`
+          : `Our board $${Math.round(ourDollar)} (no ${vendorLabel} ` +
+            `comp) — top remaining fair price`,
+    });
+  }
+  backfill.sort((a, b) => b.ourDollar - a.ourDollar);
+  return [...qualified, ...backfill].slice(0, limit);
 }
 
 // ── Inflation history series ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Good to nominate**: score now blends absolute vendor $ with % overrate, weighted by `leagueSpentPct`. Early draft → expensive names (real auctions nominate stars first to drain wallets). Late draft → % inefficiencies. Both ends behave the way real auctions do, and the panel re-blends live as picks come in.
- **Best value on the board**: keeps qualifying rows (board > vendor) on top, then backfills with highest-fair-price undrafted rookies so the panel always reaches the 10-row limit.

## Test plan
- [x] `vitest run __tests__/draft-logic.test.js` — 199 passed (3 new tests cover the early/mid/late phase blend)
- [x] `npm run build` — under bundle budgets
- [ ] Verify in prod: pre-draft "Good to nominate" leads with the expensive names, "Best value on the board" shows 10 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)