### PR TITLE
Fail loudly when prod serves a degraded (missing-sources) board

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -91,3 +91,54 @@ jobs:
           except Exception as e:
               print(f"Could not parse status: {e}")
           PY
+
+      - name: Check served-board source coverage
+        # Continuous defense-in-depth for the silent-degraded-board
+        # failure: the running process can serve the bare 3-source
+        # legacy export instead of the ~11-source enriched blend while
+        # every other health signal stays green (sites/source_health
+        # only ever list the 3 legacy sources, player_count looks
+        # normal).  ``served_source_coverage`` is the real per-source
+        # player count of the board being served right now.  A healthy
+        # board has ~16-21 covered sources; a degraded one has ~3.  A
+        # floor of 8 cleanly separates them with wide margin and
+        # tolerates a few legitimately-stale sources (e.g. idpShow).
+        # Dependency-free so this lean workflow needs no checkout.
+        if: always()
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          URL="${{ vars.PROD_PUBLIC_URL }}"
+          URL="${URL%/}"
+          HTTP_CODE=$(curl --silent --show-error --output /tmp/status_cov.json \
+            --write-out '%{http_code}' --max-time 20 "${URL}/api/status" || echo "000")
+          if [[ "${HTTP_CODE}" != "200" ]]; then
+            echo "::warning title=Status Unreachable::Coverage check skipped (HTTP ${HTTP_CODE})."
+            exit 0
+          fi
+          python3 - <<'PY'
+          import json, sys
+          MIN_PER_SOURCE = 5   # mirrors watchdog_contract_coverage._MIN_COVERAGE
+          MIN_SOURCES = 8      # healthy ~16-21; degraded ~3
+          with open("/tmp/status_cov.json") as f:
+              data = json.load(f)
+          cov = data.get("served_source_coverage")
+          if not isinstance(cov, dict) or not cov:
+              print("::error title=Degraded board::/api/status has no "
+                    "served_source_coverage — the live board is the bare "
+                    "3-source legacy export, not the enriched blend. The "
+                    "process did not re-prime from the CSVs.")
+              sys.exit(1)
+          covered = sorted(k for k, v in cov.items()
+                           if isinstance(v, (int, float)) and v >= MIN_PER_SOURCE)
+          print(f"Served sources (>= {MIN_PER_SOURCE} players): "
+                f"{len(covered)} -> {covered}")
+          if len(covered) < MIN_SOURCES:
+              print(f"::error title=Degraded live board::Only {len(covered)} "
+                    f"source(s) meaningfully cover the served board (need "
+                    f">= {MIN_SOURCES}). The process is serving a degraded "
+                    f"board (missing OTCFFB et al.). Restart the backend to "
+                    f"force a re-prime and investigate the deploy/prime path.")
+              sys.exit(1)
+          print("Served-board source coverage OK.")
+          PY

--- a/deploy/verify-deploy.sh
+++ b/deploy/verify-deploy.sh
@@ -307,6 +307,35 @@ main() {
     fi
   fi
 
+  # ── Served-board source-coverage gate ────────────────────────────
+  # The strongest guard against the silent-degraded-board failure:
+  # health/smoke checks all pass even when the process is serving the
+  # bare 3-source legacy export instead of the ~11-source enriched
+  # blend (OTCFFB et al. missing).  Assert the SERVED board actually
+  # carries every fresh registered source.  A failure here fails the
+  # deploy, which trips deploy.sh's existing auto-rollback — so a
+  # deploy can no longer "succeed" while serving wrong values.
+  # Escape hatch: VERIFY_SOURCE_COVERAGE=0 (emergencies only).
+  if [[ "${VERIFY_SOURCE_COVERAGE:-1}" != "0" ]]; then
+    local cov_python="python3"
+    if [[ -x "${VENV_DIR}/bin/python" ]]; then
+      cov_python="${VENV_DIR}/bin/python"
+    fi
+    log "Verifying served-board source coverage via /api/status"
+    if ( cd "${APP_DIR}" && "${cov_python}" \
+          scripts/verify_live_source_coverage.py \
+          "http://${APP_HOST}:${APP_PORT}" ); then
+      log "Served-board source coverage OK."
+    else
+      error "Served board is degraded (missing fresh registered sources)."
+      error "The process did not re-prime/enrich after restart.  Failing"
+      error "the deploy so auto-rollback runs; investigate the prime path."
+      exit 1
+    fi
+  else
+    warn "Source-coverage gate skipped (VERIFY_SOURCE_COVERAGE=0)."
+  fi
+
   log "Deploy verification checks passed."
 }
 

--- a/scripts/verify_live_source_coverage.py
+++ b/scripts/verify_live_source_coverage.py
@@ -1,0 +1,151 @@
+"""Assert the LIVE server is serving a fully-enriched board.
+
+The silent failure this closes: the committed export is intrinsically
+a 3-source artifact; the full ~11-source board only exists after the
+running process re-primes and ``_enrich_from_source_csvs`` grafts the
+per-source CSVs on.  If a deploy doesn't actually re-prime (or a
+source silently drops), the server keeps serving a degraded 3-source
+board and *every* health/smoke check still passes — ``/api/health``
+is 200, ``player_count`` is normal, ``sites``/``source_health`` only
+ever list the 3 legacy sources so they look unchanged.  That is
+exactly how OTCFFB (+ ~8 others) stayed off the live board for days
+with no alarm.
+
+This fetches ``/api/status``'s ``served_source_coverage`` — the real
+per-source player counts of the board being served right now — and
+runs it through the SAME fresh-but-absent decision core the CI
+contract-coverage watchdog uses (``evaluate_coverage_map``).  A
+registered source that is fresh + non-empty in the checkout but
+missing from the served board fails this check.
+
+Used at two layers so a degraded board cannot persist silently:
+  * ``deploy/verify-deploy.sh`` — on-box, right after the service
+    restart; a failure makes the deploy fail and trips the existing
+    auto-rollback, so a deploy literally cannot "succeed" while
+    serving a degraded board.
+  * ``.github/workflows/health-check.yml`` — every 6h against the
+    public URL, catching drift that happens outside a deploy.
+
+Usage:
+    python scripts/verify_live_source_coverage.py <base_url>
+    # or: DEPLOY_VERIFY_BASE_URL=http://127.0.0.1:8000 python ...
+
+Exit codes:
+  0 — every fresh registered source is present in the served board
+  1 — a fresh source is absent (degraded board), or /api/status was
+      unreachable / unparseable after retries
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.watchdog_contract_coverage import evaluate_coverage_map  # noqa: E402
+from scripts.watchdog_freshness import _read_freshness  # noqa: E402
+from src.api.source_health_alerts import load_thresholds  # noqa: E402
+
+_ATTEMPTS = 6
+_SLEEP_SECONDS = 5
+_TIMEOUT_SECONDS = 20
+
+
+def _fetch_status(base_url: str) -> dict | None:
+    """GET ``<base>/api/status`` with retries (tolerates the brief
+    window after a service restart before priming completes)."""
+    url = base_url.rstrip("/") + "/api/status"
+    for attempt in range(1, _ATTEMPTS + 1):
+        try:
+            req = urllib.request.Request(
+                url, headers={"User-Agent": "verify-live-source-coverage"}
+            )
+            with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
+                if resp.status == 200:
+                    return json.loads(resp.read().decode("utf-8"))
+                reason = f"HTTP {resp.status}"
+        except Exception as exc:  # noqa: BLE001
+            reason = repr(exc)
+        if attempt < _ATTEMPTS:
+            print(
+                f"attempt {attempt}/{_ATTEMPTS}: {url} not ready "
+                f"({reason}); retrying in {_SLEEP_SECONDS}s"
+            )
+            time.sleep(_SLEEP_SECONDS)
+    print(
+        f"::error title=Live status unreachable::{url} did not return a "
+        f"parseable 200 after {_ATTEMPTS} attempts."
+    )
+    return None
+
+
+def main() -> int:
+    base_url = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.environ.get("DEPLOY_VERIFY_BASE_URL", "")
+    ).strip()
+    if not base_url:
+        print(
+            "::error title=No base URL::Pass the server base URL as "
+            "argv[1] or set DEPLOY_VERIFY_BASE_URL."
+        )
+        return 1
+
+    status = _fetch_status(base_url)
+    if status is None:
+        return 1
+
+    cov = status.get("served_source_coverage")
+    if not isinstance(cov, dict) or not cov:
+        # Empty/absent == the served board carries no per-source
+        # coverage == degraded (or a server too old to expose it,
+        # which post-deploy is itself the regression).
+        print(
+            "::error title=Degraded board::/api/status reported no "
+            "served_source_coverage — the live board is not enriched "
+            "(serving the bare legacy export, not the ~11-source "
+            "blend).  The process did not re-prime from the CSVs."
+        )
+        return 1
+
+    cov_int = {str(k): int(v) for k, v in cov.items()}
+    freshness = _read_freshness()
+    thresholds = load_thresholds()
+    violations, ok, skipped = evaluate_coverage_map(
+        cov_int, freshness, thresholds
+    )
+
+    if not violations:
+        print(
+            f"ok: live board carries {len(ok)} registered source(s); "
+            f"0 fresh-but-absent ({len(skipped)} skipped: stale/empty)"
+        )
+        return 0
+
+    for key, c in violations:
+        print(
+            f"::error title=Source absent from LIVE board: {key}::"
+            f"{key} is fresh in the checkout but only {c} player(s) "
+            f"carry it in the SERVED board (/api/status "
+            f"served_source_coverage).  The live process is serving a "
+            f"degraded board — it did not re-prime / enrich.  A "
+            f"`systemctl restart {os.environ.get('SERVICE_NAME', 'dynasty')}` "
+            f"on the host forces a re-prime; investigate why the deploy "
+            f"restart didn't take."
+        )
+    print(
+        f"\nfail: {len(violations)} fresh source(s) missing from the "
+        f"LIVE board: {', '.join(k for k, _ in violations)}"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/watchdog_contract_coverage.py
+++ b/scripts/watchdog_contract_coverage.py
@@ -167,7 +167,24 @@ def evaluate_coverage(
       * skipped    — source keys not evaluated because they are stale
         (owned by the freshness watchdog) or have an empty/missing CSV.
     """
-    cov = _source_coverage(contract)
+    return evaluate_coverage_map(
+        _source_coverage(contract), freshness, thresholds
+    )
+
+
+def evaluate_coverage_map(
+    cov: dict[str, int],
+    freshness: dict[str, dict],
+    thresholds: dict,
+) -> tuple[list[tuple[str, int]], list[tuple[str, int]], list[str]]:
+    """Same decision core as :func:`evaluate_coverage` but driven by a
+    pre-computed ``{sourceKey: playerCount}`` map instead of a contract.
+
+    Lets the live deploy-gate / health check feed the SERVED board's
+    ``served_source_coverage`` (from ``/api/status``) through the
+    identical fresh-but-absent logic the CI watchdog uses — one
+    decision core, so the pre-merge and runtime gates can never drift.
+    """
     registered = [str(s.get("key") or "") for s in _RANKING_SOURCES]
 
     violations: list[tuple[str, int]] = []

--- a/server.py
+++ b/server.py
@@ -303,6 +303,39 @@ contract_health: dict = {
     "contractVersion": API_DATA_CONTRACT_VERSION,
     "playerCount": 0,
 }
+# Per-source coverage of the CURRENTLY-SERVED contract:
+# ``{sourceKey: playerCount}`` counted from
+# ``playersArray[*].sourceRankMeta`` — how many players each source
+# actually contributed to the live board.  Recomputed once per prime
+# (not per request).  This is the ONLY reliable "is the served board
+# fully enriched?" signal: ``sites`` / ``siteStats`` only ever list
+# the 3 legacy-scraper sources even when the contract is fully
+# CSV-enriched, so they cannot tell a healthy ~11-source board apart
+# from a degraded 3-source one (the exact silent failure that left
+# OTCFFB — and ~8 other sources — off the live board for days).  The
+# deploy-gate (deploy/verify-deploy.sh) and the scheduled health
+# check assert on this so a non-re-primed/degraded board fails
+# loudly instead of silently serving wrong values.
+served_source_coverage: dict = {}
+
+
+def _compute_served_source_coverage(contract: dict | None) -> dict:
+    """Count, per source, how many served players carry it in
+    ``sourceRankMeta`` (== "contributed to the blend").  Defensive:
+    any shape surprise yields ``{}`` rather than raising inside the
+    prime path."""
+    cov: dict[str, int] = {}
+    try:
+        for row in (contract or {}).get("playersArray") or []:
+            srm = row.get("sourceRankMeta") if isinstance(row, dict) else None
+            if isinstance(srm, dict):
+                for k in srm:
+                    cov[str(k)] = cov.get(str(k), 0) + 1
+    except Exception:  # noqa: BLE001
+        return {}
+    return cov
+
+
 # ── NEWS SERVICE ───────────────────────────────────────────────────────
 # Lazy-built singleton.  Built on first request rather than at import
 # so unit tests can monkey-patch the factory and the server can boot
@@ -1186,6 +1219,8 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
     global latest_runtime_data, latest_runtime_data_bytes, latest_runtime_data_gzip_bytes, latest_runtime_data_etag
     global latest_startup_data, latest_startup_data_bytes, latest_startup_data_gzip_bytes, latest_startup_data_etag
     global contract_health
+    global served_source_coverage
+    served_source_coverage = {}
     latest_data_bytes = None
     latest_data_gzip_bytes = None
     latest_data_etag = None
@@ -1267,6 +1302,7 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
             pass
         latest_contract_data = contract_payload
         contract_health = contract_report
+        served_source_coverage = _compute_served_source_coverage(contract_payload)
 
         # Post-scrape overlay warm — for every ACTIVE league
         # (including the default league the scraper just built for),
@@ -3077,6 +3113,11 @@ async def get_status():
         "has_data": latest_contract_data is not None,
         "player_count": int((latest_contract_data or {}).get("playerCount") or 0),
         "data_date": (latest_contract_data or {}).get("date"),
+        # Real per-source coverage of the served board (see the
+        # ``served_source_coverage`` global).  Monitoring asserts on
+        # this; ``source_health`` above is derived from the 3-source
+        # legacy ``sites`` list and cannot detect a degraded board.
+        "served_source_coverage": served_source_coverage,
         # R-4: Scrape success rate tracking
         "scrape_success_rate_24h": _scrape_success_rate_24h(),
         "last_n_scrapes": scrape_history[-20:],

--- a/tests/api/test_served_source_coverage.py
+++ b/tests/api/test_served_source_coverage.py
@@ -1,0 +1,97 @@
+"""Regression coverage for the served-board source-coverage gate.
+
+This is the runtime half of the silent-degraded-board defense (the
+CI half is ``test_contract_coverage_watchdog``).  It pins:
+
+* ``server._compute_served_source_coverage`` — the per-source player
+  count cached at prime and exposed on ``/api/status``.
+* ``evaluate_coverage_map`` parity — the live deploy-gate / health
+  check feed the SERVED coverage map through the *same* decision core
+  the CI watchdog uses, so the pre-merge and runtime gates can never
+  disagree about what "a source is missing" means.
+"""
+from __future__ import annotations
+
+import unittest
+
+import server
+from scripts.watchdog_contract_coverage import (
+    _source_coverage,
+    evaluate_coverage,
+    evaluate_coverage_map,
+)
+
+_KEY = "otcffbSf"
+
+
+class TestComputeServedSourceCoverage(unittest.TestCase):
+    def test_counts_sourcerankmeta_membership(self):
+        contract = {
+            "playersArray": [
+                {"sourceRankMeta": {_KEY: {}, "ktcSfTep": {}}},
+                {"sourceRankMeta": {"ktcSfTep": {}}},
+                {"no": "meta"},
+            ]
+        }
+        self.assertEqual(
+            server._compute_served_source_coverage(contract),
+            {_KEY: 1, "ktcSfTep": 2},
+        )
+
+    def test_defensive_on_bad_shapes(self):
+        self.assertEqual(server._compute_served_source_coverage(None), {})
+        self.assertEqual(server._compute_served_source_coverage({}), {})
+        self.assertEqual(
+            server._compute_served_source_coverage({"playersArray": "nope"}), {}
+        )
+
+    def test_degraded_board_yields_only_legacy_sources(self):
+        # A 3-source legacy board: the gate must see exactly that.
+        contract = {
+            "playersArray": [
+                {"sourceRankMeta": {"ktc": {}, "ktcSfTep": {}, "idpTradeCalc": {}}}
+                for _ in range(50)
+            ]
+        }
+        cov = server._compute_served_source_coverage(contract)
+        self.assertEqual(set(cov), {"ktc", "ktcSfTep", "idpTradeCalc"})
+
+
+class TestEvaluateCoverageMapParity(unittest.TestCase):
+    """``evaluate_coverage_map`` must return exactly what
+    ``evaluate_coverage`` returns for the same underlying coverage —
+    that equivalence is what lets the runtime gate reuse the CI
+    watchdog's decision core."""
+
+    def setUp(self):
+        import scripts.watchdog_contract_coverage as wcc
+
+        self._orig = wcc._csv_nonempty
+        wcc._csv_nonempty = lambda _k: True
+
+    def tearDown(self):
+        import scripts.watchdog_contract_coverage as wcc
+
+        wcc._csv_nonempty = self._orig
+
+    def test_map_path_equals_contract_path(self):
+        contract = {
+            "playersArray": [{"sourceRankMeta": {_KEY: {}}} for _ in range(40)]
+        }
+        freshness = {_KEY: {"ageHours": 0.0}}
+        from_contract = evaluate_coverage(contract, freshness, {})
+        from_map = evaluate_coverage_map(
+            _source_coverage(contract), freshness, {}
+        )
+        self.assertEqual(from_contract, from_map)
+
+    def test_map_flags_absent_fresh_source(self):
+        # Served map missing the fresh source entirely → violation.
+        freshness = {_KEY: {"ageHours": 0.0}}
+        violations, ok, _ = evaluate_coverage_map({}, freshness, {})
+        self.assertIn((_KEY, 0), violations)
+        self.assertNotIn(_KEY, [k for k, _ in ok])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause this closes

"OTCFFB absent / Bowers stuck at 16" was never a valuation bug — the ×1.25 and blend are correct (proven: OTCFFB-only → Bowers #8, full → #2). The real failure: the committed export is intrinsically a **3-source artifact**; the full ~11-source board only exists after the running process re-primes and `_enrich_from_source_csvs` grafts the per-source CSVs on. When a deploy/restart doesn't actually re-prime (or a source silently drops), prod keeps serving a degraded 3-source board — and **every existing check still passes**: `/api/health` 200, `player_count` normal, and `sites`/`source_health` only ever list the 3 legacy sources so they look unchanged. Nothing asserted the served board was actually enriched, so it stayed broken for days unnoticed.

## Fix — three layers, one decision core

Shares #444's fresh-but-absent logic so CI (pre-merge) and runtime can never disagree about "a source is missing":

- **`server.py` → `/api/status.served_source_coverage`** — real per-source player counts of the board being served *right now*, computed once per prime from `playersArray[*].sourceRankMeta`. The only signal that tells a healthy ~11-source board apart from a degraded 3-source one.
- **`scripts/watchdog_contract_coverage.py`** — `evaluate_coverage` refactored to delegate to a new `evaluate_coverage_map(cov, …)`; the live gate reuses the identical CI decision core.
- **`scripts/verify_live_source_coverage.py`** — fetches `/api/status`, runs `served_source_coverage` through `evaluate_coverage_map`.
- **`deploy/verify-deploy.sh`** — on-box, post-restart: a degraded served board **fails the deploy** and trips the existing auto-rollback. A deploy can no longer "succeed" while serving wrong values. Escape hatch: `VERIFY_SOURCE_COVERAGE=0`.
- **`health-check.yml`** — dependency-free continuous (every 6h) assertion so degradation *outside* a deploy is caught within hours, not days.

No valuation logic changed.

## Test plan

- [x] `tests/api/test_served_source_coverage.py` — server coverage helper (normal/empty/malformed/degraded) + `evaluate_coverage_map` parity with `evaluate_coverage`.
- [x] #444 contract-coverage + soft-source watchdog suites still pass after the refactor (21 targeted).
- [x] Full backend suite: **2879 passed, 5 skipped**.
- [x] Both workflows YAML-valid; `verify-deploy.sh` `bash -n` clean; `server._compute_served_source_coverage` verified.
- [ ] CI `Validate PR` green.

https://claude.ai/code/session_01QFzUa9x5Rqpnkwtobtcn5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFzUa9x5Rqpnkwtobtcn5J)_