### PR TITLE
fix(auth): transient status timeouts no longer sign users out; complete the page-route list

### DIFF
--- a/frontend/__tests__/components/useAuth.retry.test.jsx
+++ b/frontend/__tests__/components/useAuth.retry.test.jsx
@@ -1,0 +1,167 @@
+// A transient failure on /api/auth/status must NOT be reported as a
+// signed-out user.
+//
+// The bug these pin: the hook capped the probe at 5s with an
+// AbortController and, on timeout with no cached flag, resolved
+// authenticated = false with no retry.  A valid session was then
+// stranded on the anonymous shell for the entire life of the page —
+// no nav, no search, no team switcher — until a manual reload.
+//
+// These are deliberately driven by SIMULATED aborts/failures and fake
+// timers rather than real elapsed time: the defect is timing-dependent,
+// and asserting on wall-clock behaviour would be slow and flaky.
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAuth } from "@/components/useAuth";
+
+function authResponse(authenticated) {
+  return { ok: true, status: 200, json: async () => ({ authenticated }) };
+}
+
+/** What fetch does when an AbortController fires — what the 5s cap produces. */
+function abortError() {
+  const err = new Error("The operation was aborted.");
+  err.name = "AbortError";
+  return err;
+}
+
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  try {
+    sessionStorage.clear();
+  } catch {
+    /* jsdom always has it; guard anyway */
+  }
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("useAuth — a timeout is not a sign-out", () => {
+  it("stays UNKNOWN (not false) when the probe aborts", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw abortError(); }));
+
+    const { result } = renderHook(() => useAuth());
+    await flush();
+
+    // The load-bearing assertion.  Pre-fix this was `false`, which
+    // consumers render as a genuine signed-out user.
+    expect(result.current.authenticated).toBeNull();
+    expect(result.current.authUnknown).toBe(true);
+    // ...and the UI must never be left wedged on "checking".
+    expect(result.current.checking).toBe(false);
+  });
+
+  it("recovers a valid session on its own after transient aborts", async () => {
+    const failing = vi.fn(async () => { throw abortError(); });
+    vi.stubGlobal("fetch", failing);
+
+    const { result } = renderHook(() => useAuth());
+    await flush();
+    expect(result.current.authenticated).toBeNull();
+    const attemptsWhileDown = failing.mock.calls.length;
+
+    // Backend recovers.  No remount, no user action — the scheduled
+    // retry must pick it up.
+    vi.stubGlobal("fetch", vi.fn(async () => authResponse(true)));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(result.current.authenticated).toBe(true);
+    expect(result.current.authUnknown).toBe(false);
+    expect(attemptsWhileDown).toBeGreaterThan(0);
+  });
+
+  it("keeps retrying with backoff across repeated failures", async () => {
+    const failing = vi.fn(async () => { throw abortError(); });
+    vi.stubGlobal("fetch", failing);
+
+    renderHook(() => useAuth());
+    await flush();
+    const afterFirst = failing.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+    const afterBackoff = failing.mock.calls.length;
+
+    // Pre-fix there was exactly one probe, ever.
+    expect(afterBackoff).toBeGreaterThan(afterFirst);
+  });
+
+  it("treats a 5xx as infrastructure, not as an answer", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 502, json: async () => ({}) })),
+    );
+
+    const { result } = renderHook(() => useAuth());
+    await flush();
+
+    expect(result.current.authenticated).toBeNull();
+    expect(result.current.authUnknown).toBe(true);
+  });
+
+  it("keeps painting an optimistic session through a blip", async () => {
+    sessionStorage.setItem("next_auth_checked_v1", "true");
+    vi.stubGlobal("fetch", vi.fn(async () => { throw abortError(); }));
+
+    const { result } = renderHook(() => useAuth());
+    await flush();
+
+    // A cached "was signed in" must not be torn down by a blip.
+    expect(result.current.authenticated).toBe(true);
+    expect(result.current.authUnknown).toBe(true);
+  });
+});
+
+describe("useAuth — a real answer is still authoritative", () => {
+  it("commits false when the backend actually says signed out", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => authResponse(false)));
+
+    const { result } = renderHook(() => useAuth());
+    await flush();
+
+    // Genuine sign-out must remain distinguishable from unknown.
+    expect(result.current.authenticated).toBe(false);
+    expect(result.current.authUnknown).toBe(false);
+    expect(result.current.checking).toBe(false);
+  });
+
+  it("signs out a stale cached session when the cookie is gone", async () => {
+    // The regression the original stale-while-revalidate guarded:
+    // a cached true + a real 'no' must end as false, not stay true.
+    sessionStorage.setItem("next_auth_checked_v1", "true");
+    vi.stubGlobal("fetch", vi.fn(async () => authResponse(false)));
+
+    const { result } = renderHook(() => useAuth());
+    await flush();
+
+    expect(result.current.authenticated).toBe(false);
+    expect(sessionStorage.getItem("next_auth_checked_v1")).toBeNull();
+  });
+
+  it("stops probing once an authoritative answer lands", async () => {
+    const ok = vi.fn(async () => authResponse(true));
+    vi.stubGlobal("fetch", ok);
+
+    renderHook(() => useAuth());
+    await flush();
+    const settled = ok.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(ok.mock.calls.length).toBe(settled);
+  });
+});

--- a/frontend/components/useAuth.js
+++ b/frontend/components/useAuth.js
@@ -1,20 +1,55 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const AUTH_CHECK_KEY = "next_auth_checked_v1";
 
+// Cap on a single status probe.  Exists so a hung fetch (slow network,
+// broken proxy, iOS Safari background-tab throttling) can't leave the
+// UI wedged on ``checking = true`` forever.
+const PROBE_TIMEOUT_MS = 5000;
+
+// Backoff between probes while the answer is UNKNOWN.  The last value
+// repeats for as long as the page lives, so a session that was
+// unreachable at mount still recovers on its own instead of requiring
+// the user to reload.
+const RETRY_BACKOFF_MS = [1000, 2000, 4000, 8000, 30000];
+
 /**
  * useAuth — lightweight auth state hook.
- * Checks /api/auth/status on mount, caches result for the session.
- * Provides login/logout helpers.
+ *
+ * ``authenticated`` is deliberately THREE-valued, and the distinction
+ * is the whole point of this hook:
+ *
+ *   true   — the backend said so.
+ *   false  — the backend said so.  A genuine signed-out user.
+ *   null   — we don't know yet: still probing, or every probe so far
+ *            failed/timed out.
+ *
+ * The bug this replaced collapsed the third case into ``false``: one
+ * slow moment on ``/api/auth/status`` (5s cap, no retry) resolved a
+ * perfectly valid session to "logged out" for the entire life of the
+ * page — no nav, no search, no team switcher — until the user
+ * manually reloaded.  A transient timeout must never be
+ * indistinguishable from a real sign-out, so a failed probe now leaves
+ * the state UNKNOWN and schedules another one.
+ *
+ * Consumers render ``null`` as neutral chrome (no authed surfaces, but
+ * no "Login" affordance either), so an unknown state is quiet rather
+ * than actively wrong in either direction.
  */
 export function useAuth() {
-  const [authenticated, setAuthenticated] = useState(null); // null = checking
+  const [authenticated, setAuthenticated] = useState(null); // null = unknown
   const [checking, setChecking] = useState(true);
+  // Exposed so a caller can tell "we never got an answer" apart from
+  // "the answer was no" without re-deriving it from authenticated.
+  const [authUnknown, setAuthUnknown] = useState(false);
+  const attemptRef = useRef(0);
 
   useEffect(() => {
     let active = true;
+    let timer = null;
+
     // sessionStorage can throw synchronously in strict privacy modes
     // and locked-down WebViews — wrap every access so a thrown read
     // can't abort the effect before ``setChecking(false)`` runs.
@@ -34,25 +69,29 @@ export function useAuth() {
       }
     }
 
-    async function check() {
-      // Stale-while-revalidate: paint optimistically from the cached
-      // flag for fast first render, but ALWAYS re-verify against the
-      // backend.  A stuck "authenticated=true" cache after the cookie
-      // is gone is the entire reason this hook used to wedge users on
-      // the dashboard with a 401-on-every-request loop.
+    function scheduleRetry() {
+      if (!active) return;
+      const i = Math.min(attemptRef.current, RETRY_BACKOFF_MS.length - 1);
+      const delay = RETRY_BACKOFF_MS[i];
+      attemptRef.current += 1;
+      timer = setTimeout(() => {
+        probe();
+      }, delay);
+    }
+
+    /**
+     * One probe.  Returns nothing; drives state.
+     *
+     * Only a 200 is authoritative — ``/api/auth/status`` is public and
+     * reports signed-out users as 200 + ``{authenticated: false}``, so
+     * any non-OK status is infrastructure (5xx, 502 mid-deploy, nginx
+     * timeout), not an answer about this user.
+     */
+    async function probe() {
       const cached = readAuthCache();
-      if (cached && active) {
-        setAuthenticated(true);
-        setChecking(false);
-      }
       try {
-        // Cap the auth check so a hung fetch (slow network, broken
-        // proxy, iOS Safari background-tab throttling) can't leave
-        // the UI wedged on ``checking=true`` — every consumer that
-        // gates UI on the resolved state would otherwise sit on a
-        // blank screen until the request finally errors out.
         const ctl = new AbortController();
-        const timer = setTimeout(() => ctl.abort(), 5000);
+        const t = setTimeout(() => ctl.abort(), PROBE_TIMEOUT_MS);
         let res;
         try {
           res = await fetch("/api/auth/status", {
@@ -60,48 +99,100 @@ export function useAuth() {
             signal: ctl.signal,
           });
         } finally {
-          clearTimeout(timer);
+          clearTimeout(t);
         }
-        // /api/auth/status is public and reports unauthenticated
-        // users with 200 + {authenticated: false}, so a non-OK status
-        // here means a transient backend/proxy failure (5xx, 502
-        // during a deploy, nginx timeout).  Keep the optimistic state
-        // when we had one (don't sign out a real session on infra
-        // blips); otherwise resolve to unauthenticated so callers
-        // that treat ``null`` as "still checking" don't wedge.
+        if (!active) return;
+
         if (!res.ok) {
-          if (active && !cached) setAuthenticated(false);
+          // Transient infrastructure failure — NOT an answer.
+          markUnknown(cached);
+          scheduleRetry();
           return;
         }
+
         const data = await res.json();
+        if (!active) return;
         const authed = !!data.authenticated;
-        if (active) setAuthenticated(authed);
+        // Authoritative: stop retrying and commit, in both directions.
+        setAuthenticated(authed);
+        setAuthUnknown(false);
+        setChecking(false);
         writeAuthCache(authed);
+        attemptRef.current = 0;
       } catch {
-        // Network failure: keep optimistic state if we had one,
-        // otherwise fall to unauthenticated.  Don't clobber the cache
-        // on transient errors.
-        if (active && !cached) setAuthenticated(false);
-      } finally {
-        if (active) setChecking(false);
+        // Abort (our own timeout) or network failure.  Same class as a
+        // 5xx: we did not learn anything about this user.
+        if (!active) return;
+        markUnknown(cached);
+        scheduleRetry();
       }
     }
-    check();
-    return () => { active = false; };
+
+    function markUnknown(cached) {
+      // Never wedge on ``checking`` — consumers gate real UI on it.
+      setChecking(false);
+      setAuthUnknown(true);
+      // Stale-while-revalidate: a cached "was signed in" keeps painting
+      // optimistically so a blip doesn't tear down the authed shell.
+      // Without one we stay null (unknown) rather than claiming false —
+      // that claim was the bug.
+      if (cached) setAuthenticated(true);
+      else setAuthenticated(null);
+    }
+
+    // Paint immediately from the cached flag for a fast first render,
+    // but ALWAYS re-verify.  A stuck "authenticated=true" cache after
+    // the cookie is gone is why this hook used to wedge users on the
+    // dashboard in a 401-on-every-request loop.
+    if (readAuthCache()) {
+      setAuthenticated(true);
+      setChecking(false);
+    }
+    probe();
+
+    // A tab that was backgrounded (or offline) during every retry
+    // recovers the moment it comes back, without waiting out the
+    // backoff.  Only re-probes while the answer is still unknown.
+    function onWake() {
+      if (!active) return;
+      if (!attemptRef.current) return; // last probe was authoritative
+      if (timer) clearTimeout(timer);
+      probe();
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", onWake);
+      window.addEventListener("online", onWake);
+    }
+
+    return () => {
+      active = false;
+      if (timer) clearTimeout(timer);
+      if (typeof window !== "undefined") {
+        window.removeEventListener("focus", onWake);
+        window.removeEventListener("online", onWake);
+      }
+    };
   }, []);
 
   const logout = useCallback(async () => {
     try {
       await fetch("/api/auth/logout", { method: "POST", credentials: "same-origin" });
     } catch { /* ignore */ }
-    sessionStorage.removeItem(AUTH_CHECK_KEY);
+    try {
+      sessionStorage.removeItem(AUTH_CHECK_KEY);
+    } catch { /* sessionStorage unavailable — in-memory state still flips */ }
     setAuthenticated(false);
+    setAuthUnknown(false);
     window.location.href = "/";
   }, []);
 
   const onLoginSuccess = useCallback(() => {
-    sessionStorage.setItem(AUTH_CHECK_KEY, "true");
+    try {
+      sessionStorage.setItem(AUTH_CHECK_KEY, "true");
+    } catch { /* sessionStorage unavailable — in-memory state still flips */ }
     setAuthenticated(true);
+    setAuthUnknown(false);
+    setChecking(false);
     // Notify data hooks (useDynastyData, useUserState) so any cached
     // 401 error state from before sign-in clears immediately instead
     // of requiring a full page reload.  Listened for in
@@ -115,5 +206,5 @@ export function useAuth() {
     }
   }, []);
 
-  return { authenticated, checking, logout, onLoginSuccess };
+  return { authenticated, checking, authUnknown, logout, onLoginSuccess };
 }

--- a/server.py
+++ b/server.py
@@ -10685,6 +10685,54 @@ async def get_playerctx_player(request: Request):
     )
 
 
+# ── PAGE CATCH-ALL (MUST BE THE LAST ROUTE IN THIS FILE) ────────────────
+# Every page above this point is registered by hand.  That list has
+# drifted from the Next.js app three separate times — at the time this
+# was written /waivers, /news, /draft, /angle, /trending, /intel's
+# siblings, /players/compare, /league-comparison, /idptc-rookies,
+# /tools/ros-data-health, /rankings/[position] and every /league/*
+# subroute were all 404 through this backend while serving fine from
+# Next.  A hand-maintained mirror of another router's route table is a
+# permanent drift trap, so this forwards anything unclaimed instead.
+#
+# Next owns page routing; an unknown path gets Next's own 404, which is
+# the correct answer rather than a FastAPI one.
+#
+# Ordering is load-bearing: FastAPI matches in registration order, so
+# this only ever sees paths no explicit route above claimed.  The
+# ``/api/`` and ``/_next/`` guards are belt-and-braces for the day
+# someone appends a route below this one.
+#
+# NOT fixed here, deliberately: ``_proxy_next`` forwards neither the
+# request's cookies nor its query string, so a page served through this
+# backend renders logged-out and ignores ``?tab=``.  That is the same
+# behaviour every hand-registered page above already has — this change
+# makes the route list complete, not the proxy faithful.  Whether the
+# proxy should be repaired or declared non-production-representative
+# (nginx bypasses it in prod) is tracked separately; see issue #555.
+_PUBLIC_PAGE_PREFIXES = ("/league",)
+
+
+@app.get("/{full_path:path}", response_class=HTMLResponse)
+async def serve_next_page(request: Request, full_path: str):
+    path = "/" + full_path.lstrip("/")
+
+    # Never intercept API or asset traffic.  Unreachable while this
+    # stays the last route; cheap insurance if that ever changes.
+    if path.startswith("/api/") or path.startswith("/_next/"):
+        return JSONResponse(status_code=404, content={"error": "not_found"})
+
+    is_public = any(
+        path == prefix or path.startswith(prefix + "/") for prefix in _PUBLIC_PAGE_PREFIXES
+    )
+    if not is_public:
+        redirect = _require_auth_or_redirect(request, path)
+        if redirect is not None:
+            return redirect
+
+    return await _serve_app_shell(path)
+
+
 # ── MAIN ────────────────────────────────────────────────────────────────
 if __name__ == "__main__":
     import uvicorn

--- a/tests/api/test_page_route_coverage.py
+++ b/tests/api/test_page_route_coverage.py
@@ -1,0 +1,123 @@
+"""Every Next.js page must be reachable through this backend.
+
+Page routes used to be registered one-by-one in ``server.py``, i.e. a
+hand-maintained mirror of another router's route table.  It drifted
+three separate times: ``/waivers``, ``/news`` and ``/draft`` were all
+404 here while serving fine from Next, along with ``/angle``,
+``/trending``, ``/players/compare``, ``/league-comparison``,
+``/idptc-rookies``, ``/tools/ros-data-health``, ``/rankings/[position]``
+and every ``/league/*`` subroute.
+
+``server.py`` now ends with a catch-all that forwards anything
+unclaimed to Next.  These tests pin the properties that made the
+drift possible in the first place, so it cannot come back:
+
+  * no Next page 404s at the backend,
+  * the catch-all never swallows API or asset traffic,
+  * auth gating still applies to pages that need it.
+
+They fail loudly against the pre-catch-all server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_DIR = REPO_ROOT / "frontend" / "app"
+
+
+def _next_page_routes() -> list[str]:
+    """Derive the Next.js route table from the App Router file tree.
+
+    Deriving it here rather than hardcoding is the point: a new page
+    joins this test automatically, which is exactly the property the
+    hand-maintained list lacked.
+
+    Dynamic segments (``[position]``) and route groups are skipped —
+    they need a real parameter value to fetch, and the static routes
+    already prove the catch-all is wired.
+    """
+    routes: list[str] = []
+    for page in APP_DIR.rglob("page.jsx"):
+        rel = page.relative_to(APP_DIR).parent.as_posix()
+        route = "/" if rel == "." else "/" + rel
+        if "[" in route or "(" in route or route.startswith("/api"):
+            continue
+        routes.append(route)
+    return sorted(set(routes))
+
+
+def test_next_page_tree_is_discoverable():
+    """Guard the guard: if this returns nothing, the coverage test
+    below would vacuously pass and the drift could return unseen."""
+    routes = _next_page_routes()
+    assert len(routes) > 20, f"expected a populated Next route tree, got {routes}"
+    # Spot-check the three that actually drifted.
+    for drifted in ("/waivers", "/news", "/draft"):
+        assert drifted in routes, f"{drifted} missing from the derived route tree"
+
+
+@pytest.mark.parametrize("route", _next_page_routes())
+def test_every_next_page_is_routable(route):
+    """No Next page may 404 at the backend.
+
+    The backend is expected to be up while Next is not, so a 503
+    ("frontend unavailable") is a pass — that is the proxy correctly
+    reporting a missing upstream.  A 3xx to /login is a pass too: the
+    route resolved and the auth gate fired.  Only a 404 means the
+    route does not exist here, which is the drift this pins.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get(route, follow_redirects=False)
+    assert res.status_code != 404, (
+        f"{route} is a Next page but 404s at the backend — "
+        "the page-route catch-all is missing or shadowed"
+    )
+    assert res.status_code != 405, f"{route} rejected GET"
+
+
+def test_catch_all_does_not_swallow_unknown_api_paths():
+    """An unknown ``/api/*`` path must stay a JSON error, never get
+    proxied to Next as if it were a page.
+
+    401 rather than 404 is the correct answer here: ``_private_api_gate``
+    runs as middleware, ahead of routing, and rejects any ``/api/*`` path
+    outside the public allowlist without disclosing whether it exists.
+    Either status proves the point — what must NOT happen is an HTML
+    page body coming back from the frontend proxy.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/api/definitely-not-a-real-endpoint", follow_redirects=False)
+    assert res.status_code in (401, 404), (
+        f"unknown /api path returned {res.status_code} — if this is a 2xx the "
+        "catch-all is proxying API traffic to Next"
+    )
+    assert "application/json" in res.headers.get("content-type", "")
+
+
+def test_catch_all_still_gates_private_pages():
+    """Pages behind the auth gate must still redirect when signed out —
+    the catch-all must not become an accidental way around it."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/waivers", follow_redirects=False)
+    assert res.status_code in (302, 303, 307), (
+        f"/waivers should redirect an anonymous visitor, got {res.status_code}"
+    )
+    assert "/login" in res.headers.get("location", "")
+
+
+def test_catch_all_keeps_public_league_subroutes_public():
+    """``/league`` and its subroutes hydrate from the public pipeline
+    and must not demand a session."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.get("/league/activity", follow_redirects=False)
+    assert res.status_code not in (302, 303, 307), (
+        "/league/activity is public and must not redirect to login"
+    )
+    assert res.status_code != 404

--- a/tests/api/test_page_route_coverage.py
+++ b/tests/api/test_page_route_coverage.py
@@ -106,9 +106,11 @@ def test_catch_all_still_gates_private_pages():
     the catch-all must not become an accidental way around it."""
     with TestClient(server.app, raise_server_exceptions=True) as c:
         res = c.get("/waivers", follow_redirects=False)
-    assert res.status_code in (302, 303, 307), (
-        f"/waivers should redirect an anonymous visitor, got {res.status_code}"
-    )
+    assert res.status_code in (
+        302,
+        303,
+        307,
+    ), f"/waivers should redirect an anonymous visitor, got {res.status_code}"
     assert "/login" in res.headers.get("location", "")
 
 
@@ -117,7 +119,9 @@ def test_catch_all_keeps_public_league_subroutes_public():
     and must not demand a session."""
     with TestClient(server.app, raise_server_exceptions=True) as c:
         res = c.get("/league/activity", follow_redirects=False)
-    assert res.status_code not in (302, 303, 307), (
-        "/league/activity is public and must not redirect to login"
-    )
+    assert res.status_code not in (
+        302,
+        303,
+        307,
+    ), "/league/activity is public and must not redirect to login"
     assert res.status_code != 404


### PR DESCRIPTION
Fixes the two defects from #555 that are actionable now. The proxy's auth behaviour is **deliberately left alone** pending the "declare non-production-representative" decision.

## 1. A transient status timeout is no longer a sign-out

`useAuth` capped `/api/auth/status` at 5 s with an `AbortController` and, on timeout with no cached flag, resolved `authenticated = false` **with no retry**. One slow backend moment stranded a *valid* session on the anonymous shell for the entire life of the page — no nav, no search, no team switcher — until a manual reload.

**The 5 s cap stays.** It exists so a hung fetch can't wedge the UI on `checking = true`, which is a real failure mode. What changes is the *terminal* resolution.

`authenticated` is now honestly three-valued:

| value | meaning |
|---|---|
| `true` | the backend said so |
| `false` | the backend said so — a real signed-out user |
| `null` | unknown: still probing, or every probe so far failed |

Only a **200 is authoritative**. `/api/auth/status` is public and reports signed-out users as `200 + {authenticated:false}`, so a 5xx, an abort, or a network error tells us nothing about this user and must not be recorded as one. Those leave the state unknown and schedule another probe with backoff (1s, 2s, 4s, 8s, then every 30s), so a session unreachable at mount recovers on its own. `focus` and `online` also re-probe immediately, so a tab backgrounded or offline through the whole backoff recovers the moment it returns.

Pre-existing behaviour preserved and pinned: a cached "was signed in" still paints optimistically through a blip, and a real `no` still signs a stale cache out.

`authUnknown` is exposed so callers can distinguish "we never got an answer" from "the answer was no" without re-deriving it.

## 2. Page routes: forward what's unclaimed instead of 404ing

The hand-maintained route list had drifted **by more than was reported**. `/waivers`, `/news` and `/draft` were the known cases; the real count on this tree is **twelve** — `/angle`, `/trending`, `/players/compare`, `/league-comparison`, `/idptc-rookies`, `/design`, `/tools/ros-data-health` and the `/league/*` subroutes (`/league/activity`, `/league/phases`) all 404'd through the backend while serving fine from Next.

Replaced with a catch-all registered as the last route in the file. **Chosen over generating from Next's build manifest** because it's smaller, needs no build artefact at import time, and can't drift again by construction.

- Ordering is load-bearing (FastAPI matches in registration order), so the `/api/` and `/_next/` guards inside are belt-and-braces for the day someone appends a route below it.
- Auth gating preserved: pages default to requiring a session, `/league` and its subroutes stay public — matching the existing hand-written handlers.

## On declaring the proxy non-production-representative

**You're right, and the evidence is stronger than "nginx bypasses it."** `_proxy_next` forwards neither the request's cookies nor its query string. That's not a bug to patch, it's the absence of a reverse proxy: making it faithful means implementing cookie passthrough, query strings, header forwarding, streaming and status semantics — reimplementing nginx for a path production never takes. Declaring it non-production-representative is the correct call, and I'd add that the route list is still worth completing regardless, since dev and synthetic paths do use it and a 404 there costs real debugging time (it cost two agents exactly that).

So this PR makes the route list complete, **not** the proxy faithful. The cookie/query gap is documented inline at the catch-all so the next reader doesn't mistake it for an oversight.

## Deliberately not touched

- **`/league` SSR performance** (7-19 s) — real, but a separate perf investigation.
- **The proxy's auth mismatch** — pending the decision above.
- **Three-valued state in the shell.** `AppShellWrapper` passes `auth.authenticated === true` down, so `null` still renders as logged-out chrome; the user-visible win here is that it now *recovers in ~1 s* instead of never. Rendering a distinct "unknown" chrome is a design decision that belongs with the shell owner, not smuggled in here.

## Verification

- **`useAuth`: 8 new tests, 6 fail against the previous implementation.** Driven by simulated aborts and 5xx with fake timers rather than wall-clock assertions, since the defect is timing-dependent.
- **Route coverage: 32 tests, 14 fail against the previous server.** The test derives the Next route table from the App Router file tree instead of hardcoding it, so a new page joins the check automatically — the property the hand-maintained list lacked — and it guards itself against vacuously passing on an empty tree.
- Frontend vitest: **55 files / 1173 tests green**.
- Backend auth + route suites (`test_private_auth`, `test_page_route_coverage`, `test_cache_control_privacy`, `test_test_session_endpoint`): **70 passed**.
- `ruff format` + `ruff check` clean on `server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_