### PR TITLE
fix(screenshot): keep nav bar out of the saved page image

### DIFF
--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -189,7 +189,7 @@ function DesktopNav() {
   const { authenticated, logout } = useContext(AuthContext);
 
   return (
-    <header className="topbar desktop-only">
+    <header className="topbar desktop-only" data-html2canvas-ignore>
       <div className="topbar-inner">
         <Link href="/" className="brand">
           Risk It To Get The Brisket
@@ -290,7 +290,7 @@ function MobileNav() {
   }
 
   return (
-    <nav className="mobile-bottom-nav mobile-only" aria-label="Mobile Navigation">
+    <nav className="mobile-bottom-nav mobile-only" aria-label="Mobile Navigation" data-html2canvas-ignore>
       {visibleItems.map((item) => (
         <Link
           key={item.href}
@@ -360,7 +360,7 @@ function MobileTopBar() {
   })();
 
   return (
-    <header className="mobile-topbar mobile-only">
+    <header className="mobile-topbar mobile-only" data-html2canvas-ignore>
       <Link href="/" className="mobile-brand">Brisket</Link>
       <span className="mobile-page-title">{pageTitle}</span>
       <div className="mobile-topbar-actions">


### PR DESCRIPTION
## Problem

In the saved screenshot, the bottom navigation bar (H / R / Trade / More) appears **in the middle of the page content** instead of pinned to the bottom of the screen — looking like the nav "moves" into the content.

## Root cause

`ScreenshotFab` (`components/ScreenshotFab.jsx`) calls `html2canvas(document.body, …)` over the **full document scroll height** (`document.body.scrollHeight`). html2canvas paints `position: fixed` / `position: sticky` elements at their viewport anchor point, so on a tall page:

- the **fixed** `.mobile-bottom-nav` gets rendered roughly one viewport-height down — i.e. baked into the middle of the captured image
- the **sticky** `.mobile-topbar` / desktop `.topbar` have the same problem

The FAB button and the iOS preview overlay already opt out via `data-html2canvas-ignore`; the navigation chrome did not.

## Fix

Add `data-html2canvas-ignore` to the three navigation chrome roots in `app/AppShellWrapper.jsx`:

- `DesktopNav` `<header className="topbar desktop-only">`
- `MobileTopBar` `<header className="mobile-topbar mobile-only">`
- `MobileNav` `<nav className="mobile-bottom-nav mobile-only">`

This uses the same exclusion mechanism html2canvas already relies on elsewhere in this component, so the saved image now contains only page content — no nav bar floating in the middle. No runtime behavior changes for the live UI; the attribute is inert outside the html2canvas capture path. Targeted to the known chrome rather than a blanket `position: fixed/sticky` filter, so in-page sticky elements (e.g. sticky rankings table headers) still appear in the screenshot.

## Test plan

- [ ] On mobile, scroll a long page (e.g. `/trades`), tap the Save FAB, confirm the saved/shared image shows only content with no nav bar embedded mid-page
- [ ] Confirm the bottom nav and top bar still render and function normally in the live app
- [ ] Confirm in-page sticky content (rankings table headers) still appears in the screenshot

https://claude.ai/code/session_01H7wvkchWV78zoxZuc6icp2

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7wvkchWV78zoxZuc6icp2)_