### PR TITLE
feat(tep): split TE Premium into two operator-tunable multipliers

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -4816,9 +4816,6 @@ async def run(progress_callback=None):
     # Site mode mapping
     _rank_sites = {"dynastyNerds", "pffIdp", "draftSharksIdp", "fantasyProsIdp", "draftSharks"}
     _idp_rank_sites = set()  # currently none use idpRank mode in scraper (handled in dashboard)
-    # DynastyDaddy values are treated as non-TEP and get TEP_MULT applied for TEs.
-    _tep_sites = {"ktc", "fantasyCalc", "fantasyPros", "draftSharks",
-                  "yahoo", "dynastyNerds", "idpTradeCalc"}
     # Z-score parameters
     Z_FLOOR, Z_CEILING = -2.0, 4.0
     RANK_OFFSET, RANK_DIVISOR, RANK_EXPONENT = 27, 28, -0.66
@@ -4924,7 +4921,6 @@ async def run(progress_callback=None):
     IDP_RANK_OFFSET = 15     # Controls curve flatness near the top
     IDP_RANK_DIVISOR = 16    # Paired with offset so rank 1 → exactly IDP_ANCHOR_TOP
     IDP_RANK_EXPONENT = -0.72  # Steeper than offense (-0.66) since IDP value drops faster
-    TEP_MULT = 1.15
     SINGLE_SOURCE_DISCOUNT = 0.85  # 15% discount for players on only 1 site
     COMPOSITE_SCALE = 9999
     OUTLIER_TRIM_GAP = 0.18       # Trim only true outliers, not legitimate elite values
@@ -5360,11 +5356,6 @@ async def run(progress_callback=None):
                 site_raw = min(raw_val, IDP_ANCHOR_TOP)
             else:
                 site_raw = raw_val
-
-            # TEP boost for TEs on non-TEP sites
-            is_te = _is_te(name)
-            if is_te and dash_key not in _tep_sites and TEP_MULT > 1:
-                site_raw *= TEP_MULT
 
             if site_raw <= 0:
                 continue

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -128,6 +128,23 @@ export default function SettingsPage() {
     settings?.tepMultiplier === null ||
     settings?.tepMultiplier === undefined;
 
+  // Parallel "TEP-native" multiplier — the per-bucket boost applied
+  // to TEP-native sources (DN SF-TEP, Yahoo Boone, FP Fitzmaurice)
+  // on TE rows.  Mirrors the non-TEP knob above; default 1.10.
+  const tepNativeDefault = (() => {
+    const v = Number(rawData?.rankingsOverride?.tepNativeMultiplierDerived);
+    return Number.isFinite(v) ? v : 1.1;
+  })();
+  const tepNativeInputValue = (() => {
+    const raw = settings?.tepNativeMultiplier;
+    if (raw === null || raw === undefined) return tepNativeDefault;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : tepNativeDefault;
+  })();
+  const tepNativeIsDefault =
+    settings?.tepNativeMultiplier === null ||
+    settings?.tepNativeMultiplier === undefined;
+
   // Split the canonical registry into offense / IDP groups by the
   // declared scope field.  idpTradeCalc is listed under IDP (its
   // primary backbone scope) even though its `extraScopes` also
@@ -215,7 +232,7 @@ export default function SettingsPage() {
           </select>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-          <label style={{ minWidth: 100, fontSize: "0.82rem" }}>TE Premium</label>
+          <label style={{ minWidth: 140, fontSize: "0.82rem" }}>TEP — non-native</label>
           <input
             type="number"
             min={1.0}
@@ -259,10 +276,57 @@ export default function SettingsPage() {
             </button>
           </div>
         )}
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+          <label style={{ minWidth: 140, fontSize: "0.82rem" }}>TEP — native</label>
+          <input
+            type="number"
+            min={1.0}
+            max={1.5}
+            step={0.01}
+            value={tepNativeInputValue}
+            onChange={(e) => {
+              const n = parseFloat(e.target.value);
+              if (Number.isFinite(n)) {
+                update("tepNativeMultiplier", Math.max(1.0, Math.min(1.5, n)));
+              }
+            }}
+            style={{
+              width: 90,
+              padding: "4px 8px",
+              fontSize: "0.82rem",
+              fontFamily: "var(--mono)",
+            }}
+          />
+          <span className="muted" style={{ fontSize: "0.66rem" }}>
+            {tepNativeIsDefault
+              ? `Default ${tepNativeDefault.toFixed(2)}× — applied to TEP-native sources on TE rows`
+              : `Custom ${Number(tepNativeInputValue).toFixed(2)}× — TEP-native sources on TE rows`}
+          </span>
+        </div>
+        {!tepNativeIsDefault && (
+          <div style={{ marginTop: 4, marginBottom: 6 }}>
+            <button
+              type="button"
+              className="button-reset"
+              style={{
+                fontSize: "0.7rem",
+                color: "var(--accent-gold, #FFC704)",
+                textDecoration: "underline",
+                cursor: "pointer",
+                padding: 0,
+              }}
+              onClick={() => update("tepNativeMultiplier", null)}
+            >
+              Reset to default ({tepNativeDefault.toFixed(2)}×)
+            </button>
+          </div>
+        )}
         <p className="muted" style={{ fontSize: "0.68rem", marginTop: 4, marginBottom: 0 }}>
-          Multiplier applied to TE values from sources that don&apos;t
-          already publish a TE-premium board (DLF, FBG, FP consensus,
-          Flock, etc.).  Sources tagged{" "}
+          Two parallel TE Premium multipliers, both applied at blend
+          time on TE rows only.  <strong>Non-native</strong> covers
+          sources whose published board doesn&apos;t already bake in
+          TE premium (DLF, FBG, FP consensus, Flock, etc.).{" "}
+          <strong>Native</strong> covers sources tagged{" "}
           <span
             style={{
               fontFamily: "var(--mono)",
@@ -275,12 +339,13 @@ export default function SettingsPage() {
           >
             TEP NATIVE
           </span>{" "}
-          (KTC SfTep, IDPTC, DN SfTep, Yahoo Boone, FP Fitzmaurice) get
-          a smaller fixed 1.10× nudge instead, since their boards
-          already bake in a TE premium.  KTC standard SF is the
-          reference baseline and passes through unchanged.  Changing
-          the value re-runs the canonical ranking pipeline so every
-          page (rankings, trade calculator, edge) sees the same values.
+          (DN SfTep, Yahoo Boone, FP Fitzmaurice) — their boards
+          already publish some TE premium so the smaller default
+          (1.10×) is a calibration nudge, not a fresh boost.  KTC
+          (standard SF and SF-TE++) is the canonical baseline and
+          passes through both knobs unchanged.  Changing either value
+          re-runs the canonical ranking pipeline so every page
+          (rankings, trade calculator, edge) sees the same values.
         </p>
       </Section>
 

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -325,7 +325,7 @@ export default function SettingsPage() {
           Two parallel TE Premium multipliers, both applied at blend
           time on TE rows only.  <strong>Non-native</strong> covers
           sources whose published board doesn&apos;t already bake in
-          TE premium (DLF, FBG, FP consensus, Flock, etc.).{" "}
+          TE premium (DLF, FBG, FP consensus, Flock, DD, DraftSharks).{" "}
           <strong>Native</strong> covers sources tagged{" "}
           <span
             style={{
@@ -339,12 +339,12 @@ export default function SettingsPage() {
           >
             TEP NATIVE
           </span>{" "}
-          (DN SfTep, Yahoo Boone, FP Fitzmaurice) — their boards
-          already publish some TE premium so the smaller default
-          (1.10×) is a calibration nudge, not a fresh boost.  KTC
-          (standard SF and SF-TE++) is the canonical baseline and
-          passes through both knobs unchanged.  Changing either value
-          re-runs the canonical ranking pipeline so every page
+          (IDPTC, DN SfTep, Yahoo Boone, FP Fitzmaurice) — their
+          boards already publish some TE premium so the smaller
+          default (1.10×) is a calibration nudge, not a fresh boost.
+          KTC (standard SF and SF-TE++) is the canonical baseline
+          and passes through both knobs unchanged.  Changing either
+          value re-runs the canonical ranking pipeline so every page
           (rankings, trade calculator, edge) sees the same values.
         </p>
       </Section>

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -32,6 +32,13 @@ export function useDynastyData() {
       : Number.isFinite(Number(rawTep))
         ? Number(rawTep)
         : null;
+  const rawTepNative = settings?.tepNativeMultiplier;
+  const tepNativeMultiplier =
+    rawTepNative === null || rawTepNative === undefined
+      ? null
+      : Number.isFinite(Number(rawTepNative))
+        ? Number(rawTepNative)
+        : null;
   // Serialize the override map so the effect's dependency array
   // fires on semantic changes, not reference churn, without forcing
   // callers to memoize on their side.  The tepMultiplier is part of
@@ -77,6 +84,7 @@ export function useDynastyData() {
         const payload = await fetchDynastyData({
           siteOverrides,
           tepMultiplier,
+          tepNativeMultiplier,
         });
         if (!active) return;
 
@@ -134,7 +142,7 @@ export function useDynastyData() {
       active = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [siteOverridesKey, tepMultiplier, leagueRefreshKey]);
+  }, [siteOverridesKey, tepMultiplier, tepNativeMultiplier, leagueRefreshKey]);
 
   const rows = useMemo(() => {
     try {

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -12,18 +12,22 @@ export const SETTINGS_DEFAULTS = {
 
   // Value adjustment strengths
   //
-  // tepMultiplier: null means "use the backend default" — currently
-  // the operator-set non-TEP TE multiplier (1.25), applied to TE
-  // values from sources that don't already bake in a TE-premium board
-  // (DLF, FBG, FP consensus, Flock, etc.).  When the user drags the
-  // slider on /settings, this flips from null to a finite number,
-  // which ``fetchDynastyData`` then POSTs to the override endpoint as
-  // an explicit override on top of that default.  "Reset" returns it
-  // to null so the default kicks back in.  TEP-native sources (KTC
-  // SfTep, IDPTC, DN SfTep, Yahoo Boone, FP Fitzmaurice) are pinned at
-  // 1.10× backend-side and are not affected by this slider; KTC
-  // standard SF is exempt entirely.
+  // tepMultiplier / tepNativeMultiplier: two parallel knobs for the
+  // TE Premium boost applied at blend time.
+  //
+  //   * ``tepMultiplier`` → non-TEP sources (DLF, FBG, FP consensus,
+  //     Flock, etc.).  Default 1.25 backend-side.
+  //   * ``tepNativeMultiplier`` → TEP-native sources (DN SF-TEP,
+  //     Yahoo Boone, FP Fitzmaurice).  Default 1.10 backend-side.
+  //
+  // KTC variants (ktc, ktcSfTep) stay exempt regardless — KTC's TE++
+  // board is the canonical reference.  ``null`` means "use the
+  // backend default"; when the user types a value on /settings this
+  // flips to a finite number, which ``fetchDynastyData`` POSTs to
+  // the override endpoint as an explicit override.  "Reset" returns
+  // it to null so the default kicks back in.
   tepMultiplier: null,               // null = backend default (1.25); 1.0..1.5 = explicit operator override
+  tepNativeMultiplier: null,         // null = backend default (1.10); 1.0..1.5 = explicit operator override
 
   // Rankings display
   rankingsSortBasis: "full",         // "full" | "raw"

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -845,6 +845,18 @@ export function tepMultiplierIsCustomized(tepMultiplier) {
   return Number.isFinite(n);
 }
 
+/**
+ * Same predicate as ``tepMultiplierIsCustomized`` but for the
+ * parallel ``tepNativeMultiplier`` knob.  Treated identically: ``null``
+ * / ``undefined`` / non-finite values mean "use the backend default
+ * (1.10)" so ``fetchDynastyData`` skips posting the field.
+ */
+export function tepNativeMultiplierIsCustomized(tepNativeMultiplier) {
+  if (tepNativeMultiplier === null || tepNativeMultiplier === undefined) return false;
+  const n = Number(tepNativeMultiplier);
+  return Number.isFinite(n);
+}
+
 // ── Row materialization ──────────────────────────────────────────────
 // ``buildRows`` materializes the backend contract (``playersArray``
 // or legacy ``players`` dict) into the flat row shape every frontend
@@ -1440,9 +1452,17 @@ export async function fetchDynastyData(opts = {}) {
       : Number.isFinite(Number(rawTep))
         ? Number(rawTep)
         : null;
+  const rawTepNative = opts.tepNativeMultiplier;
+  const tepNativeMultiplier =
+    rawTepNative === null || rawTepNative === undefined
+      ? null
+      : Number.isFinite(Number(rawTepNative))
+        ? Number(rawTepNative)
+        : null;
   const sitesCustomized = siteOverridesAreCustomized(siteOverrides);
   const tepCustomized = tepMultiplierIsCustomized(tepMultiplier);
-  const customized = sitesCustomized || tepCustomized;
+  const tepNativeCustomized = tepNativeMultiplierIsCustomized(tepNativeMultiplier);
+  const customized = sitesCustomized || tepCustomized || tepNativeCustomized;
 
   // Default path (no overrides): fetch + cache the base contract.
   // The backend will derive tep_multiplier from the operator's
@@ -1469,6 +1489,9 @@ export async function fetchDynastyData(opts = {}) {
   const body = { ...(siteOverrides || {}) };
   if (tepCustomized) {
     body.tep_multiplier = tepMultiplier;
+  }
+  if (tepNativeCustomized) {
+    body.tep_native_multiplier = tepNativeMultiplier;
   }
 
   try {

--- a/server.py
+++ b/server.py
@@ -63,6 +63,7 @@ from src.api.data_contract import (
     get_ranking_source_registry,
     normalize_source_overrides,
     normalize_tep_multiplier,
+    normalize_tep_native_multiplier,
     validate_api_data_contract,
 )
 from src.api import guest_passes as _guest_passes
@@ -2713,6 +2714,7 @@ async def post_rankings_overrides(request: Request):
 
     overrides, warnings = normalize_source_overrides(body)
     tep_multiplier = normalize_tep_multiplier(body)
+    tep_native_multiplier = normalize_tep_native_multiplier(body)
 
     view = (request.query_params.get("view") or "").strip().lower()
     delta_view = view in {"delta", "compact", "slim"}
@@ -2724,6 +2726,7 @@ async def post_rankings_overrides(request: Request):
                 data_source=latest_data_source,
                 source_overrides=overrides if overrides else None,
                 tep_multiplier=tep_multiplier,
+                tep_native_multiplier=tep_native_multiplier,
             )
         else:
             contract_payload = build_api_data_contract(
@@ -2731,6 +2734,7 @@ async def post_rankings_overrides(request: Request):
                 data_source=latest_data_source,
                 source_overrides=overrides if overrides else None,
                 tep_multiplier=tep_multiplier,
+                tep_native_multiplier=tep_native_multiplier,
             )
     except Exception as exc:
         log.exception("Failed to rebuild contract with overrides: %s", exc)

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1814,6 +1814,8 @@ _RESERVED_OVERRIDE_BODY_KEYS: frozenset[str] = frozenset(
     {
         "tep_multiplier",
         "tepMultiplier",
+        "tep_native_multiplier",
+        "tepNativeMultiplier",
         "enabled_sources",
         "enabledSources",
         "weights",
@@ -1848,6 +1850,31 @@ def normalize_tep_multiplier(raw: Any) -> float | None:
     if not isinstance(raw, dict):
         return None
     for key in ("tep_multiplier", "tepMultiplier"):
+        if key in raw:
+            try:
+                v = float(raw[key])
+            except (TypeError, ValueError):
+                return None
+            if not math.isfinite(v):
+                return None
+            return max(1.0, min(1.5, v))
+    return None
+
+
+def normalize_tep_native_multiplier(raw: Any) -> float | None:
+    """Extract + clamp the TEP-native multiplier from a POST override body.
+
+    Mirrors :func:`normalize_tep_multiplier` but for the parallel knob
+    that controls the boost applied to TEP-native sources (DN SF-TEP,
+    Yahoo Boone, FP Fitzmaurice).  Returns ``None`` when the key is
+    absent / unparseable so the pipeline falls back to the hardcoded
+    default (``_TE_BLANKET_NATIVE_MULTIPLIER`` = 1.10).
+    """
+    import math
+
+    if not isinstance(raw, dict):
+        return None
+    for key in ("tep_native_multiplier", "tepNativeMultiplier"):
         if key in raw:
             try:
                 v = float(raw[key])
@@ -2015,6 +2042,9 @@ def _summarize_source_overrides(
     tep_multiplier: float = 1.0,
     tep_multiplier_derived: float = 1.0,
     tep_multiplier_source: str = "default",
+    tep_native_multiplier: float = 1.0,
+    tep_native_multiplier_derived: float = 1.0,
+    tep_native_multiplier_source: str = "default",
     tep_native_correction: float = 1.0,
 ) -> dict[str, Any]:
     """Produce the ``rankingsOverride`` contract summary block.
@@ -2110,6 +2140,27 @@ def _summarize_source_overrides(
     if abs(tep_eff - tep_derived) > 1e-6:
         is_customized = True
 
+    # TEP-native: clamp + customization check, mirroring the non-TEP
+    # multiplier above.
+    try:
+        tep_native_eff = float(tep_native_multiplier)
+    except (TypeError, ValueError):
+        tep_native_eff = 1.0
+    if not math.isfinite(tep_native_eff):
+        tep_native_eff = 1.0
+    tep_native_eff = max(1.0, min(2.0, tep_native_eff))
+
+    try:
+        tep_native_derived = float(tep_native_multiplier_derived)
+    except (TypeError, ValueError):
+        tep_native_derived = 1.0
+    if not math.isfinite(tep_native_derived):
+        tep_native_derived = 1.0
+    tep_native_derived = max(1.0, min(2.0, tep_native_derived))
+
+    if abs(tep_native_eff - tep_native_derived) > 1e-6:
+        is_customized = True
+
     # Clamp the TEP-native correction for display purposes only; the
     # pipeline already consumed it as-is during the blend.
     try:
@@ -2139,6 +2190,10 @@ def _summarize_source_overrides(
         "tepMultiplierDefault": round(tep_derived, 4),
         "tepMultiplierDerived": round(tep_derived, 4),
         "tepMultiplierSource": str(tep_multiplier_source or "default"),
+        "tepNativeMultiplier": round(tep_native_eff, 4),
+        "tepNativeMultiplierDefault": round(tep_native_derived, 4),
+        "tepNativeMultiplierDerived": round(tep_native_derived, 4),
+        "tepNativeMultiplierSource": str(tep_native_multiplier_source or "default"),
         "tepNativeCorrection": round(tep_native_corr, 4),
         # Underlying Sleeper TE-bonus value driving the derivation.
         # Empty / non-TEP leagues return 0.0; standard "TEP-1.5" is 0.5.
@@ -5108,6 +5163,7 @@ def _compute_unified_rankings(
     *,
     source_overrides: dict[str, dict[str, Any]] | None = None,
     tep_multiplier: float | None = None,
+    tep_native_multiplier: float | None = None,
     tep_native_correction: float = 1.0,
 ) -> dict[str, str]:
     """Compute a single unified ranking across all sources and positions.
@@ -5228,15 +5284,20 @@ def _compute_unified_rankings(
     # Resolve the non-TEP-source TE multiplier.  ``None`` means the
     # caller did not supply a slider override, so use the operator's
     # default (``_TE_BLANKET_NON_NATIVE_MULTIPLIER``, 1.25).  An
-    # explicit float comes from the ``/settings`` "TE Premium" slider
+    # explicit float comes from the ``/settings`` "TE Premium" input
     # via :func:`normalize_tep_multiplier`, which clamps to [1.0, 1.5].
-    # The TEP-native (1.10) factor and KTC exemption are hardcoded —
-    # only the non-TEP boost is operator-tunable.
+    # The TEP-native default (1.10) is now operator-tunable too via
+    # :func:`normalize_tep_native_multiplier`; KTC stays exempt.
     _ = tep_native_correction  # acknowledged-unused, kept for backwards-compat
     effective_non_tep_multiplier: float = (
         float(tep_multiplier)
         if tep_multiplier is not None
         else _TE_BLANKET_NON_NATIVE_MULTIPLIER
+    )
+    effective_native_multiplier: float = (
+        float(tep_native_multiplier)
+        if tep_native_multiplier is not None
+        else _TE_BLANKET_NATIVE_MULTIPLIER
     )
 
     # Build the active source list honoring user-supplied overrides.
@@ -5902,7 +5963,7 @@ def _compute_unified_rankings(
                     value *= effective_non_tep_multiplier
                     tep_applied = True
                 elif source_key in tep_native_source_keys:
-                    value *= _TE_BLANKET_NATIVE_MULTIPLIER
+                    value *= effective_native_multiplier
                     tep_native_corrected = True
             all_values.append(value)
             is_anchor_source = source_key in cross_market_keys
@@ -5929,7 +5990,7 @@ def _compute_unified_rankings(
                 meta["tepMultiplier"] = round(effective_non_tep_multiplier, 4)
             if tep_native_corrected:
                 meta["tepNativeCorrectionApplied"] = True
-                meta["tepNativeCorrection"] = round(_TE_BLANKET_NATIVE_MULTIPLIER, 4)
+                meta["tepNativeCorrection"] = round(effective_native_multiplier, 4)
 
         # ── Per-player Hampel outlier rejection (K=2.75) ──
         # Drop source values that sit more than 2.75 MADs from the
@@ -7053,6 +7114,7 @@ def build_api_data_contract(
     data_source: dict[str, Any] | None = None,
     source_overrides: dict[str, dict[str, Any]] | None = None,
     tep_multiplier: float | None = None,
+    tep_native_multiplier: float | None = None,
     _for_delta: bool = False,
 ) -> dict[str, Any]:
     """Build a full API data contract payload from a raw scraper bundle.
@@ -7091,14 +7153,18 @@ def build_api_data_contract(
     this to ``True`` so overrides round-trips don't pay for output
     blocks the wire shape drops.
     """
-    # TEP slider repurposed (2026-05-06): ``tep_multiplier`` is the
-    # operator-tunable boost applied to non-TEP-native source TE
-    # contributions.  ``None`` → use the default
-    # (``_TE_BLANKET_NON_NATIVE_MULTIPLIER``, 1.25); a finite float
-    # (clamped to [1.0, 1.5] by ``normalize_tep_multiplier``) → use
-    # the operator's slider value verbatim.  The TEP-native (1.10)
-    # correction and KTC exemption are hardcoded; only this
-    # non-TEP boost is operator-tunable.
+    # TEP inputs: two parallel knobs control the per-bucket TE boost,
+    # both operator-tunable and both falling back to hardcoded
+    # defaults when ``None``.
+    #
+    #   * ``tep_multiplier``        — non-TEP sources (default 1.25,
+    #     ``_TE_BLANKET_NON_NATIVE_MULTIPLIER``)
+    #   * ``tep_native_multiplier`` — TEP-native sources (default 1.10,
+    #     ``_TE_BLANKET_NATIVE_MULTIPLIER``)
+    #
+    # Each is clamped to [1.0, 1.5] at the normalize layer.  KTC
+    # variants stay exempt regardless — see
+    # ``_TE_BLANKET_KTC_EXEMPT_KEYS``.
     if tep_multiplier is None:
         tep_multiplier_effective = _TE_BLANKET_NON_NATIVE_MULTIPLIER
         tep_multiplier_source = "default"
@@ -7106,13 +7172,23 @@ def build_api_data_contract(
         tep_multiplier_effective = float(tep_multiplier)
         tep_multiplier_source = "override"
     tep_multiplier_derived = _TE_BLANKET_NON_NATIVE_MULTIPLIER
+
+    if tep_native_multiplier is None:
+        tep_native_multiplier_effective = _TE_BLANKET_NATIVE_MULTIPLIER
+        tep_native_multiplier_source = "default"
+    else:
+        tep_native_multiplier_effective = float(tep_native_multiplier)
+        tep_native_multiplier_source = "override"
+    tep_native_multiplier_derived = _TE_BLANKET_NATIVE_MULTIPLIER
+
     # League context still resolved for other uses (roster count,
     # logging); TEP derivation no longer drives the multiplier.
     league_context = _resolve_league_context()
 
-    # TEP-native correction retired: TEP-native sources are hardcoded
-    # at 1.10× inside ``_compute_unified_rankings``; this field is
-    # the identity (1.0) at this layer.
+    # TEP-native correction retired: TEP-native sources are now scaled
+    # via ``tep_native_multiplier_effective`` inside
+    # ``_compute_unified_rankings``; this field is the identity at
+    # this layer.
     tep_native_correction = 1.0
 
     # Two-level copy of raw_payload: shallow at the top, one-deep for
@@ -7210,6 +7286,7 @@ def build_api_data_contract(
         csv_index=csv_index,
         source_overrides=source_overrides,
         tep_multiplier=tep_multiplier_effective,
+        tep_native_multiplier=tep_native_multiplier_effective,
         tep_native_correction=tep_native_correction,
     )
 
@@ -7392,6 +7469,9 @@ def build_api_data_contract(
         tep_multiplier=tep_multiplier_effective,
         tep_multiplier_derived=tep_multiplier_derived,
         tep_multiplier_source=tep_multiplier_source,
+        tep_native_multiplier=tep_native_multiplier_effective,
+        tep_native_multiplier_derived=tep_native_multiplier_derived,
+        tep_native_multiplier_source=tep_native_multiplier_source,
         tep_native_correction=tep_native_correction,
     )
 
@@ -7482,6 +7562,7 @@ def build_rankings_delta_payload(
     data_source: dict[str, Any] | None = None,
     source_overrides: dict[str, dict[str, Any]] | None = None,
     tep_multiplier: float | None = None,
+    tep_native_multiplier: float | None = None,
 ) -> dict[str, Any]:
     """Build a compact delta contract for the rankings-override endpoint.
 
@@ -7523,6 +7604,7 @@ def build_rankings_delta_payload(
         data_source=data_source,
         source_overrides=source_overrides,
         tep_multiplier=tep_multiplier,
+        tep_native_multiplier=tep_native_multiplier,
         _for_delta=True,
     )
 

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -45,6 +45,7 @@ from src.api.data_contract import (
     get_ranking_source_registry,
     normalize_source_overrides,
     normalize_tep_multiplier,
+    normalize_tep_native_multiplier,
 )
 
 
@@ -841,6 +842,48 @@ class TestNormalizeTepMultiplier(unittest.TestCase):
         self.assertEqual(overrides, {"ktcSfTep": {"include": False}})
         self.assertEqual(warnings, [])
         self.assertEqual(normalize_tep_multiplier(body), 1.2)
+
+
+class TestNormalizeTepNativeMultiplier(unittest.TestCase):
+    """``tep_native_multiplier`` mirrors ``tep_multiplier`` exactly —
+    same validation contract (None for absent / invalid, clamp to
+    [1.0, 1.5] otherwise) but for the TEP-native bucket whose default
+    is 1.10 rather than 1.25.
+    """
+
+    def test_missing_field_returns_none(self) -> None:
+        self.assertIsNone(normalize_tep_native_multiplier(None))
+        self.assertIsNone(normalize_tep_native_multiplier({}))
+        self.assertIsNone(normalize_tep_native_multiplier({"ktcSfTep": {"include": False}}))
+        # The non-native key must NOT satisfy the native lookup.
+        self.assertIsNone(normalize_tep_native_multiplier({"tep_multiplier": 1.2}))
+
+    def test_both_key_styles_accepted(self) -> None:
+        self.assertEqual(normalize_tep_native_multiplier({"tep_native_multiplier": 1.10}), 1.10)
+        self.assertEqual(normalize_tep_native_multiplier({"tepNativeMultiplier": 1.20}), 1.20)
+
+    def test_snake_case_wins_when_both_present(self) -> None:
+        self.assertEqual(
+            normalize_tep_native_multiplier(
+                {"tep_native_multiplier": 1.10, "tepNativeMultiplier": 1.30}
+            ),
+            1.10,
+        )
+
+    def test_clamps_to_supported_range(self) -> None:
+        self.assertEqual(normalize_tep_native_multiplier({"tep_native_multiplier": 0.5}), 1.0)
+        self.assertEqual(normalize_tep_native_multiplier({"tep_native_multiplier": 3.0}), 1.5)
+        self.assertEqual(normalize_tep_native_multiplier({"tep_native_multiplier": -1}), 1.0)
+
+    def test_unparseable_returns_none(self) -> None:
+        self.assertIsNone(normalize_tep_native_multiplier({"tep_native_multiplier": "nope"}))
+        self.assertIsNone(normalize_tep_native_multiplier({"tep_native_multiplier": None}))
+        self.assertIsNone(
+            normalize_tep_native_multiplier({"tep_native_multiplier": float("inf")})
+        )
+        self.assertIsNone(
+            normalize_tep_native_multiplier({"tep_native_multiplier": float("nan")})
+        )
 
 
 class TestTepMultiplierDerivation(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **Drop the hidden ×1.15** that the scraper was baking into every TE on sites missing from a stale `_tep_sites` allowlist (`Dynasty Scraper.py`).  KTC's TE++ board was on that miss-list, so its values were silently boosted before the canonical pipeline ever saw them — the cause of Brock Bowers showing 11,020 / 9,999 in the audit on `Russini Panini`.
- **Split TE Premium into two operator inputs** on `/settings`:
  - **TEP — non-native** (`tepMultiplier`) — non-TEP sources (DLF, FBG, FP consensus, Flock, etc.).  Default 1.25, [1.0, 1.5] clamp.
  - **TEP — native** (`tepNativeMultiplier`) — TEP-native sources (DN SF-TEP, Yahoo Boone, FP Fitzmaurice).  Default 1.10, [1.0, 1.5] clamp.
- **KTC stays exempt** (`ktc` and `ktcSfTep`).  Its TE++ board is the canonical reference — no scaling, no double-boost.

## Implementation

- New `normalize_tep_native_multiplier()` mirrors `normalize_tep_multiplier()` (same clamp, same key handling).
- `_compute_unified_rankings` accepts `tep_native_multiplier` and uses it on TEP-native sources instead of the hardcoded `_TE_BLANKET_NATIVE_MULTIPLIER`.
- `build_api_data_contract` + `build_rankings_delta_payload` thread it end-to-end; `rankingsOverride` summary stamps four new fields (`tepNativeMultiplier`, `tepNativeMultiplierDefault`, `tepNativeMultiplierDerived`, `tepNativeMultiplierSource`).
- POST body for `/api/rankings/overrides` accepts `tep_native_multiplier` / `tepNativeMultiplier` (added to `_RESERVED_OVERRIDE_BODY_KEYS` so the per-source parser doesn't warn).
- Frontend: `useSettings`, `useDynastyData`, `fetchDynastyData`, and `/settings/page.jsx` all wired with the parallel knob.

## Net behaviour change

| Source bucket | Before | After |
|---|---|---|
| KTC (`ktc`, `ktcSfTep`) | scraper ×1.15 (silent) → blend exempt → **net ×1.15** | scraper untouched → blend exempt → **net ×1.0** ✓ |
| Non-TEP (DLF, FBG, FP SF, Flock, DD, DS, IDPTC, …) | scraper ×1.15 + blend ×1.25 → **×1.4375** | blend ×1.25 → **×1.25** |
| TEP-native (DN SF-TEP, Boone, Fitzmaurice) | varied (string-mismatch in `_tep_sites`) | blend ×1.10 (or operator override) |

## Test plan

- [x] `pytest tests/api/` → 1064 passed, 6 skipped (pre-existing skips unrelated)
- [x] New `TestNormalizeTepNativeMultiplier` covers clamp / unparseable / both key styles / snake-case wins
- [ ] Load `/settings`: confirm both inputs render, type non-default values into each, confirm the rankings + audit panels reflect the change
- [ ] Verify Brock Bowers' KTC audit card shows raw ~9,588 / Hill ~9,640 (no longer 11,020 / 9,999)
- [ ] "Reset to default" works on each input independently

https://claude.ai/code/session_01F16khdmaJczizucu6S2hfi

---
_Generated by [Claude Code](https://claude.ai/code/session_01F16khdmaJczizucu6S2hfi)_