### PR TITLE
feat(awards): live races top-5 players / top-3 managers

### DIFF
--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -1925,7 +1925,7 @@ def _current_season_races(
                         "starterPoints": r["starterPoints"],
                     },
                 }
-                for i, r in enumerate(playoff_mvp_rows[:3])
+                for i, r in enumerate(playoff_mvp_rows[:5])
             ],
         }
         _add(race)
@@ -1987,7 +1987,7 @@ def _current_season_races(
         },
     ))
 
-    # ── Player-award races (top 3 per position) ──
+    # ── Player-award races (top 5 per position) ──
     player_rows_by_pos = _top_player_per_position_scores(
         snapshot, season, regular_season_only=True
     )
@@ -2014,7 +2014,7 @@ def _current_season_races(
                         "gamesStarted": r["gamesStarted"],
                     },
                 }
-                for i, r in enumerate(rows[:3])
+                for i, r in enumerate(rows[:5])
             ],
         }
         _add(race)
@@ -2041,7 +2041,7 @@ def _current_season_races(
                         "gamesStarted": r["gamesStarted"],
                     },
                 }
-                for i, r in enumerate(mvp_rows[:3])
+                for i, r in enumerate(mvp_rows[:5])
             ],
         }
         _add(race)
@@ -2070,7 +2070,7 @@ def _current_season_races(
                         "gamesStarted": r["gamesStarted"],
                     },
                 }
-                for i, r in enumerate(rows[:3])
+                for i, r in enumerate(rows[:5])
             ],
         }
 

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -593,9 +593,21 @@ class AwardsLiveRaceTests(unittest.TestCase):
     def test_has_award_races(self) -> None:
         self.assertGreater(len(self.section["awardRaces"]), 0)
 
-    def test_race_top_three_only(self) -> None:
+    # Player-category races show top 5; team/manager (and NFL-team)
+    # races show top 3.
+    _PLAYER_RACE_KEYS = {
+        "league_mvp", "playoff_mvp", "off_roy", "def_roy",
+        "top_qb", "top_rb", "top_wr", "top_te", "top_k",
+        "top_dl", "top_lb", "top_db",
+    }
+
+    def test_race_leader_caps(self) -> None:
         for race in self.section["awardRaces"]:
-            self.assertLessEqual(len(race["leaders"]), 3)
+            cap = 5 if race["key"] in self._PLAYER_RACE_KEYS else 3
+            self.assertLessEqual(
+                len(race["leaders"]), cap,
+                f"{race['key']} has {len(race['leaders'])} leaders (cap {cap})",
+            )
             for i, leader in enumerate(race["leaders"]):
                 self.assertEqual(leader["rank"], i + 1)
 


### PR DESCRIPTION
## Summary
When the season is underway, the live "Award races" leaderboard now shows:
- **Top 5** for every player-category race — League MVP, Playoff MVP, Offensive/Defensive ROY, and all positional Top-QB/RB/WR/TE/K/DL/LB/DB.
- **Top 3** for team/manager-category races — Manager of the Year, Trader, Waiver King, Silent Assassin, Weekly Hammer, Mr. Consistent, Bad Beat, Top Offense, Top Defense, Top NFL Team.

Bumped the four manual player-race slices `[:3] → [:5]`; team/manager races already go through `_build_race(top_n=3)`. This only affects the in-progress-season races view (already gated by the featured-season rollout), not the finalized per-season single-winner boards. Frontend maps all backend-emitted leaders, so no UI change.

## Test plan
- [x] `test_race_leader_caps` updated — player race keys ≤5, all others ≤3, ranks contiguous
- [x] full `tests/public_league/` suite green (313)
- [x] `py_compile` clean
- [ ] CI green
- [ ] Post-deploy: in-progress-season races show 5 player rows / 3 manager rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)