### PR TITLE
feat(news): Phase 6b — per-player ESPN news, 7-day cutoff, per-player digest

### DIFF
--- a/frontend/__tests__/news-service.test.js
+++ b/frontend/__tests__/news-service.test.js
@@ -33,6 +33,33 @@ describe("fetchNews fail-fast (no mock fallback)", () => {
     expect(res.source).toBe("backend");
     expect(res.items).toHaveLength(1);
     expect(res.providersUsed).toEqual(["espn"]);
+    // No playerDigests block → clean empty array, not undefined.
+    expect(res.digests).toEqual([]);
+  });
+
+  it("parses the per-player digest block when present", async () => {
+    const digest = {
+      player: "Bijan Robinson",
+      position: "RB",
+      team: "ATL",
+      storyCount: 2,
+      sources: ["ESPN Player News", "Play For Keeps"],
+      headline: "Bijan Robinson: 2 stories this week",
+      summary: "- a\n- b",
+      latestTs: "2026-07-26T10:00:00+00:00",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ items: [], playerDigests: [digest] })),
+    );
+    const res = await fetchNews();
+    expect(res.digests).toEqual([digest]);
+  });
+
+  it("failure paths carry an empty digests array", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({}, 503)));
+    const res = await fetchNews();
+    expect(res.digests).toEqual([]);
   });
 
   it("requests the route's full limit so client-side filters see the whole feed", async () => {

--- a/frontend/__tests__/player-name-match.test.js
+++ b/frontend/__tests__/player-name-match.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   normalizePlayerNameKey,
   buildNewsIndexByPlayer,
+  buildDigestIndex,
+  lookupPlayerDigest,
   lookupPlayerNews,
   newsItemsForPlayer,
 } from "@/lib/player-name-match";
@@ -317,5 +319,38 @@ describe("lookupPlayerNews — ambiguity suppression via the pool meta index", (
         playerMeta: POOL_META,
       }),
     ).toEqual([]);
+  });
+});
+
+describe("digest index — buildDigestIndex + lookupPlayerDigest", () => {
+  const DIGESTS = [
+    { player: "Bijan Robinson", position: "RB", team: "ATL", storyCount: 2 },
+    // Collision twins: distinct digest entries behind one name key.
+    { player: "C.J. Allen", position: "WR", team: "ATL", storyCount: 2 },
+    { player: "CJ Allen", position: "LB", team: "TEN", storyCount: 3 },
+  ];
+  const index = buildDigestIndex(DIGESTS);
+
+  it("resolves a unique player's digest regardless of name variant", () => {
+    expect(lookupPlayerDigest(index, "Bijan Robinson").storyCount).toBe(2);
+    expect(lookupPlayerDigest(index, "bijan  robinson").storyCount).toBe(2);
+  });
+
+  it("collision twins resolve by position and never cross over", () => {
+    const wr = lookupPlayerDigest(index, "C.J. Allen", { position: "WR" });
+    expect(wr.team).toBe("ATL");
+    const lb = lookupPlayerDigest(index, "CJ Allen", { position: "LB" });
+    expect(lb.storyCount).toBe(3);
+    // Ambiguous without a position → null, not a guess.
+    expect(lookupPlayerDigest(index, "CJ Allen")).toBeNull();
+    // Position that matches neither twin → null.
+    expect(lookupPlayerDigest(index, "CJ Allen", { position: "QB" })).toBeNull();
+  });
+
+  it("is defensive about bad input", () => {
+    expect(buildDigestIndex(null).size).toBe(0);
+    expect(lookupPlayerDigest(null, "Anyone")).toBeNull();
+    expect(lookupPlayerDigest(index, "")).toBeNull();
+    expect(lookupPlayerDigest(index, "Nobody Here")).toBeNull();
   });
 });

--- a/frontend/app/news/page.jsx
+++ b/frontend/app/news/page.jsx
@@ -6,7 +6,11 @@ import { useTeam } from "@/components/useTeam";
 import { useNews } from "@/components/useNews";
 import { PageHeader, EmptyState } from "@/components/ui";
 import { filterByScope, timeAgo } from "@/lib/news-service";
-import { itemPlayerNames, normalizePlayerNameKey } from "@/lib/player-name-match";
+import {
+  itemPlayerNames,
+  normalizePlayerNameKey,
+  positionFamily,
+} from "@/lib/player-name-match";
 import {
   buildMentionButtons,
   buildPlayerMetaIndex,
@@ -18,6 +22,15 @@ import {
 // TeamNewsFeed: relevance is scored by useNews/rankByRelevance against
 // the selected team's roster + the league-wide player pool, then
 // filterByScope slices on the score.
+// Stories = the raw chronological feed; By player = one combined
+// digest card per player with multiple recent articles (backend
+// ``playerDigests`` — see src/news/digest.py).  Raw items stay a
+// toggle away, never hidden.
+const VIEW_TABS = [
+  { key: "stories", label: "Stories" },
+  { key: "players", label: "By player" },
+];
+
 const SCOPE_TABS = [
   { key: "roster", label: "My Roster" },
   { key: "league", label: "League" },
@@ -95,6 +108,7 @@ export default function NewsPage() {
   const playerMeta = usePlayerMeta(rows);
 
   const [scope, setScope] = useState("all");
+  const [view, setView] = useState("stories");
   const [query, setQuery] = useState("");
   const [teamFilter, setTeamFilter] = useState("ALL");
   const [posFilter, setPosFilter] = useState("ALL");
@@ -125,6 +139,64 @@ export default function NewsPage() {
     }
     return [...teams].sort();
   }, [playerMeta]);
+
+  // Digest ("By player") view — the same facet vocabulary applied to
+  // the backend's per-player digest entries.
+  const rosterKeys = useMemo(
+    () => new Set(rosterNames.map(normalizePlayerNameKey).filter(Boolean)),
+    [rosterNames],
+  );
+  const leagueKeys = useMemo(
+    () => new Set(leagueNames.map(normalizePlayerNameKey).filter(Boolean)),
+    [leagueNames],
+  );
+  const filteredDigests = useMemo(() => {
+    let list = Array.isArray(news.digests) ? news.digests : [];
+    if (scope === "roster") {
+      list = list.filter((d) => rosterKeys.has(normalizePlayerNameKey(d.player)));
+    } else if (scope === "league") {
+      list = list.filter((d) => {
+        const key = normalizePlayerNameKey(d.player);
+        return rosterKeys.has(key) || leagueKeys.has(key);
+      });
+    }
+    if (teamFilter !== "ALL") {
+      list = list.filter(
+        (d) => String(d.team || "").toUpperCase() === teamFilter,
+      );
+    }
+    if (posFilter !== "ALL") {
+      list = list.filter((d) => positionFamily(d.position) === posFilter);
+    }
+    if (sourceFilter !== "ALL") {
+      const wanted = sourceOptions.find((s) => s.key === sourceFilter)?.label;
+      list = list.filter(
+        (d) => Array.isArray(d.sources) && wanted && d.sources.includes(wanted),
+      );
+    }
+    const q = query.trim();
+    if (q) {
+      const qKey = normalizePlayerNameKey(q);
+      list = list.filter((d) => {
+        const key = normalizePlayerNameKey(d.player);
+        return (
+          (qKey && key.includes(qKey)) ||
+          String(d.player || "").toLowerCase().includes(q.toLowerCase())
+        );
+      });
+    }
+    return list;
+  }, [
+    news.digests,
+    scope,
+    rosterKeys,
+    leagueKeys,
+    teamFilter,
+    posFilter,
+    sourceFilter,
+    sourceOptions,
+    query,
+  ]);
 
   const filtered = useMemo(() => {
     let items = filterByScope(news.scored, scope);
@@ -190,6 +262,12 @@ export default function NewsPage() {
           }}
         >
           <FilterPills
+            options={VIEW_TABS}
+            value={view}
+            onChange={setView}
+            ariaLabel="News view"
+          />
+          <FilterPills
             options={SCOPE_TABS}
             value={scope}
             onChange={setScope}
@@ -253,30 +331,99 @@ export default function NewsPage() {
           />
         )}
 
-        {!news.loading && !news.unavailable && filtered.length === 0 && (
-          <EmptyState
-            title="No matching news"
-            message={
-              scope === "roster"
-                ? "No roster-relevant headlines match these filters. Widen the scope or clear a filter."
-                : "No headlines match these filters. Try clearing the search or filters."
-            }
-          />
-        )}
+        {!news.loading &&
+          !news.unavailable &&
+          view === "stories" &&
+          filtered.length === 0 && (
+            <EmptyState
+              title="No matching news"
+              message={
+                scope === "roster"
+                  ? "No roster-relevant headlines match these filters. Widen the scope or clear a filter."
+                  : "No headlines match these filters. Try clearing the search or filters."
+              }
+            />
+          )}
 
-        {!news.loading && !news.unavailable && filtered.length > 0 && (
-          <ul className="news-feed">
-            {filtered.map((item) => (
-              <NewsRow
-                key={item.id || `${item.ts}-${item.headline}`}
-                item={item}
-                onPlayerClick={openPlayerPopup}
-              />
-            ))}
-          </ul>
-        )}
+        {!news.loading &&
+          !news.unavailable &&
+          view === "stories" &&
+          filtered.length > 0 && (
+            <ul className="news-feed">
+              {filtered.map((item) => (
+                <NewsRow
+                  key={item.id || `${item.ts}-${item.headline}`}
+                  item={item}
+                  onPlayerClick={openPlayerPopup}
+                />
+              ))}
+            </ul>
+          )}
+
+        {!news.loading &&
+          !news.unavailable &&
+          view === "players" &&
+          filteredDigests.length === 0 && (
+            <EmptyState
+              title="No player digests"
+              message="Digests appear when a player has two or more stories inside the 7-day window. Switch to Stories for the raw feed."
+            />
+          )}
+
+        {!news.loading &&
+          !news.unavailable &&
+          view === "players" &&
+          filteredDigests.length > 0 && (
+            <ul className="news-feed">
+              {filteredDigests.map((d) => (
+                <DigestRow
+                  key={`${d.player}-${d.position || ""}`}
+                  digest={d}
+                  onPlayerClick={openPlayerPopup}
+                />
+              ))}
+            </ul>
+          )}
       </div>
     </section>
+  );
+}
+
+function DigestRow({ digest, onPlayerClick }) {
+  const sevClass = `news-item--sev-${digest.severity || "info"}`;
+  return (
+    <li className={`news-item ${sevClass}`}>
+      <div className="news-item-meta">
+        <span className="news-item-time">{timeAgo(digest.latestTs)}</span>
+        <span className="news-item-provider">
+          {(digest.sources || []).join(" · ") || "—"}
+        </span>
+        {digest.severity && (
+          <span
+            className={`news-item-severity news-item-severity--${digest.severity}`}
+          >
+            {digest.severity}
+          </span>
+        )}
+      </div>
+      <h3 className="news-item-headline">
+        <button
+          type="button"
+          className="news-item-player news-item-player--general"
+          onClick={() => onPlayerClick?.(digest.player)}
+          title={`Open ${digest.player}`}
+          style={{ fontSize: "inherit", fontWeight: "inherit" }}
+        >
+          {digest.player}
+        </button>
+        {digest.position ? ` · ${digest.position}` : ""}
+        {digest.team ? ` · ${digest.team}` : ""}
+        {` — ${digest.storyCount} stories`}
+      </h3>
+      <p className="news-item-body" style={{ whiteSpace: "pre-line" }}>
+        {digest.summary}
+      </p>
+    </li>
   );
 }
 

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -8,7 +8,7 @@ import { buildTeamByPlayer, normalizeName } from "@/lib/waiver-logic";
 import PlayerRankHistoryChart from "@/components/PlayerRankHistoryChart";
 import { useApp } from "@/components/AppShell";
 import { useNews } from "@/components/useNews";
-import { lookupPlayerNews } from "@/lib/player-name-match";
+import { lookupPlayerDigest, lookupPlayerNews } from "@/lib/player-name-match";
 import { buildPlayerMetaIndex } from "@/lib/news-filters";
 import { timeAgo } from "@/lib/news-service";
 import { useTeam } from "@/components/useTeam";
@@ -211,7 +211,7 @@ function RosContextSection({ row }) {
 const _POPUP_NEWS_LIMIT = 5;
 
 function PlayerNewsSection({ playerName, position, team }) {
-  const { byPlayer } = useNews();
+  const { byPlayer, digestByPlayer } = useNews();
   const { rows: liveRows } = useApp();
   // Live-pool meta index: name-only items for a name that is
   // AMBIGUOUS in the pool (CJ Allen LB vs C.J. Allen WR) are
@@ -228,12 +228,44 @@ function PlayerNewsSection({ playerName, position, team }) {
       }),
     [byPlayer, playerName, position, team, newsPlayerMeta],
   );
+  // Backend per-player digest — ONE combined entry when the player
+  // has multiple recent stories.  Rendered above the raw list; raw
+  // items stay accessible below it.
+  const digest = useMemo(
+    () => lookupPlayerDigest(digestByPlayer, playerName, { position }),
+    [digestByPlayer, playerName, position],
+  );
   if (!items.length) return null;
   return (
     <div style={{ marginTop: 14 }}>
       <div className="label" style={{ marginBottom: 6 }}>
         News ({items.length})
       </div>
+      {digest && (
+        <div
+          style={{
+            border: "1px solid var(--border-bright)",
+            borderRadius: 6,
+            padding: "8px 10px",
+            marginBottom: 6,
+            background: "rgba(34, 211, 238, 0.06)",
+            fontSize: "0.76rem",
+          }}
+        >
+          <div style={{ fontWeight: 700 }}>{digest.headline}</div>
+          <div
+            className="muted"
+            style={{ whiteSpace: "pre-line", marginTop: 4, fontSize: "0.72rem" }}
+          >
+            {digest.summary}
+          </div>
+          {Array.isArray(digest.sources) && digest.sources.length > 0 && (
+            <div className="muted" style={{ marginTop: 4, fontSize: "0.66rem" }}>
+              Sources: {digest.sources.join(" · ")}
+            </div>
+          )}
+        </div>
+      )}
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
         {items.slice(0, _POPUP_NEWS_LIMIT).map((item) => (
           <div

--- a/frontend/components/useNews.js
+++ b/frontend/components/useNews.js
@@ -2,7 +2,10 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { fetchNews as fetchNewsRaw, rankByRelevance } from "@/lib/news-service";
-import { buildNewsIndexByPlayer } from "@/lib/player-name-match";
+import {
+  buildDigestIndex,
+  buildNewsIndexByPlayer,
+} from "@/lib/player-name-match";
 
 /**
  * useNews — shared fetch + scoring hook for the landing page.
@@ -83,6 +86,7 @@ export function useNews({ rosterNames, leagueNames } = {}) {
     loading: true,
     error: null,
     items: [],
+    digests: [],
     source: null,
     unavailable: false,
     reason: null,
@@ -112,6 +116,7 @@ export function useNews({ rosterNames, leagueNames } = {}) {
             loading: false,
             error: null,
             items: Array.isArray(res.items) ? res.items : [],
+            digests: Array.isArray(res.digests) ? res.digests : [],
             source: res.source || null,
             unavailable: !!res.unavailable,
             reason: res.reason || null,
@@ -128,6 +133,7 @@ export function useNews({ rosterNames, leagueNames } = {}) {
             loading: false,
             error: err?.message || "Failed to load news",
             items: [],
+            digests: [],
             source: null,
             unavailable: true,
             reason: "fetch_failed",
@@ -167,5 +173,13 @@ export function useNews({ rosterNames, leagueNames } = {}) {
     [state.items],
   );
 
-  return { ...state, scored, byPlayer };
+  // Per-player digest index (backend ``playerDigests``): resolve a
+  // specific row's digest with ``lookupPlayerDigest(digestByPlayer,
+  // name, { position })`` — collision twins keep separate entries.
+  const digestByPlayer = useMemo(
+    () => buildDigestIndex(state.digests),
+    [state.digests],
+  );
+
+  return { ...state, scored, byPlayer, digestByPlayer };
 }

--- a/frontend/lib/news-service.js
+++ b/frontend/lib/news-service.js
@@ -58,7 +58,10 @@ export const NEWS_FETCH_LIMIT = 100;
 /**
  * Fetch news items.  Backend only — failures surface as an explicit
  * unavailable state instead of silently serving stale fixture data.
- * @returns {Promise<{items, source, providersUsed, unavailable, reason}>}
+ * ``digests`` carries the backend's per-player combined entries
+ * (``playerDigests`` — one entry per player with multiple recent
+ * stories; see src/news/digest.py).
+ * @returns {Promise<{items, digests, source, providersUsed, unavailable, reason}>}
  */
 export async function fetchNews({ signal, limit = NEWS_FETCH_LIMIT } = {}) {
   try {
@@ -71,6 +74,9 @@ export async function fetchNews({ signal, limit = NEWS_FETCH_LIMIT } = {}) {
       const items = resolveItems(payload);
       return {
         items,
+        digests: Array.isArray(payload?.playerDigests)
+          ? payload.playerDigests
+          : [],
         source: "backend",
         providersUsed: Array.isArray(payload?.providersUsed)
           ? payload.providersUsed
@@ -81,6 +87,7 @@ export async function fetchNews({ signal, limit = NEWS_FETCH_LIMIT } = {}) {
     }
     return {
       items: [],
+      digests: [],
       source: "backend",
       providersUsed: [],
       unavailable: true,
@@ -93,6 +100,7 @@ export async function fetchNews({ signal, limit = NEWS_FETCH_LIMIT } = {}) {
     if (err?.name === "AbortError") throw err;
     return {
       items: [],
+      digests: [],
       source: null,
       providersUsed: [],
       unavailable: true,

--- a/frontend/lib/player-name-match.js
+++ b/frontend/lib/player-name-match.js
@@ -223,3 +223,37 @@ export function lookupPlayerNews(index, name, context) {
 export function newsItemsForPlayer(items, name, context) {
   return lookupPlayerNews(buildNewsIndexByPlayer(items), name, context);
 }
+
+/**
+ * Index the backend's per-player digests (``playerDigests``) by
+ * normalized name key.  Each value is a LIST — name-collision twins
+ * produce separate digest entries distinguished by position.
+ */
+export function buildDigestIndex(digests) {
+  const out = new Map();
+  if (!Array.isArray(digests)) return out;
+  for (const d of digests) {
+    const key = normalizePlayerNameKey(d?.player);
+    if (!key) continue;
+    const list = out.get(key);
+    if (list) list.push(d);
+    else out.set(key, [d]);
+  }
+  return out;
+}
+
+/**
+ * Resolve THE digest for a specific player row.  With one candidate
+ * behind the key it wins outright; with several (collision twins),
+ * the caller's position picks the matching identity — and without a
+ * usable position the lookup returns null rather than guessing.
+ */
+export function lookupPlayerDigest(index, name, { position } = {}) {
+  if (!(index instanceof Map)) return null;
+  const list = index.get(normalizePlayerNameKey(name)) || [];
+  if (list.length === 0) return null;
+  if (list.length === 1) return list[0];
+  const family = positionFamily(position);
+  if (!family) return null;
+  return list.find((d) => positionFamily(d?.position) === family) || null;
+}

--- a/server.py
+++ b/server.py
@@ -79,6 +79,7 @@ from src.api import league_registry as _league_registry
 from src.api import sleeper_overlay as _sleeper_overlay
 from src.news import NewsService, build_default_service
 from src.news import custom_alerts as _custom_alerts
+from src.news.providers.espn_player import DEFAULT_MAX_TARGETS as _ESPN_NEWS_TARGET_LIMIT
 
 # ── CONFIG ──────────────────────────────────────────────────────────────
 SCRAPE_INTERVAL_HOURS = 2
@@ -446,7 +447,13 @@ def _live_player_names() -> list[str]:
 # Rostered players cluster at the top of the board, and the provider
 # trickle-refreshes ~8 ids per 3-minute aggregate cycle, so 150
 # targets fully refresh roughly hourly at a polite request rate.
-_ESPN_NEWS_TARGET_LIMIT = 150
+#
+# Single source of truth: ``_ESPN_NEWS_TARGET_LIMIT`` is imported at
+# the top of this file as an alias of the provider's own
+# ``DEFAULT_MAX_TARGETS`` — the supplier below and the provider's
+# ``_valid_targets`` truncation can never drift apart (Codex P2:
+# a local 150 here vs the provider's default 100 silently discarded
+# targets 101-150).
 
 
 def _live_espn_news_targets() -> list[dict[str, str | None]]:

--- a/server.py
+++ b/server.py
@@ -400,7 +400,16 @@ def _get_news_service() -> NewsService:
         return _news_service
     with _news_service_lock:
         if _news_service is None:
-            _news_service = build_default_service()
+            _news_service = build_default_service(
+                provider_config={
+                    # Per-player ESPN news: the provider trickle-
+                    # refreshes espn_id targets from the live board
+                    # through its own per-player TTL cache — the
+                    # supplier is read lazily on each provider fetch,
+                    # so it always sees the current contract.
+                    "espn_player": {"targets_supplier": _live_espn_news_targets},
+                }
+            )
     return _news_service
 
 
@@ -431,6 +440,74 @@ def _live_player_names() -> list[str]:
                 names.append(v.strip())
                 break
     return names
+
+
+# How many top-board players get per-player ESPN news coverage.
+# Rostered players cluster at the top of the board, and the provider
+# trickle-refreshes ~8 ids per 3-minute aggregate cycle, so 150
+# targets fully refresh roughly hourly at a polite request rate.
+_ESPN_NEWS_TARGET_LIMIT = 150
+
+
+def _live_espn_news_targets() -> list[dict[str, str | None]]:
+    """Top-board players joined to their ESPN athlete ids.
+
+    Walks the live contract's ``playersArray`` in consensus-rank
+    order, resolves each row's Sleeper ``playerId`` through the
+    contract's Sleeper player directory (``sleeper.players`` — the
+    ``/v1/players/nfl`` shape, which carries ``espn_id``), and emits
+    ``{name, espnId, position, team}`` targets for the
+    ``espn_player`` news provider.  Rows without an espn_id mapping
+    are skipped; an unloaded contract yields [] and the provider
+    stays quiet.
+    """
+    contract = latest_contract_data or {}
+    rows = contract.get("playersArray") or []
+    players_dir = (contract.get("sleeper") or {}).get("players") or {}
+    if not isinstance(players_dir, dict) or not rows:
+        return []
+
+    def _rank(row: dict) -> float:
+        try:
+            r = float(row.get("canonicalConsensusRank") or row.get("rank") or 0)
+            return r if r > 0 else float("inf")
+        except (TypeError, ValueError):
+            return float("inf")
+
+    targets: list[dict[str, str | None]] = []
+    for row in sorted((r for r in rows if isinstance(r, dict)), key=_rank):
+        sid = str(row.get("playerId") or "").strip()
+        if not sid:
+            continue
+        p = players_dir.get(sid)
+        if not isinstance(p, dict):
+            continue
+        espn_id = str(p.get("espn_id") or "").strip()
+        if not espn_id:
+            continue
+        name = ""
+        for key in ("displayName", "name", "canonicalName", "fullName"):
+            v = row.get(key)
+            if isinstance(v, str) and v.strip():
+                name = v.strip()
+                break
+        if not name:
+            continue
+        position = row.get("position")
+        team = row.get("team")
+        targets.append(
+            {
+                "name": name,
+                "espnId": espn_id,
+                "position": position.strip()
+                if isinstance(position, str) and position.strip()
+                else None,
+                "team": team.strip().upper() if isinstance(team, str) and team.strip() else None,
+            }
+        )
+        if len(targets) >= _ESPN_NEWS_TARGET_LIMIT:
+            break
+    return targets
 
 
 def _live_player_meta() -> dict[str, dict[str, str | None]]:

--- a/src/news/digest.py
+++ b/src/news/digest.py
@@ -1,0 +1,156 @@
+"""Per-player news digests.
+
+When a player has multiple recent stories, every surface (popup,
+/news tab) wants ONE combined entry instead of N near-duplicates.
+``build_player_digests`` groups the aggregated items by player
+identity (normalized name + position family, so name-collision twins
+never merge), dedupes repeated stories, and emits a compact digest
+dict per player with source attribution.
+
+The digest TEXT comes from :func:`synthesize_player_digest` — the
+single, documented seam for LLM synthesis.  Today it is a mechanical
+combine (newest-first story lines with source + date attribution);
+when an ``ANTHROPIC_API_KEY`` is provisioned, an LLM-written
+paragraph can replace the mechanical text by swapping ONLY that
+function's body.  Nothing else in the pipeline knows how the text is
+produced.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Sequence
+
+from src.utils.name_clean import normalize_player_name, normalize_position_family
+
+from .base import NewsItem
+
+#: A digest only exists when a player has at least this many distinct
+#: stories — a single article renders better as itself.
+MIN_STORIES_FOR_DIGEST = 2
+
+#: Cap the story lines included in the mechanical summary; anything
+#: beyond is summarized as a "+N more" trailer.
+_MAX_SUMMARY_LINES = 6
+
+_SEVERITY_RANK = {"alert": 3, "watch": 2, "info": 1}
+
+
+def _story_key(item: NewsItem) -> str:
+    """Dedupe key for "the same story from multiple providers"."""
+    return " ".join(str(item.headline or "").lower().split())
+
+
+def _ts_epoch(item: NewsItem) -> float:
+    try:
+        return datetime.fromisoformat(str(item.ts).replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _short_date(item: NewsItem) -> str:
+    return str(item.ts or "")[:10]
+
+
+def synthesize_player_digest(player_name: str, stories: Sequence[NewsItem]) -> str:
+    """Combine a player's stories into one digest text.
+
+    ── LLM SYNTHESIS SEAM ──────────────────────────────────────────
+    This is the ONLY place digest text is produced.  The current
+    implementation is a mechanical combine: one attributed line per
+    story, newest first.  When ``ANTHROPIC_API_KEY`` is available,
+    replace this body with a model call that writes a single
+    coherent paragraph from the same ``stories`` input — callers,
+    payload shape, and tests of the surrounding structure need no
+    changes.  (Blocked today: the key has not been provisioned.)
+    """
+    lines: List[str] = []
+    for item in stories[:_MAX_SUMMARY_LINES]:
+        source = item.provider_label or item.provider or "news"
+        lines.append(f"- {item.headline} ({source}, {_short_date(item)})")
+    extra = len(stories) - _MAX_SUMMARY_LINES
+    if extra > 0:
+        lines.append(f"- +{extra} more stor{'y' if extra == 1 else 'ies'} this week")
+    return "\n".join(lines)
+
+
+def build_player_digests(items: Sequence[NewsItem]) -> List[dict[str, Any]]:
+    """Group aggregated items into one digest entry per player.
+
+    Grouping key is ``(normalized name, position family)`` so the
+    documented name-collision twins (CJ Allen the LB vs C.J. Allen
+    the WR) never share a digest; mentions flagged ``ambiguous`` are
+    skipped entirely — a digest must never confidently attribute an
+    ambiguous story.  Stories are deduped by normalized headline and
+    ordered newest first; players with fewer than
+    :data:`MIN_STORIES_FOR_DIGEST` distinct stories emit nothing.
+    """
+    groups: dict[tuple[str, str], dict[str, Any]] = {}
+    for item in sorted(items, key=_ts_epoch, reverse=True):
+        for mention in item.players:
+            if getattr(mention, "ambiguous", False):
+                continue
+            name = str(mention.name or "").strip()
+            norm = normalize_player_name(name)
+            if not norm:
+                continue
+            family = normalize_position_family(mention.position) if mention.position else ""
+            key = (norm, family)
+            group = groups.setdefault(
+                key,
+                {
+                    "player": name,
+                    "position": mention.position,
+                    "team": mention.team,
+                    "stories": [],
+                    "storyKeys": set(),
+                },
+            )
+            skey = _story_key(item)
+            if not skey or skey in group["storyKeys"]:
+                continue
+            group["storyKeys"].add(skey)
+            group["stories"].append(item)
+            # Prefer the first non-null identity stamps seen.
+            if not group["position"] and mention.position:
+                group["position"] = mention.position
+            if not group["team"] and mention.team:
+                group["team"] = mention.team
+
+    digests: List[dict[str, Any]] = []
+    for group in groups.values():
+        stories: List[NewsItem] = group["stories"]
+        if len(stories) < MIN_STORIES_FOR_DIGEST:
+            continue
+        severity = max(
+            (s.severity for s in stories),
+            key=lambda sev: _SEVERITY_RANK.get(sev, 0),
+        )
+        sources: List[str] = []
+        for s in stories:
+            label = s.provider_label or s.provider or "news"
+            if label not in sources:
+                sources.append(label)
+        digests.append(
+            {
+                "player": group["player"],
+                "position": group["position"],
+                "team": group["team"],
+                "storyCount": len(stories),
+                "latestTs": stories[0].ts,
+                "severity": severity,
+                "sources": sources,
+                "headline": f"{group['player']}: {len(stories)} stories this week",
+                "summary": synthesize_player_digest(group["player"], stories),
+                "itemIds": [s.id for s in stories],
+            }
+        )
+    digests.sort(key=lambda d: str(d["latestTs"]), reverse=True)
+    return digests
+
+
+__all__ = [
+    "MIN_STORIES_FOR_DIGEST",
+    "build_player_digests",
+    "synthesize_player_digest",
+]

--- a/src/news/providers/__init__.py
+++ b/src/news/providers/__init__.py
@@ -41,6 +41,7 @@ from .dynasty_focused import (
     RazzballProvider,
 )
 from .espn import EspnRssProvider
+from .espn_player import EspnPlayerNewsProvider
 from .fantasypros import FantasyProsRssProvider
 from .pfk import PfkArticlesProvider
 from .rotowire import RotowireProvider
@@ -56,6 +57,7 @@ ProviderFactory = Callable[..., NewsProvider]
 _PROVIDER_FACTORIES: Dict[str, ProviderFactory] = {
     "sleeper": SleeperTrendingProvider,
     "espn": EspnRssProvider,
+    "espn_player": EspnPlayerNewsProvider,
     "fantasypros": FantasyProsRssProvider,
     "cbs": CbsFantasyRssProvider,
     "dlf": DynastyLeagueFootballProvider,
@@ -91,6 +93,7 @@ __all__ = [
     "EspnRssProvider",
     "FantasyProsRssProvider",
     "FfTodayProvider",
+    "EspnPlayerNewsProvider",
     "PfkArticlesProvider",
     "PffProvider",
     "PlayerProfilerProvider",

--- a/src/news/providers/espn_player.py
+++ b/src/news/providers/espn_player.py
@@ -1,0 +1,240 @@
+"""Per-player ESPN news provider.
+
+Fetches player-scoped news from ESPN's fantasy news API:
+
+    https://site.web.api.espn.com/apis/fantasy/v2/games/ffl/news/players?playerId={espn_id}
+
+Probed 2026-07-26: the endpoint is genuinely player-scoped (Rotowire-
+style notes with ``headline``, ``story``, ``published``, ``links``)
+— unlike ``site.api.espn.com/.../news?playerId=``, which silently
+ignores the param and returns the league-wide feed.
+
+Identity: targets come from a ``targets_supplier`` callable injected
+at construction (the server wires it to the live contract's
+top-board rows joined against the Sleeper directory's ``espn_id``).
+Each emitted mention is PRE-STAMPED with the target's position/team,
+so the service's enrichment pass has nothing to guess — the espn_id
+join is the strongest identity signal in the pipeline.
+
+Politeness: the provider keeps its own per-player TTL cache
+(default 30 min) and refreshes at most ``max_requests_per_fetch``
+players per ``fetch()`` call (the service calls ``fetch`` once per
+aggregate refresh, itself TTL-cached).  A 100-player target list
+therefore trickle-refreshes over ~40 minutes at 8 requests per
+3-minute cycle — never a fan-out on page load.  Stale entries keep
+serving until their refresh slot comes up.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime
+from typing import Any, Callable, List, Optional
+
+from ..base import NewsItem, NewsProvider, PlayerMention, stable_id, to_iso_utc
+from ._rss import classify, clean_text, default_http_fetcher, parse_pub_date
+
+log = logging.getLogger(__name__)
+
+_FEED_URL_TEMPLATE = (
+    "https://site.web.api.espn.com/apis/fantasy/v2/games/ffl/news/players"
+    "?playerId={espn_id}&limit={limit}"
+)
+
+DEFAULT_PLAYER_TTL_S = 1800.0  # 30 min per player between refetches
+DEFAULT_MAX_REQUESTS_PER_FETCH = 8
+DEFAULT_MAX_TARGETS = 100
+DEFAULT_PER_PLAYER_LIMIT = 3
+
+
+def _default_targets_supplier() -> List[dict[str, Any]]:
+    """No wiring → no targets → provider contributes nothing."""
+    return []
+
+
+class EspnPlayerNewsProvider(NewsProvider):
+    """Player-scoped ESPN news via espn_id targets."""
+
+    name = "espn_player"
+    label = "ESPN Player News"
+    user_agent = "brisket-news-espn-player/1.0"
+
+    def __init__(
+        self,
+        *,
+        targets_supplier: Optional[Callable[[], List[dict[str, Any]]]] = None,
+        fetcher: Optional[Callable[[str], bytes]] = None,
+        player_ttl_s: float = DEFAULT_PLAYER_TTL_S,
+        max_requests_per_fetch: int = DEFAULT_MAX_REQUESTS_PER_FETCH,
+        max_targets: int = DEFAULT_MAX_TARGETS,
+        per_player_limit: int = DEFAULT_PER_PLAYER_LIMIT,
+        clock: Callable[[], float] = time.monotonic,
+        **config: Any,
+    ) -> None:
+        super().__init__(**config)
+        self._targets_supplier = targets_supplier or _default_targets_supplier
+        self._fetcher = fetcher or self._default_fetcher
+        self._player_ttl_s = max(0.0, float(player_ttl_s))
+        self._max_requests = max(1, int(max_requests_per_fetch))
+        self._max_targets = max(1, int(max_targets))
+        self._per_player_limit = max(1, int(per_player_limit))
+        self._clock = clock
+        # espn_id → (fetched_at, [NewsItem]).  Entries persist past
+        # their TTL and keep serving until their refresh slot comes
+        # up — stale player news beats a hole in the feed, and the
+        # service-level age cutoff drops anything genuinely old.
+        self._player_cache: dict[str, tuple[float, List[NewsItem]]] = {}
+
+    def _default_fetcher(self, url: str) -> bytes:
+        return default_http_fetcher(url, timeout=self.timeout_s, user_agent=self.user_agent)
+
+    # ── fetch ───────────────────────────────────────────────────
+    def fetch(self, *, player_names=None, limit: int = 50) -> List[NewsItem]:
+        targets = self._valid_targets()
+        if not targets:
+            return []
+
+        now = self._clock()
+
+        # Refresh order: never-fetched first, then oldest — a simple
+        # staleness sort gives round-robin coverage across cycles.
+        def _staleness(t: dict[str, Any]) -> float:
+            cached = self._player_cache.get(str(t["espnId"]))
+            return cached[0] if cached else float("-inf")
+
+        budget = self._max_requests
+        attempted = 0
+        failed = 0
+        last_error: Optional[Exception] = None
+        for target in sorted(targets, key=_staleness):
+            espn_id = str(target["espnId"])
+            cached = self._player_cache.get(espn_id)
+            fresh = cached is not None and (now - cached[0]) < self._player_ttl_s
+            if fresh or budget <= 0:
+                continue
+            budget -= 1
+            attempted += 1
+            try:
+                raw = self._fetcher(
+                    _FEED_URL_TEMPLATE.format(espn_id=espn_id, limit=self._per_player_limit)
+                )
+                items = self._parse_feed(raw, target)
+                self._player_cache[espn_id] = (now, items)
+            except Exception as exc:  # noqa: BLE001 — per-player isolation
+                failed += 1
+                last_error = exc
+                log.warning("espn_player fetch failed for %s: %s", espn_id, exc)
+                # Keep any stale entry rather than overwriting with
+                # nothing; it refreshes on a later cycle.
+
+        # Total-failure signal: every attempted request failed AND the
+        # cache has nothing to serve.  Raising here lets the service's
+        # per-provider isolation mark the run down (and the route's
+        # all_providers_failed detection work) instead of masquerading
+        # as a healthy-but-quiet feed.
+        if attempted > 0 and failed == attempted and not self._player_cache:
+            raise last_error if last_error else RuntimeError("espn_player: all requests failed")
+
+        out: List[NewsItem] = []
+        target_ids = {str(t["espnId"]) for t in targets}
+        for espn_id, (_ts, items) in self._player_cache.items():
+            if espn_id in target_ids:
+                out.extend(items)
+        out.sort(key=lambda it: it.ts, reverse=True)
+        return out[: max(1, int(limit))]
+
+    # ── helpers ─────────────────────────────────────────────────
+    def _valid_targets(self) -> List[dict[str, Any]]:
+        try:
+            raw_targets = self._targets_supplier() or []
+        except Exception as exc:  # noqa: BLE001 — supplier reads live state
+            log.warning("espn_player targets supplier failed: %s", exc)
+            return []
+        out: List[dict[str, Any]] = []
+        seen: set[str] = set()
+        for t in raw_targets:
+            if not isinstance(t, dict):
+                continue
+            espn_id = str(t.get("espnId") or "").strip()
+            name = str(t.get("name") or "").strip()
+            if not espn_id or not name or espn_id in seen:
+                continue
+            seen.add(espn_id)
+            out.append(
+                {
+                    "espnId": espn_id,
+                    "name": name,
+                    "position": str(t.get("position") or "").strip() or None,
+                    "team": str(t.get("team") or "").strip() or None,
+                }
+            )
+            if len(out) >= self._max_targets:
+                break
+        return out
+
+    def _parse_feed(self, raw: bytes, target: dict[str, Any]) -> List[NewsItem]:
+        payload = json.loads(raw)
+        feed = payload.get("feed") if isinstance(payload, dict) else None
+        if not isinstance(feed, list):
+            return []
+        out: List[NewsItem] = []
+        for entry in feed[: self._per_player_limit]:
+            if not isinstance(entry, dict):
+                continue
+            headline = clean_text(str(entry.get("headline") or ""))
+            if not headline:
+                continue
+            body = clean_text(str(entry.get("story") or entry.get("description") or ""))
+            published = parse_pub_date(None)
+            raw_published = entry.get("published") or entry.get("lastModified")
+            if isinstance(raw_published, str) and raw_published.strip():
+                try:
+                    published = datetime.fromisoformat(raw_published.replace("Z", "+00:00"))
+                except ValueError:
+                    pass
+            url = _entry_url(entry)
+            entry_id = str(entry.get("id") or entry.get("contentKey") or headline)
+            severity, kind, impact = classify(f"{headline}\n{body}")
+            out.append(
+                NewsItem(
+                    id=stable_id(self.name, f"{target['espnId']}:{entry_id}"),
+                    ts=to_iso_utc(published),
+                    provider=self.name,
+                    provider_label=self.label,
+                    severity=severity,
+                    kind=kind,
+                    headline=headline,
+                    body=body,
+                    # Pre-stamped identity: the espn_id join already
+                    # names exactly one player — no enrichment guess.
+                    players=[
+                        PlayerMention(
+                            name=target["name"],
+                            impact=impact,
+                            position=target["position"],
+                            team=target["team"],
+                        )
+                    ],
+                    url=url,
+                    tags=[kind, "player"],
+                )
+            )
+        return out
+
+
+def _entry_url(entry: dict[str, Any]) -> Optional[str]:
+    links = entry.get("links")
+    if not isinstance(links, dict):
+        return None
+    for path in (("web", "href"), ("mobile", "href")):
+        node: Any = links
+        for key in path:
+            node = node.get(key) if isinstance(node, dict) else None
+        if isinstance(node, str) and node.startswith("http"):
+            return node
+    return None
+
+
+__all__ = ["EspnPlayerNewsProvider"]

--- a/src/news/providers/espn_player.py
+++ b/src/news/providers/espn_player.py
@@ -34,7 +34,7 @@ from datetime import datetime
 from typing import Any, Callable, List, Optional
 
 from ..base import NewsItem, NewsProvider, PlayerMention, stable_id, to_iso_utc
-from ._rss import classify, clean_text, default_http_fetcher, parse_pub_date
+from ._rss import classify, clean_text, default_http_fetcher
 
 log = logging.getLogger(__name__)
 
@@ -45,7 +45,11 @@ _FEED_URL_TEMPLATE = (
 
 DEFAULT_PLAYER_TTL_S = 1800.0  # 30 min per player between refetches
 DEFAULT_MAX_REQUESTS_PER_FETCH = 8
-DEFAULT_MAX_TARGETS = 100
+# Single source of truth for target coverage: server.py's
+# ``_live_espn_news_targets`` supplier imports this as its own cap,
+# so the supplier's emission limit and this provider's
+# ``_valid_targets`` truncation cannot drift apart.
+DEFAULT_MAX_TARGETS = 150
 DEFAULT_PER_PLAYER_LIMIT = 3
 
 
@@ -86,6 +90,10 @@ class EspnPlayerNewsProvider(NewsProvider):
         # up — stale player news beats a hole in the feed, and the
         # service-level age cutoff drops anything genuinely old.
         self._player_cache: dict[str, tuple[float, List[NewsItem]]] = {}
+        # espn_id → last attempt time (success OR failure).  Drives
+        # the round-robin ordering so persistent failers can't starve
+        # the budget — see ``_staleness`` in ``fetch``.
+        self._last_attempt: dict[str, float] = {}
 
     def _default_fetcher(self, url: str) -> bytes:
         return default_http_fetcher(url, timeout=self.timeout_s, user_agent=self.user_agent)
@@ -98,11 +106,16 @@ class EspnPlayerNewsProvider(NewsProvider):
 
         now = self._clock()
 
-        # Refresh order: never-fetched first, then oldest — a simple
-        # staleness sort gives round-robin coverage across cycles.
+        # Refresh order: never-ATTEMPTED first, then oldest attempt.
+        # Ranking by attempt time (not cache time) is what keeps the
+        # round-robin advancing past repeat offenders: a persistently
+        # failing target never enters the cache, so a cache-time sort
+        # would rank it -inf forever and let a handful of failers
+        # consume the whole budget every cycle, starving every later
+        # target (Codex P2).  A failed attempt sends the target to
+        # the back of the line until the others have had their slot.
         def _staleness(t: dict[str, Any]) -> float:
-            cached = self._player_cache.get(str(t["espnId"]))
-            return cached[0] if cached else float("-inf")
+            return self._last_attempt.get(str(t["espnId"]), float("-inf"))
 
         budget = self._max_requests
         attempted = 0
@@ -116,6 +129,7 @@ class EspnPlayerNewsProvider(NewsProvider):
                 continue
             budget -= 1
             attempted += 1
+            self._last_attempt[espn_id] = now
             try:
                 raw = self._fetcher(
                     _FEED_URL_TEMPLATE.format(espn_id=espn_id, limit=self._per_player_limit)
@@ -187,13 +201,14 @@ class EspnPlayerNewsProvider(NewsProvider):
             if not headline:
                 continue
             body = clean_text(str(entry.get("story") or entry.get("description") or ""))
-            published = parse_pub_date(None)
-            raw_published = entry.get("published") or entry.get("lastModified")
-            if isinstance(raw_published, str) and raw_published.strip():
-                try:
-                    published = datetime.fromisoformat(raw_published.replace("Z", "+00:00"))
-                except ValueError:
-                    pass
+            # Undated entries are SKIPPED, not stamped with now():
+            # defaulting to the fetch time would fabricate freshness
+            # on every refetch and smuggle possibly-old articles past
+            # the service's 7-day cutoff (which drops anything that
+            # can't prove its age).
+            published = _parse_entry_timestamp(entry)
+            if published is None:
+                continue
             url = _entry_url(entry)
             entry_id = str(entry.get("id") or entry.get("contentKey") or headline)
             severity, kind, impact = classify(f"{headline}\n{body}")
@@ -222,6 +237,21 @@ class EspnPlayerNewsProvider(NewsProvider):
                 )
             )
         return out
+
+
+def _parse_entry_timestamp(entry: dict[str, Any]) -> Optional[datetime]:
+    """Parse ``published`` (falling back to ``lastModified``) or None.
+
+    None means the entry carries no provable timestamp — callers skip
+    it rather than inventing one.
+    """
+    raw = entry.get("published") or entry.get("lastModified")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        return datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _entry_url(entry: dict[str, Any]) -> Optional[str]:

--- a/src/news/service.py
+++ b/src/news/service.py
@@ -35,11 +35,17 @@ from datetime import datetime, timezone
 from typing import Any, Iterable, List, Mapping, Optional, Sequence
 
 from .base import NewsItem, NewsProvider
+from .digest import build_player_digests
 from .providers import available_provider_names, build_provider
 
 log = logging.getLogger(__name__)
 
 DEFAULT_CACHE_TTL_S = 180  # 3 minutes — rate-limit-safe for all providers
+# Hard freshness cutoff: every surface (news tab, popups, chips)
+# must only show news from the last week, so the drop happens HERE
+# at aggregation — not per consumer.  Items whose timestamp cannot
+# be parsed are dropped too: they can't prove freshness.
+MAX_ITEM_AGE_DAYS = 7
 # All-failed aggregates get a much shorter cache life: caching an
 # outage for the full TTL would keep the client's 15/30/60s retries
 # hitting the stale failure for minutes after upstreams recover.
@@ -102,7 +108,36 @@ class AggregatedNews:
             "generatedAt": self.generated_at,
             "cacheHit": self.cache_hit,
             "count": len(self.items),
+            # One combined entry per player with multiple recent
+            # stories (see src/news/digest.py — including the LLM
+            # synthesis seam).  Computed from the already-filtered
+            # item list so every surface inherits the age cutoff.
+            "playerDigests": build_player_digests(self.items),
         }
+
+
+def _drop_stale_items(
+    items: Sequence[NewsItem],
+    *,
+    now_epoch: float,
+    max_age_days: int = MAX_ITEM_AGE_DAYS,
+) -> List[NewsItem]:
+    """Drop every item older than the hard freshness cutoff.
+
+    ``now_epoch`` comes from the service clock so tests with a fake
+    clock stay deterministic.  Unparseable timestamps are dropped —
+    an item that can't prove it is under a week old doesn't ship.
+    """
+    cutoff = now_epoch - max_age_days * 86400.0
+    out: List[NewsItem] = []
+    for it in items:
+        try:
+            ts = datetime.fromisoformat(str(it.ts).replace("Z", "+00:00")).timestamp()
+        except (TypeError, ValueError):
+            continue
+        if ts >= cutoff:
+            out.append(it)
+    return out
 
 
 def _dedupe(items: Sequence[NewsItem]) -> List[NewsItem]:
@@ -292,6 +327,11 @@ class NewsService:
 
         try:
             items, runs = self._fetch_all(known_names)
+            # Hard 7-day freshness cutoff — applied at aggregation so
+            # every downstream surface inherits it.  The cache TTL
+            # (≤180s) is far below the cutoff granularity, so cached
+            # entries can't meaningfully age past it between misses.
+            items = _drop_stale_items(items, now_epoch=self._clock())
             items = _dedupe(items)
             items = _sort_items(items)
             # Stamp position/team identity discriminators onto
@@ -411,7 +451,7 @@ class NewsService:
 # ``pfk`` is the Play For Keeps articles provider — one polite
 # sitemap request per cache refresh, isolated like every other
 # provider.
-_DEFAULT_ENABLED = ("sleeper", "espn", "fantasypros", "cbs", "pfk")
+_DEFAULT_ENABLED = ("sleeper", "espn", "espn_player", "fantasypros", "cbs", "pfk")
 
 
 def build_default_service(
@@ -451,6 +491,8 @@ __all__ = [
     "DEFAULT_CACHE_TTL_S",
     "DEFAULT_LIMIT_PER_PROVIDER",
     "DEFAULT_TOTAL_LIMIT",
+    "FAILURE_CACHE_TTL_S",
+    "MAX_ITEM_AGE_DAYS",
     "NewsService",
     "ProviderRunResult",
     "build_default_service",

--- a/tests/news/test_api_news_route.py
+++ b/tests/news/test_api_news_route.py
@@ -130,6 +130,17 @@ def test_api_news_limit_caps_response(client):
     assert data["limit"] == 3
 
 
+def test_espn_target_limit_is_the_provider_default():
+    """Single source of truth: server.py imports the espn_player
+    provider's DEFAULT_MAX_TARGETS as _ESPN_NEWS_TARGET_LIMIT, so the
+    supplier's emission cap and the provider's _valid_targets
+    truncation can never drift apart (Codex P2 — a local 150 vs the
+    provider's old default 100 silently discarded targets 101-150)."""
+    from src.news.providers.espn_player import DEFAULT_MAX_TARGETS
+
+    assert server._ESPN_NEWS_TARGET_LIMIT == DEFAULT_MAX_TARGETS
+
+
 def test_api_news_returns_503_when_all_providers_fail(client):
     svc = NewsService(
         [_FakeProvider(error=RuntimeError("boom"))],

--- a/tests/news/test_api_news_route.py
+++ b/tests/news/test_api_news_route.py
@@ -8,6 +8,8 @@ query-param parsing, response shape, 503 on all-failures.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -52,7 +54,9 @@ class _FakeProvider:
 def _make_item(id_, players=None):
     return NewsItem(
         id=id_,
-        ts="2026-04-23T10:00:00+00:00",
+        # Recent timestamp — the service drops anything older than
+        # its 7-day freshness cutoff at aggregation time.
+        ts=datetime.now(timezone.utc).isoformat(),
         provider="fake",
         provider_label="Fake",
         severity="alert",

--- a/tests/news/test_digest.py
+++ b/tests/news/test_digest.py
@@ -1,0 +1,137 @@
+"""Tests for the per-player news digest builder.
+
+Pins grouping (position-aware so name-collision twins never merge),
+story dedupe, the two-story minimum, severity/source aggregation,
+ambiguous-mention exclusion, and the mechanical output of the
+LLM-synthesis seam function.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.news.base import NewsItem, PlayerMention
+from src.news.digest import (
+    MIN_STORIES_FOR_DIGEST,
+    build_player_digests,
+    synthesize_player_digest,
+)
+
+
+def _ts(hours_ago: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+
+
+def _item(id_, headline, *, ts=None, severity="info", provider="espn", players=None):
+    return NewsItem(
+        id=id_,
+        ts=ts or _ts(),
+        provider=provider,
+        provider_label=provider.title(),
+        severity=severity,
+        kind="news",
+        headline=headline,
+        body="",
+        players=players or [],
+    )
+
+
+def _mention(name, position=None, team=None, ambiguous=False):
+    return PlayerMention(name=name, position=position, team=team, ambiguous=ambiguous)
+
+
+def test_min_two_stories_required():
+    items = [
+        _item("a", "Only story", players=[_mention("Bijan Robinson", "RB", "ATL")]),
+    ]
+    assert MIN_STORIES_FOR_DIGEST == 2
+    assert build_player_digests(items) == []
+
+
+def test_digest_groups_newest_first_with_sources():
+    items = [
+        _item(
+            "old",
+            "Robinson practice note",
+            ts=_ts(hours_ago=30),
+            provider="pfk",
+            players=[_mention("Bijan Robinson", "RB", "ATL")],
+        ),
+        _item(
+            "new",
+            "Robinson contract update",
+            ts=_ts(hours_ago=1),
+            severity="watch",
+            provider="espn",
+            players=[_mention("Bijan Robinson", "RB", "ATL")],
+        ),
+    ]
+    digests = build_player_digests(items)
+    assert len(digests) == 1
+    d = digests[0]
+    assert d["player"] == "Bijan Robinson"
+    assert d["storyCount"] == 2
+    assert d["itemIds"] == ["new", "old"]  # newest first
+    assert d["latestTs"] == items[1].ts
+    assert d["severity"] == "watch"  # max severity wins
+    assert d["sources"] == ["Espn", "Pfk"]  # order of appearance, deduped
+    assert d["position"] == "RB" and d["team"] == "ATL"
+    # Mechanical summary carries attribution per story line.
+    assert "Robinson contract update (Espn," in d["summary"]
+    assert "Robinson practice note (Pfk," in d["summary"]
+
+
+def test_same_story_from_two_providers_dedupes():
+    items = [
+        _item(
+            "e1",
+            "Robinson signs extension",
+            provider="espn",
+            players=[_mention("Bijan Robinson", "RB", "ATL")],
+        ),
+        _item(
+            "p1",
+            "Robinson Signs Extension",  # same story, case drift
+            provider="pfk",
+            players=[_mention("Bijan Robinson", "RB", "ATL")],
+        ),
+        _item(
+            "e2",
+            "Robinson practice note",
+            players=[_mention("Bijan Robinson", "RB", "ATL")],
+        ),
+    ]
+    digests = build_player_digests(items)
+    assert len(digests) == 1
+    assert digests[0]["storyCount"] == 2  # duplicate story collapsed
+
+
+def test_collision_twins_never_merge():
+    items = [
+        _item("wr1", "WR camp riser", players=[_mention("C.J. Allen", "WR", "ATL")]),
+        _item("wr2", "WR route tree note", players=[_mention("C.J. Allen", "WR", "ATL")]),
+        _item("lb1", "LB rep count", players=[_mention("CJ Allen", "LB", "TEN")]),
+        _item("lb2", "LB coverage note", players=[_mention("CJ Allen", "LB", "TEN")]),
+    ]
+    digests = build_player_digests(items)
+    assert len(digests) == 2
+    by_pos = {d["position"]: d for d in digests}
+    assert by_pos["WR"]["storyCount"] == 2
+    assert by_pos["LB"]["storyCount"] == 2
+
+
+def test_ambiguous_mentions_excluded():
+    items = [
+        _item("a1", "Ambiguous slug story", players=[_mention("CJ Allen", ambiguous=True)]),
+        _item("a2", "Another ambiguous one", players=[_mention("CJ Allen", ambiguous=True)]),
+    ]
+    assert build_player_digests(items) == []
+
+
+def test_synthesize_seam_caps_lines_with_more_trailer():
+    stories = [_item(f"s{i}", f"Story number {i}") for i in range(8)]
+    text = synthesize_player_digest("Bijan Robinson", stories)
+    lines = text.split("\n")
+    # 6 story lines + the "+2 more" trailer.
+    assert len(lines) == 7
+    assert lines[-1].startswith("- +2 more")

--- a/tests/news/test_espn_player_provider.py
+++ b/tests/news/test_espn_player_provider.py
@@ -122,6 +122,47 @@ class TestParse:
         assert _provider(fetcher, targets=[]).fetch() == []
         assert fetcher.calls == []
 
+    def test_undated_entries_are_skipped(self):
+        """No published/lastModified (or an unparseable one) → the
+        entry is dropped at the provider.  Stamping now() instead
+        would fabricate freshness on every refetch and smuggle old
+        articles past the service's 7-day cutoff."""
+        undated = {"id": "u1", "headline": "Undated note", "links": {}}
+        unparseable = {
+            "id": "u2",
+            "headline": "Bad-date note",
+            "published": "not a timestamp",
+            "links": {},
+        }
+        dated = _entry("d1", "Dated note")
+        fetcher = _RecordingFetcher({"4430807": _feed_payload(undated, unparseable, dated)})
+        items = _provider(fetcher, targets=[TARGETS[0]]).fetch()
+        assert [it.headline for it in items] == ["Dated note"]
+
+    def test_undated_entry_never_reaches_the_aggregate(self):
+        from src.news.service import NewsService
+
+        undated = {"id": "u1", "headline": "Undated note", "links": {}}
+        fetcher = _RecordingFetcher({"4430807": _feed_payload(undated)})
+        provider = _provider(fetcher, targets=[TARGETS[0]])
+        svc = NewsService([provider], cache_ttl_s=0)
+        assert svc.aggregate().items == []
+
+    def test_default_max_targets_covers_the_server_target_list(self):
+        """Codex P2: the server supplied 150 targets but the provider's
+        default cap silently discarded 101-150.  The cap now lives in
+        ONE place (DEFAULT_MAX_TARGETS) that the server imports, and
+        the default config must accept the full list."""
+        from src.news.providers.espn_player import DEFAULT_MAX_TARGETS
+
+        targets = [
+            {"name": f"Player {i}", "espnId": str(i), "position": "WR", "team": "ATL"}
+            for i in range(1, 151)
+        ]
+        assert DEFAULT_MAX_TARGETS >= 150
+        provider = EspnPlayerNewsProvider(targets_supplier=lambda: targets)
+        assert len(provider._valid_targets()) == 150
+
 
 class TestCacheAndPoliteness:
     def test_player_ttl_prevents_refetch(self):
@@ -181,6 +222,56 @@ class TestCacheAndPoliteness:
         provider = _provider(fetcher)
         with pytest.raises(OSError):
             provider.fetch()
+
+    def test_persistent_failures_dont_starve_the_round_robin(self):
+        """Repeat offenders must not eat the whole budget every cycle:
+        a failed attempt sends the target to the back of the line, so
+        later targets get their fetch slot before any retry."""
+        targets = [
+            {"name": "Failer One", "espnId": "1", "position": "WR", "team": "ATL"},
+            {"name": "Failer Two", "espnId": "2", "position": "WR", "team": "ATL"},
+            {"name": "Good Three", "espnId": "3", "position": "RB", "team": "DAL"},
+            {"name": "Good Four", "espnId": "4", "position": "TE", "team": "MIN"},
+        ]
+        fetcher = _RecordingFetcher(
+            {
+                "3": _feed_payload(_entry("g3", "Three note")),
+                "4": _feed_payload(_entry("g4", "Four note")),
+            },
+            errors_by_id={"1": OSError("down"), "2": OSError("down")},
+        )
+        clock = {"t": 0.0}
+        provider = _provider(
+            fetcher,
+            targets=targets,
+            clock=lambda: clock["t"],
+            max_requests_per_fetch=2,
+            player_ttl_s=10_000,
+        )
+
+        def _ids(calls):
+            return [url.split("playerId=")[1].split("&")[0] for url in calls]
+
+        # Cycle 1: the two (failing) heads of the list consume the
+        # budget.  With every attempted request failed and an empty
+        # cache this is indistinguishable from a full outage, so the
+        # provider raises (the service isolates it) — but the attempt
+        # timestamps are already recorded, which is what un-starves
+        # the next cycle.
+        with pytest.raises(OSError):
+            provider.fetch()
+        assert _ids(fetcher.calls) == ["1", "2"]
+        # Cycle 2: the round-robin must ADVANCE to the never-attempted
+        # targets instead of re-burning the budget on the failers.
+        clock["t"] += 1
+        items = provider.fetch()
+        assert _ids(fetcher.calls) == ["1", "2", "3", "4"]
+        assert len(items) == 2  # both good players now cached
+        # Cycle 3: everyone has had a slot; the failers (oldest
+        # attempt) are retried now — good targets stay fresh-cached.
+        clock["t"] += 1
+        provider.fetch()
+        assert _ids(fetcher.calls) == ["1", "2", "3", "4", "1", "2"]
 
     def test_supplier_failure_degrades_to_empty(self):
         provider = EspnPlayerNewsProvider(

--- a/tests/news/test_espn_player_provider.py
+++ b/tests/news/test_espn_player_provider.py
@@ -1,0 +1,222 @@
+"""Tests for the per-player ESPN news provider.
+
+All HTTP is mocked — the fetcher is injected and returns fixture
+JSON in the shape of ESPN's
+``/apis/fantasy/v2/games/ffl/news/players?playerId=`` endpoint
+(probed 2026-07-26; see the provider docstring).
+
+Pinned behavior:
+
+* feed parsing → NewsItem with PRE-STAMPED mention identity
+* per-player TTL cache (no refetch within the TTL)
+* the per-fetch request budget (politeness cap)
+* stale-serving + per-player failure isolation
+* total-failure raise for the service's outage detection
+* registry presence + default enablement
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.news.providers import available_provider_names, build_provider
+from src.news.providers.espn_player import EspnPlayerNewsProvider
+from src.news.service import _DEFAULT_ENABLED
+
+
+def _feed_payload(*entries):
+    return json.dumps({"feed": list(entries)}).encode("utf-8")
+
+
+def _entry(id_, headline, *, story="", published=None, web_url=None):
+    published = published or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    links = {"web": {"href": web_url}} if web_url else {"mobile": {"href": "http://m.espn/x"}}
+    return {
+        "id": id_,
+        "headline": headline,
+        "story": story,
+        "published": published,
+        "links": links,
+        "type": "Rotowire",
+    }
+
+
+TARGETS = [
+    {"name": "Bijan Robinson", "espnId": "4430807", "position": "RB", "team": "ATL"},
+    {"name": "Micah Parsons", "espnId": "4361423", "position": "LB", "team": "DAL"},
+]
+
+
+class _RecordingFetcher:
+    """Returns per-espn-id fixture payloads and records every URL."""
+
+    def __init__(self, payloads_by_id, errors_by_id=None):
+        self.payloads = dict(payloads_by_id)
+        self.errors = dict(errors_by_id or {})
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> bytes:
+        self.calls.append(url)
+        for espn_id, err in self.errors.items():
+            if f"playerId={espn_id}" in url:
+                raise err
+        for espn_id, payload in self.payloads.items():
+            if f"playerId={espn_id}" in url:
+                return payload
+        raise AssertionError(f"unexpected url: {url}")
+
+
+def _provider(fetcher, *, targets=None, clock=None, **kwargs):
+    return EspnPlayerNewsProvider(
+        targets_supplier=lambda: list(targets if targets is not None else TARGETS),
+        fetcher=fetcher,
+        clock=clock or (lambda: 0.0),
+        **kwargs,
+    )
+
+
+class TestParse:
+    def test_items_carry_prestamped_identity(self):
+        fetcher = _RecordingFetcher(
+            {
+                "4430807": _feed_payload(
+                    _entry(
+                        "1",
+                        "Robinson practices fully",
+                        story="Good sign.",
+                        web_url="https://espn.com/a",
+                    )
+                ),
+                "4361423": _feed_payload(_entry("2", "Parsons contract talks")),
+            }
+        )
+        items = _provider(fetcher).fetch()
+        assert len(items) == 2
+        by_headline = {it.headline: it for it in items}
+        bijan = by_headline["Robinson practices fully"]
+        m = bijan.players[0]
+        assert (m.name, m.position, m.team) == ("Bijan Robinson", "RB", "ATL")
+        assert m.ambiguous is False
+        assert bijan.url == "https://espn.com/a"
+        assert bijan.body == "Good sign."
+        assert bijan.provider == "espn_player"
+        assert bijan.ts.endswith("+00:00")
+
+    def test_stable_ids_and_kind_tags(self):
+        fetcher = _RecordingFetcher({"4430807": _feed_payload(_entry("9", "Note"))})
+        target = [TARGETS[0]]
+        first = _provider(fetcher, targets=target).fetch()
+        second = _provider(
+            _RecordingFetcher({"4430807": _feed_payload(_entry("9", "Note"))}),
+            targets=target,
+        ).fetch()
+        assert first[0].id == second[0].id
+        assert first[0].id.startswith("espn_player-")
+        assert "player" in first[0].tags
+
+    def test_no_targets_no_requests(self):
+        fetcher = _RecordingFetcher({})
+        assert _provider(fetcher, targets=[]).fetch() == []
+        assert fetcher.calls == []
+
+
+class TestCacheAndPoliteness:
+    def test_player_ttl_prevents_refetch(self):
+        clock = {"t": 0.0}
+        fetcher = _RecordingFetcher(
+            {
+                "4430807": _feed_payload(_entry("1", "A")),
+                "4361423": _feed_payload(_entry("2", "B")),
+            }
+        )
+        provider = _provider(fetcher, clock=lambda: clock["t"], player_ttl_s=1800)
+        provider.fetch()
+        assert len(fetcher.calls) == 2
+        # Within the TTL: served entirely from the player cache.
+        clock["t"] += 600
+        items = provider.fetch()
+        assert len(fetcher.calls) == 2
+        assert len(items) == 2
+        # Past the TTL: refreshes again.
+        clock["t"] += 1800
+        provider.fetch()
+        assert len(fetcher.calls) == 4
+
+    def test_request_budget_caps_fanout_per_fetch(self):
+        many_targets = [
+            {"name": f"Player {i}", "espnId": str(1000 + i), "position": "WR", "team": "ATL"}
+            for i in range(20)
+        ]
+        payloads = {str(1000 + i): _feed_payload(_entry(str(i), f"Note {i}")) for i in range(20)}
+        fetcher = _RecordingFetcher(payloads)
+        provider = _provider(fetcher, targets=many_targets, max_requests_per_fetch=5)
+        provider.fetch()
+        assert len(fetcher.calls) == 5
+        # The next cycle picks up the never-fetched players first.
+        provider.fetch()
+        assert len(fetcher.calls) == 10
+        assert len(set(fetcher.calls)) == 10  # no repeats while others wait
+
+    def test_failure_keeps_stale_entry_and_other_players(self):
+        clock = {"t": 0.0}
+        good = _feed_payload(_entry("1", "Fresh note"))
+        fetcher = _RecordingFetcher({"4430807": good, "4361423": good})
+        provider = _provider(fetcher, clock=lambda: clock["t"], player_ttl_s=100)
+        first = provider.fetch()
+        assert len(first) == 2
+        # Bijan's refresh now fails; his cached items keep serving.
+        clock["t"] += 200
+        failing = _RecordingFetcher({"4361423": good}, errors_by_id={"4430807": OSError("down")})
+        provider._fetcher = failing
+        items = provider.fetch()
+        assert len(items) == 2  # stale Bijan entry + fresh Parsons
+
+    def test_total_failure_with_empty_cache_raises(self):
+        fetcher = _RecordingFetcher(
+            {}, errors_by_id={"4430807": OSError("x"), "4361423": OSError("y")}
+        )
+        provider = _provider(fetcher)
+        with pytest.raises(OSError):
+            provider.fetch()
+
+    def test_supplier_failure_degrades_to_empty(self):
+        provider = EspnPlayerNewsProvider(
+            targets_supplier=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+            fetcher=_RecordingFetcher({}),
+        )
+        assert provider.fetch() == []
+
+
+class TestRegistration:
+    def test_registered_and_buildable(self):
+        assert "espn_player" in available_provider_names()
+        provider = build_provider("espn_player")
+        assert provider.name == "espn_player"
+        # Bare construction (no supplier) is inert, not broken.
+        assert provider.fetch() == []
+
+    def test_enabled_by_default(self):
+        assert "espn_player" in _DEFAULT_ENABLED
+
+
+def test_old_entries_survive_provider_but_die_at_service():
+    """The provider doesn't own the freshness policy — the service's
+    7-day cutoff does.  An old ESPN note flows out of the provider
+    and is dropped at aggregation."""
+    from src.news.service import NewsService
+
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fetcher = _RecordingFetcher(
+        {
+            "4430807": _feed_payload(
+                _entry("old", "Ancient note", published=old),
+            )
+        }
+    )
+    provider = _provider(fetcher, targets=[TARGETS[0]])
+    assert len(provider.fetch()) == 1
+    svc = NewsService([provider], cache_ttl_s=0)
+    assert svc.aggregate().items == []

--- a/tests/news/test_pfk_provider.py
+++ b/tests/news/test_pfk_provider.py
@@ -17,13 +17,22 @@ No HTTP happens anywhere below — the fetcher is always injected.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from src.news.providers import available_provider_names, build_provider
 from src.news.providers.pfk import PfkArticlesProvider, _humanize_slug
 from src.news.service import _DEFAULT_ENABLED, NewsService
 
-SITEMAP_FIXTURE = b"""<?xml version="1.0" encoding="UTF-8"?>
+# Fixture dates are generated relative to real now: service-level
+# tests route through the aggregation layer's 7-day freshness cutoff,
+# so static dates would silently age the fixture out of every
+# assertion within a week of writing it.
+_TODAY = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+_FIVE_DAYS_AGO = (datetime.now(timezone.utc) - timedelta(days=5)).strftime("%Y-%m-%d")
+
+SITEMAP_FIXTURE = f"""<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://playforkeepsdynasty.com/</loc>
@@ -36,22 +45,22 @@ SITEMAP_FIXTURE = b"""<?xml version="1.0" encoding="UTF-8"?>
   </url>
   <url>
     <loc>https://playforkeepsdynasty.com/article/signal-or-noise-carnell-tate</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>{_TODAY}</lastmod>
     <changefreq>monthly</changefreq>
   </url>
   <url>
     <loc>https://playforkeepsdynasty.com/article/bi-weekly-brew-new-orleans-saints-edition</loc>
-    <lastmod>2026-07-20</lastmod>
+    <lastmod>{_FIVE_DAYS_AGO}</lastmod>
   </url>
   <url>
     <loc>https://playforkeepsdynasty.com/article/undated-legacy-piece</loc>
   </url>
   <url>
     <loc>https://playforkeepsdynasty.com/trade-finder</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>{_TODAY}</lastmod>
   </url>
 </urlset>
-"""
+""".encode("utf-8")
 
 
 def _provider(**kwargs) -> PfkArticlesProvider:
@@ -81,8 +90,8 @@ class TestParse:
 
     def test_lastmod_becomes_iso_utc_ts_newest_first(self):
         items = _provider().fetch()
-        assert items[0].ts.startswith("2026-07-25")
-        assert items[1].ts.startswith("2026-07-20")
+        assert items[0].ts.startswith(_TODAY)
+        assert items[1].ts.startswith(_FIVE_DAYS_AGO)
         assert items[0].ts.endswith("+00:00")
         # Undated entries sink to the bottom instead of posing as fresh.
         assert items[-1].headline == "Undated Legacy Piece"
@@ -139,12 +148,18 @@ class TestParse:
 
 
 def _single_slug_sitemap(slug: str) -> bytes:
+    # lastmod is stamped as TODAY so the service-level tests below
+    # survive the aggregation layer's 7-day freshness cutoff no
+    # matter when they run.
+    from datetime import datetime, timezone
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d").encode("utf-8")
     return (
         b'<?xml version="1.0" encoding="UTF-8"?>\n'
         b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
         b"  <url>\n"
         b"    <loc>https://playforkeepsdynasty.com/article/" + slug.encode("utf-8") + b"</loc>\n"
-        b"    <lastmod>2026-07-25</lastmod>\n"
+        b"    <lastmod>" + today + b"</lastmod>\n"
         b"  </url>\n"
         b"</urlset>\n"
     )
@@ -249,8 +264,15 @@ class TestFailureIsolation:
         healthy = _provider()
         svc = NewsService([failing, healthy], cache_ttl_s=0)
         result = svc.aggregate()
-        # The healthy provider's items survive; PFK contributes zero.
-        assert len(result.items) == 3
+        # The healthy provider's DATED items survive; PFK's failing
+        # instance contributes zero.  The static fixture's third
+        # (undated) entry is stamped epoch by the provider and falls
+        # to the service's 7-day freshness cutoff — deliberately:
+        # an article that can't prove its age doesn't ship.
+        assert {i.headline for i in result.items} == {
+            "Signal Or Noise Carnell Tate",
+            "Bi Weekly Brew New Orleans Saints Edition",
+        }
         runs = {r.name: r for r in result.provider_runs}
         # Both instances share name "pfk"; the failing one ran first
         # so assert via the run list directly.

--- a/tests/news/test_service.py
+++ b/tests/news/test_service.py
@@ -40,7 +40,21 @@ class _StaticProvider(NewsProvider):
         return self._items
 
 
-def _item(id_, provider="static", severity="info", ts="2026-04-23T10:00:00+00:00", players=None):
+def _now_iso(hours_ago: float = 0.0) -> str:
+    """Recent ISO timestamp relative to real now.
+
+    The service applies a hard 7-day freshness cutoff at aggregation
+    (``MAX_ITEM_AGE_DAYS``), so fixture items must be freshly dated
+    or every real-clock test silently loses its items.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+
+
+def _item(id_, provider="static", severity="info", ts=None, players=None):
+    if ts is None:
+        ts = _now_iso()
     return NewsItem(
         id=id_,
         ts=ts,
@@ -116,6 +130,61 @@ def test_team_name_filter_drops_non_matching_items():
     assert [i.id for i in out.items] == ["a-1"]
 
 
+def test_seven_day_cutoff_drops_old_items():
+    """Hard freshness requirement: every item older than 7 days is
+    dropped at aggregation so all surfaces inherit the cutoff."""
+    provider = _StaticProvider(
+        items=[
+            _item("fresh", ts=_now_iso(hours_ago=2)),
+            _item("six-days", ts=_now_iso(hours_ago=6 * 24)),
+            _item("eight-days", ts=_now_iso(hours_ago=8 * 24)),
+            _item("ancient", ts="1970-01-01T00:00:00+00:00"),
+        ]
+    )
+    svc = NewsService([provider], cache_ttl_s=0)
+    out = svc.aggregate()
+    ids = {i.id for i in out.items}
+    assert ids == {"fresh", "six-days"}
+
+
+def test_seven_day_cutoff_drops_unparseable_timestamps():
+    """An item that can't prove freshness doesn't ship."""
+    provider = _StaticProvider(
+        items=[
+            _item("good", ts=_now_iso()),
+            _item("bad-ts", ts="not-a-date"),
+        ]
+    )
+    svc = NewsService([provider], cache_ttl_s=0)
+    out = svc.aggregate()
+    assert [i.id for i in out.items] == ["good"]
+
+
+def test_payload_carries_player_digests():
+    """to_dict computes per-player digests from the (already
+    cutoff-filtered) item list so every consumer inherits both."""
+    provider = _StaticProvider(
+        items=[
+            _item(
+                "d-1",
+                ts=_now_iso(hours_ago=1),
+                players=[PlayerMention(name="Bijan Robinson", position="RB", team="ATL")],
+            ),
+            _item(
+                "d-2",
+                ts=_now_iso(hours_ago=2),
+                players=[PlayerMention(name="Bijan Robinson", position="RB", team="ATL")],
+            ),
+        ]
+    )
+    svc = NewsService([provider], cache_ttl_s=0)
+    payload = svc.aggregate().to_dict()
+    digests = payload["playerDigests"]
+    assert len(digests) == 1
+    assert digests[0]["player"] == "Bijan Robinson"
+    assert digests[0]["storyCount"] == 2
+
+
 def test_dedup_by_id_across_providers():
     a = _StaticProvider(
         items=[_item("shared-1"), _item("only-a")],
@@ -135,9 +204,9 @@ def test_dedup_by_id_across_providers():
 def test_sort_alerts_float_above_info():
     provider = _StaticProvider(
         items=[
-            _item("a-info", severity="info", ts="2026-04-23T12:00:00+00:00"),
-            _item("b-alert", severity="alert", ts="2026-04-23T09:00:00+00:00"),
-            _item("c-watch", severity="watch", ts="2026-04-23T10:00:00+00:00"),
+            _item("a-info", severity="info", ts=_now_iso(hours_ago=1)),
+            _item("b-alert", severity="alert", ts=_now_iso(hours_ago=4)),
+            _item("c-watch", severity="watch", ts=_now_iso(hours_ago=3)),
         ]
     )
     svc = NewsService([provider], cache_ttl_s=0)


### PR DESCRIPTION
## Summary

Phase 6b builds on the merged Phase 6 news system (providers → service → useNews): every rostered/top-board player now gets a shot at real, player-scoped news; nothing older than a week ever ships; and players with multiple stories get one combined digest entry with a clean seam for LLM synthesis later.

### 1. Per-player ESPN news (`src/news/providers/espn_player.py`)
- **Endpoint probe**: `site.api.espn.com/.../news?playerId=` silently ignores the param and returns the league-wide feed. The genuinely player-scoped endpoint is `site.web.api.espn.com/apis/fantasy/v2/games/ffl/news/players?playerId={espn_id}` (Rotowire-style notes: `headline`, `story`, `published`, `links`). Verified live with a real athlete id.
- **Identity**: targets come from a supplier injected at service build — `server.py::_live_espn_news_targets` walks the live contract's `playersArray` in consensus-rank order (top 150) and joins each row's Sleeper `playerId` through the contract's Sleeper directory (`sleeper.players`, the `/v1/players/nfl` shape carrying `espn_id`). Emitted mentions are **pre-stamped** with the target's position/team — the espn_id join is the strongest identity signal in the pipeline, so the enrichment layer has nothing to guess and the Phase 6 collision guards get authoritative data.
- **Politeness**: the provider keeps its own per-player TTL cache (30 min) and refreshes at most **8 ids per aggregate cycle** (the service calls `fetch` once per 180s TTL-cached refresh). 150 targets trickle-refresh roughly hourly; stale entries keep serving until their slot comes up. **No per-request fan-out on page load, ever.** Per-player failures are isolated (stale entry retained); a total failure with an empty cache raises so the service's outage detection works.

### 2. 7-day hard cutoff (`src/news/service.py`)
- `_drop_stale_items` runs **at aggregation** (before dedupe/cache), so every surface — news tab, popups, chips, activity, terminal — inherits it. `MAX_ITEM_AGE_DAYS = 7`.
- Items with unparseable timestamps are dropped: an item that can't prove it's under a week old doesn't ship. (This deliberately drops PFK's undated legacy sitemap entries — noted in the test.)
- Cutoff uses the injectable service clock, so fake-clock tests stay deterministic; service-path test fixtures now generate timestamps relative to now so they can't silently age out of their own assertions.

### 3. Per-player digest (`src/news/digest.py`)
- `build_player_digests` groups aggregated items by **(normalized name, position family)** — the documented CJ Allen collision twins never merge, and `ambiguous`-flagged mentions are excluded entirely. Stories are deduped by normalized headline, ordered newest-first, and a digest only exists at **2+ distinct stories**. Each entry carries `player/position/team`, `storyCount`, `latestTs`, max `severity`, ordered unique `sources`, `headline`, `summary`, `itemIds`. Emitted as `playerDigests` on the aggregate payload (computed from the already-cutoff-filtered items).
- **⚙️ LLM synthesis seam**: `synthesize_player_digest(player_name, stories)` is the single, documented place digest text is produced. Today it's a mechanical combine — one attributed line per story (`- headline (source, date)`, capped at 6 with a "+N more" trailer). When an `ANTHROPIC_API_KEY` is provisioned, a model call replaces **only that function's body**; callers, payload shape, and structural tests need no changes. Blocked today: the key has not been provided.

### 4. Surfaces
- **PlayerPopup**: the news section renders the player's digest card (headline + attributed summary + source list) above the raw item list — raw items stay accessible.
- **/news tab**: new **Stories | By player** view toggle. "By player" renders one digest card per player through the same scope/team/position/source/search facet vocabulary; "Stories" remains the raw chronological feed. Digest lookups go through `buildDigestIndex`/`lookupPlayerDigest` (collision twins resolved by position; ambiguous lookups return null rather than guessing).
- Fail-fast behavior unchanged: every failure path carries `digests: []` and the explicit unavailable state — no mock fallback anywhere.

## Tests (no live network in any test)
- `tests/news/test_espn_player_provider.py` — mocked-HTTP suite: feed parsing with pre-stamped mention identity, stable ids, per-player TTL (no refetch inside the window), the per-fetch request budget (politeness cap, no repeats while others wait), stale-serving through per-player failures, total-failure raise, supplier-failure degradation, registration + default enablement, and old-entries-die-at-the-service.
- `tests/news/test_digest.py` — two-story minimum, newest-first grouping with severity/source aggregation, same-story dedupe across providers, collision twins never merging, ambiguous exclusion, seam output capping.
- `tests/news/test_service.py` — cutoff drops 8-day-old and unparseable-ts items while keeping 6-day-old ones; payload carries `playerDigests`.
- Frontend vitest — digest block parsing (present/absent/failure), digest index resolution incl. collision twins and defensive input.
- Results: `tests/news/` + auth gate → **175 passed**; frontend → **994 passed** (40 files); `next build` clean; `ruff check`/`format` clean under the CI-pinned **ruff 0.6.9**.

## Notes for reviewers
- `server.py` changes are additive: `_live_espn_news_targets` + `_ESPN_NEWS_TARGET_LIMIT` and the `provider_config` wiring in `_get_news_service`.
- `sleeper.players` team data is sparse until the next scrape cycle (per the #532/#535 fix); targets stamp what's available and null otherwise — position is always present.
- The digest is computed in `AggregatedNews.to_dict()` from ≤100 items per call (micro-cost), so the route and terminal both inherit it with zero extra wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_