### PR TITLE
feat(draft): live Sleeper auction pick sync

### DIFF
--- a/frontend/app/api/sleeper/draft/picks/route.js
+++ b/frontend/app/api/sleeper/draft/picks/route.js
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+
+// Proxy for the backend's live-draft picks endpoint.  Forwards the
+// session cookie (the backend route is private — not on the
+// PUBLIC_API allowlist) and passes through ``leagueKey`` +
+// ``afterPickNo`` query params.  Polled every ~2.5s by the /draft
+// page when live sync is toggled on, so this stays as thin as
+// possible — no caching, no transformation.
+const BACKEND_BASE = (() => {
+  const raw = process.env.BACKEND_API_URL || "http://127.0.0.1:8000/api/data";
+  return raw.replace(/\/api\/data\/?$/, "");
+})();
+
+export async function GET(request) {
+  const incoming = new URL(request.url);
+  const target = new URL("/api/sleeper/draft/picks", BACKEND_BASE);
+  const leagueKey = incoming.searchParams.get("leagueKey");
+  const afterPickNo = incoming.searchParams.get("afterPickNo");
+  if (leagueKey) target.searchParams.set("leagueKey", leagueKey);
+  if (afterPickNo) target.searchParams.set("afterPickNo", afterPickNo);
+
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 4000);
+  try {
+    const res = await fetch(target.toString(), {
+      cache: "no-store",
+      signal: ctl.signal,
+      headers: cookie ? { Cookie: cookie } : undefined,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "sleeper_proxy_unavailable",
+        message: err?.message || "Backend unreachable",
+      },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3899,10 +3899,25 @@ export default function DraftDashboardPage() {
       sleeperTeams || [],
     );
   }, [workspace?.teams, sleeperTeams]);
+  // ``sleeperTeams === null`` means the /api/data fetch is still in
+  // flight; an empty array means it loaded and the league has no
+  // Sleeper roster data.  The handler distinguishes "not yet" (retry)
+  // from "really empty" (skip + alert) via this ref.
+  const sleeperTeamsLoadedRef = useRef(false);
+  useEffect(() => {
+    if (sleeperTeams !== null) sleeperTeamsLoadedRef.current = true;
+  }, [sleeperTeams]);
 
   const handleLivePick = useCallback(
     (pick) => {
-      if (!pick) return;
+      if (!pick) return true;
+      // Transient: the sleeper.teams fetch hasn't resolved yet on
+      // first load.  Return false so the hook holds the cursor and
+      // re-delivers this pick on the next poll.  Without this guard
+      // a pick that lands during initial hydration would be silently
+      // dropped because the owner-id lookup is empty.
+      if (!sleeperTeamsLoadedRef.current) return false;
+
       const playerName = String(pick.playerName || "").trim();
       const sleeperPlayerId = String(pick.playerId || "");
       const amount = Math.max(0, Number(pick.amount) || 0);
@@ -3935,7 +3950,7 @@ export default function DraftDashboardPage() {
             ts: Date.now(),
           },
         ]);
-        return;
+        return true;
       }
 
       // Resolve workspace player: match by name slug.  If the player
@@ -3994,6 +4009,7 @@ export default function DraftDashboardPage() {
           amount,
         });
       });
+      return true;
     },
     [],
   );

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -5,6 +5,10 @@ import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/app/AppShellWrapper";
 import { useLeague } from "@/components/useLeague";
 import {
+  buildTeamIndexLookup,
+  useSleeperDraftSync,
+} from "@/components/useSleeperDraftSync";
+import {
   DRAFT_STORAGE_KEY,
   DEFAULT_AGGRESSION,
   DEFAULT_ENFORCE_PCT,
@@ -98,6 +102,71 @@ function fmtPct(n) {
 function fmtMultiplier(n) {
   if (n == null || !Number.isFinite(n)) return "—";
   return `${n.toFixed(2)}×`;
+}
+
+/* ── Live Sleeper sync toggle ─────────────────────────────────────── */
+
+function LiveSyncToggle({ enabled, onToggle, status, error, lastSyncAt, latestPickNo }) {
+  // Colored status dot maps directly to the hook's derived status.
+  //   connected → green   stale → amber   error → red
+  //   complete  → cyan    idle → grey
+  const dotColor = !enabled
+    ? "#666"
+    : status === "connected"
+    ? "var(--green, #4ade80)"
+    : status === "stale"
+    ? "#f59e0b"
+    : status === "error"
+    ? "#ef4444"
+    : status === "complete"
+    ? "var(--cyan)"
+    : "#888";
+  const label = !enabled
+    ? "Live sync: OFF"
+    : status === "connected"
+    ? `Live · pick ${latestPickNo || 0}`
+    : status === "stale"
+    ? "Live · waiting"
+    : status === "error"
+    ? "Live · error"
+    : status === "complete"
+    ? "Live · complete"
+    : "Live · idle";
+  const title = !enabled
+    ? "Auto-import picks from your Sleeper auction draft. OFF — toggle to start polling."
+    : error
+    ? `Live sync error: ${error}`
+    : lastSyncAt
+    ? `Last sync ${Math.round((Date.now() - lastSyncAt) / 1000)}s ago`
+    : "Live sync ON";
+  return (
+    <button
+      type="button"
+      className="button"
+      onClick={onToggle}
+      title={title}
+      style={{
+        borderColor: enabled ? "var(--green, #4ade80)" : undefined,
+        color: enabled ? "var(--green, #4ade80)" : undefined,
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          display: "inline-block",
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          backgroundColor: dotColor,
+          boxShadow: enabled && status === "connected" ? `0 0 4px ${dotColor}` : undefined,
+        }}
+      />
+      {label}
+    </button>
+  );
 }
 
 /* ── Inflation stats strip ────────────────────────────────────────── */
@@ -3254,6 +3323,38 @@ export default function DraftDashboardPage() {
   // ``allPlayersArray`` (from /api/data) so we can look up positions.
   const [rosterPlayers, setRosterPlayers] = useState(null);
   const [allPlayersArray, setAllPlayersArray] = useState(null);
+  // Sleeper teams for live-draft team mapping — Sleeper picks come
+  // back with ``ownerId``/``rosterId``; we resolve those to a
+  // workspace.teams idx via name-match against this list.
+  const [sleeperTeams, setSleeperTeams] = useState(null);
+  // Per-league localStorage flag — survives ``Reset`` (which wipes
+  // workspace) but stays scoped so toggling sync on the rookie draft
+  // doesn't bleed into the startup draft.  Defaults OFF; the user
+  // opts in via the toggle.
+  const liveSyncStorageKey = useMemo(
+    () => `next_draft_live_sync__${selectedLeagueKey || "default"}`,
+    [selectedLeagueKey],
+  );
+  const [liveSyncEnabled, setLiveSyncEnabledState] = useState(false);
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(liveSyncStorageKey);
+      setLiveSyncEnabledState(raw === "1");
+    } catch {
+      setLiveSyncEnabledState(false);
+    }
+  }, [liveSyncStorageKey]);
+  const setLiveSyncEnabled = useCallback(
+    (v) => {
+      setLiveSyncEnabledState(v);
+      try {
+        localStorage.setItem(liveSyncStorageKey, v ? "1" : "0");
+      } catch {
+        /* ignore */
+      }
+    },
+    [liveSyncStorageKey],
+  );
   const [capitalStatus, setCapitalStatus] = useState({
     loading: false,
     error: "",
@@ -3636,6 +3737,31 @@ export default function DraftDashboardPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hydrated, authenticated]);
 
+  // Auto-fetch the Sleeper teams list on mount.  Independent of the
+  // manual "Sync rookies" path (which also reads /api/data) so the
+  // live-sync hook can resolve picks to workspace team idx as soon
+  // as the toggle flips on — no extra click required.  Each live pick
+  // also arrives pre-stamped with ``playerName`` server-side, so we
+  // don't need playersArray here.
+  useEffect(() => {
+    if (!hydrated || authenticated !== true) return;
+    let cancelled = false;
+    const url = selectedLeagueKey
+      ? `/api/data?leagueKey=${encodeURIComponent(selectedLeagueKey)}`
+      : "/api/data";
+    fetch(url, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const teams = data?.sleeper?.teams || [];
+        setSleeperTeams(teams);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrated, authenticated, selectedLeagueKey]);
+
   const onSettings = useCallback(
     (patch) => setWorkspace((ws) => updateSettings(ws, patch)),
     [],
@@ -3756,6 +3882,127 @@ export default function DraftDashboardPage() {
     },
     [],
   );
+
+  // Live Sleeper auction sync: a pick arrives from the polling hook
+  // and we auto-record it on the workspace.  Resolves Sleeper
+  // ownerId → workspace teamIdx via name-match against ``sleeperTeams``
+  // (built from the /api/data sleeper.teams block, which carries the
+  // same display names the workspace teams were merged from).
+  // Conflicts (a manual entry that disagrees with the live feed) are
+  // overwritten silently when amount + team match, or pushed to the
+  // alert stack with a descriptive message when they don't — letting
+  // the user hit "↶ Undo last" if Sleeper is wrong.
+  const teamLookupRef = useRef({ byOwner: new Map(), byRoster: new Map() });
+  useEffect(() => {
+    teamLookupRef.current = buildTeamIndexLookup(
+      workspace?.teams || [],
+      sleeperTeams || [],
+    );
+  }, [workspace?.teams, sleeperTeams]);
+
+  const handleLivePick = useCallback(
+    (pick) => {
+      if (!pick) return;
+      const playerName = String(pick.playerName || "").trim();
+      const sleeperPlayerId = String(pick.playerId || "");
+      const amount = Math.max(0, Number(pick.amount) || 0);
+
+      // Resolve team idx: prefer ownerId (the human winner); fall
+      // back to rosterId (covers commish picks / co-managers where
+      // picked_by may be blank).
+      const lookup = teamLookupRef.current || {};
+      let teamIdx = null;
+      const ownerId = String(pick.ownerId || "");
+      if (ownerId && lookup.byOwner?.has(ownerId)) {
+        teamIdx = lookup.byOwner.get(ownerId);
+      } else if (lookup.byRoster && Number.isFinite(Number(pick.rosterId))) {
+        const ri = Number(pick.rosterId);
+        if (lookup.byRoster.has(ri)) teamIdx = lookup.byRoster.get(ri);
+      }
+
+      if (!Number.isInteger(teamIdx)) {
+        // No team match — push an alert so the user knows a pick
+        // landed they need to record manually.
+        const msg = playerName
+          ? `Live pick ${playerName} for $${amount}: couldn't map Sleeper team — record manually`
+          : `Live pick (Sleeper id ${sleeperPlayerId}) for $${amount}: couldn't map Sleeper team — record manually`;
+        setAlerts((prior) => [
+          ...prior,
+          {
+            id: `live-unmapped-${pick.pickNo}`,
+            message: msg,
+            level: "warn",
+            ts: Date.now(),
+          },
+        ]);
+        return;
+      }
+
+      // Resolve workspace player: match by name slug.  If the player
+      // isn't in the workspace pool, surface an alert so the user
+      // knows they need a "Sync rookies" or to add the player.
+      const slug = playerName ? playerSlug(playerName) : "";
+      setWorkspace((ws) => {
+        const players = Array.isArray(ws?.players) ? ws.players : [];
+        const row = slug
+          ? players.find((p) => p.id === slug)
+          : null;
+        if (!row) {
+          setAlerts((prior) => [
+            ...prior,
+            {
+              id: `live-unknown-${pick.pickNo}`,
+              message: playerName
+                ? `Live pick ${playerName} for $${amount} — not in rookie pool; click "Sync rookies"`
+                : `Live pick (Sleeper id ${sleeperPlayerId}) for $${amount} — player not in pool`,
+              level: "warn",
+              ts: Date.now(),
+            },
+          ]);
+          return ws;
+        }
+        // Conflict detection: existing pick with different amount or
+        // team idx.  Keep recordPick's de-dupe (Sleeper wins) and
+        // push a banner so the user can sanity-check + undo if needed.
+        const existing = (ws.picks || []).find((p) => p.playerId === row.id);
+        const conflict =
+          existing &&
+          (existing.teamIdx !== teamIdx ||
+            Math.abs((existing.amount || 0) - amount) > 0);
+        if (conflict) {
+          const prevTeamName =
+            ws.teams?.[existing.teamIdx]?.name || `Team ${existing.teamIdx + 1}`;
+          const newTeamName =
+            ws.teams?.[teamIdx]?.name || `Team ${teamIdx + 1}`;
+          setAlerts((prior) => [
+            ...prior,
+            {
+              id: `live-conflict-${pick.pickNo}-${row.id}`,
+              message: `Live sync corrected ${row.name}: $${existing.amount} → $${amount}${
+                existing.teamIdx !== teamIdx
+                  ? ` · ${prevTeamName} → ${newTeamName}`
+                  : ""
+              } — hit ↶ Undo last to revert`,
+              level: "warn",
+              ts: Date.now(),
+            },
+          ]);
+        }
+        return recordPick(ws, {
+          playerId: row.id,
+          teamIdx,
+          amount,
+        });
+      });
+    },
+    [],
+  );
+
+  const liveSync = useSleeperDraftSync({
+    leagueKey: selectedLeagueKey,
+    enabled: liveSyncEnabled && hydrated && authenticated === true,
+    onPickArrived: handleLivePick,
+  });
 
   // Pre-draft sync: fetch /api/data, shape rookies, show a preview
   // modal.  User confirms → replacePlayerPool applies; cancels →
@@ -4029,6 +4276,10 @@ export default function DraftDashboardPage() {
         .then((r) => r.json())
         .then((data) => {
           const teams = data?.sleeper?.teams || [];
+          // Capture the full Sleeper teams list so the live-draft
+          // sync hook can resolve ``picked_by`` (Sleeper user_id) to
+          // a workspace team idx by name match.
+          setSleeperTeams(teams);
           const mine = teams.find(
             (t) =>
               String(t.name || "").toLowerCase() ===
@@ -4213,6 +4464,14 @@ export default function DraftDashboardPage() {
           </p>
         </div>
         <div className="draft-page-actions">
+          <LiveSyncToggle
+            enabled={liveSyncEnabled}
+            onToggle={() => setLiveSyncEnabled(!liveSyncEnabled)}
+            status={liveSync.status}
+            error={liveSync.error}
+            lastSyncAt={liveSync.lastSyncAt}
+            latestPickNo={liveSync.latestPickNo}
+          />
           <button
             className="button"
             onClick={fetchSyncPreview}

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3745,6 +3745,13 @@ export default function DraftDashboardPage() {
   // don't need playersArray here.
   useEffect(() => {
     if (!hydrated || authenticated !== true) return;
+    // Reset to null at the start of every league-key fetch.  The
+    // live-sync handler keys its readiness gate off "sleeperTeams !==
+    // null", so leaving the old league's array in state during a
+    // switch would treat the new league's incoming picks as if the
+    // team map were ready (against stale data) and silently drop
+    // them.
+    setSleeperTeams(null);
     let cancelled = false;
     const url = selectedLeagueKey
       ? `/api/data?leagueKey=${encodeURIComponent(selectedLeagueKey)}`
@@ -3902,10 +3909,12 @@ export default function DraftDashboardPage() {
   // ``sleeperTeams === null`` means the /api/data fetch is still in
   // flight; an empty array means it loaded and the league has no
   // Sleeper roster data.  The handler distinguishes "not yet" (retry)
-  // from "really empty" (skip + alert) via this ref.
+  // from "really empty" (skip + alert) via this ref.  Strict tracking
+  // (always set, never one-way) so a league switch correctly flips
+  // it back to false until the new league's fetch resolves.
   const sleeperTeamsLoadedRef = useRef(false);
   useEffect(() => {
-    if (sleeperTeams !== null) sleeperTeamsLoadedRef.current = true;
+    sleeperTeamsLoadedRef.current = sleeperTeams !== null;
   }, [sleeperTeams]);
 
   const handleLivePick = useCallback(

--- a/frontend/components/useSleeperDraftSync.js
+++ b/frontend/components/useSleeperDraftSync.js
@@ -115,6 +115,7 @@ export function useSleeperDraftSync({ leagueKey, enabled, onPickArrived }) {
         if (cancelled) return;
 
         const picks = Array.isArray(data?.picks) ? data.picks : [];
+        let appliedAll = true;
         for (const pick of picks) {
           if (!pick || typeof pick.pickNo !== "number") continue;
           if (pick.pickNo <= cursorRef.current) continue;
@@ -135,18 +136,27 @@ export function useSleeperDraftSync({ leagueKey, enabled, onPickArrived }) {
           } catch {
             applied = true;
           }
-          if (!applied) break;
+          if (!applied) {
+            appliedAll = false;
+            break;
+          }
           cursorRef.current = pick.pickNo;
         }
 
         const latest = Number(data?.latestPickNo) || cursorRef.current;
         const status = data?.status || "unknown";
+        // Caught-up := the cursor has reached the snapshot's latest
+        // pick AND no pick in this batch was transient-skipped.
+        // ``status === "complete"`` alone is not enough to terminate
+        // polling: a completed draft can still have pending picks
+        // the handler held back during a brief readiness gap (e.g.
+        // /api/data fetch in flight on first load).  Terminating
+        // early there would leave the board permanently short of
+        // those picks.
+        const caughtUp = appliedAll && cursorRef.current >= latest;
         consecutiveErrors = 0;
 
         setState((s) => {
-          // ``complete`` is terminal — auto-stop polling once Sleeper
-          // marks the draft done so we don't pound the endpoint
-          // forever post-draft.
           const next = {
             ...s,
             draftId: data?.draftId || s.draftId,
@@ -155,7 +165,7 @@ export function useSleeperDraftSync({ leagueKey, enabled, onPickArrived }) {
             lastSyncAt: Date.now(),
             error: null,
           };
-          if (status === "complete") {
+          if (status === "complete" && caughtUp) {
             next.status = "complete";
           } else if (status === "drafting" || status === "pre_draft") {
             next.status = "connected";
@@ -165,7 +175,7 @@ export function useSleeperDraftSync({ leagueKey, enabled, onPickArrived }) {
           return next;
         });
 
-        if (status === "complete") {
+        if (status === "complete" && caughtUp) {
           // Terminal — don't reschedule.
           return;
         }

--- a/frontend/components/useSleeperDraftSync.js
+++ b/frontend/components/useSleeperDraftSync.js
@@ -118,11 +118,24 @@ export function useSleeperDraftSync({ leagueKey, enabled, onPickArrived }) {
         for (const pick of picks) {
           if (!pick || typeof pick.pickNo !== "number") continue;
           if (pick.pickNo <= cursorRef.current) continue;
+          // The handler returns ``false`` when it couldn't apply the
+          // pick for a TRANSIENT reason (e.g. the /api/data sleeper
+          // teams fetch is still in flight on first load).  In that
+          // case we hold the cursor so the same pick re-delivers on
+          // the next poll — otherwise a brief mapping gap would
+          // silently drop real picks.  Permanent failures (player
+          // not in pool, owner unmappable) are surfaced via alerts
+          // by the handler and DO advance the cursor.  A throw
+          // counts as permanent so a buggy handler can't deadlock
+          // the loop forever.
+          let applied = true;
           try {
-            onPickArrivedRef.current?.(pick);
+            const result = onPickArrivedRef.current?.(pick);
+            if (result === false) applied = false;
           } catch {
-            /* swallow — never let one bad handler kill the loop */
+            applied = true;
           }
+          if (!applied) break;
           cursorRef.current = pick.pickNo;
         }
 

--- a/frontend/components/useSleeperDraftSync.js
+++ b/frontend/components/useSleeperDraftSync.js
@@ -1,0 +1,269 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Polling cadences (ms).  Visible-tab cadence is the user-facing
+// latency target; hidden-tab cadence is courteous to Sleeper while
+// still catching up when the user returns.  Error backoff stretches
+// the interval so a Sleeper outage doesn't generate a retry storm.
+const POLL_INTERVAL_ACTIVE_MS = 2500;
+const POLL_INTERVAL_HIDDEN_MS = 10000;
+const POLL_INTERVAL_ERROR_MS = 8000;
+
+// Treat "no new pick in this long" as a stale connection — the UI
+// flips the indicator to amber.  Set generously (auctions can have
+// long lulls between nominations).
+const STALE_AFTER_MS = 20000;
+
+/**
+ * Live Sleeper auction-draft polling hook.
+ *
+ * Polls ``/api/sleeper/draft/picks`` while ``enabled`` is true,
+ * invoking ``onPickArrived(pick)`` for every new pick (in
+ * ``pickNo`` order).  Tracks a cursor in a ref so a remount or a
+ * brief network blip doesn't replay picks.
+ *
+ * @param {object} args
+ * @param {string} args.leagueKey   — active league key (passed to backend)
+ * @param {boolean} args.enabled    — master switch (toggle on the page)
+ * @param {(pick: object) => void} args.onPickArrived — called per new pick
+ * @returns {{
+ *   status: "idle" | "connected" | "stale" | "error" | "complete",
+ *   draftId: string | null,
+ *   lastPickNo: number,
+ *   latestPickNo: number,
+ *   lastSyncAt: number | null,
+ *   error: string | null,
+ * }}
+ */
+export function useSleeperDraftSync({ leagueKey, enabled, onPickArrived }) {
+  const [state, setState] = useState({
+    status: "idle",
+    draftId: null,
+    lastPickNo: 0,
+    latestPickNo: 0,
+    lastSyncAt: null,
+    error: null,
+  });
+
+  // Hold the cursor + a few callbacks in refs so the polling effect's
+  // identity doesn't change on every re-render (which would trip its
+  // own setInterval and restart the timer).
+  const cursorRef = useRef(0);
+  const onPickArrivedRef = useRef(onPickArrived);
+  useEffect(() => {
+    onPickArrivedRef.current = onPickArrived;
+  }, [onPickArrived]);
+
+  // Reset the cursor whenever the active league changes — picks are
+  // per-league, so a switch should start from pick 0 of the new
+  // league's draft.
+  useEffect(() => {
+    cursorRef.current = 0;
+    setState((s) => ({
+      ...s,
+      status: enabled ? "idle" : "idle",
+      lastPickNo: 0,
+      latestPickNo: 0,
+      draftId: null,
+      error: null,
+    }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leagueKey]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setState((s) => ({ ...s, status: "idle", error: null }));
+      return undefined;
+    }
+
+    let cancelled = false;
+    let timer = null;
+    let consecutiveErrors = 0;
+
+    const tick = async () => {
+      if (cancelled) return;
+      const ctl = new AbortController();
+      try {
+        const url = new URL("/api/sleeper/draft/picks", window.location.origin);
+        if (leagueKey) url.searchParams.set("leagueKey", leagueKey);
+        url.searchParams.set("afterPickNo", String(cursorRef.current));
+        const res = await fetch(url.toString(), {
+          cache: "no-store",
+          signal: ctl.signal,
+        });
+        if (cancelled) return;
+
+        if (res.status === 404) {
+          // ``no_active_draft`` — keep polling at the error cadence
+          // (the draft might start any minute) but flag the state so
+          // the UI dims the indicator.
+          consecutiveErrors = 0;
+          setState((s) => ({
+            ...s,
+            status: "error",
+            error: "No active draft for this league.",
+            lastSyncAt: Date.now(),
+          }));
+          schedule(POLL_INTERVAL_ERROR_MS);
+          return;
+        }
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const data = await res.json();
+        if (cancelled) return;
+
+        const picks = Array.isArray(data?.picks) ? data.picks : [];
+        for (const pick of picks) {
+          if (!pick || typeof pick.pickNo !== "number") continue;
+          if (pick.pickNo <= cursorRef.current) continue;
+          try {
+            onPickArrivedRef.current?.(pick);
+          } catch {
+            /* swallow — never let one bad handler kill the loop */
+          }
+          cursorRef.current = pick.pickNo;
+        }
+
+        const latest = Number(data?.latestPickNo) || cursorRef.current;
+        const status = data?.status || "unknown";
+        consecutiveErrors = 0;
+
+        setState((s) => {
+          // ``complete`` is terminal — auto-stop polling once Sleeper
+          // marks the draft done so we don't pound the endpoint
+          // forever post-draft.
+          const next = {
+            ...s,
+            draftId: data?.draftId || s.draftId,
+            lastPickNo: cursorRef.current,
+            latestPickNo: latest,
+            lastSyncAt: Date.now(),
+            error: null,
+          };
+          if (status === "complete") {
+            next.status = "complete";
+          } else if (status === "drafting" || status === "pre_draft") {
+            next.status = "connected";
+          } else {
+            next.status = "connected";
+          }
+          return next;
+        });
+
+        if (status === "complete") {
+          // Terminal — don't reschedule.
+          return;
+        }
+        schedule();
+      } catch (err) {
+        if (cancelled) return;
+        if (err?.name === "AbortError") return;
+        consecutiveErrors += 1;
+        setState((s) => ({
+          ...s,
+          status: "error",
+          error: err?.message || "Live sync error",
+        }));
+        schedule(POLL_INTERVAL_ERROR_MS);
+      }
+    };
+
+    const schedule = (overrideMs) => {
+      if (cancelled) return;
+      const hidden = typeof document !== "undefined" && document.hidden;
+      const ms =
+        overrideMs ??
+        (hidden ? POLL_INTERVAL_HIDDEN_MS : POLL_INTERVAL_ACTIVE_MS);
+      timer = setTimeout(tick, ms);
+    };
+
+    // Kick off immediately so the first poll lands within a render
+    // cycle — the user gets feedback that sync is active.
+    tick();
+
+    // When the tab becomes visible again, force a refresh so the
+    // user catches up to whatever happened while they were away.
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        tick();
+      }
+    };
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibility);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibility);
+      }
+    };
+  }, [enabled, leagueKey]);
+
+  // Derive a "stale" state purely from time-since-last-success so the
+  // UI can flag long gaps without an extra effect.  Polled state.
+  const derivedStatus = (() => {
+    if (state.status === "complete") return "complete";
+    if (state.status === "error") return "error";
+    if (!state.lastSyncAt) return state.status;
+    if (Date.now() - state.lastSyncAt > STALE_AFTER_MS) return "stale";
+    return state.status;
+  })();
+
+  return { ...state, status: derivedStatus };
+}
+
+/**
+ * Build a Sleeper-team-id ↔ workspace-team-idx map from the
+ * /api/data sleeper block and the workspace's teams array.
+ *
+ * Workspace teams are merged from /api/draft-capital ``teamTotals``
+ * which is itself derived from Sleeper's users + rosters — so the
+ * display name is the canonical join key.  We index by both
+ * ``ownerId`` (Sleeper user_id) and ``rosterId`` so the live pick's
+ * primary key (``picked_by``) and fallback (``roster_id``) both
+ * resolve when present.
+ *
+ * Returns ``{ byOwner: Map<string, number>, byRoster: Map<number, number> }``.
+ * Empty maps when sleeperTeams is missing — the caller falls back to
+ * surfacing the pick with no team-index so the user can record it
+ * manually.
+ */
+export function buildTeamIndexLookup(workspaceTeams, sleeperTeams) {
+  const byOwner = new Map();
+  const byRoster = new Map();
+  const wsTeams = Array.isArray(workspaceTeams) ? workspaceTeams : [];
+  const slTeams = Array.isArray(sleeperTeams) ? sleeperTeams : [];
+  if (wsTeams.length === 0 || slTeams.length === 0) {
+    return { byOwner, byRoster };
+  }
+
+  // Workspace team idx keyed by lowercase name for case-insensitive
+  // matching.  Names come from /api/draft-capital teamTotals which
+  // are emitted from the same Sleeper users feed, so this is a
+  // direct match in practice.
+  const wsIdxByName = new Map();
+  wsTeams.forEach((t, idx) => {
+    const key = String(t?.name || "").toLowerCase().trim();
+    if (key) wsIdxByName.set(key, idx);
+  });
+
+  for (const t of slTeams) {
+    const teamName = String(t?.name || "").toLowerCase().trim();
+    if (!teamName) continue;
+    const idx = wsIdxByName.get(teamName);
+    if (idx == null) continue;
+    const ownerId = String(t?.ownerId || "").trim();
+    if (ownerId) byOwner.set(ownerId, idx);
+    const rosterId = Number(t?.roster_id);
+    if (Number.isFinite(rosterId)) byRoster.set(rosterId, idx);
+  }
+  return { byOwner, byRoster };
+}

--- a/server.py
+++ b/server.py
@@ -5550,6 +5550,120 @@ async def get_draft_capital(request: Request, refresh: str = ""):
         )
 
 
+@app.get("/api/sleeper/draft/picks")
+async def get_sleeper_draft_picks(
+    request: Request,
+    afterPickNo: int = 0,
+):
+    """Live auction-draft picks stream for the /draft companion.
+
+    The /draft page polls this every 2-3 seconds while the user has
+    live sync toggled ON.  Each response carries only the picks with
+    ``pickNo > afterPickNo`` (the client passes its latest known
+    cursor) so steady-state polls return tiny payloads.
+
+    Accepts ``?leagueKey=...`` — picks are league-scoped (rosters/
+    draft data), so this follows the CLAUDE.md leagueKey routing
+    pattern rather than scoring-profile routing.  Auto-discovers the
+    in-progress draft for the league via ``/v1/league/{id}/drafts``;
+    no draft id needs to be stored in the registry.
+
+    Response shape::
+
+        {
+            "leagueKey":    str,
+            "draftId":      str,
+            "status":       "drafting" | "pre_draft" | "complete" | "unknown",
+            "latestPickNo": int,
+            "picks":        [{
+                "pickNo":  int,
+                "playerId": str,   # Sleeper player_id
+                "amount":  int,    # $ paid (0 for snake)
+                "ownerId": str,    # Sleeper user_id of winner
+                "rosterId": int|null,
+                "round":   int|null,
+                "pickedAt": int|null,
+            }, ...],
+            "fetchedAt":    iso-str,
+        }
+
+    Error responses (clean JSON, never 500):
+
+    * 400 ``unknown_league`` / ``inactive_league`` — bad ``leagueKey``
+    * 404 ``no_active_draft`` — league has no current-season draft
+    * 503 ``sleeper_unavailable`` — Sleeper fetch failed (circuit
+      breaker open, network error)
+    """
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        return err.json_response()
+
+    try:
+        snapshot = _sleeper_overlay.fetch_live_draft_picks(
+            league_cfg.sleeper_league_id,
+            after_pick_no=int(afterPickNo or 0),
+        )
+    except Exception as e:  # noqa: BLE001 — never 500 a live-poll endpoint
+        logging.warning("sleeper draft picks fetch failed: %s", e)
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "sleeper_unavailable",
+                "message": "Sleeper draft fetch failed; try again shortly.",
+            },
+        )
+
+    # Stamp each pick with the canonical display name so the
+    # frontend can match it to a workspace row (which is keyed by
+    # ``playerSlug(displayName)``) without re-fetching the full
+    # 4MB /api/data contract.  Reads ``latest_contract_data``'s in-
+    # process ``playersArray`` — already loaded, zero extra network
+    # cost.  When the contract isn't loaded (cold boot), the field
+    # is left null and the frontend falls back to surfacing the raw
+    # Sleeper player_id so the user can record manually.
+    if isinstance(snapshot, dict) and snapshot.get("picks"):
+        id_to_name: dict[str, str] = {}
+        try:
+            pa = (latest_contract_data or {}).get("playersArray") or []
+            if isinstance(pa, list):
+                for p in pa:
+                    if not isinstance(p, dict):
+                        continue
+                    pid = str(p.get("playerId") or "").strip()
+                    name = str(p.get("displayName") or p.get("canonicalName") or "").strip()
+                    if pid and name:
+                        id_to_name[pid] = name
+        except Exception:  # noqa: BLE001
+            id_to_name = {}
+        for pick in snapshot["picks"]:
+            pid = str(pick.get("playerId") or "")
+            pick["playerName"] = id_to_name.get(pid) or None
+
+    if snapshot is None:
+        # Two distinguishable cases collapse here: no active draft, or
+        # a Sleeper fetch failure inside ``fetch_live_draft_picks``.
+        # The frontend treats both as "live sync unavailable" — it
+        # auto-stops polling and shows an amber dot.  Probing
+        # ``/v1/league/{id}/drafts`` again to split the cases would
+        # cost a round-trip on every cold poll, which isn't worth it
+        # for a diagnostic the user can't act on.
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error": "no_active_draft",
+                "message": (
+                    "No active draft for this league, or Sleeper is "
+                    "unreachable right now."
+                ),
+                "leagueKey": league_cfg.key,
+            },
+        )
+
+    snapshot["leagueKey"] = league_cfg.key
+    return JSONResponse(content=snapshot)
+
+
 # ── PUBLIC LEAGUE ROUTES ───────────────────────────────────────────────
 # The /api/public/league* endpoints serve the public /league page.
 # They are intentionally fork-isolated from the private canonical

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -56,6 +56,23 @@ _CACHE_TTL_SEC = 15 * 60
 _HTTP_TIMEOUT_SEC = 8.0
 _USER_AGENT = "brisket-sleeper-overlay/1.0"
 
+# Live-draft caches.  These are deliberately separate from the overlay
+# cache so a 2-3s polling loop on /api/sleeper/draft/picks never poisons
+# the 15-minute team/trade overlay cache and vice versa.
+#
+# ``_DRAFT_ID_CACHE`` keys on the *Sleeper league id* (not draft id),
+# since draft-id discovery is the first step of every live poll.
+#   key: sleeper_league_id (str)
+#   value: {"draft_id": str | None, "_cached_at": float}
+#
+# ``_DRAFT_PICKS_CACHE`` keys on the *draft id* and stores the most
+# recent full picks list.  A 2s TTL keeps the auctioneer's tab from
+# DDoSing Sleeper while still feeling instantaneous to the user.
+_DRAFT_ID_CACHE: dict[str, dict[str, Any]] = {}
+_DRAFT_ID_CACHE_TTL_SEC = 60.0
+_DRAFT_PICKS_CACHE: dict[str, dict[str, Any]] = {}
+_DRAFT_PICKS_CACHE_TTL_SEC = 2.0
+
 
 def _utc_now_ms() -> int:
     return int(time.time() * 1000)
@@ -1055,3 +1072,263 @@ def invalidate_overlay_cache(sleeper_league_id: str | None = None) -> None:
             _CACHE.clear()
             return
         _CACHE.pop(str(sleeper_league_id), None)
+
+
+# ── Live draft sync ─────────────────────────────────────────────────────
+# Auction draft companion: the /draft route polls
+# ``/api/sleeper/draft/picks`` every 2-3s while a draft is in progress
+# and feeds new picks into the workspace via ``recordPick`` on the
+# frontend, eliminating manual entry while the auctioneer's calling
+# bids.  Lives in this module because it shares the urllib + circuit
+# breaker plumbing with the overlay; isolated caches keep the two paths
+# from interfering.
+#
+# Out of scope (mentioned for the reader, not implemented here):
+#   * Live nomination state (who's currently on the block, mid-bid
+#     amounts).  Not exposed by Sleeper's public REST API — only by an
+#     undocumented WebSocket used by browser extensions.  We stick to
+#     the documented endpoints.
+#   * Sub-second latency.  Polling at 2.5s gives ~3s worst-case lag
+#     which fully addresses "I can't manually keep up while drafting".
+
+
+def _current_season_year() -> int:
+    return _dt.datetime.now(_dt.timezone.utc).year
+
+
+def _resolve_active_draft_id(sleeper_league_id: str) -> str | None:
+    """Pick the most relevant draft for a league.
+
+    Sleeper exposes drafts via ``/v1/league/{id}/drafts`` — a league
+    can have multiple drafts across seasons (startup + every annual
+    rookie draft), so we filter to the current season and prefer
+    ``status == "drafting"``, falling back to ``"pre_draft"``, and
+    finally ``"complete"`` (so a freshly-finished draft still serves
+    its picks for review).  Ties broken by newest ``start_time``.
+
+    Returns ``None`` when no candidate draft exists or the league
+    fetch failed.  Cached for 60s per league — long enough to stay
+    cheap during a 2-hour auction, short enough that toggling the
+    draft live during a session is reflected within a minute.
+    """
+    sleeper_league_id = str(sleeper_league_id or "").strip()
+    if not sleeper_league_id:
+        return None
+
+    now = time.time()
+    with _CACHE_LOCK:
+        cached = _DRAFT_ID_CACHE.get(sleeper_league_id)
+        if cached and (now - float(cached.get("_cached_at") or 0)) < _DRAFT_ID_CACHE_TTL_SEC:
+            return cached.get("draft_id")
+
+    drafts = _http_get_json(
+        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/drafts"
+    )
+    draft_id: str | None = None
+    if isinstance(drafts, list):
+        season = str(_current_season_year())
+        # Status precedence: drafting > pre_draft > complete.  Lower is
+        # better.  Within the same status, newest start_time wins.
+        rank = {"drafting": 0, "pre_draft": 1, "complete": 2}
+        best: tuple[int, int, str] | None = None
+        for d in drafts:
+            if not isinstance(d, dict):
+                continue
+            if str(d.get("sport") or "nfl") != "nfl":
+                continue
+            d_season = str(d.get("season") or "").strip()
+            if d_season != season:
+                continue
+            status = str(d.get("status") or "").strip()
+            if status not in rank:
+                continue
+            d_id = str(d.get("draft_id") or "").strip()
+            if not d_id:
+                continue
+            try:
+                start = int(d.get("start_time") or 0)
+            except (TypeError, ValueError):
+                start = 0
+            key = (rank[status], -start, d_id)
+            if best is None or key < best:
+                best = key
+                draft_id = d_id
+
+    with _CACHE_LOCK:
+        _DRAFT_ID_CACHE[sleeper_league_id] = {
+            "draft_id": draft_id,
+            "_cached_at": now,
+        }
+    return draft_id
+
+
+def _fetch_draft_meta(draft_id: str) -> dict[str, Any] | None:
+    """Fetch ``/v1/draft/{id}`` — used to surface the draft's current
+    status (``drafting``/``pre_draft``/``complete``) so the frontend
+    knows when to stop polling.  Result is not cached separately;
+    draft-meta TTL piggybacks on ``_DRAFT_PICKS_CACHE_TTL_SEC`` via
+    its parent caller.
+    """
+    if not draft_id:
+        return None
+    data = _http_get_json(f"https://api.sleeper.app/v1/draft/{draft_id}")
+    return data if isinstance(data, dict) else None
+
+
+def _normalize_live_pick(pick: dict[str, Any]) -> dict[str, Any] | None:
+    """Project one Sleeper pick dict into the compact shape the
+    frontend hook consumes.
+
+    Returns ``None`` when required fields (pick_no, player_id) are
+    missing or unparseable — those picks are skipped so a malformed
+    row never breaks the whole stream.
+
+    Output shape::
+
+        {
+            "pickNo":  int,     # monotonic cursor
+            "playerId": str,    # Sleeper player_id (matches workspace.players[].id)
+            "amount":  int,     # auction price; 0 for snake-draft picks
+            "ownerId": str,     # Sleeper user_id of the winner ("" when unknown)
+            "rosterId": int|None,
+            "round":   int|None,
+            "pickedAt": int|None,  # epoch seconds when Sleeper recorded the pick
+        }
+    """
+    pick_no = _safe_int(pick.get("pick_no"))
+    pid = pick.get("player_id")
+    if pick_no is None or pick_no < 1 or pid is None:
+        return None
+
+    metadata = pick.get("metadata") if isinstance(pick.get("metadata"), dict) else {}
+    amount_raw = metadata.get("amount") if isinstance(metadata, dict) else None
+    # Auction picks stamp ``metadata.amount`` as a string ("$23" or
+    # "23" depending on draft type).  Strip a leading $ and coerce.
+    amount = 0
+    if amount_raw is not None:
+        try:
+            amount = int(str(amount_raw).lstrip("$").strip())
+        except (TypeError, ValueError):
+            amount = 0
+
+    owner = pick.get("picked_by")
+    owner_id = str(owner).strip() if owner else ""
+
+    return {
+        "pickNo": pick_no,
+        "playerId": str(pid),
+        "amount": amount,
+        "ownerId": owner_id,
+        "rosterId": _safe_int(pick.get("roster_id")),
+        "round": _safe_int(pick.get("round")),
+        "pickedAt": _safe_int(pick.get("picked_at")),
+    }
+
+
+def fetch_live_draft_picks(
+    sleeper_league_id: str,
+    after_pick_no: int = 0,
+    *,
+    force_refresh: bool = False,
+) -> dict[str, Any] | None:
+    """Return the current live-draft snapshot for a league.
+
+    Shape::
+
+        {
+            "draftId":      str,
+            "status":       "drafting" | "pre_draft" | "complete" | "unknown",
+            "latestPickNo": int,
+            "picks":        [<normalized pick>, ...],  # only those with pick_no > after_pick_no
+            "fetchedAt":    iso-str,
+        }
+
+    Returns ``None`` when no draft can be resolved for the league
+    (no current-season draft, league fetch failed).  Callers
+    typically degrade to a "live sync not available" UI in that case.
+
+    Caching: the FULL picks list is cached per draft id for 2s so a
+    burst of polling tabs against the same draft only round-trips
+    Sleeper at most every 2s.  Cursor filtering (``after_pick_no``)
+    happens on the cached list.
+    """
+    sleeper_league_id = str(sleeper_league_id or "").strip()
+    if not sleeper_league_id:
+        return None
+
+    draft_id = _resolve_active_draft_id(sleeper_league_id)
+    if not draft_id:
+        return None
+
+    now = time.time()
+    cache_key = f"draft_picks:{draft_id}"
+    snapshot: dict[str, Any] | None = None
+    if not force_refresh:
+        with _CACHE_LOCK:
+            cached = _DRAFT_PICKS_CACHE.get(cache_key)
+            if cached and (now - float(cached.get("_cached_at") or 0)) < _DRAFT_PICKS_CACHE_TTL_SEC:
+                snapshot = cached.get("snapshot")
+
+    if snapshot is None:
+        meta = _fetch_draft_meta(draft_id)
+        status = str(meta.get("status") if isinstance(meta, dict) else "").strip() or "unknown"
+        raw_picks = _http_get_json(
+            f"https://api.sleeper.app/v1/draft/{draft_id}/picks"
+        )
+        if not isinstance(raw_picks, list):
+            # Hard fetch failure.  Don't poison the cache — let the
+            # next poll retry.  Return None so the route surfaces a
+            # graceful "couldn't load" state without 500ing.
+            return None
+        normalized: list[dict[str, Any]] = []
+        for p in raw_picks:
+            if not isinstance(p, dict):
+                continue
+            row = _normalize_live_pick(p)
+            if row is not None:
+                normalized.append(row)
+        normalized.sort(key=lambda r: r["pickNo"])
+        latest = normalized[-1]["pickNo"] if normalized else 0
+        snapshot = {
+            "draftId": draft_id,
+            "status": status,
+            "latestPickNo": latest,
+            "picks": normalized,
+            "fetchedAt": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        }
+        with _CACHE_LOCK:
+            _DRAFT_PICKS_CACHE[cache_key] = {
+                "snapshot": snapshot,
+                "_cached_at": now,
+            }
+
+    # Apply the cursor outside the cache.  The full list lives in the
+    # cache; per-client slicing is cheap.
+    try:
+        after = max(0, int(after_pick_no))
+    except (TypeError, ValueError):
+        after = 0
+    delta_picks = [p for p in snapshot["picks"] if p["pickNo"] > after]
+    return {
+        "draftId": snapshot["draftId"],
+        "status": snapshot["status"],
+        "latestPickNo": snapshot["latestPickNo"],
+        "picks": delta_picks,
+        "fetchedAt": snapshot["fetchedAt"],
+    }
+
+
+def invalidate_live_draft_cache(sleeper_league_id: str | None = None) -> None:
+    """Drop the live-draft caches.  Used by tests + a potential future
+    admin "force refresh" endpoint.  ``None`` clears everything."""
+    with _CACHE_LOCK:
+        if sleeper_league_id is None:
+            _DRAFT_ID_CACHE.clear()
+            _DRAFT_PICKS_CACHE.clear()
+            return
+        key = str(sleeper_league_id)
+        cached = _DRAFT_ID_CACHE.pop(key, None)
+        if cached:
+            did = cached.get("draft_id")
+            if did:
+                _DRAFT_PICKS_CACHE.pop(f"draft_picks:{did}", None)

--- a/tests/api/test_sleeper_live_draft.py
+++ b/tests/api/test_sleeper_live_draft.py
@@ -1,0 +1,367 @@
+"""Tests for the live Sleeper auction-draft sync helpers in
+``src/api/sleeper_overlay.py`` — the polling path that backs
+``/api/sleeper/draft/picks``.
+
+These cover the three things that matter:
+
+  1. Draft id auto-discovery picks the right draft when a league
+     has multiple (current-season + status precedence).
+  2. ``fetch_live_draft_picks`` normalizes Sleeper's raw pick
+     shape into the compact contract the frontend hook consumes,
+     including the ``metadata.amount`` → ``amount`` coercion
+     (Sleeper stamps it as a string).
+  3. The ``after_pick_no`` cursor filters correctly so the
+     polling client only sees new picks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.api import sleeper_overlay
+
+
+@pytest.fixture(autouse=True)
+def _clear_live_caches():
+    """Fresh caches per test so the 60s draft-id memo and 2s picks
+    memo don't leak fixtures between cases.
+    """
+    sleeper_overlay.invalidate_live_draft_cache()
+    yield
+    sleeper_overlay.invalidate_live_draft_cache()
+
+
+def _stub_http(mapping):
+    """Longest-suffix-match monkeypatch helper, same pattern as the
+    overlay tests."""
+    sorted_keys = sorted(mapping.keys(), key=len, reverse=True)
+
+    def _resolve(url: str):
+        for suffix in sorted_keys:
+            if url.endswith(suffix):
+                return mapping[suffix]
+        return None
+    return _resolve
+
+
+# ── _resolve_active_draft_id ────────────────────────────────────────────
+
+
+def test_resolve_active_draft_id_prefers_drafting_status(monkeypatch):
+    """Of multiple current-season drafts, prefer status=drafting
+    over pre_draft over complete."""
+    import datetime as _dt
+    cur = _dt.datetime.now(_dt.timezone.utc).year
+    league_id = "L1"
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({
+            f"/league/{league_id}/drafts": [
+                {
+                    "draft_id": "complete-prior",
+                    "season": str(cur),
+                    "sport": "nfl",
+                    "status": "complete",
+                    "start_time": 100,
+                },
+                {
+                    "draft_id": "drafting-now",
+                    "season": str(cur),
+                    "sport": "nfl",
+                    "status": "drafting",
+                    "start_time": 200,
+                },
+                {
+                    "draft_id": "pre-draft-soon",
+                    "season": str(cur),
+                    "sport": "nfl",
+                    "status": "pre_draft",
+                    "start_time": 300,
+                },
+            ],
+        }),
+    )
+    assert sleeper_overlay._resolve_active_draft_id(league_id) == "drafting-now"
+
+
+def test_resolve_active_draft_id_skips_off_season(monkeypatch):
+    """Drafts from prior seasons must not be selected even if they
+    sit at status complete (the most common stale-data case)."""
+    import datetime as _dt
+    cur = _dt.datetime.now(_dt.timezone.utc).year
+    league_id = "L1"
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({
+            f"/league/{league_id}/drafts": [
+                {
+                    "draft_id": "last-year",
+                    "season": str(cur - 1),
+                    "sport": "nfl",
+                    "status": "complete",
+                    "start_time": 50,
+                },
+            ],
+        }),
+    )
+    assert sleeper_overlay._resolve_active_draft_id(league_id) is None
+
+
+def test_resolve_active_draft_id_returns_none_on_empty(monkeypatch):
+    """An empty /drafts response must return None, not raise — the
+    route surfaces this as 404 ``no_active_draft``."""
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({"/league/L1/drafts": []}),
+    )
+    assert sleeper_overlay._resolve_active_draft_id("L1") is None
+
+
+# ── _normalize_live_pick ────────────────────────────────────────────────
+
+
+def test_normalize_live_pick_coerces_string_amount():
+    """Sleeper stamps ``metadata.amount`` as a STRING for auction
+    picks ("$23" or "23").  Normalizer must coerce to int."""
+    row = sleeper_overlay._normalize_live_pick({
+        "pick_no": 5,
+        "player_id": "4046",
+        "picked_by": "user-123",
+        "roster_id": 7,
+        "round": 1,
+        "picked_at": 1715000000,
+        "metadata": {"amount": "$23"},
+    })
+    assert row == {
+        "pickNo": 5,
+        "playerId": "4046",
+        "amount": 23,
+        "ownerId": "user-123",
+        "rosterId": 7,
+        "round": 1,
+        "pickedAt": 1715000000,
+    }
+
+
+def test_normalize_live_pick_handles_snake_draft_no_amount():
+    """Snake-draft picks have no ``metadata.amount`` — must default
+    to 0 rather than failing the row."""
+    row = sleeper_overlay._normalize_live_pick({
+        "pick_no": 1,
+        "player_id": "4046",
+        "picked_by": "user-123",
+        "roster_id": 1,
+        "round": 1,
+        "metadata": {},
+    })
+    assert row is not None
+    assert row["amount"] == 0
+
+
+def test_normalize_live_pick_skips_malformed():
+    """Missing pick_no or player_id → return None (the row is
+    dropped from the stream rather than poisoning the cursor)."""
+    assert sleeper_overlay._normalize_live_pick({"player_id": "x"}) is None
+    assert sleeper_overlay._normalize_live_pick({"pick_no": 1}) is None
+    assert sleeper_overlay._normalize_live_pick({"pick_no": 0, "player_id": "x"}) is None
+
+
+def test_normalize_live_pick_blank_picked_by():
+    """Commish picks / co-managers can have empty picked_by — must
+    produce an empty ownerId string (not None) so the JSON response
+    has a consistent type."""
+    row = sleeper_overlay._normalize_live_pick({
+        "pick_no": 5,
+        "player_id": "4046",
+        "picked_by": None,
+        "roster_id": 7,
+        "metadata": {"amount": "10"},
+    })
+    assert row["ownerId"] == ""
+    assert row["rosterId"] == 7
+
+
+# ── fetch_live_draft_picks ──────────────────────────────────────────────
+
+
+def _fixture_picks_response():
+    """Two-pick auction-draft fixture in raw Sleeper shape."""
+    return [
+        {
+            "pick_no": 1,
+            "player_id": "4046",
+            "picked_by": "user-A",
+            "roster_id": 1,
+            "round": 1,
+            "metadata": {"amount": "23"},
+        },
+        {
+            "pick_no": 2,
+            "player_id": "5021",
+            "picked_by": "user-B",
+            "roster_id": 2,
+            "round": 1,
+            "metadata": {"amount": "$12"},
+        },
+    ]
+
+
+def _fixture_drafts_response():
+    import datetime as _dt
+    cur = _dt.datetime.now(_dt.timezone.utc).year
+    return [
+        {
+            "draft_id": "D1",
+            "season": str(cur),
+            "sport": "nfl",
+            "status": "drafting",
+            "start_time": 200,
+        },
+    ]
+
+
+def test_fetch_live_draft_picks_full_snapshot(monkeypatch):
+    """First poll with cursor=0 returns every pick, status from the
+    draft meta endpoint, and a monotonic latestPickNo."""
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({
+            "/league/L1/drafts": _fixture_drafts_response(),
+            "/draft/D1": {"status": "drafting"},
+            "/draft/D1/picks": _fixture_picks_response(),
+        }),
+    )
+    snap = sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)
+    assert snap is not None
+    assert snap["draftId"] == "D1"
+    assert snap["status"] == "drafting"
+    assert snap["latestPickNo"] == 2
+    assert len(snap["picks"]) == 2
+    # First pick exactly matches the auction shape the frontend expects.
+    assert snap["picks"][0]["playerId"] == "4046"
+    assert snap["picks"][0]["amount"] == 23
+    assert snap["picks"][0]["ownerId"] == "user-A"
+    # Second pick has $-prefixed amount in the fixture — coerced.
+    assert snap["picks"][1]["amount"] == 12
+
+
+def test_fetch_live_draft_picks_cursor_filters(monkeypatch):
+    """``after_pick_no`` filters server-side from the cached full
+    snapshot.  Picks at or below the cursor are excluded."""
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({
+            "/league/L1/drafts": _fixture_drafts_response(),
+            "/draft/D1": {"status": "drafting"},
+            "/draft/D1/picks": _fixture_picks_response(),
+        }),
+    )
+    snap = sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=1)
+    assert len(snap["picks"]) == 1
+    assert snap["picks"][0]["pickNo"] == 2
+    # latestPickNo is the full-snapshot max, not cursor-filtered.
+    assert snap["latestPickNo"] == 2
+
+
+def test_fetch_live_draft_picks_no_active_draft(monkeypatch):
+    """When the league has no current-season draft, return None
+    so the route can 404 cleanly."""
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({"/league/L1/drafts": []}),
+    )
+    assert sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0) is None
+
+
+def test_fetch_live_draft_picks_complete_status(monkeypatch):
+    """A completed draft still serves its picks (useful for replay /
+    review) and the status flag drives the frontend's auto-stop."""
+    import datetime as _dt
+    cur = _dt.datetime.now(_dt.timezone.utc).year
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({
+            "/league/L1/drafts": [{
+                "draft_id": "D1",
+                "season": str(cur),
+                "sport": "nfl",
+                "status": "complete",
+                "start_time": 100,
+            }],
+            "/draft/D1": {"status": "complete"},
+            "/draft/D1/picks": _fixture_picks_response(),
+        }),
+    )
+    snap = sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)
+    assert snap["status"] == "complete"
+    assert len(snap["picks"]) == 2
+
+
+def test_fetch_live_draft_picks_cache_isolation(monkeypatch):
+    """The live-draft 2s cache must be separate from the 15-minute
+    overlay cache.  Specifically: invalidating the LIVE cache must
+    not also wipe the team-overlay cache, and vice versa.  Earlier
+    designs sharing a single dict caused the live polling loop to
+    flush the overlay every 2s, which DDoS'd the team-overlay
+    rebuild on every page load."""
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http({
+            "/league/L1/drafts": _fixture_drafts_response(),
+            "/draft/D1": {"status": "drafting"},
+            "/draft/D1/picks": _fixture_picks_response(),
+        }),
+    )
+    # Seed both caches.
+    sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)
+    # Manually seed an overlay cache entry to prove isolation.
+    with sleeper_overlay._CACHE_LOCK:
+        sleeper_overlay._CACHE["L1"] = {
+            "payload": {"sentinel": True},
+            "_cached_at": 9_999_999_999.0,
+        }
+    sleeper_overlay.invalidate_live_draft_cache("L1")
+    with sleeper_overlay._CACHE_LOCK:
+        assert "L1" in sleeper_overlay._CACHE  # overlay cache preserved
+        assert "L1" not in sleeper_overlay._DRAFT_ID_CACHE  # live cache cleared
+
+
+def test_fetch_live_draft_picks_caches_full_list_not_delta(monkeypatch):
+    """A burst of polls with different cursors must reuse the same
+    cached snapshot — Sleeper is hit at most once per
+    ``_DRAFT_PICKS_CACHE_TTL_SEC`` regardless of cursor variance.
+    This is the load-bearing safety property: 10 tabs polling at
+    2.5s each must NOT result in 4 Sleeper round-trips per second.
+    """
+    call_count = {"n": 0}
+    real_responses = {
+        "/league/L1/drafts": _fixture_drafts_response(),
+        "/draft/D1": {"status": "drafting"},
+        "/draft/D1/picks": _fixture_picks_response(),
+    }
+    sorted_keys = sorted(real_responses.keys(), key=len, reverse=True)
+
+    def _counting_fetch(url):
+        call_count["n"] += 1
+        for suffix in sorted_keys:
+            if url.endswith(suffix):
+                return real_responses[suffix]
+        return None
+
+    monkeypatch.setattr(sleeper_overlay, "_http_get_json", _counting_fetch)
+    sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)
+    calls_after_first = call_count["n"]
+    # Second + third polls with different cursors must hit the cache.
+    sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=1)
+    sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)
+    assert call_count["n"] == calls_after_first, (
+        f"Expected cached polls to make 0 new HTTP calls; saw "
+        f"{call_count['n'] - calls_after_first}."
+    )


### PR DESCRIPTION
## Summary

Adds a polling-based bridge from a live Sleeper auction draft into the `/draft` dashboard so picks (player + $ + winning team) auto-record without manual entry while you're trying to bid.

## What it does

- **Backend** (`src/api/sleeper_overlay.py`, `server.py`)
  - New `GET /api/sleeper/draft/picks?leagueKey=…&afterPickNo=N` returns only picks beyond the client cursor
  - Auto-discovers the in-progress draft via `/v1/league/{id}/drafts` (status precedence: `drafting` → `pre_draft` → `complete`)
  - Isolated 60s + 2s caches so the polling loop never poisons the 15-minute team-overlay cache
  - Each pick is stamped server-side with `playerName` from `latest_contract_data.playersArray` so the frontend doesn't need the full 4MB contract
  - Reuses the existing `_http_get_json` urllib + circuit-breaker plumbing — no new async / aiohttp / SSE infra
- **Frontend** (`frontend/components/useSleeperDraftSync.js`, `frontend/app/draft/page.jsx`, `frontend/app/api/sleeper/draft/picks/route.js`)
  - New `useSleeperDraftSync` hook polls at 2.5s visible / 10s hidden, backs off to 8s on errors, auto-stops on `status: "complete"`
  - Toggle pill on `/draft` with a colored status dot (green connected / amber stale / red error / cyan complete / grey off)
  - Conflicts (manual entry differs from Sleeper) overwrite silently when consistent, push a `Live sync corrected …` alert when not — letting you hit the existing `↶ Undo last` button if Sleeper is wrong
  - Live-sync toggle persists per league in `localStorage` so `Reset` doesn't lose it
- **Tests** (`tests/api/test_sleeper_live_draft.py`)
  - 13 new tests covering draft-id auto-discovery, pick normalization, cursor filtering, status-complete behavior, cache isolation, and the burst-poll-caches-not-fetches invariant

## What's intentionally out of scope (Sleeper public API limits)

- **Live nominations** ("who's on the block right now"): not exposed by Sleeper's REST API; only via the undocumented WebSocket that browser extensions reverse-engineered. We don't ship reverse-engineering.
- **Mid-bid amount tracking**: same.
- **Sub-second latency**: polling at 2.5s gives ~3s worst-case lag, which is the whole point of having the sync — you stop falling behind, period.

## Test plan

- [x] `python -m pytest tests/api/` — 1100 passed, 6 skipped
- [x] `python -m pytest tests/api/test_sleeper_live_draft.py tests/api/test_sleeper_overlay.py` — 27 passed
- [x] `node --check` on new plain-JS files
- [x] `python -c "from server import app"` — route registers as `/api/sleeper/draft/picks`
- [ ] Manual: replay against a completed historical draft id, confirm picks land on workspace in order, team mapping correct
- [ ] Manual: toggle ON during live auction, confirm picks auto-record with ~2-3s lag
- [ ] Manual: enter a pick manually at a wrong amount, let live feed overwrite, confirm reconciliation banner + `↶ Undo last` restores
- [ ] Manual: tab-hidden cadence — verify poll drops to 10s in DevTools Network panel

https://claude.ai/code/session_01HhmCFHh6Mu4cEAkW3PxQwD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhmCFHh6Mu4cEAkW3PxQwD)_