### PR TITLE
Wire consolidation adjustment flag to Monte Carlo button

### DIFF
--- a/frontend/components/ui/MonteCarloButton.jsx
+++ b/frontend/components/ui/MonteCarloButton.jsx
@@ -127,7 +127,7 @@ export default function MonteCarloButton({ sides, valueMode = "full" }) {
     try {
       setState("running");
       setErr("");
-      const body = { ..._payloadFromSides(sides, valueMode, settings), nSims: 20000 };
+      const body = { ..._payloadFromSides(sides, valueMode, settings), nSims: 20000, applyConsolidationAdjustment: true };
       const res = await fetch("/api/trade/simulate-mc", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/server.py
+++ b/server.py
@@ -7700,10 +7700,11 @@ async def post_trade_simulate_mc(request: Request):
                      "team": "...", "pos": "...",
                      "valueBand": {"p10":, "p50":, "p90":}}],
           "sideB": [...],
-          "nSims": 50000,          # optional, default 50000
-          "sameTeamRho": 0.25,     # optional correlation knob
-          "samePosGroupRho": 0.10, # optional correlation knob
-          "seed": 42               # optional for reproducible runs
+          "nSims": 50000,                        # optional, default 50000
+          "sameTeamRho": 0.25,                   # optional correlation knob
+          "samePosGroupRho": 0.10,               # optional correlation knob
+          "seed": 42,                            # optional for reproducible runs
+          "applyConsolidationAdjustment": false  # optional, default false
         }
 
     Response (on success)::
@@ -7768,6 +7769,7 @@ async def post_trade_simulate_mc(request: Request):
         seed = int(seed) if seed is not None else None
     except (TypeError, ValueError):
         seed = None
+    apply_ca = bool(body.get("applyConsolidationAdjustment", False))
     # Symmetrize the direction (A→B averaged with B→A) so ordering
     # never biases the result — critical invariant per the Phase 11
     # integration pass.  Then enrich with the decision-layer fields
@@ -7778,6 +7780,7 @@ async def post_trade_simulate_mc(request: Request):
         side_a, side_b,
         n_sims=n_sims, same_team_rho=rho_t,
         same_pos_group_rho=rho_p, seed=seed,
+        apply_consolidation_adjustment=apply_ca,
     )
     enriched = _sym.enrich_with_decision_shape(base, side_a, side_b)
     return JSONResponse(content=enriched)

--- a/server.py
+++ b/server.py
@@ -7769,7 +7769,10 @@ async def post_trade_simulate_mc(request: Request):
         seed = int(seed) if seed is not None else None
     except (TypeError, ValueError):
         seed = None
-    apply_ca = bool(body.get("applyConsolidationAdjustment", False))
+    # Strict boolean check: only JSON `true` enables this.  Strings like
+    # "false" or "0" must not accidentally activate consolidation adjustment.
+    _raw_ca = body.get("applyConsolidationAdjustment", False)
+    apply_ca = _raw_ca is True
     # Symmetrize the direction (A→B averaged with B→A) so ordering
     # never biases the result — critical invariant per the Phase 11
     # integration pass.  Then enrich with the decision-layer fields

--- a/src/trade/monte_carlo.py
+++ b/src/trade/monte_carlo.py
@@ -93,7 +93,7 @@ class SimResult:
                 "where side A's total exceeds side B's — NOT a "
                 "real-world win probability."
             ),
-            "vaAdjustment": self.va_adjustment or {"applied": False},
+            "vaAdjustment": self.va_adjustment or {"side": 0, "value": 0, "effectiveValue": 0, "applied": False},
         }
 
 
@@ -152,33 +152,52 @@ def _apply_consolidation_adjustment(
     b_p50s = [p.p50 for p in side_b]
     result = ktc_adjust_package(a_p50s, b_p50s)
 
+    applied = result.displayed and result.value > 0
     va_info: dict[str, Any] = {
         "side": result.side,
         "value": result.value,
-        "applied": result.displayed and result.value > 0,
+        "effectiveValue": 0,
+        "applied": applied,
     }
 
-    if not va_info["applied"]:
+    if not applied:
         return side_a, side_b, va_info
 
-    def _shift_side(players: list[TradePlayer], p50s: list[float]) -> list[TradePlayer]:
+    def _shift_side(
+        players: list[TradePlayer], p50s: list[float]
+    ) -> tuple[list[TradePlayer], int]:
+        """Shift the band for each player proportionally.
+
+        Returns the shifted list and the *actual* total p50 shift after
+        clamping — which may be less than ``result.value`` when players
+        are already near 9999.  The caller stamps this as
+        ``effectiveValue`` so the reported diagnostic matches what the
+        simulation actually experienced.
+        """
         total = sum(p50s) or 1.0
         out = []
+        effective_total = 0.0
         for p, pv in zip(players, p50s):
             shift = result.value * (pv / total)
+            new_p50 = max(0.0, min(9999.0, p.p50 + shift))
+            effective_total += new_p50 - p.p50
             out.append(TradePlayer(
                 name=p.name,
                 team=p.team,
                 position_group=p.position_group,
                 p10=max(0.0, min(9999.0, p.p10 + shift)),
-                p50=max(0.0, min(9999.0, p.p50 + shift)),
+                p50=new_p50,
                 p90=max(0.0, min(9999.0, p.p90 + shift)),
             ))
-        return out
+        return out, int(round(effective_total))
 
     if result.side == 1:
-        return _shift_side(side_a, a_p50s), side_b, va_info
-    return side_a, _shift_side(side_b, b_p50s), va_info
+        new_a, eff = _shift_side(side_a, a_p50s)
+        va_info["effectiveValue"] = eff
+        return new_a, side_b, va_info
+    new_b, eff = _shift_side(side_b, b_p50s)
+    va_info["effectiveValue"] = eff
+    return side_a, new_b, va_info
 
 
 def simulate_trade(
@@ -217,7 +236,7 @@ def simulate_trade(
             delta_p10=0.0, delta_p50=0.0, delta_p90=0.0,
             side_a_mean=0.0, side_b_mean=0.0,
             n_sims=0, method="consensus_based_win_rate",
-            va_adjustment={"side": 0, "value": 0, "applied": False},
+            va_adjustment={"side": 0, "value": 0, "effectiveValue": 0, "applied": False},
         )
 
     # Sanity clamp on correlation params.

--- a/src/trade/monte_carlo.py
+++ b/src/trade/monte_carlo.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import math
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 _DEFAULT_SIMS = 50_000
@@ -69,6 +69,7 @@ class SimResult:
     side_b_mean: float
     n_sims: int
     method: str  # "consensus_based_win_rate"
+    va_adjustment: dict[str, Any] | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -92,6 +93,7 @@ class SimResult:
                 "where side A's total exceeds side B's — NOT a "
                 "real-world win probability."
             ),
+            "vaAdjustment": self.va_adjustment or {"applied": False},
         }
 
 
@@ -126,6 +128,59 @@ def _triangular_draw(p10: float, p50: float, p90: float, u: float) -> float:
     return p90 + t * slope
 
 
+def _apply_consolidation_adjustment(
+    side_a: list[TradePlayer],
+    side_b: list[TradePlayer],
+) -> tuple[list[TradePlayer], list[TradePlayer], dict[str, Any]]:
+    """Apply KTC consolidation premium to whichever side earns it.
+
+    Uses each player's p50 as the raw value fed to ktc_adjust_package.
+    When VA is awarded, the bonus is distributed proportionally (by p50
+    share) across the receiving side's players as an additive band shift
+    — p10/p50/p90 all move up by the same amount per player, preserving
+    the absolute spread (source disagreement is unchanged).
+
+    Returns ``(adjusted_side_a, adjusted_side_b, va_info)`` where
+    ``va_info`` is a diagnostic dict with keys ``side`` (0/1/2),
+    ``value`` (int), and ``applied`` (bool).  When VA is suppressed
+    (1v1, < 3.3% variance, or equal packages) the original lists are
+    returned unchanged and ``applied`` is False.
+    """
+    from src.trade.ktc_va import ktc_adjust_package
+
+    a_p50s = [p.p50 for p in side_a]
+    b_p50s = [p.p50 for p in side_b]
+    result = ktc_adjust_package(a_p50s, b_p50s)
+
+    va_info: dict[str, Any] = {
+        "side": result.side,
+        "value": result.value,
+        "applied": result.displayed and result.value > 0,
+    }
+
+    if not va_info["applied"]:
+        return side_a, side_b, va_info
+
+    def _shift_side(players: list[TradePlayer], p50s: list[float]) -> list[TradePlayer]:
+        total = sum(p50s) or 1.0
+        out = []
+        for p, pv in zip(players, p50s):
+            shift = result.value * (pv / total)
+            out.append(TradePlayer(
+                name=p.name,
+                team=p.team,
+                position_group=p.position_group,
+                p10=max(0.0, min(9999.0, p.p10 + shift)),
+                p50=max(0.0, min(9999.0, p.p50 + shift)),
+                p90=max(0.0, min(9999.0, p.p90 + shift)),
+            ))
+        return out
+
+    if result.side == 1:
+        return _shift_side(side_a, a_p50s), side_b, va_info
+    return side_a, _shift_side(side_b, b_p50s), va_info
+
+
 def simulate_trade(
     side_a: list[TradePlayer],
     side_b: list[TradePlayer],
@@ -134,6 +189,7 @@ def simulate_trade(
     same_team_rho: float = 0.25,
     same_pos_group_rho: float = 0.10,
     seed: int | None = None,
+    apply_consolidation_adjustment: bool = False,
 ) -> SimResult:
     """Run the simulation and return the result.
 
@@ -151,6 +207,9 @@ def simulate_trade(
     the per-player band is preserved on average.
     """
     rng = random.Random(seed)
+    va_info: dict[str, Any] = {"side": 0, "value": 0, "applied": False}
+    if apply_consolidation_adjustment and side_a and side_b:
+        side_a, side_b, va_info = _apply_consolidation_adjustment(side_a, side_b)
     players = list(side_a) + list(side_b)
     if not players:
         return SimResult(
@@ -158,6 +217,7 @@ def simulate_trade(
             delta_p10=0.0, delta_p50=0.0, delta_p90=0.0,
             side_a_mean=0.0, side_b_mean=0.0,
             n_sims=0, method="consensus_based_win_rate",
+            va_adjustment={"side": 0, "value": 0, "applied": False},
         )
 
     # Sanity clamp on correlation params.
@@ -218,6 +278,7 @@ def simulate_trade(
         side_b_mean=b_mean,
         n_sims=n_sims,
         method="consensus_based_win_rate",
+        va_adjustment=va_info,
     )
 
 

--- a/src/trade/monte_carlo.py
+++ b/src/trade/monte_carlo.py
@@ -226,7 +226,7 @@ def simulate_trade(
     the per-player band is preserved on average.
     """
     rng = random.Random(seed)
-    va_info: dict[str, Any] = {"side": 0, "value": 0, "applied": False}
+    va_info: dict[str, Any] = {"side": 0, "value": 0, "effectiveValue": 0, "applied": False}
     if apply_consolidation_adjustment and side_a and side_b:
         side_a, side_b, va_info = _apply_consolidation_adjustment(side_a, side_b)
     players = list(side_a) + list(side_b)

--- a/src/trade/symmetrize.py
+++ b/src/trade/symmetrize.py
@@ -118,7 +118,7 @@ def simulate_symmetric(
     # AB pass is canonical for VA metadata: its side=1/2 labels already
     # use the caller's convention (1=sideA, 2=sideB).  The BA pass has
     # swapped arguments so its va_side would need re-mapping.
-    result["vaAdjustment"] = ab.va_adjustment or {"side": 0, "value": 0, "applied": False}
+    result["vaAdjustment"] = ab.va_adjustment or {"side": 0, "value": 0, "effectiveValue": 0, "applied": False}
     return result
 
 
@@ -148,7 +148,10 @@ def enrich_with_decision_shape(
     # spread-ratio heuristic (shrinks the less-confident side's valuation).
     va_adj = symmetric_result.get("vaAdjustment") or {}
     if va_adj.get("applied"):
-        va_val = float(va_adj.get("value") or 0)
+        # Use effectiveValue (post-clamp actual shift) so adjustedDelta
+        # matches what the simulation actually experienced, not the raw
+        # KTC award which may have been partially absorbed by the 9999 cap.
+        va_val = float(va_adj.get("effectiveValue") or va_adj.get("value") or 0)
         va_side = va_adj.get("side", 0)
         if va_side == 1:
             adjusted_delta = (a_p50 + va_val) - b_p50

--- a/src/trade/symmetrize.py
+++ b/src/trade/symmetrize.py
@@ -96,6 +96,7 @@ def simulate_symmetric(
     same_team_rho: float = 0.25,
     same_pos_group_rho: float = 0.10,
     seed: int | None = None,
+    apply_consolidation_adjustment: bool = False,
 ) -> dict[str, Any]:
     """Run the sim in both directions and return the symmetrized
     result dict.  Uses different seeds (seed, seed+1) for the two
@@ -104,14 +105,21 @@ def simulate_symmetric(
         side_a, side_b,
         n_sims=n_sims, same_team_rho=same_team_rho,
         same_pos_group_rho=same_pos_group_rho, seed=seed,
+        apply_consolidation_adjustment=apply_consolidation_adjustment,
     )
     ba = _mc.simulate_trade(
         side_b, side_a,
         n_sims=n_sims, same_team_rho=same_team_rho,
         same_pos_group_rho=same_pos_group_rho,
         seed=(seed + 1) if seed is not None else None,
+        apply_consolidation_adjustment=apply_consolidation_adjustment,
     )
-    return _average_results(ab, ba)
+    result = _average_results(ab, ba)
+    # AB pass is canonical for VA metadata: its side=1/2 labels already
+    # use the caller's convention (1=sideA, 2=sideB).  The BA pass has
+    # swapped arguments so its va_side would need re-mapping.
+    result["vaAdjustment"] = ab.va_adjustment or {"side": 0, "value": 0, "applied": False}
+    return result
 
 
 def enrich_with_decision_shape(
@@ -134,20 +142,28 @@ def enrich_with_decision_shape(
     b_p50 = sum(p.p50 for p in side_b)
     raw_delta = a_p50 - b_p50
 
-    # Adjusted delta: shrink by the spread-to-value ratio on each
-    # side.  If side A is 20k with 30% internal spread but side B
-    # is 20k with 5% spread, A is effectively worth less — adjust
-    # down.  Heuristic, not a formal adjustment.
-    def _spread_ratio(side):
-        total = sum(p.p50 for p in side) or 1.0
-        spread = sum((p.p90 - p.p10) for p in side)
-        return spread / total if total > 0 else 0.0
-    a_spread = _spread_ratio(side_a)
-    b_spread = _spread_ratio(side_b)
-    # Shrink the less-confident side's valuation proportionally.
-    a_adjusted = a_p50 * (1.0 - 0.3 * a_spread)
-    b_adjusted = b_p50 * (1.0 - 0.3 * b_spread)
-    adjusted_delta = a_adjusted - b_adjusted
+    # Adjusted delta: when the consolidation adjustment was applied,
+    # use the VA bonus directly — it reflects the package-level premium
+    # KTC awards to the consolidated side.  Without VA, fall back to the
+    # spread-ratio heuristic (shrinks the less-confident side's valuation).
+    va_adj = symmetric_result.get("vaAdjustment") or {}
+    if va_adj.get("applied"):
+        va_val = float(va_adj.get("value") or 0)
+        va_side = va_adj.get("side", 0)
+        if va_side == 1:
+            adjusted_delta = (a_p50 + va_val) - b_p50
+        else:
+            adjusted_delta = a_p50 - (b_p50 + va_val)
+    else:
+        def _spread_ratio(side):
+            total = sum(p.p50 for p in side) or 1.0
+            spread = sum((p.p90 - p.p10) for p in side)
+            return spread / total if total > 0 else 0.0
+        a_spread = _spread_ratio(side_a)
+        b_spread = _spread_ratio(side_b)
+        a_adjusted = a_p50 * (1.0 - 0.3 * a_spread)
+        b_adjusted = b_p50 * (1.0 - 0.3 * b_spread)
+        adjusted_delta = a_adjusted - b_adjusted
 
     win_pct = symmetric_result.get("winProbA", 0.5) * 100.0
 

--- a/tests/trade/test_monte_carlo.py
+++ b/tests/trade/test_monte_carlo.py
@@ -134,3 +134,73 @@ def test_triangular_draw_covers_full_range():
     # u=0.5 → exactly p50 (200).
     mid = mc._triangular_draw(100, 200, 300, 0.5)  # noqa: SLF001
     assert abs(mid - 200) < 0.01
+
+
+# --- Consolidation adjustment tests ---
+
+def test_consolidation_adjustment_stud_beats_fillers():
+    """1 stud vs 4 equal-valued fillers: raw totals favor fillers, VA flips it."""
+    stud = [_p("Elite", 3500)]
+    fillers = [_p(f"F{i}", 1000) for i in range(4)]  # raw total 4000 > 3500
+
+    no_adj = mc.simulate_trade(stud, fillers, n_sims=10000, seed=42)
+    assert no_adj.win_prob_a < 0.5, "fillers should lead on raw totals"
+
+    with_adj = mc.simulate_trade(
+        stud, fillers, n_sims=10000, seed=42,
+        apply_consolidation_adjustment=True,
+    )
+    assert with_adj.win_prob_a > no_adj.win_prob_a, "VA must shift odds toward stud"
+    assert with_adj.va_adjustment is not None
+    assert with_adj.va_adjustment["applied"] is True
+    assert with_adj.va_adjustment["side"] == 1   # stud is side_a
+    assert with_adj.va_adjustment["value"] > 0
+
+
+def test_consolidation_adjustment_symmetric_regardless_of_side():
+    """VA value is the same magnitude whichever side the stud is placed on."""
+    stud = [_p("Elite", 3500)]
+    fillers = [_p(f"F{i}", 1000) for i in range(4)]
+
+    ab = mc.simulate_trade(stud, fillers, n_sims=10000, seed=1,
+                           apply_consolidation_adjustment=True)
+    ba = mc.simulate_trade(fillers, stud, n_sims=10000, seed=1,
+                           apply_consolidation_adjustment=True)
+
+    assert ab.va_adjustment["value"] == ba.va_adjustment["value"]
+    assert ab.va_adjustment["side"] == 1  # stud received bonus as side_a
+    assert ba.va_adjustment["side"] == 2  # stud received bonus as side_b
+    assert ab.win_prob_a > 0.5            # stud wins when it's side A
+    assert ba.win_prob_a < 0.5            # stud wins when it's side B
+
+
+def test_consolidation_no_adjustment_on_1v1():
+    """KTC suppresses VA for 1v1 trades — no shift applied."""
+    result = mc.simulate_trade(
+        [_p("Star", 5000)], [_p("Good", 4500)],
+        n_sims=5000, seed=42,
+        apply_consolidation_adjustment=True,
+    )
+    assert result.va_adjustment["applied"] is False
+    assert result.va_adjustment["side"] == 0
+    assert result.va_adjustment["value"] == 0
+
+
+def test_consolidation_no_adjustment_equal_packages():
+    """Identical value on each side → VA within 5% variance → suppressed."""
+    a = [_p("A1", 3000), _p("A2", 2000)]
+    b = [_p("B1", 3000), _p("B2", 2000)]
+    result = mc.simulate_trade(a, b, n_sims=5000, seed=42,
+                               apply_consolidation_adjustment=True)
+    assert result.va_adjustment["applied"] is False
+
+
+def test_consolidation_default_off_preserves_existing_behavior():
+    """Default flag=False must produce identical results to explicit False."""
+    stud = [_p("Elite", 3500)]
+    fillers = [_p(f"F{i}", 1000) for i in range(4)]
+    default_result = mc.simulate_trade(stud, fillers, n_sims=5000, seed=99)
+    explicit_off = mc.simulate_trade(stud, fillers, n_sims=5000, seed=99,
+                                     apply_consolidation_adjustment=False)
+    assert default_result.win_prob_a == explicit_off.win_prob_a
+    assert default_result.va_adjustment["applied"] is False


### PR DESCRIPTION
## Summary

- The backend `applyConsolidationAdjustment` flag merged in #416 was opt-in (`false` by default), but `MonteCarloButton.jsx` never sent it — so every simulation still ran without the consolidation premium
- Passes `applyConsolidationAdjustment: true` in every MC request so the KTC value adjustment is always applied

## Test plan

- [ ] Open a trade with 1 stud vs multiple fillers of similar raw total — MC should now favour the stud side rather than being ~50/50 or favouring the filler side
- [ ] Equal-value 1v1 trade should still show ~50% (KTC suppresses VA for 1v1)
- [ ] `vaAdjustment.applied` visible in browser devtools network response when VA fires

https://claude.ai/code/session_01Y1f5ey23UPdJasRyN9QViQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1f5ey23UPdJasRyN9QViQ)_