### PR TITLE
draft: add Par Sheet — pre-draft shopping list with surplus tracking

### DIFF
--- a/frontend/__tests__/draft-logic.test.js
+++ b/frontend/__tests__/draft-logic.test.js
@@ -16,19 +16,24 @@ import {
   TIER_DEFS,
   TIER_CONFIDENCE_MIN_SAMPLES,
   addPlayer,
+  addToParSheet,
   bidStatus,
+  clearParSheet,
   computeDraftStats,
   createDefaultWorkspace,
   effectiveBudgetFor,
   hydrateWorkspace,
   mergeDraftCapitalTeams,
+  moveInParSheet,
   playerSlug,
   recordPick,
+  removeFromParSheet,
   removePick,
   removePlayer,
   slotsByTeamFromPicks,
   tierForPreDraft,
   undoLastPick,
+  updateParSheetFairValue,
   updatePlayerPreDraft,
   updateSettings,
   updateTeam,
@@ -380,6 +385,220 @@ describe("state mutators", () => {
     next = removePlayer(next, target.id);
     expect(next.players.find((p) => p.id === target.id)).toBeUndefined();
     expect(next.picks).toEqual([]);
+  });
+});
+
+// ── Par Sheet ───────────────────────────────────────────────────────
+
+describe("par sheet", () => {
+  it("createDefaultWorkspace seeds an empty parSheet", () => {
+    const ws = createDefaultWorkspace();
+    expect(Array.isArray(ws.parSheet)).toBe(true);
+    expect(ws.parSheet).toEqual([]);
+  });
+
+  it("addToParSheet appends a row keyed by name slug", () => {
+    const ws = createDefaultWorkspace();
+    const next = addToParSheet(ws, {
+      name: "Jeremiyah Love",
+      fairValue: 120,
+    });
+    expect(next.parSheet.length).toBe(1);
+    expect(next.parSheet[0]).toMatchObject({
+      id: "jeremiyah-love",
+      name: "Jeremiyah Love",
+      fairValue: 120,
+    });
+  });
+
+  it("addToParSheet refuses duplicates by slug", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "Jeremiyah Love", fairValue: 120 });
+    ws = addToParSheet(ws, { name: "jeremiyah love", fairValue: 99 });
+    expect(ws.parSheet.length).toBe(1);
+    expect(ws.parSheet[0].fairValue).toBe(120);
+  });
+
+  it("addToParSheet ignores blank names", () => {
+    const ws = createDefaultWorkspace();
+    expect(addToParSheet(ws, { name: "", fairValue: 50 }).parSheet).toEqual(
+      [],
+    );
+    expect(addToParSheet(ws, { name: "   ", fairValue: 50 }).parSheet).toEqual(
+      [],
+    );
+  });
+
+  it("addToParSheet clamps negative / non-numeric FV to 0", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "A", fairValue: -50 });
+    ws = addToParSheet(ws, { name: "B", fairValue: "garbage" });
+    expect(ws.parSheet[0].fairValue).toBe(0);
+    expect(ws.parSheet[1].fairValue).toBe(0);
+  });
+
+  it("removeFromParSheet drops a single row", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "A", fairValue: 10 });
+    ws = addToParSheet(ws, { name: "B", fairValue: 20 });
+    ws = removeFromParSheet(ws, "a");
+    expect(ws.parSheet.length).toBe(1);
+    expect(ws.parSheet[0].id).toBe("b");
+  });
+
+  it("updateParSheetFairValue patches just one row", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "A", fairValue: 10 });
+    ws = addToParSheet(ws, { name: "B", fairValue: 20 });
+    ws = updateParSheetFairValue(ws, "a", 75);
+    expect(ws.parSheet[0].fairValue).toBe(75);
+    expect(ws.parSheet[1].fairValue).toBe(20);
+  });
+
+  it("moveInParSheet reorders a row up or down", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "A", fairValue: 1 });
+    ws = addToParSheet(ws, { name: "B", fairValue: 2 });
+    ws = addToParSheet(ws, { name: "C", fairValue: 3 });
+    const movedUp = moveInParSheet(ws, "c", "up");
+    expect(movedUp.parSheet.map((r) => r.id)).toEqual(["a", "c", "b"]);
+    const movedDown = moveInParSheet(ws, "a", "down");
+    expect(movedDown.parSheet.map((r) => r.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("moveInParSheet is a no-op at the boundary or on a missing id", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "A", fairValue: 1 });
+    ws = addToParSheet(ws, { name: "B", fairValue: 2 });
+    expect(moveInParSheet(ws, "a", "up").parSheet[0].id).toBe("a");
+    expect(moveInParSheet(ws, "b", "down").parSheet[1].id).toBe("b");
+    expect(moveInParSheet(ws, "missing", "up")).toBe(ws);
+  });
+
+  it("clearParSheet wipes every row", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "A", fairValue: 10 });
+    expect(clearParSheet(ws).parSheet).toEqual([]);
+  });
+
+  it("hydrateWorkspace rebuilds slugs and drops bad rows", () => {
+    const persisted = {
+      version: 1,
+      settings: {},
+      parSheet: [
+        { name: "Jeremiyah Love", fairValue: 120 },
+        { name: "", fairValue: 50 }, // dropped: blank name
+        { name: "Jeremiyah Love", fairValue: 80 }, // dropped: dup slug
+        { name: "Quinshon Judkins", fairValue: "55" },
+      ],
+    };
+    const ws = hydrateWorkspace(persisted);
+    expect(ws.parSheet.length).toBe(2);
+    expect(ws.parSheet[0]).toMatchObject({
+      id: "jeremiyah-love",
+      fairValue: 120,
+    });
+    expect(ws.parSheet[1]).toMatchObject({
+      id: "quinshon-judkins",
+      fairValue: 55,
+    });
+  });
+
+  it("computeDraftStats classifies open rows with committed FV against headroom", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "Jeremiyah Love", fairValue: 120 });
+    ws = addToParSheet(ws, { name: "Quinshon Judkins", fairValue: 60 });
+    const ps = computeDraftStats(ws).parSheetStats;
+    expect(ps.totals.targetCount).toBe(2);
+    expect(ps.totals.committedFV).toBe(180);
+    expect(ps.totals.wonCount).toBe(0);
+    expect(ps.totals.lostCount).toBe(0);
+    expect(ps.totals.surplus).toBe(0);
+    // Russini Panini's default budget is 417; nothing spent yet.
+    expect(ps.headroom).toBe(417 - 180);
+    expect(ps.status).toBe("on_track");
+  });
+
+  it("computeDraftStats books surplus when I win at below FV", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "Jeremiyah Love", fairValue: 120 });
+    // Winning Love at $115 should bank +$5 surplus and free up
+    // headroom (committedFV drops to 0 since the row is now "won").
+    ws = recordPick(ws, {
+      playerId: "jeremiyah-love",
+      teamIdx: 0,
+      amount: 115,
+    });
+    const ps = computeDraftStats(ws).parSheetStats;
+    const row = ps.rows[0];
+    expect(row.status).toBe("won");
+    expect(row.mine).toBe(true);
+    expect(row.paid).toBe(115);
+    expect(row.surplus).toBe(5);
+    expect(ps.totals.surplus).toBe(5);
+    expect(ps.totals.committedFV).toBe(0);
+    expect(ps.totals.wonFV).toBe(120);
+    expect(ps.totals.wonPaid).toBe(115);
+  });
+
+  it("computeDraftStats books deficit when I overpay vs FV", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "Jeremiyah Love", fairValue: 120 });
+    ws = recordPick(ws, {
+      playerId: "jeremiyah-love",
+      teamIdx: 0,
+      amount: 140,
+    });
+    const ps = computeDraftStats(ws).parSheetStats;
+    expect(ps.rows[0].surplus).toBe(-20);
+    expect(ps.totals.surplus).toBe(-20);
+  });
+
+  it("computeDraftStats marks rows lost when another team drafts them", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "Jeremiyah Love", fairValue: 120 });
+    ws = recordPick(ws, {
+      playerId: "jeremiyah-love",
+      teamIdx: 3, // not me (myTeamIdx defaults to 0)
+      amount: 110,
+    });
+    const ps = computeDraftStats(ws).parSheetStats;
+    expect(ps.rows[0].status).toBe("lost");
+    expect(ps.rows[0].mine).toBe(false);
+    expect(ps.totals.lostCount).toBe(1);
+    expect(ps.totals.targetCount).toBe(0);
+    expect(ps.totals.committedFV).toBe(0);
+    expect(ps.totals.wonFV).toBe(0);
+  });
+
+  it("headroom goes negative when committed FV exceeds my remaining $", () => {
+    let ws = createDefaultWorkspace();
+    // My default starting budget is 417; commit FV well above it.
+    ws = addToParSheet(ws, { name: "P1", fairValue: 250 });
+    ws = addToParSheet(ws, { name: "P2", fairValue: 250 });
+    const ps = computeDraftStats(ws).parSheetStats;
+    expect(ps.headroom).toBe(417 - 500);
+    expect(ps.status).toBe("short");
+  });
+
+  it("status flips to done when every row is resolved", () => {
+    let ws = createDefaultWorkspace();
+    ws = addToParSheet(ws, { name: "Jeremiyah Love", fairValue: 120 });
+    ws = recordPick(ws, {
+      playerId: "jeremiyah-love",
+      teamIdx: 0,
+      amount: 115,
+    });
+    const ps = computeDraftStats(ws).parSheetStats;
+    expect(ps.status).toBe("done");
+    expect(ps.statusLabel).toMatch(/surplus \+\$5/);
+  });
+
+  it("idle status when sheet is empty", () => {
+    const ws = createDefaultWorkspace();
+    const ps = computeDraftStats(ws).parSheetStats;
+    expect(ps.status).toBe("idle");
+    expect(ps.rows).toEqual([]);
   });
 });
 

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -14,9 +14,11 @@ import {
   TARGET_BOARD_MAX,
   TIER_DEFS,
   addPlayer,
+  addToParSheet,
   addToTargetBoard,
   bestValueOnBoard,
   bidStatus,
+  clearParSheet,
   clearTargetBoard,
   computeDraftReview,
   computeDraftStats,
@@ -27,6 +29,7 @@ import {
   draftReviewToCsv,
   hydrateWorkspace,
   mergeDraftCapitalTeams,
+  moveInParSheet,
   moveTargetInBoard,
   nextBestTargets,
   nominationCandidates,
@@ -34,6 +37,7 @@ import {
   playerSlug,
   recordNomination,
   recordPick,
+  removeFromParSheet,
   removeFromTargetBoard,
   removeNomination,
   removePick,
@@ -43,6 +47,7 @@ import {
   setPlayerTag,
   undoLastNomination,
   undoLastPick,
+  updateParSheetFairValue,
   updatePlayerPreDraft,
   updateSettings,
   updateTeam,
@@ -1557,6 +1562,398 @@ function InflationSparkline({ series, width = 140, height = 36 }) {
  *
  * Negative buffer renders red with "SHORT $N — trim a target".
  */
+/* ── Par Sheet ────────────────────────────────────────────────────── */
+
+/**
+ * Pre-draft "shopping list" with a per-row personal Fair Value.  As
+ * picks land, each row classifies into target / won / lost.  Footer
+ * shows committed FV, banked surplus, and how much headroom remains
+ * against my budget if I hit every target at FV.
+ *
+ * Free-text adds are accepted: the row's id is the slug of the typed
+ * name, so it auto-matches a future pick recorded under the same
+ * slug (the rookie pool seeds use the same slug rule).  Quick-add
+ * suggestions surface from the existing player pool when the typed
+ * text matches a pool name; clicking a suggestion pre-fills the FV
+ * with that player's preDraft $ — which the user can then override.
+ */
+function ParSheet({
+  stats,
+  workspace,
+  onAdd,
+  onRemove,
+  onEditFV,
+  onMove,
+  onClear,
+  onDraft,
+}) {
+  const [name, setName] = useState("");
+  const [fv, setFv] = useState("");
+  const [editingId, setEditingId] = useState(null);
+  const [editingValue, setEditingValue] = useState("");
+  const psStats = stats.parSheetStats || {
+    rows: [],
+    totals: {
+      committedFV: 0,
+      wonFV: 0,
+      wonPaid: 0,
+      lostFV: 0,
+      targetCount: 0,
+      wonCount: 0,
+      lostCount: 0,
+      surplus: 0,
+    },
+    headroom: 0,
+    status: "idle",
+    statusLabel: "",
+  };
+  const rows = psStats.rows;
+
+  // Quick-add suggestions: pool players whose name fuzzy-matches the
+  // typed text.  Excludes anything already on the par sheet.  Limit
+  // the dropdown to a handful so it stays compact.
+  const sheetIds = useMemo(
+    () => new Set(rows.map((r) => r.id)),
+    [rows],
+  );
+  const suggestions = useMemo(() => {
+    const q = name.trim().toLowerCase();
+    if (q.length < 2) return [];
+    return stats.enrichedPlayers
+      .filter((p) => !sheetIds.has(p.id) && p.name.toLowerCase().includes(q))
+      .slice(0, 6);
+  }, [name, sheetIds, stats.enrichedPlayers]);
+
+  const submitAdd = (overrideName, overrideFV) => {
+    const finalName = String(overrideName ?? name).trim();
+    if (!finalName) return;
+    const fvNum = Number(overrideFV ?? fv);
+    onAdd({
+      name: finalName,
+      fairValue: Number.isFinite(fvNum) ? Math.max(0, fvNum) : 0,
+    });
+    setName("");
+    setFv("");
+  };
+
+  const beginEditFV = (row) => {
+    setEditingId(row.id);
+    setEditingValue(String(row.fairValue || 0));
+  };
+  const commitEditFV = () => {
+    if (!editingId) return;
+    const v = Number(editingValue);
+    onEditFV(editingId, Number.isFinite(v) ? Math.max(0, v) : 0);
+    setEditingId(null);
+    setEditingValue("");
+  };
+  const cancelEditFV = () => {
+    setEditingId(null);
+    setEditingValue("");
+  };
+
+  const statusClass =
+    psStats.status === "short"
+      ? "draft-tb-status-short"
+      : psStats.status === "tight"
+        ? "draft-tb-status-tight"
+        : psStats.status === "on_track" || psStats.status === "done"
+          ? "draft-tb-status-ok"
+          : "draft-tb-status-idle";
+
+  const totals = psStats.totals;
+  const surplus = totals.surplus || 0;
+  const surplusClass =
+    surplus > 0
+      ? "draft-vs-fair-win"
+      : surplus < 0
+        ? "draft-vs-fair-lose"
+        : "";
+
+  return (
+    <div className="card draft-target-board draft-par-sheet">
+      <div className="draft-tb-head">
+        <div>
+          <h3 style={{ margin: "0 0 2px" }}>
+            Par Sheet{" "}
+            <span className="muted" style={{ fontSize: "0.72rem" }}>
+              ({rows.length} {rows.length === 1 ? "row" : "rows"} ·{" "}
+              {totals.targetCount} open · {totals.wonCount} won ·{" "}
+              {totals.lostCount} lost)
+            </span>
+          </h3>
+          <div className="muted" style={{ fontSize: "0.7rem" }}>
+            Pre-draft shopping list with your own fair value · surplus
+            on bargains rolls into headroom you can spend elsewhere
+          </div>
+        </div>
+        <div className="draft-tb-actions">
+          {rows.length > 0 && (
+            <button
+              className="button"
+              style={{ fontSize: "0.7rem", padding: "3px 8px" }}
+              onClick={() => {
+                if (
+                  typeof window !== "undefined" &&
+                  window.confirm("Clear the entire par sheet?")
+                ) {
+                  onClear();
+                }
+              }}
+              title="Clear every row on the par sheet"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {rows.length === 0 && (
+        <div
+          className="muted"
+          style={{ fontSize: "0.76rem", padding: "6px 0 4px" }}
+        >
+          Type a player and your fair-value $ below to start your par
+          sheet.  As picks land, each row marks itself "Won" (with
+          surplus vs your FV) or "Lost".  Bottom-line headroom shows
+          what you have left if you hit every open row at your FV.
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <div className="draft-tb-grid draft-ps-grid">
+          <div className="draft-tb-row draft-ps-row draft-tb-row-head">
+            <span>#</span>
+            <span>Player</span>
+            <span>FV</span>
+            <span>Paid</span>
+            <span>Δ</span>
+            <span>Status</span>
+            <span></span>
+          </div>
+          {rows.map((row, idx) => {
+            const isFirst = idx === 0;
+            const isLast = idx === rows.length - 1;
+            const drafted = row.status !== "target";
+            const status =
+              row.status === "won"
+                ? {
+                    label: `Won $${row.paid}`,
+                    cls: "draft-tb-status-won",
+                  }
+                : row.status === "lost"
+                  ? { label: "Lost", cls: "draft-tb-status-lost" }
+                  : { label: "Open", cls: "draft-tb-status-open" };
+            const surplusRow = row.surplus;
+            const enriched = row.enriched;
+            const isEditing = editingId === row.id;
+            return (
+              <div
+                key={row.id}
+                className={`draft-tb-row draft-ps-row${
+                  drafted ? " draft-tb-row-drafted" : ""
+                }${row.mine ? " draft-tb-row-mine" : ""}`}
+              >
+                <span className="draft-tb-idx">#{idx + 1}</span>
+                <span className="draft-tb-name-cell">
+                  {enriched && (
+                    <span
+                      className={`draft-tier-chip draft-tier-${enriched.tier}`}
+                      style={{ marginRight: 4 }}
+                    >
+                      {enriched.tier}
+                    </span>
+                  )}
+                  <span
+                    className="draft-nbt-name"
+                    onClick={() => {
+                      if (enriched && !drafted) onDraft(enriched);
+                    }}
+                    title={
+                      enriched
+                        ? "Open draft modal"
+                        : "Not in rookie pool yet — sync rookies to enable quick-draft"
+                    }
+                    style={!enriched ? { cursor: "default" } : undefined}
+                  >
+                    {row.name}
+                  </span>
+                </span>
+                <span className="draft-money">
+                  {isEditing ? (
+                    <input
+                      type="number"
+                      className="input draft-money-input"
+                      autoFocus
+                      value={editingValue}
+                      min="0"
+                      onChange={(e) => setEditingValue(e.target.value)}
+                      onBlur={commitEditFV}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitEditFV();
+                        if (e.key === "Escape") cancelEditFV();
+                      }}
+                      style={{ width: 56, fontSize: "0.78rem" }}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      className="button-reset draft-ps-fv-edit"
+                      onClick={() => beginEditFV(row)}
+                      title="Click to edit fair value"
+                    >
+                      {fmt$(row.fairValue)}
+                    </button>
+                  )}
+                </span>
+                <span className="draft-money">
+                  {row.status === "won" ? fmt$(row.paid) : "—"}
+                </span>
+                <span className="draft-money">
+                  {row.status === "won" && Number.isFinite(surplusRow) ? (
+                    <span
+                      className={
+                        surplusRow > 0
+                          ? "draft-vs-fair-win"
+                          : surplusRow < 0
+                            ? "draft-vs-fair-lose"
+                            : ""
+                      }
+                      title={`Fair ${fmt$(row.fairValue)} − paid ${fmt$(row.paid)}`}
+                    >
+                      {surplusRow > 0 ? "+" : ""}
+                      {fmt$(surplusRow)}
+                    </span>
+                  ) : (
+                    "—"
+                  )}
+                </span>
+                <span className={`draft-tb-status ${status.cls}`}>
+                  {status.label}
+                </span>
+                <span className="draft-tb-controls">
+                  <button
+                    className="button-reset draft-tb-ctrl"
+                    onClick={() => onMove(row.id, "up")}
+                    disabled={isFirst}
+                    title="Move up"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    className="button-reset draft-tb-ctrl"
+                    onClick={() => onMove(row.id, "down")}
+                    disabled={isLast}
+                    title="Move down"
+                  >
+                    ▼
+                  </button>
+                  <button
+                    className="button-reset draft-tb-ctrl draft-tb-ctrl-remove"
+                    onClick={() => onRemove(row.id)}
+                    title="Remove from par sheet"
+                  >
+                    ×
+                  </button>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className={`draft-tb-summary ${statusClass}`}>
+        <div className="draft-tb-summary-line">
+          <span className="muted">FV Σ (open)</span>
+          <span className="draft-money">{fmt$(totals.committedFV)}</span>
+          <span className="muted">FV Σ (won)</span>
+          <span className="draft-money">{fmt$(totals.wonFV)}</span>
+          <span className="muted">Paid Σ (won)</span>
+          <span className="draft-money">{fmt$(totals.wonPaid)}</span>
+          <span className="muted">Surplus banked</span>
+          <span className={`draft-money ${surplusClass}`}>
+            {surplus > 0 ? "+" : ""}
+            {fmt$(surplus)}
+          </span>
+        </div>
+        <div className="draft-tb-summary-line">
+          <span className="muted">My remaining</span>
+          <span className="draft-money">{fmt$(stats.myRemaining)}</span>
+          <span className="muted">− open FV</span>
+          <span className="draft-money">{fmt$(totals.committedFV)}</span>
+          <strong>=</strong>
+          <span className="draft-money draft-tb-buffer">
+            {fmt$(psStats.headroom)}
+          </span>
+          <span className="muted" style={{ marginLeft: 6 }}>
+            headroom
+          </span>
+        </div>
+        <div className="draft-tb-status-line">{psStats.statusLabel}</div>
+      </div>
+
+      <div className="draft-tb-add draft-ps-add">
+        <input
+          type="text"
+          className="input"
+          placeholder="Player name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submitAdd();
+          }}
+          style={{ flex: "1 1 180px", maxWidth: 220 }}
+        />
+        <input
+          type="number"
+          className="input"
+          placeholder="Fair $"
+          value={fv}
+          min="0"
+          onChange={(e) => setFv(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submitAdd();
+          }}
+          style={{ width: 80 }}
+        />
+        <button
+          type="button"
+          className="button"
+          onClick={() => submitAdd()}
+          disabled={!name.trim()}
+          style={{ fontSize: "0.72rem", padding: "3px 10px" }}
+        >
+          Add
+        </button>
+        {suggestions.length > 0 && (
+          <div className="draft-tb-suggest">
+            {suggestions.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                className="button draft-tb-suggest-btn"
+                onClick={() => submitAdd(p.name, p.preDraft)}
+                title={`Pre-fill ${p.name} with PreDraft ${fmt$(p.preDraft)}`}
+                style={{ fontSize: "0.72rem", padding: "3px 8px" }}
+              >
+                <span
+                  className={`draft-tier-chip draft-tier-${p.tier}`}
+                  style={{ marginRight: 4 }}
+                >
+                  {p.tier}
+                </span>
+                {p.name} ({fmt$(p.preDraft)})
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Target Board ─────────────────────────────────────────────────── */
+
 function TargetBoard({
   stats,
   workspace,
@@ -3297,6 +3694,29 @@ export default function DraftDashboardPage() {
     () => setWorkspace((ws) => clearTargetBoard(ws)),
     [],
   );
+  const onAddToParSheet = useCallback(
+    ({ name, fairValue }) =>
+      setWorkspace((ws) => addToParSheet(ws, { name, fairValue })),
+    [],
+  );
+  const onRemoveFromParSheet = useCallback(
+    (id) => setWorkspace((ws) => removeFromParSheet(ws, id)),
+    [],
+  );
+  const onEditParSheetFV = useCallback(
+    (id, fairValue) =>
+      setWorkspace((ws) => updateParSheetFairValue(ws, id, fairValue)),
+    [],
+  );
+  const onMoveInParSheet = useCallback(
+    (id, direction) =>
+      setWorkspace((ws) => moveInParSheet(ws, id, direction)),
+    [],
+  );
+  const onClearParSheet = useCallback(
+    () => setWorkspace((ws) => clearParSheet(ws)),
+    [],
+  );
   const onRecordNomination = useCallback(
     (playerId, nominatingTeamIdx) =>
       setWorkspace((ws) =>
@@ -3969,6 +4389,17 @@ export default function DraftDashboardPage() {
           </div>
         </div>
       )}
+
+      <ParSheet
+        stats={stats}
+        workspace={workspace}
+        onAdd={onAddToParSheet}
+        onRemove={onRemoveFromParSheet}
+        onEditFV={onEditParSheetFV}
+        onMove={onMoveInParSheet}
+        onClear={onClearParSheet}
+        onDraft={(p) => setModalPlayer(p)}
+      />
 
       <TargetBoard
         stats={stats}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4193,6 +4193,30 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   flex: 1;
 }
 
+/* Par Sheet — same look as Target Board, 7-col grid (no Win column) */
+.draft-par-sheet {
+  margin-bottom: 14px;
+}
+.draft-ps-row {
+  grid-template-columns: 34px 1fr 70px 70px 70px 96px 74px;
+}
+.draft-ps-fv-edit {
+  background: transparent;
+  border: 1px dashed transparent;
+  border-radius: 3px;
+  color: inherit;
+  font: inherit;
+  padding: 1px 4px;
+  cursor: pointer;
+}
+.draft-ps-fv-edit:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.draft-ps-add {
+  align-items: center;
+}
+
 /* Nomination logger in draft modal */
 .draft-modal-nom {
   margin-top: 8px;

--- a/frontend/lib/draft-logic.js
+++ b/frontend/lib/draft-logic.js
@@ -351,6 +351,16 @@ export function createDefaultWorkspace() {
     // ceiling on any given undrafted player.
     //   { playerId, nominatingTeamIdx, preDraftAtNomination, ts }
     nominations: [],
+    // parSheet: pre-draft "shopping list" of players the user wants
+    // with a personal fairValue $ for each.  Mirrors the auction par-
+    // sheet workflow: populate before the draft, watch surplus/deficit
+    // accumulate as picks land.  Independent of the Target Board so the
+    // user can keep a long pre-draft list (20+) AND a 6-slot focus
+    // board.  Players can be free-text names — slug-matched against
+    // picks at compute time, so a row auto-detects "won" / "lost" once
+    // the matching pick lands.
+    //   { id, name, fairValue, ts }
+    parSheet: [],
   };
 }
 
@@ -860,6 +870,122 @@ export function computeDraftStats(workspace) {
     nonTargetSlotsLeft,
   };
 
+  // ── Par Sheet rollup ────────────────────────────────────────────────
+  // The par sheet is a free-form "shopping list" the user populates
+  // before the draft.  Each row carries a user-entered ``fairValue``
+  // (independent of the rookie pool's preDraft).  As picks land, each
+  // row classifies into one of three states:
+  //
+  //   target:    no pick yet matches ``id`` — committed dollars
+  //              against my remaining budget at fairValue.
+  //   won:       a pick by my team matches ``id`` — surplus =
+  //              fairValue − paid (positive = bargain, negative =
+  //              overpay).  Surplus rolls into my "extra headroom"
+  //              that can fund the next target's FV bump.
+  //   lost:      a pick by another team matches ``id`` — row is
+  //              greyed out, contributes to neither commitment nor
+  //              surplus, but is kept on the list as a record.
+  //
+  // Aggregates surfaced:
+  //
+  //   committedFV    — Σ fairValue across "target" rows.  What I
+  //                    intend to spend if I get everyone left on the
+  //                    list at my own valuation.
+  //   wonFV          — Σ fairValue across "won" rows.  What I'd have
+  //                    paid if I'd hit FV on every win so far.
+  //   wonPaid        — Σ paid across "won" rows.  Actual outlay.
+  //   surplus        — wonFV − wonPaid.  Extra dollars freed up by
+  //                    bargains (positive) or burned by overpays
+  //                    (negative).
+  //   headroom       — myRemaining − committedFV.  Spare $ if I hit
+  //                    every target at my FV.  Surplus is already
+  //                    baked into myRemaining (paid amounts have
+  //                    been subtracted), so headroom shows true
+  //                    breathing room — negative = can't afford the
+  //                    list at FV, raise FVs or trim rows.
+  const parSheetRows = Array.isArray(ws.parSheet) ? ws.parSheet : [];
+  const psTotals = {
+    committedFV: 0,
+    wonFV: 0,
+    wonPaid: 0,
+    lostFV: 0,
+    targetCount: 0,
+    wonCount: 0,
+    lostCount: 0,
+    surplus: 0,
+  };
+  const enrichedParSheet = parSheetRows.map((row) => {
+    const id = String(row?.id || "");
+    const fv = Math.max(0, Number(row?.fairValue) || 0);
+    const pick = id ? pickByPlayer.get(id) : null;
+    let status = "target";
+    let mine = false;
+    let paid = null;
+    let surplus = null;
+    if (pick) {
+      mine = pick.teamIdx === myTeamIdx;
+      paid = Math.max(0, Number(pick.amount) || 0);
+      if (mine) {
+        status = "won";
+        surplus = fv - paid;
+        psTotals.wonCount += 1;
+        psTotals.wonFV += fv;
+        psTotals.wonPaid += paid;
+        psTotals.surplus += surplus;
+      } else {
+        status = "lost";
+        psTotals.lostCount += 1;
+        psTotals.lostFV += fv;
+      }
+    } else {
+      psTotals.targetCount += 1;
+      psTotals.committedFV += fv;
+    }
+    return {
+      id,
+      name: String(row?.name || ""),
+      fairValue: fv,
+      status,
+      mine,
+      paid,
+      surplus,
+      pick: pick || null,
+      enriched: id ? enrichedPlayerById.get(id) || null : null,
+      ts: Number(row?.ts) || 0,
+    };
+  });
+  const psHeadroom = myRemaining - psTotals.committedFV;
+  let psStatus = "idle";
+  let psStatusLabel = "Add players to your par sheet";
+  if (parSheetRows.length > 0) {
+    if (psTotals.targetCount === 0) {
+      psStatus = "done";
+      const surplusSign =
+        psTotals.surplus > 0
+          ? `surplus +$${Math.round(psTotals.surplus)}`
+          : psTotals.surplus < 0
+            ? `deficit −$${Math.abs(Math.round(psTotals.surplus))}`
+            : "even";
+      psStatusLabel = `Par sheet closed — ${surplusSign}`;
+    } else if (psHeadroom < 0) {
+      psStatus = "short";
+      psStatusLabel = `Short $${Math.abs(Math.round(psHeadroom))} — trim a row or raise a price elsewhere`;
+    } else if (psHeadroom < 5) {
+      psStatus = "tight";
+      psStatusLabel = `Tight — $${Math.round(psHeadroom)} of headroom against your fair values`;
+    } else {
+      psStatus = "on_track";
+      psStatusLabel = `On track — $${Math.round(psHeadroom)} of headroom on top of your fair values`;
+    }
+  }
+  const parSheetStats = {
+    rows: enrichedParSheet,
+    totals: psTotals,
+    headroom: psHeadroom,
+    status: psStatus,
+    statusLabel: psStatusLabel,
+  };
+
   // ── Nominations summary ────────────────────────────────────────────
   // Surface the raw nominations plus a per-tier count so the UI can
   // show "Joel has logged 3 S-tier noms" as a quick-read signal.
@@ -908,6 +1034,7 @@ export function computeDraftStats(workspace) {
     teamStats,
     enrichedPlayers,
     targetBoardStats,
+    parSheetStats,
     nominationsCount: nominations.length,
     nominationsByTier,
     nominationsEnriched,
@@ -1041,6 +1168,75 @@ export function moveTargetInBoard(workspace, playerId, direction) {
   const [moved] = board.splice(idx, 1);
   board.splice(to, 0, moved);
   return { ...workspace, targetBoard: board };
+}
+
+// ── Par Sheet mutators ─────────────────────────────────────────────────
+/**
+ * Append a player to the par sheet with a user-entered fair-value $.
+ * Free-text names are accepted — the row's id is the slug of the name,
+ * so a row auto-matches any pick recorded later for the same slug.
+ *
+ * Refuses duplicates (same slug already on the sheet).  Rows are
+ * append-only by default; callers that want to reorder use
+ * ``moveInParSheet``.
+ */
+export function addToParSheet(workspace, { name, fairValue } = {}) {
+  const ws = workspace || createDefaultWorkspace();
+  const cleanName = String(name || "").trim();
+  const id = playerSlug(cleanName);
+  if (!id) return ws;
+  const sheet = Array.isArray(ws.parSheet) ? ws.parSheet : [];
+  if (sheet.some((r) => r.id === id)) return ws;
+  const fv = Math.max(0, Number(fairValue) || 0);
+  return {
+    ...ws,
+    parSheet: [
+      ...sheet,
+      { id, name: cleanName, fairValue: fv, ts: Date.now() },
+    ],
+  };
+}
+
+/** Remove a single row from the par sheet by id. */
+export function removeFromParSheet(workspace, playerId) {
+  const ws = workspace || createDefaultWorkspace();
+  const sheet = Array.isArray(ws.parSheet) ? ws.parSheet : [];
+  return {
+    ...ws,
+    parSheet: sheet.filter((r) => r.id !== playerId),
+  };
+}
+
+/** Update a row's fair-value $ inline. */
+export function updateParSheetFairValue(workspace, playerId, newFairValue) {
+  const ws = workspace || createDefaultWorkspace();
+  const sheet = Array.isArray(ws.parSheet) ? ws.parSheet : [];
+  return {
+    ...ws,
+    parSheet: sheet.map((r) =>
+      r.id === playerId
+        ? { ...r, fairValue: Math.max(0, Number(newFairValue) || 0) }
+        : r,
+    ),
+  };
+}
+
+/** Reorder the par sheet by moving one row up or down by one slot. */
+export function moveInParSheet(workspace, playerId, direction) {
+  const ws = workspace || createDefaultWorkspace();
+  const sheet = [...(Array.isArray(ws.parSheet) ? ws.parSheet : [])];
+  const idx = sheet.findIndex((r) => r.id === playerId);
+  if (idx < 0) return ws;
+  const to = direction === "up" ? idx - 1 : idx + 1;
+  if (to < 0 || to >= sheet.length) return ws;
+  const [moved] = sheet.splice(idx, 1);
+  sheet.splice(to, 0, moved);
+  return { ...ws, parSheet: sheet };
+}
+
+/** Reset the par sheet to empty. */
+export function clearParSheet(workspace) {
+  return { ...(workspace || createDefaultWorkspace()), parSheet: [] };
 }
 
 // ── Nomination mutators ────────────────────────────────────────────────
@@ -1589,6 +1785,29 @@ export function hydrateWorkspace(parsed) {
             ts: Number(n?.ts) || Date.now(),
           }))
           .filter((n) => n.playerId && n.nominatingTeamIdx >= 0)
+      : [],
+    parSheet: Array.isArray(parsed.parSheet)
+      ? (() => {
+          // Drop rows missing a slug-able name; coerce each fairValue
+          // back to a non-negative number.  Rebuild the id from the
+          // name on hydrate so a hand-edited localStorage entry with
+          // a stale id still lines up correctly.
+          const seen = new Set();
+          const out = [];
+          for (const r of parsed.parSheet) {
+            const name = String(r?.name || "").trim();
+            const id = playerSlug(name);
+            if (!id || seen.has(id)) continue;
+            seen.add(id);
+            out.push({
+              id,
+              name,
+              fairValue: Math.max(0, Number(r?.fairValue) || 0),
+              ts: Number(r?.ts) || Date.now(),
+            });
+          }
+          return out;
+        })()
       : [],
   };
 }

--- a/frontend/scripts/check-bundle-sizes.mjs
+++ b/frontend/scripts/check-bundle-sizes.mjs
@@ -57,7 +57,7 @@ const BUDGETS_KB = {
   "/page": 90, // landing
   "/rankings/page": 65, // dense table + filter bar + popups
   "/trade/page": 75, // calculator + simulator + breakdown
-  "/draft/page": 115, // depth chart + analysis charts
+  "/draft/page": 125, // depth chart + analysis charts; bumped 115→125 for Par Sheet panel (PR #385)
   "/edge/page": 30,
   "/finder/page": 20,
   "/angle/page": 30,


### PR DESCRIPTION
## Summary

Adds a **Par Sheet** panel to the draft dashboard — a free-form pre-draft shopping list where you populate the players you want with your own personal **Fair Value $** for each. As picks land, every row classifies into one of three states and the footer shows live budget math.

- **target** (open) — no pick yet for that name; FV counts against your remaining budget
- **won** — your team drafted them; surplus = `FV − paid` (positive bank, negative deficit)
- **lost** — another team drafted them; row greys out, no longer counts against budget

Bottom-line headroom shows what you have left if you hit every open row at your FV. Surplus from bargains is implicitly available — it just shows up as more headroom because `myRemaining` already reflects what you've actually paid.

Sits **above** the existing 6-slot Target Board so the par sheet drives strategy and the Target Board stays your tight focus list.

## Behavior

- **Free-text adds** — type a name + dollar amount even before the rookie pool is synced. Slug-based identity matches a future pick recorded under the same slug.
- **Quick-add suggestions** — typing 2+ chars surfaces matching pool players; clicking pre-fills the FV with their PreDraft $ (overridable).
- **Inline FV editing** — click any FV cell to edit; Enter commits, Escape cancels.
- **Reorder + remove** — same ▲/▼/× controls as the Target Board.
- **Persistence** — added to the existing localStorage workspace key (per-league scoped), with hydration that rebuilds slugs and drops malformed rows.
- **Tier chip** rendered when the player exists in the rookie pool; absent for free-text rows that haven't been matched yet.
- **Status banner** — `idle` / `on_track` / `tight` / `short` / `done` with a context-aware label (e.g. *"Par sheet closed — surplus +$5"*).

Example from the request: Jeremiyah Love at FV $120, drafted to me at $115 → row shows `Won $115 / Δ +$5`, surplus banked = +$5, `committedFV` drops by 120 (he's no longer "open"), so headroom expands by 120 + the $5 saved.

## Files

- `frontend/lib/draft-logic.js` — `parSheet` workspace field, hydration, mutators (`addToParSheet`, `removeFromParSheet`, `updateParSheetFairValue`, `moveInParSheet`, `clearParSheet`), and `parSheetStats` block in `computeDraftStats`.
- `frontend/app/draft/page.jsx` — `<ParSheet>` component (mirrors `TargetBoard` conventions), 5 new `useCallback` handlers, injected just above `<TargetBoard>`.
- `frontend/app/globals.css` — `.draft-par-sheet` + `.draft-ps-*` classes (7-column grid, click-to-edit FV cell).
- `frontend/__tests__/draft-logic.test.js` — 18 new tests covering helpers + stats classification (target / won / lost / surplus / deficit / headroom-short / done / idle).

## Test plan

- [x] `npm test` — all 886 tests pass (217 in `draft-logic.test.js`, 18 new for par sheet)
- [x] `npm run build:nocheck` — Compiled successfully in 5.2s
- [ ] Manual: open `/draft`, type a player + FV, hit Add — row appears, footer updates
- [ ] Manual: record a pick for that player to my team at < FV — row flips to **Won**, surplus shows green Δ, headroom recalculates
- [ ] Manual: record a pick for another player to a different team — row flips to **Lost**, drops out of budget math
- [ ] Manual: click a FV cell, edit, Enter — value persists; reload to confirm localStorage hydration
- [ ] Manual: reorder rows with ▲/▼; remove with ×; "Clear" with confirm dialog wipes the sheet

https://claude.ai/code/session_01JgNxSnddCj6xPCFTtJyfpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgNxSnddCj6xPCFTtJyfpB)_