### PR TITLE
test(frontend): shared player fixtures + PlayerPopup behavioral tests (phase B)

### DIFF
--- a/frontend/__tests__/components/PlayerPopup.test.jsx
+++ b/frontend/__tests__/components/PlayerPopup.test.jsx
@@ -1,0 +1,96 @@
+// PlayerPopup behavioral tests.
+//
+// PlayerPopup is wired through five context hooks + a network-fetching
+// child chart. We mock the hooks to controlled defaults and stub the
+// chart so the test exercises PlayerPopup's own behavior (render,
+// close affordances, add-to-trade) and nothing downstream.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { makePlayer } from "../fixtures/players";
+
+vi.mock("@/components/AppShell", () => ({
+  useApp: () => ({ rows: [], rawData: {} }),
+}));
+vi.mock("@/components/useTeam", () => ({
+  useTeam: () => ({ selectedTeam: null }),
+}));
+vi.mock("@/components/useTerminal", () => ({
+  useTerminal: () => ({ signals: [] }),
+}));
+vi.mock("@/components/useUserState", () => ({
+  useUserState: () => ({
+    state: {},
+    toggleWatchlist: vi.fn(),
+    serverBacked: false,
+  }),
+}));
+vi.mock("@/components/useSettings", () => ({
+  useSettings: () => ({ settings: {} }),
+}));
+// Child chart fetches /api/data/player-source-history — stub it out.
+vi.mock("@/components/PlayerRankHistoryChart", () => ({
+  default: () => <div data-testid="rank-history-stub" />,
+}));
+// next/link needs the Next runtime; a plain anchor is enough here.
+vi.mock("next/link", () => ({
+  default: ({ children, href }) => <a href={href}>{children}</a>,
+}));
+
+import PlayerPopup from "@/components/PlayerPopup";
+
+beforeEach(() => {
+  // PlayerPopup loads ROS values via fetch in an effect.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+  );
+});
+
+function renderPopup(extra = {}) {
+  const onClose = vi.fn();
+  const onAddToTrade = vi.fn();
+  const row = makePlayer();
+  render(
+    <PlayerPopup
+      row={row}
+      siteKeys={["ktc", "fantasycalc"]}
+      onClose={onClose}
+      onAddToTrade={onAddToTrade}
+      {...extra}
+    />,
+  );
+  return { onClose, onAddToTrade, row };
+}
+
+describe("PlayerPopup", () => {
+  it("renders the player and a close control", () => {
+    const { row } = renderPopup();
+    expect(screen.getAllByText(new RegExp(row.name, "i")).length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: /close player details/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes on Escape", () => {
+    const { onClose } = renderPopup();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when the close button is clicked", () => {
+    const { onClose } = renderPopup();
+    fireEvent.click(
+      screen.getByRole("button", { name: /close player details/i }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("adds to trade then closes", () => {
+    const { onClose, onAddToTrade, row } = renderPopup();
+    fireEvent.click(
+      screen.getByRole("button", { name: new RegExp(`add ${row.name} to trade`, "i") }),
+    );
+    expect(onAddToTrade).toHaveBeenCalledWith(row);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/fixtures/players.js
+++ b/frontend/__tests__/fixtures/players.js
@@ -1,0 +1,44 @@
+// Shared player/contract fixtures for component + logic tests.
+//
+// Mirrors the backend-stamped contract shape (see backend
+// tests/test_trade_suggestions.py `_row`/`_contract`) and the inline
+// `withStamps` helper in dynasty-data.test.js, centralised so component
+// tests don't each re-invent a player object.
+
+export function makePlayer(overrides = {}) {
+  const name = overrides.name || "Josh Allen";
+  const value = overrides.rankDerivedValue ?? 9200;
+  const rank = overrides.canonicalConsensusRank ?? 1;
+  return {
+    name,
+    displayName: name,
+    canonicalName: name,
+    position: overrides.position || "QB",
+    pos: overrides.pos || overrides.position || "QB",
+    team: overrides.team || "BUF",
+    assetClass: overrides.assetClass || "offense",
+    rookie: overrides.rookie ?? false,
+    canonicalConsensusRank: rank,
+    rankDerivedValue: value,
+    sourceCount: overrides.sourceCount ?? 6,
+    sourceRanks: overrides.sourceRanks || { ktc: rank, fantasycalc: rank },
+    canonicalSiteValues: overrides.canonicalSiteValues || {
+      ktc: value,
+      fantasycalc: value + 50,
+    },
+    values: overrides.values || {
+      rawComposite: value,
+      finalAdjusted: value,
+      overall: value,
+    },
+    ...overrides,
+  };
+}
+
+export function makeContract(players = [makePlayer()]) {
+  const arr = players.map((p) => (p && p.name ? p : makePlayer(p)));
+  return {
+    playersArray: arr,
+    players: Object.fromEntries(arr.map((p) => [p.name, p])),
+  };
+}


### PR DESCRIPTION
## Summary
First real component coverage on the jsdom infra from #490.

- **`__tests__/fixtures/players.js`** — shared `makePlayer`/`makeContract` factory mirroring the backend-stamped contract shape (backend `_row`/`_contract` + the inline `withStamps` in `dynasty-data.test.js`).
- **`__tests__/components/PlayerPopup.test.jsx`** — PlayerPopup is wired through 5 context hooks + a network-fetching rank-history chart; all mocked/stubbed so the test exercises **PlayerPopup's own observable behavior**:
  1. renders the player + close control
  2. Escape closes
  3. close button closes
  4. add-to-trade → `onAddToTrade(row)` then `onClose`
  Assertions target confirmed `aria-label`s, not implementation.

Rankings/trade/data-hook tests are the **next** test PR (one component per PR per the approved plan; rankings is a 1938-line page needing ~7 child stubs and deserves its own focused increment).

## Test plan
- [x] `npm run test` → 31 files / **894 passed** (889 logic unchanged + infra smoke + 4 PlayerPopup)
- [x] `npm run build` → green, all pages under bundle budget
- [ ] Post-deploy: `/api/health` ok (test-only — zero runtime/bundle impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)