### PR TITLE
fix(fantasycalc): mark as non-TEP-native so global multiplier applies

### DIFF
--- a/config/sources/dlf_sources.template.json
+++ b/config/sources/dlf_sources.template.json
@@ -139,9 +139,9 @@
       "ingest_type": "api_fetch",
       "ingest_method": "json_api",
       "source_url": "https://www.fantasycalc.com/dynasty-rankings",
-      "scoring_context": "dynasty superflex TE-premium (FantasyCalc crowd-sourced trade values via api.fantasycalc.com)",
+      "scoring_context": "dynasty superflex (FantasyCalc crowd-sourced trade values via api.fantasycalc.com)",
       "includes_sf": true,
-      "includes_tep": true,
+      "includes_tep": false,
       "file": "CSVs/site_raw/fantasyCalc.csv",
       "signal_type": "value",
       "scope": {
@@ -149,7 +149,7 @@
         "depth": 450,
         "is_backbone": false
       },
-      "notes": "FantasyCalc dynasty SF + TEP crowd values via public JSON API (api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1). Natively includes both Superflex and TE-premium pricing — do NOT re-apply SF or TEP adjustments. Picks (position PICK) are dropped at fetch time; player rows cover QB/RB/WR/TE."
+      "notes": "FantasyCalc dynasty SF crowd values via public JSON API (api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1). Standard SF (numQbs=2) — the crowd does NOT natively price in TE premium, so the global TEP multiplier applies on top of this source's blended contribution. Picks (position PICK) are dropped at fetch time; player rows cover QB/RB/WR/TE."
     },
     {
       "enabled": true,

--- a/config/weights/default_weights.json
+++ b/config/weights/default_weights.json
@@ -7,7 +7,7 @@
     "DLF_IDP": "DLF Dynasty League Football full-board IDP expert consensus (185 players, DL/LB/DB together). Rank-based signal, blended via coverage-aware mean.",
     "FANTASYPROS_SF": "FantasyPros Dynasty Superflex offense expert consensus. Rank-based signal (~250 QB/RB/WR/TE players).",
     "DYNASTY_DADDY_SF": "Dynasty Daddy Superflex crowd-sourced trade values via JSON API. Value-based signal (~320 QB/RB/WR/TE players). Standard SF — no TE premium.",
-    "FANTASYCALC": "FantasyCalc Dynasty SF-TEP crowd-sourced trade values via public JSON API (api.fantasycalc.com). Value-based signal (~450 QB/RB/WR/TE players). Natively sized to Superflex + TE-premium.",
+    "FANTASYCALC": "FantasyCalc Dynasty SF crowd-sourced trade values via public JSON API (api.fantasycalc.com). Value-based signal (~450 QB/RB/WR/TE players). Standard SF (numQbs=2) — the crowd does NOT natively price in TE premium, so the global tepMultiplier applies on top of this source's contribution.",
     "FLOCK_FANTASY_SF": "Flock Fantasy Superflex expert consensus averaged ranks via JSON API. Rank-based signal (~370 QB/RB/WR/TE players). Standard SF — no TE premium.",
     "FOOTBALLGUYS_SF": "FootballGuys Dynasty Rankings — offense half (QB/RB/WR/TE) of the user-managed PDF export, 6-expert consensus. Rank-based signal (~540 players).",
     "FOOTBALLGUYS_IDP": "FootballGuys Dynasty Rankings — IDP half (DE/DT/LB/CB/S) of the same PDF export, 3-expert consensus. Rank-based signal (~400 players), translates through the shared-market IDP ladder.",

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -418,24 +418,24 @@ export const RANKING_SOURCES = [
     isTepPremium: true,
   },
   {
-    // FantasyCalc Dynasty Superflex + TE-premium trade values —
-    // crowd-sourced community values fetched from the public JSON API
-    // at api.fantasycalc.com/values/current
+    // FantasyCalc Dynasty Superflex trade values — crowd-sourced
+    // community values fetched from the public JSON API at
+    // api.fantasycalc.com/values/current
     // (?isDynasty=true&numQbs=2&numTeams=12&ppr=1) via
     // scripts/fetch_fantasycalc.py.  Same board that powers
     // https://www.fantasycalc.com/dynasty-rankings.  ~450+ offensive
     // players (QB/RB/WR/TE) after filtering.  Mirrors the backend
     // `_RANKING_SOURCES` entry in src/api/data_contract.py.
     //
-    // FantasyCalc's dynasty SF crowd is voting under TE-premium
-    // scoring with numQbs=2 baked in, so this is a TEP-native source.
-    // Flagged `isTepPremium: true` so the frontend surfaces a "TEP
-    // NATIVE" badge and the global tepMultiplier boost does NOT
-    // compound on top of this source.  Signal=value: FantasyCalc's
-    // value distribution is well-spread (no display ceiling), so the
-    // value-direct path preserves cross-position separation.
+    // FantasyCalc is standard Superflex (numQbs=2) but does NOT
+    // natively account for TE premium — declared `isTepPremium:
+    // false` so the global tepMultiplier boost applies to its
+    // contribution, just like Dynasty Daddy SF or FlockFantasy SF.
+    // Signal=value: FantasyCalc's value distribution is well-spread
+    // (no display ceiling), so the value-direct path preserves
+    // cross-position separation.
     key: "fantasyCalc",
-    displayName: "FantasyCalc Dynasty SF-TEP",
+    displayName: "FantasyCalc Dynasty SF",
     columnLabel: "FC",
     scope: "overall_offense",
     extraScopes: [],
@@ -445,7 +445,7 @@ export const RANKING_SOURCES = [
     isBackbone: false,
     isRetail: false,
     isRankSignal: false,
-    isTepPremium: true,
+    isTepPremium: false,
     needsSharedMarketTranslation: false,
     excludesRookies: false,
   },

--- a/scripts/fetch_fantasycalc.py
+++ b/scripts/fetch_fantasycalc.py
@@ -12,18 +12,20 @@ data backs the public board at https://www.fantasycalc.com/dynasty-rankings.
 Query parameters
 ----------------
 
-Dynasty Superflex + TE Premium scoring is requested via::
+Dynasty Superflex scoring is requested via::
 
     isDynasty=true   — dynasty (vs redraft) values
     numQbs=2         — Superflex (two QB slots)
     numTeams=12      — 12-team league context
     ppr=1            — full PPR
 
-FantasyCalc's standard dynasty/SF crowd values natively bake in the
-Superflex QB premium.  We do NOT re-apply SF adjustments downstream —
-``includes_sf=True`` in ``config/sources``, and the registry entry
-sets ``is_tep_premium=True`` so the global TEP multiplier does not
-compound on top of FantasyCalc's blended contribution.
+FantasyCalc's dynasty SF crowd values natively bake in the Superflex
+QB premium (numQbs=2), so ``includes_sf=True`` in ``config/sources``
+and no extra SF adjustment is applied downstream.  The crowd does
+NOT natively price in TE premium, so the registry entry sets
+``is_tep_premium=False`` and the global ``tepMultiplier`` boost
+applies to this source's blended contribution like any other non-
+TEP-native SF board (Dynasty Daddy, FlockFantasy, etc.).
 
 Output CSV
 ----------

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -293,10 +293,10 @@ _SOURCE_CSV_PATHS: dict[str, Any] = {
         "path": "CSVs/site_raw/fantasyProsIdp.csv",
         "signal": "rank",
     },
-    # FantasyCalc dynasty Superflex + TE-premium trade values —
-    # fetched from the public JSON API at
-    # https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1
-    # via ``scripts/fetch_fantasycalc.py``.  Same crowd-sourced board
+    # FantasyCalc dynasty Superflex trade values — fetched from the
+    # public JSON API at https://api.fantasycalc.com/values/current
+    # (?isDynasty=true&numQbs=2&numTeams=12&ppr=1) via
+    # ``scripts/fetch_fantasycalc.py``.  Same crowd-sourced board
     # that powers https://www.fantasycalc.com/dynasty-rankings.  We
     # filter to offensive positions (QB/RB/WR/TE) and write a
     # ``name,value,rank`` CSV.  Signal=value — FantasyCalc's value
@@ -305,6 +305,9 @@ _SOURCE_CSV_PATHS: dict[str, Any] = {
     # board's top to 9999 linearly and preserves cross-position
     # separation.  Picks (position "PICK") are dropped here and
     # tethered to rookie values in a dedicated downstream phase.
+    # Standard SF scoring — values are NOT TE-premium native, so the
+    # frontend ``tepMultiplier`` boost applies on top of the blended
+    # contribution (registry entry sets ``is_tep_premium=False``).
     "fantasyCalc": {
         "path": "CSVs/site_raw/fantasyCalc.csv",
         "signal": "value",
@@ -1115,9 +1118,9 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_tep_premium": True,
     },
     {
-        # FantasyCalc Dynasty Superflex + TE-premium trade values —
-        # crowd-sourced community values fetched from the public JSON
-        # API at https://api.fantasycalc.com/values/current
+        # FantasyCalc Dynasty Superflex trade values — crowd-sourced
+        # community values fetched from the public JSON API at
+        # https://api.fantasycalc.com/values/current
         # (?isDynasty=true&numQbs=2&numTeams=12&ppr=1) via
         # ``scripts/fetch_fantasycalc.py``.  Same board that powers
         # https://www.fantasycalc.com/dynasty-rankings.  The API
@@ -1133,21 +1136,22 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # so FantasyCalc is not expected for players ranked deeper
         # than ~562.
         #
-        # FantasyCalc's standard dynasty SF crowd values natively bake
-        # in both Superflex and TE-premium pricing (the API params set
-        # numQbs=2 and the crowd is voting under TE-premium scoring),
-        # so this is a TEP-native source: only the small 1.10× nudge
-        # toward the operator's TE++ baseline applies, never the full
-        # non-TEP 1.25×.
+        # FantasyCalc's crowd values are standard Superflex (numQbs=2)
+        # but DO NOT bake in TE-premium pricing — there's no
+        # ``teBonus`` knob on the API that meaningfully tracks our
+        # TE++ league, and crowd voting on the underlying board is
+        # standard SF.  Declared ``is_tep_premium=False`` so the
+        # frontend ``settings.tepMultiplier`` boost applies to its
+        # blended contribution like Dynasty Daddy SF or FlockFantasy.
         "key": "fantasyCalc",
-        "display_name": "FantasyCalc Dynasty SF-TEP",
+        "display_name": "FantasyCalc Dynasty SF",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "position_group": None,
         "depth": 450,
         "weight": 1.0,
         "is_backbone": False,
         "is_retail": False,
-        "is_tep_premium": True,
+        "is_tep_premium": False,
         "needs_shared_market_translation": False,
         "excludes_rookies": False,
     },


### PR DESCRIPTION
## Summary

Follow-up to #435 — the original PR marked the FantasyCalc source as `is_tep_premium=True` on the (incorrect) assumption that the crowd values bake in TE-premium pricing. They don't: the FantasyCalc API only meaningfully toggles SF via `numQbs=2`, and the crowd votes against standard SF scoring with no native TEP variant.

**Net effect of the bug**: the global `tepMultiplier` boost was suppressed for FantasyCalc's blend contribution while the underlying values had no TEP baked in → TEs underweighted in the blend.

## Fix

Flip `is_tep_premium` to `false` everywhere:

- `src/api/data_contract.py` — `_RANKING_SOURCES` entry + `_SOURCE_CSV_PATHS` comment
- `frontend/lib/dynasty-data.js` — mirror entry
- `config/sources/dlf_sources.template.json` — `includes_tep: false`, `scoring_context` and `notes` updated
- `config/weights/default_weights.json` — `weight_rationale` updated
- `scripts/fetch_fantasycalc.py` — docstring corrected

Display label: `FantasyCalc Dynasty SF-TEP` → `FantasyCalc Dynasty SF` so the UI no longer claims TEP-native. `includes_sf` stays True (numQbs=2 is genuinely baked in).

FantasyCalc is now treated identically to Dynasty Daddy SF and FlockFantasy SF: standard SF crowd values with the global `tepMultiplier` applied on top of the blended contribution.

## Test plan

- [x] `tests/api/test_source_registry_parity.py` passes (backend/frontend lockstep maintained)
- [x] `tests/adapters/test_source_config_completeness.py` passes (TEP flag presence check still satisfied)
- [x] `tests/api/test_trust_confidence.py` passes (source count and key set unchanged)
- [x] Full pytest sweep: 2850 passed, 5 skipped
- [ ] Verify in production that the FantasyCalc column on /rankings reflects the TEP multiplier when `settings.tepMultiplier > 1` (TE values shift relative to non-TE)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvZf37QSUMBjFZFGPCYu2S)_