### PR TITLE
fix(tep): default 1.15 (TEP-1.5) + clamp boosted TE values to the 9999 scale

### DIFF
--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -109,14 +109,14 @@ export default function SettingsPage() {
   }
 
   // TE Premium input value.  The backend stamps the operator's
-  // current default (``rankingsOverride.tepMultiplierDerived``, which
-  // post-2026-05-06 is just the hardcoded non-TEP default 1.25 and no
-  // longer comes from Sleeper's ``bonus_rec_te``); we use that as the
-  // displayed value when the user has not set an explicit override,
-  // falling back to 1.25 if the field is missing.
+  // current default (``rankingsOverride.tepMultiplierDerived``, the
+  // hardcoded non-native default 1.15 — TEP-1.5 platform; Sleeper
+  // never exposes ``bonus_rec_te`` here); we use that as the displayed
+  // value when the user has not set an explicit override, falling back
+  // to 1.15 if the field is missing.
   const tepDefault = (() => {
     const v = Number(rawData?.rankingsOverride?.tepMultiplierDerived);
-    return Number.isFinite(v) ? v : 1.25;
+    return Number.isFinite(v) ? v : 1.15;
   })();
   const tepSliderValue = (() => {
     const raw = settings?.tepMultiplier;
@@ -124,13 +124,13 @@ export default function SettingsPage() {
     const n = Number(raw);
     return Number.isFinite(n) ? n : tepDefault;
   })();
-  // 1.25 is the platform default (see SETTINGS_DEFAULTS.tepMultiplier).
+  // 1.15 is the platform default (see SETTINGS_DEFAULTS.tepMultiplier).
   // Treat the explicit default value — or a legacy null — as "default"
   // so the UI doesn't render the default as a Custom override.
   const tepIsDefault =
     settings?.tepMultiplier === null ||
     settings?.tepMultiplier === undefined ||
-    Number(settings?.tepMultiplier) === 1.25;
+    Number(settings?.tepMultiplier) === 1.15;
 
   // Parallel "TEP-native" multiplier — the per-bucket boost applied
   // to TEP-native sources (DN SF-TEP, Yahoo Boone, FP Fitzmaurice)
@@ -279,7 +279,7 @@ export default function SettingsPage() {
                 cursor: "pointer",
                 padding: 0,
               }}
-              onClick={() => update("tepMultiplier", 1.25)}
+              onClick={() => update("tepMultiplier", 1.15)}
             >
               Reset to default ({tepDefault.toFixed(2)}×)
             </button>

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -16,28 +16,30 @@ export const SETTINGS_DEFAULTS = {
   // TE Premium boost applied at blend time.
   //
   //   * ``tepMultiplier`` → non-TEP sources (DLF, FBG, FP consensus,
-  //     Flock, etc.).  Defaults to 1.25 (explicit operator decision —
-  //     this is a TE-premium platform; a standard-league value of
-  //     1.0 is opt-in, not the default).
+  //     Flock, etc.).  Defaults to 1.15: this platform's leagues are
+  //     TEP-1.5 (``superflex_tep15_ppr1``) and the derivation formula
+  //     ``1.0 + 0.5*0.30`` maps TEP-1.5 → 1.15.  1.25 over-boosted
+  //     elite TEs above the individual-source consensus (Bowers #2
+  //     overall when no source ranked him near there).
   //   * ``tepNativeMultiplier`` → TEP-native sources (DN SF-TEP,
   //     Yahoo Boone, FP Fitzmaurice).  Default 1.10 backend-side.
   //
   // KTC variants (ktc, ktcSfTep) stay exempt regardless — KTC's TE++
   // board is the canonical reference.  When the user types a value on
   // /settings this becomes their explicit override; "Reset" returns
-  // it to the 1.25 default.  ``tepNativeMultiplier`` keeps the ``null``
+  // it to the 1.15 default.  ``tepNativeMultiplier`` keeps the ``null``
   // = backend-default sentinel.  A one-time migration in
-  // ``readSettings`` lifts any persisted ``null`` / ``1.0``
-  // ``tepMultiplier`` (the pre-2026-05 auto-derive default, or a value
-  // a stray number-input wheel-scroll pinned) up to 1.25.
-  tepMultiplier: 1.25,               // 1.25 default; 1.0..1.5 = explicit operator override
+  // ``readSettings`` lifts any persisted "default-ish" value (``null``
+  // pre-2026-05 auto-derive, ``1.0`` from a stray wheel-scroll, or the
+  // interim ``1.25``) to 1.15.
+  tepMultiplier: 1.15,               // 1.15 default; 1.0..1.5 = explicit operator override
   tepNativeMultiplier: null,         // null = backend default (1.10); 1.0..1.5 = explicit operator override
 
   // One-time migration marker.  False/absent → ``readSettings``
-  // promotes a stale ``tepMultiplier`` of ``null`` or ``1.0`` to the
-  // 1.25 default exactly once, then sets this so a deliberate later
-  // 1.0 (genuine standard league) still sticks.
-  tepDefaultV2Applied: false,
+  // promotes a stale ``tepMultiplier`` of ``null`` / ``1.0`` / ``1.25``
+  // to the 1.15 default exactly once, then sets this so a deliberate
+  // later value still sticks.
+  tepDefaultV3Applied: false,
 
   // Rankings display
   rankingsSortBasis: "full",         // "full" | "raw"
@@ -154,17 +156,22 @@ function readSettings() {
     const raw = localStorage.getItem(SETTINGS_KEY);
     if (raw) {
       const merged = { ...SETTINGS_DEFAULTS, ...JSON.parse(raw) };
-      // One-time TEP default migration.  Pre-2026-05 builds defaulted
-      // tepMultiplier to null ("auto-derive") and a stray wheel-scroll
-      // on the /settings number input could pin it to 1.0 — both
-      // silently disable the TE premium on a TEP platform.  Promote
-      // either to the 1.25 default exactly once; a deliberate later
-      // 1.0 then persists because the flag is set.
-      if (!merged.tepDefaultV2Applied) {
-        if (merged.tepMultiplier == null || merged.tepMultiplier === 1.0) {
-          merged.tepMultiplier = 1.25;
+      // One-time TEP default migration.  Earlier builds left
+      // tepMultiplier at null ("auto-derive"), a stray wheel-scroll
+      // could pin it to 1.0, and an interim build defaulted it to
+      // 1.25 (which over-boosted elite TEs).  Promote any of those
+      // "default-ish" values to the corrected 1.15 default exactly
+      // once; a deliberate later value persists because the flag is
+      // set.
+      if (!merged.tepDefaultV3Applied) {
+        if (
+          merged.tepMultiplier == null ||
+          merged.tepMultiplier === 1.0 ||
+          merged.tepMultiplier === 1.25
+        ) {
+          merged.tepMultiplier = 1.15;
         }
-        merged.tepDefaultV2Applied = true;
+        merged.tepDefaultV3Applied = true;
         writeSettings(merged);
       }
       return merged;

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4865,7 +4865,14 @@ _TEP_NATIVE_ASSUMED_MULTIPLIER: float = 1.15
 # (KTC TE++) skip both factors.  ktc is mathematically
 # ``is_tep_premium=False`` and would normally pick up the non-TEP
 # multiplier; the exemption set below short-circuits that.
-_TE_BLANKET_NON_NATIVE_MULTIPLIER: float = 1.25
+#
+# The non-native default is 1.15: this platform's leagues are TEP-1.5
+# (``superflex_tep15_ppr1``), and the derivation formula
+# ``1.0 + 0.5*0.30`` maps TEP-1.5 → 1.15.  Sleeper's API does not
+# expose ``bonus_rec_te`` for these leagues (always 0.0), so the
+# "non-TEP fallback" is in practice the platform default and must
+# reflect TEP-1.5, not a generic 1.25.
+_TE_BLANKET_NON_NATIVE_MULTIPLIER: float = 1.15
 _TE_BLANKET_NATIVE_MULTIPLIER: float = 1.10
 _TE_BLANKET_KTC_EXEMPT_KEYS: frozenset[str] = frozenset({"ktc", "ktcSfTep"})
 
@@ -6181,19 +6188,27 @@ def _compute_unified_rankings(
             # Blanket TE-value multipliers (see the constants block
             # near ``_TE_BLANKET_NON_NATIVE_MULTIPLIER``).  Non-TEP
             # sources scale by ``effective_non_tep_multiplier`` (the
-            # operator's slider value, default 1.25).  TEP-native
+            # operator's slider value, default 1.15).  TEP-native
             # sources scale by the hardcoded 1.10×.  KTC is exempt
             # because its TE++ board is already the canonical reference
             # we're aligning everyone else to.
+            #
+            # The boosted value is clamped to the 9,999 scale ceiling
+            # that bounds every other position's contribution (the
+            # value-direct path is ``raw / site_max * 9999`` and the
+            # Hill max is ~9,999).  Without the clamp an elite TE's
+            # boosted contribution exceeds 9,999, structurally letting
+            # one TE out-value the consensus #1 overall — the premium
+            # must reposition TEs *within* the scale, not break it.
             if (
                 row_is_te
                 and source_key not in _TE_BLANKET_KTC_EXEMPT_KEYS
             ):
                 if source_key in tep_boosted_source_keys:
-                    value *= effective_non_tep_multiplier
+                    value = min(value * effective_non_tep_multiplier, 9999.0)
                     tep_applied = True
                 elif source_key in tep_native_source_keys:
-                    value *= effective_native_multiplier
+                    value = min(value * effective_native_multiplier, 9999.0)
                     tep_native_corrected = True
             all_values.append(value)
             is_anchor_source = source_key in cross_market_keys

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -1064,9 +1064,10 @@ class TestBuildContractTepAutoDerive(unittest.TestCase):
         self.assertEqual(rov.get("tepMultiplierSource"), "derived")
 
     def test_non_tep_league_falls_back_to_default(self) -> None:
-        """``bonus_rec_te == 0`` (non-TEP league) → hardcoded 1.25
-        default, not the derived 1.0.  Preserves predictable behavior
-        for leagues whose Sleeper config legitimately has no TE bonus.
+        """``bonus_rec_te == 0`` (non-TEP league) → hardcoded
+        ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` default (1.15), not the
+        derived 1.0.  Preserves predictable behavior for leagues whose
+        Sleeper config legitimately has no TE bonus.
         """
         with self._patch_context(bonus_rec_te=0.0):
             contract = build_api_data_contract(_fixture_raw_payload())
@@ -1175,8 +1176,11 @@ class TestTepMultipliersEndToEnd(unittest.TestCase):
         self.assertEqual(rov.get("tepMultiplierSource"), "default")
         self.assertEqual(rov.get("tepNativeMultiplierSource"), "default")
         # Pin the actual numeric defaults so a registry tweak that
-        # silently shifts either constant fails this test.
-        self.assertAlmostEqual(_TE_BLANKET_NON_NATIVE_MULTIPLIER, 1.25)
+        # silently shifts either constant fails this test.  Non-native
+        # is 1.15: this is a TEP-1.5 platform (1.0 + 0.5*0.30) and
+        # Sleeper never exposes bonus_rec_te, so the "fallback" is the
+        # de-facto platform default; 1.25 over-boosted elite TEs.
+        self.assertAlmostEqual(_TE_BLANKET_NON_NATIVE_MULTIPLIER, 1.15)
         self.assertAlmostEqual(_TE_BLANKET_NATIVE_MULTIPLIER, 1.10)
 
     def test_override_path_propagates_to_summary_and_per_source_meta(self) -> None:


### PR DESCRIPTION
## Problem

After the prior fix restored the TE premium, `tepMultiplier = 1.25` over-boosted elite TEs: **Brock Bowers blended to #2 overall** on the full board while no individual source ranked him above #5 (avg source rank ≈ 12). The premium was lifting a ~#12-consensus TE above a near-consensus-#1 WR (Ja'Marr Chase).

Two root causes:

1. **1.25 is too strong for this platform.** The leagues are TEP-1.5 (`superflex_tep15_ppr1`). The platform's own derivation formula `1.0 + bonus·0.30` maps TEP-1.5 → **1.15**. 1.25 was only ever the generic "unknown TEP" fallback (used because Sleeper's API reports `bonus_rec_te = 0.0` for these leagues).
2. **Boosted TE values broke the value scale.** The multiplier was applied with no ceiling, so an elite TE's per-source contribution exceeded the **9,999** cap that bounds every other position — structurally letting one TE out-value the consensus #1 overall.

## Changes

- **`src/api/data_contract.py`**: `_TE_BLANKET_NON_NATIVE_MULTIPLIER` 1.25 → **1.15**; clamp the post-multiply TE contribution to **9,999** (both the boost and native-correction branches).
- **`frontend/components/useSettings.js`**: default `tepMultiplier` 1.25 → **1.15**; one-time **V3 migration** lifts any stale `null` / `1.0` / `1.25` to 1.15 (gated by `tepDefaultV3Applied`, so deliberate later values stick).
- **`frontend/app/settings/page.jsx`**: treat 1.15 as the default state; reset writes 1.15; copy/fallbacks updated.
- **`tests/api/test_source_overrides.py`**: update the deliberate constant pin 1.25 → 1.15 and a docstring.

## Effect (verified against the live export)

| | before (1.25) | after (1.15 + clamp) |
|---|---|---|
| Brock Bowers | #2 (val 9841) | **#6** (val 9437) — next to his #5 KTC TE++ rank |
| Trey McBride | #8 | #9 |
| Board top | Allen, **Bowers**, Chase, Maye, Bijan | Allen, Chase, Maye, Bijan, JSN, **Bowers** |

Existing installs auto-migrate on next `/settings` load.

## Test plan

- [x] `tests/api/test_source_overrides.py`, `test_market_corridor_clamp.py`, `test_single_curve_live.py`, `test_compact_view.py` — 140 passed
- [x] Live-export reproduction confirms Bowers #6 / sane top-12
- [ ] CI (Validate PR) — full python + frontend jest
- [ ] Manual: `/settings` shows TEP 1.15 "Default"; single-source and blended boards both read sensibly


---
_Generated by [Claude Code](https://claude.ai/code/session_01MzoiuZKx5HVqLuE1DXR797)_