### PR TITLE
fix(deploy): resolve branch DEPLOY_REF against origin/<ref>, not stale local main

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -153,12 +153,28 @@ resolve_and_validate_sudo_binaries() {
 
 resolve_git_ref() {
   local ref="$1"
-  if git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-    git rev-parse "${ref}^{commit}"
-    return 0
+  # A full 40-char SHA is immutable — resolve directly.
+  if is_full_commit_sha "${ref}"; then
+    if git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+      git rev-parse "${ref}^{commit}"
+      return 0
+    fi
+    return 1
   fi
+  # Branch/tag NAME: the deploy target is its latest PUSHED state.
+  # ``main`` is resolved AFTER ``git fetch``, which advances
+  # ``origin/<ref>`` but NEVER the local branch.  Checking the local
+  # ref first silently deployed a STALE revision whenever local <ref>
+  # lagged origin/<ref> (routine post-merge; worse with a degraded
+  # .git fetch) — it shipped old code 3x in one session while
+  # reporting success.  Resolve ``origin/<ref>`` FIRST; fall back to
+  # the local ref only when there is no remote-tracking ref.
   if git rev-parse --verify --quiet "origin/${ref}^{commit}" >/dev/null; then
     git rev-parse "origin/${ref}^{commit}"
+    return 0
+  fi
+  if git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+    git rev-parse "${ref}^{commit}"
     return 0
   fi
   return 1


### PR DESCRIPTION
## Summary
`deploy.sh` `deploy_main` runs `git fetch` then `resolve_git_ref("main")`. **`git fetch` advances `origin/main` but never the local branch**, yet `resolve_git_ref` checked the **local** ref *first* — so any deploy where local `main` lagged `origin/main` (routine post-merge; worse after a degraded `.git` fetch) **silently deployed a stale revision while reporting success**. Hit production **3× in one session** (had to hand-`git update-ref` local `main` each time).

## Fix (`resolve_git_ref` only)
- Full 40-char SHA → resolve directly (immutable; unchanged).
- Branch/tag name → resolve **`origin/<ref>` first** (just-fetched latest pushed state), fall back to local ref only when there's no remote-tracking ref (dev checkout).

## Test plan
- [x] `bash -n` clean
- [x] Sandbox: stale local `main` (OLD) + `origin/main` (NEW) → resolves **NEW**
- [x] Sandbox: full SHA resolves directly; purely-local branch falls back
- [ ] Next real deploy: "Resolved target revision" == `origin/main` HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)