### PR TITLE
Player context data layer: nflverse contracts, snap share, depth charts

### DIFF
--- a/docs/playerctx.md
+++ b/docs/playerctx.md
@@ -68,7 +68,13 @@ an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
      `year_signed`), nickname → abbreviation.
    * snaps: newest season in the file, per-player mean snap % (0–100),
      last-3-games mean, `trend` = recent − season (postseason ordered
-     after REG), `side` = offense/defense by snap volume.
+     after REG), `side` = `offense`/`defense` by snap volume — or `st`
+     for pure special-teamers (kickers live entirely in
+     `st_snaps`/`st_pct`).  Aggregation identity is `pfr_player_id`;
+     ID-less rows fall back to normalized name + position family
+     *without* team so a traded player's stints stay one season line,
+     and an ID-less group whose rows play the same week twice (two
+     distinct humans on one key) is dropped rather than merged.
    * depth: newest `dt` per team, fantasy slots only (OL and
      non-kicker specialists dropped), slot abbreviations collapsed to
      `POSITION_ALIASES` families, `rank` = 1-based standing among the
@@ -125,7 +131,7 @@ an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
         "years": 4, "yearSigned": 2020, "endYear": 2023, "team": "CAR"
       },
       "snaps": {                        // optional block
-        "season": 2025, "games": 19, "side": "offense",
+        "season": 2025, "games": 19, "side": "offense",  // "offense" | "defense" | "st"
         "pct": 81.7, "recentPct": 75.3, "trend": -6.4
       },
       "depth": {                        // optional block

--- a/docs/playerctx.md
+++ b/docs/playerctx.md
@@ -1,0 +1,169 @@
+# Player Context Data Layer (`src/playerctx/`)
+
+Contracts, snap share, and depth-chart standing for every player in
+the Sleeper pool — the scouting-report-grade context the redesigned
+player profiles will consume.  This layer is **data + tooling only**:
+nothing in `server.py`, `data_contract.py`, or `frontend/` reads it
+yet.  Consumption wiring lands with the player-profile redesign (R2).
+
+## Datasets
+
+All sources are nflverse's public GitHub release assets (no auth, no
+API keys).  URLs verified live 2026-07-25.
+
+| Dataset | URL | Size | Join key |
+|---|---|---|---|
+| Contracts (OTC-sourced) | `https://github.com/nflverse/nflverse-data/releases/download/contracts/historical_contracts.csv.gz` | ~1.2 MB (~32k rows) | name + position (no gsis) |
+| Snap counts (PFR-sourced) | `https://github.com/nflverse/nflverse-data/releases/download/snap_counts/snap_counts_{season}.csv` | ~2.4 MB / season (~27k rows) | name + team + position (no gsis) |
+| Depth charts | `https://github.com/nflverse/nflverse-data/releases/download/depth_charts/depth_charts_{season}.csv` | 35–55 MB / season | `gsis_id` / `espn_id` (exact) |
+| Sleeper players directory | `https://api.sleeper.app/v1/players/nfl` | ~5 MB JSON | join anchor |
+
+Seasonal files are tried newest-calendar-year-first with a fallback to
+the prior season — snap counts for year N don't exist until the N
+season kicks off, while the depth-chart file for the upcoming season
+is refreshed daily through the offseason.
+
+### Verified schemas
+
+Contracts (`historical_contracts.csv.gz`):
+
+    player,position,team,is_active,year_signed,years,value,apy,
+    guaranteed,apy_cap_pct,inflated_value,...,otc_id,...,draft_team,
+    season_history
+
+`team` is the franchise **nickname** ("Packers"); dollars are raw
+integers; `is_active` is TRUE/FALSE.
+
+Snap counts (`snap_counts_{season}.csv`):
+
+    game_id,pfr_game_id,season,game_type,week,player,pfr_player_id,
+    position,team,opponent,offense_snaps,offense_pct,defense_snaps,
+    defense_pct,st_snaps,st_pct
+
+One row per player-game; `*_pct` are 0–1 fractions.
+
+Depth charts (`depth_charts_{season}.csv`):
+
+    dt,team,player_name,espn_id,gsis_id,pos_grp_id,pos_grp,pos_id,
+    pos_name,pos_abb,pos_slot,pos_rank
+
+The file appends a full dated snapshot (`dt`) per upstream scrape run;
+we keep only the **newest snapshot per team**.  `pos_grp` is one of
+an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
+"Special Teams".
+
+## Pipeline
+
+`scripts/refresh_playerctx.py` → `service.refresh_playerctx()`:
+
+1. **fetch** (`fetch.py`) — downloads to `data/playerctx/` (covered by
+   the repo-wide `data/` gitignore).  Honest UA, 15 s/180 s timeouts,
+   mtime freshness window (default 6 h, ≥20 h for the Sleeper dump per
+   Sleeper's rate guidance), then conditional GET via the stored
+   ETag/Last-Modified sidecar (`<file>.meta.json`); 304 just bumps the
+   mtime.  Network failure with a stale local copy degrades to the
+   copy instead of failing.
+2. **normalize** (`normalize.py`) — parse + aggregate:
+   * contracts: `is_active` rows only, one per player (latest
+     `year_signed`), nickname → abbreviation.
+   * snaps: newest season in the file, per-player mean snap % (0–100),
+     last-3-games mean, `trend` = recent − season (postseason ordered
+     after REG), `side` = offense/defense by snap volume.
+   * depth: newest `dt` per team, fantasy slots only (OL and
+     non-kicker specialists dropped), slot abbreviations collapsed to
+     `POSITION_ALIASES` families, `rank` = 1-based standing among the
+     team's players at that base position (slot starters first, then
+     backups).
+3. **join** — depth rows join by exact gsis/espn ID; contracts and
+   snaps go through the unified-mapper name ladder
+   (name+team+pos → name+pos → unique name, prebuilt as O(1) indexes;
+   residual misses fall through to
+   `src.identity.unified_mapper.resolve_player` for its manual
+   override + fuzzy layers).  Rows that don't map to the Sleeper pool
+   are dropped and counted.
+4. **floors** — schema drift (missing columns) or parsed-row counts
+   under the floors (`contracts` 1000, snap aggregates 700, depth rows
+   1200, joined players 400) or a >25 % player-count collapse vs the
+   last-good snapshot raise `SchemaRegressionError` → exit 2 and the
+   last-good snapshot is left untouched.  Soft failures (network,
+   empty parse) → exit 1.
+5. **store** (`store.py`) — atomic tmp-then-replace write of
+   `data/playerctx/snapshot.json`.
+
+## Snapshot contract (`playerctx.v1`)
+
+```jsonc
+{
+  "schemaVersion": "playerctx.v1",
+  "generatedAt": "2026-07-26T01:04:00+00:00",
+  "counts": {
+    "contracts":   {"parsed": 2907, "matched": 2281},
+    "snapCounts":  {"parsed": 2189, "matched": 1772},
+    "depthCharts": {"parsed": 2343, "matched": 2317},
+    "noGsisFallback": 786,
+    "players": 3856
+  },
+  "sources": { "contracts": {"url": "..."}, "snapCounts": {"url": "...", "season": 2025}, ... },
+  "sleeperIndex": { "<sleeper_id>": "<record key>", ... },
+  "players": {
+    "00-0033280": {
+      "gsisId": "00-0033280",
+      "sleeperId": "4034",
+      "name": "Christian McCaffrey",   // Sleeper pool is canonical
+      "team": "SF",
+      "position": "RB",                 // POSITION_ALIASES family
+      "contract": {                     // optional block
+        "apy": 16015853, "total": 64063412, "guaranteed": 36346412,
+        "years": 4, "yearSigned": 2020, "endYear": 2023, "team": "CAR"
+      },
+      "snaps": {                        // optional block
+        "season": 2025, "games": 19, "side": "offense",
+        "pct": 81.7, "recentPct": 75.3, "trend": -6.4
+      },
+      "depth": {                        // optional block
+        "position": "RB", "rank": 1, "depthPosition": "RB", "team": "SF"
+      }
+    }
+  }
+}
+```
+
+Consumer rules for the profile UI (R2):
+
+* **Look up by Sleeper ID through `sleeperIndex`** — record keys are
+  `gsis_id` when known, else `"sleeper:<sleeper_id>"` (Sleeper's gsis
+  coverage is sparse; ~⅓ of joined players key on the fallback).
+  Never assume every key is a gsis id.
+* Every context block (`contract` / `snaps` / `depth`) is optional —
+  render what exists, hide what doesn't.  ~700 players carry all
+  three.
+* `load_playerctx()` returns `None` when no valid snapshot exists —
+  "no context" is a normal state, not an error.
+* Contract caveats (upstream OTC semantics, surfaced in the
+  `parse_contracts` docstring): `contract.team` is the **signing**
+  franchise (traded contracts keep their origin team); `endYear` is
+  `yearSigned + years − 1` and can undershoot real expiry for
+  in-contract extensions; the asset can lag recent signings by weeks.
+
+## Refresh cadence
+
+**Weekly is enough.**  Contracts move on OTC's cadence (rebuilds every
+few weeks in the offseason), snap counts only change in-season, and
+depth charts are refreshed daily upstream but only matter at weekly
+granularity for dynasty context.  A run takes ~3 minutes (dominated by
+the fuzzy-match tail and the ~35 MB depth-chart download; unchanged
+files are skipped via ETag).  No GitHub Actions workflow is added in
+this PR — schedule `python3 scripts/refresh_playerctx.py` alongside
+the existing weekly jobs when the UI starts consuming the snapshot.
+
+`data/` is gitignored, so the snapshot is **not** a committed
+artifact: production materializes it by running the refresh script,
+same as the other `data/` pipeline outputs.
+
+## Observed baseline (2026-07-26 run)
+
+* contracts: 2,907 active parsed → 2,281 matched to the pool
+* snap counts (2025 season): 2,189 player aggregates → 1,772 matched
+* depth charts (2026 file): 2,343 fantasy-slot rows → 2,317 matched
+* joined players: 3,856 (715 with all three blocks)
+* snapshot: ~1.1 MB compact JSON

--- a/docs/playerctx.md
+++ b/docs/playerctx.md
@@ -76,17 +76,25 @@ an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
      backups).
 3. **join** — depth rows join by exact gsis/espn ID; contracts and
    snaps go through the unified-mapper name ladder
-   (name+team+pos → name+pos → unique name, prebuilt as O(1) indexes;
-   residual misses fall through to
-   `src.identity.unified_mapper.resolve_player` for its manual
-   override + fuzzy layers).  Rows that don't map to the Sleeper pool
-   are dropped and counted.
+   (name+team+pos → name+pos → unique name, prebuilt as O(1) indexes).
+   Manual overrides (`config/identity/id_overrides.json`, same file
+   and loader as the unified mapper) are reverse-indexed by normalized
+   full_name / gsis_id / espn_id → sleeper_id and consulted after the
+   deterministic rungs miss but before the fuzzy fallback — an
+   operator-pinned mapping beats a fuzzy guess, and a source row that
+   depends on an override is never dropped.  Residual misses fall
+   through to `src.identity.unified_mapper.resolve_player` for its
+   fuzzy layer.  Rows that still don't map to the Sleeper pool are
+   dropped and counted.
 4. **floors** — schema drift (missing columns) or parsed-row counts
    under the floors (`contracts` 1000, snap aggregates 700, depth rows
-   1200, joined players 400) or a >25 % player-count collapse vs the
-   last-good snapshot raise `SchemaRegressionError` → exit 2 and the
-   last-good snapshot is left untouched.  Soft failures (network,
-   empty parse) → exit 1.
+   1200, joined players 400) raise `SchemaRegressionError` → exit 2.
+   Retention vs the last-good snapshot is checked twice: the union
+   (>25 % player-count collapse) AND each source's matched count
+   individually, so one source regressing semantically (e.g. contracts
+   matching nothing after a naming change) can't hide behind a healthy
+   total.  Either breach → exit 2 with the last-good snapshot left
+   untouched.  Soft failures (network, empty parse) → exit 1.
 5. **store** (`store.py`) — atomic tmp-then-replace write of
    `data/playerctx/snapshot.json`.
 

--- a/docs/playerctx.md
+++ b/docs/playerctx.md
@@ -19,9 +19,14 @@ API keys).  URLs verified live 2026-07-25.
 | Sleeper players directory | `https://api.sleeper.app/v1/players/nfl` | ~5 MB JSON | join anchor |
 
 Seasonal files are tried newest-calendar-year-first with a fallback to
-the prior season — snap counts for year N don't exist until the N
-season kicks off, while the depth-chart file for the upcoming season
-is refreshed daily through the offseason.
+the prior season **only on a genuine upstream 404** — snap counts for
+year N don't exist until the N season kicks off, while the depth-chart
+file for the upcoming season is refreshed daily through the offseason.
+A transient failure (timeout / 5xx / connection error) on the current
+season stops the walk instead of quietly publishing last year's file:
+with no local copy the refresh fails (exit 1) and the last-good
+snapshot stays untouched; with a local copy of that season the stale
+copy is used.
 
 ### Verified schemas
 
@@ -83,15 +88,20 @@ an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
 3. **join** — depth rows join by exact gsis/espn ID; contracts and
    snaps go through the unified-mapper name ladder
    (name+team+pos → name+pos → unique name, prebuilt as O(1) indexes).
+   Each deterministic rung accepts only a **unique** candidate: when
+   two active pool players share a normalized name + position family
+   and the source team is absent or stale (contracts carry the signing
+   team), the row is never attached to "whichever was indexed first".
    Manual overrides (`config/identity/id_overrides.json`, same file
    and loader as the unified mapper) are reverse-indexed by normalized
    full_name / gsis_id / espn_id → sleeper_id and consulted after the
    deterministic rungs miss but before the fuzzy fallback — an
-   operator-pinned mapping beats a fuzzy guess, and a source row that
-   depends on an override is never dropped.  Residual misses fall
-   through to `src.identity.unified_mapper.resolve_player` for its
-   fuzzy layer.  Rows that still don't map to the Sleeper pool are
-   dropped and counted.
+   operator-pinned mapping settles ambiguity and beats a fuzzy guess.
+   Unknown names (zero candidates) fall through to
+   `src.identity.unified_mapper.resolve_player` for its fuzzy layer;
+   ambiguous names never do (its candidate walk is first-match-wins) —
+   without an override they are dropped (drop-don't-guess).  Rows that
+   still don't map to the Sleeper pool are dropped and counted.
 4. **floors** — schema drift (missing columns) or parsed-row counts
    under the floors (`contracts` 1000, snap aggregates 700, depth rows
    1200, joined players 400) raise `SchemaRegressionError` → exit 2.

--- a/docs/playerctx.md
+++ b/docs/playerctx.md
@@ -26,7 +26,10 @@ A transient failure (timeout / 5xx / connection error) on the current
 season stops the walk instead of quietly publishing last year's file:
 with no local copy the refresh fails (exit 1) and the last-good
 snapshot stays untouched; with a local copy of that season the stale
-copy is used.
+copy is used.  A 404 on a file we already hold locally (asset removed
+or temporarily unavailable upstream) also degrades to the cached copy
+rather than regressing to the prior season — only a 404 with no local
+copy walks on.
 
 ### Verified schemas
 
@@ -73,9 +76,10 @@ an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
      `year_signed`), nickname → abbreviation.
    * snaps: newest season in the file, per-player mean snap % (0–100),
      last-3-games mean, `trend` = recent − season (postseason ordered
-     after REG), `side` = `offense`/`defense` by snap volume — or `st`
-     for pure special-teamers (kickers live entirely in
-     `st_snaps`/`st_pct`).  Aggregation identity is `pfr_player_id`;
+     after REG), `side` = whichever unit has the MOST snaps across
+     offense / defense / special teams (tie precedence
+     defense > offense > st) — so a kicker with one trick-play
+     offensive snap still classifies `st` with his real ST share.  Aggregation identity is `pfr_player_id`;
      ID-less rows fall back to normalized name + position family
      *without* team so a traded player's stints stay one season line,
      and an ID-less group whose rows play the same week twice (two
@@ -92,6 +96,9 @@ an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
    two active pool players share a normalized name + position family
    and the source team is absent or stale (contracts carry the signing
    team), the row is never attached to "whichever was indexed first".
+   The team rung is consulted only when the source actually supplies a
+   team — a teamless row must not pseudo-match a free agent's
+   empty-team index entry.
    Manual overrides (`config/identity/id_overrides.json`, same file
    and loader as the unified mapper) are reverse-indexed by normalized
    full_name / gsis_id / espn_id → sleeper_id and consulted after the
@@ -100,8 +107,12 @@ an offensive formation ("3WR 1TE"), "Base 3-4 D" / "Base 4-3 D", or
    Unknown names (zero candidates) fall through to
    `src.identity.unified_mapper.resolve_player` for its fuzzy layer;
    ambiguous names never do (its candidate walk is first-match-wins) —
-   without an override they are dropped (drop-don't-guess).  Rows that
-   still don't map to the Sleeper pool are dropped and counted.
+   without an override they are dropped (drop-don't-guess).  Team is
+   decisive in the fuzzy tail: when the source names a team, fuzzy
+   runs against that team's sub-pool only, so a team-matching
+   candidate wins even at a lower score and a row never crosses teams
+   on a fuzzy guess; teamless rows fuzzy against the full pool.  Rows
+   that still don't map to the Sleeper pool are dropped and counted.
 4. **floors** — schema drift (missing columns) or parsed-row counts
    under the floors (`contracts` 1000, snap aggregates 700, depth rows
    1200, joined players 400) raise `SchemaRegressionError` → exit 2.

--- a/scripts/refresh_playerctx.py
+++ b/scripts/refresh_playerctx.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Refresh the player-context snapshot (contracts, snap share, depth
+charts) from nflverse's public datasets.
+
+Downloads land in ``data/playerctx/`` (gitignored raw cache) and the
+joined output is written atomically to
+``data/playerctx/snapshot.json``.  See ``docs/playerctx.md`` for the
+dataset URLs, schemas, and the consumption contract.
+
+Run
+---
+
+    python3 scripts/refresh_playerctx.py
+    python3 scripts/refresh_playerctx.py --force          # ignore freshness window
+    python3 scripts/refresh_playerctx.py --dry-run        # fetch + parse, no snapshot write
+
+Exit codes (repo convention — see scripts/fetch_fantasynavigator.py):
+    0  - success, snapshot written (or --dry-run parse OK)
+    1  - soft failure (fetch / parse error, missing dataset)
+    2  - schema regression (columns missing, row counts below floors,
+         or player-count collapse vs the last-good snapshot)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.playerctx import fetch as fetch_mod  # noqa: E402
+from src.playerctx import normalize as norm  # noqa: E402
+from src.playerctx.normalize import SchemaRegressionError  # noqa: E402
+from src.playerctx.service import refresh_playerctx  # noqa: E402
+
+
+def _dry_run(args: argparse.Namespace) -> int:
+    bundle = fetch_mod.fetch_all(
+        cache_dir=args.cache_dir, max_age_hours=args.max_age_hours, force=args.force
+    )
+    for w in bundle.warnings:
+        print(f"[refresh_playerctx] warning: {w}", file=sys.stderr)
+    if not (bundle.contracts and bundle.snap_counts and bundle.depth_charts):
+        print("[refresh_playerctx] dry-run: dataset(s) unavailable", file=sys.stderr)
+        return 1
+    contracts = norm.parse_contracts(bundle.contracts)
+    snaps = norm.aggregate_snaps(norm.parse_snap_counts(bundle.snap_counts))
+    depth = norm.parse_depth_charts(bundle.depth_charts)
+    print(
+        f"[refresh_playerctx] dry-run: contracts={len(contracts)} "
+        f"snapPlayers={len(snaps)} (season {bundle.snap_counts_season}) "
+        f"depthRows={len(depth)} (season {bundle.depth_charts_season}); "
+        "no snapshot written"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force", action="store_true", help="re-download even if the cache is fresh"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="fetch + parse only; skip join and snapshot write"
+    )
+    parser.add_argument(
+        "--cache-dir", type=Path, default=None, help="raw cache dir (default data/playerctx/)"
+    )
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        default=None,
+        help="snapshot output path (default data/playerctx/snapshot.json)",
+    )
+    parser.add_argument(
+        "--max-age-hours",
+        type=float,
+        default=fetch_mod.DEFAULT_MAX_AGE_HOURS,
+        help="skip re-downloading files younger than this",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.dry_run:
+            return _dry_run(args)
+        summary = refresh_playerctx(
+            force=args.force,
+            max_age_hours=args.max_age_hours,
+            cache_dir=args.cache_dir,
+            snapshot_path=args.snapshot,
+        )
+    except SchemaRegressionError as exc:
+        print(f"[refresh_playerctx] schema regression: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # noqa: BLE001 — CLI boundary: any other failure is a soft fail
+        print(f"[refresh_playerctx] failed: {exc}", file=sys.stderr)
+        return 1
+
+    for w in summary["warnings"]:
+        print(f"[refresh_playerctx] warning: {w}", file=sys.stderr)
+    counts = summary["counts"]
+    print(
+        f"[refresh_playerctx] players={counts.get('players')} "
+        f"contractsMatched={counts.get('contracts', {}).get('matched')} "
+        f"snapsMatched={counts.get('snapCounts', {}).get('matched')} "
+        f"depthMatched={counts.get('depthCharts', {}).get('matched')} "
+        f"-> {summary['snapshotPath']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/playerctx/__init__.py
+++ b/src/playerctx/__init__.py
@@ -1,0 +1,28 @@
+"""Player-context data layer: contracts, snap share, depth charts.
+
+Pre-builds the scouting-report-grade context the redesigned player
+profiles will consume.  Sources are nflverse's public datasets
+(github.com/nflverse/nflverse-data releases), joined to the Sleeper
+player pool via ``src.identity.unified_mapper``.
+
+Modules:
+    fetch      — download raw datasets to ``data/playerctx/`` (gitignored)
+    normalize  — parse + aggregate into compact per-player records
+    store      — atomic JSON snapshot persistence
+    service    — ``refresh_playerctx()`` / ``load_playerctx()`` entry points
+
+This package is deliberately NOT wired into ``server.py`` or the
+``/api/data`` contract yet — consumption wiring lands with the player
+profile redesign (R2).  Nothing imports this at server runtime today.
+"""
+
+from __future__ import annotations
+
+from src.playerctx.normalize import SchemaRegressionError
+from src.playerctx.service import load_playerctx, refresh_playerctx
+
+__all__ = [
+    "SchemaRegressionError",
+    "load_playerctx",
+    "refresh_playerctx",
+]

--- a/src/playerctx/fetch.py
+++ b/src/playerctx/fetch.py
@@ -201,6 +201,17 @@ def fetch_url(
                         fh.write(chunk)
                         size += len(chunk)
             tmp.replace(dest)
+        except requests.RequestException as exc:
+            # A connection reset MID-STREAM (very possible on the
+            # 35-55 MB depth-chart file) must degrade to the stale
+            # local copy exactly like a failure at request start —
+            # never fail the whole refresh while a usable cache sits
+            # on disk.
+            tmp.unlink(missing_ok=True)
+            if dest.exists():
+                log.warning("playerctx[%s]: stream failed (%s); keeping stale local copy", key, exc)
+                return FetchResult(key=key, path=dest, status="error", detail=f"stream: {exc}")
+            return FetchResult(key=key, path=None, status="error", detail=f"stream: {exc}")
         except BaseException:
             tmp.unlink(missing_ok=True)
             raise

--- a/src/playerctx/fetch.py
+++ b/src/playerctx/fetch.py
@@ -183,6 +183,16 @@ def fetch_url(
             _save_meta(dest, meta)
             return FetchResult(key=key, path=dest, status="not-modified")
         if resp.status_code == 404:
+            if dest.exists():
+                # The asset vanished upstream (removed / temporarily
+                # unavailable) but we HAVE a local copy of this exact
+                # file.  Discarding it would let the seasonal walk
+                # replace current-season data with last year's —
+                # degrade to the cached copy like any other failure.
+                log.warning("playerctx[%s]: upstream 404; keeping stale local copy", key)
+                return FetchResult(
+                    key=key, path=dest, status="error", detail="404 (stale local copy)"
+                )
             return FetchResult(key=key, path=None, status="missing", detail="404")
         if resp.status_code != 200:
             detail = f"HTTP {resp.status_code}"

--- a/src/playerctx/fetch.py
+++ b/src/playerctx/fetch.py
@@ -1,0 +1,340 @@
+"""Download the raw player-context datasets to ``data/playerctx/``.
+
+Datasets (all public, no auth):
+
+1. **Contracts** — OTC-sourced contracts published by nflverse::
+
+       https://github.com/nflverse/nflverse-data/releases/download/contracts/historical_contracts.csv.gz
+
+   ~32k rows, ~1.2 MB gzipped.  One release-level file (not seasonal).
+   Verified 2026-07-25: columns ``player, position, team, is_active,
+   year_signed, years, value, apy, guaranteed, ...`` — no gsis_id, so
+   the join runs on name+position through the unified mapper.
+
+2. **Snap counts** — PFR-sourced weekly snap counts, one file per
+   season::
+
+       https://github.com/nflverse/nflverse-data/releases/download/snap_counts/snap_counts_{season}.csv
+
+   ~27k rows / ~2.4 MB per season.  Keys on ``pfr_player_id`` +
+   name/team/position (no gsis_id).  The current calendar year's file
+   does not exist until the season starts, so we walk a season
+   fallback list newest-first.
+
+3. **Depth charts** — team depth charts, one file per season::
+
+       https://github.com/nflverse/nflverse-data/releases/download/depth_charts/depth_charts_{season}.csv
+
+   Large (35-55 MB — the file appends a dated snapshot per scrape run;
+   ``normalize`` keeps only the newest snapshot per team).  Carries
+   ``gsis_id`` AND ``espn_id`` → exact-ID join.  Refreshed by nflverse
+   through the offseason, so the current-year file usually exists
+   before the season starts.
+
+4. **Sleeper players directory** — the join anchor
+   (``https://api.sleeper.app/v1/players/nfl``, ~5 MB JSON).  Cached
+   like the rest; Sleeper asks integrators to fetch this at most ~once
+   a day, which the freshness window enforces.
+
+Caching:
+    Every download lands in ``data/playerctx/`` (covered by the
+    repo-wide ``data/`` gitignore — nothing to add).  A sidecar
+    ``<file>.meta.json`` records the served ETag / Last-Modified, and
+    re-fetches are skipped entirely while the local file is younger
+    than ``max_age_hours`` (mtime check).  Past the window we issue a
+    conditional GET (``If-None-Match`` / ``If-Modified-Since``) and a
+    304 just refreshes the mtime.  GitHub's release-asset host serves
+    both validators (verified live).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+log = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CACHE_DIR = REPO_ROOT / "data" / "playerctx"
+
+# Honest UA — this is a low-volume weekly fetcher, not a browser.
+USER_AGENT = (
+    "riskittogetthebrisket-playerctx/1.0 "
+    "(+https://github.com/jasonleetucker-code/riskittogetthebrisket; "
+    "dynasty fantasy football research; weekly cadence)"
+)
+
+_NFLVERSE_BASE = "https://github.com/nflverse/nflverse-data/releases/download"
+CONTRACTS_URL = f"{_NFLVERSE_BASE}/contracts/historical_contracts.csv.gz"
+SNAP_COUNTS_URL_TMPL = f"{_NFLVERSE_BASE}/snap_counts/snap_counts_{{season}}.csv"
+DEPTH_CHARTS_URL_TMPL = f"{_NFLVERSE_BASE}/depth_charts/depth_charts_{{season}}.csv"
+SLEEPER_PLAYERS_URL = "https://api.sleeper.app/v1/players/nfl"
+
+# (connect, read) — the depth-chart file is ~50 MB, give it room.
+_TIMEOUT: tuple[int, int] = (15, 180)
+
+# Default freshness window.  These datasets move at most daily; the
+# refresh cadence is weekly, so anything younger than 6h is "fresh".
+DEFAULT_MAX_AGE_HOURS = 6.0
+
+
+@dataclass
+class FetchResult:
+    """Outcome of one dataset fetch."""
+
+    key: str
+    path: Path | None
+    status: str  # "downloaded" | "not-modified" | "fresh-skip" | "missing" | "error"
+    detail: str = ""
+
+
+@dataclass
+class FetchBundle:
+    """Everything ``service.refresh_playerctx`` needs from the network."""
+
+    contracts: Path | None = None
+    snap_counts: Path | None = None
+    snap_counts_season: int | None = None
+    depth_charts: Path | None = None
+    depth_charts_season: int | None = None
+    sleeper_players: Path | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+def _meta_path(dest: Path) -> Path:
+    # NOT ``with_suffix`` — that would eat the ``.gz`` of ``*.csv.gz``.
+    return dest.parent / (dest.name + ".meta.json")
+
+
+def _load_meta(dest: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(_meta_path(dest).read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_meta(dest: Path, meta: dict[str, Any]) -> None:
+    try:
+        _meta_path(dest).write_text(
+            json.dumps(meta, ensure_ascii=False, indent=1), encoding="utf-8"
+        )
+    except OSError as exc:  # meta is an optimization, never fatal
+        log.warning("playerctx: could not write meta for %s: %s", dest.name, exc)
+
+
+def _is_fresh(dest: Path, max_age_hours: float) -> bool:
+    try:
+        age_sec = time.time() - dest.stat().st_mtime
+    except OSError:
+        return False
+    return age_sec < max_age_hours * 3600.0
+
+
+def fetch_url(
+    url: str,
+    dest: Path,
+    *,
+    key: str = "",
+    max_age_hours: float = DEFAULT_MAX_AGE_HOURS,
+    force: bool = False,
+    session: requests.Session | None = None,
+) -> FetchResult:
+    """Download ``url`` to ``dest`` with freshness + conditional-GET skip.
+
+    Returns a :class:`FetchResult`; ``path`` is ``None`` only for a 404
+    (``status="missing"``) or a hard error with no usable local copy.
+    A network error when a stale local copy exists degrades to that
+    copy (``status="error"`` but ``path`` set) so a flaky mirror never
+    wipes out last-good data.
+    """
+    key = key or dest.name
+    if not force and dest.exists() and _is_fresh(dest, max_age_hours):
+        return FetchResult(key=key, path=dest, status="fresh-skip")
+
+    headers = {"User-Agent": USER_AGENT, "Accept": "*/*"}
+    meta = _load_meta(dest)
+    if dest.exists() and not force:
+        if meta.get("etag"):
+            headers["If-None-Match"] = str(meta["etag"])
+        if meta.get("lastModified"):
+            headers["If-Modified-Since"] = str(meta["lastModified"])
+
+    http = session or requests
+    try:
+        resp = http.get(url, headers=headers, timeout=_TIMEOUT, stream=True)
+    except requests.RequestException as exc:
+        if dest.exists():
+            log.warning("playerctx[%s]: fetch failed (%s); keeping stale local copy", key, exc)
+            return FetchResult(key=key, path=dest, status="error", detail=str(exc))
+        return FetchResult(key=key, path=None, status="error", detail=str(exc))
+
+    try:
+        if resp.status_code == 304:
+            dest.touch()
+            meta["checkedAt"] = datetime.now(timezone.utc).isoformat()
+            _save_meta(dest, meta)
+            return FetchResult(key=key, path=dest, status="not-modified")
+        if resp.status_code == 404:
+            return FetchResult(key=key, path=None, status="missing", detail="404")
+        if resp.status_code != 200:
+            detail = f"HTTP {resp.status_code}"
+            if dest.exists():
+                log.warning("playerctx[%s]: %s; keeping stale local copy", key, detail)
+                return FetchResult(key=key, path=dest, status="error", detail=detail)
+            return FetchResult(key=key, path=None, status="error", detail=detail)
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dest.parent / f"{dest.name}.tmp-{int(time.time() * 1000)}"
+        size = 0
+        try:
+            with tmp.open("wb") as fh:
+                for chunk in resp.iter_content(chunk_size=1 << 16):
+                    if chunk:
+                        fh.write(chunk)
+                        size += len(chunk)
+            tmp.replace(dest)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+        _save_meta(
+            dest,
+            {
+                "url": url,
+                "etag": resp.headers.get("ETag", ""),
+                "lastModified": resp.headers.get("Last-Modified", ""),
+                "size": size,
+                "fetchedAt": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        log.info("playerctx[%s]: downloaded %d bytes", key, size)
+        return FetchResult(key=key, path=dest, status="downloaded", detail=f"{size} bytes")
+    finally:
+        resp.close()
+
+
+def _fetch_seasonal(
+    url_tmpl: str,
+    filename_tmpl: str,
+    seasons: list[int],
+    cache_dir: Path,
+    *,
+    key: str,
+    max_age_hours: float,
+    force: bool,
+    session: requests.Session | None,
+) -> tuple[Path | None, int | None, list[str]]:
+    """Try each season newest-first; first hit wins.
+
+    A 404 on the newest season is normal in the offseason (e.g. snap
+    counts for a season that hasn't kicked off) — we fall through to
+    the previous season silently.  Anything else is surfaced as a
+    warning.
+    """
+    warnings: list[str] = []
+    for season in seasons:
+        dest = cache_dir / filename_tmpl.format(season=season)
+        res = fetch_url(
+            url_tmpl.format(season=season),
+            dest,
+            key=f"{key}:{season}",
+            max_age_hours=max_age_hours,
+            force=force,
+            session=session,
+        )
+        if res.path is not None:
+            if res.status == "error":
+                warnings.append(f"{key} {season}: {res.detail} (using stale local copy)")
+            return res.path, season, warnings
+        if res.status != "missing":
+            warnings.append(f"{key} {season}: {res.status} {res.detail}")
+    warnings.append(f"{key}: no season file available for {seasons}")
+    return None, None, warnings
+
+
+def default_seasons(now: datetime | None = None) -> list[int]:
+    """Newest-first season candidates: current calendar year, then the
+    prior one.  During the offseason the current-year snap-count file
+    does not exist yet and the walk lands on the completed season."""
+    year = (now or datetime.now(timezone.utc)).year
+    return [year, year - 1]
+
+
+def fetch_all(
+    *,
+    cache_dir: Path | None = None,
+    seasons: list[int] | None = None,
+    max_age_hours: float = DEFAULT_MAX_AGE_HOURS,
+    force: bool = False,
+    session: requests.Session | None = None,
+) -> FetchBundle:
+    """Fetch every dataset the player-context snapshot needs.
+
+    Individual dataset failures degrade to ``None`` + a warning rather
+    than raising — ``service.refresh_playerctx`` decides what is fatal
+    (schema floors) and what is a soft miss.
+    """
+    cache = cache_dir or CACHE_DIR
+    cache.mkdir(parents=True, exist_ok=True)
+    season_list = seasons or default_seasons()
+    bundle = FetchBundle()
+
+    res = fetch_url(
+        CONTRACTS_URL,
+        cache / "historical_contracts.csv.gz",
+        key="contracts",
+        max_age_hours=max_age_hours,
+        force=force,
+        session=session,
+    )
+    bundle.contracts = res.path
+    if res.path is None or res.status == "error":
+        bundle.warnings.append(f"contracts: {res.status} {res.detail}")
+
+    bundle.snap_counts, bundle.snap_counts_season, warns = _fetch_seasonal(
+        SNAP_COUNTS_URL_TMPL,
+        "snap_counts_{season}.csv",
+        season_list,
+        cache,
+        key="snap_counts",
+        max_age_hours=max_age_hours,
+        force=force,
+        session=session,
+    )
+    bundle.warnings.extend(warns)
+
+    bundle.depth_charts, bundle.depth_charts_season, warns = _fetch_seasonal(
+        DEPTH_CHARTS_URL_TMPL,
+        "depth_charts_{season}.csv",
+        season_list,
+        cache,
+        key="depth_charts",
+        max_age_hours=max_age_hours,
+        force=force,
+        session=session,
+    )
+    bundle.warnings.extend(warns)
+
+    # Sleeper's guidance is ≤ ~1 fetch/day for the full players dump;
+    # a wider freshness window enforces that even under --force-free
+    # repeat runs.
+    res = fetch_url(
+        SLEEPER_PLAYERS_URL,
+        cache / "sleeper_players.json",
+        key="sleeper_players",
+        max_age_hours=max(max_age_hours, 20.0),
+        force=force,
+        session=session,
+    )
+    bundle.sleeper_players = res.path
+    if res.path is None or res.status == "error":
+        bundle.warnings.append(f"sleeper_players: {res.status} {res.detail}")
+
+    return bundle

--- a/src/playerctx/fetch.py
+++ b/src/playerctx/fetch.py
@@ -244,10 +244,16 @@ def _fetch_seasonal(
 ) -> tuple[Path | None, int | None, list[str]]:
     """Try each season newest-first; first hit wins.
 
-    A 404 on the newest season is normal in the offseason (e.g. snap
-    counts for a season that hasn't kicked off) — we fall through to
-    the previous season silently.  Anything else is surfaced as a
-    warning.
+    Only a 404 walks on to the prior season — that is the one signal
+    that the season file genuinely doesn't exist upstream yet (normal
+    in the offseason for snap counts).  A TRANSIENT failure (timeout /
+    5xx / connection error) with no usable local copy STOPS the walk
+    and reports no path: mid-season, silently publishing last year's
+    snaps or depth charts would look plausible enough to sail past the
+    retention guards, so the refresh must fail instead and leave the
+    existing last-good snapshot untouched.  A transient failure WITH a
+    local copy of that season still degrades to the stale copy
+    (``fetch_url`` returns it with ``status="error"``).
     """
     warnings: list[str] = []
     for season in seasons:
@@ -265,7 +271,13 @@ def _fetch_seasonal(
                 warnings.append(f"{key} {season}: {res.detail} (using stale local copy)")
             return res.path, season, warnings
         if res.status != "missing":
-            warnings.append(f"{key} {season}: {res.status} {res.detail}")
+            # Transient / unexpected failure with no local fallback —
+            # do NOT mask it with a prior-season download.
+            warnings.append(
+                f"{key} {season}: {res.status} {res.detail} "
+                "(transient failure — refusing prior-season fallback)"
+            )
+            return None, None, warnings
     warnings.append(f"{key}: no season file available for {seasons}")
     return None, None, warnings
 

--- a/src/playerctx/normalize.py
+++ b/src/playerctx/normalize.py
@@ -42,7 +42,7 @@ import logging
 from pathlib import Path
 from typing import Any, TextIO
 
-from src.identity.unified_mapper import resolve_player
+from src.identity.unified_mapper import _load_overrides, resolve_player
 from src.utils.name_clean import normalize_player_name, normalize_position
 
 log = logging.getLogger(__name__)
@@ -485,6 +485,7 @@ def build_player_context(
     depth: list[dict[str, Any]],
     players_dir: dict[str, dict[str, Any]],
     min_confidence: float = 0.90,
+    overrides_path: Path | None = None,
 ) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
     """Join the three datasets to the Sleeper pool.
 
@@ -501,11 +502,40 @@ def build_player_context(
     deterministic name ladder the unified mapper implements
     (name+team+pos → name+pos → unique name, built here as O(1)
     indexes because ``resolve_player`` re-indexes the pool on every
-    call); residual misses fall through to
-    :func:`src.identity.unified_mapper.resolve_player` so its manual
-    override + fuzzy layers get the last word.  Rows that still don't
-    map to the Sleeper pool are dropped and counted.
+    call).
+
+    Manual overrides (``config/identity/id_overrides.json``, same file
+    and loader as the unified mapper — ``overrides_path`` overrides the
+    location for tests) genuinely get the last word: the override
+    entries are reverse-indexed by normalized full_name / gsis_id /
+    espn_id → sleeper_id and consulted after the deterministic rungs
+    miss but BEFORE the fuzzy fallback, so an operator-pinned mapping
+    beats a fuzzy guess and a source row that depends on an override is
+    never dropped.  (``resolve_player`` alone can't do this for source
+    rows — its override rung only fires when a ``sleeper_id`` is
+    supplied, which external datasets never have.)  Residual misses
+    still fall through to
+    :func:`src.identity.unified_mapper.resolve_player` for its fuzzy
+    layer.  Rows that still don't map to the Sleeper pool are dropped
+    and counted.
     """
+    overrides = _load_overrides(overrides_path)
+    alias_by_name: dict[str, str] = {}
+    alias_by_gsis: dict[str, str] = {}
+    alias_by_espn: dict[str, str] = {}
+    for sid, ov in overrides.items():
+        if not isinstance(ov, dict):
+            continue
+        ov_name = normalize_player_name(str(ov.get("full_name") or ""))
+        if ov_name:
+            alias_by_name.setdefault(ov_name, str(sid))
+        ov_gsis = str(ov.get("gsis_id") or "").strip()
+        if ov_gsis:
+            alias_by_gsis.setdefault(ov_gsis, str(sid))
+        ov_espn = str(ov.get("espn_id") or "").strip()
+        if ov_espn:
+            alias_by_espn.setdefault(ov_espn, str(sid))
+
     by_gsis: dict[str, dict[str, Any]] = {}
     by_espn: dict[str, dict[str, Any]] = {}
     by_name_team_pos: dict[tuple[str, str, str], dict[str, Any]] = {}
@@ -539,10 +569,18 @@ def build_player_context(
             or by_name_pos.get((norm_name, fam))
             or (by_name[norm_name][0] if len(by_name.get(norm_name, [])) == 1 else None)
         )
+        if hit is None and norm_name in alias_by_name:
+            # Manual override (id_overrides.json) — an operator-pinned
+            # source-name → sleeper_id mapping beats the fuzzy guess
+            # below.  ``resolve_player`` can't reach its own override
+            # rung for source rows (it requires a sleeper_id input),
+            # so the alias index is what makes overrides effective
+            # here.
+            hit = players_dir.get(alias_by_name[norm_name])
         if hit is None:
-            # Tail cases only: the mapper's manual-override + fuzzy
-            # layers.  Too slow for the hot path (it re-indexes the
-            # pool per call) but right for the residue.
+            # Tail cases only: the mapper's fuzzy layer.  Too slow for
+            # the hot path (it re-indexes the pool per call) but right
+            # for the residue.
             got = resolve_player(
                 players_dir,
                 name=name,
@@ -589,6 +627,10 @@ def build_player_context(
 
     for d in compute_depth_ranks(depth):
         pool_rec = by_gsis.get(d["gsisId"]) or by_espn.get(d["espnId"])
+        if pool_rec is None and d["gsisId"] in alias_by_gsis:
+            pool_rec = players_dir.get(alias_by_gsis[d["gsisId"]])
+        if pool_rec is None and d["espnId"] in alias_by_espn:
+            pool_rec = players_dir.get(alias_by_espn[d["espnId"]])
         if pool_rec is None:
             pool_rec = _resolve_by_name(d["name"], d["team"], d["position"])
         if pool_rec is None:

--- a/src/playerctx/normalize.py
+++ b/src/playerctx/normalize.py
@@ -80,6 +80,8 @@ SNAPS_REQUIRED_COLS: frozenset[str] = frozenset(
         "offense_pct",
         "defense_snaps",
         "defense_pct",
+        "st_snaps",
+        "st_pct",
     }
 )
 DEPTH_REQUIRED_COLS: frozenset[str] = frozenset(
@@ -321,6 +323,8 @@ def parse_snap_counts(path: Path) -> list[dict[str, Any]]:
                     "offPct": _to_float(row.get("offense_pct")) or 0.0,
                     "defSnaps": _to_int(row.get("defense_snaps")) or 0,
                     "defPct": _to_float(row.get("defense_pct")) or 0.0,
+                    "stSnaps": _to_int(row.get("st_snaps")) or 0,
+                    "stPct": _to_float(row.get("st_pct")) or 0.0,
                 }
             )
     return [r for r in rows if r["season"] == max_season]
@@ -331,20 +335,58 @@ def aggregate_snaps(rows: list[dict[str, Any]], *, recent_games: int = 3) -> lis
 
     ``pct`` / ``recentPct`` are 0-100 with one decimal; ``trend`` is
     recent-minus-season (positive = usage climbing late).  ``side`` is
-    whichever unit the player actually plays (more snaps wins).
+    whichever unit the player actually plays (more snaps wins):
+    ``"offense"`` / ``"defense"``, or ``"st"`` for pure special-teamers
+    (kickers — retained in the pool as K — live entirely in
+    ``st_snaps``/``st_pct``; without this they'd publish a misleading
+    "offense 0%" block).
+
+    Aggregation identity: ``pfr_player_id`` when present.  The ID-less
+    fallback is normalized name + position family WITHOUT team — a
+    traded player's stints must aggregate into one season line, not
+    split per team (both stints would resolve to the same Sleeper
+    record and the last one would silently overwrite the block).  If
+    two DISTINCT ID-less players collide on that key they betray
+    themselves by playing the same week twice; such ambiguous groups
+    are dropped with a warning rather than merged (same
+    drop-don't-guess convention as the identity pipeline).
     """
     by_player: dict[str, list[dict[str, Any]]] = {}
+    fallback_keys: set[str] = set()
     for r in rows:
-        key = r["pfrId"] or f"{r['name'].lower()}|{r['team']}"
+        key = r["pfrId"]
+        if not key:
+            key = f"{normalize_player_name(r['name'])}|{normalize_position(r['position'])}"
+            fallback_keys.add(key)
         by_player.setdefault(key, []).append(r)
 
     out: list[dict[str, Any]] = []
-    for games in by_player.values():
+    for key, games in by_player.items():
+        if key in fallback_keys:
+            game_slots = [(g["gameType"], g["week"]) for g in games]
+            if len(set(game_slots)) != len(game_slots):
+                # Two rows in the same week can't be one human — this
+                # ID-less key covers distinct players.  Merging would
+                # publish a chimera; drop instead.
+                log.warning(
+                    "playerctx: dropping ambiguous ID-less snap aggregate %r "
+                    "(%d rows, duplicate week entries)",
+                    games[0]["name"],
+                    len(games),
+                )
+                continue
         games.sort(key=lambda g: (_GAME_TYPE_ORDER.get(g["gameType"], 9), g["week"]))
         off_total = sum(g["offSnaps"] for g in games)
         def_total = sum(g["defSnaps"] for g in games)
-        side = "defense" if def_total > off_total else "offense"
-        pct_key = "defPct" if side == "defense" else "offPct"
+        st_total = sum(g["stSnaps"] for g in games)
+        if def_total > off_total:
+            side, pct_key = "defense", "defPct"
+        elif off_total > 0:
+            side, pct_key = "offense", "offPct"
+        elif st_total > 0:
+            side, pct_key = "st", "stPct"
+        else:  # degenerate all-zero row set — keep the legacy label
+            side, pct_key = "offense", "offPct"
         pcts = [g[pct_key] * 100.0 for g in games]
         season_mean = sum(pcts) / len(pcts)
         recent = pcts[-recent_games:]

--- a/src/playerctx/normalize.py
+++ b/src/playerctx/normalize.py
@@ -1,0 +1,637 @@
+"""Parse the raw nflverse datasets into compact per-player records.
+
+Input schemas (verified against the live assets, 2026-07-25):
+
+contracts (``historical_contracts.csv.gz``)::
+
+    player,position,team,is_active,year_signed,years,value,apy,
+    guaranteed,apy_cap_pct,...,draft_year,...
+
+    ``team`` is the franchise nickname ("Packers"), dollars are raw
+    ints, ``is_active`` is TRUE/FALSE.  No gsis_id → name+position
+    join through the unified mapper.
+
+snap counts (``snap_counts_{season}.csv``)::
+
+    game_id,pfr_game_id,season,game_type,week,player,pfr_player_id,
+    position,team,opponent,offense_snaps,offense_pct,defense_snaps,
+    defense_pct,st_snaps,st_pct
+
+    One row per player-game; pct columns are 0-1 fractions.  No
+    gsis_id → name+team+position join.
+
+depth charts (``depth_charts_{season}.csv``)::
+
+    dt,team,player_name,espn_id,gsis_id,pos_grp_id,pos_grp,pos_id,
+    pos_name,pos_abb,pos_slot,pos_rank
+
+    The file appends a full dated snapshot per scrape run; we keep
+    only the newest ``dt`` per team.  Carries gsis_id → exact join.
+
+Schema drift in any required column raises
+:class:`SchemaRegressionError`, which the refresh CLI maps to exit
+code 2 (same convention as ``scripts/fetch_fantasynavigator.py``).
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+import logging
+from pathlib import Path
+from typing import Any, TextIO
+
+from src.identity.unified_mapper import resolve_player
+from src.utils.name_clean import normalize_player_name, normalize_position
+
+log = logging.getLogger(__name__)
+
+
+class SchemaRegressionError(RuntimeError):
+    """A dataset's shape changed out from under us (missing required
+    columns, unparseable structure).  CLI exit code 2."""
+
+
+# ── Required columns (subset check — extra columns are fine) ─────────
+
+CONTRACTS_REQUIRED_COLS: frozenset[str] = frozenset(
+    {
+        "player",
+        "position",
+        "team",
+        "is_active",
+        "year_signed",
+        "years",
+        "value",
+        "apy",
+        "guaranteed",
+    }
+)
+SNAPS_REQUIRED_COLS: frozenset[str] = frozenset(
+    {
+        "season",
+        "game_type",
+        "week",
+        "player",
+        "position",
+        "team",
+        "offense_snaps",
+        "offense_pct",
+        "defense_snaps",
+        "defense_pct",
+    }
+)
+DEPTH_REQUIRED_COLS: frozenset[str] = frozenset(
+    {
+        "dt",
+        "team",
+        "player_name",
+        "gsis_id",
+        "espn_id",
+        "pos_grp",
+        "pos_abb",
+        "pos_slot",
+        "pos_rank",
+    }
+)
+
+# ── Team normalization ───────────────────────────────────────────────
+
+# Contracts carry franchise nicknames; Sleeper carries abbreviations.
+_TEAM_NICKNAME_TO_ABBR: dict[str, str] = {
+    "CARDINALS": "ARI",
+    "FALCONS": "ATL",
+    "RAVENS": "BAL",
+    "BILLS": "BUF",
+    "PANTHERS": "CAR",
+    "BEARS": "CHI",
+    "BENGALS": "CIN",
+    "BROWNS": "CLE",
+    "COWBOYS": "DAL",
+    "BRONCOS": "DEN",
+    "LIONS": "DET",
+    "PACKERS": "GB",
+    "TEXANS": "HOU",
+    "COLTS": "IND",
+    "JAGUARS": "JAX",
+    "CHIEFS": "KC",
+    "RAIDERS": "LV",
+    "CHARGERS": "LAC",
+    "RAMS": "LAR",
+    "DOLPHINS": "MIA",
+    "VIKINGS": "MIN",
+    "PATRIOTS": "NE",
+    "SAINTS": "NO",
+    "GIANTS": "NYG",
+    "JETS": "NYJ",
+    "EAGLES": "PHI",
+    "STEELERS": "PIT",
+    "49ERS": "SF",
+    "SEAHAWKS": "SEA",
+    "BUCCANEERS": "TB",
+    "TITANS": "TEN",
+    "COMMANDERS": "WAS",
+    # Legacy franchise names that can linger on active rows.
+    "REDSKINS": "WAS",
+    "FOOTBALL TEAM": "WAS",
+    "WASHINGTON": "WAS",
+}
+
+# nflverse / PFR team codes → Sleeper-style codes.
+_TEAM_CODE_ALIASES: dict[str, str] = {
+    "LA": "LAR",
+    "STL": "LAR",
+    "SL": "LAR",
+    "SD": "LAC",
+    "OAK": "LV",
+    "LVR": "LV",
+    "WSH": "WAS",
+    "ARZ": "ARI",
+    "BLT": "BAL",
+    "CLV": "CLE",
+    "HST": "HOU",
+    "JAC": "JAX",
+    "GNB": "GB",
+    "KAN": "KC",
+    "NWE": "NE",
+    "NOR": "NO",
+    "SFO": "SF",
+    "TAM": "TB",
+}
+
+
+def normalize_team_code(team: str | None) -> str:
+    t = str(team or "").strip().upper()
+    return _TEAM_CODE_ALIASES.get(t, t)
+
+
+def team_nickname_to_abbr(nickname: str | None) -> str:
+    t = str(nickname or "").strip().upper()
+    return _TEAM_NICKNAME_TO_ABBR.get(t, "")
+
+
+# ── Depth-chart position mapping ─────────────────────────────────────
+
+# ESPN depth-chart slot abbreviations → fantasy base position.
+# Slots that map to "" (OL, punters, return/long-snap specialists)
+# are dropped — they are never in the dynasty pool.
+_DEPTH_ABB_TO_BASE: dict[str, str] = {
+    "QB": "QB",
+    "RB": "RB",
+    "FB": "RB",
+    "WR": "WR",
+    "TE": "TE",
+    "PK": "K",
+    "LDE": "DL",
+    "RDE": "DL",
+    "DE": "DL",
+    "LDT": "DL",
+    "RDT": "DL",
+    "DT": "DL",
+    "NT": "DL",
+    "LILB": "LB",
+    "RILB": "LB",
+    "ILB": "LB",
+    "MLB": "LB",
+    "WLB": "LB",
+    "SLB": "LB",
+    "OLB": "LB",
+    "LB": "LB",
+    "LCB": "DB",
+    "RCB": "DB",
+    "CB": "DB",
+    "NB": "DB",
+    "DB": "DB",
+    "FS": "DB",
+    "SS": "DB",
+    "S": "DB",
+}
+
+_GAME_TYPE_ORDER: dict[str, int] = {"REG": 0, "WC": 1, "DIV": 2, "CON": 3, "SB": 4}
+
+
+def _to_int(value: Any) -> int | None:
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _open_maybe_gzip(path: Path) -> TextIO:
+    if path.name.endswith(".gz"):
+        return io.TextIOWrapper(gzip.open(path, "rb"), encoding="utf-8", newline="")
+    return path.open("r", encoding="utf-8", newline="")
+
+
+def _check_columns(fieldnames: list[str] | None, required: frozenset[str], dataset: str) -> None:
+    have = set(fieldnames or [])
+    missing = sorted(required - have)
+    if missing:
+        raise SchemaRegressionError(
+            f"{dataset}: missing required columns {missing} (have {sorted(have)})"
+        )
+
+
+# ── Contracts ────────────────────────────────────────────────────────
+
+
+def parse_contracts(path: Path) -> list[dict[str, Any]]:
+    """Active contracts only, one row per player (latest ``year_signed``
+    wins when a player carries several active rows).
+
+    Known upstream caveats (verified against the live asset — these
+    are OTC data semantics, not parse bugs; documented for the UI):
+
+    * ``team`` is the SIGNING franchise — a traded contract keeps its
+      origin team (e.g. McCaffrey's active row says Panthers).
+    * ``endYear`` = year_signed + years - 1 is approximate: OTC's
+      ``years`` counts the newly signed years, so an in-contract
+      extension's derived endYear can undershoot the real expiry.
+    * The asset is rebuilt on OTC's cadence and can lag recent
+      extensions by weeks.
+    """
+    best: dict[str, dict[str, Any]] = {}
+    with _open_maybe_gzip(path) as fh:
+        reader = csv.DictReader(fh)
+        _check_columns(reader.fieldnames, CONTRACTS_REQUIRED_COLS, "contracts")
+        for row in reader:
+            if str(row.get("is_active") or "").strip().upper() != "TRUE":
+                continue
+            name = str(row.get("player") or "").strip()
+            if not name:
+                continue
+            year_signed = _to_int(row.get("year_signed"))
+            years = _to_int(row.get("years"))
+            rec = {
+                "name": name,
+                "position": str(row.get("position") or "").strip().upper(),
+                "team": team_nickname_to_abbr(row.get("team")),
+                "apy": _to_int(row.get("apy")),
+                "total": _to_int(row.get("value")),
+                "guaranteed": _to_int(row.get("guaranteed")),
+                "years": years,
+                "yearSigned": year_signed,
+                "endYear": (year_signed + years - 1)
+                if year_signed is not None and years is not None
+                else None,
+            }
+            key = f"{name.lower()}|{rec['position']}"
+            prev = best.get(key)
+            if prev is None or (rec["yearSigned"] or 0) > (prev["yearSigned"] or 0):
+                best[key] = rec
+    return list(best.values())
+
+
+# ── Snap counts ──────────────────────────────────────────────────────
+
+
+def parse_snap_counts(path: Path) -> list[dict[str, Any]]:
+    """Per-game rows for the file's newest season, minimally typed."""
+    rows: list[dict[str, Any]] = []
+    max_season: int | None = None
+    with _open_maybe_gzip(path) as fh:
+        reader = csv.DictReader(fh)
+        _check_columns(reader.fieldnames, SNAPS_REQUIRED_COLS, "snap_counts")
+        for row in reader:
+            season = _to_int(row.get("season"))
+            week = _to_int(row.get("week"))
+            name = str(row.get("player") or "").strip()
+            if season is None or week is None or not name:
+                continue
+            if max_season is None or season > max_season:
+                max_season = season
+            rows.append(
+                {
+                    "season": season,
+                    "gameType": str(row.get("game_type") or "").strip().upper(),
+                    "week": week,
+                    "name": name,
+                    "pfrId": str(row.get("pfr_player_id") or "").strip(),
+                    "position": str(row.get("position") or "").strip().upper(),
+                    "team": normalize_team_code(row.get("team")),
+                    "offSnaps": _to_int(row.get("offense_snaps")) or 0,
+                    "offPct": _to_float(row.get("offense_pct")) or 0.0,
+                    "defSnaps": _to_int(row.get("defense_snaps")) or 0,
+                    "defPct": _to_float(row.get("defense_pct")) or 0.0,
+                }
+            )
+    return [r for r in rows if r["season"] == max_season]
+
+
+def aggregate_snaps(rows: list[dict[str, Any]], *, recent_games: int = 3) -> list[dict[str, Any]]:
+    """Collapse per-game rows into one summary per player.
+
+    ``pct`` / ``recentPct`` are 0-100 with one decimal; ``trend`` is
+    recent-minus-season (positive = usage climbing late).  ``side`` is
+    whichever unit the player actually plays (more snaps wins).
+    """
+    by_player: dict[str, list[dict[str, Any]]] = {}
+    for r in rows:
+        key = r["pfrId"] or f"{r['name'].lower()}|{r['team']}"
+        by_player.setdefault(key, []).append(r)
+
+    out: list[dict[str, Any]] = []
+    for games in by_player.values():
+        games.sort(key=lambda g: (_GAME_TYPE_ORDER.get(g["gameType"], 9), g["week"]))
+        off_total = sum(g["offSnaps"] for g in games)
+        def_total = sum(g["defSnaps"] for g in games)
+        side = "defense" if def_total > off_total else "offense"
+        pct_key = "defPct" if side == "defense" else "offPct"
+        pcts = [g[pct_key] * 100.0 for g in games]
+        season_mean = sum(pcts) / len(pcts)
+        recent = pcts[-recent_games:]
+        recent_mean = sum(recent) / len(recent)
+        last = games[-1]
+        out.append(
+            {
+                "name": last["name"],
+                "team": last["team"],
+                "position": last["position"],
+                "season": last["season"],
+                "games": len(games),
+                "side": side,
+                "pct": round(season_mean, 1),
+                "recentPct": round(recent_mean, 1),
+                "trend": round(recent_mean - season_mean, 1),
+            }
+        )
+    return out
+
+
+# ── Depth charts ─────────────────────────────────────────────────────
+
+
+def parse_depth_charts(path: Path) -> list[dict[str, Any]]:
+    """Rows of the newest snapshot (``dt``) per team, fantasy slots only.
+
+    Streaming single pass: the seasonal file replays every dated
+    snapshot (35-55 MB); we keep only rows carrying each team's newest
+    ``dt``.  ISO-8601 timestamps compare correctly as strings.
+    """
+    latest: dict[str, tuple[str, list[dict[str, Any]]]] = {}
+    with _open_maybe_gzip(path) as fh:
+        reader = csv.DictReader(fh)
+        _check_columns(reader.fieldnames, DEPTH_REQUIRED_COLS, "depth_charts")
+        for row in reader:
+            dt = str(row.get("dt") or "").strip()
+            team = normalize_team_code(row.get("team"))
+            if not dt or not team:
+                continue
+            base = _DEPTH_ABB_TO_BASE.get(str(row.get("pos_abb") or "").strip().upper(), "")
+            if not base:
+                continue  # OL / specialists — never in the dynasty pool
+            name = str(row.get("player_name") or "").strip()
+            if not name:
+                continue
+            rec = {
+                "team": team,
+                "name": name,
+                "gsisId": str(row.get("gsis_id") or "").strip(),
+                "espnId": str(row.get("espn_id") or "").strip(),
+                "position": base,
+                "depthPosition": str(row.get("pos_abb") or "").strip().upper(),
+                "slot": _to_int(row.get("pos_slot")) or 0,
+                "slotRank": _to_int(row.get("pos_rank")) or 0,
+            }
+            cur = latest.get(team)
+            if cur is None or dt > cur[0]:
+                latest[team] = (dt, [rec])
+            elif dt == cur[0]:
+                cur[1].append(rec)
+    out: list[dict[str, Any]] = []
+    for _, (_, recs) in sorted(latest.items()):
+        out.extend(recs)
+    return out
+
+
+def compute_depth_ranks(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Stamp ``rank`` — the player's 1-based standing among his team's
+    players at the same base position.
+
+    Ordering is (slotRank asc, slot asc): all the pos_rank-1 starters
+    across slots (LWR/RWR/SWR, LDE/RDE, ...) outrank every backup.  A
+    player listed in several slots (e.g. LCB + NB) keeps his best one.
+    """
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for r in rows:
+        grouped.setdefault((r["team"], r["position"]), []).append(r)
+
+    out: list[dict[str, Any]] = []
+    for members in grouped.values():
+        members.sort(key=lambda r: (r["slotRank"], r["slot"]))
+        seen: set[str] = set()
+        rank = 0
+        for r in members:
+            ident = r["gsisId"] or r["espnId"] or r["name"].lower()
+            if ident in seen:
+                continue
+            seen.add(ident)
+            rank += 1
+            rec = dict(r)
+            rec["rank"] = rank
+            out.append(rec)
+    return out
+
+
+# ── Join to the Sleeper pool ─────────────────────────────────────────
+
+_RELEVANT_FAMILIES: frozenset[str] = frozenset({"QB", "RB", "WR", "TE", "K", "DL", "LB", "DB"})
+
+
+def build_sleeper_pool(players_dump: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Filter Sleeper's full ``/v1/players/nfl`` dump to the fantasy-
+    relevant pool and canonicalize positions to family level so the
+    unified mapper's name+position rungs compare like against like.
+    """
+    pool: dict[str, dict[str, Any]] = {}
+    if not isinstance(players_dump, dict):
+        return pool
+    for pid, rec in players_dump.items():
+        if not isinstance(rec, dict):
+            continue
+        if rec.get("active") is not True:
+            continue
+        fam = normalize_position(rec.get("position"))
+        if fam not in _RELEVANT_FAMILIES:
+            continue
+        full = str(rec.get("full_name") or "").strip()
+        if not full:
+            first = str(rec.get("first_name") or "").strip()
+            last = str(rec.get("last_name") or "").strip()
+            full = f"{first} {last}".strip()
+        pool[str(pid)] = {
+            "player_id": str(pid),
+            "full_name": full,
+            "position": fam,
+            "team": normalize_team_code(rec.get("team")),
+            "gsis_id": str(rec.get("gsis_id") or "").strip(),
+            "espn_id": str(rec.get("espn_id") or "").strip(),
+        }
+    return pool
+
+
+def build_player_context(
+    *,
+    contracts: list[dict[str, Any]],
+    snaps: list[dict[str, Any]],
+    depth: list[dict[str, Any]],
+    players_dir: dict[str, dict[str, Any]],
+    min_confidence: float = 0.90,
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Join the three datasets to the Sleeper pool.
+
+    Returns ``(records, stats)``.  Records are keyed by ``gsis_id``;
+    when neither Sleeper nor the source row knows a player's gsis_id
+    (Sleeper's gsis coverage is sparse — roughly a third of the active
+    fantasy pool) the key falls back to ``"sleeper:<sleeper_id>"`` so
+    a successful join is never thrown away.  ``sleeperIndex`` in the
+    snapshot maps sleeper_id → record key either way, which is the
+    lookup the profile UI actually uses.
+
+    Depth-chart rows join by exact gsis/espn ID against the pool.
+    Contracts and snap counts (which carry no gsis) join by the same
+    deterministic name ladder the unified mapper implements
+    (name+team+pos → name+pos → unique name, built here as O(1)
+    indexes because ``resolve_player`` re-indexes the pool on every
+    call); residual misses fall through to
+    :func:`src.identity.unified_mapper.resolve_player` so its manual
+    override + fuzzy layers get the last word.  Rows that still don't
+    map to the Sleeper pool are dropped and counted.
+    """
+    by_gsis: dict[str, dict[str, Any]] = {}
+    by_espn: dict[str, dict[str, Any]] = {}
+    by_name_team_pos: dict[tuple[str, str, str], dict[str, Any]] = {}
+    by_name_pos: dict[tuple[str, str], dict[str, Any]] = {}
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for p in players_dir.values():
+        if p.get("gsis_id"):
+            by_gsis[p["gsis_id"]] = p
+        if p.get("espn_id"):
+            by_espn[p["espn_id"]] = p
+        norm_name = normalize_player_name(p.get("full_name"))
+        if not norm_name:
+            continue
+        pos = str(p.get("position") or "").upper()
+        team = str(p.get("team") or "").upper()
+        by_name_team_pos.setdefault((norm_name, team, pos), p)
+        by_name_pos.setdefault((norm_name, pos), p)
+        by_name.setdefault(norm_name, []).append(p)
+
+    resolve_cache: dict[tuple[str, str, str], dict[str, Any] | None] = {}
+
+    def _resolve_by_name(name: str, team: str, position: str) -> dict[str, Any] | None:
+        fam = normalize_position(position)
+        team_u = (team or "").upper()
+        key = (name.lower(), team_u, fam)
+        if key in resolve_cache:
+            return resolve_cache[key]
+        norm_name = normalize_player_name(name)
+        hit = (
+            by_name_team_pos.get((norm_name, team_u, fam))
+            or by_name_pos.get((norm_name, fam))
+            or (by_name[norm_name][0] if len(by_name.get(norm_name, [])) == 1 else None)
+        )
+        if hit is None:
+            # Tail cases only: the mapper's manual-override + fuzzy
+            # layers.  Too slow for the hot path (it re-indexes the
+            # pool per call) but right for the residue.
+            got = resolve_player(
+                players_dir,
+                name=name,
+                team=team_u or None,
+                position=fam or None,
+                min_confidence=min_confidence,
+            )
+            hit = players_dir.get(got.sleeper_id) if got else None
+        resolve_cache[key] = hit
+        return hit
+
+    records: dict[str, dict[str, Any]] = {}
+    stats = {
+        "contracts": {"parsed": len(contracts), "matched": 0},
+        "snapCounts": {"parsed": len(snaps), "matched": 0},
+        "depthCharts": {"parsed": len(depth), "matched": 0},
+        "noGsisFallback": 0,
+    }
+
+    key_by_sleeper: dict[str, str] = {}
+
+    def _record_for(pool_rec: dict[str, Any], source_gsis: str = "") -> dict[str, Any]:
+        # Key preference: Sleeper's gsis → the source row's gsis
+        # (depth charts carry an authoritative one) → sleeper fallback.
+        # ``key_by_sleeper`` pins one key per player so a depth pass
+        # that learned a gsis and a later contract pass that didn't
+        # can never split the same player into two records.
+        sleeper_id = pool_rec["player_id"]
+        key = key_by_sleeper.get(sleeper_id)
+        if key is None:
+            gsis = pool_rec.get("gsis_id") or source_gsis
+            key = gsis or f"sleeper:{sleeper_id}"
+            key_by_sleeper[sleeper_id] = key
+            if not gsis:
+                stats["noGsisFallback"] += 1
+            records[key] = {
+                "gsisId": gsis,
+                "sleeperId": sleeper_id,
+                "name": pool_rec["full_name"],
+                "team": pool_rec["team"],
+                "position": pool_rec["position"],
+            }
+        return records[key]
+
+    for d in compute_depth_ranks(depth):
+        pool_rec = by_gsis.get(d["gsisId"]) or by_espn.get(d["espnId"])
+        if pool_rec is None:
+            pool_rec = _resolve_by_name(d["name"], d["team"], d["position"])
+        if pool_rec is None:
+            continue
+        rec = _record_for(pool_rec, source_gsis=d["gsisId"])
+        stats["depthCharts"]["matched"] += 1
+        rec["depth"] = {
+            "position": d["position"],
+            "rank": d["rank"],
+            "depthPosition": d["depthPosition"],
+            "team": d["team"],
+        }
+
+    for s in snaps:
+        pool_rec = _resolve_by_name(s["name"], s["team"], s["position"])
+        if pool_rec is None:
+            continue
+        rec = _record_for(pool_rec)
+        stats["snapCounts"]["matched"] += 1
+        rec["snaps"] = {
+            "season": s["season"],
+            "games": s["games"],
+            "side": s["side"],
+            "pct": s["pct"],
+            "recentPct": s["recentPct"],
+            "trend": s["trend"],
+        }
+
+    for c in contracts:
+        pool_rec = _resolve_by_name(c["name"], c["team"], c["position"])
+        if pool_rec is None:
+            continue
+        rec = _record_for(pool_rec)
+        stats["contracts"]["matched"] += 1
+        rec["contract"] = {
+            "apy": c["apy"],
+            "total": c["total"],
+            "guaranteed": c["guaranteed"],
+            "years": c["years"],
+            "yearSigned": c["yearSigned"],
+            "endYear": c["endYear"],
+            "team": c["team"],
+        }
+
+    stats["players"] = len(records)
+    return records, stats

--- a/src/playerctx/normalize.py
+++ b/src/playerctx/normalize.py
@@ -376,17 +376,22 @@ def aggregate_snaps(rows: list[dict[str, Any]], *, recent_games: int = 3) -> lis
                 )
                 continue
         games.sort(key=lambda g: (_GAME_TYPE_ORDER.get(g["gameType"], 9), g["week"]))
-        off_total = sum(g["offSnaps"] for g in games)
-        def_total = sum(g["defSnaps"] for g in games)
-        st_total = sum(g["stSnaps"] for g in games)
-        if def_total > off_total:
-            side, pct_key = "defense", "defPct"
-        elif off_total > 0:
-            side, pct_key = "offense", "offPct"
-        elif st_total > 0:
-            side, pct_key = "st", "stPct"
-        else:  # degenerate all-zero row set — keep the legacy label
-            side, pct_key = "offense", "offPct"
+        totals = {
+            "defense": sum(g["defSnaps"] for g in games),
+            "offense": sum(g["offSnaps"] for g in games),
+            "st": sum(g["stSnaps"] for g in games),
+        }
+        # The unit with the MOST snaps wins — all three compared, so a
+        # kicker with one trick-play offensive snap still classifies
+        # "st", not "offense at ~0%".  Tie precedence (rare, equal
+        # totals): defense > offense > st — ``max`` keeps the first of
+        # the iteration order.  Degenerate all-zero rows keep the
+        # legacy "offense" label.
+        if any(totals.values()):
+            side = max(("defense", "offense", "st"), key=lambda s: totals[s])
+        else:
+            side = "offense"
+        pct_key = {"defense": "defPct", "offense": "offPct", "st": "stPct"}[side]
         pcts = [g[pct_key] * 100.0 for g in games]
         season_mean = sum(pcts) / len(pcts)
         recent = pcts[-recent_games:]
@@ -597,6 +602,14 @@ def build_player_context(
         by_name_pos.setdefault((norm_name, pos), []).append(p)
         by_name.setdefault(norm_name, []).append(p)
 
+    # Per-team sub-pools for the fuzzy tail: when a source row names a
+    # team, fuzzy matching is scoped to that team's players only.
+    pool_by_team: dict[str, dict[str, dict[str, Any]]] = {}
+    for sid, p in players_dir.items():
+        team = str(p.get("team") or "").upper()
+        if team:
+            pool_by_team.setdefault(team, {})[sid] = p
+
     resolve_cache: dict[tuple[str, str, str], dict[str, Any] | None] = {}
 
     def _sole(cands: list[dict[str, Any]] | None) -> tuple[dict[str, Any] | None, bool]:
@@ -623,7 +636,15 @@ def build_player_context(
         # player).  Team match that narrows to exactly one wins;
         # otherwise ambiguity is only resolvable by a manual override,
         # never by guessing.
-        hit, ambiguous = _sole(by_name_team_pos.get((norm_name, team_u, fam)))
+        #
+        # The team rung is consulted ONLY when the source actually
+        # supplied a team: with team_u == "" the key would pair the
+        # name with pool players whose team is empty (free agents) — a
+        # pseudo-match that would accept a lone FA before the
+        # ambiguity check ever saw the rostered candidates.
+        hit, ambiguous = (None, False)
+        if team_u:
+            hit, ambiguous = _sole(by_name_team_pos.get((norm_name, team_u, fam)))
         if hit is None and not ambiguous:
             hit, ambiguous = _sole(by_name_pos.get((norm_name, fam)))
         if hit is None and not ambiguous:
@@ -643,14 +664,24 @@ def build_player_context(
             # its candidate walk is first-match-wins, i.e. exactly the
             # arbitrary pick this rung refuses; without an override an
             # ambiguous row is dropped (drop-don't-guess).
-            got = resolve_player(
-                players_dir,
-                name=name,
-                team=team_u or None,
-                position=fam or None,
-                min_confidence=min_confidence,
-            )
-            hit = players_dir.get(got.sleeper_id) if got else None
+            #
+            # Team is DECISIVE here: ``resolve_player``'s fuzzy walk
+            # ignores its team argument, so a closer-spelled player on
+            # another team could steal the row.  When the source names
+            # a team, fuzzy runs against that team's sub-pool only — a
+            # team-matching candidate wins even at a lower score, and
+            # if no same-team candidate clears min_confidence the row
+            # drops rather than crossing teams.
+            scope = pool_by_team.get(team_u, {}) if team_u else players_dir
+            if scope:
+                got = resolve_player(
+                    scope,
+                    name=name,
+                    team=team_u or None,
+                    position=fam or None,
+                    min_confidence=min_confidence,
+                )
+                hit = scope.get(got.sleeper_id) if got else None
         resolve_cache[key] = hit
         return hit
 

--- a/src/playerctx/normalize.py
+++ b/src/playerctx/normalize.py
@@ -580,8 +580,8 @@ def build_player_context(
 
     by_gsis: dict[str, dict[str, Any]] = {}
     by_espn: dict[str, dict[str, Any]] = {}
-    by_name_team_pos: dict[tuple[str, str, str], dict[str, Any]] = {}
-    by_name_pos: dict[tuple[str, str], dict[str, Any]] = {}
+    by_name_team_pos: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    by_name_pos: dict[tuple[str, str], list[dict[str, Any]]] = {}
     by_name: dict[str, list[dict[str, Any]]] = {}
     for p in players_dir.values():
         if p.get("gsis_id"):
@@ -593,11 +593,20 @@ def build_player_context(
             continue
         pos = str(p.get("position") or "").upper()
         team = str(p.get("team") or "").upper()
-        by_name_team_pos.setdefault((norm_name, team, pos), p)
-        by_name_pos.setdefault((norm_name, pos), p)
+        by_name_team_pos.setdefault((norm_name, team, pos), []).append(p)
+        by_name_pos.setdefault((norm_name, pos), []).append(p)
         by_name.setdefault(norm_name, []).append(p)
 
     resolve_cache: dict[tuple[str, str, str], dict[str, Any] | None] = {}
+
+    def _sole(cands: list[dict[str, Any]] | None) -> tuple[dict[str, Any] | None, bool]:
+        """(candidate, ambiguous): the candidate only when it is
+        UNIQUE; ambiguous=True when the key covers several players."""
+        if not cands:
+            return None, False
+        if len(cands) == 1:
+            return cands[0], False
+        return None, True
 
     def _resolve_by_name(name: str, team: str, position: str) -> dict[str, Any] | None:
         fam = normalize_position(position)
@@ -606,23 +615,34 @@ def build_player_context(
         if key in resolve_cache:
             return resolve_cache[key]
         norm_name = normalize_player_name(name)
-        hit = (
-            by_name_team_pos.get((norm_name, team_u, fam))
-            or by_name_pos.get((norm_name, fam))
-            or (by_name[norm_name][0] if len(by_name.get(norm_name, [])) == 1 else None)
-        )
+        # Deterministic rungs accept only a UNIQUE candidate.  Two
+        # active players sharing a normalized name + position family
+        # are a real case (and a contract row can carry the SIGNING
+        # team post-trade, so a team mismatch must not fall back to
+        # "first one indexed" — that attaches data to the wrong
+        # player).  Team match that narrows to exactly one wins;
+        # otherwise ambiguity is only resolvable by a manual override,
+        # never by guessing.
+        hit, ambiguous = _sole(by_name_team_pos.get((norm_name, team_u, fam)))
+        if hit is None and not ambiguous:
+            hit, ambiguous = _sole(by_name_pos.get((norm_name, fam)))
+        if hit is None and not ambiguous:
+            hit, ambiguous = _sole(by_name.get(norm_name))
         if hit is None and norm_name in alias_by_name:
             # Manual override (id_overrides.json) — an operator-pinned
-            # source-name → sleeper_id mapping beats the fuzzy guess
-            # below.  ``resolve_player`` can't reach its own override
-            # rung for source rows (it requires a sleeper_id input),
-            # so the alias index is what makes overrides effective
-            # here.
+            # source-name → sleeper_id mapping settles ambiguity and
+            # beats the fuzzy guess below.  ``resolve_player`` can't
+            # reach its own override rung for source rows (it requires
+            # a sleeper_id input), so the alias index is what makes
+            # overrides effective here.
             hit = players_dir.get(alias_by_name[norm_name])
-        if hit is None:
+        if hit is None and not ambiguous:
             # Tail cases only: the mapper's fuzzy layer.  Too slow for
             # the hot path (it re-indexes the pool per call) but right
-            # for the residue.
+            # for the residue.  Never consulted for AMBIGUOUS names —
+            # its candidate walk is first-match-wins, i.e. exactly the
+            # arbitrary pick this rung refuses; without an override an
+            # ambiguous row is dropped (drop-don't-guess).
             got = resolve_player(
                 players_dir,
                 name=name,

--- a/src/playerctx/service.py
+++ b/src/playerctx/service.py
@@ -133,6 +133,25 @@ def refresh_playerctx(
                 f"new snapshot retains only {len(records)} of {prev_n} last-good players "
                 f"(< {_LAST_GOOD_RETENTION:.0%}); keeping last-good"
             )
+        # Per-source retention: the union check above can't see one
+        # source collapsing semantically (e.g. a contracts naming-
+        # convention change producing zero matches) while the other
+        # two keep the total player count healthy — that would publish
+        # a snapshot silently missing every contract block.  Each
+        # source's matched count must hold its own retention ratio
+        # against last-good.
+        prev_counts = last_good.get("counts") or {}
+        for source_key in ("contracts", "snapCounts", "depthCharts"):
+            prev_matched = (prev_counts.get(source_key) or {}).get("matched")
+            if not isinstance(prev_matched, int) or prev_matched <= 0:
+                continue  # older snapshot without per-source counts
+            new_matched = stats[source_key]["matched"]
+            if new_matched < prev_matched * _LAST_GOOD_RETENTION:
+                raise SchemaRegressionError(
+                    f"{source_key}: matched {new_matched} retains less than "
+                    f"{_LAST_GOOD_RETENTION:.0%} of last-good {prev_matched}; "
+                    "keeping last-good"
+                )
 
     sources = {
         "contracts": {"url": fetch_mod.CONTRACTS_URL},

--- a/src/playerctx/service.py
+++ b/src/playerctx/service.py
@@ -1,0 +1,166 @@
+"""Orchestration for the player-context data layer.
+
+``refresh_playerctx()`` runs fetch → normalize → join → floor checks
+→ atomic store.  ``load_playerctx()`` is the defensive read side the
+future player-profile endpoints will call.
+
+Failure taxonomy (mirrors the fetch-script convention pinned in
+``scripts/fetch_fantasynavigator.py``):
+
+* soft failure — network down, zero rows, no Sleeper dump: raises
+  ordinary exceptions / ``RuntimeError`` → CLI exit 1.
+* schema regression — missing columns, row counts under the absolute
+  floors, or a collapse vs the last-good snapshot: raises
+  :class:`~src.playerctx.normalize.SchemaRegressionError` → CLI exit
+  2, and the last-good snapshot on disk is left untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable
+
+from src.playerctx import fetch as fetch_mod
+from src.playerctx import normalize as norm
+from src.playerctx import store
+from src.playerctx.normalize import SchemaRegressionError
+
+log = logging.getLogger(__name__)
+
+# Absolute row floors on the PARSED datasets.  Baselines from the live
+# probes (2026-07-25): contracts ~2.4k active rows after dedupe,
+# snap counts ~26.6k game rows → ~1.6k player aggregates, depth charts
+# ~2.4k fantasy-slot rows in the newest snapshot.  Floors sit at
+# roughly half so a truncated download trips exit 2 instead of
+# publishing a hollow snapshot.
+_ROW_FLOORS: dict[str, int] = {
+    "contracts": 1000,
+    "snapCounts": 700,  # player aggregates, not game rows
+    "depthCharts": 1200,
+}
+
+# Joined-player floor: the snapshot is useless below this.
+_MIN_MATCHED_PLAYERS = 400
+
+# A new snapshot may not shed more than 25% of the last-good player
+# count (same retention policy as the fetch scripts) — that shape of
+# shrink means a partial upstream file, not real roster churn.
+_LAST_GOOD_RETENTION = 0.75
+
+
+def _load_sleeper_pool(path: Path) -> dict[str, dict[str, Any]]:
+    try:
+        dump = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"sleeper players dump unreadable at {path}: {exc}") from exc
+    pool = norm.build_sleeper_pool(dump)
+    if not pool:
+        raise RuntimeError(f"sleeper players dump at {path} yielded an empty pool")
+    return pool
+
+
+def refresh_playerctx(
+    *,
+    force: bool = False,
+    max_age_hours: float = fetch_mod.DEFAULT_MAX_AGE_HOURS,
+    cache_dir: Path | None = None,
+    snapshot_path: Path | None = None,
+    fetcher: Callable[..., fetch_mod.FetchBundle] | None = None,
+    players_dir: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Fetch, normalize, join, and persist the player-context snapshot.
+
+    ``fetcher`` and ``players_dir`` are injectable for tests (no live
+    network in the suite).  Returns a summary dict::
+
+        {"snapshotPath": str, "counts": {...}, "sources": {...},
+         "warnings": [...]}
+    """
+    do_fetch = fetcher or fetch_mod.fetch_all
+    bundle = do_fetch(cache_dir=cache_dir, max_age_hours=max_age_hours, force=force)
+
+    missing = [
+        key
+        for key, path in (
+            ("contracts", bundle.contracts),
+            ("snap_counts", bundle.snap_counts),
+            ("depth_charts", bundle.depth_charts),
+        )
+        if path is None
+    ]
+    if missing:
+        raise RuntimeError(
+            f"datasets unavailable: {', '.join(missing)}; warnings={bundle.warnings}"
+        )
+
+    if players_dir is None:
+        if bundle.sleeper_players is None:
+            raise RuntimeError(f"sleeper players dump unavailable; warnings={bundle.warnings}")
+        players_dir = _load_sleeper_pool(bundle.sleeper_players)
+
+    contracts = norm.parse_contracts(bundle.contracts)
+    snap_rows = norm.parse_snap_counts(bundle.snap_counts)
+    snaps = norm.aggregate_snaps(snap_rows)
+    depth = norm.parse_depth_charts(bundle.depth_charts)
+
+    parsed_counts = {
+        "contracts": len(contracts),
+        "snapCounts": len(snaps),
+        "depthCharts": len(depth),
+    }
+    for key, floor in _ROW_FLOORS.items():
+        if parsed_counts[key] < floor:
+            raise SchemaRegressionError(
+                f"{key}: parsed row count {parsed_counts[key]} below floor {floor}"
+            )
+
+    records, stats = norm.build_player_context(
+        contracts=contracts, snaps=snaps, depth=depth, players_dir=players_dir
+    )
+    if len(records) < _MIN_MATCHED_PLAYERS:
+        raise SchemaRegressionError(
+            f"joined player count {len(records)} below floor {_MIN_MATCHED_PLAYERS}"
+        )
+
+    target = snapshot_path or store.SNAPSHOT_PATH
+    last_good = store.load_snapshot(target)
+    if last_good is not None:
+        prev_n = len(last_good.get("players") or {})
+        if prev_n > 0 and len(records) < prev_n * _LAST_GOOD_RETENTION:
+            raise SchemaRegressionError(
+                f"new snapshot retains only {len(records)} of {prev_n} last-good players "
+                f"(< {_LAST_GOOD_RETENTION:.0%}); keeping last-good"
+            )
+
+    sources = {
+        "contracts": {"url": fetch_mod.CONTRACTS_URL},
+        "snapCounts": {
+            "url": fetch_mod.SNAP_COUNTS_URL_TMPL,
+            "season": bundle.snap_counts_season,
+        },
+        "depthCharts": {
+            "url": fetch_mod.DEPTH_CHARTS_URL_TMPL,
+            "season": bundle.depth_charts_season,
+        },
+        "sleeperPlayers": {"url": fetch_mod.SLEEPER_PLAYERS_URL},
+    }
+    written = store.write_snapshot(records, counts=stats, sources=sources, path=target)
+    log.info("playerctx: wrote %d players -> %s", len(records), written)
+    return {
+        "snapshotPath": str(written),
+        "counts": stats,
+        "sources": sources,
+        "warnings": list(bundle.warnings),
+    }
+
+
+def load_playerctx(path: Path | None = None) -> dict[str, Any] | None:
+    """Read side for future consumers (player-profile endpoints).
+
+    Returns the full snapshot payload (``schemaVersion``,
+    ``generatedAt``, ``counts``, ``sleeperIndex``, ``players``) or
+    ``None`` when no valid snapshot exists — never raises.
+    """
+    return store.load_snapshot(path)

--- a/src/playerctx/store.py
+++ b/src/playerctx/store.py
@@ -1,0 +1,83 @@
+"""Atomic snapshot persistence for the player-context data layer.
+
+One compact JSON file — ``data/playerctx/snapshot.json`` — written
+atomically (same tmp-then-replace pattern as
+``src/public_league/snapshot_store.py::_atomic_write_json``) so a
+crashed refresh can never leave a half-written file for
+``load_snapshot`` to trip over.
+
+``data/`` is gitignored repo-wide, so the snapshot is generated
+infrastructure, not a committed artifact: production materializes it
+via ``scripts/refresh_playerctx.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SNAPSHOT_PATH = REPO_ROOT / "data" / "playerctx" / "snapshot.json"
+
+SCHEMA_VERSION = "playerctx.v1"
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp-{int(time.time() * 1000)}")
+    try:
+        tmp.write_text(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")), encoding="utf-8"
+        )
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def write_snapshot(
+    players: dict[str, dict[str, Any]],
+    *,
+    counts: dict[str, Any] | None = None,
+    sources: dict[str, Any] | None = None,
+    path: Path | None = None,
+) -> Path:
+    """Persist the snapshot; returns the path written."""
+    target = path or SNAPSHOT_PATH
+    payload = {
+        "schemaVersion": SCHEMA_VERSION,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "counts": counts or {},
+        "sources": sources or {},
+        # sleeper_id → gsis_id so UI callers holding Sleeper IDs can
+        # index straight into ``players`` without a scan.
+        "sleeperIndex": {
+            rec["sleeperId"]: gsis for gsis, rec in players.items() if rec.get("sleeperId")
+        },
+        "players": players,
+    }
+    _atomic_write_json(target, payload)
+    return target
+
+
+def load_snapshot(path: Path | None = None) -> dict[str, Any] | None:
+    """Defensive read: ``None`` for missing / corrupt / wrong-shape
+    files — callers must treat 'no context available' as normal."""
+    target = path or SNAPSHOT_PATH
+    if not target.exists():
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        log.warning("playerctx: failed to load %s: %s", target, exc)
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("players"), dict):
+        log.warning("playerctx: %s has unexpected shape; ignoring", target)
+        return None
+    return payload

--- a/tests/playerctx/conftest.py
+++ b/tests/playerctx/conftest.py
@@ -1,0 +1,74 @@
+"""Shared fixtures for the playerctx suite — small CSV builders that
+mirror the live nflverse schemas (verified 2026-07-25).  No network."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import pytest
+
+CONTRACTS_HEADER = (
+    "player,position,team,is_active,year_signed,years,value,apy,"
+    "guaranteed,apy_cap_pct,player_page,otc_id,draft_year"
+)
+
+SNAPS_HEADER = (
+    "game_id,pfr_game_id,season,game_type,week,player,pfr_player_id,"
+    "position,team,opponent,offense_snaps,offense_pct,defense_snaps,"
+    "defense_pct,st_snaps,st_pct"
+)
+
+DEPTH_HEADER = (
+    "dt,team,player_name,espn_id,gsis_id,pos_grp_id,pos_grp,pos_id,"
+    "pos_name,pos_abb,pos_slot,pos_rank"
+)
+
+
+def write_csv(path: Path, header: str, rows: list[str]) -> Path:
+    text = header + "\n" + "\n".join(rows) + "\n"
+    if path.name.endswith(".gz"):
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+    else:
+        path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def players_dir() -> dict[str, dict[str, str]]:
+    """A Sleeper pool shaped like ``normalize.build_sleeper_pool`` output."""
+    return {
+        "4034": {
+            "player_id": "4034",
+            "full_name": "Christian McCaffrey",
+            "position": "RB",
+            "team": "SF",
+            "gsis_id": "00-0033280",
+            "espn_id": "3117251",
+        },
+        "6794": {
+            "player_id": "6794",
+            "full_name": "Justin Jefferson",
+            "position": "WR",
+            "team": "MIN",
+            "gsis_id": "00-0036322",
+            "espn_id": "4262921",
+        },
+        "9999": {
+            "player_id": "9999",
+            "full_name": "Micah Parsons",
+            "position": "DL",
+            "team": "DAL",
+            "gsis_id": "00-0036933",
+            "espn_id": "4361429",
+        },
+        # No gsis_id — joinable but unkeyable; must be dropped+counted.
+        "7777": {
+            "player_id": "7777",
+            "full_name": "Ghost Nogsis",
+            "position": "WR",
+            "team": "CHI",
+            "gsis_id": "",
+            "espn_id": "1234567",
+        },
+    }

--- a/tests/playerctx/test_fetch.py
+++ b/tests/playerctx/test_fetch.py
@@ -37,13 +37,22 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    def __init__(self, response=None, request_exc: Exception | None = None):
+    """Single-response session, or per-URL via ``by_url`` — a mapping
+    of url → response object or Exception to raise."""
+
+    def __init__(self, response=None, request_exc: Exception | None = None, by_url=None):
         self._response = response
         self._request_exc = request_exc
+        self._by_url = by_url
         self.calls: list[dict] = []
 
     def get(self, url, headers=None, timeout=None, stream=None):
         self.calls.append({"url": url, "headers": headers})
+        if self._by_url is not None:
+            entry = self._by_url[url]
+            if isinstance(entry, Exception):
+                raise entry
+            return entry
         if self._request_exc is not None:
             raise self._request_exc
         return self._response
@@ -125,6 +134,81 @@ class TestStaleCacheDegradation:
             fetch_url("https://x.invalid/d", dest, key="d", max_age_hours=0.0, session=session)
         assert dest.read_bytes() == b"stale"
         assert list(tmp_path.glob("*.tmp-*")) == []
+
+
+class TestSeasonalTransientFailures:
+    """Regression (Codex round 3 on PR #539): the prior-season walk
+    must engage ONLY on a genuine upstream 404.  A transient failure
+    (timeout / 5xx / connection error) on the current season with no
+    local cache must stop the walk — silently publishing last year's
+    file mid-season looks plausible enough to pass the retention
+    guards."""
+
+    URL_TMPL = "https://x.invalid/snap_counts_{season}.csv"
+    FILE_TMPL = "snap_counts_{season}.csv"
+
+    def _seasonal(self, tmp_path, session, seasons=(2026, 2025)):
+        return fetch_mod._fetch_seasonal(
+            self.URL_TMPL,
+            self.FILE_TMPL,
+            list(seasons),
+            tmp_path,
+            key="snap_counts",
+            max_age_hours=0.0,
+            force=False,
+            session=session,
+        )
+
+    def test_500_without_cache_stops_walk(self, tmp_path):
+        session = _FakeSession(
+            by_url={
+                self.URL_TMPL.format(season=2026): _FakeResponse(status_code=500),
+                self.URL_TMPL.format(season=2025): _FakeResponse(chunks=[b"last-year"]),
+            }
+        )
+        path, season, warns = self._seasonal(tmp_path, session)
+        assert path is None and season is None
+        # The prior season must not even be requested.
+        assert [c["url"] for c in session.calls] == [self.URL_TMPL.format(season=2026)]
+        assert any("refusing prior-season fallback" in w for w in warns)
+        assert not (tmp_path / self.FILE_TMPL.format(season=2025)).exists()
+
+    def test_connection_error_without_cache_stops_walk(self, tmp_path):
+        session = _FakeSession(
+            by_url={
+                self.URL_TMPL.format(season=2026): requests.ConnectTimeout("slow"),
+                self.URL_TMPL.format(season=2025): _FakeResponse(chunks=[b"last-year"]),
+            }
+        )
+        path, season, warns = self._seasonal(tmp_path, session)
+        assert path is None and season is None
+        assert len(session.calls) == 1
+        assert any("refusing prior-season fallback" in w for w in warns)
+
+    def test_404_still_falls_back_to_prior_season(self, tmp_path):
+        session = _FakeSession(
+            by_url={
+                self.URL_TMPL.format(season=2026): _FakeResponse(status_code=404),
+                self.URL_TMPL.format(season=2025): _FakeResponse(chunks=[b"real-2025"]),
+            }
+        )
+        path, season, warns = self._seasonal(tmp_path, session)
+        assert season == 2025
+        assert path is not None and path.read_bytes() == b"real-2025"
+
+    def test_500_with_local_current_season_copy_uses_stale(self, tmp_path):
+        dest = tmp_path / self.FILE_TMPL.format(season=2026)
+        dest.write_bytes(b"stale-current-season")
+        session = _FakeSession(
+            by_url={
+                self.URL_TMPL.format(season=2026): _FakeResponse(status_code=500),
+            }
+        )
+        path, season, warns = self._seasonal(tmp_path, session)
+        assert path == dest
+        assert season == 2026
+        assert dest.read_bytes() == b"stale-current-season"
+        assert any("stale" in w for w in warns)
 
 
 class TestSeasonalFallbackUsesStaleCopy:

--- a/tests/playerctx/test_fetch.py
+++ b/tests/playerctx/test_fetch.py
@@ -85,6 +85,20 @@ class TestDownload:
         res = fetch_url("https://x.invalid/d", tmp_path / "d.csv", key="d", session=session)
         assert res == FetchResult(key="d", path=None, status="missing", detail="404")
 
+    def test_404_with_cached_copy_degrades_to_stale(self, tmp_path):
+        # Regression (Codex round 4 on PR #539): a 404 on a file we
+        # already hold locally (asset removed / temporarily
+        # unavailable upstream) must NOT discard the cache — that
+        # would let the seasonal walk replace current-season data
+        # with last year's.
+        dest = tmp_path / "d.csv"
+        dest.write_bytes(b"cached-current")
+        session = _FakeSession(_FakeResponse(status_code=404))
+        res = fetch_url("https://x.invalid/d", dest, key="d", max_age_hours=0.0, session=session)
+        assert res.status == "error"  # NOT "missing" — the walk must stop here
+        assert res.path == dest
+        assert dest.read_bytes() == b"cached-current"
+
 
 class TestStaleCacheDegradation:
     def test_request_start_failure_keeps_stale_copy(self, tmp_path):
@@ -208,6 +222,27 @@ class TestSeasonalTransientFailures:
         assert path == dest
         assert season == 2026
         assert dest.read_bytes() == b"stale-current-season"
+        assert any("stale" in w for w in warns)
+
+    def test_404_with_cached_current_season_uses_stale_not_prior_season(self, tmp_path):
+        # Regression (Codex round 4 on PR #539): current-season asset
+        # 404s while a local current-season cache exists — the walk
+        # must use the cached CURRENT season, never regress to the
+        # prior season.
+        dest = tmp_path / self.FILE_TMPL.format(season=2026)
+        dest.write_bytes(b"cached-2026")
+        session = _FakeSession(
+            by_url={
+                self.URL_TMPL.format(season=2026): _FakeResponse(status_code=404),
+                self.URL_TMPL.format(season=2025): _FakeResponse(chunks=[b"last-year"]),
+            }
+        )
+        path, season, warns = self._seasonal(tmp_path, session)
+        assert path == dest
+        assert season == 2026
+        assert dest.read_bytes() == b"cached-2026"
+        # The prior season must never even be requested.
+        assert [c["url"] for c in session.calls] == [self.URL_TMPL.format(season=2026)]
         assert any("stale" in w for w in warns)
 
 

--- a/tests/playerctx/test_fetch.py
+++ b/tests/playerctx/test_fetch.py
@@ -1,0 +1,149 @@
+"""``fetch.fetch_url`` behavior with a fake session — download,
+stale-cache degradation for failures at request start AND mid-stream,
+304 handling, and 404.  No network."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+
+from src.playerctx import fetch as fetch_mod
+from src.playerctx.fetch import FetchResult, fetch_url
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        chunks: list[bytes] | None = None,
+        stream_exc: Exception | None = None,
+        headers: dict | None = None,
+    ):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks or []
+        self._stream_exc = stream_exc
+        self.closed = False
+
+    def iter_content(self, chunk_size: int):
+        yield from self._chunks
+        if self._stream_exc is not None:
+            raise self._stream_exc
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSession:
+    def __init__(self, response=None, request_exc: Exception | None = None):
+        self._response = response
+        self._request_exc = request_exc
+        self.calls: list[dict] = []
+
+    def get(self, url, headers=None, timeout=None, stream=None):
+        self.calls.append({"url": url, "headers": headers})
+        if self._request_exc is not None:
+            raise self._request_exc
+        return self._response
+
+
+class TestDownload:
+    def test_streams_to_dest_and_writes_meta(self, tmp_path):
+        dest = tmp_path / "data.csv"
+        session = _FakeSession(
+            _FakeResponse(chunks=[b"abc", b"def"], headers={"ETag": '"e1"', "Last-Modified": "lm"})
+        )
+        res = fetch_url("https://x.invalid/d", dest, key="d", session=session)
+        assert res.status == "downloaded"
+        assert dest.read_bytes() == b"abcdef"
+        meta = json.loads((tmp_path / "data.csv.meta.json").read_text())
+        assert meta["etag"] == '"e1"'
+        assert meta["size"] == 6
+        assert list(tmp_path.glob("*.tmp-*")) == []
+
+    def test_not_modified_touches_and_keeps_content(self, tmp_path):
+        dest = tmp_path / "data.csv"
+        dest.write_bytes(b"cached")
+        session = _FakeSession(_FakeResponse(status_code=304))
+        res = fetch_url("https://x.invalid/d", dest, key="d", max_age_hours=0.0, session=session)
+        assert res.status == "not-modified"
+        assert dest.read_bytes() == b"cached"
+
+    def test_404_is_missing(self, tmp_path):
+        session = _FakeSession(_FakeResponse(status_code=404))
+        res = fetch_url("https://x.invalid/d", tmp_path / "d.csv", key="d", session=session)
+        assert res == FetchResult(key="d", path=None, status="missing", detail="404")
+
+
+class TestStaleCacheDegradation:
+    def test_request_start_failure_keeps_stale_copy(self, tmp_path):
+        dest = tmp_path / "data.csv"
+        dest.write_bytes(b"stale")
+        session = _FakeSession(request_exc=requests.ConnectionError("refused"))
+        res = fetch_url("https://x.invalid/d", dest, key="d", max_age_hours=0.0, session=session)
+        assert res.status == "error"
+        assert res.path == dest
+        assert dest.read_bytes() == b"stale"
+
+    def test_mid_stream_failure_keeps_stale_copy(self, tmp_path):
+        # Regression (Codex round 1, finding 2 on PR #539): a
+        # connection reset DURING iter_content — realistic on the
+        # 35-55 MB depth-chart file — previously escaped the stale-
+        # cache fallback and failed the whole refresh.
+        dest = tmp_path / "depth.csv"
+        dest.write_bytes(b"stale-but-usable")
+        session = _FakeSession(
+            _FakeResponse(chunks=[b"partial"], stream_exc=requests.ConnectionError("reset"))
+        )
+        res = fetch_url("https://x.invalid/d", dest, key="d", max_age_hours=0.0, session=session)
+        assert res.status == "error"
+        assert "stream" in res.detail
+        assert res.path == dest
+        assert dest.read_bytes() == b"stale-but-usable"  # not clobbered by the partial
+        assert list(tmp_path.glob("*.tmp-*")) == []  # temp cleaned up
+
+    def test_mid_stream_failure_without_cache_returns_none(self, tmp_path):
+        dest = tmp_path / "depth.csv"
+        session = _FakeSession(
+            _FakeResponse(chunks=[b"partial"], stream_exc=requests.ConnectionError("reset"))
+        )
+        res = fetch_url("https://x.invalid/d", dest, key="d", session=session)
+        assert res.status == "error"
+        assert res.path is None
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.tmp-*")) == []
+
+    def test_non_request_exception_still_propagates(self, tmp_path):
+        # Only network-shaped failures degrade; programming errors must
+        # stay loud.
+        dest = tmp_path / "depth.csv"
+        dest.write_bytes(b"stale")
+        session = _FakeSession(_FakeResponse(chunks=[b"partial"], stream_exc=ValueError("bug")))
+        with pytest.raises(ValueError):
+            fetch_url("https://x.invalid/d", dest, key="d", max_age_hours=0.0, session=session)
+        assert dest.read_bytes() == b"stale"
+        assert list(tmp_path.glob("*.tmp-*")) == []
+
+
+class TestSeasonalFallbackUsesStaleCopy:
+    def test_seasonal_stream_failure_degrades_with_warning(self, tmp_path):
+        dest = tmp_path / "snap_counts_2025.csv"
+        dest.write_bytes(b"stale")
+        session = _FakeSession(
+            _FakeResponse(chunks=[b"x"], stream_exc=requests.ConnectionError("reset"))
+        )
+        path, season, warns = fetch_mod._fetch_seasonal(
+            "https://x.invalid/snap_counts_{season}.csv",
+            "snap_counts_{season}.csv",
+            [2025],
+            tmp_path,
+            key="snap_counts",
+            max_age_hours=0.0,
+            force=False,
+            session=session,
+        )
+        assert path == dest
+        assert season == 2025
+        assert any("stale" in w for w in warns)

--- a/tests/playerctx/test_join.py
+++ b/tests/playerctx/test_join.py
@@ -262,3 +262,112 @@ class TestManualOverrides:
         )
         assert len(records) == 1
         assert next(iter(records.values()))["sleeperId"] == "7777"
+
+
+class TestAmbiguousNames:
+    """Regression (Codex round 3 on PR #539): two ACTIVE pool records
+    sharing a normalized name + position family must never be matched
+    arbitrarily.  The old ``setdefault`` index silently kept whichever
+    record was indexed first, so a teamless (or signing-team-stale)
+    contract row attached to the wrong player.  Deterministic rungs
+    now accept only a UNIQUE candidate; ambiguity is settled by a
+    manual override or the row is dropped — never by the fuzzy layer's
+    first-match walk."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_override_cache(self):
+        unified_mapper.reload_overrides()
+        yield
+        unified_mapper.reload_overrides()
+
+    @pytest.fixture
+    def dup_pool(self, players_dir):
+        pool = dict(players_dir)
+        pool["9001"] = {
+            "player_id": "9001",
+            "full_name": "Lamar Woods",
+            "position": "WR",
+            "team": "KC",
+            "gsis_id": "00-0900001",
+            "espn_id": "911",
+        }
+        pool["9002"] = {
+            "player_id": "9002",
+            "full_name": "Lamar Woods",
+            "position": "WR",
+            "team": "NYJ",
+            "gsis_id": "00-0900002",
+            "espn_id": "912",
+        }
+        return pool
+
+    @pytest.fixture
+    def no_overrides(self, tmp_path):
+        p = tmp_path / "no_overrides.json"
+        p.write_text("{}", encoding="utf-8")
+        return p
+
+    def test_teamless_ambiguous_row_is_dropped(self, dup_pool, no_overrides):
+        records, stats = norm.build_player_context(
+            contracts=[_contract("Lamar Woods", "", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=dup_pool,
+            overrides_path=no_overrides,
+        )
+        assert records == {}
+        assert stats["contracts"]["matched"] == 0
+
+    def test_stale_signing_team_ambiguous_row_is_dropped(self, dup_pool, no_overrides):
+        # A contract still carrying the signing team post-trade: the
+        # team matches NEITHER candidate, and name+family covers two
+        # players — must drop, not keep whichever was indexed first.
+        records, _ = norm.build_player_context(
+            contracts=[_contract("Lamar Woods", "MIA", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=dup_pool,
+            overrides_path=no_overrides,
+        )
+        assert records == {}
+
+    def test_override_settles_ambiguity(self, dup_pool, tmp_path):
+        ov = tmp_path / "id_overrides.json"
+        ov.write_text(
+            json.dumps(
+                {"9002": {"gsis_id": "00-0900002", "espn_id": "912", "full_name": "Lamar Woods"}}
+            ),
+            encoding="utf-8",
+        )
+        records, stats = norm.build_player_context(
+            contracts=[_contract("Lamar Woods", "", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=dup_pool,
+            overrides_path=ov,
+        )
+        assert set(records) == {"00-0900002"}
+        assert records["00-0900002"]["sleeperId"] == "9002"
+        assert stats["contracts"]["matched"] == 1
+
+    def test_matching_team_disambiguates_to_exactly_one(self, dup_pool, no_overrides):
+        records, _ = norm.build_player_context(
+            contracts=[_contract("Lamar Woods", "KC", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=dup_pool,
+            overrides_path=no_overrides,
+        )
+        assert set(records) == {"00-0900001"}
+        assert records["00-0900001"]["sleeperId"] == "9001"
+
+    def test_unique_name_pos_candidate_still_matches_teamless(self, dup_pool, no_overrides):
+        # Uniqueness, not team presence, is the acceptance criterion.
+        records, _ = norm.build_player_context(
+            contracts=[_contract("Justin Jefferson", "", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=dup_pool,
+            overrides_path=no_overrides,
+        )
+        assert set(records) == {"00-0036322"}

--- a/tests/playerctx/test_join.py
+++ b/tests/playerctx/test_join.py
@@ -1,0 +1,163 @@
+"""Join correctness for ``normalize.build_player_context`` against a
+fake Sleeper pool — exact-ID joins, unified-mapper name joins, and
+the drop rules.  No network."""
+
+from __future__ import annotations
+
+from src.playerctx import normalize as norm
+
+
+def _depth(name: str, gsis: str, espn: str = "", team: str = "SF", pos: str = "RB") -> dict:
+    return {
+        "team": team,
+        "name": name,
+        "gsisId": gsis,
+        "espnId": espn,
+        "position": pos,
+        "depthPosition": pos,
+        "slot": 1,
+        "slotRank": 1,
+    }
+
+
+def _snap(name: str, team: str, pos: str) -> dict:
+    return {
+        "name": name,
+        "team": team,
+        "position": pos,
+        "season": 2025,
+        "games": 16,
+        "side": "offense",
+        "pct": 80.0,
+        "recentPct": 85.0,
+        "trend": 5.0,
+    }
+
+
+def _contract(name: str, team: str, pos: str) -> dict:
+    return {
+        "name": name,
+        "position": pos,
+        "team": team,
+        "apy": 12_000_000,
+        "total": 48_000_000,
+        "guaranteed": 30_000_000,
+        "years": 4,
+        "yearSigned": 2024,
+        "endYear": 2027,
+    }
+
+
+class TestBuildPlayerContext:
+    def test_depth_joins_by_exact_gsis(self, players_dir):
+        records, stats = norm.build_player_context(
+            contracts=[],
+            snaps=[],
+            depth=[_depth("C. McCaffrey Jr.", gsis="00-0033280")],  # name mangled on purpose
+            players_dir=players_dir,
+        )
+        assert set(records) == {"00-0033280"}
+        rec = records["00-0033280"]
+        assert rec["sleeperId"] == "4034"
+        assert rec["name"] == "Christian McCaffrey"  # Sleeper pool is canonical
+        assert rec["depth"] == {
+            "position": "RB",
+            "rank": 1,
+            "depthPosition": "RB",
+            "team": "SF",
+        }
+        assert stats["depthCharts"]["matched"] == 1
+
+    def test_depth_falls_back_to_espn_then_name(self, players_dir):
+        records, _ = norm.build_player_context(
+            contracts=[],
+            snaps=[],
+            depth=[
+                _depth("J. Jefferson", gsis="", espn="4262921", team="MIN", pos="WR"),
+                _depth("Micah Parsons", gsis="", espn="", team="DAL", pos="DL"),
+            ],
+            players_dir=players_dir,
+        )
+        assert set(records) == {"00-0036322", "00-0036933"}
+
+    def test_snaps_join_by_name_team_position_family(self, players_dir):
+        # PFR position "DE" must land on the Sleeper "DL" family row.
+        records, stats = norm.build_player_context(
+            contracts=[],
+            snaps=[_snap("Micah Parsons", "DAL", "DE")],
+            depth=[],
+            players_dir=players_dir,
+        )
+        assert set(records) == {"00-0036933"}
+        assert records["00-0036933"]["snaps"]["pct"] == 80.0
+        assert stats["snapCounts"]["matched"] == 1
+
+    def test_contract_join_and_merged_record(self, players_dir):
+        records, stats = norm.build_player_context(
+            contracts=[_contract("Christian McCaffrey", "SF", "RB")],
+            snaps=[_snap("Christian McCaffrey", "SF", "RB")],
+            depth=[_depth("Christian McCaffrey", gsis="00-0033280")],
+            players_dir=players_dir,
+        )
+        rec = records["00-0033280"]
+        assert rec["contract"]["apy"] == 12_000_000
+        assert rec["contract"]["endYear"] == 2027
+        assert rec["snaps"]["season"] == 2025
+        assert rec["depth"]["rank"] == 1
+        assert stats["players"] == 1
+        assert stats["contracts"]["matched"] == 1
+
+    def test_unmapped_rows_are_dropped(self, players_dir):
+        records, stats = norm.build_player_context(
+            contracts=[_contract("Total Stranger", "GB", "QB")],
+            snaps=[_snap("Unknown Athlete", "NYJ", "WR")],
+            depth=[_depth("Mystery Man", gsis="00-9999999")],
+            players_dir=players_dir,
+        )
+        assert records == {}
+        assert stats["contracts"]["matched"] == 0
+        assert stats["snapCounts"]["matched"] == 0
+        assert stats["depthCharts"]["matched"] == 0
+
+    def test_pool_record_without_gsis_gets_fallback_key(self, players_dir):
+        # Sleeper's gsis coverage is sparse; a successful join must
+        # not be thrown away just because Sleeper doesn't know the
+        # player's gsis_id.
+        records, stats = norm.build_player_context(
+            contracts=[],
+            snaps=[_snap("Ghost Nogsis", "CHI", "WR")],
+            depth=[],
+            players_dir=players_dir,
+        )
+        assert set(records) == {"sleeper:7777"}
+        assert records["sleeper:7777"]["gsisId"] == ""
+        assert records["sleeper:7777"]["snaps"]["pct"] == 80.0
+        assert stats["noGsisFallback"] == 1
+
+    def test_source_gsis_backfills_missing_sleeper_gsis(self, players_dir):
+        # Depth charts carry an authoritative gsis_id; when Sleeper
+        # lacks one (espn-id join), the source's gsis becomes the key —
+        # and a later pass without a gsis must land on the SAME record.
+        records, stats = norm.build_player_context(
+            contracts=[_contract("Ghost Nogsis", "CHI", "WR")],
+            snaps=[],
+            depth=[_depth("Ghost Nogsis", gsis="00-0777777", espn="1234567", team="CHI", pos="WR")],
+            players_dir=players_dir,
+        )
+        assert set(records) == {"00-0777777"}
+        rec = records["00-0777777"]
+        assert rec["sleeperId"] == "7777"
+        assert rec["depth"]["rank"] == 1
+        assert rec["contract"]["apy"] == 12_000_000  # merged, not split
+        assert stats["noGsisFallback"] == 0
+
+    def test_stats_parsed_counts(self, players_dir):
+        _, stats = norm.build_player_context(
+            contracts=[_contract("Christian McCaffrey", "SF", "RB")],
+            snaps=[],
+            depth=[_depth("Christian McCaffrey", gsis="00-0033280")],
+            players_dir=players_dir,
+        )
+        assert stats["contracts"]["parsed"] == 1
+        assert stats["snapCounts"]["parsed"] == 0
+        assert stats["depthCharts"]["parsed"] == 1

--- a/tests/playerctx/test_join.py
+++ b/tests/playerctx/test_join.py
@@ -1,9 +1,14 @@
 """Join correctness for ``normalize.build_player_context`` against a
-fake Sleeper pool — exact-ID joins, unified-mapper name joins, and
-the drop rules.  No network."""
+fake Sleeper pool — exact-ID joins, unified-mapper name joins, manual
+override aliases, and the drop rules.  No network."""
 
 from __future__ import annotations
 
+import json
+
+import pytest
+
+from src.identity import unified_mapper
 from src.playerctx import normalize as norm
 
 
@@ -161,3 +166,99 @@ class TestBuildPlayerContext:
         assert stats["contracts"]["parsed"] == 1
         assert stats["snapCounts"]["parsed"] == 0
         assert stats["depthCharts"]["parsed"] == 1
+
+
+class TestManualOverrides:
+    """Regression: manual overrides (``id_overrides.json``) must be
+    reachable for source rows.  ``resolve_player``'s own override rung
+    only fires when given a ``sleeper_id`` — which external datasets
+    never carry — so ``build_player_context`` reverse-indexes the
+    override file by normalized name / gsis_id / espn_id and consults
+    it before dropping a row (Codex round 1, finding 1 on PR #539)."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_override_cache(self):
+        unified_mapper.reload_overrides()
+        yield
+        unified_mapper.reload_overrides()
+
+    @pytest.fixture
+    def overrides_path(self, tmp_path):
+        p = tmp_path / "id_overrides.json"
+        p.write_text(
+            json.dumps(
+                {
+                    # Source-name alias for a player whose pool name is
+                    # nothing like the source's ("Zzyzx Quixote" fails
+                    # every exact rung AND the fuzzy ladder).
+                    "4034": {
+                        "gsis_id": "00-0033280",
+                        "espn_id": "3117251",
+                        "full_name": "Zzyzx Quixote",
+                    },
+                    # ID alias for the no-gsis pool player: maps an
+                    # external gsis/espn the pool doesn't know.
+                    "7777": {
+                        "gsis_id": "00-0777777",
+                        "espn_id": "7654321",
+                        "full_name": "Ghost Nogsis",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return p
+
+    def test_name_alias_rescues_unmatchable_source_row(self, players_dir, overrides_path):
+        records, stats = norm.build_player_context(
+            contracts=[_contract("Zzyzx Quixote", "SF", "RB")],
+            snaps=[_snap("Zzyzx Quixote", "SF", "RB")],
+            depth=[],
+            players_dir=players_dir,
+            overrides_path=overrides_path,
+        )
+        assert set(records) == {"00-0033280"}
+        rec = records["00-0033280"]
+        assert rec["sleeperId"] == "4034"
+        assert rec["name"] == "Christian McCaffrey"  # pool stays canonical
+        assert rec["contract"]["apy"] == 12_000_000
+        assert rec["snaps"]["pct"] == 80.0
+        assert stats["contracts"]["matched"] == 1
+        assert stats["snapCounts"]["matched"] == 1
+
+    def test_same_row_is_dropped_without_the_override(self, players_dir, tmp_path):
+        empty = tmp_path / "no_overrides.json"
+        empty.write_text("{}", encoding="utf-8")
+        records, _ = norm.build_player_context(
+            contracts=[_contract("Zzyzx Quixote", "SF", "RB")],
+            snaps=[],
+            depth=[],
+            players_dir=players_dir,
+            overrides_path=empty,
+        )
+        assert records == {}
+
+    def test_gsis_alias_rescues_depth_row(self, players_dir, overrides_path):
+        # Depth row: unknown display name, gsis only known via the
+        # override entry → must land on sleeper 7777.
+        records, stats = norm.build_player_context(
+            contracts=[],
+            snaps=[],
+            depth=[_depth("Totally Different Name", gsis="00-0777777", team="CHI", pos="WR")],
+            players_dir=players_dir,
+            overrides_path=overrides_path,
+        )
+        assert set(records) == {"00-0777777"}  # source gsis backfills the key
+        assert records["00-0777777"]["sleeperId"] == "7777"
+        assert stats["depthCharts"]["matched"] == 1
+
+    def test_espn_alias_rescues_depth_row(self, players_dir, overrides_path):
+        records, _ = norm.build_player_context(
+            contracts=[],
+            snaps=[],
+            depth=[_depth("Totally Different Name", gsis="", espn="7654321", team="CHI", pos="WR")],
+            players_dir=players_dir,
+            overrides_path=overrides_path,
+        )
+        assert len(records) == 1
+        assert next(iter(records.values()))["sleeperId"] == "7777"

--- a/tests/playerctx/test_join.py
+++ b/tests/playerctx/test_join.py
@@ -371,3 +371,148 @@ class TestAmbiguousNames:
             overrides_path=no_overrides,
         )
         assert set(records) == {"00-0036322"}
+
+    @pytest.fixture
+    def fa_dup_pool(self, players_dir):
+        # Same-name-same-family pair where one is a FREE AGENT (empty
+        # team) and one is rostered.
+        pool = dict(players_dir)
+        pool["9003"] = {
+            "player_id": "9003",
+            "full_name": "Lamar Woods",
+            "position": "WR",
+            "team": "",  # free agent
+            "gsis_id": "00-0900003",
+            "espn_id": "913",
+        }
+        pool["9004"] = {
+            "player_id": "9004",
+            "full_name": "Lamar Woods",
+            "position": "WR",
+            "team": "NYJ",
+            "gsis_id": "00-0900004",
+            "espn_id": "914",
+        }
+        return pool
+
+    def test_teamless_row_never_pseudo_matches_the_free_agent(self, fa_dup_pool, no_overrides):
+        # Regression (Codex round 4 on PR #539): a teamless source row
+        # queried the team rung with team_u == "", which key-matched
+        # the lone FREE AGENT (empty-team pool entry) and accepted it
+        # before the ambiguity check ever saw the rostered candidate.
+        # The team rung must be skipped entirely without a source team.
+        records, stats = norm.build_player_context(
+            contracts=[_contract("Lamar Woods", "", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=fa_dup_pool,
+            overrides_path=no_overrides,
+        )
+        assert records == {}  # ambiguous → dropped, NOT matched to the FA
+        assert stats["contracts"]["matched"] == 0
+
+    def test_teamless_fa_ambiguity_is_override_rescuable(self, fa_dup_pool, tmp_path):
+        ov = tmp_path / "id_overrides.json"
+        ov.write_text(
+            json.dumps(
+                {"9004": {"gsis_id": "00-0900004", "espn_id": "914", "full_name": "Lamar Woods"}}
+            ),
+            encoding="utf-8",
+        )
+        records, _ = norm.build_player_context(
+            contracts=[_contract("Lamar Woods", "", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=fa_dup_pool,
+            overrides_path=ov,
+        )
+        assert set(records) == {"00-0900004"}
+        assert records["00-0900004"]["sleeperId"] == "9004"
+
+
+class TestTeamScopedFuzzy:
+    """Regression (Codex round 4 on PR #539): ``resolve_player``'s
+    fuzzy walk ignores its team argument, so a closer-spelled player
+    on ANOTHER team could steal a row even when a candidate on the
+    source's own team clears the confidence bar.  When the source
+    names a team, fuzzy now runs against that team's sub-pool only —
+    team match is decisive; with no same-team candidate the row
+    drops."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_override_cache(self):
+        unified_mapper.reload_overrides()
+        yield
+        unified_mapper.reload_overrides()
+
+    @pytest.fixture
+    def no_overrides(self, tmp_path):
+        p = tmp_path / "no_overrides.json"
+        p.write_text("{}", encoding="utf-8")
+        return p
+
+    @pytest.fixture
+    def fuzzy_pool(self, players_dir):
+        pool = dict(players_dir)
+        # A: closer spelling to the source name, WRONG team.
+        pool["9101"] = {
+            "player_id": "9101",
+            "full_name": "Marquise Brown",
+            "position": "WR",
+            "team": "LAC",
+            "gsis_id": "00-0910001",
+            "espn_id": "921",
+        }
+        # B: worse fuzzy score, but on the SOURCE's team.
+        pool["9102"] = {
+            "player_id": "9102",
+            "full_name": "Marquis Browner",
+            "position": "WR",
+            "team": "KC",
+            "gsis_id": "00-0910002",
+            "espn_id": "922",
+        }
+        return pool
+
+    def test_team_match_beats_closer_spelling_on_other_team(self, fuzzy_pool, no_overrides):
+        # "Marquis Brown" scores 0.963 vs A (LAC) and 0.929 vs B (KC).
+        # Full-pool fuzzy would pick A; team-scoped fuzzy must pick B.
+        records, stats = norm.build_player_context(
+            contracts=[],
+            snaps=[_snap("Marquis Brown", "KC", "WR")],
+            depth=[],
+            players_dir=fuzzy_pool,
+            overrides_path=no_overrides,
+        )
+        assert set(records) == {"00-0910002"}
+        assert records["00-0910002"]["sleeperId"] == "9102"
+        assert stats["snapCounts"]["matched"] == 1
+
+    def test_only_conflicting_team_candidate_is_dropped(self, players_dir, no_overrides):
+        pool = dict(players_dir)
+        pool["9101"] = {
+            "player_id": "9101",
+            "full_name": "Marquise Brown",
+            "position": "WR",
+            "team": "LAC",
+            "gsis_id": "00-0910001",
+            "espn_id": "921",
+        }
+        records, _ = norm.build_player_context(
+            contracts=[],
+            snaps=[_snap("Marquis Brown", "KC", "WR")],  # KC has no candidates
+            depth=[],
+            players_dir=pool,
+            overrides_path=no_overrides,
+        )
+        assert records == {}  # never crosses teams on a fuzzy guess
+
+    def test_teamless_row_still_uses_full_pool_fuzzy(self, fuzzy_pool, no_overrides):
+        records, _ = norm.build_player_context(
+            contracts=[_contract("Marquise Browne", "", "WR")],
+            snaps=[],
+            depth=[],
+            players_dir=fuzzy_pool,
+            overrides_path=no_overrides,
+        )
+        assert set(records) == {"00-0910001"}  # best full-pool fuzzy match

--- a/tests/playerctx/test_normalize.py
+++ b/tests/playerctx/test_normalize.py
@@ -200,6 +200,25 @@ class TestSnapCounts:
         assert agg[0]["side"] == "offense"
         assert agg[0]["pct"] == pytest.approx(60.0)
 
+    def test_kicker_with_trick_play_snap_still_classifies_st(self, tmp_path):
+        # Regression (Codex round 4 on PR #539): one offensive snap
+        # (fake FG / trick play) made ``off_total > 0`` true and the
+        # kicker classified "offense" at ~0% — all THREE unit totals
+        # must compete and the max wins.
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                # off_pct 0.02 → 1 offensive snap; st_pct 0.9 → 27 ST snaps.
+                _snap_row("Kicky McLeg", 1, 0.02, st_pct=0.9, pos="K", pfr="McLeKi00"),
+                _snap_row("Kicky McLeg", 2, 0.0, st_pct=0.9, pos="K", pfr="McLeKi00"),
+            ],
+        )
+        agg = norm.aggregate_snaps(norm.parse_snap_counts(p))
+        assert len(agg) == 1
+        assert agg[0]["side"] == "st"
+        assert agg[0]["pct"] == pytest.approx(90.0)
+
     def test_idless_traded_player_aggregates_across_teams(self, tmp_path):
         # Regression (Codex round 2 on PR #539): the ID-less fallback
         # key included the team, so a traded player's season split into

--- a/tests/playerctx/test_normalize.py
+++ b/tests/playerctx/test_normalize.py
@@ -90,6 +90,7 @@ def _snap_row(
     week: int,
     off_pct: float,
     def_pct: float = 0.0,
+    st_pct: float = 0.0,
     season: int = 2025,
     game_type: str = "REG",
     team: str = "SF",
@@ -98,9 +99,10 @@ def _snap_row(
 ) -> str:
     off_snaps = int(off_pct * 70)
     def_snaps = int(def_pct * 70)
+    st_snaps = int(st_pct * 30)
     return (
         f"2025_{week:02d}_{team}_XX,x{week},{season},{game_type},{week},{name},{pfr},"
-        f"{pos},{team},XX,{off_snaps},{off_pct},{def_snaps},{def_pct},0,0"
+        f"{pos},{team},XX,{off_snaps},{off_pct},{def_snaps},{def_pct},{st_snaps},{st_pct}"
     )
 
 
@@ -161,6 +163,92 @@ class TestSnapCounts:
         p = write_csv(tmp_path / "snaps.csv", broken, [_snap_row("X", 1, 0.5)])
         with pytest.raises(SchemaRegressionError, match="offense_pct"):
             norm.parse_snap_counts(p)
+
+    def test_missing_st_column_is_schema_regression(self, tmp_path):
+        broken = SNAPS_HEADER.replace("st_pct", "st_pct_renamed")
+        p = write_csv(tmp_path / "snaps.csv", broken, [_snap_row("X", 1, 0.5)])
+        with pytest.raises(SchemaRegressionError, match="st_pct"):
+            norm.parse_snap_counts(p)
+
+    def test_kicker_publishes_st_share(self, tmp_path):
+        # Regression (Codex round 2 on PR #539): kickers live entirely
+        # in st_snaps/st_pct; discarding the ST unit classified every
+        # K as "offense" with a misleading 0% share.
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                _snap_row("Kicky McLeg", 1, 0.0, st_pct=0.28, pos="K", pfr="McLeKi00"),
+                _snap_row("Kicky McLeg", 2, 0.0, st_pct=0.32, pos="K", pfr="McLeKi00"),
+            ],
+        )
+        agg = norm.aggregate_snaps(norm.parse_snap_counts(p))
+        assert len(agg) == 1
+        kicker = agg[0]
+        assert kicker["side"] == "st"
+        assert kicker["pct"] == pytest.approx(30.0)  # mean of 28/32
+        assert kicker["games"] == 2
+
+    def test_offense_still_wins_over_incidental_st_snaps(self, tmp_path):
+        # A skill player with a few ST snaps must stay "offense".
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [_snap_row("RB Guy", 1, 0.6, st_pct=0.2)],
+        )
+        agg = norm.aggregate_snaps(norm.parse_snap_counts(p))
+        assert agg[0]["side"] == "offense"
+        assert agg[0]["pct"] == pytest.approx(60.0)
+
+    def test_idless_traded_player_aggregates_across_teams(self, tmp_path):
+        # Regression (Codex round 2 on PR #539): the ID-less fallback
+        # key included the team, so a traded player's season split into
+        # per-stint aggregates that later overwrote each other on the
+        # same Sleeper record.
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                _snap_row("Traded Guy", 1, 0.40, team="CAR", pfr=""),
+                _snap_row("Traded Guy", 2, 0.50, team="CAR", pfr=""),
+                _snap_row("Traded Guy", 3, 0.80, team="SF", pfr=""),
+            ],
+        )
+        agg = norm.aggregate_snaps(norm.parse_snap_counts(p))
+        assert len(agg) == 1  # one season line, not one per stint
+        rec = agg[0]
+        assert rec["games"] == 3
+        assert rec["team"] == "SF"  # latest stint
+        assert rec["pct"] == pytest.approx(56.7, abs=0.05)  # mean of 40/50/80
+
+    def test_idless_same_week_collision_is_dropped(self, tmp_path):
+        # Two DISTINCT ID-less players sharing name+position betray
+        # themselves by playing the same week twice — the group must be
+        # dropped, not merged into a chimera.
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                _snap_row("Common Name", 1, 0.5, team="CAR", pfr=""),
+                _snap_row("Common Name", 1, 0.7, team="SF", pfr=""),
+            ],
+        )
+        assert norm.aggregate_snaps(norm.parse_snap_counts(p)) == []
+
+    def test_pfr_id_groups_are_exempt_from_collision_drop(self, tmp_path):
+        # An ID-bearing group is a single human by definition; the
+        # duplicate-week guard only applies to the ID-less fallback.
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                _snap_row("Id Guy", 1, 0.5, team="CAR", pfr="GuyId00"),
+                _snap_row("Id Guy", 2, 0.5, team="SF", pfr="GuyId00"),
+            ],
+        )
+        agg = norm.aggregate_snaps(norm.parse_snap_counts(p))
+        assert len(agg) == 1
+        assert agg[0]["games"] == 2
 
 
 # ── Depth charts ─────────────────────────────────────────────────────

--- a/tests/playerctx/test_normalize.py
+++ b/tests/playerctx/test_normalize.py
@@ -1,0 +1,334 @@
+"""Fixture-based tests for ``src.playerctx.normalize`` parsing +
+aggregation.  Pins the live nflverse schemas and the exit-2 schema-
+drift path.  No network."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.playerctx import normalize as norm
+from src.playerctx.normalize import SchemaRegressionError
+from tests.playerctx.conftest import (
+    CONTRACTS_HEADER,
+    DEPTH_HEADER,
+    SNAPS_HEADER,
+    write_csv,
+)
+
+# ── Contracts ────────────────────────────────────────────────────────
+
+
+def _contract_row(
+    name: str,
+    pos: str = "QB",
+    team: str = "Packers",
+    active: str = "TRUE",
+    year_signed: int = 2024,
+    years: int = 4,
+    value: int = 40_000_000,
+    apy: int = 10_000_000,
+    guaranteed: int = 20_000_000,
+) -> str:
+    return (
+        f"{name},{pos},{team},{active},{year_signed},{years},{value},"
+        f"{apy},{guaranteed},0.05,https://example.invalid,1,2020"
+    )
+
+
+class TestParseContracts:
+    def test_active_filter_and_fields(self, tmp_path):
+        p = write_csv(
+            tmp_path / "contracts.csv",
+            CONTRACTS_HEADER,
+            [
+                _contract_row("Aaron Example", active="TRUE"),
+                _contract_row("Retired Guy", active="FALSE"),
+            ],
+        )
+        rows = norm.parse_contracts(p)
+        assert len(rows) == 1
+        rec = rows[0]
+        assert rec["name"] == "Aaron Example"
+        assert rec["team"] == "GB"  # nickname → abbreviation
+        assert rec["apy"] == 10_000_000
+        assert rec["total"] == 40_000_000
+        assert rec["guaranteed"] == 20_000_000
+        assert rec["years"] == 4
+        assert rec["yearSigned"] == 2024
+        assert rec["endYear"] == 2027
+
+    def test_latest_signing_wins_for_duplicates(self, tmp_path):
+        p = write_csv(
+            tmp_path / "contracts.csv",
+            CONTRACTS_HEADER,
+            [
+                _contract_row("Dup Player", year_signed=2021, apy=5_000_000),
+                _contract_row("Dup Player", year_signed=2025, apy=9_000_000),
+            ],
+        )
+        rows = norm.parse_contracts(p)
+        assert len(rows) == 1
+        assert rows[0]["apy"] == 9_000_000
+        assert rows[0]["yearSigned"] == 2025
+
+    def test_gzip_variant(self, tmp_path):
+        p = write_csv(tmp_path / "contracts.csv.gz", CONTRACTS_HEADER, [_contract_row("Zip Man")])
+        assert norm.parse_contracts(p)[0]["name"] == "Zip Man"
+
+    def test_missing_column_is_schema_regression(self, tmp_path):
+        broken_header = CONTRACTS_HEADER.replace("apy,", "apy_renamed,")
+        p = write_csv(tmp_path / "contracts.csv", broken_header, [_contract_row("X")])
+        with pytest.raises(SchemaRegressionError, match="apy"):
+            norm.parse_contracts(p)
+
+
+# ── Snap counts ──────────────────────────────────────────────────────
+
+
+def _snap_row(
+    name: str,
+    week: int,
+    off_pct: float,
+    def_pct: float = 0.0,
+    season: int = 2025,
+    game_type: str = "REG",
+    team: str = "SF",
+    pos: str = "RB",
+    pfr: str = "McCaCh01",
+) -> str:
+    off_snaps = int(off_pct * 70)
+    def_snaps = int(def_pct * 70)
+    return (
+        f"2025_{week:02d}_{team}_XX,x{week},{season},{game_type},{week},{name},{pfr},"
+        f"{pos},{team},XX,{off_snaps},{off_pct},{def_snaps},{def_pct},0,0"
+    )
+
+
+class TestSnapCounts:
+    def test_parse_keeps_only_newest_season(self, tmp_path):
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                _snap_row("Old Season", 1, 0.9, season=2024),
+                _snap_row("New Season", 1, 0.8, season=2025),
+            ],
+        )
+        rows = norm.parse_snap_counts(p)
+        assert [r["name"] for r in rows] == ["New Season"]
+        assert rows[0]["offPct"] == pytest.approx(0.8)
+
+    def test_aggregate_pct_trend_and_side(self, tmp_path):
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                _snap_row("Christian McCaffrey", 1, 0.40),
+                _snap_row("Christian McCaffrey", 2, 0.50),
+                _snap_row("Christian McCaffrey", 3, 0.60),
+                _snap_row("Christian McCaffrey", 4, 0.70),
+                _snap_row(
+                    "Micah Parsons", 1, 0.0, def_pct=0.9, team="DAL", pos="DE", pfr="ParsMi00"
+                ),
+            ],
+        )
+        agg = {a["name"]: a for a in norm.aggregate_snaps(norm.parse_snap_counts(p))}
+        cmc = agg["Christian McCaffrey"]
+        assert cmc["games"] == 4
+        assert cmc["side"] == "offense"
+        assert cmc["pct"] == pytest.approx(55.0)  # mean of 40/50/60/70
+        assert cmc["recentPct"] == pytest.approx(60.0)  # last 3: 50/60/70
+        assert cmc["trend"] == pytest.approx(5.0)
+        parsons = agg["Micah Parsons"]
+        assert parsons["side"] == "defense"
+        assert parsons["pct"] == pytest.approx(90.0)
+
+    def test_postseason_orders_after_regular_season(self, tmp_path):
+        p = write_csv(
+            tmp_path / "snaps.csv",
+            SNAPS_HEADER,
+            [
+                _snap_row("P Layer", 1, 0.9, game_type="SB"),
+                _snap_row("P Layer", 17, 0.3, game_type="REG"),
+            ],
+        )
+        agg = norm.aggregate_snaps(norm.parse_snap_counts(p), recent_games=1)
+        # recent (last ordered game) must be the Super Bowl, not week 17
+        assert agg[0]["recentPct"] == pytest.approx(90.0)
+
+    def test_missing_column_is_schema_regression(self, tmp_path):
+        broken = SNAPS_HEADER.replace("offense_pct", "off_pct_renamed")
+        p = write_csv(tmp_path / "snaps.csv", broken, [_snap_row("X", 1, 0.5)])
+        with pytest.raises(SchemaRegressionError, match="offense_pct"):
+            norm.parse_snap_counts(p)
+
+
+# ── Depth charts ─────────────────────────────────────────────────────
+
+
+def _depth_row(
+    name: str,
+    *,
+    dt: str = "2026-07-25T08:57:25Z",
+    team: str = "SF",
+    gsis: str = "00-0000001",
+    espn: str = "111",
+    grp: str = "3WR 1TE",
+    abb: str = "WR",
+    slot: int = 1,
+    rank: int = 1,
+) -> str:
+    return f"{dt},{team},{name},{espn},{gsis},20,{grp},1,{abb},{abb},{slot},{rank}"
+
+
+class TestDepthCharts:
+    def test_newest_snapshot_wins_and_slots_filtered(self, tmp_path):
+        p = write_csv(
+            tmp_path / "depth.csv",
+            DEPTH_HEADER,
+            [
+                _depth_row("Stale Starter", dt="2026-01-01T00:00:00Z"),
+                _depth_row("Fresh Starter", dt="2026-07-25T08:57:25Z"),
+                _depth_row("Left Tackle", abb="LT"),  # OL — dropped
+                _depth_row("Punter Person", grp="Special Teams", abb="P"),  # dropped
+                _depth_row("Kicker Person", grp="Special Teams", abb="PK"),  # kept as K
+            ],
+        )
+        rows = norm.parse_depth_charts(p)
+        names = {r["name"] for r in rows}
+        assert names == {"Fresh Starter", "Kicker Person"}
+        kicker = next(r for r in rows if r["name"] == "Kicker Person")
+        assert kicker["position"] == "K"
+
+    def test_newest_snapshot_is_per_team(self, tmp_path):
+        p = write_csv(
+            tmp_path / "depth.csv",
+            DEPTH_HEADER,
+            [
+                _depth_row("Niner Guy", team="SF", dt="2026-07-25T00:00:00Z"),
+                _depth_row("Cowboy Guy", team="DAL", dt="2026-07-20T00:00:00Z"),
+            ],
+        )
+        assert {r["name"] for r in norm.parse_depth_charts(p)} == {"Niner Guy", "Cowboy Guy"}
+
+    def test_compute_depth_ranks_orders_slots_then_backups(self):
+        rows = [
+            {
+                "team": "SF",
+                "name": "WR One",
+                "gsisId": "g1",
+                "espnId": "",
+                "position": "WR",
+                "depthPosition": "WR",
+                "slot": 1,
+                "slotRank": 1,
+            },
+            {
+                "team": "SF",
+                "name": "WR Backup",
+                "gsisId": "g3",
+                "espnId": "",
+                "position": "WR",
+                "depthPosition": "WR",
+                "slot": 1,
+                "slotRank": 2,
+            },
+            {
+                "team": "SF",
+                "name": "WR Two",
+                "gsisId": "g2",
+                "espnId": "",
+                "position": "WR",
+                "depthPosition": "WR",
+                "slot": 2,
+                "slotRank": 1,
+            },
+        ]
+        ranked = {r["name"]: r["rank"] for r in norm.compute_depth_ranks(rows)}
+        assert ranked == {"WR One": 1, "WR Two": 2, "WR Backup": 3}
+
+    def test_compute_depth_ranks_dedupes_multi_slot_player(self):
+        rows = [
+            {
+                "team": "DAL",
+                "name": "Corner Man",
+                "gsisId": "g9",
+                "espnId": "",
+                "position": "DB",
+                "depthPosition": "LCB",
+                "slot": 1,
+                "slotRank": 1,
+            },
+            {
+                "team": "DAL",
+                "name": "Corner Man",
+                "gsisId": "g9",
+                "espnId": "",
+                "position": "DB",
+                "depthPosition": "NB",
+                "slot": 5,
+                "slotRank": 2,
+            },
+            {
+                "team": "DAL",
+                "name": "Safety Man",
+                "gsisId": "g8",
+                "espnId": "",
+                "position": "DB",
+                "depthPosition": "FS",
+                "slot": 3,
+                "slotRank": 1,
+            },
+        ]
+        ranked = norm.compute_depth_ranks(rows)
+        corner = [r for r in ranked if r["name"] == "Corner Man"]
+        assert len(corner) == 1
+        assert corner[0]["depthPosition"] == "LCB"  # best slot kept
+        assert len(ranked) == 2
+
+    def test_missing_column_is_schema_regression(self, tmp_path):
+        broken = DEPTH_HEADER.replace("gsis_id", "gsis_renamed")
+        p = write_csv(tmp_path / "depth.csv", broken, [_depth_row("X")])
+        with pytest.raises(SchemaRegressionError, match="gsis_id"):
+            norm.parse_depth_charts(p)
+
+
+# ── Team + pool helpers ──────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_team_code_aliases(self):
+        assert norm.normalize_team_code("LA") == "LAR"
+        assert norm.normalize_team_code("OAK") == "LV"
+        assert norm.normalize_team_code("sf") == "SF"
+        assert norm.normalize_team_code(None) == ""
+
+    def test_nickname_map_covers_all_32(self):
+        abbrs = {v for k, v in norm._TEAM_NICKNAME_TO_ABBR.items()}
+        assert len(abbrs) == 32
+
+    def test_build_sleeper_pool_filters_and_canonicalizes(self):
+        dump = {
+            "1": {
+                "active": True,
+                "position": "DE",
+                "full_name": "Edge Guy",
+                "team": "DAL",
+                "gsis_id": " 00-0001 ",
+                "espn_id": 42,
+            },
+            "2": {"active": False, "position": "QB", "full_name": "Retired QB", "team": "SF"},
+            "3": {"active": True, "position": "OT", "full_name": "Tackle Guy", "team": "SF"},
+            "4": {
+                "active": True,
+                "position": "WR",
+                "first_name": "No",
+                "last_name": "Fullname",
+                "team": "MIN",
+            },
+        }
+        pool = norm.build_sleeper_pool(dump)
+        assert set(pool) == {"1", "4"}
+        assert pool["1"]["position"] == "DL"  # DE → DL family
+        assert pool["1"]["gsis_id"] == "00-0001"  # stripped
+        assert pool["4"]["full_name"] == "No Fullname"

--- a/tests/playerctx/test_service.py
+++ b/tests/playerctx/test_service.py
@@ -136,6 +136,59 @@ class TestRefreshPlayerctx:
         with pytest.raises(RuntimeError, match="sleeper"):
             service.refresh_playerctx(fetcher=_fetcher(fixture_bundle))
 
+    def test_per_source_retention_guard(self, tmp_path, fixture_bundle, players_dir, small_floors):
+        # Regression (Codex round 1, finding 3 on PR #539): if ONE
+        # source collapses semantically (contracts matching almost
+        # nothing after a naming-convention change) while the union of
+        # player keys stays healthy, the union-only guard would publish
+        # a snapshot silently missing every contract block.  Each
+        # source's matched count must hold the retention ratio on its
+        # own.
+        target = tmp_path / "snapshot.json"
+        # Last-good: same 3 players (union check passes: 3 >= 3*0.75)
+        # but contracts historically matched 50 rows.
+        prev_players = {
+            f"00-{i:07d}": {"gsisId": f"00-{i:07d}", "sleeperId": str(i), "name": f"P{i}"}
+            for i in range(3)
+        }
+        store.write_snapshot(
+            prev_players,
+            counts={
+                "contracts": {"parsed": 60, "matched": 50},
+                "snapCounts": {"parsed": 3, "matched": 3},
+                "depthCharts": {"parsed": 3, "matched": 3},
+            },
+            path=target,
+        )
+        before = target.read_text(encoding="utf-8")
+        # New run only matches 2 contracts (fixture_bundle) — far under
+        # 75% of 50 — while depth+snaps keep the union at 3 players.
+        with pytest.raises(SchemaRegressionError, match="contracts: matched 2"):
+            service.refresh_playerctx(
+                fetcher=_fetcher(fixture_bundle),
+                players_dir=players_dir,
+                snapshot_path=target,
+            )
+        assert target.read_text(encoding="utf-8") == before  # last-good untouched
+
+    def test_per_source_guard_skips_snapshots_without_counts(
+        self, tmp_path, fixture_bundle, players_dir, small_floors
+    ):
+        # Older snapshots (or hand-rolled ones) without per-source
+        # counts must not trip the guard.
+        target = tmp_path / "snapshot.json"
+        prev_players = {
+            f"00-{i:07d}": {"gsisId": f"00-{i:07d}", "sleeperId": str(i), "name": f"P{i}"}
+            for i in range(3)
+        }
+        store.write_snapshot(prev_players, counts={}, path=target)
+        summary = service.refresh_playerctx(
+            fetcher=_fetcher(fixture_bundle),
+            players_dir=players_dir,
+            snapshot_path=target,
+        )
+        assert summary["counts"]["players"] == 3
+
 
 class TestLoadPlayerctx:
     def test_defensive_load(self, tmp_path):

--- a/tests/playerctx/test_service.py
+++ b/tests/playerctx/test_service.py
@@ -1,0 +1,173 @@
+"""Service orchestration with mocked fetch — end-to-end refresh into a
+tmp snapshot, floor/retention regression paths, and the CLI exit-code
+mapping.  No network."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts import refresh_playerctx as cli
+from src.playerctx import fetch as fetch_mod
+from src.playerctx import service, store
+from src.playerctx.normalize import SchemaRegressionError
+from tests.playerctx.conftest import (
+    CONTRACTS_HEADER,
+    DEPTH_HEADER,
+    SNAPS_HEADER,
+    write_csv,
+)
+
+
+@pytest.fixture
+def fixture_bundle(tmp_path):
+    """A FetchBundle backed by tiny on-disk fixture files."""
+    contracts = write_csv(
+        tmp_path / "historical_contracts.csv.gz",
+        CONTRACTS_HEADER,
+        [
+            "Christian McCaffrey,RB,49ers,TRUE,2024,2,38000000,19000000,24000000,"
+            "0.07,https://example.invalid,1,2017",
+            "Micah Parsons,DL,Cowboys,TRUE,2025,4,188000000,47000000,120000000,"
+            "0.18,https://example.invalid,2,2021",
+        ],
+    )
+    snaps = write_csv(
+        tmp_path / "snap_counts_2025.csv",
+        SNAPS_HEADER,
+        [
+            "2025_01_SF_XX,x1,2025,REG,1,Christian McCaffrey,McCaCh01,RB,SF,XX,60,0.85,0,0,0,0",
+            "2025_02_SF_XX,x2,2025,REG,2,Christian McCaffrey,McCaCh01,RB,SF,XX,65,0.95,0,0,0,0",
+            "2025_01_MIN_XX,x3,2025,REG,1,Justin Jefferson,JeffJu00,WR,MIN,XX,70,0.98,0,0,0,0",
+        ],
+    )
+    depth = write_csv(
+        tmp_path / "depth_charts_2026.csv",
+        DEPTH_HEADER,
+        [
+            "2026-07-25T00:00:00Z,SF,Christian McCaffrey,3117251,00-0033280,20,3WR 1TE,1,RB,RB,1,1",
+            "2026-07-25T00:00:00Z,MIN,Justin Jefferson,4262921,00-0036322,20,3WR 1TE,1,WR,WR,1,1",
+            "2026-07-25T00:00:00Z,DAL,Micah Parsons,4361429,00-0036933,16,Base 4-3 D,11,RDE,RDE,1,1",
+        ],
+    )
+    return fetch_mod.FetchBundle(
+        contracts=contracts,
+        snap_counts=snaps,
+        snap_counts_season=2025,
+        depth_charts=depth,
+        depth_charts_season=2026,
+        sleeper_players=None,
+        warnings=["snap_counts 2026: missing 404"],
+    )
+
+
+@pytest.fixture
+def small_floors(monkeypatch):
+    monkeypatch.setattr(service, "_ROW_FLOORS", {"contracts": 1, "snapCounts": 1, "depthCharts": 1})
+    monkeypatch.setattr(service, "_MIN_MATCHED_PLAYERS", 1)
+
+
+def _fetcher(bundle):
+    def fake_fetch(*, cache_dir=None, max_age_hours=None, force=False):
+        return bundle
+
+    return fake_fetch
+
+
+class TestRefreshPlayerctx:
+    def test_end_to_end_writes_snapshot(self, tmp_path, fixture_bundle, players_dir, small_floors):
+        target = tmp_path / "out" / "snapshot.json"
+        summary = service.refresh_playerctx(
+            fetcher=_fetcher(fixture_bundle),
+            players_dir=players_dir,
+            snapshot_path=target,
+        )
+        assert summary["snapshotPath"] == str(target)
+        assert summary["warnings"] == ["snap_counts 2026: missing 404"]
+        payload = store.load_snapshot(target)
+        assert payload is not None
+        players = payload["players"]
+        assert set(players) == {"00-0033280", "00-0036322", "00-0036933"}
+        cmc = players["00-0033280"]
+        assert cmc["contract"]["apy"] == 19_000_000
+        assert cmc["snaps"]["pct"] == pytest.approx(90.0)
+        assert cmc["depth"]["rank"] == 1
+        assert payload["sources"]["snapCounts"]["season"] == 2025
+        assert payload["sources"]["depthCharts"]["season"] == 2026
+
+    def test_missing_dataset_is_soft_failure(self, fixture_bundle, players_dir, small_floors):
+        fixture_bundle.contracts = None
+        with pytest.raises(RuntimeError, match="contracts"):
+            service.refresh_playerctx(fetcher=_fetcher(fixture_bundle), players_dir=players_dir)
+
+    def test_row_floor_breach_is_schema_regression(
+        self, tmp_path, fixture_bundle, players_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            service, "_ROW_FLOORS", {"contracts": 99, "snapCounts": 1, "depthCharts": 1}
+        )
+        monkeypatch.setattr(service, "_MIN_MATCHED_PLAYERS", 1)
+        with pytest.raises(SchemaRegressionError, match="contracts"):
+            service.refresh_playerctx(
+                fetcher=_fetcher(fixture_bundle),
+                players_dir=players_dir,
+                snapshot_path=tmp_path / "snap.json",
+            )
+
+    def test_retention_guard_keeps_last_good(
+        self, tmp_path, fixture_bundle, players_dir, small_floors
+    ):
+        target = tmp_path / "snapshot.json"
+        # Last-good snapshot with far more players than the new run yields.
+        many = {
+            f"00-{i:07d}": {"gsisId": f"00-{i:07d}", "sleeperId": str(i), "name": f"P{i}"}
+            for i in range(20)
+        }
+        store.write_snapshot(many, path=target)
+        before = target.read_text(encoding="utf-8")
+        with pytest.raises(SchemaRegressionError, match="retains only"):
+            service.refresh_playerctx(
+                fetcher=_fetcher(fixture_bundle),
+                players_dir=players_dir,
+                snapshot_path=target,
+            )
+        assert target.read_text(encoding="utf-8") == before  # untouched
+
+    def test_missing_sleeper_dump_is_soft_failure(self, fixture_bundle, small_floors):
+        with pytest.raises(RuntimeError, match="sleeper"):
+            service.refresh_playerctx(fetcher=_fetcher(fixture_bundle))
+
+
+class TestLoadPlayerctx:
+    def test_defensive_load(self, tmp_path):
+        assert service.load_playerctx(tmp_path / "missing.json") is None
+
+
+class TestCliExitCodes:
+    def test_success_is_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            cli,
+            "refresh_playerctx",
+            lambda **kw: {
+                "snapshotPath": "/x/snapshot.json",
+                "counts": {"players": 3, "contracts": {"matched": 2}},
+                "sources": {},
+                "warnings": ["w1"],
+            },
+        )
+        assert cli.main([]) == 0
+        err = capsys.readouterr().err
+        assert "w1" in err
+
+    def test_schema_regression_is_two(self, monkeypatch):
+        def boom(**kw):
+            raise SchemaRegressionError("columns went missing")
+
+        monkeypatch.setattr(cli, "refresh_playerctx", boom)
+        assert cli.main([]) == 2
+
+    def test_soft_failure_is_one(self, monkeypatch):
+        def boom(**kw):
+            raise RuntimeError("network sad")
+
+        monkeypatch.setattr(cli, "refresh_playerctx", boom)
+        assert cli.main([]) == 1

--- a/tests/playerctx/test_store.py
+++ b/tests/playerctx/test_store.py
@@ -1,0 +1,70 @@
+"""Snapshot store: atomic write semantics + defensive load."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.playerctx import store
+
+
+def _players() -> dict:
+    return {
+        "00-0033280": {
+            "gsisId": "00-0033280",
+            "sleeperId": "4034",
+            "name": "Christian McCaffrey",
+            "team": "SF",
+            "position": "RB",
+        }
+    }
+
+
+class TestWriteSnapshot:
+    def test_roundtrip_and_shape(self, tmp_path):
+        target = tmp_path / "snapshot.json"
+        written = store.write_snapshot(
+            _players(), counts={"players": 1}, sources={"contracts": {"url": "u"}}, path=target
+        )
+        assert written == target
+        payload = store.load_snapshot(target)
+        assert payload is not None
+        assert payload["schemaVersion"] == store.SCHEMA_VERSION
+        assert payload["generatedAt"]  # ISO stamp present
+        assert payload["counts"] == {"players": 1}
+        assert payload["sleeperIndex"] == {"4034": "00-0033280"}
+        assert payload["players"]["00-0033280"]["name"] == "Christian McCaffrey"
+
+    def test_compact_encoding(self, tmp_path):
+        target = tmp_path / "snapshot.json"
+        store.write_snapshot(_players(), path=target)
+        raw = target.read_text(encoding="utf-8")
+        assert ": " not in raw and ", " not in raw  # separators=(",", ":")
+
+    def test_failed_write_leaves_no_tmp_and_keeps_last_good(self, tmp_path):
+        target = tmp_path / "snapshot.json"
+        store.write_snapshot(_players(), path=target)
+        before = target.read_text(encoding="utf-8")
+        with pytest.raises(TypeError):
+            # object() is not JSON-serializable → dump raises mid-write
+            store.write_snapshot({"bad": {"sleeperId": object()}}, path=target)
+        assert target.read_text(encoding="utf-8") == before
+        assert list(tmp_path.glob("*.tmp-*")) == []
+
+
+class TestLoadSnapshot:
+    def test_missing_returns_none(self, tmp_path):
+        assert store.load_snapshot(tmp_path / "nope.json") is None
+
+    def test_corrupt_returns_none(self, tmp_path):
+        p = tmp_path / "snapshot.json"
+        p.write_text("{not json", encoding="utf-8")
+        assert store.load_snapshot(p) is None
+
+    def test_wrong_shape_returns_none(self, tmp_path):
+        p = tmp_path / "snapshot.json"
+        p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        assert store.load_snapshot(p) is None
+        p.write_text(json.dumps({"players": "not-a-dict"}), encoding="utf-8")
+        assert store.load_snapshot(p) is None


### PR DESCRIPTION
## What

New `src/playerctx/` package pre-building the scouting-report-grade context the redesigned player profiles will consume: **contracts, snap share, and depth-chart standing**, joined to the Sleeper pool. Data layer + CLI + tests + docs only — **nothing is wired into `server.py`, `data_contract.py`, or `frontend/`** (consumption wiring lands with the profile redesign R2).

## Datasets (public nflverse release assets — URLs + schemas verified live 2026-07-25)

| Dataset | URL | Join |
|---|---|---|
| Contracts (OTC) | `.../releases/download/contracts/historical_contracts.csv.gz` (~1.2 MB, ~32k rows) | name+position (no gsis in the CSV) |
| Snap counts (PFR) | `.../releases/download/snap_counts/snap_counts_{season}.csv` (~2.4 MB/season) | name+team+position; season fallback walk (2026 file 404s until kickoff → 2025) |
| Depth charts | `.../releases/download/depth_charts/depth_charts_{season}.csv` (35–55 MB; 2026 file exists and is refreshed daily through the offseason) | exact `gsis_id`/`espn_id`; newest dated snapshot per team |
| Sleeper `/v1/players/nfl` | join anchor (~5 MB JSON) | — |

## How

- **`fetch.py`** — raw cache in `data/playerctx/` (already covered by the repo-wide `data/` gitignore — no `.gitignore` change needed). Honest UA, timeouts, mtime freshness window (6 h; ≥20 h for the Sleeper dump per Sleeper's guidance), ETag/Last-Modified conditional GETs via a `<file>.meta.json` sidecar (304 verified live), stale-copy degradation on network failure.
- **`normalize.py`** — schema pins (missing columns → `SchemaRegressionError`); contracts deduped to the latest active signing with nickname→abbr team mapping; snaps collapsed to season %, last-3-games %, and trend (postseason ordered after REG, offense/defense side by snap volume); depth charts reduced to the newest snapshot per team, fantasy slots only, with a 1-based team-position rank.
- **Join** — depth rows by exact gsis/espn; contracts + snaps via the unified-mapper name ladder (deterministic rungs prebuilt as O(1) indexes; residual misses fall through to `unified_mapper.resolve_player` for its manual-override + fuzzy layers). Records keyed by `gsis_id` with a `sleeper:<id>` fallback — Sleeper's gsis coverage is sparse (2,501 of 7,646 pool entries), and the first-cut strict-gsis keying silently discarded 4,506 successful joins; the fallback plus source-gsis backfill from depth charts recovers them. `sleeperIndex` maps sleeper_id → record key for the UI.
- **`store.py`** — atomic tmp-then-replace snapshot write (pattern from `src/public_league/snapshot_store.py`), defensive loader.
- **`service.py`** — `refresh_playerctx()` with absolute row floors + a 75% last-good retention guard (regression keeps the last-good snapshot untouched); `load_playerctx()`.
- **`scripts/refresh_playerctx.py`** — argparse CLI, exit codes per the repo fetch-script convention: 0 ok / 1 soft fail / 2 schema regression.

## Real-run baseline (2026-07-26)

- contracts: 2,907 active parsed → **2,281 matched** to the Sleeper pool
- snap counts (2025 season): 2,189 player aggregates → **1,772 matched**
- depth charts (2026 file): 2,343 fantasy-slot rows → **2,317 matched** (99%)
- joined players: **3,856** (715 with all three blocks); snapshot ≈ **1.1 MB** compact JSON
- Snapshot is **not committed**: `data/` is gitignored repo-wide, so it follows the existing pattern — production materializes it by running the refresh script (weekly cadence recommended; see `docs/playerctx.md`).

## Known upstream caveats (documented, not bugs)

- `contract.team` is the *signing* franchise (traded contracts keep their origin team — e.g. McCaffrey's active row says Panthers); `endYear = yearSigned + years − 1` can undershoot real expiry for in-contract extensions; the contracts asset can lag recent signings by weeks (last rebuilt 2026-02-09).

## Validation

- `tests/playerctx/` — 39 tests, no network: fixture-based normalize + schema-drift (exit-2 path), join correctness against a fake pool (incl. the no-gsis fallback and record-split guard), store atomicity/corrupt-load, service orchestration with mocked fetch, CLI exit-code mapping.
- Full suite: `pytest -m "not livedata"` → **2794 passed, 280 deselected, 0 failed**.
- `ruff format` + `ruff check` clean on all new files.
- No new dependencies — CSV via stdlib (`csv` + `gzip`), HTTP via the already-pinned `requests`.

## Boundaries respected

No changes to `server.py`, `data_contract.py`, `frontend/**`, `scripts/fetch_*.py`, workflows, `src/news/**`, `src/intel/**`, `src/trade/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_