### PR TITLE
WS-J Roster Intelligence Engine: marginal contribution, per-position profiles, competitive window

### DIFF
--- a/src/roster_intel/__init__.py
+++ b/src/roster_intel/__init__.py
@@ -1,0 +1,6 @@
+"""Roster Intelligence Engine (WS-J).
+
+Pure computation over a supplied player pool. Consumes the League
+Intelligence modules (exact scorer, exact best-ball optimizer,
+replacement levels, value schema) as-is and never re-implements them.
+"""

--- a/src/roster_intel/engine.py
+++ b/src/roster_intel/engine.py
@@ -1,0 +1,410 @@
+"""Roster-level rollups — the single entry point for WS-J.
+
+Composes the pieces into one per-roster payload: values, marginal
+strength, per-position profiles, the competitive window, and (when the
+caller supplies simulator output) playoff and championship probability.
+
+``src/ros/playoff_sim.py`` is CONSUMED, not duplicated.  It already
+models the remaining schedule, per-team variance and the bracket; a
+second simulator here would be a parallel path and the two would drift.
+This module takes its output as an input and reads the rows it needs.
+
+Fragility semantics — read this before exporting it
+───────────────────────────────────────────────────
+A consuming agent derived "deficit" as ``fragility x marginal`` and got
+QB reported as the biggest need on a QB-STRONG roster.  That inversion
+is not a bug in fragility; it is fragility being read as the wrong
+quantity.
+
+    fragility  = CONCENTRATION. Share of an absent starter's value the
+                 roster fails to replace. High fragility means the
+                 position's output is concentrated in few players.
+    marginal   = CONTRIBUTION. What the position adds to the optimal
+                 lineup.
+
+A great QB room in a superflex league is BOTH high-marginal and
+high-fragility: the two starters are excellent and nobody behind them
+is close.  Multiplying those reports the roster's greatest STRENGTH as
+its greatest need.
+
+Deficiency is a different measurement and is provided here as
+``PositionNeed.deficit`` so consumers stop deriving it: it is the gap
+between what the position contributes and what a replacement-level
+occupant of the same slots would contribute.  Low contribution relative
+to replacement is a deficit; high concentration is a RISK, and the two
+are reported separately because they call for different moves — a
+deficit says acquire a starter, concentration says acquire insurance.
+
+Pure computation.  No I/O, no network, no clock.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from src.league_intel.replacement import PositionReplacement
+from src.roster_intel.marginal import position_marginals, solve_summary
+from src.roster_intel.profiles import RosterProfile, build_position_profiles
+from src.roster_intel.window import CompetitiveWindow, compute_window
+from src.ros.lineup import RosterPlayer
+
+__all__ = [
+    "PositionNeed",
+    "RosterIntel",
+    "RosterValues",
+    "analyze_roster",
+    "position_needs",
+]
+
+
+@dataclass(frozen=True)
+class RosterValues:
+    """Value rollups across the parallel scales (LI-4 schema).
+
+    Kept as separate fields rather than one blended number: the whole
+    point of the LI-4 schema is that market, consensus and
+    league-adjusted can disagree, and a blend hides the disagreement
+    that makes a trade findable.
+    """
+
+    market: float = 0.0
+    consensus: float = 0.0
+    league_adjusted: float = 0.0
+    ros: float = 0.0
+    # Starting-lineup ROS value vs everything else.
+    starters_ros: float = 0.0
+    bench_ros: float = 0.0
+    pick_value: float = 0.0
+    priced_players: int = 0
+    unpriced_players: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "market": round(self.market, 3),
+            "consensus": round(self.consensus, 3),
+            "leagueAdjusted": round(self.league_adjusted, 3),
+            "ros": round(self.ros, 3),
+            "startersRos": round(self.starters_ros, 3),
+            "benchRos": round(self.bench_ros, 3),
+            "pickValue": round(self.pick_value, 3),
+            "pricedPlayers": self.priced_players,
+            "unpricedPlayers": self.unpriced_players,
+        }
+
+
+@dataclass(frozen=True)
+class PositionNeed:
+    """Deficiency and risk, kept SEPARATE (see module docstring).
+
+    ``deficit`` answers "am I below replacement here" — acquire a
+    starter.  ``concentration_risk`` answers "would one absence hurt" —
+    acquire insurance.  A consumer that multiplies them reproduces the
+    QB inversion.
+    """
+
+    position: str
+    deficit: float
+    concentration_risk: float
+    replacement_baseline: float | None
+    actual_contribution: float
+    urgent: bool
+    reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "deficit": round(self.deficit, 3),
+            "concentrationRisk": round(self.concentration_risk, 4),
+            "replacementBaseline": (
+                round(self.replacement_baseline, 3)
+                if self.replacement_baseline is not None
+                else None
+            ),
+            "actualContribution": round(self.actual_contribution, 3),
+            "urgent": self.urgent,
+            "reasons": list(self.reasons),
+            "_semantics": {
+                "deficit": "contribution shortfall vs a replacement-level occupant; >0 means acquire a starter",
+                "concentrationRisk": "share of an absent starter's value not replaced; high means acquire insurance",
+                "warning": "do NOT multiply these; concentration is not deficiency (a strong room is high on both)",
+            },
+        }
+
+
+def position_needs(
+    profile: RosterProfile,
+    replacement: Mapping[str, PositionReplacement] | None = None,
+) -> dict[str, PositionNeed]:
+    """Deficit and concentration risk per position.
+
+    ``deficit`` = what a replacement-level occupant of this position's
+    dedicated slots WOULD contribute, minus what the roster actually
+    contributes.  Positive means the roster is below replacement there.
+
+    Deliberately NOT derived from fragility: fragility measures
+    concentration, and a strong concentrated room would invert into a
+    phantom need (the exact defect a consumer hit).
+    """
+    out: dict[str, PositionNeed] = {}
+    for pos, prof in profile.positions.items():
+        rep = (replacement or {}).get(pos)
+        baseline_per_slot = rep.value("starter") if rep else None
+        req = prof.required_slots
+
+        if baseline_per_slot is not None and req > 0:
+            baseline = baseline_per_slot * req
+            deficit = max(0.0, baseline - prof.marginal_points)
+        else:
+            baseline = None
+            deficit = 0.0
+
+        reasons = list(prof.need_reasons)
+        if deficit > 0 and baseline:
+            reasons.append(
+                f"contributes {prof.marginal_points:.0f} vs a replacement-level "
+                f"{baseline:.0f} across {req} dedicated slot(s)"
+            )
+
+        out[pos] = PositionNeed(
+            position=pos,
+            deficit=deficit,
+            concentration_risk=prof.fragility,
+            replacement_baseline=baseline,
+            actual_contribution=prof.marginal_points,
+            urgent=prof.urgent_need or deficit > 0,
+            reasons=tuple(reasons),
+        )
+    return out
+
+
+@dataclass(frozen=True)
+class RosterIntel:
+    """Everything WS-J knows about one roster."""
+
+    owner_id: str
+    values: RosterValues
+    lineup_score: float
+    filled_slots: int
+    total_slots: int
+    profile: RosterProfile
+    needs: dict[str, PositionNeed]
+    window: CompetitiveWindow
+    playoff_odds: float | None = None
+    championship_odds: float | None = None
+    playoff_odds_ci: tuple[float, float] | None = None
+    championship_odds_ci: tuple[float, float] | None = None
+    odds_source: str = "unavailable"
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ownerId": self.owner_id,
+            "values": self.values.to_dict(),
+            "lineupScore": round(self.lineup_score, 3),
+            "filledSlots": self.filled_slots,
+            "totalSlots": self.total_slots,
+            "positions": self.profile.to_dict()["positions"],
+            "needs": {k: v.to_dict() for k, v in sorted(self.needs.items())},
+            "competitiveWindow": self.window.to_dict(),
+            "playoffOdds": self.playoff_odds,
+            "playoffOddsCi": list(self.playoff_odds_ci) if self.playoff_odds_ci else None,
+            "championshipOdds": self.championship_odds,
+            "championshipOddsCi": (
+                list(self.championship_odds_ci) if self.championship_odds_ci else None
+            ),
+            "oddsSource": self.odds_source,
+            "notes": list(self.notes),
+        }
+
+
+def _rollup_values(
+    pool: Sequence[RosterPlayer],
+    entered_ids: frozenset[str],
+    player_values: Mapping[str, Mapping[str, Any]] | None,
+    pick_value: float,
+) -> RosterValues:
+    """Sum the parallel value scales over the roster.
+
+    NOTE: these are portfolio totals, deliberately NOT a strength
+    signal.  Strength is marginal (see ``marginal.py``); a summed
+    portfolio is what you would trade, not what you would score.
+    """
+    pv = player_values or {}
+    market = consensus = adjusted = ros = starters = bench = 0.0
+    priced = unpriced = 0
+    for p in pool:
+        ros += max(0.0, p.ros_value)
+        if p.ros_value > 0:
+            priced += 1
+        else:
+            unpriced += 1
+        if p.player_id in entered_ids:
+            starters += max(0.0, p.ros_value)
+        else:
+            bench += max(0.0, p.ros_value)
+        row = pv.get(p.player_id) or pv.get(p.canonical_name) or {}
+        market += float(row.get("marketValue") or 0.0)
+        consensus += float(row.get("consensusValue") or 0.0)
+        adjusted += float(row.get("leagueAdjustedDynastyValue") or row.get("consensusValue") or 0.0)
+    return RosterValues(
+        market=market,
+        consensus=consensus,
+        league_adjusted=adjusted,
+        ros=ros,
+        starters_ros=starters,
+        bench_ros=bench,
+        pick_value=pick_value,
+        priced_players=priced,
+        unpriced_players=unpriced,
+    )
+
+
+def _unpriced_note(pool: Sequence[RosterPlayer]) -> str | None:
+    """Warn that ``unpricedPlayers == 0`` is not proof of a clean join.
+
+    ``roster_source.build_roster_pool`` DROPS names it cannot value, so
+    on that path the count is structurally zero (measured: 0 for all 12
+    real rosters while 32 of 665 rostered names were dropped).  Other
+    builders — ``src/ros/team_strength.py`` — keep unvalued players at
+    0.0 instead, and there the count is real.  A reader cannot tell
+    which builder produced the pool from the number alone, so say so
+    rather than let 0 be read as full coverage.
+    """
+    if any(p.ros_value <= 0 for p in pool):
+        return None
+    return (
+        "unpricedPlayers is 0 because every player IN the pool carries a value; "
+        "this is not a join-coverage claim — builders that drop unvalued names "
+        "(roster_source.build_roster_pool) report their losses in JoinReport"
+    )
+
+
+def _odds_for(
+    owner_id: str,
+    playoff_odds: Sequence[Mapping[str, Any]] | None,
+) -> tuple[float | None, float | None, tuple[float, float] | None, tuple[float, float] | None, str]:
+    """Pull this owner's rows out of playoff_sim output.
+
+    Reads the schema ``src/ros/playoff_sim.py`` emits, including the
+    Wilson intervals LI-8 added.  Missing intervals are None rather
+    than zero-width: a point estimate with no interval must not read as
+    a certainty.
+    """
+    if not playoff_odds:
+        return None, None, None, None, "unavailable"
+    row = next((r for r in playoff_odds if str(r.get("ownerId")) == str(owner_id)), None)
+    if row is None:
+        return None, None, None, None, "owner_not_in_simulation"
+
+    def _ci(key: str) -> tuple[float, float] | None:
+        raw = row.get(key)
+        if isinstance(raw, (list, tuple)) and len(raw) == 2:
+            return (float(raw[0]), float(raw[1]))
+        return None
+
+    po = row.get("playoffOdds")
+    ch = row.get("championshipOdds")
+    return (
+        float(po) if po is not None else None,
+        float(ch) if ch is not None else None,
+        _ci("playoffOddsCi"),
+        _ci("championshipOddsCi"),
+        "playoff_sim",
+    )
+
+
+def analyze_roster(
+    owner_id: str,
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    *,
+    replacement: Mapping[str, PositionReplacement] | None = None,
+    player_meta: Mapping[str, Mapping[str, Any]] | None = None,
+    player_values: Mapping[str, Mapping[str, Any]] | None = None,
+    pick_value: float = 0.0,
+    playoff_odds: Sequence[Mapping[str, Any]] | None = None,
+    lineup_scores: Mapping[str, float] | None = None,
+    override_state: str | None = None,
+    override_reason: str | None = None,
+) -> RosterIntel:
+    """Full WS-J analysis for one roster.
+
+    ``playoff_odds`` is ``simulate_playoff_odds(...)["playoffOdds"]``
+    from ``src/ros/playoff_sim.py``.  Supplying it upgrades the
+    competitive window's competitiveness axis from a structural proxy
+    to simulated odds AND attaches the probabilities directly.
+    """
+    pool_list = list(pool)
+    slots_list = list(slots)
+
+    marg = position_marginals(pool_list, slots_list)
+    entered = solve_summary(pool_list, slots_list).assigned_ids
+
+    profile = build_position_profiles(
+        pool_list,
+        slots_list,
+        replacement=replacement,
+        player_meta=player_meta,
+        marginals=marg,
+    )
+    needs = position_needs(profile, replacement)
+    window = compute_window(
+        owner_id,
+        pool_list,
+        slots_list,
+        playoff_odds=playoff_odds,
+        lineup_scores=lineup_scores,
+        player_meta=player_meta,
+        override_state=override_state,
+        override_reason=override_reason,
+    )
+    po, ch, po_ci, ch_ci, src = _odds_for(owner_id, playoff_odds)
+
+    notes: list[str] = []
+    if src == "unavailable":
+        notes.append(
+            "no playoff_sim output supplied; playoff/championship odds omitted "
+            "and the competitive window fell back to a structural proxy"
+        )
+    elif src == "owner_not_in_simulation":
+        notes.append(f"owner {owner_id!r} absent from the supplied simulation rows")
+    if replacement is None:
+        notes.append(
+            "no replacement levels supplied; tiers default to developmental "
+            "and position deficits are not computed"
+        )
+    if window.inputs.trajectory_sample == 0 and not window.overridden:
+        # Escalated to the roster level deliberately.  With no ages the
+        # window keeps its second axis pinned at neutral and the whole
+        # distribution reduces to a one-dimensional read of
+        # competitiveness — which silently makes some states (a young
+        # roster losing now) unreachable.  Measured on the real league:
+        # with ages absent, `productive_struggle` was the most-likely
+        # state for zero of twelve teams.  That is a wiring gap, not a
+        # property of the league, and it must not read as a finding.
+        notes.append(
+            "no ages reached the window for any lineup entrant; the trajectory "
+            "axis is pinned neutral and the distribution is a competitiveness-only "
+            "read (states that require a young or old roster are unreachable) — "
+            "supply player_meta ages"
+        )
+    if unpriced_note := _unpriced_note(pool_list):
+        notes.append(unpriced_note)
+
+    return RosterIntel(
+        owner_id=owner_id,
+        values=_rollup_values(pool_list, entered, player_values, pick_value),
+        lineup_score=marg.lineup_score,
+        filled_slots=marg.filled_slots,
+        total_slots=marg.total_slots,
+        profile=profile,
+        needs=needs,
+        window=window,
+        playoff_odds=po,
+        championship_odds=ch,
+        playoff_odds_ci=po_ci,
+        championship_odds_ci=ch_ci,
+        odds_source=src,
+        notes=tuple(notes),
+    )

--- a/src/roster_intel/engine.py
+++ b/src/roster_intel/engine.py
@@ -414,9 +414,13 @@ def analyze_roster(
         # distribution reduces to a one-dimensional read of
         # competitiveness — which silently makes some states (a young
         # roster losing now) unreachable.  Measured on the real league:
-        # with ages absent, `productive_struggle` was the most-likely
-        # state for zero of twelve teams.  That is a wiring gap, not a
-        # property of the league, and it must not read as a finding.
+        # ages absent, `productive_struggle` was the most-likely state
+        # for zero of twelve teams; ages joined, for one.  That is a
+        # wiring gap, not a property of the league, and it must not read
+        # as a finding.  Ages are available offline in
+        # data/public_league/nfl_players_full.json (10,954 of 12,201
+        # entries) and on the live Sleeper overlay — there is no reason
+        # for a caller to leave this empty.
         notes.append(
             "no ages reached the window for any lineup entrant; the trajectory "
             "axis is pinned neutral and the distribution is a competitiveness-only "

--- a/src/roster_intel/engine.py
+++ b/src/roster_intel/engine.py
@@ -280,22 +280,38 @@ def _unpriced_note(pool: Sequence[RosterPlayer]) -> str | None:
     )
 
 
+@dataclass(frozen=True)
+class _Odds:
+    playoff: float | None = None
+    championship: float | None = None
+    playoff_ci: tuple[float, float] | None = None
+    championship_ci: tuple[float, float] | None = None
+    source: str = "unavailable"
+    notes: tuple[str, ...] = ()
+
+
 def _odds_for(
     owner_id: str,
     playoff_odds: Sequence[Mapping[str, Any]] | None,
-) -> tuple[float | None, float | None, tuple[float, float] | None, tuple[float, float] | None, str]:
-    """Pull this owner's rows out of playoff_sim output.
+) -> _Odds:
+    """Pull this owner's row out of playoff_sim output.
 
-    Reads the schema ``src/ros/playoff_sim.py`` emits, including the
-    Wilson intervals LI-8 added.  Missing intervals are None rather
-    than zero-width: a point estimate with no interval must not read as
-    a certainty.
+    The simulator's row schema is NOT fixed.  ``simulate_playoff_odds``
+    on main emits ``playoffOdds`` / ``byeOdds`` / ``topSeedOdds`` /
+    ``seedDistribution`` and NOTHING else — no championship odds and no
+    confidence intervals.  The bracket run and the Wilson intervals
+    come from the LI-8 work, which is a separate unmerged branch.
+
+    So the fields are read defensively AND their absence is reported.
+    Missing intervals stay None rather than collapsing to zero width: a
+    point estimate presented without an interval reads as a certainty,
+    and 0.61 from 2,000 sims is +/- 2 points.
     """
     if not playoff_odds:
-        return None, None, None, None, "unavailable"
+        return _Odds()
     row = next((r for r in playoff_odds if str(r.get("ownerId")) == str(owner_id)), None)
     if row is None:
-        return None, None, None, None, "owner_not_in_simulation"
+        return _Odds(source="owner_not_in_simulation")
 
     def _ci(key: str) -> tuple[float, float] | None:
         raw = row.get(key)
@@ -305,12 +321,29 @@ def _odds_for(
 
     po = row.get("playoffOdds")
     ch = row.get("championshipOdds")
-    return (
-        float(po) if po is not None else None,
-        float(ch) if ch is not None else None,
-        _ci("playoffOddsCi"),
-        _ci("championshipOddsCi"),
-        "playoff_sim",
+    playoff_ci = _ci("playoffOddsCi")
+    championship_ci = _ci("championshipOddsCi")
+
+    notes: list[str] = []
+    if ch is None:
+        notes.append(
+            "simulator supplied no championshipOdds; this build of "
+            "src/ros/playoff_sim.py stops at playoff qualification and does "
+            "not run the bracket"
+        )
+    if po is not None and playoff_ci is None:
+        notes.append(
+            "playoff odds carry no confidence interval; treat the point "
+            "estimate as approximate and do not compare two teams on it alone"
+        )
+
+    return _Odds(
+        playoff=float(po) if po is not None else None,
+        championship=float(ch) if ch is not None else None,
+        playoff_ci=playoff_ci,
+        championship_ci=championship_ci,
+        source="playoff_sim",
+        notes=tuple(notes),
     )
 
 
@@ -359,16 +392,17 @@ def analyze_roster(
         override_state=override_state,
         override_reason=override_reason,
     )
-    po, ch, po_ci, ch_ci, src = _odds_for(owner_id, playoff_odds)
+    odds = _odds_for(owner_id, playoff_odds)
 
     notes: list[str] = []
-    if src == "unavailable":
+    if odds.source == "unavailable":
         notes.append(
             "no playoff_sim output supplied; playoff/championship odds omitted "
             "and the competitive window fell back to a structural proxy"
         )
-    elif src == "owner_not_in_simulation":
+    elif odds.source == "owner_not_in_simulation":
         notes.append(f"owner {owner_id!r} absent from the supplied simulation rows")
+    notes.extend(odds.notes)
     if replacement is None:
         notes.append(
             "no replacement levels supplied; tiers default to developmental "
@@ -401,10 +435,10 @@ def analyze_roster(
         profile=profile,
         needs=needs,
         window=window,
-        playoff_odds=po,
-        championship_odds=ch,
-        playoff_odds_ci=po_ci,
-        championship_odds_ci=ch_ci,
-        odds_source=src,
+        playoff_odds=odds.playoff,
+        championship_odds=odds.championship,
+        playoff_odds_ci=odds.playoff_ci,
+        championship_odds_ci=odds.championship_ci,
+        odds_source=odds.source,
         notes=tuple(notes),
     )

--- a/src/roster_intel/marginal.py
+++ b/src/roster_intel/marginal.py
@@ -1,0 +1,341 @@
+"""Marginal best-ball contribution — the measurement everything else rests on.
+
+Positional strength is NOT summed value and NOT player count.  Both are
+easy to compute and both are wrong in a best-ball superflex league, for
+the same reason: they credit players who never play.
+
+A concrete failure the count/sum proxies produce, and this module does
+not.  Take a roster with five high-value QBs in a league with one QB slot
+and one SUPER_FLEX.  Summed value calls that the strongest QB room in the
+league.  Counting calls it five-deep.  In reality at most two QBs ever
+score, the third through fifth contribute only insurance, and the roster
+is starving other positions to hold them.  ``lineup.py``'s exact
+optimizer already knows this — it simply was never asked.
+
+So every strength number here is defined by re-solving the optimal
+lineup with something removed and measuring what the score loses:
+
+    marginal(position) = S(full roster) − S(roster without that position)
+    marginal(player)   = S(full roster) − S(roster without that player)
+
+That is the player's or group's actual contribution to the optimized
+lineup, which is exactly the quantity the brief demands and exactly what
+a name-value proxy cannot see.
+
+The second half of the brief — "or preserve output during absences" — is
+the ``absence`` family.  A position can contribute little marginal value
+because it is thin (bad) or because its backups are nearly as good as its
+starters (good).  Marginal contribution alone cannot tell those apart;
+leave-one-out absence drops can, so both are reported.
+
+Pure computation.  No I/O, no network, no clock — mirrors
+``src/league_intel/replacement.py``'s shape and consumes
+``src/ros/lineup.py`` as-is.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.league_intel.replacement import normalize_base_position
+from src.ros.lineup import RosterPlayer, solve_optimal_assignment
+
+__all__ = [
+    "AbsenceImpact",
+    "LineupSolutionSummary",
+    "PositionMarginal",
+    "RosterMarginals",
+    "absence_impacts",
+    "optimal_score",
+    "position_marginals",
+    "solve_summary",
+    "to_roster_players",
+]
+
+
+def to_roster_players(players: Iterable[Mapping[str, Any]]) -> list[RosterPlayer]:
+    """Map contract-shaped dicts onto the optimizer's frozen dataclass.
+
+    Mirrors ``replacement._to_roster_players`` deliberately: the two
+    modules must agree on how a roster row becomes an optimizer input,
+    or their numbers stop being comparable.  ``fantasyPositions`` is
+    carried through because Sleeper evaluates slot eligibility against
+    it (LI-3/ADR-007) — dropping it silently benches hybrid IDPs.
+    """
+    out: list[RosterPlayer] = []
+    for p in players:
+        out.append(
+            RosterPlayer(
+                player_id=str(p.get("playerId") or p.get("canonicalName") or ""),
+                canonical_name=str(p.get("canonicalName") or p.get("name") or ""),
+                position=str(p.get("position") or "").upper(),
+                ros_value=float(p.get("rosValue") or 0.0),
+                confidence=float(p.get("confidence") or 0.0),
+                injured=bool(p.get("injured")),
+                bye=bool(p.get("bye")),
+                fantasy_positions=tuple(
+                    str(fp).upper() for fp in (p.get("fantasyPositions") or ())
+                ),
+            )
+        )
+    return out
+
+
+@dataclass(frozen=True)
+class LineupSolutionSummary:
+    """One optimal-lineup solve, reduced to what the callers need."""
+
+    score: float
+    assigned_ids: frozenset[str]
+    # slot label -> player_id, so callers can see WHERE a player entered
+    # (a QB filling SUPER_FLEX is a different fact from a QB filling QB).
+    slot_assignment: dict[str, str] = field(default_factory=dict)
+    filled_slots: int = 0
+    total_slots: int = 0
+
+    @property
+    def unfilled_slots(self) -> int:
+        return max(0, self.total_slots - self.filled_slots)
+
+
+def solve_summary(
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+) -> LineupSolutionSummary:
+    """Solve the exact assignment and summarize it.
+
+    Thin wrapper over ``solve_optimal_assignment`` so this module never
+    reimplements lineup logic — the optimizer is consumed, not rebuilt.
+    """
+    slots_list = list(slots)
+    if not pool or not slots_list:
+        return LineupSolutionSummary(
+            score=0.0,
+            assigned_ids=frozenset(),
+            slot_assignment={},
+            filled_slots=0,
+            total_slots=len(slots_list),
+        )
+    assignment = solve_optimal_assignment(list(pool), slots_list)
+    score = float(sum(p.ros_value for p in assignment.values()))
+    slot_map: dict[str, str] = {}
+    for slot_idx, player in assignment.items():
+        # Key by index-qualified slot so duplicate slot labels (RB, RB)
+        # do not collide.
+        slot_map[f"{slots_list[slot_idx]}#{slot_idx}"] = player.player_id
+    return LineupSolutionSummary(
+        score=score,
+        assigned_ids=frozenset(p.player_id for p in assignment.values()),
+        slot_assignment=slot_map,
+        filled_slots=len(assignment),
+        total_slots=len(slots_list),
+    )
+
+
+def optimal_score(pool: Sequence[RosterPlayer], slots: Sequence[str]) -> float:
+    """Optimal lineup score for a pool.  Convenience for delta math."""
+    return solve_summary(pool, slots).score
+
+
+@dataclass(frozen=True)
+class PositionMarginal:
+    """What one position actually contributes to the optimized lineup."""
+
+    position: str
+    rostered: int
+    priced: int
+    # S(full) − S(full minus every player at this position).
+    marginal_points: float
+    # Share of the full lineup score this position is responsible for.
+    marginal_share: float
+    # How many of this position's players entered the optimal lineup,
+    # and where.
+    entered_lineup: int
+    entry_rate: float
+    slots_filled: tuple[str, ...]
+    # Players with real value that never enter, even though they are
+    # rostered — the clog signal.
+    non_entering_priced: int
+    clogger_value: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "rostered": self.rostered,
+            "priced": self.priced,
+            "marginalPoints": round(self.marginal_points, 3),
+            "marginalShare": round(self.marginal_share, 4),
+            "enteredLineup": self.entered_lineup,
+            "entryRate": round(self.entry_rate, 4),
+            "slotsFilled": list(self.slots_filled),
+            "nonEnteringPriced": self.non_entering_priced,
+            "cloggerValue": round(self.clogger_value, 3),
+        }
+
+
+@dataclass(frozen=True)
+class RosterMarginals:
+    """Full-roster marginal picture."""
+
+    lineup_score: float
+    filled_slots: int
+    total_slots: int
+    by_position: dict[str, PositionMarginal] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lineupScore": round(self.lineup_score, 3),
+            "filledSlots": self.filled_slots,
+            "totalSlots": self.total_slots,
+            "byPosition": {k: v.to_dict() for k, v in sorted(self.by_position.items())},
+        }
+
+
+def _base_of(player: RosterPlayer) -> str:
+    return normalize_base_position(player.position)
+
+
+def position_marginals(
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+) -> RosterMarginals:
+    """Marginal contribution of every position on one roster.
+
+    For each position P present on the roster we re-solve the lineup
+    with all of P removed.  The score difference is P's contribution.
+    This is deliberately a GROUP leave-out rather than a sum of
+    individual leave-outs: individual marginals do not add up, because
+    removing a team's QB1 promotes QB2 into the same slot.  Summing
+    them would double-count the slot and inflate every deep position.
+    """
+    pool_list = list(pool)
+    slots_list = list(slots)
+    full = solve_summary(pool_list, slots_list)
+
+    by_pos: dict[str, list[RosterPlayer]] = {}
+    for p in pool_list:
+        base = _base_of(p)
+        if base:
+            by_pos.setdefault(base, []).append(p)
+
+    out: dict[str, PositionMarginal] = {}
+    for pos, players in by_pos.items():
+        remaining = [p for p in pool_list if _base_of(p) != pos]
+        without = solve_summary(remaining, slots_list)
+        marginal = full.score - without.score
+
+        entered = [p for p in players if p.player_id in full.assigned_ids]
+        slots_filled = tuple(
+            sorted(
+                slot.split("#")[0]
+                for slot, pid in full.slot_assignment.items()
+                if pid in {p.player_id for p in entered}
+            )
+        )
+        priced = [p for p in players if p.ros_value > 0]
+        non_entering = [p for p in priced if p.player_id not in full.assigned_ids]
+
+        out[pos] = PositionMarginal(
+            position=pos,
+            rostered=len(players),
+            priced=len(priced),
+            marginal_points=marginal,
+            marginal_share=(marginal / full.score) if full.score > 0 else 0.0,
+            entered_lineup=len(entered),
+            entry_rate=(len(entered) / len(players)) if players else 0.0,
+            slots_filled=slots_filled,
+            non_entering_priced=len(non_entering),
+            clogger_value=float(sum(p.ros_value for p in non_entering)),
+        )
+
+    return RosterMarginals(
+        lineup_score=full.score,
+        filled_slots=full.filled_slots,
+        total_slots=full.total_slots,
+        by_position=out,
+    )
+
+
+@dataclass(frozen=True)
+class AbsenceImpact:
+    """How well a position preserves output when one starter is gone.
+
+    ``mean_drop`` is the average points lost across leave-one-out solves
+    for each of this position's lineup entrants.  ``worst_drop`` is the
+    single most damaging absence — the one that actually keeps a manager
+    up at night, and the number a mean hides.
+    """
+
+    position: str
+    starters_tested: int
+    mean_drop: float
+    worst_drop: float
+    # Share of an absent starter's OWN value that the roster fails to
+    # replace: 0 means the next player up is just as good (deep), 1
+    # means the starter is irreplaceable on this roster (fragile).
+    #
+    # Deliberately normalized by mean entrant value, NOT by the
+    # position's marginal contribution.  The marginal denominator is
+    # degenerate: for n entrants with no bench behind them the
+    # individual drops sum to the group marginal, so mean_drop/marginal
+    # collapses to ~1/n and reports the SAME number for a deep room and
+    # a thin one.  That is the `_positional_coverage` failure mode (a
+    # constant wearing a score's clothes) and it is guarded by
+    # test_fragility_separates_deep_from_thin.
+    fragility: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "startersTested": self.starters_tested,
+            "meanDrop": round(self.mean_drop, 3),
+            "worstDrop": round(self.worst_drop, 3),
+            "fragility": round(self.fragility, 4),
+        }
+
+
+def absence_impacts(
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+) -> dict[str, AbsenceImpact]:
+    """Leave-one-out absence cost per position.
+
+    This is the "preserve output during absences" half of strength.  A
+    position whose marginal contribution is large but whose worst-case
+    absence drop is small is genuinely strong; one where a single
+    absence erases most of the contribution is a starter plus wishes.
+
+    Cost is O(entrants × solve), which at roster scale (≤60 players,
+    ≤25 slots) is trivial — the optimizer is O(P·S·E).
+    """
+    pool_list = list(pool)
+    slots_list = list(slots)
+    full = solve_summary(pool_list, slots_list)
+
+    by_pos: dict[str, list[RosterPlayer]] = {}
+    for p in pool_list:
+        if p.player_id in full.assigned_ids:
+            base = _base_of(p)
+            if base:
+                by_pos.setdefault(base, []).append(p)
+
+    out: dict[str, AbsenceImpact] = {}
+    for pos, entrants in by_pos.items():
+        drops: list[float] = []
+        for target in entrants:
+            remaining = [p for p in pool_list if p.player_id != target.player_id]
+            drops.append(max(0.0, full.score - solve_summary(remaining, slots_list).score))
+        if not drops:
+            continue
+        mean_drop = sum(drops) / len(drops)
+        worst = max(drops)
+        mean_entrant_value = sum(p.ros_value for p in entrants) / len(entrants)
+        out[pos] = AbsenceImpact(
+            position=pos,
+            starters_tested=len(drops),
+            mean_drop=mean_drop,
+            worst_drop=worst,
+            fragility=(min(1.0, mean_drop / mean_entrant_value) if mean_entrant_value > 0 else 0.0),
+        )
+    return out

--- a/src/roster_intel/profiles.py
+++ b/src/roster_intel/profiles.py
@@ -43,11 +43,13 @@ from src.roster_intel.marginal import (
 from src.ros.lineup import RosterPlayer
 
 __all__ = [
+    "ELITE_PERCENTILE",
     "PositionProfile",
     "RosterProfile",
     "TIER_ORDER",
     "build_position_profiles",
     "classify_tier",
+    "elite_threshold",
 ]
 
 # Ordered best → worst.  A player sits in the highest tier whose
@@ -61,25 +63,83 @@ _URGENT_FRAGILITY = 0.75
 # replacement level before it is called tradeable — otherwise every
 # bench dart throw reads as an asset.
 _SURPLUS_FLOOR_RATIO = 0.60
+# "elite" = top this share of a position's rostered priced pool. Matches
+# the elite definition already in src/league_intel/replacement.py
+# (compute_scarcity_components) so the word means one thing repo-wide.
+ELITE_PERCENTILE = 0.05
+
+
+def elite_threshold(position_values: Sequence[float]) -> float | None:
+    """The top-``ELITE_PERCENTILE`` value at one position.
+
+    Deliberately the SAME definition ``src/league_intel/replacement.py``
+    already uses for ``eliteSeparation`` (``pool[round(n * 0.05) - 1]``
+    over the descending position pool), so the two do not drift into
+    two different meanings of the word "elite".
+
+    Reachable by construction: the result is an actual member of the
+    pool, so at least one player always clears it. That property is the
+    whole point — see :func:`classify_tier`.
+
+    ``None`` when nothing at the position is priced.
+    """
+    vals = sorted((float(v) for v in position_values if v and v > 0), reverse=True)
+    if not vals:
+        return None
+    return vals[max(0, round(len(vals) * ELITE_PERCENTILE) - 1)]
 
 
 def classify_tier(
     value: float,
     replacement: PositionReplacement | None,
+    *,
+    elite: float | None = None,
 ) -> str:
     """Bucket one player against the league's replacement levels.
 
-    Falls back to ``developmental`` when the position has no measured
-    levels — an unknown threshold must not promote a player.
+    Tiers, best → worst:
+
+    ``elite``          top-5% of the position's rostered priced pool
+    ``starter``        at or above the typical last starter
+    ``depth``          at or above the last player worth rostering
+    ``developmental``  everything else, and everything unmeasurable
+
+    **``elite`` is a distribution percentile, not a replacement level,
+    because no replacement level can express it.** The four levels in
+    ``replacement.py`` are all *floors* — ``starter`` is the median
+    team's weakest starter and ``bestBallStarter`` is the deepest
+    anyone dips, which is BELOW it by construction (mean of the lowest
+    marginals vs. their median). An earlier version of this function
+    read ``bestBallStarter`` as the elite bar. That is inverted: it set
+    the top tier at the startable floor, so anything reaching
+    ``starter`` had already returned ``elite``, the ``starter`` tier was
+    unreachable, and ~65-78% of every rostered player classified elite.
+
+    ``elite`` is therefore only honoured when it is strictly above
+    ``starter``. If a caller supplies nothing, or supplies a threshold
+    that does not separate, no player is promoted — an unmeasurable
+    boundary must not promote, which is the same rule that sends a
+    position with no levels at all to ``developmental``.
+
+    Args:
+        value: the player's ROS value.
+        replacement: the position's measured levels.
+        elite: the position's elite threshold, from
+            :func:`elite_threshold`. Omitted ⇒ the ``elite`` tier is
+            not assigned.
     """
     if replacement is None or value <= 0:
         return "developmental"
-    elite = replacement.value("bestBallStarter")
     starter = replacement.value("starter")
     roster = replacement.value("roster")
-    # "elite" is meaningfully above the best-ball starter floor; the
-    # levels module already smooths these with a +/-2 rank band.
-    if elite is not None and value >= elite:
+    # Strict ladder. `elite` is ignored unless it genuinely separates
+    # from `starter`, otherwise the top tier swallows the one below it.
+    if (
+        elite is not None
+        and starter is not None
+        and elite > starter
+        and value >= elite
+    ):
         return "elite"
     if starter is not None and value >= starter:
         return "starter"
@@ -209,6 +269,7 @@ def build_position_profiles(
     player_meta: Mapping[str, Mapping[str, Any]] | None = None,
     as_of_season: int | None = None,
     marginals: RosterMarginals | None = None,
+    league_position_values: Mapping[str, Sequence[float]] | None = None,
 ) -> RosterProfile:
     """Profile every position on one roster.
 
@@ -224,6 +285,11 @@ def build_position_profiles(
         as_of_season: reserved for age-at-season maths; ages are taken
             from ``player_meta`` as supplied so this stays clock-free.
         marginals: reuse a prior solve (the expensive part).
+        league_position_values: ``{base_position: [ros_value, ...]}``
+            across every rostered priced player in the LEAGUE, used for
+            the top-5% ``elite`` cut. This roster alone is far too small
+            a sample — 2-5 players at a position — so omitting it means
+            no player tiers ``elite`` rather than tiering against noise.
     """
     pool_list = list(pool)
     slots_list = list(slots)
@@ -249,9 +315,11 @@ def build_position_profiles(
         ai: AbsenceImpact | None = absence.get(pos)
         rep = (replacement or {}).get(pos)
 
+        elite_cut = elite_threshold((league_position_values or {}).get(pos, ()))
+
         tier_counts = {t: 0 for t in TIER_ORDER}
         for p in players:
-            tier_counts[classify_tier(p.ros_value, rep)] += 1
+            tier_counts[classify_tier(p.ros_value, rep, elite=elite_cut)] += 1
 
         ages = [
             float(meta.get(p.player_id, {}).get("age"))

--- a/src/roster_intel/profiles.py
+++ b/src/roster_intel/profiles.py
@@ -134,12 +134,7 @@ def classify_tier(
     roster = replacement.value("roster")
     # Strict ladder. `elite` is ignored unless it genuinely separates
     # from `starter`, otherwise the top tier swallows the one below it.
-    if (
-        elite is not None
-        and starter is not None
-        and elite > starter
-        and value >= elite
-    ):
+    if elite is not None and starter is not None and elite > starter and value >= elite:
         return "elite"
     if starter is not None and value >= starter:
         return "starter"

--- a/src/roster_intel/profiles.py
+++ b/src/roster_intel/profiles.py
@@ -1,0 +1,338 @@
+"""Per-position roster profiles, built ON the marginal engine.
+
+Every strength-flavoured field here derives from
+``marginal.position_marginals`` / ``absence_impacts`` — i.e. from
+re-solving the exact lineup — never from summed value or headcount.
+The descriptive fields (age, injury, bye, tier counts) are exactly
+that: descriptive.  They are reported beside strength, not blended
+into it, because a blend would let a young thin room and an old deep
+room land on the same number.
+
+Two judgements that need naming rather than burying:
+
+* **Tiers are defined against league replacement levels**, not against
+  a roster's own best player.  A roster-relative tier makes every team
+  look like it has an elite player, which is how "everyone is 100.00"
+  metrics get born.  Tiering against ``replacement.PositionReplacement``
+  means a weak room reports zero elites and says so.
+
+* **Surplus and need are lineup-derived, not count-derived.**  Surplus
+  is priced value that does not enter the optimal lineup and is not
+  needed as absence insurance.  Need is unfilled slots plus positions
+  where a single absence collapses the group.  Counting bodies against
+  a required-slot table would call five QBs "surplus 3" in a superflex
+  league whether or not those QBs actually play.
+
+Pure computation.  No I/O, no network, no clock: ``as_of_season`` is
+supplied by the caller so age maths stay deterministic and testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from src.league_intel.replacement import PositionReplacement, normalize_base_position
+from src.roster_intel.marginal import (
+    AbsenceImpact,
+    PositionMarginal,
+    RosterMarginals,
+    absence_impacts,
+    position_marginals,
+)
+from src.ros.lineup import RosterPlayer
+
+__all__ = [
+    "PositionProfile",
+    "RosterProfile",
+    "TIER_ORDER",
+    "build_position_profiles",
+    "classify_tier",
+]
+
+# Ordered best → worst.  A player sits in the highest tier whose
+# threshold they clear.
+TIER_ORDER = ("elite", "starter", "depth", "developmental")
+
+# A position is "urgent" when the optimizer cannot fill its slots, or
+# when losing one starter erases this share of the group's contribution.
+_URGENT_FRAGILITY = 0.75
+# Surplus must be worth at least this share of the position's starter
+# replacement level before it is called tradeable — otherwise every
+# bench dart throw reads as an asset.
+_SURPLUS_FLOOR_RATIO = 0.60
+
+
+def classify_tier(
+    value: float,
+    replacement: PositionReplacement | None,
+) -> str:
+    """Bucket one player against the league's replacement levels.
+
+    Falls back to ``developmental`` when the position has no measured
+    levels — an unknown threshold must not promote a player.
+    """
+    if replacement is None or value <= 0:
+        return "developmental"
+    elite = replacement.value("bestBallStarter")
+    starter = replacement.value("starter")
+    roster = replacement.value("roster")
+    # "elite" is meaningfully above the best-ball starter floor; the
+    # levels module already smooths these with a +/-2 rank band.
+    if elite is not None and value >= elite:
+        return "elite"
+    if starter is not None and value >= starter:
+        return "starter"
+    if roster is not None and value >= roster:
+        return "depth"
+    return "developmental"
+
+
+@dataclass(frozen=True)
+class PositionProfile:
+    """One position on one roster."""
+
+    position: str
+
+    # ── strength (all lineup-derived) ──
+    marginal_points: float
+    marginal_share: float
+    entry_rate: float
+    entered_lineup: int
+    fragility: float
+    worst_absence_drop: float
+
+    # ── structure ──
+    rostered: int
+    required_slots: int
+    tier_counts: dict[str, int] = field(default_factory=dict)
+
+    # ── exposure (descriptive, never blended into strength) ──
+    mean_age: float | None = None
+    age_over_28: int = 0
+    injured_count: int = 0
+    injured_starters: int = 0
+    bye_concentration: float | None = None
+
+    # ── market position ──
+    replacement_gap: float | None = None
+    tradeable_surplus: float = 0.0
+    surplus_players: tuple[str, ...] = ()
+    urgent_need: bool = False
+    need_reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "marginalPoints": round(self.marginal_points, 3),
+            "marginalShare": round(self.marginal_share, 4),
+            "entryRate": round(self.entry_rate, 4),
+            "enteredLineup": self.entered_lineup,
+            "fragility": round(self.fragility, 4),
+            "worstAbsenceDrop": round(self.worst_absence_drop, 3),
+            "rostered": self.rostered,
+            "requiredSlots": self.required_slots,
+            "tierCounts": dict(self.tier_counts),
+            "meanAge": round(self.mean_age, 2) if self.mean_age is not None else None,
+            "ageOver28": self.age_over_28,
+            "injuredCount": self.injured_count,
+            "injuredStarters": self.injured_starters,
+            "byeConcentration": (
+                round(self.bye_concentration, 4) if self.bye_concentration is not None else None
+            ),
+            "replacementGap": (
+                round(self.replacement_gap, 3) if self.replacement_gap is not None else None
+            ),
+            "tradeableSurplus": round(self.tradeable_surplus, 3),
+            "surplusPlayers": list(self.surplus_players),
+            "urgentNeed": self.urgent_need,
+            "needReasons": list(self.need_reasons),
+        }
+
+
+@dataclass(frozen=True)
+class RosterProfile:
+    """Every position on one roster, plus the solve it derives from."""
+
+    lineup_score: float
+    filled_slots: int
+    total_slots: int
+    positions: dict[str, PositionProfile] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lineupScore": round(self.lineup_score, 3),
+            "filledSlots": self.filled_slots,
+            "totalSlots": self.total_slots,
+            "positions": {k: v.to_dict() for k, v in sorted(self.positions.items())},
+        }
+
+
+def _required_slots(slots: Sequence[str]) -> dict[str, int]:
+    """Dedicated slot count per position.
+
+    FLEX / SUPER_FLEX / IDP_FLEX are deliberately NOT attributed to any
+    position: who fills them is endogenous (LI-5 measured QB taking
+    SUPER_FLEX 9 times in 12, TE taking FLEX zero times).  Splitting
+    them by assumption is the error that made the old even-split
+    demand numbers wrong by 40% at QB.
+    """
+    out: dict[str, int] = {}
+    for slot in slots:
+        s = normalize_base_position(str(slot).upper())
+        if s in {"FLEX", "SUPER_FLEX", "IDP_FLEX", "BN"}:
+            continue
+        out[s] = out.get(s, 0) + 1
+    return out
+
+
+def _bye_concentration(byes: Sequence[int]) -> float | None:
+    """Share of the position's players sharing its most common bye week.
+
+    1.0 means the whole room is off the same week — the case that
+    silently zeroes a position.  ``None`` when no bye data is supplied.
+    """
+    known = [b for b in byes if b]
+    if not known:
+        return None
+    counts: dict[int, int] = {}
+    for b in known:
+        counts[b] = counts.get(b, 0) + 1
+    return max(counts.values()) / len(known)
+
+
+def build_position_profiles(
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    *,
+    replacement: Mapping[str, PositionReplacement] | None = None,
+    player_meta: Mapping[str, Mapping[str, Any]] | None = None,
+    as_of_season: int | None = None,
+    marginals: RosterMarginals | None = None,
+) -> RosterProfile:
+    """Profile every position on one roster.
+
+    Args:
+        pool: the roster, already eligibility-enriched (see
+            ``roster_source.build_roster_pool`` — position-only rows
+            silently understate IDP).
+        slots: the league's flattened starter slots.
+        replacement: league replacement levels for tiering. Omitted ⇒
+            every player tiers as ``developmental`` and tier counts
+            carry no signal, which is the honest degradation.
+        player_meta: ``{player_id: {"age": int, "byeWeek": int}}``.
+        as_of_season: reserved for age-at-season maths; ages are taken
+            from ``player_meta`` as supplied so this stays clock-free.
+        marginals: reuse a prior solve (the expensive part).
+    """
+    pool_list = list(pool)
+    slots_list = list(slots)
+    marg = marginals or position_marginals(pool_list, slots_list)
+    absence = absence_impacts(pool_list, slots_list)
+    required = _required_slots(slots_list)
+    meta = player_meta or {}
+
+    # Which players actually entered the optimal lineup.
+    from src.roster_intel.marginal import solve_summary  # local: avoids cycle at import
+
+    entered_ids = solve_summary(pool_list, slots_list).assigned_ids
+
+    by_pos: dict[str, list[RosterPlayer]] = {}
+    for p in pool_list:
+        base = normalize_base_position(p.position)
+        if base:
+            by_pos.setdefault(base, []).append(p)
+
+    profiles: dict[str, PositionProfile] = {}
+    for pos, players in by_pos.items():
+        pm: PositionMarginal | None = marg.by_position.get(pos)
+        ai: AbsenceImpact | None = absence.get(pos)
+        rep = (replacement or {}).get(pos)
+
+        tier_counts = {t: 0 for t in TIER_ORDER}
+        for p in players:
+            tier_counts[classify_tier(p.ros_value, rep)] += 1
+
+        ages = [
+            float(meta.get(p.player_id, {}).get("age"))
+            for p in players
+            if meta.get(p.player_id, {}).get("age") is not None
+        ]
+        byes = [int(meta.get(p.player_id, {}).get("byeWeek") or 0) for p in players]
+
+        injured = [p for p in players if p.injured]
+        injured_starters = [p for p in injured if p.player_id in entered_ids]
+
+        # Surplus: priced, does NOT enter the lineup, and clears a
+        # meaningful share of the starter replacement level. The floor
+        # stops every bench dart throw reading as a tradeable asset.
+        starter_level = rep.value("starter") if rep else None
+        floor = (starter_level or 0.0) * _SURPLUS_FLOOR_RATIO
+        surplus = [
+            p
+            for p in players
+            if p.ros_value > 0 and p.player_id not in entered_ids and p.ros_value >= floor
+        ]
+
+        # Need: the optimizer could not fill this position's dedicated
+        # slots, or one absence collapses the group.
+        need_reasons: list[str] = []
+        req = required.get(pos, 0)
+        entered = pm.entered_lineup if pm else 0
+        if req and entered < req:
+            need_reasons.append(f"only {entered} of {req} dedicated {pos} slots filled")
+        if ai and ai.fragility >= _URGENT_FRAGILITY:
+            need_reasons.append(
+                f"one absence costs {ai.fragility:.0%} of an average starter's value"
+            )
+        if req and not players:
+            need_reasons.append(f"no {pos} rostered")
+
+        profiles[pos] = PositionProfile(
+            position=pos,
+            marginal_points=pm.marginal_points if pm else 0.0,
+            marginal_share=pm.marginal_share if pm else 0.0,
+            entry_rate=pm.entry_rate if pm else 0.0,
+            entered_lineup=entered,
+            fragility=ai.fragility if ai else 0.0,
+            worst_absence_drop=ai.worst_drop if ai else 0.0,
+            rostered=len(players),
+            required_slots=req,
+            tier_counts=tier_counts,
+            mean_age=(sum(ages) / len(ages)) if ages else None,
+            age_over_28=sum(1 for a in ages if a > 28),
+            injured_count=len(injured),
+            injured_starters=len(injured_starters),
+            bye_concentration=_bye_concentration(byes),
+            replacement_gap=(rep.value("starter") if rep else None),
+            tradeable_surplus=float(sum(p.ros_value for p in surplus)),
+            surplus_players=tuple(sorted(p.canonical_name or p.player_id for p in surplus)),
+            urgent_need=bool(need_reasons),
+            need_reasons=tuple(need_reasons),
+        )
+
+    # Positions the league requires that the roster carries NONE of.
+    for pos, req in required.items():
+        if pos in profiles:
+            continue
+        profiles[pos] = PositionProfile(
+            position=pos,
+            marginal_points=0.0,
+            marginal_share=0.0,
+            entry_rate=0.0,
+            entered_lineup=0,
+            fragility=0.0,
+            worst_absence_drop=0.0,
+            rostered=0,
+            required_slots=req,
+            tier_counts={t: 0 for t in TIER_ORDER},
+            urgent_need=True,
+            need_reasons=(f"no {pos} rostered",),
+        )
+
+    return RosterProfile(
+        lineup_score=marg.lineup_score,
+        filled_slots=marg.filled_slots,
+        total_slots=marg.total_slots,
+        positions=profiles,
+    )

--- a/src/roster_intel/roster_source.py
+++ b/src/roster_intel/roster_source.py
@@ -1,0 +1,281 @@
+"""Roster assembly — join names, values, and SLOT ELIGIBILITY.
+
+Why this module exists
+──────────────────────
+ADR-007 recorded that Sleeper evaluates slot eligibility against
+``fantasy_positions``, not ``position``.  A pass-rushing linebacker ships
+as ``position="DL"`` with ``fantasy_positions=["DL","LB"]`` and is legal
+in either slot.  LI-3 fixed that in ``src/ros/lineup.py`` and measured
+the cost of getting it wrong: hybrid IDPs were locked out of half their
+legal slots in production, and 6 of 12 teams had a materially wrong
+starting lineup.
+
+WS-J reintroduced the same defect from a different direction.  The ROS
+aggregate (``data/ros/aggregate/latest.json``) carries
+``canonicalName`` / ``position`` / ``rosValue`` and **no
+fantasy_positions**.  Joining rosters to it alone therefore hands the
+optimizer position-only rows, and the optimizer — correct as it is —
+cannot slot a hybrid it was never told about.  The bug was not in the
+code this time; it was in the data path feeding it.
+
+So eligibility is a first-class input here, not an optional extra.
+``build_roster_pool`` requires the NFL player map to enrich hybrids, and
+``hybrid_coverage`` exists so a caller can PROVE the enrichment landed
+rather than assume it.
+
+Pure computation: callers supply the loaded maps; this module does no
+I/O and no network, mirroring ``replacement.py``'s shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+__all__ = [
+    "HybridCoverage",
+    "JoinReport",
+    "build_nfl_position_index",
+    "build_roster_pool",
+    "build_value_index",
+    "hybrid_coverage",
+    "normalize_name",
+]
+
+# Positions that can legally appear in more than one slot family, i.e.
+# the ones where losing fantasy_positions actually costs lineup points.
+_MULTI_FAMILY = {
+    "DL",
+    "DE",
+    "DT",
+    "EDGE",
+    "NT",
+    "LB",
+    "ILB",
+    "OLB",
+    "MLB",
+    "DB",
+    "CB",
+    "S",
+    "FS",
+    "SS",
+}
+
+
+def normalize_name(name: Any) -> str:
+    """Lowercase alphanumeric key.  Matches the convention the rest of
+    the repo uses for name joins (``ktc_crowd_faab._normalize_name``,
+    the frontend's ``normName``), so keys agree across modules."""
+    return "".join(c for c in str(name or "").lower() if c.isalnum())
+
+
+@dataclass(frozen=True)
+class JoinReport:
+    """What the join actually managed to resolve.
+
+    Exists because a silent join loss is indistinguishable from a weak
+    roster: both show up as fewer players and a lower lineup score.
+    """
+
+    rostered: int
+    valued: int
+    eligibility_enriched: int
+    hybrids_found: int
+    unmatched_names: tuple[str, ...] = ()
+
+    @property
+    def value_join_rate(self) -> float:
+        return (self.valued / self.rostered) if self.rostered else 0.0
+
+    @property
+    def eligibility_join_rate(self) -> float:
+        return (self.eligibility_enriched / self.rostered) if self.rostered else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rostered": self.rostered,
+            "valued": self.valued,
+            "eligibilityEnriched": self.eligibility_enriched,
+            "hybridsFound": self.hybrids_found,
+            "valueJoinRate": round(self.value_join_rate, 4),
+            "eligibilityJoinRate": round(self.eligibility_join_rate, 4),
+            "unmatchedNames": list(self.unmatched_names),
+        }
+
+
+def build_value_index(
+    aggregate_rows: Iterable[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    """``normalized name -> ROS row``.
+
+    The WS-E audit found duplicate rows in the aggregate (the same
+    player under two spellings, ROS value split across both).  On a
+    collision the HIGHER-valued row wins: the split is an artifact of
+    the identity defect, and taking whichever row happens to be last
+    would make the result depend on file ordering.
+    """
+    out: dict[str, Mapping[str, Any]] = {}
+    for row in aggregate_rows:
+        key = normalize_name(row.get("canonicalName") or row.get("name"))
+        if not key:
+            continue
+        prev = out.get(key)
+        if prev is not None:
+            try:
+                if float(row.get("rosValue") or 0.0) <= float(prev.get("rosValue") or 0.0):
+                    continue
+            except (TypeError, ValueError):
+                continue
+        out[key] = row
+    return out
+
+
+def build_nfl_position_index(
+    nfl_players: Mapping[str, Mapping[str, Any]],
+) -> dict[str, tuple[str, tuple[str, ...]]]:
+    """``normalized name -> (position, fantasy_positions)``.
+
+    Keyed by name rather than Sleeper id because the ROS aggregate is
+    name-keyed; the identity layer owns id-grade joins, and duplicating
+    it here would be a second source of truth.
+    """
+    out: dict[str, tuple[str, tuple[str, ...]]] = {}
+    for entry in nfl_players.values():
+        if not isinstance(entry, Mapping):
+            continue
+        name = entry.get("full_name") or (
+            f"{entry.get('first_name') or ''} {entry.get('last_name') or ''}".strip()
+        )
+        key = normalize_name(name)
+        if not key:
+            continue
+        fpos = tuple(
+            str(fp).strip().upper()
+            for fp in (entry.get("fantasy_positions") or ())
+            if str(fp or "").strip()
+        )
+        position = str(entry.get("position") or "").strip().upper()
+        # Prefer the entry that actually carries eligibility data; the
+        # dump contains retired/duplicate shells with none.
+        prev = out.get(key)
+        if prev is not None and not fpos and prev[1]:
+            continue
+        out[key] = (position, fpos)
+    return out
+
+
+def build_roster_pool(
+    roster_names: Sequence[str],
+    *,
+    values: Mapping[str, Mapping[str, Any]],
+    eligibility: Mapping[str, tuple[str, tuple[str, ...]]],
+) -> tuple[list[dict[str, Any]], JoinReport]:
+    """Assemble optimizer-ready rows for one roster.
+
+    ``eligibility`` is REQUIRED, not optional.  Making it optional is
+    exactly how the ADR-007 defect came back: a caller omits it, the
+    rows still look valid, the optimizer still runs, and the only
+    symptom is a quietly worse lineup for teams with hybrid IDPs.
+
+    Returns the rows plus a :class:`JoinReport` so callers can assert
+    the join landed instead of trusting it.
+    """
+    rows: list[dict[str, Any]] = []
+    unmatched: list[str] = []
+    enriched = 0
+    hybrids = 0
+
+    for name in roster_names:
+        key = normalize_name(name)
+        val_row = values.get(key)
+        if val_row is None:
+            unmatched.append(str(name))
+            continue
+
+        elig = eligibility.get(key)
+        # Position precedence: the NFL dump is the host's own view and
+        # wins over the aggregate's, which is scraped from ranking
+        # sites and disagrees on IDP labelling in particular.
+        position = str(val_row.get("position") or "").strip().upper()
+        fantasy_positions: tuple[str, ...] = ()
+        if elig is not None:
+            dump_pos, fpos = elig
+            if dump_pos:
+                position = dump_pos
+            fantasy_positions = fpos
+            if fpos:
+                enriched += 1
+                if len(fpos) > 1:
+                    hybrids += 1
+
+        rows.append(
+            {
+                "playerId": str(name),
+                "canonicalName": str(name),
+                "position": position,
+                "rosValue": float(val_row.get("rosValue") or 0.0),
+                "confidence": float(val_row.get("confidence") or 0.0),
+                "fantasyPositions": fantasy_positions,
+            }
+        )
+
+    return rows, JoinReport(
+        rostered=len(roster_names),
+        valued=len(rows),
+        eligibility_enriched=enriched,
+        hybrids_found=hybrids,
+        unmatched_names=tuple(unmatched),
+    )
+
+
+@dataclass(frozen=True)
+class HybridCoverage:
+    """Proof that eligibility enrichment actually happened.
+
+    ``multi_family_without_eligibility`` is the number that matters: a
+    DL/LB/DB-family player carrying no ``fantasy_positions`` is one the
+    optimizer may bench illegally.  Zero is the target; anything else is
+    a known lower bound on IDP marginals and must be reported as such.
+    """
+
+    total: int
+    multi_family: int
+    multi_family_with_eligibility: int
+    multi_family_without_eligibility: int
+    true_hybrids: int
+
+    @property
+    def eligibility_complete(self) -> bool:
+        return self.multi_family_without_eligibility == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "multiFamily": self.multi_family,
+            "multiFamilyWithEligibility": self.multi_family_with_eligibility,
+            "multiFamilyWithoutEligibility": self.multi_family_without_eligibility,
+            "trueHybrids": self.true_hybrids,
+            "eligibilityComplete": self.eligibility_complete,
+        }
+
+
+def hybrid_coverage(rows: Iterable[Mapping[str, Any]]) -> HybridCoverage:
+    """Audit a built pool for missing slot eligibility."""
+    total = mf = mf_with = hybrids = 0
+    for r in rows:
+        total += 1
+        pos = str(r.get("position") or "").strip().upper()
+        fpos = tuple(r.get("fantasyPositions") or ())
+        if pos in _MULTI_FAMILY:
+            mf += 1
+            if fpos:
+                mf_with += 1
+        if len(fpos) > 1:
+            hybrids += 1
+    return HybridCoverage(
+        total=total,
+        multi_family=mf,
+        multi_family_with_eligibility=mf_with,
+        multi_family_without_eligibility=mf - mf_with,
+        true_hybrids=hybrids,
+    )

--- a/src/roster_intel/window.py
+++ b/src/roster_intel/window.py
@@ -1,0 +1,342 @@
+"""Competitive window as a probability distribution, not a label.
+
+Five states — ``championship_contender``, ``playoff_contender``,
+``retool``, ``productive_struggle``, ``rebuild`` — reported as
+probabilities that are mutually exclusive and sum to 1.  A binary
+contender/rebuilder flag throws away the thing managers actually
+disagree about: a 55/45 split between retool and rebuild is a real
+strategic fork, and a label picks a side without saying it was close.
+
+Ordering (recorded because a consumer asked)
+────────────────────────────────────────────
+The five sit on a contend↔rebuild axis, but that axis conflates two
+different quantities: CURRENT COMPETITIVENESS (championship / playoff
+contender) and DIRECTIONAL INTENT (retool / rebuild).
+``productive_struggle`` mixes both.  The ends are solidly ordered; the
+weak link is **retool vs productive_struggle**, which are different
+strategies at similar competitiveness rather than adjacent points on
+one scale.  ``STATE_ORDER`` encodes the axis for consumers that need
+one, and ``ORDERING_CAVEAT`` states where it is soft, so a visual form
+that assumes a strict order can be chosen deliberately rather than by
+accident.
+
+How the probabilities are produced
+──────────────────────────────────
+Two measured axes, then a softmax over each state's affinity:
+
+* ``competitiveness`` — where this roster's championship odds sit
+  relative to the league.  Sourced from ``src/ros/playoff_sim.py`` when
+  the caller supplies its output; falls back to lineup-score rank when
+  it does not, with the source stamped either way.
+* ``trajectory`` — value-weighted age of the players who actually ENTER
+  the optimal lineup, against the league's own distribution.  Weighted
+  and lineup-restricted on purpose: the age of a bench dart throw tells
+  you nothing about a window, and an unweighted mean lets six rookies
+  hide one 33-year-old anchor.
+
+Softmax rather than hand-cut thresholds because thresholds produce
+exactly the artifact this project has been burned by — a team one point
+either side of a cut flips category while its neighbour does not move
+at all.  Temperature controls decisiveness and is explicit.
+
+Pure computation: no I/O, no network, no clock.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from src.roster_intel.marginal import solve_summary
+from src.ros.lineup import RosterPlayer
+
+__all__ = [
+    "COMPETITIVE_STATES",
+    "ORDERING_CAVEAT",
+    "STATE_ORDER",
+    "CompetitiveWindow",
+    "WindowInputs",
+    "compute_window",
+    "league_competitiveness",
+    "trajectory_score",
+]
+
+COMPETITIVE_STATES = (
+    "championship_contender",
+    "playoff_contender",
+    "retool",
+    "productive_struggle",
+    "rebuild",
+)
+
+# Contend → rebuild. See the module docstring: solid at the ends, soft
+# in the middle pair.
+STATE_ORDER = COMPETITIVE_STATES
+
+ORDERING_CAVEAT = (
+    "States are ordered contend->rebuild, but the axis conflates current "
+    "competitiveness with directional intent. 'retool' vs "
+    "'productive_struggle' are different strategies at similar "
+    "competitiveness, not adjacent competitiveness levels; treat that "
+    "pair's ordering as soft. A diverging visual should place its centre "
+    "BETWEEN them, and that centre is a boundary rather than a state."
+)
+
+# Each state's ideal position in (competitiveness, trajectory) space,
+# both on 0-1. Trajectory: 1.0 = young/ascending, 0.0 = old/descending.
+_STATE_ANCHORS: dict[str, tuple[float, float]] = {
+    "championship_contender": (0.95, 0.45),
+    "playoff_contender": (0.70, 0.50),
+    "retool": (0.45, 0.70),
+    "productive_struggle": (0.25, 0.80),
+    "rebuild": (0.05, 0.60),
+}
+
+# Competitiveness matters more than trajectory for placing a roster: a
+# strong team is contending whatever its age curve, while a weak team's
+# age tells you which KIND of weak it is.
+_COMPETITIVENESS_WEIGHT = 2.0
+_TRAJECTORY_WEIGHT = 1.0
+
+DEFAULT_TEMPERATURE = 0.18
+
+# Ages bounding the trajectory scale. Outside these the score clamps;
+# they are fantasy-relevant career bounds, not biology.
+_AGE_YOUNG = 22.0
+_AGE_OLD = 32.0
+
+
+@dataclass(frozen=True)
+class WindowInputs:
+    """The measured axes, exposed so a caller can audit the placement."""
+
+    competitiveness: float
+    trajectory: float
+    competitiveness_source: str
+    trajectory_sample: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "competitiveness": round(self.competitiveness, 4),
+            "trajectory": round(self.trajectory, 4),
+            "competitivenessSource": self.competitiveness_source,
+            "trajectorySample": self.trajectory_sample,
+        }
+
+
+@dataclass(frozen=True)
+class CompetitiveWindow:
+    """Five mutually exclusive probabilities summing to 1."""
+
+    probabilities: dict[str, float]
+    inputs: WindowInputs
+    most_likely: str
+    # True when a caller pinned the state by hand.
+    overridden: bool = False
+    override_reason: str | None = None
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def confidence(self) -> float:
+        """Probability mass on the most likely state.  Near 0.2 means
+        the five are indistinguishable and the label means nothing."""
+        return self.probabilities.get(self.most_likely, 0.0)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "probabilities": {k: round(v, 4) for k, v in self.probabilities.items()},
+            "mostLikely": self.most_likely,
+            "confidence": round(self.confidence, 4),
+            "overridden": self.overridden,
+            "overrideReason": self.override_reason,
+            "inputs": self.inputs.to_dict(),
+            "stateOrder": list(STATE_ORDER),
+            "orderingCaveat": ORDERING_CAVEAT,
+            "notes": list(self.notes),
+        }
+
+
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+
+def league_competitiveness(
+    owner_id: str,
+    *,
+    playoff_odds: Sequence[Mapping[str, Any]] | None = None,
+    lineup_scores: Mapping[str, float] | None = None,
+) -> tuple[float, str]:
+    """Where this roster sits competitively, on 0-1.
+
+    Prefers championship odds from ``src/ros/playoff_sim.py`` — that
+    simulator already models schedule, variance and the bracket, and
+    building a second one here would be a parallel path (the repo's
+    one-live-path rule).  Falls back to lineup-score percentile, which
+    is a structural proxy and is stamped as such.
+
+    Returns ``(score, source)``.
+    """
+    if playoff_odds:
+        rows = [r for r in playoff_odds if r.get("ownerId")]
+        champ = {str(r["ownerId"]): float(r.get("championshipOdds") or 0.0) for r in rows}
+        if champ and any(v > 0 for v in champ.values()):
+            mine = champ.get(str(owner_id))
+            if mine is not None:
+                # Percentile against the league, so the scale is
+                # league-relative rather than absolute-odds-relative
+                # (in a 12-team league even the best team's title odds
+                # are small in absolute terms).
+                below = sum(1 for v in champ.values() if v < mine)
+                ties = sum(1 for v in champ.values() if v == mine)
+                pct = (below + 0.5 * ties) / len(champ)
+                return _clamp01(pct), "championshipOdds"
+
+    if lineup_scores:
+        mine = lineup_scores.get(str(owner_id))
+        if mine is not None and len(lineup_scores) > 1:
+            below = sum(1 for v in lineup_scores.values() if v < mine)
+            ties = sum(1 for v in lineup_scores.values() if v == mine)
+            pct = (below + 0.5 * ties) / len(lineup_scores)
+            return _clamp01(pct), "lineupScoreRank"
+
+    return 0.5, "unavailable"
+
+
+def trajectory_score(
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    player_meta: Mapping[str, Mapping[str, Any]] | None = None,
+) -> tuple[float, int]:
+    """Value-weighted age of LINEUP ENTRANTS, mapped to 0-1.
+
+    1.0 = young/ascending, 0.0 = old/descending.
+
+    Restricted to lineup entrants and weighted by value because those
+    are the two ways an age number lies: a bench dart throw's age says
+    nothing about the window, and an unweighted mean lets six rookies
+    hide one 33-year-old anchor.
+
+    Returns ``(score, sample_size)``.  Sample 0 ⇒ 0.5 (neutral), which
+    is the honest answer when no ages were supplied.
+    """
+    meta = player_meta or {}
+    entered = solve_summary(list(pool), list(slots)).assigned_ids
+    weighted_sum = 0.0
+    weight = 0.0
+    n = 0
+    for p in pool:
+        if p.player_id not in entered:
+            continue
+        age = (meta.get(p.player_id) or {}).get("age")
+        if age is None:
+            continue
+        w = max(0.0, p.ros_value)
+        if w <= 0:
+            continue
+        weighted_sum += float(age) * w
+        weight += w
+        n += 1
+    if weight <= 0 or n == 0:
+        return 0.5, 0
+    mean_age = weighted_sum / weight
+    # Older -> lower score.
+    raw = (_AGE_OLD - mean_age) / (_AGE_OLD - _AGE_YOUNG)
+    return _clamp01(raw), n
+
+
+def _softmax_affinities(
+    competitiveness: float,
+    trajectory: float,
+    temperature: float,
+) -> dict[str, float]:
+    """Distance-to-anchor softmax over the five states."""
+    scores: dict[str, float] = {}
+    for state, (c_anchor, t_anchor) in _STATE_ANCHORS.items():
+        d2 = (
+            _COMPETITIVENESS_WEIGHT * (competitiveness - c_anchor) ** 2
+            + _TRAJECTORY_WEIGHT * (trajectory - t_anchor) ** 2
+        )
+        scores[state] = -d2
+    temp = max(1e-6, temperature)
+    mx = max(scores.values())
+    exps = {k: math.exp((v - mx) / temp) for k, v in scores.items()}
+    total = sum(exps.values())
+    if total <= 0:  # pragma: no cover - unreachable while exps are positive
+        return {k: 1.0 / len(exps) for k in exps}
+    return {k: v / total for k, v in exps.items()}
+
+
+def compute_window(
+    owner_id: str,
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    *,
+    playoff_odds: Sequence[Mapping[str, Any]] | None = None,
+    lineup_scores: Mapping[str, float] | None = None,
+    player_meta: Mapping[str, Mapping[str, Any]] | None = None,
+    temperature: float = DEFAULT_TEMPERATURE,
+    override_state: str | None = None,
+    override_reason: str | None = None,
+) -> CompetitiveWindow:
+    """Probabilistic competitive window for one roster.
+
+    ``override_state`` is the manual hook.  It pins the distribution to
+    that state rather than nudging it: a manager who says "I am
+    rebuilding" is stating intent the model cannot observe, and
+    blending it with a model guess would produce a number that is
+    neither their intent nor the model's read.  The override is stamped
+    so a consumer can always tell it apart from a measurement.
+    """
+    notes: list[str] = []
+
+    if override_state is not None:
+        if override_state not in COMPETITIVE_STATES:
+            raise ValueError(
+                f"unknown competitive state {override_state!r}; "
+                f"expected one of {COMPETITIVE_STATES}"
+            )
+        probs = {s: 0.0 for s in COMPETITIVE_STATES}
+        probs[override_state] = 1.0
+        comp, comp_src = league_competitiveness(
+            owner_id, playoff_odds=playoff_odds, lineup_scores=lineup_scores
+        )
+        traj, sample = trajectory_score(pool, slots, player_meta)
+        return CompetitiveWindow(
+            probabilities=probs,
+            inputs=WindowInputs(comp, traj, comp_src, sample),
+            most_likely=override_state,
+            overridden=True,
+            override_reason=override_reason,
+            notes=("manual override; model inputs retained for audit",),
+        )
+
+    comp, comp_src = league_competitiveness(
+        owner_id, playoff_odds=playoff_odds, lineup_scores=lineup_scores
+    )
+    if comp_src == "unavailable":
+        notes.append("no competitiveness source supplied; defaulted to league median")
+    elif comp_src == "lineupScoreRank":
+        notes.append(
+            "competitiveness from lineup-score rank (structural proxy); "
+            "supply playoff_sim output for simulated odds"
+        )
+
+    traj, sample = trajectory_score(pool, slots, player_meta)
+    if sample == 0:
+        notes.append("no ages supplied for lineup entrants; trajectory neutral")
+
+    probs = _softmax_affinities(comp, traj, temperature)
+    most_likely = max(probs, key=lambda k: probs[k])
+    if probs[most_likely] < 0.30:
+        notes.append(
+            "no state clears 30%; this roster sits between windows and the "
+            "single label should not be presented alone"
+        )
+
+    return CompetitiveWindow(
+        probabilities=probs,
+        inputs=WindowInputs(comp, traj, comp_src, sample),
+        most_likely=most_likely,
+        notes=tuple(notes),
+    )

--- a/src/roster_intel/window.py
+++ b/src/roster_intel/window.py
@@ -125,6 +125,32 @@ class WindowInputs:
         }
 
 
+def _round_preserving_sum(probs: Mapping[str, float], places: int = 4) -> dict[str, float]:
+    """Round to ``places`` while keeping the sum at exactly 1.
+
+    Naive per-key rounding drifts: five values rounded to 4dp summed to
+    1.0001 in the serialized payload, so a consumer reading the JSON saw
+    a distribution that did not sum to 1 even though the underlying one
+    did.  The invariant has to survive serialization, because the
+    payload is what consumers actually read.
+
+    Largest-remainder method: floor everything at the target precision,
+    then hand the leftover quanta to the keys with the biggest discarded
+    remainder.  Deterministic — ties break on key name.
+    """
+    if not probs:
+        return {}
+    scale = 10**places
+    scaled = {k: v * scale for k, v in probs.items()}
+    floored = {k: math.floor(v) for k, v in scaled.items()}
+    remainder = int(round(scale - sum(floored.values())))
+    if remainder > 0:
+        order = sorted(probs, key=lambda k: (-(scaled[k] - floored[k]), k))
+        for k in order[:remainder]:
+            floored[k] += 1
+    return {k: floored[k] / scale for k in probs}
+
+
 @dataclass(frozen=True)
 class CompetitiveWindow:
     """Five mutually exclusive probabilities summing to 1."""
@@ -145,7 +171,7 @@ class CompetitiveWindow:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "probabilities": {k: round(v, 4) for k, v in self.probabilities.items()},
+            "probabilities": _round_preserving_sum(self.probabilities),
             "mostLikely": self.most_likely,
             "confidence": round(self.confidence, 4),
             "overridden": self.overridden,

--- a/tests/roster_intel/test_engine.py
+++ b/tests/roster_intel/test_engine.py
@@ -1,0 +1,451 @@
+"""Tests for ``src/roster_intel/engine.py``.
+
+The headline test is ``TestFragilityIsNotDeficiency``: a consuming agent
+derived deficit as ``fragility x marginal`` and got QB reported as the
+biggest need on a QB-STRONG roster.  That inversion is pinned here so
+the engine's own ``deficit`` can never reproduce it, and so the
+semantics stay stated where they are exported.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.replacement import PositionReplacement, ReplacementLevel
+from src.roster_intel.engine import analyze_roster, position_needs
+from src.roster_intel.marginal import to_roster_players
+from src.roster_intel.profiles import build_position_profiles
+
+
+def _p(pid, pos, value, **kw):
+    return {
+        "playerId": pid,
+        "canonicalName": pid,
+        "position": pos,
+        "rosValue": value,
+        "fantasyPositions": (),
+        **kw,
+    }
+
+
+def _rep(pos, elite, starter, roster, starters_per_team=2.0):
+    def lvl(tier, v):
+        return ReplacementLevel(
+            position=pos,
+            tier=tier,
+            value=v,
+            threshold_rank=None,
+            band_low=None,
+            band_high=None,
+            sample_size=50,
+        )
+
+    return PositionReplacement(
+        position=pos,
+        starters_per_team=starters_per_team,
+        rostered_count=50,
+        priced_count=50,
+        levels={
+            "bestBallStarter": lvl("bestBallStarter", elite),
+            "starter": lvl("starter", starter),
+            "roster": lvl("roster", roster),
+        },
+    )
+
+
+SLOTS = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "SUPER_FLEX"]
+
+REPLACEMENT = {
+    "QB": _rep("QB", 80.0, 55.0, 25.0),
+    "RB": _rep("RB", 70.0, 45.0, 20.0),
+    "WR": _rep("WR", 70.0, 45.0, 20.0),
+    "TE": _rep("TE", 50.0, 30.0, 12.0),
+}
+
+
+def _odds(rows):
+    return [
+        {
+            "ownerId": o,
+            "playoffOdds": p,
+            "championshipOdds": c,
+            "playoffOddsCi": [max(0.0, p - 0.05), min(1.0, p + 0.05)],
+            "championshipOddsCi": [max(0.0, c - 0.03), min(1.0, c + 0.03)],
+        }
+        for o, p, c in rows
+    ]
+
+
+# ── The inversion, pinned ──────────────────────────────────────────
+
+
+class TestFragilityIsNotDeficiency:
+    """A QB-strong roster in superflex is BOTH high-marginal and
+    high-fragility: two excellent starters, nobody close behind. Any
+    'deficit' derived from fragility x marginal therefore reports the
+    roster's greatest strength as its greatest need."""
+
+    def _qb_strong(self):
+        return to_roster_players(
+            [
+                _p("qb1", "QB", 95),
+                _p("qb2", "QB", 92),  # elite pair
+                _p("rb1", "RB", 30),
+                _p("rb2", "RB", 28),  # below replacement
+                _p("wr1", "WR", 32),
+                _p("wr2", "WR", 30),
+                _p("te1", "TE", 15),
+            ]
+        )
+
+    def test_the_naive_derivation_does_invert(self):
+        """Documents the defect this guard exists for. If this ever
+        stops inverting, the guard below is no longer meaningful and
+        someone should re-derive it rather than delete it."""
+        prof = build_position_profiles(self._qb_strong(), SLOTS, replacement=REPLACEMENT)
+        naive = {pos: p.fragility * p.marginal_points for pos, p in prof.positions.items()}
+        # The naive rule crowns QB — the roster's strongest position.
+        assert max(naive, key=lambda k: naive[k]) == "QB"
+
+    def test_engine_deficit_does_not_crown_the_strong_position(self):
+        """MECHANISM TEST. The engine's own deficit must name a WEAK
+        position, not the strong one."""
+        prof = build_position_profiles(self._qb_strong(), SLOTS, replacement=REPLACEMENT)
+        needs = position_needs(prof, REPLACEMENT)
+        assert needs["QB"].deficit == 0.0
+        worst = max(needs, key=lambda k: needs[k].deficit)
+        assert worst != "QB"
+        assert needs[worst].deficit > 0
+
+    def test_concentration_and_deficit_are_reported_separately(self):
+        prof = build_position_profiles(self._qb_strong(), SLOTS, replacement=REPLACEMENT)
+        needs = position_needs(prof, REPLACEMENT)
+        qb = needs["QB"]
+        # Strong AND concentrated: high risk, zero deficit. Both true.
+        assert qb.concentration_risk > 0.0
+        assert qb.deficit == 0.0
+
+    def test_exported_payload_states_the_semantics(self):
+        """The semantics must travel WITH the data — a consumer reading
+        only the payload has to be able to tell these apart."""
+        prof = build_position_profiles(self._qb_strong(), SLOTS, replacement=REPLACEMENT)
+        blob = position_needs(prof, REPLACEMENT)["QB"].to_dict()
+        sem = blob["_semantics"]
+        assert "acquire a starter" in sem["deficit"]
+        assert "acquire insurance" in sem["concentrationRisk"]
+        assert "do NOT multiply" in sem["warning"]
+
+
+# ── Deficit behaviour ──────────────────────────────────────────────
+
+
+class TestDeficit:
+    def test_below_replacement_position_shows_a_deficit(self):
+        pool = to_roster_players(
+            [
+                _p("qb1", "QB", 90),
+                _p("rb1", "RB", 8),
+                _p("rb2", "RB", 6),
+                _p("wr1", "WR", 60),
+                _p("wr2", "WR", 55),
+                _p("te1", "TE", 35),
+            ]
+        )
+        needs = position_needs(
+            build_position_profiles(pool, SLOTS, replacement=REPLACEMENT), REPLACEMENT
+        )
+        assert needs["RB"].deficit > 0
+        assert needs["RB"].urgent is True
+        assert any("replacement-level" in r for r in needs["RB"].reasons)
+
+    def test_no_replacement_levels_means_no_fabricated_deficit(self):
+        """Without levels there is no baseline; inventing one would be
+        the 'constant masquerading as a score' failure again."""
+        pool = to_roster_players([_p("qb1", "QB", 90), _p("rb1", "RB", 5)])
+        needs = position_needs(build_position_profiles(pool, SLOTS))
+        assert all(n.deficit == 0.0 for n in needs.values())
+        assert all(n.replacement_baseline is None for n in needs.values())
+
+    def test_deficit_scales_with_required_slots(self):
+        """Two dedicated RB slots need twice the replacement-level
+        contribution of one."""
+        pool = to_roster_players([_p("rb1", "RB", 5)])
+        one = position_needs(
+            build_position_profiles(pool, ["RB"], replacement=REPLACEMENT), REPLACEMENT
+        )["RB"]
+        two = position_needs(
+            build_position_profiles(pool, ["RB", "RB"], replacement=REPLACEMENT),
+            REPLACEMENT,
+        )["RB"]
+        assert two.deficit > one.deficit
+
+
+# ── playoff_sim wiring ─────────────────────────────────────────────
+
+
+class TestPlayoffSimWiring:
+    def _pool(self):
+        return to_roster_players(
+            [
+                _p("qb1", "QB", 90),
+                _p("rb1", "RB", 60),
+                _p("rb2", "RB", 55),
+                _p("wr1", "WR", 58),
+                _p("wr2", "WR", 52),
+                _p("te1", "TE", 40),
+            ]
+        )
+
+    def test_odds_and_intervals_are_read_from_simulator_output(self):
+        odds = _odds([("me", 0.72, 0.18), ("other", 0.30, 0.05)])
+        intel = analyze_roster("me", self._pool(), SLOTS, playoff_odds=odds)
+        assert intel.playoff_odds == pytest.approx(0.72)
+        assert intel.championship_odds == pytest.approx(0.18)
+        assert intel.playoff_odds_ci == (pytest.approx(0.67), pytest.approx(0.77))
+        assert intel.odds_source == "playoff_sim"
+
+    def test_simulator_output_upgrades_the_window_axis(self):
+        """MECHANISM TEST. Supplying odds must change the window's
+        source from the structural proxy to simulated odds."""
+        pool = self._pool()
+        proxy = analyze_roster("me", pool, SLOTS, lineup_scores={"me": 500.0, "x": 400.0})
+        simmed = analyze_roster(
+            "me",
+            pool,
+            SLOTS,
+            playoff_odds=_odds([("me", 0.9, 0.4), ("x", 0.1, 0.01)]),
+            lineup_scores={"me": 500.0, "x": 400.0},
+        )
+        assert proxy.window.inputs.competitiveness_source == "lineupScoreRank"
+        assert simmed.window.inputs.competitiveness_source == "championshipOdds"
+
+    def test_missing_simulation_is_stated_not_defaulted_to_zero(self):
+        """Zero odds would read as 'certain to miss'; None reads as
+        'not simulated'. The difference matters."""
+        intel = analyze_roster("me", self._pool(), SLOTS)
+        assert intel.playoff_odds is None
+        assert intel.championship_odds is None
+        assert intel.odds_source == "unavailable"
+        assert any("no playoff_sim output" in n for n in intel.notes)
+
+    def test_owner_absent_from_simulation_is_distinguished(self):
+        intel = analyze_roster("ghost", self._pool(), SLOTS, playoff_odds=_odds([("me", 0.5, 0.1)]))
+        assert intel.odds_source == "owner_not_in_simulation"
+        assert intel.playoff_odds is None
+
+    def test_absent_intervals_stay_none_not_zero_width(self):
+        """A point estimate with no interval must not read as certain."""
+        intel = analyze_roster(
+            "me",
+            self._pool(),
+            SLOTS,
+            playoff_odds=[{"ownerId": "me", "playoffOdds": 0.5, "championshipOdds": 0.1}],
+        )
+        assert intel.playoff_odds == pytest.approx(0.5)
+        assert intel.playoff_odds_ci is None
+
+
+# ── Value rollups ──────────────────────────────────────────────────
+
+
+class TestValueRollups:
+    def test_starter_and_bench_split_follows_the_optimizer(self):
+        """MECHANISM TEST. The split must come from the lineup solve,
+        not from a top-N slice of the roster."""
+        pool = to_roster_players(
+            [
+                _p("qb1", "QB", 90),
+                _p("qb2", "QB", 88),
+                _p("qb3", "QB", 86),  # cannot start: only 2 QB-capable slots
+                _p("rb1", "RB", 60),
+                _p("rb2", "RB", 55),
+                _p("wr1", "WR", 58),
+                _p("wr2", "WR", 52),
+                _p("te1", "TE", 40),
+            ]
+        )
+        v = analyze_roster("me", pool, SLOTS).values
+        assert v.bench_ros == pytest.approx(86.0)
+        assert v.starters_ros == pytest.approx(v.ros - 86.0)
+
+    def test_parallel_scales_stay_separate(self):
+        pool = to_roster_players([_p("a", "QB", 50), _p("b", "RB", 40)])
+        pv = {
+            "a": {"marketValue": 5000, "consensusValue": 4800, "leagueAdjustedDynastyValue": 5200},
+            "b": {"marketValue": 3000, "consensusValue": 3100},
+        }
+        v = analyze_roster("me", pool, ["QB", "RB"], player_values=pv).values
+        assert v.market == pytest.approx(8000)
+        assert v.consensus == pytest.approx(7900)
+        # b has no adjusted value -> falls back to its consensus.
+        assert v.league_adjusted == pytest.approx(5200 + 3100)
+
+    def test_unpriced_players_are_counted_not_hidden(self):
+        pool = to_roster_players([_p("a", "QB", 50), _p("b", "RB", 0)])
+        v = analyze_roster("me", pool, ["QB", "RB"]).values
+        assert v.priced_players == 1
+        assert v.unpriced_players == 1
+
+
+# ── Shape / degradation ────────────────────────────────────────────
+
+
+class TestShape:
+    def test_payload_is_json_shaped_and_complete(self):
+        intel = analyze_roster(
+            "me",
+            to_roster_players([_p("qb1", "QB", 90), _p("rb1", "RB", 50)]),
+            SLOTS,
+            replacement=REPLACEMENT,
+            playoff_odds=_odds([("me", 0.6, 0.12)]),
+        )
+        blob = intel.to_dict()
+        assert set(blob) >= {
+            "ownerId",
+            "values",
+            "lineupScore",
+            "positions",
+            "needs",
+            "competitiveWindow",
+            "playoffOdds",
+            "championshipOdds",
+            "oddsSource",
+        }
+        assert blob["competitiveWindow"]["probabilities"]
+        assert sum(blob["competitiveWindow"]["probabilities"].values()) == pytest.approx(1.0)
+
+    def test_missing_replacement_levels_are_declared(self):
+        intel = analyze_roster("me", to_roster_players([_p("qb1", "QB", 90)]), SLOTS)
+        assert any("no replacement levels" in n for n in intel.notes)
+
+    def test_analysis_varies_across_distinct_rosters(self):
+        seen = set()
+        for i in range(12):
+            intel = analyze_roster(
+                f"t{i}",
+                to_roster_players(
+                    [
+                        _p("qb1", "QB", 60 + i * 3),
+                        _p("rb1", "RB", 55 - i),
+                        _p("rb2", "RB", 40 + i * 2),
+                        _p("wr1", "WR", 58 - i * 2),
+                        _p("te1", "TE", 25 + i * 4),
+                    ]
+                ),
+                SLOTS,
+                replacement=REPLACEMENT,
+                lineup_scores={f"t{j}": 300.0 + j * 40 for j in range(12)},
+            )
+            seen.add((round(intel.lineup_score, 3), round(intel.needs["RB"].deficit, 3)))
+        assert len(seen) == 12
+
+
+# ── Disclosure of dead inputs ──────────────────────────────────────
+
+
+class TestInputDisclosure:
+    """Two inputs can be silently absent and leave a plausible payload
+    behind.  Both must announce themselves.
+
+    Measured on the real league: no committed artifact carries player
+    ages, so every roster's trajectory axis sat at exactly 0.500 with
+    sample size 0, and ``productive_struggle`` — the state that needs a
+    young roster with a bad record — was unreachable for all 12 teams.
+    Nothing in the payload said so.
+    """
+
+    _POOL = [
+        _p("qb1", "QB", 90),
+        _p("qb2", "QB", 70),
+        _p("rb1", "RB", 60),
+        _p("rb2", "RB", 45),
+        _p("wr1", "WR", 65),
+        _p("wr2", "WR", 40),
+        _p("te1", "TE", 35),
+    ]
+
+    def _run(self, meta=None):
+        return analyze_roster(
+            "me",
+            to_roster_players(self._POOL),
+            SLOTS,
+            replacement=REPLACEMENT,
+            player_meta=meta,
+            lineup_scores={"me": 300.0, "other": 200.0},
+        )
+
+    def test_absent_ages_are_disclosed(self):
+        intel = self._run()
+        assert intel.window.inputs.trajectory_sample == 0
+        assert intel.window.inputs.trajectory == pytest.approx(0.5)
+        assert any("ages" in n for n in intel.notes)
+
+    def test_supplied_ages_move_the_axis_and_drop_the_note(self):
+        """MECHANISM TEST. Fails if ``player_meta`` stops reaching the
+        window — the note would keep firing, and the trajectory would
+        stay pinned, on data that HAS ages."""
+        young = self._run({p["playerId"]: {"age": 22} for p in self._POOL})
+        old = self._run({p["playerId"]: {"age": 33} for p in self._POOL})
+
+        for intel in (young, old):
+            assert intel.window.inputs.trajectory_sample > 0
+            assert not any("ages" in n for n in intel.notes)
+
+        assert young.window.inputs.trajectory > 0.5
+        assert old.window.inputs.trajectory < 0.5
+        # ...and the axis must actually change the distribution, not
+        # just the diagnostic block.
+        assert young.window.probabilities != old.window.probabilities
+
+    def test_ages_unlock_states_a_one_dimensional_read_cannot_reach(self):
+        """The concrete cost of the dead axis: a weak-but-young roster
+        and a weak-but-old roster must not receive the same label."""
+        weak = {"me": 100.0, "a": 300.0, "b": 320.0, "c": 340.0}
+        young = analyze_roster(
+            "me",
+            to_roster_players(self._POOL),
+            SLOTS,
+            replacement=REPLACEMENT,
+            player_meta={p["playerId"]: {"age": 22} for p in self._POOL},
+            lineup_scores=weak,
+        )
+        old = analyze_roster(
+            "me",
+            to_roster_players(self._POOL),
+            SLOTS,
+            replacement=REPLACEMENT,
+            player_meta={p["playerId"]: {"age": 33} for p in self._POOL},
+            lineup_scores=weak,
+        )
+        assert young.window.most_likely != old.window.most_likely
+
+    def test_override_does_not_trigger_the_age_note(self):
+        """A pinned window is a stated intent; the trajectory axis is
+        not being used, so warning about it is noise."""
+        intel = analyze_roster(
+            "me",
+            to_roster_players(self._POOL),
+            SLOTS,
+            replacement=REPLACEMENT,
+            override_state="rebuild",
+            override_reason="manager said so",
+        )
+        assert intel.window.overridden
+        assert not any("ages" in n for n in intel.notes)
+
+    def test_zero_unpriced_is_not_sold_as_join_coverage(self):
+        """``build_roster_pool`` DROPS names it cannot value, so on the
+        live path ``unpricedPlayers`` is structurally 0 while real
+        players went missing.  Zero must not read as full coverage."""
+        clean = self._run()
+        assert clean.values.unpriced_players == 0
+        assert any("join-coverage" in n for n in clean.notes)
+
+        with_unpriced = analyze_roster(
+            "me",
+            to_roster_players([*self._POOL, _p("ghost", "WR", 0)]),
+            SLOTS,
+            replacement=REPLACEMENT,
+        )
+        assert with_unpriced.values.unpriced_players == 1
+        assert not any("join-coverage" in n for n in with_unpriced.notes)

--- a/tests/roster_intel/test_engine.py
+++ b/tests/roster_intel/test_engine.py
@@ -347,11 +347,14 @@ class TestInputDisclosure:
     """Two inputs can be silently absent and leave a plausible payload
     behind.  Both must announce themselves.
 
-    Measured on the real league: no committed artifact carries player
-    ages, so every roster's trajectory axis sat at exactly 0.500 with
-    sample size 0, and ``productive_struggle`` — the state that needs a
-    young roster with a bad record — was unreachable for all 12 teams.
-    Nothing in the payload said so.
+    Measured on the real league with ages omitted: every roster's
+    trajectory axis sat at exactly 0.500 with sample size 0, and
+    ``productive_struggle`` — the state that needs a young roster with
+    a bad record — was unreachable for all 12 teams.  Nothing in the
+    payload said so.  Ages were available the whole time in
+    ``data/public_league/nfl_players_full.json``; the caller simply had
+    not passed them.  That is precisely why the absence has to announce
+    itself rather than degrade quietly.
     """
 
     _POOL = [

--- a/tests/roster_intel/test_engine.py
+++ b/tests/roster_intel/test_engine.py
@@ -449,3 +449,74 @@ class TestInputDisclosure:
         )
         assert with_unpriced.values.unpriced_players == 1
         assert not any("join-coverage" in n for n in with_unpriced.notes)
+
+
+class TestSimulatorSchemaGaps:
+    """The simulator's row schema is not fixed, and the engine must not
+    paper over which build produced it.
+
+    ``simulate_playoff_odds`` on main emits exactly these keys — no
+    championship odds (it stops at qualification and never runs the
+    bracket) and no confidence intervals.  The bracket run and the
+    Wilson intervals are LI-8 work on a separate unmerged branch.  An
+    engine that reads the richer schema and silently returns None for
+    the missing half would present a partial simulation as a complete
+    one.
+    """
+
+    # Verbatim key set from src/ros/playoff_sim.py::simulate_playoff_odds.
+    MAIN_ROW = {
+        "ownerId": "me",
+        "displayName": "Me",
+        "playoffOdds": 0.61,
+        "byeOdds": 0.18,
+        "topSeedOdds": 0.09,
+        "missPlayoffsOdds": 0.39,
+        "expectedWins": 8.4,
+        "medianFinalSeed": 4,
+        "mostLikelySeed": 3,
+        "seedDistribution": [0.09, 0.09, 0.14, 0.2, 0.16, 0.1, 0.07, 0.05, 0.04, 0.03, 0.02, 0.01],
+    }
+
+    LI8_ROW = {
+        **MAIN_ROW,
+        "championshipOdds": 0.12,
+        "playoffOddsCi": [0.58, 0.64],
+        "championshipOddsCi": [0.10, 0.14],
+    }
+
+    def _run(self, row):
+        return analyze_roster(
+            "me",
+            to_roster_players([_p("qb1", "QB", 90), _p("rb1", "RB", 50)]),
+            SLOTS,
+            replacement=REPLACEMENT,
+            playoff_odds=[row],
+        )
+
+    def test_partial_schema_is_used_and_its_gaps_are_named(self):
+        intel = self._run(self.MAIN_ROW)
+        assert intel.odds_source == "playoff_sim"
+        assert intel.playoff_odds == pytest.approx(0.61)
+        assert intel.championship_odds is None
+        assert intel.playoff_odds_ci is None
+        assert any("championshipOdds" in n for n in intel.notes)
+        assert any("confidence interval" in n for n in intel.notes)
+
+    def test_missing_interval_is_none_not_zero_width(self):
+        """A zero-width interval reads as certainty. 0.61 off 2,000 sims
+        is roughly +/- 2 points."""
+        intel = self._run(self.MAIN_ROW)
+        assert intel.playoff_odds_ci is None
+        assert intel.to_dict()["playoffOddsCi"] is None
+
+    def test_full_schema_fires_no_gap_notes(self):
+        """MECHANISM TEST. Fails if the gap notes become unconditional —
+        they would then keep warning about a simulator that has since
+        grown the fields."""
+        intel = self._run(self.LI8_ROW)
+        assert intel.championship_odds == pytest.approx(0.12)
+        assert intel.playoff_odds_ci == (0.58, 0.64)
+        assert intel.championship_odds_ci == (0.10, 0.14)
+        assert not any("championshipOdds" in n for n in intel.notes)
+        assert not any("confidence interval" in n for n in intel.notes)

--- a/tests/roster_intel/test_marginal.py
+++ b/tests/roster_intel/test_marginal.py
@@ -1,0 +1,347 @@
+"""Tests for ``src/roster_intel/marginal.py``.
+
+The brief's single most important constraint is that positional strength
+must reflect MARGINAL BEST-BALL CONTRIBUTION, not summed value and not
+player count.  Most of this file is therefore written as
+mechanism-disconnection tests per ORCHESTRATION §2b: each one is
+constructed so that it FAILS if the implementation is quietly swapped for
+a name-value proxy, rather than merely passing when the real thing works.
+
+The anchor case is the hoarded-QB roster.  With one QB slot and one
+SUPER_FLEX, five elite QBs can contribute at most two lineup spots.
+    * summed value  would rank that room ~2.5x its true worth
+    * player count  would call it five-deep
+    * marginal      sees exactly what the optimizer sees
+Every assertion below that mentions "proxy" is checking that gap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.roster_intel.marginal import (
+    absence_impacts,
+    optimal_score,
+    position_marginals,
+    solve_summary,
+    to_roster_players,
+)
+
+
+def _p(pid: str, pos: str, value: float, **kw) -> dict:
+    return {
+        "playerId": pid,
+        "canonicalName": pid,
+        "position": pos,
+        "rosValue": value,
+        "fantasyPositions": kw.pop("fpos", ()),
+        **kw,
+    }
+
+
+# The live league's shape, trimmed to the offensive core for legibility.
+SLOTS_SF = ["QB", "RB", "RB", "WR", "WR", "WR", "TE", "FLEX", "SUPER_FLEX"]
+
+
+# ── Mechanism: marginal is not summed value ────────────────────────
+
+
+class TestNotSummedValue:
+    def test_hoarded_qbs_do_not_scale_with_count(self):
+        """Five elite QBs cannot be worth five QBs' value.
+
+        Fails if strength is computed as sum(values): the sum would keep
+        climbing with every QB added, while the true marginal saturates
+        once both QB-capable slots are filled.
+        """
+        base = [
+            _p("rb1", "RB", 60),
+            _p("rb2", "RB", 55),
+            _p("wr1", "WR", 58),
+            _p("wr2", "WR", 52),
+            _p("wr3", "WR", 48),
+            _p("te1", "TE", 40),
+        ]
+        two_qbs = to_roster_players(base + [_p("qb1", "QB", 90), _p("qb2", "QB", 88)])
+        five_qbs = to_roster_players(
+            base
+            + [
+                _p("qb1", "QB", 90),
+                _p("qb2", "QB", 88),
+                _p("qb3", "QB", 86),
+                _p("qb4", "QB", 84),
+                _p("qb5", "QB", 82),
+            ]
+        )
+
+        m2 = position_marginals(two_qbs, SLOTS_SF).by_position["QB"]
+        m5 = position_marginals(five_qbs, SLOTS_SF).by_position["QB"]
+
+        # The proxy would report 5/2 = 2.5x. Marginal must not.
+        assert m5.marginal_points == pytest.approx(m2.marginal_points, abs=1e-6)
+        assert m5.rostered == 5 and m2.rostered == 2
+        # And the extra three are visible as clog, not as strength.
+        assert m5.non_entering_priced == 3
+        assert m5.clogger_value == pytest.approx(86 + 84 + 82)
+        assert m2.non_entering_priced == 0
+
+    def test_entry_rate_falls_as_hoarding_grows(self):
+        """Count-based strength cannot see this; entry rate must."""
+        base = [
+            _p("rb1", "RB", 60),
+            _p("rb2", "RB", 55),
+            _p("wr1", "WR", 58),
+            _p("wr2", "WR", 52),
+            _p("wr3", "WR", 48),
+            _p("te1", "TE", 40),
+        ]
+        rates = []
+        for n in (1, 2, 3, 5):
+            qbs = [_p(f"qb{i}", "QB", 90 - i) for i in range(n)]
+            pool = to_roster_players(base + qbs)
+            rates.append(position_marginals(pool, SLOTS_SF).by_position["QB"].entry_rate)
+        # Monotonically non-increasing, and strictly below 1 once hoarding.
+        assert rates == sorted(rates, reverse=True)
+        assert rates[0] == 1.0
+        assert rates[-1] < 0.5
+
+    def test_a_high_value_player_who_never_plays_adds_zero_marginal(self):
+        """The cleanest disconnection test: a K with huge nominal value
+        in a league with NO kicker slot contributes exactly nothing.
+
+        Summed value would rank this roster's K room enormous.
+        """
+        pool = to_roster_players(
+            [
+                _p("qb1", "QB", 90),
+                _p("rb1", "RB", 60),
+                _p("rb2", "RB", 55),
+                _p("wr1", "WR", 58),
+                _p("wr2", "WR", 52),
+                _p("wr3", "WR", 48),
+                _p("te1", "TE", 40),
+                _p("k1", "K", 999),  # nominally the most valuable asset
+            ]
+        )
+        marg = position_marginals(pool, SLOTS_SF)
+        assert marg.by_position["K"].marginal_points == 0.0
+        assert marg.by_position["K"].entered_lineup == 0
+        assert marg.by_position["K"].clogger_value == 999
+
+
+# ── Mechanism: group leave-out, not summed individual leave-outs ───
+
+
+class TestGroupLeaveOut:
+    def test_individual_marginals_do_not_sum_to_the_group_marginal(self):
+        """Documents WHY the implementation leaves out the whole group.
+
+        Removing RB1 promotes RB2 into the same slot, so each individual
+        drop is small while the group drop is large.  An implementation
+        that summed individual leave-outs would understate deep
+        positions; this test fails if someone "simplifies" it that way.
+        """
+        # Explicit minimal slots so rb3 is genuinely benched. On the
+        # full board FLEX + SUPER_FLEX would start him, making the two
+        # quantities exactly equal and the test vacuous.
+        slots = ["RB", "RB"]
+        pool = to_roster_players([_p("rb1", "RB", 60), _p("rb2", "RB", 59), _p("rb3", "RB", 58)])
+        group = position_marginals(pool, slots).by_position["RB"].marginal_points
+
+        full = optimal_score(pool, slots)
+        individual_sum = 0.0
+        for target in [p for p in pool if p.position == "RB"]:
+            remaining = [p for p in pool if p.player_id != target.player_id]
+            individual_sum += full - optimal_score(remaining, slots)
+
+        assert group > individual_sum
+        assert individual_sum < group * 0.75  # substantially, not marginally
+
+
+# ── Mechanism: hybrid eligibility is honored ───────────────────────
+
+
+class TestHybridEligibility:
+    def test_hybrid_idp_counts_toward_both_slot_families(self):
+        """Fails if fantasy_positions is dropped on the way into the
+        optimizer — the LI-3/ADR-007 bug, re-guarded here because this
+        module builds its own RosterPlayer rows."""
+        pool = to_roster_players(
+            [
+                _p("hybrid", "DL", 30, fpos=("DL", "LB")),
+                _p("dl1", "DL", 28),
+            ]
+        )
+        summary = solve_summary(pool, ["DL", "LB"])
+        # Both slots fill only when the hybrid is legal at LB.
+        assert summary.filled_slots == 2
+        assert summary.score == pytest.approx(58.0)
+
+
+# ── Absence / fragility ────────────────────────────────────────────
+
+
+class TestAbsenceImpacts:
+    def test_fragility_separates_deep_from_thin(self):
+        """The 'preserve output during absences' half of the brief.
+
+        MECHANISM TEST. The first implementation normalized mean_drop by
+        the position's marginal contribution, which collapses to ~1/n
+        for any position with no bench — it reported the identical
+        0.3333 for a deep RB room and a thin WR room. This asserts the
+        two are distinguishable, and fails again if the denominator is
+        ever changed back.
+
+        Uses an explicit minimal slot set. On the full superflex board
+        FLEX + SUPER_FLEX absorb almost everyone, so a nominal "backup"
+        is really a starter and NEITHER position has depth — which is
+        what made the first two attempts at this test degenerate.
+        Here RB has three bodies for two slots (rb3 is genuinely
+        benched) and WR has exactly two for two.
+        """
+        slots = ["RB", "RB", "WR", "WR"]
+        pool = to_roster_players(
+            [
+                _p("rb1", "RB", 60),
+                _p("rb2", "RB", 59),
+                _p("rb3", "RB", 58),
+                _p("wr1", "WR", 60),
+                _p("wr2", "WR", 55),
+            ]
+        )
+        imp = absence_impacts(pool, slots)
+        assert imp["RB"].fragility < imp["WR"].fragility
+        # Concretely: an RB absence costs ~1 point (rb3 steps in); a WR
+        # absence costs the whole player.
+        assert imp["RB"].fragility < 0.10
+        assert imp["WR"].fragility > 0.90
+
+    def test_worst_drop_is_at_least_the_mean(self):
+        pool = to_roster_players(
+            [
+                _p("qb1", "QB", 95),
+                _p("rb1", "RB", 70),
+                _p("rb2", "RB", 30),
+                _p("wr1", "WR", 65),
+                _p("wr2", "WR", 40),
+                _p("wr3", "WR", 20),
+                _p("te1", "TE", 35),
+            ]
+        )
+        for imp in absence_impacts(pool, SLOTS_SF).values():
+            assert imp.worst_drop >= imp.mean_drop - 1e-9
+
+    def test_absence_drops_are_never_negative(self):
+        """Removing a player can never IMPROVE an optimal lineup.  A
+        negative drop would mean the optimizer is not optimal."""
+        pool = to_roster_players(
+            [_p(f"wr{i}", "WR", 50 - i) for i in range(8)]
+            + [_p("qb1", "QB", 80), _p("rb1", "RB", 45), _p("te1", "TE", 30)]
+        )
+        for imp in absence_impacts(pool, SLOTS_SF).values():
+            assert imp.mean_drop >= 0.0
+            assert imp.worst_drop >= 0.0
+
+    def test_only_lineup_entrants_are_tested(self):
+        """Benched players cannot have an absence impact — their removal
+        changes nothing."""
+        pool = to_roster_players(
+            [
+                _p("qb1", "QB", 90),
+                _p("qb2", "QB", 89),
+                _p("qb3", "QB", 88),
+                _p("qb4", "QB", 87),
+                _p("rb1", "RB", 60),
+                _p("rb2", "RB", 55),
+                _p("wr1", "WR", 58),
+                _p("wr2", "WR", 52),
+                _p("wr3", "WR", 48),
+                _p("te1", "TE", 40),
+            ]
+        )
+        imp = absence_impacts(pool, SLOTS_SF)
+        assert imp["QB"].starters_tested == 2  # QB slot + SUPER_FLEX
+
+
+# ── Solve summary invariants ───────────────────────────────────────
+
+
+class TestSolveSummary:
+    def test_empty_inputs_are_zero_not_an_error(self):
+        assert solve_summary([], ["QB"]).score == 0.0
+        assert solve_summary(to_roster_players([_p("a", "QB", 5)]), []).score == 0.0
+
+    def test_duplicate_slot_labels_do_not_collide(self):
+        """Two RB slots must both appear in the assignment map; a naive
+        dict keyed on the bare label would silently keep only one."""
+        pool = to_roster_players([_p("rb1", "RB", 60), _p("rb2", "RB", 55)])
+        summary = solve_summary(pool, ["RB", "RB"])
+        assert summary.filled_slots == 2
+        assert len(summary.slot_assignment) == 2
+        assert summary.score == pytest.approx(115.0)
+
+    def test_unfilled_slots_are_reported(self):
+        # One player fills exactly one slot — he cannot occupy both QB
+        # and SUPER_FLEX. Everything else on a 9-slot lineup is unfilled.
+        pool = to_roster_players([_p("qb1", "QB", 90)])
+        summary = solve_summary(pool, SLOTS_SF)
+        assert summary.filled_slots == 1
+        assert summary.unfilled_slots == len(SLOTS_SF) - 1
+
+    def test_marginal_share_sums_sensibly(self):
+        """Shares are per-position contributions over the full score.
+        They need not sum to 1 (slot competition means the parts
+        overlap), but no single share may exceed 1."""
+        pool = to_roster_players(
+            [
+                _p("qb1", "QB", 90),
+                _p("rb1", "RB", 60),
+                _p("rb2", "RB", 55),
+                _p("wr1", "WR", 58),
+                _p("wr2", "WR", 52),
+                _p("wr3", "WR", 48),
+                _p("te1", "TE", 40),
+            ]
+        )
+        marg = position_marginals(pool, SLOTS_SF)
+        for pm in marg.by_position.values():
+            assert 0.0 <= pm.marginal_share <= 1.0
+
+
+# ── Variation guard (the _positional_coverage lesson) ──────────────
+
+
+class TestMetricsActuallyVary:
+    """`_positional_coverage` once returned exactly 100.00 for all 12
+    teams — a constant masquerading as a score.  These assert the
+    marginal metrics discriminate between genuinely different rosters
+    rather than collapsing to a shared value."""
+
+    def _roster(self, seed: int) -> list:
+        # Deterministically distinct rosters.
+        return to_roster_players(
+            [
+                _p("qb1", "QB", 60 + seed * 3),
+                _p("rb1", "RB", 55 - seed),
+                _p("rb2", "RB", 40 + seed * 2),
+                _p("wr1", "WR", 58 - seed * 2),
+                _p("wr2", "WR", 45),
+                _p("wr3", "WR", 30 + seed),
+                _p("te1", "TE", 25 + seed * 4),
+            ]
+        )
+
+    def test_lineup_scores_vary_across_rosters(self):
+        scores = {position_marginals(self._roster(i), SLOTS_SF).lineup_score for i in range(12)}
+        assert len(scores) > 1, "lineup score is constant across 12 distinct rosters"
+
+    def test_position_marginals_vary_across_rosters(self):
+        for pos in ("QB", "RB", "WR", "TE"):
+            vals = {
+                round(
+                    position_marginals(self._roster(i), SLOTS_SF).by_position[pos].marginal_points,
+                    4,
+                )
+                for i in range(12)
+            }
+            assert len(vals) > 1, f"{pos} marginal is constant across 12 distinct rosters"

--- a/tests/roster_intel/test_profiles.py
+++ b/tests/roster_intel/test_profiles.py
@@ -1,0 +1,289 @@
+"""Tests for ``src/roster_intel/profiles.py``.
+
+Mechanism-disconnection focus (ORCHESTRATION §2b): the profile's
+strength fields must stay lineup-derived, and surplus/need must stay
+lineup-derived rather than count-derived.  Each test below is built so
+it fails if someone reconnects a headcount or a summed value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.replacement import PositionReplacement, ReplacementLevel
+from src.roster_intel.marginal import to_roster_players
+from src.roster_intel.profiles import TIER_ORDER, build_position_profiles, classify_tier
+
+
+def _p(pid, pos, value, **kw):
+    return {
+        "playerId": pid,
+        "canonicalName": pid,
+        "position": pos,
+        "rosValue": value,
+        "fantasyPositions": kw.pop("fpos", ()),
+        **kw,
+    }
+
+
+def _rep(pos, elite, starter, roster):
+    def lvl(tier, v):
+        return ReplacementLevel(
+            position=pos,
+            tier=tier,
+            value=v,
+            threshold_rank=None,
+            band_low=None,
+            band_high=None,
+            sample_size=50,
+        )
+
+    return PositionReplacement(
+        position=pos,
+        starters_per_team=2.0,
+        rostered_count=50,
+        priced_count=50,
+        levels={
+            "bestBallStarter": lvl("bestBallStarter", elite),
+            "starter": lvl("starter", starter),
+            "roster": lvl("roster", roster),
+        },
+    )
+
+
+SLOTS = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "SUPER_FLEX"]
+
+
+# ── Tiering ────────────────────────────────────────────────────────
+
+
+class TestClassifyTier:
+    def test_tiers_against_league_levels_not_roster_relative(self):
+        """A weak room must report ZERO elites. Roster-relative tiering
+        would crown every team's best player and is how 'everyone looks
+        the same' metrics are born."""
+        rep = _rep("RB", elite=70.0, starter=45.0, roster=20.0)
+        assert classify_tier(80.0, rep) == "elite"
+        assert classify_tier(50.0, rep) == "starter"
+        assert classify_tier(25.0, rep) == "depth"
+        assert classify_tier(5.0, rep) == "developmental"
+
+    def test_unknown_levels_never_promote(self):
+        assert classify_tier(999.0, None) == "developmental"
+
+    def test_zero_value_is_developmental(self):
+        assert classify_tier(0.0, _rep("RB", 70.0, 45.0, 20.0)) == "developmental"
+
+
+# ── Strength stays lineup-derived ──────────────────────────────────
+
+
+class TestStrengthIsLineupDerived:
+    def test_hoarded_qbs_do_not_inflate_strength(self):
+        """MECHANISM TEST. Five QBs vs two: marginal and entry rate must
+        expose the hoard. A summed-value or count field would not."""
+        base = [
+            _p("rb1", "RB", 60),
+            _p("rb2", "RB", 55),
+            _p("wr1", "WR", 58),
+            _p("wr2", "WR", 52),
+            _p("te1", "TE", 40),
+        ]
+        two = build_position_profiles(
+            to_roster_players(base + [_p("qb1", "QB", 90), _p("qb2", "QB", 88)]), SLOTS
+        ).positions["QB"]
+        # The five-QB set must share the SAME top two as the two-QB set,
+        # otherwise the comparison measures different players rather
+        # than the hoarding effect.
+        five = build_position_profiles(
+            to_roster_players(
+                base
+                + [
+                    _p("qb1", "QB", 90),
+                    _p("qb2", "QB", 88),
+                    _p("qb3", "QB", 86),
+                    _p("qb4", "QB", 84),
+                    _p("qb5", "QB", 82),
+                ]
+            ),
+            SLOTS,
+        ).positions["QB"]
+
+        assert five.marginal_points == pytest.approx(two.marginal_points, abs=1e-6)
+        assert five.rostered > two.rostered
+        assert five.entry_rate < two.entry_rate
+
+    def test_a_position_with_no_slot_has_zero_strength(self):
+        prof = build_position_profiles(
+            to_roster_players([_p("qb1", "QB", 90), _p("k1", "K", 999), _p("rb1", "RB", 50)]),
+            SLOTS,  # no K slot
+        )
+        assert prof.positions["K"].marginal_points == 0.0
+        assert prof.positions["K"].entered_lineup == 0
+
+
+# ── Surplus / need are lineup-derived ──────────────────────────────
+
+
+class TestSurplusAndNeed:
+    def test_surplus_is_non_entering_value_not_excess_headcount(self):
+        """MECHANISM TEST. Only players who do NOT enter the lineup can
+        be surplus. A count-vs-required-slots rule would call the QB
+        room 'surplus 3' regardless of who plays."""
+        rep = {"QB": _rep("QB", elite=80.0, starter=50.0, roster=20.0)}
+        prof = build_position_profiles(
+            to_roster_players(
+                [
+                    _p("qb1", "QB", 90),
+                    _p("qb2", "QB", 88),
+                    _p("qb3", "QB", 86),
+                    _p("qb4", "QB", 84),
+                    _p("rb1", "RB", 60),
+                    _p("rb2", "RB", 55),
+                    _p("wr1", "WR", 58),
+                    _p("wr2", "WR", 52),
+                    _p("te1", "TE", 40),
+                ]
+            ),
+            SLOTS,
+            replacement=rep,
+        ).positions["QB"]
+        # QB + SUPER_FLEX start two; the other two are surplus.
+        assert prof.entered_lineup == 2
+        assert prof.tradeable_surplus == pytest.approx(86 + 84)
+        assert set(prof.surplus_players) == {"qb3", "qb4"}
+
+    def test_low_value_bench_is_not_called_tradeable(self):
+        """Without the floor, every dart throw reads as an asset."""
+        rep = {"WR": _rep("WR", elite=80.0, starter=50.0, roster=20.0)}
+        prof = build_position_profiles(
+            to_roster_players(
+                [
+                    _p("qb1", "QB", 90),
+                    _p("wr1", "WR", 70),
+                    _p("wr2", "WR", 65),
+                    _p("wr3", "WR", 60),
+                    _p("wr4", "WR", 3),  # deep dart throw
+                    _p("rb1", "RB", 50),
+                    _p("te1", "TE", 40),
+                ]
+            ),
+            SLOTS,
+            replacement=rep,
+        ).positions["WR"]
+        assert "wr4" not in prof.surplus_players
+
+    def test_unfilled_dedicated_slots_raise_urgent_need(self):
+        prof = build_position_profiles(
+            to_roster_players([_p("qb1", "QB", 90), _p("rb1", "RB", 50)]), SLOTS
+        )
+        assert prof.positions["RB"].urgent_need is True
+        assert any("dedicated RB slots" in r for r in prof.positions["RB"].need_reasons)
+
+    def test_position_required_but_absent_is_reported(self):
+        """A position with zero bodies must still appear — omitting it
+        makes the biggest hole on the roster invisible."""
+        prof = build_position_profiles(to_roster_players([_p("qb1", "QB", 90)]), SLOTS)
+        assert "TE" in prof.positions
+        assert prof.positions["TE"].rostered == 0
+        assert prof.positions["TE"].urgent_need is True
+
+    def test_flex_slots_are_not_attributed_to_any_position(self):
+        """MECHANISM TEST. Splitting FLEX/SUPER_FLEX by assumption is
+        the error that made even-split demand wrong by 40% at QB
+        (LI-5). requiredSlots must count dedicated slots only."""
+        prof = build_position_profiles(
+            to_roster_players([_p("qb1", "QB", 90), _p("rb1", "RB", 60), _p("rb2", "RB", 55)]),
+            SLOTS,
+        )
+        assert prof.positions["QB"].required_slots == 1  # not 2 with SUPER_FLEX
+        assert prof.positions["RB"].required_slots == 2  # not 3 with FLEX
+
+
+# ── Exposure is descriptive, kept separate ─────────────────────────
+
+
+class TestExposure:
+    def test_age_and_bye_are_reported_without_touching_strength(self):
+        meta = {
+            "rb1": {"age": 30, "byeWeek": 7},
+            "rb2": {"age": 24, "byeWeek": 7},
+            "rb3": {"age": 22, "byeWeek": 9},
+        }
+        pool = to_roster_players(
+            [_p("qb1", "QB", 90), _p("rb1", "RB", 60), _p("rb2", "RB", 55), _p("rb3", "RB", 50)]
+        )
+        with_meta = build_position_profiles(pool, SLOTS, player_meta=meta).positions["RB"]
+        without = build_position_profiles(pool, SLOTS).positions["RB"]
+
+        assert with_meta.mean_age == pytest.approx((30 + 24 + 22) / 3)
+        assert with_meta.age_over_28 == 1
+        assert with_meta.bye_concentration == pytest.approx(2 / 3)
+        # Strength is identical either way — exposure never blends in.
+        assert with_meta.marginal_points == without.marginal_points
+        assert without.mean_age is None
+
+    def test_full_bye_stack_reads_as_total_concentration(self):
+        meta = {f"rb{i}": {"byeWeek": 9} for i in (1, 2)}
+        prof = build_position_profiles(
+            to_roster_players([_p("rb1", "RB", 60), _p("rb2", "RB", 55)]),
+            ["RB", "RB"],
+            player_meta=meta,
+        ).positions["RB"]
+        assert prof.bye_concentration == pytest.approx(1.0)
+
+    def test_injured_starters_are_distinguished_from_injured_bench(self):
+        pool = to_roster_players(
+            [
+                _p("rb1", "RB", 60, injured=True),  # starts
+                _p("rb2", "RB", 55),
+                _p("rb3", "RB", 10, injured=True),  # benched
+            ]
+        )
+        prof = build_position_profiles(pool, ["RB", "RB"]).positions["RB"]
+        assert prof.injured_count == 2
+        assert prof.injured_starters == 1
+
+
+# ── Shape / variation ──────────────────────────────────────────────
+
+
+class TestShape:
+    def test_tier_counts_cover_every_player_exactly_once(self):
+        rep = {"RB": _rep("RB", 70.0, 45.0, 20.0)}
+        prof = build_position_profiles(
+            to_roster_players([_p(f"rb{i}", "RB", 90 - i * 20) for i in range(4)]),
+            ["RB", "RB"],
+            replacement=rep,
+        ).positions["RB"]
+        assert sum(prof.tier_counts.values()) == prof.rostered
+        assert set(prof.tier_counts) == set(TIER_ORDER)
+
+    def test_profiles_vary_across_distinct_rosters(self):
+        """A constant here would be the `_positional_coverage` defect."""
+        vals = set()
+        for seed in range(12):
+            prof = build_position_profiles(
+                to_roster_players(
+                    [
+                        _p("qb1", "QB", 60 + seed * 3),
+                        _p("rb1", "RB", 55 - seed),
+                        _p("rb2", "RB", 40 + seed * 2),
+                        _p("wr1", "WR", 58 - seed * 2),
+                        _p("wr2", "WR", 45),
+                        _p("te1", "TE", 25 + seed * 4),
+                    ]
+                ),
+                SLOTS,
+            )
+            vals.add(round(prof.positions["RB"].marginal_points, 4))
+        assert len(vals) > 1
+
+    def test_to_dict_is_json_shaped(self):
+        prof = build_position_profiles(
+            to_roster_players([_p("qb1", "QB", 90), _p("rb1", "RB", 50)]), SLOTS
+        )
+        blob = prof.to_dict()
+        assert "positions" in blob and "lineupScore" in blob
+        qb = blob["positions"]["QB"]
+        assert set(qb) >= {"marginalPoints", "entryRate", "tierCounts", "urgentNeed"}

--- a/tests/roster_intel/test_profiles.py
+++ b/tests/roster_intel/test_profiles.py
@@ -12,7 +12,12 @@ import pytest
 
 from src.league_intel.replacement import PositionReplacement, ReplacementLevel
 from src.roster_intel.marginal import to_roster_players
-from src.roster_intel.profiles import TIER_ORDER, build_position_profiles, classify_tier
+from src.roster_intel.profiles import (
+    TIER_ORDER,
+    build_position_profiles,
+    classify_tier,
+    elite_threshold,
+)
 
 
 def _p(pid, pos, value, **kw):
@@ -62,11 +67,18 @@ class TestClassifyTier:
         """A weak room must report ZERO elites. Roster-relative tiering
         would crown every team's best player and is how 'everyone looks
         the same' metrics are born."""
-        rep = _rep("RB", elite=70.0, starter=45.0, roster=20.0)
-        assert classify_tier(80.0, rep) == "elite"
-        assert classify_tier(50.0, rep) == "starter"
-        assert classify_tier(25.0, rep) == "depth"
-        assert classify_tier(5.0, rep) == "developmental"
+        # NOTE: `_rep`'s first argument populates `bestBallStarter`,
+        # which is the startable FLOOR and sits BELOW `starter` in real
+        # measured data.  This fixture originally passed 70.0 there and
+        # called it "elite", asserting an ordering replacement.py cannot
+        # produce — that inverted fixture is precisely why the unreachable
+        # `starter` tier survived review.  The floor is now given a
+        # realistic value and the elite cut is passed explicitly.
+        rep = _rep("RB", elite=30.0, starter=45.0, roster=20.0)
+        assert classify_tier(80.0, rep, elite=70.0) == "elite"
+        assert classify_tier(50.0, rep, elite=70.0) == "starter"
+        assert classify_tier(25.0, rep, elite=70.0) == "depth"
+        assert classify_tier(5.0, rep, elite=70.0) == "developmental"
 
     def test_unknown_levels_never_promote(self):
         assert classify_tier(999.0, None) == "developmental"
@@ -287,3 +299,174 @@ class TestShape:
         assert "positions" in blob and "lineupScore" in blob
         qb = blob["positions"]["QB"]
         assert set(qb) >= {"marginalPoints", "entryRate", "tierCounts", "urgentNeed"}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tier ladder regression (peer-review defect, 2026-07-26)
+#
+# classify_tier read `bestBallStarter` as the ELITE bar.  replacement.py
+# builds that level as the mean of the LOWEST marginals and `starter` as
+# their MEDIAN, so bestBallStarter <= starter always — the top tier was
+# pinned to the startable FLOOR.  Anything reaching `starter` had
+# already returned "elite", so the `starter` tier was unreachable and
+# 65-78% of every rostered player classified elite.
+#
+# Every test below fails against that code.  `_rep(elite=70, starter=45)`
+# in the older fixtures above encodes bestBallStarter ABOVE starter,
+# which real data can never produce — that inverted fixture is why the
+# defect survived review, so these build levels from MEASURED data.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _measured_levels():
+    """Replacement levels from the synthetic 12-team league."""
+    import sys
+
+    sys.path.insert(0, "tests")
+    from league_intel.test_replacement import make_team
+
+    from src.league_intel.replacement import compute_replacement_levels
+
+    teams = [make_team(i, scale=1.0 + 0.06 * i) for i in range(12)]
+    slots = ["QB", "RB", "RB", "WR", "WR", "WR", "TE", "FLEX", "SUPER_FLEX", "LB", "LB"]
+    return teams, compute_replacement_levels(teams, slots)
+
+
+def _league_values(teams):
+    from src.league_intel.replacement import normalize_base_position
+
+    out: dict[str, list[float]] = {}
+    for t in teams:
+        for p in t["players"]:
+            base = normalize_base_position(p["position"])
+            v = float(p.get("rosValue") or 0)
+            if base and v > 0:
+                out.setdefault(base, []).append(v)
+    return out
+
+
+class TestTierLadder:
+    def test_bestball_floor_is_below_starter_in_measured_data(self):
+        """The premise. If this ever flips, the old code was defensible."""
+        _, levels = _measured_levels()
+        checked = 0
+        for pos, rep in levels.items():
+            bb, st = rep.value("bestBallStarter"), rep.value("starter")
+            if bb is None or st is None:
+                continue
+            checked += 1
+            assert bb <= st, f"{pos}: bestBallStarter {bb} > starter {st}"
+        assert checked >= 4
+
+    def test_thresholds_are_strictly_ordered(self):
+        """Property 1 — elite > starter > depth, on measured levels."""
+        teams, levels = _measured_levels()
+        vals = _league_values(teams)
+        checked = 0
+        for pos, rep in levels.items():
+            st, ro = rep.value("starter"), rep.value("roster")
+            el = elite_threshold(vals.get(pos, ()))
+            if None in (st, ro, el):
+                continue
+            checked += 1
+            assert el > st > ro, f"{pos}: elite {el} starter {st} roster {ro}"
+        assert checked >= 4
+
+    def test_every_tier_is_reachable(self):
+        """Property 2 — the one that actually catches the defect."""
+        from collections import Counter
+
+        from src.league_intel.replacement import normalize_base_position
+
+        teams, levels = _measured_levels()
+        vals = _league_values(teams)
+        counts: Counter = Counter()
+        for t in teams:
+            for p in t["players"]:
+                base = normalize_base_position(p["position"])
+                counts[
+                    classify_tier(
+                        float(p.get("rosValue") or 0),
+                        levels.get(base),
+                        elite=elite_threshold(vals.get(base, ())),
+                    )
+                ] += 1
+        assert counts["starter"] > 0, f"starter tier unreachable: {dict(counts)}"
+        assert counts["elite"] > 0, f"elite tier unreachable: {dict(counts)}"
+        total = sum(counts.values())
+        assert counts["elite"] / total < 0.25, (
+            f"elite is {100 * counts['elite'] / total:.0f}% of the league: {dict(counts)}"
+        )
+
+    def test_an_ordinary_starter_is_not_elite(self):
+        """Property 3."""
+        teams, levels = _measured_levels()
+        vals = _league_values(teams)
+        for pos, rep in levels.items():
+            st = rep.value("starter")
+            el = elite_threshold(vals.get(pos, ()))
+            if st is None or el is None:
+                continue
+            assert classify_tier(st, rep, elite=el) == "starter"
+
+    def test_the_best_player_at_a_position_is_elite(self):
+        """Property 4."""
+        teams, levels = _measured_levels()
+        vals = _league_values(teams)
+        checked = 0
+        for pos, rep in levels.items():
+            pool = vals.get(pos, [])
+            if not pool or rep.value("starter") is None:
+                continue
+            checked += 1
+            assert (
+                classify_tier(max(pool), rep, elite=elite_threshold(pool)) == "elite"
+            ), f"{pos}: best player not elite"
+        assert checked >= 4
+
+    def test_missing_replacement_data_degrades_never_promotes(self):
+        """Property 5."""
+        assert classify_tier(9999.0, None, elite=1.0) == "developmental"
+        rep = _rep("RB", elite=0.0, starter=45.0, roster=20.0)
+        assert classify_tier(9999.0, rep, elite=None) == "starter"
+
+    def test_a_degenerate_threshold_cannot_make_everyone_elite(self):
+        """Property 6 — a non-separating elite cut is ignored, not obeyed.
+
+        When every team is identical the pool has no spread, so the
+        top-5% value collapses onto `starter`. The old code's failure
+        mode was exactly this shape.
+        """
+        from collections import Counter
+
+        from src.league_intel.replacement import (
+            compute_replacement_levels,
+            normalize_base_position,
+        )
+
+        import sys
+
+        sys.path.insert(0, "tests")
+        from league_intel.test_replacement import make_team
+
+        teams = [make_team(i, scale=1.0) for i in range(12)]  # identical
+        slots = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "SUPER_FLEX", "LB", "LB"]
+        levels = compute_replacement_levels(teams, slots)
+        vals = _league_values(teams)
+        counts: Counter = Counter()
+        for t in teams:
+            for p in t["players"]:
+                base = normalize_base_position(p["position"])
+                counts[
+                    classify_tier(
+                        float(p.get("rosValue") or 0),
+                        levels.get(base),
+                        elite=elite_threshold(vals.get(base, ())),
+                    )
+                ] += 1
+        total = sum(counts.values())
+        assert counts["elite"] / total < 0.25, (
+            f"degenerate pool promoted {100 * counts['elite'] / total:.0f}% to elite: "
+            f"{dict(counts)}"
+        )
+        assert counts["starter"] > 0, f"starter unreachable: {dict(counts)}"

--- a/tests/roster_intel/test_profiles.py
+++ b/tests/roster_intel/test_profiles.py
@@ -394,9 +394,9 @@ class TestTierLadder:
         assert counts["starter"] > 0, f"starter tier unreachable: {dict(counts)}"
         assert counts["elite"] > 0, f"elite tier unreachable: {dict(counts)}"
         total = sum(counts.values())
-        assert counts["elite"] / total < 0.25, (
-            f"elite is {100 * counts['elite'] / total:.0f}% of the league: {dict(counts)}"
-        )
+        assert (
+            counts["elite"] / total < 0.25
+        ), f"elite is {100 * counts['elite'] / total:.0f}% of the league: {dict(counts)}"
 
     def test_an_ordinary_starter_is_not_elite(self):
         """Property 3."""

--- a/tests/roster_intel/test_real_rosters.py
+++ b/tests/roster_intel/test_real_rosters.py
@@ -1,0 +1,202 @@
+"""Variation guards against the REAL 12 rosters, at full roster depth.
+
+Two lessons are encoded here.
+
+1. ``_positional_coverage`` once returned exactly 100.00 for all 12
+   teams — a constant masquerading as a score.  Synthetic fixtures would
+   not have caught that, because it only collapsed on live data.  Every
+   headline metric is therefore asserted to VARY across the real league.
+
+2. The first WS-J measurement ran on ``startingLineup + benchDepth``
+   from the team-strength snapshot — 26 players against real 53-58 man
+   rosters.  A truncated pool understates depth and overstates
+   fragility, so those figures were directionally wrong in a known
+   direction.  These tests join the FULL Sleeper rosters
+   (``data/sleeper_last_good.json``) to ROS values and pin the roster
+   sizes so a future truncation regresses loudly.
+
+Marked ``livedata``: they read the live snapshots and are excluded from
+the blocking suite (``-m "not livedata"``), matching the repo's existing
+convention for data-dependent assertions.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+
+import pytest
+
+from src.roster_intel.marginal import absence_impacts, position_marginals, to_roster_players
+
+pytestmark = pytest.mark.livedata
+
+REPO = Path(__file__).resolve().parents[2]
+SLEEPER = REPO / "data" / "sleeper_last_good.json"
+AGGREGATE = REPO / "data" / "ros" / "aggregate" / "latest.json"
+
+
+def _norm(s: str) -> str:
+    return "".join(c for c in str(s or "").lower() if c.isalnum())
+
+
+@pytest.fixture(scope="module")
+def league():
+    if not SLEEPER.exists() or not AGGREGATE.exists():
+        pytest.skip("live snapshots not present in this checkout")
+
+    agg = json.loads(AGGREGATE.read_text())
+    rows = agg if isinstance(agg, list) else (agg.get("players") or list(agg.values())[0])
+    by_name: dict[str, dict] = {}
+    for r in rows:
+        k = _norm(r.get("canonicalName"))
+        if not k:
+            continue
+        # The WS-E audit recorded duplicate rows with split values; keep
+        # the higher one rather than whichever happens to be last.
+        if k in by_name and float(r.get("rosValue") or 0) <= float(by_name[k].get("rosValue") or 0):
+            continue
+        by_name[k] = r
+
+    teams = json.loads(SLEEPER.read_text())["rosterData"]["teams"]
+
+    # Read the registry FILE rather than src.api.league_registry: the
+    # module caches a resolved registry and other suites reset it, so
+    # get_default_league() returns None depending on test ordering.
+    # The file is the same source of truth without the shared state.
+    registry_path = REPO / "config" / "leagues" / "registry.json"
+    if not registry_path.exists():
+        pytest.skip("league registry not present")
+    registry = json.loads(registry_path.read_text())
+    default_key = registry.get("defaultLeagueKey")
+    entry = next(
+        (lg for lg in registry.get("leagues") or [] if lg.get("key") == default_key),
+        None,
+    )
+    if entry is None:
+        pytest.skip("default league not found in registry")
+    starters = ((entry.get("rosterSettings") or {}).get("starters")) or {}
+    alias = {"SFLEX": "SUPER_FLEX"}
+    slots: list[str] = []
+    for slot, count in starters.items():
+        try:
+            n = int(count)
+        except (TypeError, ValueError):
+            continue
+        if n > 0:
+            slots.extend([alias.get(str(slot).upper(), str(slot).upper())] * n)
+
+    built = []
+    for t in teams:
+        names = t.get("players") or []
+        pool_rows = []
+        for nm in names:
+            hit = by_name.get(_norm(nm))
+            if hit is None:
+                continue
+            pool_rows.append(
+                {
+                    "playerId": nm,
+                    "canonicalName": nm,
+                    "position": hit.get("position") or "",
+                    "rosValue": float(hit.get("rosValue") or 0.0),
+                    "confidence": float(hit.get("confidence") or 0.0),
+                    "fantasyPositions": (),
+                }
+            )
+        pool = to_roster_players(pool_rows)
+        built.append(
+            {
+                "name": t.get("name"),
+                "rostered": len(names),
+                "matched": len(pool_rows),
+                "marginals": position_marginals(pool, slots),
+                "absence": absence_impacts(pool, slots),
+            }
+        )
+    return built
+
+
+# ── The truncation guard ───────────────────────────────────────────
+
+
+def test_rosters_are_full_depth_not_the_26_player_snapshot(league):
+    """MECHANISM TEST. Fails if the pool is ever fed from
+    ``startingLineup + benchDepth`` (26) instead of the real roster.
+
+    Real rosters run 44-58 players; the team-strength snapshot exposes
+    26.  A mean below 40 means someone reconnected the truncated source
+    and every depth/fragility number silently became wrong again.
+    """
+    sizes = [t["rostered"] for t in league]
+    assert min(sizes) > 26, f"a roster came in at snapshot depth: {sizes}"
+    assert statistics.fmean(sizes) > 40
+
+
+def test_join_loss_stays_small_and_is_visible(league):
+    """The ROS aggregate has known name-casing and duplicate defects
+    (WS-E audit).  Some loss is expected; a silent jump is not."""
+    rostered = sum(t["rostered"] for t in league)
+    matched = sum(t["matched"] for t in league)
+    loss = (rostered - matched) / rostered
+    assert loss < 0.10, f"join loss {loss:.1%} — identity layer regressed"
+    assert matched > 600
+
+
+# ── Variation guards ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "metric",
+    ["lineup_score", "QB_marginal", "RB_marginal", "WR_marginal", "TE_marginal"],
+)
+def test_headline_metrics_vary_across_the_real_league(league, metric):
+    if metric == "lineup_score":
+        vals = [t["marginals"].lineup_score for t in league]
+    else:
+        pos = metric.split("_")[0]
+        vals = [
+            t["marginals"].by_position[pos].marginal_points
+            for t in league
+            if pos in t["marginals"].by_position
+        ]
+    assert len(vals) >= 10
+    assert len(set(round(v, 4) for v in vals)) > 1, f"{metric} is constant across 12 real rosters"
+    assert (
+        statistics.pstdev(vals) > 1.0
+    ), f"{metric} barely moves (sd={statistics.pstdev(vals):.3f})"
+
+
+def test_fragility_varies_and_is_not_the_old_constant(league):
+    """The first fragility definition returned ~1/n for everyone.  On
+    the real league that would show as a near-zero spread."""
+    vals = [t["absence"]["RB"].fragility for t in league if "RB" in t["absence"]]
+    assert len(set(round(v, 4) for v in vals)) > 1
+    assert statistics.pstdev(vals) > 0.05, "fragility has collapsed toward a constant"
+    assert all(0.0 <= v <= 1.0 for v in vals)
+
+
+def test_clogger_value_discriminates_hoarders(league):
+    """Clog is the signal a summed-value metric cannot express.  Some
+    roster must be carrying real un-startable value, and some must not."""
+    vals = [
+        t["marginals"].by_position["QB"].clogger_value
+        for t in league
+        if "QB" in t["marginals"].by_position
+    ]
+    assert max(vals) > 20.0, "no roster shows QB clog — suspicious in superflex"
+    assert min(vals) < max(vals)
+
+
+def test_entry_rate_is_below_one_somewhere(league):
+    """If every position on every roster had entry rate 1.0, the
+    optimizer would not be constraining anything and the metric would be
+    decorative."""
+    rates = [
+        t["marginals"].by_position["QB"].entry_rate
+        for t in league
+        if "QB" in t["marginals"].by_position
+    ]
+    assert min(rates) < 1.0
+    assert len(set(round(r, 4) for r in rates)) > 1

--- a/tests/roster_intel/test_real_rosters.py
+++ b/tests/roster_intel/test_real_rosters.py
@@ -28,7 +28,15 @@ from pathlib import Path
 
 import pytest
 
-from src.roster_intel.marginal import absence_impacts, position_marginals, to_roster_players
+from src.league_intel.replacement import compute_replacement_levels
+from src.roster_intel.engine import analyze_roster
+from src.roster_intel.marginal import (
+    absence_impacts,
+    optimal_score,
+    position_marginals,
+    to_roster_players,
+)
+from src.roster_intel.window import COMPETITIVE_STATES
 
 pytestmark = pytest.mark.livedata
 
@@ -109,6 +117,10 @@ def league():
         built.append(
             {
                 "name": t.get("name"),
+                "owner": str(t.get("ownerId") or t.get("name")),
+                "slots": slots,
+                "rows": pool_rows,
+                "pool": pool,
                 "rostered": len(names),
                 "matched": len(pool_rows),
                 "marginals": position_marginals(pool, slots),
@@ -116,6 +128,31 @@ def league():
             }
         )
     return built
+
+
+@pytest.fixture(scope="module")
+def intel(league):
+    """Full :func:`analyze_roster` output for all 12 real rosters.
+
+    Replacement levels are computed from the same 12 rosters (the
+    league IS the replacement market), and lineup scores are passed so
+    the window's competitiveness axis has a real source rather than the
+    "unavailable" default — the default would hand every team the same
+    median and manufacture the constant this file exists to catch.
+    """
+    slots = league[0]["slots"]
+    replacement = compute_replacement_levels([{"players": t["rows"]} for t in league], slots)
+    lineup_scores = {t["owner"]: optimal_score(t["pool"], slots) for t in league}
+    return [
+        analyze_roster(
+            t["owner"],
+            t["pool"],
+            slots,
+            replacement=replacement,
+            lineup_scores=lineup_scores,
+        )
+        for t in league
+    ]
 
 
 # ── The truncation guard ───────────────────────────────────────────
@@ -200,3 +237,158 @@ def test_entry_rate_is_below_one_somewhere(league):
     ]
     assert min(rates) < 1.0
     assert len(set(round(r, 4) for r in rates)) > 1
+
+
+# ── Engine rollups: variation on the real league ────────────────────
+
+
+@pytest.mark.parametrize(
+    "attr",
+    ["ros", "starters_ros", "bench_ros"],
+)
+def test_value_rollups_vary_across_the_real_league(intel, attr):
+    vals = [getattr(t.values, attr) for t in intel]
+    assert len(set(round(v, 3) for v in vals)) == len(vals), f"values.{attr} has ties across 12"
+    assert statistics.pstdev(vals) > 10.0
+
+
+def test_starters_and_bench_split_the_roster(intel):
+    """MECHANISM TEST. Fails if the starters/bench split stops reading
+    the optimizer's assignment and degenerates (all-starters or
+    all-bench), which would make ``benchRos`` a copy of ``ros``."""
+    for t in intel:
+        assert t.values.starters_ros > 0
+        assert t.values.bench_ros > 0
+        assert abs((t.values.starters_ros + t.values.bench_ros) - t.values.ros) < 0.01
+        # The optimal lineup is 21 slots against 44-58 rostered
+        # players; if starters were the whole roster the split is off.
+        assert t.values.starters_ros < t.values.ros
+
+
+def test_lineup_score_equals_the_starters_rollup(intel):
+    """The two are computed by different code paths (marginal solve vs
+    value rollup over assigned ids). They must agree, or one of them is
+    reading a stale assignment."""
+    for t in intel:
+        assert abs(t.lineup_score - t.values.starters_ros) < 0.01
+
+
+def test_needs_vary_and_are_not_all_zero(intel):
+    """Contribution must vary everywhere; deficit must be positive
+    SOMEWHERE. A board where nobody is ever below replacement means the
+    baseline is not being applied."""
+    positions = sorted({p for t in intel for p in t.needs})
+    assert len(positions) >= 6
+
+    for pos in positions:
+        contribs = [t.needs[pos].actual_contribution for t in intel if pos in t.needs]
+        risks = [t.needs[pos].concentration_risk for t in intel if pos in t.needs]
+        if len(contribs) < 10:
+            continue
+        assert (
+            len(set(round(v, 3) for v in contribs)) > 1
+        ), f"needs[{pos}].actualContribution is constant across 12 real rosters"
+        assert (
+            len(set(round(v, 4) for v in risks)) > 1
+        ), f"needs[{pos}].concentrationRisk is constant across 12 real rosters"
+
+    positive = [(t.owner_id, p) for t in intel for p, n in t.needs.items() if n.deficit > 0]
+    assert positive, "no roster is below replacement anywhere — baseline not applied"
+    # ...and not EVERY roster/position, which would mean the baseline is
+    # scaled wrong rather than applied.
+    total = sum(len(t.needs) for t in intel)
+    assert len(positive) < total * 0.5, f"{len(positive)}/{total} positions in deficit"
+
+
+def test_deficit_does_not_follow_concentration_on_the_real_league(intel):
+    """MECHANISM TEST — the inversion a consumer actually hit.
+
+    Deriving need as ``fragility x marginal`` crowns the position a
+    roster is STRONGEST at, because a great room is concentrated by
+    definition. Measured here: the naive formula names QB the top need
+    for the team with the highest QB contribution in the league.
+
+    This fails if ``position_needs`` is ever reimplemented in terms of
+    fragility.
+    """
+    qb = [(t.owner_id, t.needs["QB"]) for t in intel if "QB" in t.needs]
+    assert len(qb) == 12
+
+    naive_top = max(qb, key=lambda kv: kv[1].concentration_risk * kv[1].actual_contribution)
+    strongest = max(qb, key=lambda kv: kv[1].actual_contribution)
+    assert naive_top[0] == strongest[0], (
+        "the naive derivation no longer inverts on this data; this test's "
+        "premise needs re-measuring, not deleting"
+    )
+    # The engine must NOT agree with it.
+    assert naive_top[1].deficit == 0.0, (
+        "engine reports a deficit at the league's strongest QB room — "
+        "position_needs has been rewired to fragility"
+    )
+
+    # And the engine's own top need must differ from the naive pick on
+    # most rosters, or it is tracking concentration by accident.
+    disagreements = 0
+    for t in intel:
+        if not t.needs:
+            continue
+        engine_top = max(t.needs.values(), key=lambda n: n.deficit)
+        naive = max(t.needs.values(), key=lambda n: n.concentration_risk * n.actual_contribution)
+        if engine_top.position != naive.position:
+            disagreements += 1
+    assert disagreements >= 9, f"engine agreed with the naive ranking on {12 - disagreements}/12"
+
+
+# ── Competitive window on the real league ──────────────────────────
+
+
+def test_window_probabilities_vary_and_stay_normalized(intel):
+    for state in COMPETITIVE_STATES:
+        vals = [t.window.probabilities[state] for t in intel]
+        assert (
+            len(set(round(v, 4) for v in vals)) > 1
+        ), f"window p[{state}] is constant across 12 real rosters"
+    for t in intel:
+        assert abs(sum(t.window.probabilities.values()) - 1.0) < 1e-9
+        serialized = t.window.to_dict()["probabilities"]
+        assert abs(sum(serialized.values()) - 1.0) < 1e-9
+
+
+def test_window_assigns_more_than_one_state_across_the_league(intel):
+    """A 12-team league that reads as one state is a broken classifier,
+    not a uniform league."""
+    labels = [t.window.most_likely for t in intel]
+    assert len(set(labels)) >= 3, f"only {set(labels)} across 12 rosters"
+    assert max(labels.count(x) for x in set(labels)) <= 6
+
+
+def test_missing_ages_are_disclosed_rather_than_absorbed(intel):
+    """MECHANISM TEST for the live wiring gap.
+
+    No committed artifact carries player ages — they arrive only on the
+    live Sleeper overlay — so on this data the trajectory axis is
+    pinned neutral and the window is a competitiveness-only read. That
+    is survivable ONLY because it is stated. This fails if the note is
+    dropped, or if a future age source lands and the note is left
+    stale.
+    """
+    for t in intel:
+        has_ages = t.window.inputs.trajectory_sample > 0
+        disclosed = any("ages" in n for n in t.notes)
+        assert has_ages != disclosed, (
+            f"{t.owner_id}: trajectory_sample={t.window.inputs.trajectory_sample} "
+            f"but age disclosure={disclosed}"
+        )
+        if not has_ages:
+            assert t.window.inputs.trajectory == pytest.approx(0.5)
+
+
+def test_odds_absence_is_disclosed(intel):
+    """No simulator output is supplied here, so every roster must say
+    so rather than present a structural proxy as simulated odds."""
+    for t in intel:
+        assert t.playoff_odds is None
+        assert t.championship_odds is None
+        assert t.odds_source == "unavailable"
+        assert any("playoff_sim" in n for n in t.notes)
+        assert t.window.inputs.competitiveness_source == "lineupScoreRank"

--- a/tests/roster_intel/test_real_rosters.py
+++ b/tests/roster_intel/test_real_rosters.py
@@ -1,6 +1,6 @@
 """Variation guards against the REAL 12 rosters, at full roster depth.
 
-Two lessons are encoded here.
+Three lessons are encoded here.
 
 1. ``_positional_coverage`` once returned exactly 100.00 for all 12
    teams — a constant masquerading as a score.  Synthetic fixtures would
@@ -14,6 +14,17 @@ Two lessons are encoded here.
    direction.  These tests join the FULL Sleeper rosters
    (``data/sleeper_last_good.json``) to ROS values and pin the roster
    sizes so a future truncation regresses loudly.
+
+3. An underfed FIXTURE produces the same symptom as a broken metric.
+   This file first measured the competitive window without eligibility
+   or ages, because the fixture supplied neither — the trajectory axis
+   read exactly 0.500 for all 12 teams and ``productive_struggle`` was
+   unreachable for every one of them.  Both inputs were sitting in
+   ``data/public_league/nfl_players_full.json`` the whole time (12,201
+   entries, 11,866 with ``fantasy_positions``, 10,954 with ``age``).
+   The fixture now joins that dump, and pins the coverage it achieves,
+   so a constant here means the METRIC collapsed rather than the test
+   having starved it.
 
 Marked ``livedata``: they read the live snapshots and are excluded from
 the blocking suite (``-m "not livedata"``), matching the repo's existing
@@ -36,6 +47,13 @@ from src.roster_intel.marginal import (
     position_marginals,
     to_roster_players,
 )
+from src.roster_intel.roster_source import (
+    build_nfl_position_index,
+    build_roster_pool,
+    build_value_index,
+    hybrid_coverage,
+    normalize_name,
+)
 from src.roster_intel.window import COMPETITIVE_STATES
 
 pytestmark = pytest.mark.livedata
@@ -43,6 +61,7 @@ pytestmark = pytest.mark.livedata
 REPO = Path(__file__).resolve().parents[2]
 SLEEPER = REPO / "data" / "sleeper_last_good.json"
 AGGREGATE = REPO / "data" / "ros" / "aggregate" / "latest.json"
+NFL_DUMP = REPO / "data" / "public_league" / "nfl_players_full.json"
 
 
 def _norm(s: str) -> str:
@@ -56,16 +75,30 @@ def league():
 
     agg = json.loads(AGGREGATE.read_text())
     rows = agg if isinstance(agg, list) else (agg.get("players") or list(agg.values())[0])
-    by_name: dict[str, dict] = {}
-    for r in rows:
-        k = _norm(r.get("canonicalName"))
-        if not k:
+    # build_value_index applies the WS-E duplicate rule (higher rosValue
+    # wins) — the same rule this fixture used to hand-roll.
+    values = build_value_index(rows)
+
+    # Sleeper's own player dump: the ONLY source of slot eligibility
+    # (fantasy_positions) and of ages.  The ROS aggregate carries
+    # neither, so joining rosters to it alone reintroduces ADR-007 and
+    # leaves the window's trajectory axis inert.
+    if not NFL_DUMP.exists():
+        pytest.skip("nfl player dump not present in this checkout")
+    dump = json.loads(NFL_DUMP.read_text())
+    eligibility = build_nfl_position_index(dump)
+
+    ages: dict[str, dict[str, float]] = {}
+    for record in dump.values():
+        if not isinstance(record, dict):
             continue
-        # The WS-E audit recorded duplicate rows with split values; keep
-        # the higher one rather than whichever happens to be last.
-        if k in by_name and float(r.get("rosValue") or 0) <= float(by_name[k].get("rosValue") or 0):
-            continue
-        by_name[k] = r
+        full = record.get("full_name") or (
+            f"{record.get('first_name') or ''} {record.get('last_name') or ''}".strip()
+        )
+        key = normalize_name(full)
+        age = record.get("age")
+        if key and age:
+            ages.setdefault(key, {"age": float(age)})
 
     teams = json.loads(SLEEPER.read_text())["rosterData"]["teams"]
 
@@ -98,21 +131,7 @@ def league():
     built = []
     for t in teams:
         names = t.get("players") or []
-        pool_rows = []
-        for nm in names:
-            hit = by_name.get(_norm(nm))
-            if hit is None:
-                continue
-            pool_rows.append(
-                {
-                    "playerId": nm,
-                    "canonicalName": nm,
-                    "position": hit.get("position") or "",
-                    "rosValue": float(hit.get("rosValue") or 0.0),
-                    "confidence": float(hit.get("confidence") or 0.0),
-                    "fantasyPositions": (),
-                }
-            )
+        pool_rows, report = build_roster_pool(names, values=values, eligibility=eligibility)
         pool = to_roster_players(pool_rows)
         built.append(
             {
@@ -121,6 +140,12 @@ def league():
                 "slots": slots,
                 "rows": pool_rows,
                 "pool": pool,
+                "report": report,
+                "meta": {
+                    r["playerId"]: ages[normalize_name(r["canonicalName"])]
+                    for r in pool_rows
+                    if normalize_name(r["canonicalName"]) in ages
+                },
                 "rostered": len(names),
                 "matched": len(pool_rows),
                 "marginals": position_marginals(pool, slots),
@@ -134,21 +159,26 @@ def league():
 def intel(league):
     """Full :func:`analyze_roster` output for all 12 real rosters.
 
-    Replacement levels are computed from the same 12 rosters (the
-    league IS the replacement market), and lineup scores are passed so
-    the window's competitiveness axis has a real source rather than the
-    "unavailable" default — the default would hand every team the same
-    median and manufacture the constant this file exists to catch.
+    Every optional input is supplied, because an absent one produces a
+    constant that looks exactly like a broken metric: replacement
+    levels from the same 12 rosters (the league IS the replacement
+    market), lineup scores so the competitiveness axis has a real
+    source rather than the median default, and ages so the trajectory
+    axis is not pinned at neutral.
     """
     slots = league[0]["slots"]
     replacement = compute_replacement_levels([{"players": t["rows"]} for t in league], slots)
     lineup_scores = {t["owner"]: optimal_score(t["pool"], slots) for t in league}
+    meta: dict[str, dict[str, float]] = {}
+    for t in league:
+        meta.update(t["meta"])
     return [
         analyze_roster(
             t["owner"],
             t["pool"],
             slots,
             replacement=replacement,
+            player_meta=meta,
             lineup_scores=lineup_scores,
         )
         for t in league
@@ -354,33 +384,64 @@ def test_window_probabilities_vary_and_stay_normalized(intel):
         assert abs(sum(serialized.values()) - 1.0) < 1e-9
 
 
-def test_window_assigns_more_than_one_state_across_the_league(intel):
+def test_window_reaches_every_state_across_the_league(intel):
     """A 12-team league that reads as one state is a broken classifier,
-    not a uniform league."""
+    not a uniform league.
+
+    All five states are reachable on this data — but ONLY with ages
+    joined.  Without them the trajectory axis pins at 0.500 and
+    ``productive_struggle`` (young roster, losing now) becomes
+    unreachable no matter what the roster looks like; that measured as
+    4 of 5 states before the fixture joined the player dump.
+    """
     labels = [t.window.most_likely for t in intel]
-    assert len(set(labels)) >= 3, f"only {set(labels)} across 12 rosters"
+    assert set(labels) == set(COMPETITIVE_STATES), (
+        f"only {sorted(set(labels))} reached across 12 rosters — a state that "
+        "no roster can reach usually means one of the window's axes is inert"
+    )
     assert max(labels.count(x) for x in set(labels)) <= 6
 
 
-def test_missing_ages_are_disclosed_rather_than_absorbed(intel):
-    """MECHANISM TEST for the live wiring gap.
+def test_trajectory_axis_is_live_not_pinned(intel):
+    """MECHANISM TEST. Fails if ages stop reaching the window.
 
-    No committed artifact carries player ages — they arrive only on the
-    live Sleeper overlay — so on this data the trajectory axis is
-    pinned neutral and the window is a competitiveness-only read. That
-    is survivable ONLY because it is stated. This fails if the note is
-    dropped, or if a future age source lands and the note is left
-    stale.
+    A dead trajectory axis does not error — it returns exactly 0.500
+    for every roster and quietly reduces the five-state distribution to
+    a one-dimensional read of competitiveness.
     """
+    samples = [t.window.inputs.trajectory_sample for t in intel]
+    assert min(samples) > 10, f"ages reached almost nothing: {samples}"
+
+    traj = [t.window.inputs.trajectory for t in intel]
+    assert len(set(round(v, 4) for v in traj)) == len(traj), "trajectory has ties across 12"
+    assert statistics.pstdev(traj) > 0.05, f"trajectory barely moves: sd={statistics.pstdev(traj)}"
+    assert min(traj) < 0.45 and max(traj) > 0.55, "no roster reads as young or as old"
+
     for t in intel:
-        has_ages = t.window.inputs.trajectory_sample > 0
-        disclosed = any("ages" in n for n in t.notes)
-        assert has_ages != disclosed, (
-            f"{t.owner_id}: trajectory_sample={t.window.inputs.trajectory_sample} "
-            f"but age disclosure={disclosed}"
-        )
-        if not has_ages:
-            assert t.window.inputs.trajectory == pytest.approx(0.5)
+        assert not any("ages" in n for n in t.notes), f"{t.owner_id} still reports missing ages"
+
+
+def test_eligibility_join_is_complete_on_the_real_league(intel, league):
+    """MECHANISM TEST for ADR-007, from the data side.
+
+    A DL/LB/DB-family player with no ``fantasy_positions`` can be
+    benched illegally by the optimizer, and the only symptom is a
+    quietly lower IDP marginal.  The player dump covers every rostered
+    player here, so any shortfall means the join was dropped.
+    """
+    rows = [r for t in league for r in t["rows"]]
+    cov = hybrid_coverage(rows)
+    assert cov.multi_family > 0, "no multi-family players found — the join lost positions"
+    assert cov.multi_family_without_eligibility == 0, (
+        f"{cov.multi_family_without_eligibility} IDP-family players carry no "
+        "fantasy_positions; their positions' marginals are a lower bound"
+    )
+    assert sum(t["report"].hybrids_found for t in league) > 0
+
+    for pos in ("DL", "LB", "DB"):
+        vals = [t.needs[pos].actual_contribution for t in intel if pos in t.needs]
+        assert len(vals) == 12
+        assert len(set(round(v, 3) for v in vals)) == 12, f"{pos} contribution has ties"
 
 
 def test_odds_absence_is_disclosed(intel):

--- a/tests/roster_intel/test_roster_source.py
+++ b/tests/roster_intel/test_roster_source.py
@@ -1,0 +1,244 @@
+"""Tests for ``src/roster_intel/roster_source.py``.
+
+The module exists because WS-J reintroduced ADR-007's defect from the
+data side: the ROS aggregate carries no ``fantasy_positions``, so joining
+rosters to it alone hands the optimizer position-only rows and hybrid
+IDPs get locked out of half their legal slots.  The optimizer is correct;
+the data path feeding it was not.
+
+These are mechanism-disconnection tests per ORCHESTRATION §2b — each
+fails if eligibility enrichment is silently dropped, which is the
+failure mode that produces no error and only a quietly worse lineup.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.roster_intel.marginal import position_marginals, solve_summary, to_roster_players
+from src.roster_intel.roster_source import (
+    build_nfl_position_index,
+    build_roster_pool,
+    build_value_index,
+    hybrid_coverage,
+    normalize_name,
+)
+
+
+def _agg(name, pos, value, **kw):
+    return {"canonicalName": name, "position": pos, "rosValue": value, **kw}
+
+
+def _nfl(pid, first, last, pos, fpos):
+    return (
+        pid,
+        {"first_name": first, "last_name": last, "position": pos, "fantasy_positions": fpos},
+    )
+
+
+# ── Name normalization ─────────────────────────────────────────────
+
+
+class TestNormalizeName:
+    def test_strips_punctuation_case_and_spacing(self):
+        assert normalize_name("Ja'Marr Chase") == normalize_name("jamarr chase")
+        assert normalize_name("A.J. Brown") == normalize_name("aj brown")
+        assert normalize_name("  Bijan  Robinson ") == "bijanrobinson"
+
+    def test_empty_inputs_are_empty(self):
+        assert normalize_name(None) == ""
+        assert normalize_name("") == ""
+
+
+# ── Value index / duplicate handling ───────────────────────────────
+
+
+class TestValueIndex:
+    def test_duplicate_rows_keep_the_higher_value(self):
+        """The WS-E audit found the same player under two spellings with
+        ROS value split across both. Taking whichever row came last
+        would make the result depend on file ordering."""
+        idx = build_value_index(
+            [_agg("Cam Skattebo", "RB", 12.0), _agg("cam skattebo", "RB", 47.0)]
+        )
+        assert len(idx) == 1
+        assert idx["camskattebo"]["rosValue"] == 47.0
+
+    def test_ordering_does_not_change_the_result(self):
+        a = build_value_index([_agg("Tank Dell", "WR", 5.0), _agg("tank dell", "WR", 30.0)])
+        b = build_value_index([_agg("tank dell", "WR", 30.0), _agg("Tank Dell", "WR", 5.0)])
+        assert a["tankdell"]["rosValue"] == b["tankdell"]["rosValue"] == 30.0
+
+    def test_rows_without_a_name_are_skipped(self):
+        assert build_value_index([{"rosValue": 10.0}]) == {}
+
+
+# ── Eligibility index ──────────────────────────────────────────────
+
+
+class TestNflPositionIndex:
+    def test_carries_fantasy_positions(self):
+        idx = build_nfl_position_index(dict([_nfl("1", "Javin", "White", "LB", ["DB", "LB"])]))
+        assert idx["javinwhite"] == ("LB", ("DB", "LB"))
+
+    def test_prefers_the_entry_that_has_eligibility(self):
+        """The dump contains retired/duplicate shells with no
+        fantasy_positions; those must not overwrite a good entry."""
+        idx = build_nfl_position_index(
+            dict(
+                [
+                    _nfl("1", "Javin", "White", "LB", ["DB", "LB"]),
+                    _nfl("2", "Javin", "White", "LB", []),
+                ]
+            )
+        )
+        assert idx["javinwhite"][1] == ("DB", "LB")
+
+    def test_falls_back_to_first_last_when_full_name_absent(self):
+        idx = build_nfl_position_index(
+            {
+                "1": {
+                    "first_name": "Nico",
+                    "last_name": "Collins",
+                    "position": "WR",
+                    "fantasy_positions": ["WR"],
+                }
+            }
+        )
+        assert "nicocollins" in idx
+
+
+# ── The join, and the defect it prevents ───────────────────────────
+
+
+class TestBuildRosterPool:
+    def test_hybrid_eligibility_reaches_the_optimizer(self):
+        """MECHANISM TEST. Fails if fantasyPositions is dropped anywhere
+        between the dump and the RosterPlayer rows.
+
+        One DL/LB hybrid plus one pure DL, with a DL slot and an LB
+        slot. Both slots fill ONLY when the hybrid is legal at LB.
+        """
+        values = build_value_index([_agg("Hybrid Guy", "DL", 30.0), _agg("Pure Dl", "DL", 28.0)])
+        elig = build_nfl_position_index(
+            dict(
+                [
+                    _nfl("1", "Hybrid", "Guy", "DL", ["DL", "LB"]),
+                    _nfl("2", "Pure", "Dl", "DL", ["DL"]),
+                ]
+            )
+        )
+        rows, report = build_roster_pool(["Hybrid Guy", "Pure Dl"], values=values, eligibility=elig)
+        assert report.hybrids_found == 1
+        summary = solve_summary(to_roster_players(rows), ["DL", "LB"])
+        assert summary.filled_slots == 2
+        assert summary.score == pytest.approx(58.0)
+
+    def test_without_eligibility_the_second_slot_goes_empty(self):
+        """The defect, pinned. This is what the ROS-aggregate-only path
+        produced, and why IDP marginals were a lower bound."""
+        values = build_value_index([_agg("Hybrid Guy", "DL", 30.0), _agg("Pure Dl", "DL", 28.0)])
+        rows, _ = build_roster_pool(["Hybrid Guy", "Pure Dl"], values=values, eligibility={})
+        summary = solve_summary(to_roster_players(rows), ["DL", "LB"])
+        assert summary.filled_slots == 1
+        assert summary.score == pytest.approx(30.0)
+
+    def test_dump_position_wins_over_the_aggregate(self):
+        """The NFL dump is the host's own view; the aggregate is scraped
+        from ranking sites that disagree on IDP labelling."""
+        values = build_value_index([_agg("Edge Guy", "LB", 25.0)])
+        elig = build_nfl_position_index(dict([_nfl("1", "Edge", "Guy", "DL", ["DL", "LB"])]))
+        rows, _ = build_roster_pool(["Edge Guy"], values=values, eligibility=elig)
+        assert rows[0]["position"] == "DL"
+        assert rows[0]["fantasyPositions"] == ("DL", "LB")
+
+    def test_unvalued_players_are_reported_not_silently_dropped(self):
+        values = build_value_index([_agg("Known Guy", "WR", 40.0)])
+        rows, report = build_roster_pool(
+            ["Known Guy", "Ghost Player"], values=values, eligibility={}
+        )
+        assert len(rows) == 1
+        assert report.rostered == 2 and report.valued == 1
+        assert report.unmatched_names == ("Ghost Player",)
+        assert report.value_join_rate == pytest.approx(0.5)
+
+    def test_empty_roster_is_a_clean_zero(self):
+        rows, report = build_roster_pool([], values={}, eligibility={})
+        assert rows == []
+        assert report.value_join_rate == 0.0
+
+
+# ── Coverage audit ─────────────────────────────────────────────────
+
+
+class TestHybridCoverage:
+    def test_flags_multi_family_players_missing_eligibility(self):
+        """The number that matters: a DL/LB/DB-family player with no
+        fantasy_positions may be benched illegally."""
+        cov = hybrid_coverage(
+            [
+                {"position": "DL", "fantasyPositions": ()},
+                {"position": "LB", "fantasyPositions": ("DL", "LB")},
+                {"position": "WR", "fantasyPositions": ()},
+            ]
+        )
+        assert cov.multi_family == 2
+        assert cov.multi_family_with_eligibility == 1
+        assert cov.multi_family_without_eligibility == 1
+        assert cov.eligibility_complete is False
+        assert cov.true_hybrids == 1
+
+    def test_complete_when_every_idp_carries_eligibility(self):
+        cov = hybrid_coverage(
+            [
+                {"position": "DL", "fantasyPositions": ("DL",)},
+                {"position": "DB", "fantasyPositions": ("DB", "LB")},
+            ]
+        )
+        assert cov.eligibility_complete is True
+        assert cov.multi_family_without_eligibility == 0
+
+    def test_offense_only_pool_is_trivially_complete(self):
+        cov = hybrid_coverage([{"position": "WR", "fantasyPositions": ()}])
+        assert cov.multi_family == 0
+        assert cov.eligibility_complete is True
+
+
+# ── The lineup consequence, end to end ─────────────────────────────
+
+
+class TestEligibilityChangesMarginals:
+    def test_enrichment_never_lowers_the_lineup_score(self):
+        """Widening eligibility can only expand the optimizer's feasible
+        set, so the optimal score is monotonically non-decreasing. A
+        drop would mean the optimizer is not optimal."""
+        # Three DL-POSITION players, one of them LB-eligible, against
+        # DL/DL/LB slots. Position-only leaves the LB slot empty; with
+        # eligibility the hybrid fills it. A fixture where every slot
+        # already fills both ways proves nothing.
+        values = build_value_index(
+            [
+                _agg("Hybrid A", "DL", 30.0),
+                _agg("Pure Dl", "DL", 28.0),
+                _agg("Other Dl", "DL", 26.0),
+            ]
+        )
+        elig = build_nfl_position_index(
+            dict(
+                [
+                    _nfl("1", "Hybrid", "A", "DL", ["DL", "LB"]),
+                    _nfl("2", "Pure", "Dl", "DL", ["DL"]),
+                    _nfl("3", "Other", "Dl", "DL", ["DL"]),
+                ]
+            )
+        )
+        names = ["Hybrid A", "Pure Dl", "Other Dl"]
+        slots = ["DL", "DL", "LB"]
+
+        after_rows, _ = build_roster_pool(names, values=values, eligibility=elig)
+        before_rows = [{**r, "fantasyPositions": ()} for r in after_rows]
+
+        before = position_marginals(to_roster_players(before_rows), slots).lineup_score
+        after = position_marginals(to_roster_players(after_rows), slots).lineup_score
+        assert after >= before
+        assert after > before  # this fixture is constructed to improve

--- a/tests/roster_intel/test_window.py
+++ b/tests/roster_intel/test_window.py
@@ -1,0 +1,311 @@
+"""Tests for ``src/roster_intel/window.py``.
+
+The window is a distribution, not a label. The invariants that make it
+one — mutual exclusivity, sum-to-1, and a manual override that stays
+distinguishable from a measurement — are pinned here, along with
+mechanism-disconnection tests per ORCHESTRATION §2b: each fails if the
+placement is quietly swapped for a threshold cut or a headcount.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.roster_intel.marginal import to_roster_players
+from src.roster_intel.window import (
+    COMPETITIVE_STATES,
+    ORDERING_CAVEAT,
+    STATE_ORDER,
+    compute_window,
+    league_competitiveness,
+    trajectory_score,
+)
+
+
+def _p(pid, pos, value, **kw):
+    return {
+        "playerId": pid,
+        "canonicalName": pid,
+        "position": pos,
+        "rosValue": value,
+        "fantasyPositions": (),
+        **kw,
+    }
+
+
+SLOTS = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "SUPER_FLEX"]
+
+ROSTER = to_roster_players(
+    [
+        _p("qb1", "QB", 90),
+        _p("rb1", "RB", 60),
+        _p("rb2", "RB", 55),
+        _p("wr1", "WR", 58),
+        _p("wr2", "WR", 52),
+        _p("te1", "TE", 40),
+    ]
+)
+
+
+def _odds(mapping):
+    return [{"ownerId": k, "championshipOdds": v} for k, v in mapping.items()]
+
+
+# ── The distribution invariants ────────────────────────────────────
+
+
+class TestDistributionInvariants:
+    @pytest.mark.parametrize("comp", [0.0, 0.25, 0.5, 0.75, 1.0])
+    def test_probabilities_sum_to_one(self, comp):
+        w = compute_window("me", ROSTER, SLOTS, lineup_scores={"me": comp, "other": 0.5})
+        assert sum(w.probabilities.values()) == pytest.approx(1.0)
+
+    def test_every_state_is_present_exactly_once(self):
+        w = compute_window("me", ROSTER, SLOTS)
+        assert set(w.probabilities) == set(COMPETITIVE_STATES)
+        assert len(w.probabilities) == 5
+
+    def test_probabilities_are_non_negative(self):
+        w = compute_window("me", ROSTER, SLOTS)
+        assert all(v >= 0.0 for v in w.probabilities.values())
+
+    def test_most_likely_matches_the_argmax(self):
+        w = compute_window("me", ROSTER, SLOTS, lineup_scores={"me": 9, "a": 1, "b": 2})
+        assert w.most_likely == max(w.probabilities, key=lambda k: w.probabilities[k])
+        assert w.confidence == w.probabilities[w.most_likely]
+
+    def test_sum_to_one_holds_under_an_override(self):
+        w = compute_window("me", ROSTER, SLOTS, override_state="rebuild")
+        assert sum(w.probabilities.values()) == pytest.approx(1.0)
+
+
+# ── Placement responds to the measured axes ────────────────────────
+
+
+class TestPlacement:
+    def test_strong_roster_leans_contender_weak_leans_rebuild(self):
+        """MECHANISM TEST. Fails if competitiveness stops driving
+        placement — e.g. if someone wires it to roster headcount."""
+        scores = {"strong": 900.0, "mid": 600.0, "weak": 300.0}
+        strong = compute_window("strong", ROSTER, SLOTS, lineup_scores=scores)
+        weak = compute_window("weak", ROSTER, SLOTS, lineup_scores=scores)
+
+        contender = ("championship_contender", "playoff_contender")
+        assert sum(strong.probabilities[s] for s in contender) > sum(
+            weak.probabilities[s] for s in contender
+        )
+        assert weak.probabilities["rebuild"] > strong.probabilities["rebuild"]
+
+    def test_placement_is_continuous_not_a_threshold_cut(self):
+        """A threshold implementation makes a team one point either side
+        of a cut flip category while its neighbour does not move. This
+        asserts neighbouring rosters produce neighbouring
+        distributions."""
+        base = {f"t{i}": float(i) for i in range(12)}
+        prev = None
+        for i in range(12):
+            w = compute_window(f"t{i}", ROSTER, SLOTS, lineup_scores=base)
+            cur = w.probabilities["rebuild"]
+            if prev is not None:
+                # Monotone decreasing in competitiveness, and no single
+                # step swings the whole distribution.
+                assert cur <= prev + 1e-9
+                assert abs(cur - prev) < 0.85
+            prev = cur
+
+    def test_young_and_old_rosters_at_equal_strength_differ(self):
+        """Trajectory must matter. Fails if age is collected but never
+        reaches the placement."""
+        scores = {"me": 500.0, "a": 400.0, "b": 600.0}
+        young = compute_window(
+            "me",
+            ROSTER,
+            SLOTS,
+            lineup_scores=scores,
+            player_meta={p.player_id: {"age": 23} for p in ROSTER},
+        )
+        old = compute_window(
+            "me",
+            ROSTER,
+            SLOTS,
+            lineup_scores=scores,
+            player_meta={p.player_id: {"age": 31} for p in ROSTER},
+        )
+        assert young.probabilities != old.probabilities
+        assert young.inputs.trajectory > old.inputs.trajectory
+
+
+# ── Competitiveness sourcing ───────────────────────────────────────
+
+
+class TestCompetitivenessSource:
+    def test_prefers_simulated_championship_odds(self):
+        score, src = league_competitiveness(
+            "b",
+            playoff_odds=_odds({"a": 0.05, "b": 0.40, "c": 0.10}),
+            lineup_scores={"a": 900.0, "b": 100.0, "c": 500.0},
+        )
+        assert src == "championshipOdds"
+        assert score > 0.5  # best odds, despite the worst lineup score
+
+    def test_falls_back_to_lineup_rank_and_stamps_it(self):
+        score, src = league_competitiveness("b", lineup_scores={"a": 100.0, "b": 900.0, "c": 500.0})
+        assert src == "lineupScoreRank"
+        assert score > 0.5
+
+    def test_all_zero_odds_are_not_treated_as_a_signal(self):
+        """An unrun simulator returns zeros for everyone; that is
+        missing data, not a league of equals."""
+        _, src = league_competitiveness(
+            "b",
+            playoff_odds=_odds({"a": 0.0, "b": 0.0}),
+            lineup_scores={"a": 100.0, "b": 900.0},
+        )
+        assert src == "lineupScoreRank"
+
+    def test_no_source_is_neutral_and_says_so(self):
+        score, src = league_competitiveness("b")
+        assert score == 0.5
+        assert src == "unavailable"
+        w = compute_window("b", ROSTER, SLOTS)
+        assert any("defaulted to league median" in n for n in w.notes)
+
+    def test_proxy_source_is_flagged_in_notes(self):
+        w = compute_window("me", ROSTER, SLOTS, lineup_scores={"me": 5.0, "x": 1.0})
+        assert any("structural proxy" in n for n in w.notes)
+
+
+# ── Trajectory ─────────────────────────────────────────────────────
+
+
+class TestTrajectory:
+    def test_only_lineup_entrants_count(self):
+        """MECHANISM TEST. A bench dart throw's age says nothing about
+        the window; fails if the restriction is dropped."""
+        pool = to_roster_players([_p("qb1", "QB", 90), _p("qb2", "QB", 1), _p("rb1", "RB", 60)])
+        # qb2 is ancient but never starts on a QB-only slot set.
+        score, n = trajectory_score(
+            pool, ["QB"], {"qb1": {"age": 24}, "qb2": {"age": 40}, "rb1": {"age": 40}}
+        )
+        assert n == 1
+        assert score == pytest.approx((32.0 - 24.0) / (32.0 - 22.0))
+
+    def test_weighting_stops_scrubs_hiding_an_old_anchor(self):
+        """Unweighted, five 22-year-olds would drown one 33-year-old
+        anchor. Weighted by value, the anchor dominates."""
+        pool = to_roster_players(
+            [_p("anchor", "QB", 95)] + [_p(f"kid{i}", "RB", 3) for i in range(5)]
+        )
+        slots = ["QB", "RB", "RB", "RB", "RB", "RB"]
+        meta = {"anchor": {"age": 33}}
+        meta.update({f"kid{i}": {"age": 22} for i in range(5)})
+        score, n = trajectory_score(pool, slots, meta)
+        assert n == 6
+        unweighted = (33 + 22 * 5) / 6  # 23.83 -> would read 'young'
+        weighted_age = 32.0 - score * (32.0 - 22.0)
+        assert weighted_age > unweighted
+
+    def test_missing_ages_are_neutral_not_zero(self):
+        score, n = trajectory_score(ROSTER, SLOTS, {})
+        assert (score, n) == (0.5, 0)
+
+    def test_zero_value_players_do_not_skew_the_weighting(self):
+        pool = to_roster_players([_p("a", "QB", 50), _p("b", "QB", 0)])
+        score, n = trajectory_score(
+            pool, ["QB", "SUPER_FLEX"], {"a": {"age": 25}, "b": {"age": 40}}
+        )
+        assert n == 1
+
+
+# ── Manual override ────────────────────────────────────────────────
+
+
+class TestOverride:
+    def test_override_pins_the_state_and_is_stamped(self):
+        w = compute_window(
+            "me",
+            ROSTER,
+            SLOTS,
+            lineup_scores={"me": 900.0, "x": 100.0},  # model would say contender
+            override_state="rebuild",
+            override_reason="manager stated intent",
+        )
+        assert w.overridden is True
+        assert w.most_likely == "rebuild"
+        assert w.probabilities["rebuild"] == 1.0
+        assert w.probabilities["championship_contender"] == 0.0
+        assert w.override_reason == "manager stated intent"
+
+    def test_override_retains_model_inputs_for_audit(self):
+        """A pinned state must not erase what the model measured, or a
+        wrong override becomes undetectable."""
+        w = compute_window(
+            "me",
+            ROSTER,
+            SLOTS,
+            lineup_scores={"me": 900.0, "x": 100.0},
+            override_state="rebuild",
+        )
+        assert w.inputs.competitiveness > 0.5
+        assert w.inputs.competitiveness_source == "lineupScoreRank"
+
+    def test_unknown_override_state_raises(self):
+        with pytest.raises(ValueError, match="unknown competitive state"):
+            compute_window("me", ROSTER, SLOTS, override_state="tanking")
+
+
+# ── Ordering contract (relayed to the design agent) ────────────────
+
+
+class TestOrderingContract:
+    def test_state_order_runs_contend_to_rebuild(self):
+        assert STATE_ORDER[0] == "championship_contender"
+        assert STATE_ORDER[-1] == "rebuild"
+        assert len(STATE_ORDER) == len(COMPETITIVE_STATES)
+
+    def test_the_soft_pair_is_documented(self):
+        """The caveat is part of the contract: a consumer choosing a
+        diverging visual needs to know which adjacency is weak."""
+        assert "retool" in ORDERING_CAVEAT
+        assert "productive_struggle" in ORDERING_CAVEAT
+        w = compute_window("me", ROSTER, SLOTS)
+        assert w.to_dict()["orderingCaveat"] == ORDERING_CAVEAT
+        assert w.to_dict()["stateOrder"] == list(STATE_ORDER)
+
+
+# ── Variation guard ────────────────────────────────────────────────
+
+
+class TestVariation:
+    def test_windows_differ_across_twelve_distinct_rosters(self):
+        """A constant distribution would be the `_positional_coverage`
+        defect in probability clothing."""
+        scores = {f"t{i}": 300.0 + i * 55.0 for i in range(12)}
+        seen = set()
+        for i in range(12):
+            w = compute_window(
+                f"t{i}",
+                ROSTER,
+                SLOTS,
+                lineup_scores=scores,
+                player_meta={p.player_id: {"age": 22 + i} for p in ROSTER},
+            )
+            seen.add(tuple(round(w.probabilities[s], 4) for s in COMPETITIVE_STATES))
+        assert len(seen) == 12, "competitive window is constant across distinct rosters"
+
+    def test_low_confidence_rosters_are_flagged(self):
+        """When no state clears 30% the single label is misleading and
+        must not be presented alone."""
+        found = False
+        for i in range(12):
+            w = compute_window(
+                f"t{i}",
+                ROSTER,
+                SLOTS,
+                lineup_scores={f"t{j}": 300.0 + j * 55.0 for j in range(12)},
+                temperature=2.0,  # deliberately indecisive
+            )
+            if w.confidence < 0.30:
+                assert any("should not be presented alone" in n for n in w.notes)
+                found = True
+        assert found

--- a/tests/roster_intel/test_window.py
+++ b/tests/roster_intel/test_window.py
@@ -74,6 +74,23 @@ class TestDistributionInvariants:
         assert w.most_likely == max(w.probabilities, key=lambda k: w.probabilities[k])
         assert w.confidence == w.probabilities[w.most_likely]
 
+    @pytest.mark.parametrize("comp", [0.0, 0.13, 0.37, 0.5, 0.61, 0.88, 1.0])
+    def test_serialized_probabilities_also_sum_to_one(self, comp):
+        """The invariant must survive SERIALIZATION, not just hold on
+        the raw floats. Naive per-key rounding to 4dp drifted to 1.0001,
+        so a consumer reading the JSON saw a distribution that did not
+        sum to 1 - and the payload is what consumers actually read.
+        """
+        w = compute_window("me", ROSTER, SLOTS, lineup_scores={"me": comp, "lo": 0.0, "hi": 1.0})
+        serialized = w.to_dict()["probabilities"]
+        assert sum(serialized.values()) == pytest.approx(1.0, abs=1e-12)
+        assert set(serialized) == set(COMPETITIVE_STATES)
+
+    def test_serialized_rounding_is_deterministic(self):
+        a = compute_window("me", ROSTER, SLOTS, lineup_scores={"me": 5.0, "x": 1.0})
+        b = compute_window("me", ROSTER, SLOTS, lineup_scores={"me": 5.0, "x": 1.0})
+        assert a.to_dict()["probabilities"] == b.to_dict()["probabilities"]
+
     def test_sum_to_one_holds_under_an_override(self):
         w = compute_window("me", ROSTER, SLOTS, override_state="rebuild")
         assert sum(w.probabilities.values()) == pytest.approx(1.0)


### PR DESCRIPTION
The roster half of WS-J (Roster & Trade Intelligence). Measures **what a roster is** by re-solving the exact best-ball lineup: marginal contribution per position, absence fragility, tradeable surplus, urgent need, and the competitive window as a five-state probability distribution.

Consumes `src/league_intel/` (exact scorer, exact optimizer, replacement levels, value schema) and `src/ros/` **as-is**. It never re-implements them, per the repo's one-live-path rule.

---

## Why this PR is based on `claude/league-intel-foundation`, not `main`

This branch is **not** independent WS-J work sitting on `main`. It merged `claude/league-intel-foundation` and builds directly on it. Basing it on `main` would replay ~19 League-Intelligence commits already under review in **#550**, producing a duplicate diff and a guaranteed conflict when both land.

So this is stacked: **#550 → this PR → #563**.

**Brought up to #550's head.** `claude/league-intel-foundation` had moved four commits ahead of what this branch contained (`928a1fa8`, `e1481162`, `1768519d`, `4bb81004` — the LI-8 work), which left this PR unmergeable against its own base. Merged in at `be23a42c`, **zero conflicts**. No generated artifact needed hand-resolution: `data/ros/*`, `data/scrape_state/*` and `CSVs/site_raw/*` all merged automatically, so no data value was chosen by me.

`928a1fa8` is the one worth knowing about — it makes `allow_scalar_fallback` a real flag in `src/league_intel/cross_market.py`, where it was previously declared and never read. **Nothing in `src/roster_intel/` on this branch calls `cross_market`**, so that change is inert here. It is live on #563, where `packages.py` does pass the flag; measured and documented there.

**Diff noise.** The two branches criss-crossed merge history, so `git merge-base` reports multiple bases. **Review `src/roster_intel/`, `tests/roster_intel/`, `src/ros/lineup.py` and `src/trade/suggestions.py`** — the rest is #550's and disappears once #550 merges and this PR is retargeted to `main`. Scoped to this workstream's own files: **17 files, +4,248 / −42**.

---

## What is here

| Module | What it does |
|---|---|
| `marginal.py` | Marginal value of a position = `S(full roster) − S(roster without that position)`, both sides an exact lineup re-solve |
| `profiles.py` | Per-position profiles built on the marginal engine — fragility, surplus, deficit, urgent need |
| `window.py` | Competitive window as a 5-state probability distribution via softmax, not a single label |
| `roster_source.py` | Builds the roster pool with the real eligibility index and ages |
| `engine.py` | `analyze_roster()` composes the three into one payload and **consumes** `src/ros/playoff_sim.py` rather than simulating a second time |

`src/ros/lineup.py` gains the `fantasy_positions` slot-eligibility join (ADR-007, reintroduced from the data side). `src/trade/suggestions.py` gets a 15-line touch.

## Corrections made inside this branch, kept in the history

Each is a place where an earlier commit on this branch shipped something that looked right and was not.

**Marginals were measured on the wrong population.** First computed on starter-sized rosters; re-measured on the FULL 53-58 man rosters, the only population where "remove this position" means anything.

**`deficit` measured concentration, not shortfall.** Deriving need as `fragility × marginal` reported **QB as the biggest need on a QB-strong roster** — a great room is concentrated by definition. Reproduced on the real league: the naive formula names QB the top need for the team with the highest QB contribution of all 12. `deficit` and `concentrationRisk` are now separate fields with their semantics stamped in the payload, and `deficit` is measured against replacement-level occupancy of the position's dedicated slots, never from fragility.

**The window's five probabilities summed to 1.0001.** Naive 4dp rounding broke the sum through serialization. Fixed with largest-remainder rounding.

**A fixture omission was misdiagnosed as a dead metric — and the correction is the important part.** Commit `e6eb0c92` reported that no committed artifact carries player ages and that the window's trajectory axis was therefore inert on real data. That was **wrong, and wrong in the most dangerous direction**: a fixture that starves an input produces exactly the same symptom as a metric that has collapsed. `data/public_league/nfl_players_full.json` has 12,201 entries, 10,954 with age; the fixture was joining rosters to the ROS aggregate alone, which carries neither ages nor eligibility.

Rewired through `roster_source.build_roster_pool`, measured on the 12 real rosters:
- eligibility **633/633** enriched, 247 multi-family players all carrying `fantasy_positions`, 0 without, 40 true hybrids — ADR-007 closed *on this data* rather than assumed closed
- ages **633/633** joined; trajectory spans **0.196–0.684** (sd 0.126) instead of exactly 0.500 for every roster
- the window reaches **all 5 states, up from 4**. `productive_struggle` was not rare on this league, it was *unreachable*: a pinned trajectory axis makes "young roster losing now" impossible to express regardless of the roster.

## What the playoff simulator does NOT give us, named rather than swallowed

`src/ros/playoff_sim.py` emits `ownerId / playoffOdds / byeOdds / topSeedOdds / missPlayoffsOdds / expectedWins / medianFinalSeed / mostLikelySeed / seedDistribution`. There is **no `championshipOdds` and there are no confidence intervals** — it stops at playoff qualification and never runs the bracket.

The engine originally read both and degraded to `None`, which would have presented a qualification-only simulation as a complete one with a missing half. It now reports *which* half it got. **Intervals stay `None` rather than collapsing to zero width, because zero width reads as certainty.** A mechanism test pins the main-branch row schema verbatim and asserts the notes fire, then feeds the LI-8-shaped row and asserts they do not — so the warnings cannot become unconditional and outlive the gap.

---

## Not implemented

Stated explicitly because omission is worse than admission. The directive covers six engines; this PR is **one of them**.

**Built, but in the stacked PR #563:** Target Position/Player engines, Trade Package Generator, Partner Fit & Acceptance Model.

**Not built here:**

- **Continuous Improvement System — nothing in this PR.** No champion–challenger infrastructure, no promotion gate, no historical backtesting of the new engines, no monitoring, no recalibration schedule. **This is owned by another agent on its own branch off `main` and is actively being built** — it is not orphaned work and nothing here should be taken as a claim that it will not exist.
- **Trade Opportunity Engine** as a distinct module. `src/trade/suggestions.py` and `src/trade/finder.py` are the pre-existing engines; nothing new was written against the directive's opportunity-engine spec.
- **No API endpoint and no UI.** `src/roster_intel/` is imported by **nothing** outside its own package and its tests — not `server.py`, not `src/api/`, not `src/trade/`, not `frontend/`. Every number here is reachable only from Python. The `/gameplan` surface does not exist.
- **`src/trade/angle.py` is not rewired.** ADR-010 built the single-market valuation path; `angle.py` still sums market values across a combo never constrained to one market. That is the live call site and it is untouched.
- Trade explanation / pitch surface, user controls, admin review tools.
- `categories_rescored` ROS projections — blocked upstream on a projection source publishing raw per-category numbers.

---

## Validation

Reported as a comment on this PR with real numbers, including anything red.

No frontend file is touched by this branch, so Redesign R3 (#551) — which deleted `frontend/components/terminal/Panel.jsx` and changed the design-system `Panel` API — has no surface here. Zero conflicts is not evidence a build passes, so the suite was run rather than inferred.

## Merge order

`#550` → retarget this PR to `main` → `#563`.