### PR TITLE
Phase 7.1: Pick Projector — projected rookie-draft slots for future picks

### DIFF
--- a/src/ros/api.py
+++ b/src/ros/api.py
@@ -147,6 +147,65 @@ async def get_team_strength(request: Request, leagueKey: str | None = None) -> J
     return JSONResponse({"teams": snapshot, "leagueKey": resolved_key})
 
 
+@router.get("/pick-projections")
+async def get_pick_projections(request: Request, leagueKey: str | None = None) -> JSONResponse:
+    """Projected rookie-draft slots for every owned FUTURE pick.
+
+    Pick Projector (Phase 7.1): reverse-standings draft order
+    projected from the ROS team-strength composite, joined against
+    the sleeper overlay's live pick ownership (``pickDetails``).
+    Projection/context only — blended pick values are untouched.
+
+    League resolution mirrors ``/team-strength``.  Degraded states
+    follow this router's convention (200 + ``error`` field):
+    ``no_snapshot`` when team strength hasn't been built for the
+    league, ``no_teams`` when the Sleeper overlay is unreachable.
+    """
+    resolved_key = leagueKey
+    sleeper_league_id: str | None = None
+    try:
+        from src.api.league_registry import get_league_by_key, default_league_key  # noqa: PLC0415
+
+        if leagueKey:
+            cfg = get_league_by_key(leagueKey)
+        else:
+            cfg = get_league_by_key(default_league_key())
+        if cfg and cfg.key:
+            resolved_key = cfg.key
+            sleeper_league_id = cfg.sleeper_league_id
+    except Exception:  # noqa: BLE001
+        pass
+
+    snapshot = load_team_strength_snapshot(resolved_key)
+    if not snapshot:
+        return JSONResponse(
+            {"picks": [], "projectedOrder": [], "leagueKey": resolved_key, "error": "no_snapshot"},
+        )
+
+    teams: list[dict] = []
+    if sleeper_league_id:
+        try:
+            from src.api.sleeper_overlay import fetch_sleeper_teams_overlay  # noqa: PLC0415
+
+            block = fetch_sleeper_teams_overlay(sleeper_league_id=sleeper_league_id)
+            if isinstance(block, dict):
+                teams = block.get("teams") or []
+            elif isinstance(block, list):
+                teams = block
+        except Exception:  # noqa: BLE001
+            teams = []
+    if not teams:
+        return JSONResponse(
+            {"picks": [], "projectedOrder": [], "leagueKey": resolved_key, "error": "no_teams"},
+        )
+
+    from src.ros.pick_projection import build_pick_projections  # noqa: PLC0415
+
+    payload = build_pick_projections(teams, snapshot)
+    payload["leagueKey"] = resolved_key
+    return JSONResponse(payload)
+
+
 @router.get("/health")
 async def get_health() -> JSONResponse:
     """Combined ROS pipeline health snapshot.

--- a/src/ros/pick_projection.py
+++ b/src/ros/pick_projection.py
@@ -1,0 +1,200 @@
+"""Pick Projector — future-pick → projected-draft-slot mapping.
+
+Dynasty rookie-draft order is reverse final standings: the weakest
+team picks 1.01.  This module projects that order for FUTURE seasons
+from the ROS team-strength composite (``teamRosStrength`` in
+``data/ros/team_strength/<league>.json``) and maps every owned future
+pick (the overlay's ``pickDetails``) onto its projected slot — the
+feature gap PFK's Pick Projector covers, built on our own playoff-sim
+inputs.
+
+Strictly a PROJECTION/CONTEXT layer: blended pick values (rookie-pool
+tethering + the multiplicative future-year discount in the live
+pipeline) are untouched.  Consumers render the projected slot next to
+a pick, they do not re-value it.
+
+League-scoped per CLAUDE.md: rosters/picks and team strength both
+follow ``leagueKey`` — never collapse across leagues.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+# Confidence bands for a projected slot, derived from how isolated a
+# team's strength score is from its immediate neighbors relative to
+# the league's average inter-team gap.  A team wedged in a cluster
+# can plausibly finish several slots away; a team far adrift of the
+# pack is locked into its neighborhood.
+_CONFIDENCE_HIGH_RATIO = 1.0
+_CONFIDENCE_MEDIUM_RATIO = 0.4
+
+
+def _to_float(v: Any) -> float | None:
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f else None  # NaN guard
+
+
+def project_draft_order(strength_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Project the rookie-draft order from team-strength rows.
+
+    Returns one row per team, sorted weakest-first (slot 1 = weakest
+    projected team), each carrying::
+
+        {rosterId, ownerId, teamName, teamRosStrength,
+         projectedSlot, confidence}
+
+    Teams missing a usable ``teamRosStrength`` are excluded (a slot
+    built on an unknown score would be noise, not signal); callers
+    can detect the shortfall by comparing lengths.  Ties break on
+    rosterId for determinism.
+    """
+    usable: list[tuple[float, int, dict[str, Any]]] = []
+    for row in strength_rows or []:
+        if not isinstance(row, dict):
+            continue
+        strength = _to_float(row.get("teamRosStrength"))
+        if strength is None:
+            continue
+        try:
+            rid = int(row.get("rosterId") or 0)
+        except (TypeError, ValueError):
+            rid = 0
+        usable.append((strength, rid, row))
+    usable.sort(key=lambda t: (t[0], t[1]))
+
+    strengths = [s for s, _rid, _row in usable]
+    n = len(strengths)
+    # Average inter-team gap — the yardstick for slot confidence.
+    avg_gap = (
+        (strengths[-1] - strengths[0]) / (n - 1) if n >= 2 and strengths[-1] > strengths[0] else 0.0
+    )
+
+    order: list[dict[str, Any]] = []
+    for idx, (strength, rid, row) in enumerate(usable):
+        if avg_gap <= 0:
+            confidence = "low"
+        else:
+            gaps = []
+            if idx > 0:
+                gaps.append(strength - strengths[idx - 1])
+            if idx < n - 1:
+                gaps.append(strengths[idx + 1] - strength)
+            min_gap = min(gaps) if gaps else 0.0
+            ratio = min_gap / avg_gap
+            if ratio >= _CONFIDENCE_HIGH_RATIO:
+                confidence = "high"
+            elif ratio >= _CONFIDENCE_MEDIUM_RATIO:
+                confidence = "medium"
+            else:
+                confidence = "low"
+        order.append(
+            {
+                "rosterId": rid,
+                "ownerId": row.get("ownerId"),
+                "teamName": row.get("teamName"),
+                "teamRosStrength": strength,
+                "projectedSlot": idx + 1,
+                "confidence": confidence,
+            }
+        )
+    return order
+
+
+def build_pick_projections(
+    teams: list[dict[str, Any]],
+    strength_rows: list[dict[str, Any]],
+    *,
+    current_season: int | None = None,
+) -> dict[str, Any]:
+    """Project every owned FUTURE pick onto a draft slot.
+
+    ``teams`` is the sleeper overlay's teams block (each carrying
+    ``pickDetails`` — {season, round, original_roster_id,
+    owner_roster_id, label}); ``strength_rows`` is the ROS
+    team-strength snapshot.  Only seasons strictly AFTER
+    ``current_season`` are projected — the current season's rookie
+    draft order is actual standings, not a projection.
+
+    Returns::
+
+        {projectedOrder: [...], picks: [...], meta: {...}}
+
+    where each pick row is::
+
+        {season, round, projectedSlot, projectedPickNumber, label,
+         confidence, ownerRosterId, ownerTeam,
+         originalRosterId, originalTeam}
+    """
+    if current_season is None:
+        current_season = datetime.now(timezone.utc).year
+
+    order = project_draft_order(strength_rows)
+    slot_by_rid = {row["rosterId"]: row for row in order}
+    team_count = len(order)
+
+    name_by_rid: dict[int, str] = {}
+    for t in teams or []:
+        if not isinstance(t, dict):
+            continue
+        try:
+            rid = int(t.get("roster_id") or 0)
+        except (TypeError, ValueError):
+            continue
+        if rid:
+            name_by_rid[rid] = str(t.get("name") or f"Team {rid}")
+
+    picks: list[dict[str, Any]] = []
+    unprojectable = 0
+    for t in teams or []:
+        if not isinstance(t, dict):
+            continue
+        for pd in t.get("pickDetails") or []:
+            if not isinstance(pd, dict):
+                continue
+            try:
+                season = int(str(pd.get("season") or 0))
+                rnd = int(pd.get("round") or 0)
+                original = int(pd.get("original_roster_id") or 0)
+                owner = int(pd.get("owner_roster_id") or 0)
+            except (TypeError, ValueError):
+                continue
+            if season <= current_season or rnd < 1 or not original or not owner:
+                continue
+            # The pick's slot follows the ORIGINAL team's projected
+            # finish — that team's record sets where the pick lands.
+            slot_row = slot_by_rid.get(original)
+            if slot_row is None:
+                unprojectable += 1
+                continue
+            slot = slot_row["projectedSlot"]
+            picks.append(
+                {
+                    "season": season,
+                    "round": rnd,
+                    "projectedSlot": slot,
+                    "projectedPickNumber": (rnd - 1) * team_count + slot,
+                    "label": f"{season} {rnd}.{slot:02d}",
+                    "confidence": slot_row["confidence"],
+                    "ownerRosterId": owner,
+                    "ownerTeam": name_by_rid.get(owner),
+                    "originalRosterId": original,
+                    "originalTeam": name_by_rid.get(original),
+                }
+            )
+
+    picks.sort(key=lambda p: (p["season"], p["round"], p["projectedSlot"]))
+    return {
+        "projectedOrder": order,
+        "picks": picks,
+        "meta": {
+            "source": "teamRosStrength",
+            "teamCount": team_count,
+            "currentSeason": current_season,
+            "unprojectablePicks": unprojectable,
+        },
+    }

--- a/tests/ros/test_pick_projection.py
+++ b/tests/ros/test_pick_projection.py
@@ -1,0 +1,201 @@
+"""Pick Projector (Phase 7.1) — projection math + endpoint tests.
+
+Covers: reverse-standings order from team strength, slot-confidence
+bands, the original-roster slot rule for traded picks, the
+current-season exclusion, and the /api/ros/pick-projections endpoint's
+degraded states.  No live network anywhere.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import src.ros.api as ros_api
+from src.ros.pick_projection import build_pick_projections, project_draft_order
+
+
+def strength_row(rid: int, strength: float, name: str | None = None) -> dict:
+    return {
+        "rosterId": rid,
+        "ownerId": f"owner{rid}",
+        "teamName": name or f"Team {rid}",
+        "teamRosStrength": strength,
+    }
+
+
+def team(rid: int, name: str, pick_details: list[dict]) -> dict:
+    return {
+        "name": name,
+        "ownerId": f"owner{rid}",
+        "roster_id": rid,
+        "players": [],
+        "playerIds": [],
+        "picks": [p.get("label", "") for p in pick_details if isinstance(p, dict)],
+        "pickDetails": pick_details,
+    }
+
+
+def pick(season: int, rnd: int, original: int, owner: int) -> dict:
+    return {
+        "season": str(season),
+        "round": rnd,
+        "slot": None,
+        "original_roster_id": original,
+        "owner_roster_id": owner,
+        "label": f"{season} Round {rnd}",
+    }
+
+
+class TestProjectDraftOrder:
+    def test_weakest_team_picks_first(self):
+        rows = [strength_row(1, 900.0), strength_row(2, 400.0), strength_row(3, 650.0)]
+        order = project_draft_order(rows)
+        assert [r["rosterId"] for r in order] == [2, 3, 1]
+        assert [r["projectedSlot"] for r in order] == [1, 2, 3]
+
+    def test_ties_break_on_roster_id_for_determinism(self):
+        rows = [strength_row(9, 500.0), strength_row(3, 500.0)]
+        order = project_draft_order(rows)
+        assert [r["rosterId"] for r in order] == [3, 9]
+
+    def test_rows_without_strength_are_excluded(self):
+        rows = [strength_row(1, 500.0), {"rosterId": 2, "teamRosStrength": None}, {"junk": True}]
+        order = project_draft_order(rows)
+        assert len(order) == 1
+        assert order[0]["rosterId"] == 1
+
+    def test_confidence_bands_track_neighbor_gaps(self):
+        # 100, 105 clustered; 400 far adrift.  avg gap = 150.
+        rows = [strength_row(1, 100.0), strength_row(2, 105.0), strength_row(3, 400.0)]
+        order = project_draft_order(rows)
+        by_rid = {r["rosterId"]: r for r in order}
+        # Clustered pair: min gap 5 / 150 → low.
+        assert by_rid[1]["confidence"] == "low"
+        assert by_rid[2]["confidence"] == "low"
+        # Isolated team: min gap 295 / 150 → high.
+        assert by_rid[3]["confidence"] == "high"
+
+    def test_degenerate_league_is_low_confidence(self):
+        rows = [strength_row(1, 500.0), strength_row(2, 500.0)]
+        assert all(r["confidence"] == "low" for r in project_draft_order(rows))
+
+    def test_empty_input(self):
+        assert project_draft_order([]) == []
+
+
+class TestBuildPickProjections:
+    def _fixture(self):
+        strength = [
+            strength_row(1, 300.0, "Rebuilders"),  # slot 1
+            strength_row(2, 600.0, "Middlers"),  # slot 2
+            strength_row(3, 900.0, "Champs"),  # slot 3
+        ]
+        teams = [
+            team(1, "Rebuilders", [pick(2027, 1, 1, 1), pick(2026, 1, 1, 1)]),
+            # Champs traded their 2027 1st to Middlers.
+            team(2, "Middlers", [pick(2027, 1, 3, 2)]),
+            team(3, "Champs", [pick(2027, 2, 3, 3)]),
+        ]
+        return teams, strength
+
+    def test_current_season_picks_are_excluded(self):
+        teams, strength = self._fixture()
+        out = build_pick_projections(teams, strength, current_season=2026)
+        assert all(p["season"] > 2026 for p in out["picks"])
+
+    def test_slot_follows_the_original_roster(self):
+        teams, strength = self._fixture()
+        out = build_pick_projections(teams, strength, current_season=2026)
+        traded = next(p for p in out["picks"] if p["ownerRosterId"] == 2)
+        # Champs (slot 3) traded the pick — it projects at THEIR slot.
+        assert traded["originalRosterId"] == 3
+        assert traded["projectedSlot"] == 3
+        assert traded["label"] == "2027 1.03"
+        assert traded["ownerTeam"] == "Middlers"
+        assert traded["originalTeam"] == "Champs"
+
+    def test_pick_number_math_spans_rounds(self):
+        teams, strength = self._fixture()
+        out = build_pick_projections(teams, strength, current_season=2026)
+        second_rounder = next(p for p in out["picks"] if p["round"] == 2)
+        # 3 teams: round 2 slot 3 → overall pick 6.
+        assert second_rounder["projectedPickNumber"] == 6
+
+    def test_unprojectable_original_is_counted_not_guessed(self):
+        teams = [team(1, "A", [pick(2027, 1, 99, 1)])]
+        strength = [strength_row(1, 300.0)]
+        out = build_pick_projections(teams, strength, current_season=2026)
+        assert out["picks"] == []
+        assert out["meta"]["unprojectablePicks"] == 1
+
+    def test_output_sorted_and_meta_stamped(self):
+        teams, strength = self._fixture()
+        out = build_pick_projections(teams, strength, current_season=2026)
+        keys = [(p["season"], p["round"], p["projectedSlot"]) for p in out["picks"]]
+        assert keys == sorted(keys)
+        assert out["meta"]["teamCount"] == 3
+        assert out["meta"]["source"] == "teamRosStrength"
+
+    def test_malformed_rows_are_skipped(self):
+        teams = [team(1, "A", [{"season": "notayear", "round": 1}, "junk", None])]
+        strength = [strength_row(1, 300.0)]
+        out = build_pick_projections(teams, strength, current_season=2026)
+        assert out["picks"] == []
+
+
+class TestPickProjectionsEndpoint:
+    def _client(self):
+        app = FastAPI()
+        app.include_router(ros_api.router)
+        return TestClient(app)
+
+    def test_no_snapshot_degrades_explicitly(self, monkeypatch):
+        monkeypatch.setattr(ros_api, "load_team_strength_snapshot", lambda *a, **k: None)
+        res = self._client().get("/api/ros/pick-projections")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["error"] == "no_snapshot"
+        assert body["picks"] == []
+
+    def test_overlay_failure_degrades_explicitly(self, monkeypatch):
+        monkeypatch.setattr(
+            ros_api,
+            "load_team_strength_snapshot",
+            lambda *a, **k: [strength_row(1, 300.0)],
+        )
+        import src.api.sleeper_overlay as overlay
+
+        monkeypatch.setattr(overlay, "fetch_sleeper_teams_overlay", lambda **k: None)
+        res = self._client().get("/api/ros/pick-projections")
+        body = res.json()
+        assert body["error"] == "no_teams"
+        assert body["picks"] == []
+
+    def test_happy_path_projects_and_stamps_league(self, monkeypatch):
+        from types import SimpleNamespace
+
+        strength = [strength_row(1, 300.0, "Rebuilders"), strength_row(2, 900.0, "Champs")]
+        teams = [
+            team(1, "Rebuilders", [pick(2027, 1, 1, 1)]),
+            team(2, "Champs", [pick(2027, 1, 2, 2)]),
+        ]
+        monkeypatch.setattr(ros_api, "load_team_strength_snapshot", lambda *a, **k: strength)
+        # The endpoint resolves the league lazily through the registry;
+        # pin a fake league so the test doesn't depend on the sandbox's
+        # registry file carrying a Sleeper id.
+        import src.api.league_registry as registry
+
+        fake_cfg = SimpleNamespace(key="test_league", sleeper_league_id="123456")
+        monkeypatch.setattr(registry, "get_league_by_key", lambda *a, **k: fake_cfg)
+        monkeypatch.setattr(registry, "default_league_key", lambda: "test_league")
+        import src.api.sleeper_overlay as overlay
+
+        monkeypatch.setattr(overlay, "fetch_sleeper_teams_overlay", lambda **k: {"teams": teams})
+        res = self._client().get("/api/ros/pick-projections")
+        body = res.json()
+        assert "error" not in body
+        assert body["leagueKey"]
+        assert len(body["picks"]) == 2
+        slots = {p["originalRosterId"]: p["projectedSlot"] for p in body["picks"]}
+        assert slots == {1: 1, 2: 2}


### PR DESCRIPTION
## What this is

Phase 7.1 of the competitor-parity roadmap — the PFK "Pick Projector" equivalent, built on our own ROS pipeline inputs (which give us better team-strength signal than PFK has).

Dynasty rookie-draft order is reverse standings: the weakest team picks 1.01. This maps every owned **future** pick to its projected slot:

- **Projected order** (`src/ros/pick_projection.py::project_draft_order`): the ROS team-strength composite (`teamRosStrength`) sorted weakest-first → slots 1..N. Ties break on rosterId for determinism; teams without a usable strength score are excluded rather than guessed.
- **Slot confidence**: each team's minimum strength gap to its neighbors, relative to the league's mean inter-team gap — clustered teams get "low" (toss-up), adrift teams "high".
- **Pick mapping** (`build_pick_projections`): the sleeper overlay's `pickDetails` joined against the projected order via the pick's **original** roster — a traded pick projects where the team that surrendered it finishes. Seasons ≤ the current one are excluded (that order is actual standings, not a projection). Rows whose original roster isn't in the order are counted (`meta.unprojectablePicks`), never guessed.
- **Endpoint**: `GET /api/ros/pick-projections?leagueKey=` — league resolution mirrors `/team-strength`; teams come through the #538 teams-only overlay fast path (~4 requests, no trade-history rebuild); degraded states follow this router's 200-plus-`error`-field convention (`no_snapshot` / `no_teams`).

**Strictly a projection/context layer.** Blended pick values (rookie-pool tethering + the future-year discount) are untouched — consumers render the projected slot next to a pick; nothing re-values it. UI surfacing lands with redesign R4's draft war room.

## Tests

15 new in `tests/ros/test_pick_projection.py`: weakest-first ordering, tie determinism, missing-strength exclusion, confidence bands (clustered vs adrift, degenerate all-equal league), current-season exclusion, traded-pick original-roster rule, cross-round pick-number math, unprojectable counting, malformed-row skipping, and all three endpoint states (no_snapshot / no_teams / happy path with a stubbed registry + overlay).

`tests/ros/` suite: **112 passed**. Ruff 0.6.9 format + check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_