### PR TITLE
Audit A2: contract-aligned fail-loud floors for the 6 no-floor scrapers

### DIFF
--- a/scripts/fetch_draftsharks.py
+++ b/scripts/fetch_draftsharks.py
@@ -65,6 +65,15 @@ ENV_PATH = REPO / ".env"
 OUT_SF = REPO / "CSVs" / "site_raw" / "draftSharksSf.csv"
 OUT_IDP = REPO / "CSVs" / "site_raw" / "draftSharksIdp.csv"
 
+# Contract-aligned row-count floors (== _DEFAULT_SOURCE_ROW_FLOORS in
+# src/api/data_contract.py).  Existing guards catch idp_count==0 and
+# all-zero IDP values, but a structurally-short-but-nonzero scrape
+# still overwrote last-good and then hard-failed the contract floor
+# on a clean checkout.  Fail loud + preserve last-good if either
+# family is below its floor.
+_DS_SF_ROW_FLOOR: int = 190
+_DS_IDP_ROW_FLOOR: int = 85
+
 HOME_URL = "https://www.draftsharks.com/"
 LOGIN_URL = "https://www.draftsharks.com/login"
 RANKINGS_URL = "https://www.draftsharks.com/dynasty-rankings/te-premium-superflex"
@@ -539,6 +548,21 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+
+    # Contract-aligned floor BEFORE writing: a partial scrape (WASM
+    # worker hung, lazy-load shortfall) that still emits some positive
+    # IDP values must not overwrite last-good with a structurally-
+    # short board that then hard-fails the contract floor on a clean
+    # checkout.  Fail loud, preserve last-good.
+    if off_count < _DS_SF_ROW_FLOOR or idp_count < _DS_IDP_ROW_FLOOR:
+        print(
+            f"[DS] ERROR: degraded scrape — offense={off_count} "
+            f"(floor {_DS_SF_ROW_FLOOR}) idp={idp_count} (floor "
+            f"{_DS_IDP_ROW_FLOOR}).  Preserving last-good CSVs; not "
+            f"overwriting.",
+            file=sys.stderr,
+        )
+        return 2
 
     if args.dry_run:
         print("[DS] dry-run — skipping CSV write")

--- a/scripts/fetch_fantasypros_fitzmaurice.py
+++ b/scripts/fetch_fantasypros_fitzmaurice.py
@@ -62,6 +62,14 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 OUT_PATH = REPO / "CSVs" / "site_raw" / "fantasyProsFitzmaurice.csv"
 
+# Contract-aligned written-total floor (== _DEFAULT_SOURCE_ROW_FLOORS
+# in src/api/data_contract.py).  Previously the only guard aborted at
+# literally zero rows, so a short scrape (a monthly-article column
+# rename, a position page missing) overwrote last-good then hard-
+# failed the contract floor on a clean checkout.  Fail loud +
+# preserve last-good below this.
+_FPF_ROW_FLOOR: int = 225
+
 # Per-position column to use for our Superflex + TE-Premium league.
 # Keys are the position label we stamp onto each row; values are
 # the CSV column-name alternatives we search for in priority order
@@ -410,6 +418,20 @@ def main() -> int:
                 f"{r['team']:<4} value={r['value']}"
             )
         return 0
+
+    # Contract-aligned floor BEFORE writing: a short scrape must not
+    # overwrite last-good with a structurally-degraded board that
+    # then hard-fails the contract floor on a clean checkout.  Fail
+    # loud, preserve last-good.
+    if len(all_rows) < _FPF_ROW_FLOOR:
+        print(
+            f"[fitzmaurice] ERROR: only {len(all_rows)} rows — floor "
+            f"{_FPF_ROW_FLOOR} (== contract).  Likely a column rename "
+            f"or a missing position page.  Preserving last-good CSV; "
+            f"not overwriting.",
+            file=sys.stderr,
+        )
+        return 2
 
     count = _write_csv(OUT_PATH, all_rows)
     print(f"[fitzmaurice] wrote {count} rows → {OUT_PATH.relative_to(REPO)}")

--- a/scripts/fetch_fantasypros_idp.py
+++ b/scripts/fetch_fantasypros_idp.py
@@ -110,6 +110,13 @@ DATA_DIR_DST = REPO_ROOT / "data" / "exports" / "latest" / "site_raw" / "fantasy
 # silently publishing a degraded CSV.
 _FP_COMBINED_ROW_FLOOR: int = 50
 _FP_INDIVIDUAL_ROW_FLOOR: int = 25
+# The two floors above gate the INPUT pages.  The merged/written
+# board can still come up short (overlap dedup, anchor-fit dropping
+# rows) without tripping either input floor — which then overwrote
+# last-good and hard-failed the downstream contract floor on a clean
+# checkout.  This is the WRITTEN-total floor, == _DEFAULT_SOURCE_ROW_
+# FLOORS["fantasyProsIdp"] in src/api/data_contract.py.
+_FP_WRITTEN_ROW_FLOOR: int = 75
 
 # Safety cap for extrapolation past the last anchor — never emit an
 # effective rank deeper than this, regardless of the individual page
@@ -544,6 +551,21 @@ def main(argv: list[str] | None = None) -> int:
         for r in rows[:5]:
             print("  ", r)
         return 0
+
+    # Written-total floor BEFORE writing: input floors above gate the
+    # source pages, but the merged board can still be short.  A short
+    # merged board must not overwrite last-good (it would then hard-
+    # fail the contract floor on a clean checkout).  Fail loud,
+    # preserve last-good.
+    if len(rows) < _FP_WRITTEN_ROW_FLOOR:
+        print(
+            f"[fetch_fantasypros_idp] ERROR: merged board only "
+            f"{len(rows)} rows < written floor {_FP_WRITTEN_ROW_FLOOR} "
+            f"(== contract).  Preserving last-good CSV; not "
+            f"overwriting.",
+            file=sys.stderr,
+        )
+        return 2
 
     _write_csv(args.dest, rows)
     print(f"[fetch_fantasypros_idp] wrote {len(rows)} rows -> {args.dest}")

--- a/scripts/fetch_footballguys.py
+++ b/scripts/fetch_footballguys.py
@@ -104,6 +104,15 @@ _POS_MAP: dict[str, str] = {
 _OFFENSE_POS: frozenset[str] = frozenset({"QB", "RB", "WR", "TE"})
 _IDP_POS: frozenset[str] = frozenset({"DL", "LB", "DB"})
 
+# Contract-aligned row-count floors (== _DEFAULT_SOURCE_ROW_FLOORS in
+# src/api/data_contract.py).  Previously the only guard was a post-
+# write ``==0`` check, so a structurally-short scrape (stale session,
+# changed HTML, a family collapsing) overwrote the last-good CSVs and
+# then hard-failed the contract floor on a clean checkout.  Now: fail
+# loud + preserve last-good if either side is below its floor.
+_FBG_SF_ROW_FLOOR: int = 375
+_FBG_IDP_ROW_FLOOR: int = 230
+
 
 def _load_env_dotfile(path: Path) -> None:
     """Parse ``.env`` and populate ``os.environ`` for any keys it
@@ -458,18 +467,26 @@ def main() -> int:
         print(f"first IDP row: {first_idp}")
         return 0
 
+    # Floor check BEFORE writing: a partial scrape must not overwrite
+    # the last-good CSVs with a structurally-degraded board that would
+    # then hard-fail the downstream contract floor on a clean
+    # checkout.  Fail loud, preserve last-good.
+    off_n = sum(1 for r in all_rows if r["family"] in _OFFENSE_POS)
+    idp_n = sum(1 for r in all_rows if r["family"] in _IDP_POS)
+    if off_n < _FBG_SF_ROW_FLOOR or idp_n < _FBG_IDP_ROW_FLOOR:
+        print(
+            f"[FBG] ERROR: degraded scrape — offense={off_n} "
+            f"(floor {_FBG_SF_ROW_FLOOR}) idp={idp_n} (floor "
+            f"{_FBG_IDP_ROW_FLOOR}); session likely stale or HTML "
+            f"changed.  Preserving last-good CSVs; not overwriting.",
+            file=sys.stderr,
+        )
+        return 2
+
     off_written = _write_csv(OUT_SF, all_rows, include_families=_OFFENSE_POS)
     print(f"[FBG] wrote {OUT_SF} ({off_written} rows)")
     idp_written = _write_csv(OUT_IDP, all_rows, include_families=_IDP_POS)
     print(f"[FBG] wrote {OUT_IDP} ({idp_written} rows)")
-
-    if off_written == 0 or idp_written == 0:
-        print(
-            "[FBG] ERROR: zero rows written for one or both sides — "
-            "session likely stale or HTML structure changed",
-            file=sys.stderr,
-        )
-        return 1
     return 0
 
 

--- a/tests/api/test_source_floor_invariant.py
+++ b/tests/api/test_source_floor_invariant.py
@@ -124,12 +124,28 @@ _SCRAPER_FLOOR_RESOLVERS = {
     # No aligned internal floor today (legacy Dynasty Scraper.py
     # exports, or abort-only-at-zero scrapers).  Resolver returns None
     # => allowlisted below until the named follow-up hardens it.
-    "footballGuysSf": lambda: None,
-    "footballGuysIdp": lambda: None,
-    "draftSharks": lambda: None,
-    "draftSharksIdp": lambda: None,
-    "fantasyProsFitzmaurice": lambda: None,
-    "fantasyProsIdp": lambda: None,
+    # A2 (2026-05-17) — each now has a contract-aligned fail-loud,
+    # preserve-last-good floor; resolvers read the real constant.
+    "footballGuysSf": lambda: _module_int_const(
+        "fetch_footballguys.py", "_FBG_SF_ROW_FLOOR"
+    ),
+    "footballGuysIdp": lambda: _module_int_const(
+        "fetch_footballguys.py", "_FBG_IDP_ROW_FLOOR"
+    ),
+    "draftSharks": lambda: _module_int_const(
+        "fetch_draftsharks.py", "_DS_SF_ROW_FLOOR"
+    ),
+    "draftSharksIdp": lambda: _module_int_const(
+        "fetch_draftsharks.py", "_DS_IDP_ROW_FLOOR"
+    ),
+    "fantasyProsFitzmaurice": lambda: _module_int_const(
+        "fetch_fantasypros_fitzmaurice.py", "_FPF_ROW_FLOOR"
+    ),
+    "fantasyProsIdp": lambda: _module_int_const(
+        "fetch_fantasypros_idp.py", "_FP_WRITTEN_ROW_FLOOR"
+    ),
+    # A3 (legacy Dynasty Scraper.py FULL_DATA export) — still no
+    # aligned floor; allowlisted below until A3 lands.
     "ktc": lambda: None,
     "idpTradeCalc": lambda: None,
 }
@@ -139,12 +155,11 @@ _SCRAPER_FLOOR_RESOLVERS = {
 # REMOVE this entry.  This allowlist can only shrink (enforced by
 # ``test_known_gaps_are_still_real_gaps``).
 _KNOWN_FLOOR_GAPS: dict[str, str] = {
-    "footballGuysSf": "fetch_footballguys.py aborts only at 0 rows; add a >=375 floor + per-family guard (audit PR A2)",
-    "footballGuysIdp": "fetch_footballguys.py — add >=230 floor + per-family guard (audit PR A2)",
-    "draftSharks": "fetch_draftsharks.py aborts only at 0 rows; add a >=190 floor (audit PR A2)",
-    "draftSharksIdp": "fetch_draftsharks.py — add >=85 floor (audit PR A2)",
-    "fantasyProsFitzmaurice": "fetch_fantasypros_fitzmaurice.py aborts only at 0 rows; add a >=225 floor (audit PR A2)",
-    "fantasyProsIdp": "fetch_fantasypros_idp.py floors inputs (50+25) not the written total; add a >=75 written-total floor (audit PR A2)",
+    # A2 closed footballGuys{Sf,Idp} / draftSharks{,Idp} /
+    # fantasyProsFitzmaurice / fantasyProsIdp on 2026-05-17 — each
+    # now has a contract-aligned fail-loud floor; entries removed so
+    # test_known_gaps_are_still_real_gaps enforces the burn-down.
+    # Only the legacy Dynasty Scraper.py sources remain (A3).
     "ktc": "legacy Dynasty Scraper.py FULL_DATA export has no per-source floor; add a >=400 floor (audit PR A3)",
     "idpTradeCalc": "legacy Dynasty Scraper.py — add a >=700 floor + per-sheet guard (audit PR A3/B)",
 }

--- a/tests/scripts/test_fetch_fantasypros_idp.py
+++ b/tests/scripts/test_fetch_fantasypros_idp.py
@@ -186,11 +186,14 @@ class TestBuildRowsFromFixture(unittest.TestCase):
             (tmp / "db.html").write_text(db_html)
 
             dest = tmp / "out.csv"
-            # Bypass row-count floors on the test fixture.
+            # Bypass row-count floors on the tiny test fixture
+            # (input floors + the written-total floor added in A2).
             orig_combined = fp._FP_COMBINED_ROW_FLOOR
             orig_individual = fp._FP_INDIVIDUAL_ROW_FLOOR
+            orig_written = fp._FP_WRITTEN_ROW_FLOOR
             fp._FP_COMBINED_ROW_FLOOR = 1
             fp._FP_INDIVIDUAL_ROW_FLOOR = 1
+            fp._FP_WRITTEN_ROW_FLOOR = 1
             try:
                 rc = fp.main(
                     [
@@ -203,6 +206,7 @@ class TestBuildRowsFromFixture(unittest.TestCase):
             finally:
                 fp._FP_COMBINED_ROW_FLOOR = orig_combined
                 fp._FP_INDIVIDUAL_ROW_FLOOR = orig_individual
+                fp._FP_WRITTEN_ROW_FLOOR = orig_written
             self.assertEqual(rc, 0)
             self.assertTrue(dest.exists())
             import csv


### PR DESCRIPTION
## Summary
Second audit remediation PR. Six sources' scrapers had **no internal floor aligned to the contract** — they aborted only at literally zero rows (or floored inputs, not the written total), so a structurally-short scrape overwrote the last-good CSV and then **hard-failed the contract floor on a clean checkout** (the recurring PR-blocker class).

Each now follows the established **check-before-write → fail-loud → preserve-last-good** pattern (same as yahooBoone #455 / dlf #457), with a module-level floor constant `== _DEFAULT_SOURCE_ROW_FLOORS`:

| Scraper | Floors added |
|---|---|
| `fetch_footballguys.py` | `_FBG_SF_ROW_FLOOR=375`, `_FBG_IDP_ROW_FLOOR=230` (per-family, pre-write) |
| `fetch_draftsharks.py` | `_DS_SF_ROW_FLOOR=190`, `_DS_IDP_ROW_FLOOR=85` (pre-write, after existing 0/value guards) |
| `fetch_fantasypros_fitzmaurice.py` | `_FPF_ROW_FLOOR=225` (written-total) |
| `fetch_fantasypros_idp.py` | `_FP_WRITTEN_ROW_FLOOR=75` (the *written* board, not just the 50/25 input floors) |

`tests/api/test_source_floor_invariant.py`: the 6 resolvers now read the real constants and the 6 `_KNOWN_FLOOR_GAPS` entries are **removed** — the self-burn-down post-condition test enforces this. The allowlist is now down to just the two legacy `Dynasty Scraper.py` sources (ktc, idpTradeCalc → A3).

## Test plan
- [x] `py_compile` clean on all 4 scrapers
- [x] `test_source_floor_invariant.py` 3/3 pass (resolvers find floors ≥ contract; allowlist shrunk; post-condition enforces burn-down)
- [x] `tests/adapters/` + `tests/scripts/` + related = 224 passed (incl. updated fantasypros_idp fixture bypass for the new written floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)