### PR TITLE
fix(backup): self-healing dir + guest_passes + stdlib sqlite

### DIFF
--- a/deploy/backup_user_kv.sh
+++ b/deploy/backup_user_kv.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 #
-# backup_user_kv.sh — nightly backup of user_kv.sqlite + session_store.sqlite
+# backup_user_kv.sh — nightly backup of user_kv.sqlite + session_store.sqlite + guest_passes.sqlite
 #
 # Run from cron at 02:00 UTC:
 #   0 2 * * * /home/dynasty/trade-calculator/deploy/backup_user_kv.sh
 #
-# Keeps 30 daily + 12 monthly backups locally in /var/backups/riskit/.
-# Uses SQLite's ``.backup`` command so backups are consistent even
-# while the app is writing (WAL journaling permits online backup).
+# Keeps 30 daily + 12 monthly backups locally in /var/backups/riskit/
+# (falls back to /home/dynasty/backups/riskit if that needs root).
+# Uses the Python stdlib sqlite3 Connection.backup() primitive (the
+# sqlite3 CLI is not installed) so backups are consistent even while
+# the app is writing (WAL journaling permits online backup).
 #
 # Optional: set BACKUP_S3_BUCKET env var to also mirror to S3 / B2
 # via rclone.  If rclone is unavailable or the env var is unset,
 # local-only backup is still good.
 #
 # Weekly restore-test flag: run with --restore-test to exercise the
-# restore path (requires a DB tool; currently just validates the
-# file is readable via sqlite3).
+# restore path (decompress latest daily, run PRAGMA integrity_check
+# and a row count via the Python sqlite3 module).
 
 set -Eeuo pipefail
 
@@ -26,7 +28,69 @@ KEEP_MONTHLY="${KEEP_MONTHLY:-12}"
 DATE_STAMP="$(date -u +%Y-%m-%d)"
 DAY_OF_MONTH="$(date -u +%d)"
 
-mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/monthly"
+BACKUP_FALLBACK_DIR="${BACKUP_FALLBACK_DIR:-/home/dynasty/backups/riskit}"
+
+PYTHON_BIN="${PYTHON_BIN:-/home/dynasty/.venvs/trade-calculator/bin/python}"
+[[ -x "$PYTHON_BIN" ]] || PYTHON_BIN="$(command -v python3 || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+    echo "BACKUP-FAILED: no python interpreter available for sqlite backup" >&2
+    exit 1
+fi
+
+# Online, WAL-safe SQLite backup via the Python stdlib sqlite3 module.
+# Connection.backup() is the same online-backup primitive the sqlite3
+# CLI's ``.backup`` exposes; the CLI is not installed on this host.
+sqlite_backup() {
+    "$PYTHON_BIN" - "$1" "$2" <<'PY'
+import sqlite3, sys
+src, dst = sys.argv[1], sys.argv[2]
+con = sqlite3.connect(src)
+try:
+    bck = sqlite3.connect(dst)
+    try:
+        with bck:
+            con.backup(bck)
+    finally:
+        bck.close()
+finally:
+    con.close()
+PY
+}
+
+sqlite_query() {
+    "$PYTHON_BIN" - "$1" "$2" <<'PY'
+import sqlite3, sys
+db, sql = sys.argv[1], sys.argv[2]
+con = sqlite3.connect(db)
+try:
+    for row in con.execute(sql):
+        print("|".join("" if v is None else str(v) for v in row))
+finally:
+    con.close()
+PY
+}
+
+ensure_backup_dir() {
+    # Primary location first.  If it cannot be created or is not
+    # writable, fall back to a directory the 'dynasty' service user
+    # owns.  (/var/backups needs root; that permission failure killed
+    # backups silently for weeks — the fallback makes that impossible.)
+    if mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/monthly" 2>/dev/null \
+        && [[ -w "$BACKUP_DIR/daily" ]]; then
+        return 0
+    fi
+    local reason="primary backup dir '$BACKUP_DIR' not writable"
+    BACKUP_DIR="$BACKUP_FALLBACK_DIR"
+    if mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/monthly" 2>/dev/null \
+        && [[ -w "$BACKUP_DIR/daily" ]]; then
+        echo "BACKUP-DEGRADED: $reason, using fallback '$BACKUP_DIR'" >&2
+        return 0
+    fi
+    echo "BACKUP-FAILED: neither primary nor fallback '$BACKUP_DIR' writable" >&2
+    exit 1
+}
+
+ensure_backup_dir
 
 backup_one() {
     local src="$1"
@@ -39,7 +103,7 @@ backup_one() {
     # Online backup via SQLite's own .backup command — safe under
     # concurrent writes (WAL).
     local tmp="${BACKUP_DIR}/daily/${name%.sqlite}.${DATE_STAMP}.sqlite"
-    sqlite3 "$src" ".backup '$tmp'"
+    sqlite_backup "$src" "$tmp"
     gzip -f "$tmp"
     echo "backed up: $src → $dst"
     # On the 1st of the month, promote into monthly retention.
@@ -65,13 +129,13 @@ restore_test() {
     tmp="$(mktemp -d)"
     gunzip -c "$latest" > "$tmp/restore.sqlite"
     # Simple integrity check.
-    if ! sqlite3 "$tmp/restore.sqlite" "PRAGMA integrity_check" | grep -q "^ok$"; then
+    if ! sqlite_query "$tmp/restore.sqlite" "PRAGMA integrity_check" | grep -q "^ok$"; then
         echo "ERROR: restore integrity_check failed"
         rm -rf "$tmp"
         exit 1
     fi
     local rows
-    rows="$(sqlite3 "$tmp/restore.sqlite" "SELECT COUNT(*) FROM user_kv" 2>/dev/null || echo 0)"
+    rows="$(sqlite_query "$tmp/restore.sqlite" "SELECT COUNT(*) FROM user_kv" 2>/dev/null || echo 0)"
     echo "restore-test OK: $latest contains $rows user_kv rows"
     rm -rf "$tmp"
 }
@@ -83,5 +147,6 @@ fi
 
 backup_one "$DATA_DIR/user_kv.sqlite"
 backup_one "$DATA_DIR/session_store.sqlite"
+backup_one "$DATA_DIR/guest_passes.sqlite"
 prune
 echo "nightly backup complete: $(date -u +%FT%TZ)"


### PR DESCRIPTION
## Summary
Production SQLite backups (`user_kv`, `session_store`, `guest_passes`) had been **silently failing every night for ~2 weeks**. Audit + verification found two independent failure modes, the first masking the second:

1. `/var/backups/riskit` needs root; the backup service runs as `dynasty`, so `mkdir` failed and `set -Eeuo pipefail` aborted before any backup ran. Nothing alerted (backup health is unmonitored).
2. The `sqlite3` CLI is **not installed** on this host — `backup_one()`/`restore_test()` would have failed the moment mode 1 was fixed.

## Changes (`deploy/backup_user_kv.sh` only)
- Self-healing dir: fall back to `/home/dynasty/backups/riskit` (owned by `dynasty`) with a loud `BACKUP-DEGRADED` marker; `BACKUP-FAILED` + `exit 1` only if even the fallback is unwritable. **No sudo required.**
- Replace `sqlite3` CLI with the Python stdlib `sqlite3` `Connection.backup()` online-backup primitive (WAL-safe, equivalent to CLI `.backup`). No new dependency.
- Add `guest_passes.sqlite` to the backup set (was only `user_kv` + `session_store`).

## Test plan
- [x] `bash -n` syntax check
- [x] Full run → 3 `.sqlite.gz` written via fallback, exit 0, `BACKUP-DEGRADED` printed
- [x] `--restore-test` → `PRAGMA integrity_check` passes, exit 0
- [ ] CI green
- [ ] Post-merge: confirm next `riskit-backup.timer` fire (Mon 02:00 UTC) writes backups; backup monitoring follows in step 1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)