### PR TITLE
feat(terminal): top-3 sells / top-3 buys rail above the home grid

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -5303,6 +5303,142 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   white-space: nowrap;
 }
 
+/* ─ TopSignalsRail (your-roster top 3 sells / top 3 buys) ─ */
+.top-signals-rail {
+  margin: 0 0 var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(8, 19, 44, 0.55);
+}
+
+.top-signals-rail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 8px;
+}
+
+.top-signals-rail-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text);
+}
+
+.top-signals-rail-subtitle {
+  font-size: 0.7rem;
+}
+
+.top-signals-rail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.top-signal-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(8, 19, 44, 0.7);
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  /* Mobile tap-target minimum */
+  min-height: 80px;
+}
+
+.top-signal-card:hover,
+.top-signal-card:focus-visible {
+  background: rgba(8, 19, 44, 0.95);
+  outline: none;
+}
+
+.top-signal-card--down:hover,
+.top-signal-card--down:focus-visible {
+  border-color: var(--red);
+}
+
+.top-signal-card--up:hover,
+.top-signal-card--up:focus-visible {
+  border-color: var(--green);
+}
+
+.top-signal-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.top-signal-card-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+
+.top-signal-card-tag--down {
+  color: var(--red);
+}
+
+.top-signal-card-tag--up {
+  color: var(--green);
+}
+
+.top-signal-card-delta {
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+}
+
+.top-signal-card-delta--down {
+  color: var(--red);
+}
+
+.top-signal-card-delta--up {
+  color: var(--green);
+}
+
+.top-signal-card-name {
+  font-size: 0.92rem;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.top-signal-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.7rem;
+}
+
+.top-signal-card-pos {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.top-signal-card-evidence {
+  font-size: 0.7rem;
+  color: var(--subtext);
+  line-height: 1.3;
+  /* Two-line clamp keeps card height predictable */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* ─ Responsive grid (mobile-first) ─ */
 .terminal-grid {
   display: flex;

--- a/frontend/components/terminal/TerminalLayout.jsx
+++ b/frontend/components/terminal/TerminalLayout.jsx
@@ -4,6 +4,7 @@ import { useTeam } from "@/components/useTeam";
 import { useTerminal } from "@/components/useTerminal";
 import TeamCommandHeader from "./TeamCommandHeader";
 import MarketTicker from "./MarketTicker";
+import TopSignalsRail from "./TopSignalsRail";
 import PlayerMarketMovement from "./PlayerMarketMovement";
 import BuySellHold from "./BuySellHold";
 import MoversPanel from "./MoversPanel";
@@ -56,6 +57,7 @@ export default function TerminalLayout() {
       <StaleBanner />
       <TeamCommandHeader />
       <MarketTicker />
+      <TopSignalsRail />
 
       <div className="terminal-grid">
         <div className="terminal-col terminal-col--left">

--- a/frontend/components/terminal/TopSignalsRail.jsx
+++ b/frontend/components/terminal/TopSignalsRail.jsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useMemo } from "react";
+import { useApp } from "@/components/AppShell";
+import { useTeam } from "@/components/useTeam";
+import { useRankHistory } from "@/components/useRankHistory";
+import { useNews } from "@/components/useNews";
+import { useUserState } from "@/components/useUserState";
+import { evaluateRoster, SIGNALS } from "@/lib/signal-engine";
+
+/**
+ * TopSignalsRail — compact "your team's top moves this week" rail.
+ *
+ * Sits above the terminal grid so the FIRST thing a signed-in user
+ * sees is something specific to their roster, not a generic ranking.
+ * Surfaces the top 3 SELL + top 3 BUY signals from the same engine
+ * the deeper ``BuySellHold`` panel uses.
+ *
+ * The full panel below remains the place for bulk filtering,
+ * dismissal management, and signal evidence.  This rail is a
+ * scannable headline: one row of cards each labelled ``SELL`` or
+ * ``BUY``, tap to open the player popup.
+ *
+ * Renders nothing when:
+ *   - no team is selected (the league switcher hasn't resolved)
+ *   - the roster has zero matched rows
+ *   - both buckets are empty after dismissal filtering
+ *
+ * Hook usage mirrors ``BuySellHold`` so the underlying
+ * ``useTerminal`` cache primed by ``TerminalLayout`` is shared and
+ * the only redundant work is the local ``evaluateRoster`` pass —
+ * cheap (sort + categorize a roster's worth of rows).
+ */
+
+const TOP_PER_BUCKET = 3;
+
+function isDismissed(name, tag, dismissedMap, now) {
+  const key = `${String(name).trim()}::${String(tag || "unknown").trim()}`;
+  const expiresAt = Number(dismissedMap?.[key] || 0);
+  return expiresAt > now;
+}
+
+function valueDelta(verdict) {
+  // Pull a "what changed" hint for the card subtitle.  ``context.delta30d``
+  // (30-day rank delta) is set by ``buildContext`` in signal-engine.js
+  // when history is available — surface it as a +/- number so the card
+  // shows direction-of-change at a glance.
+  const d = Number(verdict?.context?.delta30d);
+  return Number.isFinite(d) ? d : null;
+}
+
+function valueLabel(verdict) {
+  const v = Number(verdict?.context?.value);
+  return Number.isFinite(v) && v > 0 ? Math.round(v).toLocaleString() : null;
+}
+
+function SignalCard({ entry, tone, onOpen }) {
+  const name = entry?.row?.name || entry?.context?.name || "";
+  const pos = String(entry?.row?.position || entry?.context?.position || "").toUpperCase();
+  const team = entry?.row?.team || "";
+  const value = valueLabel(entry?.verdict);
+  const delta = valueDelta(entry?.verdict);
+  const evidence = entry?.verdict?.evidence?.[0] || "";
+
+  return (
+    <button
+      type="button"
+      className={`top-signal-card top-signal-card--${tone}`}
+      onClick={() => onOpen?.(name)}
+      aria-label={`${tone === "down" ? "Sell" : "Buy"} signal: ${name}`}
+      title={evidence || name}
+    >
+      <div className="top-signal-card-head">
+        <span className={`top-signal-card-tag top-signal-card-tag--${tone}`}>
+          {tone === "down" ? "SELL" : "BUY"}
+        </span>
+        {Number.isFinite(delta) && delta !== 0 && (
+          <span className={`top-signal-card-delta top-signal-card-delta--${delta < 0 ? "down" : "up"}`}>
+            {delta > 0 ? "▲" : "▼"} {Math.abs(delta)} ranks · 30d
+          </span>
+        )}
+      </div>
+      <div className="top-signal-card-name">{name}</div>
+      <div className="top-signal-card-meta">
+        {pos && <span className="top-signal-card-pos">{pos}</span>}
+        {team && <span className="muted">· {team}</span>}
+        {value && <span className="muted">· {value}</span>}
+      </div>
+      {evidence && (
+        <div className="top-signal-card-evidence">
+          {evidence}
+        </div>
+      )}
+    </button>
+  );
+}
+
+export default function TopSignalsRail() {
+  const { rows, openPlayerPopup } = useApp();
+  const { selectedTeam, selectedLeagueKey } = useTeam();
+  const { history } = useRankHistory({ days: 30 });
+  const { state: userState } = useUserState();
+
+  const rosterNames = selectedTeam?.players || [];
+  const news = useNews({ rosterNames, leagueNames: [] });
+  const scoredNews = news.scored;
+
+  // Per-league dismissals take precedence over the legacy flat map.
+  // Mirrors the precedence ``BuySellHold`` uses — keeps "I dismissed
+  // this in the panel" honored at the rail too.
+  const dismissedMap = useMemo(() => {
+    const leagueKey = selectedTeam ? selectedLeagueKey : "";
+    const byLeague = userState?.dismissedSignalsByLeague;
+    if (leagueKey && byLeague && typeof byLeague === "object") {
+      const bucket = byLeague[leagueKey];
+      if (bucket && typeof bucket === "object") return bucket;
+    }
+    return userState?.dismissedSignals || {};
+  }, [userState?.dismissedSignalsByLeague, userState?.dismissedSignals, selectedLeagueKey, selectedTeam]);
+
+  const verdicts = useMemo(
+    () =>
+      evaluateRoster({
+        rows,
+        selectedTeam,
+        history,
+        newsItems: scoredNews,
+      }),
+    [rows, selectedTeam, history, scoredNews],
+  );
+
+  const { sells, buys, hasAny } = useMemo(() => {
+    const now = Date.now();
+    const sellsAll = [];
+    const buysAll = [];
+    for (const v of verdicts) {
+      const sig = v?.verdict?.signal;
+      const tag = v?.verdict?.tag;
+      const name = v?.row?.name || v?.context?.name || "";
+      if (!name) continue;
+      if (isDismissed(name, tag, dismissedMap, now)) continue;
+      if (sig === SIGNALS.SELL) sellsAll.push(v);
+      else if (sig === SIGNALS.BUY) buysAll.push(v);
+    }
+    return {
+      sells: sellsAll.slice(0, TOP_PER_BUCKET),
+      buys: buysAll.slice(0, TOP_PER_BUCKET),
+      sellsRemaining: Math.max(0, sellsAll.length - TOP_PER_BUCKET),
+      buysRemaining: Math.max(0, buysAll.length - TOP_PER_BUCKET),
+      hasAny: sellsAll.length > 0 || buysAll.length > 0,
+    };
+  }, [verdicts, dismissedMap]);
+
+  // Render nothing when there's nothing actionable.  The full
+  // ``BuySellHold`` panel below still surfaces RISK/MONITOR/HOLD —
+  // this rail intentionally focuses on the two clear "trade now"
+  // categories.
+  if (!selectedTeam) return null;
+  if (!hasAny) return null;
+
+  return (
+    <section className="top-signals-rail" aria-label="Top trade signals for your roster">
+      <div className="top-signals-rail-header">
+        <span className="top-signals-rail-title">This week's top moves</span>
+        <span className="top-signals-rail-subtitle muted">
+          Top 3 buy / sell candidates from your roster
+        </span>
+      </div>
+      <div className="top-signals-rail-grid">
+        {sells.map((v) => (
+          <SignalCard
+            key={`sell-${v.row?.name}`}
+            entry={v}
+            tone="down"
+            onOpen={openPlayerPopup}
+          />
+        ))}
+        {buys.map((v) => (
+          <SignalCard
+            key={`buy-${v.row?.name}`}
+            entry={v}
+            tone="up"
+            onOpen={openPlayerPopup}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a compact ``TopSignalsRail`` between ``MarketTicker`` and the terminal grid on the signed-in landing page so the FIRST thing every user sees is something specific to their roster — not a generic ranking.

## What it shows

Top 3 ``SELL`` + top 3 ``BUY`` signals from the same ``evaluateRoster`` engine the deeper ``BuySellHold`` panel uses, rendered as a horizontal rail of tap-to-open-popup cards:

```
[SELL]                 [SELL]                 [BUY]                  [BUY]
Brock Bowers           Tee Higgins            Colston Loveland       Trey McBride
TE · LV · 9,588        WR · CIN · 8,420       TE · CHI · 7,308       TE · ARI · 9,158
▼ 8 ranks · 30d        ▼ 4 ranks · 30d        ▲ 12 ranks · 30d       ▲ 3 ranks · 30d
KTC moved Bowers       Hill trade impact      Rookie hype consolid-  Steady riser since
from #1 to #5 on TE++  pushing Higgins down…  ating around Loveland  Kyler trade…
```

## Why a separate rail vs. enhancing BuySellHold

The full ``BuySellHold`` panel below stays as-is — it's the place for bulk filtering, dismissal management, RISK/MONITOR/HOLD coverage, and evidence inspection.  The rail is a scannable headline with two intentional differences:

  * Top-3 caps so the rail height is predictable (a 25-player roster with 8 sells doesn't push the grid below the fold)
  * SELL + BUY only (the two unambiguously "trade now" categories) — RISK/MONITOR are watch-list items, not "do something this week" items
  * No filter chips, no dismissal UI — those live in the panel

## Render conditions

  * No team selected → renders null
  * Both buckets empty after dismissal filtering → renders null
  * Otherwise: renders whatever it has, up to 3 per bucket

## Dismissal precedence

Mirrors ``BuySellHold``'s logic exactly: per-league bucket
(``state.dismissedSignalsByLeague[leagueKey]``) wins over the legacy
flat map (``state.dismissedSignals``).  Effect: when a user dismisses
"Bowers SELL" in the panel below, it disappears from the rail above
on the same render.

## Performance

Hook usage is identical to ``BuySellHold``:

  * ``useApp``, ``useTeam``, ``useRankHistory``, ``useNews``, ``useUserState``

The ``useTerminal`` cache primed at ``TerminalLayout`` is shared.
The only redundant work is a local ``evaluateRoster`` pass — cheap
(O(N) sort + categorize a roster's worth of rows, ~25 entries).

## Bundle impact

  * ``/page``: 72.2 KB → 75.8 KB (+3.6 KB), 14.2 KB headroom under the 90 KB budget.

## Test plan

  * [x] Frontend build passes
  * [x] Frontend tests: 886/886 pass
  * [x] Bundle still under budget
  * [ ] Manual smoke after deploy: visit ``/`` signed-in, confirm rail renders above the grid with up-to-3 cards per side; tap a card opens player popup; dismiss a signal in the panel below and confirm it disappears from the rail on the same load

🤖 Generated with [Claude Code](https://claude.com/claude-code)