### PR TITLE
fix(idptc-rookies): exclude college returners + visible More link

### DIFF
--- a/frontend/app/idptc-rookies/page.jsx
+++ b/frontend/app/idptc-rookies/page.jsx
@@ -96,6 +96,14 @@ export default function IdptcRookiesPage() {
     const candidates = [];
     for (const r of rows) {
       if (!r?.rookie) continue;
+      // Filter out players who carry the rookie flag (yearsExp===0) but
+      // are not actually on an NFL roster — e.g. college players who
+      // remain on IDPTC's prospect board after returning to school
+      // (Trinidad Chambliss).  A Sleeper ID is only minted once the
+      // player joins an NFL team, so its presence is the cleanest
+      // "actually-in-the-NFL" signal we have.
+      const sleeperId = r?.raw?._sleeperId || r?.raw?.playerId;
+      if (!sleeperId) continue;
       const raw = Number(r?.canonicalSites?.idpTradeCalc);
       if (!Number.isFinite(raw) || raw <= 0) continue;
       candidates.push({

--- a/frontend/app/more/page.jsx
+++ b/frontend/app/more/page.jsx
@@ -50,6 +50,12 @@ const SECTIONS = [
       { href: "/settings", label: "Settings", desc: "Tuning controls for valuations and display" },
     ],
   },
+  {
+    title: "Lab",
+    items: [
+      { href: "/idptc-rookies", label: "IDPTC Rookies", desc: "Top 72 rookies by raw IDPTC value with fantasy blurbs + CSV/Markdown export" },
+    ],
+  },
 ];
 
 export default function MorePage() {
@@ -77,16 +83,6 @@ export default function MorePage() {
           </div>
         </div>
       ))}
-
-      <div style={{ marginTop: "var(--space-lg)", textAlign: "right" }}>
-        <Link
-          href="/idptc-rookies"
-          className="muted text-xs"
-          style={{ opacity: 0.4, textDecoration: "none" }}
-        >
-          ·
-        </Link>
-      </div>
 
       {authenticated && (
         <div style={{ marginTop: "var(--space-lg)", paddingTop: "var(--space-md)", borderTop: "1px solid var(--border)" }}>


### PR DESCRIPTION
## Summary
- **Filter fix**: Trinidad Chambliss (and any future IDPTC-listed college returners) were appearing because the rookie list keyed solely off `_isRookie`/`yearsExp===0`, which is true for any player with zero NFL experience.  Add a Sleeper-ID-presence filter — Sleeper only mints an ID when the player is on an NFL roster, so it's the cleanest "actually-in-the-NFL" check available.
- **Visibility fix**: replaced the hidden "·" dot at the bottom of /more with a labeled "Lab" section so the page is findable.

## Test plan
- [x] `npm run build` clean
- [ ] /more shows a new **Lab → IDPTC Rookies** entry
- [ ] /idptc-rookies no longer lists Trinidad Chambliss

🤖 Generated with [Claude Code](https://claude.com/claude-code)