### PR TITLE
feat(awards): Off/Def MVP + concise descriptions + manager/player split

### DIFF
--- a/frontend/app/league/sections/awards.jsx
+++ b/frontend/app/league/sections/awards.jsx
@@ -19,7 +19,7 @@ import { TradeCard } from "./activity.jsx";
 const PLAYER_AWARD_KEYS = new Set([
   "top_qb", "top_rb", "top_wr", "top_te", "top_k",
   "top_dl", "top_lb", "top_db",
-  "league_mvp", "playoff_mvp", "off_roy", "def_roy",
+  "league_mvp", "off_mvp", "def_mvp", "playoff_mvp", "off_roy", "def_roy",
 ]);
 
 function AwardWinner({ a, managers, size = 24 }) {
@@ -262,9 +262,12 @@ function AwardsSection({ managers, data, onNavigate }) {
               title="No awards yet"
               message="Awards will appear once the season has enough games / transactions / trades on record."
             />
-          ) : (
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 10 }}>
-              {(featured.awards || []).map((a) => {
+          ) : (() => {
+            const _all = featured.awards || [];
+            const _players = _all.filter((a) => PLAYER_AWARD_KEYS.has(a.key));
+            const _mgr = _all.filter((a) => !PLAYER_AWARD_KEYS.has(a.key));
+            const _lbl = { fontSize: "0.7rem", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--subtext)", margin: "2px 0 8px" };
+            const _renderCard = (a) => {
                 const histCount = (historyByKey.get(a.key) || []).length;
                 const isBestTrade = a.key === "best_trade_of_the_year" && a.value?.trade;
                 return (
@@ -318,9 +321,29 @@ function AwardsSection({ managers, data, onNavigate }) {
                     </div>
                   </div>
                 );
-              })}
-            </div>
-          )}
+            };
+            const _grid = (list) => (
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 10 }}>
+                {list.map(_renderCard)}
+              </div>
+            );
+            return (
+              <>
+                {_mgr.length > 0 && (
+                  <div style={{ marginBottom: _players.length > 0 ? 18 : 0 }}>
+                    <div style={_lbl}>Manager &amp; Team Awards</div>
+                    {_grid(_mgr)}
+                  </div>
+                )}
+                {_players.length > 0 && (
+                  <div>
+                    <div style={_lbl}>Player Awards</div>
+                    {_grid(_players)}
+                  </div>
+                )}
+              </>
+            );
+          })()}
         </Card>
       )}
 

--- a/frontend/app/league/shared.jsx
+++ b/frontend/app/league/shared.jsx
@@ -206,6 +206,8 @@ export function renderAwardValue(key, value) {
         ? `${value.playerName} · ${fmtPoints(value.starterPoints)} pts in ${value.gamesStarted} starts`
         : `${fmtPoints(value.starterPoints)} pts`;
     case "league_mvp":
+    case "off_mvp":
+    case "def_mvp":
     case "off_roy":
     case "def_roy":
       return value.playerName

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -49,88 +49,39 @@ from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 # needs to hard-code copy.  Keep these short and human — the UI prints
 # them verbatim beneath the winner.
 AWARD_DESCRIPTIONS: dict[str, str] = {
-    "champion": "Winner of the final playoff matchup.",
-    "manager_of_the_year": (
-        "The totality of a season, weighted: 30% final finish, 25% "
-        "regular-season win%, 15% points scored, 15% trade impact, 15% "
-        "waiver impact. Every input min-max normalized across the league."
-    ),
-    "top_seed": "Best regular-season seed after tiebreaks.",
+    "champion": "Won the league.",
+    "manager_of_the_year": "The league's best manager this season.",
+    "league_mvp": "The league's Most Valuable Player.",
+    "off_mvp": "The most valuable offensive player.",
+    "def_mvp": "The most valuable defensive player.",
+    "playoff_mvp": "The champion's standout playoff performer.",
+    "off_roy": "The top first-year offensive player.",
+    "def_roy": "The top first-year defensive player.",
+    "top_seed": "Earned the #1 regular-season seed.",
     "regular_season_crown": "Best regular-season record.",
-    "points_king": "Most regular-season points scored.",
-    "highest_single_week": "Largest single-week scoring explosion.",
-    "lowest_single_week": "Smallest single-week score.",
-    "trader_of_the_year": (
-        "Realized post-trade fantasy points gained this season. Sums "
-        "points acquired minus points sent away across every trade, weighted "
-        "by the weeks played after the deal. Tiebreaks: playoff points "
-        "gained, then a server-side asset-value delta."
-    ),
-    "best_trade_of_the_year": (
-        "Best single trade by post-deal realized points for one side. "
-        "Historical only — finalized after the season."
-    ),
-    "waiver_king": (
-        "Total fantasy points your waiver / free-agent pickups scored in "
-        "weeks they were in your starting lineup. "
-        "Tiebreak: count of useful adds."
-    ),
-    "silent_assassin": (
-        "Win% in games decided by 10 points or fewer (4+ eligible games)."
-    ),
-    "weekly_hammer": "Count of weekly high-score finishes.",
-    "playoff_mvp": (
-        "The championship team's best playoff performer by VORP (Value Over "
-        "Replacement Player) — most points over positional replacement while "
-        "in the starting lineup during the playoffs."
-    ),
-    "bad_beat": "Biggest single 'points in a loss' performance.",
-    "mr_consistent": (
-        "Most consistent playoff qualifier — lowest week-to-week scoring "
-        "variability (coefficient of variation) in the regular season."
-    ),
-    "best_rebuild": (
-        "Year-over-year improvement. 40% points-rank jump + 30% record-rank "
-        "jump + 20% extra weighted stockpile + 10% more rostered rookies."
-    ),
-    "rivalry_of_the_year": (
-        "Season's nastiest head-to-head ranked by rivalry index, boosted by "
-        "playoff meetings."
-    ),
-    # ── Manager awards ──
-    "top_offense": (
-        "Most regular-season points produced by offensive starters "
-        "(QB / RB / WR / TE) — kickers and bench points excluded."
-    ),
-    "top_defense": (
-        "Most regular-season points produced by defensive starters "
-        "(DL / LB / DB / DEF) — bench points excluded."
-    ),
-    "top_nfl_team": (
-        "The NFL franchise whose players scored the most fantasy points "
-        "while in a league starting lineup (regular season)."
-    ),
-    # ── Player awards ──
-    "off_roy": (
-        "Offensive Rookie of the Year: highest VORP among first-year "
-        "QB / RB / WR / TE, from starter-only regular-season scoring."
-    ),
-    "def_roy": (
-        "Defensive Rookie of the Year: highest VORP among first-year "
-        "DL / LB / DB, from starter-only regular-season scoring."
-    ),
-    "top_qb": "Top QB by total starter-only points scored in the regular season.",
-    "top_rb": "Top RB by total starter-only points scored in the regular season.",
-    "top_wr": "Top WR by total starter-only points scored in the regular season.",
-    "top_te": "Top TE by total starter-only points scored in the regular season.",
-    "top_k":  "Top K by total starter-only points scored in the regular season.",
-    "top_dl": "Top DL by total starter-only points scored in the regular season.",
-    "top_lb": "Top LB by total starter-only points scored in the regular season.",
-    "top_db": "Top DB by total starter-only points scored in the regular season.",
-    "league_mvp": (
-        "Regular-season MVP: highest VORP (Value Over Replacement Player) "
-        "across all positions, computed from starter-only scoring."
-    ),
+    "points_king": "Scored the most points.",
+    "highest_single_week": "The biggest single-week score.",
+    "lowest_single_week": "The smallest single-week score.",
+    "trader_of_the_year": "The season's best trade-table operator.",
+    "best_trade_of_the_year": "The single best trade of the season.",
+    "waiver_king": "Got the most out of the waiver wire.",
+    "silent_assassin": "Owns the close games.",
+    "weekly_hammer": "Most weekly high-score finishes.",
+    "mr_consistent": "The most reliable team, week to week.",
+    "bad_beat": "The season's most heartbreaking loss.",
+    "best_rebuild": "The biggest year-over-year turnaround.",
+    "rivalry_of_the_year": "The season's fiercest rivalry.",
+    "top_offense": "The highest-scoring offense.",
+    "top_defense": "The highest-scoring defense.",
+    "top_nfl_team": "The NFL franchise that scored the most for the league.",
+    "top_qb": "The league's top quarterback.",
+    "top_rb": "The league's top running back.",
+    "top_wr": "The league's top wide receiver.",
+    "top_te": "The league's top tight end.",
+    "top_k": "The league's top kicker.",
+    "top_dl": "The league's top defensive lineman.",
+    "top_lb": "The league's top linebacker.",
+    "top_db": "The league's top defensive back.",
 }
 
 
@@ -175,6 +126,8 @@ _AWARD_ORDER: tuple[str, ...] = (
     "champion",
     "manager_of_the_year",
     "league_mvp",
+    "off_mvp",
+    "def_mvp",
     "playoff_mvp",
     "off_roy",
     "def_roy",
@@ -1302,6 +1255,18 @@ def _league_mvp_rows(
     return _vorp_rows(snapshot, season, regular_season_only=True)
 
 
+def _offensive_mvp_rows(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+    """League MVP restricted to offensive skill positions (QB/RB/WR/TE)."""
+    return [r for r in _vorp_rows(snapshot, season, regular_season_only=True)
+            if r["position"] in _OFF_ROY_POSITIONS]
+
+
+def _defensive_mvp_rows(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+    """League MVP restricted to defensive positions (DL/LB/DB)."""
+    return [r for r in _vorp_rows(snapshot, season, regular_season_only=True)
+            if r["position"] in _DEF_ROY_POSITIONS]
+
+
 def _rookie_of_year_rows(
     snapshot: PublicLeagueSnapshot,
     season: SeasonSnapshot,
@@ -1797,6 +1762,12 @@ def _activity_awards_for_season(
         _rookie_of_year_rows(snapshot, season, _DEF_ROY_POSITIONS),
         "def_roy", "Defensive Rookie of the Year",
     )
+    _vorp_player_award(
+        _offensive_mvp_rows(snapshot, season), "off_mvp", "Offensive MVP",
+    )
+    _vorp_player_award(
+        _defensive_mvp_rows(snapshot, season), "def_mvp", "Defensive MVP",
+    )
 
     # ── Mr. Consistent ─────────────────────────────────────────────
     _add(_award_from_row(
@@ -2081,6 +2052,12 @@ def _current_season_races(
     _add(_vorp_player_race(
         _rookie_of_year_rows(snapshot, season, _DEF_ROY_POSITIONS),
         "def_roy", "Defensive Rookie of the Year Race",
+    ))
+    _add(_vorp_player_race(
+        _offensive_mvp_rows(snapshot, season), "off_mvp", "Offensive MVP Race",
+    ))
+    _add(_vorp_player_race(
+        _defensive_mvp_rows(snapshot, season), "def_mvp", "Defensive MVP Race",
     ))
 
     return races

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -22,6 +22,8 @@ from src.public_league.awards import (
     _playoff_mvp_player_rows,
     _rivalry_of_the_year,
     _rookie_of_year_rows,
+    _offensive_mvp_rows,
+    _defensive_mvp_rows,
     _is_rookie_in_season,
     _snapshot_anchor_year,
     _silent_assassin_scores,
@@ -112,7 +114,8 @@ class AwardDescriptionsTests(unittest.TestCase):
             "best_trade_of_the_year", "waiver_king", "silent_assassin",
             "weekly_hammer", "playoff_mvp", "bad_beat", "mr_consistent",
             "best_rebuild", "rivalry_of_the_year", "off_roy", "def_roy",
-            "league_mvp", "top_qb", "top_offense", "top_defense",
+            "league_mvp", "off_mvp", "def_mvp",
+            "top_qb", "top_offense", "top_defense",
         ):
             self.assertIn(key, AWARD_DESCRIPTIONS)
             self.assertTrue(AWARD_DESCRIPTIONS[key])
@@ -321,6 +324,24 @@ class ManagerOfTheYearTests(unittest.TestCase):
         by_owner = {r["ownerId"]: r for r in rows}
         # 2025 champion = owner-B → finishRank 1.
         self.assertEqual(by_owner["owner-B"]["finishRank"], 1)
+
+
+class OffDefMvpTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.snapshot = _with_player_points(build_test_snapshot())
+
+    def test_off_mvp_only_offensive_positions(self):
+        rows = _offensive_mvp_rows(self.snapshot, self.snapshot.seasons[0])
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertIn(r["position"], _OFF_ROY_POSITIONS)
+        for a, b in zip(rows, rows[1:]):
+            self.assertGreaterEqual(a["vorp"], b["vorp"])
+
+    def test_def_mvp_only_defensive_positions(self):
+        for r in _defensive_mvp_rows(self.snapshot, self.snapshot.seasons[0]):
+            self.assertIn(r["position"], _DEF_ROY_POSITIONS)
 
 
 class RookieOfTheYearTests(unittest.TestCase):
@@ -596,7 +617,7 @@ class AwardsLiveRaceTests(unittest.TestCase):
     # Player-category races show top 5; team/manager (and NFL-team)
     # races show top 3.
     _PLAYER_RACE_KEYS = {
-        "league_mvp", "playoff_mvp", "off_roy", "def_roy",
+        "league_mvp", "off_mvp", "def_mvp", "playoff_mvp", "off_roy", "def_roy",
         "top_qb", "top_rb", "top_wr", "top_te", "top_k",
         "top_dl", "top_lb", "top_db",
     }


### PR DESCRIPTION
## Summary
Three requested awards changes, one coherent bundle:

1. **Offensive & Defensive MVP** — `_offensive_mvp_rows`/`_defensive_mvp_rows`: League MVP (VORP, regular-season starter-only) restricted to QB/RB/WR/TE and DL/LB/DB. Emitted via the existing `_vorp_player_award` + added to the live races (player-category → top 5). Ordered right after League MVP.
2. **Concise descriptions** — `AWARD_DESCRIPTIONS` rewritten to plain "what it recognizes" one-liners with **zero methodology** (no VORP/weights/thresholds/cutoffs/normalization). "They don't need to know how the soup is made."
3. **Manager vs Player split** — the `/league` featured-season board now renders two labeled groups: **Manager & Team Awards** and **Player Awards** (partitioned by `PLAYER_AWARD_KEYS`, now incl. off/def MVP). Within-group order and the tap-for-history modal are unchanged.

`shared.jsx` renders off/def MVP exactly like League MVP.

> Built in an isolated git worktree: the production main checkout is under active deploy/scrape git churn that was corrupting multi-step edits (it kept reverting `awards.py` before commits captured it). The worktree is unaffected.

## Test plan
- [x] `tests/public_league/` — 315 passed (incl. new `OffDefMvpTests`; description-key + race-cap lists updated)
- [x] `py_compile` clean
- [x] `cd frontend && npm run build` — all pages under budget
- [ ] CI green
- [ ] Post-deploy: /league shows Manager & Team / Player groups; Off/Def MVP populate; descriptions are one-liners

🤖 Generated with [Claude Code](https://claude.com/claude-code)