### PR TITLE
style(rankings): clean up player team/age meta — drop leading comma when team empty

### DIFF
--- a/frontend/app/finder/page.jsx
+++ b/frontend/app/finder/page.jsx
@@ -304,7 +304,7 @@ export default function FinderPage() {
                             </span>
                             {(row.team || row.age) && (
                               <span className="muted text-xs" style={{ marginLeft: 6 }}>
-                                {row.team || ""}{row.age ? `, ${row.age}` : ""}
+                                {[row.team, row.age].filter(Boolean).join(" · ")}
                               </span>
                             )}
                             {chips.length > 0 && (

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1319,7 +1319,7 @@ export default function RankingsPage() {
                             </span>
                             {(row.team || row.age) && (
                               <span className="rankings-player-meta">
-                                {row.team || ""}{row.age ? `, ${row.age}` : ""}
+                                {[row.team, row.age].filter(Boolean).join(" · ")}
                               </span>
                             )}
                             <RankChangeGlyph

--- a/frontend/app/waivers/page.jsx
+++ b/frontend/app/waivers/page.jsx
@@ -112,7 +112,7 @@ function PlayerCell({ row, isRookie, rosteredBy }) {
       <span style={{ fontWeight: 600 }}>{row?.name || "—"}</span>
       {row?.team || row?.age ? (
         <span className="muted text-xs" style={{ marginLeft: 6 }}>
-          {row?.team || ""}{row?.age ? `, ${row.age}` : ""}
+          {[row?.team, row?.age].filter(Boolean).join(" · ")}
         </span>
       ) : null}
       {isRookie ? <RookieBadge /> : null}


### PR DESCRIPTION
## Summary
The player-name meta (rendered next to the name in rankings, finder, and waivers) was showing as \`", 29"\` — a leading comma — for any player whose contract row had no team. Since most rows don't have team populated, the user mostly saw the bare comma form.

## Fix
Swapped the conditional concat for \`[row.team, row.age].filter(Boolean).join(" · ")\`. Cases:

| Has team | Has age | Before | After |
|---|---|---|---|
| ✓ | ✓ | \`BUF, 29\` | \`BUF · 29\` |
| ✗ | ✓ | \`, 29\` | \`29\` |
| ✓ | ✗ | \`BUF\` | \`BUF\` |
| ✗ | ✗ | (hidden by parent guard) | (hidden) |

Same change in three files (\`rankings\`, \`finder\`, \`waivers\`) since the pattern was duplicated.

## Test plan
- [x] \`npm run build\` passes — all 13 pages under bundle budget
- [x] Visual: rankings rows now show "29" alone instead of ", 29" for ageless team rows; full "BUF · 29" form when team is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)