### PR TITLE
feat(betting): private Kalshi auto-bet call sheet section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,3 +100,29 @@ LOG_FORMAT=text
 #   disable: "0" / "false" / "no" / "off"
 #
 # IDP_CALIBRATION_ALLOW_NETWORK=1
+
+# ── Betting (Kalshi auto-bet call sheet) ─────────────────────────────────
+# Private, login-gated Betting section.  See src/betting/ and
+# src/api/kalshi_client.py.  All values are server-side only — never
+# commit real keys.
+#
+# Kalshi is a CFTC-regulated event-contracts exchange whose official API
+# permits automated trading.  Demo and production are SEPARATE accounts
+# with SEPARATE keys; default is demo so a missing/typo env can never
+# trade real money.
+#
+#   KALSHI_ENV         demo (default) | prod
+#   KALSHI_API_KEY_ID  the API key id from Kalshi → Settings → API Keys
+#   KALSHI_PRIVATE_KEY the RSA private key (PEM).  May be stored on one
+#                      line with literal \n escapes between PEM lines.
+#
+# KALSHI_ENV=demo
+# KALSHI_API_KEY_ID=
+# KALSHI_PRIVATE_KEY=
+
+# The Odds API (https://the-odds-api.com) — free tier moneyline odds.
+# Used by scripts/fetch_betting_odds.py.
+# ODDS_API_KEY=
+
+# How often (minutes) the server reconciles open Kalshi bets. Default 5.
+# BETTING_RECONCILE_INTERVAL_MIN=5

--- a/config/betting_sources.json
+++ b/config/betting_sources.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "description": "Betting feature config: which sports to pull, which odds/consensus vendors feed the recommendation blend, and the default per-user guardrails.",
+  "enabled": true,
+  "sports": ["nba", "nfl", "mlb", "nhl"],
+  "vendors": [
+    {
+      "key": "the-odds-api",
+      "enabled": true,
+      "kind": "odds",
+      "weight": 1.0,
+      "auth_env": "ODDS_API_KEY",
+      "notes": "Sportsbook moneylines (h2h) across US books + public consensus. Free tier. ToS-permitted JSON API."
+    }
+  ],
+  "blend": {
+    "min_books": 1,
+    "notes": "Per-book de-vig, then average implied probability across books. Favorite side becomes the recommendation. Confidence blends favorite strength with book agreement."
+  },
+  "guardrail_defaults": {
+    "unit_usd": 5.0,
+    "per_bet_max_usd": 25.0,
+    "daily_cap_usd": 50.0,
+    "require_live_confirm": true,
+    "notes": "Server-enforced defaults for a new user. unit_usd is the default stake; per_bet_max_usd is a hard ceiling per bet; daily_cap_usd caps total committed stake per UTC day; require_live_confirm gates real-money (prod) placement behind an explicit per-user acknowledgement."
+  },
+  "kalshi": {
+    "env_default": "demo",
+    "notes": "KALSHI_ENV selects demo (default) vs prod. Demo and prod are separate accounts/keys. Native resting limit orders fill when the market reaches the target price."
+  }
+}

--- a/frontend/app/betting/page.jsx
+++ b/frontend/app/betting/page.jsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuthContext } from "@/app/AppShellWrapper";
+import CallSheet from "@/components/betting/CallSheet";
+import BetList from "@/components/betting/BetList";
+import RootingDashboard from "@/components/betting/RootingDashboard";
+import BettingSettings from "@/components/betting/BettingSettings";
+
+async function getJson(url) {
+  const res = await fetch(url, { cache: "no-store" });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = data?.detail ? ` — ${typeof data.detail === "string" ? data.detail : JSON.stringify(data.detail)}` : "";
+    throw new Error(`${data?.error || `HTTP ${res.status}`}${detail}`);
+  }
+  return data;
+}
+
+async function sendJson(url, body, method = "POST") {
+  const res = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body || {}),
+    cache: "no-store",
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = data?.detail ? ` — ${typeof data.detail === "string" ? data.detail : JSON.stringify(data.detail)}` : "";
+    throw new Error(`${data?.error || `HTTP ${res.status}`}${detail}`);
+  }
+  return data;
+}
+
+export default function BettingPage() {
+  const { authenticated } = useAuthContext();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [recs, setRecs] = useState({ recommendations: [], env: "demo", generatedAt: null });
+  const [bets, setBets] = useState([]);
+  const [settings, setSettings] = useState(null);
+  const [rooting, setRooting] = useState([]);
+
+  const refreshBets = useCallback(async () => {
+    const [b, r] = await Promise.all([getJson("/api/betting/bets"), getJson("/api/betting/rooting")]);
+    setBets(b.bets || []);
+    setRooting(r.rooting || []);
+  }, []);
+
+  useEffect(() => {
+    if (authenticated !== true) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const [recData, betData, setData, rootData] = await Promise.all([
+          getJson("/api/betting/recommendations"),
+          getJson("/api/betting/bets"),
+          getJson("/api/betting/settings"),
+          getJson("/api/betting/rooting"),
+        ]);
+        if (cancelled) return;
+        setRecs(recData);
+        setBets(betData.bets || []);
+        setSettings(setData.settings);
+        setRooting(rootData.rooting || []);
+      } catch (e) {
+        if (!cancelled) setError(e?.message || "Failed to load betting data");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated]);
+
+  const onApprove = useCallback(
+    async (payload) => {
+      await sendJson("/api/betting/bets", payload);
+      await refreshBets();
+    },
+    [refreshBets]
+  );
+
+  const onCancel = useCallback(
+    async (betId) => {
+      await sendJson(`/api/betting/bets/${betId}/cancel`, {});
+      await refreshBets();
+    },
+    [refreshBets]
+  );
+
+  const onKill = useCallback(async () => {
+    await sendJson("/api/betting/kill", {});
+    await refreshBets();
+  }, [refreshBets]);
+
+  const onSaveSettings = useCallback(async (patch) => {
+    const data = await sendJson("/api/betting/settings", patch, "PUT");
+    setSettings(data.settings);
+  }, []);
+
+  if (authenticated === false) {
+    return (
+      <section className="card">
+        <h1 className="page-title">Betting</h1>
+        <p className="muted text-sm" style={{ marginTop: 4 }}>Sign in to access the betting call sheet.</p>
+      </section>
+    );
+  }
+
+  if (authenticated === null || loading) {
+    return (
+      <section className="card">
+        <h1 className="page-title">Betting</h1>
+        <p className="muted text-sm" style={{ marginTop: 4 }}>Loading…</p>
+      </section>
+    );
+  }
+
+  const env = settings?.env || recs?.env || "demo";
+  const unitUsd = settings?.unit_usd ?? 5;
+
+  return (
+    <section>
+      <div className="card" style={{ marginBottom: "var(--space-md)" }}>
+        <h1 className="page-title">Betting</h1>
+        <p className="muted text-sm" style={{ marginTop: 4 }}>
+          Aggregated betting consensus → approve a bet → it rests on Kalshi until your price hits.
+        </p>
+      </div>
+
+      {error ? (
+        <div className="card text-red text-sm" style={{ marginBottom: "var(--space-md)" }}>{error}</div>
+      ) : null}
+
+      <RootingDashboard rooting={rooting} />
+      <CallSheet
+        recommendations={recs.recommendations}
+        env={env}
+        unitUsd={unitUsd}
+        generatedAt={recs.generatedAt}
+        onApprove={onApprove}
+      />
+      <BetList bets={bets} onCancel={onCancel} onKill={onKill} />
+      {settings ? <BettingSettings settings={settings} env={env} onSave={onSaveSettings} /> : null}
+    </section>
+  );
+}

--- a/frontend/app/more/page.jsx
+++ b/frontend/app/more/page.jsx
@@ -17,6 +17,12 @@ import { useAuthContext } from "@/app/AppShellWrapper";
  */
 const SECTIONS = [
   {
+    title: "Betting",
+    items: [
+      { href: "/betting", label: "Betting", desc: "Auto-bet call sheet — Kalshi positions, recommendations, and who to root for" },
+    ],
+  },
+  {
     title: "Trade workflow",
     items: [
       { href: "/trade", label: "Calculator", desc: "Build and grade a trade" },

--- a/frontend/components/betting/BetList.jsx
+++ b/frontend/components/betting/BetList.jsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * BetList — the user's bets with live status, plus per-bet cancel and a
+ * global kill switch that cancels every open resting order.
+ */
+const OPEN = new Set(["proposed", "approved", "resting"]);
+
+function statusClass(status) {
+  if (status === "filled" || status === "settled") return "text-green";
+  if (status === "canceled" || status === "rejected") return "muted";
+  return "text-cyan";
+}
+
+export default function BetList({ bets, onCancel, onKill }) {
+  const hasOpen = Array.isArray(bets) && bets.some((b) => OPEN.has(b.status));
+  return (
+    <section className="card" style={{ marginBottom: "var(--space-md)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h2 className="page-title" style={{ fontSize: "1rem" }}>Your bets</h2>
+        {hasOpen ? (
+          <button className="button button-danger" onClick={onKill}>
+            Kill all resting orders
+          </button>
+        ) : null}
+      </div>
+
+      {(!bets || bets.length === 0) ? (
+        <p className="muted text-sm" style={{ marginTop: "var(--space-sm)" }}>
+          No bets yet.
+        </p>
+      ) : (
+        <div className="table-wrap" style={{ marginTop: "var(--space-sm)" }}>
+          <table>
+            <thead>
+              <tr>
+                <th style={{ textAlign: "left" }}>Bet</th>
+                <th>Price</th>
+                <th>Stake</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {bets.map((b) => (
+                <tr key={b.id}>
+                  <td style={{ textAlign: "left" }}>
+                    <div style={{ fontWeight: 600 }}>{b.side_label || b.kalshi_ticker}</div>
+                    <div className="muted text-xs">{b.game || ""}</div>
+                  </td>
+                  <td style={{ textAlign: "center" }}>
+                    {b.filled_price ? `${b.filled_price}¢ fill` : `${b.target_price}¢`}
+                  </td>
+                  <td style={{ textAlign: "center" }}>${Number(b.stake_usd || 0).toFixed(2)}</td>
+                  <td style={{ textAlign: "center" }}>
+                    <span className={`badge ${statusClass(b.status)}`}>{b.status}</span>
+                    {b.env === "prod" ? null : <span className="muted text-xs"> demo</span>}
+                  </td>
+                  <td style={{ textAlign: "center" }}>
+                    {OPEN.has(b.status) ? (
+                      <button className="button button-reset text-xs" onClick={() => onCancel(b.id)}>
+                        Cancel
+                      </button>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/betting/BettingSettings.jsx
+++ b/frontend/components/betting/BettingSettings.jsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * BettingSettings — per-user guardrails: default unit, per-bet max,
+ * daily exposure cap, and the real-money confirmation toggle (only
+ * meaningful when the server is in prod/live mode).
+ */
+export default function BettingSettings({ settings, env, onSave }) {
+  const [unit, setUnit] = useState(settings?.unit_usd ?? 5);
+  const [perBet, setPerBet] = useState(settings?.per_bet_max_usd ?? 25);
+  const [daily, setDaily] = useState(settings?.daily_cap_usd ?? 50);
+  const [liveConfirmed, setLiveConfirmed] = useState(Boolean(settings?.live_confirmed));
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  async function save() {
+    setBusy(true);
+    setMsg("");
+    try {
+      await onSave({
+        unit_usd: Number(unit),
+        per_bet_max_usd: Number(perBet),
+        daily_cap_usd: Number(daily),
+        live_confirmed: liveConfirmed,
+      });
+      setMsg("Saved.");
+    } catch (e) {
+      setMsg(e?.message || "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="card" style={{ marginBottom: "var(--space-md)" }}>
+      <h2 className="page-title" style={{ fontSize: "1rem" }}>Guardrails</h2>
+      <p className="muted text-xs" style={{ marginTop: 2 }}>
+        Server-enforced limits. Every bet still requires your explicit approval.
+      </p>
+      <div style={{ display: "grid", gap: "var(--space-sm)", marginTop: "var(--space-sm)" }}>
+        <label className="label">
+          Default unit ($)
+          <input type="number" min={1} step="0.5" value={unit} onChange={(e) => setUnit(e.target.value)} />
+        </label>
+        <label className="label">
+          Per-bet max ($)
+          <input type="number" min={1} step="0.5" value={perBet} onChange={(e) => setPerBet(e.target.value)} />
+        </label>
+        <label className="label">
+          Daily exposure cap ($)
+          <input type="number" min={1} step="1" value={daily} onChange={(e) => setDaily(e.target.value)} />
+        </label>
+        <label className="label" style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+          <input
+            type="checkbox"
+            checked={liveConfirmed}
+            onChange={(e) => setLiveConfirmed(e.target.checked)}
+          />
+          I understand bets are placed with {env === "prod" ? "REAL money" : "demo funds"} and want to enable real-money placement
+        </label>
+        {env !== "prod" ? (
+          <p className="muted text-xs">
+            Server is in DEMO mode — no real money moves regardless of this toggle.
+          </p>
+        ) : null}
+        <button className="button button-primary" disabled={busy} onClick={save}>
+          {busy ? "Saving…" : "Save guardrails"}
+        </button>
+        {msg ? <div className="muted text-xs">{msg}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/betting/CallSheet.jsx
+++ b/frontend/components/betting/CallSheet.jsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * CallSheet — tonight's blended recommendations.  Each row expands into
+ * an approve form (target price + stake + optional manual Kalshi ticker).
+ * Approving calls onApprove(payload) which places a resting limit order.
+ */
+function ApproveForm({ rec, unitUsd, onApprove }) {
+  const [price, setPrice] = useState(rec.fair_price_cents);
+  const [stake, setStake] = useState(unitUsd);
+  const [ticker, setTicker] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  async function submit() {
+    setBusy(true);
+    setErr("");
+    try {
+      await onApprove({
+        sport: rec.sport,
+        game: rec.game,
+        sideTeam: rec.side_team,
+        sideLabel: rec.side_label,
+        targetPrice: Number(price),
+        stakeUsd: Number(stake),
+        ticker: ticker.trim() || undefined,
+      });
+    } catch (e) {
+      setErr(e?.message || "Failed to place bet");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ marginTop: "var(--space-sm)", display: "grid", gap: "var(--space-sm)" }}>
+      <div style={{ display: "flex", gap: "var(--space-sm)", flexWrap: "wrap" }}>
+        <label className="label" style={{ flex: 1 }}>
+          Target price (¢)
+          <input
+            type="number"
+            min={1}
+            max={99}
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+            style={{ width: "100%" }}
+          />
+        </label>
+        <label className="label" style={{ flex: 1 }}>
+          Stake ($)
+          <input
+            type="number"
+            min={1}
+            step="0.5"
+            value={stake}
+            onChange={(e) => setStake(e.target.value)}
+            style={{ width: "100%" }}
+          />
+        </label>
+      </div>
+      <label className="label">
+        Kalshi ticker (optional — only if auto-match fails)
+        <input
+          type="text"
+          placeholder="e.g. KXNBAGAME-..."
+          value={ticker}
+          onChange={(e) => setTicker(e.target.value)}
+          style={{ width: "100%" }}
+        />
+      </label>
+      {err ? (
+        <div className="text-red text-xs">{err}</div>
+      ) : null}
+      <button className="button button-primary" disabled={busy} onClick={submit}>
+        {busy ? "Placing…" : `Place resting order — $${Number(stake).toFixed(2)} @ ${price}¢`}
+      </button>
+    </div>
+  );
+}
+
+export default function CallSheet({ recommendations, env, unitUsd, generatedAt, onApprove }) {
+  const [openId, setOpenId] = useState(null);
+
+  return (
+    <section className="card" style={{ marginBottom: "var(--space-md)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h2 className="page-title" style={{ fontSize: "1rem" }}>Call sheet</h2>
+        <span className={env === "prod" ? "badge text-red" : "badge text-green"}>
+          {env === "prod" ? "LIVE — real money" : "DEMO"}
+        </span>
+      </div>
+      <p className="muted text-xs" style={{ marginTop: 2 }}>
+        Blended sportsbook consensus. {generatedAt ? `Odds as of ${generatedAt}.` : "No odds snapshot yet."}
+      </p>
+
+      {(!recommendations || recommendations.length === 0) ? (
+        <p className="muted text-sm" style={{ marginTop: "var(--space-sm)" }}>
+          No recommendations available. Run the odds fetcher
+          (<code>scripts/fetch_betting_odds.py</code>) or wait for the next scheduled refresh.
+        </p>
+      ) : (
+        <div className="list" style={{ marginTop: "var(--space-sm)" }}>
+          {recommendations.map((rec) => {
+            const id = rec.game_id;
+            const isOpen = openId === id;
+            return (
+              <div key={id} className="card">
+                <div
+                  style={{ display: "flex", justifyContent: "space-between", alignItems: "center", cursor: "pointer" }}
+                  onClick={() => setOpenId(isOpen ? null : id)}
+                >
+                  <div>
+                    <div style={{ fontWeight: 700 }} className="text-cyan">{rec.side_label}</div>
+                    <div className="muted text-xs">{rec.game}</div>
+                  </div>
+                  <div style={{ textAlign: "right" }}>
+                    <div className="text-sm">{rec.consensus_pct}% • fair {rec.fair_price_cents}¢</div>
+                    <div className="muted text-xs">
+                      conf {Math.round((rec.confidence || 0) * 100)}% • {rec.book_count} books
+                    </div>
+                  </div>
+                </div>
+                {isOpen ? (
+                  <ApproveForm rec={rec} unitUsd={unitUsd} onApprove={onApprove} />
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/betting/RootingDashboard.jsx
+++ b/frontend/components/betting/RootingDashboard.jsx
@@ -1,0 +1,49 @@
+"use client";
+
+/**
+ * RootingDashboard — "who you need to be rooting for" based on the
+ * user's open/filled Kalshi positions.  Pure presentational; data comes
+ * from GET /api/betting/rooting.
+ */
+export default function RootingDashboard({ rooting }) {
+  if (!Array.isArray(rooting) || rooting.length === 0) {
+    return (
+      <section className="card" style={{ marginBottom: "var(--space-md)" }}>
+        <h2 className="page-title" style={{ fontSize: "1rem" }}>Who to root for</h2>
+        <p className="muted text-sm" style={{ marginTop: 4 }}>
+          No active positions yet. Approve a bet from the call sheet and it&apos;ll show up here.
+        </p>
+      </section>
+    );
+  }
+  return (
+    <section className="card" style={{ marginBottom: "var(--space-md)" }}>
+      <h2 className="page-title" style={{ fontSize: "1rem" }}>Who to root for</h2>
+      <p className="muted text-xs" style={{ marginTop: 2, marginBottom: "var(--space-sm)" }}>
+        Where your money is tonight.
+      </p>
+      <div className="list">
+        {rooting.map((r, i) => (
+          <div
+            key={`${r.game}-${i}`}
+            className="card"
+            style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+          >
+            <div>
+              <div style={{ fontWeight: 700 }} className="text-cyan">
+                {r.rootFor}
+              </div>
+              <div className="muted text-xs">{r.game || "—"}</div>
+            </div>
+            <div style={{ textAlign: "right" }}>
+              <span className="badge">{r.status}</span>
+              <div className="muted text-xs" style={{ marginTop: 2 }}>
+                ${Number(r.stakeUsd || 0).toFixed(2)} @ {r.targetPrice}¢
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,11 @@ beautifulsoup4~=4.14.0
 # subscribed devices.
 pywebpush~=2.0
 
+# cryptography: RSA-PSS request signing for the Kalshi trading API
+# (src/api/kalshi_client.py).  Pulled in transitively by pywebpush, but
+# pinned explicitly here since the betting feature imports it directly.
+cryptography~=41.0
+
 # nfl_data_py: deliberately NOT in this manifest.
 #
 # nfl_data_py 0.3.x pins pandas<2.0, which forces pandas-1.5.3 to

--- a/scripts/fetch_betting_odds.py
+++ b/scripts/fetch_betting_odds.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Fetch sportsbook moneyline odds and write a normalized snapshot.
+
+Pulls head-to-head (moneyline) odds for the major US sports from The
+Odds API (https://the-odds-api.com), a clean, ToS-permitted feed with a
+free tier.  No paywall bypass or scraping — a plain ``requests.get``
+with an API key returns JSON.
+
+The vendor response is normalized into the snapshot shape consumed by
+``src/betting/recommendations.py`` so the blend logic never depends on
+any one vendor's wire format.
+
+Auth
+────
+Set ``ODDS_API_KEY`` in the environment (``.env`` locally; GitHub
+Actions secret for the scheduled fetch).
+
+Output
+──────
+``data/betting/odds_<YYYYMMDDTHHMMSSZ>.json`` (+ a freshness stamp at
+``data/scrape_state/betting_odds_last_success``).
+
+Run::
+
+    python3 scripts/fetch_betting_odds.py [--sports nba,nfl] [--dry-run]
+
+Exit codes:
+    0  - success (snapshot written, even if zero games today)
+    1  - soft failure (missing key, fetch/parse error)
+    2  - schema regression (response not a JSON array for any sport)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import requests
+except ImportError:  # pragma: no cover
+    print("[fetch_betting_odds] requests is not installed", file=sys.stderr)
+    sys.exit(1)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BETTING_DIR = REPO_ROOT / "data" / "betting"
+STAMP_PATH = REPO_ROOT / "data" / "scrape_state" / "betting_odds_last_success"
+
+ODDS_API_BASE = "https://api.the-odds-api.com/v4/sports"
+
+# Friendly alias → The Odds API sport key.
+SPORT_KEYS = {
+    "nba": "basketball_nba",
+    "nfl": "americanfootball_nfl",
+    "mlb": "baseball_mlb",
+    "nhl": "icehockey_nhl",
+}
+
+
+class OddsSchemaError(RuntimeError):
+    """Raised when a sport's response shape is not the expected JSON array."""
+
+
+def _fetch_sport(sport_key: str, api_key: str, *, timeout: int = 30) -> list[dict[str, Any]]:
+    url = f"{ODDS_API_BASE}/{sport_key}/odds"
+    params = {
+        "apiKey": api_key,
+        "regions": "us",
+        "markets": "h2h",
+        "oddsFormat": "american",
+    }
+    resp = requests.get(url, params=params, timeout=timeout)
+    resp.raise_for_status()
+    data = resp.json()
+    if not isinstance(data, list):
+        raise OddsSchemaError(f"{sport_key}: expected JSON array, got {type(data).__name__}")
+    return data
+
+
+def _normalize_game(raw: dict[str, Any], sport_key: str) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    home = str(raw.get("home_team") or "").strip()
+    away = str(raw.get("away_team") or "").strip()
+    if not home or not away:
+        return None
+    books_out: list[dict[str, Any]] = []
+    for bm in raw.get("bookmakers") or []:
+        if not isinstance(bm, dict):
+            continue
+        h2h = None
+        for mkt in bm.get("markets") or []:
+            if isinstance(mkt, dict) and mkt.get("key") == "h2h":
+                h2h = mkt
+                break
+        if not h2h:
+            continue
+        outcomes = [
+            {"team": str(oc.get("name") or "").strip(), "price": oc.get("price")}
+            for oc in (h2h.get("outcomes") or [])
+            if isinstance(oc, dict) and oc.get("name")
+        ]
+        if outcomes:
+            books_out.append({"book": str(bm.get("key") or ""), "outcomes": outcomes})
+    return {
+        "game_id": str(raw.get("id") or f"{away}@{home}"),
+        "sport": sport_key,
+        "commence_time": str(raw.get("commence_time") or ""),
+        "home_team": home,
+        "away_team": away,
+        "books": books_out,
+    }
+
+
+def _write_snapshot(snapshot: dict[str, Any]) -> Path:
+    BETTING_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dst = BETTING_DIR / f"odds_{ts}.json"
+    with dst.open("w", encoding="utf-8") as f:
+        json.dump(snapshot, f, separators=(",", ":"), ensure_ascii=False)
+    return dst
+
+
+def _write_stamp() -> None:
+    STAMP_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STAMP_PATH.write_text(str(int(time.time())), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sports",
+        default="nba,nfl,mlb,nhl",
+        help="Comma list of sports to fetch (nba,nfl,mlb,nhl).",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Don't write the snapshot.")
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read a pre-fetched normalized snapshot JSON instead of calling the API.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file:
+        try:
+            snapshot = json.loads(args.from_file.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[fetch_betting_odds] read failed: {exc}", file=sys.stderr)
+            return 1
+        games = snapshot.get("games", []) if isinstance(snapshot, dict) else []
+        print(f"[fetch_betting_odds] loaded {len(games)} games from file")
+        if not args.dry_run:
+            dst = _write_snapshot(snapshot)
+            _write_stamp()
+            print(f"[fetch_betting_odds] wrote -> {dst}")
+        return 0
+
+    api_key = (os.getenv("ODDS_API_KEY") or "").strip()
+    if not api_key:
+        print("[fetch_betting_odds] ODDS_API_KEY is not set", file=sys.stderr)
+        return 1
+
+    requested = [s.strip().lower() for s in args.sports.split(",") if s.strip()]
+    all_games: list[dict[str, Any]] = []
+    for alias in requested:
+        sport_key = SPORT_KEYS.get(alias)
+        if not sport_key:
+            print(f"[fetch_betting_odds] unknown sport '{alias}', skipping", file=sys.stderr)
+            continue
+        try:
+            raw_games = _fetch_sport(sport_key, api_key)
+        except OddsSchemaError as exc:
+            print(f"[fetch_betting_odds] schema regression: {exc}", file=sys.stderr)
+            return 2
+        except Exception as exc:  # noqa: BLE001
+            print(f"[fetch_betting_odds] fetch failed for {sport_key}: {exc}", file=sys.stderr)
+            return 1
+        for raw in raw_games:
+            game = _normalize_game(raw, sport_key)
+            if game:
+                all_games.append(game)
+
+    snapshot = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source": "the-odds-api",
+        "sports": requested,
+        "games": all_games,
+    }
+    print(f"[fetch_betting_odds] normalized {len(all_games)} games across {len(requested)} sports")
+
+    if args.dry_run:
+        print("[fetch_betting_odds] --dry-run; not writing snapshot")
+        for g in all_games[:3]:
+            print("  ", g["game"] if "game" in g else f"{g['away_team']} @ {g['home_team']}")
+        return 0
+
+    dst = _write_snapshot(snapshot)
+    _write_stamp()
+    print(f"[fetch_betting_odds] wrote {len(all_games)} games -> {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server.py
+++ b/server.py
@@ -75,6 +75,7 @@ from src.api import signal_alerts as _signal_alerts
 from src.api import terminal as _terminal
 from src.api import trade_simulator as _trade_simulator
 from src.api import user_kv as _user_kv
+from src.api import bets_store as _bets_store
 from src.api import league_registry as _league_registry
 from src.api import sleeper_overlay as _sleeper_overlay
 from src.news import NewsService, build_default_service
@@ -2088,6 +2089,92 @@ async def schedule_loop():
         await scheduled_scrape()
 
 
+# ── BETTING RECONCILIATION ──────────────────────────────────────────────
+# Native Kalshi resting limit orders fill on the exchange side; this loop
+# polls open bets and advances resting → filled / canceled so the call
+# sheet + "who to root for" dashboard reflect reality.  Odds refresh is
+# handled by scripts/fetch_betting_odds.py (scheduled workflow / manual
+# run) to respect the odds API's free-tier quota — not here.
+BETTING_RECONCILE_INTERVAL_MIN = int(os.getenv("BETTING_RECONCILE_INTERVAL_MIN", "5"))
+
+
+def _extract_filled(order: dict) -> tuple[int, int | None]:
+    """Best-effort pull of (filled_count, avg_fill_price_cents) from a
+    Kalshi order payload.  Field names vary across API versions, so we
+    probe several and tolerate absence."""
+    from src.api import kalshi_client as _kc
+
+    filled = 0
+    for k in ("filled_count", "fill_count", "taker_fill_count", "filled_quantity"):
+        v = order.get(k)
+        if isinstance(v, (int, float)):
+            filled = int(v)
+            break
+    price = None
+    for k in ("avg_fill_price", "average_price", "fill_price", "yes_price", "no_price"):
+        if k in order:
+            price = _kc.dollars_to_cents(order.get(k))
+            if price is not None:
+                break
+    return filled, price
+
+
+def _reconcile_open_bets() -> int:
+    """Sync reconciliation pass over all open bets.  Returns count updated."""
+    from src.api import kalshi_client as _kc
+
+    open_rows = _bets_store.open_bets()
+    if not open_rows:
+        return 0
+    try:
+        client = _kc.KalshiClient.from_env()
+    except _kc.KalshiConfigError:
+        return 0  # not configured yet — nothing to reconcile against
+    updated = 0
+    for bet in open_rows:
+        order_id = bet.get("kalshi_order_id")
+        if not order_id:
+            continue
+        try:
+            resp = client.get_order(str(order_id))
+        except Exception as exc:  # noqa: BLE001
+            log.warning("reconcile: get_order failed for %s: %s", bet["id"], exc)
+            continue
+        order = resp.get("order") if isinstance(resp, dict) else None
+        if not isinstance(order, dict):
+            continue
+        status = str(order.get("status") or "").strip().lower()
+        filled, price = _extract_filled(order)
+        patch: dict = {}
+        if status in ("canceled", "cancelled"):
+            patch["status"] = "canceled"
+        elif filled and filled >= int(bet.get("count") or 0):
+            patch["status"] = "filled"
+            patch["filled_count"] = filled
+            if price is not None:
+                patch["filled_price"] = price
+        elif filled:
+            patch["filled_count"] = filled
+            if price is not None:
+                patch["filled_price"] = price
+        if patch:
+            _bets_store.update_bet(bet["id"], patch)
+            updated += 1
+    return updated
+
+
+async def betting_loop():
+    """Periodically reconcile open Kalshi bets."""
+    while True:
+        await asyncio.sleep(max(60, BETTING_RECONCILE_INTERVAL_MIN * 60))
+        try:
+            n = await run_in_threadpool(_reconcile_open_bets)
+            if n:
+                log.info("betting: reconciled %d open bet(s)", n)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("betting reconciliation tick failed: %s", exc)
+
+
 # ── APP LIFECYCLE ───────────────────────────────────────────────────────
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -2145,6 +2232,7 @@ async def lifespan(app: FastAPI):
     # 3. Start the recurring schedule
     scheduler_task = asyncio.create_task(schedule_loop())
     uptime_task = asyncio.create_task(uptime_watchdog_loop())
+    betting_task = asyncio.create_task(betting_loop())
     # Public league snapshot warmup — kicks a background rebuild if
     # no persisted snapshot was loaded at boot.  Name is resolved at
     # call time (Python late-binding), so the fact that the function
@@ -2184,6 +2272,7 @@ async def lifespan(app: FastAPI):
     scrape_task.cancel()
     scheduler_task.cancel()
     uptime_task.cancel()
+    betting_task.cancel()
     log.info("Server shutting down")
 
 
@@ -7427,6 +7516,321 @@ async def put_user_state_api(request: Request):
         content={"username": username, "state": state},
         headers={"Cache-Control": "no-store"},
     )
+
+
+# ── Betting (Kalshi auto-bet call sheet) ──────────────────────────
+# Per-user, league-independent feature.  Recommendation blending lives
+# in src/betting/recommendations.py, Kalshi transport in
+# src/api/kalshi_client.py, persistence in src/api/bets_store.py.  All
+# endpoints require auth and key off ``username`` only — never leagueKey.
+BETTING_DIR = DATA_DIR / "betting"
+
+
+def _betting_username(request: Request) -> str | None:
+    session = _get_auth_session(request)
+    if not session:
+        return None
+    return str(session.get("username") or "").strip() or None
+
+
+def _betting_effective_settings(username: str) -> dict:
+    from src.betting import settings as _bset
+
+    state = _user_kv.get_user_state(username) or {}
+    return _bset.effective_settings(state.get("bettingSettings"))
+
+
+@app.get("/api/betting/recommendations")
+async def get_betting_recommendations(request: Request):
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    from src.api import kalshi_client as _kc
+    from src.betting import recommendations as _recs
+
+    def _build() -> dict:
+        path = _recs.latest_snapshot_path(BETTING_DIR)
+        if not path:
+            return {"recommendations": [], "generatedAt": None, "snapshot": None}
+        snap = _recs.load_snapshot(path)
+        return {
+            "recommendations": _recs.build_recommendations(snap),
+            "generatedAt": snap.get("generated_at"),
+            "snapshot": path.name,
+        }
+
+    payload = await run_in_threadpool(_build)
+    payload["env"] = "demo" if _kc.is_demo() else "prod"
+    return JSONResponse(content=payload, headers={"Cache-Control": "no-store"})
+
+
+@app.get("/api/betting/settings")
+async def get_betting_settings(request: Request):
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    from src.api import kalshi_client as _kc
+
+    settings = await run_in_threadpool(_betting_effective_settings, username)
+    settings["env"] = "demo" if _kc.is_demo() else "prod"
+    return JSONResponse(content={"settings": settings}, headers={"Cache-Control": "no-store"})
+
+
+@app.put("/api/betting/settings")
+async def put_betting_settings(request: Request):
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"error": "invalid_body"})
+    from src.betting import settings as _bset
+
+    patch = _bset.sanitize_settings_patch(body)
+
+    def _save() -> dict:
+        state = _user_kv.get_user_state(username) or {}
+        current = state.get("bettingSettings")
+        merged = dict(current) if isinstance(current, dict) else {}
+        merged.update(patch)
+        _user_kv.set_user_field(username, "bettingSettings", merged)
+        return _bset.effective_settings(merged)
+
+    settings = await run_in_threadpool(_save)
+    return JSONResponse(content={"settings": settings}, headers={"Cache-Control": "no-store"})
+
+
+@app.get("/api/betting/bets")
+async def get_betting_bets(request: Request):
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    bets = await run_in_threadpool(_bets_store.list_bets, username)
+    return JSONResponse(content={"bets": bets}, headers={"Cache-Control": "no-store"})
+
+
+@app.post("/api/betting/bets")
+async def post_betting_bet(request: Request):
+    """Approve a bet: validate guardrails, resolve the Kalshi market, and
+    place a resting limit order at the target price."""
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if not isinstance(body, dict):
+        return JSONResponse(status_code=400, content={"error": "invalid_body"})
+
+    target_price = 0
+    try:
+        target_price = int(body.get("targetPrice"))
+    except (TypeError, ValueError):
+        target_price = 0
+    if not (1 <= target_price <= 99):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_target_price", "detail": "targetPrice must be 1-99 cents"},
+        )
+    try:
+        stake_usd = float(body.get("stakeUsd"))
+    except (TypeError, ValueError):
+        stake_usd = 0.0
+    if stake_usd <= 0:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_stake", "detail": "stakeUsd must be greater than 0"},
+        )
+    side = str(body.get("side") or "yes").strip().lower()
+    if side not in ("yes", "no"):
+        side = "yes"
+    sport = str(body.get("sport") or "").strip()
+    game = str(body.get("game") or "").strip()
+    side_label = str(body.get("sideLabel") or "").strip()
+    manual_ticker = str(body.get("ticker") or "").strip()
+    side_team = str(body.get("sideTeam") or "").strip()
+
+    from src.api import kalshi_client as _kc
+    from src.betting import settings as _bset
+    from src.betting import kalshi_mapping as _kmap
+
+    is_live = not _kc.is_demo()
+    env = "prod" if is_live else "demo"
+
+    settings = await run_in_threadpool(_betting_effective_settings, username)
+    committed = await run_in_threadpool(_bets_store.stake_committed_today, username)
+
+    # Contracts to buy so the stake approximates the requested dollars.
+    contract_cost = target_price / 100.0
+    count = max(1, int(stake_usd // contract_cost)) if contract_cost > 0 else 0
+    actual_stake = round(count * contract_cost, 2)
+
+    verdict = _bset.check_bet_allowed(
+        stake_usd=actual_stake,
+        settings=settings,
+        committed_today_usd=committed,
+        is_live=is_live,
+    )
+    if not verdict.ok:
+        return JSONResponse(
+            status_code=400,
+            content={"error": verdict.error, "detail": verdict.detail},
+        )
+
+    # Build/sign a client; missing creds → clean 503 (feature not wired yet).
+    try:
+        client = _kc.KalshiClient.from_env()
+    except _kc.KalshiConfigError as exc:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "betting_not_configured", "detail": str(exc)},
+        )
+
+    # Resolve a ticker: manual takes precedence, else best-effort auto-match.
+    ticker = manual_ticker
+    if not ticker and side_team:
+        match = await run_in_threadpool(
+            _kmap.resolve_market,
+            client,
+            {"side_team": side_team, "game": game, "sport": sport},
+        )
+        if match:
+            ticker = match["ticker"]
+            side = match["side"]
+    if not ticker:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "market_not_resolved",
+                "detail": "Could not auto-match a Kalshi market. Provide a ticker manually.",
+            },
+        )
+
+    client_order_id = uuid.uuid4().hex
+    try:
+        resp = await run_in_threadpool(
+            lambda: client.place_limit_order(
+                ticker=ticker,
+                side=side,
+                action="buy",
+                count=count,
+                price_cents=target_price,
+                client_order_id=client_order_id,
+            )
+        )
+    except _kc.KalshiApiError as exc:
+        return JSONResponse(
+            status_code=502,
+            content={"error": "kalshi_order_rejected", "status": exc.status, "detail": exc.body[:300]},
+        )
+    except Exception as exc:  # noqa: BLE001
+        return JSONResponse(status_code=502, content={"error": "kalshi_request_failed", "detail": str(exc)})
+
+    order = resp.get("order") if isinstance(resp, dict) else None
+    order_id = str(order.get("order_id")) if isinstance(order, dict) and order.get("order_id") else None
+
+    bet = await run_in_threadpool(
+        lambda: _bets_store.create_bet(
+            username,
+            sport=sport,
+            game=game,
+            side_label=side_label or (f"{side_team} ML" if side_team else ticker),
+            kalshi_ticker=ticker,
+            kalshi_side=side,
+            target_price=target_price,
+            stake_usd=actual_stake,
+            count=count,
+            status="resting",
+            kalshi_order_id=order_id,
+            env=env,
+        )
+    )
+    return JSONResponse(content={"bet": bet}, headers={"Cache-Control": "no-store"})
+
+
+@app.post("/api/betting/bets/{bet_id}/cancel")
+async def post_betting_bet_cancel(bet_id: str, request: Request):
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    bet = await run_in_threadpool(_bets_store.get_bet, bet_id)
+    if not bet or bet.get("username") != username:
+        return JSONResponse(status_code=404, content={"error": "not_found"})
+    from src.api import kalshi_client as _kc
+
+    if bet.get("kalshi_order_id"):
+        try:
+            client = _kc.KalshiClient.from_env()
+            await run_in_threadpool(client.cancel_order, str(bet["kalshi_order_id"]))
+        except _kc.KalshiConfigError:
+            pass  # nothing live to cancel; just mark canceled locally
+        except Exception as exc:  # noqa: BLE001
+            log.warning("kalshi cancel failed for bet %s: %s", bet_id, exc)
+    updated = await run_in_threadpool(_bets_store.update_bet, bet_id, {"status": "canceled"})
+    return JSONResponse(content={"bet": updated}, headers={"Cache-Control": "no-store"})
+
+
+@app.post("/api/betting/kill")
+async def post_betting_kill(request: Request):
+    """Panic switch: cancel every open (resting) bet for this user."""
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+    from src.api import kalshi_client as _kc
+
+    def _kill() -> int:
+        bets = _bets_store.list_bets(username, statuses=_bets_store.OPEN_STATUSES)
+        client = None
+        try:
+            client = _kc.KalshiClient.from_env()
+        except _kc.KalshiConfigError:
+            client = None
+        n = 0
+        for b in bets:
+            if client and b.get("kalshi_order_id"):
+                try:
+                    client.cancel_order(str(b["kalshi_order_id"]))
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("kill: cancel failed for %s: %s", b["id"], exc)
+            _bets_store.update_bet(b["id"], {"status": "canceled"})
+            n += 1
+        return n
+
+    count = await run_in_threadpool(_kill)
+    return JSONResponse(content={"canceled": count}, headers={"Cache-Control": "no-store"})
+
+
+@app.get("/api/betting/rooting")
+async def get_betting_rooting(request: Request):
+    """Who to root for tonight — derived from the user's live/open bets."""
+    username = _betting_username(request)
+    if not username:
+        return JSONResponse(status_code=401, content={"error": "auth_required"})
+
+    def _rooting() -> list[dict]:
+        bets = _bets_store.list_bets(
+            username, statuses=frozenset({"resting", "filled"})
+        )
+        rows = []
+        for b in bets:
+            rows.append(
+                {
+                    "game": b.get("game"),
+                    "rootFor": b.get("side_label") or b.get("kalshi_ticker"),
+                    "status": b.get("status"),
+                    "stakeUsd": b.get("stake_usd"),
+                    "targetPrice": b.get("target_price"),
+                    "sport": b.get("sport"),
+                }
+            )
+        return rows
+
+    rows = await run_in_threadpool(_rooting)
+    return JSONResponse(content={"rooting": rows}, headers={"Cache-Control": "no-store"})
 
 
 # ── Web Push subscriptions ────────────────────────────────────────

--- a/server.py
+++ b/server.py
@@ -1756,8 +1756,7 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
                         "dynasty_nerds_schema_regression",
                         level="error",
                         message=(
-                            "Dynasty Nerds fetch exit=2 "
-                            "(DR_DATA shape changed or rows below floor)"
+                            "Dynasty Nerds fetch exit=2 (DR_DATA shape changed or rows below floor)"
                         ),
                         exit_code=rc,
                     )
@@ -4738,7 +4737,7 @@ async def post_angle_packages(request: Request):
             status_code=400,
             content={
                 "error": (
-                    f"Request body must include 'ownerId' and a non-empty " f"{names_key!r} list."
+                    f"Request body must include 'ownerId' and a non-empty {names_key!r} list."
                 )
             },
         )
@@ -6443,7 +6442,7 @@ async def get_sleeper_draft_picks(
             content={
                 "error": "no_active_draft",
                 "message": (
-                    "No active draft for this league, or Sleeper is " "unreachable right now."
+                    "No active draft for this league, or Sleeper is unreachable right now."
                 ),
                 "leagueKey": league_cfg.key,
             },
@@ -7725,13 +7724,21 @@ async def post_betting_bet(request: Request):
     except _kc.KalshiApiError as exc:
         return JSONResponse(
             status_code=502,
-            content={"error": "kalshi_order_rejected", "status": exc.status, "detail": exc.body[:300]},
+            content={
+                "error": "kalshi_order_rejected",
+                "status": exc.status,
+                "detail": exc.body[:300],
+            },
         )
     except Exception as exc:  # noqa: BLE001
-        return JSONResponse(status_code=502, content={"error": "kalshi_request_failed", "detail": str(exc)})
+        return JSONResponse(
+            status_code=502, content={"error": "kalshi_request_failed", "detail": str(exc)}
+        )
 
     order = resp.get("order") if isinstance(resp, dict) else None
-    order_id = str(order.get("order_id")) if isinstance(order, dict) and order.get("order_id") else None
+    order_id = (
+        str(order.get("order_id")) if isinstance(order, dict) and order.get("order_id") else None
+    )
 
     bet = await run_in_threadpool(
         lambda: _bets_store.create_bet(
@@ -7812,9 +7819,7 @@ async def get_betting_rooting(request: Request):
         return JSONResponse(status_code=401, content={"error": "auth_required"})
 
     def _rooting() -> list[dict]:
-        bets = _bets_store.list_bets(
-            username, statuses=frozenset({"resting", "filled"})
-        )
+        bets = _bets_store.list_bets(username, statuses=frozenset({"resting", "filled"}))
         rows = []
         for b in bets:
             rows.append(
@@ -9464,9 +9469,7 @@ async def get_league_article(season: str, week: int, matchup_id: int, mode: str)
             status_code=404,
             content={
                 "error": "not_found",
-                "message": (
-                    f"No {mode} article on disk for {season} W{week} " f"matchup {matchup_id}"
-                ),
+                "message": (f"No {mode} article on disk for {season} W{week} matchup {matchup_id}"),
             },
         )
     return JSONResponse(

--- a/server.py
+++ b/server.py
@@ -5009,7 +5009,7 @@ _ktc_cache = {"rookies": None, "fetched_at": 0}
 _KTC_CACHE_TTL = 6 * 3600  # 6 hours
 
 
-import re
+import re  # noqa: E402
 
 
 def _ktc_decay_curve(known_rookies, total_picks=72):
@@ -6465,19 +6465,19 @@ from src.public_league import (  # noqa: E402 — grouped after route block abov
     build_public_snapshot,
     build_section_payload,
 )
-from src.public_league.public_contract import assert_public_payload_safe
-from src.public_league.sleeper_client import PUBLIC_MAX_SEASONS
-from src.public_league import snapshot_store as public_snapshot_store
-from src.public_league import csv_export as public_csv_export
-from src.public_league import matchup_recap as public_matchup_recap
-from src.public_league import player_journey as public_player_journey
+from src.public_league.public_contract import assert_public_payload_safe  # noqa: E402
+from src.public_league.sleeper_client import PUBLIC_MAX_SEASONS  # noqa: E402
+from src.public_league import snapshot_store as public_snapshot_store  # noqa: E402
+from src.public_league import csv_export as public_csv_export  # noqa: E402
+from src.public_league import matchup_recap as public_matchup_recap  # noqa: E402
+from src.public_league import player_journey as public_player_journey  # noqa: E402
 
 _PUBLIC_LEAGUE_CACHE_TTL_SECONDS = int(os.getenv("PUBLIC_LEAGUE_CACHE_TTL", "300"))
 _PUBLIC_LEAGUE_PERSIST = _env_bool("PUBLIC_LEAGUE_PERSIST_SNAPSHOT", True)
 _PUBLIC_LEAGUE_WARMUP = _env_bool("PUBLIC_LEAGUE_WARMUP_AT_STARTUP", True)
 
 
-from src.api.public_activity_valuation import (
+from src.api.public_activity_valuation import (  # noqa: E402
     build_valuation_from_contract as _build_valuation_from_contract,
 )
 
@@ -6623,11 +6623,9 @@ def _rebuild_public_snapshot(league_id: str, *, trigger: str = "sync"):
             return cached
         started = time.time()
         snapshot = None
-        error = None
         try:
             snapshot = build_public_snapshot(league_id, max_seasons=PUBLIC_MAX_SEASONS)
         except Exception as exc:  # noqa: BLE001
-            error = exc
             _public_league_metrics["rebuild_failures"] += 1
             _log_public_league_event(
                 "rebuild_failed",

--- a/src/api/bets_store.py
+++ b/src/api/bets_store.py
@@ -1,0 +1,328 @@
+"""Bet lifecycle persistence (SQLite-backed).
+
+A durable per-user store for betting "call sheet" entries.  Modeled on
+``src/api/user_kv.py`` (WAL journal, corrupt→reset, process-wide setup
+lock) so it inherits the same crash-durability and concurrency wins.
+
+Bets are **per-user** — keyed by authenticated ``username`` only.  They
+are NOT league-scoped or scoring-profile-scoped: betting is independent
+of the dynasty league context (see CLAUDE.md scoping rules).
+
+Lifecycle
+─────────
+``proposed`` → ``approved`` → ``resting`` → ``filled`` → ``settled``
+with terminal branches ``canceled`` / ``rejected``.
+
+In practice the server inserts a row directly as ``resting`` once a
+Kalshi limit order is placed; ``proposed``/``approved`` exist for
+callers that want to stage a bet before placing it.  The background
+reconciliation loop walks ``open_bets`` and advances ``resting`` →
+``filled`` → ``settled`` from Kalshi fills/positions.
+
+Schema::
+
+    CREATE TABLE bets (
+      id              TEXT PRIMARY KEY,   -- uuid4 hex
+      username        TEXT NOT NULL,
+      created_at      TEXT NOT NULL,
+      updated_at      TEXT NOT NULL,
+      sport           TEXT,
+      game            TEXT,               -- human label, e.g. "Knicks @ Spurs"
+      side_label      TEXT,               -- human label, e.g. "Knicks ML"
+      kalshi_ticker   TEXT,
+      kalshi_side     TEXT,               -- 'yes' | 'no'
+      target_price    INTEGER,            -- limit price in cents (1-99)
+      stake_usd       REAL,               -- intended dollar stake
+      count           INTEGER,            -- contracts ordered
+      status          TEXT NOT NULL,
+      kalshi_order_id TEXT,
+      filled_count    INTEGER DEFAULT 0,
+      filled_price    INTEGER,            -- avg fill price in cents
+      env             TEXT,               -- 'demo' | 'prod' at placement time
+      note            TEXT
+    );
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+BETS_DB_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "bets.sqlite"
+
+OPEN_STATUSES = frozenset({"proposed", "approved", "resting"})
+TERMINAL_STATUSES = frozenset({"filled", "settled", "canceled", "rejected"})
+ALL_STATUSES = OPEN_STATUSES | TERMINAL_STATUSES
+
+_COLUMNS = (
+    "id",
+    "username",
+    "created_at",
+    "updated_at",
+    "sport",
+    "game",
+    "side_label",
+    "kalshi_ticker",
+    "kalshi_side",
+    "target_price",
+    "stake_usd",
+    "count",
+    "status",
+    "kalshi_order_id",
+    "filled_count",
+    "filled_price",
+    "env",
+    "note",
+)
+
+_SETUP_LOCK = threading.Lock()
+_SETUP_DONE: dict[str, bool] = {}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _connect(path: Path | None = None) -> sqlite3.Connection:
+    path = path or BETS_DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_schema(path)
+    conn = sqlite3.connect(str(path), timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_schema(path: Path) -> None:
+    key = str(path)
+    if _SETUP_DONE.get(key):
+        return
+    with _SETUP_LOCK:
+        if _SETUP_DONE.get(key):
+            return
+        _open_or_reset(path)
+        _SETUP_DONE[key] = True
+
+
+def _open_or_reset(path: Path) -> None:
+    def _apply(conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bets (
+              id              TEXT PRIMARY KEY,
+              username        TEXT NOT NULL,
+              created_at      TEXT NOT NULL,
+              updated_at      TEXT NOT NULL,
+              sport           TEXT,
+              game            TEXT,
+              side_label      TEXT,
+              kalshi_ticker   TEXT,
+              kalshi_side     TEXT,
+              target_price    INTEGER,
+              stake_usd       REAL,
+              count           INTEGER,
+              status          TEXT NOT NULL,
+              kalshi_order_id TEXT,
+              filled_count    INTEGER DEFAULT 0,
+              filled_price    INTEGER,
+              env             TEXT,
+              note            TEXT
+            )
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_bets_user ON bets(username)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_bets_status ON bets(status)")
+        conn.commit()
+
+    conn = sqlite3.connect(str(path), timeout=5.0)
+    try:
+        _apply(conn)
+        return
+    except sqlite3.DatabaseError:
+        conn.close()
+        if path.exists():
+            try:
+                path.rename(path.with_suffix(path.suffix + ".corrupt"))
+            except OSError:
+                path.unlink(missing_ok=True)
+        conn = sqlite3.connect(str(path), timeout=5.0)
+        try:
+            _apply(conn)
+        finally:
+            conn.close()
+        return
+    finally:
+        try:
+            conn.close()
+        except sqlite3.ProgrammingError:
+            pass
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return {col: row[col] for col in _COLUMNS}
+
+
+def create_bet(
+    username: str,
+    *,
+    sport: str = "",
+    game: str = "",
+    side_label: str = "",
+    kalshi_ticker: str = "",
+    kalshi_side: str = "yes",
+    target_price: int = 0,
+    stake_usd: float = 0.0,
+    count: int = 0,
+    status: str = "proposed",
+    kalshi_order_id: str | None = None,
+    env: str = "demo",
+    note: str = "",
+    path: Path | None = None,
+) -> dict[str, Any]:
+    """Insert a new bet row and return it."""
+    if not username:
+        raise ValueError("username required")
+    if status not in ALL_STATUSES:
+        raise ValueError(f"invalid status {status!r}")
+    bet_id = uuid.uuid4().hex
+    now = _utc_now_iso()
+    conn = _connect(path)
+    try:
+        conn.execute(
+            f"INSERT INTO bets ({','.join(_COLUMNS)}) "
+            f"VALUES ({','.join('?' for _ in _COLUMNS)})",
+            (
+                bet_id,
+                username,
+                now,
+                now,
+                sport,
+                game,
+                side_label,
+                kalshi_ticker,
+                kalshi_side,
+                int(target_price),
+                float(stake_usd),
+                int(count),
+                status,
+                kalshi_order_id,
+                0,
+                None,
+                env,
+                note,
+            ),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM bets WHERE id = ?", (bet_id,)).fetchone()
+        return _row_to_dict(row)
+    finally:
+        conn.close()
+
+
+def get_bet(bet_id: str, *, path: Path | None = None) -> dict[str, Any] | None:
+    conn = _connect(path)
+    try:
+        row = conn.execute("SELECT * FROM bets WHERE id = ?", (bet_id,)).fetchone()
+        return _row_to_dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def list_bets(
+    username: str,
+    *,
+    statuses: frozenset[str] | None = None,
+    path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """All bets for a user, newest first.  Optionally filter by status set."""
+    conn = _connect(path)
+    try:
+        if statuses:
+            placeholders = ",".join("?" for _ in statuses)
+            rows = conn.execute(
+                f"SELECT * FROM bets WHERE username = ? AND status IN ({placeholders}) "
+                "ORDER BY created_at DESC",
+                (username, *sorted(statuses)),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM bets WHERE username = ? ORDER BY created_at DESC",
+                (username,),
+            ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def open_bets(*, path: Path | None = None) -> list[dict[str, Any]]:
+    """Every open bet across all users — for the reconciliation loop."""
+    conn = _connect(path)
+    try:
+        placeholders = ",".join("?" for _ in OPEN_STATUSES)
+        rows = conn.execute(
+            f"SELECT * FROM bets WHERE status IN ({placeholders}) ORDER BY created_at ASC",
+            tuple(sorted(OPEN_STATUSES)),
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def update_bet(bet_id: str, patch: dict[str, Any], *, path: Path | None = None) -> dict[str, Any] | None:
+    """Update mutable fields on a bet.  Unknown keys are ignored."""
+    mutable = {
+        "status",
+        "kalshi_order_id",
+        "filled_count",
+        "filled_price",
+        "target_price",
+        "stake_usd",
+        "count",
+        "note",
+        "side_label",
+        "kalshi_ticker",
+        "kalshi_side",
+        "env",
+    }
+    sets = {k: v for k, v in patch.items() if k in mutable}
+    if "status" in sets and sets["status"] not in ALL_STATUSES:
+        raise ValueError(f"invalid status {sets['status']!r}")
+    if not sets:
+        return get_bet(bet_id, path=path)
+    sets["updated_at"] = _utc_now_iso()
+    conn = _connect(path)
+    try:
+        assignments = ", ".join(f"{k} = ?" for k in sets)
+        conn.execute(
+            f"UPDATE bets SET {assignments} WHERE id = ?",
+            (*sets.values(), bet_id),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM bets WHERE id = ?", (bet_id,)).fetchone()
+        return _row_to_dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def stake_committed_today(username: str, *, path: Path | None = None) -> float:
+    """Sum of stake_usd for bets created today (UTC) that aren't rejected/canceled.
+
+    Used by the daily-exposure guardrail.
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    conn = _connect(path)
+    try:
+        rows = conn.execute(
+            "SELECT stake_usd FROM bets WHERE username = ? "
+            "AND created_at LIKE ? AND status NOT IN ('rejected','canceled')",
+            (username, f"{today}%"),
+        ).fetchall()
+        return float(sum(float(r["stake_usd"] or 0.0) for r in rows))
+    finally:
+        conn.close()

--- a/src/api/bets_store.py
+++ b/src/api/bets_store.py
@@ -45,7 +45,6 @@ Schema::
 
 from __future__ import annotations
 
-import json
 import sqlite3
 import threading
 import uuid
@@ -195,8 +194,7 @@ def create_bet(
     conn = _connect(path)
     try:
         conn.execute(
-            f"INSERT INTO bets ({','.join(_COLUMNS)}) "
-            f"VALUES ({','.join('?' for _ in _COLUMNS)})",
+            f"INSERT INTO bets ({','.join(_COLUMNS)}) VALUES ({','.join('?' for _ in _COLUMNS)})",
             (
                 bet_id,
                 username,
@@ -274,7 +272,9 @@ def open_bets(*, path: Path | None = None) -> list[dict[str, Any]]:
         conn.close()
 
 
-def update_bet(bet_id: str, patch: dict[str, Any], *, path: Path | None = None) -> dict[str, Any] | None:
+def update_bet(
+    bet_id: str, patch: dict[str, Any], *, path: Path | None = None
+) -> dict[str, Any] | None:
     """Update mutable fields on a bet.  Unknown keys are ignored."""
     mutable = {
         "status",

--- a/src/api/kalshi_client.py
+++ b/src/api/kalshi_client.py
@@ -1,0 +1,280 @@
+"""Kalshi trading API client — RSA-PSS signed REST transport.
+
+Kalshi is a CFTC-regulated event-contracts exchange whose official API
+*explicitly permits* automated trading (unlike traditional sportsbooks,
+whose terms ban bots).  This module is pure transport: it signs and
+issues authenticated REST requests and returns parsed JSON.  All betting
+business logic (recommendation blending, market mapping, guardrails)
+lives in ``src/betting/`` and ``server.py`` — never here.
+
+Authentication
+──────────────
+Every request is signed with an RSA private key.  Three headers:
+
+* ``KALSHI-ACCESS-KEY``        — the API key id
+* ``KALSHI-ACCESS-TIMESTAMP``  — request time in epoch milliseconds
+* ``KALSHI-ACCESS-SIGNATURE``  — base64 RSA-PSS signature of the string
+  ``f"{timestamp}{METHOD}{path}"`` where ``path`` is the request path
+  WITHOUT the query string (e.g. ``/trade-api/v2/portfolio/orders``).
+
+The signature uses PSS padding, MGF1(SHA-256), salt length == digest
+length — the scheme documented at https://docs.kalshi.com.
+
+Environment
+───────────
+* ``KALSHI_ENV``         — ``"demo"`` (default) or ``"prod"``; selects host
+* ``KALSHI_API_KEY_ID``  — the key id
+* ``KALSHI_PRIVATE_KEY`` — RSA private key, PEM format.  Literal ``\\n``
+  escape sequences are tolerated so the key can live on one ``.env`` line.
+
+Demo and production are DIFFERENT accounts with DIFFERENT keys.  Default
+is demo so a missing/typo env can never accidentally trade real money.
+
+Prices
+──────
+Kalshi's March-2026 fixed-point migration made *response* prices dollar
+strings with up to 4 decimals (e.g. ``"0.6500"`` == 65¢).  Order
+placement still accepts integer-cent prices (1–99).  Use
+``dollars_to_cents`` / ``cents_to_dollars`` to convert at the boundary.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import requests
+except Exception:  # pragma: no cover - optional at import time
+    requests = None  # type: ignore[assignment]
+
+# ``cryptography`` can fail to import with a pyo3 PanicException when the
+# native backend (_cffi_backend) is unavailable.  pyo3's PanicException
+# subclasses BaseException, not Exception, so we must guard with
+# BaseException here: a missing/broken crypto backend must never crash
+# server startup — it only disables live Kalshi calls until the
+# dependency is healthy.
+try:
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
+except BaseException:  # pragma: no cover
+    hashes = serialization = padding = rsa = None  # type: ignore[assignment]
+
+
+DEMO_BASE = "https://demo-api.kalshi.co/trade-api/v2"
+# Kalshi serves sports + most markets from the elections host post-merge.
+# Confirm against live docs at integration time if a call 404s.
+PROD_BASE = "https://api.elections.kalshi.com/trade-api/v2"
+
+_UA = "riskittogetthebrisket-betting/1.0"
+
+
+class KalshiConfigError(RuntimeError):
+    """Raised when credentials/config are missing or malformed."""
+
+
+class KalshiApiError(RuntimeError):
+    """Raised when Kalshi returns a non-2xx response."""
+
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self.body = body
+        super().__init__(f"Kalshi API {status}: {body[:300]}")
+
+
+# ── price helpers ────────────────────────────────────────────────────────
+def dollars_to_cents(value: Any) -> int | None:
+    """Parse a Kalshi dollar-string/number price into integer cents.
+
+    ``"0.6500"`` → 65, ``0.65`` → 65, ``65`` → 65 (already cents).
+    Returns ``None`` for unparseable input.
+    """
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    # Values in (0, 1] are dollar-fractions; > 1 are already cents.
+    cents = round(f * 100) if 0 < f <= 1 else round(f)
+    if cents < 0:
+        return None
+    return int(cents)
+
+
+def cents_to_dollars(cents: int) -> str:
+    """Format integer cents as a Kalshi dollar string (``65`` → ``"0.6500"``)."""
+    return f"{int(cents) / 100:.4f}"
+
+
+def is_demo() -> bool:
+    return (os.getenv("KALSHI_ENV") or "demo").strip().lower() != "prod"
+
+
+# ── client ───────────────────────────────────────────────────────────────
+@dataclass
+class KalshiClient:
+    """Thin signed REST wrapper around the Kalshi v2 trading API."""
+
+    key_id: str
+    private_key: Any  # cryptography RSAPrivateKey
+    base_url: str
+    timeout: int = 20
+
+    # ── construction ──
+    @classmethod
+    def from_env(cls) -> "KalshiClient":
+        if requests is None or rsa is None:
+            raise KalshiConfigError(
+                "kalshi_client requires 'requests' and 'cryptography' installed"
+            )
+        key_id = (os.getenv("KALSHI_API_KEY_ID") or "").strip()
+        pem = os.getenv("KALSHI_PRIVATE_KEY") or ""
+        if not key_id or not pem.strip():
+            raise KalshiConfigError(
+                "KALSHI_API_KEY_ID and KALSHI_PRIVATE_KEY must be set"
+            )
+        # Allow the PEM to be stored with literal \n on a single .env line.
+        pem_bytes = pem.replace("\\n", "\n").encode("utf-8")
+        try:
+            private_key = serialization.load_pem_private_key(pem_bytes, password=None)
+        except Exception as exc:  # noqa: BLE001
+            raise KalshiConfigError(f"could not parse KALSHI_PRIVATE_KEY: {exc}") from exc
+        base = DEMO_BASE if is_demo() else PROD_BASE
+        return cls(key_id=key_id, private_key=private_key, base_url=base)
+
+    # ── signing ──
+    def _sign(self, timestamp_ms: str, method: str, path: str) -> str:
+        """RSA-PSS sign ``timestamp+METHOD+path`` (path has no query string)."""
+        message = f"{timestamp_ms}{method.upper()}{path}".encode("utf-8")
+        signature = self.private_key.sign(
+            message,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.DIGEST_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode("utf-8")
+
+    def _headers(self, method: str, path: str) -> dict[str, str]:
+        ts = str(int(time.time() * 1000))
+        return {
+            "KALSHI-ACCESS-KEY": self.key_id,
+            "KALSHI-ACCESS-TIMESTAMP": ts,
+            "KALSHI-ACCESS-SIGNATURE": self._sign(ts, method, path),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": _UA,
+        }
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue a signed request.  ``path`` is the full v2 path used for signing."""
+        # Sign the path WITHOUT query params (Kalshi requirement).
+        headers = self._headers(method, path)
+        # base_url already ends with /trade-api/v2; path begins with the
+        # same prefix for signing, so strip the prefix when building the URL.
+        suffix = path
+        if path.startswith("/trade-api/v2"):
+            suffix = path[len("/trade-api/v2"):]
+        url = f"{self.base_url}{suffix}"
+        resp = requests.request(
+            method.upper(),
+            url,
+            headers=headers,
+            params=params or None,
+            json=json_body,
+            timeout=self.timeout,
+        )
+        if resp.status_code >= 300:
+            raise KalshiApiError(resp.status_code, resp.text)
+        if not resp.content:
+            return {}
+        try:
+            return resp.json()
+        except ValueError:
+            return {}
+
+    # ── market data ──
+    def get_markets(self, **params: Any) -> dict[str, Any]:
+        """List markets.  Common filters: ``series_ticker``, ``status='open'``,
+        ``limit``, ``cursor``."""
+        return self._request("GET", "/trade-api/v2/markets", params=params)
+
+    def get_market(self, ticker: str) -> dict[str, Any]:
+        return self._request("GET", f"/trade-api/v2/markets/{ticker}")
+
+    def get_orderbook(self, ticker: str, depth: int = 10) -> dict[str, Any]:
+        return self._request(
+            "GET", f"/trade-api/v2/markets/{ticker}/orderbook", params={"depth": depth}
+        )
+
+    # ── portfolio ──
+    def get_balance(self) -> dict[str, Any]:
+        return self._request("GET", "/trade-api/v2/portfolio/balance")
+
+    def get_positions(self, **params: Any) -> dict[str, Any]:
+        return self._request("GET", "/trade-api/v2/portfolio/positions", params=params)
+
+    def get_fills(self, **params: Any) -> dict[str, Any]:
+        return self._request("GET", "/trade-api/v2/portfolio/fills", params=params)
+
+    def get_orders(self, **params: Any) -> dict[str, Any]:
+        return self._request("GET", "/trade-api/v2/portfolio/orders", params=params)
+
+    def get_order(self, order_id: str) -> dict[str, Any]:
+        return self._request("GET", f"/trade-api/v2/portfolio/orders/{order_id}")
+
+    # ── trading ──
+    def place_limit_order(
+        self,
+        *,
+        ticker: str,
+        side: str,
+        action: str,
+        count: int,
+        price_cents: int,
+        client_order_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Place a resting limit order.
+
+        ``side``   — ``"yes"`` or ``"no"``
+        ``action`` — ``"buy"`` or ``"sell"``
+        ``count``  — number of contracts (each settles at $1)
+        ``price_cents`` — limit price in integer cents (1–99)
+
+        A resting limit order sits on the book and fills when the market
+        reaches the price — which is exactly the "bet when it hits my
+        price" behaviour we want.
+        """
+        side = side.strip().lower()
+        action = action.strip().lower()
+        if side not in ("yes", "no"):
+            raise ValueError("side must be 'yes' or 'no'")
+        if action not in ("buy", "sell"):
+            raise ValueError("action must be 'buy' or 'sell'")
+        body: dict[str, Any] = {
+            "ticker": ticker,
+            "action": action,
+            "side": side,
+            "count": int(count),
+            "type": "limit",
+        }
+        # Kalshi takes the price on the side-specific field, integer cents.
+        body["yes_price" if side == "yes" else "no_price"] = int(price_cents)
+        if client_order_id:
+            body["client_order_id"] = client_order_id
+        return self._request("POST", "/trade-api/v2/portfolio/orders", json_body=body)
+
+    def cancel_order(self, order_id: str) -> dict[str, Any]:
+        return self._request("DELETE", f"/trade-api/v2/portfolio/orders/{order_id}")

--- a/src/api/kalshi_client.py
+++ b/src/api/kalshi_client.py
@@ -134,9 +134,7 @@ class KalshiClient:
         key_id = (os.getenv("KALSHI_API_KEY_ID") or "").strip()
         pem = os.getenv("KALSHI_PRIVATE_KEY") or ""
         if not key_id or not pem.strip():
-            raise KalshiConfigError(
-                "KALSHI_API_KEY_ID and KALSHI_PRIVATE_KEY must be set"
-            )
+            raise KalshiConfigError("KALSHI_API_KEY_ID and KALSHI_PRIVATE_KEY must be set")
         # Allow the PEM to be stored with literal \n on a single .env line.
         pem_bytes = pem.replace("\\n", "\n").encode("utf-8")
         try:
@@ -186,7 +184,7 @@ class KalshiClient:
         # same prefix for signing, so strip the prefix when building the URL.
         suffix = path
         if path.startswith("/trade-api/v2"):
-            suffix = path[len("/trade-api/v2"):]
+            suffix = path[len("/trade-api/v2") :]
         url = f"{self.base_url}{suffix}"
         resp = requests.request(
             method.upper(),

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -100,6 +100,11 @@ KNOWN_KEYS = frozenset(
         # — listed here so new readers know the schema includes them.
         "notificationsEmail",
         "notificationsEnabled",
+        # Per-user betting guardrail/preference blob for the Betting
+        # section: ``{unit_usd, per_bet_max_usd, daily_cap_usd,
+        # live_confirmed}``.  See src/betting/settings.py.  Betting is
+        # league-independent, so this is a flat per-user field.
+        "bettingSettings",
     }
 )
 

--- a/src/betting/__init__.py
+++ b/src/betting/__init__.py
@@ -1,0 +1,6 @@
+"""Betting feature: odds/consensus blending + Kalshi market mapping.
+
+Pure, per-user, league-independent logic for the private Betting
+section.  Transport lives in ``src/api/kalshi_client.py``; persistence
+in ``src/api/bets_store.py``.
+"""

--- a/src/betting/kalshi_mapping.py
+++ b/src/betting/kalshi_mapping.py
@@ -1,0 +1,144 @@
+"""Map a betting recommendation onto a concrete Kalshi market + side.
+
+A recommendation says "take the Knicks ML".  To place an order we need
+a Kalshi market ticker and whether to buy ``yes`` or ``no``.  Kalshi
+sports markets are typically framed as "Will <TEAM> win?" so taking a
+team usually means buying ``yes`` on that team's market.
+
+The matching here is best-effort and string-based: Kalshi's exact
+ticker/title schema varies by sport and evolves, so we score candidate
+markets by team-name and date overlap and return the best match.  The
+pure scorer (``score_market``) is unit-testable without the network;
+``resolve_market`` wraps it with a live Kalshi query.
+
+If auto-matching fails, the UI lets the user paste a ticker manually —
+so a schema drift degrades to a manual step, never a hard failure.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_STOPWORDS = frozenset(
+    {"will", "win", "the", "vs", "at", "game", "to", "beat", "match", "yes", "no"}
+)
+
+
+def _tokens(text: str) -> set[str]:
+    words = re.findall(r"[a-z0-9]+", str(text).lower())
+    return {w for w in words if w not in _STOPWORDS and len(w) > 1}
+
+
+def _team_tokens(team: str) -> set[str]:
+    """Tokens for a team, biased toward the distinctive last word (nickname).
+
+    "New York Knicks" → {"new", "york", "knicks"}; the nickname "knicks"
+    is the most reliable match key against Kalshi titles.
+    """
+    return _tokens(team)
+
+
+def score_market(market: dict[str, Any], *, team: str, opponent: str) -> float:
+    """Score how well a Kalshi market matches "<team> beats <opponent>".
+
+    Looks at the market's ``title``/``subtitle``/``yes_sub_title`` and
+    ``ticker``.  Returns a float; higher is better.  0 means no match.
+    """
+    if not isinstance(market, dict):
+        return 0.0
+    haystack = " ".join(
+        str(market.get(k) or "")
+        for k in ("title", "subtitle", "yes_sub_title", "ticker", "event_ticker")
+    )
+    hay = _tokens(haystack)
+    if not hay:
+        return 0.0
+    team_tok = _team_tokens(team)
+    opp_tok = _team_tokens(opponent)
+    team_hits = len(team_tok & hay)
+    opp_hits = len(opp_tok & hay)
+    if team_hits == 0:
+        return 0.0
+    # Reward presence of both teams (correct game) and the target team
+    # being the market's subject.
+    score = team_hits * 2.0 + opp_hits * 1.0
+    # Bonus when the target team appears in the yes-side subtitle —
+    # that's the contract that pays if the team wins.
+    yes_sub = _tokens(market.get("yes_sub_title") or market.get("title") or "")
+    if team_tok & yes_sub:
+        score += 1.5
+    return score
+
+
+def select_market(
+    markets: list[dict[str, Any]],
+    *,
+    team: str,
+    opponent: str,
+    min_score: float = 2.0,
+) -> dict[str, Any] | None:
+    """Pick the best-matching market for taking ``team`` over ``opponent``.
+
+    Returns ``{"ticker", "side", "score", "market"}`` or None.  ``side``
+    is ``"yes"`` (the team's market resolves yes if they win).
+    """
+    best: dict[str, Any] | None = None
+    best_score = 0.0
+    for m in markets or []:
+        s = score_market(m, team=team, opponent=opponent)
+        if s > best_score:
+            best_score = s
+            best = m
+    if best is None or best_score < min_score:
+        return None
+    ticker = str(best.get("ticker") or "").strip()
+    if not ticker:
+        return None
+    return {"ticker": ticker, "side": "yes", "score": best_score, "market": best}
+
+
+# ── sport → Kalshi series ticker prefixes ────────────────────────────────
+# Used to narrow the markets query.  These are the public game-winner
+# series prefixes; confirm/extend against live Kalshi data at integration.
+_SPORT_SERIES = {
+    "basketball_nba": "KXNBAGAME",
+    "americanfootball_nfl": "KXNFLGAME",
+    "baseball_mlb": "KXMLBGAME",
+    "icehockey_nhl": "KXNHLGAME",
+}
+
+
+def series_for_sport(sport: str) -> str | None:
+    return _SPORT_SERIES.get(str(sport).strip().lower())
+
+
+def resolve_market(client: Any, recommendation: dict[str, Any]) -> dict[str, Any] | None:
+    """Query Kalshi and return the best market match for a recommendation.
+
+    Best-effort: returns None when no confident match is found, leaving
+    the UI to fall back to manual ticker entry.  ``client`` is a
+    ``KalshiClient``; passed in so this stays testable with a fake.
+    """
+    side_team = str(recommendation.get("side_team") or "")
+    game = str(recommendation.get("game") or "")
+    # Derive opponent from the "AWAY @ HOME" label.
+    opponent = ""
+    if "@" in game:
+        away, home = (p.strip() for p in game.split("@", 1))
+        opponent = home if side_team == away else away
+    if not side_team:
+        return None
+
+    params: dict[str, Any] = {"status": "open", "limit": 200}
+    series = series_for_sport(recommendation.get("sport", ""))
+    if series:
+        params["series_ticker"] = series
+    try:
+        resp = client.get_markets(**params)
+    except Exception:
+        return None
+    markets = resp.get("markets") if isinstance(resp, dict) else None
+    if not isinstance(markets, list):
+        return None
+    return select_market(markets, team=side_team, opponent=opponent)

--- a/src/betting/recommendations.py
+++ b/src/betting/recommendations.py
@@ -1,0 +1,178 @@
+"""Blend sportsbook odds + consensus into per-game betting recommendations.
+
+This is the betting analogue of the dynasty rankings blend: take many
+independent signals (sportsbook moneylines, and any free consensus we
+can layer on) and produce one consensus recommendation per game.
+
+Input is the normalized odds snapshot written by
+``scripts/fetch_betting_odds.py`` (decoupled from any one vendor's wire
+format).  Snapshot shape::
+
+    {
+      "generated_at": "2026-05-21T18:00:00Z",
+      "source": "the-odds-api",
+      "games": [
+        {
+          "game_id": "...",
+          "sport": "basketball_nba",
+          "commence_time": "2026-05-21T23:30:00Z",
+          "home_team": "San Antonio Spurs",
+          "away_team": "New York Knicks",
+          "books": [
+            {"book": "draftkings",
+             "outcomes": [
+               {"team": "New York Knicks", "price": -150},
+               {"team": "San Antonio Spurs", "price": 130}
+             ]}
+          ]
+        }
+      ]
+    }
+
+Only two-way moneyline (head-to-head) markets are blended in v1 — they
+map cleanly onto Kalshi "team to win" Yes/No contracts.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+def american_to_prob(odds: Any) -> float | None:
+    """Convert American moneyline odds to implied probability (with vig)."""
+    try:
+        o = float(odds)
+    except (TypeError, ValueError):
+        return None
+    # Reject NaN/inf: float("nan") parses without error but would
+    # silently poison the de-vig math downstream.
+    if not math.isfinite(o) or o == 0:
+        return None
+    if o > 0:
+        return 100.0 / (o + 100.0)
+    return -o / (-o + 100.0)
+
+
+def _devig_two_way(p_a: float, p_b: float) -> tuple[float, float]:
+    """Remove the bookmaker margin from a two-way market (normalize to 1)."""
+    total = p_a + p_b
+    if total <= 0:
+        return 0.0, 0.0
+    return p_a / total, p_b / total
+
+
+def _blend_game(game: dict[str, Any]) -> dict[str, Any] | None:
+    """Produce one recommendation for a single game, or None if unusable."""
+    home = str(game.get("home_team") or "").strip()
+    away = str(game.get("away_team") or "").strip()
+    if not home or not away:
+        return None
+    books = game.get("books")
+    if not isinstance(books, list) or not books:
+        return None
+
+    # Accumulate de-vigged probabilities per team across books.
+    sums: dict[str, float] = {home: 0.0, away: 0.0}
+    counts: dict[str, int] = {home: 0, away: 0}
+    book_count = 0
+    for book in books:
+        if not isinstance(book, dict):
+            continue
+        outcomes = book.get("outcomes")
+        if not isinstance(outcomes, list):
+            continue
+        raw: dict[str, float] = {}
+        for oc in outcomes:
+            if not isinstance(oc, dict):
+                continue
+            team = str(oc.get("team") or "").strip()
+            prob = american_to_prob(oc.get("price"))
+            if team in sums and prob is not None:
+                raw[team] = prob
+        if home in raw and away in raw:
+            ph, pa = _devig_two_way(raw[home], raw[away])
+            sums[home] += ph
+            counts[home] += 1
+            sums[away] += pa
+            counts[away] += 1
+            book_count += 1
+
+    if book_count == 0:
+        return None
+
+    avg_home = sums[home] / counts[home] if counts[home] else 0.0
+    avg_away = sums[away] / counts[away] if counts[away] else 0.0
+    if avg_home >= avg_away:
+        side_team, fair_prob = home, avg_home
+    else:
+        side_team, fair_prob = away, avg_away
+
+    fair_price_cents = max(1, min(99, round(fair_prob * 100)))
+    # Confidence: blend of how strong the favorite is and how many books
+    # agree.  0..1.  A near-coinflip with one book is low confidence; a
+    # heavy favorite priced across many books is high.
+    edge = abs(avg_home - avg_away)  # 0 (coinflip) .. ~1 (lock)
+    book_factor = min(1.0, book_count / 5.0)
+    confidence = round(min(1.0, 0.5 * edge * 2 + 0.5 * book_factor), 3)
+
+    return {
+        "game_id": str(game.get("game_id") or f"{away}@{home}"),
+        "sport": str(game.get("sport") or ""),
+        "commence_time": str(game.get("commence_time") or ""),
+        "game": f"{away} @ {home}",
+        "side_team": side_team,
+        "side_label": f"{side_team} ML",
+        "fair_prob": round(fair_prob, 4),
+        "fair_price_cents": fair_price_cents,
+        "consensus_pct": round(fair_prob * 100, 1),
+        "book_count": book_count,
+        "confidence": confidence,
+    }
+
+
+def build_recommendations(
+    snapshot: dict[str, Any],
+    *,
+    min_books: int = 1,
+) -> list[dict[str, Any]]:
+    """Blend a normalized odds snapshot into per-game recommendations.
+
+    Sorted by confidence descending.  Games with fewer than ``min_books``
+    contributing books are dropped.
+    """
+    if not isinstance(snapshot, dict):
+        return []
+    games = snapshot.get("games")
+    if not isinstance(games, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for game in games:
+        if not isinstance(game, dict):
+            continue
+        rec = _blend_game(game)
+        if rec and rec["book_count"] >= min_books:
+            out.append(rec)
+    out.sort(key=lambda r: r["confidence"], reverse=True)
+    return out
+
+
+def load_snapshot(path: Path) -> dict[str, Any]:
+    """Read a normalized odds snapshot JSON file.  Returns {} if missing/bad."""
+    try:
+        with Path(path).open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def latest_snapshot_path(betting_dir: Path) -> Path | None:
+    """Return the newest ``odds_*.json`` in ``betting_dir`` or None."""
+    try:
+        candidates = sorted(Path(betting_dir).glob("odds_*.json"))
+    except OSError:
+        return None
+    return candidates[-1] if candidates else None

--- a/src/betting/settings.py
+++ b/src/betting/settings.py
@@ -1,0 +1,150 @@
+"""Per-user betting settings + server-side guardrail enforcement.
+
+Settings are stored per-user in ``user_kv`` under the ``bettingSettings``
+key (small preference blob).  Defaults come from
+``config/betting_sources.json`` so they can be tuned without code.
+
+Guardrails (all enforced here, never trusted from the client):
+
+1. unit_usd          — default stake per bet
+2. per_bet_max_usd   — hard ceiling on any single bet
+3. daily_cap_usd     — cap on total stake committed per UTC day
+4. require_live_confirm + live_confirmed — real-money (prod) placement
+   requires an explicit per-user acknowledgement
+5. (manual approval is structural — nothing places without an API call;
+   there is no hands-off auto mode)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "betting_sources.json"
+
+# Fallback defaults if the config file is missing/unreadable.
+_HARD_DEFAULTS = {
+    "unit_usd": 5.0,
+    "per_bet_max_usd": 25.0,
+    "daily_cap_usd": 50.0,
+    "require_live_confirm": True,
+}
+
+
+def _load_config_defaults() -> dict[str, Any]:
+    try:
+        with _CONFIG_PATH.open("r", encoding="utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return dict(_HARD_DEFAULTS)
+    gd = cfg.get("guardrail_defaults") if isinstance(cfg, dict) else None
+    if not isinstance(gd, dict):
+        return dict(_HARD_DEFAULTS)
+    out = dict(_HARD_DEFAULTS)
+    for k in _HARD_DEFAULTS:
+        if k in gd:
+            out[k] = gd[k]
+    return out
+
+
+def _coerce_positive_float(value: Any, fallback: float) -> float:
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return f if f > 0 else fallback
+
+
+def effective_settings(user_settings: dict[str, Any] | None) -> dict[str, Any]:
+    """Merge a user's stored ``bettingSettings`` over the config defaults."""
+    defaults = _load_config_defaults()
+    us = user_settings if isinstance(user_settings, dict) else {}
+    return {
+        "unit_usd": _coerce_positive_float(us.get("unit_usd"), defaults["unit_usd"]),
+        "per_bet_max_usd": _coerce_positive_float(
+            us.get("per_bet_max_usd"), defaults["per_bet_max_usd"]
+        ),
+        "daily_cap_usd": _coerce_positive_float(
+            us.get("daily_cap_usd"), defaults["daily_cap_usd"]
+        ),
+        # require_live_confirm is a safety floor: config can require it,
+        # and a user cannot turn it off (only satisfy it via live_confirmed).
+        "require_live_confirm": bool(defaults["require_live_confirm"]),
+        "live_confirmed": bool(us.get("live_confirmed", False)),
+    }
+
+
+def sanitize_settings_patch(body: dict[str, Any]) -> dict[str, Any]:
+    """Build a safe ``bettingSettings`` patch from a request body.
+
+    Only the user-tunable fields are accepted; everything else (and any
+    attempt to weaken ``require_live_confirm``) is ignored.
+    """
+    patch: dict[str, Any] = {}
+    if "unit_usd" in body:
+        patch["unit_usd"] = _coerce_positive_float(body.get("unit_usd"), _HARD_DEFAULTS["unit_usd"])
+    if "per_bet_max_usd" in body:
+        patch["per_bet_max_usd"] = _coerce_positive_float(
+            body.get("per_bet_max_usd"), _HARD_DEFAULTS["per_bet_max_usd"]
+        )
+    if "daily_cap_usd" in body:
+        patch["daily_cap_usd"] = _coerce_positive_float(
+            body.get("daily_cap_usd"), _HARD_DEFAULTS["daily_cap_usd"]
+        )
+    if "live_confirmed" in body:
+        patch["live_confirmed"] = bool(body.get("live_confirmed"))
+    return patch
+
+
+@dataclass
+class GuardrailResult:
+    ok: bool
+    error: str = ""
+    detail: dict[str, Any] | None = None
+
+
+def check_bet_allowed(
+    *,
+    stake_usd: float,
+    settings: dict[str, Any],
+    committed_today_usd: float,
+    is_live: bool,
+) -> GuardrailResult:
+    """Validate a proposed stake against all guardrails.
+
+    ``settings`` is the output of ``effective_settings``.  ``is_live`` is
+    True when ``KALSHI_ENV=prod`` (real money).
+    """
+    if stake_usd <= 0:
+        return GuardrailResult(False, "invalid_stake", {"stake_usd": stake_usd})
+
+    per_bet_max = float(settings.get("per_bet_max_usd", 0))
+    if per_bet_max > 0 and stake_usd > per_bet_max:
+        return GuardrailResult(
+            False,
+            "exceeds_per_bet_max",
+            {"stake_usd": stake_usd, "per_bet_max_usd": per_bet_max},
+        )
+
+    daily_cap = float(settings.get("daily_cap_usd", 0))
+    if daily_cap > 0 and (committed_today_usd + stake_usd) > daily_cap:
+        return GuardrailResult(
+            False,
+            "exceeds_daily_cap",
+            {
+                "stake_usd": stake_usd,
+                "committed_today_usd": committed_today_usd,
+                "daily_cap_usd": daily_cap,
+            },
+        )
+
+    if is_live and settings.get("require_live_confirm") and not settings.get("live_confirmed"):
+        return GuardrailResult(
+            False,
+            "live_confirmation_required",
+            {"hint": "Set live_confirmed=true in betting settings to enable real-money bets."},
+        )
+
+    return GuardrailResult(True)

--- a/src/betting/settings.py
+++ b/src/betting/settings.py
@@ -66,9 +66,7 @@ def effective_settings(user_settings: dict[str, Any] | None) -> dict[str, Any]:
         "per_bet_max_usd": _coerce_positive_float(
             us.get("per_bet_max_usd"), defaults["per_bet_max_usd"]
         ),
-        "daily_cap_usd": _coerce_positive_float(
-            us.get("daily_cap_usd"), defaults["daily_cap_usd"]
-        ),
+        "daily_cap_usd": _coerce_positive_float(us.get("daily_cap_usd"), defaults["daily_cap_usd"]),
         # require_live_confirm is a safety floor: config can require it,
         # and a user cannot turn it off (only satisfy it via live_confirmed).
         "require_live_confirm": bool(defaults["require_live_confirm"]),

--- a/tests/betting/test_betting.py
+++ b/tests/betting/test_betting.py
@@ -148,7 +148,11 @@ def test_resolve_market_uses_client(monkeypatch):
                 ]
             }
 
-    rec = {"side_team": "New York Knicks", "game": "New York Knicks @ San Antonio Spurs", "sport": "basketball_nba"}
+    rec = {
+        "side_team": "New York Knicks",
+        "game": "New York Knicks @ San Antonio Spurs",
+        "sport": "basketball_nba",
+    }
     m = kmap.resolve_market(FakeClient(), rec)
     assert m["ticker"] == "KXNBAGAME-NYK"
 
@@ -166,14 +170,25 @@ def test_effective_settings_merges_user_over_defaults():
 
 def test_check_bet_allowed_paths():
     eff = bset.effective_settings({"unit_usd": 5, "per_bet_max_usd": 25, "daily_cap_usd": 50})
-    assert bset.check_bet_allowed(stake_usd=5, settings=eff, committed_today_usd=0, is_live=False).ok
-    assert bset.check_bet_allowed(stake_usd=0, settings=eff, committed_today_usd=0, is_live=False).error == "invalid_stake"
+    assert bset.check_bet_allowed(
+        stake_usd=5, settings=eff, committed_today_usd=0, is_live=False
+    ).ok
     assert (
-        bset.check_bet_allowed(stake_usd=30, settings=eff, committed_today_usd=0, is_live=False).error
+        bset.check_bet_allowed(
+            stake_usd=0, settings=eff, committed_today_usd=0, is_live=False
+        ).error
+        == "invalid_stake"
+    )
+    assert (
+        bset.check_bet_allowed(
+            stake_usd=30, settings=eff, committed_today_usd=0, is_live=False
+        ).error
         == "exceeds_per_bet_max"
     )
     assert (
-        bset.check_bet_allowed(stake_usd=20, settings=eff, committed_today_usd=40, is_live=False).error
+        bset.check_bet_allowed(
+            stake_usd=20, settings=eff, committed_today_usd=40, is_live=False
+        ).error
         == "exceeds_daily_cap"
     )
     # Live + unconfirmed is blocked; demo is fine.
@@ -184,7 +199,9 @@ def test_check_bet_allowed_paths():
     eff_confirmed = bset.effective_settings(
         {"unit_usd": 5, "per_bet_max_usd": 25, "daily_cap_usd": 50, "live_confirmed": True}
     )
-    assert bset.check_bet_allowed(stake_usd=5, settings=eff_confirmed, committed_today_usd=0, is_live=True).ok
+    assert bset.check_bet_allowed(
+        stake_usd=5, settings=eff_confirmed, committed_today_usd=0, is_live=True
+    ).ok
 
 
 def test_sanitize_settings_patch_ignores_unknown_and_floor():
@@ -226,7 +243,9 @@ def test_bets_store_roundtrip(tmp_path):
     assert len(bets_store.open_bets(path=db)) == 1
 
     # advancing to filled removes it from the open set
-    bets_store.update_bet(bet["id"], {"status": "filled", "filled_count": 10, "filled_price": 59}, path=db)
+    bets_store.update_bet(
+        bet["id"], {"status": "filled", "filled_count": 10, "filled_price": 59}, path=db
+    )
     assert len(bets_store.open_bets(path=db)) == 0
     refreshed = bets_store.get_bet(bet["id"], path=db)
     assert refreshed["status"] == "filled"

--- a/tests/betting/test_betting.py
+++ b/tests/betting/test_betting.py
@@ -1,0 +1,278 @@
+"""Unit tests for the Betting feature backend.
+
+Covers the recommendation blend, Kalshi market matching, per-user
+guardrails, the SQLite bet store, and (when the crypto backend is
+available) the RSA-PSS request signer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api import bets_store
+from src.api import kalshi_client as kc
+from src.betting import kalshi_mapping as kmap
+from src.betting import recommendations as recs
+from src.betting import settings as bset
+
+
+# ── recommendation blend ────────────────────────────────────────────────
+def _snapshot():
+    return {
+        "generated_at": "2026-05-21T18:00:00Z",
+        "games": [
+            {
+                "game_id": "g1",
+                "sport": "basketball_nba",
+                "commence_time": "2026-05-21T23:30:00Z",
+                "home_team": "San Antonio Spurs",
+                "away_team": "New York Knicks",
+                "books": [
+                    {
+                        "book": "draftkings",
+                        "outcomes": [
+                            {"team": "New York Knicks", "price": -150},
+                            {"team": "San Antonio Spurs", "price": 130},
+                        ],
+                    },
+                    {
+                        "book": "fanduel",
+                        "outcomes": [
+                            {"team": "New York Knicks", "price": -145},
+                            {"team": "San Antonio Spurs", "price": 125},
+                        ],
+                    },
+                ],
+            },
+            {
+                "game_id": "g2",
+                "sport": "basketball_nba",
+                "commence_time": "2026-05-21T23:30:00Z",
+                "home_team": "Boston Celtics",
+                "away_team": "Miami Heat",
+                "books": [
+                    {
+                        "book": "draftkings",
+                        "outcomes": [
+                            {"team": "Boston Celtics", "price": -110},
+                            {"team": "Miami Heat", "price": -110},
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def test_american_to_prob():
+    assert recs.american_to_prob(-150) == pytest.approx(0.6, abs=0.01)
+    assert recs.american_to_prob(150) == pytest.approx(0.4, abs=0.01)
+    assert recs.american_to_prob("nan") is None
+    assert recs.american_to_prob(0) is None
+
+
+def test_build_recommendations_picks_favorite_and_sorts():
+    out = recs.build_recommendations(_snapshot())
+    assert len(out) == 2
+    # The Knicks game is a clearer favorite → higher confidence → first.
+    top = out[0]
+    assert top["side_team"] == "New York Knicks"
+    assert top["side_label"] == "New York Knicks ML"
+    # De-vigged fair price ~ 58-60 cents.
+    assert 55 <= top["fair_price_cents"] <= 62
+    assert top["book_count"] == 2
+    # Sorted by confidence descending.
+    assert out[0]["confidence"] >= out[1]["confidence"]
+    # The coinflip game produces a near-50 fair price.
+    coin = next(r for r in out if r["game_id"] == "g2")
+    assert 48 <= coin["fair_price_cents"] <= 52
+
+
+def test_build_recommendations_min_books_filter():
+    out = recs.build_recommendations(_snapshot(), min_books=2)
+    # Only the 2-book game survives.
+    assert [r["game_id"] for r in out] == ["g1"]
+
+
+def test_build_recommendations_handles_garbage():
+    assert recs.build_recommendations({}) == []
+    assert recs.build_recommendations({"games": "nope"}) == []
+    assert recs.build_recommendations({"games": [{"home_team": "A"}]}) == []
+
+
+# ── Kalshi market matching ──────────────────────────────────────────────
+def test_select_market_picks_target_team_yes_side():
+    markets = [
+        {
+            "ticker": "KXNBAGAME-26MAY21NYKSAS-NYK",
+            "title": "Will the New York Knicks beat the San Antonio Spurs?",
+            "yes_sub_title": "New York Knicks",
+        },
+        {
+            "ticker": "KXNBAGAME-26MAY21NYKSAS-SAS",
+            "title": "Will the San Antonio Spurs beat the New York Knicks?",
+            "yes_sub_title": "San Antonio Spurs",
+        },
+    ]
+    m = kmap.select_market(markets, team="New York Knicks", opponent="San Antonio Spurs")
+    assert m is not None
+    assert m["ticker"] == "KXNBAGAME-26MAY21NYKSAS-NYK"
+    assert m["side"] == "yes"
+
+
+def test_select_market_no_match_returns_none():
+    markets = [{"ticker": "KXNFLGAME-X", "title": "Will the Cowboys win?"}]
+    assert kmap.select_market(markets, team="New York Knicks", opponent="Spurs") is None
+
+
+def test_score_market_zero_when_team_absent():
+    assert kmap.score_market({"title": "Spurs game"}, team="Knicks", opponent="Spurs") == 0.0
+
+
+def test_series_for_sport():
+    assert kmap.series_for_sport("basketball_nba") == "KXNBAGAME"
+    assert kmap.series_for_sport("unknown") is None
+
+
+def test_resolve_market_uses_client(monkeypatch):
+    class FakeClient:
+        def get_markets(self, **params):
+            assert params.get("series_ticker") == "KXNBAGAME"
+            return {
+                "markets": [
+                    {
+                        "ticker": "KXNBAGAME-NYK",
+                        "title": "Will the New York Knicks beat the San Antonio Spurs?",
+                        "yes_sub_title": "New York Knicks",
+                    }
+                ]
+            }
+
+    rec = {"side_team": "New York Knicks", "game": "New York Knicks @ San Antonio Spurs", "sport": "basketball_nba"}
+    m = kmap.resolve_market(FakeClient(), rec)
+    assert m["ticker"] == "KXNBAGAME-NYK"
+
+
+# ── guardrails ──────────────────────────────────────────────────────────
+def test_effective_settings_merges_user_over_defaults():
+    eff = bset.effective_settings({"unit_usd": 10, "per_bet_max_usd": 40})
+    assert eff["unit_usd"] == 10
+    assert eff["per_bet_max_usd"] == 40
+    # daily_cap falls back to config default
+    assert eff["daily_cap_usd"] > 0
+    # require_live_confirm is a safety floor the user cannot disable
+    assert eff["require_live_confirm"] is True
+
+
+def test_check_bet_allowed_paths():
+    eff = bset.effective_settings({"unit_usd": 5, "per_bet_max_usd": 25, "daily_cap_usd": 50})
+    assert bset.check_bet_allowed(stake_usd=5, settings=eff, committed_today_usd=0, is_live=False).ok
+    assert bset.check_bet_allowed(stake_usd=0, settings=eff, committed_today_usd=0, is_live=False).error == "invalid_stake"
+    assert (
+        bset.check_bet_allowed(stake_usd=30, settings=eff, committed_today_usd=0, is_live=False).error
+        == "exceeds_per_bet_max"
+    )
+    assert (
+        bset.check_bet_allowed(stake_usd=20, settings=eff, committed_today_usd=40, is_live=False).error
+        == "exceeds_daily_cap"
+    )
+    # Live + unconfirmed is blocked; demo is fine.
+    assert (
+        bset.check_bet_allowed(stake_usd=5, settings=eff, committed_today_usd=0, is_live=True).error
+        == "live_confirmation_required"
+    )
+    eff_confirmed = bset.effective_settings(
+        {"unit_usd": 5, "per_bet_max_usd": 25, "daily_cap_usd": 50, "live_confirmed": True}
+    )
+    assert bset.check_bet_allowed(stake_usd=5, settings=eff_confirmed, committed_today_usd=0, is_live=True).ok
+
+
+def test_sanitize_settings_patch_ignores_unknown_and_floor():
+    patch = bset.sanitize_settings_patch(
+        {"unit_usd": 7, "require_live_confirm": False, "evil": 1, "live_confirmed": True}
+    )
+    assert patch["unit_usd"] == 7
+    assert patch["live_confirmed"] is True
+    # cannot weaken the live-confirm floor or inject arbitrary keys
+    assert "require_live_confirm" not in patch
+    assert "evil" not in patch
+
+
+# ── bet store ───────────────────────────────────────────────────────────
+def test_bets_store_roundtrip(tmp_path):
+    db = tmp_path / "bets.sqlite"
+    bet = bets_store.create_bet(
+        "alice",
+        sport="nba",
+        game="NYK @ SAS",
+        side_label="NYK ML",
+        kalshi_ticker="KXNBAGAME-NYK",
+        kalshi_side="yes",
+        target_price=60,
+        stake_usd=6.0,
+        count=10,
+        status="resting",
+        kalshi_order_id="ord1",
+        env="demo",
+        path=db,
+    )
+    assert bet["status"] == "resting"
+    assert bet["username"] == "alice"
+
+    listed = bets_store.list_bets("alice", path=db)
+    assert len(listed) == 1
+
+    # open across users
+    assert len(bets_store.open_bets(path=db)) == 1
+
+    # advancing to filled removes it from the open set
+    bets_store.update_bet(bet["id"], {"status": "filled", "filled_count": 10, "filled_price": 59}, path=db)
+    assert len(bets_store.open_bets(path=db)) == 0
+    refreshed = bets_store.get_bet(bet["id"], path=db)
+    assert refreshed["status"] == "filled"
+    assert refreshed["filled_price"] == 59
+
+    # committed-today excludes rejected/canceled
+    bets_store.create_bet("alice", stake_usd=4.0, status="canceled", path=db)
+    assert bets_store.stake_committed_today("alice", path=db) == pytest.approx(6.0)
+
+
+def test_bets_store_invalid_status(tmp_path):
+    with pytest.raises(ValueError):
+        bets_store.create_bet("bob", status="bogus", path=tmp_path / "b.sqlite")
+
+
+# ── price helpers ───────────────────────────────────────────────────────
+def test_price_helpers():
+    assert kc.dollars_to_cents("0.6500") == 65
+    assert kc.dollars_to_cents(0.65) == 65
+    assert kc.dollars_to_cents(65) == 65
+    assert kc.dollars_to_cents("garbage") is None
+    assert kc.cents_to_dollars(65) == "0.6500"
+
+
+# ── RSA signer (only when the native crypto backend is available) ────────
+def test_rsa_signature_verifies():
+    if kc.rsa is None:
+        pytest.skip("cryptography backend unavailable in this environment")
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    private_key = kc.rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    client = kc.KalshiClient(key_id="kid", private_key=private_key, base_url=kc.DEMO_BASE)
+    ts = "1716315000000"
+    method = "GET"
+    path = "/trade-api/v2/portfolio/balance"
+    sig_b64 = client._sign(ts, method, path)
+
+    import base64
+
+    signature = base64.b64decode(sig_b64)
+    message = f"{ts}{method}{path}".encode("utf-8")
+    # Raises InvalidSignature if the signature doesn't verify.
+    private_key.public_key().verify(
+        signature,
+        message,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.DIGEST_LENGTH),
+        hashes.SHA256(),
+    )

--- a/tests/betting/test_betting_api.py
+++ b/tests/betting/test_betting_api.py
@@ -1,0 +1,112 @@
+"""API-level tests for the Betting endpoints (FastAPI TestClient).
+
+Verifies auth gating, settings round-trip, guardrail rejection, and the
+clean "not configured" path when no Kalshi credentials are present.
+These run without any Kalshi/Odds credentials.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from starlette.testclient import TestClient
+
+import server
+
+
+@pytest.fixture()
+def client():
+    return TestClient(server.app)
+
+
+@pytest.fixture()
+def authed():
+    """A TestClient with an injected in-memory session cookie."""
+    sid = uuid.uuid4().hex
+    server.auth_sessions[sid] = {"username": f"tester_{sid[:8]}"}
+    c = TestClient(server.app)
+    c.cookies.set(server.JASON_AUTH_COOKIE_NAME, sid)
+    yield c
+    server.auth_sessions.pop(sid, None)
+
+
+def test_endpoints_require_auth(client):
+    gets = [
+        "/api/betting/recommendations",
+        "/api/betting/bets",
+        "/api/betting/settings",
+        "/api/betting/rooting",
+    ]
+    for path in gets:
+        assert client.get(path).status_code == 401, f"{path} should require auth"
+    assert client.post("/api/betting/bets", json={}).status_code == 401
+    assert client.post("/api/betting/kill", json={}).status_code == 401
+
+
+def test_settings_roundtrip(authed):
+    resp = authed.get("/api/betting/settings")
+    assert resp.status_code == 200
+    settings = resp.json()["settings"]
+    assert settings["unit_usd"] > 0
+    assert settings["env"] in ("demo", "prod")
+
+    resp = authed.put(
+        "/api/betting/settings",
+        json={"unit_usd": 8, "per_bet_max_usd": 30, "daily_cap_usd": 60},
+    )
+    assert resp.status_code == 200
+    saved = resp.json()["settings"]
+    assert saved["unit_usd"] == 8
+    assert saved["per_bet_max_usd"] == 30
+
+
+def test_recommendations_empty_without_snapshot(authed):
+    resp = authed.get("/api/betting/recommendations")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "recommendations" in body
+    assert isinstance(body["recommendations"], list)
+
+
+def test_post_bet_guardrail_rejects_oversized(authed):
+    # Default per-bet max is 25; a $999 stake → way over.
+    resp = authed.post(
+        "/api/betting/bets",
+        json={"targetPrice": 50, "stakeUsd": 999, "sideTeam": "New York Knicks"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "exceeds_per_bet_max"
+
+
+def test_post_bet_invalid_price(authed):
+    resp = authed.post("/api/betting/bets", json={"targetPrice": 150, "stakeUsd": 5})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_target_price"
+
+
+def test_post_bet_zero_stake_rejected(authed):
+    resp = authed.post("/api/betting/bets", json={"targetPrice": 50, "stakeUsd": 0})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_stake"
+
+
+def test_post_bet_not_configured_without_credentials(authed):
+    # Valid, within-guardrail bet — but no Kalshi creds → clean 503.
+    resp = authed.post(
+        "/api/betting/bets",
+        json={"targetPrice": 50, "stakeUsd": 5, "ticker": "KXNBAGAME-TEST"},
+    )
+    assert resp.status_code == 503
+    assert resp.json()["error"] == "betting_not_configured"
+
+
+def test_kill_and_rooting_empty(authed):
+    resp = authed.post("/api/betting/kill", json={})
+    assert resp.status_code == 200
+    assert resp.json()["canceled"] == 0
+
+    resp = authed.get("/api/betting/rooting")
+    assert resp.status_code == 200
+    assert resp.json()["rooting"] == []


### PR DESCRIPTION
## Summary

A new **private, login-gated Betting section** (linked at the top of the More page, deliberately separate from trade/rankings). It blends public sportsbook moneyline odds into per-game recommendations, lets you approve a bet with a target price + stake, and places a **native resting limit order on Kalshi** — a CFTC-regulated event-contracts exchange whose official API *permits* automated trading (unlike traditional sportsbooks). A "who to root for" dashboard reflects your open positions, and a background loop reconciles fills.

Phase 1 runs against Kalshi's **demo sandbox** by default; flipping to live is a single env toggle plus a per-user real-money confirmation.

### Backend
- `src/api/kalshi_client.py` — RSA-PSS signed REST client (demo default; degrades gracefully if the crypto backend is unavailable so it can never crash startup)
- `src/api/bets_store.py` — SQLite bet-lifecycle store (mirrors the `user_kv` patterns)
- `src/betting/recommendations.py` — per-book de-vig → averaged consensus → favorite recommendation
- `src/betting/kalshi_mapping.py` — best-effort recommendation → Kalshi market/side matcher (manual ticker fallback in the UI)
- `src/betting/settings.py` — per-user guardrails
- `scripts/fetch_betting_odds.py` — The Odds API fetcher (free tier, ToS-clean)
- `server.py` — `/api/betting/*` endpoints + background reconciliation loop wired into the lifespan

### Guardrails (all server-enforced, never trusted from the client)
- Configurable unit size, per-bet max stake, daily total exposure cap
- Always-manual approval (no hands-off auto mode)
- Demo-by-default master switch; live placement requires `KALSHI_ENV=prod` **and** an explicit per-user `live_confirmed`
- Kill switch cancels all resting orders

### Frontend
- `/betting` page with `CallSheet`, `BetList`, `RootingDashboard`, and guardrail settings; auth-gated via `useAuthContext()`, league-independent
- "Betting" added at the top of the More page's sections

### Config / credentials
- `config/betting_sources.json` for sports, vendors, blend, and guardrail defaults
- New env vars in `.env.example`: `KALSHI_ENV` / `KALSHI_API_KEY_ID` / `KALSHI_PRIVATE_KEY` / `ODDS_API_KEY` / `BETTING_RECONCILE_INTERVAL_MIN`

## Notes / follow-ups
- **Credentials needed before live use**: a Kalshi API key (demo first) and a free Odds API key.
- Recommendations stay empty until the odds fetcher runs; wiring `scripts/fetch_betting_odds.py` into the scheduled GitHub workflow is a deliberate follow-up once `ODDS_API_KEY` exists (kept out of CI to avoid burning the free-tier quota and to not touch the shared pipeline without the secret).
- Kalshi market matching and the exact order/price field names are best-effort against the documented schema and may need a small tweak when first run against the live demo API; the UI's manual-ticker fallback covers auto-match misses.

## Test plan
- [x] `pytest tests/betting/` — 23 passed (RSA signer test runs where the crypto backend is present; skips otherwise)
- [x] Full suite collects cleanly (3028 tests); `user_kv` + `config_parity` tests pass
- [x] `next build` compiles, including the new `/betting` route
- [ ] End-to-end against Kalshi **demo**: fetch odds → approve a bet → confirm a resting limit order appears in the demo dashboard → drive a fill → see it on the Rooting dashboard
- [ ] Verify guardrail rejections (per-bet max, daily cap) and the kill switch against demo
- [ ] Only after demo is verified: flip `KALSHI_ENV=prod` + set `live_confirmed`

https://claude.ai/code/session_01HA1v9TWQ5HZHnRGTUCt4iR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HA1v9TWQ5HZHnRGTUCt4iR)_