### PR TITLE
fix(angle): mobile layout, pinch-zoom refresh, target team roster selection

### DIFF
--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -137,9 +137,12 @@ export default function AnglePage() {
       });
   }, [targetTeam, targetPlayerSearch, valueByName]);
 
-  // Wipe selected players + stale results when the user switches their own team.
+  // Wipe all selections + stale results when the user switches their own team.
+  // targetPlayerNames must also be cleared — the new team may own some of those
+  // players, and the backend silently drops self-owned acquire targets.
   useEffect(() => {
     setPlayerNames(new Set());
+    setTargetPlayerNames(new Set());
     setResult(null);
     setErr(null);
   }, [ownerId]);
@@ -285,9 +288,12 @@ export default function AnglePage() {
     (isAcquireMode || playerNameList.length > 0) &&
     !loading;
 
-  // In offer mode the fixed side is result.offer (what you send).
-  // In acquire mode the fixed side is result.acquire (what you receive).
-  const fixedSide = isAcquireMode ? (result?.acquire || null) : (result?.offer || null);
+  // Drive result rendering from the mode stamped on the response, not the
+  // current UI selection.  This prevents re-labelling stale results when the
+  // user clears their selection after a search without re-running.
+  const resultMode = result?.mode ?? null;
+  const resultIsAcquire = resultMode === "acquire";
+  const fixedSide = resultIsAcquire ? (result?.acquire || null) : (result?.offer || null);
   const candidates = result?.candidates || [];
   const warnings = result?.warnings || [];
 
@@ -652,7 +658,7 @@ export default function AnglePage() {
           >
             <div style={{ flex: 1, minWidth: 220 }}>
               <div className="muted" style={{ fontSize: "0.75rem" }}>
-                {isAcquireMode ? "You receive" : "You send"}
+                {resultIsAcquire ? "You receive" : "You send"}
               </div>
               <ul
                 style={{
@@ -704,7 +710,7 @@ export default function AnglePage() {
         <section className="card">
           <div style={{ marginBottom: 10 }}>
             <strong style={{ fontSize: "1rem" }}>
-              {isAcquireMode
+              {resultIsAcquire
                 ? `What to give up${targetTeam ? ` to ${targetTeam.name}` : ""}`
                 : targetTeam
                   ? `Return options from ${targetTeam.name}`
@@ -747,8 +753,8 @@ export default function AnglePage() {
                       className="muted"
                       style={{ fontSize: "0.7rem", marginBottom: 2 }}
                     >
-                      {isAcquireMode
-                        ? `Give to ${targetTeam?.name || myTeam?.name || "them"}`
+                      {resultIsAcquire
+                        ? `Give to ${targetTeam?.name || "them"}`
                         : `From ${c.team || "(unknown)"}`}{" "}
                       · {c.size} {c.size === 1 ? "player" : "players"}
                     </div>

--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -11,6 +11,10 @@ import { useTeam } from "@/components/useTeam";
 // better on the market the counterparty consults (default ≤5%). Market
 // is per-position: IDP Trade Calculator for DL/LB/DB, KTC for everyone
 // else — backend handles routing automatically.
+//
+// When players from the target team are selected the page switches to
+// "acquire" mode: the backend finds what to give up from your roster
+// to get those specific players back.
 
 const IDP_POS_RE = /^(?:DL|DE|DT|EDGE|NT|LB|ILB|OLB|MLB|DB|CB|S|SS|FS)$/i;
 
@@ -43,8 +47,7 @@ export default function AnglePage() {
     );
   }, [rawData]);
 
-  // canonicalName → my-value, market-value, position. Mirrors the
-  // source the backend reads via _value_pair so labels and order match.
+  // canonicalName → my-value, market-value, position.
   const valueByName = useMemo(() => {
     const m = new Map();
     for (const r of rows || []) {
@@ -70,7 +73,9 @@ export default function AnglePage() {
   const [ownerId, setOwnerId] = useState("");
   const [playerNames, setPlayerNames] = useState(() => new Set());
   const [playerSearch, setPlayerSearch] = useState("");
-  const [targetOwnerId, setTargetOwnerId] = useState(""); // "" → any team
+  const [targetOwnerId, setTargetOwnerId] = useState("");
+  const [targetPlayerNames, setTargetPlayerNames] = useState(() => new Set());
+  const [targetPlayerSearch, setTargetPlayerSearch] = useState("");
   const [minMyGainPct, setMinMyGainPct] = useState(5);
   const [maxMarketGainPct, setMaxMarketGainPct] = useState(5);
   const [result, setResult] = useState(null);
@@ -99,8 +104,12 @@ export default function AnglePage() {
     [teams, ownerId],
   );
 
-  // Filter + sort the user's roster by the search input — high my-value
-  // first, alpha tie-break.
+  const targetTeam = useMemo(
+    () => teams.find((t) => String(t.ownerId || "") === String(targetOwnerId)),
+    [teams, targetOwnerId],
+  );
+
+  // Filter + sort the user's roster.
   const roster = useMemo(() => {
     if (!myTeam) return [];
     const q = playerSearch.trim().toLowerCase();
@@ -114,13 +123,34 @@ export default function AnglePage() {
       });
   }, [myTeam, playerSearch, valueByName]);
 
-  // Wipe selected players + stale results when the user switches teams
-  // — an offer from the old team is incoherent with the new roster.
+  // Filter + sort the target team's roster.
+  const targetRoster = useMemo(() => {
+    if (!targetTeam) return [];
+    const q = targetPlayerSearch.trim().toLowerCase();
+    return [...(targetTeam.players || [])]
+      .filter((name) => !q || name.toLowerCase().includes(q))
+      .sort((a, b) => {
+        const av = valueByName.get(a)?.my_value || 0;
+        const bv = valueByName.get(b)?.my_value || 0;
+        if (bv !== av) return bv - av;
+        return a.localeCompare(b);
+      });
+  }, [targetTeam, targetPlayerSearch, valueByName]);
+
+  // Wipe selected players + stale results when the user switches their own team.
   useEffect(() => {
     setPlayerNames(new Set());
     setResult(null);
     setErr(null);
   }, [ownerId]);
+
+  // Wipe target player selection when target team changes.
+  useEffect(() => {
+    setTargetPlayerNames(new Set());
+    setTargetPlayerSearch("");
+    setResult(null);
+    setErr(null);
+  }, [targetOwnerId]);
 
   function togglePlayer(name) {
     setPlayerNames((prev) => {
@@ -131,7 +161,21 @@ export default function AnglePage() {
     });
   }
 
+  function toggleTargetPlayer(name) {
+    setTargetPlayerNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }
+
   const playerNameList = useMemo(() => Array.from(playerNames), [playerNames]);
+  const targetPlayerNameList = useMemo(() => Array.from(targetPlayerNames), [targetPlayerNames]);
+
+  // Acquire mode when the user has picked target players to receive.
+  // Offer mode otherwise (find what to get back for your send players).
+  const isAcquireMode = targetPlayerNameList.length > 0;
 
   const offerTotals = useMemo(() => {
     let my = 0;
@@ -146,31 +190,53 @@ export default function AnglePage() {
     return { my, market };
   }, [playerNameList, valueByName]);
 
-  const targetTeam = useMemo(
-    () => teams.find((t) => String(t.ownerId || "") === String(targetOwnerId)),
-    [teams, targetOwnerId],
-  );
+  const targetTotals = useMemo(() => {
+    let my = 0;
+    let market = 0;
+    for (const name of targetPlayerNameList) {
+      const info = valueByName.get(name);
+      if (info) {
+        my += info.my_value || 0;
+        market += info.market_value || 0;
+      }
+    }
+    return { my, market };
+  }, [targetPlayerNameList, valueByName]);
 
   async function findTrades() {
     if (!ownerId) {
       setErr("Pick your team.");
       return;
     }
-    if (playerNameList.length === 0) {
-      setErr("Pick at least one player on your roster to send.");
+    if (isAcquireMode) {
+      // Acquire mode: find what to give up from your roster to get the target players.
+    } else if (playerNameList.length === 0) {
+      setErr("Pick at least one player on your roster to send, or select players from the target team to acquire.");
       return;
     }
     setLoading(true);
     setErr(null);
     try {
-      const body = {
-        mode: "offer",
-        ownerId,
-        playerNames: playerNameList,
-        minMyGainPct: Number(minMyGainPct),
-        maxMarketGainPct: Number(maxMarketGainPct),
-      };
-      if (targetOwnerId) body.targetTeamOwnerIds = [targetOwnerId];
+      let body;
+      if (isAcquireMode) {
+        body = {
+          mode: "acquire",
+          ownerId,
+          acquirePlayerNames: targetPlayerNameList,
+          minMyGainPct: Number(minMyGainPct),
+          maxMarketGainPct: Number(maxMarketGainPct),
+        };
+        if (targetOwnerId) body.targetTeamOwnerIds = [targetOwnerId];
+      } else {
+        body = {
+          mode: "offer",
+          ownerId,
+          playerNames: playerNameList,
+          minMyGainPct: Number(minMyGainPct),
+          maxMarketGainPct: Number(maxMarketGainPct),
+        };
+        if (targetOwnerId) body.targetTeamOwnerIds = [targetOwnerId];
+      }
       if (selectedLeagueKey) body.leagueKey = selectedLeagueKey;
       const res = await fetch("/api/angle/packages", {
         method: "POST",
@@ -214,10 +280,20 @@ export default function AnglePage() {
     );
   }
 
-  const canSubmit = !!ownerId && playerNameList.length > 0 && !loading;
+  const canSubmit =
+    !!ownerId &&
+    (isAcquireMode || playerNameList.length > 0) &&
+    !loading;
+
   const offer = result?.offer || null;
   const candidates = result?.candidates || [];
   const warnings = result?.warnings || [];
+
+  const submitLabel = loading
+    ? "Searching…"
+    : isAcquireMode
+      ? `Find what to give up (${targetPlayerNameList.length})`
+      : `Find return options${playerNameList.length ? ` (${playerNameList.length})` : ""}`;
 
   return (
     <div className="page-shell angle-page">
@@ -225,23 +301,16 @@ export default function AnglePage() {
         <div>
           <h1 className="page-title">Trade Finder</h1>
           <p className="page-subtitle muted" style={{ marginTop: 4 }}>
-            Pick one or more players from your roster — optionally pick a
-            team to focus on — and get back ranked return packages where
-            your league&apos;s board says you win and the market still
-            looks fair to the other side.
+            Pick players from your roster to send and get back ranked return
+            packages — or select players from the target team you want to
+            acquire and find what you&apos;d need to give up.
           </p>
         </div>
       </div>
 
       <section className="card">
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "minmax(180px, 1fr) minmax(280px, 2fr) minmax(220px, 1fr)",
-            gap: 16,
-            alignItems: "flex-start",
-          }}
-        >
+        <div className="angle-form-grid">
+          {/* ── Column 1: Your team ───────────────────────────── */}
           <label className="angle-field">
             <span className="muted">Your team</span>
             <select
@@ -261,12 +330,18 @@ export default function AnglePage() {
             </select>
           </label>
 
+          {/* ── Column 2: Your players to send ───────────────── */}
           <div className="angle-field">
             <span className="muted">
               Your players to send{" "}
               <span style={{ fontWeight: 400 }}>
                 ({playerNameList.length} selected)
               </span>
+              {isAcquireMode && (
+                <span className="muted" style={{ fontSize: "0.75rem", marginLeft: 6 }}>
+                  — optional in acquire mode
+                </span>
+              )}
             </span>
             <input
               type="search"
@@ -346,7 +421,8 @@ export default function AnglePage() {
             )}
           </div>
 
-          <label className="angle-field">
+          {/* ── Column 3: Trade with + optional target roster ── */}
+          <div className="angle-field">
             <span className="muted">Trade with</span>
             <select
               value={targetOwnerId}
@@ -360,6 +436,95 @@ export default function AnglePage() {
                 </option>
               ))}
             </select>
+
+            {/* Target team roster — appears when a team is selected */}
+            {targetTeam && (
+              <div style={{ marginTop: 10 }}>
+                <div className="muted" style={{ fontSize: "0.78rem", marginBottom: 4 }}>
+                  Players to acquire from {targetTeam.name}
+                  {targetPlayerNameList.length > 0 && (
+                    <span> ({targetPlayerNameList.length} selected)</span>
+                  )}
+                </div>
+                <input
+                  type="search"
+                  placeholder={`Search ${targetTeam.name}…`}
+                  value={targetPlayerSearch}
+                  onChange={(e) => setTargetPlayerSearch(e.target.value)}
+                  disabled={loading}
+                  style={{ marginBottom: 6, width: "100%" }}
+                />
+                <div
+                  style={{
+                    maxHeight: 220,
+                    overflowY: "auto",
+                    border: "1px solid var(--border, #2a2a3a)",
+                    borderRadius: 6,
+                    padding: "4px 6px",
+                    background: "var(--surface-2, transparent)",
+                  }}
+                >
+                  {targetRoster.length === 0 ? (
+                    <div className="muted" style={{ padding: 8, fontSize: "0.85rem" }}>
+                      No matches
+                    </div>
+                  ) : (
+                    targetRoster.map((name) => {
+                      const info = valueByName.get(name);
+                      const checked = targetPlayerNames.has(name);
+                      return (
+                        <label
+                          key={name}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 4px",
+                            cursor: "pointer",
+                            fontSize: "0.85rem",
+                            borderRadius: 4,
+                            background: checked
+                              ? "rgba(110, 224, 123, 0.08)"
+                              : "transparent",
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleTargetPlayer(name)}
+                            disabled={loading}
+                          />
+                          <span style={{ flex: 1 }}>
+                            {name}
+                            <span
+                              className="muted"
+                              style={{ marginLeft: 6, fontSize: "0.78rem" }}
+                            >
+                              {info?.position || "—"}
+                            </span>
+                          </span>
+                          {info?.my_value ? (
+                            <span style={{ fontVariantNumeric: "tabular-nums" }}>
+                              {fmtValue(info.my_value)}
+                            </span>
+                          ) : null}
+                        </label>
+                      );
+                    })
+                  )}
+                </div>
+                {targetPlayerNameList.length > 1 && targetTotals.my > 0 && (
+                  <div
+                    className="muted"
+                    style={{ marginTop: 4, fontSize: "0.78rem" }}
+                  >
+                    Target total: {fmtValue(targetTotals.my)} my ·{" "}
+                    {fmtValue(targetTotals.market)} market
+                  </div>
+                )}
+              </div>
+            )}
+
             <details style={{ marginTop: 12 }}>
               <summary
                 className="muted"
@@ -420,10 +585,10 @@ export default function AnglePage() {
                 </label>
               </div>
             </details>
-          </label>
+          </div>
         </div>
 
-        <div style={{ marginTop: 14, display: "flex", gap: 12, alignItems: "center" }}>
+        <div style={{ marginTop: 14, display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
           <button
             type="button"
             className="button button-primary"
@@ -431,21 +596,27 @@ export default function AnglePage() {
             disabled={!canSubmit}
             style={{ minHeight: 42 }}
           >
-            {loading
-              ? "Searching…"
-              : `Find return options${playerNameList.length ? ` (${playerNameList.length})` : ""}`}
+            {submitLabel}
           </button>
-          {playerNameList.length > 0 && !loading && (
+          {(playerNameList.length > 0 || targetPlayerNameList.length > 0) && !loading && (
             <button
               type="button"
               className="button"
-              onClick={() => setPlayerNames(new Set())}
+              onClick={() => {
+                setPlayerNames(new Set());
+                setTargetPlayerNames(new Set());
+              }}
               style={{ minHeight: 42 }}
             >
               Clear selection
             </button>
           )}
         </div>
+        {isAcquireMode && (
+          <p className="muted" style={{ marginTop: 8, fontSize: "0.8rem" }}>
+            Acquire mode — finding what you&apos;d need to give up for the selected players.
+          </p>
+        )}
         {err && (
           <p className="err-text" style={{ marginTop: 12 }}>
             {err}
@@ -479,7 +650,7 @@ export default function AnglePage() {
           >
             <div style={{ flex: 1, minWidth: 220 }}>
               <div className="muted" style={{ fontSize: "0.75rem" }}>
-                You send
+                {isAcquireMode ? "You receive" : "You send"}
               </div>
               <ul
                 style={{
@@ -531,9 +702,11 @@ export default function AnglePage() {
         <section className="card">
           <div style={{ marginBottom: 10 }}>
             <strong style={{ fontSize: "1rem" }}>
-              {targetTeam
-                ? `Return options from ${targetTeam.name}`
-                : "Return options from any team"}
+              {isAcquireMode
+                ? `What to give up${targetTeam ? ` to ${targetTeam.name}` : ""}`
+                : targetTeam
+                  ? `Return options from ${targetTeam.name}`
+                  : "Return options from any team"}
             </strong>
             <div className="muted" style={{ fontSize: "0.78rem", marginTop: 2 }}>
               Sorted by best edge. Each package clears +
@@ -545,8 +718,8 @@ export default function AnglePage() {
 
           {candidates.length === 0 ? (
             <p className="muted" style={{ margin: 0 }}>
-              No return packages clear the +{Number(minMyGainPct)}% / ±
-              {Number(maxMarketGainPct)}% bar with this offer
+              No packages clear the +{Number(minMyGainPct)}% / ±
+              {Number(maxMarketGainPct)}% bar with this selection
               {targetTeam ? ` against ${targetTeam.name}` : ""}. Try a
               different selection, loosen the percentages under
               Advanced, or remove the team filter.
@@ -572,7 +745,7 @@ export default function AnglePage() {
                       className="muted"
                       style={{ fontSize: "0.7rem", marginBottom: 2 }}
                     >
-                      From {c.team || "(unknown)"} · {c.size}{" "}
+                      {isAcquireMode ? "Give to" : "From"} {c.team || "(unknown)"} · {c.size}{" "}
                       {c.size === 1 ? "player" : "players"}
                     </div>
                     <ul style={{ margin: 0, paddingLeft: 18 }}>

--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -140,9 +140,12 @@ export default function AnglePage() {
   // Wipe all selections + stale results when the user switches their own team.
   // targetPlayerNames must also be cleared — the new team may own some of those
   // players, and the backend silently drops self-owned acquire targets.
+  // targetOwnerId is cleared when it now points at the newly selected team,
+  // which would render the user's own roster as "players to acquire."
   useEffect(() => {
     setPlayerNames(new Set());
     setTargetPlayerNames(new Set());
+    setTargetOwnerId((prev) => (prev === ownerId ? "" : prev));
     setResult(null);
     setErr(null);
   }, [ownerId]);

--- a/frontend/app/angle/page.jsx
+++ b/frontend/app/angle/page.jsx
@@ -285,7 +285,9 @@ export default function AnglePage() {
     (isAcquireMode || playerNameList.length > 0) &&
     !loading;
 
-  const offer = result?.offer || null;
+  // In offer mode the fixed side is result.offer (what you send).
+  // In acquire mode the fixed side is result.acquire (what you receive).
+  const fixedSide = isAcquireMode ? (result?.acquire || null) : (result?.offer || null);
   const candidates = result?.candidates || [];
   const warnings = result?.warnings || [];
 
@@ -637,7 +639,7 @@ export default function AnglePage() {
         </section>
       )}
 
-      {offer && (
+      {fixedSide && (
         <section className="card">
           <div
             style={{
@@ -659,7 +661,7 @@ export default function AnglePage() {
                   fontSize: "0.95rem",
                 }}
               >
-                {(offer.players || []).map((p) => (
+                {(fixedSide.players || []).map((p) => (
                   <li key={p.name}>
                     <strong>{p.name}</strong>{" "}
                     <span className="muted" style={{ fontSize: "0.78rem" }}>
@@ -674,14 +676,14 @@ export default function AnglePage() {
                 ))}
               </ul>
             </div>
-            {(offer.my_total || offer.market_total) && (
+            {(fixedSide.my_total || fixedSide.market_total) && (
               <div style={{ display: "flex", gap: 18, fontSize: "0.9rem" }}>
                 <div>
                   <div className="muted" style={{ fontSize: "0.7rem" }}>
                     My total
                   </div>
                   <div style={{ fontWeight: 600 }}>
-                    {fmtValue(offer.my_total)}
+                    {fmtValue(fixedSide.my_total)}
                   </div>
                 </div>
                 <div>
@@ -689,7 +691,7 @@ export default function AnglePage() {
                     Market total
                   </div>
                   <div style={{ fontWeight: 600 }}>
-                    {fmtValue(offer.market_total)}
+                    {fmtValue(fixedSide.market_total)}
                   </div>
                 </div>
               </div>
@@ -745,8 +747,10 @@ export default function AnglePage() {
                       className="muted"
                       style={{ fontSize: "0.7rem", marginBottom: 2 }}
                     >
-                      {isAcquireMode ? "Give to" : "From"} {c.team || "(unknown)"} · {c.size}{" "}
-                      {c.size === 1 ? "player" : "players"}
+                      {isAcquireMode
+                        ? `Give to ${targetTeam?.name || myTeam?.name || "them"}`
+                        : `From ${c.team || "(unknown)"}`}{" "}
+                      · {c.size} {c.size === 1 ? "player" : "players"}
                     </div>
                     <ul style={{ margin: 0, paddingLeft: 18 }}>
                       {(c.players || []).map((p) => (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1489,6 +1489,22 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .login-error { margin: 0; color: var(--red); font-size: 0.8rem; }
 .login-button { width: 100%; padding: 9px 12px; }
 
+/* Counter-pitch / angle page form — 3-col on desktop, stacks on mobile. */
+.angle-form-grid {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(280px, 2fr) minmax(220px, 1fr);
+  gap: 16px;
+  align-items: flex-start;
+}
+
+/* angle-field label wrapper — flex column so the <span> sits above the
+   input/select without needing inline styles on every callsite. */
+.angle-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 /* ══════════════════════════════════════════════════════════════════════════
    TABLET BREAKPOINT (≤ 1024px)
    ══════════════════════════════════════════════════════════════════════════ */
@@ -1676,6 +1692,9 @@ input[type="range"]:focus-visible::-moz-range-thumb {
     padding: 10px 14px;
     min-height: 40px;
   }
+
+  /* Angle form: collapse 3-column desktop grid to single column. */
+  .angle-form-grid { grid-template-columns: 1fr; }
 
   /* Angle filter pills — 23px tall in the wild is too small to tap
      reliably.  Bump to 36px and tighten wrap gap. */

--- a/frontend/components/PullToRefresh.jsx
+++ b/frontend/components/PullToRefresh.jsx
@@ -43,6 +43,8 @@ export default function PullToRefresh() {
 
     function onTouchStart(e) {
       if (refreshing) return;
+      // Pinch-zoom uses two fingers — don't capture it as a pull gesture.
+      if (e.touches && e.touches.length > 1) return;
       // Only start tracking when the page is genuinely at the top.
       if ((window.scrollY || window.pageYOffset || 0) > 0) return;
       const t = e.touches?.[0];
@@ -53,6 +55,11 @@ export default function PullToRefresh() {
     }
 
     function onTouchMove(e) {
+      // If a second finger appears mid-gesture (pinch), abort the pull.
+      if (e.touches && e.touches.length > 1) {
+        reset();
+        return;
+      }
       if (!trackingRef.current || refreshing) return;
       if ((window.scrollY || window.pageYOffset || 0) > 0) {
         reset();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Mobile layout**: Replaced the inline 3-column grid on the angle/counter-pitch form with a `.angle-form-grid` CSS class that collapses to a single column at ≤768px. Also added a base `.angle-field` flex-column rule so the label wrapper works without inline styles.
- **Pinch-zoom refresh**: `PullToRefresh` now checks `e.touches.length > 1` in both `onTouchStart` and `onTouchMove` — two-finger pinch gestures no longer accidentally trigger a page reload.
- **Target team roster**: Selecting a team in "Trade with" now reveals that team's full player roster with checkboxes. Selecting players from their roster switches to **acquire mode** — the backend finds what you'd need to give up from your own roster to get those players. Offer mode (find return packages for your selected send players) is unchanged when no target players are selected.

## Test plan

- [ ] On mobile, confirm the three form columns stack vertically instead of overflowing the viewport
- [ ] On a PWA install (standalone mode), confirm pinch-zooming at the top of any page no longer triggers a refresh
- [ ] Select a team in "Trade with" and confirm their roster populates with checkboxes
- [ ] Check players from the target team → button changes to "Find what to give up (N)" and results show offer-side packages
- [ ] Clear target player selection → page returns to offer mode with original button label
- [ ] Original offer-mode flow (pick your players, no target players selected) still works end-to-end

https://claude.ai/code/session_01MvyZbsKKQEoqPqiKFApMre
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvyZbsKKQEoqPqiKFApMre)_