### PR TITLE
fix(te-premium-lab): remove broken DynastyDaddy TEP pair

### DIFF
--- a/src/research/te_premium.py
+++ b/src/research/te_premium.py
@@ -147,15 +147,16 @@ _SOURCE_PAIRS: tuple[dict[str, Any], ...] = (
         "premium_label": "TE++",
         "note": "KTC SF (standard) vs KTC SF + TE++ overlay",
     },
-    {
-        "key": "dynastyDaddy",
-        "label": "Dynasty Daddy",
-        "mode": "value",
-        "normal_csv": "CSVs/site_raw/dynastyDaddySfBase.csv",
-        "premium_csv": "CSVs/site_raw/dynastyDaddySf.csv",
-        "premium_label": "TEP",
-        "note": "DD market 15 (non-TEP) vs market 14 (TEP-tuned)",
-    },
+    # DynastyDaddy intentionally not paired here — see investigation
+    # below.  The ``market=14`` and ``market=15`` endpoints we
+    # initially paired turned out to be different vendor sources
+    # (probably KTC vs FantasyCalc), not a TEP toggle within DD's
+    # own valuation.  Symptoms: top TEs like Mark Andrews and Kyle
+    # Pitts came back *negative* under the "TEP boost" math, and
+    # QB/WR positions — which TEP shouldn't affect at all — also
+    # shifted between markets.  The DD public API doesn't appear to
+    # expose a per-player non-TEP/TEP value pair via this endpoint
+    # family.  Add back here when a real DD TEP signal is identified.
     {
         "key": "dynastyNerds",
         "label": "Dynasty Nerds",

--- a/tests/research/test_te_premium.py
+++ b/tests/research/test_te_premium.py
@@ -792,7 +792,7 @@ def test_load_external_source_pairs_marks_missing_pairs_unavailable(tmp_path):
     by_key = {p["key"]: p for p in pairs}
     assert all(p["available"] is False for p in pairs)
     assert by_key["ktc"]["normal"] == {}
-    assert by_key["dynastyDaddy"]["premium"] == {}
+    assert by_key["dynastyNerds"]["premium"] == {}
 
 
 def test_compute_top_te_source_comparison_aggregates_per_source():


### PR DESCRIPTION
## Summary
You caught the bug: top TEs in the DD column showed **negative** TEP boosts (Mark Andrews −31%, Kyle Pitts −10%, Jake Ferguson −25%) — structurally impossible if market 14 vs 15 was a real TEP toggle.

## Investigation

Spot-checked DD across positions:

| Player | Pos | m14 | m15 | "Boost" |
|---|---|---|---|---|
| Bowers | TE | 8142 | 6109 | +33% |
| Andrews | TE | 1342 | 1942 | **−31%** |
| Pitts | TE | 2415 | 2681 | −10% |
| Allen | QB | 10200 | 9446 | +8% |
| Chase | WR | 10195 | 9480 | +7% |
| Bijan | RB | 10200 | 10283 | ~0% |

A pure TEP toggle would shift TE values uniformly upward (boost) and leave QB/RB/WR untouched. Two TEs going **down** and QB/WR also moving confirms market 14 and market 15 are **different vendor sources** inside DD's market multiplexer (probably KTC vs FantasyCalc), not a TEP toggle within DD's own valuation.

DD's public \`/api/v1/player/all/today?market=N\` endpoint only exposes \`sf_trade_value\` and \`trade_value\` per player — no TEP sibling field. **The TEP signal isn't reachable via this API.**

## Action
Pull DD out of \`_SOURCE_PAIRS\` until a real DD TEP signal is identified. The \`dynastyDaddySfBase.csv\` fetcher path stays so we keep raw market=15 data for future research, but the comparison loader no longer reads it.

## Remaining valid pairs
- ✅ **KTC** — values match keeptradecut.com TE++ board
- ✅ **DynastyNerds** — SFLEX vs SFLEXTEP from same payload, internally consistent
- ✅ **FantasyPros Fitzmaurice** — TEP Value vs Trade Value columns from same chart

## Test plan
- [x] \`pytest\` — 67 TE Premium tests passing (1 test updated to assert \`dynastyNerds\` instead of removed \`dynastyDaddy\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)