### PR TITLE
Add per-player value override in the trade calculator

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1097,6 +1097,37 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* When the trade page renders the value override input, asset-meta becomes
+     a flex row; the span inside handles truncation for the text portion. */
+}
+
+/* Inline value override input in the trade asset row */
+.asset-value-override-input {
+  background: none;
+  border: none;
+  border-bottom: 1px dashed color-mix(in srgb, var(--muted) 40%, transparent);
+  color: var(--muted);
+  font-size: 0.73rem;
+  font-family: inherit;
+  width: 52px;
+  padding: 0 2px;
+  text-align: right;
+  -moz-appearance: textfield;
+  flex-shrink: 0;
+}
+.asset-value-override-input::-webkit-inner-spin-button,
+.asset-value-override-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.asset-value-override-input:focus {
+  outline: none;
+  border-bottom-color: var(--cyan);
+  color: var(--text);
+}
+.asset-value-override-input.overridden {
+  color: var(--amber);
+  border-bottom-color: var(--amber);
 }
 
 .tier-label {

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -366,6 +366,11 @@ export default function TradePage() {
   const sideInputRefs = useRef({});
   const [hydrated, setHydrated] = useState(false);
 
+  // Per-player value overrides for this trade only.
+  // Keyed by player name → number (the final effective value to use in trade math).
+  // Cleared when the trade is cleared or a player is removed.
+  const [valueOverrides, setValueOverrides] = useState({});
+
   // Suggestions state
   const [rosterInput, setRosterInput] = useState("");
   const [suggestions, setSuggestions] = useState(null);
@@ -637,32 +642,46 @@ export default function TradePage() {
     }
   }, [hydrated, shareHydrated, rows, rowByName]);
 
+  // Apply per-player value overrides to the sides for all value calculations.
+  // Only modifies the asset rows that have an override; everything else passes through.
+  const sidesWithOverrides = useMemo(() => {
+    if (!Object.keys(valueOverrides).length) return sides;
+    return sides.map((s) => ({
+      ...s,
+      assets: s.assets.map((r) => {
+        const ov = valueOverrides[r.name];
+        if (ov == null) return r;
+        return { ...r, customValue: ov };
+      }),
+    }));
+  }, [sides, valueOverrides]);
+
   // ── Computed totals for all sides ────────────────────────────────────
   // Both 2-team and N-team trades use the KTC-style Value Adjustment.
   // For N ≥ 3, each side's VA is computed against the merged opposition
   // (every other side's assets flattened) — see
   // ``computeMultiSideAdjustments`` in trade-logic.js.
   const sideTotals = useMemo(() => {
-    if (sides.length === 2) {
-      const [a, b] = adjustedSideTotals(sides[0].assets, sides[1].assets, valueMode, settings);
+    if (sidesWithOverrides.length === 2) {
+      const [a, b] = adjustedSideTotals(sidesWithOverrides[0].assets, sidesWithOverrides[1].assets, valueMode, settings);
       return [a, b];
     }
-    if (sides.length > 2) {
-      return multiAdjustedSideTotals(sides.map((s) => s.assets), valueMode, settings);
+    if (sidesWithOverrides.length > 2) {
+      return multiAdjustedSideTotals(sidesWithOverrides.map((s) => s.assets), valueMode, settings);
     }
-    return sides.map((s) => {
+    return sidesWithOverrides.map((s) => {
       const raw = sideTotal(s.assets, valueMode, settings);
       return { raw, adjustment: 0, adjusted: raw };
     });
-  }, [sides, valueMode, settings]);
+  }, [sidesWithOverrides, valueMode, settings]);
 
   // Per-side flow totals: given / received / net.  In 2-team trades
   // the destinations map is ignored (assets implicitly go to the other
   // side).  In 3+-team trades each asset's destination drives the NET
   // flow, which is what the multi-team fairness bar renders.
   const sideFlows = useMemo(
-    () => computeSideFlows(sides, valueMode, settings),
-    [sides, valueMode, settings],
+    () => computeSideFlows(sidesWithOverrides, valueMode, settings),
+    [sidesWithOverrides, valueMode, settings],
   );
 
   // Per-side incoming / outgoing asset lists.  This is the
@@ -867,6 +886,28 @@ export default function TradePage() {
     return () => registerAddToTrade?.(null);
   }, [registerAddToTrade, activeSide]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  function setValueOverride(name, rawInput) {
+    const num = parseFloat(String(rawInput).replace(/,/g, ""));
+    setValueOverrides((prev) => {
+      if (!Number.isFinite(num) || num <= 0) {
+        if (!(name in prev)) return prev;
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      }
+      return { ...prev, [name]: num };
+    });
+  }
+
+  function clearValueOverride(name) {
+    setValueOverrides((prev) => {
+      if (!(name in prev)) return prev;
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+  }
+
   function removeFromSide(name, sideIdx) {
     setSides((prev) => prev.map((s, i) => {
       if (i !== sideIdx) return s;
@@ -878,10 +919,12 @@ export default function TradePage() {
         destinations: nextDestinations,
       };
     }));
+    clearValueOverride(name);
   }
 
   function clearTrade() {
     setSides((prev) => prev.map((s) => ({ ...s, assets: [], destinations: {} })));
+    setValueOverrides({});
   }
 
   function swapSides() {
@@ -2137,7 +2180,28 @@ export default function TradePage() {
                                   </span>
                                 )}
                               </div>
-                              <div className="asset-meta">{r.pos} · Consensus {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"} · {Math.round(effectiveValue(r, valueMode, settings)).toLocaleString()}</div>
+                              <div className="asset-meta" style={{ display: "flex", alignItems: "center", gap: 2, overflow: "hidden" }}>
+                                <span style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flexShrink: 1 }}>
+                                  {r.pos} · Consensus {r.blendedSourceRank != null ? r.blendedSourceRank.toFixed(1) : "—"} ·
+                                </span>
+                                <input
+                                  type="number"
+                                  className={`asset-value-override-input${valueOverrides[r.name] != null ? " overridden" : ""}`}
+                                  value={valueOverrides[r.name] != null ? valueOverrides[r.name] : ""}
+                                  placeholder={Math.round(effectiveValue(r, valueMode, settings))}
+                                  onChange={(e) => setValueOverride(r.name, e.target.value)}
+                                  onBlur={(e) => { if (e.target.value === "") clearValueOverride(r.name); }}
+                                  title="Override this player's value for this trade only"
+                                />
+                                {valueOverrides[r.name] != null && (
+                                  <button
+                                    className="button-reset"
+                                    onClick={() => clearValueOverride(r.name)}
+                                    title="Reset to default value"
+                                    style={{ color: "var(--muted)", fontSize: "0.7rem", lineHeight: 1, padding: "0 1px", flexShrink: 0 }}
+                                  >×</button>
+                                )}
+                              </div>
                             </div>
                           </div>
                           <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
@@ -2239,7 +2303,9 @@ export default function TradePage() {
                                   </div>
                                   <div className="asset-meta">
                                     {asset.pos} · from Side {sides[fromSideIdx]?.label || "?"} ·{" "}
-                                    {Math.round(effectiveValue(asset, valueMode, settings)).toLocaleString()}
+                                    <span style={valueOverrides[asset.name] != null ? { color: "var(--amber)" } : undefined}>
+                                      {Math.round(valueOverrides[asset.name] ?? effectiveValue(asset, valueMode, settings)).toLocaleString()}
+                                    </span>
                                   </div>
                                 </div>
                                 </div>

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -562,6 +562,7 @@ export default function TradePage() {
           if (VALUE_MODES.some((m) => m.key === nextMode)) setValueMode(nextMode);
           setActiveSide(restored.activeSide);
           setSides(restored.sides);
+          setValueOverrides({});
         }
       }
     } catch { /* ignore */ } finally { setHydrated(true); }
@@ -634,6 +635,7 @@ export default function TradePage() {
           return { ...side, assets: resolved, destinations: nextDestinations };
         });
       });
+      setValueOverrides({});
       setShareStatus("Loaded shared trade from link.");
     } catch {
       setShareStatus("Share link was malformed — ignored.");
@@ -1147,6 +1149,7 @@ export default function TradePage() {
         }
         return { ...s, assets: replacement, destinations: nextDestinations };
       }));
+      setValueOverrides({});
 
       const warnings = [];
       if (unresolvedOne.length) warnings.push(`unknown KTC id(s) on side A: ${unresolvedOne.join(", ")}`);
@@ -1440,6 +1443,7 @@ export default function TradePage() {
         return { ...side, assets: [], destinations: {} };
       });
     });
+    setValueOverrides({});
   }
 
   // Count per category

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -183,6 +183,10 @@ export function pickYearDiscount(pickName, currentYear) {
  * @returns {number}
  */
 export function effectiveValue(row, valueMode, settings) {
+  // Trade-specific value override set via the per-player override input.
+  // Returns the override directly, bypassing the pick-year discount so
+  // the user's typed number is the exact value used in the trade math.
+  if (row.customValue != null && row.customValue > 0) return row.customValue;
   let raw = Number(row.values?.[valueMode] || 0);
 
   if (!settings || raw <= 0) return raw;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Each asset row in the trade calculator now shows a small inline number input next to the player's value. Click it and type to override that player's value for the current trade only.
- The override flows through all trade math: totals, Value Adjustment, gap, verdict, 3-team NET flows — everything updates immediately.
- Overridden values display in amber; a × button resets the player back to their default value.
- The override is trade-scoped: it clears automatically when the player is removed from the trade or when the trade is cleared.

## How it works

- `effectiveValue` in `trade-logic.js` checks `row.customValue` first (one new guard, no signature change).
- In the trade page, a `sidesWithOverrides` memo stamps `customValue` onto any row that has an override before passing asset arrays to `sideTotals` and `sideFlows`. Original `sides` state is unchanged — overrides never mutate stored rows.
- `valueOverrides` state (`{ [playerName]: number }`) lives in the component; `clearTrade` and `removeFromSide` both reset it.

## Test plan

- [ ] Add two players to opposite sides — confirm trade balance shows normally
- [ ] Click the value input on a player and type a different number — confirm totals, gap, and verdict update immediately
- [ ] Confirm overridden value shows in amber with a × button
- [ ] Click × — confirm value resets to the original and totals revert
- [ ] Remove the player from the trade — confirm the override is gone if the player is re-added
- [ ] Click "Clear Trade" — confirm all overrides are wiped
- [ ] Test in a 3-team trade: override a value on one side, confirm the RECEIVING section on the destination side also shows the amber value and the NET flow updates

https://claude.ai/code/session_019ZxeccMRibwXyHH7nM1CFh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZxeccMRibwXyHH7nM1CFh)_