### PR TITLE
feat(retention): prune regenerable data/export archives after each scrape

### DIFF
--- a/server.py
+++ b/server.py
@@ -1804,6 +1804,18 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
                 f"{site_count}/{total_sites} sites, {elapsed:.1f}s"
             )
 
+            # Best-effort disk retention.  Regenerable raw/export
+            # archives accumulate every scrape and would otherwise fill
+            # the disk.  A prune failure must never fail the scrape.
+            try:
+                from src.maintenance.retention import prune_data_dir
+
+                _ret = prune_data_dir(BASE_DIR)
+                if _ret.total_deleted or _ret.total_errors:
+                    log.info("retention: %s", _ret.summary())
+            except Exception as _ret_exc:  # noqa: BLE001
+                log.warning("retention prune skipped: %s", _ret_exc)
+
             return result
         except Exception as e:
             elapsed = time.time() - start

--- a/src/maintenance/__init__.py
+++ b/src/maintenance/__init__.py
@@ -1,0 +1,1 @@
+"""Operational maintenance helpers (disk retention, etc.)."""

--- a/src/maintenance/retention.py
+++ b/src/maintenance/retention.py
@@ -1,0 +1,299 @@
+"""Disk-retention pruner for the generated ``data/`` and ``exports/`` trees.
+
+The scraper writes a fresh raw snapshot for every source every ~2h
+(~12 runs/day).  None of those per-run archives are read after the
+newest one is consumed, yet they accumulated unbounded — ~2 GB on the
+production box, on track to fill the disk and fail scrape writes,
+session SQLite, and new logins.
+
+This module prunes ONLY explicitly allow-listed, regenerable archive
+locations and hard-refuses to touch anything that is load-bearing or
+serves live traffic.  It is called best-effort at the end of a
+successful scrape (see ``server.py``).
+
+Retention policy (intentionally generous — these are safety margins,
+not tight budgets):
+
+* ``data/canonical/``                  — purge entirely.  The offline
+  canonical-build pipeline was retired; nothing writes or reads this
+  directory anymore (orphaned snapshots).
+* ``data/exports/archive/*.zip`` and
+  ``exports/archive/*.zip``            — keep the last 14 days.
+* ``data/raw_sources/raw_source_snapshot_*.json``
+                                       — keep the newest 30.
+* ``data/raw/<source>/<year>/*``       — keep the newest 30 per leaf.
+* ``data/dynasty_data_*.json``         — keep the last 45 days (the
+  source-history fallback in ``server.py`` mines these when the
+  dedicated history log is missing/empty; 45d is well past any window
+  the UI reads).
+
+NEVER touched (hard-guarded, not merely un-globbed):
+``exports/latest/``, ``data/rank_history.jsonl``, ``data/identity/``,
+``data/ros/``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Retention knobs.  Kept as module constants (not env-driven) so the
+# behaviour is identical in tests, CI, and prod — there is no reason to
+# tune these per-environment and an env override would just be another
+# way to accidentally nuke history.
+EXPORTS_ARCHIVE_MAX_AGE_DAYS = 14
+DYNASTY_DATA_MAX_AGE_DAYS = 45
+RAW_SOURCES_KEEP = 30
+RAW_PER_SOURCE_KEEP = 30
+
+_DAY_SECONDS = 86_400
+
+
+@dataclass
+class CategoryResult:
+    name: str
+    deleted: int = 0
+    kept: int = 0
+    bytes_freed: int = 0
+    errors: int = 0
+
+
+@dataclass
+class RetentionReport:
+    dry_run: bool = False
+    categories: list[CategoryResult] = field(default_factory=list)
+
+    def _cat(self, name: str) -> CategoryResult:
+        for c in self.categories:
+            if c.name == name:
+                return c
+        c = CategoryResult(name=name)
+        self.categories.append(c)
+        return c
+
+    @property
+    def total_deleted(self) -> int:
+        return sum(c.deleted for c in self.categories)
+
+    @property
+    def total_bytes_freed(self) -> int:
+        return sum(c.bytes_freed for c in self.categories)
+
+    @property
+    def total_errors(self) -> int:
+        return sum(c.errors for c in self.categories)
+
+    def summary(self) -> str:
+        mb = self.total_bytes_freed / (1024 * 1024)
+        prefix = "[dry-run] " if self.dry_run else ""
+        parts = [
+            f"{c.name}: -{c.deleted} ({c.bytes_freed / (1024 * 1024):.1f}MB)"
+            for c in self.categories
+            if c.deleted or c.errors
+        ]
+        detail = ", ".join(parts) if parts else "nothing to prune"
+        errs = f", {self.total_errors} errors" if self.total_errors else ""
+        return f"{prefix}reclaimed {mb:.1f}MB across {self.total_deleted} entries{errs} — {detail}"
+
+
+def _protected_paths(base_dir: Path) -> list[Path]:
+    base = base_dir.resolve()
+    return [
+        (base / "exports" / "latest").resolve(),
+        (base / "data" / "identity").resolve(),
+        (base / "data" / "ros").resolve(),
+        (base / "data" / "rank_history.jsonl").resolve(),
+    ]
+
+
+def _is_protected(target: Path, protected: list[Path]) -> bool:
+    t = target.resolve()
+    for p in protected:
+        if t == p:
+            return True
+        try:
+            t.relative_to(p)
+            return True
+        except ValueError:
+            pass
+    return False
+
+
+def _entry_size(path: Path) -> int:
+    try:
+        if path.is_dir() and not path.is_symlink():
+            return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _delete(
+    target: Path,
+    allowed_root: Path,
+    protected: list[Path],
+    cat: CategoryResult,
+    *,
+    dry_run: bool,
+) -> None:
+    """Delete one entry with containment + protected-path guards.
+
+    Containment: the resolved target MUST live inside ``allowed_root``.
+    Protected: the resolved target MUST NOT be (or be inside) any
+    load-bearing path.  Either guard failing is a bug in a caller's
+    glob — we skip and count an error rather than risk live data.
+    """
+    try:
+        resolved = target.resolve()
+        root = allowed_root.resolve()
+        resolved.relative_to(root)  # raises ValueError if escaped
+        if _is_protected(resolved, protected) or _is_protected(root, protected):
+            cat.errors += 1
+            return
+        size = _entry_size(target)
+        if dry_run:
+            cat.deleted += 1
+            cat.bytes_freed += size
+            return
+        if target.is_dir() and not target.is_symlink():
+            shutil.rmtree(target)
+        else:
+            target.unlink()
+        cat.deleted += 1
+        cat.bytes_freed += size
+    except (OSError, ValueError):
+        cat.errors += 1
+
+
+def _mtime(p: Path) -> float:
+    try:
+        return p.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _purge_dir_contents(
+    directory: Path, protected: list[Path], cat: CategoryResult, *, dry_run: bool
+) -> None:
+    if not directory.is_dir():
+        return
+    for child in sorted(directory.iterdir()):
+        if child.name == ".gitkeep":
+            cat.kept += 1
+            continue
+        _delete(child, directory, protected, cat, dry_run=dry_run)
+
+
+def _prune_by_age(
+    directory: Path,
+    pattern: str,
+    max_age_days: int,
+    protected: list[Path],
+    cat: CategoryResult,
+    *,
+    now: float,
+    dry_run: bool,
+) -> None:
+    if not directory.is_dir():
+        return
+    cutoff = now - max_age_days * _DAY_SECONDS
+    for entry in sorted(directory.glob(pattern)):
+        if _mtime(entry) < cutoff:
+            _delete(entry, directory, protected, cat, dry_run=dry_run)
+        else:
+            cat.kept += 1
+
+
+def _prune_keep_newest(
+    directory: Path,
+    pattern: str,
+    keep: int,
+    protected: list[Path],
+    cat: CategoryResult,
+    *,
+    dry_run: bool,
+) -> None:
+    if not directory.is_dir():
+        return
+    entries = sorted(directory.glob(pattern), key=_mtime, reverse=True)
+    for entry in entries[:keep]:
+        cat.kept += 1
+    for entry in entries[keep:]:
+        _delete(entry, directory, protected, cat, dry_run=dry_run)
+
+
+def prune_data_dir(
+    base_dir: Path,
+    *,
+    now: float | None = None,
+    dry_run: bool = False,
+) -> RetentionReport:
+    """Prune regenerable archives under ``base_dir`` per the module policy.
+
+    Pure with respect to ``now`` (injectable for tests).  Never raises
+    for individual entries — failures are counted in the report so a
+    flaky unlink can never abort a scrape.
+    """
+    base_dir = Path(base_dir)
+    now = time.time() if now is None else now
+    data_dir = base_dir / "data"
+    protected = _protected_paths(base_dir)
+    report = RetentionReport(dry_run=dry_run)
+
+    # 1. Orphaned retired-pipeline snapshots — purge entirely.
+    _purge_dir_contents(
+        data_dir / "canonical", protected, report._cat("canonical"), dry_run=dry_run
+    )
+
+    # 2. Export archive zips — keep 14 days (both known archive roots).
+    arch = report._cat("exports_archive")
+    for archive_dir in (data_dir / "exports" / "archive", base_dir / "exports" / "archive"):
+        _prune_by_age(
+            archive_dir,
+            "dynasty_export_*.zip",
+            EXPORTS_ARCHIVE_MAX_AGE_DAYS,
+            protected,
+            arch,
+            now=now,
+            dry_run=dry_run,
+        )
+
+    # 3. Raw source aggregate snapshots — only the newest is ever read.
+    _prune_keep_newest(
+        data_dir / "raw_sources",
+        "raw_source_snapshot_*.json",
+        RAW_SOURCES_KEEP,
+        protected,
+        report._cat("raw_sources"),
+        dry_run=dry_run,
+    )
+
+    # 4. Per-source raw archives: data/raw/<source>/<year>/<entry>.
+    raw_root = data_dir / "raw"
+    raw_cat = report._cat("raw_per_source")
+    if raw_root.is_dir():
+        for source_dir in sorted(p for p in raw_root.iterdir() if p.is_dir()):
+            for year_dir in sorted(p for p in source_dir.iterdir() if p.is_dir()):
+                _prune_keep_newest(
+                    year_dir,
+                    "*",
+                    RAW_PER_SOURCE_KEEP,
+                    protected,
+                    raw_cat,
+                    dry_run=dry_run,
+                )
+
+    # 5. Daily contract snapshots — keep 45 days (source-history fallback).
+    _prune_by_age(
+        data_dir,
+        "dynasty_data_*.json",
+        DYNASTY_DATA_MAX_AGE_DAYS,
+        protected,
+        report._cat("dynasty_data"),
+        now=now,
+        dry_run=dry_run,
+    )
+
+    return report

--- a/tests/maintenance/test_retention.py
+++ b/tests/maintenance/test_retention.py
@@ -1,0 +1,177 @@
+"""Tests for the disk-retention pruner.
+
+Safety-critical: this code deletes files on the production box.  The
+suite pins both the retention math AND the hard guarantee that
+load-bearing paths are never touched even when they superficially
+match a glob.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from src.maintenance import retention
+from src.maintenance.retention import prune_data_dir
+
+NOW = 1_750_000_000.0  # fixed reference instant for deterministic ages
+
+
+def _touch(path: Path, *, age_days: float = 0.0, size: int = 16) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+    ts = NOW - age_days * 86_400
+    os.utime(path, (ts, ts))
+    return path
+
+
+def _build_tree(base: Path) -> None:
+    data = base / "data"
+    # canonical — orphaned, must be fully purged (keep .gitkeep)
+    _touch(data / "canonical" / "canonical_snapshot_old.json", age_days=1)
+    _touch(data / "canonical" / "nested" / "blob.json", age_days=1)
+    (data / "canonical" / ".gitkeep").parent.mkdir(parents=True, exist_ok=True)
+    (data / "canonical" / ".gitkeep").write_text("")
+    # exports archive (both roots) — 14d age cutoff
+    _touch(data / "exports" / "archive" / "dynasty_export_old.zip", age_days=30)
+    _touch(data / "exports" / "archive" / "dynasty_export_new.zip", age_days=2)
+    _touch(base / "exports" / "archive" / "dynasty_export_ancient.zip", age_days=99)
+    _touch(base / "exports" / "archive" / "dynasty_export_fresh.zip", age_days=1)
+    # raw_sources — keep newest 30
+    for i in range(40):
+        _touch(
+            data / "raw_sources" / f"raw_source_snapshot_{i:03d}.json",
+            age_days=40 - i,
+        )
+    # raw/<source>/<year> — keep newest 30 per leaf, sources independent
+    for src in ("ktc", "fantasycalc"):
+        for i in range(35):
+            _touch(
+                data / "raw" / src / "2026" / f"{src}_2026_{i:03d}",
+                age_days=35 - i,
+            )
+    # dynasty_data — 45d age cutoff
+    _touch(data / "dynasty_data_2026-01-01.json", age_days=120)
+    _touch(data / "dynasty_data_2026-05-10.json", age_days=3)
+    # protected — must survive untouched
+    _touch(base / "exports" / "latest" / "dynasty_data.js", age_days=999)
+    _touch(base / "exports" / "latest" / "dynasty_export_latest.zip", age_days=999)
+    _touch(data / "rank_history.jsonl", age_days=999)
+    _touch(data / "identity" / "player_map.json", age_days=999)
+    _touch(data / "ros" / "aggregate" / "history" / "old.json", age_days=999)
+
+
+def test_canonical_fully_purged_but_gitkeep_survives(tmp_path):
+    _build_tree(tmp_path)
+    prune_data_dir(tmp_path, now=NOW)
+    canonical = tmp_path / "data" / "canonical"
+    assert canonical.is_dir()
+    assert (canonical / ".gitkeep").exists()
+    assert not (canonical / "canonical_snapshot_old.json").exists()
+    assert not (canonical / "nested").exists()
+
+
+def test_exports_archive_age_cutoff_both_roots(tmp_path):
+    _build_tree(tmp_path)
+    prune_data_dir(tmp_path, now=NOW)
+    assert not (tmp_path / "data" / "exports" / "archive" / "dynasty_export_old.zip").exists()
+    assert (tmp_path / "data" / "exports" / "archive" / "dynasty_export_new.zip").exists()
+    assert not (tmp_path / "exports" / "archive" / "dynasty_export_ancient.zip").exists()
+    assert (tmp_path / "exports" / "archive" / "dynasty_export_fresh.zip").exists()
+
+
+def test_raw_sources_keep_newest_30(tmp_path):
+    _build_tree(tmp_path)
+    prune_data_dir(tmp_path, now=NOW)
+    remaining = sorted((tmp_path / "data" / "raw_sources").glob("*.json"))
+    assert len(remaining) == retention.RAW_SOURCES_KEEP
+    # newest (highest index) must survive; oldest must be gone
+    names = {p.name for p in remaining}
+    assert "raw_source_snapshot_039.json" in names
+    assert "raw_source_snapshot_000.json" not in names
+
+
+def test_raw_per_source_keep_newest_30_independently(tmp_path):
+    _build_tree(tmp_path)
+    prune_data_dir(tmp_path, now=NOW)
+    for src in ("ktc", "fantasycalc"):
+        leaf = tmp_path / "data" / "raw" / src / "2026"
+        assert len(list(leaf.iterdir())) == retention.RAW_PER_SOURCE_KEEP
+        assert (leaf / f"{src}_2026_034").exists()
+        assert not (leaf / f"{src}_2026_000").exists()
+
+
+def test_dynasty_data_age_cutoff(tmp_path):
+    _build_tree(tmp_path)
+    prune_data_dir(tmp_path, now=NOW)
+    data = tmp_path / "data"
+    assert not (data / "dynasty_data_2026-01-01.json").exists()
+    assert (data / "dynasty_data_2026-05-10.json").exists()
+
+
+def test_protected_paths_never_touched(tmp_path):
+    _build_tree(tmp_path)
+    prune_data_dir(tmp_path, now=NOW)
+    assert (tmp_path / "exports" / "latest" / "dynasty_data.js").exists()
+    assert (tmp_path / "exports" / "latest" / "dynasty_export_latest.zip").exists()
+    assert (tmp_path / "data" / "rank_history.jsonl").exists()
+    assert (tmp_path / "data" / "identity" / "player_map.json").exists()
+    assert (tmp_path / "data" / "ros" / "aggregate" / "history" / "old.json").exists()
+
+
+def test_dry_run_deletes_nothing_but_reports(tmp_path):
+    _build_tree(tmp_path)
+    report = prune_data_dir(tmp_path, now=NOW, dry_run=True)
+    # everything that would be removed is still present
+    assert (tmp_path / "data" / "canonical" / "canonical_snapshot_old.json").exists()
+    assert (tmp_path / "data" / "dynasty_data_2026-01-01.json").exists()
+    assert report.dry_run is True
+    assert report.total_deleted > 0
+    assert report.total_bytes_freed > 0
+
+
+def test_report_accounting_matches_real_run(tmp_path):
+    _build_tree(tmp_path)
+    report = prune_data_dir(tmp_path, now=NOW)
+    assert report.total_errors == 0
+    assert report.total_deleted > 0
+    # 40 raw_sources - 30 kept = 10 deleted
+    rs = next(c for c in report.categories if c.name == "raw_sources")
+    assert rs.deleted == 10
+    assert "reclaimed" in report.summary()
+
+
+def test_missing_dirs_are_noops(tmp_path):
+    report = prune_data_dir(tmp_path, now=NOW)
+    assert report.total_deleted == 0
+    assert report.total_errors == 0
+    assert report.summary().endswith("nothing to prune")
+
+
+def test_symlink_escape_is_refused(tmp_path):
+    _build_tree(tmp_path)
+    outside = tmp_path / "OUTSIDE_secret.txt"
+    outside.write_text("must survive")
+    # An attacker-ish symlink inside a pruned leaf pointing out of root.
+    leaf = tmp_path / "data" / "raw" / "ktc" / "2026"
+    link = leaf / "ktc_2026_999_link"
+    link.symlink_to(outside)
+    os.utime(link, (NOW - 999 * 86_400, NOW - 999 * 86_400), follow_symlinks=False)
+    prune_data_dir(tmp_path, now=NOW)
+    assert outside.exists()
+    assert outside.read_text() == "must survive"
+
+
+def test_containment_guard_blocks_protected_root(tmp_path):
+    # Direct guard check: deleting something resolving into a protected
+    # dir is refused even if a caller passes it.
+    protected = retention._protected_paths(tmp_path)
+    cat = retention.CategoryResult(name="x")
+    target = tmp_path / "data" / "identity" / "player_map.json"
+    _touch(target, age_days=999)
+    retention._delete(
+        target, tmp_path / "data" / "identity", protected, cat, dry_run=False
+    )
+    assert target.exists()
+    assert cat.errors == 1
+    assert cat.deleted == 0


### PR DESCRIPTION
## Summary
- The scraper writes fresh raw snapshots for every source every ~2h with no retention; `data/` had grown to **~2.9 GB** on prod (raw/, raw_sources/, orphaned canonical/, exports/archive/) and was on track to fill the disk → failed scrape writes, session SQLite, and new logins.
- Adds `src/maintenance/retention.py`: an **allow-list-only** pruner run best-effort at the end of a successful scrape.
- Policy: purge orphaned `data/canonical/` (retired pipeline, zero readers/writers); exports-archive zips keep 14d; `dynasty_data_*.json` keep 45d (past the source-history fallback + UI windows); `raw_sources/` and per-source `raw/<src>/<year>/` keep newest 30.
- **Hard-guarded** (containment + protected-path checks, not merely un-globbed): `exports/latest/`, `data/rank_history.jsonl`, `data/identity/`, `data/ros/`.
- A prune failure can never fail a scrape (wrapped best-effort).

## Notes
- No canonical *code* to remove — the offline build/transform/pipeline path and `CANONICAL_DATA_MODE` were already retired upstream; only the orphaned data dir remained.
- rank-history is unaffected: it lives in the self-trimming `data/rank_history.jsonl`, not the JSON snapshots.

## Test plan
- [x] 11 new unit tests: retention math (age + keep-newest), both archive roots, protected-path safety, symlink-escape refusal, containment guard, dry-run, missing-dir no-ops
- [x] Full suite: `pytest tests/ -q` → 2942 passed, 3 skipped, 0 failures
- [ ] Post-deploy: confirm `du -sh data/` drops, `exports/latest/` + `/api/data/rank-history` intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)