### PR TITLE
feat(monitoring): backup-freshness watchdog (roadmap 1.2)

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -142,3 +142,47 @@ jobs:
               sys.exit(1)
           print("Served-board source coverage OK.")
           PY
+
+      - name: Check /api/status (backup freshness)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          URL="${{ vars.PROD_PUBLIC_URL }}"
+          URL="${URL%/}"
+          HTTP_CODE=$(curl --silent --show-error --output /tmp/status_bkp.json \
+            --write-out '%{http_code}' --max-time 20 "${URL}/api/status" || echo "000")
+          if [[ "${HTTP_CODE}" != "200" ]]; then
+            echo "::warning title=Status Unreachable::Backup check skipped (HTTP ${HTTP_CODE})."
+            exit 0
+          fi
+          python3 - <<'PY'
+          import json, sys
+          MAX_AGE_HOURS = 30   # nightly backup @ 02:00 UTC; >30h == missed a run
+          with open("/tmp/status_bkp.json") as f:
+              data = json.load(f)
+          bh = data.get("backup_health")
+          if not isinstance(bh, dict):
+              print("::error title=Backup health missing::/api/status has no "
+                    "backup_health block — cannot verify SQLite backups are "
+                    "running. Deploy may predate backup monitoring.")
+              sys.exit(1)
+          age = bh.get("newestBackupAgeHours")
+          if age is None:
+              print("::error title=No SQLite backups::No backup found in "
+                    "/var/backups/riskit or /home/dynasty/backups/riskit. "
+                    "deploy/backup_user_kv.sh / riskit-backup.timer is broken — "
+                    "user_kv, session_store and guest_passes are UNPROTECTED.")
+              sys.exit(1)
+          print(f"Newest backup: {age}h old (dir={bh.get('backupDirUsed')}, "
+                f"dbCount={bh.get('dbCount')})")
+          if age > MAX_AGE_HOURS:
+              print(f"::error title=Stale SQLite backups::Newest backup is "
+                    f"{age}h old (> {MAX_AGE_HOURS}h). The nightly backup has "
+                    f"not run — investigate riskit-backup.timer and "
+                    f"/var/log/riskit-backup.log.")
+              sys.exit(1)
+          if bh.get("dbCount", 0) < 3:
+              print(f"::warning title=Partial backup::Only {bh.get('dbCount')} "
+                    f"of 3 SQLite DBs in the latest backup set.")
+          print("SQLite backup freshness OK.")
+          PY

--- a/server.py
+++ b/server.py
@@ -1202,6 +1202,63 @@ def _per_source_freshness() -> dict[str, dict]:
     return out
 
 
+def _backup_freshness() -> dict:
+    """Age + location of the newest SQLite backup.
+
+    Mirrors deploy/backup_user_kv.sh: the primary dir ``/var/backups/
+    riskit`` needs root; the self-healing script falls back to
+    ``/home/dynasty/backups/riskit`` (owned by the service user).  This
+    surfaces ``newestBackupAgeHours`` so monitoring trips an alert
+    within a day of a silent backup failure — the exact gap that let
+    backups die unnoticed for ~2 weeks before the P0 fix.  Never raises;
+    returns null age when no backup is found.
+    """
+    result = {
+        "newestBackupAgeHours": None,
+        "newestBackupPath": None,
+        "backupDirUsed": "none",
+        "dbCount": 0,
+    }
+    try:
+        now_epoch = time.time()
+        newest_epoch: float | None = None
+        for label, d in (
+            ("primary", Path("/var/backups/riskit/daily")),
+            ("fallback", Path("/home/dynasty/backups/riskit/daily")),
+        ):
+            try:
+                files = list(d.glob("*.sqlite.gz"))
+            except OSError:
+                continue
+            for f in files:
+                try:
+                    mt = f.stat().st_mtime
+                except OSError:
+                    continue
+                if newest_epoch is None or mt > newest_epoch:
+                    newest_epoch = mt
+                    result["newestBackupPath"] = str(f)
+                    result["backupDirUsed"] = label
+        if newest_epoch is not None:
+            result["newestBackupAgeHours"] = round(
+                max(0.0, (now_epoch - newest_epoch) / 3600.0), 2
+            )
+            try:
+                newest = Path(result["newestBackupPath"])
+                parts = newest.name.split(".")
+                stamp = parts[1] if len(parts) >= 3 else ""
+                if stamp:
+                    result["dbCount"] = len({
+                        f.name.split(".")[0]
+                        for f in newest.parent.glob(f"*.{stamp}.sqlite.gz")
+                    })
+            except OSError:
+                pass
+    except Exception:  # noqa: BLE001 — monitoring helper must never raise
+        pass
+    return result
+
+
 
 
 # ── SCRAPER INTEGRATION ────────────────────────────────────────────────
@@ -3109,6 +3166,7 @@ async def get_status():
             "startup_payload_savings_gzip_bytes": max(0, full_gzip_bytes - startup_gzip_bytes),
         },
         "source_health": source_health,
+        "backup_health": _backup_freshness(),
         "uptime": uptime_status,
         "has_data": latest_contract_data is not None,
         "player_count": int((latest_contract_data or {}).get("playerCount") or 0),
@@ -3336,6 +3394,25 @@ async def get_health():
     circuits = _circuits_safe()
     # Any breaker in OPEN state flips overall status to degraded.
     any_breaker_open = any(c.get("state") == "open" for c in circuits)
+
+    # Backup-freshness watchdog.  Backups run nightly (riskit-backup
+    # .timer @ 02:00 UTC); anything older than 36h (or missing) means
+    # the backup pipeline is broken — the failure mode that went
+    # unnoticed for ~2 weeks.  send_alert is globally cooldown-rate-
+    # limited and no-ops when SMTP isn't configured.  Backup staleness
+    # does NOT flip the uptime status (the site is still serving).
+    backup_health = _backup_freshness()
+    _bage = backup_health.get("newestBackupAgeHours")
+    if _bage is None or _bage > 36:
+        send_alert(
+            "Risk It: SQLite backups stale",
+            f"Newest backup age: {_bage}h (dir={backup_health.get('backupDirUsed')}, "
+            f"path={backup_health.get('newestBackupPath')}, dbCount="
+            f"{backup_health.get('dbCount')}). Expected a fresh backup within 24h "
+            f"from riskit-backup.timer (02:00 UTC). Check "
+            f"deploy/backup_user_kv.sh and /var/log/riskit-backup.log.",
+        )
+
     return JSONResponse(
         status_code=200 if is_ok else 503,
         content={
@@ -3363,6 +3440,7 @@ async def get_health():
             "anyBreakerOpen": any_breaker_open,
             "startupChecks": _startup_checks_summary,
             "memberInMemorySessions": len(auth_sessions) if isinstance(auth_sessions, dict) else None,
+            "backup_health": backup_health,
         },
     )
 


### PR DESCRIPTION
## Summary
Roadmap step 1.2 — the reliability follow-on to the P0 backup fix (#468). The P0 outage ran unnoticed for ~2 weeks because **nothing monitored backup freshness**. This closes that gap.

- `server.py::_backup_freshness()` — newest `*.sqlite.gz` age across the primary (`/var/backups/riskit`) and self-healing fallback (`/home/dynasty/backups/riskit`) dirs; never raises.
- Surfaced as `backup_health` on **`/api/status`** (for CI) and **`/api/health`**.
- `/api/health` fires a cooldown-rate-limited `send_alert` when the newest backup is missing or >36h old. Backup staleness does **not** flip uptime status (the site is still serving).
- `health-check.yml`: new step asserts `backup_health` — `::error` (exit 1) if no backup or >30h; `::warning` if <3 of 3 DBs in the latest set. Mirrors the existing `served_source_coverage` assertion.

Dry-run against live prod state: `{newestBackupAgeHours: 1.52, backupDirUsed: "fallback", dbCount: 3}` — healthy.

## Test plan
- [x] `python -m py_compile server.py`
- [x] `_backup_freshness()` dry-run against real backup dirs → correct
- [x] health-check.yml step mirrors existing coverage-assert skeleton
- [ ] CI green
- [ ] Post-deploy: `curl /api/status | jq .backup_health` shows fresh age; next scheduled health-check.yml run asserts it

🤖 Generated with [Claude Code](https://claude.com/claude-code)