### PR TITLE
feat(api): reject oversized request bodies (roadmap 4.1)

### DIFF
--- a/server.py
+++ b/server.py
@@ -2038,6 +2038,39 @@ async def _count_requests(request: Request, call_next):
     return await call_next(request)
 
 
+# Roadmap 4.1: reject oversized request bodies before a handler buffers
+# them (memory-exhaustion guard on the POST endpoints: trade / angle /
+# rankings-overrides / custom-alerts / user-state / export-ktc).
+# Generous default so no legitimate payload is ever 413'd; tunable
+# without a redeploy via MAX_REQUEST_BYTES.  Only the declared
+# Content-Length is checked (covers normal clients; no body buffering
+# is added here).
+try:
+    _MAX_REQUEST_BYTES = int(os.environ.get("MAX_REQUEST_BYTES") or 2_097_152)
+except (TypeError, ValueError):
+    _MAX_REQUEST_BYTES = 2_097_152
+
+
+@app.middleware("http")
+async def _limit_request_size(request: Request, call_next):
+    if request.method in ("POST", "PUT", "PATCH"):
+        cl = request.headers.get("content-length")
+        if cl is not None:
+            try:
+                if int(cl) > _MAX_REQUEST_BYTES:
+                    return JSONResponse(
+                        status_code=413,
+                        content={
+                            "ok": False,
+                            "error": "Request body too large.",
+                            "maxBytes": _MAX_REQUEST_BYTES,
+                        },
+                    )
+            except (TypeError, ValueError):
+                pass
+    return await call_next(request)
+
+
 # Paths under /api/* that do NOT require an authenticated session.
 # Anything else gets 401'd by ``_private_api_gate`` below.  Closes
 # the scrape risk: without this gate, ``curl /api/data`` from a


### PR DESCRIPTION
## Summary
Roadmap Phase 4.1 — the last roadmap code change.

A `@app.middleware("http")` Content-Length guard (next to the metrics middleware) returns **413** for `POST/PUT/PATCH` bodies over `MAX_REQUEST_BYTES`. Default **2 MB** (generous — no real trade/roster/override/custom-alert payload approaches that), env-tunable without a redeploy. Only the declared Content-Length is inspected — no body buffering is introduced, so the guard itself can't add memory pressure.

**4.2 (error boundaries)** was found already satisfied by the Next.js App Router global boundary at `frontend/app/error.jsx` (covers every route, recoverable UI) — no redundant component added (same outcome as roadmap 1.3's verification).

## Test plan
- [x] `python -m py_compile server.py`
- [ ] CI green
- [ ] Post-deploy: normal POSTs (trade suggestions, KTC import/export, rankings overrides) unaffected; a >2 MB POST returns 413

## Roadmap status
Phases 1-4 functionally complete. Remaining **opt-in** (not auto-shipped — Medium-risk / polish): granular per-subtree error boundaries beyond the global one, and the `server.py` / `trade/page.jsx` monolith refactors (4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)