### PR TITLE
feat(picks): stamp draft-day value projections on pick rows

### DIFF
--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -718,6 +718,42 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
           </div>
         )}
 
+        {/* Pick value projection — surfaces the package-now-or-wait
+            decision the operator faces on every offseason trade
+            involving forward picks.  ``pickProjectedDraftValue`` is
+            stamped on every valued pick row by the contract builder
+            (``_stamp_pick_value_projections``); we render it only when
+            there's a positive gain to show, i.e. future-year picks.
+            Baseline-year picks have zero gain and would render a
+            no-op line.  Non-pick rows leave these fields undefined. */}
+        {row?.assetClass === "pick"
+          && Number.isFinite(row?.pickProjectedDraftValue)
+          && Number(row?.pickProjectedDraftValueGain) > 0 && (
+            <div style={{
+              marginTop: 10,
+              padding: "6px 10px",
+              borderRadius: 6,
+              background: "rgba(96, 165, 250, 0.08)",
+              border: "1px solid rgba(96, 165, 250, 0.22)",
+            }}>
+              <span style={{ fontWeight: 700, fontSize: "0.82rem", color: "var(--text)" }}>
+                📅 Projected at draft
+              </span>
+              <span className="muted" style={{ marginLeft: 8, fontSize: "0.76rem" }}>
+                ~{Number(row.pickProjectedDraftValue).toLocaleString()} by the {row.pickProjectedDraftYear} draft
+                {Number(row.pickProjectedDraftValueGainPct) > 0 && (
+                  <>
+                    {" · "}
+                    <span style={{ color: "var(--green)" }}>
+                      ▲ {row.pickProjectedDraftValueGainPct}%
+                    </span>
+                    {" gain"}
+                  </>
+                )}
+              </span>
+            </div>
+          )}
+
         {/* 180-day rank-history mini-chart */}
         <div style={{ marginTop: 14 }}>
           <PlayerRankHistoryChart row={row} />

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -5057,6 +5057,67 @@ def _apply_pick_year_discount_to_blend(
     return out, discount_applied
 
 
+def _stamp_pick_value_projections(
+    players_array: list[dict[str, Any]],
+) -> None:
+    """Stamp draft-day value projections on every pick row.
+
+    The pick year discount (``config/weights/pick_year_discount.json``)
+    deflates future-year picks below their on-draft equivalent — a
+    2027 1st today is 82% of a 2026 1.01 because of one year of
+    uncertainty + opportunity cost.  As the draft approaches, that
+    discount unwinds: when 2027 becomes the baseline year, the same
+    pick will be valued at 100% of a 1.01.
+
+    This pass projects the on-draft value by inverting the discount:
+
+        projected = rankDerivedValue / pickYearDiscount
+
+    Stamps on each pick row:
+
+      * ``pickProjectedDraftValue``     (int) — value at its own draft
+      * ``pickProjectedDraftYear``      (int) — the year the pick is drafted
+      * ``pickProjectedDraftValueGain`` (int) — projected − today (always ≥ 0)
+      * ``pickProjectedDraftValueGainPct`` (int) — gain as percent of today
+
+    Current-year picks (2026 baseline) project to their current value
+    with zero gain — the discount is already 1.0, the pick is *at*
+    its draft already.
+
+    Tier-generic picks (e.g. ``2026 Early 1st``) get a projection too;
+    the year is extracted from the name regardless of slot specificity.
+
+    Run AFTER ``_anchor_current_year_picks_to_rookies`` so the
+    projection sees the final ``rankDerivedValue`` (post-discount and
+    post-rookie-anchor) for current-year slot picks.
+    """
+    for row in players_array:
+        if row.get("assetClass") != "pick":
+            continue
+        rdv = row.get("rankDerivedValue")
+        if not isinstance(rdv, (int, float)) or rdv <= 0:
+            continue
+        year = _pick_year_from_name(row.get("canonicalName") or "")
+        if year is None:
+            continue
+        # ``pickYearDiscount`` is only stamped when the multiplier
+        # diverges from 1.0; current-year picks land here with no
+        # stamp and an effective discount of 1.0.
+        try:
+            discount = float(row.get("pickYearDiscount") or 1.0)
+        except (TypeError, ValueError):
+            discount = 1.0
+        if discount <= 0 or discount > 1.0:
+            discount = 1.0
+        projected = int(round(float(rdv) / discount))
+        gain = max(0, projected - int(rdv))
+        gain_pct = int(round((gain / float(rdv)) * 100)) if rdv > 0 else 0
+        row["pickProjectedDraftValue"] = projected
+        row["pickProjectedDraftYear"] = int(year)
+        row["pickProjectedDraftValueGain"] = gain
+        row["pickProjectedDraftValueGainPct"] = gain_pct
+
+
 def _hampel_filter_per_player(
     pairs: list[tuple[str, float]],
     *,
@@ -6573,6 +6634,16 @@ def _compute_unified_rankings(
     _anchor_year = int(_load_pick_year_discount().get("baselineYear") or 2026)
     _anchor_current_year_picks_to_rookies(players_array, _anchor_year)
 
+    # 2c) Stamp draft-day value projections on every pick row.
+    #     Inverts the year-discount so the frontend can show "this
+    #     2027 pick is worth ~5,800 today, projected ~7,000 at the
+    #     2027 draft (▲21%)" — operationalises the package-now-or-
+    #     wait decision the user has to make on every offseason
+    #     trade involving forward picks.  Runs AFTER the anchor pass
+    #     so current-year slot picks project off their final rookie-
+    #     tethered ``rankDerivedValue``.
+    _stamp_pick_value_projections(players_array)
+
     # 2a) Compact ranks after suppression/anchor so the ranked board is
     #     still contiguous 1..N and value-monotonic.  Sort primarily by
     #     rankDerivedValue desc so anchored picks naturally bubble to the
@@ -7600,6 +7671,18 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "quarantined",
     "ktcRank",
     "idpRank",
+    # Pick-specific stamps.  ``pickYearDiscount`` and
+    # ``pickProjectedDraft*`` derive directly from the post-blend
+    # ``rankDerivedValue`` — when an override changes the blend, the
+    # projection has to update on the same response so the popup's
+    # "projected at draft" line stays in sync with the value bar
+    # next to it.  Non-pick rows leave these undefined; the frontend
+    # branches on ``assetClass === "pick"`` before reading them.
+    "pickYearDiscount",
+    "pickProjectedDraftValue",
+    "pickProjectedDraftYear",
+    "pickProjectedDraftValueGain",
+    "pickProjectedDraftValueGainPct",
 )
 
 

--- a/tests/api/test_picks_end_to_end.py
+++ b/tests/api/test_picks_end_to_end.py
@@ -472,5 +472,128 @@ class TestRepresentativePicks(unittest.TestCase):
         )
 
 
+class TestPickValueProjections(unittest.TestCase):
+    """``pickProjectedDraftValue`` and friends pin the on-draft value
+    estimate for every pick.
+
+    The pick year discount deflates future picks below their on-draft
+    equivalent (a 2027 1st today is 82% of a 2026 1.01 because of one
+    year of uncertainty + opportunity cost).  ``_stamp_pick_value_projections``
+    inverts that discount to project the on-draft value:
+
+        projected = rankDerivedValue / pickYearDiscount
+
+    The frontend reads these stamps to render
+    "projected ~X,XXX at the 2027 draft (▲21%)" annotations on pick
+    rows in the player popup.
+    """
+
+    def setUp(self) -> None:
+        self.contract = _load_contract()
+        if self.contract is None:
+            self.skipTest("No live scraper export available")
+        self.picks = _pick_rows(self.contract)
+        if not self.picks:
+            self.skipTest("No pick rows in the contract")
+
+    def test_every_pick_carries_projection_stamps(self) -> None:
+        """Every pick row with a positive ``rankDerivedValue`` carries
+        all four projection fields.  A pick whose ``rankDerivedValue``
+        is zero or missing has no projection — that's the documented
+        boundary (e.g. extremely deep tier-generic rows that fell off
+        the OVERALL_RANK_LIMIT cap)."""
+        missing_stamps: list[str] = []
+        for row in self.picks:
+            rdv = row.get("rankDerivedValue")
+            if not isinstance(rdv, (int, float)) or rdv <= 0:
+                continue
+            for field in (
+                "pickProjectedDraftValue",
+                "pickProjectedDraftYear",
+                "pickProjectedDraftValueGain",
+                "pickProjectedDraftValueGainPct",
+            ):
+                if row.get(field) is None:
+                    missing_stamps.append(
+                        f"{row.get('canonicalName')}: missing {field}"
+                    )
+        self.assertEqual(
+            missing_stamps, [],
+            "Every valued pick must stamp the full projection block:\n"
+            + "\n".join(missing_stamps[:10]),
+        )
+
+    def test_baseline_year_picks_project_to_current_value(self) -> None:
+        """Baseline-year picks (2026, the current draft) have
+        ``pickYearDiscount == 1.0`` (or unstamped, equivalent), so the
+        projection equals today's value with zero gain."""
+        baseline_picks = [
+            r for r in self.picks
+            if int(r.get("pickProjectedDraftYear") or 0) == 2026
+            and (r.get("rankDerivedValue") or 0) > 0
+        ]
+        if not baseline_picks:
+            self.skipTest("No 2026 picks with positive value in contract")
+        for row in baseline_picks:
+            with self.subTest(pick=row.get("canonicalName")):
+                rdv = int(row["rankDerivedValue"])
+                self.assertEqual(
+                    int(row["pickProjectedDraftValue"]),
+                    rdv,
+                    "2026 pick projection must equal today's value (no discount to invert)",
+                )
+                self.assertEqual(int(row["pickProjectedDraftValueGain"]), 0)
+                self.assertEqual(int(row["pickProjectedDraftValueGainPct"]), 0)
+
+    def test_future_year_picks_project_above_today(self) -> None:
+        """Future-year picks (2027+) have ``pickYearDiscount < 1.0``
+        applied, so the projection inverts to a value strictly above
+        today's.  Pin the math: projected = round(rdv / discount)."""
+        future_picks = [
+            r for r in self.picks
+            if int(r.get("pickProjectedDraftYear") or 0) >= 2027
+            and (r.get("rankDerivedValue") or 0) > 0
+            and r.get("pickYearDiscount") is not None
+        ]
+        if not future_picks:
+            self.skipTest("No future-year picks with discount in contract")
+        for row in future_picks:
+            with self.subTest(pick=row.get("canonicalName")):
+                rdv = float(row["rankDerivedValue"])
+                discount = float(row["pickYearDiscount"])
+                expected = int(round(rdv / discount))
+                actual = int(row["pickProjectedDraftValue"])
+                # Allow ±1 for rounding noise around the int boundary.
+                self.assertLessEqual(
+                    abs(actual - expected),
+                    1,
+                    f"projection math drifted: rdv={rdv}, discount={discount}, "
+                    f"expected≈{expected}, got {actual}",
+                )
+                self.assertGreater(
+                    actual, int(rdv),
+                    f"future-year pick must project ABOVE today's value: "
+                    f"rdv={rdv}, projected={actual}",
+                )
+                self.assertGreater(int(row["pickProjectedDraftValueGain"]), 0)
+                self.assertGreater(int(row["pickProjectedDraftValueGainPct"]), 0)
+
+    def test_projection_year_matches_canonical_name(self) -> None:
+        """``pickProjectedDraftYear`` extracts the year from the
+        canonical name (e.g. ``"2027 Mid 1st"`` → 2027)."""
+        for row in self.picks:
+            year_stamp = row.get("pickProjectedDraftYear")
+            if year_stamp is None:
+                continue
+            with self.subTest(pick=row.get("canonicalName")):
+                name = str(row.get("canonicalName") or "")
+                m = re.search(r"\b(20\d{2})\b", name)
+                self.assertIsNotNone(
+                    m, f"pick name lacks a year but has projection stamp: {name}"
+                )
+                assert m is not None
+                self.assertEqual(int(year_stamp), int(m.group(1)))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Surfaces the package-now-or-wait decision the operator faces on every offseason trade involving forward picks.  A 2027 1st today is at 82% of a 2026 1.01 because of one year of uncertainty + opportunity cost.  When the 2027 draft arrives, that discount fully unwinds — the same pick will be worth ~22% more on the same scale.

Without this annotation, the user has to do the inversion in their head every time they consider a pick trade.  With it:

> 📅 Projected at draft  ~7,000 by the 2027 draft · ▲ 21% gain

## What it stamps

``_stamp_pick_value_projections`` (new helper; called once per contract build, immediately after ``_anchor_current_year_picks_to_rookies`` so the projection sees the final ``rankDerivedValue`` for current-year slot picks) stamps four fields on every valued pick row:

| Field | Meaning |
|---|---|
| ``pickProjectedDraftValue`` | int — value at its own draft |
| ``pickProjectedDraftYear`` | int — draft year extracted from the canonical name |
| ``pickProjectedDraftValueGain`` | int — projected − today (≥ 0) |
| ``pickProjectedDraftValueGainPct`` | int — gain as percent of today |

**Math:** ``projected = round(rankDerivedValue / pickYearDiscount)``.  Inverts the existing year-discount config (``config/weights/pick_year_discount.json``) — no new model, no new data path.

  * 2026 baseline → discount 1.0 → projection = today's value, gain 0
  * 2027 → discount 0.82 → projection ≈ today × 1.22, gain ~22%
  * 2028 → discount 0.66 → projection ≈ today × 1.51, gain ~51%
  * 2029 → discount 0.53 → projection ≈ today × 1.89, gain ~89%

## Frontend display

``PlayerPopup`` renders a small blue-tinted annotation between the edge signal and the rank-history chart for picks with positive gain:

```
📅 Projected at draft  ~7,000 by the 2027 draft · ▲ 21% gain
```

Render conditions:

  * ``assetClass === "pick"`` (non-pick rows leave the four fields undefined; the popup branches before reading)
  * ``pickProjectedDraftValueGain > 0`` (suppresses the annotation for 2026 baseline picks where the projection equals today's value — would be a no-op line)

## Delta payload

The five new fields (the four projection stamps + ``pickYearDiscount`` itself) are added to ``_DELTA_PLAYER_FIELDS``, so override responses re-stamp the projection on every blend change.  Without this, a settings tweak that shifts pick values would have left a stale "projected at draft" line in the popup until full reload.

## Test plan

  * [x] 4 new cases in ``TestPickValueProjections`` (``tests/api/test_picks_end_to_end.py``) pinning every valued pick carries all four stamps; baseline-year picks project to today's value with zero gain; future-year picks project strictly above today via ``round(rdv / discount)``; ``pickProjectedDraftYear`` matches the year embedded in the canonical name
  * [x] Tests run against the live ``exports/latest/dynasty_data_*.json`` — math is checked end-to-end on real data (186 subtests across all valued picks)
  * [x] Full ``tests/api/`` sweep: **1089 passed, 3 skipped** (was 1085, +4 from this PR)
  * [x] Frontend build clean, all pages under budget
  * [x] Frontend tests: 886/886 pass
  * [ ] Manual smoke after deploy: open the player popup for ``2027 Mid 1st`` (or any 2027+ pick), confirm the "📅 Projected at draft" annotation appears with a value above today's

🤖 Generated with [Claude Code](https://claude.com/claude-code)