### PR TITLE
fix(scrape): reap orphaned Chromium after a timed-out/cancelled scrape

### DIFF
--- a/server.py
+++ b/server.py
@@ -18,6 +18,7 @@ import json
 import math
 import os
 import sys
+import signal
 import threading
 import time
 import logging
@@ -85,6 +86,13 @@ PORT = 8000
 HOST = "0.0.0.0"  # accessible from local network; use "127.0.0.1" for local only
 SCRAPE_STALL_SECONDS = int(os.getenv("SCRAPE_STALL_SECONDS", "900"))
 SCRAPE_RUN_TIMEOUT_SECONDS = int(os.getenv("SCRAPE_RUN_TIMEOUT_SECONDS", "7200"))
+# The async scraper launches a Playwright Chromium without a try/finally,
+# so a run-timeout cancellation skips browser.close() and orphans the
+# Chromium process tree → RAM leak across repeated 2h timeouts → OOM.
+# A single scrape_run_lock guarantees that once the scrape coroutine has
+# exited, any surviving Chromium WE spawned is orphaned, so the finalize
+# path SIGKILLs Chromium descendants of this process.  Set "0" to disable.
+SCRAPE_REAP_ORPHAN_BROWSERS = os.getenv("SCRAPE_REAP_ORPHAN_BROWSERS", "1") != "0"
 # /api/trade/simulate-mc is a pure-Python Monte Carlo (no numpy) run
 # twice for A→B/B→A symmetrization.  On this box: 50k≈0.9s, 200k≈3.9s.
 # It must never run on the event loop unbounded — that freezes every
@@ -844,10 +852,107 @@ def _scrape_success_rate_24h() -> dict:
     }
 
 
+def _looks_like_playwright_chromium(cmdline: str) -> bool:
+    """True for a Playwright-spawned headless Chromium command line.
+
+    Deliberately conservative: requires BOTH a chromium binary token
+    AND an automation/headless marker, so it can't match an unrelated
+    process even before the descendant-scoping guard.
+    """
+    c = cmdline.lower()
+    if "chrome" not in c and "chromium" not in c:
+        return False
+    return (
+        "--headless" in c
+        or "--remote-debugging-" in c
+        or "--remote-debugging-pipe" in c
+        or "/ms-playwright/" in c
+        or "playwright" in c
+    )
+
+
+def _collect_descendant_pids(root_pid: int) -> set[int]:
+    """All transitive child PIDs of ``root_pid`` via /proc (Linux only).
+
+    Uses the ppid field of /proc/<pid>/stat (field after the comm
+    parenthesis) — no kernel CONFIG_PROC_CHILDREN dependency.
+    """
+    children: dict[int, list[int]] = {}
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return set()
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/stat", "rb") as fh:
+                data = fh.read().decode("latin-1")
+        except OSError:
+            continue
+        rparen = data.rfind(")")
+        if rparen == -1:
+            continue
+        fields = data[rparen + 2:].split()
+        try:
+            ppid = int(fields[1])  # fields[0]=state, fields[1]=ppid
+        except (IndexError, ValueError):
+            continue
+        children.setdefault(ppid, []).append(int(entry))
+    out: set[int] = set()
+    stack = [root_pid]
+    while stack:
+        p = stack.pop()
+        for child in children.get(p, ()):
+            if child not in out:
+                out.add(child)
+                stack.append(child)
+    return out
+
+
+def _reap_orphan_browsers(root_pid: int | None = None, match=None) -> int:
+    """SIGKILL orphaned Playwright Chromium descendants of this process.
+
+    Best-effort; never raises.  Scoped to descendants of ``root_pid``
+    (our own PID) so it can never touch unrelated system processes.
+    The scrape that spawned them already exited (single scrape_run_lock),
+    so a graceful shutdown buys nothing — SIGKILL directly, with no
+    sleep, so this stays safe to call from the async finally path.
+    """
+    try:
+        root = os.getpid() if root_pid is None else root_pid
+        predicate = _looks_like_playwright_chromium if match is None else match
+        killed = 0
+        for pid in _collect_descendant_pids(root):
+            try:
+                with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                    cmd = fh.read().replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+            except OSError:
+                continue
+            if not cmd or not predicate(cmd):
+                continue
+            try:
+                os.kill(pid, signal.SIGKILL)
+                killed += 1
+            except OSError:
+                pass
+        return killed
+    except Exception:  # noqa: BLE001 — finalize must never raise
+        return 0
+
+
 def _finalize_scrape_run(worker_id: str) -> None:
     # Guaranteed cleanup path (always called in run_scraper finally).
     if scrape_status.get("worker_id") != worker_id:
         return
+    if SCRAPE_REAP_ORPHAN_BROWSERS:
+        reaped = _reap_orphan_browsers()
+        if reaped:
+            log.warning(
+                "reaped %d orphaned Chromium process(es) after scrape "
+                "(timeout/cancel left them behind)",
+                reaped,
+            )
     if scrape_status.get("running"):
         scrape_status["running"] = False
         if not scrape_status.get("finished_at"):

--- a/tests/api/test_orphan_reaper.py
+++ b/tests/api/test_orphan_reaper.py
@@ -1,0 +1,128 @@
+"""Tests for the orphaned-Chromium reaper.
+
+Safety-critical: this code SIGKILLs processes on the production box.
+The suite pins the conservative cmdline predicate, the descendant
+scoping (it must never select a non-descendant), a real kill of a
+spawned child, and the finalize-path wiring + kill-switch.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+
+import pytest
+
+import server
+
+
+# ── cmdline predicate ────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "/root/.cache/ms-playwright/chromium-1124/chrome-linux/chrome "
+        "--headless --no-sandbox --remote-debugging-pipe",
+        "chromium --headless=new --disable-gpu",
+        "/ms-playwright/chromium-1124/chrome-linux/chrome --type=renderer",
+        "/usr/bin/chrome --remote-debugging-port=0 --headless",
+    ],
+)
+def test_predicate_matches_playwright_chromium(cmd):
+    assert server._looks_like_playwright_chromium(cmd) is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "/home/dynasty/.venvs/trade-calculator/bin/python server.py",
+        "node /app/.next/standalone/server.js",
+        "chrome",  # bare binary, no automation marker → conservative no
+        'bash -c "echo chromium is great"',
+        "sleep 30",
+        "",
+    ],
+)
+def test_predicate_rejects_unrelated(cmd):
+    assert server._looks_like_playwright_chromium(cmd) is False
+
+
+# ── descendant scoping ───────────────────────────────────────────────
+def test_collect_descendants_includes_child_excludes_init():
+    proc = subprocess.Popen(["sleep", "30"])
+    try:
+        time.sleep(0.2)
+        kids = server._collect_descendant_pids(os.getpid())
+        assert proc.pid in kids
+        assert 1 not in kids  # init/systemd is never our descendant
+        assert os.getpid() not in kids  # the root itself is excluded
+    finally:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def test_collect_descendants_bogus_root_is_empty():
+    # A PID that almost certainly has no children (or doesn't exist).
+    assert server._collect_descendant_pids(2**31 - 1) == set()
+
+
+# ── real kill path ───────────────────────────────────────────────────
+def test_reaper_kills_matching_descendant():
+    proc = subprocess.Popen(["sleep", "300"])
+    try:
+        time.sleep(0.2)
+        killed = server._reap_orphan_browsers(
+            match=lambda c: "sleep" in c and "300" in c
+        )
+        assert killed >= 1
+        # Process must actually be dead.
+        assert proc.wait(timeout=5) != 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_reaper_spares_non_matching_descendant():
+    proc = subprocess.Popen(["sleep", "5"])
+    try:
+        time.sleep(0.2)
+        killed = server._reap_orphan_browsers(match=lambda c: False)
+        assert killed == 0
+        assert proc.poll() is None  # still alive
+    finally:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def test_reaper_never_raises_on_bad_root():
+    # Must be best-effort: no descendants, returns 0, no exception.
+    assert server._reap_orphan_browsers(root_pid=2**31 - 1) == 0
+
+
+# ── finalize wiring + kill-switch ────────────────────────────────────
+def test_finalize_invokes_reaper_when_enabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(server, "_reap_orphan_browsers", lambda: calls.append(1) or 0)
+    monkeypatch.setattr(server, "SCRAPE_REAP_ORPHAN_BROWSERS", True)
+    monkeypatch.setitem(server.scrape_status, "worker_id", "wid-test")
+    server._finalize_scrape_run("wid-test")
+    assert calls == [1]
+
+
+def test_finalize_skips_reaper_when_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(server, "_reap_orphan_browsers", lambda: calls.append(1) or 0)
+    monkeypatch.setattr(server, "SCRAPE_REAP_ORPHAN_BROWSERS", False)
+    monkeypatch.setitem(server.scrape_status, "worker_id", "wid-test")
+    server._finalize_scrape_run("wid-test")
+    assert calls == []
+
+
+def test_finalize_wrong_worker_id_is_noop(monkeypatch):
+    calls = []
+    monkeypatch.setattr(server, "_reap_orphan_browsers", lambda: calls.append(1) or 0)
+    monkeypatch.setattr(server, "SCRAPE_REAP_ORPHAN_BROWSERS", True)
+    monkeypatch.setitem(server.scrape_status, "worker_id", "owner")
+    server._finalize_scrape_run("not-the-owner")
+    assert calls == []  # guard returns before the reaper


### PR DESCRIPTION
## Summary
- `Dynasty Scraper.py` uses Playwright's async API but `await browser.close()` is only on the happy path (line ~3727, **no try/finally**). When the `SCRAPE_RUN_TIMEOUT_SECONDS` `asyncio.wait_for` guard fires, `CancelledError` unwinds past `close()`; relying on `async_playwright().__aexit__` during cancellation is the classic orphan-Chromium leak. `_finalize_scrape_run` did **no** process reaping → repeated 2h timeouts leak RAM until OOM.
- Adds a stdlib `/proc` descendant walk + `SIGKILL` of orphaned Chromium, **scoped strictly to descendants of this server PID** — cannot touch unrelated processes. Safe because the single `scrape_run_lock` means any Chromium alive after the scrape coroutine exits is orphaned.
- No `sleep` (direct SIGKILL — the scrape already failed) so it's safe in the async finally path. Best-effort, never raises. `SCRAPE_REAP_ORPHAN_BROWSERS=0` disables.

## Notes
- Source-level try/finally in the 6,875-line scraper would need a risky ~190-line hand reindent; the descendant-scoped reaper fixes the OOM symptom robustly for all cancellation paths with minimal blast radius.

## Test plan
- [x] 18 tests: cmdline predicate (matches headless/playwright chromium, rejects python/node/bare-chrome), descendant scoping (never selects init/self), **real kill** of a spawned `sleep`, finalize wiring + kill-switch + wrong-worker no-op
- [x] Full suite: `pytest tests/ -q` → 2961 passed, 3 skipped, 0 failures
- [ ] Post-deploy: service health green; reaper log line appears only on a real timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)