### PR TITLE
feat(ci): pre-commit scrape sanity gate (roadmap 1.4)

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -359,6 +359,22 @@ jobs:
             git push
           fi
 
+      - name: Validate scrape sanity (pre-commit gate)
+        # Roadmap 1.4: block a corrupted scrape (row count collapsed
+        # > 50% vs the prior commit, no numeric signal in any column,
+        # or below the source's registered min line count) from being
+        # committed/deployed.  Plain step → default ``if: success()``,
+        # so a non-zero exit fails the job and the success()-gated
+        # "Commit updated data" below is SKIPPED; the existing "Alert
+        # on workflow failure" step then opens a tracking issue.  A
+        # 30-50% drop is a non-fatal ::warning (exits 0, still ships).
+        # HEAD here is prior main (Persist freshness stamps already
+        # pulled), so ``git show HEAD:`` is the previous scrape.
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python scripts/validate_scrape_sanity.py
+
       - name: Commit updated data
         shell: bash
         run: |

--- a/scripts/validate_scrape_sanity.py
+++ b/scripts/validate_scrape_sanity.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Pre-commit scrape sanity gate (roadmap 1.4).
+
+Runs in scheduled-refresh.yml AFTER the scraper writes
+``CSVs/site_raw/*.csv`` and BEFORE "Commit updated data" (which is
+``success()``-gated, so a non-zero exit here blocks the bad data from
+being committed or deployed).
+
+Per source CSV, compared against the previously-committed version
+(``git show HEAD:<path>``):
+
+  * ERROR  — current row count < the source's registered minimum, OR
+             every value cell is empty/0/NaN, OR row count collapsed
+             > 50% vs the prior commit.
+  * WARN   — row count dropped 30-50% (non-fatal; surfaces but ships).
+
+Errors exit 1 (fails the step → commit/deploy skipped → the existing
+"Alert on workflow failure" opens a tracking issue).  Warnings exit 0.
+
+Conservative by design: the 50% / all-zero error bar plus the
+``COLLAPSE_EXEMPT`` allowlist keep legitimate refreshes (rank jitter,
+seasonal ROS emptiness) from blocking the pipeline.
+"""
+from __future__ import annotations
+
+import glob
+import subprocess
+import sys
+from pathlib import Path
+
+# Mirror scheduled-refresh.yml::stamp_if_present minimum line counts
+# (header + data rows == wc -l).  Sources not listed use DEFAULT_MIN.
+MIN_LINES: dict[str, int] = {
+    "ktc": 100,
+    "ktcSfTep": 100,
+    "idpTradeCalc": 50,
+    "dynastyNerdsSfTep": 50,
+    "fantasyProsSf": 50,
+    "fantasyProsIdp": 50,
+}
+DEFAULT_MIN = 10
+
+# Sources exempt from the row-collapse / all-zero / min-line checks.
+# ROS (rest-of-season) boards are legitimately empty in the offseason
+# and intentionally keep yesterday's CSV per source, so a "collapse"
+# there is expected, not a scraper failure.
+COLLAPSE_EXEMPT = {
+    "draftSharksRosSf",
+    "draftSharksRosIdp",
+}
+
+COLLAPSE_ERROR_RATIO = 0.50   # > 50% fewer rows than prior == error
+COLLAPSE_WARN_RATIO = 0.70    # 30-50% fewer rows == warning
+
+
+def _source_key(path: str) -> str:
+    return Path(path).stem
+
+
+def _data_rows(text: str) -> list[list[str]]:
+    """Return non-empty data rows (header dropped) as split columns."""
+    lines = [ln for ln in (text or "").splitlines() if ln.strip()]
+    if not lines:
+        return []
+    return [ln.split(",") for ln in lines[1:]]
+
+
+def _has_any_numeric_signal(text: str) -> bool:
+    """True if any data row has a nonzero number in any non-name column.
+
+    site_raw CSVs have heterogeneous schemas (``name,value``;
+    ``name,Rank,position,team``; multi-column rank exports), so we don't
+    guess THE value column — a healthy scraped row always carries at
+    least one numeric signal (a rank or a value).  Only a genuinely
+    broken scrape (rows present but every numeric field empty/0/NaN)
+    has none, which is exactly the corruption this guards against.
+    """
+    for row in _data_rows(text):
+        for cell in row[1:]:  # skip col 0 (name)
+            raw = cell.strip().replace("$", "").replace(",", "")
+            if not raw or raw.lower() in {"nan", "none", "null"}:
+                continue
+            try:
+                if float(raw) != 0.0:
+                    return True
+            except ValueError:
+                continue
+    return False
+
+
+def evaluate(name: str, cur_text: str | None, prev_text: str | None) -> tuple[str, str]:
+    """Pure decision function. Returns (level, message); level in
+    {"ok","warn","error"}.  ``cur_text`` None == file unreadable."""
+    if cur_text is None:
+        return "error", f"{name}: current CSV unreadable/missing — cannot validate"
+
+    cur_rows = len(_data_rows(cur_text))
+    min_lines = MIN_LINES.get(name, DEFAULT_MIN)
+    exempt = name in COLLAPSE_EXEMPT
+
+    if not exempt and (cur_rows + 1) < min_lines:
+        return (
+            "error",
+            f"{name}: {cur_rows} data rows (+header) < required {min_lines} lines",
+        )
+
+    if not exempt and cur_rows > 0 and not _has_any_numeric_signal(cur_text):
+        return "error", f"{name}: no numeric signal in any column ({cur_rows} rows)"
+
+    if not exempt and prev_text:
+        prev_rows = len(_data_rows(prev_text))
+        if prev_rows >= 10 and cur_rows < prev_rows:
+            ratio = cur_rows / prev_rows
+            if ratio < COLLAPSE_ERROR_RATIO:
+                return (
+                    "error",
+                    f"{name}: row count collapsed {prev_rows} -> {cur_rows} "
+                    f"({ratio:.0%} of prior, < {COLLAPSE_ERROR_RATIO:.0%})",
+                )
+            if ratio < COLLAPSE_WARN_RATIO:
+                return (
+                    "warn",
+                    f"{name}: row count dropped {prev_rows} -> {cur_rows} "
+                    f"({ratio:.0%} of prior)",
+                )
+    return "ok", f"{name}: {cur_rows} rows OK"
+
+
+def _git_show(path: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "show", f"HEAD:{path}"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout
+    except subprocess.CalledProcessError:
+        return None  # new file / not in HEAD — collapse check skipped
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    csvs = sorted(glob.glob(str(repo / "CSVs" / "site_raw" / "*.csv")))
+    if not csvs:
+        print("::error title=Scrape sanity::No CSVs/site_raw/*.csv found")
+        return 1
+
+    errors = 0
+    warnings = 0
+    for path in csvs:
+        name = _source_key(path)
+        rel = str(Path(path).relative_to(repo))
+        try:
+            cur = Path(path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            cur = None
+        prev = _git_show(rel)
+        level, msg = evaluate(name, cur, prev)
+        if level == "error":
+            errors += 1
+            print(f"::error title=Scrape sanity::{msg}")
+        elif level == "warn":
+            warnings += 1
+            print(f"::warning title=Scrape sanity::{msg}")
+        else:
+            print(msg)
+
+    print(f"\nScrape sanity: {len(csvs)} sources, {errors} error(s), "
+          f"{warnings} warning(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_validate_scrape_sanity.py
+++ b/tests/scripts/test_validate_scrape_sanity.py
@@ -1,0 +1,95 @@
+"""Unit tests for the pre-commit scrape sanity gate (roadmap 1.4).
+
+Exercises the pure ``evaluate()`` decision function — no git / IO.
+"""
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "validate_scrape_sanity",
+    Path(__file__).resolve().parents[2] / "scripts" / "validate_scrape_sanity.py",
+)
+vss = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(vss)
+
+
+def _csv(rows: list[str], header: str = "name,value") -> str:
+    return "\n".join([header, *rows]) + "\n"
+
+
+class EvaluateTests(unittest.TestCase):
+    def test_healthy_value_csv_ok(self) -> None:
+        cur = _csv([f"Player {i},{100 + i}" for i in range(200)])
+        prev = _csv([f"Player {i},{100 + i}" for i in range(205)])
+        level, _ = vss.evaluate("ktc", cur, prev)
+        self.assertEqual(level, "ok")
+
+    def test_rank_only_csv_ok(self) -> None:
+        # name,Rank,position,team — value column is NOT last; the
+        # any-numeric-signal check must still see the rank.
+        rows = [f"Player {i},{i + 1},QB,BUF" for i in range(120)]
+        cur = _csv(rows, header="name,Rank,position,team")
+        level, msg = vss.evaluate("fantasyProsSf", cur, None)
+        self.assertEqual(level, "ok", msg)
+
+    def test_below_min_lines_errors(self) -> None:
+        cur = _csv([f"P{i},{i+1}" for i in range(20)])  # 20 rows, ktc needs 100
+        level, msg = vss.evaluate("ktc", cur, None)
+        self.assertEqual(level, "error")
+        self.assertIn("required", msg)
+
+    def test_all_zero_no_signal_errors(self) -> None:
+        rows = [f"Player {i},0" for i in range(150)]
+        cur = _csv(rows)
+        level, msg = vss.evaluate("ktc", cur, None)
+        self.assertEqual(level, "error")
+        self.assertIn("no numeric signal", msg)
+
+    def test_empty_values_no_signal_errors(self) -> None:
+        rows = [f"Player {i},,," for i in range(60)]
+        cur = _csv(rows, header="name,a,b,c")
+        level, _ = vss.evaluate("dynastyNerdsSfTep", cur, None)
+        self.assertEqual(level, "error")
+
+    def test_row_collapse_over_50pct_errors(self) -> None:
+        prev = _csv([f"P{i},{i+1}" for i in range(400)])
+        cur = _csv([f"P{i},{i+1}" for i in range(150)])  # 37.5% of prior
+        level, msg = vss.evaluate("otcffbSf", cur, prev)
+        self.assertEqual(level, "error")
+        self.assertIn("collapsed", msg)
+
+    def test_row_drop_30_to_50pct_warns(self) -> None:
+        prev = _csv([f"P{i},{i+1}" for i in range(400)])
+        cur = _csv([f"P{i},{i+1}" for i in range(240)])  # 60% of prior
+        level, msg = vss.evaluate("otcffbSf", cur, prev)
+        self.assertEqual(level, "warn")
+        self.assertIn("dropped", msg)
+
+    def test_minor_drift_ok(self) -> None:
+        prev = _csv([f"P{i},{i+1}" for i in range(400)])
+        cur = _csv([f"P{i},{i+1}" for i in range(395)])
+        level, _ = vss.evaluate("otcffbSf", cur, prev)
+        self.assertEqual(level, "ok")
+
+    def test_exempt_source_skips_collapse(self) -> None:
+        prev = _csv([f"P{i},{i+1}" for i in range(900)])
+        cur = _csv([f"P{i},{i+1}" for i in range(5)])  # huge collapse
+        level, _ = vss.evaluate("draftSharksRosSf", cur, prev)
+        self.assertEqual(level, "ok")  # ROS is allowlisted
+
+    def test_unreadable_current_errors(self) -> None:
+        level, msg = vss.evaluate("ktc", None, None)
+        self.assertEqual(level, "error")
+        self.assertIn("unreadable", msg)
+
+    def test_new_file_no_prev_only_min_check(self) -> None:
+        cur = _csv([f"P{i},{i+1}" for i in range(120)])
+        level, _ = vss.evaluate("ktc", cur, None)
+        self.assertEqual(level, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Roadmap step 1.4. The scheduled-refresh pipeline could commit + deploy a corrupted scrape (existing guards are mostly post-commit + KTC-only). This adds a pre-commit gate.

- `scripts/validate_scrape_sanity.py`: per `CSVs/site_raw/*.csv` vs the prior commit (`git show HEAD:`):
  - **ERROR** (exit 1): row count collapsed >50%, no numeric signal in any column, or below the source's registered min line count (mirrors `stamp_if_present`).
  - **WARN** (exit 0, ships): 30-50% row drop.
  - ROS boards allowlisted (legitimately empty in the offseason).
- `scheduled-refresh.yml`: new step between "Persist freshness stamps" and "Commit updated data". The commit step is `success()`-gated, so a failing gate skips the commit/deploy and the existing "Alert on workflow failure" opens a tracking issue.
- Heterogeneous CSV schemas (`name,value` vs `name,Rank,position,team` vs multi-col) handled by an any-numeric-signal check rather than guessing a value column (caught a false-positive on the rank-based FantasyPros CSVs during testing).

## Test plan
- [x] 11 unit tests on the pure `evaluate()` (`tests/scripts/test_validate_scrape_sanity.py`)
- [x] Ran the gate against current live `CSVs/site_raw/` → 24 sources, 0 errors, 0 warnings (does not block legit refreshes)
- [x] `py_compile` clean
- [ ] CI green
- [ ] Next scheduled-refresh exercises the gate (workflow_dispatch dry-run if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)