### PR TITLE
fix(deploy): stop Sleeper overlay warm from blocking the pre-bind startup path

### DIFF
--- a/deploy/verify-deploy.sh
+++ b/deploy/verify-deploy.sh
@@ -12,7 +12,14 @@ FRONTEND_PORT="${FRONTEND_PORT:-3000}"
 FRONTEND_BUILD_DIR="${FRONTEND_BUILD_DIR:-${APP_DIR}/frontend/.next}"
 SERVICE_NAME="${SERVICE_NAME:-dynasty}"
 PUBLIC_URL="${PUBLIC_URL:-}"
-VERIFY_MAX_ATTEMPTS="${VERIFY_MAX_ATTEMPTS:-20}"
+# 45 x 2s = ~90s.  Backend boot parses the multi-MB cached contract and
+# primes 4 payload views before the port binds; the old 40s budget was
+# tight enough that ambient slowness (disk, CPU steal on the VPS) could
+# fail an otherwise-healthy deploy and trigger a full auto-rollback.
+# The Sleeper overlay warm is no longer on the pre-bind path (see
+# server.py::_warm_overlays_in_background), so 90s is generous, not a
+# band-aid over unbounded network work.
+VERIFY_MAX_ATTEMPTS="${VERIFY_MAX_ATTEMPTS:-45}"
 VERIFY_SLEEP_SECONDS="${VERIFY_SLEEP_SECONDS:-2}"
 VERIFY_CURL_TIMEOUT="${VERIFY_CURL_TIMEOUT:-8}"
 STRICT_LOCAL_HEALTH="${STRICT_LOCAL_HEALTH:-true}"

--- a/server.py
+++ b/server.py
@@ -1418,6 +1418,62 @@ def _backup_freshness() -> dict:
 
 
 # ── SCRAPER INTEGRATION ────────────────────────────────────────────────
+def _warm_overlays_in_background(contract_payload: dict) -> None:
+    """Force-refresh the Sleeper overlay cache for every active league
+    on a daemon thread.
+
+    Called by ``_prime_latest_payload`` after a scrape / startup prime.
+    Must never run inline on the event loop — see the call site for the
+    deploy-failure history.  Thread-safe: ``fetch_sleeper_overlay`` is
+    the same sync callable the request path already invokes via
+    ``run_in_threadpool``, and it guards its own per-league cache.
+    """
+
+    def _worker() -> None:
+        try:
+            loaded_sleeper = contract_payload.get("sleeper") or {}
+            id_map = loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else {}
+            warmed: list[str] = []
+            warm_failed: list[str] = []
+            for cfg in _league_registry.active_leagues():
+                try:
+                    overlay = _sleeper_overlay.fetch_sleeper_overlay(
+                        sleeper_league_id=cfg.sleeper_league_id,
+                        id_to_player=id_map if isinstance(id_map, dict) else {},
+                        force_refresh=True,
+                    )
+                    if overlay and overlay.get("teams"):
+                        warmed.append(cfg.key)
+                    else:
+                        warm_failed.append(cfg.key)
+                except Exception as inner:  # noqa: BLE001
+                    log.warning(
+                        "post-scrape overlay warm failed for %s: %s",
+                        cfg.key,
+                        inner,
+                    )
+                    warm_failed.append(cfg.key)
+            if warmed or warm_failed:
+                log.info(
+                    "post-scrape overlay warm: %d warmed, %d failed (warmed=%s failed=%s)",
+                    len(warmed),
+                    len(warm_failed),
+                    warmed,
+                    warm_failed,
+                )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("post-scrape overlay warm pass failed: %s", exc)
+
+    try:
+        threading.Thread(
+            target=_worker,
+            name="sleeper-overlay-warm",
+            daemon=True,
+        ).start()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("post-scrape overlay warm thread failed to start: %s", exc)
+
+
 def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -> None:
     """Pre-serialize latest payload once so /api/data returns instantly.
 
@@ -1545,39 +1601,19 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         # (default + cross-league), warming the default league makes
         # the very first /api/data after a scrape return overlay-fresh
         # rosters too.  Non-fatal: any failure is logged + skipped.
-        try:
-            loaded_sleeper = contract_payload.get("sleeper") or {}
-            id_map = loaded_sleeper.get("idToPlayer") if isinstance(loaded_sleeper, dict) else {}
-            warmed: list[str] = []
-            warm_failed: list[str] = []
-            for cfg in _league_registry.active_leagues():
-                try:
-                    overlay = _sleeper_overlay.fetch_sleeper_overlay(
-                        sleeper_league_id=cfg.sleeper_league_id,
-                        id_to_player=id_map if isinstance(id_map, dict) else {},
-                        force_refresh=True,
-                    )
-                    if overlay and overlay.get("teams"):
-                        warmed.append(cfg.key)
-                    else:
-                        warm_failed.append(cfg.key)
-                except Exception as inner:  # noqa: BLE001
-                    log.warning(
-                        "post-scrape overlay warm failed for %s: %s",
-                        cfg.key,
-                        inner,
-                    )
-                    warm_failed.append(cfg.key)
-            if warmed or warm_failed:
-                log.info(
-                    "post-scrape overlay warm: %d warmed, %d failed (warmed=%s failed=%s)",
-                    len(warmed),
-                    len(warm_failed),
-                    warmed,
-                    warm_failed,
-                )
-        except Exception as exc:  # noqa: BLE001
-            log.warning("post-scrape overlay warm pass failed: %s", exc)
+        #
+        # Runs on a background daemon thread (same pattern as
+        # ``_kick_background_refresh``), NEVER inline: this function is
+        # called from the ``lifespan`` startup path BEFORE uvicorn binds
+        # the port, and from ``run_scraper`` on the event loop.  Inline,
+        # a slow Sleeper (per-league round-trips with read timeouts)
+        # blocked the socket bind past deploy verification's retry
+        # budget — the root cause of the 2026-07-25 deploy failures /
+        # auto-rollbacks — and stalled the loop at every scrape end.
+        # The warm is a cache-priming optimization; requests that land
+        # before it finishes simply fetch the overlay themselves via
+        # the existing threadpool path in ``get_data``.
+        _warm_overlays_in_background(contract_payload)
 
         if not contract_report.get("ok"):
             log.error(

--- a/tests/api/test_startup_nonblocking.py
+++ b/tests/api/test_startup_nonblocking.py
@@ -1,0 +1,91 @@
+"""Pin: payload priming must not block on Sleeper network calls.
+
+``_prime_latest_payload`` runs in two loop-critical places:
+
+* the FastAPI ``lifespan`` startup path, BEFORE uvicorn binds the
+  port — deploy verification probes the port on a fixed retry budget,
+  so anything slow here fails the deploy and triggers auto-rollback
+  (this happened three times on 2026-07-25: a slow Sleeper API held
+  the pre-bind overlay warm past the budget); and
+* ``run_scraper`` at scrape end, directly on the event loop.
+
+The overlay warm is a cache-priming optimization, so it belongs on a
+background daemon thread (``_warm_overlays_in_background``).  This test
+pins the contract: priming returns promptly even when the overlay
+fetch hangs, and the warm still happens (on a thread) once the fetch
+unblocks.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import server
+
+
+def _minimal_contract() -> dict:
+    return {
+        "meta": {"leagueKey": "main"},
+        "players": {},
+        "playersArray": [],
+        "sleeper": {"idToPlayer": {}},
+        "date": "2026-01-01",
+    }
+
+
+def test_prime_latest_payload_returns_while_overlay_fetch_hangs(monkeypatch):
+    """A wedged Sleeper API must not delay priming (and therefore must
+    not delay the port bind at boot or the loop at scrape end)."""
+    release = threading.Event()
+    started = threading.Event()
+    calls: list[str] = []
+
+    def hanging_fetch(*, sleeper_league_id, id_to_player, force_refresh=False):
+        started.set()
+        calls.append(sleeper_league_id)
+        # Simulate Sleeper stalling until the test releases it.
+        release.wait(timeout=10)
+        return {"teams": [{"ownerId": "o1"}], "overlayFetchedAt": "t"}
+
+    monkeypatch.setattr(server._sleeper_overlay, "fetch_sleeper_overlay", hanging_fetch)
+
+    t0 = time.monotonic()
+    server._prime_latest_payload(_minimal_contract())
+    elapsed = time.monotonic() - t0
+
+    try:
+        # Priming must return promptly — well under the hang window.
+        # Generous bound: serialization of the minimal contract is
+        # milliseconds; 5s only trips if the fetch ran inline.
+        assert elapsed < 5.0, (
+            f"_prime_latest_payload took {elapsed:.1f}s — the overlay warm "
+            "is blocking again (it must run on a background thread)"
+        )
+        # The warm thread did start the fetch (cache priming preserved)
+        # for at least one active league, unless no leagues are
+        # configured in this environment — in which case there is
+        # nothing to warm and nothing to block on either.
+        if server._league_registry.active_leagues():
+            assert started.wait(timeout=5), "overlay warm thread never started a fetch"
+    finally:
+        release.set()
+
+
+def test_warm_overlays_in_background_is_nonfatal_on_fetch_error(monkeypatch):
+    """A raising fetch must be swallowed by the worker (warm is
+    best-effort), never propagate to the caller."""
+
+    def broken_fetch(**_kw):
+        raise RuntimeError("sleeper down")
+
+    monkeypatch.setattr(server._sleeper_overlay, "fetch_sleeper_overlay", broken_fetch)
+
+    # Must not raise, and must return immediately.
+    t0 = time.monotonic()
+    server._warm_overlays_in_background(_minimal_contract())
+    assert time.monotonic() - t0 < 1.0
+    # Give the daemon thread a beat to run + swallow the error.
+    for th in threading.enumerate():
+        if th.name == "sleeper-overlay-warm":
+            th.join(timeout=5)


### PR DESCRIPTION
Recovery plan **A4** — the fix that lets merges to main actually reach production again. Three consecutive Deploy Production runs failed today (15:02, 15:05, 15:49 UTC), each auto-rolling back; prod is currently pinned to rollback revision `697e0ad3`.

## Root cause
The "post-scrape overlay warm" inside `_prime_latest_payload` force-refreshes the Sleeper overlay for **every active league synchronously**. That function runs in the FastAPI `lifespan` **before uvicorn binds port 8000**. When Sleeper was slow (read timeouts visible in the failed deploys' journal capture), boot blew past deploy verification's 20×2s retry budget — the port never opened (`connection refused` on all 20 probes), verify declared the deploy dead, and the rollback (which happened to hit a faster Sleeper) passed. The same inline warm also stalls the event loop at every scrape end in steady state.

## Changes
- **`server.py`**: extract the warm into `_warm_overlays_in_background()` — identical per-league force-refresh loop, now on a daemon thread (same pattern as the existing `_kick_background_refresh`). Requests landing before the warm finishes simply fetch the overlay themselves via the existing `run_in_threadpool` path in `get_data`; behavior preserved, blocking gone.
- **`deploy/verify-deploy.sh`**: retry budget 20 → 45 attempts (~90s). Boot still parses the multi-MB contract + primes 4 payload views pre-bind; 40s was tight enough for ambient VPS slowness to fail a healthy deploy. With network off the critical path this is headroom, not a band-aid.
- **`tests/api/test_startup_nonblocking.py`** (new): pins that priming returns promptly while the overlay fetch hangs (wedged-Sleeper simulation), and that a raising fetch is swallowed by the warm worker.

## Validation
- New tests + `test_startup_validation`: 12/12
- ruff check/format clean, `bash -n` on the verify script
- Full `tests/api` non-livedata suite run in progress locally; merge follows its green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_