### PR TITLE
fix(rankings): dedupe KTC in player chart, show raw KTC SF-TE++ values

### DIFF
--- a/scripts/backfill_ktc_sftep_raw.py
+++ b/scripts/backfill_ktc_sftep_raw.py
@@ -1,0 +1,179 @@
+"""One-shot backfill: rewrite ``ktcSfTep`` entries in
+``data/source_value_history.jsonl`` to use the raw scrape value from
+the matching ``data/dynasty_data_<date>.json`` instead of the
+Hill-curve ``valueContribution`` that was originally persisted.
+
+Context
+-------
+``ktcSfTep`` is in ``_RAW_VALUE_PREFERRED_KEYS`` (see
+``src/api/source_history.py``) — KTC publishes a public 0-9999 dynasty
+board on keeptradecut.com, so the chart shows the raw scrape (e.g.
+9594 for Brock Bowers on 2026-05-05) instead of the Hill contribution
+(9999) that goes into the blend.  New snapshots from the
+``_extract_player_entry`` change forward are already raw; this
+script back-rewrites the existing 180-day window so the time series
+doesn't show a discontinuity on the day the writer changed.
+
+The script is idempotent: rerunning is a no-op since the second pass
+sees raw values already.  ``--dry-run`` prints the diff without
+writing.
+
+Usage
+-----
+    python -m scripts.backfill_ktc_sftep_raw            # apply
+    python -m scripts.backfill_ktc_sftep_raw --dry-run  # preview
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HISTORY_PATH = ROOT / "data" / "source_value_history.jsonl"
+DATA_DIR = ROOT / "data"
+
+
+def _load_export_top_level_ktc_sftep(date: str) -> dict[str, int]:
+    """Return ``{playerName.lower(): raw_ktc_sftep}`` from the daily
+    export for ``date``, if present.  Empty dict when the file is
+    missing or has no ``ktcSfTep`` data.
+    """
+    export = DATA_DIR / f"dynasty_data_{date}.json"
+    if not export.exists():
+        return {}
+    try:
+        raw = json.loads(export.read_text())
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [warn] failed to read {export}: {exc}", file=sys.stderr)
+        return {}
+    players = raw.get("players")
+    if not isinstance(players, dict):
+        return {}
+    out: dict[str, int] = {}
+    for name, entry in players.items():
+        if not isinstance(entry, dict):
+            continue
+        val = entry.get("ktcSfTep")
+        try:
+            v = int(val) if val is not None else None
+        except (TypeError, ValueError):
+            v = None
+        if v is not None and v > 0:
+            out[str(name).strip().lower()] = v
+    return out
+
+
+def _norm_player_key(snap_key: str) -> str:
+    """``"Brock Bowers::offense"`` → ``"brock bowers"``.  Mirror of
+    ``source_history._norm_name_key`` reduced to just the name half
+    for matching against export player keys.
+    """
+    name = snap_key.split("::")[0]
+    return name.strip().lower()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="preview only")
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=HISTORY_PATH,
+        help="snapshot JSONL path (default: data/source_value_history.jsonl)",
+    )
+    args = parser.parse_args()
+
+    if not args.path.exists():
+        print(f"snapshot file not found: {args.path}", file=sys.stderr)
+        return 1
+
+    lines = args.path.read_text().splitlines()
+    rewritten: list[str] = []
+    total_replaced = 0
+    total_unchanged = 0
+    total_no_export = 0
+    total_dropped_missing = 0
+
+    for line in lines:
+        if not line.strip():
+            rewritten.append(line)
+            continue
+        try:
+            snap = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(f"  [warn] skipping malformed line: {exc}", file=sys.stderr)
+            rewritten.append(line)
+            continue
+
+        date = str(snap.get("date") or "")
+        players = snap.get("players")
+        if not date or not isinstance(players, dict):
+            rewritten.append(line)
+            continue
+
+        export_map = _load_export_top_level_ktc_sftep(date)
+        if not export_map:
+            total_no_export += 1
+            # Snapshot has ktcSfTep entries but no export to source raw
+            # values from — leave as-is.  Chart will show the Hill
+            # contribution for these days; it'll roll off in 180 days.
+            rewritten.append(line)
+            continue
+
+        snap_replaced = 0
+        snap_dropped = 0
+        snap_unchanged = 0
+        for snap_key, entry in players.items():
+            if not isinstance(entry, dict):
+                continue
+            sources = entry.get("sources")
+            if not isinstance(sources, dict):
+                continue
+            current = sources.get("ktcSfTep")
+            if current is None:
+                continue
+            name_key = _norm_player_key(snap_key)
+            raw = export_map.get(name_key)
+            if raw is None:
+                # Player in snapshot but not in export — drop the
+                # ktcSfTep entry rather than leave a stale Hill
+                # contribution sitting next to today's raw values.
+                sources.pop("ktcSfTep", None)
+                snap_dropped += 1
+                continue
+            if int(current) == int(raw):
+                snap_unchanged += 1
+                continue
+            sources["ktcSfTep"] = int(raw)
+            snap_replaced += 1
+
+        total_replaced += snap_replaced
+        total_unchanged += snap_unchanged
+        total_dropped_missing += snap_dropped
+        rewritten.append(json.dumps(snap, separators=(",", ":")))
+        print(
+            f"  {date}: replaced={snap_replaced} unchanged={snap_unchanged} "
+            f"dropped(no_export_match)={snap_dropped}"
+        )
+
+    print()
+    print(f"Total replaced: {total_replaced}")
+    print(f"Total unchanged (already raw): {total_unchanged}")
+    print(f"Total dropped (no export match): {total_dropped_missing}")
+    print(f"Snapshot dates with no daily export: {total_no_export}")
+
+    if args.dry_run:
+        print("[dry-run] no changes written")
+        return 0
+
+    backup = args.path.with_suffix(args.path.suffix + ".bak")
+    backup.write_text(args.path.read_text())
+    args.path.write_text("\n".join(rewritten) + ("\n" if rewritten else ""))
+    print(f"Wrote {args.path} (backup at {backup})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/source_history.py
+++ b/src/api/source_history.py
@@ -83,6 +83,37 @@ _SCOPE_TO_ASSET_CLASSES: dict[str, frozenset[str]] = {
     "position_idp": frozenset({"idp"}),
 }
 
+# Sources whose scrape data is still loaded into the contract (for the
+# trade-page arbitrage finder + per-source winner row) but should not
+# appear in the per-player value-history chart, because a canonical
+# replacement source covers the same signal and emitting both
+# double-counts.
+#
+#   ``ktc`` (standard KTC SuperFlex) was retired from the blend
+#   2026-04-28 in favour of ``ktcSfTep`` (KTC SF + TE++).  Its raw
+#   value still rides into ``canonicalSiteValues`` as a free side-effect
+#   of the same scrape (one API payload yields both boards) — the
+#   trade-page features depend on that.  But the chart double-shows
+#   "KTC" since both ``ktc`` and ``ktcSfTep`` carry per-player series.
+#
+# Filtered at write-time (new snapshots omit these) AND at read-time
+# (historical snapshots are masked) so the chart deduplicates
+# immediately without a destructive rewrite of the JSONL.
+_RETIRED_FROM_CHART_KEYS: frozenset[str] = frozenset({"ktc"})
+
+# Sources whose per-player chart series should record the *raw* scrape
+# value (top-level ``row[key]`` from the contract) rather than the
+# Hill-curve ``valueContribution``.  The contribution scale is uniform
+# across sources for blending; the raw scale is more interpretable
+# when a source publishes its own widely-recognized 0-9999 board.
+#
+#   ``ktcSfTep`` publishes a public 0-9999 dynasty board on
+#   keeptradecut.com — users compare popup values to the website
+#   directly.  Recording the contribution (e.g. 9999 for a player KTC
+#   ranks at 9594) confused users.  This flag pulls the raw value
+#   from ``row['ktcSfTep']`` instead.
+_RAW_VALUE_PREFERRED_KEYS: frozenset[str] = frozenset({"ktcSfTep"})
+
 
 def _allowed_assets_for_source(source_key: str) -> frozenset[str] | None:
     """Return the set of asset classes ``source_key`` is allowed to
@@ -193,9 +224,30 @@ def _extract_player_entry(row: dict[str, Any]) -> dict[str, Any] | None:
         blended_rank_val = None
 
     sources: dict[str, int] = {}
+    # Pre-fill raw scrape values for sources where the published 0-9999
+    # board is the meaningful number to chart (see
+    # ``_RAW_VALUE_PREFERRED_KEYS``).  These take precedence over
+    # ``valueContribution`` from the meta loop below.
+    for key in _RAW_VALUE_PREFERRED_KEYS:
+        raw = row.get(key)
+        try:
+            v = int(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            v = None
+        if v is not None and v > 0:
+            sources[str(key)] = v
+    # ``meta_yielded_any`` tracks whether the contract-builder meta
+    # was populated for *any* source — gates the canonicalSites
+    # fallback below.  Tracking this separately from ``sources``
+    # truthiness preserves the original "meta XOR canonicalSites"
+    # semantics even when raw pre-fill above has already filled in
+    # one or two keys.
+    meta_yielded_any = False
     meta = row.get("sourceRankMeta")
     if isinstance(meta, dict):
         for key, entry in meta.items():
+            if str(key) in sources:
+                continue  # raw-preferred source already filled
             if not isinstance(entry, dict):
                 continue
             contribution = entry.get("valueContribution")
@@ -205,18 +257,29 @@ def _extract_player_entry(row: dict[str, Any]) -> dict[str, Any] | None:
                 v = None
             if v is not None and v > 0:
                 sources[str(key)] = v
+                meta_yielded_any = True
     # Fallback: legacy ``canonicalSiteValues`` (raw per-source values).
     # Not normalized but still useful for pre-contract-builder rows.
-    if not sources:
+    # Fires only when the contract-builder meta produced nothing —
+    # raw pre-fill (Layer 1 above) is allowed to coexist with this
+    # fallback so a partial export with both ``ktcSfTep`` raw and
+    # ``_canonicalSiteValues`` keeps the rest of the legacy keys.
+    if not meta_yielded_any:
         canonical = row.get("canonicalSiteValues") or row.get("_canonicalSiteValues")
         if isinstance(canonical, dict):
             for key, value in canonical.items():
+                if str(key) in sources:
+                    continue
                 try:
                     v = int(value) if value is not None else None
                 except (TypeError, ValueError):
                     v = None
                 if v is not None and v > 0:
                     sources[str(key)] = v
+    # Drop sources that are kept around in the contract but should not
+    # appear in the per-player chart (see ``_RETIRED_FROM_CHART_KEYS``).
+    for key in _RETIRED_FROM_CHART_KEYS:
+        sources.pop(key, None)
 
     # Per-source ranks (1 = best).  ``row.sourceRanks`` is the
     # primary source; falls back to ``effectiveSourceRanks`` (the
@@ -236,6 +299,10 @@ def _extract_player_entry(row: dict[str, Any]) -> dict[str, Any] | None:
     sources, source_ranks = _filter_scope_mismatched(
         asset_class, sources, source_ranks
     )
+    # Same retired-from-chart filter for ranks so legacy ``ktc`` rank
+    # entries don't surface either.
+    for key in _RETIRED_FROM_CHART_KEYS:
+        source_ranks.pop(key, None)
 
     if (
         blended_val is None
@@ -526,6 +593,13 @@ def load_player_history(
             sources_raw if isinstance(sources_raw, dict) else None,
             ranks_raw if isinstance(ranks_raw, dict) else None,
         )
+        # Mask retired-from-chart sources at read time too so historical
+        # snapshots written before the write-time filter landed don't
+        # double-show their canonical replacement (e.g. ``ktc`` next to
+        # ``ktcSfTep``).
+        for key in _RETIRED_FROM_CHART_KEYS:
+            sources.pop(key, None)
+            ranks.pop(key, None)
 
         # If the snapshot is pre-contract-builder (no blended value
         # persisted) derive an approximate blend from the median of

--- a/tests/api/test_source_history.py
+++ b/tests/api/test_source_history.py
@@ -485,3 +485,140 @@ def test_scope_filter_keeps_cross_scope_source_for_both_asset_classes(path):
     idp = source_history.load_player_history("Top LB", path=path)
     assert "idpTradeCalc" in off["sources"]
     assert "idpTradeCalc" in idp["sources"]
+
+
+def test_retired_ktc_filtered_from_chart_at_write_and_read(path):
+    """``ktc`` (standard KTC SF) was retired from the blend in favour of
+    ``ktcSfTep`` (KTC SF + TE++) but its raw value is still loaded into
+    the contract so the trade-page arbitrage finder + per-source winner
+    row can keep displaying both side-by-side.  The per-player
+    value-history chart, however, would double-show "KTC" since the
+    legend collapses both keys to the same compact label.
+
+    Both write-time (``_extract_player_entry``) and read-time
+    (``load_player_history``) filters drop ``ktc`` so the chart is
+    deduplicated immediately, including for the 180-day backwards
+    window that has historical ``ktc`` entries.
+    """
+    # Write-time: row carries both ``ktc`` (in canonicalSites + meta)
+    # and ``ktcSfTep`` — only ``ktcSfTep`` should land in the snapshot.
+    contract = {
+        "date": "2026-05-05",
+        "playersArray": [
+            {
+                "displayName": "Brock Bowers",
+                "canonicalName": "Brock Bowers",
+                "position": "TE",
+                "assetClass": "offense",
+                "rankDerivedValue": 9177,
+                "canonicalConsensusRank": 6,
+                # Top-level raw values — ``ktcSfTep`` is preferred over
+                # the meta valueContribution.
+                "ktc": 7932,
+                "ktcSfTep": 9594,
+                "sourceRankMeta": {
+                    "ktc": {"valueContribution": 7950},
+                    "ktcSfTep": {"valueContribution": 9999},
+                    "fp_sf": {"valueContribution": 8500},
+                },
+                "sourceRanks": {"ktc": 14, "ktcSfTep": 6, "fp_sf": 9},
+            }
+        ],
+    }
+    source_history.append_snapshot(contract, date="2026-05-05", path=path)
+
+    # On disk: ``ktc`` is gone from both sources and sourceRanks.
+    snap = json.loads(path.read_text().strip().splitlines()[0])
+    bowers_entry = next(
+        v for k, v in snap["players"].items() if k.startswith("Brock Bowers")
+    )
+    assert "ktc" not in bowers_entry["sources"]
+    assert "ktc" not in bowers_entry.get("sourceRanks", {})
+    # ``ktcSfTep`` is the raw scrape value, not the Hill contribution.
+    assert bowers_entry["sources"]["ktcSfTep"] == 9594
+
+    # Read-time: ``load_player_history`` confirms the chart side too.
+    hist = source_history.load_player_history("Brock Bowers", path=path)
+    assert "ktc" not in hist["sources"]
+    assert hist["sources"]["ktcSfTep"][0]["value"] == 9594
+
+
+def test_retired_ktc_masked_from_legacy_snapshot_at_read_time(path):
+    """Snapshots written *before* the write-time filter landed still
+    have ``ktc`` entries on disk.  The read-time filter masks them so
+    the chart deduplicates immediately, without rewriting the JSONL.
+    """
+    legacy = {
+        "date": "2026-04-27",
+        "players": {
+            "Brock Bowers::offense": {
+                "blended": 9089,
+                "blendedRank": 7,
+                "sources": {"ktc": 7943, "ktcSfTep": 10110, "fp_sf": 8500},
+                "sourceRanks": {"ktc": 13, "ktcSfTep": 7, "fp_sf": 9},
+            }
+        },
+    }
+    path.write_text(json.dumps(legacy) + "\n")
+    hist = source_history.load_player_history("Brock Bowers", path=path)
+    assert "ktc" not in hist["sources"]
+    assert "ktc" not in hist["sourceRanks"]
+    # ``ktcSfTep`` and other sources unaffected.
+    assert hist["sources"]["ktcSfTep"][0]["value"] == 10110
+    assert hist["sources"]["fp_sf"][0]["value"] == 8500
+
+
+def test_ktc_sftep_uses_raw_top_level_value_over_contribution(path):
+    """``ktcSfTep`` is in ``_RAW_VALUE_PREFERRED_KEYS`` because KTC
+    publishes a public 0-9999 dynasty board on keeptradecut.com — users
+    compare popup values to the website directly.  The per-player
+    chart records the raw scrape (``row['ktcSfTep']``) rather than
+    the Hill-curve contribution, even when both are available.
+    """
+    contract = {
+        "date": "2026-05-05",
+        "playersArray": [
+            {
+                "displayName": "Bijan Robinson",
+                "canonicalName": "Bijan Robinson",
+                "position": "RB",
+                "assetClass": "offense",
+                "rankDerivedValue": 9998,
+                "canonicalConsensusRank": 2,
+                "ktcSfTep": 9998,  # raw scrape — matches KTC.com
+                "sourceRankMeta": {
+                    "ktcSfTep": {"valueContribution": 9999},  # Hill contribution
+                },
+            }
+        ],
+    }
+    source_history.append_snapshot(contract, date="2026-05-05", path=path)
+    hist = source_history.load_player_history("Bijan Robinson", path=path)
+    # Raw 9998 wins, not the contribution 9999.
+    assert hist["sources"]["ktcSfTep"][0]["value"] == 9998
+
+
+def test_ktc_sftep_falls_back_to_contribution_when_raw_missing(path):
+    """If a contract row is missing the top-level ``ktcSfTep`` raw
+    value (e.g. legacy export, partial scrape), fall back to the
+    ``valueContribution`` so the chart isn't blank.
+    """
+    contract = {
+        "date": "2026-05-05",
+        "playersArray": [
+            {
+                "displayName": "Some Player",
+                "canonicalName": "Some Player",
+                "position": "WR",
+                "assetClass": "offense",
+                "rankDerivedValue": 7000,
+                # No top-level ``ktcSfTep`` — only the meta entry.
+                "sourceRankMeta": {
+                    "ktcSfTep": {"valueContribution": 7100},
+                },
+            }
+        ],
+    }
+    source_history.append_snapshot(contract, date="2026-05-05", path=path)
+    hist = source_history.load_player_history("Some Player", path=path)
+    assert hist["sources"]["ktcSfTep"][0]["value"] == 7100


### PR DESCRIPTION
## Summary
- Per-player value-history popup was showing **two "KTC" entries** because both \`ktc\` (standard SF, retired from blend 2026-04-28) and \`ktcSfTep\` (canonical KTC SF + TE++ voter) collapse to the same compact label
- Displayed KTC value was the **Hill-curve contribution** (e.g. 9999 for Brock Bowers) rather than the **raw 0-9999 scrape** users see on keeptradecut.com (9594 for Bowers)

## Fix
Two surface changes in \`src/api/source_history.py\`:
- **\`_RETIRED_FROM_CHART_KEYS = {"ktc"}\`** — filters \`ktc\` from chart payloads at write-time *and* read-time, so historical snapshots are deduped immediately without rewriting the JSONL. Trade-page arbitrage finder + per-source winner row are unaffected (they read \`canonicalSiteValues\` directly from the live contract).
- **\`_RAW_VALUE_PREFERRED_KEYS = {"ktcSfTep"}\`** — records the raw top-level \`row['ktcSfTep']\` scrape value into snapshots instead of \`valueContribution\`. Other sources continue using the contribution scale (raw values for FantasyPros 82 / Yahoo 75 wouldn't be meaningful).
- **\`scripts/backfill_ktc_sftep_raw.py\`** — one-shot migration that rewrites the existing 180-day snapshot window in-place using raw values from the matching daily \`dynasty_data_<date>.json\` exports. Idempotent; creates a \`.bak\`. Already run on production (973 entries replaced, 36 dropped where the player had no name match in the daily export).

The existing \`canonicalSiteValues\` fallback path is preserved — gated on a new \`meta_yielded_any\` flag instead of \`not sources\` truthiness, so the raw pre-fill layer doesn't suppress the legacy fallback. (One existing test caught this regression and is the reason for the explicit flag.)

## Test plan
- [x] \`pytest tests/api/test_source_history.py\` — 24 passed (4 new + 20 existing)
- [x] \`pytest tests/\` minus e2e — 2870 passed, 3 skipped, 162 subtests passed
- [x] Backfill dry-run + apply on prod — verified Bowers' \`ktcSfTep\` snapshot value flipped from 9999 → 9594 (matches KTC.com), Chase 9985 → 9985 (matches), \`ktc\` keys masked at read time
- [x] No frontend changes; chart legend automatically deduplicates once \`ktc\` is gone from the API response

## New tests
- \`test_retired_ktc_filtered_from_chart_at_write_and_read\` — round-trips a contract row with both keys, asserts only \`ktcSfTep\` lands in the JSONL and the read API
- \`test_retired_ktc_masked_from_legacy_snapshot_at_read_time\` — write a legacy polluted snapshot directly, assert \`ktc\` masked at read time
- \`test_ktc_sftep_uses_raw_top_level_value_over_contribution\` — assert raw 9998 wins over contribution 9999
- \`test_ktc_sftep_falls_back_to_contribution_when_raw_missing\` — assert chart isn't blank when only the meta is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)