### PR TITLE
Audit A3: legacy-scraper ktc/idpTradeCalc floors — _KNOWN_FLOOR_GAPS now EMPTY

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -697,6 +697,17 @@ def match_all(players, name_map, results, site_key=None):
 
 # Global dict collecting full name_map for every site (for JSON export)
 FULL_DATA = {}
+
+# Contract-aligned site_raw floors for the two legacy-scraper sources
+# (== _DEFAULT_SOURCE_ROW_FLOORS["ktc"/"idpTradeCalc"] in
+# src/api/data_contract.py).  The FULL_DATA->site_raw export had NO
+# floor: a degraded/partial KTC or IDPTC map (proxy/TLS hiccup,
+# partial API intercept, a dropped IDPTC sheet) overwrote the
+# last-good CSV, which then hard-failed the downstream contract floor
+# on a clean checkout.  Below its floor we SKIP the write so the
+# "restore previous site_raw" pass keeps the prior good CSV.
+_KTC_SITE_RAW_FLOOR: int = 400
+_IDPTC_SITE_RAW_FLOOR: int = 700
 DLF_IMPORT_DEBUG = {}
 
 # KTC playerID → name mapping (populated during KTC rankings scrape)
@@ -6517,9 +6528,26 @@ async def run(progress_callback=None):
 
         # Export raw per-site maps to CSV for easier external sharing/audit.
         _fresh_site_raw: set[str] = set()
+        _site_raw_floors = {
+            "ktc": _KTC_SITE_RAW_FLOOR,
+            "idpTradeCalc": _IDPTC_SITE_RAW_FLOOR,
+        }
         for scraper_name, full_map in FULL_DATA.items():
             dash_key = site_key_map.get(scraper_name, scraper_name)
             out_csv = os.path.join(site_raw_dir, f"{dash_key}.csv")
+            # Contract-aligned floor: a degraded/partial map must NOT
+            # overwrite last-good.  Skipping the write leaves the file
+            # absent so the "restore previous site_raw" pass below
+            # preserves the prior good copy.
+            _floor = _site_raw_floors.get(dash_key)
+            if _floor is not None and len(full_map) < _floor:
+                print(
+                    f"  [site_raw] SKIP {dash_key}.csv — only "
+                    f"{len(full_map)} rows < floor {_floor}; preserving "
+                    f"last-good (not overwriting).",
+                    flush=True,
+                )
+                continue
             try:
                 with open(out_csv, "w", newline="", encoding="utf-8") as f:
                     w = csv.writer(f)

--- a/tests/api/test_source_floor_invariant.py
+++ b/tests/api/test_source_floor_invariant.py
@@ -56,7 +56,11 @@ def _module_int_const(rel_path: str, const_name: str) -> int | None:
     importing it (scrapers do import-time work / require network libs).
     Mirrors the static-parsing approach in test_source_registry_parity.
     """
+    # scripts/<rel_path> first; fall back to the repo root so legacy
+    # root-level modules (e.g. "Dynasty Scraper.py") resolve too.
     path = _SCRIPTS / rel_path
+    if not path.exists():
+        path = _REPO / rel_path
     if not path.exists():
         return None
     tree = ast.parse(path.read_text())
@@ -144,10 +148,15 @@ _SCRAPER_FLOOR_RESOLVERS = {
     "fantasyProsIdp": lambda: _module_int_const(
         "fetch_fantasypros_idp.py", "_FP_WRITTEN_ROW_FLOOR"
     ),
-    # A3 (legacy Dynasty Scraper.py FULL_DATA export) — still no
-    # aligned floor; allowlisted below until A3 lands.
-    "ktc": lambda: None,
-    "idpTradeCalc": lambda: None,
+    # A3 (2026-05-17) — legacy Dynasty Scraper.py FULL_DATA->site_raw
+    # export now skips the write below its contract-aligned floor so
+    # the existing restore-previous pass preserves last-good.
+    "ktc": lambda: _module_int_const(
+        "Dynasty Scraper.py", "_KTC_SITE_RAW_FLOOR"
+    ),
+    "idpTradeCalc": lambda: _module_int_const(
+        "Dynasty Scraper.py", "_IDPTC_SITE_RAW_FLOOR"
+    ),
 }
 
 # Sources whose scraper has NO aligned internal floor yet.  Each entry:
@@ -155,13 +164,15 @@ _SCRAPER_FLOOR_RESOLVERS = {
 # REMOVE this entry.  This allowlist can only shrink (enforced by
 # ``test_known_gaps_are_still_real_gaps``).
 _KNOWN_FLOOR_GAPS: dict[str, str] = {
-    # A2 closed footballGuys{Sf,Idp} / draftSharks{,Idp} /
-    # fantasyProsFitzmaurice / fantasyProsIdp on 2026-05-17 — each
-    # now has a contract-aligned fail-loud floor; entries removed so
-    # test_known_gaps_are_still_real_gaps enforces the burn-down.
-    # Only the legacy Dynasty Scraper.py sources remain (A3).
-    "ktc": "legacy Dynasty Scraper.py FULL_DATA export has no per-source floor; add a >=400 floor (audit PR A3)",
-    "idpTradeCalc": "legacy Dynasty Scraper.py — add a >=700 floor + per-sheet guard (audit PR A3/B)",
+    # FULLY BURNED DOWN 2026-05-17.  Every source in
+    # _DEFAULT_SOURCE_ROW_FLOORS now has a contract-aligned, fail-loud,
+    # preserve-last-good internal floor (A2 closed the 6 modular
+    # scrapers; A3 closed the 2 legacy Dynasty Scraper.py sources).
+    # This dict MUST stay empty: a new entry means a new source
+    # shipped without an aligned scraper floor — fix the scraper
+    # instead of allowlisting it.  test_scraper_floor_meets_or_
+    # exceeds_contract_floor now enforces the invariant for ALL
+    # sources with no exceptions.
 }
 
 


### PR DESCRIPTION
## Summary
Final source-integrity remediation. The legacy `Dynasty Scraper.py` `FULL_DATA`→`site_raw/*.csv` export wrote every source's CSV with **no floor**, and the existing "restore previous site_raw" fallback only fires when a file is **absent** — so a degraded/partial KTC or IDPTradeCalc map (proxy/TLS hiccup, partial API intercept, a dropped IDPTC sheet) overwrote last-good then hard-failed the contract floor on a clean checkout.

## Change
- `Dynasty Scraper.py`: module constants `_KTC_SITE_RAW_FLOOR=400`, `_IDPTC_SITE_RAW_FLOOR=700` (== `_DEFAULT_SOURCE_ROW_FLOORS`). In the export loop, when a source's produced map is below floor, **skip the write** — the file stays absent so the **existing restore-previous pass preserves the prior good CSV** (reuse, no new machinery). Loud `[site_raw] SKIP …` log.
- `tests/api/test_source_floor_invariant.py`: `_module_int_const` falls back to repo root so the root-level `"Dynasty Scraper.py"` resolves; ktc/idpTradeCalc resolvers read the new constants; **`_KNOWN_FLOOR_GAPS` is now `{}`**.

## Milestone — allowlist fully burned down (8 → 0)
Every source in `_DEFAULT_SOURCE_ROW_FLOORS` now has a contract-aligned, fail-loud, preserve-last-good internal floor. The static `test_source_floor_invariant` enforces it for **all sources with no exceptions**, complementing the deploy-time #451 gate and the runtime `/api/status` signal — defense-in-depth at all three layers, complete.

## Test plan
- [x] `py_compile "Dynasty Scraper.py"` clean
- [x] `test_source_floor_invariant.py` 3/3 pass (ktc 400≥400, idpTradeCalc 700≥700; allowlist empty)
- [x] `tests/adapters/` + `tests/scripts/` = 224 passed, regression-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)