### PR TITLE
feat(trade): mobile-first sticky quick-add bar at top of /trade

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1325,6 +1325,138 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   MOBILE QUICK ADD (sticky one-tap player search at the top of /trade)
+   ══════════════════════════════════════════════════════════════════════════ */
+.mobile-quick-add {
+  position: sticky;
+  /* The mobile topbar is ~44px tall; offset so the quick-add lands
+     just below it without overlapping. */
+  top: 44px;
+  z-index: 9;
+  margin-bottom: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(8, 19, 44, 0.92);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.mobile-quick-add-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mobile-quick-add-side-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(255, 199, 4, 0.06);
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  /* Mobile tap-target minimum */
+  min-height: 40px;
+  min-width: 56px;
+}
+
+.mobile-quick-add-side-badge:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.mobile-quick-add-side-arrow {
+  color: var(--subtext);
+  font-size: 0.82rem;
+}
+
+.mobile-quick-add-side-letter {
+  color: var(--cyan);
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+
+.mobile-quick-add-side-toggle {
+  color: var(--subtext);
+  font-size: 0.78rem;
+  margin-left: 2px;
+}
+
+.mobile-quick-add-input {
+  flex: 1;
+  min-height: 40px;
+}
+
+.mobile-quick-add-results {
+  margin-top: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(8, 19, 44, 0.96);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.mobile-quick-add-result {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  /* Mobile tap-target minimum */
+  min-height: 44px;
+}
+
+.mobile-quick-add-result:last-child {
+  border-bottom: none;
+}
+
+.mobile-quick-add-result:active {
+  background: rgba(255, 199, 4, 0.10);
+}
+
+.mobile-quick-add-result-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.mobile-quick-add-result-name {
+  font-weight: 600;
+  font-size: 0.86rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mobile-quick-add-result-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  margin-top: 2px;
+}
+
+.mobile-quick-add-empty {
+  padding: 12px;
+  font-size: 0.82rem;
+  text-align: center;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    BOTTOM SHEET (mobile modals)
    ══════════════════════════════════════════════════════════════════════════ */
 .sheet-overlay {

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -82,6 +82,134 @@ const SUGGESTION_RAIL_LABELS = {
   positionalUpgrades: { label: "Upgrade", color: "var(--purple)", hint: "Direct positional swaps that net you value." },
 };
 
+// Mobile-only sticky quick-add bar.  The full per-side search inputs
+// live deep in the page (after the suggestions rail, controls bar,
+// and side headers) — on a 390px viewport that's ~600-800px of scroll
+// before a user can type a name.  This bar surfaces a single search
+// at the top with an explicit "active side" indicator and a one-tap
+// side toggle, so dynasty owners tinkering on the couch can populate
+// both sides without scrolling away from the live verdict bar above.
+//
+// Hidden on desktop (CSS ``mobile-only``); the per-side search inputs
+// stay there because their position next to each side's asset list
+// makes them more discoverable on a wide layout.
+function MobileQuickAddBar({
+  activeSide,
+  sides,
+  onAddToActiveSide,
+  searchAssets,
+  settings,
+  onSetActiveSide,
+}) {
+  const [query, setQuery] = useState("");
+  const [focused, setFocused] = useState(false);
+  const inputRef = useRef(null);
+
+  const trimmed = query.trim();
+  const results = focused && trimmed ? searchAssets(query) : [];
+  const showResults = focused && trimmed.length > 0;
+
+  const sideLabel = sides[activeSide]?.label || sides[0]?.label || "A";
+
+  function handleAdd(row) {
+    onAddToActiveSide(row);
+    setQuery("");
+    requestAnimationFrame(() => {
+      inputRef.current?.focus({ preventScroll: true });
+    });
+  }
+
+  function cycleSide() {
+    if (sides.length < 2) return;
+    onSetActiveSide((activeSide + 1) % sides.length);
+  }
+
+  return (
+    <div className="mobile-quick-add mobile-only" role="region" aria-label="Quick add player to trade">
+      <div className="mobile-quick-add-row">
+        <button
+          type="button"
+          className="mobile-quick-add-side-badge"
+          onClick={cycleSide}
+          aria-label={`Currently adding to Side ${sideLabel}. Tap to switch sides.`}
+          title={
+            sides.length >= 2
+              ? `Adding to Side ${sideLabel} — tap to switch`
+              : `Adding to Side ${sideLabel}`
+          }
+          disabled={sides.length < 2}
+        >
+          <span className="mobile-quick-add-side-arrow" aria-hidden="true">→</span>
+          <span className="mobile-quick-add-side-letter">{sideLabel}</span>
+          {sides.length >= 2 && (
+            <span className="mobile-quick-add-side-toggle" aria-hidden="true">⇄</span>
+          )}
+        </button>
+        <input
+          ref={inputRef}
+          className="input mobile-quick-add-input"
+          placeholder={`Quick add to Side ${sideLabel}…`}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => {
+            // Delay so a tap on a result registers before the dropdown
+            // unmounts (mirrors the per-side search inputs).
+            setTimeout(() => setFocused(false), 120);
+          }}
+          inputMode="search"
+          enterKeyHint="search"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck="false"
+        />
+      </div>
+      {showResults && (
+        <div className="mobile-quick-add-results">
+          {results.length === 0 ? (
+            <div className="mobile-quick-add-empty muted">No matches.</div>
+          ) : (
+            results.map((r) => (
+              <button
+                key={`mobile-quick-${r.name}`}
+                type="button"
+                className="button-reset mobile-quick-add-result"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleAdd(r);
+                }}
+                onTouchStart={(e) => {
+                  e.preventDefault();
+                  handleAdd(r);
+                }}
+              >
+                <PlayerImage
+                  playerId={r.raw?.playerId}
+                  team={r.team}
+                  position={r.pos}
+                  name={r.name}
+                  size={26}
+                />
+                <div className="mobile-quick-add-result-body">
+                  <div className="mobile-quick-add-result-name">{r.name}</div>
+                  <div className="mobile-quick-add-result-meta">
+                    <span className={posBadgeClass(r)}>{r.pos}</span>
+                    <span className="muted">
+                      {r.blendedSourceRank != null ? `#${r.blendedSourceRank.toFixed(1)}` : "—"}
+                      {" · "}
+                      {Math.round(displayValue(r, settings)).toLocaleString()}
+                    </span>
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ProactiveSuggestionsRail({ suggestions, onApply }) {
   // For each category, take the top suggestion (already sorted by
   // the engine).  Skip categories with zero results.
@@ -1305,6 +1433,22 @@ export default function TradePage() {
           first.  Switch back to the primary league from the nav to use those
           features.
         </div>
+      )}
+
+      {/* Mobile-only sticky quick-add bar.  Sits above the suggestions
+          rail so the search input is the FIRST interactive element a
+          mobile user reaches — no scrolling needed to start populating
+          a trade.  Hidden on desktop where the per-side search inputs
+          inside each side's card are more discoverable. */}
+      {!loading && !error && (
+        <MobileQuickAddBar
+          activeSide={activeSide}
+          sides={sides}
+          onAddToActiveSide={addToActiveSide}
+          searchAssets={searchAssets}
+          settings={settings}
+          onSetActiveSide={setActiveSide}
+        />
       )}
 
       {/* Proactive "Recommended right now" rail.  Surfaces top


### PR DESCRIPTION
## Summary

Adds a single mobile-only sticky quick-add bar at the top of ``/trade`` so dynasty owners on phones can populate trades without scrolling past the suggestions rail, controls bar, and side headers to reach the per-side search inputs.

## What it looks like

```
┌─────────────────────────────────────────┐
│ [→ A ⇄]  Quick add to Side A…           │  ← sticky on mobile
├─────────────────────────────────────────┤
│  Brock Bowers                           │  ← autocomplete results
│  TE · #5.0 · 9,588                      │
│  ...                                     │
├─────────────────────────────────────────┤
│ Recommended right now                    │  ← existing rail unchanged
│ [Sell High][Buy Low][Consolidation]     │
└─────────────────────────────────────────┘
```

  * One-tap side toggle (``⇄``) cycles ``activeSide``, so a user can populate Side A then Side B without leaving the bar.
  * Sticky positioning (``top: 44px`` to clear the mobile topbar) keeps it visible while the verdict bar updates below as players are added.
  * Hidden on desktop via ``mobile-only`` class — the per-side inputs inside each side's card remain there where the wide layout makes them more discoverable.

## What it reuses

  * ``searchAssets`` (existing memoized callback from the parent — same player pool, same sort)
  * ``addToActiveSide`` / ``addToSide`` (existing handlers — same duplicate guard, same destination defaulting for 3+-team trades)
  * ``activeSide`` / ``setActiveSide`` (existing state — toggling here flows through to the per-side highlight)

No new state on ``TradePage``.  The component owns its own ``query`` / ``focused`` state and reads/writes ``activeSide`` through props the parent already exposes.

## Bundle impact

  * ``/trade/page``: 58.1 KB → 60.7 KB (+2.6 KB), still 14.3 KB under the 75 KB budget.

## Test plan

  * [x] Frontend build passes (catches JSX/webpack errors)
  * [x] Frontend tests: 886/886 pass
  * [x] Bundle still under budget
  * [ ] Manual mobile smoke after deploy: visit ``/trade`` on a phone, confirm bar renders sticky at top, autocomplete works, side toggle cycles, no overlap with mobile topbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)