### PR TITLE
feat(scraper): cached fallback for Sleeper outages (roadmap 1.5)

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -381,7 +381,7 @@ jobs:
           set -Eeuo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -f CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/ data/ros/ data/scrape_state/
+          git add -f CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/ data/ros/ data/scrape_state/ data/sleeper_last_good.json
           if git diff --cached --quiet; then
             echo "No data changes to commit"
           else

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -737,6 +737,56 @@ def compute_max(name_map):
     return max(vals) if vals else 1  # ← was 0, now 1
 
 
+_SLEEPER_CACHE_PATH = os.path.join(SCRIPT_DIR, "data", "sleeper_last_good.json")
+_SLEEPER_STAMP_PATH = os.path.join(
+    SCRIPT_DIR, "data", "scrape_state", "sleeper_last_success"
+)
+
+
+def _save_sleeper_snapshot(roster_data):
+    """Persist the last-good per-league Sleeper block (one league's
+    teams/trades/picks — small, NOT the multi-MB NFL player DB) so a
+    later Sleeper outage can still serve it.  Committed by
+    scheduled-refresh so it survives ephemeral CI runners.  Best-effort.
+    """
+    try:
+        os.makedirs(os.path.dirname(_SLEEPER_CACHE_PATH), exist_ok=True)
+        tmp = _SLEEPER_CACHE_PATH + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump({"savedAt": time.time(), "rosterData": roster_data}, f)
+        os.replace(tmp, _SLEEPER_CACHE_PATH)
+    except OSError as e:
+        print(f"  [Sleeper] snapshot save failed (non-fatal): {e}")
+
+
+def _stamp_sleeper_success():
+    """Stamp data/scrape_state/sleeper_last_success on a successful live
+    fetch so a prolonged Sleeper outage still trips the existing
+    freshness watchdog even though the scrape no longer hard-fails."""
+    try:
+        os.makedirs(os.path.dirname(_SLEEPER_STAMP_PATH), exist_ok=True)
+        with open(_SLEEPER_STAMP_PATH, "w", encoding="utf-8") as f:
+            f.write(str(time.time()))
+    except OSError as e:
+        print(f"  [Sleeper] success stamp failed (non-fatal): {e}")
+
+
+def _load_sleeper_snapshot():
+    """Return (roster_data, age_hours) from the last-good snapshot, or
+    (None, None) when absent/unreadable/empty."""
+    try:
+        with open(_SLEEPER_CACHE_PATH, "r", encoding="utf-8") as f:
+            snap = json.load(f)
+        rd = snap.get("rosterData")
+        if not isinstance(rd, dict) or not rd:
+            return None, None
+        saved = float(snap.get("savedAt") or 0)
+        age_h = max(0.0, (time.time() - saved) / 3600.0) if saved else None
+        return rd, age_h
+    except (OSError, ValueError, TypeError):
+        return None, None
+
+
 def fetch_sleeper_rosters(league_id):
     """Fetch all rostered player names from a Sleeper league.
     Returns (player_names_list, roster_data_for_json)."""
@@ -1400,11 +1450,41 @@ SLEEPER_ROSTER_DATA = {}
 SLEEPER_ALL_NFL = {}
 
 if SLEEPER_LEAGUE_ID:
-    SLEEPER_PLAYERS, SLEEPER_ROSTER_DATA = fetch_sleeper_rosters(SLEEPER_LEAGUE_ID)
-    if SLEEPER_PLAYERS:
-        print(f"  Sample: {SLEEPER_PLAYERS[:5]}")
+    try:
+        SLEEPER_PLAYERS, SLEEPER_ROSTER_DATA = fetch_sleeper_rosters(SLEEPER_LEAGUE_ID)
+    except Exception as e:  # defensive — it normally returns ([], {}) on failure
+        print(f"  [Sleeper] fetch raised: {e}")
+        SLEEPER_PLAYERS, SLEEPER_ROSTER_DATA = [], {}
+    if SLEEPER_ROSTER_DATA:
+        # Live fetch produced the per-league block: persist it as the
+        # last-good snapshot and stamp success so the freshness
+        # watchdog can see a future outage.
+        _save_sleeper_snapshot(SLEEPER_ROSTER_DATA)
+        _stamp_sleeper_success()
+        if SLEEPER_PLAYERS:
+            print(f"  Sample: {SLEEPER_PLAYERS[:5]}")
     else:
-        print("  [Sleeper] No players found — falling back to players.txt")
+        # Sleeper outage / empty result.  Keep the league `sleeper`
+        # block alive from the last-good committed snapshot instead of
+        # silently dropping it from the contract (rankings build
+        # regardless — they don't depend on the NFL-player DB).  Do
+        # NOT stamp success, so a prolonged outage trips the watchdog.
+        _cached_rd, _cache_age_h = _load_sleeper_snapshot()
+        if _cached_rd:
+            SLEEPER_ROSTER_DATA = _cached_rd
+            _age_txt = (
+                f"{_cache_age_h:.1f}h old" if _cache_age_h is not None
+                else "age unknown"
+            )
+            print(
+                "  [Sleeper] live fetch failed/empty — using cached "
+                f"snapshot ({_age_txt}); success NOT stamped"
+            )
+        else:
+            print(
+                "  [Sleeper] No players found and no cached snapshot — "
+                "falling back to players.txt"
+            )
 
 
 # PLAYERS list (for console table only)

--- a/tests/scripts/test_sleeper_fallback.py
+++ b/tests/scripts/test_sleeper_fallback.py
@@ -1,0 +1,90 @@
+"""Behavioral tests for the Sleeper cached-fallback helpers (roadmap 1.5).
+
+``Dynasty Scraper.py`` does import-time network work, so — like the
+rest of the suite — we do NOT import it.  Instead we ast-extract just
+the three pure filesystem helpers and exec them in isolation against a
+tmp dir.  This exercises the real shipped code path.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import time
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRAPER = _REPO / "Dynasty Scraper.py"
+_TARGETS = {"_save_sleeper_snapshot", "_load_sleeper_snapshot", "_stamp_sleeper_success"}
+
+
+def _load_helpers(cache_path: str, stamp_path: str) -> dict:
+    tree = ast.parse(_SCRAPER.read_text(encoding="utf-8"))
+    src_parts: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in _TARGETS:
+            src_parts.append(ast.get_source_segment(_SCRAPER.read_text(encoding="utf-8"), node))
+    assert len(src_parts) == len(_TARGETS), f"missing helpers: found {len(src_parts)}"
+    ns: dict = {"os": os, "json": json, "time": time}
+    exec(compile("\n\n".join(src_parts), "<sleeper_helpers>", "exec"), ns)
+    # Helpers read these module globals at call time.
+    ns["_SLEEPER_CACHE_PATH"] = cache_path
+    ns["_SLEEPER_STAMP_PATH"] = stamp_path
+    return ns
+
+
+class SleeperFallbackHelperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+        self.tmp = tempfile.mkdtemp()
+        self.cache = os.path.join(self.tmp, "data", "sleeper_last_good.json")
+        self.stamp = os.path.join(self.tmp, "data", "scrape_state", "sleeper_last_success")
+        self.h = _load_helpers(self.cache, self.stamp)
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_save_then_load_roundtrip(self) -> None:
+        rd = {"leagueId": "L1", "teams": [{"id": 1}], "trades": [{"tx": "a"}]}
+        self.h["_save_sleeper_snapshot"](rd)
+        loaded, age = self.h["_load_sleeper_snapshot"]()
+        self.assertEqual(loaded, rd)
+        self.assertIsNotNone(age)
+        self.assertLess(age, 1.0)  # just saved → < 1h old
+
+    def test_load_missing_returns_none(self) -> None:
+        loaded, age = self.h["_load_sleeper_snapshot"]()
+        self.assertIsNone(loaded)
+        self.assertIsNone(age)
+
+    def test_load_corrupt_returns_none(self) -> None:
+        os.makedirs(os.path.dirname(self.cache), exist_ok=True)
+        with open(self.cache, "w") as f:
+            f.write("{ not json")
+        self.assertEqual(self.h["_load_sleeper_snapshot"](), (None, None))
+
+    def test_load_empty_rosterdata_returns_none(self) -> None:
+        os.makedirs(os.path.dirname(self.cache), exist_ok=True)
+        with open(self.cache, "w") as f:
+            json.dump({"savedAt": time.time(), "rosterData": {}}, f)
+        self.assertEqual(self.h["_load_sleeper_snapshot"](), (None, None))
+
+    def test_stamp_writes_epoch(self) -> None:
+        self.h["_stamp_sleeper_success"]()
+        self.assertTrue(os.path.exists(self.stamp))
+        val = float(Path(self.stamp).read_text().strip())
+        self.assertLess(abs(time.time() - val), 5.0)
+
+    def test_save_is_best_effort_no_raise(self) -> None:
+        # Point the cache at an unwritable location → must not raise.
+        bad = _load_helpers("/proc/cannot/write/here.json", self.stamp)
+        try:
+            bad["_save_sleeper_snapshot"]({"a": 1})  # should swallow OSError
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"_save_sleeper_snapshot must be best-effort, raised {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Final Phase-1 reliability item. A Sleeper API outage made `fetch_sleeper_rosters()` return `([], {})`, which **silently dropped the entire `sleeper` block** (teams, trades, draft capital, rosters) from the live contract — league/trade/roster features broke with nothing alerting (same silent-failure class as the P0).

- On a **successful** live fetch: persist the small per-league `SLEEPER_ROSTER_DATA` to `data/sleeper_last_good.json` (added to the scheduled-refresh commit set so it survives ephemeral CI runners) and stamp `data/scrape_state/sleeper_last_success`.
- On **outage/empty**: restore the league block from that snapshot instead of dropping it, and **do not** stamp success — so a prolonged outage still trips the existing `_per_source_freshness` watchdog (1.2). The multi-MB NFL player DB is intentionally **not** cached (rankings don't depend on it; current behavior unchanged there).
- Localized: module-level call site + 3 best-effort filesystem helpers. `fetch_sleeper_rosters` internals untouched; fallback dormant unless Sleeper fails.

## Test plan
- [x] `py_compile "Dynasty Scraper.py"` (deploy.yml syntax gate)
- [x] 6 isolated helper tests — save/load roundtrip, age, missing, corrupt, empty, stamp, best-effort-no-raise (scraper not imported, per suite convention)
- [x] 1.4 sanity-gate tests still green (17 total)
- [ ] CI green
- [ ] Next scrape: confirm `data/sleeper_last_good.json` written + `sleeper_last_success` stamped; the cached path is exercised only on a real outage

🤖 Generated with [Claude Code](https://claude.com/claude-code)