### PR TITLE
Production hardening: nginx, systemd resilience, backups, health monitoring (prepared, not applied)

### DIFF
--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -159,6 +159,13 @@ apply_nginx() {
                 err "restoring ${backup}"
                 cp -p "${backup}" "${dest}"
                 nginx -t || err "restored config ALSO fails nginx -t — manual intervention required"
+            else
+                # First install: there is no known-good config to fall
+                # back to.  Leaving the invalid file + enabled symlink
+                # armed would fail the NEXT nginx restart/reboot, so
+                # remove both — nginx keeps running on whatever it had.
+                err "first install (no backup) — removing invalid ${dest} and ${link} so a later nginx restart cannot pick them up"
+                rm -f "${dest}" "${link}"
             fi
             exit 1
         fi
@@ -167,8 +174,16 @@ apply_nginx() {
         log "nginx reloaded with hardened config"
     fi
 
-    # Sanity even when unchanged: symlink + config still valid.
-    [[ -L "${link}" ]] || { [[ "${DRY_RUN}" == "true" ]] || ln -sf "${dest}" "${link}"; }
+    # Sanity even when unchanged: the enabled symlink must exist AND
+    # resolve to our destination — a stale/renamed/broken link would
+    # keep nginx serving the wrong config while this script reports
+    # up-to-date.
+    local link_target
+    link_target="$(readlink -f "${link}" 2>/dev/null || true)"
+    if [[ "${link_target}" != "${dest}" ]]; then
+        warn "sites-enabled symlink wrong (resolves to '${link_target:-<missing>}', want '${dest}') — fixing"
+        [[ "${DRY_RUN}" == "true" ]] || ln -sf "${dest}" "${link}"
+    fi
     nginx -t >/dev/null 2>&1 || warn "current nginx config fails nginx -t — investigate before next reload"
 }
 

--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -36,6 +36,21 @@ APP_USER="${APP_USER:-dynasty}"
 SERVICE_NAME="${SERVICE_NAME:-dynasty}"
 NGINX_SITE="${NGINX_SITE:-riskittogetthebrisket.org}"
 
+# VENV_DIR must be derived from the APP_USER's home, NOT from $HOME:
+# under the documented `sudo bash` invocation HOME=/root, and
+# install-systemd-service.sh's own default (${HOME}/.venvs/<slug>)
+# would render dynasty.service against /root/.venvs/... — a
+# nonexistent interpreter that takes the backend down on the next
+# restart.  getent keeps this correct for any APP_USER override.
+if [[ -z "${VENV_DIR:-}" ]]; then
+    APP_USER_HOME="$(getent passwd "${APP_USER}" | cut -d: -f6)"
+    if [[ -z "${APP_USER_HOME}" ]]; then
+        printf '[apply-hardening][ERROR] cannot resolve home directory for APP_USER=%s\n' "${APP_USER}" >&2
+        exit 1
+    fi
+    VENV_DIR="${APP_USER_HOME}/.venvs/$(basename "${APP_DIR}")"
+fi
+
 DRY_RUN=false
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
 
@@ -60,13 +75,18 @@ show_diff() {
 
 # install_unit <src> <dest> [render]
 # render=yes rewrites the canonical repo path inside the unit to APP_DIR
-# so a non-default checkout location still points at real scripts.
+# so a non-default checkout location still points at real scripts, and
+# rewrites the watchdog's HEALTH_SERVICE to SERVICE_NAME so a renamed
+# service is restarted — not the default "dynasty" (the second pattern
+# only exists in dynasty-healthcheck.service; it is a no-op elsewhere).
 install_unit() {
     local src="$1" dest="$2" render="${3:-no}"
     local staged
     staged="$(mktemp)"
     if [[ "${render}" == "yes" ]]; then
-        sed "s|/home/dynasty/trade-calculator|${APP_DIR}|g" "${src}" > "${staged}"
+        sed -e "s|/home/dynasty/trade-calculator|${APP_DIR}|g" \
+            -e "s|HEALTH_SERVICE=dynasty|HEALTH_SERVICE=${SERVICE_NAME}|g" \
+            "${src}" > "${staged}"
     else
         cp "${src}" "${staged}"
     fi
@@ -146,15 +166,27 @@ apply_nginx() {
 
 # ── 2. dynasty + dynasty-frontend units from hardened templates ──────
 apply_app_services() {
+    # Pre-flight: never rewrite the backend unit to point at an
+    # interpreter that does not exist (that is a guaranteed outage on
+    # the next restart).
+    if [[ ! -x "${VENV_DIR}/bin/python" ]]; then
+        err "pre-flight FAILED: ${VENV_DIR}/bin/python does not exist or is not executable."
+        err "Refusing to rewrite ${SERVICE_NAME}.service against a missing interpreter."
+        err "Set VENV_DIR explicitly if the venv lives elsewhere."
+        exit 1
+    fi
+    log "pre-flight OK: ${VENV_DIR}/bin/python exists"
     log "re-rendering ${SERVICE_NAME}/${SERVICE_NAME}-frontend units from templates"
     if [[ "${DRY_RUN}" == "true" ]]; then
-        log "(dry-run) would run: FORCE_SERVICE_INSTALL=true deploy/install-systemd-service.sh"
+        log "(dry-run) would run: FORCE_SERVICE_INSTALL=true VENV_DIR=${VENV_DIR} deploy/install-systemd-service.sh"
         return 0
     fi
-    # install-systemd-service.sh resolves the venv + npm paths itself and
-    # writes both units; FORCE ensures the hardened templates land even
-    # though the units already exist.  It does NOT restart anything.
+    # install-systemd-service.sh resolves the npm path itself and writes
+    # both units; FORCE ensures the hardened templates land even though
+    # the units already exist.  It does NOT restart anything.  VENV_DIR
+    # is passed explicitly — see the derivation note at the top.
     if ! APP_DIR="${APP_DIR}" APP_USER="${APP_USER}" SERVICE_NAME="${SERVICE_NAME}" \
+         VENV_DIR="${VENV_DIR}" \
          FORCE_SERVICE_INSTALL=true bash "${APP_DIR}/deploy/install-systemd-service.sh"; then
         err "install-systemd-service.sh failed — app units NOT updated"
         exit 1

--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -35,6 +35,11 @@ APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
 APP_USER="${APP_USER:-dynasty}"
 SERVICE_NAME="${SERVICE_NAME:-dynasty}"
 NGINX_SITE="${NGINX_SITE:-riskittogetthebrisket.org}"
+# Root-owned install location for scripts that systemd runs AS ROOT.
+# They must NOT execute from the deploy-user-writable checkout — that
+# would let a compromised deploy account swap a script and get root on
+# the next timer fire.  Overridable for testing (RISKIT_LIB_DIR=...).
+RISKIT_LIB_DIR="${RISKIT_LIB_DIR:-/usr/local/lib/riskit}"
 
 # VENV_DIR must be derived from the APP_USER's home, NOT from $HOME:
 # under the documented `sudo bash` invocation HOME=/root, and
@@ -74,18 +79,21 @@ show_diff() {
 }
 
 # install_unit <src> <dest> [render]
-# render=yes rewrites the canonical repo path inside the unit to APP_DIR
-# so a non-default checkout location still points at real scripts, and
-# rewrites the watchdog's HEALTH_SERVICE to SERVICE_NAME so a renamed
-# service is restarted — not the default "dynasty" (the second pattern
-# only exists in dynasty-healthcheck.service; it is a no-op elsewhere).
+# render=yes rewrites the canonical paths/names inside the unit for
+# non-default installs: checkout path → APP_DIR, root-script dir →
+# RISKIT_LIB_DIR, the watchdog's HEALTH_SERVICE → SERVICE_NAME, and
+# User/Group=dynasty → APP_USER (each pattern is a no-op in units that
+# don't contain it).
 install_unit() {
     local src="$1" dest="$2" render="${3:-no}"
     local staged
     staged="$(mktemp)"
     if [[ "${render}" == "yes" ]]; then
         sed -e "s|/home/dynasty/trade-calculator|${APP_DIR}|g" \
+            -e "s|/usr/local/lib/riskit|${RISKIT_LIB_DIR}|g" \
             -e "s|HEALTH_SERVICE=dynasty|HEALTH_SERVICE=${SERVICE_NAME}|g" \
+            -e "s|^User=dynasty$|User=${APP_USER}|" \
+            -e "s|^Group=dynasty$|Group=${APP_USER}|" \
             "${src}" > "${staged}"
     else
         cp "${src}" "${staged}"
@@ -194,6 +202,36 @@ apply_app_services() {
     CHANGED_UNITS=true
 }
 
+# ── 3a. root-owned copies of root-run scripts ────────────────────────
+# dynasty-healthcheck.sh and riskit-state-backup.sh execute as root
+# (systemctl restart / /var/backups + /var/lib reads), so their units
+# point at ${RISKIT_LIB_DIR} — root:root 0755, outside the checkout.
+# Updates flow through re-running this installer; editing the checkout
+# copy alone changes nothing at runtime.  The uptime probe is NOT
+# installed here: it runs unprivileged (User=dynasty) from the
+# checkout, which is fine because it has no more privilege than the
+# user who can already edit it.
+install_priv_script() {
+    local src="$1"
+    local dest="${RISKIT_LIB_DIR}/$(basename "$1")"
+    if [[ -f "${dest}" ]] && cmp -s "${src}" "${dest}"; then
+        log "up-to-date: ${dest}"
+        return 0
+    fi
+    log "installing root-owned script: ${dest}"
+    show_diff "${dest}" "${src}"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log "(dry-run) would install ${dest} (root:root 0755)"
+    else
+        install -o root -g root -m 0755 -D "${src}" "${dest}"
+    fi
+}
+
+apply_privileged_scripts() {
+    install_priv_script "${APP_DIR}/deploy/systemd/dynasty-healthcheck.sh"
+    install_priv_script "${APP_DIR}/deploy/backup/riskit-state-backup.sh"
+}
+
 # ── 3-5. hardening units ─────────────────────────────────────────────
 apply_hardening_units() {
     install_unit "${APP_DIR}/deploy/systemd/dynasty-healthcheck.service" \
@@ -210,14 +248,15 @@ apply_hardening_units() {
                  "/etc/systemd/system/riskit-uptime.timer"
 
     if [[ "${DRY_RUN}" != "true" ]]; then
-        chmod +x "${APP_DIR}/deploy/systemd/dynasty-healthcheck.sh" \
-                 "${APP_DIR}/deploy/backup/riskit-state-backup.sh" \
-                 "${APP_DIR}/deploy/monitoring/uptime_check.sh" 2>/dev/null || true
+        # Only the unprivileged probe runs from the checkout; the two
+        # root-run scripts execute from ${RISKIT_LIB_DIR} (see above).
+        chmod +x "${APP_DIR}/deploy/monitoring/uptime_check.sh" 2>/dev/null || true
     fi
 }
 
 apply_nginx
 apply_app_services
+apply_privileged_scripts
 apply_hardening_units
 
 if [[ "${DRY_RUN}" != "true" && "${CHANGED_UNITS}" == "true" ]]; then
@@ -253,6 +292,9 @@ cat <<CHECKLIST
    [ ] bash ${APP_DIR}/deploy/verify-deploy.sh
 
  watchdog / timers
+   [ ] ls -la ${RISKIT_LIB_DIR}/   # root:root 0755 healthcheck + backup scripts
+   [ ] systemctl cat dynasty-healthcheck riskit-state-backup | grep ExecStart
+       → both point at ${RISKIT_LIB_DIR}, NOT the checkout
    [ ] systemctl list-timers 'dynasty-*' 'riskit-*'   # all three scheduled
    [ ] sudo systemctl start dynasty-healthcheck.service && journalctl -u dynasty-healthcheck -n 5
    [ ] sudo systemctl start riskit-state-backup.service \\

--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -177,12 +177,36 @@ apply_nginx() {
     # Sanity even when unchanged: the enabled symlink must exist AND
     # resolve to our destination — a stale/renamed/broken link would
     # keep nginx serving the wrong config while this script reports
-    # up-to-date.
-    local link_target
+    # up-to-date.  Fixing the link changes what nginx WILL serve, so it
+    # gets the same validate-then-reload as the main install path;
+    # without the reload the running nginx would keep serving its
+    # previously loaded config while the installer reports completion.
+    local link_target prev_raw
     link_target="$(readlink -f "${link}" 2>/dev/null || true)"
     if [[ "${link_target}" != "${dest}" ]]; then
         warn "sites-enabled symlink wrong (resolves to '${link_target:-<missing>}', want '${dest}') — fixing"
-        [[ "${DRY_RUN}" == "true" ]] || ln -sf "${dest}" "${link}"
+        if [[ "${DRY_RUN}" == "true" ]]; then
+            log "(dry-run) would recreate ${link}, then nginx -t + reload nginx"
+        else
+            # Remember the exact previous link state (raw target, not
+            # resolved) so a failed validation restores it verbatim.
+            prev_raw="$(readlink "${link}" 2>/dev/null || true)"
+            ln -sf "${dest}" "${link}"
+            if ! nginx -t; then
+                err "nginx -t FAILED after repairing the sites-enabled symlink"
+                if [[ -n "${prev_raw}" ]]; then
+                    err "restoring previous link state: ${link} -> ${prev_raw}"
+                    ln -sf "${prev_raw}" "${link}"
+                else
+                    err "removing ${link} (no link existed before the repair)"
+                    rm -f "${link}"
+                fi
+                exit 1
+            fi
+            systemctl reload nginx
+            CHANGED_NGINX=true
+            log "nginx reloaded after sites-enabled symlink repair"
+        fi
     fi
     nginx -t >/dev/null 2>&1 || warn "current nginx config fails nginx -t — investigate before next reload"
 }

--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# apply_hardening.sh — idempotent installer for the production-hardening
+# set prepared in deploy/ (see docs/PROD-HARDENING.md).
+#
+#   1. nginx site config      (diff → backup → install → nginx -t → reload;
+#                              auto-restores the backup if nginx -t fails)
+#   2. dynasty / dynasty-frontend systemd units (re-rendered from the
+#                              hardened templates via install-systemd-service.sh)
+#   3. dynasty-healthcheck    service + timer   (backend watchdog, 1 min)
+#   4. riskit-state-backup    service + timer   (nightly 02:30 UTC)
+#   5. riskit-uptime          service + timer   (probe, 5 min)
+#
+# Safe to re-run: every step diffs current vs. desired and only touches
+# what changed.  Nothing here edits .env, credentials, certificates, or
+# application data.
+#
+# Usage (as root on the VPS):
+#   sudo bash deploy/apply_hardening.sh            # apply
+#   sudo bash deploy/apply_hardening.sh --dry-run  # show diffs only
+#
+# Env overrides:
+#   APP_DIR       default /home/dynasty/trade-calculator
+#   APP_USER      default dynasty
+#   SERVICE_NAME  default dynasty
+#   NGINX_SITE    default riskittogetthebrisket.org
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
+[[ -d "${APP_DIR}" ]] || APP_DIR="${DEFAULT_APP_DIR}"
+APP_USER="${APP_USER:-dynasty}"
+SERVICE_NAME="${SERVICE_NAME:-dynasty}"
+NGINX_SITE="${NGINX_SITE:-riskittogetthebrisket.org}"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+log()  { printf '[apply-hardening] %s\n' "$*"; }
+warn() { printf '[apply-hardening][WARN] %s\n' "$*" >&2; }
+err()  { printf '[apply-hardening][ERROR] %s\n' "$*" >&2; }
+
+if [[ "${EUID}" -ne 0 ]]; then
+    err "must run as root (nginx config + /etc/systemd/system + reloads)."
+    err "  sudo bash deploy/apply_hardening.sh"
+    exit 1
+fi
+
+CHANGED_NGINX=false
+CHANGED_UNITS=false
+ENABLED_TIMERS=()
+
+show_diff() {
+    # diff current(new-arg-order: old new) — never fails the script.
+    diff -u "$1" "$2" 2>/dev/null || true
+}
+
+# install_unit <src> <dest> [render]
+# render=yes rewrites the canonical repo path inside the unit to APP_DIR
+# so a non-default checkout location still points at real scripts.
+install_unit() {
+    local src="$1" dest="$2" render="${3:-no}"
+    local staged
+    staged="$(mktemp)"
+    if [[ "${render}" == "yes" ]]; then
+        sed "s|/home/dynasty/trade-calculator|${APP_DIR}|g" "${src}" > "${staged}"
+    else
+        cp "${src}" "${staged}"
+    fi
+    if [[ -f "${dest}" ]] && cmp -s "${staged}" "${dest}"; then
+        log "up-to-date: ${dest}"
+        rm -f "${staged}"
+        return 0
+    fi
+    log "installing: ${dest}"
+    show_diff "${dest}" "${staged}"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log "(dry-run) would install ${dest}"
+    else
+        install -m 0644 "${staged}" "${dest}"
+        CHANGED_UNITS=true
+    fi
+    rm -f "${staged}"
+}
+
+enable_timer() {
+    local timer="$1"
+    ENABLED_TIMERS+=("${timer}")
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log "(dry-run) would: systemctl enable --now ${timer}"
+    else
+        systemctl enable --now "${timer}"
+    fi
+}
+
+# ── 1. nginx ─────────────────────────────────────────────────────────
+apply_nginx() {
+    local src="${APP_DIR}/deploy/nginx/${NGINX_SITE}.conf"
+    local dest="/etc/nginx/sites-available/${NGINX_SITE}"
+    local link="/etc/nginx/sites-enabled/${NGINX_SITE}"
+
+    if ! command -v nginx >/dev/null 2>&1; then
+        warn "nginx not installed — skipping nginx step"
+        return 0
+    fi
+    [[ -f "${src}" ]] || { err "missing ${src}"; exit 1; }
+
+    if [[ -f "${dest}" ]] && cmp -s "${src}" "${dest}"; then
+        log "nginx config up-to-date: ${dest}"
+    else
+        log "nginx config differs:"
+        show_diff "${dest}" "${src}"
+        if [[ "${DRY_RUN}" == "true" ]]; then
+            log "(dry-run) would install ${dest}, test, reload"
+            return 0
+        fi
+        local backup=""
+        if [[ -f "${dest}" ]]; then
+            backup="${dest}.bak.$(date -u +%Y%m%d%H%M%S)"
+            cp -p "${dest}" "${backup}"
+            log "backed up current config to ${backup}"
+        fi
+        install -m 0644 "${src}" "${dest}"
+        ln -sf "${dest}" "${link}"
+        if ! nginx -t; then
+            err "nginx -t FAILED with the new config"
+            if [[ -n "${backup}" ]]; then
+                err "restoring ${backup}"
+                cp -p "${backup}" "${dest}"
+                nginx -t || err "restored config ALSO fails nginx -t — manual intervention required"
+            fi
+            exit 1
+        fi
+        systemctl reload nginx
+        CHANGED_NGINX=true
+        log "nginx reloaded with hardened config"
+    fi
+
+    # Sanity even when unchanged: symlink + config still valid.
+    [[ -L "${link}" ]] || { [[ "${DRY_RUN}" == "true" ]] || ln -sf "${dest}" "${link}"; }
+    nginx -t >/dev/null 2>&1 || warn "current nginx config fails nginx -t — investigate before next reload"
+}
+
+# ── 2. dynasty + dynasty-frontend units from hardened templates ──────
+apply_app_services() {
+    log "re-rendering ${SERVICE_NAME}/${SERVICE_NAME}-frontend units from templates"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log "(dry-run) would run: FORCE_SERVICE_INSTALL=true deploy/install-systemd-service.sh"
+        return 0
+    fi
+    # install-systemd-service.sh resolves the venv + npm paths itself and
+    # writes both units; FORCE ensures the hardened templates land even
+    # though the units already exist.  It does NOT restart anything.
+    if ! APP_DIR="${APP_DIR}" APP_USER="${APP_USER}" SERVICE_NAME="${SERVICE_NAME}" \
+         FORCE_SERVICE_INSTALL=true bash "${APP_DIR}/deploy/install-systemd-service.sh"; then
+        err "install-systemd-service.sh failed — app units NOT updated"
+        exit 1
+    fi
+    CHANGED_UNITS=true
+}
+
+# ── 3-5. hardening units ─────────────────────────────────────────────
+apply_hardening_units() {
+    install_unit "${APP_DIR}/deploy/systemd/dynasty-healthcheck.service" \
+                 "/etc/systemd/system/dynasty-healthcheck.service" yes
+    install_unit "${APP_DIR}/deploy/systemd/dynasty-healthcheck.timer" \
+                 "/etc/systemd/system/dynasty-healthcheck.timer"
+    install_unit "${APP_DIR}/deploy/backup/riskit-state-backup.service" \
+                 "/etc/systemd/system/riskit-state-backup.service" yes
+    install_unit "${APP_DIR}/deploy/backup/riskit-state-backup.timer" \
+                 "/etc/systemd/system/riskit-state-backup.timer"
+    install_unit "${APP_DIR}/deploy/monitoring/riskit-uptime.service" \
+                 "/etc/systemd/system/riskit-uptime.service" yes
+    install_unit "${APP_DIR}/deploy/monitoring/riskit-uptime.timer" \
+                 "/etc/systemd/system/riskit-uptime.timer"
+
+    if [[ "${DRY_RUN}" != "true" ]]; then
+        chmod +x "${APP_DIR}/deploy/systemd/dynasty-healthcheck.sh" \
+                 "${APP_DIR}/deploy/backup/riskit-state-backup.sh" \
+                 "${APP_DIR}/deploy/monitoring/uptime_check.sh" 2>/dev/null || true
+    fi
+}
+
+apply_nginx
+apply_app_services
+apply_hardening_units
+
+if [[ "${DRY_RUN}" != "true" && "${CHANGED_UNITS}" == "true" ]]; then
+    systemctl daemon-reload
+    log "systemd daemon-reload done"
+fi
+enable_timer dynasty-healthcheck.timer
+enable_timer riskit-state-backup.timer
+enable_timer riskit-uptime.timer
+
+# ── Verification checklist ───────────────────────────────────────────
+cat <<CHECKLIST
+
+════════════════════════════════════════════════════════════════════
+ VERIFICATION CHECKLIST — run each step now
+════════════════════════════════════════════════════════════════════
+ nginx
+   [ ] sudo nginx -t                          # syntax OK
+   [ ] curl -sSI https://${NGINX_SITE}/ | grep -Ei 'HTTP/|strict-transport|x-content-type'
+       → expect HTTP/2 200, HSTS + nosniff headers
+   [ ] curl -sSI https://${NGINX_SITE}/api/health
+       → 200; Cache-Control comes from the app, NOT nginx
+   [ ] curl -sS -H 'Accept-Encoding: gzip' -o /dev/null -w '%{size_download}\n' \\
+         https://${NGINX_SITE}/api/data
+       → wire size ~100-400 KB (compressed), not ~4 MB
+   [ ] curl -sSI https://${NGINX_SITE}/_next/static/<any-chunk>.js
+       → Cache-Control: public, max-age=31536000, immutable (from Next)
+
+ systemd services (hardened units land on NEXT restart; restart at a
+ quiet moment):
+   [ ] systemctl cat ${SERVICE_NAME} | grep -E 'MemoryMax|StartLimit|PrivateTmp'
+   [ ] sudo systemctl restart ${SERVICE_NAME}-frontend ${SERVICE_NAME}   # optional now
+   [ ] bash ${APP_DIR}/deploy/verify-deploy.sh
+
+ watchdog / timers
+   [ ] systemctl list-timers 'dynasty-*' 'riskit-*'   # all three scheduled
+   [ ] sudo systemctl start dynasty-healthcheck.service && journalctl -u dynasty-healthcheck -n 5
+   [ ] sudo systemctl start riskit-state-backup.service \\
+         && sudo tail -n 20 /var/log/riskit-state-backup.log \\
+         && sudo ls -la /var/backups/riskit-state/daily/\$(date -u +%F)/
+   [ ] sudo systemctl start riskit-uptime.service && sudo tail -n 3 /var/log/riskit-uptime.log
+
+ rollback (if anything misbehaves): docs/PROD-HARDENING.md § Rollback
+════════════════════════════════════════════════════════════════════
+CHECKLIST
+
+log "done (dry-run=${DRY_RUN}, nginx-changed=${CHANGED_NGINX}, units-changed=${CHANGED_UNITS})"

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -1,0 +1,108 @@
+# deploy/backup — nightly state backups
+
+Nightly local backup of every piece of production state that cannot be
+regenerated from the repo or re-scraped.
+
+## What gets backed up
+
+| Input | How | Guarded? |
+|---|---|---|
+| `data/user_kv.sqlite` | SQLite online backup → `.sqlite.gz` | skip if absent |
+| `data/session_store.sqlite` | SQLite online backup → `.sqlite.gz` | skip if absent |
+| `data/guest_passes.sqlite` | SQLite online backup → `.sqlite.gz` | skip if absent |
+| `data/public_league/` | `tar.gz` | skip if absent |
+| `data/intel/` | `tar.gz` | skip if absent (does not exist yet) |
+| `dlf_session.json`, `draftsharks_session.json`, `idpshow_session.json` (repo root) | copy, mode 0600 | skip if absent |
+| `/var/lib/dlf-fetch/dlf_session.json`, `/var/lib/idpshow-fetch/idpshow_session.json` | copy, mode 0600 | skip if absent/unreadable |
+
+The session cookie files are **secrets** (gitignored via `*_session.json`).
+They are backed up **on-box only**, under `umask 077`, and must never be
+committed to the repo or synced anywhere public.  The IDP Show session
+in particular can only be re-provisioned by hand (captcha-gated login),
+which is exactly why it is worth backing up.
+
+SQLite copies use the `sqlite3.Connection.backup()` online-backup
+primitive via the venv python (same approach as the existing
+`deploy/backup_user_kv.sh` — the sqlite3 CLI is not installed on the
+box), so they are consistent under concurrent writes (WAL).
+
+Every artifact is integrity-checked (`gzip -t` / `tar -tzf`) before the
+run reports success.
+
+## Layout & retention
+
+```
+/var/backups/riskit-state/daily/YYYY-MM-DD/
+├── sqlite/    user_kv.sqlite.gz, session_store.sqlite.gz, guest_passes.sqlite.gz
+├── dirs/      public_league.tar.gz, intel.tar.gz
+└── sessions/  repo.*.json, workdir.*.json   (mode 0600)
+```
+
+Rotation keeps the newest **14** dated directories (`KEEP_DAILY`).
+Falls back to `/home/dynasty/backups/riskit-state` if `/var/backups`
+is not writable.
+
+## Install
+
+```bash
+sudo cp deploy/backup/riskit-state-backup.service deploy/backup/riskit-state-backup.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now riskit-state-backup.timer
+systemctl list-timers riskit-state-backup.timer
+```
+
+(`deploy/apply_hardening.sh` does all of this idempotently.)
+
+Manual run / check:
+
+```bash
+sudo systemctl start riskit-state-backup.service
+sudo tail -n 30 /var/log/riskit-state-backup.log
+sudo ls -la /var/backups/riskit-state/daily/$(date -u +%F)/
+```
+
+## Optional off-box mirror (operator opt-in)
+
+Local-only by default.  To mirror to another host (Hetzner Storage Box,
+another VPS, …):
+
+```bash
+sudo systemctl edit riskit-state-backup.service
+# add:
+#   [Service]
+#   Environment="OFFBOX_RSYNC_DEST=u123456@u123456.your-storagebox.de:riskit-state/"
+```
+
+Requires `rsync` on the box and non-interactive SSH auth (key in
+root's `~/.ssh`, destination host key accepted once by hand).  A mirror
+failure logs a warning and exits non-zero but never blocks the local
+backup.  Remember the mirror includes the session **secrets** — only
+mirror to storage you control.
+
+## Relationship to `riskit-backup.timer` (existing)
+
+`deploy/backup_user_kv.sh` (02:00 UTC) covers only the three sqlite
+files but keeps 30 daily + 12 monthly generations, and has a weekly
+restore test (`riskit-backup-restore-test.timer`).  This job (02:30
+UTC) is a per-night superset with 14-day retention.  **Keep both
+enabled**: the overlap costs a few MB per night and preserves the long
+monthly sqlite history plus the exercised restore path.
+
+## Restore
+
+```bash
+# SQLite (stop the backend first so it doesn't hold the old file):
+sudo systemctl stop dynasty
+gunzip -c /var/backups/riskit-state/daily/<DATE>/sqlite/user_kv.sqlite.gz \
+  | sudo -u dynasty tee /home/dynasty/trade-calculator/data/user_kv.sqlite >/dev/null
+sudo systemctl start dynasty
+
+# Directory:
+sudo -u dynasty tar -xzf /var/backups/riskit-state/daily/<DATE>/dirs/public_league.tar.gz \
+  -C /home/dynasty/trade-calculator/data/
+
+# Session cookies (repo copy; fix ownership + mode):
+sudo install -o dynasty -g dynasty -m 0600 \
+  /var/backups/riskit-state/daily/<DATE>/sessions/repo.idpshow_session.json \
+  /home/dynasty/trade-calculator/idpshow_session.json
+```

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -50,9 +50,26 @@ leaves every prior generation (including an earlier same-day
 snapshot) untouched — consecutive failures can never erode the
 retained history.
 
+A snapshot must also contain the CORE state to count: `BACKUP_REQUIRED`
+(default `user_kv.sqlite session_store.sqlite`) lists the items that
+must be written and verified before promotion.  This closes the
+partial-snapshot hole where an unmounted/mistyped `DATA_DIR` with a
+stray session JSON still produced a nonzero artifact count.  Add dir
+names to require them too, via a service drop-in:
+`Environment="BACKUP_REQUIRED=user_kv.sqlite session_store.sqlite public_league"`.
+
+**Security note**: the systemd unit runs the ROOT-OWNED copy of the
+script installed at `/usr/local/lib/riskit/riskit-state-backup.sh` by
+`deploy/apply_hardening.sh` — never the checkout copy (a root unit
+executing a deploy-user-writable file would be a privilege-escalation
+path).  After changing the script in the repo, re-run
+`sudo bash deploy/apply_hardening.sh` to roll it out.
+
 ## Install
 
 ```bash
+# Root-owned script copy OUTSIDE the checkout (the unit executes this):
+sudo install -o root -g root -m 0755 -D deploy/backup/riskit-state-backup.sh /usr/local/lib/riskit/riskit-state-backup.sh
 sudo cp deploy/backup/riskit-state-backup.service deploy/backup/riskit-state-backup.timer /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now riskit-state-backup.timer

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -42,6 +42,14 @@ Rotation keeps the newest **14** dated directories (`KEEP_DAILY`).
 Falls back to `/home/dynasty/backups/riskit-state` if `/var/backups`
 is not writable.
 
+Destructive steps run strictly last: artifacts are written into a
+hidden staging dir, integrity-checked, and only a fully validated
+snapshot is promoted into `daily/`, mirrored off-box, or allowed to
+trigger pruning.  A failing run discards its own staging dir and
+leaves every prior generation (including an earlier same-day
+snapshot) untouched — consecutive failures can never erode the
+retained history.
+
 ## Install
 
 ```bash

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -26,8 +26,13 @@ primitive via the venv python (same approach as the existing
 `deploy/backup_user_kv.sh` — the sqlite3 CLI is not installed on the
 box), so they are consistent under concurrent writes (WAL).
 
-Every artifact is integrity-checked (`gzip -t` / `tar -tzf`) before the
-run reports success.
+Every artifact is integrity-checked before the run reports success:
+SQLite copies get `PRAGMA integrity_check` (run against the *copied*
+database — `gzip -t` alone only proves the compressed stream is
+intact, while structural corruption copies page-for-page through
+`Connection.backup()`), then `gzip -t`; tarballs get `tar -tzf`.  A
+failed check rejects the artifact like any other error — and when the
+artifact is required, it blocks promotion entirely.
 
 ## Layout & retention
 

--- a/deploy/backup/riskit-state-backup.service
+++ b/deploy/backup/riskit-state-backup.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Risk It nightly state backup (sqlite + dirs + scraper sessions)
+After=network.target
+
+[Service]
+Type=oneshot
+# Root so the job can (a) write the primary /var/backups location and
+# (b) read root-owned session files under /var/lib/*-fetch.  The
+# script itself umasks 077 and chmods session copies to 0600.
+ExecStart=/home/dynasty/trade-calculator/deploy/backup/riskit-state-backup.sh
+StandardOutput=append:/var/log/riskit-state-backup.log
+StandardError=append:/var/log/riskit-state-backup.log
+Environment="APP_DIR=/home/dynasty/trade-calculator"
+Environment="BACKUP_ROOT=/var/backups/riskit-state"
+Environment="KEEP_DAILY=14"
+# Optional off-box mirror — set via drop-in
+# (`systemctl edit riskit-state-backup.service`):
+#   Environment="OFFBOX_RSYNC_DEST=backup@host:riskit-state/"
+Nice=10
+IOSchedulingClass=idle
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/backup/riskit-state-backup.service
+++ b/deploy/backup/riskit-state-backup.service
@@ -7,7 +7,14 @@ Type=oneshot
 # Root so the job can (a) write the primary /var/backups location and
 # (b) read root-owned session files under /var/lib/*-fetch.  The
 # script itself umasks 077 and chmods session copies to 0600.
-ExecStart=/home/dynasty/trade-calculator/deploy/backup/riskit-state-backup.sh
+#
+# SECURITY: because this runs as root, ExecStart points at a ROOT-OWNED
+# copy installed OUTSIDE the deploy-user-writable checkout
+# (deploy/apply_hardening.sh installs it to /usr/local/lib/riskit/,
+# root:root 0755) — running the checkout copy as root would hand a
+# compromised deploy account a nightly root-execution path.  Script
+# updates flow through re-running deploy/apply_hardening.sh.
+ExecStart=/usr/local/lib/riskit/riskit-state-backup.sh
 StandardOutput=append:/var/log/riskit-state-backup.log
 StandardError=append:/var/log/riskit-state-backup.log
 Environment="APP_DIR=/home/dynasty/trade-calculator"

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -27,9 +27,20 @@
 #
 # Operation order (destructive steps strictly last):
 #   write artifacts into a hidden staging dir → integrity checks →
-#   FAILURE: discard staging, exit 1 (daily/ namespace untouched) |
-#   SUCCESS: promote staging → dated dir → off-box mirror (validated
-#   snapshots only) → prune oldest generations beyond $KEEP_DAILY.
+#   required-artifact manifest check → FAILURE: discard staging,
+#   exit 1 (daily/ namespace untouched) | SUCCESS: promote staging →
+#   dated dir → off-box mirror (validated snapshots only) → prune
+#   oldest generations beyond $KEEP_DAILY.
+#
+# Required-artifact manifest: a snapshot only counts as a generation
+# when it contains the CORE state.  BACKUP_REQUIRED (space-separated
+# basenames, default "user_kv.sqlite session_store.sqlite") lists the
+# items that must have been successfully written and verified; a
+# partial snapshot (e.g. DATA_DIR unmounted/mistyped while a stray
+# session JSON still bumps the artifact count) is discarded instead of
+# promoted, so it can never displace a COMPLETE older generation or
+# reach the off-box mirror.  Dir names (public_league, intel) may be
+# listed too, e.g. BACKUP_REQUIRED="user_kv.sqlite session_store.sqlite public_league".
 #
 # Off-box mirroring (OPTIONAL, operator-configured): set
 # OFFBOX_RSYNC_DEST to an rsync destination (e.g.
@@ -56,6 +67,7 @@ BACKUP_FALLBACK_ROOT="${BACKUP_FALLBACK_ROOT:-/home/dynasty/backups/riskit-state
 KEEP_DAILY="${KEEP_DAILY:-14}"
 DATE_STAMP="$(date -u +%Y-%m-%d)"
 OFFBOX_RSYNC_DEST="${OFFBOX_RSYNC_DEST:-}"
+BACKUP_REQUIRED="${BACKUP_REQUIRED:-user_kv.sqlite session_store.sqlite}"
 
 PYTHON_BIN="${PYTHON_BIN:-/home/dynasty/.venvs/trade-calculator/bin/python}"
 [[ -x "${PYTHON_BIN}" ]] || PYTHON_BIN="$(command -v python3 || true)"
@@ -100,6 +112,10 @@ find "${BACKUP_ROOT}/daily" -maxdepth 1 -name '.staging-*' -mtime +1 \
 
 ARTIFACTS=0
 ERRORS=0
+# Space-padded list of item names (sqlite basenames / dir names) that
+# were successfully written AND integrity-checked — the required-
+# artifact manifest is validated against this before promotion.
+OK_LIST=" "
 
 # ── SQLite (online, WAL-safe) ────────────────────────────────────────
 sqlite_backup() {
@@ -142,6 +158,7 @@ backup_sqlite() {
         return 0
     fi
     ARTIFACTS=$((ARTIFACTS + 1))
+    OK_LIST+="${name} "
     log "sqlite ok: ${src} -> ${out}"
 }
 
@@ -167,6 +184,7 @@ backup_dir() {
         return 0
     fi
     ARTIFACTS=$((ARTIFACTS + 1))
+    OK_LIST+="${name} "
     log "dir ok: ${src} -> ${out}"
 }
 
@@ -216,8 +234,23 @@ backup_session_file "/var/lib/idpshow-fetch/idpshow_session.json" "workdir.idpsh
 # nightly (missing data dir, broken tool) still created its dated dir,
 # displaced the oldest GOOD generation from the keep-window, and
 # eroded one good backup per day of consecutive failures.
-if (( ARTIFACTS == 0 )) || (( ERRORS > 0 )); then
-    warn "run FAILED (${ERRORS} error(s), ${ARTIFACTS} artifact(s)) — discarding staging snapshot; prior generations left untouched"
+# Required-artifact manifest: the artifact COUNT alone is not enough —
+# a misconfigured/unmounted DATA_DIR with a stray session JSON present
+# still yields ARTIFACTS>0, and promoting that partial snapshot would
+# let prune drop an older COMPLETE generation.  Every item named in
+# BACKUP_REQUIRED must have been written and verified.
+MISSING_REQUIRED=""
+for req in ${BACKUP_REQUIRED}; do
+    if [[ "${OK_LIST}" != *" ${req} "* ]]; then
+        MISSING_REQUIRED+="${req} "
+    fi
+done
+
+if (( ARTIFACTS == 0 )) || (( ERRORS > 0 )) || [[ -n "${MISSING_REQUIRED}" ]]; then
+    if [[ -n "${MISSING_REQUIRED}" ]]; then
+        warn "required artifact(s) missing from snapshot: ${MISSING_REQUIRED}(check DATA_DIR=${DATA_DIR})"
+    fi
+    warn "run FAILED (${ERRORS} error(s), ${ARTIFACTS} artifact(s), required-missing: ${MISSING_REQUIRED:-none}) — discarding staging snapshot; prior generations left untouched"
     rm -rf "${DEST}"
     exit 1
 fi

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -135,6 +135,23 @@ finally:
 PY
 }
 
+# PRAGMA integrity_check on the COPIED database.  gzip -t only proves
+# the compressed stream is intact — structural corruption that
+# Connection.backup() copies page-for-page passes it cleanly.  Exits
+# nonzero unless the check returns exactly "ok" (an unreadable /
+# not-a-database file raises and exits nonzero too).
+sqlite_integrity_ok() {
+    "${PYTHON_BIN}" - "$1" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+try:
+    rows = [str(r[0]) for r in con.execute("PRAGMA integrity_check")]
+finally:
+    con.close()
+sys.exit(0 if rows == ["ok"] else 1)
+PY
+}
+
 backup_sqlite() {
     local src="$1"
     local name
@@ -147,6 +164,12 @@ backup_sqlite() {
     local out="${tmp}.gz"
     if ! sqlite_backup "${src}" "${tmp}"; then
         warn "sqlite online backup FAILED: ${src}"
+        ERRORS=$((ERRORS + 1))
+        rm -f "${tmp}"
+        return 0
+    fi
+    if ! sqlite_integrity_ok "${tmp}" 2>/dev/null; then
+        warn "sqlite PRAGMA integrity_check FAILED on copied db: ${src} — source database is likely corrupt; artifact rejected"
         ERRORS=$((ERRORS + 1))
         rm -f "${tmp}"
         return 0

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -213,7 +213,10 @@ if [[ -n "${OFFBOX_RSYNC_DEST}" ]]; then
             ERRORS=$((ERRORS + 1))
         fi
     else
-        warn "OFFBOX_RSYNC_DEST set but rsync not installed — skipping mirror"
+        # The operator explicitly requested an off-box copy; a missing
+        # rsync must surface as a failed run, not a silent skip.
+        warn "OFFBOX_RSYNC_DEST set but rsync not installed — off-box mirror NOT performed"
+        ERRORS=$((ERRORS + 1))
     fi
 fi
 

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# riskit-state-backup.sh — nightly LOCAL backup of all irreplaceable
+# production state (everything that cannot be regenerated from the repo
+# or re-scraped):
+#
+#   * data/user_kv.sqlite        — user settings / watchlists / league prefs
+#   * data/session_store.sqlite  — login sessions
+#   * data/guest_passes.sqlite   — guest pass grants
+#   * data/public_league/        — public-league snapshots & identity
+#   * data/intel/                — intel artifacts (guarded: may not exist yet)
+#   * scraper session cookies    — dlf/draftsharks/idpshow *_session.json
+#     from the repo root and the /var/lib/{dlf,idpshow}-fetch work dirs.
+#     These are SECRETS: gitignored, manually provisioned (IDP Show's
+#     captcha-gated login can ONLY be restored by hand-pasting browser
+#     cookies).  They are backed up ON-BOX ONLY, mode 0600, and must
+#     never be committed to the repo or pushed anywhere public.
+#
+# SQLite files are copied with the online-backup primitive
+# (sqlite3.Connection.backup via the venv python — the sqlite3 CLI is
+# not installed on the box), so they are consistent even while the app
+# is writing (WAL).  Directories are tar.gz'd.  Every artifact gets an
+# integrity check (gzip -t / tar -tzf) before the run reports success.
+#
+# Layout: $BACKUP_ROOT/daily/YYYY-MM-DD/...
+# Rotation: keep the newest $KEEP_DAILY dated directories (default 14).
+#
+# Off-box mirroring (OPTIONAL, operator-configured): set
+# OFFBOX_RSYNC_DEST to an rsync destination (e.g.
+# "backup@storagebox.example:riskit-state/") in a drop-in on
+# riskit-state-backup.service.  When unset (default), the run is
+# local-only.  See deploy/backup/README.md.
+#
+# Relationship to deploy/backup_user_kv.sh (riskit-backup.timer): that
+# older job covers ONLY the three sqlite files but keeps 30 daily + 12
+# monthly generations.  This job is a superset per-night with 14-day
+# retention.  Keeping both enabled is safe (a few MB of duplicate
+# sqlite gz per night) and preserves the long/monthly sqlite history.
+#
+# Exit codes: 0 success, 1 hard failure (no backup written or integrity
+# check failed).  Unreadable OPTIONAL inputs (missing dirs, root-owned
+# session files when run unprivileged) are logged and skipped.
+
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
+DATA_DIR="${DATA_DIR:-${APP_DIR}/data}"
+BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/riskit-state}"
+BACKUP_FALLBACK_ROOT="${BACKUP_FALLBACK_ROOT:-/home/dynasty/backups/riskit-state}"
+KEEP_DAILY="${KEEP_DAILY:-14}"
+DATE_STAMP="$(date -u +%Y-%m-%d)"
+OFFBOX_RSYNC_DEST="${OFFBOX_RSYNC_DEST:-}"
+
+PYTHON_BIN="${PYTHON_BIN:-/home/dynasty/.venvs/trade-calculator/bin/python}"
+[[ -x "${PYTHON_BIN}" ]] || PYTHON_BIN="$(command -v python3 || true)"
+
+# Backups contain login-session secrets — never world/group readable.
+umask 077
+
+log()  { printf '[state-backup] %s\n' "$*"; }
+warn() { printf '[state-backup][WARN] %s\n' "$*" >&2; }
+fail() { printf '[state-backup][ERROR] %s\n' "$*" >&2; exit 1; }
+
+[[ -n "${PYTHON_BIN}" ]] || fail "no python interpreter available for sqlite online backup"
+
+# ── Destination (primary, then service-user fallback) ────────────────
+ensure_root() {
+    if mkdir -p "${BACKUP_ROOT}" 2>/dev/null && [[ -w "${BACKUP_ROOT}" ]]; then
+        return 0
+    fi
+    warn "primary backup root '${BACKUP_ROOT}' not writable, using fallback"
+    BACKUP_ROOT="${BACKUP_FALLBACK_ROOT}"
+    if mkdir -p "${BACKUP_ROOT}" 2>/dev/null && [[ -w "${BACKUP_ROOT}" ]]; then
+        return 0
+    fi
+    fail "neither primary nor fallback backup root writable"
+}
+ensure_root
+chmod 700 "${BACKUP_ROOT}" 2>/dev/null || true
+
+DEST="${BACKUP_ROOT}/daily/${DATE_STAMP}"
+mkdir -p "${DEST}/sqlite" "${DEST}/dirs" "${DEST}/sessions"
+
+ARTIFACTS=0
+ERRORS=0
+
+# ── SQLite (online, WAL-safe) ────────────────────────────────────────
+sqlite_backup() {
+    "${PYTHON_BIN}" - "$1" "$2" <<'PY'
+import sqlite3, sys
+src, dst = sys.argv[1], sys.argv[2]
+con = sqlite3.connect(src)
+try:
+    bck = sqlite3.connect(dst)
+    try:
+        with bck:
+            con.backup(bck)
+    finally:
+        bck.close()
+finally:
+    con.close()
+PY
+}
+
+backup_sqlite() {
+    local src="$1"
+    local name
+    name="$(basename "${src}")"
+    if [[ ! -f "${src}" ]]; then
+        log "skip sqlite (absent): ${src}"
+        return 0
+    fi
+    local tmp="${DEST}/sqlite/${name}"
+    local out="${tmp}.gz"
+    if ! sqlite_backup "${src}" "${tmp}"; then
+        warn "sqlite online backup FAILED: ${src}"
+        ERRORS=$((ERRORS + 1))
+        rm -f "${tmp}"
+        return 0
+    fi
+    gzip -f "${tmp}"
+    if ! gzip -t "${out}"; then
+        warn "integrity check FAILED: ${out}"
+        ERRORS=$((ERRORS + 1))
+        return 0
+    fi
+    ARTIFACTS=$((ARTIFACTS + 1))
+    log "sqlite ok: ${src} -> ${out}"
+}
+
+# ── Directories (tar.gz, guarded) ────────────────────────────────────
+backup_dir() {
+    local src="$1"
+    local name
+    name="$(basename "${src}")"
+    if [[ ! -d "${src}" ]]; then
+        log "skip dir (absent): ${src}"
+        return 0
+    fi
+    local out="${DEST}/dirs/${name}.tar.gz"
+    if ! tar -czf "${out}" -C "$(dirname "${src}")" "${name}"; then
+        warn "tar FAILED: ${src}"
+        ERRORS=$((ERRORS + 1))
+        rm -f "${out}"
+        return 0
+    fi
+    if ! tar -tzf "${out}" >/dev/null; then
+        warn "integrity check FAILED: ${out}"
+        ERRORS=$((ERRORS + 1))
+        return 0
+    fi
+    ARTIFACTS=$((ARTIFACTS + 1))
+    log "dir ok: ${src} -> ${out}"
+}
+
+# ── Scraper session cookie files (secrets — on-box only) ─────────────
+backup_session_file() {
+    local src="$1"
+    local label="$2"   # disambiguates repo copy vs /var/lib work-dir copy
+    if [[ ! -f "${src}" ]]; then
+        return 0
+    fi
+    if [[ ! -r "${src}" ]]; then
+        warn "session file present but unreadable (run as root to include): ${src}"
+        return 0
+    fi
+    local out="${DEST}/sessions/${label}"
+    if cp -f "${src}" "${out}"; then
+        chmod 600 "${out}"
+        ARTIFACTS=$((ARTIFACTS + 1))
+        log "session ok: ${src} -> ${out}"
+    else
+        warn "session copy FAILED: ${src}"
+        ERRORS=$((ERRORS + 1))
+    fi
+}
+
+backup_sqlite "${DATA_DIR}/user_kv.sqlite"
+backup_sqlite "${DATA_DIR}/session_store.sqlite"
+backup_sqlite "${DATA_DIR}/guest_passes.sqlite"
+
+backup_dir "${DATA_DIR}/public_league"
+backup_dir "${DATA_DIR}/intel"
+
+# Repo-root session files (gitignored via "*_session.json").
+backup_session_file "${APP_DIR}/dlf_session.json"         "repo.dlf_session.json"
+backup_session_file "${APP_DIR}/draftsharks_session.json" "repo.draftsharks_session.json"
+backup_session_file "${APP_DIR}/idpshow_session.json"     "repo.idpshow_session.json"
+# Fetcher work-dir copies (see deploy/dlf_fetch_and_push.sh /
+# deploy/idpshow_fetch_and_push.sh).
+backup_session_file "/var/lib/dlf-fetch/dlf_session.json"         "workdir.dlf_session.json"
+backup_session_file "/var/lib/idpshow-fetch/idpshow_session.json" "workdir.idpshow_session.json"
+
+# ── Rotation: keep newest $KEEP_DAILY dated dirs ─────────────────────
+prune() {
+    local dir
+    # Dated names sort lexicographically == chronologically.
+    while IFS= read -r dir; do
+        [[ -n "${dir}" ]] || continue
+        log "prune: ${BACKUP_ROOT}/daily/${dir}"
+        rm -rf "${BACKUP_ROOT:?}/daily/${dir}"
+    done < <(ls -1 "${BACKUP_ROOT}/daily" 2>/dev/null | sort | head -n -"${KEEP_DAILY}")
+}
+prune
+
+# ── Optional off-box mirror (operator opt-in) ────────────────────────
+if [[ -n "${OFFBOX_RSYNC_DEST}" ]]; then
+    if command -v rsync >/dev/null 2>&1; then
+        if rsync -a --delete "${BACKUP_ROOT}/daily/" "${OFFBOX_RSYNC_DEST}"; then
+            log "off-box mirror ok: ${OFFBOX_RSYNC_DEST}"
+        else
+            warn "off-box mirror FAILED (local backup unaffected)"
+            ERRORS=$((ERRORS + 1))
+        fi
+    else
+        warn "OFFBOX_RSYNC_DEST set but rsync not installed — skipping mirror"
+    fi
+fi
+
+if (( ARTIFACTS == 0 )); then
+    fail "no artifacts written — nothing was backed up"
+fi
+if (( ERRORS > 0 )); then
+    warn "completed with ${ERRORS} error(s), ${ARTIFACTS} artifact(s) written to ${DEST}"
+    exit 1
+fi
+log "state backup complete: ${ARTIFACTS} artifact(s) in ${DEST} ($(date -u +%FT%TZ))"

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -25,6 +25,12 @@
 # Layout: $BACKUP_ROOT/daily/YYYY-MM-DD/...
 # Rotation: keep the newest $KEEP_DAILY dated directories (default 14).
 #
+# Operation order (destructive steps strictly last):
+#   write artifacts into a hidden staging dir → integrity checks →
+#   FAILURE: discard staging, exit 1 (daily/ namespace untouched) |
+#   SUCCESS: promote staging → dated dir → off-box mirror (validated
+#   snapshots only) → prune oldest generations beyond $KEEP_DAILY.
+#
 # Off-box mirroring (OPTIONAL, operator-configured): set
 # OFFBOX_RSYNC_DEST to an rsync destination (e.g.
 # "backup@storagebox.example:riskit-state/") in a drop-in on
@@ -78,8 +84,19 @@ ensure_root() {
 ensure_root
 chmod 700 "${BACKUP_ROOT}" 2>/dev/null || true
 
-DEST="${BACKUP_ROOT}/daily/${DATE_STAMP}"
+# Stage the snapshot in a hidden dir and promote it to the dated slot
+# only after validation.  A failed run therefore never appears in the
+# daily/ namespace at all: it cannot displace an old generation from
+# the prune keep-window, and a failed same-day RERUN cannot clobber
+# that day's earlier good snapshot.  (Dot-prefixed names are invisible
+# to prune's `ls -1` and sort out of the retention math entirely.)
+FINAL_DEST="${BACKUP_ROOT}/daily/${DATE_STAMP}"
+DEST="${BACKUP_ROOT}/daily/.staging-${DATE_STAMP}-$$"
 mkdir -p "${DEST}/sqlite" "${DEST}/dirs" "${DEST}/sessions"
+
+# Clear stale staging dirs from previous crashed runs (>1 day old).
+find "${BACKUP_ROOT}/daily" -maxdepth 1 -name '.staging-*' -mtime +1 \
+    -exec rm -rf {} + 2>/dev/null || true
 
 ARTIFACTS=0
 ERRORS=0
@@ -191,7 +208,53 @@ backup_session_file "${APP_DIR}/idpshow_session.json"     "repo.idpshow_session.
 backup_session_file "/var/lib/dlf-fetch/dlf_session.json"         "workdir.dlf_session.json"
 backup_session_file "/var/lib/idpshow-fetch/idpshow_session.json" "workdir.idpshow_session.json"
 
+# ── Validate this run BEFORE any destructive step ────────────────────
+# Ordering is deliberate: write artifacts into staging → integrity
+# checks (above) → on failure discard the staging dir and stop → only
+# a fully validated snapshot is promoted, mirrored, or allowed to
+# trigger pruning.  The original ordering pruned first, so a failing
+# nightly (missing data dir, broken tool) still created its dated dir,
+# displaced the oldest GOOD generation from the keep-window, and
+# eroded one good backup per day of consecutive failures.
+if (( ARTIFACTS == 0 )) || (( ERRORS > 0 )); then
+    warn "run FAILED (${ERRORS} error(s), ${ARTIFACTS} artifact(s)) — discarding staging snapshot; prior generations left untouched"
+    rm -rf "${DEST}"
+    exit 1
+fi
+
+# Promote: replace any earlier same-day snapshot only now that this
+# one is fully validated.
+rm -rf "${FINAL_DEST}"
+mv "${DEST}" "${FINAL_DEST}"
+DEST="${FINAL_DEST}"
+log "snapshot promoted: ${FINAL_DEST}"
+
+# ── Optional off-box mirror (operator opt-in) ────────────────────────
+# Reached only with every artifact written and integrity-checked, so a
+# partial/corrupt snapshot can never replace the off-box copy (rsync
+# --delete makes a bad publish doubly destructive remotely).
+MIRROR_FAILED=0
+if [[ -n "${OFFBOX_RSYNC_DEST}" ]]; then
+    if command -v rsync >/dev/null 2>&1; then
+        if rsync -a --delete "${BACKUP_ROOT}/daily/" "${OFFBOX_RSYNC_DEST}"; then
+            log "off-box mirror ok: ${OFFBOX_RSYNC_DEST}"
+        else
+            warn "off-box mirror FAILED (local backup unaffected)"
+            MIRROR_FAILED=1
+        fi
+    else
+        # The operator explicitly requested an off-box copy; a missing
+        # rsync must surface as a failed run, not a silent skip.
+        warn "OFFBOX_RSYNC_DEST set but rsync not installed — off-box mirror NOT performed"
+        MIRROR_FAILED=1
+    fi
+fi
+
 # ── Rotation: keep newest $KEEP_DAILY dated dirs ─────────────────────
+# Runs last, and only after this run added a verified generation, so
+# the keep-window always counts today's GOOD snapshot — never a failed
+# stub.  (Safe even when the mirror failed above: the local snapshot
+# is validated either way.)
 prune() {
     local dir
     # Dated names sort lexicographically == chronologically.
@@ -203,28 +266,8 @@ prune() {
 }
 prune
 
-# ── Optional off-box mirror (operator opt-in) ────────────────────────
-if [[ -n "${OFFBOX_RSYNC_DEST}" ]]; then
-    if command -v rsync >/dev/null 2>&1; then
-        if rsync -a --delete "${BACKUP_ROOT}/daily/" "${OFFBOX_RSYNC_DEST}"; then
-            log "off-box mirror ok: ${OFFBOX_RSYNC_DEST}"
-        else
-            warn "off-box mirror FAILED (local backup unaffected)"
-            ERRORS=$((ERRORS + 1))
-        fi
-    else
-        # The operator explicitly requested an off-box copy; a missing
-        # rsync must surface as a failed run, not a silent skip.
-        warn "OFFBOX_RSYNC_DEST set but rsync not installed — off-box mirror NOT performed"
-        ERRORS=$((ERRORS + 1))
-    fi
-fi
-
-if (( ARTIFACTS == 0 )); then
-    fail "no artifacts written — nothing was backed up"
-fi
-if (( ERRORS > 0 )); then
-    warn "completed with ${ERRORS} error(s), ${ARTIFACTS} artifact(s) written to ${DEST}"
+if (( MIRROR_FAILED )); then
+    warn "completed locally (${ARTIFACTS} artifact(s) in ${DEST}) but off-box mirror failed"
     exit 1
 fi
 log "state backup complete: ${ARTIFACTS} artifact(s) in ${DEST} ($(date -u +%FT%TZ))"

--- a/deploy/backup/riskit-state-backup.timer
+++ b/deploy/backup/riskit-state-backup.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Nightly Risk It state backup trigger
+Requires=riskit-state-backup.service
+
+[Timer]
+# 02:30 UTC daily — offset from riskit-backup.timer (02:00) so the two
+# backup jobs never contend for I/O.  Persistent=true replays a run
+# missed while the box was down.
+OnCalendar=*-*-* 02:30:00 UTC
+Persistent=true
+AccuracySec=5min
+
+[Install]
+WantedBy=timers.target

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -53,6 +53,15 @@ Environment="NOTIFY_WEBHOOK_URL=https://ntfy.sh/<your-private-topic>"
 #Environment="NOTIFY_CMD=mail -s riskit-alert you@example.com"
 ```
 
+## Privileges
+
+The probe runs as `User=dynasty` — it only curls and logs, so it gets
+no root.  It executes from the checkout, which is safe precisely
+because the process has no more privilege than the user who can edit
+that file.  The log still lands in `/var/log/riskit-uptime.log`
+because systemd opens the `StandardOutput=append:` target as root
+before dropping to `User=`; run-to-run state lives in `/var/tmp`.
+
 ## Known limitation
 
 The probe runs **on the VPS itself**.  It catches nginx, TLS, backend,

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -1,0 +1,70 @@
+# deploy/monitoring — lightweight uptime monitoring
+
+A single probe script + systemd timer.  No third-party services; the
+probe is log-only until the operator opts in to a notification channel.
+
+## What it checks (every 5 minutes)
+
+1. `https://riskittogetthebrisket.org/api/health` — full external path:
+   DNS → TLS → nginx → FastAPI backend.
+2. `https://riskittogetthebrisket.org/` — nginx → Next.js frontend.
+3. `http://127.0.0.1:8000/api/health` — backend direct (distinguishes
+   "backend down" from "nginx/TLS broken"); disable with
+   `CHECK_LOCAL=false`.
+
+One line per run appended to `/var/log/riskit-uptime.log`:
+
+```
+2026-07-26T02:35:00Z UP public-health=ok(200,0.142s) public-frontend=ok(200,0.375s) local-backend=ok(200,0.009s)
+2026-07-26T02:40:01Z DOWN public-health=FAIL(502) public-frontend=ok(200,0.298s) local-backend=FAIL(000)
+```
+
+Add the log to rotation by appending `/var/log/riskit-uptime.log` to
+the file list in `deploy/logrotate.conf` if it grows past comfort
+(~30 KB/month at 5-minute cadence — rotation is optional).
+
+## Install
+
+```bash
+sudo cp deploy/monitoring/riskit-uptime.service deploy/monitoring/riskit-uptime.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now riskit-uptime.timer
+systemctl list-timers riskit-uptime.timer
+```
+
+(`deploy/apply_hardening.sh` does this idempotently.)  Cron works too:
+
+```
+*/5 * * * * /home/dynasty/trade-calculator/deploy/monitoring/uptime_check.sh
+```
+
+## Notifications (optional, operator's choice)
+
+The probe notifies only on **state changes** (UP→DOWN, DOWN→UP), so a
+3-hour outage is one alert, not 36.  Nothing external is contacted
+until you set one of these via `sudo systemctl edit riskit-uptime.service`:
+
+```ini
+[Service]
+# Any URL that accepts a plain-text POST — a private ntfy.sh topic,
+# a Slack/Discord incoming-webhook wrapper, a self-hosted gotify, ...
+Environment="NOTIFY_WEBHOOK_URL=https://ntfy.sh/<your-private-topic>"
+# ...or any command that reads the message on stdin:
+#Environment="NOTIFY_CMD=mail -s riskit-alert you@example.com"
+```
+
+## Known limitation
+
+The probe runs **on the VPS itself**.  It catches nginx, TLS, backend,
+and frontend failures, but a full network partition or a dead box also
+kills the prober.  If that matters, run the same script from any second
+machine (`SITE_URL=... CHECK_LOCAL=false LOG_FILE=... uptime_check.sh`
+from cron) — it has no dependencies beyond bash + curl.
+
+## Relationship to other health tooling
+
+- `deploy/systemd/dynasty-healthcheck.*` (every 1 min) is the
+  **actuator**: it restarts the backend after 3 consecutive local
+  failures.  This probe is the **observer** and never restarts anything.
+- `deploy/verify-deploy.sh` is deploy-time verification only.
+- `deploy/grafana/` visualizes public-league metrics, not uptime.

--- a/deploy/monitoring/riskit-uptime.service
+++ b/deploy/monitoring/riskit-uptime.service
@@ -5,7 +5,24 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+# SECURITY: the probe only curls and writes a log line — it needs no
+# privileges, so it runs as the deploy user (least privilege; a probe
+# running as root while executing a deploy-user-writable script would
+# be a privilege-escalation path).  Running the checkout copy is fine
+# HERE precisely because the process has no more privilege than the
+# user who can already edit that copy.
+User=dynasty
+Group=dynasty
 ExecStart=/home/dynasty/trade-calculator/deploy/monitoring/uptime_check.sh
+# systemd (pid 1) opens the append target as root before dropping to
+# User=, so the unprivileged probe still lands in /var/log.  The
+# script's own LOG_FILE points at stdout; its unwritable-fallback also
+# prints to stdout, so every line reaches the file either way.
+StandardOutput=append:/var/log/riskit-uptime.log
+StandardError=append:/var/log/riskit-uptime.log
+Environment="LOG_FILE=/dev/stdout"
+# State must live somewhere the deploy user can write.
+Environment="STATE_FILE=/var/tmp/riskit-uptime.state"
 # The probe is log-only by default.  To enable notifications, add a
 # drop-in (`systemctl edit riskit-uptime.service`):
 #   [Service]

--- a/deploy/monitoring/riskit-uptime.service
+++ b/deploy/monitoring/riskit-uptime.service
@@ -12,6 +12,10 @@ ExecStart=/home/dynasty/trade-calculator/deploy/monitoring/uptime_check.sh
 #   Environment="NOTIFY_WEBHOOK_URL=https://ntfy.sh/<your-private-topic>"
 # or
 #   Environment="NOTIFY_CMD=mail -s riskit-alert you@example.com"
+# Runtime budget: the script runs at most 3 probes x CURL_TIMEOUT (20s
+# default) = 60s worst case, single curl per endpoint.  90s leaves
+# margin; if you raise CURL_TIMEOUT via drop-in, raise this to keep
+# 3 x CURL_TIMEOUT + 10s <= TimeoutStartSec.
 TimeoutStartSec=90
 Nice=10
 # The probe exits 1 while the site is down — that is signal, not a unit

--- a/deploy/monitoring/riskit-uptime.service
+++ b/deploy/monitoring/riskit-uptime.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Risk It uptime probe (public site + local backend)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/dynasty/trade-calculator/deploy/monitoring/uptime_check.sh
+# The probe is log-only by default.  To enable notifications, add a
+# drop-in (`systemctl edit riskit-uptime.service`):
+#   [Service]
+#   Environment="NOTIFY_WEBHOOK_URL=https://ntfy.sh/<your-private-topic>"
+# or
+#   Environment="NOTIFY_CMD=mail -s riskit-alert you@example.com"
+TimeoutStartSec=90
+Nice=10
+# The probe exits 1 while the site is down — that is signal, not a unit
+# failure worth systemd's failed-state bookkeeping between runs.
+SuccessExitStatus=0 1
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/monitoring/riskit-uptime.timer
+++ b/deploy/monitoring/riskit-uptime.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Risk It uptime probe every 5 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target

--- a/deploy/monitoring/uptime_check.sh
+++ b/deploy/monitoring/uptime_check.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# uptime_check.sh — lightweight external-path uptime probe.
+#
+# Checks the PUBLIC endpoints (through nginx + TLS, i.e. the same path
+# a user takes) plus the local backend port, logs one line per run, and
+# optionally notifies on STATE CHANGES (up→down, down→up) so a sustained
+# outage produces one alert, not one per probe.
+#
+# Fired every 5 minutes by riskit-uptime.timer (or from cron:
+#   */5 * * * * /home/dynasty/trade-calculator/deploy/monitoring/uptime_check.sh
+# ).
+#
+# NOTE: running on the VPS itself, this catches nginx/TLS/backend/
+# frontend failures but NOT a network partition or a dead box — true
+# external monitoring needs a second vantage point (documented in
+# deploy/monitoring/README.md; no third-party service is wired in).
+#
+# Env overrides (drop-in on riskit-uptime.service, or cron env):
+#   SITE_URL            default https://riskittogetthebrisket.org
+#   CHECK_LOCAL         default true   (also probe 127.0.0.1:8000 directly)
+#   LOG_FILE            default /var/log/riskit-uptime.log
+#                        (falls back to stdout if unwritable)
+#   STATE_FILE          default /var/tmp/riskit-uptime.state
+#   CURL_TIMEOUT        default 20 (seconds per probe)
+#   NOTIFY_WEBHOOK_URL  default unset — OPTIONAL operator-provided URL
+#                        that accepts a POST with a text body (ntfy topic,
+#                        Slack/Discord webhook wrapper, etc.).  Unset =
+#                        log-only, nothing external is contacted.
+#   NOTIFY_CMD          default unset — alternative to the webhook: a
+#                        command that receives the message on stdin
+#                        (e.g. "mail -s riskit-alert ops@example.com").
+#
+# Exit code: 0 all checks passed, 1 otherwise.
+
+set -Eeuo pipefail
+
+SITE_URL="${SITE_URL:-https://riskittogetthebrisket.org}"
+CHECK_LOCAL="${CHECK_LOCAL:-true}"
+LOG_FILE="${LOG_FILE:-/var/log/riskit-uptime.log}"
+STATE_FILE="${STATE_FILE:-/var/tmp/riskit-uptime.state}"
+CURL_TIMEOUT="${CURL_TIMEOUT:-20}"
+NOTIFY_WEBHOOK_URL="${NOTIFY_WEBHOOK_URL:-}"
+NOTIFY_CMD="${NOTIFY_CMD:-}"
+
+NOW="$(date -u +%FT%TZ)"
+RESULTS=()
+FAILED=0
+
+logline() {
+    local line="$1"
+    if [[ -w "${LOG_FILE}" ]] || { [[ ! -e "${LOG_FILE}" ]] && touch "${LOG_FILE}" 2>/dev/null; }; then
+        printf '%s\n' "${line}" >> "${LOG_FILE}"
+    else
+        printf '%s\n' "${line}"
+    fi
+}
+
+# probe <label> <url>  — records "label=CODE/SECONDS" and tracks failure.
+probe() {
+    local label="$1" url="$2"
+    local out code secs
+    if out="$(curl -fsS -o /dev/null --max-time "${CURL_TIMEOUT}" \
+                  -w '%{http_code}/%{time_total}' "${url}" 2>/dev/null)"; then
+        code="${out%%/*}"
+        secs="${out##*/}"
+        RESULTS+=("${label}=ok(${code},${secs}s)")
+    else
+        # curl prints http_code 000 on connection failure while ALSO
+        # exiting non-zero, so capture with `|| true` and default after.
+        code="$(curl -s -o /dev/null --max-time "${CURL_TIMEOUT}" -w '%{http_code}' "${url}" 2>/dev/null || true)"
+        RESULTS+=("${label}=FAIL(${code:-000})")
+        FAILED=1
+    fi
+}
+
+probe "public-health"   "${SITE_URL}/api/health"
+probe "public-frontend" "${SITE_URL}/"
+if [[ "${CHECK_LOCAL}" == "true" ]]; then
+    probe "local-backend" "http://127.0.0.1:8000/api/health"
+fi
+
+STATUS="UP"
+(( FAILED == 0 )) || STATUS="DOWN"
+LINE="${NOW} ${STATUS} ${RESULTS[*]}"
+logline "${LINE}"
+
+# ── State-change notification (optional, operator-configured) ────────
+PREV="$(cat "${STATE_FILE}" 2>/dev/null || echo UP)"
+printf '%s\n' "${STATUS}" > "${STATE_FILE}" 2>/dev/null || true
+
+notify() {
+    local msg="$1"
+    if [[ -n "${NOTIFY_WEBHOOK_URL}" ]]; then
+        curl -fsS --max-time 10 -X POST -d "${msg}" "${NOTIFY_WEBHOOK_URL}" >/dev/null 2>&1 \
+            || logline "${NOW} WARN notify-webhook failed"
+    fi
+    if [[ -n "${NOTIFY_CMD}" ]]; then
+        printf '%s\n' "${msg}" | ${NOTIFY_CMD} >/dev/null 2>&1 \
+            || logline "${NOW} WARN notify-cmd failed"
+    fi
+}
+
+if [[ "${STATUS}" != "${PREV}" ]]; then
+    notify "[riskit-uptime] ${PREV} -> ${STATUS} at ${NOW}: ${RESULTS[*]}"
+fi
+
+exit "${FAILED}"

--- a/deploy/monitoring/uptime_check.sh
+++ b/deploy/monitoring/uptime_check.sh
@@ -57,18 +57,25 @@ logline() {
 }
 
 # probe <label> <url>  — records "label=CODE/SECONDS" and tracks failure.
+# Exactly ONE curl per endpoint: -w output is emitted even when curl
+# exits non-zero (000/0.000 on connection failure, the real HTTP code
+# on -f HTTP errors), and the `out=$(...)` assignment keeps that stdout
+# regardless of exit status.  A second "get the code" probe would
+# double the worst-case runtime — with three hung endpoints that blew
+# past the unit's TimeoutStartSec and systemd killed the run before it
+# could record DOWN.  Budget: 3 probes x CURL_TIMEOUT(20s) = 60s worst
+# case, inside riskit-uptime.service's TimeoutStartSec=90 with margin.
+# If you raise CURL_TIMEOUT, keep 3 x CURL_TIMEOUT + 10s <= TimeoutStartSec.
 probe() {
     local label="$1" url="$2"
-    local out code secs
-    if out="$(curl -fsS -o /dev/null --max-time "${CURL_TIMEOUT}" \
-                  -w '%{http_code}/%{time_total}' "${url}" 2>/dev/null)"; then
-        code="${out%%/*}"
-        secs="${out##*/}"
+    local out code secs rc=0
+    out="$(curl -fsS -o /dev/null --max-time "${CURL_TIMEOUT}" \
+               -w '%{http_code}/%{time_total}' "${url}" 2>/dev/null)" || rc=$?
+    code="${out%%/*}"
+    secs="${out##*/}"
+    if (( rc == 0 )); then
         RESULTS+=("${label}=ok(${code},${secs}s)")
     else
-        # curl prints http_code 000 on connection failure while ALSO
-        # exiting non-zero, so capture with `|| true` and default after.
-        code="$(curl -s -o /dev/null --max-time "${CURL_TIMEOUT}" -w '%{http_code}' "${url}" 2>/dev/null || true)"
         RESULTS+=("${label}=FAIL(${code:-000})")
         FAILED=1
     fi

--- a/deploy/nginx/riskittogetthebrisket.org.conf
+++ b/deploy/nginx/riskittogetthebrisket.org.conf
@@ -3,7 +3,8 @@
 #
 # Routing:
 #   /api/*          → Python backend (127.0.0.1:8000)
-#   /_next/*        → Next.js (127.0.0.1:3000)  — static assets
+#   /_next/static/* → Next.js (127.0.0.1:3000)  — immutable hashed assets (nginx-cached)
+#   /_next/*        → Next.js (127.0.0.1:3000)  — other framework routes
 #   /favicon.ico    → Next.js (127.0.0.1:3000)
 #   /*              → Next.js (127.0.0.1:3000)  — pages
 #
@@ -13,6 +14,30 @@
 #   sudo cp deploy/nginx/riskittogetthebrisket.org.conf /etc/nginx/sites-available/riskittogetthebrisket.org
 #   sudo ln -sf /etc/nginx/sites-available/riskittogetthebrisket.org /etc/nginx/sites-enabled/
 #   sudo nginx -t && sudo systemctl reload nginx
+#
+# (or run deploy/apply_hardening.sh, which diffs + validates + reloads.)
+#
+# Hardening notes (see docs/PROD-HARDENING.md for full rationale):
+#   * HTTP/2 enabled via `listen 443 ssl http2;`.  This spelling works on
+#     nginx 1.9.5+ including the 1.24.x shipped by Ubuntu LTS.  On
+#     nginx >= 1.25.1 it still works but logs a deprecation warning at
+#     `nginx -t`; the modern spelling is a separate `http2 on;` directive.
+#   * gzip is a fallback layer: the FastAPI backend already gzips
+#     responses >= 1 KB (GZipMiddleware) and pre-gzips the /api/data
+#     contract.  nginx never re-compresses responses that arrive with
+#     Content-Encoding set, so enabling gzip here only picks up whatever
+#     the upstreams left uncompressed (Next.js pages when its built-in
+#     compression is off, JSON error bodies, svg icons, etc.).
+#   * Cache-Control pass-through: the backend stamps privacy-sensitive
+#     caching headers per endpoint ("private, max-age=...", "no-store").
+#     Nothing here adds, hides, or overrides Cache-Control on proxied
+#     responses — proxy_pass forwards upstream headers untouched, and no
+#     location block uses `add_header Cache-Control` / `expires`.
+#   * Security headers are declared ONCE at server level with `always`.
+#     Do not add `add_header` inside a location block: nginx's add_header
+#     inheritance is all-or-nothing, so a single location-level add_header
+#     would silently drop every server-level security header for that
+#     location.
 
 # WebSocket upgrade map (must be at http level, before server blocks)
 map $http_upgrade $connection_upgrade {
@@ -20,24 +45,50 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+# Local cache for Next.js immutable build assets (/_next/static/*).
+# PRIVACY SCOPE: this is the ONLY shared cache in this config and it is
+# attached ONLY to the /_next/static/ location — never to /api/*.
+# tests/api/test_cache_control_privacy.py documents the invariant that
+# auth-gated endpoints must not meet a shared cache; /api responses
+# continue to pass through uncached with their app-stamped
+# "private"/"no-store" Cache-Control intact.  (nginx additionally
+# refuses to cache responses carrying Set-Cookie or Cache-Control:
+# private/no-store by default.)
+# Filenames are content-hashed, and Next.js serves them with
+# "Cache-Control: public, max-age=31536000, immutable" — nginx honors
+# those upstream headers, so entries are safe to hold for a long time
+# and repeated asset hits stop touching the node process entirely.
+# 50 MB is comfortably larger than a full .next/static build.
+proxy_cache_path /var/cache/nginx/riskit_static
+                 levels=1:2
+                 keys_zone=riskit_static:10m
+                 max_size=50m
+                 inactive=7d
+                 use_temp_path=off;
+
 upstream backend {
     server 127.0.0.1:8000;
-    keepalive 4;
+    keepalive 8;
 }
 
 upstream frontend {
     server 127.0.0.1:3000;
-    keepalive 4;
+    # HTTP/2 multiplexing fans a single page load out into many parallel
+    # asset requests; a slightly deeper idle-connection pool avoids TCP
+    # handshake churn to the node process.
+    keepalive 16;
 }
 
 server {
     listen 80;
+    listen [::]:80;
     server_name riskittogetthebrisket.org www.riskittogetthebrisket.org;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name riskittogetthebrisket.org www.riskittogetthebrisket.org;
 
     # TLS — managed by certbot (paths may vary; adjust if different)
@@ -46,7 +97,68 @@ server {
     include             /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 
-    # --- API routes → Python backend ---
+    # ── Security headers ─────────────────────────────────────────────
+    # `always` so they are attached to error responses (401/404/5xx) too.
+    #
+    # HSTS: 1 year, no includeSubDomains / no preload yet.  The apex +
+    # www are both served by this block; add "includeSubDomains" only
+    # after confirming every current & future subdomain of
+    # riskittogetthebrisket.org serves valid TLS (HSTS mistakes lock
+    # browsers out for max-age seconds).
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    # Clickjacking: frame-ancestors is the modern control and is safe to
+    # ENFORCE — it only restricts who may embed this site in a frame and
+    # has zero effect on the app's own scripts/styles.  X-Frame-Options
+    # is the legacy fallback for old browsers.
+    add_header Content-Security-Policy "frame-ancestors 'self'" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
+    # A FULL enforced CSP is intentionally NOT shipped.  Next.js 15 App
+    # Router hydration emits inline <script> chunks (self.__next_f
+    # pushes) without nonces, and the app has no nonce plumbing, so an
+    # enforced script-src would require 'unsafe-inline' (defeating most
+    # of the point) or an app-code change (out of scope for a deploy/
+    # only change).  To gather real violation data before ever
+    # enforcing, uncomment the Report-Only header below and watch the
+    # browser console / a report endpoint.  Known external origins:
+    # sleepercdn.com player headshots (img-src).  The service worker
+    # (frontend/public/sw.js) needs worker-src 'self'.
+    #add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://sleepercdn.com; font-src 'self' data:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+
+    # ── Compression (fallback layer — see header note) ───────────────
+    gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types
+        application/json
+        application/javascript
+        application/manifest+json
+        application/xml
+        image/svg+xml
+        text/css
+        text/plain
+        text/xml;
+
+    # Brotli: only if the ngx_brotli dynamic modules are installed
+    # (Ubuntu: `apt install libnginx-mod-http-brotli-filter
+    # libnginx-mod-http-brotli-static`, which drops load_module snippets
+    # into /etc/nginx/modules-enabled/).  Uncomment AFTER installing the
+    # module — with the module absent these directives fail `nginx -t`.
+    #brotli on;
+    #brotli_comp_level 5;
+    #brotli_min_length 1024;
+    #brotli_types application/json application/javascript application/manifest+json application/xml image/svg+xml text/css text/plain text/xml;
+
+    # POST bodies here are small (trade payloads, override maps); 10m is
+    # generous headroom without allowing arbitrary uploads.
+    client_max_body_size 10m;
+
+    # ── API routes → Python backend ──────────────────────────────────
     location /api/ {
         proxy_pass http://backend;
         proxy_http_version 1.1;
@@ -58,10 +170,42 @@ server {
         # Scrape cycles rebuild the in-memory cache and can hold /api/data
         # for up to ~3 minutes; 30s would surface a 504 on the Settings /
         # Rankings page every time a scheduled refresh lands on the user.
+        # Cold /api/news aggregation (~10s) also fits comfortably here.
         proxy_read_timeout 120s;
+        # Fail fast when the backend process is down instead of hanging
+        # a browser tab for the default 60s.
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 30s;
+        # The /api/data contract is MB-scale even after upstream gzip
+        # (~100-400 KB on the wire, up to ~4 MB if a client requests
+        # identity encoding).  Larger in-memory buffers keep nginx from
+        # spilling those responses to disk temp files mid-transfer.
+        proxy_buffers 32 16k;
+        proxy_busy_buffers_size 64k;
     }
 
-    # --- Next.js static assets → frontend ---
+    # ── Next.js immutable build assets → nginx cache → frontend ─────
+    # Content-hashed filenames; upstream stamps
+    # "public, max-age=31536000, immutable" and nginx passes that
+    # through untouched (no expires/add_header here — see header note).
+    # proxy_cache obeys the upstream Cache-Control for entry lifetime.
+    location /_next/static/ {
+        proxy_pass http://frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection        "";
+        proxy_cache riskit_static;
+        proxy_cache_valid 200 7d;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock on;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+    }
+
+    # ── Other Next.js framework routes (/_next/image, /_next/data) ──
     location /_next/ {
         proxy_pass http://frontend;
         proxy_http_version 1.1;
@@ -70,16 +214,21 @@ server {
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection        "";
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
     }
 
-    # --- Favicon → frontend ---
+    # ── Favicon → frontend ───────────────────────────────────────────
     location = /favicon.ico {
         proxy_pass http://frontend;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection        "";
+        proxy_connect_timeout 5s;
     }
 
-    # --- Everything else → Next.js pages ---
+    # ── Everything else → Next.js pages ──────────────────────────────
     location / {
         proxy_pass http://frontend;
         proxy_http_version 1.1;
@@ -89,5 +238,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Upgrade           $http_upgrade;
         proxy_set_header Connection        $connection_upgrade;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 75s;
     }
 }

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -26,7 +26,7 @@ systemctl list-timers riskit-*
 |---|---|---|
 | `riskit-backup.service`+ `.timer` | Nightly online SQLite backup of user_kv + session_store | Daily 02:00 UTC |
 | `riskit-backup-restore-test.service` + `.timer` | Integrity check of the latest backup | Weekly Mon 03:30 UTC |
-| `dynasty-healthcheck.service` + `.timer` + `.sh` | Backend watchdog: probes `/api/health`, restarts `dynasty` after 3 consecutive failures | Every 1 min |
+| `dynasty-healthcheck.service` + `.timer` + `.sh` | Backend LIVENESS watchdog: probes `/api/health`, restarts `dynasty` after 3 consecutive no-response probes; app-degraded 503s (stale data / failed scrape) are log-only and never restart | Every 1 min |
 
 Related units living elsewhere in deploy/:
 

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -37,6 +37,15 @@ Related units living elsewhere in deploy/:
 `deploy/apply_hardening.sh` installs/refreshes all of the above
 idempotently (see docs/PROD-HARDENING.md).
 
+**Root-run scripts execute from `/usr/local/lib/riskit/`, not the
+checkout.**  `dynasty-healthcheck.sh` and
+`deploy/backup/riskit-state-backup.sh` run as root, so the apply
+script installs root:root 0755 copies outside the deploy-user-writable
+repo and the units point there — a root unit executing a
+checkout-writable file would let a compromised deploy account escalate
+to root.  Re-run the apply script to roll out script changes; the
+repo copies are the source of truth but are inert at runtime.
+
 `dynasty.service.template` / `dynasty-frontend.service.template` are
 rendered (placeholder substitution) by `deploy/install-systemd-service.sh`
 — do not copy them into /etc/systemd/system verbatim.

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -10,6 +10,7 @@ sudo systemctl daemon-reload
 # Enable + start the timers (the .service units are triggered by them).
 sudo systemctl enable --now riskit-backup.timer
 sudo systemctl enable --now riskit-backup-restore-test.timer
+sudo systemctl enable --now dynasty-healthcheck.timer
 
 # Optional: logrotate (uses Linux's own logrotate cron, NOT a timer here).
 sudo cp deploy/logrotate.conf /etc/logrotate.d/riskit
@@ -25,6 +26,20 @@ systemctl list-timers riskit-*
 |---|---|---|
 | `riskit-backup.service`+ `.timer` | Nightly online SQLite backup of user_kv + session_store | Daily 02:00 UTC |
 | `riskit-backup-restore-test.service` + `.timer` | Integrity check of the latest backup | Weekly Mon 03:30 UTC |
+| `dynasty-healthcheck.service` + `.timer` + `.sh` | Backend watchdog: probes `/api/health`, restarts `dynasty` after 3 consecutive failures | Every 1 min |
+
+Related units living elsewhere in deploy/:
+
+- `deploy/backup/riskit-state-backup.*` — nightly full-state backup
+  (sqlite + public_league/ + intel/ + scraper session secrets), 02:30 UTC.
+- `deploy/monitoring/riskit-uptime.*` — public-URL uptime probe, 5 min.
+
+`deploy/apply_hardening.sh` installs/refreshes all of the above
+idempotently (see docs/PROD-HARDENING.md).
+
+`dynasty.service.template` / `dynasty-frontend.service.template` are
+rendered (placeholder substitution) by `deploy/install-systemd-service.sh`
+— do not copy them into /etc/systemd/system verbatim.
 
 ## Manual runs
 

--- a/deploy/systemd/dynasty-frontend.service.template
+++ b/deploy/systemd/dynasty-frontend.service.template
@@ -1,6 +1,12 @@
 [Unit]
 Description=Dynasty Frontend – Next.js (__SERVICE_NAME__-frontend)
-After=network.target
+After=network-online.target
+Wants=network-online.target
+# Crash-loop brake — same rationale as the backend unit: cap runaway
+# restart loops at ~30 per 5 minutes, recoverable via
+# `systemctl reset-failed __SERVICE_NAME__-frontend`.
+StartLimitIntervalSec=300
+StartLimitBurst=30
 
 [Service]
 Type=simple
@@ -15,10 +21,19 @@ WorkingDirectory=__APP_DIR__/frontend
 ExecStart=__NPM_BIN__ start
 Restart=always
 RestartSec=5
+TimeoutStopSec=30
 Environment=NODE_ENV=production
 Environment=PORT=3000
 Environment=PATH=__NODE_BIN_DIR__:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 EnvironmentFile=-__APP_DIR__/.env
+
+# ── Resource sanity ─────────────────────────────────────────────────
+# `next start` serving a pre-built app is far lighter than the Python
+# backend; 2 GB hard cap assumes a >=4 GB box (docs/PROD-HARDENING.md).
+MemoryHigh=1536M
+MemoryMax=2G
+
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-healthcheck.service
+++ b/deploy/systemd/dynasty-healthcheck.service
@@ -8,6 +8,10 @@ After=network.target
 Type=oneshot
 # Root: the script must be able to `systemctl reset-failed` + `restart`.
 ExecStart=/home/dynasty/trade-calculator/deploy/systemd/dynasty-healthcheck.sh
+# Which service the watchdog restarts.  deploy/apply_hardening.sh
+# rewrites this to match a SERVICE_NAME override at install time, so
+# the watchdog always targets the unit that was actually rendered.
+Environment="HEALTH_SERVICE=dynasty"
 RuntimeDirectory=dynasty-healthcheck
 RuntimeDirectoryPreserve=yes
 # Never let a wedged curl / systemctl stack up.

--- a/deploy/systemd/dynasty-healthcheck.service
+++ b/deploy/systemd/dynasty-healthcheck.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Dynasty backend health check (restarts dynasty after consecutive failures)
+# Purely local probe — no point running before the network stack is up,
+# but do not Require the backend: the whole job is to notice it missing.
+After=network.target
+
+[Service]
+Type=oneshot
+# Root: the script must be able to `systemctl reset-failed` + `restart`.
+ExecStart=/home/dynasty/trade-calculator/deploy/systemd/dynasty-healthcheck.sh
+RuntimeDirectory=dynasty-healthcheck
+RuntimeDirectoryPreserve=yes
+# Never let a wedged curl / systemctl stack up.
+TimeoutStartSec=90
+Nice=5
+# Environment overrides (see script header) go in a drop-in:
+#   systemctl edit dynasty-healthcheck.service
+# e.g. Environment="HEALTH_FAIL_THRESHOLD=5"

--- a/deploy/systemd/dynasty-healthcheck.service
+++ b/deploy/systemd/dynasty-healthcheck.service
@@ -7,7 +7,16 @@ After=network.target
 [Service]
 Type=oneshot
 # Root: the script must be able to `systemctl reset-failed` + `restart`.
-ExecStart=/home/dynasty/trade-calculator/deploy/systemd/dynasty-healthcheck.sh
+#
+# SECURITY: because this runs as root, ExecStart points at a ROOT-OWNED
+# copy installed OUTSIDE the deploy-user-writable checkout
+# (deploy/apply_hardening.sh installs it to /usr/local/lib/riskit/,
+# root:root 0755).  Executing the checkout copy directly would let a
+# compromised deploy account swap the script and get root within a
+# minute.  Script updates therefore flow through re-running
+# deploy/apply_hardening.sh — editing the checkout copy alone changes
+# nothing at runtime.
+ExecStart=/usr/local/lib/riskit/dynasty-healthcheck.sh
 # Which service the watchdog restarts.  deploy/apply_hardening.sh
 # rewrites this to match a SERVICE_NAME override at install time, so
 # the watchdog always targets the unit that was actually rendered.

--- a/deploy/systemd/dynasty-healthcheck.service
+++ b/deploy/systemd/dynasty-healthcheck.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Dynasty backend health check (restarts dynasty after consecutive failures)
+Description=Dynasty backend liveness watchdog (restarts dynasty after consecutive no-response probes; app-degraded 503s are log-only)
 # Purely local probe — no point running before the network stack is up,
 # but do not Require the backend: the whole job is to notice it missing.
 After=network.target

--- a/deploy/systemd/dynasty-healthcheck.sh
+++ b/deploy/systemd/dynasty-healthcheck.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# dynasty-healthcheck.sh — local watchdog for the FastAPI backend.
+#
+# Fired every minute by dynasty-healthcheck.timer.  Curls
+# http://127.0.0.1:8000/api/health; after HEALTH_FAIL_THRESHOLD
+# CONSECUTIVE failures it runs `systemctl reset-failed` + `systemctl
+# restart` on the backend service and clears the counter.  A single
+# blip (e.g. the service restarting on its own) never triggers a
+# restart — only a sustained outage does.
+#
+# reset-failed matters: the hardened dynasty.service has a
+# StartLimitBurst crash-loop brake, and once that trips systemd
+# refuses further starts until the failed state is cleared.
+#
+# State lives in RuntimeDirectory (/run/dynasty-healthcheck), so the
+# counter resets on reboot — correct, since a reboot is a fresh start.
+#
+# Runs as root (it must be able to systemctl restart).  Logs to the
+# journal: `journalctl -u dynasty-healthcheck.service`.
+#
+# Env overrides (set via drop-in on dynasty-healthcheck.service):
+#   HEALTH_URL             default http://127.0.0.1:8000/api/health
+#   HEALTH_SERVICE         default dynasty
+#   HEALTH_FAIL_THRESHOLD  default 3   (consecutive failures)
+#   HEALTH_CURL_TIMEOUT    default 25  (seconds; /api/health is cheap,
+#                          but stays generous so a busy event loop
+#                          during a scrape isn't misread as down)
+#   HEALTH_STATE_DIR       default /run/dynasty-healthcheck
+
+set -Eeuo pipefail
+
+HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:8000/api/health}"
+HEALTH_SERVICE="${HEALTH_SERVICE:-dynasty}"
+HEALTH_FAIL_THRESHOLD="${HEALTH_FAIL_THRESHOLD:-3}"
+HEALTH_CURL_TIMEOUT="${HEALTH_CURL_TIMEOUT:-25}"
+HEALTH_STATE_DIR="${HEALTH_STATE_DIR:-${RUNTIME_DIRECTORY:-/run/dynasty-healthcheck}}"
+
+FAIL_FILE="${HEALTH_STATE_DIR}/consecutive-failures"
+
+log() { printf '[healthcheck] %s\n' "$*"; }
+
+mkdir -p "${HEALTH_STATE_DIR}"
+
+read_failures() {
+    local n
+    n="$(cat "${FAIL_FILE}" 2>/dev/null || echo 0)"
+    [[ "${n}" =~ ^[0-9]+$ ]] || n=0
+    printf '%s' "${n}"
+}
+
+if curl -fsS --max-time "${HEALTH_CURL_TIMEOUT}" -o /dev/null "${HEALTH_URL}"; then
+    prev="$(read_failures)"
+    if [[ "${prev}" != "0" ]]; then
+        log "recovered: ${HEALTH_URL} healthy again after ${prev} failure(s)"
+    fi
+    printf '0\n' > "${FAIL_FILE}"
+    exit 0
+fi
+
+failures="$(( $(read_failures) + 1 ))"
+printf '%s\n' "${failures}" > "${FAIL_FILE}"
+log "FAIL ${failures}/${HEALTH_FAIL_THRESHOLD}: ${HEALTH_URL} not responding"
+
+if (( failures < HEALTH_FAIL_THRESHOLD )); then
+    exit 0
+fi
+
+log "threshold reached — restarting ${HEALTH_SERVICE}.service"
+# Clear any tripped StartLimit state first, otherwise restart is a no-op
+# on a unit systemd has given up on.
+systemctl reset-failed "${HEALTH_SERVICE}.service" 2>/dev/null || true
+if systemctl restart "${HEALTH_SERVICE}.service"; then
+    log "restart issued for ${HEALTH_SERVICE}.service"
+else
+    log "ERROR: systemctl restart ${HEALTH_SERVICE}.service failed"
+fi
+# Reset the counter either way so the next window measures the NEW
+# process (and a restart that doesn't help re-triggers after another
+# full threshold, not instantly every minute).
+printf '0\n' > "${FAIL_FILE}"

--- a/deploy/systemd/dynasty-healthcheck.sh
+++ b/deploy/systemd/dynasty-healthcheck.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
 #
-# dynasty-healthcheck.sh — local watchdog for the FastAPI backend.
+# dynasty-healthcheck.sh — local LIVENESS watchdog for the FastAPI
+# backend.  Liveness and application health are deliberately separate:
 #
-# Fired every minute by dynasty-healthcheck.timer.  Curls
-# http://127.0.0.1:8000/api/health; after HEALTH_FAIL_THRESHOLD
-# CONSECUTIVE failures it runs `systemctl reset-failed` + `systemctl
-# restart` on the backend service and clears the counter.  A single
-# blip (e.g. the service restarting on its own) never triggers a
-# restart — only a sustained outage does.
+#   * LIVENESS  — does the process answer HTTP at all?  ANY HTTP
+#     response (200, 401, 404, 503, ...) proves the server process is
+#     up and serving; only a connection-level failure (refused, timeout,
+#     empty reply — curl exit 7/28/52/56/...) counts as down.  We probe
+#     127.0.0.1 directly, so no proxy can answer on a dead backend's
+#     behalf.
+#   * HEALTH    — /api/health deliberately returns HTTP 503 with
+#     status "degraded" for stale data, a failed/stalled scrape, or
+#     contract validation failure WHILE the process is up and serving
+#     cached data (see server.py::get_health).  Restarting on that
+#     would bounce a healthy process — and worse, a restart clears the
+#     in-memory scrape error and reloads the disk cache with a fresh
+#     loadedAt, flipping health green WITHOUT a successful scrape and
+#     concealing the ingestion fault.  Degraded 503s are therefore
+#     LOG-ONLY (reported on state transitions): report, never restart.
+#
+# Fired every minute by dynasty-healthcheck.timer.  After
+# HEALTH_FAIL_THRESHOLD CONSECUTIVE liveness failures it runs
+# `systemctl reset-failed` + `systemctl restart` on the backend service
+# and clears the counter.  A single blip (e.g. the service restarting
+# on its own) never triggers a restart — only a sustained outage does.
 #
 # reset-failed matters: the hardened dynasty.service has a
 # StartLimitBurst crash-loop brake, and once that trips systemd
@@ -22,10 +38,10 @@
 # Env overrides (set via drop-in on dynasty-healthcheck.service):
 #   HEALTH_URL             default http://127.0.0.1:8000/api/health
 #   HEALTH_SERVICE         default dynasty
-#   HEALTH_FAIL_THRESHOLD  default 3   (consecutive failures)
-#   HEALTH_CURL_TIMEOUT    default 25  (seconds; /api/health is cheap,
-#                          but stays generous so a busy event loop
-#                          during a scrape isn't misread as down)
+#   HEALTH_FAIL_THRESHOLD  default 3   (consecutive LIVENESS failures)
+#   HEALTH_CURL_TIMEOUT    default 25  (seconds; generous so a busy
+#                          event loop during a scrape isn't misread
+#                          as down)
 #   HEALTH_STATE_DIR       default /run/dynasty-healthcheck
 
 set -Eeuo pipefail
@@ -37,6 +53,7 @@ HEALTH_CURL_TIMEOUT="${HEALTH_CURL_TIMEOUT:-25}"
 HEALTH_STATE_DIR="${HEALTH_STATE_DIR:-${RUNTIME_DIRECTORY:-/run/dynasty-healthcheck}}"
 
 FAIL_FILE="${HEALTH_STATE_DIR}/consecutive-failures"
+DEGRADED_FILE="${HEALTH_STATE_DIR}/degraded"
 
 log() { printf '[healthcheck] %s\n' "$*"; }
 
@@ -49,18 +66,37 @@ read_failures() {
     printf '%s' "${n}"
 }
 
-if curl -fsS --max-time "${HEALTH_CURL_TIMEOUT}" -o /dev/null "${HEALTH_URL}"; then
+# LIVENESS probe: no -f — any HTTP status is proof of life.  rc != 0
+# means curl got no usable HTTP response (connection refused, timeout,
+# empty reply, ...) and only that counts as a liveness failure.
+rc=0
+http_code="$(curl -sS --max-time "${HEALTH_CURL_TIMEOUT}" -o /dev/null \
+                 -w '%{http_code}' "${HEALTH_URL}" 2>/dev/null)" || rc=$?
+
+if (( rc == 0 )); then
+    # Process is alive.  Reset the liveness counter; surface app-level
+    # degradation as log-only, on transitions.
     prev="$(read_failures)"
     if [[ "${prev}" != "0" ]]; then
-        log "recovered: ${HEALTH_URL} healthy again after ${prev} failure(s)"
+        log "recovered: ${HEALTH_URL} responding again after ${prev} liveness failure(s)"
     fi
     printf '0\n' > "${FAIL_FILE}"
+
+    if [[ "${http_code}" == "503" ]]; then
+        if [[ ! -f "${DEGRADED_FILE}" ]]; then
+            log "DEGRADED (log-only): ${HEALTH_URL} returned 503 — the app reports degraded health (stale data / failed or stalled scrape / contract issue) but the process is alive and serving cached data.  NOT restarting: a restart would clear the in-memory scrape error and reload the cache with a fresh loadedAt, masking the ingestion fault.  Investigate via /api/status and journalctl -u ${HEALTH_SERVICE}."
+            : > "${DEGRADED_FILE}"
+        fi
+    elif [[ -f "${DEGRADED_FILE}" ]]; then
+        log "degraded state cleared: ${HEALTH_URL} now returns ${http_code}"
+        rm -f "${DEGRADED_FILE}"
+    fi
     exit 0
 fi
 
 failures="$(( $(read_failures) + 1 ))"
 printf '%s\n' "${failures}" > "${FAIL_FILE}"
-log "FAIL ${failures}/${HEALTH_FAIL_THRESHOLD}: ${HEALTH_URL} not responding"
+log "LIVENESS FAIL ${failures}/${HEALTH_FAIL_THRESHOLD}: no HTTP response from ${HEALTH_URL} (curl exit ${rc})"
 
 if (( failures < HEALTH_FAIL_THRESHOLD )); then
     exit 0

--- a/deploy/systemd/dynasty-healthcheck.timer
+++ b/deploy/systemd/dynasty-healthcheck.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run dynasty backend health check every minute
+
+[Timer]
+# Give the stack breathing room after boot before the first probe —
+# backend cold start parses the multi-MB contract (~90s worst case).
+OnBootSec=3min
+OnUnitActiveSec=1min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/dynasty.service.template
+++ b/deploy/systemd/dynasty.service.template
@@ -1,7 +1,16 @@
 [Unit]
 Description=Dynasty Trade Calculator (__SERVICE_NAME__)
-After=network.target __SERVICE_NAME__-frontend.service
-Wants=__SERVICE_NAME__-frontend.service
+After=network-online.target __SERVICE_NAME__-frontend.service
+Wants=network-online.target __SERVICE_NAME__-frontend.service
+# Crash-loop brake: with RestartSec=5 a hard crash loop burns ~12
+# restarts/minute.  Allow up to 30 restarts inside a 5-minute window
+# before systemd stops retrying — enough to ride out transient failures
+# (disk pressure, OOM during a scrape) without letting a genuinely
+# broken build spin forever.  Once tripped, the unit needs
+# `systemctl reset-failed` before it will start again; the
+# dynasty-healthcheck timer does exactly that before its restart.
+StartLimitIntervalSec=300
+StartLimitBurst=30
 
 [Service]
 Type=simple
@@ -11,8 +20,30 @@ WorkingDirectory=__APP_DIR__
 ExecStart=__VENV_DIR__/bin/python __APP_DIR__/server.py
 Restart=always
 RestartSec=5
+# Boot parses the multi-MB cached contract before binding the port —
+# see deploy/verify-deploy.sh (~90s budget).  Give systemd the same
+# generosity so a slow cold start is not mistaken for a hang.
+TimeoutStartSec=180
+TimeoutStopSec=30
 Environment=PYTHONUNBUFFERED=1
 EnvironmentFile=-__APP_DIR__/.env
+
+# ── Resource sanity ─────────────────────────────────────────────────
+# Assumes a >=4 GB Hetzner box (see docs/PROD-HARDENING.md; verify
+# with `free -m` before applying).  Steady-state RSS is dominated by
+# the in-memory contract + payload views; Playwright scrape cycles
+# spike it.  MemoryHigh throttles/reclaims first; MemoryMax is the
+# hard OOM line, after which Restart=always brings the service back.
+# Comment both out on a smaller box rather than guessing lower.
+MemoryHigh=2560M
+MemoryMax=3G
+
+# ── Sandbox-lite hardening ──────────────────────────────────────────
+# PrivateTmp gives the service (and Playwright browser profiles) an
+# isolated /tmp.  Stronger knobs are deliberately NOT enabled:
+# NoNewPrivileges/ProtectSystem can break Chromium's sandbox helper
+# during scrapes — do not add them without testing a full scrape cycle.
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -91,6 +91,13 @@ faults.  So:
 - Runs as root because it must drive systemctl; the frontend is left to
   its own `Restart=always` (a wedged-but-listening Next process is far
   rarer, and the uptime probe surfaces it).
+- **Root/checkout separation**: because the unit runs as root, its
+  `ExecStart` points at a root-owned copy in `/usr/local/lib/riskit/`
+  (root:root 0755) installed by `apply_hardening.sh` — executing the
+  deploy-user-writable checkout copy as root would let a compromised
+  `dynasty` account swap the script and get root within a minute.
+  Script updates flow through re-running the apply script; editing the
+  checkout copy alone changes nothing at runtime.
 
 ## 4. Backups — `deploy/backup/` (new)
 
@@ -115,6 +122,17 @@ faults.  So:
   discards its own staging dir — it can never displace a good
   generation from the keep-window or publish a partial snapshot to the
   rsync mirror.
+- **Required-artifact manifest**: an artifact *count* alone is not
+  enough — with `DATA_DIR` unmounted or mistyped, a stray session JSON
+  still produces one artifact, and that partial snapshot must never be
+  promoted over a complete generation.  `BACKUP_REQUIRED` (default
+  `user_kv.sqlite session_store.sqlite`) names the core items that
+  must be written **and** integrity-verified before promotion; a
+  missing required item discards staging and exits 1 with `daily/`
+  untouched.
+- **Root/checkout separation**: the unit runs as root, so `ExecStart`
+  points at the root-owned copy in `/usr/local/lib/riskit/` installed
+  by `apply_hardening.sh` — same rationale as the watchdog above.
 - Optional off-box mirror: set `OFFBOX_RSYNC_DEST` via a service
   drop-in (operator fills in destination + SSH key).  Unset = local
   only, nothing leaves the box.
@@ -137,6 +155,13 @@ to `/var/log/riskit-uptime.log`.
 - Honest limitation, documented: it runs on the VPS, so it cannot see a
   full network partition/dead box.  The script is dependency-free
   (bash + curl) and can be run unchanged from any second machine.
+- **Least privilege**: the probe only curls and logs, so the unit runs
+  as `User=dynasty`, not root.  It may safely execute from the
+  checkout because the process has no more privilege than the user who
+  can already edit that file.  The log still lands in
+  `/var/log/riskit-uptime.log` because systemd (pid 1) opens the
+  `StandardOutput=append:` target before dropping privileges; state
+  moves to `/var/tmp` (deploy-user writable).
 
 ## 6. Apply script — `deploy/apply_hardening.sh` (new)
 
@@ -153,13 +178,18 @@ Root-only, idempotent, `--dry-run` supported.  Order of operations:
    backend unit against a nonexistent `/root/.venvs/...` interpreter —
    and a pre-flight assertion refuses to rewrite the units unless
    `$VENV_DIR/bin/python` actually exists.
-3. Installs the healthcheck / state-backup / uptime units (diff-aware;
+3. Installs root-owned copies (root:root 0755) of the two root-run
+   scripts — `dynasty-healthcheck.sh`, `riskit-state-backup.sh` — into
+   `/usr/local/lib/riskit/` (override: `RISKIT_LIB_DIR`), diff-aware.
+   The units execute those copies, never the checkout; re-run the
+   apply script to roll out script changes.
+4. Installs the healthcheck / state-backup / uptime units (diff-aware;
    rewrites the canonical `/home/dynasty/trade-calculator` path to
-   `APP_DIR`, and the watchdog's `HEALTH_SERVICE` to `SERVICE_NAME`,
-   when overridden — so the watchdog always restarts the unit that was
-   actually rendered).
-4. `daemon-reload`, `enable --now` on the three timers.
-5. Prints the full verification checklist.
+   `APP_DIR`, `/usr/local/lib/riskit` to `RISKIT_LIB_DIR`, the
+   watchdog's `HEALTH_SERVICE` to `SERVICE_NAME`, and the uptime
+   probe's `User=/Group=` to `APP_USER`, when overridden).
+5. `daemon-reload`, `enable --now` on the three timers.
+6. Prints the full verification checklist.
 
 ## Operator runbook
 

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -179,7 +179,10 @@ Root-only, idempotent, `--dry-run` supported.  Order of operations:
    restart/reboot cannot pick them up.  The sites-enabled symlink is
    validated by resolved target (`readlink -f`), not mere existence —
    a stale or broken link is recreated to point at the intended
-   config.
+   config, and because that changes what nginx will serve, the repair
+   runs the same `nginx -t` + `systemctl reload nginx` sequence as a
+   config install (restoring the previous link state verbatim if
+   validation fails there).
 2. Re-renders `dynasty`/`dynasty-frontend` units from the hardened
    templates via the existing `install-systemd-service.sh`
    (`FORCE_SERVICE_INSTALL=true`; no restart performed).  `VENV_DIR`

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -89,6 +89,12 @@ New: `dynasty-healthcheck.sh` + `.service` + `.timer`.
   exactly why losing it hurts.
 - Every artifact integrity-checked (`gzip -t` / `tar -tzf`); the run
   fails loudly if zero artifacts were written.
+- Destructive steps run strictly last: artifacts stage into a hidden
+  dir and only a fully validated snapshot is promoted into `daily/`,
+  mirrored off-box, or allowed to trigger pruning.  A failed run
+  discards its own staging dir — it can never displace a good
+  generation from the keep-window or publish a partial snapshot to the
+  rsync mirror.
 - Optional off-box mirror: set `OFFBOX_RSYNC_DEST` via a service
   drop-in (operator fills in destination + SSH key).  Unset = local
   only, nothing leaves the box.

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -58,14 +58,34 @@ with `deploy/verify-deploy.sh`.
 
 New: `dynasty-healthcheck.sh` + `.service` + `.timer`.
 
-- Every minute, curls `http://127.0.0.1:8000/api/health` (25s budget —
-  generous so a busy event loop mid-scrape isn't misread as down).
-- After **3 consecutive** failures: `systemctl reset-failed dynasty`
-  (clears a tripped StartLimit brake) then `systemctl restart dynasty`,
-  and resets the counter so an unhelpful restart re-triggers only after
-  another full threshold.
-- Counter lives in `/run/dynasty-healthcheck` (RuntimeDirectory —
-  clean slate on reboot).  Logs to the journal.
+**Liveness and application health are deliberately separate.**
+`/api/health` returns HTTP 503 with `status: "degraded"` for stale
+data, a failed/stalled scrape, or contract validation failure while
+the process is **up and serving cached data**
+(`server.py::get_health` — `status_code=200 if is_ok else 503`).
+Restarting on a degraded 503 would bounce a healthy process, and
+worse: the restart clears the in-memory scrape error and reloads the
+disk cache with a fresh `loadedAt`, flipping health green **without a
+successful scrape** — the watchdog would actively conceal ingestion
+faults.  So:
+
+- **Liveness probe** (every minute, curls
+  `http://127.0.0.1:8000/api/health` *without* `-f`, 25s budget):
+  **any** HTTP response — 200, 401, 404, 503 — is proof of life; the
+  probe hits 127.0.0.1 directly, so no proxy can answer on a dead
+  backend's behalf.  Only a connection-level failure (refused,
+  timeout, empty reply — a non-zero curl exit) counts toward the
+  restart threshold.
+- After **3 consecutive** liveness failures: `systemctl reset-failed
+  dynasty` (clears a tripped StartLimit brake) then `systemctl
+  restart dynasty`, and the counter resets so an unhelpful restart
+  re-triggers only after another full threshold.
+- **Degraded 503s are log-only**, reported on state transitions (one
+  journal line entering degraded, one on clearing) with a pointer to
+  `/api/status` and the service journal.  The watchdog never restarts
+  a process that is answering HTTP.
+- Counter and degraded flag live in `/run/dynasty-healthcheck`
+  (RuntimeDirectory — clean slate on reboot).  Logs to the journal.
 - Tunables (`HEALTH_FAIL_THRESHOLD`, `HEALTH_URL`, …) via
   `systemctl edit dynasty-healthcheck.service`.
 - Runs as root because it must drive systemctl; the frontend is left to

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -1,0 +1,176 @@
+# Production Hardening — nginx, systemd resilience, backups, monitoring
+
+**Status: PREPARED, NOT APPLIED.**  Everything in this change set is
+files in the repo.  Nothing has touched the production server; no
+credentials, `.env` files, or certificates were read or modified.  The
+operator applies it with `deploy/apply_hardening.sh` (which is
+idempotent and prints a verification checklist), or by following the
+per-file install notes.
+
+Production context (from `deploy/PRODUCTION_BOOTSTRAP.md`): Hetzner
+VPS, app at `/home/dynasty/trade-calculator`, user `dynasty`, nginx +
+Let's Encrypt in front of `dynasty.service` (FastAPI :8000) and
+`dynasty-frontend.service` (Next.js :3000).
+
+---
+
+## 1. nginx — `deploy/nginx/riskittogetthebrisket.org.conf`
+
+| Change | Rationale |
+|---|---|
+| `listen 443 ssl http2` (+ IPv6 listeners) | HTTP/2 multiplexing removes head-of-line blocking for the asset-heavy Next.js pages.  The combined `listen ... http2` spelling works on the nginx 1.24.x that Ubuntu LTS ships; on nginx ≥ 1.25.1 it still works but logs a deprecation warning — switch to `http2 on;` there. |
+| `gzip on` + JSON-centric `gzip_types`, `gzip_min_length 1024`, `gzip_vary on`, `gzip_proxied any` | Fallback compression layer.  The backend already gzips responses ≥ 1 KB (FastAPI `GZipMiddleware`) and pre-gzips `/api/data`; nginx never re-compresses responses that arrive with `Content-Encoding`, so this only catches what upstreams leave uncompressed. |
+| Brotli block **commented** | `brotli` directives fail `nginx -t` unless the `ngx_brotli` modules are installed.  Install `libnginx-mod-http-brotli-{filter,static}` first, then uncomment. |
+| `location /_next/static/` with `proxy_cache` (new 50 MB `riskit_static` zone) | Next.js build assets are content-hashed and served with `public, max-age=31536000, immutable`; nginx caches them so repeated hits never touch the node process.  Entry lifetime is governed by the upstream Cache-Control, which nginx passes through **unmodified**.  Privacy scope: this is the only shared cache in the config and it is attached only to `/_next/static/` — `/api/*` stays uncached, preserving the invariant documented in `tests/api/test_cache_control_privacy.py` (auth-gated endpoints must never meet a shared cache).  nginx also refuses by default to cache responses carrying `Set-Cookie` or `Cache-Control: private/no-store`. |
+| `/api/` timeouts: `proxy_read_timeout 120s` (kept), `proxy_connect_timeout 5s`, `proxy_send_timeout 30s` | 120s survives scrape-cycle cache rebuilds (~3 min hold documented in the old config) and cold `/api/news` (~10s).  The 5s connect timeout makes a dead backend fail fast instead of hanging browsers for 60s. |
+| `/api/` `proxy_buffers 32 16k` | The `/api/data` contract is MB-scale; bigger in-memory buffers avoid nginx spilling responses to disk temp files. |
+| Security headers (server-level, `always`): HSTS `max-age=31536000`, `X-Content-Type-Options: nosniff`, `Content-Security-Policy: frame-ancestors 'self'` (enforced), `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy`, `Permissions-Policy` | `frame-ancestors` is safe to enforce — it only controls embedding and cannot break the app's own scripts.  HSTS deliberately ships **without** `includeSubDomains`/`preload`; add those only after confirming every subdomain serves TLS (HSTS mistakes lock browsers out for a year). |
+| Full CSP: **report-only, commented out** | Next.js 15 App Router emits inline hydration `<script>` chunks without nonces and the app has no nonce plumbing, so an enforced `script-src` would need `'unsafe-inline'` (near-worthless) or app-code changes (out of scope for a deploy-only change).  A complete Report-Only policy is included, commented, with the known externals mapped (`sleepercdn.com` images, `sw.js` worker).  Uncomment it to gather violation data before ever enforcing. |
+| **Cache-Control pass-through preserved** | The backend stamps privacy-sensitive caching per endpoint (`private, max-age=…`, `no-store`).  No location adds/hides/overrides `Cache-Control` or `expires`.  Also: no `add_header` inside location blocks at all — nginx's all-or-nothing `add_header` inheritance would otherwise silently drop the server-level security headers there. |
+| `client_max_body_size 10m`, upstream `keepalive` 8/16 | Sane request-size cap (POST bodies are small trade/override payloads); deeper idle-connection pool to the node process for HTTP/2 fan-out. |
+
+Unchanged: routing structure, upstream addresses, certbot TLS include
+lines, the 80→443 redirect, and the WebSocket upgrade path on `/`.
+
+## 2. systemd — service templates
+
+Both `deploy/systemd/dynasty.service.template` and
+`dynasty-frontend.service.template` (rendered by
+`deploy/install-systemd-service.sh`, placeholders intact):
+
+| Change | Rationale |
+|---|---|
+| `Restart=always` **kept** (not switched to `on-failure`) | Existing behavior, and strictly stronger: it also revives the service after a clean-but-unexpected exit.  RestartSec=5 kept. |
+| `StartLimitIntervalSec=300` + `StartLimitBurst=30` | Crash-loop brake: ~30 restarts per 5 min allowed, then systemd stops retrying a genuinely broken build.  The healthcheck watchdog runs `systemctl reset-failed` before its restart, so a tripped brake is recoverable automatically once the underlying cause clears. |
+| `TimeoutStartSec=180` (backend) | Boot parses the multi-MB cached contract before binding the port (`verify-deploy.sh` budgets ~90s); don't let systemd kill a slow-but-healthy cold start. |
+| `TimeoutStopSec=30` | Bounded shutdown before SIGKILL. |
+| `MemoryHigh=2560M` / `MemoryMax=3G` (backend), `1536M`/`2G` (frontend) | **Assumption: a ≥ 4 GB box** — verify with `free -m` before applying; comment the lines out on smaller boxes.  Backend RSS is dominated by the in-memory contract + payload views and spikes during Playwright scrapes; MemoryHigh throttles first, MemoryMax is the OOM line and `Restart=always` recovers. |
+| `PrivateTmp=true` | Isolated /tmp (incl. Playwright browser profiles). |
+| Deliberately **not** added: `NoNewPrivileges`, `ProtectSystem`, `ProtectHome` | The backend launches Chromium for scrapes; these knobs can break the browser sandbox/profile handling.  Documented in the unit as "test a full scrape cycle before adding". |
+| `After/Wants=network-online.target` | Don't race the network at boot. |
+
+Note: the new settings land on the **next service restart** after
+`install-systemd-service.sh` + `daemon-reload`.  The apply script does
+not restart the services for you — do it at a quiet moment and follow
+with `deploy/verify-deploy.sh`.
+
+## 3. Backend watchdog — `deploy/systemd/dynasty-healthcheck.*`
+
+New: `dynasty-healthcheck.sh` + `.service` + `.timer`.
+
+- Every minute, curls `http://127.0.0.1:8000/api/health` (25s budget —
+  generous so a busy event loop mid-scrape isn't misread as down).
+- After **3 consecutive** failures: `systemctl reset-failed dynasty`
+  (clears a tripped StartLimit brake) then `systemctl restart dynasty`,
+  and resets the counter so an unhelpful restart re-triggers only after
+  another full threshold.
+- Counter lives in `/run/dynasty-healthcheck` (RuntimeDirectory —
+  clean slate on reboot).  Logs to the journal.
+- Tunables (`HEALTH_FAIL_THRESHOLD`, `HEALTH_URL`, …) via
+  `systemctl edit dynasty-healthcheck.service`.
+- Runs as root because it must drive systemctl; the frontend is left to
+  its own `Restart=always` (a wedged-but-listening Next process is far
+  rarer, and the uptime probe surfaces it).
+
+## 4. Backups — `deploy/backup/` (new)
+
+`riskit-state-backup.sh` + `.service` + `.timer` (+ README): nightly
+02:30 UTC, keep **14** daily generations, umask 077.
+
+- SQLite (`user_kv`, `session_store`, `guest_passes`) via the same
+  WAL-safe `sqlite3.Connection.backup()` primitive the existing
+  `backup_user_kv.sh` uses.
+- `data/public_league/` and `data/intel/` as tar.gz — both guarded
+  (`intel/` does not exist yet).
+- Scraper session cookies (`dlf`/`draftsharks`/`idpshow`
+  `*_session.json`, repo root **and** `/var/lib/{dlf,idpshow}-fetch/`)
+  — gitignored secrets, backed up **on-box only**, mode 0600.  The IDP
+  Show session is manually provisioned (captcha-gated login), which is
+  exactly why losing it hurts.
+- Every artifact integrity-checked (`gzip -t` / `tar -tzf`); the run
+  fails loudly if zero artifacts were written.
+- Optional off-box mirror: set `OFFBOX_RSYNC_DEST` via a service
+  drop-in (operator fills in destination + SSH key).  Unset = local
+  only, nothing leaves the box.
+- The existing `riskit-backup.timer` (02:00, sqlite-only, 30 daily +
+  12 monthly + weekly restore test) **stays enabled** — the overlap is
+  a few MB per night and preserves the long sqlite history and the
+  exercised restore path.
+
+## 5. Uptime monitoring — `deploy/monitoring/` (new)
+
+`uptime_check.sh` + `riskit-uptime.service`/`.timer` (+ README):
+every 5 minutes probes `https://riskittogetthebrisket.org/api/health`,
+the frontend root, and the local backend port; appends one line per run
+to `/var/log/riskit-uptime.log`.
+
+- **No third-party service.**  Notification is opt-in via
+  `NOTIFY_WEBHOOK_URL` (any plain-text-POST endpoint the operator
+  chooses) or `NOTIFY_CMD` (message on stdin, e.g. `mail`), configured
+  through a drop-in.  Fires only on UP↔DOWN **state changes**.
+- Honest limitation, documented: it runs on the VPS, so it cannot see a
+  full network partition/dead box.  The script is dependency-free
+  (bash + curl) and can be run unchanged from any second machine.
+
+## 6. Apply script — `deploy/apply_hardening.sh` (new)
+
+Root-only, idempotent, `--dry-run` supported.  Order of operations:
+
+1. nginx: diff repo config vs `/etc/nginx/sites-available/…`; if
+   different → timestamped backup → install → `nginx -t` (restores the
+   backup automatically on failure) → `systemctl reload nginx`.
+2. Re-renders `dynasty`/`dynasty-frontend` units from the hardened
+   templates via the existing `install-systemd-service.sh`
+   (`FORCE_SERVICE_INSTALL=true`; no restart performed).
+3. Installs the healthcheck / state-backup / uptime units (diff-aware;
+   rewrites the canonical `/home/dynasty/trade-calculator` path to
+   `APP_DIR` when the checkout lives elsewhere).
+4. `daemon-reload`, `enable --now` on the three timers.
+5. Prints the full verification checklist.
+
+## Operator runbook
+
+```bash
+# on the VPS, as the deploy user, repo up to date on main
+cd /home/dynasty/trade-calculator
+sudo bash deploy/apply_hardening.sh --dry-run   # review every diff
+sudo bash deploy/apply_hardening.sh             # apply
+# then walk the printed checklist; at a quiet moment:
+sudo systemctl restart dynasty-frontend dynasty
+bash deploy/verify-deploy.sh
+```
+
+## Rollback
+
+Every step is independently reversible:
+
+- **nginx**: the apply script leaves
+  `/etc/nginx/sites-available/riskittogetthebrisket.org.bak.<timestamp>`.
+  `sudo cp <backup> /etc/nginx/sites-available/riskittogetthebrisket.org
+  && sudo nginx -t && sudo systemctl reload nginx`.
+- **Service units**: `git checkout <previous-commit> --
+  deploy/systemd/dynasty.service.template
+  deploy/systemd/dynasty-frontend.service.template`, then
+  `FORCE_SERVICE_INSTALL=true bash deploy/install-systemd-service.sh`,
+  `sudo systemctl daemon-reload`, restart at a quiet moment.
+- **Watchdog**: `sudo systemctl disable --now dynasty-healthcheck.timer`
+  (the backend keeps its own `Restart=always`).
+- **State backup**: `sudo systemctl disable --now riskit-state-backup.timer`
+  (the older `riskit-backup.timer` still covers sqlite).
+- **Uptime probe**: `sudo systemctl disable --now riskit-uptime.timer`.
+
+## Validation performed in the sandbox (and its limits)
+
+- `bash -n` on all four shell scripts: **pass**.
+- `systemd-analyze verify` (systemd 255) run against the concrete new
+  units: warnings limited to units referencing paths that only exist on
+  the production box — expected; no syntax errors.
+- **nginx is not installed in the sandbox**, so `nginx -t` could NOT be
+  run here.  The config was upgraded by careful review against the
+  previous known-good file; the apply script runs `nginx -t` before any
+  reload and auto-restores the backup on failure, so a syntax mistake
+  cannot take the site down.
+- `shellcheck` not available in the sandbox; scripts follow the
+  existing deploy/ conventions (`set -Eeuo pipefail`, quoted
+  expansions).
+- Full Python test suite run once to prove no app code changed.

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -114,8 +114,12 @@ faults.  So:
   — gitignored secrets, backed up **on-box only**, mode 0600.  The IDP
   Show session is manually provisioned (captcha-gated login), which is
   exactly why losing it hurts.
-- Every artifact integrity-checked (`gzip -t` / `tar -tzf`); the run
-  fails loudly if zero artifacts were written.
+- Every artifact integrity-checked: SQLite copies get
+  `PRAGMA integrity_check` against the *copied* database (structural
+  corruption copies page-for-page through `Connection.backup()` and
+  passes `gzip -t`, which only validates the compressed stream) plus
+  `gzip -t`; tarballs get `tar -tzf`.  The run fails loudly if zero
+  artifacts were written.
 - Destructive steps run strictly last: artifacts stage into a hidden
   dir and only a fully validated snapshot is promoted into `daily/`,
   mirrored off-box, or allowed to trigger pruning.  A failed run
@@ -168,8 +172,14 @@ to `/var/log/riskit-uptime.log`.
 Root-only, idempotent, `--dry-run` supported.  Order of operations:
 
 1. nginx: diff repo config vs `/etc/nginx/sites-available/…`; if
-   different → timestamped backup → install → `nginx -t` (restores the
-   backup automatically on failure) → `systemctl reload nginx`.
+   different → timestamped backup → install → `nginx -t` →
+   `systemctl reload nginx`.  On `nginx -t` failure it restores the
+   backup automatically; on a **first install** (no backup exists) it
+   removes the invalid file *and* the enabled symlink so a later nginx
+   restart/reboot cannot pick them up.  The sites-enabled symlink is
+   validated by resolved target (`readlink -f`), not mere existence —
+   a stale or broken link is recreated to point at the intended
+   config.
 2. Re-renders `dynasty`/`dynasty-frontend` units from the hardened
    templates via the existing `install-systemd-service.sh`
    (`FORCE_SERVICE_INSTALL=true`; no restart performed).  `VENV_DIR`

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -121,10 +121,17 @@ Root-only, idempotent, `--dry-run` supported.  Order of operations:
    backup automatically on failure) → `systemctl reload nginx`.
 2. Re-renders `dynasty`/`dynasty-frontend` units from the hardened
    templates via the existing `install-systemd-service.sh`
-   (`FORCE_SERVICE_INSTALL=true`; no restart performed).
+   (`FORCE_SERVICE_INSTALL=true`; no restart performed).  `VENV_DIR`
+   is derived from the **APP_USER's** home via `getent` — never from
+   `$HOME`, which is `/root` under `sudo` and would have rendered the
+   backend unit against a nonexistent `/root/.venvs/...` interpreter —
+   and a pre-flight assertion refuses to rewrite the units unless
+   `$VENV_DIR/bin/python` actually exists.
 3. Installs the healthcheck / state-backup / uptime units (diff-aware;
    rewrites the canonical `/home/dynasty/trade-calculator` path to
-   `APP_DIR` when the checkout lives elsewhere).
+   `APP_DIR`, and the watchdog's `HEALTH_SERVICE` to `SERVICE_NAME`,
+   when overridden — so the watchdog always restarts the unit that was
+   actually rendered).
 4. `daemon-reload`, `enable --now` on the three timers.
 5. Prints the full verification checklist.
 


### PR DESCRIPTION
## What this is

Ready-to-apply production hardening for the Hetzner VPS, prepared entirely as files in `deploy/` + `docs/`. **Nothing has been applied to the server** — no credentials, `.env`, certificates, or live configs were touched. The operator applies with `sudo bash deploy/apply_hardening.sh` (idempotent, `--dry-run` supported, prints a verification checklist). Full rationale + runbook + rollback: `docs/PROD-HARDENING.md`.

## 1. nginx — `deploy/nginx/riskittogetthebrisket.org.conf`

- **HTTP/2** via `listen 443 ssl http2` (+ IPv6 listeners). Spelling chosen for Ubuntu-LTS nginx 1.24.x; note in-file for ≥1.25.1.
- **gzip fallback layer** tuned for JSON (`gzip_types`, min 1 KB, `gzip_vary`, `gzip_proxied any`). The backend already gzips ≥1 KB (GZipMiddleware) and pre-gzips `/api/data`; nginx never re-compresses, so this only catches what upstreams leave uncompressed. **Brotli is a commented block** — the directives fail `nginx -t` without the `ngx_brotli` module, so it's gated on installing `libnginx-mod-http-brotli-*` first.
- **`/_next/static/` nginx cache** (new 50 MB zone): content-hashed immutable assets stop hitting the node process. Upstream `Cache-Control: public, max-age=31536000, immutable` is passed through unmodified. Privacy scope called out in-file: this is the **only** shared cache and it never touches `/api/*`, preserving the invariant documented in `tests/api/test_cache_control_privacy.py`.
- **Cache-Control pass-through preserved**: no location adds/hides/overrides `Cache-Control` or `expires`; the app's `private`/`no-store` stamps reach clients untouched. Also zero `add_header` inside location blocks (nginx's all-or-nothing inheritance would silently drop the security headers there).
- **Timeouts**: `/api/` keeps the existing 120s read (scrape-cycle holds ~3 min worst case; cold `/api/news` ~10s fits easily); adds 5s connect timeout so a dead backend fails fast instead of hanging 60s. Bigger `proxy_buffers` (32×16k) so the MB-scale contract doesn't spill to disk temp files.
- **Security headers** (server-level, `always`): HSTS `max-age=31536000` (deliberately no `includeSubDomains`/`preload` yet — documented), `X-Content-Type-Options: nosniff`, **enforced** `Content-Security-Policy: frame-ancestors 'self'` (safe — only controls embedding), `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`.
- **Full CSP: report-only, commented, documented.** Verified in the codebase that Next.js 15 App Router emits inline hydration `<script>` chunks without nonces and the app has no nonce plumbing — an enforced `script-src` would need `'unsafe-inline'` or app-code changes (out of territory). The commented Report-Only policy maps the known externals (`sleepercdn.com` images, `sw.js` service worker) for data-gathering before any future enforcement.

## 2. systemd — service templates + watchdog

`dynasty.service.template` / `dynasty-frontend.service.template` (placeholders intact; still rendered by `install-systemd-service.sh`):
- `Restart=always` **kept** (existing behavior, strictly stronger than `on-failure`), `RestartSec=5` kept; added `StartLimitIntervalSec=300` + `StartLimitBurst=30` crash-loop brake.
- `TimeoutStartSec=180` (backend cold start parses the multi-MB contract; `verify-deploy.sh` budgets ~90s), `TimeoutStopSec=30`.
- `MemoryHigh`/`MemoryMax` = 2560M/3G backend, 1536M/2G frontend — **documented assumption: ≥4 GB box; verify with `free -m` and comment out on smaller boxes**.
- `PrivateTmp=true`. Deliberately **not** added: `NoNewPrivileges`/`ProtectSystem` — the backend launches Chromium for scrapes and these can break the browser sandbox (noted in the unit).

New watchdog `deploy/systemd/dynasty-healthcheck.{sh,service,timer}`: every minute curls `http://127.0.0.1:8000/api/health`; after **3 consecutive** failures runs `systemctl reset-failed` (recovers a tripped start-limit brake) + `restart dynasty`, then resets its counter. State in `/run` (fresh on reboot), logs to journal, tunables via drop-in.

## 3. Backups — `deploy/backup/` (new)

`riskit-state-backup.{sh,service,timer}`: nightly 02:30 UTC, keep **14 daily**, `umask 077`:
- `user_kv.sqlite`, `session_store.sqlite`, `guest_passes.sqlite` via the WAL-safe `sqlite3.Connection.backup()` primitive (same approach as the existing `backup_user_kv.sh`; sqlite3 CLI isn't on the box).
- `data/public_league/`, `data/intel/` as tar.gz — both guarded (`intel/` doesn't exist yet).
- Scraper session cookies (`dlf`/`draftsharks`/`idpshow` `*_session.json`, repo root and `/var/lib/{dlf,idpshow}-fetch/`) — gitignored secrets, backed up **on-box only**, mode 0600, never into the repo.
- Every artifact integrity-checked (`gzip -t`/`tar -tzf`); run fails loudly if zero artifacts written.
- Optional off-box mirror: operator fills `OFFBOX_RSYNC_DEST` via a service drop-in; unset = local-only.
- The existing `riskit-backup.timer` (02:00, sqlite-only, 30 daily + 12 monthly + weekly restore test) **stays enabled** — few MB of overlap buys the long sqlite history and the exercised restore path.

## 4. Monitoring — `deploy/monitoring/` (new)

`uptime_check.sh` + `riskit-uptime.{service,timer}`: every 5 min probes `https://riskittogetthebrisket.org/api/health`, the frontend root, and the local backend port; one log line per run to `/var/log/riskit-uptime.log`. **No third-party services** — notification is opt-in (`NOTIFY_WEBHOOK_URL` or `NOTIFY_CMD` via drop-in) and fires only on UP↔DOWN state changes. Honest limitation documented: it runs on the VPS, so it can't see a dead box — the script is bash+curl only and runs unchanged from any second machine.

## 5. Apply script — `deploy/apply_hardening.sh` (new)

Root-only, idempotent, `--dry-run`. nginx: diff → timestamped backup → install → `nginx -t` (**auto-restores backup on failure**) → reload. App units re-rendered through the existing `install-systemd-service.sh` (no restart performed — operator restarts at a quiet moment). Hardening units installed diff-aware (repo path rewritten if `APP_DIR` differs), `daemon-reload`, `enable --now` on the three timers, then prints the full verification checklist.

## Validation done here / not possible here

| Check | Result |
|---|---|
| Full Python test suite (`pytest tests/ -q`) | **3032 passed, 3 skipped** — proves no app code changed; the deploy-file-shape tests (`test_frontend_migration.py::TestDeployConfig`) still pass against the hardened templates |
| `bash -n` on all 4 new scripts | pass |
| `systemd-analyze verify` (systemd 255) on all 6 new units | only expected "path exists on prod box only" warnings; no syntax errors |
| Functional smoke tests in sandbox | backup script end-to-end against fixture data (sqlite online backup, tar, guards for absent `intel/`, 0600 secret modes, 14-day rotation pruning verified); uptime probe fail-path + state-change notification verified (and a curl `000000` display bug found & fixed); healthcheck 3-strike counter verified; apply script `--dry-run` verified |
| `nginx -t` | **NOT possible — nginx is not installed in the sandbox.** Config upgraded by careful review against the previous known-good file; the apply script runs `nginx -t` before any reload and auto-restores on failure, so a syntax mistake cannot take the site down |
| `shellcheck` | not available in sandbox; scripts follow existing deploy/ conventions (`set -Eeuo pipefail`, quoted expansions) |

## Operator apply + verify

```bash
cd /home/dynasty/trade-calculator && git pull --ff-only   # after merge
sudo bash deploy/apply_hardening.sh --dry-run             # review every diff
sudo bash deploy/apply_hardening.sh                       # apply + checklist
# at a quiet moment:
sudo systemctl restart dynasty-frontend dynasty
bash deploy/verify-deploy.sh
```

Rollback for every piece is in `docs/PROD-HARDENING.md` § Rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_