### PR TITLE
fix(watchdog): soft-flag draftSharks while the fetcher is broken

### DIFF
--- a/config/source_staleness.json
+++ b/config/source_staleness.json
@@ -15,7 +15,9 @@
     "idpShow": 24
   },
   "_comment_soft": "Sources listed in 'soft' are still reported everywhere (on-site stale banner, email alerts with their existing cooldown, the freshness-watchdog summary) but do NOT hard-fail the scheduled-refresh workflow or open a failure issue. Use this only for sources whose staleness recurs for reasons outside the cron's control. idpShow authenticates with a browser-minted cookie (deploy/idpshow_fetch_and_push.sh) that the operator must periodically re-mint by hand; when it lapses, one expiring cookie should not turn every 2h run red. Matched by exact key or vendor prefix, same as thresholds.",
+  "_comment_draftsharks": "TEMPORARY soft-flag (added 2026-07-25): scripts/fetch_draftsharks.py has failed since 2026-06-23 - the site's #use-my-league-dropdown selector never appears (UI change or silently failing login), so draftSharks + draftSharksIdp went hard-stale and turned EVERY scheduled-refresh run red for a month, drowning real failures. Soft-flagging restores the watchdog's signal while the fetcher is repaired. REMOVE this entry (prefix covers both keys) once fetch_draftsharks.py works again.",
   "soft": [
-    "idpShow"
+    "idpShow",
+    "draftSharks"
   ]
 }


### PR DESCRIPTION
Recovery plan **A5**. `scripts/fetch_draftsharks.py` has failed since **2026-06-23** — the site's `#use-my-league-dropdown` selector never appears (UI change or silently failing login). `draftSharks` + `draftSharksIdp` went hard-stale (770h vs a 24h threshold) and turned **every** Scheduled Data Refresh run red for a month, burying real failures behind a permanently-red workflow.

## Change
Add `draftSharks` to the existing operator `soft` list in `config/source_staleness.json` (same mechanism as `idpShow`'s cookie lapses). The vendor prefix covers both registry keys. Soft sources stay visible everywhere — on-site stale banner, email alerts, watchdog summary — they just stop hard-failing the workflow. Marked TEMPORARY with a removal note for when the fetcher is repaired.

Repairing the fetcher itself needs credentialed browser access to DraftSharks and is left as a follow-up task (good isolated Codex candidate).

## Validation
- `load_soft_sources()` resolves both keys via the vendor prefix; `ktc` unaffected
- 37 staleness/watchdog/source-health tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_