### PR TITLE
feat(awards): per-year finalists in award history modal

### DIFF
--- a/frontend/app/league/sections/awards.jsx
+++ b/frontend/app/league/sections/awards.jsx
@@ -22,6 +22,45 @@ const PLAYER_AWARD_KEYS = new Set([
   "league_mvp", "off_mvp", "def_mvp", "playoff_mvp", "off_roy", "def_roy",
 ]);
 
+// One ranked row in a race / finalists list.  Shared by the live
+// "Award races" card and the per-year finalists in the history modal so
+// both render an identical ranked board.
+function LeaderRow({ awardKey, leader, managers, onNavigate }) {
+  const isPlayer = PLAYER_AWARD_KEYS.has(awardKey);
+  return (
+    <div
+      style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: "0.78rem", gap: 6 }}
+    >
+      <span style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+        <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", minWidth: 16 }}>
+          {leader.rank}.
+        </span>
+        {isPlayer && leader.value?.playerId && (
+          <PlayerImage
+            playerId={leader.value.playerId}
+            team={leader.value.team}
+            position={leader.value.position}
+            name={leader.value.playerName}
+            size={18}
+          />
+        )}
+        {leader.ownerId && (
+          <Avatar managers={managers} ownerId={leader.ownerId} size={18} />
+        )}
+        <span
+          style={{ cursor: leader.ownerId ? "pointer" : "default", color: leader.ownerId ? "var(--cyan)" : "var(--text)", overflow: "hidden", textOverflow: "ellipsis" }}
+          onClick={leader.ownerId ? () => onNavigate("franchise", { owner: leader.ownerId }) : undefined}
+        >
+          {isPlayer && leader.value?.playerName ? leader.value.playerName : leader.displayName}
+        </span>
+      </span>
+      <span style={{ fontFamily: "var(--mono)", color: "var(--text)", flexShrink: 0 }}>
+        {renderAwardValue(awardKey, leader.value)}
+      </span>
+    </div>
+  );
+}
+
 function AwardWinner({ a, managers, size = 24 }) {
   const isPlayer = PLAYER_AWARD_KEYS.has(a.key) && a.value?.playerId;
   return (
@@ -65,6 +104,15 @@ function AwardWinner({ a, managers, size = 24 }) {
 }
 
 function AwardHistoryModal({ awardKey, label, description, history, managers, onNavigate, onClose }) {
+  const [expanded, setExpanded] = useState(() => new Set());
+  const toggle = (season) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(season)) next.delete(season);
+      else next.add(season);
+      return next;
+    });
+
   useEffect(() => {
     const onKey = (e) => {
       if (e.key === "Escape") onClose();
@@ -129,27 +177,85 @@ function AwardHistoryModal({ awardKey, label, description, history, managers, on
               No prior winners on record yet.
             </div>
           )}
-          {history.map(({ season, award }) => (
-            <div
-              key={season}
-              style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}
-            >
-              <div style={{ fontSize: "0.66rem", color: "var(--subtext)", fontFamily: "var(--mono)" }}>
-                {season}
+          {history.map(({ season, award, finalists }) => {
+            const fin = finalists || [];
+            const hasFinalists = fin.length > 1;
+            const isOpen = expanded.has(season);
+            return (
+              <div
+                key={season}
+                style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: 10 }}
+              >
+                <div
+                  role={hasFinalists ? "button" : undefined}
+                  tabIndex={hasFinalists ? 0 : undefined}
+                  onClick={hasFinalists ? () => toggle(season) : undefined}
+                  onKeyDown={
+                    hasFinalists
+                      ? (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            toggle(season);
+                          }
+                        }
+                      : undefined
+                  }
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    gap: 8,
+                    cursor: hasFinalists ? "pointer" : "default",
+                  }}
+                >
+                  <div style={{ fontSize: "0.66rem", color: "var(--subtext)", fontFamily: "var(--mono)" }}>
+                    {season}
+                  </div>
+                  {hasFinalists && (
+                    <div style={{ fontSize: "0.62rem", color: "var(--cyan)", fontWeight: 600 }}>
+                      {isOpen ? "Hide finalists ▴" : `Finalists (${fin.length}) ▾`}
+                    </div>
+                  )}
+                </div>
+                <AwardWinner a={award} managers={managers} size={22} />
+                {award.value && (
+                  <div style={{ fontFamily: "var(--mono)", fontSize: "0.76rem", color: "var(--cyan)", marginTop: 6 }}>
+                    {renderAwardValue(award.key, award.value)}
+                  </div>
+                )}
+                {award.key === "best_trade_of_the_year" && award.value?.trade && (
+                  <div style={{ marginTop: 8 }}>
+                    <TradeCard trade={award.value.trade} managers={managers} onNavigate={onNavigate} />
+                  </div>
+                )}
+                {hasFinalists && isOpen && (
+                  <div
+                    style={{
+                      marginTop: 10,
+                      borderTop: "1px solid var(--border)",
+                      paddingTop: 10,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 6,
+                    }}
+                  >
+                    <div style={{ fontSize: "0.58rem", color: "var(--subtext)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                      {season} finalists
+                    </div>
+                    {fin.map((leader) => (
+                      <LeaderRow
+                        key={leader.ownerId || leader.value?.playerId || `${award.key}-${leader.rank}`}
+                        awardKey={award.key}
+                        leader={leader}
+                        managers={managers}
+                        onNavigate={onNavigate}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
-              <AwardWinner a={award} managers={managers} size={22} />
-              {award.value && (
-                <div style={{ fontFamily: "var(--mono)", fontSize: "0.76rem", color: "var(--cyan)", marginTop: 6 }}>
-                  {renderAwardValue(award.key, award.value)}
-                </div>
-              )}
-              {award.key === "best_trade_of_the_year" && award.value?.trade && (
-                <div style={{ marginTop: 8 }}>
-                  <TradeCard trade={award.value.trade} managers={managers} onNavigate={onNavigate} />
-                </div>
-              )}
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </div>
@@ -167,7 +273,11 @@ function AwardsSection({ managers, data, onNavigate }) {
     for (const s of seasons) {
       for (const a of s.awards || []) {
         if (!map.has(a.key)) map.set(a.key, []);
-        map.get(a.key).push({ season: s.season, award: a });
+        map.get(a.key).push({
+          season: s.season,
+          award: a,
+          finalists: s.finalists?.[a.key] || [],
+        });
       }
     }
     return map;
@@ -201,39 +311,13 @@ function AwardsSection({ managers, data, onNavigate }) {
                 </div>
                 <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                   {race.leaders.map((leader) => (
-                    <div
+                    <LeaderRow
                       key={leader.ownerId || leader.value?.playerId || `${race.key}-${leader.rank}`}
-                      style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: "0.78rem", gap: 6 }}
-                    >
-                      <span style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
-                        <span style={{ color: "var(--subtext)", fontFamily: "var(--mono)", minWidth: 16 }}>
-                          {leader.rank}.
-                        </span>
-                        {PLAYER_AWARD_KEYS.has(race.key) && leader.value?.playerId && (
-                          <PlayerImage
-                            playerId={leader.value.playerId}
-                            team={leader.value.team}
-                            position={leader.value.position}
-                            name={leader.value.playerName}
-                            size={18}
-                          />
-                        )}
-                        {leader.ownerId && (
-                          <Avatar managers={managers} ownerId={leader.ownerId} size={18} />
-                        )}
-                        <span
-                          style={{ cursor: leader.ownerId ? "pointer" : "default", color: leader.ownerId ? "var(--cyan)" : "var(--text)", overflow: "hidden", textOverflow: "ellipsis" }}
-                          onClick={leader.ownerId ? () => onNavigate("franchise", { owner: leader.ownerId }) : undefined}
-                        >
-                          {PLAYER_AWARD_KEYS.has(race.key) && leader.value?.playerName
-                            ? leader.value.playerName
-                            : leader.displayName}
-                        </span>
-                      </span>
-                      <span style={{ fontFamily: "var(--mono)", color: "var(--text)", flexShrink: 0 }}>
-                        {renderAwardValue(race.key, leader.value)}
-                      </span>
-                    </div>
+                      awardKey={race.key}
+                      leader={leader}
+                      managers={managers}
+                      onNavigate={onNavigate}
+                    />
                   ))}
                 </div>
               </div>

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -2055,10 +2055,16 @@ def _current_season_races(
 
 def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     by_season: list[dict[str, Any]] = []
+    races_by_season: dict[str, list[dict[str, Any]]] = {}
     for idx, season in enumerate(snapshot.seasons):
         prev = snapshot.seasons[idx + 1] if idx + 1 < len(snapshot.seasons) else None
         canonical = _season_canonical_awards(snapshot, season)
         activity_based = _activity_awards_for_season(snapshot, season, prev)
+        # Per-season races double as that year's "finalists" board so the
+        # award-history modal can show the ranked runner-ups, not just the
+        # winner.  Reused below for the featured season's live awardRaces.
+        season_races = _current_season_races(snapshot, season)
+        races_by_season[season.season] = season_races
         by_season.append({
             "season": season.season,
             "leagueId": season.league_id,
@@ -2066,6 +2072,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             "isComplete": season.is_complete,
             "hasPlayerScoring": _season_has_player_scoring(season),
             "awards": _order_awards(canonical + activity_based),
+            "finalists": {r["key"]: r["leaders"] for r in season_races},
         })
 
     # Featured season = the newest season that has actually *begun*.
@@ -2093,7 +2100,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     races: list[dict[str, Any]] = []
     current = featured
     if current is not None and not current.is_complete:
-        races = _current_season_races(snapshot, current)
+        races = races_by_season.get(current.season) or _current_season_races(snapshot, current)
 
     hottest = None
     for race in races:

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -643,6 +643,25 @@ class AwardsLiveRaceTests(unittest.TestCase):
         )
         self.assertEqual(keys & _REMOVED_KEYS, set())
 
+    def test_every_season_has_finalists_board(self) -> None:
+        for row in self.section["bySeason"]:
+            self.assertIn("finalists", row)
+            self.assertIsInstance(row["finalists"], dict)
+            for key, leaders in row["finalists"].items():
+                self.assertNotIn(key, _REMOVED_KEYS)
+                for i, leader in enumerate(leaders):
+                    self.assertEqual(leader["rank"], i + 1)
+                    self.assertIn("value", leader)
+
+    def test_featured_finalists_reuse_award_races(self) -> None:
+        # The featured (in-progress) season's finalists board must be the
+        # exact same object set as the live awardRaces — same compute,
+        # surfaced twice.
+        featured = self.section["featuredSeason"]
+        row = next(r for r in self.section["bySeason"] if r["season"] == featured)
+        race_by_key = {r["key"]: r["leaders"] for r in self.section["awardRaces"]}
+        self.assertEqual(row["finalists"], race_by_key)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- "When I click on a year I should be able to see the finalists for that year" — each year row in the award-history modal is now click-to-expand, revealing that year's ranked finalists board (runner-ups, not just the winner).
- Backend: `build_section` computes `_current_season_races` per season and attaches a `finalists` map to every `bySeason` entry. The featured season's races are reused for `awardRaces`, so net compute is N season-race passes (not N+1). Single-winner awards (champion, regular-season crown, points king, best-trade, etc.) have no race → empty finalists → unchanged winner-only render.
- Frontend: extracted the duplicated live-races leader-row JSX into one shared `LeaderRow`, now used by both the races card and the modal so both render an identical ranked board.

## Test plan
- [x] `pytest tests/public_league/` — 315 pass; `test_awards.py` 49 pass incl. 2 new (`test_every_season_has_finalists_board`, `test_featured_finalists_reuse_award_races`)
- [x] `npm run build` — clean; `/league` 166.6/170 KB under budget
- [x] Verified payload on prod snapshot: 2025→24 finalist boards, 2024→23, ranked 1..N; `champion` correctly absent (single-winner)
- [ ] Post-deploy: open `/league` → Awards → tap an award → click a year → finalists expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)