### PR TITLE
fix(te-blend): un-double-boost IDPTC + repurpose TE Premium slider

### DIFF
--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -108,31 +108,23 @@ export default function SettingsPage() {
     reset();
   }
 
-  // Derived TE-premium multiplier from the backend.  Comes from
-  // ``rankingsOverride.tepMultiplierDerived`` which the backend
-  // stamps on every /api/data + override response.  The number is
-  // computed from the operator's Sleeper league ``bonus_rec_te``
-  // (0.0 → 1.0, 0.5 → 1.15, 1.0 → 1.30, ...) and represents the
-  // "auto" baseline the slider shows when the user has not
-  // explicitly overridden it.
-  const tepDerivedFromLeague = (() => {
+  // TE Premium slider value.  The backend stamps the operator's
+  // current default (``rankingsOverride.tepMultiplierDerived``, which
+  // post-2026-05-06 is just the hardcoded non-TEP default 1.25 and no
+  // longer comes from Sleeper's ``bonus_rec_te``); we use that as the
+  // displayed value when the user has not set an explicit override,
+  // falling back to 1.25 if the field is missing.
+  const tepDefault = (() => {
     const v = Number(rawData?.rankingsOverride?.tepMultiplierDerived);
-    return Number.isFinite(v) ? v : 1.0;
+    return Number.isFinite(v) ? v : 1.25;
   })();
-  const bonusRecTeFromLeague = (() => {
-    const v = Number(rawData?.rankingsOverride?.bonusRecTe);
-    return Number.isFinite(v) && v >= 0 ? v : 0.0;
-  })();
-  // Effective slider value.  null/undefined in settings → show the
-  // derived value (auto); a finite number → show the user's override.
-  // Coerce any noise (strings, NaN) back to the derived baseline.
   const tepSliderValue = (() => {
     const raw = settings?.tepMultiplier;
-    if (raw === null || raw === undefined) return tepDerivedFromLeague;
+    if (raw === null || raw === undefined) return tepDefault;
     const n = Number(raw);
-    return Number.isFinite(n) ? n : tepDerivedFromLeague;
+    return Number.isFinite(n) ? n : tepDefault;
   })();
-  const tepIsAuto =
+  const tepIsDefault =
     settings?.tepMultiplier === null ||
     settings?.tepMultiplier === undefined;
 
@@ -228,12 +220,12 @@ export default function SettingsPage() {
           min={1.0} max={1.5} step={0.05}
           onChange={(v) => update("tepMultiplier", v)}
           hint={
-            tepIsAuto
-              ? `Auto: ${tepDerivedFromLeague.toFixed(3)}× (Sleeper bonus_rec_te = ${bonusRecTeFromLeague.toFixed(2)})`
-              : `Custom override (auto would be ${tepDerivedFromLeague.toFixed(3)}× from bonus_rec_te = ${bonusRecTeFromLeague.toFixed(2)})`
+            tepIsDefault
+              ? `Default ${tepDefault.toFixed(2)}× — applied to non-TEP sources on TE rows`
+              : `Custom ${Number(tepSliderValue).toFixed(2)}× — non-TEP sources on TE rows`
           }
         />
-        {!tepIsAuto && (
+        {!tepIsDefault && (
           <div style={{ marginTop: 4, marginBottom: 6 }}>
             <button
               type="button"
@@ -247,20 +239,14 @@ export default function SettingsPage() {
               }}
               onClick={() => update("tepMultiplier", null)}
             >
-              Reset to Auto (derive from my Sleeper league)
+              Reset to default ({tepDefault.toFixed(2)}×)
             </button>
           </div>
         )}
         <p className="muted" style={{ fontSize: "0.68rem", marginTop: 4, marginBottom: 0 }}>
-          By default, this is <strong>derived from your Sleeper league&apos;s{" "}
-          <span style={{ fontFamily: "var(--mono)", fontSize: "0.64rem" }}>
-            bonus_rec_te
-          </span></strong>{" "}
-          scoring setting: 0.0 (standard) → 1.00, 0.5 (TEP-1.5) → 1.15,
-          1.0 (TEP-2.0) → 1.30.  Dragging the slider opts into a manual
-          override on top of that.  Applied on the backend to every TE&apos;s
-          per-source contributions from rankings sources that don&apos;t
-          already bake TE premium into their ranks.  Sources tagged{" "}
+          Multiplier applied to TE values from sources that don&apos;t
+          already publish a TE-premium board (DLF, FBG, FP consensus,
+          Flock, etc.).  Sources tagged{" "}
           <span
             style={{
               fontFamily: "var(--mono)",
@@ -273,10 +259,12 @@ export default function SettingsPage() {
           >
             TEP NATIVE
           </span>{" "}
-          in the Ranking Sources table below pass through unchanged, so there is
-          no double-boost. Changing the slider re-runs the canonical ranking
-          pipeline with the new multiplier, so every page (rankings, trade
-          calculator, edge) sees the same TEP-adjusted values.
+          (KTC SfTep, IDPTC, DN SfTep, Yahoo Boone, FP Fitzmaurice) get
+          a smaller fixed 1.10× nudge instead, since their boards
+          already bake in a TE premium.  KTC standard SF is the
+          reference baseline and passes through unchanged.  Changing
+          the slider re-runs the canonical ranking pipeline so every
+          page (rankings, trade calculator, edge) sees the same values.
         </p>
       </Section>
 

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -12,21 +12,18 @@ export const SETTINGS_DEFAULTS = {
 
   // Value adjustment strengths
   //
-  // tepMultiplier: null means "auto from league" — the backend derives
-  // the TE-premium multiplier from the operator's Sleeper league
-  // ``bonus_rec_te`` scoring setting and applies that value during the
-  // blend.  A standard TEP-1.5 league (bonus_rec_te=0.5) yields 1.15;
-  // a non-TEP league yields 1.0 (a no-op).  When the user drags the
+  // tepMultiplier: null means "use the backend default" — currently
+  // the operator-set non-TEP TE multiplier (1.25), applied to TE
+  // values from sources that don't already bake in a TE-premium board
+  // (DLF, FBG, FP consensus, Flock, etc.).  When the user drags the
   // slider on /settings, this flips from null to a finite number,
   // which ``fetchDynastyData`` then POSTs to the override endpoint as
-  // an explicit override on top of the derived default.  "Reset"
-  // returns it to null so the derived baseline kicks back in.
-  //
-  // Pre-2026-04 this defaulted to 1.15 — which silently applied a TE
-  // boost to every cold-start user regardless of whether their league
-  // even had a TE premium.  Moving the default to null fixes that
-  // mismatch: the board you see reflects your Sleeper league.
-  tepMultiplier: null,               // null = auto from Sleeper bonus_rec_te; 1.0..2.0 = explicit
+  // an explicit override on top of that default.  "Reset" returns it
+  // to null so the default kicks back in.  TEP-native sources (KTC
+  // SfTep, IDPTC, DN SfTep, Yahoo Boone, FP Fitzmaurice) are pinned at
+  // 1.10× backend-side and are not affected by this slider; KTC
+  // standard SF is exempt entirely.
+  tepMultiplier: null,               // null = backend default (1.25); 1.0..1.5 = explicit operator override
 
   // Rankings display
   rankingsSortBasis: "full",         // "full" | "raw"

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -262,9 +262,11 @@ export const RANKING_SOURCES = [
     weight: 1.0,
     isBackbone: true,
     isRetail: false,
-    // IDPTradeCalc's offense board is a standard SF calculator — no
-    // TE premium baked in.
-    isTepPremium: false,
+    // IDPTradeCalc is scraped with TEP=True (see Dynasty Scraper.py):
+    // raw values come from ``value_sftep`` columns, which already bake
+    // in a TE-premium board.  Treated as TEP-native so it gets the
+    // small 1.10× nudge instead of the full non-TEP boost.
+    isTepPremium: true,
   },
   {
     // DLF Dynasty Superflex rankings — offense expert consensus.

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -886,9 +886,13 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # source's contribution.  See the blend loop in
         # ``_compute_unified_rankings`` for the exact math.
         "is_cross_market": True,
-        # IDPTradeCalc's offense autocomplete is a standard SF board,
-        # not TE-premium.  The frontend TEP boost applies.
-        "is_tep_premium": False,
+        # IDPTradeCalc is scraped with TEP=True (see Dynasty Scraper.py),
+        # pulling ``value_sftep`` rather than the vanilla SF column.
+        # That means the raw values are already a TE-premium board, so
+        # we treat IDPTC like the other TEP-native sources (Yahoo Boone,
+        # FP Fitzmaurice, DN SfTep) — only the small 1.10× nudge toward
+        # the operator's TE++ baseline, never the full non-TEP 1.25×.
+        "is_tep_premium": True,
     },
     {
         # DLF Dynasty Superflex rankings — the offense counterpart of
@@ -1827,8 +1831,9 @@ def normalize_tep_multiplier(raw: Any) -> float | None:
         back to the league-derived default".  ``build_api_data_contract``
         and ``build_rankings_delta_payload`` both treat ``None`` as
         "derive from Sleeper" via :func:`_derive_tep_multiplier_from_league`.
-      * A ``float`` clamped to ``[1.0, 2.0]`` when the key IS present
-        and parses as a finite number.  The clamped value is what the
+      * A ``float`` clamped to ``[1.0, 1.5]`` (matching the slider's
+        UI bounds) when the key IS present and parses as a finite
+        number.  The clamped value is what the
         pipeline applies verbatim (no derivation layered on top).
       * ``None`` when the key is present but unparseable / infinite —
         treated the same as "absent" so a garbled body falls back to
@@ -1850,7 +1855,7 @@ def normalize_tep_multiplier(raw: Any) -> float | None:
                 return None
             if not math.isfinite(v):
                 return None
-            return max(1.0, min(2.0, v))
+            return max(1.0, min(1.5, v))
     return None
 
 
@@ -4619,22 +4624,25 @@ _TEP_DERIVED_CLAMP_MAX = 2.0
 # have no such source so a single module-level constant suffices.
 _TEP_NATIVE_ASSUMED_MULTIPLIER: float = 1.15
 
-# Blanket TE-value multipliers (operator decision 2026-05-06).  Replaces
-# the league-derived ``tep_multiplier`` / ``tep_native_correction`` for
-# TE rows specifically.  KTC is the canonical TE++ retail signal and is
-# left untouched; every other source's TE values are scaled at blend
-# time to align with KTC's TE++ baseline:
+# Blanket TE-value multipliers.  KTC is the canonical TE++ retail signal
+# and is left untouched; every other source's TE values are scaled at
+# blend time to align with KTC's TE++ baseline:
 #
-#   * TEP-native sources (DN SfTep, Yahoo Boone, FP Fitzmaurice) — the
-#     source already publishes some TEP boost, so a small additional
-#     ``1.10×`` brings them up toward our league's TE++ scoring.
+#   * TEP-native sources (KTC SfTep, IDPTC, DN SfTep, Yahoo Boone, FP
+#     Fitzmaurice) — the source already publishes a TE-premium board,
+#     so a small additional ``1.10×`` brings them up toward our league's
+#     TE++ scoring.  This factor is hardcoded.
 #   * Non-TEP sources (DLF, FBG, FP consensus, Flock, etc.) — no TEP
-#     bake at all, so they need the full ``1.25×`` boost.
+#     bake at all, so they need a larger boost.  The factor defaults
+#     to ``1.25×`` but is operator-tunable from ``/settings`` via the
+#     "TE Premium" slider; the slider value flows through
+#     ``tep_multiplier`` on POST /api/rankings/overrides and overrides
+#     the default for the duration of that request.
 #
-# Operator's instruction was "leave KTC alone" — both ``ktc`` (standard
-# SF) and ``ktcSfTep`` (KTC TE++) skip the correction entirely.  ktc
-# is mathematically `is_tep_premium=False` and would normally pick up
-# the 1.25 boost; the exemption set below short-circuits that.
+# KTC is exempt regardless: both ``ktc`` (standard SF) and ``ktcSfTep``
+# (KTC TE++) skip both factors.  ktc is mathematically
+# ``is_tep_premium=False`` and would normally pick up the non-TEP
+# multiplier; the exemption set below short-circuits that.
 _TE_BLANKET_NON_NATIVE_MULTIPLIER: float = 1.25
 _TE_BLANKET_NATIVE_MULTIPLIER: float = 1.10
 _TE_BLANKET_KTC_EXEMPT_KEYS: frozenset[str] = frozenset({"ktc", "ktcSfTep"})
@@ -5099,7 +5107,7 @@ def _compute_unified_rankings(
     csv_index: dict[str, dict[str, dict[str, Any]]] | None = None,
     *,
     source_overrides: dict[str, dict[str, Any]] | None = None,
-    tep_multiplier: float = 1.0,
+    tep_multiplier: float | None = None,
     tep_native_correction: float = 1.0,
 ) -> dict[str, str]:
     """Compute a single unified ranking across all sources and positions.
@@ -5217,16 +5225,19 @@ def _compute_unified_rankings(
     def _percentile_denom_for_source(src_def: dict, source_key: str) -> int:
         return _PERCENTILE_REFERENCE_N
 
-    # Clamp TEP multiplier to a sane range.  1.0 is a no-op, 2.0 is
-    # a generous upper bound (the slider UI caps at 1.5 today).  The
-    # TEP (2026-04-20, simplified): one fixed 15% boost on TE rows
-    # for non-TEP-native sources.  TEP-native sources pass through
-    # unchanged (no correction factor).  The ``tep_multiplier``
-    # parameter is accepted for API compat but ignored — derivation
-    # from league, slider, and clamp all retired per user directive.
-    _ = tep_multiplier  # acknowledged-unused, kept for backwards-compat
+    # Resolve the non-TEP-source TE multiplier.  ``None`` means the
+    # caller did not supply a slider override, so use the operator's
+    # default (``_TE_BLANKET_NON_NATIVE_MULTIPLIER``, 1.25).  An
+    # explicit float comes from the ``/settings`` "TE Premium" slider
+    # via :func:`normalize_tep_multiplier`, which clamps to [1.0, 1.5].
+    # The TEP-native (1.10) factor and KTC exemption are hardcoded —
+    # only the non-TEP boost is operator-tunable.
     _ = tep_native_correction  # acknowledged-unused, kept for backwards-compat
-    tep_multiplier_effective = 1.15
+    effective_non_tep_multiplier: float = (
+        float(tep_multiplier)
+        if tep_multiplier is not None
+        else _TE_BLANKET_NON_NATIVE_MULTIPLIER
+    )
 
     # Build the active source list honoring user-supplied overrides.
     # This is the only place ranks + weights are gated, so downstream
@@ -5802,10 +5813,6 @@ def _compute_unified_rankings(
         row_is_pick = (
             players_array[row_idx].get("assetClass") == "pick"
         )
-        apply_tep = row_is_te and tep_multiplier_effective > 1.0
-        apply_tep_native_correction = (
-            row_is_te and abs(tep_native_correction - 1.0) > 1e-6
-        )
 
         # Framework step 2–3: for each source, compute
         # percentile-to-value using the source's scope-appropriate
@@ -5880,10 +5887,11 @@ def _compute_unified_rankings(
                 )
             tep_applied = False
             tep_native_corrected = False
-            # Blanket TE-value multipliers (see
-            # ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` / ``..._NATIVE_...``).
-            # Replaces the legacy league-derived ``tep_multiplier`` /
-            # ``tep_native_correction`` for TE rows.  KTC is exempt
+            # Blanket TE-value multipliers (see the constants block
+            # near ``_TE_BLANKET_NON_NATIVE_MULTIPLIER``).  Non-TEP
+            # sources scale by ``effective_non_tep_multiplier`` (the
+            # operator's slider value, default 1.25).  TEP-native
+            # sources scale by the hardcoded 1.10×.  KTC is exempt
             # because its TE++ board is already the canonical reference
             # we're aligning everyone else to.
             if (
@@ -5891,7 +5899,7 @@ def _compute_unified_rankings(
                 and source_key not in _TE_BLANKET_KTC_EXEMPT_KEYS
             ):
                 if source_key in tep_boosted_source_keys:
-                    value *= _TE_BLANKET_NON_NATIVE_MULTIPLIER
+                    value *= effective_non_tep_multiplier
                     tep_applied = True
                 elif source_key in tep_native_source_keys:
                     value *= _TE_BLANKET_NATIVE_MULTIPLIER
@@ -5918,7 +5926,7 @@ def _compute_unified_rankings(
             meta["isAnchor"] = bool(source_key in cross_market_keys)
             if tep_applied:
                 meta["tepBoostApplied"] = True
-                meta["tepMultiplier"] = round(_TE_BLANKET_NON_NATIVE_MULTIPLIER, 4)
+                meta["tepMultiplier"] = round(effective_non_tep_multiplier, 4)
             if tep_native_corrected:
                 meta["tepNativeCorrectionApplied"] = True
                 meta["tepNativeCorrection"] = round(_TE_BLANKET_NATIVE_MULTIPLIER, 4)
@@ -7083,21 +7091,28 @@ def build_api_data_contract(
     this to ``True`` so overrides round-trips don't pay for output
     blocks the wire shape drops.
     """
-    # TEP (2026-04-20, simplified): TE rows get a fixed 1.15× boost
-    # from non-TEP-native sources.  No league derivation, no slider,
-    # no TEP-native correction.  The ``tep_multiplier`` parameter is
-    # accepted for API compat but ignored.
-    _ = tep_multiplier  # intentionally ignored
-    tep_multiplier_derived = 1.15
-    tep_multiplier_effective = 1.15
-    tep_multiplier_source = "fixed"
+    # TEP slider repurposed (2026-05-06): ``tep_multiplier`` is the
+    # operator-tunable boost applied to non-TEP-native source TE
+    # contributions.  ``None`` → use the default
+    # (``_TE_BLANKET_NON_NATIVE_MULTIPLIER``, 1.25); a finite float
+    # (clamped to [1.0, 1.5] by ``normalize_tep_multiplier``) → use
+    # the operator's slider value verbatim.  The TEP-native (1.10)
+    # correction and KTC exemption are hardcoded; only this
+    # non-TEP boost is operator-tunable.
+    if tep_multiplier is None:
+        tep_multiplier_effective = _TE_BLANKET_NON_NATIVE_MULTIPLIER
+        tep_multiplier_source = "default"
+    else:
+        tep_multiplier_effective = float(tep_multiplier)
+        tep_multiplier_source = "override"
+    tep_multiplier_derived = _TE_BLANKET_NON_NATIVE_MULTIPLIER
     # League context still resolved for other uses (roster count,
-    # logging); TEP derivation is a stable constant now.
+    # logging); TEP derivation no longer drives the multiplier.
     league_context = _resolve_league_context()
 
-    # TEP-native correction retired (2026-04-20): tep_multiplier is
-    # now a fixed 1.15, and TEP-native sources pass through unchanged.
-    # The correction factor is the identity (1.0) from here on.
+    # TEP-native correction retired: TEP-native sources are hardcoded
+    # at 1.10× inside ``_compute_unified_rankings``; this field is
+    # the identity (1.0) at this layer.
     tep_native_correction = 1.0
 
     # Two-level copy of raw_payload: shallow at the top, one-deep for

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -32,6 +32,7 @@ import json
 from src.api.data_contract import (
     _DELTA_PLAYER_FIELDS,
     _RANKING_SOURCES,
+    _TE_BLANKET_NON_NATIVE_MULTIPLIER,
     _TEP_DERIVATION_SLOPE,
     _compute_unified_rankings,
     _derive_tep_multiplier_from_league,
@@ -800,7 +801,7 @@ class TestNormalizeTepMultiplier(unittest.TestCase):
 
     def test_out_of_range_values_clamp(self) -> None:
         self.assertEqual(normalize_tep_multiplier({"tep_multiplier": 0.5}), 1.0)
-        self.assertEqual(normalize_tep_multiplier({"tep_multiplier": 3.0}), 2.0)
+        self.assertEqual(normalize_tep_multiplier({"tep_multiplier": 3.0}), 1.5)
         self.assertEqual(normalize_tep_multiplier({"tep_multiplier": -1}), 1.0)
 
     def test_non_numeric_values_return_none(self) -> None:
@@ -902,36 +903,53 @@ class TestTepMultiplierDerivation(unittest.TestCase):
         self.assertAlmostEqual(_TEP_DERIVATION_SLOPE, 0.30)
 
 
-class TestBuildContractTepFixed(unittest.TestCase):
-    """TEP is a fixed 1.15 (2026-04-20 simplification).
+class TestBuildContractTepSlider(unittest.TestCase):
+    """TEP slider is operator-tunable (2026-05-06 repurpose).
 
-    The prior league-derivation / explicit-override / clamp tests
-    exercised a variance knob that no longer exists.  The one
-    invariant we still pin: every contract's summary block shows
-    tepMultiplier = 1.15 and source = "fixed", regardless of
-    league context or caller-supplied value.
+    ``tep_multiplier=None`` → use the hardcoded default
+    (``_TE_BLANKET_NON_NATIVE_MULTIPLIER``, currently 1.25), source
+    stamped ``"default"``.  An explicit float (clamped to [1.0, 1.5]
+    by ``normalize_tep_multiplier``) is used verbatim, source stamped
+    ``"override"``.  TEP-native (1.10) and KTC exemption are hardcoded
+    inside ``_compute_unified_rankings`` and not exposed here.
     """
 
-    def test_summary_always_reports_fixed_1_15(self) -> None:
+    def test_summary_default_is_non_tep_constant(self) -> None:
         contract = build_api_data_contract(_fixture_raw_payload())
         rov = contract.get("rankingsOverride") or {}
-        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.15)
-        self.assertEqual(rov.get("tepMultiplierSource"), "fixed")
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplier") or 0),
+            _TE_BLANKET_NON_NATIVE_MULTIPLIER,
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "default")
 
-    def test_caller_supplied_tep_is_ignored(self) -> None:
-        """Passing any explicit tep_multiplier is a no-op — the
-        contract still reflects the fixed 1.15 boost.
-        """
-        for v in (1.0, 1.30, 2.0, None):
+    def test_explicit_override_reflected_in_summary(self) -> None:
+        for v in (1.0, 1.10, 1.25, 1.40, 1.5):
             contract = build_api_data_contract(
                 _fixture_raw_payload(), tep_multiplier=v
             )
             rov = contract.get("rankingsOverride") or {}
             self.assertAlmostEqual(
                 float(rov.get("tepMultiplier") or 0),
-                1.15,
-                msg=f"tep_multiplier={v} produced unexpected effective value",
+                v,
+                msg=f"tep_multiplier={v} did not propagate to summary",
             )
+            self.assertEqual(
+                rov.get("tepMultiplierSource"),
+                "override",
+                msg=f"tep_multiplier={v} did not stamp source=override",
+            )
+
+    def test_none_falls_back_to_default(self) -> None:
+        contract = build_api_data_contract(
+            _fixture_raw_payload(), tep_multiplier=None
+        )
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplier") or 0),
+            _TE_BLANKET_NON_NATIVE_MULTIPLIER,
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "default")
 
 
 


### PR DESCRIPTION
## Summary

- IDPTC was misclassified `is_tep_premium=False` while its scraper now pulls already-TEP-boosted `value_sftep` values — fixed by flipping the flag to `True` in both the Python registry and the JS mirror, so it gets the same 1.10× TEP-native correction as Yahoo Boone / FP Fitzmaurice / DN SfTep instead of the full 1.25× non-TEP boost (compounding).
- `/settings` "TE Premium" slider is wired back into the apply path. `tep_multiplier=None` → backend default (`_TE_BLANKET_NON_NATIVE_MULTIPLIER`, 1.25); finite value clamped to `[1.0, 1.5]` → operator override. TEP-native (1.10×) and KTC exemption remain hardcoded — only the headline non-TEP knob is exposed.
- Obsolete league-derivation copy on `/settings` retired; description now describes the actual current behavior. Tests + frontend registry parity updated.

## Test plan

- [x] `python -m pytest tests/ -q` — 2813 passed, 3 skipped
- [x] `cd frontend && npm run build` — clean, all bundle budgets OK
- [ ] Live smoke after deploy: drag the slider on `/settings`, confirm non-TEP TE values scale, KTC/TEP-native unchanged
- [ ] Spot-check a top TE in `meta["tepMultiplier"]` (per-source audit) — IDPTC now stamps 1.10 (`tepNativeCorrectionApplied`) instead of 1.25 (`tepBoostApplied`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)