### PR TITLE
feat(trade): KTC-URL + CSV/JSON export (Phase 3)

### DIFF
--- a/frontend/__tests__/trade-export.test.js
+++ b/frontend/__tests__/trade-export.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { tradeWorkspaceToCSV, tradeWorkspaceToJSON } from "../lib/trade-logic.js";
+
+const sides = [
+  { label: "A", assets: [{ name: "Josh Allen", pos: "QB", team: "BUF", values: { full: 8000, raw: 7900 } }], destinations: {} },
+  { label: "B", assets: [{ name: "Bijan, Jr.", pos: "RB", team: "ATL", values: { full: 7000 } }], destinations: {} },
+];
+
+describe("tradeWorkspaceToCSV", () => {
+  it("emits header + a row per asset with the right value mode", () => {
+    const csv = tradeWorkspaceToCSV(sides, "full");
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe("Side,Asset,Position,Team,Value");
+    expect(lines[1]).toBe("A,Josh Allen,QB,BUF,8000");
+    // comma in name must be quoted
+    expect(lines[2]).toBe('B,"Bijan, Jr.",RB,ATL,7000');
+  });
+  it("raw mode falls back to full when raw missing", () => {
+    const csv = tradeWorkspaceToCSV(sides, "raw");
+    expect(csv).toContain("A,Josh Allen,QB,BUF,7900");
+    expect(csv).toContain('"Bijan, Jr.",RB,ATL,7000');
+  });
+});
+
+describe("tradeWorkspaceToJSON", () => {
+  it("is the canonical workspace payload, pretty-printed", () => {
+    const obj = JSON.parse(tradeWorkspaceToJSON(sides, "full", 0));
+    expect(obj.version).toBe(2);
+    expect(obj.valueMode).toBe("full");
+    expect(obj.sides[0].assets).toEqual(["Josh Allen"]);
+  });
+});

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -28,6 +28,8 @@ import {
   multiTeamAnalysis,
   createSide,
   serializeWorkspaceMulti,
+  tradeWorkspaceToCSV,
+  tradeWorkspaceToJSON,
   deserializeWorkspaceMulti,
   valueAdjustmentFromSideArrays,
   defaultDestination,
@@ -390,6 +392,7 @@ export default function TradePage() {
   const [ktcImportBusy, setKtcImportBusy] = useState(false);
   const [ktcImportError, setKtcImportError] = useState("");
   const [ktcImportStatus, setKtcImportStatus] = useState("");
+  const [exportStatus, setExportStatus] = useState("");
 
   // Share + simulator state.
   const [shareStatus, setShareStatus] = useState("");
@@ -1180,6 +1183,49 @@ export default function TradePage() {
     }
   }, [ktcImportUrl, rowByName]);
 
+  const exportKtcUrl = useCallback(async () => {
+    setExportStatus("");
+    const sideOne = (sides[0]?.assets || []).map((r) => r.name);
+    const sideTwo = (sides[1]?.assets || []).map((r) => r.name);
+    if (!sideOne.length && !sideTwo.length) { setExportStatus("Nothing to export."); return; }
+    try {
+      const res = await fetch("/api/trade/export-ktc", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sideOne, sideTwo }),
+        cache: "no-store",
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) { setExportStatus(data?.error || "KTC export failed."); return; }
+      try { await navigator.clipboard.writeText(data.url); } catch { /* clipboard blocked */ }
+      const miss = [...(data.unresolved?.sideOne || []), ...(data.unresolved?.sideTwo || [])];
+      setExportStatus("KTC URL copied" + (miss.length ? ` \u2014 unmatched: ${miss.join(", ")}` : ""));
+    } catch (e) {
+      setExportStatus("KTC export failed: " + (e?.message || e));
+    }
+  }, [sides]);
+
+  const _downloadFile = useCallback((filename, text, mime) => {
+    const blob = new Blob([text], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const el = document.createElement("a");
+    el.href = url; el.download = filename;
+    document.body.appendChild(el); el.click(); el.remove();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const exportCsv = useCallback(() => {
+    const iso = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
+    _downloadFile(`trade-${iso}.csv`, tradeWorkspaceToCSV(sides, valueMode), "text/csv");
+    setExportStatus("CSV downloaded.");
+  }, [sides, valueMode, _downloadFile]);
+
+  const exportJson = useCallback(() => {
+    const iso = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
+    _downloadFile(`trade-${iso}.json`, tradeWorkspaceToJSON(sides, valueMode, activeSide), "application/json");
+    setExportStatus("JSON downloaded.");
+  }, [sides, valueMode, activeSide, _downloadFile]);
+
   // ── Share-URL + simulator actions ─────────────────────────────────
   // Build a share-URL from the current trade and copy to clipboard.
   // Falls back to selecting the URL in a prompt when the clipboard
@@ -1554,6 +1600,36 @@ export default function TradePage() {
             >
               🔗 Copy Share Link
             </button>
+            <button
+              className="button"
+              onClick={exportKtcUrl}
+              disabled={sides.length !== 2 || !sides.some((s) => (s.assets || []).length > 0)}
+              style={{ borderColor: "var(--cyan)", color: "var(--cyan)" }}
+              title="Copy a KeepTradeCut trade-calculator URL for sides A + B"
+            >
+              ↗ Copy KTC URL
+            </button>
+            <button
+              className="button"
+              onClick={exportCsv}
+              disabled={!sides.some((s) => (s.assets || []).length > 0)}
+              title="Download this trade as CSV"
+            >
+              ⬇ CSV
+            </button>
+            <button
+              className="button"
+              onClick={exportJson}
+              disabled={!sides.some((s) => (s.assets || []).length > 0)}
+              title="Download this trade as JSON"
+            >
+              ⬇ JSON
+            </button>
+            {exportStatus && (
+              <span className="muted" style={{ fontSize: "0.72rem", flexBasis: "100%", color: "var(--cyan)" }}>
+                {exportStatus}
+              </span>
+            )}
             {sides.length === 2 && selectedTeam && (
               <button
                 className="button"

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -1433,6 +1433,29 @@ export function serializeWorkspaceMulti(sides, valueMode, activeSide) {
   };
 }
 
+export function tradeWorkspaceToJSON(sides, valueMode, activeSide) {
+  return JSON.stringify(serializeWorkspaceMulti(sides, valueMode, activeSide), null, 2);
+}
+
+export function tradeWorkspaceToCSV(sides, valueMode = "full") {
+  const esc = (v) => {
+    const s = v == null ? "" : String(v);
+    return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const pickVal = (r) => {
+    const vals = (r && r.values) || {};
+    const v = valueMode === "raw" ? (vals.raw ?? vals.full) : (vals.full ?? vals.raw);
+    return v == null ? "" : Math.round(Number(v));
+  };
+  const lines = ["Side,Asset,Position,Team,Value"];
+  for (const s of sides || []) {
+    for (const r of s.assets || []) {
+      lines.push([s.label, r.name, r.pos || "", r.team || "", pickVal(r)].map(esc).join(","));
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
 export function deserializeWorkspace(parsed, rowByName) {
   if (!parsed || typeof parsed !== "object") return null;
   const valueMode = VALUE_MODES.some((m) => m.key === parsed.valueMode) ? parsed.valueMode : "full";

--- a/server.py
+++ b/server.py
@@ -4147,6 +4147,44 @@ async def post_trade_import_ktc(request: Request):
     return JSONResponse(content={"ok": True, **result})
 
 
+@app.post("/api/trade/export-ktc")
+async def post_trade_export_ktc(request: Request):
+    """Inverse of import-ktc: the two local sides -> a KTC URL.
+
+    Body ``{"sideOne": ["Josh Allen", ...], "sideTwo": ["2026 Mid 1st", ...]}``.
+    Returns ``{ok, url, unresolved:{sideOne,sideTwo}, resolvedCount}``.
+    Reuses the cached KTC player map.  Public, like other /api/trade/*.
+    """
+    from src.trade.ktc_import import build_ktc_url  # noqa: PLC0415
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"ok": False, "error": "JSON body required."})
+
+    def _names(key):
+        raw = body.get(key)
+        if not isinstance(raw, list):
+            return []
+        return [str(x).strip() for x in raw if str(x or "").strip()]
+
+    side_one, side_two = _names("sideOne"), _names("sideTwo")
+    if not side_one and not side_two:
+        return JSONResponse(status_code=400, content={"ok": False, "error": "No assets to export."})
+
+    try:
+        result = await run_in_threadpool(build_ktc_url, side_one, side_two)
+    except Exception as exc:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502,
+            content={"ok": False, "error": "Failed to fetch KTC player map.",
+                     "detail": f"{type(exc).__name__}: {exc}"},
+        )
+    return JSONResponse(content={"ok": True, **result})
+
+
 @app.post("/api/angle/find")
 async def post_angle_find(request: Request):
     """Player-specific arbitrage: pick a player on your team, get

--- a/src/trade/ktc_import.py
+++ b/src/trade/ktc_import.py
@@ -280,3 +280,63 @@ def resolve_trade_url(url: str) -> dict[str, Any]:
         "sideTwo": two_resolved,
         "unresolved": {"sideOne": one_unresolved, "sideTwo": two_unresolved},
     }
+
+
+# ── Inverse: canonical names → KTC trade URL ──────────────────────
+_SUFFIX_RE = re.compile(r"\s+(jr|sr|ii|iii|iv|v)$", re.IGNORECASE)
+
+
+def _norm_name(s: str) -> str:
+    """Mirror the import resolver's normalization ladder so export
+    matches the same way import does."""
+    out = str(s or "").lower()
+    out = re.sub(r"[.']", "", out)
+    out = re.sub(r"\s+", " ", out).strip()
+    out = _SUFFIX_RE.sub("", out).strip()
+    return out
+
+
+def build_ktc_url(side_one_names, side_two_names, *, player_map=None):
+    """Inverse of resolve_trade_url: canonical names -> a KTC
+    trade-calculator URL.  Reuses the cached player map + the same
+    exact -> case-insensitive -> normalized ladder import uses.
+    Unmatched names returned in ``unresolved`` (honest, no silent drop).
+    """
+    if player_map is None:
+        player_map = get_ktc_player_map()
+    by_exact, by_lower, by_norm = {}, {}, {}
+    for pid, entry in player_map.items():
+        nm = entry.get("name") or ""
+        if not nm:
+            continue
+        by_exact.setdefault(nm, int(pid))
+        by_lower.setdefault(nm.lower(), int(pid))
+        by_norm.setdefault(_norm_name(nm), int(pid))
+
+    def _resolve(names):
+        ids, missing = [], []
+        for raw in names or []:
+            nm = str(raw or "").strip()
+            if not nm:
+                continue
+            pid = by_exact.get(nm) or by_lower.get(nm.lower()) or by_norm.get(_norm_name(nm))
+            if pid is None:
+                missing.append(nm)
+            else:
+                ids.append(int(pid))
+        return ids, missing
+
+    one_ids, one_missing = _resolve(side_one_names)
+    two_ids, two_missing = _resolve(side_two_names)
+    params = {
+        "var": "5", "pickVal": "0",
+        "teamOne": "|".join(str(i) for i in one_ids),
+        "teamTwo": "|".join(str(i) for i in two_ids),
+        "format": "2", "isStartup": "0", "tep": "0",
+    }
+    url = _KTC_CALCULATOR_URL + "?" + urllib.parse.urlencode(params, safe="|")
+    return {
+        "url": url,
+        "unresolved": {"sideOne": one_missing, "sideTwo": two_missing},
+        "resolvedCount": {"sideOne": len(one_ids), "sideTwo": len(two_ids)},
+    }

--- a/tests/trade/test_ktc_export.py
+++ b/tests/trade/test_ktc_export.py
@@ -1,0 +1,45 @@
+"""Tests for build_ktc_url (Phase 3) — inverse of resolve_trade_url."""
+from __future__ import annotations
+
+import unittest
+
+from src.trade import ktc_import
+
+
+_MAP = {
+    1001: {"name": "Josh Allen", "position": "QB", "team": "BUF", "slug": "josh-allen", "rookie": False},
+    1002: {"name": "Bijan Robinson", "position": "RB", "team": "ATL", "slug": "bijan", "rookie": False},
+    1003: {"name": "2026 Mid 1st", "position": "RDP", "team": "", "slug": "", "rookie": False},
+}
+
+
+class BuildKtcUrlTests(unittest.TestCase):
+    def test_resolves_and_builds_url(self) -> None:
+        out = ktc_import.build_ktc_url(["Josh Allen"], ["Bijan Robinson", "2026 Mid 1st"], player_map=_MAP)
+        self.assertIn("keeptradecut.com/trade-calculator", out["url"])
+        self.assertIn("teamOne=1001", out["url"])
+        self.assertIn("teamTwo=1002|1003", out["url"])
+        self.assertEqual(out["unresolved"], {"sideOne": [], "sideTwo": []})
+        self.assertEqual(out["resolvedCount"], {"sideOne": 1, "sideTwo": 2})
+
+    def test_normalized_and_case_insensitive_match(self) -> None:
+        out = ktc_import.build_ktc_url(["josh allen"], ["BIJAN ROBINSON"], player_map=_MAP)
+        self.assertIn("teamOne=1001", out["url"])
+        self.assertIn("teamTwo=1002", out["url"])
+
+    def test_unknown_names_surfaced_not_dropped(self) -> None:
+        out = ktc_import.build_ktc_url(["Nobody McGhost"], [], player_map=_MAP)
+        self.assertEqual(out["unresolved"]["sideOne"], ["Nobody McGhost"])
+        self.assertEqual(out["resolvedCount"]["sideOne"], 0)
+
+    def test_round_trip_through_parse_and_resolve(self) -> None:
+        built = ktc_import.build_ktc_url(["Josh Allen"], ["Bijan Robinson"], player_map=_MAP)
+        one, two = ktc_import.parse_trade_url(built["url"])
+        r1, _ = ktc_import.resolve_ktc_ids(one, player_map=_MAP)
+        r2, _ = ktc_import.resolve_ktc_ids(two, player_map=_MAP)
+        self.assertEqual([r["name"] for r in r1], ["Josh Allen"])
+        self.assertEqual([r["name"] for r in r2], ["Bijan Robinson"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Roadmap Phase 3 — export improvements.

- **Copy KTC URL**: `build_ktc_url()` in `src/trade/ktc_import.py` inverts `resolve_trade_url` — canonical names → a keeptradecut.com trade-calculator URL, reusing the cached KTC player map and the same exact → case-insensitive → normalized resolution ladder the import uses. `POST /api/trade/export-ktc` next to import-ktc. Unmatched names returned in `unresolved` (surfaced in UI, never silently dropped). Round-trips through `parse_trade_url`/`resolve_ktc_ids`.
- **CSV / JSON export**: pure `tradeWorkspaceToCSV` / `tradeWorkspaceToJSON` in `trade-logic.js` (co-located with `serializeWorkspaceMulti`, no new deps). Client-side Blob download.
- Trade controls bar gets "↗ Copy KTC URL" (gated to 2-side trades, since KTC is 2-team), "⬇ CSV", "⬇ JSON" with inline status reusing the existing muted-text pattern.

## Test plan
- [x] `tests/trade/test_ktc_export.py` — 4 tests (resolve/build, normalized+case-insensitive, unmatched surfaced, round-trip via parse+resolve)
- [x] `frontend/__tests__/trade-export.test.js` — 3 tests (CSV header/rows/quoting, raw-mode fallback, JSON canonical shape)
- [x] `cd frontend && npm run build` — all bundles under budget
- [x] `py_compile` clean (ktc_import.py, server.py)
- [ ] CI green
- [ ] Post-deploy: build a 2-side trade → Copy KTC URL → paste into KTC import round-trips; CSV/JSON download correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)