### PR TITLE
fix(dlf): force-add gitignored stamp file in fetch-and-push script

### DIFF
--- a/deploy/dlf_fetch_and_push.sh
+++ b/deploy/dlf_fetch_and_push.sh
@@ -114,8 +114,11 @@ mkdir -p data/scrape_state
 date -u +%s > data/scrape_state/dlf_last_success
 
 # Stage only the five paths we own.  No -A/-u, no broad globs - if
-# anything else in the dedicated clone got modified, ignore it.
-git add -- \
+# anything else in the dedicated clone got modified, ignore it.  Use
+# -f because data/ is gitignored at the repo level - matches the
+# "Commit updated data" step in scheduled-refresh.yml which also
+# force-adds data/scrape_state/ for the same reason.
+git add -f -- \
   CSVs/site_raw/dlfSf.csv \
   CSVs/site_raw/dlfIdp.csv \
   CSVs/site_raw/dlfRookieSf.csv \


### PR DESCRIPTION
## Summary

Follow-up to #389.  First fire of the new ``dynasty-dlf-fetch.service`` on prod failed at the staging step:

\`\`\`
[DLF] wrote 30 rows → CSVs/site_raw/dlfRookieIdp.csv
The following paths are ignored by one of your .gitignore files:
data
hint: Use -f if you really want to add them.
\`\`\`

``data/`` is gitignored at the repo level (``data/scrape_state/`` is the carve-out we want tracked).  ``git add`` without ``-f`` refuses to stage ignored paths.  Match ``scheduled-refresh.yml``'s ``Commit updated data`` step, which already uses ``git add -f`` on the same paths for the same reason.

The fetch itself succeeded — all four boards parsed 266 + 169 + 61 + 30 rows.  Only the commit step crashed, so no data was pushed but no harm was done either.

## Test plan

- [ ] After merge: re-run ``sudo systemctl start dynasty-dlf-fetch.service`` on prod and confirm a fresh DLF commit lands on main.
- [ ] After merge: confirm ``data/scrape_state/dlf_last_success`` epoch updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)