### PR TITLE
fix(pwa): reload installed PWA on SW update instead of serving stale chunks

### DIFF
--- a/frontend/components/ServiceWorkerRegistrar.jsx
+++ b/frontend/components/ServiceWorkerRegistrar.jsx
@@ -3,32 +3,76 @@
 import { useEffect } from "react";
 
 /**
- * ServiceWorkerRegistrar — registers ``/sw.js`` once per page load.
- *
- * Runs exactly once on mount.  If the browser doesn't support
- * service workers (older Safari, some corporate browser policies),
- * the registration silently no-ops — no error, no fallback UI.
- *
- * The SW handles caching for asset chunks and API-fallback for
- * offline.  It does NOT handle push notifications or background
- * sync; those are future additions.
+ * ServiceWorkerRegistrar — registers ``/sw.js`` and keeps an installed
+ * PWA from getting stuck on a stale bundle after a deploy.
  *
  * Mount inside ``layout.jsx`` so it runs on every route.
+ *
+ * Why the update plumbing matters (iOS PWA):
+ *   ``sw.js`` does ``skipWaiting()`` + ``clients.claim()`` and deletes
+ *   prior caches on ``activate``.  Without a client-side reload, an
+ *   already-open tab keeps its in-memory HTML pointing at the previous
+ *   build's ``/_next/static`` chunk hashes — which the new SW has just
+ *   evicted and the deploy has replaced — so components fail to load
+ *   ("per-source table missing on mobile").  iOS Safari makes this
+ *   worse by delaying SW activation until every PWA tab on the origin
+ *   closes.  This component closes both gaps:
+ *     1. reload once when a new SW takes control (controllerchange),
+ *     2. force a SW update check when the PWA is foregrounded
+ *        (visibilitychange) so a long-lived / backgrounded install
+ *        picks up deploys without needing every tab closed first.
+ *   This is the real fix for the bug the recurring manual
+ *   ``CACHE_VERSION`` bumps in ``sw.js`` were only papering over.
  */
 export default function ServiceWorkerRegistrar() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!("serviceWorker" in navigator)) return;
-    // Register once per page load — the browser handles activation
-    // and upgrades for subsequent versions.  We don't unregister
-    // on unmount because the SW is a page-wide singleton.
-    navigator.serviceWorker
+
+    const sw = navigator.serviceWorker;
+
+    // If the page is already SW-controlled, a later controllerchange
+    // means a NEW version took over → the in-memory HTML now references
+    // evicted chunk hashes, so reload once to pull the fresh bundle.
+    // On a first-ever (uncontrolled) load we deliberately skip this so
+    // the initial activation's controllerchange can't double-load.
+    let reloading = false;
+    const onControllerChange = () => {
+      if (reloading) return;
+      reloading = true;
+      window.location.reload();
+    };
+    const wasControlled = Boolean(sw.controller);
+    if (wasControlled) {
+      sw.addEventListener("controllerchange", onControllerChange);
+    }
+
+    // Foregrounding the PWA forces a SW update check.  Without this an
+    // installed iOS PWA can sit on a stale SW indefinitely (iOS only
+    // activates a waiting SW once every origin tab closes).
+    let registration = null;
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && registration) {
+        registration.update().catch(() => {});
+      }
+    };
+
+    sw
       .register("/sw.js", { scope: "/" })
+      .then((reg) => {
+        registration = reg;
+      })
       .catch(() => {
-        // Silent failure: common causes are DevTools "Bypass for
-        // network" toggles, private browsing in Firefox, or file://
-        // origins.  None of these block the regular app flow.
+        // Silent failure: DevTools "Bypass for network", Firefox
+        // private mode, or file:// origins.  None block the app.
       });
+
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      sw.removeEventListener("controllerchange", onControllerChange);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, []);
   return null;
 }


### PR DESCRIPTION
## Summary
- `sw.js` does `skipWaiting()` + `clients.claim()` and deletes prior caches on `activate`, but `ServiceWorkerRegistrar.jsx` had **no `controllerchange` handler**. When a new SW activated, an already-open tab kept in-memory HTML referencing the previous build's `/_next/static` chunk hashes — evicted by the new SW and replaced by the deploy — so components failed to load ("per-source table missing on mobile"). iOS Safari worsens it (SW activation delayed until all origin tabs close).
- The recurring manual `CACHE_VERSION` bumps (v3→v4→v5, each documented in `sw.js` as an iOS PWA breakage report) were papering over this. This is the root-cause fix.
- `controllerchange` → one-time `location.reload()`, guarded so a first-ever uncontrolled load can't double-load.
- `visibilitychange` → `registration.update()` so a long-lived/backgrounded iOS install picks up deploys without needing every tab closed.
- Listeners cleaned up on unmount.

## Test plan
- [x] `npm run build` — passes incl. bundle-size gate (all pages under budget)
- [x] `npm run test` (vitest) — 29 files, 889 passed
- [ ] Post-deploy: on next deploy, an open tab/PWA auto-reloads once to the fresh bundle (no manual `CACHE_VERSION` bump needed); offline shell + push still work

Note: project has no SW/RTL component-test harness (tracked separately as P1-6); frontend gate here is build + vitest per existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)