### PR TITLE
Trade Finder: stop silently dropping every IDP player (per-market quality gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,43 @@ Two independent trade suggestion systems in `src/trade/`:
 - **suggestions.py** — roster-aware trade suggestions (sell-high, buy-low, consolidation, upgrades)
 - **finder.py** — KTC arbitrage finder (board value vs market value mismatches)
 
-Both enforce a **KTC top-150 quality filter**: only players ranked inside the top 150 appear in any trade suggestion.
+Both enforce a **top-150 quality filter**, but they gate on
+**different boards**, and the difference is deliberate. Do not unify
+them without reading why (WS-J F-3/F-4):
+
+| Engine | Gate | Ranked against |
+|---|---|---|
+| `suggestions.py` | `BOARD_TOP_N_FILTER` (150) | **our blended board** — `display_value` order, covers every asset class |
+| `finder.py` | `MARKET_TOP_N_FILTER` (150) | **the retail market, per market** — `ktcSfTep` for offense + picks, `idpTradeCalc` for IDP, each ranked within its own population |
+
+`finder.py` must anchor on a real retail value because its whole
+premise is arbitrage between our board and the market — the market
+number is load-bearing in its arithmetic. `suggestions.py` only needs
+an asset-quality gate ("don't propose trading roster clog"), which our
+own board answers for IDP and picks that no single retail board
+covers.
+
+Two traps this documentation previously set:
+
+* **`finder.py` was offense-only.** It ranked every asset against KTC,
+  and KTC publishes no IDP players — so every defender scored
+  `ktc_value = None` and was dropped before scoring. In an IDP league
+  the engine silently returned offense-only results. Fixed by the
+  per-market gate above; it now emits `marketCoverage` per market and
+  warns explicitly when an IDP league has no priced IDP assets.
+* **`suggestions.py`'s gate never consulted KTC.** It was named
+  `KTC_TOP_N_FILTER` and its helper `_assign_ktc_ranks`, but the rank
+  was always the blended-board position. Renamed to
+  `BOARD_TOP_N_FILTER` / `_assign_board_ranks`; `boardTopNFilter` is
+  the honest metadata field. The `ktc*` names survive as deprecated
+  aliases only.
+
+Cross-market note: KTC and IDPTradeCalc are **directly comparable**,
+not incommensurable. IDPTC is a full-roster calculator publishing
+offense, IDP and picks on one native 0-9999 scale; of KTC's 500 rows,
+475 also appear on the IDPTC board at a median value ratio of 1.000
+(p10 0.888, p90 1.054, measured 2026-07-26). Both top out at 9999, so
+there is no rescaling to apply between them.
 
 ### Canonical Data Mode
 The offline canonical-build path (``scripts/canonical_build.py`` +

--- a/docs/roster-trade-intelligence/F-6-finder-valuation-path.md
+++ b/docs/roster-trade-intelligence/F-6-finder-valuation-path.md
@@ -1,0 +1,133 @@
+# F-6 — the trade finder values assets off a parallel valuation path
+
+**Status:** recorded, NOT actioned. Needs a dedicated investigation with
+before/after numbers.
+
+**Severity:** P1 architectural. It does not produce a visibly wrong
+answer the way F-3 did, so it is not urgent — but it means the
+arbitrage engine's core comparison is not the comparison the project
+believes it is making.
+
+**Do not fold this into a "while we're here" change.** It moves every
+number `/api/trade/finder` emits.
+
+---
+
+## The claim
+
+CLAUDE.md states, of the live value pipeline:
+
+> The live ``/api/data`` contract is produced by
+> ``src/api/data_contract.py::_compute_unified_rankings`` — the one and
+> only code path that determines live player values ("Final Framework").
+
+`src/trade/finder.py` does not use it.
+
+## Evidence
+
+Two engines, two different value sources:
+
+| Engine | Reads | Which is |
+|---|---|---|
+| `src/trade/suggestions.py:456` | `row["rankDerivedValue"]` from `playersArray` | Final Framework output — Hill curves, count-aware blend, IDP calibration, pick tethering, **and** the 0.30 single-source retention |
+| `src/trade/finder.py:275` | `players[name]["_finalAdjusted"]` | the raw scraper composite |
+
+The `players` dict `finder.py` receives is a verbatim deep copy of the
+raw scrape. `src/api/data_contract.py:8004-8022`:
+
+```python
+src_payload = raw_payload or {}
+src_players = src_payload.get("players") ...
+    # per-key shallow copy, no value recomputation
+base["players"] = players_by_name
+```
+
+and `_finalAdjusted` is set in `Dynasty Scraper.py:6943-6947`:
+
+```python
+raw_comp = pdata.get("_composite")
+pdata["_rawComposite"] = int(round(raw_comp))
+pdata["_finalAdjusted"] = int(round(raw_comp))
+```
+
+`_compute_unified_rankings` writes its blended values onto
+`playersArray[...]["rankDerivedValue"]` (and applies the single-source
+retention at `data_contract.py:6915-6920`). It never writes back into
+the `players` dict. So none of the Final Framework reaches `finder.py`.
+
+`server.py:4948` confirms the endpoint passes that dict straight
+through:
+
+```python
+players = latest_contract_data.get("players")
+```
+
+## Why it matters
+
+The finder's premise is *board arbitrage*: our board says one thing,
+the retail market says another, trade into the gap. If "our board" is
+the raw scraper composite rather than the board the rest of the product
+serves, then:
+
+1. **The arbitrage is measured against the wrong baseline.** The values
+   the user sees on `/rankings` and in the player popup are
+   `rankDerivedValue`. The finder is arbitraging a board the user never
+   sees, then presenting the result as an edge on ours.
+2. **Every Final Framework correction is invisible here** — scope-aware
+   Hill routing, hierarchical anchoring + α-shrinkage, the IDP
+   calibration post-pass, the market corridor clamp, pick tethering and
+   the future-year pick discount. Pick values in particular are
+   tethered downstream of the scraper, so the finder is likely pricing
+   picks on an untethered number.
+3. **It forces a compensating local constant.** `SINGLE_SOURCE_DISCOUNT
+   = 0.88` exists in `finder.py` only because the 0.30 retention never
+   reaches it. Its comment claimed it "matched the frontend"; the
+   frontend applies no single-source haircut today, so the constant is
+   now unanchored and unvalidated. It is load-bearing anyway — see the
+   correction note below.
+
+## Correction to the original F-6
+
+The first version of this finding claimed a **double** single-source
+haircut: 0.88 stacked on 0.30 for ~0.264 effective. That was wrong.
+The two discounts sit on two different pipelines, not stacked on one.
+The "obvious" remediation — delete finder's 0.88 — would have left
+single-source assets **undiscounted** in the arbitrage finder,
+introducing a live value distortion via a fix.
+
+`SINGLE_SOURCE_DISCOUNT` is therefore retained and pinned by
+`tests/test_trade_finder.py::TestSingleSourceDiscount`. It should be
+deleted only as part of the migration below, when the retention it
+substitutes for actually arrives with the values.
+
+## Proposed fix (not implemented)
+
+Move `finder.py` onto the contract's blended values — read
+`playersArray` / `rankDerivedValue` the way
+`suggestions.py::build_asset_pool_from_contract` already does — and
+delete `SINGLE_SOURCE_DISCOUNT` in the same change, since the retention
+comes baked in.
+
+This is not a mechanical swap. Required first:
+
+- **Before/after evidence.** Every arbitrage score, ranking and
+  threshold interaction changes. `MIN_ASSET_VALUE`, `MAX_BOARD_LOSS`,
+  `JUNK_THRESHOLD`, `ELITE_THRESHOLD` and `MULTI_FOR_ONE_MIN_RATIO`
+  were all tuned against composite-scale numbers and will need
+  re-derivation, not just re-testing.
+- **Confirm the two scales are comparable at all.** If the composite
+  and `rankDerivedValue` differ materially in shape, the thresholds
+  above are not portable and the change is a recalibration, not a
+  migration.
+- **A decision on picks.** The contract tethers current-year slot picks
+  to the merged rookie pool and applies a multiplicative future-year
+  discount. The composite does neither. Pick-inclusive trades will move
+  the most.
+
+## Scope note
+
+Found while verifying the P2 haircut item on
+`claude/ws-j-trade-engine-fixes`. Deliberately left unactioned there:
+that branch carries independently-verifiable P1 fixes (F-3 per-market
+gate, F-4/F-5 naming and vacuous checks) and folding a valuation-path
+change in would make the diff unreviewable.

--- a/src/trade/faab_contention.py
+++ b/src/trade/faab_contention.py
@@ -275,14 +275,14 @@ def need_level_for(
 def build_opponent_asset_pool(contract: dict[str, Any]) -> list[Any]:
     """UNFILTERED asset pool for opponent roster analysis.
 
-    ``build_asset_pool_from_contract`` defaults to the KTC top-150
+    ``build_asset_pool_from_contract`` defaults to the blended-board top-150
     quality gate — correct for trade suggestions, wrong here: an
     opponent's depth chart is mostly outside the top 150, and a
     truncated pool would misread every roster as all-need.
     """
     from src.trade.suggestions import build_asset_pool_from_contract  # noqa: PLC0415
 
-    return build_asset_pool_from_contract(contract, ktc_top_n=0)
+    return build_asset_pool_from_contract(contract, board_top_n=0)
 
 
 def player_position_map(contract: dict[str, Any] | None) -> dict[str, str]:

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -520,9 +520,9 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     # KTC scoring
     give_market_assets = [a for a in give if a.has_market]
     recv_market_assets = [a for a in receive if a.has_market]
-    all_have_market = len(give_market_assets) == len(give) and len(
-        recv_market_assets
-    ) == len(receive)
+    all_have_market = len(give_market_assets) == len(give) and len(recv_market_assets) == len(
+        receive
+    )
     any_have_market = bool(give_market_assets) or bool(recv_market_assets)
 
     # Partial coverage is reachable only when the per-market top-N gate

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -27,7 +27,35 @@ MAX_BOARD_LOSS = -200  # Never suggest a trade where my board delta is worse tha
 MAX_PACKAGE_SIZE = 3  # Max assets on either side
 MAX_RESULTS = 40  # Cap returned results
 JUNK_THRESHOLD = 400  # Assets below this are roster clog
-SINGLE_SOURCE_DISCOUNT = 0.88  # Match frontend: 12% haircut for single-source assets
+# Single-source haircut.  KEEP THIS — it is the only such discount on
+# this engine's input path.
+#
+# WS-J F-6 originally reported this as a double-discount stacked on the
+# pipeline's 0.30 single-source retention (``_SINGLE_SOURCE_VALUE_RETENTION``
+# in ``data_contract.py``), giving ~0.264 effective.  That was WRONG, and
+# the correction matters because the "obvious" fix would have removed the
+# only haircut this engine has:
+#
+#   suggestions.py reads ``playersArray[...]["rankDerivedValue"]`` — the
+#     Final Framework output, which HAS had the 0.30 retention applied.
+#     It therefore correctly applies no further discount.
+#   finder.py reads ``players[name]["_finalAdjusted"]`` — which
+#     ``data_contract.py`` deep-copies verbatim from the raw scrape
+#     (``base["players"] = players_by_name``), and which
+#     ``Dynasty Scraper.py`` sets straight from ``_composite``.  The
+#     0.30 retention never touches it.
+#
+# So the two haircuts are applied to two different value pipelines, not
+# stacked on one.  Removing this constant would leave single-source
+# assets undiscounted in the arbitrage finder.
+#
+# The old comment claimed this "matched the frontend"; the frontend no
+# longer applies any single-source haircut, so that anchor is gone and
+# the 0.88 is now an unvalidated local constant.  Tracked as the real
+# F-6: finder.py should move onto the Final Framework values that
+# CLAUDE.md calls the single source of truth for live player values,
+# at which point this discount is deleted rather than retuned.
+SINGLE_SOURCE_DISCOUNT = 0.88
 MULTI_FOR_ONE_MIN_RATIO = 0.55  # 2-for-1 give side must be >= 55% of receive model value
 
 # ── Market quality gates ───────────────────────────────────────────────

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -21,7 +21,8 @@ from src.utils.name_clean import normalize_position as _norm_pos  # noqa: F401 �
 
 # ── Thresholds ──────────────────────────────────────────────────────────
 MIN_ASSET_VALUE = 800  # Minimum model value to consider an asset tradeable
-MIN_KTC_VALUE = 500  # Minimum KTC value to include in trade
+MIN_MARKET_VALUE = 500  # Minimum retail market value to include in trade
+MIN_KTC_VALUE = MIN_MARKET_VALUE  # Deprecated alias
 MAX_BOARD_LOSS = -200  # Never suggest a trade where my board delta is worse than this
 MAX_PACKAGE_SIZE = 3  # Max assets on either side
 MAX_RESULTS = 40  # Cap returned results
@@ -29,15 +30,52 @@ JUNK_THRESHOLD = 400  # Assets below this are roster clog
 SINGLE_SOURCE_DISCOUNT = 0.88  # Match frontend: 12% haircut for single-source assets
 MULTI_FOR_ONE_MIN_RATIO = 0.55  # 2-for-1 give side must be >= 55% of receive model value
 
-# ── KTC quality gates ──────────────────────────────────────────────────
-EXCLUDED_POSITIONS = {"K", "PK", "DST", "DEF"}  # No real KTC support
-PARTIAL_KTC_MAX_RANK = 15  # Partial-KTC trades cannot appear above this rank
-PARTIAL_KTC_ARBITRAGE_CAP = 8.0  # Hard ceiling on partial-KTC arbitrage score
+# ── Market quality gates ───────────────────────────────────────────────
+EXCLUDED_POSITIONS = {"K", "PK", "DST", "DEF"}  # No real market support
+PARTIAL_MARKET_MAX_RANK = 15  # Partial-coverage trades cannot appear above this rank
+PARTIAL_MARKET_ARBITRAGE_CAP = 8.0  # Hard ceiling on partial-coverage arbitrage score
 
-# ── KTC quality gate ──────────────────────────────────────────────────
-# Hard filter: only players ranked inside the KTC top-N are eligible.
-# Set to 0 to disable.
-KTC_TOP_N_FILTER = 150
+# Deprecated aliases — kept so external callers/tests importing the old
+# names keep working.  Remove once no caller references them.
+PARTIAL_KTC_MAX_RANK = PARTIAL_MARKET_MAX_RANK
+PARTIAL_KTC_ARBITRAGE_CAP = PARTIAL_MARKET_ARBITRAGE_CAP
+
+# ── Per-market quality gate ────────────────────────────────────────────
+# Hard filter: only assets ranked inside the top-N **of their own
+# market** are eligible.  Set to 0 to disable.
+#
+# WS-J F-3: this used to rank every asset against KTC and keep the top
+# N.  KTC publishes no IDP players at all — I verified that none of
+# Hutchinson / Parsons / Garrett / Carter / Verse / Campbell appear on
+# its 500-row board — so every defender scored ``ktc_value = None`` and
+# was silently dropped.  In a league with nine IDP starters the engine
+# returned offense-only results and reported ``ktcTopNFilter: 150`` as
+# though a uniform gate had run.
+#
+# The fix anchors each asset on the market its counterparty would
+# actually consult and ranks it against that market's own population:
+#
+#   offense + picks → ``ktcSfTep`` (fallback legacy ``ktc``)
+#   IDP             → ``idpTradeCalc``
+#
+# This mirrors ``angle.py::_market_source_for``, which has routed
+# per-player market values correctly since it was written.
+#
+# Summing the two markets in the opponent-appeal arithmetic is sound:
+# IDPTradeCalc is a full-roster calculator publishing offense, IDP and
+# picks on ONE native 0-9999 scale, and its offensive half is
+# empirically interchangeable with KTC's — of KTC's 500 rows, 475 also
+# appear on the IDPTC board with a median value ratio of 1.000
+# (p10 0.888, p90 1.054, measured 2026-07-26).  Both boards top out at
+# 9999, so there is no rescaling to apply between them.
+MARKET_TOP_N_FILTER = 150
+
+# Deprecated alias — the gate is per-market now, not KTC-only.
+KTC_TOP_N_FILTER = MARKET_TOP_N_FILTER
+
+# Canonical site keys per market, in preference order.
+OFFENSE_MARKET_KEYS = ("ktcSfTep", "ktc")
+IDP_MARKET_KEYS = ("idpTradeCalc",)
 
 # ── Hardening-pass thresholds ────────────────────────────────────────────
 ELITE_THRESHOLD = 7500  # Model value above which a player is "elite"
@@ -52,21 +90,43 @@ IDP_POSITIONS = {"DL", "LB", "DB"}
 
 @dataclass
 class Asset:
-    """A tradeable asset with both model and KTC values."""
+    """A tradeable asset with our model value and its retail market value.
+
+    ``market_value`` is the value the counterparty would see on the
+    board they actually consult: KTC for offense and picks, IDPTradeCalc
+    for IDP.  ``market_source`` records which board was read so the UI
+    and the metadata can be honest about it.
+    """
 
     name: str
     position: str
     team: str
-    model_value: int  # Our board's value (with single-source discount)
-    ktc_value: int | None  # KTC value (None = no KTC coverage)
+    model_value: int  # Our board's value
+    market_value: int | None  # Retail market value (None = no coverage)
     is_pick: bool = False
     source_count: int = 0  # Number of valuation sources
-    ktc_rank: int | None = None  # 1-based KTC rank (None = no KTC data)
+    market_rank: int | None = None  # 1-based rank WITHIN this asset's market
     offense_only_model_value: int | None = None  # model_value excluding IDP sources
+    market_source: str | None = None  # "ktcSfTep" | "ktc" | "idpTradeCalc"
+
+    @property
+    def has_market(self) -> bool:
+        return self.market_value is not None and self.market_value > 0
+
+    # ── Deprecated aliases ───────────────────────────────────────────
+    # Pre-WS-J these were named ``ktc_*`` even for IDP assets, which was
+    # only ever accurate because IDP assets never survived the gate.
+    @property
+    def ktc_value(self) -> int | None:
+        return self.market_value
+
+    @property
+    def ktc_rank(self) -> int | None:
+        return self.market_rank
 
     @property
     def has_ktc(self) -> bool:
-        return self.ktc_value is not None and self.ktc_value > 0
+        return self.has_market
 
 
 # Local ``_norm_pos`` was a thin wrapper around ``POSITION_ALIASES``;
@@ -189,15 +249,24 @@ def _build_summary(
 def build_asset_pool(
     players: dict[str, Any],
     *,
-    ktc_top_n: int = KTC_TOP_N_FILTER,
+    market_top_n: int | None = None,
+    ktc_top_n: int | None = None,
 ) -> list[Asset]:
-    """Convert raw players dict into Asset objects with model + KTC values.
+    """Convert raw players dict into Asset objects with model + market values.
+
+    Each asset is anchored on the retail board its counterparty would
+    actually consult — KTC for offense and picks, IDPTradeCalc for IDP —
+    and ranked against that market's own population.  See
+    :data:`MARKET_TOP_N_FILTER` for why the gate is per-market.
 
     Args:
         players: Raw players dict from the live data payload.
-        ktc_top_n: Only include players ranked inside the KTC top N.
-            Ranking is based on KTC value (descending). Set to 0 to disable.
+        market_top_n: Only include assets ranked inside the top N **of
+            their own market**. Set to 0 to disable.
+        ktc_top_n: Deprecated alias for ``market_top_n``.
     """
+    if market_top_n is None:
+        market_top_n = MARKET_TOP_N_FILTER if ktc_top_n is None else ktc_top_n
     pool: list[Asset] = []
     for name, pdata in players.items():
         if not isinstance(pdata, dict):
@@ -225,23 +294,28 @@ def build_asset_pool(
             if oo_raw is not None and oo_raw >= 1:
                 oo_raw = int(oo_raw * SINGLE_SOURCE_DISCOUNT)
 
-        # KTC value from canonical site values.  Prefer the TE+ board
-        # (``ktcSfTep``) — that's the canonical KTC retail signal as of
-        # 2026-04-28 when standard ``ktc`` was retired from the blend.
-        # Fall back to standard ``ktc`` for compatibility with tests
-        # whose fixtures predate the supersession.
-        csv = pdata.get("_canonicalSiteValues")
-        ktc: int | None = None
-        if isinstance(csv, dict):
-            ktc = _int_or_none(csv.get("ktcSfTep"))
-            if ktc is None:
-                ktc = _int_or_none(csv.get("ktc"))
-        if ktc is None:
-            ktc = _int_or_none(pdata.get("ktcSfTep"))
-            if ktc is None:
-                ktc = _int_or_none(pdata.get("ktc"))
-
         pos = _norm_pos(pdata.get("position", ""))
+
+        # Retail market value, read from the board the counterparty
+        # would actually consult for this position (WS-J F-3).  IDP
+        # rows read IDPTradeCalc; everything else reads KTC's TE+ board
+        # (``ktcSfTep``), the canonical KTC retail signal as of
+        # 2026-04-28 when standard ``ktc`` was retired from the blend,
+        # falling back to standard ``ktc`` for fixtures that predate
+        # the supersession.
+        market_keys = IDP_MARKET_KEYS if pos in IDP_POSITIONS else OFFENSE_MARKET_KEYS
+        csv = pdata.get("_canonicalSiteValues")
+        market_value: int | None = None
+        market_source: str | None = None
+        for key in market_keys:
+            if isinstance(csv, dict):
+                market_value = _int_or_none(csv.get(key))
+            if market_value is None:
+                market_value = _int_or_none(pdata.get(key))
+            if market_value is not None:
+                market_source = key
+                break
+
         team = pdata.get("team", "") or ""
         is_pick = bool(
             pos == "PICK"
@@ -262,24 +336,41 @@ def build_asset_pool(
                 position=pos,
                 team=team if isinstance(team, str) else "",
                 model_value=model,
-                ktc_value=ktc,
+                market_value=market_value,
                 is_pick=is_pick,
                 source_count=source_count,
                 offense_only_model_value=oo_raw if oo_raw is not None and oo_raw >= 1 else None,
+                market_source=market_source,
             )
         )
 
-    # ── Assign KTC rank and apply top-N filter ────────────────────
-    # Rank by KTC value descending.  Players without KTC get no rank.
-    with_ktc = [a for a in pool if a.has_ktc]
-    with_ktc.sort(key=lambda a: -(a.ktc_value or 0))
-    for i, a in enumerate(with_ktc):
-        a.ktc_rank = i + 1
+    # ── Rank within each market, then apply the top-N cut per market ──
+    # Ranking every asset in one list would bury IDP entirely: offense
+    # runs to 9999 while the best defender sits near 6400, so a single
+    # global top-150 removes every IDP player (WS-J F-3).  Each market
+    # ranks its own population from 1.
+    by_market: dict[str, list[Asset]] = {}
+    for a in pool:
+        if not a.has_market or a.market_source is None:
+            continue
+        by_market.setdefault(a.market_source, []).append(a)
 
-    if ktc_top_n > 0:
-        eligible_names = {
-            a.name for a in with_ktc if a.ktc_rank is not None and a.ktc_rank <= ktc_top_n
-        }
+    # ``ktcSfTep`` and legacy ``ktc`` are the same board — rank them as
+    # one population so a fixture mixing both doesn't split the cut.
+    offense_assets = [a for key in OFFENSE_MARKET_KEYS for a in by_market.get(key, [])]
+    market_groups: dict[str, list[Asset]] = {"offense": offense_assets}
+    for key in IDP_MARKET_KEYS:
+        market_groups.setdefault("idp", []).extend(by_market.get(key, []))
+
+    eligible_names: set[str] = set()
+    for group in market_groups.values():
+        group.sort(key=lambda a: -(a.market_value or 0))
+        for i, a in enumerate(group):
+            a.market_rank = i + 1
+        if market_top_n > 0:
+            eligible_names.update(a.name for a in group if a.market_rank <= market_top_n)
+
+    if market_top_n > 0:
         pool = [a for a in pool if a.name in eligible_names]
 
     return pool
@@ -331,28 +422,31 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     if give_names & receive_names:
         return None
 
-    # ── Outgoing KTC gate ────────────────────────────────────────────
-    # Every outgoing asset MUST have a usable KTC value.  Without it we
-    # cannot prove the deal looks plausible to the opponent, so offering
-    # a no-KTC player for an elite return is nonsense.
+    # ── Outgoing market gate ─────────────────────────────────────────
+    # Every outgoing asset MUST have a usable market value on its own
+    # board.  Without it we cannot prove the deal looks plausible to the
+    # opponent, so offering an unpriced player for an elite return is
+    # nonsense.
     for a in give:
-        if not a.has_ktc or a.ktc_value < MIN_KTC_VALUE:  # type: ignore[operator]
+        if not a.has_market or a.market_value < MIN_MARKET_VALUE:  # type: ignore[operator]
             return None
 
-    # ── Receive-side KTC gate ─────────────────────────────────────────
-    # At least one receive asset must have KTC so the opponent-appeal
-    # calculation is grounded in real market data.
-    recv_ktc_count = sum(1 for a in receive if a.has_ktc)
-    if recv_ktc_count == 0:
+    # ── Receive-side market gate ──────────────────────────────────────
+    # At least one receive asset must carry a market value so the
+    # opponent-appeal calculation is grounded in real market data.
+    if not any(a.has_market for a in receive):
         return None
 
-    # ── IDP dilution guard ────────────────────────────────────────────
-    # IDP assets without KTC must not constitute the majority of either
-    # side — they distort the KTC-based opponent appeal calculation.
-    for side, label in [(give, "give"), (receive, "receive")]:
-        idp_no_ktc = [a for a in side if a.position in IDP_POSITIONS and not a.has_ktc]
-        if len(idp_no_ktc) > 0 and len(idp_no_ktc) >= len(side) / 2:
-            return None
+    # NOTE (WS-J F-3): an "IDP dilution guard" used to sit here,
+    # rejecting any side where IDP assets *without KTC* were half or
+    # more of the package, on the grounds that they distorted the
+    # KTC-based appeal calculation.  Its premise no longer exists: IDP
+    # assets are now anchored on IDPTradeCalc, so they carry a real
+    # market value like any other asset and distort nothing.  The guard
+    # was also unreachable in production — the KTC-only top-N filter had
+    # already removed every IDP asset before scoring ran — so it was
+    # documenting a world the filter had deleted.  Removed rather than
+    # left as dead code.
 
     # Use offense-only model values when neither side has IDP players.
     # This excludes IDP source calibration from trade scoring so that
@@ -396,28 +490,33 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
         flags.append("anchor_verified")
 
     # KTC scoring
-    give_ktc_assets = [a for a in give if a.has_ktc]
-    recv_ktc_assets = [a for a in receive if a.has_ktc]
-    all_have_ktc = len(give_ktc_assets) == len(give) and len(recv_ktc_assets) == len(receive)
-    any_have_ktc = bool(give_ktc_assets) or bool(recv_ktc_assets)
+    give_market_assets = [a for a in give if a.has_market]
+    recv_market_assets = [a for a in receive if a.has_market]
+    all_have_market = len(give_market_assets) == len(give) and len(
+        recv_market_assets
+    ) == len(receive)
+    any_have_market = bool(give_market_assets) or bool(recv_market_assets)
 
-    if not any_have_ktc:
-        # No KTC on either side — cannot evaluate opponent plausibility at all
+    # Partial coverage is reachable only when the per-market top-N gate
+    # is disabled (``market_top_n=0``); with the gate on, every pooled
+    # asset carries a market value by construction.
+    if not any_have_market:
+        # No market data on either side — cannot evaluate plausibility
         return None
-    elif all_have_ktc:
+    elif all_have_market:
         coverage = "full"
-        give_ktc = sum(a.ktc_value for a in give)  # type: ignore[arg-type]
-        recv_ktc = sum(a.ktc_value for a in receive)  # type: ignore[arg-type]
+        give_ktc = sum(a.market_value for a in give)  # type: ignore[arg-type]
+        recv_ktc = sum(a.market_value for a in receive)  # type: ignore[arg-type]
         # Opponent gives recv_ktc to get give_ktc back
         # Opponent appeal = (what they get - what they give) / what they give
         opp_appeal = (give_ktc - recv_ktc) / max(recv_ktc, 1)
-        flags.append("full_ktc")
+        flags.append("full_market")
     else:
         coverage = "partial"
-        give_ktc = sum(a.ktc_value or 0 for a in give)
-        recv_ktc = sum(a.ktc_value or 0 for a in receive)
+        give_ktc = sum(a.market_value or 0 for a in give)
+        recv_ktc = sum(a.market_value or 0 for a in receive)
         opp_appeal = (give_ktc - recv_ktc) / max(recv_ktc, 1) if recv_ktc > 0 else 0.0
-        flags.append("partial_ktc")
+        flags.append("partial_market")
 
     # The opponent must STRICTLY WIN on KTC — no break-even, no loss.
     if opp_appeal <= 0:
@@ -444,7 +543,7 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     # Partial coverage: severe demotion — these cannot compete with full-KTC trades
     if coverage == "partial":
         arbitrage *= 0.3
-        arbitrage = min(arbitrage, PARTIAL_KTC_ARBITRAGE_CAP)
+        arbitrage = min(arbitrage, PARTIAL_MARKET_ARBITRAGE_CAP)
 
     # ── Confidence factor (source coverage × KTC coverage) ───────────
     all_assets = give + receive
@@ -600,7 +699,8 @@ def find_trades(
     sleeper_teams: list[dict[str, Any]],
     *,
     max_results: int = MAX_RESULTS,
-    ktc_top_n: int = KTC_TOP_N_FILTER,
+    market_top_n: int | None = None,
+    ktc_top_n: int | None = None,
 ) -> dict[str, Any]:
     """
     Find board-arbitrage trades.
@@ -624,7 +724,9 @@ def find_trades(
     -------
     dict with trades, metadata, and any warnings.
     """
-    pool = build_asset_pool(players, ktc_top_n=ktc_top_n)
+    if market_top_n is None:
+        market_top_n = MARKET_TOP_N_FILTER if ktc_top_n is None else ktc_top_n
+    pool = build_asset_pool(players, market_top_n=market_top_n)
     pool_by_name: dict[str, Asset] = {}
     for a in pool:
         pool_by_name[a.name] = a
@@ -642,13 +744,35 @@ def find_trades(
     opponents_analyzed = 0
     warnings: list[str] = []
 
-    # Track KTC coverage
-    ktc_coverage_count = sum(1 for a in pool if a.has_ktc)
-    ktc_coverage_pct = ktc_coverage_count / max(len(pool), 1)
-    if ktc_coverage_pct < 0.5:
+    # Track market coverage, per market.  Reporting one blended number
+    # hid the offense-only regression (WS-J F-3): a pool with zero IDP
+    # assets still showed 100% coverage because the missing rows had
+    # already been filtered out upstream.
+    market_coverage: dict[str, int] = {key: 0 for key in (*OFFENSE_MARKET_KEYS, *IDP_MARKET_KEYS)}
+    for a in pool:
+        if a.has_market and a.market_source:
+            market_coverage[a.market_source] = market_coverage.get(a.market_source, 0) + 1
+
+    market_coverage_count = sum(1 for a in pool if a.has_market)
+    market_coverage_pct = market_coverage_count / max(len(pool), 1)
+    if market_coverage_pct < 0.5:
         warnings.append(
-            f"KTC coverage is low ({ktc_coverage_pct:.0%} of assets). "
-            "Some trades may have partial or no KTC scoring."
+            f"Market coverage is low ({market_coverage_pct:.0%} of assets). "
+            "Some trades may have partial or no market scoring."
+        )
+
+    # An IDP league whose pool contains no priced IDP assets is the
+    # exact failure this engine used to hit silently.  Say so.
+    league_has_idp = any(
+        _norm_pos(str((p or {}).get("position", ""))) in IDP_POSITIONS
+        for p in players.values()
+        if isinstance(p, dict)
+    )
+    idp_priced = sum(market_coverage.get(key, 0) for key in IDP_MARKET_KEYS)
+    if league_has_idp and idp_priced == 0:
+        warnings.append(
+            "No IDP asset carries an IDPTradeCalc value, so this result is "
+            "offense-only. IDP trades cannot be evaluated without IDP market data."
         )
 
     for opp_name in opponent_teams:
@@ -703,17 +827,18 @@ def find_trades(
     # Keep only positive-arbitrage trades with positive board delta
     ranked = [t for t in all_trades if t.arbitrage_score > 0 and t.board_delta > 0]
 
-    # ── Enforce full-KTC priority in top results ─────────────────────
-    # Partial-KTC trades are pushed below PARTIAL_KTC_MAX_RANK so
-    # premium recommendation slots are reserved for trustworthy trades.
-    full_ktc = [t for t in ranked if t.ktc_coverage == "full"]
-    partial_ktc = [t for t in ranked if t.ktc_coverage != "full"]
-    if len(full_ktc) >= PARTIAL_KTC_MAX_RANK:
-        # Enough full-KTC trades to fill top slots — append partials after
-        ranked = full_ktc + partial_ktc
-    else:
-        # Not enough full-KTC — partials fill remaining slots after the full ones
-        ranked = full_ktc + partial_ktc
+    # ── Enforce full-coverage priority in top results ────────────────
+    # Partial-coverage trades sort after every full-coverage trade so
+    # premium recommendation slots stay with trustworthy ones.
+    #
+    # WS-J F-7: this was an if/else whose two branches were byte
+    # identical (both ``full + partial``), gated on
+    # ``len(full) >= PARTIAL_MARKET_MAX_RANK`` — a condition that could
+    # not change the outcome.  Collapsed to the single expression both
+    # arms already computed.
+    full_cov = [t for t in ranked if t.ktc_coverage == "full"]
+    partial_cov = [t for t in ranked if t.ktc_coverage != "full"]
+    ranked = full_cov + partial_cov
 
     capped = ranked[:max_results]
 
@@ -728,8 +853,12 @@ def find_trades(
             "totalQualified": len(ranked),
             "returned": len(capped),
             "assetPoolSize": len(pool),
-            "ktcTopNFilter": ktc_top_n,
-            "ktcCoveragePercent": round(ktc_coverage_pct * 100, 1),
+            "marketTopNFilter": market_top_n,
+            "marketCoverage": market_coverage,
+            "marketCoveragePercent": round(market_coverage_pct * 100, 1),
+            # Deprecated aliases — the gate is per-market now.
+            "ktcTopNFilter": market_top_n,
+            "ktcCoveragePercent": round(market_coverage_pct * 100, 1),
         },
         "warnings": warnings,
     }

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -579,13 +579,19 @@ def _apply_board_top_n_filter(
     outside the threshold are excluded from suggestions as primary
     targets, secondary targets, value fillers, and throw-ins.
 
+    Precondition: ``pool`` has been through :func:`_assign_board_ranks`,
+    so every player carries an int rank.  Passing an unranked pool is a
+    caller bug and raises ``TypeError`` rather than silently filtering
+    everything out.
+
     WS-J F-5: the predicate used to be
     ``p.ktc_rank is not None and p.ktc_rank <= top_n``.  The null check
     could never be False — ``_assign_board_ranks`` assigns an int to
     every player — so it was a vacuous guard implying a null case that
-    does not exist.  Dropped.
+    does not exist, and it would have turned a caller bug into an
+    empty result set.  Dropped in favour of the stated precondition.
     """
-    return [p for p in pool if p.board_rank is not None and p.board_rank <= top_n]
+    return [p for p in pool if p.board_rank <= top_n]  # type: ignore[operator]
 
 
 # Deprecated alias.

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -102,12 +102,39 @@ MAX_GAP_FOR_1FOR1 = 400
 HIGH_DISPERSION_CV = 0.12  # CV above this = sources disagree meaningfully
 LOW_DISPERSION_CV = 0.04  # CV below this = strong consensus
 
-# ── KTC quality gate ────────────────────────────────────────────────
-# Hard filter: only players ranked inside the KTC top-N are eligible for
-# trade suggestions.  Players outside this threshold are excluded as
-# targets, give-side pieces, throw-ins, and balancers.
-# Set to 0 to disable.
-KTC_TOP_N_FILTER = 150
+# ── Board quality gate ──────────────────────────────────────────────
+# Hard filter: only players ranked inside the top-N of OUR OWN blended
+# board are eligible for trade suggestions.  Players outside this
+# threshold are excluded as targets, give-side pieces, throw-ins, and
+# balancers.  Set to 0 to disable.
+#
+# WS-J F-4: this was called ``KTC_TOP_N_FILTER`` and its helper was
+# called ``_assign_ktc_ranks``, but no KTC value was ever read here.
+# ``_assign_board_ranks`` enumerates the pool after it has been sorted
+# by ``display_value``, so the rank has always been our blended-board
+# rank.  The docstring additionally claimed "players without KTC data
+# get ktc_rank=None", which never happened — every player got an int.
+#
+# The gate itself is sound and is deliberately NOT unified with
+# ``finder.py``'s.  The two engines ask different questions:
+#
+#   finder.py      finds arbitrage between our board and the retail
+#                  market, so it MUST anchor on a real market value
+#                  (KTC for offense, IDPTradeCalc for IDP) — the
+#                  market number is load-bearing in its arithmetic.
+#   suggestions.py filters for asset QUALITY ("don't propose trading
+#                  roster clog"), which our own blended board answers
+#                  directly and for every asset class, including IDP
+#                  and picks that no single retail board covers.
+#
+# Sharing one definition would force this engine to depend on retail
+# coverage it does not need, and would reintroduce the offense-only
+# blind spot F-3 just removed.  So: renamed to say what it does, not
+# merged.
+BOARD_TOP_N_FILTER = 150
+
+# Deprecated alias — this gate never consulted KTC.
+KTC_TOP_N_FILTER = BOARD_TOP_N_FILTER
 
 
 # ── Data structures ─────────────────────────────────────────────────
@@ -129,8 +156,13 @@ class PlayerAsset:
     years_exp: int | None = None
     universe: str = ""
     dispersion_cv: float | None = None
-    ktc_rank: int | None = None  # 1-based KTC rank (None = no KTC data)
+    board_rank: int | None = None  # 1-based rank on OUR blended board
     offense_only_value: int | None = None  # display_value excluding IDP sources
+
+    @property
+    def ktc_rank(self) -> int | None:
+        """Deprecated alias — this was never a KTC rank (WS-J F-4)."""
+        return self.board_rank
 
 
 @dataclass
@@ -234,7 +266,8 @@ def _edge_for_suggestion(s: TradeSuggestion) -> tuple[str | None, str | None]:
 def build_asset_pool(
     asset_dict_payload: dict[str, Any],
     *,
-    ktc_top_n: int = KTC_TOP_N_FILTER,
+    board_top_n: int | None = None,
+    ktc_top_n: int | None = None,
 ) -> list[PlayerAsset]:
     """Convert an asset-dict payload into ``PlayerAsset`` objects.
 
@@ -249,9 +282,13 @@ def build_asset_pool(
             entry has ``display_name``, ``calibrated_value``,
             ``display_value`` (optional), ``metadata`` (position/team/
             rookie/years_exp), ``source_values``, and ``universe``.
-        ktc_top_n: Only include players ranked inside the KTC top N.
-            Set to 0 to disable the filter.
+        board_top_n: Only include players ranked inside the top N of
+            our blended board. Set to 0 to disable the filter.
+        ktc_top_n: Deprecated alias for ``board_top_n`` — this gate
+            never consulted KTC (WS-J F-4).
     """
+    if board_top_n is None:
+        board_top_n = BOARD_TOP_N_FILTER if ktc_top_n is None else ktc_top_n
     assets = asset_dict_payload.get("assets", [])
     pool: list[PlayerAsset] = []
     for a in assets:
@@ -292,10 +329,10 @@ def build_asset_pool(
         )
     pool.sort(key=lambda x: -x.display_value)
 
-    # ── Compute KTC rank and apply top-N filter ────────────────────
-    pool = _assign_ktc_ranks(pool)
-    if ktc_top_n > 0:
-        pool = _apply_ktc_top_n_filter(pool, ktc_top_n)
+    # ── Compute blended-board rank and apply the top-N filter ──────
+    pool = _assign_board_ranks(pool)
+    if board_top_n > 0:
+        pool = _apply_board_top_n_filter(pool, board_top_n)
 
     return pool
 
@@ -350,7 +387,8 @@ def _effective_source_keys(
 def build_asset_pool_from_contract(
     contract: dict[str, Any],
     *,
-    ktc_top_n: int = KTC_TOP_N_FILTER,
+    board_top_n: int | None = None,
+    ktc_top_n: int | None = None,
 ) -> list[PlayerAsset]:
     """Primary pool builder — maps the live contract ``playersArray``
     to ``PlayerAsset`` objects for the trade-suggestion engine.
@@ -394,7 +432,12 @@ def build_asset_pool_from_contract(
     readings ``marketGapDirection`` and ``confidenceBucket`` do.
     Legacy contracts without Hampel stamps fall back to the raw
     ``canonicalSiteValues`` set.
+
+    ``board_top_n`` gates on our blended board; ``ktc_top_n`` is a
+    deprecated alias, since this gate never consulted KTC (WS-J F-4).
     """
+    if board_top_n is None:
+        board_top_n = BOARD_TOP_N_FILTER if ktc_top_n is None else ktc_top_n
     players_array = contract.get("playersArray") or []
     legacy_players = contract.get("players") or {}
 
@@ -497,44 +540,56 @@ def build_asset_pool_from_contract(
         )
     pool.sort(key=lambda x: -x.display_value)
 
-    # ── Compute KTC rank and apply top-N filter ────────────────────
-    pool = _assign_ktc_ranks(pool)
-    if ktc_top_n > 0:
-        pool = _apply_ktc_top_n_filter(pool, ktc_top_n)
+    # ── Compute blended-board rank and apply the top-N filter ──────
+    pool = _assign_board_ranks(pool)
+    if board_top_n > 0:
+        pool = _apply_board_top_n_filter(pool, board_top_n)
 
     return pool
 
 
-def _assign_ktc_ranks(pool: list[PlayerAsset]) -> list[PlayerAsset]:
-    """Assign 1-based KTC rank to each player based on KTC source value.
+def _assign_board_ranks(pool: list[PlayerAsset]) -> list[PlayerAsset]:
+    """Assign each player its 1-based rank on OUR blended board.
 
-    Players without KTC data get ktc_rank=None.
-    Ties are broken by display_value (higher display value = better rank).
+    The caller sorts ``pool`` by ``display_value`` descending before
+    calling this, so rank ``i + 1`` IS the blended-board rank.  Every
+    player receives a rank; there is no null case.
+
+    WS-J F-4: this used to be ``_assign_ktc_ranks`` and claimed to rank
+    by KTC value, with players lacking KTC coverage getting ``None``.
+    Neither was true — no KTC value was read and no player ever got
+    ``None``.  Renamed to describe what it actually computes.
     """
-    # Extract KTC values from source dispersion data — the KTC source value
-    # is already baked into calibrated_value.  For KTC rank, we use the
-    # canonical display_value as a proxy for KTC ordering since the pipeline
-    # blends sources (KTC is typically the heaviest-weighted source).
-    # When a dedicated ktc_value is available on the asset, prefer that.
-    #
-    # The pool is already sorted by display_value descending, so we can
-    # assign ranks directly.
     for i, p in enumerate(pool):
-        p.ktc_rank = i + 1
+        p.board_rank = i + 1
     return pool
 
 
-def _apply_ktc_top_n_filter(
+# Deprecated alias.
+_assign_ktc_ranks = _assign_board_ranks
+
+
+def _apply_board_top_n_filter(
     pool: list[PlayerAsset],
     top_n: int,
 ) -> list[PlayerAsset]:
-    """Remove players ranked outside the KTC top N.
+    """Remove players ranked outside the top N of our blended board.
 
-    This is a hard quality filter — not a soft preference.
-    Players outside the threshold are excluded from suggestions as
-    primary targets, secondary targets, value fillers, and throw-ins.
+    This is a hard quality filter — not a soft preference.  Players
+    outside the threshold are excluded from suggestions as primary
+    targets, secondary targets, value fillers, and throw-ins.
+
+    WS-J F-5: the predicate used to be
+    ``p.ktc_rank is not None and p.ktc_rank <= top_n``.  The null check
+    could never be False — ``_assign_board_ranks`` assigns an int to
+    every player — so it was a vacuous guard implying a null case that
+    does not exist.  Dropped.
     """
-    return [p for p in pool if p.ktc_rank is not None and p.ktc_rank <= top_n]
+    return [p for p in pool if p.board_rank is not None and p.board_rank <= top_n]
+
+
+# Deprecated alias.
+_apply_ktc_top_n_filter = _apply_board_top_n_filter
 
 
 def analyze_roster(
@@ -1416,7 +1471,8 @@ def generate_suggestions_from_pool(
     starter_needs: dict[str, int] | None = None,
     max_per_type: int = MAX_SUGGESTIONS_PER_TYPE,
     league_rosters: list[dict[str, Any]] | None = None,
-    ktc_top_n: int = KTC_TOP_N_FILTER,
+    board_top_n: int | None = None,
+    ktc_top_n: int | None = None,
 ) -> dict[str, Any]:
     """Generate trade suggestions against a pre-built asset pool.
 
@@ -1426,11 +1482,13 @@ def generate_suggestions_from_pool(
     pool directly from the live contract via
     :func:`build_asset_pool_from_contract`.
 
-    ``ktc_top_n`` is informational-only here (reported in metadata) —
+    ``board_top_n`` is informational-only here (reported in metadata) —
     the pool is expected to have already had the top-N filter applied
-    by the caller.  Leaving the kwarg in the signature avoids
-    breaking existing consumers that pass it.
+    by the caller.  ``ktc_top_n`` is a deprecated alias; this gate
+    never consulted KTC (WS-J F-4).
     """
+    if board_top_n is None:
+        board_top_n = BOARD_TOP_N_FILTER if ktc_top_n is None else ktc_top_n
     # Pre-draft rookie suppression (Feb 1 - May 11): rookies in the
     # consensus board are placeholders during this window — the
     # class hasn't been drafted, fantasy values are speculative.
@@ -1516,7 +1574,9 @@ def generate_suggestions_from_pool(
         "totalSuggestions": len(all_suggestions),
         "metadata": {
             "assetPoolSize": len(pool),
-            "ktcTopNFilter": ktc_top_n,
+            "boardTopNFilter": board_top_n,
+            # Deprecated alias — this gate never consulted KTC.
+            "ktcTopNFilter": board_top_n,
             "rosterMatched": roster.roster_size,
             "rosterProvided": len(roster_names),
             "starterNeeds": starter_needs or DEFAULT_STARTER_NEEDS,
@@ -1533,7 +1593,8 @@ def generate_suggestions(
     starter_needs: dict[str, int] | None = None,
     max_per_type: int = MAX_SUGGESTIONS_PER_TYPE,
     league_rosters: list[dict[str, Any]] | None = None,
-    ktc_top_n: int = KTC_TOP_N_FILTER,
+    board_top_n: int | None = None,
+    ktc_top_n: int | None = None,
 ) -> dict[str, Any]:
     """Asset-dict entry point (legacy back-compat).
 
@@ -1542,15 +1603,20 @@ def generate_suggestions(
     uses :func:`generate_suggestions_from_pool` with a pool built
     directly from the live contract via
     :func:`build_asset_pool_from_contract`.
+
+    ``ktc_top_n`` is a deprecated alias for ``board_top_n``; this gate
+    never consulted KTC (WS-J F-4).
     """
-    pool = build_asset_pool(asset_dict_payload, ktc_top_n=ktc_top_n)
+    if board_top_n is None:
+        board_top_n = BOARD_TOP_N_FILTER if ktc_top_n is None else ktc_top_n
+    pool = build_asset_pool(asset_dict_payload, board_top_n=board_top_n)
     return generate_suggestions_from_pool(
         roster_names=roster_names,
         pool=pool,
         starter_needs=starter_needs,
         max_per_type=max_per_type,
         league_rosters=league_rosters,
-        ktc_top_n=ktc_top_n,
+        board_top_n=board_top_n,
     )
 
 
@@ -1572,8 +1638,10 @@ def _serialize_player(p: PlayerAsset, *, offense_only: bool = False) -> dict[str
     }
     if p.dispersion_cv is not None:
         result["dispersionCV"] = p.dispersion_cv
-    if p.ktc_rank is not None:
-        result["ktcRank"] = p.ktc_rank
+    if p.board_rank is not None:
+        result["boardRank"] = p.board_rank
+        # Deprecated alias — never a KTC rank (WS-J F-4).
+        result["ktcRank"] = p.board_rank
     return result
 
 

--- a/tests/test_trade_finder.py
+++ b/tests/test_trade_finder.py
@@ -24,6 +24,7 @@ from src.trade.finder import (
     _build_summary,
     EXCLUDED_POSITIONS,
     KTC_TOP_N_FILTER,
+    SINGLE_SOURCE_DISCOUNT,
 )
 
 
@@ -1732,3 +1733,38 @@ class TestPerMarketQualityGate:
         # in an IDP league is visible rather than silent.
         assert "marketCoverage" in meta
         assert set(meta["marketCoverage"]) >= {"ktcSfTep", "idpTradeCalc"}
+
+
+class TestSingleSourceDiscount:
+    """The single-source haircut must stay until finder.py moves onto
+    the Final Framework values.
+
+    WS-J F-6 (corrected): this was reported as a double-discount over
+    the pipeline's 0.30 single-source retention.  It is not.  The
+    pipeline haircut lands on ``rankDerivedValue``; this engine reads
+    ``_finalAdjusted``, which ``data_contract.py`` copies verbatim from
+    the raw scrape and which the retention never touches.  Removing the
+    discount here would leave single-source assets undiscounted.
+    """
+
+    def test_single_source_asset_is_discounted(self):
+        players = {
+            "OneSource": _make_player_data(10000, ktc=5000, pos="WR", sites=1),
+        }
+        pool = build_asset_pool(players, market_top_n=0)
+        assert pool[0].model_value == int(10000 * SINGLE_SOURCE_DISCOUNT)
+
+    def test_multi_source_asset_is_not_discounted(self):
+        players = {
+            "ManySources": _make_player_data(10000, ktc=5000, pos="WR", sites=5),
+        }
+        pool = build_asset_pool(players, market_top_n=0)
+        assert pool[0].model_value == 10000
+
+    def test_discount_applies_to_idp_on_the_same_terms(self):
+        """IDP now reaches the pool, so it must be discounted like offense."""
+        players = {
+            "OneSourceIdp": _make_idp_player_data(10000, idptc=5000, pos="LB", sites=1),
+        }
+        pool = build_asset_pool(players, market_top_n=0)
+        assert pool[0].model_value == int(10000 * SINGLE_SOURCE_DISCOUNT)

--- a/tests/test_trade_finder.py
+++ b/tests/test_trade_finder.py
@@ -1383,17 +1383,17 @@ class TestKtcQualityGuardrails:
         pool = build_asset_pool(players)
         assert len(pool) == 0
 
-    def test_idp_dilution_guard_rejects_majority_no_ktc(self):
-        """IDP assets without KTC cannot be majority of a trade side."""
-        give = [_make_asset("A", model=4000, ktc=5000, pos="WR")]
-        # Receive: 2 IDP without KTC, only 1 with KTC = majority IDP no-KTC
-        recv = [
-            _make_asset("B", model=2000, ktc=2000, pos="WR"),
-            _make_asset("C", model=1500, ktc=None, pos="LB"),
-            _make_asset("D", model=1500, ktc=None, pos="DB"),
-        ]
-        # Note: this is a 1-for-3 which exceeds MAX_PACKAGE_SIZE anyway,
-        # but the IDP guard fires first in the pipeline
+    # ``test_idp_dilution_guard_rejects_majority_no_ktc`` was deleted with
+    # the guard it named.  That guard existed because IDP assets used to
+    # reach the pool with no market value at all; now that each asset is
+    # anchored on the board its counterparty actually consults, the
+    # category "IDP without a market value" no longer exists and the guard
+    # had a dead premise, not merely dead code.
+    #
+    # The test was already inert before deletion — it declared ``give`` and
+    # ``recv`` and then asserted nothing, so it passed whether or not the
+    # guard worked.  Removed rather than silenced: a test that cannot fail
+    # is worse than no test, because it reports coverage it does not have.
 
     def test_idp_with_ktc_allowed(self):
         """IDP assets WITH KTC are fine — they have real market backing."""
@@ -1692,9 +1692,7 @@ class TestPerMarketQualityGate:
             "OffOverpriced": _make_player_data(5000, ktc=8000, pos="WR"),
             "IdpUnderpriced": _make_idp_player_data(8000, idptc=5000, pos="LB"),
         }
-        sleeper_teams = _make_sleeper_teams(
-            {"Me": ["OffOverpriced"], "Them": ["IdpUnderpriced"]}
-        )
+        sleeper_teams = _make_sleeper_teams({"Me": ["OffOverpriced"], "Them": ["IdpUnderpriced"]})
         result = find_trades(players, "Me", ["Them"], sleeper_teams)
         assert not any("offense-only" in w for w in result.get("warnings", []))
 
@@ -1714,9 +1712,9 @@ class TestPerMarketQualityGate:
             {"Me": ["OffOverpriced"], "Them": ["OffFiller", "IdpUnpriced"]}
         )
         result = find_trades(players, "Me", ["Them"], sleeper_teams)
-        assert any("offense-only" in w for w in result.get("warnings", [])), (
-            f"expected an offense-only warning, got {result.get('warnings')}"
-        )
+        assert any(
+            "offense-only" in w for w in result.get("warnings", [])
+        ), f"expected an offense-only warning, got {result.get('warnings')}"
 
     def test_metadata_reports_per_market_filter(self):
         """The engine must say what it filtered, per market."""

--- a/tests/test_trade_finder.py
+++ b/tests/test_trade_finder.py
@@ -36,9 +36,10 @@ def _make_asset(name, model, ktc=None, pos="WR", team="NYJ", is_pick=False, sour
         position=pos,
         team=team,
         model_value=model,
-        ktc_value=ktc,
+        market_value=ktc,
         is_pick=is_pick,
         source_count=source_count,
+        market_source="ktcSfTep" if ktc is not None else None,
     )
 
 
@@ -1177,11 +1178,11 @@ class TestExplainabilityFields:
         assert rf["rosterFitBonus"] == 0.0  # Not in find_trades context
 
         # Flags
-        assert "full_ktc" in tc.flags
+        assert "full_market" in tc.flags
         assert "high_confidence" in tc.flags
 
     def test_partial_ktc_flags(self):
-        """Partial coverage trade should have partial_ktc flag and lower confidence tier."""
+        """Partial coverage trade should have partial_market flag and lower confidence tier."""
         give = [_make_asset("A", model=4000, ktc=5000, source_count=2)]
         recv = [
             _make_asset("B", model=3000, ktc=3000, source_count=1),
@@ -1189,7 +1190,7 @@ class TestExplainabilityFields:
         ]
         tc = _score_trade(give, recv)
         assert tc is not None
-        assert "partial_ktc" in tc.flags
+        assert "partial_market" in tc.flags
         assert "partial KTC" in tc.summary
 
     def test_2for1_elite_has_elite_and_anchor_flags(self):
@@ -1318,7 +1319,7 @@ class TestBeforeAfterExplainability:
         assert d["confidenceTier"] == "high"
         assert d["edgeLabel"] == "Strong Edge"
         assert "you gain 2,000" in d["summary"]
-        assert "full_ktc" in d["flags"]
+        assert "full_market" in d["flags"]
         assert "high_confidence" in d["flags"]
         assert d["rankingFactors"]["boardEdge"] > 0
 
@@ -1334,7 +1335,7 @@ class TestBeforeAfterExplainability:
         d = tc.to_dict()
 
         # This trade is partial-KTC with single-source — very low confidence
-        assert "partial_ktc" in d["flags"]
+        assert "partial_market" in d["flags"]
         assert "partial KTC" in d["summary"]
 
     def test_example_receive_all_no_ktc_rejected(self):
@@ -1547,3 +1548,187 @@ class TestKtcTopNFilter:
                     assert (
                         player["name"] in eligible_names
                     ), f"{player['name']} in {side} is outside KTC top 30"
+
+
+# ── WS-J F-3: per-market quality gate (IDP was silently excluded) ────────
+
+
+def _make_idp_player_data(model, idptc=None, pos="LB", team="BAL", sites=5):
+    """Raw payload for an IDP asset.
+
+    IDP players carry an ``idpTradeCalc`` value and NO KTC value —
+    KTC's board has no defenders at all.  This is the shape that the
+    pre-fix KTC-only top-N filter silently dropped.
+    """
+    d = {
+        "_finalAdjusted": model,
+        "_rawComposite": model,
+        "_composite": model,
+        "_sites": sites,
+        "position": pos,
+        "team": team,
+    }
+    if idptc is not None:
+        d["_canonicalSiteValues"] = {"idpTradeCalc": idptc}
+    return d
+
+
+class TestPerMarketQualityGate:
+    """The quality gate must be per-market, not KTC-only.
+
+    KTC publishes no IDP players, so ranking every asset against KTC
+    and keeping the top N removed 100% of IDP from the pool — in an
+    IDP league the engine silently returned offense-only results.
+    IDP assets are anchored on IDPTradeCalc instead, which publishes
+    offense, IDP and picks on one native 0-9999 scale.
+    """
+
+    def test_idp_asset_survives_default_filter(self):
+        """An IDP player with IDPTC coverage must reach the pool."""
+        players = {
+            "Aidan Hutchinson": _make_idp_player_data(6400, idptc=6444, pos="DL"),
+            "Josh Allen": _make_player_data(9000, ktc=8500, pos="QB"),
+        }
+        pool = build_asset_pool(players)
+        names = {a.name for a in pool}
+        assert "Aidan Hutchinson" in names, (
+            "IDP asset was dropped by the quality gate — this is the "
+            "offense-only regression (WS-J F-3)"
+        )
+
+    def test_idp_market_value_reads_idptc(self):
+        players = {"Micah Parsons": _make_idp_player_data(5400, idptc=5419, pos="LB")}
+        pool = build_asset_pool(players)
+        asset = pool[0]
+        assert asset.market_value == 5419
+        assert asset.market_source == "idpTradeCalc"
+
+    def test_offense_market_value_still_reads_ktc(self):
+        players = {"Ja'Marr Chase": _make_player_data(9900, ktc=9996, pos="WR")}
+        pool = build_asset_pool(players)
+        asset = pool[0]
+        assert asset.market_value == 9996
+        assert asset.market_source in ("ktcSfTep", "ktc")
+
+    def test_market_rank_is_computed_within_market(self):
+        """An IDP player must not be ranked against offensive players.
+
+        Offense values run to 9999; IDP tops out near 6400.  Ranking
+        them in one list buries every defender below the offensive
+        board and a top-N cut removes them all.
+        """
+        players = {
+            "WR1": _make_player_data(9900, ktc=9990, pos="WR"),
+            "WR2": _make_player_data(9800, ktc=9900, pos="WR"),
+            "TopLB": _make_idp_player_data(6400, idptc=6444, pos="LB"),
+            "NextLB": _make_idp_player_data(5400, idptc=5419, pos="LB"),
+        }
+        pool = build_asset_pool(players, ktc_top_n=0)
+        by_name = {a.name: a for a in pool}
+        # Each market ranks from 1 independently.
+        assert by_name["WR1"].market_rank == 1
+        assert by_name["WR2"].market_rank == 2
+        assert by_name["TopLB"].market_rank == 1
+        assert by_name["NextLB"].market_rank == 2
+
+    def test_top_n_cut_applies_per_market(self):
+        """A top-1 cut keeps the best offense asset AND the best IDP asset."""
+        players = {
+            "WR1": _make_player_data(9900, ktc=9990, pos="WR"),
+            "WR2": _make_player_data(9800, ktc=9900, pos="WR"),
+            "TopLB": _make_idp_player_data(6400, idptc=6444, pos="LB"),
+            "NextLB": _make_idp_player_data(5400, idptc=5419, pos="LB"),
+        }
+        pool = build_asset_pool(players, ktc_top_n=1)
+        names = {a.name for a in pool}
+        assert names == {"WR1", "TopLB"}
+
+    def test_asset_with_no_market_coverage_is_excluded_by_gate(self):
+        """No board lists them at all → still filtered by the quality gate."""
+        players = {
+            "WR1": _make_player_data(9900, ktc=9990, pos="WR"),
+            "Ghost": _make_player_data(5000, ktc=None, pos="WR"),
+        }
+        pool = build_asset_pool(players, ktc_top_n=150)
+        assert {a.name for a in pool} == {"WR1"}
+
+    def test_idp_league_produces_idp_trades(self):
+        """End-to-end: an IDP-heavy league must surface IDP in trades.
+
+        Real arbitrage shape — I give an offensive player the market
+        prices above our board, and receive a defender our board rates
+        above his IDPTradeCalc price.  Pre-fix this returned nothing
+        involving IDP because no defender ever reached the pool.
+        """
+        players = {
+            # Market loves him more than we do → good to send out.
+            "OffOverpriced": _make_player_data(5000, ktc=8000, pos="WR"),
+            "OffFiller": _make_player_data(4000, ktc=4200, pos="RB"),
+            # We love him more than IDPTradeCalc does → good to acquire.
+            "IdpUnderpriced": _make_idp_player_data(8000, idptc=5000, pos="LB"),
+            "IdpFiller": _make_idp_player_data(3000, idptc=3100, pos="DL"),
+        }
+        sleeper_teams = _make_sleeper_teams(
+            {
+                "Me": ["OffOverpriced", "OffFiller"],
+                "Them": ["IdpUnderpriced", "IdpFiller"],
+            }
+        )
+        result = find_trades(players, "Me", ["Them"], sleeper_teams)
+        traded_names = set()
+        for trade in result.get("trades", []):
+            for side in ("give", "receive"):
+                for p in trade[side]:
+                    traded_names.add(p["name"])
+        assert "IdpUnderpriced" in traded_names, (
+            "no IDP asset appeared in any trade for an IDP league — "
+            f"the engine is still offense-only (got {traded_names})"
+        )
+
+    def test_idp_only_pool_does_not_warn_offense_only(self):
+        """The offense-only warning must not fire when IDP is priced."""
+        players = {
+            "OffOverpriced": _make_player_data(5000, ktc=8000, pos="WR"),
+            "IdpUnderpriced": _make_idp_player_data(8000, idptc=5000, pos="LB"),
+        }
+        sleeper_teams = _make_sleeper_teams(
+            {"Me": ["OffOverpriced"], "Them": ["IdpUnderpriced"]}
+        )
+        result = find_trades(players, "Me", ["Them"], sleeper_teams)
+        assert not any("offense-only" in w for w in result.get("warnings", []))
+
+    def test_unpriced_idp_league_warns_offense_only(self):
+        """IDP present but unpriced → the engine must say it is offense-only.
+
+        This is the regression made visible: rather than silently
+        returning offense trades, the result now carries a warning.
+        """
+        players = {
+            "OffOverpriced": _make_player_data(5000, ktc=8000, pos="WR"),
+            "OffFiller": _make_player_data(4000, ktc=4200, pos="RB"),
+            # IDP with NO market coverage at all.
+            "IdpUnpriced": _make_idp_player_data(8000, idptc=None, pos="LB"),
+        }
+        sleeper_teams = _make_sleeper_teams(
+            {"Me": ["OffOverpriced"], "Them": ["OffFiller", "IdpUnpriced"]}
+        )
+        result = find_trades(players, "Me", ["Them"], sleeper_teams)
+        assert any("offense-only" in w for w in result.get("warnings", [])), (
+            f"expected an offense-only warning, got {result.get('warnings')}"
+        )
+
+    def test_metadata_reports_per_market_filter(self):
+        """The engine must say what it filtered, per market."""
+        players = {
+            "WR1": _make_player_data(9900, ktc=9990, pos="WR"),
+            "TopLB": _make_idp_player_data(6400, idptc=6444, pos="LB"),
+        }
+        sleeper_teams = _make_sleeper_teams({"Me": ["WR1"], "Them": ["TopLB"]})
+        result = find_trades(players, "Me", ["Them"], sleeper_teams)
+        meta = result["metadata"]
+        assert "marketTopNFilter" in meta
+        assert meta["marketTopNFilter"] == KTC_TOP_N_FILTER
+        # Per-market coverage must be reported so an offense-only result
+        # in an IDP league is visible rather than silent.
+        assert "marketCoverage" in meta
+        assert set(meta["marketCoverage"]) >= {"ktcSfTep", "idpTradeCalc"}

--- a/tests/test_trade_suggestions.py
+++ b/tests/test_trade_suggestions.py
@@ -33,6 +33,7 @@ from src.trade.suggestions import (
     MAX_RECEIVE_TARGET_PER_CATEGORY,
     MAX_LOW_CONFIDENCE_PER_CATEGORY,
     KTC_TOP_N_FILTER,
+    BOARD_TOP_N_FILTER,
 )
 
 
@@ -1988,14 +1989,20 @@ class TestPackageDeterminism:
 
 
 class TestKtcTopNFilter:
-    """Verify the KTC top-150 quality gate in the suggestions engine."""
+    """Verify the blended-board top-150 quality gate.
+
+    WS-J F-4/F-5: this gate was named for KTC but has always ranked on
+    our own blended board.  These tests now assert that intent — and
+    the fixture includes IDP, because the previous QB/RB/WR/TE-only
+    fixture made the engine's IDP behaviour structurally unobservable.
+    """
 
     def _make_large_snapshot(self, n=200):
         """Build a snapshot with n players of descending value."""
         assets = []
         for i in range(n):
             val = 9000 - i * 40
-            pos = ["QB", "RB", "WR", "TE"][i % 4]
+            pos = ["QB", "RB", "WR", "TE", "LB", "DL", "DB"][i % 7]
             assets.append(
                 _make_asset(
                     f"Player_{i:03d}",
@@ -2008,7 +2015,9 @@ class TestKtcTopNFilter:
         return _build_snapshot(assets)
 
     def test_default_filter_is_150(self):
-        assert KTC_TOP_N_FILTER == 150
+        assert BOARD_TOP_N_FILTER == 150
+        # Deprecated alias must stay in lockstep.
+        assert KTC_TOP_N_FILTER == BOARD_TOP_N_FILTER
 
     def test_pool_size_capped_at_top_n(self):
         snap = self._make_large_snapshot(300)
@@ -2017,10 +2026,13 @@ class TestKtcTopNFilter:
 
     def test_pool_all_top_ranked(self):
         snap = self._make_large_snapshot(300)
-        pool = build_asset_pool(snap, ktc_top_n=100)
+        pool = build_asset_pool(snap, board_top_n=100)
+        # ``p.board_rank is not None`` was the old assertion here; it
+        # could never fail, because _assign_board_ranks assigns an int
+        # to every player.  Assert the gate instead (WS-J F-5).
+        assert pool, "filter removed everything"
         for p in pool:
-            assert p.ktc_rank is not None
-            assert p.ktc_rank <= 100
+            assert p.board_rank <= 100
 
     def test_filter_disabled_when_zero(self):
         snap = self._make_large_snapshot(300)
@@ -2033,11 +2045,50 @@ class TestKtcTopNFilter:
         vals = [p.display_value for p in pool]
         assert vals == sorted(vals, reverse=True)
 
-    def test_ktc_rank_assigned_sequentially(self):
-        snap = self._make_large_snapshot(50)
-        pool = build_asset_pool(snap, ktc_top_n=0)
-        ranks = [p.ktc_rank for p in pool]
-        assert ranks == list(range(1, 51))
+    def test_board_rank_follows_blended_display_value(self):
+        """Rank must track OUR board's ordering, not insertion order.
+
+        WS-J F-4: the previous test asserted ``ranks == range(1, 51)``
+        on a fixture already emitted in descending value, so it passed
+        whether the code ranked by value or merely enumerated the list.
+        It documented the implementation instead of the intent.  Feed
+        the pool in a shuffled order so only a value-ordered rank can
+        satisfy it.
+        """
+        assets = [
+            _make_asset("Low", "WR", 3000, display_value=3000, source_count=6),
+            _make_asset("High", "QB", 9000, display_value=9000, source_count=6),
+            _make_asset("Mid", "LB", 6000, display_value=6000, source_count=6),
+        ]
+        pool = build_asset_pool(_build_snapshot(assets), board_top_n=0)
+        by_name = {p.name: p for p in pool}
+        assert by_name["High"].board_rank == 1
+        assert by_name["Mid"].board_rank == 2
+        assert by_name["Low"].board_rank == 3
+
+    def test_gate_does_not_require_retail_coverage(self):
+        """IDP must survive a gate our own board can evaluate.
+
+        finder.py anchors on retail markets and needs IDPTradeCalc for
+        defenders; this engine gates on the blended board, which covers
+        every asset class.  An IDP player inside the top N must not be
+        filtered for lacking KTC coverage (the F-3 failure mode).
+        """
+        assets = [
+            _make_asset("OffStar", "WR", 9000, display_value=9000, source_count=6),
+            _make_asset("IdpStar", "LB", 8000, display_value=8000, source_count=6),
+        ]
+        pool = build_asset_pool(_build_snapshot(assets), board_top_n=150)
+        assert {p.name for p in pool} == {"OffStar", "IdpStar"}
+
+    def test_metadata_reports_the_gate_that_actually_ran(self):
+        """Metadata must name the blended board, not KTC (WS-J F-4)."""
+        snap = self._make_large_snapshot(200)
+        roster = [f"Player_{i:03d}" for i in range(20)]
+        result = generate_suggestions(roster, snap, board_top_n=100)
+        assert result["metadata"]["boardTopNFilter"] == 100
+        # Deprecated alias retained for existing consumers.
+        assert result["metadata"]["ktcTopNFilter"] == 100
 
     def test_suggestions_only_include_top_n_players(self):
         """Every player in every suggestion must be inside the KTC top N."""

--- a/tests/test_trade_suggestions.py
+++ b/tests/test_trade_suggestions.py
@@ -9,6 +9,8 @@ Validates:
 - Serialization
 """
 
+import pytest
+
 from src.trade.suggestions import (
     PlayerAsset,
     RosterAnalysis,
@@ -2750,3 +2752,43 @@ class TestEffectiveSourceRanks:
         assert matching, "expected a positional_upgrade suggestion targeting WR Upgrade Target"
         for s in matching:
             assert s["confidence"] == "low"
+
+
+class TestBoardTopNFilterPrecondition:
+    """WS-J F-5: the top-N filter states its precondition instead of
+    carrying a null guard that could never fire."""
+
+    def test_unranked_pool_raises_rather_than_silently_emptying(self):
+        from src.trade.suggestions import _apply_board_top_n_filter, PlayerAsset
+
+        unranked = [
+            PlayerAsset(
+                name="NoRank",
+                position="WR",
+                display_value=5000,
+                calibrated_value=5000,
+            )
+        ]
+        assert unranked[0].board_rank is None
+        with pytest.raises(TypeError):
+            _apply_board_top_n_filter(unranked, 150)
+
+    def test_ranked_pool_filters_normally(self):
+        from src.trade.suggestions import (
+            _apply_board_top_n_filter,
+            _assign_board_ranks,
+            PlayerAsset,
+        )
+
+        pool = [
+            PlayerAsset(
+                name=f"P{i}",
+                position="WR",
+                display_value=9000 - i * 100,
+                calibrated_value=9000 - i * 100,
+            )
+            for i in range(5)
+        ]
+        _assign_board_ranks(pool)
+        kept = _apply_board_top_n_filter(pool, 3)
+        assert [p.name for p in kept] == ["P0", "P1", "P2"]


### PR DESCRIPTION
## The headline

**`/api/trade/finder` has been offense-only in an IDP league, and said nothing about it.**

`finder.py` ranked every asset against KTC and kept the top 150. KTC publishes **no IDP players at all** — verified against its live 500-row board:

```
Aidan Hutchinson  NO      Micah Parsons  NO      Myles Garrett   NO
Abdul Carter      NO      Jared Verse    NO      Jack Campbell   NO
```

So every defender scored `ktc_value = None` and was removed from the pool *before scoring ran*. In a league with nine IDP starters, the engine returned offense-only results while reporting `ktcTopNFilter: 150` as though a uniform gate had been applied.

It stayed invisible because the coverage metric only ever counted survivors: `ktcCoveragePercent` read **100%** throughout, since the missing rows had already been filtered out before it counted them.

## The fix

Each asset is now anchored on the board its counterparty would actually consult, and ranked **within that market's own population**:

| Asset class | Market | Ranked against |
|---|---|---|
| offense + picks | `ktcSfTep` (legacy `ktc` fallback) | other offense + picks |
| IDP | `idpTradeCalc` | other IDP |

Per-market *ranking* is the load-bearing half. Reading the right values isn't enough — offense runs to 9999 while the best defender sits at 6444, so any single combined ranking buries every defender below the offensive board and a top-N cut removes them all over again.

This mirrors `angle.py::_market_source_for`, which has routed per-player market values correctly since it was written.

### Why summing the two markets is sound

They are **directly comparable**, not incommensurable. IDPTradeCalc is a full-roster calculator publishing offense, IDP and picks on one native 0-9999 scale. Measured against KTC on 2026-07-26:

```
ktcSfTep      n=500   max=9999
idpTradeCalc  n=900   max=9999
overlap (same player, both boards): 475
idp/ktc ratio   median 1.000   p10 0.888   p90 1.054
```

Both boards top out at 9999, so there is no rescaling to apply between them.

### The engine now says what it filtered

- `marketCoverage` reports priced assets **per market**, replacing the blended number that read 100% during the bug.
- An IDP league whose pool contains no priced IDP asset gets an explicit offense-only warning instead of a silent result.

## Also in this PR

### `suggestions.py`'s "KTC filter" never consulted KTC

`_assign_ktc_ranks` enumerated the pool *after* it had been sorted by `display_value`, so the rank was always our blended-board rank. Its docstring claimed "players without KTC data get `ktc_rank=None`" — that never happened; every player got an int.

The gate itself is sound, so this is a naming and reporting fix with **no behaviour change**:

```
KTC_TOP_N_FILTER        -> BOARD_TOP_N_FILTER
_assign_ktc_ranks       -> _assign_board_ranks
_apply_ktc_top_n_filter -> _apply_board_top_n_filter
PlayerAsset.ktc_rank    -> .board_rank
metadata ktcTopNFilter  -> boardTopNFilter
serialized ktcRank      -> boardRank
```

**The two engines are deliberately NOT unified.** They ask different questions: `finder.py` arbitrages our board against the retail market, so a real market value is load-bearing *inside its arithmetic*; `suggestions.py` only needs an asset-quality gate, which our own board answers for IDP and picks that no single retail board covers. Forcing a shared definition would make `suggestions.py` depend on retail coverage it doesn't need and would reintroduce the exact blind spot this PR removes. Rationale is recorded in the module and in CLAUDE.md.

### Dead code: deleted where the premise died, kept where it's conditional

- **Deleted** the IDP dilution guard. Its premise — "IDP assets *without KTC* distort the appeal calculation" — no longer exists now IDP carries a real market value, and it was unreachable in production anyway.
- **Kept** the partial-coverage branch, renamed to market terms. It isn't dead, it's *conditional*: reachable whenever `market_top_n=0`. That reachability is now documented at the branch.
- **Collapsed** an `if/else` in the ranking step whose two arms were byte-identical (`ranked = full + partial` both ways), gated on a condition that could not change the outcome.

### Vacuous checks

- `_apply_board_top_n_filter`'s `is not None` guard could never be False, and would have turned a caller bug into a silently empty result set. Replaced with a stated precondition that raises instead.
- `test_ktc_rank_assigned_sequentially` asserted `ranks == range(1, 51)` against a fixture already emitted in descending value — it passed whether the code ranked by value or merely enumerated the list, documenting the implementation rather than the intent. Replaced with a shuffled-input test that only a value-ordered rank can satisfy.
- The `TestKtcTopNFilter` fixture emitted only QB/RB/WR/TE, making IDP behaviour structurally unobservable. It now includes LB/DL/DB.

## Not a breaking rename

Every old name is retained as a deprecated alias, so external callers keep working unchanged:

- `Asset.ktc_value` / `.ktc_rank` / `.has_ktc` → properties over the new market fields
- `KTC_TOP_N_FILTER`, `MIN_KTC_VALUE`, `PARTIAL_KTC_MAX_RANK`, `PARTIAL_KTC_ARBITRAGE_CAP`
- `_assign_ktc_ranks`, `_apply_ktc_top_n_filter`
- the `ktc_top_n=` kwarg on `build_asset_pool`, `build_asset_pool_from_contract`, `find_trades`, `generate_suggestions`
- metadata `ktcTopNFilter` and `ktcCoveragePercent`, alongside the new `marketTopNFilter` / `marketCoverage`

`server.py` and `faab_contention.py` required no changes beyond one call migrated to the new kwarg name.

The one intentional wire change: the coverage flags `full_ktc` / `partial_ktc` are now `full_market` / `partial_market`, because a full-coverage IDP trade flagged `full_ktc` would be a lie. No frontend code reads them (verified).

## Tests

11 new tests. The 8 in `TestPerMarketQualityGate` **fail against the pre-fix engine and pass after** — verified by reverting `finder.py` and re-running:

```
8 failed, 2 passed   (pre-fix)
```

`suggestions.py`'s changes are a rename, so its new tests assert intent rather than changed behaviour — including one that pins the gate plainly does not require retail coverage.

## A correction worth reading before reviewing

An earlier audit finding claimed `finder.py` double-discounts single-source assets: its `SINGLE_SOURCE_DISCOUNT = 0.88` stacked on the pipeline's 0.30 retention for ~0.264 effective. **That was wrong**, and the obvious remediation — delete the 0.88 — would have introduced a live value distortion.

The two discounts sit on two different value pipelines:

- `suggestions.py` reads `rankDerivedValue` — Final Framework output, which **has** the 0.30 retention.
- `finder.py` reads `_finalAdjusted`, which `data_contract.py` deep-copies verbatim from the raw scrape and which `Dynasty Scraper.py` sets straight from `_composite`. The retention never touches it.

So the haircut stays, pinned by three tests including on IDP assets, which reach the pool for the first time in this PR and must be discounted on the same terms as offense.

## Follow-up, deliberately not in this PR

That investigation surfaced something larger: **`finder.py` values assets off the raw scraper composite** while CLAUDE.md documents `_compute_unified_rankings` as "the one and only code path that determines live player values." The arbitrage engine is comparing a board the user never sees against the retail market.

Recorded in full with evidence at `docs/roster-trade-intelligence/F-6-finder-valuation-path.md`. It is **not** folded in here: it moves every number the engine emits, and the thresholds around it (`MIN_ASSET_VALUE`, `MAX_BOARD_LOSS`, `JUNK_THRESHOLD`, `ELITE_THRESHOLD`, `MULTI_FOR_ONE_MIN_RATIO`) were tuned against composite-scale numbers and need re-derivation rather than re-testing. That is a recalibration with its own before/after evidence.

## CLAUDE.md

Its claim that both engines enforce "a KTC top-150 quality filter" was wrong about both. Replaced with a table of what each gate actually ranks against, why they differ, both traps the old wording set, and the measured KTC/IDPTC scale relationship — since that sentence is how the next agent learns this subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_