### PR TITLE
Contract-coverage watchdog: catch fetched-but-absent sources

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -486,6 +486,23 @@ jobs:
           set -Eeuo pipefail
           python scripts/watchdog_freshness.py
 
+      - name: Contract coverage watchdog
+        # Sibling to the freshness watchdog.  Freshness asks "did the
+        # fetcher run?"; this asks "did the fetched data actually land
+        # in the board the server will serve?".  Builds the contract
+        # exactly as ``server._prime_latest_payload`` does and fails
+        # the run if a *fresh* registered source covers ~0 players —
+        # the silent registry / enrich / prime-timing regression that
+        # let ``otcffbSf`` be fetched + committed yet absent from the
+        # live board with no error anywhere.  ``if: always()`` so a
+        # partial earlier failure still gets the red X plus the
+        # failure-handler issue.
+        if: always()
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python scripts/watchdog_contract_coverage.py
+
       - name: Alert on workflow failure
         # When the run fails (scrape crash, DLF guard tripped,
         # staleness watchdog red, etc.) open or update a tracking

--- a/scripts/watchdog_contract_coverage.py
+++ b/scripts/watchdog_contract_coverage.py
@@ -1,0 +1,266 @@
+"""Contract-coverage watchdog — fails the scheduled-refresh workflow when
+a registered ranking source is *fresh* (its CSV was fetched within
+threshold) yet is **absent from the built contract** the server will
+serve.
+
+This is the sibling of ``scripts/watchdog_freshness.py``.  Freshness
+answers "did the fetcher run recently?".  Coverage answers "did that
+fetched data actually make it into the board?".  They are different
+failure modes:
+
+  * A fetcher dies         → freshness watchdog turns the run red.
+  * A fetcher succeeds, the CSV is committed, but the source never
+    appears in the served board (registry/enrich/timing regression)
+    → only THIS watchdog catches it.
+
+The second mode is exactly the one the operator hit: ``otcffbSf.csv``
+was fetched and committed, but the served board carried zero OTCFFB
+coverage, so isolating OTCFFB on the rankings page produced fallback
+behaviour with no error anywhere.  Nothing asserted that a registered
+source actually lands in the contract.  Now something does.
+
+Method: build the contract the same way ``server._prime_latest_payload``
+does (newest ``dynasty_data_*.json`` → ``build_api_data_contract`` →
+``_enrich_from_source_csvs``), then count, per source, how many
+``playersArray`` rows carry that key in ``sourceRankMeta`` (membership
+there == "this source contributed to the blend", independent of
+value/rank signal type).  A registered source that is fresh but covers
+fewer than ``_MIN_COVERAGE`` players is reported.
+
+Why gate on freshness: a stale source is already the freshness
+watchdog's responsibility; double-reporting it here would just add
+noise.  This guard's unique signal is *fresh-but-absent*.
+
+Why ``_MIN_COVERAGE = 5``: the smallest legitimately-sparse registered
+source observed in a healthy build is the DLF rookie-IDP board at ~27
+covered players.  A floor of 5 trips only on the genuine
+absent/near-absent regression and leaves wide margin against the
+smallest real source, so it will not flake.
+
+Exit codes:
+  0 — every fresh registered source has real coverage
+  1 — at least one fresh registered source is missing from the board,
+      or the contract could not be built / no export was found
+
+Output: human-readable stdout, GitHub Actions ``::error::``
+annotations per offending source, and a step-summary table.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow ``python scripts/watchdog_contract_coverage.py`` from repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.api.data_contract import (  # noqa: E402
+    _RANKING_SOURCES,
+    _SOURCE_CSV_PATHS,
+    build_api_data_contract,
+)
+from src.api.source_health_alerts import (  # noqa: E402
+    load_thresholds,
+    resolve_threshold,
+)
+
+# Reuse the freshness watchdog's stamp-or-mtime reader verbatim so the
+# two watchdogs agree byte-for-byte on which sources are "fresh".
+from scripts.watchdog_freshness import _read_freshness  # noqa: E402
+
+# A fresh registered source covering fewer than this many players in
+# the built contract is treated as absent.  See module docstring for
+# the justification of this floor.
+_MIN_COVERAGE = 5
+
+
+def _find_latest_export() -> Path | None:
+    """Newest ``dynasty_data_*.json`` the server would prime from.
+
+    Mirrors ``server.py``'s lookup order: the ``exports/latest``
+    directory first, then a repo-root fallback.  Newest filename wins
+    (the date is embedded in the name); mtime breaks ties.
+    """
+    candidates: list[Path] = []
+    for base in (_REPO_ROOT / "exports" / "latest", _REPO_ROOT):
+        if base.is_dir():
+            candidates.extend(base.glob("dynasty_data_*.json"))
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda p: (p.name, p.stat().st_mtime))[-1]
+
+
+def _source_coverage(contract: dict) -> dict[str, int]:
+    """# of playersArray rows whose ``sourceRankMeta`` carries each key.
+
+    Membership in ``sourceRankMeta`` means the source contributed a
+    rank/value to that row's blend — the same signal the value-chain
+    UI surfaces — so it is the precise "did this source land on the
+    board" measure, independent of whether the source is value- or
+    rank-based.
+    """
+    cov: dict[str, int] = {}
+    for row in contract.get("playersArray") or []:
+        for key in (row.get("sourceRankMeta") or {}):
+            cov[key] = cov.get(key, 0) + 1
+    return cov
+
+
+def _csv_nonempty(source_key: str) -> bool:
+    """True when the source's CSV exists and has at least one data row.
+
+    A source whose CSV is genuinely empty has nothing to contribute and
+    must not be reported here — that is the fetcher's / freshness
+    watchdog's concern, not a coverage regression.
+    """
+    cfg = _SOURCE_CSV_PATHS.get(source_key)
+    csv_rel = cfg if isinstance(cfg, str) else (cfg or {}).get("path")
+    if not csv_rel:
+        return False
+    csv_path = _REPO_ROOT / csv_rel
+    try:
+        with csv_path.open("r", encoding="utf-8") as f:
+            # header + >=1 data row
+            return sum(1 for _ in zip(range(2), f)) >= 2
+    except OSError:
+        return False
+
+
+def evaluate_coverage(
+    contract: dict,
+    freshness: dict[str, dict],
+    thresholds: dict,
+) -> tuple[list[tuple[str, int]], list[tuple[str, int]], list[str]]:
+    """Pure decision core (kept IO-free so it is unit-testable).
+
+    Returns ``(violations, ok, skipped)`` where:
+      * violations — [(source_key, coverage)] fresh + CSV-non-empty
+        registered sources below ``_MIN_COVERAGE`` (the regression).
+      * ok         — [(source_key, coverage)] healthy registered
+        sources.
+      * skipped    — source keys not evaluated because they are stale
+        (owned by the freshness watchdog) or have an empty/missing CSV.
+    """
+    cov = _source_coverage(contract)
+    registered = [str(s.get("key") or "") for s in _RANKING_SOURCES]
+
+    violations: list[tuple[str, int]] = []
+    ok: list[tuple[str, int]] = []
+    skipped: list[str] = []
+
+    for key in sorted(k for k in registered if k):
+        info = freshness.get(key)
+        threshold = resolve_threshold(key, thresholds)
+        is_fresh = (
+            info is not None
+            and float(info.get("ageHours", 0.0)) <= threshold
+        )
+        if not is_fresh or not _csv_nonempty(key):
+            # Stale → freshness watchdog already owns it.
+            # Empty/missing CSV → nothing to land; not a coverage bug.
+            skipped.append(key)
+            continue
+        c = int(cov.get(key, 0))
+        if c < _MIN_COVERAGE:
+            violations.append((key, c))
+        else:
+            ok.append((key, c))
+    return violations, ok, skipped
+
+
+def _write_summary(
+    violations: list[tuple[str, int]],
+    ok: list[tuple[str, int]],
+    skipped: list[str],
+) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    lines = ["## Contract coverage watchdog", ""]
+    if violations:
+        lines += [
+            "### Fresh sources MISSING from the built board",
+            "",
+            "| source | players covered | floor |",
+            "|---|---|---|",
+        ]
+        lines += [
+            f"| `{k}` | {c} | {_MIN_COVERAGE} |" for k, c in violations
+        ]
+        lines.append("")
+    lines += [
+        "### Healthy sources",
+        "",
+        "| source | players covered |",
+        "|---|---|",
+    ]
+    lines += [f"| `{k}` | {c} |" for k, c in ok]
+    if skipped:
+        lines += ["", f"_Skipped (stale or empty CSV): {', '.join(skipped)}_"]
+    try:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    export = _find_latest_export()
+    if export is None:
+        print(
+            "::error title=No contract export::No dynasty_data_*.json "
+            "found under exports/latest/ — the scrape never produced a "
+            "board, so coverage cannot be verified."
+        )
+        return 1
+
+    try:
+        with export.open("r", encoding="utf-8") as f:
+            raw = json.load(f)
+        contract = build_api_data_contract(raw)
+    except Exception as exc:  # noqa: BLE001 — any failure here is fatal
+        print(
+            f"::error title=Contract build failed::Could not build the "
+            f"contract from {export.name}: {exc!r}.  The served board "
+            f"would be broken."
+        )
+        return 1
+
+    freshness = _read_freshness()
+    thresholds = load_thresholds()
+    violations, ok, skipped = evaluate_coverage(
+        contract, freshness, thresholds
+    )
+
+    _write_summary(violations, ok, skipped)
+
+    if not violations:
+        print(
+            f"ok: {len(ok)} registered source(s) covered, "
+            f"0 fresh-but-absent ({len(skipped)} skipped: stale/empty)"
+        )
+        return 0
+
+    for key, c in violations:
+        print(
+            f"::error title=Source absent from board: {key}::"
+            f"{key} is fresh (CSV fetched within threshold) but only "
+            f"{c} player(s) carry it in the built contract "
+            f"(floor {_MIN_COVERAGE}).  The fetched CSV is not reaching "
+            f"the served board — check the registry / "
+            f"_enrich_from_source_csvs / prime-payload timing, NOT the "
+            f"fetcher (the freshness watchdog would have caught a dead "
+            f"fetcher)."
+        )
+    print(
+        f"\nfail: {len(violations)} fresh source(s) missing from the "
+        f"board: {', '.join(k for k, _ in violations)}"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/watchdog_contract_coverage.py
+++ b/scripts/watchdog_contract_coverage.py
@@ -80,17 +80,24 @@ _MIN_COVERAGE = 5
 def _find_latest_export() -> Path | None:
     """Newest ``dynasty_data_*.json`` the server would prime from.
 
-    Mirrors ``server.py``'s lookup order: the ``exports/latest``
-    directory first, then a repo-root fallback.  Newest filename wins
-    (the date is embedded in the name); mtime breaks ties.
+    Mirrors ``server.py``'s lookup order *exactly*: it tries the
+    ``exports/latest`` directory first and only falls back to the
+    repo root when that directory yields nothing — a strict
+    precedence, not a global newest-wins.  Pooling both locations
+    and taking the global max would let a repo-root snapshot (which
+    some scraper runs also write) shadow the ``exports/latest``
+    artifact the runtime actually serves, so the watchdog would
+    validate the wrong contract.  Within the chosen directory the
+    newest filename wins (the date is embedded in the name); mtime
+    breaks ties.
     """
-    candidates: list[Path] = []
     for base in (_REPO_ROOT / "exports" / "latest", _REPO_ROOT):
-        if base.is_dir():
-            candidates.extend(base.glob("dynasty_data_*.json"))
-    if not candidates:
-        return None
-    return sorted(candidates, key=lambda p: (p.name, p.stat().st_mtime))[-1]
+        if not base.is_dir():
+            continue
+        found = list(base.glob("dynasty_data_*.json"))
+        if found:
+            return sorted(found, key=lambda p: (p.name, p.stat().st_mtime))[-1]
+    return None
 
 
 def _source_coverage(contract: dict) -> dict[str, int]:

--- a/scripts/watchdog_contract_coverage.py
+++ b/scripts/watchdog_contract_coverage.py
@@ -80,18 +80,34 @@ _MIN_COVERAGE = 5
 def _find_latest_export() -> Path | None:
     """Newest ``dynasty_data_*.json`` the server would prime from.
 
-    Mirrors ``server.py``'s lookup order *exactly*: it tries the
-    ``exports/latest`` directory first and only falls back to the
-    repo root when that directory yields nothing — a strict
-    precedence, not a global newest-wins.  Pooling both locations
-    and taking the global max would let a repo-root snapshot (which
-    some scraper runs also write) shadow the ``exports/latest``
-    artifact the runtime actually serves, so the watchdog would
-    validate the wrong contract.  Within the chosen directory the
-    newest filename wins (the date is embedded in the name); mtime
-    breaks ties.
+    Mirrors ``server.py``'s real disk-bootstrap precedence — a strict
+    first-non-empty-wins, not a global newest-across-all-locations:
+
+      1. ``data/`` (``server.DATA_DIR``) — what ``load_from_disk`` and
+         ``_latest_cached_contract_from_disk`` read FIRST; the live
+         runtime source the deployed server actually primes from.
+      2. ``exports/latest/`` — the git-committed snapshot.  PR-CI
+         never runs a scrape, so ``data/`` is empty there and this is
+         the only artifact present; it is also what
+         ``tests/api/test_player_identity_regression.py`` and the
+         project docs treat as "the file the live server reads".
+      3. repo root (``server.BASE_DIR``) — ``load_from_disk``'s
+         documented fallback for standalone scraper runs.
+
+    Earlier revisions checked ``exports/latest`` before ``data/`` (or
+    pooled locations and took a global max).  Both are wrong: the
+    server reads ``data/`` first, so a ``data/``-only snapshot must
+    win, and a stray repo-root file must never shadow the prioritized
+    artifact — otherwise the watchdog validates the wrong contract or
+    false-fails the workflow when a valid board exists only under
+    ``data/``.  Within the chosen directory the newest filename wins
+    (the date is embedded in the name); mtime breaks ties.
     """
-    for base in (_REPO_ROOT / "exports" / "latest", _REPO_ROOT):
+    for base in (
+        _REPO_ROOT / "data",
+        _REPO_ROOT / "exports" / "latest",
+        _REPO_ROOT,
+    ):
         if not base.is_dir():
             continue
         found = list(base.glob("dynasty_data_*.json"))

--- a/tests/api/test_contract_coverage_watchdog.py
+++ b/tests/api/test_contract_coverage_watchdog.py
@@ -1,0 +1,108 @@
+"""Regression coverage for ``scripts/watchdog_contract_coverage.py``.
+
+Pins the watchdog's purpose: a registered ranking source that is
+*fresh* (CSV fetched within threshold) yet absent from the built
+contract must be reported, while stale or empty-CSV sources must NOT
+be (those belong to the freshness watchdog / fetcher).
+
+This is the exact regression the operator hit: ``otcffbSf`` was
+fetched and committed but covered zero players in the served board,
+with no error anywhere.  These tests fail if that silent path ever
+reopens.
+
+The decision core ``evaluate_coverage`` is pure, so the tests drive
+it with synthetic contracts / freshness and monkeypatch the single
+filesystem touch (``_csv_nonempty``) for determinism.  ``thresholds``
+is left empty so ``resolve_threshold`` returns its 24h default; an
+``ageHours`` of 0 is therefore unambiguously fresh and 9999 stale.
+"""
+from __future__ import annotations
+
+import unittest
+
+from scripts import watchdog_contract_coverage as wcc
+
+# A real key from the ranking registry — the one the operator's
+# incident was about.
+_KEY = "otcffbSf"
+
+
+def _contract_with_coverage(key: str, n_covered: int, n_total: int = 50) -> dict:
+    """Synthetic contract: ``n_covered`` rows carry ``key`` in
+    ``sourceRankMeta``; the remaining rows carry an unrelated key so
+    the board is non-trivial."""
+    rows = []
+    for i in range(n_total):
+        meta = {key: {"effectiveRank": i + 1}} if i < n_covered else {"ktcSfTep": {}}
+        rows.append({"sourceRankMeta": meta})
+    return {"playersArray": rows}
+
+
+class TestEvaluateCoverage(unittest.TestCase):
+    def setUp(self):
+        # Default: pretend every CSV is non-empty so the test isolates
+        # the coverage dimension.  Individual tests override.
+        self._orig = wcc._csv_nonempty
+        wcc._csv_nonempty = lambda _k: True
+
+    def tearDown(self):
+        wcc._csv_nonempty = self._orig
+
+    def test_fresh_source_absent_is_a_violation(self):
+        contract = _contract_with_coverage(_KEY, 0)
+        freshness = {_KEY: {"ageHours": 0.0}}
+        violations, ok, skipped = wcc.evaluate_coverage(
+            contract, freshness, {}
+        )
+        self.assertIn((_KEY, 0), violations)
+        self.assertNotIn(_KEY, [k for k, _ in ok])
+
+    def test_fresh_source_below_floor_is_a_violation(self):
+        contract = _contract_with_coverage(_KEY, wcc._MIN_COVERAGE - 1)
+        freshness = {_KEY: {"ageHours": 1.0}}
+        violations, _ok, _sk = wcc.evaluate_coverage(contract, freshness, {})
+        self.assertEqual(
+            [v for v in violations if v[0] == _KEY],
+            [(_KEY, wcc._MIN_COVERAGE - 1)],
+        )
+
+    def test_fresh_source_well_covered_is_ok(self):
+        contract = _contract_with_coverage(_KEY, 40)
+        freshness = {_KEY: {"ageHours": 0.0}}
+        violations, ok, _sk = wcc.evaluate_coverage(contract, freshness, {})
+        self.assertNotIn(_KEY, [k for k, _ in violations])
+        self.assertIn((_KEY, 40), ok)
+
+    def test_stale_absent_source_is_skipped_not_a_violation(self):
+        # Stale → the freshness watchdog owns it; this guard must stay
+        # silent to avoid double-reporting the same outage.
+        contract = _contract_with_coverage(_KEY, 0)
+        freshness = {_KEY: {"ageHours": 9999.0}}
+        violations, _ok, skipped = wcc.evaluate_coverage(
+            contract, freshness, {}
+        )
+        self.assertNotIn(_KEY, [k for k, _ in violations])
+        self.assertIn(_KEY, skipped)
+
+    def test_empty_csv_source_is_skipped_not_a_violation(self):
+        # A genuinely empty CSV has nothing to land — not a coverage
+        # regression.
+        wcc._csv_nonempty = lambda _k: False
+        contract = _contract_with_coverage(_KEY, 0)
+        freshness = {_KEY: {"ageHours": 0.0}}
+        violations, _ok, skipped = wcc.evaluate_coverage(
+            contract, freshness, {}
+        )
+        self.assertNotIn(_KEY, [k for k, _ in violations])
+        self.assertIn(_KEY, skipped)
+
+    def test_unknown_source_not_in_freshness_is_skipped(self):
+        # No freshness entry → can't assert it should be present.
+        contract = _contract_with_coverage(_KEY, 0)
+        violations, _ok, skipped = wcc.evaluate_coverage(contract, {}, {})
+        self.assertEqual(violations, [])
+        self.assertIn(_KEY, skipped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_contract_coverage_watchdog.py
+++ b/tests/api/test_contract_coverage_watchdog.py
@@ -132,6 +132,29 @@ class TestFindLatestExport(unittest.TestCase):
                 wcc._REPO_ROOT = orig
             self.assertEqual(got, chosen_path)
 
+    def test_data_dir_wins_over_exports_latest(self):
+        # server.load_from_disk / _latest_cached_contract_from_disk read
+        # data/ FIRST, so a data/ snapshot must win even when
+        # exports/latest has a lexically-newer file (Codex PR #444 P2).
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "data").mkdir()
+            (root / "exports" / "latest").mkdir(parents=True)
+            (root / "exports" / "latest" / "dynasty_data_2999-12-31.json").write_text("{}")
+            chosen_path = root / "data" / "dynasty_data_2026-05-15.json"
+            chosen_path.write_text("{}")
+
+            orig = wcc._REPO_ROOT
+            wcc._REPO_ROOT = root
+            try:
+                got = wcc._find_latest_export()
+            finally:
+                wcc._REPO_ROOT = orig
+            self.assertEqual(got, chosen_path)
+
     def test_repo_root_fallback_when_exports_latest_empty(self):
         import tempfile
         from pathlib import Path

--- a/tests/api/test_contract_coverage_watchdog.py
+++ b/tests/api/test_contract_coverage_watchdog.py
@@ -104,5 +104,52 @@ class TestEvaluateCoverage(unittest.TestCase):
         self.assertIn(_KEY, skipped)
 
 
+class TestFindLatestExport(unittest.TestCase):
+    """exports/latest must win over a repo-root snapshot even when the
+    root file has a newer name — strict precedence, mirroring the
+    server's lookup order (Codex PR #444 P2)."""
+
+    def test_exports_latest_takes_strict_precedence(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            latest = root / "exports" / "latest"
+            latest.mkdir(parents=True)
+            # Root snapshot has a LEXICALLY-NEWER name than the
+            # exports/latest artifact; a global-max picker would
+            # wrongly choose it.
+            (root / "dynasty_data_2999-12-31.json").write_text("{}")
+            chosen_path = latest / "dynasty_data_2026-05-15.json"
+            chosen_path.write_text("{}")
+
+            orig = wcc._REPO_ROOT
+            wcc._REPO_ROOT = root
+            try:
+                got = wcc._find_latest_export()
+            finally:
+                wcc._REPO_ROOT = orig
+            self.assertEqual(got, chosen_path)
+
+    def test_repo_root_fallback_when_exports_latest_empty(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "exports" / "latest").mkdir(parents=True)  # empty
+            fallback = root / "dynasty_data_2026-05-15.json"
+            fallback.write_text("{}")
+
+            orig = wcc._REPO_ROOT
+            wcc._REPO_ROOT = root
+            try:
+                got = wcc._find_latest_export()
+            finally:
+                wcc._REPO_ROOT = orig
+            self.assertEqual(got, fallback)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Diagnosing why isolating OTCFFB on the rankings page didn't move Brock Bowers surfaced a real silent-failure gap (not a code bug — the ×1.25 and the blend are correct):

- `otcffbSf.csv` was fetched and committed to `CSVs/site_raw/`, but the **served board carried zero OTCFFB coverage**, so "OTCFFB only" produced fallback behavior with **no error anywhere**.
- The export JSON is intrinsically a 3-source artifact (legacy scraper); the full board only materializes when the server runs `build_api_data_contract` → `_enrich_from_source_csvs`. Rebuilding from the committed state proves the code is correct (Bowers #2 full / **#8** OTCFFB-only, `tepMultiplier: 1.25` applied).
- Nothing asserted that a registered source actually lands in the contract the server serves. The freshness watchdog (#437) only checks "did the fetcher run?", not "did the data reach the board?".

## What

Adds `scripts/watchdog_contract_coverage.py` (+ a `scheduled-refresh.yml` step) — a **sibling** to the freshness watchdog:

- Rebuilds the contract exactly as `server._prime_latest_payload` does (newest `dynasty_data_*.json` → `build_api_data_contract` → `_enrich_from_source_csvs`).
- Per-source coverage = # `playersArray` rows carrying the key in `sourceRankMeta` (the precise "contributed to the blend" signal; `siteStats` only ever lists the 3 core sources so it's unusable here).
- Fails the run when a **registered source that is FRESH and has a non-empty CSV** covers fewer than `_MIN_COVERAGE` (5) players — the fresh-but-absent regression. Floor justified: smallest legit sparse source in a healthy build is ~27.
- **Gates on freshness** so it never double-reports a stale source the freshness watchdog already owns. Unique signal: fetched-but-absent.
- Reuses `scripts.watchdog_freshness._read_freshness` and `source_health_alerts.{load_thresholds,resolve_threshold}` verbatim — no parallel logic to drift.
- Decision core `evaluate_coverage` is pure and unit-tested. The existing `Alert on workflow failure` step (`if: failure()`) already opens/updates the `stale-sources` issue, so coverage regressions now surface immediately.

## Test plan

- [x] `tests/api/test_contract_coverage_watchdog.py` — 6 cases (fresh-absent → violation, below-floor → violation, well-covered → ok, stale → skipped, empty-csv → skipped, unknown → skipped). Pass.
- [x] 23 watchdog/freshness tests pass; YAML validates.
- [x] `python scripts/watchdog_contract_coverage.py` against current committed state → `ok: 16 covered, 0 fresh-but-absent` (exit 0).
- [ ] CI `Validate PR` green.

Note: the OTCFFB symptom itself is operational (the running server primed before `otcffbSf.csv` landed); the next scrape/redeploy re-primes and picks it up. This PR ensures it can never silently happen again for any source.

https://claude.ai/code/session_01QFzUa9x5Rqpnkwtobtcn5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFzUa9x5Rqpnkwtobtcn5J)_