### PR TITLE
style: repo-wide ruff format sweep + hard-blocking format gate (phase A1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,14 @@ jobs:
           python -m py_compile server.py "Dynasty Scraper.py"
           python -m py_compile src/api/data_contract.py
 
+      - name: Python format gate (ruff format --check)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # Defense-in-depth mirror of the pr-validation format gate so
+          # a hotfix pushed straight to main can't bypass it.
+          python -m ruff format --check .
+
       - name: Python runtime import gate
         shell: bash
         env:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -57,6 +57,15 @@ jobs:
           python -m py_compile server.py "Dynasty Scraper.py"
           python -m py_compile src/api/data_contract.py
 
+      - name: Python format gate (ruff format --check)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # Deterministic Black-compatible formatter. Hard-blocking is
+          # safe: the repo-wide sweep already landed and the check is
+          # idempotent. Config: pyproject.toml [tool.ruff].
+          python -m ruff format --check .
+
       - name: Python import gate
         shell: bash
         env:

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -110,6 +110,7 @@ except Exception:
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_SCRIPT_DIR = SCRIPT_DIR  # immutable repo/script anchor for local source inputs
 
+
 def _env_int(name, default):
     """Read positive int env var with safe fallback."""
     try:
@@ -120,6 +121,7 @@ def _env_int(name, default):
         pass
     return int(default)
 
+
 def _env_str(name, default=""):
     """Read string env var with safe fallback."""
     raw = os.environ.get(name)
@@ -127,6 +129,7 @@ def _env_str(name, default=""):
         return str(default)
     v = str(raw).strip()
     return v if v else str(default)
+
 
 # Deep coverage targets and caps (tunable via env vars).
 TARGET_OFFENSIVE_POOL = _env_int("TARGET_OFFENSIVE_POOL", 350)
@@ -140,7 +143,12 @@ SITE_CAP_DRAFTSHARKS = _env_int("SITE_CAP_DRAFTSHARKS", 900)
 # The site's API only returns IDP players, but the search box finds offense too.
 # Enable by default so KTC offense players get looked up on IDPTradeCalc.
 IDP_AUTOCOMPLETE_MAX = _env_int("IDP_AUTOCOMPLETE_MAX", 500)
-IDP_AUTOCOMPLETE_ENABLE = _env_str("IDP_AUTOCOMPLETE_ENABLE", "true").strip().lower() in {"1", "true", "yes", "on"}
+IDP_AUTOCOMPLETE_ENABLE = _env_str("IDP_AUTOCOMPLETE_ENABLE", "true").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 TOP_OFF_COVERAGE_AUDIT_N = _env_int("TOP_OFF_COVERAGE_AUDIT_N", 300)
 TOP_IDP_COVERAGE_AUDIT_N = _env_int("TOP_IDP_COVERAGE_AUDIT_N", 250)
 TOP_OFF_MIN_SOURCES = _env_int("TOP_OFF_MIN_SOURCES", 1)
@@ -156,6 +164,7 @@ TOP_IDP_EXPECTED_SITE_KEYS = ("idpTradeCalc",)
 USE_CACHE = False
 CACHE_TTL_HOURS = 4
 CACHE_DIR = os.path.join(SCRIPT_DIR, ".scrape_cache")
+
 
 def get_cached(site_key):
     """Return cached name_map dict if fresh enough, else None."""
@@ -174,6 +183,7 @@ def get_cached(site_key):
         return data
     except Exception:
         return None
+
 
 def set_cache(site_key, name_map):
     """Save name_map to cache."""
@@ -194,6 +204,7 @@ def set_cache(site_key, name_map):
 # ─────────────────────────────────────────
 def retry(max_attempts=3, delay=2, backoff=2, exceptions=(Exception,)):
     """Retry decorator with exponential backoff for async functions."""
+
     def decorator(func):
         @functools.wraps(func)
         async def async_wrapper(*args, **kwargs):
@@ -204,11 +215,14 @@ def retry(max_attempts=3, delay=2, backoff=2, exceptions=(Exception,)):
                 except exceptions as e:
                     last_exc = e
                     if attempt < max_attempts - 1:
-                        wait = delay * (backoff ** attempt)
-                        print(f"  [Retry] {func.__name__} attempt {attempt+1} failed: {e}. "
-                              f"Retrying in {wait}s...")
+                        wait = delay * (backoff**attempt)
+                        print(
+                            f"  [Retry] {func.__name__} attempt {attempt+1} failed: {e}. "
+                            f"Retrying in {wait}s..."
+                        )
                         await asyncio.sleep(wait)
             raise last_exc
+
         @functools.wraps(func)
         def sync_wrapper(*args, **kwargs):
             last_exc = None
@@ -218,14 +232,18 @@ def retry(max_attempts=3, delay=2, backoff=2, exceptions=(Exception,)):
                 except exceptions as e:
                     last_exc = e
                     if attempt < max_attempts - 1:
-                        wait = delay * (backoff ** attempt)
-                        print(f"  [Retry] {func.__name__} attempt {attempt+1} failed: {e}. "
-                              f"Retrying in {wait}s...")
+                        wait = delay * (backoff**attempt)
+                        print(
+                            f"  [Retry] {func.__name__} attempt {attempt+1} failed: {e}. "
+                            f"Retrying in {wait}s..."
+                        )
                         time.sleep(wait)
             raise last_exc
+
         if inspect.iscoroutinefunction(func):
             return async_wrapper
         return sync_wrapper
+
     return decorator
 
 
@@ -241,6 +259,7 @@ def retry(max_attempts=3, delay=2, backoff=2, exceptions=(Exception,)):
 # for now we still scrape exactly one league per run.
 try:
     from src.api import league_registry as _league_registry  # noqa: E402
+
     _registry_league_id = _league_registry.get_sleeper_league_id()
 except Exception:  # noqa: BLE001 — registry is optional at scrape time
     _registry_league_id = None
@@ -272,14 +291,24 @@ ROOKIE_MUST_HAVE_NAMES = []
 ROOKIE_MUST_HAVE_POS_HINTS = {}
 
 _IDP_POS_TOKENS = {
-    "DL": "DL", "DE": "DL", "DT": "DL", "EDGE": "DL", "EDGE/LB": "DL",
-    "LB": "LB", "ILB": "LB", "OLB": "LB",
-    "DB": "DB", "S": "DB", "SAFETY": "DB", "FS": "DB", "SS": "DB",
-    "CB": "DB", "NB": "DB",
+    "DL": "DL",
+    "DE": "DL",
+    "DT": "DL",
+    "EDGE": "DL",
+    "EDGE/LB": "DL",
+    "LB": "LB",
+    "ILB": "LB",
+    "OLB": "LB",
+    "DB": "DB",
+    "S": "DB",
+    "SAFETY": "DB",
+    "FS": "DB",
+    "SS": "DB",
+    "CB": "DB",
+    "NB": "DB",
 }
-_OFF_POS_TOKENS = {
-    "QB": "QB", "RB": "RB", "WR": "WR", "TE": "TE", "FB": "RB"
-}
+_OFF_POS_TOKENS = {"QB": "QB", "RB": "RB", "WR": "WR", "TE": "TE", "FB": "RB"}
+
 
 def _extract_rookie_pos_hint(raw_line):
     line = str(raw_line or "").strip()
@@ -300,12 +329,14 @@ def _extract_rookie_pos_hint(raw_line):
                 return _OFF_POS_TOKENS[token]
     return ""
 
+
 def _must_have_rookie_bucket(name):
     norm = normalize_lookup_name(name) if name else ""
     hint = ROOKIE_MUST_HAVE_POS_HINTS.get(norm, "")
     if hint in {"QB", "RB", "WR", "TE", "DL", "LB", "DB"}:
         return hint
     return ""
+
 
 def load_rookie_must_have(path):
     """Load newline-delimited rookie names, deduped after cleaning."""
@@ -345,11 +376,48 @@ def load_rookie_must_have(path):
 
 # Common team abbreviations appended directly to names on some sites
 _TEAM_CODES = {
-    "ARI","ATL","BAL","BUF","CAR","CHI","CIN","CLE","DAL","DEN",
-    "DET","GB","HOU","IND","JAC","JAX","KC","LAC","LAR","LV",
-    "MIA","MIN","NE","NO","NYG","NYJ","PHI","PIT","SEA","SF",
-    "TB","TEN","WAS","FA","LVR","GBP","SFO","TBB","KCC","NEP",
+    "ARI",
+    "ATL",
+    "BAL",
+    "BUF",
+    "CAR",
+    "CHI",
+    "CIN",
+    "CLE",
+    "DAL",
+    "DEN",
+    "DET",
+    "GB",
+    "HOU",
+    "IND",
+    "JAC",
+    "JAX",
+    "KC",
+    "LAC",
+    "LAR",
+    "LV",
+    "MIA",
+    "MIN",
+    "NE",
+    "NO",
+    "NYG",
+    "NYJ",
+    "PHI",
+    "PIT",
+    "SEA",
+    "SF",
+    "TB",
+    "TEN",
+    "WAS",
+    "FA",
+    "LVR",
+    "GBP",
+    "SFO",
+    "TBB",
+    "KCC",
+    "NEP",
 }
+
 
 def clean_name(raw):
     """Strip position/team suffixes, generational suffixes, and inline team codes.
@@ -358,36 +426,35 @@ def clean_name(raw):
         return ""
     name = str(raw).strip()
     # Decode literal unicode escapes like \u0027 → '
-    if '\\u' in name:
+    if "\\u" in name:
         try:
-            name = name.encode('utf-8').decode('unicode_escape')
+            name = name.encode("utf-8").decode("unicode_escape")
         except Exception:
-            name = re.sub(r'\\u([0-9a-fA-F]{4})',
-                          lambda m: chr(int(m.group(1), 16)), name)
+            name = re.sub(r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), name)
     # Trim ranking prefixes and misc scrape markers.
     name = re.sub(r"^\s*#?\d+\s*[\).:-]\s*", "", name)
     name = re.sub(r"\s*[\*\u2020\u2021]+\s*$", "", name)
     # Strip trailing parenthetical notes: "X Player (IR)".
     name = re.sub(r"\s*\([^)]*\)\s*$", "", name).strip()
     # Normalize various apostrophe/quote chars to standard apostrophe
-    name = re.sub(r'[\u2018\u2019\u0060\u00B4\u0027\u2032]', "'", name)
+    name = re.sub(r"[\u2018\u2019\u0060\u00B4\u0027\u2032]", "'", name)
     # Convert "Last, First" to "First Last" where applicable.
     if "," in name:
         m = re.match(r"^\s*([A-Za-z.'\- ]+),\s*([A-Za-z.'\- ]+)\s*$", name)
         if m:
             name = f"{m.group(2).strip()} {m.group(1).strip()}".strip()
     # Strip position/team tag after name (e.g. "Caleb Williams QB CHI")
-    name = re.split(r'\s+(QB|RB|WR|TE|K|DEF|DST|OL|LB|DB|DL|DE|DT|CB|S|PK)\b', name)[0].strip()
+    name = re.split(r"\s+(QB|RB|WR|TE|K|DEF|DST|OL|LB|DB|DL|DE|DT|CB|S|PK)\b", name)[0].strip()
     # Strip team code glued to end (e.g. "Caleb WilliamsCHI")
-    m = re.match(r'^(.+?)([A-Z]{2,3})$', name)
+    m = re.match(r"^(.+?)([A-Z]{2,3})$", name)
     if m and m.group(2) in _TEAM_CODES and len(m.group(1).strip()) > 3:
         name = m.group(1).strip()
     # Strip generational suffixes: Jr., Sr., II, III, IV, V (with or without period/comma)
-    name = re.sub(r'[,\s]+(Jr.?|Sr.?|I{2,3}|IV|V|VI)\s*$', '', name, flags=re.IGNORECASE).strip()
+    name = re.sub(r"[,\s]+(Jr.?|Sr.?|I{2,3}|IV|V|VI)\s*$", "", name, flags=re.IGNORECASE).strip()
     # Normalize periods in initials: "T.J." → "T.J.", but also allow matching "TJ"
     # Don't strip periods here — handle in matching instead
     # Collapse any double spaces
-    name = re.sub(r'\s{2,}', ' ', name)
+    name = re.sub(r"\s{2,}", " ", name)
     return name
 
 
@@ -413,15 +480,15 @@ def normalize_lookup_name(raw):
         initial_run.append(parts[idx])
         idx += 1
     if len(initial_run) >= 2:
-        merged = ''.join(initial_run)
-        s = ' '.join([merged] + parts[idx:])
+        merged = "".join(initial_run)
+        s = " ".join([merged] + parts[idx:])
     return s
 
 
 def _tokenize(name):
     """Lowercase, normalize hyphens, split, sort tokens for order-independent comparison."""
     # Normalize hyphens to spaces, remove periods for matching: "T.J." → "tj", "Amon-Ra" → "amon ra"
-    normalized = name.lower().replace('-', ' ').replace('.', '')
+    normalized = name.lower().replace("-", " ").replace(".", "")
     return sorted(normalized.split())
 
 
@@ -452,7 +519,7 @@ def similarity(a, b):
     adjustment = 0.0
     if len(a_parts) >= 2 and len(b_parts) >= 2:
         last_a, last_b = a_parts[-1], b_parts[-1]
-        first_a, first_b = a_parts[0].rstrip('.'), b_parts[0].rstrip('.')
+        first_a, first_b = a_parts[0].rstrip("."), b_parts[0].rstrip(".")
 
         if last_a == last_b and len(last_a) > 2:
             # Same last name — check first names carefully
@@ -464,7 +531,9 @@ def similarity(a, b):
                 # Prefix-subset penalty: one first name is a strict prefix
                 # of the other with 2+ extra chars → distinct people.
                 # e.g. "james"/"jameson", "chris"/"christian"
-                shorter_f, longer_f = (first_a, first_b) if len(first_a) <= len(first_b) else (first_b, first_a)
+                shorter_f, longer_f = (
+                    (first_a, first_b) if len(first_a) <= len(first_b) else (first_b, first_a)
+                )
                 if longer_f.startswith(shorter_f) and (len(longer_f) - len(shorter_f)) >= 2:
                     adjustment = -0.20
                 else:
@@ -487,17 +556,34 @@ def similarity(a, b):
 
 # ── Position-family normalization for cross-source matching ──────────────
 _POS_FAMILY_MAP = {
-    "DE": "DL", "DT": "DL", "EDGE": "DL", "NT": "DL", "DL": "DL",
-    "CB": "DB", "S": "DB", "FS": "DB", "SS": "DB", "DB": "DB",
-    "OLB": "LB", "ILB": "LB", "MLB": "LB", "LB": "LB",
-    "QB": "QB", "RB": "RB", "WR": "WR", "TE": "TE", "K": "K",
+    "DE": "DL",
+    "DT": "DL",
+    "EDGE": "DL",
+    "NT": "DL",
+    "DL": "DL",
+    "CB": "DB",
+    "S": "DB",
+    "FS": "DB",
+    "SS": "DB",
+    "DB": "DB",
+    "OLB": "LB",
+    "ILB": "LB",
+    "MLB": "LB",
+    "LB": "LB",
+    "QB": "QB",
+    "RB": "RB",
+    "WR": "WR",
+    "TE": "TE",
+    "K": "K",
 }
+
 
 def _pos_family(pos_raw):
     """Normalize a position to its family (DL, DB, LB, QB, RB, WR, TE)."""
     if not pos_raw:
         return ""
     return _POS_FAMILY_MAP.get(pos_raw.strip().upper(), pos_raw.strip().upper())
+
 
 def _get_sleeper_pos(name):
     """Look up a player's position from SLEEPER_ROSTER_DATA (if available)."""
@@ -514,6 +600,7 @@ def _get_sleeper_pos(name):
         if k.lower() == nl:
             return _pos_family(v)
     return ""
+
 
 def _positions_compatible(name_a, name_b):
     """Check whether two player names have compatible positions.
@@ -546,6 +633,7 @@ def best_match(target, candidates, threshold=0.78, match_guard=None):
     if DEBUG and best and best_score >= threshold:
         print(f"    ✓ '{target}' → '{best}' ({best_score:.2f})")
     return best if best_score >= threshold else None
+
 
 def _name_tokens(name):
     """Normalize a name into ordered alpha tokens for conservative merge checks."""
@@ -617,6 +705,8 @@ def _is_safe_name_merge(src_name, dst_name):
         return True
 
     return False
+
+
 def match_all(players, name_map, results, site_key=None):
     """Match a list of player names against a scraped name->value dict.
     If site_key is given, stores the full name_map in FULL_DATA for JSON export.
@@ -627,10 +717,10 @@ def match_all(players, name_map, results, site_key=None):
     # Build a period-normalized index for matching "TJ Watt" ↔ "T.J. Watt"
     norm_index = {}
     lookup_index = {}
-    initial_index = {}       # (first_initial, remaining_name_tokens)
+    initial_index = {}  # (first_initial, remaining_name_tokens)
     initial_last_index = {}  # (first_initial, last_name)
     for k in name_map:
-        norm_key = k.lower().replace('.', '').replace('-', ' ').strip()
+        norm_key = k.lower().replace(".", "").replace("-", " ").strip()
         if norm_key not in norm_index:
             norm_index[norm_key] = k
         lookup_key = normalize_lookup_name(k)
@@ -639,7 +729,7 @@ def match_all(players, name_map, results, site_key=None):
         parts = normalize_lookup_name(k).split()
         if len(parts) >= 2:
             initial = parts[0][0].lower()
-            remain = ' '.join(parts[1:])
+            remain = " ".join(parts[1:])
             initial_index.setdefault((initial, remain), k)
             initial_last_index.setdefault((initial, parts[-1]), k)
 
@@ -651,7 +741,7 @@ def match_all(players, name_map, results, site_key=None):
                 print(f"    ✓ '{player}' → exact match ({name_map[player]})")
             continue
         # Try period-normalized match (T.J. ↔ TJ)
-        player_norm = player.lower().replace('.', '').replace('-', ' ').strip()
+        player_norm = player.lower().replace(".", "").replace("-", " ").strip()
         if player_norm in norm_index:
             orig_key = norm_index[player_norm]
             results[player] = name_map[orig_key]
@@ -670,14 +760,16 @@ def match_all(players, name_map, results, site_key=None):
         p_parts = player_lookup.split() if player_lookup else []
         if len(p_parts) >= 2:
             p_initial = p_parts[0][0].lower()
-            p_remaining = ' '.join(p_parts[1:])
+            p_remaining = " ".join(p_parts[1:])
             ikey = (p_initial, p_remaining)
             if ikey in initial_index:
                 orig_key = initial_index[ikey]
                 if _positions_compatible(player, orig_key):
                     results[player] = name_map[orig_key]
                     if DEBUG:
-                        print(f"    ✓ '{player}' → initial match '{orig_key}' ({name_map[orig_key]})")
+                        print(
+                            f"    ✓ '{player}' → initial match '{orig_key}' ({name_map[orig_key]})"
+                        )
                     continue
             # Looser initial+last fallback for names with middle tokens.
             ikey_last = (p_initial, p_parts[-1])
@@ -687,7 +779,9 @@ def match_all(players, name_map, results, site_key=None):
                 if _is_safe_name_merge(player, orig_key):
                     results[player] = name_map[orig_key]
                     if DEBUG:
-                        print(f"    ✓ '{player}' → initial+last match '{orig_key}' ({name_map[orig_key]})")
+                        print(
+                            f"    ✓ '{player}' → initial+last match '{orig_key}' ({name_map[orig_key]})"
+                        )
                     continue
         # Fuzzy match
         m = best_match(player, name_map.keys(), match_guard=_is_safe_name_merge)
@@ -721,7 +815,10 @@ _KTC_BLOCKER: str | None = None
 
 # KTC crowd DB league constraints (user-specific)
 KTC_CROWD_ALLOWED_TEAMS = {10, 12, 14}
-KTC_CROWD_ALLOWED_TEP_LEVELS = {1, 2}  # accept TE+ and TE++ league signal — bool-only TEP settings normalize to level 1 even for genuinely-TE++ leagues, so restricting to {2} drops valid samples.  Rankings URL is fetched at TE++ exclusively.
+KTC_CROWD_ALLOWED_TEP_LEVELS = {
+    1,
+    2,
+}  # accept TE+ and TE++ league signal — bool-only TEP settings normalize to level 1 even for genuinely-TE++ leagues, so restricting to {2} drops valid samples.  Rankings URL is fetched at TE++ exclusively.
 
 
 def compute_max(name_map):
@@ -732,15 +829,12 @@ def compute_max(name_map):
     step (raw_value / max_value), which would produce Infinity/NaN
     and poison MetaValue calculations.
     """
-    vals = [v for v in name_map.values()
-            if v is not None and isinstance(v, (int, float)) and v > 0]
+    vals = [v for v in name_map.values() if v is not None and isinstance(v, (int, float)) and v > 0]
     return max(vals) if vals else 1  # ← was 0, now 1
 
 
 _SLEEPER_CACHE_PATH = os.path.join(SCRIPT_DIR, "data", "sleeper_last_good.json")
-_SLEEPER_STAMP_PATH = os.path.join(
-    SCRIPT_DIR, "data", "scrape_state", "sleeper_last_success"
-)
+_SLEEPER_STAMP_PATH = os.path.join(SCRIPT_DIR, "data", "scrape_state", "sleeper_last_success")
 
 
 def _save_sleeper_snapshot(roster_data):
@@ -792,8 +886,7 @@ def fetch_sleeper_rosters(league_id):
     Returns (player_names_list, roster_data_for_json)."""
     _req = requests
 
-    VALID_POSITIONS = {"QB", "RB", "WR", "TE", "K", "DEF",
-                       "LB", "DL", "DE", "DT", "CB", "S", "DB"}
+    VALID_POSITIONS = {"QB", "RB", "WR", "TE", "K", "DEF", "LB", "DL", "DE", "DT", "CB", "S", "DB"}
 
     print(f"Fetching Sleeper player database...")
     try:
@@ -809,7 +902,8 @@ def fetch_sleeper_rosters(league_id):
     print(f"Fetching rosters for league {league_id}...")
     try:
         rosters_resp = _req.get(
-            f"https://api.sleeper.app/v1/league/{league_id}/rosters", timeout=15)
+            f"https://api.sleeper.app/v1/league/{league_id}/rosters", timeout=15
+        )
         rosters_resp.raise_for_status()
         rosters = rosters_resp.json()
     except Exception as e:
@@ -823,8 +917,7 @@ def fetch_sleeper_rosters(league_id):
     # name (Codex PR #437 P2).
     legacy_name_map = {}
     try:
-        users_resp = _req.get(
-            f"https://api.sleeper.app/v1/league/{league_id}/users", timeout=15)
+        users_resp = _req.get(f"https://api.sleeper.app/v1/league/{league_id}/users", timeout=15)
         users_resp.raise_for_status()
         for u in users_resp.json():
             uid = u.get("user_id")
@@ -842,8 +935,7 @@ def fetch_sleeper_rosters(league_id):
     roster_positions = []
     league_settings = {}
     try:
-        league_resp = _req.get(
-            f"https://api.sleeper.app/v1/league/{league_id}", timeout=10)
+        league_resp = _req.get(f"https://api.sleeper.app/v1/league/{league_id}", timeout=10)
         league_resp.raise_for_status()
         league_info = league_resp.json()
         league_name = league_info.get("name", "")
@@ -905,7 +997,9 @@ def fetch_sleeper_rosters(league_id):
                 owner_to_roster_id[str(oid)] = rid
             roster_name_by_id[rid] = user_map.get(oid, f"Team {rid}")
     roster_id_set = set(roster_ids)
-    league_size_for_tiers = _safe_int((league_settings or {}).get("num_teams")) or len(roster_ids) or 12
+    league_size_for_tiers = (
+        _safe_int((league_settings or {}).get("num_teams")) or len(roster_ids) or 12
+    )
     league_size_for_tiers = max(3, int(league_size_for_tiers))
 
     def _slot_to_tier_label(slot):
@@ -939,10 +1033,7 @@ def fetch_sleeper_rosters(league_id):
     # represented as 2026 1.03 instead of only Early/Mid/Late style labels.
     draft_slot_by_origin = {}  # (season, original_roster_id) -> slot
     try:
-        drafts_resp = _req.get(
-            f"https://api.sleeper.app/v1/league/{league_id}/drafts",
-            timeout=15
-        )
+        drafts_resp = _req.get(f"https://api.sleeper.app/v1/league/{league_id}/drafts", timeout=15)
         if drafts_resp.status_code == 200:
             drafts_json = drafts_resp.json()
             if isinstance(drafts_json, list):
@@ -955,8 +1046,7 @@ def fetch_sleeper_rosters(league_id):
                     draft_detail = {}
                     try:
                         detail_resp = _req.get(
-                            f"https://api.sleeper.app/v1/draft/{draft_id}",
-                            timeout=15
+                            f"https://api.sleeper.app/v1/draft/{draft_id}", timeout=15
                         )
                         if detail_resp.status_code == 200:
                             dd = detail_resp.json()
@@ -973,7 +1063,11 @@ def fetch_sleeper_rosters(league_id):
                             if rid in roster_id_set and isinstance(slot_num, int) and slot_num > 0:
                                 draft_slot_by_origin[(season, rid)] = slot_num
 
-                    slot_to_roster = draft_detail.get("slot_to_roster_id") or draft.get("slot_to_roster_id") or {}
+                    slot_to_roster = (
+                        draft_detail.get("slot_to_roster_id")
+                        or draft.get("slot_to_roster_id")
+                        or {}
+                    )
                     if isinstance(slot_to_roster, dict):
                         for slot, rid_val in slot_to_roster.items():
                             slot_num = _safe_int(slot)
@@ -986,8 +1080,7 @@ def fetch_sleeper_rosters(league_id):
     traded_picks = []
     try:
         tp_resp = _req.get(
-            f"https://api.sleeper.app/v1/league/{league_id}/traded_picks",
-            timeout=15
+            f"https://api.sleeper.app/v1/league/{league_id}/traded_picks", timeout=15
         )
         if tp_resp.status_code == 200:
             tp_json = tp_resp.json()
@@ -1003,7 +1096,8 @@ def fetch_sleeper_rosters(league_id):
         owner_rid = _safe_int(tp.get("owner_id"))
         if (
             season in pick_years
-            and isinstance(round_num, int) and 1 <= round_num <= draft_rounds
+            and isinstance(round_num, int)
+            and 1 <= round_num <= draft_rounds
             and origin_rid in roster_id_set
             and owner_rid in roster_id_set
         ):
@@ -1033,20 +1127,24 @@ def fetch_sleeper_rosters(league_id):
             display_label = f"{base_label} (from {from_team})"
 
         team_pick_assets.setdefault(owner_rid, []).append(display_label)
-        team_pick_details.setdefault(owner_rid, []).append({
-            "season": season,
-            "round": round_num,
-            "fromRosterId": origin_rid,
-            "fromTeam": from_team,
-            "ownerRosterId": owner_rid,
-            "slot": slot_num if isinstance(slot_num, int) else None,
-            "label": display_label,
-            "baseLabel": base_label,
-        })
+        team_pick_details.setdefault(owner_rid, []).append(
+            {
+                "season": season,
+                "round": round_num,
+                "fromRosterId": origin_rid,
+                "fromTeam": from_team,
+                "ownerRosterId": owner_rid,
+                "slot": slot_num if isinstance(slot_num, int) else None,
+                "label": display_label,
+                "baseLabel": base_label,
+            }
+        )
 
     if team_pick_assets:
         total_pick_assets = sum(len(v) for v in team_pick_assets.values())
-        print(f"  [Sleeper] Computed {total_pick_assets} future pick assets ({draft_rounds} rounds, years {pick_years})")
+        print(
+            f"  [Sleeper] Computed {total_pick_assets} future pick assets ({draft_rounds} rounds, years {pick_years})"
+        )
 
     for roster in rosters:
         owner_id = roster.get("owner_id", "")
@@ -1061,8 +1159,7 @@ def fetch_sleeper_rosters(league_id):
             p = all_nfl.get(pid)
             if not p:
                 continue
-            full = (p.get("full_name")
-                    or f"{p.get('first_name','')} {p.get('last_name','')}".strip())
+            full = p.get("full_name") or f"{p.get('first_name','')} {p.get('last_name','')}".strip()
             raw_pos = p.get("position", "") or ""
             # Sleeper exposes ``fantasy_positions`` as the list of
             # eligible slots; ``position`` is just the primary. For
@@ -1074,9 +1171,9 @@ def fetch_sleeper_rosters(league_id):
             # "DE", "CB", etc.) pass through untouched so offense rows
             # and the fine-grained IDP tokens downstream code may
             # still read stay intact.
-            fp_list = p.get("fantasy_positions") if isinstance(
-                p.get("fantasy_positions"), list
-            ) else None
+            fp_list = (
+                p.get("fantasy_positions") if isinstance(p.get("fantasy_positions"), list) else None
+            )
             pos = raw_pos
             if fp_list and len(fp_list) >= 2:
                 resolved_family = _resolve_idp_position(fp_list)
@@ -1106,32 +1203,34 @@ def fetch_sleeper_rosters(league_id):
                     elif cn not in position_collisions:
                         position_map[cn] = pos
 
-        teams.append({
-            "name": team_name,
-            # Backward-compat only — never rendered.  See legacy_name_map.
-            "sleeperTeamName": legacy_name_map.get(
-                owner_id, f"Team {roster.get('roster_id', '?')}"
-            ),
-            "roster_id": roster_id,
-            # Stable Sleeper user id for the current owner of this roster.
-            # The frontend uses ownerId (not roster_id) as the aggregation
-            # key for trade history so an orphaned roster that changes
-            # hands across seasons does not attribute the previous
-            # manager's trades to the new one.
-            "ownerId": str(owner_id) if owner_id else "",
-            "players": sorted(team_players),
-            "playerIds": sorted(team_player_ids),
-            "picks": sorted(team_pick_assets.get(roster_id_int, []), key=_pick_sort_key),
-            "pickDetails": sorted(
-                team_pick_details.get(roster_id_int, []),
-                key=lambda d: (
-                    int(d.get("season", 9999)),
-                    int(d.get("round", 9)),
-                    int(d.get("slot", 99)) if d.get("slot") is not None else 99,
-                    str(d.get("fromTeam", ""))
-                )
-            ),
-        })
+        teams.append(
+            {
+                "name": team_name,
+                # Backward-compat only — never rendered.  See legacy_name_map.
+                "sleeperTeamName": legacy_name_map.get(
+                    owner_id, f"Team {roster.get('roster_id', '?')}"
+                ),
+                "roster_id": roster_id,
+                # Stable Sleeper user id for the current owner of this roster.
+                # The frontend uses ownerId (not roster_id) as the aggregation
+                # key for trade history so an orphaned roster that changes
+                # hands across seasons does not attribute the previous
+                # manager's trades to the new one.
+                "ownerId": str(owner_id) if owner_id else "",
+                "players": sorted(team_players),
+                "playerIds": sorted(team_player_ids),
+                "picks": sorted(team_pick_assets.get(roster_id_int, []), key=_pick_sort_key),
+                "pickDetails": sorted(
+                    team_pick_details.get(roster_id_int, []),
+                    key=lambda d: (
+                        int(d.get("season", 9999)),
+                        int(d.get("round", 9)),
+                        int(d.get("slot", 99)) if d.get("slot") is not None else 99,
+                        str(d.get("fromTeam", "")),
+                    ),
+                ),
+            }
+        )
 
     # Position overrides: prefer non-LB for DL/LB hybrids, force Travis Hunter → WR
     POSITION_OVERRIDES = {
@@ -1144,13 +1243,11 @@ def fetch_sleeper_rosters(league_id):
 
     if position_collisions:
         preview = ", ".join(
-            f"{k} ({'/'.join(sorted(v))})"
-            for k, v in list(position_collisions.items())[:5]
+            f"{k} ({'/'.join(sorted(v))})" for k, v in list(position_collisions.items())[:5]
         )
         print(
             f"  [Sleeper] Dropped {len(position_collisions)} colliding position entries: {preview}"
         )
-
 
     teams.sort(key=lambda t: t["name"])
 
@@ -1169,9 +1266,12 @@ def fetch_sleeper_rosters(league_id):
     # ── Fetch rolling 1-year trades from Sleeper API ──
     trades = []
     trade_window_days = max(30, _env_int("SLEEPER_TRADE_HISTORY_DAYS", 365))
-    trade_cutoff_dt = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=trade_window_days)
+    trade_cutoff_dt = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        days=trade_window_days
+    )
     trade_cutoff_ms = int(trade_cutoff_dt.timestamp() * 1000)
     try:
+
         def _normalize_tx_ts(v):
             ts = _safe_int(v)
             if not isinstance(ts, int) or ts <= 0:
@@ -1189,10 +1289,7 @@ def fetch_sleeper_rosters(league_id):
                 seen.add(cur)
                 out.append(cur)
                 try:
-                    li_resp = _req.get(
-                        f"https://api.sleeper.app/v1/league/{cur}",
-                        timeout=10
-                    )
+                    li_resp = _req.get(f"https://api.sleeper.app/v1/league/{cur}", timeout=10)
                     if li_resp.status_code != 200:
                         break
                     li_json = li_resp.json()
@@ -1220,12 +1317,10 @@ def fetch_sleeper_rosters(league_id):
             rid_to_owner_id = {}
             try:
                 l_rosters_resp = _req.get(
-                    f"https://api.sleeper.app/v1/league/{target_league_id}/rosters",
-                    timeout=12
+                    f"https://api.sleeper.app/v1/league/{target_league_id}/rosters", timeout=12
                 )
                 l_users_resp = _req.get(
-                    f"https://api.sleeper.app/v1/league/{target_league_id}/users",
-                    timeout=12
+                    f"https://api.sleeper.app/v1/league/{target_league_id}/users", timeout=12
                 )
                 if l_rosters_resp.status_code != 200:
                     return rid_to_name, rid_to_owner_id
@@ -1296,7 +1391,11 @@ def fetch_sleeper_rosters(league_id):
 
             base_label = None
             if isinstance(season, int) and isinstance(round_num, int) and round_num > 0:
-                ident = pick_identity.get((season, round_num, origin_rid)) if isinstance(origin_rid, int) else None
+                ident = (
+                    pick_identity.get((season, round_num, origin_rid))
+                    if isinstance(origin_rid, int)
+                    else None
+                )
                 if isinstance(ident, dict):
                     base_label = str(ident.get("baseLabel") or "").strip() or None
                     if not from_team:
@@ -1333,7 +1432,7 @@ def fetch_sleeper_rosters(league_id):
                 try:
                     tx_resp = _req.get(
                         f"https://api.sleeper.app/v1/league/{target_league_id}/transactions/{week}",
-                        timeout=10
+                        timeout=10,
                     )
                     if tx_resp.status_code != 200:
                         continue
@@ -1385,7 +1484,9 @@ def fetch_sleeper_rosters(league_id):
                         sides = []
                         for rid in roster_ids:
                             rid_key = rid if rid in rid_to_name else _safe_int(rid)
-                            team_name = rid_to_name.get(rid_key, rid_to_name.get(str(rid), f"Team {rid}"))
+                            team_name = rid_to_name.get(
+                                rid_key, rid_to_name.get(str(rid), f"Team {rid}")
+                            )
                             # Resolve the historical owner_id for this
                             # roster in the trade's source league so
                             # aggregation can key by human identity,
@@ -1400,21 +1501,25 @@ def fetch_sleeper_rosters(league_id):
                             )
                             got = team_got.get(rid, [])
                             gave = team_gave.get(rid, [])
-                            sides.append({
-                                "team": team_name,
-                                "rosterId": rid,
-                                "ownerId": owner_id_hist,
-                                "got": got,
-                                "gave": gave,
-                            })
+                            sides.append(
+                                {
+                                    "team": team_name,
+                                    "rosterId": rid,
+                                    "ownerId": owner_id_hist,
+                                    "got": got,
+                                    "gave": gave,
+                                }
+                            )
 
                         if sides:
-                            trades.append({
-                                "leagueId": str(target_league_id),
-                                "week": week,
-                                "timestamp": created,
-                                "sides": sides,
-                            })
+                            trades.append(
+                                {
+                                    "leagueId": str(target_league_id),
+                                    "week": week,
+                                    "timestamp": created,
+                                    "sides": sides,
+                                }
+                            )
                 except Exception:
                     continue
 
@@ -1472,10 +1577,7 @@ if SLEEPER_LEAGUE_ID:
         _cached_rd, _cache_age_h = _load_sleeper_snapshot()
         if _cached_rd:
             SLEEPER_ROSTER_DATA = _cached_rd
-            _age_txt = (
-                f"{_cache_age_h:.1f}h old" if _cache_age_h is not None
-                else "age unknown"
-            )
+            _age_txt = f"{_cache_age_h:.1f}h old" if _cache_age_h is not None else "age unknown"
             print(
                 "  [Sleeper] live fetch failed/empty — using cached "
                 f"snapshot ({_age_txt}); success NOT stamped"
@@ -1491,10 +1593,7 @@ if SLEEPER_LEAGUE_ID:
 _players_file = os.path.join(SCRIPT_DIR, "players.txt")
 if os.path.exists(_players_file):
     with open(_players_file, "r", encoding="utf-8") as _f:
-        PLAYERS = [
-            line.strip() for line in _f
-            if line.strip() and not line.strip().startswith("#")
-        ]
+        PLAYERS = [line.strip() for line in _f if line.strip() and not line.strip().startswith("#")]
     if not PLAYERS:
         print("  [Warning] players.txt is empty — using defaults")
         PLAYERS = _DEFAULT_PLAYERS
@@ -1506,27 +1605,29 @@ else:
 
 ROOKIE_MUST_HAVE_NAMES = load_rookie_must_have(ROOKIE_MUST_HAVE_FILE)
 if ROOKIE_MUST_HAVE_NAMES:
-    print(f"Loaded {len(ROOKIE_MUST_HAVE_NAMES)} must-have rookies from {os.path.basename(ROOKIE_MUST_HAVE_FILE)}")
+    print(
+        f"Loaded {len(ROOKIE_MUST_HAVE_NAMES)} must-have rookies from {os.path.basename(ROOKIE_MUST_HAVE_FILE)}"
+    )
 
 SITES = {
-    "KTC":          True,
-    "FantasyCalc":  False,
+    "KTC": True,
+    "FantasyCalc": False,
     "DynastyDaddy": False,
-    "FantasyPros":  False,
-    "DraftSharks":  False,
-    "Yahoo":        False,
+    "FantasyPros": False,
+    "DraftSharks": False,
+    "Yahoo": False,
     "DynastyNerds": False,
-    "DLF":          False,
+    "DLF": False,
     "IDPTradeCalc": True,
-    "Flock":        False,
+    "Flock": False,
     # IDP-specific sites — disabled in scope reduction
-    "DraftSharks_IDP":  False,
-    "FantasyPros_IDP":  False,
+    "DraftSharks_IDP": False,
+    "FantasyPros_IDP": False,
 }
 
 SUPERFLEX = True
 TEP = True
-DEBUG     = True
+DEBUG = True
 
 # Normalize PLAYERS list at startup
 PLAYERS = [clean_name(p) for p in PLAYERS]
@@ -1590,8 +1691,12 @@ async def safe_goto(page, urls, label, wait_ms=3000):
             if resp and resp.status == 503:
                 if "TLS_error" in body_snippet or "TLSV1" in body_snippet:
                     last_blocker = "proxy_tls_incompatible"
-                    print(f"  [{label}] 503 — proxy TLS handshake failure (site requires newer TLS)")
-                elif "cloudflare" in body_snippet.lower() or "just a moment" in body_snippet.lower():
+                    print(
+                        f"  [{label}] 503 — proxy TLS handshake failure (site requires newer TLS)"
+                    )
+                elif (
+                    "cloudflare" in body_snippet.lower() or "just a moment" in body_snippet.lower()
+                ):
                     last_blocker = "cloudflare_challenge"
                     print(f"  [{label}] 503 — Cloudflare challenge page")
                 else:
@@ -1624,6 +1729,7 @@ async def safe_goto(page, urls, label, wait_ms=3000):
 
 class _GotoResult:
     """Result of safe_goto that is falsy when ok=False but carries metadata."""
+
     __slots__ = ("ok", "status", "blocker")
 
     def __init__(self, ok, status, blocker):
@@ -1700,8 +1806,16 @@ async def extract_tables(page, label):
                 if not vt:
                     continue
             else:
-                nm = next((t for t in texts if re.search(r"[A-Za-z]{3}", t) and len(t) > 4
-                           and not re.match(r"^\d+\.?\d*$", t)), "")
+                nm = next(
+                    (
+                        t
+                        for t in texts
+                        if re.search(r"[A-Za-z]{3}", t)
+                        and len(t) > 4
+                        and not re.match(r"^\d+\.?\d*$", t)
+                    ),
+                    "",
+                )
                 vt = ""
                 for t in reversed(texts):
                     try:
@@ -1721,6 +1835,7 @@ async def extract_tables(page, label):
                 pass
 
     return name_map
+
 
 async def page_dump(page, label, limit=2500):
     """Dump first N chars of page body text for debugging."""
@@ -1742,13 +1857,21 @@ async def page_dump(page, label, limit=2500):
 # rotated naming a few times and the cost of an extra .get() lookup
 # is negligible against the cost of silently writing an empty CSV.
 _KTC_TEP_FIELD_KEYS = (
-    "tepp", "teppValue", "tepp_value",
-    "tep2", "tep2Value", "tep2_value",
-    "tepLevel2", "tepValueLevel2",
+    "tepp",
+    "teppValue",
+    "tepp_value",
+    "tep2",
+    "tep2Value",
+    "tep2_value",
+    "tepLevel2",
+    "tepValueLevel2",
 )
 _KTC_TEP_TOPLEVEL_KEYS = (
-    "sfTeppValue", "sf_tepp_value", "value_sftepp",
-    "teppValue", "tepp_value",
+    "sfTeppValue",
+    "sf_tepp_value",
+    "value_sftepp",
+    "teppValue",
+    "tepp_value",
 )
 
 
@@ -1770,6 +1893,7 @@ def _ktc_extract_tep(item):
     if a candidate is a dict, pull ``.value``; if it's a scalar,
     return it directly.
     """
+
     def _coerce_value(candidate):
         if candidate is None:
             return None
@@ -1812,7 +1936,7 @@ async def scrape_ktc(page, players):
         return results
     tep_name_map = {}
     try:
-        sf  = "true" if SUPERFLEX else "false"
+        sf = "true" if SUPERFLEX else "false"
         url = f"https://keeptradecut.com/dynasty-rankings?sf={sf}&tep=3&filters=QB|WR|RB|TE|RDP"
 
         # ── Strategy 1: Intercept KTC API responses ──
@@ -1899,8 +2023,13 @@ async def scrape_ktc(page, players):
                             elif sf_vals2 is not None:
                                 val = sf_vals2
                         if val is None:
-                            for k in ["sfValue", "sf_value", "sf_trade_value",
-                                       "superflex_value", "tradeValueSuperFlex"]:
+                            for k in [
+                                "sfValue",
+                                "sf_value",
+                                "sf_trade_value",
+                                "superflex_value",
+                                "tradeValueSuperFlex",
+                            ]:
                                 val = item.get(k)
                                 if val is not None:
                                     break
@@ -1919,7 +2048,9 @@ async def scrape_ktc(page, players):
                             pass
                 if name_map and DEBUG:
                     sf_label = "SF API" if SUPERFLEX else "1QB API"
-                    print(f"  [KTC] Parsed {len(name_map)} players from API ({sf_label}): {api_url[:60]}")
+                    print(
+                        f"  [KTC] Parsed {len(name_map)} players from API ({sf_label}): {api_url[:60]}"
+                    )
                     if tep_name_map:
                         print(f"  [KTC] TE++ values present for {len(tep_name_map)} players")
                     # Show first item structure for debugging
@@ -2025,7 +2156,9 @@ async def scrape_ktc(page, players):
                         except (ValueError, TypeError):
                             pass
                 if DEBUG:
-                    print(f"  [KTC] DOM scrape found {len(name_map)} players ({len(tep_name_map)} with TE++)")
+                    print(
+                        f"  [KTC] DOM scrape found {len(name_map)} players ({len(tep_name_map)} with TE++)"
+                    )
 
         # ── Strategy 3: Full page source parsing ──
         if not name_map:
@@ -2033,8 +2166,9 @@ async def scrape_ktc(page, players):
 
             # Try inline playersArray (current KTC format as of 2026-03)
             pa_match = re.search(
-                r'var\s+playersArray\s*=\s*(\[.*?\]);\s*(?:var\s|\n)',
-                content, re.DOTALL,
+                r"var\s+playersArray\s*=\s*(\[.*?\]);\s*(?:var\s|\n)",
+                content,
+                re.DOTALL,
             )
             if pa_match:
                 try:
@@ -2065,18 +2199,23 @@ async def scrape_ktc(page, players):
                             except (ValueError, TypeError):
                                 pass
                     if name_map and DEBUG:
-                        print(f"  [KTC] playersArray parsed {len(name_map)} players ({len(tep_name_map)} with TE+)")
+                        print(
+                            f"  [KTC] playersArray parsed {len(name_map)} players ({len(tep_name_map)} with TE+)"
+                        )
                 except Exception as e:
                     if DEBUG:
                         print(f"  [KTC] playersArray parse error: {e}")
 
             # Try __NEXT_DATA__ script (legacy format)
-            next_match = re.search(r'<script\s+id="__NEXT_DATA__"[^>]*>(.*?)</script>', content, re.DOTALL)
+            next_match = re.search(
+                r'<script\s+id="__NEXT_DATA__"[^>]*>(.*?)</script>', content, re.DOTALL
+            )
             if next_match:
                 try:
                     next_data = json.loads(next_match.group(1))
-                    player_list = (next_data.get("props", {}).get("pageProps", {}).get("players", []) or
-                                   next_data.get("props", {}).get("pageProps", {}).get("rankings", []))
+                    player_list = next_data.get("props", {}).get("pageProps", {}).get(
+                        "players", []
+                    ) or next_data.get("props", {}).get("pageProps", {}).get("rankings", [])
                     for item in player_list:
                         pname = item.get("playerName")
                         if not pname:
@@ -2097,7 +2236,9 @@ async def scrape_ktc(page, players):
                             except (ValueError, TypeError):
                                 pass
                     if name_map and DEBUG:
-                        print(f"  [KTC] __NEXT_DATA__ parsed {len(name_map)} players ({len(tep_name_map)} with TE+)")
+                        print(
+                            f"  [KTC] __NEXT_DATA__ parsed {len(name_map)} players ({len(tep_name_map)} with TE+)"
+                        )
                 except Exception as e:
                     if DEBUG:
                         print(f"  [KTC] __NEXT_DATA__ parse error: {e}")
@@ -2108,14 +2249,17 @@ async def scrape_ktc(page, players):
             if not name_map and SUPERFLEX:
                 sf_pairs = re.findall(
                     r'"playerName"\s*:\s*"([^"]+)".{0,2000}?"superflexValues"\s*:\s*\{[^}]*?"value"\s*:\s*(\d+)',
-                    content, re.DOTALL
+                    content,
+                    re.DOTALL,
                 )
                 if sf_pairs:
                     for nm, val in sf_pairs:
                         name_map[clean_name(nm)] = int(val)
                     if DEBUG:
                         ja = name_map.get("Josh Allen")
-                        print(f"  [KTC] SF targeted regex found {len(name_map)} players. Josh Allen={ja}")
+                        print(
+                            f"  [KTC] SF targeted regex found {len(name_map)} players. Josh Allen={ja}"
+                        )
 
             # ── Try mapping API histories (playerID → superflex) to page names ──
             if not name_map and api_data:
@@ -2143,13 +2287,15 @@ async def scrape_ktc(page, players):
                 # Now find playerID → playerName mapping from page source
                 id_name_pairs = re.findall(
                     r'"playerID"\s*:\s*(\d+).{0,500}?"playerName"\s*:\s*"([^"]+)"',
-                    content, re.DOTALL
+                    content,
+                    re.DOTALL,
                 )
                 if not id_name_pairs:
                     # Try reverse order
                     id_name_pairs = re.findall(
                         r'"playerName"\s*:\s*"([^"]+)".{0,500}?"playerID"\s*:\s*(\d+)',
-                        content, re.DOTALL
+                        content,
+                        re.DOTALL,
                     )
                     # Swap to (id, name) order
                     id_name_pairs = [(pid, nm) for nm, pid in id_name_pairs]
@@ -2161,13 +2307,14 @@ async def scrape_ktc(page, players):
                             name_map[clean_name(pname)] = id_to_sf[pid]
                     if name_map and DEBUG:
                         ja = name_map.get("Josh Allen")
-                        print(f"  [KTC] API history + page ID mapping: {len(name_map)} players. Josh Allen={ja}")
+                        print(
+                            f"  [KTC] API history + page ID mapping: {len(name_map)} players. Josh Allen={ja}"
+                        )
 
             # ── Fallback: 1QB values if nothing else works ──
             if not name_map:
                 pairs = re.findall(
-                    r'"playerName"\s*:\s*"([^"]+)"[^}]*?"value"\s*:\s*(\d+)',
-                    content
+                    r'"playerName"\s*:\s*"([^"]+)"[^}]*?"value"\s*:\s*(\d+)', content
                 )
                 for nm, val in pairs:
                     name_map[clean_name(nm)] = int(val)
@@ -2178,21 +2325,27 @@ async def scrape_ktc(page, players):
         if not name_map and DEBUG:
             await page_dump(page, "KTC")
             # Also dump a snippet of page source to help diagnose
-            content_snippet = content[:2000] if 'content' in dir() else ''
+            content_snippet = content[:2000] if "content" in dir() else ""
             # Check what script tags exist
-            script_ids = re.findall(r'<script[^>]*id="([^"]*)"', content if 'content' in dir() else '')
+            script_ids = re.findall(
+                r'<script[^>]*id="([^"]*)"', content if "content" in dir() else ""
+            )
             print(f"  [KTC] Script IDs in page: {script_ids[:10]}")
             # Check for superflexValues anywhere in content
-            sf_count = content.count('superflexValues') if 'content' in dir() else 0
-            sf_value_count = content.count('superflexValue') if 'content' in dir() else 0
-            print(f"  [KTC] 'superflexValues' appears {sf_count}x, 'superflexValue' appears {sf_value_count}x in page")
+            sf_count = content.count("superflexValues") if "content" in dir() else 0
+            sf_value_count = content.count("superflexValue") if "content" in dir() else 0
+            print(
+                f"  [KTC] 'superflexValues' appears {sf_count}x, 'superflexValue' appears {sf_value_count}x in page"
+            )
         if DEBUG:
             # Sanity checks
             ja = name_map.get("Josh Allen", name_map.get("josh allen"))
             jl = name_map.get("Jeremiyah Love", name_map.get("jeremiyah love"))
             fm = name_map.get("Fernando Mendoza", name_map.get("fernando mendoza"))
             ah = name_map.get("Aidan Hutchinson", name_map.get("aidan hutchinson"))
-            print(f"  [KTC] {len(name_map)} players. Josh Allen={ja}, Love={jl}, Mendoza={fm}, Hutchinson={ah}")
+            print(
+                f"  [KTC] {len(name_map)} players. Josh Allen={ja}, Love={jl}, Mendoza={fm}, Hutchinson={ah}"
+            )
             print(f"  [KTC] Sample: {list(name_map.items())[:5]}")
 
         set_cache("KTC", name_map)
@@ -2209,26 +2362,35 @@ async def scrape_ktc(page, players):
             if DEBUG:
                 la = tep_name_map.get("Sam LaPorta") or tep_name_map.get("sam laporta")
                 bo = tep_name_map.get("Brock Bowers") or tep_name_map.get("brock bowers")
-                print(f"  [KTC] TE+ map stored: {len(tep_name_map)} players (LaPorta={la}, Bowers={bo})")
+                print(
+                    f"  [KTC] TE+ map stored: {len(tep_name_map)} players (LaPorta={la}, Bowers={bo})"
+                )
         elif DEBUG:
-            print(f"  [KTC] TE+ map skipped — only {len(tep_name_map)} players carried TE+ fields (need ≥25)")
+            print(
+                f"  [KTC] TE+ map skipped — only {len(tep_name_map)} players carried TE+ fields (need ≥25)"
+            )
 
         # ── Always build playerID → name mapping for trade/waiver database ──
         global KTC_ID_TO_NAME
-        if 'content' in dir() and content:
+        if "content" in dir() and content:
             id_name = re.findall(
-                r'"playerID"\s*:\s*(\d+).{0,500}?"playerName"\s*:\s*"([^"]+)"',
-                content, re.DOTALL
+                r'"playerID"\s*:\s*(\d+).{0,500}?"playerName"\s*:\s*"([^"]+)"', content, re.DOTALL
             )
             if not id_name:
-                id_name = [(pid, nm) for nm, pid in re.findall(
-                    r'"playerName"\s*:\s*"([^"]+)".{0,500}?"playerID"\s*:\s*(\d+)',
-                    content, re.DOTALL
-                )]
+                id_name = [
+                    (pid, nm)
+                    for nm, pid in re.findall(
+                        r'"playerName"\s*:\s*"([^"]+)".{0,500}?"playerID"\s*:\s*(\d+)',
+                        content,
+                        re.DOTALL,
+                    )
+                ]
             for pid_str, pname in id_name:
                 KTC_ID_TO_NAME[int(pid_str)] = clean_name(pname)
             if KTC_ID_TO_NAME:
-                print(f"  [KTC] Stored {len(KTC_ID_TO_NAME)} playerID→name mappings for trade/waiver DB")
+                print(
+                    f"  [KTC] Stored {len(KTC_ID_TO_NAME)} playerID→name mappings for trade/waiver DB"
+                )
     except Exception as e:
         print(f"  [KTC error] {e}")
     return results
@@ -2411,6 +2573,7 @@ def _extract_ktc_side_assets(side):
             return [side.get(key)]
     return []
 
+
 def _parse_ktc_settings(raw_settings):
     settings = _parse_ktc_literal(raw_settings) or {}
     if not isinstance(settings, dict):
@@ -2538,6 +2701,7 @@ def _parse_ktc_trade(item):
         "settings": settings,
     }
 
+
 # ─────────────────────────────────────────
 # KTC WAIVER DATABASE — real dynasty waivers from 3000+ leagues
 # ─────────────────────────────────────────
@@ -2567,7 +2731,9 @@ async def scrape_ktc_waiver_database(page):
                     body = await response.json()
                     if isinstance(body, list) and len(body) > 0:
                         api_data.extend(body)
-                        print(f"  [KTC Waivers] Intercepted API: {len(body)} items from {rurl[:80]}")
+                        print(
+                            f"  [KTC Waivers] Intercepted API: {len(body)} items from {rurl[:80]}"
+                        )
                         api_received.set()
             except Exception:
                 pass
@@ -2619,9 +2785,17 @@ def _parse_ktc_waiver(item):
     # Try various field names for added/dropped player
     added = None
     for k in [
-        "addedPlayer", "playerAdded", "player", "added", "addPlayer",
-        "addedPlayerId", "playerAddedId", "addPlayerId",
-        "pickedUpPlayer", "pickedUpPlayerId", "pickedUp",
+        "addedPlayer",
+        "playerAdded",
+        "player",
+        "added",
+        "addPlayer",
+        "addedPlayerId",
+        "playerAddedId",
+        "addPlayerId",
+        "pickedUpPlayer",
+        "pickedUpPlayerId",
+        "pickedUp",
     ]:
         val = item.get(k)
         if val is not None:
@@ -2631,8 +2805,13 @@ def _parse_ktc_waiver(item):
 
     dropped = None
     for k in [
-        "droppedPlayer", "playerDropped", "dropped", "dropPlayer",
-        "droppedPlayerId", "playerDroppedId", "dropPlayerId",
+        "droppedPlayer",
+        "playerDropped",
+        "dropped",
+        "dropPlayer",
+        "droppedPlayerId",
+        "playerDroppedId",
+        "dropPlayerId",
     ]:
         val = item.get(k)
         if val is not None:
@@ -2652,7 +2831,10 @@ def _parse_ktc_waiver(item):
 
     bid_pct = item.get(
         "bidPct",
-        item.get("winningBidPct", item.get("faabPct", item.get("bidPercentage", item.get("percentage", "")))),
+        item.get(
+            "winningBidPct",
+            item.get("faabPct", item.get("bidPercentage", item.get("percentage", ""))),
+        ),
     )
 
     return {
@@ -2665,6 +2847,7 @@ def _parse_ktc_waiver(item):
         "settings": settings,
     }
 
+
 # ─────────────────────────────────────────
 # DynastyDaddy — API intercept PRIMARY, DOM fallback
 # ─────────────────────────────────────────
@@ -2673,30 +2856,57 @@ async def scrape_idptradecalc(page, players):
     results = {p: None for p in players}
     name_map = {}
     try:
+
         def _idptc_value_keys():
             if SUPERFLEX and TEP:
                 return [
-                    "value_sftep", "sfTepValue", "sf_tep_value",
-                    "value_sf", "sfValue", "sf_value",
-                    "value_tep", "tepValue", "tep_value",
-                    "value_1qb", "value", "Value",
+                    "value_sftep",
+                    "sfTepValue",
+                    "sf_tep_value",
+                    "value_sf",
+                    "sfValue",
+                    "sf_value",
+                    "value_tep",
+                    "tepValue",
+                    "tep_value",
+                    "value_1qb",
+                    "value",
+                    "Value",
                 ]
             if SUPERFLEX:
                 return [
-                    "value_sf", "sfValue", "sf_value",
-                    "value_sftep", "sfTepValue", "sf_tep_value",
-                    "value_1qb", "value", "Value",
+                    "value_sf",
+                    "sfValue",
+                    "sf_value",
+                    "value_sftep",
+                    "sfTepValue",
+                    "sf_tep_value",
+                    "value_1qb",
+                    "value",
+                    "Value",
                 ]
             if TEP:
                 return [
-                    "value_tep", "tepValue", "tep_value",
-                    "value_sftep", "sfTepValue", "sf_tep_value",
-                    "value_1qb", "value", "Value",
+                    "value_tep",
+                    "tepValue",
+                    "tep_value",
+                    "value_sftep",
+                    "sfTepValue",
+                    "sf_tep_value",
+                    "value_1qb",
+                    "value",
+                    "Value",
                 ]
             return [
-                "value_1qb", "oneQbValue", "value",
-                "value_sf", "sfValue", "sf_value",
-                "value_tep", "tepValue", "tep_value",
+                "value_1qb",
+                "oneQbValue",
+                "value",
+                "value_sf",
+                "sfValue",
+                "sf_value",
+                "value_tep",
+                "tepValue",
+                "tep_value",
                 "Value",
             ]
 
@@ -2713,8 +2923,13 @@ async def scrape_idptradecalc(page, players):
                 # We MUST read all sheets — dropping Sheet3 was the root
                 # cause of ~5 top-100 offense players showing as 1-src.
                 for key in [
-                    "Sheet1", "Sheet2", "Sheet3",
-                    "players", "values", "data", "result",
+                    "Sheet1",
+                    "Sheet2",
+                    "Sheet3",
+                    "players",
+                    "values",
+                    "data",
+                    "result",
                 ]:
                     if isinstance(data_obj.get(key), list):
                         items.extend(data_obj.get(key) or [])
@@ -2795,18 +3010,28 @@ async def scrape_idptradecalc(page, players):
                 url = response.url
                 if response.status != 200:
                     return
-                if any(skip in url for skip in [
-                    "googletagmanager", "googlesyndication", "doubleclick",
-                    "usercentrics", "cmp.", "analytics", "pagead",
-                    "adsbygoogle", "gstatic.com",
-                ]):
+                if any(
+                    skip in url
+                    for skip in [
+                        "googletagmanager",
+                        "googlesyndication",
+                        "doubleclick",
+                        "usercentrics",
+                        "cmp.",
+                        "analytics",
+                        "pagead",
+                        "adsbygoogle",
+                        "gstatic.com",
+                    ]
+                ):
                     return
                 is_data = (
-                    "googleusercontent.com/macros" in url or
-                    "script.google" in url or
-                    ("json" in ct and any(k in url for k in [
-                        "values", "players", "data", ".json"
-                    ]))
+                    "googleusercontent.com/macros" in url
+                    or "script.google" in url
+                    or (
+                        "json" in ct
+                        and any(k in url for k in ["values", "players", "data", ".json"])
+                    )
                 )
                 if is_data:
                     body = await response.text()
@@ -2857,10 +3082,8 @@ async def scrape_idptradecalc(page, players):
 
         # Ensure toggles
         async def ensure_toggles_on():
-            sf_checked = await page.evaluate(
-                "document.getElementById('toggleButton').checked")
-            tep_checked = await page.evaluate(
-                "document.getElementById('toggleButtonTEP').checked")
+            sf_checked = await page.evaluate("document.getElementById('toggleButton').checked")
+            tep_checked = await page.evaluate("document.getElementById('toggleButtonTEP').checked")
             if DEBUG:
                 print(f"  [IDPTradeCalc] Checkbox state: SF={sf_checked}, TEP={tep_checked}")
 
@@ -2887,10 +3110,8 @@ async def scrape_idptradecalc(page, players):
                 await page.evaluate("document.getElementById('toggleButton').click()")
                 await page.wait_for_timeout(500)
 
-            sf_final = await page.evaluate(
-                "document.getElementById('toggleButton').checked")
-            tep_final = await page.evaluate(
-                "document.getElementById('toggleButtonTEP').checked")
+            sf_final = await page.evaluate("document.getElementById('toggleButton').checked")
+            tep_final = await page.evaluate("document.getElementById('toggleButtonTEP').checked")
             if DEBUG:
                 print(f"  [IDPTradeCalc] Final state: SF={sf_final}, TEP={tep_final}")
 
@@ -2922,10 +3143,15 @@ async def scrape_idptradecalc(page, players):
                 try:
                     if response.status == 200 and len(await response.text()) > 500:
                         url = response.url
-                        if any(k in url for k in [
-                            "googleusercontent.com/macros", "script.google",
-                            "values", "players"
-                        ]):
+                        if any(
+                            k in url
+                            for k in [
+                                "googleusercontent.com/macros",
+                                "script.google",
+                                "values",
+                                "players",
+                            ]
+                        ):
                             api_data[url] = await response.text()
                             new_event.set()
                 except Exception:
@@ -2956,24 +3182,31 @@ async def scrape_idptradecalc(page, players):
             if name_map:
                 break
 
-            if any(skip in url for skip in [
-                "googletagmanager", "googlesyndication",
-                "usercentrics", "cmp.", "analytics", "doubleclick"
-            ]):
+            if any(
+                skip in url
+                for skip in [
+                    "googletagmanager",
+                    "googlesyndication",
+                    "usercentrics",
+                    "cmp.",
+                    "analytics",
+                    "doubleclick",
+                ]
+            ):
                 continue
 
             for candidate in [body, body.strip()]:
-                stripped = re.sub(r'^[a-zA-Z_$][\w$]*\s*\(\s*', '', candidate)
-                stripped = re.sub(r'\s*\)\s*;?\s*$', '', stripped)
-                json_start = stripped.find('{')
-                json_start_arr = stripped.find('[')
+                stripped = re.sub(r"^[a-zA-Z_$][\w$]*\s*\(\s*", "", candidate)
+                stripped = re.sub(r"\s*\)\s*;?\s*$", "", stripped)
+                json_start = stripped.find("{")
+                json_start_arr = stripped.find("[")
                 if json_start == -1 and json_start_arr == -1:
                     continue
                 start = min(
-                    json_start if json_start != -1 else float('inf'),
-                    json_start_arr if json_start_arr != -1 else float('inf')
+                    json_start if json_start != -1 else float("inf"),
+                    json_start_arr if json_start_arr != -1 else float("inf"),
                 )
-                stripped = stripped[int(start):]
+                stripped = stripped[int(start) :]
 
                 try:
                     data = json.loads(stripped)
@@ -2992,7 +3225,9 @@ async def scrape_idptradecalc(page, players):
 
                 if DEBUG and parsed_map:
                     sample_name = next(iter(parsed_map))
-                    print(f"  [IDPTradeCalc] Parsed {len(parsed_map)} players (sample: {sample_name})")
+                    print(
+                        f"  [IDPTradeCalc] Parsed {len(parsed_map)} players (sample: {sample_name})"
+                    )
 
                 if not parsed_map:
                     continue
@@ -3192,7 +3427,9 @@ async def scrape_idptradecalc(page, players):
             )
         if missing and ok:
             if DEBUG:
-                print(f"  [IDPTradeCalc] {len(missing)} players missing — batch searching via autocomplete")
+                print(
+                    f"  [IDPTradeCalc] {len(missing)} players missing — batch searching via autocomplete"
+                )
 
             await ensure_toggles_on()
             await page.wait_for_timeout(500)
@@ -3200,7 +3437,9 @@ async def scrape_idptradecalc(page, players):
             found_count = 0
             for pi, player in enumerate(missing):
                 if pi % 25 == 0 and pi > 0:
-                    print(f"  [IDPTradeCalc] Progress: {pi}/{len(missing)} searched, {found_count} found")
+                    print(
+                        f"  [IDPTradeCalc] Progress: {pi}/{len(missing)} searched, {found_count} found"
+                    )
                 try:
                     input_box = await page.query_selector("#team1Name")
                     if not input_box:
@@ -3227,8 +3466,7 @@ async def scrape_idptradecalc(page, players):
                     body_text = await page.inner_text("body")
                     last_name = player.split()[-1]
                     pattern = re.compile(
-                        rf'{re.escape(last_name)}\s*\((\d+)\)\s*-\s*\w+',
-                        re.IGNORECASE
+                        rf"{re.escape(last_name)}\s*\((\d+)\)\s*-\s*\w+", re.IGNORECASE
                     )
                     match = pattern.search(body_text)
                     if match:
@@ -3277,8 +3515,9 @@ def print_health_report():
     total_unique = set()
     site_counts = {}
     for site_name, site_map in FULL_DATA.items():
-        non_zero = sum(1 for v in site_map.values()
-                       if v is not None and isinstance(v, (int, float)) and v > 0)
+        non_zero = sum(
+            1 for v in site_map.values() if v is not None and isinstance(v, (int, float)) and v > 0
+        )
         site_counts[site_name] = non_zero
         total_unique.update(site_map.keys())
         max_val = compute_max(site_map)
@@ -3289,9 +3528,14 @@ def print_health_report():
     # Coverage distribution
     player_coverage = {}
     for name in total_unique:
-        count = sum(1 for site_map in FULL_DATA.values()
-                    if name in site_map and site_map[name] is not None
-                    and isinstance(site_map[name], (int, float)) and site_map[name] > 0)
+        count = sum(
+            1
+            for site_map in FULL_DATA.values()
+            if name in site_map
+            and site_map[name] is not None
+            and isinstance(site_map[name], (int, float))
+            and site_map[name] > 0
+        )
         player_coverage[name] = count
 
     one_site = sum(1 for c in player_coverage.values() if c == 1)
@@ -3368,15 +3612,29 @@ async def run(progress_callback=None):
         "KTC": _env_int("SCRAPER_SOURCE_TIMEOUT_KTC", source_timeout_default),
         "DynastyDaddy": _env_int("SCRAPER_SOURCE_TIMEOUT_DYNASTYDADDY", source_timeout_default),
         "FantasyPros": _env_int("SCRAPER_SOURCE_TIMEOUT_FANTASYPROS", source_timeout_default),
-        "DraftSharks": _env_int("SCRAPER_SOURCE_TIMEOUT_DRAFTSHARKS", max(360, source_timeout_default)),
+        "DraftSharks": _env_int(
+            "SCRAPER_SOURCE_TIMEOUT_DRAFTSHARKS", max(360, source_timeout_default)
+        ),
         "Yahoo": _env_int("SCRAPER_SOURCE_TIMEOUT_YAHOO", source_timeout_default),
-        "DynastyNerds": _env_int("SCRAPER_SOURCE_TIMEOUT_DYNASTYNERDS", max(360, source_timeout_default)),
-        "IDPTradeCalc": _env_int("SCRAPER_SOURCE_TIMEOUT_IDPTRADECALC", max(480, source_timeout_default)),
-        "DraftSharks_IDP": _env_int("SCRAPER_SOURCE_TIMEOUT_DRAFTSHARKS_IDP", max(360, source_timeout_default)),
-        "FantasyPros_IDP": _env_int("SCRAPER_SOURCE_TIMEOUT_FANTASYPROS_IDP", source_timeout_default),
+        "DynastyNerds": _env_int(
+            "SCRAPER_SOURCE_TIMEOUT_DYNASTYNERDS", max(360, source_timeout_default)
+        ),
+        "IDPTradeCalc": _env_int(
+            "SCRAPER_SOURCE_TIMEOUT_IDPTRADECALC", max(480, source_timeout_default)
+        ),
+        "DraftSharks_IDP": _env_int(
+            "SCRAPER_SOURCE_TIMEOUT_DRAFTSHARKS_IDP", max(360, source_timeout_default)
+        ),
+        "FantasyPros_IDP": _env_int(
+            "SCRAPER_SOURCE_TIMEOUT_FANTASYPROS_IDP", source_timeout_default
+        ),
         "Flock": _env_int("SCRAPER_SOURCE_TIMEOUT_FLOCK", max(420, source_timeout_default)),
-        "KTC_TradeDB": _env_int("SCRAPER_SOURCE_TIMEOUT_KTC_TRADEDB", max(300, source_timeout_default)),
-        "KTC_WaiverDB": _env_int("SCRAPER_SOURCE_TIMEOUT_KTC_WAIVERDB", max(300, source_timeout_default)),
+        "KTC_TradeDB": _env_int(
+            "SCRAPER_SOURCE_TIMEOUT_KTC_TRADEDB", max(300, source_timeout_default)
+        ),
+        "KTC_WaiverDB": _env_int(
+            "SCRAPER_SOURCE_TIMEOUT_KTC_WAIVERDB", max(300, source_timeout_default)
+        ),
         "FantasyCalc": _env_int("SCRAPER_SOURCE_TIMEOUT_FANTASYCALC", 90),
         "DLF_LocalCSV": _env_int("SCRAPER_SOURCE_TIMEOUT_DLF_LOCALCSV", 60),
     }
@@ -3476,15 +3734,34 @@ async def run(progress_callback=None):
             row["error"] = str(message or f"{src} failed")
 
     enabled_browser_sites = [
-        s for s in (
-            "KTC", "DynastyDaddy", "FantasyPros", "DraftSharks", "Yahoo", "DynastyNerds",
-            "IDPTradeCalc", "DraftSharks_IDP", "FantasyPros_IDP"
-        ) if SITES.get(s)
+        s
+        for s in (
+            "KTC",
+            "DynastyDaddy",
+            "FantasyPros",
+            "DraftSharks",
+            "Yahoo",
+            "DynastyNerds",
+            "IDPTradeCalc",
+            "DraftSharks_IDP",
+            "FantasyPros_IDP",
+        )
+        if SITES.get(s)
     ]
-    browser_needed = any(SITES.get(s) for s in (
-        "KTC", "DynastyDaddy", "FantasyPros", "DraftSharks", "Yahoo", "DynastyNerds",
-        "IDPTradeCalc", "DraftSharks_IDP", "FantasyPros_IDP"
-    )) or SITES.get("Flock")
+    browser_needed = any(
+        SITES.get(s)
+        for s in (
+            "KTC",
+            "DynastyDaddy",
+            "FantasyPros",
+            "DraftSharks",
+            "Yahoo",
+            "DynastyNerds",
+            "IDPTradeCalc",
+            "DraftSharks_IDP",
+            "FantasyPros_IDP",
+        )
+    ) or SITES.get("Flock")
     planned_total_steps = (
         1  # bootstrap
         + (1 if SITES.get("FantasyCalc") else 0)
@@ -3519,7 +3796,7 @@ async def run(progress_callback=None):
 
     # ── Browser sites ──
     browser_order = [
-        ("KTC",          scrape_ktc),
+        ("KTC", scrape_ktc),
         ("IDPTradeCalc", scrape_idptradecalc),
     ]
 
@@ -3532,7 +3809,6 @@ async def run(progress_callback=None):
         await _phase("browser", "launch", message="Launching browser context")
         print("Launching browser...")
         async with async_playwright() as pw:
-
             # ── Browser sites ──
             active_browser = [(s, fn) for s, fn in browser_order if SITES.get(s)]
             if active_browser:
@@ -3556,18 +3832,24 @@ async def run(progress_callback=None):
                             await route.continue_()
                     except Exception:
                         pass
+
                 await context.route("**/*", _block_heavy)
 
                 # Run each browser site sequentially
                 for site, scraper in active_browser:
-                    await _phase("source_start", site, event="source_start", message=f"Scraping {site}")
+                    await _phase(
+                        "source_start", site, event="source_start", message=f"Scraping {site}"
+                    )
                     print(f"  Scraping {site}...")
                     page = await context.new_page()
                     try:
                         timeout_sec = source_timeouts.get(site, source_timeout_default)
-                        site_results = await asyncio.wait_for(scraper(page, PLAYERS), timeout=timeout_sec)
+                        site_results = await asyncio.wait_for(
+                            scraper(page, PLAYERS), timeout=timeout_sec
+                        )
                         value_count = sum(
-                            1 for v in (site_results or {}).values()
+                            1
+                            for v in (site_results or {}).values()
                             if isinstance(v, (int, float)) and v > 0
                         )
                         for p, v in site_results.items():
@@ -3591,9 +3873,13 @@ async def run(progress_callback=None):
                                 if p in all_results and v is not None:
                                     all_results[p]["IDPTradeCalc"] = v
                                     recovered += 1
-                            print(f"  [IDPTradeCalc] Timeout after {source_timeouts.get(site, source_timeout_default)}s — recovered {recovered} values from partial autocomplete")
+                            print(
+                                f"  [IDPTradeCalc] Timeout after {source_timeouts.get(site, source_timeout_default)}s — recovered {recovered} values from partial autocomplete"
+                            )
                         else:
-                            print(f"  [IDPTradeCalc] Timeout after {source_timeouts.get(site, source_timeout_default)}s")
+                            print(
+                                f"  [IDPTradeCalc] Timeout after {source_timeouts.get(site, source_timeout_default)}s"
+                            )
                         await _emit_progress(
                             step="source_failed",
                             source=site,
@@ -3620,7 +3906,12 @@ async def run(progress_callback=None):
                 # ── KTC Trade + Waiver Database scraping ──
                 if SITES.get("KTC") and KTC_ID_TO_NAME:
                     try:
-                        await _phase("source_start", "KTC_TradeDB", event="source_start", message="Scraping KTC trade database")
+                        await _phase(
+                            "source_start",
+                            "KTC_TradeDB",
+                            event="source_start",
+                            message="Scraping KTC trade database",
+                        )
                         trade_page = await context.new_page()
                         await asyncio.wait_for(
                             scrape_ktc_trade_database(trade_page),
@@ -3648,7 +3939,9 @@ async def run(progress_callback=None):
                             level="error",
                             message=f"KTC trade DB timed out after {source_timeouts['KTC_TradeDB']}s",
                         )
-                        print(f"  [KTC Trade DB error] Timeout after {source_timeouts['KTC_TradeDB']}s")
+                        print(
+                            f"  [KTC Trade DB error] Timeout after {source_timeouts['KTC_TradeDB']}s"
+                        )
                     except Exception as e:
                         await _emit_progress(
                             step="source_failed",
@@ -3661,7 +3954,12 @@ async def run(progress_callback=None):
                         )
                         print(f"  [KTC Trade DB error] {e}")
                     try:
-                        await _phase("source_start", "KTC_WaiverDB", event="source_start", message="Scraping KTC waiver database")
+                        await _phase(
+                            "source_start",
+                            "KTC_WaiverDB",
+                            event="source_start",
+                            message="Scraping KTC waiver database",
+                        )
                         waiver_page = await context.new_page()
                         await asyncio.wait_for(
                             scrape_ktc_waiver_database(waiver_page),
@@ -3689,7 +3987,9 @@ async def run(progress_callback=None):
                             level="error",
                             message=f"KTC waiver DB timed out after {source_timeouts['KTC_WaiverDB']}s",
                         )
-                        print(f"  [KTC Waiver DB error] Timeout after {source_timeouts['KTC_WaiverDB']}s")
+                        print(
+                            f"  [KTC Waiver DB error] Timeout after {source_timeouts['KTC_WaiverDB']}s"
+                        )
                     except Exception as e:
                         await _emit_progress(
                             step="source_failed",
@@ -3702,7 +4002,9 @@ async def run(progress_callback=None):
                         )
                         print(f"  [KTC Waiver DB error] {e}")
                 elif SITES.get("KTC"):
-                    print("  [KTC Crowd] Skipping trade/waiver DB — no playerID→name mapping available")
+                    print(
+                        "  [KTC Crowd] Skipping trade/waiver DB — no playerID→name mapping available"
+                    )
                     await _emit_progress(
                         step="source_partial",
                         source="KTC_TradeDB",
@@ -3740,8 +4042,10 @@ async def run(progress_callback=None):
         if site_name == "KTC_WaiverDB":
             return len(KTC_CROWD_DATA.get("waivers", []) or [])
         return sum(
-            1 for _player, row in all_results.items()
-            if isinstance((row or {}).get(site_name), (int, float)) and (row or {}).get(site_name) > 0
+            1
+            for _player, row in all_results.items()
+            if isinstance((row or {}).get(site_name), (int, float))
+            and (row or {}).get(site_name) > 0
         )
 
     # Reconcile final per-source state after all source phases complete.
@@ -3755,7 +4059,9 @@ async def run(progress_callback=None):
         _state["valueCount"] = int(_count)
         if _state.get("state") == "running":
             _state["state"] = "partial" if _count <= 0 else "complete"
-            _state["finishedAt"] = _state.get("finishedAt") or datetime.datetime.now(datetime.timezone.utc).isoformat()
+            _state["finishedAt"] = (
+                _state.get("finishedAt") or datetime.datetime.now(datetime.timezone.utc).isoformat()
+            )
             _state["durationSec"] = _duration_sec(_state.get("startedAt"), _state.get("finishedAt"))
             if _count <= 0:
                 _state["message"] = _state.get("message") or "source ended without mapped values"
@@ -3764,10 +4070,34 @@ async def run(progress_callback=None):
             _state["message"] = _state.get("message") or "source completed with zero mapped values"
 
     enabled_sources = sorted([s for s, row in source_run_state.items() if row.get("enabled")])
-    complete_sources = sorted([s for s, row in source_run_state.items() if row.get("enabled") and row.get("state") == "complete"])
-    partial_sources = sorted([s for s, row in source_run_state.items() if row.get("enabled") and row.get("state") == "partial"])
-    timeout_sources = sorted([s for s, row in source_run_state.items() if row.get("enabled") and row.get("state") == "timeout"])
-    failed_sources = sorted([s for s, row in source_run_state.items() if row.get("enabled") and row.get("state") == "failed"])
+    complete_sources = sorted(
+        [
+            s
+            for s, row in source_run_state.items()
+            if row.get("enabled") and row.get("state") == "complete"
+        ]
+    )
+    partial_sources = sorted(
+        [
+            s
+            for s, row in source_run_state.items()
+            if row.get("enabled") and row.get("state") == "partial"
+        ]
+    )
+    timeout_sources = sorted(
+        [
+            s
+            for s, row in source_run_state.items()
+            if row.get("enabled") and row.get("state") == "timeout"
+        ]
+    )
+    failed_sources = sorted(
+        [
+            s
+            for s, row in source_run_state.items()
+            if row.get("enabled") and row.get("state") == "failed"
+        ]
+    )
     run_finished_at_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
     # Inject KTC blocker diagnosis into source state if available
     if _KTC_BLOCKER and "KTC" in source_run_state:
@@ -3780,7 +4110,9 @@ async def run(progress_callback=None):
         "startedAt": run_started_at_iso,
         "finishedAt": run_finished_at_iso,
         "durationSec": _duration_sec(run_started_at_iso, run_finished_at_iso),
-        "overallStatus": "partial" if (partial_sources or timeout_sources or failed_sources) else "complete",
+        "overallStatus": "partial"
+        if (partial_sources or timeout_sources or failed_sources)
+        else "complete",
         "partialRun": bool(partial_sources or timeout_sources or failed_sources),
         "enabledSources": enabled_sources,
         "completeSources": complete_sources,
@@ -3808,7 +4140,9 @@ async def run(progress_callback=None):
     elif ktc_blocker_label:
         print(f"  [KTC Status] BLOCKED — {ktc_blocker_label} (0 players)")
     else:
-        print(f"  [KTC Status] FAILED — state={ktc_state_label}, error={ktc_row.get('error', 'unknown')} (0 players)")
+        print(
+            f"  [KTC Status] FAILED — state={ktc_state_label}, error={ktc_row.get('error', 'unknown')} (0 players)"
+        )
 
     # [NEW] Print scrape health report
     await _phase("health_report", "summary", message="Generating scrape health report")
@@ -3853,16 +4187,21 @@ async def run(progress_callback=None):
         writer = csv.writer(f)
         writer.writerow(["Player"] + active_sites)
         for player in PLAYERS:
-            writer.writerow([player] + [
-                fmt_val(all_results[player].get(s)) if all_results[player].get(s) is not None else ""
-                for s in active_sites
-            ])
+            writer.writerow(
+                [player]
+                + [
+                    fmt_val(all_results[player].get(s))
+                    if all_results[player].get(s) is not None
+                    else ""
+                    for s in active_sites
+                ]
+            )
     print(f"\nSaved to: {fname} (console players: {len(PLAYERS)})")
 
     # ── Save JSON for dashboard ──
     site_key_map = {
-        "KTC":          "ktc",
-        "KTC_TEP":      "ktcSfTep",
+        "KTC": "ktc",
+        "KTC_TEP": "ktcSfTep",
         "IDPTradeCalc": "idpTradeCalc",
     }
 
@@ -3878,8 +4217,17 @@ async def run(progress_callback=None):
             print(f"  [Max] {scraper_name} → {max_values[dash_key]}")
 
     # ── Trim sites to top N players before building JSON ──
-    _OFFENSIVE_SITES = {"KTC", "KTC_TEP", "FantasyCalc", "DynastyDaddy", "FantasyPros",
-                        "DraftSharks", "Yahoo", "DynastyNerds", "DLF_SF"}
+    _OFFENSIVE_SITES = {
+        "KTC",
+        "KTC_TEP",
+        "FantasyCalc",
+        "DynastyDaddy",
+        "FantasyPros",
+        "DraftSharks",
+        "Yahoo",
+        "DynastyNerds",
+        "DLF_SF",
+    }
     _DEFENSIVE_SITES = {"FantasyPros_IDP", "DLF_IDP"}
     _ROOKIE_ONLY_DLF_SITES = {"DLF_RSF", "DLF_RIDP"}
     _COMBINED_SITES = {"IDPTradeCalc"}  # has both OFF and IDP
@@ -3905,13 +4253,23 @@ async def run(progress_callback=None):
         if len(full_map) > cap:
             # Keep top N by value (higher = better for value sites, lower = better for rank sites)
             dash_key = site_key_map.get(site_name, site_name)
-            rank_sites = {"Flock", "DynastyNerds", "FantasyPros_IDP", "DraftSharks_IDP", "DraftSharks"}
+            rank_sites = {
+                "Flock",
+                "DynastyNerds",
+                "FantasyPros_IDP",
+                "DraftSharks_IDP",
+                "DraftSharks",
+            }
             if site_name in rank_sites:
                 # Rank-based: lower values are better
-                sorted_players = sorted(full_map.items(), key=lambda x: x[1] if x[1] is not None else 99999)
+                sorted_players = sorted(
+                    full_map.items(), key=lambda x: x[1] if x[1] is not None else 99999
+                )
             else:
                 # Value-based: higher values are better
-                sorted_players = sorted(full_map.items(), key=lambda x: -(x[1] if x[1] is not None else 0))
+                sorted_players = sorted(
+                    full_map.items(), key=lambda x: -(x[1] if x[1] is not None else 0)
+                )
             trimmed = dict(sorted_players[:cap])
             if DEBUG:
                 print(f"  [Cap] {site_name}: {len(full_map)} → {cap} players")
@@ -3929,8 +4287,15 @@ async def run(progress_callback=None):
     _pool_audit = None
     try:
         from src.pool.builder import build_canonical_pool, PoolAuditReport
-        _ktc_full_for_pool = FULL_DATA.get("KTC", {}) if isinstance(FULL_DATA.get("KTC"), dict) else {}
-        _idp_tc_for_pool = FULL_DATA.get("IDPTradeCalc", {}) if isinstance(FULL_DATA.get("IDPTradeCalc"), dict) else {}
+
+        _ktc_full_for_pool = (
+            FULL_DATA.get("KTC", {}) if isinstance(FULL_DATA.get("KTC"), dict) else {}
+        )
+        _idp_tc_for_pool = (
+            FULL_DATA.get("IDPTradeCalc", {})
+            if isinstance(FULL_DATA.get("IDPTradeCalc"), dict)
+            else {}
+        )
         _adamidp_artifact = os.path.join(SCRIPT_DIR, "data", "adamidp_normalized.json")
         _pool_rows, _pool_audit = build_canonical_pool(
             sleeper_roster_data=SLEEPER_ROSTER_DATA,
@@ -3943,16 +4308,21 @@ async def run(progress_callback=None):
         for _pr in _pool_rows:
             if _pr.canonical_name:
                 all_names.add(_pr.canonical_name)
-        print(f"  [Pool Builder] Union: {_pool_audit.final_union_count} players "
-              f"(sleeper={_pool_audit.sleeper_count}, ktc525={_pool_audit.ktc_top525_count}, "
-              f"adamidp={_pool_audit.adamidp_unique_count})")
-        print(f"  [Pool Builder] IDPTradeCalc crosswalk: "
-              f"queried={_pool_audit.idp_trade_calc_queried_count}, "
-              f"matched={_pool_audit.idp_trade_calc_matched_count}, "
-              f"unmatched={_pool_audit.idp_trade_calc_unmatched_count}")
+        print(
+            f"  [Pool Builder] Union: {_pool_audit.final_union_count} players "
+            f"(sleeper={_pool_audit.sleeper_count}, ktc525={_pool_audit.ktc_top525_count}, "
+            f"adamidp={_pool_audit.adamidp_unique_count})"
+        )
+        print(
+            f"  [Pool Builder] IDPTradeCalc crosswalk: "
+            f"queried={_pool_audit.idp_trade_calc_queried_count}, "
+            f"matched={_pool_audit.idp_trade_calc_matched_count}, "
+            f"unmatched={_pool_audit.idp_trade_calc_unmatched_count}"
+        )
     except Exception as _pool_err:
         print(f"  [Pool Builder] Error building canonical pool: {_pool_err}")
         import traceback
+
         traceback.print_exc()
 
     # ── Build canonical name resolution map ──
@@ -3968,7 +4338,7 @@ async def run(progress_callback=None):
         parts = sn.split()
         if len(parts) >= 2:
             initial = parts[0][0].lower()
-            last = ' '.join(parts[1:]).lower().replace('-', ' ').replace('.', '')
+            last = " ".join(parts[1:]).lower().replace("-", " ").replace(".", "")
             _sleeper_initial_idx[(initial, last)] = sn
 
     # Build normalized lookup from rostered Sleeper names
@@ -3991,9 +4361,9 @@ async def run(progress_callback=None):
             continue
         # Initial-expansion match? (e.g. "A. St. Brown" → "Amon-Ra St. Brown")
         parts = cn.split()
-        if len(parts) >= 2 and len(parts[0].rstrip('.')) <= 2:
-            initial = parts[0].rstrip('.')[0].lower()
-            last = ' '.join(parts[1:]).lower().replace('-', ' ').replace('.', '')
+        if len(parts) >= 2 and len(parts[0].rstrip(".")) <= 2:
+            initial = parts[0].rstrip(".")[0].lower()
+            last = " ".join(parts[1:]).lower().replace("-", " ").replace(".", "")
             key = (initial, last)
             if key in _sleeper_initial_idx:
                 _canonical_map[cn] = _sleeper_initial_idx[key]
@@ -4009,8 +4379,8 @@ async def run(progress_callback=None):
         _canonical_map[cn] = cn
 
     # ── Build full Sleeper identity indexes from the global Sleeper player DB ──
-    _sleeper_name_candidates = {}     # clean_name -> [candidate...]
-    _sleeper_norm_candidates = {}     # normalized_name -> [candidate...]
+    _sleeper_name_candidates = {}  # clean_name -> [candidate...]
+    _sleeper_norm_candidates = {}  # normalized_name -> [candidate...]
     _sleeper_initial_candidates = {}  # (initial, last_norm) -> [candidate...]
 
     for pid, pdata in SLEEPER_ALL_NFL.items():
@@ -4036,7 +4406,10 @@ async def run(progress_callback=None):
         _sleeper_norm_candidates.setdefault(normalize_lookup_name(full), []).append(cand)
         parts = full.split()
         if len(parts) >= 2:
-            key = (parts[0][0].lower(), ' '.join(parts[1:]).lower().replace('-', ' ').replace('.', ''))
+            key = (
+                parts[0][0].lower(),
+                " ".join(parts[1:]).lower().replace("-", " ").replace(".", ""),
+            )
             _sleeper_initial_candidates.setdefault(key, []).append(cand)
 
     _sleeper_name_pool = list(_sleeper_name_candidates.keys())
@@ -4106,10 +4479,15 @@ async def run(progress_callback=None):
         if not candidates:
             parts = cleaned.split()
             if len(parts) >= 2:
-                key = (parts[0][0].lower(), ' '.join(parts[1:]).lower().replace('-', ' ').replace('.', ''))
+                key = (
+                    parts[0][0].lower(),
+                    " ".join(parts[1:]).lower().replace("-", " ").replace(".", ""),
+                )
                 candidates = list(_sleeper_initial_candidates.get(key, []))
         if not candidates and _sleeper_name_pool:
-            fm = best_match(cleaned, _sleeper_name_pool, threshold=0.90, match_guard=_is_safe_name_merge)
+            fm = best_match(
+                cleaned, _sleeper_name_pool, threshold=0.90, match_guard=_is_safe_name_merge
+            )
             if fm:
                 candidates = list(_sleeper_name_candidates.get(fm, []))
         best = _pick_best_candidate(candidates, preferred_pos)
@@ -4125,7 +4503,11 @@ async def run(progress_callback=None):
     # IDP-only sites should not contribute values to offensive players
     _OFF_POSITIONS = {"QB", "RB", "WR", "TE", "K"}
     _IDP_POSITIONS = {"LB", "DL", "DE", "DT", "CB", "S", "DB", "EDGE"}
-    _IDP_ONLY_SITES = {"fantasyProsIdp", "dlfIdp", "dlfRidp"}  # IDPTradeCalc removed — it has both OFF and IDP
+    _IDP_ONLY_SITES = {
+        "fantasyProsIdp",
+        "dlfIdp",
+        "dlfRidp",
+    }  # IDPTradeCalc removed — it has both OFF and IDP
     _OFF_ONLY_SITES = {"dlfSf", "dlfRsf"}
     _pos_map = dict(SLEEPER_ROSTER_DATA.get("positions", {}))
     _player_id_map = dict(SLEEPER_ROSTER_DATA.get("playerIds", {}))
@@ -4149,7 +4531,9 @@ async def run(progress_callback=None):
         # Drop non-player bucket rows and ambiguous yearless pick labels.
         if re.match(r"^ALL OTHER\b", raw_canonical.upper()):
             continue
-        if _looks_like_pick_name(raw_canonical) and not re.match(r"^20\d{2}\b", raw_canonical.upper()):
+        if _looks_like_pick_name(raw_canonical) and not re.match(
+            r"^20\d{2}\b", raw_canonical.upper()
+        ):
             continue
 
         # Resolve to canonical rostered name first (merges "A. St. Brown" → "Amon-Ra St. Brown")
@@ -4161,7 +4545,9 @@ async def run(progress_callback=None):
         if not _looks_like_pick_name(canonical):
             sleeper_identity = _resolve_sleeper_identity(canonical, preferred_pos=player_pos)
             if not sleeper_identity and canonical != raw_canonical:
-                sleeper_identity = _resolve_sleeper_identity(raw_canonical, preferred_pos=player_pos)
+                sleeper_identity = _resolve_sleeper_identity(
+                    raw_canonical, preferred_pos=player_pos
+                )
             if sleeper_identity:
                 canonical = sleeper_identity.get("name") or canonical
                 if sleeper_identity.get("pos"):
@@ -4216,14 +4602,10 @@ async def run(progress_callback=None):
         ea = players_json.get(a, {}) if isinstance(players_json.get(a), dict) else {}
         eb = players_json.get(b, {}) if isinstance(players_json.get(b), dict) else {}
         score_a = (
-            (10 if ea.get("_sleeperId") else 0)
-            + (5 if _get_pos(a) else 0)
-            + _entry_site_count(ea)
+            (10 if ea.get("_sleeperId") else 0) + (5 if _get_pos(a) else 0) + _entry_site_count(ea)
         )
         score_b = (
-            (10 if eb.get("_sleeperId") else 0)
-            + (5 if _get_pos(b) else 0)
-            + _entry_site_count(eb)
+            (10 if eb.get("_sleeperId") else 0) + (5 if _get_pos(b) else 0) + _entry_site_count(eb)
         )
         if score_a != score_b:
             return a if score_a > score_b else b
@@ -4260,7 +4642,12 @@ async def run(progress_callback=None):
         for _k, _v in _s_entry.items():
             if str(_k).startswith("_"):
                 continue
-            if _k not in _p_entry and isinstance(_v, (int, float)) and _v is not None and float(_v) > 0:
+            if (
+                _k not in _p_entry
+                and isinstance(_v, (int, float))
+                and _v is not None
+                and float(_v) > 0
+            ):
                 _p_entry[_k] = _v
 
         # Preserve identity metadata if primary lacks it.
@@ -4272,7 +4659,11 @@ async def run(progress_callback=None):
         if not _primary_pos and _secondary_pos:
             _pos_map[_primary] = _secondary_pos
 
-        _sid = _p_entry.get("_sleeperId") or _s_entry.get("_sleeperId") or _player_id_map.get(_secondary)
+        _sid = (
+            _p_entry.get("_sleeperId")
+            or _s_entry.get("_sleeperId")
+            or _player_id_map.get(_secondary)
+        )
         if _sid:
             _sid = str(_sid)
             _p_entry["_sleeperId"] = _sid
@@ -4293,7 +4684,16 @@ async def run(progress_callback=None):
     # This keeps IDP filters/coverage accurate even for deep-tier defenders not rostered.
     # Rookie-only DLF feeds are not treated as primary cross-source identity/evidence signals.
     _IDP_SIGNAL_KEYS = {"fantasyProsIdp", "draftSharksIdp", "dlfIdp"}
-    _OFF_SIGNAL_KEYS = {"ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "draftSharks", "yahoo", "dynastyNerds", "dlfSf"}
+    _OFF_SIGNAL_KEYS = {
+        "ktc",
+        "fantasyCalc",
+        "dynastyDaddy",
+        "fantasyPros",
+        "draftSharks",
+        "yahoo",
+        "dynastyNerds",
+        "dlfSf",
+    }
     _idp_pos_backfilled = 0
     for pname, entry in players_json.items():
         if not isinstance(entry, dict):
@@ -4329,7 +4729,9 @@ async def run(progress_callback=None):
             _idp_pos_backfilled += 1
 
     if DEBUG and _idp_pos_backfilled:
-        print(f"  [IDP Coverage] Backfilled positions for {_idp_pos_backfilled} IDP-signaled players")
+        print(
+            f"  [IDP Coverage] Backfilled positions for {_idp_pos_backfilled} IDP-signaled players"
+        )
 
     # Keep enriched Sleeper identity data attached to the exported roster block.
     if _pos_map:
@@ -4528,7 +4930,8 @@ async def run(progress_callback=None):
                     return _avg(vals)
 
             years_with_tier = {
-                y for (y, r, t) in tier_values.keys()
+                y
+                for (y, r, t) in tier_values.keys()
                 if y is not None and r == round_num and t == tier
             }
             near_year = _nearest_year(years_with_tier, year)
@@ -4538,7 +4941,8 @@ async def run(progress_callback=None):
                     return _avg(vals)
 
             years_with_slots = {
-                y for (y, r, s) in slot_values.keys()
+                y
+                for (y, r, s) in slot_values.keys()
                 if y is not None and r == round_num and lo <= s <= hi
             }
             near_year = _nearest_year(years_with_slots, year)
@@ -4574,7 +4978,8 @@ async def run(progress_callback=None):
                     return _avg(vals)
 
             years_with_slot = {
-                y for (y, r, s) in slot_values.keys()
+                y
+                for (y, r, s) in slot_values.keys()
                 if y is not None and r == round_num and s == slot
             }
             near_year = _nearest_year(years_with_slot, year)
@@ -4594,7 +4999,9 @@ async def run(progress_callback=None):
                 for tier in ("early", "mid", "late"):
                     t_val = lookup_tier(year, round_num, tier)
                     if t_val is not None:
-                        out[f"{year} {tier.capitalize()} {round_num}{_pick_suffix(round_num)}"] = _fmt_pick_value(t_val)
+                        out[f"{year} {tier.capitalize()} {round_num}{_pick_suffix(round_num)}"] = (
+                            _fmt_pick_value(t_val)
+                        )
 
                 for slot in range(1, league_size + 1):
                     s_val = lookup_slot(year, round_num, slot)
@@ -4633,12 +5040,14 @@ async def run(progress_callback=None):
         if site_map:
             pick_anchors[dash_key] = site_map
             if DEBUG:
-                years = sorted({
-                    int(m.group(1))
-                    for key in site_map.keys()
-                    for m in [re.match(r"^(20\d{2})\s+", key)]
-                    if m
-                })
+                years = sorted(
+                    {
+                        int(m.group(1))
+                        for key in site_map.keys()
+                        for m in [re.match(r"^(20\d{2})\s+", key)]
+                        if m
+                    }
+                )
                 print(f"  [Pick Anchors] {dash_key}: {len(site_map)} canonical picks ({years})")
         else:
             pick_anchors[dash_key] = raw_picks
@@ -4827,7 +5236,9 @@ async def run(progress_callback=None):
 
         if allow_fuzzy:
             fuzzy_target = target_clean or target_name
-            fm = best_match(fuzzy_target, idx.get("names", []), threshold=0.90, match_guard=_is_safe_name_merge)
+            fm = best_match(
+                fuzzy_target, idx.get("names", []), threshold=0.90, match_guard=_is_safe_name_merge
+            )
             cand, val, why = _accept(fm, "fuzzy")
             if cand and val is not None:
                 return cand, val, why
@@ -4870,8 +5281,12 @@ async def run(progress_callback=None):
             if cand and val is not None:
                 entry[site_key] = _fmt_site_value(val)
                 _coverage_repair_stats["valuesBackfilled"] += 1
-                _coverage_repair_stats["bySite"][site_key] = _coverage_repair_stats["bySite"].get(site_key, 0) + 1
-                _coverage_repair_stats["byMethod"][method] = _coverage_repair_stats["byMethod"].get(method, 0) + 1
+                _coverage_repair_stats["bySite"][site_key] = (
+                    _coverage_repair_stats["bySite"].get(site_key, 0) + 1
+                )
+                _coverage_repair_stats["byMethod"][method] = (
+                    _coverage_repair_stats["byMethod"].get(method, 0) + 1
+                )
                 touched = True
         if touched:
             _coverage_repair_stats["playersTouched"] += 1
@@ -4903,12 +5318,14 @@ async def run(progress_callback=None):
                 count = max(count, _count_players_with_site_value(k))
         else:
             count = len(FULL_DATA.get(scraper_name, {}))
-        sites_meta.append({
-            "key": dash_key,
-            "label": scraper_name,
-            "max": max_values.get(dash_key, 0),
-            "playerCount": count,
-        })
+        sites_meta.append(
+            {
+                "key": dash_key,
+                "label": scraper_name,
+                "max": max_values.get(dash_key, 0),
+                "playerCount": count,
+            }
+        )
 
     # Expose per-file DLF sources for site status + source table toggles.
     _dlf_meta_sources = (
@@ -4924,12 +5341,14 @@ async def run(progress_callback=None):
         if scraper_name not in FULL_DATA:
             continue
         count = _count_players_with_site_value(dash_key)
-        sites_meta.append({
-            "key": dash_key,
-            "label": label,
-            "max": max_values.get(dash_key, 9999),
-            "playerCount": count,
-        })
+        sites_meta.append(
+            {
+                "key": dash_key,
+                "label": label,
+                "max": max_values.get(dash_key, 9999),
+                "playerCount": count,
+            }
+        )
 
     # [NEW] Compute per-site mean and stdev for z-score normalization
     site_stats = {}
@@ -4942,7 +5361,21 @@ async def run(progress_callback=None):
     # IDP Anchor System: tether the #1 IDP player to IDPTradeCalc's top non-Hunter value
     # This makes the anchor self-adjusting as the IDP market shifts
     _IDP_ANCHOR_EXCLUDE = {"travis hunter"}  # Excluded from anchor — he's a WR in dynasty
-    _IDP_ANCHOR_POSITIONS = {"LB", "DL", "DE", "DT", "CB", "S", "DB", "EDGE", "NT", "OLB", "ILB", "FS", "SS"}
+    _IDP_ANCHOR_POSITIONS = {
+        "LB",
+        "DL",
+        "DE",
+        "DT",
+        "CB",
+        "S",
+        "DB",
+        "EDGE",
+        "NT",
+        "OLB",
+        "ILB",
+        "FS",
+        "SS",
+    }
     _idp_tc_data = FULL_DATA.get("IDPTradeCalc", {})
     _pos_map_anchor = SLEEPER_ROSTER_DATA.get("positions", {})
 
@@ -4957,15 +5390,20 @@ async def run(progress_callback=None):
         return pos.upper()
 
     _idp_anchor_candidates = [
-        (name, v) for name, v in _idp_tc_data.items()
-        if v is not None and isinstance(v, (int, float)) and v > 0
+        (name, v)
+        for name, v in _idp_tc_data.items()
+        if v is not None
+        and isinstance(v, (int, float))
+        and v > 0
         and name.lower() not in _IDP_ANCHOR_EXCLUDE
         and _anchor_pos(name) in _IDP_ANCHOR_POSITIONS
     ]
     if _idp_anchor_candidates:
         _idp_anchor_candidates.sort(key=lambda x: -x[1])
         IDP_ANCHOR_TOP = _idp_anchor_candidates[0][1]
-        print(f"  [IDP Anchor] Top defensive player: {_idp_anchor_candidates[0][0]} = {IDP_ANCHOR_TOP}")
+        print(
+            f"  [IDP Anchor] Top defensive player: {_idp_anchor_candidates[0][0]} = {IDP_ANCHOR_TOP}"
+        )
         if len(_idp_anchor_candidates) >= 3:
             print(f"  [IDP Anchor] Top 3: {[(n, v) for n, v in _idp_anchor_candidates[:3]]}")
     else:
@@ -4973,17 +5411,19 @@ async def run(progress_callback=None):
         print(f"  [IDP Anchor] No defensive players found — fallback {IDP_ANCHOR_TOP}")
 
     def _idp_bucket(pos):
-        p = str(pos or '').upper()
-        if p in {'DE', 'DT', 'EDGE', 'NT'}:
-            return 'DL'
-        if p in {'CB', 'S', 'FS', 'SS', 'DB'}:
-            return 'DB'
-        if p in {'LB', 'OLB', 'ILB'}:
-            return 'LB'
-        return 'ALL'
+        p = str(pos or "").upper()
+        if p in {"DE", "DT", "EDGE", "NT"}:
+            return "DL"
+        if p in {"CB", "S", "FS", "SS", "DB"}:
+            return "DB"
+        if p in {"LB", "OLB", "ILB"}:
+            return "LB"
+        return "ALL"
 
     def _build_idp_anchor_points(values, fallback_top):
-        vals = sorted([float(v) for v in values if isinstance(v, (int, float)) and v > 0], reverse=True)
+        vals = sorted(
+            [float(v) for v in values if isinstance(v, (int, float)) and v > 0], reverse=True
+        )
         if not vals:
             return [(1, float(fallback_top))]
         ranks = [1, 3, 6, 12, 24, 48, 72, 96]
@@ -5001,6 +5441,7 @@ async def run(progress_callback=None):
 
     def _interp_anchor_points(rank_value, points):
         import math
+
         rank = max(1.0, float(rank_value))
         pts = [(float(r), float(v)) for r, v in points if r and v and v > 0]
         pts.sort(key=lambda x: x[0])
@@ -5013,7 +5454,9 @@ async def run(progress_callback=None):
             r1, v1 = pts[i]
             if rank <= r1:
                 t = (math.log(rank) - math.log(r0)) / max(1e-9, (math.log(r1) - math.log(r0)))
-                return math.exp(math.log(v0) + (math.log(v1) - math.log(v0)) * max(0.0, min(1.0, t)))
+                return math.exp(
+                    math.log(v0) + (math.log(v1) - math.log(v0)) * max(0.0, min(1.0, t))
+                )
         r0, v0 = pts[-2] if len(pts) >= 2 else pts[-1]
         r1, v1 = pts[-1]
         if r0 == r1:
@@ -5021,34 +5464,38 @@ async def run(progress_callback=None):
         slope = (math.log(v1) - math.log(v0)) / (math.log(r1) - math.log(r0))
         return max(1.0, math.exp(math.log(v1) + slope * (math.log(rank) - math.log(r1))))
 
-    _idp_backbone_values = {'ALL': [], 'LB': [], 'DL': [], 'DB': []}
+    _idp_backbone_values = {"ALL": [], "LB": [], "DL": [], "DB": []}
     for _name, _value in _idp_anchor_candidates:
         _bucket = _idp_bucket(_anchor_pos(_name))
-        _idp_backbone_values['ALL'].append(_value)
-        if _bucket != 'ALL':
+        _idp_backbone_values["ALL"].append(_value)
+        if _bucket != "ALL":
             _idp_backbone_values[_bucket].append(_value)
     _idp_anchor_curves = {
         bucket: _build_idp_anchor_points(vals, IDP_ANCHOR_TOP)
         for bucket, vals in _idp_backbone_values.items()
-        if vals or bucket == 'ALL'
+        if vals or bucket == "ALL"
     }
 
-    def _idp_rank_to_value(rank_value, pos=''):
+    def _idp_rank_to_value(rank_value, pos=""):
         bucket = _idp_bucket(pos)
-        curve = _idp_anchor_curves.get(bucket) or _idp_anchor_curves.get('ALL') or [(1, float(IDP_ANCHOR_TOP))]
+        curve = (
+            _idp_anchor_curves.get(bucket)
+            or _idp_anchor_curves.get("ALL")
+            or [(1, float(IDP_ANCHOR_TOP))]
+        )
         return _interp_anchor_points(rank_value, curve)
 
-    IDP_RANK_OFFSET = 15     # Controls curve flatness near the top
-    IDP_RANK_DIVISOR = 16    # Paired with offset so rank 1 → exactly IDP_ANCHOR_TOP
+    IDP_RANK_OFFSET = 15  # Controls curve flatness near the top
+    IDP_RANK_DIVISOR = 16  # Paired with offset so rank 1 → exactly IDP_ANCHOR_TOP
     IDP_RANK_EXPONENT = -0.72  # Steeper than offense (-0.66) since IDP value drops faster
     SINGLE_SOURCE_DISCOUNT = 0.85  # 15% discount for players on only 1 site
     COMPOSITE_SCALE = 9999
-    OUTLIER_TRIM_GAP = 0.18       # Trim only true outliers, not legitimate elite values
+    OUTLIER_TRIM_GAP = 0.18  # Trim only true outliers, not legitimate elite values
     # Elite ceiling expansion: allows top-consensus players to approach 9999.
     # Phase 3 fix: raised from 0.045 → 0.09 and lowered threshold from 0.91 → 0.88
     # so Josh Allen (highest ranked) gets closer to true top-of-market ceiling.
-    ELITE_NORM_THRESHOLD = 0.88   # Start elite expansion at moderate consensus
-    ELITE_BOOST_MAX = 0.09        # Cap elite expansion at +9%
+    ELITE_NORM_THRESHOLD = 0.88  # Start elite expansion at moderate consensus
+    ELITE_BOOST_MAX = 0.09  # Cap elite expansion at +9%
     IDP_VALUE_HEADROOM_FRACTION = 0.18  # controlled IDP lift above value-site cap
     # Single-source suppression: Phase 3 fix — lowered min from 0.70 → 0.55
     # so fragile one-source veterans (Tyler Lockett etc.) get much stronger
@@ -5066,10 +5513,18 @@ async def run(progress_callback=None):
 
     # Default site weights (market-based sources weighted higher)
     SITE_WEIGHTS = {
-        "ktc": 1.3, "fantasyCalc": 1.0, "dynastyDaddy": 1.0,
-        "fantasyPros": 0.8, "draftSharks": 0.9, "yahoo": 0.8,
-        "dynastyNerds": 0.8, "idpTradeCalc": 1.0,
-        "dlfSf": 0.8, "dlfIdp": 0.8, "dlfRsf": 0.7, "dlfRidp": 0.7,
+        "ktc": 1.3,
+        "fantasyCalc": 1.0,
+        "dynastyDaddy": 1.0,
+        "fantasyPros": 0.8,
+        "draftSharks": 0.9,
+        "yahoo": 0.8,
+        "dynastyNerds": 0.8,
+        "idpTradeCalc": 1.0,
+        "dlfSf": 0.8,
+        "dlfIdp": 0.8,
+        "dlfRsf": 0.7,
+        "dlfRidp": 0.7,
         "fantasyProsIdp": 0.7,
     }
     # Rookie-only DLF exports remain visible as source signals, but are quarantined
@@ -5078,7 +5533,9 @@ async def run(progress_callback=None):
     _REAL_IDP_MARKET_SITE_KEYS = {"idpTradeCalc", "fantasyProsIdp", "dlfIdp", "draftSharksIdp"}
     IDP_ROOKIE_ONLY_NO_MARKET_CAP = 2600
 
-    _curve_pos_map = SLEEPER_ROSTER_DATA.get("positions", {}) if isinstance(SLEEPER_ROSTER_DATA, dict) else {}
+    _curve_pos_map = (
+        SLEEPER_ROSTER_DATA.get("positions", {}) if isinstance(SLEEPER_ROSTER_DATA, dict) else {}
+    )
     _rookie_must_have_norm = {
         normalize_lookup_name(n)
         for n in (ROOKIE_MUST_HAVE_NAMES or [])
@@ -5086,7 +5543,9 @@ async def run(progress_callback=None):
     }
 
     def _pos_for_curve(name, pdata=None):
-        p = str((pdata or {}).get("position") or _curve_pos_map.get(name) or _get_pos(name) or "").upper()
+        p = str(
+            (pdata or {}).get("position") or _curve_pos_map.get(name) or _get_pos(name) or ""
+        ).upper()
         if p:
             return p
         ident = _resolve_identity_cached(name, preferred_pos="")
@@ -5151,6 +5610,7 @@ async def run(progress_callback=None):
     def _latest_file(directory, pattern):
         try:
             import fnmatch
+
             if not directory or not os.path.isdir(directory):
                 return None
             candidates = [
@@ -5193,7 +5653,13 @@ async def run(progress_callback=None):
         pos_map = sleeper.get("positions", {}) if isinstance(sleeper.get("positions"), dict) else {}
         return players, pos_map, str(p)
 
-    _curve_universes = ("offense_veterans", "offense_rookies", "idp_veterans", "idp_rookies", "picks")
+    _curve_universes = (
+        "offense_veterans",
+        "offense_rookies",
+        "idp_veterans",
+        "idp_rookies",
+        "picks",
+    )
     _rank_curve_targets = {u: [] for u in _curve_universes}
     _ref_players, _ref_pos_map, _rank_curve_ref_path = _load_rank_curve_reference_payload()
     for _nm, _pd in (_ref_players or {}).items():
@@ -5212,7 +5678,11 @@ async def run(progress_callback=None):
             _rank_curve_targets.setdefault(_u, []).append(float(_v))
     for _u in list(_rank_curve_targets.keys()):
         _rank_curve_targets[_u] = sorted(
-            [float(v) for v in _rank_curve_targets.get(_u, []) if isinstance(v, (int, float)) and v > 0],
+            [
+                float(v)
+                for v in _rank_curve_targets.get(_u, [])
+                if isinstance(v, (int, float)) and v > 0
+            ],
             reverse=True,
         )
 
@@ -5280,7 +5750,11 @@ async def run(progress_callback=None):
             "picks": 4200.0,
         }
         targets = _rank_curve_targets.get(universe_key, [])
-        top_ref = float(targets[0]) if targets else float(defaults.get(universe_key, site_max or COMPOSITE_SCALE))
+        top_ref = (
+            float(targets[0])
+            if targets
+            else float(defaults.get(universe_key, site_max or COMPOSITE_SCALE))
+        )
         top_ref = max(200.0, min(float(COMPOSITE_SCALE), top_ref))
         exp = 0.68 if "rookies" in universe_key else 0.62
         off = 8.0 if "rookies" in universe_key else 18.0
@@ -5294,11 +5768,15 @@ async def run(progress_callback=None):
         "referencePath": _rank_curve_ref_path,
         "minSourceCount": RANK_CURVE_MIN_SOURCE_COUNT,
         "minTargetCount": RANK_CURVE_MIN_TARGET_COUNT,
-        "universes": {u: {"targetCount": len(_rank_curve_targets.get(u, []))} for u in _curve_universes},
+        "universes": {
+            u: {"targetCount": len(_rank_curve_targets.get(u, []))} for u in _curve_universes
+        },
         "sources": {},
     }
 
-    def _calibrated_rank_to_value(dash_key, rank_value, pname, pdata=None, site_max=9999.0, universe_override=None):
+    def _calibrated_rank_to_value(
+        dash_key, rank_value, pname, pdata=None, site_max=9999.0, universe_override=None
+    ):
         universe_key = universe_override or _asset_universe_cached(pname, pdata)
         source_ranks = _rank_curve_source_ranks.get((dash_key, universe_key), [])
         target_curve = _rank_curve_targets.get(universe_key, [])
@@ -5312,13 +5790,20 @@ async def run(progress_callback=None):
             if isinstance(mapped, (int, float)) and mapped > 0:
                 return float(mapped), universe_key, False
         # Sparse conservative fallback (explicitly logged in diagnostics).
-        return float(_fallback_sparse_rank_value(rank_value, universe_key, site_max=site_max)), universe_key, True
+        return (
+            float(_fallback_sparse_rank_value(rank_value, universe_key, site_max=site_max)),
+            universe_key,
+            True,
+        )
 
     for _sk in sorted(_rank_curve_sites):
         for _u in _curve_universes:
             _src = _rank_curve_source_ranks.get((_sk, _u), [])
             _tgt = _rank_curve_targets.get(_u, [])
-            _curve_ready = len(_src) >= RANK_CURVE_MIN_SOURCE_COUNT and len(_tgt) >= RANK_CURVE_MIN_TARGET_COUNT
+            _curve_ready = (
+                len(_src) >= RANK_CURVE_MIN_SOURCE_COUNT
+                and len(_tgt) >= RANK_CURVE_MIN_TARGET_COUNT
+            )
             _samples = {}
             if _src:
                 for _label, _rank in (
@@ -5326,8 +5811,19 @@ async def run(progress_callback=None):
                     ("middle", _src[len(_src) // 2]),
                     ("tail", _src[-1]),
                 ):
-                    _val, _, _fb = _calibrated_rank_to_value(_sk, _rank, "", None, site_max=max_values.get(_sk, 9999), universe_override=_u)
-                    _samples[_label] = {"rank": round(float(_rank), 4), "value": int(round(_val)), "fallback": bool(_fb)}
+                    _val, _, _fb = _calibrated_rank_to_value(
+                        _sk,
+                        _rank,
+                        "",
+                        None,
+                        site_max=max_values.get(_sk, 9999),
+                        universe_override=_u,
+                    )
+                    _samples[_label] = {
+                        "rank": round(float(_rank), 4),
+                        "value": int(round(_val)),
+                        "fallback": bool(_fb),
+                    }
             _top_v = (_samples.get("top") or {}).get("value")
             _tail_v = (_samples.get("tail") or {}).get("value")
             _spread_ratio = (
@@ -5352,7 +5848,9 @@ async def run(progress_callback=None):
             }
 
     _curve_total = len(_rank_curve_diagnostics["sources"])
-    _curve_built = sum(1 for _v in _rank_curve_diagnostics["sources"].values() if _v.get("curveBuilt"))
+    _curve_built = sum(
+        1 for _v in _rank_curve_diagnostics["sources"].values() if _v.get("curveBuilt")
+    )
     _curve_fallback = _curve_total - _curve_built
     print(
         f"  [RankCurve] Built {_curve_built}/{_curve_total} source-universe curves "
@@ -5384,17 +5882,20 @@ async def run(progress_callback=None):
         if len(transformed) >= 2:
             mean_val = sum(transformed) / len(transformed)
             variance = sum((v - mean_val) ** 2 for v in transformed) / len(transformed)
-            stdev_val = variance ** 0.5
+            stdev_val = variance**0.5
             site_stats[dash_key] = {
                 "mean": round(mean_val, 2),
                 "stdev": round(stdev_val, 2),
                 "count": len(transformed),
             }
             if DEBUG:
-                print(f"  [Stats] {dash_key}: μ={mean_val:.1f}  σ={stdev_val:.1f}  n={len(transformed)}")
+                print(
+                    f"  [Stats] {dash_key}: μ={mean_val:.1f}  σ={stdev_val:.1f}  n={len(transformed)}"
+                )
 
     # ── Compute composite value for every player ──
     _pos_map = SLEEPER_ROSTER_DATA.get("positions", {})
+
     def _is_te(name):
         pos = _pos_map.get(name, "")
         if pos.upper() == "TE":
@@ -5405,6 +5906,7 @@ async def run(progress_callback=None):
         return False
 
     composites = {}
+
     def _player_is_idp(pname):
         pos = _pos_map.get(pname, "")
         if not pos:
@@ -5422,7 +5924,7 @@ async def run(progress_callback=None):
         if mean <= 0:
             return 0.0
         var = sum((v - mean) ** 2 for v in vals) / len(vals)
-        return (var ** 0.5) / mean
+        return (var**0.5) / mean
 
     def _clampf(v, lo, hi):
         try:
@@ -5515,7 +6017,9 @@ async def run(progress_callback=None):
             high_gap = sorted_norms[-1][0] - sorted_norms[-2][0]
             start_idx = 1 if low_gap >= OUTLIER_TRIM_GAP else 0
             end_idx = -1 if high_gap >= OUTLIER_TRIM_GAP else None
-            trimmed = sorted_norms[start_idx:end_idx] if end_idx is not None else sorted_norms[start_idx:]
+            trimmed = (
+                sorted_norms[start_idx:end_idx] if end_idx is not None else sorted_norms[start_idx:]
+            )
             if not trimmed:
                 trimmed = sorted_norms
         else:
@@ -5546,9 +6050,8 @@ async def run(progress_callback=None):
 
         # Single-source discount
         if len(wNorms) == 1:
-            single_src_discount = (
-                SINGLE_SOURCE_DISCOUNT_MIN
-                + ((SINGLE_SOURCE_DISCOUNT_MAX - SINGLE_SOURCE_DISCOUNT_MIN) * market_conf)
+            single_src_discount = SINGLE_SOURCE_DISCOUNT_MIN + (
+                (SINGLE_SOURCE_DISCOUNT_MAX - SINGLE_SOURCE_DISCOUNT_MIN) * market_conf
             )
             composite *= single_src_discount
 
@@ -5600,7 +6103,9 @@ async def run(progress_callback=None):
         players_json[name]["_marketConfidence"] = comp.get("marketConfidence", 0.5)
         players_json[name]["_marketDispersionCV"] = comp.get("dispersionCV", 0.0)
         players_json[name]["_idpRealMarketSources"] = int(comp.get("idpRealMarketSources", 0) or 0)
-        players_json[name]["_rookieOnlyDlfGuardrailApplied"] = bool(comp.get("rookieOnlyDlfGuardrailApplied", False))
+        players_json[name]["_rookieOnlyDlfGuardrailApplied"] = bool(
+            comp.get("rookieOnlyDlfGuardrailApplied", False)
+        )
 
     # ── Hard floor: seed rankings with at least top 400 KTC players ──
     _ktc_seed_added = 0
@@ -5754,16 +6259,23 @@ async def run(progress_callback=None):
     # Rookies are sourced from either:
     #  - Sleeper years_exp == 0, or
     #  - must-have rookie list (if the player has at least one site value).
-    _rookie_must_have_norm = {
-        normalize_lookup_name(n)
-        for n in (ROOKIE_MUST_HAVE_NAMES or [])
-        if n
-    }
+    _rookie_must_have_norm = {normalize_lookup_name(n) for n in (ROOKIE_MUST_HAVE_NAMES or []) if n}
     _rookie_site_keys = tuple(
-        k for k in (
-            "ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "draftSharks", "yahoo",
-            "dynastyNerds", "dlfSf", "dlfIdp", "dlfRsf", "dlfRidp",
-            "idpTradeCalc", "fantasyProsIdp"
+        k
+        for k in (
+            "ktc",
+            "fantasyCalc",
+            "dynastyDaddy",
+            "fantasyPros",
+            "draftSharks",
+            "yahoo",
+            "dynastyNerds",
+            "dlfSf",
+            "dlfIdp",
+            "dlfRsf",
+            "dlfRidp",
+            "idpTradeCalc",
+            "fantasyProsIdp",
         )
     )
 
@@ -5840,17 +6352,29 @@ async def run(progress_callback=None):
     # Real pick-anchor sources available from ingestion (site-specific evidence).
     # Used to avoid stamping synthetic uniform values across multiple sites.
     _legacy_pick_site_keys = [
-        sk for sk in (
-            "ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "draftSharks", "yahoo",
-            "dynastyNerds", "dlfSf", "dlfIdp", "dlfRsf", "dlfRidp",
-            "idpTradeCalc", "fantasyProsIdp"
+        sk
+        for sk in (
+            "ktc",
+            "fantasyCalc",
+            "dynastyDaddy",
+            "fantasyPros",
+            "draftSharks",
+            "yahoo",
+            "dynastyNerds",
+            "dlfSf",
+            "dlfIdp",
+            "dlfRsf",
+            "dlfRidp",
+            "idpTradeCalc",
+            "fantasyProsIdp",
         )
         if sk in _legacy_pick_anchors
     ]
 
     # Outside-market tier values for 2027/2028 rounds 1-4.
     outside_site_keys = [
-        sk for sk in ("ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "yahoo", "idpTradeCalc")
+        sk
+        for sk in ("ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "yahoo", "idpTradeCalc")
         if sk in _legacy_pick_anchors
     ]
     outside_tier = {}  # (year, round, tier) -> {"siteVals":{}, "blend":float|None}
@@ -5883,7 +6407,12 @@ async def run(progress_callback=None):
             for tier in ("early", "mid", "late"):
                 base = _tier_avg_from_slots(base_2026_slot, rnd, tier)
                 ext = outside_tier.get((year, rnd, tier), {}).get("blend")
-                if isinstance(base, (int, float)) and base > 0 and isinstance(ext, (int, float)) and ext > 0:
+                if (
+                    isinstance(base, (int, float))
+                    and base > 0
+                    and isinstance(ext, (int, float))
+                    and ext > 0
+                ):
                     ratios.append(ext / base)
         if ratios:
             med = _median(ratios, discount_by_year[year])
@@ -5892,8 +6421,8 @@ async def run(progress_callback=None):
             else:
                 discount_by_year[year] = max(0.45, min(0.85, med))
 
-    rebuilt_pick_entries = {}   # players_json labels -> entry
-    rebuilt_pick_anchors = {}   # site -> canonical pick key (no "Pick")
+    rebuilt_pick_entries = {}  # players_json labels -> entry
+    rebuilt_pick_anchors = {}  # site -> canonical pick key (no "Pick")
 
     def _put_pick(label, canonical_key, value, site_vals):
         v = max(1, int(round(float(value))))
@@ -5910,7 +6439,9 @@ async def run(progress_callback=None):
             e["ktc"] = v
             rebuilt_pick_anchors.setdefault("ktc", {})[canonical_key] = v
         e["_composite"] = v
-        e["_sites"] = max(1, sum(1 for kk, vv in e.items() if kk and kk[0] != "_" and _has_numeric_value(vv)))
+        e["_sites"] = max(
+            1, sum(1 for kk, vv in e.items() if kk and kk[0] != "_" and _has_numeric_value(vv))
+        )
         rebuilt_pick_entries[label] = e
 
     # Year 2026: direct rookie-slot mapping.
@@ -5990,7 +6521,9 @@ async def run(progress_callback=None):
             players_json.pop(_pick_name, None)
             _removed_future_slot_rows += 1
     if DEBUG and _removed_future_slot_rows:
-        print(f"  [Pick Model] Removed {_removed_future_slot_rows} future-year slot pick rows (2027/2028 tier-only).")
+        print(
+            f"  [Pick Model] Removed {_removed_future_slot_rows} future-year slot pick rows (2027/2028 tier-only)."
+        )
 
     # Attach rebuilt picks and overwrite exported pick anchors.
     players_json.update(rebuilt_pick_entries)
@@ -6003,7 +6536,14 @@ async def run(progress_callback=None):
     )
 
     # ── Roster guarantee: every rostered player gets a value/rank entry ──
-    _fallback_site_keys = ("ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "yahoo", "idpTradeCalc")
+    _fallback_site_keys = (
+        "ktc",
+        "fantasyCalc",
+        "dynastyDaddy",
+        "fantasyPros",
+        "yahoo",
+        "idpTradeCalc",
+    )
     _rostered_missing_added = 0
     _rostered_fallback_applied = 0
 
@@ -6037,15 +6577,27 @@ async def run(progress_callback=None):
     for _p, _vals in list(_pos_floor.items()):
         _pos_floor[_p] = int(round(_median(_vals, 1.0) * 0.35)) if _vals else 1
         _pos_floor[_p] = max(1, _pos_floor[_p])
-    _global_floor = max(1, int(round(_median([
-        float(p.get("_composite")) for n, p in players_json.items()
-        if (
-            isinstance(p, dict)
-            and not _looks_like_pick_name(n)
-            and isinstance(p.get("_composite"), (int, float))
-            and p.get("_composite") > 0
-        )
-    ], 800.0) * 0.20)))
+    _global_floor = max(
+        1,
+        int(
+            round(
+                _median(
+                    [
+                        float(p.get("_composite"))
+                        for n, p in players_json.items()
+                        if (
+                            isinstance(p, dict)
+                            and not _looks_like_pick_name(n)
+                            and isinstance(p.get("_composite"), (int, float))
+                            and p.get("_composite") > 0
+                        )
+                    ],
+                    800.0,
+                )
+                * 0.20
+            )
+        ),
+    )
 
     # Pre-build reverse index: normalized name → first matching player key.
     # Replaces O(N*M) inner-loop scans with O(1) dict lookups.
@@ -6084,7 +6636,12 @@ async def run(progress_callback=None):
             _rostered_missing_added += 1
 
         # Try to populate fallback site values if missing.
-        sid = str(entry.get("_sleeperId") or (ident.get("id") if ident else "") or _player_id_map.get(target_name) or "").strip()
+        sid = str(
+            entry.get("_sleeperId")
+            or (ident.get("id") if ident else "")
+            or _player_id_map.get(target_name)
+            or ""
+        ).strip()
         for sk in _fallback_site_keys:
             if _has_numeric_value(entry.get(sk)):
                 continue
@@ -6109,7 +6666,9 @@ async def run(progress_callback=None):
             _pos_map[target_name] = pref_pos
 
         if not isinstance(entry.get("_composite"), (int, float)) or entry.get("_composite", 0) <= 0:
-            site_vals, has_rookie_only_dlf, has_real_idp_market = _fallback_site_values_for_entry(entry, pref_pos)
+            site_vals, has_rookie_only_dlf, has_real_idp_market = _fallback_site_values_for_entry(
+                entry, pref_pos
+            )
             if site_vals:
                 comp_val = int(round(sum(site_vals) / len(site_vals)))
             else:
@@ -6161,7 +6720,7 @@ async def run(progress_callback=None):
         if _nn and _nn not in _must_have_order:
             _must_have_order[_nn] = _idx
 
-    for _raw_name in (ROOKIE_MUST_HAVE_NAMES or []):
+    for _raw_name in ROOKIE_MUST_HAVE_NAMES or []:
         _clean_nm = clean_name(_raw_name)
         if not _clean_nm:
             continue
@@ -6194,7 +6753,10 @@ async def run(progress_callback=None):
         if not isinstance(_entry, dict):
             _entry = {}
 
-        if not isinstance(_entry.get("_composite"), (int, float)) or _entry.get("_composite", 0) <= 0:
+        if (
+            not isinstance(_entry.get("_composite"), (int, float))
+            or _entry.get("_composite", 0) <= 0
+        ):
             _ord = _must_have_order.get(normalize_lookup_name(_clean_nm), len(_must_have_curve) - 1)
             _ord = max(0, min(_ord, len(_must_have_curve) - 1))
             _seed = max(1, int(round(_must_have_curve[_ord])))
@@ -6205,7 +6767,9 @@ async def run(progress_callback=None):
             _entry["_fallbackReason"] = "must_have_rookie_guarantee"
             _must_have_fallback += 1
 
-        _must_have_hint = _must_have_rookie_bucket(_target_name) or _must_have_rookie_bucket(_clean_nm)
+        _must_have_hint = _must_have_rookie_bucket(_target_name) or _must_have_rookie_bucket(
+            _clean_nm
+        )
         if _ident and _ident.get("id"):
             _sid = str(_ident["id"])
             _entry["_sleeperId"] = _sid
@@ -6270,7 +6834,9 @@ async def run(progress_callback=None):
             _pos_map[_name] = _hint
 
     if DEBUG:
-        print(f"  [Rookies] Tagged years_exp for {_years_exp_tagged} players; rookie-flagged {_rookie_tagged}; age tagged {_age_tagged}")
+        print(
+            f"  [Rookies] Tagged years_exp for {_years_exp_tagged} players; rookie-flagged {_rookie_tagged}; age tagged {_age_tagged}"
+        )
 
     # Set _rawComposite and _finalAdjusted directly from _composite.
     for name, pdata in players_json.items():
@@ -6316,10 +6882,21 @@ async def run(progress_callback=None):
                 continue
             if _get_pos(n) in _IDP_POSITIONS:
                 continue
-            has_idp_signal = any(isinstance(pdata.get(k), (int, float)) for k in ("fantasyProsIdp", "draftSharksIdp"))
+            has_idp_signal = any(
+                isinstance(pdata.get(k), (int, float)) for k in ("fantasyProsIdp", "draftSharksIdp")
+            )
             has_off_signal = any(
                 isinstance(pdata.get(k), (int, float))
-                for k in ("ktc", "fantasyCalc", "dynastyDaddy", "fantasyPros", "draftSharks", "yahoo", "dynastyNerds", "dlfSf")
+                for k in (
+                    "ktc",
+                    "fantasyCalc",
+                    "dynastyDaddy",
+                    "fantasyPros",
+                    "draftSharks",
+                    "yahoo",
+                    "dynastyNerds",
+                    "dlfSf",
+                )
             )
             if has_idp_signal and not has_off_signal:
                 _pos_map[n] = "LB"
@@ -6327,12 +6904,20 @@ async def run(progress_callback=None):
         if promoted:
             SLEEPER_ROSTER_DATA["positions"] = _pos_map
             offensive_count, idp_count = _coverage_counts()
-            print(f"  [Coverage] IDP hard-floor promoted {promoted} players; IDP count now {idp_count}")
+            print(
+                f"  [Coverage] IDP hard-floor promoted {promoted} players; IDP count now {idp_count}"
+            )
 
-    print(f"  [Coverage] Offensive composite players: {offensive_count} (target {TARGET_OFFENSIVE_POOL})")
-    print(f"  [Coverage] IDP composite players: {idp_count} (target {TARGET_IDP_POOL}, floor {idp_floor_target})")
+    print(
+        f"  [Coverage] Offensive composite players: {offensive_count} (target {TARGET_OFFENSIVE_POOL})"
+    )
+    print(
+        f"  [Coverage] IDP composite players: {idp_count} (target {TARGET_IDP_POOL}, floor {idp_floor_target})"
+    )
     if offensive_count < TARGET_OFFENSIVE_POOL:
-        print(f"  [Coverage] ⚠ Offensive pool below target by {TARGET_OFFENSIVE_POOL - offensive_count}")
+        print(
+            f"  [Coverage] ⚠ Offensive pool below target by {TARGET_OFFENSIVE_POOL - offensive_count}"
+        )
     if idp_count < idp_floor_target:
         print(f"  [Coverage] ⚠ IDP pool below floor by {idp_floor_target - idp_count}")
 
@@ -6408,14 +6993,16 @@ async def run(progress_callback=None):
                 reason = diag.get("reason", "unknown")
                 reason_counts[reason] = reason_counts.get(reason, 0) + 1
 
-            deficits.append({
-                "name": name,
-                "pos": pos,
-                "composite": int(round(comp)),
-                "siteCount": len(present_sites),
-                "missingSites": missing_sites,
-                "missingDiagnostics": diagnostics,
-            })
+            deficits.append(
+                {
+                    "name": name,
+                    "pos": pos,
+                    "composite": int(round(comp)),
+                    "siteCount": len(present_sites),
+                    "missingSites": missing_sites,
+                    "missingDiagnostics": diagnostics,
+                }
+            )
 
         missing_by_site = {k: v for k, v in missing_by_site.items() if v > 0}
         return {
@@ -6533,8 +7120,10 @@ async def run(progress_callback=None):
 
     if KTC_CROWD_DATA.get("trades") or KTC_CROWD_DATA.get("waivers"):
         dashboard_json["ktcCrowd"] = KTC_CROWD_DATA
-        print(f"  [KTC Crowd] {len(KTC_CROWD_DATA.get('trades', []))} trades, "
-              f"{len(KTC_CROWD_DATA.get('waivers', []))} waivers")
+        print(
+            f"  [KTC Crowd] {len(KTC_CROWD_DATA.get('trades', []))} trades, "
+            f"{len(KTC_CROWD_DATA.get('waivers', []))} waivers"
+        )
 
     if ktc_id_map:
         dashboard_json["ktcIdMap"] = ktc_id_map
@@ -6547,8 +7136,7 @@ async def run(progress_callback=None):
 
     js_fname = os.path.join(SCRIPT_DIR, "dynasty_data.js")
     with open(js_fname, "w", encoding="utf-8") as f:
-        f.write("// Auto-generated by Dynasty Scraper — "
-                f"{datetime.date.today()}\n")
+        f.write("// Auto-generated by Dynasty Scraper — " f"{datetime.date.today()}\n")
         f.write("window.DYNASTY_DATA = ")
         json.dump(dashboard_json, f, indent=2, ensure_ascii=False)
         f.write(";\n")
@@ -6622,7 +7210,7 @@ async def run(progress_callback=None):
         copy_paths = [
             json_fname,
             js_fname,
-            fname,           # dynasty_values.csv
+            fname,  # dynasty_values.csv
             full_csv_fname,  # dynasty_full.csv
         ]
         for p in copy_paths:

--- a/codex_loop.py
+++ b/codex_loop.py
@@ -10,6 +10,7 @@ from typing import Any
 JSON_START = "===AUDIT_JSON_START==="
 JSON_END = "===AUDIT_JSON_END==="
 
+
 @dataclasses.dataclass
 class CommandResult:
     command: str
@@ -19,21 +20,29 @@ class CommandResult:
     started_at: str
     finished_at: str
 
+
 def utc_now() -> str:
-    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return (
+        dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+
 
 def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
+
 
 def write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
 
+
 def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
 
+
 def file_hash(path: Path) -> str:
     return sha256_text(read_text(path)) if path.exists() else ""
+
 
 def shorten(text: str, limit: int = 5000) -> str:
     text = (text or "").strip()
@@ -43,19 +52,29 @@ def shorten(text: str, limit: int = 5000) -> str:
     tail = text[-limit // 2 :]
     return f"{head}\n\n... [truncated] ...\n\n{tail}"
 
+
 def shell_join(parts: list[str]) -> str:
     if os.name == "nt":
         return subprocess.list2cmdline(parts)
     return " ".join(shlex.quote(p) for p in parts)
 
+
 def split_command(command: str) -> list[str]:
     return shlex.split(command, posix=(os.name != "nt"))
+
 
 def has_shell_operators(command: str) -> bool:
     # Keep this conservative: if present, use shell=True for that command.
     return bool(re.search(r"[|&;<>()`]", command))
 
-def run_command(command: str | list[str], cwd: Path, stdin_text: str | None = None, timeout: int = 1800, shell: bool | None = None) -> CommandResult:
+
+def run_command(
+    command: str | list[str],
+    cwd: Path,
+    stdin_text: str | None = None,
+    timeout: int = 1800,
+    shell: bool | None = None,
+) -> CommandResult:
     if shell is None:
         shell = isinstance(command, str)
     resolved = command if isinstance(command, str) else shell_join(command)
@@ -71,11 +90,13 @@ def run_command(command: str | list[str], cwd: Path, stdin_text: str | None = No
     )
     return CommandResult(resolved, proc.returncode, proc.stdout, proc.stderr, started, utc_now())
 
+
 def is_codex_exec_command(argv: list[str]) -> bool:
     if len(argv) < 2:
         return False
     exe = Path(str(argv[0]).strip('"')).name.lower()
     return exe in {"codex", "codex.exe"} and str(argv[1]).lower() == "exec"
+
 
 def _argv_has_option(argv: list[str], opt: str) -> bool:
     for a in argv:
@@ -83,15 +104,24 @@ def _argv_has_option(argv: list[str], opt: str) -> bool:
             return True
     return False
 
+
 def codex_exec_has_prompt_token(argv: list[str]) -> bool:
     if not is_codex_exec_command(argv):
         return False
     # codex exec prompt token is positional; "-" means read prompt from stdin.
     # Skip values for known options that consume a following token.
     takes_value = {
-        "-C", "--cd", "-m", "--model", "--config", "--profile",
-        "--output-schema", "--output-last-message-file", "--output-json",
-        "--sandbox", "--approval-mode",
+        "-C",
+        "--cd",
+        "-m",
+        "--model",
+        "--config",
+        "--profile",
+        "--output-schema",
+        "--output-last-message-file",
+        "--output-json",
+        "--sandbox",
+        "--approval-mode",
     }
     need_value = False
     for token in argv[2:]:
@@ -113,7 +143,14 @@ def codex_exec_has_prompt_token(argv: list[str]) -> bool:
         return True
     return False
 
-def resolve_agent_argv(base_argv: list[str], *, audit_mode: bool = False, audit_schema_path: Path | None = None, audit_output_path: Path | None = None) -> tuple[list[str], dict[str, Any]]:
+
+def resolve_agent_argv(
+    base_argv: list[str],
+    *,
+    audit_mode: bool = False,
+    audit_schema_path: Path | None = None,
+    audit_output_path: Path | None = None,
+) -> tuple[list[str], dict[str, Any]]:
     argv = list(base_argv)
     info: dict[str, Any] = {
         "is_codex_exec": is_codex_exec_command(argv),
@@ -128,15 +165,19 @@ def resolve_agent_argv(base_argv: list[str], *, audit_mode: bool = False, audit_
         if not _argv_has_option(argv, "--output-schema"):
             argv.extend(["--output-schema", str(audit_schema_path)])
             info["schema_mode"] = True
-        if audit_output_path is not None and not _argv_has_option(argv, "--output-last-message-file"):
+        if audit_output_path is not None and not _argv_has_option(
+            argv, "--output-last-message-file"
+        ):
             argv.extend(["--output-last-message-file", str(audit_output_path)])
             info["schema_mode"] = True
     return argv, info
+
 
 def command_consumes_stdin(argv: list[str]) -> bool:
     if is_codex_exec_command(argv):
         return "-" in argv
     return True
+
 
 def try_git(repo: Path, args: list[str]) -> CommandResult | None:
     try:
@@ -144,15 +185,19 @@ def try_git(repo: Path, args: list[str]) -> CommandResult | None:
     except Exception:
         return None
 
+
 def git_available(repo: Path) -> bool:
     r = try_git(repo, ["rev-parse", "--is-inside-work-tree"])
     return bool(r and r.returncode == 0 and "true" in r.stdout.lower())
 
+
 def snapshot_hashes(repo: Path, files: list[str]) -> dict[str, str]:
     return {rel: file_hash(repo / rel) for rel in files}
 
+
 def changed_files_from_hashes(before: dict[str, str], after: dict[str, str]) -> list[str]:
     return [k for k in sorted(set(before) | set(after)) if before.get(k, "") != after.get(k, "")]
+
 
 def summarize_validations(results: list[dict[str, Any]]) -> str:
     lines = []
@@ -167,8 +212,10 @@ def summarize_validations(results: list[dict[str, Any]]) -> str:
             lines.append(shorten(r["stderr"], 1500))
     return "\n".join(lines).strip()
 
+
 def load_config(path: Path) -> dict[str, Any]:
     return json.loads(read_text(path))
+
 
 AUDIT_JSON_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -183,7 +230,14 @@ AUDIT_JSON_SCHEMA: dict[str, Any] = {
             "items": {
                 "type": "object",
                 "additionalProperties": False,
-                "required": ["severity", "title", "file", "evidence", "why_it_matters", "exact_fix"],
+                "required": [
+                    "severity",
+                    "title",
+                    "file",
+                    "evidence",
+                    "why_it_matters",
+                    "exact_fix",
+                ],
                 "properties": {
                     "severity": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
                     "title": {"type": "string"},
@@ -198,8 +252,10 @@ AUDIT_JSON_SCHEMA: dict[str, Any] = {
     },
 }
 
+
 def write_audit_schema(path: Path) -> None:
     write_text(path, json.dumps(AUDIT_JSON_SCHEMA, indent=2))
+
 
 def extract_audit_json(text: str) -> dict[str, Any] | None:
     pat = re.compile(re.escape(JSON_START) + r"\s*(\{.*?\})\s*" + re.escape(JSON_END), re.DOTALL)
@@ -210,6 +266,7 @@ def extract_audit_json(text: str) -> dict[str, Any] | None:
         return json.loads(m.group(1))
     except json.JSONDecodeError:
         return None
+
 
 def extract_json_object(text: str) -> dict[str, Any] | None:
     raw = (text or "").strip()
@@ -230,6 +287,7 @@ def extract_json_object(text: str) -> dict[str, Any] | None:
         return obj if isinstance(obj, dict) else None
     except Exception:
         return None
+
 
 def normalize_audit(audit: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(audit, dict):
@@ -252,16 +310,20 @@ def normalize_audit(audit: dict[str, Any] | None) -> dict[str, Any] | None:
             sev = str(item.get("severity", "medium")).lower()
             if sev not in {"critical", "high", "medium", "low"}:
                 sev = "medium"
-            issues.append({
-                "severity": sev,
-                "title": str(item.get("title", "") or ""),
-                "file": str(item.get("file", "") or ""),
-                "evidence": str(item.get("evidence", "") or ""),
-                "why_it_matters": str(item.get("why_it_matters", "") or ""),
-                "exact_fix": str(item.get("exact_fix", "") or ""),
-            })
+            issues.append(
+                {
+                    "severity": sev,
+                    "title": str(item.get("title", "") or ""),
+                    "file": str(item.get("file", "") or ""),
+                    "evidence": str(item.get("evidence", "") or ""),
+                    "why_it_matters": str(item.get("why_it_matters", "") or ""),
+                    "exact_fix": str(item.get("exact_fix", "") or ""),
+                }
+            )
     satisfied_when_in = audit.get("satisfied_when")
-    satisfied_when = [str(x) for x in satisfied_when_in] if isinstance(satisfied_when_in, list) else []
+    satisfied_when = (
+        [str(x) for x in satisfied_when_in] if isinstance(satisfied_when_in, list) else []
+    )
     return {
         "status": status,
         "score": score,
@@ -270,12 +332,15 @@ def normalize_audit(audit: dict[str, Any] | None) -> dict[str, Any] | None:
         "satisfied_when": satisfied_when,
     }
 
+
 def compact_issue_list(issues: list[dict[str, Any]], max_items: int = 10) -> str:
     if not issues:
         return "None."
     lines = []
     for idx, issue in enumerate(issues[:max_items], start=1):
-        lines.append(f"{idx}. [{issue.get('severity','unknown')}] {issue.get('title','Untitled issue')}")
+        lines.append(
+            f"{idx}. [{issue.get('severity','unknown')}] {issue.get('title','Untitled issue')}"
+        )
         if issue.get("why_it_matters"):
             lines.append(f"   Why: {issue['why_it_matters']}")
         if issue.get("exact_fix"):
@@ -284,11 +349,20 @@ def compact_issue_list(issues: list[dict[str, Any]], max_items: int = 10) -> str
         lines.append(f"... and {len(issues) - max_items} more")
     return "\n".join(lines)
 
-def build_implement_prompt(goal: str, files: list[str], rules: list[str], previous_findings: list[dict[str, Any]], validation_summary: str, iteration: int) -> str:
+
+def build_implement_prompt(
+    goal: str,
+    files: list[str],
+    rules: list[str],
+    previous_findings: list[dict[str, Any]],
+    validation_summary: str,
+    iteration: int,
+) -> str:
     files_block = "\n".join(f"- {x}" for x in files)
     rules_block = "\n".join(f"- {x}" for x in rules) if rules else "- Keep changes targeted."
     findings_block = compact_issue_list(previous_findings) if previous_findings else "None."
-    return textwrap.dedent(f'''
+    return (
+        textwrap.dedent(f"""
     You are operating inside a local code repository.
 
     Objective:
@@ -318,30 +392,46 @@ def build_implement_prompt(goal: str, files: list[str], rules: list[str], previo
     6. When done, print a short summary of what you changed.
 
     Do not return an audit report here. Implement only.
-    ''').strip() + "\n"
+    """).strip()
+        + "\n"
+    )
 
-def build_audit_prompt(goal: str, files: list[str], audit_requirements: list[str], validation_summary: str, iteration: int) -> str:
+
+def build_audit_prompt(
+    goal: str,
+    files: list[str],
+    audit_requirements: list[str],
+    validation_summary: str,
+    iteration: int,
+) -> str:
     files_block = "\n".join(f"- {x}" for x in files)
-    reqs_block = "\n".join(f"- {x}" for x in audit_requirements) if audit_requirements else "- Audit the real live path."
+    reqs_block = (
+        "\n".join(f"- {x}" for x in audit_requirements)
+        if audit_requirements
+        else "- Audit the real live path."
+    )
     example = {
         "status": "not_satisfied",
         "score": 72,
         "summary": "Brief overall verdict.",
-        "issues": [{
-            "severity": "high",
-            "title": "Example issue",
-            "file": "index.html",
-            "evidence": "function buildX still renders raw values from pData",
-            "why_it_matters": "Breaks canonical value display",
-            "exact_fix": "Route table cell rendering through canonical siteDetails path"
-        }],
+        "issues": [
+            {
+                "severity": "high",
+                "title": "Example issue",
+                "file": "index.html",
+                "evidence": "function buildX still renders raw values from pData",
+                "why_it_matters": "Breaks canonical value display",
+                "exact_fix": "Route table cell rendering through canonical siteDetails path",
+            }
+        ],
         "satisfied_when": [
             "All validation commands pass",
             "No high-severity issues remain",
-            "Live path matches intended architecture"
-        ]
+            "Live path matches intended architecture",
+        ],
     }
-    return textwrap.dedent(f'''
+    return (
+        textwrap.dedent(f"""
     Audit this repository without modifying files.
 
     Objective being audited:
@@ -371,9 +461,14 @@ def build_audit_prompt(goal: str, files: list[str], audit_requirements: list[str
     {JSON_START}
     {json.dumps(example, indent=2)}
     {JSON_END}
-    ''').strip() + "\n"
+    """).strip()
+        + "\n"
+    )
 
-def run_validations(repo: Path, commands: list[str], timeout_each: int = 1800) -> list[dict[str, Any]]:
+
+def run_validations(
+    repo: Path, commands: list[str], timeout_each: int = 1800
+) -> list[dict[str, Any]]:
     results = []
     for cmd in commands:
         if has_shell_operators(cmd):
@@ -383,9 +478,11 @@ def run_validations(repo: Path, commands: list[str], timeout_each: int = 1800) -
         results.append(dataclasses.asdict(r))
     return results
 
+
 def has_blocking_issues(audit: dict[str, Any], allow_medium: bool = False) -> bool:
     levels = {"critical", "high"} | (set() if allow_medium else {"medium"})
-    return any(str(i.get("severity","")).lower() in levels for i in (audit.get("issues") or []))
+    return any(str(i.get("severity", "")).lower() in levels for i in (audit.get("issues") or []))
+
 
 def build_run_summary(
     iteration: int,
@@ -405,40 +502,58 @@ def build_run_summary(
     lines.append(f"Implement command: {implement_command}")
     lines.append(f"Audit command: {audit_command}")
     lines.append(f"Audit parse: {audit_parse_source}")
-    lines.append("Changed files: " + (", ".join(changed_files) if changed_files else "none detected"))
+    lines.append(
+        "Changed files: " + (", ".join(changed_files) if changed_files else "none detected")
+    )
     if no_change_streak >= 2:
-        lines.append(f"No-op loop warning: no file changes for {no_change_streak} consecutive iterations")
+        lines.append(
+            f"No-op loop warning: no file changes for {no_change_streak} consecutive iterations"
+        )
     if identical_audit_streak >= 2:
-        lines.append(f"Repeated audit warning: identical audit output for {identical_audit_streak} consecutive iterations")
+        lines.append(
+            f"Repeated audit warning: identical audit output for {identical_audit_streak} consecutive iterations"
+        )
     if validations:
         passed = sum(1 for r in validations if r["returncode"] == 0)
         lines.append(f"Validations: {passed}/{len(validations)} passed")
     if audit:
-        lines.append(f"Audit status: {audit.get('status','unknown')}, score={audit.get('score','n/a')}")
+        lines.append(
+            f"Audit status: {audit.get('status','unknown')}, score={audit.get('score','n/a')}"
+        )
         lines.append(f"Issues: {len(audit.get('issues') or [])}")
     return "\n".join(lines)
+
 
 def default_unparseable_audit(reason: str, evidence: str) -> dict[str, Any]:
     return {
         "status": "not_satisfied",
         "score": 0,
         "summary": reason,
-        "issues": [{
-            "severity": "high",
-            "title": "Unparseable audit output",
-            "file": "",
-            "evidence": evidence,
-            "why_it_matters": "Loop cannot evaluate completion reliably.",
-            "exact_fix": "Ensure audit mode returns valid JSON via schema or required markers.",
-        }],
+        "issues": [
+            {
+                "severity": "high",
+                "title": "Unparseable audit output",
+                "file": "",
+                "evidence": evidence,
+                "why_it_matters": "Loop cannot evaluate completion reliably.",
+                "exact_fix": "Ensure audit mode returns valid JSON via schema or required markers.",
+            }
+        ],
         "satisfied_when": ["Audit output is parseable and validations pass."],
     }
 
+
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Loop an agent through implement -> validate -> audit until done.")
+    ap = argparse.ArgumentParser(
+        description="Loop an agent through implement -> validate -> audit until done."
+    )
     ap.add_argument("--repo", required=True)
     ap.add_argument("--config", required=True)
-    ap.add_argument("--agent-command", required=True, help='Shell command for your coding agent. Prompt is passed on stdin.')
+    ap.add_argument(
+        "--agent-command",
+        required=True,
+        help="Shell command for your coding agent. Prompt is passed on stdin.",
+    )
     ap.add_argument("--max-iters", type=int, default=6)
     ap.add_argument("--timeout", type=int, default=1800)
     ap.add_argument("--allow-medium", action="store_true")
@@ -497,20 +612,33 @@ def main() -> int:
 
         before_hashes = snapshot_hashes(repo, files)
 
-        impl_prompt = build_implement_prompt(goal, files, implementation_rules, previous_findings, last_validation_summary, iteration)
+        impl_prompt = build_implement_prompt(
+            goal, files, implementation_rules, previous_findings, last_validation_summary, iteration
+        )
         write_text(iter_dir / "implement_prompt.txt", impl_prompt)
         impl_argv, impl_cmd_info = resolve_agent_argv(base_agent_argv, audit_mode=False)
-        impl_result = run_command(impl_argv, cwd=repo, stdin_text=impl_prompt, timeout=args.timeout, shell=False)
+        impl_result = run_command(
+            impl_argv, cwd=repo, stdin_text=impl_prompt, timeout=args.timeout, shell=False
+        )
         write_text(iter_dir / "implement_stdout.txt", impl_result.stdout)
         write_text(iter_dir / "implement_stderr.txt", impl_result.stderr)
-        write_text(iter_dir / "implement_result.json", json.dumps(dataclasses.asdict(impl_result), indent=2))
+        write_text(
+            iter_dir / "implement_result.json",
+            json.dumps(dataclasses.asdict(impl_result), indent=2),
+        )
         write_text(iter_dir / "implement_command.txt", shell_join(impl_argv) + "\n")
-        write_text(iter_dir / "implement_diagnostics.json", json.dumps({
-            "resolved_command": shell_join(impl_argv),
-            "is_codex_exec": impl_cmd_info.get("is_codex_exec", False),
-            "codex_prompt_appended": impl_cmd_info.get("codex_prompt_appended", False),
-            "stdin_consumed": command_consumes_stdin(impl_argv),
-        }, indent=2))
+        write_text(
+            iter_dir / "implement_diagnostics.json",
+            json.dumps(
+                {
+                    "resolved_command": shell_join(impl_argv),
+                    "is_codex_exec": impl_cmd_info.get("is_codex_exec", False),
+                    "codex_prompt_appended": impl_cmd_info.get("codex_prompt_appended", False),
+                    "stdin_consumed": command_consumes_stdin(impl_argv),
+                },
+                indent=2,
+            ),
+        )
 
         after_hashes = snapshot_hashes(repo, files)
         changed_files = changed_files_from_hashes(before_hashes, after_hashes)
@@ -520,7 +648,9 @@ def main() -> int:
         write_text(iter_dir / "validations.json", json.dumps(validations, indent=2))
         last_validation_summary = summarize_validations(validations)
 
-        audit_prompt = build_audit_prompt(goal, files, audit_requirements, last_validation_summary, iteration)
+        audit_prompt = build_audit_prompt(
+            goal, files, audit_requirements, last_validation_summary, iteration
+        )
         write_text(iter_dir / "audit_prompt.txt", audit_prompt)
         audit_schema_path = iter_dir / "audit_schema.json"
         audit_output_path = iter_dir / "audit_structured_output.json"
@@ -531,10 +661,14 @@ def main() -> int:
             audit_schema_path=audit_schema_path,
             audit_output_path=audit_output_path,
         )
-        audit_result = run_command(audit_argv, cwd=repo, stdin_text=audit_prompt, timeout=args.timeout, shell=False)
+        audit_result = run_command(
+            audit_argv, cwd=repo, stdin_text=audit_prompt, timeout=args.timeout, shell=False
+        )
         write_text(iter_dir / "audit_stdout.txt", audit_result.stdout)
         write_text(iter_dir / "audit_stderr.txt", audit_result.stderr)
-        write_text(iter_dir / "audit_result.json", json.dumps(dataclasses.asdict(audit_result), indent=2))
+        write_text(
+            iter_dir / "audit_result.json", json.dumps(dataclasses.asdict(audit_result), indent=2)
+        )
         write_text(iter_dir / "audit_command.txt", shell_join(audit_argv) + "\n")
 
         audit_parse_source = "unparsed"
@@ -560,10 +694,19 @@ def main() -> int:
         )
         if audit is None and audit_cmd_info.get("schema_mode") and schema_option_error:
             legacy_audit_argv, _ = resolve_agent_argv(base_agent_argv, audit_mode=False)
-            legacy_result = run_command(legacy_audit_argv, cwd=repo, stdin_text=audit_prompt, timeout=args.timeout, shell=False)
+            legacy_result = run_command(
+                legacy_audit_argv,
+                cwd=repo,
+                stdin_text=audit_prompt,
+                timeout=args.timeout,
+                shell=False,
+            )
             write_text(iter_dir / "audit_stdout_legacy.txt", legacy_result.stdout)
             write_text(iter_dir / "audit_stderr_legacy.txt", legacy_result.stderr)
-            write_text(iter_dir / "audit_result_legacy.json", json.dumps(dataclasses.asdict(legacy_result), indent=2))
+            write_text(
+                iter_dir / "audit_result_legacy.json",
+                json.dumps(dataclasses.asdict(legacy_result), indent=2),
+            )
             audit = normalize_audit(extract_audit_json(legacy_result.stdout))
             if audit:
                 audit_parse_source = "markers_legacy"
@@ -586,14 +729,20 @@ def main() -> int:
             identical_audit_streak = 1
         previous_audit_fingerprint = audit_fingerprint
 
-        write_text(iter_dir / "audit_diagnostics.json", json.dumps({
-            "resolved_command": shell_join(audit_argv),
-            "is_codex_exec": audit_cmd_info.get("is_codex_exec", False),
-            "codex_prompt_appended": audit_cmd_info.get("codex_prompt_appended", False),
-            "schema_mode": audit_cmd_info.get("schema_mode", False),
-            "stdin_consumed": command_consumes_stdin(audit_argv),
-            "parse_source": audit_parse_source,
-        }, indent=2))
+        write_text(
+            iter_dir / "audit_diagnostics.json",
+            json.dumps(
+                {
+                    "resolved_command": shell_join(audit_argv),
+                    "is_codex_exec": audit_cmd_info.get("is_codex_exec", False),
+                    "codex_prompt_appended": audit_cmd_info.get("codex_prompt_appended", False),
+                    "schema_mode": audit_cmd_info.get("schema_mode", False),
+                    "stdin_consumed": command_consumes_stdin(audit_argv),
+                    "parse_source": audit_parse_source,
+                },
+                indent=2,
+            ),
+        )
         write_text(iter_dir / "audit.json", json.dumps(audit, indent=2))
 
         validation_failures = [r for r in validations if r["returncode"] != 0]
@@ -655,6 +804,7 @@ def main() -> int:
     write_text(log_dir / "final_result.json", json.dumps(final, indent=2))
     print("\nSTOPPED: max iterations reached before satisfied state.")
     return 1
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+# Tooling config for the lint/format/type gate (introduced in phases —
+# see /home/dynasty/.claude/plans/write-me-a-plan-temporal-harp.md).
+#
+# This PR (A1) only activates `ruff format` (a mechanical, AST-preserving
+# sweep + a hard-blocking format check in CI). The lint rules and mypy
+# blocks below are defined now but NOT yet gated in CI — the lint gate
+# lands report-only then changed-files-only in a later PR (A2/A3), and
+# mypy is ratcheted per-module later (A4). Defining them here keeps the
+# eventual config in one place without enabling enforcement early.
+
+[tool.ruff]
+line-length = 100  # matches the observed ~89% ≤100 baseline
+target-version = "py312"
+extend-exclude = ["data", "exports", ".next", "node_modules", "frontend"]
+
+[tool.ruff.lint]
+# Default ruleset (pyflakes F + pycodestyle E/W). Enforcement is added
+# in a later phase; present here only so A2/A3 don't churn this file.
+select = ["E", "F", "W"]
+
+[tool.ruff.format]
+# Black-compatible defaults (double quotes, magic trailing comma).
+# No overrides — deterministic output is what makes the CI check safe
+# to hard-block once the sweep has landed.
+
+[tool.mypy]
+# Scaffold only — no CI step runs mypy until phase A4, which ratchets
+# strictness in per-module via [[tool.mypy.overrides]].
+python_version = "3.12"
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,3 +23,10 @@ pytest~=9.0.0
 # TestClient importable but unusable.  Pin httpx here so every test
 # job has it.
 httpx~=0.28.0
+
+# Lint + format + type tooling (config in pyproject.toml).  ruff format
+# is hard-gated in CI as of the A1 sweep; ruff-check and mypy gates are
+# introduced report-only/ratcheted in later phases.  Production never
+# installs requirements-dev.txt, so these stay out of the runtime image.
+ruff~=0.6.0
+mypy~=1.13.0

--- a/scripts/_shared.py
+++ b/scripts/_shared.py
@@ -5,6 +5,7 @@ Consolidates helpers that were duplicated across 5+ scripts:
 - _latest(): find the newest file matching a glob pattern
 - _normalize_name(): minimal player name normalization for cross-system matching
 """
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/scripts/archive/backtest_mad_lambda.py
+++ b/scripts/archive/backtest_mad_lambda.py
@@ -41,6 +41,7 @@ Usage:
 No production behavior is modified.  The output is a markdown report
 + CSV of the per-λ stability metric.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -63,7 +64,16 @@ from src.api import data_contract  # noqa: E402
 
 
 LAMBDA_GRID: tuple[float, ...] = (
-    0.0, 0.05, 0.1, 0.2, 0.3, 0.5, 0.7, 1.0, 1.5, 2.0,
+    0.0,
+    0.05,
+    0.1,
+    0.2,
+    0.3,
+    0.5,
+    0.7,
+    1.0,
+    1.5,
+    2.0,
 )
 
 
@@ -112,9 +122,7 @@ def stability_metric(
     weighted_numer: float = 0.0
     weighted_denom: float = 0.0
     for prev, curr in zip(boards, boards[1:]):
-        prev_top = [
-            (name, info) for name, info in prev.items() if info["rank"] <= top_n
-        ]
+        prev_top = [(name, info) for name, info in prev.items() if info["rank"] <= top_n]
         for name, prev_info in prev_top:
             curr_info = curr.get(name)
             if curr_info is None:
@@ -126,9 +134,7 @@ def stability_metric(
             weighted_denom += weight
 
     return {
-        "mean_abs_rank_change": (
-            mean(unweighted_changes) if unweighted_changes else 0.0
-        ),
+        "mean_abs_rank_change": (mean(unweighted_changes) if unweighted_changes else 0.0),
         "value_weighted_rank_change": (
             weighted_numer / weighted_denom if weighted_denom > 0 else 0.0
         ),
@@ -168,9 +174,7 @@ def render_report(
     lines.append("")
     lines.append(f"- Snapshot count: **{len(snapshots)}**")
     if snapshots:
-        lines.append(
-            f"- Date range: **{snapshots[0][0]} → {snapshots[-1][0]}**"
-        )
+        lines.append(f"- Date range: **{snapshots[0][0]} → {snapshots[-1][0]}**")
     lines.append(f"- λ grid: {list(LAMBDA_GRID)}")
     lines.append(
         "- Chain under test: "
@@ -248,9 +252,7 @@ def write_csv(results: list[dict], out_path: Path) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w", newline="") as f:
         w = csv.writer(f)
-        w.writerow(
-            ["lambda", "mean_abs_rank_change", "value_weighted_rank_change"]
-        )
+        w.writerow(["lambda", "mean_abs_rank_change", "value_weighted_rank_change"])
         for r in results:
             w.writerow(
                 [

--- a/scripts/audit_dropped_sources.py
+++ b/scripts/audit_dropped_sources.py
@@ -29,6 +29,7 @@ Usage:
                                             [--top N]
                                             [--json]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -156,21 +157,15 @@ def _summarise(players: list[dict[str, Any]]) -> dict[str, Any]:
             }
         )
 
-    biggest_offenders.sort(
-        key=lambda o: (-len(o["dropped"]), o["rank"] or 1_000_000)
-    )
+    biggest_offenders.sort(key=lambda o: (-len(o["dropped"]), o["rank"] or 1_000_000))
 
     return {
         "total_rows": total_rows,
         "rows_with_drops": rows_with_drops,
         "drop_count_histogram": dict(sorted(drop_count_histogram.items())),
-        "dropped_by_source": dict(
-            sorted(dropped_by_source.items(), key=lambda kv: -kv[1])
-        ),
+        "dropped_by_source": dict(sorted(dropped_by_source.items(), key=lambda kv: -kv[1])),
         "eligible_rows_per_source": eligible,
-        "dropped_by_position": dict(
-            sorted(dropped_by_position.items(), key=lambda kv: -kv[1])
-        ),
+        "dropped_by_position": dict(sorted(dropped_by_position.items(), key=lambda kv: -kv[1])),
         "biggest_offenders": biggest_offenders,
     }
 
@@ -228,9 +223,7 @@ def _print_report(summary: dict[str, Any], *, top: int) -> None:
         )
         for o in offenders:
             rank = str(o["rank"]) if o["rank"] is not None else "-"
-            spread = (
-                f"{o['spread']:.3f}" if isinstance(o["spread"], (int, float)) else "-"
-            )
+            spread = f"{o['spread']:.3f}" if isinstance(o["spread"], (int, float)) else "-"
             dropped = ", ".join(o["dropped"])
             print(
                 f"  {rank:>5s}  {o['name']:<30s} {o['position']:<5s} "

--- a/scripts/audit_identity.py
+++ b/scripts/audit_identity.py
@@ -13,6 +13,7 @@ Reports:
 Usage:
     python scripts/audit_identity.py [--json-path PATH]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -134,10 +135,7 @@ def main() -> None:
 
     # ── 4. High source disagreement ──
     _section("HIGH SOURCE DISAGREEMENT (sourceRankSpread > 80)")
-    disagreed = [
-        p for p in players
-        if (p.get("sourceRankSpread") or 0) > 80
-    ]
+    disagreed = [p for p in players if (p.get("sourceRankSpread") or 0) > 80]
     disagreed.sort(key=lambda p: p.get("sourceRankSpread") or 0, reverse=True)
     if not disagreed:
         print("  (none)")
@@ -149,10 +147,7 @@ def main() -> None:
 
     # ── 5. Unsupported positions ──
     _section("UNSUPPORTED POSITIONS")
-    unsupported = [
-        p for p in players
-        if "unsupported_position" in (p.get("anomalyFlags") or [])
-    ]
+    unsupported = [p for p in players if "unsupported_position" in (p.get("anomalyFlags") or [])]
     if not unsupported:
         print("  (none)")
     else:
@@ -161,10 +156,7 @@ def main() -> None:
 
     # ── 6. No valid source values + non-zero derived value ──
     _section("NO SOURCE VALUES BUT HAS DERIVED VALUE")
-    orphans = [
-        p for p in players
-        if "no_valid_source_values" in (p.get("anomalyFlags") or [])
-    ]
+    orphans = [p for p in players if "no_valid_source_values" in (p.get("anomalyFlags") or [])]
     if not orphans:
         print("  (none)")
     else:
@@ -199,8 +191,7 @@ def main() -> None:
     # ── 8. Position-source contradictions ──
     _section("POSITION-SOURCE CONTRADICTIONS")
     contradictions = [
-        p for p in players
-        if "position_source_contradiction" in (p.get("anomalyFlags") or [])
+        p for p in players if "position_source_contradiction" in (p.get("anomalyFlags") or [])
     ]
     if not contradictions:
         print("  (none)")

--- a/scripts/auto_refit_hill_curves.py
+++ b/scripts/auto_refit_hill_curves.py
@@ -27,6 +27,7 @@ Usage:
     python3 scripts/auto_refit_hill_curves.py --dry-run
     python3 scripts/auto_refit_hill_curves.py --threshold 100
 """
+
 from __future__ import annotations
 
 import argparse
@@ -39,9 +40,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 PLAYER_VALUATION = REPO / "src" / "canonical" / "player_valuation.py"
-KTC_RECONCILIATION_TEST = (
-    REPO / "tests" / "canonical" / "test_ktc_reconciliation.py"
-)
+KTC_RECONCILIATION_TEST = REPO / "tests" / "canonical" / "test_ktc_reconciliation.py"
 FIT_SCRIPT = REPO / "scripts" / "fit_hill_curve_percentile.py"
 KTC_CSV = REPO / "CSVs" / "site_raw" / "ktc.csv"
 
@@ -57,10 +56,10 @@ CONSTANT_NAMES: tuple[str, ...] = (
 )
 
 SCOPE_TO_CS = {
-    "GLOBAL":  ("HILL_GLOBAL_PERCENTILE_C",  "HILL_GLOBAL_PERCENTILE_S"),
-    "OFFENSE": ("HILL_PERCENTILE_C",         "HILL_PERCENTILE_S"),
-    "IDP":     ("IDP_HILL_PERCENTILE_C",     "IDP_HILL_PERCENTILE_S"),
-    "ROOKIE":  ("HILL_ROOKIE_PERCENTILE_C",  "HILL_ROOKIE_PERCENTILE_S"),
+    "GLOBAL": ("HILL_GLOBAL_PERCENTILE_C", "HILL_GLOBAL_PERCENTILE_S"),
+    "OFFENSE": ("HILL_PERCENTILE_C", "HILL_PERCENTILE_S"),
+    "IDP": ("IDP_HILL_PERCENTILE_C", "IDP_HILL_PERCENTILE_S"),
+    "ROOKIE": ("HILL_ROOKIE_PERCENTILE_C", "HILL_ROOKIE_PERCENTILE_S"),
 }
 
 DRIFT_RMSE_THRESHOLD: float = 50.0
@@ -98,9 +97,7 @@ def read_committed_constants() -> dict[str, float]:
 
 def run_fit_with_json() -> dict[str, float]:
     """Run the fit script, capture JSON output, return constants dict."""
-    with tempfile.NamedTemporaryFile(
-        mode="w+", suffix=".json", delete=False
-    ) as tmp:
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as tmp:
         json_path = Path(tmp.name)
     try:
         result = subprocess.run(
@@ -124,18 +121,13 @@ def run_fit_with_json() -> dict[str, float]:
             pass
 
 
-def compute_scope_drift(
-    committed: dict[str, float], fitted: dict[str, float]
-) -> dict[str, float]:
+def compute_scope_drift(committed: dict[str, float], fitted: dict[str, float]) -> dict[str, float]:
     """Return per-scope RMSE of V_new(p) − V_old(p) over DRIFT_GRID."""
     out: dict[str, float] = {}
     for scope, (c_name, s_name) in SCOPE_TO_CS.items():
         c_old, s_old = committed[c_name], committed[s_name]
         c_new, s_new = fitted[c_name], fitted[s_name]
-        sq_diffs = [
-            (_hill(p, c_new, s_new) - _hill(p, c_old, s_old)) ** 2
-            for p in DRIFT_GRID
-        ]
+        sq_diffs = [(_hill(p, c_new, s_new) - _hill(p, c_old, s_old)) ** 2 for p in DRIFT_GRID]
         rmse = (sum(sq_diffs) / len(sq_diffs)) ** 0.5
         out[scope] = rmse
     return out
@@ -159,8 +151,7 @@ def rewrite_player_valuation(fitted: dict[str, float]) -> None:
         )
         if n != 1:
             raise RuntimeError(
-                f"Expected exactly 1 match for {name!r} in "
-                f"{PLAYER_VALUATION}, got {n}"
+                f"Expected exactly 1 match for {name!r} in " f"{PLAYER_VALUATION}, got {n}"
             )
     PLAYER_VALUATION.write_text(text)
 
@@ -189,9 +180,7 @@ def rebaseline_ktc_reconciliation(fitted: dict[str, float]) -> None:
 
     # Percentile reference N is read from data_contract.py to stay in
     # sync.  Parsing inline is cheaper than importing the module.
-    data_contract_text = (
-        REPO / "src" / "api" / "data_contract.py"
-    ).read_text()
+    data_contract_text = (REPO / "src" / "api" / "data_contract.py").read_text()
     ref_n_match = re.search(
         r"_PERCENTILE_REFERENCE_N:\s*int\s*=\s*(\d+)",
         data_contract_text,
@@ -232,9 +221,7 @@ def rebaseline_ktc_reconciliation(fitted: dict[str, float]) -> None:
     new_block_lines = ["PINNED_DELTAS: list[tuple[int, int, float, float]] = ["]
     for rank, ours, pct, tol in new_entries:
         sign = "" if pct >= 0 else ""
-        new_block_lines.append(
-            f"    ({rank:>3}, {ours:>4}, {pct:>5}, {tol:>4}),"
-        )
+        new_block_lines.append(f"    ({rank:>3}, {ours:>4}, {pct:>5}, {tol:>4}),")
     new_block_lines.append("]")
     new_block = "\n".join(new_block_lines)
 

--- a/scripts/backfill_ktc_sftep_raw.py
+++ b/scripts/backfill_ktc_sftep_raw.py
@@ -23,6 +23,7 @@ Usage
     python -m scripts.backfill_ktc_sftep_raw            # apply
     python -m scripts.backfill_ktc_sftep_raw --dry-run  # preview
 """
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/backfill_rank_history.py
+++ b/scripts/backfill_rank_history.py
@@ -64,6 +64,7 @@ Usage
         --archive-dir /tmp/fake_archive \\
         --history-path /tmp/fake_history.jsonl
 """
+
 from __future__ import annotations
 
 import argparse
@@ -312,8 +313,7 @@ def backfill(
             # before-cutoff day is expected and shouldn't pollute
             # the report.
             non_since_failures = [
-                (p, reason) for p, reason in attempt_failures
-                if reason != "before-since"
+                (p, reason) for p, reason in attempt_failures if reason != "before-since"
             ]
             if not non_since_failures:
                 continue
@@ -321,7 +321,11 @@ def backfill(
                 label = "unreadable" if reason == "unreadable" else "build-err"
                 _print(
                     f"  {filename_date:<12} {'?':>5}  {label:<9}  {path.name}"
-                    + (f": {reason[len('build-err: '):]}" if reason.startswith("build-err: ") else "")
+                    + (
+                        f": {reason[len('build-err: '):]}"
+                        if reason.startswith("build-err: ")
+                        else ""
+                    )
                 )
                 results.append(
                     {
@@ -353,9 +357,7 @@ def backfill(
             )
             status = "appended" if appended else "skipped"
 
-        _print(
-            f"  {effective_date:<12} {row_count:>5d}  {status:<9}  {zip_path.name}"
-        )
+        _print(f"  {effective_date:<12} {row_count:>5d}  {status:<9}  {zip_path.name}")
         results.append(
             {
                 "date": effective_date,

--- a/scripts/backfill_source_history.py
+++ b/scripts/backfill_source_history.py
@@ -8,6 +8,7 @@ are preserved when newer than the export.
 Run:
     python3 scripts/backfill_source_history.py
 """
+
 from __future__ import annotations
 
 import argparse
@@ -35,10 +36,7 @@ def main() -> int:
     parser.add_argument(
         "--output",
         default=None,
-        help=(
-            "Override output JSONL path.  Defaults to "
-            "src.api.source_history.HISTORY_PATH."
-        ),
+        help=("Override output JSONL path.  Defaults to " "src.api.source_history.HISTORY_PATH."),
     )
     parser.add_argument(
         "--dry-run",

--- a/scripts/backtest_alpha_lambda_joint.py
+++ b/scripts/backtest_alpha_lambda_joint.py
@@ -11,6 +11,7 @@ staying near the stability frontier.
 
 No production behavior modified.  Output: markdown heatmap + CSV.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -111,7 +112,7 @@ def render(snapshots, results) -> str:
     lines.append("")
     lines.append(
         "**Caveat**: this metric rewards stability.  The stability "
-        "optimum drifts toward α=0 and λ=0 — \"use the anchor source "
+        'optimum drifts toward α=0 and λ=0 — "use the anchor source '
         "alone, ignore the 15 other sources.\"  That's product-bad "
         "because the blend is supposed to reflect multi-source "
         "consensus.  Pick a joint point that's **near** the stability "
@@ -133,7 +134,9 @@ def render(snapshots, results) -> str:
             row_vals.append(f"{v:.3f}{marker}")
         lines.append(f"| **{a:.2f}** | " + " | ".join(row_vals) + " |")
     lines.append("")
-    lines.append(f"Stability-optimal cell: α={best['alpha']}, λ={best['lambda']} (VW={best['vw']:.3f})")
+    lines.append(
+        f"Stability-optimal cell: α={best['alpha']}, λ={best['lambda']} (VW={best['vw']:.3f})"
+    )
     lines.append("")
 
     # Pareto-ish: cells within 20% of the optimum across non-degenerate α.
@@ -180,7 +183,8 @@ def main() -> int:
 
     snapshots = load_snapshots(args.snapshots)
     if not snapshots:
-        print("No snapshots"); return 1
+        print("No snapshots")
+        return 1
     print(f"Loaded {len(snapshots)} snapshots; running 2D α × λ sweep …")
     results = sweep_2d(snapshots)
     report = render(snapshots, results)

--- a/scripts/backtest_alpha_shrinkage.py
+++ b/scripts/backtest_alpha_shrinkage.py
@@ -21,6 +21,7 @@ Usage:
 
 No production behavior is modified.  Output: markdown + CSV.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -41,7 +42,17 @@ from src.api import data_contract  # noqa: E402
 
 
 ALPHA_GRID: tuple[float, ...] = (
-    0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+    0.0,
+    0.1,
+    0.2,
+    0.3,
+    0.4,
+    0.5,
+    0.6,
+    0.7,
+    0.8,
+    0.9,
+    1.0,
 )
 
 
@@ -84,9 +95,7 @@ def stability_metric(
     weighted_numer: float = 0.0
     weighted_denom: float = 0.0
     for prev, curr in zip(boards, boards[1:]):
-        prev_top = [
-            (name, info) for name, info in prev.items() if info["rank"] <= top_n
-        ]
+        prev_top = [(name, info) for name, info in prev.items() if info["rank"] <= top_n]
         for name, prev_info in prev_top:
             curr_info = curr.get(name)
             if curr_info is None:
@@ -97,9 +106,7 @@ def stability_metric(
             weighted_numer += delta * weight
             weighted_denom += weight
     return {
-        "mean_abs_rank_change": (
-            mean(unweighted_changes) if unweighted_changes else 0.0
-        ),
+        "mean_abs_rank_change": (mean(unweighted_changes) if unweighted_changes else 0.0),
         "value_weighted_rank_change": (
             weighted_numer / weighted_denom if weighted_denom > 0 else 0.0
         ),
@@ -120,9 +127,7 @@ def sweep_alpha(snapshots: list[tuple[str, dict]]) -> list[dict]:
     return results
 
 
-def render_report(
-    snapshots: list[tuple[str, dict]], results: list[dict]
-) -> str:
+def render_report(snapshots: list[tuple[str, dict]], results: list[dict]) -> str:
     if not results:
         return "# α Shrinkage Backtest\n\n(no data)\n"
     by_weighted = sorted(results, key=lambda r: r["value_weighted_rank_change"])
@@ -133,9 +138,7 @@ def render_report(
     lines.append("")
     lines.append(f"- Snapshot count: **{len(snapshots)}**")
     if snapshots:
-        lines.append(
-            f"- Date range: **{snapshots[0][0]} → {snapshots[-1][0]}**"
-        )
+        lines.append(f"- Date range: **{snapshots[0][0]} → {snapshots[-1][0]}**")
     lines.append(f"- α grid: {list(ALPHA_GRID)}")
     lines.append(
         "- Chain under test: `Final = Anchor + α·(SubgroupBlend − Anchor)` "

--- a/scripts/backtest_ktc_volatility.py
+++ b/scripts/backtest_ktc_volatility.py
@@ -26,6 +26,7 @@ Usage:
 
 No production behavior is modified.  The output is a markdown report.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -251,9 +252,13 @@ def render_report(per_rank: dict[int, list[dict[str, Any]]]) -> str:
             "history or a data refresh will break CI.  Safe sizing rules:"
         )
         lines.append("")
-        lines.append(f"- **Strict (catches regressions earliest):** ceil(max_dod) + 1pp = {int(max_dod) + 1}pp")
+        lines.append(
+            f"- **Strict (catches regressions earliest):** ceil(max_dod) + 1pp = {int(max_dod) + 1}pp"
+        )
         lines.append(f"- **Balanced (absorbs 99% of drift):** ceil(p99) + 1pp = {int(p99) + 1}pp")
-        lines.append(f"- **Lax (absorbs 95% of drift, tolerates rare CI break):** ceil(p95) + 1pp = {int(p95) + 1}pp")
+        lines.append(
+            f"- **Lax (absorbs 95% of drift, tolerates rare CI break):** ceil(p95) + 1pp = {int(p95) + 1}pp"
+        )
         lines.append("")
         current_tol = 5.0
         if current_tol >= max_dod:
@@ -301,9 +306,7 @@ def render_report(per_rank: dict[int, list[dict[str, Any]]]) -> str:
         lines.append("| prev date | curr date | prev pct | curr pct | Δ |")
         lines.append("|---|---|---:|---:|---:|")
         for j, prev_d, curr_d, prev_p, curr_p in jumps[:3]:
-            lines.append(
-                f"| {prev_d} | {curr_d} | {prev_p:+.2f}% | {curr_p:+.2f}% | {j:+.2f}pp |"
-            )
+            lines.append(f"| {prev_d} | {curr_d} | {prev_p:+.2f}% | {curr_p:+.2f}% | {j:+.2f}pp |")
         lines.append("")
 
     return "\n".join(lines)
@@ -317,7 +320,9 @@ def write_csv(per_rank: dict[int, list[dict[str, Any]]], out_path: Path) -> None
         w.writerow(["date", "rank", "player", "ktc", "ours", "pct_diff"])
         for rank in PINNED_RANKS:
             for s in per_rank[rank]:
-                w.writerow([s["date"], rank, s["player"], s["ktc"], s["ours"], f"{s['pct_diff']:+.4f}"])
+                w.writerow(
+                    [s["date"], rank, s["player"], s["ktc"], s["ours"], f"{s['pct_diff']:+.4f}"]
+                )
 
 
 def main() -> int:

--- a/scripts/backtest_percentile_reference_n.py
+++ b/scripts/backtest_percentile_reference_n.py
@@ -16,6 +16,7 @@ Usage:
     python3 scripts/backtest_percentile_reference_n.py
     python3 scripts/backtest_percentile_reference_n.py --snapshots 10
 """
+
 from __future__ import annotations
 
 import argparse
@@ -167,7 +168,13 @@ def write_csv(results, path: Path) -> None:
         w = csv.writer(f)
         w.writerow(["N", "mean_abs_rank_change", "value_weighted_rank_change"])
         for r in results:
-            w.writerow([r["N"], f"{r['mean_abs_rank_change']:.4f}", f"{r['value_weighted_rank_change']:.4f}"])
+            w.writerow(
+                [
+                    r["N"],
+                    f"{r['mean_abs_rank_change']:.4f}",
+                    f"{r['value_weighted_rank_change']:.4f}",
+                ]
+            )
 
 
 def main() -> int:
@@ -186,7 +193,8 @@ def main() -> int:
     args = ap.parse_args()
     snapshots = load_snapshots(args.snapshots)
     if not snapshots:
-        print("No snapshots"); return 1
+        print("No snapshots")
+        return 1
     print(f"Loaded {len(snapshots)} snapshots; sweeping N …")
     results = sweep(snapshots)
     report = render(snapshots, results)

--- a/scripts/backtest_scoring_adjustment.py
+++ b/scripts/backtest_scoring_adjustment.py
@@ -77,9 +77,11 @@ def main() -> int:
     report = run_scoring_backtest(fits)
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
     if comparator_rows:
+
         def _mae(key: str) -> float:
             vals = [abs(float(r[key]) - float(r["target_ratio"])) for r in comparator_rows]
             return (sum(vals) / len(vals)) if vals else 0.0
+
         report["modelComparisons"] = {
             "n": len(comparator_rows),
             "mae_new_multiplier_vs_raw_ratio": round(_mae("new_mult"), 6),

--- a/scripts/backtest_soft_fallback.py
+++ b/scripts/backtest_soft_fallback.py
@@ -22,6 +22,7 @@ Usage:
     python3 scripts/backtest_soft_fallback.py
     python3 scripts/backtest_soft_fallback.py --snapshots 10
 """
+
 from __future__ import annotations
 
 import argparse
@@ -42,7 +43,13 @@ from src.api import data_contract  # noqa: E402
 
 
 DISTANCE_GRID: tuple[float, ...] = (
-    0.0, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0,
+    0.0,
+    0.1,
+    0.2,
+    0.3,
+    0.5,
+    0.75,
+    1.0,
 )
 
 
@@ -81,9 +88,7 @@ def stability_metric(boards, *, top_n: int = 200) -> dict[str, float]:
     weighted_numer: float = 0.0
     weighted_denom: float = 0.0
     for prev, curr in zip(boards, boards[1:]):
-        prev_top = [
-            (name, info) for name, info in prev.items() if info["rank"] <= top_n
-        ]
+        prev_top = [(name, info) for name, info in prev.items() if info["rank"] <= top_n]
         for name, prev_info in prev_top:
             curr_info = curr.get(name)
             if curr_info is None:
@@ -94,9 +99,7 @@ def stability_metric(boards, *, top_n: int = 200) -> dict[str, float]:
             weighted_numer += delta * weight
             weighted_denom += weight
     return {
-        "mean_abs_rank_change": (
-            mean(unweighted_changes) if unweighted_changes else 0.0
-        ),
+        "mean_abs_rank_change": (mean(unweighted_changes) if unweighted_changes else 0.0),
         "value_weighted_rank_change": (
             weighted_numer / weighted_denom if weighted_denom > 0 else 0.0
         ),
@@ -132,12 +135,8 @@ def render_report(snapshots, results) -> str:
         return "# Soft-Fallback Backtest\n\n(no data)\n"
 
     enabled_results = [r for r in results if r["enabled"]]
-    by_weighted = sorted(
-        enabled_results, key=lambda r: r["value_weighted_rank_change"]
-    )
-    by_unweighted = sorted(
-        enabled_results, key=lambda r: r["mean_abs_rank_change"]
-    )
+    by_weighted = sorted(enabled_results, key=lambda r: r["value_weighted_rank_change"])
+    by_unweighted = sorted(enabled_results, key=lambda r: r["mean_abs_rank_change"])
     baseline = next(r for r in results if not r["enabled"])
 
     lines: list[str] = []
@@ -145,9 +144,7 @@ def render_report(snapshots, results) -> str:
     lines.append("")
     lines.append(f"- Snapshot count: **{len(snapshots)}**")
     if snapshots:
-        lines.append(
-            f"- Date range: **{snapshots[0][0]} → {snapshots[-1][0]}**"
-        )
+        lines.append(f"- Date range: **{snapshots[0][0]} → {snapshots[-1][0]}**")
     lines.append(f"- Distance grid: {list(DISTANCE_GRID)}")
     lines.append(
         "- Chain under test: Framework step 9 soft fallback adds an "
@@ -158,9 +155,7 @@ def render_report(snapshots, results) -> str:
 
     lines.append("## Stability")
     lines.append("")
-    lines.append(
-        "| setting | mean abs rank change | value-weighted rank change |"
-    )
+    lines.append("| setting | mean abs rank change | value-weighted rank change |")
     lines.append("|:---|---:|---:|")
     lines.append(
         f"| disabled (pre-PR-4 behavior) | "
@@ -208,15 +203,9 @@ def write_csv(results: list[dict], out_path: Path) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w", newline="") as f:
         w = csv.writer(f)
-        w.writerow(
-            ["setting", "mean_abs_rank_change", "value_weighted_rank_change"]
-        )
+        w.writerow(["setting", "mean_abs_rank_change", "value_weighted_rank_change"])
         for r in results:
-            label = (
-                f"distance={r['distance']:.2f}"
-                if r["enabled"]
-                else "disabled"
-            )
+            label = f"distance={r['distance']:.2f}" if r["enabled"] else "disabled"
             w.writerow(
                 [
                     label,

--- a/scripts/build_historical_scoring_dataset.py
+++ b/scripts/build_historical_scoring_dataset.py
@@ -99,10 +99,9 @@ def main() -> int:
     out["league_points"] = out.apply(lambda r: _score_row(r, custom_map), axis=1)
     out["raw_scoring_delta"] = out["league_points"] - out["baseline_points"]
     out["raw_scoring_ratio"] = out["league_points"] / out["baseline_points"].clip(lower=1.0)
-    out["td_dependency"] = (
-        (out["pass_td"] + out["rush_td"] + out["rec_td"])
-        / (out["pass_yd"] + out["rush_yd"] + out["rec_yd"]).clip(lower=1.0)
-    )
+    out["td_dependency"] = (out["pass_td"] + out["rush_td"] + out["rec_td"]) / (
+        out["pass_yd"] + out["rush_yd"] + out["rec_yd"]
+    ).clip(lower=1.0)
     out["first_down_sensitivity"] = out["pass_fd"] + out["rush_fd"] + out["rec_fd"]
     out["reception_profile"] = out["rec"] / (out["rec"] + out.get("rush_att", 0.0)).clip(lower=1.0)
 

--- a/scripts/build_public_league_snapshot.py
+++ b/scripts/build_public_league_snapshot.py
@@ -4,6 +4,7 @@
 
 The resulting files live under ``data/public_league/``.
 """
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/calibrate_va_formula.py
+++ b/scripts/calibrate_va_formula.py
@@ -23,6 +23,7 @@ a winning candidate is found, port its predict() body over there and
 update the pinned regression tests in
 ``frontend/__tests__/trade-logic.test.js``.
 """
+
 from __future__ import annotations
 
 import itertools
@@ -43,6 +44,7 @@ class DataPoint:
     the VA.  ``large`` has more pieces.  Both are raw value lists in
     KTC's 1-9999 display scale.
     """
+
     label: str
     small: tuple[float, ...]
     large: tuple[float, ...]
@@ -64,7 +66,7 @@ class DataPoint:
 
     def extras(self) -> list[float]:
         """Multi-side pieces beyond what the small side can pair with."""
-        return self.sorted_large()[len(self.small):]
+        return self.sorted_large()[len(self.small) :]
 
     def small_top(self) -> float:
         return self.sorted_small()[0] if self.small else 0.0
@@ -198,6 +200,7 @@ DATA: list[DataPoint] = [
 # Each predict function returns the predicted VA for one DataPoint
 # given a params dict.  Signatures must match so the grid-search loop
 # can iterate uniformly.
+
 
 def predict_v1_current(pt: DataPoint, p: dict) -> float:
     """V1 (current production): top-gap scarcity * exponential-decay extras."""
@@ -438,9 +441,7 @@ def predict_v9_split(pt: DataPoint, p: dict) -> float:
         return 0.0
     count_size = len(pt.small)
     eq_va = (
-        p["eq_offset"]
-        + p["eq_top_coeff"] * small_top * top_gap
-        + p["eq_count_coeff"] * count_size
+        p["eq_offset"] + p["eq_top_coeff"] * small_top * top_gap + p["eq_count_coeff"] * count_size
     )
     return max(0.0, eq_va)
 
@@ -502,9 +503,7 @@ def predict_v10_classifier(pt: DataPoint, p: dict) -> float:
         return 0.0
 
     eq_va = (
-        p["eq_offset"]
-        + p["eq_top_coeff"] * small_top * top_gap
-        + p["eq_count_coeff"] * count_size
+        p["eq_offset"] + p["eq_top_coeff"] * small_top * top_gap + p["eq_count_coeff"] * count_size
     )
     return max(0.0, eq_va)
 
@@ -753,17 +752,10 @@ def _ktc_raw_adjustment(p: float, t: float, v: float = _KTC_V_OVERALL_MAX) -> fl
     pv = p / v if v > 0 else 0.0
     pt_ratio = p / t if t > 0 else 0.0
     pv2k = p / (v + 2000.0)
-    return p * (
-        0.1
-        + 0.04 * (pv ** 8)
-        + 0.11 * (pt_ratio ** 1.3)
-        + 0.22 * (pv2k ** 1.28)
-    )
+    return p * (0.1 + 0.04 * (pv**8) + 0.11 * (pt_ratio**1.3) + 0.22 * (pv2k**1.28))
 
 
-def _ktc_solve_for_added_value(
-    target_raw: float, t: float, v: float = _KTC_V_OVERALL_MAX
-) -> float:
+def _ktc_solve_for_added_value(target_raw: float, t: float, v: float = _KTC_V_OVERALL_MAX) -> float:
     """Find player value X such that ``_ktc_raw_adjustment(X, t, v) ≈ target_raw``.
 
     Binary search on X in [0, t].  ``raw(p, t, v)`` is monotonically
@@ -898,8 +890,10 @@ def report(predict_fn, params: dict, title: str) -> None:
     rms = ((sum(e * e for e in abs_errs) / len(abs_errs)) ** 0.5) * 100
     over_10 = sum(1 for e in abs_errs if e > 0.10)
     over_20 = sum(1 for e in abs_errs if e > 0.20)
-    print(f"  mean |err|={mean:5.2f}%  max={mx:5.2f}%  rms={rms:5.2f}%  "
-          f"(>10%: {over_10}, >20%: {over_20})")
+    print(
+        f"  mean |err|={mean:5.2f}%  max={mx:5.2f}%  rms={rms:5.2f}%  "
+        f"(>10%: {over_10}, >20%: {over_20})"
+    )
 
 
 def grid_search(predict_fn, param_grid: dict[str, list], metric: str = "rms") -> dict:
@@ -1154,8 +1148,7 @@ def main() -> None:
         rms = objective(predict_v11, params, metric="rms") * 100
         v11_results.append((alpha, params, rms))
         coef_str = ", ".join(
-            f"{name}={c:+.3f}"
-            for name, c in zip(EQ_FEATURE_NAMES, params["eq_coeffs"])
+            f"{name}={c:+.3f}" for name, c in zip(EQ_FEATURE_NAMES, params["eq_coeffs"])
         )
         print(f"  α={alpha:>5g}  rms={rms:6.2f}%   coefs: {coef_str}")
     # Pick the alpha with the lowest aggregate RMS for the report+ranking.
@@ -1179,9 +1172,13 @@ def main() -> None:
         v11_pred = predict_v11(pt, v11_best[1])
         delta = abs(v11_pred - v2_pred)
         anchor_max_delta = max(anchor_max_delta, delta)
-        print(f"  {pt.label:<2} ({pt.topology}): V2={v2_pred:6.0f}  V11={v11_pred:6.0f}  Δ={delta:5.1f}")
+        print(
+            f"  {pt.label:<2} ({pt.topology}): V2={v2_pred:6.0f}  V11={v11_pred:6.0f}  Δ={delta:5.1f}"
+        )
     if anchor_max_delta > 0.5:
-        print(f"  ✘ FAIL: V11 deviates from V2 on a baseline anchor (max Δ = {anchor_max_delta:.2f})")
+        print(
+            f"  ✘ FAIL: V11 deviates from V2 on a baseline anchor (max Δ = {anchor_max_delta:.2f})"
+        )
         print("    Hard requirement violated.  Do NOT port V11.")
     else:
         print(f"  ✓ PASS: V11 matches V2 within {anchor_max_delta:.2f} on every baseline anchor.")
@@ -1216,8 +1213,10 @@ def main() -> None:
         rms = ((sum(e * e for e in errs) / len(errs)) ** 0.5) * 100
         over_10 = sum(1 for e in errs if e > 0.10)
         over_20 = sum(1 for e in errs if e > 0.20)
-        print(f"  {name:<10}  rms={rms:5.2f}%  mean={mean:5.2f}%  max={mx:5.2f}%  "
-              f">10%: {over_10}/{total_points}  >20%: {over_20}/{total_points}")
+        print(
+            f"  {name:<10}  rms={rms:5.2f}%  mean={mean:5.2f}%  max={mx:5.2f}%  "
+            f">10%: {over_10}/{total_points}  >20%: {over_20}/{total_points}"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/check_ktc_health.py
+++ b/scripts/check_ktc_health.py
@@ -8,14 +8,17 @@ Usage:
     python scripts/check_ktc_health.py          # quick connectivity test
     python scripts/check_ktc_health.py --full    # full extraction test (slower)
 """
+
 import asyncio
 import json
 import os
 import re
 import sys
 
+
 def _detect_proxy():
     from urllib.parse import urlparse
+
     raw = os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY") or ""
     if not raw:
         return None
@@ -116,8 +119,9 @@ async def check_ktc(full=False):
 
         # Strategy 1: Check for inline playersArray (current KTC format as of 2026-03)
         pa_match = re.search(
-            r'var\s+playersArray\s*=\s*(\[.*?\]);\s*(?:var\s|\n)',
-            content, re.DOTALL,
+            r"var\s+playersArray\s*=\s*(\[.*?\]);\s*(?:var\s|\n)",
+            content,
+            re.DOTALL,
         )
         if pa_match:
             try:
@@ -143,20 +147,22 @@ async def check_ktc(full=False):
         # Strategy 2: Check __NEXT_DATA__ (legacy KTC format)
         next_match = re.search(
             r'<script\s+id="__NEXT_DATA__"[^>]*>(.*?)</script>',
-            content, re.DOTALL,
+            content,
+            re.DOTALL,
         )
         if next_match:
             nd = next_match.group(1)
             pn_count = nd.count("playerName")
             sf_count = nd.count("superflexValues")
-            print(f"__NEXT_DATA__: {len(nd)} bytes, playerName×{pn_count}, superflexValues×{sf_count}")
+            print(
+                f"__NEXT_DATA__: {len(nd)} bytes, playerName×{pn_count}, superflexValues×{sf_count}"
+            )
 
             try:
                 data = json.loads(nd)
-                players = (
-                    data.get("props", {}).get("pageProps", {}).get("players", [])
-                    or data.get("props", {}).get("pageProps", {}).get("rankings", [])
-                )
+                players = data.get("props", {}).get("pageProps", {}).get("players", []) or data.get(
+                    "props", {}
+                ).get("pageProps", {}).get("rankings", [])
                 if players:
                     sample = players[0]
                     print(f"  Players array: {len(players)} items")
@@ -177,9 +183,7 @@ async def check_ktc(full=False):
             print("__NEXT_DATA__ not found in page source")
 
         # Strategy 3: Check DOM elements
-        dom_count = await page.evaluate(
-            "document.querySelectorAll('[class*=\"player\"]').length"
-        )
+        dom_count = await page.evaluate("document.querySelectorAll('[class*=\"player\"]').length")
         print(f"DOM player elements: {dom_count}")
 
         if dom_count > 100:

--- a/scripts/collect_ktc_va.py
+++ b/scripts/collect_ktc_va.py
@@ -37,6 +37,7 @@ Options:
     --only LABEL[,...] restrict to specific fixture labels
     --refresh          recompute trades even if already captured
 """
+
 from __future__ import annotations
 
 import argparse
@@ -148,7 +149,7 @@ def _xpath_lit(s: str) -> str:
         return f'"{s}"'
     # Both kinds present: concat("foo", "'", "bar")
     parts = s.split("'")
-    return "concat(" + ", \"'\", ".join(f"'{p}'" for p in parts) + ")"
+    return "concat(" + ', "\'", '.join(f"'{p}'" for p in parts) + ")"
 
 
 async def _dump_debug_snapshot(page, tag: str) -> str:
@@ -271,9 +272,7 @@ async def _add_player(page, team_idx: int, player_name: str, *, timeout: int = 1
         debug_path = await _dump_debug_snapshot(
             page, f"add_player_no_row_team{team_idx}_{_safe_filename(player_name)}"
         )
-        msg = (
-            f"clicked dropdown for {player_name!r} but no row appeared in #{list_id}"
-        )
+        msg = f"clicked dropdown for {player_name!r} but no row appeared in #{list_id}"
         if debug_path:
             msg += f" (debug snapshot: {debug_path})"
         raise RuntimeError(msg)
@@ -297,7 +296,7 @@ async def _clear_team(page, team_idx: int) -> None:
     # list (each `css=` after the first becomes literal text and trips
     # the CSS tokenizer).  Concatenate plain CSS selectors instead.
     selector = (
-        f'#{list_id} button, '
+        f"#{list_id} button, "
         f'#{list_id} [class*="remove"], '
         f'#{list_id} [class*="close"], '
         f'#{list_id} [aria-label="Remove"]'
@@ -480,7 +479,9 @@ async def run(args: argparse.Namespace) -> int:
     try:
         from playwright.async_api import async_playwright
     except ImportError:
-        print("FAIL: playwright not installed.  Run: pip install playwright && playwright install chromium")
+        print(
+            "FAIL: playwright not installed.  Run: pip install playwright && playwright install chromium"
+        )
         return 1
 
     failures: list[tuple[str, str]] = []
@@ -540,8 +541,12 @@ def main() -> int:
     parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
     parser.add_argument("--headed", action="store_true", help="run with visible browser")
     parser.add_argument("--throttle-ms", type=int, default=2500, help="delay between trades")
-    parser.add_argument("--only", default="", help="comma-separated labels to capture (default: all)")
-    parser.add_argument("--refresh", action="store_true", help="recompute even if observation exists")
+    parser.add_argument(
+        "--only", default="", help="comma-separated labels to capture (default: all)"
+    )
+    parser.add_argument(
+        "--refresh", action="store_true", help="recompute even if observation exists"
+    )
     args = parser.parse_args()
     return asyncio.run(run(args))
 

--- a/scripts/convert_dlf_csv.py
+++ b/scripts/convert_dlf_csv.py
@@ -32,6 +32,7 @@ Usage
         --in dlf_idp.csv \\
         --out CSVs/site_raw/dlfIdp.csv
 """
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/export_player_map.py
+++ b/scripts/export_player_map.py
@@ -14,6 +14,7 @@ Usage:
 
 If paths are not provided, finds the latest available files automatically.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -141,8 +142,10 @@ def main() -> int:
     out_path.write_text(json.dumps(payload, indent=2) + "\n")
 
     print(f"[player_map] Exported {player_map['stats']['total_entries']} players → {out_path}")
-    print(f"[player_map] {player_map['stats']['unique_names']} unique names, "
-          f"{player_map['stats']['nickname_expansions']} nickname expansions")
+    print(
+        f"[player_map] {player_map['stats']['unique_names']} unique names, "
+        f"{player_map['stats']['nickname_expansions']} nickname expansions"
+    )
 
     return 0
 

--- a/scripts/fetch_dlf.py
+++ b/scripts/fetch_dlf.py
@@ -54,6 +54,7 @@ A cached session (``dlf_session.json``, gitignored) caches the login
 cookies between runs so we only re-authenticate when WordPress
 invalidates the session (typically after ~14 days).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -138,12 +139,14 @@ def _load_session_cookies() -> list[dict]:
             continue
         if c["name"].startswith("_comment"):
             continue
-        out.append({
-            "name": c["name"],
-            "value": c["value"],
-            "domain": c.get("domain") or ".dynastyleaguefootball.com",
-            "path": c.get("path") or "/",
-        })
+        out.append(
+            {
+                "name": c["name"],
+                "value": c["value"],
+                "domain": c.get("domain") or ".dynastyleaguefootball.com",
+                "path": c.get("path") or "/",
+            }
+        )
     return out
 
 
@@ -153,12 +156,14 @@ def _save_session_cookies(session) -> None:
     cookies_out: list[dict] = []
     for c in session.cookies.jar:
         try:
-            cookies_out.append({
-                "name": c.name,
-                "value": c.value,
-                "domain": c.domain or ".dynastyleaguefootball.com",
-                "path": c.path or "/",
-            })
+            cookies_out.append(
+                {
+                    "name": c.name,
+                    "value": c.value,
+                    "domain": c.domain or ".dynastyleaguefootball.com",
+                    "path": c.path or "/",
+                }
+            )
         except Exception:
             continue
     payload = {
@@ -193,8 +198,10 @@ def _build_session():
     for c in _load_session_cookies():
         try:
             session.cookies.set(
-                c["name"], c["value"],
-                domain=c.get("domain"), path=c.get("path") or "/",
+                c["name"],
+                c["value"],
+                domain=c.get("domain"),
+                path=c.get("path") or "/",
             )
         except Exception:
             continue
@@ -225,9 +232,7 @@ def _login(session) -> None:
     #    handshake requires a GET before POST).
     r1 = session.get(LOGIN_URL, timeout=30)
     if r1.status_code != 200:
-        raise RuntimeError(
-            f"DLF login GET failed: HTTP {r1.status_code}"
-        )
+        raise RuntimeError(f"DLF login GET failed: HTTP {r1.status_code}")
     # 2) Submit credentials.  WP's login form POSTs ``log`` / ``pwd``
     #    / ``wp-submit`` with a ``redirect_to`` on success.
     r2 = session.post(
@@ -247,9 +252,7 @@ def _login(session) -> None:
         allow_redirects=True,
     )
     if r2.status_code not in (200, 302):
-        raise RuntimeError(
-            f"DLF login POST failed: HTTP {r2.status_code}"
-        )
+        raise RuntimeError(f"DLF login POST failed: HTTP {r2.status_code}")
     if not _is_logged_in(session):
         # WP returns 200 with the login form on invalid credentials.
         # Surface the page's error message for diagnostics.
@@ -293,7 +296,7 @@ def _fetch_rankings_html(session, url: str) -> str:
 # truncated 10-row preview), not on generic subscription links
 # that also appear in the page footer.
 _PAYWALL_SENTINELS = (
-    "This content is for",            # WP-MemberPress upsell wrapper
+    "This content is for",  # WP-MemberPress upsell wrapper
     "Please login to access this page",
     "Your account is not yet active",
 )
@@ -345,16 +348,15 @@ def _parse_rankings(html: str) -> list[dict]:
         # Use the cell's full text (including <br>-joined expert
         # name + "Last Updated: ..." annotations) — we only care
         # about the prefix.
-        headers = [
-            (c.get_text(" ", strip=True) or "").strip().lower()
-            for c in header_cells
-        ]
+        headers = [(c.get_text(" ", strip=True) or "").strip().lower() for c in header_cells]
+
         def _find(*targets: str) -> int:
             for i, h in enumerate(headers):
                 first_tok = h.split()[0] if h else ""
                 if h in targets or first_tok in targets:
                     return i
             return -1
+
         name_idx = _find("name", "player")
         avg_idx = _find("avg", "average")
         rank_idx = _find("rank", "#")
@@ -369,10 +371,12 @@ def _parse_rankings(html: str) -> list[dict]:
             cells = tr.find_all("td")
             if not cells:
                 continue
+
             def _cell(i: int) -> str:
                 if i < 0 or i >= len(cells):
                     return ""
                 return cells[i].get_text(" ", strip=True).strip()
+
             name = _cell(name_idx)
             if not name:
                 continue
@@ -380,13 +384,15 @@ def _parse_rankings(html: str) -> list[dict]:
             rank = _cell(rank_idx)
             pos = _cell(pos_idx)
             team = _cell(team_idx)
-            rows_out.append({
-                "name": name,
-                "avg": avg,
-                "rank": rank,
-                "pos": pos,
-                "team": team,
-            })
+            rows_out.append(
+                {
+                    "name": name,
+                    "avg": avg,
+                    "rank": rank,
+                    "pos": pos,
+                    "team": team,
+                }
+            )
         if len(rows_out) >= 10:
             return rows_out
     return []
@@ -447,11 +453,15 @@ def _write_csv(path: Path, rows: list[dict]) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Scrape but don't write any CSVs.",
     )
     parser.add_argument(
-        "--only", metavar="BOARD_KEY", action="append", default=None,
+        "--only",
+        metavar="BOARD_KEY",
+        action="append",
+        default=None,
         help=f"Scrape only this board (repeatable).  Choices: {', '.join(BOARDS)}",
     )
     args = parser.parse_args()
@@ -496,8 +506,7 @@ def main() -> int:
                 continue
             if _looks_like_preview(html):
                 print(
-                    f"[DLF] {key}: still preview after re-auth — "
-                    f"membership may have lapsed.",
+                    f"[DLF] {key}: still preview after re-auth — " f"membership may have lapsed.",
                     file=sys.stderr,
                 )
                 exit_code = max(exit_code, 1)

--- a/scripts/fetch_draftsharks.py
+++ b/scripts/fetch_draftsharks.py
@@ -48,6 +48,7 @@ Run
     python3 scripts/fetch_draftsharks.py --dry-run   # print + skip write
     python3 scripts/fetch_draftsharks.py --headful   # launch visible browser
 """
+
 from __future__ import annotations
 
 import argparse
@@ -84,8 +85,7 @@ LEAGUE_ID = "995704"  # "Risk It To Get The Brisket"
 # CSV.  Rows with other or missing positions are dropped.
 _OFFENSE_FAMILIES: frozenset[str] = frozenset({"QB", "RB", "WR", "TE"})
 _IDP_FAMILIES: frozenset[str] = frozenset(
-    {"DL", "LB", "DB", "DE", "DT", "EDGE", "NT", "ILB", "OLB", "MLB",
-     "CB", "S", "SS", "FS"}
+    {"DL", "LB", "DB", "DE", "DT", "EDGE", "NT", "ILB", "OLB", "MLB", "CB", "S", "SS", "FS"}
 )
 
 # Only these cookies matter for auth + league context.  Everything
@@ -145,15 +145,17 @@ def _load_cookies() -> list[dict]:
             continue
         if c["name"].startswith("_comment"):
             continue
-        out.append({
-            "name": c["name"],
-            "value": c["value"],
-            "domain": c.get("domain") or "www.draftsharks.com",
-            "path": c.get("path") or "/",
-            "httpOnly": bool(c.get("httpOnly", True)),
-            "secure": bool(c.get("secure", True)),
-            "sameSite": str(c.get("sameSite") or "Lax").title(),
-        })
+        out.append(
+            {
+                "name": c["name"],
+                "value": c["value"],
+                "domain": c.get("domain") or "www.draftsharks.com",
+                "path": c.get("path") or "/",
+                "httpOnly": bool(c.get("httpOnly", True)),
+                "secure": bool(c.get("secure", True)),
+                "sameSite": str(c.get("sameSite") or "Lax").title(),
+            }
+        )
     return out
 
 
@@ -178,9 +180,7 @@ def _save_cookies(cookies: list[dict]) -> None:
                 "sameSite": str(c.get("sameSite") or "Lax").title(),
             }
             for c in cookies
-            if isinstance(c, dict)
-            and "name" in c
-            and c.get("name") in _AUTH_COOKIE_NAMES
+            if isinstance(c, dict) and "name" in c and c.get("name") in _AUTH_COOKIE_NAMES
         ],
     }
     SESSION_PATH.write_text(json.dumps(payload, indent=2) + "\n")
@@ -226,9 +226,7 @@ async def _browser_login(context, page) -> None:
             "() => Array.from(document.querySelectorAll('.alert, .help-block-error, [role=alert]'))"
             ".map(e => e.textContent.trim()).filter(Boolean).slice(0, 3)"
         )
-        raise RuntimeError(
-            f"DS login failed — no _identity cookie issued.  Page errors: {errors}"
-        )
+        raise RuntimeError(f"DS login failed — no _identity cookie issued.  Page errors: {errors}")
     fresh_cookies = await context.cookies("https://www.draftsharks.com")
     _save_cookies(fresh_cookies)
     count = sum(1 for c in fresh_cookies if c.get("name") in _AUTH_COOKIE_NAMES)
@@ -337,13 +335,9 @@ async def _scrape_one(page) -> list[dict]:
 
     print(f"[DS] activating league {LEAGUE_ID} …", flush=True)
     try:
-        await page.select_option(
-            "#use-my-league-dropdown", value=LEAGUE_ID, timeout=5_000
-        )
+        await page.select_option("#use-my-league-dropdown", value=LEAGUE_ID, timeout=5_000)
     except Exception as exc:
-        raise RuntimeError(
-            f"Failed to select league {LEAGUE_ID}: {exc}"
-        )
+        raise RuntimeError(f"Failed to select league {LEAGUE_ID}: {exc}")
 
     # Wait for the WASM worker to apply the league scoring.  Mahomes
     # public value is 74, league-synced ~81 in a TE-premium + IDP-
@@ -358,6 +352,7 @@ async def _scrape_one(page) -> list[dict]:
             return el ? parseFloat(el.textContent.trim()) : null;
         }""")
         return val is not None and val >= 78
+
     for _ in range(30):
         if await _applied():
             break
@@ -451,6 +446,7 @@ def _write_csv(
     the same value the user sees on the offense-combined page
     (e.g. 44, not the IDP-only-page rescaled 81)."""
     selected = [r for r in rows if r.get("position", "").upper() in include_families]
+
     # Sort by DS value desc; ties broken by DS's own rank-index, then
     # by name.  The DS worker may assign the same dsValue to multiple
     # players; use rank-index to disambiguate ordering.
@@ -460,6 +456,7 @@ def _write_csv(
             int(r.get("dsRank") or 99999),
             (r.get("name") or "").lower(),
         )
+
     selected.sort(key=_rank_sort_key)
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -467,32 +464,36 @@ def _write_csv(
         w = csv.writer(f)
         w.writerow(CSV_HEADER)
         for i, r in enumerate(selected, 1):
-            w.writerow([
-                i,
-                r.get("team") or "",
-                r.get("name") or "",
-                r.get("position") or "",
-                r.get("adp") or "",
-                r.get("bye") or "",
-                r.get("age") or "",
-                r.get("oneYr") or "",
-                r.get("threeYr") or "",
-                r.get("fiveYr") or "",
-                r.get("tenYr") or "",
-                r.get("comment") or "",
-                r.get("dsValue") or "",
-            ])
+            w.writerow(
+                [
+                    i,
+                    r.get("team") or "",
+                    r.get("name") or "",
+                    r.get("position") or "",
+                    r.get("adp") or "",
+                    r.get("bye") or "",
+                    r.get("age") or "",
+                    r.get("oneYr") or "",
+                    r.get("threeYr") or "",
+                    r.get("fiveYr") or "",
+                    r.get("tenYr") or "",
+                    r.get("comment") or "",
+                    r.get("dsValue") or "",
+                ]
+            )
     return len(selected)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Scrape but don't write the CSV.",
     )
     parser.add_argument(
-        "--headful", action="store_true",
+        "--headful",
+        action="store_true",
         help="Launch the browser visibly (useful for debugging).",
     )
     args = parser.parse_args()
@@ -509,12 +510,8 @@ def main() -> int:
     # cross-universe universe (QB + IDP on the same dsValue scale),
     # so a missing IDP count here means the worker didn't settle
     # or the position attribute normalization changed.
-    off_count = sum(
-        1 for r in rows if r.get("position", "").upper() in _OFFENSE_FAMILIES
-    )
-    idp_count = sum(
-        1 for r in rows if r.get("position", "").upper() in _IDP_FAMILIES
-    )
+    off_count = sum(1 for r in rows if r.get("position", "").upper() in _OFFENSE_FAMILIES)
+    idp_count = sum(1 for r in rows if r.get("position", "").upper() in _IDP_FAMILIES)
     print(f"[DS] family split: offense={off_count} idp={idp_count}")
     if idp_count == 0:
         print(

--- a/scripts/fetch_draftsharks_ros.py
+++ b/scripts/fetch_draftsharks_ros.py
@@ -30,6 +30,7 @@ The CSV schema matches the ROS orchestrator's existing format
 ``canonicalName`` is left empty — the orchestrator's resolver
 fills it on the next scrape pass.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -59,8 +60,7 @@ ROS_IDP_URL = "https://www.draftsharks.com/ros-rankings/idp"
 
 _OFFENSE_FAMILIES: frozenset[str] = frozenset({"QB", "RB", "WR", "TE"})
 _IDP_FAMILIES: frozenset[str] = frozenset(
-    {"DL", "LB", "DB", "DE", "DT", "EDGE", "NT", "ILB", "OLB", "MLB",
-     "CB", "S", "SS", "FS"}
+    {"DL", "LB", "DB", "DE", "DT", "EDGE", "NT", "ILB", "OLB", "MLB", "CB", "S", "SS", "FS"}
 )
 
 _USER_AGENT = (
@@ -106,15 +106,17 @@ def _load_cookies() -> list[dict]:
             continue
         if c["name"].startswith("_comment"):
             continue
-        out.append({
-            "name": c["name"],
-            "value": c["value"],
-            "domain": c.get("domain") or "www.draftsharks.com",
-            "path": c.get("path") or "/",
-            "httpOnly": bool(c.get("httpOnly", True)),
-            "secure": bool(c.get("secure", True)),
-            "sameSite": str(c.get("sameSite") or "Lax").title(),
-        })
+        out.append(
+            {
+                "name": c["name"],
+                "value": c["value"],
+                "domain": c.get("domain") or "www.draftsharks.com",
+                "path": c.get("path") or "/",
+                "httpOnly": bool(c.get("httpOnly", True)),
+                "secure": bool(c.get("secure", True)),
+                "sameSite": str(c.get("sameSite") or "Lax").title(),
+            }
+        )
     return out
 
 
@@ -177,15 +179,17 @@ def _write_csv(path: Path, rows: list[dict]) -> int:
         w = csv.DictWriter(f, fieldnames=CSV_HEADER)
         w.writeheader()
         for i, r in enumerate(rows, start=1):
-            w.writerow({
-                "canonicalName": "",
-                "sourceName": r["name"],
-                "position": _classify_position(r.get("pos") or ""),
-                "team": "",
-                "rank": i,
-                "total_ranked": n,
-                "projection": "",
-            })
+            w.writerow(
+                {
+                    "canonicalName": "",
+                    "sourceName": r["name"],
+                    "position": _classify_position(r.get("pos") or ""),
+                    "team": "",
+                    "rank": i,
+                    "total_ranked": n,
+                    "projection": "",
+                }
+            )
     return n
 
 
@@ -266,8 +270,7 @@ async def main_async() -> int:
                     file=sys.stderr,
                 )
             idp_filtered = [
-                r for r in sf_rows
-                if _classify_position(r.get("pos") or "") in _IDP_FAMILIES
+                r for r in sf_rows if _classify_position(r.get("pos") or "") in _IDP_FAMILIES
             ]
         n_idp = _write_csv(idp_csv, idp_filtered)
 

--- a/scripts/fetch_dynasty_daddy.py
+++ b/scripts/fetch_dynasty_daddy.py
@@ -41,6 +41,7 @@ Exit codes:
          * response is not a JSON array, or
          * row count below :data:`_DD_ROW_COUNT_FLOOR`
 """
+
 from __future__ import annotations
 
 import argparse
@@ -101,9 +102,7 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
     whose sf_trade_value is a positive number.
     """
     if not isinstance(data, list):
-        raise DynastyDaddySchemaError(
-            f"Expected JSON array, got {type(data).__name__}"
-        )
+        raise DynastyDaddySchemaError(f"Expected JSON array, got {type(data).__name__}")
     out: list[dict[str, Any]] = []
     for entry in data:
         name = str(entry.get("full_name") or "").strip()
@@ -211,8 +210,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if len(rows) < _DD_ROW_COUNT_FLOOR:
         print(
-            f"[fetch_dynasty_daddy] row count below floor: "
-            f"{len(rows)} < {_DD_ROW_COUNT_FLOOR}",
+            f"[fetch_dynasty_daddy] row count below floor: " f"{len(rows)} < {_DD_ROW_COUNT_FLOOR}",
             file=sys.stderr,
         )
         return 2
@@ -222,9 +220,7 @@ def main(argv: list[str] | None = None) -> int:
     for r in rows:
         # Value-only CSV doesn't carry position — count from parse step.
         pass
-    print(
-        f"[fetch_dynasty_daddy] total={len(rows)} rows with positive sf_trade_value"
-    )
+    print(f"[fetch_dynasty_daddy] total={len(rows)} rows with positive sf_trade_value")
 
     if args.dry_run:
         print("[fetch_dynasty_daddy] --dry-run; not writing CSV")

--- a/scripts/fetch_dynasty_nerds.py
+++ b/scripts/fetch_dynasty_nerds.py
@@ -37,6 +37,7 @@ Exit codes:
        regression alerts loudly instead of getting buried as a generic
        warning.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -115,9 +116,7 @@ def _extract_dr_data(html: str) -> dict:
     payload = html[start:end]
     parsed = json.loads(payload)
     if not isinstance(parsed, dict):
-        raise DynastyNerdsSchemaError(
-            f"DR_DATA expected dict, got {type(parsed).__name__}"
-        )
+        raise DynastyNerdsSchemaError(f"DR_DATA expected dict, got {type(parsed).__name__}")
     if "SFLEXTEP" not in parsed:
         raise DynastyNerdsSchemaError(
             "DR_DATA shape changed: missing SFLEXTEP key "
@@ -234,8 +233,7 @@ def main(argv: list[str] | None = None) -> int:
         # Row count regression: parsed fewer rows than the floor.  Same
         # treatment as schema error — exit 2 for structured surfacing.
         print(
-            f"[fetch_dynasty_nerds] row count below floor: "
-            f"{len(rows)} < {_DN_ROW_COUNT_FLOOR}",
+            f"[fetch_dynasty_nerds] row count below floor: " f"{len(rows)} < {_DN_ROW_COUNT_FLOOR}",
             file=sys.stderr,
         )
         return 2

--- a/scripts/fetch_fantasycalc.py
+++ b/scripts/fetch_fantasycalc.py
@@ -49,6 +49,7 @@ Exit codes:
          * response is not a JSON array, or
          * row count below :data:`_FC_ROW_COUNT_FLOOR`
 """
+
 from __future__ import annotations
 
 import argparse
@@ -65,10 +66,7 @@ except ImportError:  # pragma: no cover
     sys.exit(1)
 
 
-FC_URL = (
-    "https://api.fantasycalc.com/values/current"
-    "?isDynasty=true&numQbs=2&numTeams=12&ppr=1"
-)
+FC_URL = "https://api.fantasycalc.com/values/current" "?isDynasty=true&numQbs=2&numTeams=12&ppr=1"
 UA = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"
@@ -148,9 +146,7 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
     whose value is a positive number.
     """
     if not isinstance(data, list):
-        raise FantasyCalcSchemaError(
-            f"Expected JSON array, got {type(data).__name__}"
-        )
+        raise FantasyCalcSchemaError(f"Expected JSON array, got {type(data).__name__}")
     out: list[dict[str, Any]] = []
     for entry in data:
         if not isinstance(entry, dict):
@@ -253,15 +249,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if len(rows) < _FC_ROW_COUNT_FLOOR:
         print(
-            f"[fetch_fantasycalc] row count below floor: "
-            f"{len(rows)} < {_FC_ROW_COUNT_FLOOR}",
+            f"[fetch_fantasycalc] row count below floor: " f"{len(rows)} < {_FC_ROW_COUNT_FLOOR}",
             file=sys.stderr,
         )
         return 2
 
-    print(
-        f"[fetch_fantasycalc] total={len(rows)} rows with positive value"
-    )
+    print(f"[fetch_fantasycalc] total={len(rows)} rows with positive value")
 
     if args.dry_run:
         print("[fetch_fantasycalc] --dry-run; not writing CSV")

--- a/scripts/fetch_fantasypros_fitzmaurice.py
+++ b/scripts/fetch_fantasypros_fitzmaurice.py
@@ -49,6 +49,7 @@ Run
     python3 scripts/fetch_fantasypros_fitzmaurice.py --dry-run
     python3 scripts/fetch_fantasypros_fitzmaurice.py --url <article-url>
 """
+
 from __future__ import annotations
 
 import argparse
@@ -88,8 +89,10 @@ _POSITION_HEADINGS = (
     ("QB", ("Dynasty Trade Values: Quarterbacks", "Quarterbacks")),
     ("RB", ("Dynasty Trade Values: Running Backs", "Running Backs")),
     ("WR", ("Dynasty Trade Values: Wide Receivers", "Wide Receivers")),
-    ("TE", ("Dynasty Trade Value Chart: Tight Ends",
-            "Dynasty Trade Values: Tight Ends", "Tight Ends")),
+    (
+        "TE",
+        ("Dynasty Trade Value Chart: Tight Ends", "Dynasty Trade Values: Tight Ends", "Tight Ends"),
+    ),
 )
 
 
@@ -121,9 +124,7 @@ def _fetch_article_html(url: str) -> str | None:
     try:
         import requests
     except ImportError:
-        raise SystemExit(
-            "requests is not installed.  `pip install requests` first."
-        )
+        raise SystemExit("requests is not installed.  `pip install requests` first.")
     try:
         r = requests.get(
             url,
@@ -162,9 +163,7 @@ def _extract_chart_ids_by_position(html: str) -> dict[str, str]:
     try:
         from bs4 import BeautifulSoup
     except ImportError:
-        raise SystemExit(
-            "beautifulsoup4 not installed.  `pip install beautifulsoup4`."
-        )
+        raise SystemExit("beautifulsoup4 not installed.  `pip install beautifulsoup4`.")
     soup = BeautifulSoup(html, "html.parser")
     # Walk the document tree in source order, tracking the most
     # recent heading we saw for each position match.
@@ -201,27 +200,22 @@ def _fetch_chart_csv(chart_id: str) -> str | None:
     try:
         import requests
     except ImportError:
-        raise SystemExit(
-            "requests is not installed.  `pip install requests` first."
-        )
+        raise SystemExit("requests is not installed.  `pip install requests` first.")
     url = f"https://datawrapper.dwcdn.net/{chart_id}/1/dataset.csv"
     try:
         r = requests.get(
             url,
             headers={
-                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) "
-                              "AppleWebKit/537.36 Chrome/131",
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) " "AppleWebKit/537.36 Chrome/131",
                 "Referer": "https://www.fantasypros.com/",
             },
             timeout=20,
         )
     except Exception as exc:  # noqa: BLE001
-        print(f"[fitzmaurice] chart {chart_id} fetch failed: {exc}",
-              file=sys.stderr)
+        print(f"[fitzmaurice] chart {chart_id} fetch failed: {exc}", file=sys.stderr)
         return None
     if r.status_code != 200:
-        print(f"[fitzmaurice] chart {chart_id} status={r.status_code}",
-              file=sys.stderr)
+        print(f"[fitzmaurice] chart {chart_id} status={r.status_code}", file=sys.stderr)
         return None
     return r.text
 
@@ -262,12 +256,14 @@ def _parse_chart_rows(csv_text: str, position: str) -> list[dict]:
         # they don't pollute the tail of the combined pool.
         if val <= 1:
             continue
-        rows_out.append({
-            "name": name,
-            "team": team,
-            "position": position,
-            "value": val,
-        })
+        rows_out.append(
+            {
+                "name": name,
+                "team": team,
+                "position": position,
+                "value": val,
+            }
+        )
     return rows_out
 
 
@@ -327,17 +323,15 @@ def _write_csv(path: Path, rows: list[dict]) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Scrape but don't write the CSV.")
+    parser.add_argument("--dry-run", action="store_true", help="Scrape but don't write the CSV.")
     parser.add_argument(
-        "--url", metavar="ARTICLE_URL",
+        "--url",
+        metavar="ARTICLE_URL",
         help="Skip URL discovery and use this article URL directly.",
     )
     args = parser.parse_args()
 
-    candidate_urls: list[str] = (
-        [args.url] if args.url else _build_candidate_urls()
-    )
+    candidate_urls: list[str] = [args.url] if args.url else _build_candidate_urls()
     html: str | None = None
     used_url: str | None = None
     for candidate in candidate_urls:
@@ -388,8 +382,7 @@ def main() -> int:
         all_rows.extend(rows)
 
     if not all_rows:
-        print("[fitzmaurice] ERROR: no rows extracted from any position",
-              file=sys.stderr)
+        print("[fitzmaurice] ERROR: no rows extracted from any position", file=sys.stderr)
         return 1
 
     # Sanity floor — each position should have at least ~20 rows in
@@ -408,15 +401,9 @@ def main() -> int:
             )
 
     if args.dry_run:
-        print(
-            f"[fitzmaurice] dry-run: {len(all_rows)} total rows "
-            f"(top 5 by value):"
-        )
+        print(f"[fitzmaurice] dry-run: {len(all_rows)} total rows " f"(top 5 by value):")
         for r in sorted(all_rows, key=lambda r: -r["value"])[:5]:
-            print(
-                f"  {r['position']:<3} {r['name']:<25} "
-                f"{r['team']:<4} value={r['value']}"
-            )
+            print(f"  {r['position']:<3} {r['name']:<25} " f"{r['team']:<4} value={r['value']}")
         return 0
 
     # Contract-aligned floor BEFORE writing: a short scrape must not

--- a/scripts/fetch_fantasypros_idp.py
+++ b/scripts/fetch_fantasypros_idp.py
@@ -72,6 +72,7 @@ Exit codes:
          * any individual board row count below
            :data:`_FP_INDIVIDUAL_ROW_FLOOR`
 """
+
 from __future__ import annotations
 
 import argparse
@@ -210,9 +211,7 @@ def _extract_ecr_data(html: str) -> dict[str, Any]:
     payload = html[start:end]
     parsed = json.loads(payload)
     if not isinstance(parsed, dict):
-        raise FantasyProsSchemaError(
-            f"ecrData expected dict, got {type(parsed).__name__}"
-        )
+        raise FantasyProsSchemaError(f"ecrData expected dict, got {type(parsed).__name__}")
     if "players" not in parsed or not isinstance(parsed["players"], list):
         raise FantasyProsSchemaError(
             "ecrData shape changed: missing 'players' list "
@@ -326,8 +325,7 @@ def _interpolate(r: float, anchors: list[tuple[int, int]]) -> float:
         # ``_EXTRAPOLATION_SEGMENT_WINDOW`` (or fewer if we don't
         # have that many segments yet).
         all_slopes = [
-            (anchors[k + 1][1] - anchors[k][1])
-            / max(1, (anchors[k + 1][0] - anchors[k][0]))
+            (anchors[k + 1][1] - anchors[k][1]) / max(1, (anchors[k + 1][0] - anchors[k][0]))
             for k in range(len(anchors) - 1)
         ]
         tail = all_slopes[-_EXTRAPOLATION_SEGMENT_WINDOW:]
@@ -539,12 +537,9 @@ def main(argv: list[str] | None = None) -> int:
         ext_count = sum(
             1
             for r in rows
-            if r["derivationMethod"] == "anchored_from_individual"
-            and r["family"] == fam
+            if r["derivationMethod"] == "anchored_from_individual" and r["family"] == fam
         )
-        print(
-            f"[fetch_fantasypros_idp]   {fam}: anchors={len(a)} extension_rows={ext_count}"
-        )
+        print(f"[fetch_fantasypros_idp]   {fam}: anchors={len(a)} extension_rows={ext_count}")
 
     if args.dry_run:
         print("[fetch_fantasypros_idp] --dry-run; not writing CSV")

--- a/scripts/fetch_fantasypros_offense.py
+++ b/scripts/fetch_fantasypros_offense.py
@@ -43,6 +43,7 @@ Exit codes:
          * ecrData missing the ``players`` key, or
          * row count below :data:`_FP_ROW_COUNT_FLOOR`
 """
+
 from __future__ import annotations
 
 import argparse
@@ -122,9 +123,7 @@ def _extract_ecr_data(html: str) -> dict[str, Any]:
     payload = html[start:end]
     parsed = json.loads(payload)
     if not isinstance(parsed, dict):
-        raise FantasyProsOffenseSchemaError(
-            f"ecrData expected dict, got {type(parsed).__name__}"
-        )
+        raise FantasyProsOffenseSchemaError(f"ecrData expected dict, got {type(parsed).__name__}")
     if "players" not in parsed or not isinstance(parsed["players"], list):
         raise FantasyProsOffenseSchemaError(
             "ecrData shape changed: missing 'players' list "
@@ -252,9 +251,7 @@ def main(argv: list[str] | None = None) -> int:
     for r in rows:
         pos_counts[r["position"]] = pos_counts.get(r["position"], 0) + 1
     pos_summary = " ".join(f"{p}={c}" for p, c in sorted(pos_counts.items()))
-    print(
-        f"[fetch_fantasypros_offense] total={len(rows)} {pos_summary}"
-    )
+    print(f"[fetch_fantasypros_offense] total={len(rows)} {pos_summary}")
 
     if args.dry_run:
         print("[fetch_fantasypros_offense] --dry-run; not writing CSV")

--- a/scripts/fetch_flock_fantasy.py
+++ b/scripts/fetch_flock_fantasy.py
@@ -40,6 +40,7 @@ Exit codes:
          * response is not a dict with a ``data`` array, or
          * row count below :data:`_FF_ROW_COUNT_FLOOR`
 """
+
 from __future__ import annotations
 
 import argparse
@@ -101,14 +102,10 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
     number.
     """
     if not isinstance(data, dict) or "data" not in data:
-        raise FlockFantasySchemaError(
-            f"Expected dict with 'data' key, got {type(data).__name__}"
-        )
+        raise FlockFantasySchemaError(f"Expected dict with 'data' key, got {type(data).__name__}")
     entries = data["data"]
     if not isinstance(entries, list):
-        raise FlockFantasySchemaError(
-            f"Expected 'data' to be a list, got {type(entries).__name__}"
-        )
+        raise FlockFantasySchemaError(f"Expected 'data' to be a list, got {type(entries).__name__}")
     out: list[dict[str, Any]] = []
     for entry in entries:
         # Skip draft picks.
@@ -211,15 +208,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if len(rows) < _FF_ROW_COUNT_FLOOR:
         print(
-            f"[fetch_flock_fantasy] row count below floor: "
-            f"{len(rows)} < {_FF_ROW_COUNT_FLOOR}",
+            f"[fetch_flock_fantasy] row count below floor: " f"{len(rows)} < {_FF_ROW_COUNT_FLOOR}",
             file=sys.stderr,
         )
         return 2
 
-    print(
-        f"[fetch_flock_fantasy] total={len(rows)} rows with valid averageRank"
-    )
+    print(f"[fetch_flock_fantasy] total={len(rows)} rows with valid averageRank")
 
     if args.dry_run:
         print("[fetch_flock_fantasy] --dry-run; not writing CSV")

--- a/scripts/fetch_flock_fantasy_rookies.py
+++ b/scripts/fetch_flock_fantasy_rookies.py
@@ -44,6 +44,7 @@ Exit codes:
          * response is not a dict with a ``data`` array, or
          * row count below :data:`_FF_ROOKIE_ROW_COUNT_FLOOR`
 """
+
 from __future__ import annotations
 
 import argparse
@@ -70,14 +71,7 @@ UA = (
 )
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_DST = REPO_ROOT / "CSVs" / "site_raw" / "flockFantasySfRookies.csv"
-DATA_DIR_DST = (
-    REPO_ROOT
-    / "data"
-    / "exports"
-    / "latest"
-    / "site_raw"
-    / "flockFantasySfRookies.csv"
-)
+DATA_DIR_DST = REPO_ROOT / "data" / "exports" / "latest" / "site_raw" / "flockFantasySfRookies.csv"
 
 # Minimum row count.  The PROSPECTS_SF endpoint currently carries ~98
 # entries (one full rookie class).  Floor set at ~60 so a class shrink
@@ -257,9 +251,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    print(
-        f"[fetch_flock_fantasy_rookies] total={len(rows)} rows with valid averageRank"
-    )
+    print(f"[fetch_flock_fantasy_rookies] total={len(rows)} rows with valid averageRank")
 
     if args.dry_run:
         print("[fetch_flock_fantasy_rookies] --dry-run; not writing CSV")
@@ -268,16 +260,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     _write_csv(args.dest, rows)
-    print(
-        f"[fetch_flock_fantasy_rookies] wrote {len(rows)} rows -> {args.dest}"
-    )
+    print(f"[fetch_flock_fantasy_rookies] wrote {len(rows)} rows -> {args.dest}")
 
     if args.mirror_data_dir:
         try:
             _write_csv(DATA_DIR_DST, rows)
-            print(
-                f"[fetch_flock_fantasy_rookies] mirrored -> {DATA_DIR_DST}"
-            )
+            print(f"[fetch_flock_fantasy_rookies] mirrored -> {DATA_DIR_DST}")
         except Exception as exc:
             print(
                 f"[fetch_flock_fantasy_rookies] mirror failed: {exc}",

--- a/scripts/fetch_footballguys.py
+++ b/scripts/fetch_footballguys.py
@@ -32,6 +32,7 @@ Writes:
     CSVs/site_raw/footballGuysSf.csv   (offense: QB/RB/WR/TE)
     CSVs/site_raw/footballGuysIdp.csv  (IDP: DL/LB/DB)
 """
+
 from __future__ import annotations
 
 import argparse
@@ -168,7 +169,8 @@ def _save_cookies(cookies: list[dict]) -> None:
             for c in cookies
             if isinstance(c, dict)
             and "name" in c
-            and c.get("name") in {
+            and c.get("name")
+            in {
                 "prodwww",
                 "TN_token",
                 "TN_tvid",
@@ -232,30 +234,32 @@ async def _playwright_login() -> list[dict]:
                     "() => Array.from(document.querySelectorAll('.alert, .invalid-feedback, [role=alert]'))"
                     ".map(e => e.textContent.trim()).filter(Boolean).slice(0, 3)"
                 )
-                raise RuntimeError(
-                    f"FG login failed — no TN_token issued.  Page errors: {errors}"
-                )
+                raise RuntimeError(f"FG login failed — no TN_token issued.  Page errors: {errors}")
             # Force the league cookie so server-side rendering is
             # pinned to the operator's league regardless of the
             # account's current default selection.
-            cookies.append({
-                "name": "League_selectedid",
-                "value": LEAGUE_ID,
-                "domain": ".footballguys.com",
-                "path": "/",
-                "httpOnly": False,
-                "secure": True,
-                "sameSite": "Lax",
-            })
-            cookies.append({
-                "name": "FBG_LeagueSelect_Type",
-                "value": "users",
-                "domain": ".footballguys.com",
-                "path": "/",
-                "httpOnly": False,
-                "secure": True,
-                "sameSite": "Lax",
-            })
+            cookies.append(
+                {
+                    "name": "League_selectedid",
+                    "value": LEAGUE_ID,
+                    "domain": ".footballguys.com",
+                    "path": "/",
+                    "httpOnly": False,
+                    "secure": True,
+                    "sameSite": "Lax",
+                }
+            )
+            cookies.append(
+                {
+                    "name": "FBG_LeagueSelect_Type",
+                    "value": "users",
+                    "domain": ".footballguys.com",
+                    "path": "/",
+                    "httpOnly": False,
+                    "secure": True,
+                    "sameSite": "Lax",
+                }
+            )
             return cookies
         finally:
             await browser.close()
@@ -289,7 +293,7 @@ def _fetch(url: str, cookies: dict[str, str]) -> str:
 _ROW_RE = re.compile(
     r'<tr[^>]*data-playerid="([^"]+)"[^>]*data-playername="([^"]+)"'
     r'[^>]*data-rank="(\d+)"[^>]*class="player-row[^"]*"[^>]*>'
-    r'(.*?)</tr>',
+    r"(.*?)</tr>",
     re.DOTALL,
 )
 _POS_RE = re.compile(r'<span class="pos-([A-Z]+)">([A-Z]+\d*)</span>')
@@ -297,7 +301,7 @@ _TEAM_RE = re.compile(r'<span class="team-abbr team-abbr-([A-Z]+)">')
 # The last 3 standalone <td>N</td> cells on each row are age, years_exp,
 # and bye week.  The regex below captures those three closing cells.
 _TRAIL_RE = re.compile(
-    r'<td>([^<]*)</td><td>([^<]*)</td><td>([^<]*)</td>\s*$',
+    r"<td>([^<]*)</td><td>([^<]*)</td><td>([^<]*)</td>\s*$",
     re.DOTALL,
 )
 
@@ -344,15 +348,17 @@ def parse_rows(html: str, *, default_family: str | None = None) -> list[dict[str
         # apostrophe form Sleeper uses, so without unescape the
         # canonical-name matcher drops these players silently.
         # Affects ~11 players across the SF + IDP CSVs.
-        out.append({
-            "name": _html.unescape(name).strip(),
-            "rank": str(rank),
-            "position": position_display,
-            "family": canonical_family,
-            "team": team,
-            "age": age,
-            "years_exp": years_exp,
-        })
+        out.append(
+            {
+                "name": _html.unescape(name).strip(),
+                "rank": str(rank),
+                "position": position_display,
+                "family": canonical_family,
+                "team": team,
+                "age": age,
+                "years_exp": years_exp,
+            }
+        )
     return out
 
 
@@ -389,14 +395,16 @@ def _write_csv(
         w = csv.writer(f)
         w.writerow(["name", "rank", "position", "team", "age", "years_exp"])
         for row in selected:
-            w.writerow([
-                row["name"],
-                row["rank"],  # original cross-market rank — not re-densified
-                row["position"],
-                row["team"],
-                row["age"],
-                row["years_exp"],
-            ])
+            w.writerow(
+                [
+                    row["name"],
+                    row["rank"],  # original cross-market rank — not re-densified
+                    row["position"],
+                    row["team"],
+                    row["age"],
+                    row["years_exp"],
+                ]
+            )
     return len(selected)
 
 
@@ -450,9 +458,7 @@ def main() -> int:
     # re-ranked 1..N inside the IDP universe only, which would erase
     # FBG's native offense-vs-IDP ratio.
     print("[FBG] fetching combined rankings (pos=all) …", flush=True)
-    all_html, cookies = _fetch_with_auto_login(
-        OFFENSE_URL, cookies, label="combined"
-    )
+    all_html, cookies = _fetch_with_auto_login(OFFENSE_URL, cookies, label="combined")
     all_rows = parse_rows(all_html)
     print(f"[FBG] combined rows parsed: {len(all_rows)}")
 
@@ -461,9 +467,7 @@ def main() -> int:
         print("top 5 (combined ranking):")
         for r in all_rows[:5]:
             print(f"  {r}")
-        first_idp = next(
-            (r for r in all_rows if r["family"] in _IDP_POS), None
-        )
+        first_idp = next((r for r in all_rows if r["family"] in _IDP_POS), None)
         print(f"first IDP row: {first_idp}")
         return 0
 

--- a/scripts/fetch_idpshow.py
+++ b/scripts/fetch_idpshow.py
@@ -48,6 +48,7 @@ Run
     python3 scripts/fetch_idpshow.py
     python3 scripts/fetch_idpshow.py --dry-run
 """
+
 from __future__ import annotations
 
 import argparse
@@ -89,12 +90,14 @@ def _load_cookies() -> list[dict]:
             continue
         if c["name"].startswith("_comment"):
             continue
-        out.append({
-            "name": c["name"],
-            "value": c["value"],
-            "domain": c.get("domain") or ".theidpshow.com",
-            "path": c.get("path") or "/",
-        })
+        out.append(
+            {
+                "name": c["name"],
+                "value": c["value"],
+                "domain": c.get("domain") or ".theidpshow.com",
+                "path": c.get("path") or "/",
+            }
+        )
     return out
 
 
@@ -110,7 +113,8 @@ def _build_session():
     for c in _load_cookies():
         try:
             session.cookies.set(
-                c["name"], c["value"],
+                c["name"],
+                c["value"],
                 domain=str(c.get("domain") or "").lstrip("."),
                 path=c.get("path") or "/",
             )
@@ -122,9 +126,7 @@ def _build_session():
 def _fetch_article_html(session) -> str:
     r = session.get(ARTICLE_URL, timeout=45)
     if r.status_code != 200:
-        raise RuntimeError(
-            f"GET {ARTICLE_URL} failed: HTTP {r.status_code}"
-        )
+        raise RuntimeError(f"GET {ARTICLE_URL} failed: HTTP {r.status_code}")
     return r.text
 
 
@@ -217,9 +219,7 @@ def _fetch_dataset_csv(session, chart_id: str, version: str) -> str:
         timeout=30,
     )
     if r.status_code != 200:
-        raise RuntimeError(
-            f"GET {url} failed: HTTP {r.status_code}"
-        )
+        raise RuntimeError(f"GET {url} failed: HTTP {r.status_code}")
     return r.text
 
 
@@ -250,27 +250,25 @@ def _parse_dataset(csv_text: str) -> list[dict]:
         # Position: old ``POS`` is a bare code; new ``POSITION RANK``
         # is the code with the positional rank concatenated
         # (``ED1``).  Strip everything from the first digit on.
-        pos_src = str(
-            row.get("POS") or row.get("POSITION RANK") or ""
-        ).strip().upper()
+        pos_src = str(row.get("POS") or row.get("POSITION RANK") or "").strip().upper()
         m = re.match(r"[A-Z]+", pos_src)
         pos_raw = m.group(0) if m else pos_src
         pos_norm = _POS_NORM.get(pos_raw, pos_raw)
         # Overall rank: old ``OVR`` → new ``OVERALL``.
-        ovr_raw = str(
-            row.get("OVR") or row.get("OVERALL") or ""
-        ).strip().lstrip("0")
+        ovr_raw = str(row.get("OVR") or row.get("OVERALL") or "").strip().lstrip("0")
         try:
             rank = int(ovr_raw) if ovr_raw else None
         except (TypeError, ValueError):
             continue
         if rank is None or rank <= 0:
             continue
-        rows_out.append({
-            "name": name,
-            "position": pos_norm,
-            "rank": rank,
-        })
+        rows_out.append(
+            {
+                "name": name,
+                "position": pos_norm,
+                "rank": rank,
+            }
+        )
     return rows_out
 
 
@@ -288,7 +286,8 @@ def _write_csv(path: Path, rows: list[dict]) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Scrape but don't write the CSV.",
     )
     args = parser.parse_args()

--- a/scripts/fetch_otcffb.py
+++ b/scripts/fetch_otcffb.py
@@ -48,6 +48,7 @@ Exit codes:
     1  - soft failure (fetch / parse error, zero rows extracted)
     2  - schema regression (shape changed, row count below floor)
 """
+
 from __future__ import annotations
 
 import argparse
@@ -108,14 +109,11 @@ def _parse_players(data: Any) -> list[dict[str, Any]]:
     blend produces.
     """
     if not isinstance(data, dict):
-        raise OtcffbSchemaError(
-            f"Expected JSON object, got {type(data).__name__}"
-        )
+        raise OtcffbSchemaError(f"Expected JSON object, got {type(data).__name__}")
     players = data.get("players")
     if not isinstance(players, list):
         raise OtcffbSchemaError(
-            f"Expected dict.players to be a list, got "
-            f"{type(players).__name__}"
+            f"Expected dict.players to be a list, got " f"{type(players).__name__}"
         )
     out: list[dict[str, Any]] = []
     for entry in players:
@@ -216,8 +214,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if len(rows) < _OTC_ROW_COUNT_FLOOR:
         print(
-            f"[fetch_otcffb] row count below floor: "
-            f"{len(rows)} < {_OTC_ROW_COUNT_FLOOR}",
+            f"[fetch_otcffb] row count below floor: " f"{len(rows)} < {_OTC_ROW_COUNT_FLOOR}",
             file=sys.stderr,
         )
         return 2

--- a/scripts/fetch_yahoo_boone.py
+++ b/scripts/fetch_yahoo_boone.py
@@ -69,6 +69,7 @@ Exit codes 2 and 3 deliberately leave the previously-written CSV
 untouched: a degraded refresh keeps serving the last good board
 until a human investigates, rather than overwriting it.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -218,18 +219,12 @@ def _parse_position_table(page_html: str, position: str) -> list[YahooRow]:
     wanted = _VALUE_COLUMN[position]
 
     try:
-        player_idx = next(
-            i for i, col in enumerate(header) if col.lower() == "player"
-        )
+        player_idx = next(i for i, col in enumerate(header) if col.lower() == "player")
     except StopIteration as exc:
-        raise YahooBooneSchemaError(
-            f"{position}: no 'Player' column in header {header!r}"
-        ) from exc
+        raise YahooBooneSchemaError(f"{position}: no 'Player' column in header {header!r}") from exc
 
     try:
-        value_idx = next(
-            i for i, col in enumerate(header) if col.lower() == wanted.lower()
-        )
+        value_idx = next(i for i, col in enumerate(header) if col.lower() == wanted.lower())
     except StopIteration as exc:
         raise YahooBooneSchemaError(
             f"{position}: no '{wanted}' column in header {header!r}"
@@ -320,7 +315,9 @@ def _write_csv(path: Path, ranked: list[tuple[YahooRow, int]]) -> None:
 
 
 # ── Orchestration ─────────────────────────────────────────────────────
-def _fetch_one_position(position: str, urls: list[str]) -> tuple[list[YahooRow], str, datetime | None]:
+def _fetch_one_position(
+    position: str, urls: list[str]
+) -> tuple[list[YahooRow], str, datetime | None]:
     """Try each seed URL for a position; return (rows, final_url, pub_date)."""
     last_exc: Exception | None = None
     for url in urls:
@@ -391,10 +388,7 @@ def fetch_all(
                     f"at {final_url} — check _SEED_URLS for a fresher entry"
                 )
         combined.extend(parsed)
-        print(
-            f"[fetch_yahoo_boone] {position}: {len(parsed)} rows "
-            f"from {final_url}"
-        )
+        print(f"[fetch_yahoo_boone] {position}: {len(parsed)} rows " f"from {final_url}")
 
     return combined, warnings
 
@@ -435,8 +429,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if len(rows) < _YB_ROW_COUNT_FLOOR:
         print(
-            f"[fetch_yahoo_boone] row count below floor: "
-            f"{len(rows)} < {_YB_ROW_COUNT_FLOOR}",
+            f"[fetch_yahoo_boone] row count below floor: " f"{len(rows)} < {_YB_ROW_COUNT_FLOOR}",
             file=sys.stderr,
         )
         return 2
@@ -456,9 +449,7 @@ def main(argv: list[str] | None = None) -> int:
         if pos_seen.get(pos, 0) < _YB_MIN_ROWS_PER_POSITION
     }
     if short_positions:
-        detail = ", ".join(
-            f"{p}={pos_seen.get(p, 0)}" for p in sorted(short_positions)
-        )
+        detail = ", ".join(f"{p}={pos_seen.get(p, 0)}" for p in sorted(short_positions))
         print(
             f"[fetch_yahoo_boone] partial scrape — position(s) below "
             f"min {_YB_MIN_ROWS_PER_POSITION}: {detail} "

--- a/scripts/fit_hill_curve_from_market.py
+++ b/scripts/fit_hill_curve_from_market.py
@@ -15,6 +15,7 @@ Usage:
     python3 scripts/fit_hill_curve_from_market.py          # offense (default)
     python3 scripts/fit_hill_curve_from_market.py --universe idp
 """
+
 from __future__ import annotations
 
 import argparse
@@ -24,10 +25,10 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 
 OFFENSE_SOURCES: dict[str, tuple[str, str]] = {
-    "KTC":          ("CSVs/site_raw/ktc.csv",                 "value"),
-    "IDPTradeCalc": ("CSVs/site_raw/idpTradeCalc.csv",        "value"),
-    "DynastyDaddy": ("CSVs/site_raw/dynastyDaddySf.csv",      "value"),
-    "DynastyNerds": ("CSVs/site_raw/dynastyNerdsSfTep.csv",   "Value"),
+    "KTC": ("CSVs/site_raw/ktc.csv", "value"),
+    "IDPTradeCalc": ("CSVs/site_raw/idpTradeCalc.csv", "value"),
+    "DynastyDaddy": ("CSVs/site_raw/dynastyDaddySf.csv", "value"),
+    "DynastyNerds": ("CSVs/site_raw/dynastyNerdsSfTep.csv", "Value"),
 }
 
 # IDP market sources.  IDPTradeCalc is the retail IDP authority and
@@ -138,7 +139,9 @@ def _fit(normed_points: list[tuple[int, float]]) -> tuple[float, float, float]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--universe", choices=["offense", "idp"], default="offense",
+        "--universe",
+        choices=["offense", "idp"],
+        default="offense",
         help="Which market to fit (default: offense)",
     )
     args = parser.parse_args()
@@ -176,7 +179,9 @@ def main() -> int:
         normed = [(i + 1, v / top * 9999.0) for i, v in enumerate(values[:300])]
         m, s, mse = _fit(normed)
         fits.append((label, len(values), m, s, mse))
-        print(f"  {label:14s}  n={len(values):4d}  midpoint={m:6.2f}  slope={s:5.3f}  mse/pt={mse:.1f}")
+        print(
+            f"  {label:14s}  n={len(values):4d}  midpoint={m:6.2f}  slope={s:5.3f}  mse/pt={mse:.1f}"
+        )
 
     if not fits:
         print("No sources loaded; aborting.")
@@ -190,8 +195,12 @@ def main() -> int:
     weighted_s = sum(n * s for _, n, _, s, _ in fits) / total
 
     print()
-    print(f"  {'Simple mean':14s}                   midpoint={simple_m:6.2f}  slope={simple_s:5.3f}")
-    print(f"  {'n-Weighted':14s}                   midpoint={weighted_m:6.2f}  slope={weighted_s:5.3f}")
+    print(
+        f"  {'Simple mean':14s}                   midpoint={simple_m:6.2f}  slope={simple_s:5.3f}"
+    )
+    print(
+        f"  {'n-Weighted':14s}                   midpoint={weighted_m:6.2f}  slope={weighted_s:5.3f}"
+    )
     print(f"  {'Current (ours)':14s}                   midpoint=45.00          slope=1.100")
 
     print()
@@ -202,8 +211,13 @@ def main() -> int:
     for label, _, m, s, _ in fits:
         row = "".join(f"{int(_hill(r, m, s)):>9}" for r in ranks)
         print(f"  {label[:14]:<14}" + row)
-    print(f"  {'SIMPLE_AVG':<14}" + "".join(f"{int(_hill(r, simple_m, simple_s)):>9}" for r in ranks))
-    print(f"  {'N_WEIGHTED':<14}" + "".join(f"{int(_hill(r, weighted_m, weighted_s)):>9}" for r in ranks))
+    print(
+        f"  {'SIMPLE_AVG':<14}" + "".join(f"{int(_hill(r, simple_m, simple_s)):>9}" for r in ranks)
+    )
+    print(
+        f"  {'N_WEIGHTED':<14}"
+        + "".join(f"{int(_hill(r, weighted_m, weighted_s)):>9}" for r in ranks)
+    )
     print(f"  {'CURRENT':<14}" + "".join(f"{int(_hill(r, 45, 1.1)):>9}" for r in ranks))
     return 0
 

--- a/scripts/fit_hill_curve_percentile.py
+++ b/scripts/fit_hill_curve_percentile.py
@@ -39,6 +39,7 @@ voice, matching the framework's intent.
 Usage:
     python3 scripts/fit_hill_curve_percentile.py
 """
+
 from __future__ import annotations
 
 import argparse
@@ -56,18 +57,18 @@ GLOBAL_SOURCES: dict[str, tuple[str, str]] = {
     "IDPTradeCalc": ("CSVs/site_raw/idpTradeCalc.csv", "value"),
 }
 OFFENSE_SOURCES: dict[str, tuple[str, str]] = {
-    "KTC":          ("CSVs/site_raw/ktc.csv",                    "value"),
-    "DynastyDaddy": ("CSVs/site_raw/dynastyDaddySf.csv",         "value"),
-    "DynastyNerds": ("CSVs/site_raw/dynastyNerdsSfTep.csv",      "Value"),
+    "KTC": ("CSVs/site_raw/ktc.csv", "value"),
+    "DynastyDaddy": ("CSVs/site_raw/dynastyDaddySf.csv", "value"),
+    "DynastyNerds": ("CSVs/site_raw/dynastyNerdsSfTep.csv", "Value"),
     # Added 2026-04-21: three more value-based offense sources that
     # went live in the April source expansion.  Each is SF-TEP-native
     # (Boone pulls 2QB + TE-Prem columns; Fitzmaurice uses SF Value +
     # TEP Value; DraftSharks is league-synced via its WebAssembly
     # scoring worker).  Tops are ~141 (Boone), ~101 (Fitzmaurice),
     # ~100 (DS SF) — all normalize to 9999 at the curve's anchor.
-    "YahooBoone":   ("CSVs/site_raw/yahooBoone.csv",             "boone_value"),
-    "Fitzmaurice":  ("CSVs/site_raw/fantasyProsFitzmaurice.csv", "value"),
-    "DraftSharks":  ("CSVs/site_raw/draftSharksSf.csv",          "3D Value +"),
+    "YahooBoone": ("CSVs/site_raw/yahooBoone.csv", "boone_value"),
+    "Fitzmaurice": ("CSVs/site_raw/fantasyProsFitzmaurice.csv", "value"),
+    "DraftSharks": ("CSVs/site_raw/draftSharksSf.csv", "3D Value +"),
 }
 # IDP value sources that have pre-filtered per-position CSVs.  IDPTC
 # is NOT in this dict because its CSV is all positions mixed —
@@ -82,8 +83,7 @@ IDP_CSV_SOURCES: dict[str, tuple[str, str]] = {
 }
 
 _IDP_POSITIONS: frozenset[str] = frozenset(
-    {"DL", "DE", "DT", "EDGE", "NT", "LB", "ILB", "OLB", "MLB",
-     "DB", "CB", "S", "SS", "FS"}
+    {"DL", "DE", "DT", "EDGE", "NT", "LB", "ILB", "OLB", "MLB", "DB", "CB", "S", "SS", "FS"}
 )
 
 
@@ -218,7 +218,7 @@ def _fit(pairs: list[tuple[float, float]]) -> tuple[float, float, float]:
     """Grid-search + refine (c, s) against the pairs."""
     best: tuple[float, float, float] | None = None
     c_grid = [0.005 + 0.005 * i for i in range(100)]  # 0.005..0.5
-    s_grid = [0.4 + 0.02 * i for i in range(106)]     # 0.4..2.5
+    s_grid = [0.4 + 0.02 * i for i in range(106)]  # 0.4..2.5
     for c in c_grid:
         for s in s_grid:
             err = sum((v - _hill(p, c, s)) ** 2 for p, v in pairs)
@@ -250,11 +250,7 @@ def _trimmed_mean_median(values: list[float]) -> float:
         t = vs[1:-1]
         t_mean = sum(t) / len(t)
         m = len(t)
-        t_median = (
-            float(t[m // 2])
-            if m % 2 == 1
-            else (t[m // 2 - 1] + t[m // 2]) / 2.0
-        )
+        t_median = float(t[m // 2]) if m % 2 == 1 else (t[m // 2 - 1] + t[m // 2]) / 2.0
         return (t_mean + t_median) / 2.0
     if n == 2:
         return (vs[0] + vs[1]) / 2.0
@@ -295,7 +291,7 @@ def _fit_scope_master(
     for i in range(1, 50):
         grid.append(i / 2000.0)  # fine top-of-curve sampling
     for i in range(1, 200):
-        grid.append(i / 200.0)   # linear mid-to-tail sampling
+        grid.append(i / 200.0)  # linear mid-to-tail sampling
     grid = sorted(set(round(p, 6) for p in grid))
 
     master_pairs: list[tuple[float, float]] = []
@@ -365,10 +361,7 @@ def main() -> int:
             f"c={c:.4f}  s={s:.3f}  rmse={mse ** 0.5:.1f}"
         )
     else:
-        print(
-            f"  DraftSharks-Combined  (only {len(ds_combined)} total "
-            f"values; skipping)"
-        )
+        print(f"  DraftSharks-Combined  (only {len(ds_combined)} total " f"values; skipping)")
 
     print("\nIDP scope (IDP value sources):")
     idp_values = _load_idptc_idp_values()
@@ -392,30 +385,25 @@ def main() -> int:
     print("\nROOKIE scope (rookie slices of value-based sources):")
     rookie_fits: list[tuple[str, float, float]] = []
     for label, src_key in (
-        ("KTC-Rookie",          "ktc"),
-        ("IDPTC-Rookie",        "idpTradeCalc"),
+        ("KTC-Rookie", "ktc"),
+        ("IDPTC-Rookie", "idpTradeCalc"),
         # Added 2026-04-21: rookie slices from the newly-wired
         # value sources.  Each rookie slice is normalized so the
         # slice's top contributes 9999, same as KTC / IDPTC.
         # Small rookie classes with <10 rookies in a snapshot are
         # auto-skipped so a sparse source doesn't wreck the master.
-        ("Boone-Rookie",        "yahooBoone"),
-        ("Fitzmaurice-Rookie",  "fantasyProsFitzmaurice"),
-        ("DraftSharks-Rookie",  "draftSharks"),
+        ("Boone-Rookie", "yahooBoone"),
+        ("Fitzmaurice-Rookie", "fantasyProsFitzmaurice"),
+        ("DraftSharks-Rookie", "draftSharks"),
     ):
         rv = _load_rookie_values(src_key)
         if len(rv) < 10:
-            print(
-                f"  {label:22s}  (only {len(rv)} rookies with values; skipping)"
-            )
+            print(f"  {label:22s}  (only {len(rv)} rookies with values; skipping)")
             continue
         pairs = _percentile_pairs(rv)
         c, s, mse = _fit(pairs)
         rookie_fits.append((label, c, s))
-        print(
-            f"  {label:22s}  n={len(pairs):4d}  c={c:.4f}  "
-            f"s={s:.3f}  rmse={mse ** 0.5:.1f}"
-        )
+        print(f"  {label:22s}  n={len(pairs):4d}  c={c:.4f}  " f"s={s:.3f}  rmse={mse ** 0.5:.1f}")
 
     print("\nScope-level master curves (trimmed mean-median across per-source fits):")
     for scope_label, fits in (
@@ -429,10 +417,7 @@ def main() -> int:
             print(f"  {scope_label:8s}  (no per-source fits)")
             continue
         c, s, mse = result
-        print(
-            f"  {scope_label:8s}  c*={c:.4f}  s*={s:.3f}  "
-            f"master-fit rmse={mse ** 0.5:.1f}"
-        )
+        print(f"  {scope_label:8s}  c*={c:.4f}  s*={s:.3f}  " f"master-fit rmse={mse ** 0.5:.1f}")
 
     print()
     print("Value at key percentiles for each scope master:")
@@ -479,6 +464,7 @@ def main() -> int:
 
     if args.json_out is not None:
         import json as _json
+
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(_json.dumps(out_constants, indent=2))
     return 0

--- a/scripts/generate_test_seeds.py
+++ b/scripts/generate_test_seeds.py
@@ -10,6 +10,7 @@ being confused with real production data.
 Usage:
     python scripts/generate_test_seeds.py
 """
+
 from __future__ import annotations
 
 import csv
@@ -39,7 +40,10 @@ def load_ktc_players(repo: Path) -> list[tuple[str, int]]:
             if not name or not val:
                 continue
             # Skip picks
-            if any(x in name for x in ["Pick", "Early", "Mid", "Late", "1st", "2nd", "3rd", "4th", "5th", "6th"]):
+            if any(
+                x in name
+                for x in ["Pick", "Early", "Mid", "Late", "1st", "2nd", "3rd", "4th", "5th", "6th"]
+            ):
                 continue
             try:
                 players.append((name, int(val)))

--- a/scripts/generate_weekly_narratives.py
+++ b/scripts/generate_weekly_narratives.py
@@ -38,6 +38,7 @@ Exit codes
 * 1 — at least one generation failed; check stderr for the failure.
 * 2 — bad invocation (no league configured, unknown mode, etc.).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -144,13 +145,13 @@ async def _generate_one(
         mode=mode,
     )
     if brief is None:
-        raise RuntimeError(
-            f"could not build brief for {season} W{week} matchup {matchup_id}"
-        )
+        raise RuntimeError(f"could not build brief for {season} W{week} matchup {matchup_id}")
 
     prior = matchup_narrative.collect_prior_articles(season, n=6)
     article = await matchup_narrative.generate_article(
-        client=client, brief=brief, prior_articles=prior,
+        client=client,
+        brief=brief,
+        prior_articles=prior,
     )
     matchup_narrative.save_article(article)
     return article

--- a/scripts/identity_resolve.py
+++ b/scripts/identity_resolve.py
@@ -74,14 +74,19 @@ def main() -> int:
                 )
             )
 
-    identity = build_identity_resolution(all_records, quarantine_threshold=args.quarantine_threshold)
+    identity = build_identity_resolution(
+        all_records, quarantine_threshold=args.quarantine_threshold
+    )
     identity["input_snapshot"] = raw_file.name
     identity["run_id"] = str(raw_payload.get("run_id", ""))
     identity["generated_at"] = datetime.now(timezone.utc).isoformat()
 
     out_dir = repo / "data" / "identity"
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_file = out_dir / f"identity_resolution_{identity.get('run_id') or datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    out_file = (
+        out_dir
+        / f"identity_resolution_{identity.get('run_id') or datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
     save_json(out_file, identity)
 
     print(
@@ -97,4 +102,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/inspect_anomalies.py
+++ b/scripts/inspect_anomalies.py
@@ -12,6 +12,7 @@ Output:
     2. Confidence bucket distribution
     3. Top flagged players with their anomaly details
 """
+
 from __future__ import annotations
 
 import argparse
@@ -102,10 +103,7 @@ def main() -> None:
 
     # ── Top Flagged Players ──
     _print_section("FLAGGED PLAYERS (up to 50)")
-    flagged = [
-        p for p in players
-        if p.get("anomalyFlags")
-    ]
+    flagged = [p for p in players if p.get("anomalyFlags")]
     flagged.sort(key=lambda p: p.get("canonicalConsensusRank") or 9999)
 
     if not flagged:
@@ -121,10 +119,7 @@ def main() -> None:
 
     # ── Source Disagreement Players ──
     _print_section("SOURCE DISAGREEMENT (top 20 by spread)")
-    disagreed = [
-        p for p in players
-        if p.get("hasSourceDisagreement")
-    ]
+    disagreed = [p for p in players if p.get("hasSourceDisagreement")]
     disagreed.sort(key=lambda p: p.get("sourceRankSpread") or 0, reverse=True)
 
     if not disagreed:

--- a/scripts/parse_footballguys_pdf.py
+++ b/scripts/parse_footballguys_pdf.py
@@ -31,6 +31,7 @@ Usage::
         --out-sf CSVs/site_raw/footballGuysSf.csv \\
         --out-idp CSVs/site_raw/footballGuysIdp.csv
 """
+
 from __future__ import annotations
 
 import argparse
@@ -47,13 +48,43 @@ IDP_POSITIONS = {"DE", "DT", "LB", "CB", "S"}
 # NFL team codes (+ FA) — used to reject false matches where a name
 # suffix like "II" or "IV" (Patrick Mahomes II, Ernest Jones IV) would
 # otherwise be captured as the team.
-NFL_TEAM_CODES = frozenset({
-    "ARI", "ATL", "BAL", "BUF", "CAR", "CHI", "CIN", "CLE",
-    "DAL", "DEN", "DET", "GB", "HOU", "IND", "JAX", "KC",
-    "LV", "LAC", "LAR", "MIA", "MIN", "NE", "NO", "NYG",
-    "NYJ", "PHI", "PIT", "SF", "SEA", "TB", "TEN", "WAS",
-    "FA",
-})
+NFL_TEAM_CODES = frozenset(
+    {
+        "ARI",
+        "ATL",
+        "BAL",
+        "BUF",
+        "CAR",
+        "CHI",
+        "CIN",
+        "CLE",
+        "DAL",
+        "DEN",
+        "DET",
+        "GB",
+        "HOU",
+        "IND",
+        "JAX",
+        "KC",
+        "LV",
+        "LAC",
+        "LAR",
+        "MIA",
+        "MIN",
+        "NE",
+        "NO",
+        "NYG",
+        "NYJ",
+        "PHI",
+        "PIT",
+        "SF",
+        "SEA",
+        "TB",
+        "TEN",
+        "WAS",
+        "FA",
+    }
+)
 
 # Position-with-rank token, e.g. "QB1", "WR184", "DE10", "S5".
 _POSITION_RE = re.compile(r"^(QB|RB|WR|TE|DE|DT|LB|CB|S)(\d+)$")
@@ -210,7 +241,7 @@ def parse_players(lines: list[str]) -> list[Player]:
             # remainder.  Simpler to just search the raw line for a
             # team code AFTER the captured "team".
             suffix = team
-            remainder = line[m.end("team"):]
+            remainder = line[m.end("team") :]
             team_m = re.search(r"\b([A-Z]{2,3})\b", remainder)
             if not team_m or team_m.group(1) not in NFL_TEAM_CODES:
                 continue
@@ -240,12 +271,8 @@ def split_and_rank(players: list[Player]) -> tuple[list[Player], list[Player]]:
     universe).  The caller can emit these positions as 1..N dense ranks
     when writing the CSV.
     """
-    offense = sorted(
-        (p for p in players if p.is_offense), key=lambda p: p.overall_rank
-    )
-    idp = sorted(
-        (p for p in players if p.is_idp), key=lambda p: p.overall_rank
-    )
+    offense = sorted((p for p in players if p.is_offense), key=lambda p: p.overall_rank)
+    idp = sorted((p for p in players if p.is_idp), key=lambda p: p.overall_rank)
     return offense, idp
 
 
@@ -262,14 +289,16 @@ def write_csv(players: list[Player], out_path: Path) -> None:
         w = csv.writer(f)
         w.writerow(["name", "rank", "position", "team", "age", "years_exp"])
         for dense_rank, p in enumerate(players, start=1):
-            w.writerow([
-                p.name,
-                dense_rank,
-                f"{p.position}{p.pos_rank}",
-                p.team,
-                p.age if p.age is not None else "",
-                p.years_exp,
-            ])
+            w.writerow(
+                [
+                    p.name,
+                    dense_rank,
+                    f"{p.position}{p.pos_rank}",
+                    p.team,
+                    p.age if p.age is not None else "",
+                    p.years_exp,
+                ]
+            )
 
 
 def main() -> int:
@@ -282,7 +311,8 @@ def main() -> int:
     ap.add_argument("--out-sf", default=str(repo / "CSVs" / "site_raw" / "footballGuysSf.csv"))
     ap.add_argument("--out-idp", default=str(repo / "CSVs" / "site_raw" / "footballGuysIdp.csv"))
     ap.add_argument(
-        "--verbose", action="store_true",
+        "--verbose",
+        action="store_true",
         help="Print parsing stats + a sample of the first parsed players.",
     )
     args = ap.parse_args()
@@ -309,10 +339,14 @@ def main() -> int:
     if args.verbose:
         print("\nFirst 10 offense:")
         for p in offense[:10]:
-            print(f"  {p.overall_rank:4d}  {p.name:<30}  {p.team:<4}  {p.position}{p.pos_rank}  age={p.age} yrs={p.years_exp}")
+            print(
+                f"  {p.overall_rank:4d}  {p.name:<30}  {p.team:<4}  {p.position}{p.pos_rank}  age={p.age} yrs={p.years_exp}"
+            )
         print("\nFirst 10 IDP:")
         for p in idp[:10]:
-            print(f"  {p.overall_rank:4d}  {p.name:<30}  {p.team:<4}  {p.position}{p.pos_rank}  age={p.age} yrs={p.years_exp}")
+            print(
+                f"  {p.overall_rank:4d}  {p.name:<30}  {p.team:<4}  {p.position}{p.pos_rank}  age={p.age} yrs={p.years_exp}"
+            )
 
     return 0
 

--- a/scripts/refit_source_weights.py
+++ b/scripts/refit_source_weights.py
@@ -35,6 +35,7 @@ Exit codes
     1  pending approval (no write), caller should open a PR
     2  fatal error (bad inputs, etc.)
 """
+
 from __future__ import annotations
 
 import argparse
@@ -119,15 +120,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--alpha", type=float, default=0.25)
     parser.add_argument("--tolerance", type=float, default=0.15)
     parser.add_argument(
-        "--source-ranks-path", type=Path,
+        "--source-ranks-path",
+        type=Path,
         default=Path("data/source_rank_history.jsonl"),
     )
     parser.add_argument(
-        "--realized-path", type=Path,
+        "--realized-path",
+        type=Path,
         default=Path("data/realized_points_history.jsonl"),
     )
     parser.add_argument(
-        "--weights-out", type=Path,
+        "--weights-out",
+        type=Path,
         default=Path("config/weights/dynamic_source_weights.json"),
     )
     args = parser.parse_args(argv)
@@ -138,7 +142,8 @@ def main(argv: list[str] | None = None) -> int:
     if not source_ranks or not realized:
         _LOGGER.error(
             "refit inputs missing: source_ranks=%d, realized=%d",
-            len(source_ranks), len(realized),
+            len(source_ranks),
+            len(realized),
         )
         return 2
 
@@ -147,15 +152,22 @@ def main(argv: list[str] | None = None) -> int:
     for a in accuracies:
         _LOGGER.info(
             "  %s: rho=%.3f n=%d top50_hit=%.3f",
-            a.source, a.spearman_rho, a.n_players, a.top_50_hit_rate,
+            a.source,
+            a.spearman_rho,
+            a.n_players,
+            a.top_50_hit_rate,
         )
 
     prior = load_prior_weights(args.weights_out)
     proposal = propose_weights(
-        accuracies, prior, alpha=args.alpha, tolerance_pct=args.tolerance,
+        accuracies,
+        prior,
+        alpha=args.alpha,
+        tolerance_pct=args.tolerance,
     )
-    _LOGGER.info("proposal status=%s max_drift=%.2f%%",
-                 proposal.status, proposal.max_drift_pct * 100)
+    _LOGGER.info(
+        "proposal status=%s max_drift=%.2f%%", proposal.status, proposal.max_drift_pct * 100
+    )
     for src, w in sorted(proposal.weights.items()):
         _LOGGER.info("  %s: %.4f", src, w)
 

--- a/scripts/refit_tier_thresholds.py
+++ b/scripts/refit_tier_thresholds.py
@@ -24,6 +24,7 @@ Exit codes
     1  drift exceeds tolerance — caller opens a PR
     2  fatal (no contract available)
 """
+
 from __future__ import annotations
 
 import argparse
@@ -62,7 +63,8 @@ def _load_contract_players(path: Path) -> list[dict[str, Any]]:
                 "pos": str(p.get("position") or ""),
                 "rankDerivedValue": p.get("rankDerivedValue"),
             }
-            for p in arr if isinstance(p, dict)
+            for p in arr
+            if isinstance(p, dict)
         ]
     # Legacy dict shape — derive pos from asset stamps.
     players = data.get("players") or {}
@@ -70,11 +72,13 @@ def _load_contract_players(path: Path) -> list[dict[str, Any]]:
     for name, row in players.items():
         if not isinstance(row, dict):
             continue
-        out.append({
-            "name": name,
-            "pos": str(row.get("position") or ""),
-            "rankDerivedValue": row.get("rankDerivedValue"),
-        })
+        out.append(
+            {
+                "name": name,
+                "pos": str(row.get("position") or ""),
+                "rankDerivedValue": row.get("rankDerivedValue"),
+            }
+        )
     return out
 
 
@@ -83,11 +87,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--tolerance", type=float, default=0.15)
     parser.add_argument(
-        "--contract-path", type=Path,
+        "--contract-path",
+        type=Path,
         default=Path("data/latest_contract.json"),
     )
     parser.add_argument(
-        "--thresholds-out", type=Path,
+        "--thresholds-out",
+        type=Path,
         default=Path("config/tiers/thresholds.json"),
     )
     args = parser.parse_args(argv)
@@ -103,11 +109,15 @@ def main(argv: list[str] | None = None) -> int:
     new_thresholds = fit_thresholds_grid_search(rows)
     old_thresholds = load_thresholds(args.thresholds_out)
     drift = detect_threshold_drift(
-        old_thresholds, new_thresholds, tolerance_pct=args.tolerance,
+        old_thresholds,
+        new_thresholds,
+        tolerance_pct=args.tolerance,
     )
     _LOGGER.info(
         "fit complete: %d positions, max_drift=%.2f%%, hasDrift=%s",
-        len(new_thresholds), drift["maxDriftPct"] * 100, drift["hasDrift"],
+        len(new_thresholds),
+        drift["maxDriftPct"] * 100,
+        drift["hasDrift"],
     )
     for pos, new_t in sorted(new_thresholds.items()):
         old_t = old_thresholds.get(pos, 0.0)

--- a/scripts/refresh_depth_charts.py
+++ b/scripts/refresh_depth_charts.py
@@ -21,6 +21,7 @@ Exit codes
     0  all 32 teams fetched (or flag off → no-op)
     1  partial failure (some teams failed; see logs)
 """
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/validate_api_contract.py
+++ b/scripts/validate_api_contract.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 
 def _repo_root_from_args() -> Path:
-    parser = argparse.ArgumentParser(description="Validate /api/data contract against latest payload.")
+    parser = argparse.ArgumentParser(
+        description="Validate /api/data contract against latest payload."
+    )
     parser.add_argument("--repo", default=".", help="Repository root (default: current directory)")
     args = parser.parse_args()
     return Path(args.repo).resolve()
@@ -21,7 +23,9 @@ def _load_latest_payload(repo_root: Path) -> tuple[dict, Path]:
             continue
         candidates.extend(sorted(folder.glob("dynasty_data_*.json")))
     if not candidates:
-        raise FileNotFoundError("No dynasty_data_YYYY-MM-DD.json files found in repo/data or repo root.")
+        raise FileNotFoundError(
+            "No dynasty_data_YYYY-MM-DD.json files found in repo/data or repo root."
+        )
     latest = sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True)[0]
     with latest.open("r", encoding="utf-8") as f:
         payload = json.load(f)
@@ -86,4 +90,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/validate_ingest.py
+++ b/scripts/validate_ingest.py
@@ -131,7 +131,10 @@ def main() -> int:
                     )
 
             ext_id = str(rec.get("external_asset_id", "")).strip()
-            key_asset = str(rec.get("asset_key", "")).strip() or str(rec.get("name_normalized_guess", "")).strip()
+            key_asset = (
+                str(rec.get("asset_key", "")).strip()
+                or str(rec.get("name_normalized_guess", "")).strip()
+            )
             if key_asset:
                 current_metrics[(source, key_asset)] = {
                     "rank_raw": rec.get("rank_raw"),
@@ -183,7 +186,10 @@ def main() -> int:
         for snap in prev_payload.get("snapshots", []):
             psource = str(snap.get("source", ""))
             for rec in snap.get("records", []):
-                pkey = str(rec.get("asset_key", "")).strip() or str(rec.get("name_normalized_guess", "")).strip()
+                pkey = (
+                    str(rec.get("asset_key", "")).strip()
+                    or str(rec.get("name_normalized_guess", "")).strip()
+                )
                 if not pkey:
                     continue
                 prev_metrics[(psource, pkey)] = {
@@ -206,7 +212,9 @@ def main() -> int:
             if isinstance(cur_val, (int, float)) and isinstance(prev_val, (int, float)):
                 value_jump = float(cur_val) - float(prev_val)
 
-            if (rank_jump is not None and abs(rank_jump) >= 100) or (value_jump is not None and abs(value_jump) >= 1500):
+            if (rank_jump is not None and abs(rank_jump) >= 100) or (
+                value_jump is not None and abs(value_jump) >= 1500
+            ):
                 suspicious_rank_value_jumps.append(
                     {
                         "source": k[0],

--- a/scripts/validate_scoring_fit.py
+++ b/scripts/validate_scoring_fit.py
@@ -35,7 +35,9 @@ def load_csv_rows(path: Path) -> list[dict]:
         return list(csv.DictReader(f))
 
 
-def summarize(scoring_rows: list[dict], conf_rows: list[dict], arch_rows: list[dict], top_n: int = 25) -> str:
+def summarize(
+    scoring_rows: list[dict], conf_rows: list[dict], arch_rows: list[dict], top_n: int = 25
+) -> str:
     conf_map = {str(r.get("player_name", "")).strip(): r for r in conf_rows}
     arch_map = {str(r.get("player_name", "")).strip(): r for r in arch_rows}
 
@@ -108,11 +110,11 @@ def summarize(scoring_rows: list[dict], conf_rows: list[dict], arch_rows: list[d
     lines.append("")
 
     weak_sample_over_adjust = [
-        r for r in enriched
-        if r["confidence"] < 0.45 and abs(r["fit_ratio"] - 1.0) > 0.08
+        r for r in enriched if r["confidence"] < 0.45 and abs(r["fit_ratio"] - 1.0) > 0.08
     ]
     td_volatile_outliers = [
-        r for r in enriched
+        r
+        for r in enriched
         if r["volatility"] and r["td_dep"] >= 0.70 and abs(r["fit_ratio"] - 1.0) > 0.08
     ]
 

--- a/scripts/validate_scrape_sanity.py
+++ b/scripts/validate_scrape_sanity.py
@@ -21,6 +21,7 @@ Conservative by design: the 50% / all-zero error bar plus the
 ``COLLAPSE_EXEMPT`` allowlist keep legitimate refreshes (rank jitter,
 seasonal ROS emptiness) from blocking the pipeline.
 """
+
 from __future__ import annotations
 
 import glob
@@ -49,8 +50,8 @@ COLLAPSE_EXEMPT = {
     "draftSharksRosIdp",
 }
 
-COLLAPSE_ERROR_RATIO = 0.50   # > 50% fewer rows than prior == error
-COLLAPSE_WARN_RATIO = 0.70    # 30-50% fewer rows == warning
+COLLAPSE_ERROR_RATIO = 0.50  # > 50% fewer rows than prior == error
+COLLAPSE_WARN_RATIO = 0.70  # 30-50% fewer rows == warning
 
 
 def _source_key(path: str) -> str:
@@ -130,7 +131,9 @@ def _git_show(path: str) -> str | None:
     try:
         out = subprocess.run(
             ["git", "show", f"HEAD:{path}"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         return out.stdout
     except subprocess.CalledProcessError:
@@ -164,8 +167,7 @@ def main() -> int:
         else:
             print(msg)
 
-    print(f"\nScrape sanity: {len(csvs)} sources, {errors} error(s), "
-          f"{warnings} warning(s)")
+    print(f"\nScrape sanity: {len(csvs)} sources, {errors} error(s), " f"{warnings} warning(s)")
     return 1 if errors else 0
 
 

--- a/scripts/validate_va_v2.py
+++ b/scripts/validate_va_v2.py
@@ -29,6 +29,7 @@ for catching anything where V2 produces structurally weird output.
 
 Run: ``python3 scripts/validate_va_v2.py``
 """
+
 from __future__ import annotations
 
 import json
@@ -68,8 +69,8 @@ def compute_va_v1(small: list[float], large: list[float]) -> float:
     if scarcity == 0:
         return 0.0
     total = 0.0
-    for i, extra in enumerate(large[len(small):]):
-        total += extra * scarcity * (V1_DECAY ** i)
+    for i, extra in enumerate(large[len(small) :]):
+        total += extra * scarcity * (V1_DECAY**i)
     return total
 
 
@@ -88,11 +89,11 @@ def compute_va_v2(small: list[float], large: list[float]) -> float:
     raw = V2_SLOPE * top_gap - V2_INTERCEPT
     top_scarcity = max(0.0, min(V2_CAP, raw))
     total = 0.0
-    for i, extra in enumerate(large[len(small):]):
+    for i, extra in enumerate(large[len(small) :]):
         extra_gap = max(0.0, (top_small - extra) / top_small)
         boost = V2_BOOST * max(0.0, extra_gap - top_gap)
         effective = max(0.0, min(V2_EFFECTIVE_CAP, top_scarcity + boost))
-        total += extra * effective * (V2_DECAY ** i)
+        total += extra * effective * (V2_DECAY**i)
     return total
 
 
@@ -126,9 +127,9 @@ def build_resolvers() -> tuple[dict[str, float], dict[str, float]]:
     return player_by_name, pick_by_label
 
 
-def resolve_asset(asset: dict[str, Any],
-                  players: dict[str, float],
-                  picks: dict[str, float]) -> tuple[float, bool]:
+def resolve_asset(
+    asset: dict[str, Any], players: dict[str, float], picks: dict[str, float]
+) -> tuple[float, bool]:
     """Return (value, resolved).  ``resolved`` is False when we can't
     find a value for the asset (retired/dropped player, missing pick).
     We skip unresolved assets from VA math but still count them for
@@ -181,9 +182,9 @@ def iter_trades():
         yield trade
 
 
-def analyze_trade(trade: dict[str, Any],
-                  players: dict[str, float],
-                  picks: dict[str, float]) -> dict[str, Any]:
+def analyze_trade(
+    trade: dict[str, Any], players: dict[str, float], picks: dict[str, float]
+) -> dict[str, Any]:
     sides = trade.get("sides") or []
     if len(sides) != 2:
         return {"skipped": "multi_side"}
@@ -288,9 +289,15 @@ def main() -> None:
     deltas = [r["delta"] for r in uneven]
 
     print("\n=== V1 vs V2 VA summary ===")
-    print(f"  V1 mean: {sum(v1_vas)/len(v1_vas):7.1f}   min: {min(v1_vas):6.1f}   max: {max(v1_vas):6.1f}")
-    print(f"  V2 mean: {sum(v2_vas)/len(v2_vas):7.1f}   min: {min(v2_vas):6.1f}   max: {max(v2_vas):6.1f}")
-    print(f"  Δ mean:  {sum(deltas)/len(deltas):7.1f}   min: {min(deltas):6.1f}   max: {max(deltas):6.1f}")
+    print(
+        f"  V1 mean: {sum(v1_vas)/len(v1_vas):7.1f}   min: {min(v1_vas):6.1f}   max: {max(v1_vas):6.1f}"
+    )
+    print(
+        f"  V2 mean: {sum(v2_vas)/len(v2_vas):7.1f}   min: {min(v2_vas):6.1f}   max: {max(v2_vas):6.1f}"
+    )
+    print(
+        f"  Δ mean:  {sum(deltas)/len(deltas):7.1f}   min: {min(deltas):6.1f}   max: {max(deltas):6.1f}"
+    )
 
     print("\n=== Δ distribution (V2 − V1) ===")
     for lo, hi, cnt in _hist(deltas, bins=10):
@@ -339,9 +346,11 @@ def main() -> None:
     both_nonzero = [r for r in uneven if r["va_v1"] > 100 and r["va_v2"] > 100]
     if both_nonzero:
         ratios = [r["va_v2"] / r["va_v1"] for r in both_nonzero]
-        print(f"  V2/V1 ratio (both >100): mean {sum(ratios)/len(ratios):.2f}x  "
-              f"median {sorted(ratios)[len(ratios)//2]:.2f}x  "
-              f"min {min(ratios):.2f}x  max {max(ratios):.2f}x")
+        print(
+            f"  V2/V1 ratio (both >100): mean {sum(ratios)/len(ratios):.2f}x  "
+            f"median {sorted(ratios)[len(ratios)//2]:.2f}x  "
+            f"min {min(ratios):.2f}x  max {max(ratios):.2f}x"
+        )
 
     print("\nDone.")
 

--- a/scripts/verify_live_source_coverage.py
+++ b/scripts/verify_live_source_coverage.py
@@ -35,6 +35,7 @@ Exit codes:
   1 — a fresh source is absent (degraded board), or /api/status was
       unreachable / unparseable after retries
 """
+
 from __future__ import annotations
 
 import json
@@ -63,9 +64,7 @@ def _fetch_status(base_url: str) -> dict | None:
     url = base_url.rstrip("/") + "/api/status"
     for attempt in range(1, _ATTEMPTS + 1):
         try:
-            req = urllib.request.Request(
-                url, headers={"User-Agent": "verify-live-source-coverage"}
-            )
+            req = urllib.request.Request(url, headers={"User-Agent": "verify-live-source-coverage"})
             with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
                 if resp.status == 200:
                     return json.loads(resp.read().decode("utf-8"))
@@ -87,9 +86,7 @@ def _fetch_status(base_url: str) -> dict | None:
 
 def main() -> int:
     base_url = (
-        sys.argv[1]
-        if len(sys.argv) > 1
-        else os.environ.get("DEPLOY_VERIFY_BASE_URL", "")
+        sys.argv[1] if len(sys.argv) > 1 else os.environ.get("DEPLOY_VERIFY_BASE_URL", "")
     ).strip()
     if not base_url:
         print(
@@ -118,9 +115,7 @@ def main() -> int:
     cov_int = {str(k): int(v) for k, v in cov.items()}
     freshness = _read_freshness()
     thresholds = load_thresholds()
-    violations, ok, skipped = evaluate_coverage_map(
-        cov_int, freshness, thresholds
-    )
+    violations, ok, skipped = evaluate_coverage_map(cov_int, freshness, thresholds)
 
     if not violations:
         print(

--- a/scripts/watchdog_contract_coverage.py
+++ b/scripts/watchdog_contract_coverage.py
@@ -45,6 +45,7 @@ Exit codes:
 Output: human-readable stdout, GitHub Actions ``::error::``
 annotations per offending source, and a step-summary table.
 """
+
 from __future__ import annotations
 
 import json
@@ -127,7 +128,7 @@ def _source_coverage(contract: dict) -> dict[str, int]:
     """
     cov: dict[str, int] = {}
     for row in contract.get("playersArray") or []:
-        for key in (row.get("sourceRankMeta") or {}):
+        for key in row.get("sourceRankMeta") or {}:
             cov[key] = cov.get(key, 0) + 1
     return cov
 
@@ -167,9 +168,7 @@ def evaluate_coverage(
       * skipped    — source keys not evaluated because they are stale
         (owned by the freshness watchdog) or have an empty/missing CSV.
     """
-    return evaluate_coverage_map(
-        _source_coverage(contract), freshness, thresholds
-    )
+    return evaluate_coverage_map(_source_coverage(contract), freshness, thresholds)
 
 
 def evaluate_coverage_map(
@@ -194,10 +193,7 @@ def evaluate_coverage_map(
     for key in sorted(k for k in registered if k):
         info = freshness.get(key)
         threshold = resolve_threshold(key, thresholds)
-        is_fresh = (
-            info is not None
-            and float(info.get("ageHours", 0.0)) <= threshold
-        )
+        is_fresh = info is not None and float(info.get("ageHours", 0.0)) <= threshold
         if not is_fresh or not _csv_nonempty(key):
             # Stale → freshness watchdog already owns it.
             # Empty/missing CSV → nothing to land; not a coverage bug.
@@ -227,9 +223,7 @@ def _write_summary(
             "| source | players covered | floor |",
             "|---|---|---|",
         ]
-        lines += [
-            f"| `{k}` | {c} | {_MIN_COVERAGE} |" for k, c in violations
-        ]
+        lines += [f"| `{k}` | {c} | {_MIN_COVERAGE} |" for k, c in violations]
         lines.append("")
     lines += [
         "### Healthy sources",
@@ -271,9 +265,7 @@ def main() -> int:
 
     freshness = _read_freshness()
     thresholds = load_thresholds()
-    violations, ok, skipped = evaluate_coverage(
-        contract, freshness, thresholds
-    )
+    violations, ok, skipped = evaluate_coverage(contract, freshness, thresholds)
 
     _write_summary(violations, ok, skipped)
 

--- a/scripts/watchdog_freshness.py
+++ b/scripts/watchdog_freshness.py
@@ -22,6 +22,7 @@ Output:
   GitHub Actions error annotations (``::error::``) per stale source
   so the run page surfaces them in the UI
 """
+
 from __future__ import annotations
 
 import os
@@ -130,13 +131,13 @@ def main() -> int:
     if not freshness:
         # No sources registered at all = catastrophic regression in the
         # ranking registry.  Fail loud.
-        print("::error title=Source registry empty::No sources could be read from "
-              "_SOURCE_CSV_PATHS.  The data contract registry is broken.")
+        print(
+            "::error title=Source registry empty::No sources could be read from "
+            "_SOURCE_CSV_PATHS.  The data contract registry is broken."
+        )
         return 1
 
-    hard_stale, soft_stale, fresh = classify_freshness(
-        freshness, thresholds, soft_sources
-    )
+    hard_stale, soft_stale, fresh = classify_freshness(freshness, thresholds, soft_sources)
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     summary_lines: list[str] = ["## Source freshness watchdog", ""]
@@ -187,9 +188,7 @@ def main() -> int:
         )
 
     if not hard_stale:
-        soft_note = (
-            f", {len(soft_stale)} soft-stale (non-fatal)" if soft_stale else ""
-        )
+        soft_note = f", {len(soft_stale)} soft-stale (non-fatal)" if soft_stale else ""
         print(f"ok: {len(fresh)} sources fresh, 0 hard-stale{soft_note}")
         return 0
 

--- a/server.py
+++ b/server.py
@@ -102,6 +102,7 @@ SCRAPE_REAP_ORPHAN_BROWSERS = os.getenv("SCRAPE_REAP_ORPHAN_BROWSERS", "1") != "
 SIMULATE_MC_MAX_SIMS = int(os.getenv("SIMULATE_MC_MAX_SIMS", "50000"))
 SIMULATE_MC_TIMEOUT_SECONDS = int(os.getenv("SIMULATE_MC_TIMEOUT_SECONDS", "10"))
 
+
 # ── EMAIL ALERTS ────────────────────────────────────────────────────────
 # Configure alerts via environment variables (no hardcoded secrets):
 #   ALERT_ENABLED=true|false
@@ -115,6 +116,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
 
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://127.0.0.1:3000").rstrip("/")
 FRONTEND_RUNTIME = "next"
@@ -176,6 +178,8 @@ if not _JASON_LOGIN_PASSWORD_RAW:
 JASON_LOGIN_PASSWORD = _JASON_LOGIN_PASSWORD_RAW
 JASON_AUTH_COOKIE_NAME = "jason_session"
 JASON_AUTH_COOKIE_SECURE = _env_bool("JASON_AUTH_COOKIE_SECURE", True)
+
+
 # Match the SQLite session TTL (SESSION_TTL_DAYS, default 30) so the
 # browser cookie outlives an iOS Safari tab eviction instead of dying
 # as a session cookie the first time the OS reclaims memory.  Parse
@@ -206,6 +210,7 @@ PRIVATE_APP_ALLOWED_USERNAMES = frozenset(
 # Rate limit: max 1 email per hour to avoid spam on repeated failures
 _last_alert_time = 0
 ALERT_COOLDOWN_SEC = 3600
+
 
 def send_alert(subject: str, body: str):
     """Send an email alert. Fails silently if not configured."""
@@ -262,8 +267,10 @@ STATIC_DIR.mkdir(exist_ok=True)
 LOG_FORMAT = os.getenv("LOG_FORMAT", "text").strip().lower()
 
 if LOG_FORMAT == "json":
+
     class _JsonFormatter(logging.Formatter):
         """Minimal JSON log formatter for structured log aggregation."""
+
         def format(self, record):
             entry = {
                 "ts": datetime.now(timezone.utc).isoformat(),
@@ -414,19 +421,19 @@ _metrics: dict = {
 #   error   -> last_error
 scrape_status = {
     "running": False,
-    "is_running": False,      # legacy alias for UI compatibility
+    "is_running": False,  # legacy alias for UI compatibility
     "hung": False,
     "stalled": False,
     "started_at": None,
     "finished_at": None,
     "last_heartbeat": None,
-    "last_scrape": None,      # last successful scrape ISO timestamp
+    "last_scrape": None,  # last successful scrape ISO timestamp
     "last_success_at": None,
     "last_failure_at": None,
     "last_duration_sec": None,
-    "next_scrape": None,      # ISO timestamp
+    "next_scrape": None,  # ISO timestamp
     "error": None,
-    "last_error": None,       # legacy alias for UI compatibility
+    "last_error": None,  # legacy alias for UI compatibility
     "current_step": None,
     "current_source": None,
     "progress_step_index": 0,
@@ -518,10 +525,12 @@ def _get_auth_session(request: Request) -> dict | None:
             auth_sessions.pop(session_id, None)
             try:
                 from src.api import session_store as _ss
+
                 _ss.evict(session_id)
             except Exception as exc:  # noqa: BLE001
                 log.warning(
-                    "session_store evict on expiry failed: %s", exc,
+                    "session_store evict on expiry failed: %s",
+                    exc,
                 )
             return None
     return session
@@ -575,8 +584,10 @@ def _create_auth_session(
     # behavior (the existing behavior — no regression).
     try:
         from src.api import session_store as _ss
+
         _ss.persist(
-            session_id, payload,
+            session_id,
+            payload,
             allowlist=PRIVATE_APP_ALLOWED_USERNAMES,
         )
     except Exception as exc:  # noqa: BLE001
@@ -597,6 +608,7 @@ def _clear_auth_session(request: Request) -> None:
         auth_sessions.pop(session_id, None)
         try:
             from src.api import session_store as _ss
+
             _ss.evict(session_id)
         except Exception as exc:  # noqa: BLE001
             log.warning("session_store evict failed: %s", exc)
@@ -714,7 +726,9 @@ def _start_scrape_run(trigger: str) -> str:
         }
     )
     _sync_scrape_alias_fields()
-    _record_scrape_event("scrape_started", message=f"trigger={trigger}", trigger=trigger, worker_id=run_id)
+    _record_scrape_event(
+        "scrape_started", message=f"trigger={trigger}", trigger=trigger, worker_id=run_id
+    )
     return run_id
 
 
@@ -745,7 +759,9 @@ def _update_scrape_progress(
         _record_scrape_event(event, level=level, message=message or "", **(meta or {}))
 
 
-def _mark_scrape_success(elapsed: float, player_count: int, site_count: int, total_sites: int) -> None:
+def _mark_scrape_success(
+    elapsed: float, player_count: int, site_count: int, total_sites: int
+) -> None:
     now_iso = _utc_now_iso()
     scrape_status.update(
         {
@@ -773,8 +789,13 @@ def _mark_scrape_success(elapsed: float, player_count: int, site_count: int, tot
         duration_sec=round(elapsed, 1),
     )
     # R-4: Record to rolling history
-    _record_scrape_history("success", elapsed, player_count=player_count,
-                           site_count=site_count, total_sites=total_sites)
+    _record_scrape_history(
+        "success",
+        elapsed,
+        player_count=player_count,
+        site_count=site_count,
+        total_sites=total_sites,
+    )
     # R-9: Update metrics counters
     _metrics["scrape_total"] = _metrics.get("scrape_total", 0) + 1
     _metrics["scrape_duration_seconds_last"] = round(elapsed, 1)
@@ -893,7 +914,7 @@ def _collect_descendant_pids(root_pid: int) -> set[int]:
         rparen = data.rfind(")")
         if rparen == -1:
             continue
-        fields = data[rparen + 2:].split()
+        fields = data[rparen + 2 :].split()
         try:
             ppid = int(fields[1])  # fields[0]=state, fields[1]=ppid
         except (IndexError, ValueError):
@@ -1353,25 +1374,20 @@ def _backup_freshness() -> dict:
                     result["newestBackupPath"] = str(f)
                     result["backupDirUsed"] = label
         if newest_epoch is not None:
-            result["newestBackupAgeHours"] = round(
-                max(0.0, (now_epoch - newest_epoch) / 3600.0), 2
-            )
+            result["newestBackupAgeHours"] = round(max(0.0, (now_epoch - newest_epoch) / 3600.0), 2)
             try:
                 newest = Path(result["newestBackupPath"])
                 parts = newest.name.split(".")
                 stamp = parts[1] if len(parts) >= 3 else ""
                 if stamp:
-                    result["dbCount"] = len({
-                        f.name.split(".")[0]
-                        for f in newest.parent.glob(f"*.{stamp}.sqlite.gz")
-                    })
+                    result["dbCount"] = len(
+                        {f.name.split(".")[0] for f in newest.parent.glob(f"*.{stamp}.sqlite.gz")}
+                    )
             except OSError:
                 pass
     except Exception:  # noqa: BLE001 — monitoring helper must never raise
         pass
     return result
-
-
 
 
 # ── SCRAPER INTEGRATION ────────────────────────────────────────────────
@@ -1386,8 +1402,16 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
     only until a real scrape lands.
     """
     global latest_contract_data, latest_data_bytes, latest_data_gzip_bytes, latest_data_etag
-    global latest_runtime_data, latest_runtime_data_bytes, latest_runtime_data_gzip_bytes, latest_runtime_data_etag
-    global latest_startup_data, latest_startup_data_bytes, latest_startup_data_gzip_bytes, latest_startup_data_etag
+    global \
+        latest_runtime_data, \
+        latest_runtime_data_bytes, \
+        latest_runtime_data_gzip_bytes, \
+        latest_runtime_data_etag
+    global \
+        latest_startup_data, \
+        latest_startup_data_bytes, \
+        latest_startup_data_gzip_bytes, \
+        latest_startup_data_etag
     global contract_health
     global served_source_coverage
     served_source_coverage = {}
@@ -1437,7 +1461,8 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
                     _source_history.append_snapshot(contract_payload)
                 except Exception as inner_exc:  # noqa: BLE001
                     log.warning(
-                        "source_history: append failed: %s", inner_exc,
+                        "source_history: append failed: %s",
+                        inner_exc,
                     )
             stamped = _rank_history.stamp_contract_with_history(contract_payload)
             if stamped:
@@ -1503,13 +1528,17 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
                 except Exception as inner:  # noqa: BLE001
                     log.warning(
                         "post-scrape overlay warm failed for %s: %s",
-                        cfg.key, inner,
+                        cfg.key,
+                        inner,
                     )
                     warm_failed.append(cfg.key)
             if warmed or warm_failed:
                 log.info(
                     "post-scrape overlay warm: %d warmed, %d failed (warmed=%s failed=%s)",
-                    len(warmed), len(warm_failed), warmed, warm_failed,
+                    len(warmed),
+                    len(warm_failed),
+                    warmed,
+                    warm_failed,
                 )
         except Exception as exc:  # noqa: BLE001
             log.warning("post-scrape overlay warm pass failed: %s", exc)
@@ -1520,7 +1549,9 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
                 "; ".join((contract_report.get("errors") or [])[:5]),
             )
 
-        raw = json.dumps(contract_payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        raw = json.dumps(contract_payload, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
         latest_data_bytes = raw
         latest_data_gzip_bytes = gzip.compress(raw, compresslevel=5)
         latest_data_etag = hashlib.sha1(raw).hexdigest()
@@ -1530,7 +1561,9 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         runtime_payload = dict(contract_payload)
         runtime_payload.pop("playersArray", None)
         runtime_payload["payloadView"] = "runtime"
-        runtime_raw = json.dumps(runtime_payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        runtime_raw = json.dumps(runtime_payload, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
         latest_runtime_data = runtime_payload
         latest_runtime_data_bytes = runtime_raw
         latest_runtime_data_gzip_bytes = gzip.compress(runtime_raw, compresslevel=5)
@@ -1539,7 +1572,9 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         # Startup payload: same contract shape, but strips heavyweight fields
         # not needed for first screen render so first data-visible is faster.
         startup_payload = build_api_startup_payload(runtime_payload)
-        startup_raw = json.dumps(startup_payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        startup_raw = json.dumps(startup_payload, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
         latest_startup_data = startup_payload
         latest_startup_data_bytes = startup_raw
         latest_startup_data_gzip_bytes = gzip.compress(startup_raw, compresslevel=5)
@@ -1571,8 +1606,10 @@ def load_from_disk() -> dict | None:
             with open(latest_path) as f:
                 data = json.load(f)
             _set_latest_data_source("disk_cache", str(latest_path))
-            log.info(f"Loaded cached data from {latest_path.name} "
-                     f"({len(data.get('players', {}))} players)")
+            log.info(
+                f"Loaded cached data from {latest_path.name} "
+                f"({len(data.get('players', {}))} players)"
+            )
             return data
         except Exception as e:
             log.error(f"Failed to load {json_files[0]}: {e}")
@@ -1680,6 +1717,7 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             # format maintained separately.
             try:
                 import shutil as _sh
+
                 src_raw = DATA_DIR / "exports" / "latest" / "site_raw"
                 dst_raw = BASE_DIR / "CSVs" / "site_raw"
                 if src_raw.exists() and dst_raw.exists():
@@ -1707,6 +1745,7 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             # a transient network error cannot fail the entire scrape.
             try:
                 from scripts import fetch_dynasty_nerds as _dn_fetch
+
                 rc = _dn_fetch.main(["--mirror-data-dir"])
                 if rc == 2:
                     # Schema / row-count regression — surface loudly as
@@ -1742,6 +1781,7 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             # QB/RB/WR/TE consensus ECR ranks and writes a rank-signal CSV.
             try:
                 from scripts import fetch_fantasypros_offense as _fpoff_fetch
+
                 rc = _fpoff_fetch.main(["--mirror-data-dir"])
                 if rc == 2:
                     _record_scrape_event(
@@ -1776,6 +1816,7 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             # and writes a rank-signal CSV.
             try:
                 from scripts import fetch_fantasypros_idp as _fp_fetch
+
                 rc = _fp_fetch.main(["--mirror-data-dir"])
                 if rc == 2:
                     _record_scrape_event(
@@ -1812,6 +1853,7 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             if _idpshow_session.exists():
                 try:
                     from scripts import fetch_idpshow as _idpshow_fetch
+
                     rc = _idpshow_fetch.main([])
                     if rc != 0:
                         _record_scrape_event(
@@ -2003,7 +2045,9 @@ async def uptime_watchdog_loop():
             uptime_status["consecutive_failures"] += 1
             uptime_status["last_error"] = error
             failures = uptime_status["consecutive_failures"]
-            log.warning("Uptime check failed (%s/%s): %s", failures, UPTIME_ALERT_FAIL_THRESHOLD, error)
+            log.warning(
+                "Uptime check failed (%s/%s): %s", failures, UPTIME_ALERT_FAIL_THRESHOLD, error
+            )
             if failures >= UPTIME_ALERT_FAIL_THRESHOLD:
                 send_alert(
                     f"Uptime check failing ({failures} consecutive)",
@@ -2026,6 +2070,7 @@ async def scheduled_scrape():
     await run_scraper(trigger="scheduled")
     # Update next scrape time
     from datetime import timedelta
+
     scrape_status["next_scrape"] = (
         datetime.now(timezone.utc) + timedelta(hours=SCRAPE_INTERVAL_HOURS)
     ).isoformat()
@@ -2034,13 +2079,13 @@ async def scheduled_scrape():
 async def schedule_loop():
     """Simple async loop that runs the scraper on an interval."""
     from datetime import timedelta
+
     while True:
         scrape_status["next_scrape"] = (
             datetime.now(timezone.utc) + timedelta(hours=SCRAPE_INTERVAL_HOURS)
         ).isoformat()
         await asyncio.sleep(SCRAPE_INTERVAL_HOURS * 3600)
         await scheduled_scrape()
-
 
 
 # ── APP LIFECYCLE ───────────────────────────────────────────────────────
@@ -2056,12 +2101,17 @@ async def lifespan(app: FastAPI):
     # results and stores the summary for /api/health.
     try:
         from src.api import startup_validation as _sv
+
         _startup_checks = _sv.run_all()
         _startup_checks_summary = _sv.summary(_startup_checks)
     except Exception as exc:  # noqa: BLE001
         log.error("startup_validation crashed: %s", exc)
         _startup_checks_summary = {
-            "error": str(exc), "total": 0, "ok": 0, "failed": 1, "fatal": 0,
+            "error": str(exc),
+            "total": 0,
+            "ok": 0,
+            "failed": 1,
+            "fatal": 0,
         }
 
     # 1. Load cached data immediately so the dashboard is usable right away
@@ -2078,6 +2128,7 @@ async def lifespan(app: FastAPI):
     # session store can never brick auth entirely.
     try:
         from src.api import session_store as _ss
+
         hydrated = _ss.hydrate(allowlist=PRIVATE_APP_ALLOWED_USERNAMES)
         auth_sessions.update(hydrated)
         log.info("session_store: hydrated %d sessions from disk", len(hydrated))
@@ -2117,8 +2168,9 @@ async def lifespan(app: FastAPI):
             exports = sorted((DATA_DIR).glob("dynasty_data_*.json"))
             if exports:
                 written = _source_history.backfill_from_exports(exports)
-                log.info("source_history: backfilled %d snapshots from %d exports",
-                         written, len(exports))
+                log.info(
+                    "source_history: backfilled %d snapshots from %d exports", written, len(exports)
+                )
     except Exception as exc:  # noqa: BLE001
         log.warning("source_history: startup backfill failed: %s", exc)
 
@@ -2148,11 +2200,13 @@ app.add_middleware(GZipMiddleware, minimum_size=1024)
 # path, method, IP, traceback).  Installed before any other
 # middleware registers so it wraps everything.
 from src.api.error_responses import install_exception_handler as _install_exc_handler  # noqa: E402
+
 _install_exc_handler(app)
 
 # ROS engine router.  Strict isolation: never mutates dynasty contract
 # paths or trade-calculator math; reads/writes only ``data/ros/*``.
 from src.ros.api import router as _ros_router  # noqa: E402
+
 app.include_router(_ros_router)
 
 
@@ -2200,40 +2254,44 @@ async def _limit_request_size(request: Request, call_next):
 # Anything else gets 401'd by ``_private_api_gate`` below.  Closes
 # the scrape risk: without this gate, ``curl /api/data`` from a
 # stranger returns the full private rankings contract.
-_PUBLIC_API_EXACT = frozenset({
-    "/api/health",
-    "/api/status",
-    "/api/uptime",
-    "/api/metrics",
-    "/api/leagues",
-    "/api/rankings/sources",
-    "/api/auth/status",
-    "/api/auth/login",
-    "/api/auth/logout",
-    "/api/scaffold/status",
-    # /league page is a public view — its draft-capital tab reads
-    # this endpoint.  Payload is public Sleeper data (team names,
-    # pick dollar values, owners) already viewable on Sleeper; no
-    # private rankings / user state is leaked here.
-    "/api/draft-capital",
-})
+_PUBLIC_API_EXACT = frozenset(
+    {
+        "/api/health",
+        "/api/status",
+        "/api/uptime",
+        "/api/metrics",
+        "/api/leagues",
+        "/api/rankings/sources",
+        "/api/auth/status",
+        "/api/auth/login",
+        "/api/auth/logout",
+        "/api/scaffold/status",
+        # /league page is a public view — its draft-capital tab reads
+        # this endpoint.  Payload is public Sleeper data (team names,
+        # pick dollar values, owners) already viewable on Sleeper; no
+        # private rankings / user state is leaked here.
+        "/api/draft-capital",
+    }
+)
 # Endpoints that handle their own auth (bearer token, etc.) — the
 # session-cookie middleware must skip them so the endpoint's own
 # check runs.
-_SELF_AUTHED_API_EXACT = frozenset({
-    "/api/signal-alerts/run",
-    # Same bearer-auth pattern as signal-alerts.  Bypass session
-    # cookie gate so the systemd timer's curl call hits the
-    # endpoint's own bearer check.
-    "/api/custom-alerts/run",
-    # E2E test-session bootstrap — handles its own bearer-token auth.
-    # Returns 404 unless E2E_TEST_MODE + matching bearer secret are
-    # both set, so having it bypass the session gate doesn't leak
-    # anything in prod (env vars aren't set there).
-    "/api/test/create-session",
-    # Push public-key endpoint is read-only and stateless — no auth.
-    "/api/push/public-key",
-})
+_SELF_AUTHED_API_EXACT = frozenset(
+    {
+        "/api/signal-alerts/run",
+        # Same bearer-auth pattern as signal-alerts.  Bypass session
+        # cookie gate so the systemd timer's curl call hits the
+        # endpoint's own bearer check.
+        "/api/custom-alerts/run",
+        # E2E test-session bootstrap — handles its own bearer-token auth.
+        # Returns 404 unless E2E_TEST_MODE + matching bearer secret are
+        # both set, so having it bypass the session gate doesn't leak
+        # anything in prod (env vars aren't set there).
+        "/api/test/create-session",
+        # Push public-key endpoint is read-only and stateless — no auth.
+        "/api/push/public-key",
+    }
+)
 _PUBLIC_API_PREFIXES = (
     "/api/public/league",
     # Article reads are public so the league can share /league/articles
@@ -2274,6 +2332,7 @@ async def _private_api_gate(request: Request, call_next):
         client_ip = _client_ip_from_request(request)
         try:
             from src.api import rate_limit as _rl
+
             limited, retry_after = _rl.should_rate_limit(client_ip)
         except Exception:  # noqa: BLE001 — never let rate-limiter break the gate
             limited, retry_after = False, 0
@@ -2314,6 +2373,7 @@ async def _request_context_middleware(request: Request, call_next):
     otherwise mints a fresh token-urlsafe 12-char ID.
     """
     from src.utils import request_context as _rc
+
     incoming = str(request.headers.get("x-request-id") or "").strip()
     rid = incoming if (1 <= len(incoming) <= 64) else _rc.new_request_id()
     token = _rc.set_request_id(rid)
@@ -2339,6 +2399,7 @@ def _client_ip_from_request(request: Request) -> str:
             return first
     client = request.client
     return client.host if client else ""
+
 
 def _proxy_next(path: str) -> tuple[Response | None, str | None]:
     """
@@ -2367,7 +2428,9 @@ def _proxy_next(path: str) -> tuple[Response | None, str | None]:
             cache_control = resp.headers.get("Cache-Control")
             if cache_control:
                 headers["cache-control"] = cache_control
-            return Response(content=body, status_code=getattr(resp, "status", 200), headers=headers), None
+            return Response(
+                content=body, status_code=getattr(resp, "status", 200), headers=headers
+            ), None
     except urllib.error.HTTPError as e:
         try:
             body = e.read()
@@ -2415,8 +2478,7 @@ async def get_data(request: Request):
 
     if latest_contract_data:
         loaded_meta = (
-            latest_contract_data.get("meta") or {}
-            if isinstance(latest_contract_data, dict) else {}
+            latest_contract_data.get("meta") or {} if isinstance(latest_contract_data, dict) else {}
         )
         loaded_league = str(loaded_meta.get("leagueKey") or "")
         loaded_profile = str(loaded_meta.get("scoringProfile") or "")
@@ -2472,8 +2534,10 @@ async def get_data(request: Request):
             # if it READS one of them, which the compact shape test
             # pins against.
             from src.api.compact_view import compact_contract
+
             compact_obj = compact_contract(latest_contract_data)
             import json as _json
+
             payload_bytes = _json.dumps(compact_obj).encode("utf-8")
             payload_gzip_bytes = None  # regenerate-on-demand (no cached gzip)
             payload_etag = None
@@ -2503,7 +2567,8 @@ async def get_data(request: Request):
         # of which league is "loaded."
         loaded_sleeper = (
             (latest_contract_data or {}).get("sleeper") or {}
-            if isinstance(latest_contract_data, dict) else {}
+            if isinstance(latest_contract_data, dict)
+            else {}
         )
         id_to_player = loaded_sleeper.get("idToPlayer") or {}
         try:
@@ -2515,7 +2580,8 @@ async def get_data(request: Request):
         except Exception as exc:  # noqa: BLE001
             log.warning(
                 "sleeper_overlay fetch failed for %s: %s",
-                league_cfg.key, exc,
+                league_cfg.key,
+                exc,
             )
             overlay = None
 
@@ -2555,11 +2621,11 @@ async def get_data(request: Request):
                     "trades": overlay.get("trades") or [],
                     "waivers": overlay.get("waivers") or [],
                     "tradeWindowDays": overlay.get("tradeWindowDays")
-                        or loaded_sleeper.get("tradeWindowDays"),
+                    or loaded_sleeper.get("tradeWindowDays"),
                     "tradeWindowStart": overlay.get("tradeWindowStart")
-                        or loaded_sleeper.get("tradeWindowStart"),
+                    or loaded_sleeper.get("tradeWindowStart"),
                     "tradeWindowCutoffMs": overlay.get("tradeWindowCutoffMs")
-                        or loaded_sleeper.get("tradeWindowCutoffMs"),
+                    or loaded_sleeper.get("tradeWindowCutoffMs"),
                     "overlaySource": "live-merge",
                     "overlayFetchedAt": overlay.get("overlayFetchedAt"),
                 }
@@ -2567,9 +2633,14 @@ async def get_data(request: Request):
                 overlay_full = {
                     **{
                         k: loaded_sleeper.get(k)
-                        for k in ("positions", "playerIds", "idToPlayer",
-                                  "scoringSettings", "rosterPositions",
-                                  "leagueSettings")
+                        for k in (
+                            "positions",
+                            "playerIds",
+                            "idToPlayer",
+                            "scoringSettings",
+                            "rosterPositions",
+                            "leagueSettings",
+                        )
                         if k in loaded_sleeper
                     },
                     **overlay,
@@ -2615,13 +2686,15 @@ async def get_data(request: Request):
         accept_encoding = (request.headers.get("accept-encoding") or "").lower()
         if "gzip" in accept_encoding and payload_gzip_bytes:
             headers["Content-Encoding"] = "gzip"
-            return Response(content=payload_gzip_bytes, media_type="application/json", headers=headers)
+            return Response(
+                content=payload_gzip_bytes, media_type="application/json", headers=headers
+            )
         if payload_bytes:
             return Response(content=payload_bytes, media_type="application/json", headers=headers)
         return JSONResponse(content=payload_obj, headers=headers)
     return JSONResponse(
         status_code=503,
-        content={"error": "No data available yet. First scrape may still be running."}
+        content={"error": "No data available yet. First scrape may still be running."},
     )
 
 
@@ -2681,8 +2754,13 @@ async def get_movers(request: Request):
     history = _rank_history.load_history(days=window + 1)
     if not history:
         return JSONResponse(
-            content={"window": window, "threshold": threshold,
-                     "asOf": None, "risers": [], "fallers": []},
+            content={
+                "window": window,
+                "threshold": threshold,
+                "asOf": None,
+                "risers": [],
+                "fallers": [],
+            },
             headers={"Cache-Control": "public, max-age=60, stale-while-revalidate=300"},
         )
 
@@ -2764,9 +2842,7 @@ async def get_movers(request: Request):
         # back to the history key's parsed asset_class so picks /
         # IDPs aren't mis-stamped as "?" when the contract has
         # rotated them off the board.
-        resolved_asset = (
-            str(row.get("assetClass") or "").strip().lower() or asset_class or None
-        )
+        resolved_asset = str(row.get("assetClass") or "").strip().lower() or asset_class or None
         entry = {
             "name": clean_name,
             "assetClass": resolved_asset,
@@ -2849,7 +2925,9 @@ async def get_player_source_history(request: Request):
             content={"error": "Missing required 'name' query param."},
         )
     try:
-        requested = int(request.query_params.get("days", _source_history.DEFAULT_HISTORY_WINDOW_DAYS))
+        requested = int(
+            request.query_params.get("days", _source_history.DEFAULT_HISTORY_WINDOW_DAYS)
+        )
     except (TypeError, ValueError):
         requested = _source_history.DEFAULT_HISTORY_WINDOW_DAYS
     days = max(1, min(_source_history.MAX_SNAPSHOTS, requested))
@@ -2879,6 +2957,7 @@ async def get_player_source_history(request: Request):
 # ``build_api_data_contract()`` / ``build_rankings_delta_payload()``
 # with the overrides threaded into ``_compute_unified_rankings()``.
 
+
 @app.get("/api/rankings/sources")
 async def get_rankings_sources():
     """Return the canonical ranking-source registry.
@@ -2890,10 +2969,12 @@ async def get_rankings_sources():
     internals.  The shape matches the frontend entry exactly —
     ``assert_ranking_source_registry_parity()`` enforces that.
     """
-    return JSONResponse(content={
-        "sources": get_ranking_source_registry(),
-        "contractVersion": API_DATA_CONTRACT_VERSION,
-    })
+    return JSONResponse(
+        content={
+            "sources": get_ranking_source_registry(),
+            "contractVersion": API_DATA_CONTRACT_VERSION,
+        }
+    )
 
 
 @app.post("/api/rankings/overrides")
@@ -2943,8 +3024,7 @@ async def post_rankings_overrides(request: Request):
     except LeagueResolutionError as err:
         return err.json_response()
     loaded_meta = (
-        latest_contract_data.get("meta") or {}
-        if isinstance(latest_contract_data, dict) else {}
+        latest_contract_data.get("meta") or {} if isinstance(latest_contract_data, dict) else {}
     )
     loaded_league = str(loaded_meta.get("leagueKey") or "")
     loaded_profile = str(loaded_meta.get("scoringProfile") or "")
@@ -3073,7 +3153,8 @@ _SLEEPER_USER_TEAM_CACHE: dict[tuple[str, str], dict] = {}
 
 
 def _fetch_sleeper_user_team(
-    sleeper_league_id: str, sleeper_user_id: str,
+    sleeper_league_id: str,
+    sleeper_user_id: str,
 ) -> dict | None:
     """Return ``{"ownerId", "teamName"}`` for the user in the given
     league, or ``None`` if the user isn't in the league or Sleeper
@@ -3101,11 +3182,10 @@ def _fetch_sleeper_user_team(
         return cached.get("value")
 
     try:
-        users_url = (
-            f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users"
-        )
+        users_url = f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users"
         req = urllib.request.Request(
-            users_url, headers={"User-Agent": "brisket-user-team/1.0"},
+            users_url,
+            headers={"User-Agent": "brisket-user-team/1.0"},
         )
         with urllib.request.urlopen(req, timeout=5.0) as resp:
             users = json.loads(resp.read())
@@ -3117,11 +3197,7 @@ def _fetch_sleeper_user_team(
     team_name = ""
     for u in users or []:
         if str(u.get("user_id") or "") == sleeper_user_id:
-            team_name = (
-                (u.get("metadata") or {}).get("team_name")
-                or u.get("display_name")
-                or ""
-            )
+            team_name = (u.get("metadata") or {}).get("team_name") or u.get("display_name") or ""
             break
     if not team_name:
         _SLEEPER_USER_TEAM_CACHE[cache_key] = {"value": None, "fetched_at": now}
@@ -3167,6 +3243,7 @@ async def get_leagues(request: Request):
     # doesn't hammer Sleeper.
     def _fetch_names(cfgs):
         return [_fetch_sleeper_league_name(c.sleeper_league_id) for c in cfgs]
+
     sleeper_names = await run_in_threadpool(_fetch_names, active_cfgs)
     for i, live_name in enumerate(sleeper_names):
         if live_name:
@@ -3175,6 +3252,7 @@ async def get_leagues(request: Request):
     if session:
         username = (session.get("username") or "").strip().lower()
         sleeper_user_id = str(session.get("sleeper_user_id") or "").strip()
+
         # Stamp each league's entry with this user's default team
         # when the registry knows about one.  Only this authed user
         # sees their own default — we don't expose other usernames'
@@ -3197,13 +3275,12 @@ async def get_leagues(request: Request):
                 }
             if sleeper_user_id:
                 return _fetch_sleeper_user_team(
-                    cfg.sleeper_league_id, sleeper_user_id,
+                    cfg.sleeper_league_id,
+                    sleeper_user_id,
                 )
             return None
 
-        resolved = await run_in_threadpool(
-            lambda: [_resolve_team(c) for c in active_cfgs]
-        )
+        resolved = await run_in_threadpool(lambda: [_resolve_team(c) for c in active_cfgs])
         for i, team in enumerate(resolved):
             if team:
                 leagues[i]["userDefaultTeam"] = team
@@ -3213,9 +3290,7 @@ async def get_leagues(request: Request):
         "defaultKey": _league_registry.default_league_key(),
     }
     if session:
-        user_default = _league_registry.get_user_default_league(
-            session.get("username") or ""
-        )
+        user_default = _league_registry.get_user_default_league(session.get("username") or "")
         body["userDefaultKey"] = user_default.key if user_default else None
     return JSONResponse(content=body, headers={"Cache-Control": "no-store"})
 
@@ -3246,8 +3321,10 @@ async def get_league_comparison(request: Request):
     refresh = refresh_raw in ("1", "true", "yes", "on")
     try:
         from src.league_comparison import service as _lc_service
+
         payload = await run_in_threadpool(
-            _lc_service.build_comparison, refresh=refresh,
+            _lc_service.build_comparison,
+            refresh=refresh,
         )
     except FileNotFoundError as exc:
         return JSONResponse(
@@ -3299,54 +3376,60 @@ async def get_status():
     runtime_bytes = len(latest_runtime_data_bytes) if latest_runtime_data_bytes else 0
     startup_bytes = len(latest_startup_data_bytes) if latest_startup_data_bytes else 0
     full_gzip_bytes = len(latest_data_gzip_bytes) if latest_data_gzip_bytes else 0
-    runtime_gzip_bytes = len(latest_runtime_data_gzip_bytes) if latest_runtime_data_gzip_bytes else 0
-    startup_gzip_bytes = len(latest_startup_data_gzip_bytes) if latest_startup_data_gzip_bytes else 0
-    return JSONResponse(content={
-        **status_payload,
-        "frontend_runtime": frontend_runtime_status,
-        "contract": {
-            "version": API_DATA_CONTRACT_VERSION,
-            "health": contract_health,
-            "value_authority": (latest_contract_data or {}).get("valueAuthority"),
-        },
-        "data_runtime": {
-            "last_data_refresh_at": latest_data_source.get("loadedAt"),
-            "active_data_source": latest_data_source,
-            "payload_bytes_full": full_bytes,
-            "payload_bytes_runtime": runtime_bytes,
-            "payload_bytes_startup": startup_bytes,
-            "payload_gzip_bytes_full": full_gzip_bytes,
-            "payload_gzip_bytes_runtime": runtime_gzip_bytes,
-            "payload_gzip_bytes_startup": startup_gzip_bytes,
-            "runtime_payload_savings_bytes": max(0, full_bytes - runtime_bytes),
-            "runtime_payload_savings_gzip_bytes": max(0, full_gzip_bytes - runtime_gzip_bytes),
-            "startup_payload_savings_bytes": max(0, full_bytes - startup_bytes),
-            "startup_payload_savings_gzip_bytes": max(0, full_gzip_bytes - startup_gzip_bytes),
-        },
-        "source_health": source_health,
-        "backup_health": _backup_freshness(),
-        "uptime": uptime_status,
-        "has_data": latest_contract_data is not None,
-        "player_count": int((latest_contract_data or {}).get("playerCount") or 0),
-        "data_date": (latest_contract_data or {}).get("date"),
-        # Real per-source coverage of the served board (see the
-        # ``served_source_coverage`` global).  Monitoring asserts on
-        # this; ``source_health`` above is derived from the 3-source
-        # legacy ``sites`` list and cannot detect a degraded board.
-        "served_source_coverage": served_source_coverage,
-        # R-4: Scrape success rate tracking
-        "scrape_success_rate_24h": _scrape_success_rate_24h(),
-        "last_n_scrapes": scrape_history[-20:],
-        "leagues": _league_status_snapshot(),
-        # 2026-04 upgrade observability — feature-flag state +
-        # unified-mapper coverage.  All flags default off so this
-        # is additive/informational; enabling a flag at runtime is
-        # the operator's decision.
-        "featureFlags": _feature_flag_snapshot_safe(),
-        "idMappingCoverage": _id_mapping_coverage_safe(),
-        "nflDataProvider": _nfl_data_provider_status_safe(),
-        "normalizationHealth": _normalization_health_safe(),
-    })
+    runtime_gzip_bytes = (
+        len(latest_runtime_data_gzip_bytes) if latest_runtime_data_gzip_bytes else 0
+    )
+    startup_gzip_bytes = (
+        len(latest_startup_data_gzip_bytes) if latest_startup_data_gzip_bytes else 0
+    )
+    return JSONResponse(
+        content={
+            **status_payload,
+            "frontend_runtime": frontend_runtime_status,
+            "contract": {
+                "version": API_DATA_CONTRACT_VERSION,
+                "health": contract_health,
+                "value_authority": (latest_contract_data or {}).get("valueAuthority"),
+            },
+            "data_runtime": {
+                "last_data_refresh_at": latest_data_source.get("loadedAt"),
+                "active_data_source": latest_data_source,
+                "payload_bytes_full": full_bytes,
+                "payload_bytes_runtime": runtime_bytes,
+                "payload_bytes_startup": startup_bytes,
+                "payload_gzip_bytes_full": full_gzip_bytes,
+                "payload_gzip_bytes_runtime": runtime_gzip_bytes,
+                "payload_gzip_bytes_startup": startup_gzip_bytes,
+                "runtime_payload_savings_bytes": max(0, full_bytes - runtime_bytes),
+                "runtime_payload_savings_gzip_bytes": max(0, full_gzip_bytes - runtime_gzip_bytes),
+                "startup_payload_savings_bytes": max(0, full_bytes - startup_bytes),
+                "startup_payload_savings_gzip_bytes": max(0, full_gzip_bytes - startup_gzip_bytes),
+            },
+            "source_health": source_health,
+            "backup_health": _backup_freshness(),
+            "uptime": uptime_status,
+            "has_data": latest_contract_data is not None,
+            "player_count": int((latest_contract_data or {}).get("playerCount") or 0),
+            "data_date": (latest_contract_data or {}).get("date"),
+            # Real per-source coverage of the served board (see the
+            # ``served_source_coverage`` global).  Monitoring asserts on
+            # this; ``source_health`` above is derived from the 3-source
+            # legacy ``sites`` list and cannot detect a degraded board.
+            "served_source_coverage": served_source_coverage,
+            # R-4: Scrape success rate tracking
+            "scrape_success_rate_24h": _scrape_success_rate_24h(),
+            "last_n_scrapes": scrape_history[-20:],
+            "leagues": _league_status_snapshot(),
+            # 2026-04 upgrade observability — feature-flag state +
+            # unified-mapper coverage.  All flags default off so this
+            # is additive/informational; enabling a flag at runtime is
+            # the operator's decision.
+            "featureFlags": _feature_flag_snapshot_safe(),
+            "idMappingCoverage": _id_mapping_coverage_safe(),
+            "nflDataProvider": _nfl_data_provider_status_safe(),
+            "normalizationHealth": _normalization_health_safe(),
+        }
+    )
 
 
 def _feature_flag_snapshot_safe() -> dict:
@@ -3354,6 +3437,7 @@ def _feature_flag_snapshot_safe() -> dict:
     so a malformed upgrade doesn't 500 /api/status."""
     try:
         from src.api import feature_flags as _ff
+
         return _ff.snapshot()
     except Exception as exc:  # noqa: BLE001
         log.warning("feature_flag snapshot failed: %s", exc)
@@ -3363,6 +3447,7 @@ def _feature_flag_snapshot_safe() -> dict:
 def _id_mapping_coverage_safe() -> dict:
     try:
         from src.identity import unified_mapper as _um
+
         return _um.mapping_coverage_snapshot()
     except Exception as exc:  # noqa: BLE001
         log.warning("id mapping coverage snapshot failed: %s", exc)
@@ -3372,6 +3457,7 @@ def _id_mapping_coverage_safe() -> dict:
 def _nfl_data_provider_status_safe() -> dict:
     try:
         from src.nfl_data import ingest as _ing
+
         return _ing.provider_status()
     except Exception as exc:  # noqa: BLE001
         log.warning("nfl_data provider status failed: %s", exc)
@@ -3384,6 +3470,7 @@ def _normalization_health_safe() -> dict:
     playersArray, ~5ms for ~1100 rows."""
     try:
         from src.canonical import normalization_validator as _nv
+
         return _nv.validate_contract(latest_contract_data or {})
     except Exception as exc:  # noqa: BLE001
         log.warning("normalization validator failed: %s", exc)
@@ -3406,6 +3493,7 @@ def _league_status_snapshot() -> list[dict]:
     source is ``none`` the UI surfaces the data-not-ready state.
     """
     import time as _time
+
     snapshot: list[dict[str, Any]] = []
     loaded = latest_contract_data or {}
     loaded_meta = loaded.get("meta") or {}
@@ -3476,6 +3564,7 @@ async def get_health():
     # themselves on the next scrape.
     _session_ages: dict[str, dict] = {}
     import os as _os
+
     _session_configs = {
         # Scraper POSTs DLF_USERNAME/PASSWORD to wp-login on failure,
         # so this file auto-refreshes.  Tracked for visibility only.
@@ -3498,18 +3587,12 @@ async def get_health():
                 _session_ages[fname] = {"present": False, "autoRefresh": auto_refresh}
                 continue
             mtime_ts = fpath.stat().st_mtime
-            age_days = round(
-                (datetime.now(timezone.utc).timestamp() - mtime_ts) / 86400, 1
-            )
+            age_days = round((datetime.now(timezone.utc).timestamp() - mtime_ts) / 86400, 1)
             days_remaining = max(0.0, round(lifetime_days - age_days, 1))
             # Only MANUAL sessions get the warnSoon flag — auto-refresh
             # sessions silently rotate when cached cookies expire, so
             # the banner shouldn't nag about them.
-            warn_soon = (
-                not auto_refresh
-                and days_remaining <= 14
-                and age_days > 0
-            )
+            warn_soon = not auto_refresh and days_remaining <= 14 and age_days > 0
             expired = (not auto_refresh) and days_remaining <= 0
             _session_ages[fname] = {
                 "present": True,
@@ -3530,12 +3613,14 @@ async def get_health():
         and bool(contract_health.get("ok", False))
     )
     status = "ok" if is_ok else "degraded"
+
     # Deeper health: startup checks + circuit breakers + session
     # store size.  Wrapped so a dependency import error can't bring
     # down the health endpoint itself.
     def _circuits_safe():
         try:
             from src.utils import circuit_breaker as _cb
+
             return _cb.snapshot_all()
         except Exception as exc:  # noqa: BLE001
             log.warning("health: circuit_breaker snapshot failed: %s", exc)
@@ -3544,6 +3629,7 @@ async def get_health():
     def _sessions_safe():
         try:
             from src.api import session_store as _ss
+
             return {"persistedCount": _ss.count_active()}
         except Exception as exc:  # noqa: BLE001
             log.warning("health: session_store count failed: %s", exc)
@@ -3597,7 +3683,9 @@ async def get_health():
             "circuitBreakers": circuits,
             "anyBreakerOpen": any_breaker_open,
             "startupChecks": _startup_checks_summary,
-            "memberInMemorySessions": len(auth_sessions) if isinstance(auth_sessions, dict) else None,
+            "memberInMemorySessions": len(auth_sessions)
+            if isinstance(auth_sessions, dict)
+            else None,
             "backup_health": backup_health,
         },
     )
@@ -3634,21 +3722,23 @@ async def get_metrics():
 
     disk_ok, free_mb = _check_disk_space()
 
-    return JSONResponse(content={
-        "server_start_time": _metrics.get("server_start_time"),
-        "uptime_seconds": uptime_seconds,
-        "request_count": _metrics.get("request_count", 0),
-        "scrape_total": _metrics.get("scrape_total", 0),
-        "scrape_failures": _metrics.get("scrape_failures", 0),
-        "scrape_duration_seconds_last": _metrics.get("scrape_duration_seconds_last", 0),
-        "data_age_seconds": data_age_seconds,
-        "data_stale": (data_age_seconds or 0) > SCRAPE_INTERVAL_HOURS * 3 * 3600,
-        "has_data": latest_contract_data is not None,
-        "player_count": int((latest_contract_data or {}).get("playerCount") or 0),
-        "disk_free_mb": free_mb,
-        "disk_ok": disk_ok,
-        "scrape_running": scrape_status.get("running", False),
-    })
+    return JSONResponse(
+        content={
+            "server_start_time": _metrics.get("server_start_time"),
+            "uptime_seconds": uptime_seconds,
+            "request_count": _metrics.get("request_count", 0),
+            "scrape_total": _metrics.get("scrape_total", 0),
+            "scrape_failures": _metrics.get("scrape_failures", 0),
+            "scrape_duration_seconds_last": _metrics.get("scrape_duration_seconds_last", 0),
+            "data_age_seconds": data_age_seconds,
+            "data_stale": (data_age_seconds or 0) > SCRAPE_INTERVAL_HOURS * 3 * 3600,
+            "has_data": latest_contract_data is not None,
+            "player_count": int((latest_contract_data or {}).get("playerCount") or 0),
+            "disk_free_mb": free_mb,
+            "disk_ok": disk_ok,
+            "scrape_running": scrape_status.get("running", False),
+        }
+    )
 
 
 # ── NEWS ───────────────────────────────────────────────────────────────
@@ -3671,9 +3761,9 @@ async def get_news(request: Request):
     # separated.  Items that don't mention at least one of those
     # players are dropped from the response (client-side filtering
     # stays available for scope="roster"/"league" already).
-    team_params = request.query_params.getlist("team") if hasattr(
-        request.query_params, "getlist"
-    ) else []
+    team_params = (
+        request.query_params.getlist("team") if hasattr(request.query_params, "getlist") else []
+    )
     team_names: list[str] = []
     for raw in team_params:
         for part in str(raw).split(","):
@@ -3760,16 +3850,22 @@ async def get_scaffold_status():
                 "file": _meta(raw_file),
                 "source_count": len(raw.get("snapshots", [])) if raw else 0,
                 "record_count": (
-                    sum(len(s.get("records", [])) for s in raw.get("snapshots", []))
-                    if raw
-                    else 0
+                    sum(len(s.get("records", [])) for s in raw.get("snapshots", [])) if raw else 0
                 ),
             },
             "ingest_validation": {
                 "file": _meta(ingest_validation_file),
-                "status": ingest_validation.get("status", "missing") if ingest_validation else "missing",
-                "missing_snapshot_field_count": ingest_validation.get("missing_snapshot_field_count", 0) if ingest_validation else 0,
-                "missing_asset_field_count": ingest_validation.get("missing_asset_field_count", 0) if ingest_validation else 0,
+                "status": ingest_validation.get("status", "missing")
+                if ingest_validation
+                else "missing",
+                "missing_snapshot_field_count": ingest_validation.get(
+                    "missing_snapshot_field_count", 0
+                )
+                if ingest_validation
+                else 0,
+                "missing_asset_field_count": ingest_validation.get("missing_asset_field_count", 0)
+                if ingest_validation
+                else 0,
             },
             "league": {
                 "file": _meta(league_file),
@@ -3817,7 +3913,6 @@ async def get_scaffold_identity():
     return JSONResponse(content=payload)
 
 
-
 @app.post("/api/waiver/suggestions")
 async def post_waiver_suggestions(request: Request):
     """Generate waiver-wire suggestions for the requesting league.
@@ -3850,7 +3945,9 @@ async def post_waiver_suggestions(request: Request):
 
     try:
         league_cfg = _resolve_league_for_request(
-            request, body=body, require_loaded_contract=True,
+            request,
+            body=body,
+            require_loaded_contract=True,
         )
     except LeagueResolutionError as err:
         return err.json_response()
@@ -3920,7 +4017,9 @@ async def post_waiver_faab_recommend(request: Request):
 
     try:
         league_cfg = _resolve_league_for_request(
-            request, body=body, require_loaded_contract=True,
+            request,
+            body=body,
+            require_loaded_contract=True,
         )
     except LeagueResolutionError as err:
         return err.json_response()
@@ -3968,7 +4067,7 @@ async def post_waiver_faab_recommend(request: Request):
     sleeper_teams = sleeper.get("teams") or []
     rostered_norms: set[str] = set()
     for t in sleeper_teams:
-        for n in (t.get("players") or []):
+        for n in t.get("players") or []:
             rostered_norms.add(_norm(n))
     top_pool_value = 0.0
     for row in arr:
@@ -3988,6 +4087,7 @@ async def post_waiver_faab_recommend(request: Request):
     # confidence=low and surfaces a "league analytics missing"
     # factor row).
     from src.api import faab_analytics  # noqa: PLC0415
+
     league_summary: dict | None = None
     try:
         snap_obj = public_snapshot_store.load_snapshot()
@@ -3996,7 +4096,8 @@ async def post_waiver_faab_recommend(request: Request):
     except Exception as exc:  # noqa: BLE001
         log.warning(
             "faab analytics build failed for %s: %s",
-            league_cfg.key, exc,
+            league_cfg.key,
+            exc,
         )
         league_summary = None
 
@@ -4040,6 +4141,7 @@ async def post_waiver_faab_recommend(request: Request):
     from src.adapters.ktc_crowd_faab import (  # noqa: PLC0415
         crowd_bid_map_from_contract,
     )
+
     ktc_crowd_bids = crowd_bid_map_from_contract(latest_contract_data)
 
     from src.trade.faab_recommender import recommend_faab  # noqa: PLC0415
@@ -4098,7 +4200,9 @@ async def post_trade_suggestions(request: Request):
     # Validate leagueKey (body or query) against the registry.
     try:
         league_cfg = _resolve_league_for_request(
-            request, body=body, require_loaded_contract=True,
+            request,
+            body=body,
+            require_loaded_contract=True,
         )
     except LeagueResolutionError as err:
         return err.json_response()
@@ -4107,7 +4211,9 @@ async def post_trade_suggestions(request: Request):
     if not isinstance(roster, list) or not roster:
         return JSONResponse(
             status_code=400,
-            content={"error": "Request body must include 'roster' as a non-empty array of player names."},
+            content={
+                "error": "Request body must include 'roster' as a non-empty array of player names."
+            },
         )
 
     from src.trade.suggestions import (
@@ -4126,6 +4232,7 @@ async def post_trade_suggestions(request: Request):
     # [50, 300]; out-of-range or missing falls back to the engine's
     # default constant.
     from src.trade.suggestions import KTC_TOP_N_FILTER as _KTC_TOP_N_DEFAULT
+
     raw_ktc_top_n = body.get("ktc_top_n")
     try:
         ktc_top_n = int(raw_ktc_top_n) if raw_ktc_top_n is not None else _KTC_TOP_N_DEFAULT
@@ -4154,7 +4261,9 @@ async def post_trade_suggestions(request: Request):
         )
     except Exception as e:
         log.error(f"Trade suggestion generation failed: {e}")
-        return JSONResponse(status_code=500, content={"error": f"Suggestion generation failed: {e}"})
+        return JSONResponse(
+            status_code=500, content={"error": f"Suggestion generation failed: {e}"}
+        )
 
     if isinstance(result, dict):
         result["leagueKey"] = league_cfg.key
@@ -4196,7 +4305,9 @@ async def post_trade_finder(request: Request):
     # Validate leagueKey (body or query).
     try:
         league_cfg = _resolve_league_for_request(
-            request, body=body, require_loaded_contract=True,
+            request,
+            body=body,
+            require_loaded_contract=True,
         )
     except LeagueResolutionError as err:
         return err.json_response()
@@ -4221,8 +4332,7 @@ async def post_trade_finder(request: Request):
     raw_ktc_top_n_f = body.get("ktc_top_n")
     try:
         finder_ktc_top_n = (
-            int(raw_ktc_top_n_f) if raw_ktc_top_n_f is not None
-            else _FINDER_KTC_TOP_N_DEFAULT
+            int(raw_ktc_top_n_f) if raw_ktc_top_n_f is not None else _FINDER_KTC_TOP_N_DEFAULT
         )
     except (TypeError, ValueError):
         finder_ktc_top_n = _FINDER_KTC_TOP_N_DEFAULT
@@ -4337,8 +4447,11 @@ async def post_trade_export_ktc(request: Request):
     except Exception as exc:  # noqa: BLE001
         return JSONResponse(
             status_code=502,
-            content={"ok": False, "error": "Failed to fetch KTC player map.",
-                     "detail": f"{type(exc).__name__}: {exc}"},
+            content={
+                "ok": False,
+                "error": "Failed to fetch KTC player map.",
+                "detail": f"{type(exc).__name__}: {exc}",
+            },
         )
     return JSONResponse(content={"ok": True, **result})
 
@@ -4388,7 +4501,9 @@ async def post_angle_find(request: Request):
     # different league.
     try:
         league_cfg = _resolve_league_for_request(
-            request, body=body, require_loaded_contract=True,
+            request,
+            body=body,
+            require_loaded_contract=True,
         )
     except LeagueResolutionError as err:
         return err.json_response()
@@ -4411,9 +4526,7 @@ async def post_angle_find(request: Request):
     try:
         min_my = float(body.get("minMyGainPct", 5.0))
         # Accept new key, fall back to legacy for pre-rename clients.
-        max_market = float(
-            body.get("maxMarketGainPct", body.get("maxKtcGainPct", 5.0))
-        )
+        max_market = float(body.get("maxMarketGainPct", body.get("maxKtcGainPct", 5.0)))
         limit = int(body.get("limit", 50))
     except (TypeError, ValueError):
         return JSONResponse(
@@ -4506,7 +4619,9 @@ async def post_angle_packages(request: Request):
     # League routing (same pattern as /api/angle/find).
     try:
         league_cfg = _resolve_league_for_request(
-            request, body=body, require_loaded_contract=True,
+            request,
+            body=body,
+            require_loaded_contract=True,
         )
     except LeagueResolutionError as err:
         return err.json_response()
@@ -4535,8 +4650,7 @@ async def post_angle_packages(request: Request):
             status_code=400,
             content={
                 "error": (
-                    f"Request body must include 'ownerId' and a non-empty "
-                    f"{names_key!r} list."
+                    f"Request body must include 'ownerId' and a non-empty " f"{names_key!r} list."
                 )
             },
         )
@@ -4545,9 +4659,7 @@ async def post_angle_packages(request: Request):
     try:
         min_my = float(body.get("minMyGainPct", 5.0))
         # Accept renamed key; fall back to legacy for pre-rename clients.
-        max_market = float(
-            body.get("maxMarketGainPct", body.get("maxKtcGainPct", 5.0))
-        )
+        max_market = float(body.get("maxMarketGainPct", body.get("maxKtcGainPct", 5.0)))
         limit = int(body.get("limit", 50))
         pool = int(body.get("candidatePoolPerTeam", 25))
         per_team = int(body.get("perTeamLimit", 4))
@@ -4570,6 +4682,7 @@ async def post_angle_packages(request: Request):
     # Otherwise ``positions=["DL"]`` alone would filter the pool down
     # to zero candidates, which silently breaks those callers.
     from src.trade.angle import _IDP_POSITIONS as _ANGLE_IDP_POSITIONS
+
     if not include_idp and any(
         str(p).strip().upper() in _ANGLE_IDP_POSITIONS for p in positions_req
     ):
@@ -4750,12 +4863,14 @@ def _resolve_league_for_request(
         cfg = _league_registry.get_league_by_key(explicit)
         if cfg is None:
             raise LeagueResolutionError(
-                400, "unknown_league",
+                400,
+                "unknown_league",
                 f"Unknown leagueKey {explicit!r}",
             )
         if not cfg.active:
             raise LeagueResolutionError(
-                400, "inactive_league",
+                400,
+                "inactive_league",
                 f"League {cfg.key!r} is not active",
             )
     else:
@@ -4779,24 +4894,26 @@ def _resolve_league_for_request(
             cfg = _league_registry.get_default_league()
         if cfg is None:
             raise LeagueResolutionError(
-                404, "no_leagues_configured",
+                404,
+                "no_leagues_configured",
                 "No leagues configured on this server",
             )
 
     if require_loaded_contract:
         loaded_key = None
         try:
-            loaded_key = (
-                (latest_contract_data or {}).get("meta", {}).get("leagueKey")
-            )
+            loaded_key = (latest_contract_data or {}).get("meta", {}).get("leagueKey")
         except Exception:  # noqa: BLE001
             loaded_key = None
         if loaded_key and loaded_key != cfg.key:
             raise LeagueResolutionError(
-                503, "data_not_ready",
+                503,
+                "data_not_ready",
                 f"No data loaded for league {cfg.key!r} yet",
             )
     return cfg
+
+
 _KTC_TOTAL_PICKS = 72  # fill rookie data for all 6 rounds (12 teams × 6 rounds)
 DRAFT_TOTAL_BUDGET = 1200  # $100 × 12 teams
 
@@ -4839,11 +4956,13 @@ def _ktc_decay_curve(known_rookies, total_picks=72):
     extended = list(known_rookies)
     for i in range(n, total_picks):
         projected_value = max(1, int(round(A * math.exp(-k * i))))
-        extended.append({
-            "name": f"Rookie #{i + 1}",
-            "pos": "—",
-            "value": projected_value,
-        })
+        extended.append(
+            {
+                "name": f"Rookie #{i + 1}",
+                "pos": "—",
+                "value": projected_value,
+            }
+        )
     return extended
 
 
@@ -4924,14 +5043,16 @@ def _fetch_ktc_rookies_live():
                 if name and val_str:
                     # Clean team suffix from name (e.g. "Player NAMEnyj" -> "Player NAME")
                     # KTC appends 2-3 letter team codes or "FA"/"RFA"/"R" suffix
-                    clean_name = re.sub(r'\s+(FA|RFA|R|[A-Z]{2,3})$', '', name)
+                    clean_name = re.sub(r"\s+(FA|RFA|R|[A-Z]{2,3})$", "", name)
                     try:
                         value = int(val_str)
                         if value > 0:
                             # Filter to fantasy-relevant positions
                             pos_upper = pos.upper()
                             if any(p in pos_upper for p in ("QB", "RB", "WR", "TE")):
-                                rookies.append({"name": clean_name or name, "pos": pos, "value": value})
+                                rookies.append(
+                                    {"name": clean_name or name, "pos": pos, "value": value}
+                                )
                     except ValueError:
                         pass
                 self._in_player = False
@@ -4949,7 +5070,9 @@ def _fetch_ktc_rookies_live():
 
     # Sort by value descending (should already be, but ensure)
     rookies.sort(key=lambda r: -r["value"])
-    logging.info(f"KTC live: fetched {len(rookies)} rookies (top: {rookies[0]['name']} = {rookies[0]['value']})")
+    logging.info(
+        f"KTC live: fetched {len(rookies)} rookies (top: {rookies[0]['name']} = {rookies[0]['value']})"
+    )
     return rookies
 
 
@@ -5021,14 +5144,20 @@ def _our_rookie_pool(top_n: int = 72) -> list[dict]:
             csv = {}
         ktc_raw = csv.get("ktcSfTep") or csv.get("ktc")
         idp_raw = csv.get("idpTradeCalc")
-        out.append({
-            "name": str(p.get("canonicalName") or p.get("displayName") or ""),
-            "pos": (str(p.get("position") or "").upper() or None),
-            "value": float(val),
-            "ktcRaw": float(ktc_raw) if isinstance(ktc_raw, (int, float)) and ktc_raw > 0 else None,
-            "idpRaw": float(idp_raw) if isinstance(idp_raw, (int, float)) and idp_raw > 0 else None,
-            "assetClass": p.get("assetClass"),
-        })
+        out.append(
+            {
+                "name": str(p.get("canonicalName") or p.get("displayName") or ""),
+                "pos": (str(p.get("position") or "").upper() or None),
+                "value": float(val),
+                "ktcRaw": float(ktc_raw)
+                if isinstance(ktc_raw, (int, float)) and ktc_raw > 0
+                else None,
+                "idpRaw": float(idp_raw)
+                if isinstance(idp_raw, (int, float)) and idp_raw > 0
+                else None,
+                "assetClass": p.get("assetClass"),
+            }
+        )
     out = [r for r in out if r["name"]]
     out.sort(key=lambda r: -r["value"])
     return out[:top_n]
@@ -5053,6 +5182,7 @@ def _vendor_dollars_for_rookies(
     Returns ``(ktc_by_name, idp_by_name)`` — both maps keyed by lowercase
     name (case-insensitive) for robust frontend joining.
     """
+
     def _dollars_by_vendor(key: str) -> dict[str, float]:
         eligible = [r for r in rookies if r.get(key) and r[key] > 0]
         if not eligible:
@@ -5064,6 +5194,7 @@ def _vendor_dollars_for_rookies(
         values = [r[key] for r in eligible]
         dollars = _rookie_dollars_from_values(values, total)
         return {r["name"].lower(): d for r, d in zip(eligible, dollars)}
+
     return _dollars_by_vendor("ktcRaw"), _dollars_by_vendor("idpRaw")
 
 
@@ -5079,6 +5210,7 @@ def _read_sheet_spine_and_floor(n: int = 72) -> tuple[list[float], int]:
     """
     try:
         import openpyxl
+
         if not DRAFT_DATA_XLSX.exists():
             return [1.0] * n, 0
         wb = openpyxl.load_workbook(DRAFT_DATA_XLSX, data_only=True)
@@ -5093,7 +5225,9 @@ def _read_sheet_spine_and_floor(n: int = 72) -> tuple[list[float], int]:
     return spine, n  # R5 bonus = +$1 × 12 picks = $12 total floor add
 
 
-def _rookie_dollars_from_values(values: list[float], total: int = DRAFT_TOTAL_BUDGET) -> list[float]:
+def _rookie_dollars_from_values(
+    values: list[float], total: int = DRAFT_TOTAL_BUDGET
+) -> list[float]:
     """Convert raw rookie values to dollar amounts using the sheet's
     Hill-curve formula (column C → I → J → K → D in Draft Data.xlsx),
     summing to ``total``.
@@ -5121,6 +5255,7 @@ def _rookie_dollars_from_values(values: list[float], total: int = DRAFT_TOTAL_BU
     real R5 picks are kept above R6.
     """
     import math
+
     n = len(values)
     if n == 0:
         return []
@@ -5139,10 +5274,7 @@ def _rookie_dollars_from_values(values: list[float], total: int = DRAFT_TOTAL_BU
     else:
         decay_rate = 0.05
 
-    weights = [
-        math.exp(-decay_rate * i) * (1 - 0.2 * math.exp(-0.12 * i))
-        for i in range(n)
-    ]
+    weights = [math.exp(-decay_rate * i) * (1 - 0.2 * math.exp(-0.12 * i)) for i in range(n)]
     denom_decay = sum(values[i] * weights[i] for i in range(n)) or 1.0
     term1 = [values[i] * weights[i] / denom_decay for i in range(n)]
 
@@ -5154,10 +5286,7 @@ def _rookie_dollars_from_values(values: list[float], total: int = DRAFT_TOTAL_BU
     floors_per_row = [1.0 + (1.0 if 48 <= i < 60 else 0.0) for i in range(n)]
     floor_pool = sum(floors_per_row)
     pool = float(total) - floor_pool
-    c_vals = [
-        floors_per_row[i] + pool * (0.6 * term1[i] + 0.4 * term2[i])
-        for i in range(n)
-    ]
+    c_vals = [floors_per_row[i] + pool * (0.6 * term1[i] + 0.4 * term2[i]) for i in range(n)]
 
     # Monotone half-dollar rounding (sheet uses ×2 / /2).
     doubled = [c * 2 for c in c_vals]
@@ -5175,10 +5304,10 @@ def _rookie_dollars_from_values(values: list[float], total: int = DRAFT_TOTAL_BU
     # forces K[i] ≤ K[i-1] so the dollar curve never re-rises).
     def cap_for(i: int) -> int:
         if 48 <= i < 60:
-            return 4   # R5 cap → D ≤ $2
+            return 4  # R5 cap → D ≤ $2
         if 60 <= i < 72:
-            return 2   # R6 cap → D ≤ $1
-        return 10 ** 9
+            return 2  # R6 cap → D ≤ $1
+        return 10**9
 
     k_vals: list[int] = []
     for i in range(n):
@@ -5205,6 +5334,7 @@ def _rookie_dollars_from_values(values: list[float], total: int = DRAFT_TOTAL_BU
 def _parse_csv_rookies():
     """Parse rookie rankings from the draft data CSV (cols 22-25)."""
     import csv
+
     if not DRAFT_DATA_CSV.exists():
         return []
     try:
@@ -5220,7 +5350,7 @@ def _parse_csv_rookies():
             rank_header_idx = i
             break
     if rank_header_idx is not None:
-        for row in rows[rank_header_idx + 1:]:
+        for row in rows[rank_header_idx + 1 :]:
             if len(row) < 26:
                 continue
             rank_str = row[22].strip() if row[22] else ""
@@ -5290,22 +5420,26 @@ def _parse_draft_xlsx():
     # ── Final pick assignments Q45:R116 ──
     workbook_picks: list[dict] = []
     for row in range(45, 117):
-        rnd = ws.cell(row, 15).value   # O
-        pk  = ws.cell(row, 16).value   # P
-        val = ws.cell(row, 17).value   # Q
-        own = ws.cell(row, 18).value   # R
+        rnd = ws.cell(row, 15).value  # O
+        pk = ws.cell(row, 16).value  # P
+        val = ws.cell(row, 17).value  # Q
+        own = ws.cell(row, 18).value  # R
         if rnd is None or pk is None or val is None or own is None:
             continue
-        workbook_picks.append({
-            "round": int(rnd), "pick": int(pk),
-            "value": float(val), "owner": str(own).strip(),
-        })
+        workbook_picks.append(
+            {
+                "round": int(rnd),
+                "pick": int(pk),
+                "value": float(val),
+                "owner": str(own).strip(),
+            }
+        )
 
     # ── Standings O30:R42 — slot → original owner ──
     slot_to_original_owner: dict[int, str] = {}
     for row in range(30, 43):
         owner = ws.cell(row, 16).value  # P = Owner
-        slot  = ws.cell(row, 18).value  # R = Pick #
+        slot = ws.cell(row, 18).value  # R = Pick #
         if owner and slot is not None:
             try:
                 slot_to_original_owner[int(slot)] = str(owner).strip()
@@ -5316,7 +5450,7 @@ def _parse_draft_xlsx():
     workbook_team_totals: dict[str, float] = {}
     for row in range(63, 75):
         team = ws.cell(row, 20).value  # T
-        val  = ws.cell(row, 21).value  # U
+        val = ws.cell(row, 21).value  # U
         if team and val is not None:
             workbook_team_totals[str(team).strip()] = float(val)
 
@@ -5329,6 +5463,7 @@ def _parse_draft_csv_fallback():
     Returns (pick_dollars, workbook_picks, slot_to_original, wb_totals) or None.
     """
     import csv
+
     if not DRAFT_DATA_CSV.exists():
         return None
     try:
@@ -5385,8 +5520,8 @@ def _parse_draft_csv_fallback():
     for row in rows:
         if len(row) <= 20:
             continue
-        c19 = (row[19].strip() if row[19] else "")
-        c20 = (row[20].strip() if row[20] else "")
+        c19 = row[19].strip() if row[19] else ""
+        c20 = row[20].strip() if row[20] else ""
         if c19 == "Team" and c20.startswith("Auction"):
             in_team = True
             continue
@@ -5431,6 +5566,7 @@ def _round_to_budget(values: list[float], budget: int = 1200) -> list[int]:
     the deficit to the values with the largest fractional parts.
     """
     import math
+
     floors = [math.floor(v) for v in values]
     remainders = [(v - math.floor(v), i) for i, v in enumerate(values)]
     deficit = budget - sum(floors)
@@ -5459,7 +5595,9 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
     ``apply_sleeper_trades=False`` preserves the legacy workbook-
     only behavior (used by tests that assert sheet-derived totals).
     """
-    pick_dollars, workbook_picks, slot_to_original, wb_team_totals, rookies, pick_values_l = _parse_draft_data()
+    pick_dollars, workbook_picks, slot_to_original, wb_team_totals, rookies, pick_values_l = (
+        _parse_draft_data()
+    )
     if not workbook_picks:
         return {"error": "Draft data workbook not found or empty"}
 
@@ -5551,9 +5689,9 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         user_map: dict[str, str] = {}
         for u in json.loads(users_resp.read()):
             uid = u.get("user_id")
-            user_map[uid] = (u.get("metadata", {}).get("team_name")
-                             or u.get("display_name")
-                             or f"Team {uid}")
+            user_map[uid] = (
+                u.get("metadata", {}).get("team_name") or u.get("display_name") or f"Team {uid}"
+            )
 
         roster_name_by_id: dict[int, str] = {}
         owner_to_roster_id: dict[str, int] = {}
@@ -5715,13 +5853,9 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         # slot.  Filtering to the bridged set guarantees every
         # slot in ``effective_slot_to_rid`` has a corresponding
         # entry in ``roster_id_to_first_name`` after the join.
-        _bridged_rids: set[int] = {
-            int(rid) for rid in slot_to_roster.values()
-        }
+        _bridged_rids: set[int] = {int(rid) for rid in slot_to_roster.values()}
         _bridged_fppts: dict[int, float] = {
-            int(rid): pts
-            for rid, pts in roster_fppts.items()
-            if int(rid) in _bridged_rids
+            int(rid): pts for rid, pts in roster_fppts.items() if int(rid) in _bridged_rids
         }
         # Codex P1: a pure count gate (``len(slot_to_roster) >=
         # len(slot_to_original)``) still activates when Sleeper's
@@ -5747,21 +5881,15 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         )
         effective_slot_to_rid: dict[int, int] = dict(slot_to_roster)
         if live_standings_active:
-            _sorted_rids = sorted(
-                _bridged_fppts, key=lambda r: _bridged_fppts[r]
-            )
+            _sorted_rids = sorted(_bridged_fppts, key=lambda r: _bridged_fppts[r])
             effective_slot_to_rid = {
                 int(i): int(rid)
-                for i, rid in enumerate(
-                    _sorted_rids[:len(slot_to_original)], start=1
-                )
+                for i, rid in enumerate(_sorted_rids[: len(slot_to_original)], start=1)
             }
 
         # slot → display name, derived from the effective mapping.
         for slot, rid in effective_slot_to_rid.items():
-            slot_to_origin_display[int(slot)] = roster_name_by_id.get(
-                rid, f"Team {rid}"
-            )
+            slot_to_origin_display[int(slot)] = roster_name_by_id.get(rid, f"Team {rid}")
         # Slots in the workbook that the effective mapping didn't
         # cover (e.g. a 14-team workbook joined against a 12-roster
         # Sleeper league) fall back to the workbook's first-name →
@@ -5905,15 +6033,9 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
         if live_standings_active:
             _slot_rid = effective_slot_to_rid.get(slot)
             if _slot_rid is not None:
-                owner_first = roster_id_to_first_name.get(
-                    _slot_rid, owner_first
-                )
+                owner_first = roster_id_to_first_name.get(_slot_rid, owner_first)
                 owner_rid = _slot_rid
-        elif (
-            owner_first
-            and origin_first
-            and str(owner_first).strip() != str(origin_first).strip()
-        ):
+        elif owner_first and origin_first and str(owner_first).strip() != str(origin_first).strip():
             # Workbook-recorded (hand-entered) trade with no live
             # reshuffle: the only path that must resolve owner →
             # roster_id through the name map.  ``first_name_to_rid``
@@ -5960,25 +6082,27 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
             else float(val)
         )
 
-        all_picks.append({
-            "pick": f"{rnd}.{str(slot).zfill(2)}",
-            "round": rnd,
-            "pickInRound": slot,
-            "overallPick": overall_idx + 1,
-            "dollarValue": dollar,
-            "adjustedDollarValue": dollar,
-            # Same source as dollarValue.  The legacy distinction
-            # between expansion-averaged Q and unaveraged grid no
-            # longer applies — L is unaveraged by construction.
-            "originalDollarValue": dollar,
-            "originalOwner": origin_team,
-            "currentOwner": owner_team,
-            "isTraded": is_traded,
-            "isExpansion": slot <= 2,
-            "rookieName": None,
-            "rookiePos": None,
-            "rookieKtcValue": None,
-        })
+        all_picks.append(
+            {
+                "pick": f"{rnd}.{str(slot).zfill(2)}",
+                "round": rnd,
+                "pickInRound": slot,
+                "overallPick": overall_idx + 1,
+                "dollarValue": dollar,
+                "adjustedDollarValue": dollar,
+                # Same source as dollarValue.  The legacy distinction
+                # between expansion-averaged Q and unaveraged grid no
+                # longer applies — L is unaveraged by construction.
+                "originalDollarValue": dollar,
+                "originalOwner": origin_team,
+                "currentOwner": owner_team,
+                "isTraded": is_traded,
+                "isExpansion": slot <= 2,
+                "rookieName": None,
+                "rookiePos": None,
+                "rookieKtcValue": None,
+            }
+        )
         team_totals_decimal.setdefault(owner_team, 0.0)
         team_totals_decimal[owner_team] += float(val)
 
@@ -6003,18 +6127,24 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
     if our_rookies:
         raw_values = [r["value"] for r in our_rookies]
         rookie_dollar_overrides = _rookie_dollars_from_values(
-            raw_values, DRAFT_TOTAL_BUDGET,
+            raw_values,
+            DRAFT_TOTAL_BUDGET,
         )
         # Vendor $ on the same $1200 scale (KTC sorted by KTC raw,
         # IDPTC sorted by IDPTC raw) so the frontend's gap math is
         # honest dollar-vs-dollar instead of dollar-vs-raw-thousand.
         ktc_by_name, idp_by_name = _vendor_dollars_for_rookies(
-            our_rookies, DRAFT_TOTAL_BUDGET,
+            our_rookies,
+            DRAFT_TOTAL_BUDGET,
         )
         rookies = [
-            {"name": r["name"], "pos": r["pos"], "value": d,
-             "ktcDollar": ktc_by_name.get(r["name"].lower()),
-             "idpTradeCalcDollar": idp_by_name.get(r["name"].lower())}
+            {
+                "name": r["name"],
+                "pos": r["pos"],
+                "value": d,
+                "ktcDollar": ktc_by_name.get(r["name"].lower()),
+                "idpTradeCalcDollar": idp_by_name.get(r["name"].lower()),
+            }
             for r, d in zip(our_rookies, rookie_dollar_overrides)
         ]
     else:
@@ -6039,7 +6169,14 @@ def _fetch_draft_capital(league_key: str | None = None, *, apply_sleeper_trades:
     sorted_teams = sorted(team_totals.items(), key=lambda x: -x[1])
 
     # KTC data source info — only meaningful when we fell back to KTC.
-    ktc_source = "live" if (_ktc_cache["rookies"] is not None and (time.time() - _ktc_cache["fetched_at"]) < _KTC_CACHE_TTL) else "csv"
+    ktc_source = (
+        "live"
+        if (
+            _ktc_cache["rookies"] is not None
+            and (time.time() - _ktc_cache["fetched_at"]) < _KTC_CACHE_TTL
+        )
+        else "csv"
+    )
     ktc_count = len([r for r in rookies if not r["name"].startswith("Rookie #")]) if rookies else 0
 
     return {
@@ -6096,11 +6233,14 @@ async def get_draft_capital(request: Request, refresh: str = ""):
             # in the UI so users see "Sleeper-derived" vs.
             # "workbook-calibrated".
             from src.api.draft_capital_fallback import build_sleeper_derived
+
             result = build_sleeper_derived(
                 league_cfg.sleeper_league_id,
                 latest_contract_data or {},
                 current_season=datetime.now(timezone.utc).year,
-                num_teams=league_cfg.roster_settings.get("teamCount", 12) if hasattr(league_cfg, "roster_settings") else 12,
+                num_teams=league_cfg.roster_settings.get("teamCount", 12)
+                if hasattr(league_cfg, "roster_settings")
+                else 12,
             )
         if isinstance(result, dict):
             result["leagueKey"] = league_cfg.key
@@ -6108,8 +6248,7 @@ async def get_draft_capital(request: Request, refresh: str = ""):
     except Exception as e:
         logging.error(f"Draft capital computation failed: {e}")
         return JSONResponse(
-            status_code=500,
-            content={"error": f"Draft capital computation failed: {str(e)}"}
+            status_code=500, content={"error": f"Draft capital computation failed: {str(e)}"}
         )
 
 
@@ -6216,8 +6355,7 @@ async def get_sleeper_draft_picks(
             content={
                 "error": "no_active_draft",
                 "message": (
-                    "No active draft for this league, or Sleeper is "
-                    "unreachable right now."
+                    "No active draft for this league, or Sleeper is " "unreachable right now."
                 ),
                 "leagueKey": league_cfg.key,
             },
@@ -6276,6 +6414,8 @@ def _build_public_activity_valuation():
     so it can be unit-tested without pulling in FastAPI.
     """
     return _build_valuation_from_contract(latest_contract_data)
+
+
 _public_league_cache: dict = {
     "snapshot": None,
     "snapshot_league_id": None,
@@ -6327,21 +6467,16 @@ def _public_league_metrics_snapshot() -> dict:
     """Copy of the metrics dict safe to ship out of the process."""
     snap = dict(_public_league_metrics)
     # Derived fields.
-    total = (
-        snap["cache_hit"]
-        + snap["cache_stale_served"]
-        + snap["cache_miss_cold_rebuild"]
-    )
+    total = snap["cache_hit"] + snap["cache_stale_served"] + snap["cache_miss_cold_rebuild"]
     snap["total_served"] = total
-    snap["cache_hit_ratio"] = (
-        round(snap["cache_hit"] / total, 4) if total else None
-    )
+    snap["cache_hit_ratio"] = round(snap["cache_hit"] / total, 4) if total else None
     snap["avg_rebuild_seconds"] = (
         round(snap["total_rebuild_seconds"] / snap["rebuild_count"], 4)
         if snap["rebuild_count"]
         else None
     )
     return snap
+
 
 # Best-effort: load the most recent persisted snapshot at process
 # start so a cold-started server can still serve the public /league
@@ -6640,7 +6775,10 @@ async def get_public_league_matchup(
     try:
         snapshot = _get_public_snapshot(force_refresh=bool(refresh))
         recap = public_matchup_recap.build_matchup_recap(
-            snapshot, season, int(week), int(matchup_id),
+            snapshot,
+            season,
+            int(week),
+            int(matchup_id),
         )
         if recap is None:
             return JSONResponse(
@@ -6653,8 +6791,12 @@ async def get_public_league_matchup(
             "contractVersion": "public-league-matchup/2026-04-17.v1",
             "league": {
                 "rootLeagueId": snapshot.root_league_id,
-                "currentLeagueId": snapshot.current_season.league_id if snapshot.current_season else "",
-                "leagueName": str((snapshot.current_season.league or {}).get("name") or "") if snapshot.current_season else "",
+                "currentLeagueId": snapshot.current_season.league_id
+                if snapshot.current_season
+                else "",
+                "leagueName": str((snapshot.current_season.league or {}).get("name") or "")
+                if snapshot.current_season
+                else "",
                 "managers": snapshot.managers.to_public_list(),
                 "seasonsCovered": snapshot.season_ids,
                 "generatedAt": snapshot.generated_at,
@@ -6720,7 +6862,9 @@ async def get_public_league_player(player_id: str, refresh: str = ""):
             "contractVersion": "public-league-player/2026-04-17.v1",
             "league": {
                 "rootLeagueId": snapshot.root_league_id,
-                "leagueName": str((snapshot.current_season.league or {}).get("name") or "") if snapshot.current_season else "",
+                "leagueName": str((snapshot.current_season.league or {}).get("name") or "")
+                if snapshot.current_season
+                else "",
                 "managers": snapshot.managers.to_public_list(),
                 "seasonsCovered": snapshot.season_ids,
                 "generatedAt": snapshot.generated_at,
@@ -6831,9 +6975,7 @@ async def get_public_league_section_csv(
             kwargs["owner_id"] = str(owner).strip()
         if section == "archives" and kind:
             kwargs["kind"] = str(kind).strip()
-        filename, text = public_csv_export.export_section(
-            section, payload["data"], **kwargs
-        )
+        filename, text = public_csv_export.export_section(section, payload["data"], **kwargs)
         return Response(
             content=text,
             media_type="text/csv; charset=utf-8",
@@ -6873,8 +7015,10 @@ async def get_public_league_section(section: str, owner: str = "", refresh: str 
     if section not in PUBLIC_SECTION_KEYS:
         return JSONResponse(
             status_code=404,
-            content={"error": f"Unknown public league section: {section!r}",
-                     "availableSections": list(PUBLIC_SECTION_KEYS)},
+            content={
+                "error": f"Unknown public league section: {section!r}",
+                "availableSections": list(PUBLIC_SECTION_KEYS),
+            },
         )
     try:
         snapshot = _get_public_snapshot(force_refresh=bool(refresh))
@@ -6933,7 +7077,8 @@ async def trigger_scrape(request: Request, background_tasks: BackgroundTasks):
         # UI can show "X trades loaded" right away.
         loaded_sleeper = (
             latest_contract_data.get("sleeper") or {}
-            if isinstance(latest_contract_data, dict) else {}
+            if isinstance(latest_contract_data, dict)
+            else {}
         )
         id_map = loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else {}
         _sleeper_overlay.invalidate_overlay_cache(league_cfg.sleeper_league_id)
@@ -6962,14 +7107,16 @@ async def trigger_scrape(request: Request, background_tasks: BackgroundTasks):
                     "leagueKey": league_cfg.key,
                 },
             )
-        return JSONResponse(content={
-            "message": f"Sleeper overlay refreshed for {league_cfg.key!r}.",
-            "leagueKey": league_cfg.key,
-            "teamCount": len(overlay.get("teams") or []),
-            "tradeCount": len(overlay.get("trades") or []),
-            "waiverCount": len(overlay.get("waivers") or []),
-            "overlayFetchedAt": overlay.get("overlayFetchedAt"),
-        })
+        return JSONResponse(
+            content={
+                "message": f"Sleeper overlay refreshed for {league_cfg.key!r}.",
+                "leagueKey": league_cfg.key,
+                "teamCount": len(overlay.get("teams") or []),
+                "tradeCount": len(overlay.get("trades") or []),
+                "waiverCount": len(overlay.get("waivers") or []),
+                "overlayFetchedAt": overlay.get("overlayFetchedAt"),
+            }
+        )
 
     status_payload = _scrape_status_payload()
     if status_payload.get("is_running") or scrape_run_lock.locked():
@@ -6983,17 +7130,20 @@ async def trigger_scrape(request: Request, background_tasks: BackgroundTasks):
         )
         return JSONResponse(
             status_code=409,
-            content={"error": "Scrape already in progress",
-                     "status": status_payload}
+            content={"error": "Scrape already in progress", "status": status_payload},
         )
 
     # Run in background so the API returns immediately
-    _record_scrape_event("scrape_requested", message="Manual scrape trigger accepted", trigger="manual_api")
+    _record_scrape_event(
+        "scrape_requested", message="Manual scrape trigger accepted", trigger="manual_api"
+    )
     background_tasks.add_task(run_scraper, "manual_api")
-    return JSONResponse(content={
-        "message": "Scrape started in background",
-        "status": _scrape_status_payload(),
-    })
+    return JSONResponse(
+        content={
+            "message": "Scrape started in background",
+            "status": _scrape_status_payload(),
+        }
+    )
 
 
 @app.post("/api/test-alert")
@@ -7002,16 +7152,13 @@ async def test_alert():
     if not ALERT_ENABLED:
         return JSONResponse(
             status_code=400,
-            content={"error": "Alerts not enabled. Set environment variable ALERT_ENABLED=true"}
+            content={"error": "Alerts not enabled. Set environment variable ALERT_ENABLED=true"},
         )
     try:
         send_alert("Test Alert", "If you're reading this, email alerts are working!")
         return JSONResponse(content={"message": f"Test alert sent to {ALERT_TO}"})
     except Exception as e:
-        return JSONResponse(
-            status_code=500,
-            content={"error": f"Failed: {str(e)}"}
-        )
+        return JSONResponse(status_code=500, content={"error": f"Failed: {str(e)}"})
 
 
 # ── AUTH + ENTRY GATE ROUTES ────────────────────────────────────────────
@@ -7089,12 +7236,14 @@ async def auth_login(request: Request):
             expires_at_epoch=pass_row.expires_at_epoch,
             guest_pass_id=pass_row.id,
         )
-        response = JSONResponse(content={
-            "ok": True,
-            "redirect": next_path,
-            "guest": True,
-            "expiresAtEpoch": pass_row.expires_at_epoch,
-        })
+        response = JSONResponse(
+            content={
+                "ok": True,
+                "redirect": next_path,
+                "guest": True,
+                "expiresAtEpoch": pass_row.expires_at_epoch,
+            }
+        )
         # Cookie max-age is the smaller of the pass's remaining
         # lifetime or the standard ceiling.  Browser may still keep
         # the cookie longer if the user fiddles with system time;
@@ -7140,6 +7289,7 @@ async def auth_logout_redirect(request: Request):
 # hook falls back to a localStorage-only path when unauthenticated, so
 # a logged-out visitor still sees defaults without polluting the
 # shared store.
+
 
 @app.get("/api/user/state")
 async def get_user_state_api(request: Request):
@@ -7200,7 +7350,8 @@ async def put_user_state_api(request: Request):
             patch["dismissalAliases"] = None
         elif isinstance(da, dict):
             patch["dismissalAliases"] = {
-                str(k): str(v) for k, v in da.items()
+                str(k): str(v)
+                for k, v in da.items()
                 if isinstance(k, str) and isinstance(v, (str, int))
             }
     if "notificationsEmail" in body:
@@ -7315,7 +7466,10 @@ async def post_push_subscribe(request: Request):
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"error": str(exc)})
     await run_in_threadpool(
-        _user_kv.set_user_field, username, "pushSubscriptions", new_subs,
+        _user_kv.set_user_field,
+        username,
+        "pushSubscriptions",
+        new_subs,
     )
     return JSONResponse(
         content={"ok": True, "count": len(new_subs)},
@@ -7341,7 +7495,10 @@ async def post_push_unsubscribe(request: Request):
     state = await run_in_threadpool(_user_kv.get_user_state, username) or {}
     new_subs = _push_delivery.remove_subscription(state, endpoint)
     await run_in_threadpool(
-        _user_kv.set_user_field, username, "pushSubscriptions", new_subs,
+        _user_kv.set_user_field,
+        username,
+        "pushSubscriptions",
+        new_subs,
     )
     return JSONResponse(
         content={"ok": True, "count": len(new_subs)},
@@ -7400,7 +7557,8 @@ async def put_custom_alerts(request: Request):
         prior_state = {}
     new_ids = {r["id"] for r in cleaned}
     pruned_state = {
-        k: v for k, v in prior_state.items()
+        k: v
+        for k, v in prior_state.items()
         if isinstance(k, str) and k.split("::", 1)[0] in new_ids
     }
 
@@ -7433,7 +7591,8 @@ async def run_custom_alerts(request: Request):
         session = _get_auth_session(request)
         if not session or session.get("auth_method") != "password":
             return JSONResponse(
-                status_code=401, content={"error": "admin_auth_required"},
+                status_code=401,
+                content={"error": "admin_auth_required"},
             )
 
     if not latest_contract_data:
@@ -7455,7 +7614,9 @@ async def run_custom_alerts(request: Request):
 
         try:
             hits = _custom_alerts.evaluate_alerts(
-                rules, players_array, state=cooldown_state,
+                rules,
+                players_array,
+                state=cooldown_state,
             )
         except Exception as exc:
             log.warning("custom-alerts evaluation failed for %s: %s", username, exc)
@@ -7508,7 +7669,8 @@ async def run_custom_alerts(request: Request):
             patch["customAlertsState"] = new_state
         if endpoints_to_prune:
             kept = [
-                s for s in _push_delivery.list_subscriptions(state)
+                s
+                for s in _push_delivery.list_subscriptions(state)
                 if s.get("endpoint") not in set(endpoints_to_prune)
             ]
             patch["pushSubscriptions"] = kept
@@ -7600,7 +7762,10 @@ async def restore_signal_api(request: Request):
         if cfg is not None and cfg.active:
             scoped_key = cfg.key
     state = await run_in_threadpool(
-        _user_kv.undismiss_signal, username, signal_key, league_key=scoped_key,
+        _user_kv.undismiss_signal,
+        username,
+        signal_key,
+        league_key=scoped_key,
     )
     return JSONResponse(
         content={"username": username, "state": state},
@@ -7630,6 +7795,7 @@ async def restore_signal_api(request: Request):
 #   * If even the cached export is absent, surface a 503 with the
 #     same shape so the frontend error UI can render a coherent
 #     message.
+
 
 def _latest_cached_contract_from_disk() -> tuple[dict | None, str | None]:
     """Return the most recent on-disk ``dynasty_data_*.json`` export
@@ -7736,7 +7902,9 @@ async def get_terminal(request: Request):
             )
         except Exception as exc:  # noqa: BLE001
             log.warning(
-                "terminal overlay fetch failed for %s: %s", league_cfg.key, exc,
+                "terminal overlay fetch failed for %s: %s",
+                league_cfg.key,
+                exc,
             )
             overlay = None
         if not overlay or not overlay.get("teams"):
@@ -7755,20 +7923,29 @@ async def get_terminal(request: Request):
         hybrid_sleeper = {
             **{
                 k: loaded_sleeper.get(k)
-                for k in ("positions", "playerIds", "idToPlayer",
-                          "scoringSettings", "rosterPositions",
-                          "leagueSettings")
+                for k in (
+                    "positions",
+                    "playerIds",
+                    "idToPlayer",
+                    "scoringSettings",
+                    "rosterPositions",
+                    "leagueSettings",
+                )
                 if isinstance(loaded_sleeper, dict) and k in loaded_sleeper
             },
             **overlay,
         }
-        contract = {**contract, "sleeper": hybrid_sleeper, "meta": {
-            **loaded_meta,
-            "leagueKey": league_cfg.key,
-            "sleeperDataReady": True,
-            "sleeperSource": "overlay",
-            "sleeperLoadedLeagueKey": loaded_league,
-        }}
+        contract = {
+            **contract,
+            "sleeper": hybrid_sleeper,
+            "meta": {
+                **loaded_meta,
+                "leagueKey": league_cfg.key,
+                "sleeperDataReady": True,
+                "sleeperSource": "overlay",
+                "sleeperLoadedLeagueKey": loaded_league,
+            },
+        }
 
     params = request.query_params
     team_owner_id = (params.get("team") or params.get("ownerId") or "").strip()
@@ -7792,7 +7969,9 @@ async def get_terminal(request: Request):
         # ``team`` param — we never expose per-roster state without
         # authentication.  ``resolved_team=None`` is enforced below.
         resolved_team = _terminal.resolve_team(
-            contract, owner_id=team_owner_id, name=team_name,
+            contract,
+            owner_id=team_owner_id,
+            name=team_name,
         )
         # Auto-resolve via the authenticated Sleeper user id when the
         # client didn't pass an explicit team.  This is the "Sleeper
@@ -7803,7 +7982,9 @@ async def get_terminal(request: Request):
             session_sleeper_id = str((session or {}).get("sleeper_user_id") or "").strip()
             if session_sleeper_id:
                 resolved_team = _terminal.resolve_team(
-                    contract, owner_id=session_sleeper_id, name=None,
+                    contract,
+                    owner_id=session_sleeper_id,
+                    name=None,
                 )
 
     try:
@@ -7928,7 +8109,9 @@ async def post_trade_simulate(request: Request):
             )
         except Exception as exc:  # noqa: BLE001
             log.warning(
-                "trade-simulate overlay fetch failed for %s: %s", league_cfg.key, exc,
+                "trade-simulate overlay fetch failed for %s: %s",
+                league_cfg.key,
+                exc,
             )
             overlay = None
         if not overlay or not overlay.get("teams"):
@@ -7943,9 +8126,14 @@ async def post_trade_simulate(request: Request):
         hybrid_sleeper = {
             **{
                 k: loaded_sleeper.get(k)
-                for k in ("positions", "playerIds", "idToPlayer",
-                          "scoringSettings", "rosterPositions",
-                          "leagueSettings")
+                for k in (
+                    "positions",
+                    "playerIds",
+                    "idToPlayer",
+                    "scoringSettings",
+                    "rosterPositions",
+                    "leagueSettings",
+                )
                 if isinstance(loaded_sleeper, dict) and k in loaded_sleeper
             },
             **overlay,
@@ -7961,7 +8149,9 @@ async def post_trade_simulate(request: Request):
         team_owner_id = str(session.get("sleeper_user_id") or "").strip()
 
     resolved_team = _terminal.resolve_team(
-        contract, owner_id=team_owner_id, name=team_name,
+        contract,
+        owner_id=team_owner_id,
+        name=team_name,
     )
     if resolved_team is None:
         return JSONResponse(
@@ -8020,7 +8210,8 @@ def _deliver_email_smtp(to: str, subject: str, body: str) -> bool:
     except Exception as exc587:  # noqa: BLE001
         log.warning(
             "signal-alert SMTP 587 STARTTLS failed to %s: %s — falling back to 465",
-            to, exc587,
+            to,
+            exc587,
         )
         try:
             with smtplib.SMTP_SSL("smtp.gmail.com", 465, timeout=15) as s:
@@ -8037,6 +8228,7 @@ def _deliver_email_smtp(to: str, subject: str, body: str) -> bool:
 # Gated on both: (1) a valid session AND (2) an explicit admin
 # username check against PRIVATE_APP_ALLOWED_USERNAMES.  Every
 # admin action is logged with username + action for audit.
+
 
 def _require_admin_session(request: Request):
     """Returns the session dict on success; returns a JSONResponse
@@ -8075,7 +8267,7 @@ async def post_test_create_session(request: Request):
         return JSONResponse(status_code=404, content={"error": "not_found"})
     expected = os.getenv("E2E_TEST_SECRET", "").strip()
     auth = str(request.headers.get("authorization", "")).strip()
-    provided = auth[len("Bearer "):].strip() if auth.lower().startswith("bearer ") else ""
+    provided = auth[len("Bearer ") :].strip() if auth.lower().startswith("bearer ") else ""
     if not expected or provided != expected:
         return JSONResponse(status_code=404, content={"error": "not_found"})
     username = (os.getenv("E2E_TEST_USERNAME") or "jasonleetucker").strip().lower()
@@ -8085,12 +8277,19 @@ async def post_test_create_session(request: Request):
         display_name=username,
         auth_method="e2e_test",
     )
-    res = JSONResponse(content={
-        "ok": True, "username": username, "sessionId": session_id,
-    })
+    res = JSONResponse(
+        content={
+            "ok": True,
+            "username": username,
+            "sessionId": session_id,
+        }
+    )
     res.set_cookie(
-        JASON_AUTH_COOKIE_NAME, session_id,
-        max_age=3600, httponly=True, samesite="lax",
+        JASON_AUTH_COOKIE_NAME,
+        session_id,
+        max_age=3600,
+        httponly=True,
+        samesite="lax",
     )
     return res
 
@@ -8106,6 +8305,7 @@ async def post_admin_nfl_data_flush(request: Request):
         return session_or_err
     session = session_or_err
     from src.nfl_data import cache as _nflc
+
     cache_dir = _nflc._default_cache_dir()  # noqa: SLF001
     deleted = 0
     try:
@@ -8123,7 +8323,8 @@ async def post_admin_nfl_data_flush(request: Request):
         )
     log.info(
         "admin action: nfl_data flush by %s — %d entries evicted",
-        session.get("username"), deleted,
+        session.get("username"),
+        deleted,
     )
     return JSONResponse(content={"ok": True, "evicted": deleted})
 
@@ -8142,18 +8343,23 @@ async def post_admin_force_logout_all(request: Request):
     persisted = 0
     try:
         from src.api import session_store as _ss
+
         persisted = _ss.force_clear_all()
     except Exception as exc:  # noqa: BLE001
         log.warning("force_clear_all session_store: %s", exc)
     log.warning(
         "admin action: FORCE-LOGOUT-ALL by %s — %d in-memory + %d persisted",
-        session.get("username"), in_mem_count, persisted,
+        session.get("username"),
+        in_mem_count,
+        persisted,
     )
-    return JSONResponse(content={
-        "ok": True,
-        "inMemoryCleared": in_mem_count,
-        "persistedCleared": persisted,
-    })
+    return JSONResponse(
+        content={
+            "ok": True,
+            "inMemoryCleared": in_mem_count,
+            "persistedCleared": persisted,
+        }
+    )
 
 
 @app.post("/api/admin/guest-pass")
@@ -8205,14 +8411,18 @@ async def post_admin_guest_pass_create(request: Request):
         )
     log.info(
         "admin action: guest_pass minted id=%d by %s expires=%.0f note=%r",
-        pass_row.id, session.get("username"),
-        pass_row.expires_at_epoch, pass_row.note[:40],
+        pass_row.id,
+        session.get("username"),
+        pass_row.expires_at_epoch,
+        pass_row.note[:40],
     )
-    return JSONResponse(content={
-        "ok": True,
-        "token": token,  # plaintext — shown ONCE, never again retrievable
-        "pass": pass_row.to_dict(),
-    })
+    return JSONResponse(
+        content={
+            "ok": True,
+            "token": token,  # plaintext — shown ONCE, never again retrievable
+            "pass": pass_row.to_dict(),
+        }
+    )
 
 
 @app.get("/api/admin/guest-passes")
@@ -8229,9 +8439,11 @@ async def get_admin_guest_passes(request: Request):
         _guest_passes.list_passes,
         include_inactive=not active_only,
     )
-    return JSONResponse(content={
-        "passes": [r.to_dict() for r in rows],
-    })
+    return JSONResponse(
+        content={
+            "passes": [r.to_dict() for r in rows],
+        }
+    )
 
 
 @app.post("/api/admin/guest-pass/{pass_id:int}/revoke")
@@ -8251,7 +8463,9 @@ async def post_admin_guest_pass_revoke(pass_id: int, request: Request):
     ok = await run_in_threadpool(_guest_passes.revoke, pass_id)
     log.info(
         "admin action: guest_pass revoke id=%d by %s ok=%s",
-        pass_id, session.get("username"), ok,
+        pass_id,
+        session.get("username"),
+        ok,
     )
     return JSONResponse(content={"ok": ok, "id": pass_id})
 
@@ -8266,6 +8480,7 @@ async def post_admin_signal_state_migrate(request: Request):
         return session_or_err
     session = session_or_err
     from src.api import signal_state_migration as _mig
+
     default_cfg = _league_registry.get_default_league()
     if default_cfg is None:
         return JSONResponse(
@@ -8275,7 +8490,8 @@ async def post_admin_signal_state_migrate(request: Request):
     result = _mig.migrate_all(default_league_key=default_cfg.key)
     log.info(
         "admin action: signal-state migrate by %s — counts=%s",
-        session.get("username"), result.get("counts"),
+        session.get("username"),
+        result.get("counts"),
     )
     return JSONResponse(content=result)
 
@@ -8292,6 +8508,7 @@ async def get_player_realized(sleeper_id: str, request: Request):
     `reason` when no stats are available, rather than 500-ing.
     """
     from src.api import feature_flags as _ff
+
     session = _get_auth_session(request)
     if not session:
         return JSONResponse(status_code=401, content={"error": "auth_required"})
@@ -8318,43 +8535,53 @@ async def get_player_realized(sleeper_id: str, request: Request):
     # current season for freshness + prior season for comparison.
     from src.nfl_data import ingest as _ing
     from src.nfl_data import realized_points as _rp
+
     now_year = datetime.now(timezone.utc).year
     years = [now_year - 1, now_year]
     weekly = _ing.fetch_weekly_stats(years)
 
     if not weekly:
-        return JSONResponse(content={
-            "sleeperId": sleeper_id,
-            "leagueKey": league_cfg.key,
-            "reason": "no_stats_available",
-            "weeks": [],
-            "totalPoints": 0.0,
-            "weekCount": 0,
-        })
+        return JSONResponse(
+            content={
+                "sleeperId": sleeper_id,
+                "leagueKey": league_cfg.key,
+                "reason": "no_stats_available",
+                "weeks": [],
+                "totalPoints": 0.0,
+                "weekCount": 0,
+            }
+        )
 
     # Find this player's GSIS via the unified mapper, then filter.
     from src.identity import unified_mapper as _um
+
     players_dir = sleeper_block.get("players") or sleeper_block.get("playerDict")
     resolved = _um.resolve_player(players_dir, sleeper_id=str(sleeper_id))
     if resolved is None or not resolved.gsis_id:
-        return JSONResponse(content={
-            "sleeperId": sleeper_id,
-            "leagueKey": league_cfg.key,
-            "reason": "unmapped_player",
-            "weeks": [],
-        })
+        return JSONResponse(
+            content={
+                "sleeperId": sleeper_id,
+                "leagueKey": league_cfg.key,
+                "reason": "unmapped_player",
+                "weeks": [],
+            }
+        )
     player_rows = [r for r in weekly if str(r.get("player_id_gsis") or "") == resolved.gsis_id]
     cumulative = _rp.compute_cumulative_points(
-        player_rows, scoring_settings, position=resolved.position,
+        player_rows,
+        scoring_settings,
+        position=resolved.position,
     )
-    return JSONResponse(content={
-        "sleeperId": sleeper_id,
-        "gsisId": resolved.gsis_id,
-        "fullName": resolved.full_name,
-        "position": resolved.position,
-        "leagueKey": league_cfg.key,
-        **cumulative,
-    })
+    return JSONResponse(
+        content={
+            "sleeperId": sleeper_id,
+            "gsisId": resolved.gsis_id,
+            "fullName": resolved.full_name,
+            "position": resolved.position,
+            "leagueKey": league_cfg.key,
+            **cumulative,
+        }
+    )
 
 
 @app.post("/api/trade/simulate-mc")
@@ -8462,9 +8689,12 @@ async def post_trade_simulate_mc(request: Request):
 
     def _run_mc() -> dict:
         base = _sym.simulate_symmetric(
-            side_a, side_b,
-            n_sims=n_sims, same_team_rho=rho_t,
-            same_pos_group_rho=rho_p, seed=seed,
+            side_a,
+            side_b,
+            n_sims=n_sims,
+            same_team_rho=rho_t,
+            same_pos_group_rho=rho_p,
+            seed=seed,
             apply_consolidation_adjustment=apply_ca,
         )
         return _sym.enrich_with_decision_shape(base, side_a, side_b)
@@ -8483,7 +8713,8 @@ async def post_trade_simulate_mc(request: Request):
     except asyncio.TimeoutError:
         log.warning(
             "simulate-mc timed out after %ss (n_sims=%d)",
-            SIMULATE_MC_TIMEOUT_SECONDS, n_sims,
+            SIMULATE_MC_TIMEOUT_SECONDS,
+            n_sims,
         )
         return JSONResponse(
             status_code=504,
@@ -8496,8 +8727,6 @@ async def post_trade_simulate_mc(request: Request):
             },
         )
     return JSONResponse(content=enriched)
-
-
 
 
 @app.post("/api/signal-alerts/run")
@@ -8545,6 +8774,7 @@ async def run_signal_alerts(request: Request):
             status_code=503,
             content={"error": "no_live_contract"},
         )
+
     # Walk every user_kv row.  No pagination — at current scale
     # (dozens of users tops) this is fine.  For each user, loop
     # over every active league: build a league-specific terminal
@@ -8557,15 +8787,18 @@ async def run_signal_alerts(request: Request):
         summary: list[dict] = []
         loaded_league = (
             (latest_contract_data or {}).get("meta", {}).get("leagueKey")
-            if isinstance(latest_contract_data, dict) else None
+            if isinstance(latest_contract_data, dict)
+            else None
         )
         loaded_profile = (
             (latest_contract_data or {}).get("meta", {}).get("scoringProfile")
-            if isinstance(latest_contract_data, dict) else None
+            if isinstance(latest_contract_data, dict)
+            else None
         )
         loaded_sleeper = (
             latest_contract_data.get("sleeper") or {}
-            if isinstance(latest_contract_data, dict) else {}
+            if isinstance(latest_contract_data, dict)
+            else {}
         )
         active_leagues = _league_registry.active_leagues()
         for username, state in db.items():
@@ -8586,17 +8819,16 @@ async def run_signal_alerts(request: Request):
                 # team-map entry and the contract doesn't resolve a
                 # team, they have nothing to alert on here.
                 league_entry = selected_teams.get(cfg.key) or {}
-                league_owner_id = (
-                    str(league_entry.get("ownerId") or "").strip()
-                    or owner_id
-                )
+                league_owner_id = str(league_entry.get("ownerId") or "").strip() or owner_id
                 # Build the league-specific contract.  For the
                 # loaded league this is just latest_contract_data;
                 # for other active leagues we splice in the overlay.
                 if cfg.key == loaded_league:
                     contract = latest_contract_data
                 elif loaded_profile and loaded_profile == cfg.scoring_profile:
-                    id_map = loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else {}
+                    id_map = (
+                        loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else {}
+                    )
                     try:
                         overlay = _sleeper_overlay.fetch_sleeper_overlay(
                             sleeper_league_id=cfg.sleeper_league_id,
@@ -8605,7 +8837,9 @@ async def run_signal_alerts(request: Request):
                     except Exception as exc:  # noqa: BLE001
                         log.warning(
                             "signal-alerts overlay failed for %s / %s: %s",
-                            username, cfg.key, exc,
+                            username,
+                            cfg.key,
+                            exc,
                         )
                         overlay = None
                     if not overlay or not overlay.get("teams"):
@@ -8615,9 +8849,14 @@ async def run_signal_alerts(request: Request):
                     hybrid_sleeper = {
                         **{
                             k: loaded_sleeper.get(k)
-                            for k in ("positions", "playerIds", "idToPlayer",
-                                      "scoringSettings", "rosterPositions",
-                                      "leagueSettings")
+                            for k in (
+                                "positions",
+                                "playerIds",
+                                "idToPlayer",
+                                "scoringSettings",
+                                "rosterPositions",
+                                "leagueSettings",
+                            )
                             if isinstance(loaded_sleeper, dict) and k in loaded_sleeper
                         },
                         **overlay,
@@ -8629,7 +8868,9 @@ async def run_signal_alerts(request: Request):
                     continue
 
                 team = _terminal.resolve_team(
-                    contract, owner_id=league_owner_id, name=None,
+                    contract,
+                    owner_id=league_owner_id,
+                    name=None,
                 )
                 if team is None:
                     # User isn't in this league — nothing to alert on.
@@ -8643,10 +8884,13 @@ async def run_signal_alerts(request: Request):
                         league_key=cfg.key,
                     )
                 except Exception as exc:  # noqa: BLE001
-                    user_summary.append({
-                        "leagueKey": cfg.key, "ok": False,
-                        "reason": f"build_error:{type(exc).__name__}",
-                    })
+                    user_summary.append(
+                        {
+                            "leagueKey": cfg.key,
+                            "ok": False,
+                            "reason": f"build_error:{type(exc).__name__}",
+                        }
+                    )
                     continue
                 result = _signal_alerts.process_user_alerts(
                     username,
@@ -8673,15 +8917,14 @@ async def run_signal_alerts(request: Request):
     try:
         from src.api import ops_alerts as _ops
         from src.utils import circuit_breaker as _cb
+
         status_payload = _scrape_status_payload()
         data_age_hours = None
         loaded_at = latest_data_source.get("loadedAt")
         if loaded_at:
             try:
                 loaded_dt = datetime.fromisoformat(loaded_at)
-                data_age_hours = (
-                    datetime.now(timezone.utc) - loaded_dt
-                ).total_seconds() / 3600.0
+                data_age_hours = (datetime.now(timezone.utc) - loaded_dt).total_seconds() / 3600.0
             except (ValueError, TypeError):
                 pass
         ops_summary = _ops.check_and_alert(
@@ -8706,9 +8949,8 @@ async def run_signal_alerts(request: Request):
     # so we don't re-fire on every sweep.
     try:
         from src.api import source_health_alerts as _sha
-        source_health = _build_source_health_snapshot(
-            latest_data or latest_contract_data
-        )
+
+        source_health = _build_source_health_snapshot(latest_data or latest_contract_data)
         if source_health:
             stale_summary = _sha.check_and_alert(
                 source_health,
@@ -8767,25 +9009,30 @@ async def get_league_articles(request: Request):
     enriched = []
     for entry in items:
         full = _mn.load_article(
-            entry["season"], entry["week"], entry["matchupId"], entry["mode"],
+            entry["season"],
+            entry["week"],
+            entry["matchupId"],
+            entry["mode"],
         )
         if not full:
             continue
-        enriched.append({
-            "season": entry["season"],
-            "week": entry["week"],
-            "mode": entry["mode"],
-            "matchupId": entry["matchupId"],
-            "title": full.get("title"),
-            "kicker": full.get("kicker"),
-            "angleUsed": full.get("angleUsed"),
-            "isChampionship": full.get("isChampionship", False),
-            "roundLabel": full.get("roundLabel", ""),
-            "home": full.get("home", {}),
-            "away": full.get("away", {}),
-            "generatedAt": full.get("generatedAt"),
-            "wordCount": full.get("wordCount", 0),
-        })
+        enriched.append(
+            {
+                "season": entry["season"],
+                "week": entry["week"],
+                "mode": entry["mode"],
+                "matchupId": entry["matchupId"],
+                "title": full.get("title"),
+                "kicker": full.get("kicker"),
+                "angleUsed": full.get("angleUsed"),
+                "isChampionship": full.get("isChampionship", False),
+                "roundLabel": full.get("roundLabel", ""),
+                "home": full.get("home", {}),
+                "away": full.get("away", {}),
+                "generatedAt": full.get("generatedAt"),
+                "wordCount": full.get("wordCount", 0),
+            }
+        )
 
     return JSONResponse(
         content={
@@ -8815,8 +9062,7 @@ async def get_league_article(season: str, week: int, matchup_id: int, mode: str)
             content={
                 "error": "not_found",
                 "message": (
-                    f"No {mode} article on disk for {season} W{week} "
-                    f"matchup {matchup_id}"
+                    f"No {mode} article on disk for {season} W{week} " f"matchup {matchup_id}"
                 ),
             },
         )
@@ -8907,7 +9153,10 @@ async def post_generate_league_article(request: Request):
     if not api_key:
         return JSONResponse(
             status_code=503,
-            content={"error": "anthropic_unavailable", "message": "ANTHROPIC_API_KEY not configured"},
+            content={
+                "error": "anthropic_unavailable",
+                "message": "ANTHROPIC_API_KEY not configured",
+            },
         )
 
     # Build the snapshot off the event loop — it does ~85 HTTP GETs
@@ -8970,7 +9219,9 @@ async def post_generate_league_article(request: Request):
     client = anthropic.AsyncAnthropic(api_key=api_key)
     try:
         article = await _mn.generate_article(
-            client=client, brief=brief, prior_articles=prior,
+            client=client,
+            brief=brief,
+            prior_articles=prior,
         )
     except Exception as exc:  # noqa: BLE001 — collapse SDK / network / parse to one structured error
         # generate_article raises RuntimeError for malformed JSON, but
@@ -8981,8 +9232,11 @@ async def post_generate_league_article(request: Request):
         log.warning(
             "league_article_generation_failed",
             extra={
-                "season": season, "week": week, "matchupId": matchup_id,
-                "mode": mode, "error_type": type(exc).__name__,
+                "season": season,
+                "week": week,
+                "matchupId": matchup_id,
+                "mode": mode,
+                "error_type": type(exc).__name__,
             },
         )
         return JSONResponse(
@@ -9016,7 +9270,9 @@ async def serve_league_entry(request: Request):
     return await _serve_app_shell("/league")
 
 
-def _require_auth_or_redirect(request: Request, default_next: str = "/app") -> RedirectResponse | None:
+def _require_auth_or_redirect(
+    request: Request, default_next: str = "/app"
+) -> RedirectResponse | None:
     if _is_authenticated(request):
         return None
     return _auth_redirect_response(request, default_next)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,1 @@
 """Canonical engine scaffold package."""
-

--- a/src/adapters/base.py
+++ b/src/adapters/base.py
@@ -21,4 +21,3 @@ class SourceAdapter(Protocol):
     source_bucket: str
 
     def load(self, file_path: Path) -> AdapterResult: ...
-

--- a/src/adapters/ktc_crowd_faab.py
+++ b/src/adapters/ktc_crowd_faab.py
@@ -26,6 +26,7 @@ function of its dataclass-shaped inputs and the server endpoint
 can swap in a different crowd source (e.g. RotoBaller, FFC) by
 writing another adapter module without touching the recommender.
 """
+
 from __future__ import annotations
 
 import statistics
@@ -37,10 +38,7 @@ def _normalize_name(name: str) -> str:
     normalization the frontend's ``normName`` uses for picker
     lookups so the bridge's keys agree byte-for-byte with the
     name the API endpoint passes in."""
-    return "".join(
-        c for c in str(name or "").lower()
-        if c.isalnum()
-    )
+    return "".join(c for c in str(name or "").lower() if c.isalnum())
 
 
 def _parse_bid_pct(bid_pct_raw: Any, bid: Any, settings: dict | None = None) -> float | None:

--- a/src/adapters/scraper_bridge_adapter.py
+++ b/src/adapters/scraper_bridge_adapter.py
@@ -14,6 +14,7 @@ When ``signal_type="value"``, the CSV's ``value`` column is stored as
 ``value_raw`` on the record.  When ``signal_type="rank"``, it is stored
 as ``rank_raw`` instead.
 """
+
 from __future__ import annotations
 
 import csv
@@ -70,10 +71,7 @@ class ScraperBridgeAdapter:
             reader = csv.DictReader(f)
             for row in reader:
                 name = str(
-                    row.get("name")
-                    or row.get("player")
-                    or row.get("player_name")
-                    or ""
+                    row.get("name") or row.get("player") or row.get("player_name") or ""
                 ).strip()
                 if not name:
                     continue

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,2 +1,1 @@
 """API layer scaffold for the canonical engine."""
-

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -27,6 +27,7 @@ Cost shape at Opus 4.7 pricing (April 2026 baseline):
   * each follow-up turn: ~$0.03-$0.05 (cache read + output)
   * budget ~$5-15/month for private use
 """
+
 from __future__ import annotations
 
 import json
@@ -144,9 +145,7 @@ def build_data_snapshot(contract_or_raw: Any) -> str:
         return "[Board has no player entries.]\n"
 
     generated_at = (
-        contract_or_raw.get("generatedAt")
-        or contract_or_raw.get("scrapeTimestamp")
-        or ""
+        contract_or_raw.get("generatedAt") or contract_or_raw.get("scrapeTimestamp") or ""
     )
 
     lines: list[str] = []
@@ -183,9 +182,7 @@ def build_data_snapshot(contract_or_raw: Any) -> str:
         src_count = row.get("sourceCount")
         src_count_str = str(int(src_count)) if isinstance(src_count, int) else ""
         pspread = row.get("sourceRankPercentileSpread")
-        pspread_str = (
-            f"{float(pspread):.3f}" if isinstance(pspread, (int, float)) else ""
-        )
+        pspread_str = f"{float(pspread):.3f}" if isinstance(pspread, (int, float)) else ""
         flags_raw = row.get("anomalyFlags") or []
         flags = ",".join(sorted(str(f) for f in flags_raw)) if isinstance(flags_raw, list) else ""
         tier = row.get("canonicalTierId")

--- a/src/api/compact_view.py
+++ b/src/api/compact_view.py
@@ -33,37 +33,42 @@ Shape tests in ``tests/api/test_compact_view`` pin the
 contract so adding a field to this list either updates tests
 or is caught.
 """
+
 from __future__ import annotations
 
 from typing import Any
 
-_PRUNED_CONTRACT_FIELDS = frozenset({
-    "poolAudit",
-    "methodology",
-    "siteStats",
-    "sites",  # leave sleeper.sites in place
-})
+_PRUNED_CONTRACT_FIELDS = frozenset(
+    {
+        "poolAudit",
+        "methodology",
+        "siteStats",
+        "sites",  # leave sleeper.sites in place
+    }
+)
 
-_PRUNED_PLAYER_FIELDS = frozenset({
-    "droppedSources",
-    "effectiveSourceRanks",
-    "sourceOriginalRanks",
-    "anomalyFlags",
-    "confidenceLabel",
-    "pickDetails",
-    "marketCorridorClamp",
-    "twoWayPlayerBoost",
-    # Post-pipeline audit fields — kept in the full view, pruned here.
-    "subgroupBlendValue",
-    "subgroupDelta",
-    "alphaShrinkage",
-    "softFallbackCount",
-    "hillValueSpread",
-    "marketDispersionCV",
-    "blendedSourceRank",
-    "madPenaltyApplied",
-    "anchorValue",
-})
+_PRUNED_PLAYER_FIELDS = frozenset(
+    {
+        "droppedSources",
+        "effectiveSourceRanks",
+        "sourceOriginalRanks",
+        "anomalyFlags",
+        "confidenceLabel",
+        "pickDetails",
+        "marketCorridorClamp",
+        "twoWayPlayerBoost",
+        # Post-pipeline audit fields — kept in the full view, pruned here.
+        "subgroupBlendValue",
+        "subgroupDelta",
+        "alphaShrinkage",
+        "softFallbackCount",
+        "hillValueSpread",
+        "marketDispersionCV",
+        "blendedSourceRank",
+        "madPenaltyApplied",
+        "anchorValue",
+    }
+)
 
 # Per-source meta fields kept on the compact view.  Drives the trade
 # per-source winner card (``valueContribution``), the rankings audit
@@ -71,11 +76,13 @@ _PRUNED_PLAYER_FIELDS = frozenset({
 # and the PlayerPopup source-contribution graphs (``valueContribution``).
 # Audit-only stamps (percentile, isAnchor, TEP correction flags, etc.)
 # are dropped on mobile to keep the payload small.
-_SLIM_SOURCE_RANK_META_FIELDS = frozenset({
-    "valueContribution",
-    "effectiveWeight",
-    "method",
-})
+_SLIM_SOURCE_RANK_META_FIELDS = frozenset(
+    {
+        "valueContribution",
+        "effectiveWeight",
+        "method",
+    }
+)
 
 
 def _slim_source_rank_meta(meta: Any) -> Any:
@@ -87,8 +94,7 @@ def _slim_source_rank_meta(meta: Any) -> Any:
     for src_key, src_meta in meta.items():
         if isinstance(src_meta, dict):
             slim[src_key] = {
-                k: v for k, v in src_meta.items()
-                if k in _SLIM_SOURCE_RANK_META_FIELDS
+                k: v for k, v in src_meta.items() if k in _SLIM_SOURCE_RANK_META_FIELDS
             }
         else:
             # Defensive: preserve unexpected shapes verbatim so tests
@@ -138,15 +144,19 @@ def compact_contract(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def byte_savings(
-    full_payload: dict[str, Any], compact_payload: dict[str, Any],
+    full_payload: dict[str, Any],
+    compact_payload: dict[str, Any],
 ) -> dict[str, int]:
     """Diagnostic: JSON byte sizes of full vs. compact."""
     import json
+
     full_bytes = len(json.dumps(full_payload).encode("utf-8"))
     compact_bytes = len(json.dumps(compact_payload).encode("utf-8"))
     return {
         "fullBytes": full_bytes,
         "compactBytes": compact_bytes,
         "savedBytes": max(0, full_bytes - compact_bytes),
-        "savedPct": round((full_bytes - compact_bytes) / full_bytes * 100, 1) if full_bytes else 0.0,
+        "savedPct": round((full_bytes - compact_bytes) / full_bytes * 100, 1)
+        if full_bytes
+        else 0.0,
     }

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -34,9 +34,9 @@ _LOGGER = logging.getLogger(__name__)
 #: contradiction anymore.
 OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS: frozenset[str] = frozenset(
     {
-        "Josh Johnson",     # QB (retired journeyman) vs S (draftable prospect)
+        "Josh Johnson",  # QB (retired journeyman) vs S (draftable prospect)
         "Elijah Mitchell",  # RB (HOU backup) vs DB (draftable prospect) — Sleeper pos
-                            # map resolves to the DB; scraper has only the RB's KTC value
+        # map resolves to the DB; scraper has only the RB's KTC value
     }
 )
 
@@ -176,9 +176,7 @@ _HAMPEL_K = 2.75
 _HAMPEL_MIN_N = 4
 _HAMPEL_MIN_THRESHOLD = 1000.0
 
-_RETIRED_INVALID_PATTERNS = re.compile(
-    r"(?i)\b(retired|invalid|test|unknown|placeholder)\b"
-)
+_RETIRED_INVALID_PATTERNS = re.compile(r"(?i)\b(retired|invalid|test|unknown|placeholder)\b")
 _OL_POSITIONS = {"OL", "OT", "OG", "C", "G", "T"}
 
 # ── Identity validation constants ────────────────────────────────────────────
@@ -616,10 +614,7 @@ def _load_source_row_floors() -> dict[str, int]:
             current_mtime = None
     cached_mtime = _SOURCE_ROW_FLOORS_CACHE.get("mtime")
     cached_value = _SOURCE_ROW_FLOORS_CACHE.get("value")
-    if (
-        isinstance(cached_value, dict)
-        and cached_mtime == current_mtime
-    ):
+    if isinstance(cached_value, dict) and cached_mtime == current_mtime:
         return dict(cached_value)
     if cfg_path.exists():
         try:
@@ -637,9 +632,7 @@ def _load_source_row_floors() -> dict[str, int]:
                 _SOURCE_ROW_FLOORS_CACHE["value"] = merged
                 return dict(merged)
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.warning(
-                "Failed to load source_row_floors.json (%s); using defaults", exc
-            )
+            _LOGGER.warning("Failed to load source_row_floors.json (%s); using defaults", exc)
     default = dict(_DEFAULT_SOURCE_ROW_FLOORS)
     _SOURCE_ROW_FLOORS_CACHE["mtime"] = current_mtime
     _SOURCE_ROW_FLOORS_CACHE["value"] = default
@@ -702,10 +695,7 @@ def _load_top50_coverage_floors() -> dict[str, dict[str, int]]:
             current_mtime = None
     cached_mtime = _TOP50_COVERAGE_FLOORS_CACHE.get("mtime")
     cached_value = _TOP50_COVERAGE_FLOORS_CACHE.get("value")
-    if (
-        isinstance(cached_value, dict)
-        and cached_mtime == current_mtime
-    ):
+    if isinstance(cached_value, dict) and cached_mtime == current_mtime:
         return {k: dict(v) for k, v in cached_value.items()}
     merged: dict[str, dict[str, int]] = {
         k: dict(v) for k, v in _DEFAULT_TOP50_COVERAGE_FLOORS.items()
@@ -818,6 +808,7 @@ def _build_source_timestamps() -> dict[str, dict[str, Any]]:
                 entry["staleness"] = "fresh" if age_hours < max_age else "stale"
         out[source_key] = entry
     return out
+
 
 # ── Ranking source registry ──────────────────────────────────────────────
 # Declarative metadata describing each source that feeds the unified
@@ -1911,9 +1902,7 @@ def get_ranking_source_registry() -> list[dict[str, Any]]:
         entry: dict[str, Any] = {
             "key": str(src.get("key") or ""),
             "displayName": str(src.get("display_name") or ""),
-            "columnLabel": str(
-                src.get("column_label") or src.get("display_name") or ""
-            ),
+            "columnLabel": str(src.get("column_label") or src.get("display_name") or ""),
             "scope": str(src.get("scope") or ""),
             "extraScopes": list(src.get("extra_scopes") or []),
             "positionGroup": src.get("position_group"),
@@ -1923,9 +1912,7 @@ def get_ranking_source_registry() -> list[dict[str, Any]]:
             "isRetail": bool(src.get("is_retail")),
             "isTepPremium": bool(src.get("is_tep_premium")),
             "isRankSignal": bool(src.get("is_rank_signal")),
-            "needsSharedMarketTranslation": bool(
-                src.get("needs_shared_market_translation")
-            ),
+            "needsSharedMarketTranslation": bool(src.get("needs_shared_market_translation")),
             "excludesRookies": bool(src.get("excludes_rookies")),
         }
         out.append(entry)
@@ -2064,9 +2051,7 @@ def normalize_source_overrides(
     if raw is None:
         return out, warnings
     if not isinstance(raw, dict):
-        warnings.append(
-            f"Top-level overrides must be an object; got {type(raw).__name__}"
-        )
+        warnings.append(f"Top-level overrides must be an object; got {type(raw).__name__}")
         return out, warnings
 
     # ── Explicit request body: {"enabled_sources": [...], "weights": {...}} ──
@@ -2078,9 +2063,7 @@ def normalize_source_overrides(
     if explicit_enabled is not None or isinstance(explicit_weights, dict):
         if explicit_enabled is not None:
             if not isinstance(explicit_enabled, (list, tuple, set)):
-                warnings.append(
-                    "enabled_sources must be a list of source keys; ignoring"
-                )
+                warnings.append("enabled_sources must be a list of source keys; ignoring")
                 enabled_set: set[str] = valid_keys
             else:
                 enabled_set = set()
@@ -2089,9 +2072,7 @@ def normalize_source_overrides(
                     if k in valid_keys:
                         enabled_set.add(k)
                     else:
-                        warnings.append(
-                            f"enabled_sources: unknown source '{k}' (ignored)"
-                        )
+                        warnings.append(f"enabled_sources: unknown source '{k}' (ignored)")
         else:
             enabled_set = set(valid_keys)
 
@@ -2105,21 +2086,15 @@ def normalize_source_overrides(
             for key, value in explicit_weights.items():
                 k = str(key)
                 if k not in valid_keys:
-                    warnings.append(
-                        f"weights: unknown source '{k}' (ignored)"
-                    )
+                    warnings.append(f"weights: unknown source '{k}' (ignored)")
                     continue
                 try:
                     w = float(value)
                 except (TypeError, ValueError):
-                    warnings.append(
-                        f"weights[{k}]: value '{value}' is not a number (ignored)"
-                    )
+                    warnings.append(f"weights[{k}]: value '{value}' is not a number (ignored)")
                     continue
                 if not math.isfinite(w) or w < 0:
-                    warnings.append(
-                        f"weights[{k}]: value {w} is not non-negative finite (ignored)"
-                    )
+                    warnings.append(f"weights[{k}]: value {w} is not non-negative finite (ignored)")
                     continue
                 out.setdefault(k, {})["weight"] = w
 
@@ -2137,9 +2112,7 @@ def normalize_source_overrides(
             warnings.append(f"Unknown source '{k}' (ignored)")
             continue
         if not isinstance(value, dict):
-            warnings.append(
-                f"Override for '{k}' must be an object; got {type(value).__name__}"
-            )
+            warnings.append(f"Override for '{k}' must be an object; got {type(value).__name__}")
             continue
         entry = {}
         if "include" in value:
@@ -2154,16 +2127,12 @@ def normalize_source_overrides(
             try:
                 w = float(value.get("weight"))
             except (TypeError, ValueError):
-                warnings.append(
-                    f"Override '{k}'.weight must be a number (ignored)"
-                )
+                warnings.append(f"Override '{k}'.weight must be a number (ignored)")
             else:
                 if math.isfinite(w) and w >= 0:
                     entry["weight"] = w
                 else:
-                    warnings.append(
-                        f"Override '{k}'.weight must be non-negative finite (ignored)"
-                    )
+                    warnings.append(f"Override '{k}'.weight must be non-negative finite (ignored)")
         if entry:
             out[k] = entry
     return out, warnings
@@ -2357,9 +2326,7 @@ def assert_ranking_source_registry_parity(
     js_keys = [str(s.get("key") or "") for s in (frontend_registry or [])]
     if py_keys != js_keys:
         errors.append(
-            "Registry key order/mismatch:\n"
-            f"  python: {py_keys}\n"
-            f"  frontend: {js_keys}"
+            "Registry key order/mismatch:\n" f"  python: {py_keys}\n" f"  frontend: {js_keys}"
         )
         return errors
 
@@ -2382,9 +2349,7 @@ def assert_ranking_source_registry_parity(
                 js_val = list(js_val or [])
             if field == "weight":
                 if float(py_val or 0) != float(js_val or 0):
-                    errors.append(
-                        f"{key}.weight: python={py_val} frontend={js_val}"
-                    )
+                    errors.append(f"{key}.weight: python={py_val} frontend={js_val}")
                 continue
             if py_val != js_val:
                 errors.append(f"{key}.{field}: python={py_val} frontend={js_val}")
@@ -2419,6 +2384,7 @@ def _effective_source_weight(
     except (TypeError, ValueError):
         return default
     import math as _m
+
     if not _m.isfinite(w) or w < 0:
         return default
     return w
@@ -2485,14 +2451,10 @@ def _compute_market_gap(
         retail_keys = _retail_source_keys()
 
     retail_ranks = [
-        rank
-        for key, rank in source_ranks.items()
-        if key in retail_keys and rank is not None
+        rank for key, rank in source_ranks.items() if key in retail_keys and rank is not None
     ]
     consensus_ranks = [
-        rank
-        for key, rank in source_ranks.items()
-        if key not in retail_keys and rank is not None
+        rank for key, rank in source_ranks.items() if key not in retail_keys and rank is not None
     ]
     if not retail_ranks or not consensus_ranks:
         return "none", None
@@ -2515,6 +2477,7 @@ def _normalize_for_collision(name: str) -> str:
     would collide in the identity pipeline.
     """
     from src.utils.name_clean import normalize_player_name  # noqa: PLC0415
+
     return normalize_player_name(name)
 
 
@@ -2543,13 +2506,9 @@ def _compute_identity_confidence(
     canonical_sites = row.get("canonicalSiteValues") or {}
 
     has_off_val = any(
-        (_to_int_or_none(canonical_sites.get(k)) or 0) > 0
-        for k in _OFFENSE_SIGNAL_KEYS
+        (_to_int_or_none(canonical_sites.get(k)) or 0) > 0 for k in _OFFENSE_SIGNAL_KEYS
     )
-    has_idp_val = any(
-        (_to_int_or_none(canonical_sites.get(k)) or 0) > 0
-        for k in _IDP_SIGNAL_KEYS
-    )
+    has_idp_val = any((_to_int_or_none(canonical_sites.get(k)) or 0) > 0 for k in _IDP_SIGNAL_KEYS)
 
     if has_id:
         return 1.00, "canonical_id"
@@ -2639,13 +2598,13 @@ def _validate_and_quarantine_rows(
     for posaware, indices in posaware_to_rows.items():
         if len(indices) < 2:
             continue
-        names_involved = sorted({
-            str(players_array[i].get("canonicalName") or "") for i in indices
-        })
-        duplicate_identity_pairs.append({
-            "canonicalKey": posaware,
-            "names": names_involved,
-        })
+        names_involved = sorted({str(players_array[i].get("canonicalName") or "") for i in indices})
+        duplicate_identity_pairs.append(
+            {
+                "canonicalKey": posaware,
+                "names": names_involved,
+            }
+        )
         for i in indices:
             row = players_array[i]
             flags = row.get("anomalyFlags") or []
@@ -2665,11 +2624,13 @@ def _validate_and_quarantine_rows(
         asset_classes = {players_array[i].get("assetClass") for i in indices}
         if "offense" in asset_classes and "idp" in asset_classes:
             names_involved = [players_array[i].get("canonicalName") for i in indices]
-            collision_pairs.append({
-                "normalizedName": norm,
-                "names": names_involved,
-                "assetClasses": list(asset_classes),
-            })
+            collision_pairs.append(
+                {
+                    "normalizedName": norm,
+                    "names": names_involved,
+                    "assetClasses": list(asset_classes),
+                }
+            )
             for i in indices:
                 row = players_array[i]
                 flags = row.get("anomalyFlags") or []
@@ -2696,20 +2657,16 @@ def _validate_and_quarantine_rows(
         canonical_sites = row.get("canonicalSiteValues") or {}
 
         has_off_val = any(
-            (_to_int_or_none(canonical_sites.get(k)) or 0) > 0
-            for k in _OFFENSE_SIGNAL_KEYS
+            (_to_int_or_none(canonical_sites.get(k)) or 0) > 0 for k in _OFFENSE_SIGNAL_KEYS
         )
         has_idp_val = any(
-            (_to_int_or_none(canonical_sites.get(k)) or 0) > 0
-            for k in _IDP_SIGNAL_KEYS
+            (_to_int_or_none(canonical_sites.get(k)) or 0) > 0 for k in _IDP_SIGNAL_KEYS
         )
 
         current_flags = row.get("anomalyFlags") or []
         has_collision = "name_collision_cross_universe" in current_flags
         name = row.get("canonicalName") or ""
-        is_known_collision = (
-            has_collision and name in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
-        )
+        is_known_collision = has_collision and name in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
 
         # Offense position but only IDP values.
         if pos in _OFFENSE_POSITIONS and has_idp_val and not has_off_val:
@@ -2750,10 +2707,7 @@ def _validate_and_quarantine_rows(
     # ── Check 5: No valid source values but has derived value ──
     for idx, row in enumerate(players_array):
         canonical_sites = row.get("canonicalSiteValues") or {}
-        has_any_source = any(
-            (_to_int_or_none(v) or 0) > 0
-            for v in canonical_sites.values()
-        )
+        has_any_source = any((_to_int_or_none(v) or 0) > 0 for v in canonical_sites.values())
         rdv = row.get("rankDerivedValue")
         if not has_any_source and rdv is not None and rdv > 0:
             flags = row.get("anomalyFlags") or []
@@ -2777,9 +2731,7 @@ def _validate_and_quarantine_rows(
             current_bucket = row.get("confidenceBucket") or "none"
             if current_bucket in ("high", "medium"):
                 row["confidenceBucket"] = "low"
-                row["confidenceLabel"] = (
-                    "Low — quarantined due to identity/data-quality flags"
-                )
+                row["confidenceLabel"] = "Low — quarantined due to identity/data-quality flags"
         else:
             row["quarantined"] = False
 
@@ -2949,12 +2901,10 @@ def _strip_mismatched_family_tags(players_array: list[dict[str, Any]]) -> None:
         if not isinstance(canonical_sites, dict):
             continue
         has_off = any(
-            _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
-            for k in _OFFENSE_SIGNAL_KEYS
+            _to_int_or_none(canonical_sites.get(k)) not in (None, 0) for k in _OFFENSE_SIGNAL_KEYS
         )
         has_idp = any(
-            _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
-            for k in _IDP_SIGNAL_KEYS
+            _to_int_or_none(canonical_sites.get(k)) not in (None, 0) for k in _IDP_SIGNAL_KEYS
         )
         if pos in _IDP_POSITIONS and has_off and not has_idp:
             row["position"] = None
@@ -2968,7 +2918,9 @@ def _strip_mismatched_family_tags(players_array: list[dict[str, Any]]) -> None:
 # functions of file contents, so any rebuild that happens before the CSV
 # is re-scraped can skip the parse entirely.  Cache key is the absolute
 # csv path string; the value is a 3-tuple of (mtime, csv_lookup, schema_err).
-_SOURCE_CSV_PARSE_CACHE: dict[str, tuple[float, dict[str, list[tuple[str, int, float | None]]], dict[str, str] | None]] = {}
+_SOURCE_CSV_PARSE_CACHE: dict[
+    str, tuple[float, dict[str, list[tuple[str, int, float | None]]], dict[str, str] | None]
+] = {}
 _FP_META_CSV_CACHE: dict[str, tuple[float, dict[str, dict[str, Any]]]] = {}
 
 
@@ -3100,10 +3052,7 @@ def _parse_source_csv_cached(
                     if rank_val <= 0:
                         continue
                     synthetic = int(
-                        round(
-                            (_RANK_TO_SYNTHETIC_VALUE_OFFSET * 100)
-                            - (rank_val * 100)
-                        )
+                        round((_RANK_TO_SYNTHETIC_VALUE_OFFSET * 100) - (rank_val * 100))
                     )
                     if synthetic <= 0:
                         continue
@@ -3127,9 +3076,7 @@ def _parse_source_csv_cached(
                         except (TypeError, ValueError):
                             orig_rank = None
                     try:
-                        csv_lookup.setdefault(key, []).append(
-                            (name, int(float(val)), orig_rank)
-                        )
+                        csv_lookup.setdefault(key, []).append((name, int(float(val)), orig_rank))
                     except (ValueError, TypeError):
                         continue
     except Exception as exc:  # noqa: BLE001
@@ -3191,9 +3138,7 @@ def _parse_fp_meta_csv_cached(fp_path: Path) -> dict[str, dict[str, Any]]:
                 "fantasyProsIdpDerivationMethod": str(
                     row_csv.get("derivationMethod") or ""
                 ).strip(),
-                "fantasyProsIdpFamily": str(
-                    row_csv.get("family") or ""
-                ).strip(),
+                "fantasyProsIdpFamily": str(row_csv.get("family") or "").strip(),
                 "fantasyProsIdpNormalizedValue": norm_v,
                 "fantasyProsIdpMatchedSourceName": str(
                     row_csv.get("matchedSourceName") or nm
@@ -3273,6 +3218,7 @@ def _enrich_from_source_csvs(
         if not cname:
             continue
         from src.utils.name_clean import canonical_position_group  # noqa: PLC0415
+
         grp = canonical_position_group(row.get("position"))
         row_groups_by_key.setdefault(cname, set()).add(grp)
 
@@ -3297,14 +3243,10 @@ def _enrich_from_source_csvs(
                         "error": "file_not_found",
                     }
                 )
-                _LOGGER.warning(
-                    "Source CSV missing for %s: %s", source_key, csv_rel
-                )
+                _LOGGER.warning("Source CSV missing for %s: %s", source_key, csv_rel)
             continue
 
-        csv_lookup, schema_err = _parse_source_csv_cached(
-            csv_path, source_key, signal, csv_rel
-        )
+        csv_lookup, schema_err = _parse_source_csv_cached(csv_path, source_key, signal, csv_rel)
         if schema_err is not None:
             if parse_errors is not None:
                 parse_errors.append(schema_err)
@@ -3328,9 +3270,7 @@ def _enrich_from_source_csvs(
         if source_key == "dlfRookieSf":
             csv_lookup = {k: list(v) for k, v in csv_lookup.items()}
             _flat = [
-                (disp, syn, rnk)
-                for entries in csv_lookup.values()
-                for (disp, syn, rnk) in entries
+                (disp, syn, rnk) for entries in csv_lookup.values() for (disp, syn, rnk) in entries
             ]
             _flat.sort(key=lambda t: (-t[1], str(t[0]).lower()))
             _dlf_league_size = _resolve_league_roster_count()
@@ -3344,15 +3284,14 @@ def _enrich_from_source_csvs(
                 _pick_key = _canonical_match_key(_pick_name)
                 if not _pick_key:
                     continue
-                csv_lookup.setdefault(_pick_key, []).append(
-                    (_pick_name, _syn, float(rookie_rank))
-                )
+                csv_lookup.setdefault(_pick_key, []).append((_pick_name, _syn, float(rookie_rank)))
 
         # Persist a structured per-source entry index keyed by the
         # *position-aware* canonical key so downstream code can audit
         # exactly which CSV row matched each player row.  We resolve
         # duplicates by best-of-value within the same position group.
         from src.utils.name_clean import canonical_position_group  # noqa: PLC0415
+
         per_source: dict[str, dict[str, Any]] = {}
         for cname, entries in csv_lookup.items():
             # Quick pre-pass: figure out which position groups the
@@ -3403,8 +3342,7 @@ def _enrich_from_source_csvs(
             # finite value); for everyone else we require > 0 so a
             # stale zero doesn't block the enrichment from re-running.
             if existing is not None and (
-                existing > 0
-                or (source_key in ds_combined_rank_keys and existing <= 0)
+                existing > 0 or (source_key in ds_combined_rank_keys and existing <= 0)
             ):
                 continue
             nm = str(row.get("canonicalName") or row.get("displayName") or "")
@@ -3435,9 +3373,7 @@ def _enrich_from_source_csvs(
             # source requires > 0 to distinguish "ranked" from
             # "missing/zero".
             negatives_allowed = source_key in ds_combined_rank_keys
-            accept = val is not None and (
-                val > 0 if not negatives_allowed else True
-            )
+            accept = val is not None and (val > 0 if not negatives_allowed else True)
             if accept:
                 csv_vals[source_key] = val
                 # For rank-signal sources, preserve the original CSV rank
@@ -3459,18 +3395,14 @@ def _enrich_from_source_csvs(
     # generic enrichment above and a future refactor of one cannot
     # silently break the other.
     fp_cfg = _SOURCE_CSV_PATHS.get("fantasyProsIdp")
-    fp_rel = (
-        fp_cfg.get("path") if isinstance(fp_cfg, dict) else (fp_cfg or "")
-    )
+    fp_rel = fp_cfg.get("path") if isinstance(fp_cfg, dict) else (fp_cfg or "")
     if fp_rel:
         fp_path = repo / fp_rel
         if fp_path.exists():
             try:
                 fp_meta_lookup = _parse_fp_meta_csv_cached(fp_path)
                 for row in players_array:
-                    nm = str(
-                        row.get("canonicalName") or row.get("displayName") or ""
-                    )
+                    nm = str(row.get("canonicalName") or row.get("displayName") or "")
                     if not nm:
                         continue
                     key = _canonical_match_key(nm)
@@ -3491,9 +3423,7 @@ def _enrich_from_source_csvs(
                     for k, v in meta.items():
                         row[k] = v
             except Exception as exc:  # noqa: BLE001
-                _LOGGER.warning(
-                    "FantasyPros IDP metadata stamp failed: %s", exc
-                )
+                _LOGGER.warning("FantasyPros IDP metadata stamp failed: %s", exc)
 
     return csv_index
 
@@ -3642,9 +3572,7 @@ _PICK_SLOT_RE = re.compile(r"^(20\d{2})\s+Pick\s+([1-6])\.(0?[1-9]|1[0-2])$", re
 # Regex matching generic tier pick names like "2026 Early 1st" — used
 # by the generic-tier suppression pass to detect rows that should be
 # moved to ``pickAliases`` when slot-specific siblings exist.
-_PICK_TIER_RE = re.compile(
-    r"^(20\d{2})\s+(Early|Mid|Late)\s+([1-6])(st|nd|rd|th)$", re.I
-)
+_PICK_TIER_RE = re.compile(r"^(20\d{2})\s+(Early|Mid|Late)\s+([1-6])(st|nd|rd|th)$", re.I)
 
 # Pick year discount is loaded once per build from
 # config/weights/pick_year_discount.json.  See the file header for the
@@ -3690,9 +3618,7 @@ def _load_pick_year_discount() -> dict[str, Any]:
             cfg["baselineYear"] = int(loaded.get("baselineYear") or 2026)
             raw_discounts = loaded.get("discounts") or {}
             if isinstance(raw_discounts, dict):
-                cfg["discounts"] = {
-                    str(k): float(v) for k, v in raw_discounts.items()
-                }
+                cfg["discounts"] = {str(k): float(v) for k, v in raw_discounts.items()}
             cfg["fallbackBase"] = float(loaded.get("fallbackBase") or 0.80)
     except (OSError, ValueError, TypeError):
         # Stick with the built-in default — never block the build on
@@ -3795,8 +3721,14 @@ _MARKET_ANCHOR_BY_ASSET_CLASS: dict[str, str] = {
 # entirely and the IDP calibration's 3-4× DB bucket multipliers can
 # inflate a 1500-point uncalibrated value into a top-50 finish.
 _MARKET_ANCHOR_FALLBACKS: dict[str, list[str]] = {
-    "offense": ["ktcSfTep", "idpTradeCalc", "dynastyDaddySf", "fantasyProsFitzmaurice", "yahooBoone"],
-    "idp":     ["idpTradeCalc", "dlfIdp", "idpShow", "fantasyProsIdp", "footballGuysIdp"],
+    "offense": [
+        "ktcSfTep",
+        "idpTradeCalc",
+        "dynastyDaddySf",
+        "fantasyProsFitzmaurice",
+        "yahooBoone",
+    ],
+    "idp": ["idpTradeCalc", "dlfIdp", "idpShow", "fantasyProsIdp", "footballGuysIdp"],
 }
 
 # Percentile at which we declare a drift "too extreme" and clamp it.
@@ -4028,9 +3960,7 @@ def _apply_market_corridor_clamp(
     bucket_bands: dict[str, float] = {}
     for bucket, vals in by_bucket.items():
         if len(vals) >= _MARKET_CORRIDOR_MIN_BUCKET_N:
-            bucket_bands[bucket] = _percentile(
-                sorted(vals), _MARKET_CORRIDOR_PERCENTILE
-            )
+            bucket_bands[bucket] = _percentile(sorted(vals), _MARKET_CORRIDOR_PERCENTILE)
         else:
             bucket_bands[bucket] = overall_p90
 
@@ -4098,10 +4028,7 @@ def _get_rank_snapshot_path() -> "Path":
     global _RANK_SNAPSHOT_PATH
     if _RANK_SNAPSHOT_PATH is None:
         _RANK_SNAPSHOT_PATH = (
-            _Path(__file__).resolve().parents[2]
-            / "data"
-            / "snapshots"
-            / "ranks_last.json"
+            _Path(__file__).resolve().parents[2] / "data" / "snapshots" / "ranks_last.json"
         )
     return _RANK_SNAPSHOT_PATH
 
@@ -4224,6 +4151,7 @@ def _apply_two_way_player_boost(
         IDP_HILL_PERCENTILE_S,
         percentile_to_value,
     )
+
     # Collect IDP signal sources (the ones that could contribute to
     # an alt-family value for an offense-classed player).
     idp_source_keys = {
@@ -4287,9 +4215,7 @@ def _apply_two_way_player_boost(
                     alt_source_values.append(syn / max_native * 9999.0)
                     used_sources.append(key)
                 continue
-            rank = int(round(
-                (_RANK_TO_SYNTHETIC_VALUE_OFFSET * 100 - syn) / 100
-            ))
+            rank = int(round((_RANK_TO_SYNTHETIC_VALUE_OFFSET * 100 - syn) / 100))
             if rank <= 0:
                 continue
             # Percentile → Hill value.  Use the IDP master curve
@@ -4336,7 +4262,6 @@ def _apply_two_way_player_boost(
             if isinstance(pdata, dict):
                 pdata["rankDerivedValue"] = boosted
                 pdata["twoWayPlayerBoost"] = dict(row["twoWayPlayerBoost"])
-
 
 
 _DISPLAY_SCALE_MAX: int = 9999
@@ -4399,11 +4324,16 @@ def _build_hill_curves_block() -> dict[str, dict[str, Any]]:
         }
 
     return {
-        "global":  _entry("global",  "Global",  HILL_GLOBAL_PERCENTILE_C, HILL_GLOBAL_PERCENTILE_S, True),
-        "offense": _entry("offense", "Offense", HILL_PERCENTILE_C,        HILL_PERCENTILE_S,        True),
-        "idp":     _entry("idp",     "IDP",     IDP_HILL_PERCENTILE_C,    IDP_HILL_PERCENTILE_S,    True),
-        "rookie":  _entry("rookie",  "Rookie",  HILL_ROOKIE_PERCENTILE_C, HILL_ROOKIE_PERCENTILE_S, False),
+        "global": _entry(
+            "global", "Global", HILL_GLOBAL_PERCENTILE_C, HILL_GLOBAL_PERCENTILE_S, True
+        ),
+        "offense": _entry("offense", "Offense", HILL_PERCENTILE_C, HILL_PERCENTILE_S, True),
+        "idp": _entry("idp", "IDP", IDP_HILL_PERCENTILE_C, IDP_HILL_PERCENTILE_S, True),
+        "rookie": _entry(
+            "rookie", "Rookie", HILL_ROOKIE_PERCENTILE_C, HILL_ROOKIE_PERCENTILE_S, False
+        ),
     }
+
 
 # Final Framework step 8: subgroup shrinkage factor.
 #
@@ -4501,43 +4431,43 @@ _MAD_PENALTY_LAMBDA: float = 0.0
 # if someone adds a new negative-scale source to the registry they
 # only have to flip ``ds_combined_rank_partner``.
 _DS_COMBINED_RANK_KEYS: frozenset[str] = frozenset(
-    str(src.get("key") or "")
-    for src in _RANKING_SOURCES
-    if src.get("ds_combined_rank_partner")
+    str(src.get("key") or "") for src in _RANKING_SOURCES if src.get("ds_combined_rank_partner")
 )
 
 
-_VALUE_BASED_SOURCES: frozenset[str] = frozenset({
-    # ``ktcSfTep`` carries native 0-9999 values from KTC's TE+ sub-board.
-    # Standard ``ktc`` was retired from the blend 2026-04-28 (its values
-    # are still loaded into canonicalSiteValues for the arbitrage finder
-    # + per-source winner display, but it no longer votes).
-    "ktcSfTep",
-    "idpTradeCalc",
-    # ``fantasyCalc`` carries the FantasyCalc public API's crowd-sourced
-    # dynasty SF+TEP values.  Unlike Dynasty Daddy / Yahoo Boone /
-    # Fitzmaurice, FantasyCalc's value distribution is well-spread
-    # across the board with no display-cap clustering at the top, so
-    # the value-direct path preserves cross-position separation
-    # faithfully (e.g. top WR's value vs top RB's value carries real
-    # signal, not just an arbitrary cap).
-    "fantasyCalc",
-    # ``otcffbSf`` carries OTCFFB's trade-derived 0-100 SF values.
-    # Same shape rationale as FantasyCalc: well-spread distribution,
-    # no top-of-curve display cap (Bijan=100, Allen=96, Gibbs=95.1
-    # cleanly differentiate), so the value-direct path is appropriate.
-    "otcffbSf",
-    # ``dynastyDaddySf``, ``yahooBoone``, and ``fantasyProsFitzmaurice``
-    # were moved to the rank-signal path 2026-04-22 after the Hampel
-    # audit flagged 61% / 47% / 19% drop rates respectively — all three
-    # have compressed top-of-curve value distributions (DynastyDaddy's
-    # 10,200 cap with top 3 tied; Boone's 141 top with seven players
-    # ≥110; Fitzmaurice's 0-101 scale with the top dozen bunched
-    # 80-101) that the value-direct rescaling preserved unfaithfully.
-    # See their ``_SOURCE_CSV_PATHS`` entries above for the full
-    # rationale.  Fitzmaurice was reverted by an accidental PR #218
-    # merge and restored here.
-})
+_VALUE_BASED_SOURCES: frozenset[str] = frozenset(
+    {
+        # ``ktcSfTep`` carries native 0-9999 values from KTC's TE+ sub-board.
+        # Standard ``ktc`` was retired from the blend 2026-04-28 (its values
+        # are still loaded into canonicalSiteValues for the arbitrage finder
+        # + per-source winner display, but it no longer votes).
+        "ktcSfTep",
+        "idpTradeCalc",
+        # ``fantasyCalc`` carries the FantasyCalc public API's crowd-sourced
+        # dynasty SF+TEP values.  Unlike Dynasty Daddy / Yahoo Boone /
+        # Fitzmaurice, FantasyCalc's value distribution is well-spread
+        # across the board with no display-cap clustering at the top, so
+        # the value-direct path preserves cross-position separation
+        # faithfully (e.g. top WR's value vs top RB's value carries real
+        # signal, not just an arbitrary cap).
+        "fantasyCalc",
+        # ``otcffbSf`` carries OTCFFB's trade-derived 0-100 SF values.
+        # Same shape rationale as FantasyCalc: well-spread distribution,
+        # no top-of-curve display cap (Bijan=100, Allen=96, Gibbs=95.1
+        # cleanly differentiate), so the value-direct path is appropriate.
+        "otcffbSf",
+        # ``dynastyDaddySf``, ``yahooBoone``, and ``fantasyProsFitzmaurice``
+        # were moved to the rank-signal path 2026-04-22 after the Hampel
+        # audit flagged 61% / 47% / 19% drop rates respectively — all three
+        # have compressed top-of-curve value distributions (DynastyDaddy's
+        # 10,200 cap with top 3 tied; Boone's 141 top with seven players
+        # ≥110; Fitzmaurice's 0-101 scale with the top dozen bunched
+        # 80-101) that the value-direct rescaling preserved unfaithfully.
+        # See their ``_SOURCE_CSV_PATHS`` entries above for the full
+        # rationale.  Fitzmaurice was reverted by an accidental PR #218
+        # merge and restored here.
+    }
+)
 
 
 def _validate_value_based_sources_invariant() -> None:
@@ -4556,9 +4486,7 @@ def _validate_value_based_sources_invariant() -> None:
     Hill curve because someone forgot to add it to
     ``_VALUE_BASED_SOURCES``.
     """
-    voting_keys: set[str] = {
-        str(src.get("key") or "") for src in _RANKING_SOURCES
-    }
+    voting_keys: set[str] = {str(src.get("key") or "") for src in _RANKING_SOURCES}
 
     value_signal_keys: set[str] = set()
     for key, cfg in _SOURCE_CSV_PATHS.items():
@@ -4575,9 +4503,7 @@ def _validate_value_based_sources_invariant() -> None:
             value_signal_keys.add(key)
 
     combined_rank_exempt: set[str] = {
-        src["key"]
-        for src in _RANKING_SOURCES
-        if src.get("ds_combined_rank_partner")
+        src["key"] for src in _RANKING_SOURCES if src.get("ds_combined_rank_partner")
     }
 
     missing = value_signal_keys - _VALUE_BASED_SOURCES - combined_rank_exempt
@@ -4759,9 +4685,7 @@ def _suppress_generic_pick_tiers_when_slots_exist(
         row["rankDerivedValue"] = None
         row["canonicalTierId"] = None
         row["confidenceBucket"] = "none"
-        row["confidenceLabel"] = (
-            "None — generic tier suppressed in favor of slot-specific picks"
-        )
+        row["confidenceLabel"] = "None — generic tier suppressed in favor of slot-specific picks"
         row["pickGenericSuppressed"] = True
         # Drop quarantine / single-source flags so the suppressed row
         # cannot accidentally trip the launch-readiness 1-src gate.
@@ -4943,6 +4867,7 @@ def _resolve_league_context(
     # without touching config files.
     try:
         from src.api import league_registry as _league_registry  # local import avoids a cycle
+
         league_id = (_league_registry.get_sleeper_league_id() or "").strip()
     except Exception:  # noqa: BLE001 — if the registry module is broken, fall back to env var
         league_id = ""
@@ -5065,9 +4990,7 @@ def _anchor_current_year_picks_to_rookies(
     rookies = [
         r
         for r in players_array
-        if r.get("assetClass") != "pick"
-        and bool(r.get("rookie"))
-        and _rookie_pool_value(r) > 0
+        if r.get("assetClass") != "pick" and bool(r.get("rookie")) and _rookie_pool_value(r) > 0
     ]
     if not rookies:
         return 0
@@ -5527,9 +5450,7 @@ def _compute_unified_rankings(
     # :func:`normalize_tep_native_multiplier`; KTC stays exempt.
     _ = tep_native_correction  # acknowledged-unused, kept for backwards-compat
     effective_non_tep_multiplier: float = (
-        float(tep_multiplier)
-        if tep_multiplier is not None
-        else _TE_BLANKET_NON_NATIVE_MULTIPLIER
+        float(tep_multiplier) if tep_multiplier is not None else _TE_BLANKET_NON_NATIVE_MULTIPLIER
     )
     effective_native_multiplier: float = (
         float(tep_native_multiplier)
@@ -5645,9 +5566,9 @@ def _compute_unified_rankings(
         source_key: str = src["key"]
         position_group: str | None = src.get("position_group")
         primary_scope: str = src["scope"]
-        needs_shared_market = bool(
-            src.get("needs_shared_market_translation")
-        ) and not src.get("is_backbone")
+        needs_shared_market = bool(src.get("needs_shared_market_translation")) and not src.get(
+            "is_backbone"
+        )
         needs_rookie_xlate = bool(src.get("needs_rookie_translation"))
         # A source may contribute to multiple scopes (e.g. IDPTradeCalc
         # lists both offense and IDP players in one value pool on a shared
@@ -5663,9 +5584,7 @@ def _compute_unified_rankings(
         # offense+IDP ordering: Will Anderson's raw IDPTC value 5963 lands
         # at overall rank ~40 alongside the full offense ladder, not rank
         # 1 of a restarted IDP-only pass.
-        all_scopes: list[str] = [primary_scope] + list(
-            src.get("extra_scopes") or []
-        )
+        all_scopes: list[str] = [primary_scope] + list(src.get("extra_scopes") or [])
 
         # Gather eligible (value, row_idx, scope_for_row, tiebreak_name) tuples.
         # A row is eligible if any of the source's declared scopes accept
@@ -5718,9 +5637,7 @@ def _compute_unified_rankings(
                 continue
             if val <= 0 and source_key not in _DS_COMBINED_RANK_KEYS:
                 continue
-            tiebreak_name = str(
-                row.get("canonicalName") or row.get("displayName") or ""
-            ).lower()
+            tiebreak_name = str(row.get("canonicalName") or row.get("displayName") or "").lower()
             eligible.append((val, idx, row_scope, tiebreak_name))
 
         # Sort descending by value with a name-based secondary tiebreaker,
@@ -5773,9 +5690,7 @@ def _compute_unified_rankings(
             backbone_depth_meta: int | None = None
             if row_scope == SOURCE_SCOPE_POSITION_IDP and position_group:
                 ladder = backbone.ladder_for(position_group)
-                effective_rank, method = translate_position_rank(
-                    raw_rank, ladder
-                )
+                effective_rank, method = translate_position_rank(raw_rank, ladder)
                 ladder_depth_meta = len(ladder)
                 backbone_depth_meta = backbone_depth
             elif needs_shared_market and row_scope == SOURCE_SCOPE_OVERALL_IDP:
@@ -5783,9 +5698,7 @@ def _compute_unified_rankings(
                 # into the backbone source's combined offense+IDP rank
                 # space.  The framework's step 2 percentile normalization
                 # runs in this combined coordinate — see Phase 3.
-                effective_rank, method = translate_position_rank(
-                    raw_rank, shared_market_ladder
-                )
+                effective_rank, method = translate_position_rank(raw_rank, shared_market_ladder)
                 ladder_depth_meta = len(shared_market_ladder)
                 backbone_depth_meta = shared_market_depth
             elif needs_rookie_xlate:
@@ -5811,8 +5724,7 @@ def _compute_unified_rankings(
                 "depth": src.get("depth"),
                 "weight": float(src.get("weight") or 0.0),
                 "sharedMarketTranslated": bool(
-                    needs_shared_market
-                    and row_scope == SOURCE_SCOPE_OVERALL_IDP
+                    needs_shared_market and row_scope == SOURCE_SCOPE_OVERALL_IDP
                 ),
             }
 
@@ -5907,15 +5819,11 @@ def _compute_unified_rankings(
                 except (TypeError, ValueError):
                     continue
                 # Reverse the encoding to recover the original CSV rank.
-                csv_rank = int(round(
-                    _RANK_TO_SYNTHETIC_VALUE_OFFSET - (syn_f / 100.0)
-                ))
+                csv_rank = int(round(_RANK_TO_SYNTHETIC_VALUE_OFFSET - (syn_f / 100.0)))
                 if csv_rank <= 0:
                     continue
                 row_source_ranks[row_idx][skey] = csv_rank
-                meta = row_source_meta.setdefault(row_idx, {}).setdefault(
-                    skey, {}
-                )
+                meta = row_source_meta.setdefault(row_idx, {}).setdefault(skey, {})
                 meta["rawRank"] = meta.get("rawRank", csv_rank)
                 meta["effectiveRank"] = csv_rank
                 meta["method"] = "csv_combined_cross_market"
@@ -5995,9 +5903,7 @@ def _compute_unified_rankings(
             tail_start = ladder[len(ladder) - tail_n]
             tail_end = ladder[-1]
             slope = max(1.0, (tail_end - tail_start) / (tail_n - 1))
-        extrapolated = ladder[-1] + int(
-            round((rookie_rank - len(ladder)) * slope)
-        )
+        extrapolated = ladder[-1] + int(round((rookie_rank - len(ladder)) * slope))
         return max(1, extrapolated)
 
     # Pair each rookie source with its reference ladder.  If the
@@ -6029,13 +5935,9 @@ def _compute_unified_rankings(
                 continue
             translated = _translate_via_ladder(orig_int, ladder)
             rk_dict[rookie_key] = translated
-            meta = row_source_meta.setdefault(row_idx, {}).setdefault(
-                rookie_key, {}
-            )
+            meta = row_source_meta.setdefault(row_idx, {}).setdefault(rookie_key, {})
             meta["effectiveRank"] = translated
-            meta["method"] = (
-                f"rookie_ladder_translation_via_{ref_key}"
-            )
+            meta["method"] = f"rookie_ladder_translation_via_{ref_key}"
 
     # ── Phase 2-3: Normalized value (Hill curve) + robust blend ──
     # Look up each source's weight / depth once.
@@ -6050,14 +5952,10 @@ def _compute_unified_rankings(
     # league's actual TEP.  Reading ``is_tep_premium`` off the
     # registry once avoids per-player dict lookups in the hot blend loop.
     tep_boosted_source_keys: set[str] = {
-        str(s.get("key") or "")
-        for s in active_sources
-        if not bool(s.get("is_tep_premium"))
+        str(s.get("key") or "") for s in active_sources if not bool(s.get("is_tep_premium"))
     }
     tep_native_source_keys: set[str] = {
-        str(s.get("key") or "")
-        for s in active_sources
-        if bool(s.get("is_tep_premium"))
+        str(s.get("key") or "") for s in active_sources if bool(s.get("is_tep_premium"))
     }
 
     # Identify every cross-market source (2026-04-20 multi-anchor
@@ -6074,9 +5972,7 @@ def _compute_unified_rankings(
     # averaged anchor.  See the hierarchical-blend block further
     # down for the math.
     cross_market_keys: set[str] = {
-        str(s.get("key") or "")
-        for s in active_sources
-        if s.get("is_cross_market")
+        str(s.get("key") or "") for s in active_sources if s.get("is_cross_market")
     }
 
     # Final Framework override (2026-04-20): value-based sources vote
@@ -6108,9 +6004,7 @@ def _compute_unified_rankings(
     for row_idx, source_ranks in row_source_ranks.items():
         row_pos = str(players_array[row_idx].get("position") or "").strip().upper()
         row_is_te = row_pos == "TE"
-        row_is_pick = (
-            players_array[row_idx].get("assetClass") == "pick"
-        )
+        row_is_pick = players_array[row_idx].get("assetClass") == "pick"
 
         # Framework step 2–3: for each source, compute
         # percentile-to-value using the source's scope-appropriate
@@ -6131,9 +6025,7 @@ def _compute_unified_rankings(
         # surviving subset.
         all_value_pairs: list[tuple[str, float, bool]] = []
 
-        canonical_site_values = (
-            players_array[row_idx].get("canonicalSiteValues") or {}
-        )
+        canonical_site_values = players_array[row_idx].get("canonicalSiteValues") or {}
         if not isinstance(canonical_site_values, dict):
             canonical_site_values = {}
 
@@ -6176,13 +6068,9 @@ def _compute_unified_rankings(
                     # missing/invalid — should be rare, but protects
                     # against malformed site data dropping a source's
                     # vote to zero silently.
-                    value = float(
-                        percentile_to_value(p, midpoint=hill_c, slope=hill_s)
-                    )
+                    value = float(percentile_to_value(p, midpoint=hill_c, slope=hill_s))
             else:
-                value = float(
-                    percentile_to_value(p, midpoint=hill_c, slope=hill_s)
-                )
+                value = float(percentile_to_value(p, midpoint=hill_c, slope=hill_s))
             tep_applied = False
             tep_native_corrected = False
             # Blanket TE-value multipliers (see the constants block
@@ -6200,10 +6088,7 @@ def _compute_unified_rankings(
             # boosted contribution exceeds 9,999, structurally letting
             # one TE out-value the consensus #1 overall — the premium
             # must reposition TEs *within* the scale, not break it.
-            if (
-                row_is_te
-                and source_key not in _TE_BLANKET_KTC_EXEMPT_KEYS
-            ):
+            if row_is_te and source_key not in _TE_BLANKET_KTC_EXEMPT_KEYS:
                 if source_key in tep_boosted_source_keys:
                     value = min(value * effective_non_tep_multiplier, 9999.0)
                     tep_applied = True
@@ -6225,7 +6110,8 @@ def _compute_unified_rankings(
             meta["valueContribution"] = int(round(value))
             meta["valueContributionPath"] = (
                 "value_direct"
-                if source_key in _VALUE_BASED_SOURCES and value_source_max.get(source_key, 0.0) > 0.0
+                if source_key in _VALUE_BASED_SOURCES
+                and value_source_max.get(source_key, 0.0) > 0.0
                 else "rank_hill"
             )
             meta["effectiveWeight"] = round(effective_weight, 4)
@@ -6253,15 +6139,9 @@ def _compute_unified_rankings(
             )
             if hampel_dropped_keys:
                 kept_set = {k for k, _ in kept_pairs}
-                all_values = [
-                    v for k, v, _ in all_value_pairs if k in kept_set
-                ]
-                cross_market_values = [
-                    v for k, v, a in all_value_pairs if k in kept_set and a
-                ]
-                subgroup_values = [
-                    v for k, v, a in all_value_pairs if k in kept_set and not a
-                ]
+                all_values = [v for k, v, _ in all_value_pairs if k in kept_set]
+                cross_market_values = [v for k, v, a in all_value_pairs if k in kept_set and a]
+                subgroup_values = [v for k, v, a in all_value_pairs if k in kept_set and not a]
                 for sk in hampel_dropped_keys:
                     meta = row_source_meta[row_idx].get(sk, {})
                     meta["hampelDropped"] = True
@@ -6293,14 +6173,9 @@ def _compute_unified_rankings(
             # intentional, not a real matching failure.
             if row_is_pick and src.get("needs_rookie_translation"):
                 continue
-            src_scopes: list[str] = [src["scope"]] + list(
-                src.get("extra_scopes") or []
-            )
+            src_scopes: list[str] = [src["scope"]] + list(src.get("extra_scopes") or [])
             eligible = any(
-                _scope_eligible(
-                    row_pos, scope, src.get("position_group")
-                )
-                for scope in src_scopes
+                _scope_eligible(row_pos, scope, src.get("position_group")) for scope in src_scopes
             )
             if not eligible:
                 continue
@@ -6379,14 +6254,8 @@ def _compute_unified_rankings(
         # Framework step 6: MAD across ALL contributing sources.
         _, source_mad = _trimmed_mean_median(all_values)
 
-        if (
-            source_mad is not None
-            and _MAD_PENALTY_LAMBDA > 0
-            and not row_is_pick
-        ):
-            mad_penalty = min(
-                center_value, _MAD_PENALTY_LAMBDA * source_mad
-            )
+        if source_mad is not None and _MAD_PENALTY_LAMBDA > 0 and not row_is_pick:
+            mad_penalty = min(center_value, _MAD_PENALTY_LAMBDA * source_mad)
         else:
             mad_penalty = 0.0
 
@@ -6404,9 +6273,7 @@ def _compute_unified_rankings(
             int(round(blended_value)) if blended_value > 0 else 0
         )
 
-        hill_value_spread = (
-            statistics.stdev(all_values) if len(all_values) >= 2 else None
-        )
+        hill_value_spread = statistics.stdev(all_values) if len(all_values) >= 2 else None
 
         # Stamp anchor/subgroup diagnostics so the frontend value-chain
         # panel can surface the framework's hierarchical shape
@@ -6461,9 +6328,7 @@ def _compute_unified_rankings(
     )
 
     # ── Phase 4: Unified sort and overall rank assignment ──
-    row_normalized.sort(
-        key=lambda t: (-t[0], players_array[t[1]].get("canonicalName", "").lower())
-    )
+    row_normalized.sort(key=lambda t: (-t[0], players_array[t[1]].get("canonicalName", "").lower()))
 
     # ── Phase 4a: stamp sourceCount + sourceAudit on every contributing row.
     #
@@ -6482,6 +6347,7 @@ def _compute_unified_rankings(
     # time assertions) reads this block directly.
     csv_index = csv_index or {}
     from src.utils.name_clean import canonical_position_group  # noqa: PLC0415
+
     for row_idx, source_ranks in row_source_ranks.items():
         row = players_array[row_idx]
         row["sourceCount"] = len(source_ranks)
@@ -6501,11 +6367,7 @@ def _compute_unified_rankings(
         # enrichment + Phase 1 gates is the whole point of
         # ``_DS_COMBINED_RANK_KEYS``.
         row["sourcePresence"] = {
-            k: (
-                v is not None
-                if k in _DS_COMBINED_RANK_KEYS
-                else (v is not None and v > 0)
-            )
+            k: (v is not None if k in _DS_COMBINED_RANK_KEYS else (v is not None and v > 0))
             for k, v in canonical_sites.items()
         }
 
@@ -6573,16 +6435,10 @@ def _compute_unified_rankings(
         }
         # Semantic 1-src: only fire when matching could have produced
         # more than one source.
-        row["isSingleSource"] = (
-            len(source_ranks) == 1 and len(expected_keys) > 1
-        )
-        row["isStructurallySingleSource"] = (
-            len(source_ranks) == 1 and len(expected_keys) <= 1
-        )
+        row["isSingleSource"] = len(source_ranks) == 1 and len(expected_keys) > 1
+        row["isStructurallySingleSource"] = len(source_ranks) == 1 and len(expected_keys) <= 1
 
-    for overall_idx, (norm_val, row_idx) in enumerate(
-        row_normalized[:OVERALL_RANK_LIMIT]
-    ):
+    for overall_idx, (norm_val, row_idx) in enumerate(row_normalized[:OVERALL_RANK_LIMIT]):
         row = players_array[row_idx]
         overall_rank = overall_idx + 1
         derived = int(norm_val)
@@ -6604,12 +6460,8 @@ def _compute_unified_rankings(
         row["sourceCount"] = len(source_ranks)
 
         dropped_set = set(row.get("droppedSources") or [])
-        effective_source_ranks = {
-            k: v for k, v in source_ranks.items() if k not in dropped_set
-        }
-        effective_source_meta = {
-            k: v for k, v in source_meta.items() if k not in dropped_set
-        }
+        effective_source_ranks = {k: v for k, v in source_ranks.items() if k not in dropped_set}
+        effective_source_meta = {k: v for k, v in source_meta.items() if k not in dropped_set}
         # Publish the post-Hampel rank map so frontend display helpers
         # (frontend/lib/display-helpers.js::marketEdge / marketGapLabel)
         # compute retail-vs-consensus on the same set the backend used
@@ -6620,15 +6472,11 @@ def _compute_unified_rankings(
         rank_values = list(effective_source_ranks.values())
 
         # Caution flag when any IDP source required fallback translation
-        used_fallback = any(
-            m.get("method") == TRANSLATION_FALLBACK for m in source_meta.values()
-        )
+        used_fallback = any(m.get("method") == TRANSLATION_FALLBACK for m in source_meta.values())
         row["idpBackboneFallback"] = used_fallback
 
         # ── Trust/transparency fields (effective rank space) ──
-        blended_source_rank = (
-            sum(rank_values) / len(rank_values) if rank_values else None
-        )
+        blended_source_rank = sum(rank_values) / len(rank_values) if rank_values else None
         row["blendedSourceRank"] = (
             round(blended_source_rank, 2) if blended_source_rank is not None else None
         )
@@ -6655,9 +6503,7 @@ def _compute_unified_rankings(
         # Preserve the semantic 1-src flag stamped in Phase 4a; do
         # not collapse it back to ``len(source_ranks) == 1`` here.
         # Disagreement uses percentile spread.
-        row["hasSourceDisagreement"] = (
-            percentile_spread is not None and percentile_spread > 0.10
-        )
+        row["hasSourceDisagreement"] = percentile_spread is not None and percentile_spread > 0.10
 
         gap_dir, gap_mag = _compute_market_gap(effective_source_ranks)
         row["marketGapDirection"] = gap_dir
@@ -6667,9 +6513,7 @@ def _compute_unified_rankings(
         # because rank-spread is dominated by flat-value regions in
         # R3-R6 and KTC's per-slot synth bleeds in as fake agreement.
         if row.get("assetClass") == "pick":
-            is_slot_specific = _parse_pick_slot(
-                row.get("canonicalName") or ""
-            ) is not None
+            is_slot_specific = _parse_pick_slot(row.get("canonicalName") or "") is not None
             bucket, label = _compute_pick_confidence(
                 row.get("canonicalSiteValues") or {},
                 is_slot_specific=is_slot_specific,
@@ -6870,9 +6714,7 @@ def _compute_unified_rankings(
     # 312→313 does not.  The frontend renders the resulting tier IDs
     # as generic "Tier N" labels, so every math-detected tier flows
     # through uncapped.
-    for r, tier_id in zip(
-        tiered_rows, _compute_value_based_tier_ids(tiered_rows)
-    ):
+    for r, tier_id in zip(tiered_rows, _compute_value_based_tier_ids(tiered_rows)):
         r["canonicalTierId"] = tier_id
 
     # Rank-change vs previous scrape.  Stamps ``rankChange`` on
@@ -7053,6 +6895,7 @@ def _normalize_pos(pos: Any) -> str:
     # Audit S2 consolidated the previous inline POSITION_ALIASES.get
     # idiom.
     from src.utils.name_clean import normalize_position
+
     return normalize_position(pos)
 
 
@@ -7133,9 +6976,7 @@ def _player_value_bundle(p_data: dict[str, Any]) -> dict[str, int | None]:
     raw = _to_int_or_none(
         p_data.get("_rawComposite", p_data.get("_rawMarketValue", p_data.get("_composite")))
     )
-    final = _to_int_or_none(
-        p_data.get("_finalAdjusted", p_data.get("_composite"))
-    )
+    final = _to_int_or_none(p_data.get("_finalAdjusted", p_data.get("_composite")))
     if final is None:
         final = raw
     overall = final
@@ -7160,12 +7001,10 @@ def _derive_player_row(
     canonical_sites = _canonical_site_values(p_data, site_keys)
 
     has_off_signal = any(
-        _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
-        for k in _OFFENSE_SIGNAL_KEYS
+        _to_int_or_none(canonical_sites.get(k)) not in (None, 0) for k in _OFFENSE_SIGNAL_KEYS
     )
     has_idp_signal = any(
-        _to_int_or_none(canonical_sites.get(k)) not in (None, 0)
-        for k in _IDP_SIGNAL_KEYS
+        _to_int_or_none(canonical_sites.get(k)) not in (None, 0) for k in _IDP_SIGNAL_KEYS
     )
 
     pos = pos_from_sleeper or pos_from_player
@@ -7238,9 +7077,7 @@ def _derive_player_row(
         # scraper's direct flag, set when the player has zero NFL
         # years of experience.  Use whichever is positive so the
         # contract layer can rely on a single boolean.
-        "rookie": bool(
-            p_data.get("_formatFitRookie") or p_data.get("_isRookie")
-        ),
+        "rookie": bool(p_data.get("_formatFitRookie") or p_data.get("_isRookie")),
         "assetClass": "pick" if is_pick else ("idp" if pos in {"DL", "LB", "DB"} else "offense"),
         "values": values,
         "canonicalSiteValues": canonical_sites,
@@ -7360,7 +7197,8 @@ def _strip_legacy_lam_fields(base: dict[str, Any], players_by_name: dict[str, An
         if not isinstance(pdata, dict):
             continue
         keys_to_remove = [
-            k for k in pdata
+            k
+            for k in pdata
             if k in _LEGACY_LAM_PLAYER_FIELDS
             or any(k.startswith(prefix) for prefix in _LEGACY_LAM_PLAYER_PREFIXES)
         ]
@@ -7548,9 +7386,7 @@ def build_api_data_contract(
     # Enrich players with source CSV values that may be missing from the
     # legacy scraper payload (e.g. KTC scrape failed but CSV exists).
     source_parse_errors: list[dict[str, str]] = []
-    csv_index = _enrich_from_source_csvs(
-        players_array, parse_errors=source_parse_errors
-    )
+    csv_index = _enrich_from_source_csvs(players_array, parse_errors=source_parse_errors)
 
     # Post-enrichment position guardrail: CSV enrichment happens AFTER
     # _derive_player_row, so the in-row guardrail there runs against an
@@ -7582,7 +7418,9 @@ def build_api_data_contract(
             # sourceRankMeta / _canonicalConsensusRank etc. onto the
             # originals.  The main pass below must see unmodified state.
             _pa_copy = [dict(r) for r in players_array]
-            _pbn_copy = {k: dict(v) if isinstance(v, dict) else v for k, v in players_by_name.items()}
+            _pbn_copy = {
+                k: dict(v) if isinstance(v, dict) else v for k, v in players_by_name.items()
+            }
             _compute_unified_rankings(
                 _pa_copy,
                 _pbn_copy,
@@ -7667,15 +7505,9 @@ def build_api_data_contract(
     # that the scraper bridge never writes; this replaces it with real,
     # source-by-source freshness data that covers all 5 active sources.
     source_timestamps = _build_source_timestamps()
-    _fresh_counts = sum(
-        1 for v in source_timestamps.values() if v.get("staleness") == "fresh"
-    )
-    _stale_counts = sum(
-        1 for v in source_timestamps.values() if v.get("staleness") == "stale"
-    )
-    _missing_counts = sum(
-        1 for v in source_timestamps.values() if v.get("staleness") == "missing"
-    )
+    _fresh_counts = sum(1 for v in source_timestamps.values() if v.get("staleness") == "fresh")
+    _stale_counts = sum(1 for v in source_timestamps.values() if v.get("staleness") == "stale")
+    _missing_counts = sum(1 for v in source_timestamps.values() if v.get("staleness") == "missing")
     if _missing_counts > 0:
         _overall_staleness = "missing"
     elif _stale_counts > 0:
@@ -7819,9 +7651,7 @@ def build_api_data_contract(
         "generatedAt": generated_at,
         "playersArray": players_array,
         "playerCount": len(players_array),
-        "valueAuthority": (
-            None if _for_delta else _build_value_authority_summary(players_array)
-        ),
+        "valueAuthority": (None if _for_delta else _build_value_authority_summary(players_array)),
         "dataSource": {
             "type": str(data_source.get("type") or ""),
             "path": str(data_source.get("path") or ""),
@@ -7961,9 +7791,7 @@ def build_rankings_delta_payload(
     delta_players: list[dict[str, Any]] = []
     active_ids: list[str] = []
     for row in full.get("playersArray") or []:
-        player_id = str(
-            row.get("displayName") or row.get("canonicalName") or ""
-        ).strip()
+        player_id = str(row.get("displayName") or row.get("canonicalName") or "").strip()
         if not player_id:
             continue
         entry: dict[str, Any] = {"id": player_id}
@@ -7995,7 +7823,6 @@ def build_rankings_delta_payload(
     if warnings:
         payload["warnings"] = list(warnings)
     return payload
-
 
 
 def _strip_startup_player_fields(player_row: dict[str, Any]) -> dict[str, Any]:
@@ -8108,13 +7935,15 @@ def assert_no_unexplained_single_source(
             continue
         if audit.get("allowlistReason"):
             continue
-        unexplained.append({
-            "canonicalName": row.get("canonicalName"),
-            "position": row.get("position"),
-            "rank": rank,
-            "matchedSources": audit.get("matchedSources", []),
-            "reason": audit.get("reason"),
-        })
+        unexplained.append(
+            {
+                "canonicalName": row.get("canonicalName"),
+                "position": row.get("position"),
+                "rank": rank,
+                "matchedSources": audit.get("matchedSources", []),
+                "reason": audit.get("reason"),
+            }
+        )
     return unexplained
 
 
@@ -8152,15 +7981,11 @@ def assert_ranking_coherence(
 
         # Check 1: rank must be stamped alongside value
         if value is None or value <= 0:
-            errors.append(
-                f"#{rank} {name}: has rank but no rankDerivedValue"
-            )
+            errors.append(f"#{rank} {name}: has rank but no rankDerivedValue")
 
         # Check 2: no duplicate ranks
         if rank in seen_ranks:
-            errors.append(
-                f"#{rank} {name}: duplicate rank (also assigned to {seen_ranks[rank]})"
-            )
+            errors.append(f"#{rank} {name}: duplicate rank (also assigned to {seen_ranks[rank]})")
         seen_ranks[rank] = name
 
         # Check 3: monotonic rank (strictly increasing)
@@ -8170,23 +7995,14 @@ def assert_ranking_coherence(
             )
 
         # Check 4: value monotonically decreasing with rank
-        if (
-            prev_value is not None
-            and value is not None
-            and prev_value > 0
-            and value > prev_value
-        ):
+        if prev_value is not None and value is not None and prev_value > 0 and value > prev_value:
             errors.append(
                 f"#{rank} {name}: value {value} > prev value {prev_value} "
                 f"(#{prev_rank} {prev_name}) — rank/value order divergence"
             )
 
         # Check 5: tier non-decreasing
-        if (
-            prev_tier is not None
-            and tier is not None
-            and tier < prev_tier
-        ):
+        if prev_tier is not None and tier is not None and tier < prev_tier:
             errors.append(
                 f"#{rank} {name}: tier {tier} < prev tier {prev_tier} "
                 f"(#{prev_rank} {prev_name}) — tier boundary misalignment"
@@ -8298,9 +8114,7 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
             # fail loudly when contamination is present.
             current_flags = row.get("anomalyFlags") or []
             has_collision = "name_collision_cross_universe" in current_flags
-            is_known_collision = (
-                name in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
-            )
+            is_known_collision = name in OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
             if len(players_array) >= 250 and (has_collision or is_known_collision):
                 pass
             else:
@@ -8310,9 +8124,7 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
                 )
 
         if name:
-            norm = _canonical_match_key(name) or re.sub(
-                r"[^a-z0-9]+", "", str(name).lower()
-            )
+            norm = _canonical_match_key(name) or re.sub(r"[^a-z0-9]+", "", str(name).lower())
             normalized_pos_by_name.setdefault(norm, set()).add(pos or "?")
 
     for norm_name, poses in normalized_pos_by_name.items():
@@ -8320,7 +8132,9 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
         has_off = bool(cleaned & _OFFENSE_POSITIONS)
         has_idp = bool(cleaned & _IDP_POSITIONS)
         if has_off and has_idp:
-            errors.append(f"possible offense/IDP name collision detected for normalized name '{norm_name}'")
+            errors.append(
+                f"possible offense/IDP name collision detected for normalized name '{norm_name}'"
+            )
 
     if len(players_array) >= 250 and idp_count < 25:
         errors.append(
@@ -8354,9 +8168,7 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
                 errors.append(f"source_missing:{src_key}")
                 any_source_missing = True
             elif count < threshold:
-                warnings.append(
-                    f"source_below_floor:{src_key}:{count}:{threshold}"
-                )
+                warnings.append(f"source_below_floor:{src_key}:{count}:{threshold}")
                 below_floor_count += 1
 
         if any_source_missing or below_floor_count >= 2:
@@ -8368,14 +8180,10 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
     # recommendation.  Missing pickAnchors is also an error.
     if len(players_array) >= 250:
         pick_count = sum(
-            1
-            for row in players_array
-            if isinstance(row, dict) and row.get("assetClass") == "pick"
+            1 for row in players_array if isinstance(row, dict) and row.get("assetClass") == "pick"
         )
         if pick_count < _PICK_COUNT_FLOOR:
-            errors.append(
-                f"pick_count_below_floor:{pick_count}:{_PICK_COUNT_FLOOR}"
-            )
+            errors.append(f"pick_count_below_floor:{pick_count}:{_PICK_COUNT_FLOOR}")
         pick_anchors = payload.get("pickAnchors")
         if pick_anchors is None:
             errors.append("pickAnchors missing from payload")
@@ -8402,14 +8210,10 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
 
         for bucket, src_floors in coverage_floors.items():
             bucket_rows = [
-                r
-                for r in players_array
-                if isinstance(r, dict) and r.get("assetClass") == bucket
+                r for r in players_array if isinstance(r, dict) and r.get("assetClass") == bucket
             ]
             if len(bucket_rows) < 50:
-                warnings.append(
-                    f"top50_coverage_insufficient_rows:{bucket}:{len(bucket_rows)}"
-                )
+                warnings.append(f"top50_coverage_insufficient_rows:{bucket}:{len(bucket_rows)}")
                 continue
             bucket_rows.sort(key=lambda r: -_overall_val(r))
             top_slice = bucket_rows[:50]
@@ -8456,8 +8260,7 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(perr, dict):
                 continue
             warnings.append(
-                "source_parse_error:"
-                f"{perr.get('source', '?')}:{perr.get('error', '?')}"
+                "source_parse_error:" f"{perr.get('source', '?')}:{perr.get('error', '?')}"
             )
         degraded = True
 
@@ -8469,7 +8272,9 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
     # We now promote critical partials to errors and leave tolerable
     # partials (KTC_TradeDB / KTC_WaiverDB) as warnings.
     settings_block = payload.get("settings") if isinstance(payload.get("settings"), dict) else {}
-    run_summary = settings_block.get("sourceRunSummary") if isinstance(settings_block, dict) else None
+    run_summary = (
+        settings_block.get("sourceRunSummary") if isinstance(settings_block, dict) else None
+    )
     if isinstance(run_summary, dict):
         overall_status = run_summary.get("overallStatus")
         is_partial_run = bool(run_summary.get("partialRun")) or overall_status == "partial"
@@ -8488,10 +8293,7 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
                     continue
                 # Critical match: exact name of a primary source, or a
                 # prefix match for IDPTradeCalc's sub-endpoints.
-                is_critical = (
-                    src in _CRITICAL_PRIMARY_SOURCES
-                    or src.startswith("IDPTradeCalc")
-                )
+                is_critical = src in _CRITICAL_PRIMARY_SOURCES or src.startswith("IDPTradeCalc")
                 if is_critical:
                     errors.append(f"partial_run_critical:{src}")
                 else:

--- a/src/api/draft_capital_fallback.py
+++ b/src/api/draft_capital_fallback.py
@@ -20,6 +20,7 @@ UI labels this view as "Sleeper-derived, flat per-round valuation"
 so users know it's the backup path, not the richer workbook
 numbers.
 """
+
 from __future__ import annotations
 
 import logging
@@ -66,7 +67,10 @@ def _normalize_pick_name(season: int, round_num: int, slot: int) -> str:
 
 
 def _pick_value_from_contract(
-    contract: dict[str, Any], season: int, round_num: int, slot: int,
+    contract: dict[str, Any],
+    season: int,
+    round_num: int,
+    slot: int,
 ) -> float:
     """Look up the rankDerivedValue for a specific pick in the
     canonical contract.  Falls back to interpolation / 0."""
@@ -108,15 +112,11 @@ def build_sleeper_derived(
 
     ``contract`` is the in-memory canonical contract (for pick values).
     """
-    rosters = _fetch_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters"
+    rosters = _fetch_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters")
+    users = _fetch_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users")
+    traded = (
+        _fetch_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/traded_picks") or []
     )
-    users = _fetch_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users"
-    )
-    traded = _fetch_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/traded_picks"
-    ) or []
 
     if not rosters or not users:
         return {
@@ -136,7 +136,8 @@ def build_sleeper_derived(
             or u.get("display_name")
             or f"Team {u.get('user_id')}"
         )
-        for u in users if isinstance(u, dict)
+        for u in users
+        if isinstance(u, dict)
     }
     roster_name_by_id: dict[int, str] = {}
     for r in rosters:
@@ -177,16 +178,18 @@ def build_sleeper_derived(
                 current_rid = traded_map.get((season, round_n, original_rid), original_rid)
                 is_traded = current_rid != original_rid
                 value = _pick_value_from_contract(contract, season, round_n, slot)
-                picks.append(SleeperDerivedPick(
-                    pick=f"{round_n}.{slot:02d}",
-                    round=round_n,
-                    slot=slot,
-                    current_owner=roster_name_by_id.get(current_rid, f"Team {current_rid}"),
-                    original_owner=roster_name_by_id.get(original_rid, f"Team {original_rid}"),
-                    is_traded=is_traded,
-                    raw_value=value,
-                    dollar_value=0,  # filled after normalization
-                ))
+                picks.append(
+                    SleeperDerivedPick(
+                        pick=f"{round_n}.{slot:02d}",
+                        round=round_n,
+                        slot=slot,
+                        current_owner=roster_name_by_id.get(current_rid, f"Team {current_rid}"),
+                        original_owner=roster_name_by_id.get(original_rid, f"Team {original_rid}"),
+                        is_traded=is_traded,
+                        raw_value=value,
+                        dollar_value=0,  # filled after normalization
+                    )
+                )
 
     # Normalize to target total.
     total_raw = sum(p.raw_value for p in picks)
@@ -219,7 +222,9 @@ def build_sleeper_derived(
         ],
         "picks": [
             {
-                "pick": p.pick, "round": p.round, "slot": p.slot,
+                "pick": p.pick,
+                "round": p.round,
+                "slot": p.slot,
                 "currentOwner": p.current_owner,
                 "originalOwner": p.original_owner,
                 "isTraded": p.is_traded,

--- a/src/api/error_responses.py
+++ b/src/api/error_responses.py
@@ -28,6 +28,7 @@ This module ADDS the envelope for unhandled paths and offers the
 NOT rewrite every existing handler to conform — that would risk
 breaking client parsers.  New code should use ``error_payload``.
 """
+
 from __future__ import annotations
 
 import logging
@@ -99,6 +100,7 @@ def install_exception_handler(app: FastAPI) -> None:
     # Silence Starlette's default error logger — our handler
     # already logs the full trace + correlation context.
     import logging
+
     logging.getLogger("starlette.middleware.errors").setLevel(logging.CRITICAL)
 
     @app.exception_handler(Exception)

--- a/src/api/espn_schema_drift.py
+++ b/src/api/espn_schema_drift.py
@@ -27,6 +27,7 @@ Baseline lives in ``config/espn_schema_baseline.json`` — a
 ``{endpoint: {hash, first_seen}}`` dict.  Operators bump the
 baseline after confirming a drift is benign.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -91,7 +92,9 @@ def load_baseline(path: Path | None = None) -> dict[str, dict[str, Any]]:
 
 
 def save_baseline(
-    baseline: dict[str, dict[str, Any]], *, path: Path | None = None,
+    baseline: dict[str, dict[str, Any]],
+    *,
+    path: Path | None = None,
 ) -> Path:
     if path is None:
         repo = Path(__file__).resolve().parents[2]
@@ -123,18 +126,22 @@ def detect_drift(
         prior = baseline.get(endpoint)
         if not prior or not isinstance(prior, dict):
             out[endpoint] = {
-                "status": "new", "current_hash": h, "baseline_hash": None,
+                "status": "new",
+                "current_hash": h,
+                "baseline_hash": None,
             }
             continue
         prior_hash = str(prior.get("hash") or "")
         if h == prior_hash:
             out[endpoint] = {
-                "status": "unchanged", "current_hash": h,
+                "status": "unchanged",
+                "current_hash": h,
                 "baseline_hash": prior_hash,
             }
         else:
             out[endpoint] = {
-                "status": "drifted", "current_hash": h,
+                "status": "drifted",
+                "current_hash": h,
                 "baseline_hash": prior_hash,
             }
     return out
@@ -142,23 +149,15 @@ def detect_drift(
 
 def format_drift_email(drift_report: dict[str, dict[str, Any]]) -> tuple[str, str]:
     """Build (subject, body) for an alert email."""
-    drifted = [
-        ep for ep, info in drift_report.items()
-        if info.get("status") == "drifted"
-    ]
-    new = [
-        ep for ep, info in drift_report.items()
-        if info.get("status") == "new"
-    ]
+    drifted = [ep for ep, info in drift_report.items() if info.get("status") == "drifted"]
+    new = [ep for ep, info in drift_report.items() if info.get("status") == "new"]
     subject = f"[Brisket Ops] ESPN schema drift — {len(drifted)} endpoints changed"
     lines = []
     if drifted:
         lines.append("Endpoints whose shape changed:")
         for ep in drifted:
             info = drift_report[ep]
-            lines.append(
-                f"  • {ep}: {info['baseline_hash'][:8]} → {info['current_hash'][:8]}"
-            )
+            lines.append(f"  • {ep}: {info['baseline_hash'][:8]} → {info['current_hash'][:8]}")
         lines.append("")
         lines.append(
             "Action: inspect the response, confirm parser still works, "

--- a/src/api/faab_analytics.py
+++ b/src/api/faab_analytics.py
@@ -32,6 +32,7 @@ Out of scope
 *  Sleeper trending data — orthogonal to historical bid analytics
    and gathered separately by the recommender.
 """
+
 from __future__ import annotations
 
 import statistics
@@ -48,7 +49,7 @@ _TIER_BREAKPOINTS_PCT = (
     ("tier1", 0.20),  # ≥20% of budget  ($20+ on $100)
     ("tier2", 0.10),  # 10-20%
     ("tier3", 0.03),  # 3-10%
-    ("tier4", 0.0),   # ≤3% (incl. zero-bid free-agent pickups)
+    ("tier4", 0.0),  # ≤3% (incl. zero-bid free-agent pickups)
 )
 
 
@@ -151,18 +152,18 @@ def _walk_waivers(
             adds = tx.get("adds") or {}
             roster_ids = tx.get("roster_ids") or []
             roster_id = roster_ids[0] if roster_ids else None
-            out.append({
-                "season": season.season,
-                "leagueId": season.league_id,
-                "type": str(tx.get("type") or ""),
-                "bid": bid,
-                "adds": adds if isinstance(adds, dict) else {},
-                "rosterId": roster_id,
-                "ownerId": _owner_for_roster(season, roster_id),
-                "createdAt": int(
-                    tx.get("status_updated") or tx.get("created") or 0
-                ),
-            })
+            out.append(
+                {
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    "type": str(tx.get("type") or ""),
+                    "bid": bid,
+                    "adds": adds if isinstance(adds, dict) else {},
+                    "rosterId": roster_id,
+                    "ownerId": _owner_for_roster(season, roster_id),
+                    "createdAt": int(tx.get("status_updated") or tx.get("created") or 0),
+                }
+            )
     return out
 
 
@@ -205,17 +206,13 @@ def summarize_league_faab(
 
     all_bids: list[int] = []
     position_bids: dict[str, list[int]] = {}
-    tier_bids: dict[str, list[int]] = {
-        label: [] for label, _ in _TIER_BREAKPOINTS_PCT
-    }
+    tier_bids: dict[str, list[int]] = {label: [] for label, _ in _TIER_BREAKPOINTS_PCT}
     team_totals: dict[str, dict[str, Any]] = {}
     player_history: dict[str, list[dict[str, Any]]] = {}
     recent: list[dict[str, Any]] = []
 
     # Sort newest-first for the recentWins slice.
-    waivers_recent_first = sorted(
-        waivers, key=lambda tx: -int(tx.get("createdAt") or 0)
-    )
+    waivers_recent_first = sorted(waivers, key=lambda tx: -int(tx.get("createdAt") or 0))
 
     for tx in waivers:
         bid = int(tx.get("bid") or 0)
@@ -237,12 +234,14 @@ def summarize_league_faab(
             # Player history: every add (including FA pickups @ 0)
             # gets a row so the UI can show "this player has been
             # added X times historically".
-            player_history.setdefault(str(pid), []).append({
-                "season": tx.get("season"),
-                "bid": bid,
-                "ownerId": owner_id,
-                "type": tx.get("type"),
-            })
+            player_history.setdefault(str(pid), []).append(
+                {
+                    "season": tx.get("season"),
+                    "bid": bid,
+                    "ownerId": owner_id,
+                    "type": tx.get("type"),
+                }
+            )
 
         # Team aggression aggregates ALL spending (zero-bid FA
         # pickups don't bump avgBid but DO bump count, telling the
@@ -250,8 +249,7 @@ def summarize_league_faab(
         if owner_id:
             entry = team_totals.setdefault(
                 str(owner_id),
-                {"totalSpent": 0, "winningCount": 0, "totalCount": 0,
-                 "maxBid": 0},
+                {"totalSpent": 0, "winningCount": 0, "totalCount": 0, "maxBid": 0},
             )
             entry["totalCount"] += 1
             if bid > 0:
@@ -266,9 +264,7 @@ def summarize_league_faab(
         win_count = e["winningCount"]
         team_aggression[oid] = {
             "totalSpent": e["totalSpent"],
-            "avgBid": (
-                round(e["totalSpent"] / win_count, 2) if win_count > 0 else 0.0
-            ),
+            "avgBid": (round(e["totalSpent"] / win_count, 2) if win_count > 0 else 0.0),
             "winningCount": win_count,
             "totalCount": e["totalCount"],
             "maxBid": e["maxBid"],
@@ -286,22 +282,22 @@ def summarize_league_faab(
             added_names.append(_player_name(snapshot, str(pid)))
             if first_pos is None:
                 first_pos = _player_position(snapshot, str(pid))
-        recent.append({
-            "season": tx.get("season"),
-            "bid": tx.get("bid"),
-            "position": first_pos,
-            "addedNames": added_names,
-            "ownerId": tx.get("ownerId"),
-            "createdAt": tx.get("createdAt"),
-        })
+        recent.append(
+            {
+                "season": tx.get("season"),
+                "bid": tx.get("bid"),
+                "position": first_pos,
+                "addedNames": added_names,
+                "ownerId": tx.get("ownerId"),
+                "createdAt": tx.get("createdAt"),
+            }
+        )
         if len(recent) >= recent_limit:
             break
 
     return {
         "leagueBudget": league_budget,
-        "leagueAvgWinningBid": (
-            round(statistics.fmean(all_bids), 2) if all_bids else 0.0
-        ),
+        "leagueAvgWinningBid": (round(statistics.fmean(all_bids), 2) if all_bids else 0.0),
         "leagueMedianWinningBid": (
             round(float(statistics.median(all_bids)), 2) if all_bids else 0.0
         ),

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -23,6 +23,7 @@ to flip a flag on at deploy time without a config edit.  Set to
 Reads are cached per-process; call ``reload()`` in tests to pick up
 env changes mid-run.
 """
+
 from __future__ import annotations
 
 import os

--- a/src/api/guest_passes.py
+++ b/src/api/guest_passes.py
@@ -28,6 +28,7 @@ Threading: SQLite WAL + a module-level Lock around writes.  Reads
 are uncontested (WAL).  Mirrors the pattern used by
 ``src/api/user_kv.py`` and ``src/api/session_store.py``.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -44,9 +45,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # DB path is overridable for tests + alternate data roots.  Same
 # pattern as session_store.
-_DEFAULT_DB_PATH = (
-    Path(__file__).resolve().parents[2] / "data" / "guest_passes.sqlite"
-)
+_DEFAULT_DB_PATH = Path(__file__).resolve().parents[2] / "data" / "guest_passes.sqlite"
 _TABLE = "guest_passes"
 _TOKEN_BYTES = 24  # 24 URL-safe bytes → 32-char base64 string.
 _MAX_DURATION_HOURS = 24 * 30  # 30 days; sanity cap on creation.
@@ -65,6 +64,7 @@ class GuestPass:
     """Public representation of a stored pass.  Plaintext token is
     NEVER on this dataclass — only on the create() return value, and
     only once."""
+
     id: int
     note: str
     created_by: str
@@ -126,12 +126,10 @@ def _setup(path: Path) -> None:
                 )
             """)
             conn.execute(
-                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE}_expires "
-                f"ON {_TABLE}(expires_at_epoch)"
+                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE}_expires " f"ON {_TABLE}(expires_at_epoch)"
             )
             conn.execute(
-                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE}_token_hash "
-                f"ON {_TABLE}(token_hash)"
+                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE}_token_hash " f"ON {_TABLE}(token_hash)"
             )
         finally:
             conn.close()
@@ -197,9 +195,7 @@ def create(
     except (TypeError, ValueError) as exc:
         raise ValueError("duration_hours must be a number") from exc
     if hours < _MIN_DURATION_HOURS:
-        raise ValueError(
-            f"duration_hours must be ≥ {_MIN_DURATION_HOURS:.4f} (~1 min)"
-        )
+        raise ValueError(f"duration_hours must be ≥ {_MIN_DURATION_HOURS:.4f} (~1 min)")
     if hours > _MAX_DURATION_HOURS:
         raise ValueError(f"duration_hours must be ≤ {_MAX_DURATION_HOURS}")
 

--- a/src/api/injury_impact.py
+++ b/src/api/injury_impact.py
@@ -64,6 +64,7 @@ Age modifiers (for non-rookie):
 Values are capped at 60% total discount to stop a single news item
 from zeroing a player's value.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -79,7 +80,7 @@ from typing import Any
 BASE_DISCOUNT_PCT = {
     "alert": 4.0,
     "watch": 2.0,
-    "info":  0.5,
+    "info": 0.5,
 }
 
 # Duration (ms) over which the discount linearly decays to zero.
@@ -110,6 +111,7 @@ def _is_nfl_offseason(now_ms: int) -> bool:
     add a data dependency for a ~2-week edge case at each end.
     """
     from datetime import datetime, timezone
+
     dt = datetime.fromtimestamp(now_ms / 1000.0, tz=timezone.utc)
     return dt.month in _OFFSEASON_MONTHS
 
@@ -151,6 +153,7 @@ def _news_ms(iso: Any) -> int | None:
     if not isinstance(iso, str):
         return None
     from datetime import datetime
+
     try:
         dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
         return int(dt.timestamp() * 1000)
@@ -257,8 +260,7 @@ def compute_injury_discount(
         impacts = item.get("players") or []
         if isinstance(impacts, list):
             has_positive = any(
-                isinstance(p, dict) and str(p.get("impact") or "") == "positive"
-                for p in impacts
+                isinstance(p, dict) and str(p.get("impact") or "") == "positive" for p in impacts
             )
             if has_positive:
                 continue
@@ -314,8 +316,11 @@ def apply_injury_impact(
     age = row.get("age")
     is_rookie = bool(row.get("rookie") or row.get("isRookie"))
     impact = compute_injury_discount(
-        pos=pos, age=age, is_rookie=is_rookie,
-        news_for_player=news_for_player, now_ms=now_ms,
+        pos=pos,
+        age=age,
+        is_rookie=is_rookie,
+        news_for_player=news_for_player,
+        now_ms=now_ms,
     )
     base_value = row.get("rankDerivedValue")
     try:

--- a/src/api/league_registry.py
+++ b/src/api/league_registry.py
@@ -36,6 +36,7 @@ Not in scope for v1
   chosen team comes from ``user_kv`` in practice; the registry's
   ``default_team_map`` is for unauthenticated cold-starts only.
 """
+
 from __future__ import annotations
 
 import json
@@ -167,10 +168,7 @@ def _parse_league_entry(entry: dict[str, Any]) -> LeagueConfig:
                 }
 
     aliases_raw = entry.get("aliases") or []
-    aliases = tuple(
-        str(a).strip() for a in aliases_raw
-        if isinstance(a, str) and a.strip()
-    )
+    aliases = tuple(str(a).strip() for a in aliases_raw if isinstance(a, str) and a.strip())
 
     # ``bestBall`` is optional in the registry JSON so existing
     # registry files keep working with no edits; defaults False.

--- a/src/api/ops_alerts.py
+++ b/src/api/ops_alerts.py
@@ -18,6 +18,7 @@ alerts fire once when the condition clears.
 Intended to be called once per sweep (piggybacks on the existing
 ``/api/signal-alerts/run`` cron).  Never raises.
 """
+
 from __future__ import annotations
 
 import logging
@@ -71,16 +72,18 @@ def _check_circuit_breakers(circuits: list[dict[str, Any]]) -> list[OpsAlert]:
         age = c.get("stateAgeSec")
         if age is None or age < 600:
             continue
-        alerts.append(OpsAlert(
-            severity="warning",
-            category=f"circuit_open:{c.get('name')}",
-            title=f"Circuit breaker '{c.get('name')}' has been OPEN {int(age/60)}m",
-            detail=(
-                f"External dependency {c.get('name')!r} is failing repeatedly. "
-                f"Last error: {c.get('lastError') or '(none captured)'}.  "
-                f"Fast-fail count: {c.get('counters',{}).get('fastFail',0)}."
-            ),
-        ))
+        alerts.append(
+            OpsAlert(
+                severity="warning",
+                category=f"circuit_open:{c.get('name')}",
+                title=f"Circuit breaker '{c.get('name')}' has been OPEN {int(age/60)}m",
+                detail=(
+                    f"External dependency {c.get('name')!r} is failing repeatedly. "
+                    f"Last error: {c.get('lastError') or '(none captured)'}.  "
+                    f"Fast-fail count: {c.get('counters',{}).get('fastFail',0)}."
+                ),
+            )
+        )
     return alerts
 
 
@@ -127,12 +130,17 @@ def _load_ops_state(path: Any = None) -> dict[str, Any]:
 
 def _save_ops_state(state: dict[str, Any], path: Any = None) -> None:
     user_kv.merge_user_state(
-        _OPS_STATE_USER, {"opsAlertState": state}, path=path,
+        _OPS_STATE_USER,
+        {"opsAlertState": state},
+        path=path,
     )
 
 
 def _should_fire(
-    alert: OpsAlert, state: dict[str, Any], *, now: float,
+    alert: OpsAlert,
+    state: dict[str, Any],
+    *,
+    now: float,
 ) -> bool:
     """Cooldown check.  Returns True when an alert should fire,
     False when it's within the re-alert window."""
@@ -144,7 +152,10 @@ def _should_fire(
 
 
 def _detect_recovery(
-    active_categories: set[str], state: dict[str, Any], *, now: float,
+    active_categories: set[str],
+    state: dict[str, Any],
+    *,
+    now: float,
 ) -> list[OpsAlert]:
     """When a previously-firing alert's category is no longer in
     ``active_categories``, emit a recovery alert (once)."""
@@ -156,11 +167,14 @@ def _detect_recovery(
             continue
         if category in active_categories:
             continue
-        recovery.append(OpsAlert(
-            severity="info", category=category,
-            title=f"[RECOVERY] {category} resolved",
-            detail="Condition cleared.  No action required.",
-        ))
+        recovery.append(
+            OpsAlert(
+                severity="info",
+                category=category,
+                title=f"[RECOVERY] {category} resolved",
+                detail="Condition cleared.  No action required.",
+            )
+        )
     return recovery
 
 
@@ -236,7 +250,11 @@ def check_and_alert(
     # Mark recoveries.
     for r in recovery_alerts:
         if r.category in state:
-            state[r.category] = {**(state[r.category] or {}), "recoveryFired": True, "recoveredAt": now}
+            state[r.category] = {
+                **(state[r.category] or {}),
+                "recoveryFired": True,
+                "recoveredAt": now,
+            }
 
     _save_ops_state(state, path=kv_path)
 

--- a/src/api/public_activity_valuation.py
+++ b/src/api/public_activity_valuation.py
@@ -18,6 +18,7 @@ contract-shape dependency (``values.displayValue`` /
 ``values.rawComposite``) so a future rename to the private bundle
 keys can not silently disable public grading.
 """
+
 from __future__ import annotations
 
 from typing import Any, Callable
@@ -28,7 +29,12 @@ from typing import Any, Callable
 # labels used by ``src/api/data_contract.py`` / the frontend pick
 # candidate builder.
 _ROUND_LABELS: dict[int, str] = {
-    1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th", 6: "6th",
+    1: "1st",
+    2: "2nd",
+    3: "3rd",
+    4: "4th",
+    5: "5th",
+    6: "6th",
 }
 
 

--- a/src/api/push_delivery.py
+++ b/src/api/push_delivery.py
@@ -38,6 +38,7 @@ include in delivery failures.  When any of the three is missing,
 ``is_configured()`` returns False and the dispatch path falls back
 to email-only.
 """
+
 from __future__ import annotations
 
 import json
@@ -84,9 +85,7 @@ def list_subscriptions(user_state: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
-def upsert_subscription(
-    user_state: dict[str, Any], sub: dict[str, Any]
-) -> list[dict[str, Any]]:
+def upsert_subscription(user_state: dict[str, Any], sub: dict[str, Any]) -> list[dict[str, Any]]:
     """Add ``sub`` to the user's list, replacing any record with the
     same endpoint.  Returns the new full list (caller persists)."""
     endpoint = str(sub.get("endpoint") or "").strip()
@@ -108,9 +107,7 @@ def upsert_subscription(
     return deduped
 
 
-def remove_subscription(
-    user_state: dict[str, Any], endpoint: str
-) -> list[dict[str, Any]]:
+def remove_subscription(user_state: dict[str, Any], endpoint: str) -> list[dict[str, Any]]:
     current = list_subscriptions(user_state)
     return [s for s in current if s.get("endpoint") != endpoint]
 

--- a/src/api/rank_history.py
+++ b/src/api/rank_history.py
@@ -43,6 +43,7 @@ Public API
         frontend changes needed to activate sparklines once the
         log has >=2 entries.
 """
+
 from __future__ import annotations
 
 import json
@@ -353,7 +354,7 @@ def load_history(
     if not entries:
         return {}
     entries.sort(key=lambda e: e.get("date") or "")
-    windowed = entries[-max(1, int(days)):]
+    windowed = entries[-max(1, int(days)) :]
 
     per_player: dict[str, list[dict[str, Any]]] = {}
     for e in windowed:
@@ -374,18 +375,16 @@ def load_history(
                 # Hill curve.  Asset class is encoded in the key suffix
                 # ("::idp" / "::offense" / "::pick").
                 idx = str(name).rfind("::")
-                scope = str(name)[idx + 2:].lower() if idx >= 0 else ""
+                scope = str(name)[idx + 2 :].lower() if idx >= 0 else ""
                 val = _value_from_rank(rank, scope)
             else:
                 try:
                     val = int(stored_val)
                 except (TypeError, ValueError):
                     idx = str(name).rfind("::")
-                    scope = str(name)[idx + 2:].lower() if idx >= 0 else ""
+                    scope = str(name)[idx + 2 :].lower() if idx >= 0 else ""
                     val = _value_from_rank(rank, scope)
-            per_player.setdefault(str(name), []).append(
-                {"date": date, "rank": rank, "val": val}
-            )
+            per_player.setdefault(str(name), []).append({"date": date, "rank": rank, "val": val})
     return per_player
 
 

--- a/src/api/rate_limit.py
+++ b/src/api/rate_limit.py
@@ -16,6 +16,7 @@ Per-IP bucket stores (tokens, last_refill_epoch).  O(1) per-request.
 A background LRU-ish evict runs when the bucket dict exceeds
 _MAX_TRACKED_IPS — keeps memory bounded.
 """
+
 from __future__ import annotations
 
 import logging
@@ -48,8 +49,7 @@ _RATE_PER_HOUR = float(os.getenv("RATE_LIMIT_PER_HOUR", "1000"))
 # IPs that bypass rate limiting (uptime monitors, operator IPs, etc.).
 # Comma-separated in env.
 _BYPASS_IPS = frozenset(
-    s.strip() for s in (os.getenv("RATE_LIMIT_BYPASS_IPS") or "").split(",")
-    if s.strip()
+    s.strip() for s in (os.getenv("RATE_LIMIT_BYPASS_IPS") or "").split(",") if s.strip()
 )
 
 

--- a/src/api/session_store.py
+++ b/src/api/session_store.py
@@ -31,6 +31,7 @@ dict writes.  The auth path stays identical in shape so every
 existing code-reading session fields (``session.get("username")``)
 continues to work unchanged.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -55,7 +56,10 @@ _setup_done = threading.Event()
 
 def _connect(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(
-        str(path), timeout=5.0, isolation_level=None, check_same_thread=False,
+        str(path),
+        timeout=5.0,
+        isolation_level=None,
+        check_same_thread=False,
     )
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
@@ -82,8 +86,7 @@ def _setup(path: Path) -> None:
                 )
             """)
             conn.execute(
-                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE}_created "
-                f"ON {_TABLE}(created_at)"
+                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE}_created " f"ON {_TABLE}(created_at)"
             )
         finally:
             conn.close()
@@ -160,7 +163,8 @@ def evict(session_id: str, *, db_path: Path | None = None) -> None:
             conn = _connect(path)
             try:
                 conn.execute(
-                    f"DELETE FROM {_TABLE} WHERE session_id = ?", (str(session_id),),
+                    f"DELETE FROM {_TABLE} WHERE session_id = ?",
+                    (str(session_id),),
                 )
             finally:
                 conn.close()
@@ -203,7 +207,7 @@ def hydrate(
                 ).fetchall()
             finally:
                 conn.close()
-        for (sid, user, sluid, dn, av, am, ver, created, last) in rows:
+        for sid, user, sluid, dn, av, am, ver, created, last in rows:
             if created < cutoff:
                 expired_ids.append(sid)
                 continue
@@ -217,7 +221,8 @@ def hydrate(
                 "avatar": av,
                 "auth_method": am,
                 "created_at": time.strftime(
-                    "%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(created),
+                    "%Y-%m-%dT%H:%M:%S+00:00",
+                    time.gmtime(created),
                 ),
                 "created_at_epoch": created,
             }

--- a/src/api/signal_alerts.py
+++ b/src/api/signal_alerts.py
@@ -40,6 +40,7 @@ No-op when unauthenticated or when the user doesn't have an email
 on record (Sleeper login doesn't collect one today).  The function
 structure is also push-notification-ready for later wiring.
 """
+
 from __future__ import annotations
 
 import logging
@@ -62,6 +63,7 @@ _MIN_NOTIFY_INTERVAL_HOURS: float = 12.0
 
 def _utc_now_ms() -> int:
     import time
+
     return int(time.time() * 1000)
 
 
@@ -182,15 +184,17 @@ def detect_signal_transitions(
             }
             continue
         # Emit a transition.
-        transitions.append({
-            "signalKey": state_key,
-            "name": entry.get("name"),
-            "pos": entry.get("pos"),
-            "signal": signal,
-            "priorSignal": prev_signal or None,
-            "reason": entry.get("reason") or "",
-            "sleeperId": entry.get("sleeperId") or "",
-        })
+        transitions.append(
+            {
+                "signalKey": state_key,
+                "name": entry.get("name"),
+                "pos": entry.get("pos"),
+                "signal": signal,
+                "priorSignal": prev_signal or None,
+                "reason": entry.get("reason") or "",
+                "sleeperId": entry.get("sleeperId") or "",
+            }
+        )
         new_state[state_key] = {
             "signal": signal,
             "notifiedAt": now,
@@ -236,10 +240,7 @@ def format_alert_email(
     simplicity and spam-filter friendliness.
     """
     count = len(transitions)
-    subject = (
-        f"[Brisket] {count} signal update{'' if count == 1 else 's'}"
-        f" for your roster"
-    )
+    subject = f"[Brisket] {count} signal update{'' if count == 1 else 's'}" f" for your roster"
     lines: list[str] = []
     lines.append(f"Hi {display_name},")
     lines.append("")
@@ -287,7 +288,10 @@ def process_user_alerts(
     Omitted → legacy single-league behaviour.
     """
     transitions = detect_signal_transitions(
-        username, signals, path=path, league_key=league_key,
+        username,
+        signals,
+        path=path,
+        league_key=league_key,
     )
     if not transitions:
         return {"transitions": 0, "delivered": False, "reason": "no_transitions"}

--- a/src/api/signal_state_migration.py
+++ b/src/api/signal_state_migration.py
@@ -20,6 +20,7 @@ Called from:
     POST /api/admin/migrate-signal-state  (admin-gated)
     scripts/migrate_signal_state.py       (one-shot CLI)
 """
+
 from __future__ import annotations
 
 import logging
@@ -38,12 +39,12 @@ def migrate_user(
 ) -> dict[str, Any]:
     """Migrate one user's state.  Returns a diagnostic dict:
 
-        {
-          "username": str,
-          "action": "migrated" | "skipped" | "noop",
-          "reason": str,
-          "keys_moved": int,
-        }
+    {
+      "username": str,
+      "action": "migrated" | "skipped" | "noop",
+      "reason": str,
+      "keys_moved": int,
+    }
     """
     state = user_kv.get_user_state(username, path=path)
     legacy = state.get("signalAlertState")
@@ -58,10 +59,16 @@ def migrate_user(
             "reason": "no_legacy_state",
             "keys_moved": 0,
         }
-    if default_league_key in by_league and isinstance(by_league[default_league_key], dict) and by_league[default_league_key]:
+    if (
+        default_league_key in by_league
+        and isinstance(by_league[default_league_key], dict)
+        and by_league[default_league_key]
+    ):
         # Already migrated — just drop the legacy field.
         user_kv.merge_user_state(
-            username, {"signalAlertState": {}}, path=path,
+            username,
+            {"signalAlertState": {}},
+            path=path,
         )
         return {
             "username": username,
@@ -119,15 +126,19 @@ def migrate_all(
 
     results: list[dict[str, Any]] = []
     counts: dict[str, int] = {"migrated": 0, "skipped": 0, "noop": 0, "error": 0}
-    for username in (states or {}):
+    for username in states or {}:
         try:
             r = migrate_user(
-                username, default_league_key=default_league_key, path=path,
+                username,
+                default_league_key=default_league_key,
+                path=path,
             )
         except Exception as exc:  # noqa: BLE001
             r = {
-                "username": username, "action": "error",
-                "reason": str(exc), "keys_moved": 0,
+                "username": username,
+                "action": "error",
+                "reason": str(exc),
+                "keys_moved": 0,
             }
         results.append(r)
         counts[r.get("action", "error")] = counts.get(r.get("action", "error"), 0) + 1

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -37,6 +37,7 @@ overlay for 15 minutes so steady-state traffic doesn't hammer
 Sleeper.  ``invalidate_overlay_cache()`` is exposed for tests +
 a potential future admin "refresh" endpoint.
 """
+
 from __future__ import annotations
 
 import datetime as _dt
@@ -93,9 +94,11 @@ def _http_get_json(url: str) -> Any:
     # Circuit breaker: fail fast when Sleeper is tripped.
     try:
         from src.utils import circuit_breaker as _cb
+
         bp = _cb.get_or_create(
             "sleeper_api",
-            failure_threshold=5, failure_window_sec=60.0,
+            failure_threshold=5,
+            failure_window_sec=60.0,
             open_duration_sec=60.0,
         )
         if not bp.can_call():
@@ -193,6 +196,7 @@ def _build_pick_ownership(
     the data-not-ready state for draft-capital widgets.
     """
     import datetime as _dt
+
     if not roster_ids:
         return {}
     current_year = _dt.datetime.now(_dt.timezone.utc).year
@@ -205,9 +209,7 @@ def _build_pick_ownership(
             for rid in roster_ids:
                 ownership[(year, rnd, rid)] = rid
 
-    traded = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/traded_picks"
-    )
+    traded = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/traded_picks")
     if isinstance(traded, list):
         for tp in traded:
             if not isinstance(tp, dict):
@@ -228,14 +230,16 @@ def _build_pick_ownership(
     # Re-pivot to {current_owner: [pickDetail...]}.
     per_roster: dict[int, list[dict[str, Any]]] = {rid: [] for rid in roster_ids}
     for (season, rnd, original), current_owner in ownership.items():
-        per_roster.setdefault(current_owner, []).append({
-            "season": season,
-            "round": rnd,
-            "slot": None,
-            "original_roster_id": original,
-            "owner_roster_id": current_owner,
-            "label": _format_pick_label(season, rnd),
-        })
+        per_roster.setdefault(current_owner, []).append(
+            {
+                "season": season,
+                "round": rnd,
+                "slot": None,
+                "original_roster_id": original,
+                "owner_roster_id": current_owner,
+                "label": _format_pick_label(season, rnd),
+            }
+        )
     # Sort each team's picks year-then-round for deterministic output.
     for rid, plist in per_roster.items():
         plist.sort(key=lambda p: (p.get("season", ""), p.get("round", 0)))
@@ -260,12 +264,8 @@ def _build_teams_block(
     This is what unblocks /api/draft-capital + angle-finder for
     non-default leagues.
     """
-    rosters = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters"
-    )
-    users = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users"
-    )
+    rosters = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters")
+    users = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users")
     if not isinstance(rosters, list) or not isinstance(users, list):
         return None
 
@@ -274,14 +274,8 @@ def _build_teams_block(
     # FAAB.  When the league call fails (rare) we still emit the
     # block — faabRemaining just falls back to None and the
     # frontend renders "—" instead of a number.
-    league_info = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}"
-    )
-    league_settings = (
-        league_info.get("settings")
-        if isinstance(league_info, dict)
-        else None
-    )
+    league_info = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}")
+    league_settings = league_info.get("settings") if isinstance(league_info, dict) else None
     league_faab_budget = None
     if isinstance(league_settings, dict):
         try:
@@ -312,9 +306,7 @@ def _build_teams_block(
         label = owner_label(u) or f"Team {uid}"
         user_map[uid] = label
         legacy_name_map[uid] = str(
-            (u.get("metadata") or {}).get("team_name")
-            or u.get("display_name")
-            or f"Team {uid}"
+            (u.get("metadata") or {}).get("team_name") or u.get("display_name") or f"Team {uid}"
         )
 
     id_map = id_to_player or {}
@@ -370,22 +362,22 @@ def _build_teams_block(
         if league_faab_budget is not None and faab_used is not None:
             faab_remaining = max(0, league_faab_budget - faab_used)
 
-        teams.append({
-            "name": user_map.get(owner_id, f"Team {roster_id}"),
-            # Backward-compat only — never rendered.  See legacy_name_map.
-            "sleeperTeamName": legacy_name_map.get(
-                owner_id, f"Team {roster_id}"
-            ),
-            "ownerId": owner_id,
-            "roster_id": roster_id,
-            "players": names,
-            "playerIds": [str(pid) for pid in player_ids if pid],
-            "picks": pick_labels,
-            "pickDetails": pick_details,
-            "faabBudget": league_faab_budget,
-            "faabUsed": faab_used,
-            "faabRemaining": faab_remaining,
-        })
+        teams.append(
+            {
+                "name": user_map.get(owner_id, f"Team {roster_id}"),
+                # Backward-compat only — never rendered.  See legacy_name_map.
+                "sleeperTeamName": legacy_name_map.get(owner_id, f"Team {roster_id}"),
+                "ownerId": owner_id,
+                "roster_id": roster_id,
+                "players": names,
+                "playerIds": [str(pid) for pid in player_ids if pid],
+                "picks": pick_labels,
+                "pickDetails": pick_details,
+                "faabBudget": league_faab_budget,
+                "faabUsed": faab_used,
+                "faabRemaining": faab_remaining,
+            }
+        )
     return teams
 
 
@@ -418,12 +410,8 @@ def _league_rid_lookup(
     """
     rid_to_name: dict[Any, str] = {}
     rid_to_owner: dict[Any, str] = {}
-    rosters = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{target_league_id}/rosters"
-    )
-    users = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{target_league_id}/users"
-    )
+    rosters = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/rosters")
+    users = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/users")
     if not isinstance(rosters, list):
         return rid_to_name, rid_to_owner
     user_map: dict[str, str] = {}
@@ -435,11 +423,7 @@ def _league_rid_lookup(
             if not uid:
                 continue
             metadata = u.get("metadata") if isinstance(u.get("metadata"), dict) else {}
-            name = (
-                (metadata or {}).get("team_name")
-                or u.get("display_name")
-                or f"Team {uid}"
-            )
+            name = (metadata or {}).get("team_name") or u.get("display_name") or f"Team {uid}"
             user_map[uid] = str(name)
     for r in rosters:
         if not isinstance(r, dict):
@@ -489,9 +473,7 @@ def _league_draft_slot_lookup(
     frontend, just less precisely.
     """
     out: dict[tuple[int, int], int] = {}
-    drafts = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{target_league_id}/drafts"
-    )
+    drafts = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/drafts")
     if not isinstance(drafts, list):
         return out
 
@@ -501,9 +483,7 @@ def _league_draft_slot_lookup(
     owner_to_rid: dict[str, int] = {}
     rs = rosters
     if rs is None:
-        rs_resp = _http_get_json(
-            f"https://api.sleeper.app/v1/league/{target_league_id}/rosters"
-        )
+        rs_resp = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/rosters")
         rs = rs_resp if isinstance(rs_resp, list) else []
     for r in rs or []:
         if not isinstance(r, dict):
@@ -523,15 +503,11 @@ def _league_draft_slot_lookup(
 
         # Try the DETAIL endpoint first (slot_to_roster_id usually
         # lands here even when the LIST endpoint's copy is empty).
-        detail = _http_get_json(
-            f"https://api.sleeper.app/v1/draft/{draft_id}"
-        )
+        detail = _http_get_json(f"https://api.sleeper.app/v1/draft/{draft_id}")
         detail_dict = detail if isinstance(detail, dict) else {}
 
         # draft_order: { user_id: slot } — needs owner_id → roster_id.
-        draft_order = (
-            detail_dict.get("draft_order") or d.get("draft_order") or {}
-        )
+        draft_order = detail_dict.get("draft_order") or d.get("draft_order") or {}
         if isinstance(draft_order, dict):
             for uid, slot in draft_order.items():
                 slot_num = _safe_int(slot)
@@ -540,19 +516,12 @@ def _league_draft_slot_lookup(
                     out[(season, rid)] = slot_num
 
         # slot_to_roster_id: { slot: roster_id } — direct map.
-        slot_to_rid = (
-            detail_dict.get("slot_to_roster_id")
-            or d.get("slot_to_roster_id")
-            or {}
-        )
+        slot_to_rid = detail_dict.get("slot_to_roster_id") or d.get("slot_to_roster_id") or {}
         if isinstance(slot_to_rid, dict):
             for slot, rid_val in slot_to_rid.items():
                 slot_num = _safe_int(slot)
                 rid_num = _safe_int(rid_val)
-                if (
-                    isinstance(slot_num, int) and slot_num > 0
-                    and isinstance(rid_num, int)
-                ):
+                if isinstance(slot_num, int) and slot_num > 0 and isinstance(rid_num, int):
                     out[(season, rid_num)] = slot_num
 
     return out
@@ -609,6 +578,7 @@ def _format_trade_pick_label(
     """
     if current_year is None:
         import datetime as _dt
+
         current_year = _dt.datetime.now(_dt.timezone.utc).year
 
     season = _safe_int(pick.get("season"))
@@ -618,17 +588,12 @@ def _format_trade_pick_label(
     from_team: str | None = None
     if origin_rid is not None:
         from_team = (
-            rid_to_name.get(origin_rid)
-            or rid_to_name.get(str(origin_rid))
-            or f"Team {origin_rid}"
+            rid_to_name.get(origin_rid) or rid_to_name.get(str(origin_rid)) or f"Team {origin_rid}"
         )
 
     base_label: str | None = None
     if season is not None and round_num is not None and round_num > 0:
-        slot = (
-            draft_slot_by_origin.get((season, origin_rid))
-            if origin_rid is not None else None
-        )
+        slot = draft_slot_by_origin.get((season, origin_rid)) if origin_rid is not None else None
         if season >= current_year + 1:
             # Future year — tier label, slot-aware when known.
             # ``_round_suffix(1) = "1st"`` already includes the digit
@@ -636,9 +601,7 @@ def _format_trade_pick_label(
             # offline scraper's ``_round_suffix`` returns only the
             # suffix and prepends — same output, different code split).
             tier_label = _slot_to_tier_label(slot, league_size=league_size)
-            base_label = (
-                f"{season} {tier_label} {_round_suffix(round_num)}"
-            )
+            base_label = f"{season} {tier_label} {_round_suffix(round_num)}"
         elif isinstance(slot, int) and slot > 0:
             # Current year (or past) with known slot — slot-specific.
             base_label = f"{season} {round_num}.{str(slot).zfill(2)}"
@@ -655,7 +618,9 @@ def _format_trade_pick_label(
 
 
 def _append_trade_side_item(
-    side_map: dict[Any, list[str]], rid: Any, label: str,
+    side_map: dict[Any, list[str]],
+    rid: Any,
+    label: str,
 ) -> None:
     """Append ``label`` under both string and int keys for ``rid`` so
     later side construction can find the entries however it indexes.
@@ -723,10 +688,7 @@ def _build_waivers_block(
         rid_to_name, rid_to_owner = _league_rid_lookup(lid)
 
         for week in range(0, 19):
-            url = (
-                f"https://api.sleeper.app/v1/league/{lid}"
-                f"/transactions/{week}"
-            )
+            url = f"https://api.sleeper.app/v1/league/{lid}" f"/transactions/{week}"
             txs = _http_get_json(url)
             if not isinstance(txs, list):
                 continue
@@ -767,14 +729,8 @@ def _build_waivers_block(
                 if rid is None:
                     continue
 
-                added_names = [
-                    str(id_map.get(str(pid)) or pid)
-                    for pid in adds.keys()
-                ]
-                dropped_names = [
-                    str(id_map.get(str(pid)) or pid)
-                    for pid in drops.keys()
-                ]
+                added_names = [str(id_map.get(str(pid)) or pid) for pid in adds.keys()]
+                dropped_names = [str(id_map.get(str(pid)) or pid) for pid in drops.keys()]
 
                 # FAAB bid lives at ``settings.waiver_bid`` for waiver
                 # tx; FA tx don't carry a bid (free pickups).
@@ -793,18 +749,20 @@ def _build_waivers_block(
                     or ""
                 )
 
-                out.append({
-                    "leagueId": str(lid),
-                    "week": week,
-                    "createdAtMs": ts_ms or 0,
-                    "rosterId": rid,
-                    "ownerId": owner_id,
-                    "added": added_names,
-                    "dropped": dropped_names,
-                    "faabBid": bid,
-                    "type": str(tx_type),
-                    "transactionId": tx_id,
-                })
+                out.append(
+                    {
+                        "leagueId": str(lid),
+                        "week": week,
+                        "createdAtMs": ts_ms or 0,
+                        "rosterId": rid,
+                        "ownerId": owner_id,
+                        "added": added_names,
+                        "dropped": dropped_names,
+                        "faabBid": bid,
+                        "type": str(tx_type),
+                        "transactionId": tx_id,
+                    }
+                )
 
                 # rid_key + rid_to_name unused below but kept for
                 # potential team-name annotation in a downstream
@@ -845,6 +803,7 @@ def _build_trades_block(
     labels fall back to the raw Sleeper id.
     """
     import datetime as _dt
+
     cutoff_ms = _utc_now_ms() - int(window_days) * 24 * 3600 * 1000
     chain = _walk_league_chain(sleeper_league_id, max_depth=2)
     if not chain:
@@ -863,13 +822,12 @@ def _build_trades_block(
         # roster identity (a roster_id can change human ownership
         # across seasons).  The rosters fetch is reused by the
         # draft-slot lookup so we don't pay the round-trip twice.
-        rosters_resp = _http_get_json(
-            f"https://api.sleeper.app/v1/league/{lid}/rosters"
-        )
+        rosters_resp = _http_get_json(f"https://api.sleeper.app/v1/league/{lid}/rosters")
         rosters_list = rosters_resp if isinstance(rosters_resp, list) else []
         rid_to_name, rid_to_owner = _league_rid_lookup(lid)
         draft_slot_by_origin = _league_draft_slot_lookup(
-            lid, rosters=rosters_list,
+            lid,
+            rosters=rosters_list,
         )
         # League size drives Early/Mid/Late tier bucketing for
         # future-year picks.  Default to 12-team when the rosters
@@ -882,10 +840,7 @@ def _build_trades_block(
         # calendar.  0 is cheap to include and catches preseason
         # trades that happened before week 1.
         for week in range(0, 19):
-            url = (
-                f"https://api.sleeper.app/v1/league/{lid}"
-                f"/transactions/{week}"
-            )
+            url = f"https://api.sleeper.app/v1/league/{lid}" f"/transactions/{week}"
             txs = _http_get_json(url)
             if not isinstance(txs, list):
                 continue
@@ -931,7 +886,9 @@ def _build_trades_block(
                     owner = pick.get("owner_id")
                     prev = pick.get("previous_owner_id")
                     label = _format_trade_pick_label(
-                        pick, rid_to_name, draft_slot_by_origin,
+                        pick,
+                        rid_to_name,
+                        draft_slot_by_origin,
                         current_year=current_year,
                         league_size=league_size,
                     )
@@ -944,9 +901,7 @@ def _build_trades_block(
                 for rid in roster_ids:
                     rid_key = rid if rid in rid_to_name else _safe_int(rid)
                     team_name = (
-                        rid_to_name.get(rid_key)
-                        or rid_to_name.get(str(rid))
-                        or f"Team {rid}"
+                        rid_to_name.get(rid_key) or rid_to_name.get(str(rid)) or f"Team {rid}"
                     )
                     owner_id = (
                         rid_to_owner.get(rid)
@@ -954,21 +909,25 @@ def _build_trades_block(
                         or rid_to_owner.get(str(rid))
                         or ""
                     )
-                    sides.append({
-                        "team": team_name,
-                        "rosterId": rid,
-                        "ownerId": owner_id,
-                        "got": team_got.get(rid, []) or team_got.get(_safe_int(rid), []),
-                        "gave": team_gave.get(rid, []) or team_gave.get(_safe_int(rid), []),
-                    })
+                    sides.append(
+                        {
+                            "team": team_name,
+                            "rosterId": rid,
+                            "ownerId": owner_id,
+                            "got": team_got.get(rid, []) or team_got.get(_safe_int(rid), []),
+                            "gave": team_gave.get(rid, []) or team_gave.get(_safe_int(rid), []),
+                        }
+                    )
 
                 if sides:
-                    trades.append({
-                        "leagueId": str(lid),
-                        "week": week,
-                        "timestamp": ts_ms or 0,
-                        "sides": sides,
-                    })
+                    trades.append(
+                        {
+                            "leagueId": str(lid),
+                            "week": week,
+                            "timestamp": ts_ms or 0,
+                            "sides": sides,
+                        }
+                    )
 
     # Newest first — /trades UI sorts by recency.
     trades.sort(key=lambda t: -int(t.get("timestamp", 0) or 0))
@@ -1059,9 +1018,7 @@ def fetch_sleeper_overlay(
         id_to_player=id_to_player,
     )
 
-    cutoff_dt = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(
-        days=int(trade_window_days)
-    )
+    cutoff_dt = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=int(trade_window_days))
     payload: dict[str, Any] = {
         "leagueId": sleeper_league_id,
         "leagueName": league_name,
@@ -1122,9 +1079,7 @@ def _league_season(sleeper_league_id: str) -> str:
     fails — never hard-code or assume the year so season rollover is
     automatic when the league advances.
     """
-    info = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}"
-    )
+    info = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}")
     if isinstance(info, dict):
         season = str(info.get("season") or "").strip()
         if season:
@@ -1157,9 +1112,7 @@ def _resolve_active_draft_id(sleeper_league_id: str) -> str | None:
         if cached and (now - float(cached.get("_cached_at") or 0)) < _DRAFT_ID_CACHE_TTL_SEC:
             return cached.get("draft_id")
 
-    drafts = _http_get_json(
-        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/drafts"
-    )
+    drafts = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/drafts")
     draft_id: str | None = None
     if isinstance(drafts, list):
         season = _league_season(sleeper_league_id)
@@ -1308,9 +1261,7 @@ def fetch_live_draft_picks(
     if snapshot is None:
         meta = _fetch_draft_meta(draft_id)
         status = str(meta.get("status") if isinstance(meta, dict) else "").strip() or "unknown"
-        raw_picks = _http_get_json(
-            f"https://api.sleeper.app/v1/draft/{draft_id}/picks"
-        )
+        raw_picks = _http_get_json(f"https://api.sleeper.app/v1/draft/{draft_id}/picks")
         if not isinstance(raw_picks, list):
             # Hard fetch failure.  Don't poison the cache — let the
             # next poll retry.  Return None so the route surfaces a

--- a/src/api/source_health_alerts.py
+++ b/src/api/source_health_alerts.py
@@ -26,6 +26,7 @@ knows the current health state.
 Integration point: the signal-alert cron calls ``check_and_alert()``
 as part of its sweep — no new cron required.
 """
+
 from __future__ import annotations
 
 import json
@@ -98,6 +99,7 @@ def _iso_to_epoch(ts: str) -> float:
         return 0.0
     try:
         from datetime import datetime
+
         # Handle both Z suffix and +00:00.
         clean = ts.replace("Z", "+00:00")
         return datetime.fromisoformat(clean).timestamp()
@@ -218,10 +220,7 @@ def detect_stale_sources(
         if not isinstance(entry, dict):
             continue
         last_seen_iso = str(
-            entry.get("lastFetched")
-            or entry.get("lastSeen")
-            or entry.get("lastFetchedAt")
-            or ""
+            entry.get("lastFetched") or entry.get("lastSeen") or entry.get("lastFetchedAt") or ""
         )
         if not last_seen_iso:
             continue
@@ -231,12 +230,15 @@ def detect_stale_sources(
         hours_stale = (now - last_epoch) / 3600.0
         threshold = resolve_threshold(src, thresholds)
         if hours_stale > threshold:
-            out.append(StaleSourceAlert(
-                source=src, last_seen_iso=last_seen_iso,
-                hours_stale=round(hours_stale, 1),
-                threshold_hours=threshold,
-                transition="stale",
-            ))
+            out.append(
+                StaleSourceAlert(
+                    source=src,
+                    last_seen_iso=last_seen_iso,
+                    hours_stale=round(hours_stale, 1),
+                    threshold_hours=threshold,
+                    transition="stale",
+                )
+            )
     return out
 
 
@@ -263,7 +265,9 @@ def check_and_alert(
     alert_state = dict(state.get("sourceHealthAlertState") or {})
     now = time.time()
     stale = detect_stale_sources(
-        source_health, thresholds=thresholds, now_epoch=now,
+        source_health,
+        thresholds=thresholds,
+        now_epoch=now,
     )
     stale_sources = {a.source for a in stale}
 
@@ -274,13 +278,15 @@ def check_and_alert(
         if not isinstance(entry, dict):
             continue
         if entry.get("currentlyStale") and src not in stale_sources:
-            recovery_alerts.append(StaleSourceAlert(
-                source=src,
-                last_seen_iso=str(entry.get("lastAlertedAt") or ""),
-                hours_stale=0.0,
-                threshold_hours=0.0,
-                transition="recovered",
-            ))
+            recovery_alerts.append(
+                StaleSourceAlert(
+                    source=src,
+                    last_seen_iso=str(entry.get("lastAlertedAt") or ""),
+                    hours_stale=0.0,
+                    threshold_hours=0.0,
+                    transition="recovered",
+                )
+            )
 
     summary = {"stale": 0, "recovered": 0, "delivered": 0, "skipped_cooldown": 0}
     to_send: list[StaleSourceAlert] = []
@@ -315,7 +321,9 @@ def check_and_alert(
     # Persist state BEFORE sending so a delivery crash doesn't cause
     # re-alerts next pass.
     user_kv.merge_user_state(
-        state_user, {"sourceHealthAlertState": alert_state}, path=kv_path,
+        state_user,
+        {"sourceHealthAlertState": alert_state},
+        path=kv_path,
     )
 
     if not to_send:

--- a/src/api/source_history.py
+++ b/src/api/source_history.py
@@ -38,6 +38,7 @@ Storage cost: ~12 sources × 1200 players × ~6 bytes ≈ 85 KB per
 snapshot.  180 days ≈ 15 MB on disk — trivial relative to the daily
 ``dynasty_data_*.json`` exports at ~3-4 MB each.
 """
+
 from __future__ import annotations
 
 import json
@@ -65,8 +66,7 @@ def _today_utc() -> str:
 
 _OFFENSE_POSITIONS = frozenset({"QB", "RB", "WR", "TE"})
 _IDP_POSITIONS = frozenset(
-    {"DL", "DE", "DT", "EDGE", "NT", "LB", "OLB", "ILB", "MLB",
-     "DB", "CB", "S", "FS", "SS"}
+    {"DL", "DE", "DT", "EDGE", "NT", "LB", "OLB", "ILB", "MLB", "DB", "CB", "S", "FS", "SS"}
 )
 
 # Scope → asset classes that scope can legitimately rank.  Mirrors
@@ -309,20 +309,13 @@ def _extract_player_entry(row: dict[str, Any]) -> dict[str, Any] | None:
                 source_ranks[str(key)] = r
 
     asset_class = _infer_asset_class(row)
-    sources, source_ranks = _filter_scope_mismatched(
-        asset_class, sources, source_ranks
-    )
+    sources, source_ranks = _filter_scope_mismatched(asset_class, sources, source_ranks)
     # Same retired-from-chart filter for ranks so legacy ``ktc`` rank
     # entries don't surface either.
     for key in _RETIRED_FROM_CHART_KEYS:
         source_ranks.pop(key, None)
 
-    if (
-        blended_val is None
-        and blended_rank_val is None
-        and not sources
-        and not source_ranks
-    ):
+    if blended_val is None and blended_rank_val is None and not sources and not source_ranks:
         return None
 
     entry: dict[str, Any] = {"sources": sources}
@@ -557,7 +550,7 @@ def load_player_history(
     if not entries:
         return {"dates": [], "blended": [], "sources": {}, "sourceRanks": {}}
     entries.sort(key=lambda e: e.get("date") or "")
-    windowed = entries[-max(1, int(days)):]
+    windowed = entries[-max(1, int(days)) :]
 
     needle = name.strip().lower()
     asset = (asset_class or "").strip().lower()
@@ -630,12 +623,14 @@ def load_player_history(
                 value_out = int(round(med))
                 derived = True
 
-        blended.append({
-            "date": date,
-            "value": value_out,
-            "rank": int(br) if isinstance(br, (int, float)) else None,
-            "derived": derived,
-        })
+        blended.append(
+            {
+                "date": date,
+                "value": value_out,
+                "rank": int(br) if isinstance(br, (int, float)) else None,
+                "derived": derived,
+            }
+        )
         for key, value in sources.items():
             try:
                 v = int(value)
@@ -649,9 +644,7 @@ def load_player_history(
                 continue
             if r <= 0:
                 continue
-            source_ranks_accum.setdefault(str(key), []).append(
-                {"date": date, "rank": r}
-            )
+            source_ranks_accum.setdefault(str(key), []).append({"date": date, "rank": r})
 
     return {
         "dates": dates,
@@ -670,7 +663,7 @@ def load_all_player_names(
     snapshots.  Useful for admin endpoints; not currently wired.
     """
     path = path or HISTORY_PATH
-    entries = _read_lines(path)[-max(1, int(days)):]
+    entries = _read_lines(path)[-max(1, int(days)) :]
     names: set[str] = set()
     for snap in entries:
         players = snap.get("players") or {}

--- a/src/api/startup_validation.py
+++ b/src/api/startup_validation.py
@@ -16,6 +16,7 @@ The goal is "observable degraded startup" over "silent
 misconfiguration".  A broken .env file produces 15 explicit log
 lines telling you what's wrong, not a mysterious 503.
 """
+
 from __future__ import annotations
 
 import logging
@@ -55,7 +56,9 @@ def check_dir_writable(path: Path, *, create: bool = True) -> CheckResult:
             path.mkdir(parents=True, exist_ok=True)
         if not path.exists():
             return CheckResult(
-                name=f"dir:{path}", ok=False, message="missing",
+                name=f"dir:{path}",
+                ok=False,
+                message="missing",
                 fatal=False,
             )
         # Try to write a probe.
@@ -63,11 +66,14 @@ def check_dir_writable(path: Path, *, create: bool = True) -> CheckResult:
         probe.write_text("", encoding="utf-8")
         probe.unlink()
         return CheckResult(
-            name=f"dir:{path}", ok=True, message="writable",
+            name=f"dir:{path}",
+            ok=True,
+            message="writable",
         )
     except Exception as exc:  # noqa: BLE001
         return CheckResult(
-            name=f"dir:{path}", ok=False,
+            name=f"dir:{path}",
+            ok=False,
             message=f"not writable: {exc}",
             fatal=False,
             context={"error": str(exc)},
@@ -85,10 +91,13 @@ def check_sqlite_reachable(path: Path) -> CheckResult:
             row = conn.execute("PRAGMA integrity_check").fetchone()
             if row and row[0] == "ok":
                 return CheckResult(
-                    name=f"sqlite:{path.name}", ok=True, message="ok",
+                    name=f"sqlite:{path.name}",
+                    ok=True,
+                    message="ok",
                 )
             return CheckResult(
-                name=f"sqlite:{path.name}", ok=False,
+                name=f"sqlite:{path.name}",
+                ok=False,
                 message=f"integrity_check: {row}",
                 fatal=False,
             )
@@ -96,7 +105,8 @@ def check_sqlite_reachable(path: Path) -> CheckResult:
             conn.close()
     except Exception as exc:  # noqa: BLE001
         return CheckResult(
-            name=f"sqlite:{path.name}", ok=False,
+            name=f"sqlite:{path.name}",
+            ok=False,
             message=f"open failed: {exc}",
             fatal=False,
             context={"error": str(exc)},
@@ -108,21 +118,25 @@ def check_league_registry() -> CheckResult:
     active league."""
     try:
         from src.api import league_registry
+
         leagues = league_registry.active_leagues()
         if not leagues:
             return CheckResult(
-                name="league_registry", ok=False,
+                name="league_registry",
+                ok=False,
                 message="no active leagues configured",
                 fatal=False,
             )
         return CheckResult(
-            name="league_registry", ok=True,
+            name="league_registry",
+            ok=True,
             message=f"{len(leagues)} active",
             context={"keys": [lg.key for lg in leagues]},
         )
     except Exception as exc:  # noqa: BLE001
         return CheckResult(
-            name="league_registry", ok=False,
+            name="league_registry",
+            ok=False,
             message=f"load failed: {exc}",
             fatal=True,
             context={"error": str(exc)},
@@ -157,21 +171,24 @@ def run_all(
             try:
                 checks.append(cf())
             except Exception as exc:  # noqa: BLE001
-                checks.append(CheckResult(
-                    name=f"extra:{cf.__name__}", ok=False,
-                    message=f"check raised: {exc}",
-                    fatal=False,
-                ))
+                checks.append(
+                    CheckResult(
+                        name=f"extra:{cf.__name__}",
+                        ok=False,
+                        message=f"check raised: {exc}",
+                        fatal=False,
+                    )
+                )
 
     # Log every check.
     for r in checks:
-        level = logging.INFO if r.ok else (
-            logging.ERROR if r.fatal else logging.WARNING
-        )
+        level = logging.INFO if r.ok else (logging.ERROR if r.fatal else logging.WARNING)
         _LOGGER.log(
             level,
             "startup_check=%s ok=%s message=%r%s",
-            r.name, r.ok, r.message,
+            r.name,
+            r.ok,
+            r.message,
             f" context={r.context}" if r.context else "",
         )
 
@@ -180,12 +197,15 @@ def run_all(
     if n_fatal:
         _LOGGER.error(
             "startup_summary=degraded failures=%d fatal=%d total=%d",
-            n_failures, n_fatal, len(checks),
+            n_failures,
+            n_fatal,
+            len(checks),
         )
     elif n_failures:
         _LOGGER.warning(
             "startup_summary=degraded failures=%d total=%d",
-            n_failures, len(checks),
+            n_failures,
+            len(checks),
         )
     else:
         _LOGGER.info("startup_summary=healthy checks=%d", len(checks))
@@ -202,8 +222,11 @@ def summary(checks: list[CheckResult]) -> dict[str, Any]:
         "fatal": sum(1 for r in checks if r.fatal),
         "checks": [
             {
-                "name": r.name, "ok": r.ok, "message": r.message,
-                "fatal": r.fatal, "context": r.context or {},
+                "name": r.name,
+                "ok": r.ok,
+                "message": r.message,
+                "fatal": r.fatal,
+                "context": r.context or {},
             }
             for r in checks
         ],

--- a/src/api/team_assignment.py
+++ b/src/api/team_assignment.py
@@ -56,6 +56,7 @@ Output shape::
       "asOf": str,                    # ISO timestamp
     }
 """
+
 from __future__ import annotations
 
 import datetime as _dt
@@ -131,6 +132,7 @@ def _merge_config_with_defaults(raw: dict[str, Any]) -> dict[str, Any]:
     """Merge user config over defaults so a partial file still works.
     Strips inline ``_doc`` keys.
     """
+
     def _strip_doc(d: dict[str, Any]) -> dict[str, Any]:
         return {k: v for k, v in d.items() if k != "_doc"}
 
@@ -304,7 +306,9 @@ def _score_player(
         # proxy for "this is one of the best at their position."
         pts = int(weights["eliteProductionTop24"])
         points += pts
-        contributors.append({"points": pts, "reason": f"Top {pos} at {meta.get('team', 'NFL team')}"})
+        contributors.append(
+            {"points": pts, "reason": f"Top {pos} at {meta.get('team', 'NFL team')}"}
+        )
 
     # T4 — Rookie capital.
     if _is_rookie(meta):
@@ -338,7 +342,7 @@ def _league_idp_enabled(snapshot: PublicLeagueSnapshot) -> bool:
     season = snapshot.current_season
     if season is None:
         return False
-    raw = (season.league.get("roster_positions") or [])
+    raw = season.league.get("roster_positions") or []
     for slot in raw:
         s = str(slot or "").upper()
         if s in _IDP_POSITIONS or s in ("IDP", "IDP_FLEX", "IDP_DL", "IDP_LB", "IDP_DB"):
@@ -399,9 +403,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         favorite_entry = favorites.get(favorite_key) if favorite_key else None
 
         # Aggregator: nfl_team_abbr -> (score, contributors_list).
-        scored: dict[str, dict[str, Any]] = defaultdict(
-            lambda: {"score": 0, "contributors": []}
-        )
+        scored: dict[str, dict[str, Any]] = defaultdict(lambda: {"score": 0, "contributors": []})
 
         player_ids = roster.get("players") or []
         for pid in player_ids:
@@ -412,7 +414,9 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             if not nfl_team:
                 continue
             pts, contributors = _score_player(
-                meta, config=config, league_idp_enabled=idp_enabled,
+                meta,
+                config=config,
+                league_idp_enabled=idp_enabled,
             )
             if pts <= 0:
                 continue
@@ -420,11 +424,13 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             slot["score"] += pts
             display = _player_display(meta, pid)
             for c in contributors:
-                slot["contributors"].append({
-                    "player": display,
-                    "points": int(c["points"]),
-                    "reason": str(c["reason"]),
-                })
+                slot["contributors"].append(
+                    {
+                        "player": display,
+                        "points": int(c["points"]),
+                        "reason": str(c["reason"]),
+                    }
+                )
 
         # Build the NFL-teams list for this owner.
         nfl_teams_out: list[dict[str, Any]] = []
@@ -434,13 +440,15 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             fav_abbr = str(favorite_entry.get("abbr") or "").upper()
             fav_display = str(favorite_entry.get("display") or fav_abbr)
             slot = scored.get(fav_abbr, {"score": 0, "contributors": []})
-            nfl_teams_out.append({
-                "abbr": fav_abbr,
-                "display": fav_display,
-                "isFavorite": True,
-                "score": int(slot["score"]),
-                "contributors": list(slot["contributors"]),
-            })
+            nfl_teams_out.append(
+                {
+                    "abbr": fav_abbr,
+                    "display": fav_display,
+                    "isFavorite": True,
+                    "score": int(slot["score"]),
+                    "contributors": list(slot["contributors"]),
+                }
+            )
 
         # 2. Roster-based qualifiers — anyone else above threshold,
         #    sorted by score desc.  Skip the favorite (already added).
@@ -464,13 +472,15 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         remaining_capacity = max(0, max_teams - len(nfl_teams_out))
         nfl_teams_out.extend(roster_based[:remaining_capacity])
 
-        assignments.append({
-            "ownerId": owner_id,
-            "displayName": display_name or team_name or owner_id,
-            "teamName": team_name,
-            "favoriteKey": favorite_key,
-            "nflTeams": nfl_teams_out,
-        })
+        assignments.append(
+            {
+                "ownerId": owner_id,
+                "displayName": display_name or team_name or owner_id,
+                "teamName": team_name,
+                "favoriteKey": favorite_key,
+                "nflTeams": nfl_teams_out,
+            }
+        )
 
     # Sort by display name for stable rendering — alphabetical so
     # the page is predictable across reloads.

--- a/src/api/terminal.py
+++ b/src/api/terminal.py
@@ -28,6 +28,7 @@ The payload is cheap to build (<50ms on a warm cache) but we stamp
 ``generatedAt`` so the frontend can display age relative to the last
 scrape.
 """
+
 from __future__ import annotations
 
 import statistics
@@ -55,10 +56,25 @@ TIER_CUTOFFS = (
 # module, re-implemented here so there is one authority.
 POS_GROUPS = ("QB", "RB", "WR", "TE", "K", "DEF", "IDP", "PICK")
 
-IDP_POSITIONS = frozenset({
-    "DL", "DE", "DT", "EDGE", "NT", "LB", "OLB", "ILB", "MLB",
-    "DB", "CB", "S", "FS", "SS", "IDP",
-})
+IDP_POSITIONS = frozenset(
+    {
+        "DL",
+        "DE",
+        "DT",
+        "EDGE",
+        "NT",
+        "LB",
+        "OLB",
+        "ILB",
+        "MLB",
+        "DB",
+        "CB",
+        "S",
+        "FS",
+        "SS",
+        "IDP",
+    }
+)
 
 
 def _utc_now_iso() -> str:
@@ -67,8 +83,22 @@ def _utc_now_iso() -> str:
 
 def _normalize_pos(pos: Any) -> str:
     p = str(pos or "").upper()
-    if p in {"DB", "LB", "DL", "DE", "DT", "CB", "S", "EDGE", "NT",
-             "OLB", "ILB", "MLB", "FS", "SS"}:
+    if p in {
+        "DB",
+        "LB",
+        "DL",
+        "DE",
+        "DT",
+        "CB",
+        "S",
+        "EDGE",
+        "NT",
+        "OLB",
+        "ILB",
+        "MLB",
+        "FS",
+        "SS",
+    }:
         return "IDP"
     if p == "PK":
         return "K"
@@ -143,9 +173,11 @@ def _players_array(contract: dict[str, Any]) -> list[dict[str, Any]]:
         for r in arr:
             if not isinstance(r, dict):
                 continue
-            name_lower = str(
-                r.get("displayName") or r.get("canonicalName") or r.get("name") or ""
-            ).strip().lower()
+            name_lower = (
+                str(r.get("displayName") or r.get("canonicalName") or r.get("name") or "")
+                .strip()
+                .lower()
+            )
             if name_lower and "_sleeperId" not in r:
                 sid = sleeper_lookup.get(name_lower)
                 if sid:
@@ -189,9 +221,11 @@ def _build_sleeper_id_lookup(contract: dict[str, Any]) -> dict[str, str]:
             sid = row.get("_sleeperId") or row.get("sleeperId")
             if sid is None:
                 continue
-            n = str(
-                row.get("displayName") or row.get("canonicalName") or row.get("name") or ""
-            ).strip().lower()
+            n = (
+                str(row.get("displayName") or row.get("canonicalName") or row.get("name") or "")
+                .strip()
+                .lower()
+            )
             if n and n not in out:
                 out[n] = str(sid)
     return out
@@ -262,7 +296,9 @@ def _normalize_points(raw: Iterable[Any] | None) -> list[dict[str, Any]]:
         if not isinstance(date, str):
             continue
         try:
-            t = int(datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp() * 1000)
+            t = int(
+                datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp() * 1000
+            )
         except ValueError:
             continue
         points.append({"date": date, "t": t, "rank": rank})
@@ -335,9 +371,7 @@ def _history_lookup(history: dict[str, Any] | None) -> Callable[[str], list[dict
     return _lookup
 
 
-def _build_value_history_lookup(
-    *, days: int
-) -> Callable[[str], list[dict[str, Any]]]:
+def _build_value_history_lookup(*, days: int) -> Callable[[str], list[dict[str, Any]]]:
     """Pre-load the source-value history JSONL once per terminal
     request and return a case-insensitive lookup.
 
@@ -362,7 +396,7 @@ def _build_value_history_lookup(
     if not entries:
         return lambda _name: []
     entries.sort(key=lambda e: e.get("date") or "")
-    windowed = entries[-max(1, int(days)):]
+    windowed = entries[-max(1, int(days)) :]
 
     lookup: dict[str, list[dict[str, Any]]] = {}
     for snap in windowed:
@@ -636,21 +670,27 @@ def _compute_movers(
     elif scope == "league":
         pool = [r for r in rows if _row_name(r).lower() in league_set]
     else:
-        pool = [r for r in rows if isinstance(r.get("canonicalConsensusRank"), (int, float))
-                and 0 < (r.get("canonicalConsensusRank") or 0) <= 150]
+        pool = [
+            r
+            for r in rows
+            if isinstance(r.get("canonicalConsensusRank"), (int, float))
+            and 0 < (r.get("canonicalConsensusRank") or 0) <= 150
+        ]
     moved: list[dict[str, Any]] = []
     for r in pool:
         c = _row_rank_change(r)
         if c is None or c == 0:
             continue
-        moved.append({
-            "name": _row_name(r),
-            "pos": _normalize_pos(r.get("pos") or r.get("position")),
-            "value": int(_row_value(r)),
-            "rank": _row_rank(r),
-            "change": c,
-            "onRoster": _row_name(r).lower() in roster_set,
-        })
+        moved.append(
+            {
+                "name": _row_name(r),
+                "pos": _normalize_pos(r.get("pos") or r.get("position")),
+                "value": int(_row_value(r)),
+                "rank": _row_rank(r),
+                "change": c,
+                "onRoster": _row_name(r).lower() in roster_set,
+            }
+        )
     moved.sort(key=lambda m: (abs(m["change"]), m["value"]), reverse=True)
     return moved[:limit]
 
@@ -739,45 +779,84 @@ def _evaluate_signal(ctx: dict[str, Any]) -> dict[str, Any]:
     pos = ctx.get("positiveImpactCount") or 0
 
     def add(priority: int, signal: str, tag: str, reason: str) -> None:
-        fired.append({
-            "priority": priority,
-            "signal": signal,
-            "tag": tag,
-            "reason": reason,
-        })
+        fired.append(
+            {
+                "priority": priority,
+                "signal": signal,
+                "tag": tag,
+                "reason": reason,
+            }
+        )
 
     if alert > 0 and neg > 0 and (trend7 is not None and trend7 <= -3):
-        add(100, "RISK", "alert_with_drop",
-            f"Alert-severity news alongside a 7d drop of {_fmt_delta(trend7)}.")
+        add(
+            100,
+            "RISK",
+            "alert_with_drop",
+            f"Alert-severity news alongside a 7d drop of {_fmt_delta(trend7)}.",
+        )
     if vol_label == "high" and (trend7 is not None and trend7 <= -5):
-        add(95, "RISK", "high_vol_drop",
-            f"High volatility (MAD {float(mad or 0):.1f}) with a steep 7d drop of {_fmt_delta(trend7)}.")
+        add(
+            95,
+            "RISK",
+            "high_vol_drop",
+            f"High volatility (MAD {float(mad or 0):.1f}) with a steep 7d drop of {_fmt_delta(trend7)}.",
+        )
     if (trend7 is not None and trend7 <= -3) and (trend30 is not None and trend30 <= 0):
-        add(80, "SELL", "sustained_downtrend",
-            f"7d trend {_fmt_delta(trend7)} continues a 30d trend of {_fmt_delta(trend30)}.")
+        add(
+            80,
+            "SELL",
+            "sustained_downtrend",
+            f"7d trend {_fmt_delta(trend7)} continues a 30d trend of {_fmt_delta(trend30)}.",
+        )
     if neg > 0 and vol_label == "high":
-        add(78, "SELL", "neg_news_high_vol",
-            f"Negative news with high volatility (MAD {float(mad or 0):.1f}).")
+        add(
+            78,
+            "SELL",
+            "neg_news_high_vol",
+            f"Negative news with high volatility (MAD {float(mad or 0):.1f}).",
+        )
     if alert > 0:
-        add(65, "MONITOR", "alert_present",
-            f"{alert} alert-severity headline{'' if alert == 1 else 's'} — watch for follow-up.")
+        add(
+            65,
+            "MONITOR",
+            "alert_present",
+            f"{alert} alert-severity headline{'' if alert == 1 else 's'} — watch for follow-up.",
+        )
     if vol_label == "high":
-        add(62, "MONITOR", "high_vol",
-            f"High volatility (MAD {float(mad or 0):.1f}).")
-    if conf is not None and conf < 0.35 and (
-        vol_label == "med" or (trend7 is not None and abs(trend7) >= 2)
+        add(62, "MONITOR", "high_vol", f"High volatility (MAD {float(mad or 0):.1f}).")
+    if (
+        conf is not None
+        and conf < 0.35
+        and (vol_label == "med" or (trend7 is not None and abs(trend7) >= 2))
     ):
-        add(60, "MONITOR", "low_conf_unstable",
-            f"Low market confidence ({conf * 100:.0f}%) plus recent movement.")
+        add(
+            60,
+            "MONITOR",
+            "low_conf_unstable",
+            f"Low market confidence ({conf * 100:.0f}%) plus recent movement.",
+        )
     if value >= 7000 and (trend30 is not None and trend30 >= 0) and vol_label in ("low", "med"):
-        add(50, "STRONG_HOLD", "elite_stable",
-            f"Elite value ({int(value):,}) with a non-negative 30d trend and non-high volatility.")
+        add(
+            50,
+            "STRONG_HOLD",
+            "elite_stable",
+            f"Elite value ({int(value):,}) with a non-negative 30d trend and non-high volatility.",
+        )
     if (trend7 is not None and trend7 >= 3) and vol_label != "high":
-        add(40, "BUY", "uptrend_controlled",
-            f"7d trend of {_fmt_delta(trend7)} and volatility {vol_label or '—'}.")
+        add(
+            40,
+            "BUY",
+            "uptrend_controlled",
+            f"7d trend of {_fmt_delta(trend7)} and volatility {vol_label or '—'}.",
+        )
     if pos > 0 and (rank_change is not None and rank_change > 0):
-        add(38, "BUY", "pos_news_rising",
-            f"Positive news with rank rising {_fmt_delta(rank_change)} on the last scrape.")
+        add(
+            38,
+            "BUY",
+            "pos_news_rising",
+            f"Positive news with rank rising {_fmt_delta(rank_change)} on the last scrape.",
+        )
 
     fired.sort(key=lambda r: -r["priority"])
     if not fired:
@@ -849,19 +928,21 @@ def _compute_portfolio_insights(
         value = int(_row_value(row))
         points = _normalize_points(row_history(_row_name(row)))
         vol = _volatility(points, 30)
-        rosterValues.append({
-            "name": _row_name(row),
-            "pos": pos,
-            "value": value,
-            "rank": _row_rank(row),
-            "rankChange": _row_rank_change(row),
-            "age": row.get("age"),
-            "isRookie": bool(row.get("rookie")),
-            "trend7": _window_trend(points, 7),
-            "trend30": _window_trend(points, 30),
-            "volatility": vol,
-            "volLabel": (vol or {}).get("label") or "unknown",
-        })
+        rosterValues.append(
+            {
+                "name": _row_name(row),
+                "pos": pos,
+                "value": value,
+                "rank": _row_rank(row),
+                "rankChange": _row_rank_change(row),
+                "age": row.get("age"),
+                "isRookie": bool(row.get("rookie")),
+                "trend7": _window_trend(points, 7),
+                "trend30": _window_trend(points, 30),
+                "volatility": vol,
+                "volLabel": (vol or {}).get("label") or "unknown",
+            }
+        )
     totalValue = sum(p["value"] for p in rosterValues) or 0
 
     # Best asset
@@ -910,10 +991,11 @@ def _compute_portfolio_insights(
             }
 
     # Trade chip: mid-tier rising
-    chips = [p for p in rosterValues
-             if 3000 <= p["value"] <= 7500
-             and (p["trend7"] or 0) >= 3
-             and p["volLabel"] != "high"]
+    chips = [
+        p
+        for p in rosterValues
+        if 3000 <= p["value"] <= 7500 and (p["trend7"] or 0) >= 3 and p["volLabel"] != "high"
+    ]
     chip = max(chips, key=lambda p: p["trend7"] or 0) if chips else None
     tradeChip = None
     if chip:
@@ -995,10 +1077,10 @@ def _compute_portfolio_insights(
             by_position[g]["pct"] = round(by_position[g]["value"] / totalValue * 100, 1)
 
     by_age: dict[str, dict[str, Any]] = {
-        "rookie":  {"count": 0, "value": 0, "pct": 0.0},
-        "young":   {"count": 0, "value": 0, "pct": 0.0},
-        "prime":   {"count": 0, "value": 0, "pct": 0.0},
-        "vet":     {"count": 0, "value": 0, "pct": 0.0},
+        "rookie": {"count": 0, "value": 0, "pct": 0.0},
+        "young": {"count": 0, "value": 0, "pct": 0.0},
+        "prime": {"count": 0, "value": 0, "pct": 0.0},
+        "vet": {"count": 0, "value": 0, "pct": 0.0},
         "unknown": {"count": 0, "value": 0, "pct": 0.0},
     }
     ages: list[float] = []
@@ -1020,15 +1102,13 @@ def _compute_portfolio_insights(
     if ages:
         mid = len(ages) // 2
         median_age = (
-            ages[mid]
-            if len(ages) % 2 == 1
-            else round((ages[mid - 1] + ages[mid]) / 2.0, 1)
+            ages[mid] if len(ages) % 2 == 1 else round((ages[mid - 1] + ages[mid]) / 2.0, 1)
         )
 
     vol_exposure: dict[str, dict[str, Any]] = {
-        "low":     {"count": 0, "value": 0, "pct": 0.0},
-        "med":     {"count": 0, "value": 0, "pct": 0.0},
-        "high":    {"count": 0, "value": 0, "pct": 0.0},
+        "low": {"count": 0, "value": 0, "pct": 0.0},
+        "med": {"count": 0, "value": 0, "pct": 0.0},
+        "high": {"count": 0, "value": 0, "pct": 0.0},
         "unknown": {"count": 0, "value": 0, "pct": 0.0},
     }
     for p in rosterValues:
@@ -1159,11 +1239,15 @@ def build_terminal_payload(
     for t in teams if isinstance(teams, list) else []:
         if not isinstance(t, dict):
             continue
-        availableTeams.append({
-            "ownerId": str(t.get("ownerId") or ""),
-            "name": str(t.get("name") or ""),
-            "playerCount": len(t.get("players") or []) if isinstance(t.get("players"), list) else 0,
-        })
+        availableTeams.append(
+            {
+                "ownerId": str(t.get("ownerId") or ""),
+                "name": str(t.get("name") or ""),
+                "playerCount": len(t.get("players") or [])
+                if isinstance(t.get("players"), list)
+                else 0,
+            }
+        )
 
     team_block = None
     roster_set: set[str] = set()
@@ -1313,8 +1397,9 @@ def build_terminal_payload(
                     "rosterAware": roster_coverage["rosterAware"],
                     "tradesSeen": roster_coverage["tradesSeen"],
                     "tradesApplied": roster_coverage["tradesApplied"],
-                    "reason": roster_coverage["reason"] if value is not None
-                              else "low_history_coverage",
+                    "reason": roster_coverage["reason"]
+                    if value is not None
+                    else "low_history_coverage",
                     "pastDate": past_date,
                 }
 
@@ -1328,6 +1413,7 @@ def build_terminal_payload(
 
         # Signals for each roster player.
         import time as _time_mod
+
         now_ms = int(_time_mod.time() * 1000)
         for r in roster_rows:
             points = _normalize_points(history_for(_row_name(r)))
@@ -1350,7 +1436,9 @@ def build_terminal_payload(
             # fires.  Stamped onto the signal entry so the UI can
             # render "Jamo -15% (ACL, RB)" next to the signal reason.
             injury = _injury_impact.apply_injury_impact(
-                row=r, news_for_player=player_news, now_ms=now_ms,
+                row=r,
+                news_for_player=player_news,
+                now_ms=now_ms,
             )
             entry = {
                 **ctx,
@@ -1364,20 +1452,20 @@ def build_terminal_payload(
                 "dismissed": bool(dismissed_until),
                 "injuryImpact": injury if injury.get("appliedDiscountPct") else None,
                 "injuryAdjustedValue": (
-                    injury.get("adjustedValue")
-                    if injury.get("appliedDiscountPct")
-                    else None
+                    injury.get("adjustedValue") if injury.get("appliedDiscountPct") else None
                 ),
             }
             signals_list.append(entry)
         # Sort like the frontend: RISK/SELL/MONITOR first, HOLD last,
         # value desc within bucket, then dismissed items to the tail.
         priority = {"RISK": 0, "SELL": 1, "MONITOR": 2, "STRONG_HOLD": 3, "BUY": 4, "HOLD": 5}
-        signals_list.sort(key=lambda s: (
-            1 if s["dismissed"] else 0,
-            priority.get(s["signal"], 99),
-            -(s.get("value") or 0),
-        ))
+        signals_list.sort(
+            key=lambda s: (
+                1 if s["dismissed"] else 0,
+                priority.get(s["signal"], 99),
+                -(s.get("value") or 0),
+            )
+        )
 
         # Portfolio insights (always computed for the signed-in team).
         portfolio_block = _compute_portfolio_insights(
@@ -1401,29 +1489,34 @@ def build_terminal_payload(
         if not row:
             continue
         points = _normalize_points(history_for(name))
-        watchlist_block.append({
-            "name": _row_name(row),
-            "pos": _normalize_pos(row.get("pos") or row.get("position")),
-            "value": int(_row_value(row)),
-            "rank": _row_rank(row),
-            "rankChange": _row_rank_change(row),
-            "trend7": _window_trend(points, 7),
-            "trend30": _window_trend(points, 30),
-            "trend90": _window_trend(points, 90),
-            "trend180": _window_trend(points, 180),
-            "volatility": _volatility(points, 30),
-            "onRoster": _row_name(row).lower() in roster_set,
-        })
+        watchlist_block.append(
+            {
+                "name": _row_name(row),
+                "pos": _normalize_pos(row.get("pos") or row.get("position")),
+                "value": int(_row_value(row)),
+                "rank": _row_rank(row),
+                "rankChange": _row_rank_change(row),
+                "trend7": _window_trend(points, 7),
+                "trend30": _window_trend(points, 30),
+                "trend90": _window_trend(points, 90),
+                "trend180": _window_trend(points, 180),
+                "volatility": _volatility(points, 30),
+                "onRoster": _row_name(row).lower() in roster_set,
+            }
+        )
 
     # Movers: always include all three scopes.  ``roster`` is empty if
     # the user hasn't picked a team yet.
     movers = {
-        "roster": _compute_movers(rows, scope="roster", roster_set=roster_set,
-                                  league_set=league_set, limit=20),
-        "league": _compute_movers(rows, scope="league", roster_set=roster_set,
-                                  league_set=league_set, limit=30),
-        "top150": _compute_movers(rows, scope="top150", roster_set=roster_set,
-                                  league_set=league_set, limit=30),
+        "roster": _compute_movers(
+            rows, scope="roster", roster_set=roster_set, league_set=league_set, limit=20
+        ),
+        "league": _compute_movers(
+            rows, scope="league", roster_set=roster_set, league_set=league_set, limit=30
+        ),
+        "top150": _compute_movers(
+            rows, scope="top150", roster_set=roster_set, league_set=league_set, limit=30
+        ),
     }
 
     # News is pre-scored for the picked team.
@@ -1473,7 +1566,10 @@ def build_terminal_payload(
         payload["watchlist"] = []
         payload["teamAggregates"] = {
             "totalValue": None,
-            "delta7d": None, "delta30d": None, "delta90d": None, "delta180d": None,
+            "delta7d": None,
+            "delta30d": None,
+            "delta90d": None,
+            "delta180d": None,
             "rosterAware": False,
             "tiers": None,
             "rosterCount": 0,
@@ -1531,6 +1627,7 @@ def _back_iso_date(latest_date: str, days: int) -> str:
     except ValueError:
         return latest_date
     from datetime import timedelta
+
     return (dt - timedelta(days=int(days))).strftime("%Y-%m-%d")
 
 
@@ -1563,20 +1660,22 @@ def _score_news(
             elif n in league_set and relevance < 50:
                 relevance = 50
                 matched_scope = "league"
-        scored.append({
-            "id": it.get("id"),
-            "ts": it.get("ts"),
-            "provider": it.get("provider"),
-            "providerLabel": it.get("providerLabel"),
-            "severity": it.get("severity"),
-            "kind": it.get("kind"),
-            "headline": it.get("headline"),
-            "body": it.get("body"),
-            "players": players,
-            "url": it.get("url"),
-            "relevance": relevance,
-            "scope": matched_scope,
-        })
+        scored.append(
+            {
+                "id": it.get("id"),
+                "ts": it.get("ts"),
+                "provider": it.get("provider"),
+                "providerLabel": it.get("providerLabel"),
+                "severity": it.get("severity"),
+                "kind": it.get("kind"),
+                "headline": it.get("headline"),
+                "body": it.get("body"),
+                "players": players,
+                "url": it.get("url"),
+                "relevance": relevance,
+                "scope": matched_scope,
+            }
+        )
     scored.sort(key=lambda n: (-(n.get("relevance") or 0), -_ts_ms(n.get("ts"))))
     return scored
 

--- a/src/api/trade_simulator.py
+++ b/src/api/trade_simulator.py
@@ -20,6 +20,7 @@ exactly match what the terminal panel shows — a user can't end up
 staring at a $13 delta in the header and a $147 delta in the
 simulator for the same swap.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -71,6 +72,7 @@ def _resolve_asset(
     # per-position starter rules (DL/LB/DB are separate slots in
     # rosterSettings.starters).
     from src.utils.name_clean import normalize_position
+
     base_pos = normalize_position(row.get("pos") or row.get("position"))
     return {
         "name": row.get("displayName") or row.get("canonicalName") or name,
@@ -91,9 +93,7 @@ def _aggregate(assets: list[dict[str, Any]]) -> dict[str, Any]:
     """
     total = 0
     tiers = {"elite": 0, "high": 0, "mid": 0, "depth": 0}
-    by_position: dict[str, dict[str, int]] = {
-        g: {"count": 0, "value": 0} for g in POS_GROUPS
-    }
+    by_position: dict[str, dict[str, int]] = {g: {"count": 0, "value": 0} for g in POS_GROUPS}
     for a in assets:
         v = int(a.get("value") or 0)
         total += v
@@ -119,8 +119,10 @@ def _diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
         },
         "byPosition": {
             g: {
-                "count": int(after["byPosition"][g]["count"]) - int(before["byPosition"][g]["count"]),
-                "value": int(after["byPosition"][g]["value"]) - int(before["byPosition"][g]["value"]),
+                "count": int(after["byPosition"][g]["count"])
+                - int(before["byPosition"][g]["count"]),
+                "value": int(after["byPosition"][g]["value"])
+                - int(before["byPosition"][g]["value"]),
             }
             for g in POS_GROUPS
         },
@@ -192,14 +194,15 @@ def simulate_trade(
     # typos) should still return full-board before/after totals that match
     # the terminal panel, not offense-only baselines.
     trade_has_resolved = any(
-        row_index.get(n.strip().lower()) is not None
-        for n in all_trade_names if n.strip()
+        row_index.get(n.strip().lower()) is not None for n in all_trade_names if n.strip()
     )
     trade_has_idp = trade_has_resolved and any(
         _normalize_pos(
-            (row_index.get(n.strip().lower()) or {}).get("pos") or
-            (row_index.get(n.strip().lower()) or {}).get("position") or ""
-        ) == "IDP"
+            (row_index.get(n.strip().lower()) or {}).get("pos")
+            or (row_index.get(n.strip().lower()) or {}).get("position")
+            or ""
+        )
+        == "IDP"
         for n in all_trade_names
         if n.strip()
     )
@@ -270,6 +273,7 @@ def simulate_trade(
     # this block entirely.
     if resolved_team and roster_settings:
         from src.trade import team_impact
+
         impact = team_impact.compute(
             before_assets=before_assets,
             after_assets=after_assets,

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -49,6 +49,7 @@ backed module; the migration is a pure drop-in.  Legacy
 ``data/user_kv.json`` files are imported once on first boot (see
 ``_migrate_legacy_json_if_present``).
 """
+
 from __future__ import annotations
 
 import json
@@ -64,41 +65,43 @@ _LEGACY_JSON_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "user_k
 
 # Known top-level keys we understand.  Anything else in a user's
 # record is preserved but not validated.
-KNOWN_KEYS = frozenset({
-    "selectedTeam",
-    "watchlist",
-    "dismissedSignals",
-    # Per-league nested dismissals: ``{leagueKey: {signalKey: expiresAt}}``.
-    # Takes precedence over the flat field when ``active_dismissals``
-    # is called with a ``league_key``.  Dismissing a signal on league
-    # A no longer silences the same player's signal on league B.
-    "dismissedSignalsByLeague",
-    "dismissalAliases",
-    # Per-league signal-alert state used by signal_alerts.py for the
-    # 12-hour cooldown: ``{leagueKey: {stateKey: {signal, notifiedAt}}}``.
-    # Prevents a SELL in league A from silently suppressing the same
-    # player's SELL notification in league B.
-    "signalAlertStateByLeague",
-    "updatedAt",
-    # League preference — the user's currently-active league key from
-    # the league registry (``src/api/league_registry``).  Persists
-    # across devices so that a user who switches to the non-IDP
-    # league on mobile sees the same league on desktop.  Unvalidated
-    # here; the PUT endpoint validates against the live registry.
-    "activeLeagueKey",
-    # Per-league selected team.  Shape:
-    #   ``{ [leagueKey]: {ownerId, teamName, rosterId?, managerName?} }``
-    # Takes precedence over the legacy top-level ``selectedTeam`` when
-    # a per-league entry exists for the active league.  The legacy
-    # field is kept for back-compat — it's treated as the default
-    # league's entry on read, and writes mirror to both for one more
-    # release so pre-migration clients don't flip empty on first load.
-    "selectedTeamsByLeague",
-    # Notification preferences already flow through ``merge_user_state``
-    # — listed here so new readers know the schema includes them.
-    "notificationsEmail",
-    "notificationsEnabled",
-})
+KNOWN_KEYS = frozenset(
+    {
+        "selectedTeam",
+        "watchlist",
+        "dismissedSignals",
+        # Per-league nested dismissals: ``{leagueKey: {signalKey: expiresAt}}``.
+        # Takes precedence over the flat field when ``active_dismissals``
+        # is called with a ``league_key``.  Dismissing a signal on league
+        # A no longer silences the same player's signal on league B.
+        "dismissedSignalsByLeague",
+        "dismissalAliases",
+        # Per-league signal-alert state used by signal_alerts.py for the
+        # 12-hour cooldown: ``{leagueKey: {stateKey: {signal, notifiedAt}}}``.
+        # Prevents a SELL in league A from silently suppressing the same
+        # player's SELL notification in league B.
+        "signalAlertStateByLeague",
+        "updatedAt",
+        # League preference — the user's currently-active league key from
+        # the league registry (``src/api/league_registry``).  Persists
+        # across devices so that a user who switches to the non-IDP
+        # league on mobile sees the same league on desktop.  Unvalidated
+        # here; the PUT endpoint validates against the live registry.
+        "activeLeagueKey",
+        # Per-league selected team.  Shape:
+        #   ``{ [leagueKey]: {ownerId, teamName, rosterId?, managerName?} }``
+        # Takes precedence over the legacy top-level ``selectedTeam`` when
+        # a per-league entry exists for the active league.  The legacy
+        # field is kept for back-compat — it's treated as the default
+        # league's entry on read, and writes mirror to both for one more
+        # release so pre-migration clients don't flip empty on first load.
+        "selectedTeamsByLeague",
+        # Notification preferences already flow through ``merge_user_state``
+        # — listed here so new readers know the schema includes them.
+        "notificationsEmail",
+        "notificationsEnabled",
+    }
+)
 
 # Process-wide lock around connection setup / migration so module
 # import is thread-safe.  SQLite itself handles per-transaction
@@ -412,11 +415,7 @@ def _merge_per_league_dismissals(
     if isinstance(existing_by_league, dict):
         for k, v in existing_by_league.items():
             if isinstance(k, str) and isinstance(v, dict):
-                by_league[k] = {
-                    str(sk): int(sv)
-                    for sk, sv in v.items()
-                    if str(sk)
-                }
+                by_league[k] = {str(sk): int(sv) for sk, sv in v.items() if str(sk)}
     bucket = dict(by_league.get(league_key) or {})
     if add:
         for k, v in add.items():
@@ -466,7 +465,9 @@ def dismiss_signal(
     if key:
         existing = get_user_state(username, path=path).get("dismissedSignalsByLeague")
         patch["dismissedSignalsByLeague"] = _merge_per_league_dismissals(
-            existing, key, add={str(signal_key): expires_at},
+            existing,
+            key,
+            add={str(signal_key): expires_at},
         )
     else:
         patch["dismissedSignals"] = {str(signal_key): expires_at}

--- a/src/backtesting/correlation.py
+++ b/src/backtesting/correlation.py
@@ -11,6 +11,7 @@ who actually scored the most?"
 
 Pure-Python, no SciPy.  O(n log n) from the sort.
 """
+
 from __future__ import annotations
 
 import math
@@ -73,8 +74,10 @@ def score_source(
     common = set(source_ranks.keys()) & set(realized_points.keys())
     if len(common) < 2:
         return SourceAccuracy(
-            source=source, n_players=len(common),
-            spearman_rho=0.0, top_50_hit_rate=0.0,
+            source=source,
+            n_players=len(common),
+            spearman_rho=0.0,
+            top_50_hit_rate=0.0,
         )
     # Spearman: lower rank = better.  Negate rank so higher-number
     # means better (aligning with points direction).
@@ -102,8 +105,7 @@ def score_all_sources(
     """Score every source in the input dict and return sorted by
     descending Spearman."""
     results = [
-        score_source(src, ranks, realized_points)
-        for src, ranks in source_ranks_by_source.items()
+        score_source(src, ranks, realized_points) for src, ranks in source_ranks_by_source.items()
     ]
     results.sort(key=lambda a: -a.spearman_rho)
     return results

--- a/src/backtesting/dynamic_weights.py
+++ b/src/backtesting/dynamic_weights.py
@@ -26,6 +26,7 @@ existing ``config/weights/default.json`` (or whatever the
 canonical pipeline uses today) is unchanged.  Shipping this
 module can't regress rankings until the flag flips.
 """
+
 from __future__ import annotations
 
 import json
@@ -66,6 +67,7 @@ def raw_weights_from_accuracy(
         return {}
     # Shift to [0, 2] — rho=1 → weight exp(2), rho=-1 → exp(-0).
     import math
+
     weights_raw = {a.source: math.exp(max(0.0, a.spearman_rho + 1.0)) for a in eligible}
     total = sum(weights_raw.values())
     normalized = {s: max(floor, w / total) for s, w in weights_raw.items()}

--- a/src/backtesting/harness.py
+++ b/src/backtesting/harness.py
@@ -43,6 +43,7 @@ useful until the weight fitter is running.  Also simple
 enough that it doesn't need a flag — the module just returns
 empty summary when there's no historical data.
 """
+
 from __future__ import annotations
 
 import logging
@@ -128,7 +129,8 @@ def _bucket_for(win_prob_a: float) -> str | None:
 
 
 def _sum_value_at(
-    names: list[str], on_date: str,
+    names: list[str],
+    on_date: str,
     value_snapshots: dict[tuple[str, str], float],
 ) -> float | None:
     """Sum the values of a list of player/pick names on a specific
@@ -223,9 +225,7 @@ def format_report(summary: BacktestSummary) -> str:
         mid = (float(label.split("-")[0]) + float(label.split("-")[1])) / 2
         if bucket.total == 0:
             # Empty bucket — don't show a misleading calibration delta.
-            lines.append(
-                f"  {label:<18} {bucket.total:>5}  {bucket.correct:>7}   —       —"
-            )
+            lines.append(f"  {label:<18} {bucket.total:>5}  {bucket.correct:>7}   —       —")
             continue
         deviation = bucket.accuracy - mid
         lines.append(

--- a/src/canonical/__init__.py
+++ b/src/canonical/__init__.py
@@ -8,6 +8,7 @@ endpoint now own the full valuation flow through
 ``src.canonical`` is the scope-level Hill curves + the ``run_valuation``
 pipeline used by ``data_contract.py``.
 """
+
 from .player_valuation import (
     run_valuation,
     build_player_inputs_from_raw_records,

--- a/src/canonical/calibration.py
+++ b/src/canonical/calibration.py
@@ -14,6 +14,7 @@ Calibration is universe-aware:
 The calibration parameters are empirically chosen to maximize tier
 agreement with the legacy system based on comparison batch data.
 """
+
 from __future__ import annotations
 
 import datetime
@@ -79,7 +80,9 @@ def to_display_value(calibrated_value: int | float) -> int:
     """
     if calibrated_value <= 0:
         return 1
-    return max(1, min(DISPLAY_SCALE_MAX, round(calibrated_value * DISPLAY_SCALE_MAX / INTERNAL_SCALE_MAX)))
+    return max(
+        1, min(DISPLAY_SCALE_MAX, round(calibrated_value * DISPLAY_SCALE_MAX / INTERNAL_SCALE_MAX))
+    )
 
 
 # Non-fantasy positions that should be calibrated very low
@@ -188,7 +191,7 @@ def _pick_curve_value(info: dict[str, Any], current_year: int | None = None) -> 
     year = info.get("year")
     if year is not None and year > current_year:
         years_out = year - current_year
-        discount = PICK_YEAR_DISCOUNT ** years_out
+        discount = PICK_YEAR_DISCOUNT**years_out
         base = int(base * discount)
 
     return max(100, min(PICK_CEILING, base))
@@ -261,8 +264,7 @@ def calibrate_canonical_values(
             Hill-curve pipeline (would cause double-calibration).
     """
     canonical_tagged = [
-        a for a in assets
-        if a.get("_pick_calibration_source") == "canonical_pipeline"
+        a for a in assets if a.get("_pick_calibration_source") == "canonical_pipeline"
     ]
     if canonical_tagged:
         sample = canonical_tagged[0].get("display_name", "<unknown>")
@@ -301,10 +303,10 @@ def calibrate_canonical_values(
             rank = rank_idx + 1
             percentile = (depth - (rank - 1)) / depth
             if percentile >= uni_knee:
-                calibrated = int(round(scale * (percentile ** exponent)))
+                calibrated = int(round(scale * (percentile**exponent)))
             else:
                 # Linear ramp from 0 to the curve value at the knee
-                knee_val = scale * (uni_knee ** exponent)
+                knee_val = scale * (uni_knee**exponent)
                 calibrated = int(round(knee_val * (percentile / uni_knee)))
             calibrated = max(0, min(scale, calibrated))
 

--- a/src/canonical/confidence_intervals.py
+++ b/src/canonical/confidence_intervals.py
@@ -42,6 +42,7 @@ looks broken in the UI.
 
 Pure-Python — no numpy dependency.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -176,7 +177,7 @@ def compute_value_band(
     if source_weights:
         # Re-weight.
         pairs_w: list[tuple[float, float]] = []
-        for (v, _old) in pairs:
+        for v, _old in pairs:
             # Look up the source weight by finding it in source_ranks by v-key.
             # When we don't have a stable pairing we fall through to uniform.
             pairs_w.append((v, 1.0))
@@ -212,7 +213,9 @@ def compute_value_band(
         )
 
     return ValueBand(
-        p10=p10, p50=p50, p90=p90,
+        p10=p10,
+        p50=p50,
+        p90=p90,
         source_count=len(pairs),
         method="bracket",
     )

--- a/src/canonical/idp_backbone.py
+++ b/src/canonical/idp_backbone.py
@@ -43,6 +43,7 @@ Design notes
   `SOURCE_SCOPE_POSITION_IDP` are the canonical scope tokens used across
   both backends.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -69,11 +70,11 @@ VALID_SOURCE_SCOPES = frozenset(
 IDP_POSITION_GROUPS = ("DL", "LB", "DB")
 
 # ── Translation result constants ────────────────────────────────────────
-TRANSLATION_DIRECT = "direct"            # overall_idp / overall_offense
-TRANSLATION_EXACT = "exact"              # position_idp matched an anchor
+TRANSLATION_DIRECT = "direct"  # overall_idp / overall_offense
+TRANSLATION_EXACT = "exact"  # position_idp matched an anchor
 TRANSLATION_INTERPOLATED = "interpolated"  # fractional position between anchors
 TRANSLATION_EXTRAPOLATED = "extrapolated"  # past the last known anchor
-TRANSLATION_FALLBACK = "fallback"        # backbone absent; no-op passthrough
+TRANSLATION_FALLBACK = "fallback"  # backbone absent; no-op passthrough
 
 
 @dataclass(frozen=True)
@@ -264,7 +265,7 @@ def translate_position_rank(
 
     # Interpolation within the ladder
     if 1.0 <= pr <= float(n):
-        low_idx = int(pr) - 1           # 0-based index of left anchor
+        low_idx = int(pr) - 1  # 0-based index of left anchor
         frac = pr - float(int(pr))
         low = ladder[low_idx]
         high = ladder[min(low_idx + 1, n - 1)]

--- a/src/canonical/normalization_validator.py
+++ b/src/canonical/normalization_validator.py
@@ -28,6 +28,7 @@ Consumers:
 No silent failures — every mismatch logs a warning via the root
 logger with a structured prefix ``normalization_mismatch=…``.
 """
+
 from __future__ import annotations
 
 import logging
@@ -92,16 +93,26 @@ def _classify_position(position: str) -> str:
 
 
 def _log_mismatch(
-    category: str, detail: str, row_snippet: dict[str, Any],
+    category: str,
+    detail: str,
+    row_snippet: dict[str, Any],
 ) -> None:
     """Emit a structured single-line warning.  Prefix makes grep
     triage fast:  ``grep normalization_mismatch= dynasty.log``."""
     _LOGGER.warning(
         "normalization_mismatch=%s detail=%r row=%s",
-        category, detail,
-        {k: row_snippet.get(k) for k in (
-            "displayName", "canonicalName", "position", "assetClass", "playerId",
-        )},
+        category,
+        detail,
+        {
+            k: row_snippet.get(k)
+            for k in (
+                "displayName",
+                "canonicalName",
+                "position",
+                "assetClass",
+                "playerId",
+            )
+        },
     )
 
 
@@ -132,10 +143,13 @@ def validate_players_array(
         if dn is not None and cn is not None and dn != cn:
             result.player_name_drift += 1
             if len(result.samples) < 20:
-                result.samples.append({
-                    "category": "player_name_drift",
-                    "displayName": dn, "canonicalName": cn,
-                })
+                result.samples.append(
+                    {
+                        "category": "player_name_drift",
+                        "displayName": dn,
+                        "canonicalName": cn,
+                    }
+                )
             _log_mismatch("player_name_drift", f"{dn!r} != {cn!r}", row)
 
         # 2. Pick-name shape.
@@ -144,10 +158,12 @@ def validate_players_array(
             if not is_valid_pick_name(dn or cn or ""):
                 result.pick_name_malformed += 1
                 if len(result.samples) < 20:
-                    result.samples.append({
-                        "category": "pick_name_malformed",
-                        "name": dn or cn,
-                    })
+                    result.samples.append(
+                        {
+                            "category": "pick_name_malformed",
+                            "name": dn or cn,
+                        }
+                    )
                 _log_mismatch("pick_name_malformed", str(dn or cn), row)
 
         # 3. assetClass / position agreement.
@@ -155,24 +171,28 @@ def validate_players_array(
             if asset_class not in _VALID_ASSET_CLASSES:
                 result.asset_class_mismatch += 1
                 if len(result.samples) < 20:
-                    result.samples.append({
-                        "category": "asset_class_unknown",
-                        "assetClass": asset_class,
-                        "name": dn or cn,
-                    })
+                    result.samples.append(
+                        {
+                            "category": "asset_class_unknown",
+                            "assetClass": asset_class,
+                            "name": dn or cn,
+                        }
+                    )
                 _log_mismatch("asset_class_unknown", asset_class, row)
             else:
                 expected = _classify_position(row.get("position") or "")
                 if expected != "other" and expected != asset_class:
                     result.asset_class_mismatch += 1
                     if len(result.samples) < 20:
-                        result.samples.append({
-                            "category": "asset_class_mismatch",
-                            "position": row.get("position"),
-                            "expected": expected,
-                            "got": asset_class,
-                            "name": dn or cn,
-                        })
+                        result.samples.append(
+                            {
+                                "category": "asset_class_mismatch",
+                                "position": row.get("position"),
+                                "expected": expected,
+                                "got": asset_class,
+                                "name": dn or cn,
+                            }
+                        )
                     _log_mismatch(
                         "asset_class_mismatch",
                         f"pos={row.get('position')} exp={expected} got={asset_class}",
@@ -188,13 +208,17 @@ def validate_players_array(
         if count > 1:
             result.dup_keys += 1
             if len(result.samples) < 20:
-                result.samples.append({
-                    "category": "dup_key",
-                    "name": name_key, "count": count,
-                })
+                result.samples.append(
+                    {
+                        "category": "dup_key",
+                        "name": name_key,
+                        "count": count,
+                    }
+                )
             _LOGGER.warning(
                 "normalization_mismatch=dup_key detail=%r count=%d",
-                name_key, count,
+                name_key,
+                count,
             )
 
     return result
@@ -219,10 +243,13 @@ def validate_legacy_players_dict(
         if inner and inner != key:
             result.player_name_drift += 1
             if len(result.samples) < 20:
-                result.samples.append({
-                    "category": "player_name_drift",
-                    "key": key, "inner": inner,
-                })
+                result.samples.append(
+                    {
+                        "category": "player_name_drift",
+                        "key": key,
+                        "inner": inner,
+                    }
+                )
             _log_mismatch("player_name_drift", f"{key!r} != {inner!r}", {"key": key, **row})
     return result
 

--- a/src/canonical/player_valuation.py
+++ b/src/canonical/player_valuation.py
@@ -20,6 +20,7 @@ Pipeline:
     Step 5 – Volatility confidence adjustment
     Step 6 – Final output assembly
 """
+
 from __future__ import annotations
 
 import math
@@ -37,9 +38,9 @@ W_MEDIAN: float = 0.70
 W_MEAN: float = 0.30
 
 # Step 2: Tier detection
-TIER_GAP_WINDOW: int = 7           # rolling-median window (each side)
-TIER_GAP_THRESHOLD: float = 2.0    # gap_score above this triggers a break
-TIER_MIN_SIZE: int = 3             # minimum players in a tier before allowing split
+TIER_GAP_WINDOW: int = 7  # rolling-median window (each side)
+TIER_GAP_THRESHOLD: float = 2.0  # gap_score above this triggers a break
+TIER_MIN_SIZE: int = 3  # minimum players in a tier before allowing split
 
 # Step 3: Base value curve — Hill-style, rank 1 always = 9999
 # value = 1 + 9998 / (1 + ((rank - 1) / midpoint)^slope)
@@ -51,8 +52,8 @@ TIER_MIN_SIZE: int = 3             # minimum players in a tier before allowing s
 # top player = 9999 before fitting. Re-run
 # ``scripts/fit_hill_curve_from_market.py`` when the community's
 # dropoff shape drifts from ours and update the constants here.
-HILL_MIDPOINT: float = 48.44       # rank at which value decay inflects
-HILL_SLOPE: float = 1.149          # controls steepness of decay
+HILL_MIDPOINT: float = 48.44  # rank at which value decay inflects
+HILL_SLOPE: float = 1.149  # controls steepness of decay
 
 # IDP-specific Hill curve.  Dynasty IDP markets price differently from
 # offense: the #1 LB is nowhere near 2x the #2 the way the #1 QB is,
@@ -113,12 +114,12 @@ HILL_ROOKIE_PERCENTILE_C: float = 0.1440
 HILL_ROOKIE_PERCENTILE_S: float = 0.925
 
 # Step 4: Tier cliff injection
-CLIFF_BASE_POINTS: float = 120.0   # base cliff size in value units
-CLIFF_RANK_DECAY: float = 0.006    # cliff decays with rank (deeper = smaller cliff)
+CLIFF_BASE_POINTS: float = 120.0  # base cliff size in value units
+CLIFF_RANK_DECAY: float = 0.006  # cliff decays with rank (deeper = smaller cliff)
 
 # Step 5: Volatility adjustment
-VOL_COMPRESSION_STRENGTH: float = 0.03   # max compression fraction per unit of z-scored volatility
-VOL_FLOOR: float = 0.92                  # worst-case: retain at least 92% of value
+VOL_COMPRESSION_STRENGTH: float = 0.03  # max compression fraction per unit of z-scored volatility
+VOL_FLOOR: float = 0.92  # worst-case: retain at least 92% of value
 
 # Step 6: Display scale
 DISPLAY_SCALE_MAX: int = 9999
@@ -129,9 +130,11 @@ DISPLAY_SCALE_MIN: int = 1
 # DATA STRUCTURES
 # ══════════════════════════════════════════════════════════════════════
 
+
 @dataclass
 class PlayerValuation:
     """Full diagnostic output for a single player."""
+
     player_id: str
     display_name: str
 
@@ -140,25 +143,27 @@ class PlayerValuation:
     median_rank: float
     mean_rank: float
     consensus_rank: float
-    rank_volatility: float        # std-dev of source ranks
+    rank_volatility: float  # std-dev of source ranks
 
     # Step 2 outputs
     tier_id: int
-    is_tier_start: bool           # True if this player is the first player in a new tier (a break exists directly above)
-    gap_to_next: float | None     # raw gap to next-ranked player
-    gap_score: float | None       # normalized gap score
+    is_tier_start: bool  # True if this player is the first player in a new tier (a break exists directly above)
+    gap_to_next: float | None  # raw gap to next-ranked player
+    gap_score: float | None  # normalized gap score
 
     # Step 3–5 outputs
-    base_value: float             # from curve only
-    tier_adjustment: float        # cliff injection amount
+    base_value: float  # from curve only
+    tier_adjustment: float  # cliff injection amount
     volatility_adjustment: float  # compression amount (negative)
-    final_value: float            # base + tier_adj + vol_adj
+    final_value: float  # base + tier_adj + vol_adj
 
     # Monotonicity enforcement
-    monotonic_clamp_applied: bool  # True if this player's value was clamped down to preserve strict ordering
+    monotonic_clamp_applied: (
+        bool  # True if this player's value was clamped down to preserve strict ordering
+    )
 
     # Display
-    display_value: int            # mapped to 1–9999
+    display_value: int  # mapped to 1–9999
 
     # Pass-through metadata
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -170,28 +175,33 @@ class PlayerValuation:
 @dataclass
 class TierBoundary:
     """Record of a detected tier break."""
+
     tier_id_above: int
     tier_id_below: int
-    player_above: str        # last player in upper tier (player_id)
-    player_below: str        # first player in lower tier (player_id)
+    player_above: str  # last player in upper tier (player_id)
+    player_below: str  # first player in lower tier (player_id)
     raw_gap: float
     gap_score: float
-    rank_position: float     # consensus rank where the break occurs
+    rank_position: float  # consensus rank where the break occurs
 
 
 @dataclass
 class ValuationResult:
     """Complete output of the valuation pipeline."""
+
     players: list[PlayerValuation]
     tier_boundaries: list[TierBoundary]
     tier_count: int
-    monotonic_clamp_count: int        # number of players whose values were clamped to preserve strict ordering
+    monotonic_clamp_count: (
+        int  # number of players whose values were clamped to preserve strict ordering
+    )
     hyperparameters: dict[str, Any]
 
 
 # ══════════════════════════════════════════════════════════════════════
 # STEP 1 — CONSENSUS RANK
 # ══════════════════════════════════════════════════════════════════════
+
 
 def compute_consensus_rank(
     source_ranks: Sequence[float],
@@ -220,6 +230,7 @@ def compute_consensus_rank(
 # ══════════════════════════════════════════════════════════════════════
 # STEP 2 — TIER DETECTION
 # ══════════════════════════════════════════════════════════════════════
+
 
 def _rolling_median(values: Sequence[float], idx: int, window: int) -> float:
     """Compute rolling median of *values* centered on *idx*.
@@ -295,15 +306,17 @@ def detect_tiers(
     # Build boundary records
     boundaries: list[TierBoundary] = []
     for bi in break_indices:
-        boundaries.append(TierBoundary(
-            tier_id_above=tier_ids[bi],
-            tier_id_below=tier_ids[bi] + 1 if bi + 1 < n else tier_ids[bi],
-            player_above=player_ids[bi],
-            player_below=player_ids[bi + 1] if bi + 1 < n else player_ids[bi],
-            raw_gap=raw_gaps[bi],
-            gap_score=gap_scores[bi],
-            rank_position=consensus_ranks[bi],
-        ))
+        boundaries.append(
+            TierBoundary(
+                tier_id_above=tier_ids[bi],
+                tier_id_below=tier_ids[bi] + 1 if bi + 1 < n else tier_ids[bi],
+                player_above=player_ids[bi],
+                player_below=player_ids[bi + 1] if bi + 1 < n else player_ids[bi],
+                raw_gap=raw_gaps[bi],
+                gap_score=gap_scores[bi],
+                rank_position=consensus_ranks[bi],
+            )
+        )
 
     # Pad gaps/scores to length n (last player has no gap)
     raw_gaps_padded: list[float | None] = [*raw_gaps, None]
@@ -315,6 +328,7 @@ def detect_tiers(
 # ══════════════════════════════════════════════════════════════════════
 # STEP 3 — BASE VALUE CURVE
 # ══════════════════════════════════════════════════════════════════════
+
 
 def rank_to_value(
     rank: float,
@@ -389,6 +403,7 @@ def percentile_to_value(
 # STEP 4 — TIER CLIFF INJECTION
 # ══════════════════════════════════════════════════════════════════════
 
+
 def compute_tier_adjustments(
     consensus_ranks: list[float],
     tier_ids: list[int],
@@ -419,9 +434,7 @@ def compute_tier_adjustments(
     # to every tier above it.
     cliff_at_boundary: dict[int, float] = {}
     for b in boundaries:
-        cliff_at_boundary[b.tier_id_below] = cliff_base * math.exp(
-            -cliff_decay * b.rank_position
-        )
+        cliff_at_boundary[b.tier_id_below] = cliff_base * math.exp(-cliff_decay * b.rank_position)
 
     # Walk tiers top-down.  Tier 1 accumulates all cliffs; each subsequent
     # tier loses the cliff that sits above it.
@@ -439,6 +452,7 @@ def compute_tier_adjustments(
 # ══════════════════════════════════════════════════════════════════════
 # STEP 5 — VOLATILITY CONFIDENCE ADJUSTMENT
 # ══════════════════════════════════════════════════════════════════════
+
 
 def compute_volatility_adjustments(
     base_plus_tier: list[float],
@@ -489,6 +503,7 @@ def compute_volatility_adjustments(
 # STEP 6 — FULL PIPELINE
 # ══════════════════════════════════════════════════════════════════════
 
+
 def compute_display_anchor(**_kwargs: object) -> float:
     """Deprecated — rank_to_value() no longer needs a display anchor.
 
@@ -510,6 +525,7 @@ def _to_display(rank: float, _anchor: float = 0.0) -> int:
 @dataclass
 class PlayerInput:
     """Minimal input for the valuation pipeline."""
+
     player_id: str
     display_name: str
     source_ranks: list[float]
@@ -551,21 +567,30 @@ def run_valuation(
             tier_boundaries=[],
             tier_count=0,
             monotonic_clamp_count=0,
-            hyperparameters=_collect_hyperparams({
-                "w_median": w_median, "w_mean": w_mean,
-                "gap_window": gap_window, "gap_threshold": gap_threshold,
-                "min_tier_size": min_tier_size,
-                "hill_midpoint": hill_midpoint, "hill_slope": hill_slope,
-                "cliff_base": cliff_base, "cliff_decay": cliff_decay,
-                "vol_strength": vol_strength, "vol_floor": vol_floor,
-            }),
+            hyperparameters=_collect_hyperparams(
+                {
+                    "w_median": w_median,
+                    "w_mean": w_mean,
+                    "gap_window": gap_window,
+                    "gap_threshold": gap_threshold,
+                    "min_tier_size": min_tier_size,
+                    "hill_midpoint": hill_midpoint,
+                    "hill_slope": hill_slope,
+                    "cliff_base": cliff_base,
+                    "cliff_decay": cliff_decay,
+                    "vol_strength": vol_strength,
+                    "vol_floor": vol_floor,
+                }
+            ),
         )
 
     # ── Step 1: Consensus rank ──
     consensus_data: list[tuple[PlayerInput, float, float, float, float]] = []
     for p in players:
         cr, med, avg, vol = compute_consensus_rank(
-            p.source_ranks, w_median=w_median, w_mean=w_mean,
+            p.source_ranks,
+            w_median=w_median,
+            w_mean=w_mean,
         )
         consensus_data.append((p, cr, med, avg, vol))
 
@@ -577,7 +602,8 @@ def run_valuation(
 
     # ── Step 2: Tier detection ──
     tier_ids, raw_gaps, gap_scores, boundaries = detect_tiers(
-        sorted_ranks, sorted_ids,
+        sorted_ranks,
+        sorted_ids,
         gap_window=gap_window,
         gap_threshold=gap_threshold,
         min_tier_size=min_tier_size,
@@ -588,14 +614,16 @@ def run_valuation(
 
     # ── Step 3: Base value curve (Hill-style) ──
     base_values = [
-        float(rank_to_value(cr, midpoint=hill_midpoint, slope=hill_slope))
-        for cr in sorted_ranks
+        float(rank_to_value(cr, midpoint=hill_midpoint, slope=hill_slope)) for cr in sorted_ranks
     ]
 
     # ── Step 4: Tier cliff injection ──
     tier_adjustments = compute_tier_adjustments(
-        sorted_ranks, tier_ids, boundaries,
-        cliff_base=cliff_base, cliff_decay=cliff_decay,
+        sorted_ranks,
+        tier_ids,
+        boundaries,
+        cliff_base=cliff_base,
+        cliff_decay=cliff_decay,
     )
 
     base_plus_tier = [bv + ta for bv, ta in zip(base_values, tier_adjustments)]
@@ -603,14 +631,14 @@ def run_valuation(
     # ── Step 5: Volatility adjustment ──
     volatilities = [x[4] for x in consensus_data]
     vol_adjustments = compute_volatility_adjustments(
-        base_plus_tier, volatilities,
-        strength=vol_strength, floor=vol_floor,
+        base_plus_tier,
+        volatilities,
+        strength=vol_strength,
+        floor=vol_floor,
     )
 
     # ── Assemble raw final values ──
-    raw_finals = [
-        bpt + va for bpt, va in zip(base_plus_tier, vol_adjustments)
-    ]
+    raw_finals = [bpt + va for bpt, va in zip(base_plus_tier, vol_adjustments)]
 
     # ── Enforce strict monotonic decrease ──
     # Small rounding or volatility adjustments could theoretically create
@@ -654,14 +682,21 @@ def run_valuation(
         tier_boundaries=boundaries,
         tier_count=max(tier_ids) if tier_ids else 0,
         monotonic_clamp_count=len(clamped_indices),
-        hyperparameters=_collect_hyperparams({
-            "w_median": w_median, "w_mean": w_mean,
-            "gap_window": gap_window, "gap_threshold": gap_threshold,
-            "min_tier_size": min_tier_size,
-            "hill_midpoint": hill_midpoint, "hill_slope": hill_slope,
-            "cliff_base": cliff_base, "cliff_decay": cliff_decay,
-            "vol_strength": vol_strength, "vol_floor": vol_floor,
-        }),
+        hyperparameters=_collect_hyperparams(
+            {
+                "w_median": w_median,
+                "w_mean": w_mean,
+                "gap_window": gap_window,
+                "gap_threshold": gap_threshold,
+                "min_tier_size": min_tier_size,
+                "hill_midpoint": hill_midpoint,
+                "hill_slope": hill_slope,
+                "cliff_base": cliff_base,
+                "cliff_decay": cliff_decay,
+                "vol_strength": vol_strength,
+                "vol_floor": vol_floor,
+            }
+        ),
     )
 
 
@@ -669,14 +704,14 @@ def _collect_hyperparams(params: dict[str, Any]) -> dict[str, Any]:
     """Extract only numeric/string hyperparams from a dict."""
     skip = {"players", "self"}
     return {
-        k: v for k, v in params.items()
-        if k not in skip and isinstance(v, (int, float, str, bool))
+        k: v for k, v in params.items() if k not in skip and isinstance(v, (int, float, str, bool))
     }
 
 
 # ══════════════════════════════════════════════════════════════════════
 # INTEGRATION HELPER — bridge from existing RawAssetRecord pipeline
 # ══════════════════════════════════════════════════════════════════════
+
 
 def build_player_inputs_from_raw_records(
     records: list[dict[str, Any]],
@@ -843,8 +878,4 @@ def build_player_inputs_from_record_objects(
         by_key[key]["source_ranks"].append(float(rank))
         by_key[key]["metadata"]["_source_names"].append(source)
 
-    return [
-        PlayerInput(**data)
-        for data in by_key.values()
-        if data["source_ranks"]
-    ]
+    return [PlayerInput(**data) for data in by_key.values() if data["source_ranks"]]

--- a/src/canonical/rank_history_band.py
+++ b/src/canonical/rank_history_band.py
@@ -29,6 +29,7 @@ Output::
 Pure-Python.  Used by the player popup mini-chart when the
 ``value_confidence_intervals`` flag is on.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -54,12 +55,12 @@ class RankHistoryBand:
             "p90": [round(v, 1) for v in self.p90],
             "spread": [round(v, 1) for v in self.spread],
             "spreadChange30d": (
-                round(self.spread_change_30d, 1)
-                if self.spread_change_30d is not None else None
+                round(self.spread_change_30d, 1) if self.spread_change_30d is not None else None
             ),
             "spreadChangePct30d": (
                 round(self.spread_change_pct_30d, 3)
-                if self.spread_change_pct_30d is not None else None
+                if self.spread_change_pct_30d is not None
+                else None
             ),
             "trend": self.trend,
         }
@@ -130,7 +131,9 @@ def build_band_history(
 
     return RankHistoryBand(
         dates=dates,
-        p10=p10s, p50=p50s, p90=p90s,
+        p10=p10s,
+        p50=p50s,
+        p90=p90s,
         spread=spreads,
         spread_change_30d=spread_change,
         spread_change_pct_30d=spread_change_pct,

--- a/src/identity/matcher.py
+++ b/src/identity/matcher.py
@@ -50,7 +50,9 @@ def _confidence_for_record(rec: RawAssetRecord) -> tuple[float, str]:
     return 0.85, "exact_name_only"
 
 
-def build_master_players(records: list[RawAssetRecord]) -> tuple[dict[str, MasterPlayer], list[str]]:
+def build_master_players(
+    records: list[RawAssetRecord],
+) -> tuple[dict[str, MasterPlayer], list[str]]:
     players: dict[str, MasterPlayer] = {}
     conflicts: list[str] = []
     seen_positions: dict[str, set[str]] = defaultdict(set)
@@ -135,7 +137,9 @@ def build_identity_resolution(
                     position=rec.position_normalized_guess or rec.position_raw,
                     position_group=rec.position_normalized_guess or rec.position_raw,
                     rookie_class_year=rec.pick_year_guess if rec.rookie_flag else None,
-                    age=float(rec.age_raw) if str(rec.age_raw).strip().replace(".", "", 1).isdigit() else None,
+                    age=float(rec.age_raw)
+                    if str(rec.age_raw).strip().replace(".", "", 1).isdigit()
+                    else None,
                     is_active=True,
                     created_at=now,
                     updated_at=now,
@@ -189,7 +193,9 @@ def build_identity_resolution(
         elif rec.asset_type == "pick":
             year = rec.pick_year_guess or 0
             rnd = rec.pick_round_guess or 0
-            slot_known = bool(rec.pick_slot_guess and rec.pick_slot_guess.replace(".", "").isdigit())
+            slot_known = bool(
+                rec.pick_slot_guess and rec.pick_slot_guess.replace(".", "").isdigit()
+            )
             slot_number = None
             if slot_known:
                 try:
@@ -279,4 +285,3 @@ def build_identity_report(records: list[RawAssetRecord]) -> dict:
     Backward-compatible alias for existing scaffold call sites.
     """
     return build_identity_resolution(records)
-

--- a/src/identity/models.py
+++ b/src/identity/models.py
@@ -72,4 +72,3 @@ class PickAliasRow:
 
     def to_dict(self) -> dict:
         return asdict(self)
-

--- a/src/identity/schema.py
+++ b/src/identity/schema.py
@@ -32,4 +32,3 @@ class MasterPick:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
-

--- a/src/identity/unified_mapper.py
+++ b/src/identity/unified_mapper.py
@@ -35,6 +35,7 @@ This module reads from existing player state and returns a new
 scrape-normalize-merge flow still runs exactly as before.  The
 mapper is a LOOKUP surface, not a write path.
 """
+
 from __future__ import annotations
 
 import json
@@ -362,13 +363,21 @@ def resolve_player(
     _bump("unresolved")
     _LOGGER.debug(
         "unified_mapper: miss sleeper=%s gsis=%s espn=%s name=%s team=%s pos=%s",
-        sleeper_id, gsis_id, espn_id, name, team, position,
+        sleeper_id,
+        gsis_id,
+        espn_id,
+        name,
+        team,
+        position,
     )
     return None
 
 
 def _to_resolved(
-    p: dict[str, Any], *, confidence: float, method: str,
+    p: dict[str, Any],
+    *,
+    confidence: float,
+    method: str,
 ) -> ResolvedPlayer:
     return ResolvedPlayer(
         sleeper_id=str(p.get("player_id") or p.get("sleeper_id") or ""),

--- a/src/league_comparison/historical_stats.py
+++ b/src/league_comparison/historical_stats.py
@@ -11,6 +11,7 @@ Both sources are filtered to **regular-season weeks 1-17 only**
 before they leave this module — week 18 is the starter-rest week for
 most playoff-bound teams and would distort the multi-year sample.
 """
+
 from __future__ import annotations
 
 import logging
@@ -88,7 +89,8 @@ def load_season_rows(season: int) -> list[dict[str, Any]] | None:
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning(
             "league_compare.nflverse_fetch_failed season=%s err=%r",
-            season, exc,
+            season,
+            exc,
         )
         rows = []
     rows = _filter_to_regular_season(rows)
@@ -106,7 +108,8 @@ def load_season_rows(season: int) -> list[dict[str, Any]] | None:
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning(
             "league_compare.sleeper_fetch_failed season=%s err=%r",
-            season, exc,
+            season,
+            exc,
         )
         sleeper_rows = []
     sleeper_rows = _filter_to_regular_season(sleeper_rows)

--- a/src/league_comparison/idp.py
+++ b/src/league_comparison/idp.py
@@ -23,6 +23,7 @@ When ready to activate:
 Until then the function returns a placeholder block so the UI can
 render an "IDP coming soon" badge consistently.
 """
+
 from __future__ import annotations
 
 from typing import Any

--- a/src/league_comparison/metrics.py
+++ b/src/league_comparison/metrics.py
@@ -21,6 +21,7 @@ Multi-season combination uses **equal weighting** by design (no recency
 weighting).  Each available season counts as 1/N of the combined value,
 where N is the number of available seasons.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -52,8 +53,11 @@ IMPROVED_WEIGHT_REPL_ADJ: float = 0.10
 # get partial credit; full-season starters score the same as before
 # (blended == total when games_played == 17).
 
+
 def top_n_by_position(
-    scores: Iterable[PlayerSeasonScore], position: str, n: int,
+    scores: Iterable[PlayerSeasonScore],
+    position: str,
+    n: int,
 ) -> list[PlayerSeasonScore]:
     """Return the top-N season scores for ``position``, sorted DESC by
     blended score.
@@ -67,7 +71,8 @@ def top_n_by_position(
 
 
 def flex_top_n(
-    scores: Iterable[PlayerSeasonScore], n: int = 96,
+    scores: Iterable[PlayerSeasonScore],
+    n: int = 96,
 ) -> list[PlayerSeasonScore]:
     """Top-N RB/WR/TE pool, QB excluded, ranked by blended score.
 
@@ -80,15 +85,16 @@ def flex_top_n(
 
 # ── Per-position metrics ──────────────────────────────────────────────
 
+
 @dataclass(frozen=True)
 class PositionMetrics:
     average: float
     median: float
     p25: float
     p75: float
-    replacement_level: float    # the Nth player's points (e.g. QB24)
-    elite: float                # mean of top 3
-    replacement_adj: float      # average - replacement_level
+    replacement_level: float  # the Nth player's points (e.g. QB24)
+    elite: float  # mean of top 3
+    replacement_adj: float  # average - replacement_level
     sample_size: int
 
     def to_dict(self) -> dict[str, float | int]:
@@ -105,8 +111,13 @@ class PositionMetrics:
 
 
 _EMPTY_METRICS = PositionMetrics(
-    average=0.0, median=0.0, p25=0.0, p75=0.0,
-    replacement_level=0.0, elite=0.0, replacement_adj=0.0,
+    average=0.0,
+    median=0.0,
+    p25=0.0,
+    p75=0.0,
+    replacement_level=0.0,
+    elite=0.0,
+    replacement_adj=0.0,
     sample_size=0,
 )
 
@@ -167,6 +178,7 @@ def position_metrics(samples: Sequence[PlayerSeasonScore]) -> PositionMetrics:
 
 # ── Blended scores (the two methods) ──────────────────────────────────
 
+
 def legacy_blended(m: PositionMetrics) -> float:
     """The user's original ``(average + median) / 2`` formula."""
     return (m.average + m.median) / 2.0
@@ -186,6 +198,7 @@ def improved_blended(m: PositionMetrics) -> float:
 
 # ── Positional shares ─────────────────────────────────────────────────
 
+
 def position_shares(blended_by_pos: dict[str, float]) -> dict[str, float]:
     """Return each position's share of the total positional scoring pool.
 
@@ -200,6 +213,7 @@ def position_shares(blended_by_pos: dict[str, float]) -> dict[str, float]:
 
 
 # ── Multi-season combine (equal-weight) ───────────────────────────────
+
 
 def combine_seasons_equal_weight(values: Sequence[float]) -> float:
     """Average a list of per-season values with equal weight per season.
@@ -236,13 +250,19 @@ def combine_metrics_equal_weight(
     repl_adj = sum(m.replacement_adj for m in available) / n
     sample = int(round(sum(m.sample_size for m in available) / n))
     return PositionMetrics(
-        average=avg, median=med, p25=p25, p75=p75,
-        replacement_level=repl, elite=elite, replacement_adj=repl_adj,
+        average=avg,
+        median=med,
+        p25=p25,
+        p75=p75,
+        replacement_level=repl,
+        elite=elite,
+        replacement_adj=repl_adj,
         sample_size=sample,
     )
 
 
 # ── Status labels ─────────────────────────────────────────────────────
+
 
 @dataclass(frozen=True)
 class StatusBands:
@@ -251,6 +271,7 @@ class StatusBands:
     These are deliberately tunable in one place so the frontend
     methodology section can reference the exact same numbers.
     """
+
     excellent: float = 0.5
     good: float = 1.5
     slight: float = 3.0
@@ -279,13 +300,14 @@ def status_label(diff_pp: float, *, bands: StatusBands = _BANDS) -> str:
 
 # ── Similarity score ──────────────────────────────────────────────────
 
+
 @dataclass(frozen=True)
 class SimilarityResult:
-    score: int                   # 0..100
-    label: str                   # human descriptor
-    distortion_label: str        # "Low" / "Moderate" / "High" / "Severe"
-    total_share_dev_pp: float    # sum of |share diffs| in pp
-    flex_dev_pct: float          # |my_flex - baseline_flex| / baseline_flex * 100
+    score: int  # 0..100
+    label: str  # human descriptor
+    distortion_label: str  # "Low" / "Moderate" / "High" / "Severe"
+    total_share_dev_pp: float  # sum of |share diffs| in pp
+    flex_dev_pct: float  # |my_flex - baseline_flex| / baseline_flex * 100
 
 
 def similarity_score(
@@ -323,8 +345,7 @@ def similarity_score(
     | > 20               | < 60        | Very distorted         |
     """
     pos_dev = sum(
-        abs(my_shares.get(p, 0.0) - baseline_shares.get(p, 0.0))
-        for p in OFFENSE_POSITIONS
+        abs(my_shares.get(p, 0.0) - baseline_shares.get(p, 0.0)) for p in OFFENSE_POSITIONS
     )
     if baseline_flex > 0:
         flex_dev = abs(my_flex - baseline_flex) / baseline_flex * 100.0
@@ -334,19 +355,19 @@ def similarity_score(
 
     # Piecewise-linear: lower deviation -> higher score.
     if combined <= 2:
-        score = 95 + (2 - combined) / 2 * 5             # 95..100
+        score = 95 + (2 - combined) / 2 * 5  # 95..100
         label = "Extremely close to standard"
         distortion = "Low"
     elif combined <= 5:
-        score = 85 + (5 - combined) / 3 * 9             # 85..94
+        score = 85 + (5 - combined) / 3 * 9  # 85..94
         label = "Very close"
         distortion = "Low"
     elif combined <= 10:
-        score = 75 + (10 - combined) / 5 * 9            # 75..84
+        score = 75 + (10 - combined) / 5 * 9  # 75..84
         label = "Some noticeable differences"
         distortion = "Moderate"
     elif combined <= 20:
-        score = 60 + (20 - combined) / 10 * 14          # 60..74
+        score = 60 + (20 - combined) / 10 * 14  # 60..74
         label = "Meaningfully different"
         distortion = "High"
     else:
@@ -418,10 +439,13 @@ def recommendation(
             f"No adjustment recommended."
         )
     severity = (
-        "slightly" if abs_d <= 1.5 else
-        "noticeably" if abs_d <= 3.0 else
-        "meaningfully" if abs_d <= 5.0 else
-        "substantially"
+        "slightly"
+        if abs_d <= 1.5
+        else "noticeably"
+        if abs_d <= 3.0
+        else "meaningfully"
+        if abs_d <= 5.0
+        else "substantially"
     )
     hints = _CULPRIT_HINTS.get(position, [])
     hint_text = ""
@@ -436,6 +460,7 @@ def recommendation(
 
 # ── Convenience aggregator (used by service.py) ───────────────────────
 
+
 @dataclass(frozen=True)
 class PositionComparison:
     position: str
@@ -446,15 +471,17 @@ class PositionComparison:
     my_improved_score: float
     baseline_improved_score: float
 
-    def to_dict(self, my_share_legacy: float, my_share_improved: float,
-                base_share_legacy: float, base_share_improved: float,
-                recommendation_text: str) -> dict[str, object]:
+    def to_dict(
+        self,
+        my_share_legacy: float,
+        my_share_improved: float,
+        base_share_legacy: float,
+        base_share_improved: float,
+        recommendation_text: str,
+    ) -> dict[str, object]:
         diff_legacy = my_share_legacy - base_share_legacy
         diff_improved = my_share_improved - base_share_improved
-        rel = (
-            (diff_improved / base_share_improved * 100.0)
-            if base_share_improved > 0 else 0.0
-        )
+        rel = (diff_improved / base_share_improved * 100.0) if base_share_improved > 0 else 0.0
         return {
             "position": self.position,
             "my": {

--- a/src/league_comparison/scoring_engine.py
+++ b/src/league_comparison/scoring_engine.py
@@ -9,6 +9,7 @@ Output: a list of :class:`PlayerSeasonScore` records, one per
 ``(player_id_gsis, position, season)`` triple, that downstream metrics
 code can sort/filter/sample.
 """
+
 from __future__ import annotations
 
 import logging
@@ -81,8 +82,8 @@ def compute_blended_score(total_points: float, games_played: int) -> float:
 class PlayerSeasonScore:
     player_id: str
     player_name: str
-    position: str          # canonicalised: QB / RB / WR / TE / DL / LB / DB
-    raw_position: str      # what nflverse reported (DT, EDGE, OLB, etc.)
+    position: str  # canonicalised: QB / RB / WR / TE / DL / LB / DB
+    raw_position: str  # what nflverse reported (DT, EDGE, OLB, etc.)
     season: int
     total_points: float
     games_played: int
@@ -213,7 +214,8 @@ def compute_player_season_scores(
     if unknown_positions:
         _LOGGER.warning(
             "scoring_engine.unknown_positions_dropped season=%s positions=%s",
-            season, sorted(unknown_positions),
+            season,
+            sorted(unknown_positions),
         )
 
     return out

--- a/src/league_comparison/service.py
+++ b/src/league_comparison/service.py
@@ -32,6 +32,7 @@ Output shape
 Documented in :func:`build_comparison`'s docstring and pinned by
 ``tests/league_comparison/test_service.py``.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -58,6 +59,7 @@ _CACHE_SUBDIR = "league_comparison_cache"
 
 # ── Config loading ────────────────────────────────────────────────────
 
+
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
@@ -75,26 +77,33 @@ def _load_config() -> dict[str, Any]:
 
 # ── Cache layer (disk) ────────────────────────────────────────────────
 
+
 def _cache_dir() -> Path:
     return _repo_root() / "data" / _CACHE_SUBDIR
 
 
 def _cache_key(
     *,
-    my_id: str, baseline_id: str,
-    my_hash: str, baseline_hash: str,
-    seasons: Iterable[int], version: str,
+    my_id: str,
+    baseline_id: str,
+    my_hash: str,
+    baseline_hash: str,
+    seasons: Iterable[int],
+    version: str,
 ) -> str:
     parts = [
         version,
-        my_id, my_hash,
-        baseline_id, baseline_hash,
+        my_id,
+        my_hash,
+        baseline_id,
+        baseline_hash,
         ",".join(str(s) for s in sorted(seasons)),
     ]
     return "league_compare:" + hashlib.sha1(":".join(parts).encode("utf-8")).hexdigest()
 
 
 # ── Per-position pipeline ─────────────────────────────────────────────
+
 
 def _per_season_metrics_for_league(
     rows: list[dict[str, Any]],
@@ -140,21 +149,27 @@ def _build_league_block(
     for season, rows in seasons_map.items():
         if not rows:
             per_season[season] = {
-                "positions": {pos: _m.PositionMetrics(0, 0, 0, 0, 0, 0, 0, 0).to_dict()
-                              for pos in _m.OFFENSE_POSITIONS},
+                "positions": {
+                    pos: _m.PositionMetrics(0, 0, 0, 0, 0, 0, 0, 0).to_dict()
+                    for pos in _m.OFFENSE_POSITIONS
+                },
                 "flex": _m.PositionMetrics(0, 0, 0, 0, 0, 0, 0, 0).to_dict(),
                 "topPlayers": [],
                 "available": False,
             }
             continue
         per_pos, flex_metrics, sample_union = _per_season_metrics_for_league(
-            rows, league_info.scoring_settings, sample_sizes, season,
+            rows,
+            league_info.scoring_settings,
+            sample_sizes,
+            season,
         )
         # Top players sample for the UI year-by-year detail panel —
         # cap at 25 to keep payload light.  Sort by blended_score so
         # the displayed top matches what the ranking math actually used.
         top_players = sorted(
-            sample_union, key=lambda s: -s.blended_score,
+            sample_union,
+            key=lambda s: -s.blended_score,
         )[:25]
         per_season[season] = {
             "positions": {pos: m.to_dict() for pos, m in per_pos.items()},
@@ -186,8 +201,10 @@ def _build_league_block(
                 continue
             d = block["positions"][pos]
             per_year[season] = _m.PositionMetrics(
-                average=d["average"], median=d["median"],
-                p25=d["p25"], p75=d["p75"],
+                average=d["average"],
+                median=d["median"],
+                p25=d["p25"],
+                p75=d["p75"],
                 replacement_level=d["replacementLevel"],
                 elite=d["elite"],
                 replacement_adj=d["replacementAdj"],
@@ -200,8 +217,10 @@ def _build_league_block(
             continue
         d = block["flex"]
         flex_per_year[season] = _m.PositionMetrics(
-            average=d["average"], median=d["median"],
-            p25=d["p25"], p75=d["p75"],
+            average=d["average"],
+            median=d["median"],
+            p25=d["p25"],
+            p75=d["p75"],
             replacement_level=d["replacementLevel"],
             elite=d["elite"],
             replacement_adj=d["replacementAdj"],
@@ -215,15 +234,21 @@ def _build_league_block(
             "positions": {pos: m.to_dict() for pos, m in combined_positions.items()},
             "flex": combined_flex.to_dict(),
         },
-        "_combinedPositions": combined_positions,   # internal handle
-        "_combinedFlex": combined_flex,             # internal handle
+        "_combinedPositions": combined_positions,  # internal handle
+        "_combinedFlex": combined_flex,  # internal handle
     }
 
 
 def _build_position_comparisons(
     my_block: dict[str, Any],
     base_block: dict[str, Any],
-) -> tuple[dict[str, dict[str, Any]], dict[str, float], dict[str, float], dict[str, float], dict[str, float]]:
+) -> tuple[
+    dict[str, dict[str, Any]],
+    dict[str, float],
+    dict[str, float],
+    dict[str, float],
+    dict[str, float],
+]:
     """Compute per-position comparisons and the four share dicts (legacy
     + improved × my + baseline)."""
     my_pos: dict[str, _m.PositionMetrics] = my_block["_combinedPositions"]
@@ -243,8 +268,10 @@ def _build_position_comparisons(
     for pos in _m.OFFENSE_POSITIONS:
         diff_pp_improved = my_share_improved[pos] - base_share_improved[pos]
         rec_text = _m.recommendation(
-            pos, diff_pp_improved,
-            my_share_improved[pos], base_share_improved[pos],
+            pos,
+            diff_pp_improved,
+            my_share_improved[pos],
+            base_share_improved[pos],
         )
         comp = _m.PositionComparison(
             position=pos,
@@ -315,10 +342,7 @@ def _summary_block(
     similarity: _m.SimilarityResult,
 ) -> dict[str, Any]:
     """Compute biggest-difference + closest-match for the summary cards."""
-    diffs = [
-        (pos, abs(comp["diffPpImproved"]))
-        for pos, comp in positions.items()
-    ]
+    diffs = [(pos, abs(comp["diffPpImproved"])) for pos, comp in positions.items()]
     diffs.sort(key=lambda x: -x[1])
     biggest = diffs[0][0] if diffs else None
     closest = diffs[-1][0] if diffs else None
@@ -339,6 +363,7 @@ def _summary_block(
 
 
 # ── Top-level entry ───────────────────────────────────────────────────
+
 
 def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
     """Build the full comparison payload (or load it from cache).
@@ -361,9 +386,7 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
     _required_sample_keys = ("QB", "RB", "WR", "TE", "FLEX")
     _missing = [k for k in _required_sample_keys if k not in sample_sizes]
     if _missing:
-        raise ValueError(
-            f"config/league_comparison.json missing sample_sizes keys: {_missing}"
-        )
+        raise ValueError(f"config/league_comparison.json missing sample_sizes keys: {_missing}")
     _bad = [k for k in _required_sample_keys if sample_sizes[k] <= 0]
     if _bad:
         raise ValueError(
@@ -378,9 +401,12 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
     base_info = _sleeper.fetch_league_scoring(base_cfg["id"], refresh=refresh)
 
     cache_key = _cache_key(
-        my_id=my_info.league_id, baseline_id=base_info.league_id,
-        my_hash=my_info.scoring_hash, baseline_hash=base_info.scoring_hash,
-        seasons=seasons_requested, version=version,
+        my_id=my_info.league_id,
+        baseline_id=base_info.league_id,
+        my_hash=my_info.scoring_hash,
+        baseline_hash=base_info.scoring_hash,
+        seasons=seasons_requested,
+        version=version,
     )
     cache_dir = _cache_dir()
     if not refresh:
@@ -414,14 +440,25 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
     # Pre-flag any scoring keys present in either league but not handled
     # by the scoring engine — surfaces in the methodology / warnings UI.
     from src.nfl_data.realized_points import _SIMPLE_KEYS, _IDP_KEYS  # noqa: PLC0415
-    handled = set(_SIMPLE_KEYS.keys()) | set(_IDP_KEYS.keys()) | {
-        "bonus_rec_te",
-        "bonus_pass_yd_300", "bonus_pass_yd_400",
-        "bonus_rush_yd_100", "bonus_rush_yd_200",
-        "bonus_rec_yd_100", "bonus_rec_yd_200",
-        "pass_2pt", "rush_2pt", "rec_2pt",
-        "idp_tkl_5p", "idp_tkl_10p",
-    }
+
+    handled = (
+        set(_SIMPLE_KEYS.keys())
+        | set(_IDP_KEYS.keys())
+        | {
+            "bonus_rec_te",
+            "bonus_pass_yd_300",
+            "bonus_pass_yd_400",
+            "bonus_rush_yd_100",
+            "bonus_rush_yd_200",
+            "bonus_rec_yd_100",
+            "bonus_rec_yd_200",
+            "pass_2pt",
+            "rush_2pt",
+            "rec_2pt",
+            "idp_tkl_5p",
+            "idp_tkl_10p",
+        }
+    )
     unsupported_my = sorted(set(my_info.scoring_settings.keys()) - handled)
     unsupported_base = sorted(set(base_info.scoring_settings.keys()) - handled)
     if unsupported_my or unsupported_base:
@@ -429,7 +466,8 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
         # Only warn about keys with non-zero values — many leagues
         # have dozens of zeroed keys for unused categories.
         nonzero = [
-            k for k in keys
+            k
+            for k in keys
             if my_info.scoring_settings.get(k, 0) or base_info.scoring_settings.get(k, 0)
         ]
         if nonzero:
@@ -442,7 +480,8 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
     base_block = _build_league_block(base_info, seasons_map, sample_sizes)
 
     positions, my_sl, my_si, base_sl, base_si = _build_position_comparisons(
-        my_block, base_block,
+        my_block,
+        base_block,
     )
     flex = _flex_block(my_block, base_block)
 
@@ -520,7 +559,9 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
 
     _LOGGER.info(
         "league_compare.built my=%s baseline=%s seasons=%s ms=%d",
-        my_info.league_id, base_info.league_id,
-        avail["available"], payload["meta"]["computeMs"],
+        my_info.league_id,
+        base_info.league_id,
+        avail["available"],
+        payload["meta"]["computeMs"],
     )
     return payload

--- a/src/league_comparison/sleeper_scoring.py
+++ b/src/league_comparison/sleeper_scoring.py
@@ -10,6 +10,7 @@ rarely (commissioner edits) — a 1h TTL means a refresh after a settings
 change picks up the next hit, while normal traffic doesn't repeatedly
 hit Sleeper.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -123,7 +124,10 @@ def fetch_league_scoring(league_id: str, *, refresh: bool = False) -> LeagueScor
 
     _LOGGER.info(
         "league_compare.scoring_fetched league_id=%s name=%s keys=%d hash=%s",
-        league_id, info.name, len(scoring), info.scoring_hash,
+        league_id,
+        info.name,
+        len(scoring),
+        info.scoring_hash,
     )
     return info
 

--- a/src/league_comparison/sleeper_stats.py
+++ b/src/league_comparison/sleeper_stats.py
@@ -26,6 +26,7 @@ cached on disk via :mod:`src.nfl_data.cache` with multi-day TTLs.
 Once a NFL season is final, its weekly numbers don't change, so a
 long TTL is safe.
 """
+
 from __future__ import annotations
 
 import json
@@ -40,8 +41,8 @@ _LOGGER = logging.getLogger(__name__)
 
 _SLEEPER_API_ROOT = "https://api.sleeper.app/v1"
 _HTTP_TIMEOUT = 15.0
-_PLAYER_INDEX_TTL = 7 * 24 * 3600   # 7 days
-_WEEKLY_STATS_TTL = 7 * 24 * 3600   # 7 days
+_PLAYER_INDEX_TTL = 7 * 24 * 3600  # 7 days
+_WEEKLY_STATS_TTL = 7 * 24 * 3600  # 7 days
 
 # League-comparison samples weeks 1-17 only.  Modern NFL regular
 # seasons run 18 weeks (since 2021), but week 18 is starter-rest
@@ -91,9 +92,11 @@ _FIELD_MAP: dict[str, str] = {
 
 # ── HTTP / cache primitives ───────────────────────────────────────────
 
+
 def _http_get_json(url: str) -> Any:
     req = urllib.request.Request(
-        url, headers={"User-Agent": "riskit-league-compare/1.0"},
+        url,
+        headers={"User-Agent": "riskit-league-compare/1.0"},
     )
     with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310
         return json.loads(resp.read())
@@ -136,7 +139,8 @@ def _player_index(*, fetcher: Callable[[str], Any] | None = None) -> dict[str, d
 
 
 def _fetch_week_stats(
-    season: int, week: int,
+    season: int,
+    week: int,
     *,
     fetcher: Callable[[str], Any] | None = None,
 ) -> dict[str, dict[str, Any]] | None:
@@ -160,13 +164,17 @@ def _fetch_week_stats(
             return None
         _LOGGER.warning(
             "sleeper_stats.week_http_error season=%d week=%d code=%s",
-            season, week, exc.code,
+            season,
+            week,
+            exc.code,
         )
         return None
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning(
             "sleeper_stats.week_fetch_failed season=%d week=%d err=%r",
-            season, week, exc,
+            season,
+            week,
+            exc,
         )
         return None
     if not isinstance(raw, dict) or not raw:
@@ -179,6 +187,7 @@ def _fetch_week_stats(
 
 
 # ── Translation ───────────────────────────────────────────────────────
+
 
 def _translate_stats(sleeper_stats: dict[str, Any]) -> dict[str, float]:
     """Translate a Sleeper raw-stats dict to nflverse field names.
@@ -203,6 +212,7 @@ def _translate_stats(sleeper_stats: dict[str, Any]) -> dict[str, float]:
 
 
 # ── Public API ────────────────────────────────────────────────────────
+
 
 def fetch_sleeper_weekly_stats(
     season: int,
@@ -262,11 +272,14 @@ def fetch_sleeper_weekly_stats(
     if rows:
         _LOGGER.info(
             "sleeper_stats.fetched season=%d rows=%d weeks=%d",
-            season, len(rows), len(weeks_seen),
+            season,
+            len(rows),
+            len(weeks_seen),
         )
     else:
         _LOGGER.warning(
             "sleeper_stats.no_rows season=%d weeks_seen=%d",
-            season, len(weeks_seen),
+            season,
+            len(weeks_seen),
         )
     return rows

--- a/src/news/__init__.py
+++ b/src/news/__init__.py
@@ -9,6 +9,7 @@ Public surface:
 * ``available_provider_names`` / ``build_provider`` — registry
   introspection for diagnostics.
 """
+
 from __future__ import annotations
 
 from .base import NewsItem, NewsProvider, PlayerMention, stable_id, to_iso_utc

--- a/src/news/base.py
+++ b/src/news/base.py
@@ -19,6 +19,7 @@ The contract is deliberately a superset of two things:
 Aliases are duplicated on every item rather than computed
 client-side so consumers of either vocabulary work identically.
 """
+
 from __future__ import annotations
 
 import abc

--- a/src/news/custom_alerts.py
+++ b/src/news/custom_alerts.py
@@ -40,6 +40,7 @@ Evaluation
 the dispatcher should deliver.  No I/O, no email/push side effects;
 the cron handler in server.py wires those up.
 """
+
 from __future__ import annotations
 
 import logging
@@ -226,24 +227,25 @@ def evaluate_alerts(
             threshold = int(params.get("threshold") or 0)
             direction = str(params.get("direction") or "")
             v = int(round(float(value)))
-            crossed = (
-                (direction == "above" and v >= threshold)
-                or (direction == "below" and v <= threshold)
+            crossed = (direction == "above" and v >= threshold) or (
+                direction == "below" and v <= threshold
             )
             if not crossed:
                 continue
             arrow = "↑" if direction == "above" else "↓"
             title = f"{display_name} {arrow} {threshold}"
             body = f"Value is now {v:,} (threshold {threshold:,})."
-            out.append(Hit(
-                rule_id=rule_id,
-                kind=kind,
-                display_name=display_name,
-                title=title,
-                body=body,
-                state_key=skey,
-                channels=channels,
-            ))
+            out.append(
+                Hit(
+                    rule_id=rule_id,
+                    kind=kind,
+                    display_name=display_name,
+                    title=title,
+                    body=body,
+                    state_key=skey,
+                    channels=channels,
+                )
+            )
             continue
 
         if kind == "rank_change":
@@ -259,15 +261,17 @@ def evaluate_alerts(
             body_parts = [f"Rank moved {int(change):+d} positions"]
             if isinstance(rank, int):
                 body_parts.append(f"now #{rank}")
-            out.append(Hit(
-                rule_id=rule_id,
-                kind=kind,
-                display_name=display_name,
-                title=" · ".join(body_parts[:1]),
-                body=" · ".join(body_parts) + ".",
-                state_key=skey,
-                channels=channels,
-            ))
+            out.append(
+                Hit(
+                    rule_id=rule_id,
+                    kind=kind,
+                    display_name=display_name,
+                    title=" · ".join(body_parts[:1]),
+                    body=" · ".join(body_parts) + ".",
+                    state_key=skey,
+                    channels=channels,
+                )
+            )
             continue
 
     return out
@@ -282,12 +286,9 @@ def mark_fired(state: dict[str, Any], hit: Hit, *, now: datetime | None = None) 
     return new_state
 
 
-def prune_state_for_removed_rule(
-    state: dict[str, Any], rule_id: str
-) -> dict[str, Any]:
+def prune_state_for_removed_rule(state: dict[str, Any], rule_id: str) -> dict[str, Any]:
     """Drop cooldown entries for a deleted rule so its state_key
     namespace doesn't accumulate forever in user_kv."""
     return {
-        k: v for k, v in state.items()
-        if not (isinstance(k, str) and k.startswith(f"{rule_id}::"))
+        k: v for k, v in state.items() if not (isinstance(k, str) and k.startswith(f"{rule_id}::"))
     }

--- a/src/news/providers/__init__.py
+++ b/src/news/providers/__init__.py
@@ -23,6 +23,7 @@ Registered providers (ordered by priority — earliest first):
 Every RSS provider inherits from ``RssNewsProvider`` (in
 ``_rss.py``) — adding another source is a 6-line subclass.
 """
+
 from __future__ import annotations
 
 from typing import Callable, Dict

--- a/src/news/providers/_rss.py
+++ b/src/news/providers/_rss.py
@@ -10,6 +10,7 @@ differ between the two adapters.
 Nothing here issues network I/O; the default stdlib fetcher lives
 on the subclasses so tests can inject a fake fetcher.
 """
+
 from __future__ import annotations
 
 import re

--- a/src/news/providers/cbs.py
+++ b/src/news/providers/cbs.py
@@ -1,4 +1,5 @@
 """CBS Sports NFL headlines RSS provider."""
+
 from __future__ import annotations
 
 from ._rss import RssNewsProvider

--- a/src/news/providers/dynasty_focused.py
+++ b/src/news/providers/dynasty_focused.py
@@ -30,6 +30,7 @@ Any of the skipped sources can be added as a 6-line subclass
 once the feed URL is confirmed — that's the whole point of the
 base class.
 """
+
 from __future__ import annotations
 
 from ._rss import RssNewsProvider

--- a/src/news/providers/espn.py
+++ b/src/news/providers/espn.py
@@ -4,6 +4,7 @@ Thin subclass over ``RssNewsProvider`` — ESPN publishes a public
 NFL news RSS feed with no auth.  Fetch, parse, classification,
 and player tagging all live in the base class.
 """
+
 from __future__ import annotations
 
 from ._rss import RssNewsProvider

--- a/src/news/providers/fantasypros.py
+++ b/src/news/providers/fantasypros.py
@@ -5,6 +5,7 @@ fantasy-flavored — items tend to surface fantasy-relevant
 analysis and beat-writer notes.  Separate from the paid
 FantasyPros API (different adapter if we ever license it).
 """
+
 from __future__ import annotations
 
 from ._rss import RssNewsProvider

--- a/src/news/providers/rotowire.py
+++ b/src/news/providers/rotowire.py
@@ -11,6 +11,7 @@ implementation that hits the licensed endpoint and maps the
 response to ``NewsItem`` — the rest of the stack (service,
 aggregator, route, frontend) will light up automatically.
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/news/providers/sleeper.py
+++ b/src/news/providers/sleeper.py
@@ -25,6 +25,7 @@ Trending data maps to our news vocabulary as:
 No headline lives upstream, so we synthesize one:
     "Jayden Reed added in 18,432 leagues (last 24h)"
 """
+
 from __future__ import annotations
 
 import json
@@ -167,9 +168,7 @@ class SleeperTrendingProvider(NewsProvider):
     def _fetch_player_map(self) -> dict[str, dict[str, Any]]:
         return _PLAYER_MAP.get(fetcher=lambda: self._get_json(_PLAYERS_PATH))
 
-    def _fetch_trending_safe(
-        self, path: str
-    ) -> tuple[bool, List[dict[str, Any]]]:
+    def _fetch_trending_safe(self, path: str) -> tuple[bool, List[dict[str, Any]]]:
         """Fetch one trending endpoint, tolerating a single-endpoint outage.
 
         Returns ``(ok, rows)``.  ``ok=False`` means the upstream

--- a/src/news/service.py
+++ b/src/news/service.py
@@ -20,6 +20,7 @@ No network I/O happens in this module directly — everything runs
 through the injected providers.  That keeps the cache + dedupe
 logic testable without stubbing HTTP.
 """
+
 from __future__ import annotations
 
 import logging
@@ -73,9 +74,7 @@ class AggregatedNews:
     items: List[NewsItem]
     providers_used: List[str]
     provider_runs: List[ProviderRunResult] = field(default_factory=list)
-    generated_at: str = field(
-        default_factory=lambda: datetime.now(timezone.utc).isoformat()
-    )
+    generated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     cache_hit: bool = False
 
     def to_dict(self) -> dict[str, Any]:
@@ -216,20 +215,14 @@ class NewsService:
             # write time (not on every read) keeps the hot path
             # lock-free-ish and bounds the work by miss rate, which
             # is itself rate-limited by the TTL.
-            expired = [
-                k
-                for k, (ts, _v) in self._cache.items()
-                if (now - ts) >= self._ttl
-            ]
+            expired = [k for k, (ts, _v) in self._cache.items() if (now - ts) >= self._ttl]
             for k in expired:
                 self._cache.pop(k, None)
 
         return result
 
     # ── provider dispatch ───────────────────────────────────────
-    def _fetch_all(
-        self, known_names: list[str]
-    ) -> tuple[List[NewsItem], List[ProviderRunResult]]:
+    def _fetch_all(self, known_names: list[str]) -> tuple[List[NewsItem], List[ProviderRunResult]]:
         """Run every enabled provider and collect their items.
 
         Each provider is fully isolated — any exception is logged
@@ -260,9 +253,7 @@ class NewsService:
             except Exception as exc:  # defensive — providers
                 # shouldn't raise, but if they do we isolate the
                 # failure here rather than 500-ing the route.
-                log.warning(
-                    "news provider %s raised: %s", provider.name, exc
-                )
+                log.warning("news provider %s raised: %s", provider.name, exc)
                 run.ok = False
                 run.error = f"{type(exc).__name__}: {exc}"
             finally:

--- a/src/news/unified_signal_engine.py
+++ b/src/news/unified_signal_engine.py
@@ -29,6 +29,7 @@ Combines the raw signal strength with the player's roster impact
 signal on a Tier-5 flex player is LOW severity; a usage-spike +
 injury + depth-chart promotion on a starter is HIGH.
 """
+
 from __future__ import annotations
 
 import logging
@@ -77,6 +78,7 @@ class UnifiedSignal:
 @dataclass
 class SignalCollector:
     """Accumulates signals per player and produces a composite."""
+
     signals_by_player: dict[str, list[UnifiedSignal]] = field(default_factory=dict)
 
     def add(self, sig: UnifiedSignal) -> None:
@@ -110,18 +112,23 @@ class SignalCollector:
                 severity = {v: k for k, v in sev_order.items()}[bumped_val]
                 exp = " + ".join(s.explanation for s in sigs)
                 tag = "composite_" + "_".join(sources)
-                out.append(UnifiedSignal(
-                    name=sigs[0].name, pos=sigs[0].pos,
-                    sleeper_id=sigs[0].sleeper_id,
-                    verdict=verdict, confidence=avg_conf,
-                    severity=severity, source_class="composite",
-                    explanation=exp, tag=tag,
-                    signal_key=f"{sigs[0].name}::{tag}",
-                    alias_signal_key=(
-                        f"sid:{sigs[0].sleeper_id}::{tag}"
-                        if sigs[0].sleeper_id else ""
-                    ),
-                ))
+                out.append(
+                    UnifiedSignal(
+                        name=sigs[0].name,
+                        pos=sigs[0].pos,
+                        sleeper_id=sigs[0].sleeper_id,
+                        verdict=verdict,
+                        confidence=avg_conf,
+                        severity=severity,
+                        source_class="composite",
+                        explanation=exp,
+                        tag=tag,
+                        signal_key=f"{sigs[0].name}::{tag}",
+                        alias_signal_key=(
+                            f"sid:{sigs[0].sleeper_id}::{tag}" if sigs[0].sleeper_id else ""
+                        ),
+                    )
+                )
             else:
                 # Conflict — keep them separate so user sees both
                 # perspectives.  Don't auto-resolve contradictions.
@@ -130,7 +137,10 @@ class SignalCollector:
 
 
 def severity_from_confidence(
-    confidence: float, *, starter: bool = False, tier: int | None = None,
+    confidence: float,
+    *,
+    starter: bool = False,
+    tier: int | None = None,
 ) -> str:
     """Convert a 0..1 confidence + roster-role weight into a
     severity bucket."""
@@ -151,9 +161,14 @@ def severity_from_confidence(
 
 
 def value_movement_signal(
-    *, name: str, sleeper_id: str, position: str,
-    pct_change_7d: float, pct_change_30d: float,
-    starter: bool = False, tier: int | None = None,
+    *,
+    name: str,
+    sleeper_id: str,
+    position: str,
+    pct_change_7d: float,
+    pct_change_30d: float,
+    starter: bool = False,
+    tier: int | None = None,
 ) -> UnifiedSignal | None:
     """Convert a 7/30d value drift into a BUY/SELL/HOLD signal.
 
@@ -177,9 +192,15 @@ def value_movement_signal(
     )
     tag = "value_movement"
     return UnifiedSignal(
-        name=name, pos=position, sleeper_id=sleeper_id,
-        verdict=verdict, confidence=confidence, severity=severity,
-        source_class="value", explanation=reason, tag=tag,
+        name=name,
+        pos=position,
+        sleeper_id=sleeper_id,
+        verdict=verdict,
+        confidence=confidence,
+        severity=severity,
+        source_class="value",
+        explanation=reason,
+        tag=tag,
         signal_key=f"{name}::{tag}",
         alias_signal_key=f"sid:{sleeper_id}::{tag}" if sleeper_id else "",
     )
@@ -188,7 +209,8 @@ def value_movement_signal(
 def usage_signal_to_unified(
     usage_signal_dict: dict[str, Any],
     *,
-    starter: bool = False, tier: int | None = None,
+    starter: bool = False,
+    tier: int | None = None,
 ) -> UnifiedSignal | None:
     """Wrap an existing usage_signals output in the unified shape."""
     if not isinstance(usage_signal_dict, dict):
@@ -209,9 +231,12 @@ def usage_signal_to_unified(
     name = str(usage_signal_dict.get("name") or usage_signal_dict.get("player_id") or "")
     sleeper_id = str(usage_signal_dict.get("sleeperId") or "")
     return UnifiedSignal(
-        name=name, pos=str(usage_signal_dict.get("pos") or ""),
+        name=name,
+        pos=str(usage_signal_dict.get("pos") or ""),
         sleeper_id=sleeper_id,
-        verdict=verdict, confidence=confidence, severity=severity,
+        verdict=verdict,
+        confidence=confidence,
+        severity=severity,
         source_class="usage",
         explanation=str(usage_signal_dict.get("reason") or ""),
         tag=tag,
@@ -224,7 +249,8 @@ def injury_signal_to_unified(
     injury_diff: dict[str, Any],
     *,
     sleeper_id_resolver: Callable[[str], str] | None = None,
-    starter: bool = False, tier: int | None = None,
+    starter: bool = False,
+    tier: int | None = None,
 ) -> UnifiedSignal | None:
     """Wrap an injury_feed.diff_for_signals output in the unified
     shape.  SELL on injury transitions.
@@ -240,8 +266,12 @@ def injury_signal_to_unified(
     new_status = str(injury_diff.get("newStatus") or "")
     # Severity map: QUESTIONABLE < DOUBTFUL < OUT < IR.
     sev_map = {
-        "DAY_TO_DAY": 0.3, "QUESTIONABLE": 0.4, "DOUBTFUL": 0.6,
-        "OUT": 0.75, "PUP": 0.8, "IR": 0.95,
+        "DAY_TO_DAY": 0.3,
+        "QUESTIONABLE": 0.4,
+        "DOUBTFUL": 0.6,
+        "OUT": 0.75,
+        "PUP": 0.8,
+        "IR": 0.95,
     }
     confidence = sev_map.get(new_status, 0.5)
     severity = severity_from_confidence(confidence, starter=starter, tier=tier)
@@ -250,9 +280,12 @@ def injury_signal_to_unified(
     name = str(injury_diff.get("name") or "")
     tag = f"injury_{transition}"
     return UnifiedSignal(
-        name=name, pos=str(injury_diff.get("position") or ""),
+        name=name,
+        pos=str(injury_diff.get("position") or ""),
         sleeper_id=sleeper_id,
-        verdict="SELL", confidence=confidence, severity=severity,
+        verdict="SELL",
+        confidence=confidence,
+        severity=severity,
         source_class="injury",
         explanation=str(injury_diff.get("reason") or ""),
         tag=tag,
@@ -264,7 +297,8 @@ def injury_signal_to_unified(
 def transaction_signal_to_unified(
     txn: dict[str, Any],
     *,
-    starter: bool = False, tier: int | None = None,
+    starter: bool = False,
+    tier: int | None = None,
 ) -> UnifiedSignal | None:
     """Convert a Sleeper transaction into a signal when it
     materially affects a roster player's role.
@@ -292,9 +326,12 @@ def transaction_signal_to_unified(
     severity = severity_from_confidence(confidence, starter=starter, tier=tier)
     tag = f"transaction_{txn_type}"
     return UnifiedSignal(
-        name=affected_name, pos=str(txn.get("position") or ""),
+        name=affected_name,
+        pos=str(txn.get("position") or ""),
         sleeper_id=affected_sid,
-        verdict=verdict, confidence=confidence, severity=severity,
+        verdict=verdict,
+        confidence=confidence,
+        severity=severity,
         source_class="transaction",
         explanation=str(txn.get("reason") or f"Transaction {txn_type}"),
         tag=tag,

--- a/src/news/usage_signals.py
+++ b/src/news/usage_signals.py
@@ -26,6 +26,7 @@ so downstream delivery pipes work unchanged:
     {"name", "pos", "signal", "reason", "tag", "signalKey",
      "aliasSignalKey", "sleeperId", "dismissed": False}
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -51,7 +52,11 @@ class UsageSignal:
     carry_share_z: float | None
 
     def to_signal_dict(
-        self, *, name: str, position: str, sleeper_id: str,
+        self,
+        *,
+        name: str,
+        position: str,
+        sleeper_id: str,
     ) -> dict[str, Any]:
         """Render to the shape the existing signal_alerts engine
         consumes."""
@@ -86,8 +91,10 @@ def detect_usage_transitions(
     for w in windows:
         # Freshness: never fire on mid-week current-week data.
         if not _fresh.is_fresh_for_alerts(
-            stat_week=w.week, stat_year=w.season,
-            season_year=season_year, season_current_week=season_current_week,
+            stat_week=w.week,
+            stat_year=w.season,
+            season_year=season_year,
+            season_current_week=season_current_week,
         ):
             continue
 
@@ -95,30 +102,34 @@ def detect_usage_transitions(
         buy_reason = _check_buy(w)
         if buy_reason:
             tag, detail = buy_reason
-            out.append(UsageSignal(
-                player_id=w.player_id,
-                signal="BUY",
-                reason=detail,
-                tag=tag,
-                snap_pct_z=w.snap_pct_z,
-                target_share_z=w.target_share_z,
-                carry_share_z=w.carry_share_z,
-            ))
+            out.append(
+                UsageSignal(
+                    player_id=w.player_id,
+                    signal="BUY",
+                    reason=detail,
+                    tag=tag,
+                    snap_pct_z=w.snap_pct_z,
+                    target_share_z=w.target_share_z,
+                    carry_share_z=w.carry_share_z,
+                )
+            )
             continue  # don't double-fire buy+sell on same window
 
         # SELL rules — drop z <= -2 AND prior-window starter.
         sell_reason = _check_sell(w)
         if sell_reason:
             tag, detail = sell_reason
-            out.append(UsageSignal(
-                player_id=w.player_id,
-                signal="SELL",
-                reason=detail,
-                tag=tag,
-                snap_pct_z=w.snap_pct_z,
-                target_share_z=w.target_share_z,
-                carry_share_z=w.carry_share_z,
-            ))
+            out.append(
+                UsageSignal(
+                    player_id=w.player_id,
+                    signal="SELL",
+                    reason=detail,
+                    tag=tag,
+                    snap_pct_z=w.snap_pct_z,
+                    target_share_z=w.target_share_z,
+                    carry_share_z=w.carry_share_z,
+                )
+            )
     return out
 
 

--- a/src/nfl_data/cache.py
+++ b/src/nfl_data/cache.py
@@ -13,6 +13,7 @@ Nothing here imports pandas — the cache stores raw Python
 primitives (list[dict], dict) that any caller can shape as
 needed.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -110,10 +111,12 @@ def put(
     tmp_meta = meta_path.with_suffix(".meta.json.tmp")
     try:
         tmp_data.write_text(
-            json.dumps(value, default=str, sort_keys=True), encoding="utf-8",
+            json.dumps(value, default=str, sort_keys=True),
+            encoding="utf-8",
         )
         tmp_meta.write_text(
-            json.dumps({"fetched_at": time.time(), "key": key}), encoding="utf-8",
+            json.dumps({"fetched_at": time.time(), "key": key}),
+            encoding="utf-8",
         )
         tmp_data.replace(data_path)
         tmp_meta.replace(meta_path)

--- a/src/nfl_data/depth_charts.py
+++ b/src/nfl_data/depth_charts.py
@@ -33,6 +33,7 @@ Degradation
 * Network error → cached prior + warning log.
 * Schema drift → empty + warning log.
 """
+
 from __future__ import annotations
 
 import json
@@ -56,12 +57,42 @@ _TIMEOUT_SEC = 6.0
 
 # NFL team IDs on ESPN — used by fetch_all().  Hardcoded because
 # this list is stable (32 teams, no new teams added since 2002).
-NFL_TEAM_IDS: list[str] = sorted({
-    "22", "1", "33", "2", "29", "3", "4", "5",    # ARI, ATL, BAL, BUF, CAR, CHI, CIN, CLE
-    "6", "7", "8", "9", "34", "11", "30", "12",   # DAL, DEN, DET, GB, HOU, IND, JAX, KC
-    "24", "14", "13", "15", "16", "17", "18", "19",  # LAC, LAR, LV, MIA, MIN, NE, NO, NYG
-    "20", "21", "23", "26", "25", "27", "10", "28",  # NYJ, PHI, PIT, SEA, SF, TB, TEN, WAS
-})
+NFL_TEAM_IDS: list[str] = sorted(
+    {
+        "22",
+        "1",
+        "33",
+        "2",
+        "29",
+        "3",
+        "4",
+        "5",  # ARI, ATL, BAL, BUF, CAR, CHI, CIN, CLE
+        "6",
+        "7",
+        "8",
+        "9",
+        "34",
+        "11",
+        "30",
+        "12",  # DAL, DEN, DET, GB, HOU, IND, JAX, KC
+        "24",
+        "14",
+        "13",
+        "15",
+        "16",
+        "17",
+        "18",
+        "19",  # LAC, LAR, LV, MIA, MIN, NE, NO, NYG
+        "20",
+        "21",
+        "23",
+        "26",
+        "25",
+        "27",
+        "10",
+        "28",  # NYJ, PHI, PIT, SEA, SF, TB, TEN, WAS
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -107,9 +138,11 @@ def fetch_team_depth_chart(
     bp = None
     try:
         from src.utils import circuit_breaker as _cb
+
         bp = _cb.get_or_create(
             "espn_depth_charts",
-            failure_threshold=5, failure_window_sec=180.0,
+            failure_threshold=5,
+            failure_window_sec=180.0,
             open_duration_sec=180.0,
         )
         if not bp.can_call():
@@ -179,16 +212,16 @@ def _parse_depth_payload(payload: Any) -> list[DepthChartEntry]:
             espn_id = str(athlete.get("id") or "").strip()
             if not espn_id:
                 continue
-            full_name = str(
-                athlete.get("displayName") or athlete.get("fullName") or ""
+            full_name = str(athlete.get("displayName") or athlete.get("fullName") or "")
+            out.append(
+                DepthChartEntry(
+                    team_abbrev=team_abbr,
+                    position=pos,
+                    slot=i + 1,
+                    espn_athlete_id=espn_id,
+                    full_name=full_name,
+                )
             )
-            out.append(DepthChartEntry(
-                team_abbrev=team_abbr,
-                position=pos,
-                slot=i + 1,
-                espn_athlete_id=espn_id,
-                full_name=full_name,
-            ))
     return out
 
 
@@ -216,27 +249,31 @@ def detect_slot_changes(
         key = (e.team_abbrev, e.position, e.espn_athlete_id)
         prev_slot = prior_by.get(key)
         if prev_slot is None:
-            out.append({
+            out.append(
+                {
+                    "espnAthleteId": e.espn_athlete_id,
+                    "fullName": e.full_name,
+                    "position": e.position,
+                    "team": e.team_abbrev,
+                    "oldSlot": None,
+                    "newSlot": e.slot,
+                    "direction": "debut",
+                }
+            )
+            continue
+        if prev_slot == e.slot:
+            continue
+        out.append(
+            {
                 "espnAthleteId": e.espn_athlete_id,
                 "fullName": e.full_name,
                 "position": e.position,
                 "team": e.team_abbrev,
-                "oldSlot": None,
+                "oldSlot": prev_slot,
                 "newSlot": e.slot,
-                "direction": "debut",
-            })
-            continue
-        if prev_slot == e.slot:
-            continue
-        out.append({
-            "espnAthleteId": e.espn_athlete_id,
-            "fullName": e.full_name,
-            "position": e.position,
-            "team": e.team_abbrev,
-            "oldSlot": prev_slot,
-            "newSlot": e.slot,
-            "direction": "promoted" if e.slot < prev_slot else "demoted",
-        })
+                "direction": "promoted" if e.slot < prev_slot else "demoted",
+            }
+        )
     return out
 
 

--- a/src/nfl_data/freshness.py
+++ b/src/nfl_data/freshness.py
@@ -14,6 +14,7 @@ until Thursday local NFL day".  Callers ask
 ``is_fresh_for_alerts(week, year, now=None)`` and skip the alert
 evaluation when False.
 """
+
 from __future__ import annotations
 
 import datetime as _dt

--- a/src/nfl_data/ingest.py
+++ b/src/nfl_data/ingest.py
@@ -24,6 +24,7 @@ changes.
 
 No function raises.  Transient failures log + return [].
 """
+
 from __future__ import annotations
 
 import logging
@@ -175,6 +176,7 @@ def _nflverse_direct():
     its pandas<2.0 pin can't be satisfied on Python 3.12)."""
     try:
         from src.nfl_data import nflverse_direct
+
         return nflverse_direct
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning("nflverse_direct import failed: %s", exc)
@@ -232,7 +234,8 @@ def _try_fetch_with_fallback(
                 rows = _dataframe_to_rows(df)
                 _LOGGER.info(
                     "nfl_data_fetch=nfl_data_py label=%s rows=%d",
-                    label, len(rows),
+                    label,
+                    len(rows),
                 )
                 return rows
             except Exception as exc:  # noqa: BLE001
@@ -241,13 +244,15 @@ def _try_fetch_with_fallback(
                 _LOGGER.warning(
                     "nfl_data_fetch=nfl_data_py_runtime_failed label=%s err=%r — "
                     "falling back to nflverse_direct",
-                    label, exc,
+                    label,
+                    exc,
                 )
         else:
             _LOGGER.warning(
                 "nfl_data_fetch=nfl_data_py_method_missing label=%s method=%s — "
                 "falling back to nflverse_direct",
-                label, nfl_method,
+                label,
+                nfl_method,
             )
 
     # Rung 3: nflverse_direct (stdlib CSV).
@@ -259,20 +264,23 @@ def _try_fetch_with_fallback(
     if direct_fn is None:
         _LOGGER.warning(
             "nfl_data_fetch=direct_method_missing label=%s method=%s",
-            label, direct_method,
+            label,
+            direct_method,
         )
         return None
     try:
         rows = direct_fn(years) if years is not None else direct_fn()
         _LOGGER.info(
             "nfl_data_fetch=nflverse_direct label=%s rows=%d",
-            label, len(rows),
+            label,
+            len(rows),
         )
         return rows
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning(
             "nfl_data_fetch=nflverse_direct_failed label=%s err=%r",
-            label, exc,
+            label,
+            exc,
         )
         return None
 
@@ -294,7 +302,8 @@ def fetch_weekly_stats(
     if cached is not None:
         return cached
     rows = _try_fetch_with_fallback(
-        years, _provider,
+        years,
+        _provider,
         nfl_method="import_weekly_data",
         direct_method="fetch_weekly_stats",
         label="weekly_stats",
@@ -329,7 +338,8 @@ def fetch_weekly_defensive_stats(
     if cached is not None:
         return cached
     rows = _try_fetch_with_fallback(
-        years, _provider,
+        years,
+        _provider,
         # ``import_weekly_data_def`` was added in nfl_data_py 0.3.5;
         # earlier versions don't expose it.  The fall-through to the
         # direct fetcher handles that case.
@@ -361,7 +371,8 @@ def fetch_snap_counts(
     if cached is not None:
         return cached
     rows = _try_fetch_with_fallback(
-        years, _provider,
+        years,
+        _provider,
         nfl_method="import_snap_counts",
         direct_method="fetch_snap_counts",
         label="snap_counts",
@@ -390,7 +401,8 @@ def fetch_id_map(
     if cached is not None:
         return cached
     rows = _try_fetch_with_fallback(
-        None, _provider,
+        None,
+        _provider,
         nfl_method="import_ids",
         direct_method="fetch_id_map",
         label="id_map",
@@ -410,8 +422,7 @@ def provider_status() -> dict[str, Any]:
     return {
         "feature_flag": feature_flags.is_enabled("nfl_data_ingest"),
         "active_provider": (
-            "nfl_data_py" if installed
-            else ("nflverse_direct" if direct_available else "none")
+            "nfl_data_py" if installed else ("nflverse_direct" if direct_available else "none")
         ),
         "nfl_data_py_installed": installed,
         "nflverse_direct_available": direct_available,

--- a/src/nfl_data/injury_feed.py
+++ b/src/nfl_data/injury_feed.py
@@ -21,6 +21,7 @@ The caller (signal engine) is responsible for fanning out
 BUY/SELL transitions across rosters — this module only fetches +
 normalizes.
 """
+
 from __future__ import annotations
 
 import json
@@ -35,18 +36,24 @@ from src.nfl_data import cache as _cache
 
 _LOGGER = logging.getLogger(__name__)
 
-_ESPN_INJURIES_URL = (
-    "https://site.api.espn.com/apis/site/v2/sports/football/nfl/injuries"
-)
+_ESPN_INJURIES_URL = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/injuries"
 _UA = "riskit-injury-feed/1.0"
 _TTL_IN_SEASON = 30 * 60  # 30 min
 _TIMEOUT_SEC = 8.0
 
 
-_ACTIVE_STATUSES = frozenset({
-    "OUT", "INJURED_RESERVE", "IR", "PHYSICALLY_UNABLE",
-    "PUP", "QUESTIONABLE", "DOUBTFUL", "DAY_TO_DAY",
-})
+_ACTIVE_STATUSES = frozenset(
+    {
+        "OUT",
+        "INJURED_RESERVE",
+        "IR",
+        "PHYSICALLY_UNABLE",
+        "PUP",
+        "QUESTIONABLE",
+        "DOUBTFUL",
+        "DAY_TO_DAY",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -119,9 +126,11 @@ def fetch_injuries(
     bp = None
     try:
         from src.utils import circuit_breaker as _cb
+
         bp = _cb.get_or_create(
             "espn_injuries",
-            failure_threshold=3, failure_window_sec=120.0,
+            failure_threshold=3,
+            failure_window_sec=120.0,
             open_duration_sec=180.0,
         )
         if not bp.can_call():
@@ -132,7 +141,8 @@ def fetch_injuries(
 
     try:
         req = urllib.request.Request(
-            _ESPN_INJURIES_URL, headers={"User-Agent": _UA},
+            _ESPN_INJURIES_URL,
+            headers={"User-Agent": _UA},
         )
         opener = _url_opener or urllib.request.urlopen
         with opener(req, timeout=_TIMEOUT_SEC) as resp:
@@ -159,27 +169,27 @@ def fetch_injuries(
 def _parse_espn_payload(payload: Any) -> list[InjuryEntry]:
     """Parse ESPN's injuries response.  Shape (as of 2026-04):
 
+    {
+      "injuries": [
         {
+          "team": {"abbreviation": "BUF", ...},
           "injuries": [
             {
-              "team": {"abbreviation": "BUF", ...},
-              "injuries": [
-                {
-                  "athlete": {"id": "...", "displayName": "...",
-                              "position": {"abbreviation": "QB"}},
-                  "status": "...",
-                  "type": {"description": "...", "abbreviation": "..."},
-                  "details": {"type": "...", "location": "...",
-                              "detail": "...", "side": "...",
-                              "returnDate": "..."},
-                  "date": "...",
-                  "shortComment": "...",
-                  "longComment": "..."
-                }, ...
-              ]
+              "athlete": {"id": "...", "displayName": "...",
+                          "position": {"abbreviation": "QB"}},
+              "status": "...",
+              "type": {"description": "...", "abbreviation": "..."},
+              "details": {"type": "...", "location": "...",
+                          "detail": "...", "side": "...",
+                          "returnDate": "..."},
+              "date": "...",
+              "shortComment": "...",
+              "longComment": "..."
             }, ...
           ]
-        }
+        }, ...
+      ]
+    }
     """
     out: list[InjuryEntry] = []
     if not isinstance(payload, dict):
@@ -213,17 +223,19 @@ def _parse_espn_payload(payload: Any) -> list[InjuryEntry]:
             body_part = str(details.get("location") or details.get("type") or "")
             returning = str(details.get("returnDate") or "")
             description = str(entry.get("shortComment") or entry.get("longComment") or "")
-            out.append(InjuryEntry(
-                espn_athlete_id=espn_id,
-                full_name=name,
-                position=pos,
-                team_abbrev=team_abbr,
-                status=status_norm,
-                body_part=body_part,
-                description=description,
-                date_reported=str(entry.get("date") or ""),
-                returning=returning,
-            ))
+            out.append(
+                InjuryEntry(
+                    espn_athlete_id=espn_id,
+                    full_name=name,
+                    position=pos,
+                    team_abbrev=team_abbr,
+                    status=status_norm,
+                    body_part=body_part,
+                    description=description,
+                    date_reported=str(entry.get("date") or ""),
+                    returning=returning,
+                )
+            )
     return out
 
 
@@ -263,30 +275,33 @@ def diff_for_signals(
         prev = prior_by_id.get(curr.espn_athlete_id)
         if prev is None:
             # New injury.
-            signals.append({
-                "espnAthleteId": curr.espn_athlete_id,
-                "name": curr.full_name,
-                "position": curr.position,
-                "team": curr.team_abbrev,
-                "transition": "healthy_to_injured",
-                "newStatus": curr.status,
-                "priorStatus": None,
-                "reason": f"New injury — {curr.status}" + (
-                    f" ({curr.body_part})" if curr.body_part else ""
-                ),
-            })
+            signals.append(
+                {
+                    "espnAthleteId": curr.espn_athlete_id,
+                    "name": curr.full_name,
+                    "position": curr.position,
+                    "team": curr.team_abbrev,
+                    "transition": "healthy_to_injured",
+                    "newStatus": curr.status,
+                    "priorStatus": None,
+                    "reason": f"New injury — {curr.status}"
+                    + (f" ({curr.body_part})" if curr.body_part else ""),
+                }
+            )
             continue
         prev_sev = severity.get(prev.status, 0)
         new_sev = severity.get(curr.status, 0)
         if new_sev > prev_sev:
-            signals.append({
-                "espnAthleteId": curr.espn_athlete_id,
-                "name": curr.full_name,
-                "position": curr.position,
-                "team": curr.team_abbrev,
-                "transition": "injury_worsened",
-                "newStatus": curr.status,
-                "priorStatus": prev.status,
-                "reason": f"Status worsened: {prev.status} → {curr.status}",
-            })
+            signals.append(
+                {
+                    "espnAthleteId": curr.espn_athlete_id,
+                    "name": curr.full_name,
+                    "position": curr.position,
+                    "team": curr.team_abbrev,
+                    "transition": "injury_worsened",
+                    "newStatus": curr.status,
+                    "priorStatus": prev.status,
+                    "reason": f"Status worsened: {prev.status} → {curr.status}",
+                }
+            )
     return signals

--- a/src/nfl_data/nflverse_direct.py
+++ b/src/nfl_data/nflverse_direct.py
@@ -36,6 +36,7 @@ HTTP error, parse error, empty CSV.  Logs a structured warning
 on failure paths so ops can grep ``nflverse_direct=`` for
 upstream issues.
 """
+
 from __future__ import annotations
 
 import csv
@@ -55,9 +56,7 @@ _RELEASE_BASE = "https://github.com/nflverse/nflverse-data/releases/download"
 
 # Per-dataset URL templates.  ``{year}`` is the season year.
 _URL_TEMPLATES = {
-    "weekly_stats": (
-        f"{_RELEASE_BASE}/player_stats/player_stats_{{year}}.csv"
-    ),
+    "weekly_stats": (f"{_RELEASE_BASE}/player_stats/player_stats_{{year}}.csv"),
     "weekly_defensive_stats": (
         # Defensive per-week stats live in a separate nflverse file
         # from offensive stats.  Columns are prefixed ``def_``:
@@ -66,15 +65,9 @@ _URL_TEMPLATES = {
         # Verified live 2026-04-26.
         f"{_RELEASE_BASE}/player_stats/player_stats_def_{{year}}.csv"
     ),
-    "snap_counts": (
-        f"{_RELEASE_BASE}/snap_counts/snap_counts_{{year}}.csv"
-    ),
-    "id_map": (
-        f"{_RELEASE_BASE}/players/players.csv"
-    ),
-    "pbp": (
-        f"{_RELEASE_BASE}/pbp/play_by_play_{{year}}.csv"
-    ),
+    "snap_counts": (f"{_RELEASE_BASE}/snap_counts/snap_counts_{{year}}.csv"),
+    "id_map": (f"{_RELEASE_BASE}/players/players.csv"),
+    "pbp": (f"{_RELEASE_BASE}/pbp/play_by_play_{{year}}.csv"),
 }
 
 _HTTP_TIMEOUT_SEC = 30.0
@@ -88,15 +81,18 @@ def _fetch_csv(url: str, *, label: str) -> list[dict[str, Any]]:
     bp = None
     try:
         from src.utils import circuit_breaker as _cb
+
         bp = _cb.get_or_create(
             "nflverse_direct",
-            failure_threshold=3, failure_window_sec=180.0,
+            failure_threshold=3,
+            failure_window_sec=180.0,
             open_duration_sec=300.0,
         )
         if not bp.can_call():
             _LOGGER.warning(
                 "nflverse_direct=circuit_open label=%s url=%s",
-                label, url,
+                label,
+                url,
             )
             return []
     except Exception:  # noqa: BLE001
@@ -109,7 +105,9 @@ def _fetch_csv(url: str, *, label: str) -> list[dict[str, Any]]:
     except urllib.error.HTTPError as exc:
         _LOGGER.warning(
             "nflverse_direct=http label=%s url=%s status=%d",
-            label, url, getattr(exc, "code", 0),
+            label,
+            url,
+            getattr(exc, "code", 0),
         )
         if bp is not None:
             bp.report_failure(exc)
@@ -117,7 +115,9 @@ def _fetch_csv(url: str, *, label: str) -> list[dict[str, Any]]:
     except (urllib.error.URLError, TimeoutError) as exc:
         _LOGGER.warning(
             "nflverse_direct=network label=%s url=%s err=%r",
-            label, url, exc,
+            label,
+            url,
+            exc,
         )
         if bp is not None:
             bp.report_failure(exc)
@@ -125,7 +125,9 @@ def _fetch_csv(url: str, *, label: str) -> list[dict[str, Any]]:
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning(
             "nflverse_direct=unexpected label=%s url=%s err=%r",
-            label, url, exc,
+            label,
+            url,
+            exc,
         )
         if bp is not None:
             bp.report_failure(exc)
@@ -137,7 +139,8 @@ def _fetch_csv(url: str, *, label: str) -> list[dict[str, Any]]:
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning(
             "nflverse_direct=parse label=%s err=%r",
-            label, exc,
+            label,
+            exc,
         )
         if bp is not None:
             bp.report_failure(exc)
@@ -145,7 +148,9 @@ def _fetch_csv(url: str, *, label: str) -> list[dict[str, Any]]:
 
     _LOGGER.info(
         "nflverse_direct=ok label=%s url=%s rows=%d",
-        label, url, len(rows),
+        label,
+        url,
+        len(rows),
     )
     if bp is not None:
         bp.report_success()

--- a/src/nfl_data/opportunity_stats.py
+++ b/src/nfl_data/opportunity_stats.py
@@ -37,6 +37,7 @@ refreshes.
 Gracefully empty when nfl_data_ingest flag is off — returns empty
 list + ``reason="nfl_data_disabled"``.
 """
+
 from __future__ import annotations
 
 import logging
@@ -205,23 +206,25 @@ def build_opportunity_from_pbp(
     out: list[OpportunityStats] = []
     for (gsis, season_val), b in buckets.items():
         name, pos = names.get((gsis, season_val), ("", ""))
-        out.append(OpportunityStats(
-            player_id_gsis=gsis,
-            player_name=name,
-            position=pos,
-            season=season_val,
-            rz_targets=b.get("rz_targets", 0),
-            rz_carries=b.get("rz_carries", 0),
-            rz_receptions=b.get("rz_receptions", 0),
-            rz_touchdowns=b.get("rz_touchdowns", 0),
-            gl_carries=b.get("gl_carries", 0),
-            gl_targets=b.get("gl_targets", 0),
-            third_down_targets=b.get("third_down_targets", 0),
-            third_down_carries=b.get("third_down_carries", 0),
-            third_down_conversions=b.get("third_down_conversions", 0),
-            third_down_attempts=b.get("third_down_attempts", 0),
-            opportunity_score=_compute_opportunity_score(b, pos),
-        ))
+        out.append(
+            OpportunityStats(
+                player_id_gsis=gsis,
+                player_name=name,
+                position=pos,
+                season=season_val,
+                rz_targets=b.get("rz_targets", 0),
+                rz_carries=b.get("rz_carries", 0),
+                rz_receptions=b.get("rz_receptions", 0),
+                rz_touchdowns=b.get("rz_touchdowns", 0),
+                gl_carries=b.get("gl_carries", 0),
+                gl_targets=b.get("gl_targets", 0),
+                third_down_targets=b.get("third_down_targets", 0),
+                third_down_carries=b.get("third_down_carries", 0),
+                third_down_conversions=b.get("third_down_conversions", 0),
+                third_down_attempts=b.get("third_down_attempts", 0),
+                opportunity_score=_compute_opportunity_score(b, pos),
+            )
+        )
     return out
 
 
@@ -279,11 +282,20 @@ def fetch_opportunity_stats(
             df = nfl_data_py.import_pbp_data(
                 years,
                 columns=[
-                    "season", "week", "play_type", "down", "yardline_100",
-                    "posteam", "defteam",
-                    "receiver_player_id", "receiver_player_name",
-                    "rusher_player_id", "rusher_player_name",
-                    "complete_pass", "touchdown", "first_down",
+                    "season",
+                    "week",
+                    "play_type",
+                    "down",
+                    "yardline_100",
+                    "posteam",
+                    "defteam",
+                    "receiver_player_id",
+                    "receiver_player_name",
+                    "rusher_player_id",
+                    "rusher_player_name",
+                    "complete_pass",
+                    "touchdown",
+                    "first_down",
                 ],
             )
             pbp = df.to_dict(orient="records") if hasattr(df, "to_dict") else []

--- a/src/nfl_data/realized_points.py
+++ b/src/nfl_data/realized_points.py
@@ -53,6 +53,7 @@ Degradation
 * Zero or negative stats → included verbatim (a −1 INT
   contribution is real).
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -109,11 +110,24 @@ _IDP_KEYS: dict[str, tuple[str, str]] = {
 # Position labels that count as IDP scoring eligible.  nflverse uses
 # both the abstract group (DL/LB/DB) and the specific listing
 # (DT/DE/EDGE/ILB/OLB/CB/S/FS/SS/NT) — accept both.
-_IDP_POSITIONS = frozenset({
-    "DL", "DT", "DE", "EDGE", "NT",
-    "LB", "ILB", "OLB", "MLB",
-    "DB", "CB", "S", "FS", "SS",
-})
+_IDP_POSITIONS = frozenset(
+    {
+        "DL",
+        "DT",
+        "DE",
+        "EDGE",
+        "NT",
+        "LB",
+        "ILB",
+        "OLB",
+        "MLB",
+        "DB",
+        "CB",
+        "S",
+        "FS",
+        "SS",
+    }
+)
 
 
 def _is_idp_position(position: str | None) -> bool:
@@ -267,7 +281,10 @@ def compute_weekly_points(
             total += contribution
 
     return RealizedPoints(
-        season=season, week=week, fantasy_points=total, breakdown=breakdown,
+        season=season,
+        week=week,
+        fantasy_points=total,
+        breakdown=breakdown,
     )
 
 

--- a/src/nfl_data/usage_windows.py
+++ b/src/nfl_data/usage_windows.py
@@ -18,6 +18,7 @@ Pure-Python.  No pandas.
 Callers pass normalized stat rows in any shape — this module
 looks up keys by name and tolerates missing fields (returns 0).
 """
+
 from __future__ import annotations
 
 import math
@@ -53,7 +54,9 @@ class UsageWindow:
             "carryShareMean": round(self.carry_share_mean, 3),
             "carryShareSd": round(self.carry_share_sd, 3),
             "snapPctZ": round(self.snap_pct_z, 2) if self.snap_pct_z is not None else None,
-            "targetShareZ": round(self.target_share_z, 2) if self.target_share_z is not None else None,
+            "targetShareZ": round(self.target_share_z, 2)
+            if self.target_share_z is not None
+            else None,
             "carryShareZ": round(self.carry_share_z, 2) if self.carry_share_z is not None else None,
         }
 
@@ -136,7 +139,9 @@ def build_rolling_windows(
 
     windows: list[UsageWindow] = []
     for pid, rows in by_player.items():
-        rows_sorted = sorted(rows, key=lambda r: (int(_num(r.get("season"))), int(_num(r.get("week")))))
+        rows_sorted = sorted(
+            rows, key=lambda r: (int(_num(r.get("season"))), int(_num(r.get("week"))))
+        )
         snap_pct_hist: list[float] = []
         target_share_hist: list[float] = []
         carry_share_hist: list[float] = []
@@ -164,9 +169,15 @@ def build_rolling_windows(
                 target_share_sd=_stdev(w_tgt),
                 carry_share_mean=(sum(w_car) / len(w_car)) if w_car else 0.0,
                 carry_share_sd=_stdev(w_car),
-                snap_pct_z=_zscore(curr_snap, sum(w_snap)/len(w_snap), _stdev(w_snap)) if len(w_snap) >= 2 else None,
-                target_share_z=_zscore(curr_target, sum(w_tgt)/len(w_tgt), _stdev(w_tgt)) if len(w_tgt) >= 2 else None,
-                carry_share_z=_zscore(curr_carry, sum(w_car)/len(w_car), _stdev(w_car)) if len(w_car) >= 2 else None,
+                snap_pct_z=_zscore(curr_snap, sum(w_snap) / len(w_snap), _stdev(w_snap))
+                if len(w_snap) >= 2
+                else None,
+                target_share_z=_zscore(curr_target, sum(w_tgt) / len(w_tgt), _stdev(w_tgt))
+                if len(w_tgt) >= 2
+                else None,
+                carry_share_z=_zscore(curr_carry, sum(w_car) / len(w_car), _stdev(w_car))
+                if len(w_car) >= 2
+                else None,
             )
             windows.append(w)
             snap_pct_hist.append(curr_snap)

--- a/src/pool/builder.py
+++ b/src/pool/builder.py
@@ -10,6 +10,7 @@ IDPTradeCalc enriches the final union but NEVER decides membership.
 This module is called by Dynasty Scraper.py after raw source ingestion
 and before players_json export.
 """
+
 from __future__ import annotations
 
 import json
@@ -36,6 +37,7 @@ SOURCE_TYPES = {
 @dataclass
 class CanonicalPoolRow:
     """One player in the canonical universe."""
+
     canonical_id: str | None = None
     canonical_name: str = ""
     position: str = ""
@@ -71,6 +73,7 @@ class CanonicalPoolRow:
 @dataclass
 class AdamidpRow:
     """One row from an Adamidp PDF."""
+
     overall_rank: int | None = None
     player_name: str = ""
     position: str = ""
@@ -87,6 +90,7 @@ class AdamidpRow:
 @dataclass
 class PoolAuditReport:
     """Structured audit of the pool build."""
+
     sleeper_count: int = 0
     ktc_top525_count: int = 0
     adamidp_extracted_raw_count: int = 0
@@ -109,8 +113,21 @@ class PoolAuditReport:
 # ── Position normalization (reuse from Dynasty Scraper.py) ──
 
 _OFFENSE_POSITIONS = {"QB", "RB", "WR", "TE"}
-_IDP_POSITIONS_EXPANDED = {"DL", "DE", "DT", "LB", "DB", "CB", "S", "EDGE", "NT",
-                           "OLB", "ILB", "FS", "SS"}
+_IDP_POSITIONS_EXPANDED = {
+    "DL",
+    "DE",
+    "DT",
+    "LB",
+    "DB",
+    "CB",
+    "S",
+    "EDGE",
+    "NT",
+    "OLB",
+    "ILB",
+    "FS",
+    "SS",
+}
 _IDP_POSITIONS_NORMALIZED = {"DL", "LB", "DB"}
 
 
@@ -138,10 +155,38 @@ def is_idp(pos: str) -> bool:
 # ── Name cleaning (extracted from Dynasty Scraper.py) ──
 
 _TEAM_CODES = {
-    "ARI", "ATL", "BAL", "BUF", "CAR", "CHI", "CIN", "CLE",
-    "DAL", "DEN", "DET", "GB", "HOU", "IND", "JAX", "KC",
-    "LAC", "LAR", "LV", "MIA", "MIN", "NE", "NO", "NYG",
-    "NYJ", "PHI", "PIT", "SEA", "SF", "TB", "TEN", "WAS",
+    "ARI",
+    "ATL",
+    "BAL",
+    "BUF",
+    "CAR",
+    "CHI",
+    "CIN",
+    "CLE",
+    "DAL",
+    "DEN",
+    "DET",
+    "GB",
+    "HOU",
+    "IND",
+    "JAX",
+    "KC",
+    "LAC",
+    "LAR",
+    "LV",
+    "MIA",
+    "MIN",
+    "NE",
+    "NO",
+    "NYG",
+    "NYJ",
+    "PHI",
+    "PIT",
+    "SEA",
+    "SF",
+    "TB",
+    "TEN",
+    "WAS",
     "FA",
 }
 
@@ -151,30 +196,25 @@ def pool_clean_name(raw: str) -> str:
     if not raw:
         return ""
     name = str(raw).strip()
-    if '\\u' in name:
+    if "\\u" in name:
         try:
-            name = name.encode('utf-8').decode('unicode_escape')
+            name = name.encode("utf-8").decode("unicode_escape")
         except Exception:
-            name = re.sub(r'\\u([0-9a-fA-F]{4})',
-                          lambda m: chr(int(m.group(1), 16)), name)
+            name = re.sub(r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), name)
     name = re.sub(r"^\s*#?\d+\s*[\).:-]\s*", "", name)
     name = re.sub(r"\s*[\*\u2020\u2021]+\s*$", "", name)
     name = re.sub(r"\s*\([^)]*\)\s*$", "", name).strip()
-    name = re.sub(r'[\u2018\u2019\u0060\u00B4\u0027\u2032]', "'", name)
+    name = re.sub(r"[\u2018\u2019\u0060\u00B4\u0027\u2032]", "'", name)
     if "," in name:
         m = re.match(r"^\s*([A-Za-z.'\- ]+),\s*([A-Za-z.'\- ]+)\s*$", name)
         if m:
             name = f"{m.group(2).strip()} {m.group(1).strip()}".strip()
-    name = re.split(
-        r'\s+(QB|RB|WR|TE|K|DEF|DST|OL|LB|DB|DL|DE|DT|CB|S|PK)\b', name
-    )[0].strip()
-    m = re.match(r'^(.+?)([A-Z]{2,3})$', name)
+    name = re.split(r"\s+(QB|RB|WR|TE|K|DEF|DST|OL|LB|DB|DL|DE|DT|CB|S|PK)\b", name)[0].strip()
+    m = re.match(r"^(.+?)([A-Z]{2,3})$", name)
     if m and m.group(2) in _TEAM_CODES and len(m.group(1).strip()) > 3:
         name = m.group(1).strip()
-    name = re.sub(
-        r'[,\s]+(Jr.?|Sr.?|I{2,3}|IV|V|VI)\s*$', '', name, flags=re.IGNORECASE
-    ).strip()
-    name = re.sub(r'\s{2,}', ' ', name)
+    name = re.sub(r"[,\s]+(Jr.?|Sr.?|I{2,3}|IV|V|VI)\s*$", "", name, flags=re.IGNORECASE).strip()
+    name = re.sub(r"\s{2,}", " ", name)
     return name
 
 
@@ -194,8 +234,8 @@ def pool_normalize_lookup(raw: str) -> str:
         initial_run.append(parts[idx])
         idx += 1
     if len(initial_run) >= 2:
-        merged = ''.join(initial_run)
-        s = ' '.join([merged] + parts[idx:])
+        merged = "".join(initial_run)
+        s = " ".join([merged] + parts[idx:])
     return s
 
 
@@ -211,6 +251,7 @@ def _is_pick_name(name: str) -> bool:
 
 
 # ── Sleeper ingestion ──
+
 
 def extract_sleeper_roster_names(
     sleeper_roster_data: dict[str, Any],
@@ -228,15 +269,18 @@ def extract_sleeper_roster_names(
         clean = pool_clean_name(name)
         if not clean:
             continue
-        entries.append({
-            "name": clean,
-            "position": normalize_position(pos or ""),
-            "sleeper_id": str(player_ids.get(name, "") or ""),
-        })
+        entries.append(
+            {
+                "name": clean,
+                "position": normalize_position(pos or ""),
+                "sleeper_id": str(player_ids.get(name, "") or ""),
+            }
+        )
     return entries
 
 
 # ── KTC structured ingestion ──
+
 
 def extract_ktc_structured(
     full_data_ktc: dict[str, float | int],
@@ -263,17 +307,20 @@ def extract_ktc_structured(
 
     rows = []
     for i, entry in enumerate(cleaned[:limit]):
-        rows.append({
-            "name": entry["name"],
-            "raw_name": entry["raw_name"],
-            "source_rank": i + 1,
-            "source_value": entry["value"],
-            "position": "",  # KTC doesn't reliably expose position in name→value
-        })
+        rows.append(
+            {
+                "name": entry["name"],
+                "raw_name": entry["raw_name"],
+                "source_rank": i + 1,
+                "source_value": entry["value"],
+                "position": "",  # KTC doesn't reliably expose position in name→value
+            }
+        )
     return rows
 
 
 # ── Adamidp PDF extraction ──
+
 
 def _reconstruct_split_names(lines: list[str]) -> list[str]:
     """Reconstruct player names that were split across PDF lines.
@@ -292,14 +339,16 @@ def _reconstruct_split_names(lines: list[str]) -> list[str]:
             continue
 
         # Check if next line looks like a name continuation (no rank number, short text)
-        while (i + 1 < len(lines)
-               and lines[i + 1].strip()
-               and not re.match(r'^\d+\s', lines[i + 1].strip())
-               and len(lines[i + 1].strip().split()) <= 2
-               and re.match(r'^[A-Za-z.\'-]+$', lines[i + 1].strip().split()[0])):
+        while (
+            i + 1 < len(lines)
+            and lines[i + 1].strip()
+            and not re.match(r"^\d+\s", lines[i + 1].strip())
+            and len(lines[i + 1].strip().split()) <= 2
+            and re.match(r"^[A-Za-z.\'-]+$", lines[i + 1].strip().split()[0])
+        ):
             next_part = lines[i + 1].strip()
             # Don't merge if next line looks like a position tag
-            if re.match(r'^(QB|RB|WR|TE|LB|DL|DB|DE|DT|CB|S|K|EDGE)$', next_part, re.I):
+            if re.match(r"^(QB|RB|WR|TE|LB|DL|DB|DE|DT|CB|S|K|EDGE)$", next_part, re.I):
                 break
             line = line + " " + next_part
             i += 1
@@ -383,6 +432,7 @@ def dedupe_adamidp_rows(rows: list[AdamidpRow]) -> tuple[list[AdamidpRow], list[
 
 
 # ── Union construction ──
+
 
 def build_canonical_pool(
     *,
@@ -473,20 +523,24 @@ def build_canonical_pool(
         report.adamidp_unique_count = len(unique_rows)
 
         for arow in ambiguous_rows:
-            report.excluded_names.append({
-                "name": arow.player_name,
-                "reason": f"ambiguous: {arow.ambiguous_reason}",
-                "source": "adamidp",
-            })
+            report.excluded_names.append(
+                {
+                    "name": arow.player_name,
+                    "reason": f"ambiguous: {arow.ambiguous_reason}",
+                    "source": "adamidp",
+                }
+            )
 
         for arow in unique_rows:
             norm = pool_normalize_lookup(arow.player_name)
             if not norm:
-                report.excluded_names.append({
-                    "name": arow.player_name,
-                    "reason": "name could not be normalized",
-                    "source": "adamidp",
-                })
+                report.excluded_names.append(
+                    {
+                        "name": arow.player_name,
+                        "reason": "name could not be normalized",
+                        "source": "adamidp",
+                    }
+                )
                 continue
             if norm in norm_to_key:
                 existing_key = norm_to_key[norm]
@@ -551,11 +605,13 @@ def build_canonical_pool(
     for norm_key, row in pool.items():
         if not row.canonical_name:
             excluded_norms.add(norm_key)
-            report.excluded_names.append({
-                "name": "",
-                "reason": "empty canonical name",
-                "source": ",".join(row.raw_source_names.keys()),
-            })
+            report.excluded_names.append(
+                {
+                    "name": "",
+                    "reason": "empty canonical name",
+                    "source": ",".join(row.raw_source_names.keys()),
+                }
+            )
             continue
         if _is_pick_name(row.canonical_name):
             excluded_norms.add(norm_key)
@@ -613,12 +669,21 @@ def build_canonical_pool(
     report.final_union_count = len(final_rows)
 
     # Sample unique-to-source lists
-    sleeper_only = [r.canonical_name for r in final_rows
-                    if r.in_sleeper and not r.in_ktc_top525 and not r.in_adamidp_pdf]
-    ktc_only = [r.canonical_name for r in final_rows
-                if r.in_ktc_top525 and not r.in_sleeper and not r.in_adamidp_pdf]
-    adamidp_only = [r.canonical_name for r in final_rows
-                    if r.in_adamidp_pdf and not r.in_sleeper and not r.in_ktc_top525]
+    sleeper_only = [
+        r.canonical_name
+        for r in final_rows
+        if r.in_sleeper and not r.in_ktc_top525 and not r.in_adamidp_pdf
+    ]
+    ktc_only = [
+        r.canonical_name
+        for r in final_rows
+        if r.in_ktc_top525 and not r.in_sleeper and not r.in_adamidp_pdf
+    ]
+    adamidp_only = [
+        r.canonical_name
+        for r in final_rows
+        if r.in_adamidp_pdf and not r.in_sleeper and not r.in_ktc_top525
+    ]
 
     report.sleeper_only_sample = sleeper_only[:20]
     report.ktc_only_sample = ktc_only[:20]

--- a/src/public_league/__init__.py
+++ b/src/public_league/__init__.py
@@ -43,6 +43,7 @@ Infrastructure modules:
                       every section module
     public_contract — Public API contract wrapper + safety allowlist
 """
+
 from __future__ import annotations
 
 from .public_contract import (

--- a/src/public_league/activity.py
+++ b/src/public_league/activity.py
@@ -21,6 +21,7 @@ Blockbuster tiebreaks (prompt spec):
        deterministic tiebreaker and drop the raw number from the
        response.
 """
+
 from __future__ import annotations
 
 import math
@@ -185,7 +186,9 @@ def _player_asset(player_id: str, snapshot: PublicLeagueSnapshot) -> dict[str, A
     }
 
 
-def _normalize_trade(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, tx: dict[str, Any]) -> dict[str, Any] | None:
+def _normalize_trade(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, tx: dict[str, Any]
+) -> dict[str, Any] | None:
     roster_ids = []
     for rid in tx.get("roster_ids") or []:
         try:
@@ -221,17 +224,21 @@ def _normalize_trade(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, tx:
         side_note_count = sum(1 for a in received_assets if a.get("position") in NOTABLE_POSITIONS)
         total_assets += len(received_assets)
         total_notable += side_note_count
-        sides.append({
-            "rosterId": rid,
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
-            "teamName": metrics.team_name(snapshot, season.league_id, rid) if owner_id else f"Team {rid}",
-            "receivedAssets": received_assets,
-            "sentPlayerIds": list(sent_player_ids),
-            "receivedPlayerCount": len(received_player_ids),
-            "receivedPickCount": len(received_picks),
-            "notableAssetCount": side_note_count,
-        })
+        sides.append(
+            {
+                "rosterId": rid,
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+                "teamName": metrics.team_name(snapshot, season.league_id, rid)
+                if owner_id
+                else f"Team {rid}",
+                "receivedAssets": received_assets,
+                "sentPlayerIds": list(sent_player_ids),
+                "receivedPlayerCount": len(received_player_ids),
+                "receivedPickCount": len(received_picks),
+                "notableAssetCount": side_note_count,
+            }
+        )
 
     if not sides:
         return None
@@ -326,10 +333,7 @@ def _timeline_by_week(feed: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for t in feed:
         wk = t.get("week") or 0
         grouped[(t["season"], int(wk))] += 1
-    rows = [
-        {"season": season, "week": week, "trades": n}
-        for (season, week), n in grouped.items()
-    ]
+    rows = [{"season": season, "week": week, "trades": n} for (season, week), n in grouped.items()]
     rows.sort(key=lambda r: (r["season"], r["week"]))
     return rows
 
@@ -367,11 +371,13 @@ def build_section(
                 for side in normalized["sides"]:
                     picks_moved += side["receivedPickCount"]
                     players_moved += side["receivedPlayerCount"]
-        per_season_counts.append({
-            "season": season.season,
-            "leagueId": season.league_id,
-            "tradeCount": season_trades,
-        })
+        per_season_counts.append(
+            {
+                "season": season.season,
+                "leagueId": season.league_id,
+                "tradeCount": season_trades,
+            }
+        )
 
     feed.sort(key=lambda t: -int(t.get("createdAt") or 0))
     if valuation is not None:

--- a/src/public_league/archives.py
+++ b/src/public_league/archives.py
@@ -15,6 +15,7 @@ season, week (where applicable), manager (ownerId), player, trade
 partner (ownerIds), position, asset type, and a ``tags`` list with
 award labels when relevant.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -38,7 +39,9 @@ def _award_tags_by_owner(awards_section: dict[str, Any]) -> dict[tuple[str, str]
     return out
 
 
-def _trade_archives(snapshot: PublicLeagueSnapshot, activity: dict[str, Any]) -> list[dict[str, Any]]:
+def _trade_archives(
+    snapshot: PublicLeagueSnapshot, activity: dict[str, Any]
+) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for trade in activity.get("feed", []):
         owners = [s["ownerId"] for s in trade["sides"] if s.get("ownerId")]
@@ -53,20 +56,22 @@ def _trade_archives(snapshot: PublicLeagueSnapshot, activity: dict[str, Any]) ->
                         player_names.append(asset["playerName"])
                     if asset.get("position"):
                         positions.append(asset["position"])
-        rows.append({
-            "kind": "trade",
-            "transactionId": trade["transactionId"],
-            "season": trade["season"],
-            "leagueId": trade["leagueId"],
-            "week": trade.get("week"),
-            "createdAt": trade.get("createdAt"),
-            "ownerIds": owners,
-            "playerNames": player_names,
-            "positions": positions,
-            "assetTypes": sorted(asset_types),
-            "totalAssets": trade["totalAssets"],
-            "tags": [],
-        })
+        rows.append(
+            {
+                "kind": "trade",
+                "transactionId": trade["transactionId"],
+                "season": trade["season"],
+                "leagueId": trade["leagueId"],
+                "week": trade.get("week"),
+                "createdAt": trade.get("createdAt"),
+                "ownerIds": owners,
+                "playerNames": player_names,
+                "positions": positions,
+                "assetTypes": sorted(asset_types),
+                "totalAssets": trade["totalAssets"],
+                "tags": [],
+            }
+        )
     return rows
 
 
@@ -105,21 +110,23 @@ def _waiver_archives(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
                 }
                 for pid in drops.keys()
             ]
-            rows.append({
-                "kind": "waiver",
-                "transactionId": str(tx.get("transaction_id") or ""),
-                "season": season.season,
-                "leagueId": season.league_id,
-                "week": tx.get("_leg"),
-                "createdAt": tx.get("created") or tx.get("status_updated"),
-                "ownerId": owner_id,
-                "rosterId": primary_rid,
-                "bid": bid_n,
-                "added": added_players,
-                "dropped": dropped_players,
-                "type": str(tx.get("type") or "").lower(),
-                "tags": [],
-            })
+            rows.append(
+                {
+                    "kind": "waiver",
+                    "transactionId": str(tx.get("transaction_id") or ""),
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    "week": tx.get("_leg"),
+                    "createdAt": tx.get("created") or tx.get("status_updated"),
+                    "ownerId": owner_id,
+                    "rosterId": primary_rid,
+                    "bid": bid_n,
+                    "added": added_players,
+                    "dropped": dropped_players,
+                    "type": str(tx.get("type") or "").lower(),
+                    "tags": [],
+                }
+            )
     rows.sort(key=lambda r: -(int(r.get("createdAt") or 0)))
     return rows
 
@@ -145,27 +152,31 @@ def _weekly_matchup_archives(snapshot: PublicLeagueSnapshot) -> list[dict[str, A
                     winner = owner_b
                 else:
                     winner = ""
-                rows.append({
-                    "kind": "weekly_matchup",
-                    "season": season.season,
-                    "leagueId": season.league_id,
-                    "week": week,
-                    "isPlayoff": is_playoff,
-                    "matchupId": a.get("matchup_id"),
-                    "homeOwnerId": owner_a,
-                    "awayOwnerId": owner_b,
-                    "homeRosterId": rid_a,
-                    "awayRosterId": rid_b,
-                    "homePoints": round(pa, 2),
-                    "awayPoints": round(pb, 2),
-                    "winnerOwnerId": winner,
-                    "margin": round(abs(pa - pb), 2),
-                    "tags": ["playoff"] if is_playoff else [],
-                })
+                rows.append(
+                    {
+                        "kind": "weekly_matchup",
+                        "season": season.season,
+                        "leagueId": season.league_id,
+                        "week": week,
+                        "isPlayoff": is_playoff,
+                        "matchupId": a.get("matchup_id"),
+                        "homeOwnerId": owner_a,
+                        "awayOwnerId": owner_b,
+                        "homeRosterId": rid_a,
+                        "awayRosterId": rid_b,
+                        "homePoints": round(pa, 2),
+                        "awayPoints": round(pb, 2),
+                        "winnerOwnerId": winner,
+                        "margin": round(abs(pa - pb), 2),
+                        "tags": ["playoff"] if is_playoff else [],
+                    }
+                )
     return rows
 
 
-def _rookie_draft_archives(snapshot: PublicLeagueSnapshot, draft_section: dict[str, Any]) -> list[dict[str, Any]]:
+def _rookie_draft_archives(
+    snapshot: PublicLeagueSnapshot, draft_section: dict[str, Any]
+) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for draft in draft_section.get("drafts", []):
         if str(draft.get("type") or "").lower() not in {"rookie", "rookie_draft"}:
@@ -175,26 +186,32 @@ def _rookie_draft_archives(snapshot: PublicLeagueSnapshot, draft_section: dict[s
         for pick in draft.get("picks", []):
             if not pick.get("playerName"):
                 continue
-            rows.append({
-                "kind": "rookie_draft",
-                "draftId": draft["draftId"],
-                "season": draft["season"],
-                "leagueId": draft["leagueId"],
-                "round": pick["round"],
-                "pickNo": pick["pickNo"],
-                "ownerId": pick["ownerId"],
-                "rosterId": pick["rosterId"],
-                "teamName": pick["teamName"],
-                "playerId": pick["playerId"],
-                "playerName": pick["playerName"],
-                "position": pick.get("position"),
-                "nflTeam": pick.get("nflTeam"),
-                "tags": [],
-            })
+            rows.append(
+                {
+                    "kind": "rookie_draft",
+                    "draftId": draft["draftId"],
+                    "season": draft["season"],
+                    "leagueId": draft["leagueId"],
+                    "round": pick["round"],
+                    "pickNo": pick["pickNo"],
+                    "ownerId": pick["ownerId"],
+                    "rosterId": pick["rosterId"],
+                    "teamName": pick["teamName"],
+                    "playerId": pick["playerId"],
+                    "playerName": pick["playerName"],
+                    "position": pick.get("position"),
+                    "nflTeam": pick.get("nflTeam"),
+                    "tags": [],
+                }
+            )
     return rows
 
 
-def _season_result_archives(snapshot: PublicLeagueSnapshot, history_section: dict[str, Any], award_tags: dict[tuple[str, str], list[str]]) -> list[dict[str, Any]]:
+def _season_result_archives(
+    snapshot: PublicLeagueSnapshot,
+    history_section: dict[str, Any],
+    award_tags: dict[tuple[str, str], list[str]],
+) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for season_row in history_section.get("seasons", []):
         season = season_row["season"]
@@ -204,36 +221,40 @@ def _season_result_archives(snapshot: PublicLeagueSnapshot, history_section: dic
             tags = list(award_tags.get((season, owner_id), []))
             if standing.get("finalPlace") == 1:
                 tags.append("champion")
-            rows.append({
-                "kind": "season_result",
-                "season": season,
-                "leagueId": league_id,
-                "ownerId": owner_id,
-                "rosterId": standing["rosterId"],
-                "teamName": standing["teamName"],
-                "wins": standing["wins"],
-                "losses": standing["losses"],
-                "ties": standing["ties"],
-                "pointsFor": standing["pointsFor"],
-                "pointsAgainst": standing["pointsAgainst"],
-                "finalPlace": standing.get("finalPlace"),
-                "madePlayoffs": standing["madePlayoffs"],
-                "standing": standing["standing"],
-                "tags": sorted(set(tags)),
-            })
+            rows.append(
+                {
+                    "kind": "season_result",
+                    "season": season,
+                    "leagueId": league_id,
+                    "ownerId": owner_id,
+                    "rosterId": standing["rosterId"],
+                    "teamName": standing["teamName"],
+                    "wins": standing["wins"],
+                    "losses": standing["losses"],
+                    "ties": standing["ties"],
+                    "pointsFor": standing["pointsFor"],
+                    "pointsAgainst": standing["pointsAgainst"],
+                    "finalPlace": standing.get("finalPlace"),
+                    "madePlayoffs": standing["madePlayoffs"],
+                    "standing": standing["standing"],
+                    "tags": sorted(set(tags)),
+                }
+            )
     return rows
 
 
 def _manager_index(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for manager in snapshot.managers.ordered_managers():
-        rows.append({
-            "kind": "manager",
-            "ownerId": manager.owner_id,
-            "displayName": manager.display_name,
-            "currentTeamName": manager.current_team_name,
-            "aliases": [a.team_name for a in manager.aliases],
-        })
+        rows.append(
+            {
+                "kind": "manager",
+                "ownerId": manager.owner_id,
+                "displayName": manager.display_name,
+                "currentTeamName": manager.current_team_name,
+                "aliases": [a.team_name for a in manager.aliases],
+            }
+        )
     return rows
 
 
@@ -254,9 +275,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     # display name make the cut so we don't ship IDs for stale/orphan
     # player records.
     players_archive = [
-        {"kind": "player", **p}
-        for p in list_players_with_activity(snapshot)
-        if p.get("playerName")
+        {"kind": "player", **p} for p in list_players_with_activity(snapshot) if p.get("playerName")
     ]
 
     return {

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -34,6 +34,7 @@ Award catalog:
     league_mvp / off_roy / def_roy — VORP player awards
     top_<pos>                — positional starter-points leaders
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -90,7 +91,7 @@ _PLAYER_AWARD_KEY_BY_POS = {
     "RB": "top_rb",
     "WR": "top_wr",
     "TE": "top_te",
-    "K":  "top_k",
+    "K": "top_k",
     "DL": "top_dl",
     "LB": "top_lb",
     "DB": "top_db",
@@ -100,7 +101,7 @@ _PLAYER_AWARD_LABEL_BY_POS = {
     "RB": "Top RB",
     "WR": "Top WR",
     "TE": "Top TE",
-    "K":  "Top Kicker",
+    "K": "Top Kicker",
     "DL": "Top DL",
     "LB": "Top LB",
     "DB": "Top DB",
@@ -278,7 +279,14 @@ def _season_has_player_scoring(season: SeasonSnapshot) -> bool:
 
 
 # ── per-season canonical awards (already in v1) ────────────────────────────
-def _canonical_award(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, rid: int | None, key: str, label: str, value: Any = None) -> dict[str, Any] | None:
+def _canonical_award(
+    snapshot: PublicLeagueSnapshot,
+    season: SeasonSnapshot,
+    rid: int | None,
+    key: str,
+    label: str,
+    value: Any = None,
+) -> dict[str, Any] | None:
     if rid is None:
         return None
     owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
@@ -295,7 +303,9 @@ def _canonical_award(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, rid
     }
 
 
-def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+def _season_canonical_awards(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
+) -> list[dict[str, Any]]:
     standings = metrics.season_standings(season, snapshot.managers)
     if not standings:
         return []
@@ -322,26 +332,37 @@ def _season_canonical_awards(snapshot: PublicLeagueSnapshot, season: SeasonSnaps
     awards = [
         _canonical_award(snapshot, season, champion_rid, "champion", "Champion"),
         _canonical_award(
-            snapshot, season, best_record_rid,
-            "regular_season_crown", "Regular-Season Crown",
-            value={"record": f'{standings[0]["wins"]}-{standings[0]["losses"]}'} if standings else None,
+            snapshot,
+            season,
+            best_record_rid,
+            "regular_season_crown",
+            "Regular-Season Crown",
+            value={"record": f'{standings[0]["wins"]}-{standings[0]["losses"]}'}
+            if standings
+            else None,
         ),
         _canonical_award(
-            snapshot, season,
+            snapshot,
+            season,
             pf_leader["rosterId"] if pf_leader else None,
-            "points_king", "Points King",
+            "points_king",
+            "Points King",
             value={"pointsFor": pf_leader["pointsFor"]} if pf_leader else None,
         ),
         _canonical_award(
-            snapshot, season,
+            snapshot,
+            season,
             high_week[1] if high_week else None,
-            "highest_single_week", "Highest Single-Week Score",
+            "highest_single_week",
+            "Highest Single-Week Score",
             value={"points": round(high_week[0], 2), "week": high_week[2]} if high_week else None,
         ),
         _canonical_award(
-            snapshot, season,
+            snapshot,
+            season,
             low_week[1] if low_week else None,
-            "lowest_single_week", "Lowest Single-Week Score",
+            "lowest_single_week",
+            "Lowest Single-Week Score",
             value={"points": round(low_week[0], 2), "week": low_week[2]} if low_week else None,
         ),
     ]
@@ -445,17 +466,22 @@ def _trader_of_the_year_scores(
                 rec["biggestTradeId"] = str(tx.get("transaction_id") or "")
 
             if best_trade is None or gain > best_trade[0]:
-                best_trade = (gain, owner_id, {
-                    "transactionId": str(tx.get("transaction_id") or ""),
-                    "season": season.season,
-                    "leagueId": season.league_id,
-                    "week": leg_int,
-                    "ownerId": owner_id,
-                    "pointsGained": round(gain, 2),
-                    "playoffPointsGained": round(playoff_gain, 2),
-                    "receivedPlayerIds": list(received),
-                    "sentPlayerIds": list(sent),
-                }, tx)
+                best_trade = (
+                    gain,
+                    owner_id,
+                    {
+                        "transactionId": str(tx.get("transaction_id") or ""),
+                        "season": season.season,
+                        "leagueId": season.league_id,
+                        "week": leg_int,
+                        "ownerId": owner_id,
+                        "pointsGained": round(gain, 2),
+                        "playoffPointsGained": round(playoff_gain, 2),
+                        "receivedPlayerIds": list(received),
+                        "sentPlayerIds": list(sent),
+                    },
+                    tx,
+                )
 
     rows = list(per_owner.values())
     for r in rows:
@@ -594,16 +620,18 @@ def _silent_assassin_scores(
             continue
         win_pct = rec["wins"] / games
         avg_margin = rec["marginSum"] / rec["wins"] if rec["wins"] else 0.0
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "closeGames": games,
-            "closeWins": rec["wins"],
-            "winPct": round(win_pct, 4),
-            "avgCloseMargin": round(avg_margin, 2),
-            "seasonWins": season_wins.get(owner_id, 0),
-            "eligible": games >= min_eligible,
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "closeGames": games,
+                "closeWins": rec["wins"],
+                "winPct": round(win_pct, 4),
+                "avgCloseMargin": round(avg_margin, 2),
+                "seasonWins": season_wins.get(owner_id, 0),
+                "eligible": games >= min_eligible,
+            }
+        )
     rows.sort(
         key=lambda r: (
             -r["winPct"] if r["eligible"] else 1,
@@ -614,7 +642,9 @@ def _silent_assassin_scores(
     return rows
 
 
-def _weekly_hammer_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+def _weekly_hammer_scores(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
+) -> list[dict[str, Any]]:
     per_owner: dict[str, dict[str, Any]] = {}
 
     def _ensure(owner_id: str) -> dict[str, Any]:
@@ -631,10 +661,7 @@ def _weekly_hammer_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
         if week >= season.playoff_week_start:
             continue
         entries = season.matchups_by_week[week]
-        scored = [
-            (metrics.roster_id_of(m), metrics.matchup_points(m))
-            for m in entries
-        ]
+        scored = [(metrics.roster_id_of(m), metrics.matchup_points(m)) for m in entries]
         scored = [s for s in scored if s[0] is not None and s[1] > 0]
         if not scored:
             continue
@@ -666,7 +693,9 @@ def _weekly_hammer_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
     return rows
 
 
-def _bad_beat_scores(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+def _bad_beat_scores(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
+) -> list[dict[str, Any]]:
     per_owner: dict[str, dict[str, Any]] = {}
 
     def _ensure(owner_id: str) -> dict[str, Any]:
@@ -722,12 +751,14 @@ def _pick_hoarder_scores(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]
     rows = []
     for owner_id, picks in ownership.items():
         weight = sum(pick_weight(p["round"]) for p in picks)
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "weightedScore": weight,
-            "totalPicks": len(picks),
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "weightedScore": weight,
+                "totalPicks": len(picks),
+            }
+        )
     rows.sort(key=lambda r: (-r["weightedScore"], -r["totalPicks"]))
     return rows
 
@@ -738,7 +769,10 @@ def _best_rebuild_scores(
     previous: SeasonSnapshot,
 ) -> list[dict[str, Any]]:
     """Historical only: YoY improvement across standings + stockpile."""
-    def _rank_lookup(season: SeasonSnapshot) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
+
+    def _rank_lookup(
+        season: SeasonSnapshot,
+    ) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
         standings = metrics.season_standings(season, snapshot.managers)
         by_points = sorted(standings, key=lambda r: -r["pointsFor"])
         record_rank = {r["ownerId"]: r["standing"] for r in standings}
@@ -767,8 +801,7 @@ def _best_rebuild_scores(
     prev_record, prev_points, prev_rookies = _rank_lookup(previous)
 
     current_weighted = {
-        row["ownerId"]: row["weightedScore"]
-        for row in _pick_hoarder_scores(snapshot)
+        row["ownerId"]: row["weightedScore"] for row in _pick_hoarder_scores(snapshot)
     }
 
     rows = []
@@ -786,15 +819,17 @@ def _best_rebuild_scores(
             + 0.20 * (stockpile / 4.0)
             + 0.10 * rookies_delta
         )
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "pointsRankDelta": points_delta,
-            "recordRankDelta": record_delta,
-            "stockpileScore": stockpile,
-            "rookiesDelta": rookies_delta,
-            "compositeScore": round(composite, 3),
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "pointsRankDelta": points_delta,
+                "recordRankDelta": record_delta,
+                "stockpileScore": stockpile,
+                "rookiesDelta": rookies_delta,
+                "compositeScore": round(composite, 3),
+            }
+        )
     rows.sort(key=lambda r: (-r["compositeScore"], -r["recordRankDelta"], -r["pointsRankDelta"]))
     return rows
 
@@ -872,11 +907,13 @@ def _top_offense_scores(
     units = _manager_unit_points(snapshot, season, regular_season_only=True)
     rows = []
     for owner_id, totals in units.items():
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "offensePoints": round(totals["offense"], 2),
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "offensePoints": round(totals["offense"], 2),
+            }
+        )
     rows.sort(key=lambda r: -r["offensePoints"])
     return rows
 
@@ -888,11 +925,13 @@ def _top_defense_scores(
     units = _manager_unit_points(snapshot, season, regular_season_only=True)
     rows = []
     for owner_id, totals in units.items():
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "defensePoints": round(totals["defense"], 2),
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "defensePoints": round(totals["defense"], 2),
+            }
+        )
     # Filter out leagues with no IDP scoring on file so we don't surface
     # an "everyone tied at 0.0" race.
     rows = [r for r in rows if r["defensePoints"] > 0]
@@ -915,11 +954,7 @@ def _top_nfl_team_scores(
         if not team:
             continue
         totals[team] += pts
-    rows = [
-        {"team": team, "points": round(pts, 2)}
-        for team, pts in totals.items()
-        if pts > 0
-    ]
+    rows = [{"team": team, "points": round(pts, 2)} for team, pts in totals.items() if pts > 0]
     rows.sort(key=lambda r: -r["points"])
     return rows
 
@@ -946,11 +981,7 @@ def _finish_rank_by_owner(
             continue
 
     playoff_owners = sorted(
-        (
-            (place, owner_by_rid[rid])
-            for rid, place in placement.items()
-            if rid in owner_by_rid
-        ),
+        ((place, owner_by_rid[rid]) for rid, place in placement.items() if rid in owner_by_rid),
         key=lambda t: t[0],
     )
     ordered: list[str] = [owner for _place, owner in playoff_owners]
@@ -998,10 +1029,7 @@ def _manager_of_the_year_scores(
     waiver_gain = {r["ownerId"]: float(r.get("pointsGained") or 0.0) for r in waiver_rows}
 
     # Raw inputs (higher = better) keyed by owner.
-    raw_finish = {
-        r["ownerId"]: float(n - finish_rank.get(r["ownerId"], n))
-        for r in standings
-    }
+    raw_finish = {r["ownerId"]: float(n - finish_rank.get(r["ownerId"], n)) for r in standings}
     raw_win = {r["ownerId"]: float(r["winPct"]) for r in standings}
     raw_pf = {r["ownerId"]: float(r["pointsFor"]) for r in standings}
     raw_trade = {r["ownerId"]: trade_gain.get(r["ownerId"], 0.0) for r in standings}
@@ -1023,19 +1051,21 @@ def _manager_of_the_year_scores(
             + 0.15 * n_trade.get(oid, 0.0)
             + 0.15 * n_waiver.get(oid, 0.0)
         )
-        rows.append({
-            "ownerId": oid,
-            "displayName": metrics.display_name_for(snapshot, oid),
-            "wins": r["wins"],
-            "losses": r["losses"],
-            "ties": r["ties"],
-            "winPct": round(r["winPct"], 4),
-            "pointsFor": r["pointsFor"],
-            "finishRank": finish_rank.get(oid, n),
-            "tradePointsGained": round(trade_gain.get(oid, 0.0), 2),
-            "waiverPointsGained": round(waiver_gain.get(oid, 0.0), 2),
-            "compositeScore": round(composite, 4),
-        })
+        rows.append(
+            {
+                "ownerId": oid,
+                "displayName": metrics.display_name_for(snapshot, oid),
+                "wins": r["wins"],
+                "losses": r["losses"],
+                "ties": r["ties"],
+                "winPct": round(r["winPct"], 4),
+                "pointsFor": r["pointsFor"],
+                "finishRank": finish_rank.get(oid, n),
+                "tradePointsGained": round(trade_gain.get(oid, 0.0), 2),
+                "waiverPointsGained": round(waiver_gain.get(oid, 0.0), 2),
+                "compositeScore": round(composite, 4),
+            }
+        )
     rows.sort(key=lambda r: (-r["compositeScore"], r["finishRank"], -r["pointsFor"]))
     return rows
 
@@ -1054,16 +1084,19 @@ def _player_starter_totals(
     for week, _rid, owner_id, pid, pos, pts, _is_p in _starter_scoring_walk(
         snapshot, season, regular_season_only=regular_season_only
     ):
-        rec = out.setdefault(pid, {
-            "playerId": pid,
-            "playerName": snapshot.player_display(pid),
-            "position": pos,
-            "starterPoints": 0.0,
-            "gamesStarted": 0,
-            "ownerIds": set(),
-            "lastOwnerId": "",
-            "lastWeek": 0,
-        })
+        rec = out.setdefault(
+            pid,
+            {
+                "playerId": pid,
+                "playerName": snapshot.player_display(pid),
+                "position": pos,
+                "starterPoints": 0.0,
+                "gamesStarted": 0,
+                "ownerIds": set(),
+                "lastOwnerId": "",
+                "lastWeek": 0,
+            },
+        )
         # Track the most-recent fantasy owner so we can attribute the
         # award to a manager card on the page (ownership can change
         # mid-season after a trade).
@@ -1100,25 +1133,25 @@ def _top_player_per_position_scores(
     Returns ``{pos: [row, row, row]}`` where rows are sorted descending
     by ``starterPoints``.  Up to top 3 per position.
     """
-    totals = _player_starter_totals(
-        snapshot, season, regular_season_only=regular_season_only
-    )
+    totals = _player_starter_totals(snapshot, season, regular_season_only=regular_season_only)
     grouped: dict[str, list[dict[str, Any]]] = {pos: [] for pos in _PLAYER_AWARD_POSITIONS}
     for pid, rec in totals.items():
         pos = rec["position"]
         if pos not in grouped:
             continue
         owner_id = rec["lastOwnerId"]
-        grouped[pos].append({
-            "playerId": pid,
-            "playerName": rec["playerName"],
-            "team": _nfl_team_for(snapshot, pid),
-            "position": pos,
-            "starterPoints": rec["starterPoints"],
-            "gamesStarted": rec["gamesStarted"],
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
-        })
+        grouped[pos].append(
+            {
+                "playerId": pid,
+                "playerName": rec["playerName"],
+                "team": _nfl_team_for(snapshot, pid),
+                "position": pos,
+                "starterPoints": rec["starterPoints"],
+                "gamesStarted": rec["gamesStarted"],
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+            }
+        )
     for pos in grouped:
         grouped[pos].sort(key=lambda r: -r["starterPoints"])
     return grouped
@@ -1136,6 +1169,7 @@ def _replacement_per_game_for_position(
     module for the algorithm.
     """
     from src.scoring.replacement_level import replacement_per_game
+
     return replacement_per_game(rows or [], starter_slots, band_size=5)
 
 
@@ -1183,9 +1217,7 @@ def _vorp_rows(
     starters who scored a lot per game still rate fairly against
     healthier-but-thinner peers.
     """
-    totals = _player_starter_totals(
-        snapshot, season, regular_season_only=regular_season_only
-    )
+    totals = _player_starter_totals(snapshot, season, regular_season_only=regular_season_only)
     if not totals:
         return []
 
@@ -1194,15 +1226,17 @@ def _vorp_rows(
         pos = rec["position"]
         if not pos:
             continue
-        grouped[pos].append({
-            "playerId": rec["playerId"],
-            "playerName": rec["playerName"],
-            "position": pos,
-            "starterPoints": rec["starterPoints"],
-            "gamesStarted": rec["gamesStarted"],
-            "ownerIds": rec["ownerIds"],
-            "lastOwnerId": rec["lastOwnerId"],
-        })
+        grouped[pos].append(
+            {
+                "playerId": rec["playerId"],
+                "playerName": rec["playerName"],
+                "position": pos,
+                "starterPoints": rec["starterPoints"],
+                "gamesStarted": rec["gamesStarted"],
+                "ownerIds": rec["ownerIds"],
+                "lastOwnerId": rec["lastOwnerId"],
+            }
+        )
 
     starter_slots = _vorp_starter_slots(grouped)
     out: list[dict[str, Any]] = []
@@ -1221,18 +1255,20 @@ def _vorp_rows(
             # floored at 0 rather than shown below value.
             vorp = max(0.0, r["starterPoints"] - replacement_total)
             owner_id = r["lastOwnerId"]
-            out.append({
-                "playerId": r["playerId"],
-                "playerName": r["playerName"],
-                "team": _nfl_team_for(snapshot, r["playerId"]),
-                "position": pos,
-                "starterPoints": r["starterPoints"],
-                "gamesStarted": r["gamesStarted"],
-                "vorp": round(vorp, 2),
-                "replacementPerGame": round(replacement_per_game, 2),
-                "ownerId": owner_id,
-                "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
-            })
+            out.append(
+                {
+                    "playerId": r["playerId"],
+                    "playerName": r["playerName"],
+                    "team": _nfl_team_for(snapshot, r["playerId"]),
+                    "position": pos,
+                    "starterPoints": r["starterPoints"],
+                    "gamesStarted": r["gamesStarted"],
+                    "vorp": round(vorp, 2),
+                    "replacementPerGame": round(replacement_per_game, 2),
+                    "ownerId": owner_id,
+                    "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+                }
+            )
     out.sort(key=lambda r: -r["vorp"])
     return out
 
@@ -1245,16 +1281,26 @@ def _league_mvp_rows(
     return _vorp_rows(snapshot, season, regular_season_only=True)
 
 
-def _offensive_mvp_rows(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+def _offensive_mvp_rows(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
+) -> list[dict[str, Any]]:
     """League MVP restricted to offensive skill positions (QB/RB/WR/TE)."""
-    return [r for r in _vorp_rows(snapshot, season, regular_season_only=True)
-            if r["position"] in _OFF_ROY_POSITIONS]
+    return [
+        r
+        for r in _vorp_rows(snapshot, season, regular_season_only=True)
+        if r["position"] in _OFF_ROY_POSITIONS
+    ]
 
 
-def _defensive_mvp_rows(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> list[dict[str, Any]]:
+def _defensive_mvp_rows(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
+) -> list[dict[str, Any]]:
     """League MVP restricted to defensive positions (DL/LB/DB)."""
-    return [r for r in _vorp_rows(snapshot, season, regular_season_only=True)
-            if r["position"] in _DEF_ROY_POSITIONS]
+    return [
+        r
+        for r in _vorp_rows(snapshot, season, regular_season_only=True)
+        if r["position"] in _DEF_ROY_POSITIONS
+    ]
 
 
 def _rookie_of_year_rows(
@@ -1268,8 +1314,7 @@ def _rookie_of_year_rows(
     return [
         r
         for r in _vorp_rows(snapshot, season, regular_season_only=True)
-        if r["position"] in positions
-        and _is_rookie_in_season(snapshot, r["playerId"], season)
+        if r["position"] in positions and _is_rookie_in_season(snapshot, r["playerId"], season)
     ]
 
 
@@ -1315,17 +1360,19 @@ def _mr_consistent_scores(
         if mean <= 0:
             continue
         var = sum((x - mean) ** 2 for x in scores) / len(scores)
-        cv = (var ** 0.5) / mean
+        cv = (var**0.5) / mean
         owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
         if not owner_id:
             continue
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "cv": round(cv, 4),
-            "meanScore": round(mean, 2),
-            "weeks": len(scores),
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "cv": round(cv, 4),
+                "meanScore": round(mean, 2),
+                "weeks": len(scores),
+            }
+        )
     rows.sort(key=lambda r: (r["cv"], -r["meanScore"]))
     return rows
 
@@ -1343,9 +1390,7 @@ def _playoff_mvp_player_rows(
     champion_rid = metrics.season_champion(season)
     if champion_rid is None:
         return []
-    totals = _player_starter_totals(
-        snapshot, season, regular_season_only=False
-    )
+    totals = _player_starter_totals(snapshot, season, regular_season_only=False)
     if not totals:
         return []
     # Strip regular-season data: we want playoff-only, and only the
@@ -1358,15 +1403,18 @@ def _playoff_mvp_player_rows(
             continue
         if rid != champion_rid:
             continue
-        rec = playoff_totals.setdefault(pid, {
-            "playerId": pid,
-            "playerName": snapshot.player_display(pid),
-            "position": pos,
-            "starterPoints": 0.0,
-            "gamesStarted": 0,
-            "lastOwnerId": "",
-            "lastWeek": 0,
-        })
+        rec = playoff_totals.setdefault(
+            pid,
+            {
+                "playerId": pid,
+                "playerName": snapshot.player_display(pid),
+                "position": pos,
+                "starterPoints": 0.0,
+                "gamesStarted": 0,
+                "lastOwnerId": "",
+                "lastWeek": 0,
+            },
+        )
         rec["starterPoints"] += pts
         rec["gamesStarted"] += 1
         if week >= rec["lastWeek"]:
@@ -1395,22 +1443,26 @@ def _playoff_mvp_player_rows(
             games = r["gamesStarted"] or 1
             vorp = max(0.0, r["starterPoints"] - replacement_per_game * games)
             owner_id = r["lastOwnerId"]
-            out.append({
-                "playerId": r["playerId"],
-                "playerName": r["playerName"],
-                "team": _nfl_team_for(snapshot, r["playerId"]),
-                "position": pos,
-                "starterPoints": round(r["starterPoints"], 2),
-                "gamesStarted": r["gamesStarted"],
-                "vorp": round(vorp, 2),
-                "ownerId": owner_id,
-                "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
-            })
+            out.append(
+                {
+                    "playerId": r["playerId"],
+                    "playerName": r["playerName"],
+                    "team": _nfl_team_for(snapshot, r["playerId"]),
+                    "position": pos,
+                    "starterPoints": round(r["starterPoints"], 2),
+                    "gamesStarted": r["gamesStarted"],
+                    "vorp": round(vorp, 2),
+                    "ownerId": owner_id,
+                    "displayName": metrics.display_name_for(snapshot, owner_id) if owner_id else "",
+                }
+            )
     out.sort(key=lambda r: -r["vorp"])
     return out
 
 
-def _rivalry_of_the_year(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> dict[str, Any] | None:
+def _rivalry_of_the_year(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot
+) -> dict[str, Any] | None:
     """Season-scoped rivalry of the year."""
     pair_scores: dict[tuple[str, str], dict[str, Any]] = {}
 
@@ -1516,9 +1568,7 @@ def _award_from_row(
         "description": AWARD_DESCRIPTIONS.get(key, ""),
         "ownerId": owner_id,
         "displayName": winner.get("displayName") or metrics.display_name_for(snapshot, owner_id),
-        "teamName": (
-            metrics.team_name(snapshot, season.league_id, rid) if rid is not None else ""
-        ),
+        "teamName": (metrics.team_name(snapshot, season.league_id, rid) if rid is not None else ""),
         "value": value_builder(winner),
     }
 
@@ -1551,123 +1601,185 @@ def _activity_awards_for_season(
         if award:
             awards.append(award)
 
-    _add(_award_from_row(
-        snapshot, season, trader_rows, "trader_of_the_year", "Trader of the Year",
-        lambda r: {"pointsGained": r["pointsGained"], "trades": r["tradeCount"]},
-    ))
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            trader_rows,
+            "trader_of_the_year",
+            "Trader of the Year",
+            lambda r: {"pointsGained": r["pointsGained"], "trades": r["tradeCount"]},
+        )
+    )
     if best_trade is not None:
         gain, owner_id, payload, best_tx = best_trade
         rid = _roster_id_for_owner(season, owner_id)
         # Reuse the activity-section trade normalizer so the public
         # payload carries the full sides/assets the UI already renders.
         from .activity import _normalize_trade
+
         normalized_trade = _normalize_trade(snapshot, season, best_tx)
-        _add({
-            "key": "best_trade_of_the_year",
-            "label": "Best Trade of the Year",
-            "description": AWARD_DESCRIPTIONS["best_trade_of_the_year"],
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
-            "value": {
-                "pointsGained": payload["pointsGained"],
-                "week": payload["week"],
-                "transactionId": payload["transactionId"],
-                "trade": normalized_trade,
+        _add(
+            {
+                "key": "best_trade_of_the_year",
+                "label": "Best Trade of the Year",
+                "description": AWARD_DESCRIPTIONS["best_trade_of_the_year"],
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "teamName": metrics.team_name(snapshot, season.league_id, rid)
+                if rid is not None
+                else "",
+                "value": {
+                    "pointsGained": payload["pointsGained"],
+                    "week": payload["week"],
+                    "transactionId": payload["transactionId"],
+                    "trade": normalized_trade,
+                },
+            }
+        )
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            waiver_rows,
+            "waiver_king",
+            "Waiver King",
+            lambda r: {
+                "pointsGained": r["pointsGained"],
+                "adds": r.get("usefulAdds", 0),
             },
-        })
-    _add(_award_from_row(
-        snapshot, season, waiver_rows, "waiver_king", "Waiver King",
-        lambda r: {
-            "pointsGained": r["pointsGained"],
-            "adds": r.get("usefulAdds", 0),
-        },
-    ))
-    _add(_award_from_row(
-        snapshot, season, silent_rows, "silent_assassin", "Silent Assassin",
-        lambda r: {"winPct": r["winPct"], "closeGames": r["closeGames"], "closeWins": r["closeWins"]},
-        eligible_only=True,
-    ))
-    _add(_award_from_row(
-        snapshot, season, hammer_rows, "weekly_hammer", "Weekly Hammer",
-        lambda r: {"highScoreFinishes": r["highScoreFinishes"], "highestWeek": r["highestWeekPoints"]},
-    ))
+        )
+    )
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            silent_rows,
+            "silent_assassin",
+            "Silent Assassin",
+            lambda r: {
+                "winPct": r["winPct"],
+                "closeGames": r["closeGames"],
+                "closeWins": r["closeWins"],
+            },
+            eligible_only=True,
+        )
+    )
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            hammer_rows,
+            "weekly_hammer",
+            "Weekly Hammer",
+            lambda r: {
+                "highScoreFinishes": r["highScoreFinishes"],
+                "highestWeek": r["highestWeekPoints"],
+            },
+        )
+    )
     # Playoff MVP — VORP-based player award (replaces the prior team-points version).
     playoff_mvp_rows = _playoff_mvp_player_rows(snapshot, season)
     if playoff_mvp_rows:
         winner = playoff_mvp_rows[0]
         rid = _roster_id_for_owner(season, winner["ownerId"])
-        awards.append({
-            "key": "playoff_mvp",
-            "label": "Playoff MVP",
-            "description": AWARD_DESCRIPTIONS["playoff_mvp"],
-            "ownerId": winner["ownerId"],
-            "displayName": winner["displayName"],
-            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
-            "value": {
-                "playerId": winner["playerId"],
-                "playerName": winner["playerName"],
-                "team": winner.get("team", ""),
-                "position": winner["position"],
-                "vorp": winner["vorp"],
-                "starterPoints": winner["starterPoints"],
-                "gamesStarted": winner["gamesStarted"],
+        awards.append(
+            {
+                "key": "playoff_mvp",
+                "label": "Playoff MVP",
+                "description": AWARD_DESCRIPTIONS["playoff_mvp"],
+                "ownerId": winner["ownerId"],
+                "displayName": winner["displayName"],
+                "teamName": metrics.team_name(snapshot, season.league_id, rid)
+                if rid is not None
+                else "",
+                "value": {
+                    "playerId": winner["playerId"],
+                    "playerName": winner["playerName"],
+                    "team": winner.get("team", ""),
+                    "position": winner["position"],
+                    "vorp": winner["vorp"],
+                    "starterPoints": winner["starterPoints"],
+                    "gamesStarted": winner["gamesStarted"],
+                },
+            }
+        )
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            bad_beat_rows,
+            "bad_beat",
+            "Bad Beat",
+            lambda r: {
+                "points": r["biggestLoss"],
+                "week": r["biggestLossWeek"],
+                "opponentPoints": r["biggestLossOpponentPoints"],
             },
-        })
-    _add(_award_from_row(
-        snapshot, season, bad_beat_rows, "bad_beat", "Bad Beat",
-        lambda r: {
-            "points": r["biggestLoss"],
-            "week": r["biggestLossWeek"],
-            "opponentPoints": r["biggestLossOpponentPoints"],
-        },
-    ))
+        )
+    )
 
     # ── Manager awards ─────────────────────────────────────────────
     offense_rows = _top_offense_scores(snapshot, season)
-    _add(_award_from_row(
-        snapshot, season, offense_rows, "top_offense", "Top Offense",
-        lambda r: {"offensePoints": r["offensePoints"]},
-    ))
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            offense_rows,
+            "top_offense",
+            "Top Offense",
+            lambda r: {"offensePoints": r["offensePoints"]},
+        )
+    )
     defense_rows = _top_defense_scores(snapshot, season)
     if defense_rows:
-        _add(_award_from_row(
-            snapshot, season, defense_rows, "top_defense", "Top Defense",
-            lambda r: {"defensePoints": r["defensePoints"]},
-        ))
+        _add(
+            _award_from_row(
+                snapshot,
+                season,
+                defense_rows,
+                "top_defense",
+                "Top Defense",
+                lambda r: {"defensePoints": r["defensePoints"]},
+            )
+        )
     nfl_team_rows = _top_nfl_team_scores(snapshot, season)
     if nfl_team_rows:
         top_team = nfl_team_rows[0]
-        awards.append({
-            "key": "top_nfl_team",
-            "label": "Top Fantasy NFL Team",
-            "description": AWARD_DESCRIPTIONS["top_nfl_team"],
-            "ownerId": "",
-            "displayName": top_team["team"],
-            "teamName": "",
-            "value": {"team": top_team["team"], "points": top_team["points"]},
-        })
-    moty_rows = _manager_of_the_year_scores(
-        snapshot, season, trader_rows, waiver_rows
+        awards.append(
+            {
+                "key": "top_nfl_team",
+                "label": "Top Fantasy NFL Team",
+                "description": AWARD_DESCRIPTIONS["top_nfl_team"],
+                "ownerId": "",
+                "displayName": top_team["team"],
+                "teamName": "",
+                "value": {"team": top_team["team"], "points": top_team["points"]},
+            }
+        )
+    moty_rows = _manager_of_the_year_scores(snapshot, season, trader_rows, waiver_rows)
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            moty_rows,
+            "manager_of_the_year",
+            "Manager of the Year",
+            lambda r: {
+                "compositeScore": r["compositeScore"],
+                "wins": r["wins"],
+                "losses": r["losses"],
+                "winPct": r["winPct"],
+                "pointsFor": r["pointsFor"],
+                "finishRank": r["finishRank"],
+                "tradePointsGained": r["tradePointsGained"],
+                "waiverPointsGained": r["waiverPointsGained"],
+            },
+        )
     )
-    _add(_award_from_row(
-        snapshot, season, moty_rows, "manager_of_the_year", "Manager of the Year",
-        lambda r: {
-            "compositeScore": r["compositeScore"],
-            "wins": r["wins"],
-            "losses": r["losses"],
-            "winPct": r["winPct"],
-            "pointsFor": r["pointsFor"],
-            "finishRank": r["finishRank"],
-            "tradePointsGained": r["tradePointsGained"],
-            "waiverPointsGained": r["waiverPointsGained"],
-        },
-    ))
 
     # ── Player awards (top scorer per position, regular-season starter-only) ──
-    player_rows_by_pos = _top_player_per_position_scores(
-        snapshot, season, regular_season_only=True
-    )
+    player_rows_by_pos = _top_player_per_position_scores(snapshot, season, regular_season_only=True)
     for pos in _PLAYER_AWARD_POSITIONS:
         rows = player_rows_by_pos.get(pos) or []
         if not rows:
@@ -1676,45 +1788,53 @@ def _activity_awards_for_season(
         if winner["starterPoints"] <= 0:
             continue
         rid = _roster_id_for_owner(season, winner["ownerId"]) if winner["ownerId"] else None
-        awards.append({
-            "key": _PLAYER_AWARD_KEY_BY_POS[pos],
-            "label": _PLAYER_AWARD_LABEL_BY_POS[pos],
-            "description": AWARD_DESCRIPTIONS[_PLAYER_AWARD_KEY_BY_POS[pos]],
-            "ownerId": winner["ownerId"],
-            "displayName": winner["displayName"],
-            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
-            "value": {
-                "playerId": winner["playerId"],
-                "playerName": winner["playerName"],
-                "team": winner.get("team", ""),
-                "position": winner["position"],
-                "starterPoints": winner["starterPoints"],
-                "gamesStarted": winner["gamesStarted"],
-            },
-        })
+        awards.append(
+            {
+                "key": _PLAYER_AWARD_KEY_BY_POS[pos],
+                "label": _PLAYER_AWARD_LABEL_BY_POS[pos],
+                "description": AWARD_DESCRIPTIONS[_PLAYER_AWARD_KEY_BY_POS[pos]],
+                "ownerId": winner["ownerId"],
+                "displayName": winner["displayName"],
+                "teamName": metrics.team_name(snapshot, season.league_id, rid)
+                if rid is not None
+                else "",
+                "value": {
+                    "playerId": winner["playerId"],
+                    "playerName": winner["playerName"],
+                    "team": winner.get("team", ""),
+                    "position": winner["position"],
+                    "starterPoints": winner["starterPoints"],
+                    "gamesStarted": winner["gamesStarted"],
+                },
+            }
+        )
 
     # ── League MVP (regular-season VORP) ───────────────────────────
     mvp_rows = _league_mvp_rows(snapshot, season)
     if mvp_rows:
         winner = mvp_rows[0]
         rid = _roster_id_for_owner(season, winner["ownerId"]) if winner["ownerId"] else None
-        awards.append({
-            "key": "league_mvp",
-            "label": "League MVP",
-            "description": AWARD_DESCRIPTIONS["league_mvp"],
-            "ownerId": winner["ownerId"],
-            "displayName": winner["displayName"],
-            "teamName": metrics.team_name(snapshot, season.league_id, rid) if rid is not None else "",
-            "value": {
-                "playerId": winner["playerId"],
-                "playerName": winner["playerName"],
-                "team": winner.get("team", ""),
-                "position": winner["position"],
-                "vorp": winner["vorp"],
-                "starterPoints": winner["starterPoints"],
-                "gamesStarted": winner["gamesStarted"],
-            },
-        })
+        awards.append(
+            {
+                "key": "league_mvp",
+                "label": "League MVP",
+                "description": AWARD_DESCRIPTIONS["league_mvp"],
+                "ownerId": winner["ownerId"],
+                "displayName": winner["displayName"],
+                "teamName": metrics.team_name(snapshot, season.league_id, rid)
+                if rid is not None
+                else "",
+                "value": {
+                    "playerId": winner["playerId"],
+                    "playerName": winner["playerName"],
+                    "team": winner.get("team", ""),
+                    "position": winner["position"],
+                    "vorp": winner["vorp"],
+                    "starterPoints": winner["starterPoints"],
+                    "gamesStarted": winner["gamesStarted"],
+                },
+            }
+        )
 
     # ── Rookie of the Year (offense / defense, regular-season VORP) ──
     def _vorp_player_award(rows, key, label):
@@ -1726,75 +1846,98 @@ def _activity_awards_for_season(
         if (w.get("starterPoints") or 0) <= 0:
             return
         r_id = _roster_id_for_owner(season, w["ownerId"]) if w["ownerId"] else None
-        awards.append({
-            "key": key,
-            "label": label,
-            "description": AWARD_DESCRIPTIONS[key],
-            "ownerId": w["ownerId"],
-            "displayName": w["displayName"],
-            "teamName": metrics.team_name(snapshot, season.league_id, r_id) if r_id is not None else "",
-            "value": {
-                "playerId": w["playerId"],
-                "playerName": w["playerName"],
-                "team": w.get("team", ""),
-                "position": w["position"],
-                "vorp": w["vorp"],
-                "starterPoints": w["starterPoints"],
-                "gamesStarted": w["gamesStarted"],
-            },
-        })
+        awards.append(
+            {
+                "key": key,
+                "label": label,
+                "description": AWARD_DESCRIPTIONS[key],
+                "ownerId": w["ownerId"],
+                "displayName": w["displayName"],
+                "teamName": metrics.team_name(snapshot, season.league_id, r_id)
+                if r_id is not None
+                else "",
+                "value": {
+                    "playerId": w["playerId"],
+                    "playerName": w["playerName"],
+                    "team": w.get("team", ""),
+                    "position": w["position"],
+                    "vorp": w["vorp"],
+                    "starterPoints": w["starterPoints"],
+                    "gamesStarted": w["gamesStarted"],
+                },
+            }
+        )
 
     _vorp_player_award(
         _rookie_of_year_rows(snapshot, season, _OFF_ROY_POSITIONS),
-        "off_roy", "Offensive Rookie of the Year",
+        "off_roy",
+        "Offensive Rookie of the Year",
     )
     _vorp_player_award(
         _rookie_of_year_rows(snapshot, season, _DEF_ROY_POSITIONS),
-        "def_roy", "Defensive Rookie of the Year",
+        "def_roy",
+        "Defensive Rookie of the Year",
     )
     _vorp_player_award(
-        _offensive_mvp_rows(snapshot, season), "off_mvp", "Offensive MVP",
+        _offensive_mvp_rows(snapshot, season),
+        "off_mvp",
+        "Offensive MVP",
     )
     _vorp_player_award(
-        _defensive_mvp_rows(snapshot, season), "def_mvp", "Defensive MVP",
+        _defensive_mvp_rows(snapshot, season),
+        "def_mvp",
+        "Defensive MVP",
     )
 
     # ── Mr. Consistent ─────────────────────────────────────────────
-    _add(_award_from_row(
-        snapshot, season, _mr_consistent_scores(snapshot, season),
-        "mr_consistent", "Mr. Consistent",
-        lambda r: {"cv": r["cv"], "meanScore": r["meanScore"], "weeks": r["weeks"]},
-    ))
+    _add(
+        _award_from_row(
+            snapshot,
+            season,
+            _mr_consistent_scores(snapshot, season),
+            "mr_consistent",
+            "Mr. Consistent",
+            lambda r: {"cv": r["cv"], "meanScore": r["meanScore"], "weeks": r["weeks"]},
+        )
+    )
 
     if previous_season is not None and season.is_complete and previous_season.is_complete:
         rebuild_rows = _best_rebuild_scores(snapshot, season, previous_season)
         if rebuild_rows and rebuild_rows[0]["compositeScore"] > 0:
-            _add(_award_from_row(
-                snapshot, season, rebuild_rows, "best_rebuild", "Best Rebuild",
-                lambda r: {
-                    "compositeScore": r["compositeScore"],
-                    "recordRankDelta": r["recordRankDelta"],
-                    "pointsRankDelta": r["pointsRankDelta"],
-                },
-            ))
+            _add(
+                _award_from_row(
+                    snapshot,
+                    season,
+                    rebuild_rows,
+                    "best_rebuild",
+                    "Best Rebuild",
+                    lambda r: {
+                        "compositeScore": r["compositeScore"],
+                        "recordRankDelta": r["recordRankDelta"],
+                        "pointsRankDelta": r["pointsRankDelta"],
+                    },
+                )
+            )
 
     rivalry = _rivalry_of_the_year(snapshot, season)
     if rivalry is not None and rivalry["rivalryIndex"] > 0:
-        awards.append({
-            "key": "rivalry_of_the_year",
-            "label": "Rivalry of the Year",
-            "description": AWARD_DESCRIPTIONS["rivalry_of_the_year"],
-            "ownerId": "",
-            "displayName": f"{rivalry['displayNames'][0]} vs {rivalry['displayNames'][1]}",
-            "teamName": "",
-            "value": {
-                "ownerIds": rivalry["ownerIds"],
-                "displayNames": rivalry["displayNames"],
-                "rivalryIndex": rivalry["rivalryIndex"],
-                "totalMeetings": rivalry["totalMeetings"],
-                "playoffMeetings": rivalry["playoffMeetings"],
-            },
-        })
+        awards.append(
+            {
+                "key": "rivalry_of_the_year",
+                "label": "Rivalry of the Year",
+                "description": AWARD_DESCRIPTIONS["rivalry_of_the_year"],
+                "ownerId": "",
+                "displayName": f"{rivalry['displayNames'][0]} vs {rivalry['displayNames'][1]}",
+                "teamName": "",
+                "value": {
+                    "ownerIds": rivalry["ownerIds"],
+                    "displayNames": rivalry["displayNames"],
+                    "rivalryIndex": rivalry["rivalryIndex"],
+                    "totalMeetings": rivalry["totalMeetings"],
+                    "playoffMeetings": rivalry["playoffMeetings"],
+                },
+            }
+        )
 
     return _order_awards(awards)
 
@@ -1816,12 +1959,15 @@ def _build_race(
         return None
     leaders = []
     for i, row in enumerate(pool[:top_n]):
-        leaders.append({
-            "rank": i + 1,
-            "ownerId": row["ownerId"],
-            "displayName": row.get("displayName") or metrics.display_name_for(snapshot, row["ownerId"]),
-            "value": value_builder(row),
-        })
+        leaders.append(
+            {
+                "rank": i + 1,
+                "ownerId": row["ownerId"],
+                "displayName": row.get("displayName")
+                or metrics.display_name_for(snapshot, row["ownerId"]),
+                "value": value_builder(row),
+            }
+        )
     return {
         "key": key,
         "label": label,
@@ -1846,26 +1992,53 @@ def _current_season_races(
         if race:
             races.append(race)
 
-    _add(_build_race(
-        snapshot, "trader_of_the_year", "Trader of the Year", trader_rows,
-        lambda r: {"pointsGained": r["pointsGained"], "trades": r["tradeCount"]},
-    ))
-    _add(_build_race(
-        snapshot, "waiver_king", "Waiver King", waiver_rows,
-        lambda r: {
-            "pointsGained": r["pointsGained"],
-            "adds": r.get("usefulAdds", 0),
-        },
-    ))
-    _add(_build_race(
-        snapshot, "silent_assassin", "Silent Assassin", silent_rows,
-        lambda r: {"winPct": r["winPct"], "closeGames": r["closeGames"], "closeWins": r["closeWins"]},
-        eligible_only=True,
-    ))
-    _add(_build_race(
-        snapshot, "weekly_hammer", "Weekly Hammer", hammer_rows,
-        lambda r: {"highScoreFinishes": r["highScoreFinishes"], "highestWeek": r["highestWeekPoints"]},
-    ))
+    _add(
+        _build_race(
+            snapshot,
+            "trader_of_the_year",
+            "Trader of the Year",
+            trader_rows,
+            lambda r: {"pointsGained": r["pointsGained"], "trades": r["tradeCount"]},
+        )
+    )
+    _add(
+        _build_race(
+            snapshot,
+            "waiver_king",
+            "Waiver King",
+            waiver_rows,
+            lambda r: {
+                "pointsGained": r["pointsGained"],
+                "adds": r.get("usefulAdds", 0),
+            },
+        )
+    )
+    _add(
+        _build_race(
+            snapshot,
+            "silent_assassin",
+            "Silent Assassin",
+            silent_rows,
+            lambda r: {
+                "winPct": r["winPct"],
+                "closeGames": r["closeGames"],
+                "closeWins": r["closeWins"],
+            },
+            eligible_only=True,
+        )
+    )
+    _add(
+        _build_race(
+            snapshot,
+            "weekly_hammer",
+            "Weekly Hammer",
+            hammer_rows,
+            lambda r: {
+                "highScoreFinishes": r["highScoreFinishes"],
+                "highestWeek": r["highestWeekPoints"],
+            },
+        )
+    )
     playoff_mvp_rows = _playoff_mvp_player_rows(snapshot, season)
     if playoff_mvp_rows:
         race = {
@@ -1890,68 +2063,90 @@ def _current_season_races(
             ],
         }
         _add(race)
-    _add(_build_race(
-        snapshot, "bad_beat", "Bad Beat", bad_beat_rows,
-        lambda r: {
-            "points": r["biggestLoss"],
-            "week": r["biggestLossWeek"],
-        },
-    ))
-    _add(_build_race(
-        snapshot, "mr_consistent", "Mr. Consistent",
-        _mr_consistent_scores(snapshot, season),
-        lambda r: {"cv": r["cv"], "meanScore": r["meanScore"], "weeks": r["weeks"]},
-    ))
+    _add(
+        _build_race(
+            snapshot,
+            "bad_beat",
+            "Bad Beat",
+            bad_beat_rows,
+            lambda r: {
+                "points": r["biggestLoss"],
+                "week": r["biggestLossWeek"],
+            },
+        )
+    )
+    _add(
+        _build_race(
+            snapshot,
+            "mr_consistent",
+            "Mr. Consistent",
+            _mr_consistent_scores(snapshot, season),
+            lambda r: {"cv": r["cv"], "meanScore": r["meanScore"], "weeks": r["weeks"]},
+        )
+    )
 
     # ── Manager-award races ──
     offense_rows = _top_offense_scores(snapshot, season)
-    _add(_build_race(
-        snapshot, "top_offense", "Top Offense Race", offense_rows,
-        lambda r: {"offensePoints": r["offensePoints"]},
-    ))
+    _add(
+        _build_race(
+            snapshot,
+            "top_offense",
+            "Top Offense Race",
+            offense_rows,
+            lambda r: {"offensePoints": r["offensePoints"]},
+        )
+    )
     defense_rows = _top_defense_scores(snapshot, season)
     if defense_rows:
-        _add(_build_race(
-            snapshot, "top_defense", "Top Defense Race", defense_rows,
-            lambda r: {"defensePoints": r["defensePoints"]},
-        ))
+        _add(
+            _build_race(
+                snapshot,
+                "top_defense",
+                "Top Defense Race",
+                defense_rows,
+                lambda r: {"defensePoints": r["defensePoints"]},
+            )
+        )
     nfl_team_rows = _top_nfl_team_scores(snapshot, season)
     if nfl_team_rows:
-        _add({
-            "key": "top_nfl_team",
-            "label": "Top Fantasy NFL Team Race",
-            "description": AWARD_DESCRIPTIONS["top_nfl_team"],
-            "leaders": [
-                {
-                    "rank": i + 1,
-                    "ownerId": "",
-                    "displayName": r["team"],
-                    "value": {"team": r["team"], "points": r["points"]},
-                }
-                for i, r in enumerate(nfl_team_rows[:3])
-            ],
-        })
-    moty_rows = _manager_of_the_year_scores(
-        snapshot, season, trader_rows, waiver_rows
+        _add(
+            {
+                "key": "top_nfl_team",
+                "label": "Top Fantasy NFL Team Race",
+                "description": AWARD_DESCRIPTIONS["top_nfl_team"],
+                "leaders": [
+                    {
+                        "rank": i + 1,
+                        "ownerId": "",
+                        "displayName": r["team"],
+                        "value": {"team": r["team"], "points": r["points"]},
+                    }
+                    for i, r in enumerate(nfl_team_rows[:3])
+                ],
+            }
+        )
+    moty_rows = _manager_of_the_year_scores(snapshot, season, trader_rows, waiver_rows)
+    _add(
+        _build_race(
+            snapshot,
+            "manager_of_the_year",
+            "Manager of the Year Race",
+            moty_rows,
+            lambda r: {
+                "compositeScore": r["compositeScore"],
+                "wins": r["wins"],
+                "losses": r["losses"],
+                "winPct": r["winPct"],
+                "pointsFor": r["pointsFor"],
+                "finishRank": r["finishRank"],
+                "tradePointsGained": r["tradePointsGained"],
+                "waiverPointsGained": r["waiverPointsGained"],
+            },
+        )
     )
-    _add(_build_race(
-        snapshot, "manager_of_the_year", "Manager of the Year Race", moty_rows,
-        lambda r: {
-            "compositeScore": r["compositeScore"],
-            "wins": r["wins"],
-            "losses": r["losses"],
-            "winPct": r["winPct"],
-            "pointsFor": r["pointsFor"],
-            "finishRank": r["finishRank"],
-            "tradePointsGained": r["tradePointsGained"],
-            "waiverPointsGained": r["waiverPointsGained"],
-        },
-    ))
 
     # ── Player-award races (top 5 per position) ──
-    player_rows_by_pos = _top_player_per_position_scores(
-        snapshot, season, regular_season_only=True
-    )
+    player_rows_by_pos = _top_player_per_position_scores(snapshot, season, regular_season_only=True)
     for pos in _PLAYER_AWARD_POSITIONS:
         rows = player_rows_by_pos.get(pos) or []
         rows = [r for r in rows if r["starterPoints"] > 0]
@@ -2035,20 +2230,34 @@ def _current_season_races(
             ],
         }
 
-    _add(_vorp_player_race(
-        _rookie_of_year_rows(snapshot, season, _OFF_ROY_POSITIONS),
-        "off_roy", "Offensive Rookie of the Year Race",
-    ))
-    _add(_vorp_player_race(
-        _rookie_of_year_rows(snapshot, season, _DEF_ROY_POSITIONS),
-        "def_roy", "Defensive Rookie of the Year Race",
-    ))
-    _add(_vorp_player_race(
-        _offensive_mvp_rows(snapshot, season), "off_mvp", "Offensive MVP Race",
-    ))
-    _add(_vorp_player_race(
-        _defensive_mvp_rows(snapshot, season), "def_mvp", "Defensive MVP Race",
-    ))
+    _add(
+        _vorp_player_race(
+            _rookie_of_year_rows(snapshot, season, _OFF_ROY_POSITIONS),
+            "off_roy",
+            "Offensive Rookie of the Year Race",
+        )
+    )
+    _add(
+        _vorp_player_race(
+            _rookie_of_year_rows(snapshot, season, _DEF_ROY_POSITIONS),
+            "def_roy",
+            "Defensive Rookie of the Year Race",
+        )
+    )
+    _add(
+        _vorp_player_race(
+            _offensive_mvp_rows(snapshot, season),
+            "off_mvp",
+            "Offensive MVP Race",
+        )
+    )
+    _add(
+        _vorp_player_race(
+            _defensive_mvp_rows(snapshot, season),
+            "def_mvp",
+            "Defensive MVP Race",
+        )
+    )
 
     return races
 
@@ -2065,15 +2274,17 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         # winner.  Reused below for the featured season's live awardRaces.
         season_races = _current_season_races(snapshot, season)
         races_by_season[season.season] = season_races
-        by_season.append({
-            "season": season.season,
-            "leagueId": season.league_id,
-            "seasonStatus": str(season.league.get("status") or ""),
-            "isComplete": season.is_complete,
-            "hasPlayerScoring": _season_has_player_scoring(season),
-            "awards": _order_awards(canonical + activity_based),
-            "finalists": {r["key"]: r["leaders"] for r in season_races},
-        })
+        by_season.append(
+            {
+                "season": season.season,
+                "leagueId": season.league_id,
+                "seasonStatus": str(season.league.get("status") or ""),
+                "isComplete": season.is_complete,
+                "hasPlayerScoring": _season_has_player_scoring(season),
+                "awards": _order_awards(canonical + activity_based),
+                "finalists": {r["key"]: r["leaders"] for r in season_races},
+            }
+        )
 
     # Featured season = the newest season that has actually *begun*.
     # "Begun" means real games have been played (some matchup scored
@@ -2124,7 +2335,9 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         "bySeason": by_season,
         "awardRaces": races,
         "currentSeason": current.season if current else None,
-        "currentSeasonStatus": "in_progress" if (current and not current.is_complete) else "complete",
+        "currentSeasonStatus": "in_progress"
+        if (current and not current.is_complete)
+        else "complete",
         "featuredSeason": current.season if current else None,
         "upcomingSeason": upcoming,
         "hottestRace": hottest,

--- a/src/public_league/csv_export.py
+++ b/src/public_league/csv_export.py
@@ -14,6 +14,7 @@ attachment header.
 This module is NOT allowed to import from any private pipeline module.
 It composes over the already-safety-checked public section payloads.
 """
+
 from __future__ import annotations
 
 import csv
@@ -58,25 +59,37 @@ def export_history(data: dict[str, Any]) -> tuple[str, str]:
     for season_block in data.get("seasons", []):
         season = season_block["season"]
         for standing in season_block.get("standings", []):
-            rows.append({
-                "season": season,
-                "leagueId": season_block["leagueId"],
-                "standing": standing["standing"],
-                "finalPlace": standing.get("finalPlace"),
-                "madePlayoffs": standing.get("madePlayoffs"),
-                "ownerId": standing["ownerId"],
-                "teamName": standing["teamName"],
-                "wins": standing["wins"],
-                "losses": standing["losses"],
-                "ties": standing["ties"],
-                "pointsFor": standing["pointsFor"],
-                "pointsAgainst": standing["pointsAgainst"],
-                "winPct": standing["winPct"],
-            })
+            rows.append(
+                {
+                    "season": season,
+                    "leagueId": season_block["leagueId"],
+                    "standing": standing["standing"],
+                    "finalPlace": standing.get("finalPlace"),
+                    "madePlayoffs": standing.get("madePlayoffs"),
+                    "ownerId": standing["ownerId"],
+                    "teamName": standing["teamName"],
+                    "wins": standing["wins"],
+                    "losses": standing["losses"],
+                    "ties": standing["ties"],
+                    "pointsFor": standing["pointsFor"],
+                    "pointsAgainst": standing["pointsAgainst"],
+                    "winPct": standing["winPct"],
+                }
+            )
     fields = [
-        "season", "leagueId", "standing", "finalPlace", "madePlayoffs",
-        "ownerId", "teamName", "wins", "losses", "ties",
-        "pointsFor", "pointsAgainst", "winPct",
+        "season",
+        "leagueId",
+        "standing",
+        "finalPlace",
+        "madePlayoffs",
+        "ownerId",
+        "teamName",
+        "wins",
+        "losses",
+        "ties",
+        "pointsFor",
+        "pointsAgainst",
+        "winPct",
     ]
     return "history-standings.csv", _write_csv(rows, fields)
 
@@ -85,11 +98,22 @@ def export_history(data: dict[str, Any]) -> tuple[str, str]:
 def export_hall_of_fame(data: dict[str, Any]) -> tuple[str, str]:
     rows = data.get("hallOfFame", [])
     fields = [
-        "ownerId", "displayName", "currentTeamName", "seasonsPlayed",
-        "wins", "losses", "ties", "pointsFor", "pointsAgainst",
-        "championships", "finalsAppearances", "playoffAppearances",
-        "regularSeasonFirstPlace", "toiletBowls",
-        "bestFinish", "worstFinish",
+        "ownerId",
+        "displayName",
+        "currentTeamName",
+        "seasonsPlayed",
+        "wins",
+        "losses",
+        "ties",
+        "pointsFor",
+        "pointsAgainst",
+        "championships",
+        "finalsAppearances",
+        "playoffAppearances",
+        "regularSeasonFirstPlace",
+        "toiletBowls",
+        "bestFinish",
+        "worstFinish",
     ]
     return "hall-of-fame.csv", _write_csv(rows, fields)
 
@@ -101,32 +125,44 @@ def export_rivalries(data: dict[str, Any]) -> tuple[str, str]:
         owner_a = r["ownerIds"][0] if r.get("ownerIds") else ""
         owner_b = r["ownerIds"][1] if len(r.get("ownerIds", [])) > 1 else ""
         names = r.get("displayNames") or []
-        rows.append({
-            "ownerIdA": owner_a,
-            "displayNameA": names[0] if len(names) > 0 else "",
-            "ownerIdB": owner_b,
-            "displayNameB": names[1] if len(names) > 1 else "",
-            "totalMeetings": r["totalMeetings"],
-            "regularSeasonMeetings": r["regularSeasonMeetings"],
-            "playoffMeetings": r["playoffMeetings"],
-            "winsA": r["winsA"],
-            "winsB": r["winsB"],
-            "ties": r["ties"],
-            "pointsA": r["pointsA"],
-            "pointsB": r["pointsB"],
-            "gamesDecidedByFive": r["gamesDecidedByFive"],
-            "gamesDecidedByTen": r["gamesDecidedByTen"],
-            "seasonsWhereSeriesSplit": r["seasonsWhereSeriesSplit"],
-            "meetingsInMostRecentSeason": r["meetingsInMostRecentSeason"],
-            "rivalryIndex": r["rivalryIndex"],
-        })
+        rows.append(
+            {
+                "ownerIdA": owner_a,
+                "displayNameA": names[0] if len(names) > 0 else "",
+                "ownerIdB": owner_b,
+                "displayNameB": names[1] if len(names) > 1 else "",
+                "totalMeetings": r["totalMeetings"],
+                "regularSeasonMeetings": r["regularSeasonMeetings"],
+                "playoffMeetings": r["playoffMeetings"],
+                "winsA": r["winsA"],
+                "winsB": r["winsB"],
+                "ties": r["ties"],
+                "pointsA": r["pointsA"],
+                "pointsB": r["pointsB"],
+                "gamesDecidedByFive": r["gamesDecidedByFive"],
+                "gamesDecidedByTen": r["gamesDecidedByTen"],
+                "seasonsWhereSeriesSplit": r["seasonsWhereSeriesSplit"],
+                "meetingsInMostRecentSeason": r["meetingsInMostRecentSeason"],
+                "rivalryIndex": r["rivalryIndex"],
+            }
+        )
     fields = [
-        "ownerIdA", "displayNameA", "ownerIdB", "displayNameB",
-        "totalMeetings", "regularSeasonMeetings", "playoffMeetings",
-        "winsA", "winsB", "ties",
-        "pointsA", "pointsB",
-        "gamesDecidedByFive", "gamesDecidedByTen",
-        "seasonsWhereSeriesSplit", "meetingsInMostRecentSeason",
+        "ownerIdA",
+        "displayNameA",
+        "ownerIdB",
+        "displayNameB",
+        "totalMeetings",
+        "regularSeasonMeetings",
+        "playoffMeetings",
+        "winsA",
+        "winsB",
+        "ties",
+        "pointsA",
+        "pointsB",
+        "gamesDecidedByFive",
+        "gamesDecidedByTen",
+        "seasonsWhereSeriesSplit",
+        "meetingsInMostRecentSeason",
         "rivalryIndex",
     ]
     return "rivalries.csv", _write_csv(rows, fields)
@@ -137,37 +173,48 @@ def export_awards(data: dict[str, Any]) -> tuple[str, str]:
     rows: list[dict[str, Any]] = []
     for season_row in data.get("bySeason", []):
         for a in season_row.get("awards", []):
-            rows.append({
-                "season": season_row["season"],
-                "leagueId": season_row["leagueId"],
-                "seasonStatus": season_row.get("seasonStatus"),
-                "key": a["key"],
-                "label": a["label"],
-                "ownerId": a["ownerId"],
-                "displayName": a["displayName"],
-                "teamName": a.get("teamName"),
-                "value": a.get("value"),
-                "description": a.get("description"),
-            })
+            rows.append(
+                {
+                    "season": season_row["season"],
+                    "leagueId": season_row["leagueId"],
+                    "seasonStatus": season_row.get("seasonStatus"),
+                    "key": a["key"],
+                    "label": a["label"],
+                    "ownerId": a["ownerId"],
+                    "displayName": a["displayName"],
+                    "teamName": a.get("teamName"),
+                    "value": a.get("value"),
+                    "description": a.get("description"),
+                }
+            )
     # Live races appended with season="_race" so filters are easy.
     for race in data.get("awardRaces", []):
         for leader in race.get("leaders", []):
-            rows.append({
-                "season": "_race",
-                "leagueId": "",
-                "seasonStatus": "in_progress",
-                "key": race["key"],
-                "label": race["label"],
-                "ownerId": leader["ownerId"],
-                "displayName": leader["displayName"],
-                "teamName": "",
-                "value": {**leader.get("value", {}), "rank": leader["rank"]},
-                "description": race.get("description"),
-            })
+            rows.append(
+                {
+                    "season": "_race",
+                    "leagueId": "",
+                    "seasonStatus": "in_progress",
+                    "key": race["key"],
+                    "label": race["label"],
+                    "ownerId": leader["ownerId"],
+                    "displayName": leader["displayName"],
+                    "teamName": "",
+                    "value": {**leader.get("value", {}), "rank": leader["rank"]},
+                    "description": race.get("description"),
+                }
+            )
     fields = [
-        "season", "leagueId", "seasonStatus",
-        "key", "label", "ownerId", "displayName", "teamName",
-        "value", "description",
+        "season",
+        "leagueId",
+        "seasonStatus",
+        "key",
+        "label",
+        "ownerId",
+        "displayName",
+        "teamName",
+        "value",
+        "description",
     ]
     return "awards.csv", _write_csv(rows, fields)
 
@@ -196,11 +243,25 @@ def export_records(data: dict[str, Any]) -> tuple[str, str]:
         rows.append({"category": "longest_loss_streak", **r})
 
     fields = [
-        "category", "ownerId", "displayName", "teamName",
-        "season", "leagueId", "week", "isPlayoff",
-        "points", "opponentPoints", "margin", "result",
-        "length", "start", "end",
-        "totalPoints", "totalPointsAgainst", "avgPoints", "weeksPlayed",
+        "category",
+        "ownerId",
+        "displayName",
+        "teamName",
+        "season",
+        "leagueId",
+        "week",
+        "isPlayoff",
+        "points",
+        "opponentPoints",
+        "margin",
+        "result",
+        "length",
+        "start",
+        "end",
+        "totalPoints",
+        "totalPointsAgainst",
+        "avgPoints",
+        "weeksPlayed",
     ]
     return "records.csv", _write_csv(rows, fields)
 
@@ -214,25 +275,43 @@ def export_franchise(data: dict[str, Any], owner_id: str | None = None) -> tuple
             return f"franchise-{owner_id}.csv", "season,message\n,No franchise record found\n"
         rows = []
         for r in detail.get("seasonResults", []):
-            rows.append({
-                "ownerId": owner_id,
-                "displayName": detail.get("displayName"),
-                **r,
-            })
+            rows.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": detail.get("displayName"),
+                    **r,
+                }
+            )
         fields = [
-            "ownerId", "displayName",
-            "season", "leagueId", "rosterId", "teamName",
-            "wins", "losses", "ties",
-            "pointsFor", "pointsAgainst",
-            "standing", "finalPlace", "madePlayoffs",
+            "ownerId",
+            "displayName",
+            "season",
+            "leagueId",
+            "rosterId",
+            "teamName",
+            "wins",
+            "losses",
+            "ties",
+            "pointsFor",
+            "pointsAgainst",
+            "standing",
+            "finalPlace",
+            "madePlayoffs",
         ]
         return f"franchise-{owner_id}.csv", _write_csv(rows, fields)
 
     # No owner: index summary.
     rows = data.get("index", [])
     fields = [
-        "ownerId", "displayName", "currentTeamName", "avatar",
-        "seasonsPlayed", "wins", "losses", "championships", "bestFinish",
+        "ownerId",
+        "displayName",
+        "currentTeamName",
+        "avatar",
+        "seasonsPlayed",
+        "wins",
+        "losses",
+        "championships",
+        "bestFinish",
     ]
     return "franchises.csv", _write_csv(rows, fields)
 
@@ -243,28 +322,38 @@ def export_activity(data: dict[str, Any]) -> tuple[str, str]:
     for t in data.get("feed", []):
         for side in t.get("sides", []):
             assets_str = " | ".join(
-                a.get("playerName") or a.get("label") or ""
-                for a in side.get("receivedAssets", [])
+                a.get("playerName") or a.get("label") or "" for a in side.get("receivedAssets", [])
             )
-            rows.append({
-                "transactionId": t["transactionId"],
-                "season": t["season"],
-                "leagueId": t["leagueId"],
-                "week": t.get("week"),
-                "createdAt": t.get("createdAt"),
-                "totalAssets": t["totalAssets"],
-                "ownerId": side["ownerId"],
-                "displayName": side.get("displayName") or side.get("teamName"),
-                "teamName": side.get("teamName"),
-                "receivedPlayerCount": side.get("receivedPlayerCount", 0),
-                "receivedPickCount": side.get("receivedPickCount", 0),
-                "notableAssetCount": side.get("notableAssetCount", 0),
-                "receivedAssets": assets_str,
-            })
+            rows.append(
+                {
+                    "transactionId": t["transactionId"],
+                    "season": t["season"],
+                    "leagueId": t["leagueId"],
+                    "week": t.get("week"),
+                    "createdAt": t.get("createdAt"),
+                    "totalAssets": t["totalAssets"],
+                    "ownerId": side["ownerId"],
+                    "displayName": side.get("displayName") or side.get("teamName"),
+                    "teamName": side.get("teamName"),
+                    "receivedPlayerCount": side.get("receivedPlayerCount", 0),
+                    "receivedPickCount": side.get("receivedPickCount", 0),
+                    "notableAssetCount": side.get("notableAssetCount", 0),
+                    "receivedAssets": assets_str,
+                }
+            )
     fields = [
-        "transactionId", "season", "leagueId", "week", "createdAt",
-        "totalAssets", "ownerId", "displayName", "teamName",
-        "receivedPlayerCount", "receivedPickCount", "notableAssetCount",
+        "transactionId",
+        "season",
+        "leagueId",
+        "week",
+        "createdAt",
+        "totalAssets",
+        "ownerId",
+        "displayName",
+        "teamName",
+        "receivedPlayerCount",
+        "receivedPickCount",
+        "notableAssetCount",
         "receivedAssets",
     ]
     return "trade-activity.csv", _write_csv(rows, fields)
@@ -275,18 +364,31 @@ def export_draft(data: dict[str, Any]) -> tuple[str, str]:
     rows: list[dict[str, Any]] = []
     for d in data.get("drafts", []):
         for p in d.get("picks", []):
-            rows.append({
-                "draftId": d["draftId"],
-                "season": d["season"],
-                "leagueId": d["leagueId"],
-                "type": d.get("type"),
-                "status": d.get("status"),
-                **p,
-            })
+            rows.append(
+                {
+                    "draftId": d["draftId"],
+                    "season": d["season"],
+                    "leagueId": d["leagueId"],
+                    "type": d.get("type"),
+                    "status": d.get("status"),
+                    **p,
+                }
+            )
     fields = [
-        "draftId", "season", "leagueId", "type", "status",
-        "round", "pickNo", "rosterId", "ownerId", "teamName",
-        "playerId", "playerName", "position", "nflTeam",
+        "draftId",
+        "season",
+        "leagueId",
+        "type",
+        "status",
+        "round",
+        "pickNo",
+        "rosterId",
+        "ownerId",
+        "teamName",
+        "playerId",
+        "playerName",
+        "position",
+        "nflTeam",
     ]
     return "draft-picks.csv", _write_csv(rows, fields)
 
@@ -298,25 +400,35 @@ def export_weekly(data: dict[str, Any]) -> tuple[str, str]:
         for m in w.get("matchups", []):
             home = m.get("home") or {}
             away = m.get("away") or {}
-            rows.append({
-                "season": w["season"],
-                "leagueId": w["leagueId"],
-                "week": w["week"],
-                "isPlayoff": w.get("isPlayoff"),
-                "homeOwnerId": home.get("ownerId"),
-                "homeDisplayName": home.get("displayName"),
-                "homePoints": home.get("points"),
-                "awayOwnerId": away.get("ownerId"),
-                "awayDisplayName": away.get("displayName"),
-                "awayPoints": away.get("points"),
-                "margin": m.get("margin"),
-                "winnerOwnerId": m.get("winnerOwnerId"),
-            })
+            rows.append(
+                {
+                    "season": w["season"],
+                    "leagueId": w["leagueId"],
+                    "week": w["week"],
+                    "isPlayoff": w.get("isPlayoff"),
+                    "homeOwnerId": home.get("ownerId"),
+                    "homeDisplayName": home.get("displayName"),
+                    "homePoints": home.get("points"),
+                    "awayOwnerId": away.get("ownerId"),
+                    "awayDisplayName": away.get("displayName"),
+                    "awayPoints": away.get("points"),
+                    "margin": m.get("margin"),
+                    "winnerOwnerId": m.get("winnerOwnerId"),
+                }
+            )
     fields = [
-        "season", "leagueId", "week", "isPlayoff",
-        "homeOwnerId", "homeDisplayName", "homePoints",
-        "awayOwnerId", "awayDisplayName", "awayPoints",
-        "margin", "winnerOwnerId",
+        "season",
+        "leagueId",
+        "week",
+        "isPlayoff",
+        "homeOwnerId",
+        "homeDisplayName",
+        "homePoints",
+        "awayOwnerId",
+        "awayDisplayName",
+        "awayPoints",
+        "margin",
+        "winnerOwnerId",
     ]
     return "weekly-matchups.csv", _write_csv(rows, fields)
 
@@ -337,9 +449,20 @@ def export_superlatives(data: dict[str, Any]) -> tuple[str, str]:
                 continue
             rows.append({"superlative": f"{key}_ranking_{i+1}", **entry})
     fields = [
-        "superlative", "ownerId", "displayName", "rosterSize",
-        "qb", "rb", "wr", "te", "idp", "rookies",
-        "trades", "waivers", "weightedPickScore", "balanceScore",
+        "superlative",
+        "ownerId",
+        "displayName",
+        "rosterSize",
+        "qb",
+        "rb",
+        "wr",
+        "te",
+        "idp",
+        "rookies",
+        "trades",
+        "waivers",
+        "weightedPickScore",
+        "balanceScore",
     ]
     return "superlatives.csv", _write_csv(rows, fields)
 

--- a/src/public_league/draft.py
+++ b/src/public_league/draft.py
@@ -6,6 +6,7 @@ map, weighted stockpile per manager, most-traded pick lineage.
 Weighting (from prompt):
     1st round = 4, 2nd round = 3, 3rd round = 2, 4th+ = 1
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -24,7 +25,9 @@ def pick_weight(round_: int | None) -> int:
     return ROUND_WEIGHT.get(int(round_), 1)
 
 
-def _normalize_pick(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, pick: dict[str, Any]) -> dict[str, Any]:
+def _normalize_pick(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, pick: dict[str, Any]
+) -> dict[str, Any]:
     rid = metrics.roster_id_of(pick)
     try:
         round_ = int(pick.get("round") or 0)
@@ -57,7 +60,9 @@ def _normalize_pick(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, pick
     }
 
 
-def _draft_summary(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, draft: dict[str, Any]) -> dict[str, Any]:
+def _draft_summary(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, draft: dict[str, Any]
+) -> dict[str, Any]:
     draft_id = str(draft.get("draft_id") or "")
     picks = season.draft_picks_by_draft.get(draft_id, [])
     normalized = [_normalize_pick(snapshot, season, p) for p in picks]
@@ -70,7 +75,9 @@ def _draft_summary(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, draft
         "type": draft.get("type") or "",
         "status": draft.get("status") or "",
         "startTime": draft.get("start_time") or None,
-        "rounds": int((draft.get("settings") or {}).get("rounds") or 0) if isinstance(draft.get("settings"), dict) else 0,
+        "rounds": int((draft.get("settings") or {}).get("rounds") or 0)
+        if isinstance(draft.get("settings"), dict)
+        else 0,
         "picks": normalized,
         "firstRoundRecap": first_round,
     }
@@ -106,12 +113,14 @@ def _pick_ownership_map(snapshot: PublicLeagueSnapshot) -> dict[str, list[dict[s
             continue
         for yr in future_years:
             for rnd in range(1, draft_rounds + 1):
-                original_by_rid[rid].append({
-                    "season": yr,
-                    "round": rnd,
-                    "fromRosterId": rid,
-                    "ownerRosterId": rid,
-                })
+                original_by_rid[rid].append(
+                    {
+                        "season": yr,
+                        "round": rnd,
+                        "fromRosterId": rid,
+                        "ownerRosterId": rid,
+                    }
+                )
 
     # Apply traded picks (chronological across all seasons so the most
     # recent ownership wins).
@@ -146,13 +155,15 @@ def _pick_ownership_map(snapshot: PublicLeagueSnapshot) -> dict[str, list[dict[s
             )
             if not owner_id:
                 continue
-            by_owner[owner_id].append({
-                "season": pick["season"],
-                "round": pick["round"],
-                "originalOwnerId": original_owner_id,
-                "isTraded": owner_id != original_owner_id,
-                "label": f"{pick['season']} R{pick['round']}",
-            })
+            by_owner[owner_id].append(
+                {
+                    "season": pick["season"],
+                    "round": pick["round"],
+                    "originalOwnerId": original_owner_id,
+                    "isTraded": owner_id != original_owner_id,
+                    "label": f"{pick['season']} R{pick['round']}",
+                }
+            )
     for owner_id, lst in by_owner.items():
         lst.sort(key=lambda p: (p["season"], p["round"]))
     return dict(by_owner)
@@ -183,15 +194,19 @@ def weighted_stockpile_for_owner(snapshot: PublicLeagueSnapshot, owner_id: str) 
     }
 
 
-def _stockpile_leaderboard(snapshot: PublicLeagueSnapshot, ownership: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+def _stockpile_leaderboard(
+    snapshot: PublicLeagueSnapshot, ownership: dict[str, list[dict[str, Any]]]
+) -> list[dict[str, Any]]:
     rows = []
     for owner_id, picks in ownership.items():
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "totalPicks": len(picks),
-            "weightedScore": sum(pick_weight(p["round"]) for p in picks),
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "totalPicks": len(picks),
+                "weightedScore": sum(pick_weight(p["round"]) for p in picks),
+            }
+        )
     rows.sort(key=lambda r: (-r["weightedScore"], -r["totalPicks"]))
     return rows
 
@@ -238,15 +253,19 @@ def _pick_movement_trail(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]
             except (TypeError, ValueError):
                 continue
             original_owner_id = metrics.resolve_owner(snapshot.managers, league_id, origin_rid)
-            current_owner_id = metrics.resolve_owner(snapshot.managers, league_id, current_owner_rid)
-            out.append({
-                "season": yr,
-                "round": rnd,
-                "label": f"{yr} R{rnd}",
-                "originalOwnerId": original_owner_id,
-                "currentOwnerId": current_owner_id,
-                "sourceSeason": season.season,
-            })
+            current_owner_id = metrics.resolve_owner(
+                snapshot.managers, league_id, current_owner_rid
+            )
+            out.append(
+                {
+                    "season": yr,
+                    "round": rnd,
+                    "label": f"{yr} R{rnd}",
+                    "originalOwnerId": original_owner_id,
+                    "currentOwnerId": current_owner_id,
+                    "sourceSeason": season.season,
+                }
+            )
     return out
 
 

--- a/src/public_league/franchise.py
+++ b/src/public_league/franchise.py
@@ -10,6 +10,7 @@ Per-manager summaries within the 2-season window:
     * current draft capital summary (owned picks + weighted stockpile)
     * award shelf placeholder (later prompt wires real awards)
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -123,11 +124,14 @@ def _awards_won_by_owner(awards_section: dict[str, Any]) -> dict[str, list[dict[
             if not owner_id:
                 continue  # team/pair awards (rivalry, top NFL team) have no owner
             rec = by_owner.setdefault(owner_id, {})
-            slot = rec.setdefault(a["key"], {
-                "key": a["key"],
-                "label": a.get("label", a["key"]),
-                "seasons": [],
-            })
+            slot = rec.setdefault(
+                a["key"],
+                {
+                    "key": a["key"],
+                    "label": a.get("label", a["key"]),
+                    "seasons": [],
+                },
+            )
             if season and season not in slot["seasons"]:
                 slot["seasons"].append(season)
     out: dict[str, list[dict[str, Any]]] = {}
@@ -152,6 +156,7 @@ def build_section(
         # full-contract path passes the already-built awards section to
         # avoid recomputing it.
         from . import awards as _awards
+
         awards_section = _awards.build_section(snapshot)
     awards_by_owner = _awards_won_by_owner(awards_section)
 
@@ -176,35 +181,40 @@ def build_section(
             owner_id = row["ownerId"]
             final_place = placement.get(row["rosterId"])
             made_playoffs = row["rosterId"] in playoff_rids
-            per_owner_season.setdefault(owner_id, []).append({
-                "season": season.season,
-                "leagueId": season.league_id,
-                "rosterId": row["rosterId"],
-                "teamName": metrics.team_name(snapshot, season.league_id, row["rosterId"]),
-                "wins": row["wins"],
-                "losses": row["losses"],
-                "ties": row["ties"],
-                "pointsFor": row["pointsFor"],
-                "pointsAgainst": row["pointsAgainst"],
-                "standing": row["standing"],
-                "finalPlace": final_place,
-                "madePlayoffs": made_playoffs,
-            })
+            per_owner_season.setdefault(owner_id, []).append(
+                {
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    "rosterId": row["rosterId"],
+                    "teamName": metrics.team_name(snapshot, season.league_id, row["rosterId"]),
+                    "wins": row["wins"],
+                    "losses": row["losses"],
+                    "ties": row["ties"],
+                    "pointsFor": row["pointsFor"],
+                    "pointsAgainst": row["pointsAgainst"],
+                    "standing": row["standing"],
+                    "finalPlace": final_place,
+                    "madePlayoffs": made_playoffs,
+                }
+            )
 
-            cum = cumulative.setdefault(owner_id, {
-                "wins": 0,
-                "losses": 0,
-                "ties": 0,
-                "pointsFor": 0.0,
-                "pointsAgainst": 0.0,
-                "seasonsPlayed": 0,
-                "championships": 0,
-                "finalsAppearances": 0,
-                "playoffAppearances": 0,
-                "regularSeasonFirstPlace": 0,
-                "bestFinish": None,
-                "worstFinish": None,
-            })
+            cum = cumulative.setdefault(
+                owner_id,
+                {
+                    "wins": 0,
+                    "losses": 0,
+                    "ties": 0,
+                    "pointsFor": 0.0,
+                    "pointsAgainst": 0.0,
+                    "seasonsPlayed": 0,
+                    "championships": 0,
+                    "finalsAppearances": 0,
+                    "playoffAppearances": 0,
+                    "regularSeasonFirstPlace": 0,
+                    "bestFinish": None,
+                    "worstFinish": None,
+                },
+            )
             cum["wins"] += row["wins"]
             cum["losses"] += row["losses"]
             cum["ties"] += row["ties"]
@@ -259,17 +269,19 @@ def build_section(
             "awardsWon": awards_by_owner.get(owner_id, []),
         }
         detail[owner_id] = fr
-        index.append({
-            "ownerId": owner_id,
-            "displayName": fr["displayName"],
-            "currentTeamName": fr["currentTeamName"],
-            "avatar": fr.get("avatar") or "",
-            "seasonsPlayed": fr["cumulative"]["seasonsPlayed"],
-            "wins": fr["cumulative"]["wins"],
-            "losses": fr["cumulative"]["losses"],
-            "championships": fr["cumulative"]["championships"],
-            "bestFinish": fr["cumulative"]["bestFinish"],
-        })
+        index.append(
+            {
+                "ownerId": owner_id,
+                "displayName": fr["displayName"],
+                "currentTeamName": fr["currentTeamName"],
+                "avatar": fr.get("avatar") or "",
+                "seasonsPlayed": fr["cumulative"]["seasonsPlayed"],
+                "wins": fr["cumulative"]["wins"],
+                "losses": fr["cumulative"]["losses"],
+                "championships": fr["cumulative"]["championships"],
+                "bestFinish": fr["cumulative"]["bestFinish"],
+            }
+        )
 
     index.sort(
         key=lambda r: (

--- a/src/public_league/history.py
+++ b/src/public_league/history.py
@@ -19,6 +19,7 @@ Across the 2-season window:
 Everything attributes to ``owner_id`` at the time of the season so
 an orphaned roster that changed hands between seasons stays split.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -82,9 +83,7 @@ def _season_block(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot) -> dic
         "topSeed": _wrap(top_seed_row["rosterId"]) if top_seed_row else None,
         "regularSeasonPointsLeader": _wrap(points_leader["rosterId"]) if points_leader else None,
         "bestRegularSeasonRecord": _wrap(best_record["rosterId"]) if best_record else None,
-        "playoffTeams": [
-            _wrap(rid) for rid in sorted(playoff_rids) if _wrap(rid) is not None
-        ],
+        "playoffTeams": [_wrap(rid) for rid in sorted(playoff_rids) if _wrap(rid) is not None],
         "standings": standings,
     }
 
@@ -122,11 +121,13 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         seasons_out.append(block)
 
         if block["champion"]:
-            champions_by_season.append({
-                "season": season.season,
-                "leagueId": season.league_id,
-                **block["champion"],
-            })
+            champions_by_season.append(
+                {
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    **block["champion"],
+                }
+            )
 
         for row in block["standings"]:
             totals = _ensure(row["ownerId"])

--- a/src/public_league/identity.py
+++ b/src/public_league/identity.py
@@ -16,6 +16,7 @@ Display metadata (team name, avatar) is stored as a per-season alias
 list.  The most recent alias wins for primary display, but every
 season's alias is retained so franchise pages can show the lineage.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -37,15 +38,18 @@ from src.utils.owner_names import owner_label
 #     _RETIRED_OWNER_IDS: frozenset[str] = frozenset({
 #         "714976074907336704",  # Bwalk903 — left after 2024
 #     })
-_RETIRED_OWNER_IDS: frozenset[str] = frozenset({
-    "714976074907336704",  # Bwalk903 — left after 2024
-    "720849338183548928",  # SheriffB — left after 2024
-})
+_RETIRED_OWNER_IDS: frozenset[str] = frozenset(
+    {
+        "714976074907336704",  # Bwalk903 — left after 2024
+        "720849338183548928",  # SheriffB — left after 2024
+    }
+)
 
 
 @dataclass
 class TeamAlias:
     """Per-season team-name snapshot for a manager."""
+
     season: str
     league_id: str
     team_name: str
@@ -57,6 +61,7 @@ class TeamAlias:
 @dataclass
 class Manager:
     """Owner-id-keyed manager identity for the public league."""
+
     owner_id: str
     display_name: str = ""
     avatar: str = ""
@@ -92,6 +97,7 @@ class Manager:
 @dataclass
 class ManagerRegistry:
     """Collection of managers keyed by owner_id."""
+
     by_owner_id: dict[str, Manager] = field(default_factory=dict)
     # (league_id, roster_id) -> owner_id, built from each season's
     # roster snapshot.  Used to attribute matchups / trades / picks
@@ -180,9 +186,7 @@ def build_manager_registry(seasons: Iterable[dict[str, Any]]) -> ManagerRegistry
                 or user.get("display_name")
                 or f"Team {rid_int if rid_int is not None else owner_id}"
             )
-            display_name = (
-                owner_label(user) or user.get("display_name") or team_name
-            )
+            display_name = owner_label(user) or user.get("display_name") or team_name
             avatar = str(user.get("avatar") or metadata.get("avatar") or "")
 
             alias = TeamAlias(

--- a/src/public_league/luck.py
+++ b/src/public_league/luck.py
@@ -33,6 +33,7 @@ Output shape
 ``methodology``        — human-readable formula so the UI can render
                          the "how this is computed" footnote.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -140,9 +141,7 @@ def _actual_week_results(
     return actual, pair_pts
 
 
-def _roster_id_for_owner(
-    registry: ManagerRegistry, league_id: str, owner_id: str
-) -> int | None:
+def _roster_id_for_owner(registry: ManagerRegistry, league_id: str, owner_id: str) -> int | None:
     for (lid, rid), oid in registry.roster_to_owner.items():
         if lid == league_id and oid == owner_id:
             return rid
@@ -185,9 +184,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         lambda: {"expected": 0.0, "actual": 0.0, "games": 0}
     )
 
-    current_season_year = (
-        snapshot.current_season.season if snapshot.current_season else None
-    )
+    current_season_year = snapshot.current_season.season if snapshot.current_season else None
 
     # Iterate oldest → newest so ``trail_state`` cumulative counters
     # match the final chronological sort of ``weekly_trail``.  If we
@@ -213,7 +210,9 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                     current = snapshot.current_season
                     if current:
                         rid_current = _roster_id_for_owner(registry, current.league_id, oid)
-                        career["teamName"] = metrics.team_name(snapshot, current.league_id, rid_current)
+                        career["teamName"] = metrics.team_name(
+                            snapshot, current.league_id, rid_current
+                        )
                 career["gamesPlayed"] += 1
                 career["expectedWins"] += expected_share
                 career["actualWins"] += actual_share
@@ -257,19 +256,21 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                 t["expected"] += expected_share
                 t["actual"] += actual_share
                 t["games"] += 1
-                weekly_trail.append({
-                    "ownerId": oid,
-                    "season": season.season,
-                    "week": wk,
-                    "weekExpected": round(expected_share, 4),
-                    "weekActual": round(actual_share, 4),
-                    "weekLuckDelta": round(actual_share - expected_share, 4),
-                    "weekPoints": round(pts_for, 2),
-                    "cumExpected": round(t["expected"], 4),
-                    "cumActual": round(t["actual"], 4),
-                    "cumLuckDelta": round(t["actual"] - t["expected"], 4),
-                    "cumGames": int(t["games"]),
-                })
+                weekly_trail.append(
+                    {
+                        "ownerId": oid,
+                        "season": season.season,
+                        "week": wk,
+                        "weekExpected": round(expected_share, 4),
+                        "weekActual": round(actual_share, 4),
+                        "weekLuckDelta": round(actual_share - expected_share, 4),
+                        "weekPoints": round(pts_for, 2),
+                        "cumExpected": round(t["expected"], 4),
+                        "cumActual": round(t["actual"], 4),
+                        "cumLuckDelta": round(t["actual"] - t["expected"], 4),
+                        "cumGames": int(t["games"]),
+                    }
+                )
 
     # Finalize career rows.
     career_rows: list[dict[str, Any]] = []
@@ -278,26 +279,28 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         actual = row["actualWins"]
         expected = row["expectedWins"]
         rivals = row["allPlayRivals"]
-        career_rows.append({
-            "ownerId": oid,
-            "displayName": row["displayName"],
-            "teamName": row["teamName"],
-            "gamesPlayed": games,
-            "actualWins": round(actual, 2),
-            "expectedWins": round(expected, 2),
-            "luckDelta": round(actual - expected, 2),
-            "luckPerGame": round((actual - expected) / games, 4) if games else 0.0,
-            "actualWinPct": round(actual / games, 4) if games else 0.0,
-            "expectedWinPct": round(expected / games, 4) if games else 0.0,
-            "allPlayWinPct": round(
-                (row["allPlayBeats"] + row["allPlayTies"] * 0.5) / rivals, 4
-            ) if rivals else 0.0,
-            "allPlayBeats": row["allPlayBeats"],
-            "allPlayTies": row["allPlayTies"],
-            "allPlayLosses": rivals - row["allPlayBeats"] - row["allPlayTies"],
-            "pointsFor": round(row["pointsFor"], 2),
-            "pointsAgainst": round(row["pointsAgainst"], 2),
-        })
+        career_rows.append(
+            {
+                "ownerId": oid,
+                "displayName": row["displayName"],
+                "teamName": row["teamName"],
+                "gamesPlayed": games,
+                "actualWins": round(actual, 2),
+                "expectedWins": round(expected, 2),
+                "luckDelta": round(actual - expected, 2),
+                "luckPerGame": round((actual - expected) / games, 4) if games else 0.0,
+                "actualWinPct": round(actual / games, 4) if games else 0.0,
+                "expectedWinPct": round(expected / games, 4) if games else 0.0,
+                "allPlayWinPct": round((row["allPlayBeats"] + row["allPlayTies"] * 0.5) / rivals, 4)
+                if rivals
+                else 0.0,
+                "allPlayBeats": row["allPlayBeats"],
+                "allPlayTies": row["allPlayTies"],
+                "allPlayLosses": rivals - row["allPlayBeats"] - row["allPlayTies"],
+                "pointsFor": round(row["pointsFor"], 2),
+                "pointsAgainst": round(row["pointsAgainst"], 2),
+            }
+        )
     career_rows.sort(key=lambda r: -r["luckDelta"])
 
     # Finalize season rows.
@@ -307,31 +310,31 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         actual = row["actualWins"]
         expected = row["expectedWins"]
         rivals = row["allPlayRivals"]
-        season_rows.append({
-            "ownerId": row["ownerId"],
-            "season": row["season"],
-            "leagueId": row["leagueId"],
-            "displayName": row["displayName"],
-            "teamName": row["teamName"],
-            "gamesPlayed": games,
-            "actualWins": round(actual, 2),
-            "expectedWins": round(expected, 2),
-            "luckDelta": round(actual - expected, 2),
-            "luckPerGame": round((actual - expected) / games, 4) if games else 0.0,
-            "actualWinPct": round(actual / games, 4) if games else 0.0,
-            "expectedWinPct": round(expected / games, 4) if games else 0.0,
-            "allPlayWinPct": round(
-                (row["allPlayBeats"] + row["allPlayTies"] * 0.5) / rivals, 4
-            ) if rivals else 0.0,
-            "pointsFor": round(row["pointsFor"], 2),
-            "pointsAgainst": round(row["pointsAgainst"], 2),
-        })
+        season_rows.append(
+            {
+                "ownerId": row["ownerId"],
+                "season": row["season"],
+                "leagueId": row["leagueId"],
+                "displayName": row["displayName"],
+                "teamName": row["teamName"],
+                "gamesPlayed": games,
+                "actualWins": round(actual, 2),
+                "expectedWins": round(expected, 2),
+                "luckDelta": round(actual - expected, 2),
+                "luckPerGame": round((actual - expected) / games, 4) if games else 0.0,
+                "actualWinPct": round(actual / games, 4) if games else 0.0,
+                "expectedWinPct": round(expected / games, 4) if games else 0.0,
+                "allPlayWinPct": round((row["allPlayBeats"] + row["allPlayTies"] * 0.5) / rivals, 4)
+                if rivals
+                else 0.0,
+                "pointsFor": round(row["pointsFor"], 2),
+                "pointsAgainst": round(row["pointsAgainst"], 2),
+            }
+        )
     # Most recent season first; within a season, luckiest first.
     season_rows.sort(key=lambda r: (-_season_sort_key(r["season"]), -r["luckDelta"]))
 
-    weekly_trail.sort(
-        key=lambda t: (_season_sort_key(t["season"]), t["week"], t["ownerId"])
-    )
+    weekly_trail.sort(key=lambda t: (_season_sort_key(t["season"]), t["week"], t["ownerId"]))
 
     current_season_rows = [r for r in season_rows if r["season"] == current_season_year]
     current_season_rows.sort(key=lambda r: -r["luckDelta"])

--- a/src/public_league/matchup_narrative.py
+++ b/src/public_league/matchup_narrative.py
@@ -32,6 +32,7 @@ Key design choices:
   shouldn't 404 last season's championship recap. ``exports/narratives/``
   is committed alongside the league's other public artifacts.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -130,7 +131,11 @@ def list_articles(
     if not root.exists():
         return []
     out: list[dict[str, Any]] = []
-    seasons = [str(season)] if season is not None else sorted(p.name for p in root.iterdir() if p.is_dir())
+    seasons = (
+        [str(season)]
+        if season is not None
+        else sorted(p.name for p in root.iterdir() if p.is_dir())
+    )
     for s in seasons:
         sdir = root / s
         if not sdir.exists():
@@ -147,15 +152,19 @@ def list_articles(
                     payload = json.loads(fp.read_text(encoding="utf-8"))
                 except (json.JSONDecodeError, OSError):
                     continue
-                out.append({
-                    "season": s,
-                    "week": week_num,
-                    "mode": payload.get("mode"),
-                    "matchupId": payload.get("matchupId"),
-                    "title": payload.get("title"),
-                    "generatedAt": payload.get("generatedAt"),
-                    "path": str(fp.relative_to(root.parent)) if fp.is_relative_to(root.parent) else str(fp),
-                })
+                out.append(
+                    {
+                        "season": s,
+                        "week": week_num,
+                        "mode": payload.get("mode"),
+                        "matchupId": payload.get("matchupId"),
+                        "title": payload.get("title"),
+                        "generatedAt": payload.get("generatedAt"),
+                        "path": str(fp.relative_to(root.parent))
+                        if fp.is_relative_to(root.parent)
+                        else str(fp),
+                    }
+                )
     return out
 
 
@@ -284,11 +293,13 @@ def _multi_week_round(
             )
             if home_entry is None or away_entry is None:
                 continue
-            prior.append({
-                "week": prev,
-                "homePoints": round(metrics.matchup_points(home_entry), 2),
-                "awayPoints": round(metrics.matchup_points(away_entry), 2),
-            })
+            prior.append(
+                {
+                    "week": prev,
+                    "homePoints": round(metrics.matchup_points(home_entry), 2),
+                    "awayPoints": round(metrics.matchup_points(away_entry), 2),
+                }
+            )
             matched = True
             break
         if not matched:
@@ -346,12 +357,14 @@ def _starter_lineup(
             points = float(pp.get(pid) or 0.0)
         except (TypeError, ValueError):
             points = 0.0
-        rows.append({
-            "playerId": str(pid),
-            "playerName": snapshot.player_display(pid),
-            "position": snapshot.player_position(pid),
-            "points": round(points, 2) if include_points else None,
-        })
+        rows.append(
+            {
+                "playerId": str(pid),
+                "playerName": snapshot.player_display(pid),
+                "position": snapshot.player_position(pid),
+                "points": round(points, 2) if include_points else None,
+            }
+        )
     return rows
 
 
@@ -372,12 +385,14 @@ def _bench_top(
             points = float(pp.get(s_pid) or 0.0)
         except (TypeError, ValueError):
             points = 0.0
-        rows.append({
-            "playerId": s_pid,
-            "playerName": snapshot.player_display(s_pid),
-            "position": snapshot.player_position(s_pid),
-            "points": round(points, 2),
-        })
+        rows.append(
+            {
+                "playerId": s_pid,
+                "playerName": snapshot.player_display(s_pid),
+                "position": snapshot.player_position(s_pid),
+                "points": round(points, 2),
+            }
+        )
     rows.sort(key=lambda r: -r["points"])
     return rows[:n]
 
@@ -570,10 +585,18 @@ def build_brief(
     last_5 = matchup_preview._meetings_recent(meetings, n=5)  # noqa: SLF001
 
     home_form = matchup_preview._recent_form_for_owner(  # noqa: SLF001
-        snapshot, home_owner, season, week, n=3,
+        snapshot,
+        home_owner,
+        season,
+        week,
+        n=3,
     )
     away_form = matchup_preview._recent_form_for_owner(  # noqa: SLF001
-        snapshot, away_owner, season, week, n=3,
+        snapshot,
+        away_owner,
+        season,
+        week,
+        n=3,
     )
 
     # Pre-week standings — lifted from matchup_recap's helper.
@@ -584,7 +607,11 @@ def build_brief(
 
     # Bracket classification.
     round_label, is_championship = _bracket_round_for(
-        season_snap, matchup_id, week, home_rid, away_rid,
+        season_snap,
+        matchup_id,
+        week,
+        home_rid,
+        away_rid,
     )
     is_playoff = week >= season_snap.playoff_week_start
 
@@ -603,10 +630,14 @@ def build_brief(
     # Top-scorer / biggest-bench-miss for recaps only.
     if mode == "recap":
         home_top = max(
-            home_lineup, key=lambda r: r.get("points") or 0.0, default=None,
+            home_lineup,
+            key=lambda r: r.get("points") or 0.0,
+            default=None,
         )
         away_top = max(
-            away_lineup, key=lambda r: r.get("points") or 0.0, default=None,
+            away_lineup,
+            key=lambda r: r.get("points") or 0.0,
+            default=None,
         )
         # In best-ball, Sleeper auto-optimizes the lineup so a "bench
         # miss" (best bench scorer outscoring the worst starter) is by
@@ -707,7 +738,9 @@ def build_brief(
                 "winPct": pre_rec.get("winPct", 0.0),
                 "standing": pre_rec.get("standing"),
                 "pointsFor": pre_rec.get("pointsFor", 0.0),
-            } if pre_rec else None,
+            }
+            if pre_rec
+            else None,
             "recentForm": form,
             "starters": lineup,
             "topBench": bench,
@@ -717,18 +750,38 @@ def build_brief(
         }
 
     home_block = _side_block(
-        home_owner, home_rid, home_seed, home_pre, home_form,
-        home_lineup, home_bench, home_top, home_miss, home_points,
+        home_owner,
+        home_rid,
+        home_seed,
+        home_pre,
+        home_form,
+        home_lineup,
+        home_bench,
+        home_top,
+        home_miss,
+        home_points,
     )
     away_block = _side_block(
-        away_owner, away_rid, away_seed, away_pre, away_form,
-        away_lineup, away_bench, away_top, away_miss, away_points,
+        away_owner,
+        away_rid,
+        away_seed,
+        away_pre,
+        away_form,
+        away_lineup,
+        away_bench,
+        away_top,
+        away_miss,
+        away_points,
     )
 
     h2h_block = {
         "totalMeetings": summary.get("totalMeetings", 0),
-        "homeWins": summary.get("sideAWins", 0) if pair_key[0] == home_owner else summary.get("sideBWins", 0),
-        "awayWins": summary.get("sideBWins", 0) if pair_key[0] == home_owner else summary.get("sideAWins", 0),
+        "homeWins": summary.get("sideAWins", 0)
+        if pair_key[0] == home_owner
+        else summary.get("sideBWins", 0),
+        "awayWins": summary.get("sideBWins", 0)
+        if pair_key[0] == home_owner
+        else summary.get("sideAWins", 0),
         "ties": summary.get("ties", 0),
         "avgMargin": summary.get("avgMargin", 0.0),
         "biggestMargin": summary.get("biggestMargin", 0.0),
@@ -1056,18 +1109,24 @@ def collect_prior_articles(
     out: list[dict[str, Any]] = []
     for entry in items[:n]:
         full = load_article(
-            entry["season"], entry["week"], entry["matchupId"], entry["mode"], base=base,
+            entry["season"],
+            entry["week"],
+            entry["matchupId"],
+            entry["mode"],
+            base=base,
         )
         if not full:
             continue
-        out.append({
-            "season": full.get("season"),
-            "week": full.get("week"),
-            "mode": full.get("mode"),
-            "title": full.get("title"),
-            "lede": full.get("lede"),
-            "generatedAt": full.get("generatedAt"),
-        })
+        out.append(
+            {
+                "season": full.get("season"),
+                "week": full.get("week"),
+                "mode": full.get("mode"),
+                "title": full.get("title"),
+                "lede": full.get("lede"),
+                "generatedAt": full.get("generatedAt"),
+            }
+        )
     return out
 
 

--- a/src/public_league/matchup_preview.py
+++ b/src/public_league/matchup_preview.py
@@ -23,6 +23,7 @@ Output shape
 ``matchups``         — list of ``{home, away, h2h, form, scores}``.
 ``generatedAt``      — iso timestamp for cache debugging.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -90,22 +91,22 @@ def _build_h2h_index(
             winner = sideB_oid
         else:
             winner = None
-        idx[key].append({
-            "season": season.season,
-            "leagueId": season.league_id,
-            "week": wk,
-            "isPlayoff": is_playoff,
-            "sideAOwnerId": sideA_oid,
-            "sideBOwnerId": sideB_oid,
-            "sideAPoints": round(sideA_pts, 2),
-            "sideBPoints": round(sideB_pts, 2),
-            "winnerOwnerId": winner,
-            "margin": round(abs(sideA_pts - sideB_pts), 2),
-        })
-    for meetings in idx.values():
-        meetings.sort(
-            key=lambda m: (_season_sort(m["season"]), m["week"])
+        idx[key].append(
+            {
+                "season": season.season,
+                "leagueId": season.league_id,
+                "week": wk,
+                "isPlayoff": is_playoff,
+                "sideAOwnerId": sideA_oid,
+                "sideBOwnerId": sideB_oid,
+                "sideAPoints": round(sideA_pts, 2),
+                "sideBPoints": round(sideB_pts, 2),
+                "winnerOwnerId": winner,
+                "margin": round(abs(sideA_pts - sideB_pts), 2),
+            }
         )
+    for meetings in idx.values():
+        meetings.sort(key=lambda m: (_season_sort(m["season"]), m["week"]))
     return idx
 
 
@@ -131,10 +132,7 @@ def _recent_form_for_owner(
         # Strictly-before test.
         if _season_sort(season.season) > _season_sort(before_season):
             continue
-        if (
-            _season_sort(season.season) == _season_sort(before_season)
-            and wk >= before_week
-        ):
+        if _season_sort(season.season) == _season_sort(before_season) and wk >= before_week:
             continue
         for me, foe in ((a, b), (b, a)):
             rid = metrics.roster_id_of(me)
@@ -153,13 +151,15 @@ def _recent_form_for_owner(
                 result = "L"
             else:
                 result = "T"
-            events.append({
-                "season": season.season,
-                "week": wk,
-                "points": round(my_pts, 2),
-                "opponentPoints": round(opp_pts, 2),
-                "result": result,
-            })
+            events.append(
+                {
+                    "season": season.season,
+                    "week": wk,
+                    "points": round(my_pts, 2),
+                    "opponentPoints": round(opp_pts, 2),
+                    "result": result,
+                }
+            )
     events.sort(key=lambda e: (_season_sort(e["season"]), e["week"]))
     recent = events[-n:]
     wins = sum(1 for e in recent if e["result"] == "W")
@@ -218,7 +218,9 @@ def _meetings_recent(meetings: list[dict[str, Any]], n: int = 5) -> list[dict[st
     return list(reversed(meetings[-n:])) if meetings else []
 
 
-def _narrative(summary: dict[str, Any], sideA_name: str, sideB_name: str, last: dict[str, Any] | None) -> str:
+def _narrative(
+    summary: dict[str, Any], sideA_name: str, sideB_name: str, last: dict[str, Any] | None
+) -> str:
     """Short 1-2 sentence summary."""
     total = summary["totalMeetings"]
     if total == 0:
@@ -274,12 +276,8 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         summary["_sideA_oid"] = sideA_oid
         summary["_sideB_oid"] = sideB_oid
         recent = _meetings_recent(meetings, n=5)
-        form_a = _recent_form_for_owner(
-            snapshot, sideA_oid, current.season, week, n=3
-        )
-        form_b = _recent_form_for_owner(
-            snapshot, sideB_oid, current.season, week, n=3
-        )
+        form_a = _recent_form_for_owner(snapshot, sideA_oid, current.season, week, n=3)
+        form_b = _recent_form_for_owner(snapshot, sideB_oid, current.season, week, n=3)
 
         home_rid = metrics.roster_id_of(a) if oa == sideA_oid else metrics.roster_id_of(b)
         away_rid = metrics.roster_id_of(b) if oa == sideA_oid else metrics.roster_id_of(a)
@@ -287,45 +285,51 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         home_entry = a if oa == sideA_oid else b
         away_entry = b if oa == sideA_oid else a
 
-        out_matchups.append({
-            "matchupId": a.get("matchup_id"),
-            "home": {
-                "ownerId": sideA_oid,
-                "displayName": metrics.display_name_for(snapshot, sideA_oid),
-                "teamName": metrics.team_name(snapshot, current.league_id, home_rid),
-                "rosterId": home_rid,
-                "points": round(metrics.matchup_points(home_entry), 2) if mode == "recap" else None,
-            },
-            "away": {
-                "ownerId": sideB_oid,
-                "displayName": metrics.display_name_for(snapshot, sideB_oid),
-                "teamName": metrics.team_name(snapshot, current.league_id, away_rid),
-                "rosterId": away_rid,
-                "points": round(metrics.matchup_points(away_entry), 2) if mode == "recap" else None,
-            },
-            "h2h": {
-                "totalMeetings": summary["totalMeetings"],
-                "homeWins": summary["sideAWins"],
-                "awayWins": summary["sideBWins"],
-                "ties": summary["ties"],
-                "avgMargin": summary["avgMargin"],
-                "biggestMargin": summary["biggestMargin"],
-                "biggestMarginWinnerOwnerId": summary["biggestMarginWinner"],
-                "playoffMeetings": summary["playoffMeetings"],
-                "last5": recent,
-                "lastMeeting": recent[0] if recent else None,
-                "narrative": _narrative(
-                    summary,
-                    metrics.display_name_for(snapshot, sideA_oid),
-                    metrics.display_name_for(snapshot, sideB_oid),
-                    recent[0] if recent else None,
-                ),
-            },
-            "form": {
-                "home": form_a,
-                "away": form_b,
-            },
-        })
+        out_matchups.append(
+            {
+                "matchupId": a.get("matchup_id"),
+                "home": {
+                    "ownerId": sideA_oid,
+                    "displayName": metrics.display_name_for(snapshot, sideA_oid),
+                    "teamName": metrics.team_name(snapshot, current.league_id, home_rid),
+                    "rosterId": home_rid,
+                    "points": round(metrics.matchup_points(home_entry), 2)
+                    if mode == "recap"
+                    else None,
+                },
+                "away": {
+                    "ownerId": sideB_oid,
+                    "displayName": metrics.display_name_for(snapshot, sideB_oid),
+                    "teamName": metrics.team_name(snapshot, current.league_id, away_rid),
+                    "rosterId": away_rid,
+                    "points": round(metrics.matchup_points(away_entry), 2)
+                    if mode == "recap"
+                    else None,
+                },
+                "h2h": {
+                    "totalMeetings": summary["totalMeetings"],
+                    "homeWins": summary["sideAWins"],
+                    "awayWins": summary["sideBWins"],
+                    "ties": summary["ties"],
+                    "avgMargin": summary["avgMargin"],
+                    "biggestMargin": summary["biggestMargin"],
+                    "biggestMarginWinnerOwnerId": summary["biggestMarginWinner"],
+                    "playoffMeetings": summary["playoffMeetings"],
+                    "last5": recent,
+                    "lastMeeting": recent[0] if recent else None,
+                    "narrative": _narrative(
+                        summary,
+                        metrics.display_name_for(snapshot, sideA_oid),
+                        metrics.display_name_for(snapshot, sideB_oid),
+                        recent[0] if recent else None,
+                    ),
+                },
+                "form": {
+                    "home": form_a,
+                    "away": form_b,
+                },
+            }
+        )
 
     return {
         "currentSeason": current.season,

--- a/src/public_league/matchup_recap.py
+++ b/src/public_league/matchup_recap.py
@@ -8,6 +8,7 @@ is a featured rivalry.
 Output is composed entirely from the snapshot + the already-built
 public sections.  No private data touches this path.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -43,12 +44,14 @@ def _starter_scores(entry: dict[str, Any], snapshot: PublicLeagueSnapshot) -> li
             points = float(pp.get(pid) or 0.0)
         except (TypeError, ValueError):
             points = 0.0
-        rows.append({
-            "playerId": str(pid),
-            "playerName": name,
-            "position": pos,
-            "points": round(points, 2),
-        })
+        rows.append(
+            {
+                "playerId": str(pid),
+                "playerName": name,
+                "position": pos,
+                "points": round(points, 2),
+            }
+        )
     return rows
 
 
@@ -67,12 +70,14 @@ def _bench_scores(
             points = float(pp.get(pid) or 0.0)
         except (TypeError, ValueError):
             points = 0.0
-        rows.append({
-            "playerId": pid,
-            "playerName": snapshot.player_display(pid),
-            "position": snapshot.player_position(pid),
-            "points": round(points, 2),
-        })
+        rows.append(
+            {
+                "playerId": pid,
+                "playerName": snapshot.player_display(pid),
+                "position": snapshot.player_position(pid),
+                "points": round(points, 2),
+            }
+        )
     rows.sort(key=lambda r: -r["points"])
     return rows
 
@@ -103,7 +108,9 @@ def _side_block(
         "starters": starters,
         "bench": bench,
         "topScorer": top_scorer,
-        "biggestBenchMiss": biggest_miss if (biggest_miss and top_scorer and biggest_miss["points"] > top_scorer["points"]) else None,
+        "biggestBenchMiss": biggest_miss
+        if (biggest_miss and top_scorer and biggest_miss["points"] > top_scorer["points"])
+        else None,
         "preWeekRecord": {
             "wins": pre.get("wins", 0),
             "losses": pre.get("losses", 0),
@@ -111,7 +118,9 @@ def _side_block(
             "winPct": pre.get("winPct", 0.0),
             "standing": pre.get("standing"),
             "pointsFor": pre.get("pointsFor", 0.0),
-        } if pre else None,
+        }
+        if pre
+        else None,
     }
 
 
@@ -215,11 +224,13 @@ def list_matchups(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
                     continue
                 if not metrics.is_scored(pair[0]) and not metrics.is_scored(pair[1]):
                     continue
-                out.append({
-                    "season": season.season,
-                    "leagueId": season.league_id,
-                    "week": week,
-                    "isPlayoff": is_playoff,
-                    "matchupId": mid,
-                })
+                out.append(
+                    {
+                        "season": season.season,
+                        "leagueId": season.league_id,
+                        "week": week,
+                        "isPlayoff": is_playoff,
+                        "matchupId": mid,
+                    }
+                )
     return out

--- a/src/public_league/metrics.py
+++ b/src/public_league/metrics.py
@@ -5,6 +5,7 @@ same regular-season / playoff partitioning, the same roster→owner
 attribution, and the same pre-week standings reconstruction so
 results stay consistent across cards.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -15,7 +16,9 @@ from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
 
 # ── Matchup helpers ────────────────────────────────────────────────────────
-def matchup_pairs(week_entries: list[dict[str, Any]]) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+def matchup_pairs(
+    week_entries: list[dict[str, Any]],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
     """Group a week's matchup rows into (home, away) pairs by matchup_id.
 
     The ordering within a pair is stable — we sort by ``roster_id`` so
@@ -109,20 +112,22 @@ def season_standings(season: SeasonSnapshot, registry: ManagerRegistry) -> list[
         rec = regular_season_settings_record(roster)
         games = rec["wins"] + rec["losses"] + rec["ties"]
         win_pct = (rec["wins"] + rec["ties"] * 0.5) / games if games else 0.0
-        rows.append({
-            "ownerId": owner_id,
-            "rosterId": rid,
-            "leagueId": season.league_id,
-            "season": season.season,
-            "wins": rec["wins"],
-            "losses": rec["losses"],
-            "ties": rec["ties"],
-            "pointsFor": rec["pointsFor"],
-            "pointsAgainst": rec["pointsAgainst"],
-            "winPct": round(win_pct, 4),
-            "games": games,
-            "sleeperRank": rec["sleeperRank"],
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "rosterId": rid,
+                "leagueId": season.league_id,
+                "season": season.season,
+                "wins": rec["wins"],
+                "losses": rec["losses"],
+                "ties": rec["ties"],
+                "pointsFor": rec["pointsFor"],
+                "pointsAgainst": rec["pointsAgainst"],
+                "winPct": round(win_pct, 4),
+                "games": games,
+                "sleeperRank": rec["sleeperRank"],
+            }
+        )
     rows.sort(
         key=lambda r: (
             -r["winPct"],
@@ -293,7 +298,9 @@ def season_champion(season: SeasonSnapshot) -> int | None:
     if placement:
         return min(placement, key=lambda rid: placement[rid])
     metadata = season.league.get("metadata") or {}
-    explicit = metadata.get("latest_league_winner_roster_id") or season.league.get("last_league_winner_roster_id")
+    explicit = metadata.get("latest_league_winner_roster_id") or season.league.get(
+        "last_league_winner_roster_id"
+    )
     try:
         return int(explicit) if explicit is not None else None
     except (TypeError, ValueError):

--- a/src/public_league/overview.py
+++ b/src/public_league/overview.py
@@ -27,6 +27,7 @@ Populated blocks:
     * leagueVitals — small badge summary (games played, total trades,
       total waivers).
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -89,32 +90,54 @@ def _top_record_callouts(records_section: dict[str, Any]) -> list[dict[str, Any]
             formatted = f"{value:g}"
         else:
             formatted = str(value or "")
-        callouts.append({
-            "kind": kind,
-            "label": label,
-            "value": value,
-            "formattedValue": formatted + (f" {units}" if units else ""),
-            "ownerId": row.get("ownerId"),
-            "displayName": row.get("teamName") or row.get("displayName"),
-            "season": row.get("season"),
-            "week": row.get("week"),
-        })
+        callouts.append(
+            {
+                "kind": kind,
+                "label": label,
+                "value": value,
+                "formattedValue": formatted + (f" {units}" if units else ""),
+                "ownerId": row.get("ownerId"),
+                "displayName": row.get("teamName") or row.get("displayName"),
+                "season": row.get("season"),
+                "week": row.get("week"),
+            }
+        )
 
-    _push("highest_single_week", "Highest week", records_section.get("singleWeekHighest") or [], "points", "pts")
-    _push("biggest_margin", "Biggest blowout", records_section.get("biggestMargin") or [], "margin", "pts")
-    _push("most_points_in_season", "Most season points", records_section.get("mostPointsInSeason") or [], "totalPoints", "pts")
+    _push(
+        "highest_single_week",
+        "Highest week",
+        records_section.get("singleWeekHighest") or [],
+        "points",
+        "pts",
+    )
+    _push(
+        "biggest_margin",
+        "Biggest blowout",
+        records_section.get("biggestMargin") or [],
+        "margin",
+        "pts",
+    )
+    _push(
+        "most_points_in_season",
+        "Most season points",
+        records_section.get("mostPointsInSeason") or [],
+        "totalPoints",
+        "pts",
+    )
     if records_section.get("longestWinStreaks"):
         head = records_section["longestWinStreaks"][0]
-        callouts.append({
-            "kind": "longest_win_streak",
-            "label": "Longest win streak",
-            "value": head["length"],
-            "formattedValue": f"{head['length']} straight",
-            "ownerId": head.get("ownerId"),
-            "displayName": head.get("displayName"),
-            "season": None,
-            "week": None,
-        })
+        callouts.append(
+            {
+                "kind": "longest_win_streak",
+                "label": "Longest win streak",
+                "value": head["length"],
+                "formattedValue": f"{head['length']} straight",
+                "ownerId": head.get("ownerId"),
+                "displayName": head.get("displayName"),
+                "season": None,
+                "week": None,
+            }
+        )
     return callouts
 
 

--- a/src/public_league/player_journey.py
+++ b/src/public_league/player_journey.py
@@ -15,6 +15,7 @@ Everything is derived from the public snapshot.  No private
 internals.  This lets us render a "journey" page nobody else in dynasty
 tooling has.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -29,7 +30,9 @@ def _player_identity(snapshot: PublicLeagueSnapshot, player_id: str) -> dict[str
     return {
         "playerId": str(player_id),
         "playerName": snapshot.player_display(player_id),
-        "position": snapshot.player_position(player_id) or (p.get("position") if isinstance(p, dict) else "") or "",
+        "position": snapshot.player_position(player_id)
+        or (p.get("position") if isinstance(p, dict) else "")
+        or "",
         "nflTeam": (p.get("team") if isinstance(p, dict) else "") or "",
         "yearsExp": (p.get("years_exp") if isinstance(p, dict) else None),
     }
@@ -64,30 +67,38 @@ def _transactions_for(
             if str(player_id) in adds:
                 added_to_rid = adds[str(player_id)]
                 to_owner = _resolve(added_to_rid)
-                events.append({
-                    "kind": "add",
-                    "txType": ttype,
-                    "season": season.season,
-                    "week": week,
-                    "createdAt": tx.get("created") or tx.get("status_updated"),
-                    "transactionId": str(tx.get("transaction_id") or ""),
-                    "toOwnerId": to_owner,
-                    "toDisplayName": metrics.display_name_for(snapshot, to_owner) if to_owner else "",
-                    "faabBid": (tx.get("settings") or {}).get("waiver_bid"),
-                })
+                events.append(
+                    {
+                        "kind": "add",
+                        "txType": ttype,
+                        "season": season.season,
+                        "week": week,
+                        "createdAt": tx.get("created") or tx.get("status_updated"),
+                        "transactionId": str(tx.get("transaction_id") or ""),
+                        "toOwnerId": to_owner,
+                        "toDisplayName": metrics.display_name_for(snapshot, to_owner)
+                        if to_owner
+                        else "",
+                        "faabBid": (tx.get("settings") or {}).get("waiver_bid"),
+                    }
+                )
             if str(player_id) in drops:
                 dropped_from_rid = drops[str(player_id)]
                 from_owner = _resolve(dropped_from_rid)
-                events.append({
-                    "kind": "drop",
-                    "txType": ttype,
-                    "season": season.season,
-                    "week": week,
-                    "createdAt": tx.get("created") or tx.get("status_updated"),
-                    "transactionId": str(tx.get("transaction_id") or ""),
-                    "fromOwnerId": from_owner,
-                    "fromDisplayName": metrics.display_name_for(snapshot, from_owner) if from_owner else "",
-                })
+                events.append(
+                    {
+                        "kind": "drop",
+                        "txType": ttype,
+                        "season": season.season,
+                        "week": week,
+                        "createdAt": tx.get("created") or tx.get("status_updated"),
+                        "transactionId": str(tx.get("transaction_id") or ""),
+                        "fromOwnerId": from_owner,
+                        "fromDisplayName": metrics.display_name_for(snapshot, from_owner)
+                        if from_owner
+                        else "",
+                    }
+                )
     events.sort(key=lambda e: (int(e.get("createdAt") or 0), e.get("kind") or ""))
     return events
 
@@ -96,17 +107,21 @@ def _scoring_summary(
     snapshot: PublicLeagueSnapshot,
     season: SeasonSnapshot,
     player_id: str,
-) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None]:
+) -> tuple[
+    dict[str, dict[str, Any]], list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None
+]:
     """Per-owner points scored while this player was rostered, plus
     a sparse per-week log ``[{owner, week, points, started}]`` and
     best/worst single-week entries.
     """
-    per_owner: dict[str, dict[str, Any]] = defaultdict(lambda: {
-        "pointsStarted": 0.0,
-        "pointsBenched": 0.0,
-        "weeksStarted": 0,
-        "weeksRostered": 0,
-    })
+    per_owner: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "pointsStarted": 0.0,
+            "pointsBenched": 0.0,
+            "weeksStarted": 0,
+            "weeksRostered": 0,
+        }
+    )
     weekly_log: list[dict[str, Any]] = []
     best: dict[str, Any] | None = None
     worst: dict[str, Any] | None = None
@@ -144,14 +159,16 @@ def _scoring_summary(
             else:
                 rec["pointsBenched"] += pts
 
-            weekly_log.append({
-                "season": season.season,
-                "week": week,
-                "ownerId": owner_id,
-                "displayName": metrics.display_name_for(snapshot, owner_id),
-                "started": started,
-                "points": round(pts, 2),
-            })
+            weekly_log.append(
+                {
+                    "season": season.season,
+                    "week": week,
+                    "ownerId": owner_id,
+                    "displayName": metrics.display_name_for(snapshot, owner_id),
+                    "started": started,
+                    "points": round(pts, 2),
+                }
+            )
 
             if started and pts > 0:
                 entry_blob = {
@@ -186,7 +203,8 @@ def _draft_origin(snapshot: PublicLeagueSnapshot, player_id: str) -> dict[str, A
                 rid = metrics.roster_id_of(p)
                 owner_id = (
                     metrics.resolve_owner(snapshot.managers, season.league_id, rid)
-                    if rid is not None else ""
+                    if rid is not None
+                    else ""
                 )
                 return {
                     "season": season.season,
@@ -215,13 +233,15 @@ def build_player_journey(
     draft_origin = _draft_origin(snapshot, pid)
 
     per_season: list[dict[str, Any]] = []
-    per_owner_totals: dict[str, dict[str, Any]] = defaultdict(lambda: {
-        "pointsStarted": 0.0,
-        "pointsBenched": 0.0,
-        "pointsTotal": 0.0,
-        "weeksStarted": 0,
-        "weeksRostered": 0,
-    })
+    per_owner_totals: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "pointsStarted": 0.0,
+            "pointsBenched": 0.0,
+            "pointsTotal": 0.0,
+            "weeksStarted": 0,
+            "weeksRostered": 0,
+        }
+    )
     all_weekly: list[dict[str, Any]] = []
     best_overall: dict[str, Any] | None = None
     worst_overall: dict[str, Any] | None = None
@@ -246,27 +266,25 @@ def build_player_journey(
         if worst and (worst_overall is None or worst["points"] < worst_overall["points"]):
             worst_overall = worst
 
-        per_season.append({
-            "season": season.season,
-            "leagueId": season.league_id,
-            "transactions": txs,
-            "byOwner": [
-                {"ownerId": owner, **stats}
-                for owner, stats in sorted(
-                    scoring.items(),
-                    key=lambda kv: -kv[1]["pointsTotal"],
-                )
-            ],
-            "weeklyLog": weekly,
-            "bestWeek": best,
-            "worstWeek": worst,
-        })
+        per_season.append(
+            {
+                "season": season.season,
+                "leagueId": season.league_id,
+                "transactions": txs,
+                "byOwner": [
+                    {"ownerId": owner, **stats}
+                    for owner, stats in sorted(
+                        scoring.items(),
+                        key=lambda kv: -kv[1]["pointsTotal"],
+                    )
+                ],
+                "weeklyLog": weekly,
+                "bestWeek": best,
+                "worstWeek": worst,
+            }
+        )
 
-    has_activity = (
-        bool(all_events)
-        or bool(all_weekly)
-        or draft_origin is not None
-    )
+    has_activity = bool(all_events) or bool(all_weekly) or draft_origin is not None
     if not has_activity:
         return None
 
@@ -320,22 +338,24 @@ def list_players_with_activity(snapshot: PublicLeagueSnapshot) -> list[dict[str,
     seen: set[str] = set()
     for season in snapshot.seasons:
         for roster in season.rosters:
-            for pid in (roster.get("players") or []):
+            for pid in roster.get("players") or []:
                 if pid:
                     seen.add(str(pid))
         for week_txs in season.transactions_by_week.values():
             for tx in week_txs:
-                for pid in (tx.get("adds") or {}):
+                for pid in tx.get("adds") or {}:
                     if pid:
                         seen.add(str(pid))
-                for pid in (tx.get("drops") or {}):
+                for pid in tx.get("drops") or {}:
                     if pid:
                         seen.add(str(pid))
     out = []
     for pid in sorted(seen):
-        out.append({
-            "playerId": pid,
-            "playerName": snapshot.player_display(pid),
-            "position": snapshot.player_position(pid),
-        })
+        out.append(
+            {
+                "playerId": pid,
+                "playerName": snapshot.player_display(pid),
+                "position": snapshot.player_position(pid),
+            }
+        )
     return out

--- a/src/public_league/playoff_odds.py
+++ b/src/public_league/playoff_odds.py
@@ -52,6 +52,7 @@ The simulator degrades gracefully:
 Constants live at the top of the module so audits can see them in
 one place.
 """
+
 from __future__ import annotations
 
 import random
@@ -178,7 +179,9 @@ def _regular_season_record_to_date(
                     continue
                 pts_me = metrics.matchup_points(side)
                 pts_opp = metrics.matchup_points(opp)
-                rec = out.setdefault(owner_id, {"wins": 0, "losses": 0, "ties": 0, "pointsFor": 0.0})
+                rec = out.setdefault(
+                    owner_id, {"wins": 0, "losses": 0, "ties": 0, "pointsFor": 0.0}
+                )
                 rec["pointsFor"] += pts_me
                 if pts_me > pts_opp:
                     rec["wins"] += 1
@@ -279,9 +282,7 @@ def _infer_schedule_from_posted(
     if len(posted_pairs) < 2:
         return None
     posted_weeks = sorted(posted_pairs.keys())
-    canonical = {
-        w: frozenset(frozenset(p) for p in posted_pairs[w]) for w in posted_weeks
-    }
+    canonical = {w: frozenset(frozenset(p) for p in posted_pairs[w]) for w in posted_weeks}
     anchor = posted_weeks[0]
 
     cycle_length = _detect_cycle_length(posted_weeks, canonical)
@@ -383,7 +384,7 @@ def _round_robin_schedule(
     rotators = ring[1:]
     for i, wk in enumerate(weeks):
         pairs: list[tuple[str, str]] = []
-        rot = rotators[-i % len(rotators):] + rotators[: -i % len(rotators)]
+        rot = rotators[-i % len(rotators) :] + rotators[: -i % len(rotators)]
         # Pair fixed vs rot[0]; then pair rot[1..] inward.
         half = [fixed] + rot
         for j in range(n // 2):
@@ -490,7 +491,9 @@ def compute_playoff_odds(
     settings = season.league.get("settings") or {}
     cfg_spots = settings.get("playoff_teams") if isinstance(settings, dict) else None
     try:
-        spots = int(playoff_spots if playoff_spots is not None else cfg_spots or DEFAULT_PLAYOFF_SPOTS)
+        spots = int(
+            playoff_spots if playoff_spots is not None else cfg_spots or DEFAULT_PLAYOFF_SPOTS
+        )
     except (TypeError, ValueError):
         spots = DEFAULT_PLAYOFF_SPOTS
     spots = max(1, spots)
@@ -577,7 +580,9 @@ def compute_playoff_odds(
             }
         wins_snapshot = {o: int(current_record.get(o, {}).get("wins", 0)) for o in owners_in_league}
         ties_snapshot = {o: int(current_record.get(o, {}).get("ties", 0)) for o in owners_in_league}
-        pf_snapshot = {o: float(current_record.get(o, {}).get("pointsFor", 0.0)) for o in owners_in_league}
+        pf_snapshot = {
+            o: float(current_record.get(o, {}).get("pointsFor", 0.0)) for o in owners_in_league
+        }
         ordered = _standings_from_sim(
             wins_snapshot, pf_snapshot, owners_in_league, ties=ties_snapshot
         )
@@ -609,9 +614,7 @@ def compute_playoff_odds(
     # league will never face.  Fall back to round-robin only when
     # fewer than 2 posted weeks exist (helper returns ``None``) or
     # when the observed block has gaps that block inference.
-    inferred_full = (
-        _infer_schedule_from_posted(season, registry) if missing_weeks else None
-    )
+    inferred_full = _infer_schedule_from_posted(season, registry) if missing_weeks else None
     if missing_weeks and inferred_full is not None:
         inferred = {wk: inferred_full.get(wk, []) for wk in missing_weeks}
         used_posted_inference = True
@@ -667,9 +670,7 @@ def compute_playoff_odds(
                     # 0.5 * ties`` key in ``_standings_from_sim``.
                     sim_ties[a] = sim_ties.get(a, 0) + 1
                     sim_ties[b] = sim_ties.get(b, 0) + 1
-        ordered = _standings_from_sim(
-            sim_wins, sim_pf, owners_in_league, ties=sim_ties
-        )
+        ordered = _standings_from_sim(sim_wins, sim_pf, owners_in_league, ties=sim_ties)
         for o in ordered[:spots]:
             made_counter[o] += 1
 

--- a/src/public_league/power.py
+++ b/src/public_league/power.py
@@ -31,6 +31,7 @@ Output shape
 ``currentRanking``    — rankings of the most recently completed week.
 ``methodology``       — human-readable formula.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -75,9 +76,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
 
     # Track per-owner running totals across the ORDERED walk.  We iterate
     # oldest → newest so PPG accumulates chronologically.
-    seasons_sorted = sorted(
-        snapshot.seasons, key=lambda s: _season_sort_key(s.season)
-    )
+    seasons_sorted = sorted(snapshot.seasons, key=lambda s: _season_sort_key(s.season))
 
     # Cross-season continuous accumulators (career PPG-to-date).
     career_state: dict[str, dict[str, float | int]] = defaultdict(
@@ -148,21 +147,23 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                 record = f"{wins}-{losses}"
 
                 rid = luck._roster_id_for_owner(registry, season.league_id, oid)
-                rankings.append({
-                    "ownerId": oid,
-                    "displayName": metrics.display_name_for(snapshot, oid),
-                    "teamName": metrics.team_name(snapshot, season.league_id, rid),
-                    "power": round(power, 2),
-                    "components": {
-                        "pointsPerGame": round(ppg_vals[oid], 2),
-                        "pointsPerGamePct": round(ppg_pct, 4),
-                        "recentAvg": round(recent_vals[oid], 2),
-                        "recentAvgPct": round(recent_pct, 4),
-                        "allPlayWinPctThisWeek": round(ap_pct, 4),
-                    },
-                    "record": record,
-                    "games": games,
-                })
+                rankings.append(
+                    {
+                        "ownerId": oid,
+                        "displayName": metrics.display_name_for(snapshot, oid),
+                        "teamName": metrics.team_name(snapshot, season.league_id, rid),
+                        "power": round(power, 2),
+                        "components": {
+                            "pointsPerGame": round(ppg_vals[oid], 2),
+                            "pointsPerGamePct": round(ppg_pct, 4),
+                            "recentAvg": round(recent_vals[oid], 2),
+                            "recentAvgPct": round(recent_pct, 4),
+                            "allPlayWinPctThisWeek": round(ap_pct, 4),
+                        },
+                        "record": record,
+                        "games": games,
+                    }
+                )
 
             rankings.sort(key=lambda r: -r["power"])
             for i, r in enumerate(rankings):
@@ -173,29 +174,35 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
             for r in rankings:
                 prior_rank[r["ownerId"]] = r["rank"]
 
-            weeks_out.append({
-                "season": season.season,
-                "leagueId": season.league_id,
-                "week": wk,
-                "rankings": rankings,
-            })
+            weeks_out.append(
+                {
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    "week": wk,
+                    "rankings": rankings,
+                }
+            )
 
             for r in rankings:
-                series[r["ownerId"]].append({
-                    "season": season.season,
-                    "week": wk,
-                    "power": r["power"],
-                    "rank": r["rank"],
-                    "record": r["record"],
-                })
+                series[r["ownerId"]].append(
+                    {
+                        "season": season.season,
+                        "week": wk,
+                        "power": r["power"],
+                        "rank": r["rank"],
+                        "record": r["record"],
+                    }
+                )
 
     series_out = []
     for oid, pts in series.items():
-        series_out.append({
-            "ownerId": oid,
-            "displayName": metrics.display_name_for(snapshot, oid),
-            "points": pts,
-        })
+        series_out.append(
+            {
+                "ownerId": oid,
+                "displayName": metrics.display_name_for(snapshot, oid),
+                "points": pts,
+            }
+        )
 
     current_ranking = weeks_out[-1]["rankings"] if weeks_out else []
 

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -8,6 +8,7 @@ internals.
 The test suite pins this shape — adding a new field here requires
 updating ``tests/public_league/test_public_contract.py`` as well.
 """
+
 from __future__ import annotations
 
 from typing import Any, Callable
@@ -46,6 +47,7 @@ def _team_assignment_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     reuse the snapshot directly.
     """
     from src.api import team_assignment  # noqa: PLC0415
+
     return team_assignment.build_section(snapshot)
 
 
@@ -96,24 +98,28 @@ from src.ros import api as _ros_api  # noqa: E402
 def _ros_power_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     """Lazy-import wrapper for src.ros.power_v2."""
     from src.ros import power_v2  # noqa: PLC0415
+
     return power_v2.build_section(snapshot)
 
 
 def _ros_playoff_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     """Lazy-import wrapper for src.ros.playoff_sim."""
     from src.ros import playoff_sim  # noqa: PLC0415
+
     return playoff_sim.build_section(snapshot)
 
 
 def _ros_championship_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     """Lazy-import wrapper for src.ros.championship."""
     from src.ros import championship  # noqa: PLC0415
+
     return championship.build_section(snapshot)
 
 
 def _ros_trade_deadline_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     """Lazy-import wrapper for src.ros.trade_deadline."""
     from src.ros import trade_deadline  # noqa: PLC0415
+
     return trade_deadline.build_section(snapshot)
 
 
@@ -126,6 +132,7 @@ def _faab_analytics_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     consume it — only /waivers' upcoming FAAB recommender does.
     """
     from src.api import faab_analytics  # noqa: PLC0415
+
     return faab_analytics.build_section(snapshot)
 
 
@@ -157,9 +164,7 @@ _LAZY_SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any
 OVERVIEW_SECTION = "overview"
 
 PUBLIC_SECTION_KEYS: tuple[str, ...] = (
-    (OVERVIEW_SECTION,)
-    + tuple(_SECTION_BUILDERS.keys())
-    + tuple(_LAZY_SECTION_BUILDERS.keys())
+    (OVERVIEW_SECTION,) + tuple(_SECTION_BUILDERS.keys()) + tuple(_LAZY_SECTION_BUILDERS.keys())
 )
 
 # Subset of ``PUBLIC_SECTION_KEYS`` that have matching CSV exporters
@@ -170,9 +175,7 @@ PUBLIC_SECTION_KEYS: tuple[str, ...] = (
 # check and then raise KeyError inside ``export_section``, returning
 # 503 for a section the API appears to advertise as valid.  Per
 # Codex PR #215 round 4.
-PUBLIC_CSV_EXPORTABLE_KEYS: tuple[str, ...] = (
-    (OVERVIEW_SECTION,) + tuple(_SECTION_BUILDERS.keys())
-)
+PUBLIC_CSV_EXPORTABLE_KEYS: tuple[str, ...] = (OVERVIEW_SECTION,) + tuple(_SECTION_BUILDERS.keys())
 
 
 # Field name blocklist.  These substrings MUST NOT appear as dict keys
@@ -204,7 +207,6 @@ _PRIVATE_FIELD_BLOCKLIST: frozenset[str] = frozenset(
         "rankings_override",
         "tepMultiplier",
         "tep_multiplier",
-
         # Private edge / trade internals
         "edge",
         "edgeSignals",
@@ -230,7 +232,6 @@ _PRIVATE_FIELD_BLOCKLIST: frozenset[str] = frozenset(
         "waiver_gems",
         "arbitrageScore",
         "arbitrage_score",
-
         # Scraper / pipeline internals
         "rawSources",
         "raw_sources",
@@ -251,9 +252,7 @@ def assert_public_payload_safe(payload: Any, path: str = "$") -> None:
             if not isinstance(key, str):
                 continue
             if key.lower() in _PRIVATE_FIELD_BLOCKLIST:
-                raise AssertionError(
-                    f"Public payload contains blocked field {key!r} at {path}"
-                )
+                raise AssertionError(f"Public payload contains blocked field {key!r} at {path}")
             assert_public_payload_safe(value, f"{path}.{key}")
     elif isinstance(payload, (list, tuple)):
         for i, item in enumerate(payload):

--- a/src/public_league/records.py
+++ b/src/public_league/records.py
@@ -15,6 +15,7 @@ Single-week records use individual-week side rows (no combined-finals
 fusion) so the highest single-week always reflects exactly one NFL week
 of scoring.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -94,32 +95,32 @@ def _weekly_side_rows_individual(snapshot: PublicLeagueSnapshot) -> list[dict[st
                     opp_pts = metrics.matchup_points(foe)
                     if my_pts <= 0:
                         continue
-                    owner_id = metrics.resolve_owner(
-                        snapshot.managers, season.league_id, rid
-                    )
+                    owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
                     if not owner_id:
                         continue
                     margin = my_pts - opp_pts
                     result = "W" if margin > 0 else ("L" if margin < 0 else "T")
-                    rows.append({
-                        "season": season.season,
-                        "leagueId": season.league_id,
-                        "week": week,
-                        "isPlayoff": is_playoff,
-                        "ownerId": owner_id,
-                        "rosterId": rid,
-                        "teamName": metrics.team_name(
-                            snapshot, season.league_id, rid
-                        ),
-                        "points": round(my_pts, 2),
-                        "opponentPoints": round(opp_pts, 2),
-                        "margin": round(margin, 2),
-                        "result": result,
-                    })
+                    rows.append(
+                        {
+                            "season": season.season,
+                            "leagueId": season.league_id,
+                            "week": week,
+                            "isPlayoff": is_playoff,
+                            "ownerId": owner_id,
+                            "rosterId": rid,
+                            "teamName": metrics.team_name(snapshot, season.league_id, rid),
+                            "points": round(my_pts, 2),
+                            "opponentPoints": round(opp_pts, 2),
+                            "margin": round(margin, 2),
+                            "result": result,
+                        }
+                    )
     return rows
 
 
-def _top_n(rows: list[dict[str, Any]], key: str, reverse: bool = True, n: int = 10) -> list[dict[str, Any]]:
+def _top_n(
+    rows: list[dict[str, Any]], key: str, reverse: bool = True, n: int = 10
+) -> list[dict[str, Any]]:
     return sorted(rows, key=lambda r: r[key], reverse=reverse)[:n]
 
 
@@ -145,17 +146,21 @@ def _streaks(snapshot: PublicLeagueSnapshot) -> tuple[list[dict[str, Any]], list
                 result = "L"
             else:
                 result = "T"
-            by_owner.setdefault(owner_id, []).append((
-                season.season, week, result,
-                {
-                    "season": season.season,
-                    "leagueId": season.league_id,
-                    "week": week,
-                    "result": result,
-                    "rosterId": rid,
-                    "teamName": metrics.team_name(snapshot, season.league_id, rid),
-                },
-            ))
+            by_owner.setdefault(owner_id, []).append(
+                (
+                    season.season,
+                    week,
+                    result,
+                    {
+                        "season": season.season,
+                        "leagueId": season.league_id,
+                        "week": week,
+                        "result": result,
+                        "rosterId": rid,
+                        "teamName": metrics.team_name(snapshot, season.league_id, rid),
+                    },
+                )
+            )
 
     # Sort each owner's games chronologically.  We order by (season-year,
     # week) — seasons are snapshot order current → previous, so convert
@@ -199,17 +204,21 @@ def _streaks(snapshot: PublicLeagueSnapshot) -> tuple[list[dict[str, Any]], list
                 cur_loss = {"length": 0, "start": None, "end": None}
 
         if best_win["length"] > 0:
-            win_streaks.append({
-                "ownerId": owner_id,
-                "displayName": metrics.display_name_for(snapshot, owner_id),
-                **best_win,
-            })
+            win_streaks.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": metrics.display_name_for(snapshot, owner_id),
+                    **best_win,
+                }
+            )
         if best_loss["length"] > 0:
-            loss_streaks.append({
-                "ownerId": owner_id,
-                "displayName": metrics.display_name_for(snapshot, owner_id),
-                **best_loss,
-            })
+            loss_streaks.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": metrics.display_name_for(snapshot, owner_id),
+                    **best_loss,
+                }
+            )
 
     win_streaks.sort(key=lambda r: -r["length"])
     loss_streaks.sort(key=lambda r: -r["length"])
@@ -238,7 +247,11 @@ def _trade_waiver_counts(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]
                 player_id = player_ids[0] if player_ids else ""
                 roster_ids = tx.get("roster_ids") or []
                 rid = int(roster_ids[0]) if roster_ids else None
-                owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid) if rid is not None else ""
+                owner_id = (
+                    metrics.resolve_owner(snapshot.managers, season.league_id, rid)
+                    if rid is not None
+                    else ""
+                )
                 max_faab_row = {
                     "season": season.season,
                     "leagueId": season.league_id,
@@ -248,13 +261,15 @@ def _trade_waiver_counts(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]
                     "playerId": player_id,
                     "playerName": snapshot.player_display(player_id),
                 }
-        out.append({
-            "season": season.season,
-            "leagueId": season.league_id,
-            "tradeCount": trades,
-            "waiverCount": waivers,
-            "maxFaab": max_faab_row,
-        })
+        out.append(
+            {
+                "season": season.season,
+                "leagueId": season.league_id,
+                "tradeCount": trades,
+                "waiverCount": waivers,
+                "maxFaab": max_faab_row,
+            }
+        )
     return out
 
 
@@ -271,11 +286,7 @@ def _season_scoring_totals(
     """
     by_key: dict[tuple[str, str], dict[str, Any]] = {}
     for season in snapshot.seasons:
-        weeks = (
-            season.regular_season_weeks
-            if regular_season_only
-            else season.all_weeks
-        )
+        weeks = season.regular_season_weeks if regular_season_only else season.all_weeks
         for wk in weeks:
             for a, b in metrics.matchup_pairs(season.matchups_by_week.get(wk) or []):
                 for me, foe in ((a, b), (b, a)):
@@ -288,14 +299,17 @@ def _season_scoring_totals(
                     if not owner_id:
                         continue
                     key = (owner_id, season.season)
-                    rec = by_key.setdefault(key, {
-                        "ownerId": owner_id,
-                        "season": season.season,
-                        "leagueId": season.league_id,
-                        "weeksPlayed": 0,
-                        "totalPoints": 0.0,
-                        "totalPointsAgainst": 0.0,
-                    })
+                    rec = by_key.setdefault(
+                        key,
+                        {
+                            "ownerId": owner_id,
+                            "season": season.season,
+                            "leagueId": season.league_id,
+                            "weeksPlayed": 0,
+                            "totalPoints": 0.0,
+                            "totalPointsAgainst": 0.0,
+                        },
+                    )
                     rec["weeksPlayed"] += 1
                     rec["totalPoints"] += metrics.matchup_points(me)
                     rec["totalPointsAgainst"] += metrics.matchup_points(foe)
@@ -330,9 +344,7 @@ def _player_records(snapshot: PublicLeagueSnapshot) -> dict[str, list[dict[str, 
                 rid = metrics.roster_id_of(entry)
                 if rid is None:
                     continue
-                owner_id = metrics.resolve_owner(
-                    snapshot.managers, season.league_id, rid
-                )
+                owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
                 if not owner_id:
                     continue
                 pp = entry.get("players_points")
@@ -357,20 +369,22 @@ def _player_records(snapshot: PublicLeagueSnapshot) -> dict[str, list[dict[str, 
                     # when the headshot 403s for an obscure player.
                     nfl_player = snapshot.nfl_players.get(str(pid)) or {}
                     nfl_team = str(nfl_player.get("team") or "").upper()
-                    by_position[pos].append({
-                        "season": season.season,
-                        "leagueId": season.league_id,
-                        "week": week,
-                        "ownerId": owner_id,
-                        "rosterId": rid,
-                        "teamName": metrics.team_name(snapshot, season.league_id, rid),
-                        "displayName": metrics.display_name_for(snapshot, owner_id),
-                        "playerId": pid,
-                        "playerName": snapshot.player_display(pid),
-                        "team": nfl_team,
-                        "position": pos,
-                        "points": round(pts, 2),
-                    })
+                    by_position[pos].append(
+                        {
+                            "season": season.season,
+                            "leagueId": season.league_id,
+                            "week": week,
+                            "ownerId": owner_id,
+                            "rosterId": rid,
+                            "teamName": metrics.team_name(snapshot, season.league_id, rid),
+                            "displayName": metrics.display_name_for(snapshot, owner_id),
+                            "playerId": pid,
+                            "playerName": snapshot.player_display(pid),
+                            "team": nfl_team,
+                            "position": pos,
+                            "points": round(pts, 2),
+                        }
+                    )
 
     out: dict[str, list[dict[str, Any]]] = {}
     for pos, rows in by_position.items():
@@ -380,7 +394,9 @@ def _player_records(snapshot: PublicLeagueSnapshot) -> dict[str, list[dict[str, 
     return out
 
 
-def _playoff_records(side_rows: list[dict[str, Any]], snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+def _playoff_records(
+    side_rows: list[dict[str, Any]], snapshot: PublicLeagueSnapshot
+) -> dict[str, Any]:
     playoff_rows = [r for r in side_rows if r["isPlayoff"]]
     most_points = _top_n(playoff_rows, "points", reverse=True, n=5)
 

--- a/src/public_league/rivalries.py
+++ b/src/public_league/rivalries.py
@@ -15,6 +15,7 @@ Rivalry index =
   + 1 * total_meetings
   + 2 * meetings_in_most_recent_season
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -142,7 +143,8 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         if rec["biggestBlowout"] is None or margin_abs > rec["biggestBlowout"]["margin"]:
             rec["biggestBlowout"] = meeting
         if rec["lastMeeting"] is None or (season.season, week) > (
-            rec["lastMeeting"]["season"], rec["lastMeeting"]["week"],
+            rec["lastMeeting"]["season"],
+            rec["lastMeeting"]["week"],
         ):
             rec["lastMeeting"] = meeting
 

--- a/src/public_league/sleeper_client.py
+++ b/src/public_league/sleeper_client.py
@@ -18,6 +18,7 @@ Network layer:
     handshakes.  Drops cold-fetch from ~0.65s to ~0.25s against the
     live Sleeper chain.
 """
+
 from __future__ import annotations
 
 import logging
@@ -112,6 +113,7 @@ def _cache_get(url: str) -> Any | None:
     if _CACHE_TTL_SECONDS <= 0:
         return None
     import time as _time
+
     now = _time.time()
     with _request_cache_lock:
         entry = _request_cache.get(url)
@@ -131,6 +133,7 @@ def _cache_put(url: str, payload: Any) -> None:
         # Don't cache failures — we want the next call to retry.
         return
     import time as _time
+
     with _request_cache_lock:
         _request_cache[url] = (_time.time(), payload)
 
@@ -254,7 +257,9 @@ def reset_nfl_players_cache() -> None:
     _nfl_players_cache = None
 
 
-def walk_league_chain(start_league_id: str, max_seasons: int = PUBLIC_MAX_SEASONS) -> list[dict[str, Any]]:
+def walk_league_chain(
+    start_league_id: str, max_seasons: int = PUBLIC_MAX_SEASONS
+) -> list[dict[str, Any]]:
     """Follow ``previous_league_id`` links up to ``max_seasons`` hops.
 
     Returns a list of league objects ordered current → previous.  When

--- a/src/public_league/snapshot.py
+++ b/src/public_league/snapshot.py
@@ -21,6 +21,7 @@ so the wall-clock drops from ~8 s sequential to ~400 ms.  The
 executor is scoped to each ``build_public_snapshot`` call so there's
 no global shared state.
 """
+
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
@@ -53,6 +54,7 @@ DEFAULT_PLAYOFF_WEEK_START = 15
 @dataclass
 class SeasonSnapshot:
     """All Sleeper data the public pipeline needs for one season."""
+
     season: str
     league_id: str
     league: dict[str, Any]
@@ -146,6 +148,7 @@ class SeasonSnapshot:
 @dataclass
 class PublicLeagueSnapshot:
     """Top-level public snapshot — one per request (cheap to rebuild)."""
+
     root_league_id: str
     generated_at: str
     seasons: list[SeasonSnapshot] = field(default_factory=list)
@@ -209,9 +212,7 @@ class PublicLeagueSnapshot:
         # to the raw position string (QB/RB/WR/TE/K).
         from src.utils.name_clean import resolve_idp_position
 
-        idp = resolve_idp_position(
-            p.get("fantasy_positions"), p.get("position")
-        )
+        idp = resolve_idp_position(p.get("fantasy_positions"), p.get("position"))
         if idp:
             return idp
         return str(p.get("position") or "").upper()

--- a/src/public_league/snapshot_store.py
+++ b/src/public_league/snapshot_store.py
@@ -11,6 +11,7 @@ Files:
     data/public_league/identity.json   — compact manager registry
     data/public_league/nfl_players.json — cached players/nfl dump
 """
+
 from __future__ import annotations
 
 import json
@@ -124,7 +125,9 @@ def _registry_from_dict(d: dict[str, Any]) -> ManagerRegistry:
     return reg
 
 
-def snapshot_to_dict(snapshot: PublicLeagueSnapshot, include_nfl_players: bool = False) -> dict[str, Any]:
+def snapshot_to_dict(
+    snapshot: PublicLeagueSnapshot, include_nfl_players: bool = False
+) -> dict[str, Any]:
     out: dict[str, Any] = {
         "rootLeagueId": snapshot.root_league_id,
         "generatedAt": snapshot.generated_at,

--- a/src/public_league/streaks.py
+++ b/src/public_league/streaks.py
@@ -23,6 +23,7 @@ Output shape
 ``seasonsCovered``      — passthrough.
 ``currentSeason``       — passthrough.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -59,9 +60,7 @@ def _all_events(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
             opp_pts = metrics.matchup_points(foe)
             if my_pts <= 0 and opp_pts <= 0:
                 continue
-            owner_id = metrics.resolve_owner(
-                snapshot.managers, season.league_id, rid
-            )
+            owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
             if not owner_id:
                 continue
             if my_pts > opp_pts:
@@ -70,17 +69,19 @@ def _all_events(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
                 result = "L"
             else:
                 result = "T"
-            out.append({
-                "ownerId": owner_id,
-                "season": season.season,
-                "leagueId": season.league_id,
-                "week": week,
-                "isPlayoff": is_playoff,
-                "points": round(my_pts, 2),
-                "opponentPoints": round(opp_pts, 2),
-                "margin": round(my_pts - opp_pts, 2),
-                "result": result,
-            })
+            out.append(
+                {
+                    "ownerId": owner_id,
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    "week": week,
+                    "isPlayoff": is_playoff,
+                    "points": round(my_pts, 2),
+                    "opponentPoints": round(opp_pts, 2),
+                    "margin": round(my_pts - opp_pts, 2),
+                    "result": result,
+                }
+            )
     out.sort(key=_chron_key)
     return out
 
@@ -225,17 +226,21 @@ def _longest_streaks_per_owner(
                 w_start = None
                 l_start = None
         if best_w["length"] > 0:
-            win_rows.append({
-                "ownerId": owner_id,
-                "displayName": metrics.display_name_for(snapshot, owner_id),
-                **best_w,
-            })
+            win_rows.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": metrics.display_name_for(snapshot, owner_id),
+                    **best_w,
+                }
+            )
         if best_l["length"] > 0:
-            loss_rows.append({
-                "ownerId": owner_id,
-                "displayName": metrics.display_name_for(snapshot, owner_id),
-                **best_l,
-            })
+            loss_rows.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": metrics.display_name_for(snapshot, owner_id),
+                    **best_l,
+                }
+            )
     win_rows.sort(key=lambda r: -r["length"])
     loss_rows.sort(key=lambda r: -r["length"])
     return win_rows, loss_rows
@@ -290,65 +295,72 @@ def _notable_this_week(
 
     notables: list[dict[str, Any]] = []
     this_week_events = [
-        e for e in events
-        if e["season"] == latest_season and e["week"] == latest_week
+        e for e in events if e["season"] == latest_season and e["week"] == latest_week
     ]
     for ev in this_week_events:
         display = metrics.display_name_for(snapshot, ev["ownerId"])
         hi_rank = _rank_of(ev, by_points_hi)
         if hi_rank and hi_rank <= _RECORDS_IN_REACH_TOP_N:
-            notables.append({
-                "category": "highestSingleWeek",
-                "rank": hi_rank,
-                "label": _ordinal_label(hi_rank, "highest single-week score"),
-                "ownerId": ev["ownerId"],
-                "displayName": display,
-                "season": ev["season"],
-                "week": ev["week"],
-                "value": ev["points"],
-                "valueLabel": f"{ev['points']:.1f} pts",
-            })
-        lo_rank = _rank_of(ev, by_points_lo)
-        if lo_rank and lo_rank <= _RECORDS_IN_REACH_TOP_N:
-            notables.append({
-                "category": "lowestSingleWeek",
-                "rank": lo_rank,
-                "label": _ordinal_label(lo_rank, "lowest single-week score"),
-                "ownerId": ev["ownerId"],
-                "displayName": display,
-                "season": ev["season"],
-                "week": ev["week"],
-                "value": ev["points"],
-                "valueLabel": f"{ev['points']:.1f} pts",
-            })
-        if ev["margin"] > 0:
-            m_rank = _rank_of(ev, by_margin_hi)
-            if m_rank and m_rank <= _RECORDS_IN_REACH_TOP_N:
-                notables.append({
-                    "category": "biggestBlowout",
-                    "rank": m_rank,
-                    "label": _ordinal_label(m_rank, "biggest single-week margin"),
-                    "ownerId": ev["ownerId"],
-                    "displayName": display,
-                    "season": ev["season"],
-                    "week": ev["week"],
-                    "value": ev["margin"],
-                    "valueLabel": f"+{ev['margin']:.1f}",
-                })
-        if ev["result"] == "L":
-            bb_rank = _rank_of(ev, by_bad_beat)
-            if bb_rank and bb_rank <= _RECORDS_IN_REACH_TOP_N:
-                notables.append({
-                    "category": "badBeat",
-                    "rank": bb_rank,
-                    "label": _ordinal_label(bb_rank, "highest score in a loss"),
+            notables.append(
+                {
+                    "category": "highestSingleWeek",
+                    "rank": hi_rank,
+                    "label": _ordinal_label(hi_rank, "highest single-week score"),
                     "ownerId": ev["ownerId"],
                     "displayName": display,
                     "season": ev["season"],
                     "week": ev["week"],
                     "value": ev["points"],
-                    "valueLabel": f"{ev['points']:.1f} pts in L",
-                })
+                    "valueLabel": f"{ev['points']:.1f} pts",
+                }
+            )
+        lo_rank = _rank_of(ev, by_points_lo)
+        if lo_rank and lo_rank <= _RECORDS_IN_REACH_TOP_N:
+            notables.append(
+                {
+                    "category": "lowestSingleWeek",
+                    "rank": lo_rank,
+                    "label": _ordinal_label(lo_rank, "lowest single-week score"),
+                    "ownerId": ev["ownerId"],
+                    "displayName": display,
+                    "season": ev["season"],
+                    "week": ev["week"],
+                    "value": ev["points"],
+                    "valueLabel": f"{ev['points']:.1f} pts",
+                }
+            )
+        if ev["margin"] > 0:
+            m_rank = _rank_of(ev, by_margin_hi)
+            if m_rank and m_rank <= _RECORDS_IN_REACH_TOP_N:
+                notables.append(
+                    {
+                        "category": "biggestBlowout",
+                        "rank": m_rank,
+                        "label": _ordinal_label(m_rank, "biggest single-week margin"),
+                        "ownerId": ev["ownerId"],
+                        "displayName": display,
+                        "season": ev["season"],
+                        "week": ev["week"],
+                        "value": ev["margin"],
+                        "valueLabel": f"+{ev['margin']:.1f}",
+                    }
+                )
+        if ev["result"] == "L":
+            bb_rank = _rank_of(ev, by_bad_beat)
+            if bb_rank and bb_rank <= _RECORDS_IN_REACH_TOP_N:
+                notables.append(
+                    {
+                        "category": "badBeat",
+                        "rank": bb_rank,
+                        "label": _ordinal_label(bb_rank, "highest score in a loss"),
+                        "ownerId": ev["ownerId"],
+                        "displayName": display,
+                        "season": ev["season"],
+                        "week": ev["week"],
+                        "value": ev["points"],
+                        "valueLabel": f"{ev['points']:.1f} pts in L",
+                    }
+                )
     notables.sort(key=lambda n: (n["rank"], n["category"]))
     return notables
 
@@ -373,18 +385,20 @@ def _records_in_reach(
     scored = [e for e in events if e["points"] > 0]
     if scored:
         holder_ev = max(scored, key=lambda e: e["points"])
-        records.append({
-            "category": "highestSingleWeek",
-            "label": "Highest single-week score",
-            "holder": {
-                "ownerId": holder_ev["ownerId"],
-                "displayName": metrics.display_name_for(snapshot, holder_ev["ownerId"]),
-                "value": holder_ev["points"],
-                "valueLabel": f"{holder_ev['points']:.1f} pts",
-                "season": holder_ev["season"],
-                "week": holder_ev["week"],
-            },
-        })
+        records.append(
+            {
+                "category": "highestSingleWeek",
+                "label": "Highest single-week score",
+                "holder": {
+                    "ownerId": holder_ev["ownerId"],
+                    "displayName": metrics.display_name_for(snapshot, holder_ev["ownerId"]),
+                    "value": holder_ev["points"],
+                    "valueLabel": f"{holder_ev['points']:.1f} pts",
+                    "season": holder_ev["season"],
+                    "week": holder_ev["week"],
+                },
+            }
+        )
         current_year = snapshot.current_season.season if snapshot.current_season else None
         current = [e for e in scored if e["season"] == current_year]
         if current:
@@ -398,7 +412,8 @@ def _records_in_reach(
                     "season": chaser["season"],
                     "week": chaser["week"],
                     "gap": round(holder_ev["points"] - chaser["points"], 2),
-                    "withinReach": chaser["points"] >= holder_ev["points"] * _NEAR_RECORD_POINTS_PCT,
+                    "withinReach": chaser["points"]
+                    >= holder_ev["points"] * _NEAR_RECORD_POINTS_PCT,
                 }
 
     # Longest win streak.
@@ -478,47 +493,55 @@ def _current_streaks_per_owner(
         display = metrics.display_name_for(snapshot, owner_id)
         owner_events = by_owner.get(owner_id) or []
         if not owner_events:
-            rows.append({
-                "ownerId": owner_id,
-                "displayName": display,
-                "type": "none",
-                "length": 0,
-                "start": None,
-                "end": None,
-            })
+            rows.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": display,
+                    "type": "none",
+                    "length": 0,
+                    "start": None,
+                    "end": None,
+                }
+            )
             continue
         owner_events.sort(key=_chron_key)
         rev = list(reversed(owner_events))
         latest = rev[0]
         if latest["result"] == "W":
             length, start, end = _trailing_run(rev, lambda e: e["result"] == "W")
-            rows.append({
-                "ownerId": owner_id,
-                "displayName": display,
-                "type": "winStreak",
-                "length": length,
-                "start": start,
-                "end": end,
-            })
+            rows.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": display,
+                    "type": "winStreak",
+                    "length": length,
+                    "start": start,
+                    "end": end,
+                }
+            )
         elif latest["result"] == "L":
             length, start, end = _trailing_run(rev, lambda e: e["result"] == "L")
-            rows.append({
-                "ownerId": owner_id,
-                "displayName": display,
-                "type": "lossStreak",
-                "length": length,
-                "start": start,
-                "end": end,
-            })
+            rows.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": display,
+                    "type": "lossStreak",
+                    "length": length,
+                    "start": start,
+                    "end": end,
+                }
+            )
         else:
-            rows.append({
-                "ownerId": owner_id,
-                "displayName": display,
-                "type": "tie",
-                "length": 0,
-                "start": None,
-                "end": latest,
-            })
+            rows.append(
+                {
+                    "ownerId": owner_id,
+                    "displayName": display,
+                    "type": "tie",
+                    "length": 0,
+                    "start": None,
+                    "end": latest,
+                }
+            )
     type_priority = {"winStreak": 0, "lossStreak": 1, "tie": 2, "none": 3}
     rows.sort(key=lambda r: (type_priority.get(r["type"], 99), -r["length"]))
     return rows
@@ -545,9 +568,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     return {
         "seasonsCovered": [s.season for s in snapshot.seasons],
         "currentSeason": snapshot.current_season.season if snapshot.current_season else None,
-        "latestWeek": (
-            {"season": latest[0], "week": latest[1]} if latest else None
-        ),
+        "latestWeek": ({"season": latest[0], "week": latest[1]} if latest else None),
         "activeStreaks": active_flat,
         "activeStreaksByType": {
             k: v for k, v in active.items() if k in ("winStreak", "lossStreak")

--- a/src/public_league/superlatives.py
+++ b/src/public_league/superlatives.py
@@ -23,6 +23,7 @@ Tiebreaks use additional roster-composition counts, then weighted
 pick score, then owner_id alpha order for determinism.  No private
 rank / value is ever exposed on the output.
 """
+
 from __future__ import annotations
 
 import math
@@ -121,7 +122,9 @@ def _pick_weight_totals(snapshot: PublicLeagueSnapshot) -> dict[str, int]:
     }
 
 
-def _ranking(rows: list[dict[str, Any]], key_primary, key_tiebreak_1=None, key_tiebreak_2=None) -> list[dict[str, Any]]:
+def _ranking(
+    rows: list[dict[str, Any]], key_primary, key_tiebreak_1=None, key_tiebreak_2=None
+) -> list[dict[str, Any]]:
     def sort_key(row):
         tb1 = key_tiebreak_1(row) if key_tiebreak_1 else 0
         tb2 = key_tiebreak_2(row) if key_tiebreak_2 else 0
@@ -137,33 +140,49 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
 
     rows = []
     for owner_id, comp in composition.items():
-        rows.append({
-            "ownerId": owner_id,
-            "displayName": metrics.display_name_for(snapshot, owner_id),
-            "rosterSize": comp["rosterSize"],
-            "qb": comp["qb"],
-            "rb": comp["rb"],
-            "wr": comp["wr"],
-            "te": comp["te"],
-            "idp": comp["idp"],
-            "rookies": comp["rookies"],
-            "trades": activity.get(owner_id, {}).get("trades", 0),
-            "waivers": activity.get(owner_id, {}).get("waivers", 0),
-            "weightedPickScore": weighted.get(owner_id, 0),
-            "balanceScore": round(_balance_score(comp), 4),
-        })
+        rows.append(
+            {
+                "ownerId": owner_id,
+                "displayName": metrics.display_name_for(snapshot, owner_id),
+                "rosterSize": comp["rosterSize"],
+                "qb": comp["qb"],
+                "rb": comp["rb"],
+                "wr": comp["wr"],
+                "te": comp["te"],
+                "idp": comp["idp"],
+                "rookies": comp["rookies"],
+                "trades": activity.get(owner_id, {}).get("trades", 0),
+                "waivers": activity.get(owner_id, {}).get("waivers", 0),
+                "weightedPickScore": weighted.get(owner_id, 0),
+                "balanceScore": round(_balance_score(comp), 4),
+            }
+        )
 
     def _winner(ranked: list[dict[str, Any]]) -> dict[str, Any] | None:
         return ranked[0] if ranked else None
 
-    by_qb = _ranking(rows, lambda r: r["qb"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"])
-    by_rb = _ranking(rows, lambda r: r["rb"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"])
-    by_wr = _ranking(rows, lambda r: r["wr"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"])
-    by_te = _ranking(rows, lambda r: r["te"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"])
-    by_idp = _ranking(rows, lambda r: r["idp"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"])
+    by_qb = _ranking(
+        rows, lambda r: r["qb"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"]
+    )
+    by_rb = _ranking(
+        rows, lambda r: r["rb"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"]
+    )
+    by_wr = _ranking(
+        rows, lambda r: r["wr"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"]
+    )
+    by_te = _ranking(
+        rows, lambda r: r["te"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"]
+    )
+    by_idp = _ranking(
+        rows, lambda r: r["idp"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"]
+    )
     by_picks = _ranking(rows, lambda r: r["weightedPickScore"], lambda r: r["rosterSize"])
-    by_rookies = _ranking(rows, lambda r: r["rookies"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"])
-    by_active = _ranking(rows, lambda r: r["trades"] + r["waivers"], lambda r: r["trades"], lambda r: r["waivers"])
+    by_rookies = _ranking(
+        rows, lambda r: r["rookies"], lambda r: r["rosterSize"], lambda r: r["weightedPickScore"]
+    )
+    by_active = _ranking(
+        rows, lambda r: r["trades"] + r["waivers"], lambda r: r["trades"], lambda r: r["waivers"]
+    )
     # future-focused: pick-heavy + rookie-heavy blended
     by_future = _ranking(
         rows,

--- a/src/public_league/weekly.py
+++ b/src/public_league/weekly.py
@@ -16,6 +16,7 @@ For every completed scoring week across the 2-season window:
 Pre-week standings: built using only games completed strictly before
 the week in question.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -25,7 +26,9 @@ from .rivalries import build_section as build_rivalries
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
 
-def _side_entry(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, entry: dict[str, Any]) -> dict[str, Any] | None:
+def _side_entry(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, entry: dict[str, Any]
+) -> dict[str, Any] | None:
     rid = metrics.roster_id_of(entry)
     if rid is None:
         return None
@@ -62,11 +65,16 @@ def _upset(snapshot, season, matchups, pre_lookup) -> dict[str, Any] | None:
             continue
         # An upset requires the winner had a worse record going in.
         if win_rec["winPct"] < lose_rec["winPct"]:
-            candidates.append((m, {
-                "gap": lose_rec["winPct"] - win_rec["winPct"],
-                "winnerPF": win_rec["pointsFor"],
-                "margin": m["margin"],
-            }))
+            candidates.append(
+                (
+                    m,
+                    {
+                        "gap": lose_rec["winPct"] - win_rec["winPct"],
+                        "winnerPF": win_rec["pointsFor"],
+                        "margin": m["margin"],
+                    },
+                )
+            )
     if not candidates:
         return None
     # Tiebreaks (per spec):
@@ -170,8 +178,10 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                     continue
                 if left["points"] == 0 and right["points"] == 0:
                     continue
-                winner = left if left["points"] > right["points"] else (
-                    right if right["points"] > left["points"] else None
+                winner = (
+                    left
+                    if left["points"] > right["points"]
+                    else (right if right["points"] > left["points"] else None)
                 )
                 loser = None
                 if winner is left:
@@ -215,29 +225,35 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                 post_standings = standings_at.get(wk, pre_standings)
             post_ranks = _standing_lookup(post_standings)
 
-            weeks_out.append({
-                "season": season.season,
-                "leagueId": season.league_id,
-                "week": wk,
-                "isPlayoff": is_playoff,
-                "matchups": [
-                    {k: v for k, v in r.items() if k in {"home", "away", "margin", "winnerOwnerId", "matchupId"}}
-                    for r in matchup_rows
-                ],
-                "highlights": {
-                    "gameOfTheWeek": _pack_highlight(closest),
-                    "blowoutOfTheWeek": _pack_highlight(biggest),
-                    "highestScorer": highest,
-                    "lowestScorer": lowest,
-                    "upsetOfTheWeek": _pack_highlight(
-                        _upset(snapshot, season, matchup_rows, pre_records)
-                    ),
-                    "rivalryResult": _pack_highlight(
-                        _rivalry_result(matchup_rows, featured_pair)
-                    ),
-                    "standingsMover": _standings_mover(pre_ranks, post_ranks),
-                },
-            })
+            weeks_out.append(
+                {
+                    "season": season.season,
+                    "leagueId": season.league_id,
+                    "week": wk,
+                    "isPlayoff": is_playoff,
+                    "matchups": [
+                        {
+                            k: v
+                            for k, v in r.items()
+                            if k in {"home", "away", "margin", "winnerOwnerId", "matchupId"}
+                        }
+                        for r in matchup_rows
+                    ],
+                    "highlights": {
+                        "gameOfTheWeek": _pack_highlight(closest),
+                        "blowoutOfTheWeek": _pack_highlight(biggest),
+                        "highestScorer": highest,
+                        "lowestScorer": lowest,
+                        "upsetOfTheWeek": _pack_highlight(
+                            _upset(snapshot, season, matchup_rows, pre_records)
+                        ),
+                        "rivalryResult": _pack_highlight(
+                            _rivalry_result(matchup_rows, featured_pair)
+                        ),
+                        "standingsMover": _standings_mover(pre_ranks, post_ranks),
+                    },
+                }
+            )
 
     weeks_out.sort(key=lambda w: (w["season"], w["week"]), reverse=True)
     return {
@@ -250,4 +266,8 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
 def _pack_highlight(row: dict[str, Any] | None) -> dict[str, Any] | None:
     if not row:
         return None
-    return {k: v for k, v in row.items() if k in {"home", "away", "margin", "winnerOwnerId", "matchupId"}}
+    return {
+        k: v
+        for k, v in row.items()
+        if k in {"home", "away", "margin", "winnerOwnerId", "matchupId"}
+    }

--- a/src/public_league/weekly_recap.py
+++ b/src/public_league/weekly_recap.py
@@ -23,6 +23,7 @@ Output shape
 ``byKey``           — flat ``{"<season>:<week>": recap}`` map for
                       O(1) lookup from the dynamic route.
 """
+
 from __future__ import annotations
 
 import random
@@ -32,7 +33,9 @@ from . import metrics
 from .snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
 
-def _side_entry(snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, entry: dict[str, Any]) -> dict[str, Any]:
+def _side_entry(
+    snapshot: PublicLeagueSnapshot, season: SeasonSnapshot, entry: dict[str, Any]
+) -> dict[str, Any]:
     rid = metrics.roster_id_of(entry)
     owner_id = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
     return {
@@ -70,19 +73,23 @@ def _weekly_trades_for(
         for rid in roster_ids:
             oid = metrics.resolve_owner(snapshot.managers, season.league_id, rid)
             if oid:
-                parties.append({
-                    "ownerId": oid,
-                    "displayName": metrics.display_name_for(snapshot, oid),
-                })
+                parties.append(
+                    {
+                        "ownerId": oid,
+                        "displayName": metrics.display_name_for(snapshot, oid),
+                    }
+                )
         adds = tx.get("adds")
         assets_moved = len(adds) if isinstance(adds, dict) else 0
         picks_moved = len(tx.get("draft_picks") or [])
-        out.append({
-            "transactionId": tx.get("transaction_id"),
-            "parties": parties,
-            "assetsMoved": assets_moved,
-            "picksMoved": picks_moved,
-        })
+        out.append(
+            {
+                "transactionId": tx.get("transaction_id"),
+                "parties": parties,
+                "assetsMoved": assets_moved,
+                "picksMoved": picks_moved,
+            }
+        )
     return out
 
 
@@ -137,9 +144,7 @@ def _matchup_oneliner(home: dict, away: dict, margin: float, seed: int) -> str:
         bank = _ROLL_PHRASES
     else:
         bank = _BEAT_PHRASES
-    return _choose(bank, seed).format(
-        w=winner["displayName"], l=loser["displayName"], m=margin
-    )
+    return _choose(bank, seed).format(w=winner["displayName"], l=loser["displayName"], m=margin)
 
 
 # ── Headline phrase banks ─────────────────────────────────────────────────
@@ -207,21 +212,22 @@ def _headline(recap: dict[str, Any], seed: int) -> str:
     # story (no mega-blowout, no nailbiter <2pts) AND three sides
     # cracked the 150-point mark together.  Keeps it a niche fallback
     # rather than overwriting a real headline opportunity.
-    bigly = (blowout and blowout["margin"] >= 40)
-    super_close = (nailbiter and nailbiter["margin"] < 2)
-    if (
-        not bigly
-        and not super_close
-        and len(top) >= 3
-        and all(s["points"] >= 150 for s in top[:3])
-    ):
+    bigly = blowout and blowout["margin"] >= 40
+    super_close = nailbiter and nailbiter["margin"] < 2
+    if not bigly and not super_close and len(top) >= 3 and all(s["points"] >= 150 for s in top[:3]):
         names = ", ".join(s["displayName"] for s in top[:3])
         return _choose(_TRIPLE_LEADER_HEADLINES, seed).format(
-            leaders=names, threshold=150,
+            leaders=names,
+            threshold=150,
         )
 
     # MVP + blowout from the same manager: "stat torched in a blowout".
-    if mvp and blowout and mvp.get("ownerId") == blowout["winner"]["ownerId"] and blowout["margin"] >= 25:
+    if (
+        mvp
+        and blowout
+        and mvp.get("ownerId") == blowout["winner"]["ownerId"]
+        and blowout["margin"] >= 25
+    ):
         return _choose(_MVP_AND_BLOWOUT_HEADLINES, seed).format(
             name=mvp["displayName"], pts=mvp["points"], m=blowout["margin"]
         )
@@ -246,9 +252,7 @@ def _headline(recap: dict[str, Any], seed: int) -> str:
             m=blowout["margin"],
         )
     if mvp:
-        return _choose(_MVP_HEADLINES, seed).format(
-            name=mvp["displayName"], pts=mvp["points"]
-        )
+        return _choose(_MVP_HEADLINES, seed).format(name=mvp["displayName"], pts=mvp["points"])
     return _choose(_FALLBACK_HEADLINES, seed)
 
 
@@ -394,8 +398,10 @@ def _summary(recap: dict[str, Any], seed: int) -> str:
                 m=blowout["margin"],
             )
         )
-    if nailbiter and nailbiter["margin"] < 5 and (
-        not blowout or nailbiter["margin"] != blowout["margin"]
+    if (
+        nailbiter
+        and nailbiter["margin"] < 5
+        and (not blowout or nailbiter["margin"] != blowout["margin"])
     ):
         parts.append(
             _choose(_NAILBITER_LINES, seed + 3).format(
@@ -417,10 +423,7 @@ def _summary(recap: dict[str, Any], seed: int) -> str:
     # Skip the top-3 line when the MVP line above already names the
     # #1 unless margin between #1 and #3 is meaningful (avoid feeling
     # repetitive).
-    if (
-        len(top) >= 3
-        and (top[0]["points"] - top[2]["points"]) >= 15.0
-    ):
+    if len(top) >= 3 and (top[0]["points"] - top[2]["points"]) >= 15.0:
         parts.append(
             _choose(_TOP3_LINES, seed + 8).format(
                 a=top[0]["displayName"],
@@ -436,7 +439,7 @@ def _summary(recap: dict[str, Any], seed: int) -> str:
     # 100-pt threshold = "low" baseline; tuned for SF + TEP fantasy
     # scoring where 110-150 is a typical pace.
     if matchups and len(top) >= 2:
-        sides_total = len(top) + sum(2 for _ in matchups[len(top):])
+        sides_total = len(top) + sum(2 for _ in matchups[len(top) :])
         side_count = max(1, len(top) + 2 * max(0, len(matchups) - len(top) // 2))
         avg_side = scored_total / max(1, 2 * len(matchups))
         if avg_side >= 130:
@@ -485,9 +488,7 @@ def _summary(recap: dict[str, Any], seed: int) -> str:
     trades_count = len(recap.get("trades") or [])
     if trades_count:
         plural = "trade" if trades_count == 1 else "trades"
-        parts.append(
-            _choose(_TRADE_LINES, seed + 7).format(n=trades_count, plural=plural)
-        )
+        parts.append(_choose(_TRADE_LINES, seed + 7).format(n=trades_count, plural=plural))
 
     return " ".join(parts)
 
@@ -501,10 +502,7 @@ def _build_week_recap(
     pairs = metrics.matchup_pairs(entries)
     if not pairs:
         return None
-    scored_pairs = [
-        (a, b) for a, b in pairs
-        if metrics.is_scored(a) or metrics.is_scored(b)
-    ]
+    scored_pairs = [(a, b) for a, b in pairs if metrics.is_scored(a) or metrics.is_scored(b)]
     if not scored_pairs:
         return None
 
@@ -592,9 +590,7 @@ def _build_week_recap(
     # Top-3 weekly performers — used by the UI to render a small
     # leaderboard and by the summary phrase bank for "three teams
     # cracked X+" framing.
-    top_performers = sorted(
-        all_sides, key=lambda s: -s["points"]
-    )[:3]
+    top_performers = sorted(all_sides, key=lambda s: -s["points"])[:3]
 
     recap: dict[str, Any] = {
         "season": season.season,
@@ -616,9 +612,7 @@ def _build_week_recap(
 
 
 def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
-    seasons_sorted = sorted(
-        snapshot.seasons, key=lambda s: _season_sort_key(s.season)
-    )
+    seasons_sorted = sorted(snapshot.seasons, key=lambda s: _season_sort_key(s.season))
 
     weeks_out: list[dict[str, Any]] = []
     by_key: dict[str, dict[str, Any]] = {}

--- a/src/ros/__init__.py
+++ b/src/ros/__init__.py
@@ -33,6 +33,7 @@ ranking source registry.  ``tests/ros/test_isolation.py`` snapshots the
 dynasty contract output before+after importing this package and asserts
 byte-identical results.
 """
+
 from __future__ import annotations
 
 __all__ = ["ROS_DATA_DIR"]

--- a/src/ros/aggregate.py
+++ b/src/ros/aggregate.py
@@ -30,6 +30,7 @@ Outputs:
 The aggregator is pure — no I/O, no globals.  Storage / scheduling lives
 in ``src/ros/scrape.py`` and ``src/ros/api.py``.
 """
+
 from __future__ import annotations
 
 import statistics
@@ -114,16 +115,12 @@ def aggregate(
     for snap in snaps:
         if not snap.rows:
             continue
-        is_stale_source = (
-            snap.status not in ("ok", "partial") and snap.has_valid_cache
-        )
+        is_stale_source = snap.status not in ("ok", "partial") and snap.has_valid_cache
         # Weight is computed once per (source, player_position) bucket.
         # For PR1 we treat IDP-vs-offense as the only position split
         # that affects the format-match multiplier; sub-position
         # adjustments come in PR2/PR4.
-        sample_position = next(
-            (r.position for r in snap.rows if r.position), None
-        )
+        sample_position = next((r.position for r in snap.rows if r.position), None)
         weight = effective_source_weight(
             {
                 "base_weight": snap.base_weight,
@@ -202,13 +199,9 @@ def aggregate(
         # (% of contributors not stale).
         source_count_factor = min(1.0, len(acc.ranks) / 4.0)
         agreement_factor = max(0.0, 1.0 - stddev / 30.0)
-        freshness_factor = (
-            1.0 - (acc.stale_count / acc.total_count) if acc.total_count else 0.0
-        )
+        freshness_factor = 1.0 - (acc.stale_count / acc.total_count) if acc.total_count else 0.0
         confidence = round(
-            0.45 * source_count_factor
-            + 0.35 * agreement_factor
-            + 0.20 * freshness_factor,
+            0.45 * source_count_factor + 0.35 * agreement_factor + 0.20 * freshness_factor,
             3,
         )
         aggregated.append(

--- a/src/ros/api.py
+++ b/src/ros/api.py
@@ -14,6 +14,7 @@ Isolation invariant: this router writes to ``data/ros/*`` only.  It
 never touches ``data/exports/*``, ``CSVs/site_raw/*``, or any dynasty
 contract path.
 """
+
 from __future__ import annotations
 
 import json
@@ -51,9 +52,7 @@ def _registry_payload(overrides: dict[str, dict[str, Any]] | None = None) -> lis
     enabled = {s["key"] for s in enabled_ros_sources(overrides)}
     out: list[dict[str, Any]] = []
     for src in ROS_SOURCES:
-        public = {
-            k: v for k, v in src.items() if k not in {"scraper"}
-        }
+        public = {k: v for k, v in src.items() if k not in {"scraper"}}
         public["effectivelyEnabled"] = src["key"] in enabled
         out.append(public)
     return out
@@ -93,9 +92,7 @@ def _classify_overall_freshness(index: dict[str, Any]) -> str:
         when = datetime.fromisoformat(rebuilt.replace("Z", "+00:00"))
     except ValueError:
         return "unknown"
-    age_h = (
-        datetime.now(timezone.utc) - when.astimezone(timezone.utc)
-    ).total_seconds() / 3600
+    age_h = (datetime.now(timezone.utc) - when.astimezone(timezone.utc)).total_seconds() / 3600
     if age_h < 24:
         return "fresh"
     if age_h < 72:
@@ -108,9 +105,7 @@ async def get_player_values(limit: int = 500) -> JSONResponse:
     """Aggregated player values; defaults to top 500 by ros_value."""
     payload = _read_json(ROS_DATA_DIR / "aggregate" / "latest.json")
     if not payload:
-        return JSONResponse(
-            {"aggregatedAt": None, "players": [], "error": "no_aggregate"}
-        )
+        return JSONResponse({"aggregatedAt": None, "players": [], "error": "no_aggregate"})
     players = payload.get("players") or []
     return JSONResponse(
         {
@@ -136,6 +131,7 @@ async def get_team_strength(request: Request, leagueKey: str | None = None) -> J
     resolved_key = leagueKey
     try:
         from src.api.league_registry import get_league_by_key, default_league_key  # noqa: PLC0415
+
         if leagueKey:
             cfg = get_league_by_key(leagueKey)
             if cfg and cfg.key:
@@ -184,13 +180,9 @@ async def get_health() -> JSONResponse:
             when = datetime.fromisoformat(str(iso).replace("Z", "+00:00"))
         except ValueError:
             return None
-        return (
-            datetime.now(timezone.utc) - when.astimezone(timezone.utc)
-        ).total_seconds()
+        return (datetime.now(timezone.utc) - when.astimezone(timezone.utc)).total_seconds()
 
-    unmapped_total = sum(
-        int(t.get("unmappedPlayerCount") or 0) for t in team_strength
-    )
+    unmapped_total = sum(int(t.get("unmappedPlayerCount") or 0) for t in team_strength)
 
     return JSONResponse(
         {
@@ -199,8 +191,7 @@ async def get_health() -> JSONResponse:
             "sources": index.get("sources") or {},
             "aggregate": {
                 "aggregatedAt": aggregate.get("aggregatedAt"),
-                "playerCount": aggregate.get("playerCount")
-                or len(aggregate.get("players") or []),
+                "playerCount": aggregate.get("playerCount") or len(aggregate.get("players") or []),
                 "sourceCount": aggregate.get("sourceCount"),
                 "ageSeconds": _iso_to_age_seconds(aggregate.get("aggregatedAt")),
             },
@@ -293,6 +284,7 @@ def build_section(snapshot: Any) -> dict[str, Any]:
     league_key: str | None = None
     try:
         from src.api.league_registry import all_leagues  # noqa: PLC0415
+
         root_id = str(getattr(snapshot, "root_league_id", "") or "")
         if root_id:
             for cfg in all_leagues():

--- a/src/ros/championship.py
+++ b/src/ros/championship.py
@@ -29,6 +29,7 @@ Returns:
         "rosStrengthAvailable": bool,
     }
 """
+
 from __future__ import annotations
 
 import json
@@ -201,12 +202,8 @@ def simulate_championship_odds(
     playoff_count: dict[str, int] = {o: 0 for o in owners}
 
     for _ in range(n_simulations):
-        sim_wins: dict[str, float] = {
-            o: float(record.get(o, {}).get("wins", 0)) for o in owners
-        }
-        sim_pf: dict[str, float] = {
-            o: float(pf_by_owner.get(o, 0.0)) for o in owners
-        }
+        sim_wins: dict[str, float] = {o: float(record.get(o, {}).get("wins", 0)) for o in owners}
+        sim_pf: dict[str, float] = {o: float(pf_by_owner.get(o, 0.0)) for o in owners}
         for week, owner_a, owner_b in schedule:
             dist_a = distributions.get(owner_a)
             dist_b = distributions.get(owner_b)
@@ -279,6 +276,7 @@ def _load_cached_payload() -> dict[str, Any] | None:
     """Read ``data/ros/sims/latest_championship.json`` if fresh; else None."""
     import os
     import time
+
     path = ROS_DATA_DIR / "sims" / "latest_championship.json"
     if not path.exists():
         return None

--- a/src/ros/direction.py
+++ b/src/ros/direction.py
@@ -14,6 +14,7 @@ The classifier is deterministic — same inputs always produce the same
 label.  No mutation of dynasty values, trade math, or the player
 contract.  Read-only contender layer.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -102,16 +103,10 @@ def classify_team(
         )
     elif playoff_odds_pct < 0.25 and championship_odds_pct < 0.02:
         label = "Seller"
-        rec = (
-            "Sell aging win-now players.  Prioritize 2026/2027 picks "
-            "and 23-or-younger upside."
-        )
+        rec = "Sell aging win-now players.  Prioritize 2026/2027 picks " "and 23-or-younger upside."
     elif 0.20 <= playoff_odds_pct < 0.40:
         label = "Selective Seller"
-        rec = (
-            "Sell older short-term assets if strong offers arrive.  "
-            "Hold the youth core."
-        )
+        rec = "Sell older short-term assets if strong offers arrive.  " "Hold the youth core."
     else:
         label = "Hold / Evaluate"
         rec = (

--- a/src/ros/lineup.py
+++ b/src/ros/lineup.py
@@ -22,6 +22,7 @@ Slot eligibility map mirrors Sleeper's roster_positions naming:
     DL, LB, DB, IDP_FLEX (DL/LB/DB), DEF (team defense, ignored), K, BN
 
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -191,7 +192,7 @@ def optimize_lineup(
         seen = by_pos_seen.get(player.position.upper(), 0)
         # First bench player at a position counts fully; second decays
         # by `decay_per_player`; third by decay^2; etc.
-        depth_factor = decay_per_player ** seen
+        depth_factor = decay_per_player**seen
         adj_value = _value_with_health_penalty(player) * depth_factor
         bench_total += adj_value
         bench_rows.append(
@@ -212,12 +213,8 @@ def optimize_lineup(
     coverage_score = _positional_coverage(roster)
 
     # Health availability — share of starters not flagged injured/bye.
-    healthy_starters = sum(
-        1 for r in starting_rows if not r.get("flagged")
-    )
-    health_score = (
-        healthy_starters / len(starting_rows) * 100 if starting_rows else 0.0
-    )
+    healthy_starters = sum(1 for r in starting_rows if not r.get("flagged"))
+    health_score = healthy_starters / len(starting_rows) * 100 if starting_rows else 0.0
 
     return LineupSolution(
         starting_lineup_score=round(starting_total, 2),

--- a/src/ros/mapping.py
+++ b/src/ros/mapping.py
@@ -15,6 +15,7 @@ Confidence buckets (per spec):
 Manual overrides live at ``data/ros/mapping_overrides.json`` — entries
 there bypass the resolver entirely with confidence 1.0.
 """
+
 from __future__ import annotations
 
 import difflib
@@ -117,9 +118,7 @@ def resolve_player(
 
         # 4. Fuzzy match — single-typo / suffix variant.  Restricted to
         # ratio >= 0.92 so we don't silently fold distinct players.
-        candidates = difflib.get_close_matches(
-            normalized, canonical_universe, n=1, cutoff=0.92
-        )
+        candidates = difflib.get_close_matches(normalized, canonical_universe, n=1, cutoff=0.92)
         if candidates:
             return MappedPlayer(raw, candidates[0], 0.7, "fuzzy", position, team)
 

--- a/src/ros/parse.py
+++ b/src/ros/parse.py
@@ -14,6 +14,7 @@ Per the spec:
 These helpers are stateless so the aggregator + tests + future debugging
 tools all agree on a single canonical conversion.  No I/O here.
 """
+
 from __future__ import annotations
 
 import math

--- a/src/ros/playoff_sim.py
+++ b/src/ros/playoff_sim.py
@@ -33,6 +33,7 @@ Implementation overview:
   5. Apply tiebreaker (PF descending) and rank teams 1..N.
   6. Aggregate playoff appearance + bye + top-seed odds.
 """
+
 from __future__ import annotations
 
 import json
@@ -198,6 +199,7 @@ def _load_starter_slots() -> list[str]:
     best-ball presim then short-circuits to the empirical model."""
     try:
         from src.api.league_registry import get_default_league  # noqa: PLC0415
+
         cfg = get_default_league()
         if cfg is None or not cfg.roster_settings:
             return []
@@ -273,9 +275,15 @@ def _bestball_weekly_score(
     # Restrictive first prevents flex slots from grabbing positional
     # studs the dedicated slot would have used.
     slot_priority = {
-        "QB": 1, "RB": 2, "WR": 2, "TE": 2,
-        "DL": 3, "LB": 3, "DB": 3,
-        "FLEX": 4, "IDP_FLEX": 4,
+        "QB": 1,
+        "RB": 2,
+        "WR": 2,
+        "TE": 2,
+        "DL": 3,
+        "LB": 3,
+        "DB": 3,
+        "FLEX": 4,
+        "IDP_FLEX": 4,
         "SUPER_FLEX": 5,
     }
     slots_sorted = sorted(starter_slots, key=lambda s: slot_priority.get(s.upper(), 6))
@@ -359,15 +367,11 @@ def _build_team_distributions(
     ratio.  In start/sit leagues the bench doesn't feed weekly
     scoring, so the bump is 1.0 (no lift).
     """
-    seasons_sorted = sorted(
-        snapshot.seasons, key=luck._season_sort_key
-    )
+    seasons_sorted = sorted(snapshot.seasons, key=luck._season_sort_key)
     if not seasons_sorted:
         return {}, {}
     current_season = seasons_sorted[-1]
-    per_owner, pool = playoff_odds._season_weekly_scores(
-        current_season, snapshot.managers
-    )
+    per_owner, pool = playoff_odds._season_weekly_scores(current_season, snapshot.managers)
     pool_mean, pool_sd = _empirical_distribution(pool)
 
     # ROS strength scores are 0-100ish; convert to a per-owner z-score
@@ -423,9 +427,7 @@ def _build_team_distributions(
             blended_mean = emp_mean * (1 + ROS_BLEND * ros_z)
         else:
             blended_mean = emp_mean
-        variance_mult = _team_variance_multiplier(
-            owner_id, depth_ratios, best_ball
-        )
+        variance_mult = _team_variance_multiplier(owner_id, depth_ratios, best_ball)
         sd = emp_sd * variance_mult if emp_sd > 0 else pool_sd * variance_mult
         distributions[owner_id] = _TeamDist(
             owner_id=owner_id,
@@ -445,9 +447,7 @@ def _remaining_schedule(snapshot: PublicLeagueSnapshot) -> list[tuple[int, str, 
     The v1 helper returns ``{week: [(ownerA, ownerB), ...]}``; flatten
     to the triple form the simulator iterates.
     """
-    seasons_sorted = sorted(
-        snapshot.seasons, key=luck._season_sort_key
-    )
+    seasons_sorted = sorted(snapshot.seasons, key=luck._season_sort_key)
     if not seasons_sorted:
         return []
     season = seasons_sorted[-1]
@@ -463,15 +463,11 @@ def _current_record(
     snapshot: PublicLeagueSnapshot,
 ) -> dict[str, dict[str, float]]:
     """Wins/losses to date per owner."""
-    seasons_sorted = sorted(
-        snapshot.seasons, key=luck._season_sort_key
-    )
+    seasons_sorted = sorted(snapshot.seasons, key=luck._season_sort_key)
     if not seasons_sorted:
         return {}
     current = seasons_sorted[-1]
-    return playoff_odds._regular_season_record_to_date(
-        current, snapshot.managers
-    )
+    return playoff_odds._regular_season_record_to_date(current, snapshot.managers)
 
 
 def _league_best_ball() -> bool:
@@ -481,6 +477,7 @@ def _league_best_ball() -> bool:
     """
     try:
         from src.api.league_registry import get_default_league  # noqa: PLC0415
+
         cfg = get_default_league()
         return bool(cfg and cfg.best_ball)
     except Exception:  # noqa: BLE001
@@ -513,9 +510,7 @@ def simulate_playoff_odds(
     if best_ball is None:
         best_ball = _league_best_ball()
     ros_map = _load_ros_strength_map()
-    distributions, pf_by_owner = _build_team_distributions(
-        snapshot, ros_map, best_ball=best_ball
-    )
+    distributions, pf_by_owner = _build_team_distributions(snapshot, ros_map, best_ball=best_ball)
     if not distributions:
         return {
             "playoffOdds": [],
@@ -538,12 +533,8 @@ def simulate_playoff_odds(
     wins_total: dict[str, float] = {o: 0.0 for o in owners}
 
     for _ in range(n_simulations):
-        sim_wins: dict[str, float] = {
-            o: float(record.get(o, {}).get("wins", 0)) for o in owners
-        }
-        sim_pf: dict[str, float] = {
-            o: float(pf_by_owner.get(o, 0.0)) for o in owners
-        }
+        sim_wins: dict[str, float] = {o: float(record.get(o, {}).get("wins", 0)) for o in owners}
+        sim_pf: dict[str, float] = {o: float(pf_by_owner.get(o, 0.0)) for o in owners}
         for week, owner_a, owner_b in schedule:
             dist_a = distributions.get(owner_a)
             dist_b = distributions.get(owner_b)
@@ -629,6 +620,7 @@ _SIM_CACHE_TTL_SEC = 6 * 3600
 def _load_cached_payload() -> dict[str, Any] | None:
     """Read ``data/ros/sims/latest_playoff.json`` if fresh; else None."""
     import os
+
     path = ROS_DATA_DIR / "sims" / "latest_playoff.json"
     if not path.exists():
         return None
@@ -637,6 +629,7 @@ def _load_cached_payload() -> dict[str, Any] | None:
     except OSError:
         return None
     import time
+
     if (time.time() - age) > _SIM_CACHE_TTL_SEC:
         LOG.info("[ros] playoff cache stale (>%ds); rerunning sim", _SIM_CACHE_TTL_SEC)
         return None

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -45,6 +45,7 @@ when False, the existing ``power.py`` v1 still drives /league → Power.
 When True, /league → ROS Power renders this version side-by-side as
 the new "ROS Power" tab.
 """
+
 from __future__ import annotations
 
 import json
@@ -325,9 +326,10 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     seasons_sorted = sorted(snapshot.seasons, key=luck._season_sort_key)
     team_strength_rows = _load_team_strength_rows()
     preseason = _is_preseason(snapshot)
-    if not seasons_sorted and not team_strength_rows and (
-        snapshot.current_season is None
-        or not (snapshot.current_season.rosters or [])
+    if (
+        not seasons_sorted
+        and not team_strength_rows
+        and (snapshot.current_season is None or not (snapshot.current_season.rosters or []))
     ):
         return {
             "currentRanking": [],
@@ -377,9 +379,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                 ap = all_play.get(oid) or {}
                 last_season_allplay_share[oid] = float(ap.get("expectedShare", 0.0))
 
-    owner_ids = _enumerate_owner_ids(
-        snapshot, team_strength_rows, sorted(career_state.keys())
-    )
+    owner_ids = _enumerate_owner_ids(snapshot, team_strength_rows, sorted(career_state.keys()))
     if not owner_ids:
         return {
             "currentRanking": [],
@@ -428,7 +428,9 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                     ap = ap_week.get(oid) or {}
                     expected_share_running += float(ap.get("expectedShare", 0.0))
         luck_delta = (wins - expected_share_running) / games if games else 0.0
-        luck_score = max(0.0, min(1.0, 0.5 - luck_delta))  # underperformers get higher score (regression boost)
+        luck_score = max(
+            0.0, min(1.0, 0.5 - luck_delta)
+        )  # underperformers get higher score (regression boost)
 
         inputs[oid] = {
             "ppg": ppg,
@@ -462,9 +464,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         for component in _HISTORICAL_RESULTS_COMPONENTS:
             if component not in missing_inputs:
                 missing_inputs.append(component)
-    active_weights = {
-        k: v for k, v in WEIGHTS.items() if k not in missing_inputs
-    }
+    active_weights = {k: v for k, v in WEIGHTS.items() if k not in missing_inputs}
     weight_total = sum(active_weights.values()) or 1.0
 
     rankings: list[dict[str, Any]] = []
@@ -480,18 +480,14 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         }
         if ros_available:
             components["team_ros_strength"] = ros_pct.get(oid, 0.0)
-        components["schedule_adjusted"] = (
-            i["schedule_adjusted"] if schedule_available else 0.0
-        )
-        components["roster_health"] = (
-            i["roster_health"] if health_available else 0.0
-        )
+        components["schedule_adjusted"] = i["schedule_adjusted"] if schedule_available else 0.0
+        components["roster_health"] = i["roster_health"] if health_available else 0.0
 
         # Active weighted score in [0, 1], then scale to 100.
-        score_unit = sum(
-            active_weights.get(k, 0.0) * components.get(k, 0.0)
-            for k in active_weights
-        ) / weight_total
+        score_unit = (
+            sum(active_weights.get(k, 0.0) * components.get(k, 0.0) for k in active_weights)
+            / weight_total
+        )
         score = round(score_unit * 100, 2)
 
         ros_strength_pct = ros_pct.get(oid, None) if ros_available else None

--- a/src/ros/scrape.py
+++ b/src/ros/scrape.py
@@ -20,6 +20,7 @@ Failure isolation:
       ``data/ros/runs/index.json`` so the API can surface "all sources
       failed today; using yesterday's snapshot".
 """
+
 from __future__ import annotations
 
 import argparse
@@ -212,9 +213,8 @@ def _hydrate_overlay_players(
             # empty, which would poison the canonical lookup.
             full_name = (meta.get("full_name") or "").strip()
             if not full_name:
-                full_name = (
-                    f"{meta.get('first_name','')} {meta.get('last_name','')}".strip()
-                    or (names[i] if i < len(names) else pid_str)
+                full_name = f"{meta.get('first_name','')} {meta.get('last_name','')}".strip() or (
+                    names[i] if i < len(names) else pid_str
                 )
             position = (meta.get("position") or "").upper()
             injury = (meta.get("injury_status") or "").upper()
@@ -286,9 +286,7 @@ def _refresh_team_strength_for_league(
             )
             return None
         teams = _hydrate_overlay_players(overlay["teams"], nfl_players)
-        starter_slots = _flatten_starter_slots(
-            (cfg.roster_settings or {}).get("starters")
-        )
+        starter_slots = _flatten_starter_slots((cfg.roster_settings or {}).get("starters"))
         if not starter_slots:
             LOG.warning(
                 "[ros] team-strength %s: no starter slots configured",
@@ -303,17 +301,21 @@ def _refresh_team_strength_for_league(
         path = write_team_strength_snapshot(rows, league_key=cfg.key)
         LOG.info(
             "[ros] team-strength %s: wrote %d teams to %s",
-            cfg.key, len(rows), path,
+            cfg.key,
+            len(rows),
+            path,
         )
         return path
     except Exception as exc:  # noqa: BLE001
         LOG.warning(
             "[ros] team-strength refresh for %s failed: %s",
-            getattr(cfg, "key", "?"), exc,
+            getattr(cfg, "key", "?"),
+            exc,
         )
         LOG.debug(
             "[ros] team-strength %s traceback: %s",
-            getattr(cfg, "key", "?"), traceback.format_exc(),
+            getattr(cfg, "key", "?"),
+            traceback.format_exc(),
         )
         return None
 
@@ -370,15 +372,11 @@ def _refresh_sim_caches_for_league(cfg: Any, default_key: str | None) -> dict[st
         # picks up for each league in the multi-league iteration.
         bb = bool(getattr(cfg, "best_ball", False))
         playoff_payload = playoff_sim.simulate_playoff_odds(snap, best_ball=bb)
-        playoff_path.write_text(
-            json.dumps({"computedAt": _now(), **playoff_payload}, indent=2)
-        )
+        playoff_path.write_text(json.dumps({"computedAt": _now(), **playoff_payload}, indent=2))
         out["playoff"] = playoff_path
 
         championship_payload = championship.simulate_championship_odds(snap, best_ball=bb)
-        champ_path.write_text(
-            json.dumps({"computedAt": _now(), **championship_payload}, indent=2)
-        )
+        champ_path.write_text(json.dumps({"computedAt": _now(), **championship_payload}, indent=2))
         out["championship"] = champ_path
 
         LOG.info(
@@ -389,11 +387,13 @@ def _refresh_sim_caches_for_league(cfg: Any, default_key: str | None) -> dict[st
     except Exception as exc:  # noqa: BLE001
         LOG.warning(
             "[ros] sim-cache refresh for %s failed: %s",
-            getattr(cfg, "key", "?"), exc,
+            getattr(cfg, "key", "?"),
+            exc,
         )
         LOG.debug(
             "[ros] sim-cache %s traceback: %s",
-            getattr(cfg, "key", "?"), traceback.format_exc(),
+            getattr(cfg, "key", "?"),
+            traceback.format_exc(),
         )
         return None
 
@@ -423,9 +423,7 @@ def _build_snapshot(src_meta: dict[str, Any], result: ScrapeResult) -> SourceSna
             rank=int(row.get("rank") or 0),
             total_ranked=int(row.get("total_ranked") or len(result.rows)),
             projection_value=(
-                float(row["projection"])
-                if row.get("projection") not in (None, "", 0)
-                else None
+                float(row["projection"]) if row.get("projection") not in (None, "", 0) else None
             ),
             confidence=float(row.get("confidence") or 1.0),
         )
@@ -639,14 +637,10 @@ def run_all(
         # historical ``team_strength/latest.json`` + ``sims/latest_*.json``
         # filenames so existing readers keep working.
         "teamStrengthPaths": {
-            k: str(p.relative_to(ROS_DATA_DIR))
-            for k, p in team_strength_paths.items()
+            k: str(p.relative_to(ROS_DATA_DIR)) for k, p in team_strength_paths.items()
         },
         "simPathsByLeague": {
-            league_key: {
-                kind: str(p.relative_to(ROS_DATA_DIR))
-                for kind, p in paths.items()
-            }
+            league_key: {kind: str(p.relative_to(ROS_DATA_DIR)) for kind, p in paths.items()}
             for league_key, paths in sim_paths_by_league.items()
         },
     }
@@ -655,9 +649,7 @@ def run_all(
 def main() -> int:
     parser = argparse.ArgumentParser(prog="ros.scrape")
     parser.add_argument("--source", help="run only one source by key (debug)")
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="DEBUG logging"
-    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="DEBUG logging")
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -668,8 +660,7 @@ def main() -> int:
     overrides: dict[str, dict[str, Any]] | None = None
     if args.source:
         overrides = {
-            s["key"]: {"enabled": s["key"] == args.source}
-            for s in enabled_ros_sources(None)
+            s["key"]: {"enabled": s["key"] == args.source} for s in enabled_ros_sources(None)
         }
 
     summary = run_all(overrides=overrides)

--- a/src/ros/sources/__init__.py
+++ b/src/ros/sources/__init__.py
@@ -37,6 +37,7 @@ The registry is import-time stable and read-only.  Per-source overrides
 ``frontend/components/useSettings.js`` and arrive at the orchestrator as
 a separate ``settings`` dict — they NEVER mutate this list.
 """
+
 from __future__ import annotations
 
 from typing import Any

--- a/src/ros/sources/draftsharks_ros.py
+++ b/src/ros/sources/draftsharks_ros.py
@@ -17,6 +17,7 @@ already incorporate ROS context (their internal model blends them),
 so the 1.25 weight is still reasonable for PR 1.  Document the proxy
 status in run JSON so the source-health UI flags it.
 """
+
 from __future__ import annotations
 
 import csv
@@ -109,10 +110,8 @@ def _read_dynasty_proxy_csv(path: Path) -> list[dict[str, Any]]:
                 if not name:
                     continue
                 position = (
-                    raw.get("Fantasy Position")
-                    or raw.get("position")
-                    or ""
-                ).strip().upper()
+                    (raw.get("Fantasy Position") or raw.get("position") or "").strip().upper()
+                )
                 position = position.split("/")[0]
                 team = (raw.get("Team") or raw.get("team") or "").strip()
                 rank_field = raw.get("Rank") or raw.get("rank")
@@ -177,7 +176,10 @@ def scrape(src_meta: dict[str, Any]) -> ScrapeResult:
     rows = sf_rows + idp_rows
     LOG.info(
         "[ros] DraftSharks: %d rows (sf=%d, idp=%d, mode=%s)",
-        len(rows), len(sf_rows), len(idp_rows), source_mode,
+        len(rows),
+        len(sf_rows),
+        len(idp_rows),
+        source_mode,
     )
 
     completed = datetime.now(timezone.utc).isoformat()

--- a/src/ros/sources/fantasy_football_calculator.py
+++ b/src/ros/sources/fantasy_football_calculator.py
@@ -18,6 +18,7 @@ API shape (subset):
       ]
     }
 """
+
 from __future__ import annotations
 
 import json

--- a/src/ros/sources/fantasypros_ros_idp.py
+++ b/src/ros/sources/fantasypros_ros_idp.py
@@ -5,6 +5,7 @@ every 2h by ``scripts/fetch_fantasypros_idp.py``.  Treats it as a
 medium-weight ROS proxy until a true FantasyPros ROS-IDP page is
 verified accessible.
 """
+
 from __future__ import annotations
 
 import csv
@@ -34,16 +35,12 @@ def _read_csv() -> list[dict[str, Any]]:
                 if not name:
                     continue
                 position = (
-                    raw.get("position")
-                    or raw.get("Pos")
-                    or raw.get("Position")
-                    or ""
-                ).strip().upper().split("/")[0]
-                rank_field = (
-                    raw.get("rank")
-                    or raw.get("Rank")
-                    or raw.get("effectiveRank")
+                    (raw.get("position") or raw.get("Pos") or raw.get("Position") or "")
+                    .strip()
+                    .upper()
+                    .split("/")[0]
                 )
+                rank_field = raw.get("rank") or raw.get("Rank") or raw.get("effectiveRank")
                 try:
                     rank = int(rank_field) if rank_field else i
                 except (TypeError, ValueError):

--- a/src/ros/sources/fantasypros_ros_overall.py
+++ b/src/ros/sources/fantasypros_ros_overall.py
@@ -8,6 +8,7 @@ rest-of-season consensus across 100+ experts, refreshed weekly.
 Same ``ecrData`` JSON blob format as the dynasty page, so the parse
 shape is shared and only the URL + source_type differ.
 """
+
 from __future__ import annotations
 
 import json
@@ -87,11 +88,7 @@ def scrape(src_meta: dict[str, Any]) -> ScrapeResult:
     for entry in players:
         if not isinstance(entry, dict):
             continue
-        name = (
-            entry.get("player_name")
-            or entry.get("player_short_name")
-            or ""
-        )
+        name = entry.get("player_name") or entry.get("player_short_name") or ""
         if not name:
             continue
         try:

--- a/src/ros/sources/fantasypros_ros_sf.py
+++ b/src/ros/sources/fantasypros_ros_sf.py
@@ -17,6 +17,7 @@ signal an outage — the orchestrator will keep yesterday's CSV + mark
 the source stale, and the aggregator will downgrade availability to
 0.5 (or 0.0 if no cache exists).
 """
+
 from __future__ import annotations
 
 import json
@@ -101,11 +102,7 @@ def scrape(src_meta: dict[str, Any]) -> ScrapeResult:
     for entry in players:
         if not isinstance(entry, dict):
             continue
-        name = (
-            entry.get("player_name")
-            or entry.get("player_short_name")
-            or ""
-        )
+        name = entry.get("player_name") or entry.get("player_short_name") or ""
         if not name:
             continue
         try:

--- a/src/ros/sources/footballguys_ros_idp.py
+++ b/src/ros/sources/footballguys_ros_idp.py
@@ -4,6 +4,7 @@ Reuses the existing CSV at ``CSVs/site_raw/footballGuysIdp.csv``.  FBG
 scrapes are authenticated via Playwright in
 ``scripts/fetch_footballguys.py`` — we just read the resulting CSV.
 """
+
 from __future__ import annotations
 
 import csv

--- a/src/ros/tags.py
+++ b/src/ros/tags.py
@@ -19,6 +19,7 @@ Tags emitted:
 Read-only:  these are informational labels.  No changes to dynasty
 trade math, no changes to dynasty values.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -53,14 +54,8 @@ def tags_for_player(
     is_idp = pos in _IDP_POSITIONS
     is_strong = ros_value >= 60.0  # 0-100 normalized scale
     is_elite = ros_value >= 80.0
-    is_starter_caliber = (
-        ros_rank_overall is not None and ros_rank_overall <= 100
-    )
-    is_top_idp = (
-        is_idp
-        and ros_rank_overall is not None
-        and ros_rank_overall <= 50
-    )
+    is_starter_caliber = ros_rank_overall is not None and ros_rank_overall <= 100
+    is_top_idp = is_idp and ros_rank_overall is not None and ros_rank_overall <= 50
     veteran = _is_veteran(pos, age)
     young = False
     try:

--- a/src/ros/team_strength.py
+++ b/src/ros/team_strength.py
@@ -16,6 +16,7 @@ The output shape mirrors what ``frontend/app/league/sections/ros-team-strength.j
 will render: one row per team, with starter + bench breakdown for the
 "why is this team here?" expandable.
 """
+
 from __future__ import annotations
 
 import json
@@ -70,12 +71,7 @@ def compute_team_strength(
         roster: list[RosterPlayer] = []
         unmapped: list[str] = []
         for p in roster_players:
-            name = (
-                p.get("canonicalName")
-                or p.get("displayName")
-                or p.get("name")
-                or ""
-            )
+            name = p.get("canonicalName") or p.get("displayName") or p.get("name") or ""
             position = (p.get("position") or "").upper()
             agg = by_name.get(name)
             if not agg or agg.get("rosValue", 0) <= 0:
@@ -162,6 +158,7 @@ def _team_strength_path(league_key: str | None = None) -> Path:
     resolved = league_key
     try:
         from src.api.league_registry import get_league_by_key, default_league_key  # noqa: PLC0415
+
         cfg = get_league_by_key(league_key)
         if cfg and cfg.key:
             resolved = cfg.key

--- a/src/ros/trade_deadline.py
+++ b/src/ros/trade_deadline.py
@@ -10,6 +10,7 @@ Returns one row per team with the direction label + recommendation.
 Lazy-section friendly — call ``build_section(snapshot)`` from the
 public contract.
 """
+
 from __future__ import annotations
 
 import json
@@ -33,11 +34,7 @@ def _load_playoff_odds_map() -> dict[str, dict[str, float]]:
     except (json.JSONDecodeError, OSError):
         return {}
     rows = payload.get("playoffOdds") or []
-    return {
-        str(r.get("ownerId") or ""): r
-        for r in rows
-        if r.get("ownerId")
-    }
+    return {str(r.get("ownerId") or ""): r for r in rows if r.get("ownerId")}
 
 
 def _load_championship_map() -> dict[str, dict[str, float]]:
@@ -49,11 +46,7 @@ def _load_championship_map() -> dict[str, dict[str, float]]:
     except (json.JSONDecodeError, OSError):
         return {}
     rows = payload.get("championshipOdds") or []
-    return {
-        str(r.get("ownerId") or ""): r
-        for r in rows
-        if r.get("ownerId")
-    }
+    return {str(r.get("ownerId") or ""): r for r in rows if r.get("ownerId")}
 
 
 def build_team_directions(
@@ -74,13 +67,9 @@ def build_team_directions(
     strengths = team_strength_map or {}
     if not strengths:
         snap = load_team_strength_snapshot() or []
-        strengths = {
-            str(r.get("ownerId") or ""): r for r in snap if r.get("ownerId")
-        }
+        strengths = {str(r.get("ownerId") or ""): r for r in snap if r.get("ownerId")}
 
-    owner_ids = sorted(
-        set(playoffs) | set(champs) | set(strengths)
-    )
+    owner_ids = sorted(set(playoffs) | set(champs) | set(strengths))
     if not owner_ids:
         return []
 
@@ -93,17 +82,9 @@ def build_team_directions(
         # rank/length is the cheapest proxy.
         rank = float(strength_row.get("rank") or 0.0)
         total = max(1.0, float(len(strengths) or 1))
-        strength_pct = (
-            (total - rank + 1) / total if rank > 0 else 0.0
-        )
-        team_obj = (
-            next((t for t in (teams or []) if t.get("ownerId") == owner), None)
-        )
-        roster_age = (
-            build_roster_age_profile(team_obj.get("players") or [])
-            if team_obj
-            else {}
-        )
+        strength_pct = (total - rank + 1) / total if rank > 0 else 0.0
+        team_obj = next((t for t in (teams or []) if t.get("ownerId") == owner), None)
+        roster_age = build_roster_age_profile(team_obj.get("players") or []) if team_obj else {}
         direction = classify_team(
             playoff_odds_pct=po,
             championship_odds_pct=co,

--- a/src/scoring/archetype_model.py
+++ b/src/scoring/archetype_model.py
@@ -63,4 +63,3 @@ def summarize_archetype_priors(rows: Iterable[Dict[str, object]]) -> Dict[str, D
 
 def build_scoring_tags(bucket: str, features: Dict[str, float]) -> list[str]:
     return infer_scoring_tags(bucket, features)
-

--- a/src/scoring/backtest.py
+++ b/src/scoring/backtest.py
@@ -66,7 +66,9 @@ def run_scoring_backtest(player_fits: Dict[str, Dict[str, object]]) -> Dict[str,
             ),
             "avg_ratio": round(sum(ratios) / len(ratios), 6) if ratios else 1.0,
             "avg_confidence": round(sum(confs) / len(confs), 6) if confs else 0.0,
-            "avg_abs_delta_points": round(sum(abs_deltas) / len(abs_deltas), 6) if abs_deltas else 0.0,
+            "avg_abs_delta_points": round(sum(abs_deltas) / len(abs_deltas), 6)
+            if abs_deltas
+            else 0.0,
         },
         "byPosition": {},
         "byConfidenceBucket": {},

--- a/src/scoring/baseline_config.py
+++ b/src/scoring/baseline_config.py
@@ -75,7 +75,9 @@ DEFAULT_ROSTER_POSITIONS: List[str] = [
 ]
 
 
-def build_default_baseline_config(league_id: str = "baseline-test-default", season: int | None = None) -> ScoringConfig:
+def build_default_baseline_config(
+    league_id: str = "baseline-test-default", season: int | None = None
+) -> ScoringConfig:
     return ScoringConfig(
         scoring_version=BASELINE_SCORING_VERSION,
         league_id=str(league_id),
@@ -87,4 +89,3 @@ def build_default_baseline_config(league_id: str = "baseline-test-default", seas
             "notes": "Used only for scoring translation, never as live league scoring.",
         },
     )
-

--- a/src/scoring/feature_engineering.py
+++ b/src/scoring/feature_engineering.py
@@ -35,7 +35,11 @@ def compute_profile_features(
 
     total_td = pass_td + rush_td + rec_td
     total_yd = pass_yd + rush_yd + rec_yd
-    explosive_proxy = (_f(s.get("bonus_pass_td_50+")) + _f(s.get("bonus_rush_td_40+")) + _f(s.get("bonus_rec_td_40+")))
+    explosive_proxy = (
+        _f(s.get("bonus_pass_td_50+"))
+        + _f(s.get("bonus_rush_td_40+"))
+        + _f(s.get("bonus_rec_td_40+"))
+    )
 
     f = {
         "games_played": float(max(0, total_games)),
@@ -84,7 +88,10 @@ def compute_profile_features(
             {
                 "tackle_dependency": (_f(s.get("idp_tkl_solo")) + _f(s.get("idp_tkl_ast"))),
                 "splash_dependency": (
-                    _f(s.get("idp_sack")) + _f(s.get("idp_int")) + _f(s.get("idp_ff")) + _f(s.get("idp_fum_rec"))
+                    _f(s.get("idp_sack"))
+                    + _f(s.get("idp_int"))
+                    + _f(s.get("idp_ff"))
+                    + _f(s.get("idp_fum_rec"))
                 ),
             }
         )
@@ -106,4 +113,3 @@ def infer_scoring_tags(bucket: str, features: Dict[str, float]) -> list[str]:
     if p in {"DL", "LB", "DB"} and f.get("splash_dependency", 0.0) >= 1.0:
         tags.append("idp_splash")
     return tags
-

--- a/src/scoring/player_adjustment.py
+++ b/src/scoring/player_adjustment.py
@@ -125,8 +125,11 @@ def choose_final_multiplier(
     prod = clamp(float(production_share), 0.0, 1.0)
     score_mult = float(scoring_adjustment.final_scoring_multiplier)
     output = 1.0 + ((score_mult - 1.0) * prod)
-    if isinstance(explicit_fit_final, (int, float)) and explicit_fit_final > 0 and explicit_fit_blend > 0:
+    if (
+        isinstance(explicit_fit_final, (int, float))
+        and explicit_fit_final > 0
+        and explicit_fit_blend > 0
+    ):
         w = clamp(float(explicit_fit_blend), 0.0, 0.50)
         output = (output * (1.0 - w)) + (float(explicit_fit_final) * w)
     return clamp(output, 1.0 - float(hard_cap), 1.0 + float(hard_cap))
-

--- a/src/scoring/replacement_level.py
+++ b/src/scoring/replacement_level.py
@@ -36,6 +36,7 @@ This split is what makes the module reusable: every consumer
 produces ``PlayerSeasonRow``s from a different source, then calls
 the same VORP math.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -53,6 +54,7 @@ class PlayerSeasonRow:
     no-game-played row would otherwise produce a div-by-zero in
     the per-game replacement math).
     """
+
     player_id: str
     position: str
     points: float
@@ -151,8 +153,14 @@ def replacement_per_game(
     """
     per_game: list[float] = []
     for r in rows or []:
-        games = r.games if isinstance(r, PlayerSeasonRow) else r.get("games") or r.get("gamesStarted")
-        points = r.points if isinstance(r, PlayerSeasonRow) else r.get("points") or r.get("starterPoints")
+        games = (
+            r.games if isinstance(r, PlayerSeasonRow) else r.get("games") or r.get("gamesStarted")
+        )
+        points = (
+            r.points
+            if isinstance(r, PlayerSeasonRow)
+            else r.get("points") or r.get("starterPoints")
+        )
         try:
             g = int(games or 0)
             p = float(points or 0)

--- a/src/scoring/scoring_delta.py
+++ b/src/scoring/scoring_delta.py
@@ -15,8 +15,16 @@ RULE_META: Dict[str, Dict[str, object]] = {
     "pass_inc": {"category": "passing", "buckets": ["QB"], "rule_type": "linear"},
     "pass_fd": {"category": "first_downs", "buckets": ["QB"], "rule_type": "event"},
     "rush_yd": {"category": "rushing", "buckets": ["QB", "RB", "WR", "TE"], "rule_type": "linear"},
-    "rush_td": {"category": "touchdowns", "buckets": ["QB", "RB", "WR", "TE"], "rule_type": "event"},
-    "rush_fd": {"category": "first_downs", "buckets": ["QB", "RB", "WR", "TE"], "rule_type": "event"},
+    "rush_td": {
+        "category": "touchdowns",
+        "buckets": ["QB", "RB", "WR", "TE"],
+        "rule_type": "event",
+    },
+    "rush_fd": {
+        "category": "first_downs",
+        "buckets": ["QB", "RB", "WR", "TE"],
+        "rule_type": "event",
+    },
     "rec": {"category": "receptions", "buckets": ["RB", "WR", "TE"], "rule_type": "linear"},
     "rec_yd": {"category": "receiving", "buckets": ["RB", "WR", "TE"], "rule_type": "linear"},
     "rec_td": {"category": "touchdowns", "buckets": ["RB", "WR", "TE"], "rule_type": "event"},
@@ -29,17 +37,49 @@ RULE_META: Dict[str, Dict[str, object]] = {
     "bonus_fd_wr": {"category": "first_downs", "buckets": ["WR"], "rule_type": "event"},
     "bonus_fd_te": {"category": "first_downs", "buckets": ["TE"], "rule_type": "event"},
     "fum": {"category": "turnovers", "buckets": ["QB", "RB", "WR", "TE"], "rule_type": "event"},
-    "fum_lost": {"category": "turnovers", "buckets": ["QB", "RB", "WR", "TE"], "rule_type": "event"},
+    "fum_lost": {
+        "category": "turnovers",
+        "buckets": ["QB", "RB", "WR", "TE"],
+        "rule_type": "event",
+    },
     "bonus_pass_yd_300": {"category": "yardage_bonus", "buckets": ["QB"], "rule_type": "threshold"},
-    "bonus_rush_yd_100": {"category": "yardage_bonus", "buckets": ["QB", "RB", "WR", "TE"], "rule_type": "threshold"},
-    "bonus_rec_yd_100": {"category": "yardage_bonus", "buckets": ["RB", "WR", "TE"], "rule_type": "threshold"},
-    "bonus_pass_td_50+": {"category": "long_play_bonus", "buckets": ["QB"], "rule_type": "threshold"},
-    "bonus_rush_td_40+": {"category": "long_play_bonus", "buckets": ["QB", "RB", "WR", "TE"], "rule_type": "threshold"},
-    "bonus_rec_td_40+": {"category": "long_play_bonus", "buckets": ["RB", "WR", "TE"], "rule_type": "threshold"},
+    "bonus_rush_yd_100": {
+        "category": "yardage_bonus",
+        "buckets": ["QB", "RB", "WR", "TE"],
+        "rule_type": "threshold",
+    },
+    "bonus_rec_yd_100": {
+        "category": "yardage_bonus",
+        "buckets": ["RB", "WR", "TE"],
+        "rule_type": "threshold",
+    },
+    "bonus_pass_td_50+": {
+        "category": "long_play_bonus",
+        "buckets": ["QB"],
+        "rule_type": "threshold",
+    },
+    "bonus_rush_td_40+": {
+        "category": "long_play_bonus",
+        "buckets": ["QB", "RB", "WR", "TE"],
+        "rule_type": "threshold",
+    },
+    "bonus_rec_td_40+": {
+        "category": "long_play_bonus",
+        "buckets": ["RB", "WR", "TE"],
+        "rule_type": "threshold",
+    },
     "kick_ret_td": {"category": "returns", "buckets": ["RB", "WR", "DB"], "rule_type": "event"},
     "punt_ret_td": {"category": "returns", "buckets": ["RB", "WR", "DB"], "rule_type": "event"},
-    "idp_tkl_solo": {"category": "idp_tackles", "buckets": ["DL", "LB", "DB"], "rule_type": "linear"},
-    "idp_tkl_ast": {"category": "idp_tackles", "buckets": ["DL", "LB", "DB"], "rule_type": "linear"},
+    "idp_tkl_solo": {
+        "category": "idp_tackles",
+        "buckets": ["DL", "LB", "DB"],
+        "rule_type": "linear",
+    },
+    "idp_tkl_ast": {
+        "category": "idp_tackles",
+        "buckets": ["DL", "LB", "DB"],
+        "rule_type": "linear",
+    },
     "idp_tkl_loss": {"category": "idp_tfl", "buckets": ["DL", "LB", "DB"], "rule_type": "event"},
     "idp_sack": {"category": "idp_splash", "buckets": ["DL", "LB"], "rule_type": "event"},
     "idp_hit": {"category": "idp_splash", "buckets": ["DL", "LB"], "rule_type": "event"},
@@ -51,7 +91,9 @@ RULE_META: Dict[str, Dict[str, object]] = {
 }
 
 
-def compare_to_baseline(baseline_config: ScoringConfig, league_config: ScoringConfig) -> List[ScoringRule]:
+def compare_to_baseline(
+    baseline_config: ScoringConfig, league_config: ScoringConfig
+) -> List[ScoringRule]:
     baseline = baseline_config.scoring_map if isinstance(baseline_config, ScoringConfig) else {}
     league = league_config.scoring_map if isinstance(league_config, ScoringConfig) else {}
     keys = sorted(set(baseline.keys()) | set(league.keys()))

--- a/src/scoring/sleeper_ingest.py
+++ b/src/scoring/sleeper_ingest.py
@@ -100,7 +100,9 @@ def _to_float(value, default: Optional[float] = 0.0) -> Optional[float]:
         return default
 
 
-def fetch_league(league_id: str, timeout: int = 12, session: Optional[requests.Session] = None) -> Optional[Dict[str, object]]:
+def fetch_league(
+    league_id: str, timeout: int = 12, session: Optional[requests.Session] = None
+) -> Optional[Dict[str, object]]:
     if not league_id:
         return None
     http = session or requests
@@ -187,7 +189,9 @@ def persist_scoring_config(path: str, config: ScoringConfig) -> None:
         json.dump(config.to_dict(), f, ensure_ascii=False, indent=2, sort_keys=True)
 
 
-def build_league_scoring_config(league_id: str, timeout: int = 12, session: Optional[requests.Session] = None) -> Tuple[Optional[ScoringConfig], Optional[Dict[str, object]]]:
+def build_league_scoring_config(
+    league_id: str, timeout: int = 12, session: Optional[requests.Session] = None
+) -> Tuple[Optional[ScoringConfig], Optional[Dict[str, object]]]:
     league = fetch_league(league_id, timeout=timeout, session=session)
     if not isinstance(league, dict):
         return None, None
@@ -204,4 +208,3 @@ def build_league_scoring_config(league_id: str, timeout: int = 12, session: Opti
         season=season,
     )
     return config, league
-

--- a/src/scoring/tiering.py
+++ b/src/scoring/tiering.py
@@ -34,6 +34,7 @@ silently updating prod.
 
 Pure-Python.  No numpy.
 """
+
 from __future__ import annotations
 
 import json
@@ -153,8 +154,10 @@ def detect_tiers(
             # Everyone in one tier.
             for r in group_sorted:
                 result_map[id(r)] = TierEntry(
-                    tier_id=1, player_name=str(r.get("name") or ""),
-                    value=_value_of(r), position=pos,
+                    tier_id=1,
+                    player_name=str(r.get("name") or ""),
+                    value=_value_of(r),
+                    position=pos,
                 )
             continue
 
@@ -175,7 +178,8 @@ def detect_tiers(
             result_map[id(r)] = TierEntry(
                 tier_id=tier_id,
                 player_name=str(r.get("name") or ""),
-                value=val, position=pos,
+                value=val,
+                position=pos,
             )
 
     # Return in input order.

--- a/src/scoring/types.py
+++ b/src/scoring/types.py
@@ -105,4 +105,3 @@ class BacktestRow:
 
     def to_dict(self) -> Dict[str, object]:
         return asdict(self)
-

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -25,6 +25,7 @@ counter-offers). Same arbitrage math; combinations are evaluated per
 opposing team with the candidate pool clamped to each team's top-N
 players by your calibrated value so the search stays fast.
 """
+
 from __future__ import annotations
 
 from itertools import combinations
@@ -399,10 +400,12 @@ def find_angle_packages(
         }
 
     offer_my_total = sum(
-        _value_pair(r)[0] for r in offer_rows  # type: ignore[index]
+        _value_pair(r)[0]
+        for r in offer_rows  # type: ignore[index]
     )
     offer_market_total = sum(
-        _value_pair(r)[1] for r in offer_rows  # type: ignore[index]
+        _value_pair(r)[1]
+        for r in offer_rows  # type: ignore[index]
     )
     offer_size = len(offer_rows)
 
@@ -466,19 +469,17 @@ def find_angle_packages(
     # Offer-side value lists (sorted descending) used by the VA path
     # below. We keep raw totals available for display/back-compat.
     offer_my_values = sorted(
-        (float(_value_pair(r)[0]) for r in offer_rows), reverse=True,  # type: ignore[index]
+        (float(_value_pair(r)[0]) for r in offer_rows),
+        reverse=True,  # type: ignore[index]
     )
     offer_market_values = sorted(
-        (float(_value_pair(r)[1]) for r in offer_rows), reverse=True,  # type: ignore[index]
+        (float(_value_pair(r)[1]) for r in offer_rows),
+        reverse=True,  # type: ignore[index]
     )
 
     # Normalise target-team + seed inputs for constructed-package mode.
-    target_ids: set[str] = {
-        str(t).strip() for t in (target_team_owner_ids or []) if str(t).strip()
-    }
-    seed_names_requested = [
-        str(n).strip() for n in (seed_player_names or []) if str(n).strip()
-    ]
+    target_ids: set[str] = {str(t).strip() for t in (target_team_owner_ids or []) if str(t).strip()}
+    seed_names_requested = [str(n).strip() for n in (seed_player_names or []) if str(n).strip()]
 
     candidates: list[dict[str, Any]] = []
     seed_names_set: set[str] = set()
@@ -522,9 +523,7 @@ def find_angle_packages(
         if offer_my_adj <= 0 or offer_market_adj <= 0:
             return None
         my_gain_pct = 100.0 * (counter_my_adj - offer_my_adj) / offer_my_adj
-        market_gain_pct = (
-            100.0 * (counter_market_adj - offer_market_adj) / offer_market_adj
-        )
+        market_gain_pct = 100.0 * (counter_market_adj - offer_market_adj) / offer_market_adj
         if my_gain_pct < min_my_gain_pct:
             return None
         if market_gain_pct > max_market_gain_pct:
@@ -618,8 +617,7 @@ def find_angle_packages(
         if missing_seeds:
             warnings.append(
                 f"Dropped {len(missing_seeds)} seed player(s) with missing data: "
-                f"{', '.join(missing_seeds[:5])}"
-                + (" …" if len(missing_seeds) > 5 else "")
+                f"{', '.join(missing_seeds[:5])}" + (" …" if len(missing_seeds) > 5 else "")
             )
         if wrong_team_seeds:
             warnings.append(
@@ -833,14 +831,12 @@ def find_acquisition_packages(
     if missing:
         warnings.append(
             f"Dropped {len(missing)} desired player(s) with missing data: "
-            f"{', '.join(missing[:5])}"
-            + (" …" if len(missing) > 5 else "")
+            f"{', '.join(missing[:5])}" + (" …" if len(missing) > 5 else "")
         )
     if own_roster:
         warnings.append(
             f"Dropped {len(own_roster)} player(s) already on your roster: "
-            f"{', '.join(own_roster[:5])}"
-            + (" …" if len(own_roster) > 5 else "")
+            f"{', '.join(own_roster[:5])}" + (" …" if len(own_roster) > 5 else "")
         )
     if not desired_rows:
         return {
@@ -906,10 +902,12 @@ def find_acquisition_packages(
 
     # Desired-side value lists (sorted descending) for the VA path.
     desired_my_values = sorted(
-        (float(_value_pair(r)[0]) for r in desired_rows), reverse=True,  # type: ignore[index]
+        (float(_value_pair(r)[0]) for r in desired_rows),
+        reverse=True,  # type: ignore[index]
     )
     desired_market_values = sorted(
-        (float(_value_pair(r)[1]) for r in desired_rows), reverse=True,  # type: ignore[index]
+        (float(_value_pair(r)[1]) for r in desired_rows),
+        reverse=True,  # type: ignore[index]
     )
 
     def _make_candidate(combo: tuple[dict[str, Any], ...]) -> dict[str, Any] | None:
@@ -936,9 +934,7 @@ def find_acquisition_packages(
         if offer_my_adj <= 0 or offer_market_adj <= 0:
             return None
         my_gain_pct = 100.0 * (desired_my_adj - offer_my_adj) / offer_my_adj
-        market_gain_pct = (
-            100.0 * (desired_market_adj - offer_market_adj) / offer_market_adj
-        )
+        market_gain_pct = 100.0 * (desired_market_adj - offer_market_adj) / offer_market_adj
         if my_gain_pct < min_my_gain_pct:
             return None
         if market_gain_pct > max_market_gain_pct:

--- a/src/trade/correlation_matrix.py
+++ b/src/trade/correlation_matrix.py
@@ -37,6 +37,7 @@ shrinking rho via ``_shrink_to_pd`` until Cholesky succeeds.
 Pure-Python Cholesky — slow for N>100, but trades sizes are
 tiny (rarely >10 per side).
 """
+
 from __future__ import annotations
 
 import math
@@ -44,12 +45,16 @@ from dataclasses import dataclass
 from typing import Any
 
 # Stack rules — (pos_a, pos_b) → higher rho than "same team other pos".
-_STACK_PAIRS = frozenset({
-    ("QB", "WR"), ("WR", "QB"),
-    ("QB", "TE"), ("TE", "QB"),
-    # RB handcuff.
-    ("RB", "RB"),
-})
+_STACK_PAIRS = frozenset(
+    {
+        ("QB", "WR"),
+        ("WR", "QB"),
+        ("QB", "TE"),
+        ("TE", "QB"),
+        # RB handcuff.
+        ("RB", "RB"),
+    }
+)
 
 _SAME_TEAM_SAME_POS_RHO = 0.55
 _SAME_TEAM_STACK_RHO = 0.35
@@ -86,7 +91,10 @@ def build_matrix(
 
 
 def _pairwise_rho(
-    a: _PlayerAxis, b: _PlayerAxis, *, max_rho: float,
+    a: _PlayerAxis,
+    b: _PlayerAxis,
+    *,
+    max_rho: float,
 ) -> float:
     same_team = bool(a.team and a.team == b.team)
     same_pos = bool(a.position and a.position == b.position)
@@ -153,9 +161,11 @@ def build_axes_from_trade_players(players) -> list[_PlayerAxis]:
     """Convert ``TradePlayer`` dataclass instances into per-player axes."""
     axes = []
     for p in players:
-        axes.append(_PlayerAxis(
-            team=getattr(p, "team", "") or "",
-            position=getattr(p, "position", "") or "",
-            position_group=getattr(p, "position_group", "") or "offense",
-        ))
+        axes.append(
+            _PlayerAxis(
+                team=getattr(p, "team", "") or "",
+                position=getattr(p, "position", "") or "",
+                position_group=getattr(p, "position_group", "") or "offense",
+            )
+        )
     return axes

--- a/src/trade/faab_recommender.py
+++ b/src/trade/faab_recommender.py
@@ -19,6 +19,7 @@ surface a ``factors[].missing=true`` row so the UI can explain
 "this recommendation has lower confidence because we don't have
 trending data this week".
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -41,8 +42,8 @@ _VALUE_MOD_CEILING = 1.8
 # raw "X people added" number from the Sleeper API.
 _TRENDING_TIER_BREAKPOINTS = (
     (10000, 0.20),  # top trending: +20% to standard bid
-    (5000, 0.15),   # very hot
-    (1000, 0.10),   # warm
+    (5000, 0.15),  # very hot
+    (1000, 0.10),  # warm
 )
 
 # League-analytics calibration blend.  A 50/50 blend keeps the
@@ -61,6 +62,7 @@ class _Factor:
     folded into the final bids; ``contribution`` is for the UI
     transparency tooltip.
     """
+
     label: str
     contribution: str
     weight: float
@@ -109,10 +111,9 @@ def _position_calibration(
         # be meaningful; otherwise we'd be calibrating against
         # noise.
         return bid_estimate
-    blended = (
-        _LEAGUE_CALIBRATION_BLEND * float(avg_for_pos)
-        + (1.0 - _LEAGUE_CALIBRATION_BLEND) * float(bid_estimate)
-    )
+    blended = _LEAGUE_CALIBRATION_BLEND * float(avg_for_pos) + (
+        1.0 - _LEAGUE_CALIBRATION_BLEND
+    ) * float(bid_estimate)
     return max(0, round(blended))
 
 
@@ -180,30 +181,34 @@ def recommend_faab(
         league_budget=int(league_budget),
         top_value_in_pool=top_value_in_pool,
     )
-    factors.append(_Factor(
-        label="Player value baseline",
-        contribution=f"start at ${reasonable_base}",
-        weight=0.35,
-    ))
+    factors.append(
+        _Factor(
+            label="Player value baseline",
+            contribution=f"start at ${reasonable_base}",
+            weight=0.35,
+        )
+    )
 
     # 2. Value-gain modifier.
-    mod = _value_gain_modifier(
-        float(add_player_value), float(drop_player_value or 0)
-    )
+    mod = _value_gain_modifier(float(add_player_value), float(drop_player_value or 0))
     standard = max(0, round(reasonable_base * mod))
     if drop_player_value > 0:
         if mod > 1.05:
-            factors.append(_Factor(
-                label="Net upgrade boost",
-                contribution=f"×{mod:.2f}",
-                weight=0.20,
-            ))
+            factors.append(
+                _Factor(
+                    label="Net upgrade boost",
+                    contribution=f"×{mod:.2f}",
+                    weight=0.20,
+                )
+            )
         elif mod < 0.95:
-            factors.append(_Factor(
-                label="Marginal-upgrade penalty",
-                contribution=f"×{mod:.2f}",
-                weight=0.20,
-            ))
+            factors.append(
+                _Factor(
+                    label="Marginal-upgrade penalty",
+                    contribution=f"×{mod:.2f}",
+                    weight=0.20,
+                )
+            )
 
     # 3. Trending kicker.
     trending_count = None
@@ -217,62 +222,70 @@ def recommend_faab(
     kicker = _trending_kicker(trending_count)
     if kicker > 1.0:
         standard = round(standard * kicker)
-        factors.append(_Factor(
-            label="Trending bump",
-            contribution=f"×{kicker:.2f}",
-            weight=0.15,
-        ))
+        factors.append(
+            _Factor(
+                label="Trending bump",
+                contribution=f"×{kicker:.2f}",
+                weight=0.15,
+            )
+        )
     elif sleeper_trending is None:
-        factors.append(_Factor(
-            label="Trending data",
-            contribution="missing",
-            weight=0.15,
-            missing=True,
-        ))
+        factors.append(
+            _Factor(
+                label="Trending data",
+                contribution="missing",
+                weight=0.15,
+                missing=True,
+            )
+        )
 
     # 4. League-analytics calibration (per-position blend).
     if league_faab_summary:
         before = standard
-        standard = _position_calibration(
-            league_faab_summary, add_player_position, standard
-        )
+        standard = _position_calibration(league_faab_summary, add_player_position, standard)
         if standard != before:
             delta = standard - before
             sign = "+" if delta > 0 else ""
-            factors.append(_Factor(
-                label="League historical calibration",
-                contribution=f"{sign}${delta}",
-                weight=0.20,
-            ))
+            factors.append(
+                _Factor(
+                    label="League historical calibration",
+                    contribution=f"{sign}${delta}",
+                    weight=0.20,
+                )
+            )
         else:
-            factors.append(_Factor(
-                label="League historical data",
-                contribution="insufficient samples",
+            factors.append(
+                _Factor(
+                    label="League historical data",
+                    contribution="insufficient samples",
+                    weight=0.20,
+                    missing=True,
+                )
+            )
+    else:
+        factors.append(
+            _Factor(
+                label="League historical analytics",
+                contribution="missing",
                 weight=0.20,
                 missing=True,
-            ))
-    else:
-        factors.append(_Factor(
-            label="League historical analytics",
-            contribution="missing",
-            weight=0.20,
-            missing=True,
-        ))
+            )
+        )
 
     # 4b. KTC crowd blend (optional, B7).
     if ktc_crowd_bids:
         before = standard
-        standard = _ktc_crowd_blend(
-            ktc_crowd_bids, add_player_name, league_budget, standard
-        )
+        standard = _ktc_crowd_blend(ktc_crowd_bids, add_player_name, league_budget, standard)
         if standard != before:
             delta = standard - before
             sign = "+" if delta > 0 else ""
-            factors.append(_Factor(
-                label="KTC crowd-sourced calibration",
-                contribution=f"{sign}${delta}",
-                weight=0.10,
-            ))
+            factors.append(
+                _Factor(
+                    label="KTC crowd-sourced calibration",
+                    contribution=f"{sign}${delta}",
+                    weight=0.10,
+                )
+            )
 
     # 5. Marginal-upgrade floor: when the swap is even or negative,
     # bidding more than $1-$2 over reasonable_base is rarely worth
@@ -288,9 +301,7 @@ def recommend_faab(
 
     # 6. Floor at $0 if the swap is strictly negative.
     if drop_player_value > 0 and add_player_value < drop_player_value:
-        warnings.append(
-            "Your drop is worth more than your add — don't bid."
-        )
+        warnings.append("Your drop is worth more than your add — don't bid.")
         standard = 0
 
     # 7. Cap at team's faabRemaining.  When unknown, use the
@@ -299,15 +310,15 @@ def recommend_faab(
     cap_source = team_faab_remaining if team_faab_remaining is not None else league_budget
     cap_source = max(0, int(cap_source))
     if standard > cap_source:
-        warnings.append(
-            f"Capped at team's remaining FAAB (${cap_source})."
-        )
+        warnings.append(f"Capped at team's remaining FAAB (${cap_source}).")
         standard = cap_source
-        factors.append(_Factor(
-            label="Team FAAB cap",
-            contribution=f"clipped to ${cap_source}",
-            weight=0.10,
-        ))
+        factors.append(
+            _Factor(
+                label="Team FAAB cap",
+                contribution=f"clipped to ${cap_source}",
+                weight=0.10,
+            )
+        )
 
     # Derive the conservative / aggressive bracket from the final
     # ``standard`` so all three pills move together.
@@ -329,13 +340,11 @@ def recommend_faab(
     # Plain-English summary of the recommendation.
     if standard == 0:
         explanation = (
-            "We don't recommend bidding on this swap — the drop is "
-            "worth more than the add."
+            "We don't recommend bidding on this swap — the drop is " "worth more than the add."
         )
     elif standard <= 2:
         explanation = (
-            f"Token bid (${standard}).  Marginal upgrade or low "
-            "league budget — keep it cheap."
+            f"Token bid (${standard}).  Marginal upgrade or low " "league budget — keep it cheap."
         )
     elif drop_player_value > 0:
         net = add_player_value - drop_player_value

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -20,18 +20,18 @@ from typing import Any
 from src.utils.name_clean import normalize_position as _norm_pos  # noqa: F401 — re-exported via _norm_pos shim below for back-compat
 
 # ── Thresholds ──────────────────────────────────────────────────────────
-MIN_ASSET_VALUE = 800          # Minimum model value to consider an asset tradeable
-MIN_KTC_VALUE = 500            # Minimum KTC value to include in trade
-MAX_BOARD_LOSS = -200          # Never suggest a trade where my board delta is worse than this
-MAX_PACKAGE_SIZE = 3           # Max assets on either side
-MAX_RESULTS = 40               # Cap returned results
-JUNK_THRESHOLD = 400           # Assets below this are roster clog
+MIN_ASSET_VALUE = 800  # Minimum model value to consider an asset tradeable
+MIN_KTC_VALUE = 500  # Minimum KTC value to include in trade
+MAX_BOARD_LOSS = -200  # Never suggest a trade where my board delta is worse than this
+MAX_PACKAGE_SIZE = 3  # Max assets on either side
+MAX_RESULTS = 40  # Cap returned results
+JUNK_THRESHOLD = 400  # Assets below this are roster clog
 SINGLE_SOURCE_DISCOUNT = 0.88  # Match frontend: 12% haircut for single-source assets
-MULTI_FOR_ONE_MIN_RATIO = 0.55 # 2-for-1 give side must be >= 55% of receive model value
+MULTI_FOR_ONE_MIN_RATIO = 0.55  # 2-for-1 give side must be >= 55% of receive model value
 
 # ── KTC quality gates ──────────────────────────────────────────────────
-EXCLUDED_POSITIONS = {"K", "PK", "DST", "DEF"}   # No real KTC support
-PARTIAL_KTC_MAX_RANK = 15      # Partial-KTC trades cannot appear above this rank
+EXCLUDED_POSITIONS = {"K", "PK", "DST", "DEF"}  # No real KTC support
+PARTIAL_KTC_MAX_RANK = 15  # Partial-KTC trades cannot appear above this rank
 PARTIAL_KTC_ARBITRAGE_CAP = 8.0  # Hard ceiling on partial-KTC arbitrage score
 
 # ── KTC quality gate ──────────────────────────────────────────────────
@@ -40,12 +40,12 @@ PARTIAL_KTC_ARBITRAGE_CAP = 8.0  # Hard ceiling on partial-KTC arbitrage score
 KTC_TOP_N_FILTER = 150
 
 # ── Hardening-pass thresholds ────────────────────────────────────────────
-ELITE_THRESHOLD = 7500         # Model value above which a player is "elite"
-ELITE_MULTI_MIN_RATIO = 0.65   # Tighter ratio for elite targets in multi-for-one
+ELITE_THRESHOLD = 7500  # Model value above which a player is "elite"
+ELITE_MULTI_MIN_RATIO = 0.65  # Tighter ratio for elite targets in multi-for-one
 PACKAGE_ANCHOR_MIN_PCT = 0.35  # Best give piece must be ≥35% of best receive piece
-CONFIDENCE_SOURCE_BASELINE = 5 # Expected source count for full confidence
-ROSTER_SURPLUS_THRESHOLD = 4   # ≥4 at a position = surplus (light fit bonus)
-ROSTER_WEAK_THRESHOLD = 1      # ≤1 at a position = weakness (light fit bonus)
+CONFIDENCE_SOURCE_BASELINE = 5  # Expected source count for full confidence
+ROSTER_SURPLUS_THRESHOLD = 4  # ≥4 at a position = surplus (light fit bonus)
+ROSTER_WEAK_THRESHOLD = 1  # ≤1 at a position = weakness (light fit bonus)
 
 IDP_POSITIONS = {"DL", "LB", "DB"}
 
@@ -53,13 +53,14 @@ IDP_POSITIONS = {"DL", "LB", "DB"}
 @dataclass
 class Asset:
     """A tradeable asset with both model and KTC values."""
+
     name: str
     position: str
     team: str
-    model_value: int        # Our board's value (with single-source discount)
-    ktc_value: int | None   # KTC value (None = no KTC coverage)
+    model_value: int  # Our board's value (with single-source discount)
+    ktc_value: int | None  # KTC value (None = no KTC coverage)
     is_pick: bool = False
-    source_count: int = 0   # Number of valuation sources
+    source_count: int = 0  # Number of valuation sources
     ktc_rank: int | None = None  # 1-based KTC rank (None = no KTC data)
     offense_only_model_value: int | None = None  # model_value excluding IDP sources
 
@@ -77,30 +78,29 @@ class Asset:
 @dataclass
 class TradeCandidate:
     """A scored trade proposal."""
+
     give: list[Asset]
     receive: list[Asset]
     give_model_total: int = 0
     receive_model_total: int = 0
     give_ktc_total: int = 0
     receive_ktc_total: int = 0
-    board_delta: int = 0          # positive = good for me on our board
-    ktc_delta: int = 0            # positive = opponent gives more KTC than they get
-    opponent_ktc_appeal: float = 0.0   # how favorable for opponent on KTC (positive = they like it)
+    board_delta: int = 0  # positive = good for me on our board
+    ktc_delta: int = 0  # positive = opponent gives more KTC than they get
+    opponent_ktc_appeal: float = 0.0  # how favorable for opponent on KTC (positive = they like it)
     arbitrage_score: float = 0.0  # composite ranking score
-    ktc_coverage: str = "full"    # full / partial / none
-    confidence_score: float = 1.0 # 0-1, source coverage × KTC coverage
+    ktc_coverage: str = "full"  # full / partial / none
+    confidence_score: float = 1.0  # 0-1, source coverage × KTC coverage
 
     # ── Explainability fields ────────────────────────────────────────────
-    confidence_tier: str = "high"    # "high" / "moderate" / "low"
-    edge_label: str = ""             # "Strong Edge" / "Moderate Edge" / "Slight Edge"
-    summary: str = ""                # Human-readable one-liner
-    ranking_factors: dict = field(default_factory=dict)   # Score component breakdown
-    flags: list[str] = field(default_factory=list)        # Active guards/bonuses
+    confidence_tier: str = "high"  # "high" / "moderate" / "low"
+    edge_label: str = ""  # "Strong Edge" / "Moderate Edge" / "Slight Edge"
+    summary: str = ""  # Human-readable one-liner
+    ranking_factors: dict = field(default_factory=dict)  # Score component breakdown
+    flags: list[str] = field(default_factory=list)  # Active guards/bonuses
 
     def to_dict(self) -> dict[str, Any]:
-        trade_has_idp = any(
-            a.position in IDP_POSITIONS for a in [*self.give, *self.receive]
-        )
+        trade_has_idp = any(a.position in IDP_POSITIONS for a in [*self.give, *self.receive])
 
         def _asset_dict(a: Asset) -> dict[str, Any]:
             d: dict[str, Any] = {
@@ -139,6 +139,7 @@ class TradeCandidate:
 
 
 # ── Explainability helpers ────────────────────────────────────────────────
+
 
 def _confidence_tier(score: float) -> str:
     if score >= 0.75:
@@ -255,16 +256,18 @@ def build_asset_pool(
         if pos in EXCLUDED_POSITIONS:
             continue
 
-        pool.append(Asset(
-            name=name,
-            position=pos,
-            team=team if isinstance(team, str) else "",
-            model_value=model,
-            ktc_value=ktc,
-            is_pick=is_pick,
-            source_count=source_count,
-            offense_only_model_value=oo_raw if oo_raw is not None and oo_raw >= 1 else None,
-        ))
+        pool.append(
+            Asset(
+                name=name,
+                position=pos,
+                team=team if isinstance(team, str) else "",
+                model_value=model,
+                ktc_value=ktc,
+                is_pick=is_pick,
+                source_count=source_count,
+                offense_only_model_value=oo_raw if oo_raw is not None and oo_raw >= 1 else None,
+            )
+        )
 
     # ── Assign KTC rank and apply top-N filter ────────────────────
     # Rank by KTC value descending.  Players without KTC get no rank.
@@ -274,7 +277,9 @@ def build_asset_pool(
         a.ktc_rank = i + 1
 
     if ktc_top_n > 0:
-        eligible_names = {a.name for a in with_ktc if a.ktc_rank is not None and a.ktc_rank <= ktc_top_n}
+        eligible_names = {
+            a.name for a in with_ktc if a.ktc_rank is not None and a.ktc_rank <= ktc_top_n
+        }
         pool = [a for a in pool if a.name in eligible_names]
 
     return pool
@@ -352,9 +357,7 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     # Use offense-only model values when neither side has IDP players.
     # This excludes IDP source calibration from trade scoring so that
     # an all-offense trade isn't influenced by IDP-relative rankings.
-    trade_has_idp = any(
-        a.position in IDP_POSITIONS for a in [*give, *receive]
-    )
+    trade_has_idp = any(a.position in IDP_POSITIONS for a in [*give, *receive])
 
     def _mv(a: Asset) -> int:
         if not trade_has_idp and a.offense_only_model_value is not None:
@@ -477,8 +480,13 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     edge_lbl = _edge_label(board_gain_norm)
     pkg_size_str = f"{len(give)}-for-{len(receive)}"
     summary = _build_summary(
-        board_delta, board_gain_norm, opp_appeal,
-        coverage, conf_tier, edge_lbl, pkg_size_str,
+        board_delta,
+        board_gain_norm,
+        opp_appeal,
+        coverage,
+        conf_tier,
+        edge_lbl,
+        pkg_size_str,
     )
     ranking_factors = {
         "boardEdge": round(f_board_edge, 2),
@@ -623,8 +631,11 @@ def find_trades(
 
     my_roster = _resolve_roster(my_team, sleeper_teams, pool_by_name)
     if not my_roster:
-        return {"error": f"Could not resolve team '{my_team}' or roster is empty.",
-                "trades": [], "metadata": {}}
+        return {
+            "error": f"Could not resolve team '{my_team}' or roster is empty.",
+            "trades": [],
+            "metadata": {},
+        }
 
     my_names = {a.name for a in my_roster}
     all_trades: list[TradeCandidate] = []

--- a/src/trade/ktc_import.py
+++ b/src/trade/ktc_import.py
@@ -27,6 +27,7 @@ The player-map fetch is cached for 1 hour — KTC doesn't add new IDs
 often enough to matter, and hitting their HTML on every import would
 be rude.
 """
+
 from __future__ import annotations
 
 import json
@@ -70,9 +71,11 @@ def _fetch_ktc_players(timeout: float = 15.0) -> list[dict[str, Any]]:
     bp = None
     try:
         from src.utils import circuit_breaker as _cb
+
         bp = _cb.get_or_create(
             "ktc_scraper",
-            failure_threshold=3, failure_window_sec=120.0,
+            failure_threshold=3,
+            failure_window_sec=120.0,
             open_duration_sec=120.0,
         )
         if not bp.can_call():
@@ -180,9 +183,7 @@ def parse_trade_url(url: str) -> tuple[list[int], list[int]]:
     team_one = _parse_side(query.get("teamOne", []))
     team_two = _parse_side(query.get("teamTwo", []))
     if not team_one and not team_two:
-        raise ValueError(
-            "KTC URL is missing both teamOne and teamTwo parameters"
-        )
+        raise ValueError("KTC URL is missing both teamOne and teamTwo parameters")
     return team_one, team_two
 
 
@@ -329,10 +330,13 @@ def build_ktc_url(side_one_names, side_two_names, *, player_map=None):
     one_ids, one_missing = _resolve(side_one_names)
     two_ids, two_missing = _resolve(side_two_names)
     params = {
-        "var": "5", "pickVal": "0",
+        "var": "5",
+        "pickVal": "0",
         "teamOne": "|".join(str(i) for i in one_ids),
         "teamTwo": "|".join(str(i) for i in two_ids),
-        "format": "2", "isStartup": "0", "tep": "0",
+        "format": "2",
+        "isStartup": "0",
+        "tep": "0",
     }
     url = _KTC_CALCULATOR_URL + "?" + urllib.parse.urlencode(params, safe="|")
     return {

--- a/src/trade/ktc_va.py
+++ b/src/trade/ktc_va.py
@@ -16,6 +16,7 @@ Parity with the JS port is verified by
 fixture (``scripts/ktc_va_observations.json``) through both the
 Python and JS implementations and asserts agreement to ±1.
 """
+
 from __future__ import annotations
 
 import math
@@ -50,9 +51,7 @@ def ktc_process_v(value: float, max_in_trade: float, t: float, nerf_index: int) 
     if value <= 0 or max_in_trade <= 0 or t <= 0:
         return 0.0
     s = (
-        0.05 * math.pow(value / t, 1.3)
-        + 0.05 * math.pow(value / (1.05 * max_in_trade), 6)
-        + 0.1
+        0.05 * math.pow(value / t, 1.3) + 0.05 * math.pow(value / (1.05 * max_in_trade), 6) + 0.1
     ) * value
     if nerf_index > 0:
         s *= max(0.6, 1 - 0.15 * nerf_index)
@@ -61,9 +60,7 @@ def ktc_process_v(value: float, max_in_trade: float, t: float, nerf_index: int) 
     return s
 
 
-def ktc_reverse_adjust(
-    raw_diff: float, max_in_trade: float, t: float, nerf_count: int
-) -> int:
+def ktc_reverse_adjust(raw_diff: float, max_in_trade: float, t: float, nerf_count: int) -> int:
     """KTC's iterative virtual-player solver (site.min.js::reverseAdjust)."""
     if raw_diff <= 0 or max_in_trade <= 0:
         return 0

--- a/src/trade/monte_carlo.py
+++ b/src/trade/monte_carlo.py
@@ -36,6 +36,7 @@ No numpy required — uses Python's stdlib ``random`` module.
 NumPy acceleration kicks in when available for the hot loop
 but falls back to stdlib without user-visible difference.
 """
+
 from __future__ import annotations
 
 import math
@@ -49,6 +50,7 @@ _DEFAULT_SIMS = 50_000
 @dataclass(frozen=True)
 class TradePlayer:
     """Minimal player shape the simulator needs."""
+
     name: str
     team: str
     position_group: str  # "offense" | "idp" | "pick"
@@ -93,7 +95,8 @@ class SimResult:
                 "where side A's total exceeds side B's — NOT a "
                 "real-world win probability."
             ),
-            "vaAdjustment": self.va_adjustment or {"side": 0, "value": 0, "effectiveValue": 0, "applied": False},
+            "vaAdjustment": self.va_adjustment
+            or {"side": 0, "value": 0, "effectiveValue": 0, "applied": False},
         }
 
 
@@ -163,9 +166,7 @@ def _apply_consolidation_adjustment(
     if not applied:
         return side_a, side_b, va_info
 
-    def _shift_side(
-        players: list[TradePlayer], p50s: list[float]
-    ) -> tuple[list[TradePlayer], int]:
+    def _shift_side(players: list[TradePlayer], p50s: list[float]) -> tuple[list[TradePlayer], int]:
         """Shift the band for each player proportionally.
 
         Returns the shifted list and the *actual* total p50 shift after
@@ -181,14 +182,16 @@ def _apply_consolidation_adjustment(
             shift = result.value * (pv / total)
             new_p50 = max(0.0, min(9999.0, p.p50 + shift))
             effective_total += new_p50 - p.p50
-            out.append(TradePlayer(
-                name=p.name,
-                team=p.team,
-                position_group=p.position_group,
-                p10=max(0.0, min(9999.0, p.p10 + shift)),
-                p50=new_p50,
-                p90=max(0.0, min(9999.0, p.p90 + shift)),
-            ))
+            out.append(
+                TradePlayer(
+                    name=p.name,
+                    team=p.team,
+                    position_group=p.position_group,
+                    p10=max(0.0, min(9999.0, p.p10 + shift)),
+                    p50=new_p50,
+                    p90=max(0.0, min(9999.0, p.p90 + shift)),
+                )
+            )
         return out, int(round(effective_total))
 
     if result.side == 1:
@@ -232,10 +235,16 @@ def simulate_trade(
     players = list(side_a) + list(side_b)
     if not players:
         return SimResult(
-            win_prob_a=0.5, mean_delta=0.0, std_delta=0.0,
-            delta_p10=0.0, delta_p50=0.0, delta_p90=0.0,
-            side_a_mean=0.0, side_b_mean=0.0,
-            n_sims=0, method="consensus_based_win_rate",
+            win_prob_a=0.5,
+            mean_delta=0.0,
+            std_delta=0.0,
+            delta_p10=0.0,
+            delta_p50=0.0,
+            delta_p90=0.0,
+            side_a_mean=0.0,
+            side_b_mean=0.0,
+            n_sims=0,
+            method="consensus_based_win_rate",
             va_adjustment={"side": 0, "value": 0, "effectiveValue": 0, "applied": False},
         )
 
@@ -262,11 +271,7 @@ def simulate_trade(
             zt = z_team.get(pl.team, 0.0) if rho_t else 0.0
             zp = z_pos.get(pl.position_group, 0.0) if rho_p else 0.0
             z_play = rng.gauss(0.0, 1.0)
-            z_total = (
-                idio_sd * z_play
-                + math.sqrt(rho_t) * zt
-                + math.sqrt(rho_p) * zp
-            )
+            z_total = idio_sd * z_play + math.sqrt(rho_t) * zt + math.sqrt(rho_p) * zp
             # Convert N(0,1) to U(0,1) via standard-normal CDF.
             u = 0.5 * (1.0 + math.erf(z_total / math.sqrt(2.0)))
             # Clamp to avoid edge artifacts from float error.
@@ -334,8 +339,8 @@ def build_trade_player(
         return None
     team = str(row.get("team") or "").strip().upper()
     pos = str(row.get("pos") or row.get("position") or "").upper()
-    group = "idp" if pos in ("DL", "LB", "DB", "CB", "S") else (
-        "pick" if pos == "PICK" else "offense"
+    group = (
+        "idp" if pos in ("DL", "LB", "DB", "CB", "S") else ("pick" if pos == "PICK" else "offense")
     )
 
     # Scoring-fit shift: a single additive offset on the entire band.
@@ -357,7 +362,9 @@ def build_trade_player(
     band = row.get("valueBand") or {}
     if isinstance(band, dict) and band.get("p50") is not None:
         return TradePlayer(
-            name=name, team=team, position_group=group,
+            name=name,
+            team=team,
+            position_group=group,
             p10=_shifted(band.get("p10") or 0),
             p50=_shifted(band.get("p50") or 0),
             p90=_shifted(band.get("p90") or 0),
@@ -365,7 +372,9 @@ def build_trade_player(
     # Fallback: synthesize a 15% band around the canonical value.
     cv = float(row.get("rankDerivedValue") or row.get("values", {}).get("full") or 0)
     return TradePlayer(
-        name=name, team=team, position_group=group,
+        name=name,
+        team=team,
+        position_group=group,
         p10=_shifted(cv * 0.85),
         p50=_shifted(cv),
         p90=_shifted(cv * 1.15),

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -16,6 +16,7 @@ Design principles:
 
 The engine does NOT modify any internal canonical values or calibration.
 """
+
 from __future__ import annotations
 
 import math
@@ -31,13 +32,13 @@ from src.utils.name_clean import normalize_position as _norm_pos  # noqa: F401 �
 
 # Starter demand per position in default SF/TEP/IDP (effective starters per team)
 DEFAULT_STARTER_NEEDS: dict[str, int] = {
-    "QB": 2,   # 1 QB + ~1 SFLEX
-    "RB": 3,   # 2 RB + ~1 FLEX
-    "WR": 4,   # 3 WR + ~1 FLEX
-    "TE": 1,   # 1 TE
-    "DL": 3,   # 2 DL + ~1 IDP_FLEX
-    "LB": 3,   # 2 LB + ~1 IDP_FLEX
-    "DB": 2,   # 2 DB
+    "QB": 2,  # 1 QB + ~1 SFLEX
+    "RB": 3,  # 2 RB + ~1 FLEX
+    "WR": 4,  # 3 WR + ~1 FLEX
+    "TE": 1,  # 1 TE
+    "DL": 3,  # 2 DL + ~1 IDP_FLEX
+    "LB": 3,  # 2 LB + ~1 IDP_FLEX
+    "DB": 2,  # 2 DB
 }
 
 # Minimum display value to consider a player "rosterable" (not a throw-in)
@@ -91,8 +92,8 @@ MIN_ACTIONABLE_VALUE = 2000
 MAX_GAP_FOR_1FOR1 = 400
 
 # Market-disagreement thresholds
-HIGH_DISPERSION_CV = 0.12   # CV above this = sources disagree meaningfully
-LOW_DISPERSION_CV = 0.04    # CV below this = strong consensus
+HIGH_DISPERSION_CV = 0.12  # CV above this = sources disagree meaningfully
+LOW_DISPERSION_CV = 0.04  # CV below this = strong consensus
 
 # ── KTC quality gate ────────────────────────────────────────────────
 # Hard filter: only players ranked inside the KTC top-N are eligible for
@@ -110,6 +111,7 @@ _IDP_BASE_POSITIONS = frozenset({"DL", "LB", "DB"})
 @dataclass
 class PlayerAsset:
     """A player or pick with canonical values."""
+
     name: str
     position: str
     display_value: int
@@ -127,21 +129,23 @@ class PlayerAsset:
 @dataclass
 class RosterAnalysis:
     """Positional analysis of a roster."""
+
     roster_size: int
     by_position: dict[str, list[PlayerAsset]]
     surplus_positions: list[str]
     need_positions: list[str]
     starter_counts: dict[str, int]  # above-replacement count
-    depth_counts: dict[str, int]   # below-replacement count
+    depth_counts: dict[str, int]  # below-replacement count
 
 
 @dataclass
 class TradeSuggestion:
     """A single trade suggestion."""
+
     type: str  # "sell_high", "buy_low", "consolidation", "positional_upgrade"
     give: list[PlayerAsset]
     receive: list[PlayerAsset]
-    give_total: int   # display value
+    give_total: int  # display value
     receive_total: int
     gap: int
     fairness: str  # "even", "lean", "stretch"
@@ -152,6 +156,7 @@ class TradeSuggestion:
 
 
 # ── Market-disagreement helpers ──────────────────────────────────────
+
 
 def _compute_cv(values: list[float]) -> float | None:
     """Coefficient of variation: std / mean. None if < 2 values or mean is 0."""
@@ -257,21 +262,27 @@ def build_asset_pool(
 
         # Compute source dispersion CV
         source_values = a.get("source_values", {})
-        sv_list = [float(v) for v in source_values.values() if v is not None] if isinstance(source_values, dict) else []
+        sv_list = (
+            [float(v) for v in source_values.values() if v is not None]
+            if isinstance(source_values, dict)
+            else []
+        )
         dispersion = _compute_cv(sv_list)
 
-        pool.append(PlayerAsset(
-            name=name,
-            position=pos,
-            display_value=int(dv),
-            calibrated_value=int(cv),
-            source_count=len(sv_list),
-            team=str(meta.get("team", "") or ""),
-            rookie=bool(meta.get("rookie", False)),
-            years_exp=meta.get("years_exp"),
-            universe=str(a.get("universe", "")),
-            dispersion_cv=round(dispersion, 4) if dispersion is not None else None,
-        ))
+        pool.append(
+            PlayerAsset(
+                name=name,
+                position=pos,
+                display_value=int(dv),
+                calibrated_value=int(cv),
+                source_count=len(sv_list),
+                team=str(meta.get("team", "") or ""),
+                rookie=bool(meta.get("rookie", False)),
+                years_exp=meta.get("years_exp"),
+                universe=str(a.get("universe", "")),
+                dispersion_cv=round(dispersion, 4) if dispersion is not None else None,
+            )
+        )
     pool.sort(key=lambda x: -x.display_value)
 
     # ── Compute KTC rank and apply top-N filter ────────────────────
@@ -285,6 +296,7 @@ def build_asset_pool(
 # ──────────────────────────────────────────────────────────────────────
 # Contract-native asset pool
 # ──────────────────────────────────────────────────────────────────────
+
 
 def _universe_from_row(row: dict[str, Any]) -> str:
     """Derive the asset's universe label from the live contract row.
@@ -450,19 +462,21 @@ def build_asset_pool_from_contract(
         if isinstance(oo_rdv, (int, float)) and oo_rdv > 0:
             oo_int = int(oo_rdv)
 
-        pool.append(PlayerAsset(
-            name=name,
-            position=pos,
-            display_value=cv_int,
-            calibrated_value=cv_int,
-            source_count=len(sv_list),
-            team=team,
-            rookie=bool(row.get("rookie")),
-            years_exp=years_exp,
-            universe=_universe_from_row(row),
-            dispersion_cv=round(dispersion, 4) if dispersion is not None else None,
-            offense_only_value=oo_int,
-        ))
+        pool.append(
+            PlayerAsset(
+                name=name,
+                position=pos,
+                display_value=cv_int,
+                calibrated_value=cv_int,
+                source_count=len(sv_list),
+                team=team,
+                rookie=bool(row.get("rookie")),
+                years_exp=years_exp,
+                universe=_universe_from_row(row),
+                dispersion_cv=round(dispersion, 4) if dispersion is not None else None,
+                offense_only_value=oo_int,
+            )
+        )
     pool.sort(key=lambda x: -x.display_value)
 
     # ── Compute KTC rank and apply top-N filter ────────────────────
@@ -572,10 +586,7 @@ def _eff_val(p: PlayerAsset, offense_only: bool) -> int:
 
 
 def _trade_is_idp_free(give: list[PlayerAsset], receive: list[PlayerAsset]) -> bool:
-    return all(
-        p.position not in _IDP_BASE_POSITIONS
-        for p in [*give, *receive]
-    )
+    return all(p.position not in _IDP_BASE_POSITIONS for p in [*give, *receive])
 
 
 def _va_gap(give_vals: list[int], recv_vals: list[int]) -> int:
@@ -747,9 +758,7 @@ def rank_score_breakdown(
         "edge": round(edge_b, 2),
         "opponent_fit": round(opp_fit, 2),
         "overflow_penalty": round(-overflow_penalty, 2),
-        "total": round(
-            base + fair + conf + need_sev + edge_b + opp_fit - overflow_penalty, 2
-        ),
+        "total": round(base + fair + conf + need_sev + edge_b + opp_fit - overflow_penalty, 2),
     }
 
 
@@ -762,6 +771,7 @@ def _rank_sort_key(s: TradeSuggestion, roster: RosterAnalysis | None = None):
 
 
 # ── Opponent-aware helpers ───────────────────────────────────────────
+
 
 def _analyze_opponent_rosters(
     league_rosters: list[dict[str, Any]],
@@ -817,6 +827,7 @@ def _opponent_fit_label(
 
 # ── Suggestion generators ───────────────────────────────────────────
 
+
 def _generate_sell_high(
     roster: RosterAnalysis,
     asset_pool: list[PlayerAsset],
@@ -838,12 +849,12 @@ def _generate_sell_high(
                 # Pre-compute oo so target filtering and sorting use the same
                 # value scale as the gap calculation below.
                 trade_oo = (
-                    sell.position not in _IDP_BASE_POSITIONS
-                    and need_pos not in _IDP_BASE_POSITIONS
+                    sell.position not in _IDP_BASE_POSITIONS and need_pos not in _IDP_BASE_POSITIONS
                 )
                 sell_ev = _eff_val(sell, trade_oo)
                 targets = [
-                    a for a in asset_pool
+                    a
+                    for a in asset_pool
                     if a.position == need_pos
                     and a.name.lower() not in roster_names_set
                     and _eff_val(a, trade_oo) >= MIN_RELEVANT_VALUE
@@ -857,20 +868,24 @@ def _generate_sell_high(
                 give_val = _eff_val(sell, oo)
                 recv_val = _eff_val(target, oo)
                 gap = _va_gap([give_val], [recv_val])
-                suggestions.append(TradeSuggestion(
-                    type="sell_high",
-                    give=[sell],
-                    receive=[target],
-                    give_total=give_val,
-                    receive_total=recv_val,
-                    gap=gap,
-                    fairness=_fairness_label(gap),
-                    rationale=f"You have {pos} surplus ({len(players)} rostered, need {need}). "
-                              f"Move {sell.name} for a {need_pos} upgrade.",
-                    why_this_helps=f"Converts {pos} depth into a {need_pos} you actually need.",
-                    confidence=_confidence_from_sources(min(sell.source_count, target.source_count)),
-                    strategy=_strategy_for_player(sell),
-                ))
+                suggestions.append(
+                    TradeSuggestion(
+                        type="sell_high",
+                        give=[sell],
+                        receive=[target],
+                        give_total=give_val,
+                        receive_total=recv_val,
+                        gap=gap,
+                        fairness=_fairness_label(gap),
+                        rationale=f"You have {pos} surplus ({len(players)} rostered, need {need}). "
+                        f"Move {sell.name} for a {need_pos} upgrade.",
+                        why_this_helps=f"Converts {pos} depth into a {need_pos} you actually need.",
+                        confidence=_confidence_from_sources(
+                            min(sell.source_count, target.source_count)
+                        ),
+                        strategy=_strategy_for_player(sell),
+                    )
+                )
 
     # Preliminary sort by value; final ranking applied in generate_suggestions()
     suggestions.sort(key=lambda s: -min(s.give_total, s.receive_total))
@@ -893,7 +908,8 @@ def _generate_buy_low(
         target_floor = max(MIN_RELEVANT_VALUE, current_best)
 
         targets = [
-            a for a in asset_pool
+            a
+            for a in asset_pool
             if a.position == need_pos
             and a.name.lower() not in roster_names_set
             and _eff_val(a, pos_oo) > target_floor
@@ -912,21 +928,25 @@ def _generate_buy_low(
                     recv_val = _eff_val(target, oo)
                     gap = _va_gap([give_val], [recv_val])
                     if abs(gap) < FAIRNESS_TOLERANCE:
-                        suggestions.append(TradeSuggestion(
-                            type="buy_low",
-                            give=[sell],
-                            receive=[target],
-                            give_total=give_val,
-                            receive_total=recv_val,
-                            gap=gap,
-                            fairness=_fairness_label(gap),
-                            rationale=f"Target {target.name} ({need_pos}) fills your roster need. "
-                                      f"You can afford to trade {sell.name} from {surplus_pos} surplus.",
-                            why_this_helps=f"Adds a starter-caliber {need_pos} without weakening "
-                                           f"your {surplus_pos} starting lineup.",
-                            confidence=_confidence_from_sources(min(sell.source_count, target.source_count)),
-                            strategy="neutral",
-                        ))
+                        suggestions.append(
+                            TradeSuggestion(
+                                type="buy_low",
+                                give=[sell],
+                                receive=[target],
+                                give_total=give_val,
+                                receive_total=recv_val,
+                                gap=gap,
+                                fairness=_fairness_label(gap),
+                                rationale=f"Target {target.name} ({need_pos}) fills your roster need. "
+                                f"You can afford to trade {sell.name} from {surplus_pos} surplus.",
+                                why_this_helps=f"Adds a starter-caliber {need_pos} without weakening "
+                                f"your {surplus_pos} starting lineup.",
+                                confidence=_confidence_from_sources(
+                                    min(sell.source_count, target.source_count)
+                                ),
+                                strategy="neutral",
+                            )
+                        )
 
     # Deduplicate by receive target (keep tightest gap)
     seen: dict[str, TradeSuggestion] = {}
@@ -977,7 +997,8 @@ def _generate_consolidation(
 
             for prefer_need in [True, False]:
                 targets = [
-                    a for a in asset_pool
+                    a
+                    for a in asset_pool
                     if a.name.lower() not in roster_names_set
                     and min_target <= _eff_val(a, pair_oo) <= max_target
                     and _eff_val(a, pair_oo) > give_max
@@ -997,22 +1018,28 @@ def _generate_consolidation(
                 give_total = give_p1 + give_p2
                 recv_total = _eff_val(target, oo)
                 gap = _va_gap([give_p1, give_p2], [recv_total])
-                pos_note = f" at a position of need ({target.position})" if target.position in roster.need_positions else ""
-                suggestions.append(TradeSuggestion(
-                    type="consolidation",
-                    give=[p1, p2],
-                    receive=[target],
-                    give_total=give_total,
-                    receive_total=recv_total,
-                    gap=gap,
-                    fairness=_fairness_label(gap),
-                    rationale=f"Package {p1.name} + {p2.name} into {target.name}{pos_note}. "
-                              f"Turns two depth pieces into one difference-maker.",
-                    why_this_helps=f"Upgrades roster quality by condensing {p1.position}/{p2.position} "
-                                   f"depth into a higher-tier asset.",
-                    confidence=_confidence_from_sources(target.source_count),
-                    strategy="contender" if target.display_value >= 7000 else "neutral",
-                ))
+                pos_note = (
+                    f" at a position of need ({target.position})"
+                    if target.position in roster.need_positions
+                    else ""
+                )
+                suggestions.append(
+                    TradeSuggestion(
+                        type="consolidation",
+                        give=[p1, p2],
+                        receive=[target],
+                        give_total=give_total,
+                        receive_total=recv_total,
+                        gap=gap,
+                        fairness=_fairness_label(gap),
+                        rationale=f"Package {p1.name} + {p2.name} into {target.name}{pos_note}. "
+                        f"Turns two depth pieces into one difference-maker.",
+                        why_this_helps=f"Upgrades roster quality by condensing {p1.position}/{p2.position} "
+                        f"depth into a higher-tier asset.",
+                        confidence=_confidence_from_sources(target.source_count),
+                        strategy="contender" if target.display_value >= 7000 else "neutral",
+                    )
+                )
                 break
 
     # Preliminary sort; final ranking applied in generate_suggestions()
@@ -1048,7 +1075,8 @@ def _generate_positional_upgrades(
         upgrade_floor = ws_ev + 500
 
         targets = [
-            a for a in asset_pool
+            a
+            for a in asset_pool
             if a.position == pos
             and a.name.lower() not in roster_names_set
             and _eff_val(a, pos_oo) >= upgrade_floor
@@ -1060,7 +1088,8 @@ def _generate_positional_upgrades(
         for target in targets[:5]:
             gap_needed = _eff_val(target, pos_oo) - ws_ev
             sweeteners = [
-                p for p in depth
+                p
+                for p in depth
                 if p.name != weakest_starter.name
                 and abs(_eff_val(p, pos_oo) - gap_needed) < FAIRNESS_TOLERANCE
             ]
@@ -1090,20 +1119,22 @@ def _generate_positional_upgrades(
             if abs(gap) > FAIRNESS_TOLERANCE * 1.5:
                 continue
 
-            suggestions.append(TradeSuggestion(
-                type="positional_upgrade",
-                give=[weakest_starter, sweetener],
-                receive=[target],
-                give_total=give_total,
-                receive_total=recv_total,
-                gap=gap,
-                fairness=_fairness_label(gap),
-                rationale=f"Upgrade {pos} starter: move {weakest_starter.name} + {sweetener.name} "
-                          f"for {target.name}.",
-                why_this_helps=f"Replaces your {pos}{need} with a higher-caliber {pos} starter.",
-                confidence=_confidence_from_sources(target.source_count),
-                strategy="contender",
-            ))
+            suggestions.append(
+                TradeSuggestion(
+                    type="positional_upgrade",
+                    give=[weakest_starter, sweetener],
+                    receive=[target],
+                    give_total=give_total,
+                    receive_total=recv_total,
+                    gap=gap,
+                    fairness=_fairness_label(gap),
+                    rationale=f"Upgrade {pos} starter: move {weakest_starter.name} + {sweetener.name} "
+                    f"for {target.name}.",
+                    why_this_helps=f"Replaces your {pos}{need} with a higher-caliber {pos} starter.",
+                    confidence=_confidence_from_sources(target.source_count),
+                    strategy="contender",
+                )
+            )
 
     # Preliminary sort; final ranking applied in generate_suggestions()
     suggestions.sort(key=lambda s: -s.receive_total)
@@ -1133,19 +1164,26 @@ def _find_balancers(
     if gap < 0 and roster is not None:
         # User needs to sweeten — search THEIR roster for expendable depth
         candidates = _roster_balancer_candidates(
-            target_value, roster, exclude_names,
+            target_value,
+            roster,
+            exclude_names,
         )
     else:
         # Opponent needs to sweeten — search global pool
         candidates = _pool_balancer_candidates(
-            target_value, asset_pool, roster_names_set, exclude_names,
+            target_value,
+            asset_pool,
+            roster_names_set,
+            exclude_names,
         )
 
-    candidates.sort(key=lambda c: (
-        0 if (roster and c.position in roster.surplus_positions) else 1,
-        abs(c.display_value - target_value),
-        c.name,
-    ))
+    candidates.sort(
+        key=lambda c: (
+            0 if (roster and c.position in roster.surplus_positions) else 1,
+            abs(c.display_value - target_value),
+            c.name,
+        )
+    )
     return (candidates[:MAX_BALANCERS], side)
 
 
@@ -1181,7 +1219,8 @@ def _pool_balancer_candidates(
 ) -> list[PlayerAsset]:
     """Find realistic balancer candidates from the global asset pool."""
     return [
-        a for a in asset_pool
+        a
+        for a in asset_pool
         if a.name.lower() not in roster_names_set
         and a.name.lower() not in exclude_names
         and a.position  # skip positionless / placeholder entries
@@ -1195,6 +1234,7 @@ MAX_BALANCERS = 2
 
 
 # ── Quality filter ───────────────────────────────────────────────────
+
 
 def _apply_quality_filters(
     categories: dict[str, list[TradeSuggestion]],
@@ -1221,7 +1261,8 @@ def _apply_quality_filters(
     # no opponent accepts either.
     if "consolidation" in categories:
         categories["consolidation"] = [
-            s for s in categories["consolidation"]
+            s
+            for s in categories["consolidation"]
             if s.fairness != "stretch"
             or (s.give_total > 0 and abs(s.gap) / s.give_total <= CONSOLIDATION_MAX_OVERPAY_RATIO)
         ]
@@ -1253,11 +1294,9 @@ def _apply_quality_filters(
     # Both sides below MIN_ACTIONABLE_VALUE = not worth the conversation.
     for cat_name, suggs in categories.items():
         categories[cat_name] = [
-            s for s in suggs
-            if not all(
-                p.display_value < MIN_ACTIONABLE_VALUE
-                for p in s.give + s.receive
-            )
+            s
+            for s in suggs
+            if not all(p.display_value < MIN_ACTIONABLE_VALUE for p in s.give + s.receive)
         ]
 
     # ── 5. Suppress same-tier swaps ──────────────────────────────────
@@ -1265,7 +1304,8 @@ def _apply_quality_filters(
     # offer no strategic benefit — just lateral movement.
     for cat_name, suggs in categories.items():
         categories[cat_name] = [
-            s for s in suggs
+            s
+            for s in suggs
             if not (
                 len(s.give) == 1
                 and len(s.receive) == 1
@@ -1280,7 +1320,8 @@ def _apply_quality_filters(
     # is misleading.
     for cat_name, suggs in categories.items():
         categories[cat_name] = [
-            s for s in suggs
+            s
+            for s in suggs
             if not (
                 len(s.give) == 1
                 and len(s.receive) == 1
@@ -1309,8 +1350,7 @@ def _apply_quality_filters(
             for s in suggs:
                 # Check if ANY give-player would exceed the cap
                 would_exceed = any(
-                    give_counts.get(p.name, 0) >= MAX_GIVE_PLAYER_APPEARANCES
-                    for p in s.give
+                    give_counts.get(p.name, 0) >= MAX_GIVE_PLAYER_APPEARANCES for p in s.give
                 )
                 if would_exceed:
                     continue
@@ -1323,6 +1363,7 @@ def _apply_quality_filters(
 
 
 # ── Main entry point ─────────────────────────────────────────────────
+
 
 def _rookies_eligible_today() -> bool:
     """Return False between Feb 1 and May 11 of each year — the
@@ -1339,6 +1380,7 @@ def _rookies_eligible_today() -> bool:
     real values — eligible for suggestions like any other asset.
     """
     from datetime import datetime, timezone
+
     today = datetime.now(timezone.utc).date()
     m, d = today.month, today.day
     # Pre-draft window: Feb 1 through May 11 (inclusive).
@@ -1424,12 +1466,14 @@ def generate_suggestions_from_pool(
 
     # Phase 5: Quality filters — deduplication and noise suppression.
     # Applied AFTER ranking so we keep the best-ranked instances.
-    filtered = _apply_quality_filters({
-        "sell_high": sell_high,
-        "buy_low": buy_low,
-        "consolidation": consolidation,
-        "positional_upgrade": upgrades,
-    })
+    filtered = _apply_quality_filters(
+        {
+            "sell_high": sell_high,
+            "buy_low": buy_low,
+            "consolidation": consolidation,
+            "positional_upgrade": upgrades,
+        }
+    )
     sell_high = filtered["sell_high"]
     buy_low = filtered["buy_low"]
     consolidation = filtered["consolidation"]
@@ -1492,6 +1536,7 @@ def generate_suggestions(
 
 # ── Serializers ──────────────────────────────────────────────────────
 
+
 def _serialize_player(p: PlayerAsset, *, offense_only: bool = False) -> dict[str, Any]:
     dv = (
         p.offense_only_value
@@ -1512,7 +1557,9 @@ def _serialize_player(p: PlayerAsset, *, offense_only: bool = False) -> dict[str
     return result
 
 
-def _serialize_suggestion(s: TradeSuggestion, roster: RosterAnalysis | None = None) -> dict[str, Any]:
+def _serialize_suggestion(
+    s: TradeSuggestion, roster: RosterAnalysis | None = None
+) -> dict[str, Any]:
     oo = _trade_is_idp_free(s.give, s.receive)
     result: dict[str, Any] = {
         "type": s.type,
@@ -1553,7 +1600,6 @@ def _serialize_roster(r: RosterAnalysis) -> dict[str, Any]:
         "starterCounts": r.starter_counts,
         "depthCounts": r.depth_counts,
         "byPosition": {
-            pos: [_serialize_player(p) for p in players]
-            for pos, players in r.by_position.items()
+            pos: [_serialize_player(p) for p in players] for pos, players in r.by_position.items()
         },
     }

--- a/src/trade/symmetrize.py
+++ b/src/trade/symmetrize.py
@@ -30,6 +30,7 @@ Same keys as the underlying ``SimResult.to_dict()`` plus:
 Consumers (trade calc UI) should render the AVERAGED values and
 can optionally surface ``drift`` as a diagnostic.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -102,14 +103,19 @@ def simulate_symmetric(
     result dict.  Uses different seeds (seed, seed+1) for the two
     passes so samples aren't correlated across directions."""
     ab = _mc.simulate_trade(
-        side_a, side_b,
-        n_sims=n_sims, same_team_rho=same_team_rho,
-        same_pos_group_rho=same_pos_group_rho, seed=seed,
+        side_a,
+        side_b,
+        n_sims=n_sims,
+        same_team_rho=same_team_rho,
+        same_pos_group_rho=same_pos_group_rho,
+        seed=seed,
         apply_consolidation_adjustment=apply_consolidation_adjustment,
     )
     ba = _mc.simulate_trade(
-        side_b, side_a,
-        n_sims=n_sims, same_team_rho=same_team_rho,
+        side_b,
+        side_a,
+        n_sims=n_sims,
+        same_team_rho=same_team_rho,
         same_pos_group_rho=same_pos_group_rho,
         seed=(seed + 1) if seed is not None else None,
         apply_consolidation_adjustment=apply_consolidation_adjustment,
@@ -118,7 +124,12 @@ def simulate_symmetric(
     # AB pass is canonical for VA metadata: its side=1/2 labels already
     # use the caller's convention (1=sideA, 2=sideB).  The BA pass has
     # swapped arguments so its va_side would need re-mapping.
-    result["vaAdjustment"] = ab.va_adjustment or {"side": 0, "value": 0, "effectiveValue": 0, "applied": False}
+    result["vaAdjustment"] = ab.va_adjustment or {
+        "side": 0,
+        "value": 0,
+        "effectiveValue": 0,
+        "applied": False,
+    }
     return result
 
 
@@ -158,10 +169,12 @@ def enrich_with_decision_shape(
         else:
             adjusted_delta = a_p50 - (b_p50 + va_val)
     else:
+
         def _spread_ratio(side):
             total = sum(p.p50 for p in side) or 1.0
             spread = sum((p.p90 - p.p10) for p in side)
             return spread / total if total > 0 else 0.0
+
         a_spread = _spread_ratio(side_a)
         b_spread = _spread_ratio(side_b)
         a_adjusted = a_p50 * (1.0 - 0.3 * a_spread)
@@ -213,7 +226,4 @@ def _summary(win_pct: float, raw_delta: float, risk: str, impact: str) -> str:
     if 49.0 <= win_pct <= 51.0:
         return f"Coin-flip trade (~50%, Δ={raw_delta:+.0f} {impact}, risk {risk})"
     side = "Side A" if win_pct >= 50 else "Side B"
-    return (
-        f"{side} favored at {win_pct:.0f}% "
-        f"(Δ={raw_delta:+.0f} {impact}, risk {risk})"
-    )
+    return f"{side} favored at {win_pct:.0f}% " f"(Δ={raw_delta:+.0f} {impact}, risk {risk})"

--- a/src/trade/team_impact.py
+++ b/src/trade/team_impact.py
@@ -17,6 +17,7 @@ This module produces a *fit score alongside* a player's value.  It
 NEVER mutates ``row.value`` per team.  The retired LAM module proved
 that path is wrong — do not re-introduce it here.
 """
+
 from __future__ import annotations
 
 import json
@@ -111,8 +112,7 @@ def project_starters(
     """
     slots = _starter_slots(roster_settings)
     pool = [
-        a for a in assets
-        if (a.get("basePos") or a.get("pos") or "").upper() in _BASE_POSITIONS
+        a for a in assets if (a.get("basePos") or a.get("pos") or "").upper() in _BASE_POSITIONS
     ]
     pool.sort(key=lambda a: int(a.get("value") or 0), reverse=True)
     used: set[int] = set()
@@ -145,10 +145,7 @@ def _aggregate_state(
     """
     starters = project_starters(assets, roster_settings)
     starter_count = {p: len(starters[p]) for p in _BASE_POSITIONS}
-    starter_value = {
-        p: sum(int(a.get("value") or 0) for a in starters[p])
-        for p in _BASE_POSITIONS
-    }
+    starter_value = {p: sum(int(a.get("value") or 0) for a in starters[p]) for p in _BASE_POSITIONS}
     total_count: dict[str, int] = {p: 0 for p in _BASE_POSITIONS}
     for a in assets:
         pos = (a.get("basePos") or a.get("pos") or "").upper()
@@ -225,13 +222,15 @@ def _classify_window(
     top10_share = top10_value / total_value
 
     pick_value = sum(
-        int(a.get("value") or 0) for a in before_assets
+        int(a.get("value") or 0)
+        for a in before_assets
         if (a.get("assetClass") or "").lower() == "pick"
     )
     pick_share = pick_value / total_value
 
     young_value = sum(
-        int(a.get("value") or 0) for a in before_assets
+        int(a.get("value") or 0)
+        for a in before_assets
         if isinstance(a.get("age"), int) and a["age"] <= young_max
     )
     young_share = young_value / total_value
@@ -292,9 +291,7 @@ def _redundancy(
     the league doesn't start (no false-positives in non-IDP leagues).
     """
     starter_names = {
-        str(a.get("name") or "").lower()
-        for assets in after_starters.values()
-        for a in assets
+        str(a.get("name") or "").lower() for assets in after_starters.values() for a in assets
     }
     active = set(_league_active_positions(roster_settings))
     out: list[dict[str, Any]] = []
@@ -308,11 +305,13 @@ def _redundancy(
         before_count = before_state["totalCount"].get(pos, 0)
         needed = _needed_at(pos, roster_settings)
         if before_count >= int(needed) + 1:
-            out.append({
-                "name": asset.get("name"),
-                "pos": pos,
-                "reason": "duplicate at saturated position",
-            })
+            out.append(
+                {
+                    "name": asset.get("name"),
+                    "pos": pos,
+                    "reason": "duplicate at saturated position",
+                }
+            )
     return out
 
 
@@ -358,7 +357,9 @@ def _rationale(
         bullets.append((300, f"Acquired {r['name']} ({r['pos']}) doesn't start — duplicate"))
     if abs(window_fit) >= 0.4:
         word = "aligns with" if window_fit > 0 else "fights"
-        bullets.append((abs(window_fit) * 1000, f"Trade {word} a {posture} window ({window_fit:+.1f})"))
+        bullets.append(
+            (abs(window_fit) * 1000, f"Trade {word} a {posture} window ({window_fit:+.1f})")
+        )
     if abs(equity) >= 500:
         bullets.append((abs(equity) * 0.3, f"Net KTC equity {equity:+d}"))
     if abs(fit_score) >= 5:
@@ -391,8 +392,12 @@ def compute(
     after = _aggregate_state(after_assets, roster_settings)
     active = _league_active_positions(roster_settings)
 
-    starter_delta = {p: after["starterCount"][p] - before["starterCount"][p] for p in _BASE_POSITIONS}
-    starter_value_delta = {p: after["starterValue"][p] - before["starterValue"][p] for p in _BASE_POSITIONS}
+    starter_delta = {
+        p: after["starterCount"][p] - before["starterCount"][p] for p in _BASE_POSITIONS
+    }
+    starter_value_delta = {
+        p: after["starterValue"][p] - before["starterValue"][p] for p in _BASE_POSITIONS
+    }
     depth_delta = {p: after["depthCount"][p] - before["depthCount"][p] for p in _BASE_POSITIONS}
 
     # Overflow detection — anything above (needed + 1) is bench bloat.
@@ -406,10 +411,9 @@ def compute(
     # Average starter value per pos, for normalization.
     avg_starter_val: dict[str, float] = {}
     for p in _BASE_POSITIONS:
-        combined = (
-            [int(a.get("value") or 0) for a in before["starters"][p]]
-            + [int(a.get("value") or 0) for a in after["starters"][p]]
-        )
+        combined = [int(a.get("value") or 0) for a in before["starters"][p]] + [
+            int(a.get("value") or 0) for a in after["starters"][p]
+        ]
         avg_starter_val[p] = _avg(combined) or 1500.0
 
     w_fill = float(weights.get("fillStarter", 1.0))
@@ -456,8 +460,14 @@ def compute(
     # shift for the user.  This is reporting only, never re-prices.
     scarcity_delta: dict[str, float] = {}
     for p in active:
-        before_avg = (before["starterValue"][p] / before["starterCount"][p]) if before["starterCount"][p] else 0
-        after_avg = (after["starterValue"][p] / after["starterCount"][p]) if after["starterCount"][p] else 0
+        before_avg = (
+            (before["starterValue"][p] / before["starterCount"][p])
+            if before["starterCount"][p]
+            else 0
+        )
+        after_avg = (
+            (after["starterValue"][p] / after["starterCount"][p]) if after["starterCount"][p] else 0
+        )
         scarcity_delta[p] = round(after_avg - before_avg, 1)
 
     redundancy = _redundancy(receiving, after["starters"], before, roster_settings)

--- a/src/trade/waiver.py
+++ b/src/trade/waiver.py
@@ -9,6 +9,7 @@ Companion ``find_drop_candidates`` returns the lowest-value players
 on the user's roster — best-ball-native: when adding a FA, you have
 to drop someone, and this surfaces who first.
 """
+
 from __future__ import annotations
 
 import logging
@@ -23,12 +24,28 @@ _LOGGER = logging.getLogger(__name__)
 MIN_WAIVER_VALUE = 500
 DEFAULT_PER_POSITION_LIMIT = 6
 
-_BASE_POSITIONS = frozenset({
-    "QB", "RB", "WR", "TE",
-    "DL", "DT", "DE", "EDGE", "NT",
-    "LB", "ILB", "OLB", "MLB",
-    "DB", "CB", "S", "FS", "SS",
-})
+_BASE_POSITIONS = frozenset(
+    {
+        "QB",
+        "RB",
+        "WR",
+        "TE",
+        "DL",
+        "DT",
+        "DE",
+        "EDGE",
+        "NT",
+        "LB",
+        "ILB",
+        "OLB",
+        "MLB",
+        "DB",
+        "CB",
+        "S",
+        "FS",
+        "SS",
+    }
+)
 
 
 @dataclass
@@ -54,7 +71,9 @@ class WaiverCandidate:
                 "aggressive": self.bid_aggressive,
                 "reasonable": self.bid_reasonable,
                 "lowball": self.bid_lowball,
-            } if self.bid_aggressive is not None else None,
+            }
+            if self.bid_aggressive is not None
+            else None,
         }
 
 
@@ -163,9 +182,20 @@ def find_waiver_targets(
         total += len(capped)
 
     family_map = {
-        "DL": "DL", "DT": "DL", "DE": "DL", "EDGE": "DL", "NT": "DL",
-        "LB": "LB", "ILB": "LB", "OLB": "LB", "MLB": "LB",
-        "DB": "DB", "CB": "DB", "S": "DB", "FS": "DB", "SS": "DB",
+        "DL": "DL",
+        "DT": "DL",
+        "DE": "DL",
+        "EDGE": "DL",
+        "NT": "DL",
+        "LB": "LB",
+        "ILB": "LB",
+        "OLB": "LB",
+        "MLB": "LB",
+        "DB": "DB",
+        "CB": "DB",
+        "S": "DB",
+        "FS": "DB",
+        "SS": "DB",
     }
     by_family: dict[str, list[dict[str, Any]]] = {}
     for pos, items in out_by_position.items():
@@ -219,14 +249,19 @@ def find_drop_candidates(
         if not rationale_parts:
             rationale_parts.append("low value vs roster average")
 
-        candidates.append((float(consensus), {
-            "name": name,
-            "position": str(row.get("position") or "").upper(),
-            "consensusValue": int(round(float(consensus))),
-            "adjustedValue": int(round(float(consensus))),  # alias
-            "rank": rank if isinstance(rank, int) else None,
-            "rationale": " · ".join(rationale_parts),
-        }))
+        candidates.append(
+            (
+                float(consensus),
+                {
+                    "name": name,
+                    "position": str(row.get("position") or "").upper(),
+                    "consensusValue": int(round(float(consensus))),
+                    "adjustedValue": int(round(float(consensus))),  # alias
+                    "rank": rank if isinstance(rank, int) else None,
+                    "rationale": " · ".join(rationale_parts),
+                },
+            )
+        )
 
     candidates.sort(key=lambda x: x[0])
     return [c[1] for c in candidates[:limit]]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -35,4 +35,3 @@ __all__ = [
     "repo_root",
     "save_json",
 ]
-

--- a/src/utils/age.py
+++ b/src/utils/age.py
@@ -5,6 +5,7 @@ ISO ``YYYY-MM-DD`` form for almost every active NFL player.  This
 module converts that into the integer ``age`` the contract layer
 and frontend age-curve overlay expect.
 """
+
 from __future__ import annotations
 
 from datetime import date

--- a/src/utils/circuit_breaker.py
+++ b/src/utils/circuit_breaker.py
@@ -34,6 +34,7 @@ whatever HTTP client / caching layer each call site already uses.
 A global registry indexes breakers by name so ``/api/status`` can
 report the state of every external dependency in one snapshot.
 """
+
 from __future__ import annotations
 
 import logging
@@ -131,9 +132,7 @@ class CircuitBreaker:
             # CLOSED: push failure into the sliding window.
             self._failure_timestamps.append(now)
             cutoff = now - self.failure_window_sec
-            self._failure_timestamps = [
-                t for t in self._failure_timestamps if t > cutoff
-            ]
+            self._failure_timestamps = [t for t in self._failure_timestamps if t > cutoff]
             if len(self._failure_timestamps) >= self.failure_threshold:
                 self._transition(OPEN, now)
 
@@ -169,22 +168,25 @@ class CircuitBreaker:
         if new_state == OPEN:
             self._counters.opens += 1
             _LOGGER.warning(
-                "circuit_breaker=open name=%s threshold=%d window=%.0fs "
-                "last_error=%r",
-                self.name, self.failure_threshold,
-                self.failure_window_sec, self._last_error,
+                "circuit_breaker=open name=%s threshold=%d window=%.0fs " "last_error=%r",
+                self.name,
+                self.failure_threshold,
+                self.failure_window_sec,
+                self._last_error,
             )
         elif new_state == CLOSED:
             self._counters.closes += 1
             self._failure_timestamps.clear()
             _LOGGER.info(
                 "circuit_breaker=closed name=%s from=%s",
-                self.name, old_state,
+                self.name,
+                old_state,
             )
         elif new_state == HALF_OPEN:
             _LOGGER.info(
                 "circuit_breaker=half_open name=%s probing after %.0fs",
-                self.name, self.open_duration_sec,
+                self.name,
+                self.open_duration_sec,
             )
 
     def force_close(self) -> None:

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -24,4 +24,3 @@ def save_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2, ensure_ascii=True)
-

--- a/src/utils/http_fetch.py
+++ b/src/utils/http_fetch.py
@@ -17,6 +17,7 @@ Callers opt IN to retry; a safe default is "no retry, just log and
 return on failure" — preserves existing behavior across the
 codebase where retry would be a surprising change.
 """
+
 from __future__ import annotations
 
 import logging
@@ -73,16 +74,21 @@ def fetch(
     bp = None
     if breaker:
         from src.utils import circuit_breaker as _cb
+
         bp = _cb.get_or_create(breaker)
         if not bp.can_call():
             _LOGGER.warning(
                 "http_fetch=circuit_open label=%s breaker=%s url=%s",
-                label or "unlabeled", breaker, _truncate(url),
+                label or "unlabeled",
+                breaker,
+                _truncate(url),
             )
             return FetchResult(
-                status_code=0, body=b"",
+                status_code=0,
+                body=b"",
                 error_kind="circuit_open",
-                attempts=0, elapsed_sec=0.0,
+                attempts=0,
+                elapsed_sec=0.0,
             )
 
     last_error_kind = "retries_exhausted"
@@ -96,14 +102,21 @@ def fetch(
             elapsed = time.time() - started
             _LOGGER.info(
                 "http_fetch=ok label=%s url=%s status=%d bytes=%d attempts=%d elapsed=%.3fs",
-                label or "unlabeled", _truncate(url), status, len(body),
-                attempt + 1, elapsed,
+                label or "unlabeled",
+                _truncate(url),
+                status,
+                len(body),
+                attempt + 1,
+                elapsed,
             )
             if bp is not None:
                 bp.report_success()
             return FetchResult(
-                status_code=status, body=body, error_kind="ok",
-                attempts=attempt + 1, elapsed_sec=elapsed,
+                status_code=status,
+                body=body,
+                error_kind="ok",
+                attempts=attempt + 1,
+                elapsed_sec=elapsed,
             )
         except urllib.error.HTTPError as exc:
             last_status = getattr(exc, "code", 0)
@@ -116,52 +129,72 @@ def fetch(
             if 500 <= last_status < 600 and attempt < retries:
                 _LOGGER.warning(
                     "http_fetch=retry label=%s url=%s status=%d attempt=%d",
-                    label or "unlabeled", _truncate(url), last_status, attempt + 1,
+                    label or "unlabeled",
+                    _truncate(url),
+                    last_status,
+                    attempt + 1,
                 )
-                time.sleep(retry_delay_base * (2 ** attempt))
+                time.sleep(retry_delay_base * (2**attempt))
                 continue
             elapsed = time.time() - started
             _LOGGER.warning(
                 "http_fetch=http label=%s url=%s status=%d attempts=%d elapsed=%.3fs",
-                label or "unlabeled", _truncate(url), last_status,
-                attempt + 1, elapsed,
+                label or "unlabeled",
+                _truncate(url),
+                last_status,
+                attempt + 1,
+                elapsed,
             )
             return FetchResult(
-                status_code=last_status, body=body, error_kind="http",
-                attempts=attempt + 1, elapsed_sec=elapsed,
+                status_code=last_status,
+                body=body,
+                error_kind="http",
+                attempts=attempt + 1,
+                elapsed_sec=elapsed,
             )
         except (TimeoutError,) as exc:
             last_error_kind = "timeout"
             if attempt < retries:
                 _LOGGER.warning(
                     "http_fetch=retry label=%s url=%s kind=timeout attempt=%d",
-                    label or "unlabeled", _truncate(url), attempt + 1,
+                    label or "unlabeled",
+                    _truncate(url),
+                    attempt + 1,
                 )
-                time.sleep(retry_delay_base * (2 ** attempt))
+                time.sleep(retry_delay_base * (2**attempt))
                 continue
         except urllib.error.URLError as exc:
             last_error_kind = "network"
             if attempt < retries:
                 _LOGGER.warning(
                     "http_fetch=retry label=%s url=%s kind=network err=%r attempt=%d",
-                    label or "unlabeled", _truncate(url), exc, attempt + 1,
+                    label or "unlabeled",
+                    _truncate(url),
+                    exc,
+                    attempt + 1,
                 )
-                time.sleep(retry_delay_base * (2 ** attempt))
+                time.sleep(retry_delay_base * (2**attempt))
                 continue
         except Exception as exc:  # noqa: BLE001 — catch everything; never raise
             last_error_kind = "network"
             if attempt < retries:
                 _LOGGER.warning(
                     "http_fetch=retry label=%s url=%s kind=unexpected err=%r attempt=%d",
-                    label or "unlabeled", _truncate(url), exc, attempt + 1,
+                    label or "unlabeled",
+                    _truncate(url),
+                    exc,
+                    attempt + 1,
                 )
-                time.sleep(retry_delay_base * (2 ** attempt))
+                time.sleep(retry_delay_base * (2**attempt))
                 continue
     elapsed = time.time() - started
     _LOGGER.warning(
         "http_fetch=%s label=%s url=%s attempts=%d elapsed=%.3fs",
-        last_error_kind, label or "unlabeled", _truncate(url),
-        retries + 1, elapsed,
+        last_error_kind,
+        label or "unlabeled",
+        _truncate(url),
+        retries + 1,
+        elapsed,
     )
     # Report terminal failure to the breaker (network/timeout errors
     # only — HTTP errors reported above inside the 5xx branch when
@@ -169,9 +202,11 @@ def fetch(
     if bp is not None and last_error_kind in ("timeout", "network", "retries_exhausted"):
         bp.report_failure(last_error_kind)
     return FetchResult(
-        status_code=last_status, body=b"",
+        status_code=last_status,
+        body=b"",
         error_kind=last_error_kind,
-        attempts=retries + 1, elapsed_sec=elapsed,
+        attempts=retries + 1,
+        elapsed_sec=elapsed,
     )
 
 

--- a/src/utils/name_clean.py
+++ b/src/utils/name_clean.py
@@ -20,6 +20,7 @@ The contract layer (``src/api/data_contract.py``) and the identity
 layer (``src/identity/matcher.py``) both import from here so the same
 rules apply to every join, audit, and collision check in the pipeline.
 """
+
 from __future__ import annotations
 
 import re
@@ -143,7 +144,7 @@ CANONICAL_NAME_ALIASES: dict[str, str] = {
     "pat mahomes": "patrick mahomes",
     "mike evans": "michael evans",
     "mike gesicki": "mike gesicki",  # explicit identity — "michael gesicki"
-                                      # is NOT used anywhere
+    # is NOT used anywhere
     "kenny pickett": "kenny pickett",
     "chig okonkwo": "chigoziem okonkwo",
     "hollywood brown": "marquise brown",
@@ -155,11 +156,11 @@ CANONICAL_NAME_ALIASES: dict[str, str] = {
     # ── Cross-source first-name drift ──────────────────────────────────
     # Verified by checking all three source CSVs (KTC, IDPTradeCalc,
     # DLF) and the dynasty_data player pool.
-    "greg rousseau": "gregory rousseau",      # IDPTC "Greg" ↔ DLF "Gregory"
-    "foye oluokun": "foyesade oluokun",       # DLF/IDPTC "Foye" ↔ dynasty_data "Foyesade"
-    "josh metellus": "joshua metellus",       # DLF "Josh" ↔ dynasty_data "Joshua"
-    "kam curl": "kamren curl",                # dynasty_data "Kam" ↔ DLF/IDPTC "Kamren"
-    "kamren curl": "kamren curl",             # anchor the canonical form
+    "greg rousseau": "gregory rousseau",  # IDPTC "Greg" ↔ DLF "Gregory"
+    "foye oluokun": "foyesade oluokun",  # DLF/IDPTC "Foye" ↔ dynasty_data "Foyesade"
+    "josh metellus": "joshua metellus",  # DLF "Josh" ↔ dynasty_data "Joshua"
+    "kam curl": "kamren curl",  # dynasty_data "Kam" ↔ DLF/IDPTC "Kamren"
+    "kamren curl": "kamren curl",  # anchor the canonical form
 }
 
 

--- a/src/utils/owner_names.py
+++ b/src/utils/owner_names.py
@@ -9,6 +9,7 @@ preferred display label for any Sleeper user payload.
 The mapping is case-insensitive: Sleeper preserves the case the user
 typed, but the username is unique under case-folding.
 """
+
 from __future__ import annotations
 
 from functools import lru_cache

--- a/src/utils/request_context.py
+++ b/src/utils/request_context.py
@@ -15,6 +15,7 @@ triggered an action without the endpoint re-reading the session.
 All getters return sane defaults when called outside a request
 context (tests, scripts, startup) — never raise.
 """
+
 from __future__ import annotations
 
 import contextvars
@@ -24,13 +25,15 @@ from typing import Any
 # Generated per-request; available from any point during request
 # handling.  "" outside request scope (startup / shutdown / tests).
 _request_id: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "request_id", default="",
+    "request_id",
+    default="",
 )
 
 # Opaque user context.  Handlers that have a session set this; logs
 # pick it up.  Cleared by the middleware at response time.
 _user_ctx: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
-    "user_ctx", default={},
+    "user_ctx",
+    default={},
 )
 
 

--- a/tests/adapters/test_dlf_scraper.py
+++ b/tests/adapters/test_dlf_scraper.py
@@ -6,6 +6,7 @@ pure functions: HTML table parsing (``_parse_rankings``), rank
 column preference (``_rank_of``), paywall detection
 (``_looks_like_preview``), and CSV write (``_write_csv``).
 """
+
 from __future__ import annotations
 
 import csv
@@ -87,7 +88,8 @@ DLF_PAYWALL_HTML = """
 # articles, ad widgets) that have fewer than 10 rows and no
 # Rank/Avg headers.  The parser must walk past them and find the
 # real rankings table.
-DLF_WITH_SIDEBAR_HTML = """
+DLF_WITH_SIDEBAR_HTML = (
+    """
 <html><body>
 <table class="sidebar-ads">
   <tr><th>Ad</th></tr>
@@ -101,15 +103,18 @@ DLF_WITH_SIDEBAR_HTML = """
     </tr>
   </thead>
   <tbody>
-""" + "\n".join(
-    f"<tr><td>{i}</td><td>{i + 0.17:.2f}</td><td>QB{i}</td>"
-    f"<td>Player {i}</td><td>{i}</td><td>{i + 1}</td></tr>"
-    for i in range(1, 13)
-) + """
+"""
+    + "\n".join(
+        f"<tr><td>{i}</td><td>{i + 0.17:.2f}</td><td>QB{i}</td>"
+        f"<td>Player {i}</td><td>{i}</td><td>{i + 1}</td></tr>"
+        for i in range(1, 13)
+    )
+    + """
   </tbody>
 </table>
 </body></html>
 """
+)
 
 
 def test_parse_rankings_extracts_name_avg_rank_pos(dlf_module):
@@ -173,8 +178,8 @@ def test_write_csv_dedups_and_sorts_by_rank(dlf_module, tmp_path: Path):
         {"name": "Player A", "avg": "1.17"},
         {"name": "Player C", "avg": "2.83"},
         {"name": "Player A", "avg": "1.17"},  # duplicate — should be dropped
-        {"name": "", "avg": "4.00"},           # empty name — dropped
-        {"name": "Player D", "avg": "N/A"},    # invalid rank — dropped
+        {"name": "", "avg": "4.00"},  # empty name — dropped
+        {"name": "Player D", "avg": "N/A"},  # invalid rank — dropped
     ]
     count = dlf_module._write_csv(out, rows)
     assert count == 3
@@ -204,7 +209,10 @@ def test_boards_registry_covers_all_four_sources(dlf_module):
     _SOURCE_CSV_PATHS will silently lose coverage — this test
     trips before that happens."""
     assert set(dlf_module.BOARDS) == {
-        "dlfSf", "dlfIdp", "dlfRookieSf", "dlfRookieIdp",
+        "dlfSf",
+        "dlfIdp",
+        "dlfRookieSf",
+        "dlfRookieIdp",
     }
     for key, cfg in dlf_module.BOARDS.items():
         assert cfg["url"].startswith("https://dynastyleaguefootball.com/")
@@ -221,14 +229,11 @@ def test_boards_match_registered_csv_paths(dlf_module):
     otherwise the ranking pipeline reads a stale CSV instead of
     the freshly-fetched one."""
     from src.api.data_contract import _SOURCE_CSV_PATHS
+
     for key, cfg in dlf_module.BOARDS.items():
         reg_cfg = _SOURCE_CSV_PATHS.get(key)
-        assert reg_cfg is not None, (
-            f"Source {key} missing from _SOURCE_CSV_PATHS"
-        )
-        reg_path = (
-            reg_cfg["path"] if isinstance(reg_cfg, dict) else reg_cfg
-        )
+        assert reg_cfg is not None, f"Source {key} missing from _SOURCE_CSV_PATHS"
+        reg_path = reg_cfg["path"] if isinstance(reg_cfg, dict) else reg_cfg
         assert reg_path == cfg["out"], (
             f"Path mismatch for {key}: scraper writes {cfg['out']!r}, "
             f"registry expects {reg_path!r}"

--- a/tests/adapters/test_fantasypros_ros_scraper.py
+++ b/tests/adapters/test_fantasypros_ros_scraper.py
@@ -5,6 +5,7 @@ binary fixtures) and runs the inline-JSON extractor.  The fixture is
 trimmed to two players so the test stays fast and the expected output
 is easy to eyeball.
 """
+
 from __future__ import annotations
 
 import unittest

--- a/tests/adapters/test_fitzmaurice_scraper.py
+++ b/tests/adapters/test_fitzmaurice_scraper.py
@@ -5,6 +5,7 @@ tests here exercise the offline-safe pure functions: URL candidate
 generation, chart-ID extraction from a page snippet, per-position
 column selection, and trailing-filler-row filtering.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -19,9 +20,7 @@ import pytest
 def fz_module():
     repo = Path(__file__).resolve().parents[2]
     path = repo / "scripts" / "fetch_fantasypros_fitzmaurice.py"
-    spec = importlib.util.spec_from_file_location(
-        "fetch_fantasypros_fitzmaurice", path
-    )
+    spec = importlib.util.spec_from_file_location("fetch_fantasypros_fitzmaurice", path)
     module = importlib.util.module_from_spec(spec)
     sys.modules["fetch_fantasypros_fitzmaurice"] = module
     spec.loader.exec_module(module)
@@ -171,6 +170,7 @@ def test_write_csv_sorts_by_value_desc_and_preserves_position(fz_module, tmp_pat
     count = fz_module._write_csv(out, rows)
     assert count == 3
     import csv
+
     with out.open() as f:
         written = list(csv.DictReader(f))
     # Top-value first.

--- a/tests/adapters/test_ktc_crowd_faab.py
+++ b/tests/adapters/test_ktc_crowd_faab.py
@@ -4,6 +4,7 @@ Bridge between KTC's crowd waiver database (collected by Dynasty
 Scraper.py::scrape_ktc_waiver_database) and the FAAB recommender's
 ``ktc_crowd_bids`` calibration parameter.
 """
+
 from __future__ import annotations
 
 from src.adapters.ktc_crowd_faab import (
@@ -91,7 +92,7 @@ def test_skips_entries_missing_added_or_bid():
     ktc = {
         "waivers": [
             _wv("", bid=10, settings={"waiver_budget": 100}),  # no name
-            _wv("Bad Bid", bid=0, bid_pct=""),                 # no pct
+            _wv("Bad Bid", bid=0, bid_pct=""),  # no pct
             _wv("Good", bid_pct="20"),
             _wv("Good", bid_pct="30"),
         ],

--- a/tests/adapters/test_scraper_bridge_adapter.py
+++ b/tests/adapters/test_scraper_bridge_adapter.py
@@ -1,4 +1,5 @@
 """Unit tests for src/adapters/scraper_bridge_adapter.py"""
+
 from __future__ import annotations
 
 import textwrap
@@ -9,6 +10,7 @@ from src.adapters.scraper_bridge_adapter import ScraperBridgeAdapter
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def value_adapter():
@@ -59,6 +61,7 @@ def rank_csv(tmp_path):
 
 # ── Constructor ───────────────────────────────────────────────────────
 
+
 class TestConstructor:
     def test_valid_signal_types(self):
         ScraperBridgeAdapter("test", "test", signal_type="value")
@@ -70,6 +73,7 @@ class TestConstructor:
 
 
 # ── Value-based loading ───────────────────────────────────────────────
+
 
 class TestValueSignal:
     def test_loads_valid_csv(self, value_adapter, value_csv):
@@ -114,6 +118,7 @@ class TestValueSignal:
 
 # ── Rank-based loading ────────────────────────────────────────────────
 
+
 class TestRankSignal:
     def test_loads_valid_csv(self, rank_adapter, rank_csv):
         result = rank_adapter.load(rank_csv)
@@ -131,6 +136,7 @@ class TestRankSignal:
 
 
 # ── Edge cases ────────────────────────────────────────────────────────
+
 
 class TestEdgeCases:
     def test_missing_file(self, value_adapter, tmp_path):
@@ -193,12 +199,14 @@ class TestEdgeCases:
 
 # ── Real KTC export ──────────────────────────────────────────────────
 
+
 class TestRealKtcExport:
     """Test against the actual KTC CSV from the legacy scraper."""
 
     @pytest.fixture
     def real_csv(self):
         from pathlib import Path
+
         p = Path(__file__).resolve().parent.parent.parent / "CSVs" / "site_raw" / "ktc.csv"
         if not p.exists():
             pytest.skip("KTC export not available")

--- a/tests/adapters/test_source_config_completeness.py
+++ b/tests/adapters/test_source_config_completeness.py
@@ -1,5 +1,6 @@
 """Tests that the source config covers the allowed sources (KTC +
 IDPTradeCalc + DLF IDP) and that missing CSVs are handled gracefully."""
+
 from __future__ import annotations
 
 import json
@@ -68,7 +69,8 @@ def weights():
 
 def _enabled_bridge_sources(cfg):
     return [
-        s for s in cfg["sources"]
+        s
+        for s in cfg["sources"]
         if s.get("enabled") and s.get("adapter") in ("scraper_bridge", "bridge")
     ]
 
@@ -79,9 +81,7 @@ class TestSourceConfigCompleteness:
         assert enabled == ALLOWED_SOURCES, f"Expected only {ALLOWED_SOURCES}, got {enabled}"
 
     def test_all_scraper_exports_have_config_entries(self, config):
-        bridge_files = {
-            Path(s["file"]).name for s in _enabled_bridge_sources(config)
-        }
+        bridge_files = {Path(s["file"]).name for s in _enabled_bridge_sources(config)}
         missing = EXPECTED_SCRAPER_EXPORTS - bridge_files
         assert not missing, f"Missing config entries for scraper exports: {missing}"
 
@@ -90,17 +90,11 @@ class TestSourceConfigCompleteness:
             source_id = src["source"]
             signal = src.get("signal_type")
             if source_id in VALUE_SIGNAL_SOURCES:
-                assert signal == "value", (
-                    f"{source_id} should be signal_type=value, got {signal!r}"
-                )
+                assert signal == "value", f"{source_id} should be signal_type=value, got {signal!r}"
             elif source_id in RANK_SIGNAL_SOURCES:
-                assert signal == "rank", (
-                    f"{source_id} should be signal_type=rank, got {signal!r}"
-                )
+                assert signal == "rank", f"{source_id} should be signal_type=rank, got {signal!r}"
             else:
-                raise AssertionError(
-                    f"Unknown source {source_id!r} in enabled bridge sources"
-                )
+                raise AssertionError(f"Unknown source {source_id!r} in enabled bridge sources")
 
     def test_every_enabled_source_has_a_weight(self, config, weights):
         source_weights = weights.get("sources", {})
@@ -108,15 +102,15 @@ class TestSourceConfigCompleteness:
             if not src.get("enabled"):
                 continue
             source_id = src["source"]
-            assert source_id in source_weights, (
-                f"Source {source_id} is enabled but has no weight entry"
-            )
+            assert (
+                source_id in source_weights
+            ), f"Source {source_id} is enabled but has no weight entry"
 
     def test_no_duplicate_source_ids(self, config):
         enabled = [s["source"] for s in config["sources"] if s.get("enabled")]
-        assert len(enabled) == len(set(enabled)), (
-            f"Duplicate source IDs: {[s for s in enabled if enabled.count(s) > 1]}"
-        )
+        assert len(enabled) == len(
+            set(enabled)
+        ), f"Duplicate source IDs: {[s for s in enabled if enabled.count(s) > 1]}"
 
     def test_idptradecalc_has_idp_universe(self, config):
         """IDPTRADECALC canonical pipeline universe is idp_vet.
@@ -127,15 +121,15 @@ class TestSourceConfigCompleteness:
             if not src.get("enabled"):
                 continue
             if src["source"] == "IDPTRADECALC":
-                assert "idp" in src.get("universe", "").lower(), (
-                    f"IDPTRADECALC universe should contain 'idp', got {src.get('universe')}"
-                )
+                assert (
+                    "idp" in src.get("universe", "").lower()
+                ), f"IDPTRADECALC universe should contain 'idp', got {src.get('universe')}"
 
     def test_weights_only_contain_allowed_sources(self, weights):
         source_weights = set(weights.get("sources", {}).keys())
-        assert source_weights == ALLOWED_SOURCES, (
-            f"Weights should only contain {ALLOWED_SOURCES}, got {source_weights}"
-        )
+        assert (
+            source_weights == ALLOWED_SOURCES
+        ), f"Weights should only contain {ALLOWED_SOURCES}, got {source_weights}"
 
     def test_dlf_idp_has_idp_universe(self, config):
         """DLF_IDP is a full-board IDP source; its canonical universe is
@@ -145,9 +139,9 @@ class TestSourceConfigCompleteness:
             if not src.get("enabled"):
                 continue
             if src["source"] == "DLF_IDP":
-                assert "idp" in src.get("universe", "").lower(), (
-                    f"DLF_IDP universe should contain 'idp', got {src.get('universe')}"
-                )
+                assert (
+                    "idp" in src.get("universe", "").lower()
+                ), f"DLF_IDP universe should contain 'idp', got {src.get('universe')}"
 
 
 class TestTepSfFlags:
@@ -173,28 +167,25 @@ class TestTepSfFlags:
             if not src.get("enabled"):
                 continue
             if src["source"] in tep_expected:
-                assert src.get("includes_tep") is True, (
-                    f"{src['source']}: should have includes_tep=true"
-                )
+                assert (
+                    src.get("includes_tep") is True
+                ), f"{src['source']}: should have includes_tep=true"
             else:
                 # Sources that are NOT TEP-native must still declare the flag.
-                assert "includes_tep" in src, (
-                    f"{src['source']}: missing includes_tep flag"
-                )
+                assert "includes_tep" in src, f"{src['source']}: missing includes_tep flag"
 
     def test_all_sources_include_sf(self, config):
         """All enabled sources natively include SF pricing."""
         for src in config["sources"]:
             if not src.get("enabled"):
                 continue
-            assert src.get("includes_sf") is True, (
-                f"{src['source']}: should have includes_sf=true"
-            )
+            assert src.get("includes_sf") is True, f"{src['source']}: should have includes_sf=true"
 
 
 class TestScraperBridgeGracefulMissing:
     def test_missing_csv_produces_warning_not_error(self):
         from src.adapters.scraper_bridge_adapter import ScraperBridgeAdapter
+
         adapter = ScraperBridgeAdapter(
             source_id="TEST_MISSING",
             source_bucket="offense_vet",
@@ -207,6 +198,7 @@ class TestScraperBridgeGracefulMissing:
 
     def test_empty_path_produces_warning_not_error(self):
         from src.adapters.scraper_bridge_adapter import ScraperBridgeAdapter
+
         adapter = ScraperBridgeAdapter(
             source_id="TEST_EMPTY",
             source_bucket="offense_vet",
@@ -218,6 +210,7 @@ class TestScraperBridgeGracefulMissing:
 
     def test_directory_path_produces_warning_not_error(self, tmp_path):
         from src.adapters.scraper_bridge_adapter import ScraperBridgeAdapter
+
         adapter = ScraperBridgeAdapter(
             source_id="TEST_DIR",
             source_bucket="offense_vet",

--- a/tests/adapters/test_yahoo_boone_scraper.py
+++ b/tests/adapters/test_yahoo_boone_scraper.py
@@ -7,6 +7,7 @@ structure.  That keeps the test suite offline-safe while still
 exercising the parser, column-picker (2QB for QB, TE Prem. for TE),
 cross-position rank assignment (with ties), and CSV writer.
 """
+
 from __future__ import annotations
 
 import csv
@@ -96,11 +97,13 @@ def _make_fake_fetcher(mapping: dict[str, str]):
             if key in url:
                 return url, body
         raise RuntimeError(f"unexpected url: {url}")
+
     # match (final_url, body) signature of _fetch_html
     return lambda url, *, timeout=30: fake_fetch(url, timeout=timeout)
 
 
 # ── Column picker ─────────────────────────────────────────────────────
+
 
 class TestColumnPicker:
     def test_qb_picks_2qb_not_1qb(self, yb_module):
@@ -144,6 +147,7 @@ class TestColumnPicker:
 
 
 # ── Rank assignment ───────────────────────────────────────────────────
+
 
 class TestRankAssignment:
     def test_descending_by_value(self, yb_module):
@@ -189,12 +193,11 @@ class TestRankAssignment:
         ranked1 = yb_module._assign_ranks(rows)
         ranked2 = yb_module._assign_ranks(list(reversed(rows)))
         # Both orderings produce the same output sequence.
-        assert [(r.name, rank) for r, rank in ranked1] == [
-            (r.name, rank) for r, rank in ranked2
-        ]
+        assert [(r.name, rank) for r, rank in ranked1] == [(r.name, rank) for r, rank in ranked2]
 
 
 # ── End-to-end: fetch_all orchestration ───────────────────────────────
+
 
 class TestFetchAll:
     def test_combines_all_four_positions(self, yb_module):
@@ -280,6 +283,7 @@ class TestFetchAll:
 
 # ── CSV writer ────────────────────────────────────────────────────────
 
+
 class TestCsvWriter:
     def test_rank_column_holds_signal(self, yb_module, tmp_path):
         """``rank`` is the pipeline signal (matches _RANK_ALIASES so
@@ -295,7 +299,7 @@ class TestCsvWriter:
             data = list(csv.DictReader(f))
         assert data[0]["name"] == "Josh Allen"
         assert data[0]["pos"] == "QB"
-        assert data[0]["rank"] == "1"           # signal
+        assert data[0]["rank"] == "1"  # signal
         assert data[0]["boone_value"] == "141"  # original chart number
         assert data[1]["rank"] == "2"
 
@@ -326,6 +330,7 @@ class TestCsvWriter:
 
 # ── Partial-scrape guards (fail loudly, preserve last-good) ───────────
 
+
 class TestPartialScrapeGuards:
     """Regression for the 2026-05-16 silent-truncation incident: a TE
     seed failure produced a QB+RB+WR-only board.  The old combined
@@ -347,9 +352,7 @@ class TestPartialScrapeGuards:
     ):
         # Total 480 clears _YB_ROW_COUNT_FLOOR (400) so the per-position
         # guard is what must catch TE vanishing (TE=0 < 30).
-        board = self._board(
-            yb_module, {"QB": 80, "RB": 200, "WR": 200, "TE": 0}
-        )
+        board = self._board(yb_module, {"QB": 80, "RB": 200, "WR": 200, "TE": 0})
         monkeypatch.setattr(
             yb_module,
             "fetch_all",
@@ -364,15 +367,9 @@ class TestPartialScrapeGuards:
         assert rc == 3
         assert dest.read_text(encoding="utf-8") == sentinel
 
-    def test_total_below_floor_exits_2_and_preserves_csv(
-        self, yb_module, tmp_path, monkeypatch
-    ):
-        board = self._board(
-            yb_module, {"QB": 80, "RB": 80, "WR": 80, "TE": 80}
-        )  # 320 < 400
-        monkeypatch.setattr(
-            yb_module, "fetch_all", lambda *a, **k: (board, [])
-        )
+    def test_total_below_floor_exits_2_and_preserves_csv(self, yb_module, tmp_path, monkeypatch):
+        board = self._board(yb_module, {"QB": 80, "RB": 80, "WR": 80, "TE": 80})  # 320 < 400
+        monkeypatch.setattr(yb_module, "fetch_all", lambda *a, **k: (board, []))
         dest = tmp_path / "yahooBoone.csv"
         sentinel = "name,pos,rank,boone_value\nPrior Good,QB,1,141\n"
         dest.write_text(sentinel, encoding="utf-8")
@@ -382,15 +379,11 @@ class TestPartialScrapeGuards:
         assert rc == 2
         assert dest.read_text(encoding="utf-8") == sentinel
 
-    def test_healthy_board_writes_and_exits_0(
-        self, yb_module, tmp_path, monkeypatch
-    ):
+    def test_healthy_board_writes_and_exits_0(self, yb_module, tmp_path, monkeypatch):
         board = self._board(
             yb_module, {"QB": 80, "RB": 130, "WR": 150, "TE": 90}
         )  # 450, every position well above 30
-        monkeypatch.setattr(
-            yb_module, "fetch_all", lambda *a, **k: (board, [])
-        )
+        monkeypatch.setattr(yb_module, "fetch_all", lambda *a, **k: (board, []))
         dest = tmp_path / "yahooBoone.csv"
 
         rc = yb_module.main(["--dest", str(dest)])

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -6,6 +6,7 @@ Covers:
   * signal-state migrate: idempotent, calls the migration module.
   * Auth gates: unauthenticated → 401; authed non-admin → 403.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -19,7 +20,8 @@ def _stub_allowlist(monkeypatch):
     # Every admin test assumes a known allowlist so the "is admin"
     # check is predictable.
     monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES",
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
         frozenset({"jasonleetucker"}),
     )
     yield
@@ -28,7 +30,8 @@ def _stub_allowlist(monkeypatch):
 def _authed_admin(monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda r: {"username": "jasonleetucker"},
     )
 
@@ -36,7 +39,8 @@ def _authed_admin(monkeypatch):
 def _authed_non_admin(monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda r: {"username": "randomuser"},
     )
 
@@ -92,6 +96,7 @@ def _isolate_guest_pass_db(monkeypatch, tmp_path):
     """Point ``guest_passes`` at a temp SQLite file so admin-endpoint
     tests don't share state with the production DB."""
     from src.api import guest_passes
+
     db = tmp_path / "guest_passes.sqlite"
     monkeypatch.setattr(guest_passes, "_DEFAULT_DB_PATH", db)
     # Reset the per-path setup tracker so the new db gets its schema
@@ -167,7 +172,8 @@ def test_guest_pass_revoke_marks_revoked(monkeypatch, tmp_path):
     _isolate_guest_pass_db(monkeypatch, tmp_path)
     with TestClient(server.app, raise_server_exceptions=True) as c:
         created = c.post(
-            "/api/admin/guest-pass", json={"durationHours": 12},
+            "/api/admin/guest-pass",
+            json={"durationHours": 12},
         ).json()
         pass_id = created["pass"]["id"]
         res = c.post(f"/api/admin/guest-pass/{pass_id}/revoke")
@@ -189,13 +195,16 @@ def test_guest_pass_login_creates_time_bounded_session(monkeypatch, tmp_path):
     with TestClient(server.app, raise_server_exceptions=True) as c:
         # Mint a pass via the admin endpoint.
         created = c.post(
-            "/api/admin/guest-pass", json={"durationHours": 1},
+            "/api/admin/guest-pass",
+            json={"durationHours": 1},
         ).json()
         token = created["token"]
         # Drop the admin auth stub so the login route doesn't see us
         # as already-authed.
         monkeypatch.setattr(
-            server, "_get_auth_session", lambda r: None,
+            server,
+            "_get_auth_session",
+            lambda r: None,
         )
         monkeypatch.setattr(server, "_is_authenticated", lambda r: False)
         # Guest login: any username, password = the token.
@@ -253,6 +262,7 @@ def test_realized_points_requires_feature_flag(monkeypatch):
     # still work when explicitly disabled.)
     monkeypatch.setenv("RISKIT_FEATURE_REALIZED_POINTS_API", "0")
     from src.api import feature_flags
+
     feature_flags.reload()
     try:
         with TestClient(server.app, raise_server_exceptions=True) as c:
@@ -267,6 +277,7 @@ def test_realized_points_flag_on_returns_shape(monkeypatch):
     _authed_admin(monkeypatch)
     monkeypatch.setenv("RISKIT_FEATURE_REALIZED_POINTS_API", "1")
     from src.api import feature_flags
+
     feature_flags.reload()
     try:
         with TestClient(server.app, raise_server_exceptions=True) as c:

--- a/tests/api/test_compact_view.py
+++ b/tests/api/test_compact_view.py
@@ -1,4 +1,5 @@
 """Tests for the compact contract view builder."""
+
 from __future__ import annotations
 
 from src.api import compact_view as cv

--- a/tests/api/test_config_parity.py
+++ b/tests/api/test_config_parity.py
@@ -21,6 +21,7 @@ hidden-coupling that previously had no CI gate:
 When CI fails on one of these, the message tells you which file
 drifted.
 """
+
 from __future__ import annotations
 
 import json
@@ -146,8 +147,7 @@ class TestConfigJsonFilesParse(unittest.TestCase):
         self.assertEqual(
             bad,
             [],
-            "JSON parse errors in config/:\n"
-            + "\n".join(f"  {p}: {err}" for p, err in bad),
+            "JSON parse errors in config/:\n" + "\n".join(f"  {p}: {err}" for p, err in bad),
         )
 
 
@@ -167,9 +167,7 @@ class TestLeagueRegistryWellFormed(unittest.TestCase):
         from src.api import league_registry as lr
 
         cls._prior_registry_path = os.environ.get("LEAGUE_REGISTRY_PATH")
-        os.environ["LEAGUE_REGISTRY_PATH"] = str(
-            REPO_ROOT / "config" / "leagues" / "registry.json"
-        )
+        os.environ["LEAGUE_REGISTRY_PATH"] = str(REPO_ROOT / "config" / "leagues" / "registry.json")
         lr.reload_registry()
 
     @classmethod
@@ -243,8 +241,7 @@ class TestLeagueRegistryWellFormed(unittest.TestCase):
         self.assertEqual(
             collisions,
             [],
-            "Alias collisions between leagues:\n  "
-            + "\n  ".join(collisions),
+            "Alias collisions between leagues:\n  " + "\n  ".join(collisions),
         )
 
 
@@ -262,6 +259,7 @@ class TestSourceStalenessCoverage(unittest.TestCase):
         from src.api import source_health_alerts as sha
 
         thresholds = sha.load_thresholds()
+
         # A threshold key matches a source key if the source key starts
         # with the threshold key.  This mirrors the convention in
         # ``config/source_staleness.json`` where vendor-name keys
@@ -275,9 +273,7 @@ class TestSourceStalenessCoverage(unittest.TestCase):
                     return True
             return False
 
-        missing = sorted(
-            str(k) for k in _SOURCE_CSV_PATHS if not _has_threshold(str(k))
-        )
+        missing = sorted(str(k) for k in _SOURCE_CSV_PATHS if not _has_threshold(str(k)))
         self.assertEqual(
             missing,
             [],

--- a/tests/api/test_contract_coverage_watchdog.py
+++ b/tests/api/test_contract_coverage_watchdog.py
@@ -16,6 +16,7 @@ filesystem touch (``_csv_nonempty``) for determinism.  ``thresholds``
 is left empty so ``resolve_threshold`` returns its 24h default; an
 ``ageHours`` of 0 is therefore unambiguously fresh and 9999 stale.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -51,9 +52,7 @@ class TestEvaluateCoverage(unittest.TestCase):
     def test_fresh_source_absent_is_a_violation(self):
         contract = _contract_with_coverage(_KEY, 0)
         freshness = {_KEY: {"ageHours": 0.0}}
-        violations, ok, skipped = wcc.evaluate_coverage(
-            contract, freshness, {}
-        )
+        violations, ok, skipped = wcc.evaluate_coverage(contract, freshness, {})
         self.assertIn((_KEY, 0), violations)
         self.assertNotIn(_KEY, [k for k, _ in ok])
 
@@ -78,9 +77,7 @@ class TestEvaluateCoverage(unittest.TestCase):
         # silent to avoid double-reporting the same outage.
         contract = _contract_with_coverage(_KEY, 0)
         freshness = {_KEY: {"ageHours": 9999.0}}
-        violations, _ok, skipped = wcc.evaluate_coverage(
-            contract, freshness, {}
-        )
+        violations, _ok, skipped = wcc.evaluate_coverage(contract, freshness, {})
         self.assertNotIn(_KEY, [k for k, _ in violations])
         self.assertIn(_KEY, skipped)
 
@@ -90,9 +87,7 @@ class TestEvaluateCoverage(unittest.TestCase):
         wcc._csv_nonempty = lambda _k: False
         contract = _contract_with_coverage(_KEY, 0)
         freshness = {_KEY: {"ageHours": 0.0}}
-        violations, _ok, skipped = wcc.evaluate_coverage(
-            contract, freshness, {}
-        )
+        violations, _ok, skipped = wcc.evaluate_coverage(contract, freshness, {})
         self.assertNotIn(_KEY, [k for k, _ in violations])
         self.assertIn(_KEY, skipped)
 

--- a/tests/api/test_count_aware_blend.py
+++ b/tests/api/test_count_aware_blend.py
@@ -12,6 +12,7 @@ The prior implementation trimmed at n≥3, which collapsed sparse
 IDP / rookie groups.  These tests pin the updated rule so no future
 refactor silently over-trims or silently switches the threshold.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/api/test_data_contract.py
+++ b/tests/api/test_data_contract.py
@@ -54,8 +54,12 @@ class TestComputeKtcRankings(unittest.TestCase):
             "legacyRef": name,
             "position": pos,
             "assetClass": "offense",
-            "values": {"overall": ktc, "rawComposite": ktc,
-                       "finalAdjusted": ktc, "displayValue": None},
+            "values": {
+                "overall": ktc,
+                "rawComposite": ktc,
+                "finalAdjusted": ktc,
+                "displayValue": None,
+            },
             "canonicalSiteValues": {"ktcSfTep": ktc},
             "sourceCount": 1,
         }
@@ -63,7 +67,7 @@ class TestComputeKtcRankings(unittest.TestCase):
     def test_top_player_gets_rank_1(self):
         rows = [
             self._make_player_row("Alpha", "QB", 9000),
-            self._make_player_row("Beta",  "WR", 7000),
+            self._make_player_row("Beta", "WR", 7000),
         ]
         _compute_unified_rankings(rows, {})
         alpha = next(r for r in rows if r["canonicalName"] == "Alpha")
@@ -71,9 +75,9 @@ class TestComputeKtcRankings(unittest.TestCase):
 
     def test_rank_order_follows_ktc_value_descending(self):
         rows = [
-            self._make_player_row("Low",  "RB", 3000),
+            self._make_player_row("Low", "RB", 3000),
             self._make_player_row("High", "QB", 9000),
-            self._make_player_row("Mid",  "WR", 6000),
+            self._make_player_row("Mid", "WR", 6000),
         ]
         _compute_unified_rankings(rows, {})
         by_rank = sorted(
@@ -114,20 +118,22 @@ class TestComputeKtcRankings(unittest.TestCase):
         # And the value is NOT the Hill output at p=49/499 ≈ 0.098,
         # which would yield a much lower value under HILL_PERCENTILE_*.
         from src.api.data_contract import _PERCENTILE_REFERENCE_N  # noqa: PLC0415
+
         hill_p = (50 - 1) / (_PERCENTILE_REFERENCE_N - 1)
         hill_value = int(percentile_to_value(hill_p))
         self.assertNotEqual(
-            rank_50_row["rankDerivedValue"], hill_value,
+            rank_50_row["rankDerivedValue"],
+            hill_value,
             "Value-based source should NOT be routed through the Hill "
             "curve — ``rankDerivedValue`` must reflect the raw normalized "
-            "site value."
+            "site value.",
         )
 
     def test_picks_included(self):
         """Picks with source values participate in the unified ranking."""
         rows = [
             self._make_player_row("2026 Early 1st", "PICK", 8000),
-            self._make_player_row("Real Player",    "QB",   7000),
+            self._make_player_row("Real Player", "QB", 7000),
         ]
         rows[0]["assetClass"] = "pick"
         _compute_unified_rankings(rows, {})
@@ -138,8 +144,8 @@ class TestComputeKtcRankings(unittest.TestCase):
 
     def test_unresolved_position_excluded(self):
         rows = [
-            self._make_player_row("UnknownGuy", "?",  8000),
-            self._make_player_row("KnownGuy",   "QB", 7000),
+            self._make_player_row("UnknownGuy", "?", 8000),
+            self._make_player_row("KnownGuy", "QB", 7000),
         ]
         _compute_unified_rankings(rows, {})
         unknown = next(r for r in rows if r["canonicalName"] == "UnknownGuy")
@@ -172,12 +178,18 @@ class TestComputeKtcRankings(unittest.TestCase):
         raw = {
             "players": {
                 "Josh Allen": {
-                    "_composite": 9000, "_rawComposite": 9000, "_finalAdjusted": 9000,
-                    "_canonicalSiteValues": {"ktcSfTep": 9000}, "position": "QB",
+                    "_composite": 9000,
+                    "_rawComposite": 9000,
+                    "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktcSfTep": 9000},
+                    "position": "QB",
                 },
                 "Ja'Marr Chase": {
-                    "_composite": 8500, "_rawComposite": 8500, "_finalAdjusted": 8500,
-                    "_canonicalSiteValues": {"ktcSfTep": 8500}, "position": "WR",
+                    "_composite": 8500,
+                    "_rawComposite": 8500,
+                    "_finalAdjusted": 8500,
+                    "_canonicalSiteValues": {"ktcSfTep": 8500},
+                    "position": "WR",
                 },
             },
             "sites": [{"key": "ktcSfTep"}],
@@ -196,8 +208,11 @@ class TestComputeKtcRankings(unittest.TestCase):
         raw = {
             "players": {
                 "Josh Allen": {
-                    "_composite": 9000, "_rawComposite": 9000, "_finalAdjusted": 9000,
-                    "_canonicalSiteValues": {"ktcSfTep": 9000}, "position": "QB",
+                    "_composite": 9000,
+                    "_rawComposite": 9000,
+                    "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktcSfTep": 9000},
+                    "position": "QB",
                 },
             },
             "sites": [{"key": "ktcSfTep"}],
@@ -218,8 +233,11 @@ class TestComputeKtcRankings(unittest.TestCase):
         raw = {
             "players": {
                 "Josh Allen": {
-                    "_composite": 9000, "_rawComposite": 9000, "_finalAdjusted": 9000,
-                    "_canonicalSiteValues": {"ktcSfTep": 9000}, "position": "QB",
+                    "_composite": 9000,
+                    "_rawComposite": 9000,
+                    "_finalAdjusted": 9000,
+                    "_canonicalSiteValues": {"ktcSfTep": 9000},
+                    "position": "QB",
                 },
             },
             "sites": [{"key": "ktcSfTep"}],
@@ -252,8 +270,12 @@ class TestCanonicalConsensusRank(unittest.TestCase):
             "legacyRef": name,
             "position": pos,
             "assetClass": "offense",
-            "values": {"overall": ktc, "rawComposite": ktc,
-                       "finalAdjusted": ktc, "displayValue": None},
+            "values": {
+                "overall": ktc,
+                "rawComposite": ktc,
+                "finalAdjusted": ktc,
+                "displayValue": None,
+            },
             "canonicalSiteValues": {"ktcSfTep": ktc},
             "sourceCount": 1,
         }
@@ -261,7 +283,7 @@ class TestCanonicalConsensusRank(unittest.TestCase):
     def test_canonical_consensus_rank_stamped_on_ranked_players(self):
         rows = [
             self._make_player_row("Alpha", "QB", 9000),
-            self._make_player_row("Beta",  "WR", 7000),
+            self._make_player_row("Beta", "WR", 7000),
         ]
         _compute_unified_rankings(rows, {})
         alpha = next(r for r in rows if r["canonicalName"] == "Alpha")
@@ -309,6 +331,7 @@ class TestRankChangeMirror(unittest.TestCase):
 
     def test_rank_change_mirrors_to_legacy_dict(self):
         from src.api.data_contract import _mirror_trust_to_legacy
+
         players_array = [
             {"legacyRef": "Josh Allen", "rankChange": 3, "confidenceBucket": "high"},
             {"legacyRef": "Puka Nacua", "rankChange": None, "confidenceBucket": "high"},
@@ -390,38 +413,42 @@ class TestIdpIntegrityGuardrails(unittest.TestCase):
 
     def test_validation_flags_offense_idp_duplicate_name_collision(self):
         payload = build_api_data_contract(_minimal_raw_payload())
-        payload["playersArray"].append({
-            "playerId": None,
-            "canonicalName": "DJ Moore",
-            "displayName": "DJ Moore",
-            "position": "WR",
-            "team": "CHI",
-            "rookie": False,
-            "values": {
-                "overall": 100,
-                "rawComposite": 100,
-                "finalAdjusted": 100,
-                "displayValue": 100,
-            },
-            "canonicalSiteValues": {"ktcSfTep": 100},
-            "sourceCount": 1,
-        })
-        payload["playersArray"].append({
-            "playerId": None,
-            "canonicalName": "D.J. Moore",
-            "displayName": "D.J. Moore",
-            "position": "DB",
-            "team": "CHI",
-            "rookie": False,
-            "values": {
-                "overall": 1,
-                "rawComposite": 1,
-                "finalAdjusted": 1,
-                "displayValue": 1,
-            },
-            "canonicalSiteValues": {"idpTradeCalc": 1},
-            "sourceCount": 1,
-        })
+        payload["playersArray"].append(
+            {
+                "playerId": None,
+                "canonicalName": "DJ Moore",
+                "displayName": "DJ Moore",
+                "position": "WR",
+                "team": "CHI",
+                "rookie": False,
+                "values": {
+                    "overall": 100,
+                    "rawComposite": 100,
+                    "finalAdjusted": 100,
+                    "displayValue": 100,
+                },
+                "canonicalSiteValues": {"ktcSfTep": 100},
+                "sourceCount": 1,
+            }
+        )
+        payload["playersArray"].append(
+            {
+                "playerId": None,
+                "canonicalName": "D.J. Moore",
+                "displayName": "D.J. Moore",
+                "position": "DB",
+                "team": "CHI",
+                "rookie": False,
+                "values": {
+                    "overall": 1,
+                    "rawComposite": 1,
+                    "finalAdjusted": 1,
+                    "displayValue": 1,
+                },
+                "canonicalSiteValues": {"idpTradeCalc": 1},
+                "sourceCount": 1,
+            }
+        )
         report = validate_api_data_contract(payload)
         self.assertFalse(report["ok"])
         self.assertTrue(any("name collision" in e for e in report["errors"]))
@@ -432,28 +459,39 @@ class TestStripNameSuffix(unittest.TestCase):
 
     def test_jr_with_period(self):
         from src.api.data_contract import _strip_name_suffix
+
         self.assertEqual(_strip_name_suffix("Marvin Harrison Jr."), "Marvin Harrison")
 
     def test_jr_without_period(self):
         from src.api.data_contract import _strip_name_suffix
+
         self.assertEqual(_strip_name_suffix("Brian Thomas Jr"), "Brian Thomas")
         self.assertEqual(_strip_name_suffix("Omar Cooper Jr"), "Omar Cooper")
         self.assertEqual(_strip_name_suffix("Michael Penix Jr"), "Michael Penix")
 
     def test_iii_suffix(self):
         from src.api.data_contract import _strip_name_suffix
+
         self.assertEqual(_strip_name_suffix("Kenneth Walker III"), "Kenneth Walker")
 
     def test_suffix_variants_match_base(self):
         from src.api.data_contract import _strip_name_suffix
-        self.assertEqual(_strip_name_suffix("Kenneth Walker III"), _strip_name_suffix("Kenneth Walker"))
-        self.assertEqual(_strip_name_suffix("Marvin Harrison Jr."), _strip_name_suffix("Marvin Harrison"))
+
+        self.assertEqual(
+            _strip_name_suffix("Kenneth Walker III"), _strip_name_suffix("Kenneth Walker")
+        )
+        self.assertEqual(
+            _strip_name_suffix("Marvin Harrison Jr."), _strip_name_suffix("Marvin Harrison")
+        )
         self.assertEqual(_strip_name_suffix("Brian Thomas Jr"), _strip_name_suffix("Brian Thomas"))
         self.assertEqual(_strip_name_suffix("Omar Cooper Jr"), _strip_name_suffix("Omar Cooper"))
-        self.assertEqual(_strip_name_suffix("Michael Penix Jr"), _strip_name_suffix("Michael Penix"))
+        self.assertEqual(
+            _strip_name_suffix("Michael Penix Jr"), _strip_name_suffix("Michael Penix")
+        )
 
     def test_no_suffix_unchanged(self):
         from src.api.data_contract import _strip_name_suffix
+
         self.assertEqual(_strip_name_suffix("Patrick Mahomes"), "Patrick Mahomes")
 
 
@@ -503,6 +541,7 @@ class TestHillCurvesStamp(unittest.TestCase):
             IDP_HILL_PERCENTILE_C,
             IDP_HILL_PERCENTILE_S,
         )
+
         curves = build_api_data_contract(_minimal_raw_payload())["hillCurves"]
         self.assertAlmostEqual(curves["global"]["c"], HILL_GLOBAL_PERCENTILE_C)
         self.assertAlmostEqual(curves["global"]["s"], HILL_GLOBAL_PERCENTILE_S)
@@ -560,10 +599,7 @@ class TestRawSourceValues(unittest.TestCase):
             "sleeper": {"positions": {"Trey McBride": "TE"}},
         }
         contract = build_api_data_contract(raw)
-        row = next(
-            r for r in contract["playersArray"]
-            if r["canonicalName"] == "Trey McBride"
-        )
+        row = next(r for r in contract["playersArray"] if r["canonicalName"] == "Trey McBride")
         # rawSourceValues carries the raw scrape from the top-level
         # ``ktcSfTep`` field (the synthetic input mimics the legacy
         # divergence between raw and canonicalSites).
@@ -597,8 +633,7 @@ class TestRawSourceValues(unittest.TestCase):
         }
         contract = build_api_data_contract(raw)
         row = next(
-            r for r in contract["playersArray"]
-            if r["canonicalName"] == "Player Without Ktc"
+            r for r in contract["playersArray"] if r["canonicalName"] == "Player Without Ktc"
         )
         self.assertEqual(row["rawSourceValues"], {})
 
@@ -623,10 +658,7 @@ class TestRawSourceValues(unittest.TestCase):
             "sleeper": {"positions": {"Zeroed Player": "WR"}},
         }
         contract = build_api_data_contract(raw)
-        row = next(
-            r for r in contract["playersArray"]
-            if r["canonicalName"] == "Zeroed Player"
-        )
+        row = next(r for r in contract["playersArray"] if r["canonicalName"] == "Zeroed Player")
         self.assertNotIn("ktcSfTep", row["rawSourceValues"])
 
 

--- a/tests/api/test_data_contract_age.py
+++ b/tests/api/test_data_contract_age.py
@@ -5,6 +5,7 @@ Regression for the Age curves panel — the frontend overlay
 rows where ``age`` is null/non-finite, so any future change that
 strips this field will silently empty the curves.
 """
+
 from __future__ import annotations
 
 import unittest

--- a/tests/api/test_dlf_source.py
+++ b/tests/api/test_dlf_source.py
@@ -15,6 +15,7 @@ Covers every link in the DLF pipeline end-to-end:
       config / weights shape (those assertions live in the adapters
       test file; this module covers the data-flow contract).
 """
+
 from __future__ import annotations
 
 import csv
@@ -51,8 +52,7 @@ def _row(name: str, pos: str, *, idp=None, dlf=None, ktc=None) -> dict:
         "legacyRef": name,
         "position": pos,
         "assetClass": "offense" if pos in {"QB", "RB", "WR", "TE"} else "idp",
-        "values": {"overall": 0, "rawComposite": 0,
-                   "finalAdjusted": 0, "displayValue": None},
+        "values": {"overall": 0, "rawComposite": 0, "finalAdjusted": 0, "displayValue": None},
         "canonicalSiteValues": sites,
         "sourceCount": 1,
     }
@@ -104,8 +104,8 @@ class TestDlfCsvPreprocessor(unittest.TestCase):
             src.write_text(
                 "Rank,Avg,Pos,Name,Team\n"
                 "1,1.00,DE (DL1),Hutch,DET\n"
-                ",,,,\n"             # entirely blank row
-                "2,0,LB1,,KC\n"      # blank name
+                ",,,,\n"  # entirely blank row
+                "2,0,LB1,,KC\n"  # blank name
                 "3,-1,LB2,NegRank,KC\n"  # non-positive rank
                 "4,4.00,LB3,Jack Campbell,DET\n",
                 encoding="utf-8",
@@ -219,9 +219,7 @@ class TestDlfCsvEnrichment(unittest.TestCase):
             players,
             [("Aidan Hutchinson", 1)],
         )
-        self.assertEqual(
-            players[0]["canonicalSiteValues"]["dlfIdp"], 12345
-        )
+        self.assertEqual(players[0]["canonicalSiteValues"]["dlfIdp"], 12345)
 
     def test_missing_rank_column_skips_row(self):
         players = [_row("Ghost Player", "DL")]
@@ -317,10 +315,7 @@ class TestDlfParticipatesInUnifiedRankings(unittest.TestCase):
         best IDP in the backbone."""
         # 10 offense rows all price higher in IDPTradeCalc than any IDP,
         # so the combined-pool rank of the top IDP in IDPTC is 11.
-        rows = [
-            _row(f"off{i}", "QB" if i % 2 else "WR", idp=9999 - i * 10)
-            for i in range(10)
-        ]
+        rows = [_row(f"off{i}", "QB" if i % 2 else "WR", idp=9999 - i * 10) for i in range(10)]
         rows += [
             _row("dl1", "DL", idp=5500, dlf=9995),
             _row("lb1", "LB", idp=5000, dlf=9990),
@@ -355,12 +350,8 @@ class TestDlfParticipatesInUnifiedRankings(unittest.TestCase):
         self.assertLess(dl1["rankDerivedValue"], 9999)
         # And the unified board agrees: the best offense player still
         # outranks the best IDP.
-        top_off = next(
-            r for r in rows if r["canonicalName"] == "off0"
-        )
-        self.assertLess(
-            top_off["canonicalConsensusRank"], dl1["canonicalConsensusRank"]
-        )
+        top_off = next(r for r in rows if r["canonicalName"] == "off0")
+        self.assertLess(top_off["canonicalConsensusRank"], dl1["canonicalConsensusRank"])
 
     def test_dlf_disagreement_with_idptradecalc_blends_not_overrides(self):
         # IDPTradeCalc says dl1 > dl2; DLF disagrees and puts dl2 first.
@@ -391,7 +382,7 @@ class TestDlfParticipatesInUnifiedRankings(unittest.TestCase):
     def test_dlf_only_player_still_gets_ranked_via_overall_idp_scope(self):
         rows = [
             _row("idp_anchor", "DL", idp=900),  # IDPTradeCalc-only
-            _row("dlf_only", "DL", dlf=9950),   # DLF-only
+            _row("dlf_only", "DL", dlf=9950),  # DLF-only
         ]
         _compute_unified_rankings(rows, {})
         dlf_only = next(r for r in rows if r["canonicalName"] == "dlf_only")

--- a/tests/api/test_draft_capital.py
+++ b/tests/api/test_draft_capital.py
@@ -7,6 +7,7 @@ workbook's R45:R116 column is the fallback when Sleeper is
 unreachable.  Tests that need to assert workbook-only behavior pass
 ``apply_sleeper_trades=False``.
 """
+
 from __future__ import annotations
 
 import sys
@@ -20,11 +21,11 @@ sys.path.insert(0, str(REPO))
 
 def _load():
     import server
+
     return server._parse_draft_data()
 
 
 class TestDraftDataParsing(unittest.TestCase):
-
     def test_72_picks(self):
         pick_dollars, _, _, _, _, _ = _load()
         self.assertEqual(len(pick_dollars), 72)
@@ -46,17 +47,17 @@ class TestDraftDataParsing(unittest.TestCase):
 
 
 class TestIntegerRounding(unittest.TestCase):
-
     def test_round_to_budget_sums_to_1200(self):
         import server
+
         _, workbook_picks, _, _, _, _ = _load()
         values = [wp["value"] for wp in workbook_picks]
         rounded = server._round_to_budget(values, 1200)
-        self.assertEqual(sum(rounded), 1200,
-                         f"Rounded sum = {sum(rounded)}, expected 1200")
+        self.assertEqual(sum(rounded), 1200, f"Rounded sum = {sum(rounded)}, expected 1200")
 
     def test_round_to_budget_all_ints(self):
         import server
+
         _, workbook_picks, _, _, _, _ = _load()
         values = [wp["value"] for wp in workbook_picks]
         rounded = server._round_to_budget(values, 1200)
@@ -99,37 +100,35 @@ class TestIntegerRounding(unittest.TestCase):
         rounded = server._round_to_budget(values, 1200)
 
         # Pair at the head — both indices fall inside the +1 block.
-        self.assertEqual(rounded[0], rounded[1],
-                         f"head-pair: {rounded[0]} != {rounded[1]}")
+        self.assertEqual(rounded[0], rounded[1], f"head-pair: {rounded[0]} != {rounded[1]}")
         # Pair near the middle of the +1 block.
-        self.assertEqual(rounded[20], rounded[21],
-                         f"mid-block: {rounded[20]} != {rounded[21]}")
+        self.assertEqual(rounded[20], rounded[21], f"mid-block: {rounded[20]} != {rounded[21]}")
         # Pair outside the +1 block — equal inputs at low remainders.
-        self.assertEqual(rounded[50], rounded[51],
-                         f"outside-block: {rounded[50]} != {rounded[51]}")
+        self.assertEqual(rounded[50], rounded[51], f"outside-block: {rounded[50]} != {rounded[51]}")
 
 
 class TestApiOutput(unittest.TestCase):
-
     def test_api_values_are_half_dollar_aligned(self):
         # Pick values now come from the workbook's L2:L73 column, which
         # carries half-dollar precision (R2 picks at $28.50, R5 picks
         # at $1.50, etc.).  Each value must be a number that's an
         # integer multiple of 0.5.
         import server
+
         result = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
         for p in result["picks"]:
             v = p["adjustedDollarValue"]
-            self.assertIsInstance(v, (int, float),
-                                  f"{p['pick']}: {v} is not numeric")
+            self.assertIsInstance(v, (int, float), f"{p['pick']}: {v} is not numeric")
             doubled = float(v) * 2
-            self.assertAlmostEqual(doubled, round(doubled), places=6,
-                                   msg=f"{p['pick']}: {v} not half-dollar aligned")
+            self.assertAlmostEqual(
+                doubled, round(doubled), places=6, msg=f"{p['pick']}: {v} not half-dollar aligned"
+            )
 
     def test_api_total_budget_1200(self):
         import server
+
         result = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
@@ -137,6 +136,7 @@ class TestApiOutput(unittest.TestCase):
 
     def test_api_team_totals_sum_to_1200(self):
         import server
+
         result = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
@@ -153,13 +153,16 @@ class TestTeamTotalsMirrorSheet(unittest.TestCase):
 
     def test_decimal_totals_match_sheet_per_owner(self):
         from collections import defaultdict
+
         _, workbook_picks, _, wb_team_totals, _, _ = _load()
         computed = defaultdict(float)
         for wp in workbook_picks:
             computed[wp["owner"]] += wp["value"]
         for owner, total in computed.items():
             self.assertAlmostEqual(
-                total, wb_team_totals.get(owner, 0.0), places=2,
+                total,
+                wb_team_totals.get(owner, 0.0),
+                places=2,
                 msg=f"{owner}: computed={total}, sheet={wb_team_totals.get(owner)}",
             )
 
@@ -175,6 +178,7 @@ class TestTeamTotalsMirrorSheet(unittest.TestCase):
         invariant."""
         import server
         from collections import defaultdict
+
         _, workbook_picks, _, _, _, _ = _load()
         decimals = defaultdict(float)
         for wp in workbook_picks:
@@ -188,16 +192,17 @@ class TestTeamTotalsMirrorSheet(unittest.TestCase):
         # don't appear as owners in R45:R116 (e.g. expansion franchises
         # with no picks yet).
         api_totals = sorted(
-            [t["auctionDollars"] for t in result["teamTotals"]], reverse=True,
+            [t["auctionDollars"] for t in result["teamTotals"]],
+            reverse=True,
         )
         decimal_vals = sorted(decimals.values(), reverse=True)
         pad = max(0, len(api_totals) - len(decimal_vals))
         decimal_vals += [0.0] * pad
         expected = sorted(
-            server._round_to_budget(decimal_vals, 1200), reverse=True,
+            server._round_to_budget(decimal_vals, 1200),
+            reverse=True,
         )
-        self.assertEqual(api_totals, expected,
-                         f"api={api_totals} expected={expected}")
+        self.assertEqual(api_totals, expected, f"api={api_totals} expected={expected}")
 
 
 class TestSleeperTradeOverlay(unittest.TestCase):
@@ -218,8 +223,7 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         import json as _json
 
         meta_payload = url_to_payload.get("__LEAGUE_META__")
-        substring_map = {k: v for k, v in url_to_payload.items()
-                         if k != "__LEAGUE_META__"}
+        substring_map = {k: v for k, v in url_to_payload.items() if k != "__LEAGUE_META__"}
 
         def fake_urlopen(url, *args, **kwargs):
             target = url.full_url if hasattr(url, "full_url") else str(url)
@@ -233,12 +237,12 @@ class TestSleeperTradeOverlay(unittest.TestCase):
                 if key in target:
                     return io.BytesIO(_json.dumps(payload).encode())
             raise AssertionError(f"unexpected urlopen({target})")
+
         return fake_urlopen
 
-    def _build_overlay_fixture(self, draft_season, *,
-                               league_meta_season=None,
-                               drafts_seasons=None,
-                               traded_pick_season=None):
+    def _build_overlay_fixture(
+        self, draft_season, *, league_meta_season=None, drafts_seasons=None, traded_pick_season=None
+    ):
         """Construct mocked Sleeper responses for a single traded pick.
 
         Returns ``(url_map, wp, orig_first, other_first)`` where ``wp``
@@ -270,8 +274,7 @@ class TestSleeperTradeOverlay(unittest.TestCase):
                 continue
             orig = slot_to_original.get(wp["pick"])
             other = next(
-                (n for s, n in slot_to_original.items()
-                 if s != wp["pick"] and n != orig),
+                (n for s, n in slot_to_original.items() if s != wp["pick"] and n != orig),
                 None,
             )
             if orig and other:
@@ -288,11 +291,13 @@ class TestSleeperTradeOverlay(unittest.TestCase):
             rid = int(slot)
             owner_uid = f"u{rid}"
             rosters.append({"roster_id": rid, "owner_id": owner_uid})
-            users.append({
-                "user_id": owner_uid,
-                "display_name": f"Team-{first_name}",
-                "metadata": {},
-            })
+            users.append(
+                {
+                    "user_id": owner_uid,
+                    "display_name": f"Team-{first_name}",
+                    "metadata": {},
+                }
+            )
             slot_to_roster[str(slot)] = rid
             roster_id_for_first[first_name] = rid
 
@@ -303,18 +308,17 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         if league_meta_season is None:
             league_meta_season = draft_season
 
-        drafts = [
-            {"draft_id": f"D{i}", "season": s}
-            for i, s in enumerate(drafts_seasons, start=1)
-        ]
+        drafts = [{"draft_id": f"D{i}", "season": s} for i, s in enumerate(drafts_seasons, start=1)]
         draft_detail = {"slot_to_roster_id": slot_to_roster}
-        traded_picks = [{
-            "season": traded_pick_season,
-            "round": wp["round"],
-            "roster_id": roster_id_for_first[orig_first],
-            "owner_id": roster_id_for_first[other_first],
-            "previous_owner_id": roster_id_for_first[orig_first],
-        }]
+        traded_picks = [
+            {
+                "season": traded_pick_season,
+                "round": wp["round"],
+                "roster_id": roster_id_for_first[orig_first],
+                "owner_id": roster_id_for_first[other_first],
+                "previous_owner_id": roster_id_for_first[orig_first],
+            }
+        ]
         url_map: dict[str, object] = {
             "/rosters": rosters,
             "/users": users,
@@ -345,14 +349,15 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         orig_first, other_first) or None if the workbook is
         unavailable."""
         import server
+
         fixture = self._build_overlay_fixture(draft_season, **fixture_kwargs)
         if fixture is None:
             return None
         url_map, wp, orig_first, other_first = fixture
-        with patch.object(server.urllib.request, "urlopen",
-                          self._stub_urlopen(url_map)), \
-             patch.object(server, "_sleeper_league_id_for_draft",
-                          return_value="TEST_LEAGUE"):
+        with (
+            patch.object(server.urllib.request, "urlopen", self._stub_urlopen(url_map)),
+            patch.object(server, "_sleeper_league_id_for_draft", return_value="TEST_LEAGUE"),
+        ):
             with_overlay = server._fetch_draft_capital(apply_sleeper_trades=True)
             without_overlay = server._fetch_draft_capital(apply_sleeper_trades=False)
         if "error" in with_overlay or "error" in without_overlay:
@@ -372,19 +377,20 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         dollar total must increase and the original owner's must
         decrease — independent of whatever R45:R116 says."""
         from datetime import datetime, timezone
+
         run = self._run_overlay(datetime.now(timezone.utc).year)
         if run is None:
             self.skipTest("Workbook unavailable")
         with_overlay, without_overlay, wp, orig_first, other_first = run
 
-        delta_recv = (self._team_total(with_overlay, other_first)
-                      - self._team_total(without_overlay, other_first))
-        delta_orig = (self._team_total(with_overlay, orig_first)
-                      - self._team_total(without_overlay, orig_first))
-        self.assertGreater(delta_recv, 0,
-                           f"Receiving team did not gain dollars: {delta_recv}")
-        self.assertLess(delta_orig, 0,
-                        f"Original owner did not lose dollars: {delta_orig}")
+        delta_recv = self._team_total(with_overlay, other_first) - self._team_total(
+            without_overlay, other_first
+        )
+        delta_orig = self._team_total(with_overlay, orig_first) - self._team_total(
+            without_overlay, orig_first
+        )
+        self.assertGreater(delta_recv, 0, f"Receiving team did not gain dollars: {delta_recv}")
+        self.assertLess(delta_orig, 0, f"Original owner did not lose dollars: {delta_orig}")
 
         traded_pick_label = f"{wp['round']}.{str(wp['pick']).zfill(2)}"
         overlay_pick = next(
@@ -414,8 +420,9 @@ class TestSleeperTradeOverlay(unittest.TestCase):
              hand-maintained for N+1 in this window).
         """
         from datetime import datetime, timezone
-        active = datetime.now(timezone.utc).year + 1   # active pick season
-        prior = active - 1                              # last completed draft
+
+        active = datetime.now(timezone.utc).year + 1  # active pick season
+        prior = active - 1  # last completed draft
         run = self._run_overlay(
             active,
             league_meta_season=active,
@@ -426,19 +433,21 @@ class TestSleeperTradeOverlay(unittest.TestCase):
             self.skipTest("Workbook unavailable")
         with_overlay, without_overlay, _wp, _orig_first, _other_first = run
         # League meta drives the response season, not max(drafts).
-        self.assertEqual(with_overlay["season"], active,
-                         "Response season must follow league meta, not drafts max")
+        self.assertEqual(
+            with_overlay["season"],
+            active,
+            "Response season must follow league meta, not drafts max",
+        )
         # Overlay must not apply incorrectly: per-team totals must be
         # bit-identical between with/without when the active-season
         # slot map is unavailable.
-        with_totals = sorted(
-            (t["team"], t["auctionDollars"]) for t in with_overlay["teamTotals"]
-        )
+        with_totals = sorted((t["team"], t["auctionDollars"]) for t in with_overlay["teamTotals"])
         without_totals = sorted(
             (t["team"], t["auctionDollars"]) for t in without_overlay["teamTotals"]
         )
-        self.assertEqual(with_totals, without_totals,
-                         "Overlay shifted dollars using a cross-year slot map")
+        self.assertEqual(
+            with_totals, without_totals, "Overlay shifted dollars using a cross-year slot map"
+        )
         # And teamTotals must not contain duplicate logical teams
         # (e.g. a Sleeper "Russini Panini" row at $0 plus a workbook
         # "Jason" row at $XX).  Codex P1 round 4: when the first-name
@@ -448,7 +457,8 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         # length must equal the unique team count from the workbook.
         team_names = {row["team"] for row in with_overlay["teamTotals"]}
         self.assertEqual(
-            len(with_overlay["teamTotals"]), len(team_names),
+            len(with_overlay["teamTotals"]),
+            len(team_names),
             f"Duplicate rows in teamTotals: {with_overlay['teamTotals']}",
         )
         self.assertLessEqual(
@@ -465,6 +475,7 @@ class TestSleeperTradeOverlay(unittest.TestCase):
         Pre-fix, this filter (``season != current_year``) silently
         dropped every traded pick in that window."""
         from datetime import datetime, timezone
+
         wall_year = datetime.now(timezone.utc).year
         # Simulate the boundary: Sleeper reports next year's draft.
         sleeper_season = wall_year + 1
@@ -475,10 +486,12 @@ class TestSleeperTradeOverlay(unittest.TestCase):
 
         # The overlay must still flip the dollar totals, even though
         # the draft season differs from datetime.now().year.
-        delta_recv = (self._team_total(with_overlay, other_first)
-                      - self._team_total(without_overlay, other_first))
-        self.assertGreater(delta_recv, 0,
-                           "Trade overlay regressed under sleeper_season != calendar_year")
+        delta_recv = self._team_total(with_overlay, other_first) - self._team_total(
+            without_overlay, other_first
+        )
+        self.assertGreater(
+            delta_recv, 0, "Trade overlay regressed under sleeper_season != calendar_year"
+        )
         # And the response must report the actual draft season.
         self.assertEqual(with_overlay["season"], sleeper_season)
 
@@ -501,11 +514,17 @@ class TestLiveStandingsOverride(unittest.TestCase):
     def _stub_urlopen(self, url_to_payload):
         return TestSleeperTradeOverlay._stub_urlopen(self, url_to_payload)
 
-    def _build_fixture(self, draft_season, *, fpts_by_rid, trades=None,
-                       empty_draft_detail=False,
-                       drop_slots_from_draft_detail=None,
-                       remap_slot_keys=None,
-                       extra_unbridged_rosters=None):
+    def _build_fixture(
+        self,
+        draft_season,
+        *,
+        fpts_by_rid,
+        trades=None,
+        empty_draft_detail=False,
+        drop_slots_from_draft_detail=None,
+        remap_slot_keys=None,
+        extra_unbridged_rosters=None,
+    ):
         """Mocked Sleeper fixture with explicit per-roster fpts so the
         live-standings override fires.
 
@@ -548,16 +567,20 @@ class TestLiveStandingsOverride(unittest.TestCase):
                 "fpts": int(fpts_by_rid.get(rid, 0)),
                 "fpts_decimal": 0,
             }
-            rosters.append({
-                "roster_id": rid,
-                "owner_id": owner_uid,
-                "settings": settings,
-            })
-            users.append({
-                "user_id": owner_uid,
-                "display_name": f"Team-{first_name}",
-                "metadata": {},
-            })
+            rosters.append(
+                {
+                    "roster_id": rid,
+                    "owner_id": owner_uid,
+                    "settings": settings,
+                }
+            )
+            users.append(
+                {
+                    "user_id": owner_uid,
+                    "display_name": f"Team-{first_name}",
+                    "metadata": {},
+                }
+            )
             slot_to_roster[str(slot)] = rid
             first_name_by_rid[rid] = first_name
 
@@ -565,25 +588,29 @@ class TestLiveStandingsOverride(unittest.TestCase):
         # doesn't bridge.  These get a real /rosters entry (so they
         # show up in roster_fppts) but are intentionally absent
         # from the slot_to_roster_id draft map.
-        for rid, fpts in (extra_unbridged_rosters or ()):
+        for rid, fpts in extra_unbridged_rosters or ():
             owner_uid = f"u{rid}"
-            rosters.append({
-                "roster_id": int(rid),
-                "owner_id": owner_uid,
-                "settings": {"fpts": int(fpts), "fpts_decimal": 0},
-            })
-            users.append({
-                "user_id": owner_uid,
-                "display_name": f"Extra-{rid}",
-                "metadata": {},
-            })
+            rosters.append(
+                {
+                    "roster_id": int(rid),
+                    "owner_id": owner_uid,
+                    "settings": {"fpts": int(fpts), "fpts_decimal": 0},
+                }
+            )
+            users.append(
+                {
+                    "user_id": owner_uid,
+                    "display_name": f"Extra-{rid}",
+                    "metadata": {},
+                }
+            )
 
         drafts = [{"draft_id": "D1", "season": draft_season}]
         if empty_draft_detail:
             draft_detail: dict[str, object] = {}
         else:
             partial_map = dict(slot_to_roster)
-            for s in (drop_slots_from_draft_detail or ()):
+            for s in drop_slots_from_draft_detail or ():
                 partial_map.pop(str(s), None)
             # ``remap_slot_keys`` rewrites slot KEYS to out-of-range
             # values WITHOUT changing the entry count — simulates
@@ -595,14 +622,16 @@ class TestLiveStandingsOverride(unittest.TestCase):
                     partial_map[str(new_s)] = partial_map.pop(str(old_s))
             draft_detail = {"slot_to_roster_id": partial_map}
         traded_picks_payload = []
-        for t in (trades or []):
-            traded_picks_payload.append({
-                "season": draft_season,
-                "round": t["round"],
-                "roster_id": t["original_rid"],
-                "owner_id": t["new_rid"],
-                "previous_owner_id": t["original_rid"],
-            })
+        for t in trades or []:
+            traded_picks_payload.append(
+                {
+                    "season": draft_season,
+                    "round": t["round"],
+                    "roster_id": t["original_rid"],
+                    "owner_id": t["new_rid"],
+                    "previous_owner_id": t["original_rid"],
+                }
+            )
 
         url_map: dict[str, object] = {
             "/rosters": rosters,
@@ -616,14 +645,15 @@ class TestLiveStandingsOverride(unittest.TestCase):
 
     def _run(self, draft_season, **fixture_kwargs):
         import server
+
         fixture = self._build_fixture(draft_season, **fixture_kwargs)
         if fixture is None:
             return None
         url_map, workbook_picks, slot_to_original, first_name_by_rid = fixture
-        with patch.object(server.urllib.request, "urlopen",
-                          self._stub_urlopen(url_map)), \
-             patch.object(server, "_sleeper_league_id_for_draft",
-                          return_value="TEST_LEAGUE"):
+        with (
+            patch.object(server.urllib.request, "urlopen", self._stub_urlopen(url_map)),
+            patch.object(server, "_sleeper_league_id_for_draft", return_value="TEST_LEAGUE"),
+        ):
             result = server._fetch_draft_capital(apply_sleeper_trades=True)
         if "error" in result:
             return None
@@ -637,6 +667,7 @@ class TestLiveStandingsOverride(unittest.TestCase):
         every untraded pick read ``isTraded: true`` mid-season.
         """
         from datetime import datetime, timezone
+
         season = datetime.now(timezone.utc).year
         # Reverse the standings: roster 12 fewest points → slot 1,
         # roster 11 next → slot 2, ..., roster 1 most → slot 12.
@@ -650,12 +681,10 @@ class TestLiveStandingsOverride(unittest.TestCase):
         # originalOwner == currentOwner (regardless of which slot
         # the live reshuffle moved each team to).
         misflagged = [
-            p for p in result["picks"]
-            if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
+            p for p in result["picks"] if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
         ]
         self.assertEqual(
-            misflagged, [],
-            "Untraded picks were flagged as traded after live-standings reshuffle"
+            misflagged, [], "Untraded picks were flagged as traded after live-standings reshuffle"
         )
 
     def test_traded_pick_follows_original_roster_to_its_new_slot(self):
@@ -668,6 +697,7 @@ class TestLiveStandingsOverride(unittest.TestCase):
         untouched.
         """
         from datetime import datetime, timezone
+
         season = datetime.now(timezone.utc).year
         # Same reversed standings: rid r → slot (13 - r).
         fpts = {rid: (13 - rid) * 100 for rid in range(1, 13)}
@@ -717,7 +747,6 @@ class TestLiveStandingsOverride(unittest.TestCase):
         self.assertEqual(slot1_pick["currentOwner"], rid_12_team)
         self.assertFalse(slot1_pick["isTraded"])
 
-
     def test_traded_pick_detected_when_two_rosters_share_display_name(self):
         """Codex P2: ``isTraded`` must use stable roster_ids, not the
         rendered display names.  Sleeper doesn't enforce unique
@@ -726,6 +755,7 @@ class TestLiveStandingsOverride(unittest.TestCase):
         render to the same string.
         """
         from datetime import datetime, timezone
+
         season = datetime.now(timezone.utc).year
         # No fpts → live override doesn't fire; this exercises the
         # workbook + Sleeper trade overlay path where the display-only
@@ -748,10 +778,11 @@ class TestLiveStandingsOverride(unittest.TestCase):
                 user["display_name"] = shared_label
 
         import server
-        with patch.object(server.urllib.request, "urlopen",
-                          self._stub_urlopen(url_map)), \
-             patch.object(server, "_sleeper_league_id_for_draft",
-                          return_value="TEST_LEAGUE"):
+
+        with (
+            patch.object(server.urllib.request, "urlopen", self._stub_urlopen(url_map)),
+            patch.object(server, "_sleeper_league_id_for_draft", return_value="TEST_LEAGUE"),
+        ):
             result = server._fetch_draft_capital(apply_sleeper_trades=True)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
@@ -786,6 +817,7 @@ class TestLiveStandingsOverride(unittest.TestCase):
         roster IDs in ``slot_to_roster``.
         """
         from datetime import datetime, timezone
+
         season = datetime.now(timezone.utc).year
         # All 12 workbook rosters have meaningful fpts.
         fpts = {rid: (13 - rid) * 100 for rid in range(1, 13)}
@@ -803,11 +835,11 @@ class TestLiveStandingsOverride(unittest.TestCase):
         result, workbook_picks, slot_to_original, first_name_by_rid = run
 
         misflagged = [
-            p for p in result["picks"]
-            if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
+            p for p in result["picks"] if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
         ]
         self.assertEqual(
-            misflagged, [],
+            misflagged,
+            [],
             "Untraded picks were flagged traded when Sleeper exposed extra "
             "unbridged rosters (live reshuffle must restrict to bridged rids)",
         )
@@ -827,22 +859,22 @@ class TestLiveStandingsOverride(unittest.TestCase):
         COMPLETE bridge, not just a non-empty one.
         """
         from datetime import datetime, timezone
+
         season = datetime.now(timezone.utc).year
         fpts = {rid: (13 - rid) * 100 for rid in range(1, 13)}
         # Drop two slots from the draft detail to simulate a partial
         # bridge (10 of 12 workbook slots covered).
-        run = self._run(season, fpts_by_rid=fpts, trades=[],
-                        drop_slots_from_draft_detail=[7, 8])
+        run = self._run(season, fpts_by_rid=fpts, trades=[], drop_slots_from_draft_detail=[7, 8])
         if run is None:
             self.skipTest("Workbook unavailable")
         result, workbook_picks, slot_to_original, first_name_by_rid = run
 
         misflagged = [
-            p for p in result["picks"]
-            if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
+            p for p in result["picks"] if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
         ]
         self.assertEqual(
-            misflagged, [],
+            misflagged,
+            [],
             "Untraded picks were flagged traded under partial slot_to_roster "
             "coverage (live-standings override should require complete bridge)",
         )
@@ -859,10 +891,10 @@ class TestLiveStandingsOverride(unittest.TestCase):
         ordering in that case preserves correctness.
         """
         from datetime import datetime, timezone
+
         season = datetime.now(timezone.utc).year
         fpts = {rid: (13 - rid) * 100 for rid in range(1, 13)}
-        run = self._run(season, fpts_by_rid=fpts, trades=[],
-                        empty_draft_detail=True)
+        run = self._run(season, fpts_by_rid=fpts, trades=[], empty_draft_detail=True)
         if run is None:
             self.skipTest("Workbook unavailable")
         result, workbook_picks, slot_to_original, first_name_by_rid = run
@@ -871,11 +903,11 @@ class TestLiveStandingsOverride(unittest.TestCase):
         # the workbook's slot ordering preserved.  Untraded picks
         # must keep originalOwner == currentOwner.
         misflagged = [
-            p for p in result["picks"]
-            if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
+            p for p in result["picks"] if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
         ]
         self.assertEqual(
-            misflagged, [],
+            misflagged,
+            [],
             "Untraded picks were flagged traded when slot_to_roster was empty "
             "(live-standings override should have been gated off)",
         )
@@ -894,22 +926,22 @@ class TestLiveStandingsOverride(unittest.TestCase):
         keys; partial coverage falls back to the workbook ordering.
         """
         from datetime import datetime, timezone
+
         season = datetime.now(timezone.utc).year
         fpts = {rid: (13 - rid) * 100 for rid in range(1, 13)}
         # Same entry count (12) but slots 11 & 12 re-keyed to
         # out-of-range 101/102 so they no longer cover the workbook.
-        run = self._run(season, fpts_by_rid=fpts, trades=[],
-                        remap_slot_keys={11: 101, 12: 102})
+        run = self._run(season, fpts_by_rid=fpts, trades=[], remap_slot_keys={11: 101, 12: 102})
         if run is None:
             self.skipTest("Workbook unavailable")
         result, workbook_picks, slot_to_original, first_name_by_rid = run
 
         misflagged = [
-            p for p in result["picks"]
-            if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
+            p for p in result["picks"] if p["originalOwner"] != p["currentOwner"] or p["isTraded"]
         ]
         self.assertEqual(
-            misflagged, [],
+            misflagged,
+            [],
             "Untraded picks mis-flagged when slot_to_roster keys did not "
             "cover the workbook slot set (count-only gate regression)",
         )
@@ -958,8 +990,7 @@ class TestLiveStandingsOverride(unittest.TestCase):
         for p in wb_picks:
             if p["pick"] == dup_slot:
                 p["owner"] = shared_first
-        mutated = (pick_dollars, wb_picks, slot_to_original,
-                   wb_totals, rookies, pv_l)
+        mutated = (pick_dollars, wb_picks, slot_to_original, wb_totals, rookies, pv_l)
 
         # Full 12-roster Sleeper fixture aligned to the (mutated)
         # slot_to_original — rid == slot, distinct display names so the
@@ -970,10 +1001,14 @@ class TestLiveStandingsOverride(unittest.TestCase):
         rosters, users, slot_to_roster = [], [], {}
         for slot in slot_to_original:
             rid = int(slot)
-            rosters.append({"roster_id": rid, "owner_id": f"u{rid}",
-                             "settings": {"fpts": 0, "fpts_decimal": 0}})
-            users.append({"user_id": f"u{rid}",
-                          "display_name": f"Team-{rid}", "metadata": {}})
+            rosters.append(
+                {
+                    "roster_id": rid,
+                    "owner_id": f"u{rid}",
+                    "settings": {"fpts": 0, "fpts_decimal": 0},
+                }
+            )
+            users.append({"user_id": f"u{rid}", "display_name": f"Team-{rid}", "metadata": {}})
             slot_to_roster[str(slot)] = rid
         keep_rid, dup_rid = int(keep_slot), int(dup_slot)
         url_map = {
@@ -994,11 +1029,11 @@ class TestLiveStandingsOverride(unittest.TestCase):
             ],
             "__LEAGUE_META__": {"season": str(season)},
         }
-        with patch.object(server, "_parse_draft_data", return_value=mutated), \
-             patch.object(server.urllib.request, "urlopen",
-                          self._stub_urlopen(url_map)), \
-             patch.object(server, "_sleeper_league_id_for_draft",
-                          return_value="TEST_LEAGUE"):
+        with (
+            patch.object(server, "_parse_draft_data", return_value=mutated),
+            patch.object(server.urllib.request, "urlopen", self._stub_urlopen(url_map)),
+            patch.object(server, "_sleeper_league_id_for_draft", return_value="TEST_LEAGUE"),
+        ):
             result = server._fetch_draft_capital(apply_sleeper_trades=True)
         if "error" in result:
             self.skipTest(f"Unavailable: {result['error']}")
@@ -1018,8 +1053,7 @@ class TestLiveStandingsOverride(unittest.TestCase):
         # dup_slot's own R1 pick was NOT traded — must stay unflagged.
         self.assertFalse(
             by_pick[dup_pick]["isTraded"],
-            "Untraded pick mis-flagged traded due to duplicate-first-name "
-            "roster_id collapse",
+            "Untraded pick mis-flagged traded due to duplicate-first-name " "roster_id collapse",
         )
 
 

--- a/tests/api/test_draft_capital_fallback.py
+++ b/tests/api/test_draft_capital_fallback.py
@@ -1,6 +1,7 @@
 """Tests for the Sleeper-derived draft-capital fallback.
 
 We mock the Sleeper HTTP calls so tests run offline."""
+
 from __future__ import annotations
 
 import io
@@ -14,11 +15,13 @@ from src.api import draft_capital_fallback as dcf
 
 def _stub_fetch_json(responses):
     """Return a patched _fetch_json that reads from a URL→response map."""
+
     def fake(url):
         for key, resp in responses.items():
             if key in url:
                 return resp
         return None
+
     return fake
 
 
@@ -42,24 +45,27 @@ def _contract_with_picks():
 def test_returns_error_when_sleeper_unreachable(monkeypatch):
     monkeypatch.setattr(dcf, "_fetch_json", lambda _url: None)
     result = dcf.build_sleeper_derived(
-        "L1", _contract_with_picks(), current_season=2026, num_teams=12,
+        "L1",
+        _contract_with_picks(),
+        current_season=2026,
+        num_teams=12,
     )
     assert result.get("error") == "sleeper_unreachable"
 
 
 def test_basic_build_returns_expected_shape(monkeypatch):
     responses = {
-        "/rosters": [
-            {"roster_id": i, "owner_id": str(100 + i)} for i in range(1, 11)
-        ],
-        "/users": [
-            {"user_id": str(100 + i), "display_name": f"Team{i}"} for i in range(1, 11)
-        ],
+        "/rosters": [{"roster_id": i, "owner_id": str(100 + i)} for i in range(1, 11)],
+        "/users": [{"user_id": str(100 + i), "display_name": f"Team{i}"} for i in range(1, 11)],
         "/traded_picks": [],
     }
     monkeypatch.setattr(dcf, "_fetch_json", _stub_fetch_json(responses))
     result = dcf.build_sleeper_derived(
-        "L1", _contract_with_picks(), current_season=2026, num_teams=10, draft_rounds=4,
+        "L1",
+        _contract_with_picks(),
+        current_season=2026,
+        num_teams=10,
+        draft_rounds=4,
     )
     assert result["source"] == "sleeper_derived"
     assert result["numTeams"] == 10
@@ -87,13 +93,20 @@ def test_traded_pick_updates_ownership(monkeypatch):
         "/traded_picks": [
             # Team 2's 2026 1st (slot 2) now owned by Team 1.
             {
-                "season": "2026", "round": 1, "roster_id": 2, "owner_id": 1,
+                "season": "2026",
+                "round": 1,
+                "roster_id": 2,
+                "owner_id": 1,
             }
         ],
     }
     monkeypatch.setattr(dcf, "_fetch_json", _stub_fetch_json(responses))
     result = dcf.build_sleeper_derived(
-        "L1", _contract_with_picks(), current_season=2026, num_teams=2, draft_rounds=1,
+        "L1",
+        _contract_with_picks(),
+        current_season=2026,
+        num_teams=2,
+        draft_rounds=1,
     )
     # Find the traded pick.
     traded = [p for p in result["picks"] if p["isTraded"]]
@@ -118,7 +131,11 @@ def test_missing_contract_uses_flat_fallback(monkeypatch):
     }
     monkeypatch.setattr(dcf, "_fetch_json", _stub_fetch_json(responses))
     result = dcf.build_sleeper_derived(
-        "L1", {}, current_season=2026, num_teams=1, draft_rounds=4,
+        "L1",
+        {},
+        current_season=2026,
+        num_teams=1,
+        draft_rounds=4,
     )
     # Still produces a valid shape.
     assert result["source"] == "sleeper_derived"

--- a/tests/api/test_draftsharks_negative_values.py
+++ b/tests/api/test_draftsharks_negative_values.py
@@ -20,6 +20,7 @@ These tests guard all three gates simultaneously by building the
 live contract and asserting that a known tail-player (McNeil-Warren)
 receives credit for DS coverage end to end.
 """
+
 from __future__ import annotations
 
 import json
@@ -189,14 +190,10 @@ class DraftSharksNegativeValueTests(unittest.TestCase):
         players = self.contract.get("playersArray") or []
 
         ds_idp_covered = sum(
-            1
-            for p in players
-            if (p.get("sourcePresence") or {}).get("draftSharksIdp")
+            1 for p in players if (p.get("sourcePresence") or {}).get("draftSharksIdp")
         )
         ds_sf_covered = sum(
-            1
-            for p in players
-            if (p.get("sourcePresence") or {}).get("draftSharks")
+            1 for p in players if (p.get("sourcePresence") or {}).get("draftSharks")
         )
 
         # Regression floor: a real regression of the carve-out drops

--- a/tests/api/test_dynasty_nerds_integration.py
+++ b/tests/api/test_dynasty_nerds_integration.py
@@ -20,6 +20,7 @@ Specifically:
 7. Rows with ``value=0`` in the raw DR_DATA payload are skipped by
    the fetch script, so they never appear in the CSV at all.
 """
+
 from __future__ import annotations
 
 import csv
@@ -64,9 +65,7 @@ class TestDynastyNerdsRegistry(unittest.TestCase):
         self.assertEqual(src["scope"], SOURCE_SCOPE_OVERALL_OFFENSE)
 
     def test_source_weight_and_depth(self):
-        src = next(
-            s for s in _RANKING_SOURCES if s["key"] == "dynastyNerdsSfTep"
-        )
+        src = next(s for s in _RANKING_SOURCES if s["key"] == "dynastyNerdsSfTep")
         # Every registered source is declared at weight 1.0 so the
         # blend is an honest equal-weight consensus.  See the
         # registry note in data_contract.py.
@@ -75,9 +74,7 @@ class TestDynastyNerdsRegistry(unittest.TestCase):
         self.assertGreaterEqual(src["depth"], 290)
 
     def test_source_not_retail(self):
-        src = next(
-            s for s in _RANKING_SOURCES if s["key"] == "dynastyNerdsSfTep"
-        )
+        src = next(s for s in _RANKING_SOURCES if s["key"] == "dynastyNerdsSfTep")
         self.assertFalse(src.get("is_retail", False))
 
     def test_source_in_offense_signal_keys(self):
@@ -176,8 +173,7 @@ class TestDynastyNerdsEnrichment(unittest.TestCase):
             self.skipTest("DN CSV missing")
         pa = self.contract.get("playersArray", [])
         dn_enriched = [
-            p for p in pa
-            if (p.get("canonicalSiteValues") or {}).get("dynastyNerdsSfTep")
+            p for p in pa if (p.get("canonicalSiteValues") or {}).get("dynastyNerdsSfTep")
         ]
         # Expect at least 15 of the 20-plus synthesized rows to have
         # received an enrichment value.  A handful of top-20 names may
@@ -190,8 +186,7 @@ class TestDynastyNerdsEnrichment(unittest.TestCase):
             self.skipTest("DN CSV missing")
         pa = self.contract.get("playersArray", [])
         any_stamped = any(
-            (p.get("sourceRanks") or {}).get("dynastyNerdsSfTep") is not None
-            for p in pa
+            (p.get("sourceRanks") or {}).get("dynastyNerdsSfTep") is not None for p in pa
         )
         self.assertTrue(any_stamped)
 
@@ -199,10 +194,7 @@ class TestDynastyNerdsEnrichment(unittest.TestCase):
         if self.contract is None:
             self.skipTest("DN CSV missing")
         pa = self.contract.get("playersArray", [])
-        matched = [
-            p for p in pa
-            if (p.get("sourceOriginalRanks") or {}).get("dynastyNerdsSfTep")
-        ]
+        matched = [p for p in pa if (p.get("sourceOriginalRanks") or {}).get("dynastyNerdsSfTep")]
         self.assertTrue(matched)
         # The preserved original rank must be a positive number inside
         # the DN board's depth.
@@ -218,10 +210,7 @@ class TestDynastyNerdsEnrichment(unittest.TestCase):
         key = _canonical_match_key(top_name)
         pa = self.contract.get("playersArray", [])
         match = next(
-            (
-                p for p in pa
-                if _canonical_match_key(p.get("canonicalName") or "") == key
-            ),
+            (p for p in pa if _canonical_match_key(p.get("canonicalName") or "") == key),
             None,
         )
         self.assertIsNotNone(match, f"{top_name} missing from contract")
@@ -238,7 +227,8 @@ class TestDynastyNerdsAllowlist(unittest.TestCase):
     def test_dn_only_entries_documented(self):
         # Each DN-only entry must reference DN in the reason string.
         dn_reasons = [
-            reason for reason in SINGLE_SOURCE_ALLOWLIST.values()
+            reason
+            for reason in SINGLE_SOURCE_ALLOWLIST.values()
             if "Dynasty Nerds" in reason or "dynastyNerds" in reason
         ]
         # We do not require a specific count — just sanity-check that

--- a/tests/api/test_error_responses.py
+++ b/tests/api/test_error_responses.py
@@ -1,5 +1,6 @@
 """Tests for the standardized error-response envelope + global
 exception handler."""
+
 from __future__ import annotations
 
 import pytest
@@ -94,6 +95,7 @@ def test_global_handler_logs_full_trace(caplog):
         raise ValueError("inner detail")
 
     import logging
+
     with caplog.at_level(logging.ERROR):
         with TestClient(app, raise_server_exceptions=False) as c:
             c.get("/boom")

--- a/tests/api/test_espn_schema_drift.py
+++ b/tests/api/test_espn_schema_drift.py
@@ -1,4 +1,5 @@
 """Tests for ESPN schema drift detection."""
+
 from __future__ import annotations
 
 import json
@@ -51,7 +52,8 @@ def test_list_with_mixed_element_shapes_merges():
 def test_detect_drift_new_endpoint(tmp_path):
     baseline = tmp_path / "b.json"
     result = esd.detect_drift(
-        {"new_ep": {"a": 1}}, baseline_path=baseline,
+        {"new_ep": {"a": 1}},
+        baseline_path=baseline,
     )
     assert result["new_ep"]["status"] == "new"
 
@@ -86,12 +88,15 @@ def test_run_drift_check_delivers_email_on_drift(tmp_path):
     baseline = tmp_path / "b.json"
     esd.save_baseline({"ep1": {"hash": "old_hash_xx"}}, path=baseline)
     sends = []
+
     def delivery(to, subj, body):
         sends.append((to, subj, body))
         return True
+
     result = esd.run_drift_check(
         {"ep1": lambda: {"new": "shape"}},
-        delivery=delivery, to_email="ops@example.com",
+        delivery=delivery,
+        to_email="ops@example.com",
         baseline_path=baseline,
     )
     assert result["drifted"] >= 1
@@ -104,12 +109,15 @@ def test_run_drift_check_no_email_when_unchanged(tmp_path):
     sample = {"x": 1}
     esd.save_baseline({"ep": {"hash": esd.hash_shape(sample)}}, path=baseline)
     sends = []
+
     def delivery(to, subj, body):
         sends.append((to, subj, body))
         return True
+
     result = esd.run_drift_check(
         {"ep": lambda: sample},
-        delivery=delivery, to_email="ops@example.com",
+        delivery=delivery,
+        to_email="ops@example.com",
         baseline_path=baseline,
     )
     assert result["drifted"] == 0

--- a/tests/api/test_faab_analytics.py
+++ b/tests/api/test_faab_analytics.py
@@ -7,6 +7,7 @@ JSON-serializable block consumed by:
   1. /api/public/league/faabAnalytics  (waivers page UI)
   2. src.trade.faab_recommender         (per-pair recommender — B6)
 """
+
 from __future__ import annotations
 
 from src.api import faab_analytics
@@ -107,15 +108,19 @@ def test_uses_league_settings_waiver_budget():
 
 
 def test_avg_and_median_are_computed_correctly():
-    snap = _snap([
-        _season(txs_by_week={
-            1: [
-                _waiver_tx(bid=10, adds={"P1": 1}),
-                _waiver_tx(bid=20, adds={"P2": 1}),
-                _waiver_tx(bid=30, adds={"P3": 1}),
-            ],
-        }),
-    ])
+    snap = _snap(
+        [
+            _season(
+                txs_by_week={
+                    1: [
+                        _waiver_tx(bid=10, adds={"P1": 1}),
+                        _waiver_tx(bid=20, adds={"P2": 1}),
+                        _waiver_tx(bid=30, adds={"P3": 1}),
+                    ],
+                }
+            ),
+        ]
+    )
     out = faab_analytics.summarize_league_faab(snap)
     assert out["totalBidsAnalyzed"] == 3
     assert out["leagueAvgWinningBid"] == 20.0
@@ -125,15 +130,19 @@ def test_avg_and_median_are_computed_correctly():
 def test_zero_bid_free_agents_excluded_from_avg():
     """Zero-bid FA pickups don't pull the average down — they
     represent free pickups, not bids the league competed on."""
-    snap = _snap([
-        _season(txs_by_week={
-            1: [
-                _waiver_tx(bid=20, adds={"P1": 1}),
-                _waiver_tx(bid=0, adds={"P2": 1}, type_="free_agent"),
-                _waiver_tx(bid=0, adds={"P3": 1}, type_="free_agent"),
-            ],
-        }),
-    ])
+    snap = _snap(
+        [
+            _season(
+                txs_by_week={
+                    1: [
+                        _waiver_tx(bid=20, adds={"P1": 1}),
+                        _waiver_tx(bid=0, adds={"P2": 1}, type_="free_agent"),
+                        _waiver_tx(bid=0, adds={"P3": 1}, type_="free_agent"),
+                    ],
+                }
+            ),
+        ]
+    )
     out = faab_analytics.summarize_league_faab(snap)
     assert out["totalBidsAnalyzed"] == 1
     assert out["leagueAvgWinningBid"] == 20.0
@@ -144,19 +153,21 @@ def test_zero_bid_free_agents_excluded_from_avg():
 
 def test_tier_bucketing_by_pct_of_budget():
     """20+% → tier1, 10-20% → tier2, 3-10% → tier3, ≤3% → tier4."""
-    snap = _snap([
-        _season(
-            settings={"waiver_budget": 100},
-            txs_by_week={
-                1: [
-                    _waiver_tx(bid=25, adds={"P1": 1}),  # tier1
-                    _waiver_tx(bid=15, adds={"P2": 1}),  # tier2
-                    _waiver_tx(bid=5,  adds={"P3": 1}),  # tier3
-                    _waiver_tx(bid=2,  adds={"P4": 1}),  # tier4
-                ],
-            },
-        ),
-    ])
+    snap = _snap(
+        [
+            _season(
+                settings={"waiver_budget": 100},
+                txs_by_week={
+                    1: [
+                        _waiver_tx(bid=25, adds={"P1": 1}),  # tier1
+                        _waiver_tx(bid=15, adds={"P2": 1}),  # tier2
+                        _waiver_tx(bid=5, adds={"P3": 1}),  # tier3
+                        _waiver_tx(bid=2, adds={"P4": 1}),  # tier4
+                    ],
+                },
+            ),
+        ]
+    )
     out = faab_analytics.summarize_league_faab(snap)
     assert out["tierBids"]["tier1"]["count"] == 1
     assert out["tierBids"]["tier2"]["count"] == 1
@@ -173,12 +184,16 @@ def test_position_bids_resolve_via_nfl_players():
         "RB1": {"position": "RB", "full_name": "RB Guy"},
     }
     snap = _snap(
-        [_season(txs_by_week={
-            1: [
-                _waiver_tx(bid=15, adds={"WR1": 1}),
-                _waiver_tx(bid=8, adds={"RB1": 1}),
-            ],
-        })],
+        [
+            _season(
+                txs_by_week={
+                    1: [
+                        _waiver_tx(bid=15, adds={"WR1": 1}),
+                        _waiver_tx(bid=8, adds={"RB1": 1}),
+                    ],
+                }
+            )
+        ],
         nfl_players=nfl,
     )
     out = faab_analytics.summarize_league_faab(snap)
@@ -197,15 +212,19 @@ def test_idp_positions_normalize_to_base_buckets():
         "S1": {"position": "S"},
     }
     snap = _snap(
-        [_season(txs_by_week={
-            1: [
-                _waiver_tx(bid=5, adds={"DT1": 1}),
-                _waiver_tx(bid=4, adds={"EDGE1": 1}),
-                _waiver_tx(bid=3, adds={"ILB1": 1}),
-                _waiver_tx(bid=2, adds={"CB1": 1}),
-                _waiver_tx(bid=1, adds={"S1": 1}),
-            ],
-        })],
+        [
+            _season(
+                txs_by_week={
+                    1: [
+                        _waiver_tx(bid=5, adds={"DT1": 1}),
+                        _waiver_tx(bid=4, adds={"EDGE1": 1}),
+                        _waiver_tx(bid=3, adds={"ILB1": 1}),
+                        _waiver_tx(bid=2, adds={"CB1": 1}),
+                        _waiver_tx(bid=1, adds={"S1": 1}),
+                    ],
+                }
+            )
+        ],
         nfl_players=nfl,
     )
     out = faab_analytics.summarize_league_faab(snap)
@@ -223,20 +242,21 @@ def test_team_aggression_aggregates_per_owner():
         {"roster_id": 1, "owner_id": "ownerA"},
         {"roster_id": 2, "owner_id": "ownerB"},
     ]
-    snap = _snap([
-        _season(
-            rosters=rosters,
-            txs_by_week={
-                1: [
-                    _waiver_tx(bid=20, adds={"P1": 1}, roster_id=1),
-                    _waiver_tx(bid=10, adds={"P2": 1}, roster_id=1),
-                    _waiver_tx(bid=5, adds={"P3": 1}, roster_id=2),
-                    _waiver_tx(bid=0, adds={"P4": 1}, roster_id=2,
-                               type_="free_agent"),
-                ],
-            },
-        ),
-    ])
+    snap = _snap(
+        [
+            _season(
+                rosters=rosters,
+                txs_by_week={
+                    1: [
+                        _waiver_tx(bid=20, adds={"P1": 1}, roster_id=1),
+                        _waiver_tx(bid=10, adds={"P2": 1}, roster_id=1),
+                        _waiver_tx(bid=5, adds={"P3": 1}, roster_id=2),
+                        _waiver_tx(bid=0, adds={"P4": 1}, roster_id=2, type_="free_agent"),
+                    ],
+                },
+            ),
+        ]
+    )
     out = faab_analytics.summarize_league_faab(snap)
     a = out["teamAggression"]["ownerA"]
     assert a["totalSpent"] == 30
@@ -253,18 +273,20 @@ def test_team_aggression_aggregates_per_owner():
 
 def test_player_history_records_each_add():
     rosters = [{"roster_id": 1, "owner_id": "ownerA"}]
-    snap = _snap([
-        _season(
-            season="2025",
-            rosters=rosters,
-            txs_by_week={1: [_waiver_tx(bid=15, adds={"PX": 1})]},
-        ),
-        _season(
-            season="2026",
-            rosters=rosters,
-            txs_by_week={1: [_waiver_tx(bid=22, adds={"PX": 1})]},
-        ),
-    ])
+    snap = _snap(
+        [
+            _season(
+                season="2025",
+                rosters=rosters,
+                txs_by_week={1: [_waiver_tx(bid=15, adds={"PX": 1})]},
+            ),
+            _season(
+                season="2026",
+                rosters=rosters,
+                txs_by_week={1: [_waiver_tx(bid=22, adds={"PX": 1})]},
+            ),
+        ]
+    )
     out = faab_analytics.summarize_league_faab(snap)
     history = out["playerHistory"]["PX"]
     assert len(history) == 2
@@ -278,15 +300,18 @@ def test_player_history_records_each_add():
 def test_recent_wins_skip_zero_bid_pickups():
     """Recent-wins timeline excludes free-agent pickups so the UI
     only surfaces actual bidding activity."""
-    snap = _snap([
-        _season(txs_by_week={
-            1: [
-                _waiver_tx(bid=15, adds={"WR1": 1}, created=1000),
-                _waiver_tx(bid=0, adds={"P0": 1}, type_="free_agent",
-                           created=2000),
-                _waiver_tx(bid=10, adds={"WR2": 1}, created=3000),
-            ],
-        })],
+    snap = _snap(
+        [
+            _season(
+                txs_by_week={
+                    1: [
+                        _waiver_tx(bid=15, adds={"WR1": 1}, created=1000),
+                        _waiver_tx(bid=0, adds={"P0": 1}, type_="free_agent", created=2000),
+                        _waiver_tx(bid=10, adds={"WR2": 1}, created=3000),
+                    ],
+                }
+            )
+        ],
     )
     out = faab_analytics.summarize_league_faab(snap)
     bids = [w["bid"] for w in out["recentWins"]]
@@ -302,6 +327,7 @@ def test_recent_wins_skip_zero_bid_pickups():
 
 def test_section_registered_in_public_contract():
     from src.public_league.public_contract import PUBLIC_SECTION_KEYS
+
     assert "faabAnalytics" in PUBLIC_SECTION_KEYS
 
 

--- a/tests/api/test_fantasypros_idp_integration.py
+++ b/tests/api/test_fantasypros_idp_integration.py
@@ -4,6 +4,7 @@ These tests pin down the contract-level wiring for the 6th ranking
 source so a future refactor cannot silently drop FP from the blend
 and cannot break the combined-authority + anchored-extension rules.
 """
+
 from __future__ import annotations
 
 import csv
@@ -70,9 +71,7 @@ class TestFantasyProsIdpRegistry(unittest.TestCase):
         self.assertIn("fantasyProsIdp", keys)
 
     def test_source_scope_is_overall_idp(self):
-        src = next(
-            (s for s in _RANKING_SOURCES if s["key"] == "fantasyProsIdp"), None
-        )
+        src = next((s for s in _RANKING_SOURCES if s["key"] == "fantasyProsIdp"), None)
         self.assertIsNotNone(src)
         self.assertEqual(src["scope"], SOURCE_SCOPE_OVERALL_IDP)
 
@@ -90,9 +89,7 @@ class TestFantasyProsIdpRegistry(unittest.TestCase):
     def test_csv_path_registered_as_rank_signal(self):
         cfg = _SOURCE_CSV_PATHS.get("fantasyProsIdp")
         self.assertIsInstance(cfg, dict)
-        self.assertTrue(
-            str(cfg.get("path", "")).endswith("fantasyProsIdp.csv")
-        )
+        self.assertTrue(str(cfg.get("path", "")).endswith("fantasyProsIdp.csv"))
         self.assertEqual(cfg.get("signal"), "rank")
 
     def test_needs_shared_market_translation(self):
@@ -132,9 +129,7 @@ class TestFantasyProsIdpCsvShape(unittest.TestCase):
         rows = _fp_csv_rows()
         self.assertTrue(rows)
         methods = {r["derivationMethod"] for r in rows}
-        self.assertTrue(
-            methods.issubset({"direct_combined", "anchored_from_individual"})
-        )
+        self.assertTrue(methods.issubset({"direct_combined", "anchored_from_individual"}))
 
     # ── 1. Combined board players use direct rank ─────────────────
     def test_combined_board_players_use_direct_rank(self):
@@ -192,9 +187,9 @@ class TestFantasyProsIdpCsvShape(unittest.TestCase):
         rows = _fp_csv_rows()
         self.assertTrue(rows)
         ext = [
-            r for r in rows
-            if r["derivationMethod"] == "anchored_from_individual"
-            and r["family"] == family
+            r
+            for r in rows
+            if r["derivationMethod"] == "anchored_from_individual" and r["family"] == family
         ]
         # Sort by individual rank (originalRank), then assert
         # effectiveRank is strictly monotone increasing.
@@ -226,12 +221,8 @@ class TestFantasyProsIdpCsvShape(unittest.TestCase):
         """
         rows = _fp_csv_rows()
         self.assertTrue(rows)
-        direct_names = {
-            r["name"] for r in rows if r["derivationMethod"] == "direct_combined"
-        }
-        ext_names = {
-            r["name"] for r in rows if r["derivationMethod"] == "anchored_from_individual"
-        }
+        direct_names = {r["name"] for r in rows if r["derivationMethod"] == "direct_combined"}
+        ext_names = {r["name"] for r in rows if r["derivationMethod"] == "anchored_from_individual"}
         self.assertFalse(
             direct_names & ext_names,
             "Same player appears as both direct_combined and anchored_from_individual",
@@ -263,9 +254,9 @@ class TestFantasyProsIdpCsvShape(unittest.TestCase):
         for fam in ("DL", "LB", "DB"):
             ext = sorted(
                 (
-                    r for r in rows
-                    if r["derivationMethod"] == "anchored_from_individual"
-                    and r["family"] == fam
+                    r
+                    for r in rows
+                    if r["derivationMethod"] == "anchored_from_individual" and r["family"] == fam
                 ),
                 key=lambda r: int(r["originalRank"]),
             )
@@ -320,10 +311,7 @@ class TestFantasyProsIdpEnrichment(unittest.TestCase):
         if self.contract is None:
             self.skipTest("FP CSV missing")
         pa = self.contract.get("playersArray", [])
-        enriched = [
-            p for p in pa
-            if (p.get("canonicalSiteValues") or {}).get("fantasyProsIdp")
-        ]
+        enriched = [p for p in pa if (p.get("canonicalSiteValues") or {}).get("fantasyProsIdp")]
         self.assertGreaterEqual(len(enriched), 80)
 
     # ── 8. Source metadata present in payload ──────────────────
@@ -332,11 +320,11 @@ class TestFantasyProsIdpEnrichment(unittest.TestCase):
             self.skipTest("FP CSV missing")
         pa = self.contract.get("playersArray", [])
         have_meta = [
-            p for p in pa
+            p
+            for p in pa
             if p.get("fantasyProsIdpEffectiveRank") is not None
-            and p.get("fantasyProsIdpDerivationMethod") in (
-                "direct_combined", "anchored_from_individual"
-            )
+            and p.get("fantasyProsIdpDerivationMethod")
+            in ("direct_combined", "anchored_from_individual")
             and p.get("fantasyProsIdpFamily") in ("DL", "LB", "DB")
         ]
         self.assertGreaterEqual(
@@ -350,10 +338,7 @@ class TestFantasyProsIdpEnrichment(unittest.TestCase):
         if self.contract is None:
             self.skipTest("FP CSV missing")
         pa = self.contract.get("playersArray", [])
-        by_name = {
-            p.get("displayName") or p.get("canonicalName") or "": p
-            for p in pa
-        }
+        by_name = {p.get("displayName") or p.get("canonicalName") or "": p for p in pa}
         for r in self.fp_rows:
             if r["derivationMethod"] != "direct_combined":
                 continue
@@ -401,9 +386,7 @@ class TestFantasyProsIdpLivePayload(unittest.TestCase):
         live = _load_live_api()
         if live is None:
             self.skipTest("No live API fixture present")
-        ts = (
-            (live.get("dataFreshness") or {}).get("sourceTimestamps") or {}
-        )
+        ts = (live.get("dataFreshness") or {}).get("sourceTimestamps") or {}
         self.assertIn("fantasyProsIdp", ts)
 
     def test_fp_metadata_on_live_players(self):
@@ -411,10 +394,7 @@ class TestFantasyProsIdpLivePayload(unittest.TestCase):
         if live is None:
             self.skipTest("No live API fixture present")
         pa = live.get("playersArray") or []
-        have = [
-            p for p in pa
-            if p.get("fantasyProsIdpEffectiveRank") is not None
-        ]
+        have = [p for p in pa if p.get("fantasyProsIdpEffectiveRank") is not None]
         self.assertGreaterEqual(len(have), 80)
 
 

--- a/tests/api/test_feature_flags.py
+++ b/tests/api/test_feature_flags.py
@@ -5,6 +5,7 @@ These pin the two core guarantees:
 1. Every flag has an explicit default.  Unknown flag reads raise.
 2. Env-var override works, and reload() picks up mid-run changes.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -32,26 +33,24 @@ def test_every_flag_defaults_off_except_safe_additive():
     # _DEFAULTS explaining why it's safe + how to flip it off via
     # RISKIT_FEATURE_<NAME>=0 if needed.
     safe_on = {
-        "unified_id_mapper",           # no behavior change, read API only
-        "nfl_data_ingest",             # guarded import; empty [] if missing
-        "realized_points_api",         # endpoint-only, inert until called
+        "unified_id_mapper",  # no behavior change, read API only
+        "nfl_data_ingest",  # guarded import; empty [] if missing
+        "realized_points_api",  # endpoint-only, inert until called
         "value_confidence_intervals",  # additive valueBand field
-        "positional_tiers",            # additive tierId field
-        "usage_signals",               # freshness + starter-guarded
-        "espn_injury_feed",            # circuit-breaker protected
-        "depth_chart_validation",      # circuit-breaker protected
-        "monte_carlo_trade",           # new endpoint, old unchanged
+        "positional_tiers",  # additive tierId field
+        "usage_signals",  # freshness + starter-guarded
+        "espn_injury_feed",  # circuit-breaker protected
+        "depth_chart_validation",  # circuit-breaker protected
+        "monte_carlo_trade",  # new endpoint, old unchanged
     }
     off_only = {
-        "dynamic_source_weights",      # held OFF until backtest data exists
+        "dynamic_source_weights",  # held OFF until backtest data exists
     }
     for name, value in flags.items():
         if name in safe_on:
             continue
         if name in off_only:
-            assert value is False, (
-                f"flag {name!r} expected OFF but is ON"
-            )
+            assert value is False, f"flag {name!r} expected OFF but is ON"
             continue
         assert value is False, (
             f"flag {name!r} defaults ON but hasn't been vetted as "

--- a/tests/api/test_footballguys_source.py
+++ b/tests/api/test_footballguys_source.py
@@ -9,6 +9,7 @@ Verifies:
     * The live export carries enriched ``canonicalSiteValues`` for
       players in both sub-boards.
 """
+
 from __future__ import annotations
 
 import csv
@@ -55,7 +56,8 @@ class TestCsvExports(unittest.TestCase):
         # With IDP rows removed from this CSV, the max rank is larger
         # than len(rows) (missing slots = IDPs in the sibling CSV).
         self.assertGreater(
-            max(ranks), len(rows),
+            max(ranks),
+            len(rows),
             "SF CSV max rank should exceed row count — IDP slots live "
             "in footballGuysIdp.csv and their ranks are skipped here.",
         )
@@ -74,7 +76,8 @@ class TestCsvExports(unittest.TestCase):
         # players occupy the very top of the combined ordering, so the
         # first IDP sits somewhere in the teens-to-twenties range.
         self.assertGreater(
-            ranks[0], 1,
+            ranks[0],
+            1,
             "first IDP rank should be > 1 (offense occupies the top of "
             "FBG's combined cross-market ordering).",
         )
@@ -97,10 +100,13 @@ class TestCsvExports(unittest.TestCase):
         # carries position="IDP" now.  The enrichment path resolves
         # the real DL/LB/DB family via the sleeper positions map.
         allowed_idp = {"DE", "DT", "LB", "CB", "S", "IDP"}
-        self.assertTrue(sf_families <= {"QB", "RB", "WR", "TE"},
-                        f"Non-offense families in SF: {sf_families - {'QB','RB','WR','TE'}}")
-        self.assertTrue(idp_families <= allowed_idp,
-                        f"Non-IDP families in IDP: {idp_families - allowed_idp}")
+        self.assertTrue(
+            sf_families <= {"QB", "RB", "WR", "TE"},
+            f"Non-offense families in SF: {sf_families - {'QB','RB','WR','TE'}}",
+        )
+        self.assertTrue(
+            idp_families <= allowed_idp, f"Non-IDP families in IDP: {idp_families - allowed_idp}"
+        )
 
 
 class TestRegistryWiring(unittest.TestCase):
@@ -173,19 +179,23 @@ class TestLiveEnrichment(unittest.TestCase):
             self.skipTest("No live data")
         pa = self.contract.get("playersArray") or []
         count = sum(
-            1 for r in pa
+            1
+            for r in pa
             if isinstance((r.get("canonicalSiteValues") or {}).get("footballGuysSf"), (int, float))
             and (r.get("canonicalSiteValues") or {}).get("footballGuysSf") > 0
         )
         # Expect >= 400 matched rows (raw CSV is ~548, match rate ~85%).
-        self.assertGreater(count, 400, f"Only {count} SF matches — likely a name-normalization regression")
+        self.assertGreater(
+            count, 400, f"Only {count} SF matches — likely a name-normalization regression"
+        )
 
     def test_idp_source_matches_are_plausible(self) -> None:
         if self.contract is None:
             self.skipTest("No live data")
         pa = self.contract.get("playersArray") or []
         count = sum(
-            1 for r in pa
+            1
+            for r in pa
             if isinstance((r.get("canonicalSiteValues") or {}).get("footballGuysIdp"), (int, float))
             and (r.get("canonicalSiteValues") or {}).get("footballGuysIdp") > 0
         )
@@ -197,7 +207,9 @@ class TestLiveEnrichment(unittest.TestCase):
         # the high 240s.  The elite-stamp canary
         # (test_source_ranks_stamped_for_elite_players) is the real
         # name-normalization sentinel.
-        self.assertGreater(count, 220, f"Only {count} IDP matches — likely a name-normalization regression")
+        self.assertGreater(
+            count, 220, f"Only {count} IDP matches — likely a name-normalization regression"
+        )
 
     def test_source_ranks_stamped_for_elite_players(self) -> None:
         if self.contract is None:

--- a/tests/api/test_frontend_migration.py
+++ b/tests/api/test_frontend_migration.py
@@ -128,12 +128,17 @@ class TestIdpRankings(unittest.TestCase):
     def test_idp_players_get_ranked(self):
         """IDP players with IDP source values must receive idpRank and canonicalConsensusRank."""
         import sys
+
         sys.path.insert(0, str(REPO_ROOT))
         from src.api.data_contract import build_api_data_contract
 
         payload = {
             "players": {
-                "Test QB": {"_composite": 9000, "_canonicalSiteValues": {"ktcSfTep": 9000}, "position": "QB"},
+                "Test QB": {
+                    "_composite": 9000,
+                    "_canonicalSiteValues": {"ktcSfTep": 9000},
+                    "position": "QB",
+                },
                 "Test DL": {"_composite": 6000, "_canonicalSiteValues": {"idpTradeCalc": 5800}},
                 "Test LB": {"_composite": 5000, "_canonicalSiteValues": {"idpTradeCalc": 4000}},
             },
@@ -151,7 +156,13 @@ class TestIdpRankings(unittest.TestCase):
         self.assertEqual(dl["idpRank"], 1)
         self.assertEqual(lb["idpRank"], 2)
         # Unified board: all three get canonicalConsensusRank (1, 2, or 3)
-        ranks = sorted([qb["canonicalConsensusRank"], dl["canonicalConsensusRank"], lb["canonicalConsensusRank"]])
+        ranks = sorted(
+            [
+                qb["canonicalConsensusRank"],
+                dl["canonicalConsensusRank"],
+                lb["canonicalConsensusRank"],
+            ]
+        )
         self.assertEqual(ranks, [1, 2, 3])
         # IDP players have rankDerivedValue
         self.assertGreater(dl["rankDerivedValue"], 0)

--- a/tests/api/test_guest_passes.py
+++ b/tests/api/test_guest_passes.py
@@ -3,6 +3,7 @@
 Covers create / validate / revoke / list / purge + duration bounds
 and storage-format invariants (token hash, never plaintext).
 """
+
 from __future__ import annotations
 
 import time
@@ -24,7 +25,9 @@ def db_path(tmp_path: Path) -> Path:
 
 def test_create_returns_pass_and_plaintext_token(db_path: Path):
     pass_row, token = guest_passes.create(
-        duration_hours=1.0, note="Brent (12h)", created_by="admin",
+        duration_hours=1.0,
+        note="Brent (12h)",
+        created_by="admin",
         db_path=db_path,
     )
     assert pass_row.id > 0
@@ -56,7 +59,9 @@ def test_create_rejects_excessive_duration(db_path: Path):
 def test_create_truncates_long_note(db_path: Path):
     long_note = "x" * 1000
     pass_row, _ = guest_passes.create(
-        duration_hours=1.0, note=long_note, db_path=db_path,
+        duration_hours=1.0,
+        note=long_note,
+        db_path=db_path,
     )
     assert len(pass_row.note) <= 200
 
@@ -66,12 +71,11 @@ def test_token_is_not_stored_in_plaintext(db_path: Path, tmp_path: Path):
     token, NOT the plaintext.  Anyone reading the DB file should not
     be able to recover valid tokens."""
     _pass, token = guest_passes.create(
-        duration_hours=1.0, db_path=db_path,
+        duration_hours=1.0,
+        db_path=db_path,
     )
     raw = db_path.read_bytes()
-    assert token.encode("utf-8") not in raw, (
-        "plaintext token leaked into SQLite file!"
-    )
+    assert token.encode("utf-8") not in raw, "plaintext token leaked into SQLite file!"
     # Hash IS present.
     expected_hash = guest_passes._hash_token(token)
     assert expected_hash.encode("utf-8") in raw
@@ -82,7 +86,8 @@ def test_token_is_not_stored_in_plaintext(db_path: Path, tmp_path: Path):
 
 def test_validate_returns_pass_for_fresh_token(db_path: Path):
     created, token = guest_passes.create(
-        duration_hours=1.0, db_path=db_path,
+        duration_hours=1.0,
+        db_path=db_path,
     )
     found = guest_passes.validate(token, db_path=db_path)
     assert found is not None
@@ -104,19 +109,23 @@ def test_validate_rejects_expired_token(db_path: Path, monkeypatch):
     """Time-skip the system clock past the pass's expiry; validate
     must refuse the token even though it's still in the DB."""
     _pass, token = guest_passes.create(
-        duration_hours=1.0, db_path=db_path,
+        duration_hours=1.0,
+        db_path=db_path,
     )
     # Advance time past expiry.
     real_time = time.time
     monkeypatch.setattr(
-        guest_passes.time, "time", lambda: real_time() + 3600 + 1,
+        guest_passes.time,
+        "time",
+        lambda: real_time() + 3600 + 1,
     )
     assert guest_passes.validate(token, db_path=db_path) is None
 
 
 def test_validate_rejects_revoked_token(db_path: Path):
     pass_row, token = guest_passes.create(
-        duration_hours=1.0, db_path=db_path,
+        duration_hours=1.0,
+        db_path=db_path,
     )
     revoked = guest_passes.revoke(pass_row.id, db_path=db_path)
     assert revoked is True
@@ -128,7 +137,8 @@ def test_validate_rejects_revoked_token(db_path: Path):
 
 def test_revoke_returns_false_when_already_revoked(db_path: Path):
     pass_row, _ = guest_passes.create(
-        duration_hours=1.0, db_path=db_path,
+        duration_hours=1.0,
+        db_path=db_path,
     )
     assert guest_passes.revoke(pass_row.id, db_path=db_path) is True
     # Second revoke is a no-op.
@@ -154,30 +164,38 @@ def test_list_passes_returns_all_by_default(db_path: Path):
 
 
 def test_list_passes_active_only_excludes_revoked_and_expired(
-    db_path: Path, monkeypatch,
+    db_path: Path,
+    monkeypatch,
 ):
     p1, _ = guest_passes.create(
-        duration_hours=1.0, note="active", db_path=db_path,
+        duration_hours=1.0,
+        note="active",
+        db_path=db_path,
     )
     p2, _ = guest_passes.create(
-        duration_hours=1.0, note="revoked", db_path=db_path,
+        duration_hours=1.0,
+        note="revoked",
+        db_path=db_path,
     )
     guest_passes.revoke(p2.id, db_path=db_path)
     p3, _ = guest_passes.create(
-        duration_hours=0.02, note="expired", db_path=db_path,  # ~72s
+        duration_hours=0.02,
+        note="expired",
+        db_path=db_path,  # ~72s
     )
     # Expire p3 explicitly with a time skip well past 72s.
     real_time = time.time
     monkeypatch.setattr(
-        guest_passes.time, "time", lambda: real_time() + 600,
+        guest_passes.time,
+        "time",
+        lambda: real_time() + 600,
     )
     rows = guest_passes.list_passes(
-        include_inactive=False, db_path=db_path,
+        include_inactive=False,
+        db_path=db_path,
     )
     active_ids = {r.id for r in rows}
-    assert active_ids == {p1.id}, (
-        "active-only filter must drop revoked + expired"
-    )
+    assert active_ids == {p1.id}, "active-only filter must drop revoked + expired"
 
 
 # ── Purge ─────────────────────────────────────────────────────────────
@@ -185,18 +203,22 @@ def test_list_passes_active_only_excludes_revoked_and_expired(
 
 def test_purge_expired_keeps_grace_window(db_path: Path, monkeypatch):
     _pass, _ = guest_passes.create(
-        duration_hours=0.02, db_path=db_path,  # ~72s
+        duration_hours=0.02,
+        db_path=db_path,  # ~72s
     )
     # Advance past expiry but within the default 7-day grace.
     real_time = time.time
     monkeypatch.setattr(
-        guest_passes.time, "time", lambda: real_time() + 3600,
+        guest_passes.time,
+        "time",
+        lambda: real_time() + 3600,
     )
     deleted = guest_passes.purge_expired(db_path=db_path)
     assert deleted == 0  # still within grace
     # Now fast-forward beyond the grace + lower it artificially.
     deleted = guest_passes.purge_expired(
-        grace_seconds=0, db_path=db_path,
+        grace_seconds=0,
+        db_path=db_path,
     )
     assert deleted == 1
 
@@ -206,7 +228,8 @@ def test_purge_expired_keeps_grace_window(db_path: Path, monkeypatch):
 
 def test_to_dict_omits_token_hash(db_path: Path):
     pass_row, _ = guest_passes.create(
-        duration_hours=1.0, db_path=db_path,
+        duration_hours=1.0,
+        db_path=db_path,
     )
     d = pass_row.to_dict()
     # Must not leak the hash either — admin UI doesn't need it.
@@ -214,7 +237,14 @@ def test_to_dict_omits_token_hash(db_path: Path):
     assert "tokenHash" not in d
     # Required public fields.
     for key in (
-        "id", "note", "createdBy", "createdAtEpoch", "expiresAtEpoch",
-        "revokedAtEpoch", "isRevoked", "isExpired", "isActive",
+        "id",
+        "note",
+        "createdBy",
+        "createdAtEpoch",
+        "expiresAtEpoch",
+        "revokedAtEpoch",
+        "isRevoked",
+        "isExpired",
+        "isActive",
     ):
         assert key in d

--- a/tests/api/test_hampel_filter.py
+++ b/tests/api/test_hampel_filter.py
@@ -9,6 +9,7 @@ short-circuit, and the >=2-survivor safety guard so a future refactor
 can't silently widen / narrow the rule or strip a player down to a
 single source.
 """
+
 from __future__ import annotations
 
 from src.api.data_contract import (
@@ -137,8 +138,8 @@ class TestOutlierRejection:
             ("c", 5050.0),
             ("d", 4950.0),
             ("e", 5025.0),
-            ("f", 50.0),     # low outlier
-            ("g", 9900.0),   # high outlier
+            ("f", 50.0),  # low outlier
+            ("g", 9900.0),  # high outlier
         ]
         kept, dropped = _hampel_filter_per_player(pairs)
         assert set(dropped) == {"f", "g"}

--- a/tests/api/test_identity_validation.py
+++ b/tests/api/test_identity_validation.py
@@ -11,6 +11,7 @@ Covers:
   - Identity confidence scoring
   - Validation summary in contract payload
 """
+
 from __future__ import annotations
 
 import unittest
@@ -25,8 +26,8 @@ from src.api.data_contract import (
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-def _make_player(name, position, *, ktc=None, idp=None, team="TST",
-                 sleeper_id=None):
+
+def _make_player(name, position, *, ktc=None, idp=None, team="TST", sleeper_id=None):
     """Build a minimal raw player dict for contract builder tests."""
     sites = {}
     if ktc is not None:
@@ -75,6 +76,7 @@ def _build_and_find(payload, player_name):
 
 # ── Offense-to-IDP contamination ────────────────────────────────────────────
 
+
 class TestOffenseToIdpContamination(unittest.TestCase):
     """An offense-position player with only IDP source values should be flagged."""
 
@@ -102,6 +104,7 @@ class TestOffenseToIdpContamination(unittest.TestCase):
 
 # ── IDP-to-offense contamination ────────────────────────────────────────────
 
+
 class TestIdpToOffenseContamination(unittest.TestCase):
     """An IDP-position player with only offense source values should be flagged."""
 
@@ -126,6 +129,7 @@ class TestIdpToOffenseContamination(unittest.TestCase):
 
 
 # ── Cross-universe name collisions ──────────────────────────────────────────
+
 
 class TestCrossUniverseCollision(unittest.TestCase):
     """Same name appearing in both offense and IDP should be flagged."""
@@ -239,6 +243,7 @@ class TestCrossUniverseCollision(unittest.TestCase):
 # behavior so the noise can never come back without a deliberate
 # code change.
 
+
 class TestNearNameMismatch(unittest.TestCase):
     """The legacy ``near_name_value_mismatch`` flag is permanently disabled.
 
@@ -314,8 +319,8 @@ class TestNearNameMismatch(unittest.TestCase):
 
 # ── Unsupported position ────────────────────────────────────────────────────
 
-class TestUnsupportedPosition(unittest.TestCase):
 
+class TestUnsupportedPosition(unittest.TestCase):
     def test_ol_position_flagged_as_unsupported(self):
         rows = [
             {
@@ -352,14 +357,17 @@ class TestUnsupportedPosition(unittest.TestCase):
                 },
             ]
             _validate_and_quarantine_rows(rows)
-            self.assertNotIn("unsupported_position", rows[0]["anomalyFlags"],
-                             f"{pos} should not be flagged as unsupported")
+            self.assertNotIn(
+                "unsupported_position",
+                rows[0]["anomalyFlags"],
+                f"{pos} should not be flagged as unsupported",
+            )
 
 
 # ── Quarantine degradation ──────────────────────────────────────────────────
 
-class TestQuarantineDegradation(unittest.TestCase):
 
+class TestQuarantineDegradation(unittest.TestCase):
     def test_high_confidence_degraded_when_quarantined(self):
         rows = [
             {
@@ -419,8 +427,8 @@ class TestQuarantineDegradation(unittest.TestCase):
 
 # ── Identity confidence ─────────────────────────────────────────────────────
 
-class TestIdentityConfidence(unittest.TestCase):
 
+class TestIdentityConfidence(unittest.TestCase):
     def test_canonical_id_gives_1_0(self):
         row = {
             "playerId": "SLEEPER123",
@@ -469,8 +477,8 @@ class TestIdentityConfidence(unittest.TestCase):
 
 # ── Contract-level validation summary ───────────────────────────────────────
 
-class TestValidationSummaryInContract(unittest.TestCase):
 
+class TestValidationSummaryInContract(unittest.TestCase):
     def test_validation_summary_present_in_contract(self):
         payload = _payload_with_players(
             _make_player("Zzz Test QB Only", "QB", ktc=8000),
@@ -497,6 +505,7 @@ class TestValidationSummaryInContract(unittest.TestCase):
 
 # ── Single-source false positives ───────────────────────────────────────────
 
+
 class TestSingleSourceFalsePositive(unittest.TestCase):
     """A player with only one source should be flagged as low confidence
     but not quarantined unless there's an additional identity issue."""
@@ -514,8 +523,8 @@ class TestSingleSourceFalsePositive(unittest.TestCase):
 
 # ── Normalize for collision ─────────────────────────────────────────────────
 
-class TestNormalizeForCollision(unittest.TestCase):
 
+class TestNormalizeForCollision(unittest.TestCase):
     def test_basic_normalization(self):
         self.assertEqual(
             _normalize_for_collision("Jameson Williams"),
@@ -530,6 +539,7 @@ class TestNormalizeForCollision(unittest.TestCase):
 
 
 # ── Exception-set gap: IDP with only offense source ───────────────────────
+
 
 class TestExceptionSetCoverage(unittest.TestCase):
     """IDP players with only offense source data should be quarantined unless
@@ -555,6 +565,7 @@ class TestExceptionSetCoverage(unittest.TestCase):
         collisions only, not a blanket suppression of evidence errors.
         """
         from src.api.data_contract import OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
+
         if not OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS:
             self.skipTest("Exception set is empty")
         exc_name = next(iter(sorted(OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS)))
@@ -607,6 +618,7 @@ class TestExceptionSetCoverage(unittest.TestCase):
         data-quality error and must be quarantined.
         """
         from src.api.data_contract import OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS
+
         if not OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS:
             self.skipTest("Exception set is empty")
         exc_name = next(iter(sorted(OFFENSE_TO_IDP_VALIDATION_EXCEPTIONS)))
@@ -631,8 +643,8 @@ class TestExceptionSetCoverage(unittest.TestCase):
 
 # ── Age field scaffolding ──────────────────────────────────────────────────
 
-class TestAgeFieldScaffolding(unittest.TestCase):
 
+class TestAgeFieldScaffolding(unittest.TestCase):
     def test_age_null_when_not_provided(self):
         payload = _payload_with_players(
             _make_player("Zzz No Age Player", "QB", ktc=8000),
@@ -653,6 +665,7 @@ class TestAgeFieldScaffolding(unittest.TestCase):
 
 
 # ── Name collision guardrail: sleeper map tagging conflicts source signals ──
+
 
 class TestSleeperMapCollisionGuardrail(unittest.TestCase):
     """When the sleeper positions map is contaminated by a name collision

--- a/tests/api/test_injury_impact.py
+++ b/tests/api/test_injury_impact.py
@@ -1,4 +1,5 @@
 """Tests for ``src.api.injury_impact``."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone, timedelta
@@ -8,8 +9,12 @@ import pytest
 from src.api import injury_impact
 
 
-def _news(severity: str, hours_ago: float = 1.0, impact: str | None = "negative",
-           headline: str = "Test injury headline") -> dict:
+def _news(
+    severity: str,
+    hours_ago: float = 1.0,
+    impact: str | None = "negative",
+    headline: str = "Test injury headline",
+) -> dict:
     ts = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
     players = [{"name": "Test Player", "impact": impact}] if impact else []
     return {
@@ -32,9 +37,9 @@ def _offseason_ms() -> int:
     return int(datetime(2026, 5, 15, tzinfo=timezone.utc).timestamp() * 1000)
 
 
-def _season_news(severity: str, hours_ago: float = 1.0,
-                  impact: str | None = "negative",
-                  headline: str = "Test") -> dict:
+def _season_news(
+    severity: str, hours_ago: float = 1.0, impact: str | None = "negative", headline: str = "Test"
+) -> dict:
     """A news item whose ``ts`` is just before the in-season now_ms
     used by tests — so decay math lines up even with the fixed
     October reference time."""
@@ -51,8 +56,11 @@ def _season_news(severity: str, hours_ago: float = 1.0,
 
 def test_no_news_returns_zero_discount():
     r = injury_impact.compute_injury_discount(
-        pos="RB", age=24, is_rookie=False,
-        news_for_player=[], now_ms=_season_ms(),
+        pos="RB",
+        age=24,
+        is_rookie=False,
+        news_for_player=[],
+        now_ms=_season_ms(),
     )
     assert r["appliedDiscountPct"] == 0.0
     assert r["adjustedPct"] == 100.0
@@ -61,7 +69,9 @@ def test_no_news_returns_zero_discount():
 
 def test_alert_on_rb_mid_age_modest_discount():
     r = injury_impact.compute_injury_discount(
-        pos="RB", age=27, is_rookie=False,
+        pos="RB",
+        age=27,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=1)],
         now_ms=_season_ms(),
     )
@@ -73,7 +83,9 @@ def test_alert_on_rb_mid_age_modest_discount():
 
 def test_alert_on_qb_smaller_discount():
     r = injury_impact.compute_injury_discount(
-        pos="QB", age=30, is_rookie=False,
+        pos="QB",
+        age=30,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=1)],
         now_ms=_season_ms(),
     )
@@ -85,7 +97,9 @@ def test_discount_capped_at_five_percent():
     # Aggressive multipliers — old vet RB with severe injury — should
     # cap at 5% for the dynasty context.
     r = injury_impact.compute_injury_discount(
-        pos="RB", age=35, is_rookie=False,
+        pos="RB",
+        age=35,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=1)],
         now_ms=_season_ms(),
     )
@@ -94,12 +108,16 @@ def test_discount_capped_at_five_percent():
 
 def test_aging_rb_gets_heavier_discount():
     young = injury_impact.compute_injury_discount(
-        pos="RB", age=22, is_rookie=False,
+        pos="RB",
+        age=22,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=1)],
         now_ms=_season_ms(),
     )
     old = injury_impact.compute_injury_discount(
-        pos="RB", age=33, is_rookie=False,
+        pos="RB",
+        age=33,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=1)],
         now_ms=_season_ms(),
     )
@@ -110,12 +128,16 @@ def test_aging_rb_gets_heavier_discount():
 def test_decay_half_at_fifteen_days():
     now = _season_ms()
     r_fresh = injury_impact.compute_injury_discount(
-        pos="RB", age=27, is_rookie=False,
+        pos="RB",
+        age=27,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=1)],
         now_ms=now,
     )
     r_old = injury_impact.compute_injury_discount(
-        pos="RB", age=27, is_rookie=False,
+        pos="RB",
+        age=27,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=15 * 24)],
         now_ms=now,
     )
@@ -127,7 +149,9 @@ def test_decay_half_at_fifteen_days():
 def test_decay_zero_at_thirty_days():
     now = _season_ms()
     r = injury_impact.compute_injury_discount(
-        pos="RB", age=27, is_rookie=False,
+        pos="RB",
+        age=27,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=31 * 24)],
         now_ms=now,
     )
@@ -137,7 +161,9 @@ def test_decay_zero_at_thirty_days():
 
 def test_positive_impact_news_does_not_fire():
     r = injury_impact.compute_injury_discount(
-        pos="RB", age=27, is_rookie=False,
+        pos="RB",
+        age=27,
+        is_rookie=False,
         news_for_player=[_season_news("alert", hours_ago=1, impact="positive")],
         now_ms=_season_ms(),
     )
@@ -152,7 +178,9 @@ def test_worst_case_across_multiple_items():
         _season_news("watch", hours_ago=2, headline="Hamstring"),
     ]
     r = injury_impact.compute_injury_discount(
-        pos="RB", age=27, is_rookie=False,
+        pos="RB",
+        age=27,
+        is_rookie=False,
         news_for_player=items,
         now_ms=_season_ms(),
     )
@@ -182,7 +210,9 @@ def test_apply_injury_impact_produces_adjusted_value():
 def test_apply_injury_impact_no_news_leaves_value_untouched():
     row = {"pos": "RB", "age": 27, "rookie": False, "rankDerivedValue": 5000}
     r = injury_impact.apply_injury_impact(
-        row=row, news_for_player=[], now_ms=_season_ms(),
+        row=row,
+        news_for_player=[],
+        now_ms=_season_ms(),
     )
     assert r["appliedDiscountPct"] == 0.0
     assert r["adjustedValue"] == 5000
@@ -193,7 +223,9 @@ def test_apply_injury_impact_no_news_leaves_value_untouched():
 
 def test_offseason_alert_produces_zero_discount():
     r = injury_impact.compute_injury_discount(
-        pos="RB", age=27, is_rookie=False,
+        pos="RB",
+        age=27,
+        is_rookie=False,
         news_for_player=[_news("alert", hours_ago=1)],
         now_ms=_offseason_ms(),  # May → offseason
     )
@@ -205,20 +237,23 @@ def test_offseason_alert_produces_zero_discount():
     assert r["headline"] == "Test injury headline"
 
 
-@pytest.mark.parametrize("month,expected", [
-    (1, False),   # January — playoffs, in-season
-    (2, True),    # February — offseason starts
-    (3, True),
-    (4, True),    # Draft
-    (5, True),    # OTAs
-    (6, True),
-    (7, True),    # Training camp open
-    (8, True),    # Preseason — still classified offseason
-    (9, False),   # Week 1
-    (10, False),
-    (11, False),
-    (12, False),
-])
+@pytest.mark.parametrize(
+    "month,expected",
+    [
+        (1, False),  # January — playoffs, in-season
+        (2, True),  # February — offseason starts
+        (3, True),
+        (4, True),  # Draft
+        (5, True),  # OTAs
+        (6, True),
+        (7, True),  # Training camp open
+        (8, True),  # Preseason — still classified offseason
+        (9, False),  # Week 1
+        (10, False),
+        (11, False),
+        (12, False),
+    ],
+)
 def test_offseason_boundary_by_month(month, expected):
     ts = int(datetime(2026, month, 15, tzinfo=timezone.utc).timestamp() * 1000)
     assert injury_impact._is_nfl_offseason(ts) is expected

--- a/tests/api/test_launch_readiness.py
+++ b/tests/api/test_launch_readiness.py
@@ -9,6 +9,7 @@ Run with: python3 -m pytest tests/api/test_launch_readiness.py -v
 
 Gate failures BLOCK release.  No exceptions.
 """
+
 from __future__ import annotations
 
 import gzip
@@ -57,6 +58,7 @@ def _get():
 
 # ── GATE 1: Identity Integrity ──────────────────────────────────────────
 
+
 class TestGate1IdentityIntegrity(unittest.TestCase):
     """No duplicate names, no quarantine overload, no cross-universe collisions."""
 
@@ -102,13 +104,13 @@ class TestGate1IdentityIntegrity(unittest.TestCase):
             self.skipTest("No live data")
         _, ranked, _ = result
         collisions = sum(
-            1 for r in ranked
-            if "name_collision_cross_universe" in (r.get("anomalyFlags") or [])
+            1 for r in ranked if "name_collision_cross_universe" in (r.get("anomalyFlags") or [])
         )
         self.assertEqual(collisions, 0)
 
 
 # ── GATE 2: Source Coverage ──────────────────────────────────────────────
+
 
 class TestGate2SourceCoverage(unittest.TestCase):
     """Multi-source coverage adequate; all 1-src cases explained."""
@@ -155,12 +157,12 @@ class TestGate2SourceCoverage(unittest.TestCase):
         pa = contract.get("playersArray", [])
         unexplained = assert_no_unexplained_single_source(pa, rank_limit=400)
         self.assertEqual(
-            unexplained, [],
-            f"Unexplained 1-src: {[u['canonicalName'] for u in unexplained]}"
+            unexplained, [], f"Unexplained 1-src: {[u['canonicalName'] for u in unexplained]}"
         )
 
 
 # ── GATE 3: Rank/Value Consistency ──────────────────────────────────────
+
 
 class TestGate3RankValueConsistency(unittest.TestCase):
     """Monotonic ordering, no missing fields, coherence check passes."""
@@ -194,8 +196,8 @@ class TestGate3RankValueConsistency(unittest.TestCase):
 
 # ── GATE 4: Duplicate-Rank Prevention ───────────────────────────────────
 
-class TestGate4DuplicateRankPrevention(unittest.TestCase):
 
+class TestGate4DuplicateRankPrevention(unittest.TestCase):
     def test_no_duplicate_ranks(self):
         result = _get()
         if result is None:
@@ -216,8 +218,8 @@ class TestGate4DuplicateRankPrevention(unittest.TestCase):
 
 # ── GATE 5: Tier/Header Alignment ──────────────────────────────────────
 
-class TestGate5TierAlignment(unittest.TestCase):
 
+class TestGate5TierAlignment(unittest.TestCase):
     def test_all_ranked_have_tier(self):
         result = _get()
         if result is None:
@@ -249,7 +251,8 @@ class TestGate5TierAlignment(unittest.TestCase):
         if ranked:
             top = ranked[0]
             self.assertEqual(
-                top.get("canonicalTierId"), 1,
+                top.get("canonicalTierId"),
+                1,
                 f"Top-ranked row must be in tier 1, got {top.get('canonicalTierId')}",
             )
 
@@ -266,8 +269,8 @@ class TestGate5TierAlignment(unittest.TestCase):
 
 # ── GATE 6: Source Transparency ──────────────────────────────────────────
 
-class TestGate6SourceTransparency(unittest.TestCase):
 
+class TestGate6SourceTransparency(unittest.TestCase):
     def test_all_ranked_have_sourceAudit(self):
         result = _get()
         if result is None:
@@ -294,8 +297,8 @@ class TestGate6SourceTransparency(unittest.TestCase):
 
 # ── GATE 7: IDP Calibration ─────────────────────────────────────────────
 
-class TestGate7IdpCalibration(unittest.TestCase):
 
+class TestGate7IdpCalibration(unittest.TestCase):
     def test_idp_in_top_100(self):
         """At least 5 IDP players in the top 100."""
         result = _get()
@@ -349,7 +352,8 @@ class TestGate7IdpCalibration(unittest.TestCase):
             p = next((r for r in ranked if name in (r.get("canonicalName") or "")), None)
             self.assertIsNotNone(p, f"{name} not found")
             self.assertLessEqual(
-                p["canonicalConsensusRank"], max_rank,
+                p["canonicalConsensusRank"],
+                max_rank,
                 f"{name} ranked #{p['canonicalConsensusRank']} > {max_rank}",
             )
 
@@ -368,17 +372,14 @@ class TestGate7IdpCalibration(unittest.TestCase):
 
 # ── GATE 8: Flag/Quarantine Integrity ────────────────────────────────────
 
-class TestGate8FlagIntegrity(unittest.TestCase):
 
+class TestGate8FlagIntegrity(unittest.TestCase):
     def test_no_impossible_value_flags(self):
         result = _get()
         if result is None:
             self.skipTest("No live data")
         _, ranked, _ = result
-        impossible = sum(
-            1 for r in ranked
-            if "impossible_value" in (r.get("anomalyFlags") or [])
-        )
+        impossible = sum(1 for r in ranked if "impossible_value" in (r.get("anomalyFlags") or []))
         self.assertEqual(impossible, 0)
 
     def test_confidence_distribution_reasonable(self):
@@ -416,8 +417,8 @@ class TestGate8FlagIntegrity(unittest.TestCase):
 
 # ── GATE 9: Live-Page Verification ──────────────────────────────────────
 
-class TestGate9LivePage(unittest.TestCase):
 
+class TestGate9LivePage(unittest.TestCase):
     def test_playersArray_sorted(self):
         result = _get()
         if result is None:
@@ -449,8 +450,8 @@ class TestGate9LivePage(unittest.TestCase):
 
 # ── GATE 10: Performance & Caching ──────────────────────────────────────
 
-class TestGate10Performance(unittest.TestCase):
 
+class TestGate10Performance(unittest.TestCase):
     def test_build_under_5_seconds(self):
         result = _get()
         if result is None:
@@ -468,7 +469,8 @@ class TestGate10Performance(unittest.TestCase):
         compressed = gzip.compress(raw)
         size_kb = len(compressed) / 1024
         self.assertLess(
-            len(compressed), 2 * 1024 * 1024,
+            len(compressed),
+            2 * 1024 * 1024,
             f"Gzipped payload {size_kb:.0f} KB exceeds 2 MB",
         )
 

--- a/tests/api/test_league_articles_endpoints.py
+++ b/tests/api/test_league_articles_endpoints.py
@@ -11,6 +11,7 @@ with a fake client. Here we verify:
     * POST /api/league/articles/generate gates on admin auth and
       returns 503 when ANTHROPIC_API_KEY is missing.
 """
+
 from __future__ import annotations
 
 import json
@@ -52,8 +53,12 @@ def _make_article(season="2025", week=17, matchup_id=1, mode="recap", title="Tit
         "roundLabel": "Championship",
         "home": {"ownerId": "owner-A", "displayName": "AAron", "teamName": "Brisket Bandits"},
         "away": {"ownerId": "owner-B", "displayName": "Bea", "teamName": "Beast Mode"},
-        "usage": {"input_tokens": 100, "output_tokens": 200,
-                  "cache_read_input_tokens": 0, "cache_creation_input_tokens": 100},
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 100,
+        },
     }
 
 
@@ -69,7 +74,9 @@ def test_list_empty_returns_empty_array(article_tmpdir):
 
 
 def test_list_returns_index_after_save(article_tmpdir):
-    mn.save_article(_make_article(matchup_id=1, mode="preview", title="Preview"), base=article_tmpdir)
+    mn.save_article(
+        _make_article(matchup_id=1, mode="preview", title="Preview"), base=article_tmpdir
+    )
     mn.save_article(_make_article(matchup_id=1, mode="recap", title="Recap"), base=article_tmpdir)
     with TestClient(server.app, raise_server_exceptions=True) as c:
         res = c.get("/api/league/articles?season=2025&week=17")
@@ -127,7 +134,9 @@ def test_generate_requires_admin(article_tmpdir, monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "randomuser"})
     monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"jasonleetucker"}),
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
+        frozenset({"jasonleetucker"}),
     )
     with TestClient(server.app, raise_server_exceptions=True) as c:
         res = c.post("/api/league/articles/generate", json={"mode": "preview", "matchupId": 1})
@@ -138,7 +147,9 @@ def test_generate_validates_mode(article_tmpdir, monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "admin"})
     monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"admin"}),
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
+        frozenset({"admin"}),
     )
     with TestClient(server.app, raise_server_exceptions=True) as c:
         res = c.post("/api/league/articles/generate", json={"mode": "nope", "matchupId": 1})
@@ -149,7 +160,9 @@ def test_generate_validates_matchup_id(article_tmpdir, monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "admin"})
     monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"admin"}),
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
+        frozenset({"admin"}),
     )
     with TestClient(server.app, raise_server_exceptions=True) as c:
         res = c.post("/api/league/articles/generate", json={"mode": "preview"})
@@ -171,7 +184,9 @@ def test_generate_collapses_sdk_errors_to_502(article_tmpdir, monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "admin"})
     monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"admin"}),
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
+        frozenset({"admin"}),
     )
     monkeypatch.setenv("SLEEPER_LEAGUE_ID", "test-league-id")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key-for-test")
@@ -193,13 +208,22 @@ def test_generate_collapses_sdk_errors_to_502(article_tmpdir, monkeypatch):
     from src.public_league.snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
     fake_season = SeasonSnapshot(
-        season="2025", league_id="test", league={}, users=[], rosters=[],
-        matchups_by_week={}, transactions_by_week={}, drafts=[],
-        draft_picks_by_draft={}, traded_picks=[], winners_bracket=[],
+        season="2025",
+        league_id="test",
+        league={},
+        users=[],
+        rosters=[],
+        matchups_by_week={},
+        transactions_by_week={},
+        drafts=[],
+        draft_picks_by_draft={},
+        traded_picks=[],
+        winners_bracket=[],
         losers_bracket=[],
     )
     fake_snapshot = PublicLeagueSnapshot(
-        root_league_id="test", generated_at="2025-01-01T00:00:00",
+        root_league_id="test",
+        generated_at="2025-01-01T00:00:00",
         seasons=[fake_season],
     )
     monkeypatch.setattr(
@@ -226,6 +250,7 @@ def test_generate_collapses_sdk_errors_to_502(article_tmpdir, monkeypatch):
 
 class _StubBrief:
     """Minimal brief stub for endpoint tests that bypass build_brief."""
+
     mode = "preview"
     season = "2025"
     week = 17
@@ -249,7 +274,9 @@ def test_generate_returns_503_when_anthropic_unconfigured(article_tmpdir, monkey
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "admin"})
     monkeypatch.setattr(
-        server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"admin"}),
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
+        frozenset({"admin"}),
     )
     # Provision a league via the env-var fallback so the resolver
     # finds something (anything — we never hit the snapshot path).

--- a/tests/api/test_league_registry.py
+++ b/tests/api/test_league_registry.py
@@ -9,6 +9,7 @@ league.  These tests pin down:
 * Roster settings accessor
 * ``LEAGUE_REGISTRY_PATH`` env override resolution
 """
+
 from __future__ import annotations
 
 import json
@@ -145,9 +146,27 @@ def test_active_leagues_excludes_inactive(tmp_path, monkeypatch):
         tmp_path,
         {
             "leagues": [
-                {"key": "a", "displayName": "A", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
-                {"key": "b", "displayName": "B", "sleeperLeagueId": "2", "active": False, "rosterSettings": {}},
-                {"key": "c", "displayName": "C", "sleeperLeagueId": "3", "active": True, "rosterSettings": {}},
+                {
+                    "key": "a",
+                    "displayName": "A",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                },
+                {
+                    "key": "b",
+                    "displayName": "B",
+                    "sleeperLeagueId": "2",
+                    "active": False,
+                    "rosterSettings": {},
+                },
+                {
+                    "key": "c",
+                    "displayName": "C",
+                    "sleeperLeagueId": "3",
+                    "active": True,
+                    "rosterSettings": {},
+                },
             ],
         },
     )
@@ -208,7 +227,13 @@ def test_get_user_default_skips_inactive_team_map_match(tmp_path, monkeypatch):
         {
             "defaultLeagueKey": "main",
             "leagues": [
-                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                },
                 {
                     "key": "disabled",
                     "displayName": "Off",
@@ -319,8 +344,18 @@ def test_duplicate_keys_keep_first(tmp_path, monkeypatch):
         tmp_path,
         {
             "leagues": [
-                {"key": "dup", "displayName": "First", "sleeperLeagueId": "1", "rosterSettings": {}},
-                {"key": "dup", "displayName": "Second", "sleeperLeagueId": "2", "rosterSettings": {}},
+                {
+                    "key": "dup",
+                    "displayName": "First",
+                    "sleeperLeagueId": "1",
+                    "rosterSettings": {},
+                },
+                {
+                    "key": "dup",
+                    "displayName": "Second",
+                    "sleeperLeagueId": "2",
+                    "rosterSettings": {},
+                },
             ],
         },
     )
@@ -395,8 +430,20 @@ def test_put_user_state_accepts_valid_active_league_key(tmp_path, monkeypatch):
         tmp_path,
         {
             "leagues": [
-                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
-                {"key": "backup", "displayName": "Backup", "sleeperLeagueId": "2", "active": True, "rosterSettings": {}},
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                },
+                {
+                    "key": "backup",
+                    "displayName": "Backup",
+                    "sleeperLeagueId": "2",
+                    "active": True,
+                    "rosterSettings": {},
+                },
             ],
         },
     )
@@ -405,12 +452,14 @@ def test_put_user_state_accepts_valid_active_league_key(tmp_path, monkeypatch):
 
     # Route the user_kv DB to a temp file so we don't touch prod data.
     from src.api import user_kv
+
     user_kv_path = tmp_path / "test_user_kv.sqlite"
     monkeypatch.setattr(user_kv, "USER_KV_PATH", user_kv_path)
     user_kv._SETUP_DONE.clear()
     # Stub auth so the endpoint accepts us as 'alice'.
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda request: {"username": "alice", "auth_method": "password"},
     )
 
@@ -432,7 +481,13 @@ def test_put_user_state_drops_unknown_active_league_key(tmp_path, monkeypatch):
         tmp_path,
         {
             "leagues": [
-                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}},
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                },
             ],
         },
     )
@@ -440,11 +495,13 @@ def test_put_user_state_drops_unknown_active_league_key(tmp_path, monkeypatch):
     league_registry.reload_registry()
 
     from src.api import user_kv
+
     user_kv_path = tmp_path / "test_user_kv.sqlite"
     monkeypatch.setattr(user_kv, "USER_KV_PATH", user_kv_path)
     user_kv._SETUP_DONE.clear()
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda request: {"username": "alice", "auth_method": "password"},
     )
 
@@ -467,9 +524,28 @@ def test_put_user_state_accepts_selected_teams_by_league(tmp_path, monkeypatch):
         tmp_path,
         {
             "leagues": [
-                {"key": "main", "displayName": "Main", "sleeperLeagueId": "1", "active": True, "rosterSettings": {}, "aliases": ["primary"]},
-                {"key": "side", "displayName": "Side", "sleeperLeagueId": "2", "active": True, "rosterSettings": {}},
-                {"key": "retired", "displayName": "Off", "sleeperLeagueId": "3", "active": False, "rosterSettings": {}},
+                {
+                    "key": "main",
+                    "displayName": "Main",
+                    "sleeperLeagueId": "1",
+                    "active": True,
+                    "rosterSettings": {},
+                    "aliases": ["primary"],
+                },
+                {
+                    "key": "side",
+                    "displayName": "Side",
+                    "sleeperLeagueId": "2",
+                    "active": True,
+                    "rosterSettings": {},
+                },
+                {
+                    "key": "retired",
+                    "displayName": "Off",
+                    "sleeperLeagueId": "3",
+                    "active": False,
+                    "rosterSettings": {},
+                },
             ],
         },
     )
@@ -477,10 +553,12 @@ def test_put_user_state_accepts_selected_teams_by_league(tmp_path, monkeypatch):
     league_registry.reload_registry()
 
     from src.api import user_kv
+
     monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
     user_kv._SETUP_DONE.clear()
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda request: {"username": "alice", "auth_method": "password"},
     )
 
@@ -545,7 +623,8 @@ def test_api_leagues_includes_user_default_team_when_authed(tmp_path, monkeypatc
 
     # Authed as alice.
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda request: {"username": "alice", "auth_method": "sleeper"},
     )
     with TestClient(server.app, raise_server_exceptions=True) as c:
@@ -590,11 +669,13 @@ def test_put_user_state_canonicalizes_alias(tmp_path, monkeypatch):
     league_registry.reload_registry()
 
     from src.api import user_kv
+
     user_kv_path = tmp_path / "test_user_kv.sqlite"
     monkeypatch.setattr(user_kv, "USER_KV_PATH", user_kv_path)
     user_kv._SETUP_DONE.clear()
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda request: {"username": "alice", "auth_method": "password"},
     )
 

--- a/tests/api/test_league_routing.py
+++ b/tests/api/test_league_routing.py
@@ -17,6 +17,7 @@ test league's key so ``_resolve_league_for_request`` has something
 to match against.  We stub out Sleeper-hitting endpoints where we
 can to keep the tests local.
 """
+
 from __future__ import annotations
 
 import json
@@ -71,6 +72,7 @@ def two_league_registry(tmp_path, monkeypatch):
 
     # Isolate user_kv to a temp file so the PUT paths don't leak.
     from src.api import user_kv
+
     monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
     user_kv._SETUP_DONE.clear()
 
@@ -187,9 +189,7 @@ def test_api_data_rejects_unknown_league(two_league_registry, monkeypatch):
     assert res.json()["error"] == "unknown_league"
 
 
-def test_api_data_returns_200_with_nulled_sleeper_for_legacy_stub(
-    two_league_registry, monkeypatch
-):
+def test_api_data_returns_200_with_nulled_sleeper_for_legacy_stub(two_league_registry, monkeypatch):
     """Legacy test: the stub contract in this fixture doesn't stamp
     ``meta.scoringProfile``, which means the endpoint can't enforce
     profile matching.  In that case the pre-refactor behavior applies
@@ -221,12 +221,22 @@ def test_trade_simulate_accepts_league_key_in_body(two_league_registry, monkeypa
     with TestClient(server.app, raise_server_exceptions=True) as c:
         _install_contract_for_league(monkeypatch, "main")
         monkeypatch.setattr(
-            server, "_get_auth_session",
-            lambda request: {"username": "alice", "auth_method": "sleeper", "sleeper_user_id": "oA"},
+            server,
+            "_get_auth_session",
+            lambda request: {
+                "username": "alice",
+                "auth_method": "sleeper",
+                "sleeper_user_id": "oA",
+            },
         )
         res = c.post(
             "/api/trade/simulate",
-            json={"leagueKey": "main", "teamName": "Nonexistent", "playersIn": [], "playersOut": []},
+            json={
+                "leagueKey": "main",
+                "teamName": "Nonexistent",
+                "playersIn": [],
+                "playersOut": [],
+            },
         )
     # 404 team_not_found is the NEXT validation step after league
     # resolution — proves we got past the league check.
@@ -240,8 +250,13 @@ def test_trade_simulate_rejects_wrong_league_in_body(two_league_registry, monkey
     with TestClient(server.app, raise_server_exceptions=True) as c:
         _install_contract_for_league(monkeypatch, "main")
         monkeypatch.setattr(
-            server, "_get_auth_session",
-            lambda request: {"username": "alice", "auth_method": "sleeper", "sleeper_user_id": "oA"},
+            server,
+            "_get_auth_session",
+            lambda request: {
+                "username": "alice",
+                "auth_method": "sleeper",
+                "sleeper_user_id": "oA",
+            },
         )
         res = c.post(
             "/api/trade/simulate",
@@ -326,9 +341,7 @@ def _install_contract_with_profile(monkeypatch, league_key: str, profile: str):
     monkeypatch.setattr(server, "latest_data_etag", None)
 
 
-def test_api_data_serves_shared_rankings_for_same_profile(
-    shared_scoring_registry, monkeypatch
-):
+def test_api_data_serves_shared_rankings_for_same_profile(shared_scoring_registry, monkeypatch):
     """Loaded contract is for League 'main' (superflex_tep15_ppr1).
     Request for 'twin' (same profile) should succeed with 200,
     serve the rankings, and null the sleeper block so the UI
@@ -352,9 +365,7 @@ def test_api_data_serves_shared_rankings_for_same_profile(
     assert body["meta"]["sleeperLoadedLeagueKey"] == "main"
 
 
-def test_api_data_serves_full_contract_when_sleeper_matches(
-    shared_scoring_registry, monkeypatch
-):
+def test_api_data_serves_full_contract_when_sleeper_matches(shared_scoring_registry, monkeypatch):
     """When the loaded contract's leagueKey matches the requested
     league AND the live Sleeper overlay is unavailable, the baked-in
     sleeper block falls through unchanged.
@@ -365,7 +376,8 @@ def test_api_data_serves_full_contract_when_sleeper_matches(
     this test pins.
     """
     monkeypatch.setattr(
-        server._sleeper_overlay, "fetch_sleeper_overlay",
+        server._sleeper_overlay,
+        "fetch_sleeper_overlay",
         lambda **_kw: None,  # overlay unavailable → fall back to baked
     )
     with TestClient(server.app, raise_server_exceptions=True) as c:
@@ -377,9 +389,7 @@ def test_api_data_serves_full_contract_when_sleeper_matches(
     assert body["sleeper"]["teams"][0]["ownerId"] == "oA"
 
 
-def test_api_data_overlays_fresh_sleeper_for_loaded_league(
-    shared_scoring_registry, monkeypatch
-):
+def test_api_data_overlays_fresh_sleeper_for_loaded_league(shared_scoring_registry, monkeypatch):
     """When the live overlay is available, /api/data splices it onto
     the loaded league's response so the rosters reflect Sleeper
     activity within the overlay's 15-min cache window — even for
@@ -396,7 +406,8 @@ def test_api_data_overlays_fresh_sleeper_for_loaded_league(
         "overlayFetchedAt": "2026-04-29T11:30:00+00:00",
     }
     monkeypatch.setattr(
-        server._sleeper_overlay, "fetch_sleeper_overlay",
+        server._sleeper_overlay,
+        "fetch_sleeper_overlay",
         lambda **_kw: fresh_overlay,
     )
     with TestClient(server.app, raise_server_exceptions=True) as c:
@@ -413,9 +424,7 @@ def test_api_data_overlays_fresh_sleeper_for_loaded_league(
     assert "overlay" in res.headers.get("X-Payload-View", "")
 
 
-def test_api_data_overlay_layers_fresh_trades_in_baked_shape(
-    shared_scoring_registry, monkeypatch
-):
+def test_api_data_overlay_layers_fresh_trades_in_baked_shape(shared_scoring_registry, monkeypatch):
     """The overlay's ``trades`` block now produces the same
     ``[{leagueId, week, timestamp, sides[]}, ...]`` shape that the
     offline scraper bakes into ``sleeper.trades`` (see
@@ -432,18 +441,20 @@ def test_api_data_overlay_layers_fresh_trades_in_baked_shape(
     green.
     """
     baked_trades = [
-        {"leagueId": "L-MAIN", "sides": [{"a": 1}, {"b": 2}],
-         "timestamp": 1700000000000, "week": 3},
+        {
+            "leagueId": "L-MAIN",
+            "sides": [{"a": 1}, {"b": 2}],
+            "timestamp": 1700000000000,
+            "week": 3,
+        },
     ]
     fresh_overlay_trade = {
         "leagueId": "L-MAIN",
         "week": 5,
         "timestamp": 1730000000000,
         "sides": [
-            {"team": "Team A", "rosterId": 1, "ownerId": "oA",
-             "got": ["Fresh Player"], "gave": []},
-            {"team": "Team B", "rosterId": 2, "ownerId": "oB",
-             "got": [], "gave": ["Fresh Player"]},
+            {"team": "Team A", "rosterId": 1, "ownerId": "oA", "got": ["Fresh Player"], "gave": []},
+            {"team": "Team B", "rosterId": 2, "ownerId": "oB", "got": [], "gave": ["Fresh Player"]},
         ],
     }
     overlay_payload = {
@@ -458,7 +469,8 @@ def test_api_data_overlay_layers_fresh_trades_in_baked_shape(
         "overlayFetchedAt": "2026-04-29T12:00:00+00:00",
     }
     monkeypatch.setattr(
-        server._sleeper_overlay, "fetch_sleeper_overlay",
+        server._sleeper_overlay,
+        "fetch_sleeper_overlay",
         lambda **_kw: overlay_payload,
     )
     stub = {
@@ -495,9 +507,7 @@ def test_api_data_overlay_layers_fresh_trades_in_baked_shape(
     assert sleeper.get("overlaySource") == "live-merge"
 
 
-def test_api_data_503s_when_scoring_profile_differs(
-    shared_scoring_registry, monkeypatch
-):
+def test_api_data_503s_when_scoring_profile_differs(shared_scoring_registry, monkeypatch):
     """Loaded contract is superflex_tep15_ppr1.  Requesting the
     'stranger' league (standard_1qb_ppr1) must 503 — rankings
     genuinely can't be reused across different scoring."""
@@ -544,18 +554,21 @@ def test_api_leagues_excludes_inactive(two_league_registry):
 
 
 def test_api_leagues_autoresolves_user_team_via_sleeper(
-    two_league_registry, monkeypatch,
+    two_league_registry,
+    monkeypatch,
 ):
     """Registry has no defaultTeamMap for "main" → server should
     resolve the user's team from Sleeper via their sleeper_user_id."""
     # Seed an in-memory session with a Sleeper user_id.
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda request: {
             "username": "jasonleetucker",
             "sleeper_user_id": "U-JASON",
         },
     )
+
     # Stub the Sleeper user-team lookup to pretend Jason is in "main"
     # as "Rossini Panini" and in "side" as "Blood Sweat Crew".
     def _stub_fetch(league_id, user_id):
@@ -565,6 +578,7 @@ def test_api_leagues_autoresolves_user_team_via_sleeper(
         if league_id == "L-SIDE":
             return {"ownerId": "U-JASON", "teamName": "Blood Sweat Crew"}
         return None
+
     monkeypatch.setattr(server, "_fetch_sleeper_user_team", _stub_fetch)
     # Avoid the live Sleeper name fetch in the test.
     monkeypatch.setattr(server, "_fetch_sleeper_league_name", lambda _id: None)
@@ -579,30 +593,39 @@ def test_api_leagues_autoresolves_user_team_via_sleeper(
 
 
 def test_api_leagues_registry_default_team_wins_over_sleeper_fallback(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ):
     """When the registry DOES have a defaultTeamMap entry, that
     takes precedence — the Sleeper fallback is only for leagues the
     registry hasn't been edited for."""
     path = tmp_path / "registry.json"
-    path.write_text(json.dumps({
-        "defaultLeagueKey": "main",
-        "leagues": [{
-            "key": "main",
-            "displayName": "Main",
-            "sleeperLeagueId": "L-MAIN",
-            "active": True,
-            "rosterSettings": {},
-            "defaultTeamMap": {
-                "jasonleetucker": {"teamName": "Registry-Override"},
-            },
-        }],
-    }), encoding="utf-8")
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "L-MAIN",
+                        "active": True,
+                        "rosterSettings": {},
+                        "defaultTeamMap": {
+                            "jasonleetucker": {"teamName": "Registry-Override"},
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
     league_registry.reload_registry()
 
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda request: {
             "username": "jasonleetucker",
             "sleeper_user_id": "U-JASON",
@@ -610,9 +633,11 @@ def test_api_leagues_registry_default_team_wins_over_sleeper_fallback(
     )
     # This stub should NEVER be called if the registry entry wins.
     calls = []
+
     def _should_not_be_called(*a, **kw):
         calls.append((a, kw))
         return {"ownerId": "U-JASON", "teamName": "Sleeper-Fallback"}
+
     monkeypatch.setattr(server, "_fetch_sleeper_user_team", _should_not_be_called)
     monkeypatch.setattr(server, "_fetch_sleeper_league_name", lambda _id: None)
 
@@ -628,7 +653,8 @@ def test_api_leagues_registry_default_team_wins_over_sleeper_fallback(
 
 
 def test_api_leagues_anonymous_users_get_no_user_default_team(
-    two_league_registry, monkeypatch,
+    two_league_registry,
+    monkeypatch,
 ):
     """Anonymous callers (no session) must not get a userDefaultTeam
     block — we don't leak any user's team-in-league on an unauthed
@@ -647,8 +673,10 @@ def test_fetch_sleeper_user_team_returns_none_for_unknown_user(monkeypatch):
     """Direct unit test on the helper: an unknown user_id → None
     (not an exception)."""
     import io
+
     def _fake_urlopen(req, timeout=5.0):
         return io.BytesIO(b'[{"user_id":"OTHER","metadata":{"team_name":"Not Mine"}}]')
+
     monkeypatch.setattr(server.urllib.request, "urlopen", _fake_urlopen)
     # Clear cache so this call actually hits the stub.
     server._SLEEPER_USER_TEAM_CACHE.clear()
@@ -660,11 +688,13 @@ def test_fetch_sleeper_user_team_resolves_team_name(monkeypatch):
     """Helper returns {ownerId, teamName} when the user is present in
     the league's users list."""
     import io
+
     def _fake_urlopen(req, timeout=5.0):
         return io.BytesIO(
             b'[{"user_id":"U-JASON","metadata":{"team_name":"Brisket Crew"},'
             b'"display_name":"jasonleetucker"}]'
         )
+
     monkeypatch.setattr(server.urllib.request, "urlopen", _fake_urlopen)
     server._SLEEPER_USER_TEAM_CACHE.clear()
     result = server._fetch_sleeper_user_team("L-MAIN", "U-JASON")
@@ -676,10 +706,10 @@ def test_fetch_sleeper_user_team_falls_back_to_display_name(monkeypatch):
     ``display_name`` so the team picker shows SOMETHING instead of
     blank."""
     import io
+
     def _fake_urlopen(req, timeout=5.0):
-        return io.BytesIO(
-            b'[{"user_id":"U-JASON","display_name":"jasonleetucker"}]'
-        )
+        return io.BytesIO(b'[{"user_id":"U-JASON","display_name":"jasonleetucker"}]')
+
     monkeypatch.setattr(server.urllib.request, "urlopen", _fake_urlopen)
     server._SLEEPER_USER_TEAM_CACHE.clear()
     result = server._fetch_sleeper_user_team("L-MAIN", "U-JASON")

--- a/tests/api/test_market_corridor_clamp.py
+++ b/tests/api/test_market_corridor_clamp.py
@@ -5,6 +5,7 @@ further from their market anchor (KTC for offense, IDPTC for IDP)
 than the 90th percentile of drift within their confidence bucket.
 Non-outliers are untouched.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -60,7 +61,9 @@ class TestMarketAnchorSelection(unittest.TestCase):
 
     def test_anchor_missing_returns_none(self):
         row = _make_row(
-            name="No Anchor", asset_class="offense", value=5000,
+            name="No Anchor",
+            asset_class="offense",
+            value=5000,
             ktc=None,
         )
         self.assertIsNone(_market_anchor_value_for_row(row))
@@ -69,14 +72,18 @@ class TestMarketAnchorSelection(unittest.TestCase):
         """Zero-value anchors can't serve as denominators for the drift
         ratio — treat them as absent."""
         row = _make_row(
-            name="Zero KTC", asset_class="offense", value=5000,
+            name="Zero KTC",
+            asset_class="offense",
+            value=5000,
             ktc=0,
         )
         self.assertIsNone(_market_anchor_value_for_row(row))
 
     def test_pick_asset_class_has_no_anchor(self):
         row = _make_row(
-            name="2026 Pick 1.01", asset_class="pick", value=8000,
+            name="2026 Pick 1.01",
+            asset_class="pick",
+            value=8000,
             ktc=8200,  # pick KTC values exist but picks aren't in the clamp scope
         )
         self.assertIsNone(_market_anchor_value_for_row(row))
@@ -180,14 +187,15 @@ class TestFallbackAnchor(unittest.TestCase):
             SOURCE_SCOPE_OVERALL_IDP,
             SOURCE_SCOPE_OVERALL_OFFENSE,
         )
+
         offense_sources = {
-            s["key"] for s in _RANKING_SOURCES
+            s["key"]
+            for s in _RANKING_SOURCES
             if s.get("scope") == SOURCE_SCOPE_OVERALL_OFFENSE
             and not s.get("excludes_rookies")  # rookie-only boards aren't anchors
         }
         idp_sources = {
-            s["key"] for s in _RANKING_SOURCES
-            if s.get("scope") == SOURCE_SCOPE_OVERALL_IDP
+            s["key"] for s in _RANKING_SOURCES if s.get("scope") == SOURCE_SCOPE_OVERALL_IDP
         }
         chain_offense = set(_MARKET_ANCHOR_FALLBACKS.get("offense") or [])
         chain_idp = set(_MARKET_ANCHOR_FALLBACKS.get("idp") or [])
@@ -231,13 +239,15 @@ class TestClampFires(unittest.TestCase):
         rows = []
         # 39 "normal" medium-confidence rows with drifts ~0.10
         for i in range(39):
-            rows.append(_make_row(
-                name=f"p_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.10),  # 10% above market
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"p_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),  # 10% above market
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         # 1 outlier with drift ~0.70 (way below market)
         outlier = _make_row(
             name="outlier_low",
@@ -261,13 +271,15 @@ class TestClampFires(unittest.TestCase):
     def test_single_extreme_outlier_gets_clamped_above_market(self):
         rows = []
         for i in range(39):
-            rows.append(_make_row(
-                name=f"p_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.10),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"p_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         outlier = _make_row(
             name="outlier_high",
             asset_class="idp",
@@ -287,13 +299,15 @@ class TestClampFires(unittest.TestCase):
         rows = []
         # 40 medium rows with uniform drift 0.10
         for i in range(40):
-            rows.append(_make_row(
-                name=f"p_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.10),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"p_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         _apply_market_corridor_clamp(rows, players_by_name={})
         for row in rows:
             self.assertNotIn("marketCorridorClamp", row)
@@ -302,23 +316,27 @@ class TestClampFires(unittest.TestCase):
     def test_no_anchor_no_clamp(self):
         """Rows without a market anchor value (e.g. an IDP not listed
         by any anchor-chain source) get left alone."""
-        rows = [_make_row(
-            name="idp_no_anchor",
-            asset_class="idp",
-            value=5000,
-            idpTradeCalc=None,
-            bucket="low",
-        )]
+        rows = [
+            _make_row(
+                name="idp_no_anchor",
+                asset_class="idp",
+                value=5000,
+                idpTradeCalc=None,
+                bucket="low",
+            )
+        ]
         # Pad with anchored rows so the function has a distribution to
         # compute a band from (otherwise it no-ops on empty).
         for i in range(40):
-            rows.append(_make_row(
-                name=f"anchored_{i}",
-                asset_class="idp",
-                value=5500,
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"anchored_{i}",
+                    asset_class="idp",
+                    value=5500,
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         _apply_market_corridor_clamp(rows, players_by_name={})
         self.assertNotIn("marketCorridorClamp", rows[0])
         self.assertEqual(rows[0]["rankDerivedValue"], 5000)
@@ -333,22 +351,26 @@ class TestClampFires(unittest.TestCase):
         """
         rows = []
         for i in range(50):
-            rows.append(_make_row(
-                name=f"m_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.15),  # medium drift 0.15
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"m_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.15),  # medium drift 0.15
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         # 5 high-confidence rows, one with extreme drift
         for i in range(4):
-            rows.append(_make_row(
-                name=f"h_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.05),  # small drift 0.05
-                idpTradeCalc=5000,
-                bucket="high",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"h_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.05),  # small drift 0.05
+                    idpTradeCalc=5000,
+                    bucket="high",
+                )
+            )
         high_outlier = _make_row(
             name="h_outlier",
             asset_class="idp",
@@ -365,24 +387,28 @@ class TestClampFires(unittest.TestCase):
         self.assertEqual(high_outlier["rankDerivedValue"], 5750)
 
     def test_unranked_rows_are_skipped(self):
-        rows = [_make_row(
-            name="unranked",
-            asset_class="idp",
-            value=100,
-            idpTradeCalc=5000,
-            bucket="low",
-        )]
+        rows = [
+            _make_row(
+                name="unranked",
+                asset_class="idp",
+                value=100,
+                idpTradeCalc=5000,
+                bucket="low",
+            )
+        ]
         # Clear canonicalConsensusRank to simulate an unranked row.
         rows[0]["canonicalConsensusRank"] = None
         # Pad the distribution.
         for i in range(40):
-            rows.append(_make_row(
-                name=f"p_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.10),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"p_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         _apply_market_corridor_clamp(rows, players_by_name={})
         # Unranked row should NOT be touched.
         self.assertNotIn("marketCorridorClamp", rows[0])
@@ -394,21 +420,25 @@ class TestClampStamps(unittest.TestCase):
     the decision from the UI / logs."""
 
     def test_stamp_fields_present(self):
-        rows = [_make_row(
-            name="outlier",
-            asset_class="idp",
-            value=100,
-            idpTradeCalc=5000,
-            bucket="low",
-        )]
-        for i in range(40):
-            rows.append(_make_row(
-                name=f"p_{i}",
+        rows = [
+            _make_row(
+                name="outlier",
                 asset_class="idp",
-                value=int(5000 * 1.10),
+                value=100,
                 idpTradeCalc=5000,
-                bucket="medium",
-            ))
+                bucket="low",
+            )
+        ]
+        for i in range(40):
+            rows.append(
+                _make_row(
+                    name=f"p_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         _apply_market_corridor_clamp(rows, players_by_name={})
         stamp = rows[0].get("marketCorridorClamp")
         self.assertIsNotNone(stamp)
@@ -440,13 +470,15 @@ class TestClampStamps(unittest.TestCase):
         )
         rows = [row]
         for i in range(40):
-            rows.append(_make_row(
-                name=f"p_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.10),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"p_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         legacy = {"Clamped": {"rankDerivedValue": 100}}
         _apply_market_corridor_clamp(rows, players_by_name=legacy)
         self.assertEqual(legacy["Clamped"]["rankDerivedValue"], row["rankDerivedValue"])
@@ -458,21 +490,25 @@ class TestIdempotence(unittest.TestCase):
     every row's drift ≤ band, so a second pass should be a no-op."""
 
     def test_second_pass_no_additional_clamps(self):
-        rows = [_make_row(
-            name="outlier",
-            asset_class="idp",
-            value=100,
-            idpTradeCalc=5000,
-            bucket="medium",
-        )]
-        for i in range(40):
-            rows.append(_make_row(
-                name=f"p_{i}",
+        rows = [
+            _make_row(
+                name="outlier",
                 asset_class="idp",
-                value=int(5000 * 1.10),
+                value=100,
                 idpTradeCalc=5000,
                 bucket="medium",
-            ))
+            )
+        ]
+        for i in range(40):
+            rows.append(
+                _make_row(
+                    name=f"p_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         _apply_market_corridor_clamp(rows, players_by_name={})
         clamped_val = rows[0]["rankDerivedValue"]
         _apply_market_corridor_clamp(rows, players_by_name={})
@@ -515,13 +551,15 @@ class TestIdpMaxBandCap(unittest.TestCase):
         # bucket P90 (~30%) would NOT have clamped a 47%-drift outlier
         # without the max-band cap.
         for i in range(39):
-            rows.append(_make_row(
-                name=f"bg_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.30),  # 30% above IDPTC
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"bg_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.30),  # 30% above IDPTC
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         # The Vikings LB: 1,900 internal, 3,600 on IDPTC = 47% drift down.
         outlier = _make_row(
             name="vikings_lb",
@@ -552,13 +590,15 @@ class TestIdpMaxBandCap(unittest.TestCase):
         rows = []
         # 39 IDPs with drift 0.10 → bucket P90 = 0.10 (below cap).
         for i in range(39):
-            rows.append(_make_row(
-                name=f"bg_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.10),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"bg_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         # Outlier with 70% drift down.
         outlier = _make_row(
             name="outlier",
@@ -582,13 +622,15 @@ class TestIdpMaxBandCap(unittest.TestCase):
         rows = []
         # 39 IDPs with 30% drift to widen the bucket band past 0.15.
         for i in range(39):
-            rows.append(_make_row(
-                name=f"bg_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.30),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"bg_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.30),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         # An over-valued outlier 60% above IDPTC.
         over = _make_row(
             name="over",
@@ -622,13 +664,15 @@ class TestIdpMaxBandCap(unittest.TestCase):
         rows = []
         # IDP background so the function has a band distribution.
         for i in range(39):
-            rows.append(_make_row(
-                name=f"idp_bg_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.10),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"idp_bg_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.10),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         idp_outlier = _make_row(
             name="idp_outlier",
             asset_class="idp",
@@ -659,13 +703,15 @@ class TestIdpMaxBandCap(unittest.TestCase):
         the value — the player is already inside the 15% band."""
         rows = []
         for i in range(39):
-            rows.append(_make_row(
-                name=f"bg_{i}",
-                asset_class="idp",
-                value=int(5000 * 1.30),
-                idpTradeCalc=5000,
-                bucket="medium",
-            ))
+            rows.append(
+                _make_row(
+                    name=f"bg_{i}",
+                    asset_class="idp",
+                    value=int(5000 * 1.30),
+                    idpTradeCalc=5000,
+                    bucket="medium",
+                )
+            )
         outlier = _make_row(
             name="vikings_lb",
             asset_class="idp",

--- a/tests/api/test_name_join_hygiene.py
+++ b/tests/api/test_name_join_hygiene.py
@@ -25,6 +25,7 @@ Test coverage:
 * Downstream effect: a pair of rows that used to produce a single-source
   artefact now carries both sources on the canonical site map.
 """
+
 from __future__ import annotations
 
 import csv
@@ -55,8 +56,7 @@ def _row(name: str, pos: str, *, idp=None, dlf=None, ktc=None) -> dict:
         "legacyRef": name,
         "position": pos,
         "assetClass": "offense" if pos in {"QB", "RB", "WR", "TE"} else "idp",
-        "values": {"overall": 0, "rawComposite": 0,
-                   "finalAdjusted": 0, "displayValue": None},
+        "values": {"overall": 0, "rawComposite": 0, "finalAdjusted": 0, "displayValue": None},
         "canonicalSiteValues": sites,
         "sourceCount": 1,
     }
@@ -224,9 +224,7 @@ class TestEnrichFromSourceCsvsJoinHygiene(unittest.TestCase):
             },
         )
         self.assertIn("dlfIdp", players[0]["canonicalSiteValues"])
-        self.assertGreater(
-            players[0]["canonicalSiteValues"]["dlfIdp"], 0
-        )
+        self.assertGreater(players[0]["canonicalSiteValues"]["dlfIdp"], 0)
 
     def test_reverse_suffix_drift_joins_correctly(self):
         # And in reverse: scraper has the suffix, CSV does not.
@@ -238,9 +236,7 @@ class TestEnrichFromSourceCsvsJoinHygiene(unittest.TestCase):
             },
         )
         self.assertIn("idpTradeCalc", players[0]["canonicalSiteValues"])
-        self.assertEqual(
-            players[0]["canonicalSiteValues"]["idpTradeCalc"], 7200
-        )
+        self.assertEqual(players[0]["canonicalSiteValues"]["idpTradeCalc"], 7200)
 
     def test_diacritics_drift_joins_correctly(self):
         players = [_row("Juanyéh Thomas", "DB")]
@@ -262,9 +258,7 @@ class TestEnrichFromSourceCsvsJoinHygiene(unittest.TestCase):
             players,
             {"idpTradeCalc": [("TJ Watt", 5000)]},
         )
-        self.assertEqual(
-            players[0]["canonicalSiteValues"]["idpTradeCalc"], 4000
-        )
+        self.assertEqual(players[0]["canonicalSiteValues"]["idpTradeCalc"], 4000)
 
     def test_row_becomes_multi_source_after_hygiene_fix(self):
         # End-to-end: a T.J. Watt row that starts with zero canonical
@@ -289,9 +283,7 @@ class TestEnrichFromSourceCsvsJoinHygiene(unittest.TestCase):
             },
         )
         _compute_unified_rankings(players, {})
-        watt = next(
-            r for r in players if r["canonicalName"] == "T.J. Watt"
-        )
+        watt = next(r for r in players if r["canonicalName"] == "T.J. Watt")
         # Both sources show up on canonicalSiteValues
         self.assertIn("idpTradeCalc", watt["canonicalSiteValues"])
         self.assertIn("dlfIdp", watt["canonicalSiteValues"])

--- a/tests/api/test_ops_alerts.py
+++ b/tests/api/test_ops_alerts.py
@@ -1,4 +1,5 @@
 """Tests for the operator alerting hook."""
+
 from __future__ import annotations
 
 import pytest
@@ -33,28 +34,42 @@ def test_scrape_rate_below_25_critical():
 
 
 def test_circuit_breaker_open_briefly_not_alerted():
-    alerts = oa._check_circuit_breakers([{  # noqa: SLF001
-        "name": "sleeper", "state": "open", "stateAgeSec": 60,
-    }])
+    alerts = oa._check_circuit_breakers(
+        [
+            {  # noqa: SLF001
+                "name": "sleeper",
+                "state": "open",
+                "stateAgeSec": 60,
+            }
+        ]
+    )
     assert alerts == []
 
 
 def test_circuit_breaker_open_long_alerts():
-    alerts = oa._check_circuit_breakers([{  # noqa: SLF001
-        "name": "sleeper", "state": "open", "stateAgeSec": 900,
-        "lastError": "Connection refused",
-        "counters": {"fastFail": 50},
-    }])
+    alerts = oa._check_circuit_breakers(
+        [
+            {  # noqa: SLF001
+                "name": "sleeper",
+                "state": "open",
+                "stateAgeSec": 900,
+                "lastError": "Connection refused",
+                "counters": {"fastFail": 50},
+            }
+        ]
+    )
     assert len(alerts) == 1
     assert alerts[0].category == "circuit_open:sleeper"
     assert "sleeper" in alerts[0].title
 
 
 def test_contract_unhealthy_fires():
-    a = oa._check_contract_health({  # noqa: SLF001
-        "ok": False,
-        "errors": ["partial_run_critical:KTC", "schema_drift"],
-    })
+    a = oa._check_contract_health(
+        {  # noqa: SLF001
+            "ok": False,
+            "errors": ["partial_run_critical:KTC", "schema_drift"],
+        }
+    )
     assert a is not None
     assert a.severity == "critical"
 
@@ -73,17 +88,23 @@ def test_data_freshness_over_threshold_warns():
 
 def test_cooldown_prevents_re_fire(kv):
     delivered = []
+
     def _send(to, subj, body):
         delivered.append((to, subj))
         return True
+
     status = {"scrape_success_rate_24h": 0.1}
     s1 = oa.check_and_alert(
-        status_payload=status, delivery=_send,
-        to_email="a@b.com", kv_path=kv,
+        status_payload=status,
+        delivery=_send,
+        to_email="a@b.com",
+        kv_path=kv,
     )
     s2 = oa.check_and_alert(
-        status_payload=status, delivery=_send,
-        to_email="a@b.com", kv_path=kv,
+        status_payload=status,
+        delivery=_send,
+        to_email="a@b.com",
+        kv_path=kv,
     )
     assert s1["fired"] == 1
     assert s2["fired"] == 0  # cooled down
@@ -92,20 +113,26 @@ def test_cooldown_prevents_re_fire(kv):
 
 def test_recovery_alert_fires_when_condition_clears(kv):
     delivered = []
+
     def _send(to, subj, body):
         delivered.append((to, subj, body))
         return True
+
     # First pass: scrape rate low → alert.
     oa.check_and_alert(
         status_payload={"scrape_success_rate_24h": 0.1},
-        delivery=_send, to_email="a@b.com", kv_path=kv,
+        delivery=_send,
+        to_email="a@b.com",
+        kv_path=kv,
     )
     assert len(delivered) == 1
     assert "critical" in delivered[0][1].lower()
     # Second pass: scrape rate healthy → recovery alert.
     s = oa.check_and_alert(
         status_payload={"scrape_success_rate_24h": 0.95},
-        delivery=_send, to_email="a@b.com", kv_path=kv,
+        delivery=_send,
+        to_email="a@b.com",
+        kv_path=kv,
     )
     assert s["recovered"] == 1
     assert len(delivered) == 2
@@ -127,12 +154,16 @@ def test_format_ops_email_has_sections():
 
 def test_no_alerts_no_delivery(kv):
     delivered = []
+
     def _send(to, subj, body):
         delivered.append(1)
         return True
+
     s = oa.check_and_alert(
         status_payload={"scrape_success_rate_24h": 0.99},
-        delivery=_send, to_email="a@b.com", kv_path=kv,
+        delivery=_send,
+        to_email="a@b.com",
+        kv_path=kv,
     )
     assert s["fired"] == 0
     assert delivered == []
@@ -142,7 +173,8 @@ def test_never_crashes_on_missing_delivery(kv):
     # No delivery callable → just returns summary.
     s = oa.check_and_alert(
         status_payload={"scrape_success_rate_24h": 0.1},
-        delivery=None, kv_path=kv,
+        delivery=None,
+        kv_path=kv,
     )
     assert s["delivered"] is False
     assert s["fired"] == 1

--- a/tests/api/test_orphan_reaper.py
+++ b/tests/api/test_orphan_reaper.py
@@ -71,9 +71,7 @@ def test_reaper_kills_matching_descendant():
     proc = subprocess.Popen(["sleep", "300"])
     try:
         time.sleep(0.2)
-        killed = server._reap_orphan_browsers(
-            match=lambda c: "sleep" in c and "300" in c
-        )
+        killed = server._reap_orphan_browsers(match=lambda c: "sleep" in c and "300" in c)
         assert killed >= 1
         # Process must actually be dead.
         assert proc.wait(timeout=5) != 0

--- a/tests/api/test_per_source_freshness.py
+++ b/tests/api/test_per_source_freshness.py
@@ -6,6 +6,7 @@ record.  This is what feeds ``check_and_alert`` in
 ``src.api.source_health_alerts`` and the per-source rows on the
 ``/tools/source-health`` page.
 """
+
 from __future__ import annotations
 
 import time
@@ -42,9 +43,9 @@ def test_freshness_records_have_consistent_age_window():
         # matches it within ±2 minutes (rounded to 2 decimals).
         last = datetime.fromisoformat(entry["lastFetched"]).astimezone(timezone.utc)
         derived_hours = (now - last.timestamp()) / 3600.0
-        assert abs(derived_hours - entry["ageHours"]) < 2 / 60, (
-            f"{src}: derived={derived_hours:.4f}h vs reported={entry['ageHours']}h"
-        )
+        assert (
+            abs(derived_hours - entry["ageHours"]) < 2 / 60
+        ), f"{src}: derived={derived_hours:.4f}h vs reported={entry['ageHours']}h"
 
 
 def test_per_source_freshness_returns_empty_when_repo_missing(monkeypatch, tmp_path):
@@ -76,6 +77,7 @@ def _redirect_repo_root(monkeypatch, tmp_path, source_key: str, csv_rel: str):
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     stamp_path = tmp_path / "data" / "scrape_state" / f"{source_key}_last_success"
     from src.api import data_contract as dc
+
     monkeypatch.setattr(dc, "_SOURCE_CSV_PATHS", {source_key: csv_rel})
     return csv_path, stamp_path
 
@@ -88,13 +90,16 @@ def test_freshness_prefers_stamp_over_csv_mtime(monkeypatch, tmp_path):
     freezing CSV mtime on the last *content* change rather than the
     last *fetcher success*."""
     csv_path, stamp_path = _redirect_repo_root(
-        monkeypatch, tmp_path, "fantasyProsFitzmaurice",
+        monkeypatch,
+        tmp_path,
+        "fantasyProsFitzmaurice",
         "CSVs/site_raw/fantasyProsFitzmaurice.csv",
     )
     # CSV mtime: 4 days old
     csv_path.write_text("name,rank\nfoo,1\n")
     old = time.time() - 4 * 86400
     import os as _os
+
     _os.utime(csv_path, (old, old))
     # Stamp: 30 minutes old
     fresh_epoch = int(time.time() - 1800)
@@ -104,16 +109,19 @@ def test_freshness_prefers_stamp_over_csv_mtime(monkeypatch, tmp_path):
     out = srv._per_source_freshness()
     entry = out["fantasyProsFitzmaurice"]
     # ageHours should reflect the 30-min stamp, not the 4-day CSV.
-    assert entry["ageHours"] < 1.0, (
-        f"stamp ignored - ageHours={entry['ageHours']} suggests fall-through to CSV mtime"
-    )
+    assert (
+        entry["ageHours"] < 1.0
+    ), f"stamp ignored - ageHours={entry['ageHours']} suggests fall-through to CSV mtime"
 
 
 def test_freshness_falls_back_to_csv_when_stamp_missing(monkeypatch, tmp_path):
     """No stamp file ⇒ CSV mtime is used.  Preserves backwards-compat
     for sources that haven't been wired into the stamp pattern yet."""
     csv_path, _ = _redirect_repo_root(
-        monkeypatch, tmp_path, "ktc", "CSVs/site_raw/ktc.csv",
+        monkeypatch,
+        tmp_path,
+        "ktc",
+        "CSVs/site_raw/ktc.csv",
     )
     csv_path.write_text("name,rank\n")
     # No stamp file written.
@@ -126,7 +134,10 @@ def test_freshness_falls_back_to_csv_when_stamp_unparseable(monkeypatch, tmp_pat
     """Corrupt stamp content (non-numeric) falls through to CSV mtime
     instead of dropping the source from the freshness map."""
     csv_path, stamp_path = _redirect_repo_root(
-        monkeypatch, tmp_path, "ktc", "CSVs/site_raw/ktc.csv",
+        monkeypatch,
+        tmp_path,
+        "ktc",
+        "CSVs/site_raw/ktc.csv",
     )
     csv_path.write_text("name,rank\n")
     stamp_path.parent.mkdir(parents=True, exist_ok=True)
@@ -140,7 +151,10 @@ def test_freshness_drops_source_when_no_stamp_and_no_csv(monkeypatch, tmp_path):
     engine has nothing to alert on; the source-registry parity check
     is the right place to surface "missing CSV")."""
     _redirect_repo_root(
-        monkeypatch, tmp_path, "missingSource", "CSVs/site_raw/missingSource.csv",
+        monkeypatch,
+        tmp_path,
+        "missingSource",
+        "CSVs/site_raw/missingSource.csv",
     )
     out = srv._per_source_freshness()
     assert "missingSource" not in out

--- a/tests/api/test_pick_refinement.py
+++ b/tests/api/test_pick_refinement.py
@@ -15,6 +15,7 @@ April 2026 (see audit dated 2026-04-14):
 
 Run with:  python3 -m pytest tests/api/test_pick_refinement.py -v
 """
+
 from __future__ import annotations
 
 import json
@@ -50,9 +51,7 @@ def _get() -> dict[str, Any] | None:
 
 def _by_name(contract: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {
-        r["canonicalName"]: r
-        for r in contract.get("playersArray", [])
-        if r.get("canonicalName")
+        r["canonicalName"]: r for r in contract.get("playersArray", []) if r.get("canonicalName")
     }
 
 
@@ -264,6 +263,7 @@ class TestPickConfidenceUsesCV(unittest.TestCase):
         # All 2026 specific slots should resolve to a known pick bucket
         # — never the generic player labels.
         from src.api.data_contract import _compute_pick_confidence
+
         # Round 1 picks should be high confidence (KTC + IDPTC values
         # typically agree within 30%)
         for slot in range(1, 13):
@@ -286,10 +286,7 @@ class TestPickConfidenceUsesCV(unittest.TestCase):
         ]
         self.assertTrue(labels, "no pick labels found")
         cv_phrases = ("picks agree", "pick source", "divergent pick")
-        ok = any(
-            any(p in (lbl or "").lower() for p in cv_phrases)
-            for _n, lbl in labels
-        )
+        ok = any(any(p in (lbl or "").lower() for p in cv_phrases) for _n, lbl in labels)
         self.assertTrue(
             ok,
             f"no pick label uses CV phrasing; sample={labels[:3]}",
@@ -329,16 +326,20 @@ class TestPlayerRankingsUnchanged(unittest.TestCase):
 
     _ANCHORS: dict[str, dict[str, Any]] = {
         # ── Offense anchors ──
-        "Josh Allen":       {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
-        "Drake Maye":       {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
-        "Ja'Marr Chase":    {"max_rank": 15, "min_value": 7000, "allowed_buckets": ("high",)},
-        "Bijan Robinson":   {"max_rank": 15, "min_value": 6500, "allowed_buckets": ("high",)},
-        "Jahmyr Gibbs":     {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
-        "Jayden Daniels":   {"max_rank": 25, "min_value": 5500, "allowed_buckets": ("high",)},
-        "Puka Nacua":       {"max_rank": 25, "min_value": 5500, "allowed_buckets": ("high",)},
-        "Malik Nabers":     {"max_rank": 30, "min_value": 5000, "allowed_buckets": ("high", "medium")},
-        "Brock Bowers":     {"max_rank": 40, "min_value": 5000, "allowed_buckets": ("high", "medium")},
-        "Patrick Mahomes":  {"max_rank": 50, "min_value": 4000, "allowed_buckets": ("high", "medium")},
+        "Josh Allen": {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
+        "Drake Maye": {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
+        "Ja'Marr Chase": {"max_rank": 15, "min_value": 7000, "allowed_buckets": ("high",)},
+        "Bijan Robinson": {"max_rank": 15, "min_value": 6500, "allowed_buckets": ("high",)},
+        "Jahmyr Gibbs": {"max_rank": 20, "min_value": 6000, "allowed_buckets": ("high",)},
+        "Jayden Daniels": {"max_rank": 25, "min_value": 5500, "allowed_buckets": ("high",)},
+        "Puka Nacua": {"max_rank": 25, "min_value": 5500, "allowed_buckets": ("high",)},
+        "Malik Nabers": {"max_rank": 30, "min_value": 5000, "allowed_buckets": ("high", "medium")},
+        "Brock Bowers": {"max_rank": 40, "min_value": 5000, "allowed_buckets": ("high", "medium")},
+        "Patrick Mahomes": {
+            "max_rank": 50,
+            "min_value": 4000,
+            "allowed_buckets": ("high", "medium"),
+        },
         # ── IDP anchors ──
         # IDP rows sit deeper in the unified board (smaller pool, later
         # calibration) and their confidence buckets lean "low" because
@@ -371,10 +372,26 @@ class TestPlayerRankingsUnchanged(unittest.TestCase):
         # for elite IDPs like Parsons/Garrett who industry-consensus
         # rank below IDPTC's view of them.  Bands tracked to the new
         # neutral-calibration equilibrium.
-        "Myles Garrett":    {"max_rank": 150, "min_value": 3400, "allowed_buckets": ("low", "medium", "high")},
-        "Will Anderson":    {"max_rank": 120, "min_value": 3400, "allowed_buckets": ("low", "medium", "high")},
-        "Micah Parsons":    {"max_rank": 210, "min_value": 2500, "allowed_buckets": ("low", "medium", "high")},
-        "Fred Warner":      {"max_rank": 150, "min_value": 2800, "allowed_buckets": ("low", "medium", "high")},
+        "Myles Garrett": {
+            "max_rank": 150,
+            "min_value": 3400,
+            "allowed_buckets": ("low", "medium", "high"),
+        },
+        "Will Anderson": {
+            "max_rank": 120,
+            "min_value": 3400,
+            "allowed_buckets": ("low", "medium", "high"),
+        },
+        "Micah Parsons": {
+            "max_rank": 210,
+            "min_value": 2500,
+            "allowed_buckets": ("low", "medium", "high"),
+        },
+        "Fred Warner": {
+            "max_rank": 150,
+            "min_value": 2800,
+            "allowed_buckets": ("low", "medium", "high"),
+        },
         # Roquan max_rank widened 160 → 175 on 2026-04-30 after a
         # routine scrape moved IDPTC's view of him 152 → 165.  That
         # small shift tipped the per-player Hampel outlier filter
@@ -393,8 +410,16 @@ class TestPlayerRankingsUnchanged(unittest.TestCase):
         # (``ds_combined_rank_partner``), so de-inflating DS TEs
         # nudges DS-IDP players ~1 rank; Roquan (borderline Hampel,
         # above) tipped 175 → 176.  Real headroom, not a chase.
-        "Roquan Smith":     {"max_rank": 180, "min_value": 2300, "allowed_buckets": ("low", "medium", "high")},
-        "Kyle Hamilton":    {"max_rank": 200, "min_value": 1800, "allowed_buckets": ("low", "medium", "high")},
+        "Roquan Smith": {
+            "max_rank": 180,
+            "min_value": 2300,
+            "allowed_buckets": ("low", "medium", "high"),
+        },
+        "Kyle Hamilton": {
+            "max_rank": 200,
+            "min_value": 1800,
+            "allowed_buckets": ("low", "medium", "high"),
+        },
     }
 
     def setUp(self) -> None:
@@ -463,8 +488,7 @@ class TestPlayerRankingsUnchanged(unittest.TestCase):
                 (
                     r
                     for r in self.contract.get("playersArray") or []
-                    if r.get("assetClass") == "offense"
-                    and r.get("canonicalConsensusRank")
+                    if r.get("assetClass") == "offense" and r.get("canonicalConsensusRank")
                 ),
                 key=lambda r: int(r["canonicalConsensusRank"]),
             )[:10]

--- a/tests/api/test_pick_rookie_anchor.py
+++ b/tests/api/test_pick_rookie_anchor.py
@@ -13,6 +13,7 @@ the board by value so coherence is preserved.
 
 Run with:  python3 -m pytest tests/api/test_pick_rookie_anchor.py -v
 """
+
 from __future__ import annotations
 
 import json
@@ -63,9 +64,7 @@ class TestAnchorPassCore(unittest.TestCase):
 
         anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
         self.assertEqual(anchored, 12)
-        self.assertEqual(
-            picks[0]["rankDerivedValue"], rookies[0]["rankDerivedValue"]
-        )
+        self.assertEqual(picks[0]["rankDerivedValue"], rookies[0]["rankDerivedValue"])
         self.assertEqual(picks[0]["pickRookieAnchor"], "Rookie 1")
 
     def test_slot_mapping_is_monotonic(self) -> None:
@@ -106,17 +105,14 @@ class TestAnchorPassCore(unittest.TestCase):
 
         _anchor_current_year_picks_to_rookies(players_array, 2026)
 
-        merged_sorted = sorted(
-            offense + idp, key=lambda r: -r["rankDerivedValue"]
-        )
+        merged_sorted = sorted(offense + idp, key=lambda r: -r["rankDerivedValue"])
         for i, pick in enumerate(picks):
             if i >= len(merged_sorted):
                 continue
             self.assertEqual(
                 pick["rankDerivedValue"],
                 merged_sorted[i]["rankDerivedValue"],
-                f"pick {pick['canonicalName']} should match merged "
-                f"rookie #{i+1}",
+                f"pick {pick['canonicalName']} should match merged " f"rookie #{i+1}",
             )
 
     def test_wrong_year_untouched(self) -> None:
@@ -143,10 +139,7 @@ class TestAnchorPassCore(unittest.TestCase):
         self.assertNotIn("pickRookieAnchor", tier_pick)
 
     def test_no_rookies_is_noop(self) -> None:
-        picks = [
-            _make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 5000 - s * 10)
-            for s in range(1, 13)
-        ]
+        picks = [_make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 5000 - s * 10) for s in range(1, 13)]
         before = [p["rankDerivedValue"] for p in picks]
         anchored = _anchor_current_year_picks_to_rookies(picks, 2026)
         self.assertEqual(anchored, 0)
@@ -252,12 +245,8 @@ class TestAnchorEndToEnd(unittest.TestCase):
         )
         if pick_101 is None:
             self.skipTest("No 2026 Pick 1.01 in contract")
-        self.assertEqual(
-            pick_101.get("rankDerivedValue"), rookies[0]["rankDerivedValue"]
-        )
-        self.assertEqual(
-            pick_101.get("pickRookieAnchor"), rookies[0]["canonicalName"]
-        )
+        self.assertEqual(pick_101.get("rankDerivedValue"), rookies[0]["rankDerivedValue"])
+        self.assertEqual(pick_101.get("pickRookieAnchor"), rookies[0]["canonicalName"])
 
     def test_2026_slot_picks_have_null_canonical_rank(self) -> None:
         """2026 slot picks are proxies for their anchor rookie; they
@@ -265,7 +254,8 @@ class TestAnchorEndToEnd(unittest.TestCase):
         rank so players aren't pushed down a slot by each pick row."""
         rows = self.contract["playersArray"]
         slot_picks = [
-            r for r in rows
+            r
+            for r in rows
             if r.get("assetClass") == "pick"
             and isinstance(r.get("canonicalName"), str)
             and r["canonicalName"].startswith("2026 Pick ")
@@ -284,7 +274,8 @@ class TestAnchorEndToEnd(unittest.TestCase):
         # instead of it. (Some deep rookie slots may have no rookie
         # match; skipping to a pick that does is sufficient.)
         anchored = [
-            p for p in slot_picks
+            p
+            for p in slot_picks
             if p.get("rankDerivedValue") and int(p.get("rankDerivedValue")) > 0
         ]
         self.assertTrue(
@@ -299,18 +290,17 @@ class TestAnchorEndToEnd(unittest.TestCase):
         canonicalConsensusRank. Other pick types (tier-generic
         ``2026 Early 1st``, ``2027 Pick 1.01``) may still hold ranks
         and are checked separately."""
-        ranked = [
-            r for r in self.contract["playersArray"]
-            if r.get("canonicalConsensusRank")
-        ]
+        ranked = [r for r in self.contract["playersArray"] if r.get("canonicalConsensusRank")]
         offenders = [
-            r for r in ranked
+            r
+            for r in ranked
             if r.get("assetClass") == "pick"
             and isinstance(r.get("canonicalName"), str)
             and r["canonicalName"].startswith("2026 Pick ")
         ]
         self.assertEqual(
-            offenders, [],
+            offenders,
+            [],
             f"2026 slot picks still hold ranks: "
             f"{[r.get('canonicalName') for r in offenders[:3]]}",
         )
@@ -324,19 +314,18 @@ class TestAnchorEndToEnd(unittest.TestCase):
         """
         rows = self.contract["playersArray"]
         picks = [
-            r for r in rows
+            r
+            for r in rows
             if r.get("assetClass") == "pick"
             and isinstance(r.get("canonicalName"), str)
             and r["canonicalName"].startswith("2026 Pick ")
         ]
         if len(picks) < 72:
             self.skipTest(f"Only {len(picks)} 2026 slot picks in contract")
-        untethered = [
-            p.get("canonicalName") for p in picks
-            if not p.get("pickRookieAnchor")
-        ]
+        untethered = [p.get("canonicalName") for p in picks if not p.get("pickRookieAnchor")]
         self.assertEqual(
-            untethered, [],
+            untethered,
+            [],
             f"2026 slot picks still untethered: {untethered[:5]}.  "
             f"The combined offense+IDP rookie pool (including tail "
             f"rookies with _blendedValueUncapped) should cover all "
@@ -345,11 +334,7 @@ class TestAnchorEndToEnd(unittest.TestCase):
 
     def test_coherence_preserved_after_anchor(self) -> None:
         ranked = sorted(
-            [
-                r
-                for r in self.contract["playersArray"]
-                if r.get("canonicalConsensusRank")
-            ],
+            [r for r in self.contract["playersArray"] if r.get("canonicalConsensusRank")],
             key=lambda r: int(r["canonicalConsensusRank"]),
         )
         errors = assert_ranking_coherence(ranked)
@@ -370,9 +355,7 @@ class TestAnchorEndToEnd(unittest.TestCase):
             arr_rank = row.get("canonicalConsensusRank")
             leg_rank = legacy[legacy_ref].get("_canonicalConsensusRank")
             if arr_rank != leg_rank:
-                mismatches.append(
-                    f"{row.get('canonicalName')}: array={arr_rank} legacy={leg_rank}"
-                )
+                mismatches.append(f"{row.get('canonicalName')}: array={arr_rank} legacy={leg_rank}")
                 if len(mismatches) >= 5:
                     break
         self.assertEqual(mismatches, [])

--- a/tests/api/test_picks_end_to_end.py
+++ b/tests/api/test_picks_end_to_end.py
@@ -25,6 +25,7 @@ regress:
 
 Run with:  python3 -m pytest tests/api/test_picks_end_to_end.py -v
 """
+
 from __future__ import annotations
 
 import csv
@@ -57,12 +58,8 @@ def _load_contract() -> dict[str, Any] | None:
     return build_api_data_contract(raw)
 
 
-_DEEP_TIER_GENERIC_RE = re.compile(
-    r"^(20\d{2})\s+(Early|Mid|Late)\s+([1-6])(st|nd|rd|th)$", re.I
-)
-_DEEP_TIER_SLOT_RE = re.compile(
-    r"^(20\d{2})\s+Pick\s+([1-6])\.\d{1,2}$", re.I
-)
+_DEEP_TIER_GENERIC_RE = re.compile(r"^(20\d{2})\s+(Early|Mid|Late)\s+([1-6])(st|nd|rd|th)$", re.I)
+_DEEP_TIER_SLOT_RE = re.compile(r"^(20\d{2})\s+Pick\s+([1-6])\.\d{1,2}$", re.I)
 
 
 def _is_deep_future_tier(name: str) -> bool:
@@ -111,6 +108,7 @@ def _slot_pick_round(name: str) -> int | None:
     """Extract round number from a slot-specific pick name like
     '2026 Pick 3.06'. Returns None for non-slot-pick names."""
     import re
+
     m = re.match(r"^\d{4}\s+Pick\s+(\d+)\.\d+$", str(name or "").strip())
     if m:
         try:
@@ -121,19 +119,11 @@ def _slot_pick_round(name: str) -> int | None:
 
 
 def _pick_rows(contract: dict[str, Any]) -> list[dict[str, Any]]:
-    return [
-        r
-        for r in contract.get("playersArray", [])
-        if r.get("assetClass") == "pick"
-    ]
+    return [r for r in contract.get("playersArray", []) if r.get("assetClass") == "pick"]
 
 
 def _player_rows(contract: dict[str, Any]) -> list[dict[str, Any]]:
-    return [
-        r
-        for r in contract.get("playersArray", [])
-        if r.get("assetClass") != "pick"
-    ]
+    return [r for r in contract.get("playersArray", []) if r.get("assetClass") != "pick"]
 
 
 class TestPicksPresentInContract(unittest.TestCase):
@@ -196,15 +186,11 @@ class TestPicksPresentInContract(unittest.TestCase):
         ]
         # Allow at most a handful of deep-tier dropouts (R5/R6 future
         # years).  Any larger count is a regression in the discount.
-        unexpected = [
-            n for n in missing
-            if not _is_deep_future_tier(n)
-        ]
+        unexpected = [n for n in missing if not _is_deep_future_tier(n)]
         self.assertEqual(
             unexpected,
             [],
-            f"Picks missing rank/value (excluding deep-tier dropouts): "
-            f"{unexpected[:10]}",
+            f"Picks missing rank/value (excluding deep-tier dropouts): " f"{unexpected[:10]}",
         )
         # 2026 slot picks in rounds 1-4 must have VALUE (anchored to
         # the corresponding rookie). Later-round slot picks depend on
@@ -213,17 +199,19 @@ class TestPicksPresentInContract(unittest.TestCase):
         # anchored value — this mirrors the pre-change behaviour where
         # those picks had tier-value approximations only.
         slot_2026_early = [
-            p for p in picks
+            p
+            for p in picks
             if str(p.get("canonicalName") or "").startswith("2026 Pick ")
             and _slot_pick_round(p.get("canonicalName") or "") in (1, 2, 3, 4)
         ]
         value_missing = [
-            p["canonicalName"] for p in slot_2026_early
-            if not p.get("rankDerivedValue")
-            or p.get("rankDerivedValue", 0) <= 0
+            p["canonicalName"]
+            for p in slot_2026_early
+            if not p.get("rankDerivedValue") or p.get("rankDerivedValue", 0) <= 0
         ]
         self.assertEqual(
-            value_missing, [],
+            value_missing,
+            [],
             f"2026 rounds 1-4 slot picks missing anchored value: {value_missing[:5]}",
         )
 
@@ -240,9 +228,7 @@ class TestPicksPresentInContract(unittest.TestCase):
             and not p.get("pickGenericSuppressed")
             and not _is_deep_future_tier(p["canonicalName"])
         ]
-        self.assertEqual(
-            empty, [], f"Picks with no sourceRanks: {empty[:10]}"
-        )
+        self.assertEqual(empty, [], f"Picks with no sourceRanks: {empty[:10]}")
 
 
 class TestPickCanonicalIdentity(unittest.TestCase):
@@ -255,11 +241,7 @@ class TestPickCanonicalIdentity(unittest.TestCase):
 
     def test_pick_names_match_pick_detector(self) -> None:
         picks = _pick_rows(self.contract)
-        bad = [
-            p["canonicalName"]
-            for p in picks
-            if not _is_pick_name(p["canonicalName"] or "")
-        ]
+        bad = [p["canonicalName"] for p in picks if not _is_pick_name(p["canonicalName"] or "")]
         self.assertEqual(
             bad,
             [],
@@ -275,16 +257,13 @@ class TestPickCanonicalIdentity(unittest.TestCase):
         self.assertEqual(
             collisions,
             set(),
-            f"Pick canonical names collide with player names: "
-            f"{sorted(collisions)[:5]}",
+            f"Pick canonical names collide with player names: " f"{sorted(collisions)[:5]}",
         )
 
     def test_no_player_name_accidentally_flagged_as_pick(self) -> None:
         players = _player_rows(self.contract)
         flagged = [
-            p["canonicalName"]
-            for p in players
-            if _is_pick_name(p.get("canonicalName") or "")
+            p["canonicalName"] for p in players if _is_pick_name(p.get("canonicalName") or "")
         ]
         self.assertEqual(
             flagged,
@@ -307,11 +286,7 @@ class TestPicksDoNotBreakSafetyRails(unittest.TestCase):
         # responsible for sorting by rank first.  Existing coherence
         # tests (tests/api/test_ranking_coherence.py) sort the same way.
         ranked = sorted(
-            [
-                r
-                for r in self.contract["playersArray"]
-                if r.get("canonicalConsensusRank")
-            ],
+            [r for r in self.contract["playersArray"] if r.get("canonicalConsensusRank")],
             key=lambda r: int(r["canonicalConsensusRank"]),
         )
         errors = assert_ranking_coherence(ranked)
@@ -352,9 +327,7 @@ class TestIdpTradeCalcPicksSurviveEnrichment(unittest.TestCase):
     def test_idptc_picks_all_present_in_contract(self) -> None:
         if not self.csv_picks:
             self.skipTest("No picks in idpTradeCalc.csv")
-        contract_pick_names = {
-            p["canonicalName"] for p in _pick_rows(self.contract)
-        }
+        contract_pick_names = {p["canonicalName"] for p in _pick_rows(self.contract)}
         missing = [n for n in self.csv_picks if n not in contract_pick_names]
         self.assertEqual(
             missing,
@@ -371,16 +344,14 @@ class TestRepresentativePicks(unittest.TestCase):
         "2026 Pick 1.06",  # mid-1st, slot-specific
         "2026 Pick 1.12",  # late-1st, slot-specific
         "2026 Pick 2.06",  # mid-2nd, slot-specific
-        "2027 Mid 1st",    # generic future 1st
+        "2027 Mid 1st",  # generic future 1st
     ]
 
     def setUp(self) -> None:
         self.contract = _load_contract()
         if self.contract is None:
             self.skipTest("No live scraper export available")
-        self.by_name = {
-            p["canonicalName"]: p for p in _pick_rows(self.contract)
-        }
+        self.by_name = {p["canonicalName"]: p for p in _pick_rows(self.contract)}
 
     def test_targets_have_rank_and_value(self) -> None:
         # 2026 slot-specific picks are intentionally un-ranked — they
@@ -390,9 +361,7 @@ class TestRepresentativePicks(unittest.TestCase):
         for name in self.TARGETS:
             with self.subTest(pick=name):
                 row = self.by_name.get(name)
-                self.assertIsNotNone(
-                    row, f"{name} missing from pick contract output"
-                )
+                self.assertIsNotNone(row, f"{name} missing from pick contract output")
                 assert row is not None
                 is_2026_slot = name.startswith("2026 Pick ")
                 if is_2026_slot:
@@ -462,13 +431,11 @@ class TestRepresentativePicks(unittest.TestCase):
                 continue
             legacy_value = legacy_row.get("rankDerivedValue")
             if legacy_value != pa_value:
-                mismatched.append(
-                    f"{name}: playersArray={pa_value} legacy={legacy_value}"
-                )
+                mismatched.append(f"{name}: playersArray={pa_value} legacy={legacy_value}")
         self.assertEqual(
-            mismatched, [],
-            f"Anchored slot picks lost value in legacy mirror:\n"
-            + "\n".join(mismatched[:10]),
+            mismatched,
+            [],
+            f"Anchored slot picks lost value in legacy mirror:\n" + "\n".join(mismatched[:10]),
         )
 
 
@@ -514,11 +481,10 @@ class TestPickValueProjections(unittest.TestCase):
                 "pickProjectedDraftValueGainPct",
             ):
                 if row.get(field) is None:
-                    missing_stamps.append(
-                        f"{row.get('canonicalName')}: missing {field}"
-                    )
+                    missing_stamps.append(f"{row.get('canonicalName')}: missing {field}")
         self.assertEqual(
-            missing_stamps, [],
+            missing_stamps,
+            [],
             "Every valued pick must stamp the full projection block:\n"
             + "\n".join(missing_stamps[:10]),
         )
@@ -528,7 +494,8 @@ class TestPickValueProjections(unittest.TestCase):
         ``pickYearDiscount == 1.0`` (or unstamped, equivalent), so the
         projection equals today's value with zero gain."""
         baseline_picks = [
-            r for r in self.picks
+            r
+            for r in self.picks
             if int(r.get("pickProjectedDraftYear") or 0) == 2026
             and (r.get("rankDerivedValue") or 0) > 0
         ]
@@ -550,7 +517,8 @@ class TestPickValueProjections(unittest.TestCase):
         applied, so the projection inverts to a value strictly above
         today's.  Pin the math: projected = round(rdv / discount)."""
         future_picks = [
-            r for r in self.picks
+            r
+            for r in self.picks
             if int(r.get("pickProjectedDraftYear") or 0) >= 2027
             and (r.get("rankDerivedValue") or 0) > 0
             and r.get("pickYearDiscount") is not None
@@ -571,7 +539,8 @@ class TestPickValueProjections(unittest.TestCase):
                     f"expected≈{expected}, got {actual}",
                 )
                 self.assertGreater(
-                    actual, int(rdv),
+                    actual,
+                    int(rdv),
                     f"future-year pick must project ABOVE today's value: "
                     f"rdv={rdv}, projected={actual}",
                 )
@@ -588,9 +557,7 @@ class TestPickValueProjections(unittest.TestCase):
             with self.subTest(pick=row.get("canonicalName")):
                 name = str(row.get("canonicalName") or "")
                 m = re.search(r"\b(20\d{2})\b", name)
-                self.assertIsNotNone(
-                    m, f"pick name lacks a year but has projection stamp: {name}"
-                )
+                self.assertIsNotNone(m, f"pick name lacks a year but has projection stamp: {name}")
                 assert m is not None
                 self.assertEqual(int(year_stamp), int(m.group(1)))
 

--- a/tests/api/test_player_identity_regression.py
+++ b/tests/api/test_player_identity_regression.py
@@ -25,6 +25,7 @@ The tests are deterministic and run on the current
 ``exports/latest/dynasty_data_*.json`` snapshot — they do not require
 network or a running scraper.
 """
+
 from __future__ import annotations
 
 import json
@@ -210,27 +211,27 @@ TARGET_PLAYERS = [
     # The headline 1-src bug players
     ("Kenneth Walker", "OFFENSE", True),
     ("Marvin Harrison", "OFFENSE", True),
-    ("Brian Thomas",    "OFFENSE", True),
+    ("Brian Thomas", "OFFENSE", True),
     # Near-name collision noise targets
-    ("Quay Walker",     "IDP", True),
-    ("Jalon Walker",    "IDP", True),
-    ("CJ Allen",        "IDP", True),
-    ("Payton Wilson",   "IDP", True),
-    ("Nick Emmanwori",  "IDP", True),
+    ("Quay Walker", "IDP", True),
+    ("Jalon Walker", "IDP", True),
+    ("CJ Allen", "IDP", True),
+    ("Payton Wilson", "IDP", True),
+    ("Nick Emmanwori", "IDP", True),
     # Elite IDP cornerstones (should be cleanly multi-src in top board)
     ("Aidan Hutchinson", "IDP", True),
-    ("Will Anderson",    "IDP", True),
-    ("Micah Parsons",    "IDP", True),
+    ("Will Anderson", "IDP", True),
+    ("Micah Parsons", "IDP", True),
     ("Carson Schwesinger", "IDP", True),
-    ("Jack Campbell",    "IDP", True),
-    ("Fred Warner",      "IDP", True),
-    ("Nick Bosa",        "IDP", True),
-    ("Brian Burns",      "IDP", True),
-    ("Roquan Smith",     "IDP", True),
-    ("T.J. Watt",        "IDP", True),
-    ("Danielle Hunter",  "IDP", True),
-    ("Brian Branch",     "IDP", True),
-    ("Kyle Hamilton",    "IDP", True),
+    ("Jack Campbell", "IDP", True),
+    ("Fred Warner", "IDP", True),
+    ("Nick Bosa", "IDP", True),
+    ("Brian Burns", "IDP", True),
+    ("Roquan Smith", "IDP", True),
+    ("T.J. Watt", "IDP", True),
+    ("Danielle Hunter", "IDP", True),
+    ("Brian Branch", "IDP", True),
+    ("Kyle Hamilton", "IDP", True),
 ]
 
 
@@ -241,9 +242,7 @@ class TestTargetPlayerSourceAudit(unittest.TestCase):
     def setUpClass(cls):
         cls.payload = _latest_dynasty_payload()
         cls.contract = build_api_data_contract(cls.payload)
-        cls.by_name = {
-            r["canonicalName"]: r for r in cls.contract["playersArray"]
-        }
+        cls.by_name = {r["canonicalName"]: r for r in cls.contract["playersArray"]}
 
     def _row(self, name):
         row = self.by_name.get(name)
@@ -272,13 +271,16 @@ class TestTargetPlayerSourceAudit(unittest.TestCase):
                 self.assertIn("expectedSources", audit)
                 self.assertIn("matchedSources", audit)
                 self.assertIn("reason", audit)
-                self.assertIn(audit["reason"], {
-                    "fully_matched",
-                    "partial_coverage",
-                    "structurally_single_source",
-                    "matching_failure_other_sources_eligible",
-                    "no_source_match",
-                })
+                self.assertIn(
+                    audit["reason"],
+                    {
+                        "fully_matched",
+                        "partial_coverage",
+                        "structurally_single_source",
+                        "matching_failure_other_sources_eligible",
+                        "no_source_match",
+                    },
+                )
 
     def test_target_players_in_top_board_have_canonical_rank(self):
         for name, _, expected_top in TARGET_PLAYERS:
@@ -330,13 +332,13 @@ class TestTargetPlayerSourceAudit(unittest.TestCase):
 # must be accompanied by a one-line rationale so future maintainers
 # can see why it was added.
 KNOWN_TOP_BOARD_SINGLE_SOURCE_ALLOWLIST: dict[str, str] = {
-    "Kenneth Walker":  "IDPTradeCalc upstream feed has no entry under Kenneth Walker / Kenneth Walker III",
+    "Kenneth Walker": "IDPTradeCalc upstream feed has no entry under Kenneth Walker / Kenneth Walker III",
     "Marvin Harrison": "IDPTradeCalc upstream feed has no entry under Marvin Harrison / Marvin Harrison Jr.",
-    "Brian Thomas":    "IDPTradeCalc upstream feed has no entry under Brian Thomas / Brian Thomas Jr.",
-    "Michael Penix":   "IDPTradeCalc upstream feed has no entry under Michael Penix / Michael Penix Jr.",
-    "Omar Cooper":     "Indiana WR (current college rookie) — not yet listed in IDPTradeCalc autocomplete",
-    "Devin Bush":      "Veteran depth IDP — outside DLF top-185 cut",
-    "David Bailey":    "Edge rookie IDP — only FantasyPros IDP covers him; moved into top-200 after 2026 slot picks were un-ranked",
+    "Brian Thomas": "IDPTradeCalc upstream feed has no entry under Brian Thomas / Brian Thomas Jr.",
+    "Michael Penix": "IDPTradeCalc upstream feed has no entry under Michael Penix / Michael Penix Jr.",
+    "Omar Cooper": "Indiana WR (current college rookie) — not yet listed in IDPTradeCalc autocomplete",
+    "Devin Bush": "Veteran depth IDP — outside DLF top-185 cut",
+    "David Bailey": "Edge rookie IDP — only FantasyPros IDP covers him; moved into top-200 after 2026 slot picks were un-ranked",
     # ── IDP top-board 1-src that surfaced after the IDP Hill curve
     # was refit to IDPTC (midpoint 69.50 / slope 0.945).  The steeper
     # top-of-curve elevation pulled these into the top 200 where they
@@ -348,7 +350,7 @@ KNOWN_TOP_BOARD_SINGLE_SOURCE_ALLOWLIST: dict[str, str] = {
     # appear_on_board) requires every allowlist entry to be on the
     # live contract; restore the entry if he climbs back into the
     # window.
-    "Malachi Moore":   "Veteran S only ranked by FantasyPros IDP — IDPTC/FBG haven't picked him up",
+    "Malachi Moore": "Veteran S only ranked by FantasyPros IDP — IDPTC/FBG haven't picked him up",
     # Lavonte David removed 2026-04-25: 36yo FA, FBG dropped him in
     # the latest scrape and he no longer appears on the live board.
     # Allowlist entries must reflect a player who CURRENTLY exists on
@@ -361,11 +363,11 @@ KNOWN_TOP_BOARD_SINGLE_SOURCE_ALLOWLIST: dict[str, str] = {
     # the 250-400 tail).  Each is a genuine FBG-only veteran that
     # IDPTC, DLF IDP, and the other IDP boards have either dropped or
     # never carried. ──
-    "DaRon Bland":      "Veteran CB only ranked by FootballGuys IDP",
-    "Jordan Davis":     "Veteran DL only ranked by FootballGuys IDP",
-    "Marlon Humphrey":  "Veteran CB only ranked by FootballGuys IDP",
-    "Mike Jackson":     "Veteran CB only ranked by FootballGuys IDP",
-    "Nahshon Wright":   "Veteran CB only ranked by FootballGuys IDP",
+    "DaRon Bland": "Veteran CB only ranked by FootballGuys IDP",
+    "Jordan Davis": "Veteran DL only ranked by FootballGuys IDP",
+    "Marlon Humphrey": "Veteran CB only ranked by FootballGuys IDP",
+    "Mike Jackson": "Veteran CB only ranked by FootballGuys IDP",
+    "Nahshon Wright": "Veteran CB only ranked by FootballGuys IDP",
 }
 
 
@@ -518,24 +520,18 @@ class TestExpectedSourcesRefinement(unittest.TestCase):
     """
 
     def test_rookie_idp_player_does_not_expect_dlf(self):
-        off, idp = _expected_sources_for_position(
-            "LB", is_rookie=True, player_effective_rank=120
-        )
+        off, idp = _expected_sources_for_position("LB", is_rookie=True, player_effective_rank=120)
         self.assertNotIn("dlfIdp", off | idp)
         self.assertIn("idpTradeCalc", off | idp)
 
     def test_veteran_idp_inside_dlf_depth_expects_dlf(self):
-        off, idp = _expected_sources_for_position(
-            "LB", is_rookie=False, player_effective_rank=50
-        )
+        off, idp = _expected_sources_for_position("LB", is_rookie=False, player_effective_rank=50)
         self.assertIn("dlfIdp", off | idp)
         self.assertIn("idpTradeCalc", off | idp)
 
     def test_veteran_idp_beyond_dlf_depth_does_not_expect_dlf(self):
         # 250 > 185 * 1.25 = ~231 → DLF dropped from expected set.
-        off, idp = _expected_sources_for_position(
-            "LB", is_rookie=False, player_effective_rank=300
-        )
+        off, idp = _expected_sources_for_position("LB", is_rookie=False, player_effective_rank=300)
         self.assertNotIn("dlfIdp", off | idp)
         self.assertIn("idpTradeCalc", off | idp)
 

--- a/tests/api/test_private_auth.py
+++ b/tests/api/test_private_auth.py
@@ -9,6 +9,7 @@ rankings contract.
 These tests pin that gate.  It's the core privacy guarantee for
 this deployment.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -43,9 +44,13 @@ PRIVATE_API_PATHS = [
     "/api/admin/signal-state/migrate",
 ]
 PRIVATE_POST_PATHS = {
-    "/api/trade/suggestions", "/api/trade/finder", "/api/trade/simulate",
+    "/api/trade/suggestions",
+    "/api/trade/finder",
+    "/api/trade/simulate",
     "/api/trade/simulate-mc",
-    "/api/angle/find", "/api/angle/packages", "/api/rankings/overrides",
+    "/api/angle/find",
+    "/api/angle/packages",
+    "/api/rankings/overrides",
     # Phase 11 admin endpoints
     "/api/admin/nfl-data/flush",
     "/api/admin/sessions/force-logout-all",
@@ -62,9 +67,7 @@ def test_private_api_paths_require_auth(path):
             res = c.post(path, json={})
         else:
             res = c.get(path)
-    assert res.status_code == 401, (
-        f"{path} leaked without auth: {res.status_code} {res.text[:200]}"
-    )
+    assert res.status_code == 401, f"{path} leaked without auth: {res.status_code} {res.text[:200]}"
     body = res.json()
     assert body.get("error") == "auth_required"
 
@@ -97,9 +100,9 @@ def test_public_api_paths_pass_without_auth(path):
     the login flow + the public-league pipeline."""
     with TestClient(server.app, raise_server_exceptions=True) as c:
         res = c.get(path)
-    assert res.status_code != 401, (
-        f"{path} requires auth unexpectedly: {res.status_code} {res.text[:200]}"
-    )
+    assert (
+        res.status_code != 401
+    ), f"{path} requires auth unexpectedly: {res.status_code} {res.text[:200]}"
 
 
 def test_public_league_prefix_passes_without_auth():
@@ -130,9 +133,8 @@ def test_allowlist_reads_env_var_lowercased():
     """Module-level parse must lowercase + split comma-separated
     entries in the env var."""
     import os
+
     expected = frozenset(
-        u.strip().lower()
-        for u in "JasonLeeTucker, AnotherUser".split(",")
-        if u.strip()
+        u.strip().lower() for u in "JasonLeeTucker, AnotherUser".split(",") if u.strip()
     )
     assert expected == {"jasonleetucker", "anotheruser"}

--- a/tests/api/test_public_activity_valuation.py
+++ b/tests/api/test_public_activity_valuation.py
@@ -9,6 +9,7 @@ is a frontend-only rename).  An earlier version of this bridge
 assumed ``values.full`` and silently disabled public trade grading
 in production; this test would have caught that immediately.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -116,19 +117,23 @@ class BuildValuationFromContractTests(unittest.TestCase):
         self.assertIsNotNone(valuation)
         # ID miss → name fallback (case-insensitive).
         self.assertEqual(
-            valuation({
-                "kind": "player",
-                "playerId": "unknown-id",
-                "playerName": "Jahmyr Gibbs",
-            }),
+            valuation(
+                {
+                    "kind": "player",
+                    "playerId": "unknown-id",
+                    "playerName": "Jahmyr Gibbs",
+                }
+            ),
             7500.0,
         )
         self.assertEqual(
-            valuation({
-                "kind": "player",
-                "playerId": "",
-                "playerName": "JAHMYR GIBBS",
-            }),
+            valuation(
+                {
+                    "kind": "player",
+                    "playerId": "",
+                    "playerName": "JAHMYR GIBBS",
+                }
+            ),
             7500.0,
         )
 

--- a/tests/api/test_push_delivery.py
+++ b/tests/api/test_push_delivery.py
@@ -4,6 +4,7 @@ We don't drive an actual webpush server here — we monkeypatch the
 ``send_push`` function to confirm the fanout helper walks every
 subscription and forwards prune signals correctly.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -26,24 +27,30 @@ def test_upsert_dedupes_by_endpoint():
 
 def test_upsert_appends_distinct_endpoints():
     state: dict = {}
-    state["pushSubscriptions"] = pd.upsert_subscription(state, {
-        "endpoint": "https://example.com/push/a",
-        "keys": {"p256dh": "p1", "auth": "a1"},
-    })
-    state["pushSubscriptions"] = pd.upsert_subscription(state, {
-        "endpoint": "https://example.com/push/b",
-        "keys": {"p256dh": "p2", "auth": "a2"},
-    })
+    state["pushSubscriptions"] = pd.upsert_subscription(
+        state,
+        {
+            "endpoint": "https://example.com/push/a",
+            "keys": {"p256dh": "p1", "auth": "a1"},
+        },
+    )
+    state["pushSubscriptions"] = pd.upsert_subscription(
+        state,
+        {
+            "endpoint": "https://example.com/push/b",
+            "keys": {"p256dh": "p2", "auth": "a2"},
+        },
+    )
     assert len(state["pushSubscriptions"]) == 2
 
 
 @pytest.mark.parametrize(
     "bad",
     [
-        {"keys": {"p256dh": "p", "auth": "a"}},                     # no endpoint
-        {"endpoint": "https://x", "keys": {}},                       # no key fields
-        {"endpoint": "https://x", "keys": {"p256dh": "p"}},          # missing auth
-        {"endpoint": "https://x"},                                    # no keys
+        {"keys": {"p256dh": "p", "auth": "a"}},  # no endpoint
+        {"endpoint": "https://x", "keys": {}},  # no key fields
+        {"endpoint": "https://x", "keys": {"p256dh": "p"}},  # missing auth
+        {"endpoint": "https://x"},  # no keys
     ],
 )
 def test_upsert_rejects_malformed_subscription(bad):
@@ -52,31 +59,37 @@ def test_upsert_rejects_malformed_subscription(bad):
 
 
 def test_remove_subscription_filters_by_endpoint():
-    state = {"pushSubscriptions": [
-        {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
-        {"endpoint": "https://x/b", "keys": {"p256dh": "p", "auth": "a"}},
-    ]}
+    state = {
+        "pushSubscriptions": [
+            {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
+            {"endpoint": "https://x/b", "keys": {"p256dh": "p", "auth": "a"}},
+        ]
+    }
     new = pd.remove_subscription(state, "https://x/a")
     assert [s["endpoint"] for s in new] == ["https://x/b"]
 
 
 def test_list_subscriptions_filters_invalid_records():
-    state = {"pushSubscriptions": [
-        {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
-        "not-a-dict",
-        {"endpoint": None, "keys": {}},
-    ]}
+    state = {
+        "pushSubscriptions": [
+            {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
+            "not-a-dict",
+            {"endpoint": None, "keys": {}},
+        ]
+    }
     out = pd.list_subscriptions(state)
     assert len(out) == 1
     assert out[0]["endpoint"] == "https://x/a"
 
 
 def test_fanout_walks_every_subscription_and_collects_prunes(monkeypatch):
-    state = {"pushSubscriptions": [
-        {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
-        {"endpoint": "https://x/b", "keys": {"p256dh": "p", "auth": "a"}},
-        {"endpoint": "https://x/c", "keys": {"p256dh": "p", "auth": "a"}},
-    ]}
+    state = {
+        "pushSubscriptions": [
+            {"endpoint": "https://x/a", "keys": {"p256dh": "p", "auth": "a"}},
+            {"endpoint": "https://x/b", "keys": {"p256dh": "p", "auth": "a"}},
+            {"endpoint": "https://x/c", "keys": {"p256dh": "p", "auth": "a"}},
+        ]
+    }
 
     def fake_send(sub, **_):
         if sub["endpoint"].endswith("a"):

--- a/tests/api/test_rank_history.py
+++ b/tests/api/test_rank_history.py
@@ -7,6 +7,7 @@ Covers:
 * Corrupt-line tolerance on read
 * stamp_contract_with_history mutation
 """
+
 from __future__ import annotations
 
 import json
@@ -72,10 +73,13 @@ class ExtractRanks(unittest.TestCase):
             ]
         }
         ranks = rank_history._extract_ranks(c)
-        self.assertEqual(ranks, {
-            _key("James Williams", "offense"): 78,
-            _key("James Williams", "idp"): 215,
-        })
+        self.assertEqual(
+            ranks,
+            {
+                _key("James Williams", "offense"): 78,
+                _key("James Williams", "idp"): 215,
+            },
+        )
 
     def test_skips_unranked_rows(self) -> None:
         c = {
@@ -90,7 +94,11 @@ class ExtractRanks(unittest.TestCase):
         self.assertEqual(rank_history._extract_ranks(c), {_key("A"): 1})
 
     def test_falls_back_to_displayName(self) -> None:
-        c = {"playersArray": [{"displayName": "Nickname", "canonicalConsensusRank": 9, "assetClass": "offense"}]}
+        c = {
+            "playersArray": [
+                {"displayName": "Nickname", "canonicalConsensusRank": 9, "assetClass": "offense"}
+            ]
+        }
         self.assertEqual(rank_history._extract_ranks(c), {_key("Nickname"): 9})
 
     def test_missing_asset_class_gets_unknown(self) -> None:
@@ -116,21 +124,15 @@ class AppendSnapshot(unittest.TestCase):
             entries = [json.loads(line) for line in path.read_text().splitlines()]
             self.assertEqual(len(entries), 1)
             self.assertEqual(entries[0]["date"], "2026-04-20")
-            self.assertEqual(
-                entries[0]["ranks"], {_key("A"): 1, _key("B"): 2}
-            )
+            self.assertEqual(entries[0]["ranks"], {_key("A"): 1, _key("B"): 2})
 
     def test_idempotent_per_date(self) -> None:
         # Re-running the same date overwrites — the file has exactly
         # one entry for that date after a re-run with different ranks.
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "rank_history.jsonl"
-            rank_history.append_snapshot(
-                _contract_with({"A": 1}), date="2026-04-20", path=path
-            )
-            rank_history.append_snapshot(
-                _contract_with({"A": 5}), date="2026-04-20", path=path
-            )
+            rank_history.append_snapshot(_contract_with({"A": 1}), date="2026-04-20", path=path)
+            rank_history.append_snapshot(_contract_with({"A": 5}), date="2026-04-20", path=path)
             entries = [json.loads(line) for line in path.read_text().splitlines()]
             self.assertEqual(len(entries), 1)
             self.assertEqual(entries[0]["ranks"], {_key("A"): 5})
@@ -284,8 +286,16 @@ class StampContract(unittest.TestCase):
             )
             contract = {
                 "playersArray": [
-                    {"canonicalName": "Ja'Marr Chase", "canonicalConsensusRank": 1, "assetClass": "offense"},
-                    {"canonicalName": "Nobody", "canonicalConsensusRank": 500, "assetClass": "offense"},
+                    {
+                        "canonicalName": "Ja'Marr Chase",
+                        "canonicalConsensusRank": 1,
+                        "assetClass": "offense",
+                    },
+                    {
+                        "canonicalName": "Nobody",
+                        "canonicalConsensusRank": 500,
+                        "assetClass": "offense",
+                    },
                 ]
             }
             stamped = rank_history.stamp_contract_with_history(contract, path=path)
@@ -323,9 +333,7 @@ class StampContract(unittest.TestCase):
             stamped = rank_history.stamp_contract_with_history(contract, path=path)
             self.assertEqual(stamped, 1)
             self.assertIn("rankHistory", contract["players"]["Josh Allen"])
-            self.assertEqual(
-                len(contract["players"]["Josh Allen"]["rankHistory"]), 2
-            )
+            self.assertEqual(len(contract["players"]["Josh Allen"]["rankHistory"]), 2)
 
     def test_infer_asset_class_position_to_class(self) -> None:
         infer = rank_history._infer_asset_class
@@ -340,9 +348,7 @@ class StampContract(unittest.TestCase):
         self.assertEqual(infer({"position": "PICK"}), "pick")
         self.assertEqual(infer({"position": "K"}), "unknown")
         # Explicit assetClass wins over inferred.
-        self.assertEqual(
-            infer({"position": "DL", "assetClass": "offense"}), "offense"
-        )
+        self.assertEqual(infer({"position": "DL", "assetClass": "offense"}), "offense")
 
     def test_infers_pick_from_name_when_no_position_or_asset(self) -> None:
         # Regression for Codex PR #217 round 4: runtime generic-pick
@@ -392,9 +398,7 @@ class StampContract(unittest.TestCase):
             }
             stamped = rank_history.stamp_contract_with_history(contract, path=path)
             self.assertEqual(stamped, 1)
-            self.assertEqual(
-                len(contract["players"]["2026 Early 1st"]["rankHistory"]), 2
-            )
+            self.assertEqual(len(contract["players"]["2026 Early 1st"]["rankHistory"]), 2)
 
     def test_stamps_legacy_players_dict_for_runtime_view(self) -> None:
         # Regression for Codex PR #217 round 2: the runtime view
@@ -422,9 +426,7 @@ class StampContract(unittest.TestCase):
             stamped = rank_history.stamp_contract_with_history(contract, path=path)
             self.assertEqual(stamped, 1)
             self.assertIn("rankHistory", contract["players"]["Test Player"])
-            self.assertEqual(
-                len(contract["players"]["Test Player"]["rankHistory"]), 2
-            )
+            self.assertEqual(len(contract["players"]["Test Player"]["rankHistory"]), 2)
             self.assertNotIn("rankHistory", contract["players"]["Nobody"])
 
     def test_stamps_both_playersArray_and_legacy_dict(self) -> None:
@@ -439,7 +441,11 @@ class StampContract(unittest.TestCase):
             )
             contract = {
                 "playersArray": [
-                    {"canonicalName": "Dual Player", "canonicalConsensusRank": 7, "assetClass": "offense"},
+                    {
+                        "canonicalName": "Dual Player",
+                        "canonicalConsensusRank": 7,
+                        "assetClass": "offense",
+                    },
                 ],
                 "players": {
                     "Dual Player": {"assetClass": "offense"},
@@ -457,8 +463,16 @@ class StampContract(unittest.TestCase):
             rank_history.append_snapshot(
                 {
                     "playersArray": [
-                        {"canonicalName": "Clone", "canonicalConsensusRank": 10, "assetClass": "offense"},
-                        {"canonicalName": "Clone", "canonicalConsensusRank": 200, "assetClass": "idp"},
+                        {
+                            "canonicalName": "Clone",
+                            "canonicalConsensusRank": 10,
+                            "assetClass": "offense",
+                        },
+                        {
+                            "canonicalName": "Clone",
+                            "canonicalConsensusRank": 200,
+                            "assetClass": "idp",
+                        },
                     ],
                 },
                 date="2026-04-19",
@@ -467,7 +481,11 @@ class StampContract(unittest.TestCase):
             # Stamp two contract rows that differ only by asset class.
             contract = {
                 "playersArray": [
-                    {"canonicalName": "Clone", "canonicalConsensusRank": 10, "assetClass": "offense"},
+                    {
+                        "canonicalName": "Clone",
+                        "canonicalConsensusRank": 10,
+                        "assetClass": "offense",
+                    },
                     {"canonicalName": "Clone", "canonicalConsensusRank": 200, "assetClass": "idp"},
                 ]
             }
@@ -499,7 +517,11 @@ class StampContract(unittest.TestCase):
             rank_history.append_snapshot(
                 {
                     "playersArray": [
-                        {"canonicalName": "Bare Legacy", "canonicalConsensusRank": 42, "assetClass": "offense"},
+                        {
+                            "canonicalName": "Bare Legacy",
+                            "canonicalConsensusRank": 42,
+                            "assetClass": "offense",
+                        },
                     ],
                 },
                 date="2026-04-22",
@@ -507,7 +529,12 @@ class StampContract(unittest.TestCase):
             )
             contract = {
                 "playersArray": [
-                    {"canonicalName": "Bare Legacy", "canonicalConsensusRank": 42, "assetClass": "offense", "displayName": "Bare Legacy"},
+                    {
+                        "canonicalName": "Bare Legacy",
+                        "canonicalConsensusRank": 42,
+                        "assetClass": "offense",
+                        "displayName": "Bare Legacy",
+                    },
                 ],
                 "players": {
                     # Mimic the production shape: no assetClass, no position.
@@ -516,6 +543,4 @@ class StampContract(unittest.TestCase):
             }
             rank_history.stamp_contract_with_history(contract, path=path)
             self.assertIn("rankHistory", contract["players"]["Bare Legacy"])
-            self.assertEqual(
-                contract["players"]["Bare Legacy"]["rankHistory"][-1]["rank"], 42
-            )
+            self.assertEqual(contract["players"]["Bare Legacy"]["rankHistory"][-1]["rank"], 42)

--- a/tests/api/test_ranking_coherence.py
+++ b/tests/api/test_ranking_coherence.py
@@ -10,6 +10,7 @@ Hard safety rails:
 4. Frontend helper logic cannot override authoritative ordering.
 5. Backend stamps canonicalTierId on every ranked row.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -41,7 +42,12 @@ def _row(
         "position": position,
         "assetClass": "idp" if position in ("DL", "LB", "DB") else "offense",
         "canonicalSiteValues": sites,
-        "values": {"overall": max(v or 0 for v in sites.values()), "rawComposite": None, "finalAdjusted": None, "displayValue": None},
+        "values": {
+            "overall": max(v or 0 for v in sites.values()),
+            "rawComposite": None,
+            "finalAdjusted": None,
+            "displayValue": None,
+        },
         "sourceCount": 0,
         "sourcePresence": {},
         "rookie": False,
@@ -69,10 +75,7 @@ class TestMonotonicOrdering(unittest.TestCase):
 
     def test_rank_value_never_diverge(self):
         """If rank A < rank B, then value A >= value B (no inversions)."""
-        rows = [
-            _row(f"P{i}", "QB", ktc=9999 - i * 100, idp=9999 - i * 100)
-            for i in range(20)
-        ]
+        rows = [_row(f"P{i}", "QB", ktc=9999 - i * 100, idp=9999 - i * 100) for i in range(20)]
         _compute_unified_rankings(rows, {})
         ranked = sorted(
             [r for r in rows if r.get("canonicalConsensusRank")],
@@ -91,10 +94,7 @@ class TestNoDuplicateRanks(unittest.TestCase):
     """Proof that duplicate ranks are impossible."""
 
     def test_no_duplicate_ranks(self):
-        rows = [
-            _row(f"P{i}", "QB", ktc=9999 - i * 50, idp=9999 - i * 50)
-            for i in range(50)
-        ]
+        rows = [_row(f"P{i}", "QB", ktc=9999 - i * 50, idp=9999 - i * 50) for i in range(50)]
         _compute_unified_rankings(rows, {})
         ranks = [r["canonicalConsensusRank"] for r in rows if r.get("canonicalConsensusRank")]
         self.assertEqual(len(ranks), len(set(ranks)), "Duplicate ranks detected")
@@ -132,10 +132,7 @@ class TestTierAlignment(unittest.TestCase):
 
     def test_tiers_non_decreasing(self):
         """Tier IDs must be non-decreasing when sorted by rank."""
-        rows = [
-            _row(f"P{i}", "QB", ktc=9999 - i * 80, idp=9999 - i * 80)
-            for i in range(100)
-        ]
+        rows = [_row(f"P{i}", "QB", ktc=9999 - i * 80, idp=9999 - i * 80) for i in range(100)]
         _compute_unified_rankings(rows, {})
         ranked = sorted(
             [r for r in rows if r.get("canonicalConsensusRank")],
@@ -144,9 +141,12 @@ class TestTierAlignment(unittest.TestCase):
         prev_tier = 0
         for r in ranked:
             tier = r.get("canonicalTierId")
-            self.assertIsNotNone(tier, f"Row #{r['canonicalConsensusRank']} missing canonicalTierId")
+            self.assertIsNotNone(
+                tier, f"Row #{r['canonicalConsensusRank']} missing canonicalTierId"
+            )
             self.assertGreaterEqual(
-                tier, prev_tier,
+                tier,
+                prev_tier,
                 f"Tier decreased at rank {r['canonicalConsensusRank']}: {tier} < {prev_tier}",
             )
             prev_tier = tier

--- a/tests/api/test_rankings_our_rank.py
+++ b/tests/api/test_rankings_our_rank.py
@@ -18,6 +18,7 @@ The tests below now pin the INVERSE invariant: the frontend lib must
 NOT carry any of the removed symbols.  If someone reintroduces a
 client-side ranking engine these assertions fail loudly.
 """
+
 from __future__ import annotations
 
 import re
@@ -53,6 +54,7 @@ def _strip_comments(src: str) -> str:
 
 # ── Fallback removal guarantee ────────────────────────────────────────────────
 
+
 class TestFallbackRemoved:
     """The frontend ranking fallback was removed; verify the symbols are gone.
 
@@ -78,9 +80,9 @@ class TestFallbackRemoved:
 
     def test_non_canonical_fallback_symbol_is_removed(self):
         src = _strip_comments(_src(NEXT_JS))
-        assert "NON_CANONICAL_FALLBACK" not in src, (
-            "NON_CANONICAL_FALLBACK marker must not be present"
-        )
+        assert (
+            "NON_CANONICAL_FALLBACK" not in src
+        ), "NON_CANONICAL_FALLBACK marker must not be present"
 
     def test_overall_rank_limit_constant_is_removed(self):
         src = _strip_comments(_src(NEXT_JS))
@@ -91,20 +93,19 @@ class TestFallbackRemoved:
 
 # ── Backend-authoritative row materialization ────────────────────────────────
 
+
 class TestBackendAuthoritative:
     """The frontend must read backend-stamped rank/value fields verbatim."""
 
     def test_reads_backend_canonical_consensus_rank(self):
         src = _src(NEXT_JS)
-        assert "canonicalConsensusRank" in src, (
-            "Next.js lib must read backend-computed canonicalConsensusRank"
-        )
+        assert (
+            "canonicalConsensusRank" in src
+        ), "Next.js lib must read backend-computed canonicalConsensusRank"
 
     def test_reads_backend_rank_derived_value(self):
         src = _src(NEXT_JS)
-        assert "rankDerivedValue" in src, (
-            "Next.js lib must read backend-computed rankDerivedValue"
-        )
+        assert "rankDerivedValue" in src, "Next.js lib must read backend-computed rankDerivedValue"
 
     def test_build_rows_is_pure_materializer(self):
         src = _src(NEXT_JS)
@@ -114,6 +115,7 @@ class TestBackendAuthoritative:
 
 # ── Python Hill-curve spot check (backend-only) ──────────────────────────────
 
+
 class TestBackendFormulaIntact:
     """The backend rank-to-value curve is the single source of truth."""
 
@@ -122,18 +124,18 @@ class TestBackendFormulaIntact:
             HILL_MIDPOINT,
             rank_to_value,
         )
+
         assert rank_to_value(1) == 9999, "Rank 1 must produce 9999"
         assert rank_to_value(0) == 0, "Rank 0 must produce 0"
         # Rank == midpoint+1 is the Hill curve's inflection point:
         # v = 1 + 9998/(1 + 1^slope) = 5000 regardless of slope.
         mid_rank = int(round(HILL_MIDPOINT)) + 1
         mid = rank_to_value(mid_rank)
-        assert 4900 <= mid <= 5100, (
-            f"Rank {mid_rank} (midpoint+1) produced {mid}, expected ~5000"
-        )
+        assert 4900 <= mid <= 5100, f"Rank {mid_rank} (midpoint+1) produced {mid}, expected ~5000"
 
 
 # ── Unified rank precedence ──────────────────────────────────────────────────
+
 
 class TestResolvedRankPrecedence:
     """Next.js renderer must use the same rank resolution precedence:

--- a/tests/api/test_rate_limit.py
+++ b/tests/api/test_rate_limit.py
@@ -1,4 +1,5 @@
 """Tests for the public-endpoint rate limiter."""
+
 from __future__ import annotations
 
 import pytest
@@ -20,7 +21,9 @@ def test_first_request_is_never_limited():
 
 def test_bypass_ip_never_limited(monkeypatch):
     monkeypatch.setattr(
-        rate_limit, "_BYPASS_IPS", frozenset({"127.0.0.1"}),
+        rate_limit,
+        "_BYPASS_IPS",
+        frozenset({"127.0.0.1"}),
     )
     for _ in range(200):
         limited, _ = rate_limit.should_rate_limit("127.0.0.1")

--- a/tests/api/test_scope_aware_rankings.py
+++ b/tests/api/test_scope_aware_rankings.py
@@ -17,6 +17,7 @@ category the IDP ranking brief called out:
     F. Edge cases: empty backbone fallback, extrapolation past the tail,
        zero/missing source values
 """
+
 from __future__ import annotations
 
 import copy
@@ -54,8 +55,7 @@ def _row(name: str, pos: str, *, ktc=None, idp=None, extra=None) -> dict:
         "legacyRef": name,
         "position": pos,
         "assetClass": "offense" if pos in {"QB", "RB", "WR", "TE"} else "idp",
-        "values": {"overall": 0, "rawComposite": 0,
-                   "finalAdjusted": 0, "displayValue": None},
+        "values": {"overall": 0, "rawComposite": 0, "finalAdjusted": 0, "displayValue": None},
         "canonicalSiteValues": sites,
         "sourceCount": 1,
     }
@@ -74,12 +74,8 @@ class TestAFullOverallIdpSource(unittest.TestCase):
             _row("db_low", "DB", idp=400),
         ]
         _compute_unified_rankings(rows, {})
-        by_rank = sorted(
-            (r for r in rows if "idpRank" in r), key=lambda r: r["idpRank"]
-        )
-        self.assertEqual(
-            [r["canonicalName"] for r in by_rank], ["dl_top", "lb_mid", "db_low"]
-        )
+        by_rank = sorted((r for r in rows if "idpRank" in r), key=lambda r: r["idpRank"])
+        self.assertEqual([r["canonicalName"] for r in by_rank], ["dl_top", "lb_mid", "db_low"])
         # Overall IDP is direct — no translation metadata should say fallback.
         for r in rows:
             meta = r["sourceRankMeta"]["idpTradeCalc"]
@@ -161,9 +157,14 @@ class TestBPositionOnlySourceTranslation(unittest.TestCase):
         rows = copy.deepcopy(self._fixture_rows)
         # DL3 gets dlTop5 raw rank 3 (only one row with the value).  Its
         # synthetic overall rank must match the backbone ladder DL[2]=5.
-        self._attach_dl_top5(rows, {
-            "dl1": 100, "dl2": 90, "dl3": 80,
-        })
+        self._attach_dl_top5(
+            rows,
+            {
+                "dl1": 100,
+                "dl2": 90,
+                "dl3": 80,
+            },
+        )
         _compute_unified_rankings(rows, {})
         dl3 = next(r for r in rows if r["canonicalName"] == "dl3")
         meta = dl3["sourceRankMeta"]["dlTop5"]
@@ -192,18 +193,23 @@ class TestBPositionOnlySourceTranslation(unittest.TestCase):
         ]
         # Set dlTop5 values for the first five DLs too so their raw ranks
         # take the expected order.
-        self._attach_dl_top5(rows, {
-            "dl1": 100, "dl2": 90, "dl3": 80, "dl4": 75, "dl5": 72,
-        })
+        self._attach_dl_top5(
+            rows,
+            {
+                "dl1": 100,
+                "dl2": 90,
+                "dl3": 80,
+                "dl4": 75,
+                "dl5": 72,
+            },
+        )
         rows.extend(ghosts)
         _compute_unified_rankings(rows, {})
         dl6 = next(r for r in rows if r["canonicalName"] == "dl6")
         dl7 = next(r for r in rows if r["canonicalName"] == "dl7")
         dl8 = next(r for r in rows if r["canonicalName"] == "dl8")
         for g in (dl6, dl7, dl8):
-            self.assertEqual(
-                g["sourceRankMeta"]["dlTop5"]["method"], TRANSLATION_EXTRAPOLATED
-            )
+            self.assertEqual(g["sourceRankMeta"]["dlTop5"]["method"], TRANSLATION_EXTRAPOLATED)
         # Strict monotonicity: each extrapolated synthetic rank > previous.
         r6 = dl6["sourceRankMeta"]["dlTop5"]["effectiveRank"]
         r7 = dl7["sourceRankMeta"]["dlTop5"]["effectiveRank"]
@@ -246,9 +252,9 @@ class TestCCoverageAwareBlending(unittest.TestCase):
         weighting the backbone dominates.
         """
         rows = [
-            _row("dl_backbone_top", "DL", idp=900),   # backbone DL1
-            _row("dl_backbone_two", "DL", idp=800),   # backbone DL2
-            _row("dl_A",            "DL", idp=700),   # backbone DL3
+            _row("dl_backbone_top", "DL", idp=900),  # backbone DL1
+            _row("dl_backbone_two", "DL", idp=800),  # backbone DL2
+            _row("dl_A", "DL", idp=700),  # backbone DL3
         ]
         rows[2]["canonicalSiteValues"]["dlTop5"] = 100  # ← DL1 in shallow list
         _compute_unified_rankings(rows, {})
@@ -326,9 +332,7 @@ class TestDNoOffenseRegression(unittest.TestCase):
             _row("pick1", "PICK", ktc=8000),
         ]
         _compute_unified_rankings(rows, {})
-        by_rank = sorted(
-            (r for r in rows if "ktcRank" in r), key=lambda r: r["ktcRank"]
-        )
+        by_rank = sorted((r for r in rows if "ktcRank" in r), key=lambda r: r["ktcRank"])
         self.assertEqual(
             [r["canonicalName"] for r in by_rank],
             ["qb1", "wr1", "rb1", "pick1"],
@@ -378,8 +382,7 @@ class TestETransparencyFields(unittest.TestCase):
             ):
                 self.assertIn(field, r, f"missing {field} on {r['canonicalName']}")
             # meta dict keys match sourceRanks keys
-            self.assertEqual(set(r["sourceRankMeta"].keys()),
-                             set(r["sourceRanks"].keys()))
+            self.assertEqual(set(r["sourceRankMeta"].keys()), set(r["sourceRanks"].keys()))
 
     def test_legacy_rank_fields_mirror_source_ranks(self):
         rows = [
@@ -573,8 +576,7 @@ class TestHCrossUniverseRanking(unittest.TestCase):
         # above the top IDP, mirroring the production distribution where
         # ~40 offense stars outvalue the #1 DL on IDPTC's combined pool.
         rows = [
-            _row(f"off{i}", "QB" if i % 2 == 0 else "WR",
-                 ktc=9999 - i * 10, idp=9900 - i * 80)
+            _row(f"off{i}", "QB" if i % 2 == 0 else "WR", ktc=9999 - i * 10, idp=9900 - i * 80)
             for i in range(40)
         ]
         rows.append(_row("dl_top", "DL", idp=5963))
@@ -660,12 +662,7 @@ class TestFEdgeCases(unittest.TestCase):
         saved = copy.deepcopy(_RANKING_SOURCES)
         # Remove the backbone (idpTradeCalc) and add a DL-only source.
         _RANKING_SOURCES.clear()
-        _RANKING_SOURCES.extend(
-            [
-                s for s in saved
-                if s["scope"] != SOURCE_SCOPE_OVERALL_IDP
-            ]
-        )
+        _RANKING_SOURCES.extend([s for s in saved if s["scope"] != SOURCE_SCOPE_OVERALL_IDP])
         _RANKING_SOURCES.append(
             {
                 "key": "dlOnly",
@@ -684,9 +681,7 @@ class TestFEdgeCases(unittest.TestCase):
             ]
             _compute_unified_rankings(rows, {})
             dl1 = next(r for r in rows if r["canonicalName"] == "dl1")
-            self.assertEqual(
-                dl1["sourceRankMeta"]["dlOnly"]["method"], TRANSLATION_FALLBACK
-            )
+            self.assertEqual(dl1["sourceRankMeta"]["dlOnly"]["method"], TRANSLATION_FALLBACK)
             self.assertTrue(dl1["idpBackboneFallback"])
         finally:
             _RANKING_SOURCES.clear()

--- a/tests/api/test_served_source_coverage.py
+++ b/tests/api/test_served_source_coverage.py
@@ -10,6 +10,7 @@ CI half is ``test_contract_coverage_watchdog``).  It pins:
   the CI watchdog uses, so the pre-merge and runtime gates can never
   disagree about what "a source is missing" means.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -41,9 +42,7 @@ class TestComputeServedSourceCoverage(unittest.TestCase):
     def test_defensive_on_bad_shapes(self):
         self.assertEqual(server._compute_served_source_coverage(None), {})
         self.assertEqual(server._compute_served_source_coverage({}), {})
-        self.assertEqual(
-            server._compute_served_source_coverage({"playersArray": "nope"}), {}
-        )
+        self.assertEqual(server._compute_served_source_coverage({"playersArray": "nope"}), {})
 
     def test_degraded_board_yields_only_legacy_sources(self):
         # A 3-source legacy board: the gate must see exactly that.
@@ -75,14 +74,10 @@ class TestEvaluateCoverageMapParity(unittest.TestCase):
         wcc._csv_nonempty = self._orig
 
     def test_map_path_equals_contract_path(self):
-        contract = {
-            "playersArray": [{"sourceRankMeta": {_KEY: {}}} for _ in range(40)]
-        }
+        contract = {"playersArray": [{"sourceRankMeta": {_KEY: {}}} for _ in range(40)]}
         freshness = {_KEY: {"ageHours": 0.0}}
         from_contract = evaluate_coverage(contract, freshness, {})
-        from_map = evaluate_coverage_map(
-            _source_coverage(contract), freshness, {}
-        )
+        from_map = evaluate_coverage_map(_source_coverage(contract), freshness, {})
         self.assertEqual(from_contract, from_map)
 
     def test_map_flags_absent_fresh_source(self):

--- a/tests/api/test_session_store.py
+++ b/tests/api/test_session_store.py
@@ -8,6 +8,7 @@ Pins:
   * evict removes a single session.
   * force_clear_all removes everything.
 """
+
 from __future__ import annotations
 
 import time
@@ -53,8 +54,10 @@ def test_hydrate_empty_db_returns_empty_dict(tmp_path):
 def test_allowlist_rotation_invalidates_sessions(tmp_path):
     db = tmp_path / "s.sqlite"
     session_store.persist(
-        "sid-1", {"username": "old_user"},
-        allowlist=["old_user"], db_path=db,
+        "sid-1",
+        {"username": "old_user"},
+        allowlist=["old_user"],
+        db_path=db,
     )
     # Rotate — old_user removed, new_user added.
     session_store._setup_done.clear()  # noqa: SLF001
@@ -67,8 +70,10 @@ def test_ttl_expiry_drops_old_sessions(tmp_path, monkeypatch):
     # Tighten TTL for the test.
     monkeypatch.setattr(session_store, "_SESSION_TTL_SECONDS", 1.0)
     session_store.persist(
-        "sid-fresh", {"username": "u"},
-        allowlist=["u"], db_path=db,
+        "sid-fresh",
+        {"username": "u"},
+        allowlist=["u"],
+        db_path=db,
     )
     time.sleep(1.2)  # force expiry
     session_store._setup_done.clear()  # noqa: SLF001
@@ -92,12 +97,14 @@ def test_persist_on_conflict_updates_last_seen(tmp_path):
     session_store.persist(
         "sid-1",
         {"username": "u", "created_at_epoch": time.time() - 1000},
-        allowlist=["u"], db_path=db,
+        allowlist=["u"],
+        db_path=db,
     )
     session_store.persist(
         "sid-1",
         {"username": "u", "created_at_epoch": time.time() - 1000},
-        allowlist=["u"], db_path=db,
+        allowlist=["u"],
+        db_path=db,
     )
     # Single row, not a duplicate.
     assert session_store.count_active(db_path=db) == 1
@@ -107,8 +114,10 @@ def test_force_clear_all_removes_everything(tmp_path):
     db = tmp_path / "s.sqlite"
     for i in range(5):
         session_store.persist(
-            f"sid-{i}", {"username": "u"},
-            allowlist=["u"], db_path=db,
+            f"sid-{i}",
+            {"username": "u"},
+            allowlist=["u"],
+            db_path=db,
         )
     assert session_store.count_active(db_path=db) == 5
     removed = session_store.force_clear_all(db_path=db)

--- a/tests/api/test_signal_alerts.py
+++ b/tests/api/test_signal_alerts.py
@@ -1,4 +1,5 @@
 """Tests for ``src.api.signal_alerts``."""
+
 from __future__ import annotations
 
 import time
@@ -61,6 +62,7 @@ def test_changed_signal_fires_after_cooldown(kv_path, monkeypatch):
     )
     # Fast-forward well beyond the 12-hour cooldown.
     import src.api.signal_alerts as mod
+
     fake_now = mod._utc_now_ms() + 24 * 3600 * 1000
     monkeypatch.setattr(mod, "_utc_now_ms", lambda: fake_now)
     transitions = signal_alerts.detect_signal_transitions(
@@ -191,7 +193,10 @@ def test_cooldown_is_scoped_per_league(kv_path):
 
     # League A: first fire — transition emitted.
     a1 = signal_alerts.detect_signal_transitions(
-        "alice", [sig], path=kv_path, league_key="dynasty_main",
+        "alice",
+        [sig],
+        path=kv_path,
+        league_key="dynasty_main",
     )
     assert len(a1) == 1
 
@@ -199,18 +204,23 @@ def test_cooldown_is_scoped_per_league(kv_path):
     # this must ALSO fire even though the cooldown in league A
     # just set notifiedAt = now.
     b1 = signal_alerts.detect_signal_transitions(
-        "alice", [sig], path=kv_path, league_key="dynasty_new",
+        "alice",
+        [sig],
+        path=kv_path,
+        league_key="dynasty_new",
     )
     assert len(b1) == 1, (
-        "league B fire suppressed by league A's cooldown — per-league "
-        "bucketing is broken"
+        "league B fire suppressed by league A's cooldown — per-league " "bucketing is broken"
     )
 
     # Re-fire in league A within the cooldown window: correctly
     # suppressed (same-league flicker guard is what the cooldown is
     # for in the first place).
     a2 = signal_alerts.detect_signal_transitions(
-        "alice", [sig], path=kv_path, league_key="dynasty_main",
+        "alice",
+        [sig],
+        path=kv_path,
+        league_key="dynasty_main",
     )
     assert a2 == [], "league A cooldown should still guard same-league flicker"
 
@@ -223,6 +233,7 @@ def test_legacy_flat_state_read_for_default_league(kv_path):
     """
     # Seed a pre-migration state blob.
     from src.api import user_kv
+
     seeded = {
         "signalAlertState": {
             "sid:4017::elite_stable": {
@@ -237,7 +248,9 @@ def test_legacy_flat_state_read_for_default_league(kv_path):
     # suppress.
     sig = _sig("Josh Allen", "elite_stable", "SELL", sid="4017")
     legacy = signal_alerts.detect_signal_transitions(
-        "alice", [sig], path=kv_path,  # no league_key
+        "alice",
+        [sig],
+        path=kv_path,  # no league_key
     )
     assert legacy == [], "legacy flat signalAlertState must still gate cooldowns"
 

--- a/tests/api/test_signal_state_migration.py
+++ b/tests/api/test_signal_state_migration.py
@@ -1,4 +1,5 @@
 """Tests for signalAlertState legacy migration."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/api/test_single_authority.py
+++ b/tests/api/test_single_authority.py
@@ -11,6 +11,7 @@ canonicalTierId, sourceRanks, confidenceBucket, anomalyFlags,
 isSingleSource, or hasSourceDisagreement AFTER build_api_data_contract()
 has produced the playersArray.
 """
+
 from __future__ import annotations
 
 import json
@@ -69,7 +70,9 @@ class TestSingleAuthority(unittest.TestCase):
         for r in ranked[:200]:  # check top 200
             for field in AUTHORITATIVE_FIELDS:
                 if field not in r or r[field] is None:
-                    missing.append(f"#{r.get('canonicalConsensusRank')} {r.get('canonicalName')}: missing {field}")
+                    missing.append(
+                        f"#{r.get('canonicalConsensusRank')} {r.get('canonicalName')}: missing {field}"
+                    )
 
         self.assertEqual(missing, [], f"Missing authoritative fields:\n" + "\n".join(missing[:20]))
 
@@ -115,13 +118,11 @@ class TestSingleAuthority(unittest.TestCase):
         out_of_range = [
             f"#{r['canonicalConsensusRank']}: tier={r.get('canonicalTierId')}"
             for r in ranked
-            if not (
-                isinstance(r.get("canonicalTierId"), int)
-                and r["canonicalTierId"] >= 1
-            )
+            if not (isinstance(r.get("canonicalTierId"), int) and r["canonicalTierId"] >= 1)
         ]
         self.assertEqual(
-            out_of_range, [],
+            out_of_range,
+            [],
             f"Tier IDs must be positive ints:\n" + "\n".join(out_of_range[:10]),
         )
         prev_tier = 0
@@ -134,9 +135,9 @@ class TestSingleAuthority(unittest.TestCase):
                 )
             prev_tier = t
         self.assertEqual(
-            non_monotonic, [],
-            f"Tier IDs must be non-decreasing with rank:\n"
-            + "\n".join(non_monotonic[:10]),
+            non_monotonic,
+            [],
+            f"Tier IDs must be non-decreasing with rank:\n" + "\n".join(non_monotonic[:10]),
         )
 
 
@@ -146,6 +147,7 @@ class TestOverlayRemoved(unittest.TestCase):
     def test_overlay_function_is_absent(self):
         """_apply_canonical_primary_overlay must not exist on the server module."""
         import importlib
+
         try:
             server = importlib.import_module("server")
             self.assertFalse(
@@ -167,7 +169,11 @@ class TestFrontendFallbackGuards(unittest.TestCase):
             "computedConsensusRank": 99,
         }
         # resolvedRank logic: canonicalConsensusRank ?? computedConsensusRank ?? Infinity
-        resolved = row_with_backend.get("canonicalConsensusRank") or row_with_backend.get("computedConsensusRank") or float("inf")
+        resolved = (
+            row_with_backend.get("canonicalConsensusRank")
+            or row_with_backend.get("computedConsensusRank")
+            or float("inf")
+        )
         self.assertEqual(resolved, 42, "Must prefer backend rank over computed")
 
     def test_computed_rank_is_fallback_only(self):
@@ -176,7 +182,11 @@ class TestFrontendFallbackGuards(unittest.TestCase):
             "canonicalConsensusRank": None,
             "computedConsensusRank": 99,
         }
-        resolved = row_without_backend.get("canonicalConsensusRank") or row_without_backend.get("computedConsensusRank") or float("inf")
+        resolved = (
+            row_without_backend.get("canonicalConsensusRank")
+            or row_without_backend.get("computedConsensusRank")
+            or float("inf")
+        )
         self.assertEqual(resolved, 99, "Must fall back to computed rank")
 
 

--- a/tests/api/test_single_curve_live.py
+++ b/tests/api/test_single_curve_live.py
@@ -22,6 +22,7 @@ outright.
 These tests are invariant-band style (PR #154): they assert the
 structural chain holds for today's snapshot, not specific values.
 """
+
 from __future__ import annotations
 
 import json
@@ -91,8 +92,7 @@ class TestOffenseHasNoCalibrationLayer(unittest.TestCase):
                 continue
             if "offenseCalibrationMultiplier" in row:
                 offending.append(
-                    f"{row.get('canonicalName')}: "
-                    f"{row['offenseCalibrationMultiplier']}"
+                    f"{row.get('canonicalName')}: " f"{row['offenseCalibrationMultiplier']}"
                 )
         self.assertFalse(
             offending,
@@ -120,9 +120,7 @@ class TestVolatilityPassIsRemoved(unittest.TestCase):
 
     def test_no_row_carries_prevolatility_stamp(self) -> None:
         offending = [
-            r.get("canonicalName")
-            for r in _ranked_rows(self.contract)
-            if "preVolatilityValue" in r
+            r.get("canonicalName") for r in _ranked_rows(self.contract) if "preVolatilityValue" in r
         ]
         self.assertFalse(
             offending,
@@ -172,9 +170,7 @@ class TestValueChain(unittest.TestCase):
         for row in self.rows:
             for key in banned:
                 if key in row and row.get(key) is not None:
-                    offenders.append(
-                        f"{row.get('canonicalName')}::{key}={row.get(key)}"
-                    )
+                    offenders.append(f"{row.get('canonicalName')}::{key}={row.get(key)}")
                     break
         self.assertFalse(
             offenders,
@@ -242,9 +238,7 @@ class TestHierarchicalAnchorChain(unittest.TestCase):
                 continue
             pos = str(row.get("position") or "").upper()
             expected = _ALPHA_SHRINKAGE if pos in _IDP_POSITIONS else 0.0
-            self.assertAlmostEqual(
-                float(stamped), expected, places=4
-            )
+            self.assertAlmostEqual(float(stamped), expected, places=4)
 
     def test_anchor_plus_shrunk_subgroup_matches_rank_derived_value(self) -> None:
         """For IDP rows with both anchor and subgroup stamped, the
@@ -273,12 +267,7 @@ class TestHierarchicalAnchorChain(unittest.TestCase):
             delta = row.get("subgroupDelta")
             final = row.get("rankDerivedValue")
             mad = row.get("sourceSpread")
-            if (
-                anchor is None
-                or subgroup is None
-                or delta is None
-                or final is None
-            ):
+            if anchor is None or subgroup is None or delta is None or final is None:
                 continue
             # Skip rows where the market-corridor clamp has pulled
             # the final value away from the pure blend output.
@@ -288,9 +277,7 @@ class TestHierarchicalAnchorChain(unittest.TestCase):
             expected_center = float(anchor) + _ALPHA_SHRINKAGE * float(delta)
             expected_penalty = 0.0
             if mad is not None:
-                expected_penalty = min(
-                    expected_center, _MAD_PENALTY_LAMBDA * float(mad)
-                )
+                expected_penalty = min(expected_center, _MAD_PENALTY_LAMBDA * float(mad))
             expected_final = max(0.0, expected_center - expected_penalty)
             self.assertLessEqual(
                 abs(int(final) - int(round(expected_final))),
@@ -321,9 +308,7 @@ class TestHierarchicalAnchorChain(unittest.TestCase):
                 continue
             delta = row.get("subgroupDelta")
             if delta is not None:
-                offenders.append(
-                    f"{row.get('canonicalName')}: subgroupDelta={delta}"
-                )
+                offenders.append(f"{row.get('canonicalName')}: subgroupDelta={delta}")
         self.assertFalse(
             offenders,
             f"Offense rows stamping subgroupDelta — flat blend should "
@@ -364,11 +349,11 @@ class TestMADPenaltyChain(unittest.TestCase):
             mad = row.get("sourceSpread")
             self.assertIsNotNone(
                 mad,
-                f"{row.get('canonicalName')}: multi-source row missing "
-                f"sourceSpread stamp",
+                f"{row.get('canonicalName')}: multi-source row missing " f"sourceSpread stamp",
             )
             self.assertGreaterEqual(
-                float(mad), 0.0,
+                float(mad),
+                0.0,
                 f"{row.get('canonicalName')}: sourceSpread={mad} is negative",
             )
             checked += 1
@@ -405,14 +390,10 @@ class TestMADPenaltyChain(unittest.TestCase):
             if row.get("assetClass") != "pick":
                 continue
             if row.get("madPenaltyApplied") not in (None, 0):
-                offenders.append(
-                    f"{row.get('canonicalName')}: "
-                    f"{row['madPenaltyApplied']}"
-                )
+                offenders.append(f"{row.get('canonicalName')}: " f"{row['madPenaltyApplied']}")
         self.assertFalse(
             offenders,
-            f"Pick rows carrying MAD penalty (should be exempt): "
-            f"{offenders[:5]}",
+            f"Pick rows carrying MAD penalty (should be exempt): " f"{offenders[:5]}",
         )
 
 
@@ -453,8 +434,7 @@ class TestSoftFallbackIsCoverageDiagnosticOnly(unittest.TestCase):
                 missing.append(str(row.get("canonicalName") or ""))
         self.assertFalse(
             missing,
-            f"Ranked non-pick rows without softFallbackCount: "
-            f"{missing[:5]}",
+            f"Ranked non-pick rows without softFallbackCount: " f"{missing[:5]}",
         )
 
     def test_soft_fallback_count_nonnegative(self) -> None:
@@ -463,7 +443,8 @@ class TestSoftFallbackIsCoverageDiagnosticOnly(unittest.TestCase):
             if sfc is None:
                 continue
             self.assertGreaterEqual(
-                int(sfc), 0,
+                int(sfc),
+                0,
                 f"{row.get('canonicalName')}: negative softFallbackCount",
             )
 
@@ -475,7 +456,8 @@ class TestSoftFallbackIsCoverageDiagnosticOnly(unittest.TestCase):
         for row in self.rows:
             for key in banned:
                 self.assertNotIn(
-                    key, row,
+                    key,
+                    row,
                     f"{row.get('canonicalName')}: forbidden fallback-"
                     f"value field {key!r} present — soft fallback is "
                     f"supposed to be a coverage diagnostic only.",
@@ -536,23 +518,19 @@ class TestScopeMasterRouting(unittest.TestCase):
             IDP_HILL_PERCENTILE_S,
             percentile_to_value,
         )
+
         # Sanity — the two master curves produce different V at
         # typical mid-pack percentile.
         p = 0.1
-        off_v = int(
-            percentile_to_value(
-                p, midpoint=HILL_PERCENTILE_C, slope=HILL_PERCENTILE_S
-            )
-        )
+        off_v = int(percentile_to_value(p, midpoint=HILL_PERCENTILE_C, slope=HILL_PERCENTILE_S))
         idp_v = int(
-            percentile_to_value(
-                p, midpoint=IDP_HILL_PERCENTILE_C, slope=IDP_HILL_PERCENTILE_S
-            )
+            percentile_to_value(p, midpoint=IDP_HILL_PERCENTILE_C, slope=IDP_HILL_PERCENTILE_S)
         )
         self.assertNotEqual(
-            off_v, idp_v,
+            off_v,
+            idp_v,
             f"Offense and IDP master curves produce identical V at p={p}: "
-            f"{off_v}.  Framework-update requires distinct scope curves."
+            f"{off_v}.  Framework-update requires distinct scope curves.",
         )
 
 
@@ -601,13 +579,15 @@ class TestRookieScopeRouting(unittest.TestCase):
                 # (if it's still 1 the translation didn't run) and
                 # the contribution must be well below the max 9999.
                 self.assertGreater(
-                    eff, 1,
+                    eff,
+                    1,
                     f"{src_key} rank-1 player {row.get('canonicalName')}"
                     f" still at effective rank {eff} — the Phase 1d"
                     f" rookie-ladder translation is OFF.",
                 )
                 self.assertLess(
-                    vc, 9999,
+                    vc,
+                    9999,
                     f"{src_key} rank-1 player contribution still 9999"
                     f" — ladder translation should cap it below that.",
                 )
@@ -617,7 +597,8 @@ class TestRookieScopeRouting(unittest.TestCase):
                 # top rookie at very different ranks.
                 bound = _SANITY_UPPER_BOUND[src_key]
                 self.assertLess(
-                    eff, bound,
+                    eff,
+                    bound,
                     f"{src_key} rank-1 translated to {eff} (sanity"
                     f" bound {bound}) — reference ladder may be"
                     f" malformed or universe filter incorrect.",
@@ -643,18 +624,19 @@ class TestRookieScopeRouting(unittest.TestCase):
             IDP_HILL_PERCENTILE_S,
             percentile_to_value,
         )
+
         p = 0.3
-        off_v = int(percentile_to_value(
-            p, midpoint=HILL_PERCENTILE_C, slope=HILL_PERCENTILE_S
-        ))
-        idp_v = int(percentile_to_value(
-            p, midpoint=IDP_HILL_PERCENTILE_C, slope=IDP_HILL_PERCENTILE_S
-        ))
-        rook_v = int(percentile_to_value(
-            p,
-            midpoint=HILL_ROOKIE_PERCENTILE_C,
-            slope=HILL_ROOKIE_PERCENTILE_S,
-        ))
+        off_v = int(percentile_to_value(p, midpoint=HILL_PERCENTILE_C, slope=HILL_PERCENTILE_S))
+        idp_v = int(
+            percentile_to_value(p, midpoint=IDP_HILL_PERCENTILE_C, slope=IDP_HILL_PERCENTILE_S)
+        )
+        rook_v = int(
+            percentile_to_value(
+                p,
+                midpoint=HILL_ROOKIE_PERCENTILE_C,
+                slope=HILL_ROOKIE_PERCENTILE_S,
+            )
+        )
         # All three masters must produce distinct V at p=0.3.
         self.assertNotEqual(rook_v, off_v)
         self.assertNotEqual(rook_v, idp_v)
@@ -677,11 +659,7 @@ class TestNoSecondHillCurve(unittest.TestCase):
 
     def test_top_50_value_range_is_wide(self) -> None:
         offense = sorted(
-            (
-                r
-                for r in self.rows
-                if str(r.get("position") or "").upper() in _OFFENSE_POSITIONS
-            ),
+            (r for r in self.rows if str(r.get("position") or "").upper() in _OFFENSE_POSITIONS),
             key=lambda r: int(r["canonicalConsensusRank"]),
         )[:50]
         if len(offense) < 50:
@@ -716,8 +694,7 @@ class TestNoSecondHillCurve(unittest.TestCase):
                 offenders.append((str(row.get("canonicalName") or ""), v))
         self.assertFalse(
             offenders,
-            f"Rows above _DISPLAY_SCALE_MAX={_DISPLAY_SCALE_MAX}: "
-            f"{offenders[:5]}",
+            f"Rows above _DISPLAY_SCALE_MAX={_DISPLAY_SCALE_MAX}: " f"{offenders[:5]}",
         )
 
 
@@ -773,8 +750,7 @@ class TestValueBasedSourceDirectVote(unittest.TestCase):
                 path = m.get("valueContributionPath")
                 if path != "value_direct":
                     offenders.append(
-                        f"{row.get('canonicalName')} [{src_key}]: "
-                        f"path={path!r} (raw={raw})"
+                        f"{row.get('canonicalName')} [{src_key}]: " f"path={path!r} (raw={raw})"
                     )
                 checked += 1
         self.assertFalse(
@@ -783,7 +759,8 @@ class TestValueBasedSourceDirectVote(unittest.TestCase):
             f"(offenders first 5): {offenders[:5]}",
         )
         self.assertGreater(
-            checked, 100,
+            checked,
+            100,
             "expected many value-direct source contributions across the board",
         )
 
@@ -799,15 +776,11 @@ class TestValueBasedSourceDirectVote(unittest.TestCase):
                     continue
                 path = m.get("valueContributionPath")
                 if path != "rank_hill":
-                    offenders.append(
-                        f"{row.get('canonicalName')} [{src_key}]: "
-                        f"path={path!r}"
-                    )
+                    offenders.append(f"{row.get('canonicalName')} [{src_key}]: " f"path={path!r}")
                 checked += 1
         self.assertFalse(
             offenders,
-            f"Rank-only sources NOT routed through Hill "
-            f"(offenders first 5): {offenders[:5]}",
+            f"Rank-only sources NOT routed through Hill " f"(offenders first 5): {offenders[:5]}",
         )
         self.assertGreater(checked, 100, "expected many rank-hill contributions")
 
@@ -855,13 +828,13 @@ class TestValueBasedSourceDirectVote(unittest.TestCase):
                 # contribution on TE rows.  Skip those to keep this
                 # test focused on the normalization rule itself; the
                 # TEP path is covered by dedicated TEP tests.
-                if row_is_te and (
-                    m.get("tepBoostApplied") or m.get("tepNativeCorrectionApplied")
-                ):
+                if row_is_te and (m.get("tepBoostApplied") or m.get("tepNativeCorrectionApplied")):
                     continue
                 actual = m.get("valueContribution")
                 self.assertAlmostEqual(
-                    float(actual), expected, delta=1.5,
+                    float(actual),
+                    expected,
+                    delta=1.5,
                     msg=(
                         f"{row.get('canonicalName')} [{src_key}]: "
                         f"valueContribution={actual} but raw={raw} "
@@ -870,7 +843,8 @@ class TestValueBasedSourceDirectVote(unittest.TestCase):
                 )
                 checked += 1
         self.assertGreater(
-            checked, 50,
+            checked,
+            50,
             "expected many value-direct rows to cross-check against raw",
         )
 
@@ -897,7 +871,8 @@ class TestMADPenaltyNeutralized(unittest.TestCase):
         from src.api.data_contract import _MAD_PENALTY_LAMBDA  # noqa: PLC0415
 
         self.assertEqual(
-            _MAD_PENALTY_LAMBDA, 0.0,
+            _MAD_PENALTY_LAMBDA,
+            0.0,
             "λ·MAD has been retired in favour of the count-aware + "
             "anchor damping layers.  Reinstating λ > 0 needs a fresh "
             "backtest proving the extra penalty is non-duplicative.",
@@ -908,9 +883,7 @@ class TestMADPenaltyNeutralized(unittest.TestCase):
         for row in self.rows:
             penalty = row.get("madPenaltyApplied")
             if penalty is not None and float(penalty) > 0:
-                offenders.append(
-                    f"{row.get('canonicalName')}: madPenaltyApplied={penalty}"
-                )
+                offenders.append(f"{row.get('canonicalName')}: madPenaltyApplied={penalty}")
         self.assertFalse(
             offenders,
             f"Live rows carrying madPenaltyApplied > 0 despite λ=0 "
@@ -927,7 +900,8 @@ class TestMADPenaltyNeutralized(unittest.TestCase):
             self.skipTest("no multi-source rows in live data")
         stamped = sum(1 for r in multi_source if r.get("sourceSpread") is not None)
         self.assertGreater(
-            stamped, 0,
+            stamped,
+            0,
             "sourceSpread diagnostic is missing on every multi-source row",
         )
 
@@ -969,18 +943,21 @@ class TestDraftSharksCombinedCrossMarket(unittest.TestCase):
                 m = meta.get(src_key)
                 if not m:
                     continue
-                out.append((
-                    int(m.get("effectiveRank") or 0),
-                    src_key,
-                    str(row.get("canonicalName") or ""),
-                    str(m.get("method") or ""),
-                ))
+                out.append(
+                    (
+                        int(m.get("effectiveRank") or 0),
+                        src_key,
+                        str(row.get("canonicalName") or ""),
+                        str(m.get("method") or ""),
+                    )
+                )
         return out
 
     def test_method_stamp_identifies_cross_market(self) -> None:
         entries = self._ds_eff_ranks()
         self.assertGreater(
-            len(entries), 100,
+            len(entries),
+            100,
             "expected many DS entries in the live contract",
         )
         offenders = [
@@ -990,8 +967,7 @@ class TestDraftSharksCombinedCrossMarket(unittest.TestCase):
         ]
         self.assertFalse(
             offenders,
-            f"DS entries without combined-cross-market method stamp "
-            f"(first 5): {offenders[:5]}",
+            f"DS entries without combined-cross-market method stamp " f"(first 5): {offenders[:5]}",
         )
 
     def test_combined_ranks_are_unique_across_sources(self) -> None:
@@ -1002,8 +978,7 @@ class TestDraftSharksCombinedCrossMarket(unittest.TestCase):
         dupes = [r for r in set(ranks) if ranks.count(r) > 1]
         self.assertFalse(
             dupes,
-            f"Duplicate DS effective ranks across SF+IDP pool "
-            f"(first 5): {dupes[:5]}",
+            f"Duplicate DS effective ranks across SF+IDP pool " f"(first 5): {dupes[:5]}",
         )
 
     def test_top_idp_rank_exceeds_top_offense_rank(self) -> None:
@@ -1023,11 +998,13 @@ class TestDraftSharksCombinedCrossMarket(unittest.TestCase):
         if top_off_rank is None or top_idp_rank is None:
             self.skipTest("DS SF or IDP entries absent")
         self.assertEqual(
-            top_off_rank, 1,
+            top_off_rank,
+            1,
             "top DS offense player should be at combined rank 1",
         )
         self.assertGreater(
-            top_idp_rank, 1,
+            top_idp_rank,
+            1,
             "top DS IDP player should sit behind the top offense "
             "player on the combined ladder — cross-market premium "
             "is the whole point of this pre-pass.",
@@ -1051,4 +1028,5 @@ class TestValueBasedRegistryInvariant(unittest.TestCase):
         from src.api.data_contract import (  # noqa: PLC0415
             _validate_value_based_sources_invariant,
         )
+
         _validate_value_based_sources_invariant()

--- a/tests/api/test_single_source_resolution.py
+++ b/tests/api/test_single_source_resolution.py
@@ -8,6 +8,7 @@ These tests guarantee that:
 3. Cross-source name aliases resolve correctly.
 4. The allowlist build check catches unexplained 1-src cases.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -26,6 +27,7 @@ from src.utils.name_clean import (
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────
+
 
 def _row(
     name: str,
@@ -51,7 +53,12 @@ def _row(
         "position": position,
         "assetClass": "idp" if position in ("DL", "LB", "DB") else "offense",
         "canonicalSiteValues": sites,
-        "values": {"overall": max(v or 0 for v in sites.values()), "rawComposite": None, "finalAdjusted": None, "displayValue": None},
+        "values": {
+            "overall": max(v or 0 for v in sites.values()),
+            "rawComposite": None,
+            "finalAdjusted": None,
+            "displayValue": None,
+        },
         "sourceCount": 0,
         "sourcePresence": {},
         "rookie": rookie,
@@ -59,6 +66,7 @@ def _row(
 
 
 # ── Test: Name alias resolution ─────────────────────────────────────────
+
 
 class TestNameAliases(unittest.TestCase):
     """Verify cross-source name aliases collapse correctly."""
@@ -133,6 +141,7 @@ class TestNameAliases(unittest.TestCase):
 
 # ── Test: Top offense players must NOT be semantic 1-src ─────────────────
 
+
 class TestTopOffenseNotSemantic1Src(unittest.TestCase):
     """Regression guard: known top offensive players must never be flagged
     as ``isSingleSource=True`` (semantic 1-src / matching failure).
@@ -191,14 +200,19 @@ class TestTopOffenseNotSemantic1Src(unittest.TestCase):
         ]
         _compute_unified_rankings(rows, {})
         for row in rows:
-            self.assertFalse(row.get("isSingleSource"), f"{row['canonicalName']} should not be 1-src")
-            self.assertFalse(row.get("isStructurallySingleSource"), f"{row['canonicalName']} should not be structural 1-src")
+            self.assertFalse(
+                row.get("isSingleSource"), f"{row['canonicalName']} should not be 1-src"
+            )
+            self.assertFalse(
+                row.get("isStructurallySingleSource"),
+                f"{row['canonicalName']} should not be structural 1-src",
+            )
 
 
 # ── Test: IDP 1-src for rookies/depth is structural, not semantic ────────
 
-class TestIdpStructural1Src(unittest.TestCase):
 
+class TestIdpStructural1Src(unittest.TestCase):
     def test_idp_rookie_without_dlf_or_fp_or_fbg_is_structural(self):
         """IDP rookies missing from DLF, FP, AND FootballGuys are structural
         1-src (not semantic).  DLF and FP exclude rookies structurally;
@@ -223,13 +237,14 @@ class TestIdpStructural1Src(unittest.TestCase):
 
 # ── Test: Allowlist completeness ─────────────────────────────────────────
 
-class TestAllowlistCompleteness(unittest.TestCase):
 
+class TestAllowlistCompleteness(unittest.TestCase):
     def test_all_allowlist_keys_are_normalized(self):
         """Every allowlist key must be a valid normalized name."""
         for key in SINGLE_SOURCE_ALLOWLIST:
             self.assertEqual(
-                key, normalize_player_name(key),
+                key,
+                normalize_player_name(key),
                 f"Allowlist key '{key}' is not in normalized form",
             )
 
@@ -250,8 +265,8 @@ class TestAllowlistCompleteness(unittest.TestCase):
 
 # ── Test: Build check function ───────────────────────────────────────────
 
-class TestBuildCheck(unittest.TestCase):
 
+class TestBuildCheck(unittest.TestCase):
     def test_no_unexplained_1src_with_allowlist(self):
         """Players on the allowlist should not appear as unexplained.
 

--- a/tests/api/test_sleeper_live_draft.py
+++ b/tests/api/test_sleeper_live_draft.py
@@ -13,6 +13,7 @@ These cover the three things that matter:
   3. The ``after_pick_no`` cursor filters correctly so the
      polling client only sees new picks.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -40,6 +41,7 @@ def _stub_http(mapping):
             if url.endswith(suffix):
                 return mapping[suffix]
         return None
+
     return _resolve
 
 
@@ -50,36 +52,39 @@ def test_resolve_active_draft_id_prefers_drafting_status(monkeypatch):
     """Of multiple current-season drafts, prefer status=drafting
     over pre_draft over complete."""
     import datetime as _dt
+
     cur = _dt.datetime.now(_dt.timezone.utc).year
     league_id = "L1"
     monkeypatch.setattr(
         sleeper_overlay,
         "_http_get_json",
-        _stub_http({
-            f"/league/{league_id}/drafts": [
-                {
-                    "draft_id": "complete-prior",
-                    "season": str(cur),
-                    "sport": "nfl",
-                    "status": "complete",
-                    "start_time": 100,
-                },
-                {
-                    "draft_id": "drafting-now",
-                    "season": str(cur),
-                    "sport": "nfl",
-                    "status": "drafting",
-                    "start_time": 200,
-                },
-                {
-                    "draft_id": "pre-draft-soon",
-                    "season": str(cur),
-                    "sport": "nfl",
-                    "status": "pre_draft",
-                    "start_time": 300,
-                },
-            ],
-        }),
+        _stub_http(
+            {
+                f"/league/{league_id}/drafts": [
+                    {
+                        "draft_id": "complete-prior",
+                        "season": str(cur),
+                        "sport": "nfl",
+                        "status": "complete",
+                        "start_time": 100,
+                    },
+                    {
+                        "draft_id": "drafting-now",
+                        "season": str(cur),
+                        "sport": "nfl",
+                        "status": "drafting",
+                        "start_time": 200,
+                    },
+                    {
+                        "draft_id": "pre-draft-soon",
+                        "season": str(cur),
+                        "sport": "nfl",
+                        "status": "pre_draft",
+                        "start_time": 300,
+                    },
+                ],
+            }
+        ),
     )
     assert sleeper_overlay._resolve_active_draft_id(league_id) == "drafting-now"
 
@@ -88,22 +93,25 @@ def test_resolve_active_draft_id_skips_off_season(monkeypatch):
     """Drafts from prior seasons must not be selected even if they
     sit at status complete (the most common stale-data case)."""
     import datetime as _dt
+
     cur = _dt.datetime.now(_dt.timezone.utc).year
     league_id = "L1"
     monkeypatch.setattr(
         sleeper_overlay,
         "_http_get_json",
-        _stub_http({
-            f"/league/{league_id}/drafts": [
-                {
-                    "draft_id": "last-year",
-                    "season": str(cur - 1),
-                    "sport": "nfl",
-                    "status": "complete",
-                    "start_time": 50,
-                },
-            ],
-        }),
+        _stub_http(
+            {
+                f"/league/{league_id}/drafts": [
+                    {
+                        "draft_id": "last-year",
+                        "season": str(cur - 1),
+                        "sport": "nfl",
+                        "status": "complete",
+                        "start_time": 50,
+                    },
+                ],
+            }
+        ),
     )
     assert sleeper_overlay._resolve_active_draft_id(league_id) is None
 
@@ -125,15 +133,17 @@ def test_resolve_active_draft_id_returns_none_on_empty(monkeypatch):
 def test_normalize_live_pick_coerces_string_amount():
     """Sleeper stamps ``metadata.amount`` as a STRING for auction
     picks ("$23" or "23").  Normalizer must coerce to int."""
-    row = sleeper_overlay._normalize_live_pick({
-        "pick_no": 5,
-        "player_id": "4046",
-        "picked_by": "user-123",
-        "roster_id": 7,
-        "round": 1,
-        "picked_at": 1715000000,
-        "metadata": {"amount": "$23"},
-    })
+    row = sleeper_overlay._normalize_live_pick(
+        {
+            "pick_no": 5,
+            "player_id": "4046",
+            "picked_by": "user-123",
+            "roster_id": 7,
+            "round": 1,
+            "picked_at": 1715000000,
+            "metadata": {"amount": "$23"},
+        }
+    )
     assert row == {
         "pickNo": 5,
         "playerId": "4046",
@@ -148,14 +158,16 @@ def test_normalize_live_pick_coerces_string_amount():
 def test_normalize_live_pick_handles_snake_draft_no_amount():
     """Snake-draft picks have no ``metadata.amount`` — must default
     to 0 rather than failing the row."""
-    row = sleeper_overlay._normalize_live_pick({
-        "pick_no": 1,
-        "player_id": "4046",
-        "picked_by": "user-123",
-        "roster_id": 1,
-        "round": 1,
-        "metadata": {},
-    })
+    row = sleeper_overlay._normalize_live_pick(
+        {
+            "pick_no": 1,
+            "player_id": "4046",
+            "picked_by": "user-123",
+            "roster_id": 1,
+            "round": 1,
+            "metadata": {},
+        }
+    )
     assert row is not None
     assert row["amount"] == 0
 
@@ -172,13 +184,15 @@ def test_normalize_live_pick_blank_picked_by():
     """Commish picks / co-managers can have empty picked_by — must
     produce an empty ownerId string (not None) so the JSON response
     has a consistent type."""
-    row = sleeper_overlay._normalize_live_pick({
-        "pick_no": 5,
-        "player_id": "4046",
-        "picked_by": None,
-        "roster_id": 7,
-        "metadata": {"amount": "10"},
-    })
+    row = sleeper_overlay._normalize_live_pick(
+        {
+            "pick_no": 5,
+            "player_id": "4046",
+            "picked_by": None,
+            "roster_id": 7,
+            "metadata": {"amount": "10"},
+        }
+    )
     assert row["ownerId"] == ""
     assert row["rosterId"] == 7
 
@@ -210,6 +224,7 @@ def _fixture_picks_response():
 
 def _fixture_drafts_response():
     import datetime as _dt
+
     cur = _dt.datetime.now(_dt.timezone.utc).year
     return [
         {
@@ -228,11 +243,13 @@ def test_fetch_live_draft_picks_full_snapshot(monkeypatch):
     monkeypatch.setattr(
         sleeper_overlay,
         "_http_get_json",
-        _stub_http({
-            "/league/L1/drafts": _fixture_drafts_response(),
-            "/draft/D1": {"status": "drafting"},
-            "/draft/D1/picks": _fixture_picks_response(),
-        }),
+        _stub_http(
+            {
+                "/league/L1/drafts": _fixture_drafts_response(),
+                "/draft/D1": {"status": "drafting"},
+                "/draft/D1/picks": _fixture_picks_response(),
+            }
+        ),
     )
     snap = sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)
     assert snap is not None
@@ -254,11 +271,13 @@ def test_fetch_live_draft_picks_cursor_filters(monkeypatch):
     monkeypatch.setattr(
         sleeper_overlay,
         "_http_get_json",
-        _stub_http({
-            "/league/L1/drafts": _fixture_drafts_response(),
-            "/draft/D1": {"status": "drafting"},
-            "/draft/D1/picks": _fixture_picks_response(),
-        }),
+        _stub_http(
+            {
+                "/league/L1/drafts": _fixture_drafts_response(),
+                "/draft/D1": {"status": "drafting"},
+                "/draft/D1/picks": _fixture_picks_response(),
+            }
+        ),
     )
     snap = sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=1)
     assert len(snap["picks"]) == 1
@@ -282,21 +301,26 @@ def test_fetch_live_draft_picks_complete_status(monkeypatch):
     """A completed draft still serves its picks (useful for replay /
     review) and the status flag drives the frontend's auto-stop."""
     import datetime as _dt
+
     cur = _dt.datetime.now(_dt.timezone.utc).year
     monkeypatch.setattr(
         sleeper_overlay,
         "_http_get_json",
-        _stub_http({
-            "/league/L1/drafts": [{
-                "draft_id": "D1",
-                "season": str(cur),
-                "sport": "nfl",
-                "status": "complete",
-                "start_time": 100,
-            }],
-            "/draft/D1": {"status": "complete"},
-            "/draft/D1/picks": _fixture_picks_response(),
-        }),
+        _stub_http(
+            {
+                "/league/L1/drafts": [
+                    {
+                        "draft_id": "D1",
+                        "season": str(cur),
+                        "sport": "nfl",
+                        "status": "complete",
+                        "start_time": 100,
+                    }
+                ],
+                "/draft/D1": {"status": "complete"},
+                "/draft/D1/picks": _fixture_picks_response(),
+            }
+        ),
     )
     snap = sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)
     assert snap["status"] == "complete"
@@ -313,11 +337,13 @@ def test_fetch_live_draft_picks_cache_isolation(monkeypatch):
     monkeypatch.setattr(
         sleeper_overlay,
         "_http_get_json",
-        _stub_http({
-            "/league/L1/drafts": _fixture_drafts_response(),
-            "/draft/D1": {"status": "drafting"},
-            "/draft/D1/picks": _fixture_picks_response(),
-        }),
+        _stub_http(
+            {
+                "/league/L1/drafts": _fixture_drafts_response(),
+                "/draft/D1": {"status": "drafting"},
+                "/draft/D1/picks": _fixture_picks_response(),
+            }
+        ),
     )
     # Seed both caches.
     sleeper_overlay.fetch_live_draft_picks("L1", after_pick_no=0)

--- a/tests/api/test_sleeper_overlay.py
+++ b/tests/api/test_sleeper_overlay.py
@@ -7,6 +7,7 @@ reflect Sleeper activity within ~15 min instead of the next 2h
 scrape cadence — the previous overlay returned raw Sleeper
 transactions which the frontend's trade-grading couldn't parse.
 """
+
 from __future__ import annotations
 
 import time
@@ -49,6 +50,7 @@ def _stub_http_responses(mapping):
             if url.endswith(suffix):
                 return mapping[suffix]
         return None
+
     return _resolve
 
 
@@ -88,8 +90,13 @@ def test_build_trades_block_emits_processed_sides_shape(monkeypatch):
             "adds": {"P-A": 1, "P-B": 2},
             "drops": {"P-A": 2, "P-B": 1},
             "draft_picks": [
-                {"season": "2026", "round": 1, "roster_id": 1,
-                 "owner_id": 2, "previous_owner_id": 1},
+                {
+                    "season": "2026",
+                    "round": 1,
+                    "roster_id": 1,
+                    "owner_id": 2,
+                    "previous_owner_id": 1,
+                },
             ],
         },
     ]
@@ -100,12 +107,16 @@ def test_build_trades_block_emits_processed_sides_shape(monkeypatch):
         responses[f"/league/{league_id}/transactions/{w}"] = []
 
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
 
     id_to_player = {"P-A": "Player A", "P-B": "Player B"}
     trades = sleeper_overlay._build_trades_block(
-        league_id, window_days=365, id_to_player=id_to_player,
+        league_id,
+        window_days=365,
+        id_to_player=id_to_player,
     )
 
     assert len(trades) == 1
@@ -148,15 +159,25 @@ def test_build_trades_block_filters_incomplete_trades(monkeypatch):
     for w in range(0, 19):
         responses[f"/league/{league_id}/transactions/{w}"] = []
     responses[f"/league/{league_id}/transactions/2"] = [
-        {"transaction_id": "tx-pending", "type": "trade",
-         "status": "pending", "roster_ids": [1],
-         "status_updated": 1730000000000},
-        {"transaction_id": "tx-failed", "type": "trade",
-         "status": "failed", "roster_ids": [1],
-         "status_updated": 1730000000000},
+        {
+            "transaction_id": "tx-pending",
+            "type": "trade",
+            "status": "pending",
+            "roster_ids": [1],
+            "status_updated": 1730000000000,
+        },
+        {
+            "transaction_id": "tx-failed",
+            "type": "trade",
+            "status": "failed",
+            "roster_ids": [1],
+            "status_updated": 1730000000000,
+        },
     ]
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     trades = sleeper_overlay._build_trades_block(league_id, window_days=365)
     assert trades == []
@@ -176,12 +197,18 @@ def test_build_trades_block_filters_outside_window(monkeypatch):
     for w in range(0, 19):
         responses[f"/league/{league_id}/transactions/{w}"] = []
     responses[f"/league/{league_id}/transactions/1"] = [
-        {"transaction_id": "tx-ancient", "type": "trade",
-         "status": "complete", "status_updated": very_old_ms,
-         "roster_ids": [1]},
+        {
+            "transaction_id": "tx-ancient",
+            "type": "trade",
+            "status": "complete",
+            "status_updated": very_old_ms,
+            "roster_ids": [1],
+        },
     ]
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     trades = sleeper_overlay._build_trades_block(league_id, window_days=30)
     assert trades == []
@@ -216,7 +243,9 @@ def test_build_trades_block_dedupes_across_chain(monkeypatch):
     responses[f"/league/{cur}/transactions/4"] = [base_tx]
     responses[f"/league/{prev}/transactions/4"] = [base_tx]
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     trades = sleeper_overlay._build_trades_block(cur, window_days=365)
     assert len(trades) == 1
@@ -266,13 +295,20 @@ def test_build_trades_block_uses_draft_slot_when_available(monkeypatch):
             "adds": {},
             "drops": {},
             "draft_picks": [
-                {"season": "2026", "round": 1, "roster_id": 1,
-                 "owner_id": 2, "previous_owner_id": 1},
+                {
+                    "season": "2026",
+                    "round": 1,
+                    "roster_id": 1,
+                    "owner_id": 2,
+                    "previous_owner_id": 1,
+                },
             ],
         },
     ]
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     trades = sleeper_overlay._build_trades_block(league_id, window_days=365)
     assert len(trades) == 1
@@ -321,13 +357,20 @@ def test_build_trades_block_resolves_slot_via_draft_order(monkeypatch):
             "status_updated": _recent_ms(),
             "roster_ids": [1, 2],
             "draft_picks": [
-                {"season": "2026", "round": 2, "roster_id": 1,
-                 "owner_id": 2, "previous_owner_id": 1},
+                {
+                    "season": "2026",
+                    "round": 2,
+                    "roster_id": 1,
+                    "owner_id": 2,
+                    "previous_owner_id": 1,
+                },
             ],
         },
     ]
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     trades = sleeper_overlay._build_trades_block(league_id, window_days=365)
     assert len(trades) == 1
@@ -346,17 +389,13 @@ def test_build_trades_block_uses_tier_label_for_future_year_picks(monkeypatch):
     bug this whole code path is fixing.
     """
     import datetime as _dt
+
     league_id = "L1"
     next_year = _dt.datetime.now(_dt.timezone.utc).year + 1
     # 12-team league so the Early/Mid/Late thirds (per_tier=4) match
     # the realistic boundaries: slots 1-4 Early, 5-8 Mid, 9-12 Late.
-    rosters = [
-        {"roster_id": i + 1, "owner_id": f"o{i + 1}"} for i in range(12)
-    ]
-    users = [
-        {"user_id": f"o{i + 1}", "display_name": f"Team {i + 1}"}
-        for i in range(12)
-    ]
+    rosters = [{"roster_id": i + 1, "owner_id": f"o{i + 1}"} for i in range(12)]
+    users = [{"user_id": f"o{i + 1}", "display_name": f"Team {i + 1}"} for i in range(12)]
     responses = {
         f"/league/{league_id}": {"name": "Main", "previous_league_id": None},
         f"/league/{league_id}/rosters": rosters,
@@ -382,13 +421,20 @@ def test_build_trades_block_uses_tier_label_for_future_year_picks(monkeypatch):
             "status_updated": _recent_ms(),
             "roster_ids": [1, 2],
             "draft_picks": [
-                {"season": str(next_year), "round": 1, "roster_id": 1,
-                 "owner_id": 2, "previous_owner_id": 1},
+                {
+                    "season": str(next_year),
+                    "round": 1,
+                    "roster_id": 1,
+                    "owner_id": 2,
+                    "previous_owner_id": 1,
+                },
             ],
         },
     ]
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     trades = sleeper_overlay._build_trades_block(league_id, window_days=365)
     assert len(trades) == 1
@@ -462,12 +508,16 @@ def test_build_waivers_block_emits_waiver_and_free_agent(monkeypatch):
         responses[f"/league/{league_id}/transactions/{w}"] = []
 
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
 
     id_map = {"P-A": "Player A", "P-B": "Player B", "P-Z": "Player Z"}
     waivers = sleeper_overlay._build_waivers_block(
-        league_id, window_days=365, id_to_player=id_map,
+        league_id,
+        window_days=365,
+        id_to_player=id_map,
     )
     assert len(waivers) == 2
     by_id = {w["transactionId"]: w for w in waivers}
@@ -516,7 +566,9 @@ def test_build_waivers_block_filters_incomplete_status(monkeypatch):
             continue
         responses[f"/league/{league_id}/transactions/{w}"] = []
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     waivers = sleeper_overlay._build_waivers_block(league_id)
     assert waivers == []
@@ -545,11 +597,11 @@ def test_build_waivers_block_dedupes_across_chain(monkeypatch):
         responses[f"/league/{lid}/users"] = [{"user_id": "oA", "display_name": "A"}]
         responses[f"/league/{lid}/drafts"] = []
         for w in range(0, 19):
-            responses[f"/league/{lid}/transactions/{w}"] = (
-                [common_tx] if w == 2 else []
-            )
+            responses[f"/league/{lid}/transactions/{w}"] = [common_tx] if w == 2 else []
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     waivers = sleeper_overlay._build_waivers_block(cur)
     assert len(waivers) == 1
@@ -583,7 +635,9 @@ def test_build_waivers_block_filters_outside_window(monkeypatch):
             continue
         responses[f"/league/{league_id}/transactions/{w}"] = []
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     waivers = sleeper_overlay._build_waivers_block(league_id, window_days=30)
     assert waivers == []
@@ -624,9 +678,13 @@ def test_build_teams_block_includes_faab_fields(monkeypatch):
         f"/league/{league_id}/traded_picks": [],
     }
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
-    teams = sleeper_overlay._build_teams_block(league_id, id_to_player={"P-1": "P One", "P-2": "P Two"})
+    teams = sleeper_overlay._build_teams_block(
+        league_id, id_to_player={"P-1": "P One", "P-2": "P Two"}
+    )
     assert teams is not None
     by_owner = {t["ownerId"]: t for t in teams}
     a = by_owner["oA"]
@@ -672,7 +730,9 @@ def test_build_teams_block_faab_falls_back_when_missing(monkeypatch):
         f"/league/{league_id}/traded_picks": [],
     }
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     teams = sleeper_overlay._build_teams_block(league_id, id_to_player={})
     assert teams is not None
@@ -733,7 +793,9 @@ def test_fetch_sleeper_overlay_includes_waivers_and_meta(monkeypatch):
             continue
         responses[f"/league/{league_id}/transactions/{w}"] = []
     monkeypatch.setattr(
-        sleeper_overlay, "_http_get_json", _stub_http_responses(responses),
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
     )
     payload = sleeper_overlay.fetch_sleeper_overlay(
         sleeper_league_id=league_id,

--- a/tests/api/test_source_floor_invariant.py
+++ b/tests/api/test_source_floor_invariant.py
@@ -38,6 +38,7 @@ self-burning-down pattern as
 ``test_known_gaps_are_still_real_gaps`` forces removal of an entry the
 moment its scraper is hardened, so the allowlist can only shrink.
 """
+
 from __future__ import annotations
 
 import ast
@@ -108,21 +109,11 @@ def _dlf_board_min_rows(board_key: str) -> int | None:
 # real guard value.  Resolver returns the int, or None if the scraper
 # has NO aligned internal floor (=> must be in _KNOWN_FLOOR_GAPS).
 _SCRAPER_FLOOR_RESOLVERS = {
-    "yahooBoone": lambda: _module_int_const(
-        "fetch_yahoo_boone.py", "_YB_ROW_COUNT_FLOOR"
-    ),
-    "dynastyNerdsSfTep": lambda: _module_int_const(
-        "fetch_dynasty_nerds.py", "_DN_ROW_COUNT_FLOOR"
-    ),
-    "dynastyDaddySf": lambda: _module_int_const(
-        "fetch_dynasty_daddy.py", "_DD_ROW_COUNT_FLOOR"
-    ),
-    "flockFantasySf": lambda: _module_int_const(
-        "fetch_flock_fantasy.py", "_FF_ROW_COUNT_FLOOR"
-    ),
-    "idpShow": lambda: _module_int_const(
-        "fetch_idpshow.py", "_IDPSHOW_ROW_FLOOR"
-    ),
+    "yahooBoone": lambda: _module_int_const("fetch_yahoo_boone.py", "_YB_ROW_COUNT_FLOOR"),
+    "dynastyNerdsSfTep": lambda: _module_int_const("fetch_dynasty_nerds.py", "_DN_ROW_COUNT_FLOOR"),
+    "dynastyDaddySf": lambda: _module_int_const("fetch_dynasty_daddy.py", "_DD_ROW_COUNT_FLOOR"),
+    "flockFantasySf": lambda: _module_int_const("fetch_flock_fantasy.py", "_FF_ROW_COUNT_FLOOR"),
+    "idpShow": lambda: _module_int_const("fetch_idpshow.py", "_IDPSHOW_ROW_FLOOR"),
     "dlfSf": lambda: _dlf_board_min_rows("dlfSf"),
     "dlfIdp": lambda: _dlf_board_min_rows("dlfIdp"),
     # No aligned internal floor today (legacy Dynasty Scraper.py
@@ -130,18 +121,10 @@ _SCRAPER_FLOOR_RESOLVERS = {
     # => allowlisted below until the named follow-up hardens it.
     # A2 (2026-05-17) — each now has a contract-aligned fail-loud,
     # preserve-last-good floor; resolvers read the real constant.
-    "footballGuysSf": lambda: _module_int_const(
-        "fetch_footballguys.py", "_FBG_SF_ROW_FLOOR"
-    ),
-    "footballGuysIdp": lambda: _module_int_const(
-        "fetch_footballguys.py", "_FBG_IDP_ROW_FLOOR"
-    ),
-    "draftSharks": lambda: _module_int_const(
-        "fetch_draftsharks.py", "_DS_SF_ROW_FLOOR"
-    ),
-    "draftSharksIdp": lambda: _module_int_const(
-        "fetch_draftsharks.py", "_DS_IDP_ROW_FLOOR"
-    ),
+    "footballGuysSf": lambda: _module_int_const("fetch_footballguys.py", "_FBG_SF_ROW_FLOOR"),
+    "footballGuysIdp": lambda: _module_int_const("fetch_footballguys.py", "_FBG_IDP_ROW_FLOOR"),
+    "draftSharks": lambda: _module_int_const("fetch_draftsharks.py", "_DS_SF_ROW_FLOOR"),
+    "draftSharksIdp": lambda: _module_int_const("fetch_draftsharks.py", "_DS_IDP_ROW_FLOOR"),
     "fantasyProsFitzmaurice": lambda: _module_int_const(
         "fetch_fantasypros_fitzmaurice.py", "_FPF_ROW_FLOOR"
     ),
@@ -151,12 +134,8 @@ _SCRAPER_FLOOR_RESOLVERS = {
     # A3 (2026-05-17) — legacy Dynasty Scraper.py FULL_DATA->site_raw
     # export now skips the write below its contract-aligned floor so
     # the existing restore-previous pass preserves last-good.
-    "ktc": lambda: _module_int_const(
-        "Dynasty Scraper.py", "_KTC_SITE_RAW_FLOOR"
-    ),
-    "idpTradeCalc": lambda: _module_int_const(
-        "Dynasty Scraper.py", "_IDPTC_SITE_RAW_FLOOR"
-    ),
+    "ktc": lambda: _module_int_const("Dynasty Scraper.py", "_KTC_SITE_RAW_FLOOR"),
+    "idpTradeCalc": lambda: _module_int_const("Dynasty Scraper.py", "_IDPTC_SITE_RAW_FLOOR"),
 }
 
 # Sources whose scraper has NO aligned internal floor yet.  Each entry:
@@ -184,9 +163,7 @@ class TestScraperFloorInvariant(unittest.TestCase):
         """A new source in _DEFAULT_SOURCE_ROW_FLOORS must be wired
         here (resolver + either aligned floor or allowlist entry) —
         otherwise its scraper floor is unaudited."""
-        missing = sorted(
-            set(_DEFAULT_SOURCE_ROW_FLOORS) - set(_SCRAPER_FLOOR_RESOLVERS)
-        )
+        missing = sorted(set(_DEFAULT_SOURCE_ROW_FLOORS) - set(_SCRAPER_FLOOR_RESOLVERS))
         self.assertEqual(
             missing,
             [],
@@ -218,8 +195,7 @@ class TestScraperFloorInvariant(unittest.TestCase):
         self.assertEqual(
             violations,
             [],
-            "Scraper-floor < contract-floor (the yahooBoone class):\n  "
-            + "\n  ".join(violations),
+            "Scraper-floor < contract-floor (the yahooBoone class):\n  " + "\n  ".join(violations),
         )
 
     def test_known_gaps_are_still_real_gaps(self):
@@ -237,10 +213,7 @@ class TestScraperFloorInvariant(unittest.TestCase):
             )
             resolver = _SCRAPER_FLOOR_RESOLVERS.get(key)
             scraper_floor = resolver() if resolver else None
-            if (
-                scraper_floor is not None
-                and scraper_floor >= _DEFAULT_SOURCE_ROW_FLOORS[key]
-            ):
+            if scraper_floor is not None and scraper_floor >= _DEFAULT_SOURCE_ROW_FLOORS[key]:
                 stale.append(
                     f"{key}: scraper now floors at {scraper_floor} >= "
                     f"contract {_DEFAULT_SOURCE_ROW_FLOORS[key]} — remove "
@@ -249,8 +222,7 @@ class TestScraperFloorInvariant(unittest.TestCase):
         self.assertEqual(
             stale,
             [],
-            "Closed gaps still allowlisted (allowlist must shrink):\n  "
-            + "\n  ".join(stale),
+            "Closed gaps still allowlisted (allowlist must shrink):\n  " + "\n  ".join(stale),
         )
 
 

--- a/tests/api/test_source_health_alerts.py
+++ b/tests/api/test_source_health_alerts.py
@@ -1,4 +1,5 @@
 """Tests for the source-health staleness alert engine."""
+
 from __future__ import annotations
 
 import time
@@ -20,6 +21,7 @@ def kv(tmp_path):
 def _iso(hours_ago):
     t = time.time() - hours_ago * 3600
     import datetime as dt
+
     return dt.datetime.fromtimestamp(t, dt.timezone.utc).isoformat()
 
 
@@ -54,7 +56,10 @@ def test_universal_24h_policy_flags_dlf_after_one_day():
     }
     alerts = sha.detect_stale_sources(health)
     assert {a.source for a in alerts} == {
-        "dlfSf", "dlfIdp", "dlfRookieSf", "dlfRookieIdp",
+        "dlfSf",
+        "dlfIdp",
+        "dlfRookieSf",
+        "dlfRookieIdp",
     }
     assert all(a.threshold_hours == 24.0 for a in alerts)
 
@@ -128,44 +133,61 @@ def test_missing_last_fetched_is_skipped():
 
 def test_check_and_alert_fires_once_then_cools_down(kv):
     sends = []
+
     def delivery(to, subj, body):
         sends.append((to, subj, body))
         return True
+
     health = {"ktc": {"lastFetched": _iso(30)}}
     # First call — should send.
     sha.check_and_alert(
         health,
-        delivery=delivery, to_email="test@example.com",
-        kv_path=kv, cooldown_hours=72,
+        delivery=delivery,
+        to_email="test@example.com",
+        kv_path=kv,
+        cooldown_hours=72,
     )
     assert len(sends) == 1
     # Second call within cooldown — skipped.
     sha.check_and_alert(
         health,
-        delivery=delivery, to_email="test@example.com",
-        kv_path=kv, cooldown_hours=72,
+        delivery=delivery,
+        to_email="test@example.com",
+        kv_path=kv,
+        cooldown_hours=72,
     )
     assert len(sends) == 1
 
 
 def test_recovery_alert_fires_when_source_returns(kv):
     sends = []
+
     def delivery(to, subj, body):
         sends.append((to, subj, body))
         return True
+
     stale_health = {"ktc": {"lastFetched": _iso(30)}}
     fresh_health = {"ktc": {"lastFetched": _iso(1)}}
     sha.check_and_alert(
-        stale_health, delivery=delivery, to_email="test@example.com", kv_path=kv,
+        stale_health,
+        delivery=delivery,
+        to_email="test@example.com",
+        kv_path=kv,
     )
     assert len(sends) == 1
     result = sha.check_and_alert(
-        fresh_health, delivery=delivery, to_email="test@example.com", kv_path=kv,
+        fresh_health,
+        delivery=delivery,
+        to_email="test@example.com",
+        kv_path=kv,
     )
     assert result["recovered"] >= 1
     assert len(sends) == 2
     sha.check_and_alert(
-        fresh_health, delivery=delivery, to_email="test@example.com", kv_path=kv,
+        fresh_health,
+        delivery=delivery,
+        to_email="test@example.com",
+        kv_path=kv,
     )
     assert len(sends) == 2
 
@@ -173,7 +195,10 @@ def test_recovery_alert_fires_when_source_returns(kv):
 def test_no_delivery_hook_doesnt_crash(kv):
     health = {"ktc": {"lastFetched": _iso(30)}}
     result = sha.check_and_alert(
-        health, delivery=None, to_email=None, kv_path=kv,
+        health,
+        delivery=None,
+        to_email=None,
+        kv_path=kv,
     )
     assert result["delivered"] == 0
     assert result["stale"] == 1
@@ -182,6 +207,7 @@ def test_no_delivery_hook_doesnt_crash(kv):
 def test_load_thresholds_reads_config(tmp_path):
     cfg = tmp_path / "st.json"
     import json
+
     cfg.write_text(json.dumps({"thresholds": {"customSrc": 12}}), encoding="utf-8")
     t = sha.load_thresholds(cfg)
     assert t["customSrc"] == 12
@@ -198,10 +224,17 @@ def test_production_config_is_uniform_24h():
     """The shipped config/source_staleness.json should encode the
     documented 24h-everywhere policy."""
     from pathlib import Path
+
     repo = Path(__file__).resolve().parents[2]
     thresholds = sha.load_thresholds(repo / "config" / "source_staleness.json")
-    for vendor in ("ktc", "dlf", "fantasyCalc", "dynastyDaddy",
-                   "fantasyPros", "footballGuys", "yahooBoone", "idpShow"):
-        assert thresholds[vendor] == 24, (
-            f"{vendor} threshold drifted from the universal 24h policy"
-        )
+    for vendor in (
+        "ktc",
+        "dlf",
+        "fantasyCalc",
+        "dynastyDaddy",
+        "fantasyPros",
+        "footballGuys",
+        "yahooBoone",
+        "idpShow",
+    ):
+        assert thresholds[vendor] == 24, f"{vendor} threshold drifted from the universal 24h policy"

--- a/tests/api/test_source_history.py
+++ b/tests/api/test_source_history.py
@@ -1,4 +1,5 @@
 """Tests for per-source value history persistence + backfill."""
+
 from __future__ import annotations
 
 import json
@@ -64,11 +65,15 @@ def test_append_then_load(path):
 def test_dedupe_same_date(path):
     # Two writes on the same date — the second wins.
     source_history.append_snapshot(
-        _make_contract([{"name": "A", "blended": 1000, "sources": {"ktcSfTep": 900}}], date="2026-04-23"),
+        _make_contract(
+            [{"name": "A", "blended": 1000, "sources": {"ktcSfTep": 900}}], date="2026-04-23"
+        ),
         path=path,
     )
     source_history.append_snapshot(
-        _make_contract([{"name": "A", "blended": 1200, "sources": {"ktcSfTep": 1100}}], date="2026-04-23"),
+        _make_contract(
+            [{"name": "A", "blended": 1200, "sources": {"ktcSfTep": 1100}}], date="2026-04-23"
+        ),
         path=path,
     )
     hist = source_history.load_player_history("A", path=path)
@@ -107,6 +112,7 @@ def test_retention_trims_to_max_snapshots(path):
     # iteration that avoids the Jan/Feb modulo collision an earlier
     # version of this test had.
     from datetime import date as _date, timedelta
+
     base = _date(2026, 1, 1)
     for i in range(200):
         d = (base + timedelta(days=i)).isoformat()
@@ -123,7 +129,10 @@ def test_retention_trims_to_max_snapshots(path):
 
 def test_case_insensitive_name_lookup(path):
     source_history.append_snapshot(
-        _make_contract([{"name": "Ja'Marr Chase", "blended": 9999, "sources": {"ktcSfTep": 9900}}], date="2026-04-23"),
+        _make_contract(
+            [{"name": "Ja'Marr Chase", "blended": 9999, "sources": {"ktcSfTep": 9900}}],
+            date="2026-04-23",
+        ),
         path=path,
     )
     hist = source_history.load_player_history("ja'marr chase", path=path)
@@ -203,16 +212,28 @@ def test_missing_player_returns_empty(path):
 def test_backfill_from_exports_merges_with_existing(tmp_path, path):
     # Seed an existing snapshot for 2026-04-23 via the live path.
     source_history.append_snapshot(
-        _make_contract([{"name": "A", "blended": 9999, "sources": {"ktcSfTep": 9000}}], date="2026-04-23"),
+        _make_contract(
+            [{"name": "A", "blended": 9999, "sources": {"ktcSfTep": 9000}}], date="2026-04-23"
+        ),
         date="2026-04-23",
         path=path,
     )
     # Now point backfill at a historical export dated earlier.
     export = tmp_path / "dynasty_data_2026-04-20.json"
-    export.write_text(json.dumps({
-        "date": "2026-04-20",
-        "players": {"A": {"ktcSfTep": 8000, "dlfSf": 8500, "_canonicalSiteValues": {"ktcSfTep": 8000, "dlfSf": 8500}}},
-    }))
+    export.write_text(
+        json.dumps(
+            {
+                "date": "2026-04-20",
+                "players": {
+                    "A": {
+                        "ktcSfTep": 8000,
+                        "dlfSf": 8500,
+                        "_canonicalSiteValues": {"ktcSfTep": 8000, "dlfSf": 8500},
+                    }
+                },
+            }
+        )
+    )
 
     written = source_history.backfill_from_exports([export], path=path)
     assert written == 1
@@ -225,7 +246,10 @@ def test_backfill_from_exports_merges_with_existing(tmp_path, path):
 
 
 def test_append_returns_false_for_empty_contract(path):
-    assert source_history.append_snapshot({"date": "2026-04-23", "playersArray": []}, path=path) is False
+    assert (
+        source_history.append_snapshot({"date": "2026-04-23", "playersArray": []}, path=path)
+        is False
+    )
     assert not path.exists() or path.read_text() == ""
 
 
@@ -295,23 +319,30 @@ def test_backfill_derives_ranks_for_legacy_dict_export(tmp_path, path):
     should populate the derived rank history so the chart can draw
     per-source rank lines for historical dates."""
     export = tmp_path / "dynasty_data_2026-04-15.json"
-    export.write_text(json.dumps({
-        "date": "2026-04-15",
-        "players": {
-            "Star WR": {
-                "ktcSfTep": 9500, "dlfSf": 9000,
-                "_canonicalSiteValues": {"ktcSfTep": 9500, "dlfSf": 9000},
-            },
-            "Mid WR": {
-                "ktcSfTep": 7000, "dlfSf": 7500,
-                "_canonicalSiteValues": {"ktcSfTep": 7000, "dlfSf": 7500},
-            },
-            "Bench WR": {
-                "ktcSfTep": 4000, "dlfSf": 4500,
-                "_canonicalSiteValues": {"ktcSfTep": 4000, "dlfSf": 4500},
-            },
-        },
-    }))
+    export.write_text(
+        json.dumps(
+            {
+                "date": "2026-04-15",
+                "players": {
+                    "Star WR": {
+                        "ktcSfTep": 9500,
+                        "dlfSf": 9000,
+                        "_canonicalSiteValues": {"ktcSfTep": 9500, "dlfSf": 9000},
+                    },
+                    "Mid WR": {
+                        "ktcSfTep": 7000,
+                        "dlfSf": 7500,
+                        "_canonicalSiteValues": {"ktcSfTep": 7000, "dlfSf": 7500},
+                    },
+                    "Bench WR": {
+                        "ktcSfTep": 4000,
+                        "dlfSf": 4500,
+                        "_canonicalSiteValues": {"ktcSfTep": 4000, "dlfSf": 4500},
+                    },
+                },
+            }
+        )
+    )
     source_history.backfill_from_exports([export], path=path)
     # Verify the JSONL stamps sourceRanks for the legacy export.
     raw = path.read_text().strip().splitlines()
@@ -319,19 +350,13 @@ def test_backfill_derives_ranks_for_legacy_dict_export(tmp_path, path):
     snap = json.loads(raw[0])
     # Keys are ``"<displayName>::<assetClass>"`` per ``_player_key``;
     # legacy dict rows without a position resolve to ``"unknown"``.
-    star_entry = next(
-        v for k, v in snap["players"].items() if k.startswith("Star WR")
-    )
+    star_entry = next(v for k, v in snap["players"].items() if k.startswith("Star WR"))
     assert star_entry["sourceRanks"]["ktcSfTep"] == 1
     assert star_entry["sourceRanks"]["dlfSf"] == 1
-    mid_entry = next(
-        v for k, v in snap["players"].items() if k.startswith("Mid WR")
-    )
+    mid_entry = next(v for k, v in snap["players"].items() if k.startswith("Mid WR"))
     assert mid_entry["sourceRanks"]["ktcSfTep"] == 2
     assert mid_entry["sourceRanks"]["dlfSf"] == 2
-    bench_entry = next(
-        v for k, v in snap["players"].items() if k.startswith("Bench WR")
-    )
+    bench_entry = next(v for k, v in snap["players"].items() if k.startswith("Bench WR"))
     assert bench_entry["sourceRanks"]["ktcSfTep"] == 3
     assert bench_entry["sourceRanks"]["dlfSf"] == 3
 
@@ -372,9 +397,7 @@ def test_scope_filter_drops_idp_source_for_offense_player(path):
     # IDP-scope contribution from ever landing in the JSONL.
     raw = path.read_text().strip().splitlines()
     snap = json.loads(raw[0])
-    chase_entry = next(
-        v for k, v in snap["players"].items() if k.startswith("Ja'Marr Chase")
-    )
+    chase_entry = next(v for k, v in snap["players"].items() if k.startswith("Ja'Marr Chase"))
     assert "draftSharksIdp" not in chase_entry["sources"]
     assert "ktcSfTep" in chase_entry["sources"]
 
@@ -529,9 +552,7 @@ def test_retired_ktc_filtered_from_chart_at_write_and_read(path):
 
     # On disk: ``ktc`` is gone from both sources and sourceRanks.
     snap = json.loads(path.read_text().strip().splitlines()[0])
-    bowers_entry = next(
-        v for k, v in snap["players"].items() if k.startswith("Brock Bowers")
-    )
+    bowers_entry = next(v for k, v in snap["players"].items() if k.startswith("Brock Bowers"))
     assert "ktc" not in bowers_entry["sources"]
     assert "ktc" not in bowers_entry.get("sourceRanks", {})
     # ``ktcSfTep`` is the raw scrape value, not the Hill contribution.
@@ -624,7 +645,7 @@ def test_ktc_sftep_reads_raw_from_rawsource_values_field(path):
                 "rankDerivedValue": 7527,
                 "canonicalConsensusRank": 23,
                 "canonicalSiteValues": {"ktcSfTep": 8434},  # synthetic divergent value
-                "rawSourceValues": {"ktcSfTep": 7334},      # raw scrape
+                "rawSourceValues": {"ktcSfTep": 7334},  # raw scrape
                 "sourceRankMeta": {
                     "ktcSfTep": {"valueContribution": 7648},  # Hill contribution
                 },

--- a/tests/api/test_source_monitoring.py
+++ b/tests/api/test_source_monitoring.py
@@ -6,6 +6,7 @@ to contractHealth.
 
 Run with: python3 -m pytest tests/api/test_source_monitoring.py -v
 """
+
 from __future__ import annotations
 
 import copy
@@ -164,9 +165,7 @@ class TestParseErrors(unittest.TestCase):
 
         bogus_paths = dict(_SOURCE_CSV_PATHS)
         bogus_paths["ktc"] = "CSVs/site_raw/nonexistent-ktc.csv"
-        with mock.patch(
-            "src.api.data_contract._SOURCE_CSV_PATHS", bogus_paths
-        ):
+        with mock.patch("src.api.data_contract._SOURCE_CSV_PATHS", bogus_paths):
             contract = build_api_data_contract(raw)
         parse_errors = contract.get("sourceParseErrors")
         self.assertIsInstance(parse_errors, list)
@@ -189,9 +188,7 @@ class TestParseErrors(unittest.TestCase):
 
 
 class TestPartialRunCrossWire(unittest.TestCase):
-    def _minimal_payload_with_partial(
-        self, partial_sources: list[str]
-    ) -> dict[str, Any]:
+    def _minimal_payload_with_partial(self, partial_sources: list[str]) -> dict[str, Any]:
         """Build a minimal payload that passes the other validators but
         carries a partial-run marker in settings.sourceRunSummary."""
         return {
@@ -223,17 +220,13 @@ class TestPartialRunCrossWire(unittest.TestCase):
 
     def test_partial_run_with_tolerable_source_warns_but_ok(self):
         """KTC_TradeDB / KTC_WaiverDB stay as warnings, not errors."""
-        payload = self._minimal_payload_with_partial(
-            ["KTC_TradeDB", "KTC_WaiverDB"]
-        )
+        payload = self._minimal_payload_with_partial(["KTC_TradeDB", "KTC_WaiverDB"])
         report = validate_api_data_contract(payload)
         self.assertTrue(
             report["ok"],
             f"Tolerable partials should not flip ok. errors={report['errors']}",
         )
-        tolerable_warnings = [
-            w for w in report["warnings"] if "partial_run_tolerable" in w
-        ]
+        tolerable_warnings = [w for w in report["warnings"] if "partial_run_tolerable" in w]
         self.assertEqual(len(tolerable_warnings), 2)
 
     def test_tolerable_allowlist_covers_known_ktc_subendpoints(self):
@@ -252,9 +245,7 @@ class TestPickCountFloor(unittest.TestCase):
             self.skipTest("No live data")
         contract, report = result
         pa = contract.get("playersArray") or []
-        pick_count = sum(
-            1 for r in pa if isinstance(r, dict) and r.get("assetClass") == "pick"
-        )
+        pick_count = sum(1 for r in pa if isinstance(r, dict) and r.get("assetClass") == "pick")
         self.assertGreaterEqual(
             pick_count,
             _PICK_COUNT_FLOOR,
@@ -292,9 +283,7 @@ class TestPickCountFloor(unittest.TestCase):
             f"Expected ok=False after dropping picks, got errors={report['errors'][:5]}",
         )
         self.assertTrue(
-            any(
-                e.startswith("pick_count_below_floor:") for e in report["errors"]
-            ),
+            any(e.startswith("pick_count_below_floor:") for e in report["errors"]),
             f"Expected pick_count_below_floor error, got {report['errors'][:5]}",
         )
 
@@ -330,10 +319,7 @@ class TestPayloadSizeFloor(unittest.TestCase):
         )
         # No payload_size_below_floor warning on healthy live.
         self.assertFalse(
-            any(
-                w.startswith("payload_size_below_floor:")
-                for w in report["warnings"]
-            ),
+            any(w.startswith("payload_size_below_floor:") for w in report["warnings"]),
             f"Unexpected payload_size_below_floor warning: {report['warnings'][:5]}",
         )
 
@@ -404,9 +390,7 @@ class TestPayloadSizeFloor(unittest.TestCase):
             "Synthetic payload needs ≥250 players so the floor block runs",
         )
         report = validate_api_data_contract(synthetic)
-        warn_hits = [
-            w for w in report["warnings"] if w.startswith("payload_size_below_floor:")
-        ]
+        warn_hits = [w for w in report["warnings"] if w.startswith("payload_size_below_floor:")]
         self.assertEqual(
             len(warn_hits),
             1,
@@ -473,8 +457,7 @@ class TestTop50Coverage(unittest.TestCase):
         report = validate_api_data_contract(synthetic)
         self.assertTrue(
             any(
-                w.startswith("top50_coverage_below_floor:offense:ktc:")
-                for w in report["warnings"]
+                w.startswith("top50_coverage_below_floor:offense:ktc:") for w in report["warnings"]
             ),
             f"Expected top50_coverage_below_floor:offense:ktc warning, got {report['warnings'][:10]}",
         )
@@ -500,9 +483,7 @@ class TestDlfSchemaProbe(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             bogus = Path(tmpdir) / "dlf_bogus.csv"
-            bogus.write_text(
-                "totally,unrelated,columns\nfoo,bar,baz\n", encoding="utf-8"
-            )
+            bogus.write_text("totally,unrelated,columns\nfoo,bar,baz\n", encoding="utf-8")
             # Use a relative path that resolves correctly from repo root.
             repo_root = Path(__file__).resolve().parents[2]
             try:
@@ -513,9 +494,7 @@ class TestDlfSchemaProbe(unittest.TestCase):
                 rel = str(bogus.resolve())
             patched_paths = dict(_SOURCE_CSV_PATHS)
             patched_paths["dlfSf"] = {"path": rel, "signal": "rank"}
-            with mock.patch(
-                "src.api.data_contract._SOURCE_CSV_PATHS", patched_paths
-            ):
+            with mock.patch("src.api.data_contract._SOURCE_CSV_PATHS", patched_paths):
                 contract = build_api_data_contract(raw)
         parse_errors = contract.get("sourceParseErrors") or []
         schema_errors = [

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -21,6 +21,7 @@ Coverage:
        sourceRankMeta, confidence) is stamped on both paths.
     7. Backbone fallback when the backbone source is disabled.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -244,9 +245,7 @@ class TestNormalizeSourceOverrides(unittest.TestCase):
         self.assertTrue(any("fakeSource" in w for w in warnings))
 
     def test_invalid_weight_is_rejected(self) -> None:
-        out, warnings = normalize_source_overrides(
-            {"ktcSfTep": {"weight": "not a number"}}
-        )
+        out, warnings = normalize_source_overrides({"ktcSfTep": {"weight": "not a number"}})
         self.assertNotIn("weight", out.get("ktcSfTep", {}))
         self.assertTrue(warnings)
         out, warnings = normalize_source_overrides({"ktcSfTep": {"weight": -1}})
@@ -327,9 +326,7 @@ class TestBuildApiDataContractDefaultPath(unittest.TestCase):
         self.assertIsNotNone(rov)
         self.assertFalse(rov.get("isCustomized"))
         # Every registered source should be enabled in the default state.
-        self.assertEqual(
-            set(rov["enabledSources"]), set(get_ranking_source_keys())
-        )
+        self.assertEqual(set(rov["enabledSources"]), set(get_ranking_source_keys()))
         # Every effective weight should match the default (1.0 across the board).
         for key, weight in rov["weights"].items():
             self.assertEqual(weight, rov["defaults"].get(key))
@@ -337,9 +334,7 @@ class TestBuildApiDataContractDefaultPath(unittest.TestCase):
     def test_default_path_equals_explicit_none(self) -> None:
         """Passing ``source_overrides=None`` must be identical to omitting it."""
         a = build_api_data_contract(_fixture_raw_payload())
-        b = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=None
-        )
+        b = build_api_data_contract(_fixture_raw_payload(), source_overrides=None)
         # Strip generatedAt (timestamp differs) before comparing.
         a.pop("generatedAt", None)
         b.pop("generatedAt", None)
@@ -389,9 +384,7 @@ class TestBuildApiDataContractOverridePath(unittest.TestCase):
         # we disable one of the sources that scores him highly, his
         # blended rank-derived value should move.
         override = {"dlfSf": {"include": False}}
-        overridden = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=override
-        )
+        overridden = build_api_data_contract(_fixture_raw_payload(), source_overrides=override)
         by_name = _by_name(overridden)
         allen_baseline = self.baseline_by_name["Josh Allen"]
         allen_overridden = by_name["Josh Allen"]
@@ -410,9 +403,7 @@ class TestBuildApiDataContractOverridePath(unittest.TestCase):
             "dlfSf": {"weight": 0},
             "dynastyNerdsSfTep": {"weight": 0},
         }
-        overridden = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=override
-        )
+        overridden = build_api_data_contract(_fixture_raw_payload(), source_overrides=override)
         by_name = _by_name(overridden)
         # With every other offense source at weight 0, the blend
         # collapses to KTC.  Rookie Wonder (KTC-only, rank 3) should
@@ -424,9 +415,7 @@ class TestBuildApiDataContractOverridePath(unittest.TestCase):
 
     def test_override_rankings_override_block_reflects_config(self) -> None:
         override = {"ktcSfTep": {"include": False}, "dlfSf": {"weight": 0.5}}
-        contract = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=override
-        )
+        contract = build_api_data_contract(_fixture_raw_payload(), source_overrides=override)
         rov = contract.get("rankingsOverride") or {}
         self.assertTrue(rov.get("isCustomized"))
         self.assertNotIn("ktcSfTep", rov.get("enabledSources") or [])
@@ -434,12 +423,8 @@ class TestBuildApiDataContractOverridePath(unittest.TestCase):
         self.assertEqual(rov.get("defaults", {}).get("dlfSf"), 1.0)
 
     def test_disabling_all_sources_produces_empty_ranks(self) -> None:
-        every_off = {
-            key: {"include": False} for key in get_ranking_source_keys()
-        }
-        contract = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=every_off
-        )
+        every_off = {key: {"include": False} for key in get_ranking_source_keys()}
+        contract = build_api_data_contract(_fixture_raw_payload(), source_overrides=every_off)
         # Every row's sourceRanks should be empty.
         for row in contract.get("playersArray", []):
             self.assertEqual(row.get("sourceRanks") or {}, {})
@@ -477,9 +462,7 @@ class TestRankingsTradeCalculatorAlignment(unittest.TestCase):
 
     def test_override_response_stamps_consistent_fields(self) -> None:
         override = {"dlfSf": {"include": False}, "ktcSfTep": {"weight": 2.0}}
-        contract = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=override
-        )
+        contract = build_api_data_contract(_fixture_raw_payload(), source_overrides=override)
         for row in contract.get("playersArray", []):
             source_ranks = row.get("sourceRanks") or {}
             source_meta = row.get("sourceRankMeta") or {}
@@ -500,15 +483,9 @@ class TestRankingsTradeCalculatorAlignment(unittest.TestCase):
         """The final board's canonicalConsensusRank must be monotonic
         by rankDerivedValue under any override."""
         override = {"dlfSf": {"weight": 0}}
-        contract = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=override
-        )
+        contract = build_api_data_contract(_fixture_raw_payload(), source_overrides=override)
         ranked_rows = sorted(
-            [
-                r
-                for r in contract.get("playersArray") or []
-                if r.get("canonicalConsensusRank")
-            ],
+            [r for r in contract.get("playersArray") or [] if r.get("canonicalConsensusRank")],
             key=lambda r: int(r["canonicalConsensusRank"]),
         )
         # Walk adjacent rows: rank i → rank i+1, value should be
@@ -531,9 +508,7 @@ class TestSummarizeSourceOverrides(unittest.TestCase):
     def test_none_input_produces_defaults_summary(self) -> None:
         summary = _summarize_source_overrides(None)
         self.assertFalse(summary["isCustomized"])
-        self.assertEqual(
-            set(summary["enabledSources"]), set(get_ranking_source_keys())
-        )
+        self.assertEqual(set(summary["enabledSources"]), set(get_ranking_source_keys()))
 
     def test_explicit_default_weight_is_not_customized(self) -> None:
         summary = _summarize_source_overrides({"ktcSfTep": {"weight": 1.0}})
@@ -564,9 +539,7 @@ class TestOffenseAndIdpResponseToOverrides(unittest.TestCase):
         # Disabling dlfSf should drop the source from an offense row's
         # stamp.
         self.assertIn("dlfSf", base_by_name["Josh Allen"].get("sourceRanks") or {})
-        self.assertNotIn(
-            "dlfSf", override_by_name["Josh Allen"].get("sourceRanks") or {}
-        )
+        self.assertNotIn("dlfSf", override_by_name["Josh Allen"].get("sourceRanks") or {})
 
     def test_idp_player_responds_to_idp_override(self) -> None:
         base = build_api_data_contract(_fixture_raw_payload())
@@ -577,9 +550,7 @@ class TestOffenseAndIdpResponseToOverrides(unittest.TestCase):
         base_by_name = _by_name(base)
         override_by_name = _by_name(override)
         self.assertIn("dlfIdp", base_by_name["Myles Garrett"].get("sourceRanks") or {})
-        self.assertNotIn(
-            "dlfIdp", override_by_name["Myles Garrett"].get("sourceRanks") or {}
-        )
+        self.assertNotIn("dlfIdp", override_by_name["Myles Garrett"].get("sourceRanks") or {})
 
 
 class TestBuildRankingsDeltaPayload(unittest.TestCase):
@@ -726,12 +697,8 @@ class TestBuildRankingsDeltaPayload(unittest.TestCase):
         """
         override = {"idpTradeCalc": {"weight": 2.0}}
         base = build_api_data_contract(_fixture_raw_payload())
-        full_overridden = build_api_data_contract(
-            _fixture_raw_payload(), source_overrides=override
-        )
-        delta = build_rankings_delta_payload(
-            _fixture_raw_payload(), source_overrides=override
-        )
+        full_overridden = build_api_data_contract(_fixture_raw_payload(), source_overrides=override)
+        delta = build_rankings_delta_payload(_fixture_raw_payload(), source_overrides=override)
 
         # Manually merge in Python — mirrors the JS mergeRankingsDelta.
         delta_by_id = {e["id"]: e for e in delta["rankingsDelta"]["players"]}
@@ -798,9 +765,7 @@ class TestNormalizeTepMultiplier(unittest.TestCase):
     def test_snake_case_wins_over_camel_case(self) -> None:
         # Both forms present: snake_case is the canonical spelling and
         # should win if a caller mixes them.
-        result = normalize_tep_multiplier(
-            {"tep_multiplier": 1.15, "tepMultiplier": 1.5}
-        )
+        result = normalize_tep_multiplier({"tep_multiplier": 1.15, "tepMultiplier": 1.5})
         self.assertEqual(result, 1.15)
 
     def test_out_of_range_values_clamp(self) -> None:
@@ -813,12 +778,8 @@ class TestNormalizeTepMultiplier(unittest.TestCase):
         # not to a silent 1.0 (which would mask garbled bodies).
         self.assertIsNone(normalize_tep_multiplier({"tep_multiplier": "nope"}))
         self.assertIsNone(normalize_tep_multiplier({"tep_multiplier": None}))
-        self.assertIsNone(
-            normalize_tep_multiplier({"tep_multiplier": float("inf")})
-        )
-        self.assertIsNone(
-            normalize_tep_multiplier({"tep_multiplier": float("nan")})
-        )
+        self.assertIsNone(normalize_tep_multiplier({"tep_multiplier": float("inf")}))
+        self.assertIsNone(normalize_tep_multiplier({"tep_multiplier": float("nan")}))
 
     def test_non_dict_input_returns_none(self) -> None:
         self.assertIsNone(normalize_tep_multiplier("1.15"))
@@ -881,12 +842,8 @@ class TestNormalizeTepNativeMultiplier(unittest.TestCase):
     def test_unparseable_returns_none(self) -> None:
         self.assertIsNone(normalize_tep_native_multiplier({"tep_native_multiplier": "nope"}))
         self.assertIsNone(normalize_tep_native_multiplier({"tep_native_multiplier": None}))
-        self.assertIsNone(
-            normalize_tep_native_multiplier({"tep_native_multiplier": float("inf")})
-        )
-        self.assertIsNone(
-            normalize_tep_native_multiplier({"tep_native_multiplier": float("nan")})
-        )
+        self.assertIsNone(normalize_tep_native_multiplier({"tep_native_multiplier": float("inf")}))
+        self.assertIsNone(normalize_tep_native_multiplier({"tep_native_multiplier": float("nan")}))
 
 
 class TestTepMultiplierDerivation(unittest.TestCase):
@@ -926,15 +883,9 @@ class TestTepMultiplierDerivation(unittest.TestCase):
 
     def test_derive_floors_at_one(self) -> None:
         """Negative / invalid bonuses floor at 1.0 (no TE discount)."""
-        self.assertEqual(
-            _derive_tep_multiplier_from_league({"bonus_rec_te": -0.5}), 1.0
-        )
-        self.assertEqual(
-            _derive_tep_multiplier_from_league({"bonus_rec_te": None}), 1.0
-        )
-        self.assertEqual(
-            _derive_tep_multiplier_from_league({"bonus_rec_te": "nope"}), 1.0
-        )
+        self.assertEqual(_derive_tep_multiplier_from_league({"bonus_rec_te": -0.5}), 1.0)
+        self.assertEqual(_derive_tep_multiplier_from_league({"bonus_rec_te": None}), 1.0)
+        self.assertEqual(_derive_tep_multiplier_from_league({"bonus_rec_te": "nope"}), 1.0)
 
     def test_derive_with_none_context_falls_back_to_default(self) -> None:
         """No context (offline / no SLEEPER_LEAGUE_ID) → no-op."""
@@ -978,9 +929,7 @@ class TestBuildContractTepSlider(unittest.TestCase):
 
     def test_explicit_override_reflected_in_summary(self) -> None:
         for v in (1.0, 1.10, 1.25, 1.40, 1.5):
-            contract = build_api_data_contract(
-                _fixture_raw_payload(), tep_multiplier=v
-            )
+            contract = build_api_data_contract(_fixture_raw_payload(), tep_multiplier=v)
             rov = contract.get("rankingsOverride") or {}
             self.assertAlmostEqual(
                 float(rov.get("tepMultiplier") or 0),
@@ -994,9 +943,7 @@ class TestBuildContractTepSlider(unittest.TestCase):
             )
 
     def test_none_falls_back_to_default(self) -> None:
-        contract = build_api_data_contract(
-            _fixture_raw_payload(), tep_multiplier=None
-        )
+        contract = build_api_data_contract(_fixture_raw_payload(), tep_multiplier=None)
         rov = contract.get("rankingsOverride") or {}
         self.assertAlmostEqual(
             float(rov.get("tepMultiplier") or 0),
@@ -1047,9 +994,7 @@ class TestBuildContractTepAutoDerive(unittest.TestCase):
             contract = build_api_data_contract(_fixture_raw_payload())
         rov = contract.get("rankingsOverride") or {}
         self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.15, places=4)
-        self.assertAlmostEqual(
-            float(rov.get("tepMultiplierDerived") or 0), 1.15, places=4
-        )
+        self.assertAlmostEqual(float(rov.get("tepMultiplierDerived") or 0), 1.15, places=4)
         self.assertEqual(rov.get("tepMultiplierSource"), "derived")
         # Reverse-derive bonusRecTe lands back at 0.5 (round-trip
         # through the summary stamp).
@@ -1101,14 +1046,10 @@ class TestBuildContractTepAutoDerive(unittest.TestCase):
         with 1.40" semantics.
         """
         with self._patch_context(bonus_rec_te=0.5):
-            contract = build_api_data_contract(
-                _fixture_raw_payload(), tep_multiplier=1.40
-            )
+            contract = build_api_data_contract(_fixture_raw_payload(), tep_multiplier=1.40)
         rov = contract.get("rankingsOverride") or {}
         self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.40, places=4)
-        self.assertAlmostEqual(
-            float(rov.get("tepMultiplierDerived") or 0), 1.15, places=4
-        )
+        self.assertAlmostEqual(float(rov.get("tepMultiplierDerived") or 0), 1.15, places=4)
         self.assertEqual(rov.get("tepMultiplierSource"), "override")
 
     def test_tep_native_default_unchanged_by_derivation(self) -> None:
@@ -1122,14 +1063,10 @@ class TestBuildContractTepAutoDerive(unittest.TestCase):
             contract = build_api_data_contract(_fixture_raw_payload())
         rov = contract.get("rankingsOverride") or {}
         # Non-TEP slider auto-derives to 1.30 for TEP-2.0
-        self.assertAlmostEqual(
-            float(rov.get("tepMultiplier") or 0), 1.30, places=4
-        )
+        self.assertAlmostEqual(float(rov.get("tepMultiplier") or 0), 1.30, places=4)
         self.assertEqual(rov.get("tepMultiplierSource"), "derived")
         # TEP-native stays at 1.10 default — unaffected
-        self.assertAlmostEqual(
-            float(rov.get("tepNativeMultiplier") or 0), 1.10, places=4
-        )
+        self.assertAlmostEqual(float(rov.get("tepNativeMultiplier") or 0), 1.10, places=4)
         self.assertEqual(rov.get("tepNativeMultiplierSource"), "default")
 
 
@@ -1210,9 +1147,7 @@ class TestTepMultipliersEndToEnd(unittest.TestCase):
             dlf_meta.get("tepBoostApplied"),
             "dlfSf on a TE row must be marked as TEP-boosted",
         )
-        self.assertAlmostEqual(
-            float(dlf_meta.get("tepMultiplier") or 0), 1.30
-        )
+        self.assertAlmostEqual(float(dlf_meta.get("tepMultiplier") or 0), 1.30)
 
         # TEP-native source: dynastyNerdsSfTep carries the native flag
         # and the effective correction.
@@ -1221,9 +1156,7 @@ class TestTepMultipliersEndToEnd(unittest.TestCase):
             dn_meta.get("tepNativeCorrectionApplied"),
             "dynastyNerdsSfTep on a TE row must be marked as TEP-native-corrected",
         )
-        self.assertAlmostEqual(
-            float(dn_meta.get("tepNativeCorrection") or 0), 1.05
-        )
+        self.assertAlmostEqual(float(dn_meta.get("tepNativeCorrection") or 0), 1.05)
 
         # The non-native and native paths are mutually exclusive — a
         # source flagged as one bucket must not pick up the other.
@@ -1250,13 +1183,9 @@ class TestTepMultipliersEndToEnd(unittest.TestCase):
                 {"tep_multiplier": 1.45, "tep_native_multiplier": 1.20},
             ),
         ):
-            contract = build_api_data_contract(
-                _fixture_raw_payload(), **kwargs
-            )
+            contract = build_api_data_contract(_fixture_raw_payload(), **kwargs)
             bowers = _by_name(contract).get("Brock Bowers")
-            self.assertIsNotNone(
-                bowers, f"{label}: fixture must include the Brock Bowers TE row"
-            )
+            self.assertIsNotNone(bowers, f"{label}: fixture must include the Brock Bowers TE row")
             ktc_meta = (bowers.get("sourceRankMeta") or {}).get("ktcSfTep") or {}
             # The exempt source carries no boost / correction flag, so
             # ``valueContribution`` is the raw curve value untouched.

--- a/tests/api/test_source_registry_parity.py
+++ b/tests/api/test_source_registry_parity.py
@@ -18,6 +18,7 @@ When adding a new source:
     3. Run this test — it must pass.  If it fails, your frontend
        registry doesn't match the Python one.
 """
+
 from __future__ import annotations
 
 import re
@@ -53,9 +54,7 @@ def _parse_frontend_registry() -> list[dict[str, Any]]:
     the Python registry.
     """
     if not FRONTEND_REGISTRY_PATH.exists():
-        raise FileNotFoundError(
-            f"Frontend registry file not found: {FRONTEND_REGISTRY_PATH}"
-        )
+        raise FileNotFoundError(f"Frontend registry file not found: {FRONTEND_REGISTRY_PATH}")
     text = FRONTEND_REGISTRY_PATH.read_text(encoding="utf-8")
 
     start_match = re.search(

--- a/tests/api/test_startup_validation.py
+++ b/tests/api/test_startup_validation.py
@@ -1,4 +1,5 @@
 """Tests for startup validation checks."""
+
 from __future__ import annotations
 
 import pytest
@@ -76,6 +77,7 @@ def test_summary_shape(tmp_path):
 def test_run_all_never_raises_on_broken_extra_check(tmp_path):
     def _bad():
         raise RuntimeError("boom")
+
     checks = sv.run_all(data_dir=tmp_path, extra_checks=[_bad])
     names = {c.name for c in checks}
     assert "extra:_bad" in names

--- a/tests/api/test_team_assignment.py
+++ b/tests/api/test_team_assignment.py
@@ -6,6 +6,7 @@ T5 IDP), the assignment threshold, the max-3 cap, the favorite-
 always-wins invariant, and the config fallback when the JSON file
 is malformed.
 """
+
 from __future__ import annotations
 
 import json
@@ -116,10 +117,16 @@ def test_load_config_falls_back_on_malformed_json(tmp_path: Path):
 
 
 def test_load_config_strips_doc_keys(tmp_path: Path):
-    p = _config_path(tmp_path, {
-        "_doc": "outer doc",
-        "favorites": {"_doc": "inner doc", "joel": {"abbr": "KC", "display": "Kansas City Chiefs"}},
-    })
+    p = _config_path(
+        tmp_path,
+        {
+            "_doc": "outer doc",
+            "favorites": {
+                "_doc": "inner doc",
+                "joel": {"abbr": "KC", "display": "Kansas City Chiefs"},
+            },
+        },
+    )
     cfg = team_assignment.load_config(p)
     assert "_doc" not in cfg
     assert "_doc" not in cfg["favorites"]
@@ -127,9 +134,12 @@ def test_load_config_strips_doc_keys(tmp_path: Path):
 
 
 def test_load_config_merges_partial_user_config_over_defaults(tmp_path: Path):
-    p = _config_path(tmp_path, {
-        "weights": {"qbAnchor": 999},  # override one knob; rest stays default
-    })
+    p = _config_path(
+        tmp_path,
+        {
+            "weights": {"qbAnchor": 999},  # override one knob; rest stays default
+        },
+    )
     cfg = team_assignment.load_config(p)
     assert cfg["weights"]["qbAnchor"] == 999
     # Sibling weights still defaulted.
@@ -151,14 +161,8 @@ def test_resolve_favorite_key_direct_match():
 def test_resolve_favorite_key_via_alias():
     favs = {"jason": {"abbr": "MIN"}, "michaela": {"abbr": "MIA"}}
     aliases = {"jasonleetucker": "jason", "makayla": "michaela"}
-    assert (
-        team_assignment._resolve_favorite_key("JasonLeeTucker", favs, aliases)
-        == "jason"
-    )
-    assert (
-        team_assignment._resolve_favorite_key("MaKayla", favs, aliases)
-        == "michaela"
-    )
+    assert team_assignment._resolve_favorite_key("JasonLeeTucker", favs, aliases) == "jason"
+    assert team_assignment._resolve_favorite_key("MaKayla", favs, aliases) == "michaela"
 
 
 def test_resolve_favorite_key_missing_falls_to_none():
@@ -179,7 +183,9 @@ def _config():
 def test_score_qb_anchor():
     qb = _player("KC", "QB", depth=1, years_exp=5)
     pts, contribs = team_assignment._score_player(
-        qb, config=_config(), league_idp_enabled=False,
+        qb,
+        config=_config(),
+        league_idp_enabled=False,
     )
     # T1 (10) + T3 elite proxy at QB depth 1 (3) = 13.
     assert pts == 13
@@ -190,7 +196,9 @@ def test_score_qb_anchor():
 def test_score_qb_backup_no_anchor():
     qb = _player("KC", "QB", depth=2, years_exp=5)
     pts, _ = team_assignment._score_player(
-        qb, config=_config(), league_idp_enabled=False,
+        qb,
+        config=_config(),
+        league_idp_enabled=False,
     )
     # No T1 (depth != 1).  No T3 (also gated on depth 1).  No
     # rookie / IDP / skill rules apply.  → 0.
@@ -200,7 +208,9 @@ def test_score_qb_backup_no_anchor():
 def test_score_skill_starter_and_elite_proxy():
     rb = _player("BUF", "RB", depth=1, years_exp=3)
     pts, contribs = team_assignment._score_player(
-        rb, config=_config(), league_idp_enabled=False,
+        rb,
+        config=_config(),
+        league_idp_enabled=False,
     )
     # T2 starter (5) + T3 elite proxy (3) = 8.
     assert pts == 8
@@ -211,7 +221,9 @@ def test_score_skill_starter_and_elite_proxy():
 def test_score_skill_committee():
     rb = _player("BUF", "RB", depth=2, years_exp=3)
     pts, _ = team_assignment._score_player(
-        rb, config=_config(), league_idp_enabled=False,
+        rb,
+        config=_config(),
+        league_idp_enabled=False,
     )
     # T2 committee (2).  No T3 (depth != 1).  → 2.
     assert pts == 2
@@ -220,7 +232,9 @@ def test_score_skill_committee():
 def test_score_skill_bench_zero():
     rb = _player("BUF", "RB", depth=4, years_exp=3)
     pts, _ = team_assignment._score_player(
-        rb, config=_config(), league_idp_enabled=False,
+        rb,
+        config=_config(),
+        league_idp_enabled=False,
     )
     assert pts == 0
 
@@ -228,7 +242,9 @@ def test_score_skill_bench_zero():
 def test_score_rookie_round_one():
     rookie = _player("CHI", "WR", depth=1, years_exp=0, draft_round=1)
     pts, contribs = team_assignment._score_player(
-        rookie, config=_config(), league_idp_enabled=False,
+        rookie,
+        config=_config(),
+        league_idp_enabled=False,
     )
     # T2 starter (5) + T3 elite proxy (3) + T4 round 1 (4) = 12.
     assert pts == 12
@@ -238,7 +254,9 @@ def test_score_rookie_round_one():
 def test_score_rookie_round_two():
     rookie = _player("CHI", "WR", depth=2, years_exp=0, draft_round=2)
     pts, contribs = team_assignment._score_player(
-        rookie, config=_config(), league_idp_enabled=False,
+        rookie,
+        config=_config(),
+        league_idp_enabled=False,
     )
     # T2 committee (2) + T4 round 2 (2) = 4.
     assert pts == 4
@@ -249,12 +267,16 @@ def test_score_idp_starter_only_when_league_idp_enabled():
     lb = _player("DAL", "LB", depth=1, years_exp=3)
     # IDP off -> no points at all.
     off_pts, _ = team_assignment._score_player(
-        lb, config=_config(), league_idp_enabled=False,
+        lb,
+        config=_config(),
+        league_idp_enabled=False,
     )
     assert off_pts == 0
     # IDP on -> T5 starter (2).
     on_pts, _ = team_assignment._score_player(
-        lb, config=_config(), league_idp_enabled=True,
+        lb,
+        config=_config(),
+        league_idp_enabled=True,
     )
     assert on_pts == 2
 
@@ -262,7 +284,9 @@ def test_score_idp_starter_only_when_league_idp_enabled():
 def test_score_player_with_no_position_returns_zero():
     odd = {"team": "KC", "position": ""}
     pts, contribs = team_assignment._score_player(
-        odd, config=_config(), league_idp_enabled=False,
+        odd,
+        config=_config(),
+        league_idp_enabled=False,
     )
     assert pts == 0
     assert contribs == []
@@ -274,17 +298,20 @@ def test_score_player_with_no_position_returns_zero():
 def _stub_config(monkeypatch, tmp_path: Path):
     """Patch the module's _CONFIG_PATH to a tmp file so each test
     runs against an isolated config without leaking real favorites."""
-    cfg_path = _config_path(tmp_path, {
-        "favorites": {
-            "jason": {"abbr": "MIN", "display": "Minnesota Vikings"},
-            "brent": {"abbr": "BUF", "display": "Buffalo Bills"},
+    cfg_path = _config_path(
+        tmp_path,
+        {
+            "favorites": {
+                "jason": {"abbr": "MIN", "display": "Minnesota Vikings"},
+                "brent": {"abbr": "BUF", "display": "Buffalo Bills"},
+            },
+            "displayNameAliases": {
+                "jasonleetucker": "jason",
+            },
+            "thresholds": {"assignmentMinPoints": 10},
+            "limits": {"maxTeamsPerOwner": 3},
         },
-        "displayNameAliases": {
-            "jasonleetucker": "jason",
-        },
-        "thresholds": {"assignmentMinPoints": 10},
-        "limits": {"maxTeamsPerOwner": 3},
-    })
+    )
     monkeypatch.setattr(team_assignment, "_CONFIG_PATH", cfg_path)
 
 
@@ -319,9 +346,9 @@ def test_build_section_includes_roster_based_when_above_threshold(monkeypatch, t
         {"roster_id": 1, "owner_id": "oA", "players": ["p1", "p2", "p3"]},
     ]
     nfl = {
-        "p1": _player("BUF", "QB", depth=1, years_exp=5),       # +13
-        "p2": _player("BUF", "RB", depth=1, years_exp=3),       # +8
-        "p3": _player("BUF", "WR", depth=2, years_exp=3),       # +2
+        "p1": _player("BUF", "QB", depth=1, years_exp=5),  # +13
+        "p2": _player("BUF", "RB", depth=1, years_exp=3),  # +8
+        "p3": _player("BUF", "WR", depth=2, years_exp=3),  # +2
     }
     # Total Bills score: 23.  Threshold is 10.  Should appear.
     snap = _snapshot(rosters, nfl, mgrs)
@@ -364,16 +391,16 @@ def test_build_section_caps_at_max_teams(monkeypatch, tmp_path: Path):
     # Stock five different NFL teams with +13 each (QB anchor + elite).
     nfl = {
         "p1": _player("BUF", "QB", depth=1, years_exp=5),
-        "p2": _player("KC",  "QB", depth=1, years_exp=5),
+        "p2": _player("KC", "QB", depth=1, years_exp=5),
         "p3": _player("DET", "QB", depth=1, years_exp=5),
         "p4": _player("PHI", "QB", depth=1, years_exp=5),
         "p5": _player("BAL", "QB", depth=1, years_exp=5),
         # Ensure tiebreaker is alphabetical when scores are equal.
         "p6": _player("BUF", "RB", depth=1, years_exp=5),  # bumps BUF to 21
         "p7": _player("BUF", "WR", depth=1, years_exp=5),  # bumps BUF to 29
-        "p8": _player("KC",  "RB", depth=1, years_exp=5),  # bumps KC to 21
+        "p8": _player("KC", "RB", depth=1, years_exp=5),  # bumps KC to 21
         "p9": _player("DET", "RB", depth=1, years_exp=5),  # bumps DET to 21
-        "p10": _player("PHI", "RB", depth=1, years_exp=5), # bumps PHI to 21
+        "p10": _player("PHI", "RB", depth=1, years_exp=5),  # bumps PHI to 21
     }
     snap = _snapshot(rosters, nfl, mgrs)
     section = team_assignment.build_section(snap)
@@ -421,9 +448,7 @@ def test_build_section_emits_contributors_breakdown(monkeypatch, tmp_path: Path)
     }
     snap = _snapshot(rosters, nfl, mgrs)
     section = team_assignment.build_section(snap)
-    bills = next(
-        t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "BUF"
-    )
+    bills = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "BUF")
     contribs = bills["contributors"]
     # Expect one contributor row per scoring rule that fired.
     assert len(contribs) >= 3
@@ -464,9 +489,7 @@ def test_build_section_idp_on_includes_idp_starter_when_above_threshold(
     assert "DAL" in abbrs
 
 
-def test_build_section_no_favorite_match_still_emits_roster_assignment(
-    monkeypatch, tmp_path: Path
-):
+def test_build_section_no_favorite_match_still_emits_roster_assignment(monkeypatch, tmp_path: Path):
     """Manager with no favorite configured still gets roster-based
     assignments above the threshold."""
     _stub_config(monkeypatch, tmp_path)
@@ -490,11 +513,13 @@ def test_build_section_orders_assignments_alphabetically_by_display_name(
     monkeypatch, tmp_path: Path
 ):
     _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={
-        "oA": _manager("oA", "Zane"),
-        "oB": _manager("oB", "Alex"),
-        "oC": _manager("oC", "Brent"),
-    })
+    mgrs = ManagerRegistry(
+        by_owner_id={
+            "oA": _manager("oA", "Zane"),
+            "oB": _manager("oB", "Alex"),
+            "oC": _manager("oC", "Brent"),
+        }
+    )
     rosters = [
         {"roster_id": 1, "owner_id": "oA", "players": []},
         {"roster_id": 2, "owner_id": "oB", "players": []},
@@ -514,6 +539,7 @@ def test_section_registered_in_public_contract():
         _SECTION_BUILDERS,
         PUBLIC_SECTION_KEYS,
     )
+
     assert "teamAssignment" in _SECTION_BUILDERS
     assert "teamAssignment" in PUBLIC_SECTION_KEYS
 

--- a/tests/api/test_terminal.py
+++ b/tests/api/test_terminal.py
@@ -1,4 +1,5 @@
 """Tests for the ``/api/terminal`` aggregation endpoint builder."""
+
 from __future__ import annotations
 
 import json
@@ -23,14 +24,16 @@ def history_path(tmp_path, monkeypatch):
     lines = []
     for i in range(0, 200):
         d = today - timedelta(days=i)
-        lines.append({
-            "date": _iso(d),
-            "ranks": {
-                "Alice::offense": 10 + (i // 30),
-                "Bob::offense": 25 + (i // 20),
-                "Carlo::offense": 60,
-            },
-        })
+        lines.append(
+            {
+                "date": _iso(d),
+                "ranks": {
+                    "Alice::offense": 10 + (i // 30),
+                    "Bob::offense": 25 + (i // 20),
+                    "Carlo::offense": 60,
+                },
+            }
+        )
     # Reverse so we write oldest-first just to match production style.
     for line in reversed(lines):
         path.open("a").write(json.dumps(line) + "\n")
@@ -157,7 +160,9 @@ def test_build_terminal_payload_full_for_selected_team(history_path):
 def test_build_terminal_payload_with_no_team_still_renders(history_path):
     contract = _mk_contract(history_path)
     payload = terminal.build_terminal_payload(
-        contract, resolved_team=None, window_days=30,
+        contract,
+        resolved_team=None,
+        window_days=30,
     )
     assert payload["team"] is None
     assert payload["teamAggregates"]["totalValue"] is None
@@ -168,7 +173,9 @@ def test_build_terminal_payload_with_no_team_still_renders(history_path):
 def test_trend_windows_advertised(history_path):
     contract = _mk_contract(history_path)
     payload = terminal.build_terminal_payload(
-        contract, resolved_team=None, window_days=30,
+        contract,
+        resolved_team=None,
+        window_days=30,
     )
     assert payload["trendWindows"] == [7, 30, 90, 180]
 
@@ -199,7 +206,9 @@ def test_roster_aware_delta_uses_trade_history(history_path):
     ]
     team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
     payload = terminal.build_terminal_payload(
-        contract, resolved_team=team, window_days=30,
+        contract,
+        resolved_team=team,
+        window_days=30,
     )
     # Past roster for owner-1 at 30d ago should have INCLUDED Bob (he
     # was on the team before the trade).  Current roster only has
@@ -240,7 +249,9 @@ def test_dismissed_signals_reflected_in_payload(history_path):
 def test_available_teams_returned_for_picker(history_path):
     contract = _mk_contract(history_path)
     payload = terminal.build_terminal_payload(
-        contract, resolved_team=None, window_days=30,
+        contract,
+        resolved_team=None,
+        window_days=30,
     )
     owners = {t["ownerId"] for t in payload["availableTeams"]}
     assert owners == {"owner-1", "owner-2"}
@@ -360,17 +371,19 @@ def test_low_coverage_produces_null_value_with_fraction(history_path):
     team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
     # Add a 3rd roster player with no history to drop coverage below 60%.
     contract["sleeper"]["teams"][0]["players"].append("Ghost")
-    contract["playersArray"].append({
-        "displayName": "Ghost",
-        "canonicalName": "Ghost",
-        "assetClass": "offense",
-        "position": "TE",
-        "pos": "TE",
-        "canonicalConsensusRank": 200,
-        "rankChange": None,
-        "rankDerivedValue": 100,
-        "values": {"full": 100},
-    })
+    contract["playersArray"].append(
+        {
+            "displayName": "Ghost",
+            "canonicalName": "Ghost",
+            "assetClass": "offense",
+            "position": "TE",
+            "pos": "TE",
+            "canonicalConsensusRank": 200,
+            "rankChange": None,
+            "rankDerivedValue": 100,
+            "values": {"full": 100},
+        }
+    )
     team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
     payload = terminal.build_terminal_payload(contract, resolved_team=team, window_days=30)
     d30 = payload["teamAggregates"]["delta30dDetail"]
@@ -478,7 +491,9 @@ def test_value_history_fallback_covers_when_rank_history_missing(tmp_path, monke
     contract = _mk_contract(tmp_path / "rank_history.jsonl")
     team = terminal.resolve_team(contract, owner_id="owner-1", name=None)
     payload = terminal.build_terminal_payload(
-        contract, resolved_team=team, window_days=30,
+        contract,
+        resolved_team=team,
+        window_days=30,
     )
     d30 = payload["teamAggregates"]["delta30dDetail"]
     # With value-history now primed, we should see real coverage
@@ -508,8 +523,7 @@ def test_dismissal_resolves_via_alias_key_after_rename(history_path):
             row["displayName"] = "Alice Renamed"
             row["canonicalName"] = "Alice Renamed"
     contract["sleeper"]["teams"][0]["players"] = [
-        "Alice Renamed" if p == "Alice" else p
-        for p in contract["sleeper"]["teams"][0]["players"]
+        "Alice Renamed" if p == "Alice" else p for p in contract["sleeper"]["teams"][0]["players"]
     ]
     # Append "Alice Renamed::offense" to every snapshot with the
     # same ranks the log already has for Alice.

--- a/tests/api/test_test_session_endpoint.py
+++ b/tests/api/test_test_session_endpoint.py
@@ -3,6 +3,7 @@
 Key invariant: the endpoint 404's (NOT 401) when E2E_TEST_MODE is
 off — 401 would leak the endpoint's existence.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/api/test_trade_simulate_mc.py
+++ b/tests/api/test_trade_simulate_mc.py
@@ -6,6 +6,7 @@ Pins:
   * Flag on + valid body → 200 with expected shape.
   * Disclaimer + labelHint always present in the response.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -26,14 +27,18 @@ def _sample_body():
     return {
         "sideA": [
             {
-                "name": "Josh Allen", "team": "BUF", "pos": "QB",
+                "name": "Josh Allen",
+                "team": "BUF",
+                "pos": "QB",
                 "rankDerivedValue": 9200,
                 "valueBand": {"p10": 8500, "p50": 9200, "p90": 9900},
             }
         ],
         "sideB": [
             {
-                "name": "Jalen Hurts", "team": "PHI", "pos": "QB",
+                "name": "Jalen Hurts",
+                "team": "PHI",
+                "pos": "QB",
                 "rankDerivedValue": 8500,
                 "valueBand": {"p10": 7800, "p50": 8500, "p90": 9200},
             }
@@ -103,8 +108,11 @@ def test_invalid_body_returns_400(monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "test"})
     with TestClient(server.app, raise_server_exceptions=True) as c:
-        res = c.post("/api/trade/simulate-mc", content=b"not json",
-                     headers={"content-type": "application/json"})
+        res = c.post(
+            "/api/trade/simulate-mc",
+            content=b"not json",
+            headers={"content-type": "application/json"},
+        )
     assert res.status_code == 400
 
 
@@ -148,6 +156,7 @@ def test_timeout_returns_clean_504(monkeypatch):
 
     def _slow(*a, **k):
         import time as _t
+
         _t.sleep(1.5)
         raise AssertionError("should have timed out before returning")
 

--- a/tests/api/test_trade_simulator.py
+++ b/tests/api/test_trade_simulator.py
@@ -1,4 +1,5 @@
 """Tests for the ``/api/trade/simulate`` helper."""
+
 from __future__ import annotations
 
 import pytest
@@ -12,6 +13,7 @@ def _mk_contract() -> dict:
     from ``rank_to_value`` so the simulator can operate on real
     Hill-curve numbers.
     """
+
     def row(name, rank, pos="WR", asset="offense"):
         return {
             "displayName": name,
@@ -24,6 +26,7 @@ def _mk_contract() -> dict:
             "rankDerivedValue": int(rank_to_value(rank)),
             "values": {"full": int(rank_to_value(rank))},
         }
+
     return {
         "playersArray": [
             row("Alice", 5, "QB"),
@@ -56,8 +59,10 @@ def test_simulate_empty_trade_equity_zero():
     contract = _mk_contract()
     team = terminal.resolve_team(contract, owner_id="o1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=[], players_out=[],
+        contract,
+        resolved_team=team,
+        players_in=[],
+        players_out=[],
     )
     assert result["equity"] == 0
     assert result["before"]["totalValue"] == result["after"]["totalValue"]
@@ -69,8 +74,10 @@ def test_simulate_straight_swap():
     team = terminal.resolve_team(contract, owner_id="o1", name=None)
     # Alice(QB rank 5) OUT for Diana(TE rank 90) IN — big value loss.
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["Diana"], players_out=["Alice"],
+        contract,
+        resolved_team=team,
+        players_in=["Diana"],
+        players_out=["Alice"],
     )
     assert len(result["receiving"]) == 1
     assert len(result["sending"]) == 1
@@ -87,7 +94,8 @@ def test_simulate_two_for_one_net_positive():
     team = terminal.resolve_team(contract, owner_id="o1", name=None)
     # Sending Alice + Bob, receiving Diana only — equity is negative.
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
+        contract,
+        resolved_team=team,
         players_in=["Diana"],
         players_out=["Alice", "Bob"],
     )
@@ -108,7 +116,8 @@ def test_simulate_unresolved_names_surfaced():
     contract = _mk_contract()
     team = terminal.resolve_team(contract, owner_id="o1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
+        contract,
+        resolved_team=team,
         players_in=["Totally Fake Person"],
         players_out=["Alice"],
     )
@@ -126,7 +135,8 @@ def test_simulate_dedupes_when_outbound_player_not_on_roster():
     # Trying to trade Carlo (on Team Bravo, not Alpha) OUT shouldn't
     # crash; the simulator treats it as "removed if present".
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
+        contract,
+        resolved_team=team,
         players_in=["Diana"],
         players_out=["Carlo"],
     )
@@ -142,8 +152,10 @@ def test_simulate_dedupes_when_outbound_player_not_on_roster():
 def test_simulate_no_team_returns_empty_before():
     contract = _mk_contract()
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=None,
-        players_in=["Alice"], players_out=[],
+        contract,
+        resolved_team=None,
+        players_in=["Alice"],
+        players_out=[],
     )
     assert result["team"] is None
     assert result["before"]["totalValue"] == 0
@@ -155,9 +167,16 @@ def test_simulate_no_team_returns_empty_before():
 _IDP_LEAGUE_SETTINGS = {
     "teamCount": 12,
     "starters": {
-        "QB": 1, "RB": 2, "WR": 3, "TE": 1,
-        "FLEX": 2, "SFLEX": 1,
-        "DL": 2, "LB": 2, "DB": 2, "IDP_FLEX": 2,
+        "QB": 1,
+        "RB": 2,
+        "WR": 3,
+        "TE": 1,
+        "FLEX": 2,
+        "SFLEX": 1,
+        "DL": 2,
+        "LB": 2,
+        "DB": 2,
+        "IDP_FLEX": 2,
     },
     "flexEligible": ["RB", "WR", "TE"],
     "sflexEligible": ["QB", "RB", "WR", "TE"],
@@ -167,8 +186,12 @@ _IDP_LEAGUE_SETTINGS = {
 _NON_IDP_LEAGUE_SETTINGS = {
     "teamCount": 10,
     "starters": {
-        "QB": 1, "RB": 2, "WR": 3, "TE": 1,
-        "FLEX": 2, "SFLEX": 1,
+        "QB": 1,
+        "RB": 2,
+        "WR": 3,
+        "TE": 1,
+        "FLEX": 2,
+        "SFLEX": 1,
     },
     "flexEligible": ["RB", "WR", "TE"],
     "sflexEligible": ["QB", "RB", "WR", "TE"],
@@ -177,6 +200,7 @@ _NON_IDP_LEAGUE_SETTINGS = {
 
 def _mk_full_roster_contract():
     """Roster with realistic depth/holes for fit-score tests."""
+
     def row(name, rank, pos, age=27, asset="offense"):
         return {
             "displayName": name,
@@ -190,6 +214,7 @@ def _mk_full_roster_contract():
             "rankDerivedValue": int(rank_to_value(rank)),
             "values": {"full": int(rank_to_value(rank))},
         }
+
     rows = [
         row("StarQB", 5, "QB", age=27),
         row("StarQB2", 12, "QB", age=26),
@@ -208,14 +233,25 @@ def _mk_full_roster_contract():
     return {
         "playersArray": rows,
         "sleeper": {
-            "teams": [{
-                "ownerId": "u1",
-                "name": "User",
-                "roster_id": 1,
-                "players": ["StarQB", "StarQB2", "RB1", "RB2", "RB3",
-                            "WR1", "WR2", "WR3", "TE1"],
-                "picks": [],
-            }],
+            "teams": [
+                {
+                    "ownerId": "u1",
+                    "name": "User",
+                    "roster_id": 1,
+                    "players": [
+                        "StarQB",
+                        "StarQB2",
+                        "RB1",
+                        "RB2",
+                        "RB3",
+                        "WR1",
+                        "WR2",
+                        "WR3",
+                        "TE1",
+                    ],
+                    "picks": [],
+                }
+            ],
         },
     }
 
@@ -224,8 +260,10 @@ def test_team_impact_absent_without_roster_settings():
     contract = _mk_full_roster_contract()
     team = terminal.resolve_team(contract, owner_id="u1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["FreeWR"], players_out=["TE1"],
+        contract,
+        resolved_team=team,
+        players_in=["FreeWR"],
+        players_out=["TE1"],
     )
     assert "teamImpact" not in result
 
@@ -233,8 +271,10 @@ def test_team_impact_absent_without_roster_settings():
 def test_team_impact_absent_without_resolved_team():
     contract = _mk_full_roster_contract()
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=None,
-        players_in=["FreeWR"], players_out=["TE1"],
+        contract,
+        resolved_team=None,
+        players_in=["FreeWR"],
+        players_out=["TE1"],
         roster_settings=_IDP_LEAGUE_SETTINGS,
     )
     assert "teamImpact" not in result
@@ -246,16 +286,25 @@ def test_team_impact_filling_starter_hole_positive_fit():
     contract = _mk_full_roster_contract()
     team = terminal.resolve_team(contract, owner_id="u1", name=None)
     # Add a strong TE to acquire.  Inject directly.
-    contract["playersArray"].append({
-        "displayName": "EliteTE", "canonicalName": "EliteTE",
-        "assetClass": "offense", "position": "TE", "pos": "TE", "age": 25,
-        "canonicalConsensusRank": 15, "rankChange": 0,
-        "rankDerivedValue": int(rank_to_value(15)),
-        "values": {"full": int(rank_to_value(15))},
-    })
+    contract["playersArray"].append(
+        {
+            "displayName": "EliteTE",
+            "canonicalName": "EliteTE",
+            "assetClass": "offense",
+            "position": "TE",
+            "pos": "TE",
+            "age": 25,
+            "canonicalConsensusRank": 15,
+            "rankChange": 0,
+            "rankDerivedValue": int(rank_to_value(15)),
+            "values": {"full": int(rank_to_value(15))},
+        }
+    )
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["EliteTE"], players_out=["FreeWR"],
+        contract,
+        resolved_team=team,
+        players_in=["EliteTE"],
+        players_out=["FreeWR"],
         roster_settings=_IDP_LEAGUE_SETTINGS,
     )
     impact = result["teamImpact"]
@@ -269,8 +318,10 @@ def test_team_impact_duplicating_saturated_position_negative():
     contract = _mk_full_roster_contract()
     team = terminal.resolve_team(contract, owner_id="u1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["FreeRB"], players_out=["TE1"],
+        contract,
+        resolved_team=team,
+        players_in=["FreeRB"],
+        players_out=["TE1"],
         roster_settings=_IDP_LEAGUE_SETTINGS,
     )
     impact = result["teamImpact"]
@@ -283,17 +334,26 @@ def test_team_impact_redundancy_skipped_in_non_idp_league():
     """Acquiring an IDP player in a non-IDP league must not generate
     redundancy flags or starterDelta entries for DL/LB/DB."""
     contract = _mk_full_roster_contract()
-    contract["playersArray"].append({
-        "displayName": "IDPGuy", "canonicalName": "IDPGuy",
-        "assetClass": "idp", "position": "LB", "pos": "LB", "age": 25,
-        "canonicalConsensusRank": 80, "rankChange": 0,
-        "rankDerivedValue": int(rank_to_value(80)),
-        "values": {"full": int(rank_to_value(80))},
-    })
+    contract["playersArray"].append(
+        {
+            "displayName": "IDPGuy",
+            "canonicalName": "IDPGuy",
+            "assetClass": "idp",
+            "position": "LB",
+            "pos": "LB",
+            "age": 25,
+            "canonicalConsensusRank": 80,
+            "rankChange": 0,
+            "rankDerivedValue": int(rank_to_value(80)),
+            "values": {"full": int(rank_to_value(80))},
+        }
+    )
     team = terminal.resolve_team(contract, owner_id="u1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["IDPGuy"], players_out=["FreeWR"],
+        contract,
+        resolved_team=team,
+        players_in=["IDPGuy"],
+        players_out=["FreeWR"],
         roster_settings=_NON_IDP_LEAGUE_SETTINGS,
     )
     impact = result["teamImpact"]
@@ -306,17 +366,26 @@ def test_team_impact_redundancy_skipped_in_non_idp_league():
 def test_team_impact_verdict_thresholds_cross_correctly():
     """Verdict ladders as compositeScore moves."""
     contract = _mk_full_roster_contract()
-    contract["playersArray"].append({
-        "displayName": "EliteTE", "canonicalName": "EliteTE",
-        "assetClass": "offense", "position": "TE", "pos": "TE", "age": 25,
-        "canonicalConsensusRank": 8, "rankChange": 0,
-        "rankDerivedValue": int(rank_to_value(8)),
-        "values": {"full": int(rank_to_value(8))},
-    })
+    contract["playersArray"].append(
+        {
+            "displayName": "EliteTE",
+            "canonicalName": "EliteTE",
+            "assetClass": "offense",
+            "position": "TE",
+            "pos": "TE",
+            "age": 25,
+            "canonicalConsensusRank": 8,
+            "rankChange": 0,
+            "rankDerivedValue": int(rank_to_value(8)),
+            "values": {"full": int(rank_to_value(8))},
+        }
+    )
     team = terminal.resolve_team(contract, owner_id="u1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["EliteTE"], players_out=["FreeRB"],
+        contract,
+        resolved_team=team,
+        players_in=["EliteTE"],
+        players_out=["FreeRB"],
         roster_settings=_IDP_LEAGUE_SETTINGS,
     )
     impact = result["teamImpact"]
@@ -332,31 +401,56 @@ def test_team_impact_idp_trade_in_idp_league_seen():
     DL/LB/DB) — otherwise IDP trades are invisible to the analyzer.
     """
     contract = _mk_full_roster_contract()
-    contract["playersArray"].extend([
-        # Roster gets two starting LBs + two starting DLs already.
-        {"displayName": "MyLB1", "canonicalName": "MyLB1", "assetClass": "idp",
-         "position": "LB", "pos": "LB", "age": 25,
-         "canonicalConsensusRank": 80, "rankChange": 0,
-         "rankDerivedValue": int(rank_to_value(80)),
-         "values": {"full": int(rank_to_value(80))}},
-        {"displayName": "MyLB2", "canonicalName": "MyLB2", "assetClass": "idp",
-         "position": "LB", "pos": "LB", "age": 26,
-         "canonicalConsensusRank": 95, "rankChange": 0,
-         "rankDerivedValue": int(rank_to_value(95)),
-         "values": {"full": int(rank_to_value(95))}},
-        # Trade target — an elite LB upgrade.
-        {"displayName": "EliteLB", "canonicalName": "EliteLB", "assetClass": "idp",
-         "position": "LB", "pos": "LB", "age": 25,
-         "canonicalConsensusRank": 25, "rankChange": 0,
-         "rankDerivedValue": int(rank_to_value(25)),
-         "values": {"full": int(rank_to_value(25))}},
-    ])
+    contract["playersArray"].extend(
+        [
+            # Roster gets two starting LBs + two starting DLs already.
+            {
+                "displayName": "MyLB1",
+                "canonicalName": "MyLB1",
+                "assetClass": "idp",
+                "position": "LB",
+                "pos": "LB",
+                "age": 25,
+                "canonicalConsensusRank": 80,
+                "rankChange": 0,
+                "rankDerivedValue": int(rank_to_value(80)),
+                "values": {"full": int(rank_to_value(80))},
+            },
+            {
+                "displayName": "MyLB2",
+                "canonicalName": "MyLB2",
+                "assetClass": "idp",
+                "position": "LB",
+                "pos": "LB",
+                "age": 26,
+                "canonicalConsensusRank": 95,
+                "rankChange": 0,
+                "rankDerivedValue": int(rank_to_value(95)),
+                "values": {"full": int(rank_to_value(95))},
+            },
+            # Trade target — an elite LB upgrade.
+            {
+                "displayName": "EliteLB",
+                "canonicalName": "EliteLB",
+                "assetClass": "idp",
+                "position": "LB",
+                "pos": "LB",
+                "age": 25,
+                "canonicalConsensusRank": 25,
+                "rankChange": 0,
+                "rankDerivedValue": int(rank_to_value(25)),
+                "values": {"full": int(rank_to_value(25))},
+            },
+        ]
+    )
     # Add the LBs to the roster.
     contract["sleeper"]["teams"][0]["players"].extend(["MyLB1", "MyLB2"])
     team = terminal.resolve_team(contract, owner_id="u1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["EliteLB"], players_out=["MyLB2"],
+        contract,
+        resolved_team=team,
+        players_in=["EliteLB"],
+        players_out=["MyLB2"],
         roster_settings=_IDP_LEAGUE_SETTINGS,
     )
     impact = result["teamImpact"]
@@ -370,8 +464,10 @@ def test_team_impact_rationale_bullets_max_five():
     contract = _mk_full_roster_contract()
     team = terminal.resolve_team(contract, owner_id="u1", name=None)
     result = trade_simulator.simulate_trade(
-        contract, resolved_team=team,
-        players_in=["FreeWR2"], players_out=["WR3"],
+        contract,
+        resolved_team=team,
+        players_in=["FreeWR2"],
+        players_out=["WR3"],
         roster_settings=_IDP_LEAGUE_SETTINGS,
     )
     assert len(result["teamImpact"]["rationale"]) <= 5

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -7,6 +7,7 @@ Covers:
   - New per-player fields stamped by _compute_unified_rankings
   - Payload-level methodology, dataFreshness, and anomalySummary blocks
 """
+
 from __future__ import annotations
 
 import copy
@@ -83,11 +84,7 @@ def _make_player(name, position, *, ktc=None, idp=None, team="TST", sibling=None
             "_composite": composite_max,
             "_rawComposite": composite_max,
             "_finalAdjusted": composite_max,
-            "_sites": (
-                (1 if ktc else 0)
-                + (1 if idp else 0)
-                + (1 if sibling else 0)
-            ),
+            "_sites": ((1 if ktc else 0) + (1 if idp else 0) + (1 if sibling else 0)),
             "position": position,
             "team": team,
             "_canonicalSiteValues": sites,
@@ -124,7 +121,6 @@ def _build_and_find(payload, player_name):
 
 
 class TestConfidenceBucket(unittest.TestCase):
-
     def test_high_bucket(self):
         bucket, label = _compute_confidence_bucket(2, 20.0)
         self.assertEqual(bucket, "high")
@@ -162,7 +158,6 @@ class TestConfidenceBucket(unittest.TestCase):
 
 
 class TestAnomalyFlags(unittest.TestCase):
-
     def test_no_flags_for_clean_player(self):
         flags = _compute_anomaly_flags(
             name="Patrick Mahomes",
@@ -289,7 +284,6 @@ class TestAnomalyFlags(unittest.TestCase):
 
 
 class TestMarketGap(unittest.TestCase):
-
     def test_retail_premium_vs_single_consensus_source(self):
         # KTC (retail) rank 10, IDPTC (consensus) rank 50 → retail mean 10
         # vs consensus mean 50 → retail ranks the player 40 positions
@@ -365,7 +359,6 @@ class TestMarketGap(unittest.TestCase):
 
 
 class TestSingleSourceRow(unittest.TestCase):
-
     def test_single_source_offense_player(self):
         # Use a unique name that won't match CSV enrichment data on disk.
         # With two primary-scope offense sources now registered (KTC +
@@ -401,7 +394,6 @@ class TestSingleSourceRow(unittest.TestCase):
 
 
 class TestTwoSourceRow(_SecondOffenseSourceMixin, unittest.TestCase):
-
     def test_two_source_player_tight_agreement(self):
         """Two offense sources with similar values → high confidence,
         no disagreement.  Uses the test-only ktcMirror sibling source
@@ -427,7 +419,6 @@ class TestTwoSourceRow(_SecondOffenseSourceMixin, unittest.TestCase):
 
 
 class TestUnrankedPlayer(unittest.TestCase):
-
     def test_unranked_player_gets_defaults(self):
         """A player with no source values should still have trust fields."""
         payload = _payload_with_players(
@@ -447,7 +438,6 @@ class TestUnrankedPlayer(unittest.TestCase):
 
 
 class TestPayloadLevelBlocks(unittest.TestCase):
-
     def test_methodology_block_present(self):
         payload = _payload_with_players(
             _make_player("Test QB", "QB", ktc=8000),
@@ -552,7 +542,6 @@ class TestPayloadLevelBlocks(unittest.TestCase):
 
 
 class TestRequiredPlayerKeys(unittest.TestCase):
-
     def test_new_fields_in_required_keys(self):
         from src.api.data_contract import REQUIRED_PLAYER_KEYS
 
@@ -607,9 +596,14 @@ class TestIdentityConfidence(unittest.TestCase):
         row = _build_and_find(payload, "No ID QB")
         # No playerId, but position matches source evidence
         self.assertGreaterEqual(row["identityConfidence"], 0.70)
-        self.assertIn(row["identityMethod"], (
-            "name_only", "position_source_aligned", "partial_evidence",
-        ))
+        self.assertIn(
+            row["identityMethod"],
+            (
+                "name_only",
+                "position_source_aligned",
+                "partial_evidence",
+            ),
+        )
 
     def test_identity_fields_present(self):
         payload = _payload_with_players(
@@ -722,10 +716,18 @@ class TestEdgeCaseFixtures(_SecondOffenseSourceMixin, unittest.TestCase):
         )
         row = _build_and_find(payload, "Complete QB")
         required_fields = [
-            "confidenceBucket", "confidenceLabel", "anomalyFlags",
-            "isSingleSource", "hasSourceDisagreement", "blendedSourceRank",
-            "sourceRankSpread", "marketGapDirection", "marketGapMagnitude",
-            "identityConfidence", "identityMethod", "quarantined",
+            "confidenceBucket",
+            "confidenceLabel",
+            "anomalyFlags",
+            "isSingleSource",
+            "hasSourceDisagreement",
+            "blendedSourceRank",
+            "sourceRankSpread",
+            "marketGapDirection",
+            "marketGapMagnitude",
+            "identityConfidence",
+            "identityMethod",
+            "quarantined",
         ]
         for field in required_fields:
             self.assertIn(field, row, f"Missing trust field: {field}")
@@ -741,10 +743,18 @@ class TestTrustMirrorToLegacy(_SecondOffenseSourceMixin, unittest.TestCase):
     """
 
     TRUST_FIELDS = [
-        "confidenceBucket", "confidenceLabel", "anomalyFlags",
-        "isSingleSource", "hasSourceDisagreement", "blendedSourceRank",
-        "sourceRankSpread", "marketGapDirection", "marketGapMagnitude",
-        "identityConfidence", "identityMethod", "quarantined",
+        "confidenceBucket",
+        "confidenceLabel",
+        "anomalyFlags",
+        "isSingleSource",
+        "hasSourceDisagreement",
+        "blendedSourceRank",
+        "sourceRankSpread",
+        "marketGapDirection",
+        "marketGapMagnitude",
+        "identityConfidence",
+        "identityMethod",
+        "quarantined",
     ]
 
     def test_trust_fields_mirrored_to_legacy_dict(self):
@@ -757,8 +767,7 @@ class TestTrustMirrorToLegacy(_SecondOffenseSourceMixin, unittest.TestCase):
         self.assertIsNotNone(legacy_entry, "Legacy dict entry missing")
 
         for field in self.TRUST_FIELDS:
-            self.assertIn(field, legacy_entry,
-                          f"Trust field '{field}' not mirrored to legacy dict")
+            self.assertIn(field, legacy_entry, f"Trust field '{field}' not mirrored to legacy dict")
 
     def test_mirrored_values_match_players_array(self):
         """Mirrored legacy values must match the playersArray values."""
@@ -776,9 +785,9 @@ class TestTrustMirrorToLegacy(_SecondOffenseSourceMixin, unittest.TestCase):
 
         for field in self.TRUST_FIELDS:
             self.assertEqual(
-                legacy_entry[field], row[field],
-                f"Mismatch on '{field}': legacy={legacy_entry[field]!r}, "
-                f"array={row[field]!r}",
+                legacy_entry[field],
+                row[field],
+                f"Mismatch on '{field}': legacy={legacy_entry[field]!r}, " f"array={row[field]!r}",
             )
 
     def test_quarantine_reflected_in_legacy_dict(self):

--- a/tests/api/test_user_kv.py
+++ b/tests/api/test_user_kv.py
@@ -1,4 +1,5 @@
 """Tests for ``src.api.user_kv`` — durable per-user preference store."""
+
 from __future__ import annotations
 
 import json
@@ -93,35 +94,61 @@ def test_dismissals_scoped_per_league(kv_path):
     """Dismissing a signal in league A must NOT hide the same
     signal in league B — both leagues get independent buckets."""
     user_kv.dismiss_signal(
-        "u", "Josh Allen::elite_stable", ttl_ms=60_000,
-        league_key="dynasty_main", path=kv_path,
+        "u",
+        "Josh Allen::elite_stable",
+        ttl_ms=60_000,
+        league_key="dynasty_main",
+        path=kv_path,
     )
     # League A has it; league B does not.
     assert "Josh Allen::elite_stable" in user_kv.active_dismissals(
-        "u", league_key="dynasty_main", path=kv_path,
+        "u",
+        league_key="dynasty_main",
+        path=kv_path,
     )
-    assert user_kv.active_dismissals(
-        "u", league_key="dynasty_new", path=kv_path,
-    ) == {}
+    assert (
+        user_kv.active_dismissals(
+            "u",
+            league_key="dynasty_new",
+            path=kv_path,
+        )
+        == {}
+    )
 
 
 def test_undismiss_scoped_per_league(kv_path):
     """Un-dismissing in league A leaves league B's dismissal alone."""
     user_kv.dismiss_signal(
-        "u", "Josh Allen::elite_stable", league_key="dynasty_main", path=kv_path,
+        "u",
+        "Josh Allen::elite_stable",
+        league_key="dynasty_main",
+        path=kv_path,
     )
     user_kv.dismiss_signal(
-        "u", "Josh Allen::elite_stable", league_key="dynasty_new", path=kv_path,
+        "u",
+        "Josh Allen::elite_stable",
+        league_key="dynasty_new",
+        path=kv_path,
     )
     user_kv.undismiss_signal(
-        "u", "Josh Allen::elite_stable", league_key="dynasty_main", path=kv_path,
+        "u",
+        "Josh Allen::elite_stable",
+        league_key="dynasty_main",
+        path=kv_path,
     )
     # A gone, B intact.
-    assert user_kv.active_dismissals(
-        "u", league_key="dynasty_main", path=kv_path,
-    ) == {}
+    assert (
+        user_kv.active_dismissals(
+            "u",
+            league_key="dynasty_main",
+            path=kv_path,
+        )
+        == {}
+    )
     assert "Josh Allen::elite_stable" in user_kv.active_dismissals(
-        "u", league_key="dynasty_new", path=kv_path,
+        "u",
+        league_key="dynasty_new",
+        path=kv_path,
     )
 
 
@@ -135,9 +162,14 @@ def test_legacy_flat_dismissals_unchanged(kv_path):
     # Per-league reader on a league with no bucket returns empty —
     # it does NOT surface the flat field (we'd be showing default-
     # league dismissals under league B's name).
-    assert user_kv.active_dismissals(
-        "u", league_key="dynasty_new", path=kv_path,
-    ) == {}
+    assert (
+        user_kv.active_dismissals(
+            "u",
+            league_key="dynasty_new",
+            path=kv_path,
+        )
+        == {}
+    )
 
 
 def test_corrupt_file_starts_fresh(kv_path):
@@ -246,14 +278,16 @@ def test_legacy_json_migration_runs_on_first_boot(tmp_path, monkeypatch):
     monkeypatch.setattr(user_kv, "_LEGACY_JSON_PATH", legacy_path)
 
     legacy_path.write_text(
-        json.dumps({
-            "alice": {
-                "watchlist": ["Ja'Marr Chase"],
-                "selectedTeam": {"ownerId": "o", "name": "Alphas"},
-                "updatedAt": "2026-04-22T10:00:00Z",
-            },
-            "bob": {"watchlist": ["Bijan Robinson"]},
-        })
+        json.dumps(
+            {
+                "alice": {
+                    "watchlist": ["Ja'Marr Chase"],
+                    "selectedTeam": {"ownerId": "o", "name": "Alphas"},
+                    "updatedAt": "2026-04-22T10:00:00Z",
+                },
+                "bob": {"watchlist": ["Bijan Robinson"]},
+            }
+        )
     )
     user_kv._SETUP_DONE.clear()
     # First call triggers migration.
@@ -283,14 +317,16 @@ def test_dismiss_signal_without_alias_keeps_existing_map(kv_path):
     # Set one alias, then dismiss another signal without providing
     # alias args — the first mapping must persist.
     user_kv.dismiss_signal(
-        "u", "A::tag",
+        "u",
+        "A::tag",
         ttl_ms=60_000,
         alias_sleeper_id="111",
         alias_display_name="A",
         path=kv_path,
     )
     user_kv.dismiss_signal(
-        "u", "B::tag",
+        "u",
+        "B::tag",
         ttl_ms=60_000,
         path=kv_path,
     )

--- a/tests/api/test_watchdog_freshness_soft.py
+++ b/tests/api/test_watchdog_freshness_soft.py
@@ -12,6 +12,7 @@ config-backed ``load_soft_sources`` / ``is_soft_source`` helpers, and
 asserts the shipped ``config/source_staleness.json`` actually flags
 ``idpShow`` soft so the policy is wired end-to-end.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -31,26 +32,20 @@ class TestClassifyFreshness(unittest.TestCase):
 
     def test_soft_stale_source_is_non_fatal(self):
         freshness = {"idpShow": {"ageHours": 103.0, "lastFetched": "x"}}
-        hard, soft, fresh = classify_freshness(
-            freshness, self.THRESHOLDS, {"idpShow"}
-        )
+        hard, soft, fresh = classify_freshness(freshness, self.THRESHOLDS, {"idpShow"})
         self.assertEqual(hard, [])
         self.assertEqual([s[0] for s in soft], ["idpShow"])
         self.assertEqual(fresh, [])
 
     def test_non_soft_stale_source_is_fatal(self):
         freshness = {"ktc": {"ageHours": 50.0, "lastFetched": "x"}}
-        hard, soft, fresh = classify_freshness(
-            freshness, self.THRESHOLDS, {"idpShow"}
-        )
+        hard, soft, fresh = classify_freshness(freshness, self.THRESHOLDS, {"idpShow"})
         self.assertEqual([s[0] for s in hard], ["ktc"])
         self.assertEqual(soft, [])
 
     def test_fresh_soft_source_is_just_fresh(self):
         freshness = {"idpShow": {"ageHours": 1.0, "lastFetched": "x"}}
-        hard, soft, fresh = classify_freshness(
-            freshness, self.THRESHOLDS, {"idpShow"}
-        )
+        hard, soft, fresh = classify_freshness(freshness, self.THRESHOLDS, {"idpShow"})
         self.assertEqual(hard, [])
         self.assertEqual(soft, [])
         self.assertEqual([s[0] for s in fresh], ["idpShow"])
@@ -69,9 +64,9 @@ class TestSoftSourceConfig(unittest.TestCase):
 
     def test_is_soft_source_exact_and_vendor_prefix(self):
         soft = {"idpShow", "fantasyPros"}
-        self.assertTrue(is_soft_source("idpShow", soft))          # exact
-        self.assertTrue(is_soft_source("fantasyProsSf", soft))    # prefix
-        self.assertTrue(is_soft_source("fantasyProsIdp", soft))   # prefix
+        self.assertTrue(is_soft_source("idpShow", soft))  # exact
+        self.assertTrue(is_soft_source("fantasyProsSf", soft))  # prefix
+        self.assertTrue(is_soft_source("fantasyProsIdp", soft))  # prefix
         self.assertFalse(is_soft_source("ktc", soft))
         # Word-boundary: a shared leading substring must not match
         # unless the next char starts a new camel segment.

--- a/tests/backtesting/test_correlation.py
+++ b/tests/backtesting/test_correlation.py
@@ -1,4 +1,5 @@
 """Tests for Spearman correlation + per-source accuracy scoring."""
+
 from __future__ import annotations
 
 from src.backtesting import correlation
@@ -40,6 +41,7 @@ def test_score_source_perfect_source():
 
 def test_score_source_random_ranks_near_zero():
     import random
+
     random.seed(42)
     source_ranks = {f"p{i}": i + 1 for i in range(40)}
     # Shuffle points independently so there's no relationship.

--- a/tests/backtesting/test_dynamic_weights.py
+++ b/tests/backtesting/test_dynamic_weights.py
@@ -1,4 +1,5 @@
 """Tests for the dynamic weights fitter + approval gate."""
+
 from __future__ import annotations
 
 import json

--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -1,4 +1,5 @@
 """Tests for the backtesting harness."""
+
 from __future__ import annotations
 
 from src.backtesting import harness as bh
@@ -6,8 +7,11 @@ from src.backtesting import harness as bh
 
 def _record(tid, date, a, b, win_a):
     return bh.TradeRecord(
-        trade_id=tid, date=date, side_a_names=a,
-        side_b_names=b, win_prob_a=win_a,
+        trade_id=tid,
+        date=date,
+        side_a_names=a,
+        side_b_names=b,
+        win_prob_a=win_a,
     )
 
 
@@ -21,8 +25,10 @@ def test_empty_records_returns_zero_summary():
 def test_correct_prediction_increments_both_counts():
     """Calc said A wins (0.65), A's value went up more → correct."""
     snapshots = {
-        ("A", "2024-01-01"): 8000, ("B", "2024-01-01"): 7500,
-        ("A", "2024-06-29"): 8500, ("B", "2024-06-29"): 7200,
+        ("A", "2024-01-01"): 8000,
+        ("B", "2024-01-01"): 7500,
+        ("A", "2024-06-29"): 8500,
+        ("B", "2024-06-29"): 7200,
     }
     records = [_record("t1", "2024-01-01", ["A"], ["B"], 0.65)]
     s = bh.run_backtest(records, snapshots, horizon_days=180)
@@ -35,8 +41,10 @@ def test_correct_prediction_increments_both_counts():
 def test_wrong_prediction_still_counted():
     """Calc said A wins (0.65), B actually gained more → incorrect."""
     snapshots = {
-        ("A", "2024-01-01"): 8000, ("B", "2024-01-01"): 7500,
-        ("A", "2024-06-29"): 7000, ("B", "2024-06-29"): 8500,
+        ("A", "2024-01-01"): 8000,
+        ("B", "2024-01-01"): 7500,
+        ("A", "2024-06-29"): 7000,
+        ("B", "2024-06-29"): 8500,
     }
     records = [_record("t1", "2024-01-01", ["A"], ["B"], 0.65)]
     s = bh.run_backtest(records, snapshots, horizon_days=180)
@@ -63,8 +71,10 @@ def test_below_50_win_prob_maps_to_inverse_bucket():
 
 def test_format_report_has_bucket_lines():
     snapshots = {
-        ("A", "2024-01-01"): 8000, ("B", "2024-01-01"): 7500,
-        ("A", "2024-06-29"): 8500, ("B", "2024-06-29"): 7200,
+        ("A", "2024-01-01"): 8000,
+        ("B", "2024-01-01"): 7500,
+        ("A", "2024-06-29"): 8500,
+        ("B", "2024-06-29"): 7200,
     }
     records = [_record("t1", "2024-01-01", ["A"], ["B"], 0.85)]
     s = bh.run_backtest(records, snapshots)
@@ -83,8 +93,10 @@ def test_bad_date_format_skip():
 
 def test_horizon_days_configurable():
     snapshots = {
-        ("A", "2024-01-01"): 8000, ("B", "2024-01-01"): 7500,
-        ("A", "2024-04-01"): 8500, ("B", "2024-04-01"): 7000,
+        ("A", "2024-01-01"): 8000,
+        ("B", "2024-01-01"): 7500,
+        ("A", "2024-04-01"): 8500,
+        ("B", "2024-04-01"): 7000,
     }
     records = [_record("t1", "2024-01-01", ["A"], ["B"], 0.65)]
     # Use 91-day horizon (2024 Q1 → Q2).
@@ -94,8 +106,10 @@ def test_horizon_days_configurable():
 
 def test_to_dict_round_trips():
     snapshots = {
-        ("A", "2024-01-01"): 8000, ("B", "2024-01-01"): 7500,
-        ("A", "2024-06-29"): 8500, ("B", "2024-06-29"): 7200,
+        ("A", "2024-01-01"): 8000,
+        ("B", "2024-01-01"): 7500,
+        ("A", "2024-06-29"): 8500,
+        ("B", "2024-06-29"): 7200,
     }
     records = [_record("t1", "2024-01-01", ["A"], ["B"], 0.65)]
     s = bh.run_backtest(records, snapshots)

--- a/tests/canonical/test_calibration.py
+++ b/tests/canonical/test_calibration.py
@@ -1,4 +1,5 @@
 """Tests for canonical value calibration layer."""
+
 from __future__ import annotations
 
 import sys
@@ -29,8 +30,12 @@ LEGACY_PATH = REPO / "data" / "legacy_data_2026-03-22.json"
 
 def _make_assets(universe: str, values: list[int], names: list[str] | None = None) -> list[dict]:
     return [
-        {"blended_value": v, "display_name": names[i] if names else f"Player_{i}",
-         "universe": universe, "source_values": {"SRC": v}}
+        {
+            "blended_value": v,
+            "display_name": names[i] if names else f"Player_{i}",
+            "universe": universe,
+            "source_values": {"SRC": v},
+        }
         for i, v in enumerate(values)
     ]
 
@@ -132,6 +137,7 @@ class TestPickCurveValue:
     def test_current_year_not_discounted(self):
         """A pick in the current year should NOT receive a future-year discount."""
         import datetime
+
         this_year = datetime.date.today().year
         current_val = _pick_curve_value({"year": this_year, "round": 1})
         no_year_val = _pick_curve_value({"round": 1})
@@ -141,6 +147,7 @@ class TestPickCurveValue:
     def test_default_year_uses_today(self):
         """Default current_year should derive from today, not a hard-coded constant."""
         import datetime
+
         this_year = datetime.date.today().year
         next_year = this_year + 1
         # A pick dated next year should be discounted when using the default
@@ -158,8 +165,12 @@ class TestPickCalibrationWithLegacy:
         if not LEGACY_PATH.exists():
             pytest.skip("No legacy data")
         assets = [
-            {"display_name": "2026 Pick 1.01", "blended_value": 9999,
-             "universe": "offense_vet", "source_values": {"KTC": 9999}},
+            {
+                "display_name": "2026 Pick 1.01",
+                "blended_value": 9999,
+                "universe": "offense_vet",
+                "source_values": {"KTC": 9999},
+            },
         ]
         result = calibrate_canonical_values(assets, legacy_path=LEGACY_PATH)
         pick = result[0]
@@ -169,8 +180,12 @@ class TestPickCalibrationWithLegacy:
 
     def test_round_curve_fallback(self):
         assets = [
-            {"display_name": "2030 Early 1st", "blended_value": 5000,
-             "universe": "offense_vet", "source_values": {"KTC": 5000}},
+            {
+                "display_name": "2030 Early 1st",
+                "blended_value": 5000,
+                "universe": "offense_vet",
+                "source_values": {"KTC": 5000},
+            },
         ]
         result = calibrate_canonical_values(assets)
         pick = result[0]
@@ -182,11 +197,22 @@ class TestPickCalibrationWithLegacy:
 class TestNonFantasyCeiling:
     def test_kickers_capped(self):
         from src.canonical.calibration import NON_FANTASY_CEILING
+
         assets = [
-            {"blended_value": 9999, "display_name": "Star QB", "universe": "offense_vet",
-             "metadata": {"position": "QB"}, "source_values": {"SRC": 9999}},
-            {"blended_value": 8000, "display_name": "Brandon Aubrey", "universe": "offense_vet",
-             "metadata": {"position": "K"}, "source_values": {"SRC": 8000}},
+            {
+                "blended_value": 9999,
+                "display_name": "Star QB",
+                "universe": "offense_vet",
+                "metadata": {"position": "QB"},
+                "source_values": {"SRC": 9999},
+            },
+            {
+                "blended_value": 8000,
+                "display_name": "Brandon Aubrey",
+                "universe": "offense_vet",
+                "metadata": {"position": "K"},
+                "source_values": {"SRC": 8000},
+            },
         ]
         result = calibrate_canonical_values(assets)
         kicker = [a for a in result if a["display_name"] == "Brandon Aubrey"][0]
@@ -200,11 +226,16 @@ class TestCalibrationDistribution:
         result = calibrate_canonical_values(assets)
 
         from collections import Counter
+
         def tier(v):
-            if v >= 7000: return "elite"
-            if v >= 5000: return "star"
-            if v >= 3000: return "starter"
-            if v >= 1500: return "bench"
+            if v >= 7000:
+                return "elite"
+            if v >= 5000:
+                return "star"
+            if v >= 3000:
+                return "starter"
+            if v >= 1500:
+                return "bench"
             return "depth"
 
         tiers = Counter(tier(a["calibrated_value"]) for a in result)
@@ -230,8 +261,6 @@ class TestCalibrationParams:
 
     def test_custom_scales(self):
         assets = _make_assets("offense_vet", [9000, 7000, 5000])
-        result = calibrate_canonical_values(
-            assets, universe_scales={"offense_vet": 5000}
-        )
+        result = calibrate_canonical_values(assets, universe_scales={"offense_vet": 5000})
         top = max(result, key=lambda a: a["calibrated_value"])
         assert top["calibrated_value"] == 5000

--- a/tests/canonical/test_canonical_single_curve.py
+++ b/tests/canonical/test_canonical_single_curve.py
@@ -18,6 +18,7 @@ These tests pin that invariant from two directions:
      ``RuntimeError`` if called on a canonical-tagged asset, defending
      against accidental double-calibration.
 """
+
 from __future__ import annotations
 
 import sys

--- a/tests/canonical/test_confidence_intervals.py
+++ b/tests/canonical/test_confidence_intervals.py
@@ -6,6 +6,7 @@ These pin:
   * The three fallback branches.
   * The stamp helper's non-destructiveness.
 """
+
 from __future__ import annotations
 
 from src.canonical import confidence_intervals as ci

--- a/tests/canonical/test_idp_backbone.py
+++ b/tests/canonical/test_idp_backbone.py
@@ -8,6 +8,7 @@ These tests pin the math in `src/canonical/idp_backbone.py`:
 They are intentionally pure-Python (no contract fixtures) so regressions
 here are isolated from the full pipeline.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -71,22 +72,15 @@ class TestBackboneConstruction(unittest.TestCase):
 
     def test_build_backbone_from_rows_sorts_by_source_value(self):
         rows = [
-            {"canonicalName": "lb2", "position": "LB",
-             "canonicalSiteValues": {"idpTC": 40}},
-            {"canonicalName": "dl1", "position": "DL",
-             "canonicalSiteValues": {"idpTC": 90}},
-            {"canonicalName": "dl2", "position": "DL",
-             "canonicalSiteValues": {"idpTC": 70}},
-            {"canonicalName": "lb1", "position": "LB",
-             "canonicalSiteValues": {"idpTC": 60}},
-            {"canonicalName": "db1", "position": "DB",
-             "canonicalSiteValues": {"idpTC": 50}},
+            {"canonicalName": "lb2", "position": "LB", "canonicalSiteValues": {"idpTC": 40}},
+            {"canonicalName": "dl1", "position": "DL", "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "dl2", "position": "DL", "canonicalSiteValues": {"idpTC": 70}},
+            {"canonicalName": "lb1", "position": "LB", "canonicalSiteValues": {"idpTC": 60}},
+            {"canonicalName": "db1", "position": "DB", "canonicalSiteValues": {"idpTC": 50}},
             # Row with missing value is skipped
-            {"canonicalName": "dl_ghost", "position": "DL",
-             "canonicalSiteValues": {"idpTC": None}},
+            {"canonicalName": "dl_ghost", "position": "DL", "canonicalSiteValues": {"idpTC": None}},
             # Non-IDP row is skipped
-            {"canonicalName": "josh", "position": "QB",
-             "canonicalSiteValues": {"idpTC": 1000}},
+            {"canonicalName": "josh", "position": "QB", "canonicalSiteValues": {"idpTC": 1000}},
         ]
         bb = build_backbone_from_rows(rows, source_key="idpTC")
         # Desc order: dl1(90), dl2(70), lb1(60), db1(50), lb2(40)
@@ -171,10 +165,8 @@ class TestSharedMarketIdpLadder(unittest.TestCase):
 
     def test_empty_when_offense_positions_not_supplied(self):
         rows = [
-            {"canonicalName": "dl1", "position": "DL",
-             "canonicalSiteValues": {"idpTC": 90}},
-            {"canonicalName": "qb1", "position": "QB",
-             "canonicalSiteValues": {"idpTC": 95}},
+            {"canonicalName": "dl1", "position": "DL", "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "qb1", "position": "QB", "canonicalSiteValues": {"idpTC": 95}},
         ]
         bb = build_backbone_from_rows(rows, source_key="idpTC")
         self.assertEqual(bb.shared_market_idp_ladder, [])
@@ -184,16 +176,11 @@ class TestSharedMarketIdpLadder(unittest.TestCase):
     def test_shared_ladder_reflects_combined_pool_ordering(self):
         # IDPTC combined-pool order: qb(95) > dl1(90) > wr1(85) > lb1(80) > db1(70)
         rows = [
-            {"canonicalName": "qb1", "position": "QB",
-             "canonicalSiteValues": {"idpTC": 95}},
-            {"canonicalName": "dl1", "position": "DL",
-             "canonicalSiteValues": {"idpTC": 90}},
-            {"canonicalName": "wr1", "position": "WR",
-             "canonicalSiteValues": {"idpTC": 85}},
-            {"canonicalName": "lb1", "position": "LB",
-             "canonicalSiteValues": {"idpTC": 80}},
-            {"canonicalName": "db1", "position": "DB",
-             "canonicalSiteValues": {"idpTC": 70}},
+            {"canonicalName": "qb1", "position": "QB", "canonicalSiteValues": {"idpTC": 95}},
+            {"canonicalName": "dl1", "position": "DL", "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "wr1", "position": "WR", "canonicalSiteValues": {"idpTC": 85}},
+            {"canonicalName": "lb1", "position": "LB", "canonicalSiteValues": {"idpTC": 80}},
+            {"canonicalName": "db1", "position": "DB", "canonicalSiteValues": {"idpTC": 70}},
         ]
         bb = build_backbone_from_rows(
             rows,
@@ -214,16 +201,11 @@ class TestSharedMarketIdpLadder(unittest.TestCase):
         # With the shared-market ladder = [2, 4, 5], translating DLF's
         # raw IDP ranks 1/2/3 must yield 2/4/5 respectively.
         rows = [
-            {"canonicalName": "qb1", "position": "QB",
-             "canonicalSiteValues": {"idpTC": 95}},
-            {"canonicalName": "dl1", "position": "DL",
-             "canonicalSiteValues": {"idpTC": 90}},
-            {"canonicalName": "wr1", "position": "WR",
-             "canonicalSiteValues": {"idpTC": 85}},
-            {"canonicalName": "lb1", "position": "LB",
-             "canonicalSiteValues": {"idpTC": 80}},
-            {"canonicalName": "db1", "position": "DB",
-             "canonicalSiteValues": {"idpTC": 70}},
+            {"canonicalName": "qb1", "position": "QB", "canonicalSiteValues": {"idpTC": 95}},
+            {"canonicalName": "dl1", "position": "DL", "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "wr1", "position": "WR", "canonicalSiteValues": {"idpTC": 85}},
+            {"canonicalName": "lb1", "position": "LB", "canonicalSiteValues": {"idpTC": 80}},
+            {"canonicalName": "db1", "position": "DB", "canonicalSiteValues": {"idpTC": 70}},
         ]
         bb = build_backbone_from_rows(
             rows,
@@ -231,12 +213,9 @@ class TestSharedMarketIdpLadder(unittest.TestCase):
             offense_positions={"QB", "WR"},
         )
         ladder = bb.shared_idp_ladder()
-        self.assertEqual(translate_position_rank(1, ladder),
-                         (2, TRANSLATION_EXACT))
-        self.assertEqual(translate_position_rank(2, ladder),
-                         (4, TRANSLATION_EXACT))
-        self.assertEqual(translate_position_rank(3, ladder),
-                         (5, TRANSLATION_EXACT))
+        self.assertEqual(translate_position_rank(1, ladder), (2, TRANSLATION_EXACT))
+        self.assertEqual(translate_position_rank(2, ladder), (4, TRANSLATION_EXACT))
+        self.assertEqual(translate_position_rank(3, ladder), (5, TRANSLATION_EXACT))
         # Past the ladder extrapolates monotonically.
         syn, method = translate_position_rank(4, ladder)
         self.assertEqual(method, TRANSLATION_EXTRAPOLATED)
@@ -247,10 +226,8 @@ class TestSharedMarketIdpLadder(unittest.TestCase):
         # the combined-pool collapses to the IDP pool, so the ladder
         # is [1,2,3,...].
         rows = [
-            {"canonicalName": "dl1", "position": "DL",
-             "canonicalSiteValues": {"idpTC": 90}},
-            {"canonicalName": "lb1", "position": "LB",
-             "canonicalSiteValues": {"idpTC": 80}},
+            {"canonicalName": "dl1", "position": "DL", "canonicalSiteValues": {"idpTC": 90}},
+            {"canonicalName": "lb1", "position": "LB", "canonicalSiteValues": {"idpTC": 80}},
         ]
         bb = build_backbone_from_rows(
             rows,
@@ -272,9 +249,7 @@ class TestCoverageWeight(unittest.TestCase):
 
     def test_shallow_depth_scales_linearly(self):
         # A top-20 list with declared weight 1.0 contributes 20/60 = 0.333...
-        self.assertAlmostEqual(
-            coverage_weight(1.0, 20), 20 / MIN_FULL_COVERAGE_DEPTH, places=6
-        )
+        self.assertAlmostEqual(coverage_weight(1.0, 20), 20 / MIN_FULL_COVERAGE_DEPTH, places=6)
 
     def test_zero_depth_returns_zero_weight(self):
         self.assertEqual(coverage_weight(1.0, 0), 0.0)
@@ -284,9 +259,7 @@ class TestCoverageWeight(unittest.TestCase):
 
     def test_custom_min_depth(self):
         # With min_full_depth=30 a depth-15 list yields half the declared weight.
-        self.assertAlmostEqual(
-            coverage_weight(1.0, 15, min_full_depth=30), 0.5, places=6
-        )
+        self.assertAlmostEqual(coverage_weight(1.0, 15, min_full_depth=30), 0.5, places=6)
 
 
 if __name__ == "__main__":

--- a/tests/canonical/test_ktc_reconciliation.py
+++ b/tests/canonical/test_ktc_reconciliation.py
@@ -23,6 +23,7 @@ The KTC fixture is the live offense-vet snapshot at
 ``CSVs/site_raw/ktc.csv``.  Picks (rows like "2026 Early 1st") are
 filtered out so the rank index reflects player ordering only.
 """
+
 from __future__ import annotations
 
 import csv
@@ -104,16 +105,16 @@ def _load_ktc_players_sorted() -> list[tuple[str, int]]:
 # a regression — break CI, investigate, re-baseline the affected ranks.
 # ──────────────────────────────────────────────────────────────────────
 PINNED_DELTAS: list[tuple[int, int, float, float]] = [
-    (  1, 9999,   0.0,  3.0),
-    (  5, 9544,  -0.7,  3.0),
-    ( 12, 8675,  10.9,  3.0),
-    ( 24, 7371,   9.9,  3.0),
-    ( 50, 5402,   3.1,  3.0),
-    (100, 3436,  -6.5,  5.0),
-    (150, 2465, -12.5,  5.0),
+    (1, 9999, 0.0, 3.0),
+    (5, 9544, -0.7, 3.0),
+    (12, 8675, 10.9, 3.0),
+    (24, 7371, 9.9, 3.0),
+    (50, 5402, 3.1, 3.0),
+    (100, 3436, -6.5, 5.0),
+    (150, 2465, -12.5, 5.0),
     (200, 1899, -21.3, 10.0),
     (300, 1280, -20.2, 10.0),
-    (400,  953,  -4.9, 10.0),
+    (400, 953, -4.9, 10.0),
 ]
 
 
@@ -182,9 +183,7 @@ class TestKTCCurveShapeInvariants:
     until the Hill curve is re-fit.
     """
 
-    def test_rank_one_matches_by_construction(
-        self, ktc_players: list[tuple[str, int]]
-    ) -> None:
+    def test_rank_one_matches_by_construction(self, ktc_players: list[tuple[str, int]]) -> None:
         # Both curves anchor at ~9999 at rank 1.  Our Hill ceiling
         # is exactly 9999 by construction; KTC's actual top varies
         # depending on scrape timing — their #1 player occasionally
@@ -197,9 +196,7 @@ class TestKTCCurveShapeInvariants:
         ours_top = _ours(1)
         assert abs(ours_top - ktc_top) <= 25
 
-    def test_midrange_is_higher_than_ktc(
-        self, ktc_players: list[tuple[str, int]]
-    ) -> None:
+    def test_midrange_is_higher_than_ktc(self, ktc_players: list[tuple[str, int]]) -> None:
         # Ranks 10-15 — our percentile-Hill curve sits above KTC
         # (their curve dips faster through the early top-12 than
         # the fitted Hill shape).
@@ -207,13 +204,10 @@ class TestKTCCurveShapeInvariants:
             _, ktc = ktc_players[rank - 1]
             ours = _ours(rank)
             assert ours > ktc, (
-                f"Expected our curve above KTC at rank {rank}, "
-                f"got ours={ours}, ktc={ktc}"
+                f"Expected our curve above KTC at rank {rank}, " f"got ours={ours}, ktc={ktc}"
             )
 
-    def test_tail_stays_bounded_vs_ktc(
-        self, ktc_players: list[tuple[str, int]]
-    ) -> None:
+    def test_tail_stays_bounded_vs_ktc(self, ktc_players: list[tuple[str, int]]) -> None:
         # Past rank 100, the divergence from KTC stays within ±40pp.
         # Our offense master curve is the unweighted mean of KTC, DD,
         # and DN per-source fits; DD and DN have steeper tails than
@@ -224,6 +218,5 @@ class TestKTCCurveShapeInvariants:
             ours = _ours(rank)
             pct = abs(100.0 * (ours - ktc) / ktc)
             assert pct <= 40.0, (
-                f"Divergence at rank {rank} too large: "
-                f"ours={ours}, ktc={ktc}, |pct|={pct:.1f}%"
+                f"Divergence at rank {rank} too large: " f"ours={ours}, ktc={ktc}, |pct|={pct:.1f}%"
             )

--- a/tests/canonical/test_normalization_validator.py
+++ b/tests/canonical/test_normalization_validator.py
@@ -1,4 +1,5 @@
 """Tests for the normalization validator."""
+
 from __future__ import annotations
 
 import logging
@@ -10,12 +11,16 @@ def test_valid_contract_reports_healthy():
     contract = {
         "playersArray": [
             {
-                "displayName": "Josh Allen", "canonicalName": "Josh Allen",
-                "position": "QB", "assetClass": "offense",
+                "displayName": "Josh Allen",
+                "canonicalName": "Josh Allen",
+                "position": "QB",
+                "assetClass": "offense",
             },
             {
-                "displayName": "2027 Mid 4th", "canonicalName": "2027 Mid 4th",
-                "position": "PICK", "assetClass": "pick",
+                "displayName": "2027 Mid 4th",
+                "canonicalName": "2027 Mid 4th",
+                "position": "PICK",
+                "assetClass": "pick",
             },
         ],
     }
@@ -28,8 +33,10 @@ def test_detects_display_canonical_drift(caplog):
     contract = {
         "playersArray": [
             {
-                "displayName": "Joshua Allen", "canonicalName": "Josh Allen",
-                "position": "QB", "assetClass": "offense",
+                "displayName": "Joshua Allen",
+                "canonicalName": "Josh Allen",
+                "position": "QB",
+                "assetClass": "offense",
             },
         ],
     }
@@ -38,18 +45,17 @@ def test_detects_display_canonical_drift(caplog):
     assert result["healthy"] is False
     assert result["playersArray"]["playerNameDrift"] == 1
     # Structured log line emitted.
-    assert any(
-        "normalization_mismatch=player_name_drift" in rec.message
-        for rec in caplog.records
-    )
+    assert any("normalization_mismatch=player_name_drift" in rec.message for rec in caplog.records)
 
 
 def test_detects_malformed_pick_name():
     contract = {
         "playersArray": [
             {
-                "displayName": "not a real pick", "canonicalName": "not a real pick",
-                "position": "PICK", "assetClass": "pick",
+                "displayName": "not a real pick",
+                "canonicalName": "not a real pick",
+                "position": "PICK",
+                "assetClass": "pick",
             },
         ],
     }
@@ -62,7 +68,8 @@ def test_detects_asset_class_mismatch():
     contract = {
         "playersArray": [
             {
-                "displayName": "Josh Allen", "canonicalName": "Josh Allen",
+                "displayName": "Josh Allen",
+                "canonicalName": "Josh Allen",
                 "position": "QB",
                 "assetClass": "idp",  # wrong — QB is offense
             },
@@ -88,8 +95,10 @@ def test_sample_cap_limits_output_size():
     contract = {
         "playersArray": [
             {
-                "displayName": f"Bad {i}", "canonicalName": f"Real {i}",
-                "position": "QB", "assetClass": "offense",
+                "displayName": f"Bad {i}",
+                "canonicalName": f"Real {i}",
+                "position": "QB",
+                "assetClass": "offense",
             }
             for i in range(50)
         ],
@@ -100,9 +109,13 @@ def test_sample_cap_limits_output_size():
 
 def test_valid_pick_patterns_accepted():
     names = [
-        "2027 Mid 4th", "2026 Early 1st", "2027 Late 6th",
-        "2026 Pick 1.01", "2027 Pick 2.12",
-        "2026 1st Round", "2027 4th Round",
+        "2027 Mid 4th",
+        "2026 Early 1st",
+        "2027 Late 6th",
+        "2026 Pick 1.01",
+        "2027 Pick 2.12",
+        "2026 1st Round",
+        "2027 4th Round",
     ]
     for name in names:
         assert nv.is_valid_pick_name(name), name

--- a/tests/canonical/test_player_valuation.py
+++ b/tests/canonical/test_player_valuation.py
@@ -10,6 +10,7 @@ Covers:
     - Trade-scenario validation
     - Stability under small rank perturbations
 """
+
 from __future__ import annotations
 
 import math
@@ -52,6 +53,7 @@ from src.canonical.player_valuation import (
 # Helpers
 # ─────────────────────────────────────────────────────────────
 
+
 def _make_players(ranks_by_player: dict[str, list[float]]) -> list[PlayerInput]:
     """Build PlayerInput list from {name: [source_ranks]}."""
     return [
@@ -67,6 +69,7 @@ def _quick_pipeline(ranks_by_player: dict[str, list[float]], **kwargs) -> Valuat
 # ─────────────────────────────────────────────────────────────
 # Step 1 – Consensus Rank
 # ─────────────────────────────────────────────────────────────
+
 
 class TestConsensusRank:
     def test_single_source(self):
@@ -111,6 +114,7 @@ class TestConsensusRank:
 # Step 2 – Tier Detection
 # ─────────────────────────────────────────────────────────────
 
+
 class TestTierDetection:
     def test_no_tiers_for_uniform_gaps(self):
         """Uniformly spaced players should produce one tier."""
@@ -134,9 +138,9 @@ class TestTierDetection:
     def test_multiple_cliffs(self):
         """Multiple well-separated clusters should produce multiple tiers."""
         ranks = (
-            [float(i) for i in range(1, 6)]       # tier 1: 1–5
-            + [float(i) for i in range(25, 30)]    # tier 2: 25–29
-            + [float(i) for i in range(55, 60)]    # tier 3: 55–59
+            [float(i) for i in range(1, 6)]  # tier 1: 1–5
+            + [float(i) for i in range(25, 30)]  # tier 2: 25–29
+            + [float(i) for i in range(55, 60)]  # tier 3: 55–59
         )
         ids = [f"P{i}" for i in range(15)]
         tier_ids, _, _, boundaries = detect_tiers(ranks, ids)
@@ -159,7 +163,9 @@ class TestTierDetection:
         ranks = [1.0, 2.0, 50.0, 51.0, 52.0, 53.0, 54.0]
         ids = [f"P{i}" for i in range(7)]
         tier_ids, _, _, boundaries = detect_tiers(
-            ranks, ids, min_tier_size=3,
+            ranks,
+            ids,
+            min_tier_size=3,
         )
         # First 2 players can't form a tier of size 3, so break should
         # be deferred or not happen at rank index 1
@@ -181,6 +187,7 @@ class TestTierDetection:
 # Step 3 – Base Value Curve
 # ─────────────────────────────────────────────────────────────
 
+
 class TestBaseValueCurve:
     """Tests for rank_to_value (Hill-style curve) and its base_value_curve alias."""
 
@@ -192,10 +199,22 @@ class TestBaseValueCurve:
         # DynastyDaddy / DynastyNerds. Re-run
         # ``scripts/fit_hill_curve_from_market.py`` to refresh the
         # constants and update these expected values together.
-        expected = {1: 9999, 2: 9885, 3: 9749, 5: 9460, 10: 8736,
-                    25: 6914, 50: 4967, 100: 3055, 200: 1648, 500: 643}
+        expected = {
+            1: 9999,
+            2: 9885,
+            3: 9749,
+            5: 9460,
+            10: 8736,
+            25: 6914,
+            50: 4967,
+            100: 3055,
+            200: 1648,
+            500: 643,
+        }
         for rank, val in expected.items():
-            assert rank_to_value(rank) == val, f"rank {rank}: got {rank_to_value(rank)}, expected {val}"
+            assert (
+                rank_to_value(rank) == val
+            ), f"rank {rank}: got {rank_to_value(rank)}, expected {val}"
 
     def test_monotonically_decreasing(self):
         values = [rank_to_value(r) for r in range(1, 301)]
@@ -230,6 +249,7 @@ class TestBaseValueCurve:
 # Step 4 – Tier Cliff Injection
 # ─────────────────────────────────────────────────────────────
 
+
 class TestTierCliffs:
     def test_no_cliffs_single_tier(self):
         ranks = [1.0, 2.0, 3.0]
@@ -241,9 +261,13 @@ class TestTierCliffs:
         ranks = [1.0, 2.0, 3.0, 20.0, 21.0, 22.0]
         tiers = [1, 1, 1, 2, 2, 2]
         boundary = TierBoundary(
-            tier_id_above=1, tier_id_below=2,
-            player_above="P2", player_below="P3",
-            raw_gap=17.0, gap_score=3.0, rank_position=3.0,
+            tier_id_above=1,
+            tier_id_below=2,
+            player_above="P2",
+            player_below="P3",
+            raw_gap=17.0,
+            gap_score=3.0,
+            rank_position=3.0,
         )
         adj = compute_tier_adjustments(ranks, tiers, [boundary])
         # Tier 1 players should get a positive adjustment
@@ -255,20 +279,30 @@ class TestTierCliffs:
     def test_cliff_decays_with_rank(self):
         """Later cliffs should be smaller than early ones."""
         boundary_early = TierBoundary(
-            tier_id_above=1, tier_id_below=2,
-            player_above="P", player_below="Q",
-            raw_gap=10.0, gap_score=3.0, rank_position=5.0,
+            tier_id_above=1,
+            tier_id_below=2,
+            player_above="P",
+            player_below="Q",
+            raw_gap=10.0,
+            gap_score=3.0,
+            rank_position=5.0,
         )
         boundary_late = TierBoundary(
-            tier_id_above=2, tier_id_below=3,
-            player_above="Q", player_below="R",
-            raw_gap=10.0, gap_score=3.0, rank_position=100.0,
+            tier_id_above=2,
+            tier_id_below=3,
+            player_above="Q",
+            player_below="R",
+            raw_gap=10.0,
+            gap_score=3.0,
+            rank_position=100.0,
         )
         # Two-boundary scenario
         ranks = [1.0, 2.0, 50.0, 51.0, 150.0, 151.0]
         tiers = [1, 1, 2, 2, 3, 3]
         adj = compute_tier_adjustments(
-            ranks, tiers, [boundary_early, boundary_late],
+            ranks,
+            tiers,
+            [boundary_early, boundary_late],
         )
         # Tier 1 adj (includes both cliffs) > Tier 2 adj (includes only late cliff)
         assert adj[0] > adj[2]
@@ -282,6 +316,7 @@ class TestTierCliffs:
 # ─────────────────────────────────────────────────────────────
 # Step 5 – Volatility Adjustment
 # ─────────────────────────────────────────────────────────────
+
 
 class TestVolatilityAdjustment:
     def test_zero_vol_no_adjustment(self):
@@ -320,6 +355,7 @@ class TestVolatilityAdjustment:
 # Step 6 – Full Pipeline Integration
 # ─────────────────────────────────────────────────────────────
 
+
 class TestFullPipeline:
     def test_empty_input(self):
         result = run_valuation([])
@@ -341,9 +377,9 @@ class TestFullPipeline:
         result = _quick_pipeline(players)
         values = [p.final_value for p in result.players]
         for i in range(1, len(values)):
-            assert values[i] < values[i - 1], (
-                f"Non-decreasing at index {i}: {values[i-1]:.2f} -> {values[i]:.2f}"
-            )
+            assert (
+                values[i] < values[i - 1]
+            ), f"Non-decreasing at index {i}: {values[i-1]:.2f} -> {values[i]:.2f}"
 
     def test_display_values_in_range(self):
         players = {f"P{i}": [float(i)] for i in range(1, 101)}
@@ -361,9 +397,9 @@ class TestFullPipeline:
         """
         result = _quick_pipeline({"A": [1.0], "B": [5.0], "C": [10.0]})
         top_dv = result.players[0].display_value
-        assert top_dv > DISPLAY_SCALE_MAX * 0.90, (
-            f"Top player display {top_dv} too low — should be near {DISPLAY_SCALE_MAX}"
-        )
+        assert (
+            top_dv > DISPLAY_SCALE_MAX * 0.90
+        ), f"Top player display {top_dv} too low — should be near {DISPLAY_SCALE_MAX}"
         assert top_dv <= DISPLAY_SCALE_MAX
 
     def test_display_anchor_is_stable(self):
@@ -428,10 +464,12 @@ class TestFullPipeline:
         assert all(not p.is_tier_start for p in tier1)
 
     def test_diagnostics_populated(self):
-        result = _quick_pipeline({
-            "A": [1.0, 2.0, 3.0],
-            "B": [4.0, 5.0, 6.0],
-        })
+        result = _quick_pipeline(
+            {
+                "A": [1.0, 2.0, 3.0],
+                "B": [4.0, 5.0, 6.0],
+            }
+        )
         for p in result.players:
             assert p.median_rank > 0
             assert p.mean_rank > 0
@@ -469,8 +507,11 @@ class TestFullPipeline:
     def test_monotonic_clamp_count_matches_per_player_flags(self):
         """Result-level count must equal the number of per-player flags."""
         players = {
-            "A": [1.0], "B": [1.0], "C": [1.0],  # all tied
-            "D": [10.0], "E": [20.0],
+            "A": [1.0],
+            "B": [1.0],
+            "C": [1.0],  # all tied
+            "D": [10.0],
+            "E": [20.0],
         }
         result = _quick_pipeline(players)
         flag_count = sum(1 for p in result.players if p.monotonic_clamp_applied)
@@ -485,6 +526,7 @@ class TestFullPipeline:
 # Trade Scenario Validation
 # ─────────────────────────────────────────────────────────────
 
+
 class TestTradeScenarios:
     """Validate that the model produces realistic dynasty trade behavior.
 
@@ -498,6 +540,7 @@ class TestTradeScenarios:
     def market(self):
         """A 200-player market with realistic multi-source ranks."""
         import random
+
         random.seed(42)
         players = {}
         for i in range(1, 201):
@@ -535,12 +578,12 @@ class TestTradeScenarios:
         top5_span = top5_values[0] - top5_values[-1]
         full_range = market.players[0].final_value - market.players[-1].final_value
         span_share = top5_span / full_range
-        assert span_share < 0.50, (
-            f"Top-5 span consumes {span_share*100:.1f}% of full range — too concentrated"
-        )
-        assert span_share > 0.02, (
-            f"Top-5 span is only {span_share*100:.1f}% of full range — elites too flat"
-        )
+        assert (
+            span_share < 0.50
+        ), f"Top-5 span consumes {span_share*100:.1f}% of full range — too concentrated"
+        assert (
+            span_share > 0.02
+        ), f"Top-5 span is only {span_share*100:.1f}% of full range — elites too flat"
 
     # ── 2. Tier-down premium ──
 
@@ -565,14 +608,12 @@ class TestTradeScenarios:
             # value users see.  final_value is an intermediate pipeline value
             # and can have near-zero gaps at late tiers due to cliff decay.
             cross_gap = above.display_value - below.display_value
-            assert cross_gap > 0, (
-                f"Tier boundary {b.tier_id_above}→{b.tier_id_below} has non-positive display gap"
-            )
+            assert (
+                cross_gap > 0
+            ), f"Tier boundary {b.tier_id_above}→{b.tier_id_below} has non-positive display gap"
 
             # Gather intra-tier adjacent display_value gaps for each side
-            tier_above_players = [
-                p for p in market.players if p.tier_id == b.tier_id_above
-            ]
+            tier_above_players = [p for p in market.players if p.tier_id == b.tier_id_above]
             if len(tier_above_players) >= 2:
                 intra_above = [
                     tier_above_players[j].display_value - tier_above_players[j + 1].display_value
@@ -582,9 +623,7 @@ class TestTradeScenarios:
             else:
                 median_intra_above = 0.0
 
-            tier_below_players = [
-                p for p in market.players if p.tier_id == b.tier_id_below
-            ]
+            tier_below_players = [p for p in market.players if p.tier_id == b.tier_id_below]
             if len(tier_below_players) >= 2:
                 intra_below = [
                     tier_below_players[j].display_value - tier_below_players[j + 1].display_value
@@ -697,6 +736,7 @@ class TestTradeScenarios:
 # Stability Tests
 # ─────────────────────────────────────────────────────────────
 
+
 class TestStability:
     def test_small_rank_change_small_value_change(self):
         """Moving one player by 1–2 spots should not cause wild swings."""
@@ -721,6 +761,7 @@ class TestStability:
     def test_ordering_stable_under_noise(self):
         """Adding small noise to sources should preserve overall ordering."""
         import random
+
         random.seed(99)
         base_players = {f"P{i}": [float(i)] for i in range(1, 51)}
         base_result = _quick_pipeline(base_players)
@@ -743,15 +784,31 @@ class TestStability:
 # Integration bridge
 # ─────────────────────────────────────────────────────────────
 
+
 class TestBuildPlayerInputs:
     def test_basic_conversion(self):
         records = [
-            {"asset_key": "mahomes", "display_name": "Patrick Mahomes",
-             "source": "KTC", "rank_raw": 1.0, "position_normalized_guess": "QB"},
-            {"asset_key": "mahomes", "display_name": "Patrick Mahomes",
-             "source": "IDPTRADECALC", "rank_raw": 2.0, "position_normalized_guess": "QB"},
-            {"asset_key": "chase", "display_name": "Ja'Marr Chase",
-             "source": "KTC", "rank_raw": 3.0, "position_normalized_guess": "WR"},
+            {
+                "asset_key": "mahomes",
+                "display_name": "Patrick Mahomes",
+                "source": "KTC",
+                "rank_raw": 1.0,
+                "position_normalized_guess": "QB",
+            },
+            {
+                "asset_key": "mahomes",
+                "display_name": "Patrick Mahomes",
+                "source": "IDPTRADECALC",
+                "rank_raw": 2.0,
+                "position_normalized_guess": "QB",
+            },
+            {
+                "asset_key": "chase",
+                "display_name": "Ja'Marr Chase",
+                "source": "KTC",
+                "rank_raw": 3.0,
+                "position_normalized_guess": "WR",
+            },
         ]
         inputs = build_player_inputs_from_raw_records(records)
         assert len(inputs) == 2
@@ -762,33 +819,30 @@ class TestBuildPlayerInputs:
     def test_excluded_sources_are_filtered(self):
         """Records from excluded sources should be dropped entirely."""
         records = [
-            {"asset_key": "p1", "display_name": "P1",
-             "source": "BAD", "rank_raw": 1.0},
-            {"asset_key": "p1", "display_name": "P1",
-             "source": "GOOD", "rank_raw": 3.0},
+            {"asset_key": "p1", "display_name": "P1", "source": "BAD", "rank_raw": 1.0},
+            {"asset_key": "p1", "display_name": "P1", "source": "GOOD", "rank_raw": 3.0},
         ]
         inputs = build_player_inputs_from_raw_records(
-            records, excluded_sources={"BAD"},
+            records,
+            excluded_sources={"BAD"},
         )
         assert len(inputs) == 1
         assert inputs[0].source_ranks == [3.0]
 
     def test_excluding_all_sources_yields_empty(self):
         records = [
-            {"asset_key": "p1", "display_name": "P1",
-             "source": "ONLY", "rank_raw": 1.0},
+            {"asset_key": "p1", "display_name": "P1", "source": "ONLY", "rank_raw": 1.0},
         ]
         inputs = build_player_inputs_from_raw_records(
-            records, excluded_sources={"ONLY"},
+            records,
+            excluded_sources={"ONLY"},
         )
         assert len(inputs) == 0
 
     def test_no_exclusions_includes_everything(self):
         records = [
-            {"asset_key": "p1", "display_name": "P1",
-             "source": "A", "rank_raw": 1.0},
-            {"asset_key": "p1", "display_name": "P1",
-             "source": "B", "rank_raw": 5.0},
+            {"asset_key": "p1", "display_name": "P1", "source": "A", "rank_raw": 1.0},
+            {"asset_key": "p1", "display_name": "P1", "source": "B", "rank_raw": 5.0},
         ]
         inputs = build_player_inputs_from_raw_records(records)
         assert len(inputs) == 1
@@ -796,8 +850,7 @@ class TestBuildPlayerInputs:
 
     def test_skips_no_rank(self):
         records = [
-            {"asset_key": "p1", "display_name": "P1",
-             "source": "SRC", "rank_raw": None},
+            {"asset_key": "p1", "display_name": "P1", "source": "SRC", "rank_raw": None},
         ]
         inputs = build_player_inputs_from_raw_records(records)
         assert len(inputs) == 0
@@ -807,8 +860,10 @@ class TestBuildPlayerInputs:
 # Record-object bridge (RawAssetRecord-style objects)
 # ─────────────────────────────────────────────────────────────
 
+
 class _FakeRecord:
     """Mimics RawAssetRecord attribute interface for testing."""
+
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -817,16 +872,28 @@ class _FakeRecord:
 class TestBuildPlayerInputsFromRecordObjects:
     def test_basic_conversion(self):
         records = [
-            _FakeRecord(asset_key="mahomes", display_name="Patrick Mahomes",
-                        source="KTC", rank_raw=1.0,
-                        position_normalized_guess="QB", position_raw="QB",
-                        team_normalized_guess="KC", team_raw="KC",
-                        universe="offense_vet"),
-            _FakeRecord(asset_key="mahomes", display_name="Patrick Mahomes",
-                        source="IDPTRADECALC", rank_raw=2.0,
-                        position_normalized_guess="QB", position_raw="QB",
-                        team_normalized_guess="KC", team_raw="KC",
-                        universe="offense_vet"),
+            _FakeRecord(
+                asset_key="mahomes",
+                display_name="Patrick Mahomes",
+                source="KTC",
+                rank_raw=1.0,
+                position_normalized_guess="QB",
+                position_raw="QB",
+                team_normalized_guess="KC",
+                team_raw="KC",
+                universe="offense_vet",
+            ),
+            _FakeRecord(
+                asset_key="mahomes",
+                display_name="Patrick Mahomes",
+                source="IDPTRADECALC",
+                rank_raw=2.0,
+                position_normalized_guess="QB",
+                position_raw="QB",
+                team_normalized_guess="KC",
+                team_raw="KC",
+                universe="offense_vet",
+            ),
         ]
         inputs = build_player_inputs_from_record_objects(records)
         assert len(inputs) == 1
@@ -836,16 +903,28 @@ class TestBuildPlayerInputsFromRecordObjects:
 
     def test_excluded_sources(self):
         records = [
-            _FakeRecord(asset_key="p1", display_name="P1",
-                        source="BAD", rank_raw=1.0,
-                        position_normalized_guess="", position_raw="",
-                        team_normalized_guess="", team_raw="",
-                        universe="offense_vet"),
-            _FakeRecord(asset_key="p1", display_name="P1",
-                        source="GOOD", rank_raw=3.0,
-                        position_normalized_guess="", position_raw="",
-                        team_normalized_guess="", team_raw="",
-                        universe="offense_vet"),
+            _FakeRecord(
+                asset_key="p1",
+                display_name="P1",
+                source="BAD",
+                rank_raw=1.0,
+                position_normalized_guess="",
+                position_raw="",
+                team_normalized_guess="",
+                team_raw="",
+                universe="offense_vet",
+            ),
+            _FakeRecord(
+                asset_key="p1",
+                display_name="P1",
+                source="GOOD",
+                rank_raw=3.0,
+                position_normalized_guess="",
+                position_raw="",
+                team_normalized_guess="",
+                team_raw="",
+                universe="offense_vet",
+            ),
         ]
         inputs = build_player_inputs_from_record_objects(records, excluded_sources={"BAD"})
         assert len(inputs) == 1
@@ -853,11 +932,17 @@ class TestBuildPlayerInputsFromRecordObjects:
 
     def test_universe_in_metadata(self):
         records = [
-            _FakeRecord(asset_key="watt", display_name="T.J. Watt",
-                        source="IDP", rank_raw=1.0,
-                        position_normalized_guess="LB", position_raw="LB",
-                        team_normalized_guess="PIT", team_raw="PIT",
-                        universe="idp_vet"),
+            _FakeRecord(
+                asset_key="watt",
+                display_name="T.J. Watt",
+                source="IDP",
+                rank_raw=1.0,
+                position_normalized_guess="LB",
+                position_raw="LB",
+                team_normalized_guess="PIT",
+                team_raw="PIT",
+                universe="idp_vet",
+            ),
         ]
         inputs = build_player_inputs_from_record_objects(records)
         assert inputs[0].metadata["universe"] == "idp_vet"
@@ -866,6 +951,7 @@ class TestBuildPlayerInputsFromRecordObjects:
 # ─────────────────────────────────────────────────────────────
 # Asset dict conversion
 # ─────────────────────────────────────────────────────────────
+
 
 class TestValuationResultToAssetDicts:
     def _run_and_convert(self, n=20, universe="offense_vet"):
@@ -880,9 +966,17 @@ class TestValuationResultToAssetDicts:
 
     def test_required_fields_present(self):
         _, dicts = self._run_and_convert()
-        required = {"asset_key", "display_name", "universe", "source_values",
-                     "blended_value", "calibrated_value", "display_value",
-                     "source_count", "metadata"}
+        required = {
+            "asset_key",
+            "display_name",
+            "universe",
+            "source_values",
+            "blended_value",
+            "calibrated_value",
+            "display_value",
+            "source_count",
+            "metadata",
+        }
         for d in dicts:
             assert required.issubset(d.keys()), f"Missing: {required - d.keys()}"
 
@@ -895,9 +989,14 @@ class TestValuationResultToAssetDicts:
 
     def test_explainability_fields(self):
         _, dicts = self._run_and_convert()
-        explain_keys = {"canonical_consensus_rank", "canonical_tier_id",
-                        "canonical_base_value", "canonical_final_value",
-                        "canonical_rank_volatility", "canonical_monotonic_clamp"}
+        explain_keys = {
+            "canonical_consensus_rank",
+            "canonical_tier_id",
+            "canonical_base_value",
+            "canonical_final_value",
+            "canonical_rank_volatility",
+            "canonical_monotonic_clamp",
+        }
         for d in dicts:
             assert explain_keys.issubset(d.keys())
 
@@ -926,10 +1025,10 @@ class TestValuationResultToAssetDicts:
             assert d["calibrated_value"] == d["display_value"]
 
 
-
 # ─────────────────────────────────────────────────────────────
 # Calibration Fixtures — market-realistic scenario tests
 # ─────────────────────────────────────────────────────────────
+
 
 class TestCalibrationFixtures:
     """Validate value distributions match dynasty trade market expectations."""
@@ -938,6 +1037,7 @@ class TestCalibrationFixtures:
     def _market_result(n=200):
         """Simulate a realistic 200-player market with 3 sources."""
         import random
+
         random.seed(42)
         players = {}
         for i in range(1, n + 1):
@@ -957,9 +1057,7 @@ class TestCalibrationFixtures:
         vals = [p.display_value for p in top_24]
         spread = max(vals) - min(vals)
         # Top 24 should span at least 20% of the full display range
-        assert spread >= DISPLAY_SCALE_MAX * 0.20, (
-            f"Top-24 spread {spread} is too compressed"
-        )
+        assert spread >= DISPLAY_SCALE_MAX * 0.20, f"Top-24 spread {spread} is too compressed"
 
     def test_startup_round_groupings(self):
         """Players within startup rounds should have declining average value."""
@@ -972,9 +1070,9 @@ class TestCalibrationFixtures:
             round_avgs.append(avg)
         # Each round's average should be strictly less than the previous
         for i in range(1, len(round_avgs)):
-            assert round_avgs[i] < round_avgs[i - 1], (
-                f"Round {i+1} avg ({round_avgs[i]:.0f}) >= Round {i} avg ({round_avgs[i-1]:.0f})"
-            )
+            assert (
+                round_avgs[i] < round_avgs[i - 1]
+            ), f"Round {i+1} avg ({round_avgs[i]:.0f}) >= Round {i} avg ({round_avgs[i-1]:.0f})"
 
     def test_idp_cluster_ceiling(self):
         """IDP and offense universes with same ranks produce same pipeline output.
@@ -1010,22 +1108,23 @@ class TestCalibrationFixtures:
         assert all(v >= DISPLAY_SCALE_MIN for v in vals), "Tail values below minimum"
         # Hill curve has a higher tail than the old inverse-power curve by design.
         # Rank 180 maps to ~1700; threshold is 20% of scale (2000).
-        assert max(vals) < DISPLAY_SCALE_MAX * 0.20, (
-            f"Tail max {max(vals)} too high — should be <20% of scale"
-        )
+        assert (
+            max(vals) < DISPLAY_SCALE_MAX * 0.20
+        ), f"Tail max {max(vals)} too high — should be <20% of scale"
 
     def test_tier_count_reasonable(self):
         """A 200-player market should produce a reasonable number of tiers."""
         result = self._market_result()
         # Expect somewhere between 3 and 30 tiers
-        assert 3 <= result.tier_count <= 30, (
-            f"Tier count {result.tier_count} outside expected 3-30 range"
-        )
+        assert (
+            3 <= result.tier_count <= 30
+        ), f"Tier count {result.tier_count} outside expected 3-30 range"
 
 
 # ─────────────────────────────────────────────────────────────
 # Parameter-sweep calibration harness
 # ─────────────────────────────────────────────────────────────
+
 
 class TestParameterSweep:
     """Verify pipeline behaves sensibly across a range of hyperparameter values."""
@@ -1034,6 +1133,7 @@ class TestParameterSweep:
     def _sweep_players():
         """Standard 50-player set with 2 sources for sweeps."""
         import random
+
         random.seed(123)
         players = {}
         for i in range(1, 51):
@@ -1051,18 +1151,18 @@ class TestParameterSweep:
         calibration refreshes.
         """
         import random
+
         random.seed(123)
         # Generate a deeper sweep (150 players) so the tail probe lands
         # well past the midpoint even if constants shift.
-        players = {
-            f"P{i}": [float(i), float(i) + random.uniform(-1, 1)]
-            for i in range(1, 151)
-        }
+        players = {f"P{i}": [float(i), float(i) + random.uniform(-1, 1)] for i in range(1, 151)}
         tail_fractions = []
         for slope in [0.6, 1.10, 1.5, 2.0]:
             result = run_valuation(
-                [PlayerInput(player_id=k, display_name=k, source_ranks=v)
-                 for k, v in players.items()],
+                [
+                    PlayerInput(player_id=k, display_name=k, source_ranks=v)
+                    for k, v in players.items()
+                ],
                 hill_slope=slope,
             )
             top_dv = result.players[0].display_value
@@ -1083,8 +1183,10 @@ class TestParameterSweep:
         tier_counts = []
         for thresh in [1.0, 2.0, 4.0, 8.0]:
             result = run_valuation(
-                [PlayerInput(player_id=k, display_name=k, source_ranks=v)
-                 for k, v in players.items()],
+                [
+                    PlayerInput(player_id=k, display_name=k, source_ranks=v)
+                    for k, v in players.items()
+                ],
                 gap_threshold=thresh,
             )
             tier_counts.append(result.tier_count)
@@ -1099,6 +1201,7 @@ class TestParameterSweep:
         """Higher cliff base should increase cross-tier value gaps."""
         # Use data with natural gaps to ensure tier detection fires
         import random
+
         random.seed(789)
         players_data = {}
         rank = 1.0
@@ -1111,8 +1214,7 @@ class TestParameterSweep:
 
         players = players_data
         default_result = run_valuation(
-            [PlayerInput(player_id=k, display_name=k, source_ranks=v)
-             for k, v in players.items()],
+            [PlayerInput(player_id=k, display_name=k, source_ranks=v) for k, v in players.items()],
         )
         if not default_result.tier_boundaries:
             pytest.skip("No tier boundaries detected in sweep data")
@@ -1120,8 +1222,10 @@ class TestParameterSweep:
         cross_tier_gaps = []
         for cliff in [50.0, 120.0, 250.0]:
             result = run_valuation(
-                [PlayerInput(player_id=k, display_name=k, source_ranks=v)
-                 for k, v in players.items()],
+                [
+                    PlayerInput(player_id=k, display_name=k, source_ranks=v)
+                    for k, v in players.items()
+                ],
                 cliff_base=cliff,
             )
             # Measure value gap at first tier boundary
@@ -1143,6 +1247,7 @@ class TestParameterSweep:
     def test_vol_strength_sweep(self):
         """Higher vol strength should compress high-volatility players more."""
         import random
+
         random.seed(456)
         # Create players with varying volatility
         players_data = []
@@ -1178,10 +1283,14 @@ class TestParameterSweep:
     def test_monotonicity_preserved_across_all_sweeps(self):
         """All parameter combinations should maintain strict display ordering."""
         import random
+
         random.seed(999)
         players = [
-            PlayerInput(player_id=f"P{i}", display_name=f"P{i}",
-                        source_ranks=[float(i), float(i) + random.uniform(-2, 2)])
+            PlayerInput(
+                player_id=f"P{i}",
+                display_name=f"P{i}",
+                source_ranks=[float(i), float(i) + random.uniform(-2, 2)],
+            )
             for i in range(1, 41)
         ]
         for slope in [0.8, 1.4]:
@@ -1189,16 +1298,15 @@ class TestParameterSweep:
                 result = run_valuation(players, hill_slope=slope, gap_threshold=thresh)
                 vals = [p.display_value for p in result.players]
                 for i in range(1, len(vals)):
-                    assert vals[i] <= vals[i - 1], (
-                        f"Non-monotonic at index {i} with slope={slope}, thresh={thresh}"
-                    )
+                    assert (
+                        vals[i] <= vals[i - 1]
+                    ), f"Non-monotonic at index {i} with slope={slope}, thresh={thresh}"
 
     def test_all_defaults_produce_valid_output(self):
         """Running with all default hyperparameters should produce valid output."""
         players = self._sweep_players()
         result = run_valuation(
-            [PlayerInput(player_id=k, display_name=k, source_ranks=v)
-             for k, v in players.items()],
+            [PlayerInput(player_id=k, display_name=k, source_ranks=v) for k, v in players.items()],
         )
         assert len(result.players) == 50
         assert result.tier_count >= 1

--- a/tests/canonical/test_rank_history_band.py
+++ b/tests/canonical/test_rank_history_band.py
@@ -1,4 +1,5 @@
 """Tests for the rankHistory band (rolling CI over time)."""
+
 from __future__ import annotations
 
 from src.canonical import rank_history_band as rhb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Global test fixtures."""
+
 from __future__ import annotations
 
 import os
@@ -37,6 +38,7 @@ os.environ.pop("SLEEPER_LEAGUE_ID", None)
 os.environ["LEAGUE_REGISTRY_PATH"] = "/nonexistent/path/for/tests.json"
 try:
     from src.api import league_registry as _league_registry
+
     _league_registry.reload_registry()
 except Exception:  # noqa: BLE001 — conftest must never block collection
     pass
@@ -68,24 +70,26 @@ except Exception:  # noqa: BLE001 — conftest must never block collection
 # of editing ~16 files; a new live-data test just adds its module here.
 # (test_source_floor_invariant.py is intentionally NOT here — it is the
 # pure static pre-merge guard and must keep blocking.)
-_LIVEDATA_MODULES = frozenset({
-    "test_launch_readiness.py",
-    "test_source_monitoring.py",
-    "test_footballguys_source.py",
-    "test_picks_end_to_end.py",
-    "test_pick_refinement.py",
-    "test_pick_rookie_anchor.py",
-    "test_player_identity_regression.py",
-    "test_single_curve_live.py",
-    "test_single_authority.py",
-    "test_per_source_freshness.py",
-    "test_data_contract.py",
-    "test_dlf_source.py",
-    "test_dlf_scraper.py",
-    "test_fantasypros_idp_integration.py",
-    "test_ktc_reconciliation.py",
-    "test_fetch_flock_fantasy_rookies.py",
-})
+_LIVEDATA_MODULES = frozenset(
+    {
+        "test_launch_readiness.py",
+        "test_source_monitoring.py",
+        "test_footballguys_source.py",
+        "test_picks_end_to_end.py",
+        "test_pick_refinement.py",
+        "test_pick_rookie_anchor.py",
+        "test_player_identity_regression.py",
+        "test_single_curve_live.py",
+        "test_single_authority.py",
+        "test_per_source_freshness.py",
+        "test_data_contract.py",
+        "test_dlf_source.py",
+        "test_dlf_scraper.py",
+        "test_fantasypros_idp_integration.py",
+        "test_ktc_reconciliation.py",
+        "test_fetch_flock_fantasy_rookies.py",
+    }
+)
 
 
 def pytest_configure(config):

--- a/tests/identity/test_matcher.py
+++ b/tests/identity/test_matcher.py
@@ -1,4 +1,5 @@
 """Unit tests for src/identity/matcher.py"""
+
 from __future__ import annotations
 
 import pytest
@@ -51,6 +52,7 @@ def _make_record(
 
 # ── Confidence ladder tests ──────────────────────────────────────────
 
+
 class TestConfidenceLadder:
     def test_exact_id_gives_1_00(self):
         rec = _make_record(external_id="sleeper_123")
@@ -80,6 +82,7 @@ class TestConfidenceLadder:
 
 
 # ── Master player building ───────────────────────────────────────────
+
 
 class TestBuildMasterPlayers:
     def test_single_record_creates_one_player(self):
@@ -133,6 +136,7 @@ class TestBuildMasterPlayers:
 
 
 # ── Full identity resolution ─────────────────────────────────────────
+
 
 class TestBuildIdentityResolution:
     def test_basic_resolution(self):
@@ -208,6 +212,7 @@ class TestBuildIdentityResolution:
 
 # ── Confidence ladder edge cases ──────────────────────────────────────
 
+
 class TestConfidenceLadderEdgeCases:
     def test_team_raw_fallback_when_no_normalized(self):
         """If team_normalized_guess is empty but team_raw has value, should still count."""
@@ -237,6 +242,7 @@ class TestConfidenceLadderEdgeCases:
 
 
 # ── Master player building edge cases ─────────────────────────────────
+
 
 class TestBuildMasterPlayersEdgeCases:
     def test_three_sources_merge_into_one_player(self):
@@ -273,6 +279,7 @@ class TestBuildMasterPlayersEdgeCases:
 
 
 # ── Pick processing edge cases ────────────────────────────────────────
+
 
 class TestPickProcessingEdgeCases:
     def test_pick_with_numeric_slot(self):
@@ -336,6 +343,7 @@ class TestPickProcessingEdgeCases:
 
 # ── Age parsing ───────────────────────────────────────────────────────
 
+
 class TestAgeParsingInResolution:
     def test_valid_integer_age(self):
         rec = _make_record()
@@ -368,9 +376,11 @@ class TestAgeParsingInResolution:
 
 # ── build_identity_report backward compat ─────────────────────────────
 
+
 class TestBuildIdentityReport:
     def test_is_alias_for_build_identity_resolution(self):
         from src.identity.matcher import build_identity_report
+
         records = [_make_record()]
         report = build_identity_report(records)
         assert report["master_player_count"] == 1

--- a/tests/identity/test_unified_mapper.py
+++ b/tests/identity/test_unified_mapper.py
@@ -3,6 +3,7 @@
 Pins the 3-layer match ladder, the override short-circuit, the
 coverage-metric snapshot, and graceful handling of absent data.
 """
+
 from __future__ import annotations
 
 import json
@@ -80,7 +81,10 @@ def test_name_plus_team_plus_pos_disambiguates_same_name(sleeper_dir):
     """Two "Josh Allen" exist — QB in BUF, LB in JAX.  Name+team+pos
     must land on the QB."""
     got = unified_mapper.resolve_player(
-        sleeper_dir, name="Josh Allen", team="BUF", position="QB",
+        sleeper_dir,
+        name="Josh Allen",
+        team="BUF",
+        position="QB",
     )
     assert got is not None
     assert got.sleeper_id == "4017"
@@ -90,7 +94,9 @@ def test_name_plus_team_plus_pos_disambiguates_same_name(sleeper_dir):
 
 def test_name_plus_pos_ladder_rung(sleeper_dir):
     got = unified_mapper.resolve_player(
-        sleeper_dir, name="Josh Allen", position="LB",
+        sleeper_dir,
+        name="Josh Allen",
+        position="LB",
     )
     assert got is not None
     assert got.sleeper_id == "6794"
@@ -111,7 +117,9 @@ def test_fuzzy_name_match_for_dropped_suffix(sleeper_dir):
         "espn_id": "4432577",
     }
     got = unified_mapper.resolve_player(
-        dir_with_suffix, name="Marvin Harrison", position="WR",
+        dir_with_suffix,
+        name="Marvin Harrison",
+        position="WR",
     )
     assert got is not None
     assert got.sleeper_id == "11000"
@@ -121,7 +129,9 @@ def test_fuzzy_name_match_for_dropped_suffix(sleeper_dir):
 
 def test_unresolved_returns_none_and_bumps_metric(sleeper_dir):
     got = unified_mapper.resolve_player(
-        sleeper_dir, name="Totally Made Up Player", position="QB",
+        sleeper_dir,
+        name="Totally Made Up Player",
+        position="QB",
     )
     assert got is None
     snap = unified_mapper.mapping_coverage_snapshot()
@@ -133,15 +143,20 @@ def test_manual_override_short_circuits_mapper(sleeper_dir, tmp_path):
     use these values verbatim.  Use case: a practice-squad call-up
     not yet in the Sleeper player dir on the day of the injury."""
     overrides_file = tmp_path / "id_overrides.json"
-    overrides_file.write_text(json.dumps({
-        "99999": {
-            "gsis_id": "00-0099999",
-            "espn_id": "9999999",
-            "full_name": "Practice Squad Guy",
-            "position": "WR",
-            "team": "SF",
-        }
-    }), encoding="utf-8")
+    overrides_file.write_text(
+        json.dumps(
+            {
+                "99999": {
+                    "gsis_id": "00-0099999",
+                    "espn_id": "9999999",
+                    "full_name": "Practice Squad Guy",
+                    "position": "WR",
+                    "team": "SF",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     unified_mapper.reload_overrides()
     got = unified_mapper.resolve_player(
         sleeper_dir,

--- a/tests/integration/test_ktc_import_e2e.py
+++ b/tests/integration/test_ktc_import_e2e.py
@@ -11,6 +11,7 @@ pick bug was reported.  It would have caught it at test time
 rather than after a user report.  Pinning it here prevents
 regression.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -37,10 +38,7 @@ def test_ktc_backend_returns_pick_with_valid_canonical_name():
         result = ktc_import.resolve_trade_url(_BUG_URL)
     except Exception as exc:
         pytest.skip(f"KTC upstream unreachable: {exc}")
-    pick_entries = [
-        e for e in (result["sideOne"] + result["sideTwo"])
-        if e.get("isPick")
-    ]
+    pick_entries = [e for e in (result["sideOne"] + result["sideTwo"]) if e.get("isPick")]
     assert pick_entries, "Backend dropped the pick from the KTC URL"
     for pe in pick_entries:
         name = pe["name"]
@@ -58,10 +56,7 @@ def test_ktc_backend_returns_all_four_assets():
     except Exception as exc:
         pytest.skip(f"KTC upstream unreachable: {exc}")
     total = len(result["sideOne"]) + len(result["sideTwo"])
-    unresolved = (
-        len(result["unresolved"]["sideOne"])
-        + len(result["unresolved"]["sideTwo"])
-    )
+    unresolved = len(result["unresolved"]["sideOne"]) + len(result["unresolved"]["sideTwo"])
     assert total + unresolved == 4, (
         f"KTC parsed 4 IDs but returned {total} resolved + "
         f"{unresolved} unresolved — something went missing"
@@ -73,25 +68,55 @@ def test_ktc_endpoint_returns_structured_response(monkeypatch):
     structured shape the frontend expects, even on error."""
     # Stub the KTC resolver so the test doesn't depend on KTC being up.
     from src.trade import ktc_import as ki
-    monkeypatch.setattr(ki, "resolve_trade_url", lambda _url: {
-        "sourceUrl": _url,
-        "sideOne": [
-            {"ktcId": 1934, "name": "Jeremiyah Love", "position": "RB",
-             "team": "", "slug": "", "isPick": False},
-            {"ktcId": 1273, "name": "Jameson Williams", "position": "WR",
-             "team": "", "slug": "", "isPick": False},
-            {"ktcId": 1712, "name": "2027 Mid 4th", "position": "RDP",
-             "team": "", "slug": "", "isPick": True},
-        ],
-        "sideTwo": [
-            {"ktcId": 1415, "name": "Jahmyr Gibbs", "position": "RB",
-             "team": "", "slug": "", "isPick": False},
-        ],
-        "unresolved": {"sideOne": [], "sideTwo": []},
-    })
+
+    monkeypatch.setattr(
+        ki,
+        "resolve_trade_url",
+        lambda _url: {
+            "sourceUrl": _url,
+            "sideOne": [
+                {
+                    "ktcId": 1934,
+                    "name": "Jeremiyah Love",
+                    "position": "RB",
+                    "team": "",
+                    "slug": "",
+                    "isPick": False,
+                },
+                {
+                    "ktcId": 1273,
+                    "name": "Jameson Williams",
+                    "position": "WR",
+                    "team": "",
+                    "slug": "",
+                    "isPick": False,
+                },
+                {
+                    "ktcId": 1712,
+                    "name": "2027 Mid 4th",
+                    "position": "RDP",
+                    "team": "",
+                    "slug": "",
+                    "isPick": True,
+                },
+            ],
+            "sideTwo": [
+                {
+                    "ktcId": 1415,
+                    "name": "Jahmyr Gibbs",
+                    "position": "RB",
+                    "team": "",
+                    "slug": "",
+                    "isPick": False,
+                },
+            ],
+            "unresolved": {"sideOne": [], "sideTwo": []},
+        },
+    )
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(
-        server, "_get_auth_session",
+        server,
+        "_get_auth_session",
         lambda r: {"username": "testuser"},
     )
     with TestClient(server.app, raise_server_exceptions=True) as c:
@@ -111,9 +136,13 @@ def test_ktc_endpoint_returns_structured_response(monkeypatch):
 def test_pick_name_validator_accepts_all_canonical_shapes():
     """Pin the set of pick-name shapes we treat as canonical."""
     valid = [
-        "2027 Mid 4th", "2026 Early 1st", "2026 Late 3rd",
-        "2026 Pick 1.01", "2027 Pick 2.12",
-        "2026 1st Round", "2027 4th Round",
+        "2027 Mid 4th",
+        "2026 Early 1st",
+        "2026 Late 3rd",
+        "2026 Pick 1.01",
+        "2027 Pick 2.12",
+        "2026 1st Round",
+        "2027 4th Round",
     ]
     invalid = [
         "2027 4th",  # missing tier

--- a/tests/integration/test_multi_source_pipeline.py
+++ b/tests/integration/test_multi_source_pipeline.py
@@ -5,6 +5,7 @@ have been retired as part of the canonical-pipeline purge.  What
 remains is the adapter-loading smoke — if these CSVs don't parse, the
 live contract pipeline can't blend them either.
 """
+
 from __future__ import annotations
 
 import sys
@@ -20,6 +21,7 @@ if str(REPO) not in sys.path:
 class TestAdapterLoads:
     def test_scraper_bridge_loads_ktc(self):
         from src.adapters.scraper_bridge_adapter import ScraperBridgeAdapter
+
         ktc_path = REPO / "CSVs" / "site_raw" / "ktc.csv"
         if not ktc_path.exists():
             pytest.skip("ktc.csv not present in exports")
@@ -32,6 +34,7 @@ class TestAdapterLoads:
 
     def test_scraper_bridge_loads_idptradecalc(self):
         from src.adapters.scraper_bridge_adapter import ScraperBridgeAdapter
+
         idp_path = REPO / "CSVs" / "site_raw" / "idpTradeCalc.csv"
         if not idp_path.exists():
             pytest.skip("idpTradeCalc.csv not present in exports")

--- a/tests/league_comparison/test_combine_seasons.py
+++ b/tests/league_comparison/test_combine_seasons.py
@@ -1,4 +1,5 @@
 """Test equal-weight season combination + missing-season behavior."""
+
 from __future__ import annotations
 
 import pytest
@@ -8,9 +9,14 @@ from src.league_comparison import metrics as m
 
 def _pm(avg: float, med: float, sample: int = 24) -> m.PositionMetrics:
     return m.PositionMetrics(
-        average=avg, median=med, p25=med * 0.7, p75=med * 1.3,
-        replacement_level=med * 0.5, elite=med * 1.5,
-        replacement_adj=avg - med * 0.5, sample_size=sample,
+        average=avg,
+        median=med,
+        p25=med * 0.7,
+        p75=med * 1.3,
+        replacement_level=med * 0.5,
+        elite=med * 1.5,
+        replacement_adj=avg - med * 0.5,
+        sample_size=sample,
     )
 
 

--- a/tests/league_comparison/test_historical_stats.py
+++ b/tests/league_comparison/test_historical_stats.py
@@ -1,5 +1,6 @@
 """Tests for the nflverse → Sleeper fallback chain in
 :mod:`src.league_comparison.historical_stats`."""
+
 from __future__ import annotations
 
 import pytest
@@ -47,7 +48,8 @@ def test_falls_back_to_sleeper_when_nflverse_empty(monkeypatch):
     source map records 'sleeper'."""
     monkeypatch.setattr(_hs._ingest, "fetch_weekly_stats", lambda yrs: [])
     monkeypatch.setattr(
-        _hs._sleeper_stats, "fetch_sleeper_weekly_stats",
+        _hs._sleeper_stats,
+        "fetch_sleeper_weekly_stats",
         lambda s: [_row(s, 1, player_id="y")],
     )
     rows = _hs.load_season_rows(2025)
@@ -65,7 +67,8 @@ def test_falls_back_to_sleeper_when_nflverse_raises(monkeypatch):
 
     monkeypatch.setattr(_hs._ingest, "fetch_weekly_stats", fake_nflverse_raises)
     monkeypatch.setattr(
-        _hs._sleeper_stats, "fetch_sleeper_weekly_stats",
+        _hs._sleeper_stats,
+        "fetch_sleeper_weekly_stats",
         lambda s: [_row(s, 1, player_id="z")],
     )
     rows = _hs.load_season_rows(2025)
@@ -87,11 +90,13 @@ def test_summarize_availability_includes_sources(monkeypatch):
     """The summary must surface which sources actually fed each
     available season so the API meta block can show provenance."""
     monkeypatch.setattr(
-        _hs._ingest, "fetch_weekly_stats",
+        _hs._ingest,
+        "fetch_weekly_stats",
         lambda yrs: [_row(yrs[0], 1)] if yrs[0] != 2025 else [],
     )
     monkeypatch.setattr(
-        _hs._sleeper_stats, "fetch_sleeper_weekly_stats",
+        _hs._sleeper_stats,
+        "fetch_sleeper_weekly_stats",
         lambda s: [_row(s, 1)] if s == 2025 else [],
     )
     seasons_map = _hs.load_all_seasons([2023, 2024, 2025])
@@ -103,15 +108,17 @@ def test_summarize_availability_includes_sources(monkeypatch):
 
 # ── Regular-season week filter ───────────────────────────────────────
 
+
 def test_filter_drops_week_18_and_postseason(monkeypatch):
     """Both nflverse and Sleeper should be cut to weeks 1-17 inclusive."""
     monkeypatch.setattr(
-        _hs._ingest, "fetch_weekly_stats",
+        _hs._ingest,
+        "fetch_weekly_stats",
         lambda yrs: [
             _row(yrs[0], 1, player_id="w1"),
             _row(yrs[0], 17, player_id="w17"),
-            _row(yrs[0], 18, player_id="w18"),     # starter-rest week
-            _row(yrs[0], 19, player_id="wpost"),   # nflverse postseason
+            _row(yrs[0], 18, player_id="w18"),  # starter-rest week
+            _row(yrs[0], 19, player_id="wpost"),  # nflverse postseason
         ],
     )
     monkeypatch.setattr(_hs._sleeper_stats, "fetch_sleeper_weekly_stats", lambda s: [])
@@ -126,10 +133,11 @@ def test_filter_drops_rows_with_missing_week(monkeypatch):
     """Defensive: a row missing the week field shouldn't crash the
     filter — just drop quietly."""
     monkeypatch.setattr(
-        _hs._ingest, "fetch_weekly_stats",
+        _hs._ingest,
+        "fetch_weekly_stats",
         lambda yrs: [
             {"player_id": "good", "season": yrs[0], "week": 5},
-            {"player_id": "bad", "season": yrs[0]},        # no week
+            {"player_id": "bad", "season": yrs[0]},  # no week
             {"player_id": "string", "season": yrs[0], "week": "wat"},
         ],
     )

--- a/tests/league_comparison/test_metrics.py
+++ b/tests/league_comparison/test_metrics.py
@@ -1,4 +1,5 @@
 """Unit tests for src.league_comparison.metrics — the pure stat math."""
+
 from __future__ import annotations
 
 import math
@@ -23,10 +24,14 @@ def _score(pts: float, pos: str = "QB", pid: str | None = None) -> PlayerSeasonS
 
 # ── top_n_by_position / flex_top_n ────────────────────────────────────
 
+
 def test_top_n_filters_by_position_and_sorts_desc():
     pool = [
-        _score(100, "QB"), _score(200, "RB"), _score(300, "QB"),
-        _score(150, "QB"), _score(50, "QB"),
+        _score(100, "QB"),
+        _score(200, "RB"),
+        _score(300, "QB"),
+        _score(150, "QB"),
+        _score(50, "QB"),
     ]
     out = m.top_n_by_position(pool, "QB", 3)
     assert [s.total_points for s in out] == [300, 150, 100]
@@ -50,7 +55,7 @@ def test_top_n_handles_oversized_request():
 
 def test_flex_excludes_qb():
     pool = [
-        _score(500, "QB"),    # would be #1 by points but excluded
+        _score(500, "QB"),  # would be #1 by points but excluded
         _score(200, "RB"),
         _score(150, "WR"),
         _score(100, "TE"),
@@ -69,6 +74,7 @@ def test_flex_top_n_with_size_limit():
 
 
 # ── position_metrics ─────────────────────────────────────────────────
+
 
 def test_position_metrics_basic():
     pts = [300, 250, 200, 150, 100]
@@ -101,26 +107,38 @@ def test_position_metrics_single_value():
 
 # ── blended scores ───────────────────────────────────────────────────
 
+
 def test_legacy_blended_is_avg_median_average():
     metrics = m.PositionMetrics(
-        average=200, median=180, p25=150, p75=250,
-        replacement_level=100, elite=300, replacement_adj=100, sample_size=5,
+        average=200,
+        median=180,
+        p25=150,
+        p75=250,
+        replacement_level=100,
+        elite=300,
+        replacement_adj=100,
+        sample_size=5,
     )
     assert m.legacy_blended(metrics) == pytest.approx(190.0)
 
 
 def test_improved_blended_uses_documented_weights():
     metrics = m.PositionMetrics(
-        average=200, median=180, p25=120, p75=240,
-        replacement_level=100, elite=300, replacement_adj=100, sample_size=5,
+        average=200,
+        median=180,
+        p25=120,
+        p75=240,
+        replacement_level=100,
+        elite=300,
+        replacement_adj=100,
+        sample_size=5,
     )
-    expected = (
-        0.35 * 180 + 0.25 * 200 + 0.20 * 240 + 0.10 * 120 + 0.10 * 100
-    )
+    expected = 0.35 * 180 + 0.25 * 200 + 0.20 * 240 + 0.10 * 120 + 0.10 * 100
     assert m.improved_blended(metrics) == pytest.approx(expected)
 
 
 # ── shares ───────────────────────────────────────────────────────────
+
 
 def test_position_shares_sum_to_100():
     inp = {"QB": 100, "RB": 200, "WR": 300, "TE": 400}
@@ -139,10 +157,11 @@ def test_position_shares_treats_negative_as_zero():
     shares = m.position_shares({"QB": -50, "RB": 100, "WR": 100, "TE": 100})
     # Negative QB drops to zero in the total; RB/WR/TE split 100% three ways
     assert shares["QB"] == 0
-    assert shares["RB"] == pytest.approx(100/3)
+    assert shares["RB"] == pytest.approx(100 / 3)
 
 
 # ── status_label ─────────────────────────────────────────────────────
+
 
 @pytest.mark.parametrize(
     "diff,expected",
@@ -164,6 +183,7 @@ def test_status_label_bands(diff, expected):
 
 
 # ── similarity score ─────────────────────────────────────────────────
+
 
 def test_similarity_score_perfect_match_is_100():
     shares = {"QB": 25, "RB": 25, "WR": 30, "TE": 20}
@@ -202,7 +222,8 @@ def test_similarity_score_handles_zero_baseline_flex():
     out = m.similarity_score(
         {"QB": 25, "RB": 25, "WR": 30, "TE": 20},
         {"QB": 25, "RB": 25, "WR": 30, "TE": 20},
-        my_flex=200, baseline_flex=0,
+        my_flex=200,
+        baseline_flex=0,
     )
     # No NaN, no crash; flex deviation simply zero
     assert math.isfinite(out.score)
@@ -210,6 +231,7 @@ def test_similarity_score_handles_zero_baseline_flex():
 
 
 # ── recommendations ──────────────────────────────────────────────────
+
 
 def test_recommendation_aligned_says_no_adjustment():
     text = m.recommendation("QB", 0.3, my_share=25.0, baseline_share=24.7)

--- a/tests/league_comparison/test_scoring_engine.py
+++ b/tests/league_comparison/test_scoring_engine.py
@@ -1,4 +1,5 @@
 """Test the per-player season scoring engine."""
+
 from __future__ import annotations
 
 import pytest
@@ -14,9 +15,14 @@ from src.league_comparison.scoring_engine import (
 
 
 _PPR = {
-    "pass_yd": 0.04, "pass_td": 4, "pass_int": -2,
-    "rush_yd": 0.1, "rush_td": 6,
-    "rec": 1.0, "rec_yd": 0.1, "rec_td": 6,
+    "pass_yd": 0.04,
+    "pass_td": 4,
+    "pass_int": -2,
+    "rush_yd": 0.1,
+    "rush_td": 6,
+    "rec": 1.0,
+    "rec_yd": 0.1,
+    "rec_td": 6,
     "fum_lost": -2,
 }
 
@@ -28,9 +34,14 @@ def _stat(pid: str, pos: str, week: int, **stats):
         "position": pos,
         "season": 2024,
         "week": week,
-        "passing_yards": 0, "passing_tds": 0, "interceptions": 0,
-        "rushing_yards": 0, "rushing_tds": 0,
-        "receptions": 0, "receiving_yards": 0, "receiving_tds": 0,
+        "passing_yards": 0,
+        "passing_tds": 0,
+        "interceptions": 0,
+        "rushing_yards": 0,
+        "rushing_tds": 0,
+        "receptions": 0,
+        "receiving_yards": 0,
+        "receiving_tds": 0,
         "fumbles_lost": 0,
         **stats,
     }
@@ -52,7 +63,7 @@ def test_canonical_position_collapses_idp():
 
 
 def test_canonical_position_filters_unknown():
-    assert _canonical_position("K") is None    # kickers excluded
+    assert _canonical_position("K") is None  # kickers excluded
     assert _canonical_position("OL") is None
     assert _canonical_position("") is None
     assert _canonical_position(None) is None
@@ -106,9 +117,9 @@ def test_te_premium_only_applies_to_te():
 
 def test_unknown_position_filtered_out():
     rows = [
-        _stat("k1", "K", 1, rushing_yards=10),       # kicker — drop
-        _stat("ol1", "OL", 1, fumbles_lost=1),       # offensive line — drop
-        _stat("qb1", "QB", 1, passing_yards=200),    # keep
+        _stat("k1", "K", 1, rushing_yards=10),  # kicker — drop
+        _stat("ol1", "OL", 1, fumbles_lost=1),  # offensive line — drop
+        _stat("qb1", "QB", 1, passing_yards=200),  # keep
     ]
     scores = compute_player_season_scores(rows, _PPR)
     assert {s.player_id for s in scores} == {"qb1"}
@@ -123,9 +134,13 @@ def test_missing_scoring_settings_returns_empty():
 def test_handles_player_id_field_alias():
     """nflverse uses player_id; some fixtures might use player_id_gsis."""
     row = {
-        "player_id_gsis": "g1", "player_name": "G1", "position": "RB",
-        "season": 2024, "week": 1,
-        "rushing_yards": 100, "rushing_tds": 1,
+        "player_id_gsis": "g1",
+        "player_name": "G1",
+        "position": "RB",
+        "season": 2024,
+        "week": 1,
+        "rushing_yards": 100,
+        "rushing_tds": 1,
     }
     scores = compute_player_season_scores([row], _PPR)
     assert len(scores) == 1
@@ -133,6 +148,7 @@ def test_handles_player_id_field_alias():
 
 
 # ── Blended score (volume + pace) ────────────────────────────────────
+
 
 def test_blended_full_season_equals_total():
     """A 17-game player has blended == total: ppg×17 collapses to total."""
@@ -150,7 +166,7 @@ def test_blended_partial_season_rewards_pace():
 def test_blended_below_min_games_uses_total_only():
     """Less than MIN_GAMES_FOR_PPG → no PPG bonus, blended == total.
     Prevents a 1-game outlier from inflating the ranking."""
-    assert MIN_GAMES_FOR_PPG == 8        # pin the threshold
+    assert MIN_GAMES_FOR_PPG == 8  # pin the threshold
     # 7 games at 30 ppg = 210 raw — should NOT extrapolate to 510.
     assert compute_blended_score(total_points=210.0, games_played=7) == pytest.approx(210.0)
     assert compute_blended_score(total_points=30.0, games_played=1) == pytest.approx(30.0)
@@ -170,8 +186,13 @@ def test_blended_at_min_games_threshold_includes_pace():
 def test_player_season_score_blended_property_matches_function():
     """The dataclass property delegates to compute_blended_score."""
     s = PlayerSeasonScore(
-        player_id="p", player_name="P", position="QB", raw_position="QB",
-        season=2024, total_points=200.0, games_played=10,
+        player_id="p",
+        player_name="P",
+        position="QB",
+        raw_position="QB",
+        season=2024,
+        total_points=200.0,
+        games_played=10,
     )
     assert s.blended_score == compute_blended_score(200.0, 10)
     assert s.points_per_game == pytest.approx(20.0)

--- a/tests/league_comparison/test_service.py
+++ b/tests/league_comparison/test_service.py
@@ -3,6 +3,7 @@
 We don't hit Sleeper or nflverse here — both are stubbed at the module
 boundary so the test runs offline and pins the response shape.
 """
+
 from __future__ import annotations
 
 import json
@@ -17,6 +18,7 @@ from src.league_comparison import (
 
 # ── Fixtures ──────────────────────────────────────────────────────────
 
+
 @pytest.fixture(autouse=True)
 def isolate_caches(tmp_path, monkeypatch):
     """Redirect both the per-league scoring cache and the disk
@@ -24,23 +26,37 @@ def isolate_caches(tmp_path, monkeypatch):
     other or into real cache files."""
     _sleeper_mod.evict()
     monkeypatch.setattr(
-        _service, "_cache_dir", lambda: tmp_path / "lc_cache",
+        _service,
+        "_cache_dir",
+        lambda: tmp_path / "lc_cache",
     )
     yield
     _sleeper_mod.evict()
 
 
 _MY_SCORING = {
-    "pass_yd": 0.04, "pass_td": 5, "pass_int": -2,
-    "rush_yd": 0.1, "rush_td": 6,
-    "rec": 0.75, "rec_yd": 0.1, "rec_td": 6,
-    "bonus_rec_te": 0.38, "fum_lost": -2,
+    "pass_yd": 0.04,
+    "pass_td": 5,
+    "pass_int": -2,
+    "rush_yd": 0.1,
+    "rush_td": 6,
+    "rec": 0.75,
+    "rec_yd": 0.1,
+    "rec_td": 6,
+    "bonus_rec_te": 0.38,
+    "fum_lost": -2,
 }
 _BASE_SCORING = {
-    "pass_yd": 0.04, "pass_td": 4, "pass_int": -2,
-    "rush_yd": 0.1, "rush_td": 6,
-    "rec": 1.0, "rec_yd": 0.1, "rec_td": 6,
-    "bonus_rec_te": 0.5, "fum_lost": -2,
+    "pass_yd": 0.04,
+    "pass_td": 4,
+    "pass_int": -2,
+    "rush_yd": 0.1,
+    "rush_td": 6,
+    "rec": 1.0,
+    "rec_yd": 0.1,
+    "rec_td": 6,
+    "bonus_rec_te": 0.5,
+    "fum_lost": -2,
 }
 
 
@@ -57,27 +73,40 @@ def _stub_scoring_fetch(monkeypatch):
     def fake(league_id, *, refresh=False):
         if league_id == my_id:
             return _sleeper_mod.LeagueScoringInfo(
-                league_id=league_id, name="My League",
-                season="2025", season_type="regular",
+                league_id=league_id,
+                name="My League",
+                season="2025",
+                season_type="regular",
                 scoring_settings=_MY_SCORING,
                 scoring_hash="hashMY",
             )
         return _sleeper_mod.LeagueScoringInfo(
-            league_id=league_id, name="Standard Baseline",
-            season="2025", season_type="regular",
+            league_id=league_id,
+            name="Standard Baseline",
+            season="2025",
+            season_type="regular",
             scoring_settings=_BASE_SCORING,
             scoring_hash="hashBASE",
         )
+
     monkeypatch.setattr(_sleeper_mod, "fetch_league_scoring", fake)
 
 
 def _row(pid, pos, week, season, **stats):
     base = {
-        "player_id": pid, "player_name": pid.upper(),
-        "position": pos, "season": season, "week": week,
-        "passing_yards": 0, "passing_tds": 0, "interceptions": 0,
-        "rushing_yards": 0, "rushing_tds": 0,
-        "receptions": 0, "receiving_yards": 0, "receiving_tds": 0,
+        "player_id": pid,
+        "player_name": pid.upper(),
+        "position": pos,
+        "season": season,
+        "week": week,
+        "passing_yards": 0,
+        "passing_tds": 0,
+        "interceptions": 0,
+        "rushing_yards": 0,
+        "rushing_tds": 0,
+        "receptions": 0,
+        "receiving_yards": 0,
+        "receiving_tds": 0,
         "fumbles_lost": 0,
     }
     base.update(stats)
@@ -92,33 +121,53 @@ def _make_season(season: int):
     # plus headroom.  Vary points by index so ranking is deterministic.
     for i in range(30):
         for week in range(1, 18):
-            rows.append(_row(
-                f"qb{i}", "QB", week, season,
-                passing_yards=200 + (29 - i) * 5,
-                passing_tds=2 if i < 12 else 1,
-            ))
+            rows.append(
+                _row(
+                    f"qb{i}",
+                    "QB",
+                    week,
+                    season,
+                    passing_yards=200 + (29 - i) * 5,
+                    passing_tds=2 if i < 12 else 1,
+                )
+            )
     for i in range(30):
         for week in range(1, 18):
-            rows.append(_row(
-                f"rb{i}", "RB", week, season,
-                rushing_yards=60 + (29 - i) * 3,
-                receptions=2 + (i % 4),
-                receiving_yards=15 + (i % 5) * 4,
-            ))
+            rows.append(
+                _row(
+                    f"rb{i}",
+                    "RB",
+                    week,
+                    season,
+                    rushing_yards=60 + (29 - i) * 3,
+                    receptions=2 + (i % 4),
+                    receiving_yards=15 + (i % 5) * 4,
+                )
+            )
     for i in range(40):
         for week in range(1, 18):
-            rows.append(_row(
-                f"wr{i}", "WR", week, season,
-                receptions=4 + (39 - i) // 5,
-                receiving_yards=50 + (39 - i) * 2,
-            ))
+            rows.append(
+                _row(
+                    f"wr{i}",
+                    "WR",
+                    week,
+                    season,
+                    receptions=4 + (39 - i) // 5,
+                    receiving_yards=50 + (39 - i) * 2,
+                )
+            )
     for i in range(15):
         for week in range(1, 18):
-            rows.append(_row(
-                f"te{i}", "TE", week, season,
-                receptions=3 + (14 - i) // 3,
-                receiving_yards=30 + (14 - i) * 2,
-            ))
+            rows.append(
+                _row(
+                    f"te{i}",
+                    "TE",
+                    week,
+                    season,
+                    receptions=3 + (14 - i) // 3,
+                    receiving_yards=30 + (14 - i) * 2,
+                )
+            )
     return rows
 
 
@@ -127,10 +176,12 @@ def _stub_stats_fetch(monkeypatch, available_seasons):
         if season in available_seasons:
             return _make_season(season)
         return None
+
     monkeypatch.setattr(_stats_mod, "load_season_rows", fake_load)
 
 
 # ── Tests ─────────────────────────────────────────────────────────────
+
 
 def test_build_comparison_returns_full_shape(monkeypatch, tmp_path):
     _stub_scoring_fetch(monkeypatch)
@@ -139,7 +190,16 @@ def test_build_comparison_returns_full_shape(monkeypatch, tmp_path):
     out = _service.build_comparison(refresh=True)
 
     # Top-level keys
-    for key in ("meta", "summary", "similarity", "positions", "flex", "bySeason", "idp", "warnings"):
+    for key in (
+        "meta",
+        "summary",
+        "similarity",
+        "positions",
+        "flex",
+        "bySeason",
+        "idp",
+        "warnings",
+    ):
         assert key in out, f"missing top-level key: {key}"
 
     # Meta block
@@ -218,7 +278,10 @@ def test_cache_hit_avoids_recomputation(monkeypatch):
     assert call_count["n"] == n_after_first
     assert second["meta"]["cacheHit"] is True
     # Same shape, same positions
-    assert second["positions"]["QB"]["my"]["improvedScore"] == first["positions"]["QB"]["my"]["improvedScore"]
+    assert (
+        second["positions"]["QB"]["my"]["improvedScore"]
+        == first["positions"]["QB"]["my"]["improvedScore"]
+    )
 
 
 def test_refresh_bypasses_cache(monkeypatch):

--- a/tests/league_comparison/test_sleeper_scoring.py
+++ b/tests/league_comparison/test_sleeper_scoring.py
@@ -1,4 +1,5 @@
 """Tests for the Sleeper scoring fetcher's caching + parsing behavior."""
+
 from __future__ import annotations
 
 import json
@@ -36,7 +37,10 @@ def test_fetch_parses_scoring_settings(monkeypatch):
     assert info.name == "Test League"
     assert info.season == "2025"
     assert info.scoring_settings == {
-        "pass_yd": 0.04, "pass_td": 5.0, "rec": 0.75, "bonus_rec_te": 0.38,
+        "pass_yd": 0.04,
+        "pass_td": 5.0,
+        "rec": 0.75,
+        "bonus_rec_te": 0.38,
     }
     assert len(info.scoring_hash) == 12
 

--- a/tests/league_comparison/test_sleeper_stats.py
+++ b/tests/league_comparison/test_sleeper_stats.py
@@ -4,6 +4,7 @@ The HTTP boundary is mocked at every test entrypoint via the
 ``fetcher`` parameter on the public functions, so these tests run
 fully offline.
 """
+
 from __future__ import annotations
 
 import urllib.error
@@ -15,14 +16,22 @@ from src.league_comparison import sleeper_stats as _ss
 
 # ── Field translation ────────────────────────────────────────────────
 
+
 def test_translate_stats_maps_offense_keys():
     """Sleeper short keys → nflverse long keys for offense scoring."""
-    out = _ss._translate_stats({
-        "pass_yd": 280, "pass_td": 2, "pass_int": 1,
-        "rush_yd": 35, "rush_td": 1,
-        "rec": 5, "rec_yd": 60, "rec_td": 1,
-        "fum_lost": 0,
-    })
+    out = _ss._translate_stats(
+        {
+            "pass_yd": 280,
+            "pass_td": 2,
+            "pass_int": 1,
+            "rush_yd": 35,
+            "rush_td": 1,
+            "rec": 5,
+            "rec_yd": 60,
+            "rec_td": 1,
+            "fum_lost": 0,
+        }
+    )
     assert out["passing_yards"] == 280
     assert out["passing_tds"] == 2
     assert out["interceptions"] == 1
@@ -36,10 +45,16 @@ def test_translate_stats_maps_offense_keys():
 
 def test_translate_stats_maps_idp_keys():
     """Sleeper idp_* → nflverse def_* for the realized-points engine."""
-    out = _ss._translate_stats({
-        "idp_tkl": 6, "idp_tkl_solo": 4, "idp_tkl_ast": 2,
-        "idp_sack": 1, "idp_qb_hit": 1, "idp_int": 1,
-    })
+    out = _ss._translate_stats(
+        {
+            "idp_tkl": 6,
+            "idp_tkl_solo": 4,
+            "idp_tkl_ast": 2,
+            "idp_sack": 1,
+            "idp_qb_hit": 1,
+            "idp_int": 1,
+        }
+    )
     assert out["def_tackles"] == 6
     assert out["def_tackles_solo"] == 4
     assert out["def_tackle_assists"] == 2
@@ -59,11 +74,13 @@ def test_translate_stats_passes_through_unmapped_keys():
 def test_translate_stats_skips_non_numeric():
     """Sleeper occasionally returns null / strings — those should be
     dropped, not raise."""
-    out = _ss._translate_stats({
-        "pass_yd": 250,
-        "weather_note": "rain",
-        "rush_yd": None,
-    })
+    out = _ss._translate_stats(
+        {
+            "pass_yd": 250,
+            "weather_note": "rain",
+            "rush_yd": None,
+        }
+    )
     assert "passing_yards" in out
     assert "weather_note" not in out
     assert "rushing_yards" not in out
@@ -71,12 +88,14 @@ def test_translate_stats_skips_non_numeric():
 
 # ── fetch_sleeper_weekly_stats end-to-end (mocked HTTP) ───────────────
 
+
 def _make_fake_fetcher(player_index, weeks):
     """Build a fake fetcher that returns a player index for the
     /players/nfl URL and per-week stat dicts for /stats/* URLs.
 
     ``weeks`` is ``{week: stats_dict}``; missing weeks raise 404.
     """
+
     def fetcher(url):
         if "/players/nfl" in url:
             return player_index
@@ -89,6 +108,7 @@ def _make_fake_fetcher(player_index, weeks):
         if week not in weeks:
             raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
         return weeks[week]
+
     return fetcher
 
 
@@ -131,12 +151,12 @@ def test_fetch_sleeper_weekly_stats_returns_nflverse_shaped_rows():
     sample = qb_rows[0]
     assert sample["season"] == 2025
     assert sample["week"] in (1, 2)
-    assert sample["player_id"] == "00-G100"   # gsis_id is canonical
+    assert sample["player_id"] == "00-G100"  # gsis_id is canonical
     assert sample["player_id_gsis"] == "00-G100"
     assert sample["player_id_sleeper"] == "100"
     assert sample["player_name"] == "Test QB"
-    assert "passing_yards" in sample        # translated
-    assert "pass_yd" in sample              # original retained
+    assert "passing_yards" in sample  # translated
+    assert "pass_yd" in sample  # original retained
 
 
 def test_fetch_sleeper_weekly_stats_skips_players_without_position():

--- a/tests/maintenance/test_retention.py
+++ b/tests/maintenance/test_retention.py
@@ -169,9 +169,7 @@ def test_containment_guard_blocks_protected_root(tmp_path):
     cat = retention.CategoryResult(name="x")
     target = tmp_path / "data" / "identity" / "player_map.json"
     _touch(target, age_days=999)
-    retention._delete(
-        target, tmp_path / "data" / "identity", protected, cat, dry_run=False
-    )
+    retention._delete(target, tmp_path / "data" / "identity", protected, cat, dry_run=False)
     assert target.exists()
     assert cat.errors == 1
     assert cat.deleted == 0

--- a/tests/news/test_api_news_route.py
+++ b/tests/news/test_api_news_route.py
@@ -5,6 +5,7 @@ Uses an in-memory stub NewsService injected via
 touch the network.  The route is otherwise exercised verbatim —
 query-param parsing, response shape, 503 on all-failures.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/news/test_cbs_provider.py
+++ b/tests/news/test_cbs_provider.py
@@ -4,6 +4,7 @@ Shares the ``_rss`` helpers with ESPN / FantasyPros, so the
 surface exercised here is provider identity + the raise-on-
 failure contract.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/news/test_custom_alerts.py
+++ b/tests/news/test_custom_alerts.py
@@ -1,4 +1,5 @@
 """Custom-alert rule validation, evaluation, and cooldown tests."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -9,11 +10,13 @@ from src.news import custom_alerts as ca
 
 
 def test_validate_value_crosses_rule():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Caleb Williams",
-        "params": {"threshold": 7000, "direction": "above"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Caleb Williams",
+            "params": {"threshold": 7000, "direction": "above"},
+        }
+    )
     assert rule["kind"] == "value_crosses"
     assert rule["displayName"] == "Caleb Williams"
     assert rule["params"] == {"threshold": 7000, "direction": "above"}
@@ -22,12 +25,14 @@ def test_validate_value_crosses_rule():
 
 
 def test_validate_rank_change_rule():
-    rule = ca.validate_rule({
-        "kind": "rank_change",
-        "displayName": "Bo Nix",
-        "params": {"minDelta": 10},
-        "channels": ["email", "push"],
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "rank_change",
+            "displayName": "Bo Nix",
+            "params": {"minDelta": 10},
+            "channels": ["email", "push"],
+        }
+    )
     assert rule["params"] == {"minDelta": 10}
     assert set(rule["channels"]) == {"email", "push"}
 
@@ -39,14 +44,16 @@ def test_validate_rank_change_rule():
         ({"kind": "value_crosses"}, "displayName"),
         ({"kind": "value_crosses", "displayName": "X"}, "threshold"),
         (
-            {"kind": "value_crosses", "displayName": "X",
-             "params": {"threshold": 1, "direction": "sideways"}},
+            {
+                "kind": "value_crosses",
+                "displayName": "X",
+                "params": {"threshold": 1, "direction": "sideways"},
+            },
             "direction",
         ),
         ({"kind": "rank_change", "displayName": "X"}, "minDelta"),
         (
-            {"kind": "rank_change", "displayName": "X",
-             "params": {"minDelta": 10}, "channels": []},
+            {"kind": "rank_change", "displayName": "X", "params": {"minDelta": 10}, "channels": []},
             "channel",
         ),
     ],
@@ -67,11 +74,13 @@ def _fake_player(name="Test Player", *, value=6000, rank_change=0, rank=50):
 
 
 def test_value_crosses_above_fires_when_value_meets_threshold():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Caleb",
-        "params": {"threshold": 5000, "direction": "above"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Caleb",
+            "params": {"threshold": 5000, "direction": "above"},
+        }
+    )
     hits = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=6000)])
     assert len(hits) == 1
     assert hits[0].kind == "value_crosses"
@@ -79,53 +88,63 @@ def test_value_crosses_above_fires_when_value_meets_threshold():
 
 
 def test_value_crosses_above_silent_when_below_threshold():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Caleb",
-        "params": {"threshold": 7000, "direction": "above"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Caleb",
+            "params": {"threshold": 7000, "direction": "above"},
+        }
+    )
     hits = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=6000)])
     assert hits == []
 
 
 def test_value_crosses_below_fires_when_value_drops_under_threshold():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Bo",
-        "params": {"threshold": 4000, "direction": "below"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Bo",
+            "params": {"threshold": 4000, "direction": "below"},
+        }
+    )
     hits = ca.evaluate_alerts([rule], [_fake_player("Bo", value=3500)])
     assert len(hits) == 1
     assert "↓" in hits[0].title
 
 
 def test_rank_change_fires_when_delta_meets_threshold():
-    rule = ca.validate_rule({
-        "kind": "rank_change",
-        "displayName": "Drake",
-        "params": {"minDelta": 5},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "rank_change",
+            "displayName": "Drake",
+            "params": {"minDelta": 5},
+        }
+    )
     hits = ca.evaluate_alerts([rule], [_fake_player("Drake", rank_change=-7)])
     assert len(hits) == 1
     assert hits[0].kind == "rank_change"
 
 
 def test_rank_change_silent_when_movement_below_threshold():
-    rule = ca.validate_rule({
-        "kind": "rank_change",
-        "displayName": "Drake",
-        "params": {"minDelta": 10},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "rank_change",
+            "displayName": "Drake",
+            "params": {"minDelta": 10},
+        }
+    )
     hits = ca.evaluate_alerts([rule], [_fake_player("Drake", rank_change=3)])
     assert hits == []
 
 
 def test_cooldown_suppresses_recent_fire():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Caleb",
-        "params": {"threshold": 5000, "direction": "above"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Caleb",
+            "params": {"threshold": 5000, "direction": "above"},
+        }
+    )
     # 1 hour ago → still in 24h cooldown.
     last_iso = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
         "%Y-%m-%dT%H:%M:%SZ",
@@ -133,17 +152,21 @@ def test_cooldown_suppresses_recent_fire():
     skey = f"{rule['id']}::caleb"
     state = {skey: {"lastFiredAt": last_iso}}
     hits = ca.evaluate_alerts(
-        [rule], [_fake_player("Caleb", value=6000)], state=state,
+        [rule],
+        [_fake_player("Caleb", value=6000)],
+        state=state,
     )
     assert hits == []
 
 
 def test_cooldown_lifts_after_24h():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Caleb",
-        "params": {"threshold": 5000, "direction": "above"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Caleb",
+            "params": {"threshold": 5000, "direction": "above"},
+        }
+    )
     # 25 hours ago → cooldown elapsed.
     last_iso = (datetime.now(timezone.utc) - timedelta(hours=25)).strftime(
         "%Y-%m-%dT%H:%M:%SZ",
@@ -151,17 +174,21 @@ def test_cooldown_lifts_after_24h():
     skey = f"{rule['id']}::caleb"
     state = {skey: {"lastFiredAt": last_iso}}
     hits = ca.evaluate_alerts(
-        [rule], [_fake_player("Caleb", value=6000)], state=state,
+        [rule],
+        [_fake_player("Caleb", value=6000)],
+        state=state,
     )
     assert len(hits) == 1
 
 
 def test_mark_fired_records_timestamp_under_state_key():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Caleb",
-        "params": {"threshold": 5000, "direction": "above"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Caleb",
+            "params": {"threshold": 5000, "direction": "above"},
+        }
+    )
     [hit] = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=6000)])
     new_state = ca.mark_fired({}, hit)
     assert hit.state_key in new_state
@@ -181,10 +208,12 @@ def test_prune_state_drops_only_matching_rule_id():
 
 
 def test_unknown_player_does_not_fire():
-    rule = ca.validate_rule({
-        "kind": "value_crosses",
-        "displayName": "Phantom",
-        "params": {"threshold": 1, "direction": "above"},
-    })
+    rule = ca.validate_rule(
+        {
+            "kind": "value_crosses",
+            "displayName": "Phantom",
+            "params": {"threshold": 1, "direction": "above"},
+        }
+    )
     hits = ca.evaluate_alerts([rule], [_fake_player("Caleb", value=9999)])
     assert hits == []

--- a/tests/news/test_dynasty_focused_providers.py
+++ b/tests/news/test_dynasty_focused_providers.py
@@ -17,6 +17,7 @@ What still needs pinning per-provider:
 
 Everything below is a static contract check — no HTTP.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/news/test_espn_provider.py
+++ b/tests/news/test_espn_provider.py
@@ -2,6 +2,7 @@
 
 Tests inject a fake RSS-body fetcher so no network access happens.
 """
+
 from __future__ import annotations
 
 from src.news.providers.espn import EspnRssProvider

--- a/tests/news/test_fantasypros_provider.py
+++ b/tests/news/test_fantasypros_provider.py
@@ -5,6 +5,7 @@ so the surface tested here is mostly provider-identity + the
 raise-on-failure contract.  The full classification matrix is
 covered in ``test_espn_provider.py``.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -41,9 +42,7 @@ def _provider(rss_bytes=_SAMPLE_RSS):
 
 
 def test_items_parse_and_tag_provider_identity():
-    items = _provider().fetch(
-        player_names=["Bijan Robinson", "Jahmyr Gibbs"]
-    )
+    items = _provider().fetch(player_names=["Bijan Robinson", "Jahmyr Gibbs"])
     assert len(items) == 2
     for it in items:
         assert it.provider == "fantasypros"

--- a/tests/news/test_news_contract.py
+++ b/tests/news/test_news_contract.py
@@ -7,6 +7,7 @@ and the enriched vocabulary (``publishedAt``, ``summary``,
 breaks, every downstream consumer breaks — hence a dedicated
 contract test instead of folding it into a provider test.
 """
+
 from __future__ import annotations
 
 from src.news.base import NewsItem, PlayerMention, stable_id, to_iso_utc

--- a/tests/news/test_service.py
+++ b/tests/news/test_service.py
@@ -9,6 +9,7 @@ Verifies:
 * priority ordering — Sleeper items appear ahead of ESPN in the
   aggregator before the severity/time sort re-orders them
 """
+
 from __future__ import annotations
 
 from src.news.base import NewsItem, NewsProvider, PlayerMention
@@ -181,9 +182,7 @@ def test_total_limit_matches_route_cap():
 
 
 def test_serialize_to_dict_shape():
-    provider = _StaticProvider(
-        items=[_item("a-1", players=[PlayerMention(name="Player X")])]
-    )
+    provider = _StaticProvider(items=[_item("a-1", players=[PlayerMention(name="Player X")])])
     svc = NewsService([provider], cache_ttl_s=0)
     payload = svc.aggregate().to_dict()
     assert "items" in payload

--- a/tests/news/test_sleeper_provider.py
+++ b/tests/news/test_sleeper_provider.py
@@ -4,6 +4,7 @@ These exercise the normalization path — upstream HTTP is stubbed
 via a fake ``requests.Session`` so the tests stay offline and
 deterministic.
 """
+
 from __future__ import annotations
 
 from src.news.providers.sleeper import (
@@ -128,6 +129,7 @@ def test_cold_player_map_failure_propagates():
         def get(self, url, timeout=None, headers=None):
             self.calls.append(url)
             if "trending" in url:
+
                 class _R:
                     def raise_for_status(self):
                         return None
@@ -166,6 +168,7 @@ def test_warm_player_map_failure_degrades_gracefully():
     class _WarmMapOutage:
         def get(self, url, timeout=None, headers=None):
             if "trending" in url:
+
                 class _R:
                     def raise_for_status(self):
                         return None
@@ -214,6 +217,7 @@ def test_provider_tolerates_one_endpoint_failing():
         def get(self, url, timeout=None, headers=None):
             self.calls.append(url)
             if self._ok_path in url:
+
                 class _R:
                     def raise_for_status(self):
                         return None
@@ -223,6 +227,7 @@ def test_provider_tolerates_one_endpoint_failing():
 
                 return _R()
             if "/players/nfl" in url and "trending" not in url:
+
                 class _R2:
                     def raise_for_status(self):
                         return None
@@ -234,9 +239,7 @@ def test_provider_tolerates_one_endpoint_failing():
             raise RuntimeError("drops unavailable")
 
     _reset_player_map_for_tests()
-    provider = SleeperTrendingProvider(
-        session=_SplitSession("/trending/add")
-    )
+    provider = SleeperTrendingProvider(session=_SplitSession("/trending/add"))
     items = provider.fetch()
     assert len(items) == 1
     assert items[0].players[0].name == "Only Add"

--- a/tests/news/test_unified_signal_engine.py
+++ b/tests/news/test_unified_signal_engine.py
@@ -1,4 +1,5 @@
 """Tests for the unified signal engine."""
+
 from __future__ import annotations
 
 from src.news import unified_signal_engine as ue
@@ -18,16 +19,22 @@ def test_severity_bumps_for_starter():
 
 def test_value_movement_below_threshold_is_none():
     sig = ue.value_movement_signal(
-        name="X", sleeper_id="1", position="WR",
-        pct_change_7d=0.03, pct_change_30d=0.05,
+        name="X",
+        sleeper_id="1",
+        position="WR",
+        pct_change_7d=0.03,
+        pct_change_30d=0.05,
     )
     assert sig is None
 
 
 def test_value_movement_positive_fires_buy():
     sig = ue.value_movement_signal(
-        name="X", sleeper_id="1", position="WR",
-        pct_change_7d=0.12, pct_change_30d=0.20,
+        name="X",
+        sleeper_id="1",
+        position="WR",
+        pct_change_7d=0.12,
+        pct_change_30d=0.20,
     )
     assert sig is not None
     assert sig.verdict == "BUY"
@@ -36,17 +43,25 @@ def test_value_movement_positive_fires_buy():
 
 def test_value_movement_negative_fires_sell():
     sig = ue.value_movement_signal(
-        name="X", sleeper_id="1", position="WR",
-        pct_change_7d=-0.12, pct_change_30d=-0.20,
+        name="X",
+        sleeper_id="1",
+        position="WR",
+        pct_change_7d=-0.12,
+        pct_change_30d=-0.20,
     )
     assert sig.verdict == "SELL"
 
 
 def test_usage_signal_converts_correctly():
     raw = {
-        "signal": "BUY", "tag": "usage_spike_snap",
-        "name": "Player", "pos": "WR", "sleeperId": "1",
-        "snap_pct_z": 3.0, "target_share_z": None, "carry_share_z": None,
+        "signal": "BUY",
+        "tag": "usage_spike_snap",
+        "name": "Player",
+        "pos": "WR",
+        "sleeperId": "1",
+        "snap_pct_z": 3.0,
+        "target_share_z": None,
+        "carry_share_z": None,
         "reason": "Snap spike",
     }
     sig = ue.usage_signal_to_unified(raw)
@@ -82,7 +97,8 @@ def test_injury_ir_status_is_high_severity():
         "transition": "healthy_to_injured",
         "newStatus": "IR",
         "espnAthleteId": "1",
-        "name": "X", "position": "RB",
+        "name": "X",
+        "position": "RB",
         "reason": "IR placement",
     }
     sig = ue.injury_signal_to_unified(diff, starter=True, tier=1)
@@ -109,18 +125,30 @@ def test_unified_composite_bumps_severity_on_agreement():
     # Three sources all saying SELL on same player → composite
     # with bumped severity + explanation combining all.
     value = ue.value_movement_signal(
-        name="Player", sleeper_id="1", position="WR",
-        pct_change_7d=-0.15, pct_change_30d=-0.25,
+        name="Player",
+        sleeper_id="1",
+        position="WR",
+        pct_change_7d=-0.15,
+        pct_change_30d=-0.25,
     )
-    usage = ue.usage_signal_to_unified({
-        "signal": "SELL", "tag": "usage_drop_snap",
-        "name": "Player", "pos": "WR", "sleeperId": "1",
-        "snap_pct_z": -3.5, "reason": "Snap drop",
-    })
+    usage = ue.usage_signal_to_unified(
+        {
+            "signal": "SELL",
+            "tag": "usage_drop_snap",
+            "name": "Player",
+            "pos": "WR",
+            "sleeperId": "1",
+            "snap_pct_z": -3.5,
+            "reason": "Snap drop",
+        }
+    )
     injury = ue.injury_signal_to_unified(
         {
-            "transition": "injury_worsened", "newStatus": "OUT",
-            "espnAthleteId": "1", "name": "Player", "position": "WR",
+            "transition": "injury_worsened",
+            "newStatus": "OUT",
+            "espnAthleteId": "1",
+            "name": "Player",
+            "position": "WR",
             "reason": "Q → Out",
         },
         sleeper_id_resolver=lambda _: "1",
@@ -136,13 +164,19 @@ def test_unified_composite_bumps_severity_on_agreement():
 def test_unified_conflict_keeps_signals_separate():
     # Value says BUY, injury says SELL — don't auto-resolve.
     v = ue.value_movement_signal(
-        name="P", sleeper_id="1", position="WR",
-        pct_change_7d=0.15, pct_change_30d=0.25,
+        name="P",
+        sleeper_id="1",
+        position="WR",
+        pct_change_7d=0.15,
+        pct_change_30d=0.25,
     )
     i = ue.injury_signal_to_unified(
         {
-            "transition": "healthy_to_injured", "newStatus": "OUT",
-            "espnAthleteId": "1", "name": "P", "position": "WR",
+            "transition": "healthy_to_injured",
+            "newStatus": "OUT",
+            "espnAthleteId": "1",
+            "name": "P",
+            "position": "WR",
             "reason": "injury",
         },
         sleeper_id_resolver=lambda _: "1",
@@ -158,11 +192,23 @@ def test_legacy_shape_compatible_with_signal_alerts():
     """to_legacy_shape output must be consumable by
     detect_signal_transitions — same key names."""
     sig = ue.value_movement_signal(
-        name="X", sleeper_id="1", position="QB",
-        pct_change_7d=0.12, pct_change_30d=0.20,
+        name="X",
+        sleeper_id="1",
+        position="QB",
+        pct_change_7d=0.12,
+        pct_change_30d=0.20,
     )
     shape = sig.to_legacy_shape()
     # Keys the existing signal_alerts pipeline reads.
-    for k in ("name", "pos", "signal", "reason", "tag", "signalKey",
-              "aliasSignalKey", "sleeperId", "dismissed"):
+    for k in (
+        "name",
+        "pos",
+        "signal",
+        "reason",
+        "tag",
+        "signalKey",
+        "aliasSignalKey",
+        "sleeperId",
+        "dismissed",
+    ):
         assert k in shape

--- a/tests/news/test_usage_signals.py
+++ b/tests/news/test_usage_signals.py
@@ -3,6 +3,7 @@
 These pin the gating rules: flag-off = no output, freshness guard
 blocks mid-week data, z-score thresholds fire in the right
 direction, and SELL requires active-starter status."""
+
 from __future__ import annotations
 
 import datetime as _dt
@@ -26,11 +27,18 @@ def _flags():
 
 def _mk_window(**overrides):
     base = {
-        "player_id": "A", "season": 2024, "week": 17,
-        "snap_pct_mean": 0.50, "snap_pct_sd": 0.05,
-        "target_share_mean": 0.15, "target_share_sd": 0.02,
-        "carry_share_mean": 0.10, "carry_share_sd": 0.02,
-        "snap_pct_z": None, "target_share_z": None, "carry_share_z": None,
+        "player_id": "A",
+        "season": 2024,
+        "week": 17,
+        "snap_pct_mean": 0.50,
+        "snap_pct_sd": 0.05,
+        "target_share_mean": 0.15,
+        "target_share_sd": 0.02,
+        "carry_share_mean": 0.10,
+        "carry_share_sd": 0.02,
+        "snap_pct_z": None,
+        "target_share_z": None,
+        "carry_share_z": None,
     }
     base.update(overrides)
     return UsageWindow(**base)
@@ -60,7 +68,8 @@ def test_target_spike_fires_buy(monkeypatch):
     monkeypatch.setenv("RISKIT_FEATURE_USAGE_SIGNALS", "1")
     feature_flags.reload()
     out = usage_signals.detect_usage_transitions(
-        [_mk_window(season=2024, target_share_z=2.5)], season_year=2026,
+        [_mk_window(season=2024, target_share_z=2.5)],
+        season_year=2026,
     )
     assert len(out) == 1
     assert out[0].tag == "usage_spike_target"
@@ -88,7 +97,9 @@ def test_freshness_guard_blocks_current_week(monkeypatch):
     # No freshness-context args would pass the guard trivially.
     # Pass season_current_week=6 and the test should skip.
     out = usage_signals.detect_usage_transitions(
-        [w], season_year=2025, season_current_week=6,
+        [w],
+        season_year=2025,
+        season_current_week=6,
     )
     # Default now is today in NFL TZ; at our test time (2026-04-24)
     # is_fresh_for_alerts treats stat_year 2025 ≠ season_year 2026
@@ -107,8 +118,13 @@ def test_freshness_guard_blocks_current_week(monkeypatch):
 
 def test_signal_dict_format_matches_expected_shape():
     s = usage_signals.UsageSignal(
-        player_id="A", signal="BUY", reason="test", tag="usage_spike_snap",
-        snap_pct_z=2.5, target_share_z=None, carry_share_z=None,
+        player_id="A",
+        signal="BUY",
+        reason="test",
+        tag="usage_spike_snap",
+        snap_pct_z=2.5,
+        target_share_z=None,
+        carry_share_z=None,
     )
     d = s.to_signal_dict(name="Josh Allen", position="QB", sleeper_id="4017")
     assert d["name"] == "Josh Allen"

--- a/tests/nfl_data/test_cache.py
+++ b/tests/nfl_data/test_cache.py
@@ -1,5 +1,6 @@
 """Tests for src.nfl_data.cache — the TTL file cache used by every
 nflverse / ESPN ingest path."""
+
 from __future__ import annotations
 
 import time
@@ -22,7 +23,10 @@ def test_expired_entry_returns_none(tmp_path):
     # Force a past fetched_at.
     _, meta = cache._entry_paths(tmp_path, "stale")  # noqa: SLF001
     import json
-    meta.write_text(json.dumps({"fetched_at": time.time() - 3600, "key": "stale"}), encoding="utf-8")
+
+    meta.write_text(
+        json.dumps({"fetched_at": time.time() - 3600, "key": "stale"}), encoding="utf-8"
+    )
     assert cache.get("stale", ttl_seconds=60, cache_dir=tmp_path) is None
 
 

--- a/tests/nfl_data/test_depth_charts.py
+++ b/tests/nfl_data/test_depth_charts.py
@@ -1,4 +1,5 @@
 """Tests for ESPN depth chart + usage cross-check gate."""
+
 from __future__ import annotations
 
 import io
@@ -43,8 +44,10 @@ def _sample_depth_payload():
 def test_flag_off_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_DEPTH_CHART_VALIDATION", "0")
     feature_flags.reload()
+
     def opener(req, timeout=None):
         return io.BytesIO(b"{}")
+
     out = dc.fetch_team_depth_chart("2", _url_opener=opener, cache_dir=tmp_path)
     assert out == []
 
@@ -52,8 +55,10 @@ def test_flag_off_returns_empty(monkeypatch, tmp_path):
 def test_parse_depth_payload_shapes(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_DEPTH_CHART_VALIDATION", "1")
     feature_flags.reload()
+
     def opener(req, timeout=None):
         return io.BytesIO(json.dumps(_sample_depth_payload()).encode("utf-8"))
+
     out = dc.fetch_team_depth_chart("2", _url_opener=opener, cache_dir=tmp_path)
     # 2 QBs + 3 RBs = 5 entries
     assert len(out) == 5

--- a/tests/nfl_data/test_freshness.py
+++ b/tests/nfl_data/test_freshness.py
@@ -2,6 +2,7 @@
 
 The rule: don't fire alerts on current-week data before Thursday
 (NFL-TZ).  The tests pin every quadrant of the decision tree."""
+
 from __future__ import annotations
 
 import datetime as _dt
@@ -20,72 +21,106 @@ def _mk(year, month, day, hour=10, weekday=None):
 
 def test_historical_year_is_always_fresh():
     # Current season 2026, stat year 2024 → fresh regardless of day.
-    assert freshness.is_fresh_for_alerts(
-        stat_week=10, stat_year=2024,
-        now=_mk(2026, 4, 24),  # a Friday
-        season_year=2026, season_current_week=3,
-    ) is True
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=10,
+            stat_year=2024,
+            now=_mk(2026, 4, 24),  # a Friday
+            season_year=2026,
+            season_current_week=3,
+        )
+        is True
+    )
 
 
 def test_prior_completed_week_is_fresh():
     # Stat week 2 of 2026, current week 4 → finalized → fresh.
-    assert freshness.is_fresh_for_alerts(
-        stat_week=2, stat_year=2026,
-        now=_mk(2026, 9, 29),  # arbitrary
-        season_year=2026, season_current_week=4,
-    ) is True
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=2,
+            stat_year=2026,
+            now=_mk(2026, 9, 29),  # arbitrary
+            season_year=2026,
+            season_current_week=4,
+        )
+        is True
+    )
 
 
 def test_future_week_is_never_fresh():
     # Stat week 8 when current week is only 5 → bogus data.
-    assert freshness.is_fresh_for_alerts(
-        stat_week=8, stat_year=2026,
-        now=_mk(2026, 10, 10),
-        season_year=2026, season_current_week=5,
-    ) is False
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=8,
+            stat_year=2026,
+            now=_mk(2026, 10, 10),
+            season_year=2026,
+            season_current_week=5,
+        )
+        is False
+    )
 
 
 def test_current_week_monday_morning_is_not_fresh():
     # Monday Oct 13, 2025 — Mon=0, before Thursday cutoff.
     monday = _dt.datetime(2025, 10, 13, 9, tzinfo=NFL_TZ)
     assert monday.weekday() == 0
-    assert freshness.is_fresh_for_alerts(
-        stat_week=6, stat_year=2025,
-        now=monday,
-        season_year=2025, season_current_week=6,
-    ) is False
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=6,
+            stat_year=2025,
+            now=monday,
+            season_year=2025,
+            season_current_week=6,
+        )
+        is False
+    )
 
 
 def test_current_week_thursday_morning_is_fresh():
     # Thursday Oct 16, 2025.
     thursday = _dt.datetime(2025, 10, 16, 9, tzinfo=NFL_TZ)
     assert thursday.weekday() == 3
-    assert freshness.is_fresh_for_alerts(
-        stat_week=6, stat_year=2025,
-        now=thursday,
-        season_year=2025, season_current_week=6,
-    ) is True
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=6,
+            stat_year=2025,
+            now=thursday,
+            season_year=2025,
+            season_current_week=6,
+        )
+        is True
+    )
 
 
 def test_current_week_sunday_evening_is_fresh():
     # Sunday evening after the games — week games are over.
     sunday = _dt.datetime(2025, 10, 19, 23, tzinfo=NFL_TZ)
     assert sunday.weekday() == 6
-    assert freshness.is_fresh_for_alerts(
-        stat_week=6, stat_year=2025,
-        now=sunday,
-        season_year=2025, season_current_week=6,
-    ) is True
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=6,
+            stat_year=2025,
+            now=sunday,
+            season_year=2025,
+            season_current_week=6,
+        )
+        is True
+    )
 
 
 def test_unknown_season_context_is_conservative():
     # No season_current_week → conservative False.
-    assert freshness.is_fresh_for_alerts(
-        stat_week=6, stat_year=2025,
-        now=_mk(2025, 10, 13),
-        season_year=2025,
-        season_current_week=None,
-    ) is False
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=6,
+            stat_year=2025,
+            now=_mk(2025, 10, 13),
+            season_year=2025,
+            season_current_week=None,
+        )
+        is False
+    )
 
 
 def test_naive_datetime_assumed_nfl_tz():
@@ -95,9 +130,11 @@ def test_naive_datetime_assumed_nfl_tz():
     naive = _dt.datetime(2025, 10, 13, 9)
     # Shouldn't raise.
     freshness.is_fresh_for_alerts(
-        stat_week=6, stat_year=2025,
+        stat_week=6,
+        stat_year=2025,
         now=naive,
-        season_year=2025, season_current_week=6,
+        season_year=2025,
+        season_current_week=6,
     )
 
 
@@ -105,13 +142,23 @@ def test_week_is_in_flight_matches_inverse():
     """week_is_in_flight = True iff is_fresh_for_alerts = False for
     a current-week row."""
     monday = _dt.datetime(2025, 10, 13, 9, tzinfo=NFL_TZ)
-    assert freshness.week_is_in_flight(
-        stat_week=6, stat_year=2025,
-        now=monday,
-        season_year=2025, season_current_week=6,
-    ) is True
-    assert freshness.is_fresh_for_alerts(
-        stat_week=6, stat_year=2025,
-        now=monday,
-        season_year=2025, season_current_week=6,
-    ) is False
+    assert (
+        freshness.week_is_in_flight(
+            stat_week=6,
+            stat_year=2025,
+            now=monday,
+            season_year=2025,
+            season_current_week=6,
+        )
+        is True
+    )
+    assert (
+        freshness.is_fresh_for_alerts(
+            stat_week=6,
+            stat_year=2025,
+            now=monday,
+            season_year=2025,
+            season_current_week=6,
+        )
+        is False
+    )

--- a/tests/nfl_data/test_ingest.py
+++ b/tests/nfl_data/test_ingest.py
@@ -6,6 +6,7 @@ Key invariants:
   * Provider exceptions are swallowed; return [].
   * The absence of nfl_data_py is NEVER a crash.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -27,13 +28,18 @@ def test_flag_off_returns_empty_without_provider_call(monkeypatch, tmp_path):
     # gate behavior must still work when explicitly disabled.
     monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "0")
     from src.api import feature_flags
+
     feature_flags.reload()
     calls = []
+
     def provider(years):
         calls.append(years)
         return [{"stub": True}]
+
     out = ingest.fetch_weekly_stats(
-        [2024], _provider=provider, cache_dir=tmp_path,
+        [2024],
+        _provider=provider,
+        cache_dir=tmp_path,
     )
     assert out == []
     assert calls == [], "flag off must not call provider"
@@ -43,18 +49,24 @@ def test_flag_on_runs_provider_and_caches(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "1")
     feature_flags.reload()
     calls = []
+
     def provider(years):
         calls.append(years)
         return [{"player_id_gsis": "00-1", "season": 2024, "week": 1}]
+
     # First call: hits provider.
     out = ingest.fetch_weekly_stats(
-        [2024], _provider=provider, cache_dir=tmp_path,
+        [2024],
+        _provider=provider,
+        cache_dir=tmp_path,
     )
     assert out and out[0]["player_id_gsis"] == "00-1"
     assert len(calls) == 1
     # Second call: cache hit, provider not called again.
     out2 = ingest.fetch_weekly_stats(
-        [2024], _provider=provider, cache_dir=tmp_path,
+        [2024],
+        _provider=provider,
+        cache_dir=tmp_path,
     )
     assert out2 == out
     assert len(calls) == 1
@@ -63,10 +75,14 @@ def test_flag_on_runs_provider_and_caches(monkeypatch, tmp_path):
 def test_provider_exception_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "1")
     feature_flags.reload()
+
     def boom(years):
         raise RuntimeError("upstream 503")
+
     out = ingest.fetch_weekly_stats(
-        [2024], _provider=boom, cache_dir=tmp_path,
+        [2024],
+        _provider=boom,
+        cache_dir=tmp_path,
     )
     assert out == []
 
@@ -74,21 +90,34 @@ def test_provider_exception_returns_empty(monkeypatch, tmp_path):
 def test_snap_counts_flag_gated(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "0")
     feature_flags.reload()
+
     def provider(years):
         return [{"pfr_id": "A", "week": 1}]
-    assert ingest.fetch_snap_counts(
-        [2024], _provider=provider, cache_dir=tmp_path,
-    ) == []
+
+    assert (
+        ingest.fetch_snap_counts(
+            [2024],
+            _provider=provider,
+            cache_dir=tmp_path,
+        )
+        == []
+    )
 
 
 def test_id_map_flag_gated(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "0")
     feature_flags.reload()
+
     def provider():
         return [{"gsis_id": "00-1", "sleeper_id": "4017"}]
-    assert ingest.fetch_id_map(
-        _provider=provider, cache_dir=tmp_path,
-    ) == []
+
+    assert (
+        ingest.fetch_id_map(
+            _provider=provider,
+            cache_dir=tmp_path,
+        )
+        == []
+    )
 
 
 def test_provider_status_without_pandas_is_not_a_crash():

--- a/tests/nfl_data/test_injury_feed.py
+++ b/tests/nfl_data/test_injury_feed.py
@@ -1,4 +1,5 @@
 """Tests for the ESPN injury feed parser + signal diff."""
+
 from __future__ import annotations
 
 import io
@@ -75,9 +76,11 @@ def test_flag_off_returns_empty(monkeypatch, tmp_path):
     feature_flags.reload()
     # No network call: opener should never be invoked.
     calls = []
+
     def opener(req, timeout=None):
         calls.append(req)
         return io.BytesIO(b"{}")
+
     out = injury_feed.fetch_injuries(_url_opener=opener, cache_dir=tmp_path)
     assert out == []
     assert calls == []
@@ -87,9 +90,11 @@ def test_flag_on_parses_and_caches(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_ESPN_INJURY_FEED", "1")
     feature_flags.reload()
     calls = []
+
     def opener(req, timeout=None):
         calls.append(req)
         return io.BytesIO(json.dumps(_sample_payload()).encode("utf-8"))
+
     out = injury_feed.fetch_injuries(_url_opener=opener, cache_dir=tmp_path)
     names = {e.full_name for e in out}
     # Questionable + Out = both active; Probable (→ DAY_TO_DAY) is active too.
@@ -111,8 +116,10 @@ def test_status_normalization():
 def test_malformed_payload_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_ESPN_INJURY_FEED", "1")
     feature_flags.reload()
+
     def opener(req, timeout=None):
         return io.BytesIO(b'{"not": "expected shape"}')
+
     out = injury_feed.fetch_injuries(_url_opener=opener, cache_dir=tmp_path)
     assert out == []
 
@@ -120,8 +127,10 @@ def test_malformed_payload_returns_empty(monkeypatch, tmp_path):
 def test_network_error_returns_empty_not_crash(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_ESPN_INJURY_FEED", "1")
     feature_flags.reload()
+
     def opener(req, timeout=None):
         raise TimeoutError("upstream")
+
     out = injury_feed.fetch_injuries(_url_opener=opener, cache_dir=tmp_path)
     assert out == []
 
@@ -130,9 +139,15 @@ def test_diff_new_injury_fires():
     prior = []
     current = [
         injury_feed.InjuryEntry(
-            espn_athlete_id="X", full_name="X Y", position="WR",
-            team_abbrev="SF", status="OUT", body_part="Knee",
-            description="", date_reported="", returning="",
+            espn_athlete_id="X",
+            full_name="X Y",
+            position="WR",
+            team_abbrev="SF",
+            status="OUT",
+            body_part="Knee",
+            description="",
+            date_reported="",
+            returning="",
         )
     ]
     signals = injury_feed.diff_for_signals(prior, current)
@@ -141,16 +156,32 @@ def test_diff_new_injury_fires():
 
 
 def test_diff_worsened_fires():
-    prior = [injury_feed.InjuryEntry(
-        espn_athlete_id="X", full_name="X Y", position="WR",
-        team_abbrev="SF", status="QUESTIONABLE", body_part="",
-        description="", date_reported="", returning="",
-    )]
-    current = [injury_feed.InjuryEntry(
-        espn_athlete_id="X", full_name="X Y", position="WR",
-        team_abbrev="SF", status="OUT", body_part="",
-        description="", date_reported="", returning="",
-    )]
+    prior = [
+        injury_feed.InjuryEntry(
+            espn_athlete_id="X",
+            full_name="X Y",
+            position="WR",
+            team_abbrev="SF",
+            status="QUESTIONABLE",
+            body_part="",
+            description="",
+            date_reported="",
+            returning="",
+        )
+    ]
+    current = [
+        injury_feed.InjuryEntry(
+            espn_athlete_id="X",
+            full_name="X Y",
+            position="WR",
+            team_abbrev="SF",
+            status="OUT",
+            body_part="",
+            description="",
+            date_reported="",
+            returning="",
+        )
+    ]
     signals = injury_feed.diff_for_signals(prior, current)
     assert len(signals) == 1
     assert signals[0]["transition"] == "injury_worsened"
@@ -158,9 +189,15 @@ def test_diff_worsened_fires():
 
 def test_diff_unchanged_does_not_fire():
     e = injury_feed.InjuryEntry(
-        espn_athlete_id="X", full_name="X Y", position="WR",
-        team_abbrev="SF", status="OUT", body_part="",
-        description="", date_reported="", returning="",
+        espn_athlete_id="X",
+        full_name="X Y",
+        position="WR",
+        team_abbrev="SF",
+        status="OUT",
+        body_part="",
+        description="",
+        date_reported="",
+        returning="",
     )
     signals = injury_feed.diff_for_signals([e], [e])
     assert signals == []
@@ -169,11 +206,19 @@ def test_diff_unchanged_does_not_fire():
 def test_diff_recovered_does_not_fire_sell_signal():
     """A player who GETS BETTER → we DON'T emit a SELL transition.
     Recovery is a different signal class covered elsewhere."""
-    prior = [injury_feed.InjuryEntry(
-        espn_athlete_id="X", full_name="X Y", position="WR",
-        team_abbrev="SF", status="OUT", body_part="",
-        description="", date_reported="", returning="",
-    )]
+    prior = [
+        injury_feed.InjuryEntry(
+            espn_athlete_id="X",
+            full_name="X Y",
+            position="WR",
+            team_abbrev="SF",
+            status="OUT",
+            body_part="",
+            description="",
+            date_reported="",
+            returning="",
+        )
+    ]
     current: list[injury_feed.InjuryEntry] = []
     signals = injury_feed.diff_for_signals(prior, current)
     assert signals == []

--- a/tests/nfl_data/test_nflverse_direct.py
+++ b/tests/nfl_data/test_nflverse_direct.py
@@ -1,4 +1,5 @@
 """Tests for the direct nflverse CSV fetcher (no nfl_data_py)."""
+
 from __future__ import annotations
 
 import io
@@ -20,13 +21,17 @@ def _reset_cb():
 
 def _csv_response(csv_text: str):
     """Build a fake urlopen context-manager that returns ``csv_text``."""
+
     class _R:
         def read(self):
             return csv_text.encode("utf-8")
+
         def __enter__(self):
             return self
+
         def __exit__(self, *a):
             pass
+
     return _R()
 
 
@@ -41,6 +46,7 @@ def test_fetch_csv_parses_rows():
 def test_fetch_csv_network_error_returns_empty():
     def _raise(*_a, **_kw):
         raise urllib.error.URLError("connection refused")
+
     with patch.object(nd.urllib.request, "urlopen", side_effect=_raise):
         rows = nd._fetch_csv("https://example.com/x.csv", label="test")  # noqa: SLF001
     assert rows == []
@@ -49,8 +55,13 @@ def test_fetch_csv_network_error_returns_empty():
 def test_fetch_csv_http_4xx_returns_empty():
     def _raise(*_a, **_kw):
         raise urllib.error.HTTPError(
-            "https://x", 404, "Not Found", {}, io.BytesIO(b""),
+            "https://x",
+            404,
+            "Not Found",
+            {},
+            io.BytesIO(b""),
         )
+
     with patch.object(nd.urllib.request, "urlopen", side_effect=_raise):
         rows = nd._fetch_csv("https://example.com/x.csv", label="test")  # noqa: SLF001
     assert rows == []
@@ -59,6 +70,7 @@ def test_fetch_csv_http_4xx_returns_empty():
 def test_fetch_csv_timeout_returns_empty():
     def _raise(*_a, **_kw):
         raise TimeoutError("slow")
+
     with patch.object(nd.urllib.request, "urlopen", side_effect=_raise):
         rows = nd._fetch_csv("https://example.com/x.csv", label="test")  # noqa: SLF001
     assert rows == []
@@ -67,6 +79,7 @@ def test_fetch_csv_timeout_returns_empty():
 def test_fetch_csv_unexpected_exception_returns_empty():
     def _raise(*_a, **_kw):
         raise RuntimeError("unexpected")
+
     with patch.object(nd.urllib.request, "urlopen", side_effect=_raise):
         rows = nd._fetch_csv("https://example.com/x.csv", label="test")  # noqa: SLF001
     assert rows == []
@@ -76,9 +89,11 @@ def test_circuit_breaker_short_circuits_when_open():
     bp = cb.get_or_create("nflverse_direct", failure_threshold=1, failure_window_sec=60)
     bp.report_failure("priming")
     calls = []
+
     def _never(*_a, **_kw):
         calls.append(1)
         return _csv_response("x")
+
     with patch.object(nd.urllib.request, "urlopen", side_effect=_never):
         rows = nd._fetch_csv("https://example.com/x.csv", label="test")  # noqa: SLF001
     assert rows == []

--- a/tests/nfl_data/test_opportunity_stats.py
+++ b/tests/nfl_data/test_opportunity_stats.py
@@ -1,4 +1,5 @@
 """Tests for red-zone + 3rd-down opportunity aggregation."""
+
 from __future__ import annotations
 
 import pytest
@@ -14,24 +15,39 @@ def _flags():
     feature_flags.reload()
 
 
-def _pass(yardline_100, down=1, receiver_id="wr1", name="WR One",
-          complete=0, td=0, first_down=0, season=2024):
+def _pass(
+    yardline_100,
+    down=1,
+    receiver_id="wr1",
+    name="WR One",
+    complete=0,
+    td=0,
+    first_down=0,
+    season=2024,
+):
     return {
-        "play_type": "pass", "season": season,
-        "down": down, "yardline_100": yardline_100,
+        "play_type": "pass",
+        "season": season,
+        "down": down,
+        "yardline_100": yardline_100,
         "receiver_player_id": receiver_id,
         "receiver_player_name": name,
-        "complete_pass": complete, "touchdown": td, "first_down": first_down,
+        "complete_pass": complete,
+        "touchdown": td,
+        "first_down": first_down,
     }
 
 
-def _run(yardline_100, down=1, rusher_id="rb1", name="RB One",
-         td=0, first_down=0, season=2024):
+def _run(yardline_100, down=1, rusher_id="rb1", name="RB One", td=0, first_down=0, season=2024):
     return {
-        "play_type": "run", "season": season,
-        "down": down, "yardline_100": yardline_100,
-        "rusher_player_id": rusher_id, "rusher_player_name": name,
-        "touchdown": td, "first_down": first_down,
+        "play_type": "run",
+        "season": season,
+        "down": down,
+        "yardline_100": yardline_100,
+        "rusher_player_id": rusher_id,
+        "rusher_player_name": name,
+        "touchdown": td,
+        "first_down": first_down,
     }
 
 
@@ -91,10 +107,7 @@ def test_third_down_failed_conversion():
 def test_opportunity_score_monotonic():
     """More RZ touches → higher opportunity score."""
     plays_low = [_pass(15, receiver_id="A", complete=1)]
-    plays_high = [
-        _pass(15, receiver_id="A", complete=1)
-        for _ in range(10)
-    ]
+    plays_high = [_pass(15, receiver_id="A", complete=1) for _ in range(10)]
     low = op.build_opportunity_from_pbp(plays_low, season=2024)
     high = op.build_opportunity_from_pbp(plays_high, season=2024)
     assert low[0].opportunity_score < high[0].opportunity_score
@@ -136,7 +149,9 @@ def test_fetch_flag_off_returns_empty(tmp_path, monkeypatch):
     monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "0")
     feature_flags.reload()
     result = op.fetch_opportunity_stats(
-        [2024], _provider=lambda _: [_pass(15)], cache_dir=tmp_path,
+        [2024],
+        _provider=lambda _: [_pass(15)],
+        cache_dir=tmp_path,
     )
     assert result == []
 
@@ -145,15 +160,21 @@ def test_fetch_flag_on_round_trips_through_cache(monkeypatch, tmp_path):
     monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "1")
     feature_flags.reload()
     calls = []
+
     def provider(years):
         calls.append(years)
         return [_pass(15, receiver_id="WR1", complete=1)]
+
     r1 = op.fetch_opportunity_stats(
-        [2024], _provider=provider, cache_dir=tmp_path,
+        [2024],
+        _provider=provider,
+        cache_dir=tmp_path,
     )
     assert r1 and r1[0]["playerIdGsis"] == "WR1"
     r2 = op.fetch_opportunity_stats(
-        [2024], _provider=provider, cache_dir=tmp_path,
+        [2024],
+        _provider=provider,
+        cache_dir=tmp_path,
     )
     assert r2 == r1
     assert len(calls) == 1  # cache hit on 2nd call
@@ -161,7 +182,8 @@ def test_fetch_flag_on_round_trips_through_cache(monkeypatch, tmp_path):
 
 def test_to_dict_shape():
     stats = op.build_opportunity_from_pbp(
-        [_pass(15, receiver_id="A")], season=2024,
+        [_pass(15, receiver_id="A")],
+        season=2024,
     )
     d = stats[0].to_dict()
     assert "rzTargets" in d

--- a/tests/nfl_data/test_realized_points.py
+++ b/tests/nfl_data/test_realized_points.py
@@ -1,6 +1,7 @@
 """Tests for realized fantasy points math.  These pin the scoring
 rules we actually implement — they're the source of truth for
 the 'value vs realized' feature in the upgraded player popup."""
+
 from __future__ import annotations
 
 from src.nfl_data import realized_points as rp
@@ -8,9 +9,14 @@ from src.nfl_data import realized_points as rp
 
 def _half_ppr():
     return {
-        "pass_yd": 0.04, "pass_td": 4, "pass_int": -2,
-        "rush_yd": 0.1, "rush_td": 6,
-        "rec": 0.5, "rec_yd": 0.1, "rec_td": 6,
+        "pass_yd": 0.04,
+        "pass_td": 4,
+        "pass_int": -2,
+        "rush_yd": 0.1,
+        "rush_td": 6,
+        "rec": 0.5,
+        "rec_yd": 0.1,
+        "rec_td": 6,
         "fum_lost": -2,
     }
 
@@ -37,8 +43,12 @@ def test_no_scoring_settings_returns_zero_with_reason():
 def test_passing_qb_ppr_math():
     # 250 yards, 2 TDs, 1 INT → 250*0.04 + 2*4 + -2*1 = 10 + 8 - 2 = 16
     stat = {
-        "season": 2025, "week": 1, "position": "QB",
-        "passing_yards": 250, "passing_tds": 2, "interceptions": 1,
+        "season": 2025,
+        "week": 1,
+        "position": "QB",
+        "passing_yards": 250,
+        "passing_tds": 2,
+        "interceptions": 1,
     }
     out = rp.compute_weekly_points(stat, _ppr())
     assert out is not None
@@ -48,8 +58,12 @@ def test_passing_qb_ppr_math():
 def test_rb_receiving_ppr_math():
     # 80 rush yds (8) + 1 rush TD (6) + 3 rec (3) + 30 rec yds (3) = 20
     stat = {
-        "season": 2025, "week": 1, "position": "RB",
-        "rushing_yards": 80, "rushing_tds": 1, "receptions": 3,
+        "season": 2025,
+        "week": 1,
+        "position": "RB",
+        "rushing_yards": 80,
+        "rushing_tds": 1,
+        "receptions": 3,
         "receiving_yards": 30,
     }
     out = rp.compute_weekly_points(stat, _ppr())
@@ -58,8 +72,11 @@ def test_rb_receiving_ppr_math():
 
 def test_half_ppr_scales_rec_but_not_other():
     stat = {
-        "season": 2025, "week": 1, "position": "RB",
-        "receptions": 4, "receiving_yards": 40,
+        "season": 2025,
+        "week": 1,
+        "position": "RB",
+        "receptions": 4,
+        "receiving_yards": 40,
     }
     ppr_out = rp.compute_weekly_points(stat, _ppr())
     half_out = rp.compute_weekly_points(stat, _half_ppr())
@@ -82,8 +99,11 @@ def test_te_premium_only_applies_to_tes():
 
 def test_threshold_bonus_applies_once():
     stat = {
-        "season": 2025, "week": 1, "position": "QB",
-        "passing_yards": 350, "passing_tds": 2,
+        "season": 2025,
+        "week": 1,
+        "position": "QB",
+        "passing_yards": 350,
+        "passing_tds": 2,
     }
     scoring = {**_ppr(), "bonus_pass_yd_300": 3, "bonus_pass_yd_400": 5}
     out = rp.compute_weekly_points(stat, scoring)

--- a/tests/nfl_data/test_usage_windows.py
+++ b/tests/nfl_data/test_usage_windows.py
@@ -1,4 +1,5 @@
 """Tests for rolling-window usage derivatives."""
+
 from __future__ import annotations
 
 from src.nfl_data import usage_windows as uw
@@ -8,8 +9,13 @@ def test_single_week_produces_zero_history():
     """First week → mean/SD = 0 and z-scores = None (no history)."""
     stat_rows = [
         {
-            "player_id_gsis": "00-1", "season": 2024, "week": 1, "recent_team": "BUF",
-            "targets": 10, "carries": 0, "snap_pct": 0.9,
+            "player_id_gsis": "00-1",
+            "season": 2024,
+            "week": 1,
+            "recent_team": "BUF",
+            "targets": 10,
+            "carries": 0,
+            "snap_pct": 0.9,
         }
     ]
     windows = uw.build_rolling_windows(stat_rows)
@@ -22,14 +28,26 @@ def test_single_week_produces_zero_history():
 def test_rolling_mean_tracks_history():
     # Player has 4 weeks of consistent 0.80 snap share, then week 5.
     stat_rows = [
-        {"player_id_gsis": "A", "season": 2024, "week": w, "recent_team": "BUF",
-         "targets": 10, "snap_pct": 0.80}
+        {
+            "player_id_gsis": "A",
+            "season": 2024,
+            "week": w,
+            "recent_team": "BUF",
+            "targets": 10,
+            "snap_pct": 0.80,
+        }
         for w in range(1, 5)
     ]
-    stat_rows.append({
-        "player_id_gsis": "A", "season": 2024, "week": 5, "recent_team": "BUF",
-        "targets": 10, "snap_pct": 0.80,
-    })
+    stat_rows.append(
+        {
+            "player_id_gsis": "A",
+            "season": 2024,
+            "week": 5,
+            "recent_team": "BUF",
+            "targets": 10,
+            "snap_pct": 0.80,
+        }
+    )
     windows = uw.build_rolling_windows(stat_rows)
     final = [w for w in windows if w.week == 5][0]
     assert abs(final.snap_pct_mean - 0.80) < 0.01
@@ -40,14 +58,26 @@ def test_spike_produces_positive_zscore():
     be positive and large."""
     rows = []
     for w in range(1, 5):
-        rows.append({
-            "player_id_gsis": "A", "season": 2024, "week": w, "recent_team": "BUF",
-            "targets": 3, "snap_pct": 0.30,
-        })
-    rows.append({
-        "player_id_gsis": "A", "season": 2024, "week": 5, "recent_team": "BUF",
-        "targets": 10, "snap_pct": 0.80,
-    })
+        rows.append(
+            {
+                "player_id_gsis": "A",
+                "season": 2024,
+                "week": w,
+                "recent_team": "BUF",
+                "targets": 3,
+                "snap_pct": 0.30,
+            }
+        )
+    rows.append(
+        {
+            "player_id_gsis": "A",
+            "season": 2024,
+            "week": 5,
+            "recent_team": "BUF",
+            "targets": 10,
+            "snap_pct": 0.80,
+        }
+    )
     windows = uw.build_rolling_windows(rows)
     final = [w for w in windows if w.week == 5][0]
     # With exactly-equal history, SD is 0 → z is None.  So insert a
@@ -66,19 +96,47 @@ def test_target_share_normalizes_by_team_total():
     """Share math: my_targets / team_total.  Two players on the
     same team-week split correctly."""
     rows = [
-        {"player_id_gsis": "A", "season": 2024, "week": 1, "recent_team": "BUF",
-         "targets": 7, "snap_pct": 0.9},
-        {"player_id_gsis": "B", "season": 2024, "week": 1, "recent_team": "BUF",
-         "targets": 3, "snap_pct": 0.8},
+        {
+            "player_id_gsis": "A",
+            "season": 2024,
+            "week": 1,
+            "recent_team": "BUF",
+            "targets": 7,
+            "snap_pct": 0.9,
+        },
+        {
+            "player_id_gsis": "B",
+            "season": 2024,
+            "week": 1,
+            "recent_team": "BUF",
+            "targets": 3,
+            "snap_pct": 0.8,
+        },
     ]
     # Build windows — at week 1 there's no history, so mean_share=0,
     # but the internal computation uses team totals correctly.
     windows = uw.build_rolling_windows(rows)
     # Extend for week 2 to push last-week share into history.
-    rows.append({"player_id_gsis": "A", "season": 2024, "week": 2, "recent_team": "BUF",
-                 "targets": 5, "snap_pct": 0.9})
-    rows.append({"player_id_gsis": "B", "season": 2024, "week": 2, "recent_team": "BUF",
-                 "targets": 5, "snap_pct": 0.8})
+    rows.append(
+        {
+            "player_id_gsis": "A",
+            "season": 2024,
+            "week": 2,
+            "recent_team": "BUF",
+            "targets": 5,
+            "snap_pct": 0.9,
+        }
+    )
+    rows.append(
+        {
+            "player_id_gsis": "B",
+            "season": 2024,
+            "week": 2,
+            "recent_team": "BUF",
+            "targets": 5,
+            "snap_pct": 0.8,
+        }
+    )
     windows = uw.build_rolling_windows(rows)
     week2_A = [w for w in windows if w.player_id == "A" and w.week == 2][0]
     # Week 1: A had 7/10 = 0.7 share
@@ -87,12 +145,30 @@ def test_target_share_normalizes_by_team_total():
 
 def test_latest_window_per_player():
     rows = [
-        {"player_id_gsis": "A", "season": 2024, "week": 1, "recent_team": "BUF",
-         "targets": 1, "snap_pct": 0.5},
-        {"player_id_gsis": "A", "season": 2024, "week": 2, "recent_team": "BUF",
-         "targets": 2, "snap_pct": 0.6},
-        {"player_id_gsis": "B", "season": 2024, "week": 1, "recent_team": "BUF",
-         "targets": 3, "snap_pct": 0.7},
+        {
+            "player_id_gsis": "A",
+            "season": 2024,
+            "week": 1,
+            "recent_team": "BUF",
+            "targets": 1,
+            "snap_pct": 0.5,
+        },
+        {
+            "player_id_gsis": "A",
+            "season": 2024,
+            "week": 2,
+            "recent_team": "BUF",
+            "targets": 2,
+            "snap_pct": 0.6,
+        },
+        {
+            "player_id_gsis": "B",
+            "season": 2024,
+            "week": 1,
+            "recent_team": "BUF",
+            "targets": 3,
+            "snap_pct": 0.7,
+        },
     ]
     windows = uw.build_rolling_windows(rows)
     latest = uw.latest_window_per_player(windows)

--- a/tests/pool/test_builder.py
+++ b/tests/pool/test_builder.py
@@ -1,4 +1,5 @@
 """Tests for the canonical player pool builder."""
+
 from __future__ import annotations
 
 import json
@@ -25,6 +26,7 @@ from src.pool.builder import (
 
 # ── Fixtures ──
 
+
 def _sleeper_data(names_positions: dict[str, str], ids: dict[str, str] | None = None) -> dict:
     return {
         "positions": names_positions,
@@ -37,6 +39,7 @@ def _ktc_data(players: list[tuple[str, float]]) -> dict[str, float]:
 
 
 # ── Pool builder: membership tests ──
+
 
 class TestPoolMembership:
     def test_sleeper_fringe_player_outside_ktc_is_included(self):
@@ -138,6 +141,7 @@ class TestPoolMembership:
 
 # ── KTC structured ingestion ──
 
+
 class TestKtcStructured:
     def test_ktc_rows_have_rank_and_value(self):
         ktc = _ktc_data([("A", 9000), ("B", 8000), ("C", 7000)])
@@ -157,16 +161,32 @@ class TestKtcStructured:
 
 # ── Adamidp PDF extraction ──
 
+
 class TestAdamidpExtraction:
     def test_split_line_names_dedupe(self):
         """Overlapping PDF segments dedupe correctly."""
         rows = [
-            AdamidpRow(overall_rank=1, player_name="Will Anderson", position="DL",
-                       position_rank=1, source_pdf="a.pdf"),
-            AdamidpRow(overall_rank=1, player_name="Will Anderson", position="DL",
-                       position_rank=1, source_pdf="b.pdf"),
-            AdamidpRow(overall_rank=2, player_name="Micah Parsons", position="LB",
-                       position_rank=1, source_pdf="a.pdf"),
+            AdamidpRow(
+                overall_rank=1,
+                player_name="Will Anderson",
+                position="DL",
+                position_rank=1,
+                source_pdf="a.pdf",
+            ),
+            AdamidpRow(
+                overall_rank=1,
+                player_name="Will Anderson",
+                position="DL",
+                position_rank=1,
+                source_pdf="b.pdf",
+            ),
+            AdamidpRow(
+                overall_rank=2,
+                player_name="Micah Parsons",
+                position="LB",
+                position_rank=1,
+                source_pdf="a.pdf",
+            ),
         ]
         unique, ambig = dedupe_adamidp_rows(rows)
         assert len(unique) == 2
@@ -190,10 +210,20 @@ class TestAdamidpExtraction:
         """Read from a JSON artifact file."""
         data = {
             "rows": [
-                {"overallRank": 1, "playerName": "Will Anderson", "position": "DL",
-                 "positionRank": 1, "tradeValueText": "Tier 1"},
-                {"overallRank": 2, "playerName": "Micah Parsons", "position": "LB",
-                 "positionRank": 1, "tradeValueText": "Tier 1"},
+                {
+                    "overallRank": 1,
+                    "playerName": "Will Anderson",
+                    "position": "DL",
+                    "positionRank": 1,
+                    "tradeValueText": "Tier 1",
+                },
+                {
+                    "overallRank": 2,
+                    "playerName": "Micah Parsons",
+                    "position": "LB",
+                    "positionRank": 1,
+                    "tradeValueText": "Tier 1",
+                },
             ]
         }
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
@@ -207,9 +237,12 @@ class TestAdamidpExtraction:
 
 # ── Name matching/identity tests ──
 
+
 class TestNameMatching:
     def test_jr_sr_normalization(self):
-        assert pool_normalize_lookup("Patrick Mahomes Jr.") == pool_normalize_lookup("Patrick Mahomes")
+        assert pool_normalize_lookup("Patrick Mahomes Jr.") == pool_normalize_lookup(
+            "Patrick Mahomes"
+        )
         assert pool_normalize_lookup("Odell Beckham Jr") == pool_normalize_lookup("Odell Beckham")
 
     def test_ii_iii_normalization(self):
@@ -220,7 +253,9 @@ class TestNameMatching:
         assert pool_normalize_lookup("Ja\u2019Marr Chase") == pool_normalize_lookup("JaMarr Chase")
 
     def test_hyphen_handling(self):
-        assert pool_normalize_lookup("Amon-Ra St. Brown") == pool_normalize_lookup("Amon Ra St Brown")
+        assert pool_normalize_lookup("Amon-Ra St. Brown") == pool_normalize_lookup(
+            "Amon Ra St Brown"
+        )
 
     def test_initial_handling(self):
         assert pool_normalize_lookup("T.J. Watt") == pool_normalize_lookup("TJ Watt")
@@ -231,6 +266,7 @@ class TestNameMatching:
 
 
 # ── Position safety ──
+
 
 class TestPositionSafety:
     def test_offense_cannot_become_idp(self):
@@ -255,6 +291,7 @@ class TestPositionSafety:
 
 # ── IDPTradeCalc crosswalk ──
 
+
 class TestIDPTradeCalcCrosswalk:
     def test_every_union_player_is_queried(self):
         sleeper = _sleeper_data({"A": "QB", "B": "RB"})
@@ -269,7 +306,10 @@ class TestIDPTradeCalcCrosswalk:
         assert report.idp_trade_calc_queried_count == 3
         assert report.idp_trade_calc_matched_count == 2  # A and C
         assert report.idp_trade_calc_unmatched_count == 1  # B
-        assert report.idp_trade_calc_matched_count + report.idp_trade_calc_unmatched_count == report.idp_trade_calc_queried_count
+        assert (
+            report.idp_trade_calc_matched_count + report.idp_trade_calc_unmatched_count
+            == report.idp_trade_calc_queried_count
+        )
 
     def test_unmatched_names_reported(self):
         sleeper = _sleeper_data({"A": "QB", "B": "RB"})
@@ -284,6 +324,7 @@ class TestIDPTradeCalcCrosswalk:
 
 
 # ── Audit report ──
+
 
 class TestAuditReport:
     def test_report_has_all_counts(self):
@@ -312,6 +353,7 @@ class TestAuditReport:
 
 # ── Integration: Adamidp IDP players survive downstream ──
 
+
 class TestAdamidpIntegration:
     """Integration tests: IDP players from Adamidp survive through pool builder."""
 
@@ -333,8 +375,12 @@ class TestAdamidpIntegration:
         )
         names = {r.canonical_name for r in rows}
         # All Adamidp IDP players should be in the pool
-        for expected in ["Travis Hunter", "Will Anderson", "Aidan Hutchinson",
-                         "Carson Schwesinger"]:
+        for expected in [
+            "Travis Hunter",
+            "Will Anderson",
+            "Aidan Hutchinson",
+            "Carson Schwesinger",
+        ]:
             assert expected in names, f"{expected} missing from pool"
         # Rueben Bain Jr. should match after suffix stripping
         assert any("Rueben Bain" in n for n in names), "Rueben Bain Jr. missing from pool"
@@ -362,10 +408,12 @@ class TestAdamidpIntegration:
 
     def test_offense_players_not_emitted_as_idp(self):
         """DJ Moore and Elijah Mitchell cannot be reclassified as IDP."""
-        sleeper = _sleeper_data({
-            "DJ Moore": "WR",
-            "Elijah Mitchell": "RB",
-        })
+        sleeper = _sleeper_data(
+            {
+                "DJ Moore": "WR",
+                "Elijah Mitchell": "RB",
+            }
+        )
         ktc = _ktc_data([("DJ Moore", 5000), ("Elijah Mitchell", 3000)])
         # Even if somehow an Adamidp row matches these offense players,
         # position safety prevents reclassification.
@@ -380,7 +428,9 @@ class TestAdamidpIntegration:
         moore = next(r for r in rows if "moore" in r.canonical_name.lower())
         mitchell = next(r for r in rows if "mitchell" in r.canonical_name.lower())
         assert moore.position == "WR", f"DJ Moore wrongly classified as {moore.position}"
-        assert mitchell.position == "RB", f"Elijah Mitchell wrongly classified as {mitchell.position}"
+        assert (
+            mitchell.position == "RB"
+        ), f"Elijah Mitchell wrongly classified as {mitchell.position}"
 
     def test_adamidp_artifact_reads_correctly(self):
         """The artifact file format is correctly parsed."""

--- a/tests/pool/test_valuation.py
+++ b/tests/pool/test_valuation.py
@@ -4,6 +4,7 @@ These test the documented behavior of the live valuation pipeline parameters.
 They verify configuration values and document intended behavior without running
 the full scraper pipeline.
 """
+
 from __future__ import annotations
 
 import re
@@ -45,7 +46,9 @@ class TestEliteCeilingBehavior:
         m = re.search(r"elite_cap = cap_limit \* \(1\.0 \+ \(([\d.]+) \* market_conf\)\)", src)
         assert m is not None
         # The second match (non-IDP path) should be >= 0.08
-        matches = re.findall(r"elite_cap = cap_limit \* \(1\.0 \+ \(([\d.]+) \* market_conf\)\)", src)
+        matches = re.findall(
+            r"elite_cap = cap_limit \* \(1\.0 \+ \(([\d.]+) \* market_conf\)\)", src
+        )
         assert len(matches) >= 2
         offense_factor = float(matches[1])  # second match is the non-IDP one
         assert offense_factor >= 0.08, f"Offense elite cap factor {offense_factor} too low"
@@ -109,11 +112,13 @@ class TestSourceTypeHandling:
 
     def test_source_types_documented_in_pool_builder(self):
         from src.pool.builder import SOURCE_TYPES
+
         assert "ktc" in SOURCE_TYPES
         assert "idpTradeCalc" in SOURCE_TYPES
 
     def test_source_type_categories(self):
         from src.pool.builder import SOURCE_TYPES
+
         types = set(SOURCE_TYPES.values())
         expected = {
             "full_mixed_value",
@@ -123,4 +128,5 @@ class TestSourceTypeHandling:
 
     def test_idptradecalc_is_mixed_bridge(self):
         from src.pool.builder import SOURCE_TYPES
+
         assert SOURCE_TYPES["idpTradeCalc"] == "mixed_offense_idp_bridge"

--- a/tests/public_league/fixtures.py
+++ b/tests/public_league/fixtures.py
@@ -12,6 +12,7 @@ Provides a fully-deterministic two-season league chain with:
     * Traded picks so the Draft Center pick-ownership map has data.
     * NFL players dump stub so position-based superlatives work.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -26,7 +27,17 @@ def _user(uid: str, display_name: str, team_name: str) -> dict[str, Any]:
     }
 
 
-def _roster(rid: int, owner_id: str, players: list[str], wins: int = 0, losses: int = 0, ties: int = 0, pf: float = 0.0, pa: float = 0.0, rank: int | None = None) -> dict[str, Any]:
+def _roster(
+    rid: int,
+    owner_id: str,
+    players: list[str],
+    wins: int = 0,
+    losses: int = 0,
+    ties: int = 0,
+    pf: float = 0.0,
+    pa: float = 0.0,
+    rank: int | None = None,
+) -> dict[str, Any]:
     pf_int = int(pf)
     pf_dec = int(round((pf - pf_int) * 100))
     pa_int = int(pa)
@@ -54,56 +65,70 @@ def _roster(rid: int, owner_id: str, players: list[str], wins: int = 0, losses: 
 # by the rookie-superlative calculation; we make pid-rookie players
 # have years_exp=0.
 NFL_PLAYERS_STUB: dict[str, dict[str, Any]] = {
-    "p-qb1":  {"first_name": "Ann",   "last_name": "QB-One",   "position": "QB", "years_exp": 5},
-    "p-qb2":  {"first_name": "Bob",   "last_name": "QB-Two",   "position": "QB", "years_exp": 3},
-    "p-rb1":  {"first_name": "Cam",   "last_name": "RB-One",   "position": "RB", "years_exp": 4},
-    "p-rb2":  {"first_name": "Dan",   "last_name": "RB-Two",   "position": "RB", "years_exp": 0},
-    "p-rb3":  {"first_name": "Eve",   "last_name": "RB-Three", "position": "RB", "years_exp": 2},
-    "p-wr1":  {"first_name": "Flo",   "last_name": "WR-One",   "position": "WR", "years_exp": 6},
-    "p-wr2":  {"first_name": "Gus",   "last_name": "WR-Two",   "position": "WR", "years_exp": 0},
-    "p-wr3":  {"first_name": "Hal",   "last_name": "WR-Three", "position": "WR", "years_exp": 2},
-    "p-te1":  {"first_name": "Iva",   "last_name": "TE-One",   "position": "TE", "years_exp": 7},
-    "p-te2":  {"first_name": "Jax",   "last_name": "TE-Two",   "position": "TE", "years_exp": 1},
-    "p-idp1": {"first_name": "Kim",   "last_name": "DL-One",   "position": "DL", "years_exp": 3},
-    "p-idp2": {"first_name": "Leo",   "last_name": "LB-One",   "position": "LB", "years_exp": 0},
-    "p-idp3": {"first_name": "Max",   "last_name": "DB-One",   "position": "DB", "years_exp": 2},
+    "p-qb1": {"first_name": "Ann", "last_name": "QB-One", "position": "QB", "years_exp": 5},
+    "p-qb2": {"first_name": "Bob", "last_name": "QB-Two", "position": "QB", "years_exp": 3},
+    "p-rb1": {"first_name": "Cam", "last_name": "RB-One", "position": "RB", "years_exp": 4},
+    "p-rb2": {"first_name": "Dan", "last_name": "RB-Two", "position": "RB", "years_exp": 0},
+    "p-rb3": {"first_name": "Eve", "last_name": "RB-Three", "position": "RB", "years_exp": 2},
+    "p-wr1": {"first_name": "Flo", "last_name": "WR-One", "position": "WR", "years_exp": 6},
+    "p-wr2": {"first_name": "Gus", "last_name": "WR-Two", "position": "WR", "years_exp": 0},
+    "p-wr3": {"first_name": "Hal", "last_name": "WR-Three", "position": "WR", "years_exp": 2},
+    "p-te1": {"first_name": "Iva", "last_name": "TE-One", "position": "TE", "years_exp": 7},
+    "p-te2": {"first_name": "Jax", "last_name": "TE-Two", "position": "TE", "years_exp": 1},
+    "p-idp1": {"first_name": "Kim", "last_name": "DL-One", "position": "DL", "years_exp": 3},
+    "p-idp2": {"first_name": "Leo", "last_name": "LB-One", "position": "LB", "years_exp": 0},
+    "p-idp3": {"first_name": "Max", "last_name": "DB-One", "position": "DB", "years_exp": 2},
     "p-rookie-a": {"first_name": "Rudy", "last_name": "Rook", "position": "WR", "years_exp": 0},
-    "p-rookie-b": {"first_name": "Sal",  "last_name": "Stud", "position": "RB", "years_exp": 0},
+    "p-rookie-b": {"first_name": "Sal", "last_name": "Stud", "position": "RB", "years_exp": 0},
 }
 
 
 # Roster inventories.  Different positional tilts so superlatives
 # produce deterministic winners.
-ROSTER_A_PLAYERS = ["p-qb1", "p-qb2", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]   # QB-heavy, rookies=2 (p-rb2 added in wk3 waiver)
-ROSTER_B_PLAYERS = ["p-rb3", "p-rb2", "p-wr1", "p-wr2", "p-te1", "p-rookie-b"]    # RB-heavy, rookies=2
-ROSTER_C_PLAYERS = ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1", "p-idp3"]        # WR-heavy
-ROSTER_D_PLAYERS = ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]       # IDP/TE-heavy
+ROSTER_A_PLAYERS = [
+    "p-qb1",
+    "p-qb2",
+    "p-rb1",
+    "p-wr1",
+    "p-te1",
+    "p-rookie-a",
+]  # QB-heavy, rookies=2 (p-rb2 added in wk3 waiver)
+ROSTER_B_PLAYERS = [
+    "p-rb3",
+    "p-rb2",
+    "p-wr1",
+    "p-wr2",
+    "p-te1",
+    "p-rookie-b",
+]  # RB-heavy, rookies=2
+ROSTER_C_PLAYERS = ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1", "p-idp3"]  # WR-heavy
+ROSTER_D_PLAYERS = ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]  # IDP/TE-heavy
 
 
 USERS_2025 = [
     _user("owner-A", "AAron", "Brisket Bandits"),
-    _user("owner-B", "Bea",   "Bea's Beast Mode"),
-    _user("owner-C", "Cole",  "Cole Train"),
-    _user("owner-D", "Dana",  "Dana's Dynasty"),
+    _user("owner-B", "Bea", "Bea's Beast Mode"),
+    _user("owner-C", "Cole", "Cole Train"),
+    _user("owner-D", "Dana", "Dana's Dynasty"),
 ]
 USERS_2024 = [
     _user("owner-A", "AAron", "AAron Classic"),
-    _user("owner-B", "Bea",   "Bea's Beast Mode"),
-    _user("owner-C", "Cole",  "Cole Train"),
+    _user("owner-B", "Bea", "Bea's Beast Mode"),
+    _user("owner-C", "Cole", "Cole Train"),
     _user("owner-X", "Xavier", "Xavier XL"),
 ]
 
 ROSTERS_2025 = [
-    _roster(1, "owner-A", ROSTER_A_PLAYERS, wins=9,  losses=5, pf=1450.12, pa=1320.44, rank=2),
+    _roster(1, "owner-A", ROSTER_A_PLAYERS, wins=9, losses=5, pf=1450.12, pa=1320.44, rank=2),
     _roster(2, "owner-B", ROSTER_B_PLAYERS, wins=11, losses=3, pf=1600.50, pa=1200.10, rank=1),
-    _roster(3, "owner-C", ROSTER_C_PLAYERS, wins=5,  losses=9, pf=1250.00, pa=1520.80, rank=4),
-    _roster(4, "owner-D", ROSTER_D_PLAYERS, wins=7,  losses=7, pf=1380.30, pa=1405.20, rank=3),
+    _roster(3, "owner-C", ROSTER_C_PLAYERS, wins=5, losses=9, pf=1250.00, pa=1520.80, rank=4),
+    _roster(4, "owner-D", ROSTER_D_PLAYERS, wins=7, losses=7, pf=1380.30, pa=1405.20, rank=3),
 ]
 ROSTERS_2024 = [
-    _roster(1, "owner-A", ROSTER_A_PLAYERS, wins=8,  losses=6, pf=1390.10, pa=1400.30, rank=2),
+    _roster(1, "owner-A", ROSTER_A_PLAYERS, wins=8, losses=6, pf=1390.10, pa=1400.30, rank=2),
     _roster(2, "owner-B", ROSTER_B_PLAYERS, wins=12, losses=2, pf=1700.00, pa=1150.00, rank=1),
-    _roster(3, "owner-C", ROSTER_C_PLAYERS, wins=6,  losses=8, pf=1295.50, pa=1480.90, rank=3),
-    _roster(4, "owner-X", ["p-qb1", "p-rb1"], wins=3,  losses=11, pf=1100.00, pa=1580.10, rank=4),
+    _roster(3, "owner-C", ROSTER_C_PLAYERS, wins=6, losses=8, pf=1295.50, pa=1480.90, rank=3),
+    _roster(4, "owner-X", ["p-qb1", "p-rb1"], wins=3, losses=11, pf=1100.00, pa=1580.10, rank=4),
 ]
 
 
@@ -111,27 +136,27 @@ ROSTERS_2024 = [
 MATCHUPS_2025 = {
     1: [
         {"matchup_id": 1, "roster_id": 1, "points": 120.5},
-        {"matchup_id": 1, "roster_id": 2, "points": 135.2},   # B beats A by 14.7
+        {"matchup_id": 1, "roster_id": 2, "points": 135.2},  # B beats A by 14.7
         {"matchup_id": 2, "roster_id": 3, "points": 95.0},
-        {"matchup_id": 2, "roster_id": 4, "points": 110.3},   # D beats C by 15.3
+        {"matchup_id": 2, "roster_id": 4, "points": 110.3},  # D beats C by 15.3
     ],
     2: [
         {"matchup_id": 1, "roster_id": 1, "points": 145.8},
-        {"matchup_id": 1, "roster_id": 3, "points": 142.1},   # A beats C by 3.7 (close)
+        {"matchup_id": 1, "roster_id": 3, "points": 142.1},  # A beats C by 3.7 (close)
         {"matchup_id": 2, "roster_id": 2, "points": 165.0},
-        {"matchup_id": 2, "roster_id": 4, "points": 95.6},    # B beats D by 69.4 (blowout)
+        {"matchup_id": 2, "roster_id": 4, "points": 95.6},  # B beats D by 69.4 (blowout)
     ],
     15: [
         # Playoff semifinals.
         {"matchup_id": 1, "roster_id": 2, "points": 155.5},
-        {"matchup_id": 1, "roster_id": 4, "points": 130.0},   # B beats D by 25.5
+        {"matchup_id": 1, "roster_id": 4, "points": 130.0},  # B beats D by 25.5
         {"matchup_id": 2, "roster_id": 1, "points": 150.0},
-        {"matchup_id": 2, "roster_id": 3, "points": 140.0},   # A beats C by 10.0
+        {"matchup_id": 2, "roster_id": 3, "points": 140.0},  # A beats C by 10.0
     ],
     16: [
         # Playoff championship: B vs A.
         {"matchup_id": 1, "roster_id": 2, "points": 145.0},
-        {"matchup_id": 1, "roster_id": 1, "points": 120.0},   # B beats A by 25.0
+        {"matchup_id": 1, "roster_id": 1, "points": 120.0},  # B beats A by 25.0
     ],
 }
 MATCHUPS_2024 = {
@@ -143,9 +168,9 @@ MATCHUPS_2024 = {
     ],
     2: [
         {"matchup_id": 1, "roster_id": 1, "points": 130.0},
-        {"matchup_id": 1, "roster_id": 2, "points": 155.0},   # B beats A (2nd reg meeting)
+        {"matchup_id": 1, "roster_id": 2, "points": 155.0},  # B beats A (2nd reg meeting)
         {"matchup_id": 2, "roster_id": 3, "points": 110.0},
-        {"matchup_id": 2, "roster_id": 4, "points": 112.0},   # X (owner-X) beats C close
+        {"matchup_id": 2, "roster_id": 4, "points": 112.0},  # X (owner-X) beats C close
     ],
     3: [
         # Upsets across the board:
@@ -229,10 +254,20 @@ DRAFT_2025 = {
 }
 
 DRAFT_PICKS_2025 = [
-    {"round": 1, "pick_no": 1, "roster_id": 3, "player_id": "p-rookie-a",
-     "metadata": {"first_name": "Rudy", "last_name": "Rook", "position": "WR", "team": "LV"}},
-    {"round": 1, "pick_no": 2, "roster_id": 4, "player_id": "p-rookie-b",
-     "metadata": {"first_name": "Sal", "last_name": "Stud", "position": "RB", "team": "JAX"}},
+    {
+        "round": 1,
+        "pick_no": 1,
+        "roster_id": 3,
+        "player_id": "p-rookie-a",
+        "metadata": {"first_name": "Rudy", "last_name": "Rook", "position": "WR", "team": "LV"},
+    },
+    {
+        "round": 1,
+        "pick_no": 2,
+        "roster_id": 4,
+        "player_id": "p-rookie-b",
+        "metadata": {"first_name": "Sal", "last_name": "Stud", "position": "RB", "team": "JAX"},
+    },
 ]
 
 

--- a/tests/public_league/test_awards.py
+++ b/tests/public_league/test_awards.py
@@ -5,6 +5,7 @@ cutoff) trader/waiver, starting-lineup-only Waiver King, champion-only
 Playoff MVP, the weighted Manager of the Year, Off/Def Rookie of the
 Year, Mr. Consistent, and canonical award ordering.
 """
+
 from __future__ import annotations
 
 import copy
@@ -53,8 +54,12 @@ from tests.public_league.fixtures import build_test_snapshot
 _NO_CUTOFF = contextlib.nullcontext()
 
 _REMOVED_KEYS = {
-    "chaos_agent", "most_active", "pick_hoarder",
-    "runner_up", "points_black_hole", "toilet_bowl",
+    "chaos_agent",
+    "most_active",
+    "pick_hoarder",
+    "runner_up",
+    "points_black_hole",
+    "toilet_bowl",
 }
 
 
@@ -70,26 +75,89 @@ def _with_player_points(snapshot):
     s2025 = snap.seasons[0]
     for wk, per_rid in {
         1: {
-            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 20.0, "p-te1": 15.0, "p-rookie-a": 15.5}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
-            2: ({"p-qb2": 45.0, "p-rb3": 35.0, "p-wr2": 25.0, "p-te1": 15.0, "p-rookie-b": 15.2}, ["p-qb2", "p-rb3", "p-wr2", "p-te1", "p-rookie-b"]),
-            3: ({"p-wr1": 20.0, "p-wr2": 20.0, "p-wr3": 15.0, "p-rb1": 20.0, "p-qb1": 20.0}, ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"]),
-            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 20.0, "p-idp3": 25.0, "p-qb2": 15.3}, ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]),
+            1: (
+                {"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 20.0, "p-te1": 15.0, "p-rookie-a": 15.5},
+                ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"],
+            ),
+            2: (
+                {"p-qb2": 45.0, "p-rb3": 35.0, "p-wr2": 25.0, "p-te1": 15.0, "p-rookie-b": 15.2},
+                ["p-qb2", "p-rb3", "p-wr2", "p-te1", "p-rookie-b"],
+            ),
+            3: (
+                {"p-wr1": 20.0, "p-wr2": 20.0, "p-wr3": 15.0, "p-rb1": 20.0, "p-qb1": 20.0},
+                ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"],
+            ),
+            4: (
+                {
+                    "p-te1": 15.0,
+                    "p-te2": 20.0,
+                    "p-idp1": 15.0,
+                    "p-idp2": 20.0,
+                    "p-idp3": 25.0,
+                    "p-qb2": 15.3,
+                },
+                ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"],
+            ),
         },
         2: {
-            1: ({"p-qb1": 40.0, "p-rb1": 35.0, "p-wr1": 25.8, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
-            3: ({"p-wr1": 25.0, "p-wr2": 25.0, "p-wr3": 30.0, "p-rb1": 32.1, "p-qb1": 30.0}, ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"]),
-            2: ({"p-qb2": 50.0, "p-rb2": 40.0, "p-wr2": 35.0, "p-te1": 20.0, "p-rookie-b": 20.0}, ["p-qb2", "p-rb2", "p-wr2", "p-te1", "p-rookie-b"]),
-            4: ({"p-te1": 15.0, "p-te2": 20.0, "p-idp1": 15.0, "p-idp2": 15.0, "p-idp3": 15.0, "p-qb2": 15.6}, ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]),
+            1: (
+                {"p-qb1": 40.0, "p-rb1": 35.0, "p-wr1": 25.8, "p-te1": 20.0, "p-rookie-a": 25.0},
+                ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"],
+            ),
+            3: (
+                {"p-wr1": 25.0, "p-wr2": 25.0, "p-wr3": 30.0, "p-rb1": 32.1, "p-qb1": 30.0},
+                ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"],
+            ),
+            2: (
+                {"p-qb2": 50.0, "p-rb2": 40.0, "p-wr2": 35.0, "p-te1": 20.0, "p-rookie-b": 20.0},
+                ["p-qb2", "p-rb2", "p-wr2", "p-te1", "p-rookie-b"],
+            ),
+            4: (
+                {
+                    "p-te1": 15.0,
+                    "p-te2": 20.0,
+                    "p-idp1": 15.0,
+                    "p-idp2": 15.0,
+                    "p-idp3": 15.0,
+                    "p-qb2": 15.6,
+                },
+                ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"],
+            ),
         },
         15: {
-            2: ({"p-rb2": 55.5, "p-wr2": 35.0, "p-qb2": 40.0, "p-te1": 15.0, "p-rookie-b": 10.0}, ["p-rb2", "p-wr2", "p-qb2", "p-te1", "p-rookie-b"]),
-            4: ({"p-te1": 15.0, "p-te2": 30.0, "p-idp1": 30.0, "p-idp2": 25.0, "p-idp3": 20.0, "p-qb2": 10.0}, ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"]),
-            1: ({"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 35.0, "p-te1": 20.0, "p-rookie-a": 25.0}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
-            3: ({"p-wr1": 40.0, "p-wr2": 30.0, "p-wr3": 25.0, "p-rb1": 25.0, "p-qb1": 20.0}, ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"]),
+            2: (
+                {"p-rb2": 55.5, "p-wr2": 35.0, "p-qb2": 40.0, "p-te1": 15.0, "p-rookie-b": 10.0},
+                ["p-rb2", "p-wr2", "p-qb2", "p-te1", "p-rookie-b"],
+            ),
+            4: (
+                {
+                    "p-te1": 15.0,
+                    "p-te2": 30.0,
+                    "p-idp1": 30.0,
+                    "p-idp2": 25.0,
+                    "p-idp3": 20.0,
+                    "p-qb2": 10.0,
+                },
+                ["p-te1", "p-te2", "p-idp1", "p-idp2", "p-idp3", "p-qb2"],
+            ),
+            1: (
+                {"p-qb1": 40.0, "p-rb1": 30.0, "p-wr1": 35.0, "p-te1": 20.0, "p-rookie-a": 25.0},
+                ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"],
+            ),
+            3: (
+                {"p-wr1": 40.0, "p-wr2": 30.0, "p-wr3": 25.0, "p-rb1": 25.0, "p-qb1": 20.0},
+                ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"],
+            ),
         },
         16: {
-            2: ({"p-rb2": 50.0, "p-wr2": 30.0, "p-qb2": 35.0, "p-te1": 15.0, "p-rookie-b": 15.0}, ["p-rb2", "p-wr2", "p-qb2", "p-te1", "p-rookie-b"]),
-            1: ({"p-qb1": 30.0, "p-rb1": 25.0, "p-wr1": 25.0, "p-te1": 15.0, "p-rookie-a": 25.0}, ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"]),
+            2: (
+                {"p-rb2": 50.0, "p-wr2": 30.0, "p-qb2": 35.0, "p-te1": 15.0, "p-rookie-b": 15.0},
+                ["p-rb2", "p-wr2", "p-qb2", "p-te1", "p-rookie-b"],
+            ),
+            1: (
+                {"p-qb1": 30.0, "p-rb1": 25.0, "p-wr1": 25.0, "p-te1": 15.0, "p-rookie-a": 25.0},
+                ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"],
+            ),
         },
     }.items():
         for e in s2025.matchups_by_week.get(wk, []):
@@ -110,12 +178,26 @@ def _with_player_points(snapshot):
 class AwardDescriptionsTests(unittest.TestCase):
     def test_active_awards_have_descriptions(self) -> None:
         for key in (
-            "champion", "manager_of_the_year", "trader_of_the_year",
-            "best_trade_of_the_year", "waiver_king", "silent_assassin",
-            "weekly_hammer", "playoff_mvp", "bad_beat", "mr_consistent",
-            "best_rebuild", "rivalry_of_the_year", "off_roy", "def_roy",
-            "league_mvp", "off_mvp", "def_mvp",
-            "top_qb", "top_offense", "top_defense",
+            "champion",
+            "manager_of_the_year",
+            "trader_of_the_year",
+            "best_trade_of_the_year",
+            "waiver_king",
+            "silent_assassin",
+            "weekly_hammer",
+            "playoff_mvp",
+            "bad_beat",
+            "mr_consistent",
+            "best_rebuild",
+            "rivalry_of_the_year",
+            "off_roy",
+            "def_roy",
+            "league_mvp",
+            "off_mvp",
+            "def_mvp",
+            "top_qb",
+            "top_offense",
+            "top_defense",
         ):
             self.assertIn(key, AWARD_DESCRIPTIONS)
             self.assertTrue(AWARD_DESCRIPTIONS[key])
@@ -141,8 +223,7 @@ class SeasonScopedTransactionTests(unittest.TestCase):
 
     def test_section_includes_trader_waiver_for_season_with_txns(self) -> None:
         section = awards.build_section(self.snapshot)
-        by_year = {s["season"]: {a["key"] for a in s["awards"]}
-                   for s in section["bySeason"]}
+        by_year = {s["season"]: {a["key"] for a in s["awards"]} for s in section["bySeason"]}
         k2025 = by_year.get("2025", set())
         self.assertIn("trader_of_the_year", k2025)
         self.assertIn("waiver_king", k2025)
@@ -318,9 +399,7 @@ class ManagerOfTheYearTests(unittest.TestCase):
             self.assertGreaterEqual(a["compositeScore"], b["compositeScore"])
 
     def test_champion_has_best_finish_rank(self) -> None:
-        rows = _manager_of_the_year_scores(
-            self.snapshot, self.snapshot.seasons[0], [], []
-        )
+        rows = _manager_of_the_year_scores(self.snapshot, self.snapshot.seasons[0], [], [])
         by_owner = {r["ownerId"]: r for r in rows}
         # 2025 champion = owner-B → finishRank 1.
         self.assertEqual(by_owner["owner-B"]["finishRank"], 1)
@@ -350,18 +429,14 @@ class RookieOfTheYearTests(unittest.TestCase):
         cls.snapshot = _with_player_points(build_test_snapshot())
 
     def test_off_roy_only_offensive_rookies(self) -> None:
-        rows = _rookie_of_year_rows(
-            self.snapshot, self.snapshot.seasons[0], _OFF_ROY_POSITIONS
-        )
+        rows = _rookie_of_year_rows(self.snapshot, self.snapshot.seasons[0], _OFF_ROY_POSITIONS)
         for r in rows:
             self.assertIn(r["position"], _OFF_ROY_POSITIONS)
             meta = self.snapshot.nfl_players.get(r["playerId"]) or {}
             self.assertEqual(int(meta.get("years_exp")), 0)
 
     def test_def_roy_only_defensive_rookies(self) -> None:
-        rows = _rookie_of_year_rows(
-            self.snapshot, self.snapshot.seasons[0], _DEF_ROY_POSITIONS
-        )
+        rows = _rookie_of_year_rows(self.snapshot, self.snapshot.seasons[0], _DEF_ROY_POSITIONS)
         for r in rows:
             self.assertIn(r["position"], _DEF_ROY_POSITIONS)
             meta = self.snapshot.nfl_players.get(r["playerId"]) or {}
@@ -488,8 +563,11 @@ class TopNflTeamTests(unittest.TestCase):
         # Fixture stub has no NFL team tags — assign a few so the
         # aggregation has data (nfl_players is deep-copied, safe).
         for pid, team in {
-            "p-qb1": "DET", "p-rb1": "DET", "p-wr1": "SF",
-            "p-qb2": "KC", "p-rb2": "KC",
+            "p-qb1": "DET",
+            "p-rb1": "DET",
+            "p-wr1": "SF",
+            "p-qb2": "KC",
+            "p-rb2": "KC",
         }.items():
             if pid in snap.nfl_players:
                 snap.nfl_players[pid] = {**snap.nfl_players[pid], "team": team}
@@ -521,8 +599,11 @@ class TopNflTeamTests(unittest.TestCase):
 class AwardOrderingTests(unittest.TestCase):
     def test_champion_then_moty_lead(self) -> None:
         keys = [
-            "rivalry_of_the_year", "manager_of_the_year", "top_qb",
-            "champion", "bad_beat",
+            "rivalry_of_the_year",
+            "manager_of_the_year",
+            "top_qb",
+            "champion",
+            "bad_beat",
         ]
         awarded = [{"key": k} for k in keys]
         ordered = [a["key"] for a in _order_awards(awarded)]
@@ -617,16 +698,28 @@ class AwardsLiveRaceTests(unittest.TestCase):
     # Player-category races show top 5; team/manager (and NFL-team)
     # races show top 3.
     _PLAYER_RACE_KEYS = {
-        "league_mvp", "off_mvp", "def_mvp", "playoff_mvp", "off_roy", "def_roy",
-        "top_qb", "top_rb", "top_wr", "top_te", "top_k",
-        "top_dl", "top_lb", "top_db",
+        "league_mvp",
+        "off_mvp",
+        "def_mvp",
+        "playoff_mvp",
+        "off_roy",
+        "def_roy",
+        "top_qb",
+        "top_rb",
+        "top_wr",
+        "top_te",
+        "top_k",
+        "top_dl",
+        "top_lb",
+        "top_db",
     }
 
     def test_race_leader_caps(self) -> None:
         for race in self.section["awardRaces"]:
             cap = 5 if race["key"] in self._PLAYER_RACE_KEYS else 3
             self.assertLessEqual(
-                len(race["leaders"]), cap,
+                len(race["leaders"]),
+                cap,
                 f"{race['key']} has {len(race['leaders'])} leaders (cap {cap})",
             )
             for i, leader in enumerate(race["leaders"]):
@@ -638,8 +731,13 @@ class AwardsLiveRaceTests(unittest.TestCase):
         # (week-count / eligibility / champion); the core set is always
         # present for a season that has trades/waivers.
         self.assertTrue(
-            {"trader_of_the_year", "waiver_king", "weekly_hammer",
-             "bad_beat", "manager_of_the_year"}.issubset(keys)
+            {
+                "trader_of_the_year",
+                "waiver_king",
+                "weekly_hammer",
+                "bad_beat",
+                "manager_of_the_year",
+            }.issubset(keys)
         )
         self.assertEqual(keys & _REMOVED_KEYS, set())
 

--- a/tests/public_league/test_combined_weeks.py
+++ b/tests/public_league/test_combined_weeks.py
@@ -11,6 +11,7 @@ These tests pin the combine behavior at the iterator layer
 (``walk_matchup_pairs``) and verify it propagates into the record +
 rivalry engines.
 """
+
 from __future__ import annotations
 
 import unittest

--- a/tests/public_league/test_csv_export.py
+++ b/tests/public_league/test_csv_export.py
@@ -1,4 +1,5 @@
 """Tests for the public-league CSV exporters."""
+
 from __future__ import annotations
 
 import csv
@@ -69,7 +70,8 @@ class CsvExportTests(unittest.TestCase):
 
     def test_franchise_export_owner_scoped(self) -> None:
         name, text = csv_export.export_franchise(
-            self.sections["franchise"], owner_id="owner-B",
+            self.sections["franchise"],
+            owner_id="owner-B",
         )
         self.assertIn("owner-B", name)
         rows = self._parse(text)
@@ -137,6 +139,7 @@ class CsvExportTests(unittest.TestCase):
 
 try:
     from fastapi.testclient import TestClient
+
     _HAVE_TC = True
 except Exception:  # noqa: BLE001
     _HAVE_TC = False
@@ -152,12 +155,15 @@ class CsvRouteTests(unittest.TestCase):
         install_stubs(build_stub_client())
         os.environ["SLEEPER_LEAGUE_ID"] = "L2025"
         from server import app, _public_league_cache
+
         _public_league_cache.clear()
-        _public_league_cache.update({
-            "snapshot": None,
-            "snapshot_league_id": None,
-            "fetched_at": 0.0,
-        })
+        _public_league_cache.update(
+            {
+                "snapshot": None,
+                "snapshot_league_id": None,
+                "fetched_at": 0.0,
+            }
+        )
         cls.client = TestClient(app)
 
     def test_csv_route_serves_text_csv(self) -> None:
@@ -188,7 +194,16 @@ class CsvRouteTests(unittest.TestCase):
         self.assertEqual(r.status_code, 404)
 
     def test_csv_payload_never_leaks_private_fields(self) -> None:
-        for section in ["history", "rivalries", "awards", "records", "activity", "draft", "weekly", "superlatives"]:
+        for section in [
+            "history",
+            "rivalries",
+            "awards",
+            "records",
+            "activity",
+            "draft",
+            "weekly",
+            "superlatives",
+        ]:
             r = self.client.get(f"/api/public/league/{section}.csv")
             self.assertEqual(r.status_code, 200)
             blob = r.text.lower()

--- a/tests/public_league/test_identity_retirement.py
+++ b/tests/public_league/test_identity_retirement.py
@@ -8,6 +8,7 @@ Historical matchup/trade data that references their old roster
 slot falls through to the orphaned-roster path already handled by
 the section modules.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -27,14 +28,8 @@ def _season(
 ) -> dict:
     return {
         "league": {"league_id": league_id, "season": season},
-        "users": [
-            {"user_id": uid, "display_name": name}
-            for uid, name in user_names.items()
-        ],
-        "rosters": [
-            {"roster_id": rid, "owner_id": owner}
-            for rid, owner in roster_owner_pairs
-        ],
+        "users": [{"user_id": uid, "display_name": name} for uid, name in user_names.items()],
+        "rosters": [{"roster_id": rid, "owner_id": owner} for rid, owner in roster_owner_pairs],
     }
 
 

--- a/tests/public_league/test_luck.py
+++ b/tests/public_league/test_luck.py
@@ -5,6 +5,7 @@ actual-wins math.  The fixture has 4 owners, 2 seasons, and scored
 regular-season weeks 1+2 (2025) and 1+2+3 (2024) — enough to catch
 edge cases in the all-play computation and cross-season aggregation.
 """
+
 from __future__ import annotations
 
 import unittest

--- a/tests/public_league/test_matchup_and_player.py
+++ b/tests/public_league/test_matchup_and_player.py
@@ -1,4 +1,5 @@
 """Tests for matchup recap + player journey views."""
+
 from __future__ import annotations
 
 import copy
@@ -13,18 +14,32 @@ def _with_player_points(snapshot):
     """Copy + inject per-player scoring so the journey/recap logic has
     something to chew on."""
     snap = copy.deepcopy(snapshot)
+
     def _stamp(entry, pp, starters):
         entry["players_points"] = pp
         entry["starters"] = starters
+
     s2025 = snap.seasons[0]
     stamps = {
         1: {
-            1: ({"p-qb1": 40.5, "p-rb1": 35.0, "p-wr1": 20.0, "p-te1": 15.0, "p-rookie-a": 10.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
-            2: ({"p-qb2": 50.0, "p-rb2": 30.0, "p-wr2": 25.0, "p-te1": 15.2, "p-rookie-b": 15.0}, ["p-qb2","p-rb2","p-wr2","p-te1","p-rookie-b"]),
+            1: (
+                {"p-qb1": 40.5, "p-rb1": 35.0, "p-wr1": 20.0, "p-te1": 15.0, "p-rookie-a": 10.0},
+                ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"],
+            ),
+            2: (
+                {"p-qb2": 50.0, "p-rb2": 30.0, "p-wr2": 25.0, "p-te1": 15.2, "p-rookie-b": 15.0},
+                ["p-qb2", "p-rb2", "p-wr2", "p-te1", "p-rookie-b"],
+            ),
         },
         2: {
-            1: ({"p-qb1": 60.0, "p-rb1": 35.0, "p-wr1": 25.8, "p-te1": 15.0, "p-rookie-a": 10.0}, ["p-qb1","p-rb1","p-wr1","p-te1","p-rookie-a"]),
-            3: ({"p-wr1": 25.0, "p-wr2": 25.0, "p-wr3": 30.0, "p-rb1": 32.1, "p-qb1": 30.0}, ["p-wr1","p-wr2","p-wr3","p-rb1","p-qb1"]),
+            1: (
+                {"p-qb1": 60.0, "p-rb1": 35.0, "p-wr1": 25.8, "p-te1": 15.0, "p-rookie-a": 10.0},
+                ["p-qb1", "p-rb1", "p-wr1", "p-te1", "p-rookie-a"],
+            ),
+            3: (
+                {"p-wr1": 25.0, "p-wr2": 25.0, "p-wr3": 30.0, "p-rb1": 32.1, "p-qb1": 30.0},
+                ["p-wr1", "p-wr2", "p-wr3", "p-rb1", "p-qb1"],
+            ),
         },
     }
     for wk, by_rid in stamps.items():
@@ -124,6 +139,7 @@ class PlayerJourneyTests(unittest.TestCase):
 
 try:
     from fastapi.testclient import TestClient
+
     _HAVE_TC = True
 except Exception:  # noqa: BLE001
     _HAVE_TC = False
@@ -139,12 +155,15 @@ class MatchupAndPlayerRouteTests(unittest.TestCase):
         install_stubs(build_stub_client())
         os.environ["SLEEPER_LEAGUE_ID"] = "L2025"
         from server import app, _public_league_cache
+
         _public_league_cache.clear()
-        _public_league_cache.update({
-            "snapshot": None,
-            "snapshot_league_id": None,
-            "fetched_at": 0.0,
-        })
+        _public_league_cache.update(
+            {
+                "snapshot": None,
+                "snapshot_league_id": None,
+                "fetched_at": 0.0,
+            }
+        )
         cls.client = TestClient(app)
 
     def test_matchup_route_returns_payload(self) -> None:

--- a/tests/public_league/test_matchup_narrative.py
+++ b/tests/public_league/test_matchup_narrative.py
@@ -17,6 +17,7 @@ Coverage map:
     * generate_article happy-path with a fake AsyncAnthropic client.
     * generate_article error path on malformed JSON.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -78,17 +79,35 @@ class StorageRoundTripTests(unittest.TestCase):
 
     def test_save_rejects_bad_mode(self) -> None:
         with self.assertRaises(ValueError):
-            mn.save_article({"mode": "garbage", "season": "2025", "week": 1, "matchupId": 1}, base=self.base)
+            mn.save_article(
+                {"mode": "garbage", "season": "2025", "week": 1, "matchupId": 1}, base=self.base
+            )
 
     def test_list_articles_orders_by_path(self) -> None:
         for week, mid, mode in [(15, 1, "recap"), (16, 1, "preview"), (16, 2, "preview")]:
-            mn.save_article({
-                "mode": mode, "season": "2025", "week": week, "matchupId": mid,
-                "title": f"{week}-{mid}-{mode}", "lede": "", "body": "", "kicker": "",
-                "angleUsed": "", "persona": "", "wordCount": 0,
-                "model": "", "generatedAt": "", "isChampionship": False,
-                "roundLabel": "", "home": {}, "away": {}, "usage": {},
-            }, base=self.base)
+            mn.save_article(
+                {
+                    "mode": mode,
+                    "season": "2025",
+                    "week": week,
+                    "matchupId": mid,
+                    "title": f"{week}-{mid}-{mode}",
+                    "lede": "",
+                    "body": "",
+                    "kicker": "",
+                    "angleUsed": "",
+                    "persona": "",
+                    "wordCount": 0,
+                    "model": "",
+                    "generatedAt": "",
+                    "isChampionship": False,
+                    "roundLabel": "",
+                    "home": {},
+                    "away": {},
+                    "usage": {},
+                },
+                base=self.base,
+            )
         items = mn.list_articles(season="2025", base=self.base)
         self.assertEqual(len(items), 3)
         keys = [(i["week"], i["matchupId"], i["mode"]) for i in items]
@@ -103,7 +122,11 @@ class BriefAssemblyTests(unittest.TestCase):
     def test_recap_brief_for_fixture_championship(self) -> None:
         # Fixture's 2025 wk-16 is the championship: B (145.0) vs A (120.0).
         brief = mn.build_brief(
-            self.snapshot, season="2025", week=16, matchup_id=1, mode="recap",
+            self.snapshot,
+            season="2025",
+            week=16,
+            matchup_id=1,
+            mode="recap",
         )
         self.assertIsNotNone(brief)
         self.assertEqual(brief.mode, "recap")
@@ -129,15 +152,29 @@ class BriefAssemblyTests(unittest.TestCase):
         snap = build_test_snapshot()
         current = snap.seasons[0]
         current.matchups_by_week[17] = [
-            {"matchup_id": 1, "roster_id": 1, "points": 0,
-             "starters": ["p-qb1", "p-rb1"], "players": ["p-qb1", "p-rb1"],
-             "players_points": {"p-qb1": 0, "p-rb1": 0}},
-            {"matchup_id": 1, "roster_id": 2, "points": 0,
-             "starters": ["p-qb2", "p-rb2"], "players": ["p-qb2", "p-rb2"],
-             "players_points": {"p-qb2": 0, "p-rb2": 0}},
+            {
+                "matchup_id": 1,
+                "roster_id": 1,
+                "points": 0,
+                "starters": ["p-qb1", "p-rb1"],
+                "players": ["p-qb1", "p-rb1"],
+                "players_points": {"p-qb1": 0, "p-rb1": 0},
+            },
+            {
+                "matchup_id": 1,
+                "roster_id": 2,
+                "points": 0,
+                "starters": ["p-qb2", "p-rb2"],
+                "players": ["p-qb2", "p-rb2"],
+                "players_points": {"p-qb2": 0, "p-rb2": 0},
+            },
         ]
         brief = mn.build_brief(
-            snap, season="2025", week=17, matchup_id=1, mode="preview",
+            snap,
+            season="2025",
+            week=17,
+            matchup_id=1,
+            mode="preview",
         )
         self.assertIsNotNone(brief)
         self.assertEqual(brief.mode, "preview")
@@ -146,16 +183,32 @@ class BriefAssemblyTests(unittest.TestCase):
             self.assertIsNone(row["points"])
 
     def test_brief_is_none_for_missing_matchup(self) -> None:
-        self.assertIsNone(mn.build_brief(
-            self.snapshot, season="2025", week=99, matchup_id=1, mode="recap",
-        ))
-        self.assertIsNone(mn.build_brief(
-            self.snapshot, season="2025", week=16, matchup_id=99, mode="recap",
-        ))
+        self.assertIsNone(
+            mn.build_brief(
+                self.snapshot,
+                season="2025",
+                week=99,
+                matchup_id=1,
+                mode="recap",
+            )
+        )
+        self.assertIsNone(
+            mn.build_brief(
+                self.snapshot,
+                season="2025",
+                week=16,
+                matchup_id=99,
+                mode="recap",
+            )
+        )
 
     def test_to_dict_is_json_serializable(self) -> None:
         brief = mn.build_brief(
-            self.snapshot, season="2025", week=16, matchup_id=1, mode="recap",
+            self.snapshot,
+            season="2025",
+            week=16,
+            matchup_id=1,
+            mode="recap",
         )
         # Round-trip through json so the schema survives serialization.
         s = json.dumps(brief.to_dict())
@@ -168,44 +221,68 @@ class BriefAssemblyTests(unittest.TestCase):
 class AnglePoolTests(unittest.TestCase):
     def test_first_meeting_added_when_no_h2h(self) -> None:
         pool = mn._angle_pool(
-            is_championship=False, is_playoff=False,
-            h2h_total=0, multi_week=None, cumulative_close=False, underdog_seed_gap=0,
+            is_championship=False,
+            is_playoff=False,
+            h2h_total=0,
+            multi_week=None,
+            cumulative_close=False,
+            underdog_seed_gap=0,
         )
         self.assertIn("first-meeting", pool)
         self.assertNotIn("rivalry-grudge", pool)
 
     def test_rivalry_grudge_only_with_history(self) -> None:
         pool = mn._angle_pool(
-            is_championship=False, is_playoff=False,
-            h2h_total=10, multi_week=None, cumulative_close=False, underdog_seed_gap=0,
+            is_championship=False,
+            is_playoff=False,
+            h2h_total=10,
+            multi_week=None,
+            cumulative_close=False,
+            underdog_seed_gap=0,
         )
         self.assertIn("rivalry-grudge", pool)
         self.assertNotIn("first-meeting", pool)
 
     def test_comeback_arc_only_with_lead(self) -> None:
         no_lead = mn._angle_pool(
-            is_championship=True, is_playoff=True,
-            h2h_total=2, multi_week={"priorLead": 5.0}, cumulative_close=True, underdog_seed_gap=0,
+            is_championship=True,
+            is_playoff=True,
+            h2h_total=2,
+            multi_week={"priorLead": 5.0},
+            cumulative_close=True,
+            underdog_seed_gap=0,
         )
         self.assertNotIn("comeback-arc", no_lead)
         self.assertIn("razor-thin", no_lead)
         big_lead = mn._angle_pool(
-            is_championship=True, is_playoff=True,
-            h2h_total=2, multi_week={"priorLead": 25.0}, cumulative_close=False, underdog_seed_gap=0,
+            is_championship=True,
+            is_playoff=True,
+            h2h_total=2,
+            multi_week={"priorLead": 25.0},
+            cumulative_close=False,
+            underdog_seed_gap=0,
         )
         self.assertIn("comeback-arc", big_lead)
 
     def test_championship_stakes_always_included(self) -> None:
         pool = mn._angle_pool(
-            is_championship=True, is_playoff=True,
-            h2h_total=0, multi_week=None, cumulative_close=False, underdog_seed_gap=0,
+            is_championship=True,
+            is_playoff=True,
+            h2h_total=0,
+            multi_week=None,
+            cumulative_close=False,
+            underdog_seed_gap=0,
         )
         self.assertEqual(pool[0], "championship-stakes")
 
     def test_pool_is_deduplicated(self) -> None:
         pool = mn._angle_pool(
-            is_championship=False, is_playoff=False,
-            h2h_total=10, multi_week=None, cumulative_close=False, underdog_seed_gap=5,
+            is_championship=False,
+            is_playoff=False,
+            h2h_total=10,
+            multi_week=None,
+            cumulative_close=False,
+            underdog_seed_gap=5,
         )
         self.assertEqual(len(pool), len(set(pool)))
 
@@ -229,24 +306,50 @@ class MultiWeekRoundTests(unittest.TestCase):
         current = snap.seasons[0]
         # Mock a wk-16 + wk-17 championship between rosters 1 and 2.
         current.matchups_by_week[16] = [
-            {"matchup_id": 1, "roster_id": 1, "points": 100.0,
-             "starters": [], "players": [], "players_points": {}},
-            {"matchup_id": 1, "roster_id": 2, "points": 120.0,
-             "starters": [], "players": [], "players_points": {}},
+            {
+                "matchup_id": 1,
+                "roster_id": 1,
+                "points": 100.0,
+                "starters": [],
+                "players": [],
+                "players_points": {},
+            },
+            {
+                "matchup_id": 1,
+                "roster_id": 2,
+                "points": 120.0,
+                "starters": [],
+                "players": [],
+                "players_points": {},
+            },
         ]
         current.matchups_by_week[17] = [
-            {"matchup_id": 1, "roster_id": 1, "points": 130.0,
-             "starters": ["p-qb1"], "players": ["p-qb1"],
-             "players_points": {"p-qb1": 30.0}},
-            {"matchup_id": 1, "roster_id": 2, "points": 90.0,
-             "starters": ["p-qb2"], "players": ["p-qb2"],
-             "players_points": {"p-qb2": 20.0}},
+            {
+                "matchup_id": 1,
+                "roster_id": 1,
+                "points": 130.0,
+                "starters": ["p-qb1"],
+                "players": ["p-qb1"],
+                "players_points": {"p-qb1": 30.0},
+            },
+            {
+                "matchup_id": 1,
+                "roster_id": 2,
+                "points": 90.0,
+                "starters": ["p-qb2"],
+                "players": ["p-qb2"],
+                "players_points": {"p-qb2": 20.0},
+            },
         ]
         current.winners_bracket = [
             {"r": 2, "t1": 1, "t2": 2, "w": 1, "l": 2, "p": 1},
         ]
         brief = mn.build_brief(
-            snap, season="2025", week=17, matchup_id=1, mode="recap",
+            snap,
+            season="2025",
+            week=17,
+            matchup_id=1,
+            mode="recap",
         )
         self.assertIsNotNone(brief)
         self.assertIsNotNone(brief.multi_week_round)
@@ -271,7 +374,11 @@ class MultiWeekRoundTests(unittest.TestCase):
         snap = build_test_snapshot()
         # Fixture wk-16 championship is single-week — no prior pairing.
         brief = mn.build_brief(
-            snap, season="2025", week=16, matchup_id=1, mode="recap",
+            snap,
+            season="2025",
+            week=16,
+            matchup_id=1,
+            mode="recap",
         )
         self.assertIsNotNone(brief)
         self.assertIsNone(brief.multi_week_round)
@@ -282,7 +389,11 @@ class PromptAssemblyTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.snapshot = build_test_snapshot()
         cls.brief = mn.build_brief(
-            cls.snapshot, season="2025", week=16, matchup_id=1, mode="recap",
+            cls.snapshot,
+            season="2025",
+            week=16,
+            matchup_id=1,
+            mode="recap",
         )
 
     def test_prompt_returns_system_and_user_blocks(self) -> None:
@@ -297,9 +408,14 @@ class PromptAssemblyTests(unittest.TestCase):
 
     def test_prior_articles_are_referenced(self) -> None:
         prior = [
-            {"season": "2025", "week": 14, "mode": "recap",
-             "title": "Prior title", "lede": "Prior lede.",
-             "generatedAt": "2025-01-01T00:00:00Z"},
+            {
+                "season": "2025",
+                "week": 14,
+                "mode": "recap",
+                "title": "Prior title",
+                "lede": "Prior lede.",
+                "generatedAt": "2025-01-01T00:00:00Z",
+            },
         ]
         _, messages = mn.assemble_prompt(self.brief, prior_articles=prior)
         self.assertIn("Prior title", messages[0]["content"])
@@ -322,7 +438,11 @@ class BestBallPromptTests(unittest.TestCase):
 
     def _brief(self, *, best_ball: bool):
         brief = mn.build_brief(
-            self.snapshot, season="2025", week=16, matchup_id=1, mode="recap",
+            self.snapshot,
+            season="2025",
+            week=16,
+            matchup_id=1,
+            mode="recap",
         )
         # build_brief reads best_ball off the Sleeper league settings;
         # the fixture doesn't set it, so we override on the dataclass
@@ -359,17 +479,29 @@ class BestBallPromptTests(unittest.TestCase):
         current = snap.seasons[0]
         current.league = {**(current.league or {}), "settings": {"best_ball": 1}}
         current.matchups_by_week[17] = [
-            {"matchup_id": 1, "roster_id": 1, "points": 100.0,
-             "starters": ["p-qb1"],
-             "players": ["p-qb1", "p-rb2"],
-             "players_points": {"p-qb1": 30.0, "p-rb2": 50.0}},
-            {"matchup_id": 1, "roster_id": 2, "points": 80.0,
-             "starters": ["p-qb2"],
-             "players": ["p-qb2"],
-             "players_points": {"p-qb2": 25.0}},
+            {
+                "matchup_id": 1,
+                "roster_id": 1,
+                "points": 100.0,
+                "starters": ["p-qb1"],
+                "players": ["p-qb1", "p-rb2"],
+                "players_points": {"p-qb1": 30.0, "p-rb2": 50.0},
+            },
+            {
+                "matchup_id": 1,
+                "roster_id": 2,
+                "points": 80.0,
+                "starters": ["p-qb2"],
+                "players": ["p-qb2"],
+                "players_points": {"p-qb2": 25.0},
+            },
         ]
         brief = mn.build_brief(
-            snap, season="2025", week=17, matchup_id=1, mode="recap",
+            snap,
+            season="2025",
+            week=17,
+            matchup_id=1,
+            mode="recap",
         )
         self.assertIsNotNone(brief)
         self.assertTrue(brief.best_ball)
@@ -381,8 +513,14 @@ class BestBallPromptTests(unittest.TestCase):
 
 
 class _FakeUsage:
-    def __init__(self, *, input_tokens: int = 100, output_tokens: int = 200,
-                 cache_read_input_tokens: int = 0, cache_creation_input_tokens: int = 0) -> None:
+    def __init__(
+        self,
+        *,
+        input_tokens: int = 100,
+        output_tokens: int = 200,
+        cache_read_input_tokens: int = 0,
+        cache_creation_input_tokens: int = 0,
+    ) -> None:
         self.input_tokens = input_tokens
         self.output_tokens = output_tokens
         self.cache_read_input_tokens = cache_read_input_tokens
@@ -419,20 +557,28 @@ class GenerateArticleTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.snapshot = build_test_snapshot()
         cls.brief = mn.build_brief(
-            cls.snapshot, season="2025", week=16, matchup_id=1, mode="recap",
+            cls.snapshot,
+            season="2025",
+            week=16,
+            matchup_id=1,
+            mode="recap",
         )
 
     def test_happy_path_returns_persisted_shape(self) -> None:
-        fake_text = json.dumps({
-            "title": "Title",
-            "lede": "Lede.",
-            "body": "Body.",
-            "kicker": "Kicker.",
-            "angleUsed": "championship-stakes",
-            "wordCount": 200,
-        })
+        fake_text = json.dumps(
+            {
+                "title": "Title",
+                "lede": "Lede.",
+                "body": "Body.",
+                "kicker": "Kicker.",
+                "angleUsed": "championship-stakes",
+                "wordCount": 200,
+            }
+        )
         client = _FakeClient(fake_text)
-        article = asyncio.run(mn.generate_article(client=client, brief=self.brief, prior_articles=[]))
+        article = asyncio.run(
+            mn.generate_article(client=client, brief=self.brief, prior_articles=[])
+        )
         self.assertEqual(article["title"], "Title")
         self.assertEqual(article["body"], "Body.")
         self.assertEqual(article["mode"], "recap")
@@ -446,12 +592,24 @@ class GenerateArticleTests(unittest.TestCase):
         self.assertIn("away", article)
 
     def test_handles_fenced_json(self) -> None:
-        fake_text = "```json\n" + json.dumps({
-            "title": "T", "lede": "L", "body": "B", "kicker": "K",
-            "angleUsed": "vibes-check", "wordCount": 50,
-        }) + "\n```"
+        fake_text = (
+            "```json\n"
+            + json.dumps(
+                {
+                    "title": "T",
+                    "lede": "L",
+                    "body": "B",
+                    "kicker": "K",
+                    "angleUsed": "vibes-check",
+                    "wordCount": 50,
+                }
+            )
+            + "\n```"
+        )
         client = _FakeClient(fake_text)
-        article = asyncio.run(mn.generate_article(client=client, brief=self.brief, prior_articles=[]))
+        article = asyncio.run(
+            mn.generate_article(client=client, brief=self.brief, prior_articles=[])
+        )
         self.assertEqual(article["title"], "T")
 
     def test_malformed_json_raises(self) -> None:

--- a/tests/public_league/test_matchup_preview.py
+++ b/tests/public_league/test_matchup_preview.py
@@ -5,6 +5,7 @@ The fixture's 2025 season is fully scored through week 16, so
 recently scored week.  We also test the preview path by manually
 unscoring a matchup row.
 """
+
 from __future__ import annotations
 
 import copy

--- a/tests/public_league/test_metrics_engines.py
+++ b/tests/public_league/test_metrics_engines.py
@@ -4,11 +4,23 @@ These assertions pin concrete expected values against the rich
 fixture in ``tests/public_league/fixtures.py``.  Changing the
 fixture (or a metric) will fail here — by design.
 """
+
 from __future__ import annotations
 
 import unittest
 
-from src.public_league import activity, archives, awards, draft, franchise, history, records, rivalries, superlatives, weekly
+from src.public_league import (
+    activity,
+    archives,
+    awards,
+    draft,
+    franchise,
+    history,
+    records,
+    rivalries,
+    superlatives,
+    weekly,
+)
 from src.public_league.metrics import (
     matchup_pairs,
     playoff_placement,
@@ -276,7 +288,9 @@ class DraftTests(_BaseFixture):
 
     def test_pick_ownership_applies_traded_picks(self) -> None:
         section = draft.build_section(self.snapshot)
-        owner_a_picks = {(p["season"], p["round"], p["isTraded"]) for p in section["pickOwnership"]["owner-A"]}
+        owner_a_picks = {
+            (p["season"], p["round"], p["isTraded"]) for p in section["pickOwnership"]["owner-A"]
+        }
         # owner-A traded away their 2026 R2 (to owner-B) and received 2026 R4 from owner-B.
         self.assertNotIn(("2026", 2, False), owner_a_picks)
         self.assertIn(("2026", 4, True), owner_a_picks)

--- a/tests/public_league/test_overview.py
+++ b/tests/public_league/test_overview.py
@@ -1,4 +1,5 @@
 """Tests for the overview section + contract integration."""
+
 from __future__ import annotations
 
 import unittest

--- a/tests/public_league/test_player_position_multi.py
+++ b/tests/public_league/test_player_position_multi.py
@@ -1,6 +1,7 @@
 """PublicLeagueSnapshot.player_position must collapse Sleeper
 multi-position players using DL > DB > LB, matching every other
 IDP-position reader in the repo."""
+
 from __future__ import annotations
 
 from src.public_league.snapshot import PublicLeagueSnapshot

--- a/tests/public_league/test_playoff_odds.py
+++ b/tests/public_league/test_playoff_odds.py
@@ -7,6 +7,7 @@ Covers:
 * Fallback to league-wide scoring pool for owners with too-few
   sampled weeks.
 """
+
 from __future__ import annotations
 
 import random
@@ -25,9 +26,7 @@ class _Base(unittest.TestCase):
 class ShapeAndDeterminism(_Base):
     def test_output_shape(self) -> None:
         rng = random.Random(1234)
-        result = playoff_odds.compute_playoff_odds(
-            self.snapshot, num_sims=200, rng=rng
-        )
+        result = playoff_odds.compute_playoff_odds(self.snapshot, num_sims=200, rng=rng)
         self.assertIn("season", result)
         self.assertIn("numSims", result)
         self.assertIn("playoffSpots", result)
@@ -50,12 +49,8 @@ class ShapeAndDeterminism(_Base):
             self.assertLessEqual(owner["playoffProbability"], 1.0)
 
     def test_seeded_run_is_deterministic(self) -> None:
-        r1 = playoff_odds.compute_playoff_odds(
-            self.snapshot, num_sims=400, rng=random.Random(42)
-        )
-        r2 = playoff_odds.compute_playoff_odds(
-            self.snapshot, num_sims=400, rng=random.Random(42)
-        )
+        r1 = playoff_odds.compute_playoff_odds(self.snapshot, num_sims=400, rng=random.Random(42))
+        r2 = playoff_odds.compute_playoff_odds(self.snapshot, num_sims=400, rng=random.Random(42))
         self.assertEqual(r1["owners"], r2["owners"])
 
 
@@ -64,9 +59,7 @@ class CompletedSeasonCollapse(_Base):
         # The fixture's season-0 is marked completed.  When every
         # regular-season week is played, ``remainingWeeks == 0`` and
         # the simulator returns 0/1 probabilities deterministically.
-        result = playoff_odds.compute_playoff_odds(
-            self.snapshot, num_sims=0, rng=random.Random(0)
-        )
+        result = playoff_odds.compute_playoff_odds(self.snapshot, num_sims=0, rng=random.Random(0))
         # The fixture's current season is 2025; check that the
         # simulator either collapses (weeksRemaining=0) or keeps
         # probabilities in [0,1].  The strictly-collapsed case:
@@ -280,9 +273,7 @@ class ZeroPointPastWeek(unittest.TestCase):
                 {"roster_id": 2, "matchup_id": 20, "points": 105.0},
             ],
         }
-        rec = playoff_odds._regular_season_record_to_date(
-            self._make_season(entries), None
-        )
+        rec = playoff_odds._regular_season_record_to_date(self._make_season(entries), None)
         # Owner-1: 1 win week 1, 1 loss week 2.
         self.assertEqual(rec["owner-1"]["wins"], 1)
         self.assertEqual(rec["owner-1"]["losses"], 1)
@@ -300,9 +291,7 @@ class ZeroPointPastWeek(unittest.TestCase):
                 {"roster_id": 2, "matchup_id": 10, "points": 0.0},
             ],
         }
-        rec = playoff_odds._regular_season_record_to_date(
-            self._make_season(entries), None
-        )
+        rec = playoff_odds._regular_season_record_to_date(self._make_season(entries), None)
         self.assertEqual(rec, {})
 
 
@@ -316,18 +305,14 @@ class TieHandling(unittest.TestCase):
         wins = {"loser": 0, "tier": 0}
         points = {"loser": 1000.0, "tier": 500.0}
         ties = {"loser": 0, "tier": 1}
-        ordered = playoff_odds._standings_from_sim(
-            wins, points, ["loser", "tier"], ties=ties
-        )
+        ordered = playoff_odds._standings_from_sim(wins, points, ["loser", "tier"], ties=ties)
         self.assertEqual(ordered, ["tier", "loser"])
 
     def test_standings_uses_pf_tiebreak_when_record_matches(self) -> None:
         wins = {"a": 5, "b": 5}
         points = {"a": 1500.0, "b": 1200.0}
         ties = {"a": 1, "b": 1}
-        ordered = playoff_odds._standings_from_sim(
-            wins, points, ["a", "b"], ties=ties
-        )
+        ordered = playoff_odds._standings_from_sim(wins, points, ["a", "b"], ties=ties)
         self.assertEqual(ordered, ["a", "b"])
 
     def test_record_counts_tied_matchup(self) -> None:
@@ -504,9 +489,7 @@ class NumSimsGuard(_Base):
         # Pass num_sims=0 explicitly.  Either the season has no
         # remaining weeks (collapse path, probabilities are 0/1) or
         # we hit the new guard and every probability is None.
-        result = playoff_odds.compute_playoff_odds(
-            self.snapshot, num_sims=0, rng=random.Random(0)
-        )
+        result = playoff_odds.compute_playoff_odds(self.snapshot, num_sims=0, rng=random.Random(0))
         self.assertEqual(result["numSims"], 0)
         for owner in result["owners"]:
             self.assertIn(
@@ -516,14 +499,14 @@ class NumSimsGuard(_Base):
             )
 
     def test_negative_sims_normalised_to_zero(self) -> None:
-        result = playoff_odds.compute_playoff_odds(
-            self.snapshot, num_sims=-5, rng=random.Random(0)
-        )
+        result = playoff_odds.compute_playoff_odds(self.snapshot, num_sims=-5, rng=random.Random(0))
         self.assertEqual(result["numSims"], 0)
 
     def test_non_integer_sims_normalised_to_zero(self) -> None:
         result = playoff_odds.compute_playoff_odds(
-            self.snapshot, num_sims="bogus", rng=random.Random(0)  # type: ignore[arg-type]
+            self.snapshot,
+            num_sims="bogus",
+            rng=random.Random(0),  # type: ignore[arg-type]
         )
         self.assertEqual(result["numSims"], 0)
 
@@ -574,16 +557,36 @@ class ScheduleInferenceFromPosted(unittest.TestCase):
         # should inherit week 3's pairing (same residue mod 3).
         # Week 1: (1v2, 3v4); Week 2: (1v3, 2v4); Week 3: (1v4, 2v3).
         entries = {
-            1: [self._pair_row(10, 1, 120.0), self._pair_row(10, 2, 110.0),
-                self._pair_row(11, 3,  95.0), self._pair_row(11, 4, 105.0)],
-            2: [self._pair_row(20, 1, 130.0), self._pair_row(20, 3, 115.0),
-                self._pair_row(21, 2, 140.0), self._pair_row(21, 4,  98.0)],
-            3: [self._pair_row(30, 1, 125.0), self._pair_row(30, 4, 108.0),
-                self._pair_row(31, 2, 133.0), self._pair_row(31, 3, 112.0)],
-            4: [self._pair_row(40, 1,   0.0), self._pair_row(40, 2,   0.0),
-                self._pair_row(41, 3,   0.0), self._pair_row(41, 4,   0.0)],
-            5: [self._pair_row(50, 1,   0.0), self._pair_row(50, 3,   0.0),
-                self._pair_row(51, 2,   0.0), self._pair_row(51, 4,   0.0)],
+            1: [
+                self._pair_row(10, 1, 120.0),
+                self._pair_row(10, 2, 110.0),
+                self._pair_row(11, 3, 95.0),
+                self._pair_row(11, 4, 105.0),
+            ],
+            2: [
+                self._pair_row(20, 1, 130.0),
+                self._pair_row(20, 3, 115.0),
+                self._pair_row(21, 2, 140.0),
+                self._pair_row(21, 4, 98.0),
+            ],
+            3: [
+                self._pair_row(30, 1, 125.0),
+                self._pair_row(30, 4, 108.0),
+                self._pair_row(31, 2, 133.0),
+                self._pair_row(31, 3, 112.0),
+            ],
+            4: [
+                self._pair_row(40, 1, 0.0),
+                self._pair_row(40, 2, 0.0),
+                self._pair_row(41, 3, 0.0),
+                self._pair_row(41, 4, 0.0),
+            ],
+            5: [
+                self._pair_row(50, 1, 0.0),
+                self._pair_row(50, 3, 0.0),
+                self._pair_row(51, 2, 0.0),
+                self._pair_row(51, 4, 0.0),
+            ],
             # Weeks 6..14 intentionally absent — inference must fill them.
         }
         # Regular season weeks 1..14, playoffs week 15+.  Note the
@@ -606,8 +609,9 @@ class ScheduleInferenceFromPosted(unittest.TestCase):
         self.assertEqual(_pair_set(schedule[8]), _pair_set(schedule[2]))
         self.assertEqual(_pair_set(schedule[14]), _pair_set(schedule[2]))
         # And posted weeks survive verbatim.
-        self.assertEqual(_pair_set(schedule[1]),
-                         _pair_set([("owner-1", "owner-2"), ("owner-3", "owner-4")]))
+        self.assertEqual(
+            _pair_set(schedule[1]), _pair_set([("owner-1", "owner-2"), ("owner-3", "owner-4")])
+        )
 
     def test_odd_team_count_league_cycle_propagates(self) -> None:
         # 5 teams, 2 pairs posted per week (one roster sits out each
@@ -616,11 +620,11 @@ class ScheduleInferenceFromPosted(unittest.TestCase):
         # 5-week cycle (week 6 == week 1).  Inference must carry that
         # pattern into weeks 7+, preserving the bye rotation.
         weekly_pairs = {
-            1: [(1, 2), (3, 4)],              # roster 5 on bye
-            2: [(1, 3), (2, 5)],              # roster 4 on bye
-            3: [(1, 4), (3, 5)],              # roster 2 on bye
-            4: [(1, 5), (2, 4)],              # roster 3 on bye
-            5: [(2, 3), (4, 5)],              # roster 1 on bye
+            1: [(1, 2), (3, 4)],  # roster 5 on bye
+            2: [(1, 3), (2, 5)],  # roster 4 on bye
+            3: [(1, 4), (3, 5)],  # roster 2 on bye
+            4: [(1, 5), (2, 4)],  # roster 3 on bye
+            5: [(2, 3), (4, 5)],  # roster 1 on bye
         }
         # Week 6 repeats week 1 to give the detector something to
         # latch onto.
@@ -631,7 +635,7 @@ class ScheduleInferenceFromPosted(unittest.TestCase):
             rows: list[dict] = []
             for idx, (a, b) in enumerate(pairs):
                 rows.append(self._pair_row(wk * 100 + idx, a, 100.0))
-                rows.append(self._pair_row(wk * 100 + idx, b,  90.0))
+                rows.append(self._pair_row(wk * 100 + idx, b, 90.0))
             entries[wk] = rows
         for wk in range(7, 15):
             entries[wk] = []
@@ -661,8 +665,12 @@ class ScheduleInferenceFromPosted(unittest.TestCase):
         # "inferred" (no posted at all).  Either way, NOT
         # "inferred_from_posted".
         entries = {
-            1: [self._pair_row(10, 1, 120.0), self._pair_row(10, 2, 110.0),
-                self._pair_row(11, 3,  95.0), self._pair_row(11, 4, 105.0)],
+            1: [
+                self._pair_row(10, 1, 120.0),
+                self._pair_row(10, 2, 110.0),
+                self._pair_row(11, 3, 95.0),
+                self._pair_row(11, 4, 105.0),
+            ],
         }
         for wk in range(2, 15):
             entries[wk] = []
@@ -678,14 +686,30 @@ class ScheduleInferenceFromPosted(unittest.TestCase):
         # Integration: the new certainty value reaches the public
         # payload when inference drives the missing-week schedule.
         entries = {
-            1: [self._pair_row(10, 1, 120.0), self._pair_row(10, 2, 110.0),
-                self._pair_row(11, 3,  95.0), self._pair_row(11, 4, 105.0)],
-            2: [self._pair_row(20, 1, 130.0), self._pair_row(20, 3, 115.0),
-                self._pair_row(21, 2, 140.0), self._pair_row(21, 4,  98.0)],
-            3: [self._pair_row(30, 1, 125.0), self._pair_row(30, 4, 108.0),
-                self._pair_row(31, 2, 133.0), self._pair_row(31, 3, 112.0)],
-            4: [self._pair_row(40, 1, 118.0), self._pair_row(40, 2, 111.0),
-                self._pair_row(41, 3,  97.0), self._pair_row(41, 4, 101.0)],
+            1: [
+                self._pair_row(10, 1, 120.0),
+                self._pair_row(10, 2, 110.0),
+                self._pair_row(11, 3, 95.0),
+                self._pair_row(11, 4, 105.0),
+            ],
+            2: [
+                self._pair_row(20, 1, 130.0),
+                self._pair_row(20, 3, 115.0),
+                self._pair_row(21, 2, 140.0),
+                self._pair_row(21, 4, 98.0),
+            ],
+            3: [
+                self._pair_row(30, 1, 125.0),
+                self._pair_row(30, 4, 108.0),
+                self._pair_row(31, 2, 133.0),
+                self._pair_row(31, 3, 112.0),
+            ],
+            4: [
+                self._pair_row(40, 1, 118.0),
+                self._pair_row(40, 2, 111.0),
+                self._pair_row(41, 3, 97.0),
+                self._pair_row(41, 4, 101.0),
+            ],
         }
         for wk in range(5, 15):
             entries[wk] = []

--- a/tests/public_league/test_power.py
+++ b/tests/public_league/test_power.py
@@ -1,4 +1,5 @@
 """Tests for ``src/public_league/power.py``."""
+
 from __future__ import annotations
 
 import unittest

--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -14,6 +14,7 @@ pipeline from ever leaking private signals:
        modules (``src.canonical``, ``src.api.data_contract``,
        ``src.trade``) — enforced by an import-surface scan.
 """
+
 from __future__ import annotations
 
 import re
@@ -61,6 +62,7 @@ class PublicContractSafetyTests(unittest.TestCase):
             _LAZY_SECTION_BUILDERS,
             OVERVIEW_SECTION,
         )
+
         eager = (OVERVIEW_SECTION,) + tuple(_SECTION_BUILDERS.keys())
         for key in eager:
             self.assertIn(key, c["sections"])
@@ -313,12 +315,12 @@ class ActivityGradingTests(unittest.TestCase):
             return 0.0
 
         contract = build_public_contract(
-            self.snapshot, activity_valuation=_valuation,
+            self.snapshot,
+            activity_valuation=_valuation,
         )
         feed = contract["sections"]["activity"]["feed"]
         graded_sides = [
-            side for trade in feed for side in (trade.get("sides") or [])
-            if "grade" in side
+            side for trade in feed for side in (trade.get("sides") or []) if "grade" in side
         ]
         # At least the 2025 two-player swap should be graded.
         self.assertGreater(len(graded_sides), 0)
@@ -350,7 +352,8 @@ class ActivityGradingTests(unittest.TestCase):
             return 0.0
 
         contract = build_public_contract(
-            self.snapshot, activity_valuation=_valuation,
+            self.snapshot,
+            activity_valuation=_valuation,
         )
         feed = contract["sections"]["activity"]["feed"]
         trade_2025 = next(t for t in feed if t["transactionId"] == "tx-2025-a")
@@ -369,14 +372,18 @@ class ActivityGradingTests(unittest.TestCase):
         trade = {
             "transactionId": "synthetic-nan",
             "sides": [
-                {"receivedAssets": [
-                    {"kind": "player", "playerId": "a"},
-                    {"kind": "player", "playerId": "nan-1"},
-                ]},
-                {"receivedAssets": [
-                    {"kind": "player", "playerId": "b"},
-                    {"kind": "player", "playerId": "nan-2"},
-                ]},
+                {
+                    "receivedAssets": [
+                        {"kind": "player", "playerId": "a"},
+                        {"kind": "player", "playerId": "nan-1"},
+                    ]
+                },
+                {
+                    "receivedAssets": [
+                        {"kind": "player", "playerId": "b"},
+                        {"kind": "player", "playerId": "nan-2"},
+                    ]
+                },
             ],
         }
 
@@ -437,7 +444,9 @@ class ActivityGradingTests(unittest.TestCase):
             return 100.0
 
         payload = build_section_payload(
-            self.snapshot, "activity", activity_valuation=_valuation,
+            self.snapshot,
+            "activity",
+            activity_valuation=_valuation,
         )
         feed = payload["data"]["feed"]
         self.assertGreater(len(feed), 0)
@@ -474,8 +483,7 @@ class ImportSurfaceTests(unittest.TestCase):
                         offenders.append(f"{path.name}: {line.strip()}")
         self.assertFalse(
             offenders,
-            msg="Public league package must not import private internals:\n"
-            + "\n".join(offenders),
+            msg="Public league package must not import private internals:\n" + "\n".join(offenders),
         )
 
 

--- a/tests/public_league/test_server_routes.py
+++ b/tests/public_league/test_server_routes.py
@@ -4,6 +4,7 @@ Uses the FastAPI TestClient so we exercise the actual route handlers,
 not just the section builders.  The sleeper client is stubbed via
 tests/public_league/fixtures so no network calls are made.
 """
+
 from __future__ import annotations
 
 import os
@@ -11,6 +12,7 @@ import unittest
 
 try:
     from fastapi.testclient import TestClient
+
     _HAVE_TESTCLIENT = True
 except Exception:  # noqa: BLE001
     _HAVE_TESTCLIENT = False
@@ -29,11 +31,13 @@ class PublicLeagueRouteTests(unittest.TestCase):
 
         # Force the on-process cache to refresh with the stubbed client.
         _public_league_cache.clear()
-        _public_league_cache.update({
-            "snapshot": None,
-            "snapshot_league_id": None,
-            "fetched_at": 0.0,
-        })
+        _public_league_cache.update(
+            {
+                "snapshot": None,
+                "snapshot_league_id": None,
+                "fetched_at": 0.0,
+            }
+        )
         cls.client = TestClient(app)
 
     def test_full_contract_returns_expected_shape(self) -> None:

--- a/tests/public_league/test_streaks.py
+++ b/tests/public_league/test_streaks.py
@@ -10,6 +10,7 @@ regular + playoff games.  We pin:
     * "Notable this week" entries are keyed by the most recently scored
       game in the snapshot.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -31,9 +32,7 @@ class TrailingRunTests(unittest.TestCase):
             {"result": "W"},
             {"result": "W"},
         ]
-        length, start, end = _trailing_run(
-            list(reversed(events)), lambda e: e["result"] == "W"
-        )
+        length, start, end = _trailing_run(list(reversed(events)), lambda e: e["result"] == "W")
         self.assertEqual(length, 3)
         # end_event is the MOST recent (last chronologically).
         self.assertIs(end, events[-1])
@@ -47,16 +46,12 @@ class TrailingRunTests(unittest.TestCase):
             {"result": "L"},
             {"result": "W"},
         ]
-        length, _, _ = _trailing_run(
-            list(reversed(events)), lambda e: e["result"] == "W"
-        )
+        length, _, _ = _trailing_run(list(reversed(events)), lambda e: e["result"] == "W")
         self.assertEqual(length, 1)
 
     def test_zero_when_tail_is_false(self) -> None:
         events = [{"result": "W"}, {"result": "L"}]
-        length, start, end = _trailing_run(
-            list(reversed(events)), lambda e: e["result"] == "W"
-        )
+        length, start, end = _trailing_run(list(reversed(events)), lambda e: e["result"] == "W")
         self.assertEqual(length, 0)
         self.assertIsNone(start)
         self.assertIsNone(end)

--- a/tests/public_league/test_weekly_recap.py
+++ b/tests/public_league/test_weekly_recap.py
@@ -1,4 +1,5 @@
 """Tests for ``src/public_league/weekly_recap.py``."""
+
 from __future__ import annotations
 
 import unittest
@@ -33,7 +34,9 @@ class WeeklyRecapSectionTests(unittest.TestCase):
                 "headline",
                 "summary",
             ):
-                self.assertIn(key, recap, f"missing {key} in recap {recap.get('season')}:{recap.get('week')}")
+                self.assertIn(
+                    key, recap, f"missing {key} in recap {recap.get('season')}:{recap.get('week')}"
+                )
             self.assertIsInstance(recap["headline"], str)
             self.assertTrue(recap["headline"])
             self.assertIsInstance(recap["summary"], str)

--- a/tests/ros/test_aggregate.py
+++ b/tests/ros/test_aggregate.py
@@ -4,6 +4,7 @@ Pin the rank → score conversion, weighted-average behavior, confidence
 math, and tier assignment.  Inputs are entirely synthetic so these
 tests don't depend on a live scrape.
 """
+
 from __future__ import annotations
 
 import math
@@ -33,7 +34,9 @@ _NOW = datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone.utc)
 _FRESH = "2026-04-28T11:00:00+00:00"
 
 
-def _snapshot(key: str, base_weight: float, rows: list[tuple[str, str, int]], total: int) -> SourceSnapshot:
+def _snapshot(
+    key: str, base_weight: float, rows: list[tuple[str, str, int]], total: int
+) -> SourceSnapshot:
     return SourceSnapshot(
         source_key=key,
         base_weight=base_weight,
@@ -177,14 +180,10 @@ class TestAggregate(unittest.TestCase):
         rows1 = [("A", "QB", 1)]
         rows3 = [("A", "QB", 1)] * 1  # same player from one source
         # 1-source confidence
-        s1 = aggregate(
-            [_snapshot("only", 1.0, rows1, 1)], league=_LEAGUE
-        )[0]["confidence"]
+        s1 = aggregate([_snapshot("only", 1.0, rows1, 1)], league=_LEAGUE)[0]["confidence"]
         # 4-source confidence (saturates at 4)
         agg4 = aggregate(
-            [
-                _snapshot(f"src{i}", 1.0, rows1, 1) for i in range(4)
-            ],
+            [_snapshot(f"src{i}", 1.0, rows1, 1) for i in range(4)],
             league=_LEAGUE,
         )[0]["confidence"]
         self.assertGreater(agg4, s1)

--- a/tests/ros/test_direction_and_tags.py
+++ b/tests/ros/test_direction_and_tags.py
@@ -2,6 +2,7 @@
 
 Pure-function tests with synthetic inputs.  No I/O, no live snapshots.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -116,9 +117,7 @@ class TestTagsForPlayer(unittest.TestCase):
         self.assertEqual(tags, [])
 
     def test_zero_ros_value_no_tags(self):
-        tags = tags_for_player(
-            canonical_name="X", position="QB", age=25, ros_value=0
-        )
+        tags = tags_for_player(canonical_name="X", position="QB", age=25, ros_value=0)
         self.assertEqual(tags, [])
 
     def test_win_now_target_for_strong_vet(self):
@@ -178,7 +177,13 @@ class TestTagsForPlayer(unittest.TestCase):
             {"position": "WR", "age": 30, "ros_value": 70, "dynasty_value": 40},
             {"position": "WR", "age": 22, "ros_value": 40},
             {"position": "LB", "age": 27, "ros_value": 80, "ros_rank_overall": 20},
-            {"position": "RB", "age": 30, "ros_value": 65, "volatility_flag": True, "ros_rank_overall": 50},
+            {
+                "position": "RB",
+                "age": 30,
+                "ros_value": 65,
+                "volatility_flag": True,
+                "ros_rank_overall": 50,
+            },
         ]:
             tags = tags_for_player(canonical_name="X", **params)
             all_tags_emitted.update(tags)

--- a/tests/ros/test_isolation.py
+++ b/tests/ros/test_isolation.py
@@ -8,6 +8,7 @@ module, then again after, and asserting byte-identical results.
 If this test fails, a code change accidentally crossed the dynasty/ROS
 boundary — fix the offending change rather than relaxing the test.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -35,10 +36,9 @@ class TestRosIsolation(unittest.TestCase):
             if mod.startswith("src.api.data_contract"):
                 del sys.modules[mod]
         from src.api import data_contract as before_module
+
         before = {
-            "ranking_sources": [
-                dict(s) for s in before_module._RANKING_SOURCES
-            ],
+            "ranking_sources": [dict(s) for s in before_module._RANKING_SOURCES],
             "source_csv_paths": dict(before_module._SOURCE_CSV_PATHS),
             "value_based_sources": set(before_module._VALUE_BASED_SOURCES),
             "source_max_age": dict(before_module._SOURCE_MAX_AGE_HOURS),
@@ -46,7 +46,10 @@ class TestRosIsolation(unittest.TestCase):
         before_hash = _hash(
             {
                 "rs": before["ranking_sources"],
-                "csv": {k: (v if isinstance(v, str) else dict(v)) for k, v in before["source_csv_paths"].items()},
+                "csv": {
+                    k: (v if isinstance(v, str) else dict(v))
+                    for k, v in before["source_csv_paths"].items()
+                },
                 "vbs": sorted(before["value_based_sources"]),
                 "max_age": before["source_max_age"],
             }
@@ -64,10 +67,9 @@ class TestRosIsolation(unittest.TestCase):
         importlib.import_module("src.ros.team_strength")
 
         from src.api import data_contract as after_module
+
         after = {
-            "ranking_sources": [
-                dict(s) for s in after_module._RANKING_SOURCES
-            ],
+            "ranking_sources": [dict(s) for s in after_module._RANKING_SOURCES],
             "source_csv_paths": dict(after_module._SOURCE_CSV_PATHS),
             "value_based_sources": set(after_module._VALUE_BASED_SOURCES),
             "source_max_age": dict(after_module._SOURCE_MAX_AGE_HOURS),
@@ -75,7 +77,10 @@ class TestRosIsolation(unittest.TestCase):
         after_hash = _hash(
             {
                 "rs": after["ranking_sources"],
-                "csv": {k: (v if isinstance(v, str) else dict(v)) for k, v in after["source_csv_paths"].items()},
+                "csv": {
+                    k: (v if isinstance(v, str) else dict(v))
+                    for k, v in after["source_csv_paths"].items()
+                },
                 "vbs": sorted(after["value_based_sources"]),
                 "max_age": after["source_max_age"],
             }
@@ -105,6 +110,7 @@ class TestTradeLogicNonRegression(unittest.TestCase):
         # rather than re-implement it.
         import subprocess
         import sys
+
         result = subprocess.run(
             [
                 sys.executable,

--- a/tests/ros/test_mapping.py
+++ b/tests/ros/test_mapping.py
@@ -4,6 +4,7 @@ Cover the four resolution paths (override / exact / alias / fuzzy) +
 the quarantine fallback.  Inputs are pure strings so these tests
 don't depend on a live player pool.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -24,6 +25,7 @@ class TestResolvePlayer(unittest.TestCase):
     def test_exact_match_against_universe(self):
         # Pre-normalize the canonical entry so the input lands on it.
         from src.utils.name_clean import normalize_player_name
+
         target = normalize_player_name("Justin Jefferson")
         universe = {target}
         result = resolve_player("Justin Jefferson", canonical_universe=universe, overrides={})
@@ -33,11 +35,10 @@ class TestResolvePlayer(unittest.TestCase):
 
     def test_fuzzy_picks_closest_match(self):
         from src.utils.name_clean import normalize_player_name
+
         universe = {normalize_player_name("Marvin Harrison Jr.")}
         # Source typo: "Marvin Harrison J" — single-character edit.
-        result = resolve_player(
-            "Marvin Harrison J", canonical_universe=universe, overrides={}
-        )
+        result = resolve_player("Marvin Harrison J", canonical_universe=universe, overrides={})
         self.assertEqual(result.method, "fuzzy")
         self.assertEqual(result.canonical_name, normalize_player_name("Marvin Harrison Jr."))
 

--- a/tests/ros/test_playoff_sim.py
+++ b/tests/ros/test_playoff_sim.py
@@ -5,6 +5,7 @@ count for speed, and assert structural properties: probabilities sum
 to 1.0 across seeds, contender tier classification matches the spec,
 ROS-strength availability gracefully degrades to empirical-only.
 """
+
 from __future__ import annotations
 
 import random
@@ -41,12 +42,14 @@ class TestEmptySnapshot(unittest.TestCase):
 
     def test_playoff_empty(self):
         from types import SimpleNamespace
+
         snap = SimpleNamespace(seasons=[], managers=None)
         out = playoff_sim.simulate_playoff_odds(snap, n_simulations=10)
         self.assertEqual(out["playoffOdds"], [])
 
     def test_championship_empty(self):
         from types import SimpleNamespace
+
         snap = SimpleNamespace(seasons=[], managers=None)
         out = championship.simulate_championship_odds(snap, n_simulations=10)
         self.assertEqual(out["championshipOdds"], [])
@@ -55,6 +58,7 @@ class TestEmptySnapshot(unittest.TestCase):
 class TestRosStrengthLoader(unittest.TestCase):
     def test_returns_empty_when_no_snapshot(self):
         from pathlib import Path
+
         with patch.object(playoff_sim, "ROS_DATA_DIR", Path("/nonexistent")):
             self.assertEqual(playoff_sim._load_ros_strength_map(), {})
 

--- a/tests/ros/test_power_v2.py
+++ b/tests/ros/test_power_v2.py
@@ -3,6 +3,7 @@
 Verifies the formula composition + handling of missing inputs +
 graceful degradation when ROS team-strength snapshot is absent.
 """
+
 from __future__ import annotations
 
 import json
@@ -59,6 +60,7 @@ class TestLoadTeamStrength(unittest.TestCase):
         # Use a temp dir so we never touch the production snapshot —
         # under the real ROS_DATA_DIR this test would wipe live data.
         import tempfile
+
         with tempfile.TemporaryDirectory() as tmp:
             tmp_root = Path(tmp)
             target = tmp_root / "team_strength" / "latest.json"
@@ -116,10 +118,12 @@ class TestDisplayNameResolution(unittest.TestCase):
     these unit tests pin the helper itself so a future refactor of
     metrics.py won't silently regress the call site.
     """
+
     def test_metrics_display_name_for_resolves_registered_owner(self):
         from src.public_league.identity import Manager, ManagerRegistry
         from src.public_league.snapshot import PublicLeagueSnapshot
         from src.public_league import metrics
+
         registry = ManagerRegistry(
             by_owner_id={
                 "owner-A": Manager(
@@ -145,6 +149,7 @@ class TestDisplayNameResolution(unittest.TestCase):
         from src.public_league.identity import ManagerRegistry
         from src.public_league.snapshot import PublicLeagueSnapshot
         from src.public_league import metrics
+
         snapshot = PublicLeagueSnapshot(
             root_league_id="L1",
             generated_at="2026-04-29T00:00:00Z",
@@ -165,6 +170,7 @@ class TestDisplayNameResolution(unittest.TestCase):
         silently fall back to owner_id again.  This test is the
         canary."""
         from src.public_league.identity import ManagerRegistry
+
         self.assertFalse(
             hasattr(ManagerRegistry, "display_name_for"),
             "If ManagerRegistry gains a display_name_for method, "
@@ -287,9 +293,7 @@ class TestEnumerateOwnerIds(unittest.TestCase):
             {"ownerId": "alpha"},
             {"ownerId": "bravo"},
         ]
-        snapshot.managers.by_owner_id["bravo"] = Manager(
-            owner_id="bravo", display_name="Bravo"
-        )
+        snapshot.managers.by_owner_id["bravo"] = Manager(owner_id="bravo", display_name="Bravo")
         ids = power_v2._enumerate_owner_ids(snapshot, ts_rows, [])
         self.assertEqual(ids, ["alpha", "bravo"])
 
@@ -309,9 +313,7 @@ class TestEnumerateOwnerIds(unittest.TestCase):
         snapshot = _make_snapshot(
             rosters=[{"owner_id": "alpha", "roster_id": 1}],
         )
-        snapshot.managers.by_owner_id["legacy"] = Manager(
-            owner_id="legacy", display_name="Legacy"
-        )
+        snapshot.managers.by_owner_id["legacy"] = Manager(owner_id="legacy", display_name="Legacy")
         ids = power_v2._enumerate_owner_ids(snapshot, [], ["legacy"])
         self.assertIn("legacy", ids)
 
@@ -359,8 +361,8 @@ class TestEnumerateOwnerIds(unittest.TestCase):
             rosters=[{"owner_id": "alpha", "roster_id": 1}],
         )
         ts_rows = [
-            {"ownerId": "alpha"},      # registered, keep
-            {"ownerId": "departed"},   # stale entry, drop
+            {"ownerId": "alpha"},  # registered, keep
+            {"ownerId": "departed"},  # stale entry, drop
         ]
         ids = power_v2._enumerate_owner_ids(snapshot, ts_rows, [])
         self.assertIn("alpha", ids)
@@ -387,10 +389,7 @@ class TestBuildSectionPreseason(unittest.TestCase):
     """
 
     def test_twelve_owners_preseason(self):
-        rosters = [
-            {"owner_id": f"owner-{i:02d}", "roster_id": i}
-            for i in range(1, 13)
-        ]
+        rosters = [{"owner_id": f"owner-{i:02d}", "roster_id": i} for i in range(1, 13)]
         # Two of the twelve are brand new — keep them out of the
         # historical-careers walk by virtue of empty matchups.
         snapshot = _make_snapshot(rosters=rosters)
@@ -446,11 +445,16 @@ class TestBuildSectionPreseason(unittest.TestCase):
             target = tmp_root / "team_strength" / "latest.json"
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(
-                json.dumps([
-                    {"ownerId": f"o{i}", "teamRosStrength": 50.0,
-                     "healthAvailabilityScore": 100}
-                    for i in range(1, 4)
-                ])
+                json.dumps(
+                    [
+                        {
+                            "ownerId": f"o{i}",
+                            "teamRosStrength": 50.0,
+                            "healthAvailabilityScore": 100,
+                        }
+                        for i in range(1, 4)
+                    ]
+                )
             )
             with patch.object(power_v2, "ROS_DATA_DIR", tmp_root):
                 section = power_v2.build_section(snapshot)

--- a/tests/ros/test_scrape_failure_resilience.py
+++ b/tests/ros/test_scrape_failure_resilience.py
@@ -4,6 +4,7 @@ When an adapter crashes or returns failed status, the orchestrator
 MUST keep yesterday's CSV on disk so the aggregate continues to use
 the last-known-good values.  A bad scrape never erases data.
 """
+
 from __future__ import annotations
 
 import csv

--- a/tests/ros/test_sources_registry_parity.py
+++ b/tests/ros/test_sources_registry_parity.py
@@ -8,6 +8,7 @@ walk (no eval) and diffs each entry against
 Adding a new ROS source REQUIRES updating both registries — this test
 fails loudly when they drift.
 """
+
 from __future__ import annotations
 
 import re

--- a/tests/ros/test_team_strength.py
+++ b/tests/ros/test_team_strength.py
@@ -7,6 +7,7 @@ Mocks a tiny roster + an aggregated player-values list and verifies:
   - Bench depth contribution decays with position seen-count.
   - Composite weighting matches the documented weights.
 """
+
 from __future__ import annotations
 
 import unittest

--- a/tests/scoring/test_scoring_modules.py
+++ b/tests/scoring/test_scoring_modules.py
@@ -91,7 +91,6 @@ class ScoringModuleTests(unittest.TestCase):
             self.assertEqual(payload["customLeagueId"], "123")
             self.assertTrue(any(r.get("key") == "pass_td" for r in payload.get("rules", [])))
 
-
     def test_bucket_rule_contributions_detail_isolates_te_bonus(self):
         """`bucket_rule_contributions` aggregates `bonus_fd_te` and
         `rec_fd` into a single `first_downs` bucket on TE rows; the

--- a/tests/scoring/test_tiering.py
+++ b/tests/scoring/test_tiering.py
@@ -1,6 +1,7 @@
 """Tests for src.scoring.tiering.  Pins the Cohen's-d tier walk,
 the fallback behavior when SD is zero, the grid-search fitter,
 and drift detection."""
+
 from __future__ import annotations
 
 import json
@@ -104,9 +105,13 @@ def test_grid_search_fits_something_reasonable():
     """With 30 QBs spread in value, the fitter should land on a
     threshold that produces 4–6 tiers."""
     import random
+
     random.seed(42)
     vals = sorted([random.gauss(5000, 2000) for _ in range(30)], reverse=True)
-    rows = [{"name": f"QB_{i}", "pos": "QB", "rankDerivedValue": max(100, v)} for i, v in enumerate(vals)]
+    rows = [
+        {"name": f"QB_{i}", "pos": "QB", "rankDerivedValue": max(100, v)}
+        for i, v in enumerate(vals)
+    ]
     fit = tiering.fit_thresholds_grid_search(rows)
     assert "QB" in fit
     # Verify the fit actually produces in-range tier counts.

--- a/tests/scripts/test_audit_dropped_sources.py
+++ b/tests/scripts/test_audit_dropped_sources.py
@@ -5,6 +5,7 @@ These tests pin the shape of its summary output so a future refactor
 can't silently break the histogram / per-source / biggest-offender
 sections consumers rely on.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -18,9 +19,7 @@ SCRIPT = REPO / "scripts" / "audit_dropped_sources.py"
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "audit_dropped_sources", SCRIPT
-    )
+    spec = importlib.util.spec_from_file_location("audit_dropped_sources", SCRIPT)
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     assert spec.loader is not None
@@ -121,12 +120,16 @@ class TestSummariseShape:
     def test_drops_surface_in_every_facet(self):
         players = [
             _row(
-                "A", "WR", 1,
+                "A",
+                "WR",
+                1,
                 {"ktc": 1, "dlfSf": 1, "dynastyNerdsSfTep": 300},
                 dropped=["dynastyNerdsSfTep"],
             ),
             _row(
-                "B", "LB", 50,
+                "B",
+                "LB",
+                50,
                 {"idpTradeCalc": 50, "dlfIdp": 50, "footballGuysIdp": 400},
                 dropped=["footballGuysIdp"],
                 spread=0.25,
@@ -170,7 +173,9 @@ class TestSummariseShape:
             dropped = ["footballGuysIdp"] if i < 3 else []
             players.append(
                 _row(
-                    f"P{i}", "LB", i + 1,
+                    f"P{i}",
+                    "LB",
+                    i + 1,
                     {"idpTradeCalc": i + 1, "dlfIdp": i + 1, "footballGuysIdp": i + 1},
                     dropped=dropped,
                 )

--- a/tests/scripts/test_backfill_rank_history.py
+++ b/tests/scripts/test_backfill_rank_history.py
@@ -7,6 +7,7 @@ is responsible for.  Instead we inject a pass-through
 each synthetic zip and verify the iteration / dedup / dry-run
 plumbing around it.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -362,9 +363,16 @@ class TestCorruptLatestFallback(unittest.TestCase):
             _write_zip(
                 archive / "dynasty_export_20260308_020000.zip",
                 date="2026-03-08",
-                payload={"flavour": "good", "playersArray": [
-                    {"canonicalName": "Alice", "canonicalConsensusRank": 1, "assetClass": "offense"},
-                ]},
+                payload={
+                    "flavour": "good",
+                    "playersArray": [
+                        {
+                            "canonicalName": "Alice",
+                            "canonicalConsensusRank": 1,
+                            "assetClass": "offense",
+                        },
+                    ],
+                },
             )
             _write_zip(
                 archive / "dynasty_export_20260308_220000.zip",

--- a/tests/scripts/test_calibrate_va_formula.py
+++ b/tests/scripts/test_calibrate_va_formula.py
@@ -10,6 +10,7 @@ Also verifies the predict_v8 monotonicity: increasing
 ``stud_coeff`` increases the prediction for elite-top trades and
 leaves sub-threshold trades unchanged.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -46,8 +47,12 @@ def _point(cal, *, small, large, label="test"):
 
 def _v7_params():
     return {
-        "slope": 4.0, "intercept": 0.30, "cap": 0.60,
-        "decay": 0.50, "boost": 1.0, "effective_cap": 1.10,
+        "slope": 4.0,
+        "intercept": 0.30,
+        "cap": 0.60,
+        "decay": 0.50,
+        "boost": 1.0,
+        "effective_cap": 1.10,
     }
 
 
@@ -62,9 +67,9 @@ def test_v8_collapses_to_v7_when_stud_coeff_zero(cal):
     pt = _point(cal, small=[8500], large=[6800, 4200])
     v7_pred = cal.predict_v7_full_loop(pt, _v7_params())
     v8_pred = cal.predict_v8_stud_factor(pt, _v8_params(stud_coeff=0.0))
-    assert abs(v7_pred - v8_pred) < 1e-6, (
-        f"V8 with stud_coeff=0 must equal V7: v7={v7_pred} v8={v8_pred}"
-    )
+    assert (
+        abs(v7_pred - v8_pred) < 1e-6
+    ), f"V8 with stud_coeff=0 must equal V7: v7={v7_pred} v8={v8_pred}"
 
 
 def test_v8_collapses_when_top_below_threshold(cal):
@@ -73,7 +78,8 @@ def test_v8_collapses_when_top_below_threshold(cal):
     pt = _point(cal, small=[5000], large=[4500, 3000])
     v7_pred = cal.predict_v7_full_loop(pt, _v7_params())
     v8_pred = cal.predict_v8_stud_factor(
-        pt, _v8_params(stud_coeff=1.5, stud_threshold=7000.0),
+        pt,
+        _v8_params(stud_coeff=1.5, stud_threshold=7000.0),
     )
     # top_small (5000) < threshold (7000) → stud_excess = 0 → mult = 1
     assert abs(v7_pred - v8_pred) < 1e-6
@@ -84,11 +90,10 @@ def test_v8_amplifies_for_elite_top(cal):
     pt = _point(cal, small=[9500], large=[7500, 5000])
     v7_pred = cal.predict_v7_full_loop(pt, _v7_params())
     v8_pred = cal.predict_v8_stud_factor(
-        pt, _v8_params(stud_coeff=1.0, stud_threshold=7000.0),
+        pt,
+        _v8_params(stud_coeff=1.0, stud_threshold=7000.0),
     )
-    assert v8_pred > v7_pred, (
-        f"V8 should amplify elite trades: v7={v7_pred} v8={v8_pred}"
-    )
+    assert v8_pred > v7_pred, f"V8 should amplify elite trades: v7={v7_pred} v8={v8_pred}"
 
 
 def test_v8_returns_zero_when_small_larger(cal):
@@ -96,7 +101,8 @@ def test_v8_returns_zero_when_small_larger(cal):
     same as V7."""
     pt = _point(cal, small=[5000, 4000, 3000], large=[8000])
     v8_pred = cal.predict_v8_stud_factor(
-        pt, _v8_params(stud_coeff=0.5),
+        pt,
+        _v8_params(stud_coeff=0.5),
     )
     assert v8_pred == 0.0
 
@@ -120,14 +126,9 @@ def test_v8_monotonic_in_stud_coeff(cal):
     pt = _point(cal, small=[9000], large=[7500, 4500])
     base = _v8_params(stud_coeff=0.0)
     coeffs = [0.0, 0.25, 0.5, 1.0, 1.5]
-    preds = [
-        cal.predict_v8_stud_factor(pt, {**base, "stud_coeff": c})
-        for c in coeffs
-    ]
+    preds = [cal.predict_v8_stud_factor(pt, {**base, "stud_coeff": c}) for c in coeffs]
     for i in range(len(preds) - 1):
-        assert preds[i + 1] >= preds[i], (
-            f"V8 must be monotonic in stud_coeff: {preds}"
-        )
+        assert preds[i + 1] >= preds[i], f"V8 must be monotonic in stud_coeff: {preds}"
 
 
 def test_v8_in_main_candidates_list(cal):

--- a/tests/scripts/test_fetch_dynasty_daddy.py
+++ b/tests/scripts/test_fetch_dynasty_daddy.py
@@ -8,6 +8,7 @@ Covers:
   * Exit-code behaviour for schema regressions and row-count floors
   * Non-TEP metadata (standard SF scoring)
 """
+
 from __future__ import annotations
 
 import csv
@@ -63,7 +64,9 @@ class TestParsePlayersPositionFilter(unittest.TestCase):
         # Only QB/RB/WR/TE should pass through.
         self.assertEqual(len(rows), 4)
         names = {r["name"] for r in rows}
-        self.assertEqual(names, {"Patrick Mahomes", "Saquon Barkley", "CeeDee Lamb", "Travis Kelce"})
+        self.assertEqual(
+            names, {"Patrick Mahomes", "Saquon Barkley", "CeeDee Lamb", "Travis Kelce"}
+        )
 
     def test_zero_value_filtered_out(self):
         data = _make_players(
@@ -110,9 +113,7 @@ class TestCsvOutputShape(unittest.TestCase):
             orig_floor = dd._DD_ROW_COUNT_FLOOR
             dd._DD_ROW_COUNT_FLOOR = 1
             try:
-                rc = dd.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = dd.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 dd._DD_ROW_COUNT_FLOOR = orig_floor
 
@@ -148,9 +149,7 @@ class TestFromFileEndToEnd(unittest.TestCase):
             orig_floor = dd._DD_ROW_COUNT_FLOOR
             dd._DD_ROW_COUNT_FLOOR = 1
             try:
-                rc = dd.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = dd.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 dd._DD_ROW_COUNT_FLOOR = orig_floor
 
@@ -180,9 +179,7 @@ class TestFromFileEndToEnd(unittest.TestCase):
             orig_floor = dd._DD_ROW_COUNT_FLOOR
             dd._DD_ROW_COUNT_FLOOR = 1
             try:
-                rc = dd.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = dd.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 dd._DD_ROW_COUNT_FLOOR = orig_floor
 

--- a/tests/scripts/test_fetch_dynasty_nerds.py
+++ b/tests/scripts/test_fetch_dynasty_nerds.py
@@ -3,6 +3,7 @@
 Covers the schema probe (DR_DATA missing SFLEXTEP) and row-count floor
 added as part of the source-monitoring hardening pass.
 """
+
 from __future__ import annotations
 
 import json
@@ -52,9 +53,7 @@ class TestMainExitCodes(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             html_path = Path(tmpdir) / "dn.html"
-            html_path.write_text(
-                _wrap_html({"PPR": [], "_meta": {}}), encoding="utf-8"
-            )
+            html_path.write_text(_wrap_html({"PPR": [], "_meta": {}}), encoding="utf-8")
             dest_path = Path(tmpdir) / "out.csv"
             rc = dn.main(
                 [

--- a/tests/scripts/test_fetch_fantasypros_idp.py
+++ b/tests/scripts/test_fetch_fantasypros_idp.py
@@ -7,6 +7,7 @@ Covers:
   * Hill curve value formula byte match
   * End-to-end fixture build: ``--from-dir`` with tiny HTML blobs
 """
+
 from __future__ import annotations
 
 import json
@@ -18,10 +19,7 @@ from scripts import fetch_fantasypros_idp as fp
 
 
 def _wrap_html(data_obj: dict) -> str:
-    return (
-        "<html><body><script>var ecrData = "
-        f"{json.dumps(data_obj)};</script></body></html>"
-    )
+    return "<html><body><script>var ecrData = " f"{json.dumps(data_obj)};</script></body></html>"
 
 
 def _make_players(*entries: tuple[int, str, str, str]) -> list[dict]:
@@ -210,6 +208,7 @@ class TestBuildRowsFromFixture(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertTrue(dest.exists())
             import csv
+
             rows = list(csv.DictReader(dest.open(encoding="utf-8-sig")))
             names = {r["name"]: r for r in rows}
             # All 3 combined + 3 extension = 6 total rows.
@@ -242,12 +241,8 @@ class TestMainExitCodes(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
             # 1 player on combined — below the 50-row floor.
-            combined = _wrap_html(
-                {"players": _make_players((1, "Solo", "DE1", "DE"))}
-            )
-            fam = _wrap_html(
-                {"players": _make_players((1, "Solo", "DE1", "DE"))}
-            )
+            combined = _wrap_html({"players": _make_players((1, "Solo", "DE1", "DE"))})
+            fam = _wrap_html({"players": _make_players((1, "Solo", "DE1", "DE"))})
             (tmp / "combined.html").write_text(combined)
             (tmp / "dl.html").write_text(fam)
             (tmp / "lb.html").write_text(fam)

--- a/tests/scripts/test_fetch_fantasypros_offense.py
+++ b/tests/scripts/test_fetch_fantasypros_offense.py
@@ -6,6 +6,7 @@ Covers:
   * End-to-end fixture build: ``--from-file`` with a tiny HTML blob
   * Exit-code behaviour for schema regressions and row-count floors
 """
+
 from __future__ import annotations
 
 import csv
@@ -18,10 +19,7 @@ from scripts import fetch_fantasypros_offense as fp
 
 
 def _wrap_html(data_obj: dict) -> str:
-    return (
-        "<html><body><script>var ecrData = "
-        f"{json.dumps(data_obj)};</script></body></html>"
-    )
+    return "<html><body><script>var ecrData = " f"{json.dumps(data_obj)};</script></body></html>"
 
 
 def _make_players(
@@ -113,9 +111,7 @@ class TestFromFileEndToEnd(unittest.TestCase):
             orig_floor = fp._FP_ROW_COUNT_FLOOR
             fp._FP_ROW_COUNT_FLOOR = 1
             try:
-                rc = fp.main(
-                    ["--from-file", str(html_path), "--dest", str(dest)]
-                )
+                rc = fp.main(["--from-file", str(html_path), "--dest", str(dest)])
             finally:
                 fp._FP_ROW_COUNT_FLOOR = orig_floor
 
@@ -152,9 +148,7 @@ class TestFromFileEndToEnd(unittest.TestCase):
             orig_floor = fp._FP_ROW_COUNT_FLOOR
             fp._FP_ROW_COUNT_FLOOR = 1
             try:
-                rc = fp.main(
-                    ["--from-file", str(html_path), "--dest", str(dest)]
-                )
+                rc = fp.main(["--from-file", str(html_path), "--dest", str(dest)])
             finally:
                 fp._FP_ROW_COUNT_FLOOR = orig_floor
 

--- a/tests/scripts/test_fetch_flock_fantasy.py
+++ b/tests/scripts/test_fetch_flock_fantasy.py
@@ -10,6 +10,7 @@ Covers:
   * Non-TEP metadata (standard SF scoring)
   * Dry-run mode
 """
+
 from __future__ import annotations
 
 import csv
@@ -73,7 +74,9 @@ class TestParsePlayersPositionFilter(unittest.TestCase):
         rows = ff._parse_players(data)
         self.assertEqual(len(rows), 4)
         names = {r["name"] for r in rows}
-        self.assertEqual(names, {"Patrick Mahomes", "Saquon Barkley", "CeeDee Lamb", "Travis Kelce"})
+        self.assertEqual(
+            names, {"Patrick Mahomes", "Saquon Barkley", "CeeDee Lamb", "Travis Kelce"}
+        )
 
     def test_draft_picks_filtered_out(self):
         data = _make_api_response(
@@ -88,8 +91,18 @@ class TestParsePlayersPositionFilter(unittest.TestCase):
     def test_none_averageRank_filtered_out(self):
         data = {
             "data": [
-                {"playerName": "Patrick Mahomes", "position": "QB", "averageRank": 1.63, "isDraftPick": False},
-                {"playerName": "Ghost Player", "position": "RB", "averageRank": None, "isDraftPick": False},
+                {
+                    "playerName": "Patrick Mahomes",
+                    "position": "QB",
+                    "averageRank": 1.63,
+                    "isDraftPick": False,
+                },
+                {
+                    "playerName": "Ghost Player",
+                    "position": "RB",
+                    "averageRank": None,
+                    "isDraftPick": False,
+                },
             ]
         }
         rows = ff._parse_players(data)
@@ -124,9 +137,7 @@ class TestCsvOutputShape(unittest.TestCase):
             orig_floor = ff._FF_ROW_COUNT_FLOOR
             ff._FF_ROW_COUNT_FLOOR = 1
             try:
-                rc = ff.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = ff.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 ff._FF_ROW_COUNT_FLOOR = orig_floor
 
@@ -162,9 +173,7 @@ class TestFromFileEndToEnd(unittest.TestCase):
             orig_floor = ff._FF_ROW_COUNT_FLOOR
             ff._FF_ROW_COUNT_FLOOR = 1
             try:
-                rc = ff.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = ff.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 ff._FF_ROW_COUNT_FLOOR = orig_floor
 
@@ -194,9 +203,7 @@ class TestFromFileEndToEnd(unittest.TestCase):
             orig_floor = ff._FF_ROW_COUNT_FLOOR
             ff._FF_ROW_COUNT_FLOOR = 1
             try:
-                rc = ff.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = ff.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 ff._FF_ROW_COUNT_FLOOR = orig_floor
 

--- a/tests/scripts/test_fetch_flock_fantasy_rookies.py
+++ b/tests/scripts/test_fetch_flock_fantasy_rookies.py
@@ -10,6 +10,7 @@ Covers:
   * Registry metadata: rookie translation, scope, non-TEP, non-retail
   * Dry-run mode
 """
+
 from __future__ import annotations
 
 import csv
@@ -227,9 +228,7 @@ class TestCsvOutputShape(unittest.TestCase):
             orig_floor = ffr._FF_ROOKIE_ROW_COUNT_FLOOR
             ffr._FF_ROOKIE_ROW_COUNT_FLOOR = 1
             try:
-                rc = ffr.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = ffr.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 ffr._FF_ROOKIE_ROW_COUNT_FLOOR = orig_floor
 
@@ -263,9 +262,7 @@ class TestFromFileEndToEnd(unittest.TestCase):
             orig_floor = ffr._FF_ROOKIE_ROW_COUNT_FLOOR
             ffr._FF_ROOKIE_ROW_COUNT_FLOOR = 1
             try:
-                rc = ffr.main(
-                    ["--from-file", str(json_path), "--dest", str(dest)]
-                )
+                rc = ffr.main(["--from-file", str(json_path), "--dest", str(dest)])
             finally:
                 ffr._FF_ROOKIE_ROW_COUNT_FLOOR = orig_floor
 
@@ -367,9 +364,7 @@ class TestRegistryMetadata(unittest.TestCase):
         return None
 
     def test_source_registered(self):
-        self.assertIsNotNone(
-            self._entry(), "flockFantasySfRookies not in registry"
-        )
+        self.assertIsNotNone(self._entry(), "flockFantasySfRookies not in registry")
 
     def test_scope_overall_offense(self):
         entry = self._entry()
@@ -392,9 +387,7 @@ class TestRegistryMetadata(unittest.TestCase):
         self.assertIn("flockFantasySfRookies", _SOURCE_CSV_PATHS)
         cfg = _SOURCE_CSV_PATHS["flockFantasySfRookies"]
         self.assertEqual(cfg.get("signal"), "rank")
-        self.assertEqual(
-            cfg.get("path"), "CSVs/site_raw/flockFantasySfRookies.csv"
-        )
+        self.assertEqual(cfg.get("path"), "CSVs/site_raw/flockFantasySfRookies.csv")
 
     def test_needs_rookie_translation_flag(self):
         from src.api.data_contract import _RANKING_SOURCES

--- a/tests/scripts/test_generate_weekly_narratives.py
+++ b/tests/scripts/test_generate_weekly_narratives.py
@@ -6,6 +6,7 @@ the season-targeting logic, which the cron uses for live runs and a
 human uses for backfills.  Both paths must agree on which season's
 files get written.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -50,7 +51,10 @@ class ResolveTargetWeekTests(unittest.TestCase):
     def test_no_season_no_week_picks_current_recap_week(self) -> None:
         # Fixture's 2025 is fully scored through wk-16.
         season, week = self.script._resolve_target_week(  # noqa: SLF001
-            self.snapshot, mode="recap", explicit_week=None, explicit_season=None,
+            self.snapshot,
+            mode="recap",
+            explicit_week=None,
+            explicit_season=None,
         )
         self.assertEqual(season, "2025")
         self.assertEqual(week, 16)
@@ -58,7 +62,10 @@ class ResolveTargetWeekTests(unittest.TestCase):
     def test_explicit_season_routes_to_that_season(self) -> None:
         # Fixture has 2024 + 2025; backfill should target 2024.
         season, week = self.script._resolve_target_week(  # noqa: SLF001
-            self.snapshot, mode="recap", explicit_week=None, explicit_season="2024",
+            self.snapshot,
+            mode="recap",
+            explicit_week=None,
+            explicit_season="2024",
         )
         self.assertEqual(season, "2024")
         # 2024 fixture is scored through wk-3.
@@ -66,7 +73,10 @@ class ResolveTargetWeekTests(unittest.TestCase):
 
     def test_explicit_season_and_week_overrides_detector(self) -> None:
         season, week = self.script._resolve_target_week(  # noqa: SLF001
-            self.snapshot, mode="preview", explicit_week=14, explicit_season="2024",
+            self.snapshot,
+            mode="preview",
+            explicit_week=14,
+            explicit_season="2024",
         )
         self.assertEqual(season, "2024")
         self.assertEqual(week, 14)
@@ -74,8 +84,10 @@ class ResolveTargetWeekTests(unittest.TestCase):
     def test_unknown_season_raises_with_helpful_message(self) -> None:
         with self.assertRaises(RuntimeError) as ctx:
             self.script._resolve_target_week(  # noqa: SLF001
-                self.snapshot, mode="recap",
-                explicit_week=None, explicit_season="1999",
+                self.snapshot,
+                mode="recap",
+                explicit_week=None,
+                explicit_season="1999",
             )
         self.assertIn("1999", str(ctx.exception))
         self.assertIn("2025", str(ctx.exception))  # available seasons listed
@@ -83,7 +95,10 @@ class ResolveTargetWeekTests(unittest.TestCase):
     def test_explicit_week_only_uses_current_season(self) -> None:
         # No --season but explicit --week → current (2025) season.
         season, week = self.script._resolve_target_week(  # noqa: SLF001
-            self.snapshot, mode="preview", explicit_week=10, explicit_season=None,
+            self.snapshot,
+            mode="preview",
+            explicit_week=10,
+            explicit_season=None,
         )
         self.assertEqual(season, "2025")
         self.assertEqual(week, 10)

--- a/tests/scripts/test_sleeper_candidate_score.py
+++ b/tests/scripts/test_sleeper_candidate_score.py
@@ -18,6 +18,7 @@ We mirror the scraper's scoring function rather than importing
 ``Dynasty Scraper.py`` directly (it has a top-level Playwright
 import that isn't available in CI).
 """
+
 from __future__ import annotations
 
 
@@ -96,7 +97,21 @@ def test_position_hint_breaks_ties_between_active_homonyms():
     # DJ Turner WR (CIN) vs DJ Turner II CB (ARI): both active,
     # both rostered. With a position hint we should land on the
     # right family.
-    wr = {"id": "WR1", "active": 1, "team": "CIN", "search_rank": 250.0, "years_exp": 2, "pos": "WR"}
-    cb = {"id": "CB1", "active": 1, "team": "ARI", "search_rank": 300.0, "years_exp": 2, "pos": "CB"}
+    wr = {
+        "id": "WR1",
+        "active": 1,
+        "team": "CIN",
+        "search_rank": 250.0,
+        "years_exp": 2,
+        "pos": "WR",
+    }
+    cb = {
+        "id": "CB1",
+        "active": 1,
+        "team": "ARI",
+        "search_rank": 300.0,
+        "years_exp": 2,
+        "pos": "CB",
+    }
     assert _pick([wr, cb], preferred_pos="WR")["id"] == "WR1"
     assert _pick([wr, cb], preferred_pos="CB")["id"] == "CB1"

--- a/tests/scripts/test_sleeper_dual_position.py
+++ b/tests/scripts/test_sleeper_dual_position.py
@@ -10,6 +10,7 @@ compete in the off-ball LB bucket downstream.
 Single-position rows and pure-offense rows must pass through
 unchanged.
 """
+
 from __future__ import annotations
 
 from src.utils.name_clean import resolve_idp_position

--- a/tests/scripts/test_sleeper_fallback.py
+++ b/tests/scripts/test_sleeper_fallback.py
@@ -5,6 +5,7 @@ rest of the suite — we do NOT import it.  Instead we ast-extract just
 the three pure filesystem helpers and exec them in isolation against a
 tmp dir.  This exercises the real shipped code path.
 """
+
 from __future__ import annotations
 
 import ast
@@ -37,6 +38,7 @@ def _load_helpers(cache_path: str, stamp_path: str) -> dict:
 class SleeperFallbackHelperTests(unittest.TestCase):
     def setUp(self) -> None:
         import tempfile
+
         self.tmp = tempfile.mkdtemp()
         self.cache = os.path.join(self.tmp, "data", "sleeper_last_good.json")
         self.stamp = os.path.join(self.tmp, "data", "scrape_state", "sleeper_last_success")
@@ -44,6 +46,7 @@ class SleeperFallbackHelperTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         import shutil
+
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     def test_save_then_load_roundtrip(self) -> None:

--- a/tests/scripts/test_validate_scrape_sanity.py
+++ b/tests/scripts/test_validate_scrape_sanity.py
@@ -2,6 +2,7 @@
 
 Exercises the pure ``evaluate()`` decision function — no git / IO.
 """
+
 from __future__ import annotations
 
 import importlib.util

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -1,4 +1,5 @@
 """Unit tests for src.trade.angle.find_angles / find_angle_packages."""
+
 from __future__ import annotations
 
 import pytest
@@ -67,8 +68,8 @@ def test_excludes_same_team_players():
 def test_sorts_by_arb_score_desc():
     players = [
         _player("Jayden Daniels", 5000, 5000),
-        _player("Trade Target Good", 6000, 5100),   # +20% / +2% => arb 18
-        _player("Trade Target Gold", 7500, 4800),   # +50% / -4% => arb 54
+        _player("Trade Target Good", 6000, 5100),  # +20% / +2% => arb 18
+        _player("Trade Target Gold", 7500, 4800),  # +50% / -4% => arb 54
     ]
     result = find_angles(players, "Jayden Daniels", "owner-a", _teams())
     names = [c["name"] for c in result["candidates"]]
@@ -82,7 +83,11 @@ def test_respects_min_my_gain_threshold():
         _player("Trade Target Good", 5100, 4900),  # only +2% my gain
     ]
     result = find_angles(
-        players, "Jayden Daniels", "owner-a", _teams(), min_my_gain_pct=10.0,
+        players,
+        "Jayden Daniels",
+        "owner-a",
+        _teams(),
+        min_my_gain_pct=10.0,
     )
     assert result["candidates"] == []
 
@@ -152,8 +157,8 @@ def test_limit_caps_results():
 def test_target_team_filter_restricts_candidates_to_one_team():
     players = [
         _player("Jayden Daniels", 5000, 5000),
-        _player("Trade Target Good", 6000, 5000),    # Team B
-        _player("Trade Target Gold", 7500, 4800),    # Team C — even better arb
+        _player("Trade Target Good", 6000, 5000),  # Team B
+        _player("Trade Target Gold", 7500, 4800),  # Team C — even better arb
     ]
     result = find_angles(
         players,
@@ -194,8 +199,8 @@ def test_target_team_filter_does_not_return_free_agents():
     # A player who exists in players_array but isn't on any sleeper team.
     players = [
         _player("Jayden Daniels", 5000, 5000),
-        _player("Trade Target Good", 6000, 5000),       # Team B
-        _player("Free Agent Stud", 7500, 5000),         # not rostered anywhere
+        _player("Trade Target Good", 6000, 5000),  # Team B
+        _player("Free Agent Stud", 7500, 5000),  # not rostered anywhere
     ]
     result = find_angles(
         players,
@@ -258,7 +263,10 @@ def _pkg_players():
 def test_packages_returns_counter_offers_sized_within_plus_minus_one():
     offer = ["Jayden Daniels", "CeeDee Lamb"]  # N = 2
     result = find_angle_packages(
-        _pkg_players(), offer, "owner-a", _pkg_teams(),
+        _pkg_players(),
+        offer,
+        "owner-a",
+        _pkg_teams(),
     )
     # Target sizes must be {1, 2, 3} — no 4 or higher.
     target_sizes = set(result["thresholds"]["target_sizes"])
@@ -270,7 +278,10 @@ def test_packages_returns_counter_offers_sized_within_plus_minus_one():
 def test_packages_offer_of_one_allows_sizes_one_and_two():
     offer = ["Jayden Daniels"]  # N = 1 — size 0 collapses to 1
     result = find_angle_packages(
-        _pkg_players(), offer, "owner-a", _pkg_teams(),
+        _pkg_players(),
+        offer,
+        "owner-a",
+        _pkg_teams(),
     )
     assert set(result["thresholds"]["target_sizes"]) == {1, 2}
 
@@ -278,7 +289,10 @@ def test_packages_offer_of_one_allows_sizes_one_and_two():
 def test_packages_excludes_same_team_players_from_candidates():
     offer = ["Jayden Daniels"]
     result = find_angle_packages(
-        _pkg_players(), offer, "owner-a", _pkg_teams(),
+        _pkg_players(),
+        offer,
+        "owner-a",
+        _pkg_teams(),
     )
     owners = {c["owner_id"] for c in result["candidates"]}
     assert "owner-a" not in owners  # never trade with yourself
@@ -290,7 +304,10 @@ def test_packages_filters_on_market_gap_threshold():
     # the market gap constraint vs the offer's market total (which
     # for this all-offense offer happens to equal the KTC total).
     result = find_angle_packages(
-        _pkg_players(), offer, "owner-a", _pkg_teams(),
+        _pkg_players(),
+        offer,
+        "owner-a",
+        _pkg_teams(),
     )
     offer_market = 10000
     for c in result["candidates"]:
@@ -300,7 +317,10 @@ def test_packages_filters_on_market_gap_threshold():
 def test_packages_sorts_by_arb_score_desc():
     offer = ["Jayden Daniels", "CeeDee Lamb"]
     result = find_angle_packages(
-        _pkg_players(), offer, "owner-a", _pkg_teams(),
+        _pkg_players(),
+        offer,
+        "owner-a",
+        _pkg_teams(),
     )
     scores = [c["arb_score"] for c in result["candidates"]]
     assert scores == sorted(scores, reverse=True)
@@ -309,7 +329,10 @@ def test_packages_sorts_by_arb_score_desc():
 def test_packages_offer_totals_are_correct():
     offer = ["Jayden Daniels", "CeeDee Lamb"]
     result = find_angle_packages(
-        _pkg_players(), offer, "owner-a", _pkg_teams(),
+        _pkg_players(),
+        offer,
+        "owner-a",
+        _pkg_teams(),
     )
     assert result["offer"]["my_total"] == 10000
     assert result["offer"]["market_total"] == 10000
@@ -386,7 +409,12 @@ def test_packages_per_team_limit_disabled_by_zero_or_negative():
         players.append(_player(f"B {i}", my_val=6000 + i * 10, ktc_val=5000))
     # per_team_limit=0 disables the cap — lots of Team B candidates.
     result = find_angle_packages(
-        players, offer, "owner-a", teams, per_team_limit=0, limit=100,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        per_team_limit=0,
+        limit=100,
     )
     team_b_count = sum(1 for c in result["candidates"] if c["owner_id"] == "owner-b")
     assert team_b_count > 4
@@ -412,13 +440,21 @@ def test_packages_position_filter_restricts_candidates():
     ]
     # Only want WRs back.
     result = find_angle_packages(
-        players, offer, "owner-a", teams, positions=["WR"],
+        players,
+        offer,
+        "owner-a",
+        teams,
+        positions=["WR"],
     )
     pos_seen = {p["position"] for c in result["candidates"] for p in c["players"]}
     assert pos_seen == {"WR"}
     # Empty position filter = any position accepted.
     result2 = find_angle_packages(
-        players, offer, "owner-a", teams, positions=[],
+        players,
+        offer,
+        "owner-a",
+        teams,
+        positions=[],
     )
     pos_seen2 = {p["position"] for c in result2["candidates"] for p in c["players"]}
     assert pos_seen2 == {"WR", "RB", "TE"}
@@ -435,7 +471,11 @@ def test_packages_position_filter_case_insensitive():
         _player("B WR", 6000, 5000, position="WR"),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams, positions=["wr"],
+        players,
+        offer,
+        "owner-a",
+        teams,
+        positions=["wr"],
     )
     assert any(p["name"] == "B WR" for c in result["candidates"] for p in c["players"])
 
@@ -457,13 +497,21 @@ def test_packages_min_player_my_value_filters_filler():
     ]
     # Default 3000 floor — B Filler's my_value=500 is excluded.
     result = find_angle_packages(
-        players, offer, "owner-a", teams, min_player_my_value=3000,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        min_player_my_value=3000,
     )
     names = {p["name"] for c in result["candidates"] for p in c["players"]}
     assert "B Filler" not in names
     # Zero floor — Filler can come along.
     result2 = find_angle_packages(
-        players, offer, "owner-a", teams, min_player_my_value=0,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        min_player_my_value=0,
     )
     names2 = {p["name"] for c in result2["candidates"] for p in c["players"]}
     assert "B Star" in names2  # at minimum
@@ -480,8 +528,12 @@ def test_packages_filters_surfaced_in_thresholds():
         _player("B WR", 6000, 5000, position="WR"),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
-        positions=["WR", "TE"], min_player_my_value=2500,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        positions=["WR", "TE"],
+        min_player_my_value=2500,
     )
     th = result["thresholds"]
     assert th["positions"] == ["TE", "WR"]  # sorted
@@ -504,7 +556,10 @@ def test_packages_target_teams_restrict_candidates():
         _player("C Star", 6000, 5000),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
+        players,
+        offer,
+        "owner-a",
+        teams,
         target_team_owner_ids=["owner-b"],
     )
     # Every candidate has owner_id == "owner-b" (our single target).
@@ -518,23 +573,28 @@ def test_packages_seed_player_must_appear_in_every_candidate():
     offer = ["Jayden Daniels", "CeeDee Lamb"]  # N = 2
     teams = [
         {
-            "name": "Team A", "ownerId": "owner-a",
+            "name": "Team A",
+            "ownerId": "owner-a",
             "players": ["Jayden Daniels", "CeeDee Lamb"],
         },
         {
-            "name": "Team B", "ownerId": "owner-b",
+            "name": "Team B",
+            "ownerId": "owner-b",
             "players": ["B Star", "B Mid", "B Bench"],
         },
     ]
     players = [
         _player("Jayden Daniels", 5000, 5000),
         _player("CeeDee Lamb", 5000, 5000),
-        _player("B Star", 6500, 5200),    # this is the seed
+        _player("B Star", 6500, 5200),  # this is the seed
         _player("B Mid", 5500, 4800),
         _player("B Bench", 4500, 4500),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
+        players,
+        offer,
+        "owner-a",
+        teams,
         target_team_owner_ids=["owner-b"],
         seed_player_names=["B Star"],
     )
@@ -551,7 +611,8 @@ def test_packages_two_target_teams_draw_from_union():
     offer = ["Jayden Daniels", "CeeDee Lamb"]
     teams = [
         {
-            "name": "Team A", "ownerId": "owner-a",
+            "name": "Team A",
+            "ownerId": "owner-a",
             "players": ["Jayden Daniels", "CeeDee Lamb"],
         },
         {"name": "Team B", "ownerId": "owner-b", "players": ["B Star"]},
@@ -564,7 +625,10 @@ def test_packages_two_target_teams_draw_from_union():
         _player("C Star", 6000, 5000),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
+        players,
+        offer,
+        "owner-a",
+        teams,
         target_team_owner_ids=["owner-b", "owner-c"],
         seed_player_names=["B Star", "C Star"],
     )
@@ -590,7 +654,10 @@ def test_packages_warning_for_seed_not_on_target_team():
         _player("C Star", 6000, 5000),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
+        players,
+        offer,
+        "owner-a",
+        teams,
         target_team_owner_ids=["owner-b"],
         seed_player_names=["C Star"],  # not on Team B — should be ignored w/ warning
     )
@@ -644,12 +711,20 @@ def test_idp_players_compared_on_idptc_not_ktc():
     players = [
         _player_with_markets("My DL", my_val=5000, ktc=5000, idptc=5000, position="DL"),
         _player_with_markets(
-            "Better DL", my_val=6000, ktc=7000, idptc=5100, position="DL",
+            "Better DL",
+            my_val=6000,
+            ktc=7000,
+            idptc=5100,
+            position="DL",
         ),
     ]
     result = find_angles(
-        players, "My DL", "owner-a", teams,
-        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+        players,
+        "My DL",
+        "owner-a",
+        teams,
+        min_my_gain_pct=5.0,
+        max_market_gain_pct=5.0,
     )
     names = [c["name"] for c in result["candidates"]]
     assert "Better DL" in names, (
@@ -671,19 +746,31 @@ def test_offense_players_still_compared_on_ktc():
     players = [
         _player_with_markets("My QB", my_val=5000, ktc=5000, idptc=5000, position="QB"),
         _player_with_markets(
-            "Other QB", my_val=6000, ktc=6500, idptc=5050, position="QB",
+            "Other QB",
+            my_val=6000,
+            ktc=6500,
+            idptc=5050,
+            position="QB",
         ),
     ]
     result = find_angles(
-        players, "My QB", "owner-a", teams,
-        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+        players,
+        "My QB",
+        "owner-a",
+        teams,
+        min_my_gain_pct=5.0,
+        max_market_gain_pct=5.0,
     )
     names = [c["name"] for c in result["candidates"]]
     assert "Other QB" not in names
     # Raising the ceiling admits it.
     result2 = find_angles(
-        players, "My QB", "owner-a", teams,
-        min_my_gain_pct=5.0, max_market_gain_pct=40.0,
+        players,
+        "My QB",
+        "owner-a",
+        teams,
+        min_my_gain_pct=5.0,
+        max_market_gain_pct=40.0,
     )
     cand = next(c for c in result2["candidates"] if c["name"] == "Other QB")
     assert cand["market_source"] == "ktc"
@@ -728,7 +815,10 @@ def _acq_players():
 
 def test_acquire_returns_offer_packages_from_user_roster():
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Target Star"],
+        "owner-a",
+        _acq_teams(),
     )
     assert result["acquire"]["size"] == 1
     # Every candidate player must come from the user's roster.
@@ -740,7 +830,10 @@ def test_acquire_returns_offer_packages_from_user_roster():
 
 def test_acquire_candidate_sizes_within_plus_minus_one():
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star", "B Filler"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Target Star", "B Filler"],
+        "owner-a",
+        _acq_teams(),
     )
     # Desired N=2 → sizes {1,2,3}
     assert set(result["thresholds"]["target_sizes"]) == {1, 2, 3}
@@ -754,7 +847,10 @@ def test_acquire_my_gain_threshold_enforced():
     # single-player combo qualifies and only multi-player combos that
     # under-shoot enough on my-value remain.
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Target Star"],
+        "owner-a",
+        _acq_teams(),
         min_my_gain_pct=25.0,
     )
     for c in result["candidates"]:
@@ -766,8 +862,12 @@ def test_acquire_market_gap_threshold_enforced():
     # max_market_gain_pct=2, the single-player My QB1 offer is the
     # tightest fit.
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
-        min_my_gain_pct=5.0, max_market_gain_pct=2.0,
+        _acq_players(),
+        ["Target Star"],
+        "owner-a",
+        _acq_teams(),
+        min_my_gain_pct=5.0,
+        max_market_gain_pct=2.0,
     )
     assert result["candidates"], "expected at least one qualifying offer"
     for c in result["candidates"]:
@@ -777,7 +877,10 @@ def test_acquire_market_gap_threshold_enforced():
 def test_acquire_rejects_own_roster_targets_with_warning():
     # "My QB1" is on owner-a's roster — can't "acquire" from yourself.
     result = find_acquisition_packages(
-        _acq_players(), ["My QB1"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["My QB1"],
+        "owner-a",
+        _acq_teams(),
     )
     assert result["acquire"]["size"] == 0
     assert result["candidates"] == []
@@ -786,7 +889,10 @@ def test_acquire_rejects_own_roster_targets_with_warning():
 
 def test_acquire_unknown_targets_dropped_with_warning():
     result = find_acquisition_packages(
-        _acq_players(), ["Ghost Player", "Target Star"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Ghost Player", "Target Star"],
+        "owner-a",
+        _acq_teams(),
     )
     assert result["acquire"]["size"] == 1
     assert any("Ghost Player" in w for w in result["warnings"])
@@ -794,7 +900,10 @@ def test_acquire_unknown_targets_dropped_with_warning():
 
 def test_acquire_sorts_by_arb_score_desc():
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Target Star"],
+        "owner-a",
+        _acq_teams(),
     )
     scores = [c["arb_score"] for c in result["candidates"]]
     assert scores == sorted(scores, reverse=True)
@@ -802,7 +911,10 @@ def test_acquire_sorts_by_arb_score_desc():
 
 def test_acquire_target_team_list_in_response():
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star", "Target Gold"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Target Star", "Target Gold"],
+        "owner-a",
+        _acq_teams(),
     )
     owner_ids = {t["owner_id"] for t in result["acquire"]["targets"]}
     assert owner_ids == {"owner-b", "owner-c"}
@@ -810,7 +922,10 @@ def test_acquire_target_team_list_in_response():
 
 def test_acquire_unknown_owner_returns_warning():
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star"], "owner-missing", _acq_teams(),
+        _acq_players(),
+        ["Target Star"],
+        "owner-missing",
+        _acq_teams(),
     )
     assert result["candidates"] == []
     assert any("not found" in w for w in result["warnings"])
@@ -818,7 +933,10 @@ def test_acquire_unknown_owner_returns_warning():
 
 def test_acquire_respects_position_filter_on_own_roster():
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Target Star"],
+        "owner-a",
+        _acq_teams(),
         positions=["WR"],
     )
     for c in result["candidates"]:
@@ -829,7 +947,10 @@ def test_acquire_respects_position_filter_on_own_roster():
 def test_acquire_respects_min_player_value_on_own_roster():
     # With floor 3000, "My Bench" (my_val=200) is excluded.
     result = find_acquisition_packages(
-        _acq_players(), ["Target Star"], "owner-a", _acq_teams(),
+        _acq_players(),
+        ["Target Star"],
+        "owner-a",
+        _acq_teams(),
         min_player_my_value=3000,
     )
     names = {p["name"] for c in result["candidates"] for p in c["players"]}
@@ -851,8 +972,12 @@ def test_acquire_idp_target_compares_on_idptc():
     # otherwise be filtered out of the candidate pool by the default
     # IDP gate.
     result = find_acquisition_packages(
-        players, ["Target DL"], "owner-a", teams,
-        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+        players,
+        ["Target DL"],
+        "owner-a",
+        teams,
+        min_my_gain_pct=5.0,
+        max_market_gain_pct=5.0,
         include_idp=True,
     )
     assert result["candidates"], "IDP acquire should qualify on IDPTC"
@@ -865,7 +990,8 @@ def test_packages_player_rows_expose_per_position_market_source():
     teams = [
         {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
         {
-            "name": "Team B", "ownerId": "owner-b",
+            "name": "Team B",
+            "ownerId": "owner-b",
             "players": ["IDP Target", "Off Target"],
         },
     ]
@@ -875,8 +1001,12 @@ def test_packages_player_rows_expose_per_position_market_source():
         _player_with_markets("Off Target", 6000, 5100, 7000, position="WR"),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
-        min_my_gain_pct=5.0, max_market_gain_pct=5.0,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        min_my_gain_pct=5.0,
+        max_market_gain_pct=5.0,
     )
     for c in result["candidates"]:
         for p in c["players"]:
@@ -958,8 +1088,12 @@ def test_packages_consolidation_trade_is_filtered_by_va():
         _player("Filler 4", 2400, 2400),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
-        min_my_gain_pct=0.0, max_market_gain_pct=5.0,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        min_my_gain_pct=0.0,
+        max_market_gain_pct=5.0,
     )
     # Under raw arithmetic the 4-filler counter is within both
     # thresholds. With VA applied to the smaller (stud) side, the
@@ -977,7 +1111,8 @@ def test_packages_candidate_exposes_va_adjustment_fields():
     offer = ["Offer Star", "Offer Depth"]
     teams = [
         {
-            "name": "Team A", "ownerId": "owner-a",
+            "name": "Team A",
+            "ownerId": "owner-a",
             "players": ["Offer Star", "Offer Depth"],
         },
         {"name": "Team B", "ownerId": "owner-b", "players": ["Target Star"]},
@@ -989,13 +1124,17 @@ def test_packages_candidate_exposes_va_adjustment_fields():
         _player("Target Star", 9000, 8200),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
+        players,
+        offer,
+        "owner-a",
+        teams,
         # KTC's native algorithm produces a stronger consolidation
         # premium than the V2 regression fit (~50% market gap on this
         # 2-for-1) so the threshold has to be loose enough for the
         # candidate to survive.  100% gives ample headroom while still
         # being a meaningful filter for less-extreme topologies.
-        min_my_gain_pct=0.0, max_market_gain_pct=100.0,
+        min_my_gain_pct=0.0,
+        max_market_gain_pct=100.0,
     )
     size_one = next((c for c in result["candidates"] if c["size"] == 1), None)
     assert size_one is not None, "expected the single-player counter to qualify"
@@ -1012,7 +1151,8 @@ def test_packages_idp_excluded_from_pool_by_default():
     teams = [
         {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
         {
-            "name": "Team B", "ownerId": "owner-b",
+            "name": "Team B",
+            "ownerId": "owner-b",
             "players": ["Opp DL", "Opp WR"],
         },
     ]
@@ -1022,7 +1162,10 @@ def test_packages_idp_excluded_from_pool_by_default():
         _player("Opp WR", 6000, 5000, position="WR"),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,  # include_idp default False
+        players,
+        offer,
+        "owner-a",
+        teams,  # include_idp default False
     )
     names = {p["name"] for c in result["candidates"] for p in c["players"]}
     assert "Opp DL" not in names
@@ -1050,7 +1193,11 @@ def test_packages_idp_included_when_flag_set():
         _idp_player("Opp DL", 6000, 5000, position="DL"),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams, include_idp=True,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        include_idp=True,
     )
     names = {p["name"] for c in result["candidates"] for p in c["players"]}
     assert "Opp DL" in names
@@ -1063,7 +1210,8 @@ def test_packages_idp_filter_does_not_touch_seed_players():
     teams = [
         {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
         {
-            "name": "Team B", "ownerId": "owner-b",
+            "name": "Team B",
+            "ownerId": "owner-b",
             "players": ["Opp Seed DL", "Opp WR"],
         },
     ]
@@ -1073,7 +1221,10 @@ def test_packages_idp_filter_does_not_touch_seed_players():
         _player("Opp WR", 6000, 5000, position="WR"),
     ]
     result = find_angle_packages(
-        players, offer, "owner-a", teams,
+        players,
+        offer,
+        "owner-a",
+        teams,
         target_team_owner_ids=["owner-b"],
         seed_player_names=["Opp Seed DL"],
     )
@@ -1091,7 +1242,8 @@ def test_acquire_idp_excluded_from_offer_pool_by_default():
     zero offers."""
     teams = [
         {
-            "name": "Team A", "ownerId": "owner-a",
+            "name": "Team A",
+            "ownerId": "owner-a",
             "players": ["My LB 1", "My LB 2"],
         },
         {"name": "Team B", "ownerId": "owner-b", "players": ["Target WR"]},
@@ -1102,12 +1254,18 @@ def test_acquire_idp_excluded_from_offer_pool_by_default():
         _player("Target WR", 6000, 5000, position="WR"),
     ]
     result = find_acquisition_packages(
-        players, ["Target WR"], "owner-a", teams,  # include_idp default False
+        players,
+        ["Target WR"],
+        "owner-a",
+        teams,  # include_idp default False
     )
     assert result["candidates"] == []
     # Flip include_idp on and the offer packages appear.
     result2 = find_acquisition_packages(
-        players, ["Target WR"], "owner-a", teams,
+        players,
+        ["Target WR"],
+        "owner-a",
+        teams,
         include_idp=True,
     )
     assert result2["candidates"], "LB offers should qualify once IDP is allowed"
@@ -1118,7 +1276,8 @@ def test_acquire_idp_filter_does_not_drop_desired_player():
     survive the IDP gate even when include_idp is False."""
     teams = [
         {
-            "name": "Team A", "ownerId": "owner-a",
+            "name": "Team A",
+            "ownerId": "owner-a",
             "players": ["My WR 1", "My WR 2"],
         },
         {"name": "Team B", "ownerId": "owner-b", "players": ["Target DL"]},
@@ -1129,8 +1288,12 @@ def test_acquire_idp_filter_does_not_drop_desired_player():
         _idp_player("Target DL", 6000, 5500, position="DL"),
     ]
     result = find_acquisition_packages(
-        players, ["Target DL"], "owner-a", teams,  # default include_idp=False
-        min_my_gain_pct=0.0, max_market_gain_pct=50.0,
+        players,
+        ["Target DL"],
+        "owner-a",
+        teams,  # default include_idp=False
+        min_my_gain_pct=0.0,
+        max_market_gain_pct=50.0,
     )
     # Desired player survives the gate.
     assert result["acquire"]["size"] == 1
@@ -1152,6 +1315,10 @@ def test_packages_include_idp_flag_surfaced_in_thresholds():
     result_off = find_angle_packages(players, offer, "owner-a", teams)
     assert result_off["thresholds"]["include_idp"] is False
     result_on = find_angle_packages(
-        players, offer, "owner-a", teams, include_idp=True,
+        players,
+        offer,
+        "owner-a",
+        teams,
+        include_idp=True,
     )
     assert result_on["thresholds"]["include_idp"] is True

--- a/tests/test_trade_finder.py
+++ b/tests/test_trade_finder.py
@@ -35,6 +35,7 @@ from src.trade.finder import (
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
+
 def _make_asset(name, model, ktc=None, pos="WR", team="NYJ", is_pick=False, source_count=0):
     return Asset(
         name=name,
@@ -69,6 +70,7 @@ def _make_sleeper_teams(teams_dict):
 
 # ── Position normalization ───────────────────────────────────────────────
 
+
 class TestNormPos:
     def test_basic(self):
         assert _norm_pos("QB") == "QB"
@@ -87,6 +89,7 @@ class TestNormPos:
 
 
 # ── Asset construction ───────────────────────────────────────────────────
+
 
 class TestBuildAssetPool:
     def test_basic_pool(self):
@@ -157,6 +160,7 @@ class TestBuildAssetPool:
 
 
 # ── Trade scoring ────────────────────────────────────────────────────────
+
 
 class TestScoreTrade:
     def test_positive_board_arbitrage_with_ktc_appeal(self):
@@ -236,7 +240,10 @@ class TestScoreTrade:
 
         # Partial: receive has one with KTC, one without
         give_partial = [_make_asset("C", model=4000, ktc=5000)]
-        recv_partial = [_make_asset("D", model=3000, ktc=3500), _make_asset("E", model=2000, ktc=None)]
+        recv_partial = [
+            _make_asset("D", model=3000, ktc=3500),
+            _make_asset("E", model=2000, ktc=None),
+        ]
         tc_partial = _score_trade(give_partial, recv_partial)
 
         assert tc_full is not None
@@ -275,6 +282,7 @@ class TestScoreTrade:
 
 # ── Strict positive opponent KTC gate ────────────────────────────────────
 
+
 class TestStrictPositiveOpponentKtc:
     """Opponent must STRICTLY WIN on KTC — no break-even, no loss."""
 
@@ -310,16 +318,14 @@ class TestStrictPositiveOpponentKtc:
     def test_partial_ktc_zero_appeal_rejected(self):
         """Partial KTC with zero opponent appeal → rejected."""
         give = [_make_asset("A", model=4000, ktc=3000)]
-        recv = [_make_asset("B", model=3000, ktc=3000),
-                _make_asset("C", model=2000, ktc=None)]
+        recv = [_make_asset("B", model=3000, ktc=3000), _make_asset("C", model=2000, ktc=None)]
         tc = _score_trade(give, recv)
         assert tc is None
 
     def test_partial_ktc_positive_appeal_allowed(self):
         """Partial KTC with positive opponent appeal → allowed."""
         give = [_make_asset("A", model=4000, ktc=5000)]
-        recv = [_make_asset("B", model=3000, ktc=3000),
-                _make_asset("C", model=2000, ktc=None)]
+        recv = [_make_asset("B", model=3000, ktc=3000), _make_asset("C", model=2000, ktc=None)]
         tc = _score_trade(give, recv)
         assert tc is not None
         assert tc.opponent_ktc_appeal > 0
@@ -327,8 +333,7 @@ class TestStrictPositiveOpponentKtc:
     def test_partial_ktc_negative_appeal_rejected(self):
         """Partial KTC with negative opponent appeal → rejected."""
         give = [_make_asset("A", model=4000, ktc=2500)]
-        recv = [_make_asset("B", model=3000, ktc=3000),
-                _make_asset("C", model=2000, ktc=None)]
+        recv = [_make_asset("B", model=3000, ktc=3000), _make_asset("C", model=2000, ktc=None)]
         tc = _score_trade(give, recv)
         assert tc is None
 
@@ -341,15 +346,17 @@ class TestStrictPositiveOpponentKtc:
             "Opp WR1": _make_player_data(5500, ktc=4500, pos="WR"),
             "Opp RB1": _make_player_data(4500, ktc=4000, pos="RB"),
         }
-        teams = _make_sleeper_teams({
-            "Me": ["My WR1", "My WR2", "My RB1"],
-            "Them": ["Opp WR1", "Opp RB1"],
-        })
+        teams = _make_sleeper_teams(
+            {
+                "Me": ["My WR1", "My WR2", "My RB1"],
+                "Them": ["Opp WR1", "Opp RB1"],
+            }
+        )
         result = find_trades(players, "Me", ["Them"], teams)
         for t in result["trades"]:
-            assert t["opponentKtcAppeal"] > 0, (
-                f"Trade has non-positive opponent KTC appeal: {t['opponentKtcAppeal']}"
-            )
+            assert (
+                t["opponentKtcAppeal"] > 0
+            ), f"Trade has non-positive opponent KTC appeal: {t['opponentKtcAppeal']}"
 
     def test_no_breaks_even_in_any_summary(self):
         """No trade summary should contain 'breaks even'."""
@@ -359,18 +366,21 @@ class TestStrictPositiveOpponentKtc:
             "Opp WR1": _make_player_data(5500, ktc=4500, pos="WR"),
             "Opp RB1": _make_player_data(4500, ktc=4000, pos="RB"),
         }
-        teams = _make_sleeper_teams({
-            "Me": ["My WR1", "My RB1"],
-            "Them": ["Opp WR1", "Opp RB1"],
-        })
+        teams = _make_sleeper_teams(
+            {
+                "Me": ["My WR1", "My RB1"],
+                "Them": ["Opp WR1", "Opp RB1"],
+            }
+        )
         result = find_trades(players, "Me", ["Them"], teams)
         for t in result["trades"]:
-            assert "breaks even" not in t["summary"], (
-                f"Summary contains 'breaks even': {t['summary']}"
-            )
+            assert (
+                "breaks even" not in t["summary"]
+            ), f"Summary contains 'breaks even': {t['summary']}"
 
 
 # ── Candidate generation ─────────────────────────────────────────────────
+
 
 class TestGenerate1for1:
     def test_generates_viable_trades(self):
@@ -419,6 +429,7 @@ class TestGenerate1for2:
 
 # ── Deduplication ────────────────────────────────────────────────────────
 
+
 class TestDeduplicate:
     def test_removes_duplicates(self):
         a = _make_asset("A", 4000, 5000)
@@ -439,6 +450,7 @@ class TestDeduplicate:
 
 
 # ── Roster resolution ────────────────────────────────────────────────────
+
 
 class TestResolveRoster:
     def test_resolves_team(self):
@@ -462,6 +474,7 @@ class TestResolveRoster:
 
 
 # ── End-to-end find_trades ───────────────────────────────────────────────
+
 
 class TestFindTrades:
     def _sample_players(self):
@@ -573,6 +586,7 @@ class TestFindTrades:
 
 # ── Source robustness and fire-sale guard regression tests ───────────────
 
+
 class TestSourceRobustness:
     """Test single-source discount and value fallback robustness."""
 
@@ -680,6 +694,7 @@ class TestFireSaleGuard:
 
 # ── Elite target protection ─────────────────────────────────────────────
 
+
 class TestEliteTargetProtection:
     """Verify that elite targets (≥7500 model) require tighter multi-for-one ratios."""
 
@@ -730,6 +745,7 @@ class TestEliteTargetProtection:
 
 # ── Package anchor quality ──────────────────────────────────────────────
 
+
 class TestPackageAnchorQuality:
     """Verify that multi-for-one requires at least one meaningful anchor piece."""
 
@@ -760,6 +776,7 @@ class TestPackageAnchorQuality:
 
 
 # ── Confidence scoring ──────────────────────────────────────────────────
+
 
 class TestConfidenceScoring:
     """Verify confidence factor impacts ranking."""
@@ -816,6 +833,7 @@ class TestConfidenceScoring:
 
 # ── Trade ranking realism ───────────────────────────────────────────────
 
+
 class TestTradeRankingRealism:
     """Verify that the ranking formula produces believable orderings."""
 
@@ -853,6 +871,7 @@ class TestTradeRankingRealism:
 
 # ── Roster-fit awareness ────────────────────────────────────────────────
 
+
 class TestRosterFit:
     """Verify light roster-fit bonus in end-to-end find_trades."""
 
@@ -879,8 +898,7 @@ class TestRosterFit:
         result = find_trades(players, "My Team", ["Rival"], teams)
         # Should have trades; giving WRs (surplus=4) should get fit bonus
         wr_give_trades = [
-            t for t in result["trades"]
-            if any(a["position"] == "WR" for a in t["give"])
+            t for t in result["trades"] if any(a["position"] == "WR" for a in t["give"])
         ]
         assert len(wr_give_trades) > 0
 
@@ -891,14 +909,14 @@ class TestRosterFit:
         result = find_trades(players, "My Team", ["Rival"], teams)
         # Check that some trades receiving RB or QB exist
         weakness_trades = [
-            t for t in result["trades"]
-            if any(a["position"] in ("RB", "QB") for a in t["receive"])
+            t for t in result["trades"] if any(a["position"] in ("RB", "QB") for a in t["receive"])
         ]
         # These should exist and be ranked well
         assert len(weakness_trades) > 0
 
 
 # ── Representative scenario validation (10+) ────────────────────────────
+
 
 class TestRepresentativeScenarios:
     """
@@ -1072,6 +1090,7 @@ class TestRepresentativeScenarios:
 
 # ── Explainability helpers ──────────────────────────────────────────────
 
+
 class TestConfidenceTier:
     def test_high(self):
         assert _confidence_tier(1.0) == "high"
@@ -1131,6 +1150,7 @@ class TestBuildSummary:
 
 # ── Explainability fields on TradeCandidate ─────────────────────────────
 
+
 class TestExplainabilityFields:
     """Verify that scored trades carry all explainability metadata."""
 
@@ -1169,8 +1189,10 @@ class TestExplainabilityFields:
     def test_partial_ktc_flags(self):
         """Partial coverage trade should have partial_ktc flag and lower confidence tier."""
         give = [_make_asset("A", model=4000, ktc=5000, source_count=2)]
-        recv = [_make_asset("B", model=3000, ktc=3000, source_count=1),
-                _make_asset("C", model=2000, ktc=None, source_count=1)]
+        recv = [
+            _make_asset("B", model=3000, ktc=3000, source_count=1),
+            _make_asset("C", model=2000, ktc=None, source_count=1),
+        ]
         tc = _score_trade(give, recv)
         assert tc is not None
         assert "partial_ktc" in tc.flags
@@ -1229,11 +1251,14 @@ class TestExplainabilityFields:
         rf = tc.ranking_factors
         # Core = (boardEdge + ktcAppeal + positiveBonus) * confidenceMultiplier + valueScale + simplicityPenalty
         core = rf["boardEdge"] + rf["ktcAppeal"] + rf["positiveBonus"]
-        reconstructed = core * rf["confidenceMultiplier"] + rf["valueScale"] + rf["simplicityPenalty"]
+        reconstructed = (
+            core * rf["confidenceMultiplier"] + rf["valueScale"] + rf["simplicityPenalty"]
+        )
         assert abs(reconstructed - tc.arbitrage_score) < 0.1
 
 
 # ── Roster-fit explainability ───────────────────────────────────────────
+
 
 class TestRosterFitExplainability:
     """Verify roster-fit bonus is visible in flags, ranking_factors, and summary."""
@@ -1249,8 +1274,7 @@ class TestRosterFitExplainability:
             "Opp QB Star": _make_player_data(5500, ktc=4500, pos="QB"),
         }
         teams = [
-            {"name": "My Team", "players": [
-                "My WR1", "My WR2", "My WR3", "My WR4", "My WR5"]},
+            {"name": "My Team", "players": ["My WR1", "My WR2", "My WR3", "My WR4", "My WR5"]},
             {"name": "Rival", "players": ["Opp QB Star"]},
         ]
         return players, teams
@@ -1283,6 +1307,7 @@ class TestRosterFitExplainability:
 
 # ── Before/after output examples ────────────────────────────────────────
 
+
 class TestBeforeAfterExplainability:
     """Document concrete before/after examples showing the new fields."""
 
@@ -1306,8 +1331,10 @@ class TestBeforeAfterExplainability:
     def test_example_low_confidence_partial_output(self):
         """Example: Low-confidence partial-KTC trade (receive side has at least one KTC)."""
         give = [_make_asset("Single", model=3000, ktc=4000, source_count=1)]
-        recv = [_make_asset("HasKTC", model=2500, ktc=2000, source_count=1),
-                _make_asset("NoKTC", model=1500, ktc=None, source_count=1)]
+        recv = [
+            _make_asset("HasKTC", model=2500, ktc=2000, source_count=1),
+            _make_asset("NoKTC", model=1500, ktc=None, source_count=1),
+        ]
         tc = _score_trade(give, recv)
         assert tc is not None
         d = tc.to_dict()
@@ -1325,6 +1352,7 @@ class TestBeforeAfterExplainability:
 
 
 # ── KTC quality guardrails ──────────────────────────────────────────────
+
 
 class TestKtcQualityGuardrails:
     """Tests for the new KTC quality gates added to fix recommendation trust."""
@@ -1421,6 +1449,7 @@ class TestKtcQualityGuardrails:
 
 # ── KTC Top-N Filter ───────────────────────────────────────────────────
 
+
 class TestKtcTopNFilter:
     """Verify the KTC top-150 quality gate in the finder engine."""
 
@@ -1433,7 +1462,9 @@ class TestKtcTopNFilter:
         for i in range(200):
             ktc = 9000 - i * 40
             players[f"Player_{i:03d}"] = _make_player_data(
-                model=ktc, ktc=ktc, pos="WR",
+                model=ktc,
+                ktc=ktc,
+                pos="WR",
             )
         pool = build_asset_pool(players, ktc_top_n=100)
         assert len(pool) == 100
@@ -1443,7 +1474,9 @@ class TestKtcTopNFilter:
         for i in range(200):
             ktc = 9000 - i * 40
             players[f"Player_{i:03d}"] = _make_player_data(
-                model=ktc, ktc=ktc, pos="WR",
+                model=ktc,
+                ktc=ktc,
+                pos="WR",
             )
         pool = build_asset_pool(players, ktc_top_n=0)
         assert len(pool) == 200
@@ -1476,12 +1509,17 @@ class TestKtcTopNFilter:
             f"P{i}": _make_player_data(5000 - i * 10, ktc=5000 - i * 10, pos="WR")
             for i in range(20)
         }
-        sleeper_teams = _make_sleeper_teams({
-            "MyTeam": [f"P{i}" for i in range(10)],
-            "TheirTeam": [f"P{i}" for i in range(10, 20)],
-        })
+        sleeper_teams = _make_sleeper_teams(
+            {
+                "MyTeam": [f"P{i}" for i in range(10)],
+                "TheirTeam": [f"P{i}" for i in range(10, 20)],
+            }
+        )
         result = find_trades(
-            players, "MyTeam", ["TheirTeam"], sleeper_teams,
+            players,
+            "MyTeam",
+            ["TheirTeam"],
+            sleeper_teams,
             ktc_top_n=50,
         )
         assert result["metadata"]["ktcTopNFilter"] == 50
@@ -1495,18 +1533,23 @@ class TestKtcTopNFilter:
             pos = ["QB", "RB", "WR", "TE"][i % 4]
             players[f"P{i:02d}"] = _make_player_data(model, ktc=ktc, pos=pos)
 
-        sleeper_teams = _make_sleeper_teams({
-            "Me": [f"P{i:02d}" for i in range(0, 25)],
-            "Them": [f"P{i:02d}" for i in range(25, 50)],
-        })
+        sleeper_teams = _make_sleeper_teams(
+            {
+                "Me": [f"P{i:02d}" for i in range(0, 25)],
+                "Them": [f"P{i:02d}" for i in range(25, 50)],
+            }
+        )
         result = find_trades(
-            players, "Me", ["Them"], sleeper_teams,
+            players,
+            "Me",
+            ["Them"],
+            sleeper_teams,
             ktc_top_n=30,
         )
         eligible_names = {f"P{i:02d}" for i in range(30)}
         for trade in result.get("trades", []):
             for side in ("give", "receive"):
                 for player in trade[side]:
-                    assert player["name"] in eligible_names, (
-                        f"{player['name']} in {side} is outside KTC top 30"
-                    )
+                    assert (
+                        player["name"] in eligible_names
+                    ), f"{player['name']} in {side} is outside KTC top 30"

--- a/tests/test_trade_suggestions.py
+++ b/tests/test_trade_suggestions.py
@@ -8,6 +8,7 @@ Validates:
 - Fairness labeling
 - Serialization
 """
+
 import pytest
 
 from src.trade.suggestions import (
@@ -45,8 +46,18 @@ from src.trade.suggestions import (
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
-def _make_asset(name, pos, cal_value, display_value=None, source_count=6,
-                team="", rookie=False, years_exp=None, source_values=None):
+
+def _make_asset(
+    name,
+    pos,
+    cal_value,
+    display_value=None,
+    source_count=6,
+    team="",
+    rookie=False,
+    years_exp=None,
+    source_values=None,
+):
     """Create a minimal canonical asset dict."""
     if display_value is None:
         display_value = max(1, round(cal_value * 9999 / 7800))
@@ -54,7 +65,8 @@ def _make_asset(name, pos, cal_value, display_value=None, source_count=6,
         "display_name": name,
         "calibrated_value": cal_value,
         "display_value": display_value,
-        "source_values": source_values or {f"src{i}": cal_value + i * 100 for i in range(source_count)},
+        "source_values": source_values
+        or {f"src{i}": cal_value + i * 100 for i in range(source_count)},
         "universe": "offense_vet" if pos in ("QB", "RB", "WR", "TE") else "idp_vet",
         "metadata": {
             "position": pos,
@@ -74,58 +86,79 @@ def _sample_snapshot():
     assets = []
     # QBs (need 2 starters)
     for name, val, team in [
-        ("Josh Allen", 7738, "BUF"), ("Lamar Jackson", 7552, "BAL"),
-        ("Joe Burrow", 7369, "CIN"), ("Drake Maye", 7583, "NE"),
-        ("Caleb Williams", 7279, "CHI"), ("Justin Herbert", 7219, "LAC"),
-        ("Tua Tagovailoa", 3897, "MIA"), ("Kirk Cousins", 2172, "ATL"),
+        ("Josh Allen", 7738, "BUF"),
+        ("Lamar Jackson", 7552, "BAL"),
+        ("Joe Burrow", 7369, "CIN"),
+        ("Drake Maye", 7583, "NE"),
+        ("Caleb Williams", 7279, "CHI"),
+        ("Justin Herbert", 7219, "LAC"),
+        ("Tua Tagovailoa", 3897, "MIA"),
+        ("Kirk Cousins", 2172, "ATL"),
     ]:
         assets.append(_make_asset(name, "QB", val, team=team))
 
     # RBs (need 3 starters)
     for name, val, team in [
-        ("Bijan Robinson", 7800, "ATL"), ("Jahmyr Gibbs", 7769, "DET"),
-        ("De'Von Achane", 7521, "MIA"), ("Jonathan Taylor", 7339, "IND"),
-        ("Ashton Jeanty", 7675, "LV"), ("Aaron Jones", 2674, "MIN"),
+        ("Bijan Robinson", 7800, "ATL"),
+        ("Jahmyr Gibbs", 7769, "DET"),
+        ("De'Von Achane", 7521, "MIA"),
+        ("Jonathan Taylor", 7339, "IND"),
+        ("Ashton Jeanty", 7675, "LV"),
+        ("Aaron Jones", 2674, "MIN"),
         ("Nick Chubb", 1450, "CLE"),
     ]:
         assets.append(_make_asset(name, "RB", val, team=team))
 
     # WRs (need 4 starters)
     for name, val, team in [
-        ("Ja'Marr Chase", 7460, "CIN"), ("Puka Nacua", 7309, "LAR"),
-        ("CeeDee Lamb", 7100, "DAL"), ("Amon-Ra St. Brown", 6900, "DET"),
-        ("Garrett Wilson", 5500, "NYJ"), ("Courtland Sutton", 3200, "DEN"),
-        ("Jaxon Smith-Njigba", 7399, "SEA"), ("Drake London", 6500, "ATL"),
+        ("Ja'Marr Chase", 7460, "CIN"),
+        ("Puka Nacua", 7309, "LAR"),
+        ("CeeDee Lamb", 7100, "DAL"),
+        ("Amon-Ra St. Brown", 6900, "DET"),
+        ("Garrett Wilson", 5500, "NYJ"),
+        ("Courtland Sutton", 3200, "DEN"),
+        ("Jaxon Smith-Njigba", 7399, "SEA"),
+        ("Drake London", 6500, "ATL"),
     ]:
         assets.append(_make_asset(name, "WR", val, team=team))
 
     # TEs (need 1 starter)
     for name, val, team in [
-        ("Brock Bowers", 7644, "LV"), ("Trey McBride", 7614, "ARI"),
-        ("Sam LaPorta", 5800, "DET"), ("Dalton Kincaid", 4500, "BUF"),
+        ("Brock Bowers", 7644, "LV"),
+        ("Trey McBride", 7614, "ARI"),
+        ("Sam LaPorta", 5800, "DET"),
+        ("Dalton Kincaid", 4500, "BUF"),
     ]:
         assets.append(_make_asset(name, "TE", val, team=team))
 
     # IDP DLs
     for name, val, team in [
-        ("Aidan Hutchinson", 5407, "DET"), ("Myles Garrett", 5314, "CLE"),
-        ("Nick Bosa", 4900, "SF"), ("Micah Parsons", 4800, "DAL"),
-        ("Chase Young", 3500, "NO"), ("Josh Hines-Allen", 4600, "JAX"),
+        ("Aidan Hutchinson", 5407, "DET"),
+        ("Myles Garrett", 5314, "CLE"),
+        ("Nick Bosa", 4900, "SF"),
+        ("Micah Parsons", 4800, "DAL"),
+        ("Chase Young", 3500, "NO"),
+        ("Josh Hines-Allen", 4600, "JAX"),
     ]:
         assets.append(_make_asset(name, "DL", val, team=team))
 
     # IDP LBs
     for name, val, team in [
-        ("Jack Campbell", 5012, "DET"), ("Roquan Smith", 4866, "BAL"),
-        ("Fred Warner", 4700, "SF"), ("Devin White", 2800, "PHI"),
-        ("Demario Davis", 1479, "NO"), ("Foyesade Oluokun", 3900, "JAX"),
+        ("Jack Campbell", 5012, "DET"),
+        ("Roquan Smith", 4866, "BAL"),
+        ("Fred Warner", 4700, "SF"),
+        ("Devin White", 2800, "PHI"),
+        ("Demario Davis", 1479, "NO"),
+        ("Foyesade Oluokun", 3900, "JAX"),
     ]:
         assets.append(_make_asset(name, "LB", val, team=team))
 
     # IDP DBs
     for name, val, team in [
-        ("Kyle Hamilton", 4779, "BAL"), ("Sauce Gardner", 4500, "NYJ"),
-        ("Patrick Surtain", 4200, "DEN"), ("Antoine Winfield", 3800, "TB"),
+        ("Kyle Hamilton", 4779, "BAL"),
+        ("Sauce Gardner", 4500, "NYJ"),
+        ("Patrick Surtain", 4200, "DEN"),
+        ("Antoine Winfield", 3800, "TB"),
     ]:
         assets.append(_make_asset(name, "DB", val, team=team))
 
@@ -133,6 +166,7 @@ def _sample_snapshot():
 
 
 # ── Tests ────────────────────────────────────────────────────────────
+
 
 class TestNormPos:
     def test_standard_positions(self):
@@ -164,29 +198,35 @@ class TestFairnessLabel:
 
 class TestBuildAssetPool:
     def test_builds_from_snapshot(self):
-        snap = _build_snapshot([
-            _make_asset("Player A", "QB", 7000),
-            _make_asset("Player B", "RB", 5000),
-        ])
+        snap = _build_snapshot(
+            [
+                _make_asset("Player A", "QB", 7000),
+                _make_asset("Player B", "RB", 5000),
+            ]
+        )
         pool = build_asset_pool(snap)
         assert len(pool) == 2
         assert pool[0].name == "Player A"
         assert pool[0].display_value > pool[1].display_value
 
     def test_skips_missing_fields(self):
-        snap = _build_snapshot([
-            {"display_name": "No Value"},
-            {"calibrated_value": 5000},
-        ])
+        snap = _build_snapshot(
+            [
+                {"display_name": "No Value"},
+                {"calibrated_value": 5000},
+            ]
+        )
         pool = build_asset_pool(snap)
         assert len(pool) == 0
 
     def test_sorted_by_display_value_desc(self):
-        snap = _build_snapshot([
-            _make_asset("Low", "WR", 1000),
-            _make_asset("High", "QB", 7000),
-            _make_asset("Mid", "RB", 4000),
-        ])
+        snap = _build_snapshot(
+            [
+                _make_asset("Low", "WR", 1000),
+                _make_asset("High", "QB", 7000),
+                _make_asset("Mid", "RB", 4000),
+            ]
+        )
         pool = build_asset_pool(snap)
         assert [p.name for p in pool] == ["High", "Mid", "Low"]
 
@@ -197,17 +237,27 @@ class TestAnalyzeRoster:
         pool = build_asset_pool(snap)
         # Roster heavy on QB, light on WR
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",  # 4 QBs
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",  # 3 RBs
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",  # 4 QBs
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",  # 3 RBs
             "Ja'Marr Chase",  # 1 WR (need 4)
-            "Brock Bowers",   # 1 TE
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",  # 3 DL
-            "Jack Campbell", "Roquan Smith", "Fred Warner",     # 3 LB
-            "Kyle Hamilton", "Sauce Gardner",                   # 2 DB
+            "Brock Bowers",  # 1 TE
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",  # 3 DL
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",  # 3 LB
+            "Kyle Hamilton",
+            "Sauce Gardner",  # 2 DB
         ]
         analysis = analyze_roster(roster, pool)
         assert "QB" in analysis.surplus_positions  # 4 QBs, need 2
-        assert "WR" in analysis.need_positions     # 1 WR, need 4
+        assert "WR" in analysis.need_positions  # 1 WR, need 4
 
     def test_empty_roster(self):
         snap = _sample_snapshot()
@@ -221,13 +271,23 @@ class TestGenerateSuggestions:
     def test_produces_suggestions(self):
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
         assert "rosterAnalysis" in result
@@ -242,13 +302,22 @@ class TestGenerateSuggestions:
         """Same inputs must produce identical outputs."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         r1 = generate_suggestions(roster, snap)
         r2 = generate_suggestions(roster, snap)
@@ -258,13 +327,24 @@ class TestGenerateSuggestions:
         snap = _sample_snapshot()
         # QB-heavy roster
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams", "Joe Burrow",
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Joe Burrow",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
         sell_high = result["sellHigh"]
@@ -276,13 +356,25 @@ class TestGenerateSuggestions:
     def test_consolidation_produces_upgrades(self):
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane", "Jonathan Taylor",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",
+            "Jonathan Taylor",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa", "Micah Parsons",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Micah Parsons",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
         consol = result["consolidation"]
@@ -294,16 +386,30 @@ class TestGenerateSuggestions:
     def test_suggestion_structure(self):
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
-        all_suggs = result["sellHigh"] + result["buyLow"] + result["consolidation"] + result["positionalUpgrades"]
+        all_suggs = (
+            result["sellHigh"]
+            + result["buyLow"]
+            + result["consolidation"]
+            + result["positionalUpgrades"]
+        )
         for s in all_suggs:
             assert "type" in s
             assert "give" in s
@@ -327,20 +433,36 @@ class TestGenerateSuggestions:
         """Suggestions should never have you trading for your own players."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         roster_set = {n.lower() for n in roster}
         result = generate_suggestions(roster, snap)
-        all_suggs = result["sellHigh"] + result["buyLow"] + result["consolidation"] + result["positionalUpgrades"]
+        all_suggs = (
+            result["sellHigh"]
+            + result["buyLow"]
+            + result["consolidation"]
+            + result["positionalUpgrades"]
+        )
         for s in all_suggs:
             for p in s["receive"]:
-                assert p["name"].lower() not in roster_set, f"{p['name']} is on roster but suggested as receive"
+                assert (
+                    p["name"].lower() not in roster_set
+                ), f"{p['name']} is on roster but suggested as receive"
 
     def test_empty_roster_no_crash(self):
         snap = _sample_snapshot()
@@ -350,6 +472,7 @@ class TestGenerateSuggestions:
 
 
 # ── Phase 2: Market-disagreement tests ───────────────────────────────
+
 
 class TestComputeCV:
     def test_uniform_values(self):
@@ -371,10 +494,14 @@ class TestComputeCV:
 class TestDispersionInPool:
     def test_dispersion_cv_computed(self):
         """Asset pool should compute dispersion_cv from source_values."""
-        snap = _build_snapshot([
-            _make_asset("Agreed", "QB", 7000, source_values={"a": 9000, "b": 9000, "c": 9000}),
-            _make_asset("Disputed", "RB", 5000, source_values={"a": 3000, "b": 7000, "c": 9000}),
-        ])
+        snap = _build_snapshot(
+            [
+                _make_asset("Agreed", "QB", 7000, source_values={"a": 9000, "b": 9000, "c": 9000}),
+                _make_asset(
+                    "Disputed", "RB", 5000, source_values={"a": 3000, "b": 7000, "c": 9000}
+                ),
+            ]
+        )
         pool = build_asset_pool(snap)
         agreed = next(p for p in pool if p.name == "Agreed")
         disputed = next(p for p in pool if p.name == "Disputed")
@@ -383,9 +510,11 @@ class TestDispersionInPool:
         assert disputed.dispersion_cv > agreed.dispersion_cv
 
     def test_single_source_no_cv(self):
-        snap = _build_snapshot([
-            _make_asset("Solo", "WR", 5000, source_values={"a": 5000}),
-        ])
+        snap = _build_snapshot(
+            [
+                _make_asset("Solo", "WR", 5000, source_values={"a": 5000}),
+            ]
+        )
         pool = build_asset_pool(snap)
         assert pool[0].dispersion_cv is None
 
@@ -395,17 +524,31 @@ class TestEdgeSignals:
         """Suggestions with high-dispersion targets should get edge labels."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
         # Edge fields should be present on suggestions that have them (or absent)
-        all_suggs = result["sellHigh"] + result["buyLow"] + result["consolidation"] + result["positionalUpgrades"]
+        all_suggs = (
+            result["sellHigh"]
+            + result["buyLow"]
+            + result["consolidation"]
+            + result["positionalUpgrades"]
+        )
         for s in all_suggs:
             if "edge" in s:
                 assert s["edge"] in ("market_discount", "market_premium", "high_dispersion")
@@ -421,30 +564,47 @@ class TestEdgeSignals:
 
 # ── Phase 3: Opponent-aware tests ────────────────────────────────────
 
+
 class TestOpponentAware:
     def test_opponent_fit_appears_when_rosters_provided(self):
         snap = _sample_snapshot()
         my_roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         # Opponent who needs QB and has WR surplus
         opponent_rosters = [
             {
                 "team_name": "Team RB Heavy",
                 "players": [
-                    "Tua Tagovailoa",                           # 1 QB (needs 2)
-                    "Jonathan Taylor", "Nick Chubb",            # RBs
-                    "Puka Nacua", "CeeDee Lamb", "Amon-Ra St. Brown",
-                    "Garrett Wilson", "Courtland Sutton",       # WR surplus
+                    "Tua Tagovailoa",  # 1 QB (needs 2)
+                    "Jonathan Taylor",
+                    "Nick Chubb",  # RBs
+                    "Puka Nacua",
+                    "CeeDee Lamb",
+                    "Amon-Ra St. Brown",
+                    "Garrett Wilson",
+                    "Courtland Sutton",  # WR surplus
                     "Trey McBride",
-                    "Chase Young", "Josh Hines-Allen",
-                    "Foyesade Oluokun", "Devin White",
+                    "Chase Young",
+                    "Josh Hines-Allen",
+                    "Foyesade Oluokun",
+                    "Devin White",
                     "Sauce Gardner",
                 ],
             },
@@ -454,7 +614,12 @@ class TestOpponentAware:
         assert result["metadata"]["opponentRostersAnalyzed"] >= 1
 
         # Check that at least some suggestions have opponentFit
-        all_suggs = result["sellHigh"] + result["buyLow"] + result["consolidation"] + result["positionalUpgrades"]
+        all_suggs = (
+            result["sellHigh"]
+            + result["buyLow"]
+            + result["consolidation"]
+            + result["positionalUpgrades"]
+        )
         fits = [s for s in all_suggs if "opponentFit" in s]
         # May or may not have fits depending on roster composition — just check no crash
         for s in fits:
@@ -464,13 +629,22 @@ class TestOpponentAware:
     def test_opponent_aware_still_deterministic(self):
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         opp = [{"team_name": "Opp", "players": ["Tua Tagovailoa", "Puka Nacua", "CeeDee Lamb"]}]
         r1 = generate_suggestions(roster, snap, league_rosters=opp)
@@ -490,10 +664,19 @@ class TestOpponentAware:
 
 # ── Phase 4: Ranking tests ──────────────────────────────────────────
 
+
 def _make_suggestion(
-    give_val=5000, recv_val=5200, fairness="even", confidence="high",
-    give_pos="RB", recv_pos="WR", give_name="Player A", recv_name="Player B",
-    strategy="neutral", edge=None, opponent_fit=None,
+    give_val=5000,
+    recv_val=5200,
+    fairness="even",
+    confidence="high",
+    give_pos="RB",
+    recv_pos="WR",
+    give_name="Player A",
+    recv_name="Player B",
+    strategy="neutral",
+    edge=None,
+    opponent_fit=None,
 ):
     """Helper to build a TradeSuggestion with optional enrichment."""
     s = TradeSuggestion(
@@ -571,8 +754,12 @@ class TestRankScore:
         s = _make_suggestion(edge="high_dispersion", opponent_fit="Team A")
         bd = rank_score_breakdown(s)
         expected = (
-            bd["base_value"] + bd["fairness"] + bd["confidence"]
-            + bd["need_severity"] + bd["edge"] + bd["opponent_fit"]
+            bd["base_value"]
+            + bd["fairness"]
+            + bd["confidence"]
+            + bd["need_severity"]
+            + bd["edge"]
+            + bd["opponent_fit"]
         )
         assert abs(bd["total"] - expected) < 0.01
 
@@ -583,8 +770,12 @@ class TestRankScore:
         expensive_bad: base=7.0 + fair=0 + conf=0 = 7.0
         Quality factors outweigh raw value.
         """
-        cheap_good = _make_suggestion(give_val=2500, recv_val=2600, fairness="even", confidence="high")
-        expensive_bad = _make_suggestion(give_val=7000, recv_val=9500, fairness="stretch", confidence="low")
+        cheap_good = _make_suggestion(
+            give_val=2500, recv_val=2600, fairness="even", confidence="high"
+        )
+        expensive_bad = _make_suggestion(
+            give_val=7000, recv_val=9500, fairness="stretch", confidence="low"
+        )
         assert rank_score(cheap_good) > rank_score(expensive_bad)
 
 
@@ -593,16 +784,30 @@ class TestRankingInOutput:
         """Every suggestion in output must include rankScore breakdown."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
-        all_suggs = result["sellHigh"] + result["buyLow"] + result["consolidation"] + result["positionalUpgrades"]
+        all_suggs = (
+            result["sellHigh"]
+            + result["buyLow"]
+            + result["consolidation"]
+            + result["positionalUpgrades"]
+        )
         for s in all_suggs:
             assert "rankScore" in s
             rs = s["rankScore"]
@@ -618,13 +823,23 @@ class TestRankingInOutput:
         """Within each category, suggestions must be ordered by rank score descending."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
         for cat in ["sellHigh", "buyLow", "consolidation", "positionalUpgrades"]:
@@ -633,21 +848,30 @@ class TestRankingInOutput:
                 continue
             scores = [s["rankScore"]["total"] for s in suggs]
             for i in range(len(scores) - 1):
-                assert scores[i] >= scores[i + 1], (
-                    f"{cat}[{i}] score {scores[i]} < [{i+1}] score {scores[i+1]}"
-                )
+                assert (
+                    scores[i] >= scores[i + 1]
+                ), f"{cat}[{i}] score {scores[i]} < [{i+1}] score {scores[i+1]}"
 
     def test_ranking_still_deterministic(self):
         """Ranked output must be identical across runs."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         r1 = generate_suggestions(roster, snap)
         r2 = generate_suggestions(roster, snap)
@@ -656,13 +880,22 @@ class TestRankingInOutput:
     def test_ranking_with_opponents_deterministic(self):
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         opp = [{"team_name": "Opp", "players": ["Tua Tagovailoa", "Puka Nacua", "CeeDee Lamb"]}]
         r1 = generate_suggestions(roster, snap, league_rosters=opp)
@@ -672,6 +905,7 @@ class TestRankingInOutput:
 
 # ── Phase 5: Quality filter tests ────────────────────────────────────
 
+
 class TestQualityFilters:
     def test_consolidation_stretches_removed(self):
         """Consolidation stretches with high overpay ratio are suppressed."""
@@ -679,19 +913,24 @@ class TestQualityFilters:
         s_even.type = "consolidation"
         # High overpay: give_total=5000, gap=+2000 → overpay 40% > 30% threshold
         s_stretch_bad = _make_suggestion(
-            fairness="stretch", give_val=5000, recv_val=3000,
-            give_name="Player C", recv_name="Player D",
+            fairness="stretch",
+            give_val=5000,
+            recv_val=3000,
+            give_name="Player C",
+            recv_name="Player D",
         )
         s_stretch_bad.type = "consolidation"
         s_lean = _make_suggestion(fairness="lean", give_name="Player E", recv_name="Player F")
         s_lean.type = "consolidation"
 
-        result = _apply_quality_filters({
-            "sell_high": [],
-            "buy_low": [],
-            "consolidation": [s_even, s_stretch_bad, s_lean],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [],
+                "consolidation": [s_even, s_stretch_bad, s_lean],
+                "positional_upgrade": [],
+            }
+        )
         consol = result["consolidation"]
         assert len(consol) == 2
         assert s_stretch_bad not in consol
@@ -699,15 +938,16 @@ class TestQualityFilters:
     def test_receive_target_cap(self):
         """Max 2 suggestions per receive-target within a category."""
         suggs = [
-            _make_suggestion(give_name=f"Seller {i}", recv_name="Same Target")
-            for i in range(5)
+            _make_suggestion(give_name=f"Seller {i}", recv_name="Same Target") for i in range(5)
         ]
-        result = _apply_quality_filters({
-            "sell_high": suggs,
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": suggs,
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == MAX_RECEIVE_TARGET_PER_CATEGORY
 
     def test_low_confidence_cap(self):
@@ -718,12 +958,14 @@ class TestQualityFilters:
         ]
         # Add one high-conf to verify it's not affected
         high = _make_suggestion(confidence="high", give_name="High Guy", recv_name="High Target")
-        result = _apply_quality_filters({
-            "sell_high": [high] + suggs,
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [high] + suggs,
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         low_count = sum(1 for s in result["sell_high"] if s.confidence == "low")
         assert low_count == MAX_LOW_CONFIDENCE_PER_CATEGORY
         # High-conf still present
@@ -733,23 +975,22 @@ class TestQualityFilters:
         """A player appearing as give in sell_high should count toward their
         cap in buy_low too."""
         # 2 sell_high suggestions giving Player A (fills cap at 2)
-        sell = [
-            _make_suggestion(give_name="Player A", recv_name=f"Target {i}")
-            for i in range(2)
-        ]
+        sell = [_make_suggestion(give_name="Player A", recv_name=f"Target {i}") for i in range(2)]
         # 2 more in buy_low giving Player A — should be blocked
         buy = [
-            _make_suggestion(give_name="Player A", recv_name=f"Buy Target {i}")
-            for i in range(2)
+            _make_suggestion(give_name="Player A", recv_name=f"Buy Target {i}") for i in range(2)
         ]
-        result = _apply_quality_filters({
-            "sell_high": sell,
-            "buy_low": buy,
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": sell,
+                "buy_low": buy,
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         total_a = sum(
-            1 for s in result["sell_high"] + result["buy_low"]
+            1
+            for s in result["sell_high"] + result["buy_low"]
             if any(p.name == "Player A" for p in s.give)
         )
         assert total_a <= MAX_GIVE_PLAYER_APPEARANCES
@@ -768,36 +1009,49 @@ class TestQualityFilters:
         consol_3.type = "consolidation"
         consol_3.give.append(PlayerAsset("Player D", "RB", 3000, 3000, source_count=6))
 
-        result = _apply_quality_filters({
-            "sell_high": [],
-            "buy_low": [],
-            "consolidation": [consol_1, consol_2, consol_3],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [],
+                "consolidation": [consol_1, consol_2, consol_3],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["consolidation"]) == 2
 
     def test_filters_preserve_order(self):
         """Filters should never reorder; only remove."""
         suggs = [
-            _make_suggestion(give_name=f"Player {i}", recv_name=f"Target {i}", give_val=9000 - i * 100)
+            _make_suggestion(
+                give_name=f"Player {i}", recv_name=f"Target {i}", give_val=9000 - i * 100
+            )
             for i in range(6)
         ]
-        result = _apply_quality_filters({
-            "sell_high": suggs,
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": suggs,
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         vals = [s.give_total for s in result["sell_high"]]
         assert vals == sorted(vals, reverse=True)
 
     def test_quality_filters_deterministic(self):
         """Same inputs to quality filter produce same outputs."""
         suggs = [
-            _make_suggestion(give_name=f"P{i}", recv_name=f"T{i}", confidence=("low" if i > 3 else "high"))
+            _make_suggestion(
+                give_name=f"P{i}", recv_name=f"T{i}", confidence=("low" if i > 3 else "high")
+            )
             for i in range(6)
         ]
-        cats = {"sell_high": list(suggs), "buy_low": [], "consolidation": [], "positional_upgrade": []}
+        cats = {
+            "sell_high": list(suggs),
+            "buy_low": [],
+            "consolidation": [],
+            "positional_upgrade": [],
+        }
         r1 = _apply_quality_filters(dict(cats))
         r2 = _apply_quality_filters(dict(cats))
         assert len(r1["sell_high"]) == len(r2["sell_high"])
@@ -810,36 +1064,53 @@ class TestQualityFilters:
         # Build an IDP-heavy roster from sample data
         roster = [
             "Joe Burrow",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa", "Micah Parsons",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Micah Parsons",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
         from collections import Counter
+
         freq = Counter()
         for cat in ["sellHigh", "buyLow", "consolidation", "positionalUpgrades"]:
             for s in result[cat]:
                 for p in s["give"]:
                     freq[p["name"]] += 1
         if freq:
-            assert freq.most_common(1)[0][1] <= MAX_GIVE_PLAYER_APPEARANCES, (
-                f"{freq.most_common(1)[0][0]} appears {freq.most_common(1)[0][1]}x as give"
-            )
+            assert (
+                freq.most_common(1)[0][1] <= MAX_GIVE_PLAYER_APPEARANCES
+            ), f"{freq.most_common(1)[0][0]} appears {freq.most_common(1)[0][1]}x as give"
 
     def test_filtered_output_still_deterministic(self):
         """Full pipeline with filters must remain deterministic."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         r1 = generate_suggestions(roster, snap)
         r2 = generate_suggestions(roster, snap)
@@ -848,54 +1119,69 @@ class TestQualityFilters:
 
 # ── Phase 2A: Noise suppression filter tests ─────────────────────────
 
+
 class TestFairButWeakFilter:
     """Filter 4: suppress trades where both sides are below MIN_ACTIONABLE_VALUE."""
 
     def test_both_sides_low_value_suppressed(self):
         """Two low-value players trading — not worth the conversation."""
         s_low = _make_suggestion(
-            give_val=1500, recv_val=1600,
-            give_name="Scrub A", recv_name="Scrub B",
+            give_val=1500,
+            recv_val=1600,
+            give_name="Scrub A",
+            recv_name="Scrub B",
         )
         s_high = _make_suggestion(
-            give_val=6000, recv_val=6200,
-            give_name="Star A", recv_name="Star B",
+            give_val=6000,
+            recv_val=6200,
+            give_name="Star A",
+            recv_name="Star B",
         )
-        result = _apply_quality_filters({
-            "sell_high": [s_high, s_low],
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [s_high, s_low],
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 1
         assert result["sell_high"][0].give[0].name == "Star A"
 
     def test_one_side_above_threshold_kept(self):
         """If one side is above MIN_ACTIONABLE_VALUE, the trade is kept."""
         s = _make_suggestion(
-            give_val=1500, recv_val=3000,
-            give_name="Depth", recv_name="Starter",
+            give_val=1500,
+            recv_val=3000,
+            give_name="Depth",
+            recv_name="Starter",
         )
-        result = _apply_quality_filters({
-            "sell_high": [s],
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [s],
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 1
 
     def test_exactly_at_threshold_kept(self):
         """Players at exactly MIN_ACTIONABLE_VALUE are kept."""
         s = _make_suggestion(
-            give_val=MIN_ACTIONABLE_VALUE, recv_val=MIN_ACTIONABLE_VALUE,
-            give_name="Border A", recv_name="Border B",
+            give_val=MIN_ACTIONABLE_VALUE,
+            recv_val=MIN_ACTIONABLE_VALUE,
+            give_name="Border A",
+            recv_name="Border B",
         )
-        result = _apply_quality_filters({
-            "sell_high": [s],
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [s],
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 1
 
 
@@ -905,62 +1191,82 @@ class TestSameTierSwapFilter:
     def test_same_pos_close_value_suppressed(self):
         """WR-for-WR within 200 value — lateral move, no strategic gain."""
         s = _make_suggestion(
-            give_val=5000, recv_val=5200,
-            give_pos="WR", recv_pos="WR",
-            give_name="WR A", recv_name="WR B",
+            give_val=5000,
+            recv_val=5200,
+            give_pos="WR",
+            recv_pos="WR",
+            give_name="WR A",
+            recv_name="WR B",
         )
-        result = _apply_quality_filters({
-            "sell_high": [s],
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [s],
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 0
 
     def test_same_pos_large_gap_kept(self):
         """WR-for-WR with 600 value difference — meaningful upgrade, kept."""
         s = _make_suggestion(
-            give_val=5000, recv_val=5600,
-            give_pos="WR", recv_pos="WR",
-            give_name="WR A", recv_name="WR B",
+            give_val=5000,
+            recv_val=5600,
+            give_pos="WR",
+            recv_pos="WR",
+            give_name="WR A",
+            recv_name="WR B",
         )
-        result = _apply_quality_filters({
-            "sell_high": [s],
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [s],
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 1
 
     def test_different_pos_close_value_kept(self):
         """RB-for-WR within 200 value — cross-position, has strategic value."""
         s = _make_suggestion(
-            give_val=5000, recv_val=5200,
-            give_pos="RB", recv_pos="WR",
-            give_name="RB Guy", recv_name="WR Guy",
+            give_val=5000,
+            recv_val=5200,
+            give_pos="RB",
+            recv_pos="WR",
+            give_name="RB Guy",
+            recv_name="WR Guy",
         )
-        result = _apply_quality_filters({
-            "sell_high": [s],
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [s],
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 1
 
     def test_multi_player_trade_not_affected(self):
         """2-for-1 trades are never caught by same-tier filter."""
         s = _make_suggestion(
-            give_val=5000, recv_val=5200,
-            give_pos="WR", recv_pos="WR",
-            give_name="WR A", recv_name="WR B",
+            give_val=5000,
+            recv_val=5200,
+            give_pos="WR",
+            recv_pos="WR",
+            give_name="WR A",
+            recv_name="WR B",
         )
         s.give.append(PlayerAsset("WR C", "WR", 2000, 2000, source_count=6))
-        result = _apply_quality_filters({
-            "sell_high": [s],
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [s],
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 1
 
 
@@ -970,67 +1276,77 @@ class TestNearMiss1For1Filter:
     def test_big_gap_with_balancers_suppressed(self):
         """Gap > MAX_GAP_FOR_1FOR1 with balancers = should be a package deal."""
         s = _make_suggestion(
-            give_val=6000, recv_val=6600,
-            give_name="Player A", recv_name="Player B",
+            give_val=6000,
+            recv_val=6600,
+            give_name="Player A",
+            recv_name="Player B",
         )
-        s.__dict__["balancers"] = [
-            PlayerAsset("Filler", "WR", 600, 600, source_count=4)
-        ]
-        result = _apply_quality_filters({
-            "sell_high": [],
-            "buy_low": [s],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        s.__dict__["balancers"] = [PlayerAsset("Filler", "WR", 600, 600, source_count=4)]
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [s],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["buy_low"]) == 0
 
     def test_small_gap_with_balancers_kept(self):
         """Gap <= MAX_GAP_FOR_1FOR1 with balancers — close enough, keep it."""
         s = _make_suggestion(
-            give_val=6000, recv_val=6300,
-            give_name="Player A", recv_name="Player B",
+            give_val=6000,
+            recv_val=6300,
+            give_name="Player A",
+            recv_name="Player B",
         )
-        s.__dict__["balancers"] = [
-            PlayerAsset("Filler", "WR", 300, 300, source_count=4)
-        ]
-        result = _apply_quality_filters({
-            "sell_high": [],
-            "buy_low": [s],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        s.__dict__["balancers"] = [PlayerAsset("Filler", "WR", 300, 300, source_count=4)]
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [s],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["buy_low"]) == 1
 
     def test_big_gap_no_balancers_kept(self):
         """Gap > MAX_GAP_FOR_1FOR1 but no balancers — engine didn't flag it."""
         s = _make_suggestion(
-            give_val=6000, recv_val=6600,
-            give_name="Player A", recv_name="Player B",
+            give_val=6000,
+            recv_val=6600,
+            give_name="Player A",
+            recv_name="Player B",
         )
-        result = _apply_quality_filters({
-            "sell_high": [],
-            "buy_low": [s],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [s],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["buy_low"]) == 1
 
     def test_multi_player_trade_not_affected(self):
         """2-for-1 with gap and balancers — not a 1-for-1, keep it."""
         s = _make_suggestion(
-            give_val=6000, recv_val=6600,
-            give_name="Player A", recv_name="Player B",
+            give_val=6000,
+            recv_val=6600,
+            give_name="Player A",
+            recv_name="Player B",
         )
         s.give.append(PlayerAsset("Player C", "RB", 500, 500, source_count=4))
-        s.__dict__["balancers"] = [
-            PlayerAsset("Filler", "WR", 600, 600, source_count=4)
-        ]
-        result = _apply_quality_filters({
-            "sell_high": [],
-            "buy_low": [s],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        s.__dict__["balancers"] = [PlayerAsset("Filler", "WR", 600, 600, source_count=4)]
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [s],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["buy_low"]) == 1
 
 
@@ -1042,20 +1358,16 @@ class TestTightenedGivePlayerCap:
 
     def test_third_appearance_blocked(self):
         """Player A appearing 3x in sell_high — only first 2 survive."""
-        suggs = [
-            _make_suggestion(give_name="Player A", recv_name=f"Target {i}")
-            for i in range(3)
-        ]
-        result = _apply_quality_filters({
-            "sell_high": suggs,
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
-        total_a = sum(
-            1 for s in result["sell_high"]
-            if any(p.name == "Player A" for p in s.give)
+        suggs = [_make_suggestion(give_name="Player A", recv_name=f"Target {i}") for i in range(3)]
+        result = _apply_quality_filters(
+            {
+                "sell_high": suggs,
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
         )
+        total_a = sum(1 for s in result["sell_high"] if any(p.name == "Player A" for p in s.give))
         assert total_a == 2
 
     def test_different_players_unaffected(self):
@@ -1066,12 +1378,14 @@ class TestTightenedGivePlayerCap:
             _make_suggestion(give_name="Player B", recv_name="T3"),
             _make_suggestion(give_name="Player B", recv_name="T4"),
         ]
-        result = _apply_quality_filters({
-            "sell_high": suggs,
-            "buy_low": [],
-            "consolidation": [],
-            "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": suggs,
+                "buy_low": [],
+                "consolidation": [],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["sell_high"]) == 4
 
 
@@ -1081,13 +1395,23 @@ class TestNewFiltersDeterministic:
     def test_full_pipeline_deterministic(self):
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         r1 = generate_suggestions(roster, snap)
         r2 = generate_suggestions(roster, snap)
@@ -1096,19 +1420,30 @@ class TestNewFiltersDeterministic:
 
 # ── Phase 2B: Balancer improvement tests ─────────────────────────────
 
+
 def _make_pool_and_roster():
     """Build a test pool and roster with known depth for balancer testing."""
     snap = _sample_snapshot()
     pool = build_asset_pool(snap)
     # QB-heavy roster with known surplus
     roster_names = [
-        "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",  # 4 QB (need 2 → 2 depth)
-        "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",  # 3 RB (need 3 → 0 depth)
-        "Ja'Marr Chase",                                     # 1 WR (need 4 → deficit)
-        "Brock Bowers",                                      # 1 TE
-        "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",   # 3 DL
-        "Jack Campbell", "Roquan Smith", "Fred Warner",      # 3 LB
-        "Kyle Hamilton", "Sauce Gardner",                    # 2 DB
+        "Josh Allen",
+        "Lamar Jackson",
+        "Drake Maye",
+        "Caleb Williams",  # 4 QB (need 2 → 2 depth)
+        "Bijan Robinson",
+        "Jahmyr Gibbs",
+        "De'Von Achane",  # 3 RB (need 3 → 0 depth)
+        "Ja'Marr Chase",  # 1 WR (need 4 → deficit)
+        "Brock Bowers",  # 1 TE
+        "Aidan Hutchinson",
+        "Myles Garrett",
+        "Nick Bosa",  # 3 DL
+        "Jack Campbell",
+        "Roquan Smith",
+        "Fred Warner",  # 3 LB
+        "Kyle Hamilton",
+        "Sauce Gardner",  # 2 DB
     ]
     roster = analyze_roster(roster_names, pool)
     roster_set = {n.lower() for n in roster_names}
@@ -1278,18 +1613,29 @@ class TestBalancerSideSerialization:
         """Suggestions with balancers should include balancerSide."""
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         result = generate_suggestions(roster, snap)
         all_suggs = (
-            result["sellHigh"] + result["buyLow"]
-            + result["consolidation"] + result["positionalUpgrades"]
+            result["sellHigh"]
+            + result["buyLow"]
+            + result["consolidation"]
+            + result["positionalUpgrades"]
         )
         for s in all_suggs:
             if "suggestedBalancers" in s:
@@ -1309,13 +1655,22 @@ class TestBalancerDeterminism:
     def test_full_pipeline_with_balancers_deterministic(self):
         snap = _sample_snapshot()
         roster = [
-            "Josh Allen", "Lamar Jackson", "Drake Maye", "Caleb Williams",
-            "Bijan Robinson", "Jahmyr Gibbs",
+            "Josh Allen",
+            "Lamar Jackson",
+            "Drake Maye",
+            "Caleb Williams",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
             "Ja'Marr Chase",
             "Brock Bowers",
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",
-            "Jack Campbell", "Roquan Smith", "Fred Warner",
-            "Kyle Hamilton", "Sauce Gardner",
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",
+            "Kyle Hamilton",
+            "Sauce Gardner",
         ]
         r1 = generate_suggestions(roster, snap)
         r2 = generate_suggestions(roster, snap)
@@ -1323,6 +1678,7 @@ class TestBalancerDeterminism:
 
 
 # ── Phase 2C: Package logic tests ────────────────────────────────────
+
 
 class TestConsolidationClosestValueTarget:
     """Consolidation should target closest-value match, not highest value."""
@@ -1333,17 +1689,33 @@ class TestConsolidationClosestValueTarget:
         pool = build_asset_pool(snap)
         # IDP-stacked roster with deep DL/LB surplus
         idp = [
-            "Bo Nix", "TreVeyon Henderson", "Cameron Skattebo",
-            "George Pickens", "Ladd McConkey", "Dalton Kincaid",
-            "Aidan Hutchinson", "Will Anderson", "Micah Parsons",
-            "Myles Garrett", "Maxx Crosby", "Abdul Carter", "Jared Verse",
-            "Nik Bonitto", "Nathan Landman", "Arvell Reese", "Sonny Styles",
-            "Jack Campbell", "Carson Schwesinger", "David Bailey",
-            "Roquan Smith", "Ernest Jones",
+            "Bo Nix",
+            "TreVeyon Henderson",
+            "Cameron Skattebo",
+            "George Pickens",
+            "Ladd McConkey",
+            "Dalton Kincaid",
+            "Aidan Hutchinson",
+            "Will Anderson",
+            "Micah Parsons",
+            "Myles Garrett",
+            "Maxx Crosby",
+            "Abdul Carter",
+            "Jared Verse",
+            "Nik Bonitto",
+            "Nathan Landman",
+            "Arvell Reese",
+            "Sonny Styles",
+            "Jack Campbell",
+            "Carson Schwesinger",
+            "David Bailey",
+            "Roquan Smith",
+            "Ernest Jones",
         ]
         roster = analyze_roster(idp, pool)
         roster_set = {n.lower() for n in idp}
         from src.trade.suggestions import _generate_consolidation
+
         results = _generate_consolidation(roster, pool, roster_set)
         if results:
             # Each suggestion should target the closest value match
@@ -1361,10 +1733,14 @@ class TestConsolidationStretchFilter:
         s = _make_suggestion(fairness="stretch", give_val=10000, recv_val=8000)
         s.type = "consolidation"
         # gap = 10000 - 8000 = +2000, ratio = 2000/10000 = 20%
-        result = _apply_quality_filters({
-            "sell_high": [], "buy_low": [],
-            "consolidation": [s], "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [],
+                "consolidation": [s],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["consolidation"]) == 1
 
     def test_high_overpay_stretch_blocked(self):
@@ -1372,10 +1748,14 @@ class TestConsolidationStretchFilter:
         s = _make_suggestion(fairness="stretch", give_val=10000, recv_val=5000)
         s.type = "consolidation"
         # gap = 10000 - 5000 = +5000, ratio = 5000/10000 = 50%
-        result = _apply_quality_filters({
-            "sell_high": [], "buy_low": [],
-            "consolidation": [s], "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [],
+                "consolidation": [s],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["consolidation"]) == 0
 
     def test_even_and_lean_still_pass(self):
@@ -1384,10 +1764,14 @@ class TestConsolidationStretchFilter:
         s_even.type = "consolidation"
         s_lean = _make_suggestion(fairness="lean", give_name="P2", recv_name="P3")
         s_lean.type = "consolidation"
-        result = _apply_quality_filters({
-            "sell_high": [], "buy_low": [],
-            "consolidation": [s_even, s_lean], "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [],
+                "consolidation": [s_even, s_lean],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["consolidation"]) == 2
 
 
@@ -1415,9 +1799,7 @@ class TestVaAwareGap:
         raw_gap = (4900 + 4800) - 9600  # +100, "even" on raw
         assert abs(raw_gap) < 256
         va = _va_gap([4900, 4800], [9600])
-        assert va < -769, (
-            f"expected a VA-lopsided gap, got {va} (raw was {raw_gap})"
-        )
+        assert va < -769, f"expected a VA-lopsided gap, got {va} (raw was {raw_gap})"
 
     def test_user_favorable_va_stretch_is_filtered(self):
         """A consolidation whose VA gap lands hugely in the user's
@@ -1428,10 +1810,14 @@ class TestVaAwareGap:
         s.type = "consolidation"
         s.give.append(PlayerAsset("Depth Piece", "WR", 4000, 4000, source_count=6))
         s.gap = -4712  # VA gap: opponent grossly overpays — no one accepts
-        result = _apply_quality_filters({
-            "sell_high": [], "buy_low": [],
-            "consolidation": [s], "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [],
+                "consolidation": [s],
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["consolidation"]) == 0
 
 
@@ -1448,10 +1834,14 @@ class TestSeparateGivePlayerBudgets:
         consol.type = "consolidation"
         consol.give.append(PlayerAsset("Player B", "RB", 3000, 3000, source_count=6))
 
-        result = _apply_quality_filters({
-            "sell_high": sell, "buy_low": [],
-            "consolidation": [consol], "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": sell,
+                "buy_low": [],
+                "consolidation": [consol],
+                "positional_upgrade": [],
+            }
+        )
         # Consolidation should survive — separate budget
         assert len(result["consolidation"]) == 1
 
@@ -1464,10 +1854,14 @@ class TestSeparateGivePlayerBudgets:
             s.give.append(PlayerAsset(f"Partner {i}", "RB", 3000, 3000, source_count=6))
             consols.append(s)
 
-        result = _apply_quality_filters({
-            "sell_high": [], "buy_low": [],
-            "consolidation": consols, "positional_upgrade": [],
-        })
+        result = _apply_quality_filters(
+            {
+                "sell_high": [],
+                "buy_low": [],
+                "consolidation": consols,
+                "positional_upgrade": [],
+            }
+        )
         assert len(result["consolidation"]) == MAX_GIVE_PLAYER_APPEARANCES
 
 
@@ -1481,14 +1875,23 @@ class TestConsolidationInLiveOutput:
         # Build a roster with deep LB surplus (mid-range depth, not elite)
         # so that pairs fall in range of real targets.
         roster_names = [
-            "Josh Allen",                                        # QB
-            "Bijan Robinson", "Jahmyr Gibbs", "De'Von Achane",  # RB
-            "Ja'Marr Chase",                                     # WR
-            "Brock Bowers",                                      # TE
-            "Aidan Hutchinson", "Myles Garrett", "Nick Bosa",   # DL starters
-            "Jack Campbell", "Roquan Smith", "Fred Warner",      # LB starters (need 3)
-            "Nathan Landman", "Jordyn Brooks", "Nick Bolton",    # LB surplus
-            "Kyle Hamilton", "Sauce Gardner",                    # DB
+            "Josh Allen",  # QB
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "De'Von Achane",  # RB
+            "Ja'Marr Chase",  # WR
+            "Brock Bowers",  # TE
+            "Aidan Hutchinson",
+            "Myles Garrett",
+            "Nick Bosa",  # DL starters
+            "Jack Campbell",
+            "Roquan Smith",
+            "Fred Warner",  # LB starters (need 3)
+            "Nathan Landman",
+            "Jordyn Brooks",
+            "Nick Bolton",  # LB surplus
+            "Kyle Hamilton",
+            "Sauce Gardner",  # DB
         ]
         result = generate_suggestions(roster_names, snap)
         cons = result["consolidation"]
@@ -1502,12 +1905,25 @@ class TestConsolidationInLiveOutput:
         """Rosters with all-elite surplus correctly get 0 packages."""
         snap = _sample_snapshot()
         rb_heavy = [
-            "Lamar Jackson", "Bijan Robinson", "Jahmyr Gibbs",
-            "Ashton Jeanty", "De'Von Achane", "Jonathan Taylor",
-            "James Cook", "Breece Hall", "Kenneth Walker",
-            "Chris Olave", "Garrett Wilson", "Tucker Kraft",
-            "Maxx Crosby", "Will Anderson", "Myles Garrett", "Jared Verse",
-            "Ernest Jones", "Jordyn Brooks", "Nick Bolton",
+            "Lamar Jackson",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "Ashton Jeanty",
+            "De'Von Achane",
+            "Jonathan Taylor",
+            "James Cook",
+            "Breece Hall",
+            "Kenneth Walker",
+            "Chris Olave",
+            "Garrett Wilson",
+            "Tucker Kraft",
+            "Maxx Crosby",
+            "Will Anderson",
+            "Myles Garrett",
+            "Jared Verse",
+            "Ernest Jones",
+            "Jordyn Brooks",
+            "Nick Bolton",
         ]
         result = generate_suggestions(rb_heavy, snap)
         assert len(result["consolidation"]) == 0
@@ -1516,12 +1932,25 @@ class TestConsolidationInLiveOutput:
         """Existing 1-for-1 sell_high suggestions are unchanged."""
         snap = _sample_snapshot()
         roster = [
-            "Lamar Jackson", "Bijan Robinson", "Jahmyr Gibbs",
-            "Ashton Jeanty", "De'Von Achane", "Jonathan Taylor",
-            "James Cook", "Breece Hall", "Kenneth Walker",
-            "Chris Olave", "Garrett Wilson", "Tucker Kraft",
-            "Maxx Crosby", "Will Anderson", "Myles Garrett", "Jared Verse",
-            "Ernest Jones", "Jordyn Brooks", "Nick Bolton",
+            "Lamar Jackson",
+            "Bijan Robinson",
+            "Jahmyr Gibbs",
+            "Ashton Jeanty",
+            "De'Von Achane",
+            "Jonathan Taylor",
+            "James Cook",
+            "Breece Hall",
+            "Kenneth Walker",
+            "Chris Olave",
+            "Garrett Wilson",
+            "Tucker Kraft",
+            "Maxx Crosby",
+            "Will Anderson",
+            "Myles Garrett",
+            "Jared Verse",
+            "Ernest Jones",
+            "Jordyn Brooks",
+            "Nick Bolton",
         ]
         result = generate_suggestions(roster, snap)
         assert len(result["sellHigh"]) > 0, "sell_high should still have suggestions"
@@ -1536,13 +1965,28 @@ class TestPackageDeterminism:
     def test_deterministic_with_consolidation(self):
         snap = _sample_snapshot()
         idp = [
-            "Bo Nix", "TreVeyon Henderson", "Cameron Skattebo",
-            "George Pickens", "Ladd McConkey", "Dalton Kincaid",
-            "Aidan Hutchinson", "Will Anderson", "Micah Parsons",
-            "Myles Garrett", "Maxx Crosby", "Abdul Carter", "Jared Verse",
-            "Nik Bonitto", "Nathan Landman", "Arvell Reese", "Sonny Styles",
-            "Jack Campbell", "Carson Schwesinger", "David Bailey",
-            "Roquan Smith", "Ernest Jones",
+            "Bo Nix",
+            "TreVeyon Henderson",
+            "Cameron Skattebo",
+            "George Pickens",
+            "Ladd McConkey",
+            "Dalton Kincaid",
+            "Aidan Hutchinson",
+            "Will Anderson",
+            "Micah Parsons",
+            "Myles Garrett",
+            "Maxx Crosby",
+            "Abdul Carter",
+            "Jared Verse",
+            "Nik Bonitto",
+            "Nathan Landman",
+            "Arvell Reese",
+            "Sonny Styles",
+            "Jack Campbell",
+            "Carson Schwesinger",
+            "David Bailey",
+            "Roquan Smith",
+            "Ernest Jones",
         ]
         r1 = generate_suggestions(idp, snap)
         r2 = generate_suggestions(idp, snap)
@@ -1550,6 +1994,7 @@ class TestPackageDeterminism:
 
 
 # ── KTC Top-N Filter ───────────────────────────────────────────────────
+
 
 class TestKtcTopNFilter:
     """Verify the KTC top-150 quality gate in the suggestions engine."""
@@ -1560,11 +2005,15 @@ class TestKtcTopNFilter:
         for i in range(n):
             val = 9000 - i * 40
             pos = ["QB", "RB", "WR", "TE"][i % 4]
-            assets.append(_make_asset(
-                f"Player_{i:03d}", pos, val,
-                display_value=val,
-                source_count=6,
-            ))
+            assets.append(
+                _make_asset(
+                    f"Player_{i:03d}",
+                    pos,
+                    val,
+                    display_value=val,
+                    source_count=6,
+                )
+            )
         return _build_snapshot(assets)
 
     def test_default_filter_is_150(self):
@@ -1614,12 +2063,11 @@ class TestKtcTopNFilter:
         for s in all_suggestions:
             for side in ("give", "receive"):
                 for player in s[side]:
-                    assert player.get("ktcRank") is not None, (
-                        f"{player['name']} in {side} has no ktcRank"
-                    )
+                    assert (
+                        player.get("ktcRank") is not None
+                    ), f"{player['name']} in {side} has no ktcRank"
                     assert player["ktcRank"] <= 100, (
-                        f"{player['name']} ranked {player['ktcRank']} — "
-                        f"outside top 100 filter"
+                        f"{player['name']} ranked {player['ktcRank']} — " f"outside top 100 filter"
                     )
 
     def test_no_suggestions_with_very_tight_filter(self):
@@ -1698,6 +2146,7 @@ class TestBuildAssetPoolFromContract:
 
     def test_builds_expected_player_fields(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         rows = [
             self._row("Josh Allen", "QB", 9997, team="BUF"),
             self._row("Bijan Robinson", "RB", 9604, team="ATL"),
@@ -1708,9 +2157,7 @@ class TestBuildAssetPoolFromContract:
             "Josh Allen": {"_yearsExp": 7},
             "Bijan Robinson": {"_yearsExp": 2},
         }
-        pool = build_asset_pool_from_contract(
-            self._contract(rows, players_dict), ktc_top_n=0
-        )
+        pool = build_asset_pool_from_contract(self._contract(rows, players_dict), ktc_top_n=0)
         assert len(pool) == 2
         allen = next(p for p in pool if p.name == "Josh Allen")
         bijan = next(p for p in pool if p.name == "Bijan Robinson")
@@ -1727,13 +2174,15 @@ class TestBuildAssetPoolFromContract:
 
     def test_universe_labels(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         rows = [
-            self._row("Josh Allen", "QB", 9000),                     # offense_vet
-            self._row("Jeremiyah Love", "RB", 7000, rookie=True),    # offense_rookie
-            self._row("Will Anderson", "DL", 7000),                  # idp_vet
-            self._row("Arvell Reese", "LB", 5000, rookie=True),      # idp_rookie
-            self._row("2026 Pick 1.01", "PICK", 9000,
-                      asset_class="pick", site_values={"ktc": 9000}),
+            self._row("Josh Allen", "QB", 9000),  # offense_vet
+            self._row("Jeremiyah Love", "RB", 7000, rookie=True),  # offense_rookie
+            self._row("Will Anderson", "DL", 7000),  # idp_vet
+            self._row("Arvell Reese", "LB", 5000, rookie=True),  # idp_rookie
+            self._row(
+                "2026 Pick 1.01", "PICK", 9000, asset_class="pick", site_values={"ktc": 9000}
+            ),
         ]
         pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
         universes = {p.name: p.universe for p in pool}
@@ -1745,6 +2194,7 @@ class TestBuildAssetPoolFromContract:
 
     def test_skips_rows_without_value(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         rows = [
             self._row("Josh Allen", "QB", 9997),
             # rankDerivedValue=0 → pool skip (mirrors canonical-snapshot
@@ -1759,13 +2209,22 @@ class TestBuildAssetPoolFromContract:
 
     def test_dispersion_cv_uses_canonical_site_values(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         # Site values with meaningful spread → dispersion_cv > 0.
         rows = [
-            self._row("Spread Player", "WR", 8000,
-                      site_values={"ktc": 9000, "idpTradeCalc": 7000, "dlfSf": 8000}),
+            self._row(
+                "Spread Player",
+                "WR",
+                8000,
+                site_values={"ktc": 9000, "idpTradeCalc": 7000, "dlfSf": 8000},
+            ),
             # Identical site values → dispersion_cv == 0.
-            self._row("Consensus Player", "WR", 8000,
-                      site_values={"ktc": 8000, "idpTradeCalc": 8000, "dlfSf": 8000}),
+            self._row(
+                "Consensus Player",
+                "WR",
+                8000,
+                site_values={"ktc": 8000, "idpTradeCalc": 8000, "dlfSf": 8000},
+            ),
         ]
         pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
         spread = next(p for p in pool if p.name == "Spread Player")
@@ -1775,6 +2234,7 @@ class TestBuildAssetPoolFromContract:
 
     def test_pool_sorted_by_display_value_desc(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         rows = [
             self._row("Low Value", "WR", 3000),
             self._row("High Value", "WR", 9000),
@@ -1785,10 +2245,8 @@ class TestBuildAssetPoolFromContract:
 
     def test_ktc_top_n_filter_applies(self):
         from src.trade.suggestions import build_asset_pool_from_contract, KTC_TOP_N_FILTER
-        rows = [
-            self._row(f"Player {i:03d}", "WR", 9999 - i)
-            for i in range(KTC_TOP_N_FILTER + 50)
-        ]
+
+        rows = [self._row(f"Player {i:03d}", "WR", 9999 - i) for i in range(KTC_TOP_N_FILTER + 50)]
         pool = build_asset_pool_from_contract(self._contract(rows))
         # Every asset in the pool must have a ktc_rank within the filter.
         assert len(pool) <= KTC_TOP_N_FILTER
@@ -1804,19 +2262,16 @@ class TestBuildAssetPoolFromContract:
             build_asset_pool_from_contract,
             generate_suggestions_from_pool,
         )
+
         rows = []
         # Enough players to survive the starter-needs check + KTC filter.
         positions = [("QB", 10), ("RB", 12), ("WR", 15), ("TE", 8)]
         value = 9500
         for pos, n in positions:
             for i in range(n):
-                rows.append(
-                    self._row(f"{pos}{i:02d}", pos, value, team="X")
-                )
+                rows.append(self._row(f"{pos}{i:02d}", pos, value, team="X"))
                 value -= 25
-        pool = build_asset_pool_from_contract(
-            self._contract(rows), ktc_top_n=0
-        )
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
         roster_names = ["QB00", "RB00", "WR00", "WR01", "TE00"]
         result = generate_suggestions_from_pool(
             roster_names=roster_names,
@@ -1833,6 +2288,7 @@ class TestBuildAssetPoolFromContract:
 
 
 # ── effectiveSourceRanks (post-Hampel) regression ────────────────────
+
 
 class TestEffectiveSourceRanks:
     """Regression coverage for the post-Hampel source read.
@@ -1876,8 +2332,9 @@ class TestEffectiveSourceRanks:
             "rookie": rookie,
             "assetClass": asset_class,
             "rankDerivedValue": value,
-            "canonicalSiteValues": site_values if site_values is not None
-                else {"ktc": value, "idpTradeCalc": value - 50},
+            "canonicalSiteValues": site_values
+            if site_values is not None
+            else {"ktc": value, "idpTradeCalc": value - 50},
             "legacyRef": legacy_ref or name,
         }
         if effective_source_ranks is not None:
@@ -1891,11 +2348,14 @@ class TestEffectiveSourceRanks:
 
     def test_source_count_uses_effective_source_ranks(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         # 8 raw site values, but Hampel dropped 5 → effective count = 3.
         site_values = {f"src{i}": 7000 for i in range(8)}
         effective = {"src0": 10, "src1": 11, "src2": 12}
         row = self._row(
-            "Post Hampel", "WR", 7000,
+            "Post Hampel",
+            "WR",
+            7000,
             site_values=site_values,
             effective_source_ranks=effective,
             dropped_sources=[f"src{i}" for i in range(3, 8)],
@@ -1903,21 +2363,26 @@ class TestEffectiveSourceRanks:
         pool = build_asset_pool_from_contract(self._contract([row]), ktc_top_n=0)
         assert len(pool) == 1
         assert pool[0].source_count == 3, (
-            "source_count must be the post-Hampel effective count, "
-            "not len(canonicalSiteValues)"
+            "source_count must be the post-Hampel effective count, " "not len(canonicalSiteValues)"
         )
 
     def test_dispersion_cv_uses_effective_source_ranks(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         # Tight consensus on 4 sources + one extreme outlier Hampel drops.
         site_values = {
-            "ktc": 7000, "dynastyNerds": 7050, "dynastyDaddy": 6980,
-            "dlfSf": 7020, "idpTradeCalc": 1500,  # outlier
+            "ktc": 7000,
+            "dynastyNerds": 7050,
+            "dynastyDaddy": 6980,
+            "dlfSf": 7020,
+            "idpTradeCalc": 1500,  # outlier
         }
         # Post-Hampel: outlier removed, consensus is tight.
         effective = {"ktc": 10, "dynastyNerds": 11, "dynastyDaddy": 12, "dlfSf": 13}
         row_filtered = self._row(
-            "Hampel Filtered", "WR", 7000,
+            "Hampel Filtered",
+            "WR",
+            7000,
             site_values=site_values,
             effective_source_ranks=effective,
             dropped_sources=["idpTradeCalc"],
@@ -1925,12 +2390,12 @@ class TestEffectiveSourceRanks:
         # Same site values, no Hampel stamps → legacy read, outlier
         # inflates the dispersion.
         row_raw = self._row(
-            "Raw Unfiltered", "WR", 7000,
+            "Raw Unfiltered",
+            "WR",
+            7000,
             site_values=site_values,
         )
-        pool = build_asset_pool_from_contract(
-            self._contract([row_filtered, row_raw]), ktc_top_n=0
-        )
+        pool = build_asset_pool_from_contract(self._contract([row_filtered, row_raw]), ktc_top_n=0)
         filtered = next(p for p in pool if p.name == "Hampel Filtered")
         raw = next(p for p in pool if p.name == "Raw Unfiltered")
         assert filtered.dispersion_cv is not None
@@ -1943,9 +2408,12 @@ class TestEffectiveSourceRanks:
         """Legacy fallback: a contract with ``droppedSources`` but no
         ``effectiveSourceRanks`` should still respect the drop list."""
         from src.trade.suggestions import build_asset_pool_from_contract
+
         site_values = {"a": 7000, "b": 7050, "c": 6980, "d": 1500}
         row = self._row(
-            "Partial Stamps", "WR", 7000,
+            "Partial Stamps",
+            "WR",
+            7000,
             site_values=site_values,
             dropped_sources=["d"],
         )
@@ -1956,8 +2424,11 @@ class TestEffectiveSourceRanks:
 
     def test_legacy_contract_without_stamps_uses_raw_site_values(self):
         from src.trade.suggestions import build_asset_pool_from_contract
+
         row = self._row(
-            "Legacy Row", "WR", 7000,
+            "Legacy Row",
+            "WR",
+            7000,
             site_values={"a": 7000, "b": 7050, "c": 6980, "d": 1500},
             # No effectiveSourceRanks, no droppedSources → legacy contract.
         )
@@ -1991,34 +2462,30 @@ class TestEffectiveSourceRanks:
         rows = [
             # QB surplus (4 QBs, need 2).
             self._row(
-                "QB Sell", "QB", 5500,
+                "QB Sell",
+                "QB",
+                5500,
                 site_values=self._raw_site_values(5500),
                 effective_source_ranks=self._effective_ranks(
                     [f"src{i}" for i in range(effective_count_for_sell)]
                 ),
-                dropped_sources=[
-                    f"src{i}" for i in range(effective_count_for_sell, 8)
-                ],
+                dropped_sources=[f"src{i}" for i in range(effective_count_for_sell, 8)],
             ),
-            self._row("QB Starter A", "QB", 7500,
-                      site_values=self._raw_site_values(7500)),
-            self._row("QB Starter B", "QB", 7300,
-                      site_values=self._raw_site_values(7300)),
-            self._row("QB Depth", "QB", 5200,
-                      site_values=self._raw_site_values(5200)),
+            self._row("QB Starter A", "QB", 7500, site_values=self._raw_site_values(7500)),
+            self._row("QB Starter B", "QB", 7300, site_values=self._raw_site_values(7300)),
+            self._row("QB Depth", "QB", 5200, site_values=self._raw_site_values(5200)),
             # WR target the engine can swap into.  Generous effective
             # ranks so the target side is always "high".
             self._row(
-                "WR Target", "WR", 5700,
+                "WR Target",
+                "WR",
+                5700,
                 site_values=self._raw_site_values(5700),
-                effective_source_ranks=self._effective_ranks(
-                    [f"src{i}" for i in range(7)]
-                ),
+                effective_source_ranks=self._effective_ranks([f"src{i}" for i in range(7)]),
                 dropped_sources=["src7"],
             ),
             # Other WRs so the user has a WR need (0 starters).
-            self._row("WR Other", "WR", 1500,
-                      site_values=self._raw_site_values(1500)),
+            self._row("WR Other", "WR", 1500, site_values=self._raw_site_values(1500)),
         ]
         roster = ["QB Sell", "QB Starter A", "QB Starter B", "QB Depth"]
         return rows, roster
@@ -2034,27 +2501,22 @@ class TestEffectiveSourceRanks:
             build_asset_pool_from_contract,
             generate_suggestions_from_pool,
         )
+
         rows, roster = self._build_sell_high_scenario(effective_count_for_sell=3)
-        pool = build_asset_pool_from_contract(
-            self._contract(rows), ktc_top_n=0
-        )
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
         sell_player = next(p for p in pool if p.name == "QB Sell")
         assert sell_player.source_count == 3  # effective, not 8
 
         result = generate_suggestions_from_pool(
-            roster_names=roster, pool=pool,
+            roster_names=roster,
+            pool=pool,
         )
         sell_high = result["sellHigh"]
         # Filter to suggestions that actually trade the Hampel-filtered
         # sell piece — other surplus QBs may also generate sell-high
         # entries with unfiltered (high) confidence.
-        hampel_sells = [
-            s for s in sell_high
-            if any(g["name"] == "QB Sell" for g in s["give"])
-        ]
-        assert hampel_sells, (
-            "expected a sell_high suggestion that moves QB Sell"
-        )
+        hampel_sells = [s for s in sell_high if any(g["name"] == "QB Sell" for g in s["give"])]
+        assert hampel_sells, "expected a sell_high suggestion that moves QB Sell"
         # confidence = min(sell.source_count, target.source_count)
         # = min(3, 7) = 3 → "medium".  Proves the post-Hampel count
         # flowed through.
@@ -2066,44 +2528,37 @@ class TestEffectiveSourceRanks:
             build_asset_pool_from_contract,
             generate_suggestions_from_pool,
         )
+
         # Roster has QB surplus but WR need → engine buys-low at WR.
         # WR target carries 8 raw sources but only 2 effective → low.
         rows = [
-            self._row("QB1", "QB", 8000,
-                      site_values=self._raw_site_values(8000)),
-            self._row("QB2", "QB", 7700,
-                      site_values=self._raw_site_values(7700)),
-            self._row("QB3", "QB", 6500,
-                      site_values=self._raw_site_values(6500)),
-            self._row("QB4", "QB", 6000,
-                      site_values=self._raw_site_values(6000)),
+            self._row("QB1", "QB", 8000, site_values=self._raw_site_values(8000)),
+            self._row("QB2", "QB", 7700, site_values=self._raw_site_values(7700)),
+            self._row("QB3", "QB", 6500, site_values=self._raw_site_values(6500)),
+            self._row("QB4", "QB", 6000, site_values=self._raw_site_values(6000)),
             # WR starter slot empty-ish on roster.
             self._row(
-                "WR Buy Low", "WR", 6200,
+                "WR Buy Low",
+                "WR",
+                6200,
                 site_values=self._raw_site_values(6200),
-                effective_source_ranks=self._effective_ranks(
-                    ["src0", "src1"]
-                ),
+                effective_source_ranks=self._effective_ranks(["src0", "src1"]),
                 dropped_sources=[f"src{i}" for i in range(2, 8)],
             ),
         ]
         roster = ["QB1", "QB2", "QB3", "QB4"]
-        pool = build_asset_pool_from_contract(
-            self._contract(rows), ktc_top_n=0
-        )
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
         target = next(p for p in pool if p.name == "WR Buy Low")
         assert target.source_count == 2
 
         result = generate_suggestions_from_pool(
-            roster_names=roster, pool=pool,
+            roster_names=roster,
+            pool=pool,
         )
         buy_low = result["buyLow"]
         # If any buy-low targets "WR Buy Low", its confidence should be
         # "low" (min(give=high, target=2) = 2 → low).
-        matching = [
-            s for s in buy_low
-            if any(r["name"] == "WR Buy Low" for r in s["receive"])
-        ]
+        matching = [s for s in buy_low if any(r["name"] == "WR Buy Low" for r in s["receive"])]
         assert matching, "expected a buy_low suggestion for WR Buy Low"
         for s in matching:
             assert s["confidence"] == "low"
@@ -2118,52 +2573,44 @@ class TestEffectiveSourceRanks:
             build_asset_pool_from_contract,
             generate_suggestions_from_pool,
         )
+
         rows = [
             # 4 RBs on roster — surplus depth the user can package.
-            self._row("RB1", "RB", 5000,
-                      site_values=self._raw_site_values(5000)),
-            self._row("RB2", "RB", 4800,
-                      site_values=self._raw_site_values(4800)),
-            self._row("RB3", "RB", 4600,
-                      site_values=self._raw_site_values(4600)),
-            self._row("RB Depth A", "RB", 3200,
-                      site_values=self._raw_site_values(3200)),
-            self._row("RB Depth B", "RB", 3100,
-                      site_values=self._raw_site_values(3100)),
+            self._row("RB1", "RB", 5000, site_values=self._raw_site_values(5000)),
+            self._row("RB2", "RB", 4800, site_values=self._raw_site_values(4800)),
+            self._row("RB3", "RB", 4600, site_values=self._raw_site_values(4600)),
+            self._row("RB Depth A", "RB", 3200, site_values=self._raw_site_values(3200)),
+            self._row("RB Depth B", "RB", 3100, site_values=self._raw_site_values(3100)),
             # Consolidation target at WR (a need position).  Valued so
             # the (3200 + 3100) depth package lands VA-near-even once
             # KTC's quantity discount is applied — a realistic
             # consolidation, not a raw-even-but-VA-lopsided 2-for-1.
             self._row(
-                "WR Consolidation Target", "WR", 4600,
+                "WR Consolidation Target",
+                "WR",
+                4600,
                 site_values=self._raw_site_values(4600),
-                effective_source_ranks=self._effective_ranks(
-                    ["src0", "src1", "src2", "src3"]
-                ),
+                effective_source_ranks=self._effective_ranks(["src0", "src1", "src2", "src3"]),
                 dropped_sources=[f"src{i}" for i in range(4, 8)],
             ),
         ]
         roster = ["RB1", "RB2", "RB3", "RB Depth A", "RB Depth B"]
-        pool = build_asset_pool_from_contract(
-            self._contract(rows), ktc_top_n=0
-        )
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
         target = next(p for p in pool if p.name == "WR Consolidation Target")
         assert target.source_count == 4
 
         result = generate_suggestions_from_pool(
-            roster_names=roster, pool=pool,
+            roster_names=roster,
+            pool=pool,
         )
         cons = result["consolidation"]
         # The suggestion list may be pruned by quality filters; assert
         # every remaining consolidation targeting our WR is "medium"
         # (4 effective sources → medium tier), not "high".
         matching = [
-            s for s in cons
-            if any(r["name"] == "WR Consolidation Target" for r in s["receive"])
+            s for s in cons if any(r["name"] == "WR Consolidation Target" for r in s["receive"])
         ]
-        assert matching, (
-            "expected a consolidation suggestion targeting WR Consolidation Target"
-        )
+        assert matching, "expected a consolidation suggestion targeting WR Consolidation Target"
         for s in matching:
             assert s["confidence"] == "medium"
 
@@ -2177,64 +2624,58 @@ class TestEffectiveSourceRanks:
             build_asset_pool_from_contract,
             generate_suggestions_from_pool,
         )
+
         rows = [
             # 4 WR starters so the upgrade target clears upgrade_floor
             # against the weakest slotted starter (WR Starter D = 3300).
-            self._row("WR Starter A", "WR", 6000,
-                      site_values=self._raw_site_values(6000)),
-            self._row("WR Starter B", "WR", 5000,
-                      site_values=self._raw_site_values(5000)),
-            self._row("WR Starter C", "WR", 4000,
-                      site_values=self._raw_site_values(4000)),
-            self._row("WR Starter D", "WR", 3300,
-                      site_values=self._raw_site_values(3300)),
-            self._row("WR Depth", "WR", 3200,
-                      site_values=self._raw_site_values(3200)),
+            self._row("WR Starter A", "WR", 6000, site_values=self._raw_site_values(6000)),
+            self._row("WR Starter B", "WR", 5000, site_values=self._raw_site_values(5000)),
+            self._row("WR Starter C", "WR", 4000, site_values=self._raw_site_values(4000)),
+            self._row("WR Starter D", "WR", 3300, site_values=self._raw_site_values(3300)),
+            self._row("WR Depth", "WR", 3200, site_values=self._raw_site_values(3200)),
             # RB surplus (3 starters + 2 depth) supplies the sweetener
             # search fallback the engine uses for positional upgrades.
             # Depth sized so weakest_starter + sweetener vs. target is
             # VA-near-even, not raw-even-but-VA-lopsided.
-            self._row("RB1", "RB", 7000,
-                      site_values=self._raw_site_values(7000)),
-            self._row("RB2", "RB", 6800,
-                      site_values=self._raw_site_values(6800)),
-            self._row("RB3", "RB", 6600,
-                      site_values=self._raw_site_values(6600)),
-            self._row("RB Depth A", "RB", 1420,
-                      site_values=self._raw_site_values(1420)),
-            self._row("RB Depth B", "RB", 1400,
-                      site_values=self._raw_site_values(1400)),
+            self._row("RB1", "RB", 7000, site_values=self._raw_site_values(7000)),
+            self._row("RB2", "RB", 6800, site_values=self._raw_site_values(6800)),
+            self._row("RB3", "RB", 6600, site_values=self._raw_site_values(6600)),
+            self._row("RB Depth A", "RB", 1420, site_values=self._raw_site_values(1420)),
+            self._row("RB Depth B", "RB", 1400, site_values=self._raw_site_values(1400)),
             # Upgrade target at WR: raw=8 sources, effective=2 → low.
             self._row(
-                "WR Upgrade Target", "WR", 4200,
+                "WR Upgrade Target",
+                "WR",
+                4200,
                 site_values=self._raw_site_values(4200),
-                effective_source_ranks=self._effective_ranks(
-                    ["src0", "src1"]
-                ),
+                effective_source_ranks=self._effective_ranks(["src0", "src1"]),
                 dropped_sources=[f"src{i}" for i in range(2, 8)],
             ),
         ]
         roster = [
-            "WR Starter A", "WR Starter B", "WR Starter C", "WR Starter D",
+            "WR Starter A",
+            "WR Starter B",
+            "WR Starter C",
+            "WR Starter D",
             "WR Depth",
-            "RB1", "RB2", "RB3", "RB Depth A", "RB Depth B",
+            "RB1",
+            "RB2",
+            "RB3",
+            "RB Depth A",
+            "RB Depth B",
         ]
-        pool = build_asset_pool_from_contract(
-            self._contract(rows), ktc_top_n=0
-        )
+        pool = build_asset_pool_from_contract(self._contract(rows), ktc_top_n=0)
         target = next(p for p in pool if p.name == "WR Upgrade Target")
         assert target.source_count == 2
 
         result = generate_suggestions_from_pool(
-            roster_names=roster, pool=pool,
+            roster_names=roster,
+            pool=pool,
         )
         upgrades = result["positionalUpgrades"]
         matching = [
-            s for s in upgrades
-            if any(r["name"] == "WR Upgrade Target" for r in s["receive"])
+            s for s in upgrades if any(r["name"] == "WR Upgrade Target" for r in s["receive"])
         ]
-        assert matching, (
-            "expected a positional_upgrade suggestion targeting WR Upgrade Target"
-        )
+        assert matching, "expected a positional_upgrade suggestion targeting WR Upgrade Target"
         for s in matching:
             assert s["confidence"] == "low"

--- a/tests/trade/test_correlation_matrix.py
+++ b/tests/trade/test_correlation_matrix.py
@@ -1,4 +1,5 @@
 """Tests for the Monte Carlo correlation matrix builder."""
+
 from __future__ import annotations
 
 from src.trade import correlation_matrix as cm
@@ -109,9 +110,9 @@ def test_shrink_to_pd_falls_back_to_identity_when_stuck():
 
 def test_build_axes_from_trade_players():
     from src.trade.monte_carlo import TradePlayer
+
     players = [
-        TradePlayer(name="A", team="BUF", position_group="offense",
-                    p10=100, p50=200, p90=300),
+        TradePlayer(name="A", team="BUF", position_group="offense", p10=100, p50=200, p90=300),
     ]
     axes = cm.build_axes_from_trade_players(players)
     assert len(axes) == 1

--- a/tests/trade/test_faab_recommender.py
+++ b/tests/trade/test_faab_recommender.py
@@ -9,6 +9,7 @@ These tests pin every fallback path so a future "let's just blend
 in X" tweak doesn't silently break confidence reporting or the
 explanation copy.
 """
+
 from __future__ import annotations
 
 from src.trade.faab_recommender import recommend_faab
@@ -21,8 +22,14 @@ def test_minimal_inputs_returns_full_shape():
     out = recommend_faab(add_player_value=4000)
     # All four bid pills present, plus confidence + breakdown.
     assert set(out.keys()) >= {
-        "conservative", "standard", "aggressive", "max",
-        "confidence", "factors", "warnings", "explanation",
+        "conservative",
+        "standard",
+        "aggressive",
+        "max",
+        "confidence",
+        "factors",
+        "warnings",
+        "explanation",
     }
     assert out["standard"] >= 0
     assert out["confidence"] == "low"  # most factors missing
@@ -46,10 +53,12 @@ def test_value_gain_boosts_standard_for_real_upgrades():
     """A 4000-value add beating a 2000-value drop should
     recommend MORE than the same add against a 4000-value drop."""
     big_upgrade = recommend_faab(
-        add_player_value=4000, drop_player_value=2000,
+        add_player_value=4000,
+        drop_player_value=2000,
     )
     even_swap = recommend_faab(
-        add_player_value=4000, drop_player_value=4000,
+        add_player_value=4000,
+        drop_player_value=4000,
     )
     assert big_upgrade["standard"] >= even_swap["standard"]
 
@@ -65,8 +74,10 @@ def test_marginal_swap_caps_bid_with_warning():
     """Add value == drop value ⇒ marginal upgrade ⇒ standard
     capped to a token bid."""
     out = recommend_faab(
-        add_player_value=3000, drop_player_value=3000,
-        team_faab_remaining=100, league_budget=100,
+        add_player_value=3000,
+        drop_player_value=3000,
+        team_faab_remaining=100,
+        league_budget=100,
     )
     # Marginal — capped to roughly 50% of the baseline reasonable.
     # Without a drop side the bid would be ~$13; with the marginal
@@ -80,11 +91,13 @@ def test_marginal_swap_caps_bid_with_warning():
 
 def test_trending_count_high_bumps_standard():
     base = recommend_faab(
-        add_player_value=4000, drop_player_value=1000,
+        add_player_value=4000,
+        drop_player_value=1000,
         league_budget=100,
     )
     hot = recommend_faab(
-        add_player_value=4000, drop_player_value=1000,
+        add_player_value=4000,
+        drop_player_value=1000,
         league_budget=100,
         sleeper_trending={"count": 12000},  # top tier (10000+ → +20%)
     )
@@ -118,7 +131,8 @@ def test_league_calibration_blends_to_historical_bid():
         },
     }
     out = recommend_faab(
-        add_player_value=2000, drop_player_value=500,
+        add_player_value=2000,
+        drop_player_value=500,
         add_player_position="WR",
         league_faab_summary=summary,
         league_budget=100,
@@ -127,8 +141,7 @@ def test_league_calibration_blends_to_historical_bid():
     # towards $30 should pull it up.
     assert out["standard"] > 15
     factor = next(
-        (f for f in out["factors"]
-         if f["label"].lower().startswith("league historical")),
+        (f for f in out["factors"] if f["label"].lower().startswith("league historical")),
         None,
     )
     assert factor is not None
@@ -150,8 +163,7 @@ def test_league_calibration_skipped_when_position_undersamples():
         league_budget=100,
     )
     factor = next(
-        (f for f in out["factors"]
-         if f["label"].lower().startswith("league historical")),
+        (f for f in out["factors"] if f["label"].lower().startswith("league historical")),
         None,
     )
     assert factor is not None
@@ -161,8 +173,7 @@ def test_league_calibration_skipped_when_position_undersamples():
 def test_league_summary_missing_marks_factor():
     out = recommend_faab(add_player_value=2000)
     factor = next(
-        (f for f in out["factors"]
-         if "league" in f["label"].lower()),
+        (f for f in out["factors"] if "league" in f["label"].lower()),
         None,
     )
     assert factor is not None
@@ -176,7 +187,8 @@ def test_ktc_crowd_blend_pulls_towards_crowd_bid():
     """KTC crowd reports 35% of budget for player → blend pulls
     standard towards $35 in a 100-budget league."""
     out = recommend_faab(
-        add_player_value=2000, drop_player_value=500,
+        add_player_value=2000,
+        drop_player_value=500,
         add_player_position="WR",
         add_player_name="Test Player",
         league_budget=100,
@@ -185,8 +197,7 @@ def test_ktc_crowd_blend_pulls_towards_crowd_bid():
     # Without crowd: ~$15; with 70/30 blend toward $35 → up.
     assert out["standard"] > 15
     factor = next(
-        (f for f in out["factors"]
-         if f["label"].lower().startswith("ktc crowd")),
+        (f for f in out["factors"] if f["label"].lower().startswith("ktc crowd")),
         None,
     )
     assert factor is not None
@@ -201,8 +212,7 @@ def test_ktc_crowd_missing_player_is_noop():
         ktc_crowd_bids={"different person": 25.0},
     )
     factor = next(
-        (f for f in out["factors"]
-         if f["label"].lower().startswith("ktc crowd")),
+        (f for f in out["factors"] if f["label"].lower().startswith("ktc crowd")),
         None,
     )
     assert factor is None
@@ -214,7 +224,8 @@ def test_ktc_crowd_missing_player_is_noop():
 def test_team_faab_cap_clips_recommendation():
     """When a team has $5 FAAB left, we never recommend more than $5."""
     out = recommend_faab(
-        add_player_value=8000, drop_player_value=1000,
+        add_player_value=8000,
+        drop_player_value=1000,
         team_faab_remaining=5,
         league_budget=100,
     )
@@ -222,8 +233,7 @@ def test_team_faab_cap_clips_recommendation():
     assert out["max"] == 5
     assert any("cap" in w.lower() for w in out["warnings"])
     factor = next(
-        (f for f in out["factors"]
-         if f["label"].lower().startswith("team faab cap")),
+        (f for f in out["factors"] if f["label"].lower().startswith("team faab cap")),
         None,
     )
     assert factor is not None
@@ -245,7 +255,8 @@ def test_team_faab_zero_recommends_zero():
 
 def test_all_inputs_present_returns_high_confidence():
     out = recommend_faab(
-        add_player_value=4000, drop_player_value=1000,
+        add_player_value=4000,
+        drop_player_value=1000,
         add_player_position="WR",
         add_player_name="Hot Pickup",
         team_faab_remaining=80,
@@ -285,8 +296,10 @@ def test_explanation_present_for_every_branch():
         ),
         # Drop-side present → "swap" copy.
         recommend_faab(
-            add_player_value=4000, drop_player_value=1000,
-            team_faab_remaining=80, league_budget=100,
+            add_player_value=4000,
+            drop_player_value=1000,
+            team_faab_remaining=80,
+            league_budget=100,
         ),
         # No drop → "free-agent target" copy.
         recommend_faab(add_player_value=4000),

--- a/tests/trade/test_ktc_export.py
+++ b/tests/trade/test_ktc_export.py
@@ -1,4 +1,5 @@
 """Tests for build_ktc_url (Phase 3) — inverse of resolve_trade_url."""
+
 from __future__ import annotations
 
 import unittest
@@ -7,15 +8,29 @@ from src.trade import ktc_import
 
 
 _MAP = {
-    1001: {"name": "Josh Allen", "position": "QB", "team": "BUF", "slug": "josh-allen", "rookie": False},
-    1002: {"name": "Bijan Robinson", "position": "RB", "team": "ATL", "slug": "bijan", "rookie": False},
+    1001: {
+        "name": "Josh Allen",
+        "position": "QB",
+        "team": "BUF",
+        "slug": "josh-allen",
+        "rookie": False,
+    },
+    1002: {
+        "name": "Bijan Robinson",
+        "position": "RB",
+        "team": "ATL",
+        "slug": "bijan",
+        "rookie": False,
+    },
     1003: {"name": "2026 Mid 1st", "position": "RDP", "team": "", "slug": "", "rookie": False},
 }
 
 
 class BuildKtcUrlTests(unittest.TestCase):
     def test_resolves_and_builds_url(self) -> None:
-        out = ktc_import.build_ktc_url(["Josh Allen"], ["Bijan Robinson", "2026 Mid 1st"], player_map=_MAP)
+        out = ktc_import.build_ktc_url(
+            ["Josh Allen"], ["Bijan Robinson", "2026 Mid 1st"], player_map=_MAP
+        )
         self.assertIn("keeptradecut.com/trade-calculator", out["url"])
         self.assertIn("teamOne=1001", out["url"])
         self.assertIn("teamTwo=1002|1003", out["url"])

--- a/tests/trade/test_ktc_import_parse.py
+++ b/tests/trade/test_ktc_import_parse.py
@@ -4,6 +4,7 @@
 KTC uses either ``,`` or ``|`` to separate multiple player IDs in
 ``teamOne`` / ``teamTwo``.  The parser must accept both forms.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -21,8 +22,7 @@ class TestParseTradeUrl(unittest.TestCase):
     def test_comma_separated_multi_ids(self):
         """Legacy KTC URL form — comma-delimited."""
         url = (
-            "https://keeptradecut.com/trade-calculator"
-            "?teamOne=1274,542&teamTwo=1555,1751&tep=0"
+            "https://keeptradecut.com/trade-calculator" "?teamOne=1274,542&teamTwo=1555,1751&tep=0"
         )
         one, two = parse_trade_url(url)
         self.assertEqual(one, [1274, 542])
@@ -44,10 +44,7 @@ class TestParseTradeUrl(unittest.TestCase):
         """Defensive: if KTC ever generates mixed ``,`` and ``|``, we
         still handle it.  Not observed in the wild, but cheap to
         support with a single regex split."""
-        url = (
-            "https://keeptradecut.com/trade-calculator"
-            "?teamOne=100,200|300&teamTwo=400|500,600"
-        )
+        url = "https://keeptradecut.com/trade-calculator" "?teamOne=100,200|300&teamTwo=400|500,600"
         one, two = parse_trade_url(url)
         self.assertEqual(one, [100, 200, 300])
         self.assertEqual(two, [400, 500, 600])

--- a/tests/trade/test_ktc_va_python_port.py
+++ b/tests/trade/test_ktc_va_python_port.py
@@ -8,6 +8,7 @@ fidelity as the JS port (verified by ``scripts/test_ktc_va_port.mjs``).
 Companion fixture is the single source of truth shared between the JS
 and Python implementations — drift in either direction trips here.
 """
+
 from __future__ import annotations
 
 import json
@@ -45,7 +46,9 @@ def test_fixture_overall_rms_under_50():
         ported = result.value if result.displayed else 0
         sq_err += (ported - observed) ** 2
     rms = math.sqrt(sq_err / len(obs))
-    assert rms < 50, f"RMS error {rms:.1f} exceeds 50 — Python port may have drifted from KTC's algorithm"
+    assert (
+        rms < 50
+    ), f"RMS error {rms:.1f} exceeds 50 — Python port may have drifted from KTC's algorithm"
 
 
 def test_fixture_recipient_side_100pct():
@@ -65,7 +68,9 @@ def test_fixture_recipient_side_100pct():
         result = ktc_adjust_package(a, b)
         if result.displayed and result.side == observed_side:
             matched += 1
-    assert matched == fires, f"Recipient-side parity: {matched}/{fires} (every fired VA must pick the right side)"
+    assert (
+        matched == fires
+    ), f"Recipient-side parity: {matched}/{fires} (every fired VA must pick the right side)"
 
 
 def test_fixture_suppression_100pct():
@@ -83,7 +88,9 @@ def test_fixture_suppression_100pct():
         result = ktc_adjust_package(a, b)
         if not result.displayed or result.value == 0:
             matched += 1
-    assert matched == silent, f"Suppression parity: {matched}/{silent} (every KTC-suppressed trade must also suppress in the port)"
+    assert (
+        matched == silent
+    ), f"Suppression parity: {matched}/{silent} (every KTC-suppressed trade must also suppress in the port)"
 
 
 def test_users_5v2_trade_returns_4161_to_side2():
@@ -123,4 +130,6 @@ def test_process_v_canonical_inputs():
     ]
     for value, expected, tol in cases:
         got = ktc_process_v(value, 9999, 10041, -1)
-        assert abs(got - expected) < tol, f"ktc_process_v({value}) = {got:.2f}, expected {expected} ± {tol}"
+        assert (
+            abs(got - expected) < tol
+        ), f"ktc_process_v({value}) = {got:.2f}, expected {expected} ± {tol}"

--- a/tests/trade/test_monte_carlo.py
+++ b/tests/trade/test_monte_carlo.py
@@ -8,6 +8,7 @@ Key invariants:
   * Empty sides don't crash.
   * Label stays explicit: "consensus_based_win_rate".
 """
+
 from __future__ import annotations
 
 from src.trade import monte_carlo as mc
@@ -15,8 +16,12 @@ from src.trade import monte_carlo as mc
 
 def _p(name, p50, spread=0.15, team="BUF", group="offense"):
     return mc.TradePlayer(
-        name=name, team=team, position_group=group,
-        p10=p50 * (1 - spread), p50=p50, p90=p50 * (1 + spread),
+        name=name,
+        team=team,
+        position_group=group,
+        p10=p50 * (1 - spread),
+        p50=p50,
+        p90=p50 * (1 + spread),
     )
 
 
@@ -25,7 +30,8 @@ def test_clear_winner_gives_near_one_win_prob():
     result = mc.simulate_trade(
         [_p("A", 10000)],
         [_p("B", 100)],
-        n_sims=5000, seed=42,
+        n_sims=5000,
+        seed=42,
     )
     assert result.win_prob_a > 0.99
 
@@ -34,7 +40,8 @@ def test_clear_loser_gives_near_zero_win_prob():
     result = mc.simulate_trade(
         [_p("A", 100)],
         [_p("B", 10000)],
-        n_sims=5000, seed=42,
+        n_sims=5000,
+        seed=42,
     )
     assert result.win_prob_a < 0.01
 
@@ -44,7 +51,8 @@ def test_equal_trade_near_half():
     result = mc.simulate_trade(
         [_p("A", 5000)],
         [_p("B", 5000)],
-        n_sims=10000, seed=42,
+        n_sims=10000,
+        seed=42,
     )
     assert 0.40 <= result.win_prob_a <= 0.60
 
@@ -90,7 +98,9 @@ def test_to_dict_preserves_disclaimer():
 
 def test_build_trade_player_uses_band_when_available():
     row = {
-        "name": "Josh Allen", "team": "BUF", "pos": "QB",
+        "name": "Josh Allen",
+        "team": "BUF",
+        "pos": "QB",
         "rankDerivedValue": 9000,
         "valueBand": {"p10": 8200, "p50": 9000, "p90": 9700},
     }
@@ -138,6 +148,7 @@ def test_triangular_draw_covers_full_range():
 
 # --- Consolidation adjustment tests ---
 
+
 def test_consolidation_adjustment_stud_beats_fillers():
     """1 stud vs 4 equal-valued fillers: raw totals favor fillers, VA flips it."""
     stud = [_p("Elite", 3500)]
@@ -147,13 +158,16 @@ def test_consolidation_adjustment_stud_beats_fillers():
     assert no_adj.win_prob_a < 0.5, "fillers should lead on raw totals"
 
     with_adj = mc.simulate_trade(
-        stud, fillers, n_sims=10000, seed=42,
+        stud,
+        fillers,
+        n_sims=10000,
+        seed=42,
         apply_consolidation_adjustment=True,
     )
     assert with_adj.win_prob_a > no_adj.win_prob_a, "VA must shift odds toward stud"
     assert with_adj.va_adjustment is not None
     assert with_adj.va_adjustment["applied"] is True
-    assert with_adj.va_adjustment["side"] == 1   # stud is side_a
+    assert with_adj.va_adjustment["side"] == 1  # stud is side_a
     assert with_adj.va_adjustment["value"] > 0
 
 
@@ -162,23 +176,23 @@ def test_consolidation_adjustment_symmetric_regardless_of_side():
     stud = [_p("Elite", 3500)]
     fillers = [_p(f"F{i}", 1000) for i in range(4)]
 
-    ab = mc.simulate_trade(stud, fillers, n_sims=10000, seed=1,
-                           apply_consolidation_adjustment=True)
-    ba = mc.simulate_trade(fillers, stud, n_sims=10000, seed=1,
-                           apply_consolidation_adjustment=True)
+    ab = mc.simulate_trade(stud, fillers, n_sims=10000, seed=1, apply_consolidation_adjustment=True)
+    ba = mc.simulate_trade(fillers, stud, n_sims=10000, seed=1, apply_consolidation_adjustment=True)
 
     assert ab.va_adjustment["value"] == ba.va_adjustment["value"]
     assert ab.va_adjustment["side"] == 1  # stud received bonus as side_a
     assert ba.va_adjustment["side"] == 2  # stud received bonus as side_b
-    assert ab.win_prob_a > 0.5            # stud wins when it's side A
-    assert ba.win_prob_a < 0.5            # stud wins when it's side B
+    assert ab.win_prob_a > 0.5  # stud wins when it's side A
+    assert ba.win_prob_a < 0.5  # stud wins when it's side B
 
 
 def test_consolidation_no_adjustment_on_1v1():
     """KTC suppresses VA for 1v1 trades — no shift applied."""
     result = mc.simulate_trade(
-        [_p("Star", 5000)], [_p("Good", 4500)],
-        n_sims=5000, seed=42,
+        [_p("Star", 5000)],
+        [_p("Good", 4500)],
+        n_sims=5000,
+        seed=42,
         apply_consolidation_adjustment=True,
     )
     assert result.va_adjustment["applied"] is False
@@ -190,8 +204,7 @@ def test_consolidation_no_adjustment_equal_packages():
     """Identical value on each side → VA within 5% variance → suppressed."""
     a = [_p("A1", 3000), _p("A2", 2000)]
     b = [_p("B1", 3000), _p("B2", 2000)]
-    result = mc.simulate_trade(a, b, n_sims=5000, seed=42,
-                               apply_consolidation_adjustment=True)
+    result = mc.simulate_trade(a, b, n_sims=5000, seed=42, apply_consolidation_adjustment=True)
     assert result.va_adjustment["applied"] is False
 
 
@@ -200,7 +213,8 @@ def test_consolidation_default_off_preserves_existing_behavior():
     stud = [_p("Elite", 3500)]
     fillers = [_p(f"F{i}", 1000) for i in range(4)]
     default_result = mc.simulate_trade(stud, fillers, n_sims=5000, seed=99)
-    explicit_off = mc.simulate_trade(stud, fillers, n_sims=5000, seed=99,
-                                     apply_consolidation_adjustment=False)
+    explicit_off = mc.simulate_trade(
+        stud, fillers, n_sims=5000, seed=99, apply_consolidation_adjustment=False
+    )
     assert default_result.win_prob_a == explicit_off.win_prob_a
     assert default_result.va_adjustment["applied"] is False

--- a/tests/trade/test_symmetrize.py
+++ b/tests/trade/test_symmetrize.py
@@ -1,4 +1,5 @@
 """Tests for trade-direction symmetrization + decision-layer fields."""
+
 from __future__ import annotations
 
 from src.trade import monte_carlo as mc
@@ -7,15 +8,22 @@ from src.trade import symmetrize as sym
 
 def _p(name, p50, team="BUF", group="offense"):
     return mc.TradePlayer(
-        name=name, team=team, position_group=group,
-        p10=p50 * 0.85, p50=p50, p90=p50 * 1.15,
+        name=name,
+        team=team,
+        position_group=group,
+        p10=p50 * 0.85,
+        p50=p50,
+        p90=p50 * 1.15,
     )
 
 
 def test_symmetric_result_sums_to_one_on_win_prob():
     """Core invariant: winProbA + winProbB == 1 exactly."""
     result = sym.simulate_symmetric(
-        [_p("A", 5000)], [_p("B", 4500)], n_sims=2000, seed=1,
+        [_p("A", 5000)],
+        [_p("B", 4500)],
+        n_sims=2000,
+        seed=1,
     )
     assert abs(result["winProbA"] + result["winProbB"] - 1.0) < 1e-6
 
@@ -34,14 +42,20 @@ def test_reversed_sides_give_flipped_win_prob():
 
 def test_clear_winner_still_clear_after_symmetrization():
     result = sym.simulate_symmetric(
-        [_p("A", 10000)], [_p("B", 100)], n_sims=5000, seed=42,
+        [_p("A", 10000)],
+        [_p("B", 100)],
+        n_sims=5000,
+        seed=42,
     )
     assert result["winProbA"] > 0.99
 
 
 def test_equal_sides_centers_on_half():
     result = sym.simulate_symmetric(
-        [_p("A", 5000)], [_p("B", 5000)], n_sims=5000, seed=1,
+        [_p("A", 5000)],
+        [_p("B", 5000)],
+        n_sims=5000,
+        seed=1,
     )
     # True 50/50 — with symmetrization we should land within 1% of 0.5.
     assert 0.49 <= result["winProbA"] <= 0.51
@@ -49,7 +63,10 @@ def test_equal_sides_centers_on_half():
 
 def test_symmetry_check_drift_reported():
     result = sym.simulate_symmetric(
-        [_p("A", 7000)], [_p("B", 6500)], n_sims=2000, seed=9,
+        [_p("A", 7000)],
+        [_p("B", 6500)],
+        n_sims=2000,
+        seed=9,
     )
     assert "symmetryCheck" in result
     sc = result["symmetryCheck"]
@@ -60,7 +77,10 @@ def test_symmetry_check_drift_reported():
 
 def test_delta_range_monotonic_after_symmetrization():
     result = sym.simulate_symmetric(
-        [_p("A", 8000)], [_p("B", 6000)], n_sims=2000, seed=5,
+        [_p("A", 8000)],
+        [_p("B", 6000)],
+        n_sims=2000,
+        seed=5,
     )
     r = result["deltaRange"]
     assert r["p10"] <= r["p50"] <= r["p90"]
@@ -69,26 +89,37 @@ def test_delta_range_monotonic_after_symmetrization():
 def test_n_sims_doubled_to_capture_both_directions():
     """The reported nSims should reflect that we ran the sim twice."""
     result = sym.simulate_symmetric(
-        [_p("A", 5000)], [_p("B", 5000)], n_sims=3000, seed=1,
+        [_p("A", 5000)],
+        [_p("B", 5000)],
+        n_sims=3000,
+        seed=1,
     )
     assert result["nSims"] == 6000
 
 
 def test_disclaimer_mentions_symmetrization():
     result = sym.simulate_symmetric(
-        [_p("A", 5000)], [_p("B", 5000)], n_sims=1000, seed=1,
+        [_p("A", 5000)],
+        [_p("B", 5000)],
+        n_sims=1000,
+        seed=1,
     )
     assert "symmetrized" in result["disclaimer"].lower()
 
 
 def test_enrich_adds_decision_layer_fields():
     base = sym.simulate_symmetric(
-        [_p("A", 8000)], [_p("B", 5000)], n_sims=2000, seed=1,
+        [_p("A", 8000)],
+        [_p("B", 5000)],
+        n_sims=2000,
+        seed=1,
     )
-    side_a = [mc.TradePlayer(name="A", team="BUF", position_group="offense",
-                              p10=6800, p50=8000, p90=9200)]
-    side_b = [mc.TradePlayer(name="B", team="KC", position_group="offense",
-                              p10=4250, p50=5000, p90=5750)]
+    side_a = [
+        mc.TradePlayer(name="A", team="BUF", position_group="offense", p10=6800, p50=8000, p90=9200)
+    ]
+    side_b = [
+        mc.TradePlayer(name="B", team="KC", position_group="offense", p10=4250, p50=5000, p90=5750)
+    ]
     enriched = sym.enrich_with_decision_shape(base, side_a, side_b)
     assert "valueDelta" in enriched
     assert "adjustedDelta" in enriched
@@ -102,20 +133,26 @@ def test_enrich_adds_decision_layer_fields():
 
 def test_close_trade_has_high_risk_label():
     # Two roughly-equal sides with wide bands → high risk.
-    side_a = [mc.TradePlayer(name="A", team="BUF", position_group="offense",
-                              p10=3000, p50=5000, p90=7000)]
-    side_b = [mc.TradePlayer(name="B", team="KC", position_group="offense",
-                              p10=3000, p50=5000, p90=7000)]
+    side_a = [
+        mc.TradePlayer(name="A", team="BUF", position_group="offense", p10=3000, p50=5000, p90=7000)
+    ]
+    side_b = [
+        mc.TradePlayer(name="B", team="KC", position_group="offense", p10=3000, p50=5000, p90=7000)
+    ]
     base = sym.simulate_symmetric(side_a, side_b, n_sims=2000, seed=1)
     enriched = sym.enrich_with_decision_shape(base, side_a, side_b)
     assert enriched["riskLevel"] in ("medium", "high")
 
 
 def test_lopsided_trade_has_significant_impact():
-    side_a = [mc.TradePlayer(name="A", team="BUF", position_group="offense",
-                              p10=8000, p50=9000, p90=10000)]
-    side_b = [mc.TradePlayer(name="B", team="KC", position_group="offense",
-                              p10=500, p50=600, p90=700)]
+    side_a = [
+        mc.TradePlayer(
+            name="A", team="BUF", position_group="offense", p10=8000, p50=9000, p90=10000
+        )
+    ]
+    side_b = [
+        mc.TradePlayer(name="B", team="KC", position_group="offense", p10=500, p50=600, p90=700)
+    ]
     base = sym.simulate_symmetric(side_a, side_b, n_sims=2000, seed=1)
     enriched = sym.enrich_with_decision_shape(base, side_a, side_b)
     assert enriched["tierImpact"] == "significant"

--- a/tests/utils/test_age.py
+++ b/tests/utils/test_age.py
@@ -1,4 +1,5 @@
 """Tests for src.utils.age.age_from_birthdate."""
+
 from __future__ import annotations
 
 from datetime import date

--- a/tests/utils/test_circuit_breaker.py
+++ b/tests/utils/test_circuit_breaker.py
@@ -1,4 +1,5 @@
 """Tests for the circuit breaker."""
+
 from __future__ import annotations
 
 import time
@@ -36,8 +37,10 @@ def test_failures_at_threshold_open_the_breaker():
 
 def test_opens_then_half_opens_after_duration():
     bp = cb.get_or_create(
-        "test", failure_threshold=2,
-        failure_window_sec=60, open_duration_sec=0.05,
+        "test",
+        failure_threshold=2,
+        failure_window_sec=60,
+        open_duration_sec=0.05,
     )
     bp.report_failure("x")
     bp.report_failure("y")
@@ -50,8 +53,10 @@ def test_opens_then_half_opens_after_duration():
 
 def test_success_in_half_open_closes():
     bp = cb.get_or_create(
-        "test", failure_threshold=1,
-        failure_window_sec=60, open_duration_sec=0.05,
+        "test",
+        failure_threshold=1,
+        failure_window_sec=60,
+        open_duration_sec=0.05,
     )
     bp.report_failure("x")
     time.sleep(0.1)
@@ -62,8 +67,10 @@ def test_success_in_half_open_closes():
 
 def test_failure_in_half_open_reopens():
     bp = cb.get_or_create(
-        "test", failure_threshold=1,
-        failure_window_sec=60, open_duration_sec=0.05,
+        "test",
+        failure_threshold=1,
+        failure_window_sec=60,
+        open_duration_sec=0.05,
     )
     bp.report_failure("first")
     time.sleep(0.1)
@@ -74,7 +81,9 @@ def test_failure_in_half_open_reopens():
 
 def test_sliding_window_evicts_old_failures():
     bp = cb.get_or_create(
-        "test", failure_threshold=3, failure_window_sec=0.05,
+        "test",
+        failure_threshold=3,
+        failure_window_sec=0.05,
     )
     bp.report_failure("a")
     bp.report_failure("b")
@@ -86,7 +95,9 @@ def test_sliding_window_evicts_old_failures():
 
 def test_fast_fail_counter_increments_when_open():
     bp = cb.get_or_create(
-        "test", failure_threshold=1, failure_window_sec=60,
+        "test",
+        failure_threshold=1,
+        failure_window_sec=60,
         open_duration_sec=60,
     )
     bp.report_failure("x")
@@ -97,7 +108,9 @@ def test_fast_fail_counter_increments_when_open():
 
 def test_force_close_resets_state():
     bp = cb.get_or_create(
-        "test", failure_threshold=1, failure_window_sec=60,
+        "test",
+        failure_threshold=1,
+        failure_window_sec=60,
     )
     bp.report_failure("x")
     assert bp.snapshot()["state"] == "open"
@@ -122,6 +135,7 @@ def test_snapshot_all_lists_every_breaker():
 
 def test_open_transition_logs_warning(caplog):
     import logging
+
     bp = cb.get_or_create("loud", failure_threshold=1, failure_window_sec=60)
     with caplog.at_level(logging.WARNING):
         bp.report_failure("boom")
@@ -130,9 +144,12 @@ def test_open_transition_logs_warning(caplog):
 
 def test_close_transition_logs_info(caplog):
     import logging
+
     bp = cb.get_or_create(
-        "quiet", failure_threshold=1,
-        failure_window_sec=60, open_duration_sec=0.05,
+        "quiet",
+        failure_threshold=1,
+        failure_window_sec=60,
+        open_duration_sec=0.05,
     )
     bp.report_failure("x")
     time.sleep(0.1)

--- a/tests/utils/test_http_fetch.py
+++ b/tests/utils/test_http_fetch.py
@@ -1,4 +1,5 @@
 """Tests for the shared HTTP fetch helper."""
+
 from __future__ import annotations
 
 import io
@@ -13,12 +14,16 @@ def _fake_response(body=b"{}", status=200):
         def __init__(self):
             self.status = status
             self._body = body
+
         def read(self):
             return self._body
+
         def __enter__(self):
             return self
+
         def __exit__(self, *a):
             pass
+
     return _R()
 
 
@@ -34,8 +39,13 @@ def test_successful_fetch_returns_ok():
 def test_http_4xx_does_not_retry():
     def _raise(*_a, **_kw):
         raise urllib.error.HTTPError(
-            "https://x", 404, "Not Found", {}, io.BytesIO(b"not found"),
+            "https://x",
+            404,
+            "Not Found",
+            {},
+            io.BytesIO(b"not found"),
         )
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_raise):
         result = hf.fetch("https://example.com", retries=3, label="t")
     # 404 is caller error; only ONE attempt.
@@ -47,8 +57,13 @@ def test_http_4xx_does_not_retry():
 def test_http_5xx_retries_until_exhausted():
     def _raise(*_a, **_kw):
         raise urllib.error.HTTPError(
-            "https://x", 502, "Bad Gateway", {}, io.BytesIO(b""),
+            "https://x",
+            502,
+            "Bad Gateway",
+            {},
+            io.BytesIO(b""),
         )
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_raise):
         result = hf.fetch("https://example.com", retries=2, retry_delay_base=0, label="t")
     # 1 initial + 2 retries = 3.
@@ -59,6 +74,7 @@ def test_http_5xx_retries_until_exhausted():
 def test_timeout_retries():
     def _raise(*_a, **_kw):
         raise TimeoutError("too slow")
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_raise):
         result = hf.fetch("https://example.com", retries=2, retry_delay_base=0)
     assert result.attempts == 3
@@ -68,6 +84,7 @@ def test_timeout_retries():
 def test_url_error_retries():
     def _raise(*_a, **_kw):
         raise urllib.error.URLError("connection refused")
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_raise):
         result = hf.fetch("https://example.com", retries=2, retry_delay_base=0)
     assert result.attempts == 3
@@ -77,6 +94,7 @@ def test_url_error_retries():
 def test_unexpected_exception_doesnt_crash():
     def _raise(*_a, **_kw):
         raise RuntimeError("boom")
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_raise):
         result = hf.fetch("https://example.com", retries=1, retry_delay_base=0)
     assert result.attempts == 2
@@ -86,8 +104,10 @@ def test_unexpected_exception_doesnt_crash():
 def test_retry_delay_exponential(monkeypatch):
     sleeps = []
     monkeypatch.setattr(hf.time, "sleep", lambda s: sleeps.append(s))
+
     def _raise(*_a, **_kw):
         raise urllib.error.URLError("x")
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_raise):
         hf.fetch("https://example.com", retries=3, retry_delay_base=0.5)
     # 0.5, 1.0, 2.0 — exponential base × 2^attempt.
@@ -96,6 +116,7 @@ def test_retry_delay_exponential(monkeypatch):
 
 def test_ok_logs_structured_line(caplog):
     import logging
+
     with patch.object(hf.urllib.request, "urlopen", return_value=_fake_response(b"x")):
         with caplog.at_level(logging.INFO):
             hf.fetch("https://example.com", label="my_fetch")
@@ -112,13 +133,16 @@ def test_elapsed_time_reasonable():
 def test_circuit_breaker_short_circuits_when_open():
     """When the named breaker is open, no network call happens."""
     from src.utils import circuit_breaker as cb
+
     cb.reset_all_for_tests()
     bp = cb.get_or_create("test_external", failure_threshold=1, failure_window_sec=60)
     bp.report_failure("priming")  # trip it
     calls = []
+
     def _never(*_a, **_kw):
         calls.append(1)
         return _fake_response(b"shouldn't see this")
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_never):
         result = hf.fetch("https://example.com", breaker="test_external")
     assert result.error_kind == "circuit_open"
@@ -129,6 +153,7 @@ def test_circuit_breaker_short_circuits_when_open():
 
 def test_circuit_breaker_success_reports_to_breaker():
     from src.utils import circuit_breaker as cb
+
     cb.reset_all_for_tests()
     bp = cb.get_or_create("test_ext2", failure_threshold=2, failure_window_sec=60)
     with patch.object(hf.urllib.request, "urlopen", return_value=_fake_response(b"ok")):
@@ -140,10 +165,13 @@ def test_circuit_breaker_success_reports_to_breaker():
 
 def test_circuit_breaker_network_failures_trip_it():
     from src.utils import circuit_breaker as cb
+
     cb.reset_all_for_tests()
     bp = cb.get_or_create("test_ext3", failure_threshold=3, failure_window_sec=60)
+
     def _raise(*_a, **_kw):
         raise urllib.error.URLError("refused")
+
     with patch.object(hf.urllib.request, "urlopen", side_effect=_raise):
         for _ in range(3):
             hf.fetch("https://example.com", breaker="test_ext3", retry_delay_base=0)

--- a/tests/utils/test_name_clean.py
+++ b/tests/utils/test_name_clean.py
@@ -1,4 +1,5 @@
 """Unit tests for src/utils/name_clean.py"""
+
 from __future__ import annotations
 
 import pytest
@@ -7,6 +8,7 @@ from src.utils.name_clean import normalize_player_name, normalize_position_famil
 
 
 # ── normalize_player_name ────────────────────────────────────────────
+
 
 class TestNormalizePlayerName:
     def test_basic_name(self):
@@ -26,9 +28,15 @@ class TestNormalizePlayerName:
 
     def test_known_suffix_players_all_normalize_identically(self):
         """Players with Jr/Sr/III suffixes must all collapse to the same key."""
-        assert normalize_player_name("Kenneth Walker III") == normalize_player_name("Kenneth Walker")
-        assert normalize_player_name("Marvin Harrison Jr.") == normalize_player_name("Marvin Harrison")
-        assert normalize_player_name("Marvin Harrison Jr") == normalize_player_name("Marvin Harrison")
+        assert normalize_player_name("Kenneth Walker III") == normalize_player_name(
+            "Kenneth Walker"
+        )
+        assert normalize_player_name("Marvin Harrison Jr.") == normalize_player_name(
+            "Marvin Harrison"
+        )
+        assert normalize_player_name("Marvin Harrison Jr") == normalize_player_name(
+            "Marvin Harrison"
+        )
         assert normalize_player_name("Brian Thomas Jr.") == normalize_player_name("Brian Thomas")
         assert normalize_player_name("Brian Thomas Jr") == normalize_player_name("Brian Thomas")
         assert normalize_player_name("Omar Cooper Jr.") == normalize_player_name("Omar Cooper")
@@ -69,6 +77,7 @@ class TestNormalizePlayerName:
 
 # ── normalize_team ───────────────────────────────────────────────────
 
+
 class TestNormalizeTeam:
     def test_basic_team(self):
         assert normalize_team("kc") == "KC"
@@ -86,41 +95,54 @@ class TestNormalizeTeam:
 
 # ── normalize_position_family ────────────────────────────────────────
 
+
 class TestNormalizePositionFamily:
-    @pytest.mark.parametrize("input_pos,expected", [
-        ("QB", "QB"),
-        ("qb", "QB"),
-        ("RB", "RB"),
-        ("WR", "WR"),
-        ("TE", "TE"),
-    ])
+    @pytest.mark.parametrize(
+        "input_pos,expected",
+        [
+            ("QB", "QB"),
+            ("qb", "QB"),
+            ("RB", "RB"),
+            ("WR", "WR"),
+            ("TE", "TE"),
+        ],
+    )
     def test_offensive_positions(self, input_pos, expected):
         assert normalize_position_family(input_pos) == expected
 
-    @pytest.mark.parametrize("input_pos,expected", [
-        ("DE", "DL"),
-        ("DT", "DL"),
-        ("DL", "DL"),
-        ("EDGE", "DL"),
-    ])
+    @pytest.mark.parametrize(
+        "input_pos,expected",
+        [
+            ("DE", "DL"),
+            ("DT", "DL"),
+            ("DL", "DL"),
+            ("EDGE", "DL"),
+        ],
+    )
     def test_defensive_line(self, input_pos, expected):
         assert normalize_position_family(input_pos) == expected
 
-    @pytest.mark.parametrize("input_pos,expected", [
-        ("LB", "LB"),
-        ("ILB", "LB"),
-        ("OLB", "LB"),
-    ])
+    @pytest.mark.parametrize(
+        "input_pos,expected",
+        [
+            ("LB", "LB"),
+            ("ILB", "LB"),
+            ("OLB", "LB"),
+        ],
+    )
     def test_linebackers(self, input_pos, expected):
         assert normalize_position_family(input_pos) == expected
 
-    @pytest.mark.parametrize("input_pos,expected", [
-        ("S", "DB"),
-        ("SS", "DB"),
-        ("FS", "DB"),
-        ("CB", "DB"),
-        ("DB", "DB"),
-    ])
+    @pytest.mark.parametrize(
+        "input_pos,expected",
+        [
+            ("S", "DB"),
+            ("SS", "DB"),
+            ("FS", "DB"),
+            ("CB", "DB"),
+            ("DB", "DB"),
+        ],
+    )
     def test_defensive_backs(self, input_pos, expected):
         assert normalize_position_family(input_pos) == expected
 
@@ -141,6 +163,7 @@ class TestNormalizePositionFamily:
 
 
 # ── Dynasty-specific name edge cases ─────────────────────────────────
+
 
 class TestDynastyNameEdgeCases:
     """Real player names that have historically caused matching failures."""
@@ -207,11 +230,14 @@ class TestDynastyNameEdgeCases:
 class TestNormalizePositionFamilyEdgeCases:
     """Position strings seen across different data sources."""
 
-    @pytest.mark.parametrize("input_pos,expected", [
-        ("NT", "DL"),       # Nose tackle — maps to DL in canonical aliases
-        ("FLEX", "FLEX"),   # Fantasy position
-        ("SUPER_FLEX", "SUPER"),  # startswith check takes first token
-    ])
+    @pytest.mark.parametrize(
+        "input_pos,expected",
+        [
+            ("NT", "DL"),  # Nose tackle — maps to DL in canonical aliases
+            ("FLEX", "FLEX"),  # Fantasy position
+            ("SUPER_FLEX", "SUPER"),  # startswith check takes first token
+        ],
+    )
     def test_fantasy_and_rare_positions(self, input_pos, expected):
         assert normalize_position_family(input_pos) == expected
 
@@ -245,6 +271,7 @@ class TestNormalizeTeamEdgeCases:
 
 
 # ── normalize_position_family ──────────────────────────────────────
+
 
 class TestNormalizePositionFamily:
     # Standard positions

--- a/tests/utils/test_request_context.py
+++ b/tests/utils/test_request_context.py
@@ -1,4 +1,5 @@
 """Tests for per-request correlation context."""
+
 from __future__ import annotations
 
 import asyncio
@@ -33,6 +34,7 @@ def test_new_request_id_is_url_safe_and_short():
 def test_context_isolated_across_async_tasks():
     """Each async task has its own context — one task's request
     ID doesn't leak to a sibling."""
+
     async def _run(tag):
         rc.set_request_id(f"req-{tag}")
         await asyncio.sleep(0.01)
@@ -51,8 +53,10 @@ def test_context_isolated_across_threads():
     """Separate thread → separate context.  Context only crosses
     task/thread boundaries via explicit copy, which we don't do."""
     rc.set_request_id("main-thread")
+
     def _inner():
         return rc.current_request_id()
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
         val = ex.submit(_inner).result()
     # The thread doesn't inherit the ContextVar (no copy_context).

--- a/tests/utils/test_resolve_idp_position.py
+++ b/tests/utils/test_resolve_idp_position.py
@@ -2,6 +2,7 @@
 Sleeper players under the same priority: DL > DB > LB. These tests pin
 the shared helper behaviour. Every site-level test below (in the other
 test modules) asserts the *integration* with this helper."""
+
 from __future__ import annotations
 
 import pytest
@@ -25,7 +26,7 @@ class TestResolveIdpPosition:
             # DL beats LB no matter which side or notation.
             (("DL", "LB"), "DL"),
             (("LB", "DL"), "DL"),
-            (("DE", "OLB"), "DL"),            # DE → DL; OLB → LB
+            (("DE", "OLB"), "DL"),  # DE → DL; OLB → LB
             (("EDGE", "ILB"), "DL"),
             # DB beats LB.
             (("LB", "DB"), "DB"),
@@ -83,14 +84,14 @@ class TestResolveIdpPosition:
     @pytest.mark.parametrize(
         "inputs",
         [
-            ("QB", "LB"),          # mixed offense + LB
-            ("LB", "QB"),          # reversed order
-            (["QB", "LB"],),       # list form
-            ("QB/LB",),            # slash form
-            ("LB,WR",),            # comma form
-            ("LB|TE",),            # pipe form
-            ("LB", ["RB"]),        # split across candidates
-            ("K", "LB"),           # kicker + LB
+            ("QB", "LB"),  # mixed offense + LB
+            ("LB", "QB"),  # reversed order
+            (["QB", "LB"],),  # list form
+            ("QB/LB",),  # slash form
+            ("LB,WR",),  # comma form
+            ("LB|TE",),  # pipe form
+            ("LB", ["RB"]),  # split across candidates
+            ("K", "LB"),  # kicker + LB
         ],
     )
     def test_lb_is_refused_when_any_non_idp_is_present(self, inputs):
@@ -188,7 +189,7 @@ class TestNormalizePositionFamily:
             ("DL LB", "DL"),
             ("LB DL", "DL"),
             ("DL DB", "DL"),
-            ("LB WR", "WR"),         # exclusivity
+            ("LB WR", "WR"),  # exclusivity
             ("WR LB", "WR"),
             # Mixed separator + whitespace (e.g. "LB, CB").
             ("LB, CB", "DB"),
@@ -196,9 +197,7 @@ class TestNormalizePositionFamily:
             ("LB|  CB", "DB"),
         ],
     )
-    def test_whitespace_and_mixed_separator_inputs_route_through_idp_priority(
-        self, pos, expected
-    ):
+    def test_whitespace_and_mixed_separator_inputs_route_through_idp_priority(self, pos, expected):
         assert normalize_position_family(pos) == expected
 
     @pytest.mark.parametrize(
@@ -207,8 +206,8 @@ class TestNormalizePositionFamily:
             # resolve_idp_position itself must also split on whitespace.
             ("DL LB", "DL"),
             ("LB CB", "DB"),
-            ("LB WR", ""),       # LB exclusivity: non-IDP present → empty
-            ("DL WR", "DL"),     # DL wins regardless
+            ("LB WR", ""),  # LB exclusivity: non-IDP present → empty
+            ("DL WR", "DL"),  # DL wins regardless
         ],
     )
     def test_resolve_idp_position_splits_whitespace(self, inputs, expected):

--- a/tools/rankings_diff.py
+++ b/tools/rankings_diff.py
@@ -31,6 +31,7 @@ Exit codes
 
 Pure-Python; no external deps beyond urllib.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -90,7 +91,9 @@ def _ranks_by_name(payload: dict[str, Any]) -> dict[str, tuple[int, str]]:
     return out
 
 
-def _diff(baseline: dict[str, tuple[int, str]], candidate: dict[str, tuple[int, str]]) -> dict[str, Any]:
+def _diff(
+    baseline: dict[str, tuple[int, str]], candidate: dict[str, tuple[int, str]]
+) -> dict[str, Any]:
     """Compute the diff.  Returns a dict with all the stats."""
     common = set(baseline.keys()) & set(candidate.keys())
     only_baseline = set(baseline.keys()) - set(candidate.keys())
@@ -130,8 +133,7 @@ def _diff(baseline: dict[str, tuple[int, str]], candidate: dict[str, tuple[int, 
     biggest_drops = deltas[-20:][::-1]
 
     by_pos = {
-        pos: round(sum(vals) / len(vals), 2) if vals else 0.0
-        for pos, vals in by_pos_abs.items()
+        pos: round(sum(vals) / len(vals), 2) if vals else 0.0 for pos, vals in by_pos_abs.items()
     }
     return {
         "commonCount": len(common),
@@ -164,11 +166,11 @@ def _format_report(diff: dict[str, Any]) -> str:
         lines.append(f"  {pos:>5}: {diff['byPosMeanAbs'][pos]:.2f}")
     lines.append("")
     lines.append("Biggest CLIMBS (rank improved most):")
-    for (name, b, c, d, pos) in diff["biggestClimbs"]:
+    for name, b, c, d, pos in diff["biggestClimbs"]:
         lines.append(f"  {pos:>4} {name[:28]:<28} {b:>4} → {c:<4} ({d:+d})")
     lines.append("")
     lines.append("Biggest DROPS (rank worsened most):")
-    for (name, b, c, d, pos) in diff["biggestDrops"]:
+    for name, b, c, d, pos in diff["biggestDrops"]:
         lines.append(f"  {pos:>4} {name[:28]:<28} {b:>4} → {c:<4} ({d:+d})")
     return "\n".join(lines)
 
@@ -179,7 +181,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("candidate", help="file path or URL")
     parser.add_argument("--cookie", help="Cookie header for authed URLs")
     parser.add_argument(
-        "--warn-threshold", type=int, default=50,
+        "--warn-threshold",
+        type=int,
+        default=50,
         help="Exit 1 if any player moves >N ranks (default 50)",
     )
     args = parser.parse_args(argv)
@@ -194,7 +198,9 @@ def main(argv: list[str] | None = None) -> int:
     diff = _diff(b_ranks, c_ranks)
     print(_format_report(diff))
     if diff["moved"][args.warn_threshold] > 0:
-        print(f"\nWARN: {diff['moved'][args.warn_threshold]} players moved >{args.warn_threshold} ranks")
+        print(
+            f"\nWARN: {diff['moved'][args.warn_threshold]} players moved >{args.warn_threshold} ranks"
+        )
         return 1
     return 0
 


### PR DESCRIPTION
## Summary
Phase **A1** of the approved P1 lint/format/type roadmap. Mechanical, behavior-preserving `ruff format` sweep + a hard-blocking format check in CI. **No logic changes.**

- New `pyproject.toml`: `[tool.ruff]` (`line-length=100`, py312, excludes data/exports/.next/node_modules/frontend) + Black-compatible `[tool.ruff.format]`; `[tool.ruff.lint]`/`[tool.mypy]` scaffolds defined but **not gated** (lint→A2/A3 report-only then changed-files; mypy→A4 per-module ratchet).
- `ruff`/`mypy` pinned in `requirements-dev.txt` (prod runtime unaffected).
- `ruff format .` → **393 files reformatted**.
- Hard-blocking `python -m ruff format --check .` added to `pr-validation.yml` + `deploy.yml` validate job.

## Behavior preservation (proven, not assumed)
- **String-normalized AST equivalence** across all 408 comparable `.py` files → **zero structural changes**. The only raw-AST deltas were PEP-257 docstring re-indentation (intentional ruff/Black behavior).
- Full suite: **2961 passed, 3 skipped, 0 failures**.
- `ruff format --check .` idempotent post-sweep.

## Test plan
- [x] AST-equivalence verification (string-normalized) — zero structural change
- [x] `pytest tests/ -q` — 2961 passed
- [x] `ruff format --check .` — clean (gate will pass)
- [ ] Post-deploy: `/api/health` ok; CI format gate visibly enforced on subsequent PRs

Note: large diff (393 files) is purely mechanical formatting; review by trusting the AST proof + suite, not line-by-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)