### PR TITLE
fix(awards): season-scope trader/waiver/best-trade (drop the date cutoff)

### DIFF
--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -38,33 +38,11 @@ Award catalog:
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime, timezone
 from typing import Any
 
 from . import metrics
 from .draft import _pick_ownership_map, pick_weight
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
-
-
-# Trader of the Year and Waiver King begin tracking on this date — they
-# are new awards introduced 2026-05-12, not retroactively computed for
-# prior seasons.  Only Sleeper transactions whose ``created`` timestamp
-# is at or after this instant count; seasons with no qualifying activity
-# simply do not emit these awards.
-TRADER_WAIVER_TRACKING_START_MS = int(
-    datetime(2026, 5, 12, tzinfo=timezone.utc).timestamp() * 1000
-)
-
-
-def _tx_created_ms(tx: dict[str, Any]) -> int:
-    try:
-        return int(tx.get("created") or tx.get("status_updated") or 0)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _tx_after_tracking_start(tx: dict[str, Any]) -> bool:
-    return _tx_created_ms(tx) >= TRADER_WAIVER_TRACKING_START_MS
 
 
 # Explanation strings exposed on every award card so the page never
@@ -83,18 +61,18 @@ AWARD_DESCRIPTIONS: dict[str, str] = {
     "highest_single_week": "Largest single-week scoring explosion.",
     "lowest_single_week": "Smallest single-week score.",
     "trader_of_the_year": (
-        "Realized post-trade fantasy points gained since 2026-05-12. Sums "
+        "Realized post-trade fantasy points gained this season. Sums "
         "points acquired minus points sent away across every trade, weighted "
         "by the weeks played after the deal. Tiebreaks: playoff points "
         "gained, then a server-side asset-value delta."
     ),
     "best_trade_of_the_year": (
-        "Best single trade by post-deal realized points for one side "
-        "(since 2026-05-12). Historical only — finalized after the season."
+        "Best single trade by post-deal realized points for one side. "
+        "Historical only — finalized after the season."
     ),
     "waiver_king": (
         "Total fantasy points your waiver / free-agent pickups scored in "
-        "weeks they were in your starting lineup, since 2026-05-12. "
+        "weeks they were in your starting lineup. "
         "Tiebreak: count of useful adds."
     ),
     "silent_assassin": (
@@ -451,8 +429,6 @@ def _trader_of_the_year_scores(
     best_trade: tuple[float, str, dict[str, Any], dict[str, Any]] | None = None
 
     for tx in season.trades():
-        if not _tx_after_tracking_start(tx):
-            continue
         leg = tx.get("leg") or tx.get("_leg") or 0
         try:
             leg_int = int(leg)
@@ -573,8 +549,6 @@ def _waiver_king_scores(
         return per_owner[owner_id]
 
     for tx in season.waivers():
-        if not _tx_after_tracking_start(tx):
-            continue
         leg = tx.get("leg") or tx.get("_leg") or 0
         try:
             leg_int = int(leg)

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -1,7 +1,7 @@
 """Tests for the reworked awards engine.
 
-Covers the 2026 rework: removed awards, the 2026-05-12 trader/waiver
-tracking cutoff, starting-lineup-only Waiver King, champion-only
+Covers the 2026 rework: removed awards, season-scoped (no date
+cutoff) trader/waiver, starting-lineup-only Waiver King, champion-only
 Playoff MVP, the weighted Manager of the Year, Off/Def Rookie of the
 Year, Mr. Consistent, and canonical award ordering.
 """
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import copy
 import unittest
-from unittest import mock
+import contextlib
 
 from src.public_league import awards
 from src.public_league.awards import (
@@ -45,10 +45,10 @@ from src.public_league.public_contract import assert_public_payload_safe, build_
 from tests.public_league.fixtures import build_test_snapshot
 
 
-# Fixture transactions are stamped in 2024; the real cutoff is
-# 2026-05-12.  Patch it to 0 when validating the *math* so the fixture
-# transactions count; leave it real when validating the *gating*.
-_NO_CUTOFF = mock.patch.object(awards, "TRADER_WAIVER_TRACKING_START_MS", 0)
+# Transaction awards are season-scoped (no date cutoff), like every
+# other award.  This null context keeps the historical call sites
+# readable without rewriting each one.
+_NO_CUTOFF = contextlib.nullcontext()
 
 _REMOVED_KEYS = {
     "chaos_agent", "most_active", "pick_hoarder",
@@ -122,33 +122,28 @@ class AwardDescriptionsTests(unittest.TestCase):
             self.assertNotIn(key, AWARD_DESCRIPTIONS)
 
 
-class TrackingCutoffTests(unittest.TestCase):
-    """Trader of the Year / Waiver King only start 2026-05-12."""
+class SeasonScopedTransactionTests(unittest.TestCase):
+    """Trader / Best Trade / Waiver King are bounded by their Sleeper
+    season — no date cutoff, consistent with every other award."""
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.snapshot = _with_player_points(build_test_snapshot())
 
-    def test_pre_cutoff_transactions_are_excluded(self) -> None:
-        # Fixture txs are stamped in 2024 — before the real cutoff.
+    def test_season_transactions_count(self) -> None:
         rows, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
-        self.assertEqual(rows, [])
-        self.assertIsNone(best)
-        self.assertEqual(_waiver_king_scores(self.snapshot, self.snapshot.seasons[0]), [])
-
-    def test_section_omits_trader_and_waiver_pre_cutoff(self) -> None:
-        section = awards.build_section(self.snapshot)
-        for season_row in section["bySeason"]:
-            keys = {a["key"] for a in season_row["awards"]}
-            self.assertNotIn("trader_of_the_year", keys)
-            self.assertNotIn("waiver_king", keys)
-            self.assertNotIn("best_trade_of_the_year", keys)
-
-    def test_post_cutoff_transactions_count(self) -> None:
-        with _NO_CUTOFF:
-            rows, best = _trader_of_the_year_scores(self.snapshot, self.snapshot.seasons[0])
         self.assertTrue(rows)
         self.assertIsNotNone(best)
+        self.assertTrue(_waiver_king_scores(self.snapshot, self.snapshot.seasons[0]))
+
+    def test_section_includes_trader_waiver_for_season_with_txns(self) -> None:
+        section = awards.build_section(self.snapshot)
+        by_year = {s["season"]: {a["key"] for a in s["awards"]}
+                   for s in section["bySeason"]}
+        k2025 = by_year.get("2025", set())
+        self.assertIn("trader_of_the_year", k2025)
+        self.assertIn("waiver_king", k2025)
+        self.assertIn("best_trade_of_the_year", k2025)
 
 
 class TraderAndBestTradeTests(unittest.TestCase):
@@ -608,7 +603,7 @@ class AwardsLiveRaceTests(unittest.TestCase):
         keys = {r["key"] for r in self.section["awardRaces"]}
         # mr_consistent / silent_assassin / playoff_mvp are conditional
         # (week-count / eligibility / champion); the core set is always
-        # present once the cutoff lets trades/waivers through.
+        # present for a season that has trades/waivers.
         self.assertTrue(
             {"trader_of_the_year", "waiver_king", "weekly_hammer",
              "bad_beat", "manager_of_the_year"}.issubset(keys)


### PR DESCRIPTION
## Decision
Per our discussion — adopt one uniform policy: **every award is bounded by its Sleeper season; nothing uses a hardcoded date.** Removes the 2026-05-12 `TRADER_WAIVER_TRACKING_START_MS` cutoff that made Trader / Best Trade / Waiver King the *only* date-special awards and hid the full, finalized **2025 & 2024** results.

- `season.trades()` / `season.waivers()` are already per-league-season, so dropping the guard makes these naturally season-scoped like champion/MVP/etc.
- The cutoff's only real purpose (keep pre-season 2026 offseason churn out of the *live* race) is already handled better by the featured-season rollover (#470 — 2025 stays featured until 2026 plays games; and in-progress partial-ness is true of *all* 2026 awards).
- Descriptions de-dated; `TrackingCutoffTests` reworked into `SeasonScopedTransactionTests`.

## Result
- **2025 & 2024 boards now show Trader of the Year / Best Trade / Waiver King** (full finalized history).
- 2026 shows season-to-date, consistent with every other 2026 award.

## Test plan
- [x] full `tests/public_league/` suite green (313)
- [x] `py_compile` clean
- [ ] CI green
- [ ] Post-deploy: 2025/2024 boards show the three transaction awards (alongside the now-also-fixed Off/Def ROY from #479)

🤖 Generated with [Claude Code](https://claude.com/claude-code)