### PR TITLE
ci(lint): enforce ruff on changed files only (phase A3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,9 +74,13 @@ jobs:
           # a hotfix pushed straight to main can't bypass it.
           python -m ruff format --check .
 
-      - name: Python lint (ruff check — report-only)
-        # Phase A2: non-blocking (mirrors pr-validation). Becomes a
-        # changed-files-only hard gate in A3.
+      - name: Python lint (ruff check — report-only mirror)
+        # Enforcement lives on the PR gate (pr-validation.yml runs the
+        # changed-files-only blocking ruff check; nothing reaches main
+        # without passing it). This post-merge whole-repo run stays
+        # report-only — a visible signal of the pre-existing backlog
+        # without re-deriving "changed files" from a merge commit,
+        # which is fragile and would gain nothing.
         if: ${{ always() }}
         continue-on-error: true
         shell: bash

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history so the changed-files ruff gate can diff the
+          # PR against its base SHA.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -66,16 +70,30 @@ jobs:
           # idempotent. Config: pyproject.toml [tool.ruff].
           python -m ruff format --check .
 
-      - name: Python lint (ruff check — report-only)
-        # Phase A2: non-blocking so the lint surface is visible on PRs
-        # without false-blocking on the pre-existing backlog. Flipped
-        # to changed-files-only enforcement in A3.
-        if: ${{ always() }}
-        continue-on-error: true
+      - name: Python lint (ruff check — changed files, blocking)
+        # Phase A3: ratcheted enforcement. We lint ONLY the .py files
+        # this PR adds/modifies/renames, diffed against the PR base
+        # SHA. The ~77-item pre-existing backlog stays unblocked
+        # (whole-repo enforcement was never the goal); any NEW lint
+        # violation introduced by the PR fails here. force-exclude in
+        # pyproject keeps excluded dirs excluded even when passed
+        # explicitly. (deploy.yml keeps a report-only mirror — merges
+        # can't land without passing this gate, so post-merge
+        # changed-files diffing there would add fragility for no gain.)
         shell: bash
         run: |
           set -Eeuo pipefail
-          python -m ruff check . --output-format concise
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          changed="$(git diff --name-only --diff-filter=ACMR "${base_sha}" HEAD -- '*.py' || true)"
+          if [ -z "${changed}" ]; then
+            echo "No changed .py files — nothing to lint."
+            exit 0
+          fi
+          echo "Linting changed .py files:"
+          printf '%s\n' "${changed}"
+          # -d '\n' so a path with a space ("Dynasty Scraper.py") is
+          # passed as a single argument.
+          printf '%s\n' "${changed}" | xargs -r -d '\n' python -m ruff check
 
       - name: Python import gate
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@
 line-length = 100  # matches the observed ~89% ≤100 baseline
 target-version = "py312"
 extend-exclude = ["data", "exports", ".next", "node_modules", "frontend"]
+# Honour the excludes even when a path is passed explicitly (the A3
+# changed-files gate calls `ruff check <file>...`); without this a
+# changed .py under an excluded dir would still get linted.
+force-exclude = true
 
 [tool.ruff.lint]
 # Pyflakes (F) + pycodestyle (E/W). Lint runs report-only in CI as of


### PR DESCRIPTION
## Summary
Flips the A2 report-only ruff step to a **blocking, ratcheted** gate.

- **pr-validation.yml**: lints **only** the `.py` files the PR adds/modifies/renames (`git diff --diff-filter=ACMR <base.sha> HEAD -- '*.py'`), **blocking**. The ~77-item pre-existing backlog stays unblocked; any **new** violation a PR introduces fails CI. `Checkout` gains `fetch-depth: 0`; `xargs -d '\n'` keeps `Dynasty Scraper.py` a single arg; empty set → `exit 0`.
- **pyproject.toml**: `force-exclude = true` so a changed `.py` under an excluded dir is still skipped when passed explicitly.
- **deploy.yml**: ruff stays a **report-only** whole-repo mirror — nothing reaches main without passing the PR gate, so re-deriving "changed files" from a merge commit there would add fragility for no gain.

## Test plan
- [x] All gate branches simulated locally: clean→pass, new-violation→**block** (incl. space-named path), empty→exit 0, force-exclude→skip
- [x] `ruff format --check` green (A1 gate unaffected); full suite **2982 passed**
- [x] This PR touches no `.py` → its own changed-files step is a correct no-op; the next `.py` PR exercises enforcement
- [ ] Post-deploy: `/api/health` ok; CI shows the new blocking step green here

🤖 Generated with [Claude Code](https://claude.com/claude-code)