### PR TITLE
feat(awards): rework awards engine + UI

### DIFF
--- a/frontend/app/league/sections/activity.jsx
+++ b/frontend/app/league/sections/activity.jsx
@@ -106,7 +106,7 @@ function ActivitySection({ managers, data, onNavigate }) {
   );
 }
 
-function TradeCard({ trade, managers, onNavigate }) {
+export function TradeCard({ trade, managers, onNavigate }) {
   return (
     <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}>
       <div style={{ fontSize: "0.64rem", color: "var(--subtext)" }}>

--- a/frontend/app/league/sections/awards.jsx
+++ b/frontend/app/league/sections/awards.jsx
@@ -1,24 +1,185 @@
 "use client";
 
 // AwardsSection — public /league tab view.
-// Extracted from page.jsx to keep the tab file lean.
+//
+// Shows the featured season's awards (Champion + Manager of the Year
+// pinned first by the backend).  Tap any award to open its full
+// multi-season history.  Season rollover is automatic — the backend
+// picks the featured season and keeps last season featured until the
+// next one is underway.
 
+import { useEffect, useMemo, useState } from "react";
 import { EmptyState, PlayerImage } from "@/components/ui";
 import { Avatar, Card, EmptyCard, LinkButton, renderAwardValue } from "../shared.jsx";
+import { TradeCard } from "./activity.jsx";
 
-// Award keys whose ``value`` payload carries a player (top_qb, MVP, etc.).
-// We render the player's headshot next to the manager's avatar so the
-// player part of the award is visible at a glance.
+// Award keys whose ``value`` payload carries a player — render the
+// headshot next to the manager's avatar.
 const PLAYER_AWARD_KEYS = new Set([
   "top_qb", "top_rb", "top_wr", "top_te", "top_k",
   "top_dl", "top_lb", "top_db",
-  "league_mvp", "playoff_mvp",
+  "league_mvp", "playoff_mvp", "off_roy", "def_roy",
 ]);
+
+function AwardWinner({ a, managers, size = 24 }) {
+  const isPlayer = PLAYER_AWARD_KEYS.has(a.key) && a.value?.playerId;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+      {isPlayer && (
+        <PlayerImage
+          playerId={a.value.playerId}
+          team={a.value.team}
+          position={a.value.position}
+          name={a.value.playerName}
+          size={size + 8}
+        />
+      )}
+      {a.ownerId && <Avatar managers={managers} ownerId={a.ownerId} size={size} />}
+      <div style={{ minWidth: 0 }}>
+        {isPlayer && a.value?.playerName ? (
+          <>
+            <div style={{ fontWeight: 700, fontSize: "0.98rem" }}>
+              {a.value.playerName}
+              {a.value.position && (
+                <span style={{ color: "var(--subtext)", fontSize: "0.7rem", marginLeft: 6 }}>
+                  ({a.value.position})
+                </span>
+              )}
+            </div>
+            {a.displayName && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>{a.displayName}</div>
+            )}
+          </>
+        ) : (
+          <>
+            <div style={{ fontWeight: 700, fontSize: "0.98rem" }}>{a.displayName || "—"}</div>
+            {a.teamName && a.teamName !== a.displayName && (
+              <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>{a.teamName}</div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AwardHistoryModal({ awardKey, label, description, history, managers, onNavigate, onClose }) {
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed", inset: 0, zIndex: 1000,
+        background: "rgba(2, 6, 18, 0.72)",
+        display: "flex", alignItems: "flex-start", justifyContent: "center",
+        padding: "5vh 12px", overflowY: "auto",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: "min(560px, 100%)",
+          background: "var(--card)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-lg, 14px)",
+          padding: 16,
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+          <div>
+            <div style={{ fontSize: "1.1rem", fontWeight: 800 }}>{label}</div>
+            {description && (
+              <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 4, lineHeight: 1.45 }}>
+                {description}
+              </div>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close award history"
+            style={{
+              background: "transparent", border: "1px solid var(--border)",
+              borderRadius: 8, color: "var(--text)", cursor: "pointer",
+              fontSize: "1rem", lineHeight: 1, padding: "4px 9px",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em", margin: "14px 0 8px" }}>
+          History
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {history.length === 0 && (
+            <div style={{ fontSize: "0.78rem", color: "var(--subtext)" }}>
+              No prior winners on record yet.
+            </div>
+          )}
+          {history.map(({ season, award }) => (
+            <div
+              key={season}
+              style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}
+            >
+              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", fontFamily: "var(--mono)" }}>
+                {season}
+              </div>
+              <AwardWinner a={award} managers={managers} size={22} />
+              {award.value && (
+                <div style={{ fontFamily: "var(--mono)", fontSize: "0.76rem", color: "var(--cyan)", marginTop: 6 }}>
+                  {renderAwardValue(award.key, award.value)}
+                </div>
+              )}
+              {award.key === "best_trade_of_the_year" && award.value?.trade && (
+                <div style={{ marginTop: 8 }}>
+                  <TradeCard trade={award.value.trade} managers={managers} onNavigate={onNavigate} />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function AwardsSection({ managers, data, onNavigate }) {
   const seasons = data?.bySeason || [];
   const races = data?.awardRaces || [];
+  const [openKey, setOpenKey] = useState(null);
+
+  // History per award key across every season (bySeason is newest-first).
+  const historyByKey = useMemo(() => {
+    const map = new Map();
+    for (const s of seasons) {
+      for (const a of s.awards || []) {
+        if (!map.has(a.key)) map.set(a.key, []);
+        map.get(a.key).push({ season: s.season, award: a });
+      }
+    }
+    return map;
+  }, [seasons]);
+
   if (!seasons.length && !races.length) return <EmptyCard label="Awards" />;
+
+  const featuredName = data?.featuredSeason || data?.currentSeason || seasons[0]?.season;
+  const featured = seasons.find((s) => s.season === featuredName) || seasons[0] || null;
+  const upcoming = data?.upcomingSeason;
+
+  const openHistory = openKey ? historyByKey.get(openKey) || [] : [];
+  const openMeta = openHistory[0]?.award;
 
   return (
     <>
@@ -80,96 +241,103 @@ function AwardsSection({ managers, data, onNavigate }) {
         </Card>
       )}
 
-      {seasons.map((s) => (
+      {featured && (
         <Card
-          key={s.leagueId}
-          title={`${s.season} award winners`}
-          subtitle={s.isComplete ? "Season complete" : "Season in progress"}
+          title={`${featured.season} awards`}
+          subtitle={
+            (featured.isComplete ? "Season complete" : "Season in progress") +
+            " · tap an award for its full history" +
+            (upcoming ? ` · ${upcoming} hasn't started yet` : "")
+          }
         >
-          {s.hasPlayerScoring === false && (
+          {featured.hasPlayerScoring === false && (
             <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginBottom: 8 }}>
-              Trader / Waiver / Playoff MVP awards depend on per-player scoring that
+              Trader / Waiver / MVP / Rookie awards depend on per-player scoring that
               Sleeper didn't surface for this season — some awards may be skipped.
             </div>
           )}
-          {(s.awards || []).length === 0 ? (
+          {(featured.awards || []).length === 0 ? (
             <EmptyState
               title="No awards yet"
               message="Awards will appear once the season has enough games / transactions / trades on record."
             />
           ) : (
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 10 }}>
-              {(s.awards || []).map((a) => (
-                <div
-                  key={a.key}
-                  style={{
-                    border: "1px solid var(--border)",
-                    borderRadius: "var(--radius)",
-                    padding: 12,
-                    background: "rgba(15, 28, 59, 0.45)",
-                  }}
-                >
-                  <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
-                    {a.label}
-                  </div>
-                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
-                    {PLAYER_AWARD_KEYS.has(a.key) && a.value?.playerId && (
-                      <PlayerImage
-                        playerId={a.value.playerId}
-                        team={a.value.team}
-                        position={a.value.position}
-                        name={a.value.playerName}
-                        size={32}
-                      />
+              {(featured.awards || []).map((a) => {
+                const histCount = (historyByKey.get(a.key) || []).length;
+                const isBestTrade = a.key === "best_trade_of_the_year" && a.value?.trade;
+                return (
+                  <div
+                    key={a.key}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => setOpenKey(a.key)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setOpenKey(a.key);
+                      }
+                    }}
+                    style={{
+                      border: "1px solid var(--border)",
+                      borderRadius: "var(--radius)",
+                      padding: 12,
+                      background: "rgba(15, 28, 59, 0.45)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 6 }}>
+                      <div style={{ fontSize: "0.62rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                        {a.label}
+                      </div>
+                      {histCount > 1 && (
+                        <div style={{ fontSize: "0.58rem", color: "var(--subtext)" }}>
+                          {histCount} yrs →
+                        </div>
+                      )}
+                    </div>
+                    <AwardWinner a={a} managers={managers} />
+                    {a.value && (
+                      <div style={{ fontFamily: "var(--mono)", fontSize: "0.78rem", color: "var(--cyan)", marginTop: 6 }}>
+                        {renderAwardValue(a.key, a.value)}
+                      </div>
                     )}
-                    {a.ownerId && <Avatar managers={managers} ownerId={a.ownerId} size={24} />}
-                    <div style={{ minWidth: 0 }}>
-                      {PLAYER_AWARD_KEYS.has(a.key) && a.value?.playerName && (
-                        <div style={{ fontWeight: 700, fontSize: "0.98rem" }}>
-                          {a.value.playerName}
-                          {a.value.position && (
-                            <span style={{ color: "var(--subtext)", fontSize: "0.7rem", marginLeft: 6 }}>
-                              ({a.value.position})
-                            </span>
-                          )}
-                        </div>
-                      )}
-                      {(!PLAYER_AWARD_KEYS.has(a.key) || !a.value?.playerName) && (
-                        <div style={{ fontWeight: 700, fontSize: "0.98rem" }}>{a.displayName}</div>
-                      )}
-                      {PLAYER_AWARD_KEYS.has(a.key) && a.value?.playerName && a.displayName && (
-                        <div style={{ fontSize: "0.72rem", color: "var(--subtext)" }}>
-                          {a.displayName}
-                        </div>
-                      )}
-                      {(!PLAYER_AWARD_KEYS.has(a.key) || !a.value?.playerName) && a.teamName && a.teamName !== a.displayName && (
-                        <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>{a.teamName}</div>
-                      )}
-                    </div>
+                    {isBestTrade && (
+                      <div style={{ marginTop: 8 }} onClick={(e) => e.stopPropagation()}>
+                        <TradeCard trade={a.value.trade} managers={managers} onNavigate={onNavigate} />
+                      </div>
+                    )}
+                    {a.description && (
+                      <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 8, lineHeight: 1.4 }}>
+                        {a.description}
+                      </div>
+                    )}
+                    {a.ownerId && (
+                      <div style={{ marginTop: 8 }} onClick={(e) => e.stopPropagation()}>
+                        <LinkButton onClick={() => onNavigate("franchise", { owner: a.ownerId })}>
+                          Franchise page →
+                        </LinkButton>
+                      </div>
+                    )}
                   </div>
-                  {a.value && (
-                    <div style={{ fontFamily: "var(--mono)", fontSize: "0.78rem", color: "var(--cyan)", marginTop: 6 }}>
-                      {renderAwardValue(a.key, a.value)}
-                    </div>
-                  )}
-                  {a.description && (
-                    <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 8, lineHeight: 1.4 }}>
-                      {a.description}
-                    </div>
-                  )}
-                  {a.ownerId && (
-                    <div style={{ marginTop: 8 }}>
-                      <LinkButton onClick={() => onNavigate("franchise", { owner: a.ownerId })}>
-                        Franchise page →
-                      </LinkButton>
-                    </div>
-                  )}
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </Card>
-      ))}
+      )}
+
+      {openKey && openMeta && (
+        <AwardHistoryModal
+          awardKey={openKey}
+          label={openMeta.label}
+          description={openMeta.description}
+          history={openHistory}
+          managers={managers}
+          onNavigate={onNavigate}
+          onClose={() => setOpenKey(null)}
+        />
+      )}
     </>
   );
 }

--- a/frontend/app/league/sections/overview.jsx
+++ b/frontend/app/league/sections/overview.jsx
@@ -32,7 +32,6 @@ function OverviewSection({ managers, data, onNavigate }) {
   const draftLeader = data.draftCapitalLeader;
   const recap = data.latestWeeklyRecap;
   const decorated = data.mostDecoratedFranchise;
-  const chaos = data.mostChaoticManager;
   const hottest = data.hottestRace;
   const vitals = data.leagueVitals || {};
   const hottestTrade = data.hottestTrade;
@@ -320,23 +319,6 @@ function OverviewSection({ managers, data, onNavigate }) {
               <LinkButton onClick={() => onNavigate("franchise", { owner: decorated.ownerId })}>
                 Open franchise page →
               </LinkButton>
-            </div>
-          </div>
-        )}
-        {chaos && (
-          <div className="card" style={{ flex: "1 1 280px" }}>
-            <div style={{ fontSize: "0.66rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
-              Most chaotic manager
-            </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 6 }}>
-              <Avatar managers={managers} ownerId={chaos.ownerId} size={36} />
-              <div style={{ fontSize: "1.05rem", fontWeight: 800 }}>{chaos.displayName}</div>
-            </div>
-            <div style={{ fontSize: "0.74rem", color: "var(--subtext)", marginTop: 4 }}>
-              Chaos score {chaos.score ?? "—"}{chaos.season ? ` · ${chaos.season}` : ""}
-            </div>
-            <div style={{ marginTop: 10 }}>
-              <LinkButton onClick={() => onNavigate("activity")}>See trade activity →</LinkButton>
             </div>
           </div>
         )}

--- a/frontend/app/league/shared.jsx
+++ b/frontend/app/league/shared.jsx
@@ -148,8 +148,6 @@ export function renderAwardValue(key, value) {
   if (!value) return "";
   switch (key) {
     case "champion":
-    case "runner_up":
-    case "toilet_bowl":
       return "";
     case "top_seed":
       return `Win% ${fmtPercent(value.winPct)}`;
@@ -157,8 +155,6 @@ export function renderAwardValue(key, value) {
       return value.record || "";
     case "points_king":
       return `${fmtNumber(value.pointsFor, 1)} PF`;
-    case "points_black_hole":
-      return `${fmtNumber(value.pointsAgainst, 1)} PA`;
     case "highest_single_week":
     case "lowest_single_week":
       return `Wk ${value.week} · ${fmtPoints(value.points)} pts`;
@@ -168,18 +164,11 @@ export function renderAwardValue(key, value) {
       return `+${fmtPoints(value.pointsGained)} pts · Wk ${value.week}`;
     case "waiver_king":
       return `+${fmtPoints(value.pointsGained)} pts · ${value.adds} adds`;
-    case "chaos_agent":
-      return `Score ${value.score} · ${value.trades} trades · ${value.partners} partners`;
-    case "most_active":
-      return `${value.total} moves`;
     case "silent_assassin":
       return `${fmtPercent(value.winPct)} in ${value.closeGames} close games`;
     case "weekly_hammer":
       return `${value.highScoreFinishes} high-score wks`;
     case "playoff_mvp": {
-      // Player-based VORP MVP (new format).  Older shape carried
-      // playoffPoints; both are tolerated here so old cached payloads
-      // still render.
       if (value.playerName) {
         return `${value.playerName} (${value.position}) · VORP ${fmtPoints(value.vorp)}`;
       }
@@ -187,19 +176,23 @@ export function renderAwardValue(key, value) {
     }
     case "bad_beat":
       return `${fmtPoints(value.points)} in loss · Wk ${value.week}`;
+    case "mr_consistent":
+      return `CV ${fmtNumber(value.cv, 3)} · ${fmtNumber(value.meanScore, 1)} avg · ${value.weeks} wks`;
     case "best_rebuild":
       return `Composite ${value.compositeScore}`;
     case "rivalry_of_the_year":
       return `${value.displayNames[0]} vs ${value.displayNames[1]} · Index ${value.rivalryIndex}`;
-    case "pick_hoarder":
-      return `Weighted ${value.weightedScore} · ${value.totalPicks} picks`;
     // ── Manager awards ──
     case "top_offense":
       return `${fmtNumber(value.offensePoints, 1)} starter pts`;
     case "top_defense":
       return `${fmtNumber(value.defensePoints, 1)} starter pts`;
-    case "manager_of_the_year":
-      return `${value.wins}-${value.losses} · ${fmtNumber(value.pointsFor, 1)} PF · score ${fmtNumber(value.compositeScore, 3)}`;
+    case "top_nfl_team":
+      return `${value.team} · ${fmtNumber(value.points, 1)} starter pts`;
+    case "manager_of_the_year": {
+      const finish = value.finishRank ? ` · #${value.finishRank} finish` : "";
+      return `Score ${fmtNumber(value.compositeScore, 3)}${finish} · ${value.wins}-${value.losses} · ${fmtNumber(value.pointsFor, 1)} PF`;
+    }
     // ── Player awards ──
     case "top_qb":
     case "top_rb":
@@ -213,6 +206,8 @@ export function renderAwardValue(key, value) {
         ? `${value.playerName} · ${fmtPoints(value.starterPoints)} pts in ${value.gamesStarted} starts`
         : `${fmtPoints(value.starterPoints)} pts`;
     case "league_mvp":
+    case "off_roy":
+    case "def_roy":
       return value.playerName
         ? `${value.playerName} (${value.position}) · VORP ${fmtPoints(value.vorp)}`
         : `VORP ${fmtPoints(value.vorp)}`;

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -1115,6 +1115,23 @@ def _current_season_year() -> int:
     return _dt.datetime.now(_dt.timezone.utc).year
 
 
+def _league_season(sleeper_league_id: str) -> str:
+    """Authoritative season for a league: the Sleeper league object's
+    ``season`` field (single source of truth, same as the public-league
+    pipeline).  Falls back to the calendar year only if the league fetch
+    fails — never hard-code or assume the year so season rollover is
+    automatic when the league advances.
+    """
+    info = _http_get_json(
+        f"https://api.sleeper.app/v1/league/{sleeper_league_id}"
+    )
+    if isinstance(info, dict):
+        season = str(info.get("season") or "").strip()
+        if season:
+            return season
+    return str(_current_season_year())
+
+
 def _resolve_active_draft_id(sleeper_league_id: str) -> str | None:
     """Pick the most relevant draft for a league.
 
@@ -1145,7 +1162,7 @@ def _resolve_active_draft_id(sleeper_league_id: str) -> str | None:
     )
     draft_id: str | None = None
     if isinstance(drafts, list):
-        season = str(_current_season_year())
+        season = _league_season(sleeper_league_id)
         # Status precedence: drafting > pre_draft > complete.  Lower is
         # better.  Within the same status, newest start_time wins.
         rank = {"drafting": 0, "pre_draft": 1, "complete": 2}

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -16,30 +16,29 @@ public-safe values.
 
 Award catalog:
     champion                 — winner of the finals
-    runner_up                — loser of the finals
+    manager_of_the_year      — weighted totality composite (pinned #2)
     top_seed                 — best regular-season seed
     regular_season_crown     — best regular-season record
     points_king              — most regular-season points
-    points_black_hole        — most points ALLOWED
-    toilet_bowl              — worst final playoff placement
     highest_single_week      — largest single-week score
     lowest_single_week       — smallest single-week score
-    trader_of_the_year       — realized points gained via trades
+    trader_of_the_year       — realized points gained via trades (since cutoff)
     best_trade_of_the_year   — single-trade bake-off (historical only)
-    waiver_king              — realized points gained via waivers/FA
-    chaos_agent              — transaction chaos score
-    most_active              — raw transaction volume
-    pick_hoarder             — weighted draft stockpile
+    waiver_king              — starting-lineup points from waiver adds (since cutoff)
     silent_assassin          — win% in close games
     weekly_hammer            — weekly high-score finishes
-    playoff_mvp              — playoff team points (+ top individual scorer)
+    playoff_mvp              — champion's best playoff VORP performer
     bad_beat                 — biggest "points in a loss" performance
+    mr_consistent            — lowest weekly scoring CV among playoff teams
     best_rebuild             — year-over-year improvement (finalized only)
     rivalry_of_the_year      — season-scoped rivalry_index peak
+    league_mvp / off_roy / def_roy — VORP player awards
+    top_<pos>                — positional starter-points leaders
 """
 from __future__ import annotations
 
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any
 
 from . import metrics
@@ -47,51 +46,71 @@ from .draft import _pick_ownership_map, pick_weight
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
 
+# Trader of the Year and Waiver King begin tracking on this date — they
+# are new awards introduced 2026-05-12, not retroactively computed for
+# prior seasons.  Only Sleeper transactions whose ``created`` timestamp
+# is at or after this instant count; seasons with no qualifying activity
+# simply do not emit these awards.
+TRADER_WAIVER_TRACKING_START_MS = int(
+    datetime(2026, 5, 12, tzinfo=timezone.utc).timestamp() * 1000
+)
+
+
+def _tx_created_ms(tx: dict[str, Any]) -> int:
+    try:
+        return int(tx.get("created") or tx.get("status_updated") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _tx_after_tracking_start(tx: dict[str, Any]) -> bool:
+    return _tx_created_ms(tx) >= TRADER_WAIVER_TRACKING_START_MS
+
+
 # Explanation strings exposed on every award card so the page never
 # needs to hard-code copy.  Keep these short and human — the UI prints
 # them verbatim beneath the winner.
 AWARD_DESCRIPTIONS: dict[str, str] = {
     "champion": "Winner of the final playoff matchup.",
-    "runner_up": "Lost in the final playoff matchup.",
+    "manager_of_the_year": (
+        "The totality of a season, weighted: 30% final finish, 25% "
+        "regular-season win%, 15% points scored, 15% trade impact, 15% "
+        "waiver impact. Every input min-max normalized across the league."
+    ),
     "top_seed": "Best regular-season seed after tiebreaks.",
     "regular_season_crown": "Best regular-season record.",
     "points_king": "Most regular-season points scored.",
-    "points_black_hole": "Most regular-season points allowed.",
-    "toilet_bowl": "Worst final finish in the consolation bracket.",
     "highest_single_week": "Largest single-week scoring explosion.",
     "lowest_single_week": "Smallest single-week score.",
     "trader_of_the_year": (
-        "Realized post-trade fantasy points gained. Sums points acquired "
-        "minus points sent away across every trade, weighted by the weeks "
-        "played after the deal. Tiebreaks: playoff points gained, then a "
-        "server-side asset-value delta."
+        "Realized post-trade fantasy points gained since 2026-05-12. Sums "
+        "points acquired minus points sent away across every trade, weighted "
+        "by the weeks played after the deal. Tiebreaks: playoff points "
+        "gained, then a server-side asset-value delta."
     ),
     "best_trade_of_the_year": (
-        "Best single trade by post-deal realized points for one side. "
-        "Historical only — finalized after the season."
+        "Best single trade by post-deal realized points for one side "
+        "(since 2026-05-12). Historical only — finalized after the season."
     ),
     "waiver_king": (
-        "Realized points scored by your own waiver / FA pickups after they "
-        "were added. Tiebreaks: FAAB efficiency, then count of useful adds."
-    ),
-    "chaos_agent": (
-        "Chaos score. 3 points per trade, 1 per unique partner, 1 per asset "
-        "moved, 1 per pick moved, 0.5 per waiver add."
-    ),
-    "most_active": "Total trades + waivers + drops + free-agent adds.",
-    "pick_hoarder": (
-        "Weighted draft stockpile. 1st round = 4, 2nd = 3, 3rd = 2, 4th+ = 1."
+        "Total fantasy points your waiver / free-agent pickups scored in "
+        "weeks they were in your starting lineup, since 2026-05-12. "
+        "Tiebreak: count of useful adds."
     ),
     "silent_assassin": (
         "Win% in games decided by 10 points or fewer (4+ eligible games)."
     ),
     "weekly_hammer": "Count of weekly high-score finishes.",
     "playoff_mvp": (
-        "Highest playoff VORP (Value Over Replacement Player) — the player "
-        "who outscored his position's playoff replacement by the most while "
-        "in a starting lineup."
+        "The championship team's best playoff performer by VORP (Value Over "
+        "Replacement Player) — most points over positional replacement while "
+        "in the starting lineup during the playoffs."
     ),
     "bad_beat": "Biggest single 'points in a loss' performance.",
+    "mr_consistent": (
+        "Most consistent playoff qualifier — lowest week-to-week scoring "
+        "variability (coefficient of variation) in the regular season."
+    ),
     "best_rebuild": (
         "Year-over-year improvement. 40% points-rank jump + 30% record-rank "
         "jump + 20% extra weighted stockpile + 10% more rostered rookies."
@@ -103,17 +122,25 @@ AWARD_DESCRIPTIONS: dict[str, str] = {
     # ── Manager awards ──
     "top_offense": (
         "Most regular-season points produced by offensive starters "
-        "(QB / RB / WR / TE / K) — bench points excluded."
+        "(QB / RB / WR / TE) — kickers and bench points excluded."
     ),
     "top_defense": (
         "Most regular-season points produced by defensive starters "
         "(DL / LB / DB / DEF) — bench points excluded."
     ),
-    "manager_of_the_year": (
-        "Composite manager rating: 60% regular-season win%, 40% "
-        "regular-season points scored (normalized to league high)."
+    "top_nfl_team": (
+        "The NFL franchise whose players scored the most fantasy points "
+        "while in a league starting lineup (regular season)."
     ),
     # ── Player awards ──
+    "off_roy": (
+        "Offensive Rookie of the Year: highest VORP among first-year "
+        "QB / RB / WR / TE, from starter-only regular-season scoring."
+    ),
+    "def_roy": (
+        "Defensive Rookie of the Year: highest VORP among first-year "
+        "DL / LB / DB, from starter-only regular-season scoring."
+    ),
     "top_qb": "Top QB by total starter-only points scored in the regular season.",
     "top_rb": "Top RB by total starter-only points scored in the regular season.",
     "top_wr": "Top WR by total starter-only points scored in the regular season.",
@@ -153,8 +180,69 @@ _PLAYER_AWARD_LABEL_BY_POS = {
 }
 
 # Offensive vs defensive position families for manager awards.
+# Top Offense intentionally excludes K (kickers are not "offense" for
+# this award); the broader offensive set is still used for ROY split.
 _OFFENSIVE_POSITIONS = frozenset({"QB", "RB", "WR", "TE", "K"})
+_TOP_OFFENSE_POSITIONS = frozenset({"QB", "RB", "WR", "TE"})
 _DEFENSIVE_POSITIONS = frozenset({"DL", "LB", "DB", "DEF"})
+# Rookie of the Year position families (kickers excluded from OROY).
+_OFF_ROY_POSITIONS = frozenset({"QB", "RB", "WR", "TE"})
+_DEF_ROY_POSITIONS = frozenset({"DL", "LB", "DB"})
+
+
+# Canonical display order for every award.  Champion is always first and
+# Manager of the Year always second (pinned right below champion); any
+# award key not listed sorts after these in a stable manner.
+_AWARD_ORDER: tuple[str, ...] = (
+    "champion",
+    "manager_of_the_year",
+    "league_mvp",
+    "playoff_mvp",
+    "off_roy",
+    "def_roy",
+    "top_seed",
+    "regular_season_crown",
+    "points_king",
+    "highest_single_week",
+    "lowest_single_week",
+    "trader_of_the_year",
+    "best_trade_of_the_year",
+    "waiver_king",
+    "silent_assassin",
+    "weekly_hammer",
+    "mr_consistent",
+    "bad_beat",
+    "top_offense",
+    "top_defense",
+    "top_nfl_team",
+    "top_qb",
+    "top_rb",
+    "top_wr",
+    "top_te",
+    "top_k",
+    "top_dl",
+    "top_lb",
+    "top_db",
+    "best_rebuild",
+    "rivalry_of_the_year",
+)
+_AWARD_ORDER_INDEX = {k: i for i, k in enumerate(_AWARD_ORDER)}
+
+
+def _order_awards(awards: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Stable-sort awards into canonical display order."""
+    return sorted(
+        awards,
+        key=lambda a: _AWARD_ORDER_INDEX.get(a.get("key", ""), len(_AWARD_ORDER)),
+    )
+
+
+def _is_rookie(snapshot: PublicLeagueSnapshot, player_id: str) -> bool:
+    meta = snapshot.nfl_players.get(str(player_id)) or {}
+    try:
+        return int(meta.get("years_exp")) == 0
+    except (TypeError, ValueError):
+        return False
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -243,21 +331,13 @@ def _canonical_award(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, rid
 
 def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
     standings = metrics.season_standings(season, snapshot.managers)
-    placement = metrics.playoff_placement(season.winners_bracket)
     if not standings:
         return []
 
     champion_rid = metrics.season_champion(season)
-    runner_up_rid = metrics.season_runner_up(season)
     top_seed = metrics.top_seed(standings)
     best_record_rid = standings[0]["rosterId"] if standings else None
     pf_leader = max(standings, key=lambda r: r["pointsFor"], default=None)
-    pa_leader = max(standings, key=lambda r: r["pointsAgainst"], default=None)
-
-    worst_place = max((p for p in placement.values()), default=None)
-    toilet_rid: int | None = None
-    if worst_place is not None:
-        toilet_rid = next((rid for rid, p in placement.items() if p == worst_place), None)
 
     high_week: tuple[float, int, int] | None = None
     low_week: tuple[float, int, int] | None = None
@@ -276,7 +356,6 @@ def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnaps
 
     awards = [
         _canonical_award(snapshot, season, champion_rid, "champion", "Champion"),
-        _canonical_award(snapshot, season, runner_up_rid, "runner_up", "Runner-Up"),
         _canonical_award(
             snapshot, season,
             top_seed["rosterId"] if top_seed else None,
@@ -294,13 +373,6 @@ def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnaps
             "points_king", "Points King",
             value={"pointsFor": pf_leader["pointsFor"]} if pf_leader else None,
         ),
-        _canonical_award(
-            snapshot, season,
-            pa_leader["rosterId"] if pa_leader else None,
-            "points_black_hole", "Points Black Hole",
-            value={"pointsAgainst": pa_leader["pointsAgainst"]} if pa_leader else None,
-        ),
-        _canonical_award(snapshot, season, toilet_rid, "toilet_bowl", "Toilet Bowl"),
         _canonical_award(
             snapshot, season,
             high_week[1] if high_week else None,
@@ -338,9 +410,11 @@ def _trader_of_the_year_scores(
             }
         return per_owner[owner_id]
 
-    best_trade: tuple[float, str, dict[str, Any]] | None = None
+    best_trade: tuple[float, str, dict[str, Any], dict[str, Any]] | None = None
 
     for tx in season.trades():
+        if not _tx_after_tracking_start(tx):
+            continue
         leg = tx.get("leg") or tx.get("_leg") or 0
         try:
             leg_int = int(leg)
@@ -424,7 +498,7 @@ def _trader_of_the_year_scores(
                     "playoffPointsGained": round(playoff_gain, 2),
                     "receivedPlayerIds": list(received),
                     "sentPlayerIds": list(sent),
-                })
+                }, tx)
 
     rows = list(per_owner.values())
     for r in rows:
@@ -455,13 +529,14 @@ def _waiver_king_scores(
             per_owner[owner_id] = {
                 "ownerId": owner_id,
                 "pointsGained": 0.0,
-                "faabSpent": 0,
                 "addCount": 0,
                 "usefulAdds": 0,
             }
         return per_owner[owner_id]
 
     for tx in season.waivers():
+        if not _tx_after_tracking_start(tx):
+            continue
         leg = tx.get("leg") or tx.get("_leg") or 0
         try:
             leg_int = int(leg)
@@ -471,12 +546,6 @@ def _waiver_king_scores(
         if not post_weeks:
             continue
         adds = tx.get("adds") or {}
-        settings = tx.get("settings") or {}
-        bid_raw = settings.get("waiver_bid")
-        try:
-            bid = int(bid_raw) if bid_raw is not None else 0
-        except (TypeError, ValueError):
-            bid = 0
 
         for pid, rid in adds.items():
             try:
@@ -488,7 +557,8 @@ def _waiver_king_scores(
                 continue
             rec = _ensure(owner_id)
             rec["addCount"] += 1
-            rec["faabSpent"] += max(0, bid)
+            # Only points scored while the pickup was actually in the
+            # starting lineup count — bench weeks are ignored entirely.
             gain = 0.0
             started_at_least_once = False
             for week in post_weeks:
@@ -498,14 +568,6 @@ def _waiver_king_scores(
                 if starter_pts is not None:
                     gain += starter_pts
                     started_at_least_once = True
-                    continue
-                total_pts = _player_points_in_week_for_roster(
-                    season, week, rid_int, pid, require_started=False
-                )
-                if total_pts is not None and not _starter_set(
-                    _matchup_for(season, week, rid_int) or {}
-                ):
-                    gain += total_pts
             rec["pointsGained"] += gain
             if started_at_least_once and gain > 0:
                 rec["usefulAdds"] += 1
@@ -513,149 +575,13 @@ def _waiver_king_scores(
     rows = list(per_owner.values())
     for r in rows:
         r["pointsGained"] = round(r["pointsGained"], 2)
-        r["faabEfficiency"] = (
-            round(r["pointsGained"] / r["faabSpent"], 3) if r["faabSpent"] > 0 else None
-        )
         r["displayName"] = metrics.display_name_for(snapshot, r["ownerId"])
     rows.sort(
         key=lambda r: (
             -r["pointsGained"],
-            -(r["faabEfficiency"] or 0),
             -r["usefulAdds"],
         )
     )
-    return rows
-
-
-def _matchup_for(season: SeasonSnapshot, week: int, roster_id: int) -> dict[str, Any] | None:
-    for m in season.matchups_by_week.get(week) or []:
-        try:
-            if int(m.get("roster_id")) == roster_id:
-                return m
-        except (TypeError, ValueError):
-            continue
-    return None
-
-
-def _chaos_agent_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
-    per_owner: dict[str, dict[str, Any]] = {}
-
-    def _ensure(owner_id: str) -> dict[str, Any]:
-        if owner_id not in per_owner:
-            per_owner[owner_id] = {
-                "ownerId": owner_id,
-                "trades": 0,
-                "waiverAdds": 0,
-                "distinctPartners": 0,
-                "playersMoved": 0,
-                "picksMoved": 0,
-                "score": 0.0,
-                "_partners": set(),
-            }
-        return per_owner[owner_id]
-
-    for tx in season.trades():
-        roster_ids = []
-        for rid in tx.get("roster_ids") or []:
-            try:
-                roster_ids.append(int(rid))
-            except (TypeError, ValueError):
-                continue
-        if len(roster_ids) < 2:
-            continue
-        owners = [
-            metrics.resolve_owner(snapshot.managers, season.league_id, rid)
-            for rid in roster_ids
-        ]
-        owners = [o for o in owners if o]
-        if len(owners) < 2:
-            continue
-        adds = tx.get("adds") or {}
-        picks = tx.get("draft_picks") or []
-        for owner in owners:
-            rec = _ensure(owner)
-            rec["trades"] += 1
-            rec["_partners"].update(o for o in owners if o != owner)
-            rid = next(
-                (
-                    r for r in roster_ids
-                    if metrics.resolve_owner(snapshot.managers, season.league_id, r) == owner
-                ),
-                None,
-            )
-            if rid is None:
-                continue
-            rec["playersMoved"] += sum(1 for _, r in adds.items() if int(r) == rid)
-            rec["picksMoved"] += sum(
-                1 for pk in picks if int(pk.get("owner_id") or 0) == rid
-            )
-
-    for tx in season.waivers():
-        for rid in tx.get("roster_ids") or []:
-            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
-            if not owner_id:
-                continue
-            rec = _ensure(owner_id)
-            rec["waiverAdds"] += 1
-
-    rows = []
-    for owner_id, rec in per_owner.items():
-        rec["distinctPartners"] = len(rec["_partners"])
-        rec.pop("_partners", None)
-        score = (
-            3 * rec["trades"]
-            + 1 * rec["distinctPartners"]
-            + 1 * rec["playersMoved"]
-            + 1 * rec["picksMoved"]
-            + 0.5 * rec["waiverAdds"]
-        )
-        rec["score"] = round(score, 2)
-        rec["displayName"] = metrics.display_name_for(snapshot, owner_id)
-        rows.append(rec)
-    rows.sort(key=lambda r: (-r["score"], -r["trades"], -r["waiverAdds"]))
-    return rows
-
-
-def _most_active_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
-    per_owner: dict[str, dict[str, int]] = defaultdict(lambda: {
-        "trades": 0, "waivers": 0, "freeAgents": 0, "drops": 0,
-    })
-    for tx in season.trades():
-        for rid in tx.get("roster_ids") or []:
-            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
-            if owner_id:
-                per_owner[owner_id]["trades"] += 1
-    for week in sorted(season.transactions_by_week.keys()):
-        for tx in season.transactions_by_week[week]:
-            ttype = str(tx.get("type") or "").lower()
-            status = str(tx.get("status") or "").lower()
-            if status != "complete":
-                continue
-            for rid in tx.get("roster_ids") or []:
-                owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
-                if not owner_id:
-                    continue
-                if ttype == "waiver":
-                    per_owner[owner_id]["waivers"] += 1
-                elif ttype == "free_agent":
-                    per_owner[owner_id]["freeAgents"] += 1
-                drops = tx.get("drops") or {}
-                per_owner[owner_id]["drops"] += sum(
-                    1 for _, r in drops.items() if int(r) == int(rid)
-                )
-    rows = []
-    for owner_id, rec in per_owner.items():
-        total = sum(rec.values())
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "trades": rec["trades"],
-            "waivers": rec["waivers"],
-            "freeAgents": rec["freeAgents"],
-            "drops": rec["drops"],
-            "total": total,
-        })
-    rows.sort(key=lambda r: (-r["total"], -r["trades"], -r["waivers"]))
     return rows
 
 
@@ -782,55 +708,6 @@ def _weekly_hammer_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
             -r["highestWeekPoints"],
         )
     )
-    return rows
-
-
-def _playoff_mvp_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
-    per_owner: dict[str, dict[str, Any]] = {}
-
-    def _ensure(owner_id: str) -> dict[str, Any]:
-        if owner_id not in per_owner:
-            per_owner[owner_id] = {
-                "ownerId": owner_id,
-                "playoffPoints": 0.0,
-                "playoffWeeksPlayed": 0,
-                "topPlayerName": "",
-                "topPlayerPosition": "",
-                "topPlayerPoints": 0.0,
-            }
-        return per_owner[owner_id]
-
-    for week in sorted(season.matchups_by_week.keys()):
-        if week < season.playoff_week_start:
-            continue
-        for entry in season.matchups_by_week[week]:
-            rid = metrics.roster_id_of(entry)
-            if rid is None:
-                continue
-            pts = metrics.matchup_points(entry)
-            if pts <= 0:
-                continue
-            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
-            if not owner_id:
-                continue
-            rec = _ensure(owner_id)
-            rec["playoffPoints"] += pts
-            rec["playoffWeeksPlayed"] += 1
-            for pid, pp in _roster_player_points(entry).items():
-                if pp is None:
-                    continue
-                if pp > rec["topPlayerPoints"]:
-                    rec["topPlayerPoints"] = pp
-                    rec["topPlayerName"] = snapshot.player_display(pid) or pid
-                    rec["topPlayerPosition"] = snapshot.player_position(pid)
-
-    rows = []
-    for owner_id, rec in per_owner.items():
-        rec["displayName"] = metrics.display_name_for(snapshot, owner_id)
-        rec["playoffPoints"] = round(rec["playoffPoints"], 2)
-        rec["topPlayerPoints"] = round(rec["topPlayerPoints"], 2)
-        rows.append(rec)
-    rows.sort(key=lambda r: (-r["playoffPoints"], -r["playoffWeeksPlayed"]))
     return rows
 
 
@@ -1017,23 +894,19 @@ def _manager_unit_points(
 ) -> dict[str, dict[str, float]]:
     """Aggregate starter-only points per owner, partitioned by offense /
     defense unit.  Returns ``{owner_id: {"offense": pts, "defense": pts}}``.
+
+    Offense is QB/RB/WR/TE only — kickers are deliberately excluded from
+    Top Offense; unmapped positions count toward neither unit.
     """
     out: dict[str, dict[str, float]] = {}
     for _wk, _rid, owner_id, _pid, pos, pts, _is_p in _starter_scoring_walk(
         snapshot, season, regular_season_only=regular_season_only
     ):
         rec = out.setdefault(owner_id, {"offense": 0.0, "defense": 0.0})
-        if pos in _OFFENSIVE_POSITIONS or pos == "":
-            # Default unmapped positions into offense (covers DEF/ST team
-            # defenses too if they appear in an offense-style starter slot).
-            if pos in _DEFENSIVE_POSITIONS:
-                rec["defense"] += pts
-            else:
-                rec["offense"] += pts
+        if pos in _TOP_OFFENSE_POSITIONS:
+            rec["offense"] += pts
         elif pos in _DEFENSIVE_POSITIONS:
             rec["defense"] += pts
-        else:
-            rec["offense"] += pts
     return out
 
 
@@ -1072,33 +945,143 @@ def _top_defense_scores(
     return rows
 
 
-def _manager_of_the_year_scores(
+def _top_nfl_team_scores(
     snapshot: PublicLeagueSnapshot,
     season: SeasonSnapshot,
 ) -> list[dict[str, Any]]:
-    """60% regular-season win% + 40% PF-normalized.  Both rescaled to
-    [0, 1] within the league so a perfect manager would score 1.0.
+    """Total fantasy points each NFL team's players scored while in any
+    manager's starting lineup (regular season).  The 'winner' is an NFL
+    team, not a manager."""
+    totals: dict[str, float] = defaultdict(float)
+    for _wk, _rid, _owner, pid, _pos, pts, _is_p in _starter_scoring_walk(
+        snapshot, season, regular_season_only=True
+    ):
+        team = _nfl_team_for(snapshot, pid)
+        if not team:
+            continue
+        totals[team] += pts
+    rows = [
+        {"team": team, "points": round(pts, 2)}
+        for team, pts in totals.items()
+        if pts > 0
+    ]
+    rows.sort(key=lambda r: -r["points"])
+    return rows
+
+
+def _finish_rank_by_owner(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    standings: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Overall final finish per owner, 1 = champion.
+
+    Playoff teams are ordered by their bracket placement (champion
+    first); everyone else follows in regular-season standings order.
+    When no bracket exists yet (season in progress) this collapses to
+    the regular-season standings order, which is the right proxy for
+    the live race.
+    """
+    placement = metrics.playoff_placement(season.winners_bracket)
+    owner_by_rid: dict[int, str] = {}
+    for r in standings:
+        try:
+            owner_by_rid[int(r["rosterId"])] = r["ownerId"]
+        except (TypeError, ValueError, KeyError):
+            continue
+
+    playoff_owners = sorted(
+        (
+            (place, owner_by_rid[rid])
+            for rid, place in placement.items()
+            if rid in owner_by_rid
+        ),
+        key=lambda t: t[0],
+    )
+    ordered: list[str] = [owner for _place, owner in playoff_owners]
+    seen = set(ordered)
+    for r in standings:  # standings already sorted best→worst
+        if r["ownerId"] not in seen:
+            ordered.append(r["ownerId"])
+            seen.add(r["ownerId"])
+    return {owner: i + 1 for i, owner in enumerate(ordered)}
+
+
+def _minmax(values: dict[str, float]) -> dict[str, float]:
+    """Min-max normalize to [0, 1]; all-equal inputs map to 0.0."""
+    if not values:
+        return {}
+    lo = min(values.values())
+    hi = max(values.values())
+    span = hi - lo
+    if span <= 1e-9:
+        return {k: 0.0 for k in values}
+    return {k: (v - lo) / span for k, v in values.items()}
+
+
+def _manager_of_the_year_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    trader_rows: list[dict[str, Any]],
+    waiver_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """The totality of a season, weighted (no human judgment):
+
+        30% final finish + 25% regular-season win% + 15% points scored
+        + 15% trade impact + 15% waiver impact
+
+    Every input is min-max normalized across the league for the season,
+    so a hypothetical best-at-everything manager scores 1.0.
     """
     standings = metrics.season_standings(season, snapshot.managers)
     if not standings:
         return []
-    pf_max = max((r["pointsFor"] for r in standings), default=0.0) or 1.0
+
+    n = len(standings)
+    finish_rank = _finish_rank_by_owner(snapshot, season, standings)
+    trade_gain = {r["ownerId"]: float(r.get("pointsGained") or 0.0) for r in trader_rows}
+    waiver_gain = {r["ownerId"]: float(r.get("pointsGained") or 0.0) for r in waiver_rows}
+
+    # Raw inputs (higher = better) keyed by owner.
+    raw_finish = {
+        r["ownerId"]: float(n - finish_rank.get(r["ownerId"], n))
+        for r in standings
+    }
+    raw_win = {r["ownerId"]: float(r["winPct"]) for r in standings}
+    raw_pf = {r["ownerId"]: float(r["pointsFor"]) for r in standings}
+    raw_trade = {r["ownerId"]: trade_gain.get(r["ownerId"], 0.0) for r in standings}
+    raw_waiver = {r["ownerId"]: waiver_gain.get(r["ownerId"], 0.0) for r in standings}
+
+    n_finish = _minmax(raw_finish)
+    n_win = _minmax(raw_win)
+    n_pf = _minmax(raw_pf)
+    n_trade = _minmax(raw_trade)
+    n_waiver = _minmax(raw_waiver)
+
     rows = []
     for r in standings:
-        win_component = r["winPct"]
-        pf_component = r["pointsFor"] / pf_max
-        composite = 0.6 * win_component + 0.4 * pf_component
+        oid = r["ownerId"]
+        composite = (
+            0.30 * n_finish.get(oid, 0.0)
+            + 0.25 * n_win.get(oid, 0.0)
+            + 0.15 * n_pf.get(oid, 0.0)
+            + 0.15 * n_trade.get(oid, 0.0)
+            + 0.15 * n_waiver.get(oid, 0.0)
+        )
         rows.append({
-            "ownerId": r["ownerId"],
-            "displayName": metrics.display_name_for(snapshot, r["ownerId"]),
+            "ownerId": oid,
+            "displayName": metrics.display_name_for(snapshot, oid),
             "wins": r["wins"],
             "losses": r["losses"],
             "ties": r["ties"],
             "winPct": round(r["winPct"], 4),
             "pointsFor": r["pointsFor"],
+            "finishRank": finish_rank.get(oid, n),
+            "tradePointsGained": round(trade_gain.get(oid, 0.0), 2),
+            "waiverPointsGained": round(waiver_gain.get(oid, 0.0), 2),
             "compositeScore": round(composite, 4),
         })
-    rows.sort(key=lambda r: (-r["compositeScore"], -r["wins"], -r["pointsFor"]))
+    rows.sort(key=lambda r: (-r["compositeScore"], r["finishRank"], -r["pointsFor"]))
     return rows
 
 
@@ -1201,21 +1184,36 @@ def _replacement_per_game_for_position(
     return replacement_per_game(rows or [], starter_slots, band_size=5)
 
 
-def _starter_slot_counts(
-    season: SeasonSnapshot,
-) -> dict[str, int]:
-    """Total starting slots per position across the entire league per week.
+# Replacement-level starter depth per position (the cutoff index whose
+# next-5 band defines replacement value).  Fixed by league convention;
+# RB/WR are derived dynamically from the top-84 RB+WR (flex) pool so
+# they stay current with how the position split actually plays out.
+_VORP_FIXED_STARTER_SLOTS: dict[str, int] = {
+    "QB": 24,
+    "TE": 24,
+    "K": 12,
+    "DL": 36,
+    "LB": 36,
+    "DB": 36,
+}
+_FLEX_RBWR_POOL = 84  # top 84 RB+WR by starter points (TEs excluded)
 
-    Thin shim around
-    :func:`src.scoring.replacement_level.starter_slot_counts`.  Pulls
-    ``roster_positions`` + team count off the snapshot and delegates
-    the FLEX / SUPER_FLEX / IDP_FLEX splitting to the shared module.
+
+def _vorp_starter_slots(grouped: dict[str, list[dict[str, Any]]]) -> dict[str, int]:
+    """Replacement-cutoff slot count per position.
+
+    Fixed for QB/TE/K/DL/LB/DB; RB and WR are split out of the top-84
+    RB+WR pool (ranked by starter points) so the flex baseline tracks
+    the real RB/WR balance each season.
     """
-    from src.scoring.replacement_level import starter_slot_counts
-    return starter_slot_counts(
-        season.league.get("roster_positions") or [],
-        season.num_teams,
-    )
+    slots = dict(_VORP_FIXED_STARTER_SLOTS)
+    pool = sorted(
+        (grouped.get("RB") or []) + (grouped.get("WR") or []),
+        key=lambda r: -float(r.get("starterPoints") or 0.0),
+    )[:_FLEX_RBWR_POOL]
+    slots["RB"] = sum(1 for r in pool if r.get("position") == "RB")
+    slots["WR"] = sum(1 for r in pool if r.get("position") == "WR")
+    return slots
 
 
 def _vorp_rows(
@@ -1251,7 +1249,7 @@ def _vorp_rows(
             "lastOwnerId": rec["lastOwnerId"],
         })
 
-    starter_slots = _starter_slot_counts(season)
+    starter_slots = _vorp_starter_slots(grouped)
     out: list[dict[str, Any]] = []
     for pos, rows in grouped.items():
         slots = starter_slots.get(pos, 0)
@@ -1264,7 +1262,9 @@ def _vorp_rows(
         for r in rows:
             games = r["gamesStarted"] or 1
             replacement_total = replacement_per_game * games
-            vorp = r["starterPoints"] - replacement_total
+            # Never award negative VORP — a sub-replacement player is
+            # floored at 0 rather than shown below value.
+            vorp = max(0.0, r["starterPoints"] - replacement_total)
             owner_id = r["lastOwnerId"]
             out.append({
                 "playerId": r["playerId"],
@@ -1290,23 +1290,104 @@ def _league_mvp_rows(
     return _vorp_rows(snapshot, season, regular_season_only=True)
 
 
+def _rookie_of_year_rows(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    positions: frozenset[str],
+) -> list[dict[str, Any]]:
+    """First-year players (years_exp == 0) at the given positions,
+    ranked by regular-season VORP (starter-only)."""
+    return [
+        r
+        for r in _vorp_rows(snapshot, season, regular_season_only=True)
+        if r["position"] in positions and _is_rookie(snapshot, r["playerId"])
+    ]
+
+
+def _mr_consistent_scores(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    min_weeks: int = 4,
+) -> list[dict[str, Any]]:
+    """Lowest week-to-week scoring variability among playoff qualifiers.
+
+    Coefficient of variation = stdev(weekly score) / mean(weekly score)
+    over the regular season; lower is steadier.  Falls back to all
+    rosters when no bracket exists yet (keeps the live race meaningful).
+    """
+    qualifiers = set(metrics.playoff_teams(season.winners_bracket))
+    if not qualifiers:
+        for r in season.rosters:
+            try:
+                qualifiers.add(int(r.get("roster_id")))
+            except (TypeError, ValueError):
+                continue
+    if not qualifiers:
+        return []
+
+    weekly: dict[int, list[float]] = defaultdict(list)
+    for week in sorted(season.matchups_by_week.keys()):
+        if week >= season.playoff_week_start:
+            continue
+        for entry in season.matchups_by_week[week]:
+            rid = metrics.roster_id_of(entry)
+            if rid is None or rid not in qualifiers:
+                continue
+            pts = metrics.matchup_points(entry)
+            if pts <= 0:
+                continue
+            weekly[rid].append(pts)
+
+    rows: list[dict[str, Any]] = []
+    for rid, scores in weekly.items():
+        if len(scores) < min_weeks:
+            continue
+        mean = sum(scores) / len(scores)
+        if mean <= 0:
+            continue
+        var = sum((x - mean) ** 2 for x in scores) / len(scores)
+        cv = (var ** 0.5) / mean
+        owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+        if not owner_id:
+            continue
+        rows.append({
+            "ownerId": owner_id,
+            "displayName": metrics.display_name_for(snapshot, owner_id),
+            "cv": round(cv, 4),
+            "meanScore": round(mean, 2),
+            "weeks": len(scores),
+        })
+    rows.sort(key=lambda r: (r["cv"], -r["meanScore"]))
+    return rows
+
+
 def _playoff_mvp_player_rows(
     snapshot: PublicLeagueSnapshot,
     season: SeasonSnapshot,
 ) -> list[dict[str, Any]]:
-    """Playoff MVP candidates ranked by VORP across playoff weeks only."""
+    """Playoff MVP candidates: the championship team's playoff starters
+    ranked by VORP across playoff weeks only.
+
+    Returns ``[]`` until a champion exists (season still in progress or
+    no winners bracket), so this award only finalizes post-season.
+    """
+    champion_rid = metrics.season_champion(season)
+    if champion_rid is None:
+        return []
     totals = _player_starter_totals(
         snapshot, season, regular_season_only=False
     )
     if not totals:
         return []
-    # Strip regular-season data: we want playoff-only.  Re-run the walk
-    # but only over playoff weeks.
+    # Strip regular-season data: we want playoff-only, and only the
+    # championship roster's starters.
     playoff_totals: dict[str, dict[str, Any]] = {}
-    for week, _rid, owner_id, pid, pos, pts, is_playoff in _starter_scoring_walk(
+    for week, rid, owner_id, pid, pos, pts, is_playoff in _starter_scoring_walk(
         snapshot, season, regular_season_only=False
     ):
         if not is_playoff:
+            continue
+        if rid != champion_rid:
             continue
         rec = playoff_totals.setdefault(pid, {
             "playerId": pid,
@@ -1334,7 +1415,7 @@ def _playoff_mvp_player_rows(
             continue
         grouped[pos].append(rec)
 
-    starter_slots = _starter_slot_counts(season)
+    starter_slots = _vorp_starter_slots(grouped)
     out: list[dict[str, Any]] = []
     for pos, rows in grouped.items():
         slots = starter_slots.get(pos, 0)
@@ -1343,7 +1424,7 @@ def _playoff_mvp_player_rows(
         replacement_per_game = _replacement_per_game_for_position(rows, slots)
         for r in rows:
             games = r["gamesStarted"] or 1
-            vorp = r["starterPoints"] - replacement_per_game * games
+            vorp = max(0.0, r["starterPoints"] - replacement_per_game * games)
             owner_id = r["lastOwnerId"]
             out.append({
                 "playerId": r["playerId"],
@@ -1491,11 +1572,8 @@ def _activity_awards_for_season(
 ) -> list[dict[str, Any]]:
     trader_rows, best_trade = _trader_of_the_year_scores(snapshot, season)
     waiver_rows = _waiver_king_scores(snapshot, season)
-    chaos_rows = _chaos_agent_scores(snapshot, season)
-    active_rows = _most_active_scores(snapshot, season)
     silent_rows = _silent_assassin_scores(snapshot, season)
     hammer_rows = _weekly_hammer_scores(snapshot, season)
-    playoff_rows = _playoff_mvp_scores(snapshot, season)
     bad_beat_rows = _bad_beat_scores(snapshot, season)
 
     awards: list[dict[str, Any]] = []
@@ -1509,8 +1587,12 @@ def _activity_awards_for_season(
         lambda r: {"pointsGained": r["pointsGained"], "trades": r["tradeCount"]},
     ))
     if best_trade is not None:
-        gain, owner_id, payload = best_trade
+        gain, owner_id, payload, best_tx = best_trade
         rid = _roster_id_for_owner(season, owner_id)
+        # Reuse the activity-section trade normalizer so the public
+        # payload carries the full sides/assets the UI already renders.
+        from .activity import _normalize_trade
+        normalized_trade = _normalize_trade(snapshot, season, best_tx)
         _add({
             "key": "best_trade_of_the_year",
             "label": "Best Trade of the Year",
@@ -1522,6 +1604,7 @@ def _activity_awards_for_season(
                 "pointsGained": payload["pointsGained"],
                 "week": payload["week"],
                 "transactionId": payload["transactionId"],
+                "trade": normalized_trade,
             },
         })
     _add(_award_from_row(
@@ -1529,16 +1612,7 @@ def _activity_awards_for_season(
         lambda r: {
             "pointsGained": r["pointsGained"],
             "adds": r.get("usefulAdds", 0),
-            "faabEfficiency": r.get("faabEfficiency"),
         },
-    ))
-    _add(_award_from_row(
-        snapshot, season, chaos_rows, "chaos_agent", "Chaos Agent",
-        lambda r: {"score": r["score"], "trades": r["trades"], "partners": r["distinctPartners"]},
-    ))
-    _add(_award_from_row(
-        snapshot, season, active_rows, "most_active", "Most Active",
-        lambda r: {"total": r["total"], "trades": r["trades"], "waivers": r["waivers"]},
     ))
     _add(_award_from_row(
         snapshot, season, silent_rows, "silent_assassin", "Silent Assassin",
@@ -1592,7 +1666,21 @@ def _activity_awards_for_season(
             snapshot, season, defense_rows, "top_defense", "Top Defense",
             lambda r: {"defensePoints": r["defensePoints"]},
         ))
-    moty_rows = _manager_of_the_year_scores(snapshot, season)
+    nfl_team_rows = _top_nfl_team_scores(snapshot, season)
+    if nfl_team_rows:
+        top_team = nfl_team_rows[0]
+        awards.append({
+            "key": "top_nfl_team",
+            "label": "Top Fantasy NFL Team",
+            "description": AWARD_DESCRIPTIONS["top_nfl_team"],
+            "ownerId": "",
+            "displayName": top_team["team"],
+            "teamName": "",
+            "value": {"team": top_team["team"], "points": top_team["points"]},
+        })
+    moty_rows = _manager_of_the_year_scores(
+        snapshot, season, trader_rows, waiver_rows
+    )
     _add(_award_from_row(
         snapshot, season, moty_rows, "manager_of_the_year", "Manager of the Year",
         lambda r: {
@@ -1601,6 +1689,9 @@ def _activity_awards_for_season(
             "losses": r["losses"],
             "winPct": r["winPct"],
             "pointsFor": r["pointsFor"],
+            "finishRank": r["finishRank"],
+            "tradePointsGained": r["tradePointsGained"],
+            "waiverPointsGained": r["waiverPointsGained"],
         },
     ))
 
@@ -1656,12 +1747,49 @@ def _activity_awards_for_season(
             },
         })
 
-    pick_rows = _pick_hoarder_scores(snapshot)
-    if pick_rows:
-        _add(_award_from_row(
-            snapshot, season, pick_rows, "pick_hoarder", "Pick Hoarder",
-            lambda r: {"weightedScore": r["weightedScore"], "totalPicks": r["totalPicks"]},
-        ))
+    # ── Rookie of the Year (offense / defense, regular-season VORP) ──
+    def _vorp_player_award(rows, key, label):
+        if not rows:
+            return
+        w = rows[0]
+        # Crown the best rookie even if at/below replacement (VORP is
+        # floored at 0); only skip when nobody actually started/scored.
+        if (w.get("starterPoints") or 0) <= 0:
+            return
+        r_id = _roster_id_for_owner(season, w["ownerId"]) if w["ownerId"] else None
+        awards.append({
+            "key": key,
+            "label": label,
+            "description": AWARD_DESCRIPTIONS[key],
+            "ownerId": w["ownerId"],
+            "displayName": w["displayName"],
+            "teamName": metrics.team_name(snapshot, season.league_id, r_id) if r_id is not None else "",
+            "value": {
+                "playerId": w["playerId"],
+                "playerName": w["playerName"],
+                "team": w.get("team", ""),
+                "position": w["position"],
+                "vorp": w["vorp"],
+                "starterPoints": w["starterPoints"],
+                "gamesStarted": w["gamesStarted"],
+            },
+        })
+
+    _vorp_player_award(
+        _rookie_of_year_rows(snapshot, season, _OFF_ROY_POSITIONS),
+        "off_roy", "Offensive Rookie of the Year",
+    )
+    _vorp_player_award(
+        _rookie_of_year_rows(snapshot, season, _DEF_ROY_POSITIONS),
+        "def_roy", "Defensive Rookie of the Year",
+    )
+
+    # ── Mr. Consistent ─────────────────────────────────────────────
+    _add(_award_from_row(
+        snapshot, season, _mr_consistent_scores(snapshot, season),
+        "mr_consistent", "Mr. Consistent",
+        lambda r: {"cv": r["cv"], "meanScore": r["meanScore"], "weeks": r["weeks"]},
+    ))
 
     if previous_season is not None and season.is_complete and previous_season.is_complete:
         rebuild_rows = _best_rebuild_scores(snapshot, season, previous_season)
@@ -1693,7 +1821,7 @@ def _activity_awards_for_season(
             },
         })
 
-    return awards
+    return _order_awards(awards)
 
 
 def _build_race(
@@ -1735,13 +1863,9 @@ def _current_season_races(
 
     trader_rows, _ = _trader_of_the_year_scores(snapshot, season)
     waiver_rows = _waiver_king_scores(snapshot, season)
-    chaos_rows = _chaos_agent_scores(snapshot, season)
-    active_rows = _most_active_scores(snapshot, season)
     silent_rows = _silent_assassin_scores(snapshot, season)
     hammer_rows = _weekly_hammer_scores(snapshot, season)
-    playoff_rows = _playoff_mvp_scores(snapshot, season)
     bad_beat_rows = _bad_beat_scores(snapshot, season)
-    pick_rows = _pick_hoarder_scores(snapshot)
 
     def _add(race):
         if race:
@@ -1756,16 +1880,7 @@ def _current_season_races(
         lambda r: {
             "pointsGained": r["pointsGained"],
             "adds": r.get("usefulAdds", 0),
-            "faabEfficiency": r.get("faabEfficiency"),
         },
-    ))
-    _add(_build_race(
-        snapshot, "chaos_agent", "Chaos Agent", chaos_rows,
-        lambda r: {"score": r["score"], "trades": r["trades"], "partners": r["distinctPartners"]},
-    ))
-    _add(_build_race(
-        snapshot, "most_active", "Most Active", active_rows,
-        lambda r: {"total": r["total"], "trades": r["trades"], "waivers": r["waivers"]},
     ))
     _add(_build_race(
         snapshot, "silent_assassin", "Silent Assassin", silent_rows,
@@ -1808,8 +1923,9 @@ def _current_season_races(
         },
     ))
     _add(_build_race(
-        snapshot, "pick_hoarder", "Pick Hoarder", pick_rows,
-        lambda r: {"weightedScore": r["weightedScore"], "totalPicks": r["totalPicks"]},
+        snapshot, "mr_consistent", "Mr. Consistent",
+        _mr_consistent_scores(snapshot, season),
+        lambda r: {"cv": r["cv"], "meanScore": r["meanScore"], "weeks": r["weeks"]},
     ))
 
     # ── Manager-award races ──
@@ -1824,7 +1940,25 @@ def _current_season_races(
             snapshot, "top_defense", "Top Defense Race", defense_rows,
             lambda r: {"defensePoints": r["defensePoints"]},
         ))
-    moty_rows = _manager_of_the_year_scores(snapshot, season)
+    nfl_team_rows = _top_nfl_team_scores(snapshot, season)
+    if nfl_team_rows:
+        _add({
+            "key": "top_nfl_team",
+            "label": "Top Fantasy NFL Team Race",
+            "description": AWARD_DESCRIPTIONS["top_nfl_team"],
+            "leaders": [
+                {
+                    "rank": i + 1,
+                    "ownerId": "",
+                    "displayName": r["team"],
+                    "value": {"team": r["team"], "points": r["points"]},
+                }
+                for i, r in enumerate(nfl_team_rows[:3])
+            ],
+        })
+    moty_rows = _manager_of_the_year_scores(
+        snapshot, season, trader_rows, waiver_rows
+    )
     _add(_build_race(
         snapshot, "manager_of_the_year", "Manager of the Year Race", moty_rows,
         lambda r: {
@@ -1833,6 +1967,9 @@ def _current_season_races(
             "losses": r["losses"],
             "winPct": r["winPct"],
             "pointsFor": r["pointsFor"],
+            "finishRank": r["finishRank"],
+            "tradePointsGained": r["tradePointsGained"],
+            "waiverPointsGained": r["waiverPointsGained"],
         },
     ))
 
@@ -1895,6 +2032,43 @@ def _current_season_races(
         }
         _add(race)
 
+    # ── Rookie of the Year races ──
+    def _vorp_player_race(rows, key, label):
+        rows = [r for r in rows if r.get("vorp", 0) > 0]
+        if not rows:
+            return None
+        return {
+            "key": key,
+            "label": label,
+            "description": AWARD_DESCRIPTIONS[key],
+            "leaders": [
+                {
+                    "rank": i + 1,
+                    "ownerId": r["ownerId"],
+                    "displayName": r["displayName"],
+                    "value": {
+                        "playerId": r["playerId"],
+                        "playerName": r["playerName"],
+                        "team": r.get("team", ""),
+                        "position": r["position"],
+                        "vorp": r["vorp"],
+                        "starterPoints": r["starterPoints"],
+                        "gamesStarted": r["gamesStarted"],
+                    },
+                }
+                for i, r in enumerate(rows[:3])
+            ],
+        }
+
+    _add(_vorp_player_race(
+        _rookie_of_year_rows(snapshot, season, _OFF_ROY_POSITIONS),
+        "off_roy", "Offensive Rookie of the Year Race",
+    ))
+    _add(_vorp_player_race(
+        _rookie_of_year_rows(snapshot, season, _DEF_ROY_POSITIONS),
+        "def_roy", "Defensive Rookie of the Year Race",
+    ))
+
     return races
 
 
@@ -1910,11 +2084,26 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             "seasonStatus": str(season.league.get("status") or ""),
             "isComplete": season.is_complete,
             "hasPlayerScoring": _season_has_player_scoring(season),
-            "awards": canonical + activity_based,
+            "awards": _order_awards(canonical + activity_based),
         })
 
+    # Featured season = the newest season that has actually *begun*.  A
+    # freshly-created next-year league still in pre_draft/drafting must
+    # NOT blank out the board — last season's awards stay featured until
+    # the new season is underway.
+    def _has_begun(s: SeasonSnapshot) -> bool:
+        status = str(s.league.get("status") or "").lower()
+        if status in {"in_season", "post_season", "postseason", "complete"}:
+            return True
+        return bool(s.matchups_by_week)
+
+    featured = next(
+        (s for s in snapshot.seasons if _has_begun(s)),
+        snapshot.current_season,
+    )
+
     races: list[dict[str, Any]] = []
-    current = snapshot.current_season
+    current = featured
     if current is not None and not current.is_complete:
         races = _current_season_races(snapshot, current)
 
@@ -1929,11 +2118,20 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             }
             break
 
+    newest = snapshot.current_season
+    upcoming = (
+        newest.season
+        if (newest is not None and current is not None and newest.season != current.season)
+        else None
+    )
+
     return {
         "bySeason": by_season,
         "awardRaces": races,
         "currentSeason": current.season if current else None,
         "currentSeasonStatus": "in_progress" if (current and not current.is_complete) else "complete",
+        "featuredSeason": current.season if current else None,
+        "upcomingSeason": upcoming,
         "hottestRace": hottest,
         "descriptions": AWARD_DESCRIPTIONS,
     }

--- a/src/public_league/overview.py
+++ b/src/public_league/overview.py
@@ -214,30 +214,6 @@ def _most_decorated_franchise(history_section: dict[str, Any]) -> dict[str, Any]
     }
 
 
-def _most_chaotic_manager(awards_section: dict[str, Any]) -> dict[str, Any] | None:
-    races = awards_section.get("awardRaces") or []
-    for race in races:
-        if race["key"] == "chaos_agent" and race.get("leaders"):
-            leader = race["leaders"][0]
-            return {
-                "ownerId": leader["ownerId"],
-                "displayName": leader["displayName"],
-                "score": leader["value"].get("score"),
-            }
-    # Fallback to the most-recent season's historical chaos winner.
-    for season_row in awards_section.get("bySeason") or []:
-        for a in season_row.get("awards", []):
-            if a["key"] == "chaos_agent":
-                val = a.get("value") or {}
-                return {
-                    "ownerId": a["ownerId"],
-                    "displayName": a["displayName"],
-                    "score": val.get("score"),
-                    "season": season_row["season"],
-                }
-    return None
-
-
 # ── v2 home callouts (from specialized sections) ────────────────────────
 def _current_power_leader(power_section: dict[str, Any]) -> dict[str, Any] | None:
     ranking = power_section.get("currentRanking") or []
@@ -421,7 +397,6 @@ def build_section(
         "latestWeeklyRecap": _latest_weekly_recap(weekly_section),
         "mostDecoratedFranchise": _most_decorated_franchise(history_section),
         "hottestRace": awards_section.get("hottestRace"),
-        "mostChaoticManager": _most_chaotic_manager(awards_section),
         "leagueVitals": _league_vitals(snapshot),
         # v2 Home callouts — derived from the 5 specialized sections
         # added in PR #83.  Each may be null when the source section

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -1,81 +1,99 @@
-"""Tests for the extended awards engine.
+"""Tests for the reworked awards engine.
 
-These tests exercise every award formula against the fixture in
-``tests/public_league/fixtures.py`` and extend the fixture with
-``players_points`` where a calculation depends on per-player scoring
-data (Trader of the Year, Waiver King, Playoff MVP).
+Covers the 2026 rework: removed awards, the 2026-05-12 trader/waiver
+tracking cutoff, starting-lineup-only Waiver King, champion-only
+Playoff MVP, the weighted Manager of the Year, Off/Def Rookie of the
+Year, Mr. Consistent, and canonical award ordering.
 """
 from __future__ import annotations
 
 import copy
 import unittest
+from unittest import mock
 
 from src.public_league import awards
 from src.public_league.awards import (
     AWARD_DESCRIPTIONS,
     _bad_beat_scores,
-    _chaos_agent_scores,
-    _most_active_scores,
-    _pick_hoarder_scores,
-    _playoff_mvp_scores,
+    _manager_of_the_year_scores,
+    _manager_unit_points,
+    _mr_consistent_scores,
+    _order_awards,
+    _playoff_mvp_player_rows,
     _rivalry_of_the_year,
+    _rookie_of_year_rows,
     _silent_assassin_scores,
+    _starter_scoring_walk,
+    _top_nfl_team_scores,
     _trader_of_the_year_scores,
+    _vorp_rows,
+    _vorp_starter_slots,
     _waiver_king_scores,
     _weekly_hammer_scores,
     _best_rebuild_scores,
+    _OFF_ROY_POSITIONS,
+    _DEF_ROY_POSITIONS,
+    _TOP_OFFENSE_POSITIONS,
+    _DEFENSIVE_POSITIONS,
+    _VORP_FIXED_STARTER_SLOTS,
+    _FLEX_RBWR_POOL,
 )
 from src.public_league.public_contract import assert_public_payload_safe, build_public_contract
 
 from tests.public_league.fixtures import build_test_snapshot
 
 
+# Fixture transactions are stamped in 2024; the real cutoff is
+# 2026-05-12.  Patch it to 0 when validating the *math* so the fixture
+# transactions count; leave it real when validating the *gating*.
+_NO_CUTOFF = mock.patch.object(awards, "TRADER_WAIVER_TRACKING_START_MS", 0)
+
+_REMOVED_KEYS = {
+    "chaos_agent", "most_active", "pick_hoarder",
+    "runner_up", "points_black_hole", "toilet_bowl",
+}
+
+
 def _with_player_points(snapshot):
-    """Return a deep-copy of snapshot with rich players_points / starters
-    stamps so awards relying on per-player scoring have data."""
+    """Deep-copy snapshot with rich players_points / starters stamps."""
     snap = copy.deepcopy(snapshot)
 
-    # 2025 season — manufacture per-player scoring for each matchup so
-    # trader/waiver/playoff-MVP calculations have numbers to crunch.
     def _stamp(entry, players_points, starters=None):
         entry["players_points"] = players_points
         if starters is not None:
             entry["starters"] = starters
 
     s2025 = snap.seasons[0]
-    # wk1 roster 1 started p-qb1 (40pts), p-rb1 (30), p-wr1 (20) etc.
     for wk, per_rid in {
         1: {
-            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 20.0, "p-te1": 15.0, "p-rookie-a": 15.5}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
-            2: ({"p-qb2": 45.0, "p-rb3": 35.0, "p-wr2": 25.0, "p-te1": 15.0, "p-rookie-b": 15.2}, ["p-qb2","p-rb3","p-wr2","p-te1","p-rookie-b"]),
-            3: ({"p-wr1": 20.0, "p-wr2": 20.0, "p-wr3": 15.0, "p-rb1": 20.0, "p-qb1": 20.0}, ["p-wr1","p-wr2","p-wr3","p-rb1","p-qb1"]),
-            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 20.0, "p-idp3": 25.0, "p-qb2": 15.3}, ["p-te1","p-te2","p-idp1","p-idp2","p-idp3","p-qb2"]),
+            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 20.0, "p-te1": 15.0, "p-rookie-a": 15.5}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
+            2: ({"p-qb2": 45.0, "p-rb3": 35.0, "p-wr2": 25.0, "p-te1": 15.0, "p-rookie-b": 15.2}, ["p-qb2", "p-rb3", "p-wr2", "p-te1", "p-rookie-b"]),
+            3: ({"p-wr1": 20.0, "p-wr2": 20.0, "p-wr3": 15.0, "p-rb1": 20.0, "p-qb1": 20.0}, ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"]),
+            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 20.0, "p-idp3": 25.0, "p-qb2": 15.3}, ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]),
         },
         2: {
-            1: ({"p-qb1": 40.0, "p-rb1": 35.0, "p-wr1": 25.8, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
-            3: ({"p-wr1": 25.0, "p-wr2": 25.0, "p-wr3": 30.0, "p-rb1": 32.1, "p-qb1": 30.0}, ["p-wr1","p-wr2","p-wr3","p-rb1","p-qb1"]),
-            2: ({"p-qb2": 50.0, "p-rb2": 40.0, "p-wr2": 35.0, "p-te1": 20.0, "p-rookie-b": 20.0}, ["p-qb2","p-rb2","p-wr2","p-te1","p-rookie-b"]),
-            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 15.0, "p-idp3": 15.0, "p-qb2": 15.6}, ["p-te1","p-te2","p-idp1","p-idp2","p-idp3","p-qb2"]),
+            1: ({"p-qb1": 40.0, "p-rb1": 35.0, "p-wr1": 25.8, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
+            3: ({"p-wr1": 25.0, "p-wr2": 25.0, "p-wr3": 30.0, "p-rb1": 32.1, "p-qb1": 30.0}, ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"]),
+            2: ({"p-qb2": 50.0, "p-rb2": 40.0, "p-wr2": 35.0, "p-te1": 20.0, "p-rookie-b": 20.0}, ["p-qb2", "p-rb2", "p-wr2", "p-te1", "p-rookie-b"]),
+            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 15.0, "p-idp3": 15.0, "p-qb2": 15.6}, ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]),
         },
         15: {
-            2: ({"p-rb2": 55.5, "p-wr2": 35.0, "p-qb2": 40.0, "p-te1": 15.0, "p-rookie-b": 10.0}, ["p-rb2","p-wr2","p-qb2","p-te1","p-rookie-b"]),
-            4: ({"p-te1": 15.0, "p-te2": 30.0, "p-idp1": 30.0, "p-idp2": 25.0, "p-idp3": 20.0, "p-qb2": 10.0}, ["p-te1","p-te2","p-idp1","p-idp2","p-idp3","p-qb2"]),
-            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 35.0, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
-            3: ({"p-wr1": 40.0, "p-wr2": 30.0, "p-wr3": 25.0, "p-rb1": 25.0, "p-qb1": 20.0}, ["p-wr1","p-wr2","p-wr3","p-rb1","p-qb1"]),
+            2: ({"p-rb2": 55.5, "p-wr2": 35.0, "p-qb2": 40.0, "p-te1": 15.0, "p-rookie-b": 10.0}, ["p-rb2", "p-wr2", "p-qb2", "p-te1", "p-rookie-b"]),
+            4: ({"p-te1": 15.0, "p-te2": 30.0, "p-idp1": 30.0, "p-idp2": 25.0, "p-idp3": 20.0, "p-qb2": 10.0}, ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]),
+            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 35.0, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
+            3: ({"p-wr1": 40.0, "p-wr2": 30.0, "p-wr3": 25.0, "p-rb1": 25.0, "p-qb1": 20.0}, ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"]),
         },
         16: {
-            2: ({"p-rb2": 50.0, "p-wr2": 30.0, "p-qb2": 35.0, "p-te1": 15.0, "p-rookie-b": 15.0}, ["p-rb2","p-wr2","p-qb2","p-te1","p-rookie-b"]),
-            1: ({"p-qb1": 30.0, "p-rb1": 25.0, "p-wr1": 25.0, "p-te1": 15.0, "p-rookie-a": 25.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
+            2: ({"p-rb2": 50.0, "p-wr2": 30.0, "p-qb2": 35.0, "p-te1": 15.0, "p-rookie-b": 15.0}, ["p-rb2", "p-wr2", "p-qb2", "p-te1", "p-rookie-b"]),
+            1: ({"p-qb1": 30.0, "p-rb1": 25.0, "p-wr1": 25.0, "p-te1": 15.0, "p-rookie-a": 25.0}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
         },
     }.items():
-        entries = s2025.matchups_by_week.get(wk, [])
-        for e in entries:
+        for e in s2025.matchups_by_week.get(wk, []):
             rid = int(e.get("roster_id"))
             if rid in per_rid:
                 pp, st = per_rid[rid]
                 _stamp(e, pp, starters=st)
 
-    # 2024 season — simpler but sufficient for tests.
     s2024 = snap.seasons[1]
     for wk in s2024.matchups_by_week.keys():
         for entry in s2024.matchups_by_week[wk]:
@@ -86,15 +104,49 @@ def _with_player_points(snapshot):
 
 
 class AwardDescriptionsTests(unittest.TestCase):
-    def test_every_award_has_a_description(self):
+    def test_active_awards_have_descriptions(self) -> None:
         for key in (
-            "trader_of_the_year", "best_trade_of_the_year", "waiver_king",
-            "chaos_agent", "most_active", "pick_hoarder", "silent_assassin",
-            "weekly_hammer", "playoff_mvp", "bad_beat", "best_rebuild",
-            "rivalry_of_the_year",
+            "champion", "manager_of_the_year", "trader_of_the_year",
+            "best_trade_of_the_year", "waiver_king", "silent_assassin",
+            "weekly_hammer", "playoff_mvp", "bad_beat", "mr_consistent",
+            "best_rebuild", "rivalry_of_the_year", "off_roy", "def_roy",
+            "league_mvp", "top_qb", "top_offense", "top_defense",
         ):
             self.assertIn(key, AWARD_DESCRIPTIONS)
             self.assertTrue(AWARD_DESCRIPTIONS[key])
+
+    def test_removed_awards_have_no_description(self) -> None:
+        for key in _REMOVED_KEYS:
+            self.assertNotIn(key, AWARD_DESCRIPTIONS)
+
+
+class TrackingCutoffTests(unittest.TestCase):
+    """Trader of the Year / Waiver King only start 2026-05-12."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_pre_cutoff_transactions_are_excluded(self) -> None:
+        # Fixture txs are stamped in 2024 — before the real cutoff.
+        rows, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
+        self.assertEqual(rows, [])
+        self.assertIsNone(best)
+        self.assertEqual(_waiver_king_scores(self.snapshot, self.snapshot.seasons[0]), [])
+
+    def test_section_omits_trader_and_waiver_pre_cutoff(self) -> None:
+        section = awards.build_section(self.snapshot)
+        for season_row in section["bySeason"]:
+            keys = {a["key"] for a in season_row["awards"]}
+            self.assertNotIn("trader_of_the_year", keys)
+            self.assertNotIn("waiver_king", keys)
+            self.assertNotIn("best_trade_of_the_year", keys)
+
+    def test_post_cutoff_transactions_count(self) -> None:
+        with _NO_CUTOFF:
+            rows, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
+        self.assertTrue(rows)
+        self.assertIsNotNone(best)
 
 
 class TraderAndBestTradeTests(unittest.TestCase):
@@ -103,21 +155,37 @@ class TraderAndBestTradeTests(unittest.TestCase):
         cls.snapshot = _with_player_points(build_test_snapshot())
 
     def test_trader_rows_sort_by_points_gained(self) -> None:
-        rows, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
+        with _NO_CUTOFF:
+            rows, _ = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
         self.assertTrue(rows)
-        # Descending order by pointsGained.
         for a, b in zip(rows, rows[1:]):
             self.assertGreaterEqual(a["pointsGained"], b["pointsGained"])
-        # Every row includes human-friendly display name.
         for r in rows:
             self.assertTrue(r["displayName"])
 
-    def test_best_trade_has_a_winner_when_trade_exists(self) -> None:
-        _, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
+    def test_best_trade_is_four_tuple_with_tx(self) -> None:
+        with _NO_CUTOFF:
+            _, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
         self.assertIsNotNone(best)
-        gain, owner_id, payload = best
+        gain, owner_id, payload, tx = best
         self.assertIn(owner_id, {"owner-A", "owner-B"})
         self.assertIn("transactionId", payload)
+        self.assertEqual(tx.get("type"), "trade")
+
+    def test_best_trade_award_carries_full_trade_detail(self) -> None:
+        with _NO_CUTOFF:
+            section = awards.build_section(self.snapshot)
+        found = None
+        for season_row in section["bySeason"]:
+            for a in season_row["awards"]:
+                if a["key"] == "best_trade_of_the_year":
+                    found = a
+        self.assertIsNotNone(found)
+        trade = found["value"].get("trade")
+        self.assertIsNotNone(trade)
+        self.assertIn("sides", trade)
+        self.assertGreaterEqual(len(trade["sides"]), 2)
+        self.assertIn("receivedAssets", trade["sides"][0])
 
 
 class WaiverKingTests(unittest.TestCase):
@@ -125,52 +193,26 @@ class WaiverKingTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.snapshot = _with_player_points(build_test_snapshot())
 
-    def test_waiver_rows_have_faab_efficiency_when_bid_present(self) -> None:
-        rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[0])
+    def test_value_shape_has_no_faab(self) -> None:
+        with _NO_CUTOFF:
+            rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[0])
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertIn("pointsGained", r)
+            self.assertIn("usefulAdds", r)
+            self.assertNotIn("faabEfficiency", r)
+            self.assertNotIn("faabSpent", r)
+
+    def test_only_started_weeks_count(self) -> None:
+        # wv-2025-a adds p-wr3 to roster 3 at leg 1.  Post-add weeks are
+        # >1: roster 3 starts p-wr3 in wk2 (30.0) and wk15 (25.0) only —
+        # week 1 is pre-add and bench weeks never count → exactly 55.0.
+        with _NO_CUTOFF:
+            rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[0])
         cole = next((r for r in rows if r["ownerId"] == "owner-C"), None)
         self.assertIsNotNone(cole)
-        self.assertIsNotNone(cole["faabEfficiency"])
-
-    def test_missing_bids_do_not_crash(self) -> None:
-        rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[1])
-        # 2024 season has a free_agent add with no bid — should not explode.
-        for r in rows:
-            self.assertIn("faabEfficiency", r)
-
-
-class ChaosAgentTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.snapshot = _with_player_points(build_test_snapshot())
-
-    def test_chaos_formula_matches_spec(self) -> None:
-        rows = _chaos_agent_scores(self.snapshot, self.snapshot.seasons[0])
-        # 2025 has one trade (owner-A ↔ owner-B).  Each side should earn:
-        #   3 * 1 trade + 1 * 1 partner + 1 * 1 player + 1 * 1 pick = 6
-        # plus owner-A's side has 1 pick received; owner-B has 1 pick too.
-        owner_a = next(r for r in rows if r["ownerId"] == "owner-A")
-        self.assertEqual(owner_a["trades"], 1)
-        self.assertEqual(owner_a["distinctPartners"], 1)
-        # players_moved includes received players only — 1 for each side.
-        self.assertEqual(owner_a["playersMoved"], 1)
-        self.assertEqual(owner_a["picksMoved"], 1)
-        self.assertEqual(owner_a["score"], 3 * 1 + 1 * 1 + 1 * 1 + 1 * 1)
-
-    def test_sort_descending(self) -> None:
-        rows = _chaos_agent_scores(self.snapshot, self.snapshot.seasons[0])
-        for a, b in zip(rows, rows[1:]):
-            self.assertGreaterEqual(a["score"], b["score"])
-
-
-class MostActiveTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.snapshot = _with_player_points(build_test_snapshot())
-
-    def test_total_sums_all_activity(self) -> None:
-        rows = _most_active_scores(self.snapshot, self.snapshot.seasons[0])
-        for r in rows:
-            self.assertEqual(r["total"], r["trades"] + r["waivers"] + r["freeAgents"] + r["drops"])
+        self.assertEqual(cole["pointsGained"], 55.0)
+        self.assertEqual(cole["usefulAdds"], 1)
 
 
 class SilentAssassinTests(unittest.TestCase):
@@ -186,7 +228,6 @@ class SilentAssassinTests(unittest.TestCase):
 
     def test_close_games_only_count_under_ten(self) -> None:
         rows = _silent_assassin_scores(self.snapshot, self.snapshot.seasons[0], min_eligible=1)
-        # No row should ever record a loss from a blowout as a "close game".
         for r in rows:
             self.assertLessEqual(r["avgCloseMargin"], 10.0 + 1e-6)
 
@@ -199,32 +240,129 @@ class WeeklyHammerTests(unittest.TestCase):
     def test_high_score_finishes_count(self) -> None:
         rows = _weekly_hammer_scores(self.snapshot, self.snapshot.seasons[0])
         by_owner = {r["ownerId"]: r for r in rows}
-        # Weeks 1 & 2 regular season.  Week 1 top: owner-B 135.2,
-        # week 2 top: owner-B 165.0.  Owner-B should have 2 high-score
-        # finishes.  No one else should have 2.
         self.assertEqual(by_owner["owner-B"]["highScoreFinishes"], 2)
         for owner_id, r in by_owner.items():
             if owner_id != "owner-B":
                 self.assertLessEqual(r["highScoreFinishes"], 1)
 
 
-class PlayoffMvpTests(unittest.TestCase):
+class PlayoffMvpChampionOnlyTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.snapshot = _with_player_points(build_test_snapshot())
 
-    def test_playoff_points_accumulate(self) -> None:
-        rows = _playoff_mvp_scores(self.snapshot, self.snapshot.seasons[0])
-        by_owner = {r["ownerId"]: r for r in rows}
-        # owner-B played week 15 (155.5) + week 16 (145.0) = 300.5.
-        self.assertAlmostEqual(by_owner["owner-B"]["playoffPoints"], 300.5, places=1)
+    def test_only_champion_roster_players(self) -> None:
+        # 2025 champion = roster 2 (owner-B).  Every candidate must
+        # attribute to owner-B.
+        rows = _playoff_mvp_player_rows(self.snapshot, self.snapshot.seasons[0])
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertEqual(r["ownerId"], "owner-B")
+        # Sorted by VORP desc.
+        for a, b in zip(rows, rows[1:]):
+            self.assertGreaterEqual(a["vorp"], b["vorp"])
 
-    def test_top_player_populated(self) -> None:
-        rows = _playoff_mvp_scores(self.snapshot, self.snapshot.seasons[0])
+    def test_no_champion_returns_empty(self) -> None:
+        snap = copy.deepcopy(self.snapshot)
+        snap.seasons[0].winners_bracket = []
+        self.assertEqual(_playoff_mvp_player_rows(snap, snap.seasons[0]), [])
+
+
+class TopOffenseExcludesKickerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_offense_defense_partition_matches_position_sets(self) -> None:
+        season = self.snapshot.seasons[0]
+        units = _manager_unit_points(self.snapshot, season, regular_season_only=True)
+        expected: dict[str, dict[str, float]] = {}
+        for _wk, _rid, owner_id, _pid, pos, pts, _is_p in _starter_scoring_walk(
+            self.snapshot, season, regular_season_only=True
+        ):
+            rec = expected.setdefault(owner_id, {"offense": 0.0, "defense": 0.0})
+            if pos in _TOP_OFFENSE_POSITIONS:
+                rec["offense"] += pts
+            elif pos in _DEFENSIVE_POSITIONS:
+                rec["defense"] += pts
+            # K / unmapped contribute to neither.
+        for owner_id, rec in units.items():
+            self.assertAlmostEqual(rec["offense"], expected[owner_id]["offense"], places=2)
+            self.assertAlmostEqual(rec["defense"], expected[owner_id]["defense"], places=2)
+
+    def test_kicker_excluded_from_offense_and_off_roy(self) -> None:
+        self.assertNotIn("K", _TOP_OFFENSE_POSITIONS)
+        self.assertNotIn("K", _OFF_ROY_POSITIONS)
+
+
+class ManagerOfTheYearTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_composite_in_unit_range_and_sorted(self) -> None:
+        with _NO_CUTOFF:
+            trader_rows, _ = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
+            waiver_rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[0])
+            rows = _manager_of_the_year_scores(
+                self.snapshot, self.snapshot.seasons[0], trader_rows, waiver_rows
+            )
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertGreaterEqual(r["compositeScore"], 0.0)
+            self.assertLessEqual(r["compositeScore"], 1.0)
+            self.assertIn("finishRank", r)
+            self.assertIn("tradePointsGained", r)
+            self.assertIn("waiverPointsGained", r)
+        for a, b in zip(rows, rows[1:]):
+            self.assertGreaterEqual(a["compositeScore"], b["compositeScore"])
+
+    def test_champion_has_best_finish_rank(self) -> None:
+        rows = _manager_of_the_year_scores(
+            self.snapshot, self.snapshot.seasons[0], [], []
+        )
         by_owner = {r["ownerId"]: r for r in rows}
-        # owner-B's stamp has p-rb2 as 55.5 in wk15; we overwrite
-        # starters/players_points so the top player should be p-rb2.
-        self.assertTrue(by_owner["owner-B"]["topPlayerName"])
+        # 2025 champion = owner-B → finishRank 1.
+        self.assertEqual(by_owner["owner-B"]["finishRank"], 1)
+
+
+class RookieOfTheYearTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_off_roy_only_offensive_rookies(self) -> None:
+        rows = _rookie_of_year_rows(
+            self.snapshot, self.snapshot.seasons[0], _OFF_ROY_POSITIONS
+        )
+        for r in rows:
+            self.assertIn(r["position"], _OFF_ROY_POSITIONS)
+            meta = self.snapshot.nfl_players.get(r["playerId"]) or {}
+            self.assertEqual(int(meta.get("years_exp")), 0)
+
+    def test_def_roy_only_defensive_rookies(self) -> None:
+        rows = _rookie_of_year_rows(
+            self.snapshot, self.snapshot.seasons[0], _DEF_ROY_POSITIONS
+        )
+        for r in rows:
+            self.assertIn(r["position"], _DEF_ROY_POSITIONS)
+            meta = self.snapshot.nfl_players.get(r["playerId"]) or {}
+            self.assertEqual(int(meta.get("years_exp")), 0)
+
+
+class MrConsistentTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_sorted_ascending_cv_and_nonnegative(self) -> None:
+        rows = _mr_consistent_scores(self.snapshot, self.snapshot.seasons[0], min_weeks=1)
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertGreaterEqual(r["cv"], 0.0)
+            self.assertGreater(r["meanScore"], 0.0)
+        for a, b in zip(rows, rows[1:]):
+            self.assertLessEqual(a["cv"], b["cv"])
 
 
 class BadBeatTests(unittest.TestCase):
@@ -235,25 +373,7 @@ class BadBeatTests(unittest.TestCase):
     def test_points_in_loss_only(self) -> None:
         rows = _bad_beat_scores(self.snapshot, self.snapshot.seasons[0])
         by_owner = {r["ownerId"]: r for r in rows}
-        # owner-C lost wk1 (95.0 vs owner-D 110.3) and wk2 (142.1 vs
-        # owner-A 145.8).  biggestLoss=142.1.
         self.assertAlmostEqual(by_owner["owner-C"]["biggestLoss"], 142.1, places=1)
-
-
-class PickHoarderTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.snapshot = _with_player_points(build_test_snapshot())
-
-    def test_weighted_score_nonzero(self) -> None:
-        rows = _pick_hoarder_scores(self.snapshot)
-        self.assertTrue(rows)
-        self.assertGreater(rows[0]["weightedScore"], 0)
-
-    def test_sort_descending(self) -> None:
-        rows = _pick_hoarder_scores(self.snapshot)
-        for a, b in zip(rows, rows[1:]):
-            self.assertGreaterEqual(a["weightedScore"], b["weightedScore"])
 
 
 class BestRebuildTests(unittest.TestCase):
@@ -263,12 +383,9 @@ class BestRebuildTests(unittest.TestCase):
 
     def test_composite_populated_for_known_owners(self) -> None:
         rows = _best_rebuild_scores(
-            self.snapshot,
-            self.snapshot.seasons[0],
-            self.snapshot.seasons[1],
+            self.snapshot, self.snapshot.seasons[0], self.snapshot.seasons[1]
         )
         owners = {r["ownerId"] for r in rows}
-        # Only owners present in BOTH seasons should appear.
         self.assertEqual(owners, {"owner-A", "owner-B", "owner-C"})
 
 
@@ -281,11 +398,108 @@ class RivalryOfTheYearTests(unittest.TestCase):
         r = _rivalry_of_the_year(self.snapshot, self.snapshot.seasons[0])
         self.assertIsNotNone(r)
         self.assertIn("rivalryIndex", r)
-        # A vs C meets in wk2 (margin 3.7 — both close-bands) and wk15
-        # playoff semifinal (margin 10.0 — within 10-band).  Their
-        # rivalry_index 14 beats A-B's 7 (one playoff game, no close
-        # bands).
         self.assertEqual(sorted(r["ownerIds"]), sorted(["owner-A", "owner-C"]))
+
+
+class VorpFloorAndSlotsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_no_negative_vorp_regular_season(self) -> None:
+        rows = _vorp_rows(self.snapshot, self.snapshot.seasons[0], regular_season_only=True)
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertGreaterEqual(r["vorp"], 0.0)
+
+    def test_no_negative_vorp_playoffs(self) -> None:
+        rows = _playoff_mvp_player_rows(self.snapshot, self.snapshot.seasons[0])
+        for r in rows:
+            self.assertGreaterEqual(r["vorp"], 0.0)
+
+    def test_fixed_slots_exact(self) -> None:
+        slots = _vorp_starter_slots({})
+        self.assertEqual(slots["QB"], 24)
+        self.assertEqual(slots["TE"], 24)
+        self.assertEqual(slots["K"], 12)
+        self.assertEqual(slots["DL"], 36)
+        self.assertEqual(slots["LB"], 36)
+        self.assertEqual(slots["DB"], 36)
+        self.assertEqual(_VORP_FIXED_STARTER_SLOTS["QB"], 24)
+
+    def test_rbwr_split_from_top_84(self) -> None:
+        rb = [{"position": "RB", "starterPoints": float(200 - i)} for i in range(60)]
+        wr = [{"position": "WR", "starterPoints": float(150 - i)} for i in range(60)]
+        slots = _vorp_starter_slots({"RB": rb, "WR": wr})
+        # 120 RB+WR total → top 84 by points splits into RB+WR == 84.
+        self.assertEqual(slots["RB"] + slots["WR"], _FLEX_RBWR_POOL)
+        self.assertGreater(slots["RB"], 0)
+        self.assertGreater(slots["WR"], 0)
+
+    def test_rbwr_split_smaller_than_pool(self) -> None:
+        rb = [{"position": "RB", "starterPoints": 50.0} for _ in range(10)]
+        wr = [{"position": "WR", "starterPoints": 40.0} for _ in range(5)]
+        slots = _vorp_starter_slots({"RB": rb, "WR": wr})
+        self.assertEqual(slots["RB"], 10)
+        self.assertEqual(slots["WR"], 5)
+
+
+class TopNflTeamTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        snap = _with_player_points(build_test_snapshot())
+        # Fixture stub has no NFL team tags — assign a few so the
+        # aggregation has data (nfl_players is deep-copied, safe).
+        for pid, team in {
+            "p-qb1": "DET", "p-rb1": "DET", "p-wr1": "SF",
+            "p-qb2": "KC", "p-rb2": "KC",
+        }.items():
+            if pid in snap.nfl_players:
+                snap.nfl_players[pid] = {**snap.nfl_players[pid], "team": team}
+        cls.snapshot = snap
+
+    def test_scores_sorted_and_positive(self) -> None:
+        rows = _top_nfl_team_scores(self.snapshot, self.snapshot.seasons[0])
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertGreater(r["points"], 0)
+            self.assertTrue(r["team"])
+        for a, b in zip(rows, rows[1:]):
+            self.assertGreaterEqual(a["points"], b["points"])
+
+    def test_award_emitted_with_team_value(self) -> None:
+        section = awards.build_section(self.snapshot)
+        found = None
+        for season_row in section["bySeason"]:
+            for a in season_row["awards"]:
+                if a["key"] == "top_nfl_team":
+                    found = a
+        self.assertIsNotNone(found)
+        self.assertEqual(found["ownerId"], "")
+        self.assertIn("team", found["value"])
+        self.assertIn("points", found["value"])
+        self.assertEqual(found["displayName"], found["value"]["team"])
+
+
+class AwardOrderingTests(unittest.TestCase):
+    def test_champion_then_moty_lead(self) -> None:
+        keys = [
+            "rivalry_of_the_year", "manager_of_the_year", "top_qb",
+            "champion", "bad_beat",
+        ]
+        awarded = [{"key": k} for k in keys]
+        ordered = [a["key"] for a in _order_awards(awarded)]
+        self.assertEqual(ordered[0], "champion")
+        self.assertEqual(ordered[1], "manager_of_the_year")
+
+    def test_section_orders_champion_first_moty_second(self) -> None:
+        snapshot = _with_player_points(build_test_snapshot())
+        section = awards.build_section(snapshot)
+        for season_row in section["bySeason"]:
+            ks = [a["key"] for a in season_row["awards"]]
+            if "champion" in ks and "manager_of_the_year" in ks:
+                self.assertEqual(ks[0], "champion")
+                self.assertEqual(ks[1], "manager_of_the_year")
 
 
 class AwardsSectionIntegrationTests(unittest.TestCase):
@@ -294,7 +508,7 @@ class AwardsSectionIntegrationTests(unittest.TestCase):
         cls.snapshot = _with_player_points(build_test_snapshot())
         cls.section = awards.build_section(cls.snapshot)
 
-    def test_each_historical_award_has_required_fields(self) -> None:
+    def test_each_award_has_required_fields(self) -> None:
         for season_row in self.section["bySeason"]:
             for a in season_row["awards"]:
                 self.assertIn("key", a)
@@ -302,17 +516,19 @@ class AwardsSectionIntegrationTests(unittest.TestCase):
                 self.assertIn("description", a)
                 self.assertIn("ownerId", a)
 
-    def test_live_races_empty_when_current_season_complete(self) -> None:
-        # Fixture marks both seasons "complete" → zero live races.
-        self.assertEqual(self.section["awardRaces"], [])
-
-    def test_every_award_has_a_description_in_the_payload(self) -> None:
+    def test_removed_awards_absent(self) -> None:
         for season_row in self.section["bySeason"]:
             for a in season_row["awards"]:
-                self.assertEqual(
-                    a["description"],
-                    AWARD_DESCRIPTIONS.get(a["key"], ""),
-                )
+                self.assertNotIn(a["key"], _REMOVED_KEYS)
+
+    def test_descriptions_match(self) -> None:
+        for season_row in self.section["bySeason"]:
+            for a in season_row["awards"]:
+                self.assertEqual(a["description"], AWARD_DESCRIPTIONS.get(a["key"], ""))
+
+    def test_featured_season_keys_present(self) -> None:
+        self.assertIn("featuredSeason", self.section)
+        self.assertIn("upcomingSeason", self.section)
 
     def test_no_private_fields_leak(self) -> None:
         contract = build_public_contract(self.snapshot)
@@ -320,14 +536,12 @@ class AwardsSectionIntegrationTests(unittest.TestCase):
 
 
 class AwardsLiveRaceTests(unittest.TestCase):
-    """In-progress season → live races populated + top-3 only."""
-
     @classmethod
     def setUpClass(cls) -> None:
         base = _with_player_points(build_test_snapshot())
-        # Mark 2025 as in_progress so the live-race branch fires.
         base.seasons[0].league["status"] = "in_season"
-        cls.section = awards.build_section(base)
+        with _NO_CUTOFF:
+            cls.section = awards.build_section(base)
 
     def test_has_award_races(self) -> None:
         self.assertGreater(len(self.section["awardRaces"]), 0)
@@ -338,50 +552,16 @@ class AwardsLiveRaceTests(unittest.TestCase):
             for i, leader in enumerate(race["leaders"]):
                 self.assertEqual(leader["rank"], i + 1)
 
-    def test_hottest_race_populated(self) -> None:
-        self.assertIsNotNone(self.section["hottestRace"])
-        self.assertIn("topLeader", self.section["hottestRace"])
-
-    def test_race_catalog_covers_expected_keys(self) -> None:
+    def test_race_catalog_covers_expected_and_excludes_removed(self) -> None:
         keys = {r["key"] for r in self.section["awardRaces"]}
-        expected = {
-            "trader_of_the_year", "waiver_king", "chaos_agent",
-            "most_active", "weekly_hammer", "bad_beat", "pick_hoarder",
-        }
-        # silent_assassin and playoff_mvp are conditional (eligibility /
-        # playoff-only).  Must still include the core races above.
-        self.assertTrue(expected.issubset(keys))
-
-
-class EdgeCaseTests(unittest.TestCase):
-    """Defensive tests: renamed teams, missing FAAB, tied values."""
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.snapshot = _with_player_points(build_test_snapshot())
-
-    def test_renamed_team_attributes_to_single_owner(self) -> None:
-        # owner-A renamed team between 2024 and 2025.  The Trader of
-        # the Year row must appear ONCE per season, keyed by owner-A.
-        section = awards.build_section(self.snapshot)
-        for season_row in section["bySeason"]:
-            owners_in_toy = [
-                a["ownerId"] for a in season_row["awards"] if a["key"] == "trader_of_the_year"
-            ]
-            # Either one winner or none (if no trades that season).
-            self.assertLessEqual(len(owners_in_toy), 1)
-
-    def test_no_faab_bid_returns_none_efficiency(self) -> None:
-        rows = _waiver_king_scores(self.snapshot, self.snapshot.seasons[1])
-        for r in rows:
-            if r["faabSpent"] == 0:
-                self.assertIsNone(r["faabEfficiency"])
-
-    def test_ties_are_deterministic(self) -> None:
-        # Running twice must produce identical ordering.
-        a = _most_active_scores(self.snapshot, self.snapshot.seasons[0])
-        b = _most_active_scores(self.snapshot, self.snapshot.seasons[0])
-        self.assertEqual([r["ownerId"] for r in a], [r["ownerId"] for r in b])
+        # mr_consistent / silent_assassin / playoff_mvp are conditional
+        # (week-count / eligibility / champion); the core set is always
+        # present once the cutoff lets trades/waivers through.
+        self.assertTrue(
+            {"trader_of_the_year", "waiver_king", "weekly_hammer",
+             "bad_beat", "manager_of_the_year"}.issubset(keys)
+        )
+        self.assertEqual(keys & _REMOVED_KEYS, set())
 
 
 if __name__ == "__main__":

--- a/tests/public_league/test_csv_export.py
+++ b/tests/public_league/test_csv_export.py
@@ -51,7 +51,7 @@ class CsvExportTests(unittest.TestCase):
         rows = self._parse(text)
         self.assertTrue(rows)
         keys = {r["key"] for r in rows}
-        for required in ("champion", "runner_up", "top_seed"):
+        for required in ("champion", "manager_of_the_year", "top_seed"):
             self.assertIn(required, keys)
 
     def test_records_export_has_categories(self) -> None:

--- a/tests/public_league/test_metrics_engines.py
+++ b/tests/public_league/test_metrics_engines.py
@@ -410,12 +410,10 @@ class AwardsTests(_BaseFixture):
             keys = {a["key"] for a in season_row["awards"]}
             for expected in (
                 "champion",
-                "runner_up",
+                "manager_of_the_year",
                 "top_seed",
                 "regular_season_crown",
                 "points_king",
-                "points_black_hole",
-                "toilet_bowl",
                 "highest_single_week",
                 "lowest_single_week",
             ):


### PR DESCRIPTION
## Summary
Full rework of the league Awards section per requested changes.

**Removed:** Chaos Agent, Most Active, Pick Hoarder, Toilet Bowl, Runner-Up, Points Black Hole (+ dead "most chaotic manager" home highlight).

**Changed:**
- Trader of the Year / Waiver King now begin **2026-05-12** (Sleeper `created` cutoff); pre-cutoff seasons omit them.
- Waiver King = total points the pickup scored **while in the starting lineup** (no bench/FAAB).
- Playoff MVP = the **championship team's** best playoff VORP performer.
- Top Offense excludes kickers.
- **Manager of the Year** = `0.30·finish + 0.25·winPct + 0.15·pointsFor + 0.15·tradeGain + 0.15·waiverPts`, every term min-max normalized; pinned right below Champion via canonical award order.
- Best Trade of the Year carries the full normalized trade (UI renders what the trade was, reusing `TradeCard`).
- VORP floored at 0 (never negative); replacement depth fixed QB24/TE24/K12/DL36/LB36/DB36, RB/WR derived from the live top-84 RB+WR flex pool.

**Added:** Offensive & Defensive Rookie of the Year (VORP), Mr. Consistent, Top Fantasy NFL Team.

**UI:** awards default to the featured season; tap an award for its full multi-season history (modal). Season rollover automatic; draft discovery now derives season from the Sleeper league object, not the calendar year.

## Test plan
- [x] `tests/public_league/` — 310 passed (incl. 7 new: VORP floor, slots, Top NFL Team, cutoff gating, MOTY, champion-only playoff MVP, ordering)
- [x] `tests/api/` — 1135 passed / 3 skipped (covers sleeper_overlay season fix)
- [x] `cd frontend && npm run build` — all bundles under budget (/league 164/170 KB)
- [ ] CI green
- [ ] Post-deploy: visit /league → Awards; verify Champion→Manager of the Year order, tap-for-history, Best Trade detail, new awards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)