### PR TITLE
feat(tep): auto-derive tep_multiplier from Sleeper league bonus_rec_te

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -7144,25 +7144,28 @@ def build_api_data_contract(
 
     ``tep_multiplier`` is the league-wide TE premium boost, applied
     value-level inside the canonical blend (see
-    ``_compute_unified_rankings`` docstring).  Two modes:
+    ``_compute_unified_rankings`` docstring).  Three modes:
 
-      * ``None`` (default) — derive the multiplier from the operator's
-        Sleeper league context via
-        :func:`_derive_tep_multiplier_from_league`.  A standard TEP-1.5
-        league (``bonus_rec_te == 0.5``) yields ``1.15``; a non-TEP
-        league yields ``1.0`` (a no-op).  This is the production
-        cold-start path.
+      * ``None`` + Sleeper league context with ``bonus_rec_te > 0`` —
+        auto-derive the multiplier via
+        :func:`_derive_tep_multiplier_from_league`.  TEP-1.5
+        (``bonus_rec_te == 0.5``) → ``1.15``; TEP-2.0
+        (``bonus_rec_te == 1.0``) → ``1.30``.  Stamped as
+        ``rankingsOverride.tepMultiplierSource = "derived"``.
+      * ``None`` + no Sleeper context (cold start, offline, registry
+        miss) OR non-TEP league (``bonus_rec_te == 0``) — fall back
+        to the hardcoded ``_TE_BLANKET_NON_NATIVE_MULTIPLIER``
+        (1.25).  Stamped as ``tepMultiplierSource = "default"``.
       * an explicit ``float`` — use the caller's value verbatim (the
         contract-summary stamp clamps to ``[1.0, 1.5]``, matching the
         API-ingress ``normalize_tep_multiplier`` and the /settings
         slider).  Used by the override endpoint when the user moves
-        the TEP slider.
+        the TEP slider.  Stamped as ``tepMultiplierSource = "override"``.
 
-    Previously this parameter defaulted to ``1.0``, which meant every
-    cold start produced a "clean" board regardless of league setup
-    and the frontend had to stamp its own ``tepMultiplier=1.15``
-    default on top.  That path is now symmetric: absent override →
-    league-derived, explicit override → user value.
+    The /settings page reads ``rankingsOverride.tepMultiplierDerived``
+    to render the "Auto" baseline next to the slider, so users in a
+    TEP-1.5 league see the slider default at 1.15 (their league's
+    actual setting) rather than the generic 1.25 fallback.
 
     ``_for_delta`` (internal) skips work that only feeds fields the
     delta payload discards (trust-mirror into legacy players dict,
@@ -7182,13 +7185,44 @@ def build_api_data_contract(
     # Each is clamped to [1.0, 1.5] at the normalize layer.  KTC
     # variants stay exempt regardless — see
     # ``_TE_BLANKET_KTC_EXEMPT_KEYS``.
+    # Resolve league context once, then use it for both TEP derivation
+    # and the roster-count / logging consumers further down.
+    league_context = _resolve_league_context()
+
+    # Auto-derive ``tep_multiplier_derived`` from the league's
+    # ``bonus_rec_te`` when Sleeper actually returned scoring data AND
+    # the league has a positive TE bonus.  Otherwise fall back to the
+    # hardcoded ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` (1.25) so cold-
+    # start, offline, and non-TEP leagues keep predictable behavior.
+    #
+    # Examples:
+    #   * TEP-1.5 league (bonus_rec_te=0.5) → derived 1.15
+    #   * TEP-2.0 league (bonus_rec_te=1.0) → derived 1.30
+    #   * Non-TEP / no Sleeper context       → derived 1.25 (default)
+    #
+    # When the operator hasn't explicitly overridden via the slider
+    # (``tep_multiplier=None``), the derived value becomes the
+    # effective multiplier and the summary stamps the source as
+    # ``"derived"`` so the frontend can label the slider state
+    # ("Auto from league" vs "Custom override").
+    try:
+        sleeper_bonus = float(league_context.get("bonus_rec_te") or 0.0)
+    except (TypeError, ValueError):
+        sleeper_bonus = 0.0
+    sleeper_real = bool(league_context.get("fetched_from_sleeper"))
+    if sleeper_real and sleeper_bonus > 0.0:
+        tep_multiplier_derived = _derive_tep_multiplier_from_league(league_context)
+        tep_default_source: str = "derived"
+    else:
+        tep_multiplier_derived = _TE_BLANKET_NON_NATIVE_MULTIPLIER
+        tep_default_source = "default"
+
     if tep_multiplier is None:
-        tep_multiplier_effective = _TE_BLANKET_NON_NATIVE_MULTIPLIER
-        tep_multiplier_source = "default"
+        tep_multiplier_effective = tep_multiplier_derived
+        tep_multiplier_source = tep_default_source
     else:
         tep_multiplier_effective = float(tep_multiplier)
         tep_multiplier_source = "override"
-    tep_multiplier_derived = _TE_BLANKET_NON_NATIVE_MULTIPLIER
 
     if tep_native_multiplier is None:
         tep_native_multiplier_effective = _TE_BLANKET_NATIVE_MULTIPLIER
@@ -7197,10 +7231,6 @@ def build_api_data_contract(
         tep_native_multiplier_effective = float(tep_native_multiplier)
         tep_native_multiplier_source = "override"
     tep_native_multiplier_derived = _TE_BLANKET_NATIVE_MULTIPLIER
-
-    # League context still resolved for other uses (roster count,
-    # logging); TEP derivation no longer drives the multiplier.
-    league_context = _resolve_league_context()
 
     # TEP-native correction retired: TEP-native sources are now scaled
     # via ``tep_native_multiplier_effective`` inside

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import unittest
 from copy import deepcopy
 from typing import Any
+from unittest.mock import patch
 
 import json
 
@@ -951,12 +952,19 @@ class TestTepMultiplierDerivation(unittest.TestCase):
 class TestBuildContractTepSlider(unittest.TestCase):
     """TEP slider is operator-tunable (2026-05-06 repurpose).
 
-    ``tep_multiplier=None`` → use the hardcoded default
-    (``_TE_BLANKET_NON_NATIVE_MULTIPLIER``, currently 1.25), source
-    stamped ``"default"``.  An explicit float (clamped to [1.0, 1.5]
-    by ``normalize_tep_multiplier``) is used verbatim, source stamped
+    ``tep_multiplier=None`` triggers the auto-derive path (see
+    :class:`TestBuildContractTepAutoDerive` below).  When Sleeper
+    context is unavailable or non-TEP, the default falls back to
+    ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` (1.25), source stamped
+    ``"default"``.  An explicit float (clamped to [1.0, 1.5] by
+    ``normalize_tep_multiplier``) is used verbatim, source stamped
     ``"override"``.  TEP-native (1.10) and KTC exemption are hardcoded
     inside ``_compute_unified_rankings`` and not exposed here.
+
+    These tests run in the conftest-cleared environment (no
+    ``SLEEPER_LEAGUE_ID``), so ``_resolve_league_context()`` returns
+    its fallback dict and the auto-derive path correctly defers to
+    the hardcoded default.
     """
 
     def test_summary_default_is_non_tep_constant(self) -> None:
@@ -995,6 +1003,133 @@ class TestBuildContractTepSlider(unittest.TestCase):
             _TE_BLANKET_NON_NATIVE_MULTIPLIER,
         )
         self.assertEqual(rov.get("tepMultiplierSource"), "default")
+
+
+class TestBuildContractTepAutoDerive(unittest.TestCase):
+    """Auto-derive ``tep_multiplier`` from the operator's Sleeper league
+    when the slider isn't overridden.
+
+    Trigger conditions (all must hold):
+      1. ``tep_multiplier=None`` on the call (no slider override).
+      2. ``_resolve_league_context()`` returned ``fetched_from_sleeper=True``
+         (i.e. Sleeper actually responded with scoring data).
+      3. The league's ``bonus_rec_te > 0`` (the league has TE premium
+         scoring; non-TEP leagues take the hardcoded default path).
+
+    When all three hold, the contract stamps:
+      * ``tepMultiplier``: derived value (e.g. 1.15 for TEP-1.5)
+      * ``tepMultiplierDerived``: same as above (frontend reads this
+        for the slider's "Auto" baseline)
+      * ``tepMultiplierSource``: ``"derived"``
+
+    These tests patch ``_resolve_league_context`` to simulate live
+    Sleeper data; the real resolver is exercised by
+    ``TestTepMultiplierDerivation`` above.
+    """
+
+    _RESOLVER_PATH = "src.api.data_contract._resolve_league_context"
+
+    def _patch_context(
+        self, *, bonus_rec_te: float, fetched: bool = True, roster_count: int = 12
+    ) -> Any:
+        return patch(
+            self._RESOLVER_PATH,
+            return_value={
+                "roster_count": roster_count,
+                "bonus_rec_te": bonus_rec_te,
+                "fetched_from_sleeper": fetched,
+            },
+        )
+
+    def test_tep_15_league_derives_115(self) -> None:
+        """TEP-1.5 league (``bonus_rec_te == 0.5``) → derived 1.15."""
+        with self._patch_context(bonus_rec_te=0.5):
+            contract = build_api_data_contract(_fixture_raw_payload())
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.15, places=4)
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplierDerived") or 0), 1.15, places=4
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "derived")
+        # Reverse-derive bonusRecTe lands back at 0.5 (round-trip
+        # through the summary stamp).
+        self.assertAlmostEqual(float(rov.get("bonusRecTe") or 0), 0.5, places=2)
+
+    def test_tep_20_league_derives_130(self) -> None:
+        """TEP-2.0 league (``bonus_rec_te == 1.0``) → derived 1.30."""
+        with self._patch_context(bonus_rec_te=1.0):
+            contract = build_api_data_contract(_fixture_raw_payload())
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.30, places=4)
+        self.assertEqual(rov.get("tepMultiplierSource"), "derived")
+
+    def test_non_tep_league_falls_back_to_default(self) -> None:
+        """``bonus_rec_te == 0`` (non-TEP league) → hardcoded 1.25
+        default, not the derived 1.0.  Preserves predictable behavior
+        for leagues whose Sleeper config legitimately has no TE bonus.
+        """
+        with self._patch_context(bonus_rec_te=0.0):
+            contract = build_api_data_contract(_fixture_raw_payload())
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplier") or 0),
+            _TE_BLANKET_NON_NATIVE_MULTIPLIER,
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "default")
+
+    def test_no_sleeper_context_falls_back_to_default(self) -> None:
+        """When ``_resolve_league_context`` returns its fallback dict
+        (Sleeper fetch failed, env var unset, registry miss), even a
+        positive ``bonus_rec_te`` in the dict can't be trusted —
+        ``fetched_from_sleeper=False`` blocks the auto-derive.
+        """
+        with self._patch_context(bonus_rec_te=0.5, fetched=False):
+            contract = build_api_data_contract(_fixture_raw_payload())
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplier") or 0),
+            _TE_BLANKET_NON_NATIVE_MULTIPLIER,
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "default")
+
+    def test_explicit_override_beats_derived(self) -> None:
+        """Explicit slider override wins over the auto-derived value
+        even when Sleeper context is live.  Stamps ``"override"``,
+        not ``"derived"``.  ``tepMultiplierDerived`` still carries
+        the auto value so the frontend can show "you overrode 1.15
+        with 1.40" semantics.
+        """
+        with self._patch_context(bonus_rec_te=0.5):
+            contract = build_api_data_contract(
+                _fixture_raw_payload(), tep_multiplier=1.40
+            )
+        rov = contract.get("rankingsOverride") or {}
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.40, places=4)
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplierDerived") or 0), 1.15, places=4
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "override")
+
+    def test_tep_native_default_unchanged_by_derivation(self) -> None:
+        """Auto-deriving ``tep_multiplier`` does NOT touch the parallel
+        ``tep_native_multiplier`` knob — it stays at the hardcoded
+        default (1.10) until the operator overrides it explicitly.
+        Native-source calibration is a separate concern from league
+        TEP detection.
+        """
+        with self._patch_context(bonus_rec_te=1.0):
+            contract = build_api_data_contract(_fixture_raw_payload())
+        rov = contract.get("rankingsOverride") or {}
+        # Non-TEP slider auto-derives to 1.30 for TEP-2.0
+        self.assertAlmostEqual(
+            float(rov.get("tepMultiplier") or 0), 1.30, places=4
+        )
+        self.assertEqual(rov.get("tepMultiplierSource"), "derived")
+        # TEP-native stays at 1.10 default — unaffected
+        self.assertAlmostEqual(
+            float(rov.get("tepNativeMultiplier") or 0), 1.10, places=4
+        )
+        self.assertEqual(rov.get("tepNativeMultiplierSource"), "default")
 
 
 class TestTepMultipliersEndToEnd(unittest.TestCase):


### PR DESCRIPTION
## Summary

Re-wires ``_derive_tep_multiplier_from_league`` (already implemented and unit-tested but disconnected) into the live ``build_api_data_contract`` path.  When the operator hasn't moved the slider, the contract now stamps the league's actual TEP setting instead of a generic 1.25 fallback.

The derivation formula and the function itself are unchanged from before — this PR just connects them up.  Existing TEP-1.5 leagues (Russini Panini and Blood, Sweat, and Beers, both ``superflex_tep15_ppr1`` per ``config/leagues/registry.json``) will see the slider's "Auto" baseline drop from 1.25 → 1.15, matching their actual scoring.

## How the auto-derive triggers

Three conditions must all hold for the auto-derive path to fire:

1. ``tep_multiplier=None`` on the call (no slider override)
2. ``_resolve_league_context()`` returned ``fetched_from_sleeper=True`` — Sleeper actually responded
3. ``bonus_rec_te > 0`` — the league has TE-premium scoring

Yields:

| League TEP setting | ``bonus_rec_te`` | Derived multiplier |
|---|---:|---:|
| Non-TEP | 0.0 | falls back to 1.25 default |
| TEP-1.5 | 0.5 | **1.15** |
| TEP-2.0 | 1.0 | **1.30** |
| Heavy TEP | 3.33+ | 2.0 (clamped) |

Falls back to the hardcoded ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` (1.25) when any condition fails — preserves predictable behavior on cold start, offline, registry miss, or non-TEP leagues.

## Behavioural change

For Sleeper leagues that have responded successfully and use TEP-1.5 or TEP-2.0 scoring, the default ``tepMultiplier`` will shift:

  * **TEP-1.5 leagues**: 1.25 → 1.15.  TE values drop ~8% relative to non-TE positions on the default board.  Operator can manually move the slider back to 1.25 (or higher) if they prefer the previous calibration.
  * **TEP-2.0 leagues**: 1.25 → 1.30.  TE values rise ~4%.

Operators who already moved the slider see no change — explicit overrides still win.  Non-TEP leagues, offline runs, and the test environment all keep the 1.25 default.

## Stamps

  * ``rankingsOverride.tepMultiplier``: effective value
  * ``rankingsOverride.tepMultiplierDerived``: auto-derived (or fallback) baseline — read by /settings to render the slider's "Auto" label
  * ``rankingsOverride.tepMultiplierSource``: ``"derived"`` / ``"default"`` / ``"override"``

The /settings page already reads ``rankingsOverride.tepMultiplierDerived`` for the displayed default; the comment there saying it "post-2026-05-06 is just the hardcoded non-TEP default" is now stale and will refresh in a follow-up.

## Test plan

  * [x] 6 new cases in ``TestBuildContractTepAutoDerive`` covering TEP-1.5, TEP-2.0, non-TEP, no-Sleeper-context, explicit-override-wins, native-multiplier-untouched
  * [x] Full ``tests/api/`` sweep: **1085 passed, 3 skipped** (was 1079; +6 from this PR)
  * [x] Existing ``TestBuildContractTepSlider`` cases continue to pass (test env's ``_resolve_league_context`` returns the fallback dict, auto-derive correctly defers to the hardcoded default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)