### PR TITLE
fix(awards): drop redundant Top Seed award

### DIFF
--- a/frontend/app/league/shared.jsx
+++ b/frontend/app/league/shared.jsx
@@ -149,8 +149,6 @@ export function renderAwardValue(key, value) {
   switch (key) {
     case "champion":
       return "";
-    case "top_seed":
-      return `Win% ${fmtPercent(value.winPct)}`;
     case "regular_season_crown":
       return value.record || "";
     case "points_king":

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -17,7 +17,6 @@ public-safe values.
 Award catalog:
     champion                 — winner of the finals
     manager_of_the_year      — weighted totality composite (pinned #2)
-    top_seed                 — best regular-season seed
     regular_season_crown     — best regular-season record
     points_king              — most regular-season points
     highest_single_week      — largest single-week score
@@ -57,7 +56,6 @@ AWARD_DESCRIPTIONS: dict[str, str] = {
     "playoff_mvp": "The champion's standout playoff performer.",
     "off_roy": "The top first-year offensive player.",
     "def_roy": "The top first-year defensive player.",
-    "top_seed": "Earned the #1 regular-season seed.",
     "regular_season_crown": "Best regular-season record.",
     "points_king": "Scored the most points.",
     "highest_single_week": "The biggest single-week score.",
@@ -131,7 +129,6 @@ _AWARD_ORDER: tuple[str, ...] = (
     "playoff_mvp",
     "off_roy",
     "def_roy",
-    "top_seed",
     "regular_season_crown",
     "points_king",
     "highest_single_week",
@@ -304,7 +301,6 @@ def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnaps
         return []
 
     champion_rid = metrics.season_champion(season)
-    top_seed = metrics.top_seed(standings)
     best_record_rid = standings[0]["rosterId"] if standings else None
     pf_leader = max(standings, key=lambda r: r["pointsFor"], default=None)
 
@@ -325,12 +321,6 @@ def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnaps
 
     awards = [
         _canonical_award(snapshot, season, champion_rid, "champion", "Champion"),
-        _canonical_award(
-            snapshot, season,
-            top_seed["rosterId"] if top_seed else None,
-            "top_seed", "Top Seed",
-            value={"winPct": top_seed["winPct"]} if top_seed else None,
-        ),
         _canonical_award(
             snapshot, season, best_record_rid,
             "regular_season_crown", "Regular-Season Crown",

--- a/tests/public_league/test_csv_export.py
+++ b/tests/public_league/test_csv_export.py
@@ -51,7 +51,7 @@ class CsvExportTests(unittest.TestCase):
         rows = self._parse(text)
         self.assertTrue(rows)
         keys = {r["key"] for r in rows}
-        for required in ("champion", "manager_of_the_year", "top_seed"):
+        for required in ("champion", "manager_of_the_year", "regular_season_crown"):
             self.assertIn(required, keys)
 
     def test_records_export_has_categories(self) -> None:

--- a/tests/public_league/test_metrics_engines.py
+++ b/tests/public_league/test_metrics_engines.py
@@ -417,7 +417,6 @@ class AwardsTests(_BaseFixture):
             for expected in (
                 "champion",
                 "manager_of_the_year",
-                "top_seed",
                 "regular_season_crown",
                 "points_king",
                 "highest_single_week",


### PR DESCRIPTION
## Summary
Top Seed and Regular-Season Crown are the same award twice: `metrics.top_seed(standings)` returns `standings[0]` — the best regular-season record — which is exactly what Regular-Season Crown already awards. Removed **Top Seed** (catalog docstring, `AWARD_DESCRIPTIONS`, `_AWARD_ORDER`, canonical emission, `shared.jsx` value case). Kept **Regular-Season Crown** (conventional fantasy name; shows the W-L record, more informative than win%).

`metrics.top_seed()` is **retained** — the history / hall-of-fame "top seed" stat (`history.py` → `history.jsx`) is a separate surface that still uses it and wasn't flagged.

## Test plan
- [x] `tests/public_league/` — 315 passed (`test_top_seed_uses_win_pct_then_pf` still green: the metrics fn is unchanged); `test_metrics_engines` / `test_csv_export` expected-key lists updated
- [x] `py_compile` clean
- [x] `cd frontend && npm run build` — all pages under budget
- [ ] CI green
- [ ] Post-deploy: /league board no longer shows a Top Seed card; Regular-Season Crown remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)