### PR TITLE
fix: serve ROS roster strength via public league contract

### DIFF
--- a/frontend/app/league/sections/ros-team-strength.jsx
+++ b/frontend/app/league/sections/ros-team-strength.jsx
@@ -1,15 +1,48 @@
 "use client";
 
 // ROS Roster Strength section — first surface of the new ROS engine.
-// Reads /api/ros/team-strength and renders one row per team with the
-// composite score + lineup vs depth split + a "why" expandable.
-// Strictly informational; no value math is exposed beyond what the
-// backend already computed.
+// Reads /api/public/league/rosTeamStrength (the public-contract lazy
+// section that wraps the cached ROS team-strength snapshot) and
+// renders one row per team with the composite score + lineup vs
+// depth split + a "why" expandable.  /league is a PUBLIC route, so
+// hitting the private /api/ros/team-strength endpoint here would
+// 401 unauthenticated visitors; the public-contract path serves the
+// same shape via the public allowlist.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { LoadingState, EmptyState } from "@/components/ui";
 import { EmptyCard } from "../shared.jsx";
-import { useRosTeamStrength } from "@/lib/ros-data";
+
+// Module-level cache so tab-switching doesn't re-fetch on every mount.
+// Same pattern + 30-min TTL that the other ROS sections use.
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const _cache = { data: null, error: null, inflight: null, fetchedAt: 0 };
+
+async function _fetchRosTeamStrength() {
+  const fresh = _cache.data && Date.now() - _cache.fetchedAt < CACHE_TTL_MS;
+  if (fresh) return { data: _cache.data, error: null };
+  if (_cache.inflight) return _cache.inflight;
+
+  const promise = fetch("/api/public/league/rosTeamStrength")
+    .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+    .then((payload) => {
+      const body = payload?.data || payload?.section || payload;
+      _cache.data = body;
+      _cache.error = null;
+      _cache.fetchedAt = Date.now();
+      _cache.inflight = null;
+      return { data: body, error: null };
+    })
+    .catch((err) => {
+      _cache.inflight = null;
+      const message = String(err?.message || err);
+      _cache.error = message;
+      return { data: _cache.data, error: message };
+    });
+
+  _cache.inflight = promise;
+  return promise;
+}
 
 function fmtScore(v) {
   if (v == null || !Number.isFinite(Number(v))) return "—";
@@ -101,12 +134,27 @@ function TeamRow({ team, expanded, onToggle }) {
   );
 }
 
-export default function RosTeamStrengthSection({ leagueKey }) {
-  const { data, loading, error } = useRosTeamStrength(leagueKey);
+export default function RosTeamStrengthSection() {
+  const [data, setData] = useState(() => _cache.data);
+  const [error, setError] = useState(_cache.error);
+  const [loading, setLoading] = useState(!_cache.data);
   const [expanded, setExpanded] = useState(null);
 
-  if (loading) return <LoadingState message="Loading ROS roster strength..." />;
-  if (error) {
+  useEffect(() => {
+    let active = true;
+    _fetchRosTeamStrength().then(({ data: d, error: e }) => {
+      if (!active) return;
+      setData(d);
+      setError(e);
+      setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (loading && !data) return <LoadingState message="Loading ROS roster strength..." />;
+  if (error && !data) {
     return (
       <div className="card" style={{ marginTop: "var(--space-md)" }}>
         <EmptyState title="ROS roster strength unavailable" message={error} />


### PR DESCRIPTION
## Summary

The `/league` page is a public route, but the ROS Strength section was fetching `/api/ros/team-strength` directly. That path falls outside the public API allowlist (`server.py::_PUBLIC_API_EXACT` / `_PUBLIC_API_PREFIXES`), so the private API gate returned **401** for unauthenticated visitors and the section rendered:

> ROS roster strength unavailable
> HTTP 401 fetching /api/ros/team-strength

`rosTeamStrength` is already registered as a lazy section builder in the public contract (`src/public_league/public_contract.py::_LAZY_SECTION_BUILDERS["rosTeamStrength"] = _ros_api.build_section`) and is addressable via `/api/public/league/rosTeamStrength`, which **is** in the public prefix allowlist. The cached snapshot itself contains nothing private (team names + composite scores + lineup labels — same data the section already wanted to render).

This PR switches `frontend/app/league/sections/ros-team-strength.jsx` from `useRosTeamStrength` (which calls the private endpoint) to a direct fetch of `/api/public/league/rosTeamStrength`, mirroring the module-level cache + `payload?.data || payload?.section || payload` unwrap pattern already used by `ros-championship.jsx` and `ros-power.jsx`.

- No backend change required.
- No new exposed data — the public lazy-section builder was already wired up.
- Other consumers of `lib/ros-data.js` (`/tools/ros-data-health`) are admin-only and unaffected.

## Test plan

- [ ] Sign out, visit `/league?tab=rosTeamStrength` — section should render team rows instead of the 401 banner.
- [ ] Tab-switch between ROS Strength / Championship / Power — each section uses its own module-level cache; no re-fetch flicker on return.
- [ ] Confirm `/tools/ros-data-health` still loads (admin path; uses `fetchRosSources` / `fetchRosHealth`, both untouched).
- [ ] Confirm signed-in users see no regression on the section.

https://claude.ai/code/session_01UDtE8Wz9uMYghhtjhwuCbU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDtE8Wz9uMYghhtjhwuCbU)_