### PR TITLE
feat: TE Premium Lab — sandbox for evaluating TEP removal + 2-TE start

### DIFF
--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -353,6 +353,7 @@ function MobileTopBar() {
       login: "Login",
       more: "More",
       "draft-capital": "Draft Capital",
+      "te-premium-lab": "TE Premium Lab",
       tools: "Tools",
       admin: "Admin",
     };

--- a/frontend/app/api/te-premium/league-scenarios/route.js
+++ b/frontend/app/api/te-premium/league-scenarios/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+export async function GET(request) {
+  const url = new URL(request.url);
+  const leagueKey = url.searchParams.get("leagueKey");
+  const searchParams = leagueKey ? { leagueKey } : undefined;
+  try {
+    const { data, status } = await proxyGet("/api/te-premium/league-scenarios", {
+      timeoutMs: 10000,
+      searchParams,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "TE Premium service unavailable", detail: err?.message || String(err) },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/api/te-premium/overview/route.js
+++ b/frontend/app/api/te-premium/overview/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+// Sandbox endpoint — read-only.  The backend never mutates live values
+// from this path; the proxy is just a Next-side passthrough so the
+// browser doesn't need a separate origin for the FastAPI backend.
+export async function GET(request) {
+  const url = new URL(request.url);
+  const leagueKey = url.searchParams.get("leagueKey");
+  const searchParams = leagueKey ? { leagueKey } : undefined;
+  try {
+    const { data, status } = await proxyGet("/api/te-premium/overview", {
+      timeoutMs: 8000,
+      searchParams,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "TE Premium service unavailable", detail: err?.message || String(err) },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/api/te-premium/recommendations/route.js
+++ b/frontend/app/api/te-premium/recommendations/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+export async function GET(request) {
+  const url = new URL(request.url);
+  const leagueKey = url.searchParams.get("leagueKey");
+  const searchParams = leagueKey ? { leagueKey } : undefined;
+  try {
+    const { data, status } = await proxyGet("/api/te-premium/recommendations", {
+      timeoutMs: 15000,
+      searchParams,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "TE Premium service unavailable", detail: err?.message || String(err) },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/api/te-premium/run-analysis/route.js
+++ b/frontend/app/api/te-premium/run-analysis/route.js
@@ -13,6 +13,22 @@ export async function POST(request) {
   } catch {
     body = {};
   }
+  // Forward ``leagueKey`` from the query string when present so this
+  // POST proxy resolves the league the same way the sibling GET
+  // proxies do (overview / source-comparison / league-scenarios all
+  // forward the query param).  The backend's
+  // ``_resolve_league_for_request`` checks the body too, so we merge
+  // it in only when not already set so an explicit body value wins.
+  // Codex P2 review on PR #392.
+  try {
+    const url = new URL(request.url);
+    const leagueKey = url.searchParams.get("leagueKey");
+    if (leagueKey && !body.leagueKey) {
+      body = { ...body, leagueKey };
+    }
+  } catch {
+    // URL parse failure → fall through with the body as-is.
+  }
   try {
     const { data, status } = await proxyPost("/api/te-premium/run-analysis", body, {
       timeoutMs: 15000,

--- a/frontend/app/api/te-premium/run-analysis/route.js
+++ b/frontend/app/api/te-premium/run-analysis/route.js
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { proxyPost } from "@/lib/backend-proxy";
+
+// Sandbox-only POST.  The backend handler in
+// ``server.py::post_te_premium_run_analysis`` never mutates live
+// player values — it computes the scenario, returns the payload, and
+// optionally writes a side-car JSON to ``data/sandbox/te_premium/``
+// (a directory the live ``/api/data`` pipeline does not read).
+export async function POST(request) {
+  let body = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  try {
+    const { data, status } = await proxyPost("/api/te-premium/run-analysis", body, {
+      timeoutMs: 15000,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "TE Premium service unavailable", detail: err?.message || String(err) },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/api/te-premium/source-comparison/route.js
+++ b/frontend/app/api/te-premium/source-comparison/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+export async function GET(request) {
+  const url = new URL(request.url);
+  const leagueKey = url.searchParams.get("leagueKey");
+  const searchParams = leagueKey ? { leagueKey } : undefined;
+  try {
+    const { data, status } = await proxyGet("/api/te-premium/source-comparison", {
+      timeoutMs: 10000,
+      searchParams,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "TE Premium service unavailable", detail: err?.message || String(err) },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/more/page.jsx
+++ b/frontend/app/more/page.jsx
@@ -38,6 +38,16 @@ const SECTIONS = [
     ],
   },
   {
+    title: "Research",
+    items: [
+      {
+        href: "/te-premium-lab",
+        label: "Tight End Premium Lab",
+        desc: "Sandbox: simulate removing TE Premium scoring + starting two TEs (does not affect live values)",
+      },
+    ],
+  },
+  {
     title: "League",
     items: [
       { href: "/rosters", label: "Roster Dashboard", desc: "Team strength rankings with position breakdowns" },

--- a/frontend/app/te-premium-lab/page.jsx
+++ b/frontend/app/te-premium-lab/page.jsx
@@ -211,6 +211,15 @@ export default function TEPremiumLabPage() {
       const s = scoringById.get(p.player_id) || {};
       const sc = scarcityById.get(p.player_id) || {};
       const r = recById.get(p.player_id) || {};
+      // Surface the per-row "TE first-down bonus is estimated"
+      // flag (set by the backend when the contract lacks
+      // rule_contributions_detail.bonus_fd_te) as an inline note so
+      // the operator sees per-player precision, not just the global
+      // warning banner.
+      const notes = [...(r.notes || [])];
+      if (s.te_fd_estimated) {
+        notes.push("TE 1D bonus estimated from first_downs aggregate");
+      }
       return {
         player_id: p.player_id,
         display_name: p.display_name,
@@ -224,6 +233,7 @@ export default function TEPremiumLabPage() {
         market_boost_pct: b.boost_pct ?? null,
         market_reliable: b.reliable ?? null,
         scoring_swing_ppg: s.scoring_swing_ppg ?? null,
+        te_fd_estimated: s.te_fd_estimated ?? false,
         ppg_baseline: p.ppg_baseline,
         ppg_league: p.ppg_league,
         rep_one_te: sc.replacement_one_te_ppg ?? null,
@@ -235,7 +245,7 @@ export default function TEPremiumLabPage() {
         recommended_value: r.recommended_value ?? null,
         confidence: r.confidence ?? null,
         tier: r.tier ?? p.tier?.tier_label ?? "—",
-        notes: r.notes || [],
+        notes,
       };
     });
   }, [analysis]);

--- a/frontend/app/te-premium-lab/page.jsx
+++ b/frontend/app/te-premium-lab/page.jsx
@@ -547,7 +547,14 @@ function SummaryTab({ summary, scarcity, sources, tierSummary, lineup }) {
             Team count: <strong>{lineup.team_count}</strong> · TE starters
             today: <strong>{lineup.te_starters_one}</strong> (incl. flex
             contribution) · TE starters under "start 2 TEs":{" "}
-            <strong>{lineup.te_starters_two}</strong>.
+            <strong>{lineup.te_starters_two}</strong>
+            {lineup.two_te_is_noop && (
+              <>
+                {" "}
+                <em>(no-op — league already starts {lineup.direct_te_per_team_current} TEs/team)</em>
+              </>
+            )}
+            .
           </>
         ) : (
           "League settings unavailable."

--- a/frontend/app/te-premium-lab/page.jsx
+++ b/frontend/app/te-premium-lab/page.jsx
@@ -1,0 +1,899 @@
+"use client";
+
+// ── TE Premium Lab — research / sandbox page ──────────────────────────
+//
+// Helps decide how to adjust tight end values BEFORE any change is
+// applied to live values.  Specifically: "if we drop the TE reception
+// premium + TE first-down premium but require teams to start two
+// tight ends, how should TE values shift?".
+//
+// Read-only sandbox.  Every fetch on this page goes through the
+// ``/api/te-premium/*`` proxy → FastAPI handlers in ``server.py``,
+// which call ``src/research/te_premium.py``.  None of those code
+// paths mutate ``latest_contract_data`` or any persisted live value.
+// The page surfaces a "Research only" banner so the operator never
+// confuses these projections with applied changes.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import PageHeader from "@/components/ui/PageHeader";
+import SubNav from "@/components/ui/SubNav";
+import EmptyState from "@/components/ui/EmptyState";
+import LoadingState from "@/components/ui/LoadingState";
+import ErrorState from "@/components/ui/ErrorState";
+
+const TABS = [
+  { key: "summary", label: "Summary" },
+  { key: "sources", label: "External Sources" },
+  { key: "scenarios", label: "League Scenarios" },
+  { key: "recommendations", label: "Recommendations" },
+];
+
+const DEFAULT_SCENARIO = {
+  remove_te_reception_bonus: true,
+  remove_te_first_down_bonus: true,
+  use_two_te_starters: true,
+  include_rookies: true,
+};
+
+// ── Small format helpers ─────────────────────────────────────────────
+
+function fmtPct(value, digits = 1) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+function fmtSignedPct(value, digits = 1) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${(value * 100).toFixed(digits)}%`;
+}
+
+function fmtNum(value, digits = 0) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  return Number(value).toFixed(digits);
+}
+
+function fmtSigned(value, digits = 2) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${Number(value).toFixed(digits)}`;
+}
+
+// ── CSV export ───────────────────────────────────────────────────────
+
+function exportRecommendationsCsv(rows, filename = "te-premium-sandbox.csv") {
+  if (!Array.isArray(rows) || rows.length === 0) return;
+  const headers = [
+    "player_id",
+    "display_name",
+    "tier",
+    "age",
+    "current_value",
+    "market_boost_pct",
+    "scoring_swing_ppg",
+    "scarcity_value_delta",
+    "recommended_adjustment_pct",
+    "recommended_value",
+    "confidence",
+    "notes",
+  ];
+  const escape = (v) => {
+    if (v === null || v === undefined) return "";
+    const s = Array.isArray(v) ? v.join(" | ") : String(v);
+    if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+    return s;
+  };
+  const lines = [headers.join(",")];
+  for (const r of rows) {
+    lines.push(headers.map((h) => escape(r[h])).join(","));
+  }
+  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ── Main component ──────────────────────────────────────────────────
+
+export default function TEPremiumLabPage() {
+  const [tab, setTab] = useState("summary");
+  const [scenario, setScenario] = useState(DEFAULT_SCENARIO);
+  const [overview, setOverview] = useState(null);
+  const [analysis, setAnalysis] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState("");
+  const [tableSort, setTableSort] = useState({
+    column: "te_pool_rank",
+    direction: "asc",
+  });
+  const [tableFilter, setTableFilter] = useState("");
+
+  // Fetch overview + initial analysis on mount.  Sequential (not
+  // parallel) because the analysis is a superset of overview signal —
+  // if overview 503s the analysis would too, and we'd rather show one
+  // clear error than two competing ones.
+  const loadInitial = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [ovRes, anRes] = await Promise.all([
+        fetch("/api/te-premium/overview", { cache: "no-store" }),
+        fetch("/api/te-premium/run-analysis", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(scenario),
+          cache: "no-store",
+        }),
+      ]);
+      if (!ovRes.ok) {
+        const body = await ovRes.json().catch(() => ({}));
+        throw new Error(body?.message || body?.error || `Overview ${ovRes.status}`);
+      }
+      if (!anRes.ok) {
+        const body = await anRes.json().catch(() => ({}));
+        throw new Error(body?.message || body?.error || `Analysis ${anRes.status}`);
+      }
+      setOverview(await ovRes.json());
+      setAnalysis(await anRes.json());
+    } catch (err) {
+      setError(err?.message || "Failed to load TE Premium Lab.");
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    loadInitial();
+  }, [loadInitial]);
+
+  const runAnalysis = useCallback(
+    async (nextScenario) => {
+      setRunning(true);
+      setError("");
+      try {
+        const res = await fetch("/api/te-premium/run-analysis", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(nextScenario || scenario),
+          cache: "no-store",
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body?.message || body?.error || `Analysis ${res.status}`);
+        }
+        setAnalysis(await res.json());
+      } catch (err) {
+        setError(err?.message || "Failed to run analysis.");
+      } finally {
+        setRunning(false);
+      }
+    },
+    [scenario],
+  );
+
+  const toggleScenario = useCallback(
+    (key) => {
+      const next = { ...scenario, [key]: !scenario[key] };
+      setScenario(next);
+    },
+    [scenario],
+  );
+
+  // ── Player table — joined view ─────────────────────────────────
+  const playerTableRows = useMemo(() => {
+    if (!analysis) return [];
+    const players = analysis.players || [];
+    const boostById = new Map();
+    for (const b of analysis.external_boost || []) {
+      boostById.set(b.player_id, b);
+    }
+    const scoringById = new Map();
+    for (const s of analysis.scoring_effect || []) {
+      scoringById.set(s.player_id, s);
+    }
+    const scarcityById = new Map();
+    for (const s of analysis.scarcity_effect || []) {
+      scarcityById.set(s.player_id, s);
+    }
+    const recById = new Map();
+    for (const r of analysis.recommendations || []) {
+      recById.set(r.player_id, r);
+    }
+    return players.map((p) => {
+      const b = boostById.get(p.player_id) || {};
+      const s = scoringById.get(p.player_id) || {};
+      const sc = scarcityById.get(p.player_id) || {};
+      const r = recById.get(p.player_id) || {};
+      return {
+        player_id: p.player_id,
+        display_name: p.display_name,
+        team: p.team,
+        age: p.age,
+        te_pool_rank: p.te_pool_rank,
+        position_rank: p.position_rank,
+        current_value: p.current_value,
+        ktc_normal_value: p.ktc_normal_value,
+        ktc_premium_value: p.ktc_premium_value,
+        market_boost_pct: b.boost_pct ?? null,
+        market_reliable: b.reliable ?? null,
+        scoring_swing_ppg: s.scoring_swing_ppg ?? null,
+        ppg_baseline: p.ppg_baseline,
+        ppg_league: p.ppg_league,
+        rep_one_te: sc.replacement_one_te_ppg ?? null,
+        rep_two_te: sc.replacement_two_te_ppg ?? null,
+        vor_one_te: sc.vor_one_te ?? null,
+        vor_two_te: sc.vor_two_te ?? null,
+        vor_delta: sc.vor_delta ?? null,
+        recommended_adjustment_pct: r.recommended_adjustment_pct ?? null,
+        recommended_value: r.recommended_value ?? null,
+        confidence: r.confidence ?? null,
+        tier: r.tier ?? p.tier?.tier_label ?? "—",
+        notes: r.notes || [],
+      };
+    });
+  }, [analysis]);
+
+  const sortedFilteredRows = useMemo(() => {
+    let rows = playerTableRows;
+    if (tableFilter.trim()) {
+      const q = tableFilter.toLowerCase();
+      rows = rows.filter((r) => (r.display_name || "").toLowerCase().includes(q));
+    }
+    const { column, direction } = tableSort;
+    const dir = direction === "desc" ? -1 : 1;
+    return [...rows].sort((a, b) => {
+      const va = a[column];
+      const vb = b[column];
+      if (va === null || va === undefined) return 1;
+      if (vb === null || vb === undefined) return -1;
+      if (typeof va === "number" && typeof vb === "number") {
+        return (va - vb) * dir;
+      }
+      return String(va).localeCompare(String(vb)) * dir;
+    });
+  }, [playerTableRows, tableSort, tableFilter]);
+
+  const handleSort = useCallback(
+    (column) => {
+      setTableSort((prev) => ({
+        column,
+        direction: prev.column === column && prev.direction === "asc" ? "desc" : "asc",
+      }));
+    },
+    [],
+  );
+
+  // ── Render ─────────────────────────────────────────────────────
+  if (loading && !analysis) {
+    return (
+      <div className="page-container">
+        <PageHeader
+          title="Tight End Premium Lab"
+          subtitle="Research-only sandbox — does not affect live player values."
+        />
+        <LoadingState message="Loading TE Premium sandbox…" />
+      </div>
+    );
+  }
+
+  if (error && !analysis) {
+    return (
+      <div className="page-container">
+        <PageHeader
+          title="Tight End Premium Lab"
+          subtitle="Research-only sandbox — does not affect live player values."
+        />
+        <ErrorState message={error} retry={loadInitial} />
+      </div>
+    );
+  }
+
+  const summary = analysis?.summary || {};
+  const tierSummary = analysis?.tier_summary || [];
+  const scarcity = analysis?.scarcity_summary || {};
+  const warnings = (analysis?.warnings || []).concat(overview?.warnings || []);
+  const sources = overview?.sources || [];
+
+  return (
+    <div className="page-container te-premium-lab">
+      <PageHeader
+        title="Tight End Premium Lab"
+        subtitle="Compare external TE Premium markets against your league's scoring + lineup pressure. Sandbox only — never applied to live values."
+        actions={
+          <button
+            type="button"
+            className="button"
+            onClick={() => exportRecommendationsCsv(analysis?.recommendations, "te-premium-sandbox.csv")}
+            disabled={!analysis?.recommendations?.length}
+            title="Download per-player recommendations as CSV"
+          >
+            Export CSV
+          </button>
+        }
+      />
+
+      <div
+        className="warning-banner"
+        role="status"
+        style={{
+          background: "var(--warning-bg, #3a2a14)",
+          color: "var(--warning-fg, #ffcb6b)",
+          border: "1px solid var(--warning-border, #604322)",
+          borderRadius: 8,
+          padding: "10px 14px",
+          margin: "12px 0",
+          fontSize: 13,
+          fontWeight: 500,
+        }}
+      >
+        <strong>Research only.</strong> Outputs from this page are not
+        applied to live player values. Use this view to plan adjustments;
+        a separate manually-approved promotion path would be required to
+        push any change live.
+      </div>
+
+      {warnings.length > 0 && (
+        <ul className="warning-list muted" style={{ fontSize: 12, marginBottom: 8 }}>
+          {warnings.map((w, idx) => (
+            <li key={idx}>⚠ {w}</li>
+          ))}
+        </ul>
+      )}
+
+      <ScenarioControls
+        scenario={scenario}
+        onToggle={toggleScenario}
+        onRun={runAnalysis}
+        running={running}
+      />
+
+      <SubNav items={TABS} active={tab} onChange={setTab} />
+
+      {tab === "summary" && (
+        <SummaryTab
+          summary={summary}
+          scarcity={scarcity}
+          sources={sources}
+          tierSummary={tierSummary}
+          lineup={summary.lineup}
+        />
+      )}
+
+      {tab === "sources" && (
+        <SourcesTab
+          sources={sources}
+          boostRows={analysis?.external_boost || []}
+          marketAvailable={
+            analysis?.external_boards?.ktc_premium_available &&
+            analysis?.external_boards?.ktc_normal_available
+          }
+        />
+      )}
+
+      {tab === "scenarios" && (
+        <ScenariosTab
+          summary={summary}
+          scarcity={scarcity}
+          scoringRows={analysis?.scoring_effect || []}
+          scarcityRows={analysis?.scarcity_effect || []}
+          tierSummary={tierSummary}
+        />
+      )}
+
+      {tab === "recommendations" && (
+        <RecommendationsTab
+          rows={sortedFilteredRows}
+          onSort={handleSort}
+          sort={tableSort}
+          filter={tableFilter}
+          onFilter={setTableFilter}
+          tierSummary={tierSummary}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Scenario controls ───────────────────────────────────────────────
+
+function ScenarioControls({ scenario, onToggle, onRun, running }) {
+  return (
+    <div
+      className="controls-panel"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 10,
+        alignItems: "center",
+        background: "var(--card-bg, rgba(255,255,255,0.04))",
+        border: "1px solid var(--border, rgba(255,255,255,0.1))",
+        borderRadius: 8,
+        padding: 12,
+        margin: "12px 0",
+      }}
+    >
+      <strong style={{ marginRight: 8 }}>Scenario:</strong>
+      <ScenarioToggle
+        label="Remove TE reception bonus"
+        checked={!!scenario.remove_te_reception_bonus}
+        onChange={() => onToggle("remove_te_reception_bonus")}
+      />
+      <ScenarioToggle
+        label="Remove TE 1D bonus"
+        checked={!!scenario.remove_te_first_down_bonus}
+        onChange={() => onToggle("remove_te_first_down_bonus")}
+      />
+      <ScenarioToggle
+        label="Start 2 TEs"
+        checked={!!scenario.use_two_te_starters}
+        onChange={() => onToggle("use_two_te_starters")}
+      />
+      <ScenarioToggle
+        label="Include rookies"
+        checked={!!scenario.include_rookies}
+        onChange={() => onToggle("include_rookies")}
+      />
+      <button
+        type="button"
+        className="button"
+        onClick={() => onRun()}
+        disabled={running}
+        style={{ marginLeft: "auto" }}
+      >
+        {running ? "Running…" : "Run Sandbox Analysis"}
+      </button>
+    </div>
+  );
+}
+
+function ScenarioToggle({ label, checked, onChange }) {
+  return (
+    <label
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        cursor: "pointer",
+        fontSize: 13,
+        userSelect: "none",
+      }}
+    >
+      <input type="checkbox" checked={checked} onChange={onChange} />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+// ── Summary tab ─────────────────────────────────────────────────────
+
+function SummaryTab({ summary, scarcity, sources, tierSummary, lineup }) {
+  const cards = [
+    {
+      label: "Avg external TE Premium boost",
+      value: fmtSignedPct(summary.avg_market_boost_pct),
+      hint: "KTC normal vs KTC TE+ board",
+    },
+    {
+      label: "Avg internal scoring penalty",
+      value: `${fmtSigned(summary.avg_internal_scoring_swing_ppg, 2)} PPG`,
+      hint: "PPG lost when removing the TEP scoring rules",
+    },
+    {
+      label: "Avg scarcity boost (2-TE start)",
+      value: `${fmtSigned(summary.avg_scarcity_vor_delta_points, 1)} pts`,
+      hint: `Replacement: ${fmtNum(scarcity.replacement_one_te_ppg, 2)} → ${fmtNum(scarcity.replacement_two_te_ppg, 2)} PPG`,
+    },
+    {
+      label: "Net recommended adjustment",
+      value: fmtSignedPct(summary.avg_recommended_adjustment_pct, 1),
+      hint: "Average across evaluated TEs (clipped ±25%)",
+    },
+    {
+      label: "Confidence",
+      value: fmtPct(summary.avg_confidence, 0),
+      hint: "Geometric mean of market + scoring + scarcity confidences",
+    },
+  ];
+
+  return (
+    <div className="summary-tab">
+      <div
+        className="summary-cards"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+          gap: 10,
+          margin: "12px 0",
+        }}
+      >
+        {cards.map((c) => (
+          <div
+            key={c.label}
+            style={{
+              background: "var(--card-bg, rgba(255,255,255,0.04))",
+              border: "1px solid var(--border, rgba(255,255,255,0.1))",
+              borderRadius: 8,
+              padding: 12,
+            }}
+          >
+            <div className="muted" style={{ fontSize: 11 }}>{c.label}</div>
+            <div style={{ fontSize: 22, fontWeight: 700, marginTop: 4 }}>{c.value}</div>
+            {c.hint && <div className="muted" style={{ fontSize: 11, marginTop: 4 }}>{c.hint}</div>}
+          </div>
+        ))}
+      </div>
+
+      <h3>League context</h3>
+      <p className="muted" style={{ fontSize: 13 }}>
+        {lineup ? (
+          <>
+            Team count: <strong>{lineup.team_count}</strong> · TE starters
+            today: <strong>{lineup.te_starters_one}</strong> (incl. flex
+            contribution) · TE starters under "start 2 TEs":{" "}
+            <strong>{lineup.te_starters_two}</strong>.
+          </>
+        ) : (
+          "League settings unavailable."
+        )}
+      </p>
+
+      <h3 style={{ marginTop: 18 }}>Tier breakdown</h3>
+      <TierTable tierSummary={tierSummary} />
+
+      <h3 style={{ marginTop: 18 }}>Source availability</h3>
+      <ul style={{ fontSize: 13, lineHeight: 1.6, paddingLeft: 18 }}>
+        {sources.map((s) => (
+          <li key={s.key}>
+            <strong>{s.label}</strong>{" "}
+            <span className="muted">
+              [normal: {s.supports_normal ? "yes" : "no"} · TE+: {s.supports_te_premium ? "yes" : "no"} · TE++: {s.supports_te_plus_plus ? "yes" : "no"}]
+            </span>
+            {!s.available && <span className="muted"> — unavailable</span>}
+            <div className="muted" style={{ fontSize: 11 }}>{s.note}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function TierTable({ tierSummary }) {
+  if (!tierSummary || tierSummary.length === 0) {
+    return <EmptyState title="No tier data yet" message="Run the analysis to populate tier rollups." />;
+  }
+  return (
+    <div className="table-wrap" style={{ overflowX: "auto" }}>
+      <table className="data-table" style={{ width: "100%", fontSize: 13 }}>
+        <thead>
+          <tr>
+            <th>Tier</th>
+            <th style={{ textAlign: "right" }}>n</th>
+            <th style={{ textAlign: "right" }}>Avg current value</th>
+            <th style={{ textAlign: "right" }}>Avg market boost</th>
+            <th style={{ textAlign: "right" }}>Avg scoring swing</th>
+            <th style={{ textAlign: "right" }}>Avg scarcity Δ</th>
+            <th style={{ textAlign: "right" }}>Avg recommended</th>
+            <th style={{ textAlign: "right" }}>Confidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tierSummary.map((t) => (
+            <tr key={t.tier_key}>
+              <td>{t.tier_label}</td>
+              <td style={{ textAlign: "right" }}>{t.player_count}</td>
+              <td style={{ textAlign: "right" }}>{fmtNum(t.avg_current_value)}</td>
+              <td style={{ textAlign: "right" }}>{fmtSignedPct(t.avg_market_boost_pct)}</td>
+              <td style={{ textAlign: "right" }}>{fmtSigned(t.avg_scoring_swing_ppg, 2)}</td>
+              <td style={{ textAlign: "right" }}>{fmtSigned(t.avg_scarcity_vor_delta, 1)}</td>
+              <td style={{ textAlign: "right" }}>{fmtSignedPct(t.avg_recommended_adjustment_pct)}</td>
+              <td style={{ textAlign: "right" }}>{fmtPct(t.avg_confidence, 0)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Sources tab ─────────────────────────────────────────────────────
+
+function SourcesTab({ sources, boostRows, marketAvailable }) {
+  const reliable = (boostRows || []).filter((b) => b.reliable);
+  const unreliable = (boostRows || []).filter((b) => !b.reliable);
+  return (
+    <div className="sources-tab">
+      <p className="muted" style={{ fontSize: 13 }}>
+        For every external source that exposes both a normal and a TE-Premium
+        board, we compute per-player percentage boost. Today only KTC ships
+        both boards from the same scrape; other sources show as unavailable
+        and would need a CSV upload or scraper update.
+      </p>
+
+      {!marketAvailable && (
+        <div
+          style={{
+            background: "var(--warning-bg, #3a2a14)",
+            border: "1px solid var(--warning-border, #604322)",
+            color: "var(--warning-fg, #ffcb6b)",
+            padding: 10,
+            borderRadius: 6,
+            margin: "8px 0",
+            fontSize: 13,
+          }}
+        >
+          KTC TE-Premium board not loaded. Boost rows shown below are empty;
+          recommendations fall back to tier-default heuristics until a fresh
+          scrape lands.
+        </div>
+      )}
+
+      <h3>KTC normal vs KTC TE+ — reliable rows</h3>
+      <div className="table-wrap" style={{ overflowX: "auto" }}>
+        <table className="data-table" style={{ width: "100%", fontSize: 13 }}>
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th style={{ textAlign: "right" }}>Normal value</th>
+              <th style={{ textAlign: "right" }}>Normal rank</th>
+              <th style={{ textAlign: "right" }}>Premium value</th>
+              <th style={{ textAlign: "right" }}>Premium rank</th>
+              <th style={{ textAlign: "right" }}>Boost</th>
+              <th style={{ textAlign: "right" }}>Δ rank</th>
+              <th style={{ textAlign: "right" }}>log ratio</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reliable.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="muted" style={{ padding: 8 }}>
+                  No reliable comparisons available.
+                </td>
+              </tr>
+            ) : (
+              reliable.map((b) => (
+                <tr key={`${b.source}-${b.player_id}`}>
+                  <td>{b.display_name}</td>
+                  <td style={{ textAlign: "right" }}>{fmtNum(b.normal_value)}</td>
+                  <td style={{ textAlign: "right" }}>{fmtNum(b.normal_rank)}</td>
+                  <td style={{ textAlign: "right" }}>{fmtNum(b.premium_value)}</td>
+                  <td style={{ textAlign: "right" }}>{fmtNum(b.premium_rank)}</td>
+                  <td style={{ textAlign: "right" }}>{fmtSignedPct(b.boost_pct)}</td>
+                  <td style={{ textAlign: "right" }}>{fmtSigned(b.rank_change, 0)}</td>
+                  <td style={{ textAlign: "right" }}>{fmtNum(b.log_ratio, 3)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {unreliable.length > 0 && (
+        <>
+          <h3 style={{ marginTop: 18 }}>Flagged unreliable</h3>
+          <ul className="muted" style={{ fontSize: 12 }}>
+            {unreliable.map((b) => (
+              <li key={`u-${b.player_id}`}>
+                <strong>{b.display_name}</strong> — {b.note || "missing data"}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Scenarios tab ───────────────────────────────────────────────────
+
+function ScenariosTab({ summary, scarcity, scoringRows, scarcityRows, tierSummary }) {
+  const topScoringHits = useMemo(
+    () =>
+      [...(scoringRows || [])]
+        .filter((s) => Math.abs(s.scoring_swing_ppg) > 0)
+        .sort((a, b) => a.scoring_swing_ppg - b.scoring_swing_ppg)
+        .slice(0, 15),
+    [scoringRows],
+  );
+  const topScarcityWinners = useMemo(
+    () => [...(scarcityRows || [])].sort((a, b) => b.vor_delta - a.vor_delta).slice(0, 15),
+    [scarcityRows],
+  );
+
+  return (
+    <div className="scenarios-tab">
+      <p className="muted" style={{ fontSize: 13 }}>
+        Internal scoring + scarcity comparison.  Scoring effect uses the
+        per-rule contributions already attached to each TE in the live
+        contract — we strip the TE Premium category and the TE-specific
+        first-down bonus.  Scarcity uses the same VOR engine that powers
+        the awards / scoring-fit pipeline.
+      </p>
+
+      <h3>Largest scoring losses (PPG)</h3>
+      <div className="table-wrap" style={{ overflowX: "auto" }}>
+        <table className="data-table" style={{ width: "100%", fontSize: 13 }}>
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th style={{ textAlign: "right" }}>Current Δ vs baseline</th>
+              <th style={{ textAlign: "right" }}>TE rec bonus</th>
+              <th style={{ textAlign: "right" }}>TE 1D bonus</th>
+              <th style={{ textAlign: "right" }}>Proposed Δ</th>
+              <th style={{ textAlign: "right" }}>Swing</th>
+              <th style={{ textAlign: "right" }}>Confidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {topScoringHits.map((s) => (
+              <tr key={`sc-${s.player_id}`}>
+                <td>{s.display_name}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.current_ppg_delta)}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.te_premium_ppg)}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.te_first_down_ppg)}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.proposed_ppg_delta)}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.scoring_swing_ppg)}</td>
+                <td style={{ textAlign: "right" }}>{fmtPct(s.confidence, 0)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 style={{ marginTop: 18 }}>Biggest scarcity winners (2-TE start)</h3>
+      <p className="muted" style={{ fontSize: 12 }}>
+        Replacement PPG: {fmtNum(scarcity.replacement_one_te_ppg, 2)} (1
+        starter) → {fmtNum(scarcity.replacement_two_te_ppg, 2)} (2 starters)
+      </p>
+      <div className="table-wrap" style={{ overflowX: "auto" }}>
+        <table className="data-table" style={{ width: "100%", fontSize: 13 }}>
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th style={{ textAlign: "right" }}>Season pts</th>
+              <th style={{ textAlign: "right" }}>VOR (1 TE)</th>
+              <th style={{ textAlign: "right" }}>VOR (2 TE)</th>
+              <th style={{ textAlign: "right" }}>VOR Δ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {topScarcityWinners.map((s) => (
+              <tr key={`vor-${s.player_id}`}>
+                <td>{s.display_name}</td>
+                <td style={{ textAlign: "right" }}>{fmtNum(s.points, 1)}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.vor_one_te, 1)}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.vor_two_te, 1)}</td>
+                <td style={{ textAlign: "right" }}>{fmtSigned(s.vor_delta, 1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 style={{ marginTop: 18 }}>By tier</h3>
+      <TierTable tierSummary={tierSummary} />
+    </div>
+  );
+}
+
+// ── Recommendations tab ─────────────────────────────────────────────
+
+const COLUMNS = [
+  { key: "te_pool_rank", label: "TE#", numeric: true },
+  { key: "display_name", label: "Player", numeric: false },
+  { key: "team", label: "Team", numeric: false },
+  { key: "age", label: "Age", numeric: true },
+  { key: "tier", label: "Tier", numeric: false },
+  { key: "current_value", label: "Cur value", numeric: true, fmt: (v) => fmtNum(v, 0) },
+  { key: "ktc_normal_value", label: "KTC norm", numeric: true, fmt: (v) => fmtNum(v, 0) },
+  { key: "ktc_premium_value", label: "KTC TEP", numeric: true, fmt: (v) => fmtNum(v, 0) },
+  { key: "market_boost_pct", label: "Mkt boost", numeric: true, fmt: (v) => fmtSignedPct(v) },
+  { key: "ppg_baseline", label: "PPG (base)", numeric: true, fmt: (v) => fmtNum(v, 2) },
+  { key: "ppg_league", label: "PPG (league)", numeric: true, fmt: (v) => fmtNum(v, 2) },
+  { key: "scoring_swing_ppg", label: "Scoring Δ PPG", numeric: true, fmt: (v) => fmtSigned(v, 2) },
+  { key: "rep_one_te", label: "Rep 1TE", numeric: true, fmt: (v) => fmtNum(v, 2) },
+  { key: "rep_two_te", label: "Rep 2TE", numeric: true, fmt: (v) => fmtNum(v, 2) },
+  { key: "vor_delta", label: "VOR Δ", numeric: true, fmt: (v) => fmtSigned(v, 1) },
+  { key: "recommended_adjustment_pct", label: "Rec %", numeric: true, fmt: (v) => fmtSignedPct(v) },
+  { key: "recommended_value", label: "Sandbox value", numeric: true, fmt: (v) => fmtNum(v, 0) },
+  { key: "confidence", label: "Conf", numeric: true, fmt: (v) => fmtPct(v, 0) },
+];
+
+function RecommendationsTab({ rows, onSort, sort, filter, onFilter, tierSummary }) {
+  return (
+    <div className="recommendations-tab">
+      <div style={{ display: "flex", gap: 8, alignItems: "center", margin: "10px 0" }}>
+        <input
+          type="search"
+          placeholder="Filter by player name…"
+          value={filter}
+          onChange={(e) => onFilter(e.target.value)}
+          style={{
+            padding: "6px 10px",
+            border: "1px solid var(--border, rgba(255,255,255,0.15))",
+            borderRadius: 6,
+            background: "var(--input-bg, rgba(255,255,255,0.04))",
+            color: "inherit",
+            fontSize: 13,
+            minWidth: 220,
+          }}
+        />
+        <span className="muted" style={{ fontSize: 12 }}>
+          {rows.length} TEs · sandbox values are NOT applied to live data
+        </span>
+      </div>
+      <div className="table-wrap" style={{ overflowX: "auto" }}>
+        <table className="data-table" style={{ width: "100%", fontSize: 12 }}>
+          <thead>
+            <tr>
+              {COLUMNS.map((col) => {
+                const active = sort.column === col.key;
+                return (
+                  <th
+                    key={col.key}
+                    onClick={() => onSort(col.key)}
+                    style={{
+                      cursor: "pointer",
+                      textAlign: col.numeric ? "right" : "left",
+                      whiteSpace: "nowrap",
+                      userSelect: "none",
+                      borderBottom: active
+                        ? "2px solid var(--accent, #6da3ff)"
+                        : "1px solid var(--border, rgba(255,255,255,0.1))",
+                    }}
+                    title="Click to sort"
+                  >
+                    {col.label}
+                    {active && (sort.direction === "asc" ? " ▲" : " ▼")}
+                  </th>
+                );
+              })}
+              <th style={{ textAlign: "left" }}>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={COLUMNS.length + 1} className="muted" style={{ padding: 8 }}>
+                  No TEs match the current filter.
+                </td>
+              </tr>
+            ) : (
+              rows.map((r) => (
+                <tr key={r.player_id}>
+                  {COLUMNS.map((col) => {
+                    const v = r[col.key];
+                    const text = col.fmt ? col.fmt(v) : v ?? "—";
+                    return (
+                      <td
+                        key={col.key}
+                        style={{
+                          textAlign: col.numeric ? "right" : "left",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {text}
+                      </td>
+                    );
+                  })}
+                  <td style={{ fontSize: 11, color: "var(--muted, rgba(255,255,255,0.6))" }}>
+                    {(r.notes || []).join(" · ")}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 style={{ marginTop: 18 }}>Tier rollups</h3>
+      <TierTable tierSummary={tierSummary} />
+    </div>
+  );
+}

--- a/server.py
+++ b/server.py
@@ -4347,6 +4347,202 @@ async def get_scaffold_report():
     return FileResponse(file_path, media_type="text/markdown")
 
 
+# ── TE PREMIUM LAB (research-only sandbox) ─────────────────────────────
+#
+# Read-only "what-if" analysis for the question: "If we drop the TE
+# reception bonus + TE first-down bonus but require teams to start two
+# tight ends, how should TE values shift?".  Outputs are NEVER applied
+# to the live ``latest_contract_data`` — these handlers compute and
+# return; nothing else.  The companion module
+# ``src/research/te_premium.py`` enforces the same contract on its
+# side: no writes to live globals, no mutation of input contracts.
+
+def _te_premium_serialize(payload: dict) -> dict:
+    """Pre-JSON shaping for TE-premium responses.
+
+    The dataclasses returned by ``src.research.te_premium`` are
+    serialised via ``__dict__`` in ``run_analysis``; we just hand the
+    payload back as-is plus the standard meta envelope every other
+    endpoint stamps so the frontend can verify the league + sandbox
+    flag before trusting the body.
+    """
+    return {
+        "ok": True,
+        "sandbox": True,
+        "appliesToLiveValues": False,
+        **payload,
+    }
+
+
+@app.get("/api/te-premium/overview")
+async def get_te_premium_overview(request: Request):
+    """Sandbox overview: data-source availability + league lineup.
+
+    Cheap; intended to populate the page header + controls panel
+    before any heavy analysis is requested.  Never mutates state.
+    """
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
+    from src.research import te_premium as _te_premium  # noqa: PLC0415
+
+    overview = _te_premium.build_overview(
+        latest_contract_data, league_cfg=league_cfg,
+    )
+    return JSONResponse(content=_te_premium_serialize(overview))
+
+
+@app.get("/api/te-premium/source-comparison")
+async def get_te_premium_source_comparison(request: Request):
+    """Per-TE normal-vs-TEP boost from the loaded external boards.
+
+    Today the only external source we can compare both ways is KTC
+    (``CSVs/site_raw/ktc.csv`` vs ``CSVs/site_raw/ktcSfTep.csv``);
+    sources without a TEP variant are skipped at the module level
+    rather than guessed.
+    """
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
+    from src.research import te_premium as _te_premium  # noqa: PLC0415
+
+    te_rows = _te_premium.extract_te_players_from_contract(latest_contract_data)
+    boards = _te_premium.load_external_ktc_boards()
+    boost_rows = _te_premium.compute_external_market_boost(
+        te_rows, boards=boards, source="ktc",
+    )
+    return JSONResponse(
+        content=_te_premium_serialize({
+            "leagueKey": league_cfg.key,
+            "scoringProfile": league_cfg.scoring_profile,
+            "te_count": len(te_rows),
+            "external_boards": {
+                "ktc_normal_available": bool(boards.get("normal_available")),
+                "ktc_premium_available": bool(boards.get("premium_available")),
+                "ktc_te_plus_plus_available": False,
+            },
+            "boosts": [b.__dict__ for b in boost_rows],
+        })
+    )
+
+
+@app.get("/api/te-premium/league-scenarios")
+async def get_te_premium_league_scenarios(request: Request):
+    """Internal scoring + scarcity comparison: 1-TE vs 2-TE start.
+
+    Reads each TE's pre-computed ``rule_contributions`` block from
+    the live contract (built by ``src/scoring/scoring_delta.py``) and
+    runs the VOR math from ``src/scoring/replacement_level.py``
+    against both lineup environments.  No live values are recomputed.
+    """
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
+    from src.research import te_premium as _te_premium  # noqa: PLC0415
+
+    te_rows = _te_premium.extract_te_players_from_contract(latest_contract_data)
+    scoring_rows = _te_premium.compute_internal_scoring_effect(
+        te_rows,
+        remove_te_reception_bonus=True,
+        remove_te_first_down_bonus=True,
+    )
+    lineup = _te_premium._league_lineup_settings(league_cfg)
+    scarcity_rows, scarcity_summary = _te_premium.compute_scarcity_effect(
+        te_rows,
+        one_te_starters=lineup["te_starters_one"],
+        two_te_starters=lineup["te_starters_two"],
+    )
+    return JSONResponse(
+        content=_te_premium_serialize({
+            "leagueKey": league_cfg.key,
+            "scoringProfile": league_cfg.scoring_profile,
+            "lineup": lineup,
+            "scoring_effect": [s.__dict__ for s in scoring_rows],
+            "scarcity_effect": [s.__dict__ for s in scarcity_rows],
+            "scarcity_summary": scarcity_summary,
+        })
+    )
+
+
+@app.post("/api/te-premium/run-analysis")
+async def post_te_premium_run_analysis(request: Request):
+    """Full sandbox analysis with caller-controlled toggles.
+
+    Body (all optional, sensible defaults):
+        {
+            "remove_te_reception_bonus": true,
+            "remove_te_first_down_bonus": true,
+            "use_two_te_starters": true,
+            "include_rookies": true,
+            "persist": false,
+            "leagueKey": "dynasty_main"   // optional override
+        }
+
+    Returns the full per-player + per-tier analysis payload.  When
+    ``persist=true`` the result is also written to
+    ``data/sandbox/te_premium/<run_id>.json`` for later audit; this
+    is additive (a brand-new directory the live pipeline doesn't
+    touch) and never overwrites a live snapshot.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    try:
+        league_cfg = _resolve_league_for_request(request, body=body)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
+    from src.research import te_premium as _te_premium  # noqa: PLC0415
+
+    payload = _te_premium.run_analysis(
+        latest_contract_data,
+        league_cfg=league_cfg,
+        remove_te_reception_bonus=bool(body.get("remove_te_reception_bonus", True)),
+        remove_te_first_down_bonus=bool(body.get("remove_te_first_down_bonus", True)),
+        use_two_te_starters=bool(body.get("use_two_te_starters", True)),
+        include_rookies=bool(body.get("include_rookies", True)),
+        persist=bool(body.get("persist", False)),
+    )
+    return JSONResponse(content=_te_premium_serialize(payload))
+
+
+@app.get("/api/te-premium/recommendations")
+async def get_te_premium_recommendations(request: Request):
+    """Default-scenario recommendations — sandbox.  Never written to live."""
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
+    from src.research import te_premium as _te_premium  # noqa: PLC0415
+
+    payload = _te_premium.run_analysis(
+        latest_contract_data, league_cfg=league_cfg, persist=False,
+    )
+    # Trim to the recommendation + tier-summary slices for callers
+    # that only want the bottom-line numbers.
+    return JSONResponse(
+        content=_te_premium_serialize({
+            "leagueKey": payload.get("leagueKey"),
+            "scoringProfile": payload.get("scoringProfile"),
+            "summary": payload.get("summary"),
+            "recommendations": payload.get("recommendations"),
+            "tier_summary": payload.get("tier_summary"),
+            "warnings": payload.get("warnings"),
+        })
+    )
+
+
 # ── DRAFT CAPITAL ──────────────────────────────────────────────────────
 # Pick dollar values from CSV, rookie rankings from KTC (live) or CSV (fallback).
 # Uses a decay curve to fill/extrapolate KTC values to all 72 picks.

--- a/server.py
+++ b/server.py
@@ -4374,6 +4374,51 @@ def _te_premium_serialize(payload: dict) -> dict:
     }
 
 
+def _te_premium_scoring_profile_guard(league_cfg) -> "JSONResponse | None":
+    """Block TE-premium analysis when the loaded contract's scoring
+    profile doesn't match the requested league's profile.
+
+    TE Premium analysis reads player values + per-rule scoring
+    contributions out of ``latest_contract_data``.  Per the
+    architecture rule "rankings follow scoring profile, not league"
+    same-profile leagues legitimately share the loaded contract — but
+    a profile MISMATCH means the rankings + per-player scoring
+    contributions are computed from different scoring rules, so
+    serving them under the requested league's metadata would be
+    materially wrong.  Mirrors the pattern in ``GET /api/data``
+    (server.py around line 2177) which 503s in exactly the same case.
+
+    Codex P1 review on PR #392 commit cac140a flagged that
+    ``post_te_premium_run_analysis`` could return 200 against a
+    different league's loaded contract.  This guard is the fix; the
+    handler has to call it after league resolution succeeds.
+    """
+    if not isinstance(latest_contract_data, dict):
+        return None
+    loaded_meta = latest_contract_data.get("meta") or {}
+    loaded_profile = str(loaded_meta.get("scoringProfile") or "")
+    requested_profile = str(getattr(league_cfg, "scoring_profile", "") or "")
+    # Missing loaded_profile = pre-refactor contract; fall through and
+    # let the handler serve (same lenient behaviour as /api/data).
+    if loaded_profile and requested_profile and loaded_profile != requested_profile:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": (
+                    f"League {league_cfg.key!r} uses scoring profile "
+                    f"{requested_profile!r}, but the loaded contract is "
+                    f"{loaded_profile!r}.  TE Premium analysis is not "
+                    f"compatible across scoring profiles."
+                ),
+                "leagueKey": league_cfg.key,
+                "scoringProfile": requested_profile,
+                "loadedScoringProfile": loaded_profile,
+            },
+        )
+    return None
+
+
 @app.get("/api/te-premium/overview")
 async def get_te_premium_overview(request: Request):
     """Sandbox overview: data-source availability + league lineup.
@@ -4385,6 +4430,10 @@ async def get_te_premium_overview(request: Request):
         league_cfg = _resolve_league_for_request(request)
     except LeagueResolutionError as err:
         return err.json_response()
+
+    profile_err = _te_premium_scoring_profile_guard(league_cfg)
+    if profile_err is not None:
+        return profile_err
 
     from src.research import te_premium as _te_premium  # noqa: PLC0415
 
@@ -4407,6 +4456,10 @@ async def get_te_premium_source_comparison(request: Request):
         league_cfg = _resolve_league_for_request(request)
     except LeagueResolutionError as err:
         return err.json_response()
+
+    profile_err = _te_premium_scoring_profile_guard(league_cfg)
+    if profile_err is not None:
+        return profile_err
 
     from src.research import te_premium as _te_premium  # noqa: PLC0415
 
@@ -4443,6 +4496,10 @@ async def get_te_premium_league_scenarios(request: Request):
         league_cfg = _resolve_league_for_request(request)
     except LeagueResolutionError as err:
         return err.json_response()
+
+    profile_err = _te_premium_scoring_profile_guard(league_cfg)
+    if profile_err is not None:
+        return profile_err
 
     from src.research import te_premium as _te_premium  # noqa: PLC0415
 
@@ -4502,6 +4559,10 @@ async def post_te_premium_run_analysis(request: Request):
     except LeagueResolutionError as err:
         return err.json_response()
 
+    profile_err = _te_premium_scoring_profile_guard(league_cfg)
+    if profile_err is not None:
+        return profile_err
+
     from src.research import te_premium as _te_premium  # noqa: PLC0415
 
     payload = _te_premium.run_analysis(
@@ -4523,6 +4584,10 @@ async def get_te_premium_recommendations(request: Request):
         league_cfg = _resolve_league_for_request(request)
     except LeagueResolutionError as err:
         return err.json_response()
+
+    profile_err = _te_premium_scoring_profile_guard(league_cfg)
+    if profile_err is not None:
+        return profile_err
 
     from src.research import te_premium as _te_premium  # noqa: PLC0415
 

--- a/src/research/__init__.py
+++ b/src/research/__init__.py
@@ -1,0 +1,7 @@
+"""Research / sandbox modules.
+
+Sandbox-only analyses live here.  Modules in this package are
+explicitly forbidden from mutating the live contract or any of the
+``latest_*`` globals in ``server.py``.  Their job is to read the live
+contract + raw source CSVs and produce read-only "what-if" projections.
+"""

--- a/src/research/te_premium.py
+++ b/src/research/te_premium.py
@@ -1056,9 +1056,6 @@ def _league_lineup_settings(
     a 12-team league with QB/RB/RB/WR/WR/WR/TE/FLEX/FLEX/SFLEX
     starters — the registry default for ``dynasty_main``.
     """
-    starters: dict[str, int] = {}
-    team_count = fallback_team_count
-    extra_te = 0
     if league_cfg is not None:
         rs = getattr(league_cfg, "roster_settings", None) or {}
         if isinstance(rs, dict):
@@ -1067,6 +1064,14 @@ def _league_lineup_settings(
             except (TypeError, ValueError):
                 team_count = fallback_team_count
             starters_raw = rs.get("starters") or {}
+            # Direct TE slot count per team (e.g. ``starters.TE`` in
+            # the registry; 1 in our default config).  This is the
+            # *direct* count — flex/superflex contributions are added
+            # by ``starter_slot_counts`` below.
+            try:
+                direct_te_per_team = int(starters_raw.get("TE") or 0)
+            except (TypeError, ValueError):
+                direct_te_per_team = 0
             roster_positions: list[str] = []
             for pos, count in starters_raw.items():
                 try:
@@ -1075,18 +1080,34 @@ def _league_lineup_settings(
                     n = 0
                 pos_norm = str(pos).upper()
                 roster_positions.extend([pos_norm] * max(0, n))
-            slots = starter_slot_counts(roster_positions, team_count)
-            te_one = int(slots.get("TE", team_count))
-            te_two = te_one + team_count  # +1 starter per team
+            slots_one = starter_slot_counts(roster_positions, team_count)
+            te_one = int(slots_one.get("TE", team_count))
+
+            # "Start 2 TEs" semantic = exactly 2 direct TE starters
+            # per team (flex contributions are unchanged).  When the
+            # league already starts ≥2 TEs directly, the toggle is a
+            # no-op; we don't keep stacking extra TE slots.  Codex P2
+            # review on PR #392: the prior +team_count formula
+            # over-modeled scarcity for leagues that already
+            # start 2+ TEs.
+            target_te_per_team = 2
+            extra_per_team = max(0, target_te_per_team - direct_te_per_team)
+            te_two = te_one + team_count * extra_per_team
             return {
                 "team_count": team_count,
                 "te_starters_one": te_one,
                 "te_starters_two": te_two,
+                "direct_te_per_team_current": direct_te_per_team,
+                "direct_te_per_team_proposed": max(direct_te_per_team, target_te_per_team),
+                "two_te_is_noop": extra_per_team == 0,
             }
     return {
-        "team_count": team_count,
-        "te_starters_one": team_count,
-        "te_starters_two": team_count * 2,
+        "team_count": fallback_team_count,
+        "te_starters_one": fallback_team_count,
+        "te_starters_two": fallback_team_count * 2,
+        "direct_te_per_team_current": 1,
+        "direct_te_per_team_proposed": 2,
+        "two_te_is_noop": False,
     }
 
 

--- a/src/research/te_premium.py
+++ b/src/research/te_premium.py
@@ -144,7 +144,23 @@ class TEPremiumBoost:
 
 @dataclass(frozen=True)
 class TEScoringEffect:
-    """Per-player effect of removing the TE premium scoring rules."""
+    """Per-player effect of removing the TE premium scoring rules.
+
+    ``te_first_down_ppg`` is the TE-bonus-specific first-down
+    contribution (``bonus_fd_te``), NOT the broader ``first_downs``
+    category aggregate (which on TE rows also pools ``rec_fd`` /
+    ``rush_fd`` from positional first-down rules common to RB/WR/TE).
+    When the live contract carries the per-rule detail map at
+    ``_scoringAdjustment.rule_contributions_detail.bonus_fd_te`` we
+    use it directly; otherwise we fall back to a conservative
+    estimate and flag ``te_fd_estimated=True`` so the operator knows
+    the precision is limited.
+
+    ``te_premium_ppg`` is always the ``te_premium`` category — that
+    category is TE-only by construction (driven by the ``bonus_rec_te``
+    rule, whose ``relevant_buckets`` is ``["TE"]``), so no aggregate
+    pollution is possible there.
+    """
 
     player_id: str
     display_name: str
@@ -155,6 +171,8 @@ class TEScoringEffect:
     scoring_swing_ppg: float
     confidence: float
     archetype: str = ""
+    te_fd_estimated: bool = False
+    te_fd_source: str = ""
 
 
 @dataclass(frozen=True)
@@ -362,6 +380,9 @@ def extract_te_players_from_contract(contract: dict | None) -> list[dict]:
         rule_contribs = (
             scoring_adj.get("rule_contributions") if isinstance(scoring_adj, dict) else {}
         ) or {}
+        rule_contribs_detail = (
+            scoring_adj.get("rule_contributions_detail") if isinstance(scoring_adj, dict) else {}
+        ) or {}
 
         rows[key] = {
             "player_id": key,
@@ -400,6 +421,9 @@ def extract_te_players_from_contract(contract: dict | None) -> list[dict]:
             "ppg_league": ppg_custom,
             "scoring_adjustment": dict(scoring_adj) if isinstance(scoring_adj, dict) else {},
             "rule_contributions": dict(rule_contribs) if isinstance(rule_contribs, dict) else {},
+            "rule_contributions_detail": (
+                dict(rule_contribs_detail) if isinstance(rule_contribs_detail, dict) else {}
+            ),
             "archetype": str(scoring_adj.get("archetype") or "") if isinstance(scoring_adj, dict) else "",
             "scoring_confidence": _coerce_float(
                 scoring_adj.get("confidence") if isinstance(scoring_adj, dict) else None
@@ -562,37 +586,59 @@ def compute_internal_scoring_effect(
 ) -> list[TEScoringEffect]:
     """Project the PPG impact of removing TE premium components.
 
-    Reads each TE's pre-computed ``rule_contributions`` map (already
-    on every offensive row in the live contract via
-    ``src/scoring/scoring_delta.py::bucket_rule_contributions``).
-    The relevant categories:
+    Reads each TE's pre-computed ``rule_contributions`` map.  TE
+    Premium consists of two distinct rules:
 
-        * ``te_premium``  — bonus for extra TE receptions (``bonus_rec_te``)
-        * ``first_downs`` — TE-specific portion is ``bonus_fd_te``,
-          but the contribution dict aggregates QB/RB/WR/TE first-down
-          bonuses into a single ``first_downs`` key.  For TEs the only
-          first-down rule that contributes is the TE one, so the full
-          category contribution attributed to a TE row IS the TE
-          first-down bonus.  This holds because
-          ``bucket_rule_contributions`` filters rules by
-          ``relevant_buckets`` before summing.
+        * ``bonus_rec_te`` — extra-PPR-for-TE.  Tracked under the
+          ``te_premium`` category, which is TE-bucket-only by
+          construction (only ``bonus_rec_te`` belongs to it), so
+          ``rule_contributions["te_premium"]`` is precisely the
+          TE reception-bonus contribution.
 
-    Removing one or both of those rules takes the player's existing
-    ``final_scoring_delta_points`` and adds the offsetting amount.
+        * ``bonus_fd_te`` — extra TE first-down bonus.  Tracked
+          under the ``first_downs`` category, which on TE rows ALSO
+          aggregates positional first-down rules ``rec_fd`` and
+          ``rush_fd`` (both relevant to TE).  Subtracting the
+          aggregate would over-remove if the league differs from
+          baseline on ``rec_fd`` / ``rush_fd``.
+
+    To avoid that over-removal we prefer the per-rule detail map at
+    ``rule_contributions_detail["bonus_fd_te"]`` when the contract
+    carries it (post-PR-392-fix).  When the detail map is absent
+    (older contracts) we fall back to a conservative position:
+
+      * If a non-zero ``first_downs`` aggregate exists we attribute
+        no more than its absolute value to ``bonus_fd_te`` and flag
+        ``te_fd_estimated=True``.  This preserves the current
+        behaviour when ``rec_fd``/``rush_fd`` deltas are zero (the
+        common Sleeper-baseline case) but is signalled clearly so
+        the operator can read the warning rather than trust an
+        unverified number.
     """
     out: list[TEScoringEffect] = []
     for row in te_rows:
         sa = row.get("scoring_adjustment") or {}
         rules = row.get("rule_contributions") or {}
+        rules_detail = row.get("rule_contributions_detail") or {}
         current_delta = _coerce_float(sa.get("final_scoring_delta_points")) or 0.0
 
+        # te_premium category is TE-only — safe to read directly.
         te_premium_ppg = _coerce_float(rules.get("te_premium")) or 0.0
-        te_fd_ppg = _coerce_float(rules.get("first_downs")) or 0.0
+
+        # bonus_fd_te: prefer the per-rule detail map.  Fall back to
+        # the aggregate ``first_downs`` category and mark estimated.
+        te_fd_estimated = False
+        te_fd_source = "rule_contributions_detail.bonus_fd_te"
+        te_fd_ppg = _coerce_float(rules_detail.get("bonus_fd_te"))
+        if te_fd_ppg is None:
+            te_fd_ppg = _coerce_float(rules.get("first_downs")) or 0.0
+            te_fd_estimated = True
+            te_fd_source = "rule_contributions.first_downs (estimated)"
 
         # Removing a rule means subtracting its delta contribution
-        # from the league side (not the baseline side).  The rule_contributions
-        # map carries (league - baseline) per category, so dropping the
-        # rule entirely zeros that category's contribution.
+        # from the league side (not the baseline side).  The
+        # contribution map carries (league - baseline), so dropping
+        # the rule entirely zeros its contribution.
         offset = 0.0
         if remove_te_reception_bonus:
             offset -= te_premium_ppg
@@ -613,6 +659,8 @@ def compute_internal_scoring_effect(
                 scoring_swing_ppg=round(scoring_swing, 4),
                 confidence=float(row.get("scoring_confidence") or 0.0),
                 archetype=str(row.get("archetype") or ""),
+                te_fd_estimated=te_fd_estimated,
+                te_fd_source=te_fd_source,
             )
         )
     return out
@@ -1020,6 +1068,31 @@ def _league_lineup_settings(
     }
 
 
+def _collect_run_warnings(
+    boards: dict, scoring_rows: list[TEScoringEffect]
+) -> list[str]:
+    """Build the warnings list for ``run_analysis`` output.
+
+    Surfaces:
+      * external boards missing (recommendations use tier defaults)
+      * any TE row's first-down bonus contribution was estimated
+        from the aggregate ``first_downs`` category rather than the
+        per-rule ``bonus_fd_te`` detail (precision warning — see the
+        ``compute_internal_scoring_effect`` docstring for context).
+    """
+    out: list[str] = []
+    if not (boards.get("normal_available") and boards.get("premium_available")):
+        out.append("External market boards unavailable; recommendations use tier defaults.")
+    estimated_count = sum(1 for s in scoring_rows if getattr(s, "te_fd_estimated", False))
+    if estimated_count > 0:
+        out.append(
+            f"TE first-down bonus impact estimated from aggregate first_downs "
+            f"category for {estimated_count} TE row(s).  Re-scrape to populate "
+            f"rule_contributions_detail.bonus_fd_te for exact isolation."
+        )
+    return out
+
+
 def build_overview(
     contract: dict | None,
     league_cfg: Any | None = None,
@@ -1093,6 +1166,23 @@ def build_overview(
             "No scoring rule contributions found on TE rows; the internal "
             "scoring effect tab will read zero.  Likely the live contract "
             "predates the per-rule scoring delta refactor."
+        )
+    elif te_rows and not any(
+        (r.get("rule_contributions_detail") or {}).get("bonus_fd_te") is not None
+        for r in te_rows
+    ):
+        # Detail map is missing — the sandbox falls back to the
+        # aggregate `first_downs` category for the TE first-down
+        # bonus, which on TE rows can also pool `rec_fd` / `rush_fd`
+        # contributions.  Safe in the common case where league
+        # `rec_fd`/`rush_fd` deltas are zero, but surface so the
+        # operator knows the precision is limited until the next
+        # scrape rebuilds the contract with the per-rule detail.
+        warnings.append(
+            "Contract lacks per-rule scoring detail (rule_contributions_detail). "
+            "TE first-down bonus impact is estimated from the aggregate "
+            "first_downs category and may over-remove if league rec_fd/rush_fd "
+            "deltas are non-zero.  Re-scrape to refresh."
         )
     if not boards.get("premium_available"):
         warnings.append(
@@ -1248,11 +1338,7 @@ def run_analysis(
             {**r.__dict__, "notes": list(r.notes)} for r in recommendations
         ],
         "tier_summary": tier_summary,
-        "warnings": (
-            []
-            if (boards.get("normal_available") and boards.get("premium_available"))
-            else ["External market boards unavailable; recommendations use tier defaults."]
-        ),
+        "warnings": _collect_run_warnings(boards, scoring_rows),
     }
 
     if persist:

--- a/src/research/te_premium.py
+++ b/src/research/te_premium.py
@@ -1,0 +1,1284 @@
+"""TE Premium Lab — sandbox analysis of TE scoring + lineup changes.
+
+Research-only.  This module never writes to ``latest_contract_data``,
+never persists anything to the live ``data/canonical/`` snapshot,
+and never adjusts any player's ``rankDerivedValue``, ``_composite``,
+or any other live ranking field.  All outputs are computed on-the-fly
+from immutable inputs and returned as plain dicts.
+
+What this module answers
+────────────────────────
+"If we remove TE Premium scoring (extra TE reception bonus + extra TE
+first-down bonus) but require teams to start two tight ends, how
+should TE values shift compared to today?"
+
+It separates four signals so they can be inspected independently:
+
+1. **External market TE Premium boost** — for every source where we
+   have both a "normal" and a "TE Premium" board, the per-player
+   percentage boost the market applies to TEs.  Today the only source
+   that gives us both boards in one scrape is KTC (``ktc.csv`` vs
+   ``ktcSfTep.csv``).  Everything else either ships only one board
+   (DLF SF, FantasyCalc, etc.) or is rank-only and not directly
+   comparable; those are flagged "unavailable" rather than guessed.
+
+2. **Internal scoring effect** — uses the existing
+   ``_scoringAdjustment`` block already present on every offensive
+   player in the live contract.  Each row carries a per-rule
+   ``rule_contributions`` map keyed by category — e.g.
+   ``{"te_premium": -0.35, "first_downs": 3.01, "receptions": -3.39}``
+   in PPG terms vs the league's baseline scoring.  Removing the TE
+   premium category + the TE-specific portion of ``first_downs``
+   tells us how many PPG each TE *loses* if we strip those bonuses
+   from the scoring config.
+
+3. **Internal scarcity effect** — VOR (value over replacement) with
+   the league's actual lineup vs the proposed lineup.  Today's
+   ``starters.TE = 1`` plus FLEX/SFLEX contributions yields ~12-14
+   starting TEs in a 12-team league.  Bumping ``starters.TE`` to 2
+   yields ~24-26.  Replacement-level PPG drops accordingly, every
+   TE's VOR rises, and the scarcity boost partially offsets the lost
+   premium scoring.
+
+4. **Recommended adjustment** — a per-player and per-tier net
+   estimate combining (1) + (2) + (3).  Tier-based, not flat.  Marked
+   with confidence so the operator can see when the signal is thin.
+
+Math + safety notes
+───────────────────
+* Percentage boosts use a min-floor on the denominator
+  (``_MIN_VALUE_FLOOR``) so a ``$50 → $200`` move on a deep-bench TE
+  doesn't get reported as ``+300%`` against a near-zero base.  Below
+  the floor the boost is reported as ``None`` and flagged
+  ``unreliable``.
+* The Hill curve from ``src/canonical/player_valuation.py`` is reused
+  for converting hypothetical rank moves to value moves — never
+  redefined, never re-fit.  This module imports ``rank_to_value``
+  directly so any future curve refit picks up automatically.
+* ``compute_internal_scoring_effect`` strips the TE premium
+  contributions from each player's existing PPG delta in the live
+  contract, rather than re-running the scoring pipeline from scratch.
+  This keeps the sandbox aligned with the same scoring engine that
+  produced the live values; we're not running a second-source
+  scoring engine that could disagree.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+import statistics
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from src.canonical.player_valuation import (
+    HILL_MIDPOINT,
+    HILL_SLOPE,
+    rank_to_value,
+)
+from src.scoring.replacement_level import (
+    PlayerSeasonRow,
+    replacement_per_game,
+    starter_slot_counts,
+    vorp_table,
+)
+
+
+# ── Constants ────────────────────────────────────────────────────────
+
+# Below this raw source value, percentage boosts become unstable.
+# Reported as ``None`` + flagged unreliable instead of producing wild
+# multipliers on near-zero bench rows.
+_MIN_VALUE_FLOOR: float = 200.0
+
+# Default repo paths — overridable via kwargs for testing.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_KTC_NORMAL_CSV = _REPO_ROOT / "CSVs" / "site_raw" / "ktc.csv"
+_DEFAULT_KTC_TEP_CSV = _REPO_ROOT / "CSVs" / "site_raw" / "ktcSfTep.csv"
+_DEFAULT_LEAGUE_REGISTRY = _REPO_ROOT / "config" / "leagues" / "registry.json"
+_DEFAULT_SANDBOX_DIR = _REPO_ROOT / "data" / "sandbox" / "te_premium"
+
+# TE tier definitions — combine TE rank + age so "young upside" and
+# "older productive" surface as distinct buckets.  Boundaries are
+# deliberately conservative: a flat 24-row TE2 cutoff in a 2-TE-start
+# 12-team league is the entire starter pool, and "depth" (TE3+)
+# captures everyone outside.
+_TIER_DEFS: tuple[dict[str, Any], ...] = (
+    {"key": "elite_te1", "label": "Elite TE1", "max_rank": 3},
+    {"key": "strong_te1", "label": "Strong TE1", "max_rank": 8},
+    {"key": "back_te1", "label": "Low TE1 / High TE2", "max_rank": 14},
+    {"key": "te2", "label": "TE2 range", "max_rank": 24},
+    {"key": "depth", "label": "Depth TE", "max_rank": 60},
+    {"key": "deep", "label": "Deep TE", "max_rank": 999},
+)
+
+# Age buckets — applied as a secondary tag, not a primary tier.
+_YOUNG_AGE_THRESHOLD = 25
+_OLDER_AGE_THRESHOLD = 30
+
+
+# ── Public dataclasses ───────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TEPremiumBoost:
+    """One source's normal-vs-premium comparison for one player."""
+
+    source: str
+    player_id: str
+    display_name: str
+    normal_value: float | None
+    premium_value: float | None
+    normal_rank: int | None
+    premium_rank: int | None
+    boost_abs: float | None
+    boost_pct: float | None
+    log_ratio: float | None
+    rank_change: int | None
+    reliable: bool
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class TEScoringEffect:
+    """Per-player effect of removing the TE premium scoring rules."""
+
+    player_id: str
+    display_name: str
+    current_ppg_delta: float
+    te_premium_ppg: float
+    te_first_down_ppg: float
+    proposed_ppg_delta: float
+    scoring_swing_ppg: float
+    confidence: float
+    archetype: str = ""
+
+
+@dataclass(frozen=True)
+class TEScarcityRow:
+    """Per-TE VOR under both lineup configurations."""
+
+    player_id: str
+    display_name: str
+    points: float
+    games: int
+    vor_one_te: float
+    vor_two_te: float
+    vor_delta: float
+    replacement_one_te_ppg: float
+    replacement_two_te_ppg: float
+
+
+@dataclass(frozen=True)
+class TEPremiumRecommendation:
+    player_id: str
+    display_name: str
+    tier: str
+    age: int | None
+    current_value: float | None
+    market_boost_pct: float | None
+    scoring_swing_ppg: float
+    scarcity_value_delta: float
+    recommended_adjustment_pct: float
+    recommended_value: float | None
+    confidence: float
+    notes: list[str] = field(default_factory=list)
+
+
+# ── External market loaders ──────────────────────────────────────────
+
+
+def _read_ktc_csv(path: Path) -> dict[str, float]:
+    """Read a KTC CSV (``name,value`` rows) into a name→value dict.
+
+    The current scrape format is a flat two-column CSV with no
+    position metadata; we filter out picks (anything starting with a
+    year prefix) at the caller and rely on the contract's own TE list
+    for matching.  Missing file → empty dict; the comparison code
+    flags the source as unavailable in that case.
+    """
+    out: dict[str, float] = {}
+    if not path.exists():
+        return out
+    try:
+        with path.open("r", encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                name = (row.get("name") or "").strip()
+                if not name:
+                    continue
+                try:
+                    val = float(row.get("value") or 0)
+                except (TypeError, ValueError):
+                    continue
+                if val <= 0:
+                    continue
+                out[_normalize_name_for_match(name)] = val
+    except (OSError, csv.Error):
+        return {}
+    return out
+
+
+def _normalize_name_for_match(name: str) -> str:
+    """Lower-case + strip punctuation for fuzzy-but-deterministic match.
+
+    Mirrors the same normalisation used in ``src/utils/name_clean``
+    minimally — keeping the surface area small so the sandbox doesn't
+    drift from the canonical matcher's contract.  This is only used
+    for comparing scraped CSV rows to live-contract player names; the
+    live contract already carries Sleeper IDs we use as the primary
+    key when available.
+    """
+    s = (name or "").lower().strip()
+    s = s.replace(".", "").replace("'", "").replace("-", " ")
+    s = " ".join(s.split())
+    # Drop common position/team suffixes the CSVs sometimes carry.
+    for suffix in (" qb", " rb", " wr", " te", " k", " def", " dl", " lb", " db"):
+        if s.endswith(suffix):
+            s = s[: -len(suffix)]
+    return s.strip()
+
+
+def load_external_ktc_boards(
+    *,
+    normal_path: Path | None = None,
+    premium_path: Path | None = None,
+) -> dict[str, dict]:
+    """Load both KTC boards (normal SF + TE-Premium SF) into name maps.
+
+    Returns:
+        ``{
+            "normal": {normalized_name: value, ...},
+            "premium": {normalized_name: value, ...},
+            "normal_path": "...",
+            "premium_path": "...",
+            "normal_available": bool,
+            "premium_available": bool,
+        }``
+
+    Both paths default to the canonical scraper outputs at
+    ``CSVs/site_raw/ktc.csv`` and ``CSVs/site_raw/ktcSfTep.csv``.
+    The "premium" board is KTC's TE+ Level 1 ("TE Premium") sub-board.
+    KTC's TE++ (Level 2) board is structurally available in the API
+    response but is NOT currently extracted by ``Dynasty Scraper.py``
+    (see ``_KTC_TEP_FIELD_KEYS`` — only level 1 is plucked); when
+    requested it's flagged unavailable.
+    """
+    np_path = Path(normal_path) if normal_path else _DEFAULT_KTC_NORMAL_CSV
+    pp_path = Path(premium_path) if premium_path else _DEFAULT_KTC_TEP_CSV
+    normal = _read_ktc_csv(np_path)
+    premium = _read_ktc_csv(pp_path)
+    return {
+        "normal": normal,
+        "premium": premium,
+        "normal_path": str(np_path),
+        "premium_path": str(pp_path),
+        "normal_available": bool(normal),
+        "premium_available": bool(premium),
+    }
+
+
+# ── Contract readers ─────────────────────────────────────────────────
+
+
+def _coerce_float(v: Any) -> float | None:
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(f) or math.isinf(f):
+        return None
+    return f
+
+
+def _coerce_int(v: Any) -> int | None:
+    f = _coerce_float(v)
+    if f is None:
+        return None
+    return int(round(f))
+
+
+def extract_te_players_from_contract(contract: dict | None) -> list[dict]:
+    """Pull the TE rows out of the live contract.
+
+    Returns a list of dicts with the fields the sandbox needs:
+    ``player_id`` (Sleeper ID when available, else canonical name),
+    ``display_name``, ``team``, ``age``, ``position``, ``rank``,
+    ``position_rank``, ``current_value``, ``ktc_normal``,
+    ``ktc_premium``, ``scoring_adjustment`` (the raw block from the
+    contract), ``ppg_test`` / ``ppg_custom`` / ``games`` etc.
+
+    The contract has two parallel shapes — a name-keyed ``players``
+    dict and a flat ``playersArray`` — depending on which field has
+    been populated.  Both can carry TE rows; we consume whichever is
+    present and dedupe by Sleeper ID first, name second.
+    """
+    if not isinstance(contract, dict):
+        return []
+
+    rows: dict[str, dict] = {}
+
+    def _push(row: dict) -> None:
+        if not isinstance(row, dict):
+            return
+        position = str(row.get("position") or row.get("pos") or "").upper()
+        if position != "TE":
+            return
+        sleeper_id = (
+            row.get("_sleeperId")
+            or row.get("sleeperId")
+            or row.get("sleeper_id")
+        )
+        sleeper_id = str(sleeper_id) if sleeper_id else ""
+        display_name = str(
+            row.get("displayName")
+            or row.get("display_name")
+            or row.get("name")
+            or row.get("playerName")
+            or ""
+        ).strip()
+        if not display_name:
+            return
+        key = sleeper_id or display_name.lower()
+        if key in rows:
+            return  # First write wins; both shapes carry the same fields.
+
+        scoring_adj = (
+            row.get("_scoringAdjustment")
+            or row.get("scoringAdjustment")
+            or {}
+        )
+        ppg_test = _coerce_float(
+            row.get("_formatFitPPGTest") or row.get("formatFitPPGTest")
+        )
+        ppg_custom = _coerce_float(
+            row.get("_formatFitPPGCustom") or row.get("formatFitPPGCustom")
+        )
+        rule_contribs = (
+            scoring_adj.get("rule_contributions") if isinstance(scoring_adj, dict) else {}
+        ) or {}
+
+        rows[key] = {
+            "player_id": key,
+            "sleeper_id": sleeper_id,
+            "display_name": display_name,
+            "team": str(row.get("team") or row.get("team_abbr") or "").upper() or None,
+            "age": _coerce_int(row.get("age")),
+            "position": "TE",
+            "rank": _coerce_int(
+                row.get("rank")
+                or row.get("canonicalConsensusRank")
+                or row.get("canonical_consensus_rank")
+            ),
+            "position_rank": _coerce_int(
+                row.get("positionRank") or row.get("position_rank")
+            ),
+            "current_value": _coerce_float(
+                row.get("rankDerivedValue")
+                or row.get("rank_derived_value")
+                or row.get("_composite")
+                or row.get("displayValue")
+                or row.get("value")
+            ),
+            "ktc_normal_value": _coerce_float(
+                row.get("ktc")
+                or row.get("KTC")
+                or (row.get("_canonicalSiteValues") or {}).get("ktc")
+            ),
+            "ktc_premium_value": _coerce_float(
+                row.get("ktcSfTep")
+                or row.get("ktcSftep")
+                or row.get("ktc_sf_tep")
+                or (row.get("_canonicalSiteValues") or {}).get("ktcSfTep")
+            ),
+            "ppg_baseline": ppg_test,
+            "ppg_league": ppg_custom,
+            "scoring_adjustment": dict(scoring_adj) if isinstance(scoring_adj, dict) else {},
+            "rule_contributions": dict(rule_contribs) if isinstance(rule_contribs, dict) else {},
+            "archetype": str(scoring_adj.get("archetype") or "") if isinstance(scoring_adj, dict) else "",
+            "scoring_confidence": _coerce_float(
+                scoring_adj.get("confidence") if isinstance(scoring_adj, dict) else None
+            ) or 0.0,
+            "rookie": bool(row.get("rookie") or row.get("isRookie")),
+        }
+
+    players_dict = contract.get("players")
+    if isinstance(players_dict, dict):
+        for name, row in players_dict.items():
+            if isinstance(row, dict):
+                merged = dict(row)
+                merged.setdefault("displayName", name)
+                _push(merged)
+
+    arr = contract.get("playersArray")
+    if isinstance(arr, list):
+        for row in arr:
+            _push(row)
+
+    out = list(rows.values())
+    # Sort by current_value descending so the natural "TE rank within the TE pool"
+    # is just the index + 1.
+    out.sort(key=lambda r: -(r.get("current_value") or 0))
+    for idx, row in enumerate(out):
+        row["te_pool_rank"] = idx + 1
+    return out
+
+
+# ── 1. External market boost ─────────────────────────────────────────
+
+
+def compute_external_market_boost(
+    te_rows: list[dict],
+    *,
+    boards: dict | None = None,
+    source: str = "ktc",
+) -> list[TEPremiumBoost]:
+    """Compute per-TE normal-vs-premium boost for an external source.
+
+    Today only KTC publishes both boards from the same scrape.  The
+    function is structured so additional sources can be added by
+    extending ``boards`` (each entry needs a ``normal`` + ``premium``
+    name→value map).  Sources without both boards are skipped at the
+    caller; this function expects a usable ``boards`` argument.
+
+    Per player:
+        boost_abs = premium - normal
+        boost_pct = (premium - normal) / max(normal, _MIN_VALUE_FLOOR)
+        log_ratio = log(premium / normal)  when both > 0
+
+    When either side is missing we return ``None`` for the derived
+    fields and ``reliable=False`` with a note.  When ``normal`` is
+    below ``_MIN_VALUE_FLOOR`` we still compute ``boost_abs`` but flag
+    ``boost_pct`` unreliable so the UI can mark it.
+    """
+    out: list[TEPremiumBoost] = []
+    if not te_rows or not isinstance(boards, dict):
+        return out
+    normal_map = (boards.get("normal") or {}) if isinstance(boards.get("normal"), dict) else {}
+    premium_map = (
+        (boards.get("premium") or {}) if isinstance(boards.get("premium"), dict) else {}
+    )
+    if not normal_map or not premium_map:
+        return out
+
+    # Pre-compute per-board ranks so we can report rank movement.
+    normal_ranked = sorted(normal_map.items(), key=lambda kv: -kv[1])
+    premium_ranked = sorted(premium_map.items(), key=lambda kv: -kv[1])
+    normal_rank = {name: idx + 1 for idx, (name, _) in enumerate(normal_ranked)}
+    premium_rank = {name: idx + 1 for idx, (name, _) in enumerate(premium_ranked)}
+
+    for row in te_rows:
+        norm_key = _normalize_name_for_match(row.get("display_name") or "")
+        if not norm_key:
+            continue
+        n_val = normal_map.get(norm_key)
+        p_val = premium_map.get(norm_key)
+        if n_val is None and p_val is None:
+            continue  # No comparison data for this player; skip rather than emit nulls.
+
+        boost_abs: float | None = None
+        boost_pct: float | None = None
+        log_ratio: float | None = None
+        reliable = True
+        note = ""
+
+        if n_val is None:
+            note = "missing on normal board"
+            reliable = False
+        elif p_val is None:
+            note = "missing on premium board"
+            reliable = False
+        else:
+            boost_abs = float(p_val) - float(n_val)
+            denom = max(float(n_val), _MIN_VALUE_FLOOR)
+            boost_pct = boost_abs / denom
+            if float(n_val) < _MIN_VALUE_FLOOR:
+                reliable = False
+                note = (
+                    f"normal value {n_val:.0f} below floor "
+                    f"{_MIN_VALUE_FLOOR:.0f}; pct unreliable"
+                )
+            if n_val and p_val and n_val > 0 and p_val > 0:
+                log_ratio = math.log(float(p_val) / float(n_val))
+
+        n_rank = normal_rank.get(norm_key)
+        p_rank = premium_rank.get(norm_key)
+        rank_change = (
+            (n_rank - p_rank) if isinstance(n_rank, int) and isinstance(p_rank, int) else None
+        )
+
+        out.append(
+            TEPremiumBoost(
+                source=source,
+                player_id=str(row.get("player_id") or row.get("display_name") or ""),
+                display_name=str(row.get("display_name") or ""),
+                normal_value=float(n_val) if n_val is not None else None,
+                premium_value=float(p_val) if p_val is not None else None,
+                normal_rank=n_rank,
+                premium_rank=p_rank,
+                boost_abs=boost_abs,
+                boost_pct=boost_pct,
+                log_ratio=log_ratio,
+                rank_change=rank_change,
+                reliable=reliable,
+                note=note,
+            )
+        )
+    return out
+
+
+# ── 2. Internal scoring effect ───────────────────────────────────────
+
+
+def _ppg_to_value_units(
+    ppg: float, *, current_value: float | None, ppg_baseline: float | None
+) -> float:
+    """Crude PPG→value conversion using the player's own implied scale.
+
+    Uses the player's existing ``current_value : ppg_baseline`` ratio
+    when both are present; otherwise falls back to ~25 value units per
+    PPG, which is the empirical median across mid-pack TEs in the
+    legacy ``_formatFitFinalScoringDeltaValue`` field (e.g. -0.72 PPG
+    × ~26.7 = -19.2 value units on Brock Bowers).  This is "good
+    enough" for a sandbox — the operator looks at the magnitude, not
+    the third decimal.
+    """
+    if current_value and ppg_baseline and ppg_baseline > 0:
+        ratio = current_value / ppg_baseline
+        return ppg * ratio
+    return ppg * 25.0
+
+
+def compute_internal_scoring_effect(
+    te_rows: list[dict],
+    *,
+    remove_te_reception_bonus: bool = True,
+    remove_te_first_down_bonus: bool = True,
+) -> list[TEScoringEffect]:
+    """Project the PPG impact of removing TE premium components.
+
+    Reads each TE's pre-computed ``rule_contributions`` map (already
+    on every offensive row in the live contract via
+    ``src/scoring/scoring_delta.py::bucket_rule_contributions``).
+    The relevant categories:
+
+        * ``te_premium``  — bonus for extra TE receptions (``bonus_rec_te``)
+        * ``first_downs`` — TE-specific portion is ``bonus_fd_te``,
+          but the contribution dict aggregates QB/RB/WR/TE first-down
+          bonuses into a single ``first_downs`` key.  For TEs the only
+          first-down rule that contributes is the TE one, so the full
+          category contribution attributed to a TE row IS the TE
+          first-down bonus.  This holds because
+          ``bucket_rule_contributions`` filters rules by
+          ``relevant_buckets`` before summing.
+
+    Removing one or both of those rules takes the player's existing
+    ``final_scoring_delta_points`` and adds the offsetting amount.
+    """
+    out: list[TEScoringEffect] = []
+    for row in te_rows:
+        sa = row.get("scoring_adjustment") or {}
+        rules = row.get("rule_contributions") or {}
+        current_delta = _coerce_float(sa.get("final_scoring_delta_points")) or 0.0
+
+        te_premium_ppg = _coerce_float(rules.get("te_premium")) or 0.0
+        te_fd_ppg = _coerce_float(rules.get("first_downs")) or 0.0
+
+        # Removing a rule means subtracting its delta contribution
+        # from the league side (not the baseline side).  The rule_contributions
+        # map carries (league - baseline) per category, so dropping the
+        # rule entirely zeros that category's contribution.
+        offset = 0.0
+        if remove_te_reception_bonus:
+            offset -= te_premium_ppg
+        if remove_te_first_down_bonus:
+            offset -= te_fd_ppg
+
+        proposed_delta = current_delta + offset
+        scoring_swing = proposed_delta - current_delta  # always == offset
+
+        out.append(
+            TEScoringEffect(
+                player_id=str(row.get("player_id") or ""),
+                display_name=str(row.get("display_name") or ""),
+                current_ppg_delta=round(current_delta, 4),
+                te_premium_ppg=round(te_premium_ppg, 4),
+                te_first_down_ppg=round(te_fd_ppg, 4),
+                proposed_ppg_delta=round(proposed_delta, 4),
+                scoring_swing_ppg=round(scoring_swing, 4),
+                confidence=float(row.get("scoring_confidence") or 0.0),
+                archetype=str(row.get("archetype") or ""),
+            )
+        )
+    return out
+
+
+# ── 3. Internal scarcity effect ──────────────────────────────────────
+
+
+def _build_player_season_rows(
+    te_rows: list[dict],
+    *,
+    games: int = 17,
+    ppg_field: str = "ppg_league",
+) -> list[PlayerSeasonRow]:
+    """Convert TE contract rows to PlayerSeasonRow for VOR math.
+
+    Uses the season-pace PPG as the "points" anchor and assumes a full
+    17-game season for replacement math.  The replacement_per_game
+    helper in ``src/scoring/replacement_level.py`` only cares about
+    per-game pace, so any consistent ``games`` works.
+
+    Falls back to ``ppg_baseline`` (test scoring) when ``ppg_league``
+    is missing — this can happen for TEs without enough sample for a
+    league-specific projection, in which case the baseline pace is
+    still a reasonable scarcity signal.
+    """
+    out: list[PlayerSeasonRow] = []
+    for row in te_rows:
+        ppg = _coerce_float(row.get(ppg_field))
+        if ppg is None:
+            ppg = _coerce_float(row.get("ppg_baseline"))
+        if ppg is None or ppg <= 0:
+            continue
+        out.append(
+            PlayerSeasonRow(
+                player_id=str(row.get("player_id") or ""),
+                position="TE",
+                points=float(ppg) * games,
+                games=games,
+                player_name=str(row.get("display_name") or ""),
+            )
+        )
+    return out
+
+
+def compute_scarcity_effect(
+    te_rows: list[dict],
+    *,
+    one_te_starters: int = 12,
+    two_te_starters: int = 24,
+    games: int = 17,
+    ppg_field: str = "ppg_league",
+) -> tuple[list[TEScarcityRow], dict]:
+    """Compute VOR for every TE under both lineup environments.
+
+    ``one_te_starters`` defaults to 12 (a 12-team league with one TE
+    starter slot, ignoring flex contributions which the league
+    registry exposes separately).  ``two_te_starters`` defaults to 24
+    (the proposed scenario: 12 teams × 2 starting TEs).  Both can be
+    overridden by the caller — e.g. a 10-team league passes 10 / 20.
+
+    Returns ``(rows, summary)`` where ``summary`` carries the
+    replacement-level baselines, the count of evaluable TEs, and a
+    quick-stat for the average value swing.  All values rounded.
+    """
+    season_rows = _build_player_season_rows(te_rows, games=games, ppg_field=ppg_field)
+    if not season_rows:
+        return [], {
+            "evaluable_tes": 0,
+            "replacement_one_te_ppg": 0.0,
+            "replacement_two_te_ppg": 0.0,
+            "avg_vor_delta": 0.0,
+        }
+
+    rep_one = replacement_per_game(season_rows, one_te_starters)
+    rep_two = replacement_per_game(season_rows, two_te_starters)
+
+    rows: list[TEScarcityRow] = []
+    for r in season_rows:
+        vor_one = r.points - (rep_one * r.games)
+        vor_two = r.points - (rep_two * r.games)
+        rows.append(
+            TEScarcityRow(
+                player_id=r.player_id,
+                display_name=r.player_name,
+                points=round(r.points, 2),
+                games=r.games,
+                vor_one_te=round(vor_one, 2),
+                vor_two_te=round(vor_two, 2),
+                vor_delta=round(vor_two - vor_one, 2),
+                replacement_one_te_ppg=round(rep_one, 4),
+                replacement_two_te_ppg=round(rep_two, 4),
+            )
+        )
+
+    rows.sort(key=lambda r: -r.vor_two_te)
+    avg_delta = (
+        statistics.fmean(r.vor_delta for r in rows) if rows else 0.0
+    )
+    summary = {
+        "evaluable_tes": len(rows),
+        "replacement_one_te_ppg": round(rep_one, 4),
+        "replacement_two_te_ppg": round(rep_two, 4),
+        "avg_vor_delta": round(avg_delta, 2),
+    }
+    return rows, summary
+
+
+# ── 4. Tier assignment + recommendation ──────────────────────────────
+
+
+def assign_te_tier(te_pool_rank: int | None, age: int | None) -> dict[str, str]:
+    """Map (TE-pool rank, age) → tier label + age tag.
+
+    Tier is the primary classification (rank-based); age tag is a
+    secondary signal so the recommendation can dampen older productive
+    TEs and lift young upside TEs even within the same tier.
+    """
+    tier_key = "deep"
+    tier_label = "Deep TE"
+    if isinstance(te_pool_rank, int) and te_pool_rank > 0:
+        for spec in _TIER_DEFS:
+            if te_pool_rank <= spec["max_rank"]:
+                tier_key = spec["key"]
+                tier_label = spec["label"]
+                break
+    age_tag = ""
+    if isinstance(age, int):
+        if age <= _YOUNG_AGE_THRESHOLD:
+            age_tag = "young_upside"
+        elif age >= _OLDER_AGE_THRESHOLD:
+            age_tag = "older_productive"
+    return {"tier_key": tier_key, "tier_label": tier_label, "age_tag": age_tag}
+
+
+def _tier_market_boost_default(tier_key: str) -> float:
+    """Heuristic fallback when the live KTC TEP boards are missing.
+
+    These are *not* used when the actual boards are loaded — the real
+    per-player boost wins.  They exist so the page renders something
+    sensible on a fresh dev machine without scraped CSVs.  Magnitudes
+    chosen to be conservative (smaller than the typical KTC-observed
+    boost) so the operator notices the disclaimer rather than acting
+    on a synthetic recommendation.
+    """
+    return {
+        "elite_te1": 0.05,
+        "strong_te1": 0.07,
+        "back_te1": 0.10,
+        "te2": 0.12,
+        "depth": 0.08,
+        "deep": 0.04,
+    }.get(tier_key, 0.06)
+
+
+def build_recommendations(
+    te_rows: list[dict],
+    *,
+    boost_rows: list[TEPremiumBoost] | None,
+    scoring_rows: list[TEScoringEffect],
+    scarcity_rows: list[TEScarcityRow],
+    market_available: bool,
+) -> list[TEPremiumRecommendation]:
+    """Combine the three signals into a per-player recommended adjust %.
+
+    Net adjustment = market_boost_pct (sign-flipped — when removing
+    TEP we *give back* whatever TEP added) + scarcity_value_delta_pct
+    + scoring_value_delta_pct.
+
+    Confidence is the geometric mean of the per-source confidences:
+    market reliability + internal scoring confidence + a flat 0.7 for
+    scarcity (the VOR math is well-defined but depends on PPG inputs
+    that have their own variance).
+    """
+    boost_by_id: dict[str, TEPremiumBoost] = {}
+    for b in boost_rows or []:
+        if b.reliable and b.boost_pct is not None:
+            boost_by_id[b.player_id] = b
+    scoring_by_id = {s.player_id: s for s in scoring_rows}
+    scarcity_by_id = {s.player_id: s for s in scarcity_rows}
+
+    out: list[TEPremiumRecommendation] = []
+    for row in te_rows:
+        pid = str(row.get("player_id") or "")
+        tier = assign_te_tier(row.get("te_pool_rank"), row.get("age"))
+        current_value = _coerce_float(row.get("current_value"))
+
+        # Market signal: invert sign because removing TEP unwinds the
+        # market premium, but adding scarcity from 2-TE start re-applies
+        # demand pressure.  Net market + lineup pressure ≈
+        # -market_pct + market_pct = 0 only if 2-TE start fully
+        # mirrors KTC TEP — historically it's slightly larger
+        # (KTC TE++ > KTC TEP+), so the operator sees this in the
+        # sandbox and decides whether to lift or hold.
+        m_signal: float | None = None
+        m_boost = boost_by_id.get(pid)
+        if m_boost and m_boost.boost_pct is not None:
+            m_signal = float(m_boost.boost_pct)
+        elif not market_available:
+            m_signal = _tier_market_boost_default(tier["tier_key"])
+
+        # Internal scoring signal — convert PPG swing to value units
+        # using the player's own value:ppg ratio, then to pct of value.
+        s_eff = scoring_by_id.get(pid)
+        scoring_swing_ppg = float(s_eff.scoring_swing_ppg) if s_eff else 0.0
+        scoring_value_delta = _ppg_to_value_units(
+            scoring_swing_ppg,
+            current_value=current_value,
+            ppg_baseline=row.get("ppg_baseline"),
+        )
+        scoring_value_delta_pct = (
+            scoring_value_delta / current_value if current_value and current_value > 0 else 0.0
+        )
+
+        # Scarcity signal — convert VOR delta (extra points above
+        # replacement when we go to 2-TE start) to a percentage of
+        # current value.  The VOR delta is in season-points; the
+        # ppg→value mapping above already amortizes that.
+        sc_row = scarcity_by_id.get(pid)
+        scarcity_value_delta = 0.0
+        scarcity_value_delta_pct = 0.0
+        if sc_row:
+            scarcity_value_delta = _ppg_to_value_units(
+                sc_row.vor_delta / max(1, sc_row.games),
+                current_value=current_value,
+                ppg_baseline=row.get("ppg_baseline"),
+            )
+            if current_value and current_value > 0:
+                scarcity_value_delta_pct = scarcity_value_delta / current_value
+
+        # Market boost is what KTC charges for TE Premium — when we
+        # *remove* TEP, we unwind that boost (negative).  The
+        # 2-TE-start scarcity demand re-adds value (positive).  Net
+        # is: -market_pct + scarcity_pct + scoring_pct.
+        market_unwind_pct = -float(m_signal) if m_signal is not None else 0.0
+        net_pct = market_unwind_pct + scarcity_value_delta_pct + scoring_value_delta_pct
+
+        # Cap the recommended adjustment to ±25% to prevent runaway
+        # values on thin signal — the sandbox surfaces the unclipped
+        # signal in the player table for transparency, but the
+        # recommendation column stays in a reasonable range.
+        recommended_pct = max(-0.25, min(0.25, net_pct))
+        recommended_value = (
+            current_value * (1.0 + recommended_pct) if current_value else None
+        )
+
+        # Confidence: geometric mean of three components, clamped to
+        # [0.1, 1.0].  Missing market data drops the market component
+        # to 0.5, missing scoring to 0.5.
+        market_conf = 0.85 if (m_boost and m_boost.reliable) else 0.5
+        scoring_conf = float(s_eff.confidence) if s_eff and s_eff.confidence else 0.5
+        scarcity_conf = 0.7 if sc_row else 0.4
+        confidence = (market_conf * scoring_conf * scarcity_conf) ** (1.0 / 3.0)
+
+        notes: list[str] = []
+        if m_boost and not m_boost.reliable:
+            notes.append("Market boost flagged unreliable.")
+        if not market_available:
+            notes.append("No external market boards loaded; using tier default.")
+        if s_eff and s_eff.confidence < 0.4:
+            notes.append("Low scoring-fit confidence (small projection sample).")
+        if not sc_row:
+            notes.append("No PPG sample; scarcity skipped.")
+        if abs(net_pct) > 0.25:
+            notes.append(
+                f"Raw net signal {net_pct:+.0%} clipped to "
+                f"{recommended_pct:+.0%} for safety."
+            )
+        if tier.get("age_tag") == "older_productive":
+            notes.append("Older productive — discount a touch beyond the model.")
+        if tier.get("age_tag") == "young_upside":
+            notes.append("Young upside — model may understate ceiling.")
+
+        out.append(
+            TEPremiumRecommendation(
+                player_id=pid,
+                display_name=str(row.get("display_name") or ""),
+                tier=tier["tier_label"],
+                age=row.get("age"),
+                current_value=current_value,
+                market_boost_pct=m_signal,
+                scoring_swing_ppg=scoring_swing_ppg,
+                scarcity_value_delta=round(scarcity_value_delta, 2),
+                recommended_adjustment_pct=round(recommended_pct, 4),
+                recommended_value=round(recommended_value, 0) if recommended_value else None,
+                confidence=round(confidence, 3),
+                notes=notes,
+            )
+        )
+    return out
+
+
+# ── Tier summary ─────────────────────────────────────────────────────
+
+
+def summarise_by_tier(
+    te_rows: list[dict],
+    *,
+    boost_rows: list[TEPremiumBoost],
+    scoring_rows: list[TEScoringEffect],
+    scarcity_rows: list[TEScarcityRow],
+    recommendations: list[TEPremiumRecommendation],
+) -> list[dict]:
+    """Group every per-player signal into the tier definitions."""
+    boost_by_id = {b.player_id: b for b in boost_rows if b.reliable}
+    scoring_by_id = {s.player_id: s for s in scoring_rows}
+    scarcity_by_id = {s.player_id: s for s in scarcity_rows}
+    rec_by_id = {r.player_id: r for r in recommendations}
+
+    by_tier: dict[str, list[dict]] = {spec["key"]: [] for spec in _TIER_DEFS}
+    for row in te_rows:
+        tier = assign_te_tier(row.get("te_pool_rank"), row.get("age"))
+        by_tier.setdefault(tier["tier_key"], []).append(row)
+
+    out: list[dict] = []
+    for spec in _TIER_DEFS:
+        members = by_tier.get(spec["key"]) or []
+        if not members:
+            continue
+        ids = [str(m.get("player_id") or "") for m in members]
+        cur_values = [v for v in (m.get("current_value") for m in members) if v]
+        boosts = [boost_by_id[i].boost_pct for i in ids if i in boost_by_id and boost_by_id[i].boost_pct is not None]
+        scoring_swings = [scoring_by_id[i].scoring_swing_ppg for i in ids if i in scoring_by_id]
+        scarcity_deltas = [scarcity_by_id[i].vor_delta for i in ids if i in scarcity_by_id]
+        rec_pcts = [rec_by_id[i].recommended_adjustment_pct for i in ids if i in rec_by_id]
+        confs = [rec_by_id[i].confidence for i in ids if i in rec_by_id]
+
+        out.append(
+            {
+                "tier_key": spec["key"],
+                "tier_label": spec["label"],
+                "player_count": len(members),
+                "avg_current_value": round(statistics.fmean(cur_values), 0) if cur_values else None,
+                "avg_market_boost_pct": (
+                    round(statistics.fmean(boosts), 4) if boosts else None
+                ),
+                "avg_scoring_swing_ppg": (
+                    round(statistics.fmean(scoring_swings), 4) if scoring_swings else None
+                ),
+                "avg_scarcity_vor_delta": (
+                    round(statistics.fmean(scarcity_deltas), 2) if scarcity_deltas else None
+                ),
+                "recommended_adjustment_range": (
+                    [round(min(rec_pcts), 4), round(max(rec_pcts), 4)] if rec_pcts else None
+                ),
+                "avg_recommended_adjustment_pct": (
+                    round(statistics.fmean(rec_pcts), 4) if rec_pcts else None
+                ),
+                "avg_confidence": (
+                    round(statistics.fmean(confs), 3) if confs else None
+                ),
+            }
+        )
+    return out
+
+
+# ── Top-level orchestrators ──────────────────────────────────────────
+
+
+def _league_lineup_settings(
+    league_cfg: Any | None,
+    *,
+    fallback_team_count: int = 12,
+) -> dict[str, int]:
+    """Pull starter slot counts for TE under 1-TE and 2-TE lineups.
+
+    Reuses ``starter_slot_counts`` from
+    ``src/scoring/replacement_level.py`` so flex/superflex
+    contributions are accounted for consistently with the rest of the
+    app's VOR math.  When ``league_cfg`` is missing we fall back to
+    a 12-team league with QB/RB/RB/WR/WR/WR/TE/FLEX/FLEX/SFLEX
+    starters — the registry default for ``dynasty_main``.
+    """
+    starters: dict[str, int] = {}
+    team_count = fallback_team_count
+    extra_te = 0
+    if league_cfg is not None:
+        rs = getattr(league_cfg, "roster_settings", None) or {}
+        if isinstance(rs, dict):
+            try:
+                team_count = int(rs.get("teamCount") or fallback_team_count)
+            except (TypeError, ValueError):
+                team_count = fallback_team_count
+            starters_raw = rs.get("starters") or {}
+            roster_positions: list[str] = []
+            for pos, count in starters_raw.items():
+                try:
+                    n = int(count)
+                except (TypeError, ValueError):
+                    n = 0
+                pos_norm = str(pos).upper()
+                roster_positions.extend([pos_norm] * max(0, n))
+            slots = starter_slot_counts(roster_positions, team_count)
+            te_one = int(slots.get("TE", team_count))
+            te_two = te_one + team_count  # +1 starter per team
+            return {
+                "team_count": team_count,
+                "te_starters_one": te_one,
+                "te_starters_two": te_two,
+            }
+    return {
+        "team_count": team_count,
+        "te_starters_one": team_count,
+        "te_starters_two": team_count * 2,
+    }
+
+
+def build_overview(
+    contract: dict | None,
+    league_cfg: Any | None = None,
+    *,
+    boards: dict | None = None,
+) -> dict:
+    """Read-only overview: data sources, league settings, warnings.
+
+    Cheap; no heavy computation.  Used to populate the page header +
+    controls panel before any analysis is run.
+    """
+    te_rows = extract_te_players_from_contract(contract)
+    if boards is None:
+        boards = load_external_ktc_boards()
+    lineup = _league_lineup_settings(league_cfg)
+
+    sources_status = [
+        {
+            "key": "ktc",
+            "label": "KeepTradeCut",
+            "supports_normal": True,
+            "supports_te_premium": bool(boards.get("premium_available")),
+            "supports_te_plus_plus": False,
+            "note": (
+                "KTC ships normal SF + TE+ Level 1 boards from the same scrape. "
+                "TE++ (Level 2) is in the API response but not currently "
+                "extracted by Dynasty Scraper.py — see _KTC_TEP_FIELD_KEYS."
+            ),
+            "available": bool(boards.get("normal_available") and boards.get("premium_available")),
+        },
+        {
+            "key": "dlf_sf",
+            "label": "Dynasty League Football",
+            "supports_normal": True,
+            "supports_te_premium": False,
+            "supports_te_plus_plus": False,
+            "note": "DLF SF board is rank-only and standard SF — no TEP variant available.",
+            "available": False,
+        },
+        {
+            "key": "fantasy_calc",
+            "label": "FantasyCalc",
+            "supports_normal": True,
+            "supports_te_premium": False,
+            "supports_te_plus_plus": False,
+            "note": "FantasyCalc has TE Premium settings on their site; not currently scraped here.",
+            "available": False,
+        },
+        {
+            "key": "manual_csv",
+            "label": "Manual CSV upload",
+            "supports_normal": True,
+            "supports_te_premium": True,
+            "supports_te_plus_plus": True,
+            "note": "Drop a CSV at CSVs/site_raw/te_premium_manual.csv with columns name,value,format.",
+            "available": False,
+        },
+    ]
+
+    # Surface a warning if the live contract has no TEs (likely a
+    # cold-start dev machine before the first scrape) or no scoring
+    # adjustment block (running against legacy data).
+    warnings: list[str] = []
+    if not te_rows:
+        warnings.append(
+            "No TE rows found in the live contract.  Run a scrape first; "
+            "until then this page renders with empty data."
+        )
+    elif not any(r.get("rule_contributions") for r in te_rows):
+        warnings.append(
+            "No scoring rule contributions found on TE rows; the internal "
+            "scoring effect tab will read zero.  Likely the live contract "
+            "predates the per-rule scoring delta refactor."
+        )
+    if not boards.get("premium_available"):
+        warnings.append(
+            "KTC TE-Premium board (CSVs/site_raw/ktcSfTep.csv) is empty or missing.  "
+            "External market comparison falls back to tier-default heuristics."
+        )
+
+    return {
+        "leagueKey": getattr(league_cfg, "key", None),
+        "scoringProfile": getattr(league_cfg, "scoring_profile", None),
+        "lineup": lineup,
+        "te_count": len(te_rows),
+        "sources": sources_status,
+        "warnings": warnings,
+        "sandbox": True,
+        "note": (
+            "Research-only sandbox.  Outputs from this page are NOT applied "
+            "to live player values.  No write endpoint exists for that path."
+        ),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def run_analysis(
+    contract: dict | None,
+    league_cfg: Any | None = None,
+    *,
+    remove_te_reception_bonus: bool = True,
+    remove_te_first_down_bonus: bool = True,
+    use_two_te_starters: bool = True,
+    include_rookies: bool = True,
+    boards: dict | None = None,
+    persist: bool = False,
+    sandbox_dir: Path | None = None,
+) -> dict:
+    """One-shot sandbox analysis.
+
+    Pure read against ``contract``; does NOT mutate any field.  When
+    ``persist=True`` the result is also written to
+    ``data/sandbox/te_premium/<run_id>.json`` for audit; this is
+    additive (a brand-new directory the live pipeline doesn't touch)
+    and never overwrites a live snapshot.
+    """
+    te_rows = extract_te_players_from_contract(contract)
+    if not include_rookies:
+        te_rows = [r for r in te_rows if not r.get("rookie")]
+    if boards is None:
+        boards = load_external_ktc_boards()
+    lineup = _league_lineup_settings(league_cfg)
+
+    boost_rows = compute_external_market_boost(te_rows, boards=boards, source="ktc")
+    scoring_rows = compute_internal_scoring_effect(
+        te_rows,
+        remove_te_reception_bonus=remove_te_reception_bonus,
+        remove_te_first_down_bonus=remove_te_first_down_bonus,
+    )
+
+    one_te = lineup["te_starters_one"]
+    two_te = lineup["te_starters_two"] if use_two_te_starters else lineup["te_starters_one"]
+    scarcity_rows, scarcity_summary = compute_scarcity_effect(
+        te_rows,
+        one_te_starters=one_te,
+        two_te_starters=two_te,
+    )
+
+    market_available = bool(boards.get("premium_available") and boards.get("normal_available"))
+    recommendations = build_recommendations(
+        te_rows,
+        boost_rows=boost_rows,
+        scoring_rows=scoring_rows,
+        scarcity_rows=scarcity_rows,
+        market_available=market_available,
+    )
+    tier_summary = summarise_by_tier(
+        te_rows,
+        boost_rows=boost_rows,
+        scoring_rows=scoring_rows,
+        scarcity_rows=scarcity_rows,
+        recommendations=recommendations,
+    )
+
+    avg_market_boost = (
+        statistics.fmean(b.boost_pct for b in boost_rows if b.reliable and b.boost_pct is not None)
+        if any(b.reliable and b.boost_pct is not None for b in boost_rows)
+        else None
+    )
+    avg_scoring_swing = (
+        statistics.fmean(s.scoring_swing_ppg for s in scoring_rows)
+        if scoring_rows
+        else 0.0
+    )
+    avg_scarcity_delta = scarcity_summary.get("avg_vor_delta") or 0.0
+    avg_recommended_pct = (
+        statistics.fmean(r.recommended_adjustment_pct for r in recommendations)
+        if recommendations
+        else 0.0
+    )
+    avg_confidence = (
+        statistics.fmean(r.confidence for r in recommendations) if recommendations else 0.0
+    )
+
+    summary = {
+        "te_count": len(te_rows),
+        "evaluable_for_market": sum(1 for b in boost_rows if b.reliable),
+        "evaluable_for_scoring": sum(
+            1 for s in scoring_rows if abs(s.scoring_swing_ppg) > 1e-6
+        ),
+        "evaluable_for_scarcity": scarcity_summary.get("evaluable_tes", 0),
+        "avg_market_boost_pct": (
+            round(avg_market_boost, 4) if avg_market_boost is not None else None
+        ),
+        "avg_internal_scoring_swing_ppg": round(avg_scoring_swing, 4),
+        "avg_scarcity_vor_delta_points": round(avg_scarcity_delta, 2),
+        "avg_recommended_adjustment_pct": round(avg_recommended_pct, 4),
+        "avg_confidence": round(avg_confidence, 3),
+        "lineup": lineup,
+        "te_starters_proposed": two_te,
+    }
+
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    payload = {
+        "run_id": run_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sandbox": True,
+        "leagueKey": getattr(league_cfg, "key", None),
+        "scoringProfile": getattr(league_cfg, "scoring_profile", None),
+        "scenario": {
+            "remove_te_reception_bonus": remove_te_reception_bonus,
+            "remove_te_first_down_bonus": remove_te_first_down_bonus,
+            "use_two_te_starters": use_two_te_starters,
+            "include_rookies": include_rookies,
+        },
+        "summary": summary,
+        "scarcity_summary": scarcity_summary,
+        "external_boards": {
+            "ktc_normal_available": bool(boards.get("normal_available")),
+            "ktc_premium_available": bool(boards.get("premium_available")),
+            "ktc_te_plus_plus_available": False,
+            "normal_path": boards.get("normal_path"),
+            "premium_path": boards.get("premium_path"),
+        },
+        "players": [
+            {
+                **{k: v for k, v in row.items() if k not in {"rule_contributions", "scoring_adjustment"}},
+                "tier": assign_te_tier(row.get("te_pool_rank"), row.get("age")),
+            }
+            for row in te_rows
+        ],
+        "external_boost": [b.__dict__ for b in boost_rows],
+        "scoring_effect": [s.__dict__ for s in scoring_rows],
+        "scarcity_effect": [s.__dict__ for s in scarcity_rows],
+        "recommendations": [
+            {**r.__dict__, "notes": list(r.notes)} for r in recommendations
+        ],
+        "tier_summary": tier_summary,
+        "warnings": (
+            []
+            if (boards.get("normal_available") and boards.get("premium_available"))
+            else ["External market boards unavailable; recommendations use tier defaults."]
+        ),
+    }
+
+    if persist:
+        out_dir = Path(sandbox_dir) if sandbox_dir else _DEFAULT_SANDBOX_DIR
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"te_premium_{run_id}.json"
+        with out_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        payload["persisted_path"] = str(out_path)
+
+    return payload
+
+
+__all__ = [
+    "TEPremiumBoost",
+    "TEScoringEffect",
+    "TEScarcityRow",
+    "TEPremiumRecommendation",
+    "load_external_ktc_boards",
+    "extract_te_players_from_contract",
+    "compute_external_market_boost",
+    "compute_internal_scoring_effect",
+    "compute_scarcity_effect",
+    "assign_te_tier",
+    "build_recommendations",
+    "summarise_by_tier",
+    "build_overview",
+    "run_analysis",
+]

--- a/src/research/te_premium.py
+++ b/src/research/te_premium.py
@@ -69,6 +69,7 @@ import json
 import math
 import os
 import statistics
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -823,12 +824,22 @@ def build_recommendations(
     scoring_rows: list[TEScoringEffect],
     scarcity_rows: list[TEScarcityRow],
     market_available: bool,
+    remove_te_reception_bonus: bool = True,
+    remove_te_first_down_bonus: bool = True,
 ) -> list[TEPremiumRecommendation]:
     """Combine the three signals into a per-player recommended adjust %.
 
-    Net adjustment = market_boost_pct (sign-flipped — when removing
-    TEP we *give back* whatever TEP added) + scarcity_value_delta_pct
-    + scoring_value_delta_pct.
+    Net adjustment = market_unwind_pct + scarcity_value_delta_pct +
+    scoring_value_delta_pct.
+
+    ``market_unwind_pct`` is ``-market_boost_pct`` ONLY when at least
+    one TE Premium scoring rule (``bonus_rec_te`` or ``bonus_fd_te``)
+    is being removed in this scenario.  When NEITHER is being removed
+    the operator is studying the lineup-only effect (e.g. just
+    "what's the impact of starting two TEs?") and the external KTC
+    TEP premium should not be unwound — TEP is still in the league's
+    scoring rules, so the market premium still applies.  Codex
+    review on PR #392 flagged the missing gate.
 
     Confidence is the geometric mean of the per-source confidences:
     market reliability + internal scoring confidence + a flat 0.7 for
@@ -895,7 +906,18 @@ def build_recommendations(
         # *remove* TEP, we unwind that boost (negative).  The
         # 2-TE-start scarcity demand re-adds value (positive).  Net
         # is: -market_pct + scarcity_pct + scoring_pct.
-        market_unwind_pct = -float(m_signal) if m_signal is not None else 0.0
+        # Only unwind the external TEP market premium when the
+        # operator is actually removing at least one TEP scoring
+        # rule.  Lineup-only scenarios (e.g. 2-TE start with TEP
+        # scoring untouched) leave the market premium intact.
+        any_tep_rule_removed = bool(
+            remove_te_reception_bonus or remove_te_first_down_bonus
+        )
+        market_unwind_pct = (
+            -float(m_signal)
+            if (m_signal is not None and any_tep_rule_removed)
+            else 0.0
+        )
         net_pct = market_unwind_pct + scarcity_value_delta_pct + scoring_value_delta_pct
 
         # Cap the recommended adjustment to ±25% to prevent runaway
@@ -1255,6 +1277,8 @@ def run_analysis(
         scoring_rows=scoring_rows,
         scarcity_rows=scarcity_rows,
         market_available=market_available,
+        remove_te_reception_bonus=remove_te_reception_bonus,
+        remove_te_first_down_bonus=remove_te_first_down_bonus,
     )
     tier_summary = summarise_by_tier(
         te_rows,
@@ -1302,7 +1326,17 @@ def run_analysis(
         "te_starters_proposed": two_te,
     }
 
-    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    # Sub-second timestamp + 8-char hex suffix so concurrent
+    # ``persist=true`` runs (or rapid retries) never collide on the
+    # filesystem.  Codex P2 review on PR #392: a second-level
+    # timestamp can be hit twice within one wallclock second.
+    _now = datetime.now(timezone.utc)
+    run_id = (
+        _now.strftime("%Y%m%dT%H%M%S")
+        + f"_{_now.microsecond:06d}"
+        + f"_{uuid.uuid4().hex[:8]}"
+        + "Z"
+    )
     payload = {
         "run_id": run_id,
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/src/scoring/__init__.py
+++ b/src/scoring/__init__.py
@@ -7,7 +7,13 @@ from .sleeper_ingest import (
     normalize_scoring_settings,
     persist_scoring_config,
 )
-from .scoring_delta import bucket_rule_contributions, compare_to_baseline, persist_scoring_delta_map
+from .scoring_delta import (
+    RULE_CONTRIBUTION_DETAIL_KEYS,
+    bucket_rule_contributions,
+    bucket_rule_contributions_detail,
+    compare_to_baseline,
+    persist_scoring_delta_map,
+)
 from .feature_engineering import compute_profile_features, infer_scoring_tags
 from .archetype_model import build_scoring_tags, infer_archetype, summarize_archetype_priors
 from .player_adjustment import (
@@ -30,6 +36,8 @@ __all__ = [
     "persist_scoring_config",
     "compare_to_baseline",
     "bucket_rule_contributions",
+    "bucket_rule_contributions_detail",
+    "RULE_CONTRIBUTION_DETAIL_KEYS",
     "persist_scoring_delta_map",
     "compute_profile_features",
     "infer_scoring_tags",

--- a/src/scoring/player_adjustment.py
+++ b/src/scoring/player_adjustment.py
@@ -71,6 +71,7 @@ def build_player_scoring_adjustment(
     archetype_prior_ratio: float = 1.0,
     value_anchor: float = 1000.0,
     source: str = "scoring_translation_hybrid",
+    rule_contributions_detail: Optional[Dict[str, float]] = None,
 ) -> PlayerScoringAdjustment:
     p_base = max(0.0, float(baseline_ppg or 0.0))
     p_league = max(0.0, float(league_ppg or 0.0))
@@ -106,6 +107,9 @@ def build_player_scoring_adjustment(
         scoring_tags=list(scoring_tags or []),
         source=str(source or "scoring_translation_hybrid"),
         rule_contributions={k: round(float(v), 6) for k, v in (rule_contributions or {}).items()},
+        rule_contributions_detail={
+            k: round(float(v), 6) for k, v in (rule_contributions_detail or {}).items()
+        },
     )
 
 

--- a/src/scoring/scoring_delta.py
+++ b/src/scoring/scoring_delta.py
@@ -77,7 +77,33 @@ def compare_to_baseline(baseline_config: ScoringConfig, league_config: ScoringCo
     return out
 
 
-def bucket_rule_contributions(bucket: str, stats_per_game: Dict[str, float], delta_rules: List[ScoringRule]) -> Dict[str, float]:
+# Rule keys whose per-rule contribution is preserved separately
+# alongside the category aggregate.  Sandbox / research consumers (the
+# TE Premium Lab) need to isolate these specific TE-bonus rules from
+# the broader category buckets they share — e.g. ``bonus_fd_te`` is in
+# the ``first_downs`` category, but the category aggregate also pools
+# ``rec_fd`` and ``rush_fd``.  Removing the category-level aggregate
+# when the operator only meant to remove the TE bonus would
+# over-remove.  Keeping per-rule entries is additive — the existing
+# category aggregate is unchanged.
+RULE_CONTRIBUTION_DETAIL_KEYS: tuple[str, ...] = (
+    "bonus_rec_te",
+    "bonus_fd_te",
+)
+
+
+def bucket_rule_contributions(
+    bucket: str,
+    stats_per_game: Dict[str, float],
+    delta_rules: List[ScoringRule],
+) -> Dict[str, float]:
+    """Aggregate per-bucket rule contributions by category.
+
+    The aggregated map is what the live valuation pipeline has
+    historically consumed.  For per-rule precision (e.g. isolating
+    ``bonus_fd_te`` from the ``first_downs`` category), use
+    ``bucket_rule_contributions_detail`` alongside this function.
+    """
     if not isinstance(stats_per_game, dict):
         return {}
     out: Dict[str, float] = {}
@@ -91,6 +117,48 @@ def bucket_rule_contributions(bucket: str, stats_per_game: Dict[str, float], del
             continue
         out[rule.category] = out.get(rule.category, 0.0) + contrib
     return {k: round(float(v), 6) for k, v in out.items()}
+
+
+def bucket_rule_contributions_detail(
+    bucket: str,
+    stats_per_game: Dict[str, float],
+    delta_rules: List[ScoringRule],
+    *,
+    rule_keys: tuple[str, ...] = RULE_CONTRIBUTION_DETAIL_KEYS,
+) -> Dict[str, float]:
+    """Per-rule (rule.key) contributions for the selected rule keys.
+
+    Same math as ``bucket_rule_contributions`` (stat × delta), but
+    keyed by ``rule.key`` rather than ``rule.category`` so the
+    operator can read each rule independently.  By default only the
+    TE-bonus-specific rules in ``RULE_CONTRIBUTION_DETAIL_KEYS`` are
+    emitted — keeping the surface area small for the contract.
+
+    Every rule listed in ``rule_keys`` that's relevant to ``bucket``
+    is included in the output, even when the contribution is zero,
+    so a downstream consumer can deterministically tell "this rule
+    has zero impact" apart from "this rule wasn't computed".  Rules
+    irrelevant to the bucket (e.g. ``bonus_fd_te`` on a QB row) are
+    skipped.
+    """
+    if not isinstance(stats_per_game, dict):
+        return {}
+    selected = set(rule_keys or ())
+    if not selected:
+        return {}
+    b = str(bucket or "").upper()
+    rule_by_key: Dict[str, ScoringRule] = {}
+    for rule in delta_rules or []:
+        if rule.key not in selected:
+            continue
+        if rule.relevant_buckets and b not in rule.relevant_buckets:
+            continue
+        rule_by_key[rule.key] = rule
+    out: Dict[str, float] = {}
+    for key, rule in rule_by_key.items():
+        stat_value = float(stats_per_game.get(key, 0.0) or 0.0)
+        out[key] = round(stat_value * float(rule.delta), 6)
+    return out
 
 
 def persist_scoring_delta_map(

--- a/src/scoring/types.py
+++ b/src/scoring/types.py
@@ -78,6 +78,15 @@ class PlayerScoringAdjustment:
     scoring_tags: List[str] = field(default_factory=list)
     source: str = "scoring_translation_hybrid"
     rule_contributions: Dict[str, float] = field(default_factory=dict)
+    # Per-rule-key contribution for selected rules where the
+    # category-level aggregate is too coarse to be useful (e.g. the
+    # ``first_downs`` category aggregates ``rec_fd``, ``rush_fd``,
+    # and ``bonus_fd_te`` for TE rows; the TE Premium Lab needs to
+    # isolate ``bonus_fd_te`` from the others).  Optional, additive,
+    # populated only for the rules listed in
+    # ``RULE_CONTRIBUTION_DETAIL_KEYS`` in ``scoring_delta.py``.
+    # Older contracts simply won't carry this field.
+    rule_contributions_detail: Dict[str, float] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, object]:
         return asdict(self)

--- a/tests/api/test_te_premium_endpoints.py
+++ b/tests/api/test_te_premium_endpoints.py
@@ -1,0 +1,346 @@
+"""Endpoint contract tests for the TE Premium Lab sandbox.
+
+Coverage:
+
+* All four endpoints respond 200 with the documented payload shape
+  when ``latest_contract_data`` carries TE rows.
+* Mutation safety: ``latest_contract_data`` is byte-identical before
+  and after every endpoint call (the most important invariant — these
+  endpoints must never reach into the live contract).
+* Stable schema across runs: a second call to ``run-analysis``
+  returns the same top-level keys.
+* Graceful behaviour when the contract is empty (no scrape yet).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import league_registry as _league_registry
+from src.research import te_premium as tep
+
+
+def _make_te_row(
+    name: str,
+    sleeper_id: str,
+    *,
+    composite: float = 5000,
+    age: int = 26,
+    ppg_baseline: float = 11.0,
+    ppg_league: float = 10.5,
+    ktc: float | None = 6500,
+    ktc_sf_tep: float | None = 7000,
+) -> dict:
+    return {
+        "displayName": name,
+        "_sleeperId": sleeper_id,
+        "position": "TE",
+        "age": age,
+        "team": "BUF",
+        "_composite": composite,
+        "rankDerivedValue": composite,
+        "ktc": ktc,
+        "ktcSfTep": ktc_sf_tep,
+        "_formatFitPPGTest": ppg_baseline,
+        "_formatFitPPGCustom": ppg_league,
+        "_scoringAdjustment": {
+            "final_scoring_delta_points": -0.5,
+            "rule_contributions": {
+                "te_premium": -0.4,
+                "first_downs": 2.5,
+                "receptions": -2.6,
+            },
+            "archetype": "chain_mover",
+            "confidence": 0.7,
+        },
+    }
+
+
+@pytest.fixture
+def client_with_te_contract(tmp_path, monkeypatch):
+    """Install a synthetic contract with a TE pool, point the league
+    registry at a real test fixture, bypass auth, and yield a
+    TestClient that talks to ``server.app``.
+
+    The global conftest deliberately points
+    ``LEAGUE_REGISTRY_PATH`` at a missing file so tests don't leak
+    onto the operator's real registry.  We override that for the
+    duration of this fixture so ``_resolve_league_for_request``
+    actually has a default league to resolve.  Same pattern as
+    ``tests/api/test_league_routing.py::two_league_registry``."""
+    # Real test registry — minimal but enough for resolution.
+    reg_path = tmp_path / "registry.json"
+    reg_path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "dynasty_main",
+                "leagues": [
+                    {
+                        "key": "dynasty_main",
+                        "displayName": "Risk It (Test)",
+                        "sleeperLeagueId": "L-TEST",
+                        "scoringProfile": "superflex_tep15_ppr1",
+                        "active": True,
+                        "rosterSettings": {
+                            "teamCount": 12,
+                            "starters": {
+                                "QB": 1, "RB": 2, "WR": 3, "TE": 1,
+                                "FLEX": 2, "SFLEX": 1,
+                            },
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(reg_path))
+    _league_registry.reload_registry()
+
+    rows = [
+        _make_te_row(f"TE Player {i}", f"te_id_{i}", composite=9000 - i * 200)
+        for i in range(20)
+    ]
+    contract = {
+        "meta": {"leagueKey": "dynasty_main", "scoringProfile": "superflex_tep15_ppr1"},
+        "players": {row["displayName"]: row for row in rows},
+        "playersArray": [],
+        "playerCount": len(rows),
+    }
+    original = server.latest_contract_data
+    monkeypatch.setattr(server, "latest_contract_data", contract)
+    monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
+    monkeypatch.setattr(
+        server, "_get_auth_session",
+        lambda r: {"username": "jasonleetucker"},
+    )
+    yield TestClient(server.app), contract
+    monkeypatch.setattr(server, "latest_contract_data", original)
+    # Restore the conftest's registry state so later tests don't see
+    # this fixture's leagues bleed in.
+    _league_registry.reload_registry()
+
+
+def _snapshot(contract: dict) -> str:
+    return json.dumps(contract, sort_keys=True, default=str)
+
+
+# ── Overview ─────────────────────────────────────────────────────────
+
+
+def test_overview_returns_sandbox_envelope(client_with_te_contract):
+    client, _ = client_with_te_contract
+    res = client.get("/api/te-premium/overview")
+    assert res.status_code == 200, f"body: {res.text}"
+    body = res.json()
+    assert body["sandbox"] is True
+    assert body["appliesToLiveValues"] is False
+    assert body["te_count"] == 20
+    assert body.get("note", "").lower().startswith("research-only")
+    assert isinstance(body.get("sources"), list) and len(body["sources"]) >= 1
+    assert isinstance(body.get("warnings"), list)
+
+
+def test_overview_does_not_mutate_contract(client_with_te_contract):
+    client, contract = client_with_te_contract
+    before = _snapshot(contract)
+    client.get("/api/te-premium/overview")
+    after = _snapshot(contract)
+    assert before == after, "Overview endpoint mutated latest_contract_data"
+
+
+# ── Source comparison ───────────────────────────────────────────────
+
+
+def test_source_comparison_shape(client_with_te_contract, monkeypatch):
+    # Force the boards to be available so the response carries data.
+    monkeypatch.setattr(
+        tep,
+        "load_external_ktc_boards",
+        lambda **_: {
+            "normal": {f"te player {i}": 9000 - i * 200 for i in range(20)},
+            "premium": {f"te player {i}": (9000 - i * 200) * 1.1 for i in range(20)},
+            "normal_path": "test",
+            "premium_path": "test",
+            "normal_available": True,
+            "premium_available": True,
+        },
+    )
+    client, _ = client_with_te_contract
+    res = client.get("/api/te-premium/source-comparison")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["sandbox"] is True
+    assert body["te_count"] == 20
+    assert isinstance(body.get("boosts"), list)
+    assert len(body["boosts"]) == 20
+    # Every boost has the documented fields
+    for b in body["boosts"]:
+        assert {"source", "player_id", "display_name", "normal_value",
+                "premium_value", "boost_pct", "reliable"}.issubset(b.keys())
+
+
+def test_source_comparison_does_not_mutate_contract(client_with_te_contract):
+    client, contract = client_with_te_contract
+    before = _snapshot(contract)
+    client.get("/api/te-premium/source-comparison")
+    after = _snapshot(contract)
+    assert before == after
+
+
+# ── League scenarios ────────────────────────────────────────────────
+
+
+def test_league_scenarios_returns_both_arrays(client_with_te_contract):
+    client, _ = client_with_te_contract
+    res = client.get("/api/te-premium/league-scenarios")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["sandbox"] is True
+    assert isinstance(body.get("scoring_effect"), list)
+    assert isinstance(body.get("scarcity_effect"), list)
+    assert "scarcity_summary" in body
+    assert "lineup" in body
+
+
+def test_league_scenarios_does_not_mutate_contract(client_with_te_contract):
+    client, contract = client_with_te_contract
+    before = _snapshot(contract)
+    client.get("/api/te-premium/league-scenarios")
+    after = _snapshot(contract)
+    assert before == after
+
+
+# ── Run analysis ────────────────────────────────────────────────────
+
+
+def test_run_analysis_default_scenario(client_with_te_contract):
+    client, _ = client_with_te_contract
+    res = client.post("/api/te-premium/run-analysis", json={})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["sandbox"] is True
+    assert body["appliesToLiveValues"] is False
+    assert body["scenario"]["remove_te_reception_bonus"] is True
+    assert body["scenario"]["remove_te_first_down_bonus"] is True
+    assert body["scenario"]["use_two_te_starters"] is True
+    assert "summary" in body
+    assert "recommendations" in body
+    assert "tier_summary" in body
+    # Recommendations are clipped to ±25%
+    for r in body["recommendations"]:
+        assert -0.25 <= r["recommended_adjustment_pct"] <= 0.25
+
+
+def test_run_analysis_respects_toggle_overrides(client_with_te_contract):
+    client, _ = client_with_te_contract
+    res = client.post(
+        "/api/te-premium/run-analysis",
+        json={
+            "remove_te_reception_bonus": False,
+            "remove_te_first_down_bonus": False,
+            "use_two_te_starters": False,
+        },
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scenario"]["remove_te_reception_bonus"] is False
+    assert body["scenario"]["remove_te_first_down_bonus"] is False
+    assert body["scenario"]["use_two_te_starters"] is False
+    # Scoring swing should be zero when neither rule is removed.
+    assert all(abs(s["scoring_swing_ppg"]) < 1e-6 for s in body["scoring_effect"])
+
+
+def test_run_analysis_does_not_mutate_contract(client_with_te_contract):
+    """Most important safety property — run twice with different
+    scenarios and verify the contract bytes never change."""
+    client, contract = client_with_te_contract
+    before = _snapshot(contract)
+    client.post("/api/te-premium/run-analysis", json={})
+    client.post(
+        "/api/te-premium/run-analysis",
+        json={"use_two_te_starters": False, "remove_te_reception_bonus": False},
+    )
+    after = _snapshot(contract)
+    assert before == after, "run-analysis mutated latest_contract_data"
+
+
+def test_run_analysis_does_not_persist_by_default(client_with_te_contract, tmp_path, monkeypatch):
+    # Note: tmp_path is shared with the fixture's registry.json, so we
+    # filter for the sandbox naming prefix rather than checking the
+    # whole directory.
+    sandbox_dir = tmp_path / "sandbox"
+    sandbox_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(tep, "_DEFAULT_SANDBOX_DIR", sandbox_dir)
+    client, _ = client_with_te_contract
+    client.post("/api/te-premium/run-analysis", json={})
+    assert list(sandbox_dir.glob("te_premium_*.json")) == []
+
+
+def test_run_analysis_persist_writes_sidecar(client_with_te_contract, tmp_path, monkeypatch):
+    sandbox_dir = tmp_path / "sandbox_persist"
+    sandbox_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(tep, "_DEFAULT_SANDBOX_DIR", sandbox_dir)
+    client, _ = client_with_te_contract
+    res = client.post("/api/te-premium/run-analysis", json={"persist": True})
+    assert res.status_code == 200
+    body = res.json()
+    files = list(sandbox_dir.glob("te_premium_*.json"))
+    assert len(files) == 1
+    assert body.get("persisted_path") == str(files[0])
+
+
+def test_run_analysis_handles_empty_contract(client_with_te_contract, monkeypatch):
+    client, _ = client_with_te_contract
+    monkeypatch.setattr(server, "latest_contract_data", {"meta": {}, "players": {}, "playersArray": []})
+    res = client.post("/api/te-premium/run-analysis", json={})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["summary"]["te_count"] == 0
+    assert body["recommendations"] == []
+
+
+# ── Recommendations ─────────────────────────────────────────────────
+
+
+def test_recommendations_endpoint_returns_summary_slice(client_with_te_contract):
+    client, _ = client_with_te_contract
+    res = client.get("/api/te-premium/recommendations")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["sandbox"] is True
+    assert "summary" in body
+    assert "recommendations" in body
+    assert "tier_summary" in body
+    # Slice should NOT include the bulky external_boost / scoring_effect arrays
+    assert "external_boost" not in body
+    assert "scoring_effect" not in body
+
+
+def test_recommendations_does_not_mutate_contract(client_with_te_contract):
+    client, contract = client_with_te_contract
+    before = _snapshot(contract)
+    client.get("/api/te-premium/recommendations")
+    after = _snapshot(contract)
+    assert before == after
+
+
+# ── Schema stability ────────────────────────────────────────────────
+
+
+def test_run_analysis_returns_stable_top_level_keys(client_with_te_contract):
+    client, _ = client_with_te_contract
+    keys_first = set(client.post("/api/te-premium/run-analysis", json={}).json().keys())
+    keys_second = set(client.post("/api/te-premium/run-analysis", json={}).json().keys())
+    assert keys_first == keys_second
+    expected = {
+        "ok", "sandbox", "appliesToLiveValues",
+        "run_id", "generated_at", "leagueKey", "scoringProfile",
+        "scenario", "summary", "scarcity_summary", "external_boards",
+        "players", "external_boost", "scoring_effect", "scarcity_effect",
+        "recommendations", "tier_summary", "warnings",
+    }
+    assert expected.issubset(keys_first)

--- a/tests/api/test_te_premium_endpoints.py
+++ b/tests/api/test_te_premium_endpoints.py
@@ -331,6 +331,100 @@ def test_recommendations_does_not_mutate_contract(client_with_te_contract):
 # ── Schema stability ────────────────────────────────────────────────
 
 
+def test_endpoints_503_on_scoring_profile_mismatch(tmp_path, monkeypatch):
+    """Codex P1 fix: when the loaded contract's scoringProfile doesn't
+    match the requested league's profile, every TE-premium endpoint
+    must 503 ``data_not_ready`` rather than serving the wrong data
+    under a misleading leagueKey stamp.
+
+    Mirrors the same guard ``GET /api/data`` enforces (server.py
+    around line 2177)."""
+    # Set up a registry with a "ppr_only" league whose scoring profile
+    # is intentionally distinct from the loaded contract's
+    # ``superflex_tep15_ppr1``.
+    reg_path = tmp_path / "registry.json"
+    reg_path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "dynasty_main",
+                "leagues": [
+                    {
+                        "key": "dynasty_main",
+                        "displayName": "Risk It (Test)",
+                        "sleeperLeagueId": "L-MAIN",
+                        "scoringProfile": "superflex_tep15_ppr1",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12, "starters": {"TE": 1}},
+                    },
+                    {
+                        "key": "ppr_only",
+                        "displayName": "PPR Only (Test)",
+                        "sleeperLeagueId": "L-PPR",
+                        "scoringProfile": "ppr_no_tep",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12, "starters": {"TE": 1}},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(reg_path))
+    _league_registry.reload_registry()
+
+    # Loaded contract is stamped for the dynasty_main scoring profile.
+    rows = [
+        _make_te_row(f"TE Player {i}", f"te_id_{i}", composite=9000 - i * 200)
+        for i in range(5)
+    ]
+    contract = {
+        "meta": {
+            "leagueKey": "dynasty_main",
+            "scoringProfile": "superflex_tep15_ppr1",
+        },
+        "players": {row["displayName"]: row for row in rows},
+        "playersArray": [],
+    }
+    monkeypatch.setattr(server, "latest_contract_data", contract)
+    monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
+    monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "jasonleetucker"})
+
+    client = TestClient(server.app)
+    # All four endpoints should 503 when ``leagueKey=ppr_only`` is requested.
+    for path in (
+        "/api/te-premium/overview",
+        "/api/te-premium/source-comparison",
+        "/api/te-premium/league-scenarios",
+        "/api/te-premium/recommendations",
+    ):
+        res = client.get(f"{path}?leagueKey=ppr_only")
+        assert res.status_code == 503, f"{path} returned {res.status_code}: {res.text}"
+        body = res.json()
+        assert body["error"] == "data_not_ready"
+        assert body["leagueKey"] == "ppr_only"
+        assert "ppr_no_tep" in body.get("message", "") or body.get("scoringProfile") == "ppr_no_tep"
+
+    # POST run-analysis with the mismatched leagueKey in the body too.
+    res = client.post("/api/te-premium/run-analysis", json={"leagueKey": "ppr_only"})
+    assert res.status_code == 503
+    assert res.json()["error"] == "data_not_ready"
+
+    # Restore registry afterwards so later tests don't see this fixture.
+    _league_registry.reload_registry()
+
+
+def test_endpoints_serve_when_scoring_profiles_match(client_with_te_contract):
+    """Same scoring profile but different league keys: the endpoints
+    should still serve (per the architecture rule "rankings follow
+    scoring profile, not league key")."""
+    client, _ = client_with_te_contract
+    # The fixture's only league is ``dynasty_main`` with the matching
+    # profile, so this asserts the positive path.  ``leagueKey`` defaults
+    # to dynasty_main → matches loaded contract → 200.
+    res = client.get("/api/te-premium/overview")
+    assert res.status_code == 200
+
+
 def test_run_analysis_returns_stable_top_level_keys(client_with_te_contract):
     client, _ = client_with_te_contract
     keys_first = set(client.post("/api/te-premium/run-analysis", json={}).json().keys())

--- a/tests/research/test_te_premium.py
+++ b/tests/research/test_te_premium.py
@@ -32,19 +32,37 @@ def _make_te_row(
     age: int = 26,
     team: str = "BUF",
     rule_contributions: dict | None = None,
+    rule_contributions_detail: dict | None = None,
     ppg_baseline: float = 12.0,
     ppg_league: float = 11.5,
     ktc: float | None = 6500,
     ktc_sf_tep: float | None = 7000,
     rookie: bool = False,
 ) -> dict:
-    """Build a synthetic players-dict row that mimics the live contract."""
+    """Build a synthetic players-dict row that mimics the live contract.
+
+    By default ``rule_contributions_detail`` is omitted (matching the
+    pre-refactor contract shape) so most tests exercise the
+    sandbox's fallback path.  Tests that want to exercise the
+    precise per-rule path pass an explicit ``rule_contributions_detail``."""
     if rule_contributions is None:
         rule_contributions = {
             "te_premium": -0.4,
             "first_downs": 2.5,
             "receptions": -2.0,
         }
+    scoring_adj = {
+        "final_scoring_delta_points": (
+            rule_contributions.get("te_premium", 0.0)
+            + rule_contributions.get("first_downs", 0.0)
+            + rule_contributions.get("receptions", 0.0)
+        ),
+        "rule_contributions": dict(rule_contributions),
+        "archetype": "chain_mover",
+        "confidence": 0.7,
+    }
+    if rule_contributions_detail is not None:
+        scoring_adj["rule_contributions_detail"] = dict(rule_contributions_detail)
     return {
         "displayName": name,
         "_sleeperId": sleeper_id or name.lower().replace(" ", "_"),
@@ -58,16 +76,7 @@ def _make_te_row(
         "_formatFitPPGTest": ppg_baseline,
         "_formatFitPPGCustom": ppg_league,
         "rookie": rookie,
-        "_scoringAdjustment": {
-            "final_scoring_delta_points": (
-                rule_contributions.get("te_premium", 0.0)
-                + rule_contributions.get("first_downs", 0.0)
-                + rule_contributions.get("receptions", 0.0)
-            ),
-            "rule_contributions": dict(rule_contributions),
-            "archetype": "chain_mover",
-            "confidence": 0.7,
-        },
+        "_scoringAdjustment": scoring_adj,
     }
 
 
@@ -266,6 +275,118 @@ def test_scoring_effect_removes_both_rules():
     # Drop both: +0.4 (rec) + -2.5 (1d) → swing -2.1
     assert eff[0].scoring_swing_ppg == pytest.approx(-2.1)
     assert eff[0].proposed_ppg_delta == pytest.approx(0.1 - 2.1)
+
+
+def test_scoring_effect_uses_detail_map_when_available():
+    """When the contract carries `rule_contributions_detail.bonus_fd_te`,
+    the sandbox isolates ONLY that rule for the first-down toggle —
+    not the aggregate `first_downs` category which on TE rows pools
+    `rec_fd` / `rush_fd` contributions too.
+
+    This is the fix for the Codex P1 review: removing the entire
+    `first_downs` category over-removes when league rec_fd/rush_fd
+    differs from baseline."""
+    rows = [
+        _make_te_row(
+            "Bowers",
+            rule_contributions={
+                "te_premium": -0.4,
+                # Aggregate `first_downs` of 2.5 = bonus_fd_te (1.5)
+                # + rec_fd contribution (1.0) for a league with
+                # non-zero rec_fd delta.  Removing the aggregate
+                # would over-remove by 1.0 PPG.
+                "first_downs": 2.5,
+                "receptions": -2.0,
+            },
+            rule_contributions_detail={
+                "bonus_fd_te": 1.5,
+                "bonus_rec_te": -0.4,
+            },
+        )
+    ]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    eff = tep.compute_internal_scoring_effect(
+        extracted,
+        remove_te_reception_bonus=False,
+        remove_te_first_down_bonus=True,
+    )
+    # Removing only the TE first-down BONUS (not the rec_fd portion)
+    # should swing PPG by exactly bonus_fd_te = -1.5, not the
+    # aggregate -2.5.
+    assert eff[0].te_first_down_ppg == pytest.approx(1.5)
+    assert eff[0].scoring_swing_ppg == pytest.approx(-1.5)
+    assert eff[0].te_fd_estimated is False
+    assert eff[0].te_fd_source == "rule_contributions_detail.bonus_fd_te"
+
+
+def test_scoring_effect_falls_back_with_estimation_flag_when_detail_missing():
+    """When the detail map isn't in the contract (older scrape), the
+    sandbox falls back to the aggregate `first_downs` category and
+    flags the row `te_fd_estimated=True` so the operator sees the
+    precision is limited."""
+    rows = [
+        _make_te_row(
+            "Legacy",
+            rule_contributions={
+                "te_premium": -0.4,
+                "first_downs": 2.5,
+                "receptions": -2.0,
+            },
+            # No rule_contributions_detail — older contract shape.
+            rule_contributions_detail=None,
+        )
+    ]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    eff = tep.compute_internal_scoring_effect(
+        extracted, remove_te_first_down_bonus=True,
+    )
+    assert eff[0].te_fd_estimated is True
+    assert "estimated" in eff[0].te_fd_source.lower()
+    # Falls back to aggregate first_downs.
+    assert eff[0].te_first_down_ppg == pytest.approx(2.5)
+
+
+def test_run_analysis_warns_when_any_te_uses_estimated_first_down():
+    rows = [
+        _make_te_row(f"Legacy {i}", composite=9000 - i * 200) for i in range(5)
+    ]
+    contract = _make_contract(rows)
+    payload = tep.run_analysis(contract)
+    warnings_text = " ".join(payload.get("warnings") or [])
+    assert "rule_contributions_detail" in warnings_text or "estimated" in warnings_text.lower()
+
+
+def test_run_analysis_does_not_warn_when_detail_present():
+    rows = [
+        _make_te_row(
+            f"Modern {i}",
+            composite=9000 - i * 200,
+            rule_contributions_detail={"bonus_fd_te": 0.5, "bonus_rec_te": -0.4},
+        )
+        for i in range(5)
+    ]
+    contract = _make_contract(rows)
+    boards = {
+        "normal": {f"modern {i}": 9000 - i * 200 for i in range(5)},
+        "premium": {f"modern {i}": (9000 - i * 200) * 1.1 for i in range(5)},
+        "normal_available": True,
+        "premium_available": True,
+    }
+    payload = tep.run_analysis(contract, boards=boards)
+    warnings_text = " ".join(payload.get("warnings") or [])
+    assert "estimated" not in warnings_text.lower()
+    assert "rule_contributions_detail" not in warnings_text
+
+
+def test_overview_warns_when_detail_map_missing():
+    rows = [_make_te_row("Legacy", composite=8000)]
+    contract = _make_contract(rows)
+    ov = tep.build_overview(
+        contract,
+        boards={"normal": {"legacy": 8000}, "premium": {"legacy": 8500},
+                "normal_available": True, "premium_available": True},
+    )
+    assert any("rule_contributions_detail" in w for w in ov["warnings"])
 
 
 def test_scoring_effect_removes_neither_is_noop():

--- a/tests/research/test_te_premium.py
+++ b/tests/research/test_te_premium.py
@@ -480,6 +480,103 @@ def test_recommendations_clip_to_safety_bounds():
     assert any("clipped" in n for n in recs[0].notes)
 
 
+def test_recommendations_skip_market_unwind_when_no_tep_rule_removed():
+    """Codex P1 fix: when neither TEP rule is being removed, the
+    market unwind should be zero so a lineup-only scenario doesn't
+    spuriously knock down TE values via the external KTC TEP signal.
+
+    A 2-TE-start scenario with TEP scoring still in place should
+    produce a positive (or zero) recommendation, not a negative one
+    driven by the KTC premium that's still applicable."""
+    rows = [_make_te_row("Brock Bowers", composite=8000, ppg_league=14.0)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    boards = {
+        "normal": {"brock bowers": 5000.0},
+        "premium": {"brock bowers": 7500.0},  # +50% market boost
+    }
+    boosts = tep.compute_external_market_boost(extracted, boards=boards)
+    scoring_no_removal = tep.compute_internal_scoring_effect(
+        extracted,
+        remove_te_reception_bonus=False,
+        remove_te_first_down_bonus=False,
+    )
+    scarcity, _ = tep.compute_scarcity_effect(extracted)
+    recs = tep.build_recommendations(
+        extracted,
+        boost_rows=boosts,
+        scoring_rows=scoring_no_removal,
+        scarcity_rows=scarcity,
+        market_available=True,
+        remove_te_reception_bonus=False,
+        remove_te_first_down_bonus=False,
+    )
+    # No TEP rule removed → market unwind = 0.  With a single-player
+    # pool the scarcity delta is also ~0, so the rec collapses to ~0
+    # rather than the -25% it would be if the market were unwound.
+    assert recs[0].recommended_adjustment_pct >= -0.05
+    # And the market_boost_pct is still surfaced for transparency.
+    assert recs[0].market_boost_pct is not None
+
+
+def test_recommendations_apply_market_unwind_when_either_tep_rule_removed():
+    """Removing only the reception bonus (not the first-down bonus)
+    is still a TEP-removal scenario, so market unwind should fire."""
+    rows = [_make_te_row("Brock Bowers", composite=8000)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    boards = {
+        "normal": {"brock bowers": 5000.0},
+        "premium": {"brock bowers": 6000.0},
+    }
+    boosts = tep.compute_external_market_boost(extracted, boards=boards)
+    scoring = tep.compute_internal_scoring_effect(extracted)
+    scarcity, _ = tep.compute_scarcity_effect(extracted)
+    recs_only_rec = tep.build_recommendations(
+        extracted,
+        boost_rows=boosts,
+        scoring_rows=scoring,
+        scarcity_rows=scarcity,
+        market_available=True,
+        remove_te_reception_bonus=True,
+        remove_te_first_down_bonus=False,
+    )
+    recs_neither = tep.build_recommendations(
+        extracted,
+        boost_rows=boosts,
+        scoring_rows=scoring,
+        scarcity_rows=scarcity,
+        market_available=True,
+        remove_te_reception_bonus=False,
+        remove_te_first_down_bonus=False,
+    )
+    # The "remove rec only" recommendation must be more negative than
+    # the "remove neither" recommendation (the difference is the
+    # market unwind, which only applies in the first case).
+    assert recs_only_rec[0].recommended_adjustment_pct < recs_neither[0].recommended_adjustment_pct
+
+
+def test_run_analysis_run_id_has_subsecond_entropy():
+    """Codex P2: two analyses started in the same wallclock second
+    must produce distinct run_ids so persist=true never overwrites
+    a prior file."""
+    rows = [_make_te_row(f"TE{i}", composite=9000 - i * 200) for i in range(3)]
+    contract = _make_contract(rows)
+    p1 = tep.run_analysis(contract)
+    p2 = tep.run_analysis(contract)
+    assert p1["run_id"] != p2["run_id"]
+    # Sanity: the new format includes a microsecond block + uuid suffix.
+    parts = p1["run_id"].rstrip("Z").split("_")
+    assert len(parts) == 3, f"unexpected run_id format: {p1['run_id']}"
+
+
+def test_run_analysis_persist_does_not_overwrite_in_rapid_succession(tmp_path):
+    rows = [_make_te_row(f"TE{i}", composite=9000 - i * 200) for i in range(3)]
+    contract = _make_contract(rows)
+    tep.run_analysis(contract, persist=True, sandbox_dir=tmp_path)
+    tep.run_analysis(contract, persist=True, sandbox_dir=tmp_path)
+    files = list(tmp_path.glob("te_premium_*.json"))
+    assert len(files) == 2, "second persist run silently overwrote the first"
+
+
 def test_recommendations_use_tier_default_when_no_market():
     rows = [_make_te_row("Bowers", composite=8000)]
     extracted = tep.extract_te_players_from_contract(_make_contract(rows))

--- a/tests/research/test_te_premium.py
+++ b/tests/research/test_te_premium.py
@@ -1,0 +1,474 @@
+"""Unit tests for the TE Premium Lab sandbox analysis.
+
+Coverage:
+
+* Boost math (raw, percentage, log-ratio, near-zero handling)
+* TE row extraction from both ``players`` dict and ``playersArray``
+* Internal scoring effect — toggles off TE reception bonus, TE 1D
+  bonus, or both
+* Scarcity effect — VOR delta is positive going from 12 to 24 starters
+* Tier assignment — rank thresholds + age tags
+* End-to-end run_analysis returns the documented payload shape
+* MUTATION SAFETY — analysis never modifies the input contract or the
+  TE rows passed in (the contract dict is deep-compared before/after)
+* Graceful degradation when external boards are unavailable
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from src.research import te_premium as tep
+
+
+def _make_te_row(
+    name: str,
+    *,
+    sleeper_id: str | None = None,
+    composite: float = 5000,
+    age: int = 26,
+    team: str = "BUF",
+    rule_contributions: dict | None = None,
+    ppg_baseline: float = 12.0,
+    ppg_league: float = 11.5,
+    ktc: float | None = 6500,
+    ktc_sf_tep: float | None = 7000,
+    rookie: bool = False,
+) -> dict:
+    """Build a synthetic players-dict row that mimics the live contract."""
+    if rule_contributions is None:
+        rule_contributions = {
+            "te_premium": -0.4,
+            "first_downs": 2.5,
+            "receptions": -2.0,
+        }
+    return {
+        "displayName": name,
+        "_sleeperId": sleeper_id or name.lower().replace(" ", "_"),
+        "position": "TE",
+        "age": age,
+        "team": team,
+        "_composite": composite,
+        "rankDerivedValue": composite,
+        "ktc": ktc,
+        "ktcSfTep": ktc_sf_tep,
+        "_formatFitPPGTest": ppg_baseline,
+        "_formatFitPPGCustom": ppg_league,
+        "rookie": rookie,
+        "_scoringAdjustment": {
+            "final_scoring_delta_points": (
+                rule_contributions.get("te_premium", 0.0)
+                + rule_contributions.get("first_downs", 0.0)
+                + rule_contributions.get("receptions", 0.0)
+            ),
+            "rule_contributions": dict(rule_contributions),
+            "archetype": "chain_mover",
+            "confidence": 0.7,
+        },
+    }
+
+
+def _make_contract(te_rows: list[dict]) -> dict:
+    """Wrap TE rows in a minimal ``players`` dict contract."""
+    return {
+        "players": {row["displayName"]: row for row in te_rows},
+    }
+
+
+# ── Extraction ───────────────────────────────────────────────────────
+
+
+def test_extract_te_players_from_players_dict():
+    contract = _make_contract([_make_te_row("Brock Bowers", composite=8000)])
+    rows = tep.extract_te_players_from_contract(contract)
+    assert len(rows) == 1
+    assert rows[0]["display_name"] == "Brock Bowers"
+    assert rows[0]["position"] == "TE"
+    assert rows[0]["te_pool_rank"] == 1
+    assert rows[0]["current_value"] == 8000
+
+
+def test_extract_te_players_from_players_array():
+    row = _make_te_row("Sam LaPorta", composite=6000)
+    row["displayName"] = "Sam LaPorta"
+    contract = {"playersArray": [row]}
+    rows = tep.extract_te_players_from_contract(contract)
+    assert len(rows) == 1
+    assert rows[0]["display_name"] == "Sam LaPorta"
+
+
+def test_extract_skips_non_te():
+    contract = {
+        "players": {
+            "Josh Allen": {
+                "displayName": "Josh Allen",
+                "position": "QB",
+                "_composite": 9999,
+                "_sleeperId": "qb1",
+            },
+            "Brock Bowers": _make_te_row("Brock Bowers"),
+        }
+    }
+    rows = tep.extract_te_players_from_contract(contract)
+    names = [r["display_name"] for r in rows]
+    assert names == ["Brock Bowers"]
+
+
+def test_extract_dedupes_by_sleeper_id_when_both_shapes_present():
+    row = _make_te_row("Brock Bowers", sleeper_id="11604")
+    contract = {
+        "players": {"Brock Bowers": row},
+        "playersArray": [row],
+    }
+    rows = tep.extract_te_players_from_contract(contract)
+    assert len(rows) == 1
+
+
+def test_extract_assigns_te_pool_rank_descending_by_value():
+    rows = [
+        _make_te_row("Mid TE", composite=5000),
+        _make_te_row("Top TE", composite=9000),
+        _make_te_row("Low TE", composite=1000),
+    ]
+    contract = _make_contract(rows)
+    extracted = tep.extract_te_players_from_contract(contract)
+    by_name = {r["display_name"]: r["te_pool_rank"] for r in extracted}
+    assert by_name == {"Top TE": 1, "Mid TE": 2, "Low TE": 3}
+
+
+# ── External boost math ──────────────────────────────────────────────
+
+
+def test_boost_basic_math():
+    rows = [_make_te_row("Brock Bowers", composite=8000)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    boards = {
+        "normal": {"brock bowers": 9000.0},
+        "premium": {"brock bowers": 9500.0},
+    }
+    boosts = tep.compute_external_market_boost(extracted, boards=boards)
+    assert len(boosts) == 1
+    b = boosts[0]
+    assert b.normal_value == 9000.0
+    assert b.premium_value == 9500.0
+    assert b.boost_abs == pytest.approx(500.0)
+    assert b.boost_pct == pytest.approx(500.0 / 9000.0)
+    assert b.log_ratio == pytest.approx(__import__("math").log(9500.0 / 9000.0))
+    assert b.reliable is True
+    assert b.note == ""
+
+
+def test_boost_near_zero_flagged_unreliable():
+    # Use a name without a trailing position-letter pair so the
+    # name-normaliser doesn't strip it (it strips " te"/" rb"/etc.).
+    rows = [_make_te_row("Deep Reserve", composite=400)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    boards = {
+        "normal": {"deep reserve": 50.0},  # below floor 200
+        "premium": {"deep reserve": 250.0},
+    }
+    boosts = tep.compute_external_market_boost(extracted, boards=boards)
+    b = boosts[0]
+    assert b.reliable is False
+    assert "below floor" in b.note
+    # boost_pct uses floor as denominator, never returns infinity
+    assert b.boost_pct is not None
+    assert abs(b.boost_pct) < 5.0  # sanity bound
+
+
+def test_boost_missing_premium_value_flagged_unreliable():
+    rows = [_make_te_row("Brock Bowers", composite=8000)]
+    boards = {
+        "normal": {"brock bowers": 9000.0},
+        "premium": {},
+    }
+    # The orchestrator returns no boards if either side is empty.
+    boosts = tep.compute_external_market_boost(rows, boards=boards)
+    assert boosts == []
+
+
+def test_boost_partial_normal_only_skips_player():
+    """If both boards exist but a single player only appears in one,
+    we still emit a row with reliable=False so the operator sees
+    the gap explicitly."""
+    rows = [_make_te_row("Brock Bowers", composite=8000)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    boards = {
+        "normal": {"brock bowers": 9000.0, "other te": 5000.0},
+        "premium": {"other te": 6000.0},
+    }
+    boosts = tep.compute_external_market_boost(extracted, boards=boards)
+    assert len(boosts) == 1
+    assert boosts[0].reliable is False
+    assert "missing on premium" in boosts[0].note
+
+
+def test_boost_rank_change_signed():
+    rows = [
+        _make_te_row("Alpha Player", composite=9000),
+        _make_te_row("Beta Player", composite=5000),
+    ]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    boards = {
+        "normal": {"alpha player": 9000.0, "beta player": 5000.0},
+        "premium": {"alpha player": 9000.0, "beta player": 9500.0},
+    }
+    boosts = tep.compute_external_market_boost(extracted, boards=boards)
+    by_name = {b.display_name: b for b in boosts}
+    # Beta jumps to premium #1 (was #2) → rank_change = +1
+    assert by_name["Beta Player"].rank_change == 1
+    # Alpha drops to premium #2 (was #1) → rank_change = -1
+    assert by_name["Alpha Player"].rank_change == -1
+
+
+# ── Scoring effect ───────────────────────────────────────────────────
+
+
+def test_scoring_effect_removes_te_premium_only():
+    rows = [
+        _make_te_row(
+            "Bowers",
+            rule_contributions={"te_premium": -0.4, "first_downs": 2.5, "receptions": -2.0},
+        )
+    ]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    eff = tep.compute_internal_scoring_effect(
+        extracted,
+        remove_te_reception_bonus=True,
+        remove_te_first_down_bonus=False,
+    )
+    assert len(eff) == 1
+    # current = -0.4 + 2.5 - 2.0 = 0.1; remove te_premium (-0.4) → +0.5
+    assert eff[0].current_ppg_delta == pytest.approx(0.1)
+    assert eff[0].te_premium_ppg == pytest.approx(-0.4)
+    assert eff[0].te_first_down_ppg == pytest.approx(2.5)
+    assert eff[0].proposed_ppg_delta == pytest.approx(0.5)
+    # Removing a negative-contribution rule lifts the projection
+    assert eff[0].scoring_swing_ppg == pytest.approx(0.4)
+
+
+def test_scoring_effect_removes_both_rules():
+    rows = [
+        _make_te_row(
+            "Bowers",
+            rule_contributions={"te_premium": -0.4, "first_downs": 2.5, "receptions": -2.0},
+        )
+    ]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    eff = tep.compute_internal_scoring_effect(
+        extracted,
+        remove_te_reception_bonus=True,
+        remove_te_first_down_bonus=True,
+    )
+    # Drop both: +0.4 (rec) + -2.5 (1d) → swing -2.1
+    assert eff[0].scoring_swing_ppg == pytest.approx(-2.1)
+    assert eff[0].proposed_ppg_delta == pytest.approx(0.1 - 2.1)
+
+
+def test_scoring_effect_removes_neither_is_noop():
+    rows = [
+        _make_te_row(
+            "Bowers",
+            rule_contributions={"te_premium": -0.4, "first_downs": 2.5},
+        )
+    ]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    eff = tep.compute_internal_scoring_effect(
+        extracted,
+        remove_te_reception_bonus=False,
+        remove_te_first_down_bonus=False,
+    )
+    assert eff[0].scoring_swing_ppg == pytest.approx(0.0)
+    assert eff[0].proposed_ppg_delta == pytest.approx(eff[0].current_ppg_delta)
+
+
+# ── Scarcity effect ──────────────────────────────────────────────────
+
+
+def test_scarcity_two_te_lowers_replacement_pace():
+    rows = [_make_te_row(f"TE{i}", composite=8000 - i * 100, ppg_league=14 - i * 0.4) for i in range(40)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    sc_rows, summary = tep.compute_scarcity_effect(
+        extracted,
+        one_te_starters=12,
+        two_te_starters=24,
+    )
+    assert summary["replacement_two_te_ppg"] < summary["replacement_one_te_ppg"]
+    # VOR rises for every TE when we go to 2-TE start
+    assert all(r.vor_two_te >= r.vor_one_te - 1e-6 for r in sc_rows)
+    assert summary["avg_vor_delta"] > 0
+
+
+def test_scarcity_skips_players_with_no_ppg():
+    row = _make_te_row("Bowers")
+    row["_formatFitPPGTest"] = None
+    row["_formatFitPPGCustom"] = None
+    extracted = tep.extract_te_players_from_contract(_make_contract([row]))
+    sc_rows, summary = tep.compute_scarcity_effect(extracted)
+    assert sc_rows == []
+    assert summary["evaluable_tes"] == 0
+
+
+# ── Tier assignment ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "rank,age,expected_tier_key,expected_age",
+    [
+        (1, 22, "elite_te1", "young_upside"),
+        (3, 26, "elite_te1", ""),
+        (8, 31, "strong_te1", "older_productive"),
+        (12, 24, "back_te1", "young_upside"),
+        (20, 27, "te2", ""),
+        (50, 30, "depth", "older_productive"),
+        (200, 22, "deep", "young_upside"),
+        (None, 25, "deep", "young_upside"),
+    ],
+)
+def test_assign_te_tier(rank, age, expected_tier_key, expected_age):
+    out = tep.assign_te_tier(rank, age)
+    assert out["tier_key"] == expected_tier_key
+    assert out["age_tag"] == expected_age
+
+
+# ── Recommendations ──────────────────────────────────────────────────
+
+
+def test_recommendations_clip_to_safety_bounds():
+    """Even with absurdly large signals, recommended_pct stays in ±25%."""
+    rows = [_make_te_row("Brock Bowers", composite=8000)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    boards = {
+        "normal": {"brock bowers": 5000.0},
+        "premium": {"brock bowers": 50000.0},  # +900% boost
+    }
+    boosts = tep.compute_external_market_boost(extracted, boards=boards)
+    scoring = tep.compute_internal_scoring_effect(extracted)
+    scarcity, _ = tep.compute_scarcity_effect(extracted)
+    recs = tep.build_recommendations(
+        extracted,
+        boost_rows=boosts,
+        scoring_rows=scoring,
+        scarcity_rows=scarcity,
+        market_available=True,
+    )
+    assert -0.25 <= recs[0].recommended_adjustment_pct <= 0.25
+    assert any("clipped" in n for n in recs[0].notes)
+
+
+def test_recommendations_use_tier_default_when_no_market():
+    rows = [_make_te_row("Bowers", composite=8000)]
+    extracted = tep.extract_te_players_from_contract(_make_contract(rows))
+    scoring = tep.compute_internal_scoring_effect(extracted)
+    scarcity, _ = tep.compute_scarcity_effect(extracted)
+    recs = tep.build_recommendations(
+        extracted,
+        boost_rows=[],
+        scoring_rows=scoring,
+        scarcity_rows=scarcity,
+        market_available=False,
+    )
+    assert any("tier default" in n for n in recs[0].notes)
+
+
+# ── End-to-end + safety ──────────────────────────────────────────────
+
+
+def test_run_analysis_returns_documented_shape(monkeypatch):
+    rows = [
+        _make_te_row(f"TE{i}", composite=9000 - i * 200, ppg_league=14 - i * 0.3)
+        for i in range(20)
+    ]
+    contract = _make_contract(rows)
+    boards = {
+        "normal": {f"te{i}": 9000 - i * 200 for i in range(20)},
+        "premium": {f"te{i}": (9000 - i * 200) * 1.1 for i in range(20)},
+        "normal_available": True,
+        "premium_available": True,
+    }
+    payload = tep.run_analysis(contract, boards=boards)
+    assert payload["sandbox"] is True
+    assert payload["scenario"]["remove_te_reception_bonus"] is True
+    assert "summary" in payload
+    assert "recommendations" in payload
+    assert "tier_summary" in payload
+    assert "external_boost" in payload
+    assert "scoring_effect" in payload
+    assert "scarcity_effect" in payload
+    assert payload["summary"]["te_count"] == 20
+
+
+def test_run_analysis_does_not_mutate_input_contract():
+    """The single most important safety property: every analysis is a
+    pure read.  Deep-compare the contract before and after."""
+    rows = [_make_te_row(f"TE{i}", composite=9000 - i * 200) for i in range(15)]
+    contract = _make_contract(rows)
+    snapshot = json.dumps(contract, sort_keys=True, default=str)
+    tep.run_analysis(contract)
+    after = json.dumps(contract, sort_keys=True, default=str)
+    assert snapshot == after, "run_analysis mutated its input contract"
+
+
+def test_run_analysis_does_not_persist_unless_asked(tmp_path):
+    rows = [_make_te_row(f"TE{i}", composite=9000 - i * 200) for i in range(10)]
+    contract = _make_contract(rows)
+    payload = tep.run_analysis(contract, sandbox_dir=tmp_path)
+    # Nothing written on the default path
+    assert list(tmp_path.glob("*.json")) == []
+    assert "persisted_path" not in payload
+
+
+def test_run_analysis_persists_when_asked(tmp_path):
+    rows = [_make_te_row(f"TE{i}", composite=9000 - i * 200) for i in range(5)]
+    contract = _make_contract(rows)
+    payload = tep.run_analysis(contract, persist=True, sandbox_dir=tmp_path)
+    files = list(tmp_path.glob("te_premium_*.json"))
+    assert len(files) == 1
+    assert payload.get("persisted_path") == str(files[0])
+    on_disk = json.loads(files[0].read_text())
+    assert on_disk["sandbox"] is True
+
+
+def test_build_overview_warns_when_no_te_rows():
+    contract = {"players": {}}
+    ov = tep.build_overview(contract, boards={"normal": {}, "premium": {}, "normal_available": False, "premium_available": False})
+    assert ov["te_count"] == 0
+    assert any("No TE rows" in w for w in ov["warnings"])
+    assert ov["sandbox"] is True
+
+
+def test_run_analysis_handles_empty_contract():
+    payload = tep.run_analysis({}, boards={"normal": {}, "premium": {}})
+    assert payload["summary"]["te_count"] == 0
+    assert payload["recommendations"] == []
+
+
+# ── External board loader ────────────────────────────────────────────
+
+
+def test_load_external_ktc_boards_handles_missing_files(tmp_path):
+    boards = tep.load_external_ktc_boards(
+        normal_path=tmp_path / "missing_normal.csv",
+        premium_path=tmp_path / "missing_premium.csv",
+    )
+    assert boards["normal_available"] is False
+    assert boards["premium_available"] is False
+    assert boards["normal"] == {}
+    assert boards["premium"] == {}
+
+
+def test_load_external_ktc_boards_reads_real_files(tmp_path):
+    csv_path = tmp_path / "ktc.csv"
+    csv_path.write_text("name,value\nBrock Bowers,9000\nSam LaPorta,7500\n")
+    premium_path = tmp_path / "ktcSfTep.csv"
+    premium_path.write_text("name,value\nBrock Bowers,9500\nSam LaPorta,8200\n")
+    boards = tep.load_external_ktc_boards(
+        normal_path=csv_path, premium_path=premium_path,
+    )
+    assert boards["normal_available"] is True
+    assert boards["premium_available"] is True
+    assert boards["normal"]["brock bowers"] == 9000.0
+    assert boards["premium"]["sam laporta"] == 8200.0

--- a/tests/research/test_te_premium.py
+++ b/tests/research/test_te_premium.py
@@ -577,6 +577,61 @@ def test_run_analysis_persist_does_not_overwrite_in_rapid_succession(tmp_path):
     assert len(files) == 2, "second persist run silently overwrote the first"
 
 
+def test_lineup_settings_two_te_is_noop_when_league_already_starts_two():
+    """Codex P2 fix: in a league whose starters.TE is already 2,
+    the "Start 2 TEs" toggle should be a no-op rather than adding
+    another TE per team (which would over-model scarcity)."""
+    class _FakeCfg:
+        roster_settings = {
+            "teamCount": 12,
+            "starters": {
+                "QB": 1, "RB": 2, "WR": 3, "TE": 2,  # already 2
+                "FLEX": 1, "SFLEX": 1,
+            },
+        }
+
+    out = tep._league_lineup_settings(_FakeCfg())
+    assert out["te_starters_one"] == out["te_starters_two"]
+    assert out["two_te_is_noop"] is True
+    assert out["direct_te_per_team_current"] == 2
+
+
+def test_lineup_settings_two_te_adds_one_te_per_team_when_league_starts_one():
+    """Default case: TE=1 → 2-TE toggle adds one direct starter per team."""
+    class _FakeCfg:
+        roster_settings = {
+            "teamCount": 12,
+            "starters": {
+                "QB": 1, "RB": 2, "WR": 3, "TE": 1,
+                "FLEX": 2, "SFLEX": 1,
+            },
+        }
+
+    out = tep._league_lineup_settings(_FakeCfg())
+    assert out["te_starters_two"] == out["te_starters_one"] + 12
+    assert out["two_te_is_noop"] is False
+    assert out["direct_te_per_team_current"] == 1
+    assert out["direct_te_per_team_proposed"] == 2
+
+
+def test_lineup_settings_two_te_handles_zero_direct_te():
+    """Edge: a league with no direct TE slot (TE only via flex).
+    Going to "Start 2 TEs" should add 2 starters per team."""
+    class _FakeCfg:
+        roster_settings = {
+            "teamCount": 10,
+            "starters": {
+                "QB": 1, "RB": 2, "WR": 3, "FLEX": 2, "SFLEX": 1,
+            },
+        }
+
+    out = tep._league_lineup_settings(_FakeCfg())
+    # 2 TEs/team × 10 teams = 20 added on top of flex contributions.
+    assert out["te_starters_two"] - out["te_starters_one"] == 20
+    assert out["two_te_is_noop"] is False
+    assert out["direct_te_per_team_current"] == 0
+
+
 def test_recommendations_use_tier_default_when_no_market():
     rows = [_make_te_row("Bowers", composite=8000)]
     extracted = tep.extract_te_players_from_contract(_make_contract(rows))

--- a/tests/scoring/test_scoring_modules.py
+++ b/tests/scoring/test_scoring_modules.py
@@ -8,7 +8,13 @@ from src.scoring.player_adjustment import (
     build_player_scoring_adjustment,
     ratio_to_multiplier,
 )
-from src.scoring.scoring_delta import compare_to_baseline, persist_scoring_delta_map
+from src.scoring.scoring_delta import (
+    RULE_CONTRIBUTION_DETAIL_KEYS,
+    bucket_rule_contributions,
+    bucket_rule_contributions_detail,
+    compare_to_baseline,
+    persist_scoring_delta_map,
+)
 from src.scoring.sleeper_ingest import normalize_scoring_settings
 
 
@@ -84,6 +90,81 @@ class ScoringModuleTests(unittest.TestCase):
                 payload = json.load(f)
             self.assertEqual(payload["customLeagueId"], "123")
             self.assertTrue(any(r.get("key") == "pass_td" for r in payload.get("rules", [])))
+
+
+    def test_bucket_rule_contributions_detail_isolates_te_bonus(self):
+        """`bucket_rule_contributions` aggregates `bonus_fd_te` and
+        `rec_fd` into a single `first_downs` bucket on TE rows; the
+        `_detail` variant emits each per rule key so the TE Premium
+        Lab can isolate just the TE-bonus portion."""
+        baseline = build_default_baseline_config("b")
+        # League differs from baseline on rec_fd (default 0 → 0.5)
+        # AND on bonus_fd_te (default 0 → 0.5), but NOT on
+        # bonus_rec_te (the default baseline already carries 0.5;
+        # we bump to 1.0 to force a non-zero delta we can read).
+        league = normalize_scoring_settings(
+            {
+                "rec": 1.0,
+                "rec_fd": 0.5,
+                "bonus_rec_te": 1.0,
+                "bonus_fd_te": 0.5,
+            },
+            ["TE"],
+            league_id="l",
+        )
+        delta_rules = compare_to_baseline(baseline, league)
+        stats = {
+            "rec": 6.0,
+            "rec_fd": 1.0,
+            "bonus_rec_te": 6.0,  # same as rec for a TE
+            "bonus_fd_te": 1.0,
+        }
+        agg = bucket_rule_contributions("TE", stats, delta_rules)
+        # Aggregate `first_downs` pools rec_fd (1.0 × 0.5 = 0.5) +
+        # bonus_fd_te (1.0 × 0.5 = 0.5) = 1.0 total.
+        self.assertAlmostEqual(agg.get("first_downs", 0.0), 1.0, places=4)
+
+        detail = bucket_rule_contributions_detail("TE", stats, delta_rules)
+        # Detail keeps them separated by rule key.
+        self.assertAlmostEqual(detail.get("bonus_fd_te", 0.0), 0.5, places=4)
+        # bonus_rec_te delta = 1.0 - 0.5 = 0.5; stat = 6 → 6 × 0.5 = 3.0
+        self.assertAlmostEqual(detail.get("bonus_rec_te", 0.0), 3.0, places=4)
+        self.assertNotIn("rec_fd", detail)  # not in the detail allowlist
+
+    def test_bucket_rule_contributions_detail_skips_irrelevant_buckets(self):
+        baseline = build_default_baseline_config("b")
+        league = normalize_scoring_settings(
+            {"bonus_fd_te": 0.5, "bonus_rec_te": 0.5},
+            ["TE"],
+            league_id="l",
+        )
+        delta_rules = compare_to_baseline(baseline, league)
+        # On a QB row, neither TE-bonus rule is relevant — should be
+        # absent from the detail map.
+        detail = bucket_rule_contributions_detail(
+            "QB", {"bonus_fd_te": 5.0, "bonus_rec_te": 5.0}, delta_rules
+        )
+        self.assertEqual(detail, {})
+
+    def test_player_adjustment_carries_detail_map(self):
+        adj = build_player_scoring_adjustment(
+            baseline_scoring_version="b",
+            league_scoring_version="l",
+            league_id="123",
+            baseline_ppg=12.0,
+            league_ppg=13.0,
+            position_bucket="TE",
+            archetype="chain_mover",
+            confidence=0.7,
+            sample_size_score=0.5,
+            projection_weight=0.2,
+            data_quality_flag="ok",
+            scoring_tags=[],
+            rule_contributions={"te_premium": 0.5, "first_downs": 0.5},
+            rule_contributions_detail={"bonus_rec_te": 0.5, "bonus_fd_te": 0.5},
+        )
+        self.assertEqual(adj.rule_contributions_detail.get("bonus_fd_te"), 0.5)
+        self.assertEqual(adj.rule_contributions_detail.get("bonus_rec_te"), 0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a research-only **Tight End Premium Lab** at `/te-premium-lab` that lets us answer:

> "If we remove TE Premium scoring (extra TE reception bonus + extra TE first-down bonus) but require teams to start two tight ends, how should TE values shift compared to today?"

**Critical safety property:** Nothing on this page touches live values. Every code path is forbidden from mutating `latest_contract_data` or any persisted ranking field. The page surfaces a "Research only" banner so projections never get confused with applied changes. Mutation-safety unit tests deep-compare the input contract before/after every endpoint call.

## What it computes

The page separates four signals so the operator can see them independently before deciding on an adjustment:

1. **External market TE-Premium boost** — for every source where we have both a normal and a TE-Premium board, the per-player percentage boost the market applies. Today only KTC ships both boards from one scrape (`CSVs/site_raw/ktc.csv` vs `CSVs/site_raw/ktcSfTep.csv`); other sources are flagged unavailable rather than guessed. Math: `(premium - normal) / max(normal, floor)` with a near-zero floor + reliability flag. KTC TE++ (Level 2) is in the API response but isn't currently extracted by `Dynasty Scraper.py` — flagged in the UI with a TODO.

2. **Internal scoring effect** — strips the `te_premium` category contribution + the TE first-down contribution from each TE's pre-computed `rule_contributions` map (already on every offensive row in the live contract via `src/scoring/scoring_delta.py`). No second scoring engine; we read what the canonical pipeline already produced.

3. **Internal scarcity effect** — runs `src/scoring/replacement_level.py::vorp_table` against both 1-TE and 2-TE starter counts, derived from the league registry's actual roster settings (flex/superflex contributions included). Replacement PPG drops, every TE's VOR rises, and we report the per-player and average swing.

4. **Per-player + per-tier net recommendation** — combines the three signals (sign-flipping the market boost since we *unwind* TEP), clips to ±25% for safety, attaches confidence as a geometric mean of per-component reliabilities, and surfaces tier-level rollups (Elite TE1 / Strong TE1 / Low TE1-High TE2 / TE2 / Depth / Deep) plus age-tag flags (young upside / older productive).

## API

Five read-only endpoints under `/api/te-premium/*`:

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/te-premium/overview` | Source availability + lineup + warnings |
| GET | `/api/te-premium/source-comparison` | Per-TE KTC normal vs TE+ boost |
| GET | `/api/te-premium/league-scenarios` | Scoring + scarcity comparison |
| POST | `/api/te-premium/run-analysis` | Full sandbox analysis with toggles |
| GET | `/api/te-premium/recommendations` | Default-scenario summary slice |

Each response carries `sandbox: true` and `appliesToLiveValues: false` envelope flags. There is **no** write endpoint that adjusts live values; that promotion path is intentionally absent and would have to be added behind admin-only approval if/when we want to act on the recommendations.

## Frontend

- New page: `frontend/app/te-premium-lab/page.jsx` with four tabs (Summary / External Sources / League Scenarios / Recommendations), scenario toggles, sortable filterable player table, CSV export, and a prominent "Research only" warning banner.
- Linked from `/more` under a new "Research" section.
- Five Next.js proxy routes under `frontend/app/api/te-premium/*`.

## Reused, not duplicated

- `src/canonical/player_valuation.py::rank_to_value` — Hill curve constants
- `src/scoring/replacement_level.py` — VOR + flex-aware starter slot counting
- `src/scoring/scoring_delta.py` — per-rule contribution map (already on every offensive row)
- `src/api/league_registry.py` — `_resolve_league_for_request` for league-aware routing

## Data sources today

| Source | Normal | TE Premium | TE++ | Notes |
|---|---|---|---|---|
| KTC | ✅ | ✅ (Level 1) | ❌ | Both boards in one scrape; TE++ structurally available but not currently extracted |
| DLF SF | ✅ | ❌ | ❌ | Standard SF only |
| FantasyCalc | ✅ | ❌ | ❌ | Site has TEP setting, not currently scraped |
| Manual CSV | — | — | — | Hook in place at `CSVs/site_raw/te_premium_manual.csv` for future imports |

Future work (out of scope here, called out in the page UI):
- Extend `Dynasty Scraper.py::_KTC_TEP_FIELD_KEYS` to extract TE++ (Level 2) — the field is structurally present in the KTC API payload.
- Add manual-CSV upload pipeline for FantasyCalc TEP / DLF TEP if/when we want non-KTC market signals.

## Test plan

- [x] Backend unit tests (33) — boost math, scoring effect toggles, scarcity VOR delta, tier assignment, recommendation clipping, end-to-end shape
- [x] API endpoint tests (15) — all 5 endpoints respond 200, mutation-safety asserts (`latest_contract_data` byte-identical before/after every call), schema stability across runs, persist on/off, empty-contract handling
- [x] Full backend sweep: 1107 tests pass, 6 skipped (no regressions)
- [x] Full frontend sweep: 886 vitest tests pass
- [x] `npm run build:nocheck` — `/te-premium-lab` listed as static route (6.46 kB / 109 kB first-load)
- [ ] Playwright E2E coverage — adding `tests/e2e/specs/te-premium-lab.spec.js` is sensible follow-up work (navigate, toggle scenarios, sort table, verify live values elsewhere unchanged); skipped here to keep the PR focused on the analysis layer
- [ ] Manual smoke against live data once deployed

https://claude.ai/code/session_01K824KNiaNEK6191C2KNDDv

---
_Generated by [Claude Code](https://claude.ai/code/session_01K824KNiaNEK6191C2KNDDv)_