### PR TITLE
fix(deploy): verify-deploy.sh aborted on unbound VENV_DIR — every deploy auto-rolled-back

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -758,6 +758,7 @@ verify_deploy() {
     APP_HOST="${APP_HOST}" \
     APP_PORT="${APP_PORT}" \
     APP_DIR="${APP_DIR}" \
+    VENV_DIR="${VENV_DIR}" \
     FRONTEND_HOST="${FRONTEND_HOST}" \
     FRONTEND_PORT="${FRONTEND_PORT}" \
     FRONTEND_BUILD_DIR="${APP_DIR}/frontend/.next" \

--- a/deploy/verify-deploy.sh
+++ b/deploy/verify-deploy.sh
@@ -318,8 +318,15 @@ main() {
   # Escape hatch: VERIFY_SOURCE_COVERAGE=0 (emergencies only).
   if [[ "${VERIFY_SOURCE_COVERAGE:-1}" != "0" ]]; then
     local cov_python="python3"
-    if [[ -x "${VENV_DIR}/bin/python" ]]; then
-      cov_python="${VENV_DIR}/bin/python"
+    # verify-deploy.sh runs under ``set -u``; ``VENV_DIR`` is not
+    # guaranteed in the environment (deploy.sh's verify_deploy() did
+    # not export it, and the 6h health-check workflow runs this
+    # standalone).  Default to deploy.sh's own convention
+    # (``${APP_DIR}/.venv``) so an unset VENV_DIR can't abort the
+    # whole deploy with an "unbound variable" before the gate runs.
+    local cov_venv_dir="${VENV_DIR:-${APP_DIR:-.}/.venv}"
+    if [[ -x "${cov_venv_dir}/bin/python" ]]; then
+      cov_python="${cov_venv_dir}/bin/python"
     fi
     log "Verifying served-board source coverage via /api/status"
     if ( cd "${APP_DIR}" && "${cov_python}" \


### PR DESCRIPTION
## Summary
#451's served-board source-coverage gate references `${VENV_DIR}` in `deploy/verify-deploy.sh`, but that script runs under `set -Eeuo pipefail` and `deploy.sh`'s `verify_deploy()` never exported `VENV_DIR` into its environment (it passes `APP_DIR/APP_HOST/APP_PORT` but not `VENV_DIR`).

**Impact:** once #451 landed on `main`, *every* deploy hit `verify-deploy.sh: line 321: VENV_DIR: unbound variable`, exited 1 **before the coverage check could run**, and tripped auto-rollback. Production stayed safe (rolled back to the idpShow-fix commit each time) but #451 was effectively un-deployable and **all deploys were blocked**.

## Fix (two minimal, complementary edits — mirrors deploy.sh's own `VENV_DIR:-${APP_DIR}/.venv` convention)
- **verify-deploy.sh**: default `cov_venv_dir="${VENV_DIR:-${APP_DIR:-.}/.venv}"` so an unset `VENV_DIR` can't abort the deploy (also makes it correct when the 6h health-check workflow runs it standalone).
- **deploy.sh**: export `VENV_DIR` into verify-deploy.sh's env alongside the other vars so the real venv path propagates.

This unblocks deploys and lets #451's coverage gate run for the first time.

## Test plan
- [x] `bash -n` syntax-clean on both scripts
- [x] Simulated the exact failing condition (`set -u`, `VENV_DIR` unset, `APP_DIR` set) → resolves to the real venv (`/home/dynasty/trade-calculator/.venv/bin/python`), no unbound error
- [ ] Deploy: verify-deploy.sh runs the coverage gate to completion (pass = #451 live & working; or a true-positive degraded-source catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)