### PR TITLE
feat: exclude IDP sources from trade evaluation when no IDP players are involved

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -7389,6 +7389,40 @@ def build_api_data_contract(
     # the DB-tagged row.
     _strip_mismatched_family_tags(players_array)
 
+    # Pre-pass: compute offense-only values by disabling all IDP-scoped
+    # sources.  The result is stored as ``offenseOnlyRankDerivedValue``
+    # on each row and used by trade evaluation endpoints when none of
+    # the players in a trade are IDP (DL/LB/DB).  The main pass below
+    # then overwrites ``rankDerivedValue`` with the full-source board.
+    # Skipped on delta/override builds since those don't feed the
+    # trade evaluation path.
+    if not source_overrides and not _for_delta:
+        _idp_off_overrides: dict[str, dict[str, Any]] = {
+            src["key"]: {"include": False}
+            for src in _RANKING_SOURCES
+            if src.get("scope") in (SOURCE_SCOPE_OVERALL_IDP, SOURCE_SCOPE_POSITION_IDP)
+        }
+        if _idp_off_overrides:
+            # Use shallow copies of both rows and legacy dicts so the
+            # pre-pass never stamps canonicalConsensusRank /
+            # sourceRankMeta / _canonicalConsensusRank etc. onto the
+            # originals.  The main pass below must see unmodified state.
+            _pa_copy = [dict(r) for r in players_array]
+            _pbn_copy = {k: dict(v) if isinstance(v, dict) else v for k, v in players_by_name.items()}
+            _compute_unified_rankings(
+                _pa_copy,
+                _pbn_copy,
+                csv_index=csv_index,
+                source_overrides=_idp_off_overrides,
+                tep_multiplier=tep_multiplier_effective,
+                tep_native_multiplier=tep_native_multiplier_effective,
+                tep_native_correction=tep_native_correction,
+            )
+            for _orig, _copy in zip(players_array, _pa_copy):
+                _rdv = _copy.get("rankDerivedValue")
+                if isinstance(_rdv, (int, float)) and _rdv > 0:
+                    _orig["offenseOnlyRankDerivedValue"] = int(_rdv)
+
     # Compute unified rankings: all sources, all positions, one board.
     # The CSV index lets the ranker stamp a per-row ``sourceAudit``
     # block describing which CSV row matched each player and why.
@@ -7435,6 +7469,18 @@ def build_api_data_contract(
     # delta payload drops the legacy ``players`` dict entirely.
     if not _for_delta:
         _mirror_trust_to_legacy(players_array, players_by_name)
+        # Mirror offenseOnlyRankDerivedValue to the legacy players dict so
+        # the trade finder (which reads from the players dict) can use it.
+        for _row in players_array:
+            _ordv = _row.get("offenseOnlyRankDerivedValue")
+            if not isinstance(_ordv, int):
+                continue
+            _legacy_ref = _row.get("legacyRef")
+            if not _legacy_ref or _legacy_ref not in players_by_name:
+                continue
+            _pdata = players_by_name[_legacy_ref]
+            if isinstance(_pdata, dict):
+                _pdata["_offenseOnlyFinalAdjusted"] = _ordv
 
     data_source = data_source or {}
     generated_at = utc_now_iso()

--- a/src/api/trade_simulator.py
+++ b/src/api/trade_simulator.py
@@ -183,8 +183,12 @@ def simulate_trade(
     # Determine whether any asset in the trade is an IDP player.
     # When the entire trade is offense + picks, use offense-only values
     # that exclude IDP source calibration from the blend.
+    # Only applies when at least one asset is being traded — empty
+    # requests must resolve before/after with the same full-board values
+    # as the terminal panel (parity requirement).
     all_trade_names = [*players_in, *players_out, *picks_in, *picks_out]
-    trade_has_idp = any(
+    trade_has_assets = bool(all_trade_names)
+    trade_has_idp = trade_has_assets and any(
         _normalize_pos(
             (row_index.get(n.strip().lower()) or {}).get("pos") or
             (row_index.get(n.strip().lower()) or {}).get("position") or ""
@@ -192,7 +196,7 @@ def simulate_trade(
         for n in all_trade_names
         if n.strip()
     )
-    offense_only = not trade_has_idp
+    offense_only = trade_has_assets and not trade_has_idp
 
     def _resolve_many(names: list[str]) -> tuple[list[dict[str, Any]], list[str]]:
         resolved: list[dict[str, Any]] = []

--- a/src/api/trade_simulator.py
+++ b/src/api/trade_simulator.py
@@ -35,13 +35,23 @@ from src.api.terminal import (
 )
 
 
+_IDP_BASE_POSITIONS = frozenset({"DL", "LB", "DB"})
+
+
 def _resolve_asset(
     name: str,
     *,
     row_index: dict[str, dict[str, Any]],
+    offense_only: bool = False,
 ) -> dict[str, Any] | None:
     """Resolve a single display name to a summary dict for the
     simulator output.  Matches ``terminal.py``'s rowValue semantics.
+
+    When ``offense_only`` is True and the row carries a pre-computed
+    ``offenseOnlyRankDerivedValue`` (set by the IDP-disabled pipeline
+    pre-pass), that value is used instead of the full-source
+    ``rankDerivedValue``.  This ensures trades involving only offense
+    players and picks aren't influenced by IDP source calibration.
     """
     if not name:
         return None
@@ -49,7 +59,11 @@ def _resolve_asset(
     row = row_index.get(key)
     if not row:
         return None
-    value = int(_row_value(row))
+    if offense_only:
+        oo = row.get("offenseOnlyRankDerivedValue")
+        value = int(oo) if isinstance(oo, (int, float)) and oo > 0 else int(_row_value(row))
+    else:
+        value = int(_row_value(row))
     pos = _normalize_pos(row.get("pos") or row.get("position"))
     age = row.get("age")
     # ``pos`` collapses DL/LB/DB to "IDP" for terminal aggregation;
@@ -166,11 +180,25 @@ def simulate_trade(
         }
         current_players = [str(p) for p in (resolved_team.get("players") or [])]
 
+    # Determine whether any asset in the trade is an IDP player.
+    # When the entire trade is offense + picks, use offense-only values
+    # that exclude IDP source calibration from the blend.
+    all_trade_names = [*players_in, *players_out, *picks_in, *picks_out]
+    trade_has_idp = any(
+        _normalize_pos(
+            (row_index.get(n.strip().lower()) or {}).get("pos") or
+            (row_index.get(n.strip().lower()) or {}).get("position") or ""
+        ) == "IDP"
+        for n in all_trade_names
+        if n.strip()
+    )
+    offense_only = not trade_has_idp
+
     def _resolve_many(names: list[str]) -> tuple[list[dict[str, Any]], list[str]]:
         resolved: list[dict[str, Any]] = []
         missing: list[str] = []
         for n in names:
-            hit = _resolve_asset(n, row_index=row_index)
+            hit = _resolve_asset(n, row_index=row_index, offense_only=offense_only)
             if hit is None:
                 missing.append(n)
             else:
@@ -180,7 +208,7 @@ def simulate_trade(
     # BEFORE state: the team's current roster + picks, resolved.
     before_assets: list[dict[str, Any]] = []
     for name in current_players:
-        hit = _resolve_asset(name, row_index=row_index)
+        hit = _resolve_asset(name, row_index=row_index, offense_only=offense_only)
         if hit is not None:
             before_assets.append(hit)
     current_picks = (
@@ -189,7 +217,7 @@ def simulate_trade(
         else []
     )
     for pick in current_picks:
-        hit = _resolve_asset(pick, row_index=row_index)
+        hit = _resolve_asset(pick, row_index=row_index, offense_only=offense_only)
         if hit is not None:
             before_assets.append(hit)
 

--- a/src/api/trade_simulator.py
+++ b/src/api/trade_simulator.py
@@ -187,8 +187,15 @@ def simulate_trade(
     # requests must resolve before/after with the same full-board values
     # as the terminal panel (parity requirement).
     all_trade_names = [*players_in, *players_out, *picks_in, *picks_out]
-    trade_has_assets = bool(all_trade_names)
-    trade_has_idp = trade_has_assets and any(
+    # Only activate offense-only mode when at least one name resolves to
+    # a known row.  A request where every name is unresolvable (e.g. all
+    # typos) should still return full-board before/after totals that match
+    # the terminal panel, not offense-only baselines.
+    trade_has_resolved = any(
+        row_index.get(n.strip().lower()) is not None
+        for n in all_trade_names if n.strip()
+    )
+    trade_has_idp = trade_has_resolved and any(
         _normalize_pos(
             (row_index.get(n.strip().lower()) or {}).get("pos") or
             (row_index.get(n.strip().lower()) or {}).get("position") or ""
@@ -196,7 +203,7 @@ def simulate_trade(
         for n in all_trade_names
         if n.strip()
     )
-    offense_only = trade_has_assets and not trade_has_idp
+    offense_only = trade_has_resolved and not trade_has_idp
 
     def _resolve_many(names: list[str]) -> tuple[list[dict[str, Any]], list[str]]:
         resolved: list[dict[str, Any]] = []

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -512,6 +512,16 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     return tc
 
 
+def _peak_value(a: Asset) -> int:
+    """Return the higher of full-board and offense-only model value.
+
+    Used for MIN_ASSET_VALUE eligibility so that an offense player who
+    qualifies under offense-only scoring (IDP sources excluded) isn't
+    silently dropped from candidate generation.
+    """
+    return max(a.model_value, a.offense_only_model_value or 0)
+
+
 def _generate_1for1(
     my_assets: list[Asset],
     opp_assets: list[Asset],
@@ -519,10 +529,10 @@ def _generate_1for1(
     """Generate all viable 1-for-1 trades."""
     results: list[TradeCandidate] = []
     for mine in my_assets:
-        if mine.model_value < MIN_ASSET_VALUE:
+        if _peak_value(mine) < MIN_ASSET_VALUE:
             continue
         for theirs in opp_assets:
-            if theirs.model_value < MIN_ASSET_VALUE:
+            if _peak_value(theirs) < MIN_ASSET_VALUE:
                 continue
             tc = _score_trade([mine], [theirs])
             if tc is not None:
@@ -537,8 +547,8 @@ def _generate_2for1(
     """Generate viable 2-for-1 trades (I give 2, get 1)."""
     results: list[TradeCandidate] = []
     # Limit combinations for performance
-    my_tradeable = [a for a in my_assets if a.model_value >= MIN_ASSET_VALUE]
-    opp_tradeable = [a for a in opp_assets if a.model_value >= MIN_ASSET_VALUE]
+    my_tradeable = [a for a in my_assets if _peak_value(a) >= MIN_ASSET_VALUE]
+    opp_tradeable = [a for a in opp_assets if _peak_value(a) >= MIN_ASSET_VALUE]
     if len(my_tradeable) < 2:
         return results
 
@@ -556,8 +566,8 @@ def _generate_1for2(
 ) -> list[TradeCandidate]:
     """Generate viable 1-for-2 trades (I give 1, get 2)."""
     results: list[TradeCandidate] = []
-    my_tradeable = [a for a in my_assets if a.model_value >= MIN_ASSET_VALUE]
-    opp_tradeable = [a for a in opp_assets if a.model_value >= MIN_ASSET_VALUE]
+    my_tradeable = [a for a in my_assets if _peak_value(a) >= MIN_ASSET_VALUE]
+    opp_tradeable = [a for a in opp_assets if _peak_value(a) >= MIN_ASSET_VALUE]
     if len(opp_tradeable) < 2:
         return results
 

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -512,16 +512,6 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     return tc
 
 
-def _peak_value(a: Asset) -> int:
-    """Return the higher of full-board and offense-only model value.
-
-    Used for MIN_ASSET_VALUE eligibility so that an offense player who
-    qualifies under offense-only scoring (IDP sources excluded) isn't
-    silently dropped from candidate generation.
-    """
-    return max(a.model_value, a.offense_only_model_value or 0)
-
-
 def _generate_1for1(
     my_assets: list[Asset],
     opp_assets: list[Asset],
@@ -529,10 +519,10 @@ def _generate_1for1(
     """Generate all viable 1-for-1 trades."""
     results: list[TradeCandidate] = []
     for mine in my_assets:
-        if _peak_value(mine) < MIN_ASSET_VALUE:
+        if mine.model_value < MIN_ASSET_VALUE:
             continue
         for theirs in opp_assets:
-            if _peak_value(theirs) < MIN_ASSET_VALUE:
+            if theirs.model_value < MIN_ASSET_VALUE:
                 continue
             tc = _score_trade([mine], [theirs])
             if tc is not None:
@@ -547,8 +537,8 @@ def _generate_2for1(
     """Generate viable 2-for-1 trades (I give 2, get 1)."""
     results: list[TradeCandidate] = []
     # Limit combinations for performance
-    my_tradeable = [a for a in my_assets if _peak_value(a) >= MIN_ASSET_VALUE]
-    opp_tradeable = [a for a in opp_assets if _peak_value(a) >= MIN_ASSET_VALUE]
+    my_tradeable = [a for a in my_assets if a.model_value >= MIN_ASSET_VALUE]
+    opp_tradeable = [a for a in opp_assets if a.model_value >= MIN_ASSET_VALUE]
     if len(my_tradeable) < 2:
         return results
 
@@ -566,8 +556,8 @@ def _generate_1for2(
 ) -> list[TradeCandidate]:
     """Generate viable 1-for-2 trades (I give 1, get 2)."""
     results: list[TradeCandidate] = []
-    my_tradeable = [a for a in my_assets if _peak_value(a) >= MIN_ASSET_VALUE]
-    opp_tradeable = [a for a in opp_assets if _peak_value(a) >= MIN_ASSET_VALUE]
+    my_tradeable = [a for a in my_assets if a.model_value >= MIN_ASSET_VALUE]
+    opp_tradeable = [a for a in opp_assets if a.model_value >= MIN_ASSET_VALUE]
     if len(opp_tradeable) < 2:
         return results
 

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -61,6 +61,7 @@ class Asset:
     is_pick: bool = False
     source_count: int = 0   # Number of valuation sources
     ktc_rank: int | None = None  # 1-based KTC rank (None = no KTC data)
+    offense_only_model_value: int | None = None  # model_value excluding IDP sources
 
     @property
     def has_ktc(self) -> bool:
@@ -97,15 +98,27 @@ class TradeCandidate:
     flags: list[str] = field(default_factory=list)        # Active guards/bonuses
 
     def to_dict(self) -> dict[str, Any]:
+        trade_has_idp = any(
+            a.position in IDP_POSITIONS for a in [*self.give, *self.receive]
+        )
+
+        def _asset_dict(a: Asset) -> dict[str, Any]:
+            d: dict[str, Any] = {
+                "name": a.name,
+                "position": a.position,
+                "team": a.team,
+                "modelValue": a.model_value,
+                "ktcValue": a.ktc_value,
+                "ktcRank": a.ktc_rank,
+            }
+            if not trade_has_idp and a.offense_only_model_value is not None:
+                d["modelValue"] = a.offense_only_model_value
+                d["modelValueFull"] = a.model_value
+            return d
+
         return {
-            "give": [{"name": a.name, "position": a.position, "team": a.team,
-                       "modelValue": a.model_value,
-                       "ktcValue": a.ktc_value,
-                       "ktcRank": a.ktc_rank} for a in self.give],
-            "receive": [{"name": a.name, "position": a.position, "team": a.team,
-                         "modelValue": a.model_value,
-                         "ktcValue": a.ktc_value,
-                         "ktcRank": a.ktc_rank} for a in self.receive],
+            "give": [_asset_dict(a) for a in self.give],
+            "receive": [_asset_dict(a) for a in self.receive],
             "giveModelTotal": self.give_model_total,
             "receiveModelTotal": self.receive_model_total,
             "giveKtcTotal": self.give_ktc_total,
@@ -199,10 +212,17 @@ def build_asset_pool(
         if model is None or model < 1:
             continue
 
+        # Offense-only model value: uses the value computed with IDP
+        # sources excluded.  Applied to trades where no side has an IDP
+        # player, so IDP source calibration doesn't influence the score.
+        oo_raw = _int_or_none(pdata.get("_offenseOnlyFinalAdjusted"))
+
         # Apply single-source discount to match frontend behavior
         source_count = _int_or_none(pdata.get("_sites")) or 0
         if source_count == 1:
             model = int(model * SINGLE_SOURCE_DISCOUNT)
+            if oo_raw is not None and oo_raw >= 1:
+                oo_raw = int(oo_raw * SINGLE_SOURCE_DISCOUNT)
 
         # KTC value from canonical site values.  Prefer the TE+ board
         # (``ktcSfTep``) — that's the canonical KTC retail signal as of
@@ -243,6 +263,7 @@ def build_asset_pool(
             ktc_value=ktc,
             is_pick=is_pick,
             source_count=source_count,
+            offense_only_model_value=oo_raw if oo_raw is not None and oo_raw >= 1 else None,
         ))
 
     # ── Assign KTC rank and apply top-N filter ────────────────────
@@ -328,8 +349,20 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
         if len(idp_no_ktc) > 0 and len(idp_no_ktc) >= len(side) / 2:
             return None
 
-    give_model = sum(a.model_value for a in give)
-    recv_model = sum(a.model_value for a in receive)
+    # Use offense-only model values when neither side has IDP players.
+    # This excludes IDP source calibration from trade scoring so that
+    # an all-offense trade isn't influenced by IDP-relative rankings.
+    trade_has_idp = any(
+        a.position in IDP_POSITIONS for a in [*give, *receive]
+    )
+
+    def _mv(a: Asset) -> int:
+        if not trade_has_idp and a.offense_only_model_value is not None:
+            return a.offense_only_model_value
+        return a.model_value
+
+    give_model = sum(_mv(a) for a in give)
+    recv_model = sum(_mv(a) for a in receive)
     board_delta = recv_model - give_model
 
     # Must be positive on our board (we receive more model value than we give)
@@ -346,7 +379,7 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
         if give_model < recv_model * MULTI_FOR_ONE_MIN_RATIO:
             return None
         # ── Elite target protection (tighter ratio) ──────────────────
-        max_recv = max(a.model_value for a in receive)
+        max_recv = max(_mv(a) for a in receive)
         if max_recv >= ELITE_THRESHOLD:
             if give_model < recv_model * ELITE_MULTI_MIN_RATIO:
                 return None
@@ -354,7 +387,7 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
         # ── Package anchor quality ───────────────────────────────────
         # At least one give piece must be a real starter-quality asset,
         # not just two bench stashes that happen to sum high enough.
-        max_give = max(a.model_value for a in give)
+        max_give = max(_mv(a) for a in give)
         if max_give < max_recv * PACKAGE_ANCHOR_MIN_PCT:
             return None
         flags.append("anchor_verified")
@@ -388,9 +421,9 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
         return None
 
     # Filter out junk trades: at least one meaningful asset on each side
-    if all(a.model_value < JUNK_THRESHOLD for a in give):
+    if all(_mv(a) < JUNK_THRESHOLD for a in give):
         return None
-    if all(a.model_value < JUNK_THRESHOLD for a in receive):
+    if all(_mv(a) < JUNK_THRESHOLD for a in receive):
         return None
 
     # Arbitrage score: how much we gain on our board while the opponent

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -1019,29 +1019,33 @@ def _generate_positional_upgrades(
             continue
 
         starters = players[:need]
-        depth = [p for p in players[need:] if p.display_value >= MIN_RELEVANT_VALUE]
+        # pos is always an offense position in DEFAULT_STARTER_NEEDS; using
+        # pos_oo=True means IDP sweeteners fall back to display_value safely.
+        pos_oo = pos not in _IDP_BASE_POSITIONS
+        depth = [p for p in players[need:] if _eff_val(p, pos_oo) >= MIN_RELEVANT_VALUE]
         if not starters or not depth:
             continue
 
         weakest_starter = starters[-1]
-        upgrade_floor = weakest_starter.display_value + 500
+        ws_ev = _eff_val(weakest_starter, pos_oo)
+        upgrade_floor = ws_ev + 500
 
         targets = [
             a for a in asset_pool
             if a.position == pos
             and a.name.lower() not in roster_names_set
-            and a.display_value >= upgrade_floor
+            and _eff_val(a, pos_oo) >= upgrade_floor
         ]
         if not targets:
             continue
 
-        targets.sort(key=lambda t: t.display_value)  # closest upgrade first
+        targets.sort(key=lambda t: _eff_val(t, pos_oo))  # closest upgrade first
         for target in targets[:5]:
-            gap_needed = target.display_value - weakest_starter.display_value
+            gap_needed = _eff_val(target, pos_oo) - ws_ev
             sweeteners = [
                 p for p in depth
                 if p.name != weakest_starter.name
-                and abs(p.display_value - gap_needed) < FAIRNESS_TOLERANCE
+                and abs(_eff_val(p, pos_oo) - gap_needed) < FAIRNESS_TOLERANCE
             ]
             if not sweeteners:
                 # Widen tolerance for surplus-position sweeteners — these
@@ -1051,12 +1055,13 @@ def _generate_positional_upgrades(
                     sp_depth = roster.by_position.get(sp, [])
                     sp_need = DEFAULT_STARTER_NEEDS.get(sp, 1)
                     for p in sp_depth[sp_need:]:
-                        if p.display_value >= MIN_RELEVANT_VALUE and abs(p.display_value - gap_needed) < surplus_tol:
+                        sp_ev = _eff_val(p, pos_oo)
+                        if sp_ev >= MIN_RELEVANT_VALUE and abs(sp_ev - gap_needed) < surplus_tol:
                             sweeteners.append(p)
             if not sweeteners:
                 continue
 
-            sweeteners.sort(key=lambda s: abs(s.display_value - gap_needed))
+            sweeteners.sort(key=lambda s: abs(_eff_val(s, pos_oo) - gap_needed))
             sweetener = sweeteners[0]
             oo = _trade_is_idp_free([weakest_starter, sweetener], [target])
             give_total = _eff_val(weakest_starter, oo) + _eff_val(sweetener, oo)

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -1444,11 +1444,16 @@ def generate_suggestions(
 
 # ── Serializers ──────────────────────────────────────────────────────
 
-def _serialize_player(p: PlayerAsset) -> dict[str, Any]:
+def _serialize_player(p: PlayerAsset, *, offense_only: bool = False) -> dict[str, Any]:
+    dv = (
+        p.offense_only_value
+        if offense_only and p.offense_only_value is not None
+        else p.display_value
+    )
     result: dict[str, Any] = {
         "name": p.name,
         "position": p.position,
-        "displayValue": p.display_value,
+        "displayValue": dv,
         "team": p.team,
         "rookie": p.rookie,
     }
@@ -1460,10 +1465,11 @@ def _serialize_player(p: PlayerAsset) -> dict[str, Any]:
 
 
 def _serialize_suggestion(s: TradeSuggestion, roster: RosterAnalysis | None = None) -> dict[str, Any]:
+    oo = _trade_is_idp_free(s.give, s.receive)
     result: dict[str, Any] = {
         "type": s.type,
-        "give": [_serialize_player(p) for p in s.give],
-        "receive": [_serialize_player(p) for p in s.receive],
+        "give": [_serialize_player(p, offense_only=oo) for p in s.give],
+        "receive": [_serialize_player(p, offense_only=oo) for p in s.receive],
         "giveTotal": s.give_total,
         "receiveTotal": s.receive_total,
         "gap": s.gap,

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -103,6 +103,9 @@ KTC_TOP_N_FILTER = 150
 
 # ── Data structures ─────────────────────────────────────────────────
 
+_IDP_BASE_POSITIONS = frozenset({"DL", "LB", "DB"})
+
+
 @dataclass
 class PlayerAsset:
     """A player or pick with canonical values."""
@@ -117,6 +120,7 @@ class PlayerAsset:
     universe: str = ""
     dispersion_cv: float | None = None
     ktc_rank: int | None = None  # 1-based KTC rank (None = no KTC data)
+    offense_only_value: int | None = None  # display_value excluding IDP sources
 
 
 @dataclass
@@ -440,6 +444,11 @@ def build_asset_pool_from_contract(
                 except (TypeError, ValueError):
                     years_exp = None
 
+        oo_rdv = row.get("offenseOnlyRankDerivedValue")
+        oo_int: int | None = None
+        if isinstance(oo_rdv, (int, float)) and oo_rdv > 0:
+            oo_int = int(oo_rdv)
+
         pool.append(PlayerAsset(
             name=name,
             position=pos,
@@ -451,6 +460,7 @@ def build_asset_pool_from_contract(
             years_exp=years_exp,
             universe=_universe_from_row(row),
             dispersion_cv=round(dispersion, 4) if dispersion is not None else None,
+            offense_only_value=oo_int,
         ))
     pool.sort(key=lambda x: -x.display_value)
 
@@ -545,6 +555,25 @@ def analyze_roster(
         need_positions=need_positions,
         starter_counts=starter_counts,
         depth_counts=depth_counts,
+    )
+
+
+def _eff_val(p: PlayerAsset, offense_only: bool) -> int:
+    """Return the effective value for a player in the context of a trade.
+
+    When ``offense_only`` is True and the player carries a pre-computed
+    offense-only value, that value is returned.  This ensures trades
+    with no IDP players are not influenced by IDP source calibration.
+    """
+    if offense_only and p.offense_only_value is not None:
+        return p.offense_only_value
+    return p.display_value
+
+
+def _trade_is_idp_free(give: list[PlayerAsset], receive: list[PlayerAsset]) -> bool:
+    return all(
+        p.position not in _IDP_BASE_POSITIONS
+        for p in [*give, *receive]
     )
 
 
@@ -798,13 +827,16 @@ def _generate_sell_high(
                     continue
                 targets.sort(key=lambda t: abs(t.display_value - sell.display_value))
                 target = targets[0]
-                gap = sell.display_value - target.display_value
+                oo = _trade_is_idp_free([sell], [target])
+                give_val = _eff_val(sell, oo)
+                recv_val = _eff_val(target, oo)
+                gap = give_val - recv_val
                 suggestions.append(TradeSuggestion(
                     type="sell_high",
                     give=[sell],
                     receive=[target],
-                    give_total=sell.display_value,
-                    receive_total=target.display_value,
+                    give_total=give_val,
+                    receive_total=recv_val,
                     gap=gap,
                     fairness=_fairness_label(gap),
                     rationale=f"You have {pos} surplus ({len(players)} rostered, need {need}). "
@@ -846,14 +878,17 @@ def _generate_buy_low(
                 need = DEFAULT_STARTER_NEEDS.get(surplus_pos, 1)
                 tradeable = [p for p in depth[need:] if p.display_value >= MIN_RELEVANT_VALUE]
                 for sell in tradeable[:2]:
-                    gap = sell.display_value - target.display_value
+                    oo = _trade_is_idp_free([sell], [target])
+                    give_val = _eff_val(sell, oo)
+                    recv_val = _eff_val(target, oo)
+                    gap = give_val - recv_val
                     if abs(gap) < FAIRNESS_TOLERANCE:
                         suggestions.append(TradeSuggestion(
                             type="buy_low",
                             give=[sell],
                             receive=[target],
-                            give_total=sell.display_value,
-                            receive_total=target.display_value,
+                            give_total=give_val,
+                            receive_total=recv_val,
                             gap=gap,
                             fairness=_fairness_label(gap),
                             rationale=f"Target {target.name} ({need_pos}) fills your roster need. "
@@ -921,14 +956,17 @@ def _generate_consolidation(
                 # the most expensive one.  This produces fairer packages.
                 targets.sort(key=lambda t: abs(combined - t.display_value))
                 target = targets[0]
-                gap = combined - target.display_value
+                oo = _trade_is_idp_free([p1, p2], [target])
+                give_total = _eff_val(p1, oo) + _eff_val(p2, oo)
+                recv_total = _eff_val(target, oo)
+                gap = give_total - recv_total
                 pos_note = f" at a position of need ({target.position})" if target.position in roster.need_positions else ""
                 suggestions.append(TradeSuggestion(
                     type="consolidation",
                     give=[p1, p2],
                     receive=[target],
-                    give_total=combined,
-                    receive_total=target.display_value,
+                    give_total=give_total,
+                    receive_total=recv_total,
                     gap=gap,
                     fairness=_fairness_label(gap),
                     rationale=f"Package {p1.name} + {p2.name} into {target.name}{pos_note}. "
@@ -1000,8 +1038,10 @@ def _generate_positional_upgrades(
 
             sweeteners.sort(key=lambda s: abs(s.display_value - gap_needed))
             sweetener = sweeteners[0]
-            give_total = weakest_starter.display_value + sweetener.display_value
-            gap = give_total - target.display_value
+            oo = _trade_is_idp_free([weakest_starter, sweetener], [target])
+            give_total = _eff_val(weakest_starter, oo) + _eff_val(sweetener, oo)
+            recv_total = _eff_val(target, oo)
+            gap = give_total - recv_total
 
             if abs(gap) > FAIRNESS_TOLERANCE * 1.5:
                 continue
@@ -1011,7 +1051,7 @@ def _generate_positional_upgrades(
                 give=[weakest_starter, sweetener],
                 receive=[target],
                 give_total=give_total,
-                receive_total=target.display_value,
+                receive_total=recv_total,
                 gap=gap,
                 fairness=_fairness_label(gap),
                 rationale=f"Upgrade {pos} starter: move {weakest_starter.name} + {sweetener.name} "

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -866,15 +866,18 @@ def _generate_buy_low(
     suggestions: list[TradeSuggestion] = []
 
     for need_pos in roster.need_positions:
+        # Pre-compute target-side oo from need_pos so candidate gating
+        # uses the same value scale as the final gap calculation.
+        pos_oo = need_pos not in _IDP_BASE_POSITIONS
         current = roster.by_position.get(need_pos, [])
-        current_best = current[0].display_value if current else 0
+        current_best = _eff_val(current[0], pos_oo) if current else 0
         target_floor = max(MIN_RELEVANT_VALUE, current_best)
 
         targets = [
             a for a in asset_pool
             if a.position == need_pos
             and a.name.lower() not in roster_names_set
-            and a.display_value > target_floor
+            and _eff_val(a, pos_oo) > target_floor
         ]
         if not targets:
             continue
@@ -883,7 +886,10 @@ def _generate_buy_low(
             for surplus_pos in roster.surplus_positions:
                 depth = roster.by_position.get(surplus_pos, [])
                 need = DEFAULT_STARTER_NEEDS.get(surplus_pos, 1)
-                tradeable = [p for p in depth[need:] if p.display_value >= MIN_RELEVANT_VALUE]
+                tradeable = [
+                    p for p in depth[need:]
+                    if _eff_val(p, surplus_pos not in _IDP_BASE_POSITIONS) >= MIN_RELEVANT_VALUE
+                ]
                 for sell in tradeable[:2]:
                     oo = _trade_is_idp_free([sell], [target])
                     give_val = _eff_val(sell, oo)
@@ -959,6 +965,9 @@ def _generate_consolidation(
                     if a.name.lower() not in roster_names_set
                     and min_target <= _eff_val(a, pair_oo) <= max_target
                     and _eff_val(a, pair_oo) > give_max
+                    # When the give pair is offense-only, restrict to offense
+                    # targets so pair_oo matches the final oo (no scale flip).
+                    and (not pair_oo or a.position not in _IDP_BASE_POSITIONS)
                     and (not prefer_need or a.position in roster.need_positions)
                 ]
                 if not targets:

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -816,16 +816,23 @@ def _generate_sell_high(
 
         for sell in sell_candidates[:3]:
             for need_pos in roster.need_positions:
+                # Pre-compute oo so target filtering and sorting use the same
+                # value scale as the gap calculation below.
+                trade_oo = (
+                    sell.position not in _IDP_BASE_POSITIONS
+                    and need_pos not in _IDP_BASE_POSITIONS
+                )
+                sell_ev = _eff_val(sell, trade_oo)
                 targets = [
                     a for a in asset_pool
                     if a.position == need_pos
                     and a.name.lower() not in roster_names_set
-                    and a.display_value >= MIN_RELEVANT_VALUE
-                    and abs(a.display_value - sell.display_value) < FAIRNESS_TOLERANCE
+                    and _eff_val(a, trade_oo) >= MIN_RELEVANT_VALUE
+                    and abs(_eff_val(a, trade_oo) - sell_ev) < FAIRNESS_TOLERANCE
                 ]
                 if not targets:
                     continue
-                targets.sort(key=lambda t: abs(t.display_value - sell.display_value))
+                targets.sort(key=lambda t: abs(_eff_val(t, trade_oo) - sell_ev))
                 target = targets[0]
                 oo = _trade_is_idp_free([sell], [target])
                 give_val = _eff_val(sell, oo)
@@ -933,28 +940,32 @@ def _generate_consolidation(
     for i in range(min(len(tradeable), 6)):
         for j in range(i + 1, min(len(tradeable), 8)):
             p1, p2 = tradeable[i], tradeable[j]
-            combined = p1.display_value + p2.display_value
             pair_key = f"{p1.name}|{p2.name}"
             if pair_key in tried:
                 continue
             tried.add(pair_key)
 
+            # Pre-compute oo from the give side so range filtering and
+            # sorting use the same value scale as the final gap calc.
+            pair_oo = _trade_is_idp_free([p1, p2], [])
+            combined = _eff_val(p1, pair_oo) + _eff_val(p2, pair_oo)
             min_target = int(combined * CONSOLIDATION_MIN_UPGRADE_RATIO)
             max_target = combined + FAIRNESS_TOLERANCE
+            give_max = max(_eff_val(p1, pair_oo), _eff_val(p2, pair_oo))
 
             for prefer_need in [True, False]:
                 targets = [
                     a for a in asset_pool
                     if a.name.lower() not in roster_names_set
-                    and min_target <= a.display_value <= max_target
-                    and a.display_value > max(p1.display_value, p2.display_value)
+                    and min_target <= _eff_val(a, pair_oo) <= max_target
+                    and _eff_val(a, pair_oo) > give_max
                     and (not prefer_need or a.position in roster.need_positions)
                 ]
                 if not targets:
                     continue
                 # Pick the closest-value target (smallest gap) rather than
                 # the most expensive one.  This produces fairer packages.
-                targets.sort(key=lambda t: abs(combined - t.display_value))
+                targets.sort(key=lambda t: abs(combined - _eff_val(t, pair_oo)))
                 target = targets[0]
                 oo = _trade_is_idp_free([p1, p2], [target])
                 give_total = _eff_val(p1, oo) + _eff_val(p2, oo)

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -886,10 +886,7 @@ def _generate_buy_low(
             for surplus_pos in roster.surplus_positions:
                 depth = roster.by_position.get(surplus_pos, [])
                 need = DEFAULT_STARTER_NEEDS.get(surplus_pos, 1)
-                tradeable = [
-                    p for p in depth[need:]
-                    if _eff_val(p, surplus_pos not in _IDP_BASE_POSITIONS) >= MIN_RELEVANT_VALUE
-                ]
+                tradeable = [p for p in depth[need:] if p.display_value >= MIN_RELEVANT_VALUE]
                 for sell in tradeable[:2]:
                     oo = _trade_is_idp_free([sell], [target])
                     give_val = _eff_val(sell, oo)
@@ -1508,7 +1505,7 @@ def _serialize_suggestion(s: TradeSuggestion, roster: RosterAnalysis | None = No
     result["rankScore"] = rank_score_breakdown(s, roster)
     balancers = s.__dict__.get("balancers", [])
     if balancers:
-        result["suggestedBalancers"] = [_serialize_player(b) for b in balancers]
+        result["suggestedBalancers"] = [_serialize_player(b, offense_only=oo) for b in balancers]
         bal_side = s.__dict__.get("balancer_side", "")
         if bal_side:
             result["balancerSide"] = bal_side

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import os
 
+# Allow ``import server`` in tests without a real JASON_LOGIN_PASSWORD.
+# The placeholder "changeme" is acceptable for unit/integration tests;
+# production rejects ALLOW_DEFAULT_LOGIN_DEV=1 by design.
+os.environ.setdefault("ALLOW_DEFAULT_LOGIN_DEV", "1")
 
 # ── Sleeper league context isolation ──────────────────────────────────
 # ``src/api/data_contract.py::_resolve_league_context`` reads the


### PR DESCRIPTION
## Summary

- When a trade involves only offense players (QB/RB/WR/TE) and/or picks — no IDP (DL/LB/DB) — player values used for trade evaluation are now computed from a pipeline that excludes all IDP-scoped sources, preventing IDP calibration from bleeding into pure-offense trade math
- Affects all three trade evaluation surfaces: `/api/trade/simulate`, `/api/trade/finder`, and `/api/trade/suggestions`
- A pre-pass in `data_contract.py` runs the full ranking pipeline with IDP sources disabled and snapshots `offenseOnlyRankDerivedValue` on each row; shallow copies of both `players_array` rows and `players_by_name` dicts are used so the pre-pass cannot contaminate `canonicalConsensusRank` / `_canonicalConsensusRank` on out-of-range players

## Test plan

- [ ] `test_combined_ranks_are_unique_across_sources` passes (was failing before the shallow-copy fix)
- [ ] `test_legacy_dict_mirror_matches_players_array` passes (was failing before `_pbn_copy` fix)
- [ ] Full `tests/api/` + `tests/trade/` suite: 990 passing, 25 pre-existing failures unrelated to this change (draft capital, league registry, signal alerts)

https://claude.ai/code/session_016YVLJR7tRFqeJw2SixWmjK

---
_Generated by [Claude Code](https://claude.ai/code/session_016YVLJR7tRFqeJw2SixWmjK)_