### PR TITLE
Phase 3: player search & filter system (team/yearsExp enrichment + filter engine)

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -438,7 +438,11 @@ jobs:
           # otherwise the prune never lands in a commit and the next
           # checkout resurrects the files forever (Codex review on
           # PR #532).
-          for p in CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/ data/ros/ data/scrape_state/ data/sleeper_last_good.json; do
+          # data/player_map/ persists team_map_last_good.json — the
+          # scraper's Sleeper-outage fallback for NFL-team tags.  Fresh
+          # runners start from the repo, so an unstaged map would never
+          # survive to the run that needs it (Codex round 7 on PR #535).
+          for p in CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/ data/player_map/ data/ros/ data/scrape_state/ data/sleeper_last_good.json; do
             if [ -e "$p" ]; then
               git add -f -- "$p"
             elif [ -n "$(git ls-files -- "$p")" ]; then

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -1155,6 +1155,14 @@ def fetch_sleeper_rosters(league_id):
         team_player_ids = []
 
         for pid in player_ids:
+            # Every raw roster id lands in team_player_ids
+            # UNCONDITIONALLY: the frontend's definitive-ID-miss rule
+            # (player-filters.js::resolveOwnerTeam) treats a populated
+            # byId index as complete, so gating ids on VALID_POSITIONS
+            # (raw IDP labels like ILB/EDGE/FS/NT aren't in it) made
+            # rostered IDPs classify as unrostered (Codex round 7 on
+            # PR #535).  Name/position handling below stays filtered.
+            team_player_ids.append(str(pid))
             p = all_nfl.get(pid)
             if not p:
                 continue
@@ -1185,7 +1193,6 @@ def fetch_sleeper_rosters(league_id):
                 team_players.append(cn)
                 all_names.append(cn)
                 sid = str(pid)
-                team_player_ids.append(sid)
                 if cn and sid:
                     player_id_map[cn] = sid
                     id_to_player[sid] = cn

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -6812,33 +6812,54 @@ async def run(progress_callback=None):
 
     # Persist rookie visibility metadata for dashboard filtering/debugging.
     #
-    # NFL-team stamps get a LAST-GOOD fallback (Codex round 6 on
-    # PR #535): when the Sleeper /players/nfl fetch fails,
-    # SLEEPER_ALL_NFL is empty and every live lookup returns None —
-    # without a fallback the fresh export would publish team-less rows
-    # and empty every NFL-team filter until the next successful fetch.
-    # After a healthy pass we persist the name→team map; on an outage
-    # pass we stamp from the saved map instead.
+    # NFL-team, years-exp, and age stamps get a LAST-GOOD fallback
+    # (Codex rounds 6+8 on PR #535): when the Sleeper /players/nfl
+    # fetch fails, SLEEPER_ALL_NFL is empty and every live lookup
+    # returns None — without a fallback the fresh export would publish
+    # rows with no team/yearsExp/age, and because the frontend's
+    # team/experience/age predicates fail closed, those filters would
+    # empty the rankings board until the next successful fetch.  After
+    # a healthy pass we persist per-player {team, yearsExp, age}; on an
+    # outage pass we stamp from the saved map instead.  The legacy
+    # "teams" key is kept alongside the newer "players" map so an
+    # outage right after this change still reads pre-change files.
     _team_map_path = os.path.join("data", "player_map", "team_map_last_good.json")
     _team_map_fallback: dict = {}
+    _meta_map_fallback: dict = {}
     if not SLEEPER_ALL_NFL:
         try:
             with open(_team_map_path, "r", encoding="utf-8") as _fh:
-                _team_map_fallback = json.load(_fh).get("teams", {})
+                _last_good_meta = json.load(_fh)
+            _team_map_fallback = _last_good_meta.get("teams", {})
+            _meta_map_fallback = _last_good_meta.get("players", {})
             print(
                 f"  [Teams] Sleeper player DB unavailable — using last-good "
-                f"team map ({len(_team_map_fallback)} entries)"
+                f"metadata map ({len(_team_map_fallback)} teams, "
+                f"{len(_meta_map_fallback)} player metadata rows)"
             )
         except Exception:
             _team_map_fallback = {}
+            _meta_map_fallback = {}
     _years_exp_tagged = 0
     _rookie_tagged = 0
     _age_tagged = 0
     _team_tagged = 0
+
+    def _last_good_int(name, key):
+        row = _meta_map_fallback.get(name)
+        if not isinstance(row, dict):
+            return None
+        try:
+            return int(row.get(key))
+        except Exception:
+            return None
+
     for _name, _pdata in players_json.items():
         if not isinstance(_pdata, dict) or _looks_like_pick_name(_name):
             continue
         _yrs = _player_years_exp_local(_name, _pdata)
+        if _yrs is None:
+            _yrs = _last_good_int(_name, "yearsExp")
         if isinstance(_yrs, int) and _yrs >= 0:
             _pdata["_yearsExp"] = int(_yrs)
             _years_exp_tagged += 1
@@ -6850,6 +6871,8 @@ async def run(progress_callback=None):
             _pdata["_isRookie"] = True
             _rookie_tagged += 1
         _age = _player_age_local(_name, _pdata)
+        if _age is None:
+            _age = _last_good_int(_name, "age")
         if isinstance(_age, int):
             _pdata["age"] = _age
             _age_tagged += 1
@@ -6861,21 +6884,37 @@ async def run(progress_callback=None):
     # outage pass would just re-save the fallback it loaded).
     if SLEEPER_ALL_NFL and _team_tagged:
         try:
+            _lg_players = {}
+            for _n, _d in players_json.items():
+                if not isinstance(_d, dict):
+                    continue
+                _row = {}
+                if isinstance(_d.get("team"), str) and _d.get("team"):
+                    _row["team"] = _d["team"]
+                if isinstance(_d.get("_yearsExp"), int):
+                    _row["yearsExp"] = _d["_yearsExp"]
+                if isinstance(_d.get("age"), int):
+                    _row["age"] = _d["age"]
+                if _row:
+                    _lg_players[_n] = _row
             os.makedirs(os.path.dirname(_team_map_path), exist_ok=True)
             with open(_team_map_path, "w", encoding="utf-8") as _fh:
                 json.dump(
                     {
                         "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                        # Legacy key — older readers only understand
+                        # the flat name→team shape.
                         "teams": {
                             n: d["team"]
                             for n, d in players_json.items()
                             if isinstance(d, dict) and isinstance(d.get("team"), str)
                         },
+                        "players": _lg_players,
                     },
                     _fh,
                 )
         except Exception as _exc:
-            print(f"  [Teams] last-good team map save failed (non-fatal): {_exc}")
+            print(f"  [Teams] last-good metadata map save failed (non-fatal): {_exc}")
 
     # Final must-have rookie position enforcement. Do this after fallback creation and
     # rookie tagging so defensive prospects cannot drift back into generic offense entries.

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -216,7 +216,7 @@ def retry(max_attempts=3, delay=2, backoff=2, exceptions=(Exception,)):
                     if attempt < max_attempts - 1:
                         wait = delay * (backoff**attempt)
                         print(
-                            f"  [Retry] {func.__name__} attempt {attempt+1} failed: {e}. "
+                            f"  [Retry] {func.__name__} attempt {attempt + 1} failed: {e}. "
                             f"Retrying in {wait}s..."
                         )
                         await asyncio.sleep(wait)
@@ -233,7 +233,7 @@ def retry(max_attempts=3, delay=2, backoff=2, exceptions=(Exception,)):
                     if attempt < max_attempts - 1:
                         wait = delay * (backoff**attempt)
                         print(
-                            f"  [Retry] {func.__name__} attempt {attempt+1} failed: {e}. "
+                            f"  [Retry] {func.__name__} attempt {attempt + 1} failed: {e}. "
                             f"Retrying in {wait}s..."
                         )
                         time.sleep(wait)
@@ -1158,7 +1158,9 @@ def fetch_sleeper_rosters(league_id):
             p = all_nfl.get(pid)
             if not p:
                 continue
-            full = p.get("full_name") or f"{p.get('first_name','')} {p.get('last_name','')}".strip()
+            full = (
+                p.get("full_name") or f"{p.get('first_name', '')} {p.get('last_name', '')}".strip()
+            )
             raw_pos = p.get("position", "") or ""
             # Sleeper exposes ``fantasy_positions`` as the list of
             # eligible slots; ``position`` is just the primary. For
@@ -1583,8 +1585,7 @@ if SLEEPER_LEAGUE_ID:
             )
         else:
             print(
-                "  [Sleeper] No players found and no cached snapshot — "
-                "falling back to players.txt"
+                "  [Sleeper] No players found and no cached snapshot — falling back to players.txt"
             )
 
 
@@ -2323,8 +2324,6 @@ async def scrape_ktc(page, players):
 
         if not name_map and DEBUG:
             await page_dump(page, "KTC")
-            # Also dump a snippet of page source to help diagnose
-            content_snippet = content[:2000] if "content" in dir() else ""
             # Check what script tags exist
             script_ids = re.findall(
                 r'<script[^>]*id="([^"]*)"', content if "content" in dir() else ""
@@ -3798,9 +3797,6 @@ async def run(progress_callback=None):
         ("KTC", scrape_ktc),
         ("IDPTradeCalc", scrape_idptradecalc),
     ]
-
-    # Parallel scraping — these sites can be scraped concurrently
-    PARALLEL_SITES = {"KTC"}
 
     browser_needed = any(SITES.get(s) for s, _ in browser_order)
 
@@ -5356,7 +5352,6 @@ async def run(progress_callback=None):
     _idp_rank_sites = set()  # currently none use idpRank mode in scraper (handled in dashboard)
     # Z-score parameters
     Z_FLOOR, Z_CEILING = -2.0, 4.0
-    RANK_OFFSET, RANK_DIVISOR, RANK_EXPONENT = 27, 28, -0.66
     # IDP Anchor System: tether the #1 IDP player to IDPTradeCalc's top non-Hunter value
     # This makes the anchor self-adjusting as the IDP market shifts
     _IDP_ANCHOR_EXCLUDE = {"travis hunter"}  # Excluded from anchor — he's a WR in dynasty
@@ -5484,10 +5479,6 @@ async def run(progress_callback=None):
         )
         return _interp_anchor_points(rank_value, curve)
 
-    IDP_RANK_OFFSET = 15  # Controls curve flatness near the top
-    IDP_RANK_DIVISOR = 16  # Paired with offset so rank 1 → exactly IDP_ANCHOR_TOP
-    IDP_RANK_EXPONENT = -0.72  # Steeper than offense (-0.66) since IDP value drops faster
-    SINGLE_SOURCE_DISCOUNT = 0.85  # 15% discount for players on only 1 site
     COMPOSITE_SCALE = 9999
     OUTLIER_TRIM_GAP = 0.18  # Trim only true outliers, not legitimate elite values
     # Elite ceiling expansion: allows top-consensus players to approach 9999.
@@ -6181,6 +6172,24 @@ async def run(progress_callback=None):
             return None
         return _age_from_birthdate(row.get("birth_date"))
 
+    def _player_team_local(pname, pdata):
+        """NFL team abbreviation from the Sleeper players blob.  Free
+        agents carry ``team: None`` in Sleeper — return "FA" for a
+        matched player without a team so the contract can distinguish
+        "free agent" from "identity never matched" (None)."""
+        sid = str((pdata or {}).get("_sleeperId") or _player_id_map.get(pname) or "").strip()
+        if not sid:
+            ident = _resolve_identity_cached(pname, preferred_pos=_get_pos(pname))
+            if ident and ident.get("id"):
+                sid = str(ident.get("id"))
+        if not sid:
+            return None
+        row = SLEEPER_ALL_NFL.get(sid)
+        if not isinstance(row, dict):
+            return None
+        team = str(row.get("team") or "").strip().upper()
+        return team or "FA"
+
     def _median(vals, default_val):
         arr = sorted(v for v in vals if isinstance(v, (int, float)) and v > 0)
         if not arr:
@@ -6798,6 +6807,7 @@ async def run(progress_callback=None):
     _years_exp_tagged = 0
     _rookie_tagged = 0
     _age_tagged = 0
+    _team_tagged = 0
     for _name, _pdata in players_json.items():
         if not isinstance(_pdata, dict) or _looks_like_pick_name(_name):
             continue
@@ -6816,6 +6826,10 @@ async def run(progress_callback=None):
         if isinstance(_age, int):
             _pdata["age"] = _age
             _age_tagged += 1
+        _team = _player_team_local(_name, _pdata)
+        if isinstance(_team, str) and _team:
+            _pdata["team"] = _team
+            _team_tagged += 1
 
     # Final must-have rookie position enforcement. Do this after fallback creation and
     # rookie tagging so defensive prospects cannot drift back into generic offense entries.
@@ -6834,7 +6848,7 @@ async def run(progress_callback=None):
 
     if DEBUG:
         print(
-            f"  [Rookies] Tagged years_exp for {_years_exp_tagged} players; rookie-flagged {_rookie_tagged}; age tagged {_age_tagged}"
+            f"  [Rookies] Tagged years_exp for {_years_exp_tagged} players; rookie-flagged {_rookie_tagged}; age tagged {_age_tagged}; team tagged {_team_tagged}"
         )
 
     # Set _rawComposite and _finalAdjusted directly from _composite.
@@ -7135,7 +7149,7 @@ async def run(progress_callback=None):
 
     js_fname = os.path.join(SCRIPT_DIR, "dynasty_data.js")
     with open(js_fname, "w", encoding="utf-8") as f:
-        f.write("// Auto-generated by Dynasty Scraper — " f"{datetime.date.today()}\n")
+        f.write(f"// Auto-generated by Dynasty Scraper — {datetime.date.today()}\n")
         f.write("window.DYNASTY_DATA = ")
         json.dump(dashboard_json, f, indent=2, ensure_ascii=False)
         f.write(";\n")
@@ -7358,7 +7372,6 @@ def check_value_alerts(current_json):
         return
 
     # Get my roster players
-    my_team_name = ""  # Will be set from settings if available
     my_players = set()
     if SLEEPER_ROSTER_DATA and SLEEPER_ROSTER_DATA.get("teams"):
         # Use all rostered players for now (user picks team in dashboard)

--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -6804,6 +6804,26 @@ async def run(progress_callback=None):
         )
 
     # Persist rookie visibility metadata for dashboard filtering/debugging.
+    #
+    # NFL-team stamps get a LAST-GOOD fallback (Codex round 6 on
+    # PR #535): when the Sleeper /players/nfl fetch fails,
+    # SLEEPER_ALL_NFL is empty and every live lookup returns None —
+    # without a fallback the fresh export would publish team-less rows
+    # and empty every NFL-team filter until the next successful fetch.
+    # After a healthy pass we persist the name→team map; on an outage
+    # pass we stamp from the saved map instead.
+    _team_map_path = os.path.join("data", "player_map", "team_map_last_good.json")
+    _team_map_fallback: dict = {}
+    if not SLEEPER_ALL_NFL:
+        try:
+            with open(_team_map_path, "r", encoding="utf-8") as _fh:
+                _team_map_fallback = json.load(_fh).get("teams", {})
+            print(
+                f"  [Teams] Sleeper player DB unavailable — using last-good "
+                f"team map ({len(_team_map_fallback)} entries)"
+            )
+        except Exception:
+            _team_map_fallback = {}
     _years_exp_tagged = 0
     _rookie_tagged = 0
     _age_tagged = 0
@@ -6826,10 +6846,29 @@ async def run(progress_callback=None):
         if isinstance(_age, int):
             _pdata["age"] = _age
             _age_tagged += 1
-        _team = _player_team_local(_name, _pdata)
+        _team = _player_team_local(_name, _pdata) or _team_map_fallback.get(_name)
         if isinstance(_team, str) and _team:
             _pdata["team"] = _team
             _team_tagged += 1
+    # Save the last-good map only from a HEALTHY player-DB pass (an
+    # outage pass would just re-save the fallback it loaded).
+    if SLEEPER_ALL_NFL and _team_tagged:
+        try:
+            os.makedirs(os.path.dirname(_team_map_path), exist_ok=True)
+            with open(_team_map_path, "w", encoding="utf-8") as _fh:
+                json.dump(
+                    {
+                        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                        "teams": {
+                            n: d["team"]
+                            for n, d in players_json.items()
+                            if isinstance(d, dict) and isinstance(d.get("team"), str)
+                        },
+                    },
+                    _fh,
+                )
+        except Exception as _exc:
+            print(f"  [Teams] last-good team map save failed (non-fatal): {_exc}")
 
     # Final must-have rookie position enforcement. Do this after fallback creation and
     # rookie tagging so defensive prospects cannot drift back into generic offense entries.

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -129,6 +129,22 @@ describe("resolveOwnerTeam — real buildTeamByPlayer shape", () => {
   it("still accepts the plain-object fixture shape", () => {
     expect(resolveOwnerTeam(row(), { "test player": "Brisket Bros" })).toBe("Brisket Bros");
   });
+
+  it("a definitive ID miss does NOT fall back to the name twin", () => {
+    // Offense/IDP same-display-name collision: the unrostered twin
+    // carries a different playerId; the populated byId index missing
+    // it is definitive — no name fallback (Codex round 2 on #535).
+    const unrosteredTwin = row({ name: "Test Player", playerId: "7777" });
+    expect(resolveOwnerTeam(unrosteredTwin, index)).toBe(null);
+    expect(rowMatches(unrosteredTwin, { ownerTeam: FREE_AGENT_OWNER }, { teamByPlayer: index })).toBe(true);
+  });
+
+  it("name fallback still applies when the index has no ids", () => {
+    const nameOnlyIndex = buildTeamByPlayer([
+      { name: "Brisket Bros", ownerId: "u1", players: ["Test Player"], playerIds: [] },
+    ]);
+    expect(resolveOwnerTeam(row({ playerId: "7777" }), nameOnlyIndex)).toBe("Brisket Bros");
+  });
 });
 
 describe("matchesQuery — token grammar", () => {

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -1,0 +1,143 @@
+/**
+ * player-filters.js — Phase 3 filter-engine tests.
+ *
+ * Pure-predicate coverage: every criterion alone, fail-closed
+ * semantics for unknown fields under range filters, owner mapping via
+ * the league-scoped teamByPlayer join, and the token search grammar.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  EXPERIENCE_BUCKETS,
+  FREE_AGENT_OWNER,
+  filterRows,
+  matchesQuery,
+  rowMatches,
+  teamOptions,
+} from "../lib/player-filters.js";
+
+const row = (over = {}) => ({
+  name: "Test Player",
+  pos: "WR",
+  team: "CHI",
+  age: 25,
+  yearsExp: 3,
+  rookie: false,
+  canonicalConsensusRank: 40,
+  rankDerivedValue: 5000,
+  canonicalTierId: 3,
+  marketGapDirection: "none",
+  ...over,
+});
+
+describe("rowMatches — individual criteria", () => {
+  it("empty criteria matches everything", () => {
+    expect(rowMatches(row(), {})).toBe(true);
+  });
+
+  it("positions set", () => {
+    expect(rowMatches(row(), { positions: new Set(["WR"]) })).toBe(true);
+    expect(rowMatches(row(), { positions: new Set(["QB"]) })).toBe(false);
+  });
+
+  it("age range is inclusive and fails closed on unknown age", () => {
+    expect(rowMatches(row(), { ageMin: 25, ageMax: 25 })).toBe(true);
+    expect(rowMatches(row({ age: null }), { ageMin: 20 })).toBe(false);
+    expect(rowMatches(row(), { ageMax: 24 })).toBe(false);
+  });
+
+  it("experience buckets map yearsExp", () => {
+    expect(rowMatches(row({ yearsExp: 0 }), { experience: "rookie" })).toBe(true);
+    expect(rowMatches(row({ yearsExp: 1 }), { experience: "sophomore" })).toBe(true);
+    expect(rowMatches(row({ yearsExp: 7 }), { experience: "vet" })).toBe(true);
+    expect(rowMatches(row({ yearsExp: 0 }), { experience: "vet" })).toBe(false);
+    // unknown experience fails closed under an experience filter
+    expect(rowMatches(row({ yearsExp: null }), { experience: "vet" })).toBe(false);
+  });
+
+  it("nfl team incl. FA", () => {
+    expect(rowMatches(row(), { nflTeam: "chi" })).toBe(true);
+    expect(rowMatches(row({ team: "FA" }), { nflTeam: "FA" })).toBe(true);
+    expect(rowMatches(row({ team: null }), { nflTeam: "CHI" })).toBe(false);
+  });
+
+  it("owner filter uses the teamByPlayer join, FREE_AGENT_OWNER matches unmapped", () => {
+    const extras = { teamByPlayer: { "test player": "Brisket Bros" } };
+    expect(rowMatches(row(), { ownerTeam: "Brisket Bros" }, extras)).toBe(true);
+    expect(rowMatches(row(), { ownerTeam: "Other Team" }, extras)).toBe(false);
+    expect(rowMatches(row(), { ownerTeam: FREE_AGENT_OWNER }, extras)).toBe(false);
+    expect(rowMatches(row({ name: "Nobody Owns Me" }), { ownerTeam: FREE_AGENT_OWNER }, extras)).toBe(true);
+  });
+
+  it("rank / value ranges and tier", () => {
+    expect(rowMatches(row(), { rankMin: 1, rankMax: 40 })).toBe(true);
+    expect(rowMatches(row(), { rankMax: 39 })).toBe(false);
+    expect(rowMatches(row({ canonicalConsensusRank: null }), { rankMax: 100 })).toBe(false);
+    expect(rowMatches(row(), { valueMin: 5000 })).toBe(true);
+    expect(rowMatches(row(), { valueMin: 5001 })).toBe(false);
+    expect(rowMatches(row(), { tier: 3 })).toBe(true);
+    expect(rowMatches(row(), { tier: 2 })).toBe(false);
+  });
+
+  it("edge direction maps buy/sell to marketGapDirection", () => {
+    expect(rowMatches(row({ marketGapDirection: "consensus_higher" }), { edge: "buy" })).toBe(true);
+    expect(rowMatches(row({ marketGapDirection: "market_higher" }), { edge: "sell" })).toBe(true);
+    expect(rowMatches(row(), { edge: "buy" })).toBe(false);
+  });
+
+  it("rookieOnly and watchlist", () => {
+    expect(rowMatches(row({ rookie: true }), { rookieOnly: true })).toBe(true);
+    expect(rowMatches(row(), { rookieOnly: true })).toBe(false);
+    expect(rowMatches(row(), { watchlist: new Set(["test player"]) })).toBe(true);
+    expect(rowMatches(row(), { watchlist: new Set(["someone else"]) })).toBe(false);
+  });
+});
+
+describe("matchesQuery — token grammar", () => {
+  it("all tokens must match across name/team/pos/owner", () => {
+    expect(matchesQuery(row(), "test")).toBe(true);
+    expect(matchesQuery(row(), "wr chi")).toBe(true);
+    expect(matchesQuery(row(), "qb chi")).toBe(false);
+  });
+
+  it("explicit prefixes", () => {
+    const extras = { teamByPlayer: { "test player": "Brisket Bros" } };
+    expect(matchesQuery(row(), "owner:brisket", extras)).toBe(true);
+    expect(matchesQuery(row(), "owner:nope", extras)).toBe(false);
+    expect(matchesQuery(row(), "team:chi pos:wr")).toBe(true);
+    expect(matchesQuery(row(), "pos:qb")).toBe(false);
+  });
+
+  it("empty query matches", () => {
+    expect(matchesQuery(row(), "")).toBe(true);
+  });
+});
+
+describe("filterRows + teamOptions", () => {
+  it("no active criteria returns the same array reference", () => {
+    const rows = [row()];
+    expect(filterRows(rows, {})).toBe(rows);
+  });
+
+  it("combined criteria conjunct", () => {
+    const rows = [
+      row({ name: "A", pos: "WR", age: 22, yearsExp: 1 }),
+      row({ name: "B", pos: "WR", age: 29, yearsExp: 7 }),
+      row({ name: "C", pos: "QB", age: 22, yearsExp: 1 }),
+    ];
+    const out = filterRows(rows, { positions: new Set(["WR"]), ageMax: 25 });
+    expect(out.map((r) => r.name)).toEqual(["A"]);
+  });
+
+  it("teamOptions sorts FA last and drops unknowns", () => {
+    const rows = [row({ team: "GB" }), row({ team: "FA" }), row({ team: "ARI" }), row({ team: null })];
+    expect(teamOptions(rows)).toEqual(["ARI", "GB", "FA"]);
+  });
+
+  it("EXPERIENCE_BUCKETS covers 0/1/2+ exhaustively", () => {
+    for (const y of [0, 1, 2, 5, 15]) {
+      const matches = EXPERIENCE_BUCKETS.filter((b) => b.match(y));
+      expect(matches.length).toBe(1);
+    }
+  });
+});

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -188,6 +188,28 @@ describe("filterRows + teamOptions", () => {
     expect(teamOptions(rows)).toEqual(["ARI", "GB", "FA"]);
   });
 
+  it("legacy materializer combines both rookie signals", async () => {
+    // _isRookie (scraper zero-exp flag) alone must mark the row
+    // rookie on the view=app legacy path (Codex round 4 on #535).
+    const { buildRows } = await import("../lib/dynasty-data.js");
+    const data = {
+      players: {
+        "Rookie Only IsRookie": {
+          _canonicalConsensusRank: 5,
+          _canonicalSiteValues: { ktc: 5000 },
+          rankDerivedValue: 5000,
+          sourceRanks: { ktc: 5 },
+          _isRookie: true,
+        },
+      },
+      sleeper: { positions: { "Rookie Only IsRookie": "WR" } },
+    };
+    const rows = buildRows(data);
+    const r = rows.find((x) => x.name === "Rookie Only IsRookie");
+    expect(r.rookie).toBe(true);
+    expect(rowMatches(r, { rookieOnly: true })).toBe(true);
+  });
+
   it("EXPERIENCE_BUCKETS covers 0/1/2+ exhaustively", () => {
     for (const y of [0, 1, 2, 5, 15]) {
       const matches = EXPERIENCE_BUCKETS.filter((b) => b.match(y));

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -188,6 +188,31 @@ describe("filterRows + teamOptions", () => {
     expect(teamOptions(rows)).toEqual(["ARI", "GB", "FA"]);
   });
 
+  it("legacy rows resolve ownership by materialized playerId", async () => {
+    // The default view=app path materializes legacy rows; playerId
+    // must come through from _sleeperId so ID-first resolution works
+    // there too (Codex round 5 on #535).
+    const { buildRows } = await import("../lib/dynasty-data.js");
+    const data = {
+      players: {
+        "Test Player": {
+          _canonicalConsensusRank: 5,
+          _canonicalSiteValues: { ktc: 5000 },
+          rankDerivedValue: 5000,
+          sourceRanks: { ktc: 5 },
+          _sleeperId: "1234",
+        },
+      },
+      sleeper: { positions: { "Test Player": "WR" } },
+    };
+    const legacyRow = buildRows(data).find((x) => x.name === "Test Player");
+    expect(legacyRow.playerId).toBe("1234");
+    const teams = [
+      { name: "Brisket Bros", ownerId: "u1", players: [], playerIds: ["1234"] },
+    ];
+    expect(resolveOwnerTeam(legacyRow, buildTeamByPlayer(teams))).toBe("Brisket Bros");
+  });
+
   it("legacy materializer combines both rookie signals", async () => {
     // _isRookie (scraper zero-exp flag) alone must mark the row
     // rookie on the view=app legacy path (Codex round 4 on #535).

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -81,9 +81,13 @@ describe("rowMatches — individual criteria", () => {
     expect(rowMatches(row(), { tier: 2 })).toBe(false);
   });
 
-  it("edge direction maps buy/sell to marketGapDirection", () => {
-    expect(rowMatches(row({ marketGapDirection: "consensus_higher" }), { edge: "buy" })).toBe(true);
-    expect(rowMatches(row({ marketGapDirection: "market_higher" }), { edge: "sell" })).toBe(true);
+  it("edge direction maps buy/sell to the contract's marketGapDirection enum", () => {
+    // Values must be the REAL _compute_market_gap enum — the round-9
+    // regression hid behind fixtures using an invented enum.
+    expect(rowMatches(row({ marketGapDirection: "consensus_premium" }), { edge: "buy" })).toBe(true);
+    expect(rowMatches(row({ marketGapDirection: "retail_premium" }), { edge: "sell" })).toBe(true);
+    expect(rowMatches(row({ marketGapDirection: "consensus_premium" }), { edge: "sell" })).toBe(false);
+    expect(rowMatches(row({ marketGapDirection: "retail_premium" }), { edge: "buy" })).toBe(false);
     expect(rowMatches(row(), { edge: "buy" })).toBe(false);
   });
 

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -12,9 +12,11 @@ import {
   FREE_AGENT_OWNER,
   filterRows,
   matchesQuery,
+  resolveOwnerTeam,
   rowMatches,
   teamOptions,
 } from "../lib/player-filters.js";
+import { buildTeamByPlayer } from "../lib/waiver-logic.js";
 
 const row = (over = {}) => ({
   name: "Test Player",
@@ -90,6 +92,42 @@ describe("rowMatches — individual criteria", () => {
     expect(rowMatches(row(), { rookieOnly: true })).toBe(false);
     expect(rowMatches(row(), { watchlist: new Set(["test player"]) })).toBe(true);
     expect(rowMatches(row(), { watchlist: new Set(["someone else"]) })).toBe(false);
+  });
+});
+
+describe("resolveOwnerTeam — real buildTeamByPlayer shape", () => {
+  // The REAL helper returns { byId: Map, byName: Map } with full team
+  // objects as values (waiver-logic.js) — Codex round 1 on PR #535
+  // caught the engine assuming a plain object. Pin the real shape.
+  const teams = [
+    { name: "Brisket Bros", ownerId: "u1", players: ["Test Player"], playerIds: ["1234"] },
+    { name: "Other Team", ownerId: "u2", players: ["Someone Else"], playerIds: ["5678"] },
+  ];
+  const index = buildTeamByPlayer(teams);
+
+  it("resolves by stable playerId first", () => {
+    expect(resolveOwnerTeam(row({ playerId: "1234", name: "Renamed Player" }), index)).toBe("Brisket Bros");
+  });
+
+  it("falls back to normalized name when the row has no id", () => {
+    expect(resolveOwnerTeam(row({ playerId: null }), index)).toBe("Brisket Bros");
+  });
+
+  it("returns null for unrostered players (FREE_AGENT_OWNER works)", () => {
+    const fa = row({ name: "Nobody Owns Me", playerId: "9999" });
+    expect(resolveOwnerTeam(fa, index)).toBe(null);
+    expect(rowMatches(fa, { ownerTeam: FREE_AGENT_OWNER }, { teamByPlayer: index })).toBe(true);
+  });
+
+  it("owner filter + owner: query work end-to-end with the real index", () => {
+    const extras = { teamByPlayer: index };
+    expect(rowMatches(row({ playerId: "1234" }), { ownerTeam: "Brisket Bros" }, extras)).toBe(true);
+    expect(rowMatches(row({ playerId: "1234" }), { ownerTeam: "Other Team" }, extras)).toBe(false);
+    expect(matchesQuery(row({ playerId: "1234" }), "owner:brisket", extras)).toBe(true);
+  });
+
+  it("still accepts the plain-object fixture shape", () => {
+    expect(resolveOwnerTeam(row(), { "test player": "Brisket Bros" })).toBe("Brisket Bros");
   });
 });
 

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -113,6 +113,14 @@ describe("resolveOwnerTeam — real buildTeamByPlayer shape", () => {
     expect(resolveOwnerTeam(row({ playerId: null }), index)).toBe("Brisket Bros");
   });
 
+  it("draft picks are excluded from owner filtering entirely", () => {
+    // Pick ownership lives outside buildTeamByPlayer's index; a null
+    // owner must not classify owned picks as free agents (round 6).
+    const pick = row({ name: "2027 Pick 1.01", pos: "PICK", assetClass: "pick", playerId: null });
+    expect(rowMatches(pick, { ownerTeam: FREE_AGENT_OWNER }, { teamByPlayer: index })).toBe(false);
+    expect(rowMatches(pick, { ownerTeam: "Brisket Bros" }, { teamByPlayer: index })).toBe(false);
+  });
+
   it("returns null for unrostered players (FREE_AGENT_OWNER works)", () => {
     const fa = row({ name: "Nobody Owns Me", playerId: "9999" });
     expect(resolveOwnerTeam(fa, index)).toBe(null);

--- a/frontend/__tests__/player-filters.test.js
+++ b/frontend/__tests__/player-filters.test.js
@@ -221,6 +221,34 @@ describe("filterRows + teamOptions", () => {
     expect(resolveOwnerTeam(legacyRow, buildTeamByPlayer(teams))).toBe("Brisket Bros");
   });
 
+  it("contract playersArray rows resolve ownership by playerId", async () => {
+    // Backend playersArray rows (and mergeRankingsDelta-synthesized
+    // rows) carry the Sleeper id as ``playerId``, not ``_sleeperId`` —
+    // the array materializer must read it or every contract-path row
+    // loses ID-first ownership resolution (Codex round 7 on #535).
+    const { buildRows } = await import("../lib/dynasty-data.js");
+    const data = {
+      playersArray: [
+        {
+          displayName: "Test Player",
+          position: "WR",
+          canonicalConsensusRank: 5,
+          rankDerivedValue: 5000,
+          sourceRanks: { ktc: 5 },
+          sourceCount: 1,
+          canonicalSiteValues: { ktc: 5000 },
+          playerId: "1234",
+        },
+      ],
+    };
+    const arrayRow = buildRows(data).find((x) => x.name === "Test Player");
+    expect(arrayRow.playerId).toBe("1234");
+    const teams = [
+      { name: "Brisket Bros", ownerId: "u1", players: [], playerIds: ["1234"] },
+    ];
+    expect(resolveOwnerTeam(arrayRow, buildTeamByPlayer(teams))).toBe("Brisket Bros");
+  });
+
   it("legacy materializer combines both rookie signals", async () => {
     // _isRookie (scraper zero-exp flag) alone must mark the row
     // rookie on the view=app legacy path (Codex round 4 on #535).

--- a/frontend/__tests__/site-overrides.test.js
+++ b/frontend/__tests__/site-overrides.test.js
@@ -433,6 +433,8 @@ describe("mergeRankingsDelta — runtime-view base (no playersArray)", () => {
             _canonicalConsensusRank: 1,
             _canonicalSiteValues: { ktc: 9999, idpTradeCalc: 9800 },
             sourceNativeValues: { fantasyCalc: 10208 },
+            _sleeperId: "4984",
+            _yearsExp: 8,
             rankDerivedValue: 9800,
             sourceRanks: { ktc: 1, idpTradeCalc: 1 },
             sourceRankMeta: {
@@ -506,6 +508,19 @@ describe("mergeRankingsDelta — runtime-view base (no playersArray)", () => {
       },
     };
   }
+
+  it("carries playerId + yearsExp through synthesis (Codex round 3)", () => {
+    // Without these copies, override mode breaks ID-first ownership
+    // resolution (name-twin contamination) and the fail-closed
+    // experience filters return an empty board.
+    const merged = mergeRankingsDelta(runtimeBaseContract(), deltaKtcOff());
+    const row = merged.data.playersArray.find((r) => r.displayName === "Player A");
+    expect(row.playerId).toBe("4984");
+    expect(row.yearsExp).toBe(8);
+    const rows = buildRows(merged.data);
+    const a = rows.find((r) => r.name === "Player A");
+    expect(a.yearsExp).toBe(8);
+  });
 
   it("carries override-invariant sourceNativeValues from the legacy dict", () => {
     // The delta deliberately omits native values (they never change

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -30,6 +30,13 @@ import {
   marketAction,
   isEligibleForBoard,
 } from "@/lib/display-helpers";
+import {
+  EXPERIENCE_BUCKETS,
+  FREE_AGENT_OWNER,
+  rowMatches,
+  teamOptions,
+} from "@/lib/player-filters";
+import { buildTeamByPlayer } from "@/lib/waiver-logic";
 import HillCurveExplorer from "@/components/graphs/HillCurveExplorer";
 import TierGapWaterfall from "@/components/graphs/TierGapWaterfall";
 import SourceContributionBars from "@/components/graphs/SourceContributionBars";
@@ -532,6 +539,20 @@ export default function RankingsPage() {
   const [copyStatus, setCopyStatus] = useState("");
   const [showMethodology, setShowMethodology] = useState(false);
   const [expandedRow, setExpandedRow] = useState(null);
+  // Advanced filter rail (Phase 3).  ``adv`` holds raw control values
+  // (strings from inputs); the criteria object handed to rowMatches is
+  // derived in ``advCriteria`` below.
+  const [advOpen, setAdvOpen] = useState(false);
+  const [adv, setAdv] = useState({});
+  const setAdvField = useCallback((key, value) => {
+    setAdv((prev) => {
+      const next = { ...prev };
+      if (value === "" || value === false || value == null) delete next[key];
+      else next[key] = value;
+      return next;
+    });
+  }, []);
+  const clearAdv = useCallback(() => setAdv({}), []);
 
 
   const handleSort = useCallback((col) => {
@@ -639,9 +660,49 @@ export default function RankingsPage() {
   // ── Edge summary ─────────────────────────────────────────────────
   const edgeSummary = useMemo(() => computeEdgeSummary(eligible), [eligible]);
 
+  // ── Advanced filters (Phase 3) ──────────────────────────────────
+  // Ownership is league-scoped while rows are scoring-profile-scoped
+  // (the CLAUDE.md split), so the owner join happens here at render
+  // time via buildTeamByPlayer — never stamped into the contract.
+  const teamByPlayer = useMemo(
+    () => buildTeamByPlayer(rawData?.sleeper?.teams || []),
+    [rawData?.sleeper?.teams],
+  );
+  const ownerOptions = useMemo(
+    () =>
+      (rawData?.sleeper?.teams || [])
+        .map((t) => String(t?.name || "").trim())
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b)),
+    [rawData?.sleeper?.teams],
+  );
+  const nflTeamOptions = useMemo(() => teamOptions(eligible), [eligible]);
+  const advCriteria = useMemo(() => {
+    const c = {};
+    const numOrNull = (v) => {
+      if (v === "" || v == null) return null;
+      const n = Number(v);
+      return Number.isFinite(n) ? n : null;
+    };
+    if (numOrNull(adv.ageMin) != null) c.ageMin = numOrNull(adv.ageMin);
+    if (numOrNull(adv.ageMax) != null) c.ageMax = numOrNull(adv.ageMax);
+    if (adv.experience) c.experience = adv.experience;
+    if (adv.nflTeam) c.nflTeam = adv.nflTeam;
+    if (adv.ownerTeam) c.ownerTeam = adv.ownerTeam;
+    if (numOrNull(adv.rankMin) != null) c.rankMin = numOrNull(adv.rankMin);
+    if (numOrNull(adv.rankMax) != null) c.rankMax = numOrNull(adv.rankMax);
+    if (numOrNull(adv.valueMin) != null) c.valueMin = numOrNull(adv.valueMin);
+    if (numOrNull(adv.valueMax) != null) c.valueMax = numOrNull(adv.valueMax);
+    if (adv.edge) c.edge = adv.edge;
+    if (adv.rookieOnly) c.rookieOnly = true;
+    if (adv.watchlistOnly) c.watchlist = watchlistLower;
+    return c;
+  }, [adv, watchlistLower]);
+  const advActiveCount = Object.keys(advCriteria).length;
+
   // ── Filtered + sorted list ──────────────────────────────────────
   const ranked = useMemo(() => {
-    const q = query.trim().toLowerCase();
+    const q = query.trim();
 
     // Start with lens-filtered list
     let list = applyLens(eligible, activeLens);
@@ -656,8 +717,11 @@ export default function RankingsPage() {
         return r.confidenceBucket === confFilter;
       });
     }
-    if (q) {
-      list = list.filter((r) => r.name.toLowerCase().includes(q));
+    // Token search (name / NFL team / pos / owner, with owner:/team:/
+    // pos: prefixes) + the advanced criteria, one predicate pass.
+    if (q || advActiveCount > 0) {
+      const criteria = q ? { ...advCriteria, query: q } : advCriteria;
+      list = list.filter((r) => rowMatches(r, criteria, { teamByPlayer }));
     }
 
     // If lens provides its own sort and user hasn't overridden, use it
@@ -739,10 +803,11 @@ export default function RankingsPage() {
       }
     });
     return sorted;
-  }, [eligible, activeLens, posFilter, confFilter, query, sortCol, sortAsc]);
+  }, [eligible, activeLens, posFilter, confFilter, query, sortCol, sortAsc, advCriteria, advActiveCount, teamByPlayer]);
 
   // Apply row limit — search/filter bypasses the limit
-  const hasActiveFilter = query || posFilter !== "all" || confFilter !== "all" || activeLens !== "consensus";
+  const hasActiveFilter =
+    query || posFilter !== "all" || confFilter !== "all" || activeLens !== "consensus" || advActiveCount > 0;
   const displayRows = hasActiveFilter ? ranked : ranked.slice(0, rowLimit);
   const hasMore = !hasActiveFilter && ranked.length > rowLimit;
 
@@ -1293,7 +1358,7 @@ export default function RankingsPage() {
           <div className="filter-bar">
             <input
               className="input"
-              placeholder="Search player..."
+              placeholder="Search — name, team, pos, owner: team: pos:"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               style={{ flex: 1, minWidth: 140 }}
@@ -1336,7 +1401,162 @@ export default function RankingsPage() {
             >
               Tiers
             </button>
+            <button
+              className={`button ${advActiveCount > 0 ? "button-primary" : ""}`}
+              onClick={() => setAdvOpen((v) => !v)}
+              title="Advanced filters: age, experience, NFL team, owner, rank/value range, edge, watchlist"
+              aria-expanded={advOpen}
+            >
+              Filters{advActiveCount > 0 ? ` (${advActiveCount})` : ""}
+            </button>
           </div>
+
+          {/* Advanced filter rail (Phase 3) — every criterion routes
+              through lib/player-filters.js rowMatches; owner filtering
+              joins league rosters at render time via buildTeamByPlayer
+              (rows are scoring-profile-scoped; owners are league-scoped). */}
+          {advOpen && (
+            <div
+              className="filter-bar"
+              style={{ marginTop: 6, alignItems: "center", rowGap: 6 }}
+            >
+              <label className="muted text-xs" style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                Age
+                <input
+                  className="input"
+                  type="number"
+                  min="18"
+                  max="45"
+                  placeholder="min"
+                  value={adv.ageMin ?? ""}
+                  onChange={(e) => setAdvField("ageMin", e.target.value)}
+                  style={{ width: 62 }}
+                />
+                –
+                <input
+                  className="input"
+                  type="number"
+                  min="18"
+                  max="45"
+                  placeholder="max"
+                  value={adv.ageMax ?? ""}
+                  onChange={(e) => setAdvField("ageMax", e.target.value)}
+                  style={{ width: 62 }}
+                />
+              </label>
+              <select
+                className="select"
+                value={adv.experience ?? ""}
+                onChange={(e) => setAdvField("experience", e.target.value)}
+                title="Experience"
+              >
+                <option value="">Any experience</option>
+                {EXPERIENCE_BUCKETS.map((b) => (
+                  <option key={b.key} value={b.key}>{b.label}</option>
+                ))}
+              </select>
+              <select
+                className="select"
+                value={adv.nflTeam ?? ""}
+                onChange={(e) => setAdvField("nflTeam", e.target.value)}
+                title="NFL team"
+              >
+                <option value="">Any NFL team</option>
+                {nflTeamOptions.map((t) => (
+                  <option key={t} value={t}>{t === "FA" ? "Free agent (NFL)" : t}</option>
+                ))}
+              </select>
+              {ownerOptions.length > 0 && (
+                <select
+                  className="select"
+                  value={adv.ownerTeam ?? ""}
+                  onChange={(e) => setAdvField("ownerTeam", e.target.value)}
+                  title="Fantasy owner"
+                >
+                  <option value="">Any owner</option>
+                  <option value={FREE_AGENT_OWNER}>Unrostered</option>
+                  {ownerOptions.map((t) => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              )}
+              <label className="muted text-xs" style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                Rank
+                <input
+                  className="input"
+                  type="number"
+                  min="1"
+                  placeholder="min"
+                  value={adv.rankMin ?? ""}
+                  onChange={(e) => setAdvField("rankMin", e.target.value)}
+                  style={{ width: 62 }}
+                />
+                –
+                <input
+                  className="input"
+                  type="number"
+                  min="1"
+                  placeholder="max"
+                  value={adv.rankMax ?? ""}
+                  onChange={(e) => setAdvField("rankMax", e.target.value)}
+                  style={{ width: 62 }}
+                />
+              </label>
+              <label className="muted text-xs" style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                Value
+                <input
+                  className="input"
+                  type="number"
+                  min="0"
+                  placeholder="min"
+                  value={adv.valueMin ?? ""}
+                  onChange={(e) => setAdvField("valueMin", e.target.value)}
+                  style={{ width: 72 }}
+                />
+                –
+                <input
+                  className="input"
+                  type="number"
+                  min="0"
+                  placeholder="max"
+                  value={adv.valueMax ?? ""}
+                  onChange={(e) => setAdvField("valueMax", e.target.value)}
+                  style={{ width: 72 }}
+                />
+              </label>
+              <select
+                className="select"
+                value={adv.edge ?? ""}
+                onChange={(e) => setAdvField("edge", e.target.value)}
+                title="Market edge direction"
+              >
+                <option value="">Any edge</option>
+                <option value="buy">Buy edge</option>
+                <option value="sell">Sell edge</option>
+              </select>
+              <label className="muted text-xs" style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={!!adv.rookieOnly}
+                  onChange={(e) => setAdvField("rookieOnly", e.target.checked)}
+                />
+                Rookies
+              </label>
+              <label className="muted text-xs" style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={!!adv.watchlistOnly}
+                  onChange={(e) => setAdvField("watchlistOnly", e.target.checked)}
+                />
+                Watchlist
+              </label>
+              {advActiveCount > 0 && (
+                <button className="button" onClick={clearAdv} title="Clear advanced filters">
+                  Clear
+                </button>
+              )}
+            </div>
+          )}
 
           <p className="muted text-xs" style={{ margin: "6px 0 0" }}>
             {displayRows.length.toLocaleString()}{hasMore ? ` of ${ranked.length.toLocaleString()}` : ""} shown

--- a/frontend/components/AppShell.jsx
+++ b/frontend/components/AppShell.jsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useDynastyData } from "@/components/useDynastyData";
+import { buildTeamByPlayer } from "@/lib/waiver-logic";
 import PlayerPopup from "@/components/PlayerPopup";
 import GlobalSearch from "@/components/GlobalSearch";
 
@@ -155,6 +156,14 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
     setSearchOpen(true);
   }, [searchEnabled]);
 
+  // League-scoped ownership index for GlobalSearch's owner: tokens.
+  // Rows are scoring-profile-scoped and never carry the owner; the
+  // join happens here at render time (CLAUDE.md split).
+  const teamByPlayer = useMemo(
+    () => buildTeamByPlayer(rawData?.sleeper?.teams || []),
+    [rawData?.sleeper?.teams],
+  );
+
   // Global "/" keyboard shortcut for search
   useEffect(() => {
     if (!searchEnabled) return undefined;
@@ -198,6 +207,7 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
       {searchEnabled && (
         <GlobalSearch
           rows={rows}
+          teamByPlayer={teamByPlayer}
           isOpen={searchOpen}
           onClose={() => setSearchOpen(false)}
           onSelect={(row) => openPlayerPopup(row)}

--- a/frontend/components/GlobalSearch.jsx
+++ b/frontend/components/GlobalSearch.jsx
@@ -2,18 +2,20 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { resolvedRank } from "@/lib/dynasty-data";
+import { matchesQuery } from "@/lib/player-filters";
 
 /**
  * Global search overlay — keyboard-first player/pick finder.
  * Triggered by "/" shortcut or search icon in nav.
  *
  * Props:
- *   rows       — All player rows from buildRows()
- *   isOpen     — Whether the search overlay is visible
- *   onClose    — Callback to close
- *   onSelect   — Callback when a player is selected: (row) => void
+ *   rows         — All player rows from buildRows()
+ *   isOpen       — Whether the search overlay is visible
+ *   onClose      — Callback to close
+ *   onSelect     — Callback when a player is selected: (row) => void
+ *   teamByPlayer — optional buildTeamByPlayer index for owner: tokens
  */
-export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect }) {
+export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect, teamByPlayer = null }) {
   const [query, setQuery] = useState("");
   const [selectedIdx, setSelectedIdx] = useState(0);
   const inputRef = useRef(null);
@@ -29,12 +31,26 @@ export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect }) {
     }
   }, [isOpen]);
 
-  // Filter results
-  const results = query.trim().length > 0
-    ? rows
-        .filter((r) => r.name.toLowerCase().includes(query.trim().toLowerCase()))
-        .slice(0, 30)
-    : [];
+  // Filter results — token search over name / NFL team / pos / owner
+  // (lib/player-filters.js grammar: "wr chi", "owner:jason rb").  Name
+  // matches rank first (prefix, then substring) so typing a player
+  // name never buries them under position/team matches; within each
+  // tier the incoming rank order is preserved.
+  const q = query.trim();
+  let results = [];
+  if (q.length > 0) {
+    const extras = { teamByPlayer };
+    const ql = q.toLowerCase();
+    const matched = [];
+    for (const r of rows) {
+      if (!matchesQuery(r, q, extras)) continue;
+      const name = String(r.name || "").toLowerCase();
+      const tier = name.startsWith(ql) ? 0 : name.includes(ql) ? 1 : 2;
+      matched.push([tier, matched.length, r]);
+    }
+    matched.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+    results = matched.slice(0, 30).map((m) => m[2]);
+  }
 
   // Keyboard navigation
   const onKeyDown = useCallback(
@@ -93,7 +109,7 @@ export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect }) {
             ref={inputRef}
             className="input global-search-input"
             type="text"
-            placeholder="Search players and picks..."
+            placeholder="Search — name, team, pos, owner:"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onKeyDown}
@@ -156,6 +172,10 @@ export default function GlobalSearch({ rows = [], isOpen, onClose, onSelect }) {
         {query.trim().length === 0 && (
           <div className="muted" style={{ padding: "16px 0", textAlign: "center", fontSize: "0.78rem" }}>
             Start typing to search players and picks.
+            <br />
+            <span style={{ fontSize: "0.7rem" }}>
+              Try <code>wr chi</code>, <code>owner:jason rb</code>, <code>pos:te team:kc</code>
+            </span>
             <br />
             <span style={{ fontSize: "0.7rem" }}>
               Use <kbd style={{ padding: "1px 4px", border: "1px solid var(--border)", borderRadius: 3 }}>&uarr;</kbd>{" "}

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1109,6 +1109,10 @@ function _materializePlayerArrayRow(player) {
     // to sourceOriginalRanks; keep both materializers in lockstep).
     sourceNativeValues: player.sourceNativeValues && typeof player.sourceNativeValues === "object"
       ? player.sourceNativeValues : {},
+    // NFL years of experience (0 = rookie) — drives the experience
+    // filter; null when the Sleeper blob never matched this player.
+    yearsExp: Number.isFinite(Number(player.yearsExp)) && player.yearsExp !== null
+      ? Number(player.yearsExp) : (Number.isFinite(Number(player._yearsExp)) && player._yearsExp !== null ? Number(player._yearsExp) : null),
     identityConfidence: Number(player.identityConfidence ?? 0.7),
     identityMethod: String(player.identityMethod || "name_only"),
     quarantined: Boolean(player.quarantined),
@@ -1194,6 +1198,10 @@ function _materializeLegacyDictRow(name, player, posMap) {
     // to sourceOriginalRanks; keep both materializers in lockstep).
     sourceNativeValues: player.sourceNativeValues && typeof player.sourceNativeValues === "object"
       ? player.sourceNativeValues : {},
+    // NFL years of experience (0 = rookie) — drives the experience
+    // filter; null when the Sleeper blob never matched this player.
+    yearsExp: Number.isFinite(Number(player.yearsExp)) && player.yearsExp !== null
+      ? Number(player.yearsExp) : (Number.isFinite(Number(player._yearsExp)) && player._yearsExp !== null ? Number(player._yearsExp) : null),
     identityConfidence: Number(player.identityConfidence ?? 0.7),
     identityMethod: String(player.identityMethod || "name_only"),
     quarantined: Boolean(player.quarantined),

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1158,7 +1158,13 @@ function _materializeLegacyDictRow(name, player, posMap) {
     pos: pos || "?",
     team: String(player.team || ""),
     age: Number(player.age) || null,
-    rookie: Boolean(player._formatFitRookie),
+    // Combine BOTH upstream rookie signals like the contract row
+    // builder does (_formatFitRookie = format-fit pass, _isRookie =
+    // scraper's zero-experience flag) — the live export has rookies
+    // carrying only _isRookie, so reading one signal alone made
+    // rookie filters exclude every actual rookie on the view=app
+    // path (Codex round 4 on PR #535).
+    rookie: Boolean(player._formatFitRookie || player._isRookie || player.rookie),
     assetClass: classifyPos(pos || "?"),
     values,
     siteCount: Number(player.sourceCount || player._sites || 0),
@@ -1520,7 +1526,7 @@ export function mergeRankingsDelta(baseContract, delta) {
         // experience filters return an empty board whenever a source
         // override is active (fail-closed predicate over null).
         yearsExp: legacy._yearsExp != null ? legacy._yearsExp : null,
-        rookie: Boolean(legacy._formatFitRookie || legacy.rookie),
+        rookie: Boolean(legacy._formatFitRookie || legacy._isRookie || legacy.rookie),
         assetClass: String(legacy.assetClass || ""),
         identityConfidence: Number(legacy.identityConfidence ?? 0.7),
         identityMethod: String(legacy.identityMethod || "name_only"),

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1012,12 +1012,13 @@ function _materializePlayerArrayRow(player) {
 
   return {
     name,
-    // Stable Sleeper id, materialized so ID-first ownership
-    // resolution works on the DEFAULT view=app path too — the legacy
-    // dict carries it as _sleeperId only (Codex round 5 on PR #535;
-    // keep in lockstep with the playersArray materializer + override
+    // Stable Sleeper id for ID-first ownership resolution.  Backend
+    // playersArray rows and mergeRankingsDelta-synthesized rows carry
+    // it as ``playerId``; ``_sleeperId`` covers any legacy-shaped row
+    // routed through this materializer (Codex rounds 5+7 on PR #535;
+    // keep in lockstep with the legacy materializer + override
     // synthesis).
-    playerId: String(player._sleeperId || "").trim() || null,
+    playerId: String(player.playerId || player._sleeperId || "").trim() || null,
     pos: pos || "?",
     team: String(player.team || ""),
     age: Number(player.age) || null,

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1505,11 +1505,21 @@ export function mergeRankingsDelta(baseContract, delta) {
       const row = {
         displayName: id,
         canonicalName: String(legacy.canonicalName || id),
+        // Stable Sleeper id — required by ID-first ownership
+        // resolution (player-filters resolveOwnerTeam); without it
+        // every override-synthesized row degrades to name lookup and
+        // offense/IDP name twins can inherit each other's owner
+        // (Codex round 3 on PR #535).
+        playerId: String(legacy._sleeperId || "").trim() || null,
         position: isPick
           ? "PICK"
           : String(posMap[id] || legacy.position || ""),
         team: legacy.team != null ? legacy.team : null,
         age: legacy.age != null ? legacy.age : null,
+        // Override-invariant like team/age: without this copy the
+        // experience filters return an empty board whenever a source
+        // override is active (fail-closed predicate over null).
+        yearsExp: legacy._yearsExp != null ? legacy._yearsExp : null,
         rookie: Boolean(legacy._formatFitRookie || legacy.rookie),
         assetClass: String(legacy.assetClass || ""),
         identityConfidence: Number(legacy.identityConfidence ?? 0.7),

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1012,6 +1012,12 @@ function _materializePlayerArrayRow(player) {
 
   return {
     name,
+    // Stable Sleeper id, materialized so ID-first ownership
+    // resolution works on the DEFAULT view=app path too — the legacy
+    // dict carries it as _sleeperId only (Codex round 5 on PR #535;
+    // keep in lockstep with the playersArray materializer + override
+    // synthesis).
+    playerId: String(player._sleeperId || "").trim() || null,
     pos: pos || "?",
     team: String(player.team || ""),
     age: Number(player.age) || null,
@@ -1155,6 +1161,12 @@ function _materializeLegacyDictRow(name, player, posMap) {
 
   return {
     name,
+    // Stable Sleeper id, materialized so ID-first ownership
+    // resolution works on the DEFAULT view=app path too — the legacy
+    // dict carries it as _sleeperId only (Codex round 5 on PR #535;
+    // keep in lockstep with the playersArray materializer + override
+    // synthesis).
+    playerId: String(player._sleeperId || "").trim() || null,
     pos: pos || "?",
     team: String(player.team || ""),
     age: Number(player.age) || null,

--- a/frontend/lib/player-filters.js
+++ b/frontend/lib/player-filters.js
@@ -7,10 +7,11 @@
 //     the redesign lands, the R2 terminal board) applies these
 //     client-side over ~1.1k rows, which is fast enough that no
 //     memoization layer is needed here.
-//   • Owner filtering takes an externally-built name→team map
-//     (buildTeamByPlayer from waiver-logic.js) because ownership is
-//     league-scoped while rows are scoring-profile-scoped — the
-//     CLAUDE.md split.  Rows never carry the owner.
+//   • Owner filtering takes buildTeamByPlayer's { byId, byName }
+//     index (waiver-logic.js) — or a plain name→teamName object —
+//     because ownership is league-scoped while rows are
+//     scoring-profile-scoped (the CLAUDE.md split).  Rows never
+//     carry the owner; see resolveOwnerTeam.
 //   • Every criterion is optional; an empty criteria object matches
 //     every row.  Unknown/null row fields fail closed for range
 //     filters (a player with unknown age is excluded by an age
@@ -38,6 +39,37 @@ function num(v) {
 
 function norm(s) {
   return String(s || "").trim().toLowerCase();
+}
+
+/**
+ * Resolve a row's fantasy-owner TEAM NAME from whichever ownership
+ * shape the caller supplied:
+ *   • waiver-logic's ``buildTeamByPlayer(...)`` → ``{ byId: Map,
+ *     byName: Map }`` whose values are full team objects — preferred:
+ *     resolve by the row's stable Sleeper ``playerId`` first (avoids
+ *     offense/IDP cross-universe name collisions), then normalized
+ *     name.
+ *   • a plain ``normalizedName → teamName`` object (test fixtures /
+ *     lightweight callers).
+ * Returns the owner team's display name, or null when unrostered.
+ */
+export function resolveOwnerTeam(row, teamByPlayer) {
+  if (!teamByPlayer) return null;
+  const teamName = (t) => (t && typeof t === "object" ? String(t.name || "") : String(t || ""));
+  const byId = teamByPlayer.byId instanceof Map ? teamByPlayer.byId : null;
+  const byName = teamByPlayer.byName instanceof Map ? teamByPlayer.byName : null;
+  if (byId || byName) {
+    const pid = String(row?.playerId || row?.raw?.playerId || "").trim();
+    if (byId && pid && byId.has(pid)) return teamName(byId.get(pid)) || null;
+    const key = norm(row?.name);
+    if (byName && key && byName.has(key)) return teamName(byName.get(key)) || null;
+    return null;
+  }
+  if (typeof teamByPlayer === "object") {
+    const hit = teamByPlayer[norm(row?.name)];
+    return hit ? teamName(hit) || null : null;
+  }
+  return null;
 }
 
 /**
@@ -76,7 +108,8 @@ export function teamOptions(rows) {
  *   watchlist:   Set of lowercase names (row must be in it)
  *   query:       free-text token search (see matchesQuery)
  * }
- * extras = { teamByPlayer } — name → fantasy team name map.
+ * extras = { teamByPlayer } — buildTeamByPlayer's { byId, byName }
+ * index (preferred) or a plain normalizedName → teamName object.
  */
 export const FREE_AGENT_OWNER = "__free_agent__";
 
@@ -105,7 +138,7 @@ export function rowMatches(row, criteria, extras = {}) {
   }
 
   if (c.ownerTeam) {
-    const owner = (extras.teamByPlayer || {})[norm(row.name)] || null;
+    const owner = resolveOwnerTeam(row, extras.teamByPlayer);
     if (c.ownerTeam === FREE_AGENT_OWNER) {
       if (owner) return false;
     } else if (norm(owner) !== norm(c.ownerTeam)) {
@@ -152,7 +185,7 @@ export function matchesQuery(row, query, extras = {}) {
   const name = norm(row.name);
   const team = norm(row.team);
   const pos = norm(row.pos);
-  const owner = norm((extras.teamByPlayer || {})[name] || "");
+  const owner = norm(resolveOwnerTeam(row, extras.teamByPlayer) || "");
   for (const token of tokens) {
     let ok;
     if (token.startsWith("owner:")) {

--- a/frontend/lib/player-filters.js
+++ b/frontend/lib/player-filters.js
@@ -1,0 +1,184 @@
+// player-filters.js — pure predicate engine for the player search /
+// filter system (Phase 3).
+//
+// Design rules:
+//   • Pure functions over materialized rows (buildRows output) — no
+//     fetching, no React, no globals.  The rankings page (and, after
+//     the redesign lands, the R2 terminal board) applies these
+//     client-side over ~1.1k rows, which is fast enough that no
+//     memoization layer is needed here.
+//   • Owner filtering takes an externally-built name→team map
+//     (buildTeamByPlayer from waiver-logic.js) because ownership is
+//     league-scoped while rows are scoring-profile-scoped — the
+//     CLAUDE.md split.  Rows never carry the owner.
+//   • Every criterion is optional; an empty criteria object matches
+//     every row.  Unknown/null row fields fail closed for range
+//     filters (a player with unknown age is excluded by an age
+//     filter) but match "any" (absent criterion) — filtering on a
+//     field should never surface rows the filter can't evaluate.
+
+/** Experience buckets keyed by yearsExp (0 = rookie). */
+export const EXPERIENCE_BUCKETS = [
+  { key: "rookie", label: "Rookie", match: (y) => y === 0 },
+  { key: "sophomore", label: "2nd Year", match: (y) => y === 1 },
+  { key: "vet", label: "3+ Years", match: (y) => y >= 2 },
+];
+
+const EXPERIENCE_BY_KEY = Object.fromEntries(
+  EXPERIENCE_BUCKETS.map((b) => [b.key, b]),
+);
+
+function num(v) {
+  // Number(null) === 0 — guard explicitly so unknown fields stay
+  // unknown (fail-closed under range filters) instead of becoming 0.
+  if (v === null || v === undefined || v === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function norm(s) {
+  return String(s || "").trim().toLowerCase();
+}
+
+/**
+ * Build the option list for the NFL-team dropdown from live rows.
+ * "FA" (matched free agents) sorts last; unknown-team rows are not an
+ * option (they're excluded whenever a team filter is active).
+ */
+export function teamOptions(rows) {
+  const teams = new Set();
+  for (const r of rows || []) {
+    const t = String(r?.team || "").trim().toUpperCase();
+    if (t) teams.add(t);
+  }
+  const arr = Array.from(teams).sort();
+  const i = arr.indexOf("FA");
+  if (i >= 0) {
+    arr.splice(i, 1);
+    arr.push("FA");
+  }
+  return arr;
+}
+
+/**
+ * criteria = {
+ *   positions:   Set|array of position codes (row.pos exact match)
+ *   ageMin/ageMax:       inclusive bounds (row.age)
+ *   experience:  bucket key from EXPERIENCE_BUCKETS (row.yearsExp)
+ *   nflTeam:     team abbreviation ("FA" = matched free agents)
+ *   ownerTeam:   fantasy owner team name, or FREE_AGENT_OWNER for
+ *                unrostered players (evaluated via teamByPlayer map)
+ *   rankMin/rankMax:     inclusive bounds on canonicalConsensusRank
+ *   valueMin/valueMax:   inclusive bounds on rankDerivedValue
+ *   tier:        canonicalTierId exact match
+ *   edge:        "buy" | "sell" (marketGapDirection mapping)
+ *   rookieOnly:  boolean
+ *   watchlist:   Set of lowercase names (row must be in it)
+ *   query:       free-text token search (see matchesQuery)
+ * }
+ * extras = { teamByPlayer } — name → fantasy team name map.
+ */
+export const FREE_AGENT_OWNER = "__free_agent__";
+
+export function rowMatches(row, criteria, extras = {}) {
+  if (!row) return false;
+  const c = criteria || {};
+
+  if (c.positions && (c.positions.size ?? c.positions.length)) {
+    const set = c.positions instanceof Set ? c.positions : new Set(c.positions);
+    if (!set.has(row.pos)) return false;
+  }
+
+  const age = num(row.age);
+  if (c.ageMin != null && (age === null || age < c.ageMin)) return false;
+  if (c.ageMax != null && (age === null || age > c.ageMax)) return false;
+
+  if (c.experience) {
+    const bucket = EXPERIENCE_BY_KEY[c.experience];
+    const y = num(row.yearsExp);
+    if (!bucket || y === null || !bucket.match(y)) return false;
+  }
+
+  if (c.nflTeam) {
+    const t = String(row.team || "").trim().toUpperCase();
+    if (t !== String(c.nflTeam).trim().toUpperCase()) return false;
+  }
+
+  if (c.ownerTeam) {
+    const owner = (extras.teamByPlayer || {})[norm(row.name)] || null;
+    if (c.ownerTeam === FREE_AGENT_OWNER) {
+      if (owner) return false;
+    } else if (norm(owner) !== norm(c.ownerTeam)) {
+      return false;
+    }
+  }
+
+  const rank = num(row.canonicalConsensusRank);
+  if (c.rankMin != null && (rank === null || rank < c.rankMin)) return false;
+  if (c.rankMax != null && (rank === null || rank > c.rankMax)) return false;
+
+  const value = num(row.rankDerivedValue);
+  if (c.valueMin != null && (value === null || value < c.valueMin)) return false;
+  if (c.valueMax != null && (value === null || value > c.valueMax)) return false;
+
+  if (c.tier != null && num(row.canonicalTierId) !== num(c.tier)) return false;
+
+  if (c.edge) {
+    const dir = String(row.marketGapDirection || "none");
+    const want = c.edge === "buy" ? "consensus_higher" : "market_higher";
+    if (dir !== want) return false;
+  }
+
+  if (c.rookieOnly && !row.rookie) return false;
+
+  if (c.watchlist && c.watchlist.size != null) {
+    if (!c.watchlist.has(norm(row.name))) return false;
+  }
+
+  if (c.query && !matchesQuery(row, c.query, extras)) return false;
+
+  return true;
+}
+
+/**
+ * Token search: every whitespace token must match at least one of
+ * name / NFL team / position / fantasy owner.  Supports explicit
+ * prefixes: "owner:jason", "team:chi", "pos:wr".  "WR CHI" therefore
+ * finds Chicago wide receivers; "owner:Jason RB" finds Jason's RBs.
+ */
+export function matchesQuery(row, query, extras = {}) {
+  const tokens = String(query || "").split(/\s+/).map(norm).filter(Boolean);
+  if (!tokens.length) return true;
+  const name = norm(row.name);
+  const team = norm(row.team);
+  const pos = norm(row.pos);
+  const owner = norm((extras.teamByPlayer || {})[name] || "");
+  for (const token of tokens) {
+    let ok;
+    if (token.startsWith("owner:")) {
+      ok = owner.includes(token.slice(6));
+    } else if (token.startsWith("team:")) {
+      ok = team === token.slice(5) || team.includes(token.slice(5));
+    } else if (token.startsWith("pos:")) {
+      ok = pos === token.slice(4);
+    } else {
+      ok = name.includes(token) || team === token || pos === token || owner.includes(token);
+    }
+    if (!ok) return false;
+  }
+  return true;
+}
+
+/** Apply criteria over all rows. */
+export function filterRows(rows, criteria, extras = {}) {
+  if (!Array.isArray(rows)) return [];
+  const c = criteria || {};
+  const active =
+    (c.positions && (c.positions.size ?? c.positions.length)) ||
+    c.ageMin != null || c.ageMax != null || c.experience || c.nflTeam ||
+    c.ownerTeam || c.rankMin != null || c.rankMax != null ||
+    c.valueMin != null || c.valueMax != null || c.tier != null ||
+    c.edge || c.rookieOnly || c.watchlist || c.query;
+  if (!active) return rows;
+  return rows.filter((r) => rowMatches(r, c, extras));
+}

--- a/frontend/lib/player-filters.js
+++ b/frontend/lib/player-filters.js
@@ -60,7 +60,18 @@ export function resolveOwnerTeam(row, teamByPlayer) {
   const byName = teamByPlayer.byName instanceof Map ? teamByPlayer.byName : null;
   if (byId || byName) {
     const pid = String(row?.playerId || row?.raw?.playerId || "").trim();
-    if (byId && pid && byId.has(pid)) return teamName(byId.get(pid)) || null;
+    if (byId && byId.size > 0 && pid) {
+      // A populated ID index missing this row's stable id is a
+      // DEFINITIVE answer: this exact player is unrostered.  Falling
+      // through to the name map here would let an unrostered player
+      // inherit their offense/IDP name-twin's team (Codex round 2 on
+      // PR #535).  Assumption: byId is built from every team's
+      // playerIds in one pass (buildTeamByPlayer), so it is complete
+      // whenever it is non-empty.
+      return byId.has(pid) ? teamName(byId.get(pid)) || null : null;
+    }
+    // Name fallback only when the row has no usable id or the index
+    // carries no ids (legacy rows, picks, id-less league payloads).
     const key = norm(row?.name);
     if (byName && key && byName.has(key)) return teamName(byName.get(key)) || null;
     return null;

--- a/frontend/lib/player-filters.js
+++ b/frontend/lib/player-filters.js
@@ -174,8 +174,13 @@ export function rowMatches(row, criteria, extras = {}) {
   if (c.tier != null && num(row.canonicalTierId) !== num(c.tier)) return false;
 
   if (c.edge) {
+    // Contract enum from _compute_market_gap: "consensus_premium"
+    // (consensus ranks the player better than the retail market →
+    // BUY-low) / "retail_premium" (market ranks better → SELL-high).
+    // Same mapping as trade-logic.js buildEdgeSignal (Codex round 9
+    // on PR #535 — the first cut invented a nonexistent enum).
     const dir = String(row.marketGapDirection || "none");
-    const want = c.edge === "buy" ? "consensus_higher" : "market_higher";
+    const want = c.edge === "buy" ? "consensus_premium" : "retail_premium";
     if (dir !== want) return false;
   }
 

--- a/frontend/lib/player-filters.js
+++ b/frontend/lib/player-filters.js
@@ -149,6 +149,12 @@ export function rowMatches(row, criteria, extras = {}) {
   }
 
   if (c.ownerTeam) {
+    // Draft picks are excluded from owner filtering entirely: their
+    // ownership lives in the separate picks data that
+    // buildTeamByPlayer doesn't index, so a null owner would wrongly
+    // classify every owned pick as a "free agent" (Codex round 6 on
+    // PR #535).  Revisit if/when a pick-ownership join is added.
+    if (row.pos === "PICK" || row.assetClass === "pick") return false;
     const owner = resolveOwnerTeam(row, extras.teamByPlayer);
     if (c.ownerTeam === FREE_AGENT_OWNER) {
       if (owner) return false;

--- a/frontend/lib/player-filters.js
+++ b/frontend/lib/player-filters.js
@@ -59,7 +59,7 @@ export function resolveOwnerTeam(row, teamByPlayer) {
   const byId = teamByPlayer.byId instanceof Map ? teamByPlayer.byId : null;
   const byName = teamByPlayer.byName instanceof Map ? teamByPlayer.byName : null;
   if (byId || byName) {
-    const pid = String(row?.playerId || row?.raw?.playerId || "").trim();
+    const pid = String(row?.playerId || row?.raw?.playerId || row?.raw?._sleeperId || "").trim();
     if (byId && byId.size > 0 && pid) {
       // A populated ID index missing this row's stable id is a
       // DEFINITIVE answer: this exact player is unrostered.  Falling

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -7721,11 +7721,21 @@ def _derive_player_row(
         "displayName": canonical_name,
         "position": pos or None,
         "_positionFromSleeperOnly": position_from_sleeper_only,
+        # NFL team abbreviation ("FA" for matched free agents), stamped
+        # by the scraper's metadata pass from the Sleeper players blob
+        # (2026-07-26 — previously scaffolded but never written; the
+        # search/filter system needs it).
         "team": p_data.get("team") if isinstance(p_data.get("team"), str) else None,
         # Age: scaffolded for future use.  Populated when source data includes
         # age_raw (e.g. DLF CSV adapter).  Currently null for most players
         # because the scraper bridge does not supply age.
         "age": _to_int_or_none(p_data.get("age")) or _to_int_or_none(p_data.get("age_raw")),
+        # NFL years of experience from the Sleeper blob (rookie = 0).
+        # The legacy dict has carried ``_yearsExp`` since the rookie
+        # visibility pass; the row previously exposed only its
+        # ``rookie`` derivative — the experience-bucket filter needs
+        # the number itself.
+        "yearsExp": _to_int_or_none(p_data.get("_yearsExp")),
         # Two upstream rookie signals: ``_formatFitRookie`` is set by
         # the canonical pipeline's format-fit pass and is None for
         # rows that haven't been through it.  ``_isRookie`` is the


### PR DESCRIPTION
## Summary

Phase 3 of the competitor-parity roadmap: the player search & filtering system. Landing in slices on this PR.

### Slice 1 (this push)

**Data enrichment — the two dead fields the audit flagged:**
- `Dynasty Scraper.py`: new `_player_team_local` resolver stamps each player's NFL team from the Sleeper players blob during the existing metadata pass (`"FA"` for matched free agents so "free agent" is distinguishable from "identity never matched"). The contract's `team` field existed but was 0/1077 populated — the write simply never existed. Populates on the next scrape cycle.
- Contract rows now stamp `yearsExp` from the legacy `_yearsExp` (86% coverage on the current export; previously only its `rookie` derivative was exposed). Mapped in both frontend materializers.

**Filter engine** — new `frontend/lib/player-filters.js`, a pure predicate module (no React, no fetching): position / age range / experience bucket (Rookie / 2nd-year / 3+) / NFL team / fantasy-owner (league-scoped join via `buildTeamByPlayer` — rows never carry the owner, per the scoring-profile/league split) / consensus-rank range / value band / tier / market-edge direction / rookie flag / watchlist, plus a token search grammar (`WR CHI`, `owner:jason`, `pos:`/`team:` prefixes). Range filters fail closed on unknown fields — including the `Number(null) === 0` trap, regression-tested. Built deliberately UI-agnostic so the redesign's R2 board consumes it unchanged.

**Housekeeping:** removed 10 pre-existing dead assignments (F841) + format drift in `Dynasty Scraper.py`, required by the changed-file lint gate.

### Coming in the next slice
Filter-rail UI wiring on `/rankings` + GlobalSearch token support, using existing UI patterns (the visual treatment arrives with redesign R2).

## Tests
24 new vitest cases for the filter engine; full frontend suite 938 green; targeted pytest subset (contract/registry/scraper) 236 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_