### PR TITLE
WS-J Trade layer: target engines, partner fit &amp; acceptance model, Trade Package Generator

### DIFF
--- a/docs/league-intelligence/DECISIONS.md
+++ b/docs/league-intelligence/DECISIONS.md
@@ -38,6 +38,95 @@ adoption land immediately after R2 merges, through the stable R1 shell
 unvalidated number.
 **Status:** accepted.
 
+## ADR-014: the competitive window enters per POSITION as a horizon weight, not as a global win-now scalar (WS-J)
+**Status:** accepted 2026-07-26. Implemented in
+`src/roster_intel/targets.py::horizon_weight`; `win_now_weight` is
+retained for magnitude reporting only.
+
+**The defect.** `rank_target_positions` multiplied every position's
+priority by a single scalar, `win_now_weight(window)` — the
+probability-weighted mean of per-state weights (championship_contender
+1.00 → rebuild 0.15). That scalar is *uniform across positions* by
+construction, and a uniform positive multiplier cannot reorder a list.
+
+The consequence was not a rounding artifact, it was the whole feature:
+a rebuilding roster and a championship contender, given the same
+candidate pool, received the **identical ranked order** of target
+positions and differed only in the absolute magnitude of `priority`.
+The docstring and the `notes` stamp both claimed the competitive window
+affected the recommendation. It provably could not. This is exactly the
+class of defect §2b exists to catch — a term that is *reported* as
+applied while being incapable of changing any decision.
+
+**Why a global scalar cannot be repaired in place.** For the window to
+reorder positions it must interact with something that varies *by*
+position. `win_now_weight` reads only `window.probabilities`, which has
+no position axis. No re-tuning of the five state weights fixes this;
+the term is structurally inert. It had to be replaced, not calibrated.
+
+**The mechanism chosen: horizon, keyed to the age of what is obtainable.**
+`horizon_weight(window, mean_candidate_age)` keeps the same five-state
+distribution but modulates it per position by the mean age of that
+position's top-`REALISTIC_CANDIDATE_DEPTH` candidates:
+
+```
+youth     = clamp((AGE_OLD - mean_age) / (AGE_OLD - AGE_YOUNG), 0, 1)
+age_mult  = (1 - future) + future * (FUTURE_AGE_FLOOR + FUTURE_AGE_SPAN * youth)
+weight    = Σ_state p(state) · base(state) · age_mult(state)   /   Σ_state p(state)
+```
+
+`_STATE_FUTURE_ORIENTATION` (championship_contender 0.00 → rebuild 1.00)
+decides how much a state cares about age at all. Win-now states ignore it
+— a contender should take the best available upgrade regardless of age.
+Future-oriented states reward youth, so a rebuilding roster prefers
+positions where the *obtainable* upgrades are young. Same window,
+different positions, genuinely different order.
+
+This was picked over the two alternatives because it is the only one
+that needs no new data and no fitted parameter. Positional value curves
+by window would require a measured contender/rebuilder value split that
+does not exist for this league; a per-position win-now prior would be
+invented weights wearing a measurement's clothes.
+
+**What is measured and what is assumed.**
+
+*ASSUMED, not measured* — all of it. `_WIN_NOW_WEIGHTS`,
+`_STATE_FUTURE_ORIENTATION`, `_AGE_YOUNG`/`_AGE_OLD`, `FUTURE_AGE_FLOOR`
+and `FUTURE_AGE_SPAN` are judgement calls. There is no dataset of
+"positions a rebuilding manager should have attacked" to fit them
+against. `describe_limitations()` stamps `winNowWeightsAreMeasured:
+False` and the constants are emitted verbatim so a reader can see the
+numbers rather than trust the label.
+
+*The directional claim is the defensible part.* That a rebuilder should
+prefer young acquisitions and a contender should not care is a
+first-principles consequence of dynasty roster construction, not a
+fitted result. The **ordering** the term produces is therefore more
+trustworthy than the magnitudes it multiplies by.
+
+**The honest failure mode, and why it is `None` and not `1.0`.**
+`horizon_weight` returns `None` when the window is absent OR when no
+candidate at that position has a known age. `None` means *the term did
+not apply*. The caller then sets `window_mult = 1.0` and, when a window
+was supplied but ages were not, appends an explicit note:
+
+> competitive window supplied but no candidate ages — the window weight
+> is per-position by age and could not be computed, so it did NOT affect
+> this ranking
+
+`PositionTarget.win_now_weight` is serialized as `winNowWeight: null` in
+that case. Stamping the global scalar there instead would have
+reproduced the original defect one layer down: a number that looks
+applied, is reported as applied, and changes nothing. A caller must be
+able to distinguish "the window said 1.0" from "the window was not
+consulted", and only `null` does that.
+
+**Consequence for callers.** `winNowWeight` is not a reliable field to
+sort or filter on — it is `null` on exactly the rows where age data is
+missing, which is not a random subset (rookies and recently-added
+players are likelier to be missing). Read `priority` for ordering and
+`notes` for whether the window participated.
+
 ## ADR-013: the League Twin bridge scales for the ROS blend, and reports the variance the odds path drops (LI-8)
 **Status:** accepted 2026-07-26 on `claude/li8-league-twin`.  Library +
 tests; no endpoint, nothing user-visible.

--- a/src/roster_intel/__init__.py
+++ b/src/roster_intel/__init__.py
@@ -4,4 +4,19 @@ Additive layer over the League Intelligence engine. Valuation, exact
 scoring, the best-ball optimizer, replacement levels and the value
 schema are consumed from ``src/league_intel/`` as-is — nothing here
 re-derives them.
+
+Two halves that meet at ``RosterProfile`` / ``CompetitiveWindow``:
+
+* **Roster engine** — ``marginal``, ``profiles``, ``window``,
+  ``roster_source``, ``engine``. Measures what a roster IS by
+  re-solving the exact lineup: marginal contribution, absence
+  fragility, tradeable surplus, urgent need, and the competitive
+  window as a five-state distribution. ``engine.analyze_roster``
+  composes them and consumes ``src/ros/playoff_sim`` rather than
+  simulating a second time.
+* **Trade engine** — ``partner``, ``targets``, ``packages``. Measures
+  what to DO about it: which positions are worth attacking, which
+  players are worth pursuing, how a counterparty is likely to receive
+  an offer, and which concrete packages are worth sending. Consumes
+  the roster engine's output; never re-derives it.
 """

--- a/src/roster_intel/__init__.py
+++ b/src/roster_intel/__init__.py
@@ -1,6 +1,7 @@
-"""Roster Intelligence Engine (WS-J).
+"""Roster & Trade Intelligence (WS-J).
 
-Pure computation over a supplied player pool. Consumes the League
-Intelligence modules (exact scorer, exact best-ball optimizer,
-replacement levels, value schema) as-is and never re-implements them.
+Additive layer over the League Intelligence engine. Valuation, exact
+scoring, the best-ball optimizer, replacement levels and the value
+schema are consumed from ``src/league_intel/`` as-is — nothing here
+re-derives them.
 """

--- a/src/roster_intel/packages.py
+++ b/src/roster_intel/packages.py
@@ -1,0 +1,918 @@
+"""Trade Package Generator (WS-J).
+
+Builds concrete, legal, defensible trade packages between our roster and
+one opposing roster, and returns a **Pareto frontier** across competing
+objectives rather than a single ranked list.
+
+Consumes, never rebuilds:
+
+* ``league_intel.cross_market.value_package`` / ``compare_packages`` —
+  package valuation and the boundary-proximity suppression rule. Every
+  package is valued **entirely within one market** (offense-only →
+  ``ktcSfTep``; anything with IDP → ``idpTradeCalc``), which is exact
+  and needs no conversion.
+* ``roster_intel.marginal.optimal_score`` — exact lineup re-solve for
+  what a package actually does to a starting lineup.
+* ``roster_intel.partner.assess_partner`` — how a counterparty is
+  likely to receive the offer.
+
+Pure computation: no I/O, no clock, no globals.
+
+──────────────────────────────────────────────────────────────────────
+A frontier, not a score
+──────────────────────────────────────────────────────────────────────
+Packages are judged on four axes that share no unit:
+
+* ``value_efficiency`` — market value retained, from WS-E
+* ``roster_improvement`` — lineup points gained, from an exact re-solve
+* ``acceptance_plausibility`` — from the partner model
+* ``simplicity`` — fewer moving parts
+
+Blending them into one number requires an exchange rate between market
+points, lineup points and plausibility. **No such rate exists**, and
+inventing one silently encodes a preference as if it were a
+measurement. So this module returns the non-dominated set: every
+package on the frontier is the best available at *something*, and the
+choice between them is the manager's to make. :func:`label_frontier`
+names which axis each member wins on, so a caller can present them as
+alternatives rather than as a ranking.
+
+──────────────────────────────────────────────────────────────────────
+Staged generation, not brute force
+──────────────────────────────────────────────────────────────────────
+The full combination space over two 30-man rosters is astronomically
+larger than the useful part of it. Generation runs in stages, and each
+stage only expands what the previous stage proved was **worth**
+expanding:
+
+1. 1-for-1 from a pre-filtered seed set.
+2. 2-for-1 / 1-for-2, expanding ONLY near-misses — packages that failed
+   on value gap but are close enough that one more asset could close
+   it. A package that already succeeded is never expanded, because the
+   simpler version dominates it by construction.
+3. 2-for-2, from stage-2 near-misses only.
+
+Within each stage, cheap filters run before expensive ones: legality,
+then market valuation, then the rejection rules, and only then the
+exact lineup re-solve. The solve is the expensive step and it never
+runs on a package that was already going to be rejected.
+
+──────────────────────────────────────────────────────────────────────
+On ``acceptance_plausibility``
+──────────────────────────────────────────────────────────────────────
+It is inherited from :mod:`roster_intel.partner`, and it carries that
+model's limitations unchanged: **we never observe a rejection**, so
+this is a plausibility score wearing probability units, not a
+calibrated acceptance probability. No output of this module may be
+rendered as "manager X will accept this". See
+:func:`describe_limitations`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.league_intel.cross_market import (
+    DEFAULT_GATE_PCT,
+    PackageComparison,
+    compare_packages,
+    value_package,
+)
+from src.roster_intel.marginal import optimal_score
+from src.roster_intel.partner import (
+    PartnerInputs,
+    RosterSignal,
+    TradeShape,
+    assess_partner,
+)
+from src.ros.lineup import RosterPlayer
+
+__all__ = [
+    "CORNERSTONE_PREMIUM_PCT",
+    "MAX_PACKAGE_ASSETS",
+    "NEAR_MISS_PCT",
+    "PACKAGES_MODEL_VERSION",
+    "PackageCandidate",
+    "RejectionReason",
+    "TradeAsset",
+    "describe_limitations",
+    "generate_packages",
+    "label_frontier",
+    "pareto_frontier",
+]
+
+PACKAGES_MODEL_VERSION = "wsj.packages.2026-07-27.v1"
+
+
+# ── Tunables ─────────────────────────────────────────────────────────
+
+MAX_PACKAGE_ASSETS = 2
+"""Most assets from either side in a generated package.
+
+Two, not three, and for a reason beyond combinatorics: each additional
+asset multiplies the search AND weakens the result, because a package
+that needs three pieces to balance is usually a package whose core
+premise does not balance. Three-for-threes are real in dynasty, but
+they are negotiated, not generated — a generator proposing them is
+almost always laundering a bad core swap behind filler.
+"""
+
+NEAR_MISS_PCT = 25.0
+"""How far off the value gate a package may be and still be worth
+expanding with another asset.
+
+A package 200% off is not fixable by adding a bench piece; expanding it
+burns search budget on combinations that cannot converge. A package 8%
+off might well be. This constant is what makes the staging real rather
+than decorative — without it stage 2 would expand everything and the
+'staged' generator would be brute force with extra steps.
+"""
+
+CORNERSTONE_PREMIUM_PCT = 15.0
+"""Market premium required before asking for a cornerstone is a
+serious offer rather than a lowball.
+
+Cornerstones do not move at market price. A manager surrenders one for
+a clear overpay or not at all, so a package that asks for one at parity
+is not a package — it is noise that costs credibility to send.
+"""
+
+CORNERSTONE_TOP_N = 3
+"""Most assets on a roster that can be cornerstones. A ceiling, not a
+definition — see :data:`CORNERSTONE_VALUE_SHARE`."""
+
+CORNERSTONE_VALUE_SHARE = 0.60
+"""Share of the roster's most valuable asset an asset must reach before
+it counts as a cornerstone.
+
+Rank alone is not enough, and this is not hypothetical: with a
+candidate pool of three, a pure top-3 rule makes EVERY asset a
+cornerstone — including a 2,200-value bench receiver sitting beside a
+9,500 stud — and the premium rule then rejects almost every package
+that could be built. "Cornerstone" has to mean genuinely elite relative
+to the roster, not merely present in a short list.
+"""
+
+_MIN_ROSTER_SIZE = 1
+_TINY = 1e-9
+
+
+class RejectionReason(str, Enum):
+    """Why a package was refused. Every rejection is explainable."""
+
+    NONE = "none"
+
+    ILLEGAL_ROSTER = "illegalRoster"
+    """The trade leaves a roster outside its legal size, or moves an
+    asset a side does not own."""
+
+    WORSENS_CRITICAL_NEED = "worsensCriticalNeed"
+    """Takes from a position the partner is already critically short at,
+    without sending compensation there."""
+
+    CORNERSTONE_WITHOUT_PREMIUM = "cornerstoneWithoutPremium"
+    """Asks for a cornerstone at or near market price."""
+
+    UNVALUABLE = "unvaluable"
+    """WS-E could not value the package on a single market."""
+
+    VERDICT_UNCERTAIN = "verdictUncertain"
+    """The propagated uncertainty band straddles the decision gate, so
+    the comparison is withheld. Boundary-proximity, not presence."""
+
+    DOMINATED = "dominated"
+    """A simpler package is at least as good on every axis."""
+
+    DOMINATED_BY_NO_TRADE = "dominatedByNoTrade"
+    """Strictly worse than the status quo on both self-interested axes.
+
+    The simplest package of all is no package, and it is always
+    available. A trade that loses market value AND loses lineup points
+    is dominated by declining to trade, so high acceptance plausibility
+    cannot rescue it — plausibility measures how the PARTNER receives
+    the offer, and being easy to give away is not a reason to give
+    something away."""
+
+
+@dataclass(frozen=True)
+class TradeAsset:
+    """One tradeable asset, carrying both representations it needs.
+
+    ``row`` is the contract-shaped row WS-E's ``value_package`` consumes
+    (``canonicalSiteValues``, ``position``, ``displayName``).
+    ``player`` is the optimizer's view. Both are required: market value
+    and lineup value are different questions and neither substitutes for
+    the other.
+    """
+
+    asset_id: str
+    name: str
+    position: str
+    row: Mapping[str, Any]
+    player: RosterPlayer | None = None
+
+    @classmethod
+    def from_player(cls, player: RosterPlayer, site_values: Mapping[str, float]) -> TradeAsset:
+        return cls(
+            asset_id=player.player_id,
+            name=player.canonical_name,
+            position=player.position,
+            row={
+                "displayName": player.canonical_name,
+                "position": player.position,
+                "canonicalSiteValues": dict(site_values),
+            },
+            player=player,
+        )
+
+
+@dataclass(frozen=True)
+class PackageCandidate:
+    """One proposed trade, with every axis it is judged on."""
+
+    send: tuple[TradeAsset, ...]
+    receive: tuple[TradeAsset, ...]
+    stage: int
+
+    accepted: bool = False
+    rejection: RejectionReason = RejectionReason.NONE
+    rejection_detail: str = ""
+
+    # ── the four frontier axes ──
+    value_efficiency: float = 0.0
+    roster_improvement: float = 0.0
+    acceptance_plausibility: float = 0.0
+    simplicity: float = 0.0
+
+    comparison: PackageComparison | None = None
+    acceptance_confidence: float = 0.0
+    notes: tuple[str, ...] = ()
+
+    @property
+    def asset_count(self) -> int:
+        return len(self.send) + len(self.receive)
+
+    @property
+    def axes(self) -> tuple[float, float, float, float]:
+        return (
+            self.value_efficiency,
+            self.roster_improvement,
+            self.acceptance_plausibility,
+            self.simplicity,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "send": [{"id": a.asset_id, "name": a.name, "position": a.position} for a in self.send],
+            "receive": [
+                {"id": a.asset_id, "name": a.name, "position": a.position} for a in self.receive
+            ],
+            "stage": self.stage,
+            "accepted": self.accepted,
+            "rejection": self.rejection.value,
+            "rejectionDetail": self.rejection_detail,
+            "valueEfficiency": round(self.value_efficiency, 4),
+            "rosterImprovement": round(self.roster_improvement, 3),
+            "acceptancePlausibility": round(self.acceptance_plausibility, 4),
+            "acceptanceConfidence": round(self.acceptance_confidence, 4),
+            "simplicity": round(self.simplicity, 4),
+            "assetCount": self.asset_count,
+            "marketGainPct": (
+                self.comparison.market_gain_pct if self.comparison is not None else None
+            ),
+            "verdictCertain": (
+                self.comparison.verdict_certain if self.comparison is not None else None
+            ),
+            "notes": list(self.notes),
+            "modelVersion": PACKAGES_MODEL_VERSION,
+            "acceptanceCaveat": (
+                "acceptancePlausibility is a plausibility score in probability "
+                "units, not a calibrated acceptance probability. Rejections are "
+                "never observed. Never render as 'they will accept'."
+            ),
+        }
+
+
+# ── Pareto machinery ─────────────────────────────────────────────────
+
+
+def _dominates(a: PackageCandidate, b: PackageCandidate) -> bool:
+    """True when ``a`` is at least as good on every axis and strictly
+    better on one. Ties on every axis are NOT domination — otherwise
+    ordering would decide which of two equivalent packages survives."""
+    aa, bb = a.axes, b.axes
+    return all(x >= y - _TINY for x, y in zip(aa, bb)) and any(
+        x > y + _TINY for x, y in zip(aa, bb)
+    )
+
+
+def pareto_frontier(candidates: Sequence[PackageCandidate]) -> list[PackageCandidate]:
+    """Non-dominated packages, i.e. the set of real alternatives.
+
+    A package survives when nothing else is at least as good on market
+    efficiency, roster improvement, acceptance plausibility AND
+    simplicity simultaneously. Every survivor is the best available at
+    something; choosing between them is a preference, not a
+    computation, which is exactly why this returns a set.
+    """
+    live = [c for c in candidates if c.accepted]
+    out: list[PackageCandidate] = []
+    for cand in live:
+        if not any(_dominates(other, cand) for other in live if other is not cand):
+            out.append(cand)
+    out.sort(key=lambda c: (-c.value_efficiency, c.asset_count, _package_key(c)))
+    return out
+
+
+_AXIS_LABELS = (
+    ("valueEfficiency", "best market value"),
+    ("rosterImprovement", "biggest lineup upgrade"),
+    ("acceptancePlausibility", "most plausible to land"),
+    ("simplicity", "simplest structure"),
+)
+
+
+def label_frontier(frontier: Sequence[PackageCandidate]) -> dict[str, Any]:
+    """Name which axis each frontier member wins, so a caller can show
+    alternatives instead of implying a ranking."""
+    if not frontier:
+        return {"members": [], "bestBy": {}}
+    best_by: dict[str, str] = {}
+    for idx, (axis, _label) in enumerate(_AXIS_LABELS):
+        winner = max(frontier, key=lambda c, i=idx: (c.axes[i], -c.asset_count))
+        best_by[axis] = _package_key(winner)
+    return {
+        "members": [c.to_dict() for c in frontier],
+        "bestBy": best_by,
+        "axisLabels": {axis: label for axis, label in _AXIS_LABELS},
+        "note": (
+            "These are alternatives on a Pareto frontier, not a ranking. No "
+            "exchange rate exists between market points, lineup points and "
+            "acceptance plausibility, so choosing among them is a preference."
+        ),
+    }
+
+
+def _package_key(c: PackageCandidate) -> str:
+    return (
+        "+".join(sorted(a.asset_id for a in c.send))
+        + "->"
+        + "+".join(sorted(a.asset_id for a in c.receive))
+    )
+
+
+# ── Rejection rules ──────────────────────────────────────────────────
+
+
+def _check_legality(
+    send: Sequence[TradeAsset],
+    receive: Sequence[TradeAsset],
+    our_size: int,
+    their_size: int,
+    roster_limit: int | None,
+) -> tuple[bool, str]:
+    """Roster legality. Cheapest check, so it runs first."""
+    if not send or not receive:
+        return False, "a package must have assets on both sides"
+    send_ids = {a.asset_id for a in send}
+    recv_ids = {a.asset_id for a in receive}
+    if send_ids & recv_ids:
+        return False, "the same asset appears on both sides"
+    if len(send_ids) != len(send) or len(recv_ids) != len(receive):
+        return False, "an asset appears twice on one side"
+
+    our_after = our_size - len(send) + len(receive)
+    their_after = their_size - len(receive) + len(send)
+    if our_after < _MIN_ROSTER_SIZE or their_after < _MIN_ROSTER_SIZE:
+        return False, "trade would empty a roster"
+    if roster_limit is not None:
+        if our_after > roster_limit:
+            return False, f"our roster would hold {our_after} > {roster_limit}"
+        if their_after > roster_limit:
+            return False, f"their roster would hold {their_after} > {roster_limit}"
+    return True, ""
+
+
+def _check_critical_need(
+    send: Sequence[TradeAsset],
+    receive: Sequence[TradeAsset],
+    their_signal: RosterSignal | None,
+) -> tuple[bool, str]:
+    """Never strip a position the partner is already critical at.
+
+    Taking a running back from a team whose only real hole is running
+    back is not a trade offer, it is an insult with a spreadsheet
+    attached. It is allowed only when the same position is replenished
+    from our side.
+
+    "Critical" is the partner's LARGEST deficit — deficits are relative
+    magnitudes, so a fixed threshold on the engine's units would not
+    transfer between rosters.
+    """
+    if their_signal is None or not their_signal.deficit:
+        return True, ""
+    peak = max(their_signal.deficit.values())
+    if peak <= 0:
+        return True, ""
+    critical = {pos for pos, mag in their_signal.deficit.items() if mag >= 0.75 * peak}
+    taken = {a.position.upper() for a in receive}
+    given = {a.position.upper() for a in send}
+    stripped = (taken & critical) - given
+    if stripped:
+        pos = sorted(stripped)[0]
+        return False, (
+            f"takes {pos} from a partner whose {pos} room is already one of their "
+            "most critical needs, with no {pos} sent back as compensation".replace("{pos}", pos)
+        )
+    return True, ""
+
+
+def _check_cornerstone(
+    receive: Sequence[TradeAsset],
+    cornerstones: frozenset[str],
+    comparison: PackageComparison | None,
+) -> tuple[bool, str]:
+    """Asking for a cornerstone requires a real premium.
+
+    ``market_gain_pct`` is OUR gain, so a genuine overpay to them is a
+    NEGATIVE gain of at least the premium.
+    """
+    asked = {a.asset_id for a in receive} & cornerstones
+    if not asked:
+        return True, ""
+    if comparison is None or comparison.market_gain_pct is None:
+        return False, "asks for a cornerstone but the package could not be priced"
+    if comparison.market_gain_pct > -CORNERSTONE_PREMIUM_PCT:
+        return False, (
+            f"asks for a cornerstone while our side gains "
+            f"{comparison.market_gain_pct:+.1f}%; a cornerstone moves only for a "
+            f"clear overpay (at least {CORNERSTONE_PREMIUM_PCT:.0f}% in their favour)"
+        )
+    return True, ""
+
+
+# ── Generation ───────────────────────────────────────────────────────
+
+
+def _evaluate(
+    send: tuple[TradeAsset, ...],
+    receive: tuple[TradeAsset, ...],
+    stage: int,
+    *,
+    our_pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    base_lineup: float,
+    our_size: int,
+    their_size: int,
+    roster_limit: int | None,
+    their_signal: RosterSignal | None,
+    our_signal: RosterSignal | None,
+    cornerstones: frozenset[str],
+    gate_pct: float,
+    partner_owner_id: str,
+    allow_scalar_fallback: bool,
+) -> PackageCandidate:
+    """Run one candidate through the pipeline, cheapest check first."""
+    notes: list[str] = []
+
+    def _reject(reason: RejectionReason, detail: str) -> PackageCandidate:
+        return PackageCandidate(
+            send=send,
+            receive=receive,
+            stage=stage,
+            accepted=False,
+            rejection=reason,
+            rejection_detail=detail,
+            notes=tuple(notes),
+        )
+
+    # 1 ── legality (cheapest)
+    ok, detail = _check_legality(send, receive, our_size, their_size, roster_limit)
+    if not ok:
+        return _reject(RejectionReason.ILLEGAL_ROSTER, detail)
+
+    # 2 ── critical-need protection (dict lookups)
+    ok, detail = _check_critical_need(send, receive, their_signal)
+    if not ok:
+        return _reject(RejectionReason.WORSENS_CRITICAL_NEED, detail)
+
+    # 3 ── market valuation, entirely within one market (WS-E)
+    out_val = value_package([a.row for a in send], allow_scalar_fallback=allow_scalar_fallback)
+    in_val = value_package([a.row for a in receive], allow_scalar_fallback=allow_scalar_fallback)
+    if not out_val.is_rankable or not in_val.is_rankable:
+        blocked = out_val if not out_val.is_rankable else in_val
+        return _reject(
+            RejectionReason.UNVALUABLE,
+            blocked.suppressed_reason or "package could not be valued on one market",
+        )
+
+    # ``compare_packages`` treats the first argument as the side we
+    # GAIN. We receive ``in_val``, so it is the counter side.
+    comparison = compare_packages(in_val, out_val, gate_pct=gate_pct)
+    if comparison.market_gain_pct is None:
+        return _reject(
+            RejectionReason.UNVALUABLE,
+            comparison.suppressed_reason or "no comparable market totals",
+        )
+    if not comparison.verdict_certain:
+        # Boundary proximity, NOT presence of a conversion.
+        return PackageCandidate(
+            send=send,
+            receive=receive,
+            stage=stage,
+            accepted=False,
+            rejection=RejectionReason.VERDICT_UNCERTAIN,
+            rejection_detail=comparison.suppressed_reason or "verdict uncertain",
+            comparison=comparison,
+            notes=tuple(notes),
+        )
+
+    # 4 ── cornerstone premium
+    ok, detail = _check_cornerstone(receive, cornerstones, comparison)
+    if not ok:
+        return _reject(RejectionReason.CORNERSTONE_WITHOUT_PREMIUM, detail)
+
+    # 5 ── exact lineup re-solve (EXPENSIVE — survivors only)
+    sent_ids = {a.asset_id for a in send}
+    after = [p for p in our_pool if p.player_id not in sent_ids]
+    after.extend(a.player for a in receive if a.player is not None)
+    roster_improvement = optimal_score(after, slots) - base_lineup
+
+    # 6 ── acceptance plausibility (never a claim about a decision)
+    shape = TradeShape(
+        send_positions=_position_counts(send),
+        receive_positions=_position_counts(receive),
+        market_value_sent=out_val.total,
+        market_value_received=in_val.total,
+        markets_mixed=(out_val.market != in_val.market),
+    )
+    assessment = assess_partner(
+        PartnerInputs(
+            owner_id=partner_owner_id,
+            our_roster=our_signal,
+            their_roster=their_signal,
+            shape=shape,
+        )
+    )
+    if shape.markets_mixed:
+        notes.append("sides priced on different markets; fairness suppressed per audit F-1")
+
+    gain = comparison.market_gain_pct
+
+    # The null trade is always on the table, costs nothing, and is
+    # simpler than anything else. A package that is strictly worse than
+    # it on both axes we care about is dominated before it is ranked.
+    if gain < 0 and roster_improvement < 0:
+        return PackageCandidate(
+            send=send,
+            receive=receive,
+            stage=stage,
+            accepted=False,
+            rejection=RejectionReason.DOMINATED_BY_NO_TRADE,
+            rejection_detail=(
+                f"loses {abs(gain):.1f}% of market value AND "
+                f"{abs(roster_improvement):.1f} lineup points; declining to "
+                "trade is strictly better on both"
+            ),
+            value_efficiency=gain,
+            roster_improvement=roster_improvement,
+            comparison=comparison,
+            notes=tuple(notes),
+        )
+
+    return PackageCandidate(
+        send=send,
+        receive=receive,
+        stage=stage,
+        accepted=True,
+        value_efficiency=gain,
+        roster_improvement=roster_improvement,
+        acceptance_plausibility=assessment.trade_acceptance_estimate,
+        acceptance_confidence=assessment.acceptance_confidence,
+        simplicity=1.0 / float(len(send) + len(receive)),
+        comparison=comparison,
+        notes=tuple(notes),
+    )
+
+
+def _position_counts(assets: Sequence[TradeAsset]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for a in assets:
+        pos = a.position.upper()
+        out[pos] = out.get(pos, 0.0) + 1.0
+    return out
+
+
+def _is_near_miss(cand: PackageCandidate, gate_pct: float) -> bool:
+    """Worth spending another asset on?
+
+    Only packages that failed on VALUE and failed by a closeable margin.
+    A structural rejection (illegal, critical need, cornerstone) is not
+    fixed by adding filler, so expanding it wastes the budget the
+    staging exists to protect.
+    """
+    if cand.accepted:
+        # Already works — the simpler version dominates any expansion.
+        return False
+    if cand.rejection in {
+        RejectionReason.ILLEGAL_ROSTER,
+        RejectionReason.WORSENS_CRITICAL_NEED,
+        RejectionReason.UNVALUABLE,
+    }:
+        return False
+    if cand.comparison is None or cand.comparison.market_gain_pct is None:
+        return False
+    return abs(cand.comparison.market_gain_pct - gate_pct) <= NEAR_MISS_PCT
+
+
+def generate_packages(
+    our_pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    *,
+    our_assets: Sequence[TradeAsset],
+    their_assets: Sequence[TradeAsset],
+    their_full_roster: Sequence[TradeAsset] | None = None,
+    partner_owner_id: str = "partner",
+    our_signal: RosterSignal | None = None,
+    their_signal: RosterSignal | None = None,
+    roster_limit: int | None = None,
+    gate_pct: float = DEFAULT_GATE_PCT,
+    max_assets_per_side: int = MAX_PACKAGE_ASSETS,
+    max_candidates_per_stage: int = 400,
+    allow_scalar_fallback: bool = False,
+) -> dict[str, Any]:
+    """Generate, filter and return a Pareto frontier of trade packages.
+
+    Args:
+        our_pool: our full roster, for the lineup re-solve.
+        slots: the league's flattened starter slots.
+        our_assets: what we are willing to send. Pre-filtering this to
+            genuine surplus is the caller's job and is the single
+            biggest lever on both quality and cost.
+        their_assets: what we would want from them.
+        our_signal / their_signal: roster engine output, via
+            ``RosterSignal.from_engine``. ``their_signal`` powers the
+            critical-need rejection; absent, that rule cannot fire and
+            says so.
+        roster_limit: league roster size cap, for the legality rule.
+        gate_pct: the market-gain decision threshold handed to WS-E.
+        max_assets_per_side: hard cap per side.
+        max_candidates_per_stage: search budget. Exceeding it truncates
+            and stamps a note rather than silently returning a partial
+            frontier as though it were complete.
+
+    Returns:
+        ``{"frontier": [...], "bestBy": {...}, "rejected": [...],
+        "stages": [...], "truncated": bool}``
+    """
+    base_lineup = optimal_score(our_pool, slots)
+    our_size = len(our_pool)
+    their_size = max(len(their_assets), 1)
+
+    # Cornerstones come from their FULL roster when we have it. Deriving
+    # them from ``their_assets`` — the filtered list of players we want —
+    # is wrong: if we only ask about their two best players, both look
+    # elite relative to that list and the premium rule refuses every
+    # package. Falling back is supported but stamped.
+    cornerstone_pool = their_full_roster if their_full_roster else their_assets
+    cornerstones = _identify_cornerstones(cornerstone_pool)
+
+    evaluated: list[PackageCandidate] = []
+    stage_report: list[dict[str, Any]] = []
+    truncated = False
+
+    def _run(
+        pairs: Iterable[tuple[tuple[TradeAsset, ...], tuple[TradeAsset, ...]]],
+        stage: int,
+    ) -> list[PackageCandidate]:
+        nonlocal truncated
+        out: list[PackageCandidate] = []
+        for send, receive in pairs:
+            if len(out) >= max_candidates_per_stage:
+                truncated = True
+                break
+            out.append(
+                _evaluate(
+                    send,
+                    receive,
+                    stage,
+                    our_pool=our_pool,
+                    slots=slots,
+                    base_lineup=base_lineup,
+                    our_size=our_size,
+                    their_size=their_size,
+                    roster_limit=roster_limit,
+                    their_signal=their_signal,
+                    our_signal=our_signal,
+                    cornerstones=cornerstones,
+                    gate_pct=gate_pct,
+                    partner_owner_id=partner_owner_id,
+                    allow_scalar_fallback=allow_scalar_fallback,
+                )
+            )
+        return out
+
+    # ── Stage 1: 1-for-1 ─────────────────────────────────────────────
+    stage1 = _run((((o,), (t,)) for o in our_assets for t in their_assets), 1)
+    evaluated.extend(stage1)
+    stage_report.append(
+        {"stage": 1, "evaluated": len(stage1), "accepted": sum(c.accepted for c in stage1)}
+    )
+
+    # ── Stage 2: expand ONLY near-misses ─────────────────────────────
+    near = [c for c in stage1 if _is_near_miss(c, gate_pct)]
+    stage2: list[PackageCandidate] = []
+    if max_assets_per_side >= 2 and near:
+        pairs: list[tuple[tuple[TradeAsset, ...], tuple[TradeAsset, ...]]] = []
+        for cand in near:
+            base_send, base_recv = cand.send, cand.receive
+            gain = cand.comparison.market_gain_pct if cand.comparison else 0.0
+            if gain > gate_pct:
+                # We are gaining too much: add to OUR side to balance.
+                for extra in our_assets:
+                    if extra.asset_id not in {a.asset_id for a in base_send}:
+                        pairs.append(((*base_send, extra), base_recv))
+            else:
+                # We are giving too much: ask for more back.
+                for extra in their_assets:
+                    if extra.asset_id not in {a.asset_id for a in base_recv}:
+                        pairs.append((base_send, (*base_recv, extra)))
+        stage2 = _run(pairs, 2)
+        evaluated.extend(stage2)
+    stage_report.append(
+        {
+            "stage": 2,
+            "expandedFrom": len(near),
+            "evaluated": len(stage2),
+            "accepted": sum(c.accepted for c in stage2),
+        }
+    )
+
+    # ── Stage 3: 2-for-2, from stage-2 near-misses only ──────────────
+    near2 = [c for c in stage2 if _is_near_miss(c, gate_pct)]
+    stage3: list[PackageCandidate] = []
+    if max_assets_per_side >= 2 and near2:
+        pairs = []
+        for cand in near2:
+            if len(cand.send) == 1:
+                for extra in our_assets:
+                    if extra.asset_id not in {a.asset_id for a in cand.send}:
+                        pairs.append(((*cand.send, extra), cand.receive))
+            elif len(cand.receive) == 1:
+                for extra in their_assets:
+                    if extra.asset_id not in {a.asset_id for a in cand.receive}:
+                        pairs.append((cand.send, (*cand.receive, extra)))
+        stage3 = _run(pairs, 3)
+        evaluated.extend(stage3)
+    stage_report.append(
+        {
+            "stage": 3,
+            "expandedFrom": len(near2),
+            "evaluated": len(stage3),
+            "accepted": sum(c.accepted for c in stage3),
+        }
+    )
+
+    # ── Domination: a simpler package that is no worse wins ──────────
+    frontier = pareto_frontier(evaluated)
+    frontier_keys = {_package_key(c) for c in frontier}
+    dominated = [
+        PackageCandidate(
+            send=c.send,
+            receive=c.receive,
+            stage=c.stage,
+            accepted=False,
+            rejection=RejectionReason.DOMINATED,
+            rejection_detail=(
+                "another package is at least as good on market value, lineup "
+                "improvement, acceptance plausibility and simplicity"
+            ),
+            value_efficiency=c.value_efficiency,
+            roster_improvement=c.roster_improvement,
+            acceptance_plausibility=c.acceptance_plausibility,
+            acceptance_confidence=c.acceptance_confidence,
+            simplicity=c.simplicity,
+            comparison=c.comparison,
+            notes=c.notes,
+        )
+        for c in evaluated
+        if c.accepted and _package_key(c) not in frontier_keys
+    ]
+
+    rejected = [c for c in evaluated if not c.accepted] + dominated
+    labelled = label_frontier(frontier)
+
+    notes: list[str] = []
+    if their_signal is None:
+        notes.append(
+            "no partner roster signal supplied — the critical-need rejection "
+            "rule could not fire; packages are not screened against their needs"
+        )
+    if not their_full_roster:
+        notes.append(
+            "cornerstones inferred from the requested assets rather than the "
+            "partner's full roster; if that list is already their best players, "
+            "the cornerstone rule is stricter than intended. Pass "
+            "their_full_roster to measure it properly"
+        )
+    if truncated:
+        notes.append(
+            f"search truncated at {max_candidates_per_stage} candidates in at "
+            "least one stage; the frontier is valid for what was explored but "
+            "is not exhaustive"
+        )
+
+    return {
+        **labelled,
+        "frontier": [c.to_dict() for c in frontier],
+        "rejected": [c.to_dict() for c in rejected],
+        "stages": stage_report,
+        "truncated": truncated,
+        "evaluatedTotal": len(evaluated),
+        "notes": notes,
+        "modelVersion": PACKAGES_MODEL_VERSION,
+    }
+
+
+def _identify_cornerstones(assets: Sequence[TradeAsset]) -> frozenset[str]:
+    """Which assets are genuinely elite for this roster.
+
+    Both conditions required: inside the top ``CORNERSTONE_TOP_N`` AND
+    worth at least ``CORNERSTONE_VALUE_SHARE`` of the roster's best
+    asset. Rank alone would make every asset a cornerstone whenever the
+    candidate pool is small, which turns the premium rule from a
+    safeguard into a blanket refusal.
+    """
+    ranked = sorted(assets, key=lambda a: (-_market_hint(a), a.asset_id))
+    if not ranked:
+        return frozenset()
+    top_value = _market_hint(ranked[0])
+    if top_value <= 0:
+        return frozenset()
+    floor = CORNERSTONE_VALUE_SHARE * top_value
+    return frozenset(a.asset_id for a in ranked[:CORNERSTONE_TOP_N] if _market_hint(a) >= floor)
+
+
+def _market_hint(asset: TradeAsset) -> float:
+    """Rough value for cornerstone identification only.
+
+    Deliberately NOT used for any package total — those go through
+    ``value_package`` so the single-market rule is never bypassed.
+    """
+    sites = asset.row.get("canonicalSiteValues")
+    if not isinstance(sites, Mapping):
+        return 0.0
+    vals = [float(v) for v in sites.values() if isinstance(v, (int, float)) and v > 0]
+    return max(vals) if vals else 0.0
+
+
+def describe_limitations() -> dict[str, Any]:
+    """Machine-readable limitations. Asserted by tests."""
+    return {
+        "modelVersion": PACKAGES_MODEL_VERSION,
+        "canSupport": [
+            "Generating legal, single-market-valued trade packages between two "
+            "specific rosters.",
+            "Presenting a Pareto frontier of genuine alternatives rather than a "
+            "single blended ranking.",
+            "Explaining, per package, exactly why it was rejected.",
+            "Withholding a comparison whose verdict its own uncertainty could "
+            "flip — on proximity to the decision boundary, not on the presence "
+            "of a conversion.",
+        ],
+        "cannotSupport": [
+            "Any claim that a manager will accept a package. "
+            "acceptancePlausibility inherits the partner model's limitation: "
+            "rejections are never observed, so it is a plausibility score in "
+            "probability units and not a calibrated probability.",
+            "Exhaustive search. Generation is staged and budgeted; the frontier "
+            "is valid for what was explored, not proven globally optimal.",
+            "Packages beyond the configured asset cap — a deal needing three "
+            "pieces per side to balance is negotiated, not generated.",
+            "Multi-year or rebuild framing: lineup improvement is "
+            "rest-of-season, inheriting the target engine's scope.",
+            "Any ranking ACROSS the frontier. No exchange rate exists between "
+            "market points, lineup points and plausibility; a caller that "
+            "collapses the frontier to one pick is expressing a preference.",
+        ],
+        "keyAssumptions": {
+            "maxPackageAssets": MAX_PACKAGE_ASSETS,
+            "nearMissPct": NEAR_MISS_PCT,
+            "cornerstonePremiumPct": CORNERSTONE_PREMIUM_PCT,
+            "cornerstoneTopN": CORNERSTONE_TOP_N,
+            "thresholdsAreMeasured": False,
+            "thresholdsNote": (
+                "All four are assumed, not fitted. No dataset of accepted vs "
+                "rejected offers exists to calibrate them against — the same "
+                "gap that makes the acceptance estimate uncalibratable."
+            ),
+        },
+        "whatWouldUnlockMore": [
+            "A record of DECLINED offers, which would calibrate both the "
+            "acceptance estimate and the cornerstone premium.",
+            "Measured roster-limit and lineup-legality rules per league, so "
+            "the legality check can go beyond size bounds.",
+        ],
+    }

--- a/src/roster_intel/partner.py
+++ b/src/roster_intel/partner.py
@@ -60,6 +60,29 @@ ordering below is enforced by the size of the caps, not by convention.
    trades each, a manager effect estimated from acceptances alone
    would be indistinguishable from noise. The gate is a real branch
    with a real threshold, not a comment.
+
+──────────────────────────────────────────────────────────────────────
+Confidence is a ranking input, not a label
+──────────────────────────────────────────────────────────────────────
+``acceptanceConfidence`` reflects the strength of the EVIDENCE, never
+the size of the estimate — a wildly generous offer and an insulting
+one, assessed from the same inputs, carry identical confidence.
+
+It is then *used*: :func:`assess_partner` shrinks the estimate toward
+the prior in proportion to confidence before computing
+``tradePartnerFitScore``. The operative consequence, pinned by tests,
+is that **a higher raw estimate built on thinner evidence ranks below
+a lower one built on real signal.** Two things reduce it:
+
+* the tier ceiling — :data:`MAX_CONFIDENCE_WITHOUT_DECISION_DATA`,
+  binding on every tier reachable today
+* structural coverage — :data:`STRUCTURAL_COVERAGE_FLOOR`, docking
+  confidence for each of fairness / roster fit / window fit that had
+  to abstain rather than measure
+
+Evidence tiers key on whether a term could be *measured*, never on how
+large its contribution was. A perfectly balanced offer contributes a
+fairness delta of exactly zero and is still a measurement.
 """
 
 from __future__ import annotations
@@ -685,16 +708,12 @@ def assess_partner(inp: PartnerInputs) -> PartnerAssessment:
         )
 
     if tier is not AcceptanceEvidence.DECISION_CALIBRATED:
-        bound = confidence > MAX_CONFIDENCE_WITHOUT_DECISION_DATA
+        verb = "capped at" if confidence > MAX_CONFIDENCE_WITHOUT_DECISION_DATA else "held under"
         confidence = min(confidence, MAX_CONFIDENCE_WITHOUT_DECISION_DATA)
         notes.append(
-            (
-                "acceptanceConfidence capped at " f"{MAX_CONFIDENCE_WITHOUT_DECISION_DATA}: "
-                if bound
-                else f"acceptanceConfidence held under {MAX_CONFIDENCE_WITHOUT_DECISION_DATA}: "
-            )
-            + "no rejection data exists, so this estimate is a plausibility "
-            "score in probability units, not a calibrated acceptance probability"
+            f"acceptanceConfidence {verb} {MAX_CONFIDENCE_WITHOUT_DECISION_DATA}: no "
+            "rejection data exists, so this estimate is a plausibility score in "
+            "probability units, not a calibrated acceptance probability"
         )
 
     # ── the ranking quantity ─────────────────────────────────────────

--- a/src/roster_intel/partner.py
+++ b/src/roster_intel/partner.py
@@ -115,6 +115,14 @@ MAX_HISTORY_LOGIT = 0.35
 manager trade at all), which is a propensity proxy and emphatically not
 an acceptance rate."""
 
+PAIR_FAMILIARITY_SHARE = 0.5
+"""Fraction of the history budget available to pair familiarity — prior
+completed trades between US and this manager specifically.
+
+It SHARES the history budget rather than extending it, so wiring a
+second history signal cannot quietly double that term's influence over
+the ranking."""
+
 MAX_MANAGER_LOGIT = 0.50
 """Budget the manager term *would* get if its evidence gate cleared.
 Today it never does, so this constant is latent."""
@@ -294,11 +302,14 @@ class PartnerInputs:
     #: League-wide mean completed trades per manager, for shrinkage.
     league_mean_trades: float | None = None
     #: Completed trades between US and this manager specifically.
+    #: Feeds the pair-familiarity half of the history term.
     pair_trades_completed: int = 0
-    #: ``faab_analytics.teamAggression`` entry, if available. Used only
-    #: as a weak engagement proxy — a manager who never spends FAAB is
-    #: plausibly less transaction-active. Never as an acceptance rate.
-    team_aggression: Mapping[str, Any] | None = None
+    # NOT INCLUDED, deliberately: faab_analytics.teamAggression. FAAB
+    # spend is waiver-market behaviour, and treating it as a trade
+    # engagement proxy would be an inference the data does not support —
+    # an aggressive bidder may be aggressive precisely because they do
+    # not trade. Left out rather than wired in as a plausible-sounding
+    # noise source.
     #: Observed accept/reject decisions. Populated only if a source of
     #: DECLINED offers ever exists; the public snapshot has none.
     decisions_accepted: int | None = None
@@ -389,47 +400,70 @@ def _fairness_term(shape: TradeShape | None) -> tuple[float, str | None]:
 
 
 # ── term: roster need alignment ──────────────────────────────────────
-def _need_alignment(
-    ours: RosterSignal | None, theirs: RosterSignal | None, shape: TradeShape | None
-) -> tuple[float, str | None]:
-    """Fraction of what we send that lands on a position they lack.
+def _match_score(
+    weights: Mapping[str, float] | None, target: Mapping[str, float] | None
+) -> float | None:
+    """How well a positional weighting lands on a target positional map.
 
-    Complementarity, not charity: we only get credit where OUR surplus
-    meets THEIR deficit. Returns a 0..1 alignment score.
+    Returns 0..1, or ``None`` when there is nothing to measure. Rescaled
+    by the target's peak share so a perfectly-targeted package reads as
+    ~1.0 rather than being capped by how concentrated the target is.
     """
-    if theirs is None:
-        return 0.5, "roster engine output unavailable — need alignment defaults to neutral"
-    if not theirs.deficit:
-        return 0.5, "partner shows no positional deficit — need alignment neutral"
-
-    sending = dict(shape.send_positions) if shape and shape.send_positions else {}
-    if not sending and ours is not None and ours.surplus:
-        # No concrete package: score the STANDING complementarity of the
-        # two rosters instead, which is what a partner-ranking view wants
-        # before any specific offer exists.
-        sending = dict(ours.surplus)
-    if not sending:
-        return 0.5, "nothing to match against partner deficit — neutral"
-
-    total = sum(max(0.0, v) for v in sending.values())
+    if not weights or not target:
+        return None
+    total = sum(max(0.0, float(v)) for v in weights.values())
     if total <= 0:
-        return 0.5, "no positive send-side weight — neutral"
-
-    deficit_total = sum(max(0.0, v) for v in theirs.deficit.values()) or 1.0
+        return None
+    target_total = sum(max(0.0, float(v)) for v in target.values())
+    if target_total <= 0:
+        return None
+    peak = max(max(0.0, float(v)) for v in target.values()) / target_total
+    if peak <= 0:
+        return None
     matched = 0.0
-    for pos, weight in sending.items():
+    for pos, weight in weights.items():
         w = max(0.0, float(weight))
         if w <= 0:
             continue
-        need = max(0.0, float(theirs.deficit.get(pos, 0.0)))
-        matched += w * (need / deficit_total)
-    # matched/total is in [0,1] but concentrated low; rescale so a
-    # perfectly-targeted package reads as ~1.0.
-    raw = matched / total
-    peak = max(max(0.0, float(v)) for v in theirs.deficit.values()) / deficit_total
-    if peak <= 0:
-        return 0.5, "partner deficit has no positive mass — neutral"
-    return _clamp(raw / peak, 0.0, 1.0), None
+        matched += w * (max(0.0, float(target.get(pos, 0.0))) / target_total)
+    return _clamp((matched / total) / peak, 0.0, 1.0)
+
+
+def _need_alignment(
+    ours: RosterSignal | None, theirs: RosterSignal | None, shape: TradeShape | None
+) -> tuple[float, str | None]:
+    """Two-sided positional complementarity with the partner.
+
+    Both halves of a trade matter, and they are not the same question:
+
+    * **Send side** — does what we give land on a position they LACK?
+    * **Ask side** — does what we want come from a position they have
+      to SPARE? Asking a partner for their only starting tight end is
+      a materially harder sell than asking for their third one, even
+      when the market values are identical, and a model that scores
+      only the send side cannot tell those two offers apart.
+
+    Whichever halves are measurable are averaged. Returns 0..1.
+    """
+    if theirs is None:
+        return 0.5, "roster engine output unavailable — need alignment defaults to neutral"
+
+    sending = dict(shape.send_positions) if shape and shape.send_positions else {}
+    asking = dict(shape.receive_positions) if shape and shape.receive_positions else {}
+    if not sending and not asking and ours is not None:
+        # No concrete package: score the STANDING complementarity of the
+        # two rosters instead, which is what a partner-ranking view wants
+        # before any specific offer exists.
+        sending = dict(ours.surplus or {})
+        asking = dict(ours.deficit or {})
+
+    send_score = _match_score(sending, theirs.deficit)
+    ask_score = _match_score(asking, theirs.surplus)
+
+    parts = [s for s in (send_score, ask_score) if s is not None]
+    if not parts:
+        return 0.5, "no measurable positional overlap with partner — need alignment neutral"
+    return sum(parts) / len(parts), None
 
 
 # ── term: competitive-window alignment ───────────────────────────────
@@ -460,20 +494,36 @@ def _history_term(inp: PartnerInputs) -> tuple[float, str | None]:
     league mean with a small prior sample size, so a manager with two
     trades barely moves off the mean.
     """
-    if inp.league_mean_trades is None:
-        return 0.0, "no league trade baseline — history term inert"
-    mean = max(0.0, float(inp.league_mean_trades))
-    observed = max(0, int(inp.trades_completed))
-    # Shrink toward the mean: with PRIOR_N pseudo-observations at the
-    # league mean, a manager needs real volume to move.
-    prior_n = 5.0
-    shrunk = (observed + prior_n * mean) / (1.0 + prior_n)
-    if mean <= 0:
-        return 0.0, "league mean trade count is zero — history term inert"
-    ratio = shrunk / mean
-    # log ratio, saturating, scaled into the small history budget.
-    delta = MAX_HISTORY_LOGIT * math.tanh(math.log(max(ratio, _TINY)))
-    return delta, None
+    activity: float | None = None
+    if inp.league_mean_trades is not None:
+        mean = max(0.0, float(inp.league_mean_trades))
+        if mean > 0:
+            observed = max(0, int(inp.trades_completed))
+            # Shrink toward the mean: with PRIOR_N pseudo-observations at
+            # the league mean, a manager needs real volume to move.
+            prior_n = 5.0
+            shrunk = (observed + prior_n * mean) / (1.0 + prior_n)
+            ratio = shrunk / mean
+            # log ratio, saturating, scaled into the small history budget.
+            activity = MAX_HISTORY_LOGIT * math.tanh(math.log(max(ratio, _TINY)))
+
+    # Pair familiarity: managers who have completed trades with US
+    # before are demonstrably willing to transact with us specifically.
+    # This is the one history signal that is about the dyad rather than
+    # the individual, and it is still ACTIVITY — a pair that has never
+    # traded may simply never have talked. One-sided (no penalty for
+    # zero), and it shares the history budget rather than extending it.
+    pair = max(0, int(inp.pair_trades_completed))
+    familiarity = PAIR_FAMILIARITY_SHARE * MAX_HISTORY_LOGIT * math.tanh(pair / 2.0)
+
+    if activity is None and pair <= 0:
+        return (
+            0.0,
+            "no league trade baseline and no prior trades with this manager — history term inert",
+        )
+
+    delta = (activity or 0.0) + familiarity
+    return _clamp(delta, -MAX_HISTORY_LOGIT, MAX_HISTORY_LOGIT), None
 
 
 # ── the manager gate ─────────────────────────────────────────────────

--- a/src/roster_intel/partner.py
+++ b/src/roster_intel/partner.py
@@ -1,0 +1,749 @@
+"""Trade partner fit + acceptance model (WS-J).
+
+Produces, per opposing roster: ``tradePartnerFitScore``,
+``tradeAcceptanceEstimate``, ``partnerNeedAlignment``,
+``partnerWindowAlignment``, and the first-class ``acceptanceConfidence``.
+
+Pure computation: no I/O, no clock, no globals.
+
+──────────────────────────────────────────────────────────────────────
+READ THIS BEFORE TRUSTING ``tradeAcceptanceEstimate``
+──────────────────────────────────────────────────────────────────────
+**We never observe a rejection.** The league snapshot ingests only
+``status == "complete"`` transactions, and an offer a manager declined
+in the Sleeper UI leaves no record anywhere. So the dataset contains
+the numerator of an acceptance rate (accepted trades) and never the
+denominator (offers made).
+
+An acceptance *rate* is therefore **statistically unidentifiable from
+this data**, and no amount of modelling fixes that. What this module
+emits is not a calibrated accept/reject probability. It is:
+
+    "how plausible is it that an offer of this SHAPE gets engaged
+     with, given fairness, roster fit, and window fit"
+
+That is a **plausibility score wearing probability units**, and every
+consumer must treat it as such. The field is deliberately named
+``tradeAcceptanceEstimate`` — *estimate* — and ships beside
+``acceptanceConfidence`` which, under current data, never exceeds
+:data:`MAX_CONFIDENCE_WITHOUT_DECISION_DATA`.
+
+**Never render this as "manager X will accept".** See
+:func:`describe_limitations` for the machine-readable version of this
+paragraph, which is a required deliverable and is asserted by tests.
+
+──────────────────────────────────────────────────────────────────────
+Model hierarchy (most-shrunk first)
+──────────────────────────────────────────────────────────────────────
+Terms accumulate in **log-odds**, each contributing a bounded delta.
+Bounded-delta accumulation *is* the shrinkage mechanism: a term cannot
+dominate simply by being confident about a large number, and the
+ordering below is enforced by the size of the caps, not by convention.
+
+    general plausibility prior      base rate, an ASSUMPTION (§1)
+  + market fairness                 ±MAX_FAIRNESS_LOGIT   (strongest)
+  + roster fit                      ±MAX_NEED_LOGIT
+  + competitive-window fit          ±MAX_WINDOW_LOGIT
+  + league-history adjustment       ±MAX_HISTORY_LOGIT    (shrunk hard)
+  + manager-specific adjustment     ±MAX_MANAGER_LOGIT    (GATED, §2)
+
+§1 The prior is not measured. With 12 managers and no rejection data
+   there is nothing to measure it against, so it is a documented
+   assumption (:data:`BASE_ACCEPTANCE_PRIOR`) rather than a fitted
+   value, and it is stated as such in the explanation payload.
+
+§2 The manager term is gated by :func:`manager_evidence`, which
+   requires **decision** data — accepts *and* rejects. The public
+   snapshot supplies only accepts, so the gate does not clear today
+   and the term contributes exactly zero. That is the expected
+   outcome, not a shortfall: with ~12 managers and single-digit
+   trades each, a manager effect estimated from acceptances alone
+   would be indistinguishable from noise. The gate is a real branch
+   with a real threshold, not a comment.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence
+
+__all__ = [
+    "BASE_ACCEPTANCE_PRIOR",
+    "MANAGER_EVIDENCE_MIN_DECISIONS",
+    "MANAGER_EVIDENCE_MIN_Z",
+    "MAX_CONFIDENCE_WITHOUT_DECISION_DATA",
+    "PARTNER_MODEL_VERSION",
+    "STRUCTURAL_COVERAGE_FLOOR",
+    "AcceptanceEvidence",
+    "ManagerEvidence",
+    "PartnerAssessment",
+    "PartnerInputs",
+    "RosterSignal",
+    "TradeShape",
+    "assess_partner",
+    "assess_partners",
+    "describe_limitations",
+    "manager_evidence",
+]
+
+PARTNER_MODEL_VERSION = "wsj.partner.2026-07-27.v1"
+
+
+# ── Tunables, all named and justified ────────────────────────────────
+
+BASE_ACCEPTANCE_PRIOR = 0.18
+"""Prior probability a well-formed, roughly-fair offer gets engaged with.
+
+**An assumption, not a measurement.** No rejection data exists to fit
+it against (see module docstring). 0.18 is deliberately pessimistic:
+in a 12-team league most offers go nowhere, and a prior that is too
+high manufactures false optimism in every downstream ranking. Moving
+this constant moves every estimate, which is why it is named, single,
+and surfaced in the explanation rather than buried in an expression.
+"""
+
+MAX_FAIRNESS_LOGIT = 1.40
+"""Market fairness gets the largest budget — it is the only term backed
+by a real, per-trade measurement (both sides' market values)."""
+
+MAX_NEED_LOGIT = 0.90
+MAX_WINDOW_LOGIT = 0.60
+MAX_HISTORY_LOGIT = 0.35
+"""League history is shrunk hard: it measures trade ACTIVITY (does this
+manager trade at all), which is a propensity proxy and emphatically not
+an acceptance rate."""
+
+MAX_MANAGER_LOGIT = 0.50
+"""Budget the manager term *would* get if its evidence gate cleared.
+Today it never does, so this constant is latent."""
+
+MANAGER_EVIDENCE_MIN_DECISIONS = 30
+"""Minimum observed accept/reject DECISIONS for one manager before a
+manager-specific term is admissible.
+
+Rationale, not vibes: for a binary outcome the standard error of an
+estimated rate is ``sqrt(p(1-p)/n)``. At n=30 and p≈0.2 that is ≈0.073
+— i.e. ±7 percentage points, which is the coarsest resolution at which
+a manager-specific claim is worth making at all. Below it the estimate
+is dominated by sampling noise. At the league's actual volume
+(single-digit trades per manager) the SE is ≈±0.2, wider than the
+entire effect being claimed.
+"""
+
+MANAGER_EVIDENCE_MIN_Z = 2.0
+"""Even with enough decisions, the manager's rate must sit at least
+this many standard errors from the league mean. Volume alone does not
+license a manager term — a manager who behaves exactly like the league
+should contribute exactly zero, not a confidently-estimated zero-ish
+number."""
+
+MAX_CONFIDENCE_WITHOUT_DECISION_DATA = 0.45
+"""Ceiling on ``acceptanceConfidence`` while no rejection data exists.
+
+Confidence tracks EVIDENCE, not the size of the estimate. Without
+decision data the model can be internally consistent but cannot be
+*calibrated*, so it is capped below the midpoint no matter how clean
+the fairness and fit signals look.
+"""
+
+STRUCTURAL_COVERAGE_FLOOR = 0.55
+"""Confidence multiplier when NONE of the structural terms could be
+measured, rising to 1.0 when all three could.
+
+Without this, a partner assessed blind — no roster engine output, so
+need and window both silently default to neutral — would carry exactly
+the same confidence as one assessed with full roster context, purely
+because both landed in the same evidence tier. That is wrong: a
+defaulted term is an abstention, not a measurement, and abstentions
+must cost confidence or the score launders ignorance into certainty.
+
+The floor is not zero because a measured fairness edge on its own is
+still real evidence about the offer; it is just thinner evidence.
+"""
+
+_TINY = 1e-9
+
+
+class AcceptanceEvidence(str, Enum):
+    """How well-supported an acceptance estimate is. Weakest first.
+
+    Mirrors the naming and semantics of
+    ``league_intel.adjustment.EvidenceTier`` on purpose so the two
+    compose later; not imported, because that module lives on another
+    workstream's branch and this one must stay dependency-free.
+    """
+
+    ABSENT = "absent"
+    """No admissible signal. The estimate is the bare prior."""
+
+    SHAPE_ONLY = "shapeOnly"
+    """Fairness and/or roster-fit measured from the offer itself. Real
+    evidence about the TRADE; none about the MANAGER."""
+
+    HISTORY_INFORMED = "historyInformed"
+    """Shape evidence plus league trade-activity context."""
+
+    DECISION_CALIBRATED = "decisionCalibrated"
+    """Estimate validated against observed accept/reject decisions.
+    **Unreachable** until a source of declined offers exists."""
+
+
+_EVIDENCE_CONFIDENCE: Mapping[AcceptanceEvidence, float] = {
+    AcceptanceEvidence.ABSENT: 0.05,
+    AcceptanceEvidence.SHAPE_ONLY: 0.30,
+    AcceptanceEvidence.HISTORY_INFORMED: 0.40,
+    AcceptanceEvidence.DECISION_CALIBRATED: 0.85,
+}
+
+
+# ── Consumed contracts ───────────────────────────────────────────────
+# The roster engine (claude/ws-j-roster-intel) owns production of
+# RosterSignal. This module declares the shape it consumes and degrades
+# cleanly when it is absent, so the two workstreams can land in either
+# order.
+
+
+@dataclass(frozen=True)
+class RosterSignal:
+    """What the roster engine tells us about one roster.
+
+    ``surplus`` / ``deficit`` map position → magnitude in whatever
+    positive-is-more units the engine emits; only their RELATIVE sizes
+    are used here, so the engine's scale is not baked in.
+
+    ``contend_probability`` ∈ [0,1] is the engine's competitive-window
+    read: 1.0 = firmly contending, 0.0 = firmly rebuilding.
+    """
+
+    owner_id: str
+    surplus: Mapping[str, float] = field(default_factory=dict)
+    deficit: Mapping[str, float] = field(default_factory=dict)
+    contend_probability: float | None = None
+
+    @property
+    def has_window(self) -> bool:
+        return self.contend_probability is not None
+
+
+@dataclass(frozen=True)
+class TradeShape:
+    """The offer being assessed, from OUR side.
+
+    ``send_positions`` / ``receive_positions`` are position → count.
+    ``market_value_sent`` / ``market_value_received`` are on ONE market
+    scale — the caller is responsible for not mixing KTC and IDPTC
+    (audit F-1). ``markets_mixed`` records that the caller could not
+    guarantee it; a mixed shape suppresses the fairness term rather
+    than trusting an addition with no defined meaning.
+    """
+
+    send_positions: Mapping[str, float] = field(default_factory=dict)
+    receive_positions: Mapping[str, float] = field(default_factory=dict)
+    market_value_sent: float | None = None
+    market_value_received: float | None = None
+    markets_mixed: bool = False
+
+    @property
+    def has_market_values(self) -> bool:
+        return (
+            not self.markets_mixed
+            and self.market_value_sent is not None
+            and self.market_value_received is not None
+            and self.market_value_sent > 0
+            and self.market_value_received > 0
+        )
+
+
+@dataclass(frozen=True)
+class ManagerEvidence:
+    """Whether a manager-specific term is admissible, and why not."""
+
+    owner_id: str
+    admissible: bool
+    reason: str
+    decisions_observed: int = 0
+    accepts_observed: int = 0
+    rejects_observed: int = 0
+    z_score: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ownerId": self.owner_id,
+            "admissible": self.admissible,
+            "reason": self.reason,
+            "decisionsObserved": self.decisions_observed,
+            "acceptsObserved": self.accepts_observed,
+            "rejectsObserved": self.rejects_observed,
+            "zScore": self.z_score,
+        }
+
+
+@dataclass(frozen=True)
+class PartnerInputs:
+    """Everything needed to assess one opposing roster."""
+
+    owner_id: str
+    display_name: str = ""
+    our_roster: RosterSignal | None = None
+    their_roster: RosterSignal | None = None
+    shape: TradeShape | None = None
+    #: Completed trades involving this manager (activity, NOT acceptance).
+    trades_completed: int = 0
+    #: League-wide mean completed trades per manager, for shrinkage.
+    league_mean_trades: float | None = None
+    #: Completed trades between US and this manager specifically.
+    pair_trades_completed: int = 0
+    #: ``faab_analytics.teamAggression`` entry, if available. Used only
+    #: as a weak engagement proxy — a manager who never spends FAAB is
+    #: plausibly less transaction-active. Never as an acceptance rate.
+    team_aggression: Mapping[str, Any] | None = None
+    #: Observed accept/reject decisions. Populated only if a source of
+    #: DECLINED offers ever exists; the public snapshot has none.
+    decisions_accepted: int | None = None
+    decisions_rejected: int | None = None
+
+
+@dataclass(frozen=True)
+class PartnerAssessment:
+    """Per-partner output. All scores in [0,1] unless noted."""
+
+    owner_id: str
+    display_name: str
+    trade_partner_fit_score: float  # 0..100, the RANKING quantity
+    trade_acceptance_estimate: float
+    partner_need_alignment: float
+    partner_window_alignment: float
+    acceptance_confidence: float
+    evidence: AcceptanceEvidence
+    manager_evidence: ManagerEvidence
+    contributions: Mapping[str, float] = field(default_factory=dict)
+    notes: Sequence[str] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ownerId": self.owner_id,
+            "displayName": self.display_name,
+            "tradePartnerFitScore": round(self.trade_partner_fit_score, 2),
+            "tradeAcceptanceEstimate": round(self.trade_acceptance_estimate, 4),
+            "partnerNeedAlignment": round(self.partner_need_alignment, 4),
+            "partnerWindowAlignment": round(self.partner_window_alignment, 4),
+            "acceptanceConfidence": round(self.acceptance_confidence, 4),
+            "evidence": self.evidence.value,
+            "managerEvidence": self.manager_evidence.to_dict(),
+            "contributions": {k: round(v, 4) for k, v in sorted(self.contributions.items())},
+            "notes": list(self.notes),
+            "modelVersion": PARTNER_MODEL_VERSION,
+        }
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return lo if v < lo else hi if v > hi else v
+
+
+def _logit(p: float) -> float:
+    p = _clamp(p, _TINY, 1.0 - _TINY)
+    return math.log(p / (1.0 - p))
+
+
+def _sigmoid(x: float) -> float:
+    if x >= 0:
+        z = math.exp(-x)
+        return 1.0 / (1.0 + z)
+    z = math.exp(x)
+    return z / (1.0 + z)
+
+
+# ── term: market fairness ────────────────────────────────────────────
+def _fairness_term(shape: TradeShape | None) -> tuple[float, str | None]:
+    """Log-odds delta from how the offer prices out for THEM.
+
+    Positive when the partner receives more market value than they send
+    — an offer that favours them is more likely to be engaged with.
+    Saturating so a wildly lopsided gift does not run away to certainty:
+    a 100% overpay is implausible for reasons this model cannot see
+    (collusion optics, roster space, the partner smelling a rat).
+    """
+    if shape is None:
+        return 0.0, "no trade shape supplied — fairness term inert"
+    if not shape.has_market_values:
+        if shape.markets_mixed:
+            return 0.0, (
+                "package mixes offense and IDP markets; per audit F-1 there is no "
+                "validated cross-market normalization, so the fairness term is "
+                "suppressed rather than computed from an undefined sum"
+            )
+        return 0.0, "market values unavailable — fairness term inert"
+
+    sent = float(shape.market_value_sent or 0.0)
+    received = float(shape.market_value_received or 0.0)
+    # From the PARTNER's perspective: they receive what we send.
+    partner_gets = sent
+    partner_gives = received
+    denom = max(partner_gets + partner_gives, _TINY)
+    # Normalised edge in [-1, 1]; +1 = they get everything for nothing.
+    edge = (partner_gets - partner_gives) / denom
+    return MAX_FAIRNESS_LOGIT * math.tanh(2.0 * edge), None
+
+
+# ── term: roster need alignment ──────────────────────────────────────
+def _need_alignment(
+    ours: RosterSignal | None, theirs: RosterSignal | None, shape: TradeShape | None
+) -> tuple[float, str | None]:
+    """Fraction of what we send that lands on a position they lack.
+
+    Complementarity, not charity: we only get credit where OUR surplus
+    meets THEIR deficit. Returns a 0..1 alignment score.
+    """
+    if theirs is None:
+        return 0.5, "roster engine output unavailable — need alignment defaults to neutral"
+    if not theirs.deficit:
+        return 0.5, "partner shows no positional deficit — need alignment neutral"
+
+    sending = dict(shape.send_positions) if shape and shape.send_positions else {}
+    if not sending and ours is not None and ours.surplus:
+        # No concrete package: score the STANDING complementarity of the
+        # two rosters instead, which is what a partner-ranking view wants
+        # before any specific offer exists.
+        sending = dict(ours.surplus)
+    if not sending:
+        return 0.5, "nothing to match against partner deficit — neutral"
+
+    total = sum(max(0.0, v) for v in sending.values())
+    if total <= 0:
+        return 0.5, "no positive send-side weight — neutral"
+
+    deficit_total = sum(max(0.0, v) for v in theirs.deficit.values()) or 1.0
+    matched = 0.0
+    for pos, weight in sending.items():
+        w = max(0.0, float(weight))
+        if w <= 0:
+            continue
+        need = max(0.0, float(theirs.deficit.get(pos, 0.0)))
+        matched += w * (need / deficit_total)
+    # matched/total is in [0,1] but concentrated low; rescale so a
+    # perfectly-targeted package reads as ~1.0.
+    raw = matched / total
+    peak = max(max(0.0, float(v)) for v in theirs.deficit.values()) / deficit_total
+    if peak <= 0:
+        return 0.5, "partner deficit has no positive mass — neutral"
+    return _clamp(raw / peak, 0.0, 1.0), None
+
+
+# ── term: competitive-window alignment ───────────────────────────────
+def _window_alignment(
+    ours: RosterSignal | None, theirs: RosterSignal | None
+) -> tuple[float, str | None]:
+    """Do our windows point in useful opposite directions?
+
+    A contender and a rebuilder are natural counterparties; two teams in
+    the same phase compete for the same assets. 1.0 = maximally
+    complementary, 0.0 = identical windows.
+    """
+    if theirs is None or not theirs.has_window:
+        return 0.5, "partner window probability unavailable — window alignment neutral"
+    if ours is None or not ours.has_window:
+        return 0.5, "our window probability unavailable — window alignment neutral"
+    gap = abs(float(ours.contend_probability or 0.0) - float(theirs.contend_probability or 0.0))
+    return _clamp(gap, 0.0, 1.0), None
+
+
+# ── term: league history (activity, shrunk) ──────────────────────────
+def _history_term(inp: PartnerInputs) -> tuple[float, str | None]:
+    """Shrunk log-odds delta from observed trade ACTIVITY.
+
+    This is not an acceptance rate and is never treated as one — it
+    only says "this manager transacts more/less than the league".
+    Shrinkage is an explicit James-Stein-flavoured pull toward the
+    league mean with a small prior sample size, so a manager with two
+    trades barely moves off the mean.
+    """
+    if inp.league_mean_trades is None:
+        return 0.0, "no league trade baseline — history term inert"
+    mean = max(0.0, float(inp.league_mean_trades))
+    observed = max(0, int(inp.trades_completed))
+    # Shrink toward the mean: with PRIOR_N pseudo-observations at the
+    # league mean, a manager needs real volume to move.
+    prior_n = 5.0
+    shrunk = (observed + prior_n * mean) / (1.0 + prior_n)
+    if mean <= 0:
+        return 0.0, "league mean trade count is zero — history term inert"
+    ratio = shrunk / mean
+    # log ratio, saturating, scaled into the small history budget.
+    delta = MAX_HISTORY_LOGIT * math.tanh(math.log(max(ratio, _TINY)))
+    return delta, None
+
+
+# ── the manager gate ─────────────────────────────────────────────────
+def manager_evidence(inp: PartnerInputs) -> ManagerEvidence:
+    """Is a manager-specific term admissible for this owner?
+
+    **This is the gate.** Two conditions, both required:
+
+    1. ``decisions_observed >= MANAGER_EVIDENCE_MIN_DECISIONS`` — where
+       a *decision* is an offer this manager accepted **or rejected**.
+       Completed trades alone are not decisions: they are the accepted
+       arm only, with no denominator.
+    2. ``|z| >= MANAGER_EVIDENCE_MIN_Z`` against the league mean, so
+       volume alone cannot license a term for a manager who behaves
+       exactly like everyone else.
+
+    Under the current data the first condition is **structurally
+    unsatisfiable**: the snapshot ingests only ``status == "complete"``
+    transactions, and declined offers are not recorded anywhere. The
+    gate therefore reports ``admissible=False`` with a reason naming
+    the missing input, and the manager term contributes exactly zero.
+    """
+    accepted = inp.decisions_accepted
+    rejected = inp.decisions_rejected
+
+    if accepted is None or rejected is None:
+        return ManagerEvidence(
+            owner_id=inp.owner_id,
+            admissible=False,
+            reason=(
+                "no decision data: the league snapshot records only completed "
+                "trades, so rejections are unobserved and an acceptance rate is "
+                "unidentifiable. Manager-specific term contributes zero."
+            ),
+            accepts_observed=int(inp.trades_completed),
+        )
+
+    decisions = int(accepted) + int(rejected)
+    if decisions < MANAGER_EVIDENCE_MIN_DECISIONS:
+        return ManagerEvidence(
+            owner_id=inp.owner_id,
+            admissible=False,
+            reason=(
+                f"only {decisions} observed decisions; "
+                f"{MANAGER_EVIDENCE_MIN_DECISIONS} required before a "
+                "manager-specific rate is distinguishable from sampling noise"
+            ),
+            decisions_observed=decisions,
+            accepts_observed=int(accepted),
+            rejects_observed=int(rejected),
+        )
+
+    rate = accepted / decisions
+    baseline = BASE_ACCEPTANCE_PRIOR
+    se = math.sqrt(max(baseline * (1.0 - baseline) / decisions, _TINY))
+    z = (rate - baseline) / se
+    if abs(z) < MANAGER_EVIDENCE_MIN_Z:
+        return ManagerEvidence(
+            owner_id=inp.owner_id,
+            admissible=False,
+            reason=(
+                f"manager rate {rate:.2f} is {abs(z):.2f} SE from the league "
+                f"baseline; {MANAGER_EVIDENCE_MIN_Z} required — behaves like "
+                "the league, so no manager-specific term is warranted"
+            ),
+            decisions_observed=decisions,
+            accepts_observed=int(accepted),
+            rejects_observed=int(rejected),
+            z_score=z,
+        )
+
+    return ManagerEvidence(
+        owner_id=inp.owner_id,
+        admissible=True,
+        reason=(
+            f"{decisions} decisions, rate {rate:.2f} at {abs(z):.2f} SE from "
+            "baseline — manager-specific term admissible"
+        ),
+        decisions_observed=decisions,
+        accepts_observed=int(accepted),
+        rejects_observed=int(rejected),
+        z_score=z,
+    )
+
+
+def _manager_term(ev: ManagerEvidence) -> float:
+    """Log-odds delta from the manager term. Zero unless the gate cleared."""
+    if not ev.admissible or ev.z_score is None:
+        return 0.0
+    # Bounded by the manager budget; tanh keeps an extreme z from
+    # swamping the fairness signal.
+    return MAX_MANAGER_LOGIT * math.tanh(ev.z_score / 4.0)
+
+
+# ── assembly ─────────────────────────────────────────────────────────
+def assess_partner(inp: PartnerInputs) -> PartnerAssessment:
+    """Assess one opposing roster. Pure."""
+    notes: list[str] = []
+
+    fairness, fairness_note = _fairness_term(inp.shape)
+    if fairness_note:
+        notes.append(fairness_note)
+
+    need, need_note = _need_alignment(inp.our_roster, inp.their_roster, inp.shape)
+    if need_note:
+        notes.append(need_note)
+
+    window, window_note = _window_alignment(inp.our_roster, inp.their_roster)
+    if window_note:
+        notes.append(window_note)
+
+    history, history_note = _history_term(inp)
+    if history_note:
+        notes.append(history_note)
+
+    ev = manager_evidence(inp)
+    manager = _manager_term(ev)
+    if not ev.admissible:
+        notes.append(f"manager term inert: {ev.reason}")
+
+    # Alignment scores are 0..1 centred at 0.5; convert to a signed
+    # contribution so a genuinely poor fit can push the estimate DOWN.
+    need_logit = MAX_NEED_LOGIT * (2.0 * need - 1.0)
+    window_logit = MAX_WINDOW_LOGIT * (2.0 * window - 1.0)
+
+    total = _logit(BASE_ACCEPTANCE_PRIOR) + fairness + need_logit + window_logit + history + manager
+    estimate = _sigmoid(total)
+
+    # ── evidence tier + confidence ───────────────────────────────────
+    # Tier keys on whether a term could be MEASURED, never on how large
+    # its contribution turned out to be. A perfectly balanced offer
+    # yields a fairness delta of exactly 0.0 and a league-average
+    # manager yields a history delta of exactly 0.0 — both are real
+    # measurements that happen to say "no adjustment", and treating
+    # them as absent evidence would penalise the cleanest cases.
+    # Each term returns a note iff it abstained.
+    if ev.admissible:
+        tier = AcceptanceEvidence.DECISION_CALIBRATED
+    elif history_note is None:
+        tier = AcceptanceEvidence.HISTORY_INFORMED
+    elif fairness_note is None or need_note is None or window_note is None:
+        tier = AcceptanceEvidence.SHAPE_ONLY
+    else:
+        tier = AcceptanceEvidence.ABSENT
+
+    confidence = _EVIDENCE_CONFIDENCE[tier]
+
+    # Structural coverage: how many of the three per-offer terms were
+    # actually MEASURED rather than defaulted to neutral. Each term
+    # returns a note iff it abstained, so this counts real signal.
+    measured = sum(1 for note in (fairness_note, need_note, window_note) if note is None)
+    coverage = measured / 3.0
+    confidence *= STRUCTURAL_COVERAGE_FLOOR + (1.0 - STRUCTURAL_COVERAGE_FLOOR) * coverage
+    if measured < 3:
+        notes.append(
+            f"structural coverage {measured}/3: confidence reduced because "
+            "one or more of fairness, roster fit and window fit had to "
+            "abstain rather than measure"
+        )
+
+    if tier is not AcceptanceEvidence.DECISION_CALIBRATED:
+        bound = confidence > MAX_CONFIDENCE_WITHOUT_DECISION_DATA
+        confidence = min(confidence, MAX_CONFIDENCE_WITHOUT_DECISION_DATA)
+        notes.append(
+            (
+                "acceptanceConfidence capped at " f"{MAX_CONFIDENCE_WITHOUT_DECISION_DATA}: "
+                if bound
+                else f"acceptanceConfidence held under {MAX_CONFIDENCE_WITHOUT_DECISION_DATA}: "
+            )
+            + "no rejection data exists, so this estimate is a plausibility "
+            "score in probability units, not a calibrated acceptance probability"
+        )
+
+    # ── the ranking quantity ─────────────────────────────────────────
+    # Confidence is NOT decoration: it multiplies. A high-looking
+    # estimate built on thin evidence must rank below a moderate
+    # estimate built on real signal, which is exactly what shrinking
+    # toward the prior by (1 - confidence) achieves.
+    anchored = BASE_ACCEPTANCE_PRIOR + confidence * (estimate - BASE_ACCEPTANCE_PRIOR)
+    structural = 0.5 * (need + window)
+    fit_score = 100.0 * _clamp(0.65 * anchored + 0.35 * structural * confidence, 0.0, 1.0)
+
+    return PartnerAssessment(
+        owner_id=inp.owner_id,
+        display_name=inp.display_name or inp.owner_id,
+        trade_partner_fit_score=fit_score,
+        trade_acceptance_estimate=estimate,
+        partner_need_alignment=need,
+        partner_window_alignment=window,
+        acceptance_confidence=confidence,
+        evidence=tier,
+        manager_evidence=ev,
+        contributions={
+            "prior": _logit(BASE_ACCEPTANCE_PRIOR),
+            "marketFairness": fairness,
+            "rosterFit": need_logit,
+            "windowFit": window_logit,
+            "leagueHistory": history,
+            "managerSpecific": manager,
+        },
+        notes=tuple(notes),
+    )
+
+
+def assess_partners(inputs: Iterable[PartnerInputs]) -> list[PartnerAssessment]:
+    """Assess many partners, ranked by fit score descending.
+
+    Ranking uses ``tradePartnerFitScore``, which already carries the
+    confidence penalty — so a confidently-mediocre partner outranks a
+    speculatively-attractive one, by construction.
+    """
+    out = [assess_partner(i) for i in inputs]
+    out.sort(key=lambda a: (-a.trade_partner_fit_score, a.owner_id))
+    return out
+
+
+def describe_limitations() -> dict[str, Any]:
+    """Machine-readable limitations of the acceptance model.
+
+    Required deliverable of the WS-J directive, and asserted by tests so
+    it cannot silently drift away from the model's real behaviour. Any
+    surface that renders ``tradeAcceptanceEstimate`` should render this
+    alongside it.
+    """
+    return {
+        "modelVersion": PARTNER_MODEL_VERSION,
+        "canSupport": [
+            "Ranking opposing rosters by structural trade fit (positional "
+            "complementarity and competitive-window opposition).",
+            "Flagging offers that are implausible on market fairness grounds.",
+            "Stating, with an auditable reason, why a manager-specific term " "was not applied.",
+            "Relative comparison between partners assessed under identical " "assumptions.",
+        ],
+        "cannotSupport": [
+            "Any claim that a specific manager will accept a specific trade.",
+            "A calibrated acceptance PROBABILITY: rejections are never "
+            "observed, so the rate is statistically unidentifiable.",
+            "Manager-specific behavioural effects: the evidence gate requires "
+            f"{MANAGER_EVIDENCE_MIN_DECISIONS} accept/reject decisions and the "
+            "available data supplies zero rejections.",
+            "Absolute probability calibration of any kind — only the ordering "
+            "of partners is meaningful.",
+            "Cross-market (offense+IDP) fairness, pending audit F-1's " "normalization work.",
+        ],
+        "keyAssumptions": {
+            "baseAcceptancePrior": BASE_ACCEPTANCE_PRIOR,
+            "baseAcceptancePriorIsMeasured": False,
+            "baseAcceptancePriorNote": (
+                "Assumed, not fitted. Nothing in the available data can "
+                "estimate a base acceptance rate."
+            ),
+        },
+        "confidenceCeiling": MAX_CONFIDENCE_WITHOUT_DECISION_DATA,
+        "confidenceCeilingReason": (
+            "No decision data exists, so the model can be internally "
+            "consistent but not calibrated."
+        ),
+        "structuralCoverageFloor": STRUCTURAL_COVERAGE_FLOOR,
+        "structuralCoverageNote": (
+            "Confidence is additionally reduced when fairness, roster fit or "
+            "window fit had to abstain instead of measure, so a partner "
+            "assessed blind never scores as though it were assessed fully."
+        ),
+        "whatWouldUnlockMore": [
+            "A record of DECLINED offers — the single highest-value missing "
+            "input; it converts the estimate from plausibility to a "
+            "calibratable rate.",
+            "Cross-league decision data from src/intel/ if it ever captures "
+            "offers rather than only completed trades.",
+            "A validated offense/IDP market normalization (audit F-1), which "
+            "would let mixed packages use the fairness term at all.",
+        ],
+    }

--- a/src/roster_intel/partner.py
+++ b/src/roster_intel/partner.py
@@ -275,6 +275,7 @@ class RosterSignal:
         owner_id: str,
         profile: Any | None = None,
         window: Any | None = None,
+        starter_levels: Mapping[str, float] | None = None,
     ) -> RosterSignal:
         """Build from the roster engine's ``RosterProfile`` /
         ``CompetitiveWindow``.
@@ -283,12 +284,39 @@ class RosterSignal:
         dependency on the roster engine — the partner model must remain
         usable with hand-built signals in tests and callers.
 
-        Surplus comes from ``tradeable_surplus`` (lineup-derived: value
-        that does not enter the optimal lineup and is not needed as
-        absence insurance) rather than headcount. Deficit combines the
-        engine's ``urgent_need`` flag with fragility, so a position that
-        collapses on one absence registers as a need even when it is
-        nominally staffed.
+        **Surplus** comes from ``tradeable_surplus``: value that does not
+        enter the optimal lineup and is not needed as absence insurance.
+        Lineup-derived, not headcount.
+
+        **Deficit** is a shortfall below a startable baseline, which is
+        why ``starter_levels`` matters. Two tempting shortcuts are both
+        wrong and are deliberately not used:
+
+        * ``fragility × marginal_points`` measures CONCENTRATION, not
+          deficiency. A lone elite quarterback has fragility 1.0 —
+          losing him erases the whole group — so this makes a roster's
+          strongest position read as its biggest hole, and would tell
+          the partner model to send a quarterback to a team that
+          already has a good one.
+        * ``urgent_need`` alone conflates a structural hole ("slots
+          unfilled") with an insurance risk ("one absence hurts"). Both
+          are real, but only the first is a shortfall.
+
+        So deficit is measured as, per position, the larger of the
+        structural shortfall (unfilled dedicated slots × starter level)
+        and the below-replacement shortfall (starter level × required
+        slots, minus what the position actually contributes).
+
+        ``starter_levels`` maps position → the league's starter
+        replacement level, e.g.
+        ``{p: r.value("starter") for p, r in replacement.items()}``.
+        **Without it a deficit magnitude is not computable** — nothing
+        in a single roster's profile says whether 20 points at tight end
+        is bad or 100 at quarterback is good. Absent, only unambiguous
+        structural holes are reported, and a position that is merely
+        weak contributes nothing rather than a fabricated magnitude.
+        Downstream that degrades ``_need_alignment`` to neutral, which
+        is the honest outcome.
 
         Positions the engine could not attribute — FLEX / SUPER_FLEX /
         IDP_FLEX — are absent from its per-position output by design,
@@ -297,19 +325,37 @@ class RosterSignal:
         """
         surplus: dict[str, float] = {}
         deficit: dict[str, float] = {}
+        levels = starter_levels or {}
         if profile is not None:
             for pos, pp in (getattr(profile, "positions", None) or {}).items():
                 ts = float(getattr(pp, "tradeable_surplus", 0.0) or 0.0)
                 if ts > 0:
                     surplus[pos] = ts
-                frag = float(getattr(pp, "fragility", 0.0) or 0.0)
+
+                req = int(getattr(pp, "required_slots", 0) or 0)
+                entered = int(getattr(pp, "entered_lineup", 0) or 0)
                 marg = float(getattr(pp, "marginal_points", 0.0) or 0.0)
-                need = frag * marg
-                if getattr(pp, "urgent_need", False) or need > 0:
-                    # Urgent positions floor at the group's contribution so a
-                    # structurally unfilled slot is never scored as a smaller
-                    # need than a merely fragile one.
-                    deficit[pos] = max(need, marg if getattr(pp, "urgent_need", False) else 0.0)
+                level = levels.get(pos)
+                if level is None:
+                    level = getattr(pp, "replacement_gap", None)
+                level = float(level) if level else 0.0
+
+                unfilled = max(0, req - entered)
+                # Structural: slots the optimizer could not fill at all.
+                structural = unfilled * level if level > 0 else 0.0
+                # Below-replacement: staffed, but not to a startable
+                # standard. Only computable with a starter level.
+                shortfall = max(0.0, level * req - marg) if level > 0 and req else 0.0
+
+                need = max(structural, shortfall)
+                if need <= 0 and unfilled > 0 and level <= 0:
+                    # No calibration available, but an unfilled required
+                    # slot is unambiguous regardless of scale. Use the
+                    # position's own per-slot contribution as the unit so
+                    # the magnitude stays in the engine's units.
+                    need = (marg / max(entered, 1)) if entered else marg
+                if need > 0:
+                    deficit[pos] = need
 
         contend: float | None = None
         if window is not None:

--- a/src/roster_intel/partner.py
+++ b/src/roster_intel/partner.py
@@ -230,22 +230,34 @@ _EVIDENCE_CONFIDENCE: Mapping[AcceptanceEvidence, float] = {
 
 
 # ── Consumed contracts ───────────────────────────────────────────────
-# The roster engine (claude/ws-j-roster-intel) owns production of
-# RosterSignal. This module declares the shape it consumes and degrades
-# cleanly when it is absent, so the two workstreams can land in either
-# order.
+# The roster engine owns production of RosterProfile / CompetitiveWindow
+# (``profiles.py``, ``window.py``). RosterSignal is the narrow view this
+# module needs, built from those via :meth:`RosterSignal.from_engine`.
+#
+# It stays a separate type on purpose: the partner model uses only
+# relative positional magnitudes and a scalar win-now read, and binding
+# directly to RosterProfile would couple every future change in the
+# roster engine's rich per-position output to this model's arithmetic.
 
 
 @dataclass(frozen=True)
 class RosterSignal:
-    """What the roster engine tells us about one roster.
+    """What the partner model needs to know about one roster.
 
     ``surplus`` / ``deficit`` map position → magnitude in whatever
     positive-is-more units the engine emits; only their RELATIVE sizes
     are used here, so the engine's scale is not baked in.
 
-    ``contend_probability`` ∈ [0,1] is the engine's competitive-window
-    read: 1.0 = firmly contending, 0.0 = firmly rebuilding.
+    ``contend_probability`` ∈ [0,1] collapses the roster engine's
+    five-state window onto a single contend↔rebuild scalar. **That
+    collapse loses information the engine deliberately preserves** — a
+    45/40 retool/rebuild split and a firm 85% retool land on similar
+    scalars while being different strategic positions. It is acceptable
+    *here* because the window term only asks "are these two rosters
+    pointed in usefully opposite directions", and it is bounded to the
+    smallest budget of the three structural terms. Anything reasoning
+    about strategy rather than counterparty-matching should consume
+    ``CompetitiveWindow`` directly instead.
     """
 
     owner_id: str
@@ -256,6 +268,62 @@ class RosterSignal:
     @property
     def has_window(self) -> bool:
         return self.contend_probability is not None
+
+    @classmethod
+    def from_engine(
+        cls,
+        owner_id: str,
+        profile: Any | None = None,
+        window: Any | None = None,
+    ) -> RosterSignal:
+        """Build from the roster engine's ``RosterProfile`` /
+        ``CompetitiveWindow``.
+
+        Typed loosely and imported lazily so this module keeps no import
+        dependency on the roster engine — the partner model must remain
+        usable with hand-built signals in tests and callers.
+
+        Surplus comes from ``tradeable_surplus`` (lineup-derived: value
+        that does not enter the optimal lineup and is not needed as
+        absence insurance) rather than headcount. Deficit combines the
+        engine's ``urgent_need`` flag with fragility, so a position that
+        collapses on one absence registers as a need even when it is
+        nominally staffed.
+
+        Positions the engine could not attribute — FLEX / SUPER_FLEX /
+        IDP_FLEX — are absent from its per-position output by design,
+        and are therefore absent here too rather than being split by
+        assumption.
+        """
+        surplus: dict[str, float] = {}
+        deficit: dict[str, float] = {}
+        if profile is not None:
+            for pos, pp in (getattr(profile, "positions", None) or {}).items():
+                ts = float(getattr(pp, "tradeable_surplus", 0.0) or 0.0)
+                if ts > 0:
+                    surplus[pos] = ts
+                frag = float(getattr(pp, "fragility", 0.0) or 0.0)
+                marg = float(getattr(pp, "marginal_points", 0.0) or 0.0)
+                need = frag * marg
+                if getattr(pp, "urgent_need", False) or need > 0:
+                    # Urgent positions floor at the group's contribution so a
+                    # structurally unfilled slot is never scored as a smaller
+                    # need than a merely fragile one.
+                    deficit[pos] = max(need, marg if getattr(pp, "urgent_need", False) else 0.0)
+
+        contend: float | None = None
+        if window is not None:
+            probs = getattr(window, "probabilities", None) or {}
+            contend = float(probs.get("championship_contender", 0.0)) + float(
+                probs.get("playoff_contender", 0.0)
+            )
+
+        return cls(
+            owner_id=owner_id,
+            surplus=surplus,
+            deficit=deficit,
+            contend_probability=contend,
+        )
 
 
 @dataclass(frozen=True)

--- a/src/roster_intel/targets.py
+++ b/src/roster_intel/targets.py
@@ -53,11 +53,27 @@ added to *this* season's optimal lineup.
 
 That is the right unit for a contender and an incomplete one for a
 rebuild, where the value of an acquisition is mostly its price in two
-years. The window distribution is applied as a multiplier
-(:func:`win_now_weight`) so rebuild-leaning rosters discount win-now
-gains, but a multiplier on a current-season number **cannot** represent
+years. A multiplier on a current-season number **cannot** represent
 future value, and this module does not pretend otherwise. See
 :func:`describe_limitations`.
+
+**How the competitive window enters, and a defect worth remembering.**
+The window is applied through :func:`horizon_weight`, which is computed
+**per position** from the age of that position's obtainable upgrades.
+It has to be per-position to do anything at all: an earlier version
+multiplied every position by the single global :func:`win_now_weight`
+scalar, and since ``priority`` is used only for sorting and display, a
+uniform positive multiplier **cannot reorder a list**. A rebuilding
+roster and a contending roster received the identical ranked order and
+differed only in the absolute numbers — an input that provably could
+not move the output, while being documented as if it did.
+
+Keyed to horizon instead, the window changes WHICH positions to
+attack: given equally-sized upgrades, a contender takes the bigger
+one and a rebuilder takes the younger one. When candidate ages are
+unavailable the term is **not applied and is reported as ``None``**,
+because a field that looks applied and is not is the same false claim
+in quieter clothing.
 """
 
 from __future__ import annotations
@@ -89,6 +105,7 @@ __all__ = [
     "describe_limitations",
     "rank_target_players",
     "rank_target_positions",
+    "horizon_weight",
     "win_now_weight",
 ]
 
@@ -154,7 +171,37 @@ prefers more points to fewer at equal cost — what changes is the price
 it should pay, not the sign of the value. It is emphatically not a
 claim that this engine prices a rebuild's real objective; see the
 module docstring.
+
+**On its own this is a global scalar and therefore inert for ranking**
+— see :func:`horizon_weight`.
 """
+
+_STATE_FUTURE_ORIENTATION: Mapping[str, float] = {
+    "championship_contender": 0.00,
+    "playoff_contender": 0.15,
+    "retool": 0.65,
+    "productive_struggle": 0.85,
+    "rebuild": 1.00,
+}
+"""How much each state cares about an acquisition's remaining horizon.
+
+A contender will happily take a 30-year-old who starts this week; a
+rebuilding roster mostly should not. This is the axis that lets the
+competitive window change WHICH positions to target rather than merely
+rescaling all of them.
+"""
+
+_AGE_YOUNG = 22.0
+_AGE_OLD = 32.0
+"""Bounds of the youth scale, matching ``window.trajectory_score`` so
+the two modules do not disagree about what 'young' means."""
+
+_FUTURE_AGE_FLOOR = 0.40
+_FUTURE_AGE_SPAN = 1.20
+"""A future-oriented roster values the youngest obtainable upgrade
+``(FLOOR + SPAN)`` and the oldest ``FLOOR`` — a 4x spread, which is what
+makes the term capable of reordering positions rather than scaling
+them."""
 
 _SCARCITY_SIGNAL_PERCENTILE = 0.60
 """Waiver scarcity above this marks a position where replacement is
@@ -231,7 +278,7 @@ class PositionTarget:
     urgent_need: bool = False
     need_reasons: tuple[str, ...] = ()
 
-    win_now_weight: float = 1.0
+    win_now_weight: float | None = None
     scarcity_multiplier: float = 1.0
     market_efficiency: float | None = None
     confidence: float = 0.0
@@ -251,7 +298,9 @@ class PositionTarget:
             "severity": round(self.severity, 3),
             "urgentNeed": self.urgent_need,
             "needReasons": list(self.need_reasons),
-            "winNowWeight": round(self.win_now_weight, 4),
+            "winNowWeight": (
+                round(self.win_now_weight, 4) if self.win_now_weight is not None else None
+            ),
             "scarcityMultiplier": round(self.scarcity_multiplier, 4),
             "marketEfficiency": (
                 round(self.market_efficiency, 4) if self.market_efficiency is not None else None
@@ -329,6 +378,12 @@ def win_now_weight(window: CompetitiveWindow | None) -> float:
     a different decision from one sitting at 85% retool, and collapsing
     to the argmax throws away exactly that difference — which is the
     reason the roster engine reports probabilities in the first place.
+
+    **This is a global scalar. It cannot, by itself, change which
+    position ranks first** — multiplying every candidate by the same
+    positive number leaves the order untouched. It is exposed for
+    magnitude reporting and consumed by :func:`horizon_weight`, which is
+    the per-position form that actually differentiates.
     """
     if window is None:
         return 1.0
@@ -343,6 +398,61 @@ def win_now_weight(window: CompetitiveWindow | None) -> float:
     if mass <= _TINY:
         return 1.0
     return total / mass
+
+
+def horizon_weight(window: CompetitiveWindow | None, mean_age: float | None) -> float | None:
+    """Per-position window weight, sensitive to the AGE of what is
+    obtainable there.
+
+    This is the fix for a real defect: the previous implementation
+    applied :func:`win_now_weight` — a single global scalar — uniformly
+    to every position. A uniform positive multiplier cannot reorder a
+    list, so a rebuilding roster and a contending roster received the
+    *identical ranked order* of target positions and differed only in
+    the absolute numbers. The term was documented as affecting the
+    recommendation and provably could not.
+
+    A window weight that genuinely differentiates has to enter
+    per-position, and the mechanism that does so honestly is horizon:
+    a contender should take the best available upgrade regardless of
+    age, while a rebuilding roster should prefer positions where the
+    obtainable upgrades are young. Same window, different positions.
+
+    Returns ``None`` when it cannot be computed — no window, or no age
+    data for the position's candidates. **None means the term did not
+    apply**, and callers must not stamp a number that looks applied.
+    """
+    if window is None or mean_age is None:
+        return None
+    total = 0.0
+    mass = 0.0
+    youth = _clamp((_AGE_OLD - float(mean_age)) / (_AGE_OLD - _AGE_YOUNG), 0.0, 1.0)
+    for state in COMPETITIVE_STATES:
+        p = float(window.probabilities.get(state, 0.0))
+        if p <= 0:
+            continue
+        base = _WIN_NOW_WEIGHTS.get(state, 0.5)
+        future = _STATE_FUTURE_ORIENTATION.get(state, 0.5)
+        # Win-now states ignore age; future-oriented states reward youth.
+        age_mult = (1.0 - future) * 1.0 + future * (_FUTURE_AGE_FLOOR + _FUTURE_AGE_SPAN * youth)
+        total += p * base * age_mult
+        mass += p
+    if mass <= _TINY:
+        return None
+    return total / mass
+
+
+def _mean_candidate_age(
+    candidates: Sequence[RosterPlayer], ages: Mapping[str, float] | None
+) -> float | None:
+    """Mean age of the candidates that define a position's realistic
+    gain. ``None`` when no candidate has a known age."""
+    if not ages:
+        return None
+    known = [float(ages[c.player_id]) for c in candidates if c is not None and c.player_id in ages]
+    if not known:
+        return None
+    return sum(known) / len(known)
 
 
 def _scarcity_multiplier(sc: ScarcityComponents | None) -> tuple[float, str | None]:
@@ -387,6 +497,7 @@ def rank_target_positions(
     scarcity: Mapping[str, ScarcityComponents] | None = None,
     replacement: Mapping[str, PositionReplacement] | None = None,
     market_prices: Mapping[str, float] | None = None,
+    candidate_ages: Mapping[str, float] | None = None,
     candidate_depth: int = REALISTIC_CANDIDATE_DEPTH,
 ) -> list[PositionTarget]:
     """Rank positions worth attacking. Non-viable positions are returned
@@ -419,7 +530,10 @@ def rank_target_positions(
     slots_list = list(slots)
     base_score = optimal_score(pool_list, slots_list)
     cands = candidates or {}
-    ww = win_now_weight(window)
+    # Reported for magnitude context only. It is a GLOBAL scalar and is
+    # deliberately not used as the ranking multiplier — see
+    # horizon_weight for why.
+    global_ww = win_now_weight(window)
 
     positions = set(cands)
     if profile is not None:
@@ -451,7 +565,7 @@ def rank_target_positions(
                     severity=severity,
                     urgent_need=bool(pprof.urgent_need) if pprof else False,
                     need_reasons=tuple(pprof.need_reasons) if pprof else (),
-                    win_now_weight=ww,
+                    win_now_weight=global_ww,
                     scarcity_multiplier=scar_mult,
                     notes=tuple(notes),
                 )
@@ -486,7 +600,7 @@ def rank_target_positions(
                     severity=severity,
                     urgent_need=bool(pprof.urgent_need) if pprof else False,
                     need_reasons=tuple(pprof.need_reasons) if pprof else (),
-                    win_now_weight=ww,
+                    win_now_weight=global_ww,
                     scarcity_multiplier=scar_mult,
                     notes=tuple(notes),
                 )
@@ -511,7 +625,7 @@ def rank_target_positions(
                     severity=severity,
                     urgent_need=bool(pprof.urgent_need) if pprof else False,
                     need_reasons=tuple(pprof.need_reasons) if pprof else (),
-                    win_now_weight=ww,
+                    win_now_weight=global_ww,
                     scarcity_multiplier=scar_mult,
                     notes=tuple(notes),
                 )
@@ -558,7 +672,28 @@ def rank_target_positions(
                 "realistic gain rests on a thin sample"
             )
 
-        priority = realistic * ww * scar_mult * eff_mult * confidence
+        # ── competitive-window weight, PER POSITION ──────────────────
+        # Keyed to the age of what is obtainable here, so a rebuilding
+        # roster prefers positions with young upgrades rather than
+        # receiving the contender's list at a smaller scale. When ages
+        # are unavailable the term cannot differentiate, so it is not
+        # applied at all and is reported as None rather than as a
+        # number that looks applied.
+        top_candidates = [c for _, c in gains[: max(1, int(candidate_depth))]]
+        mean_age = _mean_candidate_age(top_candidates, candidate_ages)
+        hw = horizon_weight(window, mean_age)
+        if hw is None:
+            window_mult = 1.0
+            if window is not None:
+                notes.append(
+                    "competitive window supplied but no candidate ages — the "
+                    "window weight is per-position by age and could not be "
+                    "computed, so it did NOT affect this ranking"
+                )
+        else:
+            window_mult = hw
+
+        priority = realistic * window_mult * scar_mult * eff_mult * confidence
 
         out.append(
             PositionTarget(
@@ -574,7 +709,7 @@ def rank_target_positions(
                 severity=severity,
                 urgent_need=bool(pprof.urgent_need) if pprof else False,
                 need_reasons=tuple(pprof.need_reasons) if pprof else (),
-                win_now_weight=ww,
+                win_now_weight=hw,
                 scarcity_multiplier=scar_mult,
                 market_efficiency=efficiency,
                 confidence=confidence,
@@ -782,9 +917,9 @@ def describe_limitations() -> dict[str, Any]:
         "cannotSupport": [
             "Multi-year or rebuild value. Everything is denominated in "
             "rest-of-season points, so a rebuild's real objective — what an "
-            "asset is worth in two years — is not represented. The win-now "
-            "weight discounts current-season gains; it does not price the "
-            "future.",
+            "asset is worth in two years — is not represented. The horizon "
+            "weight changes WHICH positions a rebuilding roster prefers; it "
+            "does not price the future.",
             "Any claim about what a trade will COST. The engines rank what is "
             "worth wanting, not what it takes to get it.",
             "Availability in any measured sense unless the caller supplies "
@@ -807,6 +942,14 @@ def describe_limitations() -> dict[str, Any]:
             "minCorroboratingSignals": MIN_CORROBORATING_SIGNALS,
             "winNowWeights": dict(_WIN_NOW_WEIGHTS),
             "winNowWeightsAreMeasured": False,
+            "windowAppliedPerPosition": True,
+            "windowAppliedPerPositionNote": (
+                "The competitive window enters via horizon_weight, computed per "
+                "position from the age of that position's obtainable upgrades. A "
+                "global scalar cannot reorder a ranking, so a uniform win-now "
+                "multiplier would be inert. Requires candidate_ages; without them "
+                "the term is not applied and winNowWeight is reported as null."
+            ),
         },
         "whatWouldUnlockMore": [
             "A dynasty/multi-year value scale alongside ros_value, which "

--- a/src/roster_intel/targets.py
+++ b/src/roster_intel/targets.py
@@ -1,0 +1,819 @@
+"""Target Position and Target Player engines (WS-J).
+
+Answers the two questions that follow from a roster profile:
+
+* **Which positions are worth attacking?** — :func:`rank_target_positions`
+* **Which players are worth pursuing?** — :func:`rank_target_players`
+
+Both consume the roster engine (``marginal``, ``profiles``, ``window``)
+and the League Intelligence replacement levels as-is. Nothing here
+re-derives lineup value, replacement levels, or window state.
+
+Pure computation: no I/O, no clock, no globals.
+
+──────────────────────────────────────────────────────────────────────
+Two gates, and why they are gates rather than score terms
+──────────────────────────────────────────────────────────────────────
+The temptation in both engines is to build one weighted product and
+rank on it. That is wrong in a specific, load-bearing way: a weighted
+score lets a large factor **compensate** for a fatal one. Two failures
+are not "low score", they are disqualifying, so they are branches.
+
+**Gate 1 — obtainability (positions).** A position is not a target
+just because it is your worst. If nothing you could plausibly acquire
+would improve the lineup, the correct output is "confirmed weakness,
+unfixable", not a recommendation. The engine measures this **exactly**:
+it re-solves the optimal lineup with each candidate added and reads the
+delta off the solver. A position whose realistic gain is immaterial is
+reported with :class:`TargetViability` explaining which way it failed,
+and is **excluded from the ranked recommendations**.
+
+Ranking the weakest position by default is how a system recommends
+chasing a tight end in a league where every startable tight end is
+already rostered.
+
+**Gate 2 — corroboration (players).** Internal-vs-market edge is never
+sufficient on its own. Edge is a statement about our own numbers, so an
+edge-only recommendation is the model agreeing with itself — and if the
+valuation is wrong, edge is *most* confident exactly where it is most
+wrong. Every recommended player must carry at least
+:data:`MIN_CORROBORATING_SIGNALS` signal that is **not** derived from
+our own valuation: measured lineup fit, positional scarcity, external
+role data, an independent projection, or availability.
+
+Both gates report *why* they failed, so a caller can render the
+distinction between "no target here" and "we could not tell".
+
+──────────────────────────────────────────────────────────────────────
+Scope: this is a CURRENT-SEASON engine
+──────────────────────────────────────────────────────────────────────
+Everything downstream of ``marginal.optimal_score`` is denominated in
+``ros_value`` — rest-of-season points. So "upgrade impact" means points
+added to *this* season's optimal lineup.
+
+That is the right unit for a contender and an incomplete one for a
+rebuild, where the value of an acquisition is mostly its price in two
+years. The window distribution is applied as a multiplier
+(:func:`win_now_weight`) so rebuild-leaning rosters discount win-now
+gains, but a multiplier on a current-season number **cannot** represent
+future value, and this module does not pretend otherwise. See
+:func:`describe_limitations`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.league_intel.replacement import (
+    PositionReplacement,
+    ScarcityComponents,
+    normalize_base_position,
+)
+from src.roster_intel.marginal import optimal_score
+from src.roster_intel.profiles import PositionProfile, RosterProfile
+from src.roster_intel.window import COMPETITIVE_STATES, CompetitiveWindow
+from src.ros.lineup import RosterPlayer
+
+__all__ = [
+    "MIN_CORROBORATING_SIGNALS",
+    "MIN_MATERIAL_POINTS",
+    "MIN_MATERIAL_SHARE",
+    "REALISTIC_CANDIDATE_DEPTH",
+    "TARGETS_MODEL_VERSION",
+    "PlayerTarget",
+    "PositionTarget",
+    "TargetViability",
+    "ValueSignal",
+    "describe_limitations",
+    "rank_target_players",
+    "rank_target_positions",
+    "win_now_weight",
+]
+
+TARGETS_MODEL_VERSION = "wsj.targets.2026-07-27.v1"
+
+
+# ── Tunables ─────────────────────────────────────────────────────────
+
+MIN_MATERIAL_POINTS = 3.0
+"""Minimum rest-of-season points an upgrade must add to the optimal
+lineup before the position counts as a target.
+
+Not zero, and that matters. The solver will happily report a +0.4 gain
+from swapping a bench body, and a strictly-positive test would let
+every position pass the gate — turning the gate back into the ranking
+it was built to replace. Three points is roughly a third of a starter's
+weekly output: below it the recommendation cannot survive the noise in
+the underlying ROS values.
+"""
+
+MIN_MATERIAL_SHARE = 0.01
+"""Second materiality test, relative rather than absolute: the gain must
+also be at least this share of the roster's own lineup score.
+
+Both tests apply because they fail in opposite directions. A flat
+points floor is too strict for a weak roster and too lax for a strong
+one; a pure share floor lets a tiny gain pass on a tiny roster.
+"""
+
+REALISTIC_CANDIDATE_DEPTH = 3
+"""How many of a position's best obtainable candidates define the
+"realistic" gain.
+
+The gate reads the MEDIAN gain across this many candidates, not the
+maximum. Gating on the best available player means every position
+justifies itself with "if I acquire the best guy on the market", which
+is best-case reasoning wearing a measurement's clothes. Requiring that
+several plausible acquisitions all clear the bar is the difference
+between a fixable weakness and a lottery ticket.
+"""
+
+MIN_CORROBORATING_SIGNALS = 1
+"""Non-edge signals a player must carry to be recommended at all.
+
+One, not two, and the reason is honest: with the sources currently
+wired, demanding two corroborators would reject nearly everything and
+the engine would recommend nothing. One is the weakest gate that still
+forbids the failure mode it exists to prevent — a recommendation
+resting purely on our own valuation disagreeing with the market.
+"""
+
+_WIN_NOW_WEIGHTS: Mapping[str, float] = {
+    "championship_contender": 1.00,
+    "playoff_contender": 0.85,
+    "retool": 0.45,
+    "productive_struggle": 0.30,
+    "rebuild": 0.15,
+}
+"""How much a point added to THIS season's lineup is worth per state.
+
+Rebuild is 0.15 rather than 0.0 because a rebuilding roster still
+prefers more points to fewer at equal cost — what changes is the price
+it should pay, not the sign of the value. It is emphatically not a
+claim that this engine prices a rebuild's real objective; see the
+module docstring.
+"""
+
+_SCARCITY_SIGNAL_PERCENTILE = 0.60
+"""Waiver scarcity above this marks a position where replacement is
+genuinely hard, which is what makes an asset there worth corroborating."""
+
+_TINY = 1e-9
+
+
+# ── Outcomes ─────────────────────────────────────────────────────────
+
+
+class TargetViability(str, Enum):
+    """Why a position is or is not a target. Only ``VIABLE`` is ranked."""
+
+    VIABLE = "viable"
+    """An obtainable player would add material lineup value."""
+
+    NO_CANDIDATES = "noCandidates"
+    """No acquirable players were supplied for this position. This is
+    'we could not tell', NOT 'nothing is available' — the distinction
+    matters and is never collapsed."""
+
+    NO_OBTAINABLE_UPGRADE = "noObtainableUpgrade"
+    """Candidates exist and none of them improve the optimal lineup.
+    A confirmed weakness that nobody can fix. Reported, never ranked."""
+
+    IMMATERIAL_GAIN = "immaterialGain"
+    """A real but trivial gain — below the materiality floors."""
+
+
+class ValueSignal(str, Enum):
+    """Independent reasons to want a player.
+
+    ``MARKET_EDGE`` is deliberately NOT in
+    :data:`CORROBORATING_SIGNALS`: it is derived from our own valuation,
+    so it cannot corroborate itself.
+    """
+
+    MARKET_EDGE = "marketEdge"
+    ROSTER_FIT = "rosterFit"
+    SCARCITY = "scarcity"
+    ROLE = "role"
+    PROJECTION = "projection"
+    AVAILABILITY = "availability"
+
+
+CORROBORATING_SIGNALS = frozenset(
+    {
+        ValueSignal.ROSTER_FIT,
+        ValueSignal.SCARCITY,
+        ValueSignal.ROLE,
+        ValueSignal.PROJECTION,
+        ValueSignal.AVAILABILITY,
+    }
+)
+
+
+@dataclass(frozen=True)
+class PositionTarget:
+    """One position's assessment. ``viability`` decides if it is ranked."""
+
+    position: str
+    viability: TargetViability
+    reason: str
+
+    #: Median added lineup points across the best obtainable candidates.
+    realistic_gain: float = 0.0
+    #: Best single candidate's added points. Context only — never gated on.
+    best_case_gain: float = 0.0
+    candidates_tested: int = 0
+
+    #: Current cost of the weakness, in lineup points.
+    severity: float = 0.0
+    urgent_need: bool = False
+    need_reasons: tuple[str, ...] = ()
+
+    win_now_weight: float = 1.0
+    scarcity_multiplier: float = 1.0
+    market_efficiency: float | None = None
+    confidence: float = 0.0
+
+    #: The ranking quantity. Zero for anything not VIABLE.
+    priority: float = 0.0
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "viability": self.viability.value,
+            "reason": self.reason,
+            "realisticGain": round(self.realistic_gain, 3),
+            "bestCaseGain": round(self.best_case_gain, 3),
+            "candidatesTested": self.candidates_tested,
+            "severity": round(self.severity, 3),
+            "urgentNeed": self.urgent_need,
+            "needReasons": list(self.need_reasons),
+            "winNowWeight": round(self.win_now_weight, 4),
+            "scarcityMultiplier": round(self.scarcity_multiplier, 4),
+            "marketEfficiency": (
+                round(self.market_efficiency, 4) if self.market_efficiency is not None else None
+            ),
+            "confidence": round(self.confidence, 4),
+            "priority": round(self.priority, 3),
+            "notes": list(self.notes),
+            "modelVersion": TARGETS_MODEL_VERSION,
+        }
+
+
+@dataclass(frozen=True)
+class PlayerTarget:
+    """One candidate player's assessment."""
+
+    player_id: str
+    name: str
+    position: str
+    recommended: bool
+    reason: str
+
+    signals: tuple[ValueSignal, ...] = ()
+    corroborating: tuple[ValueSignal, ...] = ()
+
+    lineup_gain: float = 0.0
+    market_edge: float | None = None
+    availability: float | None = None
+    confidence: float = 0.0
+    priority: float = 0.0
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "playerId": self.player_id,
+            "name": self.name,
+            "position": self.position,
+            "recommended": self.recommended,
+            "reason": self.reason,
+            "signals": [s.value for s in self.signals],
+            "corroborating": [s.value for s in self.corroborating],
+            "lineupGain": round(self.lineup_gain, 3),
+            "marketEdge": (round(self.market_edge, 4) if self.market_edge is not None else None),
+            "availability": (
+                round(self.availability, 4) if self.availability is not None else None
+            ),
+            "confidence": round(self.confidence, 4),
+            "priority": round(self.priority, 3),
+            "notes": list(self.notes),
+            "modelVersion": TARGETS_MODEL_VERSION,
+        }
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return lo if v < lo else hi if v > hi else v
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return 0.5 * (ordered[mid - 1] + ordered[mid])
+
+
+def win_now_weight(window: CompetitiveWindow | None) -> float:
+    """Expected value of a point added to this season's lineup.
+
+    Consumes the full five-state distribution rather than
+    ``most_likely``. A roster split 45/40 between retool and rebuild is
+    a different decision from one sitting at 85% retool, and collapsing
+    to the argmax throws away exactly that difference — which is the
+    reason the roster engine reports probabilities in the first place.
+    """
+    if window is None:
+        return 1.0
+    total = 0.0
+    mass = 0.0
+    for state in COMPETITIVE_STATES:
+        p = float(window.probabilities.get(state, 0.0))
+        if p <= 0:
+            continue
+        total += p * _WIN_NOW_WEIGHTS.get(state, 0.5)
+        mass += p
+    if mass <= _TINY:
+        return 1.0
+    return total / mass
+
+
+def _scarcity_multiplier(sc: ScarcityComponents | None) -> tuple[float, str | None]:
+    """How durable an upgrade at this position is.
+
+    Uses ``waiver_scarcity`` specifically, and only that. The
+    replacement module keeps its six signals separate on purpose —
+    "top-heavy" and "nothing on waivers" call for opposite moves — so
+    collapsing them here would undo that design. Waiver scarcity is the
+    one that answers the question this engine is asking: if I do not
+    trade for this, can I just pick one up?
+    """
+    if sc is None or sc.waiver_scarcity is None:
+        return 1.0, "no scarcity data — position scarcity multiplier inert"
+    # 0.85x when trivially replaceable, 1.15x when nothing is available.
+    return 0.85 + 0.30 * _clamp(float(sc.waiver_scarcity), 0.0, 1.0), None
+
+
+def _position_severity(profile: PositionProfile | None) -> float:
+    """Current cost of the weakness, in lineup points.
+
+    Fragility × the group's contribution: a position that collapses when
+    one player is absent is expensive whether or not it looks thin by
+    headcount. Unfilled slots are already reflected in the marginal
+    solve, so they are not added again here.
+    """
+    if profile is None:
+        return 0.0
+    return max(0.0, float(profile.fragility)) * max(0.0, float(profile.marginal_points))
+
+
+# ── Target Position engine ───────────────────────────────────────────
+
+
+def rank_target_positions(
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    *,
+    profile: RosterProfile | None = None,
+    candidates: Mapping[str, Sequence[RosterPlayer]] | None = None,
+    window: CompetitiveWindow | None = None,
+    scarcity: Mapping[str, ScarcityComponents] | None = None,
+    replacement: Mapping[str, PositionReplacement] | None = None,
+    market_prices: Mapping[str, float] | None = None,
+    candidate_depth: int = REALISTIC_CANDIDATE_DEPTH,
+) -> list[PositionTarget]:
+    """Rank positions worth attacking. Non-viable positions are returned
+    too, unranked, so a caller can show a confirmed-but-unfixable
+    weakness instead of silently omitting it.
+
+    Args:
+        pool: our roster, eligibility-enriched.
+        slots: the league's flattened starter slots.
+        profile: roster engine output. Supplies severity and need
+            context; absent ⇒ severity reads zero and confidence drops.
+        candidates: ``{position: [acquirable players]}``. **This is what
+            makes the obtainability gate real.** Absent for a position ⇒
+            :attr:`TargetViability.NO_CANDIDATES` — "we could not tell",
+            never "nothing available".
+        window: five-state competitive window; scales win-now value.
+        scarcity: per-position scarcity components.
+        replacement: league replacement levels, for market efficiency.
+        market_prices: ``{position: typical acquisition cost}`` in the
+            same units as player value. Absent ⇒ efficiency unreported.
+        candidate_depth: how many top candidates define the realistic
+            gain.
+
+    Returns:
+        Viable targets first, ranked by ``priority`` descending, then
+        non-viable positions ordered by severity so the biggest
+        unfixable weakness is still visible.
+    """
+    pool_list = list(pool)
+    slots_list = list(slots)
+    base_score = optimal_score(pool_list, slots_list)
+    cands = candidates or {}
+    ww = win_now_weight(window)
+
+    positions = set(cands)
+    if profile is not None:
+        positions |= set(profile.positions)
+    positions = {normalize_base_position(p) for p in positions if p}
+
+    out: list[PositionTarget] = []
+    for pos in sorted(positions):
+        pprof = profile.positions.get(pos) if profile else None
+        severity = _position_severity(pprof)
+        scar_mult, scar_note = _scarcity_multiplier((scarcity or {}).get(pos))
+        notes: list[str] = []
+        if scar_note:
+            notes.append(scar_note)
+
+        pos_candidates = [c for c in (cands.get(pos) or []) if c is not None]
+
+        # ── the obtainability gate ───────────────────────────────────
+        if not pos_candidates:
+            out.append(
+                PositionTarget(
+                    position=pos,
+                    viability=TargetViability.NO_CANDIDATES,
+                    reason=(
+                        "no acquirable candidates supplied for this position, so "
+                        "obtainable upgrade value is unknown — this is 'not "
+                        "measured', not 'nothing available'"
+                    ),
+                    severity=severity,
+                    urgent_need=bool(pprof.urgent_need) if pprof else False,
+                    need_reasons=tuple(pprof.need_reasons) if pprof else (),
+                    win_now_weight=ww,
+                    scarcity_multiplier=scar_mult,
+                    notes=tuple(notes),
+                )
+            )
+            continue
+
+        # Exact re-solve per candidate: what does adding them do to the
+        # optimal lineup? This is measured, not inferred from value.
+        gains = [
+            (optimal_score([*pool_list, cand], slots_list) - base_score, cand)
+            for cand in pos_candidates
+        ]
+        gains.sort(key=lambda g: (-g[0], g[1].player_id))
+        best_case = gains[0][0] if gains else 0.0
+        top = [g for g, _ in gains[: max(1, int(candidate_depth))]]
+        realistic = _median(top)
+
+        material_floor = max(MIN_MATERIAL_POINTS, MIN_MATERIAL_SHARE * base_score)
+        if best_case <= _TINY:
+            out.append(
+                PositionTarget(
+                    position=pos,
+                    viability=TargetViability.NO_OBTAINABLE_UPGRADE,
+                    reason=(
+                        f"tested {len(gains)} obtainable candidates; none improves "
+                        "the optimal lineup. A confirmed weakness that cannot "
+                        "currently be fixed is not a target"
+                    ),
+                    realistic_gain=realistic,
+                    best_case_gain=best_case,
+                    candidates_tested=len(gains),
+                    severity=severity,
+                    urgent_need=bool(pprof.urgent_need) if pprof else False,
+                    need_reasons=tuple(pprof.need_reasons) if pprof else (),
+                    win_now_weight=ww,
+                    scarcity_multiplier=scar_mult,
+                    notes=tuple(notes),
+                )
+            )
+            continue
+
+        if realistic < material_floor:
+            out.append(
+                PositionTarget(
+                    position=pos,
+                    viability=TargetViability.IMMATERIAL_GAIN,
+                    reason=(
+                        f"realistic gain {realistic:.2f} pts is below the "
+                        f"materiality floor {material_floor:.2f} "
+                        f"(max({MIN_MATERIAL_POINTS}, "
+                        f"{MIN_MATERIAL_SHARE:.0%} of lineup score)); best single "
+                        f"candidate would add {best_case:.2f}"
+                    ),
+                    realistic_gain=realistic,
+                    best_case_gain=best_case,
+                    candidates_tested=len(gains),
+                    severity=severity,
+                    urgent_need=bool(pprof.urgent_need) if pprof else False,
+                    need_reasons=tuple(pprof.need_reasons) if pprof else (),
+                    win_now_weight=ww,
+                    scarcity_multiplier=scar_mult,
+                    notes=tuple(notes),
+                )
+            )
+            continue
+
+        # ── market efficiency (reported, bounded, never a gate) ──────
+        efficiency: float | None = None
+        eff_mult = 1.0
+        price = (market_prices or {}).get(pos)
+        rep = (replacement or {}).get(pos)
+        if price is not None and price > 0:
+            starter = rep.value("starter") if rep else None
+            if starter:
+                efficiency = float(starter) / float(price)
+                eff_mult = _clamp(0.80 + 0.40 * _clamp(efficiency, 0.0, 2.0) / 2.0, 0.80, 1.20)
+            else:
+                notes.append(
+                    "market price supplied but no starter replacement level — "
+                    "market efficiency not computable"
+                )
+        else:
+            notes.append("no market price for this position — efficiency unreported")
+
+        # ── confidence ───────────────────────────────────────────────
+        # Tracks how much of the input set was actually supplied. Same
+        # rule as the partner model: a defaulted input is an abstention
+        # and must cost confidence rather than pass silently.
+        supplied = sum(
+            1
+            for present in (
+                profile is not None,
+                window is not None,
+                (scarcity or {}).get(pos) is not None,
+                efficiency is not None,
+            )
+            if present
+        )
+        confidence = _clamp(0.40 + 0.15 * supplied, 0.0, 1.0)
+        if len(gains) < candidate_depth:
+            confidence *= 0.85
+            notes.append(
+                f"only {len(gains)} candidates tested (< {candidate_depth}); the "
+                "realistic gain rests on a thin sample"
+            )
+
+        priority = realistic * ww * scar_mult * eff_mult * confidence
+
+        out.append(
+            PositionTarget(
+                position=pos,
+                viability=TargetViability.VIABLE,
+                reason=(
+                    f"{len(gains)} candidates tested; a realistic acquisition adds "
+                    f"{realistic:.2f} pts to the optimal lineup"
+                ),
+                realistic_gain=realistic,
+                best_case_gain=best_case,
+                candidates_tested=len(gains),
+                severity=severity,
+                urgent_need=bool(pprof.urgent_need) if pprof else False,
+                need_reasons=tuple(pprof.need_reasons) if pprof else (),
+                win_now_weight=ww,
+                scarcity_multiplier=scar_mult,
+                market_efficiency=efficiency,
+                confidence=confidence,
+                priority=priority,
+                notes=tuple(notes),
+            )
+        )
+
+    viable = [t for t in out if t.viability is TargetViability.VIABLE]
+    rest = [t for t in out if t.viability is not TargetViability.VIABLE]
+    viable.sort(key=lambda t: (-t.priority, t.position))
+    rest.sort(key=lambda t: (-t.severity, t.position))
+    return viable + rest
+
+
+# ── Target Player engine ─────────────────────────────────────────────
+
+
+def rank_target_players(
+    pool: Sequence[RosterPlayer],
+    slots: Sequence[str],
+    candidates: Sequence[RosterPlayer],
+    *,
+    market_values: Mapping[str, float] | None = None,
+    scarcity: Mapping[str, ScarcityComponents] | None = None,
+    role_scores: Mapping[str, float] | None = None,
+    projection_scores: Mapping[str, float] | None = None,
+    availability: Mapping[str, float] | None = None,
+    min_corroborating: int = MIN_CORROBORATING_SIGNALS,
+) -> list[PlayerTarget]:
+    """Rank individual players worth pursuing.
+
+    **A player is never recommended on internal-vs-market edge alone.**
+    Edge is computed from our own valuation, so an edge-only case is the
+    model agreeing with itself; where the valuation is wrong, edge is
+    most confident exactly where it is most wrong. Each candidate must
+    carry at least ``min_corroborating`` signal from
+    :data:`CORROBORATING_SIGNALS`, all of which come from somewhere
+    other than our price.
+
+    Args:
+        pool: our roster.
+        slots: the league's starter slots.
+        candidates: players who might be acquired.
+        market_values: ``{player_id: market price}``. Drives the edge
+            signal only — never sufficient by itself.
+        scarcity: per-position scarcity components.
+        role_scores: ``{player_id: 0-1}`` external usage/role evidence
+            (snap share, target share, depth chart) — independent of our
+            valuation, which is what makes it corroborating.
+        projection_scores: ``{player_id: 0-1}`` independent projection
+            percentile.
+        availability: ``{player_id: 0-1}`` how obtainable they are —
+            e.g. from ``partner.assess_partner``, or their owner's
+            surplus at that position.
+        min_corroborating: the gate. Lowering it to 0 disables the
+            corroboration requirement and is not supported.
+
+    Returns:
+        Recommended players first by ``priority`` descending, then
+        rejected candidates with the reason they failed the gate.
+    """
+    pool_list = list(pool)
+    slots_list = list(slots)
+    base_score = optimal_score(pool_list, slots_list)
+    material_floor = max(MIN_MATERIAL_POINTS, MIN_MATERIAL_SHARE * base_score)
+
+    out: list[PlayerTarget] = []
+    for cand in candidates:
+        if cand is None:
+            continue
+        pos = normalize_base_position(cand.position)
+        notes: list[str] = []
+        signals: list[ValueSignal] = []
+
+        # ── measured lineup fit (exact re-solve) ─────────────────────
+        gain = optimal_score([*pool_list, cand], slots_list) - base_score
+        if gain >= material_floor:
+            signals.append(ValueSignal.ROSTER_FIT)
+
+        # ── market edge — necessary for value, never sufficient ──────
+        edge: float | None = None
+        price = (market_values or {}).get(cand.player_id)
+        if price is not None and price > 0:
+            edge = (float(cand.ros_value) - float(price)) / float(price)
+            if edge > 0:
+                signals.append(ValueSignal.MARKET_EDGE)
+        else:
+            notes.append("no market value supplied — edge unmeasured")
+
+        # ── corroborators ────────────────────────────────────────────
+        sc = (scarcity or {}).get(pos)
+        if sc is not None and sc.waiver_scarcity is not None:
+            if float(sc.waiver_scarcity) >= _SCARCITY_SIGNAL_PERCENTILE:
+                signals.append(ValueSignal.SCARCITY)
+
+        role = (role_scores or {}).get(cand.player_id)
+        if role is not None and float(role) >= 0.6:
+            signals.append(ValueSignal.ROLE)
+
+        proj = (projection_scores or {}).get(cand.player_id)
+        if proj is not None and float(proj) >= 0.6:
+            signals.append(ValueSignal.PROJECTION)
+
+        avail = (availability or {}).get(cand.player_id)
+        if avail is not None and float(avail) >= 0.5:
+            signals.append(ValueSignal.AVAILABILITY)
+
+        corroborating = tuple(s for s in signals if s in CORROBORATING_SIGNALS)
+
+        # ── the corroboration gate ───────────────────────────────────
+        if len(corroborating) < min_corroborating:
+            if ValueSignal.MARKET_EDGE in signals:
+                reason = (
+                    f"market edge {edge:+.1%} is the only signal; a recommendation "
+                    "resting solely on our own valuation disagreeing with the "
+                    "market is the model agreeing with itself. Needs at least "
+                    f"{min_corroborating} independent signal (roster fit, "
+                    "scarcity, role, projection or availability)"
+                )
+            else:
+                reason = (
+                    "no admissible value signal: the player neither improves the "
+                    "optimal lineup nor carries scarcity, role, projection or "
+                    "availability evidence"
+                )
+            out.append(
+                PlayerTarget(
+                    player_id=cand.player_id,
+                    name=cand.canonical_name,
+                    position=pos,
+                    recommended=False,
+                    reason=reason,
+                    signals=tuple(signals),
+                    corroborating=corroborating,
+                    lineup_gain=gain,
+                    market_edge=edge,
+                    availability=avail,
+                    notes=tuple(notes),
+                )
+            )
+            continue
+
+        # ── priority for gated-in players ────────────────────────────
+        # Anchored on measured lineup gain, because that is the only
+        # component denominated in points. Edge and availability adjust
+        # it within bounds; neither can manufacture a target on its own,
+        # which the gate above has already guaranteed.
+        scar_mult, _ = _scarcity_multiplier(sc)
+        edge_mult = 1.0 + _clamp(edge or 0.0, -0.5, 0.5) * 0.4
+        avail_mult = 0.7 + 0.6 * _clamp(avail if avail is not None else 0.5, 0.0, 1.0)
+        confidence = _clamp(0.35 + 0.15 * len(corroborating), 0.0, 1.0)
+
+        # A corroborated player with no measured lineup gain is still a
+        # legitimate target (scarcity/role cases), so the anchor floors
+        # at a fraction of the materiality bar rather than zero.
+        anchor = max(gain, 0.25 * material_floor)
+        priority = anchor * scar_mult * edge_mult * avail_mult * confidence
+
+        out.append(
+            PlayerTarget(
+                player_id=cand.player_id,
+                name=cand.canonical_name,
+                position=pos,
+                recommended=True,
+                reason=(
+                    "corroborated by "
+                    + ", ".join(s.value for s in corroborating)
+                    + (f"; adds {gain:.2f} pts to the optimal lineup" if gain > 0 else "")
+                ),
+                signals=tuple(signals),
+                corroborating=corroborating,
+                lineup_gain=gain,
+                market_edge=edge,
+                availability=avail,
+                confidence=confidence,
+                priority=priority,
+                notes=tuple(notes),
+            )
+        )
+
+    rec = [t for t in out if t.recommended]
+    rej = [t for t in out if not t.recommended]
+    rec.sort(key=lambda t: (-t.priority, t.player_id))
+    rej.sort(key=lambda t: (-t.lineup_gain, t.player_id))
+    return rec + rej
+
+
+def describe_limitations() -> dict[str, Any]:
+    """Machine-readable limitations of both target engines.
+
+    Asserted by tests so it cannot drift from behaviour.
+    """
+    return {
+        "modelVersion": TARGETS_MODEL_VERSION,
+        "canSupport": [
+            "Ranking positions by measured, obtainable upgrade value — the "
+            "gain is read off an exact lineup re-solve, not inferred from "
+            "player value.",
+            "Distinguishing a fixable weakness from a confirmed weakness "
+            "nobody can fix, and from one we simply have no market data for.",
+            "Rejecting players whose only case is that our valuation " "disagrees with the market.",
+            "Explaining, per position and per player, which signal drove the " "recommendation.",
+        ],
+        "cannotSupport": [
+            "Multi-year or rebuild value. Everything is denominated in "
+            "rest-of-season points, so a rebuild's real objective — what an "
+            "asset is worth in two years — is not represented. The win-now "
+            "weight discounts current-season gains; it does not price the "
+            "future.",
+            "Any claim about what a trade will COST. The engines rank what is "
+            "worth wanting, not what it takes to get it.",
+            "Availability in any measured sense unless the caller supplies "
+            "it; absent that, the availability signal simply does not fire.",
+            "Positions with no supplied candidates — reported as "
+            "'not measured', never as 'nothing available'.",
+            "Cross-market (offense + IDP) comparison, which inherits audit "
+            "F-1's missing normalization.",
+        ],
+        "keyAssumptions": {
+            "materialityFloorPoints": MIN_MATERIAL_POINTS,
+            "materialityFloorShare": MIN_MATERIAL_SHARE,
+            "materialityFloorIsMeasured": False,
+            "materialityFloorNote": (
+                "Assumed, not fitted. Chosen so a bench-body swap cannot clear "
+                "the gate; no calibration data exists to tune it against."
+            ),
+            "realisticCandidateDepth": REALISTIC_CANDIDATE_DEPTH,
+            "realisticGainIsMedianNotMax": True,
+            "minCorroboratingSignals": MIN_CORROBORATING_SIGNALS,
+            "winNowWeights": dict(_WIN_NOW_WEIGHTS),
+            "winNowWeightsAreMeasured": False,
+        },
+        "whatWouldUnlockMore": [
+            "A dynasty/multi-year value scale alongside ros_value, which "
+            "would let the engine price rebuild targets rather than "
+            "discounting win-now ones.",
+            "Measured acquisition costs, turning 'worth wanting' into " "'worth paying for'.",
+            "External role data (snap share, target share, depth chart) — the "
+            "corroborating signal most often missing today.",
+        ],
+    }

--- a/tests/roster_intel/test_packages.py
+++ b/tests/roster_intel/test_packages.py
@@ -656,3 +656,87 @@ class TestPurity:
         before = [(p.player_id, p.ros_value) for p in pool]
         generate_packages(pool, SLOTS, our_assets=_ours(), their_assets=_theirs())
         assert [(p.player_id, p.ros_value) for p in pool] == before
+
+
+# ─────────────────────────────────────────────────────────────────────
+# allow_scalar_fallback, at the GENERATOR level
+#
+# 928a1fa8 made the flag real in cross_market.py — it had been declared
+# and never read, so a caller that opted OUT of scalar conversion
+# silently got converted totals anyway.  generate_packages defaults it
+# to False, so that fix changes what this module returns.
+#
+# tests/league_intel/test_cross_market.py covers value_package directly.
+# Nothing covered the generator, and test_packages.py was 47/47 green
+# both before and after the fix — a behaviour change no test observed.
+# These close that gap.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _ktc_only_asset(pid: str, pos: str, ktc: float) -> TradeAsset:
+    """Priced ONLY on ktcSfTep — the offense-side mirror of
+    ``_idp_asset``.  A package holding one of each cannot be valued on
+    a single market, which is the only way to reach the scalar path."""
+    return TradeAsset.from_player(_player(pid, pos, ktc / 100.0), {MARKET_KTC: ktc})
+
+
+class TestScalarFallbackReachesTheGenerator:
+    """A package whose SIDE mixes a KTC-only and an IDPTC-only asset."""
+
+    @staticmethod
+    def _run(*, allow_scalar_fallback: bool):
+        their = [
+            _ktc_only_asset("wr9", "WR", 2900.0),
+            TradeAsset.from_player(_player("lb9", "LB", 15.0), {MARKET_IDPTC: 1500.0}),
+        ]
+        # A deep partner roster so `wr9` is not read as a cornerstone —
+        # otherwise the structural rule fires first and the 1-for-2 is
+        # never generated.
+        deep = [
+            _asset("stud", "WR", 9500.0),
+            _asset("stud2", "RB", 9000.0),
+            _asset("stud3", "QB", 8800.0),
+        ]
+        return generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_ktc_only_asset("te1", "TE", 3000.0)],
+            their_assets=their,
+            their_full_roster=deep + their,
+            allow_scalar_fallback=allow_scalar_fallback,
+        )
+
+    def test_default_is_opt_out(self):
+        """The default must be the strict one. If this flips, every
+        caller silently starts trusting a converted total again."""
+        import inspect
+
+        sig = inspect.signature(generate_packages)
+        assert sig.parameters["allow_scalar_fallback"].default is False
+
+    def test_mixed_market_package_is_unvaluable_by_default(self):
+        res = self._run(allow_scalar_fallback=False)
+        unvaluable = [r for r in res["rejected"] if r["rejection"] == "unvaluable"]
+        assert unvaluable, (
+            "a package mixing a KTC-only and an IDPTC-only asset resolved "
+            "without conversion — the scalar path is being taken despite "
+            f"the opt-out: {res['rejected']}"
+        )
+        assert not res["members"]
+
+    def test_the_same_package_resolves_when_conversion_is_opted_in(self):
+        """The other half of the proof: the package is otherwise fine,
+        so the rejection above is the FLAG and not some unrelated rule."""
+        res = self._run(allow_scalar_fallback=True)
+        assert not [r for r in res["rejected"] if r["rejection"] == "unvaluable"]
+        assert res["members"], "opting in should price the package"
+
+    def test_the_flag_changes_the_frontier(self):
+        """Stated as the difference, so a future refactor that stops
+        threading the flag through fails here rather than silently."""
+        strict = self._run(allow_scalar_fallback=False)
+        lenient = self._run(allow_scalar_fallback=True)
+        assert len(strict["members"]) != len(lenient["members"]), (
+            "allow_scalar_fallback made no difference to the frontier — "
+            "it is no longer reaching value_package"
+        )

--- a/tests/roster_intel/test_packages.py
+++ b/tests/roster_intel/test_packages.py
@@ -1,0 +1,658 @@
+"""Tests for the Trade Package Generator.
+
+The properties that matter, all directive constraints:
+
+* generation is **staged** — later stages expand only what earlier
+  stages proved was worth expanding, and structural rejections are
+  never expanded;
+* the result is a **Pareto frontier**, not a blended score;
+* the four rejection rules are real branches with explainable reasons;
+* package valuation goes through WS-E's single-market path, and
+  suppression keys on **boundary proximity**, not on the presence of a
+  conversion;
+* nothing ever claims a manager will accept.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.cross_market import MARKET_IDPTC, MARKET_KTC
+from src.roster_intel.packages import (
+    CORNERSTONE_PREMIUM_PCT,
+    NEAR_MISS_PCT,
+    PACKAGES_MODEL_VERSION,
+    PackageCandidate,
+    RejectionReason,
+    TradeAsset,
+    describe_limitations,
+    generate_packages,
+    label_frontier,
+    pareto_frontier,
+)
+from src.roster_intel.partner import RosterSignal
+from src.ros.lineup import RosterPlayer
+
+SLOTS = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX"]
+
+
+def _player(pid: str, pos: str, value: float) -> RosterPlayer:
+    return RosterPlayer(player_id=pid, canonical_name=pid.upper(), position=pos, ros_value=value)
+
+
+def _asset(pid: str, pos: str, ktc: float, ros: float | None = None) -> TradeAsset:
+    return TradeAsset.from_player(
+        _player(pid, pos, ros if ros is not None else ktc / 100.0),
+        {MARKET_KTC: ktc, MARKET_IDPTC: ktc},
+    )
+
+
+def _idp_asset(pid: str, pos: str, idptc: float) -> TradeAsset:
+    """IDP assets are priced ONLY on idpTradeCalc — the situation that
+    forces the single-market rule."""
+    return TradeAsset.from_player(_player(pid, pos, idptc / 100.0), {MARKET_IDPTC: idptc})
+
+
+def _our_pool() -> list[RosterPlayer]:
+    return [
+        _player("qb1", "QB", 100.0),
+        _player("rb1", "RB", 90.0),
+        _player("rb2", "RB", 80.0),
+        _player("wr1", "WR", 95.0),
+        _player("wr2", "WR", 85.0),
+        _player("te1", "TE", 20.0),
+        _player("bench1", "WR", 40.0),
+    ]
+
+
+def _ours() -> list[TradeAsset]:
+    return [_asset("rb2", "RB", 5000.0, 80.0), _asset("bench1", "WR", 2000.0, 40.0)]
+
+
+def _theirs() -> list[TradeAsset]:
+    return [
+        _asset("their_te", "TE", 5000.0, 85.0),
+        _asset("their_wr", "WR", 2200.0, 50.0),
+        _asset("their_stud", "RB", 9500.0, 99.0),
+    ]
+
+
+# ══ Staged generation ═══════════════════════════════════════════════
+
+
+class TestStagedGeneration:
+    def test_stage_one_runs_and_is_reported(self):
+        res = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        s1 = res["stages"][0]
+        assert s1["stage"] == 1
+        assert s1["evaluated"] == len(_ours()) * len(_theirs())
+
+    def test_accepted_packages_are_never_expanded(self):
+        """A package that already works dominates any expansion of
+        itself, so expanding it can only produce dominated output."""
+        from src.roster_intel.packages import _is_near_miss
+
+        good = PackageCandidate(send=(), receive=(), stage=1, accepted=True)
+        assert _is_near_miss(good, 5.0) is False
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            RejectionReason.ILLEGAL_ROSTER,
+            RejectionReason.WORSENS_CRITICAL_NEED,
+            RejectionReason.UNVALUABLE,
+        ],
+    )
+    def test_structural_rejections_are_never_expanded(self, reason):
+        """Adding filler does not make an illegal trade legal, or make a
+        partner stop needing the position you are stripping. Expanding
+        these burns the budget the staging exists to protect."""
+        from src.roster_intel.packages import _is_near_miss
+
+        cand = PackageCandidate(send=(), receive=(), stage=1, accepted=False, rejection=reason)
+        assert _is_near_miss(cand, 5.0) is False
+
+    def test_near_miss_window_is_bounded(self):
+        """A package 200% off is not fixable by adding a bench piece.
+        Without this bound stage 2 expands everything and 'staged'
+        becomes brute force with extra steps."""
+        from src.league_intel.cross_market import PackageComparison, PackageValuation
+        from src.league_intel.cross_market import NormalizationStrategy as NS
+        from src.roster_intel.packages import _is_near_miss
+
+        def _cand(gain: float) -> PackageCandidate:
+            pv = PackageValuation(strategy=NS.SINGLE_MARKET, market=MARKET_KTC, total=1.0)
+            return PackageCandidate(
+                send=(),
+                receive=(),
+                stage=1,
+                accepted=False,
+                rejection=RejectionReason.CORNERSTONE_WITHOUT_PREMIUM,
+                comparison=PackageComparison(
+                    counter=pv, offer=pv, market_gain_pct=gain, gate_pct=5.0
+                ),
+            )
+
+        assert _is_near_miss(_cand(5.0 + NEAR_MISS_PCT - 1), 5.0) is True
+        assert _is_near_miss(_cand(5.0 + NEAR_MISS_PCT + 1), 5.0) is False
+        assert _is_near_miss(_cand(200.0), 5.0) is False
+
+    def test_search_budget_truncates_loudly(self):
+        """A partial frontier presented as complete is worse than no
+        frontier."""
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=_ours(),
+            their_assets=_theirs(),
+            max_candidates_per_stage=2,
+        )
+        assert res["truncated"] is True
+        assert any("not exhaustive" in n for n in res["notes"])
+
+    def test_stage_report_is_complete(self):
+        res = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        assert [s["stage"] for s in res["stages"]] == [1, 2, 3]
+
+
+# ══ Pareto frontier ═════════════════════════════════════════════════
+
+
+class TestParetoFrontier:
+    def _c(self, ve, ri, ap, si, key="x") -> PackageCandidate:
+        return PackageCandidate(
+            send=(_asset(key, "RB", 1.0),),
+            receive=(_asset(key + "r", "WR", 1.0),),
+            stage=1,
+            accepted=True,
+            value_efficiency=ve,
+            roster_improvement=ri,
+            acceptance_plausibility=ap,
+            simplicity=si,
+        )
+
+    def test_dominated_package_is_excluded(self):
+        best = self._c(10, 10, 0.5, 0.5, "a")
+        worse = self._c(5, 5, 0.4, 0.5, "b")
+        front = pareto_frontier([best, worse])
+        assert len(front) == 1
+        assert front[0].value_efficiency == 10
+
+    def test_tradeoffs_both_survive(self):
+        """The whole point: two packages that each win on a different
+        axis are both real options, and no blend can say which is
+        right."""
+        value_play = self._c(20, 1, 0.2, 0.5, "a")
+        upgrade_play = self._c(2, 40, 0.2, 0.5, "b")
+        front = pareto_frontier([value_play, upgrade_play])
+        assert len(front) == 2
+
+    def test_identical_packages_both_survive(self):
+        """Ties are not domination — otherwise iteration order would
+        silently decide which of two equivalent packages you see."""
+        a = self._c(5, 5, 0.3, 0.5, "a")
+        b = self._c(5, 5, 0.3, 0.5, "b")
+        assert len(pareto_frontier([a, b])) == 2
+
+    def test_rejected_packages_never_reach_the_frontier(self):
+        good = self._c(10, 10, 0.5, 0.5, "a")
+        bad = PackageCandidate(send=(), receive=(), stage=1, accepted=False, value_efficiency=999)
+        assert pareto_frontier([good, bad]) == [good]
+
+    def test_value_and_acceptance_are_structurally_anti_correlated(self):
+        """A property worth stating rather than discovering.
+
+        ``value_efficiency`` is OUR market gain; acceptance rises as the
+        partner gains. For a 1-for-1 the two move in opposite directions
+        by construction, so almost every simple package is Pareto-
+        optimal and frontiers are wide. That is the frontier telling the
+        truth — there really is no dominant answer — but a caller
+        expecting a short list should know why it is long.
+        """
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=[
+                _asset("cheap", "TE", 4000.0, 70.0),
+                _asset("fair", "TE", 5000.0, 70.0),
+                _asset("rich", "TE", 6000.0, 70.0),
+            ],
+            their_full_roster=[_asset("untouchable", "RB", 9900.0)],
+            gate_pct=100.0,
+        )
+        front = res["frontier"]
+        assert len(front) >= 2
+        by_value = sorted(front, key=lambda p: p["valueEfficiency"])
+        assert by_value[0]["acceptancePlausibility"] > by_value[-1]["acceptancePlausibility"]
+
+    def test_frontier_is_labelled_by_axis_not_ranked(self):
+        front = pareto_frontier([self._c(20, 1, 0.2, 0.5, "a"), self._c(2, 40, 0.9, 0.5, "b")])
+        labelled = label_frontier(front)
+        assert set(labelled["bestBy"]) == {
+            "valueEfficiency",
+            "rosterImprovement",
+            "acceptancePlausibility",
+            "simplicity",
+        }
+        assert "preference" in labelled["note"]
+
+    def test_simpler_package_wins_the_simplicity_axis(self):
+        simple = PackageCandidate(
+            send=(_asset("a", "RB", 1.0),),
+            receive=(_asset("b", "WR", 1.0),),
+            stage=1,
+            accepted=True,
+            simplicity=0.5,
+        )
+        complex_ = PackageCandidate(
+            send=(_asset("a", "RB", 1.0), _asset("c", "WR", 1.0)),
+            receive=(_asset("b", "WR", 1.0), _asset("d", "TE", 1.0)),
+            stage=2,
+            accepted=True,
+            simplicity=0.25,
+        )
+        assert simple.simplicity > complex_.simplicity
+
+    def test_domination_is_reported_as_a_rejection(self):
+        """A package beaten on every axis is dropped from the frontier
+        but still returned, labelled — a silent omission would leave a
+        caller unable to explain why a plausible trade vanished."""
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            # IDENTICAL market value, so value efficiency and acceptance
+            # plausibility tie; the only axis that moves is lineup fit.
+            their_assets=[
+                _asset("fits_us", "TE", 5000.0, 85.0),
+                _asset("fits_worse", "TE", 5000.0, 60.0),
+            ],
+            their_full_roster=[
+                _asset("untouchable", "RB", 9900.0),
+                _asset("fits_us", "TE", 5000.0, 85.0),
+                _asset("fits_worse", "TE", 5000.0, 60.0),
+            ],
+            gate_pct=100.0,
+        )
+        reasons = {r["rejection"] for r in res["rejected"]}
+        assert RejectionReason.DOMINATED.value in reasons
+        dom = next(r for r in res["rejected"] if r["rejection"] == "dominated")
+        assert "at least as good" in dom["rejectionDetail"]
+
+
+# ══ Rejection rules ═════════════════════════════════════════════════
+
+
+class TestRejectionRules:
+    def test_illegal_roster_is_rejected(self):
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=_ours(),
+            their_assets=_theirs(),
+            roster_limit=len(_our_pool()) - 1,
+        )
+        rejects = [r for r in res["rejected"] if r["rejection"] == "illegalRoster"]
+        assert rejects
+        assert "roster would hold" in rejects[0]["rejectionDetail"]
+
+    def test_same_asset_on_both_sides_is_illegal(self):
+        from src.roster_intel.packages import _check_legality
+
+        a = _asset("dup", "RB", 1000.0)
+        ok, detail = _check_legality([a], [a], 10, 10, None)
+        assert ok is False
+        assert "both sides" in detail
+
+    def test_worsening_a_critical_need_is_rejected(self):
+        """Taking a partner's only scarce position without sending one
+        back is not an offer."""
+        their_signal = RosterSignal(owner_id="them", deficit={"TE": 100.0}, surplus={"RB": 50.0})
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=[_asset("their_te", "TE", 5000.0, 85.0)],
+            their_signal=their_signal,
+        )
+        rejects = [r for r in res["rejected"] if r["rejection"] == "worsensCriticalNeed"]
+        assert rejects
+        assert "TE" in rejects[0]["rejectionDetail"]
+
+    def test_compensating_at_the_same_position_is_allowed(self):
+        their_signal = RosterSignal(owner_id="them", deficit={"TE": 100.0})
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("my_te", "TE", 5200.0, 82.0)],
+            their_assets=[_asset("their_te", "TE", 5000.0, 85.0)],
+            their_signal=their_signal,
+        )
+        assert not [r for r in res["rejected"] if r["rejection"] == "worsensCriticalNeed"]
+
+    def test_rule_cannot_fire_without_partner_signal_and_says_so(self):
+        res = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        assert any("critical-need rejection" in n for n in res["notes"])
+
+    def test_cornerstone_at_market_price_is_rejected(self):
+        """A cornerstone moves for a clear overpay or not at all."""
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 9500.0, 80.0)],
+            their_assets=[_asset("their_stud", "RB", 9500.0, 99.0)],
+        )
+        rejects = [r for r in res["rejected"] if r["rejection"] == "cornerstoneWithoutPremium"]
+        assert rejects
+        assert "clear overpay" in rejects[0]["rejectionDetail"]
+
+    def test_cornerstone_with_a_real_premium_is_allowed(self):
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 13000.0, 80.0)],
+            their_assets=[_asset("their_stud", "RB", 9500.0, 99.0)],
+            gate_pct=100.0,
+        )
+        assert not [r for r in res["rejected"] if r["rejection"] == "cornerstoneWithoutPremium"]
+
+    def test_premium_is_measured_in_their_favour(self):
+        """Sign check. market_gain_pct is OUR gain, so a real overpay to
+        them is negative. Getting this backwards would demand a premium
+        in the wrong direction and reject every serious offer."""
+        from src.league_intel.cross_market import (
+            NormalizationStrategy as NS,
+        )
+        from src.league_intel.cross_market import (
+            PackageComparison,
+            PackageValuation,
+        )
+        from src.roster_intel.packages import _check_cornerstone
+
+        pv = PackageValuation(strategy=NS.SINGLE_MARKET, market=MARKET_KTC, total=1.0)
+        stone = frozenset({"s"})
+        recv = [_asset("s", "RB", 9000.0)]
+
+        overpay = PackageComparison(
+            counter=pv, offer=pv, market_gain_pct=-(CORNERSTONE_PREMIUM_PCT + 5), gate_pct=5.0
+        )
+        lowball = PackageComparison(counter=pv, offer=pv, market_gain_pct=+20.0, gate_pct=5.0)
+        assert _check_cornerstone(recv, stone, overpay)[0] is True
+        assert _check_cornerstone(recv, stone, lowball)[0] is False
+
+    def test_cornerstone_requires_elite_value_not_merely_top_rank(self):
+        """Regression. With a short candidate pool a pure top-N rule
+        makes every asset a cornerstone — a 2,200 bench receiver beside
+        a 9,500 stud — and the premium rule then refuses nearly every
+        package that could be built."""
+        from src.roster_intel.packages import _identify_cornerstones
+
+        stones = _identify_cornerstones(
+            [
+                _asset("stud", "RB", 9500.0),
+                _asset("mid", "TE", 5000.0),
+                _asset("bench", "WR", 2200.0),
+            ]
+        )
+        assert stones == {"stud"}
+
+    def test_cornerstones_come_from_the_full_roster_not_the_wanted_list(self):
+        """Regression. Deriving cornerstones from the players we ASKED
+        about means that if we ask only about their two best, both look
+        elite relative to that list and the premium rule refuses
+        everything buildable."""
+        wanted = [_asset("mid_te", "TE", 5000.0, 85.0)]
+        full = [
+            _asset("untouchable", "RB", 9900.0),
+            _asset("mid_te", "TE", 5000.0, 85.0),
+        ]
+        narrow = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=wanted,
+            gate_pct=100.0,
+        )
+        informed = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=wanted,
+            their_full_roster=full,
+            gate_pct=100.0,
+        )
+        narrow_blocked = [
+            r for r in narrow["rejected"] if r["rejection"] == "cornerstoneWithoutPremium"
+        ]
+        informed_blocked = [
+            r for r in informed["rejected"] if r["rejection"] == "cornerstoneWithoutPremium"
+        ]
+        assert narrow_blocked and not informed_blocked
+        assert any("full roster" in n for n in narrow["notes"])
+        assert not any("full roster" in n for n in informed["notes"])
+
+    def test_cornerstone_set_is_capped_by_rank_too(self):
+        from src.roster_intel.packages import _identify_cornerstones
+
+        stones = _identify_cornerstones([_asset(f"p{i}", "RB", 9000.0 + i) for i in range(6)])
+        assert len(stones) == 3
+
+    def test_package_worse_than_no_trade_is_rejected(self):
+        """The simplest package of all is no package, and it is always
+        available. A trade that loses market value AND lineup points is
+        dominated by declining to trade."""
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=[_asset("junk", "WR", 2200.0, 10.0)],
+            their_full_roster=[_asset("untouchable", "RB", 9900.0)],
+            gate_pct=100.0,
+        )
+        rejects = [r for r in res["rejected"] if r["rejection"] == "dominatedByNoTrade"]
+        assert rejects
+        assert "declining to trade is strictly better" in rejects[0]["rejectionDetail"]
+
+    def test_high_acceptance_cannot_rescue_a_bad_trade(self):
+        """Plausibility measures how the PARTNER receives the offer.
+        Being easy to give away is not a reason to give something away —
+        without this rule the most lopsided giveaway lands on the
+        frontier as 'most plausible to land'."""
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=[_asset("junk", "WR", 2200.0, 10.0)],
+            their_full_roster=[_asset("untouchable", "RB", 9900.0)],
+            gate_pct=100.0,
+        )
+        assert res["frontier"] == []
+
+    def test_a_trade_that_gains_on_one_axis_survives(self):
+        """The rule must reject only packages worse on BOTH axes — a
+        value-losing trade that materially improves the lineup is a
+        legitimate win-now move, not a mistake."""
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            # A bench piece, so we surrender no starter.
+            our_assets=[_asset("bench1", "WR", 6000.0, 40.0)],
+            # Costs market value, but a real lineup upgrade at our hole.
+            their_assets=[_asset("good_te", "TE", 4000.0, 90.0)],
+            their_full_roster=[_asset("untouchable", "RB", 9900.0)],
+            gate_pct=100.0,
+        )
+        assert not [r for r in res["rejected"] if r["rejection"] == "dominatedByNoTrade"]
+        assert res["frontier"]
+
+    def test_every_rejection_carries_a_detail(self):
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=_ours(),
+            their_assets=_theirs(),
+            roster_limit=3,
+        )
+        for r in res["rejected"]:
+            assert r["rejection"] != "none"
+            assert r["rejectionDetail"]
+
+
+# ══ WS-E integration ════════════════════════════════════════════════
+
+
+class TestCrossMarketIntegration:
+    def test_idp_package_routes_to_the_idp_board(self):
+        """An IDP asset forces idpTradeCalc, the only board spanning
+        both universes. Exact — no conversion."""
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=[_idp_asset("edge1", "DL", 5100.0)],
+            gate_pct=100.0,
+        )
+        assert not [r for r in res["rejected"] if r["rejection"] == "unvaluable"]
+
+    def test_asset_priced_on_neither_board_is_unvaluable(self):
+        orphan = TradeAsset(
+            asset_id="ghost",
+            name="Ghost",
+            position="WR",
+            row={"displayName": "Ghost", "position": "WR", "canonicalSiteValues": {}},
+            player=_player("ghost", "WR", 10.0),
+        )
+        res = generate_packages(
+            _our_pool(),
+            SLOTS,
+            our_assets=[_asset("rb2", "RB", 5000.0, 80.0)],
+            their_assets=[orphan],
+        )
+        assert [r for r in res["rejected"] if r["rejection"] == "unvaluable"]
+
+    def test_suppression_is_boundary_proximity_not_conversion_presence(self):
+        """The rule WS-E arrived at after two wrong revisions: a package
+        is withheld only when its band straddles the gate. A wide band
+        far from the boundary must still resolve."""
+        from src.league_intel.cross_market import (
+            NormalizationStrategy as NS,
+        )
+        from src.league_intel.cross_market import (
+            PackageValuation,
+            compare_packages,
+        )
+
+        wide_far = compare_packages(
+            PackageValuation(
+                strategy=NS.SCALAR_FALLBACK,
+                market=MARKET_IDPTC,
+                total=10000.0,
+                uncertainty_band=800.0,
+            ),
+            PackageValuation(strategy=NS.SINGLE_MARKET, market=MARKET_IDPTC, total=5000.0),
+            gate_pct=5.0,
+        )
+        assert wide_far.verdict_certain is True
+
+        narrow_near = compare_packages(
+            PackageValuation(
+                strategy=NS.SCALAR_FALLBACK,
+                market=MARKET_IDPTC,
+                total=5200.0,
+                uncertainty_band=300.0,
+            ),
+            PackageValuation(strategy=NS.SINGLE_MARKET, market=MARKET_IDPTC, total=5000.0),
+            gate_pct=5.0,
+        )
+        assert narrow_near.verdict_certain is False
+
+    def test_generator_does_not_reimplement_valuation(self):
+        import inspect
+
+        from src.roster_intel import packages
+
+        src = inspect.getsource(packages)
+        assert "value_package" in src and "compare_packages" in src
+        # No hand-rolled summing of market values across a package.
+        assert "sum(a.raw_market_value" not in src
+
+    def test_does_not_depend_on_the_pre_fix_trade_engines(self):
+        """finder.py was silently offense-only until recently."""
+        import inspect
+
+        from src.roster_intel import packages
+
+        assert "src.trade" not in inspect.getsource(packages)
+
+
+# ══ Acceptance language ═════════════════════════════════════════════
+
+
+class TestAcceptanceLanguage:
+    def test_every_package_carries_the_acceptance_caveat(self):
+        res = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        for pkg in res["frontier"] + res["rejected"]:
+            assert "not a calibrated acceptance probability" in pkg["acceptanceCaveat"]
+            assert "will accept" in pkg["acceptanceCaveat"]
+
+    def test_field_is_named_plausibility_not_probability(self):
+        res = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        for pkg in res["frontier"]:
+            assert "acceptancePlausibility" in pkg
+            assert "acceptanceProbability" not in pkg
+
+    def test_confidence_travels_with_the_estimate(self):
+        res = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        for pkg in res["frontier"]:
+            assert pkg["acceptanceConfidence"] <= 0.45
+
+
+# ══ Limitations ═════════════════════════════════════════════════════
+
+
+class TestLimitations:
+    def test_inherits_the_acceptance_limitation(self):
+        lim = describe_limitations()
+        blob = " ".join(lim["cannotSupport"]).lower()
+        assert "will accept" in blob
+        assert "rejections are never observed" in blob
+
+    def test_declares_search_is_not_exhaustive(self):
+        lim = describe_limitations()
+        assert any("exhaustive" in s.lower() for s in lim["cannotSupport"])
+
+    def test_declares_the_frontier_must_not_be_collapsed(self):
+        lim = describe_limitations()
+        assert any("exchange rate" in s.lower() for s in lim["cannotSupport"])
+
+    def test_declares_thresholds_are_assumed(self):
+        lim = describe_limitations()
+        assert lim["keyAssumptions"]["thresholdsAreMeasured"] is False
+        assert lim["keyAssumptions"]["cornerstonePremiumPct"] == CORNERSTONE_PREMIUM_PCT
+
+    def test_model_version_is_stamped(self):
+        res = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        assert res["modelVersion"] == PACKAGES_MODEL_VERSION
+
+
+class TestPurity:
+    def test_no_io(self):
+        import inspect
+
+        from src.roster_intel import packages
+
+        src = inspect.getsource(packages)
+        for forbidden in ("import requests", "open(", "datetime.now", "os.getenv"):
+            assert forbidden not in src
+
+    def test_deterministic(self):
+        a = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        b = generate_packages(_our_pool(), SLOTS, our_assets=_ours(), their_assets=_theirs())
+        assert a["frontier"] == b["frontier"]
+
+    def test_inputs_not_mutated(self):
+        pool = _our_pool()
+        before = [(p.player_id, p.ros_value) for p in pool]
+        generate_packages(pool, SLOTS, our_assets=_ours(), their_assets=_theirs())
+        assert [(p.player_id, p.ros_value) for p in pool] == before

--- a/tests/roster_intel/test_partner.py
+++ b/tests/roster_intel/test_partner.py
@@ -28,6 +28,7 @@ from src.roster_intel.partner import (
     MANAGER_EVIDENCE_MIN_DECISIONS,
     MANAGER_EVIDENCE_MIN_Z,
     MAX_CONFIDENCE_WITHOUT_DECISION_DATA,
+    MAX_HISTORY_LOGIT,
     PARTNER_MODEL_VERSION,
     STRUCTURAL_COVERAGE_FLOOR,
     AcceptanceEvidence,
@@ -402,23 +403,61 @@ class TestMixedMarketSuppression:
 
 
 class TestNeedAlignment:
-    def test_sending_their_biggest_deficit_scores_maximally(self):
-        a = assess_partner(_inputs(shape=_shape(send_positions={"RB": 1.0})))
+    """Partner deficit is RB 3.0 / WR 1.0; partner surplus is TE 2.0."""
+
+    def test_perfect_two_sided_fit_scores_maximally(self):
+        """Give them their biggest hole, ask for their surplus."""
+        a = assess_partner(
+            _inputs(shape=_shape(send_positions={"RB": 1.0}, receive_positions={"TE": 1.0}))
+        )
         assert a.partner_need_alignment == pytest.approx(1.0)
 
-    def test_sending_a_position_they_do_not_need_scores_zero(self):
-        a = assess_partner(_inputs(shape=_shape(send_positions={"QB": 1.0})))
+    def test_worst_two_sided_fit_scores_zero(self):
+        """Give them what they already have, ask for what they lack —
+        the offer a manager would find least worth reading."""
+        a = assess_partner(
+            _inputs(shape=_shape(send_positions={"QB": 1.0}, receive_positions={"RB": 1.0}))
+        )
         assert a.partner_need_alignment == pytest.approx(0.0)
 
+    def test_send_side_alone_scores_the_send_side(self):
+        good = assess_partner(
+            _inputs(shape=_shape(send_positions={"RB": 1.0}, receive_positions={}))
+        )
+        bad = assess_partner(
+            _inputs(shape=_shape(send_positions={"QB": 1.0}, receive_positions={}))
+        )
+        assert good.partner_need_alignment == pytest.approx(1.0)
+        assert bad.partner_need_alignment == pytest.approx(0.0)
+
+    def test_asking_for_a_surplus_asset_beats_asking_for_a_scarce_one(self):
+        """The ask side is the half a send-only model cannot see.
+
+        Both offers give the partner the same thing. One asks for the
+        tight end they have to spare; the other asks for a running back
+        they are already short of. Those are not equally sellable, and
+        the model has to say so.
+        """
+        spare = assess_partner(
+            _inputs(shape=_shape(send_positions={"RB": 1.0}, receive_positions={"TE": 1.0}))
+        )
+        scarce = assess_partner(
+            _inputs(shape=_shape(send_positions={"RB": 1.0}, receive_positions={"RB": 1.0}))
+        )
+        assert spare.partner_need_alignment > scarce.partner_need_alignment
+        assert spare.trade_acceptance_estimate > scarce.trade_acceptance_estimate
+
     def test_secondary_need_scores_between(self):
-        a = assess_partner(_inputs(shape=_shape(send_positions={"WR": 1.0})))
+        a = assess_partner(_inputs(shape=_shape(send_positions={"WR": 1.0}, receive_positions={})))
         assert 0.0 < a.partner_need_alignment < 1.0
 
     def test_poor_fit_pushes_the_estimate_down_not_merely_to_neutral(self):
         """The need term is signed: a genuinely bad positional fit has to
         cost the estimate, otherwise 'no fit' and 'perfect fit' would
         differ only in the upside."""
-        bad = assess_partner(_inputs(shape=_shape(send_positions={"QB": 1.0})))
+        bad = assess_partner(
+            _inputs(shape=_shape(send_positions={"QB": 1.0}, receive_positions={"RB": 1.0}))
+        )
         assert bad.contributions["rosterFit"] < 0
 
     def test_missing_roster_engine_output_degrades_to_neutral(self):
@@ -490,6 +529,33 @@ class TestHistoryTerm:
         active = assess_partner(_inputs(trades_completed=8, league_mean_trades=4.0))
         delta = active.contributions["leagueHistory"] - avg.contributions["leagueHistory"]
         assert 0 < delta < 0.20
+
+    def test_prior_trades_with_us_raise_the_history_term(self):
+        """Pair familiarity is the one history signal about the dyad
+        rather than the individual: this manager has demonstrably
+        transacted with US before."""
+        cold = assess_partner(_inputs(pair_trades_completed=0, league_mean_trades=4.0))
+        warm = assess_partner(_inputs(pair_trades_completed=3, league_mean_trades=4.0))
+        assert warm.contributions["leagueHistory"] > cold.contributions["leagueHistory"]
+
+    def test_pair_familiarity_is_one_sided(self):
+        """Never having traded with someone is not evidence against them
+        — you may simply never have talked. No penalty for zero."""
+        no_baseline = assess_partner(_inputs(pair_trades_completed=0))
+        assert no_baseline.contributions["leagueHistory"] == 0.0
+
+    def test_pair_familiarity_alone_activates_the_history_term(self):
+        a = assess_partner(_inputs(pair_trades_completed=4, league_mean_trades=None))
+        assert a.contributions["leagueHistory"] > 0
+        assert a.evidence is AcceptanceEvidence.HISTORY_INFORMED
+
+    def test_history_stays_within_its_budget_when_both_signals_fire(self):
+        """Wiring a second history signal must not let the term exceed
+        the budget the hierarchy allocated it."""
+        maxed = assess_partner(
+            _inputs(trades_completed=500, league_mean_trades=1.0, pair_trades_completed=50)
+        )
+        assert maxed.contributions["leagueHistory"] <= MAX_HISTORY_LOGIT + 1e-9
 
     def test_history_never_exceeds_the_fairness_budget(self):
         extreme = assess_partner(_inputs(trades_completed=500, league_mean_trades=1.0))

--- a/tests/roster_intel/test_partner.py
+++ b/tests/roster_intel/test_partner.py
@@ -1,0 +1,599 @@
+"""Tests for the WS-J trade partner fit + acceptance model.
+
+The point of this suite is not coverage for its own sake. Four
+properties in ``src/roster_intel/partner.py`` are load-bearing claims
+made to the directive, and each one is pinned here so it cannot rot:
+
+1. The manager-specific evidence gate is a **real branch with a real
+   threshold**, and under the data we actually have it does not clear.
+2. ``acceptanceConfidence`` is **capped** while no rejection data
+   exists, regardless of how clean the other signals look.
+3. Confidence **reduces the ranking quantity** — it is not decoration
+   printed beside the score.
+4. Mixed offense/IDP packages **suppress** the fairness term (audit
+   F-1) rather than summing incompatible markets.
+
+Plus the required limitations deliverable, asserted so the prose
+cannot drift away from the code's behaviour.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.roster_intel.partner import (
+    BASE_ACCEPTANCE_PRIOR,
+    MANAGER_EVIDENCE_MIN_DECISIONS,
+    MANAGER_EVIDENCE_MIN_Z,
+    MAX_CONFIDENCE_WITHOUT_DECISION_DATA,
+    PARTNER_MODEL_VERSION,
+    STRUCTURAL_COVERAGE_FLOOR,
+    AcceptanceEvidence,
+    PartnerInputs,
+    RosterSignal,
+    TradeShape,
+    assess_partner,
+    assess_partners,
+    describe_limitations,
+    manager_evidence,
+)
+
+# ── fixtures / builders ──────────────────────────────────────────────
+
+
+def _our_roster(contend: float | None = 0.9) -> RosterSignal:
+    return RosterSignal(
+        owner_id="us",
+        surplus={"RB": 2.0, "WR": 1.0},
+        deficit={"TE": 1.0},
+        contend_probability=contend,
+    )
+
+
+def _their_roster(contend: float | None = 0.1) -> RosterSignal:
+    """Deficit is RB-heavy: RB 3.0, WR 1.0 (total 4.0, peak share 0.75)."""
+    return RosterSignal(
+        owner_id="them",
+        surplus={"TE": 2.0},
+        deficit={"RB": 3.0, "WR": 1.0},
+        contend_probability=contend,
+    )
+
+
+def _shape(**kw) -> TradeShape:
+    base = dict(
+        send_positions={"RB": 1.0},
+        receive_positions={"TE": 1.0},
+        market_value_sent=5000.0,
+        market_value_received=5000.0,
+    )
+    base.update(kw)
+    return TradeShape(**base)
+
+
+def _inputs(**kw) -> PartnerInputs:
+    base = dict(
+        owner_id="them",
+        display_name="Partner",
+        our_roster=_our_roster(),
+        their_roster=_their_roster(),
+        shape=_shape(),
+    )
+    base.update(kw)
+    return PartnerInputs(**base)
+
+
+# ── 1. the manager evidence gate ─────────────────────────────────────
+
+
+class TestManagerEvidenceGate:
+    def test_gate_does_not_clear_on_real_league_data(self):
+        """The decisive property: our snapshot has completed trades only.
+
+        ``trades_completed`` is the accepted arm with no denominator, so
+        however many of them a manager racks up, the gate must stay
+        shut and say why.
+        """
+        ev = manager_evidence(_inputs(trades_completed=99, league_mean_trades=4.0))
+        assert ev.admissible is False
+        assert "no decision data" in ev.reason
+        # Names the missing input, not a vague "insufficient data".
+        assert "rejections are unobserved" in ev.reason
+        assert ev.decisions_observed == 0
+        assert ev.z_score is None
+
+    def test_completed_trades_are_never_counted_as_decisions(self):
+        ev = manager_evidence(_inputs(trades_completed=50))
+        assert ev.decisions_observed == 0
+        assert ev.accepts_observed == 50
+        assert ev.rejects_observed == 0
+
+    def test_half_populated_decision_data_is_not_enough(self):
+        """Accepts without rejects is exactly the unidentifiable case."""
+        ev = manager_evidence(_inputs(decisions_accepted=40, decisions_rejected=None))
+        assert ev.admissible is False
+        assert "no decision data" in ev.reason
+
+    def test_volume_gate_blocks_below_threshold(self):
+        accepted, rejected = 5, 5
+        assert accepted + rejected < MANAGER_EVIDENCE_MIN_DECISIONS
+        ev = manager_evidence(_inputs(decisions_accepted=accepted, decisions_rejected=rejected))
+        assert ev.admissible is False
+        assert str(MANAGER_EVIDENCE_MIN_DECISIONS) in ev.reason
+        assert ev.decisions_observed == 10
+
+    def test_volume_alone_does_not_license_a_manager_term(self):
+        """A manager who behaves like the league gets no term, even with
+        plenty of decisions. This is the second gate condition."""
+        # 40 decisions at rate 0.175, essentially the 0.18 baseline.
+        ev = manager_evidence(_inputs(decisions_accepted=7, decisions_rejected=33))
+        assert ev.decisions_observed >= MANAGER_EVIDENCE_MIN_DECISIONS
+        assert ev.admissible is False
+        assert abs(ev.z_score) < MANAGER_EVIDENCE_MIN_Z
+        assert "behaves like" in ev.reason
+
+    def test_gate_clears_only_when_both_conditions_hold(self):
+        ev = manager_evidence(_inputs(decisions_accepted=16, decisions_rejected=24))
+        assert ev.decisions_observed >= MANAGER_EVIDENCE_MIN_DECISIONS
+        assert abs(ev.z_score) >= MANAGER_EVIDENCE_MIN_Z
+        assert ev.admissible is True
+
+    def test_threshold_matches_its_stated_rationale(self):
+        """MANAGER_EVIDENCE_MIN_DECISIONS is documented as the n at which
+        the standard error of a binary rate is ~7pp. If someone lowers it
+        without revisiting the rationale, this fails."""
+        se = math.sqrt(
+            BASE_ACCEPTANCE_PRIOR * (1 - BASE_ACCEPTANCE_PRIOR) / MANAGER_EVIDENCE_MIN_DECISIONS
+        )
+        assert se == pytest.approx(0.0701, abs=0.01)
+
+    def test_inadmissible_gate_contributes_exactly_zero(self):
+        a = assess_partner(_inputs())
+        assert a.manager_evidence.admissible is False
+        assert a.contributions["managerSpecific"] == 0.0
+        assert any("manager term inert" in n for n in a.notes)
+
+
+# ── 2. confidence is capped, and tracks evidence not value ───────────
+
+
+class TestAcceptanceConfidence:
+    def test_capped_without_decision_data_even_with_perfect_signals(self):
+        a = assess_partner(
+            _inputs(
+                shape=_shape(market_value_sent=9000.0, market_value_received=1000.0),
+                their_roster=_their_roster(contend=0.0),
+                our_roster=_our_roster(contend=1.0),
+                trades_completed=20,
+                league_mean_trades=4.0,
+            )
+        )
+        assert a.acceptance_confidence <= MAX_CONFIDENCE_WITHOUT_DECISION_DATA
+        assert a.evidence is not AcceptanceEvidence.DECISION_CALIBRATED
+        assert any("not a calibrated acceptance probability" in n for n in a.notes)
+
+    def test_every_reachable_tier_is_below_the_cap(self):
+        """Not just the tier we happen to hit — the cap must bind for all
+        of them, since none are decision-calibrated."""
+        cases = [
+            _inputs(our_roster=None, their_roster=None, shape=None),
+            _inputs(),
+            _inputs(trades_completed=20, league_mean_trades=4.0),
+        ]
+        tiers = set()
+        for inp in cases:
+            a = assess_partner(inp)
+            tiers.add(a.evidence)
+            assert a.acceptance_confidence <= MAX_CONFIDENCE_WITHOUT_DECISION_DATA
+        # Confirms the cases really do exercise distinct tiers.
+        assert len(tiers) >= 2
+        assert AcceptanceEvidence.DECISION_CALIBRATED not in tiers
+
+    def test_bare_inputs_yield_absent_tier_at_the_prior(self):
+        a = assess_partner(
+            PartnerInputs(owner_id="them", our_roster=None, their_roster=None, shape=None)
+        )
+        assert a.evidence is AcceptanceEvidence.ABSENT
+        # No admissible signal anywhere: the estimate is the bare prior.
+        assert a.trade_acceptance_estimate == pytest.approx(BASE_ACCEPTANCE_PRIOR, abs=1e-6)
+
+    def test_abstaining_terms_cost_confidence(self):
+        """A defaulted term is an abstention, not a measurement. Partners
+        assessed on fewer real signals must carry less confidence even
+        when they land in the same evidence tier."""
+        full = assess_partner(_inputs())
+        no_window = assess_partner(
+            _inputs(our_roster=_our_roster(None), their_roster=_their_roster(None))
+        )
+        blind = assess_partner(_inputs(our_roster=None, their_roster=None))
+
+        assert full.evidence is no_window.evidence is blind.evidence
+        assert full.acceptance_confidence > no_window.acceptance_confidence
+        assert no_window.acceptance_confidence > blind.acceptance_confidence
+
+    def test_coverage_shortfall_is_reported(self):
+        blind = assess_partner(_inputs(our_roster=None, their_roster=None))
+        assert any("structural coverage 1/3" in n for n in blind.notes)
+
+    def test_full_coverage_is_not_penalised(self):
+        full = assess_partner(_inputs())
+        assert not any("structural coverage" in n for n in full.notes)
+        assert full.acceptance_confidence == pytest.approx(0.30)
+
+    def test_a_zero_contribution_is_still_a_measurement(self):
+        """Regression. Tier must key on whether a term could be measured,
+        not on the magnitude of its contribution.
+
+        A perfectly balanced 5000-for-5000 offer produces a fairness
+        delta of exactly 0.0, and a manager trading at exactly the league
+        mean produces a history delta of exactly 0.0. Both are genuine
+        measurements that say 'no adjustment'. Scoring them as absent
+        evidence would give the cleanest, best-understood cases the
+        lowest confidence — precisely backwards.
+        """
+        balanced = assess_partner(
+            _inputs(
+                our_roster=None,
+                their_roster=None,
+                shape=_shape(market_value_sent=5000.0, market_value_received=5000.0),
+            )
+        )
+        assert balanced.contributions["marketFairness"] == 0.0
+        assert balanced.evidence is AcceptanceEvidence.SHAPE_ONLY
+
+        average = assess_partner(_inputs(trades_completed=4, league_mean_trades=4.0))
+        assert average.contributions["leagueHistory"] == pytest.approx(0.0, abs=1e-9)
+        assert average.evidence is AcceptanceEvidence.HISTORY_INFORMED
+
+    def test_confidence_rises_with_evidence_not_with_the_estimate(self):
+        """Two partners, same evidence tier, wildly different estimates:
+        confidence must be identical. Confidence is about support, not
+        about how attractive the number is."""
+        generous = assess_partner(
+            _inputs(shape=_shape(market_value_sent=9000.0, market_value_received=1000.0))
+        )
+        insulting = assess_partner(
+            _inputs(shape=_shape(market_value_sent=1000.0, market_value_received=9000.0))
+        )
+        assert generous.trade_acceptance_estimate > insulting.trade_acceptance_estimate
+        assert generous.evidence is insulting.evidence
+        assert generous.acceptance_confidence == insulting.acceptance_confidence
+
+
+# ── 3. confidence reduces the ranking quantity ───────────────────────
+
+
+def _fit_at_full_confidence(a) -> float:
+    """Recompute the fit score as if confidence were 1.0.
+
+    Mirrors ``assess_partner``'s final expression deliberately: the test
+    is asserting that the confidence factor is *present and binding*, so
+    it needs the counterfactual to compare against.
+    """
+    anchored = a.trade_acceptance_estimate
+    structural = 0.5 * (a.partner_need_alignment + a.partner_window_alignment)
+    return 100.0 * min(max(0.65 * anchored + 0.35 * structural, 0.0), 1.0)
+
+
+class TestConfidencePenalisesRanking:
+    def test_thin_evidence_scores_below_its_face_value(self):
+        a = assess_partner(
+            _inputs(shape=_shape(market_value_sent=8000.0, market_value_received=2000.0))
+        )
+        assert a.acceptance_confidence < 1.0
+        assert a.trade_acceptance_estimate > BASE_ACCEPTANCE_PRIOR
+        # The confidence factor must actually cost the partner ranking
+        # points, not merely appear in the payload.
+        assert a.trade_partner_fit_score < _fit_at_full_confidence(a)
+
+    def test_higher_estimate_on_thinner_evidence_still_ranks_lower(self):
+        """The sharpest form of the requirement.
+
+        ``speculative`` is assessed blind — no roster engine output, so
+        need and window abstain — but carries a *more attractive* raw
+        estimate thanks to a lopsided offer. ``supported`` is a fair
+        offer measured on all three structural terms.
+
+        If confidence were decoration, speculative would win on the
+        estimate. It must not.
+        """
+        speculative = _inputs(
+            owner_id="speculative",
+            our_roster=None,
+            their_roster=None,
+            shape=_shape(market_value_sent=9000.0, market_value_received=1000.0),
+        )
+        supported = _inputs(
+            owner_id="supported",
+            shape=_shape(market_value_sent=5000.0, market_value_received=5000.0),
+        )
+        spec, sup = assess_partner(speculative), assess_partner(supported)
+
+        # Precondition: the raw estimate really does favour the blind one.
+        assert spec.trade_acceptance_estimate > sup.trade_acceptance_estimate
+        assert spec.acceptance_confidence < sup.acceptance_confidence
+        # ...and the ranking inverts it anyway.
+        assert spec.trade_partner_fit_score < sup.trade_partner_fit_score
+        assert [a.owner_id for a in assess_partners([speculative, supported])] == [
+            "supported",
+            "speculative",
+        ]
+
+    def test_ranking_is_by_fit_score_descending_and_deterministic(self):
+        made = [
+            _inputs(owner_id="b", shape=_shape(market_value_sent=6000.0)),
+            _inputs(owner_id="a", shape=_shape(market_value_sent=6000.0)),
+            _inputs(owner_id="c", shape=_shape(market_value_sent=1000.0)),
+        ]
+        ranked = assess_partners(made)
+        scores = [a.trade_partner_fit_score for a in ranked]
+        assert scores == sorted(scores, reverse=True)
+        # Ties break on owner id, so the order is stable across runs.
+        assert [a.owner_id for a in ranked] == ["a", "b", "c"]
+
+    def test_fit_score_stays_in_range(self):
+        extremes = [
+            _inputs(shape=_shape(market_value_sent=9999.0, market_value_received=1.0)),
+            _inputs(shape=_shape(market_value_sent=1.0, market_value_received=9999.0)),
+            _inputs(our_roster=None, their_roster=None, shape=None),
+        ]
+        for inp in extremes:
+            a = assess_partner(inp)
+            assert 0.0 <= a.trade_partner_fit_score <= 100.0
+            assert 0.0 <= a.trade_acceptance_estimate <= 1.0
+            assert 0.0 <= a.acceptance_confidence <= 1.0
+
+
+# ── 4. audit F-1: mixed markets suppress fairness ────────────────────
+
+
+class TestMixedMarketSuppression:
+    def test_mixed_markets_suppress_the_fairness_term(self):
+        mixed = assess_partner(
+            _inputs(
+                shape=_shape(
+                    market_value_sent=9000.0,
+                    market_value_received=1000.0,
+                    markets_mixed=True,
+                )
+            )
+        )
+        assert mixed.contributions["marketFairness"] == 0.0
+        assert any("audit F-1" in n for n in mixed.notes)
+
+    def test_suppression_is_not_silent(self):
+        """A suppressed fairness term must be visible in the notes, or a
+        consumer will read the resulting mediocre score as a measurement
+        rather than an abstention."""
+        mixed = assess_partner(_inputs(shape=_shape(markets_mixed=True)))
+        note = next(n for n in mixed.notes if "audit F-1" in n)
+        assert "suppressed" in note
+
+    def test_same_market_package_does_use_fairness(self):
+        clean = assess_partner(
+            _inputs(shape=_shape(market_value_sent=9000.0, market_value_received=1000.0))
+        )
+        assert clean.contributions["marketFairness"] > 0.0
+
+    def test_fairness_sign_follows_the_partners_side_of_the_deal(self):
+        """Positive when THEY come out ahead. Getting this backwards
+        would invert every recommendation, so it is pinned explicitly."""
+        favours_them = assess_partner(
+            _inputs(shape=_shape(market_value_sent=8000.0, market_value_received=2000.0))
+        )
+        favours_us = assess_partner(
+            _inputs(shape=_shape(market_value_sent=2000.0, market_value_received=8000.0))
+        )
+        assert favours_them.contributions["marketFairness"] > 0
+        assert favours_us.contributions["marketFairness"] < 0
+
+    def test_fairness_saturates_rather_than_running_to_certainty(self):
+        lopsided = assess_partner(
+            _inputs(shape=_shape(market_value_sent=9999.0, market_value_received=1.0))
+        )
+        assert lopsided.trade_acceptance_estimate < 1.0
+        # A gift is more plausible than a fair deal, but not a certainty.
+        assert lopsided.trade_acceptance_estimate < 0.75
+
+
+# ── term behaviour: need + window alignment ──────────────────────────
+
+
+class TestNeedAlignment:
+    def test_sending_their_biggest_deficit_scores_maximally(self):
+        a = assess_partner(_inputs(shape=_shape(send_positions={"RB": 1.0})))
+        assert a.partner_need_alignment == pytest.approx(1.0)
+
+    def test_sending_a_position_they_do_not_need_scores_zero(self):
+        a = assess_partner(_inputs(shape=_shape(send_positions={"QB": 1.0})))
+        assert a.partner_need_alignment == pytest.approx(0.0)
+
+    def test_secondary_need_scores_between(self):
+        a = assess_partner(_inputs(shape=_shape(send_positions={"WR": 1.0})))
+        assert 0.0 < a.partner_need_alignment < 1.0
+
+    def test_poor_fit_pushes_the_estimate_down_not_merely_to_neutral(self):
+        """The need term is signed: a genuinely bad positional fit has to
+        cost the estimate, otherwise 'no fit' and 'perfect fit' would
+        differ only in the upside."""
+        bad = assess_partner(_inputs(shape=_shape(send_positions={"QB": 1.0})))
+        assert bad.contributions["rosterFit"] < 0
+
+    def test_missing_roster_engine_output_degrades_to_neutral(self):
+        """The roster engine is another workstream. Landing before it is
+        a supported state, not a crash."""
+        a = assess_partner(_inputs(our_roster=None, their_roster=None))
+        assert a.partner_need_alignment == pytest.approx(0.5)
+        assert a.contributions["rosterFit"] == pytest.approx(0.0)
+        assert any("roster engine output unavailable" in n for n in a.notes)
+
+    def test_standing_complementarity_used_when_no_package_exists(self):
+        """Partner ranking has to work before any specific offer is
+        constructed — fall back to surplus-vs-deficit."""
+        a = assess_partner(_inputs(shape=None))
+        assert a.partner_need_alignment > 0.5
+
+
+class TestWindowAlignment:
+    def test_contender_and_rebuilder_are_complementary(self):
+        a = assess_partner(_inputs(our_roster=_our_roster(1.0), their_roster=_their_roster(0.0)))
+        assert a.partner_window_alignment == pytest.approx(1.0)
+
+    def test_identical_windows_are_not_complementary(self):
+        a = assess_partner(_inputs(our_roster=_our_roster(0.8), their_roster=_their_roster(0.8)))
+        assert a.partner_window_alignment == pytest.approx(0.0)
+        assert a.contributions["windowFit"] < 0
+
+    def test_missing_window_degrades_to_neutral(self):
+        a = assess_partner(_inputs(our_roster=_our_roster(None), their_roster=_their_roster(None)))
+        assert a.partner_window_alignment == pytest.approx(0.5)
+        assert any("window" in n for n in a.notes)
+
+    def test_window_budget_is_smaller_than_need_budget(self):
+        """Hierarchy check: window fit must not outweigh roster fit,
+        which must not outweigh market fairness."""
+        strong = assess_partner(
+            _inputs(
+                shape=_shape(
+                    send_positions={"RB": 1.0},
+                    market_value_sent=8000.0,
+                    market_value_received=2000.0,
+                ),
+                our_roster=_our_roster(1.0),
+                their_roster=_their_roster(0.0),
+            )
+        )
+        c = strong.contributions
+        assert c["marketFairness"] > c["rosterFit"] > c["windowFit"] > 0
+
+
+# ── league history is activity, hard-shrunk ──────────────────────────
+
+
+class TestHistoryTerm:
+    def test_inert_without_a_league_baseline(self):
+        a = assess_partner(_inputs(trades_completed=12, league_mean_trades=None))
+        assert a.contributions["leagueHistory"] == 0.0
+        assert any("no league trade baseline" in n for n in a.notes)
+
+    def test_league_average_manager_gets_no_nudge(self):
+        a = assess_partner(_inputs(trades_completed=4, league_mean_trades=4.0))
+        assert a.contributions["leagueHistory"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_shrinkage_keeps_a_low_volume_outlier_near_the_mean(self):
+        """One extra trade in a 12-team league is noise. The history term
+        must barely move, or it becomes a manager term through the back
+        door — which is precisely what the gate exists to prevent."""
+        avg = assess_partner(_inputs(trades_completed=4, league_mean_trades=4.0))
+        active = assess_partner(_inputs(trades_completed=8, league_mean_trades=4.0))
+        delta = active.contributions["leagueHistory"] - avg.contributions["leagueHistory"]
+        assert 0 < delta < 0.20
+
+    def test_history_never_exceeds_the_fairness_budget(self):
+        extreme = assess_partner(_inputs(trades_completed=500, league_mean_trades=1.0))
+        assert abs(extreme.contributions["leagueHistory"]) < abs(
+            assess_partner(
+                _inputs(shape=_shape(market_value_sent=8000.0, market_value_received=2000.0))
+            ).contributions["marketFairness"]
+        )
+
+
+# ── serialization + the limitations deliverable ──────────────────────
+
+
+class TestSerialization:
+    def test_to_dict_carries_confidence_and_evidence_alongside_the_estimate(self):
+        """Anything that renders the estimate must be able to render its
+        caveats from the same payload — no separate lookup."""
+        d = assess_partner(_inputs()).to_dict()
+        for key in (
+            "tradePartnerFitScore",
+            "tradeAcceptanceEstimate",
+            "partnerNeedAlignment",
+            "partnerWindowAlignment",
+            "acceptanceConfidence",
+            "evidence",
+            "managerEvidence",
+            "modelVersion",
+        ):
+            assert key in d
+        assert d["modelVersion"] == PARTNER_MODEL_VERSION
+        assert d["managerEvidence"]["admissible"] is False
+        assert d["managerEvidence"]["reason"]
+
+    def test_contributions_expose_every_term_for_audit(self):
+        d = assess_partner(_inputs()).to_dict()
+        assert set(d["contributions"]) == {
+            "prior",
+            "marketFairness",
+            "rosterFit",
+            "windowFit",
+            "leagueHistory",
+            "managerSpecific",
+        }
+
+
+class TestLimitationsDeliverable:
+    def test_states_the_unidentifiability_of_an_acceptance_rate(self):
+        lim = describe_limitations()
+        blob = " ".join(lim["cannotSupport"]).lower()
+        assert "will accept" in blob
+        assert "unidentifiable" in blob
+
+    def test_declares_the_prior_as_an_assumption(self):
+        lim = describe_limitations()
+        assert lim["keyAssumptions"]["baseAcceptancePriorIsMeasured"] is False
+        assert lim["keyAssumptions"]["baseAcceptancePrior"] == BASE_ACCEPTANCE_PRIOR
+
+    def test_confidence_ceiling_matches_the_code_that_enforces_it(self):
+        """If someone raises the cap without revisiting the doc, or vice
+        versa, the deliverable stops describing the model."""
+        lim = describe_limitations()
+        assert lim["confidenceCeiling"] == MAX_CONFIDENCE_WITHOUT_DECISION_DATA
+        a = assess_partner(_inputs(trades_completed=20, league_mean_trades=4.0))
+        assert a.acceptance_confidence <= lim["confidenceCeiling"]
+
+    def test_structural_coverage_floor_is_documented(self):
+        lim = describe_limitations()
+        assert lim["structuralCoverageFloor"] == STRUCTURAL_COVERAGE_FLOOR
+        assert "abstain" in lim["structuralCoverageNote"]
+
+    def test_names_what_would_unlock_more(self):
+        lim = describe_limitations()
+        assert any("declined" in s.lower() for s in lim["whatWouldUnlockMore"])
+
+    def test_gate_threshold_is_quoted_accurately(self):
+        lim = describe_limitations()
+        assert any(str(MANAGER_EVIDENCE_MIN_DECISIONS) in s for s in lim["cannotSupport"])
+
+
+# ── purity ───────────────────────────────────────────────────────────
+
+
+class TestPurity:
+    def test_repeated_assessment_is_identical(self):
+        inp = _inputs(trades_completed=6, league_mean_trades=4.0)
+        first = assess_partner(inp).to_dict()
+        second = assess_partner(inp).to_dict()
+        assert first == second
+
+    def test_assessment_does_not_mutate_its_inputs(self):
+        shape = _shape()
+        theirs = _their_roster()
+        inp = _inputs(shape=shape, their_roster=theirs)
+        assess_partner(inp)
+        assert dict(shape.send_positions) == {"RB": 1.0}
+        assert dict(theirs.deficit) == {"RB": 3.0, "WR": 1.0}
+
+    def test_module_performs_no_io(self):
+        """Pure computation is a directive constraint, so it is checked
+        structurally rather than trusted."""
+        import inspect
+
+        from src.roster_intel import partner
+
+        src = inspect.getsource(partner)
+        for forbidden in ("import requests", "open(", "Path(", "datetime.now", "os.getenv"):
+            assert forbidden not in src, f"{forbidden} found — module must stay pure"

--- a/tests/roster_intel/test_targets.py
+++ b/tests/roster_intel/test_targets.py
@@ -32,6 +32,7 @@ from src.roster_intel.targets import (
     TargetViability,
     ValueSignal,
     describe_limitations,
+    horizon_weight,
     rank_target_players,
     rank_target_positions,
     win_now_weight,
@@ -249,18 +250,110 @@ class TestWinNowWeight:
     def test_absent_window_is_neutral(self):
         assert win_now_weight(None) == pytest.approx(1.0)
 
-    def test_window_scales_priority(self):
-        pool = _roster()
-        cands = {"TE": [_p("te_a", "TE", 80.0), _p("te_b", "TE", 78.0), _p("te_c", "TE", 76.0)]}
-        contender = rank_target_positions(
-            pool, SLOTS, candidates=cands, window=_window(championship_contender=1.0)
-        )[0]
-        rebuilder = rank_target_positions(
-            pool, SLOTS, candidates=cands, window=_window(rebuild=1.0)
-        )[0]
-        assert contender.priority > rebuilder.priority
-        # The measured gain is identical; only its worth to us changed.
-        assert contender.realistic_gain == pytest.approx(rebuilder.realistic_gain)
+    def test_global_scalar_is_documented_as_inert_for_ranking(self):
+        """``win_now_weight`` is exposed for magnitude reporting only.
+        Multiplying every candidate by the same positive number leaves
+        the order untouched, so it must never BE the ranking multiplier
+        — that is the defect ``horizon_weight`` exists to fix."""
+        import inspect
+
+        from src.roster_intel import targets
+
+        doc = inspect.getdoc(targets.win_now_weight) or ""
+        assert "cannot" in doc and "global scalar" in doc.lower()
+
+
+class TestHorizonWeight:
+    """The per-position window term.
+
+    Regression suite for a real defect: the window used to be applied as
+    a single global scalar multiplied uniformly into every position's
+    priority. Since priority is only ever sorted and displayed, a
+    uniform positive multiplier cannot reorder anything — a rebuilding
+    roster and a contending roster got the identical ranked order, while
+    the docs claimed the window shaped the recommendation.
+    """
+
+    #: TE upgrades are old, WR upgrades are young. TE has the bigger
+    #: raw gain, so a contender should want TE and a rebuilder WR.
+    CANDS = {
+        "TE": [_p("t1", "TE", 82.0), _p("t2", "TE", 81.0), _p("t3", "TE", 80.0)],
+        "WR": [_p("w1", "WR", 99.0), _p("w2", "WR", 98.5), _p("w3", "WR", 98.0)],
+    }
+    AGES = {"t1": 30.0, "t2": 31.0, "t3": 30.0, "w1": 23.0, "w2": 22.5, "w3": 23.0}
+
+    def _order(self, window):
+        return [
+            t.position
+            for t in rank_target_positions(
+                _roster(),
+                SLOTS,
+                candidates=self.CANDS,
+                window=window,
+                candidate_ages=self.AGES,
+            )
+            if t.viability is TargetViability.VIABLE
+        ]
+
+    def test_window_actually_reorders_positions(self):
+        """The property the old implementation could not deliver."""
+        contender = self._order(_window(championship_contender=1.0))
+        rebuild = self._order(_window(rebuild=1.0))
+        assert contender != rebuild
+        assert contender[0] == "TE"  # bigger upgrade
+        assert rebuild[0] == "WR"  # younger upgrade
+
+    def test_a_global_scalar_could_not_have_done_this(self):
+        """Guards the fix at the level of the mechanism, not the output:
+        if someone reverts to multiplying by a single scalar, the two
+        orders collapse back together and this fails."""
+        orders = {
+            tuple(self._order(_window(**w)))
+            for w in (
+                {"championship_contender": 1.0},
+                {"rebuild": 1.0},
+                {"retool": 0.5, "rebuild": 0.5},
+            )
+        }
+        assert len(orders) > 1
+
+    def test_contender_ignores_age(self):
+        young = horizon_weight(_window(championship_contender=1.0), 22.0)
+        old = horizon_weight(_window(championship_contender=1.0), 32.0)
+        assert young == pytest.approx(old)
+
+    def test_rebuilder_strongly_prefers_youth(self):
+        young = horizon_weight(_window(rebuild=1.0), 22.0)
+        old = horizon_weight(_window(rebuild=1.0), 32.0)
+        assert young > old * 3
+
+    def test_not_applied_without_ages_and_reported_as_none(self):
+        """A field that looks applied and is not is the same false claim
+        in quieter clothing."""
+        res = [
+            t
+            for t in rank_target_positions(
+                _roster(), SLOTS, candidates=self.CANDS, window=_window(rebuild=1.0)
+            )
+            if t.viability is TargetViability.VIABLE
+        ]
+        assert all(t.win_now_weight is None for t in res)
+        assert all(t.to_dict()["winNowWeight"] is None for t in res)
+        assert any("did NOT affect this ranking" in n for n in res[0].notes)
+
+    def test_not_applied_without_a_window(self):
+        assert horizon_weight(None, 25.0) is None
+
+    def test_uses_the_full_distribution(self):
+        decisive = horizon_weight(_window(rebuild=1.0), 30.0)
+        split = horizon_weight(_window(rebuild=0.5, championship_contender=0.5), 30.0)
+        assert decisive != pytest.approx(split)
+
+    def test_limitations_describe_the_per_position_application(self):
+        lim = describe_limitations()
+        assert lim["keyAssumptions"]["windowAppliedPerPosition"] is True
+        note = lim["keyAssumptions"]["windowAppliedPerPositionNote"]
+        assert "global scalar cannot reorder" in note
 
 
 # ══ Gate 2: corroboration ═══════════════════════════════════════════

--- a/tests/roster_intel/test_targets.py
+++ b/tests/roster_intel/test_targets.py
@@ -521,6 +521,54 @@ class TestRosterEngineIntegration:
         assert sig.contend_probability is None
         assert sig.has_window is False
 
+    def test_deficit_identifies_the_weak_position_not_the_concentrated_one(self):
+        """Regression, and the important one.
+
+        This roster is strong at QB (100 vs a 90 starter level) and
+        genuinely thin at TE (20 vs 50). A lone elite QB has fragility
+        1.0 because losing him erases the whole group, so any deficit
+        built from ``fragility x marginal_points`` reports QB as the
+        biggest hole — which would tell the partner model to send a
+        quarterback to a team that already has a good one.
+
+        Deficit must track shortfall below a startable baseline.
+        """
+        from src.roster_intel.partner import RosterSignal
+
+        pool = _roster()
+        profile = build_position_profiles(pool, SLOTS)
+        sig = RosterSignal.from_engine(
+            "owner1",
+            profile=profile,
+            starter_levels={"QB": 90.0, "RB": 55.0, "WR": 55.0, "TE": 50.0},
+        )
+        assert "TE" in sig.deficit
+        assert "QB" not in sig.deficit
+        assert sig.deficit["TE"] == pytest.approx(30.0)
+
+    def test_deficit_is_empty_without_a_startable_baseline(self):
+        """Nothing in a single roster's profile says whether 20 points at
+        TE is bad. Reporting a magnitude anyway would be fabricating
+        calibration, so the honest output is nothing."""
+        from src.roster_intel.partner import RosterSignal
+
+        pool = _roster()
+        profile = build_position_profiles(pool, SLOTS)
+        sig = RosterSignal.from_engine("owner1", profile=profile)
+        assert sig.deficit == {}
+        # Surplus needs no league baseline and is still reported.
+        assert sig.surplus
+
+    def test_uncalibrated_deficit_degrades_need_alignment_to_neutral(self):
+        """The downstream consequence of the honest degradation."""
+        from src.roster_intel.partner import PartnerInputs, RosterSignal, assess_partner
+
+        pool = _roster()
+        profile = build_position_profiles(pool, SLOTS)
+        theirs = RosterSignal.from_engine("them", profile=profile)
+        a = assess_partner(PartnerInputs(owner_id="them", their_roster=theirs))
+        assert a.partner_need_alignment == pytest.approx(0.5)
+
 
 # ══ Serialization + limitations ═════════════════════════════════════
 

--- a/tests/roster_intel/test_targets.py
+++ b/tests/roster_intel/test_targets.py
@@ -1,0 +1,613 @@
+"""Tests for the Target Position and Target Player engines.
+
+The two properties this suite exists to defend, both of which are
+directive constraints rather than nice-to-haves:
+
+1. **The weakest position is not automatically the recommendation.** A
+   position nobody can upgrade is reported as a confirmed weakness and
+   excluded from the ranked targets.
+2. **No player is recommended on market edge alone.** Edge is derived
+   from our own valuation and cannot corroborate itself.
+
+Everything else here is supporting evidence that those two gates are
+real branches rather than score terms that happen to be small.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.replacement import (
+    PositionReplacement,
+    ReplacementLevel,
+    ScarcityComponents,
+)
+from src.roster_intel.profiles import build_position_profiles
+from src.roster_intel.targets import (
+    MIN_CORROBORATING_SIGNALS,
+    MIN_MATERIAL_POINTS,
+    REALISTIC_CANDIDATE_DEPTH,
+    TARGETS_MODEL_VERSION,
+    PlayerTarget,
+    TargetViability,
+    ValueSignal,
+    describe_limitations,
+    rank_target_players,
+    rank_target_positions,
+    win_now_weight,
+)
+from src.roster_intel.window import COMPETITIVE_STATES, CompetitiveWindow, WindowInputs
+from src.ros.lineup import RosterPlayer
+
+SLOTS = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX"]
+
+
+def _p(pid: str, pos: str, value: float, name: str | None = None) -> RosterPlayer:
+    return RosterPlayer(
+        player_id=pid,
+        canonical_name=name or f"{pos} {pid}",
+        position=pos,
+        ros_value=value,
+    )
+
+
+def _roster() -> list[RosterPlayer]:
+    """A roster that is strong at RB/WR and genuinely thin at TE."""
+    return [
+        _p("qb1", "QB", 100.0),
+        _p("rb1", "RB", 90.0),
+        _p("rb2", "RB", 80.0),
+        _p("rb3", "RB", 70.0),
+        _p("wr1", "WR", 95.0),
+        _p("wr2", "WR", 85.0),
+        _p("wr3", "WR", 60.0),
+        _p("te1", "TE", 20.0),
+    ]
+
+
+def _window(**probs: float) -> CompetitiveWindow:
+    full = {s: 0.0 for s in COMPETITIVE_STATES}
+    full.update(probs)
+    total = sum(full.values()) or 1.0
+    full = {k: v / total for k, v in full.items()}
+    return CompetitiveWindow(
+        probabilities=full,
+        inputs=WindowInputs(
+            competitiveness=0.5,
+            trajectory=0.5,
+            competitiveness_source="test",
+            trajectory_sample=8,
+        ),
+        most_likely=max(full, key=lambda k: full[k]),
+    )
+
+
+# ══ Gate 1: obtainability ════════════════════════════════════════════
+
+
+class TestObtainabilityGate:
+    def test_weakest_position_is_not_a_target_when_nobody_can_fix_it(self):
+        """The headline requirement.
+
+        TE is by far the weakest spot on this roster, but every TE on
+        the market is worse than the one already rostered. The engine
+        must report a confirmed weakness and must NOT rank it.
+        """
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={
+                "TE": [_p("fa_te1", "TE", 12.0), _p("fa_te2", "TE", 8.0)],
+            },
+        )
+        te = next(t for t in targets if t.position == "TE")
+        assert te.viability is TargetViability.NO_OBTAINABLE_UPGRADE
+        assert te.priority == 0.0
+        assert "cannot currently be fixed" in te.reason
+
+        viable = [t for t in targets if t.viability is TargetViability.VIABLE]
+        assert "TE" not in {t.position for t in viable}
+
+    def test_a_real_upgrade_does_pass_the_gate(self):
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={"TE": [_p("elite_te", "TE", 88.0), _p("good_te", "TE", 75.0)]},
+        )
+        te = next(t for t in targets if t.position == "TE")
+        assert te.viability is TargetViability.VIABLE
+        assert te.priority > 0
+        assert te.realistic_gain >= MIN_MATERIAL_POINTS
+
+    def test_gain_is_measured_by_resolving_the_lineup_not_by_value(self):
+        """A 200-point QB is worth less to THIS roster than a 60-point
+        TE, because the QB slot is already filled and the TE slot is a
+        hole. Only an actual re-solve can express that."""
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={
+                "QB": [_p("qb_stud", "QB", 200.0)],
+                "TE": [_p("te_ok", "TE", 60.0)],
+            },
+        )
+        by_pos = {t.position: t for t in targets}
+        # QB upgrade replaces a 100 starter -> +100. TE replaces 20 -> +40.
+        assert by_pos["QB"].best_case_gain == pytest.approx(100.0)
+        assert by_pos["TE"].best_case_gain == pytest.approx(40.0)
+
+    def test_trivial_gain_is_rejected_as_immaterial(self):
+        """A strictly-positive test would let every position through and
+        turn the gate back into the ranking it replaced."""
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={"TE": [_p("marginal_te", "TE", 21.0)]},
+        )
+        te = next(t for t in targets if t.position == "TE")
+        assert te.viability is TargetViability.IMMATERIAL_GAIN
+        assert te.best_case_gain == pytest.approx(1.0)
+        assert te.priority == 0.0
+
+    def test_missing_candidates_is_not_measured_not_nothing_available(self):
+        """These are different claims and must never be collapsed."""
+        pool = _roster()
+        targets = rank_target_positions(pool, SLOTS, candidates={"TE": []}, profile=None)
+        te = next(t for t in targets if t.position == "TE")
+        assert te.viability is TargetViability.NO_CANDIDATES
+        assert "not measured" in te.reason
+        assert te.viability is not TargetViability.NO_OBTAINABLE_UPGRADE
+
+    def test_realistic_gain_uses_median_not_best_case(self):
+        """Gating on the best available player is best-case reasoning in
+        a measurement's clothing — every position justifies itself with
+        'if I land the best guy on the market'."""
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={
+                "TE": [
+                    _p("one_stud", "TE", 90.0),
+                    _p("dud_a", "TE", 10.0),
+                    _p("dud_b", "TE", 9.0),
+                ]
+            },
+        )
+        te = next(t for t in targets if t.position == "TE")
+        assert te.best_case_gain == pytest.approx(70.0)
+        # Median of [70, 0, 0] is 0 -> a lottery ticket, not a fixable hole.
+        assert te.realistic_gain == pytest.approx(0.0)
+        assert te.viability is TargetViability.IMMATERIAL_GAIN
+
+    def test_consistent_depth_clears_where_one_stud_does_not(self):
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={
+                "TE": [
+                    _p("te_a", "TE", 80.0),
+                    _p("te_b", "TE", 75.0),
+                    _p("te_c", "TE", 70.0),
+                ]
+            },
+        )
+        te = next(t for t in targets if t.position == "TE")
+        assert te.viability is TargetViability.VIABLE
+        assert te.realistic_gain == pytest.approx(55.0)
+
+    def test_non_viable_positions_are_still_returned_for_display(self):
+        """A caller has to be able to show 'your worst spot is TE and
+        nothing helps' — silently omitting it would be worse than not
+        ranking it."""
+        pool = _roster()
+        targets = rank_target_positions(pool, SLOTS, candidates={"TE": [_p("bad_te", "TE", 5.0)]})
+        assert any(t.position == "TE" for t in targets)
+
+    def test_viable_sort_before_non_viable(self):
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={
+                "TE": [_p("bad", "TE", 1.0)],
+                "QB": [_p("qb_up", "QB", 150.0)],
+            },
+        )
+        assert targets[0].position == "QB"
+        assert targets[0].viability is TargetViability.VIABLE
+        assert targets[-1].viability is not TargetViability.VIABLE
+
+
+# ══ Window consumption ══════════════════════════════════════════════
+
+
+class TestWinNowWeight:
+    def test_uses_the_full_distribution_not_the_argmax(self):
+        """The roster engine reports probabilities precisely so
+        consumers stop collapsing to a label. A near-tie and a decisive
+        read must not produce the same weight."""
+        decisive = _window(retool=0.85, rebuild=0.15)
+        split = _window(retool=0.45, rebuild=0.40, playoff_contender=0.15)
+        assert win_now_weight(decisive) != pytest.approx(win_now_weight(split))
+
+    def test_contender_values_win_now_more_than_rebuilder(self):
+        contender = _window(championship_contender=1.0)
+        rebuilder = _window(rebuild=1.0)
+        assert win_now_weight(contender) > win_now_weight(rebuilder)
+
+    def test_rebuild_is_discounted_not_zeroed(self):
+        """A rebuilder still prefers more points to fewer at equal cost;
+        what changes is the price it should pay."""
+        assert 0.0 < win_now_weight(_window(rebuild=1.0)) < 0.5
+
+    def test_absent_window_is_neutral(self):
+        assert win_now_weight(None) == pytest.approx(1.0)
+
+    def test_window_scales_priority(self):
+        pool = _roster()
+        cands = {"TE": [_p("te_a", "TE", 80.0), _p("te_b", "TE", 78.0), _p("te_c", "TE", 76.0)]}
+        contender = rank_target_positions(
+            pool, SLOTS, candidates=cands, window=_window(championship_contender=1.0)
+        )[0]
+        rebuilder = rank_target_positions(
+            pool, SLOTS, candidates=cands, window=_window(rebuild=1.0)
+        )[0]
+        assert contender.priority > rebuilder.priority
+        # The measured gain is identical; only its worth to us changed.
+        assert contender.realistic_gain == pytest.approx(rebuilder.realistic_gain)
+
+
+# ══ Gate 2: corroboration ═══════════════════════════════════════════
+
+
+class TestCorroborationGate:
+    def test_market_edge_alone_is_rejected(self):
+        """The headline requirement for the player engine.
+
+        This candidate is cheap relative to our valuation and nothing
+        else. That is the model agreeing with itself.
+        """
+        pool = _roster()
+        cand = _p("edge_only", "QB", 30.0)
+        out = rank_target_players(pool, SLOTS, [cand], market_values={"edge_only": 10.0})
+        assert len(out) == 1
+        t = out[0]
+        assert t.recommended is False
+        assert ValueSignal.MARKET_EDGE in t.signals
+        assert t.corroborating == ()
+        assert "agreeing with itself" in t.reason
+
+    def test_edge_plus_one_corroborator_is_admitted(self):
+        pool = _roster()
+        cand = _p("real_te", "TE", 80.0)
+        out = rank_target_players(pool, SLOTS, [cand], market_values={"real_te": 40.0})
+        t = out[0]
+        assert t.recommended is True
+        assert ValueSignal.ROSTER_FIT in t.corroborating
+        assert ValueSignal.MARKET_EDGE in t.signals
+
+    def test_market_edge_is_not_a_corroborating_signal(self):
+        """Structural guarantee, independent of any particular input."""
+        from src.roster_intel.targets import CORROBORATING_SIGNALS
+
+        assert ValueSignal.MARKET_EDGE not in CORROBORATING_SIGNALS
+        assert len(CORROBORATING_SIGNALS) >= 1
+
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            ({"role_scores": {"c": 0.9}}, ValueSignal.ROLE),
+            ({"projection_scores": {"c": 0.9}}, ValueSignal.PROJECTION),
+            ({"availability": {"c": 0.9}}, ValueSignal.AVAILABILITY),
+        ],
+    )
+    def test_each_external_signal_can_carry_the_gate(self, kwargs, expected):
+        """Each corroborator is independently sufficient, so a player
+        with no lineup fit can still be a legitimate target on external
+        evidence."""
+        pool = _roster()
+        cand = _p("c", "WR", 30.0)
+        out = rank_target_players(pool, SLOTS, [cand], **kwargs)
+        t = out[0]
+        assert t.recommended is True
+        assert expected in t.corroborating
+
+    def test_scarcity_corroborates_only_when_genuinely_scarce(self):
+        pool = _roster()
+        cand = _p("c", "TE", 25.0)
+        scarce = ScarcityComponents(
+            position="TE",
+            lineup_scarcity=None,
+            roster_scarcity=None,
+            waiver_scarcity=0.9,
+            elite_separation=None,
+            starter_separation=None,
+            replacement_gap=None,
+        )
+        plentiful = ScarcityComponents(
+            position="TE",
+            lineup_scarcity=None,
+            roster_scarcity=None,
+            waiver_scarcity=0.1,
+            elite_separation=None,
+            starter_separation=None,
+            replacement_gap=None,
+        )
+        assert rank_target_players(pool, SLOTS, [cand], scarcity={"TE": scarce})[0].recommended
+        assert not rank_target_players(pool, SLOTS, [cand], scarcity={"TE": plentiful})[
+            0
+        ].recommended
+
+    def test_no_signal_at_all_is_rejected_with_a_distinct_reason(self):
+        """'Nothing to recommend' must read differently from 'edge
+        only' — they are different failures."""
+        pool = _roster()
+        cand = _p("nobody", "WR", 5.0)
+        t = rank_target_players(pool, SLOTS, [cand])[0]
+        assert t.recommended is False
+        assert "no admissible value signal" in t.reason
+
+    def test_gate_threshold_is_honoured(self):
+        pool = _roster()
+        cand = _p("real_te", "TE", 80.0)
+        strict = rank_target_players(
+            pool, SLOTS, [cand], market_values={"real_te": 40.0}, min_corroborating=2
+        )[0]
+        assert strict.recommended is False
+        assert len(strict.corroborating) < 2
+
+    def test_rejected_candidates_are_returned_not_dropped(self):
+        pool = _roster()
+        out = rank_target_players(
+            pool,
+            SLOTS,
+            [_p("good", "TE", 80.0), _p("edge_only", "QB", 30.0)],
+            market_values={"edge_only": 10.0, "good": 50.0},
+        )
+        assert len(out) == 2
+        assert out[0].recommended is True
+        assert out[-1].recommended is False
+
+
+# ══ Ranking behaviour ═══════════════════════════════════════════════
+
+
+class TestRanking:
+    def test_confidence_reduces_priority(self):
+        """Same measured gain, less supplied evidence, lower rank —
+        matching the partner model's treatment of confidence."""
+        pool = _roster()
+        cands = {"TE": [_p("a", "TE", 80.0), _p("b", "TE", 78.0), _p("c", "TE", 76.0)]}
+        bare = rank_target_positions(pool, SLOTS, candidates=cands)[0]
+        rich = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates=cands,
+            window=_window(championship_contender=1.0),
+            scarcity={
+                "TE": ScarcityComponents(
+                    position="TE",
+                    lineup_scarcity=None,
+                    roster_scarcity=None,
+                    waiver_scarcity=0.5,
+                    elite_separation=None,
+                    starter_separation=None,
+                    replacement_gap=None,
+                )
+            },
+        )[0]
+        assert rich.confidence > bare.confidence
+
+    def test_thin_candidate_sample_is_flagged_and_discounted(self):
+        pool = _roster()
+        thin = rank_target_positions(pool, SLOTS, candidates={"TE": [_p("a", "TE", 80.0)]})[0]
+        assert any("thin sample" in n for n in thin.notes)
+        assert thin.candidates_tested < REALISTIC_CANDIDATE_DEPTH
+
+    def test_positions_ranked_by_priority_descending(self):
+        pool = _roster()
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            candidates={
+                "TE": [_p("t1", "TE", 80.0), _p("t2", "TE", 79.0), _p("t3", "TE", 78.0)],
+                "WR": [_p("w1", "WR", 97.0), _p("w2", "WR", 96.0), _p("w3", "WR", 96.0)],
+            },
+        )
+        viable = [t for t in targets if t.viability is TargetViability.VIABLE]
+        assert [t.priority for t in viable] == sorted([t.priority for t in viable], reverse=True)
+        # TE is the bigger hole and should win on measured gain.
+        assert viable[0].position == "TE"
+
+    def test_ranking_is_deterministic(self):
+        pool = _roster()
+        cands = {"TE": [_p("a", "TE", 80.0), _p("b", "TE", 80.0), _p("c", "TE", 80.0)]}
+        first = [t.to_dict() for t in rank_target_positions(pool, SLOTS, candidates=cands)]
+        second = [t.to_dict() for t in rank_target_positions(pool, SLOTS, candidates=cands)]
+        assert first == second
+
+    def test_player_priority_anchors_on_measured_points(self):
+        """Edge adjusts, it does not drive. A player with a huge edge
+        but no lineup impact must not outrank a real upgrade."""
+        pool = _roster()
+        out = rank_target_players(
+            pool,
+            SLOTS,
+            [
+                _p("big_upgrade", "TE", 85.0),
+                _p("cheap_bench", "WR", 30.0),
+            ],
+            market_values={"big_upgrade": 84.0, "cheap_bench": 3.0},
+            role_scores={"cheap_bench": 0.9},
+        )
+        rec = [t for t in out if t.recommended]
+        assert rec[0].player_id == "big_upgrade"
+
+
+# ══ Integration with the roster engine ══════════════════════════════
+
+
+class TestRosterEngineIntegration:
+    def test_consumes_a_real_roster_profile(self):
+        """Uses the roster engine's own builder rather than a hand-made
+        stand-in, so a shape change upstream fails here."""
+        pool = _roster()
+        replacement = {
+            "TE": PositionReplacement(
+                position="TE",
+                starters_per_team=1.0,
+                rostered_count=12,
+                levels={
+                    "starter": ReplacementLevel(
+                        position="TE",
+                        tier="starter",
+                        value=50.0,
+                        threshold_rank=12,
+                        band_low=45.0,
+                        band_high=55.0,
+                        sample_size=24,
+                    )
+                },
+            )
+        }
+        profile = build_position_profiles(pool, SLOTS, replacement=replacement)
+        targets = rank_target_positions(
+            pool,
+            SLOTS,
+            profile=profile,
+            candidates={"TE": [_p("up", "TE", 80.0), _p("up2", "TE", 78.0), _p("up3", "TE", 76.0)]},
+            replacement=replacement,
+            market_prices={"TE": 60.0},
+        )
+        te = next(t for t in targets if t.position == "TE")
+        assert te.viability is TargetViability.VIABLE
+        assert te.market_efficiency is not None
+        assert te.severity >= 0.0
+
+    def test_flex_is_never_reported_as_a_target_position(self):
+        """The roster engine deliberately does not attribute FLEX /
+        SUPER_FLEX to any position because who fills them is
+        endogenous. Inventing a FLEX target would reintroduce exactly
+        the even-split assumption that was measured wrong."""
+        pool = _roster()
+        profile = build_position_profiles(pool, SLOTS)
+        targets = rank_target_positions(pool, SLOTS, profile=profile)
+        positions = {t.position for t in targets}
+        assert not positions & {"FLEX", "SUPER_FLEX", "IDP_FLEX", "BN"}
+
+    def test_partner_signal_bridges_from_engine_output(self):
+        from src.roster_intel.partner import RosterSignal
+
+        pool = _roster()
+        profile = build_position_profiles(pool, SLOTS)
+        window = _window(championship_contender=0.6, playoff_contender=0.2, rebuild=0.2)
+        sig = RosterSignal.from_engine("owner1", profile=profile, window=window)
+        assert sig.owner_id == "owner1"
+        assert sig.contend_probability == pytest.approx(0.8)
+        assert not set(sig.surplus) & {"FLEX", "SUPER_FLEX", "BN"}
+
+    def test_partner_signal_degrades_without_engine_output(self):
+        from src.roster_intel.partner import RosterSignal
+
+        sig = RosterSignal.from_engine("owner1")
+        assert sig.surplus == {}
+        assert sig.deficit == {}
+        assert sig.contend_probability is None
+        assert sig.has_window is False
+
+
+# ══ Serialization + limitations ═════════════════════════════════════
+
+
+class TestSerialization:
+    def test_position_target_round_trips(self):
+        pool = _roster()
+        d = rank_target_positions(pool, SLOTS, candidates={"TE": [_p("a", "TE", 80.0)]})[
+            0
+        ].to_dict()
+        for key in ("position", "viability", "reason", "realisticGain", "priority", "modelVersion"):
+            assert key in d
+        assert d["modelVersion"] == TARGETS_MODEL_VERSION
+
+    def test_player_target_exposes_its_signals(self):
+        pool = _roster()
+        d = rank_target_players(pool, SLOTS, [_p("a", "TE", 80.0)])[0].to_dict()
+        assert d["recommended"] is True
+        assert "rosterFit" in d["corroborating"]
+        assert "marketEdge" not in d["corroborating"]
+
+    def test_rejection_reason_is_always_populated(self):
+        pool = _roster()
+        for t in rank_target_players(pool, SLOTS, [_p("x", "WR", 1.0)]):
+            assert t.reason
+
+
+class TestLimitationsDeliverable:
+    def test_declares_the_current_season_scope(self):
+        lim = describe_limitations()
+        blob = " ".join(lim["cannotSupport"]).lower()
+        assert "rebuild" in blob
+        assert "rest-of-season" in blob
+
+    def test_declares_it_does_not_price_cost(self):
+        lim = describe_limitations()
+        assert any("cost" in s.lower() for s in lim["cannotSupport"])
+
+    def test_declares_the_materiality_floor_as_an_assumption(self):
+        lim = describe_limitations()
+        assert lim["keyAssumptions"]["materialityFloorIsMeasured"] is False
+        assert lim["keyAssumptions"]["materialityFloorPoints"] == MIN_MATERIAL_POINTS
+
+    def test_declares_median_not_max(self):
+        lim = describe_limitations()
+        assert lim["keyAssumptions"]["realisticGainIsMedianNotMax"] is True
+
+    def test_gate_constant_matches_the_code(self):
+        lim = describe_limitations()
+        assert lim["keyAssumptions"]["minCorroboratingSignals"] == MIN_CORROBORATING_SIGNALS
+
+    def test_not_measured_distinction_is_documented(self):
+        lim = describe_limitations()
+        assert any("nothing available" in s for s in lim["cannotSupport"])
+
+
+class TestPurity:
+    def test_no_io_in_the_module(self):
+        import inspect
+
+        from src.roster_intel import targets
+
+        src = inspect.getsource(targets)
+        for forbidden in ("import requests", "open(", "datetime.now", "os.getenv"):
+            assert forbidden not in src, f"{forbidden} found — module must stay pure"
+
+    def test_does_not_depend_on_the_pre_fix_trade_engines(self):
+        """src/trade/finder.py was returning offense-only results until
+        recently (the KTC top-150 filter excluded every IDP defender).
+        This engine measures lineup impact directly and must not inherit
+        that bug by consuming those outputs."""
+        import inspect
+
+        from src.roster_intel import targets
+
+        assert "src.trade" not in inspect.getsource(targets)
+
+    def test_inputs_are_not_mutated(self):
+        pool = _roster()
+        before = [(p.player_id, p.ros_value) for p in pool]
+        rank_target_positions(pool, SLOTS, candidates={"TE": [_p("a", "TE", 80.0)]})
+        rank_target_players(pool, SLOTS, [_p("a", "TE", 80.0)])
+        assert [(p.player_id, p.ros_value) for p in pool] == before
+        assert len(pool) == 8
+
+
+def test_player_target_is_frozen():
+    t = PlayerTarget(player_id="x", name="X", position="WR", recommended=False, reason="r")
+    with pytest.raises(Exception):
+        t.recommended = True  # type: ignore[misc]


### PR DESCRIPTION
The trade half of WS-J. Consumes the roster engine from **#562** and answers *what to do about* a roster: which positions are worth attacking, which players are worth pursuing, how a given counterparty is likely to receive an offer, and which concrete packages are worth putting in front of them.

Valuation runs through `src/league_intel/cross_market.py`'s `value_package` / `compare_packages` — **single-market, exact, no fitted conversion**. Deliberately **not** through `src/trade/finder.py`, which was offense-only (that is #556's finding, and the reason a defender never reached the finder's arithmetic).

Scoped footprint: **10 files, +5,969 / −1**.

---

## Stack position and the divergence you need to know about

`#550 → #562 → this PR`.

**These two branches were a clean superset at the start of the session and are not any more.** `claude/ws-j-partner-fit` forked from `claude/ws-j-roster-intel` at `14d41f69`. Roster-intel has since gained three commits **not** in this branch:

| Commit | What it adds |
|---|---|
| `0cf29560` | `src/roster_intel/engine.py` — `analyze_roster()` rollup + `playoff_sim` wiring |
| `e6eb0c92` | Names the simulator's schema gaps instead of degrading to `None` |
| `b58aa48b` | Feeds the livedata fixture the eligibility index and ages it was starving |

**What conflicts when this lands.** Nothing textually — those commits add `engine.py`, which this branch does not have. The real coupling is semantic: `b58aa48b` changes what the competitive window produces on real data (trajectory goes from a pinned 0.500 to a 0.196–0.684 spread; the window reaches 5 states instead of 4). **The target engine in this PR consumes that window.** Its ranked output on live rosters will change once #562's head is merged in — the code is correct either way, but any output snapshot taken from this branch alone was taken against a starved trajectory axis.

## Brought up to date, and one live semantic change

**`main` merged in at `7671c9dd`, zero conflicts.** This also **deletes `.github/workflows/grant-ssh-access.yml`**, which matters: `main` removed it in `c534280d`, this branch still carried it, and `docs/ORCHESTRATION.md` is explicit that it *must* be deleted — it is a dispatch-only path to a production shell. Before this merge, landing this branch would have **resurrected** it.

**`claude/league-intel-foundation` merged in at `c8cd5179`, zero conflicts** — and this one is textually clean but semantically live. `928a1fa8` makes `allow_scalar_fallback` a **real** flag in `cross_market.py`; it was previously declared and never read, so a caller that opted out of scalar conversion silently got converted totals anyway.

This branch is that caller — `packages.py:502` passes the flag through and `generate_packages` defaults it to `False`. Measured directly rather than inferred from the diff, same mixed offense/IDP package:

```
allow_scalar_fallback=True   ->  total = 6605.5  (market: idpTradeCalc)
allow_scalar_fallback=False  ->  total = None    (unvaluable)
```

So packages needing a cross-market conversion are now **rejected as `UNVALUABLE` instead of ranked on a converted total** — the direction ADR-010's materiality gate intends, and what the caller was already asking for.

> **For the reviewer:** `tests/roster_intel/test_packages.py` is **47/47 green both before and after** that merge, which means the existing tests do not exercise a package needing conversion under the default flag. The behaviour change is real and currently **uncovered**. That gap is worth closing before this ships.

---

## What is here

| Module | What it does |
|---|---|
| `src/league_intel/cross_market.py` | `value_package` / `compare_packages` — every package priced entirely within one market (offense-only → `ktcSfTep`; anything with IDP → `idpTradeCalc`), plus the boundary-proximity suppression rule |
| `partner.py` | Partner fit + acceptance model, two-sided need alignment, pair familiarity |
| `targets.py` | Target Position and Target Player engines |
| `packages.py` | Trade Package Generator — staged search, Pareto frontier |
| `docs/…/DECISIONS.md` | **ADR-012** (new, this PR) |

Generation is **staged, not brute force**: 1-for-1 from a pre-filtered seed set → 2-for-1 / 1-for-2 expanding *only* near-misses → 2-for-2 from stage-2 near-misses. A package that already succeeded is never expanded, because the simpler version dominates it by construction. Cheap filters run before expensive ones, so the exact lineup re-solve never runs on a package already going to be rejected.

---

## Five things a reader would otherwise assume are stronger than they are

**1. `winNowWeight` reports `null` and is genuinely not applied when candidate ages are unavailable.**
`horizon_weight(window, mean_age)` returns `None` when there is no window *or* no age data for that position's candidates. `None` means **the term did not apply**. The caller sets `window_mult = 1.0` and, when a window was supplied but ages were not, appends an explicit note: *"competitive window supplied but no candidate ages — the window weight is per-position by age and could not be computed, so it did NOT affect this ranking."* The field serializes as `winNowWeight: null`.

Stamping the old global scalar there instead would have reproduced the original defect one layer down — a number that looks applied, is reported as applied, and changes nothing. **`winNowWeight` is not safe to sort or filter on**: it is `null` on exactly the rows missing age data, which is not a random subset (rookies and recent adds are likelier to be missing). Read `priority` for ordering and `notes` for whether the window participated. Recorded as **ADR-012**, added in this PR.

**2. The Pareto frontier comes out wide, and that is structural, not a bug.**
`value_efficiency` and `acceptance_plausibility` are **anti-correlated by construction** — `market_gain_pct` is *our* gain, so a genuine overpay to them is a loss to us. Two of the four axes therefore move in opposite directions almost by definition. For **1-for-1 packages nearly everything is Pareto-optimal**, and frontiers come out long.

A caller expecting a short list should expect the opposite, and should not read frontier length as a quality signal. `label_frontier()` names which axis each member wins on precisely so the set reads as *alternatives* rather than a ranking. There is deliberately no blended score: an exchange rate between market points, lineup points and plausibility does not exist, and inventing one silently encodes a preference as a measurement.

**3. Cornerstone detection needs rank AND share, and reads the partner's full roster.**
Top-N rank alone made **every asset in a short pool a cornerstone** — including a 2,200-value bench receiver sitting beside a genuine stud. Detection now requires top-`CORNERSTONE_TOP_N` (3) **and** ≥ `CORNERSTONE_VALUE_SHARE` (0.60) of the roster's best asset.

It is also derived from the partner's **full roster** when we have it, not from the subset of their players we happen to want — deriving it from the subset would let the asset we are asking for define its own peer group.

**4. The fifth rejection rule is an addition beyond the original spec.**
The directive specified four: illegal roster, worsens a critical need, unvaluable / verdict-uncertain, cornerstone without premium. `DOMINATED_BY_NO_TRADE` is a **fifth rule added here, not part of that spec.**

Its argument: the simplest package of all is no package, and it is always available. A trade that loses market value **and** loses lineup points is dominated by declining to trade, so high acceptance plausibility cannot rescue it — plausibility measures how the *partner* receives the offer, and being easy to give away is not a reason to give something away. Treat it as a proposal, not a spec item already agreed.

**5. The field is `acceptancePlausibility`, never `acceptanceProbability`.**
**We never observe a rejection.** There is no record of declined offers anywhere in this repo, so there is nothing to calibrate against. It is a plausibility score wearing probability units, and every package carries that caveat. `describe_limitations()` states that no output may be rendered as *"manager X will accept this"*, and the tests assert it.

The same gap is why `maxPackageAssets`, `nearMissPct`, `cornerstonePremiumPct` and `cornerstoneTopN` are all stamped `thresholdsAreMeasured: False` — assumed, not fitted.

## Other honest limits, from `describe_limitations()`

- **Search is not exhaustive.** Generation is staged and budgeted; the frontier is valid for what was explored, not proven globally optimal.
- Packages beyond the asset cap are out of scope — a deal needing three pieces per side to balance is negotiated, not generated.
- Lineup improvement is **rest-of-season only**; no multi-year or rebuild framing.
- ADR-012's six constants (`_WIN_NOW_WEIGHTS`, `_STATE_FUTURE_ORIENTATION`, `_AGE_YOUNG`/`_AGE_OLD`, `_FUTURE_AGE_FLOOR`, `_FUTURE_AGE_SPAN`) are judgement calls. The *directional* claim — a rebuilder should prefer young acquisitions, a contender should not care — is first-principles; the magnitudes are not measured.

---

## Not implemented

Stated explicitly because the governing directive said not to silently omit requirements.

- **Continuous Improvement System — nothing in this PR.** No champion–challenger infrastructure, no promotion gate, no historical backtesting, no monitoring, no recalibration schedule. **Owned by another agent on its own branch off `main` and actively being built** — not orphaned, and nothing here should be read as a claim it will not exist.
- **Trade Opportunity Engine** as a distinct module. `suggestions.py` / `finder.py` are the pre-existing engines; nothing new was written against the directive's opportunity-engine spec.
- **No API endpoint and no UI.** `src/roster_intel/` is imported by **nothing** outside its own package and its tests — not `server.py`, not `src/api/`, not `src/trade/`, not `frontend/`. Everything here is reachable only from Python. The `/gameplan` surface does not exist.
- **`src/trade/angle.py` is not rewired.** This is the one that matters most. ADR-010 built the single-market path and `packages.py` uses it, but `angle.py::_make_candidate` still sums market values across a combo never constrained to one market — on the offer side (`:378-388`, `:471-478`, `:526`) and the acquire side (`:913`). **That is the live, user-reachable call site and it is untouched by this PR.** Per the audit, the genuinely reachable shape is the offer side, which has no IDP gate at all.
- Trade explanation / pitch surface; user controls; admin review tools.
- `categories_rescored` ROS projections — blocked upstream on a projection source publishing raw per-category numbers.
- **`SHARED_SCALE_ASSUMPTION` is unvalidated and load-bearing.** The two boards interleave (n=475 paired, median ratio 1.000, p10 0.888 / p90 1.054), which establishes *coherence*. It does not establish that IDPTC's internal offense↔IDP exchange rate is *correct*. There is no ground truth for what an edge rusher is worth in WR points, and nothing here supplies one.

---

## Validation

Reported as a comment on this PR with real numbers, including anything red. `python -m ruff check src/roster_intel src/league_intel/cross_market.py` — clean on ruff 0.6.9 (the CI pin).

No frontend file is touched by this branch, so Redesign R3 (#551) has no surface here. Zero conflicts is not evidence a build passes, which is why the suite was run rather than inferred.

## Merge order

`#550` → `#562` → merge #562's head into this branch → this PR.