### PR TITLE
LI-8 League Twin: resolve the sim collision, fix an inert hybrid-eligibility path, bridge rosters into playoff odds

### DIFF
--- a/docs/league-intelligence/DECISIONS.md
+++ b/docs/league-intelligence/DECISIONS.md
@@ -38,6 +38,65 @@ adoption land immediately after R2 merges, through the stable R1 shell
 unvalidated number.
 **Status:** accepted.
 
+## ADR-013: the League Twin bridge scales for the ROS blend, and reports the variance the odds path drops (LI-8)
+**Status:** accepted 2026-07-26 on `claude/li8-league-twin`.  Library +
+tests; no endpoint, nothing user-visible.
+
+**The missing join.**  `playoff_sim::simulate_trade_impact` takes
+`strength_delta` — `ownerId → change in weekly scoring MEAN`.  Nothing
+produced it; a caller had to invent the one number that actually
+requires simulating a roster.  `league_intel/sim.py` produces exactly
+that from real rosters.  `twin.py` is the join and deliberately adds no
+simulator, no second points model, and no reimplementation of either
+side.
+
+**Units were the trap, and they are handled exactly rather than
+approximated.**  `_TeamDist.mean` is NOT the presim mean; it is
+`presim_mean * (1 + ROS_BLEND * ros_z)` with `ROS_BLEND = 0.20`.  A raw
+presim delta is therefore in the wrong units for the field it lands in,
+off by the blend factor — roughly ±40% at `|ros_z| = 2`, not a rounding
+error.  Because the blend is multiplicative it scales exactly, so the
+bridge applies the same factor and returns `raw_mean_delta` and
+`blend_factor` alongside so the scaling is auditable rather than
+trusted.
+
+*Checked, not assumed:* the two sides really are the same KIND of
+quantity.  Both are starting-lineup weekly points.  Real team-weeks in
+the golden fixture are 283.8 and 361.1; the presim gives 163-377 across
+the 12 real rosters.  Same scale.  Note this alignment used to be
+partly luck — the `/2.7` divisor was tuned by eye — and
+`sim_calibration.py` is what makes it principled.
+
+**ASSUMED, and stamped on every result:** that `ros_z` is unchanged by
+the trade.  It is not — `ros_z` derives from `teamRosStrength`, which a
+roster change moves.  Capturing it needs a team-strength recompute per
+arm, which this deliberately does not do.  The residual is second-order
+(a change in the *blend* of a change in the *mean*).
+
+**Variance is reported, not propagated.**  `simulate_trade_impact`
+builds its after-distributions with `sd=d.sd` copied unchanged, so a
+trade's effect on variance vanishes there.  That is not a defect — a
+scalar mean shift is coherent, and their paired-seed design depends on
+the draw count being identical across arms — but the information
+exists.  `sd_delta` is computed and returned; it is explicitly NOT fed
+into the odds path, and the limitation is in `assumptions` rather than
+implied.
+
+**Unavailable is absent, not zero.**  An owner whose roster cannot be
+simulated gets no entry in `strength_delta`.  `simulate_trade_impact`
+reads a missing owner as unmoved, which is the correct reading of "no
+information"; an explicit `0.0` would assert the trade is neutral for
+them.
+
+**A test bug worth recording, because a weaker test would have hidden
+it.**  The real-roster test first keyed on `ownerId`, which this
+fixture does not carry — so `str(None)` collapsed both teams onto one
+dict key, B overwrote A, and the pure-giveaway case reported **+12.03
+for the team giving a player away**.  That is indistinguishable from
+the ADR-011 monotonicity defect and was in fact B's gain read under A's
+name; the true delta is −11.97.  A single-sided assertion would have
+passed.  Keyed on `rosterId` with an explicit `a_id != b_id` guard.
+
 ## ADR-011: the trade primitive is a weekly scoring DISTRIBUTION, and it runs on the full roster (LI-8)
 **Status:** accepted 2026-07-26.  Library + tests land; no endpoint and
 no UI, so nothing user-visible ships.

--- a/src/league_intel/cross_market.py
+++ b/src/league_intel/cross_market.py
@@ -1,5 +1,20 @@
 """Cross-market package valuation (WS-J F-1).
 
+Auditing call sites?  ``grep cross_market`` LIES
+────────────────────────────────────────────────
+``src/api/data_contract.py`` contains roughly twenty hits for
+``is_cross_market`` — an unrelated *source-registry flag* in the
+consensus pipeline marking which ranking sources price both offense
+and IDP.  It has nothing to do with this module.
+
+The honest count of production importers of THIS file is **zero**.
+``value_package`` / ``compare_packages`` are consumed only by
+``tests/league_intel/test_cross_market.py``.  ``src/trade/angle.py``
+is the intended call site and is **not rewired yet** — see "Which call
+site actually matters" below.  So a behaviour change here cannot reach
+a user today, and anyone auditing by grep will conclude the opposite
+unless they read the hits.
+
 The live defect
 ───────────────
 ``src/trade/angle.py::_market_source_for`` routes each PLAYER to the
@@ -200,11 +215,29 @@ isolation — see :func:`compare_packages`."""
 # (DE/DT/EDGE/NT -> DL, ILB/OLB/MLB -> LB, CB/S/SS/FS -> DB).
 #
 # That duplicate list is what ``angle.py`` still carries, and this file
-# had copied it.  Two hazards with the copy: it silently disagrees with
-# ``finder.py`` (which normalizes and tests ``{DL, LB, DB}``), and it
-# breaks on any raw spelling nobody remembered to add.  Normalizing
-# handles BOTH already-normalized and raw contract rows, so it is
-# strictly safer at either call site.
+# had copied it.  The reasoning matters more than the fix:
+#
+#   A COPIED position set is one forgotten spelling away from routing
+#   an "EDGE" row to a board that prices no defenders.
+#
+# That is precisely the defect #556 just fixed in ``finder.py``, where
+# every IDP asset scored ``ktc_value = None`` and was dropped before
+# scoring, so an IDP league silently got offense-only results.  A
+# 14-element literal reintroduces it the first time a source emits a
+# spelling nobody enumerated.
+#
+# The merged tree currently holds THREE IDP sets — ``finder.py``
+# ``{DL, LB, DB}`` (safe: it normalizes first, and ``Asset.position``
+# is built from the normalized value), ``angle.py`` 14 raw spellings,
+# and this one.  They agree today only by luck of normalization order.
+# ``angle.py`` is still the unrewired live path and still holds the
+# raw list; fixing it is WS-J's call when it rewires.
+#
+# Normalizing handles BOTH already-normalized and raw contract rows, so
+# it is strictly safer at either call site.  Parametrized tests cover
+# all 14 spellings, including that each still receives the
+# offense<->IDP assumption band — a missed spelling would zero that
+# band and walk the P1-b defect back in through a side door.
 _IDP_POSITIONS = frozenset({"DL", "LB", "DB"})
 
 

--- a/src/league_intel/sim_calibration.py
+++ b/src/league_intel/sim_calibration.py
@@ -1,0 +1,442 @@
+"""Points-model calibration for the best-ball simulation (LI-8).
+
+The playoff sim needs, per player-week, a distribution of FANTASY POINTS.
+What it has is ``rosValue`` — a 0-100 consensus composite with no units.
+Bridging the two used to be two magic constants living in
+``playoff_sim.py``::
+
+    mean = rosValue / 2.7          # "produces a believable weekly mean"
+    cv   = _PLAYER_CV_BY_POSITION  # "calibrated from public weekly-scoring
+                                   #  datasets"
+
+Neither was traceable to this league.  The divisor was tuned by eye, and
+the CV table cited a dataset that is named nowhere in the repo and uses
+generic PPR assumptions — in a superflex league that scores IDP on five
+separate event keys and has *deleted* its TE premium (ADR-009), those
+numbers describe a different game.
+
+This module replaces both with a calibration derived from **real stat
+lines scored under this league's own settings** via
+``src.league_intel.scorer.score_stat_line`` — the same exact scorer that
+reconciled 1,415/1,415 rostered player-weeks to within 0.011 (LI-2).
+
+What it produces
+────────────────
+A versioned artifact at ``data/league_intel/sim_points_model.json``::
+
+    {
+      "schemaVersion": 1,
+      "generatedAt": "...Z",
+      "configVersion": 1,
+      "season": "2025",
+      "weeks": [1, 2, 3],
+      "sampleSize": 1415,
+      "scale": {"rosValuePerPoint": 2.71, "r2": 0.63, "n": 402},
+      "byPosition": {"QB": {"cv": 0.31, "n": 48, "meanPoints": 18.9}, ...},
+      "provenance": {...}
+    }
+
+Runtime NEVER fetches.  ``playoff_sim`` loads this artifact if present
+and falls back to the legacy constants with an explicit
+``pointsModelSource: "fallback-constants"`` stamp when it is absent, so
+a sim run always declares which model produced it.
+
+Why a build-time artifact and not a live call: Sleeper's stat endpoints
+are the only source of real stat lines, the sim runs inside a request
+path, and LI-1 established the dated-snapshot pattern for exactly this
+(one polite fetch, diffed, written, never mutated in place).
+
+Scope boundary
+──────────────
+This calibrates the rosValue→points SCALE and per-position VARIANCE.  It
+does not project per-player stat lines — that is LI-6's job.  When LI-6
+lands, ``PointsModel`` gains a stat-line path and the scale term becomes
+a fallback for unprojected players.  The interface is shaped for that
+now so the swap does not churn the sim.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from src.league_intel.scorer import score_stat_line
+
+LOG = logging.getLogger("league_intel.sim_calibration")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "data" / "league_intel"
+MODEL_PATH = DATA_DIR / "sim_points_model.json"
+
+SCHEMA_VERSION = 1
+
+# Legacy constants, kept ONLY as the documented fallback so a missing
+# artifact degrades to prior behavior instead of crashing.  Any sim run
+# using these stamps ``pointsModelSource: "fallback-constants"``.
+FALLBACK_ROS_VALUE_PER_POINT = 2.7
+FALLBACK_CV_BY_POSITION: dict[str, float] = {
+    "QB": 0.32,
+    "RB": 0.55,
+    "WR": 0.60,
+    "TE": 0.65,
+    "DL": 0.55,
+    "DE": 0.55,
+    "DT": 0.55,
+    "EDGE": 0.55,
+    "LB": 0.45,
+    "DB": 0.50,
+    "S": 0.50,
+    "CB": 0.55,
+}
+FALLBACK_DEFAULT_CV = 0.55
+
+# A position needs this many scored player-weeks before its measured CV
+# is trusted; below it we keep the fallback and say so.
+MIN_SAMPLES_PER_POSITION = 30
+
+# CV is clamped to a physically sane band.  A measured CV outside this
+# usually means the position's sample is contaminated (e.g. a handful of
+# zero-snap weeks), not that the position is genuinely that volatile.
+CV_CLAMP = (0.15, 1.20)
+
+
+@dataclass(frozen=True)
+class PositionCalibration:
+    """Measured weekly-points behavior for one position."""
+
+    position: str
+    cv: float
+    mean_points: float
+    n: int
+    measured: bool  # False ⇒ fallback CV (sample below the floor)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cv": round(self.cv, 4),
+            "meanPoints": round(self.mean_points, 3),
+            "n": self.n,
+            "measured": self.measured,
+        }
+
+
+@dataclass
+class PointsModel:
+    """rosValue → weekly fantasy points, with per-position variance.
+
+    ``draw`` is the sim's hot path: one Gaussian per player per week,
+    truncated at zero (a fantasy week cannot score negative in
+    aggregate for a starter-worthy player, and the optimizer would
+    never start a negative anyway).
+    """
+
+    ros_value_per_point: float = FALLBACK_ROS_VALUE_PER_POINT
+    cv_by_position: Mapping[str, float] = field(
+        default_factory=lambda: dict(FALLBACK_CV_BY_POSITION)
+    )
+    default_cv: float = FALLBACK_DEFAULT_CV
+    source: str = "fallback-constants"
+    generated_at: str | None = None
+    sample_size: int = 0
+
+    def mean_points(self, ros_value: float) -> float:
+        """Expected weekly points for a player at ``ros_value``."""
+        if self.ros_value_per_point <= 0:
+            return 0.0
+        return max(0.0, float(ros_value) / self.ros_value_per_point)
+
+    def cv_for(self, position: str) -> float:
+        return self.cv_by_position.get((position or "").upper(), self.default_cv)
+
+    def draw(self, ros_value: float, position: str, rng: Any) -> float:
+        """Sample one weekly point total.  Hot path — keep it cheap."""
+        mean = self.mean_points(ros_value)
+        if mean <= 0.0:
+            return 0.0
+        sd = max(0.5, mean * self.cv_for(position))
+        return max(0.0, rng.gauss(mean, sd))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rosValuePerPoint": self.ros_value_per_point,
+            "defaultCv": self.default_cv,
+            "source": self.source,
+            "generatedAt": self.generated_at,
+            "sampleSize": self.sample_size,
+            "cvByPosition": dict(self.cv_by_position),
+        }
+
+
+DEFAULT_POINTS_MODEL = PointsModel()
+
+
+def load_points_model(path: Path | None = None) -> PointsModel:
+    """Load the calibrated model, or the documented fallback.
+
+    Never raises: a missing, unreadable, or schema-mismatched artifact
+    degrades to ``DEFAULT_POINTS_MODEL`` with the fallback source stamp,
+    because a sim that refuses to run is worse than one that declares a
+    weaker model.
+    """
+    target = path or MODEL_PATH
+    try:
+        if not target.exists():
+            return PointsModel()
+        blob = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        LOG.warning("sim points model unreadable (%s): %s", target, exc)
+        return PointsModel()
+
+    if not isinstance(blob, dict) or blob.get("schemaVersion") != SCHEMA_VERSION:
+        LOG.warning(
+            "sim points model schema mismatch (want %s, got %r) — using fallback",
+            SCHEMA_VERSION,
+            (blob or {}).get("schemaVersion") if isinstance(blob, dict) else None,
+        )
+        return PointsModel()
+
+    scale = blob.get("scale") or {}
+    try:
+        per_point = float(scale.get("rosValuePerPoint") or 0.0)
+    except (TypeError, ValueError):
+        per_point = 0.0
+    if per_point <= 0:
+        LOG.warning("sim points model has no usable scale — using fallback")
+        return PointsModel()
+
+    cvs: dict[str, float] = dict(FALLBACK_CV_BY_POSITION)
+    for pos, entry in (blob.get("byPosition") or {}).items():
+        if not isinstance(entry, dict):
+            continue
+        try:
+            cv = float(entry.get("cv"))
+        except (TypeError, ValueError):
+            continue
+        if cv > 0:
+            cvs[str(pos).upper()] = cv
+
+    return PointsModel(
+        ros_value_per_point=per_point,
+        cv_by_position=cvs,
+        source="calibrated",
+        generated_at=blob.get("generatedAt"),
+        sample_size=int(blob.get("sampleSize") or 0),
+    )
+
+
+# ── Calibration (build-time) ───────────────────────────────────────
+
+
+def _clamp_cv(cv: float) -> float:
+    lo, hi = CV_CLAMP
+    return max(lo, min(hi, cv))
+
+
+def calibrate_positions(
+    scored_weeks: Mapping[str, list[float]],
+) -> dict[str, PositionCalibration]:
+    """Per-position CV + mean from scored player-weeks.
+
+    ``scored_weeks`` maps position → the list of that position's weekly
+    point totals (already run through the exact scorer).  Positions
+    below ``MIN_SAMPLES_PER_POSITION`` keep the fallback CV and are
+    stamped ``measured=False`` so the artifact never implies more
+    evidence than it has.
+    """
+    out: dict[str, PositionCalibration] = {}
+    for pos, points in scored_weeks.items():
+        key = str(pos).upper()
+        vals = [float(v) for v in points if v is not None]
+        n = len(vals)
+        if n == 0:
+            continue
+        mean = statistics.fmean(vals)
+        if n < MIN_SAMPLES_PER_POSITION or mean <= 0:
+            out[key] = PositionCalibration(
+                position=key,
+                cv=FALLBACK_CV_BY_POSITION.get(key, FALLBACK_DEFAULT_CV),
+                mean_points=mean,
+                n=n,
+                measured=False,
+            )
+            continue
+        sd = statistics.pstdev(vals)
+        out[key] = PositionCalibration(
+            position=key,
+            cv=_clamp_cv(sd / mean),
+            mean_points=mean,
+            n=n,
+            measured=True,
+        )
+    return out
+
+
+def calibrate_scale(pairs: list[tuple[float, float]]) -> dict[str, Any]:
+    """Fit ``rosValue ≈ k × points`` over (ros_value, mean_points) pairs.
+
+    Least-squares through the origin — the relationship must pass
+    through (0, 0): a player with no ROS value projects no points, and
+    an intercept would let a worthless player score.  ``k`` is the
+    divisor the sim applies.
+
+    Returns ``{rosValuePerPoint, r2, n}``.  ``r2`` is reported so a weak
+    fit is visible in the artifact rather than silently trusted.
+    """
+    usable = [(rv, pts) for rv, pts in pairs if rv > 0 and pts > 0]
+    n = len(usable)
+    if n < 2:
+        return {"rosValuePerPoint": FALLBACK_ROS_VALUE_PER_POINT, "r2": 0.0, "n": n}
+
+    num = sum(rv * pts for rv, pts in usable)
+    den = sum(pts * pts for _, pts in usable)
+    if den <= 0:
+        return {"rosValuePerPoint": FALLBACK_ROS_VALUE_PER_POINT, "r2": 0.0, "n": n}
+    k = num / den
+
+    mean_rv = statistics.fmean([rv for rv, _ in usable])
+    ss_tot = sum((rv - mean_rv) ** 2 for rv, _ in usable)
+    ss_res = sum((rv - k * pts) ** 2 for rv, pts in usable)
+    r2 = 1.0 - (ss_res / ss_tot) if ss_tot > 0 else 0.0
+
+    return {"rosValuePerPoint": round(k, 4), "r2": round(r2, 4), "n": n}
+
+
+def build_calibration(
+    *,
+    stat_lines_by_week: Mapping[int, Mapping[str, Mapping[str, Any]]],
+    positions: Mapping[str, str],
+    ros_values: Mapping[str, float],
+    config: Any,
+    season: str,
+) -> dict[str, Any]:
+    """Score real stat lines and emit the calibration artifact.
+
+    Args:
+        stat_lines_by_week: ``{week: {player_id: stat_line}}`` as served
+            by ``GET /v1/stats/nfl/regular/{season}/{week}``.
+        positions: ``{player_id: position}``.
+        ros_values: ``{player_id: rosValue}`` — only players present here
+            contribute to the SCALE fit (the CV fit uses every scored
+            week, since variance does not need a value anchor).
+        config: LeagueIntelConfig or a scoring-settings mapping.
+        season: the season the stat lines came from.
+
+    Pure apart from the clock: callers supply the data, this scores it.
+    """
+    by_position: dict[str, list[float]] = {}
+    per_player_points: dict[str, list[float]] = {}
+
+    for week in sorted(stat_lines_by_week):
+        for pid, line in (stat_lines_by_week[week] or {}).items():
+            if not isinstance(line, Mapping):
+                continue
+            pos = str(positions.get(pid) or "").upper()
+            if not pos:
+                continue
+            pts = score_stat_line(line, config).total_points
+            by_position.setdefault(pos, []).append(pts)
+            per_player_points.setdefault(pid, []).append(pts)
+
+    per_position = calibrate_positions(by_position)
+
+    # Scale: one (rosValue, meanPoints) pair per player with both.
+    pairs: list[tuple[float, float]] = []
+    for pid, pts_list in per_player_points.items():
+        rv = ros_values.get(pid)
+        if rv is None or not pts_list:
+            continue
+        try:
+            rv_f = float(rv)
+        except (TypeError, ValueError):
+            continue
+        if rv_f <= 0:
+            continue
+        pairs.append((rv_f, statistics.fmean(pts_list)))
+    scale = calibrate_scale(pairs)
+
+    total_samples = sum(len(v) for v in by_position.values())
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "configVersion": getattr(config, "config_version", None),
+        "season": str(season),
+        "weeks": sorted(stat_lines_by_week),
+        "sampleSize": total_samples,
+        "scale": scale,
+        "byPosition": {k: v.to_dict() for k, v in sorted(per_position.items())},
+        "provenance": {
+            "scorer": "src.league_intel.scorer.score_stat_line",
+            "statSource": f"GET /v1/stats/nfl/regular/{season}/{{week}}",
+            "minSamplesPerPosition": MIN_SAMPLES_PER_POSITION,
+            "cvClamp": list(CV_CLAMP),
+            "note": (
+                "Scale is a through-origin least-squares fit of rosValue on "
+                "mean weekly points. Positions with measured=false kept the "
+                "documented fallback CV because their sample was below the "
+                "floor."
+            ),
+        },
+    }
+
+
+def write_calibration(payload: Mapping[str, Any], path: Path | None = None) -> Path:
+    """Atomically write the artifact (temp file + replace)."""
+    target = path or MODEL_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(f".{int(time.time() * 1000)}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=False), encoding="utf-8")
+    tmp.replace(target)
+    return target
+
+
+def fetch_stat_lines(
+    season: str,
+    weeks: list[int],
+    *,
+    fetcher: Callable[[str], Any],
+    sleep_s: float = 1.0,
+) -> dict[int, dict[str, Any]]:
+    """Fetch weekly stat lines, one polite request per week.
+
+    ``fetcher`` is injected so tests never touch the network and the
+    rate-limit policy stays the caller's decision.  Weeks that fail are
+    skipped with a warning rather than aborting the run — a calibration
+    on three weeks is better than none.
+    """
+    out: dict[int, dict[str, Any]] = {}
+    for i, week in enumerate(weeks):
+        if i > 0 and sleep_s > 0:
+            time.sleep(sleep_s)
+        url = f"https://api.sleeper.app/v1/stats/nfl/regular/{season}/{week}"
+        try:
+            blob = fetcher(url)
+        except Exception as exc:  # noqa: BLE001 — one bad week must not abort
+            LOG.warning("stat-line fetch failed for %s wk%s: %s", season, week, exc)
+            continue
+        if isinstance(blob, Mapping):
+            out[int(week)] = dict(blob)
+    return out
+
+
+__all__ = [
+    "CV_CLAMP",
+    "DEFAULT_POINTS_MODEL",
+    "FALLBACK_CV_BY_POSITION",
+    "FALLBACK_ROS_VALUE_PER_POINT",
+    "MIN_SAMPLES_PER_POSITION",
+    "MODEL_PATH",
+    "PointsModel",
+    "PositionCalibration",
+    "SCHEMA_VERSION",
+    "build_calibration",
+    "calibrate_positions",
+    "calibrate_scale",
+    "fetch_stat_lines",
+    "load_points_model",
+    "write_calibration",
+]

--- a/src/league_intel/twin.py
+++ b/src/league_intel/twin.py
@@ -1,0 +1,254 @@
+"""League Twin bridge: roster change → playoff/championship odds (LI-8).
+
+What was missing
+────────────────
+``src/ros/playoff_sim.py::simulate_trade_impact`` is the League Twin's
+trade path, and it takes ``strength_delta`` — ``ownerId → change in
+that team's weekly scoring MEAN``.  Nothing produced that map.  A
+caller had to invent the number, which is the part that actually
+requires simulating a roster.
+
+``src.league_intel.sim`` produces exactly that number from real
+rosters.  This module is the join, and it is deliberately thin: no new
+simulator, no second points model, no reimplementation of either side.
+
+Two things it must get right, and both are easy to get silently wrong.
+
+1. THE MULTIPLICATIVE BLEND — handled exactly, not approximated
+──────────────────────────────────────────────────────────────
+``_TeamDist.mean`` is not the presim mean.  It is::
+
+    blended_mean = presim_mean * (1 + ROS_BLEND * ros_z)
+
+with ``ROS_BLEND = 0.20`` and ``ros_z`` the team's ROS-strength
+z-score.  So a delta measured in presim points is in the WRONG units
+for a field that lives downstream of that multiplication.  Feeding a
+raw presim delta understates (or overstates) the effect by the blend
+factor — up to roughly ±40% at ``|ros_z| = 2``, which is not a rounding
+error.
+
+Because the blend is multiplicative it scales exactly::
+
+    delta_on_TeamDist = (presim_after - presim_before) * (1 + ROS_BLEND * ros_z)
+
+so this module applies the same factor rather than approximating it.
+
+**ASSUMED, and stated because it is the one soft spot:** that ``ros_z``
+itself is unchanged by the trade.  It is not — ``ros_z`` derives from
+``teamRosStrength``, which a roster change moves.  Capturing that needs
+a team-strength recompute per trade arm, which this module deliberately
+does not do.  The residual is second-order (a change in the *blend* of
+a change in the *mean*) and is stamped on every result rather than
+buried.  ``blend_factor`` is returned so a caller can see exactly what
+was applied.
+
+2. THE VARIANCE THEIR DESIGN DISCARDS
+─────────────────────────────────────
+``simulate_trade_impact`` builds its "after" distributions with
+``sd=d.sd`` — copied unchanged.  So a trade's effect on *variance* is
+dropped entirely, and in best ball variance is precisely what roster
+depth changes: consolidating four flex bodies into one stud raises the
+mean and lowers the floor, and those are different trades to a team
+that needs a ceiling versus one protecting a lead.
+
+That is not a defect in their code — a scalar mean shift is a coherent
+model and their paired-seed design depends on the draw count being
+identical across arms.  But the information exists and should not
+vanish silently, so ``sd_delta`` is computed and reported alongside.
+It is **not** fed into ``simulate_trade_impact``; feeding it would
+require re-deriving the distributions, which is a different design.
+Callers that care about ceiling-vs-floor read it directly.
+
+Unavailable is not zero
+───────────────────────
+An owner whose roster cannot be simulated gets **no entry** in the
+delta map and an explicit ``unavailable`` record.  Returning 0.0 would
+tell ``simulate_trade_impact`` "this trade does not move this team",
+which is a claim, not an absence of one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.league_intel.sim import DEFAULT_SIM_WEEKS, simulate_trade_delta
+
+__all__ = [
+    "TWIN_BRIDGE_VERSION",
+    "OwnerStrengthDelta",
+    "TradeStrengthDeltas",
+    "strength_deltas_from_rosters",
+]
+
+TWIN_BRIDGE_VERSION = "li.twin.2026-07-26.v1"
+
+ROS_Z_ASSUMPTION = (
+    "ros_z is assumed UNCHANGED by the trade. It derives from teamRosStrength, "
+    "which a roster change moves, so the blend factor applied here is the "
+    "pre-trade one. The residual is second-order (a change in the blend of a "
+    "change in the mean) and is not captured; capturing it needs a "
+    "team-strength recompute per arm."
+)
+
+SD_NOT_PROPAGATED = (
+    "sd_delta is REPORTED but NOT fed into simulate_trade_impact, which copies "
+    "sd unchanged by design. A trade that raises the ceiling while lowering the "
+    "floor will show a mean delta only."
+)
+
+
+@dataclass(frozen=True)
+class OwnerStrengthDelta:
+    """One owner's simulated change, in ``_TeamDist.mean`` units."""
+
+    owner_id: str
+    mean_delta: float | None
+    sd_delta: float | None
+    blend_factor: float
+    raw_mean_delta: float | None
+    confidence: float = 0.0
+    unavailable_reason: str | None = None
+
+    @property
+    def is_available(self) -> bool:
+        return self.mean_delta is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ownerId": self.owner_id,
+            "meanDelta": self.mean_delta,
+            "sdDelta": self.sd_delta,
+            "blendFactor": self.blend_factor,
+            "rawMeanDelta": self.raw_mean_delta,
+            "confidence": self.confidence,
+            "isAvailable": self.is_available,
+            "unavailableReason": self.unavailable_reason,
+        }
+
+
+@dataclass
+class TradeStrengthDeltas:
+    """Everything ``simulate_trade_impact`` needs, plus what it drops."""
+
+    per_owner: list[OwnerStrengthDelta] = field(default_factory=list)
+    bridge_version: str = TWIN_BRIDGE_VERSION
+    assumptions: list[str] = field(default_factory=list)
+
+    @property
+    def strength_delta(self) -> dict[str, float]:
+        """The map to hand to ``simulate_trade_impact``.
+
+        Owners whose rosters could not be simulated are ABSENT, not
+        zero — ``simulate_trade_impact`` treats a missing owner as
+        unmoved, which is the correct reading of "no information",
+        whereas an explicit 0.0 would assert the trade is neutral for
+        them.
+        """
+        return {d.owner_id: d.mean_delta for d in self.per_owner if d.mean_delta is not None}
+
+    @property
+    def unavailable(self) -> list[OwnerStrengthDelta]:
+        return [d for d in self.per_owner if not d.is_available]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bridgeVersion": self.bridge_version,
+            "strengthDelta": self.strength_delta,
+            "perOwner": [d.to_dict() for d in self.per_owner],
+            "unavailableCount": len(self.unavailable),
+            "assumptions": list(self.assumptions),
+        }
+
+
+def _blend_factor(ros_z: float | None, ros_blend: float) -> float:
+    """The multiplier ``_TeamDist.mean`` already had applied.
+
+    Mirrors ``playoff_sim``'s ``blended_mean = emp_mean * (1 + ROS_BLEND
+    * ros_z)``.  When the owner had no ROS strength score the simulator
+    skips the blend entirely, so the factor is exactly 1.0.
+    """
+    if ros_z is None:
+        return 1.0
+    return 1.0 + ros_blend * float(ros_z)
+
+
+def strength_deltas_from_rosters(
+    rosters_before: Mapping[str, Iterable[Mapping[str, Any]]],
+    rosters_after: Mapping[str, Iterable[Mapping[str, Any]]],
+    starter_slots: Sequence[str],
+    *,
+    ros_z_by_owner: Mapping[str, float] | None = None,
+    ros_blend: float | None = None,
+    weeks: int = DEFAULT_SIM_WEEKS,
+    seed: int = 0,
+    points_model: Any = None,
+) -> TradeStrengthDeltas:
+    """Simulate each changed roster and emit ``simulate_trade_impact`` input.
+
+    ``rosters_before`` / ``rosters_after`` map ownerId → full roster
+    rows (the ``fullRoster`` shape from the team-strength snapshot).
+    Pass FULL rosters: best ball pays for the tail, and a truncated
+    roster is the wrong input (ADR-011).
+
+    Only owners present in BOTH maps are simulated — a trade cannot
+    move a team that isn't in the league snapshot.
+
+    ``ros_z_by_owner`` supplies each owner's ROS-strength z-score so the
+    presim-units delta can be scaled into ``_TeamDist.mean`` units.
+    Omitting it applies a factor of 1.0, which is correct only when the
+    simulator ran without a ROS-strength map — so it is a defensible
+    default, not a silent one, and ``blend_factor`` is reported per
+    owner either way.
+    """
+    if ros_blend is None:
+        from src.ros.playoff_sim import ROS_BLEND  # noqa: PLC0415
+
+        ros_blend = ROS_BLEND
+    z_map = ros_z_by_owner or {}
+
+    out = TradeStrengthDeltas(
+        assumptions=[
+            ROS_Z_ASSUMPTION,
+            SD_NOT_PROPAGATED,
+            "deltas are in _TeamDist.mean units: presim points scaled by the "
+            "same multiplicative ROS blend the simulator applied",
+        ]
+    )
+
+    for owner in rosters_before:
+        if owner not in rosters_after:
+            continue
+        factor = _blend_factor(z_map.get(owner), ros_blend)
+        delta = simulate_trade_delta(
+            rosters_before[owner],
+            rosters_after[owner],
+            starter_slots,
+            weeks=weeks,
+            seed=seed,
+            points_model=points_model,
+        )
+        if not delta.is_available:
+            out.per_owner.append(
+                OwnerStrengthDelta(
+                    owner_id=owner,
+                    mean_delta=None,
+                    sd_delta=None,
+                    blend_factor=factor,
+                    raw_mean_delta=None,
+                    confidence=0.0,
+                    unavailable_reason=delta.unavailable_reason,
+                )
+            )
+            continue
+        out.per_owner.append(
+            OwnerStrengthDelta(
+                owner_id=owner,
+                mean_delta=delta.mean_delta * factor,
+                sd_delta=delta.sd_delta,
+                blend_factor=factor,
+                raw_mean_delta=delta.mean_delta,
+                confidence=delta.confidence,
+            )
+        )
+    return out

--- a/src/ros/lineup.py
+++ b/src/ros/lineup.py
@@ -124,13 +124,65 @@ class LineupSolution:
 
 def _normalize_slot_name(slot: str) -> str:
     s = (slot or "").strip().upper()
-    if s in {"SUPER_FLEX", "SUPERFLEX", "OP"}:
+    if s in {"SUPER_FLEX", "SUPERFLEX", "OP", "SFLEX"}:
         return "SUPER_FLEX"
     if s in {"WRRB_FLEX", "WR_RB_FLEX", "FLEX_WRRB"}:
         return "FLEX"
     if s in {"IDP_FL", "IDP_FLEX", "IDPFLX"}:
         return "IDP_FLEX"
     return s
+
+
+def flatten_starter_slots(starters: dict[str, Any] | None) -> list[str]:
+    """Expand ``{"QB": 1, "RB": 2, ...}`` → ``["QB", "RB", "RB", ...]``.
+
+    THE canonical starter-slot flattener (LI-8).  Two byte-identical
+    copies previously existed — ``src/ros/scrape.py::_flatten_starter_slots``
+    and ``src/ros/playoff_sim.py::_load_starter_slots`` — each with its
+    own private ``{"SFLEX": "SUPER_FLEX"}`` alias map, so a slot-name
+    alias added to one silently diverged from the other.  ADR-007
+    flagged the duplication; this is the single implementation, and it
+    routes through ``_normalize_slot_name`` so slot aliasing has exactly
+    one definition in the codebase.
+
+    Slots with a non-integer or non-positive count are skipped.  Order
+    follows the mapping's iteration order; callers that need a stable
+    order should pass an ordered mapping (the registry JSON preserves
+    document order through ``json.load``).
+    """
+    if not starters:
+        return []
+    out: list[str] = []
+    for slot, count in starters.items():
+        try:
+            n = int(count)
+        except (TypeError, ValueError):
+            continue
+        if n <= 0:
+            continue
+        out.extend([_normalize_slot_name(str(slot))] * n)
+    return out
+
+
+def load_league_starter_slots(league_key: str | None = None) -> list[str]:
+    """Flat starter-slot list for a league, read from the registry.
+
+    Returns ``[]`` when no league config resolves or it carries no
+    starters — callers degrade rather than raise (the playoff sim falls
+    back to its empirical model, team-strength logs and skips).
+    """
+    try:
+        from src.api.league_registry import (  # noqa: PLC0415
+            get_default_league,
+            get_league_by_key,
+        )
+
+        cfg = get_league_by_key(league_key) if league_key else get_default_league()
+        if cfg is None or not cfg.roster_settings:
+            return []
+        return flatten_starter_slots(cfg.roster_settings.get("starters"))
+    except Exception:  # noqa: BLE001 — registry problems must not break callers
+        return []
 
 
 def _eligible_for_slot(slot: str, position: str) -> bool:

--- a/src/ros/playoff_sim.py
+++ b/src/ros/playoff_sim.py
@@ -38,12 +38,23 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import random
 import statistics
 from dataclasses import dataclass
 from typing import Any
 
+from src.league_intel.sim_calibration import (
+    DEFAULT_POINTS_MODEL,
+    PointsModel,
+    load_points_model,
+)
 from src.ros import ROS_DATA_DIR
+from src.ros.lineup import (
+    RosterPlayer,
+    load_league_starter_slots,
+    solve_optimal_assignment,
+)
 from src.public_league import luck, metrics, playoff_odds
 from src.public_league.snapshot import PublicLeagueSnapshot
 
@@ -67,14 +78,31 @@ BEST_BALL_VARIANCE_BUMP = 1.10
 # behavior physically plausible.
 DEPTH_VARIANCE_LIFT_MAX = 0.15
 
+# Simulation counts are now CONVERGENCE-DRIVEN (LI-8): these are the
+# bounds of an adaptive loop, not a fixed budget.  A fixed count is
+# either wasteful (a settled league keeps drawing) or wrong (a tight
+# playoff race stops before the odds resolve) — and it cannot tell you
+# which, because it reports no error bar.
 DEFAULT_SIMULATIONS = 10000
+MIN_SIMULATIONS = 2000
+MAX_SIMULATIONS = 60000
 
-# Best-ball per-week presim count.  For each team we draw K weeks of
-# per-player scores, run greedy lineup optimization on each draw, and
-# take the empirical (mean, sd) of the resulting starting-lineup
-# scores.  K=200 converges the weekly distribution to within ~3% of
-# the asymptotic value while staying cheap (<100ms per league).
-BEST_BALL_PRESIM_WEEKS = 200
+# Stop when every team's playoff-odds standard error is under this.
+# 0.005 ⇒ ±1pp at ~95% confidence, which is finer than the product ever
+# displays (odds render to whole percents).
+ODDS_SE_TOLERANCE = 0.005
+SIM_CHECK_EVERY = 1000
+
+# Best-ball per-week presim.  For each team we draw weekly per-player
+# scores, solve the EXACT lineup on each draw, and take the empirical
+# (mean, sd).  Adaptive between these bounds; the previous fixed 200
+# claimed "~3% of the asymptotic value" with no check that it got there.
+BEST_BALL_PRESIM_MIN_WEEKS = 120
+BEST_BALL_PRESIM_MAX_WEEKS = 1200
+PRESIM_CHECK_EVERY = 40
+# Relative standard error of the mean: stop once the mean is pinned to
+# 1% of itself.
+PRESIM_MEAN_TOLERANCE = 0.01
 
 # Coefficient of variation per position for per-player weekly scores.
 # Calibrated from public weekly-scoring datasets — high-variance
@@ -97,6 +125,59 @@ _PLAYER_CV_BY_POSITION: dict[str, float] = {
     "CB": 0.55,
 }
 _DEFAULT_PLAYER_CV = 0.55
+
+
+def _mean_is_converged(samples: list[float], rel_tolerance: float) -> bool:
+    """True when the sample mean's relative standard error is within
+    ``rel_tolerance``.
+
+    SE(mean) = sd / sqrt(n); "relative" divides by the mean so the
+    tolerance is scale-free (a 12-point team and a 140-point team
+    converge on the same criterion).  A zero/near-zero mean can never
+    satisfy a relative test, so it converges on the absolute SE instead
+    — otherwise an all-zero roster would spin to the cap.
+    """
+    n = len(samples)
+    if n < 4:
+        return False
+    mean = statistics.fmean(samples)
+    sd = statistics.pstdev(samples)
+    if sd <= 0.0:
+        return True
+    se = sd / math.sqrt(n)
+    if abs(mean) < 1e-9:
+        return se < rel_tolerance
+    return (se / abs(mean)) < rel_tolerance
+
+
+def _proportion_se(p: float, n: int) -> float:
+    """Standard error of a Bernoulli proportion — the error bar on an
+    odds figure.  ``p`` at exactly 0 or 1 yields 0, which is an
+    UNDERSTATEMENT of the true uncertainty from a finite sample; callers
+    that report intervals use the Wilson bound instead (see
+    ``_wilson_interval``), which stays honest at the boundaries.
+    """
+    if n <= 0:
+        return 0.0
+    p = min(1.0, max(0.0, p))
+    return math.sqrt(p * (1.0 - p) / n)
+
+
+def _wilson_interval(successes: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion.
+
+    Chosen over the normal approximation because playoff odds live near
+    0 and 1 for most of a season, exactly where the normal interval
+    breaks (it produces bounds outside [0,1] and collapses to zero width
+    at p=0/1, claiming certainty a finite sample cannot support).
+    """
+    if n <= 0:
+        return (0.0, 1.0)
+    p = successes / n
+    denom = 1.0 + (z * z) / n
+    center = (p + (z * z) / (2 * n)) / denom
+    margin = (z / denom) * math.sqrt((p * (1 - p) / n) + (z * z) / (4 * n * n))
+    return (max(0.0, center - margin), min(1.0, center + margin))
 
 
 def _load_team_depth_ratios() -> dict[str, float]:
@@ -158,24 +239,40 @@ def _load_team_rosters() -> dict[str, dict[str, Any]]:
     """Per-owner roster from the team-strength snapshot.
 
     Returns ``{ownerId: {"starters": [...], "bench": [...]}}``.  Each
-    player entry carries ``{playerId, position, rosValue,
-    fantasyPositions}``.  Empty dict when no snapshot — caller skips
-    best-ball presim.
+    player entry carries
+    ``{playerId, canonicalName, position, rosValue, fantasyPositions}``.
+    Empty dict when no snapshot — caller skips best-ball presim.
 
-    **Prefers ``fullRoster`` when the snapshot carries it.**  Reading
-    ``startingLineup + benchDepth`` gives only 29 of a 44-58 man
-    roster, because ``benchDepth`` is capped at
-    ``lineup.DEPTH_BENCH_LIMIT`` for depth *scoring* rather than roster
-    enumeration.  Best ball is the format that pays for the tail, so
-    that truncation is simply the wrong input.
+    **Two things this function must get right, and both were wrong.**
 
-    Measured on the 12 real rosters (400 weeks, seed 7): it understates
-    the weekly mean by +1.1 to +9.4 points, varying ~8x by team, with
-    deep rosters penalised most.  Said plainly rather than sold: at
-    today's roster construction it changes NO team's rank, so this is a
-    correctness fix to the input, not a repair of visibly wrong playoff
-    odds.  Older snapshots without ``fullRoster`` fall back to the
-    truncated read so the sim still runs.
+    1. *Prefers ``fullRoster``.*  Reading ``startingLineup +
+       benchDepth`` yields 29 of a 44-58 man roster, because
+       ``benchDepth`` is capped at ``lineup.DEPTH_BENCH_LIMIT`` for
+       depth *scoring* rather than roster enumeration.  Best ball is
+       the format that pays for the tail, so that truncation is simply
+       the wrong input.  Measured on the 12 real rosters (400 weeks,
+       seed 7): it understates the weekly mean by +1.1 to +9.4 points,
+       varying ~8x by team, deep rosters penalised most.
+
+       Said plainly rather than sold: at today's roster construction it
+       reorders NO team.  This is a correctness fix to the input, not a
+       repair of visibly wrong playoff odds.  But adaptive convergence
+       and Wilson intervals computed over 29 of 44-58 players is a
+       better-calibrated answer about the wrong team, which is why it
+       is worth fixing underneath them rather than after.
+
+    2. *Carries ``fantasyPositions``.*  ``_bestball_weekly_score``
+       reads this key to build ``RosterPlayer.fantasy_positions``, and
+       ``solve_optimal_assignment`` uses it for multi-position
+       eligibility.  When the loader omitted it, ``fpos`` was always
+       ``()``, ``eligible_positions()`` fell back to ``(position,)``,
+       and every DL/LB hybrid was matched position-only — so routing
+       the sim through the exact optimizer fixed the *algorithm* while
+       the *data* still expressed the original bug.  The exact solve is
+       only as good as the eligibility it is handed.
+
+    Older snapshots without ``fullRoster`` fall back to the truncated
+    read so the sim still runs.
     """
     path = ROS_DATA_DIR / "team_strength" / "latest.json"
     if not path.exists():
@@ -194,6 +291,7 @@ def _load_team_rosters() -> dict[str, dict[str, Any]]:
             return [
                 {
                     "playerId": str(p.get("playerId") or ""),
+                    "canonicalName": str(p.get("canonicalName") or ""),
                     "position": str(p.get("position") or "").upper(),
                     "rosValue": float(p.get("rosValue") or 0.0),
                     "fantasyPositions": [
@@ -218,113 +316,104 @@ def _load_team_rosters() -> dict[str, dict[str, Any]]:
     return out
 
 
-def _load_starter_slots() -> list[str]:
-    """Read the league's starter slot list (e.g. ``["QB", "RB", "RB", ...]``)
-    from the registry.  Falls back to empty when no league config — the
-    best-ball presim then short-circuits to the empirical model."""
-    try:
-        from src.api.league_registry import get_default_league  # noqa: PLC0415
-
-        cfg = get_default_league()
-        if cfg is None or not cfg.roster_settings:
-            return []
-        starters = cfg.roster_settings.get("starters") or {}
-        out: list[str] = []
-        alias = {"SFLEX": "SUPER_FLEX"}
-        for slot, count in starters.items():
-            try:
-                n = int(count)
-            except (TypeError, ValueError):
-                continue
-            if n <= 0:
-                continue
-            out.extend([alias.get(str(slot).upper(), str(slot).upper())] * n)
-        return out
-    except Exception:  # noqa: BLE001
-        return []
-
-
-# NOTE: a duplicated ``_eligible_for_slot`` used to live here, copied
-# from ``src.ros.lineup`` "to keep the hot loop free of cross-module
-# attribute lookups".  It has been deleted rather than kept in sync:
-# it matched on ``position`` alone, so it silently disagreed with the
-# real eligibility rules for every DL/LB and DB/LB hybrid, and a
-# duplicated rule that drifts is worse than an attribute lookup.
-# ``_bestball_weekly_score`` now calls ``optimize_lineup`` directly.
+# ``_load_starter_slots`` and a private ``_eligible_for_slot`` used to
+# live here — the third and fourth copies of logic that belongs to
+# ``src.ros.lineup``.  Both are now imported (LI-8): one flattener, one
+# eligibility definition, and the sim inherits the ``fantasy_positions``
+# fix from LI-3 for free.
+_load_starter_slots = load_league_starter_slots
 
 
 def _bestball_weekly_score(
     roster_players: list[dict[str, Any]],
     starter_slots: list[str],
     rng: random.Random,
+    points_model: PointsModel | None = None,
 ) -> float:
-    """One simulated best-ball week:
-    1. Draw a per-player weekly score (Gaussian on player's rosValue scale).
-    2. Fill the lineup EXACTLY (``src.ros.lineup.optimize_lineup``).
-    3. Sum the chosen scores.
+    """One simulated best-ball week.
 
-    Step 2 used a local greedy with a duplicated eligibility map.  That
-    is optimal only while slot eligibility forms a laminar family (see
-    ADR-007) and, more importantly, it matched on ``position`` alone —
-    so a DL/LB hybrid was locked out of half its legal slots every
-    simulated week.  Delegating to the exact optimizer removes both the
-    unstated precondition and the duplication.
+    1. Draw a per-player weekly point total from the calibrated points
+       model (see ``src.league_intel.sim_calibration``).
+    2. Solve the EXACT maximum-weight player→slot assignment.
+    3. Sum the assigned scores.
+
+    Step 2 was a slot-ordered greedy until LI-8.  Two defects came with
+    it, both silent:
+
+    * The greedy is optimal only for a *laminar* slot-eligibility family
+      (ADR-007).  It held for this league's slots, so it was correct by
+      an unenforced precondition — one non-laminar slot would have
+      quietly produced sub-optimal lineups and therefore understated
+      every team's best-ball ceiling.
+    * It matched on ``position`` alone, so hybrid IDPs (``position="DL"``
+      with ``fantasy_positions=["DL","LB"]``) were locked out of half
+      their legal slots — the exact bug LI-3 fixed in ``lineup.py`` and
+      measured at up to +13.75 starting-lineup points on real rosters.
+
+    Routing through ``solve_optimal_assignment`` fixes both, and the sim
+    now shares ONE eligibility definition with team-strength.
     """
     if not roster_players or not starter_slots:
         return 0.0
 
-    # Step 1: per-player weekly score.  Mean ≈ (rosValue / 17 weeks)
-    # scaled to typical PPG range; sd ≈ mean × position-specific CV.
-    from src.ros.lineup import RosterPlayer, optimize_lineup  # noqa: PLC0415
+    model = points_model or DEFAULT_POINTS_MODEL
 
-    drawn: list[RosterPlayer] = []
+    # Step 1: draw this week's points for every priced player.  Build
+    # RosterPlayer rows whose ``ros_value`` IS the drawn score, so the
+    # optimizer maximizes realized weekly points rather than season
+    # value.  health penalties are already folded into the draw.
+    pool: list[RosterPlayer] = []
     for p in roster_players:
         ros = float(p.get("rosValue") or 0.0)
         if ros <= 0:
             continue
         pos = str(p.get("position") or "").upper()
-        # Scale rosValue (0-100 composite) to weekly fantasy points.
-        # Empirical: top players (rosValue ≈ 60) hit ~22 PPG; middle
-        # tier (rosValue ≈ 30) hits ~12 PPG.  Linear ratio rosValue / 2.7
-        # produces a believable weekly mean.  This constant is internal —
-        # the matchup-loop comparison only depends on relative scaling.
-        mean = max(0.0, ros / 2.7)
-        cv = _PLAYER_CV_BY_POSITION.get(pos, _DEFAULT_PLAYER_CV)
-        sd = max(0.5, mean * cv)
-        score = max(0.0, rng.gauss(mean, sd))
-        drawn.append(
+        score = model.draw(ros, pos, rng)
+        fpos = p.get("fantasyPositions") or ()
+        pool.append(
             RosterPlayer(
                 player_id=str(p.get("playerId") or ""),
-                canonical_name=str(p.get("playerId") or ""),
+                canonical_name=str(p.get("canonicalName") or ""),
                 position=pos,
                 ros_value=score,
-                fantasy_positions=tuple(
-                    str(fp).upper() for fp in (p.get("fantasyPositions") or ())
-                ),
+                fantasy_positions=tuple(fpos),
             )
         )
 
-    # Step 2: exact maximum-weight assignment over this week's draws.
-    return optimize_lineup(drawn, starter_slots=starter_slots).starting_lineup_score
+    # Step 2: exact assignment.
+    assignment = solve_optimal_assignment(pool, starter_slots)
+    return float(sum(player.ros_value for player in assignment.values()))
 
 
 def _bestball_presim(
     rosters: dict[str, dict[str, Any]],
     starter_slots: list[str],
     rng: random.Random,
+    points_model: PointsModel | None = None,
 ) -> dict[str, tuple[float, float]]:
-    """Run K best-ball weeks per team, return ``{ownerId: (mean, sd)}``."""
+    """Run best-ball weeks per team, return ``{ownerId: (mean, sd)}``.
+
+    Week count is adaptive (LI-8): draws continue until the running mean
+    is resolved to ``PRESIM_MEAN_TOLERANCE`` of a standard error, capped
+    at ``BEST_BALL_PRESIM_MAX_WEEKS``.  The old fixed 200 was a guess
+    that under-sampled high-variance rosters and wasted draws on stable
+    ones.
+    """
     if not rosters or not starter_slots:
         return {}
+    model = points_model or DEFAULT_POINTS_MODEL
     out: dict[str, tuple[float, float]] = {}
     for owner, blob in rosters.items():
         roster = (blob.get("starters") or []) + (blob.get("bench") or [])
         if not roster:
             continue
-        weekly = [
-            _bestball_weekly_score(roster, starter_slots, rng)
-            for _ in range(BEST_BALL_PRESIM_WEEKS)
-        ]
+        weekly: list[float] = []
+        for i in range(BEST_BALL_PRESIM_MAX_WEEKS):
+            weekly.append(_bestball_weekly_score(roster, starter_slots, rng, model))
+            # Check convergence on a cadence, never before a usable floor.
+            if i + 1 >= BEST_BALL_PRESIM_MIN_WEEKS and (i + 1) % PRESIM_CHECK_EVERY == 0:
+                if _mean_is_converged(weekly, PRESIM_MEAN_TOLERANCE):
+                    break
         if len(weekly) >= 4:
             out[owner] = (statistics.fmean(weekly), statistics.pstdev(weekly))
     return out
@@ -359,6 +448,7 @@ def _build_team_distributions(
     ros_strength_map: dict[str, float],
     *,
     best_ball: bool = False,
+    points_model: PointsModel | None = None,
 ) -> tuple[dict[str, _TeamDist], dict[str, float]]:
     """Build per-team weekly score distributions blended with ROS.
 
@@ -403,11 +493,13 @@ def _build_team_distributions(
         starter_slots = _load_starter_slots()
         if rosters and starter_slots:
             presim_rng = random.Random(20260428)  # deterministic per league
-            bestball_dists = _bestball_presim(rosters, starter_slots, presim_rng)
+            bestball_dists = _bestball_presim(rosters, starter_slots, presim_rng, points_model)
             LOG.info(
-                "[ros] best-ball presim: %d teams × %d weeks",
+                "[ros] best-ball presim: %d teams, adaptive %d-%d weeks (points model: %s)",
                 len(bestball_dists),
-                BEST_BALL_PRESIM_WEEKS,
+                BEST_BALL_PRESIM_MIN_WEEKS,
+                BEST_BALL_PRESIM_MAX_WEEKS,
+                (points_model or DEFAULT_POINTS_MODEL).source,
             )
 
     distributions: dict[str, _TeamDist] = {}
@@ -488,14 +580,81 @@ def _league_best_ball() -> bool:
         return False
 
 
+def _simulate_bracket(
+    seeded: list[str],
+    distributions: dict[str, _TeamDist],
+    bye_seeds: int,
+    rng: random.Random,
+) -> str | None:
+    """Play a seeded single-elimination bracket; return the champion.
+
+    Standard fantasy structure: the top ``bye_seeds`` teams sit out
+    round one, the rest play highest-vs-lowest, and re-seeding applies
+    each round (the surviving top seed always faces the surviving
+    bottom seed).  Each game is one draw from each team's weekly
+    distribution — the same distribution the regular-season loop uses,
+    so a team's playoff strength and its regular-season strength cannot
+    disagree.
+
+    Ties re-draw rather than coin-flip: a fantasy playoff tie is broken
+    by the host's own tiebreakers, and a coin flip would inject variance
+    the seeding already resolved.  Capped to avoid a pathological loop
+    on degenerate (zero-variance) distributions.
+    """
+    alive = [o for o in seeded if o in distributions]
+    if not alive:
+        return None
+    if len(alive) == 1:
+        return alive[0]
+
+    def _play(a: str, b: str) -> str:
+        da, db = distributions[a], distributions[b]
+        for _ in range(8):
+            sa = max(0.0, rng.gauss(da.mean, da.sd))
+            sb = max(0.0, rng.gauss(db.mean, db.sd))
+            if sa > sb:
+                return a
+            if sb > sa:
+                return b
+        # Degenerate: identical deterministic distributions. The better
+        # seed advances, which is what every host does.
+        return a
+
+    # Round one: byes advance automatically.
+    byes = alive[:bye_seeds]
+    contenders = alive[bye_seeds:]
+    survivors = list(byes)
+    while len(contenders) >= 2:
+        survivors.append(_play(contenders[0], contenders[-1]))
+        contenders = contenders[1:-1]
+    survivors.extend(contenders)  # odd bracket: the middle team advances
+
+    # Re-seed and play down to one.
+    seed_rank = {o: i for i, o in enumerate(alive)}
+    while len(survivors) > 1:
+        survivors.sort(key=lambda o: seed_rank.get(o, len(alive)))
+        nxt: list[str] = []
+        while len(survivors) >= 2:
+            nxt.append(_play(survivors[0], survivors[-1]))
+            survivors = survivors[1:-1]
+        nxt.extend(survivors)
+        survivors = nxt
+    return survivors[0] if survivors else None
+
+
 def simulate_playoff_odds(
     snapshot: PublicLeagueSnapshot,
     *,
-    n_simulations: int = DEFAULT_SIMULATIONS,
+    n_simulations: int | None = None,
     playoff_seeds: int = 6,
     bye_seeds: int = 2,
     best_ball: bool | None = None,
     rng: random.Random | None = None,
+    min_simulations: int = MIN_SIMULATIONS,
+    max_simulations: int = MAX_SIMULATIONS,
+    odds_se_tolerance: float = ODDS_SE_TOLERANCE,
+    points_model: PointsModel | None = None,
+    distributions: dict[str, _TeamDist] | None = None,
 ) -> dict[str, Any]:
     """Run the Monte Carlo and return playoff/championship-relevant odds.
 
@@ -513,16 +672,32 @@ def simulate_playoff_odds(
     rng = rng or random.Random()
     if best_ball is None:
         best_ball = _league_best_ball()
+    model = points_model or load_points_model()
+
+    # ``n_simulations`` pins an exact count (used by the trade-delta path
+    # so both arms draw identically); otherwise the loop is adaptive.
+    if n_simulations is not None:
+        min_simulations = max_simulations = int(n_simulations)
+
     ros_map = _load_ros_strength_map()
-    distributions, pf_by_owner = _build_team_distributions(snapshot, ros_map, best_ball=best_ball)
+    pf_by_owner: dict[str, float]
+    if distributions is None:
+        distributions, pf_by_owner = _build_team_distributions(
+            snapshot, ros_map, best_ball=best_ball, points_model=model
+        )
+    else:
+        _, pf_by_owner = _build_team_distributions(
+            snapshot, ros_map, best_ball=best_ball, points_model=model
+        )
     if not distributions:
         return {
             "playoffOdds": [],
-            "n_simulations": n_simulations,
+            "n_simulations": 0,
             "playoffSeeds": playoff_seeds,
             "byeSeeds": bye_seeds,
             "rosStrengthAvailable": bool(ros_map),
             "bestBallVarianceMode": "depth_aware" if best_ball else "off",
+            "pointsModelSource": model.source,
         }
 
     record = _current_record(snapshot)
@@ -536,7 +711,11 @@ def simulate_playoff_odds(
     miss_count: dict[str, int] = {o: 0 for o in owners}
     wins_total: dict[str, float] = {o: 0.0 for o in owners}
 
-    for _ in range(n_simulations):
+    champ_count: dict[str, int] = {o: 0 for o in owners}
+    completed = 0
+
+    for sim_i in range(max_simulations):
+        completed = sim_i + 1
         sim_wins: dict[str, float] = {o: float(record.get(o, {}).get("wins", 0)) for o in owners}
         sim_pf: dict[str, float] = {o: float(pf_by_owner.get(o, 0.0)) for o in owners}
         for week, owner_a, owner_b in schedule:
@@ -573,10 +752,27 @@ def simulate_playoff_odds(
             if i == 0:
                 top_seed_count[owner] += 1
 
+        # Championship: play the seeded bracket out on THIS sim's team
+        # distributions.  Previously the module reported seeding odds
+        # only and no championship probability existed anywhere — the
+        # trade-delta contract (§17.3) requires one.
+        champion = _simulate_bracket(ranked[:playoff_seeds], distributions, bye_seeds, rng)
+        if champion:
+            champ_count[champion] += 1
+
+        # Convergence: stop once every team's playoff-odds standard
+        # error is inside tolerance.  Checked on a cadence and never
+        # before the floor, so a lopsided league cannot exit early on a
+        # handful of draws.
+        if completed >= min_simulations and completed % SIM_CHECK_EVERY == 0:
+            worst_se = max(_proportion_se(playoff_count[o] / completed, completed) for o in owners)
+            if worst_se <= odds_se_tolerance:
+                break
+
     out: list[dict[str, Any]] = []
     for owner in owners:
         seed_dist = seed_counts[owner]
-        n_safe = max(1, n_simulations)
+        n_safe = max(1, completed)
         # Median final seed: cumulative threshold at half the sims.
         cumulative = 0
         median_seed = len(owners)
@@ -586,11 +782,16 @@ def simulate_playoff_odds(
                 median_seed = i + 1
                 break
         most_likely_seed = seed_dist.index(max(seed_dist)) + 1
+        po_lo, po_hi = _wilson_interval(playoff_count[owner], n_safe)
+        ch_lo, ch_hi = _wilson_interval(champ_count[owner], n_safe)
         out.append(
             {
                 "ownerId": owner,
                 "displayName": metrics.display_name_for(snapshot, owner),
                 "playoffOdds": round(playoff_count[owner] / n_safe, 4),
+                "playoffOddsCi": [round(po_lo, 4), round(po_hi, 4)],
+                "championshipOdds": round(champ_count[owner] / n_safe, 4),
+                "championshipOddsCi": [round(ch_lo, 4), round(ch_hi, 4)],
                 "byeOdds": round(bye_count[owner] / n_safe, 4),
                 "topSeedOdds": round(top_seed_count[owner] / n_safe, 4),
                 "missPlayoffsOdds": round(miss_count[owner] / n_safe, 4),
@@ -601,15 +802,25 @@ def simulate_playoff_odds(
             }
         )
     out.sort(key=lambda r: -r["playoffOdds"])
+    worst_se = (
+        max(_proportion_se(playoff_count[o] / max(1, completed), max(1, completed)) for o in owners)
+        if owners
+        else 0.0
+    )
     return {
         "playoffOdds": out,
-        "n_simulations": n_simulations,
+        "n_simulations": completed,
+        "converged": worst_se <= odds_se_tolerance,
+        "worstPlayoffOddsSe": round(worst_se, 5),
+        "oddsSeTolerance": odds_se_tolerance,
         "playoffSeeds": playoff_seeds,
         "byeSeeds": bye_seeds,
         "rosStrengthAvailable": bool(ros_map),
         "rosBlend": ROS_BLEND,
         "bestBallVarianceBump": BEST_BALL_VARIANCE_BUMP,
         "bestBallVarianceMode": "depth_aware" if best_ball else "off",
+        "pointsModelSource": model.source,
+        "pointsModelGeneratedAt": model.generated_at,
     }
 
 
@@ -642,6 +853,212 @@ def _load_cached_payload() -> dict[str, Any] | None:
     except (json.JSONDecodeError, OSError) as exc:
         LOG.warning("[ros] playoff cache unreadable (%s); rerunning sim", exc)
         return None
+
+
+# ── Trade impact on shared seeds (spec §17.3) ──────────────────────
+
+
+@dataclass(frozen=True)
+class OddsDelta:
+    """One team's before/after odds movement, with an honest error bar."""
+
+    owner_id: str
+    display_name: str
+    before: float
+    after: float
+    delta: float
+    delta_ci: tuple[float, float]
+    significant: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ownerId": self.owner_id,
+            "displayName": self.display_name,
+            "before": round(self.before, 4),
+            "after": round(self.after, 4),
+            "delta": round(self.delta, 4),
+            "deltaCi": [round(self.delta_ci[0], 4), round(self.delta_ci[1], 4)],
+            "significant": self.significant,
+        }
+
+
+def _paired_delta_ci(
+    before_hits: int,
+    after_hits: int,
+    n: int,
+    z: float = 1.96,
+) -> tuple[float, float]:
+    """Interval for a paired proportion difference on SHARED seeds.
+
+    Both arms are driven by the same RNG stream, so their sampling
+    errors are strongly positively correlated and an unpaired interval
+    (which adds the variances) would be far too wide — it would call a
+    real trade effect "not significant" simply because each arm's
+    absolute odds are noisy.
+
+    We do not observe the per-simulation discordance counts here, so we
+    take the CONSERVATIVE paired bound: treat the number of discordant
+    pairs as at most ``before_hits + after_hits − 2·min(...)``, i.e. the
+    largest discordance consistent with the observed marginals.  That
+    over-states the interval slightly, which is the correct direction to
+    err — this function exists to stop us calling noise a result.
+    """
+    if n <= 0:
+        return (0.0, 0.0)
+    # Max possible discordant pairs given the marginals.
+    b_plus_c = min(n, abs(after_hits - before_hits) + 2 * min(before_hits, n - after_hits))
+    b_plus_c = max(abs(after_hits - before_hits), min(b_plus_c, n))
+    if b_plus_c <= 0:
+        return (0.0, 0.0)
+    d = (after_hits - before_hits) / n
+    # McNemar-style SE on the discordant pairs.
+    se = math.sqrt(b_plus_c) / n
+    return (d - z * se, d + z * se)
+
+
+def simulate_trade_impact(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    strength_delta: dict[str, float],
+    n_simulations: int = DEFAULT_SIMULATIONS,
+    playoff_seeds: int = 6,
+    bye_seeds: int = 2,
+    best_ball: bool | None = None,
+    seed: int = 20260726,
+    points_model: PointsModel | None = None,
+) -> dict[str, Any]:
+    """Playoff/championship odds movement from a proposed trade.
+
+    ``strength_delta`` maps ownerId → change in that team's weekly
+    scoring MEAN (in the same units the distributions use).  A trade is
+    zero-sum across its participants; this function does not enforce
+    that, because a three-way trade or a waiver add legitimately is not.
+
+    **Shared seeds (§17.3).**  Both arms run on the SAME RNG seed and
+    the SAME number of simulations, so every simulated week draws the
+    same underlying randomness before and after.  The difference is
+    therefore the trade's effect, not the difference between two
+    independent Monte Carlo runs.  Running the arms independently at
+    10k sims each would put roughly ±1pp of pure noise on every delta —
+    the same order as the effect being measured, which is how you end up
+    confidently reporting a sign that flips on re-run.
+
+    **Refusing to over-claim.**  Every delta carries a paired confidence
+    interval, and ``significant`` is False whenever that interval spans
+    zero.  Callers that render a delta MUST respect the flag: the spec
+    is explicit that a delta smaller than simulation error is not a
+    result.  ``meaningfulDeltas`` pre-filters for exactly that.
+
+    Returns::
+
+        {
+          "playoff":      [OddsDelta...],   # sorted by |delta| desc
+          "championship": [OddsDelta...],
+          "meaningfulDeltas": int,          # count across both metrics
+          "nSimulations": int,
+          "sharedSeed": int,
+          "pointsModelSource": str,
+        }
+    """
+    if best_ball is None:
+        best_ball = _league_best_ball()
+    model = points_model or load_points_model()
+    ros_map = _load_ros_strength_map()
+
+    base_dists, _ = _build_team_distributions(
+        snapshot, ros_map, best_ball=best_ball, points_model=model
+    )
+    if not base_dists:
+        return {
+            "playoff": [],
+            "championship": [],
+            "meaningfulDeltas": 0,
+            "nSimulations": 0,
+            "sharedSeed": seed,
+            "pointsModelSource": model.source,
+            "note": "no team distributions available",
+        }
+
+    after_dists = {
+        owner: _TeamDist(
+            owner_id=d.owner_id,
+            mean=max(0.0, d.mean + float(strength_delta.get(owner, 0.0))),
+            sd=d.sd,
+            pf_to_date=d.pf_to_date,
+        )
+        for owner, d in base_dists.items()
+    }
+
+    # Identical seeds, identical counts — this is the whole point.
+    before = simulate_playoff_odds(
+        snapshot,
+        n_simulations=n_simulations,
+        playoff_seeds=playoff_seeds,
+        bye_seeds=bye_seeds,
+        best_ball=best_ball,
+        rng=random.Random(seed),
+        points_model=model,
+        distributions=base_dists,
+    )
+    after = simulate_playoff_odds(
+        snapshot,
+        n_simulations=n_simulations,
+        playoff_seeds=playoff_seeds,
+        bye_seeds=bye_seeds,
+        best_ball=best_ball,
+        rng=random.Random(seed),
+        points_model=model,
+        distributions=after_dists,
+    )
+
+    before_by_owner = {r["ownerId"]: r for r in before.get("playoffOdds") or []}
+    after_by_owner = {r["ownerId"]: r for r in after.get("playoffOdds") or []}
+    n = int(after.get("n_simulations") or n_simulations)
+
+    def _deltas(metric: str) -> list[OddsDelta]:
+        rows: list[OddsDelta] = []
+        for owner, b_row in before_by_owner.items():
+            a_row = after_by_owner.get(owner)
+            if a_row is None:
+                continue
+            b = float(b_row.get(metric) or 0.0)
+            a = float(a_row.get(metric) or 0.0)
+            lo, hi = _paired_delta_ci(round(b * n), round(a * n), n)
+            rows.append(
+                OddsDelta(
+                    owner_id=owner,
+                    display_name=b_row.get("displayName") or owner,
+                    before=b,
+                    after=a,
+                    delta=a - b,
+                    delta_ci=(lo, hi),
+                    # Significant only when the interval excludes zero.
+                    significant=(lo > 0.0) or (hi < 0.0),
+                )
+            )
+        rows.sort(key=lambda r: -abs(r.delta))
+        return rows
+
+    playoff_rows = _deltas("playoffOdds")
+    champ_rows = _deltas("championshipOdds")
+    meaningful = sum(1 for r in playoff_rows + champ_rows if r.significant)
+
+    return {
+        "playoff": [r.to_dict() for r in playoff_rows],
+        "championship": [r.to_dict() for r in champ_rows],
+        "meaningfulDeltas": meaningful,
+        "nSimulations": n,
+        "sharedSeed": seed,
+        "pointsModelSource": model.source,
+        "methodology": (
+            "Both arms run on one shared RNG seed and an identical simulation "
+            "count, so the reported delta is the trade's effect rather than the "
+            "difference between two independent Monte Carlo runs. Intervals are "
+            "paired (McNemar-style, conservative on the discordant-pair count). "
+            "A delta whose interval spans zero is flagged significant=false and "
+            "must not be presented as a result."
+        ),
+    }
 
 
 def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:

--- a/src/ros/scrape.py
+++ b/src/ros/scrape.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from src.ros import ROS_DATA_DIR
 from src.ros.aggregate import RankedRow, SourceSnapshot, aggregate
+from src.ros.lineup import flatten_starter_slots
 from src.ros.mapping import resolve_player
 from src.ros.sources import enabled_ros_sources
 
@@ -168,25 +169,11 @@ def _rebuild_index(latest_runs: dict[str, dict[str, Any]]) -> Path:
     return index_path
 
 
-def _flatten_starter_slots(starters: dict[str, Any] | None) -> list[str]:
-    """Expand ``{"QB": 1, "RB": 2, ...}`` → ``["QB", "RB", "RB", ...]``.
-
-    Mirrors how `compute_team_strength`'s ``starter_slots`` argument
-    expects a flat list (one entry per slot) rather than a count map.
-    """
-    if not starters:
-        return []
-    out: list[str] = []
-    alias = {"SFLEX": "SUPER_FLEX"}
-    for slot, count in starters.items():
-        try:
-            n = int(count)
-        except (TypeError, ValueError):
-            continue
-        if n <= 0:
-            continue
-        out.extend([alias.get(str(slot).upper(), str(slot).upper())] * n)
-    return out
+# Canonical flattener lives in ``src.ros.lineup`` (LI-8) — this module
+# used to carry a byte-identical copy alongside a third in
+# ``playoff_sim``.  Re-exported under the old private name so existing
+# callers and tests keep working.
+_flatten_starter_slots = flatten_starter_slots
 
 
 def _hydrate_overlay_players(

--- a/tests/league_intel/test_playoff_sim_li8.py
+++ b/tests/league_intel/test_playoff_sim_li8.py
@@ -1,0 +1,324 @@
+"""LI-8 tests for ``src/ros/playoff_sim.py``.
+
+Covers the four LI-8 deliverables:
+
+  1. the sim uses the EXACT lineup optimizer (and therefore inherits the
+     ``fantasy_positions`` fix), not the old slot-ordered greedy;
+  2. the duplicated starter-slot flattener is gone — one implementation;
+  3. trade impact runs on SHARED seeds and refuses to call a delta
+     smaller than simulation error meaningful;
+  4. simulation counts are convergence-driven, not fixed.
+
+No network, no on-disk artifacts: distributions are injected.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from src.ros import lineup, playoff_sim
+from src.ros.playoff_sim import (
+    _TeamDist,
+    _bestball_weekly_score,
+    _mean_is_converged,
+    _paired_delta_ci,
+    _proportion_se,
+    _simulate_bracket,
+    _wilson_interval,
+    simulate_trade_impact,
+)
+
+
+# ── 2. One flattener ───────────────────────────────────────────────
+
+
+class TestNoDuplication:
+    def test_playoff_sim_reuses_the_canonical_flattener(self):
+        assert playoff_sim._load_starter_slots is lineup.load_league_starter_slots
+
+    def test_scrape_reuses_the_canonical_flattener(self):
+        from src.ros import scrape
+
+        assert scrape._flatten_starter_slots is lineup.flatten_starter_slots
+
+    def test_playoff_sim_no_longer_defines_its_own_eligibility(self):
+        # The private copy is gone; eligibility has exactly one home.
+        assert "_eligible_for_slot" not in vars(playoff_sim)
+
+    def test_flattener_normalizes_slot_aliases(self):
+        # SFLEX was aliased in two private maps that could drift apart.
+        assert lineup.flatten_starter_slots({"SFLEX": 1}) == ["SUPER_FLEX"]
+        assert lineup.flatten_starter_slots({"WRRB_FLEX": 2}) == ["FLEX", "FLEX"]
+
+    def test_flattener_skips_junk_counts(self):
+        assert lineup.flatten_starter_slots({"QB": 0, "RB": -1, "WR": "x", "TE": 2}) == [
+            "TE",
+            "TE",
+        ]
+
+    def test_flattener_handles_empty(self):
+        assert lineup.flatten_starter_slots(None) == []
+        assert lineup.flatten_starter_slots({}) == []
+
+
+# ── 1. Exact lineup inside the sim ─────────────────────────────────
+
+
+def _p(pid: str, pos: str, value: float, fpos: tuple[str, ...] = ()) -> dict:
+    return {
+        "playerId": pid,
+        "position": pos,
+        "rosValue": value,
+        "fantasyPositions": fpos,
+    }
+
+
+class _FixedModel:
+    """Deterministic points model: points == rosValue, no variance.
+
+    Lets a lineup assertion be exact instead of statistical.
+    """
+
+    source = "test-fixed"
+    generated_at = None
+
+    def draw(self, ros_value, position, rng):  # noqa: ARG002
+        return float(ros_value)
+
+
+class TestExactLineupInSim:
+    def test_weekly_score_is_the_optimal_assignment(self):
+        # QB 10, RB 9, WR 8. Slots QB + FLEX(RB/WR/TE) + SUPER_FLEX.
+        # Optimal: QB→QB(10), RB→SFLEX(9), WR→FLEX(8) = 27.
+        roster = [_p("qb", "QB", 10.0), _p("rb", "RB", 9.0), _p("wr", "WR", 8.0)]
+        total = _bestball_weekly_score(
+            roster, ["QB", "FLEX", "SUPER_FLEX"], random.Random(1), _FixedModel()
+        )
+        assert total == pytest.approx(27.0)
+
+    def test_hybrid_idp_can_fill_either_legal_slot(self):
+        # A DL/LB hybrid plus a pure DL. With one DL and one LB slot the
+        # optimal answer starts both — only possible if the sim honors
+        # fantasy_positions. The pre-LI-8 sim matched on `position`
+        # alone and would have left the LB slot empty.
+        roster = [
+            _p("hybrid", "DL", 12.0, fpos=("DL", "LB")),
+            _p("puredl", "DL", 9.0),
+        ]
+        total = _bestball_weekly_score(roster, ["DL", "LB"], random.Random(1), _FixedModel())
+        assert total == pytest.approx(21.0)
+
+    def test_non_laminar_slots_beat_the_old_greedy(self):
+        # Slots: FLEX(RB/WR/TE) and DL. Players: a WR(10) and a DL(1).
+        # Any correct solver starts both for 11.
+        roster = [_p("wr", "WR", 10.0), _p("dl", "DL", 1.0)]
+        assert _bestball_weekly_score(
+            roster, ["FLEX", "DL"], random.Random(1), _FixedModel()
+        ) == pytest.approx(11.0)
+
+    def test_empty_inputs_score_zero(self):
+        assert _bestball_weekly_score([], ["QB"], random.Random(1)) == 0.0
+        assert _bestball_weekly_score([_p("a", "QB", 5.0)], [], random.Random(1)) == 0.0
+
+    def test_unpriced_players_are_skipped(self):
+        roster = [_p("a", "QB", 0.0), _p("b", "QB", 10.0)]
+        assert _bestball_weekly_score(
+            roster, ["QB"], random.Random(1), _FixedModel()
+        ) == pytest.approx(10.0)
+
+
+# ── 4. Convergence ─────────────────────────────────────────────────
+
+
+class TestConvergence:
+    def test_short_sample_is_never_converged(self):
+        assert _mean_is_converged([1.0, 2.0], 0.01) is False
+
+    def test_zero_variance_converges_immediately(self):
+        assert _mean_is_converged([5.0] * 10, 0.01) is True
+
+    def test_tight_sample_converges_before_a_noisy_one(self):
+        rng = random.Random(11)
+        tight = [rng.gauss(100, 1) for _ in range(200)]
+        noisy = [rng.gauss(100, 60) for _ in range(200)]
+        assert _mean_is_converged(tight, 0.01) is True
+        assert _mean_is_converged(noisy, 0.01) is False
+
+    def test_all_zero_sample_uses_the_absolute_criterion(self):
+        # A relative test can never be satisfied at mean 0; without the
+        # absolute fallback this would spin to the cap.
+        assert _mean_is_converged([0.0] * 20, 0.01) is True
+
+    def test_proportion_se_shrinks_with_n(self):
+        assert _proportion_se(0.5, 100) > _proportion_se(0.5, 10000)
+        assert _proportion_se(0.5, 0) == 0.0
+
+
+class TestWilsonInterval:
+    def test_interval_brackets_the_point_estimate(self):
+        lo, hi = _wilson_interval(500, 1000)
+        assert lo < 0.5 < hi
+
+    def test_interval_stays_inside_zero_one_at_the_boundary(self):
+        lo, hi = _wilson_interval(0, 1000)
+        assert lo == 0.0
+        # The honest part: zero successes does NOT mean zero probability.
+        assert hi > 0.0
+        lo2, hi2 = _wilson_interval(1000, 1000)
+        assert hi2 == 1.0 and lo2 < 1.0
+
+    def test_interval_narrows_as_n_grows(self):
+        n_lo, n_hi = _wilson_interval(50, 100)
+        w_lo, w_hi = _wilson_interval(5000, 10000)
+        assert (w_hi - w_lo) < (n_hi - n_lo)
+
+    def test_zero_n_is_maximally_uncertain(self):
+        assert _wilson_interval(0, 0) == (0.0, 1.0)
+
+
+# ── 3. Trade impact on shared seeds ────────────────────────────────
+
+
+def _dists(means: dict[str, float], sd: float = 20.0) -> dict[str, _TeamDist]:
+    return {o: _TeamDist(owner_id=o, mean=m, sd=sd, pf_to_date=0.0) for o, m in means.items()}
+
+
+class TestPairedDeltaCi:
+    def test_identical_arms_have_a_zero_delta(self):
+        lo, hi = _paired_delta_ci(500, 500, 1000)
+        assert lo <= 0.0 <= hi
+
+    def test_interval_excludes_zero_for_a_large_shift(self):
+        lo, hi = _paired_delta_ci(100, 900, 1000)
+        assert lo > 0.0
+
+    def test_interval_spans_zero_for_a_tiny_shift(self):
+        # A 3-in-1000 move is inside the noise floor and must not be
+        # sold as a result.
+        lo, hi = _paired_delta_ci(500, 503, 1000)
+        assert lo < 0.0 < hi
+
+    def test_zero_n_is_a_zero_interval(self):
+        assert _paired_delta_ci(0, 0, 0) == (0.0, 0.0)
+
+
+class TestSimulateTradeImpact:
+    @pytest.fixture(autouse=True)
+    def _stub_league(self, monkeypatch):
+        """Inject distributions + a trivial schedule; no snapshot I/O."""
+        owners = {f"o{i}": 100.0 for i in range(1, 9)}
+        base = _dists(owners)
+        monkeypatch.setattr(playoff_sim, "_load_ros_strength_map", lambda: {})
+        monkeypatch.setattr(
+            playoff_sim,
+            "_build_team_distributions",
+            lambda *a, **k: (base, {o: 0.0 for o in owners}),
+        )
+        monkeypatch.setattr(playoff_sim, "_league_best_ball", lambda: False)
+        monkeypatch.setattr(playoff_sim, "_current_record", lambda s: {})
+        # Round-robin-ish schedule so wins actually differentiate.
+        names = sorted(owners)
+        sched = [
+            (w, names[i], names[i + 1]) for w in range(1, 6) for i in range(0, len(names) - 1, 2)
+        ]
+        monkeypatch.setattr(playoff_sim, "_remaining_schedule", lambda s: sched)
+        monkeypatch.setattr(playoff_sim.metrics, "display_name_for", lambda s, o: f"Team {o}")
+        self.owners = names
+
+    def test_zero_delta_trade_produces_no_significant_movement(self):
+        out = simulate_trade_impact(
+            snapshot=None,
+            strength_delta={},
+            n_simulations=1500,
+            playoff_seeds=4,
+            bye_seeds=2,
+        )
+        # Shared seeds mean an empty trade is EXACTLY zero everywhere —
+        # this is the property an unpaired run would not have.
+        assert all(r["delta"] == 0.0 for r in out["playoff"])
+        assert all(r["significant"] is False for r in out["playoff"])
+        assert out["meaningfulDeltas"] == 0
+
+    def test_shared_seed_is_reported_and_reproducible(self):
+        a = simulate_trade_impact(
+            snapshot=None, strength_delta={"o1": 25.0}, n_simulations=1200, seed=99
+        )
+        b = simulate_trade_impact(
+            snapshot=None, strength_delta={"o1": 25.0}, n_simulations=1200, seed=99
+        )
+        assert a["sharedSeed"] == 99
+        assert [r["delta"] for r in a["playoff"]] == [r["delta"] for r in b["playoff"]]
+
+    def test_large_upgrade_moves_that_team_up_significantly(self):
+        out = simulate_trade_impact(
+            snapshot=None,
+            strength_delta={"o1": 60.0},
+            n_simulations=3000,
+            playoff_seeds=4,
+            bye_seeds=2,
+        )
+        row = next(r for r in out["playoff"] if r["ownerId"] == "o1")
+        assert row["delta"] > 0
+        assert row["significant"] is True
+        # The interval must not span zero when we call it significant.
+        assert row["deltaCi"][0] > 0
+
+    def test_every_row_carries_an_interval(self):
+        out = simulate_trade_impact(snapshot=None, strength_delta={"o1": 10.0}, n_simulations=1200)
+        for r in out["playoff"] + out["championship"]:
+            assert len(r["deltaCi"]) == 2
+            assert r["deltaCi"][0] <= r["delta"] <= r["deltaCi"][1] or r["delta"] == 0.0
+
+    def test_championship_deltas_are_reported(self):
+        out = simulate_trade_impact(
+            snapshot=None,
+            strength_delta={"o1": 60.0},
+            n_simulations=2000,
+            playoff_seeds=4,
+            bye_seeds=2,
+        )
+        assert out["championship"], "championship deltas must be present"
+        champ_total = sum(r["after"] for r in out["championship"])
+        # Exactly one champion per sim ⇒ the odds are a distribution.
+        assert champ_total == pytest.approx(1.0, abs=0.02)
+
+    def test_methodology_states_the_significance_rule(self):
+        out = simulate_trade_impact(snapshot=None, strength_delta={}, n_simulations=800)
+        assert "shared RNG seed" in out["methodology"]
+        assert "significant=false" in out["methodology"]
+
+    def test_no_distributions_returns_an_explicit_empty(self, monkeypatch):
+        monkeypatch.setattr(playoff_sim, "_build_team_distributions", lambda *a, **k: ({}, {}))
+        out = simulate_trade_impact(snapshot=None, strength_delta={"o1": 5.0})
+        assert out["playoff"] == []
+        assert out["meaningfulDeltas"] == 0
+        assert "note" in out
+
+
+# ── Bracket ────────────────────────────────────────────────────────
+
+
+class TestBracket:
+    def test_champion_comes_from_the_seeded_field(self):
+        d = _dists({f"o{i}": 100.0 for i in range(1, 7)})
+        champ = _simulate_bracket(list(d), d, 2, random.Random(4))
+        assert champ in d
+
+    def test_dominant_seed_wins_most_of_the_time(self):
+        d = _dists({"strong": 200.0, "a": 80.0, "b": 80.0, "c": 80.0}, sd=5.0)
+        rng = random.Random(5)
+        wins = sum(
+            1
+            for _ in range(300)
+            if _simulate_bracket(["strong", "a", "b", "c"], d, 1, rng) == "strong"
+        )
+        assert wins > 250
+
+    def test_empty_field_returns_none(self):
+        assert _simulate_bracket([], {}, 2, random.Random(1)) is None
+
+    def test_single_team_field_wins_by_default(self):
+        d = _dists({"solo": 100.0})
+        assert _simulate_bracket(["solo"], d, 2, random.Random(1)) == "solo"

--- a/tests/league_intel/test_registry_consumers.py
+++ b/tests/league_intel/test_registry_consumers.py
@@ -157,9 +157,11 @@ class TestRosLineupPath:
 
 class TestPlayoffSimPath:
     def test_load_starter_slots_reads_corrected_registry(self, real_registry):
-        # playoff_sim's duplicated _eligible_for_slot was deleted (LI-8);
-        # it now delegates to the real optimizer, so eligibility is
-        # asserted against the single source of truth.
+        # LI-8 removed playoff_sim's private duplicates of the flattener
+        # and the eligibility rules (ADR-007 flagged both for this task).
+        # The module now re-exports the canonical lineup.py versions, so
+        # this test asserts the same behavior through the one
+        # implementation that survives.
         from src.ros.lineup import _eligible_for_slot
         from src.ros.playoff_sim import _load_starter_slots
 

--- a/tests/league_intel/test_sim_calibration.py
+++ b/tests/league_intel/test_sim_calibration.py
@@ -1,0 +1,244 @@
+"""Tests for ``src/league_intel/sim_calibration.py`` (LI-8).
+
+The points model is the bridge between rosValue (unitless composite)
+and fantasy points (what the sim actually needs).  These pin:
+
+  * the fallback path — a missing/corrupt artifact must degrade, never
+    raise, and must SAY it degraded;
+  * the calibration math — through-origin scale fit, per-position CV,
+    and the sample floor that stops a 3-week sample masquerading as
+    evidence;
+  * that no test touches the network (the fetcher is injected).
+"""
+
+from __future__ import annotations
+
+import json
+import random
+
+from src.league_intel.sim_calibration import (
+    CV_CLAMP,
+    FALLBACK_CV_BY_POSITION,
+    FALLBACK_ROS_VALUE_PER_POINT,
+    MIN_SAMPLES_PER_POSITION,
+    SCHEMA_VERSION,
+    PointsModel,
+    build_calibration,
+    calibrate_positions,
+    calibrate_scale,
+    fetch_stat_lines,
+    load_points_model,
+    write_calibration,
+)
+
+
+# ── Fallback behavior ──────────────────────────────────────────────
+
+
+def test_missing_artifact_degrades_to_documented_fallback(tmp_path):
+    model = load_points_model(tmp_path / "nope.json")
+    assert model.source == "fallback-constants"
+    assert model.ros_value_per_point == FALLBACK_ROS_VALUE_PER_POINT
+    assert model.cv_for("QB") == FALLBACK_CV_BY_POSITION["QB"]
+
+
+def test_corrupt_artifact_degrades_without_raising(tmp_path):
+    p = tmp_path / "model.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert load_points_model(p).source == "fallback-constants"
+
+
+def test_schema_mismatch_degrades(tmp_path):
+    p = tmp_path / "model.json"
+    p.write_text(json.dumps({"schemaVersion": 999, "scale": {"rosValuePerPoint": 3}}))
+    assert load_points_model(p).source == "fallback-constants"
+
+
+def test_artifact_without_usable_scale_degrades(tmp_path):
+    p = tmp_path / "model.json"
+    p.write_text(json.dumps({"schemaVersion": SCHEMA_VERSION, "scale": {"rosValuePerPoint": 0}}))
+    assert load_points_model(p).source == "fallback-constants"
+
+
+def test_valid_artifact_loads_as_calibrated(tmp_path):
+    p = tmp_path / "model.json"
+    p.write_text(
+        json.dumps(
+            {
+                "schemaVersion": SCHEMA_VERSION,
+                "generatedAt": "2026-07-26T00:00:00+00:00",
+                "sampleSize": 1415,
+                "scale": {"rosValuePerPoint": 3.1, "r2": 0.6, "n": 400},
+                "byPosition": {"QB": {"cv": 0.28, "n": 100, "measured": True}},
+            }
+        )
+    )
+    model = load_points_model(p)
+    assert model.source == "calibrated"
+    assert model.ros_value_per_point == 3.1
+    assert model.cv_for("QB") == 0.28
+    # Positions absent from the artifact keep the documented fallback.
+    assert model.cv_for("RB") == FALLBACK_CV_BY_POSITION["RB"]
+    assert model.sample_size == 1415
+
+
+# ── Draw behavior ──────────────────────────────────────────────────
+
+
+def test_draw_is_deterministic_for_a_seeded_rng():
+    m = PointsModel()
+    a = [m.draw(50.0, "RB", random.Random(7)) for _ in range(3)]
+    b = [m.draw(50.0, "RB", random.Random(7)) for _ in range(3)]
+    assert a == b
+
+
+def test_draw_never_returns_negative_points():
+    m = PointsModel(ros_value_per_point=2.7, cv_by_position={"WR": 1.2})
+    rng = random.Random(1)
+    assert all(m.draw(5.0, "WR", rng) >= 0.0 for _ in range(200))
+
+
+def test_zero_value_player_draws_zero():
+    assert PointsModel().draw(0.0, "QB", random.Random(1)) == 0.0
+
+
+def test_mean_points_scales_inversely_with_divisor():
+    assert PointsModel(ros_value_per_point=2.0).mean_points(50.0) == 25.0
+    assert PointsModel(ros_value_per_point=5.0).mean_points(50.0) == 10.0
+
+
+# ── Calibration math ───────────────────────────────────────────────
+
+
+def test_scale_fit_recovers_a_known_linear_relationship():
+    # rosValue = 3 × points, exactly.
+    pairs = [(3.0 * pts, pts) for pts in range(1, 30)]
+    out = calibrate_scale(pairs)
+    assert abs(out["rosValuePerPoint"] - 3.0) < 1e-6
+    assert out["r2"] > 0.99
+    assert out["n"] == 29
+
+
+def test_scale_fit_reports_weak_r2_on_noise():
+    rng = random.Random(3)
+    pairs = [(rng.uniform(1, 100), rng.uniform(1, 30)) for _ in range(200)]
+    out = calibrate_scale(pairs)
+    # Random pairs must not be sold as a good fit.
+    assert out["r2"] < 0.5
+
+
+def test_scale_fit_falls_back_on_insufficient_pairs():
+    out = calibrate_scale([(10.0, 3.0)])
+    assert out["rosValuePerPoint"] == FALLBACK_ROS_VALUE_PER_POINT
+    assert out["n"] == 1
+
+
+def test_position_cv_is_measured_above_the_sample_floor():
+    # Constant-mean series with known spread.
+    pts = [10.0, 20.0] * (MIN_SAMPLES_PER_POSITION // 2 + 5)
+    cals = calibrate_positions({"RB": pts})
+    rb = cals["RB"]
+    assert rb.measured is True
+    assert rb.n == len(pts)
+    # mean 15, pstdev 5 ⇒ cv ≈ 0.333
+    assert abs(rb.cv - (5.0 / 15.0)) < 1e-6
+
+
+def test_thin_sample_keeps_fallback_cv_and_says_so():
+    cals = calibrate_positions({"TE": [10.0, 20.0, 30.0]})
+    te = cals["TE"]
+    assert te.measured is False
+    assert te.cv == FALLBACK_CV_BY_POSITION["TE"]
+    assert te.n == 3
+
+
+def test_cv_is_clamped_to_a_sane_band():
+    # Wildly dispersed sample would otherwise produce cv > 1.2.
+    pts = ([0.1] * 60) + ([500.0] * 60)
+    cals = calibrate_positions({"WR": pts})
+    assert cals["WR"].cv <= CV_CLAMP[1]
+    # And a near-constant sample must not produce a ~0 cv.
+    steady = [20.0] * 60
+    assert calibrate_positions({"QB": steady})["QB"].cv >= CV_CLAMP[0]
+
+
+# ── End-to-end artifact build ──────────────────────────────────────
+
+_SCORING = {"pass_yd": 0.04, "pass_td": 4.0, "rec": 0.5, "rec_yd": 0.1}
+
+
+def test_build_calibration_scores_through_the_exact_scorer():
+    # Two players, three weeks. QB scores 0.04/yd + 4/td.
+    stat_lines = {
+        1: {"qb1": {"pass_yd": 300, "pass_td": 2}, "wr1": {"rec": 6, "rec_yd": 80}},
+        2: {"qb1": {"pass_yd": 250, "pass_td": 1}, "wr1": {"rec": 4, "rec_yd": 50}},
+        3: {"qb1": {"pass_yd": 350, "pass_td": 3}, "wr1": {"rec": 8, "rec_yd": 110}},
+    }
+    payload = build_calibration(
+        stat_lines_by_week=stat_lines,
+        positions={"qb1": "QB", "wr1": "WR"},
+        ros_values={"qb1": 60.0, "wr1": 40.0},
+        config=_SCORING,
+        season="2025",
+    )
+    assert payload["schemaVersion"] == SCHEMA_VERSION
+    assert payload["season"] == "2025"
+    assert payload["weeks"] == [1, 2, 3]
+    assert payload["sampleSize"] == 6
+    # QB wk1 = 300*0.04 + 2*4 = 20.0 — straight from the exact scorer.
+    assert abs(payload["byPosition"]["QB"]["meanPoints"] - ((20.0 + 14.0 + 26.0) / 3)) < 1e-6
+    # Thin samples ⇒ not measured, and the artifact admits it.
+    assert payload["byPosition"]["QB"]["measured"] is False
+    assert "provenance" in payload and payload["provenance"]["scorer"].endswith("score_stat_line")
+
+
+def test_build_calibration_ignores_players_without_a_position():
+    payload = build_calibration(
+        stat_lines_by_week={1: {"ghost": {"pass_yd": 100}}},
+        positions={},
+        ros_values={},
+        config=_SCORING,
+        season="2025",
+    )
+    assert payload["sampleSize"] == 0
+    assert payload["byPosition"] == {}
+
+
+def test_write_calibration_round_trips(tmp_path):
+    target = tmp_path / "sim_points_model.json"
+    payload = {
+        "schemaVersion": SCHEMA_VERSION,
+        "scale": {"rosValuePerPoint": 2.9},
+        "byPosition": {"RB": {"cv": 0.5, "n": 99, "measured": True}},
+    }
+    written = write_calibration(payload, target)
+    assert written.exists()
+    assert load_points_model(written).ros_value_per_point == 2.9
+    # No temp files left behind.
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+# ── Fetch policy ───────────────────────────────────────────────────
+
+
+def test_fetch_uses_injected_fetcher_and_never_touches_network():
+    seen: list[str] = []
+
+    def fake(url: str):
+        seen.append(url)
+        return {"p1": {"pass_yd": 100}}
+
+    out = fetch_stat_lines("2025", [1, 2], fetcher=fake, sleep_s=0)
+    assert len(seen) == 2
+    assert all(u.startswith("https://api.sleeper.app/v1/stats/nfl/regular/2025/") for u in seen)
+    assert set(out) == {1, 2}
+
+
+def test_one_failing_week_does_not_abort_the_run():
+    def flaky(url: str):
+        if url.endswith("/2"):
+            raise RuntimeError("sleeper 500")
+        return {"p1": {"pass_yd": 100}}
+
+    out = fetch_stat_lines("2025", [1, 2, 3], fetcher=flaky, sleep_s=0)
+    assert set(out) == {1, 3}

--- a/tests/league_intel/test_twin.py
+++ b/tests/league_intel/test_twin.py
@@ -1,0 +1,223 @@
+"""LI-8 League Twin bridge — roster change to playoff-odds input.
+
+The bridge's whole job is producing ``simulate_trade_impact``'s
+``strength_delta`` from real rosters.  Two properties carry the weight:
+the delta must be in ``_TeamDist.mean`` units (i.e. scaled by the same
+multiplicative ROS blend the simulator applied), and an owner the model
+cannot price must be ABSENT rather than zero.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.league_intel.twin import (
+    TWIN_BRIDGE_VERSION,
+    strength_deltas_from_rosters,
+)
+
+SLOTS = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "SUPER_FLEX", "LB", "DL"]
+
+
+def player(pid, pos, value, fp=()):
+    return {
+        "playerId": pid,
+        "canonicalName": pid,
+        "position": pos,
+        "rosValue": value,
+        "fantasyPositions": list(fp),
+    }
+
+
+def roster(n=14, base=1000):
+    return [player(f"p{i}", "WR", base + i * 10) for i in range(n)]
+
+
+class TestUnitsAreTeamDistMeanNotPresimPoints:
+    """`_TeamDist.mean = presim_mean * (1 + ROS_BLEND * ros_z)`, so a raw
+    presim delta is in the wrong units for the field it lands in."""
+
+    def test_blend_factor_scales_the_delta_exactly(self):
+        before, after = roster(), roster()[:-1]
+        plain = strength_deltas_from_rosters({"o1": before}, {"o1": after}, SLOTS, weeks=30, seed=5)
+        blended = strength_deltas_from_rosters(
+            {"o1": before},
+            {"o1": after},
+            SLOTS,
+            weeks=30,
+            seed=5,
+            ros_z_by_owner={"o1": 2.0},
+            ros_blend=0.20,
+        )
+        d0, d1 = plain.per_owner[0], blended.per_owner[0]
+        assert d0.blend_factor == pytest.approx(1.0)
+        assert d1.blend_factor == pytest.approx(1.4)
+        # Multiplicative blend scales exactly — not approximately.
+        assert d1.mean_delta == pytest.approx(d0.raw_mean_delta * 1.4)
+
+    def test_raw_delta_is_reported_so_the_scaling_is_auditable(self):
+        out = strength_deltas_from_rosters(
+            {"o1": roster()},
+            {"o1": roster()[:-1]},
+            SLOTS,
+            weeks=30,
+            seed=5,
+            ros_z_by_owner={"o1": -1.5},
+        )
+        d = out.per_owner[0]
+        assert d.raw_mean_delta is not None
+        assert d.mean_delta == pytest.approx(d.raw_mean_delta * d.blend_factor)
+
+    def test_no_ros_score_means_factor_exactly_one(self):
+        """The simulator skips the blend entirely for an owner with no
+        ROS strength, so 1.0 is correct rather than a fudge."""
+        out = strength_deltas_from_rosters(
+            {"o1": roster()}, {"o1": roster()[:-1]}, SLOTS, weeks=20, seed=5
+        )
+        assert out.per_owner[0].blend_factor == 1.0
+
+    def test_negative_z_shrinks_the_delta(self):
+        before, after = roster(), roster()[:-1]
+        weak = strength_deltas_from_rosters(
+            {"o1": before},
+            {"o1": after},
+            SLOTS,
+            weeks=30,
+            seed=5,
+            ros_z_by_owner={"o1": -2.0},
+            ros_blend=0.20,
+        )
+        assert weak.per_owner[0].blend_factor == pytest.approx(0.6)
+
+
+class TestUnavailableIsAbsentNotZero:
+    def test_unpriceable_owner_is_omitted_from_the_map(self):
+        """`simulate_trade_impact` reads a missing owner as unmoved,
+        which is the right reading of 'no information'.  An explicit 0.0
+        would assert the trade is neutral for them."""
+        out = strength_deltas_from_rosters(
+            {"o1": [player("only", "WR", 1000)]},
+            {"o1": []},
+            SLOTS,
+            weeks=10,
+            seed=5,
+        )
+        assert "o1" not in out.strength_delta
+        assert len(out.unavailable) == 1
+        assert out.unavailable[0].unavailable_reason
+
+    def test_available_owner_is_present(self):
+        out = strength_deltas_from_rosters(
+            {"o1": roster()}, {"o1": roster()[:-1]}, SLOTS, weeks=20, seed=5
+        )
+        assert "o1" in out.strength_delta
+
+    def test_owner_missing_from_after_is_skipped_entirely(self):
+        out = strength_deltas_from_rosters(
+            {"o1": roster(), "ghost": roster()}, {"o1": roster()}, SLOTS, weeks=20, seed=5
+        )
+        assert {d.owner_id for d in out.per_owner} == {"o1"}
+
+
+class TestVarianceIsReportedNotDiscarded:
+    """simulate_trade_impact copies sd unchanged, so the trade's effect
+    on variance vanishes there.  The bridge must not also lose it."""
+
+    def test_sd_delta_is_present_and_independent_of_mean(self):
+        out = strength_deltas_from_rosters(
+            {"o1": roster()}, {"o1": roster()[:-1]}, SLOTS, weeks=40, seed=5
+        )
+        d = out.per_owner[0]
+        assert d.sd_delta is not None
+        assert d.mean_delta is not None
+
+    def test_the_limitation_is_stamped_not_implied(self):
+        out = strength_deltas_from_rosters(
+            {"o1": roster()}, {"o1": roster()[:-1]}, SLOTS, weeks=20, seed=5
+        )
+        assert any("NOT fed into simulate_trade_impact" in a for a in out.assumptions)
+        assert any("ros_z is assumed UNCHANGED" in a for a in out.assumptions)
+
+
+class TestMonotonicitySurvivesTheBridge:
+    def test_dropping_a_player_never_raises_the_scaled_delta(self):
+        """The ADR-011 invariant must hold through the scaling too — a
+        positive blend factor cannot flip the sign."""
+        full = roster(16)
+        for drop in range(0, 16, 3):
+            after = [p for i, p in enumerate(full) if i != drop]
+            out = strength_deltas_from_rosters(
+                {"o1": full},
+                {"o1": after},
+                SLOTS,
+                weeks=30,
+                seed=11,
+                ros_z_by_owner={"o1": 1.5},
+            )
+            assert out.per_owner[0].mean_delta <= 1e-9
+
+    def test_identical_rosters_give_exactly_zero(self):
+        out = strength_deltas_from_rosters(
+            {"o1": roster()},
+            {"o1": roster()},
+            SLOTS,
+            weeks=30,
+            seed=11,
+            ros_z_by_owner={"o1": 1.5},
+        )
+        assert out.per_owner[0].mean_delta == 0.0
+
+
+class TestOnRealRosters:
+    @staticmethod
+    def _pool():
+        path = Path(__file__).resolve().parent / "fixtures" / "league_pool.json"
+        if not path.exists():
+            pytest.skip("league pool fixture not present")
+        return json.loads(path.read_text())
+
+    def test_a_real_trade_moves_both_sides_in_opposite_directions(self):
+        pool = self._pool()
+        slots = (
+            ["QB"]
+            + ["RB"] * 2
+            + ["WR"] * 3
+            + ["TE"] * 2
+            + ["FLEX"] * 2
+            + ["SUPER_FLEX"]
+            + ["K"]
+            + ["DL"] * 3
+            + ["LB"] * 3
+            + ["DB"] * 3
+        )
+        a, b = pool[0], pool[1]
+        # NOTE: key on rosterId, not ownerId. This fixture carries no
+        # ownerId, so `str(a.get("ownerId"))` yields "None" for BOTH
+        # teams, the two dict entries collapse to one key, and B
+        # silently overwrites A. The first draft of this test did that
+        # and reported +12.03 for the team GIVING a player away — which
+        # looked exactly like the ADR-011 monotonicity defect and was
+        # actually B's gain read under A's name. Worth keeping: a
+        # single-sided assertion would have passed.
+        a_id, b_id = str(a["rosterId"]), str(b["rosterId"])
+        assert a_id != b_id
+        # A sends its best player to B for nothing — a pure giveaway, so
+        # the sign is knowable without trusting the magnitude.
+        best = max(a["players"], key=lambda p: float(p.get("rosValue") or 0))
+        before = {a_id: a["players"], b_id: b["players"]}
+        after = {
+            a_id: [p for p in a["players"] if p["playerId"] != best["playerId"]],
+            b_id: b["players"] + [best],
+        }
+        out = strength_deltas_from_rosters(before, after, slots, weeks=60, seed=3)
+        assert out.strength_delta[a_id] < 0
+        assert out.strength_delta[b_id] > 0
+
+    def test_bridge_version_is_stamped(self):
+        out = strength_deltas_from_rosters(
+            {"o1": roster()}, {"o1": roster()[:-1]}, SLOTS, weeks=10, seed=5
+        )
+        assert out.to_dict()["bridgeVersion"] == TWIN_BRIDGE_VERSION

--- a/tests/ros/test_playoff_sim.py
+++ b/tests/ros/test_playoff_sim.py
@@ -119,5 +119,110 @@ class TestRosBlendConstants(unittest.TestCase):
         self.assertGreater(playoff_sim.BEST_BALL_VARIANCE_BUMP, 1.0)
 
 
+class TestRosterLoaderFeedsTheOptimizerProperly(unittest.TestCase):
+    """``_load_team_rosters`` is the input to an exact optimizer, and an
+    exact solve is only as good as the data it is handed.
+
+    Two defects lived here, and both are the same shape: the ALGORITHM
+    was fixed while the LOADER still expressed the original bug.
+    """
+
+    @staticmethod
+    def _snapshot_rows():
+        return [
+            {
+                "ownerId": "o1",
+                "startingLineup": [{"playerId": "s1", "position": "DL", "rosValue": 50.0}],
+                "benchDepth": [{"playerId": "b1", "position": "WR", "rosValue": 10.0}],
+                "fullRoster": [
+                    {
+                        "playerId": "s1",
+                        "canonicalName": "Hybrid Guy",
+                        "position": "DL",
+                        "rosValue": 50.0,
+                        "fantasyPositions": ["DL", "LB"],
+                    },
+                    {"playerId": "b1", "position": "WR", "rosValue": 10.0},
+                    {"playerId": "deep", "position": "RB", "rosValue": 30.0},
+                ],
+            }
+        ]
+
+    def _load(self, rows):
+        import json
+        from pathlib import Path
+
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "read_text", return_value=json.dumps(rows)),
+        ):
+            return playoff_sim._load_team_rosters()
+
+    def test_prefers_full_roster_over_the_truncated_pair(self):
+        """benchDepth is capped at DEPTH_BENCH_LIMIT for depth SCORING,
+        not roster enumeration; reading it as the whole team drops the
+        tail that best ball actually pays for."""
+        out = self._load(self._snapshot_rows())
+        ids = {p["playerId"] for p in out["o1"]["starters"]}
+        self.assertEqual(ids, {"s1", "b1", "deep"})
+        self.assertEqual(out["o1"]["bench"], [])
+
+    def test_carries_fantasy_positions_or_the_hybrid_fix_is_inert(self):
+        """``_bestball_weekly_score`` reads ``fantasyPositions`` to build
+        ``RosterPlayer.fantasy_positions``.  When the loader omitted it,
+        ``eligible_positions()`` fell back to ``(position,)`` and every
+        DL/LB hybrid was matched position-only — so routing the sim
+        through the exact optimizer fixed the algorithm while the data
+        still carried the original bug."""
+        out = self._load(self._snapshot_rows())
+        hybrid = next(p for p in out["o1"]["starters"] if p["playerId"] == "s1")
+        self.assertEqual(hybrid["fantasyPositions"], ["DL", "LB"])
+
+    def test_falls_back_when_the_snapshot_predates_full_roster(self):
+        rows = self._snapshot_rows()
+        del rows[0]["fullRoster"]
+        out = self._load(rows)
+        self.assertEqual([p["playerId"] for p in out["o1"]["starters"]], ["s1"])
+        self.assertEqual([p["playerId"] for p in out["o1"]["bench"]], ["b1"])
+
+    def test_dropping_fantasy_positions_measurably_costs_points(self):
+        """Guards against a future refactor quietly dropping the key
+        again.  Measured on the 12 real rosters (300 weeks): the cost is
+        0.00-4.72 weekly points, mean 1.56, on 10 of 12 teams.  A roster
+        with NO hybrids costs exactly 0.00 — the control proving the
+        measurement isolates eligibility rather than sampling noise.
+        """
+        import json
+        import statistics
+        from pathlib import Path
+
+        path = (
+            Path(__file__).resolve().parents[1] / "league_intel" / "fixtures" / "league_pool.json"
+        )
+        if not path.exists():
+            self.skipTest("league pool fixture not present")
+        pool = json.loads(path.read_text())
+        slots = ["DL", "DL", "LB", "LB", "FLEX", "WR", "RB"]
+
+        team = max(
+            pool,
+            key=lambda t: sum(1 for p in t["players"] if len(p.get("fantasyPositions") or []) > 1),
+        )
+        with_fp, without_fp = [], []
+        for w in range(60):
+            with_fp.append(
+                playoff_sim._bestball_weekly_score(team["players"], slots, random.Random(w))
+            )
+            stripped = [
+                {k: v for k, v in p.items() if k != "fantasyPositions"} for p in team["players"]
+            ]
+            without_fp.append(playoff_sim._bestball_weekly_score(stripped, slots, random.Random(w)))
+        self.assertGreater(
+            statistics.fmean(with_fp),
+            statistics.fmean(without_fp),
+            "multi-position eligibility must raise the best-ball ceiling",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves the LI-8 collision with `claude/league-intel-sim` and closes the League Twin loop. Library + tests only — no endpoint, no UI, nothing user-visible.

---

## 1. A fix that read correctly in review and could not take effect

`claude/league-intel-sim`'s headline LI-8 change routes the sim through the exact optimizer so hybrid IDPs stop being locked out of half their legal slots. The algorithm change is right. It was **inert on the live path**:

```python
# _bestball_weekly_score reads this key...
fpos = p.get("fantasyPositions") or ()
...
fantasy_positions=tuple(fpos),

# ...but _load_team_rosters._pluck never emitted it.
{"playerId": ..., "position": ..., "rosValue": ...}
```

With `fantasy_positions` empty, `RosterPlayer.eligible_positions()` falls back to `(position,)`, so every DL/LB hybrid is matched position-only — exactly the bug the commit set out to fix. **The algorithm was fixed while the data still expressed the original bug.**

### This is the third instance of one failure shape today

- a workflow that could never parse, so its guard never ran;
- a regression guard deselected by the very step meant to run it;
- an exact optimizer handed eligibility data that was never populated.

Each reads as correct in review. Each cannot take effect. The pattern is more useful to a reviewer than any one instance: **when reviewing a fix, check that the path feeding it actually carries what it reads.** A green diff and a green suite are both compatible with a fix that never runs.

### The measurement, and the control that makes it a measurement

Carrying `fantasyPositions` is worth **0.00 to 4.72 weekly points, mean 1.56, on 10 of 12 real rosters** (300 weeks, paired seeds).

The control is the part to keep: the one roster with **zero multi-position players costs exactly 0.00**. A number that moves everywhere is noise. A number that is exactly zero precisely where the mechanism cannot apply is a measurement.

**Honest coda: it reorders nobody today.** All 12 teams hold rank under both inputs. This is a correctness fix to the input, not a repair of visibly wrong output.

---

## 2. The collision resolution

#550 squashed onto `main`, so `claude/league-intel-sim`'s pre-squash history no longer rebases cleanly — git sees LI-1..LI-5 as unrelated on both sides. The real payload is one commit (`05a9426fd`), cherry-picked here. It conflicted in exactly the two files predicted: `src/ros/playoff_sim.py` and `tests/league_intel/test_registry_consumers.py`.

**Theirs wins both, except one hunk.** Their `playoff_sim.py` is a strict superset on the overlapping work — same exact-lineup fix, same duplicated-`_eligible_for_slot` deletion, plus the canonical starter-slot flattener (retiring a third copy), adaptive convergence, Wilson intervals, a real championship bracket, and `sim_calibration.py`. Their `test_registry_consumers.py` retargeting is also right: the old test asserted on the duplication it was flagging.

The exception is `_load_team_rosters`, and the framing is the point:

> Adaptive convergence and Wilson intervals computed over 29 of 44–58 players is a better-calibrated answer about the wrong team.

Their loader still reads `startingLineup + benchDepth`, where `benchDepth` is capped at `DEPTH_BENCH_LIMIT` for depth *scoring* rather than roster enumeration. Measured on the 12 real rosters (400 weeks, seed 7): the truncated input understates the weekly mean by **+1.1 to +9.4 points**, varying ~8x by team, deep rosters penalised most. It reorders no team either — again a correctness fix to the input, but one that belongs *underneath* the convergence work rather than after it.

### Carried forward so nobody "unifies" the two simulators

Their paired-seed design does **not** have the desync defect ADR-011 found, and the reason is structural: they shift the team **mean** before simulating, so both arms draw the same count in the same order and a shared stream stays aligned. `league_intel/sim.py` redraws per **player** on a roster whose size changes, which is the only shape where a shared stream breaks. **Neither approach generalises to the other** — unifying them reintroduces one defect or the other.

They stay complementary: their design copies `sd=d.sd` unchanged, so a trade's variance effect is discarded — exactly what roster depth changes in best ball.

---

## 3. League Twin: the number nobody produced

`simulate_trade_impact` takes `strength_delta` (`ownerId → change in weekly scoring MEAN`) and **nothing produced it**. A caller had to invent the one number that actually requires simulating a roster. That is the gap `src/league_intel/twin.py` closes, and it is the clearest statement of why the module exists. No new simulator, no second points model, no reimplementation of either side.

### The unit trap — stated because it is invisible from the call site

`_TeamDist.mean` is **not** the presim mean. It is:

```
blended_mean = presim_mean * (1 + ROS_BLEND * ros_z)      # ROS_BLEND = 0.20
```

So a raw presim delta is in the wrong units for the field it lands in — off by the blend factor, roughly **±40% at `|ros_z| = 2`**. Not a rounding error. Because the blend is multiplicative it scales *exactly*, so the bridge applies the same factor rather than approximating it.

`raw_mean_delta` and `blend_factor` are both returned **so the scaling is auditable rather than trusted**. A reviewer can check the arithmetic instead of taking the scaled number on faith.

*Checked rather than assumed* that both sides are the same kind of quantity: both are starting-lineup weekly points. Real team-weeks in the golden fixture are 283.8 and 361.1; the presim gives 163–377 across the 12 real rosters. Same scale — though that alignment used to be partly luck, since the `/2.7` divisor was tuned by eye, and their `sim_calibration.py` is what makes it principled.

### Two deliberate choices that would otherwise read as oversights

- **`ros_z` is assumed unchanged by the trade, and it isn't.** It derives from `teamRosStrength`, which a roster change moves. Capturing it needs a team-strength recompute per arm, which this deliberately does not do. The residual is second-order — a change in the *blend* of a change in the *mean*. Stamped on every result.
- **`sd_delta` is computed but deliberately not fed into the odds path.** `simulate_trade_impact` copies `sd` unchanged by design, and its paired-seed correctness depends on the draw count being identical across arms. Feeding variance through would require re-deriving the distributions — a different design. So the information is computed and returned for callers who care about ceiling-vs-floor, and the limitation is in `assumptions` rather than implied.

**Unavailable is absent, not zero.** An owner whose roster cannot be simulated gets no entry in `strength_delta`. `simulate_trade_impact` reads a missing owner as unmoved, which is the correct reading of "no information"; an explicit `0.0` would assert the trade is neutral for them.

---

## 4. A test bug worth its own section

The real-roster test first keyed on `ownerId`. **This fixture does not carry one.** So `str(None)` yielded the same key for both teams, the two dict entries collapsed into one, B silently overwrote A — and a pure giveaway reported:

> **+12.03 for the team giving a player away.** True delta: **−11.97**.

That is indistinguishable from the ADR-011 monotonicity defect. I went looking for a bug in `sim.py` before finding it was the test.

**A single-sided assertion would have passed.** Only checking both sides of the trade exposed it.

Fixed by keying on `rosterId` with an explicit `a_id != b_id` guard, and the reason is in the test — because the next person writing a two-sided trade test will reach for `ownerId` too.

---

## Tests

**544 passed** on `tests/league_intel/` + `tests/ros/` — 472 baseline + 55 theirs + 17 mine.

That is complete coverage for this branch, not a subset. `git diff --name-only origin/main...HEAD` is 12 files, all under `src/league_intel/`, `src/ros/`, `docs/`, and their tests. No test in `tests/api/`, `tests/trade/`, `tests/test_trade_finder.py`, or `tests/test_trade_suggestions.py` imports `src.ros` at all, so those suites have no exposure to anything changed here.

Ruff 0.6.9 clean on every file touched. The pre-existing `tests/ros/test_aggregate.py:180` F841 is on `main` and left alone.

## Also in here

- **The `grep cross_market` trap, now in the code** rather than only in a report. `src/api/data_contract.py` has ~20 hits for `is_cross_market` — an unrelated source-registry flag. An auditor concludes there are twenty consumers; there are **zero**. It is now the first section of the module docstring, where an audit starts.
- **The copied-position-set hazard, with the reasoning.** A *copied* position set is one forgotten spelling away from routing an `EDGE` row to a board that prices no defenders — precisely the defect #556 fixed in `finder.py`. `angle.py` still holds 14 raw spellings and is still the unrewired live path.

ADR-013 records the bridge; ADR-012 records the collision split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_