### PR TITLE
fix(te-premium-lab): label KTC premium board as TE++ (was stale 'TE+')

### DIFF
--- a/frontend/app/te-premium-lab/page.jsx
+++ b/frontend/app/te-premium-lab/page.jsx
@@ -500,7 +500,7 @@ function SummaryTab({ summary, scarcity, sources, tierSummary, lineup }) {
     {
       label: "Avg external TE Premium boost",
       value: fmtSignedPct(summary.avg_market_boost_pct),
-      hint: "KTC normal vs KTC TE+ board",
+      hint: "KTC SF (standard) vs KTC SF + TE++",
     },
     {
       label: "Avg internal scoring penalty",
@@ -876,7 +876,7 @@ function SourcesTab({ sources, boostRows, marketAvailable, comparison }) {
         </div>
       )}
 
-      <h3 style={{ marginTop: 24 }}>KTC normal vs KTC TE+ — reliable rows</h3>
+      <h3 style={{ marginTop: 24 }}>KTC SF (standard) vs KTC SF + TE++ — reliable rows</h3>
       <div className="table-wrap" style={{ overflowX: "auto" }}>
         <table className="data-table" style={{ width: "100%", fontSize: 13 }}>
           <thead>

--- a/src/research/te_premium.py
+++ b/src/research/te_premium.py
@@ -378,11 +378,9 @@ def load_external_ktc_boards(
 
     Both paths default to the canonical scraper outputs at
     ``CSVs/site_raw/ktc.csv`` and ``CSVs/site_raw/ktcSfTep.csv``.
-    The "premium" board is KTC's TE+ Level 1 ("TE Premium") sub-board.
-    KTC's TE++ (Level 2) board is structurally available in the API
-    response but is NOT currently extracted by ``Dynasty Scraper.py``
-    (see ``_KTC_TEP_FIELD_KEYS`` — only level 1 is plucked); when
-    requested it's flagged unavailable.
+    The "premium" board is KTC's TE++ Level 2 sub-board (per #393,
+    2026-05-05 — the file name ``ktcSfTep.csv`` predates the rename
+    and is kept for compatibility with the live data_contract path).
     """
     np_path = Path(normal_path) if normal_path else _DEFAULT_KTC_NORMAL_CSV
     pp_path = Path(premium_path) if premium_path else _DEFAULT_KTC_TEP_CSV
@@ -1555,11 +1553,12 @@ def build_overview(
             "label": "KeepTradeCut",
             "supports_normal": True,
             "supports_te_premium": bool(boards.get("premium_available")),
-            "supports_te_plus_plus": False,
+            "supports_te_plus_plus": bool(boards.get("premium_available")),
             "note": (
-                "KTC ships normal SF + TE+ Level 1 boards from the same scrape. "
-                "TE++ (Level 2) is in the API response but not currently "
-                "extracted by Dynasty Scraper.py — see _KTC_TEP_FIELD_KEYS."
+                "KTC ships SF (standard) + SF+TE++ Level 2 boards from the "
+                "same scrape.  The 'premium' file is named ``ktcSfTep.csv`` "
+                "for backwards compatibility with the live data_contract path "
+                "but contains TE++ values as of #393 (2026-05-05)."
             ),
             "available": bool(boards.get("normal_available") and boards.get("premium_available")),
         },


### PR DESCRIPTION
## Summary
You caught the inconsistency on \`/te-premium-lab\`: the new multi-source comparison table header correctly reads "TE++" but two stale labels still read "TE+":
- The summary card hint ("KTC normal vs KTC TE+ board")
- The legacy "KTC normal vs KTC TE+ — reliable rows" heading

The underlying \`ktcSfTep.csv\` was switched from TE+ Level 1 to TE++ Level 2 in #393 (2026-05-05). Spot-check confirms the values match keeptradecut.com's TE++ board (Bowers 9589 ≈ 9592, McBride 9154 ≈ 9146). The CSV filename is unchanged for backwards compat with \`_SOURCE_CSV_PATHS\` in the live data contract.

Also flipped \`supports_te_plus_plus\` to \`True\` in the source metadata since KTC's premium board now IS TE++.

## Test plan
- [x] \`pytest tests/research/test_te_premium.py\` — 50 passed
- [x] \`npm run build\` — all pages under budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)