### PR TITLE
fix(blend): DraftSharks is TEP-native — stop double-counting TE premium (Bowers too high)

### DIFF
--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -709,8 +709,15 @@ export const RANKING_SOURCES = [
     // ``fetch_draftsharks.py`` scraper splits DS's single
     // offense-combined DOM by position family into two CSVs, so
     // this is the SF slice only.  Value signal off the ``3D Value +``
-    // column; DraftSharks' scoring is standard dynasty (not TE-
-    // premium native), so the frontend ``tepMultiplier`` applies.
+    // column.  DraftSharks IS scraped from the TE-PREMIUM superflex
+    // board (fetch_draftsharks.py RANKINGS_URL =
+    // /dynasty-rankings/te-premium-superflex), so its values already
+    // bake in TE premium — TEP-native like KTC SF-TE++ / DN SF-TEP /
+    // Yahoo Boone.  isTepPremium:true so TE rows get only the small
+    // native nudge, not the larger non-TEP boost (mis-flagged false
+    // until 2026-05-16, which double-counted TEP for DS and inflated
+    // top TEs like Brock Bowers).  Lockstep with
+    // src/api/data_contract.py::_RANKING_SOURCES.
     key: "draftSharks",
     displayName: "Draft Sharks Dynasty",
     columnLabel: "DS",
@@ -722,7 +729,7 @@ export const RANKING_SOURCES = [
     isBackbone: false,
     isRetail: false,
     isRankSignal: false,
-    isTepPremium: false,
+    isTepPremium: true,
     needsSharedMarketTranslation: false,
     excludesRookies: false,
   },

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1476,9 +1476,21 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # prospects below the default DS position-filter cutoff).
         # Value signal off the ``3D Value +`` column; the blend
         # normalises via Hill curve over within-source rank so the
-        # 0-100 absolute scale is irrelevant.  DraftSharks' scoring
-        # is standard dynasty (not TE-premium native), so the
-        # frontend ``tepMultiplier`` applies.
+        # 0-100 absolute scale is irrelevant.  DraftSharks IS scraped
+        # from the TE-PREMIUM superflex board —
+        # ``scripts/fetch_draftsharks.py`` ``RANKINGS_URL`` =
+        # ``https://www.draftsharks.com/dynasty-rankings/te-premium-superflex``,
+        # read under the TE++ league's ``3D Value +`` (and the legacy
+        # ``Dynasty Scraper.py`` header agrees: "DraftSharks — TEP
+        # url").  Its raw values therefore ALREADY bake in TE premium,
+        # so it is TEP-native like KTC SF-TE++ / DN SF-TEP / Yahoo
+        # Boone / FP Fitzmaurice / IDPTC: declared
+        # ``is_tep_premium=True`` so TE rows get only the small 1.10×
+        # native nudge, never the 1.25× non-TEP boost.  (Before
+        # 2026-05-16 this was mis-flagged False, double-counting TE
+        # premium for DS — its already-TEP TE values got the larger
+        # non-TEP multiplier — which inflated every TE's DS
+        # contribution and pushed top TEs like Brock Bowers too high.)
         "key": "draftSharks",
         "display_name": "Draft Sharks Dynasty",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
@@ -1488,7 +1500,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "weight": 1.0,
         "is_backbone": False,
         "is_retail": False,
-        "is_tep_premium": False,
+        "is_tep_premium": True,
         "needs_shared_market_translation": False,
         "excludes_rookies": False,
         # DraftSharks SF and IDP are split across two CSVs but share

--- a/tests/api/test_pick_refinement.py
+++ b/tests/api/test_pick_refinement.py
@@ -385,7 +385,15 @@ class TestPlayerRankingsUnchanged(unittest.TestCase):
         # outlier rejection.  No upstream regression — Roquan is a
         # genuinely borderline Hampel case, so the band needed real
         # headroom rather than a 5-rank tweak.
-        "Roquan Smith":     {"max_rank": 175, "min_value": 2300, "allowed_buckets": ("low", "medium", "high")},
+        # 2026-05-16: widened 175 → 180.  The DraftSharks TEP
+        # mis-flag fix (is_tep_premium False→True — DS is scraped
+        # from the te-premium-superflex board, so its values already
+        # bake in TE premium) correctly de-inflates DS TE values.
+        # DS SF+IDP share one combined value ladder
+        # (``ds_combined_rank_partner``), so de-inflating DS TEs
+        # nudges DS-IDP players ~1 rank; Roquan (borderline Hampel,
+        # above) tipped 175 → 176.  Real headroom, not a chase.
+        "Roquan Smith":     {"max_rank": 180, "min_value": 2300, "allowed_buckets": ("low", "medium", "high")},
         "Kyle Hamilton":    {"max_rank": 200, "min_value": 1800, "allowed_buckets": ("low", "medium", "high")},
     }
 


### PR DESCRIPTION
## Summary
**Root cause of "Brock Bowers ranked too high."** DraftSharks is scraped from its **TE-Premium** superflex board (`scripts/fetch_draftsharks.py` `RANKINGS_URL = .../dynasty-rankings/te-premium-superflex`, read under the TE++ league's `3D Value +`; `Dynasty Scraper.py:9` agrees: *"DraftSharks — TEP url"*). Its raw values **already bake in TE premium**, but the registry flagged `draftSharks` as `is_tep_premium=False`, so the blend applied the larger **1.25× non-TEP boost on top of already-TEP values** — double-counting TE premium for DraftSharks and inflating every TE's DS contribution.

This was the one mis-flagged source; the other 14 SF sources audited clean (each verified against its actual scraper URL/column).

## Change (smallest correct)
- Flip `is_tep_premium`/`isTepPremium` **False→True** for `draftSharks` in **both** `src/api/data_contract.py::_RANKING_SOURCES` and `frontend/lib/dynasty-data.js::RANKING_SOURCES` (lockstep — `test_source_registry_parity.py` enforces it) + corrected both misleading comments.
- The 1.10× (TEP-native) / 1.25× (non-TEP) constants are **unchanged** — DS just moves into the correct bucket, alongside KTC SF-TE++, DN SF-TEP, Yahoo Boone, FP Fitzmaurice, IDPTC.
- `tests/api/test_pick_refinement.py`: widened the `Roquan Smith` invariant 175→180 (documented). DS SF+IDP share one combined value ladder (`ds_combined_rank_partner`), so correctly de-inflating DS TEs nudges DS-IDP players ~1 rank; Roquan (a known borderline-Hampel case) tipped 175→176.

## Effect (verified against live contract)
- **Brock Bowers `canonicalConsensusRank` #2 → ~#4.** DS source meta now reports `tepNativeCorrectionApplied` (1.10) instead of the erroneous 1.25 `tepBoost`.

## Test plan
- [x] `test_source_registry_parity` (Python↔JS lockstep) — pass
- [x] `test_source_overrides` (TEP multiplier mechanism) — pass
- [x] `test_single_curve_live` (DraftSharks cross-market + TEP) — pass
- [x] `test_pick_refinement::test_known_player_values_unchanged` — pass after documented Roquan baseline update
- [x] Full `tests/api/` suite — 1131 pass; only unrelated pre-existing failure is `yahooBoone` below row floor (fails on clean main too — flagged separately, not in scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)