### PR TITLE
chore(tep): post-split followups — comment refresh, end-to-end test, prod verification

### DIFF
--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3881,10 +3881,11 @@ export default function DraftDashboardPage() {
               // 2026-04-28 registry change in #393).  Prefer the raw
               // scrape from ``rawSourceValues.ktcSfTep`` so rookie
               // dollar values match what keeptradecut.com displays
-              // for the TE++ board.  Falls back to TEP-corrected
-              // ``canonicalSiteValues.ktcSfTep`` (which equals raw
-              // for non-TEs anyway), then to the legacy ``ktc`` key
-              // for pre-#393 fixtures.
+              // for the TE++ board.  Falls back to
+              // ``canonicalSiteValues.ktcSfTep`` (post PR #406 this
+              // equals the raw scrape verbatim — KTC is exempt from
+              // the blend-time TE multiplier), then to the legacy
+              // ``ktc`` key for pre-#393 fixtures.
               ktcRawValue:
                 (typeof p?.rawSourceValues?.ktcSfTep === "number"
                   ? p.rawSourceValues.ktcSfTep : null)

--- a/frontend/components/trade/TradeSourceBreakdown.jsx
+++ b/frontend/components/trade/TradeSourceBreakdown.jsx
@@ -105,12 +105,12 @@ export default function TradeSourceBreakdown({
         //
         // Read the raw scrape from ``row.rawSourceValues.ktcSfTep``
         // so TE rows feed the V13 formula the actual KTC TE++ value
-        // (e.g. McBride 9154) rather than the TEP-corrected internal
-        // number stored in ``canonicalSites`` (10527 for McBride —
-        // wrong scale for the formula).  ``canonicalSites.ktcSfTep``
-        // remains a fallback because non-TE rows have it equal to
-        // the raw scrape, and pre-rawSourceValues fixtures still need
-        // a path through.
+        // straight from keeptradecut.com.  Post PR #406 the canonical
+        // ``canonicalSites.ktcSfTep`` stamp matches the raw scrape
+        // (KTC is in ``_TE_BLANKET_KTC_EXEMPT_KEYS`` and the scraper-
+        // side ×1.15 has been removed), so the two paths agree — the
+        // canonical fallback stays in place for legacy fixtures and
+        // as a defense against any future canonical-pipeline drift.
         //
         // For every other vendor we keep the Hill-normalized
         // ``valueContribution``: rank-only sources don't have a raw

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -904,9 +904,10 @@ export function getPlayerEdge(row) {
   //
   // Read KTC's TE++ raw scrape (``rawSourceValues.ktcSfTep``) so the
   // gap matches what the user sees on keeptradecut.com.  Falls back
-  // to ``canonicalSites.ktcSfTep`` (TEP-corrected internal value, raw
-  // for non-TEs) if the raw stamp is missing, then to the legacy
-  // ``canonicalSites.ktc`` board for pre-#393 fixtures.
+  // to ``canonicalSites.ktcSfTep`` (post PR #406 this equals the raw
+  // scrape verbatim — KTC is exempt from the blend-time TE
+  // multiplier) if the rawSourceValues stamp is missing, then to the
+  // legacy ``canonicalSites.ktc`` board for pre-#393 fixtures.
   let edgePct = 0;
   const ourValue = Number(row?.values?.full);
   const ktcValue =

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -6847,12 +6847,14 @@ def _source_count(p_data: dict[str, Any], canonical_sites: dict[str, int | None]
 # Sources whose 0-9999 published board is the user-meaningful value
 # (e.g. KTC publishes its dynasty rankings publicly on
 # keeptradecut.com — users compare popup chips to the website
-# directly).  ``canonicalSiteValues`` for these keys gets a TEP
-# correction applied for TE rows during blending, which makes the
-# stored value diverge from the raw scrape (e.g. Trey McBride's
-# ``ktcSfTep``: raw 9154, TEP-corrected canonicalSites 10527).  The
-# popup chip render reads ``rawSourceValues`` first for these keys so
-# the displayed number matches the source's website.  Mirrors
+# directly).  After the 2026-05 TEP split (PR #406), the scraper-
+# side ×1.15 is gone and ``ktcSfTep`` is in
+# ``_TE_BLANKET_KTC_EXEMPT_KEYS``, so ``canonicalSiteValues.ktcSfTep``
+# now equals the raw scrape verbatim for both TE and non-TE rows.
+# ``rawSourceValues`` is preserved as a parallel read path: the popup
+# chip render and per-player source-history chart read from it first,
+# which keeps display robust against any future divergence between
+# the canonical pipeline and the raw scrape.  Mirrors
 # ``_RAW_VALUE_PREFERRED_KEYS`` in ``src/api/source_history.py``.
 _RAW_VALUE_PREFERRED_KEYS: frozenset[str] = frozenset({"ktcSfTep"})
 
@@ -6991,9 +6993,12 @@ def _derive_player_row(
         # board is the user-meaningful display number (see
         # ``_RAW_VALUE_PREFERRED_KEYS``).  The popup chip render reads
         # this map first for these keys so the displayed number matches
-        # the source's website (e.g. KTC TE++ shows 9154 for McBride,
-        # not the TEP-corrected 10527 in canonicalSiteValues).  Sparse
-        # by design — only present for the listed keys.
+        # the source's website (KTC TE++ at keeptradecut.com).  Post
+        # the 2026-05 TEP split (PR #406), this stamp equals the
+        # corresponding ``canonicalSiteValues`` entry — the parallel
+        # path remains as a robustness guarantee against future
+        # canonical-pipeline corrections.  Sparse by design — only
+        # present for the listed keys.
         "rawSourceValues": _raw_source_values(p_data),
         "sourceCount": source_count,
         "sourcePresence": {k: (v is not None and v > 0) for k, v in canonical_sites.items()},

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -521,19 +521,24 @@ class TestRawSourceValues(unittest.TestCase):
     Value Adjustment formula read from this map so the displayed
     value matches the source's website (keeptradecut.com).
 
-    Without this stamp, ``canonicalSiteValues.ktcSfTep`` carries the
-    TEP-corrected internal value for TE rows (e.g. McBride raw 9154
-    becomes 10527 after the TE-only TEP multiplier), which doesn't
-    match what users see on the source.  ``rawSourceValues.ktcSfTep``
-    is the unmodified scrape from
+    Post PR #406 (the 2026-05 TEP split), ``ktcSfTep`` is exempt from
+    blend-time TE multipliers and the scraper-side ×1.15 has been
+    removed, so ``canonicalSiteValues.ktcSfTep`` equals the raw
+    scrape in production.  These tests still feed divergent values
+    to prove the contract layer's pass-through is faithful in BOTH
+    fields independently — that resilience is what protects the
+    display layer if a future correction is reintroduced upstream.
+    ``rawSourceValues.ktcSfTep`` mirrors
     ``CSVs/site_raw/ktcSfTep.csv``.
     """
 
     def test_raw_source_values_carries_ktc_sf_tep_for_te_row(self):
         """A TE with a top-level ``ktcSfTep`` raw scrape must surface
         that value at ``rawSourceValues.ktcSfTep`` on the playersArray
-        row.  ``canonicalSiteValues.ktcSfTep`` may carry the
-        TEP-corrected internal value; rawSourceValues stays raw.
+        row.  ``canonicalSiteValues.ktcSfTep`` is passed through
+        verbatim from the upstream canonical pipeline — the test
+        deliberately uses divergent inputs to assert independent
+        pass-through of both fields.
         """
         raw = {
             "players": {
@@ -543,7 +548,7 @@ class TestRawSourceValues(unittest.TestCase):
                     "_finalAdjusted": 9000,
                     "_canonicalSiteValues": {
                         "ktc": 7560,
-                        "ktcSfTep": 10527,  # TEP-corrected internal value
+                        "ktcSfTep": 10527,  # synthetic divergent value (production: equals raw)
                     },
                     "ktc": 7560,
                     "ktcSfTep": 9154,  # raw scrape — matches keeptradecut.com
@@ -559,12 +564,15 @@ class TestRawSourceValues(unittest.TestCase):
             r for r in contract["playersArray"]
             if r["canonicalName"] == "Trey McBride"
         )
-        # rawSourceValues carries the raw scrape, not the
-        # TEP-corrected internal value.
+        # rawSourceValues carries the raw scrape from the top-level
+        # ``ktcSfTep`` field (the synthetic input mimics the legacy
+        # divergence between raw and canonicalSites).
         self.assertIn("rawSourceValues", row)
         self.assertEqual(row["rawSourceValues"]["ktcSfTep"], 9154)
-        # canonicalSiteValues continues to carry whatever the upstream
-        # canonical pipeline computed (TEP-corrected for TE rows).
+        # canonicalSiteValues passes through whatever the upstream
+        # canonical pipeline emitted (post PR #406 these match in
+        # production; the test asserts the contract layer doesn't
+        # collapse the two fields).
         self.assertEqual(row["canonicalSiteValues"]["ktcSfTep"], 10527)
 
     def test_raw_source_values_omits_missing_keys(self):

--- a/tests/api/test_source_history.py
+++ b/tests/api/test_source_history.py
@@ -623,7 +623,7 @@ def test_ktc_sftep_reads_raw_from_rawsource_values_field(path):
                 "assetClass": "offense",
                 "rankDerivedValue": 7527,
                 "canonicalConsensusRank": 23,
-                "canonicalSiteValues": {"ktcSfTep": 8434},  # TEP-corrected
+                "canonicalSiteValues": {"ktcSfTep": 8434},  # synthetic divergent value
                 "rawSourceValues": {"ktcSfTep": 7334},      # raw scrape
                 "sourceRankMeta": {
                     "ktcSfTep": {"valueContribution": 7648},  # Hill contribution
@@ -634,7 +634,9 @@ def test_ktc_sftep_reads_raw_from_rawsource_values_field(path):
     source_history.append_snapshot(contract, date="2026-05-05", path=path)
     hist = source_history.load_player_history("Colston Loveland", path=path)
     # The raw scrape (7334) wins — not the contribution (7648) or the
-    # TEP-corrected canonicalSites value (8434).
+    # canonicalSites value (8434).  Post PR #406 the canonicalSites
+    # entry equals the raw scrape in production; this fixture uses
+    # divergent values to prove the priority order is enforced.
     assert hist["sources"]["ktcSfTep"][0]["value"] == 7334
 
 

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -32,6 +32,8 @@ import json
 from src.api.data_contract import (
     _DELTA_PLAYER_FIELDS,
     _RANKING_SOURCES,
+    _TE_BLANKET_KTC_EXEMPT_KEYS,
+    _TE_BLANKET_NATIVE_MULTIPLIER,
     _TE_BLANKET_NON_NATIVE_MULTIPLIER,
     _TEP_DERIVATION_SLOPE,
     _compute_unified_rankings,
@@ -994,6 +996,182 @@ class TestBuildContractTepSlider(unittest.TestCase):
         )
         self.assertEqual(rov.get("tepMultiplierSource"), "default")
 
+
+class TestTepMultipliersEndToEnd(unittest.TestCase):
+    """End-to-end coverage for the operator-tunable TEP split (PR #406).
+
+    The input-validation classes ``TestNormalizeTepMultiplier`` and
+    ``TestNormalizeTepNativeMultiplier`` above pin the API ingress.
+    This class pins the wiring downstream of that ingress: how the
+    arguments to ``build_api_data_contract`` flow into
+    ``rankingsOverride`` and into per-source meta stamps on TE rows,
+    plus the KTC exemption that keeps the TE++ board off both
+    multiplier paths.
+
+    The fixture's Brock Bowers row is a TE covered by all four offense
+    sources, one from each bucket:
+
+      * ``dlfSf``                 — non-TEP-native (gets ``tep_multiplier``)
+      * ``dynastyNerdsSfTep``     — TEP-native     (gets ``tep_native_multiplier``)
+      * ``ktcSfTep``              — KTC exempt
+      * ``idpTradeCalc``          — TEP-native     (cross-market anchor)
+    """
+
+    def test_default_path_stamps_module_constants(self) -> None:
+        """``tep_multiplier=None`` and ``tep_native_multiplier=None``
+        fall back to the module-level defaults (``1.25`` and ``1.10``).
+        Both must surface verbatim in ``rankingsOverride`` — the
+        frontend reads them to render the slider's ``"Auto"`` baseline.
+        """
+        contract = build_api_data_contract(
+            _fixture_raw_payload(),
+            tep_multiplier=None,
+            tep_native_multiplier=None,
+        )
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplier") or 0),
+            _TE_BLANKET_NON_NATIVE_MULTIPLIER,
+        )
+        self.assertAlmostEqual(
+            float(rov.get("tepNativeMultiplier") or 0),
+            _TE_BLANKET_NATIVE_MULTIPLIER,
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "default")
+        self.assertEqual(rov.get("tepNativeMultiplierSource"), "default")
+        # Pin the actual numeric defaults so a registry tweak that
+        # silently shifts either constant fails this test.
+        self.assertAlmostEqual(_TE_BLANKET_NON_NATIVE_MULTIPLIER, 1.25)
+        self.assertAlmostEqual(_TE_BLANKET_NATIVE_MULTIPLIER, 1.10)
+
+    def test_override_path_propagates_to_summary_and_per_source_meta(self) -> None:
+        """Explicit ``tep_multiplier`` and ``tep_native_multiplier``
+        arrive verbatim in ``rankingsOverride`` AND on the per-source
+        ``sourceRankMeta`` entries for the TE row's non-exempt sources.
+        """
+        contract = build_api_data_contract(
+            _fixture_raw_payload(),
+            tep_multiplier=1.30,
+            tep_native_multiplier=1.05,
+        )
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.30)
+        self.assertAlmostEqual(float(rov.get("tepNativeMultiplier") or 0), 1.05)
+        self.assertEqual(rov.get("tepMultiplierSource"), "override")
+        self.assertEqual(rov.get("tepNativeMultiplierSource"), "override")
+
+        bowers = _by_name(contract).get("Brock Bowers")
+        self.assertIsNotNone(bowers, "fixture must include the Brock Bowers TE row")
+        meta = bowers.get("sourceRankMeta") or {}
+
+        # Non-TEP-native source: dlfSf carries the boost flag and the
+        # effective multiplier.
+        dlf_meta = meta.get("dlfSf") or {}
+        self.assertTrue(
+            dlf_meta.get("tepBoostApplied"),
+            "dlfSf on a TE row must be marked as TEP-boosted",
+        )
+        self.assertAlmostEqual(
+            float(dlf_meta.get("tepMultiplier") or 0), 1.30
+        )
+
+        # TEP-native source: dynastyNerdsSfTep carries the native flag
+        # and the effective correction.
+        dn_meta = meta.get("dynastyNerdsSfTep") or {}
+        self.assertTrue(
+            dn_meta.get("tepNativeCorrectionApplied"),
+            "dynastyNerdsSfTep on a TE row must be marked as TEP-native-corrected",
+        )
+        self.assertAlmostEqual(
+            float(dn_meta.get("tepNativeCorrection") or 0), 1.05
+        )
+
+        # The non-native and native paths are mutually exclusive — a
+        # source flagged as one bucket must not pick up the other.
+        self.assertNotIn("tepNativeCorrectionApplied", dlf_meta)
+        self.assertNotIn("tepBoostApplied", dn_meta)
+
+    def test_ktc_exemption_holds_under_default_and_override(self) -> None:
+        """The KTC variants in ``_TE_BLANKET_KTC_EXEMPT_KEYS`` (``ktc``,
+        ``ktcSfTep``) stay exempt from BOTH TEP correction paths, with
+        or without an explicit override.  KTC's TE++ board is the
+        canonical reference the rest of the blend aligns to — letting
+        either multiplier touch it would double-boost.
+        """
+        # Sanity: pin the exempt set so a registry refactor that drops
+        # ktcSfTep from the exemption fails this test before the
+        # behavioural assertions below would.
+        self.assertIn("ktcSfTep", _TE_BLANKET_KTC_EXEMPT_KEYS)
+        self.assertIn("ktc", _TE_BLANKET_KTC_EXEMPT_KEYS)
+
+        for label, kwargs in (
+            ("default", {}),
+            (
+                "override",
+                {"tep_multiplier": 1.45, "tep_native_multiplier": 1.20},
+            ),
+        ):
+            contract = build_api_data_contract(
+                _fixture_raw_payload(), **kwargs
+            )
+            bowers = _by_name(contract).get("Brock Bowers")
+            self.assertIsNotNone(
+                bowers, f"{label}: fixture must include the Brock Bowers TE row"
+            )
+            ktc_meta = (bowers.get("sourceRankMeta") or {}).get("ktcSfTep") or {}
+            # The exempt source carries no boost / correction flag, so
+            # ``valueContribution`` is the raw curve value untouched.
+            self.assertNotIn(
+                "tepBoostApplied",
+                ktc_meta,
+                f"{label}: ktcSfTep must not be marked TEP-boosted on a TE row",
+            )
+            self.assertNotIn(
+                "tepNativeCorrectionApplied",
+                ktc_meta,
+                f"{label}: ktcSfTep must not be marked TEP-native-corrected on a TE row",
+            )
+            self.assertNotIn(
+                "tepMultiplier",
+                ktc_meta,
+                f"{label}: ktcSfTep meta must not stamp a tepMultiplier value",
+            )
+            self.assertNotIn(
+                "tepNativeCorrection",
+                ktc_meta,
+                f"{label}: ktcSfTep meta must not stamp a tepNativeCorrection value",
+            )
+
+    def test_out_of_range_overrides_are_clamped_in_summary(self) -> None:
+        """A caller bypassing the ``normalize_*`` ingress (which
+        clamps to ``[1.0, 1.5]``) and passing an out-of-range value
+        directly to ``build_api_data_contract`` is still clamped at
+        the contract-layer summary.
+
+        ``_summarize_source_overrides`` clamps to ``[1.0, 2.0]`` —
+        intentionally wider than the ingress so league-derived values
+        from ``_derive_tep_multiplier_from_league`` (which can reach
+        ``2.0`` on heavy-TEP leagues) pass through unchanged.  Values
+        above ``2.0`` are pinned at ``2.0``; the test uses ``3.0``
+        unambiguously past both ranges to exercise the clamp.
+        """
+        contract = build_api_data_contract(
+            _fixture_raw_payload(),
+            tep_multiplier=3.0,
+            tep_native_multiplier=3.0,
+        )
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 2.0)
+        self.assertAlmostEqual(float(rov.get("tepNativeMultiplier") or 0), 2.0)
+        # Lower-bound clamp: negative or sub-1.0 inputs floor at 1.0.
+        contract = build_api_data_contract(
+            _fixture_raw_payload(),
+            tep_multiplier=-1.0,
+            tep_native_multiplier=0.5,
+        )
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.0)
+        self.assertAlmostEqual(float(rov.get("tepNativeMultiplier") or 0), 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three post-merge followups for #406 (TE Premium split into two operator-tunable multipliers).

## Summary

- **Comment refresh** — strip the stale ``raw 9154 / TEP-corrected canonicalSites 10527`` narrative from ``data_contract.py``, ``trade-logic.js``, ``TradeSourceBreakdown.jsx``, ``draft/page.jsx``, ``test_data_contract.py``, and ``test_source_history.py``.  Post #406 the scraper-side ×1.15 is gone and ``ktcSfTep`` is in ``_TE_BLANKET_KTC_EXEMPT_KEYS``, so ``canonicalSiteValues.ktcSfTep`` matches the raw scrape verbatim.  Test fixtures keep their divergent synthetic numbers (the contract layer's pass-through is still the contract under test); only the surrounding narrative changes.
- **End-to-end regression test** — new ``TestTepMultipliersEndToEnd`` in ``tests/api/test_source_overrides.py`` (4 tests, all pass).  Pins:
  - default path: ``rankingsOverride.tepMultiplier == 1.25`` and ``tepNativeMultiplier == 1.10``
  - override path: ``tep_multiplier=1.30`` / ``tep_native_multiplier=1.05`` propagate to ``rankingsOverride`` and to per-source meta on the Brock Bowers TE row (``dlfSf`` boosted 1.30, ``dynastyNerdsSfTep`` corrected 1.05)
  - KTC exemption holds: ``sourceRankMeta.ktcSfTep`` carries no ``tepBoostApplied`` / ``tepNativeCorrectionApplied`` flags under default OR override
  - clamping at the contract layer: out-of-range inputs land at ``[1.0, 2.0]`` per ``_summarize_source_overrides`` (intentionally wider than the ``[1.0, 1.5]`` ingress clamp so league-derived values up to 2.0 pass through)

  Note on the clamp range: the task spec said ``2.0 → 1.5``.  In the actual code ``_summarize_source_overrides`` clamps to ``[1.0, 2.0]`` — the test pins that range and uses ``3.0 → 2.0`` to exercise the upper bound unambiguously.
- **Production verification** — ran an audit against the freshest production export (``exports/latest/dynasty_data_2026-05-07.json``, scrape ``2026-05-07T01:15:40Z``, post-deploy of #406).  Same export the live ``/api/data`` endpoint serves; the audit reads the JSON and runs the same ``build_api_data_contract`` the API does.  All four invariants the follow-up task listed pass.

## Production verification result

- [x] ``canonicalSiteValues.ktcSfTep`` for Brock Bowers (9588) **matches** the within-scrape raw ``ktcSfTep`` top-level (9588) — no scraper-side ×1.15 in evidence.
- [x] ``sourceRankMeta["ktcSfTep"]`` on Bowers carries **neither** ``tepBoostApplied`` nor ``tepNativeCorrectionApplied`` (both ``None``); ``tepMultiplier`` / ``tepNativeCorrection`` not stamped.
- [x] ``valueContribution`` for ``ktcSfTep`` on Bowers = **9589** = ``round(9588 / 9998 × 9999)`` — value-direct path with no extra multiplier.
- [x] **Bijan Robinson is #1 on the KTC TE++ board** (``canonicalSites.ktcSfTep`` = 9998).  Brock Bowers is #5 at his uninflated raw 9588.  Pre-PR, Bowers' ``11017`` (= 9580 × 1.15) silently put him #1 above Bijan; that no longer happens.

KTC TE++ board, top 5 (sorted by ``canonicalSiteValues.ktcSfTep`` desc, post-PR scrape):

| # | Player           | ktcSfTep | pos |
|---|------------------|---------:|-----|
| 1 | Bijan Robinson   |     9998 | RB  |
| 2 | Josh Allen       |     9995 | QB  |
| 3 | Ja'Marr Chase    |     9942 | WR  |
| 4 | Jaxon Smith-Njigba |   9909 | WR  |
| 5 | Brock Bowers     |     9588 | TE  |

## Test plan

- [x] ``ALLOW_DEFAULT_LOGIN_DEV=1 pytest tests/api/`` → 1079 passed, 3 skipped (pre-existing)
- [x] ``pytest tests/api/test_source_overrides.py::TestTepMultipliersEndToEnd`` → 4 passed
- [x] Production audit against ``exports/latest/dynasty_data_2026-05-07.json`` → all four checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)