### PR TITLE
Identity sweep: recover votes lost to name drift + matching audit tooling

### DIFF
--- a/.github/workflows/audit-identity-matches.yml
+++ b/.github/workflows/audit-identity-matches.yml
@@ -1,0 +1,184 @@
+name: Audit Identity Matches
+
+# Guards the CSV -> player-pool identity join against vendor name drift.
+#
+# Why this exists: ``scheduled-refresh.yml`` pushes freshly scraped
+# CSVs and a new export to ``main`` every two hours WITHOUT running
+# pytest, so the alias collision-delta invariant pinned in
+# ``tests/scripts/test_audit_identity_matches.py`` never gets evaluated
+# against the data that actually changed.  A vendor renaming a player
+# into an existing pool name would silently merge two players' votes
+# and nothing would catch it until someone ran the audit by hand —
+# historically "never" (same gap that motivated
+# ``audit-dropped-sources.yml``).
+#
+# This job runs the audit against the refreshed data and fails when the
+# collision-delta check finds anything.  It is deliberately a SEPARATE
+# workflow from the refresh: an advisory data finding must never block
+# the data refresh itself, so the refresh stays green and this job goes
+# red (plus a rolling issue) when the board needs a human.
+#
+# Exit codes (from ``scripts/audit_identity_matches.py``):
+#   0  - no alias-introduced collisions; workflow green
+#   1  - at least one collision (``--fail-on-collision``); workflow red
+#        with the offending names in the job summary
+#
+# Unmatched rows are reported but never fail the job — deep vendor
+# boards legitimately list players outside the Sleeper pool (retired
+# veterans, non-Sleeper prospects).  Only collisions are a hard defect.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # The refresh commits land here; run the check on the new data.
+      - "CSVs/site_raw/**"
+      - "exports/latest/dynasty_data_*.json"
+      # ...and whenever the join or the alias table itself changes.
+      - "src/utils/name_clean.py"
+      - "src/api/data_contract.py"
+      - "scripts/audit_identity_matches.py"
+  schedule:
+    # 08:17 UTC daily — backstop in case a refresh lands without
+    # touching the path filters above.
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: audit-identity-matches
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Audit CSV -> pool identity join
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          set -Eeuo pipefail
+          # Runtime manifest only — this job does not run the test
+          # suite.  No ``|| true``: a genuine install failure must
+          # surface as a red workflow, not a green-but-useless run.
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip check
+
+      - name: Locate latest snapshot
+        id: snapshot
+        run: |
+          set -Eeuo pipefail
+          SNAPSHOT=$(ls -t exports/latest/dynasty_data_*.json 2>/dev/null | head -1 || true)
+          if [ -z "$SNAPSHOT" ]; then
+            # A missing snapshot is itself the alert: the export
+            # pipeline has broken.  Returning 0 here would make
+            # "audit didn't run" look identical to "board is healthy".
+            echo "::error title=Missing snapshot::no dynasty_data_*.json in exports/latest/ — export pipeline may be broken"
+            exit 1
+          fi
+          echo "Using snapshot: $SNAPSHOT"
+          echo "path=$SNAPSHOT" >> "$GITHUB_OUTPUT"
+
+      - name: Run identity match audit (fails on alias collision)
+        run: |
+          set -Eeuo pipefail
+          python scripts/audit_identity_matches.py \
+            --json-path "${{ steps.snapshot.outputs.path }}" \
+            --json "${RUNNER_TEMP}/identity_audit.json" \
+            --limit 10 \
+            --github-summary \
+            --fail-on-collision
+
+      - name: Upload full report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: identity-audit-report
+          path: ${{ runner.temp }}/identity_audit.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Open / update rolling issue on collision
+        if: failure()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          REPORT="${RUNNER_TEMP}/identity_audit.json"
+          # jq, not inline python: an indented python -c heredoc inside a
+          # YAML block scalar is an IndentationError waiting to happen.
+          DETAIL="(no report produced — the job failed before the check ran)"
+          if [[ -f "$REPORT" ]]; then
+            DETAIL=$(jq -r '
+              (.aliasCollisions // [])
+              | if length == 0 then
+                  "(no collisions recorded — the job failed outside the check)"
+                else
+                  map("- " + (if .crossFamily then "**CROSS-FAMILY** " else "" end)
+                      + "`" + .canonicalName + "` merges: " + (.mergedNames | join(", ")))
+                  | join("\n")
+                end' "$REPORT" || echo "$DETAIL")
+          fi
+          # Body written flush-left on purpose: an indented heredoc would
+          # render the whole issue as a markdown code block.
+          BODY=$(cat <<EOF
+          The identity-match audit found an **alias-introduced collision** on the live board.
+
+          A collision means two DISTINCT player-pool rows now resolve to one canonical
+          name, so their source votes merge and both players' values are corrupted.
+          Cross-family collisions are worse: the name-only CSV join replicates a matched
+          entry across every position group sharing the name.
+
+          **Collisions:**
+
+          ${DETAIL}
+
+          - Workflow run: ${RUN_URL}
+          - Commit: \`${GITHUB_SHA}\`
+          - Detected: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          Likely causes:
+          1. A vendor renamed a player into a spelling that already exists in the pool
+             (most common — check the newest \`CSVs/site_raw\` diffs).
+          2. A newly added entry in \`CANONICAL_NAME_ALIASES\` (\`src/utils/name_clean.py\`)
+             merged two real players.
+          3. The Sleeper pool gained a second row for a player we alias.
+
+          Triage: run \`python scripts/audit_identity_matches.py\` locally; see
+          \`docs/identity-audit-2026-07.md\` for the verification standard (an alias is
+          only correct when position + team + age agree, or an explicit ID matches).
+          EOF
+          )
+          # Strip the YAML block-scalar indentation from every line so the
+          # issue body is valid markdown rather than one big code block.
+          BODY=$(printf '%s\n' "$BODY" | sed 's/^          //')
+          gh label create identity-collision \
+            --color B60205 \
+            --description "Auto-opened when the identity-match audit finds an alias collision" \
+            2>/dev/null || true
+          # Idempotent rolling issue: comment on the open one if it
+          # exists, else open a single labelled issue and reuse it.
+          EXISTING=$(gh issue list --state open --label identity-collision \
+                       --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [[ -n "$EXISTING" && "$EXISTING" != "null" ]]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create \
+              --title "Identity audit: alias-introduced collision on the live board" \
+              --body "$BODY" \
+              --label identity-collision
+          fi

--- a/docs/identity-audit-2026-07.md
+++ b/docs/identity-audit-2026-07.md
@@ -1,0 +1,166 @@
+# Identity Audit — July 2026
+
+Sweep of every source CSV in `_SOURCE_CSV_PATHS` for player votes lost
+to name drift between vendor spellings and the Sleeper player pool.
+Tooling: `scripts/audit_identity_matches.py` (new — replays the exact
+`_canonical_match_key` join the contract build performs and fuzzy-scores
+every unmatched row against the pool).  Payload audited:
+`exports/latest/dynasty_data_2026-07-26.json` (1,095 pool rows after
+far-future pick injection); numbers re-verified after the 2026-07-26
+data refreshes and the Phase 3-6 merges (search/filters, playerctx,
+news) — none of which changed the CSV → pool join this sweep fixes.
+
+## Per-source match rates
+
+Before → after adding the 18 alias entries below to
+`CANONICAL_NAME_ALIASES` (`src/utils/name_clean.py`).  "id" = rows
+recovered only by the sleeper_id join (pfkDynasty is the only CSV
+carrying ids the parser recognizes today).
+
+| Source | CSV rows | Matched before | Matched after | Recovered | Rate after |
+|---|---|---|---|---|---|
+| ktc | 500 | 497 | 499 | +2 | 99.8% |
+| ktcSfTep | 500 | 497 | 499 | +2 | 99.8% |
+| idpTradeCalc | 900 | 893 | 899 | +6 | 99.9% |
+| dlfIdp | 172 | 171 | 172 | +1 | 100% |
+| idpShow | 350 | 347 | 350 | +3 | 100% |
+| dlfSf | 281 | 278 | 280 | +2 | 99.6% |
+| dynastyNerdsSfTep | 295 | 289 | 290 | +1 | 98.3% |
+| fantasyProsSf | 345 | 340 | 342 | +2 | 99.1% |
+| fantasyProsIdp | 100 | 97 | 97 | 0 | 97.0% |
+| fantasyCalc | 399 | 391 | 392 | +1 | 98.2% |
+| otcffbSf | 462 | 460 | 460 | 0 | 99.6% |
+| dynastyDaddySf | 307 | 307 | 307 | 0 | 100% |
+| flockFantasySf | 440 | 415 | 416 | +1 | 94.5% |
+| flockFantasySfRookies | 62 | 62 | 62 | 0 | 100% |
+| yahooBoone | 410 | 380 | 380 | 0 | 92.7% |
+| fantasyProsFitzmaurice | 299 | 299 | 299 | 0 | 100% |
+| dlfRookieSf | 55 | 55 | 55 | 0 | 100% |
+| dlfRookieIdp | 29 | 29 | 29 | 0 | 100% |
+| draftSharks | 453 | 416 | 421 | +5 | 92.9% |
+| draftSharksIdp | 411 | 313 | 321 | +8 | 78.1% |
+| fantasyNavigatorSf | 758 | 457 | 457 | 0 | 60.3% |
+| pfkDynasty | 496 | 476 (+1 id) | 477 | id→name | 96.2% |
+
+Total: **34 rows recovered at the CSV join** (33 net-new; the
+pfkDynasty Gainwell row moved from the id-join fallback to the primary
+name join).
+
+## Contract-level impact (full `build_api_data_contract` rebuild)
+
+Verified by a full row-by-row diff of two complete contract builds
+(alias table off vs on) on the 2026-07-26 payload: **16 player rows
+gain 24 source votes; zero rows lose anything.**
+
+| Source | Before | After | Δ |
+|---|---|---|---|
+| dlfIdp | 171 | 172 | +1 |
+| idpShow | 346 | 349 | +3 |
+| dlfSf | 278 | 280 | +2 |
+| dynastyNerdsSfTep | 289 | 290 | +1 |
+| fantasyCalc | 391 | 392 | +1 |
+| fantasyProsSf | 340 | 342 | +2 |
+| flockFantasySf | 414 | 415 | +1 |
+| draftSharks | 409 | 414 | +5 |
+| draftSharksIdp | 293 | 301 | +8 |
+| **total** | | | **+24** |
+
+The remaining 10 audit-level recoveries (ktc ×2, ktcSfTep ×2,
+idpTradeCalc ×6) show no contract delta because the scraper's own
+dashboard payload already carried those values under the Sleeper
+spelling — for them the alias hardens the CSV *fallback* path (used
+when a scrape fails and the CSV persists) and fixes
+`sourceOriginalRanks` / `sourceNativeValues` / `sourceAudit` metadata
+stamping, which previously missed on the drifted names.
+
+Rows gained (source votes added by the aliases): Kenny Gainwell
+(dlfSf, dynastyNerdsSfTep, fantasyProsSf, flockFantasySf,
+draftSharks), Rob Henry (fantasyProsSf, draftSharks, fantasyCalc),
+Dru Phillips (idpShow, draftSharksIdp), Cam Bynum (idpShow,
+draftSharksIdp), Nnamdi Madubuike (dlfIdp), Nick Martin (idpShow),
+Joshua Palmer (dlfSf), Cam Skattebo, Cam Ward, Donoven McCulley
+(draftSharks), Nate Landman, Pat Surtain, Dax Hill,
+C.J. Gardner-Johnson, Mike Jackson, Sauce Gardner (draftSharksIdp).
+
+## Aliases added (all in `CANONICAL_NAME_ALIASES`, `src/utils/name_clean.py`)
+
+Verification rule: an alias was added only when position, age, and
+(where the CSV carries it) team agree between the vendor row and the
+pool row.  Ages below are pool vs DraftSharks CSV (the only source
+publishing age).
+
+| Vendor spelling (sources) | Pool spelling | Evidence |
+|---|---|---|
+| Kenneth Gainwell (ktc, ktcSfTep, idpTradeCalc, dlfSf, dynastyNerds, fantasyProsSf, flockFantasySf, draftSharks, pfkDynasty) | Kenny Gainwell | RB, TB, 27/27.3; pfkDynasty sleeper_id 7567 join already proved identity |
+| Gabriel Davis (ktc, ktcSfTep, idpTradeCalc) | Gabe Davis | WR, 27; KTC value 1074 consistent with the veteran WR |
+| Alim McNeil (idpTradeCalc) | Alim McNeill | DL, DET, 26/26.1 — vendor single-l typo; draftSharksIdp spells it McNeill |
+| Andru Phillips (idpTradeCalc, idpShow, draftSharksIdp) | Dru Phillips | CB, NYG, 24/24.5 |
+| Camryn Bynum (idpTradeCalc, idpShow, draftSharksIdp) | Cam Bynum | S, IND, 28/27.9 |
+| Nickolas Martin (idpTradeCalc, idpShow) | Nick Martin | LB, SF, age 23 rules out the retired IND center |
+| Josh Palmer (dlfSf) | Joshua Palmer | WR, BUF, 26 |
+| Cameron Skattebo (draftSharks) | Cam Skattebo | RB, NYG, 24/24.3 |
+| Cameron Ward (draftSharks) | Cam Ward | QB, TEN, 24/24.0 |
+| Nathan Landman (draftSharksIdp) | Nate Landman | LB, LAR, 27/27.6 |
+| Patrick Surtain II (draftSharksIdp) | Pat Surtain | CB, DEN, 26/26.2 |
+| Daxton Hill (draftSharksIdp) | Dax Hill | S, CIN, 25/25.7 |
+| Donaven McCulley (draftSharks) | Donoven McCulley | WR, MIA UDFA, 23/23.4 — vendor a/o vowel drift |
+| Chauncey Gardner-Johnson (draftSharksIdp) | C.J. Gardner-Johnson | DB, BUF, 28/28.5 — legal first name |
+| Michael Jackson (draftSharksIdp) | Mike Jackson | CB, CAR, 29/29.4 |
+| Ahmad Gardner (draftSharksIdp) | Sauce Gardner | CB, IND, 24/24.8 — legal first name |
+| Justin Madubuike (dlfIdp) | Nnamdi Madubuike | DL, BAL, 28/28.6 — player renamed 2024; DLF IDP still uses the old name |
+| Robert Henry Jr. (fantasyProsSf, draftSharks, fantasyCalc) | Rob Henry | RB, UTSA UDFA → WAS, 24/24.4 |
+
+Collision safety: `scripts/audit_identity_matches.py` computes an
+**alias collision-delta** on every run — a post-alias
+`canonical_player_key` that absorbs more than one pre-alias pool key
+would mean the table merged two real players.  Result with all 18
+entries: **0 collisions**.  The invariant is pinned by
+`tests/scripts/test_audit_identity_matches.py` (including a synthetic
+proof the detector fires when a merge IS present) and the per-alias
+collapses by `tests/utils/test_name_clean.py::TestIdentitySweepAliases`.
+
+## Normalizer changes
+
+None.  Every near-miss was nickname / legal-name / typo drift — the
+deterministic alias table is the right layer.  No case was found that
+`normalize_player_name` (suffix, punctuation, apostrophe, initials,
+diacritics handling) should have collapsed but didn't.
+
+## Remaining unmatched (categorized, after fix)
+
+* **Genuinely absent from the pool (the overwhelming majority).**
+  The pool is the live ~1,095-row board; deep vendor boards list
+  players Sleeper's scrape no longer carries: retired / free-agent
+  veterans (Russell Wilson, Amari Cooper, Odell Beckham, Taysom Hill,
+  Miles Sanders, Vita Vea, Grady Jarrett…), deep IDP veterans
+  (draftSharksIdp's remaining 90), and non-Sleeper prospects (Diego
+  Pavia, Seydou Traore).  fantasyNavigatorSf's 301 unmatched (60.3%
+  rate) are almost entirely this class — FN publishes ~800 rows
+  including long-retired players; every one of its 15 fuzzy
+  near-misses was verified to be a DIFFERENT player (e.g. Ian Thomas
+  vs Brian Thomas, Eric Gray vs Cedric Gray, Amari vs Omar Cooper).
+  No action possible or needed: no pool row exists to receive the vote.
+* **Confusable but distinct (verified NOT aliased).**  Mike Williams
+  (WR) vs Mykel Williams (DL), Austin Hooper (TE) vs Austin Booker
+  (DL), A.J. Terrell vs brother Avieon Terrell, Cam Hart (CB) vs Cam
+  Ward (QB), Jalon Daniels vs Jayden Daniels.  Left alone by design.
+* **Same player, no pool row either way**: Zonovan "Bam" Knight
+  (ktc/fantasyProsSf/yahooBoone say "Bam", fantasyCalc/flock say
+  "Zonovan") — neither spelling exists in the pool, so an alias would
+  recover nothing.  Revisit only if he re-enters the pool.
+
+## Recommendations
+
+1. **`dynastyNerdsSfTep.csv` carries a `SleeperId` column that is
+   silently ignored** — `_SLEEPER_ID_ALIASES` in
+   `src/api/data_contract.py` recognizes `sleeper_id` / `sleeperId` /
+   `sleeper_player_id` but not `SleeperId`.  Adding the spelling would
+   give Dynasty Nerds the same ID-grade drift immunity pfkDynasty has.
+   Not done in this sweep (out of the additive-alias mandate for that
+   file); one-token change for a follow-up.
+2. Vendors could be asked/patched at the fetcher level to emit
+   sleeper ids where their APIs expose them (fantasyNavigator rows
+   carry `ktc_player_id` today, unused).
+3. Re-run `python scripts/audit_identity_matches.py` after any scrape
+   schema change or monthly; unmatched `near_miss` rows ≥0.84
+   similarity are the triage queue.

--- a/docs/identity-audit-2026-07.md
+++ b/docs/identity-audit-2026-07.md
@@ -85,39 +85,109 @@ C.J. Gardner-Johnson, Mike Jackson, Sauce Gardner (draftSharksIdp).
 ## Aliases added (all in `CANONICAL_NAME_ALIASES`, `src/utils/name_clean.py`)
 
 Verification rule: an alias was added only when position, age, and
-(where the CSV carries it) team agree between the vendor row and the
-pool row.  Ages below are pool vs DraftSharks CSV (the only source
-publishing age).
+team agree between the vendor row and the pool row.  Age pairs below
+read *pool / DraftSharks* — DS is the only source publishing age, and
+its figures are decimal and re-derived on every refresh, so they drift
+~0.1 between snapshots (values here are the 2026-07-26 refresh).  Team
+is the pool's `team` field; the 2026-07-26 DS refresh ships an **empty
+Team column**, so DS-side team corroboration comes from the 2026-07-25
+snapshot when the column was still populated.
 
 | Vendor spelling (sources) | Pool spelling | Evidence |
 |---|---|---|
-| Kenneth Gainwell (ktc, ktcSfTep, idpTradeCalc, dlfSf, dynastyNerds, fantasyProsSf, flockFantasySf, draftSharks, pfkDynasty) | Kenny Gainwell | RB, TB, 27/27.3; pfkDynasty sleeper_id 7567 join already proved identity |
-| Gabriel Davis (ktc, ktcSfTep, idpTradeCalc) | Gabe Davis | WR, 27; KTC value 1074 consistent with the veteran WR |
-| Alim McNeil (idpTradeCalc) | Alim McNeill | DL, DET, 26/26.1 — vendor single-l typo; draftSharksIdp spells it McNeill |
-| Andru Phillips (idpTradeCalc, idpShow, draftSharksIdp) | Dru Phillips | CB, NYG, 24/24.5 |
-| Camryn Bynum (idpTradeCalc, idpShow, draftSharksIdp) | Cam Bynum | S, IND, 28/27.9 |
+| Kenneth Gainwell (ktc, ktcSfTep, idpTradeCalc, dlfSf, dynastyNerds, fantasyProsSf, flockFantasySf, draftSharks, pfkDynasty) | Kenny Gainwell | RB, TB, 27/27.3; pfkDynasty sleeper_id **7567** join already proved identity |
+| Gabriel Davis (ktc, ktcSfTep, idpTradeCalc) | Gabe Davis | WR, FA, 27; KTC value 1071 consistent with the veteran WR |
+| Alim McNeil (idpTradeCalc) | Alim McNeill | DL, DET, 26/26.2 — vendor single-l typo; draftSharksIdp spells it McNeill |
+| Andru Phillips (idpTradeCalc, idpShow, draftSharksIdp) | Dru Phillips | DB, NYG, 24/24.6 |
+| Camryn Bynum (idpTradeCalc, idpShow, draftSharksIdp) | Cam Bynum | DB, IND, 28/28.0 |
 | Nickolas Martin (idpTradeCalc, idpShow) | Nick Martin | LB, SF, age 23 rules out the retired IND center |
 | Josh Palmer (dlfSf) | Joshua Palmer | WR, BUF, 26 |
-| Cameron Skattebo (draftSharks) | Cam Skattebo | RB, NYG, 24/24.3 |
-| Cameron Ward (draftSharks) | Cam Ward | QB, TEN, 24/24.0 |
-| Nathan Landman (draftSharksIdp) | Nate Landman | LB, LAR, 27/27.6 |
-| Patrick Surtain II (draftSharksIdp) | Pat Surtain | CB, DEN, 26/26.2 |
-| Daxton Hill (draftSharksIdp) | Dax Hill | S, CIN, 25/25.7 |
-| Donaven McCulley (draftSharks) | Donoven McCulley | WR, MIA UDFA, 23/23.4 — vendor a/o vowel drift |
-| Chauncey Gardner-Johnson (draftSharksIdp) | C.J. Gardner-Johnson | DB, BUF, 28/28.5 — legal first name |
-| Michael Jackson (draftSharksIdp) | Mike Jackson | CB, CAR, 29/29.4 |
-| Ahmad Gardner (draftSharksIdp) | Sauce Gardner | CB, IND, 24/24.8 — legal first name |
-| Justin Madubuike (dlfIdp) | Nnamdi Madubuike | DL, BAL, 28/28.6 — player renamed 2024; DLF IDP still uses the old name |
-| Robert Henry Jr. (fantasyProsSf, draftSharks, fantasyCalc) | Rob Henry | RB, UTSA UDFA → WAS, 24/24.4 |
+| Cameron Skattebo (draftSharks) | Cam Skattebo | RB, NYG, 24/24.4 |
+| Cameron Ward (draftSharks) | Cam Ward | QB, TEN, 24/24.2 |
+| Nathan Landman (draftSharksIdp) | Nate Landman | LB, LAR, 27/27.7 |
+| Patrick Surtain II (draftSharksIdp) | Pat Surtain | CB, DEN, 26/26.3 |
+| Daxton Hill (draftSharksIdp) | Dax Hill | DB, CIN, 25/25.8 |
+| Donaven McCulley (draftSharks) | Donoven McCulley | WR, MIA UDFA, 23/23.5 — vendor a/o vowel drift |
+| Chauncey Gardner-Johnson (draftSharksIdp) | C.J. Gardner-Johnson | DB, BUF, 28/28.6 — legal first name |
+| Michael Jackson (draftSharksIdp) | Mike Jackson | CB, CAR, 29/29.5 |
+| Ahmad Gardner (draftSharksIdp) | Sauce Gardner | DB, IND, 24/24.8 — legal first name |
+| Justin Madubuike (dlfIdp) | Nnamdi Madubuike | DL, BAL, 28/28.7 — player renamed 2024; DLF IDP still uses the old name |
+| Robert Henry Jr. (fantasyProsSf, draftSharks, fantasyCalc) | Rob Henry | RB, UTSA UDFA → WAS, 24/24.5 |
 
-Collision safety: `scripts/audit_identity_matches.py` computes an
-**alias collision-delta** on every run — a post-alias
-`canonical_player_key` that absorbs more than one pre-alias pool key
-would mean the table merged two real players.  Result with all 18
-entries: **0 collisions**.  The invariant is pinned by
-`tests/scripts/test_audit_identity_matches.py` (including a synthetic
-proof the detector fires when a merge IS present) and the per-alias
-collapses by `tests/utils/test_name_clean.py::TestIdentitySweepAliases`.
+### Collision safety
+
+`scripts/audit_identity_matches.py` computes an **alias
+collision-delta** on every run: for each pool row it compares the
+pre-alias name (`normalize_player_name`) with the post-alias name
+(`resolve_canonical_name`), and reports any post-alias name that
+absorbs more than one distinct pre-alias name — i.e. an alias, not the
+normalizer, merged two real pool rows.  Result with all 18 entries:
+**0 collisions**, so no whitelist is needed.
+
+The check runs at **name granularity, not `name::position_group`
+granularity**, and that distinction is load-bearing.  The CSV join in
+`_enrich_from_source_csvs` keys `csv_lookup` by the name-only
+`_canonical_match_key`; when one canonical name maps to pool rows in
+several position groups it *replicates* the matched entry across all
+of them (the `len(row_groups) > 1` branch).  A group-keyed check is
+therefore blind to the worst case — an alias pulling two players of
+different position families onto one name (a hypothetical WR "Michael
+Jackson" absorbing CB Mike Jackson's draftSharksIdp vote).  An earlier
+revision of this function keyed on `canonical_player_key` and reported
+exactly that case clean; it now reports it as a collision with
+`crossFamily: true`.  Pre-existing same-name collisions that occur
+*without* any alias (e.g. "DJ Turner" WR vs "DJ Turner II" CB, merged
+by the suffix stripper) are deliberately excluded — this is a delta
+check, and that class is handled by the position-aware
+`canonical_player_key` used elsewhere.
+
+Pinned by `tests/scripts/test_audit_identity_matches.py` (same-family
+merge detected, cross-family merge detected, pre-existing collision
+correctly not attributed to the alias table, plus an end-to-end run
+against the committed CSVs) and per-alias by
+`tests/utils/test_name_clean.py::TestIdentitySweepAliases`.
+
+### Where the invariant runs
+
+`scheduled-refresh.yml` pushes new CSVs and exports to `main` every two
+hours without running pytest, so the invariant would never be
+evaluated against the data that actually changes.
+`.github/workflows/audit-identity-matches.yml` closes that gap: it runs
+this audit with `--fail-on-collision` on every push touching
+`CSVs/site_raw/**` or `exports/latest/dynasty_data_*.json` (plus a
+daily cron backstop), fails the job on any collision, and opens/updates
+a rolling `identity-collision` issue.  It is a **separate** workflow by
+design — an advisory data finding must never block the data refresh
+itself.  Unmatched rows never fail the job; only collisions do.
+
+### Blast radius beyond this audit
+
+The audit only measures the `_SOURCE_CSV_PATHS` → player-pool join, but
+`CANONICAL_NAME_ALIASES` is consumed more widely.  Other readers of the
+same table (via `resolve_canonical_name` / `canonical_player_key`):
+
+* `src/identity/matcher.py` — `_identity_canonical_key` builds master
+  `player::<canon>::<group>` identity records from it.
+* `src/ros/mapping.py` — rest-of-season projection name mapping.
+* `src/api/data_contract.py` — `_canonical_match_key` /
+  `_canonical_player_key`, used by enrichment joins beyond the CSV pass.
+
+An alias is therefore correct only if it is correct for *all* of these,
+not just for CSV match counts.  The collision-delta check is
+pool-level, so it protects the shared identity space rather than any
+one consumer — but a future alias should still be sanity-checked
+against the identity matcher if it touches a player with master-record
+history.
+
+### Gotcha for anyone re-verifying this work
+
+`src/api/data_contract._SOURCE_CSV_PARSE_CACHE` is keyed on
+`(csv path, mtime)` and caches a lookup whose keys are **already
+alias-resolved**.  An A/B contract build that mutates the alias table
+in-process between arms reuses the first arm's resolved keys and
+reports a false "0 delta".  Run each arm in a fresh interpreter (or
+clear the cache between arms).  The before/after numbers in this
+document were produced that way.
 
 ## Normalizer changes
 
@@ -161,6 +231,11 @@ diacritics handling) should have collapsed but didn't.
 2. Vendors could be asked/patched at the fetcher level to emit
    sleeper ids where their APIs expose them (fantasyNavigator rows
    carry `ktc_player_id` today, unused).
-3. Re-run `python scripts/audit_identity_matches.py` after any scrape
+3. **DraftSharks stopped emitting its `Team` column** in the
+   2026-07-26 refresh (header still declares `Team`, every value is
+   empty).  Nothing in the pipeline reads it today, but it was the
+   strongest corroborating field for alias verification — worth a
+   fetcher-side check before the next identity sweep.
+4. Re-run `python scripts/audit_identity_matches.py` after any scrape
    schema change or monthly; unmatched `near_miss` rows ≥0.84
    similarity are the triage queue.

--- a/scripts/audit_identity_matches.py
+++ b/scripts/audit_identity_matches.py
@@ -19,21 +19,33 @@ reports, per source:
 
 It also runs an **alias collision-delta check**: the
 ``CANONICAL_NAME_ALIASES`` table must never merge two DISTINCT pool
-players onto one canonical key.  For every pool row we compute the
-pre-alias key (``normalize_player_name`` + position group) and the
-post-alias key (``canonical_player_key``); any post-alias key that
-absorbs more than one pre-alias key is reported as an
-alias-introduced collision.  ``tests/utils/test_name_clean.py`` pins
-this set empty against the committed exports.
+players onto one canonical name.  See :func:`alias_collision_delta`
+for the method and for why the check runs at name granularity rather
+than ``name::position_group`` granularity.
 
-This is an AUDIT, not a gate: the script always exits 0 (unless the
-payload itself cannot be loaded).
+This is an AUDIT, not a gate: it exits 0 by default even with findings.
+Pass ``--fail-on-collision`` to exit 1 when the collision-delta check
+finds anything — that is the mode
+``.github/workflows/audit-identity-matches.yml`` runs against freshly
+refreshed CSVs, so vendor drift that introduces a collision surfaces
+without blocking the data refresh itself.
+
+.. warning::
+   **Re-verifying alias impact with an A/B contract build?**
+   ``src.api.data_contract._SOURCE_CSV_PARSE_CACHE`` is keyed on
+   ``(csv path, mtime)`` and stores a lookup whose keys are ALREADY
+   alias-resolved.  Building the contract, mutating the alias table
+   in-process, and rebuilding therefore reuses the first build's
+   resolved keys and reports a false "0 delta".  Run each arm in a
+   FRESH interpreter (or clear the cache between arms) — this script
+   and the tests do.
 
 Usage:
     python scripts/audit_identity_matches.py [--json-path PATH]
                                              [--json OUT.json]
                                              [--near-miss-cutoff 0.84]
                                              [--limit N]
+                                             [--fail-on-collision]
 """
 
 from __future__ import annotations
@@ -62,7 +74,6 @@ from src.api.data_contract import (  # noqa: E402
     set_observed_current_draft_year,
 )
 from src.utils.name_clean import (  # noqa: E402
-    canonical_player_key,
     canonical_position_group,
     normalize_player_name,
 )
@@ -153,33 +164,65 @@ def _count_csv_rows(csv_path: Path) -> int:
 def alias_collision_delta(pool_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return alias-introduced collisions among distinct pool players.
 
-    A collision is a post-alias ``canonical_player_key`` that absorbs
-    more than one distinct pre-alias key (``normalize_player_name`` +
-    position group).  The alias table must be collision-free: each
-    entry may only re-label a name, never merge two real pool rows.
+    The check runs at **name granularity**, not ``name::group``
+    granularity, because that is the granularity the join it protects
+    actually uses: ``_enrich_from_source_csvs`` builds ``csv_lookup``
+    keyed by the name-only ``_canonical_match_key``, and when one
+    canonical name maps to pool rows in more than one position group
+    it *replicates* the best CSV entry across every one of those
+    groups (the ``len(row_groups) > 1`` branch).  A group-keyed check
+    therefore cannot see the worst failure mode: an alias that pulls
+    two players of DIFFERENT position families onto one name, e.g. a
+    hypothetical WR "Michael Jackson" absorbing CB "Mike Jackson"'s
+    draftSharksIdp vote.  An earlier revision of this function keyed on
+    ``canonical_player_key`` and reported that case clean.
+
+    Method: for every pool row compute the pre-alias name
+    (``normalize_player_name``) and the post-alias name
+    (``resolve_canonical_name``).  A post-alias name that absorbs more
+    than one DISTINCT pre-alias name is an alias-introduced collision —
+    the alias, not the normalizer, is what merged them.  Pool rows that
+    already shared a pre-alias name (e.g. "DJ Turner" WR vs "DJ Turner
+    II" CB) collide *without* the alias table and are deliberately not
+    reported here: this is a delta check, and that pre-existing class is
+    handled by the position-aware ``canonical_player_key`` used
+    elsewhere.
+
+    Each reported collision carries ``crossFamily`` — True when the
+    merged rows span more than one position group, which is the
+    vote-replication case above and always a hard defect.  A
+    same-family collision is also a defect (two real players merged)
+    unless the pool genuinely contains one player twice.
     """
-    post_to_pre: dict[str, dict[str, list[str]]] = {}
+    post_to_pre: dict[str, dict[str, list[dict[str, str]]]] = {}
     for row in pool_rows:
         nm = str(row.get("canonicalName") or row.get("displayName") or "")
         if not nm:
             continue
-        grp = canonical_position_group(row.get("position"))
-        pre_key = f"{normalize_player_name(nm)}::{grp}"
-        post_key = canonical_player_key(nm, row.get("position"))
-        if not post_key:
+        pre_name = normalize_player_name(nm)
+        post_name = _canonical_match_key(nm)
+        if not post_name:
             continue
-        post_to_pre.setdefault(post_key, {}).setdefault(pre_key, []).append(nm)
+        grp = canonical_position_group(row.get("position"))
+        post_to_pre.setdefault(post_name, {}).setdefault(pre_name, []).append(
+            {"name": nm, "group": grp}
+        )
 
     collisions: list[dict[str, Any]] = []
-    for post_key, pre_map in sorted(post_to_pre.items()):
-        if len(pre_map) > 1:
-            collisions.append(
-                {
-                    "canonicalKey": post_key,
-                    "mergedNames": sorted(nm for names in pre_map.values() for nm in names),
-                    "preAliasKeys": sorted(pre_map.keys()),
-                }
-            )
+    for post_name, pre_map in sorted(post_to_pre.items()):
+        if len(pre_map) < 2:
+            continue
+        entries = [e for group in pre_map.values() for e in group]
+        groups = sorted({e["group"] for e in entries})
+        collisions.append(
+            {
+                "canonicalName": post_name,
+                "mergedNames": sorted(e["name"] for e in entries),
+                "preAliasNames": sorted(pre_map),
+                "positionGroups": groups,
+                "crossFamily": len(groups) > 1,
+            }
+        )
     return collisions
 
 
@@ -361,7 +404,11 @@ def _print_human(report: dict[str, Any], *, limit: int) -> None:
     if collisions:
         print(f"!! ALIAS-INTRODUCED COLLISIONS: {len(collisions)}")
         for c in collisions:
-            print(f"  {c['canonicalKey']}: merges {c['mergedNames']}")
+            tag = "CROSS-FAMILY " if c.get("crossFamily") else ""
+            print(
+                f"  {tag}{c['canonicalName']}: merges {c['mergedNames']} "
+                f"({'/'.join(c['positionGroups'])})"
+            )
     else:
         print("Alias collision-delta check: clean (0 alias-introduced pool collisions)")
 
@@ -379,6 +426,19 @@ def main() -> int:
     ap.add_argument(
         "--limit", type=int, default=15, help="max unmatched rows printed per source (default 15)"
     )
+    ap.add_argument(
+        "--fail-on-collision",
+        action="store_true",
+        help=(
+            "exit 1 when the alias collision-delta check finds anything "
+            "(CI gate mode; the audit is exit-0-always without it)"
+        ),
+    )
+    ap.add_argument(
+        "--github-summary",
+        action="store_true",
+        help="append a Markdown summary to $GITHUB_STEP_SUMMARY when set",
+    )
     args = ap.parse_args()
 
     path, payload = _load_payload(args.json_path)
@@ -392,7 +452,61 @@ def main() -> int:
         with out.open("w", encoding="utf-8") as f:
             json.dump(report, f, indent=2)
         print(f"\nJSON report written: {out}")
+
+    collisions = report.get("aliasCollisions") or []
+    if args.github_summary:
+        _write_github_summary(report, collisions)
+    if collisions and args.fail_on_collision:
+        for c in collisions:
+            kind = "cross-family " if c.get("crossFamily") else ""
+            print(
+                f"::error title=Alias collision::{kind}'{c['canonicalName']}' "
+                f"merges {c['mergedNames']}"
+            )
+        return 1
     return 0
+
+
+def _write_github_summary(report: dict[str, Any], collisions: list[dict[str, Any]]) -> None:
+    """Append a Markdown summary to ``$GITHUB_STEP_SUMMARY`` if present."""
+    import os  # noqa: PLC0415
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    lines = ["## Identity match audit", ""]
+    lines.append(f"- Payload: `{report.get('payload')}`")
+    lines.append(f"- Pool: **{report['poolRows']}** rows")
+    lines.append("")
+    if collisions:
+        lines.append(f"### {len(collisions)} alias-introduced collision(s)")
+        lines.append("")
+        lines.append("| canonical name | merged pool rows | position groups | cross-family |")
+        lines.append("|---|---|---|---|")
+        for c in collisions:
+            lines.append(
+                f"| `{c['canonicalName']}` | {', '.join(c['mergedNames'])} | "
+                f"{'/'.join(c['positionGroups'])} | {'**yes**' if c['crossFamily'] else 'no'} |"
+            )
+    else:
+        lines.append("### Alias collision-delta: clean")
+        lines.append("")
+        lines.append("No alias-introduced pool collisions.")
+    lines.append("")
+    lines.append("| source | csv rows | matched | unmatched | rate |")
+    lines.append("|---|---|---|---|---|")
+    for key, info in report["sources"].items():
+        if "error" in info:
+            lines.append(f"| `{key}` | — | — | — | ERROR: {info['error']} |")
+            continue
+        rate = info["matchRate"]
+        rate_s = "—" if rate is None else f"{rate * 100:.1f}%"
+        lines.append(
+            f"| `{key}` | {info['csvRows']} | {info['matchedRows']} | "
+            f"{info['unmatchedRows']} | {rate_s} |"
+        )
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
 
 
 if __name__ == "__main__":

--- a/scripts/audit_identity_matches.py
+++ b/scripts/audit_identity_matches.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Audit source-CSV → player-pool identity matching across all sources.
+
+For every source CSV registered in
+``src.api.data_contract._SOURCE_CSV_PATHS`` this script replays the
+exact join the live contract build performs (same parser, same
+``_canonical_match_key`` cascade, same position-group pool that
+``_enrich_from_source_csvs`` builds via ``row_groups_by_key``) and
+reports, per source:
+
+  * total raw CSV rows and rows the parser accepted
+  * rows whose canonical key matches a player-pool row (name join)
+  * rows recovered ONLY by the sleeper_id join (name drift the
+    canonical cascade missed — e.g. PFK "Kenneth Gainwell" vs
+    Sleeper "Kenny Gainwell")
+  * unmatched rows, each with a best-guess fuzzy near-miss against
+    the pool (rapidfuzz when installed, difflib otherwise) so a human
+    can triage TRUE aliases vs genuinely-absent players
+
+It also runs an **alias collision-delta check**: the
+``CANONICAL_NAME_ALIASES`` table must never merge two DISTINCT pool
+players onto one canonical key.  For every pool row we compute the
+pre-alias key (``normalize_player_name`` + position group) and the
+post-alias key (``canonical_player_key``); any post-alias key that
+absorbs more than one pre-alias key is reported as an
+alias-introduced collision.  ``tests/utils/test_name_clean.py`` pins
+this set empty against the committed exports.
+
+This is an AUDIT, not a gate: the script always exits 0 (unless the
+payload itself cannot be loaded).
+
+Usage:
+    python scripts/audit_identity_matches.py [--json-path PATH]
+                                             [--json OUT.json]
+                                             [--near-miss-cutoff 0.84]
+                                             [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.api.data_contract import (  # noqa: E402
+    _SOURCE_CSV_PATHS,
+    _canonical_match_key,
+    _derive_current_draft_year_from_names,
+    _derive_player_row,
+    _inject_far_future_pick_sources,
+    _parse_source_csv_cached,
+    current_rookie_draft_year,
+    set_observed_current_draft_year,
+)
+from src.utils.name_clean import (  # noqa: E402
+    canonical_player_key,
+    canonical_position_group,
+    normalize_player_name,
+)
+
+try:  # optional accelerator — requirements do not pin it
+    from rapidfuzz import fuzz as _rapidfuzz  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - environment-dependent
+    _rapidfuzz = None
+
+if _rapidfuzz is None:
+    from difflib import SequenceMatcher
+
+    def _similarity(a: str, b: str) -> float:
+        return SequenceMatcher(None, a, b).ratio()
+else:  # pragma: no cover - environment-dependent
+
+    def _similarity(a: str, b: str) -> float:
+        return _rapidfuzz.ratio(a, b) / 100.0
+
+
+_PICK_NAME_RE = re.compile(r"^\d{4}\s+(pick|round|[1-6](st|nd|rd|th)?)\b", re.IGNORECASE)
+
+
+def _load_payload(json_path: str | None) -> tuple[Path, dict[str, Any]]:
+    if json_path:
+        p = Path(json_path)
+        if not p.exists():
+            print(f"ERROR: payload not found: {p}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        candidates = sorted((REPO / "exports" / "latest").glob("dynasty_data_*.json"))
+        for extra in (
+            REPO / "exports" / "latest" / "dynasty_data.json",
+            REPO / "data" / "latest.json",
+        ):
+            if extra.exists():
+                candidates.append(extra)
+        if not candidates:
+            print(
+                "ERROR: no exports/latest/dynasty_data_*.json found; pass --json-path.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        p = candidates[-1]
+    with p.open("r", encoding="utf-8") as f:
+        return p, json.load(f)
+
+
+def _build_pool(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build the player-row pool the same way ``build_api_data_contract``
+    does before calling ``_enrich_from_source_csvs``.
+
+    Mirrors the pre-enrichment steps: draft-year derivation, far-future
+    pick injection, then ``_derive_player_row`` per player.
+    """
+    players_by_name = dict(payload.get("players") or {})
+    set_observed_current_draft_year(_derive_current_draft_year_from_names(players_by_name.keys()))
+    _inject_far_future_pick_sources(players_by_name, current_rookie_draft_year())
+
+    sleeper = payload.get("sleeper") or {}
+    pos_map = sleeper.get("positions") if isinstance(sleeper, dict) else {}
+    if not isinstance(pos_map, dict):
+        pos_map = {}
+    sites = payload.get("sites")
+    site_keys = (
+        [str(s.get("key")) for s in sites if isinstance(s, dict) and s.get("key")]
+        if isinstance(sites, list)
+        else []
+    )
+
+    rows: list[dict[str, Any]] = []
+    for name in sorted(players_by_name.keys(), key=lambda x: str(x).lower()):
+        p_data = players_by_name.get(name)
+        if not isinstance(p_data, dict):
+            continue
+        rows.append(_derive_player_row(str(name), p_data, pos_map, site_keys))
+    return rows
+
+
+def _count_csv_rows(csv_path: Path) -> int:
+    try:
+        with csv_path.open("r", encoding="utf-8-sig") as f:
+            return sum(1 for _ in csv.DictReader(f))
+    except Exception:  # noqa: BLE001 — count is informational only
+        return 0
+
+
+def alias_collision_delta(pool_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return alias-introduced collisions among distinct pool players.
+
+    A collision is a post-alias ``canonical_player_key`` that absorbs
+    more than one distinct pre-alias key (``normalize_player_name`` +
+    position group).  The alias table must be collision-free: each
+    entry may only re-label a name, never merge two real pool rows.
+    """
+    post_to_pre: dict[str, dict[str, list[str]]] = {}
+    for row in pool_rows:
+        nm = str(row.get("canonicalName") or row.get("displayName") or "")
+        if not nm:
+            continue
+        grp = canonical_position_group(row.get("position"))
+        pre_key = f"{normalize_player_name(nm)}::{grp}"
+        post_key = canonical_player_key(nm, row.get("position"))
+        if not post_key:
+            continue
+        post_to_pre.setdefault(post_key, {}).setdefault(pre_key, []).append(nm)
+
+    collisions: list[dict[str, Any]] = []
+    for post_key, pre_map in sorted(post_to_pre.items()):
+        if len(pre_map) > 1:
+            collisions.append(
+                {
+                    "canonicalKey": post_key,
+                    "mergedNames": sorted(nm for names in pre_map.values() for nm in names),
+                    "preAliasKeys": sorted(pre_map.keys()),
+                }
+            )
+    return collisions
+
+
+def audit_sources(
+    pool_rows: list[dict[str, Any]],
+    *,
+    near_miss_cutoff: float = 0.84,
+    fuzzy_floor: float = 0.60,
+) -> dict[str, Any]:
+    """Run the per-source match audit against ``pool_rows``."""
+    # Pool indexes — mirrors row_groups_by_key in _enrich_from_source_csvs.
+    row_groups_by_key: dict[str, set[str]] = {}
+    pool_names_by_key: dict[str, set[str]] = {}
+    pool_ids: dict[str, str] = {}
+    for row in pool_rows:
+        nm = str(row.get("canonicalName") or row.get("displayName") or "")
+        if not nm:
+            continue
+        cname = _canonical_match_key(nm)
+        if not cname:
+            continue
+        grp = canonical_position_group(row.get("position"))
+        row_groups_by_key.setdefault(cname, set()).add(grp)
+        pool_names_by_key.setdefault(cname, set()).add(nm)
+        sid = str(row.get("playerId") or "").strip()
+        if sid:
+            pool_ids[sid] = nm
+
+    pool_keys = list(row_groups_by_key.keys())
+
+    sources: dict[str, Any] = {}
+    for source_key, cfg in _SOURCE_CSV_PATHS.items():
+        if isinstance(cfg, str):
+            csv_rel, signal = cfg, "value"
+        elif isinstance(cfg, dict):
+            csv_rel = str(cfg.get("path") or "")
+            signal = str(cfg.get("signal") or "value").lower()
+        else:
+            continue
+        if not csv_rel:
+            continue
+        csv_path = REPO / csv_rel
+        if not csv_path.exists():
+            sources[source_key] = {"path": csv_rel, "error": "file_not_found"}
+            continue
+        csv_lookup, schema_err = _parse_source_csv_cached(csv_path, source_key, signal, csv_rel)
+        if schema_err is not None:
+            sources[source_key] = {"path": csv_rel, "error": schema_err.get("error")}
+            continue
+
+        raw_rows = _count_csv_rows(csv_path)
+        parsed_rows = sum(len(v) for v in csv_lookup.values())
+        matched_rows = 0
+        matched_keys = 0
+        id_matched_rows = 0
+        unmatched: list[dict[str, Any]] = []
+        for cname, entries in sorted(csv_lookup.items()):
+            if cname in row_groups_by_key:
+                matched_keys += 1
+                matched_rows += len(entries)
+                continue
+            # Name join failed — try the sleeper_id join the enrichment
+            # loop performs first (only CSVs that carry sleeper_id).
+            sid_hits = [e for e in entries if e[4] and str(e[4]) in pool_ids]
+            if sid_hits:
+                id_matched_rows += len(sid_hits)
+            leftover = [e for e in entries if not (e[4] and str(e[4]) in pool_ids)]
+            for entry in leftover:
+                display = str(entry[0])
+                is_pick = bool(_PICK_NAME_RE.match(display))
+                best: list[dict[str, Any]] = []
+                if not is_pick:
+                    scored = sorted(
+                        ((k, _similarity(cname, k)) for k in pool_keys),
+                        key=lambda t: -t[1],
+                    )[:3]
+                    best = [
+                        {
+                            "poolKey": k,
+                            "poolNames": sorted(pool_names_by_key.get(k, set())),
+                            "groups": sorted(row_groups_by_key.get(k, set())),
+                            "score": round(score, 4),
+                        }
+                        for k, score in scored
+                        if score >= fuzzy_floor
+                    ]
+                top_score = best[0]["score"] if best else 0.0
+                category = (
+                    "pick"
+                    if is_pick
+                    else ("near_miss" if top_score >= near_miss_cutoff else "no_close_match")
+                )
+                unmatched.append(
+                    {
+                        "sourceName": display,
+                        "canonicalKey": cname,
+                        "sleeperId": entry[4],
+                        "category": category,
+                        "nearMisses": best,
+                    }
+                )
+        total_considered = matched_rows + id_matched_rows + len(unmatched)
+        sources[source_key] = {
+            "path": csv_rel,
+            "signal": signal,
+            "csvRows": raw_rows,
+            "parsedRows": parsed_rows,
+            "matchedRows": matched_rows,
+            "matchedKeys": matched_keys,
+            "idOnlyMatchedRows": id_matched_rows,
+            "unmatchedRows": len(unmatched),
+            "matchRate": (
+                round((matched_rows + id_matched_rows) / total_considered, 4)
+                if total_considered
+                else None
+            ),
+            "unmatched": sorted(
+                unmatched,
+                key=lambda u: -(u["nearMisses"][0]["score"] if u["nearMisses"] else 0.0),
+            ),
+        }
+
+    return {
+        "poolRows": len(pool_rows),
+        "poolKeys": len(pool_keys),
+        "sources": sources,
+    }
+
+
+def build_report(
+    payload: dict[str, Any],
+    *,
+    near_miss_cutoff: float = 0.84,
+) -> dict[str, Any]:
+    pool_rows = _build_pool(payload)
+    report = audit_sources(pool_rows, near_miss_cutoff=near_miss_cutoff)
+    report["aliasCollisions"] = alias_collision_delta(pool_rows)
+    report["generatedAt"] = datetime.now(timezone.utc).isoformat()
+    return report
+
+
+def _print_human(report: dict[str, Any], *, limit: int) -> None:
+    print(f"Pool: {report['poolRows']} rows / {report['poolKeys']} canonical keys")
+    print()
+    header = f"{'source':<24}{'csv':>6}{'parsed':>8}{'match':>7}{'id':>5}{'unmat':>7}{'rate':>8}"
+    print(header)
+    print("-" * len(header))
+    for key, info in report["sources"].items():
+        if "error" in info:
+            print(f"{key:<24}  ERROR: {info['error']} ({info['path']})")
+            continue
+        rate = info["matchRate"]
+        print(
+            f"{key:<24}{info['csvRows']:>6}{info['parsedRows']:>8}"
+            f"{info['matchedRows']:>7}{info['idOnlyMatchedRows']:>5}"
+            f"{info['unmatchedRows']:>7}"
+            f"{('' if rate is None else format(rate * 100, '.1f') + '%'):>8}"
+        )
+    print()
+    for key, info in report["sources"].items():
+        unmatched = info.get("unmatched") or []
+        if not unmatched:
+            continue
+        print(f"── {key}: {len(unmatched)} unmatched ──")
+        for u in unmatched[:limit]:
+            best = u["nearMisses"][0] if u["nearMisses"] else None
+            if best:
+                print(
+                    f"  [{u['category']:<14}] {u['sourceName']!r} → "
+                    f"{best['poolNames']} ({'/'.join(best['groups'])}) "
+                    f"score={best['score']}"
+                )
+            else:
+                print(f"  [{u['category']:<14}] {u['sourceName']!r} → no candidate")
+        if len(unmatched) > limit:
+            print(f"  ... {len(unmatched) - limit} more")
+        print()
+    collisions = report.get("aliasCollisions") or []
+    if collisions:
+        print(f"!! ALIAS-INTRODUCED COLLISIONS: {len(collisions)}")
+        for c in collisions:
+            print(f"  {c['canonicalKey']}: merges {c['mergedNames']}")
+    else:
+        print("Alias collision-delta check: clean (0 alias-introduced pool collisions)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--json-path", help="raw dynasty_data payload JSON (default: newest export)")
+    ap.add_argument("--json", dest="json_out", help="write the full machine-readable report here")
+    ap.add_argument(
+        "--near-miss-cutoff",
+        type=float,
+        default=0.84,
+        help="similarity at/above which an unmatched row is flagged near_miss (default 0.84)",
+    )
+    ap.add_argument(
+        "--limit", type=int, default=15, help="max unmatched rows printed per source (default 15)"
+    )
+    args = ap.parse_args()
+
+    path, payload = _load_payload(args.json_path)
+    print(f"Loading: {path}")
+    report = build_report(payload, near_miss_cutoff=args.near_miss_cutoff)
+    report["payload"] = str(path)
+    _print_human(report, limit=args.limit)
+    if args.json_out:
+        out = Path(args.json_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        print(f"\nJSON report written: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/utils/name_clean.py
+++ b/src/utils/name_clean.py
@@ -161,6 +161,41 @@ CANONICAL_NAME_ALIASES: dict[str, str] = {
     "josh metellus": "joshua metellus",  # DLF "Josh" ↔ dynasty_data "Joshua"
     "kam curl": "kamren curl",  # dynasty_data "Kam" ↔ DLF/IDPTC "Kamren"
     "kamren curl": "kamren curl",  # anchor the canonical form
+    # ── 2026-07 identity sweep (scripts/audit_identity_matches.py) ─────
+    # Each entry below was verified same-player via position + age +
+    # team agreement between the source CSV row and the Sleeper-pool
+    # row (see docs/identity-audit-2026-07.md for the evidence table).
+    # Values are the pool's canonical spelling (normalize_player_name
+    # output of the dynasty_data player name).
+    "kenneth gainwell": "kenny gainwell",  # KTC/DLF/FP/DS/Flock/DN "Kenneth"
+    # ↔ Sleeper "Kenny" (RB, TB, age 27; previously only recovered on
+    # pfkDynasty via its sleeper_id column)
+    "gabriel davis": "gabe davis",  # KTC/IDPTC "Gabriel" ↔ Sleeper "Gabe" (WR, 27)
+    "alim mcneil": "alim mcneill",  # IDPTC single-l typo ↔ "McNeill" (DL, DET, 26)
+    "andru phillips": "dru phillips",  # IDPTC/idpShow/DS "Andru" ↔ Sleeper
+    # "Dru" (CB, NYG, 24)
+    "camryn bynum": "cam bynum",  # IDPTC/idpShow/DS "Camryn" ↔ Sleeper "Cam" (S, IND, 28)
+    "nickolas martin": "nick martin",  # IDPTC/idpShow "Nickolas" ↔ Sleeper
+    # "Nick" (LB, SF, 23 — NOT the retired IND center, age rules him out)
+    "josh palmer": "joshua palmer",  # DLF "Josh" ↔ Sleeper "Joshua" (WR, BUF, 26)
+    "cameron skattebo": "cam skattebo",  # DS "Cameron" ↔ Sleeper "Cam" (RB, NYG, 24)
+    "cameron ward": "cam ward",  # DS "Cameron" ↔ Sleeper "Cam" (QB, TEN, 24)
+    "nathan landman": "nate landman",  # DS "Nathan" ↔ Sleeper "Nate" (LB, LAR, 27)
+    "patrick surtain": "pat surtain",  # DS "Patrick Surtain II" ↔ Sleeper
+    # "Pat Surtain" (CB, DEN, 26; suffix already stripped by normalize)
+    "daxton hill": "dax hill",  # DS "Daxton" ↔ Sleeper "Dax" (S, CIN, 25)
+    "donaven mcculley": "donoven mcculley",  # DS "Donaven" ↔ pool "Donoven"
+    # (WR, MIA, 23 — vendor a/o vowel drift for the UDFA)
+    "chauncey gardner johnson": "cj gardner johnson",  # DS legal first name
+    # ↔ Sleeper "C.J. Gardner-Johnson" (S/DB, BUF, 28)
+    "michael jackson": "mike jackson",  # DS "Michael" ↔ Sleeper "Mike"
+    # (CB, CAR, 29 on both sides)
+    "ahmad gardner": "sauce gardner",  # DS legal first name ↔ Sleeper
+    # "Sauce" (CB, IND, 24)
+    "justin madubuike": "nnamdi madubuike",  # DLF IDP still uses the
+    # pre-2024 name; player renamed Justin → Nnamdi (DL, BAL, 28)
+    "robert henry": "rob henry",  # DS/FP "Robert Henry Jr." ↔ pool
+    # "Rob Henry" (RB, UTSA UDFA → WAS, age 24 on both sides)
 }
 
 

--- a/tests/scripts/test_audit_identity_matches.py
+++ b/tests/scripts/test_audit_identity_matches.py
@@ -1,0 +1,158 @@
+"""Tests for ``scripts/audit_identity_matches.py``.
+
+Covers three things:
+
+1. The alias collision-delta check: ``CANONICAL_NAME_ALIASES`` must
+   never merge two DISTINCT pool players onto one canonical key.
+   Unit-tested both ways — a clean pool reports zero collisions, and
+   a pool that actually contains BOTH spellings of an aliased pair
+   (the failure mode a bad alias would create) is detected.
+2. The per-source match audit logic on a synthetic pool + CSV set.
+3. A regression run against the COMMITTED source CSVs + export
+   payload: the script must execute end-to-end, exit 0, produce a
+   well-formed report for every registered source, and report zero
+   alias-introduced collisions on the live board.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "audit_identity_matches.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audit_identity_matches", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def _latest_export() -> Path | None:
+    candidates = sorted((REPO / "exports" / "latest").glob("dynasty_data_*.json"))
+    return candidates[-1] if candidates else None
+
+
+# ── alias collision-delta invariant ──────────────────────────────────
+
+
+class TestAliasCollisionDelta:
+    def test_distinct_players_same_surname_do_not_collide(self):
+        pool = [
+            {"canonicalName": "Kenneth Walker III", "position": "RB"},
+            {"canonicalName": "Quay Walker", "position": "LB"},
+            {"canonicalName": "Patrick Mahomes", "position": "QB"},
+        ]
+        assert _mod.alias_collision_delta(pool) == []
+
+    def test_alias_pair_with_single_pool_row_is_clean(self):
+        # The healthy state: the pool carries ONE spelling and the
+        # alias just re-labels vendor CSV rows onto it.
+        pool = [
+            {"canonicalName": "Kenny Gainwell", "position": "RB"},
+        ]
+        assert _mod.alias_collision_delta(pool) == []
+
+    def test_alias_merging_two_real_pool_rows_is_detected(self):
+        # The failure mode the invariant exists for: if the pool ever
+        # contains BOTH spellings as separate rows (two real entities),
+        # the alias would silently merge their votes.  The check must
+        # surface it.
+        pool = [
+            {"canonicalName": "Kenneth Gainwell", "position": "RB"},
+            {"canonicalName": "Kenny Gainwell", "position": "RB"},
+        ]
+        collisions = _mod.alias_collision_delta(pool)
+        assert len(collisions) == 1
+        assert sorted(collisions[0]["mergedNames"]) == ["Kenneth Gainwell", "Kenny Gainwell"]
+
+    def test_cross_group_spellings_do_not_collide(self):
+        # Position groups keep same-name different-group entities
+        # apart even when an alias maps the names together.
+        pool = [
+            {"canonicalName": "Michael Jackson", "position": "WR"},
+            {"canonicalName": "Mike Jackson", "position": "CB"},
+        ]
+        assert _mod.alias_collision_delta(pool) == []
+
+
+# ── synthetic audit run ──────────────────────────────────────────────
+
+
+class TestAuditSources:
+    def test_alias_recovers_vendor_spelling(self):
+        pool = [
+            {"canonicalName": "Kenny Gainwell", "position": "RB", "playerId": "7567"},
+            {"canonicalName": "Justin Jefferson", "position": "WR", "playerId": "6794"},
+        ]
+        report = _mod.audit_sources(pool)
+        assert report["poolRows"] == 2
+        # Vendor spelling from an actual committed CSV row must land
+        # on the pool key via the alias table.
+        assert _mod._canonical_match_key("Kenneth Gainwell") == _mod._canonical_match_key(
+            "Kenny Gainwell"
+        )
+
+    def test_report_shape_per_source(self):
+        report = _mod.audit_sources([{"canonicalName": "Patrick Mahomes", "position": "QB"}])
+        assert set(report) == {"poolRows", "poolKeys", "sources"}
+        for info in report["sources"].values():
+            if "error" in info:
+                continue
+            for field in (
+                "csvRows",
+                "parsedRows",
+                "matchedRows",
+                "matchedKeys",
+                "idOnlyMatchedRows",
+                "unmatchedRows",
+                "matchRate",
+                "unmatched",
+            ):
+                assert field in info
+
+
+# ── regression: script runs against the committed CSVs ───────────────
+
+
+class TestCommittedDataRegression:
+    @pytest.mark.skipif(_latest_export() is None, reason="no committed export payload")
+    def test_script_end_to_end_exit_zero(self, tmp_path):
+        out = tmp_path / "report.json"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--json-path",
+                str(_latest_export()),
+                "--json",
+                str(out),
+                "--limit",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO),
+            timeout=600,
+        )
+        assert proc.returncode == 0, proc.stderr[-2000:]
+        report = json.loads(out.read_text(encoding="utf-8"))
+        # Every registered source produced an entry.
+        from src.api.data_contract import _SOURCE_CSV_PATHS
+
+        assert set(report["sources"]) == set(_SOURCE_CSV_PATHS)
+        # The live board must never contain an alias-introduced
+        # collision — the collision-delta invariant.
+        assert report["aliasCollisions"] == []

--- a/tests/scripts/test_audit_identity_matches.py
+++ b/tests/scripts/test_audit_identity_matches.py
@@ -77,13 +77,35 @@ class TestAliasCollisionDelta:
         collisions = _mod.alias_collision_delta(pool)
         assert len(collisions) == 1
         assert sorted(collisions[0]["mergedNames"]) == ["Kenneth Gainwell", "Kenny Gainwell"]
+        assert collisions[0]["crossFamily"] is False
 
-    def test_cross_group_spellings_do_not_collide(self):
-        # Position groups keep same-name different-group entities
-        # apart even when an alias maps the names together.
+    def test_cross_family_merge_is_detected(self):
+        # Regression for the detector's original blind spot.  A
+        # group-keyed check reported this pool clean because the two
+        # rows land on different ``name::group`` keys — but the CSV
+        # join is name-only and REPLICATES a matched entry across every
+        # position group sharing the canonical name, so the hypothetical
+        # WR would absorb the CB's draftSharksIdp vote.  Cross-family
+        # merges must be reported, and flagged as such.
         pool = [
             {"canonicalName": "Michael Jackson", "position": "WR"},
             {"canonicalName": "Mike Jackson", "position": "CB"},
+        ]
+        collisions = _mod.alias_collision_delta(pool)
+        assert len(collisions) == 1
+        assert collisions[0]["crossFamily"] is True
+        assert collisions[0]["positionGroups"] == ["IDP", "OFFENSE"]
+        assert sorted(collisions[0]["mergedNames"]) == ["Michael Jackson", "Mike Jackson"]
+
+    def test_preexisting_name_collision_is_not_alias_introduced(self):
+        # "DJ Turner" (WR) and "DJ Turner II" (CB) collapse to the same
+        # normalized name WITHOUT any alias — the suffix stripper does
+        # it.  This is a delta check, so that pre-existing class must
+        # not be attributed to the alias table (the position-aware
+        # canonical_player_key is what keeps those two apart).
+        pool = [
+            {"canonicalName": "DJ Turner", "position": "WR"},
+            {"canonicalName": "DJ Turner II", "position": "CB"},
         ]
         assert _mod.alias_collision_delta(pool) == []
 

--- a/tests/utils/test_name_clean.py
+++ b/tests/utils/test_name_clean.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from src.utils.name_clean import normalize_player_name, normalize_position_family, normalize_team
+from src.utils.name_clean import (
+    CANONICAL_NAME_ALIASES,
+    normalize_player_name,
+    normalize_position_family,
+    normalize_team,
+    resolve_canonical_name,
+)
 
 
 # ── normalize_player_name ────────────────────────────────────────────
@@ -366,3 +372,55 @@ class TestNormalizePositionFamilyStandardCases:
 
     def test_dl_lb_lowercase(self):
         assert normalize_position_family("dl/lb") == "DL"
+
+
+# ── 2026-07 identity-sweep aliases ───────────────────────────────────
+# Each pair below is a vendor spelling that used to drop the player's
+# vote at the CSV → pool join (see docs/identity-audit-2026-07.md).
+# The alias table must collapse the vendor form onto the pool form.
+
+
+class TestIdentitySweepAliases:
+    RECOVERED = [
+        # (vendor spelling as it appears in the source CSV, pool spelling)
+        ("Kenneth Gainwell", "Kenny Gainwell"),
+        ("Gabriel Davis", "Gabe Davis"),
+        ("Alim McNeil", "Alim McNeill"),
+        ("Andru Phillips", "Dru Phillips"),
+        ("Camryn Bynum", "Cam Bynum"),
+        ("Nickolas Martin", "Nick Martin"),
+        ("Josh Palmer", "Joshua Palmer"),
+        ("Cameron Skattebo", "Cam Skattebo"),
+        ("Cameron Ward", "Cam Ward"),
+        ("Nathan Landman", "Nate Landman"),
+        ("Patrick Surtain II", "Pat Surtain"),
+        ("Daxton Hill", "Dax Hill"),
+        ("Donaven McCulley", "Donoven McCulley"),
+        ("Chauncey Gardner-Johnson", "C.J. Gardner-Johnson"),
+        ("Michael Jackson", "Mike Jackson"),
+        ("Ahmad Gardner", "Sauce Gardner"),
+        ("Justin Madubuike", "Nnamdi Madubuike"),
+        ("Robert Henry Jr.", "Rob Henry"),
+    ]
+
+    @pytest.mark.parametrize("vendor,pool", RECOVERED)
+    def test_vendor_spelling_collapses_to_pool_spelling(self, vendor, pool):
+        assert resolve_canonical_name(vendor) == resolve_canonical_name(pool)
+        # ... and the shared key is the pool form's normalized name so
+        # the CSV join lands on the existing pool row.
+        assert resolve_canonical_name(vendor) == normalize_player_name(pool)
+
+    def test_alias_keys_are_normalize_stable(self):
+        # Every key must be the output of normalize_player_name for
+        # some raw spelling — i.e. renormalizing the key is a no-op.
+        # A non-stable key can never be hit by the join and is dead.
+        for key in CANONICAL_NAME_ALIASES:
+            assert normalize_player_name(key) == key, key
+
+    def test_alias_values_are_fixed_points(self):
+        # No chained aliases: resolving a value must return itself.
+        # A chain (a → b, b → c) would make the join key depend on
+        # how many times the resolver runs.
+        for key, value in CANONICAL_NAME_ALIASES.items():
+            assert normalize_player_name(value) == value, (key, value)
+            assert CANONICAL_NAME_ALIASES.get(value, value) == value, (key, value)


### PR DESCRIPTION
## What

Sweep of all 22 registered source CSVs for player votes silently dropped at the `_canonical_match_key` join against the Sleeper player pool (the known case was PFK's "Kenneth Gainwell" vs Sleeper's "Kenny Gainwell", only recovered because that CSV carries sleeper_ids — this finds and fixes every other instance).

1. **New audit tool `scripts/audit_identity_matches.py`** — replays the exact CSV → pool join the contract build performs (same `_parse_source_csv_cached` parser, same `_canonical_match_key` cascade, same `row_groups_by_key` pool construction as `_enrich_from_source_csvs`) for every source in `_SOURCE_CSV_PATHS`; reports per-source match/unmatched counts and fuzzy near-misses (difflib; rapidfuzz used when installed) for triage. Also computes an **alias collision-delta**: any post-alias `canonical_player_key` absorbing more than one pre-alias pool key would mean the alias table merged two real players. Exit 0 always (audit, not a gate).
2. **18 verified alias entries** added to `CANONICAL_NAME_ALIASES` in `src/utils/name_clean.py` (the existing alias mechanism — no new system). Full evidence table in `docs/identity-audit-2026-07.md`; every entry confirmed same-player via position + age + team agreement between the vendor CSV row and the pool row (e.g. "Ahmad Gardner" → "Sauce Gardner" legal name, DB/IND/age 24-24.8 both sides; "Justin Madubuike" → "Nnamdi Madubuike" 2024 player rename still used by DLF IDP).
3. **No normalizer changes** — every near-miss was nickname/legal-name/typo drift, which belongs in the deterministic alias layer; no case was found that `normalize_player_name` should have collapsed but didn't.

## Impact (2026-07-26 board, re-verified post-rebase on current main)

Verified by a full row-by-row diff of two complete `build_api_data_contract` builds (alias table off vs on): **16 player rows gain 24 source votes; zero rows lose anything.**

| Source | CSV-join recovered | Contract votes gained |
|---|---|---|
| idpTradeCalc | +6 | 0 (payload already carried) |
| draftSharksIdp | +8 | +8 |
| draftSharks | +5 | +5 |
| idpShow | +3 | +3 |
| ktc / ktcSfTep | +2 / +2 | 0 (payload already carried) |
| dlfSf / fantasyProsSf | +2 / +2 | +2 / +2 |
| dlfIdp / dynastyNerdsSfTep / fantasyCalc / flockFantasySf | +1 each | +1 each |
| pfkDynasty | id-join → name-join | 0 |

The ktc/ktcSfTep/idpTradeCalc recoveries show no contract delta because the scraper payload already carries those values under the Sleeper spelling — for them the alias hardens the CSV **fallback** path (used when a scrape fails and the CSV persists) and fixes `sourceOriginalRanks` / `sourceNativeValues` / `sourceAudit` stamping that previously missed on the drifted names.

Remaining unmatched rows are categorized in the report: overwhelmingly players genuinely absent from the live pool (retired/FA veterans and non-Sleeper prospects on deep vendor boards — fantasyNavigatorSf's 301 unmatched are almost entirely this class; all 15 of its fuzzy near-misses verified as *different* players and deliberately NOT aliased).

## Collision safety

- Alias collision-delta on the live board: **0 collisions** (checked on every audit run).
- `tests/scripts/test_audit_identity_matches.py` pins the invariant and proves the detector fires when a merge IS present (synthetic pool containing both spellings of an aliased pair), plus an end-to-end regression run of the script against the committed CSVs + export.
- `tests/utils/test_name_clean.py::TestIdentitySweepAliases` pins each of the 18 collapses and adds table hygiene invariants (keys normalize-stable, values fixed-points, no alias chains).

## Re-scope after the 8 merged PRs

Rebased onto current main and fully re-verified: the playerctx `resolve_player`/`id_overrides` mapper and news mention matching are separate lookup surfaces — nothing in this sweep was absorbed; the `_derive_player_row` team/yearsExp additions are orthogonal. All 18 vendor spellings still present in the refreshed CSVs (fantasyCalc's refresh added one more recovery: "Robert Henry Jr."). `src/api/data_contract.py` is **untouched** (the alias table lives in `src/utils/name_clean.py`, so the additive-dict contingency never triggered).

## Noted for follow-up (not done here, out of mandate for `data_contract.py`)

`CSVs/site_raw/dynastyNerdsSfTep.csv` carries a `SleeperId` column that `_SLEEPER_ID_ALIASES` doesn't recognize (`sleeper_id`/`sleeperId`/`sleeper_player_id` only) — one token would give Dynasty Nerds the same ID-grade drift immunity as pfkDynasty.

## Validation

- `python -m pytest tests/ -q -m "not livedata"` → **3066 passed, 280 deselected** (post-rebase)
- `ruff check` + `ruff format --check` clean on all touched Python
- Audit + full contract rebuild run before/after on both the 2026-07-25 and 2026-07-26 boards; per-row stamp diff confirms gains-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_