### PR TITLE
chore(tep): tighten contract-layer TEP clamp to [1.0, 1.5]

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2113,15 +2113,22 @@ def _summarize_source_overrides(
         else:
             effective_weights[key] = default_weight
 
-    # Clamp the TEP multiplier identically to the blend path so the
-    # summary reflects what was actually applied, not what was sent.
+    # Clamp the TEP multiplier to the same [1.0, 1.5] range the
+    # ``normalize_tep_multiplier`` ingress and the /settings slider
+    # enforce, so a non-normalize caller (direct ``build_api_data_contract``
+    # invocation, malformed body, etc.) can't pump TE values off the
+    # board through the summary stamp.  Live derivations land at the
+    # hardcoded default 1.25; the wider [1.0, 2.0] range that historically
+    # accommodated ``_derive_tep_multiplier_from_league`` outputs is no
+    # longer needed (that derivation is no longer wired into the live
+    # build_api_data_contract path — see line ~7190).
     try:
         tep_eff = float(tep_multiplier)
     except (TypeError, ValueError):
         tep_eff = 1.0
     if not math.isfinite(tep_eff):
         tep_eff = 1.0
-    tep_eff = max(1.0, min(2.0, tep_eff))
+    tep_eff = max(1.0, min(1.5, tep_eff))
 
     try:
         tep_derived = float(tep_multiplier_derived)
@@ -2129,7 +2136,7 @@ def _summarize_source_overrides(
         tep_derived = 1.0
     if not math.isfinite(tep_derived):
         tep_derived = 1.0
-    tep_derived = max(1.0, min(2.0, tep_derived))
+    tep_derived = max(1.0, min(1.5, tep_derived))
 
     # isCustomized flips only when the user-facing effective value
     # diverges from the league-derived baseline.  A league with
@@ -2141,14 +2148,15 @@ def _summarize_source_overrides(
         is_customized = True
 
     # TEP-native: clamp + customization check, mirroring the non-TEP
-    # multiplier above.
+    # multiplier above.  Same [1.0, 1.5] range as the
+    # ``normalize_tep_native_multiplier`` ingress.
     try:
         tep_native_eff = float(tep_native_multiplier)
     except (TypeError, ValueError):
         tep_native_eff = 1.0
     if not math.isfinite(tep_native_eff):
         tep_native_eff = 1.0
-    tep_native_eff = max(1.0, min(2.0, tep_native_eff))
+    tep_native_eff = max(1.0, min(1.5, tep_native_eff))
 
     try:
         tep_native_derived = float(tep_native_multiplier_derived)
@@ -2156,7 +2164,7 @@ def _summarize_source_overrides(
         tep_native_derived = 1.0
     if not math.isfinite(tep_native_derived):
         tep_native_derived = 1.0
-    tep_native_derived = max(1.0, min(2.0, tep_native_derived))
+    tep_native_derived = max(1.0, min(1.5, tep_native_derived))
 
     if abs(tep_native_eff - tep_native_derived) > 1e-6:
         is_customized = True
@@ -5222,9 +5230,11 @@ def _compute_unified_rankings(
     the correction lifts them ~13%.
 
     Non-TE positions are untouched by either multiplier.  Expected
-    range for ``tep_multiplier`` is ``[1.0, 2.0]``; ``1.0`` is a
-    no-op for non-TEP sources but still triggers the correction
-    (drops TEP-native values to match).
+    range for ``tep_multiplier`` is ``[1.0, 1.5]`` — the same range
+    enforced at the API ingress (``normalize_tep_multiplier``) and at
+    the contract-summary stamp (``_summarize_source_overrides``).
+    ``1.0`` is a no-op for non-TEP sources but still triggers the
+    correction (drops TEP-native values to match).
 
     Stamps onto each row:
       - sourceRanks:  dict[str, int] — effective rank per source (the
@@ -7142,9 +7152,11 @@ def build_api_data_contract(
         league (``bonus_rec_te == 0.5``) yields ``1.15``; a non-TEP
         league yields ``1.0`` (a no-op).  This is the production
         cold-start path.
-      * an explicit ``float`` — use the caller's value verbatim (after
-        the same ``[1.0, 2.0]`` clamp the derivation applies).  Used by
-        the override endpoint when the user moves the TEP slider.
+      * an explicit ``float`` — use the caller's value verbatim (the
+        contract-summary stamp clamps to ``[1.0, 1.5]``, matching the
+        API-ingress ``normalize_tep_multiplier`` and the /settings
+        slider).  Used by the override endpoint when the user moves
+        the TEP slider.
 
     Previously this parameter defaulted to ``1.0``, which meant every
     cold start produced a "clean" board regardless of league setup

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -1148,12 +1148,11 @@ class TestTepMultipliersEndToEnd(unittest.TestCase):
         directly to ``build_api_data_contract`` is still clamped at
         the contract-layer summary.
 
-        ``_summarize_source_overrides`` clamps to ``[1.0, 2.0]`` —
-        intentionally wider than the ingress so league-derived values
-        from ``_derive_tep_multiplier_from_league`` (which can reach
-        ``2.0`` on heavy-TEP leagues) pass through unchanged.  Values
-        above ``2.0`` are pinned at ``2.0``; the test uses ``3.0``
-        unambiguously past both ranges to exercise the clamp.
+        ``_summarize_source_overrides`` clamps to ``[1.0, 1.5]`` —
+        the same range as the API ingress and the /settings slider,
+        so every layer of the system enforces the same bound.  Values
+        above ``1.5`` are pinned at ``1.5``; the test uses ``3.0``
+        unambiguously past the range to exercise the clamp.
         """
         contract = build_api_data_contract(
             _fixture_raw_payload(),
@@ -1161,8 +1160,8 @@ class TestTepMultipliersEndToEnd(unittest.TestCase):
             tep_native_multiplier=3.0,
         )
         rov = contract.get("rankingsOverride") or {}
-        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 2.0)
-        self.assertAlmostEqual(float(rov.get("tepNativeMultiplier") or 0), 2.0)
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.5)
+        self.assertAlmostEqual(float(rov.get("tepNativeMultiplier") or 0), 1.5)
         # Lower-bound clamp: negative or sub-1.0 inputs floor at 1.0.
         contract = build_api_data_contract(
             _fixture_raw_payload(),


### PR DESCRIPTION
Follow-up to #407 (which itself followed up on #406).

## Why

``_summarize_source_overrides`` was clamping ``tepMultiplier`` and ``tepNativeMultiplier`` to ``[1.0, 2.0]``.  The wider upper bound dated to a retired code path: ``_derive_tep_multiplier_from_league`` could output up to ``2.0`` for heavy-TEP leagues, and the summary stamp had to admit that range.

Post #406, the derivation is no longer wired into ``build_api_data_contract`` — ``tep_multiplier_derived`` is hardcoded to ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` (1.25) at line 7179, and the live ``_compute_unified_rankings`` path receives only the operator-tuned multiplier (which the API ingress already clamps to ``[1.0, 1.5]``).  ``_derive_tep_multiplier_from_league`` is dead in the live path; only its own unit tests in ``TestTepMultiplierDerivation`` keep it alive.

Result: nothing the live blend produces could legitimately land above 1.5.  The 2.0 cap was admitting only out-of-range bypass attempts.

## What

Tightens the contract-summary clamp from ``[1.0, 2.0]`` to ``[1.0, 1.5]`` for both the non-native and native multipliers, and updates the related docstrings (``_compute_unified_rankings`` and ``build_api_data_contract``) to reflect the unified bound.  The live blend math is unchanged — ``_compute_unified_rankings`` still applies the multiplier verbatim; only the summary stamp is now strict.

System now has a single bound across all four layers:

| Layer | Range |
|---|---|
| /settings slider                | [1.0, 1.5] |
| ``normalize_tep_multiplier``    | [1.0, 1.5] |
| Live blend (verbatim)           | uses whatever ingress passed |
| ``_summarize_source_overrides`` | [1.0, 1.5] (was [1.0, 2.0]) |

## Test plan

- [x] ``test_out_of_range_overrides_are_clamped_in_summary`` updated to expect 1.5 (was 2.0)
- [x] Full ``tests/api/`` sweep: 1079 passed, 3 skipped — no other test relied on the wider range
- [x] No production code path produces values above 1.5; the only callers of the wider range are in ``TestTepMultiplierDerivation`` which tests the helper directly, not through the contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)