### PR TITLE
Raise Player Market Movement row cap from 40 to 80

### DIFF
--- a/frontend/components/terminal/PlayerMarketMovement.jsx
+++ b/frontend/components/terminal/PlayerMarketMovement.jsx
@@ -33,7 +33,7 @@ const SORTS = {
   vol: { key: "vol", label: "Most Volatile" },
 };
 
-const MAX_ROWS = 40;
+const MAX_ROWS = 80;
 
 function toSet(names) {
   const s = new Set();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `MAX_ROWS` in `PlayerMarketMovement.jsx` was capped at 40, cutting off players when viewing "My Roster" sorted "By Value"
- Raised the cap to 80 so full rosters are visible

## Test plan
- [ ] Navigate to the home page, select your team
- [ ] Open the "Player Market Movement" panel, set scope to "My Roster" and sort to "By Value"
- [ ] Confirm all roster players appear (up to 80)

https://claude.ai/code/session_01B9gMmYhz3PNBJb8RUgw564
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9gMmYhz3PNBJb8RUgw564)_