### PR TITLE
Decouple expansion-pair rounding test from live workbook

### DIFF
--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -65,7 +65,8 @@ class TestIntegerRounding(unittest.TestCase):
 
     def test_equal_inputs_round_to_equal_outputs(self):
         """``_round_to_budget`` must give equal-value inputs the same
-        rounded output, regardless of where they sit in the list.
+        rounded output, both inside and outside the deficit-incremented
+        block.
 
         The workbook's expansion-pair averaging (R1 picks 1+2 sharing a
         value, etc.) is operator-chosen and varies year-to-year — the
@@ -74,18 +75,38 @@ class TestIntegerRounding(unittest.TestCase):
         use asymmetric pick values. This synthetic version pins the
         rounding function's own invariant so it stays meaningful
         regardless of workbook content.
+
+        Two scenarios are exercised:
+          1. A high-remainder pair that sits INSIDE the +1 allocation
+             block (both indices receive the deficit increment).
+          2. A low-remainder pair that sits OUTSIDE the +1 allocation
+             block (neither index receives it). The prior version only
+             covered case 1, which let a position-dependent regression
+             for later indices slip through.
         """
         import server
-        # 72 picks summing to 1200 with deliberate duplicates at head
-        # (idx 0, 1) and mid-list (idx 12, 13) so the equality
-        # invariant is exercised at both ends of the tie-break order.
-        values = [16.5] * 71
-        values.append(1200 - sum(values))  # tail value normalises the sum
+
+        # Scenario 1 — pair inside the +1 block, pair outside.
+        # 72 picks: 36 with remainder 0.9 (idx 0..35, top of sort),
+        # 36 with remainder 0.1 (idx 36..71, bottom of sort).
+        # floors sum = 36*10 + 36*10 = 720. Pad with a flat pick value
+        # so the deficit allocation lands exactly at the boundary
+        # between the two remainder tiers: top 36 indices get +1.
+        values = [10.9] * 36 + [10.1] * 36
+        # Normalise to exactly 1200.
+        deficit = 1200 - sum(values)
+        values[-1] += deficit
         rounded = server._round_to_budget(values, 1200)
+
+        # Pair at the head — both indices fall inside the +1 block.
         self.assertEqual(rounded[0], rounded[1],
-                         f"equal inputs at idx 0/1 produced {rounded[0]} != {rounded[1]}")
-        self.assertEqual(rounded[12], rounded[13],
-                         f"equal inputs at idx 12/13 produced {rounded[12]} != {rounded[13]}")
+                         f"head-pair: {rounded[0]} != {rounded[1]}")
+        # Pair near the middle of the +1 block.
+        self.assertEqual(rounded[20], rounded[21],
+                         f"mid-block: {rounded[20]} != {rounded[21]}")
+        # Pair outside the +1 block — equal inputs at low remainders.
+        self.assertEqual(rounded[50], rounded[51],
+                         f"outside-block: {rounded[50]} != {rounded[51]}")
 
 
 class TestApiOutput(unittest.TestCase):

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -63,17 +63,29 @@ class TestIntegerRounding(unittest.TestCase):
         for i, v in enumerate(rounded):
             self.assertIsInstance(v, int, f"rounded[{i}] is {type(v)}")
 
-    def test_expansion_picks_equal_after_rounding(self):
-        """Picks 1 and 2 in each round should be equal (same input value
-        produces same rounded output)."""
+    def test_equal_inputs_round_to_equal_outputs(self):
+        """``_round_to_budget`` must give equal-value inputs the same
+        rounded output, regardless of where they sit in the list.
+
+        The workbook's expansion-pair averaging (R1 picks 1+2 sharing a
+        value, etc.) is operator-chosen and varies year-to-year — the
+        prior test pinned this property indirectly via the live sheet
+        and false-failed once the operator hand-edited the workbook to
+        use asymmetric pick values. This synthetic version pins the
+        rounding function's own invariant so it stays meaningful
+        regardless of workbook content.
+        """
         import server
-        _, workbook_picks, _, _, _, _ = _load()
-        values = [wp["value"] for wp in workbook_picks]
+        # 72 picks summing to 1200 with deliberate duplicates at head
+        # (idx 0, 1) and mid-list (idx 12, 13) so the equality
+        # invariant is exercised at both ends of the tie-break order.
+        values = [16.5] * 71
+        values.append(1200 - sum(values))  # tail value normalises the sum
         rounded = server._round_to_budget(values, 1200)
-        for rnd in range(6):
-            idx = rnd * 12
-            self.assertEqual(rounded[idx], rounded[idx + 1],
-                             f"R{rnd+1}: pick1={rounded[idx]} != pick2={rounded[idx+1]}")
+        self.assertEqual(rounded[0], rounded[1],
+                         f"equal inputs at idx 0/1 produced {rounded[0]} != {rounded[1]}")
+        self.assertEqual(rounded[12], rounded[13],
+                         f"equal inputs at idx 12/13 produced {rounded[12]} != {rounded[13]}")
 
 
 class TestApiOutput(unittest.TestCase):


### PR DESCRIPTION
## Summary

PR validation is currently red on every PR because `test_expansion_picks_equal_after_rounding` reads pick values from the live Draft Data workbook (Q45:Q116) and asserts that R1 picks 1+2 (and each subsequent round's first pair) round to the same dollar value.

That invariant only holds when the workbook column is **expansion-pair-averaged** — which is operator-chosen and not guaranteed. After the latest hand-maintenance pass (workbook now has R1 picks at $134.50 and $100.50 instead of the previous symmetric pair), the assertion fails with `R1: pick1=135 != pick2=101` and blocks every open PR's CI.

Replace with `test_equal_inputs_round_to_equal_outputs`: a synthetic-input test that pins `_round_to_budget`'s own equality-preservation property — equal-value inputs must produce equal rounded outputs at any position in the list — without depending on workbook content.

## Test plan

- [x] `python -m pytest tests/api/test_draft_capital.py -q` → 15 passed
- [x] Full suite (excluding `test_push_delivery` requiring `pywebpush` build): 2839 passed, 5 skipped
- [ ] CI green on this PR → unblocks PR #432 and any other open PRs

https://claude.ai/code/session_01Ck1VvSEtv4oKW5cnTonBDc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ck1VvSEtv4oKW5cnTonBDc)_