### PR TITLE
test(yahooBoone): cover #455 partial-scrape guards; document exit 3

### DIFF
--- a/scripts/fetch_yahoo_boone.py
+++ b/scripts/fetch_yahoo_boone.py
@@ -62,6 +62,12 @@ Exit codes:
     1 — soft failure (fetch / parse error for all positions, or zero rows)
     2 — schema regression (no parseable table on a successful response,
         or total row count below ``_YB_ROW_COUNT_FLOOR``)
+    3 — partial scrape: a position in ``_SEED_URLS`` fell below
+        ``_YB_MIN_ROWS_PER_POSITION``.
+
+Exit codes 2 and 3 deliberately leave the previously-written CSV
+untouched: a degraded refresh keeps serving the last good board
+until a human investigates, rather than overwriting it.
 """
 from __future__ import annotations
 

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -569,9 +569,16 @@ _DEFAULT_SOURCE_ROW_FLOORS: dict[str, int] = {
     # match counts.
     "footballGuysSf": 375,
     "footballGuysIdp": 230,
-    # Yahoo / Justin Boone charts: QB+RB+WR+TE combined = ~500 rows
-    # at the April 2026 baseline.  Floor at ~80% so a scrape regression
-    # trips a warning.
+    # Yahoo / Justin Boone charts: a complete QB+RB+WR+TE board is
+    # ~450 raw rows that canonicalize to ~425 matches against the
+    # Sleeper pool (this floor is checked against canonical matches,
+    # not raw rows).  Boone is scraped as four independent per-position
+    # seed URLs; one silently dropping out (dead redirect / changed
+    # table) removes ~80-90 matches — losing TE alone drops the count
+    # to ~344.  scripts/fetch_yahoo_boone now fails loudly and
+    # preserves the last-good CSV in that case (``_YB_ROW_COUNT_FLOOR``
+    # 400 + per-position ``_YB_MIN_ROWS_PER_POSITION`` 30), so this
+    # contract floor is the second line of defence, not the first.
     "yahooBoone": 400,
     # FantasyPros / Pat Fitzmaurice: QB (50) + RB (~88) + WR (~115) +
     # TE (~46) ≈ 299 rows at the April 2026 baseline.  Floor at ~75%.

--- a/tests/adapters/test_yahoo_boone_scraper.py
+++ b/tests/adapters/test_yahoo_boone_scraper.py
@@ -322,3 +322,81 @@ class TestCsvWriter:
         assert allen.rank_raw == 1.0
         assert allen.value_raw is None
         assert allen.position_raw == "QB"
+
+
+# ── Partial-scrape guards (fail loudly, preserve last-good) ───────────
+
+class TestPartialScrapeGuards:
+    """Regression for the 2026-05-16 silent-truncation incident: a TE
+    seed failure produced a QB+RB+WR-only board.  The old combined
+    floor (225) let that 3-of-4-position board through, it was written
+    and auto-committed, then failed the downstream yahooBoone contract
+    floor (344 < 400) on clean main.  ``main`` must now refuse to
+    overwrite the last-good CSV when the board is structurally degraded.
+    """
+
+    def _board(self, yb_module, counts: dict[str, int]):
+        Row = yb_module.YahooRow
+        rows = []
+        for pos, n in counts.items():
+            rows.extend(Row(f"{pos}{i}", pos, 200 - i) for i in range(n))
+        return rows
+
+    def test_position_below_per_position_floor_exits_3_and_preserves_csv(
+        self, yb_module, tmp_path, monkeypatch
+    ):
+        # Total 480 clears _YB_ROW_COUNT_FLOOR (400) so the per-position
+        # guard is what must catch TE vanishing (TE=0 < 30).
+        board = self._board(
+            yb_module, {"QB": 80, "RB": 200, "WR": 200, "TE": 0}
+        )
+        monkeypatch.setattr(
+            yb_module,
+            "fetch_all",
+            lambda *a, **k: (board, ["TE: fetch/parse failed — boom"]),
+        )
+        dest = tmp_path / "yahooBoone.csv"
+        sentinel = "name,pos,rank,boone_value\nPrior Good,QB,1,141\n"
+        dest.write_text(sentinel, encoding="utf-8")
+
+        rc = yb_module.main(["--dest", str(dest)])
+
+        assert rc == 3
+        assert dest.read_text(encoding="utf-8") == sentinel
+
+    def test_total_below_floor_exits_2_and_preserves_csv(
+        self, yb_module, tmp_path, monkeypatch
+    ):
+        board = self._board(
+            yb_module, {"QB": 80, "RB": 80, "WR": 80, "TE": 80}
+        )  # 320 < 400
+        monkeypatch.setattr(
+            yb_module, "fetch_all", lambda *a, **k: (board, [])
+        )
+        dest = tmp_path / "yahooBoone.csv"
+        sentinel = "name,pos,rank,boone_value\nPrior Good,QB,1,141\n"
+        dest.write_text(sentinel, encoding="utf-8")
+
+        rc = yb_module.main(["--dest", str(dest)])
+
+        assert rc == 2
+        assert dest.read_text(encoding="utf-8") == sentinel
+
+    def test_healthy_board_writes_and_exits_0(
+        self, yb_module, tmp_path, monkeypatch
+    ):
+        board = self._board(
+            yb_module, {"QB": 80, "RB": 130, "WR": 150, "TE": 90}
+        )  # 450, every position well above 30
+        monkeypatch.setattr(
+            yb_module, "fetch_all", lambda *a, **k: (board, [])
+        )
+        dest = tmp_path / "yahooBoone.csv"
+
+        rc = yb_module.main(["--dest", str(dest)])
+
+        assert rc == 0
+        with dest.open() as f:
+            data = list(csv.DictReader(f))
+        assert {r["pos"] for r in data} == {"QB", "RB", "WR", "TE"}
+        assert len(data) == 450


### PR DESCRIPTION
## Summary

Follow-up hardening for #455 (which fixed the `yahooBoone 344 < 400`
contract-floor failure on clean main). #455 added the partial-scrape
guards to `scripts/fetch_yahoo_boone.py` but shipped **no regression
test** for them and left **exit code 3 undocumented**.

- **Regression tests** (`TestPartialScrapeGuards`): a position below
  `_YB_MIN_ROWS_PER_POSITION` exits 3; a sub-`_YB_ROW_COUNT_FLOOR`
  total exits 2; a healthy 450-row board exits 0 — and both failure
  modes **preserve the prior CSV** (the invariant that protects prod).
- **Docs**: document exit code 3 + the preserve-last-good contract in
  the fetcher docstring.
- **Comment fix**: the stale `_DEFAULT_SOURCE_ROW_FLOORS["yahooBoone"]`
  comment claimed "~500 rows / ~80%"; the floor is actually checked
  against ~425 canonical matches. Corrected + cross-referenced to the
  scraper guard.

No behaviour change to the merged guard or the regenerated CSV — test
+ docs only.

## Test plan

- [x] `pytest tests/adapters/test_yahoo_boone_scraper.py` (incl. 3 new guard tests)
- [x] `pytest tests/api/test_source_monitoring.py` (originally-failing `test_per_source_row_count_floors_pass_on_live` green)
- [x] 39 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)