### PR TITLE
fix(awards): keep last completed season featured until games are played

### DIFF
--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -2087,15 +2087,22 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             "awards": _order_awards(canonical + activity_based),
         })
 
-    # Featured season = the newest season that has actually *begun*.  A
-    # freshly-created next-year league still in pre_draft/drafting must
-    # NOT blank out the board — last season's awards stay featured until
-    # the new season is underway.
+    # Featured season = the newest season that has actually *begun*.
+    # "Begun" means real games have been played (some matchup scored
+    # points) OR the season is complete.  Sleeper flips dynasty leagues
+    # to ``in_season`` in the offseason — months before NFL Week 1 — so
+    # status alone is NOT a reliable "started" signal: last season's
+    # full award board must stay featured until the new season actually
+    # plays games.
+    def _has_played_games(s: SeasonSnapshot) -> bool:
+        for entries in s.matchups_by_week.values():
+            for m in entries:
+                if metrics.matchup_points(m) > 0:
+                    return True
+        return False
+
     def _has_begun(s: SeasonSnapshot) -> bool:
-        status = str(s.league.get("status") or "").lower()
-        if status in {"in_season", "post_season", "postseason", "complete"}:
-            return True
-        return bool(s.matchups_by_week)
+        return s.is_complete or _has_played_games(s)
 
     featured = next(
         (s for s in snapshot.seasons if _has_begun(s)),

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -502,6 +502,37 @@ class AwardOrderingTests(unittest.TestCase):
                 self.assertEqual(ks[1], "manager_of_the_year")
 
 
+class FeaturedSeasonRolloverTests(unittest.TestCase):
+    """Sleeper flips dynasty leagues to ``in_season`` in the offseason —
+    before any NFL games.  The last completed season's full award board
+    must stay featured until the new season actually plays games."""
+
+    def test_in_season_but_no_games_keeps_prior_complete_featured(self) -> None:
+        # Deep-copy: build_test_snapshot() shares module-level fixture
+        # dicts/lists; mutating them in place would pollute other tests.
+        snap = copy.deepcopy(build_test_snapshot())  # [2025 complete, 2024 complete]
+        newest = snap.seasons[0]
+        # Simulate the live 2026 offseason: status in_season, zero games.
+        newest.league["status"] = "in_season"
+        for entries in newest.matchups_by_week.values():
+            for m in entries:
+                m["points"] = 0
+                m.pop("players_points", None)
+                m.pop("starters", None)
+        section = awards.build_section(snap)
+        # Fixture seasons are [2025, 2024]; treating the newest (2025)
+        # as the empty offseason league, the prior complete season
+        # (2024) must be featured, with 2025 marked upcoming.
+        self.assertEqual(section["featuredSeason"], snap.seasons[1].season)
+        self.assertEqual(section["upcomingSeason"], newest.season)
+
+    def test_played_games_promote_new_season(self) -> None:
+        snap = _with_player_points(build_test_snapshot())
+        snap.seasons[0].league["status"] = "in_season"  # has real points
+        section = awards.build_section(snap)
+        self.assertEqual(section["featuredSeason"], snap.seasons[0].season)
+
+
 class AwardsSectionIntegrationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
## Summary
Follow-up to #469. Sleeper flips dynasty leagues to `status="in_season"` in the offseason — the live 2026 league is already `in_season` with **zero games played**. The featured-season rule from #469 treated `in_season` as "started", so it would feature 2026's sparse 9-award board instead of 2025's full 26-winner board.

A season now counts as **begun** only when it is `complete` **or** has ≥1 matchup with points actually scored. So 2025's full award board stays featured (default view) until 2026 actually plays games; 2026 still shows as `upcomingSeason` and prior years remain in the per-award history modal.

## Test plan
- [x] `tests/public_league/` — 312 passed (incl. 2 new: in_season-no-games keeps prior complete featured; played games promote new season)
- [x] Verified against live Sleeper state: 2026=`in_season` no champ (9 awards), 2025=`complete` (26 awards) → 2025 will be featured
- [ ] CI green
- [ ] Post-deploy: `/league` Awards defaults to 2025's full winner board

🤖 Generated with [Claude Code](https://claude.com/claude-code)