### PR TITLE
fix(settings): default TEP to 1.25, migrate stale 1.0/null, guard wheel-scroll

### DIFF
--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -239,6 +239,11 @@ export default function SettingsPage() {
             max={1.5}
             step={0.01}
             value={tepSliderValue}
+            // Wheel-scrolling a focused number input silently mutates
+            // it (and a stray tick here pins TEP to an explicit
+            // override that overrides the league default).  Blur on
+            // wheel so only deliberate typing changes the value.
+            onWheel={(e) => e.currentTarget.blur()}
             onChange={(e) => {
               const n = parseFloat(e.target.value);
               if (Number.isFinite(n)) {
@@ -284,6 +289,7 @@ export default function SettingsPage() {
             max={1.5}
             step={0.01}
             value={tepNativeInputValue}
+            onWheel={(e) => e.currentTarget.blur()}
             onChange={(e) => {
               const n = parseFloat(e.target.value);
               if (Number.isFinite(n)) {

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -124,9 +124,13 @@ export default function SettingsPage() {
     const n = Number(raw);
     return Number.isFinite(n) ? n : tepDefault;
   })();
+  // 1.25 is the platform default (see SETTINGS_DEFAULTS.tepMultiplier).
+  // Treat the explicit default value — or a legacy null — as "default"
+  // so the UI doesn't render the default as a Custom override.
   const tepIsDefault =
     settings?.tepMultiplier === null ||
-    settings?.tepMultiplier === undefined;
+    settings?.tepMultiplier === undefined ||
+    Number(settings?.tepMultiplier) === 1.25;
 
   // Parallel "TEP-native" multiplier — the per-bucket boost applied
   // to TEP-native sources (DN SF-TEP, Yahoo Boone, FP Fitzmaurice)
@@ -275,7 +279,7 @@ export default function SettingsPage() {
                 cursor: "pointer",
                 padding: 0,
               }}
-              onClick={() => update("tepMultiplier", null)}
+              onClick={() => update("tepMultiplier", 1.25)}
             >
               Reset to default ({tepDefault.toFixed(2)}×)
             </button>

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -16,18 +16,28 @@ export const SETTINGS_DEFAULTS = {
   // TE Premium boost applied at blend time.
   //
   //   * ``tepMultiplier`` → non-TEP sources (DLF, FBG, FP consensus,
-  //     Flock, etc.).  Default 1.25 backend-side.
+  //     Flock, etc.).  Defaults to 1.25 (explicit operator decision —
+  //     this is a TE-premium platform; a standard-league value of
+  //     1.0 is opt-in, not the default).
   //   * ``tepNativeMultiplier`` → TEP-native sources (DN SF-TEP,
   //     Yahoo Boone, FP Fitzmaurice).  Default 1.10 backend-side.
   //
   // KTC variants (ktc, ktcSfTep) stay exempt regardless — KTC's TE++
-  // board is the canonical reference.  ``null`` means "use the
-  // backend default"; when the user types a value on /settings this
-  // flips to a finite number, which ``fetchDynastyData`` POSTs to
-  // the override endpoint as an explicit override.  "Reset" returns
-  // it to null so the default kicks back in.
-  tepMultiplier: null,               // null = backend default (1.25); 1.0..1.5 = explicit operator override
+  // board is the canonical reference.  When the user types a value on
+  // /settings this becomes their explicit override; "Reset" returns
+  // it to the 1.25 default.  ``tepNativeMultiplier`` keeps the ``null``
+  // = backend-default sentinel.  A one-time migration in
+  // ``readSettings`` lifts any persisted ``null`` / ``1.0``
+  // ``tepMultiplier`` (the pre-2026-05 auto-derive default, or a value
+  // a stray number-input wheel-scroll pinned) up to 1.25.
+  tepMultiplier: 1.25,               // 1.25 default; 1.0..1.5 = explicit operator override
   tepNativeMultiplier: null,         // null = backend default (1.10); 1.0..1.5 = explicit operator override
+
+  // One-time migration marker.  False/absent → ``readSettings``
+  // promotes a stale ``tepMultiplier`` of ``null`` or ``1.0`` to the
+  // 1.25 default exactly once, then sets this so a deliberate later
+  // 1.0 (genuine standard league) still sticks.
+  tepDefaultV2Applied: false,
 
   // Rankings display
   rankingsSortBasis: "full",         // "full" | "raw"
@@ -142,7 +152,23 @@ export const SETTINGS_DEFAULTS = {
 function readSettings() {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
-    if (raw) return { ...SETTINGS_DEFAULTS, ...JSON.parse(raw) };
+    if (raw) {
+      const merged = { ...SETTINGS_DEFAULTS, ...JSON.parse(raw) };
+      // One-time TEP default migration.  Pre-2026-05 builds defaulted
+      // tepMultiplier to null ("auto-derive") and a stray wheel-scroll
+      // on the /settings number input could pin it to 1.0 — both
+      // silently disable the TE premium on a TEP platform.  Promote
+      // either to the 1.25 default exactly once; a deliberate later
+      // 1.0 then persists because the flag is set.
+      if (!merged.tepDefaultV2Applied) {
+        if (merged.tepMultiplier == null || merged.tepMultiplier === 1.0) {
+          merged.tepMultiplier = 1.25;
+        }
+        merged.tepDefaultV2Applied = true;
+        writeSettings(merged);
+      }
+      return merged;
+    }
   } catch { /* ignore */ }
   return { ...SETTINGS_DEFAULTS };
 }


### PR DESCRIPTION
## Problem

A user with a single source selected saw Brock Bowers (TE) stuck at the source's native rank in a TE-premium league. After rigorous reproduction against the real exported contract, the backend was proven **correct in every path** (single OTC source → Bowers rank 8 with the 1.25 default; rank 16 *only* when the multiplier is forced to exactly 1.0).

Root cause: the user's persisted `settings.tepMultiplier` was an explicit `1.0` ("Custom"), which the frontend posts verbatim, overriding the league default and disabling the TE premium. The value got pinned because a focused `<input type="number">` silently changes on mouse-wheel scroll, and the pre-2026-05 default of `null`/`1.0` was what showed there.

## Changes

1. **`frontend/app/settings/page.jsx`** — `onWheel` blur guard on both TEP number inputs so a stray scroll can't mutate them. Settings UI now treats `1.25` as the default state (not a "Custom" override) and the reset affordance returns to `1.25`.
2. **`frontend/components/useSettings.js`** — `SETTINGS_DEFAULTS.tepMultiplier` now defaults to **`1.25`** (this is a TE-premium platform; a standard-league `1.0` is opt-in). A one-time migration in `readSettings` lifts any persisted `null` or `1.0` up to `1.25`, gated by a `tepDefaultV2Applied` version flag so a deliberate later `1.0` still sticks.

## Effect

Existing installs (including the reporting user's) auto-migrate on next load: `tepMultiplier` 1.0/null → 1.25, and Brock Bowers moves from rank 16 → rank 8 with the TE premium applied. The wheel guard prevents recurrence.

## Test plan

- [x] Backend reproduction confirms 1.25 → Bowers rank 8 (value 7749); 1.0 → rank 16 (value 6199)
- [x] No existing test asserts `SETTINGS_DEFAULTS.tepMultiplier === null`; `tepMultiplierIsCustomized` / `fetchDynastyData` / trade-logic tests pass explicit values and are unaffected
- [ ] CI (Validate PR) — frontend jest + python suites (jest not runnable in this environment; relying on CI)
- [ ] Manual: load /settings, confirm TEP shows 1.25 "Default", wheel-scroll over the field is inert, single-source board shows Bowers boosted


---
_Generated by [Claude Code](https://claude.ai/code/session_01MzoiuZKx5HVqLuE1DXR797)_