### PR TITLE
feat(watchlist): rankings star toggle + settings manage list (Phase 2)

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -6,6 +6,7 @@ import { resolvedRank, RANKING_SOURCES, getRetailLabel, siteOverridesAreCustomiz
 import { useSettings } from "@/components/useSettings";
 import { useApp } from "@/components/AppShell";
 import { useTeam } from "@/components/useTeam";
+import { useUserState } from "@/components/useUserState";
 import {
   tierLabel,
   effectiveTierId,
@@ -481,6 +482,15 @@ export default function RankingsPage() {
   // don't surface it here.  ``useTeam`` reads the flag off the
   // registry's league config via ``useLeague``.
   const { idpEnabled, selectedLeagueKey } = useTeam();
+  const {
+    state: userState,
+    toggleWatchlist,
+    serverBacked: watchlistServerBacked,
+  } = useUserState();
+  const watchlistLower = useMemo(
+    () => new Set((userState?.watchlist || []).map((n) => String(n).toLowerCase())),
+    [userState?.watchlist],
+  );
   // Pull recent news so we can stamp a "📰" chip on rows whose
   // player has fresh news / injury status.  Looks up by lowercase
   // name in O(1).  News data is single-flighted at module level so
@@ -1442,6 +1452,36 @@ export default function RankingsPage() {
                             >
                               {row.name}
                             </span>
+                            {(() => {
+                              const onWatch = watchlistLower.has(
+                                String(row.name || "").toLowerCase()
+                              );
+                              return (
+                                <button
+                                  type="button"
+                                  className={`button-reset rankings-watch-star${onWatch ? " is-active" : ""}`}
+                                  aria-pressed={onWatch}
+                                  title={
+                                    onWatch
+                                      ? `Remove from watchlist${watchlistServerBacked ? " (synced)" : ""}`
+                                      : `Add to watchlist${watchlistServerBacked ? " (synced)" : " (local)"}`
+                                  }
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    toggleWatchlist(row.name);
+                                  }}
+                                  style={{
+                                    cursor: "pointer",
+                                    color: onWatch ? "var(--cyan)" : "var(--subtext)",
+                                    fontSize: "0.95rem",
+                                    lineHeight: 1,
+                                    padding: "0 4px",
+                                  }}
+                                >
+                                  {onWatch ? "★" : "☆"}
+                                </button>
+                              );
+                            })()}
                             {(row.team || row.age) && (
                               <span className="rankings-player-meta">
                                 {[row.team, row.age].filter(Boolean).join(" · ")}

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -72,7 +72,8 @@ function ToggleRow({ label, checked, onChange, hint }) {
 export default function SettingsPage() {
   const { loading, error, rows, rawData } = useDynastyData();
   const { settings, update, updateSiteWeight, resetSiteWeights, reset } = useSettings();
-  const { state: userState, serverBacked, setNotifications } = useUserState();
+  const { state: userState, serverBacked, setNotifications, toggleWatchlist } = useUserState();
+  const [watchAddName, setWatchAddName] = useState("");
   const [hydrated, setHydrated] = useState(true);
   const [emailDraft, setEmailDraft] = useState("");
   const [emailStatus, setEmailStatus] = useState("");
@@ -623,6 +624,84 @@ export default function SettingsPage() {
             Sign in to enable email notifications.  Your notification preferences
             are stored on the server and apply across devices.
           </p>
+        )}
+      </Section>
+
+      <Section title="Watchlist" defaultOpen={false}>
+        <div style={{ fontSize: "0.78rem", color: "var(--subtext)", marginBottom: 8 }}>
+          Players you star (here or via the ☆ on Rankings / a player card).
+          {serverBacked ? " Synced across your devices." : " Saved on this device."}
+        </div>
+        <div style={{ display: "flex", gap: 6, marginBottom: 10, flexWrap: "wrap" }}>
+          <input
+            className="input"
+            value={watchAddName}
+            placeholder="Add player by name"
+            list="brisket-watchlist-player-list"
+            onChange={(e) => setWatchAddName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && watchAddName.trim()) {
+                toggleWatchlist(watchAddName.trim());
+                setWatchAddName("");
+              }
+            }}
+            style={{ flex: "1 1 220px", minWidth: 180, fontSize: "0.8rem" }}
+          />
+          <datalist id="brisket-watchlist-player-list">
+            {(rows || [])
+              .map((p) => p?.name || p?.displayName)
+              .filter((n) => typeof n === "string" && n.length > 0)
+              .slice(0, 800)
+              .map((n) => (
+                <option key={n} value={n} />
+              ))}
+          </datalist>
+          <button
+            type="button"
+            className="button"
+            disabled={!watchAddName.trim()}
+            onClick={() => {
+              if (watchAddName.trim()) {
+                toggleWatchlist(watchAddName.trim());
+                setWatchAddName("");
+              }
+            }}
+          >
+            Add
+          </button>
+        </div>
+        {(userState?.watchlist || []).length === 0 ? (
+          <div style={{ fontSize: "0.78rem", color: "var(--subtext)" }}>
+            No players on your watchlist yet.
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            {(userState.watchlist || []).map((name) => (
+              <div
+                key={name}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  gap: 10,
+                  fontSize: "0.82rem",
+                  borderBottom: "1px solid var(--border)",
+                  padding: "4px 0",
+                }}
+              >
+                <span>{name}</span>
+                <button
+                  type="button"
+                  className="button-reset"
+                  title="Remove from watchlist"
+                  onClick={() => toggleWatchlist(name)}
+                  style={{ cursor: "pointer", color: "var(--subtext)", padding: "0 6px" }}
+                >
+                  ☆ remove
+                </button>
+              </div>
+            ))}
+          </div>
         )}
       </Section>
 


### PR DESCRIPTION
## Summary
Roadmap Phase 2.

- **2.1 Custom alerts** — verified already wired (`settings/page.jsx` renders `CustomAlertsConfigurator`; backend `GET/PUT/run` routes exist). No change.
- **2.2** — ⭐/☆ watchlist toggle on every `/rankings` player row, reusing the existing `PlayerPopup` pattern (`useUserState.toggleWatchlist`, case-insensitive match, `serverBacked`-aware tooltip, `stopPropagation` so it doesn't expand the row). No backend change — `PUT /api/user/state` already validates `watchlist`.
- **2.3** — new "Watchlist" `Section` in `/settings` (next to Custom alerts): add-by-name with datalist autocomplete from `rows`, per-entry remove, backed by the same `toggleWatchlist`. Reuses the in-file `Section`.

Watchlist data shape unchanged (string array of player names) so the existing terminal `WatchlistPanel` consumer stays consistent.

## Test plan
- [x] `cd frontend && npm run build` — all bundles under budget
- [ ] CI green
- [ ] Post-deploy: star a player on /rankings → persists, shows in terminal Watchlist + /settings list; remove from /settings → unstars on /rankings

🤖 Generated with [Claude Code](https://claude.com/claude-code)