### PR TITLE
Audit PR A: enforce scraper-floor ≥ contract-floor invariant + harden dlf/idpShow

### DIFF
--- a/scripts/fetch_dlf.py
+++ b/scripts/fetch_dlf.py
@@ -79,13 +79,18 @@ BOARDS: dict[str, dict[str, str]] = {
         "url": "https://dynastyleaguefootball.com/dynasty-superflex-rankings/",
         "out": "CSVs/site_raw/dlfSf.csv",
         "label": "Dynasty Superflex",
-        "min_rows": 200,
+        # Aligned with the downstream contract floor
+        # ``_DEFAULT_SOURCE_ROW_FLOORS["dlfSf"]`` (240) so a partial
+        # scrape fails here and preserves last-good rather than
+        # shipping a CSV that later hard-fails the contract test.
+        "min_rows": 240,
     },
     "dlfIdp": {
         "url": "https://dynastyleaguefootball.com/rankings/dynasty-idp-rankings/",
         "out": "CSVs/site_raw/dlfIdp.csv",
         "label": "Dynasty IDP",
-        "min_rows": 120,
+        # Aligned with ``_DEFAULT_SOURCE_ROW_FLOORS["dlfIdp"]`` (150).
+        "min_rows": 150,
     },
     "dlfRookieSf": {
         "url": "https://dynastyleaguefootball.com/dynasty-rookie-superflex-rankings/",
@@ -511,18 +516,28 @@ def main() -> int:
                     f"pos={r.get('pos')!r}"
                 )
             continue
+        # Check the floor BEFORE writing.  The old code wrote the CSV
+        # first and only WARNed when short — so a partial/degraded
+        # scrape overwrote the last-good board and (because the floor
+        # was below the downstream contract floor) silently shipped a
+        # CSV that later hard-failed the contract-coverage test on a
+        # clean checkout.  Now: fail loudly, preserve last-good, never
+        # overwrite with a structurally-degraded board.
+        if len(rows) < min_rows:
+            print(
+                f"[DLF] {key}: parsed only {len(rows)} rows — expected "
+                f"≥{min_rows} (aligned with the downstream contract "
+                f"floor).  Partial/degraded scrape; preserving last-good "
+                f"CSV, NOT overwriting {out_path.relative_to(REPO)}.",
+                file=sys.stderr,
+            )
+            exit_code = max(exit_code, 2)
+            continue
         count = _write_csv(out_path, rows)
         print(
             f"[DLF] wrote {count} rows → {out_path.relative_to(REPO)}",
             flush=True,
         )
-        if count < min_rows:
-            print(
-                f"[DLF] WARN: {key} wrote only {count} rows — expected ≥{min_rows}.  "
-                f"DLF page structure may have changed; inspect "
-                f"{out_path.relative_to(REPO)}.",
-                file=sys.stderr,
-            )
     return exit_code
 
 

--- a/scripts/fetch_idpshow.py
+++ b/scripts/fetch_idpshow.py
@@ -363,12 +363,24 @@ def main() -> int:
         )
         return 1
 
-    if len(rows) < 100:
+    # Hard floor aligned with the downstream contract guard
+    # ``_DEFAULT_SOURCE_ROW_FLOORS["idpShow"]`` (150).  Previously a
+    # WARN at <100 that still wrote the CSV — a partial scrape (e.g. a
+    # republished/truncated Datawrapper chart) overwrote the last-good
+    # board and silently shipped a CSV that then hard-failed the
+    # contract-coverage test on a clean checkout.  Fail loudly and
+    # preserve last-good instead.  Skipped under --dry-run so the
+    # sample below still prints for diagnosis.
+    _IDPSHOW_ROW_FLOOR = 150
+    if not args.dry_run and len(rows) < _IDPSHOW_ROW_FLOOR:
         print(
-            f"[idpshow] WARN: only {len(rows)} rows — expected ~400.  "
-            "CSV structure may have changed.",
+            f"[idpshow] ERROR: only {len(rows)} rows — expected ≥"
+            f"{_IDPSHOW_ROW_FLOOR} (contract floor "
+            f"_DEFAULT_SOURCE_ROW_FLOORS['idpShow']).  Partial/degraded "
+            f"scrape; preserving last-good CSV, not overwriting.",
             file=sys.stderr,
         )
+        return 2
 
     if args.dry_run:
         print("[idpshow] dry-run — top 5:")

--- a/tests/api/test_source_floor_invariant.py
+++ b/tests/api/test_source_floor_invariant.py
@@ -1,0 +1,232 @@
+"""Invariant: every scraper's internal row-count floor must be >= the
+downstream contract floor in ``_DEFAULT_SOURCE_ROW_FLOORS``.
+
+WHY THIS EXISTS
+---------------
+Three production incidents in May 2026 had the same root cause: a
+scraper's *internal* "too few rows" guard was weaker than the
+*contract* floor the live board is later asserted against
+(``src/api/data_contract.py::_DEFAULT_SOURCE_ROW_FLOORS``, enforced by
+``tests/api/test_source_monitoring.py``).  So a partial/degraded
+scrape (a vanished position, a republished chart, a dropped sheet)
+passed the scraper's own guard, the degraded CSV was written +
+auto-committed, and it then HARD-FAILED CI on a clean checkout —
+blocking every PR — while #451's runtime coverage gate only catches
+it at deploy time.
+
+  * yahooBoone: scraper floor 225 < contract 400 (TE article vanished
+    → 360 rows shipped).  Fixed: floor 400 + per-position guard.
+  * dlfSf/dlfIdp: scraper min_rows 200/120 < contract 240/150, and
+    write-then-WARN (overwrote last-good).  Fixed: floors aligned +
+    check-before-write.
+  * idpShow: WARN-only at <100 < contract 150.  Fixed: hard-fail at
+    <150, preserve last-good.
+
+This test makes the floor>=contract relationship a STATIC, pre-merge
+invariant so the class cannot silently recur: a new source, a lowered
+scraper floor, or a raised contract floor that breaks the relationship
+fails here before it can ship.
+
+ALLOWLIST PATTERN
+-----------------
+Some scrapers still have no aligned internal floor (legacy
+``Dynasty Scraper.py`` exports, or scrapers that only abort at
+literally zero rows).  Each is listed in ``_KNOWN_FLOOR_GAPS`` with a
+one-line rationale + the follow-up that will close it — same
+self-burning-down pattern as
+``test_player_identity_regression.KNOWN_TOP_BOARD_SINGLE_SOURCE_ALLOWLIST``.
+``test_known_gaps_are_still_real_gaps`` forces removal of an entry the
+moment its scraper is hardened, so the allowlist can only shrink.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import unittest
+from pathlib import Path
+
+from src.api.data_contract import _DEFAULT_SOURCE_ROW_FLOORS
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO / "scripts"
+
+
+def _module_int_const(rel_path: str, const_name: str) -> int | None:
+    """Statically read ``const_name = <int>`` from a script WITHOUT
+    importing it (scrapers do import-time work / require network libs).
+    Mirrors the static-parsing approach in test_source_registry_parity.
+    """
+    path = _SCRIPTS / rel_path
+    if not path.exists():
+        return None
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        # Plain ``X = 400``.
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if (
+                    isinstance(tgt, ast.Name)
+                    and tgt.id == const_name
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, int)
+                ):
+                    return int(node.value.value)
+        # Annotated ``X: int = 400`` (most scrapers use this form).
+        elif isinstance(node, ast.AnnAssign):
+            tgt = node.target
+            if (
+                isinstance(tgt, ast.Name)
+                and tgt.id == const_name
+                and node.value is not None
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, int)
+            ):
+                return int(node.value.value)
+    return None
+
+
+def _dlf_board_min_rows(board_key: str) -> int | None:
+    """Extract ``"min_rows": N`` for one board out of fetch_dlf.py's
+    BOARDS dict (it's a per-board config dict, not a flat constant)."""
+    path = _SCRIPTS / "fetch_dlf.py"
+    if not path.exists():
+        return None
+    src = path.read_text()
+    # Find the board's block, then the first min_rows int after it.
+    m = re.search(rf'"{re.escape(board_key)}"\s*:\s*\{{(.*?)\}}', src, re.S)
+    if not m:
+        return None
+    mr = re.search(r'"min_rows"\s*:\s*(\d+)', m.group(1))
+    return int(mr.group(1)) if mr else None
+
+
+# Effective internal floor per source key — how to read each scraper's
+# real guard value.  Resolver returns the int, or None if the scraper
+# has NO aligned internal floor (=> must be in _KNOWN_FLOOR_GAPS).
+_SCRAPER_FLOOR_RESOLVERS = {
+    "yahooBoone": lambda: _module_int_const(
+        "fetch_yahoo_boone.py", "_YB_ROW_COUNT_FLOOR"
+    ),
+    "dynastyNerdsSfTep": lambda: _module_int_const(
+        "fetch_dynasty_nerds.py", "_DN_ROW_COUNT_FLOOR"
+    ),
+    "dynastyDaddySf": lambda: _module_int_const(
+        "fetch_dynasty_daddy.py", "_DD_ROW_COUNT_FLOOR"
+    ),
+    "flockFantasySf": lambda: _module_int_const(
+        "fetch_flock_fantasy.py", "_FF_ROW_COUNT_FLOOR"
+    ),
+    "idpShow": lambda: _module_int_const(
+        "fetch_idpshow.py", "_IDPSHOW_ROW_FLOOR"
+    ),
+    "dlfSf": lambda: _dlf_board_min_rows("dlfSf"),
+    "dlfIdp": lambda: _dlf_board_min_rows("dlfIdp"),
+    # No aligned internal floor today (legacy Dynasty Scraper.py
+    # exports, or abort-only-at-zero scrapers).  Resolver returns None
+    # => allowlisted below until the named follow-up hardens it.
+    "footballGuysSf": lambda: None,
+    "footballGuysIdp": lambda: None,
+    "draftSharks": lambda: None,
+    "draftSharksIdp": lambda: None,
+    "fantasyProsFitzmaurice": lambda: None,
+    "fantasyProsIdp": lambda: None,
+    "ktc": lambda: None,
+    "idpTradeCalc": lambda: None,
+}
+
+# Sources whose scraper has NO aligned internal floor yet.  Each entry:
+# one-line rationale + the follow-up PR that will add the guard and
+# REMOVE this entry.  This allowlist can only shrink (enforced by
+# ``test_known_gaps_are_still_real_gaps``).
+_KNOWN_FLOOR_GAPS: dict[str, str] = {
+    "footballGuysSf": "fetch_footballguys.py aborts only at 0 rows; add a >=375 floor + per-family guard (audit PR A2)",
+    "footballGuysIdp": "fetch_footballguys.py — add >=230 floor + per-family guard (audit PR A2)",
+    "draftSharks": "fetch_draftsharks.py aborts only at 0 rows; add a >=190 floor (audit PR A2)",
+    "draftSharksIdp": "fetch_draftsharks.py — add >=85 floor (audit PR A2)",
+    "fantasyProsFitzmaurice": "fetch_fantasypros_fitzmaurice.py aborts only at 0 rows; add a >=225 floor (audit PR A2)",
+    "fantasyProsIdp": "fetch_fantasypros_idp.py floors inputs (50+25) not the written total; add a >=75 written-total floor (audit PR A2)",
+    "ktc": "legacy Dynasty Scraper.py FULL_DATA export has no per-source floor; add a >=400 floor (audit PR A3)",
+    "idpTradeCalc": "legacy Dynasty Scraper.py — add a >=700 floor + per-sheet guard (audit PR A3/B)",
+}
+
+
+class TestScraperFloorInvariant(unittest.TestCase):
+    """Static, pre-merge: scraper floor >= contract floor for every
+    source not explicitly (and still-validly) allowlisted."""
+
+    def test_every_contract_floor_source_has_a_resolver(self):
+        """A new source in _DEFAULT_SOURCE_ROW_FLOORS must be wired
+        here (resolver + either aligned floor or allowlist entry) —
+        otherwise its scraper floor is unaudited."""
+        missing = sorted(
+            set(_DEFAULT_SOURCE_ROW_FLOORS) - set(_SCRAPER_FLOOR_RESOLVERS)
+        )
+        self.assertEqual(
+            missing,
+            [],
+            f"Sources in _DEFAULT_SOURCE_ROW_FLOORS with no scraper-floor "
+            f"resolver in test_source_floor_invariant: {missing}. Wire "
+            f"each (aligned internal floor, or _KNOWN_FLOOR_GAPS entry).",
+        )
+
+    def test_scraper_floor_meets_or_exceeds_contract_floor(self):
+        """The core invariant for every non-allowlisted source."""
+        violations: list[str] = []
+        for key, contract_floor in sorted(_DEFAULT_SOURCE_ROW_FLOORS.items()):
+            if key in _KNOWN_FLOOR_GAPS:
+                continue
+            resolver = _SCRAPER_FLOOR_RESOLVERS.get(key)
+            scraper_floor = resolver() if resolver else None
+            if scraper_floor is None:
+                violations.append(
+                    f"{key}: no internal scraper floor found, but not "
+                    f"in _KNOWN_FLOOR_GAPS (contract floor "
+                    f"{contract_floor})"
+                )
+            elif scraper_floor < contract_floor:
+                violations.append(
+                    f"{key}: scraper floor {scraper_floor} < contract "
+                    f"floor {contract_floor} — a partial scrape can "
+                    f"ship a CSV that hard-fails the contract test"
+                )
+        self.assertEqual(
+            violations,
+            [],
+            "Scraper-floor < contract-floor (the yahooBoone class):\n  "
+            + "\n  ".join(violations),
+        )
+
+    def test_known_gaps_are_still_real_gaps(self):
+        """Self-burning-down: once a scraper is hardened to meet its
+        contract floor, its _KNOWN_FLOOR_GAPS entry MUST be removed.
+        Mirrors test_player_identity_regression's allowlist
+        post-condition."""
+        stale: list[str] = []
+        for key in sorted(_KNOWN_FLOOR_GAPS):
+            self.assertIn(
+                key,
+                _DEFAULT_SOURCE_ROW_FLOORS,
+                f"_KNOWN_FLOOR_GAPS lists '{key}' which is not in "
+                f"_DEFAULT_SOURCE_ROW_FLOORS — drop the stale entry.",
+            )
+            resolver = _SCRAPER_FLOOR_RESOLVERS.get(key)
+            scraper_floor = resolver() if resolver else None
+            if (
+                scraper_floor is not None
+                and scraper_floor >= _DEFAULT_SOURCE_ROW_FLOORS[key]
+            ):
+                stale.append(
+                    f"{key}: scraper now floors at {scraper_floor} >= "
+                    f"contract {_DEFAULT_SOURCE_ROW_FLOORS[key]} — remove "
+                    f"it from _KNOWN_FLOOR_GAPS (gap is closed)."
+                )
+        self.assertEqual(
+            stale,
+            [],
+            "Closed gaps still allowlisted (allowlist must shrink):\n  "
+            + "\n  ".join(stale),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
First remediation PR from the source-degradation audit. Three May-2026 incidents (yahooBoone #455, dlfSf/dlfIdp, idpShow) shared one root cause: a scraper's internal row-count guard was **weaker than the downstream contract floor** (`_DEFAULT_SOURCE_ROW_FLOORS`), so a partial scrape passed the scraper, the degraded CSV got committed, and it then **hard-failed CI on a clean checkout — blocking every PR**, while #451's coverage gate only catches it at deploy time.

## Changes
- **New `tests/api/test_source_floor_invariant.py`** — static, pre-merge invariant: every scraper's internal floor ≥ its contract floor. Statically extracts each scraper's floor (no import side-effects, like the existing JS-parsing parity test). Includes a **self-burning-down `_KNOWN_FLOOR_GAPS` allowlist** (same proven pattern as `test_player_identity_regression`'s allowlist) — a post-condition test forces an entry's removal the moment its scraper is hardened, so the allowlist can only shrink. A new source, a lowered scraper floor, or a raised contract floor that breaks the relationship now **fails before it can ship**.
- **`fetch_dlf.py`**: `dlfSf` min_rows 200→240, `dlfIdp` 120→150 (aligned to contract); **check-before-write** so a short scrape preserves last-good instead of overwrite-then-WARN.
- **`fetch_idpshow.py`**: WARN-only at `<100` → **hard-fail at `<150`** (contract floor), preserve last-good (skipped under `--dry-run`).

## Remaining (tracked in `_KNOWN_FLOOR_GAPS`, follow-up PRs)
footballGuys×2, draftSharks×2, fantasyProsFitzmaurice, fantasyProsIdp (input-floor not total), ktc, idpTradeCalc — each allowlisted with a TODO; audit PR A2 (no-floor scrapers) + PR A3 (legacy `Dynasty Scraper.py`) + PR B (per-segment guards) will close them, and the post-condition test enforces allowlist removal on fix.

## Test plan
- [x] `py_compile` clean on both scrapers
- [x] New invariant test: 3/3 pass
- [x] `test_source_monitoring` + `test_launch_readiness` + `test_yahoo_boone_scraper` + full `tests/adapters` + `tests/scripts`: 239 + 68 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)