### PR TITLE
WS-J: Continuous Improvement System — the weekly refit rewrites production valuation constants with no check at all

### DIFF
--- a/config/model_registry/hill_scope_masters.json
+++ b/config/model_registry/hill_scope_masters.json
@@ -1,0 +1,80 @@
+{
+  "modelId": "hill_scope_masters",
+  "schemaVersion": 1,
+  "updatedAt": "2026-07-26T20:14:13.272875+00:00",
+  "championVersion": 1,
+  "versions": [
+    {
+      "modelId": "hill_scope_masters",
+      "version": 1,
+      "params": {
+        "HILL_GLOBAL_PERCENTILE_C": 0.113,
+        "HILL_GLOBAL_PERCENTILE_S": 0.87,
+        "HILL_PERCENTILE_C": 0.118,
+        "HILL_PERCENTILE_S": 1.17,
+        "IDP_HILL_PERCENTILE_C": 0.093,
+        "IDP_HILL_PERCENTILE_S": 0.97,
+        "HILL_ROOKIE_PERCENTILE_C": 0.128,
+        "HILL_ROOKIE_PERCENTILE_S": 0.865
+      },
+      "fittedAt": "unknown",
+      "producer": "seeded from committed constants in player_valuation.py",
+      "status": "champion",
+      "trainingInputs": {
+        "DraftSharks": "sha256:c37dc3fb4b127a2d",
+        "DynastyDaddy": "sha256:5b9d328ae8f51887",
+        "DynastyNerds": "sha256:f155042eb4257334",
+        "Fitzmaurice": "sha256:caf3ef4823ffcaf8",
+        "KTC": "sha256:4c4cabe5385d0822",
+        "YahooBoone": "sha256:8687353a0fcbb9ee"
+      },
+      "holdout": {
+        "criterion": 849.8254,
+        "criterionName": "mean_per_source_rmse",
+        "criterionUnits": "points on the 0-9999 value scale (lower is better)",
+        "perSource": {
+          "FantasyCalc": 852.6106,
+          "FantasyNavigator": 1185.153,
+          "OTCFFB": 1104.867,
+          "PFKDynasty": 256.6712
+        },
+        "perSourceRows": {
+          "FantasyCalc": 399,
+          "FantasyNavigator": 400,
+          "OTCFFB": 400,
+          "PFKDynasty": 400
+        },
+        "skipped": {},
+        "params": {
+          "c": 0.118,
+          "s": 1.17
+        },
+        "holdoutSources": [
+          "FantasyCalc",
+          "FantasyNavigator",
+          "OTCFFB",
+          "PFKDynasty"
+        ],
+        "trainingSources": [
+          "DraftSharks",
+          "DynastyDaddy",
+          "DynastyNerds",
+          "Fitzmaurice",
+          "KTC",
+          "YahooBoone"
+        ],
+        "_semantics": {
+          "measures": "generalization across dynasty markets \u2014 whether a curve fitted to the training boards also describes boards it never saw",
+          "doesNotMeasure": "accuracy against reality; every holdout board is another consensus market correlated with the training boards, and no ground truth for dynasty value exists"
+        }
+      },
+      "qualified": true,
+      "confidence": "measured",
+      "notes": [
+        "seeded, not validated: these constants were live before the registry existed and carry no out-of-sample score"
+      ],
+      "promotedAt": "2026-07-26T20:14:13.267338+00:00",
+      "retiredAt": null
+    }
+  ]
+}

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -78,6 +78,41 @@ surfaced only because a test asserted confidence should rise and it
 didn't. **Write the test that fails if the mechanism is disconnected**,
 not just the test that passes when it works.
 
+**A named failure mode: an underfed fixture is indistinguishable from a
+collapsed metric.** When a metric reads constant across every real
+subject, there are two candidate explanations and they look identical
+from the outside — the metric collapsed, or the harness never supplied
+the input the metric needs. Check the second one first; it is cheaper
+to rule out and, in this repo, has been the answer.
+
+WS-J measured the competitive window across the 12 real rosters and
+found the trajectory axis pinned at exactly 0.500 for every team, with
+`productive_struggle` the most-likely state for none of them. That
+reads as a broken classifier. It was a starved fixture: the test joined
+rosters to the ROS aggregate, which carries no ages, while
+`data/public_league/nfl_players_full.json` had been sitting in the repo
+the whole time with 10,954 ages and 11,866 `fantasy_positions` entries.
+Joining it moved trajectory to 0.196–0.684 and the window to all five
+states. The first report went out claiming "no committed artifact
+carries ages" — a data-gap finding that was really a harness bug, and
+the more damaging error of the two because it would have sent someone
+to build an ingestion path for data already present.
+
+The `_positional_coverage` incident (100.00 for all 12 teams) is the
+same shape from the other direction, which is exactly why the two
+cannot be told apart by staring at the output. **Before reporting a
+constant as a finding, prove the metric was fed** — assert the input
+coverage the fixture achieved, not just the output it produced.
+
+The inverse has teeth too: **a state that can never fire looks exactly
+like a state that never happens.** `productive_struggle` was not rare
+on this league, it was unreachable — one axis being inert made a whole
+category structurally impossible, and no amount of staring at the
+distribution would have shown that, because the other four states
+summed to 1.0 and looked plausible. When a category never appears, ask
+whether it *can* appear before concluding anything about the world.
+The same logic condemned LI-7's `projection_corroborated` above.
+
 A third form: the fix that reads correctly but cannot take effect. R3's
 mobile-order restoration was **inert on first write** — a media query adds
 no specificity, so `.col{display:contents}` inside `@media` and a bare

--- a/docs/roster-trade-intelligence/DECISIONS.md
+++ b/docs/roster-trade-intelligence/DECISIONS.md
@@ -32,7 +32,8 @@ No human sees the diff. That is the "model autonomously rewriting
 production code" the directive prohibits, and the prohibition is not
 academic: the constants determine every displayed value on the board.
 
-**The guard cannot fail.** Two independent reasons, either sufficient:
+**The guard cannot fail.** Three independent reasons, any one
+sufficient:
 
 * *The pins are recomputed from the challenger.*
   `rebaseline_ktc_reconciliation` computes `ours = _hill(p, c_new,
@@ -51,6 +52,14 @@ academic: the constants determine every displayed value on the board.
   `percentile_to_value` uses and the test evaluates. Scoring a fit
   against its own training data is ORCHESTRATION.md §2b: the
   assumption reflected back.
+* *The guard is not even run.* `tests/conftest.py` auto-marks
+  `test_ktc_reconciliation.py` as `livedata`, and the refit workflow's
+  regression step is `pytest tests/ -q -m "not livedata"`. Verified:
+  that command deselects all 13 of the guard's tests. The refit
+  rewrites the guard's expectations and then skips the guard.
+
+So the constants reach production, and trigger a deploy, with no check
+of any kind — not a weak check, none.
 
 The repo already half-knew this. The workflow's own comment says the
 pins "are REWRITTEN by this very refit — so gating the refit commit on
@@ -168,7 +177,9 @@ The minimal follow-up, for review as its own change:
 5. Commit **only** `config/model_registry/*.json`. Production constants
    move solely via `promote` + `apply`, run by a human.
 
-That removes both halves of the defect: the constants stop being
-rewritten unreviewed, and the guard stops being rewritten at all.
+That removes all three defects: the constants stop being rewritten
+unreviewed, the guard stops being rewritten at all, and the gate that
+does run is one the fit never saw — so `-m "not livedata"` no longer
+skips the only thing checking it.
 
 **Status:** accepted 2026-07-26; implementation in `src/model_registry/`.

--- a/docs/roster-trade-intelligence/DECISIONS.md
+++ b/docs/roster-trade-intelligence/DECISIONS.md
@@ -127,18 +127,62 @@ The live OFFENSE master (`c=0.118, s=1.17`) scores **849.8** on the
 held-out criterion — FantasyCalc 852.6, FantasyNavigator 1185.2,
 OTCFFB 1104.9, PFKDynasty 256.7.
 
-A curve at `c=0.098` scores **648.2** on the same boards. **The live
-champion is not at the holdout optimum, and the gap is ~200 points.**
-This is reported, not acted on: changing it is a live valuation change
-requiring its own verification of downstream effects, and this
-workstream's constraint was explicitly not to fold that in. Scoped as
-follow-up work.
+The training and holdout objectives **disagree in direction**: moving
+to `s=1.37` makes the training mean worse (774.4 → 796.8) while making
+the holdout mean better (849.8 → 758.2). A rubber stamp cannot
+disagree with what it stamps, so this is the evidence that the gate is
+real.
 
-Note also that the training and holdout objectives *disagree in
-direction* — moving to `s=1.37` makes the training mean worse
-(774 → 797) while making the holdout mean better (850 → 758). That
-disagreement is the evidence that the gate is not a rubber stamp for
-the fit.
+**The champion is off the mean-holdout optimum — but the claim must be
+stated narrowly.** A first pass recorded "~200 points off optimum at
+`c=0.098`". Re-measuring per board rather than on the mean showed that
+figure to be both too strong and too specific, so it is corrected here
+rather than quietly dropped:
+
+| board | role | RMSE @ champion | best on grid | best `c` |
+|---|---|---|---|---|
+| FantasyCalc | holdout | 852.6 | 321.2 | 0.080 |
+| FantasyNavigator | holdout | 1185.2 | 401.5 | 0.080 |
+| OTCFFB | holdout | 1104.9 | 395.8 | 0.080 |
+| PFKDynasty | holdout | 256.7 | 240.3 | 0.112 |
+| KTC | train | 816.6 | 172.6 | 0.144 |
+| Fitzmaurice | train | 1116.3 | 514.8 | 0.180 |
+| DynastyNerds | train | 1026.2 | 257.4 | 0.096 |
+| DraftSharks | train | 683.2 | 359.5 | 0.080 |
+
+Three findings follow, and the first two disqualify the original claim:
+
+1. **The holdout boards do not agree.** At `c=0.098`, three improve by
+   287–304 points and PFKDynasty gets **worse** by 80.5. PFKDynasty is
+   also the board the champion already fits best — 256.7 against a
+   best-possible 240.3, i.e. the live curve is within ~16 points of
+   *that* board's optimum. The mean improvement is three boards
+   outvoting one, not a consensus.
+2. **The mean-holdout "optimum" is a boundary solution.** Three of four
+   holdout boards bottom out at `c=0.080`, the edge of the search grid,
+   so the grid does not bracket a minimum. Reporting `c=0.098` as "the
+   optimum" was wrong: it is merely a point that scores better than the
+   champion.
+3. **The training boards disagree at least as much** (KTC wants 0.144,
+   Fitzmaurice 0.180, DraftSharks 0.080). The champion at 0.118 sits
+   near the training mean optimum (`c=0.104, s=1.15`, 750.8 vs the
+   champion's 774.4) and far from the holdout mean optimum. That is
+   consistent with the fit tracking its own sources — which is what a
+   holdout is for.
+
+**What is and is not supported.** Supported: *the mean criterion over
+these four boards improves substantially at lower `c`, driven by three
+of them.* Not supported: *the champion is wrong.* The holdout boards
+may share a curve shape the fit sources do not, in which case the
+"optimum" moves with that shared bias rather than toward accuracy.
+Distinguishing the two needs evidence outside all ten boards, and none
+exists here — the same limit already stated for the criterion itself.
+
+**Nothing is acted on.** `src/canonical/player_valuation.py` is
+byte-identical on this branch, and `model_registry.py apply --dry-run`
+reports the shipped champion already matches the live constants (exit
+1, no change). Any curve change is a live valuation change requiring
+its own downstream verification and is explicitly out of scope here.
 
 ### Not implemented, and why
 

--- a/docs/roster-trade-intelligence/DECISIONS.md
+++ b/docs/roster-trade-intelligence/DECISIONS.md
@@ -1,0 +1,174 @@
+# Roster & Trade Intelligence (WS-J) — Architecture Decision Records
+
+Numbering continues the League Intelligence series in
+`docs/league-intelligence/DECISIONS.md` (ADR-001..007) so a reference
+like "ADR-008" is unambiguous across both workstreams.
+
+---
+
+## ADR-008: Continuous Improvement — the refit is gated, not trusted
+
+**Directive clause.** *"Do not allow a model to autonomously rewrite
+production code. Use controlled retraining, champion–challenger
+validation, model versioning, and rollback. Do not present
+low-confidence output as precise."*
+
+### Finding: what the refit path actually does today
+
+`.github/workflows/refit-hill-curves.yml` runs weekly (Tue 06:17 UTC).
+On drift above 50 RMSE points it invokes
+`scripts/auto_refit_hill_curves.py`, which:
+
+1. rewrites the eight `HILL_*_C/S` constants in
+   `src/canonical/player_valuation.py` — the live valuation path,
+   step 3 of the Final Framework;
+2. rewrites `PINNED_DELTAS` in
+   `tests/canonical/test_ktc_reconciliation.py`, the only test that
+   guards those constants;
+3. runs `pytest -m "not livedata"`;
+4. commits and pushes to `main`, which triggers `deploy.yml`.
+
+No human sees the diff. That is the "model autonomously rewriting
+production code" the directive prohibits, and the prohibition is not
+academic: the constants determine every displayed value on the board.
+
+**The guard cannot fail.** Two independent reasons, either sufficient:
+
+* *The pins are recomputed from the challenger.*
+  `rebaseline_ktc_reconciliation` computes `ours = _hill(p, c_new,
+  s_new)` and writes it as the test's `pinned_ours`, then computes
+  `pct_diff` from that same `ours` against the same `ktc.csv` the test
+  reads. Both of the test's assertions — the exact
+  `ours == pinned_ours` pin and the `abs(actual_pct - pinned_pct) <=
+  tolerance_pp` band — therefore have a zero residual by construction,
+  for *any* curve. Verified in
+  `tests/model_registry/test_refit_path_characterisation.py` by running
+  the rebaseline arithmetic for `(c=0.118, s=1.17)` and `(c=0.300,
+  s=2.50)`: both pass every pinned rank.
+* *KTC is a training source.* `ktc.csv` is in
+  `fit_hill_curve_percentile.OFFENSE_SOURCES`, which fits
+  `HILL_PERCENTILE_C/S` — precisely the constants
+  `percentile_to_value` uses and the test evaluates. Scoring a fit
+  against its own training data is ORCHESTRATION.md §2b: the
+  assumption reflected back.
+
+The repo already half-knew this. The workflow's own comment says the
+pins "are REWRITTEN by this very refit — so gating the refit commit on
+them is circular", and uses it to justify *excluding* them from the
+blocking gate. The conclusion drawn was "don't gate on the circular
+check". The conclusion available was "the check is circular; build one
+that isn't".
+
+### Decision
+
+A refit produces a **challenger**, never a champion. Promotion is a
+separate, recorded act gated on a criterion the fit never saw.
+
+**Held-out criterion.** Mean per-source RMSE of the OFFENSE master
+against four value-publishing dynasty boards that
+`fit_hill_curve_percentile.py` does not read: FantasyCalc, OTCFFB,
+PFKDynasty, FantasyNavigator. Same metric as the fit's own objective
+(top-400, native percentile, top anchored at 9999) so the numbers are
+comparable; different data, so the check can fail.
+
+`ktcSfTep` is deliberately **not** treated as held out despite being
+absent from the fit's source dict — it is KeepTradeCut's own SF-TEP
+board, the same market maker as the `KTC` training source. The
+train/holdout split is enforced by **file path**, not label, so
+relabelling a training CSV cannot smuggle it back in.
+
+**What the criterion measures — and does not.** It measures
+generalization across dynasty markets: whether a curve fitted to six
+boards also describes boards it never saw. It does **not** measure
+accuracy against reality. Every holdout board is another consensus
+market pricing the same players off the same news, and there is no
+ground truth for what a dynasty asset is worth. A promotion means the
+challenger is less overfitted to its six training boards. It does not
+mean the challenger is right. Both statements ship in the payload's
+`_semantics` block.
+
+**Promotion margin: 25 points**, measured rather than chosen. Champion
+and challenger are always scored on the *same* snapshot, so market
+drift is common-mode and cancels. Across 30 real FantasyCalc snapshots
+(2026-04-03 → 04-08) the *absolute* criterion moved 584.90–653.04 (sd
+19.28) while the *paired* delta between two fixed curves was
+near-deterministic — worst sd 1.51, zero sign flips in 29 consecutive
+pairs. The noise floor a margin must clear is therefore ~1.5, not ~19;
+25 sits ~16× above it. Ties go to the incumbent.
+
+**Unmeasured incumbent blocks promotion.** If the champion has no
+out-of-sample score, no challenger can pass it. An unmeasured incumbent
+is unknown, not beaten, and promoting past it would reproduce the
+autonomous rewrite in a new costume.
+
+**Rollback** is two commands (`rollback` then `apply`), not a hand-edit
+of eight floats from a diff. Only a *former champion* is a valid
+rollback target; reinstating something never live is an unvalidated
+promotion wearing the word.
+
+**Confidence honesty** is structural, not advisory. A version with no
+held-out score is `qualified=False` / `confidence="unvalidated"`, and
+`status` prints a warning. Buckets are coarse (`unvalidated` /
+`provisional` / `measured`) on purpose: a continuous confidence score
+here would itself be an unvalidated model.
+
+### Measured result on the shipped champion
+
+The live OFFENSE master (`c=0.118, s=1.17`) scores **849.8** on the
+held-out criterion — FantasyCalc 852.6, FantasyNavigator 1185.2,
+OTCFFB 1104.9, PFKDynasty 256.7.
+
+A curve at `c=0.098` scores **648.2** on the same boards. **The live
+champion is not at the holdout optimum, and the gap is ~200 points.**
+This is reported, not acted on: changing it is a live valuation change
+requiring its own verification of downstream effects, and this
+workstream's constraint was explicitly not to fold that in. Scoped as
+follow-up work.
+
+Note also that the training and holdout objectives *disagree in
+direction* — moving to `s=1.37` makes the training mean worse
+(774 → 797) while making the holdout mean better (850 → 758). That
+disagreement is the evidence that the gate is not a rubber stamp for
+the fit.
+
+### Not implemented, and why
+
+* **Temporal holdout.** Rejected as currently unbuildable rather than
+  built weakly. `data/raw/ktc/2026/` holds 30 snapshots spanning
+  2026-04-17 → 04-20 — four days, three months stale. A four-day
+  forward window cannot distinguish curve quality from a quiet market,
+  and no held-out-in-time evaluation over it would be evidence. If
+  snapshot retention is extended to cover a season, this becomes the
+  stronger criterion and should replace the cross-source one.
+* **Gating IDP / GLOBAL / ROOKIE masters.** Only the OFFENSE master has
+  a genuine holdout today; the IDP and GLOBAL scopes are trained on
+  IDPTradeCalc and DraftSharks, and the only other IDP value boards in
+  the repo (`idpShow`, `footballGuysIdp`) feed the live blend but have
+  not been checked for independence from the fit. The registry versions
+  all eight constants; the *validation* covers the OFFENSE pair. This
+  is stated in the payload rather than papered over.
+* **The workflow rewiring itself.** `.github/workflows/refit-hill-curves.yml`
+  and `scripts/auto_refit_hill_curves.py` are **untouched** by this
+  change. Fixing them is a fix to the existing refit path — production
+  automation that currently pushes to `main` and triggers `deploy.yml`
+  — and it is scoped separately on purpose rather than folded into the
+  change that characterises the defect. Nothing in `src/model_registry/`
+  runs on a schedule, imports the valuation pipeline, or alters any
+  endpoint. The registry records and gates; today a human drives it.
+
+### Proposed wiring (scoped, not landed here)
+
+The minimal follow-up, for review as its own change:
+
+1. Refit emits challenger params instead of writing them:
+   `fit_hill_curve_percentile.py --json-out challenger.json`.
+2. `model_registry.py evaluate --champion --record`
+3. `model_registry.py register --params challenger.json`
+4. `model_registry.py validate <n>` — exit 0 promotes, 1 rejects.
+5. Commit **only** `config/model_registry/*.json`. Production constants
+   move solely via `promote` + `apply`, run by a human.
+
+That removes both halves of the defect: the constants stop being
+rewritten unreviewed, and the guard stops being rewritten at all.
+
+**Status:** accepted 2026-07-26; implementation in `src/model_registry/`.

--- a/scripts/model_registry.py
+++ b/scripts/model_registry.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Continuous Improvement System CLI — versioning, validation, rollback.
+
+Subcommands
+-----------
+    status      Show the champion, its confidence, and the version log.
+    sources     Print the train/holdout split so it can be checked.
+    evaluate    Score a (c, s) pair — or the champion — out of sample.
+    register    Record a challenger produced by a refit.
+    validate    Champion vs challenger on the held-out criterion.
+    promote     Make a challenger the champion (records the reason).
+    rollback    Reinstate the previous champion. THE undo.
+    apply       Write the champion's params into player_valuation.py.
+
+Rollback, in full, is:
+
+    python3 scripts/model_registry.py rollback --reason "bad refit"
+    python3 scripts/model_registry.py apply
+
+Exit codes:
+    0   success / promote
+    1   no-op (no drift, or challenger rejected)
+    2   error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.model_registry.holdout import (  # noqa: E402
+    HoldoutError,
+    evaluate_offense_master,
+    source_roles,
+)
+from src.model_registry.promotion import decide_promotion  # noqa: E402
+from src.model_registry.versioning import (  # noqa: E402
+    ModelRegistry,
+    ModelVersion,
+    RegistryError,
+    fingerprint_inputs,
+)
+
+MODEL_ID = "hill_scope_masters"
+PLAYER_VALUATION = REPO / "src" / "canonical" / "player_valuation.py"
+
+CONSTANT_NAMES: tuple[str, ...] = (
+    "HILL_GLOBAL_PERCENTILE_C",
+    "HILL_GLOBAL_PERCENTILE_S",
+    "HILL_PERCENTILE_C",
+    "HILL_PERCENTILE_S",
+    "IDP_HILL_PERCENTILE_C",
+    "IDP_HILL_PERCENTILE_S",
+    "HILL_ROOKIE_PERCENTILE_C",
+    "HILL_ROOKIE_PERCENTILE_S",
+)
+
+
+def read_committed_constants() -> dict[str, float]:
+    text = PLAYER_VALUATION.read_text()
+    out: dict[str, float] = {}
+    for name in CONSTANT_NAMES:
+        m = re.search(rf"^{re.escape(name)}:\s*float\s*=\s*([0-9.]+)\s*$", text, re.MULTILINE)
+        if not m:
+            raise RegistryError(f"could not find {name!r} in {PLAYER_VALUATION}")
+        out[name] = float(m.group(1))
+    return out
+
+
+def write_committed_constants(params: dict[str, float]) -> None:
+    text = PLAYER_VALUATION.read_text()
+    for name in CONSTANT_NAMES:
+        if name not in params:
+            raise RegistryError(f"champion params missing {name!r}")
+        literal = f"{params[name]:.4f}" if name.endswith("_C") else f"{params[name]:.3f}"
+        text, n = re.subn(
+            rf"^({re.escape(name)}:\s*float\s*=\s*)[0-9.]+(\s*)$",
+            rf"\g<1>{literal}\g<2>",
+            text,
+            flags=re.MULTILINE,
+        )
+        if n != 1:
+            raise RegistryError(f"expected 1 match for {name!r}, got {n}")
+    PLAYER_VALUATION.write_text(text)
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(REPO),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _training_input_paths() -> dict[str, Path]:
+    return {role.label: REPO / role.path for role in source_roles() if role.role == "train"}
+
+
+def _load_or_seed() -> ModelRegistry:
+    """Load the registry, seeding from live constants on first use.
+
+    Seeding records what is ALREADY live as v1 champion.  It is not a
+    claim that those constants won anything — ``qualified`` stays False
+    until someone evaluates them.
+    """
+    try:
+        return ModelRegistry.load(MODEL_ID)
+    except RegistryError:
+        reg = ModelRegistry(MODEL_ID)
+        reg.seed_champion(
+            ModelVersion(
+                model_id=MODEL_ID,
+                version=1,
+                params=read_committed_constants(),
+                fitted_at="unknown",
+                producer="seeded from committed constants in player_valuation.py",
+                training_inputs=fingerprint_inputs(_training_input_paths()),
+                notes=(
+                    "seeded, not validated: these constants were live before the "
+                    "registry existed and carry no out-of-sample score",
+                ),
+            )
+        )
+        reg.save()
+        return reg
+
+
+# ── subcommands ────────────────────────────────────────────────────
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    reg = _load_or_seed()
+    champ = reg.champion
+    print(f"model: {reg.model_id}")
+    print(f"champion: v{champ.version}  confidence={champ.confidence}")
+    if not champ.qualified:
+        print(
+            "  WARNING: champion has no out-of-sample score. Its output must not "
+            "be presented as validated. Run `evaluate --champion`."
+        )
+    else:
+        print(f"  held-out criterion: {champ.holdout['criterion']:.1f} (lower is better)")
+    print(f"  fitted: {champ.fitted_at}   producer: {champ.producer}")
+    print()
+    print(f"{'ver':>4}  {'status':<11}{'confidence':<13}{'criterion':>11}  fitted")
+    for v in reg.versions:
+        crit = (v.holdout or {}).get("criterion")
+        crit_s = f"{crit:.1f}" if crit is not None else "-"
+        print(f"{v.version:>4}  {v.status:<11}{v.confidence:<13}{crit_s:>11}  {v.fitted_at}")
+    return 0
+
+
+def cmd_sources(args: argparse.Namespace) -> int:
+    print(f"{'source':<20}{'role':<10}{'rows':>7}  path")
+    for role in source_roles():
+        path = REPO / role.path
+        rows = "missing"
+        if path.exists():
+            with path.open(encoding="utf-8") as f:
+                rows = str(max(0, sum(1 for _ in f) - 1))
+        print(f"{role.label:<20}{role.role:<10}{rows:>7}  {role.path}")
+    print()
+    print(
+        "Holdout boards are value-publishing dynasty markets the fit never reads.\n"
+        "They measure generalization across markets, NOT accuracy: every board is\n"
+        "another consensus market pricing the same players off the same news."
+    )
+    return 0
+
+
+def cmd_evaluate(args: argparse.Namespace) -> int:
+    if args.champion:
+        reg = _load_or_seed()
+        params = reg.champion.params
+        c, s = params["HILL_PERCENTILE_C"], params["HILL_PERCENTILE_S"]
+        label = f"champion v{reg.champion.version}"
+    else:
+        c, s = args.c, args.s
+        label = f"c={c} s={s}"
+
+    try:
+        result = evaluate_offense_master(c, s)
+    except HoldoutError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"held-out evaluation — {label}")
+    print(f"  criterion (mean per-source RMSE): {result.criterion:.1f}")
+    for src, rmse in sorted(result.per_source.items()):
+        print(f"    {src:<20}{rmse:>9.1f}   n={result.per_source_rows[src]}")
+    for src, why in sorted(result.skipped.items()):
+        print(f"    {src:<20}{'skipped':>9}   {why}")
+
+    if args.champion and args.record:
+        reg = _load_or_seed()
+        champ = reg.champion
+        updated = [
+            ModelVersion(
+                model_id=v.model_id,
+                version=v.version,
+                params=v.params,
+                fitted_at=v.fitted_at,
+                producer=v.producer,
+                status=v.status,
+                training_inputs=v.training_inputs,
+                holdout=result.to_dict() if v.version == champ.version else v.holdout,
+                notes=v.notes,
+                promoted_at=v.promoted_at,
+                retired_at=v.retired_at,
+            )
+            for v in reg.versions
+        ]
+        ModelRegistry(MODEL_ID, updated).save()
+        print(f"  recorded against champion v{champ.version}")
+    return 0
+
+
+def cmd_register(args: argparse.Namespace) -> int:
+    reg = _load_or_seed()
+    params = json.loads(Path(args.params).read_text())
+    params = {str(k): float(v) for k, v in params.items()}
+    missing = [n for n in CONSTANT_NAMES if n not in params]
+    if missing:
+        print(f"ERROR: params missing {missing}", file=sys.stderr)
+        return 2
+
+    try:
+        result = evaluate_offense_master(params["HILL_PERCENTILE_C"], params["HILL_PERCENTILE_S"])
+    except HoldoutError as exc:
+        print(f"ERROR: challenger could not be evaluated: {exc}", file=sys.stderr)
+        return 2
+
+    version = ModelVersion(
+        model_id=MODEL_ID,
+        version=reg.next_version(),
+        params=params,
+        fitted_at=args.fitted_at or "unknown",
+        producer=args.producer or f"scripts/fit_hill_curve_percentile.py @ {_git_sha()}",
+        status="challenger",
+        training_inputs=fingerprint_inputs(_training_input_paths()),
+        holdout=result.to_dict(),
+    )
+    reg.add(version)
+    reg.save()
+    print(f"registered challenger v{version.version}  criterion={result.criterion:.1f}")
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    reg = _load_or_seed()
+    champ = reg.champion
+    try:
+        challenger = reg.get(args.version)
+    except RegistryError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    champ_crit = (champ.holdout or {}).get("criterion")
+    chal_crit = (challenger.holdout or {}).get("criterion")
+    if chal_crit is None:
+        print(f"ERROR: challenger v{challenger.version} has no held-out score", file=sys.stderr)
+        return 2
+
+    decision = decide_promotion(champ_crit, chal_crit)
+    print(f"champion   v{champ.version}: {champ_crit if champ_crit is not None else 'unmeasured'}")
+    print(f"challenger v{challenger.version}: {chal_crit:.1f}")
+    print(f"verdict: {'PROMOTE' if decision.promote else 'REJECT'} — {decision.reason}")
+    if decision.alarm:
+        print("ALARM: regression large enough to suspect the fit or its inputs.")
+    return 0 if decision.promote else 1
+
+
+def cmd_promote(args: argparse.Namespace) -> int:
+    reg = _load_or_seed()
+    try:
+        champ = reg.promote(args.version, reason=args.reason)
+    except RegistryError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    reg.save()
+    print(f"champion is now v{champ.version}")
+    print("Run `apply` to write these constants into player_valuation.py.")
+    return 0
+
+
+def cmd_rollback(args: argparse.Namespace) -> int:
+    reg = _load_or_seed()
+    try:
+        champ = reg.rollback(to_version=args.to_version, reason=args.reason)
+    except RegistryError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    reg.save()
+    print(f"rolled back — champion is now v{champ.version}")
+    print("Run `apply` to write these constants into player_valuation.py.")
+    return 0
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    reg = _load_or_seed()
+    champ = reg.champion
+    live = read_committed_constants()
+    if live == champ.params:
+        print(f"player_valuation.py already matches champion v{champ.version} — no change")
+        return 1
+    if args.dry_run:
+        print(f"would write champion v{champ.version}:")
+        for name in CONSTANT_NAMES:
+            if live.get(name) != champ.params.get(name):
+                print(f"  {name}: {live.get(name)} -> {champ.params.get(name)}")
+        return 0
+    write_committed_constants(champ.params)
+    print(f"wrote champion v{champ.version} into {PLAYER_VALUATION.relative_to(REPO)}")
+    print("Run the test suite before committing.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("status", help="show champion + version log").set_defaults(fn=cmd_status)
+    sub.add_parser("sources", help="print the train/holdout split").set_defaults(fn=cmd_sources)
+
+    p_eval = sub.add_parser("evaluate", help="score a (c, s) pair out of sample")
+    p_eval.add_argument("--c", type=float, help="Hill midpoint")
+    p_eval.add_argument("--s", type=float, help="Hill slope")
+    p_eval.add_argument("--champion", action="store_true", help="score the current champion")
+    p_eval.add_argument("--record", action="store_true", help="store the score on the champion")
+    p_eval.set_defaults(fn=cmd_evaluate)
+
+    p_reg = sub.add_parser("register", help="record a challenger from a refit")
+    p_reg.add_argument("--params", required=True, help="JSON file of the 8 constants")
+    p_reg.add_argument("--producer", help="what produced it")
+    p_reg.add_argument("--fitted-at", help="ISO 8601 timestamp")
+    p_reg.set_defaults(fn=cmd_register)
+
+    p_val = sub.add_parser("validate", help="champion vs challenger")
+    p_val.add_argument("version", type=int)
+    p_val.set_defaults(fn=cmd_validate)
+
+    p_pro = sub.add_parser("promote", help="make a challenger the champion")
+    p_pro.add_argument("version", type=int)
+    p_pro.add_argument("--reason", required=True)
+    p_pro.set_defaults(fn=cmd_promote)
+
+    p_rb = sub.add_parser("rollback", help="reinstate the previous champion")
+    p_rb.add_argument("--to-version", type=int, default=None)
+    p_rb.add_argument("--reason", required=True)
+    p_rb.set_defaults(fn=cmd_rollback)
+
+    p_ap = sub.add_parser("apply", help="write champion params into player_valuation.py")
+    p_ap.add_argument("--dry-run", action="store_true")
+    p_ap.set_defaults(fn=cmd_apply)
+
+    args = ap.parse_args()
+    if getattr(args, "cmd", None) == "evaluate" and not args.champion:
+        if args.c is None or args.s is None:
+            ap.error("evaluate requires --c and --s, or --champion")
+    try:
+        return int(args.fn(args))
+    except RegistryError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/model_registry/__init__.py
+++ b/src/model_registry/__init__.py
@@ -1,0 +1,59 @@
+"""Continuous Improvement System — controlled retraining for fitted models.
+
+The governing directive is one sentence long and every module here
+exists to satisfy a clause of it:
+
+    Do not allow a model to autonomously rewrite production code.  Use
+    controlled retraining, champion-challenger validation, model
+    versioning, and rollback.  Do not present low-confidence output as
+    precise.
+
+Scope.  A "model" here is any tunable that behaves like a FITTED
+PARAMETER — a number produced by an optimizer against data, not chosen
+by a human for a reason they could state.  The Hill scope masters are
+the live example: eight constants in
+``src/canonical/player_valuation.py`` refit weekly by
+``.github/workflows/refit-hill-curves.yml`` and committed to main
+without review.
+
+What this package does NOT do: it does not compute values, does not
+import the valuation pipeline, and does not change what any live
+endpoint returns.  It records what a fitted parameter set is, where it
+came from, how it scored on data it never saw, and which version is
+authoritative.  Promotion and rollback are explicit operations.
+
+Modules
+-------
+``versioning``  Model versions, provenance, the champion pointer,
+                promote/rollback as single operations.
+``holdout``     Out-of-sample evaluation, with a hard guard against
+                scoring a model on its own training sources.
+``promotion``   The champion-challenger decision and its stated limits.
+"""
+
+from src.model_registry.holdout import (
+    HoldoutResult,
+    SourceRole,
+    evaluate_offense_master,
+    source_roles,
+)
+from src.model_registry.promotion import PromotionDecision, decide_promotion
+from src.model_registry.versioning import (
+    ModelRegistry,
+    ModelVersion,
+    RegistryError,
+    fingerprint_file,
+)
+
+__all__ = [
+    "HoldoutResult",
+    "ModelRegistry",
+    "ModelVersion",
+    "PromotionDecision",
+    "RegistryError",
+    "SourceRole",
+    "decide_promotion",
+    "evaluate_offense_master",
+    "fingerprint_file",
+    "source_roles",
+]

--- a/src/model_registry/holdout.py
+++ b/src/model_registry/holdout.py
@@ -1,0 +1,281 @@
+"""Out-of-sample evaluation for the Hill scope masters.
+
+Why this module exists
+──────────────────────
+The refit workflow's only guard is
+``tests/canonical/test_ktc_reconciliation.py``, and that guard cannot
+fail after a refit, for two independent reasons:
+
+1. ``scripts/auto_refit_hill_curves.py::rebaseline_ktc_reconciliation``
+   REWRITES the test's expected values from the new constants before
+   the test runs.  Both assertions — the exact ``ours == pinned_ours``
+   pin and the ``pct_diff`` band — are recomputed from the challenger
+   itself against the same ``ktc.csv`` the test reads.  The residual is
+   zero by construction.
+2. Even with honest pins, KTC is a TRAINING source: ``ktc.csv`` is in
+   ``fit_hill_curve_percentile.OFFENSE_SOURCES``, and the OFFENSE
+   master it trains is exactly the ``HILL_PERCENTILE_C/S`` pair that
+   ``percentile_to_value`` uses.  Scoring the fit against its own
+   training data is ORCHESTRATION.md §2b: the assumption reflected
+   back.
+
+So this module evaluates the curve against value-publishing markets
+that the fit never sees, using the fit's own metric so the numbers are
+comparable.
+
+What the criterion measures — and what it does not
+──────────────────────────────────────────────────
+It measures GENERALIZATION ACROSS MARKETS: does a curve fitted to six
+dynasty value boards also describe boards it was not fitted to?  A
+challenger that improves here is describing the shape of the dynasty
+market more faithfully than the incumbent.
+
+It does NOT measure accuracy against reality.  Every holdout source is
+another consensus market, correlated with the training sources by
+construction — they price the same players off the same news.  There
+is no ground truth for what a dynasty asset is "really" worth, so no
+check here can establish that the curve is CORRECT.  It can only
+establish that the curve is not overfitted to the particular six
+boards it was trained on.  Anyone citing these numbers must say which
+of those two claims they are making.
+
+Pure computation over supplied files.  No network.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Mirrors scripts/fit_hill_curve_percentile.py::OFFENSE_SOURCES.  Kept
+# as a literal rather than imported because that file is a script with
+# side-effecting module scope; a parity test pins the two together so
+# this cannot silently drift.
+OFFENSE_TRAINING_SOURCES: dict[str, tuple[str, str]] = {
+    "KTC": ("CSVs/site_raw/ktc.csv", "value"),
+    "DynastyDaddy": ("CSVs/site_raw/dynastyDaddySf.csv", "value"),
+    "DynastyNerds": ("CSVs/site_raw/dynastyNerdsSfTep.csv", "Value"),
+    "YahooBoone": ("CSVs/site_raw/yahooBoone.csv", "boone_value"),
+    "Fitzmaurice": ("CSVs/site_raw/fantasyProsFitzmaurice.csv", "value"),
+    "DraftSharks": ("CSVs/site_raw/draftSharksSf.csv", "3D Value +"),
+}
+
+# Value-publishing offense boards that the fit does NOT consume.
+#
+# ktcSfTep is deliberately EXCLUDED despite not appearing in the fit's
+# source dict: it is KeepTradeCut's own SF-TEP board, the same market
+# maker as the ``KTC`` training source.  Treating it as held out would
+# smuggle a training source back in under a different filename, which
+# is the subtler version of the defect this module exists to catch.
+OFFENSE_HOLDOUT_SOURCES: dict[str, tuple[str, str]] = {
+    "FantasyCalc": ("CSVs/site_raw/fantasyCalc.csv", "value"),
+    "OTCFFB": ("CSVs/site_raw/otcffbSf.csv", "value"),
+    "PFKDynasty": ("CSVs/site_raw/pfkDynasty.csv", "value"),
+    "FantasyNavigator": ("CSVs/site_raw/fantasyNavigatorSf.csv", "value"),
+}
+
+# The fit truncates every source to its top 400 before computing
+# percentiles.  Matched exactly so train and holdout RMSE are the same
+# quantity measured on different data.
+FIT_TOP_N: int = 400
+MIN_ROWS_FOR_SCORING: int = 100
+
+
+class HoldoutError(RuntimeError):
+    """Raised when an evaluation would be meaningless if it succeeded."""
+
+
+@dataclass(frozen=True)
+class SourceRole:
+    """Which side of the train/holdout line a source sits on."""
+
+    label: str
+    path: str
+    value_column: str
+    role: str  # "train" | "holdout"
+
+
+def source_roles() -> tuple[SourceRole, ...]:
+    """Every offense value source, labelled by role.
+
+    Exported so a caller can print the split rather than trust it.
+    """
+    out: list[SourceRole] = []
+    for label, (path, col) in sorted(OFFENSE_TRAINING_SOURCES.items()):
+        out.append(SourceRole(label, path, col, "train"))
+    for label, (path, col) in sorted(OFFENSE_HOLDOUT_SOURCES.items()):
+        out.append(SourceRole(label, path, col, "holdout"))
+    return tuple(out)
+
+
+def _load_values(path: Path, column: str) -> list[float]:
+    """Positive values from ``column``, descending.  Mirrors the fit."""
+    values: list[float] = []
+    with path.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            raw = row.get(column)
+            try:
+                v = float(raw) if raw not in (None, "") else 0.0
+            except (TypeError, ValueError):
+                continue
+            if v > 0:
+                values.append(v)
+    values.sort(reverse=True)
+    return values
+
+
+def _percentile_pairs(values: Sequence[float]) -> list[tuple[float, float]]:
+    """``[(p, normalized_value)]`` with the top anchored at 9999.
+
+    Identical to ``fit_hill_curve_percentile._percentile_pairs`` — the
+    percentile is native to the source's own pool, and the top value
+    normalizes to the curve's anchor.
+    """
+    vs = list(values[:FIT_TOP_N])
+    n = len(vs)
+    if n < 2:
+        return []
+    top = vs[0]
+    if top <= 0:
+        return []
+    return [(i / (n - 1), vs[i] / top * 9999.0) for i in range(n)]
+
+
+def hill(p: float, c: float, s: float) -> float:
+    """``V(p) = 9999 / (1 + (p/c)^s)`` — the fit's model, standalone.
+
+    Duplicated from ``player_valuation.percentile_to_value`` on
+    purpose: this module must be able to score an ARBITRARY (c, s)
+    pair, including a challenger that is not installed anywhere, and
+    the production function reads committed module constants.
+    """
+    if p <= 0.0:
+        return 9999.0
+    return 9999.0 / (1.0 + (min(p, 1.0) / c) ** s)
+
+
+def _rmse(pairs: Sequence[tuple[float, float]], c: float, s: float) -> float:
+    return (sum((hill(p, c, s) - v) ** 2 for p, v in pairs) / len(pairs)) ** 0.5
+
+
+@dataclass(frozen=True)
+class HoldoutResult:
+    """Out-of-sample score for one (c, s) pair.
+
+    ``criterion`` is the mean per-source RMSE across held-out boards.
+    Mean rather than pooled: pooling would weight a 400-row board four
+    times a 100-row one, letting one market dominate the verdict.
+    """
+
+    criterion: float
+    per_source: dict[str, float]
+    per_source_rows: dict[str, int]
+    skipped: dict[str, str]
+    params: dict[str, float]
+    holdout_labels: tuple[str, ...]
+    training_labels: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "criterion": round(self.criterion, 4),
+            "criterionName": "mean_per_source_rmse",
+            "criterionUnits": "points on the 0-9999 value scale (lower is better)",
+            "perSource": {k: round(v, 4) for k, v in sorted(self.per_source.items())},
+            "perSourceRows": dict(sorted(self.per_source_rows.items())),
+            "skipped": dict(sorted(self.skipped.items())),
+            "params": dict(self.params),
+            "holdoutSources": list(self.holdout_labels),
+            "trainingSources": list(self.training_labels),
+            "_semantics": {
+                "measures": (
+                    "generalization across dynasty markets — whether a curve fitted "
+                    "to the training boards also describes boards it never saw"
+                ),
+                "doesNotMeasure": (
+                    "accuracy against reality; every holdout board is another "
+                    "consensus market correlated with the training boards, and no "
+                    "ground truth for dynasty value exists"
+                ),
+            },
+        }
+
+
+def evaluate_offense_master(
+    c: float,
+    s: float,
+    *,
+    repo_root: Path | None = None,
+    holdout_sources: Mapping[str, tuple[str, str]] | None = None,
+    training_sources: Mapping[str, tuple[str, str]] | None = None,
+) -> HoldoutResult:
+    """Score an OFFENSE Hill master on boards the fit never consumed.
+
+    Raises :class:`HoldoutError` rather than returning a number when
+    the evaluation would be vacuous — an overlap between the training
+    and holdout sets, or no usable holdout board.  A validation gate
+    that silently degrades to "no data, therefore pass" is worse than
+    no gate, because it reports success.
+    """
+    root = repo_root or REPO
+    # `is None`, not `or`: an explicitly EMPTY holdout set is a caller
+    # saying "I have no held-out data", and falling back to the default
+    # set would answer a question they did not ask — with a passing
+    # score, which is the exact failure this function exists to refuse.
+    holdout = dict(OFFENSE_HOLDOUT_SOURCES if holdout_sources is None else holdout_sources)
+    training = dict(OFFENSE_TRAINING_SOURCES if training_sources is None else training_sources)
+
+    overlap = sorted(set(holdout) & set(training))
+    if overlap:
+        raise HoldoutError(
+            f"sources {overlap} are in BOTH the training and holdout sets; "
+            "scoring a fit against its own training data measures nothing"
+        )
+    train_paths = {p for p, _ in training.values()}
+    path_overlap = sorted({label for label, (p, _) in holdout.items() if p in train_paths})
+    if path_overlap:
+        raise HoldoutError(
+            f"holdout sources {path_overlap} point at a training CSV; the split is "
+            "by FILE, not by label"
+        )
+    if not holdout:
+        raise HoldoutError("no holdout sources configured")
+
+    per_source: dict[str, float] = {}
+    per_source_rows: dict[str, int] = {}
+    skipped: dict[str, str] = {}
+
+    for label, (rel_path, column) in sorted(holdout.items()):
+        path = root / rel_path
+        if not path.exists():
+            skipped[label] = "csv missing"
+            continue
+        values = _load_values(path, column)
+        if len(values) < MIN_ROWS_FOR_SCORING:
+            skipped[label] = f"only {len(values)} priced rows (need {MIN_ROWS_FOR_SCORING})"
+            continue
+        pairs = _percentile_pairs(values)
+        if not pairs:
+            skipped[label] = "no usable percentile pairs"
+            continue
+        per_source[label] = _rmse(pairs, c, s)
+        per_source_rows[label] = len(pairs)
+
+    if not per_source:
+        raise HoldoutError(
+            f"no holdout board could be scored (skipped: {skipped}); refusing to "
+            "report a passing evaluation with no evidence behind it"
+        )
+
+    return HoldoutResult(
+        criterion=sum(per_source.values()) / len(per_source),
+        per_source=per_source,
+        per_source_rows=per_source_rows,
+        skipped=skipped,
+        params={"c": c, "s": s},
+        holdout_labels=tuple(sorted(per_source)),
+        training_labels=tuple(sorted(training)),
+    )

--- a/src/model_registry/promotion.py
+++ b/src/model_registry/promotion.py
@@ -1,0 +1,156 @@
+"""The champion-challenger decision.
+
+A refit produces a CHALLENGER.  It becomes champion only by beating the
+incumbent on the held-out criterion by a margin larger than the
+criterion's own noise.  Everything else is rejected and kept.
+
+Why a margin, and why the comparison must be PAIRED
+───────────────────────────────────────────────────
+The criterion's absolute level is not stable: re-scoring the committed
+OFFENSE master against 30 consecutive FantasyCalc snapshots (2026-04-03
+to 04-08) gave 584.90 to 653.04 — a 68-point range, sd 19.28.  A rule
+that compared this week's challenger to last week's champion SCORE
+would be reading five days of market drift as model quality.
+
+That drift is common-mode, so the comparison is always made on ONE
+snapshot with both curves scored against it.  Measured on the same 30
+snapshots, the paired delta is near-deterministic:
+
+    challenger        mean delta    sd    sign flips
+    c + 0.001            -13.39   0.01        0/29
+    c + 0.005            -66.81   0.08        0/29
+    c - 0.020           +257.51   1.51        0/29
+    s + 0.200            +37.95   0.95        0/29
+
+So the noise a margin must clear is ~1.5 points, not ~19.  Ties still
+go to the INCUMBENT: the cost of holding a slightly stale curve is
+bounded, while churning production constants weekly is not — every
+promotion invalidates the pins, the caches, and any human's mental
+model of the board.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Minimum improvement in mean per-source RMSE for a challenger to win.
+#
+# Measured, not picked round.  Worst observed paired-delta sd across the
+# 30-snapshot series above is 1.51 points, so 25 sits ~16x above the
+# noise floor.  For scale in parameter terms, a c shift of 0.001 moves
+# the criterion ~13 points, so the margin corresponds to roughly
+# c +/- 0.002 — tight enough that genuine refits clear it (a real
+# c 0.118 -> 0.098 shift moves the criterion ~258) and loose enough
+# that a rescrape cannot.
+PROMOTION_MARGIN: float = 25.0
+
+# A challenger this much WORSE than the champion is not merely rejected
+# — it is evidence the fit itself misbehaved (bad scrape, collapsed
+# source) and the run deserves a human.
+REGRESSION_ALARM: float = 250.0
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    """The verdict, with the arithmetic that produced it."""
+
+    promote: bool
+    reason: str
+    champion_criterion: float | None
+    challenger_criterion: float
+    margin_required: float
+    improvement: float | None
+    alarm: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "promote": self.promote,
+            "reason": self.reason,
+            "championCriterion": (
+                round(self.champion_criterion, 4) if self.champion_criterion is not None else None
+            ),
+            "challengerCriterion": round(self.challenger_criterion, 4),
+            "improvement": (round(self.improvement, 4) if self.improvement is not None else None),
+            "marginRequired": self.margin_required,
+            "alarm": self.alarm,
+            "_semantics": {
+                "improvement": "champion criterion minus challenger criterion; positive is better",
+                "warning": (
+                    "a promotion means the challenger generalizes better across "
+                    "held-out dynasty markets, NOT that it is more accurate"
+                ),
+            },
+        }
+
+
+def decide_promotion(
+    champion_criterion: float | None,
+    challenger_criterion: float,
+    *,
+    margin: float = PROMOTION_MARGIN,
+    alarm_threshold: float = REGRESSION_ALARM,
+) -> PromotionDecision:
+    """Compare a challenger to the incumbent on the held-out criterion.
+
+    ``champion_criterion is None`` means the incumbent has never been
+    evaluated out of sample.  That does NOT hand the win to the
+    challenger: an unmeasured incumbent is unknown, not bad, and
+    promoting past it would be exactly the autonomous rewrite the
+    directive prohibits.  Evaluate the champion first.
+    """
+    if champion_criterion is None:
+        return PromotionDecision(
+            promote=False,
+            reason=(
+                "incumbent has no out-of-sample score; evaluate the champion "
+                "before comparing (an unmeasured incumbent is unknown, not beaten)"
+            ),
+            champion_criterion=None,
+            challenger_criterion=challenger_criterion,
+            margin_required=margin,
+            improvement=None,
+        )
+
+    improvement = champion_criterion - challenger_criterion
+
+    if improvement <= -alarm_threshold:
+        return PromotionDecision(
+            promote=False,
+            reason=(
+                f"challenger is {-improvement:.1f} points WORSE than the champion "
+                f"(alarm threshold {alarm_threshold:.0f}); this is large enough to "
+                "suggest the fit or its inputs misbehaved — investigate before refitting"
+            ),
+            champion_criterion=champion_criterion,
+            challenger_criterion=challenger_criterion,
+            margin_required=margin,
+            improvement=improvement,
+            alarm=True,
+        )
+
+    if improvement < margin:
+        return PromotionDecision(
+            promote=False,
+            reason=(
+                f"improvement {improvement:+.1f} does not clear the {margin:.0f}-point "
+                "margin; within criterion noise, so the incumbent keeps the tie"
+            ),
+            champion_criterion=champion_criterion,
+            challenger_criterion=challenger_criterion,
+            margin_required=margin,
+            improvement=improvement,
+        )
+
+    return PromotionDecision(
+        promote=True,
+        reason=(
+            f"challenger improves the held-out criterion by {improvement:.1f} points "
+            f"({champion_criterion:.1f} -> {challenger_criterion:.1f}), clearing the "
+            f"{margin:.0f}-point margin"
+        ),
+        champion_criterion=champion_criterion,
+        challenger_criterion=challenger_criterion,
+        margin_required=margin,
+        improvement=improvement,
+    )

--- a/src/model_registry/versioning.py
+++ b/src/model_registry/versioning.py
@@ -1,0 +1,383 @@
+"""Model versions, provenance, and the champion pointer.
+
+Every fitted parameter set gets an identity: a monotonic version, the
+exact parameters, when it was fitted, what produced it, and a
+fingerprint of every training input.  Without the fingerprints
+"version 7" is a label; with them it is reproducible.
+
+The champion pointer is the only thing that says which version is
+authoritative.  Rollback is therefore a pointer move plus a file
+rewrite, not a hand-edit of constants — which is the whole point:
+a human reverting a bad refit at 2am should type one command, not
+retype eight floats from a diff.
+
+Storage is a single JSON document per model id under
+``config/model_registry/``.  JSON because every other tunable in this
+repo is JSON config, and because a human needs to be able to read the
+history without running anything.
+
+Pure computation over supplied paths.  No network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY_DIR = REPO / "config" / "model_registry"
+
+# A version is one of these and nothing else.  "rejected" is retained
+# rather than deleted: a challenger that lost is evidence about the
+# search space, and deleting it invites refitting the same loser.
+VERSION_STATUSES: tuple[str, ...] = ("champion", "challenger", "retired", "rejected")
+
+
+class RegistryError(RuntimeError):
+    """Raised for any operation that would leave the registry incoherent."""
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def fingerprint_file(path: Path) -> str:
+    """Content hash of a training input.
+
+    Short sha256.  The point is not cryptographic strength, it is
+    being able to answer "was this version fitted on the same data I
+    am looking at now" without storing the data.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return f"sha256:{h.hexdigest()[:16]}"
+
+
+def fingerprint_inputs(paths: Mapping[str, Path]) -> dict[str, str]:
+    """Fingerprint each named training input; missing files are stamped.
+
+    A missing input is recorded as ``"missing"`` rather than skipped.
+    Silently omitting it would make a version fitted on five sources
+    indistinguishable from one fitted on six.
+    """
+    out: dict[str, str] = {}
+    for label, path in sorted(paths.items()):
+        out[label] = fingerprint_file(path) if path.exists() else "missing"
+    return out
+
+
+@dataclass(frozen=True)
+class ModelVersion:
+    """One fitted parameter set, with everything needed to judge it.
+
+    ``confidence`` and ``qualified`` are the directive's "do not
+    present low-confidence output as precise" clause made structural:
+    a version that has never been evaluated out of sample is
+    ``qualified=False``, and any consumer that surfaces its output is
+    obliged to say so.
+    """
+
+    model_id: str
+    version: int
+    params: dict[str, float]
+    fitted_at: str
+    producer: str
+    status: str = "challenger"
+    training_inputs: dict[str, str] = field(default_factory=dict)
+    holdout: dict[str, Any] | None = None
+    notes: tuple[str, ...] = ()
+    promoted_at: str | None = None
+    retired_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in VERSION_STATUSES:
+            raise RegistryError(
+                f"unknown status {self.status!r}; expected one of {VERSION_STATUSES}"
+            )
+        if self.version < 1:
+            raise RegistryError(f"version must be >= 1, got {self.version}")
+
+    @property
+    def qualified(self) -> bool:
+        """True only if this version has a recorded out-of-sample score.
+
+        Deliberately not defaulting to True.  The seeded champion is
+        unqualified until someone evaluates it, and that is an honest
+        statement about it rather than a defect.
+        """
+        return bool(self.holdout) and self.holdout.get("criterion") is not None
+
+    @property
+    def confidence(self) -> str:
+        """Coarse label, sized to what is actually known.
+
+        Three buckets, not a number: a continuous confidence score
+        here would itself be an unvalidated model, which is the
+        failure mode this package exists to prevent.
+        """
+        if not self.qualified:
+            return "unvalidated"
+        sources = (self.holdout or {}).get("perSource") or {}
+        return "measured" if len(sources) >= 3 else "provisional"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "modelId": self.model_id,
+            "version": self.version,
+            "params": dict(self.params),
+            "fittedAt": self.fitted_at,
+            "producer": self.producer,
+            "status": self.status,
+            "trainingInputs": dict(self.training_inputs),
+            "holdout": self.holdout,
+            "qualified": self.qualified,
+            "confidence": self.confidence,
+            "notes": list(self.notes),
+            "promotedAt": self.promoted_at,
+            "retiredAt": self.retired_at,
+        }
+
+    @classmethod
+    def from_dict(cls, blob: Mapping[str, Any]) -> ModelVersion:
+        return cls(
+            model_id=str(blob["modelId"]),
+            version=int(blob["version"]),
+            params={str(k): float(v) for k, v in (blob.get("params") or {}).items()},
+            fitted_at=str(blob.get("fittedAt") or ""),
+            producer=str(blob.get("producer") or "unknown"),
+            status=str(blob.get("status") or "challenger"),
+            training_inputs={str(k): str(v) for k, v in (blob.get("trainingInputs") or {}).items()},
+            holdout=blob.get("holdout"),
+            notes=tuple(blob.get("notes") or ()),
+            promoted_at=blob.get("promotedAt"),
+            retired_at=blob.get("retiredAt"),
+        )
+
+
+class ModelRegistry:
+    """Versions of one model id, plus the champion pointer."""
+
+    def __init__(self, model_id: str, versions: Iterable[ModelVersion] = ()) -> None:
+        self.model_id = model_id
+        self._versions: list[ModelVersion] = sorted(versions, key=lambda v: v.version)
+        self._validate()
+
+    # ── persistence ────────────────────────────────────────────────
+
+    @classmethod
+    def path_for(cls, model_id: str, registry_dir: Path | None = None) -> Path:
+        safe = re.sub(r"[^a-z0-9_]+", "_", model_id.lower())
+        return (registry_dir or DEFAULT_REGISTRY_DIR) / f"{safe}.json"
+
+    @classmethod
+    def load(cls, model_id: str, registry_dir: Path | None = None) -> ModelRegistry:
+        path = cls.path_for(model_id, registry_dir)
+        if not path.exists():
+            raise RegistryError(f"no registry for model {model_id!r} at {path}")
+        blob = json.loads(path.read_text())
+        return cls(
+            model_id=str(blob.get("modelId") or model_id),
+            versions=[ModelVersion.from_dict(v) for v in blob.get("versions") or []],
+        )
+
+    def save(self, registry_dir: Path | None = None) -> Path:
+        path = self.path_for(self.model_id, registry_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "modelId": self.model_id,
+            "schemaVersion": 1,
+            "updatedAt": _utcnow(),
+            "championVersion": self.champion.version if self.has_champion else None,
+            "versions": [v.to_dict() for v in self._versions],
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n")
+        return path
+
+    # ── invariants ─────────────────────────────────────────────────
+
+    def _validate(self) -> None:
+        seen: set[int] = set()
+        for v in self._versions:
+            if v.model_id != self.model_id:
+                raise RegistryError(
+                    f"version {v.version} belongs to {v.model_id!r}, not {self.model_id!r}"
+                )
+            if v.version in seen:
+                raise RegistryError(f"duplicate version {v.version} for {self.model_id!r}")
+            seen.add(v.version)
+        champions = [v for v in self._versions if v.status == "champion"]
+        if len(champions) > 1:
+            raise RegistryError(
+                f"{self.model_id!r} has {len(champions)} champions "
+                f"({[c.version for c in champions]}); exactly one is allowed"
+            )
+
+    # ── reads ──────────────────────────────────────────────────────
+
+    @property
+    def versions(self) -> tuple[ModelVersion, ...]:
+        return tuple(self._versions)
+
+    @property
+    def has_champion(self) -> bool:
+        return any(v.status == "champion" for v in self._versions)
+
+    @property
+    def champion(self) -> ModelVersion:
+        for v in self._versions:
+            if v.status == "champion":
+                return v
+        raise RegistryError(f"{self.model_id!r} has no champion")
+
+    def get(self, version: int) -> ModelVersion:
+        for v in self._versions:
+            if v.version == version:
+                return v
+        raise RegistryError(f"{self.model_id!r} has no version {version}")
+
+    def next_version(self) -> int:
+        return (max((v.version for v in self._versions), default=0)) + 1
+
+    # ── writes ─────────────────────────────────────────────────────
+
+    def add(self, version: ModelVersion) -> ModelVersion:
+        """Register a new version.  Never auto-promotes."""
+        if version.status == "champion":
+            raise RegistryError(
+                "add() cannot introduce a champion directly — register the "
+                "version, then promote() it, so the transition is recorded"
+            )
+        self._versions.append(version)
+        self._versions.sort(key=lambda v: v.version)
+        self._validate()
+        return version
+
+    def seed_champion(self, version: ModelVersion) -> ModelVersion:
+        """Install the first champion for a model that has none.
+
+        Separate from ``promote`` because there is no incumbent to
+        compare against: seeding is an act of recording what is
+        ALREADY live, not a claim that it won anything.
+        """
+        if self.has_champion:
+            raise RegistryError(
+                f"{self.model_id!r} already has a champion (v{self.champion.version}); "
+                "use promote()"
+            )
+        seeded = replace(version, status="champion", promoted_at=_utcnow())
+        self._versions.append(seeded)
+        self._versions.sort(key=lambda v: v.version)
+        self._validate()
+        return seeded
+
+    def promote(self, version: int, *, reason: str) -> ModelVersion:
+        """Make ``version`` the champion; retire the incumbent.
+
+        The reason is mandatory and stored.  A promotion with no stated
+        reason is indistinguishable from an accident.
+        """
+        if not reason.strip():
+            raise RegistryError("promote() requires a non-empty reason")
+        target = self.get(version)
+        if target.status == "champion":
+            raise RegistryError(f"v{version} is already champion")
+        if target.status == "retired":
+            raise RegistryError(
+                f"v{version} is retired; use rollback() to reinstate a former champion"
+            )
+
+        now = _utcnow()
+        out: list[ModelVersion] = []
+        for v in self._versions:
+            if v.status == "champion":
+                out.append(replace(v, status="retired", retired_at=now))
+            elif v.version == version:
+                out.append(
+                    replace(
+                        v,
+                        status="champion",
+                        promoted_at=now,
+                        notes=(*v.notes, f"promoted: {reason.strip()}"),
+                    )
+                )
+            else:
+                out.append(v)
+        self._versions = sorted(out, key=lambda v: v.version)
+        self._validate()
+        return self.champion
+
+    def reject(self, version: int, *, reason: str) -> ModelVersion:
+        """Mark a challenger as having lost.  Kept, not deleted."""
+        if not reason.strip():
+            raise RegistryError("reject() requires a non-empty reason")
+        target = self.get(version)
+        if target.status == "champion":
+            raise RegistryError(f"v{version} is the champion; it cannot be rejected")
+        out = [
+            replace(v, status="rejected", notes=(*v.notes, f"rejected: {reason.strip()}"))
+            if v.version == version
+            else v
+            for v in self._versions
+        ]
+        self._versions = sorted(out, key=lambda v: v.version)
+        self._validate()
+        return self.get(version)
+
+    def rollback(self, *, to_version: int | None = None, reason: str) -> ModelVersion:
+        """Reinstate a previous champion — the single documented undo.
+
+        With no ``to_version`` this reinstates the most recently
+        retired champion, which is what "undo the last refit" means.
+        Only a FORMER champion can be rolled back to: rolling back to
+        something that was never live is not a rollback, it is an
+        unvalidated promotion wearing the word.
+        """
+        if not reason.strip():
+            raise RegistryError("rollback() requires a non-empty reason")
+
+        former = [v for v in self._versions if v.status == "retired" and v.promoted_at]
+        if not former:
+            raise RegistryError(f"{self.model_id!r} has no former champion to roll back to")
+        if to_version is None:
+            target = max(former, key=lambda v: (v.retired_at or "", v.version))
+        else:
+            target = self.get(to_version)
+            if target.status != "retired" or not target.promoted_at:
+                raise RegistryError(
+                    f"v{to_version} was never a champion; rollback targets former " "champions only"
+                )
+
+        now = _utcnow()
+        out: list[ModelVersion] = []
+        for v in self._versions:
+            if v.status == "champion":
+                out.append(
+                    replace(
+                        v,
+                        status="retired",
+                        retired_at=now,
+                        notes=(*v.notes, f"rolled back: {reason.strip()}"),
+                    )
+                )
+            elif v.version == target.version:
+                out.append(
+                    replace(
+                        v,
+                        status="champion",
+                        promoted_at=now,
+                        retired_at=None,
+                        notes=(*v.notes, f"reinstated: {reason.strip()}"),
+                    )
+                )
+            else:
+                out.append(v)
+        self._versions = sorted(out, key=lambda v: v.version)
+        self._validate()
+        return self.champion

--- a/tests/model_registry/test_holdout.py
+++ b/tests/model_registry/test_holdout.py
@@ -184,3 +184,60 @@ class TestAgainstRealBoards:
         base = evaluate_offense_master(0.118, 1.17).criterion
         moved = evaluate_offense_master(0.098, 1.17).criterion
         assert abs(base - moved) > 50, "real-board criterion is insensitive to the curve"
+
+
+@pytest.mark.livedata
+class TestTheBoardsDisagree:
+    """Pins the disagreement that narrowed ADR-008's headline claim.
+
+    A first pass reported "the champion is ~200 points off the holdout
+    optimum". Measuring per board rather than on the mean showed that
+    to be too strong: the improvement is three boards outvoting one,
+    and the mean-optimal point sits on the edge of the search grid
+    rather than at a bracketed minimum.
+
+    These tests exist so the narrower claim cannot quietly drift back
+    to the stronger one, and so a data refresh that changes the picture
+    surfaces here rather than in a confident sentence.
+    """
+
+    CHAMPION = (0.118, 1.17)
+    PROPOSED = (0.098, 1.17)
+
+    def test_the_mean_improves_but_not_every_board_does(self):
+        champ = evaluate_offense_master(*self.CHAMPION)
+        proposed = evaluate_offense_master(*self.PROPOSED)
+        assert proposed.criterion < champ.criterion
+
+        improved = [b for b in champ.per_source if proposed.per_source[b] < champ.per_source[b]]
+        worsened = [b for b in champ.per_source if proposed.per_source[b] > champ.per_source[b]]
+        assert improved and worsened, (
+            "every holdout board now moves the same way — the mean is no longer "
+            "hiding a disagreement, so ADR-008's narrowing may need revisiting"
+        )
+
+    def test_the_board_the_champion_fits_best_is_the_one_that_worsens(self):
+        """The specific shape of the disagreement: the curve is already
+        close to one board's optimum, and moving away costs there."""
+        champ = evaluate_offense_master(*self.CHAMPION)
+        proposed = evaluate_offense_master(*self.PROPOSED)
+        best_fit = min(champ.per_source, key=lambda b: champ.per_source[b])
+        assert proposed.per_source[best_fit] > champ.per_source[best_fit]
+
+    def test_the_mean_optimum_is_not_bracketed_by_the_search_grid(self):
+        """MECHANISM TEST. If the criterion still falls at the grid
+        floor, no interior optimum has been located and no specific
+        (c, s) may be reported as "the optimum"."""
+        floor = evaluate_offense_master(0.080, 1.30).criterion
+        inside = evaluate_offense_master(0.090, 1.30).criterion
+        assert floor < inside, (
+            "the criterion now has an interior minimum above c=0.080; an optimum "
+            "can be quoted, which ADR-008 currently says it cannot"
+        )
+
+    def test_training_and_holdout_objectives_disagree_in_direction(self):
+        """The evidence that the gate is not a rubber stamp: a change
+        that hurts the training mean helps the holdout mean."""
+        base = evaluate_offense_master(0.118, 1.17).criterion
+        moved = evaluate_offense_master(0.118, 1.37).criterion
+        assert moved < base, "holdout no longer prefers s=1.37 over s=1.17"

--- a/tests/model_registry/test_holdout.py
+++ b/tests/model_registry/test_holdout.py
@@ -1,0 +1,186 @@
+"""Tests for the held-out evaluation.
+
+The headline requirement is that this gate CAN FAIL.  The gate it
+replaces could not: ``auto_refit_hill_curves.rebaseline_ktc_reconciliation``
+rewrites the KTC test's expectations from the challenger before the
+test runs, and KTC is a training source besides.  A validation gate
+whose only outcome is "pass" is worse than no gate, because it reports
+success.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from src.model_registry.holdout import (
+    MIN_ROWS_FOR_SCORING,
+    OFFENSE_HOLDOUT_SOURCES,
+    OFFENSE_TRAINING_SOURCES,
+    HoldoutError,
+    evaluate_offense_master,
+    hill,
+    source_roles,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _write_board(path: Path, values: list[float], column: str = "value") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["name", column])
+        w.writeheader()
+        for i, v in enumerate(values):
+            w.writerow({"name": f"player{i}", column: v})
+
+
+def _curve_board(c: float, s: float, n: int = 400) -> list[float]:
+    """A board that a curve with (c, s) fits exactly."""
+    return [hill(i / (n - 1), c, s) for i in range(n)]
+
+
+class TestTrainHoldoutSeparation:
+    """The split is the whole mechanism. Guard it from every angle."""
+
+    def test_no_source_is_in_both_sets(self):
+        assert not (set(OFFENSE_TRAINING_SOURCES) & set(OFFENSE_HOLDOUT_SOURCES))
+
+    def test_no_holdout_csv_is_a_training_csv(self):
+        """MECHANISM TEST. The split is by FILE, not by label — renaming
+        a training source would otherwise smuggle it into the holdout."""
+        train_paths = {p for p, _ in OFFENSE_TRAINING_SOURCES.values()}
+        for label, (path, _) in OFFENSE_HOLDOUT_SOURCES.items():
+            assert path not in train_paths, f"{label} points at a training CSV"
+
+    def test_overlapping_sets_raise_rather_than_score(self, tmp_path):
+        """A gate that scores a model on its own training data must
+        refuse, not return a good-looking number."""
+        board = tmp_path / "b.csv"
+        _write_board(board, _curve_board(0.118, 1.17))
+        shared = {"KTC": ("b.csv", "value")}
+        with pytest.raises(HoldoutError, match="BOTH the training and holdout"):
+            evaluate_offense_master(
+                0.118, 1.17, repo_root=tmp_path, holdout_sources=shared, training_sources=shared
+            )
+
+    def test_same_file_under_a_different_label_still_raises(self):
+        """MECHANISM TEST for the subtle version: relabel, same data."""
+        with pytest.raises(HoldoutError, match="point at a training CSV"):
+            evaluate_offense_master(
+                0.118,
+                1.17,
+                holdout_sources={"KTC_Renamed": ("CSVs/site_raw/ktc.csv", "value")},
+                training_sources=OFFENSE_TRAINING_SOURCES,
+            )
+
+    def test_ktc_sf_tep_is_not_treated_as_held_out(self):
+        """ktcSfTep is KTC's own board. Holding it out would be the
+        same market maker scoring its own fit."""
+        holdout_paths = {p for p, _ in OFFENSE_HOLDOUT_SOURCES.values()}
+        assert not any("ktc" in p.lower() for p in holdout_paths)
+
+    def test_roles_cover_every_configured_source(self):
+        roles = source_roles()
+        assert {r.label for r in roles if r.role == "train"} == set(OFFENSE_TRAINING_SOURCES)
+        assert {r.label for r in roles if r.role == "holdout"} == set(OFFENSE_HOLDOUT_SOURCES)
+
+
+class TestGateCanFail:
+    """The property the replaced gate lacked."""
+
+    def test_a_wrong_curve_scores_worse_than_the_right_one(self, tmp_path):
+        """MECHANISM TEST. If this ever stops discriminating, the
+        criterion has gone constant and the gate is decorative."""
+        _write_board(tmp_path / "h.csv", _curve_board(0.118, 1.17))
+        sources = {"H": ("h.csv", "value")}
+
+        exact = evaluate_offense_master(
+            0.118, 1.17, repo_root=tmp_path, holdout_sources=sources, training_sources={}
+        )
+        wrong = evaluate_offense_master(
+            0.200, 1.60, repo_root=tmp_path, holdout_sources=sources, training_sources={}
+        )
+        assert exact.criterion < 1.0, "a curve fitted exactly should score ~0"
+        assert wrong.criterion > 100.0
+        assert wrong.criterion > exact.criterion
+
+    def test_criterion_responds_monotonically_to_error(self, tmp_path):
+        _write_board(tmp_path / "h.csv", _curve_board(0.118, 1.17))
+        sources = {"H": ("h.csv", "value")}
+        scores = [
+            evaluate_offense_master(
+                c, 1.17, repo_root=tmp_path, holdout_sources=sources, training_sources={}
+            ).criterion
+            for c in (0.118, 0.128, 0.148, 0.188)
+        ]
+        assert scores == sorted(scores), f"criterion not monotonic in error: {scores}"
+
+
+class TestRefusesVacuousSuccess:
+    """No-evidence must not read as pass."""
+
+    def test_missing_boards_raise_rather_than_pass(self, tmp_path):
+        with pytest.raises(HoldoutError, match="no holdout board could be scored"):
+            evaluate_offense_master(
+                0.118,
+                1.17,
+                repo_root=tmp_path,
+                holdout_sources={"Gone": ("nope.csv", "value")},
+                training_sources={},
+            )
+
+    def test_thin_boards_are_skipped_and_named(self, tmp_path):
+        _write_board(tmp_path / "thin.csv", _curve_board(0.118, 1.17, n=10))
+        _write_board(tmp_path / "fat.csv", _curve_board(0.118, 1.17, n=400))
+        result = evaluate_offense_master(
+            0.118,
+            1.17,
+            repo_root=tmp_path,
+            holdout_sources={"Thin": ("thin.csv", "value"), "Fat": ("fat.csv", "value")},
+            training_sources={},
+        )
+        assert "Thin" in result.skipped
+        assert str(MIN_ROWS_FOR_SCORING) in result.skipped["Thin"]
+        assert "Fat" in result.per_source
+
+    def test_empty_holdout_config_raises(self):
+        with pytest.raises(HoldoutError, match="no holdout sources"):
+            evaluate_offense_master(0.118, 1.17, holdout_sources={}, training_sources={})
+
+
+class TestPayloadStatesItsLimits:
+    def test_serialized_result_says_what_it_does_not_measure(self, tmp_path):
+        _write_board(tmp_path / "h.csv", _curve_board(0.118, 1.17))
+        result = evaluate_offense_master(
+            0.118,
+            1.17,
+            repo_root=tmp_path,
+            holdout_sources={"H": ("h.csv", "value")},
+            training_sources={},
+        )
+        blob = result.to_dict()
+        assert "doesNotMeasure" in blob["_semantics"]
+        assert "ground truth" in blob["_semantics"]["doesNotMeasure"]
+        assert blob["criterionUnits"]
+        assert blob["trainingSources"] is not None
+
+
+@pytest.mark.livedata
+class TestAgainstRealBoards:
+    """The criterion must discriminate on the actual CSVs, not just
+    synthetic ones — the `_positional_coverage` lesson."""
+
+    def test_real_holdout_boards_produce_varying_scores(self):
+        result = evaluate_offense_master(0.118, 1.17)
+        assert len(result.per_source) >= 3
+        scores = list(result.per_source.values())
+        assert len(set(round(v, 2) for v in scores)) == len(scores)
+        assert max(scores) - min(scores) > 100, "all real boards score alike — suspicious"
+
+    def test_criterion_moves_on_real_boards(self):
+        base = evaluate_offense_master(0.118, 1.17).criterion
+        moved = evaluate_offense_master(0.098, 1.17).criterion
+        assert abs(base - moved) > 50, "real-board criterion is insensitive to the curve"

--- a/tests/model_registry/test_lifecycle.py
+++ b/tests/model_registry/test_lifecycle.py
@@ -1,0 +1,157 @@
+"""End-to-end: refit -> challenger -> validation -> promotion -> rollback.
+
+The unit tests cover each piece.  This covers the property that matters
+operationally: a challenger cannot reach production without clearing
+the gate, and a human can undo it in one step.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from src.model_registry.holdout import evaluate_offense_master, hill
+from src.model_registry.promotion import decide_promotion
+from src.model_registry.versioning import ModelRegistry, ModelVersion
+
+CHAMPION = {"HILL_PERCENTILE_C": 0.118, "HILL_PERCENTILE_S": 1.17}
+
+
+def _board(path: Path, c: float, s: float, n: int = 400) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["name", "value"])
+        w.writeheader()
+        for i in range(n):
+            w.writerow({"name": f"p{i}", "value": hill(i / (n - 1), c, s)})
+
+
+@pytest.fixture
+def world(tmp_path):
+    """Three held-out boards whose true shape is (0.100, 1.25).
+
+    The incumbent (0.118, 1.17) is therefore genuinely wrong, and a
+    challenger closer to the truth genuinely deserves promotion — the
+    fixture is not rigged toward either outcome.
+    """
+    for i in range(3):
+        _board(tmp_path / f"h{i}.csv", 0.100 + i * 0.002, 1.25)
+    sources = {f"H{i}": (f"h{i}.csv", "value") for i in range(3)}
+
+    def score(params):
+        return evaluate_offense_master(
+            params["HILL_PERCENTILE_C"],
+            params["HILL_PERCENTILE_S"],
+            repo_root=tmp_path,
+            holdout_sources=sources,
+            training_sources={},
+        )
+
+    return score
+
+
+def _registry(champ_holdout=None) -> ModelRegistry:
+    reg = ModelRegistry("hill")
+    reg.seed_champion(
+        ModelVersion(
+            model_id="hill",
+            version=1,
+            params=dict(CHAMPION),
+            fitted_at="2026-07-01T00:00:00+00:00",
+            producer="seed",
+            holdout=champ_holdout,
+        )
+    )
+    return reg
+
+
+def test_a_better_challenger_is_promoted_and_can_be_rolled_back(world, tmp_path):
+    champ_score = world(CHAMPION)
+    reg = _registry(champ_score.to_dict())
+
+    better = {"HILL_PERCENTILE_C": 0.101, "HILL_PERCENTILE_S": 1.24}
+    chal_score = world(better)
+    reg.add(
+        ModelVersion(
+            model_id="hill",
+            version=2,
+            params=better,
+            fitted_at="2026-07-08T00:00:00+00:00",
+            producer="refit",
+            holdout=chal_score.to_dict(),
+        )
+    )
+
+    decision = decide_promotion(champ_score.criterion, chal_score.criterion)
+    assert decision.promote, decision.reason
+
+    reg.promote(2, reason=decision.reason)
+    assert reg.champion.params == better
+    assert reg.champion.confidence == "measured"
+
+    reg.rollback(reason="prod regression")
+    assert reg.champion.params == CHAMPION
+
+    reg.save(tmp_path)
+    assert ModelRegistry.load("hill", tmp_path).champion.params == CHAMPION
+
+
+def test_a_worse_challenger_never_reaches_production(world):
+    """MECHANISM TEST. The gate's reason for existing."""
+    champ_score = world(CHAMPION)
+    reg = _registry(champ_score.to_dict())
+
+    worse = {"HILL_PERCENTILE_C": 0.180, "HILL_PERCENTILE_S": 1.60}
+    chal_score = world(worse)
+    reg.add(
+        ModelVersion(
+            model_id="hill",
+            version=2,
+            params=worse,
+            fitted_at="",
+            producer="refit",
+            holdout=chal_score.to_dict(),
+        )
+    )
+
+    decision = decide_promotion(champ_score.criterion, chal_score.criterion)
+    assert not decision.promote
+    reg.reject(2, reason=decision.reason)
+
+    assert reg.champion.version == 1
+    assert reg.champion.params == CHAMPION
+    assert reg.get(2).status == "rejected"
+
+
+def test_a_noise_level_challenger_does_not_churn_production(world):
+    champ_score = world(CHAMPION)
+    nudged = world({"HILL_PERCENTILE_C": 0.1181, "HILL_PERCENTILE_S": 1.17})
+    decision = decide_promotion(champ_score.criterion, nudged.criterion)
+    assert not decision.promote
+
+
+def test_an_unevaluated_champion_blocks_the_whole_pipeline(world):
+    """MECHANISM TEST. Without this, the FIRST refit after the registry
+    is seeded would promote unopposed — exactly the autonomous rewrite
+    the directive prohibits."""
+    reg = _registry(champ_holdout=None)
+    assert not reg.champion.qualified
+
+    chal_score = world({"HILL_PERCENTILE_C": 0.100, "HILL_PERCENTILE_S": 1.25})
+    decision = decide_promotion((reg.champion.holdout or {}).get("criterion"), chal_score.criterion)
+    assert not decision.promote
+    assert "unmeasured incumbent" in decision.reason
+
+
+@pytest.mark.livedata
+def test_the_shipped_registry_is_coherent():
+    """The committed registry must load, have exactly one champion, and
+    state its own confidence."""
+    reg = ModelRegistry.load("hill_scope_masters")
+    assert reg.champion
+    assert reg.champion.confidence in {"unvalidated", "provisional", "measured"}
+    if reg.champion.qualified:
+        assert reg.champion.holdout["criterion"] > 0
+        assert "doesNotMeasure" in reg.champion.holdout["_semantics"]

--- a/tests/model_registry/test_promotion.py
+++ b/tests/model_registry/test_promotion.py
@@ -1,0 +1,89 @@
+"""Tests for the champion-challenger decision."""
+
+from __future__ import annotations
+
+from src.model_registry.promotion import (
+    PROMOTION_MARGIN,
+    REGRESSION_ALARM,
+    decide_promotion,
+)
+
+
+class TestGateHasBothOutcomes:
+    """A gate with one possible outcome is not a gate."""
+
+    def test_a_clear_win_promotes(self):
+        d = decide_promotion(900.0, 600.0)
+        assert d.promote
+        assert d.improvement == 300.0
+
+    def test_a_clear_loss_rejects(self):
+        d = decide_promotion(600.0, 700.0)
+        assert not d.promote
+        assert d.improvement == -100.0
+
+    def test_both_outcomes_are_reachable(self):
+        outcomes = {decide_promotion(800.0, x).promote for x in (500.0, 799.0, 900.0)}
+        assert outcomes == {True, False}
+
+
+class TestMargin:
+    def test_improvement_inside_the_margin_does_not_promote(self):
+        d = decide_promotion(800.0, 800.0 - (PROMOTION_MARGIN - 1))
+        assert not d.promote
+        assert "margin" in d.reason
+
+    def test_improvement_at_the_margin_promotes(self):
+        d = decide_promotion(800.0, 800.0 - PROMOTION_MARGIN)
+        assert d.promote
+
+    def test_ties_go_to_the_incumbent(self):
+        assert not decide_promotion(700.0, 700.0).promote
+
+    def test_a_hair_better_is_not_better(self):
+        """The specific failure a bare `<` produces: promoting weekly on
+        noise, a random walk that always reports an improvement."""
+        assert not decide_promotion(700.0, 699.99).promote
+
+    def test_margin_clears_the_measured_noise_floor(self):
+        """The paired-delta sd measured across 30 real snapshots was at
+        most 1.51 points. The margin must sit well above it."""
+        assert PROMOTION_MARGIN > 1.51 * 10
+
+
+class TestUnmeasuredIncumbent:
+    def test_unmeasured_champion_blocks_promotion(self):
+        """MECHANISM TEST. An unmeasured incumbent is unknown, not
+        beaten — promoting past it is the autonomous rewrite the
+        directive prohibits."""
+        d = decide_promotion(None, 1.0)
+        assert not d.promote
+        assert "unmeasured incumbent is unknown" in d.reason
+
+    def test_even_a_spectacular_challenger_cannot_pass_an_unmeasured_champion(self):
+        assert not decide_promotion(None, 0.0).promote
+
+
+class TestRegressionAlarm:
+    def test_large_regression_raises_the_alarm(self):
+        d = decide_promotion(500.0, 500.0 + REGRESSION_ALARM + 1)
+        assert not d.promote
+        assert d.alarm
+        assert "investigate" in d.reason
+
+    def test_ordinary_regression_does_not_alarm(self):
+        d = decide_promotion(500.0, 550.0)
+        assert not d.promote
+        assert not d.alarm
+
+
+class TestPayloadHonesty:
+    def test_decision_states_what_a_promotion_means(self):
+        blob = decide_promotion(900.0, 600.0).to_dict()
+        assert "NOT that it is more accurate" in blob["_semantics"]["warning"]
+        assert blob["improvement"] == 300.0
+        assert blob["marginRequired"] == PROMOTION_MARGIN
+
+    def test_reason_is_always_populated(self):
+        for champ, chal in ((None, 1.0), (500.0, 499.0), (500.0, 400.0), (500.0, 900.0)):
+            assert decide_promotion(champ, chal).reason.strip()

--- a/tests/model_registry/test_refit_path_characterisation.py
+++ b/tests/model_registry/test_refit_path_characterisation.py
@@ -180,3 +180,37 @@ class TestTheCircularityIsReal:
 
                 assert ours == pinned_ours
                 assert abs(actual_pct - pinned_pct) <= 10.0
+
+
+class TestTheGuardIsNotEvenRun:
+    """Reason three, independent of the other two.
+
+    ``tests/conftest.py`` auto-marks ``test_ktc_reconciliation.py``
+    ``livedata``, and the refit workflow's regression step runs
+    ``pytest tests/ -q -m "not livedata"``.  So the refit rewrites the
+    guard's expectations and then deselects the guard.
+
+    Each of the three defects is individually sufficient; together they
+    mean the constants reach production with no check of any kind.
+    """
+
+    def test_the_guard_module_is_auto_marked_livedata(self):
+        conftest = (REPO / "tests" / "conftest.py").read_text()
+        block = conftest.split("_LIVEDATA_MODULES")[1].split(")")[0]
+        assert '"test_ktc_reconciliation.py"' in block
+
+    def test_the_refit_workflow_excludes_livedata(self):
+        wf = WORKFLOW.read_text()
+        assert 'pytest tests/ -q -m "not livedata"' in wf
+
+    def test_the_two_combine_to_deselect_the_guard(self):
+        """MECHANISM TEST. Fails if either the marking or the filter
+        changes such that the guard would actually run — at which point
+        the other two defects become load-bearing again."""
+        conftest = (REPO / "tests" / "conftest.py").read_text()
+        marked = '"test_ktc_reconciliation.py"' in conftest.split("_LIVEDATA_MODULES")[1]
+        excluded = 'm "not livedata"' in WORKFLOW.read_text()
+        assert marked and excluded, (
+            "the refit's regression step would now run the KTC guard; "
+            "re-check whether the rebaseline circularity still makes it vacuous"
+        )

--- a/tests/model_registry/test_refit_path_characterisation.py
+++ b/tests/model_registry/test_refit_path_characterisation.py
@@ -1,0 +1,182 @@
+"""Pins the honest characterisation of the EXISTING refit path.
+
+These tests do not assert that the current behaviour is good.  They
+assert that it is what this workstream documented it to be, so that the
+finding cannot rot and so a future change to the refit path shows up
+here rather than in a surprise.
+
+The finding, in one sentence: the weekly refit rewrites production
+constants AND rewrites the only test that guards them, from the
+challenger's own output, against a board that is also a training
+source — so the guard cannot fail.
+
+Source of truth for the claims:
+  scripts/auto_refit_hill_curves.py
+  .github/workflows/refit-hill-curves.yml
+  tests/canonical/test_ktc_reconciliation.py
+  scripts/fit_hill_curve_percentile.py
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.model_registry.holdout import OFFENSE_TRAINING_SOURCES
+
+REPO = Path(__file__).resolve().parents[2]
+REFIT = REPO / "scripts" / "auto_refit_hill_curves.py"
+FIT = REPO / "scripts" / "fit_hill_curve_percentile.py"
+KTC_TEST = REPO / "tests" / "canonical" / "test_ktc_reconciliation.py"
+WORKFLOW = REPO / ".github" / "workflows" / "refit-hill-curves.yml"
+PLAYER_VALUATION = REPO / "src" / "canonical" / "player_valuation.py"
+
+
+def _strip_comments_and_docstrings(text: str) -> str:
+    """Assert on code, not on prose about the code.
+
+    ORCHESTRATION.md §2b records a matcher that passed on the CSS
+    *comments* documenting a rule rather than the rule itself.  Same
+    trap applies here: every claim below is about behaviour, and a
+    docstring describing the behaviour must not satisfy it.
+    """
+    text = re.sub(r'"""(?:.|\n)*?"""', "", text)
+    text = re.sub(r"'''(?:.|\n)*?'''", "", text)
+    return re.sub(r"(?m)#.*$", "", text)
+
+
+class TestTheRefitRewritesProductionCode:
+    def test_refit_writes_player_valuation(self):
+        code = _strip_comments_and_docstrings(REFIT.read_text())
+        assert "PLAYER_VALUATION.write_text" in code
+
+    def test_refit_writes_its_own_guard_test(self):
+        code = _strip_comments_and_docstrings(REFIT.read_text())
+        assert "KTC_RECONCILIATION_TEST.write_text" in code
+
+    def test_workflow_commits_both_files_unreviewed(self):
+        wf = WORKFLOW.read_text()
+        assert "git commit" in wf and "git push" in wf
+        assert "src/canonical/player_valuation.py" in wf
+        assert "tests/canonical/test_ktc_reconciliation.py" in wf
+
+
+class TestTheGuardCannotFail:
+    """Two independent reasons, either one sufficient."""
+
+    def test_reason_one_the_pins_are_recomputed_from_the_challenger(self):
+        """``rebaseline_ktc_reconciliation`` derives ``ours`` from the
+        NEW constants and writes it as the expected value, so the
+        test's exact pin has a zero residual by construction."""
+        code = _strip_comments_and_docstrings(REFIT.read_text())
+        fn = code.split("def rebaseline_ktc_reconciliation")[1].split("\ndef ")[0]
+        assert 'c_off = fitted["HILL_PERCENTILE_C"]' in fn
+        assert "_hill(p, c_off, s_off)" in fn
+        assert "pct_diff" in fn
+        assert "PINNED_DELTAS" in fn
+
+    def test_the_guard_asserts_exactly_what_the_refit_wrote(self):
+        code = _strip_comments_and_docstrings(KTC_TEST.read_text())
+        assert "assert ours == pinned_ours" in code
+        assert "abs(actual_pct - pinned_pct) <= tolerance_pp" in code
+
+    def test_reason_two_ktc_is_a_training_source(self):
+        """Even with honest pins, scoring the OFFENSE master against KTC
+        is training-set validation — ORCHESTRATION.md §2b."""
+        fit_code = FIT.read_text()
+        offense_block = fit_code.split("OFFENSE_SOURCES")[1].split("}")[0]
+        assert "ktc.csv" in offense_block
+        assert "KTC" in OFFENSE_TRAINING_SOURCES
+
+    def test_the_guarded_constants_are_the_ones_ktc_trains(self):
+        """Closes the loop: the fit trains HILL_PERCENTILE_C/S from a
+        set containing KTC, and the guard evaluates exactly those."""
+        refit_code = REFIT.read_text()
+        assert '"OFFENSE": ("HILL_PERCENTILE_C", "HILL_PERCENTILE_S")' in refit_code
+        pv = _strip_comments_and_docstrings(PLAYER_VALUATION.read_text())
+        sig = pv.split("def percentile_to_value")[1].split(")")[0]
+        assert "midpoint: float = HILL_PERCENTILE_C" in sig
+        assert "slope: float = HILL_PERCENTILE_S" in sig
+
+    def test_the_workflow_already_admits_the_circularity(self):
+        """The comment is in the repo today. This pins it so the fix
+        cannot be claimed without removing the admission."""
+        wf = WORKFLOW.read_text()
+        assert "circular" in wf.lower()
+
+
+class TestParityWithTheFitSourceList:
+    """The holdout module mirrors OFFENSE_SOURCES as a literal. If the
+    fit gains a source and the mirror does not, a training board
+    silently becomes eligible as holdout."""
+
+    def test_training_mirror_matches_the_fit_script(self):
+        fit_code = FIT.read_text()
+        block = fit_code.split("OFFENSE_SOURCES: dict[str, tuple[str, str]] = {")[1]
+        block = block.split("}")[0]
+        found = set(re.findall(r'^\s*"([A-Za-z]+)":', block, re.MULTILINE))
+        assert found == set(OFFENSE_TRAINING_SOURCES), (
+            f"fit script has {sorted(found)}, holdout mirror has "
+            f"{sorted(OFFENSE_TRAINING_SOURCES)} — update src/model_registry/holdout.py"
+        )
+
+    def test_mirrored_paths_match_the_fit_script(self):
+        fit_code = FIT.read_text()
+        block = fit_code.split("OFFENSE_SOURCES: dict[str, tuple[str, str]] = {")[1]
+        block = block.split("}")[0]
+        for label, (path, _) in OFFENSE_TRAINING_SOURCES.items():
+            assert path in block, f"{label} path {path} not in the fit script"
+
+
+@pytest.mark.livedata
+class TestTheCircularityIsReal:
+    """Demonstrate it rather than only asserting the code shape."""
+
+    def test_rebaselining_drives_the_residual_to_zero(self):
+        """Recompute the pins the way the refit does, then check the
+        guard's own assertion against them: the residual is identically
+        zero, for ANY curve — which is what 'cannot fail' means."""
+        from src.model_registry.holdout import hill
+
+        ktc_csv = REPO / "CSVs" / "site_raw" / "ktc.csv"
+        if not ktc_csv.exists():
+            pytest.skip("KTC fixture missing")
+
+        import csv as _csv
+
+        pick = re.compile(r"^\d{4}\s+(Early|Mid|Late)\s+\d", re.IGNORECASE)
+        rows: list[int] = []
+        with ktc_csv.open(encoding="utf-8") as f:
+            for r in _csv.DictReader(f):
+                name = (r.get("name") or "").strip()
+                val = (r.get("value") or "").strip()
+                if not name or not val or pick.match(name):
+                    continue
+                try:
+                    rows.append(int(val))
+                except ValueError:
+                    continue
+        rows.sort(reverse=True)
+
+        ref_n = int(
+            re.search(
+                r"_PERCENTILE_REFERENCE_N:\s*int\s*=\s*(\d+)",
+                (REPO / "src" / "api" / "data_contract.py").read_text(),
+            ).group(1)
+        )
+
+        # Two wildly different "challengers". Both must pass the
+        # rebaselined guard, which is the whole problem.
+        for c, s in ((0.118, 1.17), (0.300, 2.50)):
+            for rank in (1, 12, 50, 150, 400):
+                ktc = rows[rank - 1]
+                p = max(0.0, min(1.0, (rank - 1) / (ref_n - 1)))
+                ours = int(round(hill(p, c, s)))
+                pinned_ours = ours  # what rebaseline writes
+                pinned_pct = round(100.0 * (ours - ktc) / ktc, 1)
+                actual_pct = 100.0 * (ours - ktc) / ktc
+
+                assert ours == pinned_ours
+                assert abs(actual_pct - pinned_pct) <= 10.0

--- a/tests/model_registry/test_versioning.py
+++ b/tests/model_registry/test_versioning.py
@@ -1,0 +1,239 @@
+"""Tests for model versioning, the champion pointer, and rollback."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.model_registry.versioning import (
+    ModelRegistry,
+    ModelVersion,
+    RegistryError,
+    fingerprint_file,
+    fingerprint_inputs,
+)
+
+PARAMS = {"HILL_PERCENTILE_C": 0.118, "HILL_PERCENTILE_S": 1.17}
+
+
+def _v(n: int, *, status: str = "challenger", holdout=None, **kw) -> ModelVersion:
+    return ModelVersion(
+        model_id="m",
+        version=n,
+        params=dict(PARAMS),
+        fitted_at=f"2026-07-{n:02d}T00:00:00+00:00",
+        producer="test",
+        status=status,
+        holdout=holdout,
+        **kw,
+    )
+
+
+class TestInvariants:
+    def test_two_champions_is_rejected(self):
+        with pytest.raises(RegistryError, match="2 champions"):
+            ModelRegistry("m", [_v(1, status="champion"), _v(2, status="champion")])
+
+    def test_duplicate_versions_rejected(self):
+        with pytest.raises(RegistryError, match="duplicate version"):
+            ModelRegistry("m", [_v(1), _v(1)])
+
+    def test_foreign_version_rejected(self):
+        other = ModelVersion(model_id="other", version=1, params={}, fitted_at="", producer="x")
+        with pytest.raises(RegistryError, match="belongs to"):
+            ModelRegistry("m", [other])
+
+    def test_unknown_status_rejected(self):
+        with pytest.raises(RegistryError, match="unknown status"):
+            _v(1, status="great")
+
+    def test_add_cannot_introduce_a_champion(self):
+        """MECHANISM TEST. A refit must not be able to write itself
+        straight to champion — promotion has to be its own recorded act."""
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        with pytest.raises(RegistryError, match="cannot introduce a champion"):
+            reg.add(_v(2, status="champion"))
+
+
+class TestPromotion:
+    def test_promote_retires_the_incumbent(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        reg.add(_v(2))
+        reg.promote(2, reason="beat it")
+        assert reg.champion.version == 2
+        assert reg.get(1).status == "retired"
+        assert reg.get(1).retired_at
+
+    def test_promotion_reason_is_mandatory_and_recorded(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        reg.add(_v(2))
+        with pytest.raises(RegistryError, match="non-empty reason"):
+            reg.promote(2, reason="   ")
+        reg.promote(2, reason="held-out win")
+        assert any("held-out win" in n for n in reg.champion.notes)
+
+    def test_rejected_versions_are_kept_not_deleted(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        reg.add(_v(2))
+        reg.reject(2, reason="lost")
+        assert reg.get(2).status == "rejected"
+        assert len(reg.versions) == 2
+
+    def test_champion_cannot_be_rejected(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        with pytest.raises(RegistryError, match="cannot be rejected"):
+            reg.reject(1, reason="nope")
+
+    def test_seeding_twice_is_refused(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        with pytest.raises(RegistryError, match="already has a champion"):
+            reg.seed_champion(_v(2))
+
+
+class TestRollback:
+    def test_rollback_reinstates_the_previous_champion(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        reg.add(_v(2))
+        reg.promote(2, reason="win")
+        reg.rollback(reason="regression in prod")
+        assert reg.champion.version == 1
+        assert reg.get(2).status == "retired"
+        assert any("rolled back" in n for n in reg.get(2).notes)
+
+    def test_rollback_picks_the_most_recent_former_champion(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        reg.add(_v(2))
+        reg.add(_v(3))
+        reg.promote(2, reason="a")
+        reg.promote(3, reason="b")
+        reg.rollback(reason="undo")
+        assert reg.champion.version == 2, "rollback must undo one step, not jump to v1"
+
+    def test_rollback_refuses_a_version_that_was_never_champion(self):
+        """MECHANISM TEST. Rolling back to something never live is an
+        unvalidated promotion wearing the word 'rollback'."""
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        reg.add(_v(2))
+        reg.add(_v(3))
+        reg.promote(2, reason="a")
+        with pytest.raises(RegistryError, match="never a champion"):
+            reg.rollback(to_version=3, reason="sideways")
+
+    def test_rollback_with_no_history_refuses(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        with pytest.raises(RegistryError, match="no former champion"):
+            reg.rollback(reason="undo")
+
+    def test_rollback_reason_is_mandatory(self):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        reg.add(_v(2))
+        reg.promote(2, reason="a")
+        with pytest.raises(RegistryError, match="non-empty reason"):
+            reg.rollback(reason="")
+
+    def test_round_trip_returns_to_the_original_params(self):
+        """Rollback must restore the exact numbers, not approximately."""
+        reg = ModelRegistry("m")
+        original = {"HILL_PERCENTILE_C": 0.118, "HILL_PERCENTILE_S": 1.17}
+        reg.seed_champion(
+            ModelVersion(model_id="m", version=1, params=original, fitted_at="", producer="t")
+        )
+        reg.add(
+            ModelVersion(
+                model_id="m",
+                version=2,
+                params={"HILL_PERCENTILE_C": 0.098, "HILL_PERCENTILE_S": 1.30},
+                fitted_at="",
+                producer="t",
+            )
+        )
+        reg.promote(2, reason="win")
+        reg.rollback(reason="undo")
+        assert reg.champion.params == original
+
+
+class TestConfidenceHonesty:
+    """The directive's 'do not present low-confidence output as precise'."""
+
+    def test_unevaluated_version_is_unqualified(self):
+        v = _v(1)
+        assert not v.qualified
+        assert v.confidence == "unvalidated"
+
+    def test_holdout_without_a_criterion_does_not_qualify(self):
+        """MECHANISM TEST. A holdout block that exists but carries no
+        score must not read as validated."""
+        v = _v(1, holdout={"perSource": {"A": 1.0}, "criterion": None})
+        assert not v.qualified
+        assert v.confidence == "unvalidated"
+
+    def test_thin_evidence_reads_provisional_not_measured(self):
+        v = _v(1, holdout={"criterion": 500.0, "perSource": {"A": 500.0}})
+        assert v.qualified
+        assert v.confidence == "provisional"
+
+    def test_broad_evidence_reads_measured(self):
+        v = _v(1, holdout={"criterion": 500.0, "perSource": dict.fromkeys("abc", 500.0)})
+        assert v.confidence == "measured"
+
+    def test_confidence_is_serialized(self):
+        blob = _v(1).to_dict()
+        assert blob["confidence"] == "unvalidated"
+        assert blob["qualified"] is False
+
+
+class TestPersistence:
+    def test_round_trips_through_disk(self, tmp_path):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1, holdout={"criterion": 12.5, "perSource": {"A": 12.5}}))
+        reg.add(_v(2))
+        reg.promote(2, reason="win")
+        reg.save(tmp_path)
+
+        loaded = ModelRegistry.load("m", tmp_path)
+        assert loaded.champion.version == 2
+        assert loaded.get(1).status == "retired"
+        assert loaded.get(1).holdout["criterion"] == 12.5
+
+    def test_saved_document_names_the_champion(self, tmp_path):
+        reg = ModelRegistry("m")
+        reg.seed_champion(_v(1))
+        path = reg.save(tmp_path)
+        blob = json.loads(path.read_text())
+        assert blob["championVersion"] == 1
+        assert blob["schemaVersion"] == 1
+
+    def test_missing_registry_raises(self, tmp_path):
+        with pytest.raises(RegistryError, match="no registry"):
+            ModelRegistry.load("nope", tmp_path)
+
+
+class TestProvenance:
+    def test_fingerprint_changes_with_content(self, tmp_path):
+        p = tmp_path / "a.csv"
+        p.write_text("a,b\n1,2\n")
+        first = fingerprint_file(p)
+        p.write_text("a,b\n1,3\n")
+        assert fingerprint_file(p) != first
+
+    def test_missing_inputs_are_stamped_not_dropped(self, tmp_path):
+        """MECHANISM TEST. Omitting a missing input would make a fit on
+        five sources indistinguishable from one on six."""
+        present = tmp_path / "p.csv"
+        present.write_text("x\n1\n")
+        out = fingerprint_inputs({"P": present, "Gone": tmp_path / "nope.csv"})
+        assert out["Gone"] == "missing"
+        assert out["P"].startswith("sha256:")
+        assert len(out) == 2


### PR DESCRIPTION
> **Scope, up front.** This PR **changes no live player values.**
> `src/canonical/player_valuation.py` is byte-identical to `main`.
> `refit-hill-curves.yml` and `auto_refit_hill_curves.py` are untouched.
> It adds a registry, an out-of-sample gate, and rollback — nothing runs on a schedule and no endpoint changes.
> It reports one finding about the live curve **without applying it**, and it does **not** claim the current curve is wrong — see the per-board table below.

## A workflow rewrites production valuation constants weekly, and nothing checks it

Not "a circular check". Not "a weak check". **None.**

`.github/workflows/refit-hill-curves.yml` runs every Tuesday. On drift above threshold it rewrites the eight `HILL_*_C/S` constants in `src/canonical/player_valuation.py` — step 3 of the Final Framework, which determines every displayed value on the board — commits to `main`, and triggers `deploy.yml`. No human sees the diff.

The governing WS-J directive says, in these words:

> Do not allow a model to autonomously rewrite production code. Use controlled retraining, champion–challenger validation, model versioning, and rollback. Do not present low-confidence output as precise.

This is that, exactly.

### Reason 3 is the one that matters: the guard is never run

`tests/conftest.py` auto-marks `test_ktc_reconciliation.py` as `livedata` (it is in `_LIVEDATA_MODULES`). The refit's regression step is `pytest tests/ -q -m "not livedata"`.

Measured:

```
$ python -m pytest tests/canonical/test_ktc_reconciliation.py -q -m "not livedata"
13 deselected in 0.03s
```

**13 deselected, 0 run.** The refit rewrites the guard's expected values and then skips the guard.

The `livedata` marking is itself defensible — it was added because data-coupled failures were blocking every PR. Its interaction with the refit was not considered, and the effect is that the one test written to guard these constants is the one test guaranteed not to see them.

### Reasons 1 and 2 make the guard weak (they matter only once 3 is fixed)

**1. The pins are recomputed from the challenger.** `auto_refit_hill_curves.rebaseline_ktc_reconciliation` computes `ours = _hill(p, c_new, s_new)`, writes it as the test's `pinned_ours`, and derives `pct_diff` from that same value against the same `ktc.csv` the test reads. Both assertions have a zero residual by construction.

Demonstrated, not argued: running the rebaseline arithmetic for `(c=0.118, s=1.17)` and `(c=0.300, s=2.50)` — two wildly different curves — passes **every pinned rank in both cases**.

**2. KTC is a training source.** `ktc.csv` is in `fit_hill_curve_percentile.OFFENSE_SOURCES`, which fits `HILL_PERCENTILE_C/S` — precisely the constants `percentile_to_value` uses and the test evaluates. ORCHESTRATION.md §2b: the assumption reflected back.

The repo half-knew about (1). The workflow comments that gating on the pins "is circular" and uses that to justify *excluding* them from the blocking gate. That is how a deliberate decision became an invisible hole.

---

## What this adds

`src/model_registry/` — no scheduled entry point, no import of the valuation pipeline, no endpoint touched.

| Module | Role |
|---|---|
| `versioning.py` | Versions with provenance (params, producer, sha256 per training input); one champion pointer; promote / reject / rollback as recorded ops |
| `holdout.py` | Out-of-sample scoring against boards the fit never reads |
| `promotion.py` | The champion–challenger decision |
| `scripts/model_registry.py` | `status`, `sources`, `evaluate`, `register`, `validate`, `promote`, `rollback`, `apply` |

**Rollback is two commands**, not a hand-edit of eight floats from a diff:

```
python3 scripts/model_registry.py rollback --reason "bad refit"
python3 scripts/model_registry.py apply
```

Only a *former champion* is a valid rollback target — reinstating something never live is an unvalidated promotion wearing the word.

### The gate can fail, and I checked

Four value-publishing dynasty boards the fit never reads: **FantasyCalc, OTCFFB, PFKDynasty, FantasyNavigator**. Same metric as the fit's own objective (top-400, native percentile, top anchored at 9999) so the numbers are comparable; different data, so the check can fail.

- The split is enforced by **file path, not label**. `ktcSfTep` is deliberately excluded despite being absent from the fit's source dict — it is KeepTradeCut's own board, the same market maker as the `KTC` training source.
- Evaluation **raises** rather than returning a passing score when it would be vacuous (overlap, missing boards, thin boards). No-evidence must not read as pass.

**Training and holdout disagree in direction.** Moving to `s=1.37` makes the training mean *worse* (774.4 → 796.8) while making the holdout mean *better* (849.8 → 758.2). A rubber stamp cannot disagree with what it stamps.

### The margin is measured, not chosen

Champion and challenger always score the *same* snapshot, so market drift is common-mode and cancels. Across 30 real FantasyCalc snapshots (2026-04-03 → 04-08):

| quantity | result |
|---|---|
| absolute criterion | 584.90 – 653.04, sd **19.28** |
| paired delta, two fixed curves | worst sd **1.51**, **0 sign flips in 29 pairs** |

Noise floor is ~1.5, not ~19. `PROMOTION_MARGIN = 25` sits ~16× above it. Ties go to the incumbent.

**An unmeasured incumbent blocks promotion.** If the champion has no out-of-sample score, no challenger passes it — otherwise the first refit after seeding would promote unopposed, reproducing the autonomous rewrite in a new costume.

**Confidence honesty is structural.** A version with no held-out score is `qualified=False` / `confidence="unvalidated"` and `status` prints a warning. Buckets are coarse (`unvalidated` / `provisional` / `measured`) on purpose — a continuous confidence score here would itself be an unvalidated model.

---

## Finding: the champion sits off the mean-holdout optimum — NOT included, and narrower than it first looked

**No values change in this PR.** `src/canonical/player_valuation.py` is byte-identical; `apply --dry-run` reports the shipped champion already matches the live constants (exit 1, no change). Do not merge this thinking values moved.

Live champion `c=0.118, s=1.17` scores **849.8**. A first pass recorded "~200 points off optimum at `c=0.098`". Measuring **per board** instead of on the mean showed that too strong and too specific, so it is corrected rather than quietly dropped:

| board | role | RMSE @ champion | best on grid | best `c` |
|---|---|---|---|---|
| FantasyCalc | holdout | 852.6 | 321.2 | 0.080 |
| FantasyNavigator | holdout | 1185.2 | 401.5 | 0.080 |
| OTCFFB | holdout | 1104.9 | 395.8 | 0.080 |
| PFKDynasty | holdout | 256.7 | 240.3 | 0.112 |
| KTC | train | 816.6 | 172.6 | 0.144 |
| Fitzmaurice | train | 1116.3 | 514.8 | 0.180 |

1. **The boards disagree.** At `c=0.098` three improve by 287–304 points and **PFKDynasty gets worse by 80.5** — and PFKDynasty is the board the champion already fits best (256.7 vs a best-possible 240.3, i.e. within ~16 points of *that* board's optimum). Three boards outvoting one, not a consensus.
2. **The mean "optimum" is a boundary solution — so "optimum" was never an available word.** Three of four holdout boards bottom out at `c=0.080`, the *edge of the search grid*. Nothing is bracketed: the criterion is still falling when the grid runs out, so no specific `(c, s)` has been shown to be a minimum at all.
3. **Training boards disagree at least as much** (KTC 0.144, Fitzmaurice 0.180, DraftSharks 0.080). The champion sits near the *training* mean optimum (750.8 vs its 774.4) and far from the *holdout* one — consistent with the fit tracking its own sources, which is what a holdout is for.

**Supported:** the mean criterion over these four boards improves at lower `c`, driven by three of them.
**Not supported:** the champion is wrong. These four boards may share a curve shape the fit sources do not, in which case the "optimum" moves with that shared bias rather than toward accuracy. Separating the two needs evidence outside all ten boards, and none exists here.

`TestTheBoardsDisagree` pins this, including a mechanism test that **fails if the criterion ever develops an interior minimum above the grid floor** — at which point an optimum could honestly be quoted and this narrowing must be revisited. The caveat expires automatically when the evidence changes rather than surviving as a permanent hedge.

---

## Not implemented, and why

- **Temporal holdout.** Rejected as unbuildable rather than built weakly. `data/raw/ktc/2026/` holds 30 snapshots spanning 2026-04-17 → 04-20 — four days, three months stale. A four-day forward window cannot separate curve quality from a quiet market. If snapshot retention reaches a season, this becomes the stronger criterion and should replace the cross-source one.
- **IDP / GLOBAL / ROOKIE validation.** All eight constants are versioned; only the **OFFENSE pair** has a genuine holdout today. The other scopes train on IDPTradeCalc and DraftSharks, and the remaining IDP boards in the repo have not been checked for independence from the fit. Stated in the payload rather than papered over.
- **The workflow rewiring itself.** `refit-hill-curves.yml` and `auto_refit_hill_curves.py` are **untouched, deliberately.** Fixing production automation that pushes to `main` is scoped separately from the change that characterises the defect. The proposed five-step wiring is in ADR-008 for its own review.

## Validation

- `tests/model_registry/`: **77 passed** — 69 in the blocking gate, 8 `livedata` (both tiers run and green).
- Full blocking suite on the final tree:

```
3177 passed, 288 deselected, 1 warning, 4 subtests passed in 901.63s (0:15:01)
```

  Zero failures, zero errors. Quoted from the summary line, not inferred from an absence of `FAILED` — two earlier runs of this suite were **killed** (exit 144) at 29% with clean-looking dots and no summary, which is indistinguishable from a slow run if you only check for failures.
- `python -m ruff check` + `format --check` clean under the pinned ruff 0.6.9 (`python -m ruff`, not the PATH binary, which is 0.15.8 and disagrees).
- Branch point is `49e005b2`; diffed against the **merge base** rather than the tip of `main`. 13 files, 2,550 insertions, additions only. `main` has since moved (#558, #560, #561, a DLF refresh) but touches none of the files this PR's characterisation tests bind to — `refit-hill-curves.yml`, `tests/conftest.py`, `auto_refit_hill_curves.py`, `fit_hill_curve_percentile.py`, `player_valuation.py`, the source CSVs are all unchanged — so every measured number above still holds. File sets are disjoint; no conflict.

Two catches worth naming, both on my own work:

- A test found a **real bug**: `holdout_sources={}` is falsy, so an explicitly empty holdout set silently fell back to the defaults and returned a **passing** score. Fixed with `is None`.
- §2b applied where it is hardest — I patched `auto_refit_hill_curves.py` to simulate the defect being *fixed* and confirmed the characterisation test **actually fails** there. It tracks the code, not prose about the code. (Comments and docstrings are stripped before matching, after the R3 incident where a matcher passed on the comments documenting a rule rather than the rule.)

Also records in ORCHESTRATION.md §2b the general law from the WS-J roster work: **an underfed fixture is indistinguishable from a collapsed metric**, and **a state that can never fire looks exactly like a state that never happens.**

ADR-008: `docs/roster-trade-intelligence/DECISIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_