### PR TITLE
CI: fail loudly when a deploy would skip or reverse shipped code

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,11 @@ on:
         description: "Optional git ref (commit/tag/branch) to deploy. Default is current commit."
         required: false
         type: string
+      allow_non_fast_forward:
+        description: "Deploy even if it moves production BACKWARDS or sideways (intentional rollback). Normally leave false."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: production-deploy
@@ -198,6 +203,15 @@ jobs:
     timeout-minutes: 25
     environment: production
     steps:
+      # This job did not previously check out the repo — it only needed
+      # SSH.  The deploy-skip guard below does merge-base ancestry
+      # between the sha being deployed and the sha already in
+      # production, so it needs real history here.
+      - name: Checkout (full history for the deploy-skip guard)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Preflight validate deploy inputs (no SSH)
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
@@ -343,6 +357,113 @@ jobs:
              ( [[ -x /bin/journalctl ]] && sudo -n /bin/journalctl --version >/dev/null 2>&1 ) || ( [[ -x /usr/bin/journalctl ]] && sudo -n /usr/bin/journalctl --version >/dev/null 2>&1 ) || { echo \"[remote] missing NOPASSWD sudo permission for journalctl (/bin/journalctl or /usr/bin/journalctl)\" >&2; exit 20; }; \
              ( [[ -x /usr/bin/install ]] && sudo -n /usr/bin/install --version >/dev/null 2>&1 ) || ( [[ -x /bin/install ]] && sudo -n /bin/install --version >/dev/null 2>&1 ) || { echo \"[remote] missing NOPASSWD sudo permission for install (/usr/bin/install or /bin/install)\" >&2; exit 21; }; \
              echo '[remote] preflight checks passed'"
+
+      # ── Deploy-skip guard ────────────────────────────────────────────
+      # Concurrency group ``production-deploy`` sets
+      # ``cancel-in-progress: false``, which protects the RUNNING deploy
+      # but not queued ones: GitHub holds only ONE pending run per group,
+      # so when N merges land inside a few minutes each new run evicts the
+      # previously-queued one.  Only the first and last deploys survive;
+      # every middle merge's deploy is silently cancelled.
+      #
+      # That is harmless while the train is linear, because the surviving
+      # run's sha is a descendant and carries the evicted commits anyway.
+      # It is NOT harmless when it isn't: a revert, a force-push, or a
+      # ``workflow_dispatch`` pinned to an older ``deploy_ref`` (which
+      # this workflow accepts) can leave a commit that reached ``main``
+      # silently unshipped, with a grey "cancelled" tick as the only
+      # trace — and that tick reads as "my change failed to deploy" when
+      # it actually shipped.
+      #
+      # So assert the property rather than relying on it: whatever we are
+      # about to deploy must be a descendant of what is already in
+      # production.  Observed 2026-07-26, when three merges in nine
+      # minutes cancelled the middle deploy (run 30217214959).
+      - name: Guard against skipping or reversing a deploy
+        env:
+          DEPLOY_REF_INPUT: ${{ inputs.deploy_ref }}
+          ALLOW_NON_FF: ${{ inputs.allow_non_fast_forward }}
+          LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE: ${{ vars.PROD_LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE || '/home/dynasty/.deploy-state/trade-calculator.last_successful_deploy_commit' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          DEPLOY_REF="${DEPLOY_REF_INPUT:-${GITHUB_SHA}}"
+          SSH_PORT="${DEPLOY_PORT_RESOLVED}"
+          TARGET="${DEPLOY_USER_RESOLVED}@${DEPLOY_HOST_RESOLVED}"
+
+          # Read the last sha that actually reached production.  A missing
+          # or unreadable file is not an error — first deploy, or a fresh
+          # host — it just means there is no baseline to compare against.
+          LAST_DEPLOYED="$(
+            ssh \
+              -i "${DEPLOY_KEY_FILE}" \
+              -o BatchMode=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile="${DEPLOY_KNOWN_HOSTS_FILE}" \
+              -o ConnectTimeout=15 \
+              -p "${SSH_PORT}" \
+              "${TARGET}" \
+              "cat '${LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE}' 2>/dev/null | tr -d '[:space:]'" \
+            || true
+          )"
+
+          TARGET_SHA="$(git rev-parse --verify "${DEPLOY_REF}^{commit}" 2>/dev/null || true)"
+          if [[ -z "${TARGET_SHA}" ]]; then
+            echo "::error title=Unknown deploy ref::'${DEPLOY_REF}' does not resolve to a commit in this checkout."
+            exit 1
+          fi
+          echo "Deploying:      ${TARGET_SHA}"
+          echo "In production:  ${LAST_DEPLOYED:-<none recorded>}"
+
+          if [[ -z "${LAST_DEPLOYED}" ]]; then
+            echo "::notice title=No deploy baseline::No last-successful-deploy commit recorded; skipping the ancestry check. This is expected on a first deploy."
+            exit 0
+          fi
+
+          if ! git cat-file -e "${LAST_DEPLOYED}^{commit}" 2>/dev/null; then
+            echo "::warning title=Baseline commit not found::The recorded production commit ${LAST_DEPLOYED} is not in this repository — history may have been rewritten. Cannot verify the deploy moves forward."
+            if [[ "${ALLOW_NON_FF}" == "true" ]]; then
+              echo "allow_non_fast_forward=true — proceeding anyway."
+              exit 0
+            fi
+            echo "::error title=Cannot verify deploy safety::Re-run with allow_non_fast_forward=true if this is intentional."
+            exit 1
+          fi
+
+          if [[ "${LAST_DEPLOYED}" == "${TARGET_SHA}" ]]; then
+            echo "::notice title=Redeploy::Already at this commit; redeploying the same tree."
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor "${LAST_DEPLOYED}" "${TARGET_SHA}"; then
+            AHEAD="$(git rev-list --count "${LAST_DEPLOYED}..${TARGET_SHA}")"
+            echo "::notice title=Fast-forward deploy::Moving production forward by ${AHEAD} commit(s)."
+            # Name them, so a cancelled middle deploy is visibly carried
+            # rather than merely assumed to be.
+            git log --oneline --no-decorate "${LAST_DEPLOYED}..${TARGET_SHA}" | sed 's/^/  shipping: /'
+            exit 0
+          fi
+
+          # Not a fast-forward.  Either we are going backwards (deploying
+          # an ancestor of what is live) or the histories diverged.
+          if git merge-base --is-ancestor "${TARGET_SHA}" "${LAST_DEPLOYED}"; then
+            BEHIND="$(git rev-list --count "${TARGET_SHA}..${LAST_DEPLOYED}")"
+            REASON="this would move production BACKWARDS by ${BEHIND} commit(s), un-shipping code that is already live"
+          else
+            REASON="the deploy ref and the live commit have DIVERGED (neither is an ancestor of the other) — likely a force-push or an unrelated ref"
+          fi
+
+          echo "Commits that would be lost from production:"
+          git log --oneline --no-decorate "${TARGET_SHA}..${LAST_DEPLOYED}" | sed 's/^/  dropping: /'
+
+          if [[ "${ALLOW_NON_FF}" == "true" ]]; then
+            echo "::warning title=Non-fast-forward deploy::${REASON}. Proceeding because allow_non_fast_forward=true."
+            exit 0
+          fi
+
+          echo "::error title=Deploy would skip or reverse shipped code::${REASON}. If this is an intentional rollback, re-run via workflow_dispatch with allow_non_fast_forward=true."
+          exit 1
 
       - name: Run remote deploy script
         env:


### PR DESCRIPTION
## The hazard

`deploy.yml:19-21` sets:

```yaml
concurrency:
  group: production-deploy
  cancel-in-progress: false
```

`cancel-in-progress: false` protects the **running** deploy. It does not protect **queued** ones — GitHub holds only *one* pending run per concurrency group, so when several merges land close together each new run **evicts the previously-queued one**. Only the first and last deploys survive; every middle merge's deploy is silently cancelled.

**Observed today.** Three merges in nine minutes — #553, #556, #551. The middle run (`30217214959`, the IDP trade-finder fix) was cancelled with **zero jobs started**:

```
30217264780 | 253568bc | pending    | Redesign R3 (#551)     19:38:08
30217214959 | a2099f1b | CANCELLED  | Trade Finder (#556)    19:36:44
30216945074 | a8a9595e | in_progress| docs+ops (#553)        19:29:10
```

It was harmless — `a2099f1b` is an ancestor of `253568bc`, so the surviving R3 deploy carries the fix — but that had to be checked by hand to know it.

**The window is much wider than "a few minutes."** The concurrency group is held for the *whole workflow*, including `validate`. On #553's run the unit-test step alone took 14 minutes (19:29:51 → 19:43:49). Any two merges inside roughly a 16-minute window will collide, which during a merge train is most of them.

## Why it needs a gate, not a note

Two failure modes, both currently invisible:

1. **Silent skip.** A revert, a force-push, or a `workflow_dispatch` pinned to an older `deploy_ref` (which this workflow accepts) can leave a commit that reached `main` unshipped. Nothing in the pipeline reports it.
2. **Misleading signal.** A cancelled run shows a grey ✗ that reads as *"my change failed to deploy"* when it actually shipped — costing exactly the debugging time this session has already lost twice to signals that lie.

## The guard

A new step runs after the SSH preflight and before the deploy script. It reads the last successfully-deployed sha off the host — the workflow already knows where that lives (`PROD_LAST_SUCCESSFUL_DEPLOY_COMMIT_FILE`) — and requires it to be an ancestor of what is about to be deployed.

| Case | Result |
|---|---|
| fast-forward | **pass**, and *lists the commits being shipped* |
| same commit | pass (redeploy) |
| no baseline recorded | pass (first deploy / fresh host) |
| moves backwards | **fail** — names the commits that would be un-shipped |
| histories diverged | **fail** — force-push or unrelated ref |
| baseline not in repo | **fail** — history rewritten, cannot verify |

The fast-forward case listing what it ships is the part that fixes the *ambiguity*, not just the risk: an evicted middle deploy becomes visibly carried in the log rather than assumed to be.

`workflow_dispatch` gains `allow_non_fast_forward` (default false) so an intentional rollback is one checkbox away rather than blocked outright.

## Verification

All seven branches exercised offline against **real shas from today's train**, not synthetic ones:

```
1. TODAY'S REAL CASE — prod at a8a9595e (#553), deploying 253568bc (R3)
   PASS: fast-forward by 2 commit(s)
       shipping: 253568bc Redesign R3 (#551)
       shipping: a2099f1b Trade Finder — IDP fix (#556)   ← the evicted deploy, visibly carried

2. THE DANGEROUS INVERSE — prod at 253568bc, someone dispatches older a8a9595e
   FAIL: BACKWARDS by 2 commit(s)
       dropping: 253568bc Redesign R3 (#551)
       dropping: a2099f1b Trade Finder — IDP fix (#556)

3. Same, with allow_non_fast_forward=true   → PASS(override)
4. Redeploy same commit                     → PASS
5. No baseline                              → PASS
6. Baseline commit not in repo              → FAIL
7. Diverged histories                       → FAIL (names all 24 commits it would drop)
```

Case 1 is the proof the guard would have made today's cancellation self-explaining instead of something I had to investigate.

## One structural change

The `deploy` job **did not previously check out the repo** — it only needed SSH. It now does, with `fetch-depth: 0`, which `merge-base` requires. The `validate` job's checkout is deliberately left shallow so this costs nothing there.

## Risk

The guard only ever *blocks* a deploy; it cannot cause a bad one. Its failure modes are conservative: no baseline passes, unreadable baseline file passes, and every genuine block has an override. The one behaviour change to a currently-succeeding path is the added checkout in the deploy job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_