### PR TITLE
feat(picks): value picks 3 years out (adds 2029)

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -874,7 +874,7 @@ def fetch_sleeper_rosters(league_id):
     draft_rounds = _safe_int((league_settings or {}).get("draft_rounds")) or 4
     draft_rounds = max(1, min(6, draft_rounds))
     current_year = datetime.date.today().year
-    pick_years = [current_year, current_year + 1, current_year + 2]
+    pick_years = [current_year, current_year + 1, current_year + 2, current_year + 3]
 
     pick_owner = {}  # (season, round, original_roster_id) -> owner_roster_id
     # Canonical pick identity map so trade-history can reference the exact pick label
@@ -962,7 +962,8 @@ def fetch_sleeper_rosters(league_id):
     for (season, round_num, origin_rid), owner_rid in pick_owner.items():
         slot_num = draft_slot_by_origin.get((season, origin_rid))
         # Keep current-year picks as slot-specific when available.
-        # For future years (2027/2028), normalize to Early/Mid/Late buckets.
+        # For all future years (current+1 .. current+3), normalize to
+        # Early/Mid/Late buckets.
         if season >= current_year + 1:
             tier_label = _slot_to_tier_label(slot_num)
             base_label = f"{season} {tier_label} {round_num}{_round_suffix(round_num)}"
@@ -4522,7 +4523,7 @@ async def run(progress_callback=None):
         return out
 
     current_year = datetime.date.today().year
-    target_pick_years = [current_year, current_year + 1, current_year + 2]
+    target_pick_years = [current_year, current_year + 1, current_year + 2, current_year + 3]
     # Explicitly exclude non-pick sources from pick values.
     PICK_VALUE_EXCLUDED_SITES = {"draftSharks"}
     pick_anchors = {}


### PR DESCRIPTION
## Summary
Dynasty trades regularly include picks 3 years out, but `Dynasty Scraper.py` only generated/anchored future picks for `current_year .. current_year+2` — so **2029 picks (in 2026) never entered the valuation pipeline** and showed no value.

Extends both horizons to `current_year + 3`:
- Sleeper future-pick ownership generation (`pick_years`)
- Source pick-anchor target years (`target_pick_years`)

No downstream change needed: `config/weights/pick_year_discount.json` already lists `2029: 0.53` (and falls back exponentially beyond), `_pick_year_from_name` parses any year, and the pick-tethering/discount passes are year-agnostic. 2029 picks will tether to the rookie pool and apply the 0.53 multiplier like 2027/2028 do today.

Takes effect on the next scrape (every 2h via scheduled-refresh).

## Test plan
- [x] `python -m py_compile "Dynasty Scraper.py"` (deploy.yml syntax gate)
- [x] Traced pipeline: scraper horizon → `_parse_pick_label`/`_build_site_pick_map` → data_contract pick tether (Phase 11) → year discount (Phase 12, 2029=0.53) — only the scraper horizon gated it
- [ ] CI green
- [ ] Post next scrape: 2029 picks appear with values (~0.53× the rookie-pool equivalent), like 2027/2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)