### PR TITLE
fix(trade): apply KTC Value Adjustment to suggestion gap/fairness

### DIFF
--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from src.canonical.calibration import to_display_value
+from src.trade.ktc_va import adjusted_pair_totals
 from src.utils.name_clean import normalize_position as _norm_pos  # noqa: F401 — see _norm_pos shim removal below (audit S2)
 
 
@@ -577,6 +578,24 @@ def _trade_is_idp_free(give: list[PlayerAsset], receive: list[PlayerAsset]) -> b
     )
 
 
+def _va_gap(give_vals: list[int], recv_vals: list[int]) -> int:
+    """Trade gap after KTC's Value Adjustment.
+
+    The trade analyzer applies KTC's VA before computing its
+    "Major gap" verdict (frontend/lib/trade-logic.js, backed by the
+    same src.trade.ktc_va port).  Suggestions must use the identical
+    math or they propose packages that look even on raw totals but
+    show a major gap once loaded into the builder — e.g. 2-for-1
+    consolidations where KTC's quantity discount inflates the
+    single-stud side.  Callers MUST pass the individual piece values
+    (not a pre-summed total) so the per-piece discount actually
+    triggers; for genuine 1-for-1s KTC suppresses VA, so the result
+    equals the raw difference.
+    """
+    give_adj, recv_adj, _, _ = adjusted_pair_totals(give_vals, recv_vals)
+    return int(round(give_adj - recv_adj))
+
+
 def _fairness_label(gap: int) -> str:
     a = abs(gap)
     if a < 256:
@@ -837,7 +856,7 @@ def _generate_sell_high(
                 oo = _trade_is_idp_free([sell], [target])
                 give_val = _eff_val(sell, oo)
                 recv_val = _eff_val(target, oo)
-                gap = give_val - recv_val
+                gap = _va_gap([give_val], [recv_val])
                 suggestions.append(TradeSuggestion(
                     type="sell_high",
                     give=[sell],
@@ -891,7 +910,7 @@ def _generate_buy_low(
                     oo = _trade_is_idp_free([sell], [target])
                     give_val = _eff_val(sell, oo)
                     recv_val = _eff_val(target, oo)
-                    gap = give_val - recv_val
+                    gap = _va_gap([give_val], [recv_val])
                     if abs(gap) < FAIRNESS_TOLERANCE:
                         suggestions.append(TradeSuggestion(
                             type="buy_low",
@@ -974,9 +993,10 @@ def _generate_consolidation(
                 targets.sort(key=lambda t: abs(combined - _eff_val(t, pair_oo)))
                 target = targets[0]
                 oo = _trade_is_idp_free([p1, p2], [target])
-                give_total = _eff_val(p1, oo) + _eff_val(p2, oo)
+                give_p1, give_p2 = _eff_val(p1, oo), _eff_val(p2, oo)
+                give_total = give_p1 + give_p2
                 recv_total = _eff_val(target, oo)
-                gap = give_total - recv_total
+                gap = _va_gap([give_p1, give_p2], [recv_total])
                 pos_note = f" at a position of need ({target.position})" if target.position in roster.need_positions else ""
                 suggestions.append(TradeSuggestion(
                     type="consolidation",
@@ -1061,9 +1081,11 @@ def _generate_positional_upgrades(
             sweeteners.sort(key=lambda s: abs(_eff_val(s, pos_oo) - gap_needed))
             sweetener = sweeteners[0]
             oo = _trade_is_idp_free([weakest_starter, sweetener], [target])
-            give_total = _eff_val(weakest_starter, oo) + _eff_val(sweetener, oo)
+            give_ws = _eff_val(weakest_starter, oo)
+            give_sw = _eff_val(sweetener, oo)
+            give_total = give_ws + give_sw
             recv_total = _eff_val(target, oo)
-            gap = give_total - recv_total
+            gap = _va_gap([give_ws, give_sw], [recv_total])
 
             if abs(gap) > FAIRNESS_TOLERANCE * 1.5:
                 continue
@@ -1191,13 +1213,17 @@ def _apply_quality_filters(
     Each filter preserves the existing rank order — it only removes, never reorders.
     """
     # ── 1. Suppress unrealistic consolidation stretches ────────────
-    # Allow stretch consolidations where the overpay is ≤30% of the
-    # give total — these are plausible "package for upgrade" deals.
+    # Allow stretch consolidations where the VA-adjusted gap is ≤30%
+    # of the give total — these are plausible "package for upgrade"
+    # deals.  The magnitude is bounded in both directions: a package
+    # that lands hugely in the user's favour after VA (a single elite
+    # for two depth pieces) is just as unrealistic as a big overpay —
+    # no opponent accepts either.
     if "consolidation" in categories:
         categories["consolidation"] = [
             s for s in categories["consolidation"]
             if s.fairness != "stretch"
-            or (s.give_total > 0 and s.gap / s.give_total <= CONSOLIDATION_MAX_OVERPAY_RATIO)
+            or (s.give_total > 0 and abs(s.gap) / s.give_total <= CONSOLIDATION_MAX_OVERPAY_RATIO)
         ]
 
     # ── 2. Cap receive-target repetition per category ────────────────

--- a/tests/test_trade_suggestions.py
+++ b/tests/test_trade_suggestions.py
@@ -19,6 +19,7 @@ from src.trade.suggestions import (
     rank_score,
     rank_score_breakdown,
     _fairness_label,
+    _va_gap,
     _norm_pos,
     _compute_cv,
     _edge_for_suggestion,
@@ -1390,6 +1391,50 @@ class TestConsolidationStretchFilter:
         assert len(result["consolidation"]) == 2
 
 
+class TestVaAwareGap:
+    """The suggestion gap must use KTC's Value Adjustment — the same
+    math the trade analyzer applies before its 'Major gap' verdict.
+
+    Regression for the reported bug: a 2-for-1 consolidation that is
+    even on raw value sums but VA-lopsided once KTC's quantity
+    discount inflates the single-stud side was being surfaced as a
+    fair suggestion, then showed a 'Major gap (33%)' the moment it
+    was loaded into the trade builder.
+    """
+
+    def test_one_for_one_gap_equals_raw(self):
+        """KTC suppresses VA on genuine 1-for-1s, so the VA gap must
+        equal the raw difference (no behavior change for swaps)."""
+        assert _va_gap([5000], [4800]) == 200
+        assert _va_gap([4800], [5000]) == -200
+
+    def test_two_for_one_raw_even_is_va_lopsided(self):
+        """Two depth pieces summing ≈ one stud is even on raw totals
+        but a large negative VA gap once KTC's consolidation premium
+        boosts the single-stud side."""
+        raw_gap = (4900 + 4800) - 9600  # +100, "even" on raw
+        assert abs(raw_gap) < 256
+        va = _va_gap([4900, 4800], [9600])
+        assert va < -769, (
+            f"expected a VA-lopsided gap, got {va} (raw was {raw_gap})"
+        )
+
+    def test_user_favorable_va_stretch_is_filtered(self):
+        """A consolidation whose VA gap lands hugely in the user's
+        favour (single elite for two depth pieces) is just as
+        unrealistic as a big overpay — the magnitude is bounded in
+        both directions, so it must be suppressed."""
+        s = _make_suggestion(fairness="stretch", give_val=9518, recv_val=9518)
+        s.type = "consolidation"
+        s.give.append(PlayerAsset("Depth Piece", "WR", 4000, 4000, source_count=6))
+        s.gap = -4712  # VA gap: opponent grossly overpays — no one accepts
+        result = _apply_quality_filters({
+            "sell_high": [], "buy_low": [],
+            "consolidation": [s], "positional_upgrade": [],
+        })
+        assert len(result["consolidation"]) == 0
+
+
 class TestSeparateGivePlayerBudgets:
     """1-for-1 and package categories have separate give-player caps."""
 
@@ -2085,10 +2130,13 @@ class TestEffectiveSourceRanks:
                       site_values=self._raw_site_values(3200)),
             self._row("RB Depth B", "RB", 3100,
                       site_values=self._raw_site_values(3100)),
-            # Consolidation target at WR (a need position).
+            # Consolidation target at WR (a need position).  Valued so
+            # the (3200 + 3100) depth package lands VA-near-even once
+            # KTC's quantity discount is applied — a realistic
+            # consolidation, not a raw-even-but-VA-lopsided 2-for-1.
             self._row(
-                "WR Consolidation Target", "WR", 6200,
-                site_values=self._raw_site_values(6200),
+                "WR Consolidation Target", "WR", 4600,
+                site_values=self._raw_site_values(4600),
                 effective_source_ranks=self._effective_ranks(
                     ["src0", "src1", "src2", "src3"]
                 ),
@@ -2131,33 +2179,35 @@ class TestEffectiveSourceRanks:
         )
         rows = [
             # 4 WR starters so the upgrade target clears upgrade_floor
-            # against the weakest slotted starter.
+            # against the weakest slotted starter (WR Starter D = 3300).
             self._row("WR Starter A", "WR", 6000,
                       site_values=self._raw_site_values(6000)),
-            self._row("WR Starter B", "WR", 5500,
-                      site_values=self._raw_site_values(5500)),
-            self._row("WR Starter C", "WR", 5000,
+            self._row("WR Starter B", "WR", 5000,
                       site_values=self._raw_site_values(5000)),
-            self._row("WR Starter D", "WR", 4500,
-                      site_values=self._raw_site_values(4500)),
+            self._row("WR Starter C", "WR", 4000,
+                      site_values=self._raw_site_values(4000)),
+            self._row("WR Starter D", "WR", 3300,
+                      site_values=self._raw_site_values(3300)),
             self._row("WR Depth", "WR", 3200,
                       site_values=self._raw_site_values(3200)),
             # RB surplus (3 starters + 2 depth) supplies the sweetener
             # search fallback the engine uses for positional upgrades.
+            # Depth sized so weakest_starter + sweetener vs. target is
+            # VA-near-even, not raw-even-but-VA-lopsided.
             self._row("RB1", "RB", 7000,
                       site_values=self._raw_site_values(7000)),
             self._row("RB2", "RB", 6800,
                       site_values=self._raw_site_values(6800)),
             self._row("RB3", "RB", 6600,
                       site_values=self._raw_site_values(6600)),
-            self._row("RB Depth A", "RB", 2800,
-                      site_values=self._raw_site_values(2800)),
-            self._row("RB Depth B", "RB", 2700,
-                      site_values=self._raw_site_values(2700)),
+            self._row("RB Depth A", "RB", 1420,
+                      site_values=self._raw_site_values(1420)),
+            self._row("RB Depth B", "RB", 1400,
+                      site_values=self._raw_site_values(1400)),
             # Upgrade target at WR: raw=8 sources, effective=2 → low.
             self._row(
-                "WR Upgrade Target", "WR", 7500,
-                site_values=self._raw_site_values(7500),
+                "WR Upgrade Target", "WR", 4200,
+                site_values=self._raw_site_values(4200),
                 effective_source_ranks=self._effective_ranks(
                     ["src0", "src1"]
                 ),


### PR DESCRIPTION
## Summary

The trade **suggestions** engine judged fairness from **raw** value sums, while the trade **analyzer/builder** applies KTC's Value Adjustment (the `+VA` in the UI) before computing its "Major gap" verdict. The two paths disagreed: 2-for-1 consolidations that looked even on raw totals (e.g. *Give: Chris Olave + Omar Cooper → Get: Bijan Robinson*) showed a **Major gap (33%)** the instant they were loaded into the builder, because KTC's quantity discount inflates the single-stud side.

A verified Python port of KTC's VA already exists (`src/trade/ktc_va.py`) and is used by the angle finder and Monte Carlo paths — the suggestions engine simply never called it.

## Changes

- Added `_va_gap()` in `src/trade/suggestions.py` that routes give/receive values through `src.trade.ktc_va.adjusted_pair_totals` (the same port the analyzer is backed by).
- All four suggestion gap computations (`sell_high`, `buy_low`, `consolidation`, `positional_upgrade`) now use the VA-aware gap, so fairness labels, balancer sizing, ranking tiebreakers, and edge detection all reflect the VA the user actually sees.
- Per-piece values are passed (not pre-summed totals) so KTC's per-piece quantity discount triggers; genuine 1-for-1s are unchanged since KTC suppresses VA there.
- The consolidation "stretch" quality filter now bounds `abs(gap)` instead of the signed gap, so packages that land hugely in the user's favour (a single elite for two depth pieces — which no opponent would accept) are dropped just like big overpays.
- Retuned two `TestEffectiveSourceRanks` fixtures whose constructed 2-for-1s were raw-even but VA-lopsided, so they remain VA-fair (the tests assert confidence tiers, which are orthogonal to this fix).
- Added `TestVaAwareGap` regression coverage pinning the exact reported bug.

## Test plan

- [x] `pytest tests/test_trade_suggestions.py tests/trade/` — 193 passed (incl. 3 new regression tests)
- [x] Confirmed the remaining full-suite failures (adapters / draft_capital / league_registry / public_league) are pre-existing and caused by missing optional deps (`fastapi`, `openpyxl`) in the CI sandbox, not this change — verified by re-running them on a clean tree.
- [ ] Manual: load a previously-flagged "fair" 2-for-1 consolidation suggestion into the trade builder and confirm the suggested gap now matches the analyzer's adjusted gap / no longer surfaces lopsided packages.

https://claude.ai/code/session_011x4qY4DHWRqSJj7RkJLDBx

---
_Generated by [Claude Code](https://claude.ai/code/session_011x4qY4DHWRqSJj7RkJLDBx)_