### PR TITLE
Fix screenshot not saving to iOS Photos

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3097,6 +3097,53 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   }
 }
 
+/* Screenshot image preview overlay (iOS fallback when Web Share API is
+   unavailable — user long-presses the image to save to Photos) */
+.screenshot-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.82);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+.screenshot-preview-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  max-width: 100%;
+  max-height: 100%;
+}
+.screenshot-preview-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--cyan);
+  text-align: center;
+}
+.screenshot-preview-img {
+  max-width: 100%;
+  max-height: 60vh;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-bright);
+  object-fit: contain;
+}
+.screenshot-preview-close {
+  padding: 10px 28px;
+  border-radius: 999px;
+  border: 1px solid var(--border-bright);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.screenshot-preview-close:hover { border-color: var(--cyan); }
+
 /* ══════════════════════════════════════════════════════════════════════════
    PER-SOURCE TRADE BREAKDOWN TABLE
    Rendered below the trade meter on /trade — one row per ranking source,

--- a/frontend/components/ScreenshotFab.jsx
+++ b/frontend/components/ScreenshotFab.jsx
@@ -4,22 +4,23 @@ import { useRef, useState } from "react";
 
 export default function ScreenshotFab() {
   const [capturing, setCapturing] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState(null);
   const btnRef = useRef(null);
+
+  function closePreview() {
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(null);
+  }
 
   async function takeScreenshot() {
     if (capturing) return;
     setCapturing(true);
+    if (btnRef.current) btnRef.current.style.visibility = "hidden";
     try {
       const { default: html2canvas } = await import("html2canvas");
 
-      // Hide the FAB itself so it doesn't appear in the capture
-      if (btnRef.current) btnRef.current.style.visibility = "hidden";
-
-      // Compute a scale that stays within Safari/WKWebView's practical canvas
-      // area limit (~5 MP per html2canvas docs; 16.8 MP is the theoretical max
-      // but real iOS devices produce empty captures well below that).
-      // allowTaint is intentionally omitted (default false) — a tainted canvas
-      // cannot be exported via toBlob(), so we skip non-CORS images instead.
+      // Keep canvas within Safari/WKWebView's practical ~5 MP limit.
+      // allowTaint omitted (default false) — tainted canvases block toBlob().
       const MAX_CANVAS_AREA = 5_000_000;
       const rawW = document.documentElement.scrollWidth;
       const rawH = document.body.scrollHeight;
@@ -33,70 +34,105 @@ export default function ScreenshotFab() {
         logging: false,
       });
 
-      if (btnRef.current) btnRef.current.style.visibility = "";
-
       await new Promise((resolve, reject) => {
         canvas.toBlob(async (blob) => {
           if (!blob) { reject(new Error("canvas toBlob returned null")); return; }
           const filename = `brisket-${new Date().toISOString().slice(0, 10)}.png`;
           const file = new File([blob], filename, { type: "image/png" });
-          try {
-            if (navigator.share && navigator.canShare?.({ files: [file] })) {
-              // iOS/Android: share sheet offers "Save to Photos" / camera roll
+
+          // Try Web Share API with files first (iOS 15+ / Android).
+          // The native share sheet includes "Save Image" → camera roll.
+          if (navigator.share && navigator.canShare?.({ files: [file] })) {
+            try {
               await navigator.share({ files: [file], title: "Brisket Rankings" });
-            } else {
-              // Desktop fallback: trigger download
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement("a");
-              a.href = url;
-              a.download = filename;
-              document.body.appendChild(a);
-              a.click();
-              document.body.removeChild(a);
-              URL.revokeObjectURL(url);
+              resolve();
+              return;
+            } catch (err) {
+              if (err.name === "AbortError") { resolve(); return; }
+              // Non-abort error — fall through to overlay
             }
-            resolve();
-          } catch (err) {
-            // AbortError = user dismissed the share sheet — not an error
-            if (err.name === "AbortError") resolve();
-            else reject(err);
           }
+
+          // Fallback path:
+          // iOS: a.download just opens the file in the browser and doesn't
+          // save to camera roll. Instead, show the image in an overlay —
+          // the user can long-press it → "Save to Photos".
+          // Desktop: trigger a normal file download.
+          const url = URL.createObjectURL(blob);
+          const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+            (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+          if (isIOS) {
+            setPreviewUrl(url);
+          } else {
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+          }
+          resolve();
         }, "image/png");
       });
     } catch (err) {
-      if (btnRef.current) btnRef.current.style.visibility = "";
       console.error("Screenshot failed:", err);
     } finally {
+      if (btnRef.current) btnRef.current.style.visibility = "";
       setCapturing(false);
     }
   }
 
   return (
-    <button
-      ref={btnRef}
-      type="button"
-      className={`screenshot-fab${capturing ? " screenshot-fab--busy" : ""}`}
-      onClick={takeScreenshot}
-      disabled={capturing}
-      aria-label="Save page as image"
-      title="Screenshot this page"
-    >
-      <span className="screenshot-fab-icon" aria-hidden="true">
-        {capturing ? (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z">
-              <animateTransform attributeName="transform" type="rotate" from="0 12 12" to="360 12 12" dur="0.8s" repeatCount="indefinite"/>
-            </path>
-          </svg>
-        ) : (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"/>
-          </svg>
-        )}
-      </span>
-      <span className="screenshot-fab-label">
-        {capturing ? "Saving…" : "Save"}
-      </span>
-    </button>
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        className={`screenshot-fab${capturing ? " screenshot-fab--busy" : ""}`}
+        onClick={takeScreenshot}
+        disabled={capturing}
+        aria-label="Save page as image"
+        title="Screenshot this page"
+      >
+        <span className="screenshot-fab-icon" aria-hidden="true">
+          {capturing ? (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z">
+                <animateTransform attributeName="transform" type="rotate" from="0 12 12" to="360 12 12" dur="0.8s" repeatCount="indefinite"/>
+              </path>
+            </svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"/>
+            </svg>
+          )}
+        </span>
+        <span className="screenshot-fab-label">
+          {capturing ? "Saving…" : "Save"}
+        </span>
+      </button>
+
+      {previewUrl && (
+        <div className="screenshot-preview-overlay" onClick={closePreview}>
+          <div className="screenshot-preview-inner" onClick={(e) => e.stopPropagation()}>
+            <p className="screenshot-preview-hint">
+              Hold the image &rarr; &ldquo;Save to Photos&rdquo;
+            </p>
+            <img
+              src={previewUrl}
+              alt="Page screenshot"
+              className="screenshot-preview-img"
+            />
+            <button
+              type="button"
+              className="screenshot-preview-close"
+              onClick={closePreview}
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The previous fallback used `a.download`, which on iOS just opens the image in the browser — it never saves to camera roll. This is why the button appeared to work but left nothing in Photos.
- Now: tries the Web Share API first (iOS 15+ native share sheet with "Save Image"); if that path isn't available (older iOS, some PWA contexts) or fails, shows the captured image in an in-app overlay with a **"Hold image → Save to Photos"** prompt the user can act on.
- Desktop path unchanged: still triggers a normal file download.
- FAB button visibility is now restored in the `finally` block so it's never left invisible if an error occurs mid-capture.

## Test plan

- [ ] Tap the camera button on iOS — share sheet appears with "Save Image" option → tapping it saves to Photos
- [ ] On an older iOS / PWA context where `canShare` returns false — overlay appears with the screenshot and hold-to-save hint
- [ ] Tapping "Done" or the backdrop closes the overlay
- [ ] On desktop — clicking the button triggers a file download as before
- [ ] If capture errors mid-way, the camera button reappears (not left invisible)

https://claude.ai/code/session_01Ck1VvSEtv4oKW5cnTonBDc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ck1VvSEtv4oKW5cnTonBDc)_