### PR TITLE
draft: round Pick Values cells to integers (match sheet display)

### DIFF
--- a/frontend/app/league/sections/_trade-simulator.jsx
+++ b/frontend/app/league/sections/_trade-simulator.jsx
@@ -13,8 +13,8 @@ function fmtDollar(v) {
   if (v == null) return "$0";
   const n = Number(v);
   if (!Number.isFinite(n)) return "$0";
-  if (Number.isInteger(n)) return `$${n}`;
-  return `$${n.toFixed(2).replace(/\.?0+$/, "")}`;
+  // Match the sheet's currency-with-0-decimals display: $1.5 → $2.
+  return `$${Math.round(n)}`;
 }
 
 const simBtnStyle = {

--- a/frontend/app/league/sections/draft-capital.jsx
+++ b/frontend/app/league/sections/draft-capital.jsx
@@ -21,11 +21,11 @@ function fmtDollar(v) {
   if (v == null) return "$0";
   const n = Number(v);
   if (!Number.isFinite(n)) return "$0";
-  // Show .5 precision when the value is half-integer (e.g. R5 picks at
-  // $1.50 in the sheet's Final Dollar Per Pick column).  Plain integers
-  // render without a trailing ".0" so common cases stay clean.
-  if (Number.isInteger(n)) return `$${n}`;
-  return `$${n.toFixed(2).replace(/\.?0+$/, "")}`;
+  // Match the Google Sheet's display: currency format with 0 decimals
+  // rounds half-dollars up ($1.5 → $2, $28.5 → $29).  The underlying
+  // value the server returns stays half-dollar so team-totals math
+  // remains accurate; only the per-cell display is rounded.
+  return `$${Math.round(n)}`;
 }
 
 export default function DraftCapitalSection() {


### PR DESCRIPTION
## Summary
The sheet's L column stores half-dollars (\$1.50, \$28.50) but renders them as integers via cell formatting. Match that in the Pick Values panel and Trade Simulator: \$1.5 → \$2, \$28.5 → \$29. Server values stay half-dollar precision so team totals math stays on the \$1200 budget — only the per-cell display is rounded.

## Test plan
- [x] \`npm run build\` — under bundle budgets
- [ ] Verify on /league: R5 cells now show \$2, R2 cells show \$29/\$26/\$24/\$22, totals row preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)