### PR TITLE
fix: drop scope-mismatched per-source values from player history

### DIFF
--- a/src/api/source_history.py
+++ b/src/api/source_history.py
@@ -69,6 +69,70 @@ _IDP_POSITIONS = frozenset(
      "DB", "CB", "S", "FS", "SS"}
 )
 
+# Scope → asset classes that scope can legitimately rank.  Mirrors
+# ``_scope_eligible`` in ``data_contract.py``: overall_offense covers
+# QB/RB/WR/TE plus picks; overall_idp and position_idp cover IDP only.
+# Used to drop scope-mismatched per-source values/ranks when extracting
+# a snapshot from a contract row and when reading the JSONL — without
+# this filter a WR like Ja'Marr Chase can carry a ``draftSharksIdp``
+# rank into the per-player history chart even though the IDP-scope
+# source never legitimately ranked him.
+_SCOPE_TO_ASSET_CLASSES: dict[str, frozenset[str]] = {
+    "overall_offense": frozenset({"offense", "pick"}),
+    "overall_idp": frozenset({"idp"}),
+    "position_idp": frozenset({"idp"}),
+}
+
+
+def _allowed_assets_for_source(source_key: str) -> frozenset[str] | None:
+    """Return the set of asset classes ``source_key`` is allowed to
+    rank, or None when the source isn't in the registry (legacy
+    snapshots with retired keys — preserve their data, don't filter).
+    """
+    cache = _allowed_assets_for_source.__dict__.setdefault("_cache", {})
+    if cache:
+        return cache.get(source_key)
+    # Lazy-import the registry to avoid pulling data_contract.py at
+    # module load (it's ~8k lines of pipeline code).
+    try:
+        from src.api.data_contract import get_ranking_source_registry  # noqa: PLC0415
+    except Exception:
+        return None
+    for src in get_ranking_source_registry():
+        scopes: list[str] = [str(src.get("scope") or "")]
+        scopes.extend(str(s) for s in (src.get("extraScopes") or []))
+        allowed: set[str] = set()
+        for scope in scopes:
+            allowed.update(_SCOPE_TO_ASSET_CLASSES.get(scope, frozenset()))
+        cache[str(src.get("key") or "")] = frozenset(allowed)
+    return cache.get(source_key)
+
+
+def _filter_scope_mismatched(
+    asset_class: str,
+    sources: dict[str, int] | None,
+    source_ranks: dict[str, int] | None,
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Drop entries whose source scope can't legitimately rank
+    ``asset_class``.  Unknown asset classes ("unknown" — pre-asset-
+    class snapshots) and unknown source keys pass through unchanged
+    so legacy data isn't silently erased.
+    """
+    src_out: dict[str, int] = dict(sources or {})
+    rank_out: dict[str, int] = dict(source_ranks or {})
+    if asset_class not in {"offense", "idp", "pick"}:
+        return src_out, rank_out
+    for key in list(src_out.keys()):
+        allowed = _allowed_assets_for_source(key)
+        if allowed is not None and asset_class not in allowed:
+            src_out.pop(key, None)
+            rank_out.pop(key, None)
+    for key in list(rank_out.keys()):
+        allowed = _allowed_assets_for_source(key)
+        if allowed is not None and asset_class not in allowed:
+            rank_out.pop(key, None)
+    return src_out, rank_out
+
 
 def _infer_asset_class(row: dict[str, Any]) -> str:
     """Mirror of ``rank_history._infer_asset_class`` — keep in sync so
@@ -167,6 +231,11 @@ def _extract_player_entry(row: dict[str, Any]) -> dict[str, Any] | None:
                 r = None
             if r is not None and r > 0:
                 source_ranks[str(key)] = r
+
+    asset_class = _infer_asset_class(row)
+    sources, source_ranks = _filter_scope_mismatched(
+        asset_class, sources, source_ranks
+    )
 
     if (
         blended_val is None
@@ -444,8 +513,19 @@ def load_player_history(
         dates.append(date)
         bv = entry.get("blended")
         br = entry.get("blendedRank")
-        sources = entry.get("sources") or {}
-        ranks = entry.get("sourceRanks") or {}
+        sources_raw = entry.get("sources") or {}
+        ranks_raw = entry.get("sourceRanks") or {}
+        # Apply the same scope filter that ``_extract_player_entry``
+        # uses so historical snapshots written before the write-time
+        # gate (or with a pre-fix contract leak) don't surface
+        # scope-mismatched per-source values/ranks on the chart.
+        # Asset class comes from the snapshot key itself.
+        _, snap_asset = _norm_name_key(hit_key)
+        sources, ranks = _filter_scope_mismatched(
+            snap_asset,
+            sources_raw if isinstance(sources_raw, dict) else None,
+            ranks_raw if isinstance(ranks_raw, dict) else None,
+        )
 
         # If the snapshot is pre-contract-builder (no blended value
         # persisted) derive an approximate blend from the median of
@@ -469,24 +549,22 @@ def load_player_history(
             "rank": int(br) if isinstance(br, (int, float)) else None,
             "derived": derived,
         })
-        if isinstance(sources, dict):
-            for key, value in sources.items():
-                try:
-                    v = int(value)
-                except (TypeError, ValueError):
-                    continue
-                sources_accum.setdefault(str(key), []).append({"date": date, "value": v})
-        if isinstance(ranks, dict):
-            for key, rank_val in ranks.items():
-                try:
-                    r = int(rank_val)
-                except (TypeError, ValueError):
-                    continue
-                if r <= 0:
-                    continue
-                source_ranks_accum.setdefault(str(key), []).append(
-                    {"date": date, "rank": r}
-                )
+        for key, value in sources.items():
+            try:
+                v = int(value)
+            except (TypeError, ValueError):
+                continue
+            sources_accum.setdefault(str(key), []).append({"date": date, "value": v})
+        for key, rank_val in ranks.items():
+            try:
+                r = int(rank_val)
+            except (TypeError, ValueError):
+                continue
+            if r <= 0:
+                continue
+            source_ranks_accum.setdefault(str(key), []).append(
+                {"date": date, "rank": r}
+            )
 
     return {
         "dates": dates,

--- a/tests/api/test_source_history.py
+++ b/tests/api/test_source_history.py
@@ -334,3 +334,154 @@ def test_backfill_derives_ranks_for_legacy_dict_export(tmp_path, path):
     )
     assert bench_entry["sourceRanks"]["ktcSfTep"] == 3
     assert bench_entry["sourceRanks"]["dlfSf"] == 3
+
+
+def test_scope_filter_drops_idp_source_for_offense_player(path):
+    """An offense WR that somehow carries an ``draftSharksIdp`` value /
+    rank in the contract row (e.g. a downstream cross-market leak)
+    must NOT surface in the per-source history.  IDP-scope sources
+    only legitimately rank IDP players; an offense-classed snapshot
+    entry has those keys filtered both at write time
+    (``_extract_player_entry``) and at read time
+    (``load_player_history``).
+    """
+    contract = _make_contract(
+        [
+            {
+                "name": "Ja'Marr Chase",
+                "pos": "WR",
+                "assetClass": "offense",
+                "blended": 9700,
+                "rank": 5,
+                # Both an offense source (legitimate) and an IDP-scope
+                # source (illegitimate leak) — the filter must drop
+                # only the IDP-scope key.
+                "sources": {"ktcSfTep": 9900, "draftSharksIdp": 1500},
+            },
+        ],
+        date="2026-05-04",
+    )
+    assert source_history.append_snapshot(contract, date="2026-05-04", path=path) is True
+
+    # Read back: only the offense source survives in the history.
+    hist = source_history.load_player_history("Ja'Marr Chase", path=path)
+    assert "ktcSfTep" in hist["sources"]
+    assert "draftSharksIdp" not in hist["sources"]
+
+    # Snapshot on disk is also clean — write-time filter prevents the
+    # IDP-scope contribution from ever landing in the JSONL.
+    raw = path.read_text().strip().splitlines()
+    snap = json.loads(raw[0])
+    chase_entry = next(
+        v for k, v in snap["players"].items() if k.startswith("Ja'Marr Chase")
+    )
+    assert "draftSharksIdp" not in chase_entry["sources"]
+    assert "ktcSfTep" in chase_entry["sources"]
+
+
+def test_scope_filter_drops_offense_source_for_idp_player(path):
+    """Symmetric guard: an IDP player that picks up an offense-scope
+    source value (e.g. ``dlfSf``) must have it filtered out.  IDP
+    sources like IDPTradeCalc that declare ``extra_scopes`` covering
+    offense remain valid for both asset classes; pure-offense scopes
+    do not.
+    """
+    contract = _make_contract(
+        [
+            {
+                "name": "Carson Schwesinger",
+                "pos": "LB",
+                "assetClass": "idp",
+                "blended": 5500,
+                "rank": 80,
+                "sources": {"draftSharksIdp": 4400, "dlfSf": 9000},
+            },
+        ],
+        date="2026-05-04",
+    )
+    source_history.append_snapshot(contract, date="2026-05-04", path=path)
+    hist = source_history.load_player_history("Carson Schwesinger", path=path)
+    assert "draftSharksIdp" in hist["sources"]
+    assert "dlfSf" not in hist["sources"]
+
+
+def test_scope_filter_read_time_strips_legacy_polluted_snapshot(path):
+    """Old snapshots written before the write-time filter could carry
+    scope-mismatched per-source entries.  ``load_player_history``
+    must drop them at read time so the chart never surfaces a
+    ``draftSharksIdp`` rank for a WR even when the JSONL on disk
+    has the legacy pollution.
+    """
+    polluted = {
+        "date": "2026-03-23",
+        "players": {
+            "Ja'Marr Chase::offense": {
+                "blended": 9550,
+                "blendedRank": 5,
+                "sources": {"ktcSfTep": 9849, "draftSharksIdp": 1552},
+                "sourceRanks": {"ktcSfTep": 5, "draftSharksIdp": 414},
+            }
+        },
+    }
+    path.write_text(json.dumps(polluted) + "\n")
+    hist = source_history.load_player_history("Ja'Marr Chase", path=path)
+    assert "ktcSfTep" in hist["sources"]
+    assert "draftSharksIdp" not in hist["sources"]
+    assert "ktcSfTep" in hist["sourceRanks"]
+    assert "draftSharksIdp" not in hist["sourceRanks"]
+
+
+def test_scope_filter_preserves_unknown_source_keys(path):
+    """Source keys not present in the registry (retired sources,
+    custom keys from old exports) pass through unchanged so legacy
+    history isn't silently erased.  Only registry-known keys whose
+    scope mismatches the player's asset class get dropped.
+    """
+    polluted = {
+        "date": "2026-03-23",
+        "players": {
+            "Ja'Marr Chase::offense": {
+                "blended": 9550,
+                "sources": {"someRetiredKey": 8000, "draftSharksIdp": 1500},
+                "sourceRanks": {"someRetiredKey": 7, "draftSharksIdp": 414},
+            }
+        },
+    }
+    path.write_text(json.dumps(polluted) + "\n")
+    hist = source_history.load_player_history("Ja'Marr Chase", path=path)
+    # Unknown key survives — preserves legacy data we can't classify.
+    assert "someRetiredKey" in hist["sources"]
+    # Registry-known IDP-scope key is filtered for the offense entry.
+    assert "draftSharksIdp" not in hist["sources"]
+
+
+def test_scope_filter_keeps_cross_scope_source_for_both_asset_classes(path):
+    """``idpTradeCalc`` declares ``scope=overall_idp`` plus
+    ``extra_scopes=[overall_offense]`` — it's a cross-market
+    source that legitimately ranks both offense and IDP.  The
+    scope filter must accept it for both asset classes.
+    """
+    contract = _make_contract(
+        [
+            {
+                "name": "Top WR",
+                "pos": "WR",
+                "assetClass": "offense",
+                "blended": 9000,
+                "sources": {"idpTradeCalc": 8800},
+            },
+            {
+                "name": "Top LB",
+                "pos": "LB",
+                "assetClass": "idp",
+                "blended": 5000,
+                "sources": {"idpTradeCalc": 4900},
+            },
+        ],
+        date="2026-05-04",
+    )
+    source_history.append_snapshot(contract, path=path)
+    off = source_history.load_player_history("Top WR", path=path)
+    idp = source_history.load_player_history("Top LB", path=path)
+    assert "idpTradeCalc" in off["sources"]
+    assert "idpTradeCalc" in idp["sources"]


### PR DESCRIPTION
## Summary

- Filter scope-mismatched per-source values/ranks at both the snapshot write path (`_extract_player_entry`) and the read path (`load_player_history`) so an offense WR like Ja'Marr Chase never surfaces a `draftSharksIdp` rank on the per-player history chart.
- Cross-scope sources like `idpTradeCalc` (declares `extra_scopes=[overall_offense]`) remain valid for both asset classes; retired/unknown source keys pass through unchanged so legacy data isn't silently erased.

## Why

Per-player rank/value history was surfacing scope-mismatched entries — e.g. Chase at #414 → #629 in Draft Sharks IDP, alongside his real #5 → #10 in Draft Sharks Dynasty. The live `_compute_unified_rankings` already gates by `_scope_eligible(pos, scope, ...)`, but historical snapshots and any downstream cross-market leak could still land those entries in `data/source_value_history.jsonl`. The filter is registry-driven (mirrors `_SCOPE_TO_ASSET_CLASSES` against the canonical source registry) so adding new sources doesn't require touching the filter.

## Test plan

- [x] New regression tests in `tests/api/test_source_history.py`:
  - `test_scope_filter_drops_idp_source_for_offense_player` — IDP-scope source dropped for WR
  - `test_scope_filter_drops_offense_source_for_idp_player` — offense-scope source dropped for IDP
  - `test_scope_filter_read_time_strips_legacy_polluted_snapshot` — legacy JSONL pollution masked at read time
  - `test_scope_filter_preserves_unknown_source_keys` — unknown registry keys pass through
  - `test_scope_filter_keeps_cross_scope_source_for_both_asset_classes` — `idpTradeCalc` honored for both
- [x] All 80 source-history / source-overrides / source-registry-parity tests pass
- [ ] Verify on Ja'Marr Chase's per-player rank chart that the second "Draft Sha…" line no longer appears after deploy

https://claude.ai/code/session_01Mk4ypXiXeeNdduz1ibAY3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mk4ypXiXeeNdduz1ibAY3u)_