### PR TITLE
fix(trades): resolve unknown Sleeper ids + two-team combined history

### DIFF
--- a/frontend/__tests__/league-analysis.test.js
+++ b/frontend/__tests__/league-analysis.test.js
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   analyzeSleeperTradeHistory,
   analyzeTradeTendencies,
+  buildCombinedPairTrade,
   buildSleeperIdentityMaps,
 } from "@/lib/league-analysis";
 
@@ -437,5 +438,99 @@ describe("analyzeTradeTendencies — ownerId aggregation", () => {
     // 3 managers: user-prev under historical name, user-new under
     // current name, user-opponent under current name.
     expect(managers).toEqual(["New Manager", "Opponent", "Previous Manager"]);
+  });
+});
+
+describe("buildCombinedPairTrade — two-team net history", () => {
+  // Mirror the "Dak" example: an asset that goes A→B, back B→A, then
+  // A→B again must net to a single A→B move (odd crossings collapse to
+  // one); an asset that goes there-and-back exactly once cancels.
+  const tradeAtoB = mkTrade({
+    offsetDaysAgo: 9,
+    sides: [
+      { team: "Brent", got: ["Test Mid"], gave: ["Test Star"] },
+      { team: "Roy", got: ["Test Star"], gave: ["Test Mid"] },
+    ],
+  });
+  const tradeBtoA = mkTrade({
+    offsetDaysAgo: 6,
+    sides: [
+      { team: "Brent", got: ["Test Star"], gave: ["Test Mid"] },
+      { team: "Roy", got: ["Test Mid"], gave: ["Test Star"] },
+    ],
+  });
+
+  it("collapses repeated back-and-forth into a single net move", () => {
+    const rawData = {
+      sleeper: { trades: [tradeAtoB, tradeBtoA, { ...tradeAtoB }] },
+    };
+    const analysis = analyzeSleeperTradeHistory(rawData, rows);
+    const combined = buildCombinedPairTrade(
+      analysis,
+      "Brent",
+      "Roy",
+      rawData,
+      rows,
+    );
+    expect(combined).toBeTruthy();
+    expect(combined.combined).toBe(true);
+    expect(combined.tradeCount).toBe(3);
+    const brent = combined.sides.find((s) => s.team === "Brent");
+    const roy = combined.sides.find((s) => s.team === "Roy");
+    // Test Star: gave, got, gave → net A→B once.  Test Mid mirrors.
+    expect(brent.gave.map((i) => i.name)).toEqual(["Test Star"]);
+    expect(brent.got.map((i) => i.name)).toEqual(["Test Mid"]);
+    // No asset is double-counted — exactly one of each survives.
+    expect(brent.gave).toHaveLength(1);
+    expect(brent.got).toHaveLength(1);
+    // Roy is the exact mirror of Brent.
+    expect(roy.got.map((i) => i.name)).toEqual(["Test Star"]);
+    expect(roy.gave.map((i) => i.name)).toEqual(["Test Mid"]);
+  });
+
+  it("returns a wash when a single there-and-back fully cancels", () => {
+    const rawData = { sleeper: { trades: [tradeAtoB, tradeBtoA] } };
+    const analysis = analyzeSleeperTradeHistory(rawData, rows);
+    const combined = buildCombinedPairTrade(
+      analysis,
+      "Brent",
+      "Roy",
+      rawData,
+      rows,
+    );
+    expect(combined).toEqual({
+      wash: true,
+      teamA: "Brent",
+      teamB: "Roy",
+      tradeCount: 2,
+    });
+  });
+
+  it("returns null when the two teams never traded head-to-head", () => {
+    const rawData = { sleeper: { trades: [tradeAtoB] } };
+    const analysis = analyzeSleeperTradeHistory(rawData, rows);
+    expect(
+      buildCombinedPairTrade(analysis, "Brent", "Ghost", rawData, rows),
+    ).toBeNull();
+    // Same team twice is a no-op.
+    expect(
+      buildCombinedPairTrade(analysis, "Brent", "Brent", rawData, rows),
+    ).toBeNull();
+  });
+
+  it("skips 3+ team trades (ambiguous A↔B flow)", () => {
+    const threeWay = mkTrade({
+      offsetDaysAgo: 2,
+      sides: [
+        { team: "Brent", got: ["Test Star"], gave: ["Test Mid"] },
+        { team: "Roy", got: ["Test Mid"], gave: [] },
+        { team: "Carl", got: [], gave: ["Test Star"] },
+      ],
+    });
+    const rawData = { sleeper: { trades: [threeWay] } };
+    const analysis = analyzeSleeperTradeHistory(rawData, rows);
+    expect(
+      buildCombinedPairTrade(analysis, "Brent", "Roy", rawData, rows),
+    ).toBeNull();
   });
 });

--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -9,6 +9,7 @@ import { TRADE_ALPHA } from "@/lib/trade-logic";
 import {
   analyzeSleeperTradeHistory,
   analyzeTradeTendencies,
+  buildCombinedPairTrade,
   POS_GROUP_COLORS,
 } from "@/lib/league-analysis";
 import { encodeTrade, SHARE_PARAM } from "@/lib/trade-share";
@@ -25,6 +26,7 @@ export default function TradesPage() {
   const { rows, rawData, loading, error } = useApp();
   const { settings } = useSettings();
   const [teamFilter, setTeamFilter] = useState("");
+  const [teamFilterB, setTeamFilterB] = useState("");
   const [playerQuery, setPlayerQuery] = useState("");
 
   const alpha = settings.alpha || TRADE_ALPHA;
@@ -95,6 +97,22 @@ export default function TradesPage() {
     return results;
   }, [analysis, teamFilter, playerQuery]);
 
+  // When two distinct teams are picked, collapse their entire
+  // head-to-head history into one synthetic "big trade" — assets that
+  // bounced back and forth cancel out (see buildCombinedPairTrade).
+  const combined = useMemo(() => {
+    if (!teamFilter || !teamFilterB || teamFilter === teamFilterB) return null;
+    return buildCombinedPairTrade(
+      analysis,
+      teamFilter,
+      teamFilterB,
+      rawData,
+      rows,
+      alpha,
+    );
+  }, [analysis, teamFilter, teamFilterB, rawData, rows, alpha]);
+  const combineMode = !!(teamFilter && teamFilterB && teamFilter !== teamFilterB);
+
   const tendencies = useMemo(
     () => analyzeTradeTendencies(rawData, rows),
     [rawData, rows],
@@ -110,29 +128,57 @@ export default function TradesPage() {
       <div className="card">
         <PageHeader
           title="Trade History"
-          subtitle={`Analyzing ${analysis.analyzed.length} trades in the last ${windowDays} days using alpha=${alpha}`}
+          subtitle={
+            combineMode
+              ? `Combined head-to-head history: ${teamFilter} ↔ ${teamFilterB} (assets that bounced back cancel out)`
+              : `Analyzing ${analysis.analyzed.length} trades in the last ${windowDays} days using alpha=${alpha}`
+          }
           actions={
             hasTrades && (
               <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                <input
-                  className="input"
-                  type="search"
-                  placeholder="Search player or pick..."
-                  value={playerQuery}
-                  onChange={(e) => setPlayerQuery(e.target.value)}
-                  style={{ minWidth: 200 }}
-                />
+                {!combineMode && (
+                  <input
+                    className="input"
+                    type="search"
+                    placeholder="Search player or pick..."
+                    value={playerQuery}
+                    onChange={(e) => setPlayerQuery(e.target.value)}
+                    style={{ minWidth: 200 }}
+                  />
+                )}
                 {teams.length > 0 && (
                   <select
                     className="input"
                     value={teamFilter}
-                    onChange={(e) => setTeamFilter(e.target.value)}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setTeamFilter(v);
+                      // Clearing the first team, or matching the
+                      // second, drops the combine selection.
+                      if (!v || v === teamFilterB) setTeamFilterB("");
+                    }}
                     style={{ minWidth: 160 }}
                   >
                     <option value="">All teams</option>
                     {teams.map((t) => (
                       <option key={t} value={t}>{t}</option>
                     ))}
+                  </select>
+                )}
+                {teams.length > 0 && teamFilter && (
+                  <select
+                    className="input"
+                    value={teamFilterB}
+                    onChange={(e) => setTeamFilterB(e.target.value)}
+                    style={{ minWidth: 180 }}
+                    aria-label="Combine with a second team"
+                  >
+                    <option value="">+ combine 2nd team…</option>
+                    {teams
+                      .filter((t) => t !== teamFilter)
+                      .map((t) => (
+                        <option key={t} value={t}>vs {t}</option>
+                      ))}
                   </select>
                 )}
               </div>
@@ -150,38 +196,51 @@ export default function TradesPage() {
         </div>
       )}
 
-      {/* Winners & Losers stats card */}
-      {hasTrades && <TeamScoresCard teamScores={analysis.teamScores} alpha={alpha} />}
-
-      {/* Trade tendencies */}
-      {hasTrades && tendencies.length > 0 && <TradeTendenciesCard tendencies={tendencies} />}
-
-      {/* Trade list */}
-      {filtered.length > 0 && (
-        <div className="list" style={{ marginTop: "var(--space-md)" }}>
-          {filtered.map((a, idx) => (
-            <TradeCard
-              key={idx}
-              analysis={a}
-              retroSides={retroByTrade.get(a.id) || []}
-            />
-          ))}
-        </div>
+      {/* Two-team combined view: one synthetic "big trade". */}
+      {hasTrades && combineMode && (
+        <CombinedTradeSection
+          combined={combined}
+          teamA={teamFilter}
+          teamB={teamFilterB}
+        />
       )}
 
-      {(teamFilter || playerQuery) && filtered.length === 0 && (
-        <div className="card">
-          <EmptyState
-            title="No trades match"
-            message={
-              teamFilter && playerQuery
-                ? `No trades for ${teamFilter} involving "${playerQuery}".`
-                : playerQuery
-                  ? `No trades involving "${playerQuery}".`
-                  : `No trades found for ${teamFilter}.`
-            }
-          />
-        </div>
+      {hasTrades && !combineMode && (
+        <>
+          {/* Winners & Losers stats card */}
+          <TeamScoresCard teamScores={analysis.teamScores} alpha={alpha} />
+
+          {/* Trade tendencies */}
+          {tendencies.length > 0 && <TradeTendenciesCard tendencies={tendencies} />}
+
+          {/* Trade list */}
+          {filtered.length > 0 && (
+            <div className="list" style={{ marginTop: "var(--space-md)" }}>
+              {filtered.map((a, idx) => (
+                <TradeCard
+                  key={idx}
+                  analysis={a}
+                  retroSides={retroByTrade.get(a.id) || []}
+                />
+              ))}
+            </div>
+          )}
+
+          {(teamFilter || playerQuery) && filtered.length === 0 && (
+            <div className="card">
+              <EmptyState
+                title="No trades match"
+                message={
+                  teamFilter && playerQuery
+                    ? `No trades for ${teamFilter} involving "${playerQuery}".`
+                    : playerQuery
+                      ? `No trades involving "${playerQuery}".`
+                      : `No trades found for ${teamFilter}.`
+                }
+              />
+            </div>
+          )}
+        </>
       )}
     </section>
   );
@@ -349,6 +408,36 @@ function fmtRetro(retro) {
   };
 }
 
+function CombinedTradeSection({ combined, teamA, teamB }) {
+  if (!combined) {
+    return (
+      <div className="card" style={{ marginTop: "var(--space-md)" }}>
+        <EmptyState
+          title="No head-to-head trades"
+          message={`${teamA} and ${teamB} have never traded directly with each other (3+ team trades are not combined).`}
+        />
+      </div>
+    );
+  }
+  if (combined.wash) {
+    return (
+      <div className="card" style={{ marginTop: "var(--space-md)" }}>
+        <EmptyState
+          title="Net wash"
+          message={`Across ${combined.tradeCount} trade${
+            combined.tradeCount === 1 ? "" : "s"
+          }, every asset ${teamA} and ${teamB} swapped eventually came back — the combined trade nets to nothing.`}
+        />
+      </div>
+    );
+  }
+  return (
+    <div className="list" style={{ marginTop: "var(--space-md)" }}>
+      <TradeCard analysis={combined} retroSides={[]} />
+    </div>
+  );
+}
+
 function TradeCard({ analysis: a, retroSides = [] }) {
   // Headline reflects the largest grievance — winner OR loser,
   // whichever has the biggest magnitude pctGap.  If no side clears
@@ -393,7 +482,9 @@ function TradeCard({ analysis: a, retroSides = [] }) {
       {/* Header */}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
         <span style={{ fontSize: "0.68rem", color: "var(--subtext)" }}>
-          Week {a.trade.week} &middot; {a.date}
+          {a.combined
+            ? `${a.teamA} ↔ ${a.teamB} · ${a.tradeCount} trade${a.tradeCount === 1 ? "" : "s"} combined`
+            : `Week ${a.trade.week} · ${a.date}`}
         </span>
         {showBadge ? (
           <span className="badge" style={{ background: badgeBg, color: badgeColor }}>

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -289,6 +289,148 @@ function sideDisplayName(side, identityMaps) {
  * split across the two owners.  Falls back to rosterId and then team
  * name for older scraper output that did not emit ownerId.
  */
+// Resolve a list of raw item labels to { items, linear, weighted, values }.
+// ``weighted`` uses the alpha exponent so a single star asset counts
+// more than a pile of scrubs with the same linear sum.  ``values`` is
+// the bare numeric array — needed by V12 VA which computes per-piece
+// raw_adjustments based on the absolute KTC scale.
+function resolveTradeSideList(rawList, ctx) {
+  const { rowLookup, posMap, pickAliases, alpha } = ctx;
+  const items = [];
+  const values = [];
+  let linear = 0;
+  let weighted = 0;
+  for (const rawItem of getTradeSideItemLabels(rawList)) {
+    const resolved = resolveTradeItemValue(rawItem, rowLookup, posMap, pickAliases);
+    const safeVal = Number.isFinite(resolved.value) ? Math.max(0, resolved.value) : 0;
+    linear += safeVal;
+    weighted += Math.pow(Math.max(safeVal, 1), alpha);
+    if (safeVal > 0) values.push(safeVal);
+    items.push({
+      name: resolved.name,
+      val: Math.round(safeVal),
+      pos: resolved.pos,
+      isPick: resolved.isPick,
+      playerId: resolved.playerId,
+      team: resolved.team,
+    });
+  }
+  return { items, linear, weighted, values };
+}
+
+// KTC value adjustment for one team's "got vs gave" comparison —
+// routes through ``ktcAdjustPackage``, the verbatim port of KTC's
+// site.min.js algorithm (PR #335).  Treat got/gave as a 2-side trade:
+// positive ``vaNet`` means this team RECEIVED the stud premium (got
+// side wins on KTC's intensity-adjusted raw_adj); negative means they
+// GAVE the studs away.  Pure: value arrays only, no React/row refs.
+function computeTradeVANet(gotValues, gaveValues) {
+  if (!gotValues.length || !gaveValues.length) return 0;
+  const result = ktcAdjustPackage(gotValues, gaveValues);
+  if (!result.displayed || result.value <= 0) return 0;
+  // ktcAdjustPackage's `side` follows KTC's team1/team2 convention.
+  // We pass got=team1, gave=team2.  side=1 means got receives the VA
+  // (positive); side=2 means gave receives it (penalty for got).
+  return result.side === 1 ? result.value : -result.value;
+}
+
+/**
+ * Build the shared resolution context (row lookup, position map, pick
+ * aliases, identity maps, alpha) used to value any single trade.
+ * Extracted so both the rolling-window scan and the two-team combined
+ * aggregator value assets through exactly the same pipeline.
+ */
+export function buildTradeAnalysisCtx(rawData, rows, alpha = TRADE_ALPHA) {
+  return {
+    rowLookup: buildRowLookup(rows),
+    posMap: rawData?.sleeper?.positions || {},
+    pickAliases: rawData?.pickAliases || null,
+    identityMaps: buildSleeperIdentityMaps(rawData?.sleeper?.teams),
+    alpha,
+  };
+}
+
+/**
+ * Analyze ONE raw trade ({week, timestamp, sides:[{team, got, gave,
+ * ownerId?, rosterId?}]}) into the rendered card shape.  Pure given a
+ * ctx from ``buildTradeAnalysisCtx``.  Does NOT touch teamScores —
+ * the caller owns league-wide aggregation.
+ */
+export function analyzeRawTrade(trade, ctx) {
+  const { identityMaps } = ctx;
+  const ts = normalizeTradeTimestampMs(trade.timestamp);
+  const date = ts ? new Date(ts).toLocaleDateString() : "?";
+  const sides = [];
+
+  for (const side of trade.sides || []) {
+    const got = resolveTradeSideList(side?.got, ctx);
+    const gave = resolveTradeSideList(side?.gave, ctx);
+    const netLinear = got.linear - gave.linear;
+    const netWeighted = got.weighted - gave.weighted;
+    // V13 KTC-style VA for this team's got-vs-gave equation.
+    const vaNet = computeTradeVANet(got.values, gave.values);
+    const netAdjusted = netLinear + vaNet;
+    // Denominator is the larger EFFECTIVE side total (linear + VA).
+    // Don't include the alpha-powered weighted sums — those dominate
+    // by an order of magnitude and would crush all pcts toward zero.
+    const gotEffective = got.linear + Math.max(0, vaNet);
+    const gaveEffective = gave.linear + Math.max(0, -vaNet);
+    const scale = Math.max(gotEffective, gaveEffective, 1);
+    const pctGap = (netAdjusted / scale) * 100;
+    const grade = gradeTradeHistorySide(Math.abs(pctGap), pctGap > 0);
+
+    const displayTeam = sideDisplayName(side, identityMaps);
+    sides.push({
+      team: displayTeam,
+      historicalTeam: side.team || "",
+      ownerId: side.ownerId || null,
+      rosterId: side.rosterId ?? null,
+      got: got.items,
+      gave: gave.items,
+      gotValue: got.linear,
+      gotWeighted: got.weighted,
+      gaveValue: gave.linear,
+      gaveWeighted: gave.weighted,
+      netValue: netLinear,
+      netWeighted,
+      vaNet,
+      netAdjusted,
+      pctGap,
+      grade,
+    });
+  }
+
+  // Headline reflects the largest grievance — the side with the
+  // biggest magnitude ``pctGap``, winner or loser.
+  const sortedByNet = [...sides].sort((a, b) => b.netWeighted - a.netWeighted);
+  const winner = sortedByNet[0] || null;
+  const loser = sortedByNet[sortedByNet.length - 1] || null;
+  const headlineSide = sides.reduce(
+    (best, s) => (Math.abs(s.pctGap) > Math.abs(best?.pctGap ?? 0) ? s : best),
+    null,
+  );
+  const headlinePct = headlineSide ? Math.abs(headlineSide.pctGap) : 0;
+  const headlineNet = headlineSide
+    ? Math.abs(Math.round(headlineSide.netAdjusted ?? headlineSide.netValue))
+    : 0;
+  const headlineDirection =
+    headlineSide && headlineSide.pctGap < 0 ? "overpaid" : "won";
+
+  return {
+    trade,
+    date,
+    sides,
+    winner,
+    loser,
+    pctGap: headlinePct,
+    headlineNet,
+    headlineSide,
+    headlineDirection,
+    winnerGrade: winner ? winner.grade : null,
+    loserGrade: loser && loser !== winner ? loser.grade : null,
+  };
+}
+
 export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alpha = TRADE_ALPHA) {
   const trades = rawData?.sleeper?.trades;
   if (!Array.isArray(trades) || !trades.length) {
@@ -298,163 +440,17 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
   const filtered = filterTradesToRollingWindow(trades, windowDays);
   if (!filtered.length) return { windowDays, analyzed: [], teamScores: {} };
 
-  const rowLookup = buildRowLookup(rows);
-  const posMap = rawData?.sleeper?.positions || {};
-  const pickAliases = rawData?.pickAliases || null;
-  const identityMaps = buildSleeperIdentityMaps(rawData?.sleeper?.teams);
+  const ctx = buildTradeAnalysisCtx(rawData, rows, alpha);
   const teamScores = {};
   const analyzed = [];
 
-  // Resolve a list of raw item labels to { items, linear, weighted, values }.
-  // ``weighted`` uses the alpha exponent so a single star asset counts
-  // more than a pile of scrubs with the same linear sum.
-  // ``values`` is the bare numeric array — needed by V12 VA which
-  // computes per-piece raw_adjustments based on the absolute KTC scale.
-  const resolveSideList = (rawList) => {
-    const items = [];
-    const values = [];
-    let linear = 0;
-    let weighted = 0;
-    for (const rawItem of getTradeSideItemLabels(rawList)) {
-      const resolved = resolveTradeItemValue(rawItem, rowLookup, posMap, pickAliases);
-      const safeVal = Number.isFinite(resolved.value) ? Math.max(0, resolved.value) : 0;
-      linear += safeVal;
-      weighted += Math.pow(Math.max(safeVal, 1), alpha);
-      if (safeVal > 0) values.push(safeVal);
-      items.push({
-        name: resolved.name,
-        val: Math.round(safeVal),
-        pos: resolved.pos,
-        isPick: resolved.isPick,
-        playerId: resolved.playerId,
-        team: resolved.team,
-      });
-    }
-    return { items, linear, weighted, values };
-  };
-
-  // KTC value adjustment for one team's "got vs gave" comparison —
-  // routes through ``ktcAdjustPackage``, the verbatim port of KTC's
-  // site.min.js algorithm (PR #335).  Treat got/gave as a 2-side
-  // trade: positive ``vaNet`` means this team RECEIVED the stud
-  // premium (got side wins on KTC's intensity-adjusted raw_adj);
-  // negative means they GAVE the studs away.  Magnitude is exactly
-  // what KTC.com would display for the equivalent 2-team trade,
-  // signed by which direction it lands.
-  //
-  // Trade-grading historically used the V12 regression fit; switching
-  // to the native port makes the /trades page agree with the trade
-  // calculator's per-source winner row to ±1.
-  //
-  // Pure: takes value arrays only, no React or row references.
-  const computeTradeVANet = (gotValues, gaveValues) => {
-    if (!gotValues.length || !gaveValues.length) return 0;
-    const result = ktcAdjustPackage(gotValues, gaveValues);
-    if (!result.displayed || result.value <= 0) return 0;
-    // ktcAdjustPackage's `side` follows KTC's team1/team2 convention.
-    // We pass got=team1, gave=team2.  side=1 means got receives the
-    // VA (positive); side=2 means gave receives it (penalty for got).
-    return result.side === 1 ? result.value : -result.value;
-  };
-
   for (const trade of filtered) {
-    const ts = normalizeTradeTimestampMs(trade.timestamp);
-    const date = ts ? new Date(ts).toLocaleDateString() : "?";
-    const sides = [];
+    const entry = analyzeRawTrade(trade, ctx);
 
-    for (const side of trade.sides || []) {
-      const got = resolveSideList(side?.got);
-      const gave = resolveSideList(side?.gave);
-      const netLinear = got.linear - gave.linear;
-      const netWeighted = got.weighted - gave.weighted;
-      // V13 KTC-style VA for this team's got-vs-gave equation.
-      // Positive vaNet = team got the stud premium (received side has
-      // bigger raw_adjustment_sum); negative = team gave the studs
-      // away.  Adjusted net = linear net + VA net = the "effective"
-      // trade outcome that includes stud-scarcity adjustment.
-      const vaNet = computeTradeVANet(got.values, gave.values);
-      const netAdjusted = netLinear + vaNet;
-      // pctGap is now driven by netAdjusted (V13).  This means trade
-      // history grades reflect KTC's stud-scarcity logic:
-      //
-      //   * "2 studs for a pile of mids" reads as a clear win for the
-      //     studs side, even when raw linear sums are close.
-      //   * Trades where the best+worst piece are both on one side
-      //     (the article's "fair trade" suppression case) grade as
-      //     fair when V13 zeros out the VA.
-      //
-      // The denominator is the larger of the two sides' EFFECTIVE
-      // values (linear + their share of the VA).  This keeps the
-      // pct intuitive: "+20% = I got 20% more effective value than
-      // I gave."  Falls back to weighted scale on degenerate input
-      // so the calc never divides by zero.
-      const gotEffective = got.linear + Math.max(0, vaNet);
-      const gaveEffective = gave.linear + Math.max(0, -vaNet);
-      // Denominator is the larger EFFECTIVE side total (linear +
-      // VA).  Don't include ``got.weighted`` / ``gave.weighted`` —
-      // those are alpha-powered (^1.65) and dominate by an order of
-      // magnitude, which would crush all pcts toward zero.
-      const scale = Math.max(gotEffective, gaveEffective, 1);
-      const pctGap = (netAdjusted / scale) * 100;
-      const grade = gradeTradeHistorySide(Math.abs(pctGap), pctGap > 0);
-
-      const displayTeam = sideDisplayName(side, identityMaps);
-      sides.push({
-        team: displayTeam,
-        historicalTeam: side.team || "",
-        ownerId: side.ownerId || null,
-        rosterId: side.rosterId ?? null,
-        got: got.items,
-        gave: gave.items,
-        gotValue: got.linear,
-        gotWeighted: got.weighted,
-        gaveValue: gave.linear,
-        gaveWeighted: gave.weighted,
-        netValue: netLinear,
-        netWeighted,
-        // V13 stud-aware fields drive the displayed pctGap + grade.
-        vaNet,
-        netAdjusted,
-        pctGap,
-        grade,
-      });
-    }
-
-    // Biggest winner = highest positive netWeighted; biggest loser =
-    // lowest (most negative).  Headline reflects the largest
-    // grievance — the side with the biggest magnitude ``pctGap``,
-    // whether that's a clear winner or a clear loser.  In 3+ team
-    // trades, several sides can share small positive nets (<3% each)
-    // while one side absorbs a −15% loss; if we anchored the headline
-    // to the winner's tiny pct, the card would read "Fair trade" even
-    // though one team was graded F.  Using the max-magnitude side
-    // keeps the header consistent with per-side grades and the W/L
-    // credit below.
-    const sortedByNet = [...sides].sort((a, b) => b.netWeighted - a.netWeighted);
-    const winner = sortedByNet[0] || null;
-    const loser = sortedByNet[sortedByNet.length - 1] || null;
-    const headlineSide = sides.reduce(
-      (best, s) => (Math.abs(s.pctGap) > Math.abs(best?.pctGap ?? 0) ? s : best),
-      null,
-    );
-    const headlinePct = headlineSide ? Math.abs(headlineSide.pctGap) : 0;
-    // Absolute V13-adjusted point gap for the headline side.  Reads
-    // more naturally than a percent — "won by 1,820" tells you the
-    // raw stud-aware gap directly, while "won by 6.7%" requires
-    // mental arithmetic against the trade size.
-    const headlineNet = headlineSide
-      ? Math.abs(Math.round(headlineSide.netAdjusted ?? headlineSide.netValue))
-      : 0;
-    // If the largest-magnitude side is a loser (negative pctGap), the
-    // UI should say "X overpaid by Y" rather than "X won by Y".
-    const headlineDirection =
-      headlineSide && headlineSide.pctGap < 0 ? "overpaid" : "won";
-
-    // Per-side W/L for team scores.  3% is the fairness threshold
-    // carried over from the prior grading regime — any trade where
-    // every team's net rounds below 3% shouldn't count as a win or
-    // loss for anyone.
-    for (const s of sides) {
+    // Per-side W/L for team scores.  3% is the fairness threshold —
+    // any trade where every team's net rounds below 3% shouldn't
+    // count as a win or loss for anyone.
+    for (const s of entry.sides) {
       const key = sideAggregationKey(s);
       if (!teamScores[key]) {
         teamScores[key] = {
@@ -477,25 +473,91 @@ export function analyzeSleeperTradeHistory(rawData, rows, windowDays = 365, alph
       }
     }
 
-    analyzed.push({
-      trade,
-      date,
-      sides,
-      winner,
-      loser,
-      pctGap: headlinePct,
-      headlineNet,
-      headlineSide,
-      headlineDirection,
-      // Legacy top-level grades kept for any caller that still reads
-      // the overall winnerGrade/loserGrade — rendering prefers the
-      // per-side ``side.grade`` field now.
-      winnerGrade: winner ? winner.grade : null,
-      loserGrade: loser && loser !== winner ? loser.grade : null,
-    });
+    analyzed.push(entry);
   }
 
   return { windowDays, analyzed, teamScores };
+}
+
+// ── Two-Team Combined Trade History ─────────────────────────────────────
+/**
+ * Collapse the ENTIRE head-to-head trade history between two teams
+ * into a SINGLE synthetic trade.  Only pure 2-team trades whose two
+ * sides are exactly ``teamA`` and ``teamB`` are considered (3+ team
+ * trades have ambiguous A↔B flow and are skipped).
+ *
+ * Net-flow rule, from team A's perspective: +1 every time A received
+ * an asset, -1 every time A sent it.  An asset that bounced back and
+ * forth therefore cancels — an even number of crossings nets to zero
+ * (omitted entirely), an odd number collapses to a single instance in
+ * its net direction.  Example: Dak going Brent→Roy, Roy→Brent, then
+ * Brent→Roy again nets to Dak going Brent→Roy exactly once; a single
+ * there-and-back cancels out.
+ *
+ * Returns an analyzed-trade entry (same shape as ``analyzeRawTrade``,
+ * with ``combined: true`` plus ``teamA`` / ``teamB`` / ``tradeCount``),
+ * ``{ wash: true, ... }`` when every asset cancelled, or ``null`` when
+ * the two teams never traded head-to-head.
+ */
+export function buildCombinedPairTrade(analysis, teamA, teamB, rawData, rows, alpha = TRADE_ALPHA) {
+  if (!teamA || !teamB || teamA === teamB) return null;
+  const analyzed = analysis?.analyzed || [];
+  const headToHead = analyzed.filter(
+    (a) =>
+      a.sides.length === 2 &&
+      a.sides.some((s) => s.team === teamA) &&
+      a.sides.some((s) => s.team === teamB),
+  );
+  if (!headToHead.length) return null;
+
+  // asset label → net count from A's perspective (+got, -gave).
+  // Keyed by the exact resolved label so a player/pick that bounced
+  // back and forth between A and B cancels cleanly.
+  const ledger = new Map();
+  let latestTs = 0;
+  for (const a of headToHead) {
+    const sideA = a.sides.find((s) => s.team === teamA);
+    if (!sideA) continue;
+    const ts =
+      normalizeTradeTimestampMs(a.trade?.timestamp) || Date.parse(a.date) || 0;
+    if (Number.isFinite(ts) && ts > latestTs) latestTs = ts;
+    for (const it of sideA.got || []) {
+      ledger.set(it.name, (ledger.get(it.name) || 0) + 1);
+    }
+    for (const it of sideA.gave || []) {
+      ledger.set(it.name, (ledger.get(it.name) || 0) - 1);
+    }
+  }
+
+  const aGot = [];
+  const aGave = [];
+  for (const [name, net] of ledger) {
+    if (!name) continue;
+    if (net > 0) aGot.push(name);
+    else if (net < 0) aGave.push(name);
+  }
+
+  if (!aGot.length && !aGave.length) {
+    // Everything they swapped came back — a net wash.
+    return { wash: true, teamA, teamB, tradeCount: headToHead.length };
+  }
+
+  const synthetic = {
+    week: null,
+    timestamp: latestTs || Date.now(),
+    sides: [
+      { team: teamA, got: aGot, gave: aGave },
+      { team: teamB, got: aGave, gave: aGot },
+    ],
+  };
+  const ctx = buildTradeAnalysisCtx(rawData, rows, alpha);
+  const entry = analyzeRawTrade(synthetic, ctx);
+  entry.combined = true;
+  entry.teamA = teamA;
+  entry.teamB = teamB;
+  entry.tradeCount = headToHead.length;
+  entry.date = `${headToHead.length} trade${headToHead.length === 1 ? "" : "s"} combined`;
+  return entry;
 }
 
 // ── Build Player Meta Map ───────────────────────────────────────────────

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -76,6 +76,21 @@ _DRAFT_ID_CACHE_TTL_SEC = 60.0
 _DRAFT_PICKS_CACHE: dict[str, dict[str, Any]] = {}
 _DRAFT_PICKS_CACHE_TTL_SEC = 2.0
 
+# Lazy fallback Sleeper-ID → display-name map.  The primary id→name
+# source is the loaded contract's NFL map, which only spans players in
+# the rankings pool.  Deep-bench / unranked / retired players (and team
+# defenses) that show up in trade, roster or waiver history miss that
+# map and would otherwise render as a raw numeric Sleeper id on the UI.
+# This is populated from Sleeper's full ``/v1/players/nfl`` dump
+# (~5 MB) the first time a miss is hit, then process-cached.  Failed
+# attempts are not cached permanently — they are retried (rate-limited)
+# so a transient Sleeper blip doesn't disable the fallback for the
+# life of the process.
+_FALLBACK_NAMES: dict[str, str] | None = None
+_FALLBACK_NAMES_LOCK = threading.Lock()
+_FALLBACK_ATTEMPT_AT: float = 0.0
+_FALLBACK_RETRY_SEC = 300.0
+
 
 def _utc_now_ms() -> int:
     return int(time.time() * 1000)
@@ -336,8 +351,7 @@ def _build_teams_block(
             pid_str = str(pid or "")
             if not pid_str:
                 continue
-            mapped = id_map.get(pid_str)
-            names.append(mapped if mapped else pid_str)
+            names.append(_resolve_player_label(pid_str, id_map))
         try:
             rid_int = int(roster_id) if roster_id is not None else 0
         except (TypeError, ValueError):
@@ -640,6 +654,72 @@ def _append_trade_side_item(
             arr.append(label)
 
 
+def _sleeper_fallback_name_map() -> dict[str, str]:
+    """Process-cached Sleeper ``player_id`` → ``"First Last"`` map,
+    built lazily from the full ``/v1/players/nfl`` dump.
+
+    Consulted ONLY when the loaded contract's NFL id map misses an id
+    (so the steady-state hot path never pays for it).  Best-effort:
+    returns ``{}`` on any failure so callers degrade to the prior
+    raw-id behaviour.  Goes through the module's own ``_http_get_json``
+    so it shares the ``sleeper_api`` circuit breaker and stays
+    monkeypatchable in tests.
+    """
+    global _FALLBACK_NAMES, _FALLBACK_ATTEMPT_AT
+    if _FALLBACK_NAMES is not None:
+        return _FALLBACK_NAMES
+    with _FALLBACK_NAMES_LOCK:
+        if _FALLBACK_NAMES is not None:
+            return _FALLBACK_NAMES
+        now = time.time()
+        if now - _FALLBACK_ATTEMPT_AT < _FALLBACK_RETRY_SEC:
+            # Recent attempt failed — don't hammer Sleeper.  Degrade to
+            # raw-id until the retry window elapses.
+            return {}
+        _FALLBACK_ATTEMPT_AT = now
+        dump = _http_get_json("https://api.sleeper.app/v1/players/nfl")
+        if not isinstance(dump, dict) or not dump:
+            return {}
+        out: dict[str, str] = {}
+        for pid, rec in dump.items():
+            if not isinstance(rec, dict):
+                continue
+            full = str(rec.get("full_name") or "").strip()
+            if not full:
+                first = str(rec.get("first_name") or "").strip()
+                last = str(rec.get("last_name") or "").strip()
+                full = f"{first} {last}".strip()
+            if not full and str(rec.get("position") or "") == "DEF":
+                # Team defenses key on the team abbr and carry no name
+                # fields — synthesise a readable "<ABBR> DEF" label.
+                full = f"{str(pid).upper()} DEF"
+            if full:
+                out[str(pid)] = full
+        # Only persist a non-empty result; an empty dump is treated as
+        # a soft failure (retry-eligible) above.
+        _FALLBACK_NAMES = out
+        return _FALLBACK_NAMES
+
+
+def _resolve_player_label(pid: Any, id_map: dict[str, str]) -> str:
+    """Resolve a Sleeper player id to a display name.
+
+    Resolution order: loaded-contract NFL map → full Sleeper players
+    dump (lazy, process-cached) → the raw id string as a last resort
+    so the row still renders rather than vanishing.
+    """
+    pid_str = str(pid if pid is not None else "").strip()
+    if not pid_str:
+        return ""
+    mapped = id_map.get(pid_str)
+    if mapped:
+        return str(mapped)
+    fallback = _sleeper_fallback_name_map().get(pid_str)
+    if fallback:
+        return fallback
+    return pid_str
+
+
 def _build_waivers_block(
     sleeper_league_id: str,
     window_days: int = 365,
@@ -688,7 +768,7 @@ def _build_waivers_block(
         rid_to_name, rid_to_owner = _league_rid_lookup(lid)
 
         for week in range(0, 19):
-            url = f"https://api.sleeper.app/v1/league/{lid}" f"/transactions/{week}"
+            url = f"https://api.sleeper.app/v1/league/{lid}/transactions/{week}"
             txs = _http_get_json(url)
             if not isinstance(txs, list):
                 continue
@@ -729,8 +809,8 @@ def _build_waivers_block(
                 if rid is None:
                     continue
 
-                added_names = [str(id_map.get(str(pid)) or pid) for pid in adds.keys()]
-                dropped_names = [str(id_map.get(str(pid)) or pid) for pid in drops.keys()]
+                added_names = [_resolve_player_label(pid, id_map) for pid in adds.keys()]
+                dropped_names = [_resolve_player_label(pid, id_map) for pid in drops.keys()]
 
                 # FAAB bid lives at ``settings.waiver_bid`` for waiver
                 # tx; FA tx don't carry a bid (free pickups).
@@ -840,7 +920,7 @@ def _build_trades_block(
         # calendar.  0 is cheap to include and catches preseason
         # trades that happened before week 1.
         for week in range(0, 19):
-            url = f"https://api.sleeper.app/v1/league/{lid}" f"/transactions/{week}"
+            url = f"https://api.sleeper.app/v1/league/{lid}/transactions/{week}"
             txs = _http_get_json(url)
             if not isinstance(txs, list):
                 continue
@@ -873,11 +953,9 @@ def _build_trades_block(
 
                 # adds/drops keyed by sleeper player_id → roster_id.
                 for pid, rid in (adds or {}).items():
-                    label = id_map.get(str(pid)) or str(pid)
-                    _append_trade_side_item(team_got, rid, str(label))
+                    _append_trade_side_item(team_got, rid, _resolve_player_label(pid, id_map))
                 for pid, rid in (drops or {}).items():
-                    label = id_map.get(str(pid)) or str(pid)
-                    _append_trade_side_item(team_gave, rid, str(label))
+                    _append_trade_side_item(team_gave, rid, _resolve_player_label(pid, id_map))
 
                 # Draft picks: owner gained, previous_owner lost.
                 for pick in draft_picks:
@@ -1039,6 +1117,15 @@ def fetch_sleeper_overlay(
     with _CACHE_LOCK:
         _CACHE[sleeper_league_id] = {"payload": dict(payload), "_cached_at": now}
     return payload
+
+
+def reset_fallback_name_cache() -> None:
+    """Test hook — clear the lazy Sleeper fallback name map so a
+    monkeypatched ``_http_get_json`` is re-consulted."""
+    global _FALLBACK_NAMES, _FALLBACK_ATTEMPT_AT
+    with _FALLBACK_NAMES_LOCK:
+        _FALLBACK_NAMES = None
+        _FALLBACK_ATTEMPT_AT = 0.0
 
 
 def invalidate_overlay_cache(sleeper_league_id: str | None = None) -> None:

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -695,8 +695,13 @@ def _sleeper_fallback_name_map() -> dict[str, str]:
                 full = f"{str(pid).upper()} DEF"
             if full:
                 out[str(pid)] = full
-        # Only persist a non-empty result; an empty dump is treated as
-        # a soft failure (retry-eligible) above.
+        if not out:
+            # Non-empty payload but zero usable records (schema drift /
+            # missing name fields).  Treat as a retry-eligible soft
+            # failure — do NOT persist {} or every later miss leaks the
+            # raw id for the process lifetime.  ``_FALLBACK_ATTEMPT_AT``
+            # was stamped above so the retry stays rate-limited.
+            return {}
         _FALLBACK_NAMES = out
         return _FALLBACK_NAMES
 

--- a/tests/api/test_sleeper_overlay.py
+++ b/tests/api/test_sleeper_overlay.py
@@ -216,6 +216,39 @@ def test_build_trades_block_resolves_unknown_id_via_players_dump(monkeypatch):
     assert "Deep Bencher" in by_rid[1]["got"]
 
 
+def test_fallback_name_map_does_not_cache_empty_result(monkeypatch):
+    """A non-empty ``/v1/players/nfl`` payload that yields zero usable
+    records (schema drift / missing name fields) must be treated as a
+    retry-eligible soft failure — NOT persisted as ``{}`` for the
+    process lifetime, which would leak raw ids until restart.
+    """
+    sleeper_overlay.reset_fallback_name_cache()
+    # Non-empty dump, but every record lacks any name field.
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses({"/players/nfl": {"4574": {"position": "WR"}}}),
+    )
+
+    result = sleeper_overlay._sleeper_fallback_name_map()
+    assert result == {}
+    # The empty map was NOT persisted — a later (post-window) attempt
+    # is still allowed to re-fetch.
+    assert sleeper_overlay._FALLBACK_NAMES is None
+
+    # Now a healthy payload resolves and IS cached.
+    sleeper_overlay.reset_fallback_name_cache()
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses({"/players/nfl": {"4574": {"full_name": "Real Player"}}}),
+    )
+    healthy = sleeper_overlay._sleeper_fallback_name_map()
+    assert healthy == {"4574": "Real Player"}
+    assert sleeper_overlay._FALLBACK_NAMES == {"4574": "Real Player"}
+    sleeper_overlay.reset_fallback_name_cache()
+
+
 def test_build_trades_block_filters_incomplete_trades(monkeypatch):
     """Only ``status == "complete"`` trades are emitted.  Mid-flight
     proposals and rejected trades must not appear on /trades.

--- a/tests/api/test_sleeper_overlay.py
+++ b/tests/api/test_sleeper_overlay.py
@@ -145,6 +145,77 @@ def test_build_trades_block_emits_processed_sides_shape(monkeypatch):
     assert b["ownerId"] == "oB"
 
 
+def test_build_trades_block_resolves_unknown_id_via_players_dump(monkeypatch):
+    """Players outside the loaded contract's rankings pool (deep bench
+    / unranked / retired) miss the ``id_to_player`` map.  Rather than
+    rendering the raw numeric Sleeper id on the UI, the block must fall
+    back to Sleeper's full ``/v1/players/nfl`` dump so the trade card
+    shows the real name.  Regression for the "45 4574 0" glitch.
+    """
+    sleeper_overlay.reset_fallback_name_cache()
+    league_id = "L1"
+    responses = {
+        f"/league/{league_id}": {"name": "Main", "previous_league_id": None},
+        f"/league/{league_id}/rosters": [
+            {"roster_id": 1, "owner_id": "oA"},
+            {"roster_id": 2, "owner_id": "oB"},
+        ],
+        f"/league/{league_id}/users": [
+            {"user_id": "oA", "display_name": "Team A"},
+            {"user_id": "oB", "display_name": "Team B"},
+        ],
+        f"/league/{league_id}/drafts": [],
+        # The full players dump the fallback consults on a miss.
+        "/players/nfl": {
+            "4574": {"first_name": "Deep", "last_name": "Bencher", "position": "WR"},
+            "4129": {"full_name": "Retired Vet", "position": "RB"},
+        },
+    }
+    fresh_ms = _recent_ms()
+    responses[f"/league/{league_id}/transactions/3"] = [
+        {
+            "transaction_id": "tx-1",
+            "type": "trade",
+            "status": "complete",
+            "status_updated": fresh_ms,
+            "roster_ids": [1, 2],
+            # "P-A" is in the contract map; "4574"/"4129" are not.
+            "adds": {"P-A": 1, "4574": 1, "4129": 2},
+            "drops": {"4574": 2, "4129": 1, "P-A": 2},
+        },
+    ]
+    for w in range(0, 19):
+        if w == 3:
+            continue
+        responses[f"/league/{league_id}/transactions/{w}"] = []
+
+    monkeypatch.setattr(
+        sleeper_overlay,
+        "_http_get_json",
+        _stub_http_responses(responses),
+    )
+
+    trades = sleeper_overlay._build_trades_block(
+        league_id,
+        window_days=365,
+        id_to_player={"P-A": "Player A"},
+    )
+    sleeper_overlay.reset_fallback_name_cache()
+
+    assert len(trades) == 1
+    labels = set()
+    for s in trades[0]["sides"]:
+        labels.update(s["got"])
+        labels.update(s["gave"])
+    # Contract-mapped + fallback-dump names all resolve; the raw
+    # numeric Sleeper ids must never leak through to the UI.
+    assert {"Player A", "Deep Bencher", "Retired Vet"} <= labels
+    assert "4574" not in labels
+    assert "4129" not in labels
+    by_rid = {s["rosterId"]: s for s in trades[0]["sides"]}
+    assert "Deep Bencher" in by_rid[1]["got"]
+
+
 def test_build_trades_block_filters_incomplete_trades(monkeypatch):
     """Only ``status == "complete"`` trades are emitted.  Mid-flight
     proposals and rejected trades must not appear on /trades.


### PR DESCRIPTION
## Summary

Two changes to the Trade History page.

### 1. Fix the "raw id" display glitch

Some traded assets rendered as a raw numeric Sleeper player id (e.g. the `45 4574 0` / `41 4129 0` chips in the screenshots) instead of the player's name. Root cause: `src/api/sleeper_overlay.py` resolved player ids only against the loaded contract's NFL id map, which only spans players in the rankings pool. Deep-bench, unranked, retired players (and team defenses) miss that map and fell back to the raw id.

- Added `_sleeper_fallback_name_map()` — a lazy, process-cached resolver backed by Sleeper's full `/v1/players/nfl` dump. Consulted **only** on a miss, so the steady-state hot path is unchanged. Failed fetches are retry-eligible (rate-limited) rather than permanently cached, and it routes through the module's existing circuit-broken `_http_get_json`.
- Shared resolver `_resolve_player_label()` now used by the trades, teams **and** waivers blocks (the same bug existed in all three).
- Picks were never affected — they already resolve through `_format_trade_pick_label`.

### 2. Two-team combined trade history

The team filter now accepts an optional second "vs" team. With two teams selected, their entire head-to-head history collapses into **one synthetic trade**:

- Only pure 2-team trades between exactly those two teams are considered (3+ team trades have ambiguous A↔B flow and are skipped).
- Each asset is tallied from one team's perspective: +1 each time received, −1 each time given. An asset that bounced back and forth nets out — an even number of crossings cancels entirely, an odd number collapses to a single move in the net direction. Nothing is double counted. (e.g. Dak going Brent→Roy, back, then Brent→Roy again ⇒ Brent→Roy once.)
- A net-zero result renders an explicit "Net wash" card; teams that never traded head-to-head show a clear empty state.

The per-trade valuation/grading logic was extracted into reusable `analyzeRawTrade` / `buildTradeAnalysisCtx` helpers so the combined card values assets through the exact same pipeline as the normal cards (existing behavior preserved — all 898 frontend tests pass).

## Test plan

- [x] `tests/api/test_sleeper_overlay.py` — 15 pass, incl. new regression locking the unknown-id fallback (no raw id leaks)
- [x] `frontend/__tests__/league-analysis.test.js` — new `buildCombinedPairTrade` cases (back-and-forth collapse, single-swap wash, no head-to-head → null, 3-team skip)
- [x] Full frontend vitest suite: 898 pass
- [x] ruff check + format clean on changed Python
- [ ] Manual UI check on `/trades`: pick a player previously shown as a raw id; pick two teams and confirm the combined card + wash/empty states

https://claude.ai/code/session_01NykpvSCzfFKB6d87GvP41u

---
_Generated by [Claude Code](https://claude.ai/code/session_01NykpvSCzfFKB6d87GvP41u)_