### PR TITLE
Audit B: fail-loud multi-segment guards (draftsharks_ros IDP page, IDPTC Sheet3)

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -2637,6 +2637,31 @@ async def scrape_idptradecalc(page, players):
                 ]:
                     if isinstance(data_obj.get(key), list):
                         items.extend(data_obj.get(key) or [])
+                # Per-sheet presence guard (defense-in-depth; the A3
+                # idpTradeCalc site_raw floor enforces preserve-last-
+                # good on the total).  Sheet3 is the ~500-player
+                # offense pool; its silent absence while Sheet1 is
+                # present was the historical root cause of top-100
+                # offense players going 1-src.  Surface it loudly.
+                _s1 = (
+                    len(data_obj.get("Sheet1") or [])
+                    if isinstance(data_obj.get("Sheet1"), list)
+                    else 0
+                )
+                _s3 = (
+                    len(data_obj.get("Sheet3") or [])
+                    if isinstance(data_obj.get("Sheet3"), list)
+                    else 0
+                )
+                if _s1 > 0 and _s3 == 0:
+                    print(
+                        f"  [IDPTradeCalc] WARN: Sheet1 present "
+                        f"({_s1}) but Sheet3 (offense pool) MISSING "
+                        f"— partial Apps-Script response; the "
+                        f"idpTradeCalc site_raw floor will preserve "
+                        f"last-good.",
+                        flush=True,
+                    )
                 if not items:
                     for v in data_obj.values():
                         if isinstance(v, list):

--- a/scripts/fetch_draftsharks_ros.py
+++ b/scripts/fetch_draftsharks_ros.py
@@ -217,11 +217,13 @@ async def main_async() -> int:
         # off (rare but possible in a deep IDP league).  Fall back to
         # filtering the SF list on failure.
         idp_only_rows: list[dict] = []
+        idp_page_failed = False
         try:
             idp_only_rows = await _fetch_page(page, ROS_IDP_URL)
             print(f"[ds-ros] idp page yielded {len(idp_only_rows)} unique rows")
         except Exception as exc:
-            print(f"[ds-ros] idp fetch failed: {exc}; will filter SF list instead")
+            idp_page_failed = True
+            print(f"[ds-ros] idp fetch failed: {exc}; preserving last-good if present")
 
         await browser.close()
 
@@ -236,21 +238,43 @@ async def main_async() -> int:
     # which is how DS publishes their ROS list).  Position is preserved.
     n_sf = _write_csv(sf_csv, sf_rows)
 
-    # IDP CSV gets:
-    #   - rows from the IDP page if it loaded
-    #   - else IDPs filtered from the SF list (graceful degradation)
-    if idp_only_rows:
-        idp_filtered = idp_only_rows
+    # IDP CSV.  The SF-filter fallback is acceptable when the IDP
+    # page merely loaded empty, but a FAILED IDP fetch must NOT
+    # silently overwrite the last-good IDP CSV with a degraded
+    # SF-filtered board (this was a silent-degradation bug).  On
+    # failure: preserve last-good if it exists and fail loud; only
+    # fall back when there is no prior good CSV (genuine first run).
+    idp_degraded = False
+    if idp_page_failed and idp_csv.exists():
+        print(
+            f"[ds-ros] ERROR: IDP page fetch failed — preserving "
+            f"last-good {idp_csv.relative_to(REPO)} (NOT overwriting "
+            f"with the SF-filtered fallback).",
+            file=sys.stderr,
+        )
+        idp_degraded = True
+        n_idp = -1
     else:
-        idp_filtered = [
-            r for r in sf_rows
-            if _classify_position(r.get("pos") or "") in _IDP_FAMILIES
-        ]
-    n_idp = _write_csv(idp_csv, idp_filtered)
+        if idp_only_rows:
+            idp_filtered = idp_only_rows
+        else:
+            if idp_page_failed:
+                print(
+                    "[ds-ros] WARN: IDP page failed and no prior "
+                    "draftSharksRosIdp.csv — writing SF-filtered "
+                    "fallback (first run only).",
+                    file=sys.stderr,
+                )
+            idp_filtered = [
+                r for r in sf_rows
+                if _classify_position(r.get("pos") or "") in _IDP_FAMILIES
+            ]
+        n_idp = _write_csv(idp_csv, idp_filtered)
 
     print(f"[ds-ros] wrote {n_sf} rows → {sf_csv.relative_to(REPO)}")
-    print(f"[ds-ros] wrote {n_idp} rows → {idp_csv.relative_to(REPO)}")
-    return 0
+    if n_idp >= 0:
+        print(f"[ds-ros] wrote {n_idp} rows → {idp_csv.relative_to(REPO)}")
+    return 1 if idp_degraded else 0
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
Closes the two HIGH-risk multi-segment scrapers from the audit — where one segment of a multi-part scrape could vanish and the scraper still shipped a degraded board.

- **`scripts/fetch_draftsharks_ros.py`** (the genuine silent bug): a *failed* IDP-page fetch was swallowed and the code silently overwrote the last-good `draftSharksRosIdp.csv` with an SF-filtered fallback. Now: track `idp_page_failed`; on failure with a prior CSV present, **preserve last-good (skip overwrite) and `return 1`** (loud). The SF-filter fallback now applies only on a genuine first run (no prior CSV).
- **`Dynasty Scraper.py` `_extract_idptc_name_map`**: `items.extend(get(key) or [])` silently tolerated a missing Sheet3 (the ~500-player offense pool — historical root cause of top-100 offense going 1-src). Add a loud `WARN` when Sheet1 is present but Sheet3 is absent. **Detection/earlier-signal only** — A3's `idpTradeCalc` site_raw floor (Sheet1+2 ≈625 < 700) already enforces preserve-last-good on the total; this is defense-in-depth with a precise earlier signal.

## Test plan
- [x] `py_compile` clean on both files
- [x] `tests/scripts/` + `tests/adapters/` + `test_source_floor_invariant` regression-clean
- [x] Both commits HEAD-verified (authoritative `git show HEAD:` greps; lint-race-resilient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)