### PR TITLE
feat: team-aware trade impact analyzer + Sleeper age backfill

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -61,6 +61,7 @@ _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 from src.utils.name_clean import resolve_idp_position as _resolve_idp_position  # noqa: E402
+from src.utils.age import age_from_birthdate as _age_from_birthdate  # noqa: E402
 
 try:
     from src.scoring import (
@@ -5552,6 +5553,19 @@ async def run(progress_callback=None):
         except Exception:
             return None
 
+    def _player_age_local(pname, pdata):
+        sid = str((pdata or {}).get("_sleeperId") or _player_id_map.get(pname) or "").strip()
+        if not sid:
+            ident = _resolve_identity_cached(pname, preferred_pos=_get_pos(pname))
+            if ident and ident.get("id"):
+                sid = str(ident.get("id"))
+        if not sid:
+            return None
+        row = SLEEPER_ALL_NFL.get(sid)
+        if not isinstance(row, dict):
+            return None
+        return _age_from_birthdate(row.get("birth_date"))
+
     def _median(vals, default_val):
         arr = sorted(v for v in vals if isinstance(v, (int, float)) and v > 0)
         if not arr:
@@ -6109,6 +6123,7 @@ async def run(progress_callback=None):
     # Persist rookie visibility metadata for dashboard filtering/debugging.
     _years_exp_tagged = 0
     _rookie_tagged = 0
+    _age_tagged = 0
     for _name, _pdata in players_json.items():
         if not isinstance(_pdata, dict) or _looks_like_pick_name(_name):
             continue
@@ -6123,6 +6138,10 @@ async def run(progress_callback=None):
             # Must-have rookies that are not in Sleeper's NFL player DB yet.
             _pdata["_isRookie"] = True
             _rookie_tagged += 1
+        _age = _player_age_local(_name, _pdata)
+        if isinstance(_age, int):
+            _pdata["age"] = _age
+            _age_tagged += 1
 
     # Final must-have rookie position enforcement. Do this after fallback creation and
     # rookie tagging so defensive prospects cannot drift back into generic offense entries.
@@ -6140,7 +6159,7 @@ async def run(progress_callback=None):
             _pos_map[_name] = _hint
 
     if DEBUG:
-        print(f"  [Rookies] Tagged years_exp for {_years_exp_tagged} players; rookie-flagged {_rookie_tagged}")
+        print(f"  [Rookies] Tagged years_exp for {_years_exp_tagged} players; rookie-flagged {_rookie_tagged}; age tagged {_age_tagged}")
 
     # Set _rawComposite and _finalAdjusted directly from _composite.
     for name, pdata in players_json.items():

--- a/config/trade/team_impact.json
+++ b/config/trade/team_impact.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "weights": {
+    "fillStarter": 1.0,
+    "depth": 0.25,
+    "overflow": 0.6,
+    "fitNormalization": 4000,
+    "equityNormalization": 2500,
+    "compositeFitWeight": 0.55,
+    "compositeEquityWeight": 0.45
+  },
+  "verdictThresholds": {
+    "accept": 20,
+    "leanAccept": 8,
+    "leanDecline": -8,
+    "decline": -20
+  },
+  "windowFit": {
+    "contendIndexThreshold": 0.15,
+    "youngStarterMaxAge": 23,
+    "primeStarterMinAge": 24,
+    "primeStarterMaxAge": 29
+  }
+}

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -1495,6 +1495,136 @@ export default function TradePage() {
                       );
                     })}
                   </div>
+                  {simResult.teamImpact && (() => {
+                    const ti = simResult.teamImpact;
+                    const verdictColor = {
+                      "accept": "var(--green)",
+                      "lean accept": "var(--green)",
+                      "neutral": "var(--muted)",
+                      "lean decline": "var(--red)",
+                      "decline": "var(--red)",
+                    }[ti.verdict] || "var(--muted)";
+                    const starterPosEntries = Object.entries(ti.starterValueDelta || {})
+                      .filter(([, v]) => v !== 0);
+                    return (
+                      <div style={{
+                        marginTop: 10,
+                        paddingTop: 8,
+                        borderTop: "1px solid var(--border)",
+                      }}>
+                        <div style={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                          marginBottom: 6,
+                        }}>
+                          <div style={{ fontSize: "0.7rem", fontWeight: 700, letterSpacing: "0.04em" }}>
+                            ROSTER FIT
+                          </div>
+                          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                            <span style={{
+                              fontSize: "0.66rem",
+                              padding: "2px 8px",
+                              borderRadius: 4,
+                              background: verdictColor,
+                              color: "var(--bg)",
+                              fontWeight: 700,
+                              textTransform: "uppercase",
+                            }}>
+                              {ti.verdict}
+                            </span>
+                            <span style={{ fontSize: "0.78rem", fontWeight: 700, color: verdictColor }}>
+                              {ti.compositeScore >= 0 ? "+" : ""}{ti.compositeScore.toFixed(1)}
+                            </span>
+                          </div>
+                        </div>
+                        <div style={{
+                          display: "grid",
+                          gridTemplateColumns: "repeat(3, minmax(0,1fr))",
+                          gap: 6,
+                          fontSize: "0.68rem",
+                          marginBottom: 6,
+                        }}>
+                          <div>
+                            <div className="muted" style={{ fontSize: "0.62rem" }}>Fit</div>
+                            <div style={{
+                              fontWeight: 700,
+                              color: ti.fitScore >= 0 ? "var(--green)" : "var(--red)",
+                            }}>
+                              {ti.fitScore >= 0 ? "+" : ""}{ti.fitScore.toFixed(1)}
+                            </div>
+                          </div>
+                          <div>
+                            <div className="muted" style={{ fontSize: "0.62rem" }}>Equity</div>
+                            <div style={{
+                              fontWeight: 700,
+                              color: ti.equityScore >= 0 ? "var(--green)" : "var(--red)",
+                            }}>
+                              {ti.equityScore >= 0 ? "+" : ""}{ti.equityScore.toFixed(1)}
+                            </div>
+                          </div>
+                          <div>
+                            <div className="muted" style={{ fontSize: "0.62rem" }}>
+                              {ti.posture}
+                            </div>
+                            <div style={{
+                              fontWeight: 700,
+                              color: ti.windowFit >= 0 ? "var(--green)" : "var(--red)",
+                            }}>
+                              window {ti.windowFit >= 0 ? "+" : ""}{ti.windowFit.toFixed(2)}
+                            </div>
+                          </div>
+                        </div>
+                        {starterPosEntries.length > 0 && (
+                          <div style={{
+                            display: "grid",
+                            gridTemplateColumns: "repeat(auto-fit, minmax(80px, 1fr))",
+                            gap: 4,
+                            fontSize: "0.66rem",
+                            marginBottom: 6,
+                          }}>
+                            {starterPosEntries.map(([pos, dv]) => (
+                              <div key={pos} style={{
+                                padding: "2px 6px",
+                                border: "1px solid var(--border)",
+                                borderRadius: 3,
+                              }}>
+                                <span className="muted">{pos} starter </span>
+                                <span style={{
+                                  color: dv > 0 ? "var(--green)" : "var(--red)",
+                                  fontWeight: 600,
+                                }}>
+                                  {dv > 0 ? "+" : ""}{Math.round(dv).toLocaleString()}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        {ti.rationale?.length > 0 && (
+                          <ul style={{
+                            margin: "4px 0 0",
+                            paddingLeft: 18,
+                            fontSize: "0.7rem",
+                            lineHeight: 1.4,
+                          }}>
+                            {ti.rationale.map((r, i) => (
+                              <li key={i}>{r}</li>
+                            ))}
+                          </ul>
+                        )}
+                        {ti.redundancy?.length > 0 && (
+                          <div style={{
+                            marginTop: 6,
+                            fontSize: "0.68rem",
+                            color: "var(--red)",
+                          }}>
+                            Redundant:{" "}
+                            {ti.redundancy.map((r) => `${r.name} (${r.pos})`).join(", ")}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })()}
                   {(simResult.unresolvedIn?.length > 0 || simResult.unresolvedOut?.length > 0) && (
                     <div className="muted" style={{ fontSize: "0.7rem", marginTop: 6, color: "var(--red)" }}>
                       Unresolved:{" "}

--- a/server.py
+++ b/server.py
@@ -7267,6 +7267,7 @@ async def post_trade_simulate(request: Request):
         players_out=_str_list("playersOut"),
         picks_in=_str_list("picksIn"),
         picks_out=_str_list("picksOut"),
+        roster_settings=dict(league_cfg.roster_settings or {}),
     )
     result["leagueKey"] = league_cfg.key
     return JSONResponse(

--- a/src/adapters/scraper_bridge_adapter.py
+++ b/src/adapters/scraper_bridge_adapter.py
@@ -107,7 +107,7 @@ class ScraperBridgeAdapter:
                         display_name=name,
                         team_raw=str(row.get("team") or ""),
                         position_raw=str(row.get("pos") or row.get("position") or ""),
-                        age_raw="",
+                        age_raw=str(row.get("age") or row.get("age_raw") or ""),
                         rookie_flag_raw="",
                         rank_raw=rank_raw,
                         value_raw=value_raw,

--- a/src/api/trade_simulator.py
+++ b/src/api/trade_simulator.py
@@ -51,12 +51,15 @@ def _resolve_asset(
         return None
     value = int(_row_value(row))
     pos = _normalize_pos(row.get("pos") or row.get("position"))
+    age = row.get("age")
     return {
         "name": row.get("displayName") or row.get("canonicalName") or name,
         "pos": pos,
         "value": value,
         "rank": _row_rank(row),
         "tier": _tier_bucket(value),
+        "age": int(age) if isinstance(age, (int, float)) and age else None,
+        "assetClass": row.get("assetClass") or ("pick" if pos == "PICK" else "player"),
     }
 
 
@@ -112,6 +115,7 @@ def simulate_trade(
     players_out: list[str] | None = None,
     picks_in: list[str] | None = None,
     picks_out: list[str] | None = None,
+    roster_settings: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the simulator payload for a single hypothetical trade.
 
@@ -202,7 +206,7 @@ def simulate_trade(
 
     equity = sum(a["value"] for a in receiving) - sum(a["value"] for a in sending)
 
-    return {
+    response: dict[str, Any] = {
         "team": team_block,
         "before": before,
         "after": after,
@@ -213,3 +217,22 @@ def simulate_trade(
         "unresolvedOut": unresolved_out,
         "equity": int(equity),
     }
+
+    # Roster-shape-aware fit verdict.  Only computed when we have both
+    # a resolved team and league roster settings — free-analysis mode
+    # (no team selected) and contracts without league context skip
+    # this block entirely.
+    if resolved_team and roster_settings:
+        from src.trade import team_impact
+        impact = team_impact.compute(
+            before_assets=before_assets,
+            after_assets=after_assets,
+            receiving=receiving,
+            sending=sending,
+            equity=int(equity),
+            roster_settings=roster_settings,
+        )
+        if impact is not None:
+            response["teamImpact"] = impact
+
+    return response

--- a/src/api/trade_simulator.py
+++ b/src/api/trade_simulator.py
@@ -52,9 +52,16 @@ def _resolve_asset(
     value = int(_row_value(row))
     pos = _normalize_pos(row.get("pos") or row.get("position"))
     age = row.get("age")
+    # ``pos`` collapses DL/LB/DB to "IDP" for terminal aggregation;
+    # ``basePos`` preserves the distinction so team_impact can apply
+    # per-position starter rules (DL/LB/DB are separate slots in
+    # rosterSettings.starters).
+    from src.utils.name_clean import normalize_position
+    base_pos = normalize_position(row.get("pos") or row.get("position"))
     return {
         "name": row.get("displayName") or row.get("canonicalName") or name,
         "pos": pos,
+        "basePos": base_pos or pos,
         "value": value,
         "rank": _row_rank(row),
         "tier": _tier_bucket(value),

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -649,7 +649,16 @@ def rank_score(
     # 6. Opponent-fit bonus
     opp_fit = 1.5 if s.__dict__.get("opponent_fit") else 0.0
 
-    return base + fair + conf + need_sev + edge_b + opp_fit
+    # 7. Roster-fit penalty: receiving an asset at a saturated position
+    # is bench bloat in dynasty, even if equity is positive.  Mirrors
+    # the team_impact module's overflow penalty in the trade simulator.
+    overflow_penalty = 0.0
+    if roster is not None:
+        for p in s.receive:
+            if p.position in roster.surplus_positions:
+                overflow_penalty += 1.0
+
+    return base + fair + conf + need_sev + edge_b + opp_fit - overflow_penalty
 
 
 def rank_score_breakdown(
@@ -676,6 +685,12 @@ def rank_score_breakdown(
     edge_b = _EDGE_RANK_BONUS.get(edge, 0.0) if edge else 0.0
     opp_fit = 1.5 if s.__dict__.get("opponent_fit") else 0.0
 
+    overflow_penalty = 0.0
+    if roster is not None:
+        for p in s.receive:
+            if p.position in roster.surplus_positions:
+                overflow_penalty += 1.0
+
     return {
         "base_value": round(base, 2),
         "fairness": round(fair, 2),
@@ -683,7 +698,10 @@ def rank_score_breakdown(
         "need_severity": round(need_sev, 2),
         "edge": round(edge_b, 2),
         "opponent_fit": round(opp_fit, 2),
-        "total": round(base + fair + conf + need_sev + edge_b + opp_fit, 2),
+        "overflow_penalty": round(-overflow_penalty, 2),
+        "total": round(
+            base + fair + conf + need_sev + edge_b + opp_fit - overflow_penalty, 2
+        ),
     }
 
 

--- a/src/trade/team_impact.py
+++ b/src/trade/team_impact.py
@@ -112,7 +112,7 @@ def project_starters(
     slots = _starter_slots(roster_settings)
     pool = [
         a for a in assets
-        if (a.get("pos") or "").upper() in _BASE_POSITIONS
+        if (a.get("basePos") or a.get("pos") or "").upper() in _BASE_POSITIONS
     ]
     pool.sort(key=lambda a: int(a.get("value") or 0), reverse=True)
     used: set[int] = set()
@@ -128,7 +128,7 @@ def project_starters(
                 break
             if idx in used:
                 continue
-            pos = (asset.get("pos") or "").upper()
+            pos = (asset.get("basePos") or asset.get("pos") or "").upper()
             if _eligible(slot, pos, roster_settings):
                 starters[pos].append(asset)
                 used.add(idx)
@@ -151,7 +151,7 @@ def _aggregate_state(
     }
     total_count: dict[str, int] = {p: 0 for p in _BASE_POSITIONS}
     for a in assets:
-        pos = (a.get("pos") or "").upper()
+        pos = (a.get("basePos") or a.get("pos") or "").upper()
         if pos in total_count:
             total_count[pos] += 1
     depth_count = {p: max(0, total_count[p] - starter_count[p]) for p in _BASE_POSITIONS}
@@ -299,7 +299,7 @@ def _redundancy(
     active = set(_league_active_positions(roster_settings))
     out: list[dict[str, Any]] = []
     for asset in receiving:
-        pos = (asset.get("pos") or "").upper()
+        pos = (asset.get("basePos") or asset.get("pos") or "").upper()
         if pos not in active:
             continue
         name_key = str(asset.get("name") or "").lower()

--- a/src/trade/team_impact.py
+++ b/src/trade/team_impact.py
@@ -1,0 +1,489 @@
+"""Team-aware trade impact analyzer.
+
+Produces a roster-shape-aware verdict on a proposed trade — the dynasty
+manager's actual question: *does this trade FIT my roster*, not just
+*is the equity fair*.
+
+Pure functions; no I/O.  Inputs are the same resolved-asset dicts that
+``src/api/trade_simulator.py`` already builds, plus the league's
+``rosterSettings`` (from ``src.api.league_registry``).
+
+CRITICAL ARCHITECTURAL RULE — see ``src/league/README.md``:
+
+    Player VALUES are global per scoring profile.
+    Team FIT is per-league.
+
+This module produces a *fit score alongside* a player's value.  It
+NEVER mutates ``row.value`` per team.  The retired LAM module proved
+that path is wrong — do not re-introduce it here.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Greedy starter fill order — premium positions first, then flex
+# slots, then IDP.  Within each slot, highest value eligible asset
+# wins.  IDP slots are skipped automatically if the league has no
+# DL/LB/DB starters configured.
+_FILL_ORDER = ("QB", "RB", "WR", "TE", "SFLEX", "FLEX", "DL", "LB", "DB", "IDP_FLEX")
+
+_BASE_POSITIONS = ("QB", "RB", "WR", "TE", "DL", "LB", "DB")
+
+_DEFAULT_FLEX_ELIGIBLE = ("RB", "WR", "TE")
+_DEFAULT_SFLEX_ELIGIBLE = ("QB", "RB", "WR", "TE")
+_DEFAULT_IDP_FLEX_ELIGIBLE = ("DL", "LB", "DB")
+
+
+def _load_default_weights() -> dict[str, Any]:
+    """Read config/trade/team_impact.json once.  Falls back to safe
+    defaults if the file is missing — same shape as the JSON.
+    """
+    try:
+        path = Path(__file__).resolve().parents[2] / "config" / "trade" / "team_impact.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {
+            "weights": {
+                "fillStarter": 1.0,
+                "depth": 0.25,
+                "overflow": 0.6,
+                "fitNormalization": 4000,
+                "equityNormalization": 2500,
+                "compositeFitWeight": 0.55,
+                "compositeEquityWeight": 0.45,
+            },
+            "verdictThresholds": {
+                "accept": 20,
+                "leanAccept": 8,
+                "leanDecline": -8,
+                "decline": -20,
+            },
+            "windowFit": {
+                "contendIndexThreshold": 0.15,
+                "youngStarterMaxAge": 23,
+                "primeStarterMinAge": 24,
+                "primeStarterMaxAge": 29,
+            },
+        }
+
+
+def _starter_slots(roster_settings: dict[str, Any]) -> dict[str, int]:
+    """Extract the per-slot starter counts dict (e.g. {"QB":1,"RB":2,...}).
+    Returns ``{}`` if absent — caller treats that as "no fit analysis
+    possible".
+    """
+    s = roster_settings.get("starters") if isinstance(roster_settings, dict) else None
+    if not isinstance(s, dict):
+        return {}
+    return {str(k).upper(): int(v) for k, v in s.items() if isinstance(v, (int, float))}
+
+
+def _eligible(slot: str, pos: str, roster_settings: dict[str, Any]) -> bool:
+    pos = (pos or "").upper()
+    slot = slot.upper()
+    if not pos:
+        return False
+    if slot == pos:
+        return True
+    if slot == "FLEX":
+        eligible = roster_settings.get("flexEligible") or _DEFAULT_FLEX_ELIGIBLE
+        return pos in {p.upper() for p in eligible}
+    if slot == "SFLEX":
+        eligible = roster_settings.get("sflexEligible") or _DEFAULT_SFLEX_ELIGIBLE
+        return pos in {p.upper() for p in eligible}
+    if slot == "IDP_FLEX":
+        eligible = roster_settings.get("idpFlexEligible") or _DEFAULT_IDP_FLEX_ELIGIBLE
+        return pos in {p.upper() for p in eligible}
+    return False
+
+
+def project_starters(
+    assets: list[dict[str, Any]],
+    roster_settings: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    """Greedy-fill starting lineup from a list of resolved assets.
+
+    Returns ``{base_pos: [asset, ...]}`` — the starters at each base
+    position (RB starters from FLEX go into the RB bucket).  Picks
+    are ignored (they don't start).
+    """
+    slots = _starter_slots(roster_settings)
+    pool = [
+        a for a in assets
+        if (a.get("pos") or "").upper() in _BASE_POSITIONS
+    ]
+    pool.sort(key=lambda a: int(a.get("value") or 0), reverse=True)
+    used: set[int] = set()
+    starters: dict[str, list[dict[str, Any]]] = {p: [] for p in _BASE_POSITIONS}
+
+    for slot in _FILL_ORDER:
+        count = slots.get(slot, 0)
+        if count <= 0:
+            continue
+        filled = 0
+        for idx, asset in enumerate(pool):
+            if filled >= count:
+                break
+            if idx in used:
+                continue
+            pos = (asset.get("pos") or "").upper()
+            if _eligible(slot, pos, roster_settings):
+                starters[pos].append(asset)
+                used.add(idx)
+                filled += 1
+    return starters
+
+
+def _aggregate_state(
+    assets: list[dict[str, Any]],
+    roster_settings: dict[str, Any],
+) -> dict[str, Any]:
+    """Project starters + compute totalCount/starterCount/depthCount/
+    starterValue per base position.
+    """
+    starters = project_starters(assets, roster_settings)
+    starter_count = {p: len(starters[p]) for p in _BASE_POSITIONS}
+    starter_value = {
+        p: sum(int(a.get("value") or 0) for a in starters[p])
+        for p in _BASE_POSITIONS
+    }
+    total_count: dict[str, int] = {p: 0 for p in _BASE_POSITIONS}
+    for a in assets:
+        pos = (a.get("pos") or "").upper()
+        if pos in total_count:
+            total_count[pos] += 1
+    depth_count = {p: max(0, total_count[p] - starter_count[p]) for p in _BASE_POSITIONS}
+    return {
+        "starters": starters,
+        "starterCount": starter_count,
+        "starterValue": starter_value,
+        "totalCount": total_count,
+        "depthCount": depth_count,
+    }
+
+
+def _flex_share(pos: str, roster_settings: dict[str, Any]) -> float:
+    """Approximate share of FLEX/SFLEX slots a base position absorbs.
+
+    Used to compute ``needed[pos]`` for overflow detection.  Pure
+    convenience — equal split across eligible positions.
+    """
+    slots = _starter_slots(roster_settings)
+    share = 0.0
+    if pos in (roster_settings.get("flexEligible") or _DEFAULT_FLEX_ELIGIBLE):
+        eligible = roster_settings.get("flexEligible") or _DEFAULT_FLEX_ELIGIBLE
+        share += slots.get("FLEX", 0) / max(1, len(eligible))
+    if pos in (roster_settings.get("sflexEligible") or _DEFAULT_SFLEX_ELIGIBLE):
+        eligible = roster_settings.get("sflexEligible") or _DEFAULT_SFLEX_ELIGIBLE
+        share += slots.get("SFLEX", 0) / max(1, len(eligible))
+    if pos in (roster_settings.get("idpFlexEligible") or _DEFAULT_IDP_FLEX_ELIGIBLE):
+        eligible = roster_settings.get("idpFlexEligible") or _DEFAULT_IDP_FLEX_ELIGIBLE
+        share += slots.get("IDP_FLEX", 0) / max(1, len(eligible))
+    return share
+
+
+def _needed_at(pos: str, roster_settings: dict[str, Any]) -> float:
+    slots = _starter_slots(roster_settings)
+    return slots.get(pos, 0) + _flex_share(pos, roster_settings)
+
+
+def _avg(values: list[int]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _league_active_positions(roster_settings: dict[str, Any]) -> list[str]:
+    """Positions the league actually starts.  ``dynasty_new`` returns
+    only QB/RB/WR/TE; ``dynasty_main`` adds DL/LB/DB.  This is the
+    guard that prevents IDP redundancy false-positives in non-IDP
+    leagues.
+    """
+    return [p for p in _BASE_POSITIONS if _needed_at(p, roster_settings) > 0]
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+def _classify_window(
+    before_assets: list[dict[str, Any]],
+    config: dict[str, Any],
+) -> str:
+    """Posture from current roster: contender / balanced / rebuilder.
+
+    Heuristic:
+      contendIndex = top10 starter value share
+                   - (rookie pick share + young (<24) starter share)
+    """
+    threshold = float(config.get("windowFit", {}).get("contendIndexThreshold", 0.15))
+    young_max = int(config.get("windowFit", {}).get("youngStarterMaxAge", 23))
+
+    total_value = sum(int(a.get("value") or 0) for a in before_assets) or 1
+    by_value = sorted(before_assets, key=lambda a: int(a.get("value") or 0), reverse=True)
+    top10_value = sum(int(a.get("value") or 0) for a in by_value[:10])
+    top10_share = top10_value / total_value
+
+    pick_value = sum(
+        int(a.get("value") or 0) for a in before_assets
+        if (a.get("assetClass") or "").lower() == "pick"
+    )
+    pick_share = pick_value / total_value
+
+    young_value = sum(
+        int(a.get("value") or 0) for a in before_assets
+        if isinstance(a.get("age"), int) and a["age"] <= young_max
+    )
+    young_share = young_value / total_value
+
+    contend_index = top10_share - (pick_share + young_share)
+    if contend_index > threshold:
+        return "contender"
+    if contend_index < -threshold:
+        return "rebuilder"
+    return "balanced"
+
+
+def _window_fit_for_asset(
+    asset: dict[str, Any],
+    posture: str,
+    config: dict[str, Any],
+    *,
+    sign: int,
+) -> float:
+    """Score one moving asset against the team's posture.
+
+    ``sign=+1`` for receiving, ``sign=-1`` for sending.  Returns a
+    float in roughly [-1, +1] before averaging.
+    """
+    wf = config.get("windowFit", {})
+    prime_min = int(wf.get("primeStarterMinAge", 24))
+    prime_max = int(wf.get("primeStarterMaxAge", 29))
+    young_max = int(wf.get("youngStarterMaxAge", 23))
+
+    is_pick = (asset.get("assetClass") or "").lower() == "pick"
+    age = asset.get("age") if isinstance(asset.get("age"), int) else None
+    is_young = age is not None and age <= young_max
+    is_prime = age is not None and prime_min <= age <= prime_max
+
+    if posture == "contender":
+        if is_prime:
+            return 1.0 * sign
+        if is_pick or is_young:
+            return -1.0 * sign
+        return 0.0
+    if posture == "rebuilder":
+        if is_pick or is_young:
+            return 1.0 * sign
+        if is_prime:
+            return -0.5 * sign
+        return 0.0
+    return 0.0
+
+
+def _redundancy(
+    receiving: list[dict[str, Any]],
+    after_starters: dict[str, list[dict[str, Any]]],
+    before_state: dict[str, Any],
+    roster_settings: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Flag acquired assets that don't crack the starting lineup at a
+    position the team was already saturated in.  Skipped for positions
+    the league doesn't start (no false-positives in non-IDP leagues).
+    """
+    starter_names = {
+        str(a.get("name") or "").lower()
+        for assets in after_starters.values()
+        for a in assets
+    }
+    active = set(_league_active_positions(roster_settings))
+    out: list[dict[str, Any]] = []
+    for asset in receiving:
+        pos = (asset.get("pos") or "").upper()
+        if pos not in active:
+            continue
+        name_key = str(asset.get("name") or "").lower()
+        if name_key in starter_names:
+            continue
+        before_count = before_state["totalCount"].get(pos, 0)
+        needed = _needed_at(pos, roster_settings)
+        if before_count >= int(needed) + 1:
+            out.append({
+                "name": asset.get("name"),
+                "pos": pos,
+                "reason": "duplicate at saturated position",
+            })
+    return out
+
+
+def _verdict(composite: float, thresholds: dict[str, Any]) -> str:
+    if composite >= float(thresholds.get("accept", 20)):
+        return "accept"
+    if composite >= float(thresholds.get("leanAccept", 8)):
+        return "lean accept"
+    if composite > float(thresholds.get("leanDecline", -8)):
+        return "neutral"
+    if composite > float(thresholds.get("decline", -20)):
+        return "lean decline"
+    return "decline"
+
+
+def _rationale(
+    *,
+    starter_value_delta: dict[str, int],
+    starter_delta: dict[str, int],
+    overflow_delta: dict[str, int],
+    redundancy: list[dict[str, Any]],
+    window_fit: float,
+    posture: str,
+    equity: int,
+    fit_score: float,
+) -> list[str]:
+    """Top 5 bullets ranked by absolute contribution to verdict."""
+    bullets: list[tuple[float, str]] = []
+    for pos, dv in starter_value_delta.items():
+        if dv == 0:
+            continue
+        sign = "+" if dv > 0 else ""
+        if dv > 0 and starter_delta.get(pos, 0) > 0:
+            bullets.append((abs(dv), f"Adds a starting {pos} ({sign}{dv} starter value)"))
+        elif dv < 0 and starter_delta.get(pos, 0) < 0:
+            bullets.append((abs(dv), f"Loses a starting {pos} ({sign}{dv} starter value)"))
+        else:
+            bullets.append((abs(dv) * 0.6, f"Shifts {pos} starter quality ({sign}{dv})"))
+    for pos, od in overflow_delta.items():
+        if od >= 1:
+            bullets.append((400 * od, f"Adds bench depth at saturated {pos} (-overflow)"))
+    for r in redundancy:
+        bullets.append((300, f"Acquired {r['name']} ({r['pos']}) doesn't start — duplicate"))
+    if abs(window_fit) >= 0.4:
+        word = "aligns with" if window_fit > 0 else "fights"
+        bullets.append((abs(window_fit) * 1000, f"Trade {word} a {posture} window ({window_fit:+.1f})"))
+    if abs(equity) >= 500:
+        bullets.append((abs(equity) * 0.3, f"Net KTC equity {equity:+d}"))
+    if abs(fit_score) >= 5:
+        bullets.append((abs(fit_score) * 5, f"Roster-shape fit score {fit_score:+.0f}"))
+    bullets.sort(key=lambda b: b[0], reverse=True)
+    return [b[1] for b in bullets[:5]]
+
+
+def compute(
+    *,
+    before_assets: list[dict[str, Any]],
+    after_assets: list[dict[str, Any]],
+    receiving: list[dict[str, Any]],
+    sending: list[dict[str, Any]],
+    equity: int,
+    roster_settings: dict[str, Any],
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Build the ``teamImpact`` payload.  Returns ``None`` when
+    ``roster_settings`` lacks starter slots (no fit analysis possible).
+    """
+    cfg = config or _load_default_weights()
+    weights = cfg.get("weights", {})
+    thresholds = cfg.get("verdictThresholds", {})
+
+    if not _starter_slots(roster_settings):
+        return None
+
+    before = _aggregate_state(before_assets, roster_settings)
+    after = _aggregate_state(after_assets, roster_settings)
+    active = _league_active_positions(roster_settings)
+
+    starter_delta = {p: after["starterCount"][p] - before["starterCount"][p] for p in _BASE_POSITIONS}
+    starter_value_delta = {p: after["starterValue"][p] - before["starterValue"][p] for p in _BASE_POSITIONS}
+    depth_delta = {p: after["depthCount"][p] - before["depthCount"][p] for p in _BASE_POSITIONS}
+
+    # Overflow detection — anything above (needed + 1) is bench bloat.
+    overflow_delta: dict[str, int] = {}
+    for p in _BASE_POSITIONS:
+        cap = int(_needed_at(p, roster_settings)) + 1
+        before_over = max(0, before["totalCount"][p] - cap)
+        after_over = max(0, after["totalCount"][p] - cap)
+        overflow_delta[p] = after_over - before_over
+
+    # Average starter value per pos, for normalization.
+    avg_starter_val: dict[str, float] = {}
+    for p in _BASE_POSITIONS:
+        combined = (
+            [int(a.get("value") or 0) for a in before["starters"][p]]
+            + [int(a.get("value") or 0) for a in after["starters"][p]]
+        )
+        avg_starter_val[p] = _avg(combined) or 1500.0
+
+    w_fill = float(weights.get("fillStarter", 1.0))
+    w_depth = float(weights.get("depth", 0.25))
+    w_overflow = float(weights.get("overflow", 0.6))
+    fit_norm = float(weights.get("fitNormalization", 4000)) or 4000.0
+
+    fit_raw = 0.0
+    for p in active:
+        fit_raw += w_fill * starter_value_delta[p]
+        # Diminishing depth: only the first depth piece earns a bonus.
+        before_first_depth = 1 if before["depthCount"][p] >= 1 else 0
+        after_first_depth = 1 if after["depthCount"][p] >= 1 else 0
+        fit_raw += w_depth * (after_first_depth - before_first_depth) * avg_starter_val[p]
+        fit_raw -= w_overflow * max(0, overflow_delta[p]) * avg_starter_val[p]
+
+    fit_score = _clamp(100.0 * fit_raw / fit_norm, -100.0, 100.0)
+    equity_norm = float(weights.get("equityNormalization", 2500)) or 2500.0
+    equity_score = _clamp(100.0 * float(equity) / equity_norm, -100.0, 100.0)
+
+    cw_fit = float(weights.get("compositeFitWeight", 0.55))
+    cw_eq = float(weights.get("compositeEquityWeight", 0.45))
+    composite = cw_fit * fit_score + cw_eq * equity_score
+
+    posture = _classify_window(before_assets, cfg)
+    window_score = 0.0
+    moving = []
+    for a in receiving:
+        moving.append(_window_fit_for_asset(a, posture, cfg, sign=+1))
+    for a in sending:
+        moving.append(_window_fit_for_asset(a, posture, cfg, sign=-1))
+    if moving:
+        window_score = sum(moving) / len(moving)
+
+    def _avg_age(assets: list[dict[str, Any]]) -> float | None:
+        ages = [a["age"] for a in assets if isinstance(a.get("age"), int)]
+        return sum(ages) / len(ages) if ages else None
+
+    in_age = _avg_age(receiving)
+    out_age = _avg_age(sending)
+    age_delta = (in_age - out_age) if (in_age is not None and out_age is not None) else 0.0
+
+    # Scarcity delta — reports the per-position starter-vs-replacement
+    # shift for the user.  This is reporting only, never re-prices.
+    scarcity_delta: dict[str, float] = {}
+    for p in active:
+        before_avg = (before["starterValue"][p] / before["starterCount"][p]) if before["starterCount"][p] else 0
+        after_avg = (after["starterValue"][p] / after["starterCount"][p]) if after["starterCount"][p] else 0
+        scarcity_delta[p] = round(after_avg - before_avg, 1)
+
+    redundancy = _redundancy(receiving, after["starters"], before, roster_settings)
+    rationale = _rationale(
+        starter_value_delta={p: starter_value_delta[p] for p in active},
+        starter_delta={p: starter_delta[p] for p in active},
+        overflow_delta={p: overflow_delta[p] for p in active},
+        redundancy=redundancy,
+        window_fit=window_score,
+        posture=posture,
+        equity=equity,
+        fit_score=fit_score,
+    )
+
+    return {
+        "fitScore": round(fit_score, 1),
+        "equityScore": round(equity_score, 1),
+        "compositeScore": round(composite, 1),
+        "verdict": _verdict(composite, thresholds),
+        "posture": posture,
+        "starterDelta": {p: starter_delta[p] for p in active},
+        "starterValueDelta": {p: starter_value_delta[p] for p in active},
+        "depthDelta": {p: depth_delta[p] for p in active},
+        "windowFit": round(window_score, 2),
+        "ageDelta": round(age_delta, 1),
+        "scarcityDelta": scarcity_delta,
+        "redundancy": redundancy,
+        "rationale": rationale,
+    }

--- a/src/utils/age.py
+++ b/src/utils/age.py
@@ -23,9 +23,13 @@ def age_from_birthdate(bd: str | None, *, today: date | None = None) -> int | No
         return None
     try:
         parts = str(bd).split("-")
-        y, m, d = int(parts[0]), int(parts[1]), int(parts[2])
+        if len(parts) != 3:
+            return None
+        # ``date(...)`` validates calendar correctness — Feb 31, month 99,
+        # etc. raise ValueError instead of producing a wrong-but-numeric age.
+        born = date(int(parts[0]), int(parts[1]), int(parts[2]))
     except (ValueError, IndexError, AttributeError, TypeError):
         return None
     ref = today or date.today()
-    age = ref.year - y - ((ref.month, ref.day) < (m, d))
+    age = ref.year - born.year - ((ref.month, ref.day) < (born.month, born.day))
     return age if 15 <= age <= 50 else None

--- a/src/utils/age.py
+++ b/src/utils/age.py
@@ -1,0 +1,31 @@
+"""Age helpers for player records.
+
+Sleeper's ``/v1/players/nfl`` payload exposes ``birth_date`` in
+ISO ``YYYY-MM-DD`` form for almost every active NFL player.  This
+module converts that into the integer ``age`` the contract layer
+and frontend age-curve overlay expect.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+
+def age_from_birthdate(bd: str | None, *, today: date | None = None) -> int | None:
+    """Convert an ISO ``YYYY-MM-DD`` birth_date to integer age.
+
+    Returns ``None`` for empty / malformed input or implausible ages
+    (the Sleeper dump occasionally has corrupt rows; clamping to
+    15..50 filters those without affecting any real NFL player).
+
+    ``today`` is injected for deterministic testing.
+    """
+    if not bd:
+        return None
+    try:
+        parts = str(bd).split("-")
+        y, m, d = int(parts[0]), int(parts[1]), int(parts[2])
+    except (ValueError, IndexError, AttributeError, TypeError):
+        return None
+    ref = today or date.today()
+    age = ref.year - y - ((ref.month, ref.day) < (m, d))
+    return age if 15 <= age <= 50 else None

--- a/tests/api/test_data_contract_age.py
+++ b/tests/api/test_data_contract_age.py
@@ -1,0 +1,76 @@
+"""Pin that ``age`` flows from raw scraper output to the contract row.
+
+Regression for the Age curves panel — the frontend overlay
+(``frontend/components/graphs/AgeCurveOverlay.jsx``) filters out
+rows where ``age`` is null/non-finite, so any future change that
+strips this field will silently empty the curves.
+"""
+from __future__ import annotations
+
+import unittest
+
+from src.api.data_contract import build_api_data_contract
+
+
+def _payload_with_ages():
+    return {
+        "players": {
+            "Josh Allen": {
+                "_composite": 8500,
+                "_rawComposite": 8500,
+                "_finalAdjusted": 8400,
+                "_sites": 6,
+                "position": "QB",
+                "team": "BUF",
+                "age": 30,
+            },
+            "Ja'Marr Chase": {
+                "_composite": 9200,
+                "_rawComposite": 9200,
+                "_finalAdjusted": 9100,
+                "_sites": 7,
+                "position": "WR",
+                "team": "CIN",
+                "age": 26,
+            },
+            "Mystery Rookie": {
+                "_composite": 5000,
+                "_rawComposite": 5000,
+                "_finalAdjusted": 5000,
+                "_sites": 4,
+                "position": "RB",
+                "team": "FA",
+                # No age — Sleeper hasn't ingested birth_date yet.
+            },
+        },
+        "sites": [{"key": "ktcSfTep"}],
+        "maxValues": {"ktcSfTep": 9999},
+        "sleeper": {
+            "positions": {
+                "Josh Allen": "QB",
+                "Ja'Marr Chase": "WR",
+                "Mystery Rookie": "RB",
+            }
+        },
+    }
+
+
+class TestContractAgePreservation(unittest.TestCase):
+    def test_age_stamped_on_player_rows(self):
+        contract = build_api_data_contract(_payload_with_ages())
+        rows = {r["canonicalName"]: r for r in contract.get("playersArray", [])}
+        self.assertEqual(rows["Josh Allen"]["age"], 30)
+        self.assertEqual(rows["Ja'Marr Chase"]["age"], 26)
+
+    def test_age_null_when_source_missing(self):
+        contract = build_api_data_contract(_payload_with_ages())
+        rows = {r["canonicalName"]: r for r in contract.get("playersArray", [])}
+        self.assertIsNone(rows["Mystery Rookie"]["age"])
+
+    def test_age_raw_fallback_used_when_age_absent(self):
+        payload = _payload_with_ages()
+        payload["players"]["Josh Allen"].pop("age")
+        payload["players"]["Josh Allen"]["age_raw"] = 30
+        contract = build_api_data_contract(payload)
+        rows = {r["canonicalName"]: r for r in contract.get("playersArray", [])}
+        self.assertEqual(rows["Josh Allen"]["age"], 30)

--- a/tests/api/test_trade_simulator.py
+++ b/tests/api/test_trade_simulator.py
@@ -326,6 +326,46 @@ def test_team_impact_verdict_thresholds_cross_correctly():
     assert -100 <= impact["compositeScore"] <= 100
 
 
+def test_team_impact_idp_trade_in_idp_league_seen():
+    """Codex P1 regression: terminal._normalize_pos collapses DL/LB/DB
+    to ``IDP``, so team_impact must read from ``basePos`` (preserved
+    DL/LB/DB) — otherwise IDP trades are invisible to the analyzer.
+    """
+    contract = _mk_full_roster_contract()
+    contract["playersArray"].extend([
+        # Roster gets two starting LBs + two starting DLs already.
+        {"displayName": "MyLB1", "canonicalName": "MyLB1", "assetClass": "idp",
+         "position": "LB", "pos": "LB", "age": 25,
+         "canonicalConsensusRank": 80, "rankChange": 0,
+         "rankDerivedValue": int(rank_to_value(80)),
+         "values": {"full": int(rank_to_value(80))}},
+        {"displayName": "MyLB2", "canonicalName": "MyLB2", "assetClass": "idp",
+         "position": "LB", "pos": "LB", "age": 26,
+         "canonicalConsensusRank": 95, "rankChange": 0,
+         "rankDerivedValue": int(rank_to_value(95)),
+         "values": {"full": int(rank_to_value(95))}},
+        # Trade target — an elite LB upgrade.
+        {"displayName": "EliteLB", "canonicalName": "EliteLB", "assetClass": "idp",
+         "position": "LB", "pos": "LB", "age": 25,
+         "canonicalConsensusRank": 25, "rankChange": 0,
+         "rankDerivedValue": int(rank_to_value(25)),
+         "values": {"full": int(rank_to_value(25))}},
+    ])
+    # Add the LBs to the roster.
+    contract["sleeper"]["teams"][0]["players"].extend(["MyLB1", "MyLB2"])
+    team = terminal.resolve_team(contract, owner_id="u1", name=None)
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=team,
+        players_in=["EliteLB"], players_out=["MyLB2"],
+        roster_settings=_IDP_LEAGUE_SETTINGS,
+    )
+    impact = result["teamImpact"]
+    # LB must appear in starterDelta — the trade swaps the team's
+    # weaker LB for an elite one, so starter VALUE at LB should rise.
+    assert "LB" in impact["starterValueDelta"]
+    assert impact["starterValueDelta"]["LB"] > 0
+
+
 def test_team_impact_rationale_bullets_max_five():
     contract = _mk_full_roster_contract()
     team = terminal.resolve_team(contract, owner_id="u1", name=None)

--- a/tests/api/test_trade_simulator.py
+++ b/tests/api/test_trade_simulator.py
@@ -148,3 +148,190 @@ def test_simulate_no_team_returns_empty_before():
     assert result["team"] is None
     assert result["before"]["totalValue"] == 0
     assert result["after"]["totalValue"] == int(rank_to_value(5))
+
+
+# ── Team-aware impact analyzer ─────────────────────────────────────────
+
+_IDP_LEAGUE_SETTINGS = {
+    "teamCount": 12,
+    "starters": {
+        "QB": 1, "RB": 2, "WR": 3, "TE": 1,
+        "FLEX": 2, "SFLEX": 1,
+        "DL": 2, "LB": 2, "DB": 2, "IDP_FLEX": 2,
+    },
+    "flexEligible": ["RB", "WR", "TE"],
+    "sflexEligible": ["QB", "RB", "WR", "TE"],
+    "idpFlexEligible": ["DL", "LB", "DB"],
+}
+
+_NON_IDP_LEAGUE_SETTINGS = {
+    "teamCount": 10,
+    "starters": {
+        "QB": 1, "RB": 2, "WR": 3, "TE": 1,
+        "FLEX": 2, "SFLEX": 1,
+    },
+    "flexEligible": ["RB", "WR", "TE"],
+    "sflexEligible": ["QB", "RB", "WR", "TE"],
+}
+
+
+def _mk_full_roster_contract():
+    """Roster with realistic depth/holes for fit-score tests."""
+    def row(name, rank, pos, age=27, asset="offense"):
+        return {
+            "displayName": name,
+            "canonicalName": name,
+            "assetClass": asset,
+            "position": pos,
+            "pos": pos,
+            "age": age,
+            "canonicalConsensusRank": rank,
+            "rankChange": 0,
+            "rankDerivedValue": int(rank_to_value(rank)),
+            "values": {"full": int(rank_to_value(rank))},
+        }
+    rows = [
+        row("StarQB", 5, "QB", age=27),
+        row("StarQB2", 12, "QB", age=26),
+        row("RB1", 18, "RB", age=25),
+        row("RB2", 35, "RB", age=24),
+        row("RB3", 70, "RB", age=23),
+        row("WR1", 8, "WR", age=24),
+        row("WR2", 22, "WR", age=26),
+        row("WR3", 48, "WR", age=27),
+        row("TE1", 60, "TE", age=28),
+        row("FreeWR", 30, "WR", age=24),
+        row("FreeWR2", 33, "WR", age=25),
+        row("FreeRB", 40, "RB", age=23),
+        row("Pick26", 50, "PICK", age=None, asset="pick"),
+    ]
+    return {
+        "playersArray": rows,
+        "sleeper": {
+            "teams": [{
+                "ownerId": "u1",
+                "name": "User",
+                "roster_id": 1,
+                "players": ["StarQB", "StarQB2", "RB1", "RB2", "RB3",
+                            "WR1", "WR2", "WR3", "TE1"],
+                "picks": [],
+            }],
+        },
+    }
+
+
+def test_team_impact_absent_without_roster_settings():
+    contract = _mk_full_roster_contract()
+    team = terminal.resolve_team(contract, owner_id="u1", name=None)
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=team,
+        players_in=["FreeWR"], players_out=["TE1"],
+    )
+    assert "teamImpact" not in result
+
+
+def test_team_impact_absent_without_resolved_team():
+    contract = _mk_full_roster_contract()
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=None,
+        players_in=["FreeWR"], players_out=["TE1"],
+        roster_settings=_IDP_LEAGUE_SETTINGS,
+    )
+    assert "teamImpact" not in result
+
+
+def test_team_impact_filling_starter_hole_positive_fit():
+    """Acquiring a starting-quality TE when team has only one
+    weak TE should produce positive fitScore."""
+    contract = _mk_full_roster_contract()
+    team = terminal.resolve_team(contract, owner_id="u1", name=None)
+    # Add a strong TE to acquire.  Inject directly.
+    contract["playersArray"].append({
+        "displayName": "EliteTE", "canonicalName": "EliteTE",
+        "assetClass": "offense", "position": "TE", "pos": "TE", "age": 25,
+        "canonicalConsensusRank": 15, "rankChange": 0,
+        "rankDerivedValue": int(rank_to_value(15)),
+        "values": {"full": int(rank_to_value(15))},
+    })
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=team,
+        players_in=["EliteTE"], players_out=["FreeWR"],
+        roster_settings=_IDP_LEAGUE_SETTINGS,
+    )
+    impact = result["teamImpact"]
+    assert impact["fitScore"] > 0
+    assert impact["starterValueDelta"]["TE"] > 0
+
+
+def test_team_impact_duplicating_saturated_position_negative():
+    """Acquiring a 4th startable RB onto a 3-RB roster + saturated FLEX
+    should flag redundancy and depress fitScore."""
+    contract = _mk_full_roster_contract()
+    team = terminal.resolve_team(contract, owner_id="u1", name=None)
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=team,
+        players_in=["FreeRB"], players_out=["TE1"],
+        roster_settings=_IDP_LEAGUE_SETTINGS,
+    )
+    impact = result["teamImpact"]
+    # TE went from 1 to 0 starters (lost a starter); RB total went up
+    # but team was already at the FLEX cap.
+    assert impact["starterDelta"]["TE"] < 0
+
+
+def test_team_impact_redundancy_skipped_in_non_idp_league():
+    """Acquiring an IDP player in a non-IDP league must not generate
+    redundancy flags or starterDelta entries for DL/LB/DB."""
+    contract = _mk_full_roster_contract()
+    contract["playersArray"].append({
+        "displayName": "IDPGuy", "canonicalName": "IDPGuy",
+        "assetClass": "idp", "position": "LB", "pos": "LB", "age": 25,
+        "canonicalConsensusRank": 80, "rankChange": 0,
+        "rankDerivedValue": int(rank_to_value(80)),
+        "values": {"full": int(rank_to_value(80))},
+    })
+    team = terminal.resolve_team(contract, owner_id="u1", name=None)
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=team,
+        players_in=["IDPGuy"], players_out=["FreeWR"],
+        roster_settings=_NON_IDP_LEAGUE_SETTINGS,
+    )
+    impact = result["teamImpact"]
+    assert "LB" not in impact["starterDelta"]
+    assert "DL" not in impact["starterDelta"]
+    assert "DB" not in impact["starterDelta"]
+    assert all(r["pos"] != "LB" for r in impact["redundancy"])
+
+
+def test_team_impact_verdict_thresholds_cross_correctly():
+    """Verdict ladders as compositeScore moves."""
+    contract = _mk_full_roster_contract()
+    contract["playersArray"].append({
+        "displayName": "EliteTE", "canonicalName": "EliteTE",
+        "assetClass": "offense", "position": "TE", "pos": "TE", "age": 25,
+        "canonicalConsensusRank": 8, "rankChange": 0,
+        "rankDerivedValue": int(rank_to_value(8)),
+        "values": {"full": int(rank_to_value(8))},
+    })
+    team = terminal.resolve_team(contract, owner_id="u1", name=None)
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=team,
+        players_in=["EliteTE"], players_out=["FreeRB"],
+        roster_settings=_IDP_LEAGUE_SETTINGS,
+    )
+    impact = result["teamImpact"]
+    assert impact["verdict"] in {"accept", "lean accept", "neutral", "lean decline", "decline"}
+    assert -100 <= impact["fitScore"] <= 100
+    assert -100 <= impact["equityScore"] <= 100
+    assert -100 <= impact["compositeScore"] <= 100
+
+
+def test_team_impact_rationale_bullets_max_five():
+    contract = _mk_full_roster_contract()
+    team = terminal.resolve_team(contract, owner_id="u1", name=None)
+    result = trade_simulator.simulate_trade(
+        contract, resolved_team=team,
+        players_in=["FreeWR2"], players_out=["WR3"],
+        roster_settings=_IDP_LEAGUE_SETTINGS,
+    )
+    assert len(result["teamImpact"]["rationale"]) <= 5

--- a/tests/utils/test_age.py
+++ b/tests/utils/test_age.py
@@ -1,0 +1,51 @@
+"""Tests for src.utils.age.age_from_birthdate."""
+from __future__ import annotations
+
+from datetime import date
+
+from src.utils.age import age_from_birthdate
+
+
+REF = date(2026, 5, 4)
+
+
+class TestAgeFromBirthdate:
+    def test_basic_age(self):
+        assert age_from_birthdate("2000-01-15", today=REF) == 26
+
+    def test_birthday_not_yet_passed(self):
+        # Born May 5: birthday tomorrow → still age - 1
+        assert age_from_birthdate("2000-05-05", today=REF) == 25
+
+    def test_birthday_today(self):
+        assert age_from_birthdate("2000-05-04", today=REF) == 26
+
+    def test_birthday_yesterday(self):
+        assert age_from_birthdate("2000-05-03", today=REF) == 26
+
+    def test_empty_string(self):
+        assert age_from_birthdate("", today=REF) is None
+
+    def test_none(self):
+        assert age_from_birthdate(None, today=REF) is None
+
+    def test_malformed(self):
+        assert age_from_birthdate("not-a-date", today=REF) is None
+
+    def test_partial(self):
+        assert age_from_birthdate("2000-01", today=REF) is None
+
+    def test_out_of_range_too_young(self):
+        # Younger than 15 — sleeper dump corruption.
+        assert age_from_birthdate("2020-01-01", today=REF) is None
+
+    def test_out_of_range_too_old(self):
+        # Older than 50 — sleeper dump corruption.
+        assert age_from_birthdate("1900-01-01", today=REF) is None
+
+    def test_uses_today_default_when_not_provided(self):
+        # Just check it returns *something* sensible (an int) for a
+        # realistic birth_date when today is not injected.
+        result = age_from_birthdate("1995-06-15")
+        assert isinstance(result, int)
+        assert 15 <= result <= 50

--- a/tests/utils/test_age.py
+++ b/tests/utils/test_age.py
@@ -43,6 +43,18 @@ class TestAgeFromBirthdate:
         # Older than 50 — sleeper dump corruption.
         assert age_from_birthdate("1900-01-01", today=REF) is None
 
+    def test_invalid_calendar_month(self):
+        # Codex P2: month 99 must be rejected, not silently treated as
+        # year-only math.
+        assert age_from_birthdate("2000-99-15", today=REF) is None
+
+    def test_invalid_calendar_day(self):
+        # Feb 31 is not a real date.
+        assert age_from_birthdate("2000-02-31", today=REF) is None
+
+    def test_zero_month(self):
+        assert age_from_birthdate("2000-00-15", today=REF) is None
+
     def test_uses_today_default_when_not_provided(self):
         # Just check it returns *something* sensible (an int) for a
         # realistic birth_date when today is not injected.


### PR DESCRIPTION
## Summary

Two changes addressing gaps surfaced from the BrisketRosters page:

1. **Team-aware trade impact** — `/api/trade/simulate` now returns a `teamImpact` block scoring how a proposed trade fits the user's specific roster shape, not just raw KTC equity. Shows verdict (accept / lean accept / neutral / lean decline / decline), fit vs. equity scores, starter-by-position diff, contender/rebuilder window fit, and rationale bullets.
2. **Age curves fix** — extracts `birth_date` from Sleeper's `/v1/players/nfl` payload, computes integer ages, and stamps them on player rows. The Age curves panel was empty because almost every row had `age=null` (the scraper only pulled `years_exp`).

## Trade impact details

- New `src/trade/team_impact.py` — pure module, no I/O.
- Greedy starter projection against `rosterSettings.starters` + flex/sflex/idp_flex eligibility.
- `fitScore = sum(W_FILL * starterValueDelta - W_OVERFLOW * overflow * avg + W_DEPTH * firstDepthBonus)`, normalized to ±100.
- `compositeScore = 0.55 * fit + 0.45 * equity`. Tunable weights in `config/trade/team_impact.json`.
- Window classification from the *current* roster (top-10 starter share vs. pick share + young-starter share). Drives `windowFit`.
- Redundancy detection skipped for positions the league doesn't start — no IDP false positives in `dynasty_new`.
- **Architectural rule preserved**: never mutates `row.value` per team. See `src/league/README.md` — the retired LAM module proved that path is wrong.

`suggestions.rank_score` also gains an `overflow_penalty` so the Trade Targets card naturally deprioritizes saturated-position acquisitions.

## Age backfill details

- `src/utils/age.py::age_from_birthdate` — testable, deterministic (`today` injectable), filters implausible ages.
- `Dynasty Scraper.py` adds `_player_age_local` mirroring `_player_years_exp_local` and stamps `pdata["age"]` in the same loop where `_yearsExp` is set.
- `scraper_bridge_adapter.py` forwards age from CSVs that carry it.
- The contract reader (`data_contract.py:6853`) already preferred `age`, so this just populates the field `AgeCurveOverlay.jsx` was filtering on.

## Test plan

- [x] `pytest tests/` — **2,774 pass, 0 fail, 6 skipped**
- [x] 14 new tests for age helpers (boundary conditions, malformed input, contract preservation)
- [x] 7 new tests for team-impact (verdict thresholds, redundancy, IDP vs. non-IDP league handling, fit vs. equity sign)
- [ ] Manual: confirm Age curves panel renders dots after next nightly scrape
- [ ] Manual: confirm trade page shows verdict badge + fit panel for known-good trades

https://claude.ai/code/session_01QPdH3pYDPrba4tLcwQZtaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPdH3pYDPrba4tLcwQZtaZ)_