### PR TITLE
fix(deploy): post-deploy smoke must wait out the cold public-league snapshot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -476,7 +476,7 @@ jobs:
             # filenames like "app/api/public/league/[section]/route-*.js"
             # which preserve the brackets on disk.
             code=$(curl --silent --show-error --globoff --output /dev/null \
-              --write-out '%{http_code}' --max-time 15 "${full_url}" || echo "000")
+              --write-out '%{http_code}' --max-time 30 "${full_url}" || echo "000")
             if [[ "${code}" == "${expect_code}" ]]; then
               echo "PASS: ${path} -> ${code}"
               PASS=$((PASS + 1))
@@ -501,6 +501,27 @@ jobs:
               break
             fi
             sleep 3
+          done
+
+          # The public-league snapshot is ALWAYS cold right after a
+          # restart: the first request kicks a multi-season Sleeper
+          # rebuild that can take minutes.  The event loop stays
+          # responsive during the rebuild (threadpool offload, #519) —
+          # which is why /api/status passes while /league and
+          # /api/public/league still wait on the snapshot — but a 15s
+          # single-shot probe here false-failed the 2026-07-25 deploy
+          # AFTER verification had already passed.  Kick the rebuild
+          # and poll until warm (up to ~6 min) before the pass/fail
+          # probes below.
+          echo "Waiting for ${URL}/api/public/league snapshot to come warm…"
+          for _i in $(seq 1 24); do
+            _plc=$(curl --silent --globoff --output /dev/null --max-time 20 \
+              --write-out '%{http_code}' "${URL}/api/public/league" || echo "000")
+            if [[ "${_plc}" == "200" ]]; then
+              echo "  public-league snapshot warm after ~$(( _i * 15 ))s"
+              break
+            fi
+            sleep 15
           done
 
           check_endpoint "/api/health" 200


### PR DESCRIPTION
The 17:00 deploy **proved the startup fix (#523)**: backend bound port 8000 in ~6s (3 verify attempts vs. never-binding before), verification passed, no rollback — the new revision shipped to production. The run still went red because the *separate* post-deploy smoke step probed `/league` and `/api/public/league` with 15s single-shot curls moments after the restart — when the public-league snapshot is **always cold** and the first request kicks a multi-season Sleeper rebuild that takes minutes. (The event loop stays responsive during the rebuild — #519's threadpool offload — which is exactly why `/api/status` passed at the same instant.)

## Changes (`.github/workflows/deploy.yml`)
- Kick the rebuild and **poll `/api/public/league` until warm (up to ~6 min)** before the pass/fail probes, mirroring the existing health-ready wait.
- `check_endpoint` curl budget 15s → 30s, same as smoke-test.yml (#528): `/league` SSR runs ~15s in production and sat on the edge.

## Validation
YAML parses; change is confined to the smoke step (probe list and rollback logic untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_