### PR TITLE
fix(awards/ui): history modal, award-history link, franchise award list, em-dashes

### DIFF
--- a/frontend/app/finder/page.jsx
+++ b/frontend/app/finder/page.jsx
@@ -337,7 +337,7 @@ export default function FinderPage() {
                               ) : row.marketGapDirection === "consensus_premium" ? (
                                 <span className="text-amber">Buy</span>
                               ) : (
-                                <span className="muted">\u2014</span>
+                                <span className="muted">—</span>
                               )}
                             </td>
                           )}
@@ -357,7 +357,7 @@ export default function FinderPage() {
                                 {c.label}
                               </span>
                             ))}
-                            {!action && cautions.length === 0 && <span className="muted">\u2014</span>}
+                            {!action && cautions.length === 0 && <span className="muted">—</span>}
                           </td>
                         </tr>
                       );

--- a/frontend/app/league/sections/awards.jsx
+++ b/frontend/app/league/sections/awards.jsx
@@ -9,8 +9,9 @@
 // next one is underway.
 
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { EmptyState, PlayerImage } from "@/components/ui";
-import { Avatar, Card, EmptyCard, LinkButton, renderAwardValue } from "../shared.jsx";
+import { Avatar, Card, EmptyCard, renderAwardValue } from "../shared.jsx";
 import { TradeCard } from "./activity.jsx";
 
 // Award keys whose ``value`` payload carries a player — render the
@@ -312,13 +313,9 @@ function AwardsSection({ managers, data, onNavigate }) {
                         {a.description}
                       </div>
                     )}
-                    {a.ownerId && (
-                      <div style={{ marginTop: 8 }} onClick={(e) => e.stopPropagation()}>
-                        <LinkButton onClick={() => onNavigate("franchise", { owner: a.ownerId })}>
-                          Franchise page →
-                        </LinkButton>
-                      </div>
-                    )}
+                    <div style={{ marginTop: 8, fontSize: "0.72rem", color: "var(--cyan)", fontWeight: 600 }}>
+                      Award history →
+                    </div>
                   </div>
                 );
               })}
@@ -327,17 +324,19 @@ function AwardsSection({ managers, data, onNavigate }) {
         </Card>
       )}
 
-      {openKey && openMeta && (
-        <AwardHistoryModal
-          awardKey={openKey}
-          label={openMeta.label}
-          description={openMeta.description}
-          history={openHistory}
-          managers={managers}
-          onNavigate={onNavigate}
-          onClose={() => setOpenKey(null)}
-        />
-      )}
+      {openKey && openMeta && typeof document !== "undefined" &&
+        createPortal(
+          <AwardHistoryModal
+            awardKey={openKey}
+            label={openMeta.label}
+            description={openMeta.description}
+            history={openHistory}
+            managers={managers}
+            onNavigate={onNavigate}
+            onClose={() => setOpenKey(null)}
+          />,
+          document.body,
+        )}
     </>
   );
 }

--- a/frontend/app/league/sections/franchise.jsx
+++ b/frontend/app/league/sections/franchise.jsx
@@ -138,6 +138,34 @@ function FranchiseSection({ managers, data, onNavigate, initialOwner, setOwner }
             </div>
           )}
 
+          <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10, marginBottom: 14 }}>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>
+              Awards won {(fr.awardsWon || []).length > 0 ? `(${(fr.awardsWon || []).reduce((n, a) => n + (a.count || a.seasons.length), 0)})` : ""}
+            </div>
+            {(fr.awardsWon || []).length === 0 ? (
+              <div style={{ fontSize: "0.74rem", color: "var(--subtext)" }}>No awards yet.</div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                {(fr.awardsWon || []).map((aw) => (
+                  <div
+                    key={aw.key}
+                    style={{ display: "flex", justifyContent: "space-between", gap: 10, fontSize: "0.78rem" }}
+                  >
+                    <span style={{ fontWeight: 600 }}>
+                      {aw.label}
+                      {aw.count > 1 && (
+                        <span style={{ color: "var(--subtext)", fontWeight: 400 }}> ×{aw.count}</span>
+                      )}
+                    </span>
+                    <span style={{ fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+                      {aw.seasons.join(", ")}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
           <div style={{ fontWeight: 600, marginBottom: 6 }}>Season results</div>
           <div className="table-wrap">
             <table>

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1325,7 +1325,7 @@ export default function RankingsPage() {
                       col={`src:${src.key}`}
                       style={{ textAlign: "right", width: 90 }}
                       className="hide-mobile rankings-source-col"
-                      title={`${src.displayName} — cell shows the source's 1\u20139,999 scale value (${
+                      title={`${src.displayName} — cell shows the source's 1–9,999 scale value (${
                         src.isRankSignal ? "Hill curve from this source's ordinal rank" : "linear rescale of this source's native trade value"
                       }) with its effective rank on the shared board in parentheses.`}
                     >
@@ -1466,7 +1466,7 @@ export default function RankingsPage() {
                                       rel="noopener noreferrer"
                                       onClick={(e) => e.stopPropagation()}
                                       className={`badge ${c.css} rankings-chip`}
-                                      title={`${c.title} \u2014 click to read`}
+                                      title={`${c.title} — click to read`}
                                       style={{ cursor: "pointer", textDecoration: "none" }}
                                     >
                                       {c.label}
@@ -1544,7 +1544,7 @@ export default function RankingsPage() {
                             "rookie cohort" so the user knows the value
                             is a draft-capital estimate, not realized
                             production. */}
-                        <td style={{ textAlign: "right" }} title={`Hill-curve value ${val.toLocaleString()} (scale 1\u20139,999) — click to see per-source breakdown`}>
+                        <td style={{ textAlign: "right" }} title={`Hill-curve value ${val.toLocaleString()} (scale 1–9,999) — click to see per-source breakdown`}>
                           <span
                             className="rankings-value rankings-value-clickable"
                             onClick={(e) => { e.stopPropagation(); openPlayerPopup?.(row); }}
@@ -1716,7 +1716,7 @@ export default function RankingsPage() {
                                 <span className="muted" style={{ marginLeft: 12 }}>
                                   {audit.reason === "fully_matched" ? "All expected sources matched" :
                                    audit.reason === "structurally_single_source" ? "Only one source structurally covers this player" :
-                                   audit.reason === "matching_failure_other_sources_eligible" ? "Matching failure \u2014 expected source(s) did not match" :
+                                   audit.reason === "matching_failure_other_sources_eligible" ? "Matching failure — expected source(s) did not match" :
                                    audit.reason === "partial_coverage" ? "Some expected sources missing" :
                                    audit.reason === "no_source_match" ? "No source matched" :
                                    audit.reason || ""}
@@ -1856,9 +1856,9 @@ export default function RankingsPage() {
                               <div className="source-audit-summary">
                                 <span><strong>Rank:</strong> {row.rank ? `#${row.rank}` : "\u2014 (unranked)"} (final ordinal — the engine's opinion)</span>
                                 <span><strong>Consensus:</strong> {row.blendedSourceRank?.toFixed(1) ?? "\u2014"} (mean of per-source effective ranks — orthogonal to Rank; gaps reveal blend arbitration)</span>
-                                <span><strong>Value:</strong> {val.toLocaleString()} (Hill curve, 1\u20139,999 scale)</span>
+                                <span><strong>Value:</strong> {val.toLocaleString()} (Hill curve, 1–9,999 scale)</span>
                                 <span><strong>Confidence:</strong> {confExplain}</span>
-                                <span><strong>Edge:</strong> {edge.label} \u2014 {edge.title}</span>
+                                <span><strong>Edge:</strong> {edge.label} — {edge.title}</span>
                                 {row.sourceRankSpread != null && (
                                   <span><strong>Source spread:</strong> {Math.round(row.sourceRankSpread)} ordinal ranks between the highest and lowest source</span>
                                 )}

--- a/src/public_league/franchise.py
+++ b/src/public_league/franchise.py
@@ -111,9 +111,49 @@ def _weekly_scoring_by_owner(
     return out
 
 
-def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+def _awards_won_by_owner(awards_section: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Map owner_id -> [{key, label, seasons:[...]}] across every season,
+    so each franchise page can list every award that manager has won and
+    the years they won it."""
+    by_owner: dict[str, dict[str, dict[str, Any]]] = {}
+    for season_row in awards_section.get("bySeason", []):
+        season = season_row.get("season")
+        for a in season_row.get("awards", []):
+            owner_id = a.get("ownerId")
+            if not owner_id:
+                continue  # team/pair awards (rivalry, top NFL team) have no owner
+            rec = by_owner.setdefault(owner_id, {})
+            slot = rec.setdefault(a["key"], {
+                "key": a["key"],
+                "label": a.get("label", a["key"]),
+                "seasons": [],
+            })
+            if season and season not in slot["seasons"]:
+                slot["seasons"].append(season)
+    out: dict[str, list[dict[str, Any]]] = {}
+    for owner_id, by_key in by_owner.items():
+        rows = list(by_key.values())
+        for r in rows:
+            r["seasons"].sort(reverse=True)
+            r["count"] = len(r["seasons"])
+        rows.sort(key=lambda r: (-r["count"], r["label"]))
+        out[owner_id] = rows
+    return out
+
+
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    awards_section: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     rivalries_section = build_rivalries(snapshot)
     trade_counts = _trade_waiver_counts(snapshot)
+    if awards_section is None:
+        # Section endpoint / tests call us with just the snapshot; the
+        # full-contract path passes the already-built awards section to
+        # avoid recomputing it.
+        from . import awards as _awards
+        awards_section = _awards.build_section(snapshot)
+    awards_by_owner = _awards_won_by_owner(awards_section)
 
     # Per-owner weekly scoring trajectory — finer-grained than the
     # season-aggregate ``seasonResults`` below and the proper signal
@@ -216,7 +256,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             "tradeCount": trade_counts.get(owner_id, {}).get("trades", 0),
             "waiverCount": trade_counts.get(owner_id, {}).get("waivers", 0),
             "draftCapital": capital,
-            "awardShelf": [],
+            "awardsWon": awards_by_owner.get(owner_id, []),
         }
         detail[owner_id] = fr
         index.append({

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -324,6 +324,13 @@ def build_section_payload(
         for key, builder in _SECTION_BUILDERS.items():
             if key == "activity":
                 sections[key] = _build_activity_section(snapshot, activity_valuation)
+            elif key == "franchise":
+                # awards is built earlier in the dict order; reuse it so
+                # franchise can list each manager's awards without a
+                # second (expensive) awards computation.
+                sections[key] = franchise.build_section(
+                    snapshot, awards_section=sections.get("awards")
+                )
             else:
                 sections[key] = builder(snapshot)
         section_body = _build_overview(snapshot, sections)

--- a/tests/public_league/test_metrics_engines.py
+++ b/tests/public_league/test_metrics_engines.py
@@ -182,7 +182,13 @@ class FranchiseTests(_BaseFixture):
         self.assertEqual(owner_b["cumulative"]["championships"], 2)
         self.assertEqual(owner_b["cumulative"]["wins"], 11 + 12)
         self.assertGreaterEqual(owner_b["tradeCount"], 1)
-        self.assertEqual(owner_b["awardShelf"], [])
+        # owner-B is the 2x champion → awardsWon lists champion w/ both years.
+        won = owner_b["awardsWon"]
+        self.assertIsInstance(won, list)
+        champ = next((w for w in won if w["key"] == "champion"), None)
+        self.assertIsNotNone(champ)
+        self.assertEqual(sorted(champ["seasons"]), ["2024", "2025"])
+        self.assertEqual(champ["count"], 2)
 
     def test_best_finish(self) -> None:
         section = franchise.build_section(self.snapshot)


### PR DESCRIPTION
## Summary
Fixes the issues reported on the live site after the awards rework:

- **Award history modal didn't open** — it was mounting but `position:fixed` was being clipped by the league tab's transformed/overflow ancestor. Now rendered via `createPortal` to `document.body` so it always overlays the viewport.
- **Per-award "Franchise page →" link removed**, replaced with an explicit **"Award history →"** affordance (the card opens the multi-season history).
- **Franchise pages now list every award the manager has won and the years** (`franchise.build_section` reuses the already-built awards section via `public_contract`; computes it standalone for the section endpoint / tests).
- **Literal `—` / `–` showing as text** on `/finder` and `/rankings` (JSX text nodes don't interpret `\uXXXX`) — now real `—` / `–`.

## Note on "removed a lot of awards"
The sparse board you saw was 2026's in-progress data being featured. #470 (merged) makes the last completed season (2025, full 26-award board led by Champion → Manager of the Year) the default until 2026 actually plays games. Only the awards explicitly requested for removal were removed (chaos agent, most active, pick hoarder, toilet bowl, runner-up, points black hole).

## Test plan
- [x] `tests/public_league/` — 312 passed (franchise awardsWon asserted: owner-B = 2x champion w/ 2024+2025)
- [x] `cd frontend && npm run build` — all bundles under budget
- [ ] CI green
- [ ] Post-deploy: /league Awards tab → click award shows history modal with past winners; franchise page lists awards+years; /finder & /rankings show real dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)