### PR TITLE
feat(rank-history): derive rank from value so it always renders alongside value history

### DIFF
--- a/frontend/components/PlayerRankHistoryChart.jsx
+++ b/frontend/components/PlayerRankHistoryChart.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { RANKING_SOURCES } from "@/lib/dynasty-data";
+import { rankFromValue } from "@/lib/value-history";
 
 /**
  * PlayerRankHistoryChart — 180-day per-source + blended value chart.
@@ -257,20 +258,59 @@ export default function PlayerRankHistoryChart({
      for SOMETHING, we surface the empty-state copy below the title
      instead of an empty axis. */
   const rankGeometry = useMemo(() => {
-    const sourceRanks = {};
-    for (const [key, series] of Object.entries(state.sourceRanks || {})) {
-      if (!Array.isArray(series)) continue;
-      sourceRanks[key] = series
-        .map((p) => ({ t: parseMs(p.date), rank: Number(p.rank) }))
+    // Build one rank line: start from PERSISTED ranks, then DERIVE a
+    // rank from the value-history series for any snapshot date that
+    // has a value but no persisted rank.  Per-source ranks only began
+    // persisting 2026-04-29 while value history goes back further, so
+    // without this the rank chart was empty/short even when the value
+    // chart spanned the full 180d window.  Derived points reuse the
+    // same Hill curve (rankFromValue = closed-form inverse of
+    // valueFromRank) so they are exactly consistent with the rest of
+    // the app, and are flagged ``derived`` so the legend can note the
+    // approximation (mirrors the value chart's ``anyDerived``).
+    const buildRankSeries = (persistedRaw, valueRaw) => {
+      const persisted = (Array.isArray(persistedRaw) ? persistedRaw : [])
+        .map((p) => ({
+          t: parseMs(p.date),
+          rank: Number(p.rank),
+          derived: false,
+        }))
         .filter((p) => p.t != null && Number.isFinite(p.rank) && p.rank > 0);
+      const haveRankAt = new Set(persisted.map((p) => p.t));
+      const derived = [];
+      for (const p of Array.isArray(valueRaw) ? valueRaw : []) {
+        const t = parseMs(p.date);
+        if (t == null || haveRankAt.has(t)) continue;
+        const r = rankFromValue(Number(p.value));
+        if (r == null || !Number.isFinite(r) || r <= 0) continue;
+        derived.push({ t, rank: r, derived: true });
+      }
+      return [...persisted, ...derived].sort((a, b) => a.t - b.t);
+    };
+
+    const sourceRanks = {};
+    const sourceKeysAll = new Set([
+      ...Object.keys(state.sourceRanks || {}),
+      ...Object.keys(state.sources || {}),
+    ]);
+    for (const key of sourceKeysAll) {
+      const merged = buildRankSeries(
+        (state.sourceRanks || {})[key],
+        (state.sources || {})[key],
+      );
+      if (merged.length) sourceRanks[key] = merged;
     }
     // Our (blended) rank — the bold main line, mirroring "Our blend"
-    // on the value chart.  ``state.blended[].rank`` is the
-    // backend-stamped consensus rank for each historical snapshot;
-    // present alongside ``value`` since the schema's earliest write.
-    const blendedRanks = (state.blended || [])
-      .map((p) => ({ t: parseMs(p.date), rank: Number(p.rank) }))
-      .filter((p) => p.t != null && Number.isFinite(p.rank) && p.rank > 0);
+    // on the value chart.  Persisted ``state.blended[].rank`` where
+    // the backend stamped it; derived from ``state.blended[].value``
+    // for older snapshots that only carry a value.
+    const blendedRanks = buildRankSeries(
+      (state.blended || []).map((p) => ({ date: p.date, rank: p.rank })),
+      (state.blended || []).map((p) => ({ date: p.date, value: p.value })),
+    );
+    const anyRankDerived =
+      blendedRanks.some((p) => p.derived) ||
+      Object.values(sourceRanks).some((s) => s.some((p) => p.derived));
 
     const allTimes = [];
     const allRanks = [];
@@ -370,6 +410,7 @@ export default function PlayerRankHistoryChart({
       chartH,
       rMin,
       rMax,
+      anyDerived: anyRankDerived,
     };
   }, [state, width, height]);
 
@@ -490,6 +531,15 @@ export default function PlayerRankHistoryChart({
           >
             <span className="player-rank-chart-label">
               Rank history · 180d (per source)
+              {rankGeometry.anyDerived && (
+                <span
+                  className="player-rank-chart-asterisk"
+                  title="Ranks for snapshots before per-source ranks began persisting (2026-04-29) are derived from each source's value via the same Hill curve, so the rank line spans the full value-history window."
+                >
+                  {" "}
+                  *
+                </span>
+              )}
             </span>
             <span
               className={`player-rank-chart-delta player-rank-chart-delta--${

--- a/frontend/lib/value-history.js
+++ b/frontend/lib/value-history.js
@@ -306,3 +306,30 @@ export function valueFromRank(rank) {
   const CEIL = 9999;
   return Math.round(1 + CEIL / (1 + Math.pow((r - 1) / K, EXP)));
 }
+
+/**
+ * Closed-form inverse of {@link valueFromRank}.  Given a blended
+ * value on the 1..(1+CEIL) Hill scale, return the rank that produces
+ * it.  Solving ``v = 1 + CEIL / (1 + ((r-1)/K)^EXP)`` for r:
+ *   r = 1 + K * (CEIL/(v-1) - 1)^(1/EXP)
+ *
+ * Used to DERIVE a rank-history line for historical snapshots that
+ * persisted a value but not a rank (per-source ranks only began
+ * persisting 2026-04-29 while value history goes back further).  Same
+ * K/EXP/CEIL as valueFromRank so derived ranks are exactly consistent
+ * with the curve the rest of the app uses.  Returns null when the
+ * value is outside the curve's invertible domain.
+ */
+export function rankFromValue(value) {
+  const v = Number(value);
+  const K = 45;
+  const EXP = 1.1;
+  const CEIL = 9999;
+  if (!Number.isFinite(v) || v <= 1) return null;
+  if (v >= 1 + CEIL) return 1; // saturated → top rank
+  const base = CEIL / (v - 1) - 1; // > 0 for 1 < v < 1+CEIL
+  if (!(base > 0)) return 1;
+  const r = 1 + K * Math.pow(base, 1 / EXP);
+  if (!Number.isFinite(r)) return null;
+  return Math.max(1, Math.round(r));
+}


### PR DESCRIPTION
## Summary
Your original Request 1: *"everywhere there is a value history, there should be a rank history."*

The PlayerPopup rank-history chart only used separately-persisted per-source ranks (which began **2026-04-29**) plus the backend-stamped blended rank. Value history goes back further (the backfill mined older exports), so for many players the **value chart spanned the full 180d while the rank chart showed the gray "fills in over time" fallback** — a value history with no matching rank history.

## Change (frontend only, no backend/data change)
- **`lib/value-history.js`**: add `rankFromValue()` — the **closed-form inverse** of the existing `valueFromRank()` Hill curve (same K=45 / EXP=1.1 / CEIL=9999). Verified the inverse is mathematically exact (rank→value→rank round-trips perfectly: 1→10000→1, 50→4767→50, 400→832→400).
- **`PlayerRankHistoryChart.jsx`** `rankGeometry`: build each rank line as **persisted ranks + a rank derived from that same series' value** at any snapshot lacking a persisted rank. Net effect: the rank chart spans the **same window as the value chart and renders whenever it does**. Derived points are flagged and a `*` marker on the rank header notes the approximation — mirroring the value chart's existing `anyDerived` asterisk convention.

## Test plan
- [x] JS syntax clean (`node -c`)
- [x] `rankFromValue` inverts `valueFromRank` exactly across rank 1..400
- [x] `npm run build` — clean, all pages under budget, no compile/import errors (JSX/webpack issues don't surface in pytest)
- [ ] Visual: open a player popup whose value history predates 2026-04-29 → rank chart now renders across the full window with a `*` derived marker instead of the gray fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)