### PR TITLE
Refit gate: the weekly Hill refit can no longer ship constants nothing checked

### DIFF
--- a/.github/workflows/refit-hill-curves.yml
+++ b/.github/workflows/refit-hill-curves.yml
@@ -1,29 +1,34 @@
 name: Refit Hill Curves
 
-# Re-fits the four scope-level master Hill curves (GLOBAL/OFFENSE/IDP/ROOKIE)
-# from the latest value-based sources and commits new constants when the
-# drift exceeds the 50-RMSE-point threshold.  See
-# scripts/auto_refit_hill_curves.py for the drift metric and the exact
-# files rewritten (src/canonical/player_valuation.py + the pinned deltas
-# in tests/canonical/test_ktc_reconciliation.py).
+# Weekly re-fit of the four scope-level master Hill curves
+# (GLOBAL/OFFENSE/IDP/ROOKIE).
+#
+# This workflow NO LONGER SHIPS CONSTANTS.  Until 2026-07-26 it rewrote
+# src/canonical/player_valuation.py and pushed to main, triggering a
+# deploy, with nothing checking the result — see ADR-008 for the three
+# independent reasons the guard could not fail, the third being that
+# the guard was auto-marked `livedata` and this workflow's own
+# `-m "not livedata"` filter deselected it (13 deselected, 0 run).
+#
+# Now: fit -> challenger -> score against boards the fit never reads ->
+# record in the model registry -> report.  Production constants move
+# only via `scripts/model_registry.py promote` + `apply`, run by a
+# human.  The only file this workflow commits is the registry JSON.
 #
 # Behaviour by exit code from the driver:
-#   0 (no drift)  - no files changed, workflow ends green
-#   1 (applied)   - files rewritten, tests run, commit + push on success
-#   2 (error)     - workflow fails, human investigates
+#   0 champion stands  - no drift, or challenger missed the margin. Green.
+#   1 promotable       - green, and opens an issue so it is acted on.
+#   2 error            - RED. Fit failed, or the gate could not be scored.
+#   3 regression alarm - RED, and opens an issue. Points at the fit or
+#                        its inputs, not at the curve.
 
 on:
   schedule:
-    # Weekly Tuesday at 06:17 UTC (off the top-of-hour thundering
-    # herd, after the morning scheduled-refresh tick).  Tuesday lines
-    # up with nflverse republish cadence so the refit consumes fresh
-    # data, and the audit-dropped-sources Sunday cron has already run
-    # so any source-side regressions are already surfaced when this
-    # fires.  Auto-commits when drift exceeds the 50-RMSE-point
-    # threshold (see ``scripts/auto_refit_hill_curves.py`` exit codes
-    # — code 1 = applied, 0 = no drift).  Bumped from monthly per
-    # audit OPEN_QUESTIONS_FOR_PRODUCT.md → Q4 → option A (auto-commit
-    # weekly).
+    # Weekly Tuesday at 06:17 UTC (off the top-of-hour thundering herd,
+    # after the morning scheduled-refresh tick).  Tuesday lines up with
+    # nflverse republish cadence so the refit consumes fresh data, and
+    # the audit-dropped-sources Sunday cron has already run so
+    # source-side regressions are surfaced before this fires.
     - cron: "17 6 * * 2"
   workflow_dispatch:
     inputs:
@@ -33,7 +38,12 @@ on:
         type: string
         default: ""
       dry_run:
-        description: "Report drift but do not rewrite files"
+        description: "Evaluate and report, but do not record the challenger"
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: "Evaluate even when drift is below the threshold"
         required: false
         type: boolean
         default: false
@@ -44,10 +54,11 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   refit:
-    name: Fit + Drift Check + Apply
+    name: Fit + Held-Out Gate + Record
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -64,14 +75,23 @@ jobs:
         run: |
           set -Eeuo pipefail
           python -m pip install --upgrade pip
-          # Unified manifest: requirements-dev.txt pulls in runtime deps
-          # via ``-r requirements.txt`` and adds pytest + httpx for the
-          # post-refit regression step below.
           pip install -r requirements-dev.txt
           pip check
           python scripts/check_env.py
 
-      - name: Run auto-refit driver
+      - name: Self-test the gate before trusting it
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # The gate is only worth running if its own code is sound.
+          # Cheap (<1s) and directly relevant, unlike the full suite —
+          # which this workflow used to run against constants it had
+          # just rewritten, while skipping the one test that guarded
+          # them.  Nothing in this job modifies application code now,
+          # so there is nothing for a full sweep to regress.
+          python -m pytest tests/model_registry/ -q
+
+      - name: Run refit + held-out gate
         id: refit
         shell: bash
         run: |
@@ -83,80 +103,91 @@ jobs:
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             ARGS="${ARGS} --dry-run"
           fi
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            ARGS="${ARGS} --force"
+          fi
           set +e
-          python scripts/auto_refit_hill_curves.py ${ARGS} | tee refit_report.txt
+          python scripts/auto_refit_hill_curves.py ${ARGS} 2>&1 | tee refit_report.txt
           CODE=${PIPESTATUS[0]}
           set -e
           echo "exit_code=${CODE}" >> "$GITHUB_OUTPUT"
-          if (( CODE == 2 )); then
-            echo "::error title=Refit failed::auto_refit_hill_curves.py exited 2"
-            exit 1
-          fi
+          echo "Driver exited ${CODE}"
 
-      - name: Append drift report to job summary
+      - name: Job summary
         if: always()
         shell: bash
         run: |
-          echo "## Hill scope master drift report" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat refit_report.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "(no report)" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Hill refit — held-out gate"
+            echo ""
+            case "${{ steps.refit.outputs.exit_code }}" in
+              0) echo "**Champion stands.** No drift, or the challenger did not clear the margin." ;;
+              1) echo "**Challenger is PROMOTABLE.** A human must promote it — see the issue." ;;
+              2) echo "**ERROR.** The fit failed or the gate could not be scored." ;;
+              3) echo "**REGRESSION ALARM.** Challenger far worse than champion." ;;
+              *) echo "Driver exit code \`${{ steps.refit.outputs.exit_code }}\`." ;;
+            esac
+            echo ""
+            echo '```'
+            cat refit_report.txt 2>/dev/null || echo "(no report)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run test suite on refit
-        if: steps.refit.outputs.exit_code == '1' && inputs.dry_run != true
-        shell: bash
-        env:
-          # ``server.py`` raises at import time when JASON_LOGIN_PASSWORD
-          # is unset and ALLOW_DEFAULT_LOGIN_DEV isn't truthy (audit M1
-          # removed the source-code default).  Several tests under
-          # ``tests/api/`` import ``server`` at collection time, so the
-          # full ``pytest tests/`` sweep can't even collect without one
-          # of those.  Match pr-validation.yml: enable the dev escape
-          # hatch on the CI runner.  Without this every Tuesday refit
-          # run that hits drift fails at the test step before commit.
-          ALLOW_DEFAULT_LOGIN_DEV: "1"
-        run: |
-          set -Eeuo pipefail
-          # Hard-gate on code tests only, matching pr-validation.yml.
-          # Data-coupled (livedata) tests must not block the refit:
-          # a routine source row-count dip is not a code defect, and
-          # the KTC drift pins are REWRITTEN by this very refit — so
-          # gating the refit commit on them is circular.  Four straight
-          # weekly refits (Jun 30 - Jul 21) died here on an unrelated
-          # yahooBoone row-floor dip while curve drift accumulated.
-          python -m pytest tests/ -q -m "not livedata"
-
-      - name: Commit and push refit
-        if: steps.refit.outputs.exit_code == '1' && inputs.dry_run != true
+      # The registry is the audit trail: a dated entry every time the
+      # gate runs, whatever the verdict.  A rejected challenger is kept
+      # rather than discarded — it is evidence about the search space,
+      # and a MISSING weekly entry is itself the signal that this
+      # workflow stopped running.
+      - name: Commit the registry record
+        if: steps.refit.outputs.exit_code != '2' && inputs.dry_run != true
         shell: bash
         run: |
           set -Eeuo pipefail
-          # The driver rewrites constants/pins mechanically; normalize to
-          # the repo formatter BEFORE committing, or the refit commit
-          # fails pr-validation's repo-wide 'ruff format --check' for
-          # every PR until someone hand-formats (this happened with the
-          # 2026-07-25 refit — see #526).
-          python -m ruff format src/canonical/player_valuation.py tests/canonical/test_ktc_reconciliation.py
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/canonical/player_valuation.py tests/canonical/test_ktc_reconciliation.py
+          # ONLY the registry. Never player_valuation.py, never the
+          # reconciliation pins. If this path ever grows another file,
+          # the autonomous-rewrite prohibition is gone.
+          git add config/model_registry/
           if git diff --cached --quiet; then
-            echo "Refit driver reported drift but staging diff is empty — skipping commit"
+            echo "No registry change to commit"
             exit 0
           fi
           git commit -m "$(cat <<'EOF'
-          chore(calibration): auto-refit Hill scope masters
+          chore(calibration): record Hill refit challenger
 
-          Drift exceeded the 50-RMSE-point threshold on at least one
-          scope — see the workflow summary for the per-scope report.
-          Rewrites the eight HILL_*_C/S constants in
-          src/canonical/player_valuation.py and rebaselines the pinned
-          deltas in tests/canonical/test_ktc_reconciliation.py.
+          Held-out gate result recorded in config/model_registry/.
+          No production constants changed — promotion is a human
+          action (scripts/model_registry.py promote + apply).
           EOF
           )"
           git pull --rebase origin main
           git push
-          # deploy.yml auto-triggers on push to main (paths-ignore only
-          # skips data/** and exports/**, not src/**), so no explicit
-          # dispatch needed.  That also avoids needing actions:write on
-          # the GITHUB_TOKEN — which the default workflow token lacks.
+
+      - name: Open an issue when a human must act
+        if: steps.refit.outputs.exit_code == '1' || steps.refit.outputs.exit_code == '3'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          if [[ "${{ steps.refit.outputs.exit_code }}" == "1" ]]; then
+            TITLE="Hill refit: challenger cleared the held-out gate"
+            LEAD="A challenger beat the champion out of sample and is waiting for a human to promote it."
+          else
+            TITLE="Hill refit: REGRESSION ALARM"
+            LEAD="The challenger scored far worse than the champion. That usually means a collapsed or stale source, not a bad curve."
+          fi
+          BODY=$(printf '%s\n\n```\n%s\n```\n\nRun: %s\n' \
+            "${LEAD}" \
+            "$(cat refit_report.txt)" \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+          gh issue create --title "${TITLE}" --body "${BODY}" --label calibration \
+            || gh issue create --title "${TITLE}" --body "${BODY}"
+
+      - name: Fail loudly on error or regression
+        if: steps.refit.outputs.exit_code == '2' || steps.refit.outputs.exit_code == '3'
+        shell: bash
+        run: |
+          echo "::error title=Hill refit gate::driver exited ${{ steps.refit.outputs.exit_code }}"
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,9 +258,16 @@ Steps:
 12. Multiplicative future-year pick discount
     (``config/weights/pick_year_discount.json``)
 
-Master curve constants auto-refit weekly by
+Master curve constants are refit weekly by
 ``.github/workflows/refit-hill-curves.yml`` (see
-``scripts/auto_refit_hill_curves.py``).
+``scripts/auto_refit_hill_curves.py``), but the refit **no longer
+ships them**.  It produces a *challenger*, scores it against dynasty
+boards the fit never reads (``src/model_registry/holdout.py``), records
+the verdict in ``config/model_registry/``, and stops.  Production
+constants move only via ``scripts/model_registry.py promote`` +
+``apply``, run by a human — see ADR-008 in
+``docs/roster-trade-intelligence/DECISIONS.md`` for the three reasons
+the previous auto-commit path had no working guard.
 
 Blend weights live in the ``_RANKING_SOURCES`` registry (all 1.0 by
 policy).  ``config/weights/default_weights.json`` is historical

--- a/docs/roster-trade-intelligence/DECISIONS.md
+++ b/docs/roster-trade-intelligence/DECISIONS.md
@@ -209,21 +209,86 @@ its own downstream verification and is explicitly out of scope here.
   runs on a schedule, imports the valuation pipeline, or alters any
   endpoint. The registry records and gates; today a human drives it.
 
-### Proposed wiring (scoped, not landed here)
+### The wiring — LANDED 2026-07-26
 
-The minimal follow-up, for review as its own change:
+The five-step plan below was the original scope. It landed as a single
+driver rather than five CLI calls chained in YAML; the differences are
+recorded because the plan was written before the code existed.
 
-1. Refit emits challenger params instead of writing them:
-   `fit_hill_curve_percentile.py --json-out challenger.json`.
+Original plan:
+
+1. Refit emits challenger params instead of writing them.
 2. `model_registry.py evaluate --champion --record`
 3. `model_registry.py register --params challenger.json`
 4. `model_registry.py validate <n>` — exit 0 promotes, 1 rejects.
-5. Commit **only** `config/model_registry/*.json`. Production constants
-   move solely via `promote` + `apply`, run by a human.
+5. Commit **only** `config/model_registry/*.json`.
 
-That removes all three defects: the constants stop being rewritten
-unreviewed, the guard stops being rewritten at all, and the gate that
-does run is one the fit never saw — so `-m "not livedata"` no longer
-skips the only thing checking it.
+What actually shipped, and why it differs:
 
-**Status:** accepted 2026-07-26; implementation in `src/model_registry/`.
+* **Steps 1–4 collapsed into `scripts/auto_refit_hill_curves.py`.**
+  Chaining four CLI calls through workflow steps means passing a
+  params file and a version number between shell steps, and every hand-
+  off is a place for the gate to be skipped by an `if:` condition. One
+  driver with one exit-code contract has no such seam.
+* **Exit codes are richer than "0 promotes, 1 rejects".** The plan's
+  binary conflates two very different outcomes. Shipped contract:
+  `0` champion stands (no drift, or the challenger missed the margin —
+  the ordinary weekly result), `1` promotable, `2` error, `3`
+  regression alarm.
+* **Added: the champion must match what is deployed.** The driver
+  refuses to run if the registry's champion params differ from the
+  constants in `player_valuation.py`. Not in the plan, and necessary —
+  comparing a challenger against a champion that is not live yields a
+  correct-looking verdict about the wrong incumbent.
+* **Added: the workflow self-tests the gate before trusting it**
+  (`pytest tests/model_registry/`, ~2s).
+* **Added: an issue is opened when a human must act** (promotable, or
+  alarm).
+* **Removed: the full `pytest -m "not livedata"` step.** It existed to
+  check code the refit had just rewritten. The refit rewrites nothing
+  now, so there is nothing for a full sweep to regress — and running
+  it weekly for 15 minutes to check an unchanged tree is the kind of
+  ritual that makes a real signal easy to ignore.
+
+**Reason 3 was NOT fixed by un-marking the guard.**
+`test_ktc_reconciliation.py` keeps its `livedata` marking; that marking
+exists because a yahooBoone row-count dip once stalled every PR, and it
+is still correct. The gate moved out of pytest entirely instead. A gate
+invoked through pytest can be deselected by a filter; a gate invoked as
+a function call cannot. `TestTheLivedataMarkingIsPreserved` fails if
+anyone "fixes" it the other way.
+
+The guard itself is left in place and is no longer rewritten, so its
+pins are now a real tripwire: if the constants change and the pins are
+not re-baselined by hand, it fails — which is the behaviour its
+docstring always claimed.
+
+### What happens on rejection
+
+Stated explicitly, because "nothing reported red because nothing ran"
+is the failure class this whole change exists to remove.
+
+| Outcome | Constants | Registry | Workflow | Human notified |
+|---|---|---|---|---|
+| No drift | untouched | unchanged | green | no |
+| Rejected within margin | untouched | challenger recorded as `rejected` | green | no |
+| **Promotable** | untouched | challenger recorded | green | **issue opened** |
+| **Regression alarm** | untouched | challenger recorded as `rejected` | **red** | **issue opened** |
+| Error | untouched | unchanged | **red** | workflow failure email |
+
+Two deliberate choices in that table:
+
+* **Routine rejection does not page anyone.** It is the expected weekly
+  outcome; alerting on it trains people to ignore the alert, which is
+  how a deliberate decision became an invisible hole the first time.
+  It is still *recorded* — every run leaves a dated registry entry.
+* **A promotable challenger DOES page.** Otherwise improvements never
+  land and the system quietly becomes a no-op — the same "nothing
+  happened and nobody noticed" shape, just with the sign flipped.
+
+The registry is the audit trail, and its absence is itself the signal:
+a week with no new entry means the workflow did not run.
+
+**Status:** accepted 2026-07-26; registry in `src/model_registry/`,
+wiring landed in `scripts/auto_refit_hill_curves.py` +
+`.github/workflows/refit-hill-curves.yml`.

--- a/scripts/auto_refit_hill_curves.py
+++ b/scripts/auto_refit_hill_curves.py
@@ -1,59 +1,84 @@
 #!/usr/bin/env python3
-"""Auto-refit the Hill scope masters and apply if drift exceeds threshold.
+"""Weekly Hill refit — produces a CHALLENGER, never a champion.
 
-Reads the committed Hill constants from
-``src/canonical/player_valuation.py``, runs the framework-faithful
-fit via ``scripts/fit_hill_curve_percentile.py``, computes curve-shape
-drift between committed and newly-fit masters, and applies the new
-constants (rewriting ``player_valuation.py`` and re-baselining the
-KTC reconciliation test pins) when drift exceeds the threshold.
+What this used to do, and why it changed
+────────────────────────────────────────
+Until 2026-07-26 this script rewrote the eight ``HILL_*_C/S`` constants
+in ``src/canonical/player_valuation.py`` and the pinned deltas in
+``tests/canonical/test_ktc_reconciliation.py``, and the workflow
+committed both to ``main``, triggering a deploy.  Three independent
+defects meant nothing checked the result (ADR-008):
 
-Drift metric: RMSE of V_new(p) − V_old(p) over the percentile grid
-{0.01, 0.05, 0.10, 0.20, 0.30, 0.50, 0.70, 0.90} for each scope
-master.  The max RMSE across all four scopes is compared to the
-threshold.
+1. ``rebaseline_ktc_reconciliation`` recomputed the guard's expected
+   values FROM the new constants, so its residual was zero by
+   construction for any curve.
+2. KTC is a TRAINING source for the very constants the guard scored,
+   so even honest pins would have been training-set validation.
+3. The guard is auto-marked ``livedata`` and the workflow ran
+   ``pytest -m "not livedata"`` — 13 deselected, 0 run.  It was never
+   executed at all.
 
-Threshold (``DRIFT_RMSE_THRESHOLD``): **50 points** on the 0–9999
-scale (~0.5% of scale).  Well above grid-search fit noise (~5 pts)
-and well below typical market-shift curve drift (~100–500 pts).
+All three are fixed here, and the fix for (3) is deliberately NOT
+"un-mark the guard".  That marking exists because data-coupled
+failures once stalled every PR, and it is still correct.  Instead the
+refit calls the held-out evaluation DIRECTLY, so the gate cannot be
+switched off by a marker policy tuned for a different purpose.
 
-Exit codes:
-    0   no drift — no changes made
-    1   drift applied — files modified, ready to commit
-    2   error — fit or file rewrite failed
+What it does now
+────────────────
+Fit → challenger → score champion and challenger on boards the fit
+never reads → record both in the model registry → report.  This script
+no longer writes ``player_valuation.py``, and does not import the
+function that can.  Constants move only through
+``scripts/model_registry.py promote`` + ``apply``, run by a human.
+
+Exit codes (the workflow branches on these):
+    0   champion stands — no drift, or the challenger did not clear
+        the promotion margin.  The ordinary weekly outcome.
+    1   challenger is PROMOTABLE — a human should review and promote.
+    2   error — fit failed, or the gate could not be evaluated.
+    3   REGRESSION ALARM — the challenger is far worse than the
+        champion, which points at the fit or its inputs.
 
 Usage:
     python3 scripts/auto_refit_hill_curves.py
     python3 scripts/auto_refit_hill_curves.py --dry-run
     python3 scripts/auto_refit_hill_curves.py --threshold 100
+    python3 scripts/auto_refit_hill_curves.py --challenger-json c.json
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-PLAYER_VALUATION = REPO / "src" / "canonical" / "player_valuation.py"
-KTC_RECONCILIATION_TEST = REPO / "tests" / "canonical" / "test_ktc_reconciliation.py"
-FIT_SCRIPT = REPO / "scripts" / "fit_hill_curve_percentile.py"
-KTC_CSV = REPO / "CSVs" / "site_raw" / "ktc.csv"
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
 
-CONSTANT_NAMES: tuple[str, ...] = (
-    "HILL_GLOBAL_PERCENTILE_C",
-    "HILL_GLOBAL_PERCENTILE_S",
-    "HILL_PERCENTILE_C",
-    "HILL_PERCENTILE_S",
-    "IDP_HILL_PERCENTILE_C",
-    "IDP_HILL_PERCENTILE_S",
-    "HILL_ROOKIE_PERCENTILE_C",
-    "HILL_ROOKIE_PERCENTILE_S",
+from src.model_registry.hill_masters import (  # noqa: E402
+    CONSTANT_NAMES,
+    MODEL_ID,
+    VALIDATED_PARAMS,
+    git_sha,
+    load_or_seed_registry,
+    read_committed_constants,
+    training_input_paths,
 )
+from src.model_registry.holdout import HoldoutError, evaluate_offense_master  # noqa: E402
+from src.model_registry.promotion import decide_promotion  # noqa: E402
+from src.model_registry.versioning import (  # noqa: E402
+    ModelVersion,
+    RegistryError,
+    fingerprint_inputs,
+)
+
+FIT_SCRIPT = REPO / "scripts" / "fit_hill_curve_percentile.py"
 
 SCOPE_TO_CS = {
     "GLOBAL": ("HILL_GLOBAL_PERCENTILE_C", "HILL_GLOBAL_PERCENTILE_S"),
@@ -65,176 +90,44 @@ SCOPE_TO_CS = {
 DRIFT_RMSE_THRESHOLD: float = 50.0
 DRIFT_GRID: tuple[float, ...] = (0.01, 0.05, 0.10, 0.20, 0.30, 0.50, 0.70, 0.90)
 
+EXIT_CHAMPION_STANDS = 0
+EXIT_PROMOTABLE = 1
+EXIT_ERROR = 2
+EXIT_ALARM = 3
+
 
 def _hill(p: float, c: float, s: float) -> float:
-    """Pure Hill eval — must match ``percentile_to_value`` at p>0."""
     if p <= 0.0:
         return 9999.0
-    if p >= 1.0:
-        p = 1.0
-    return 9999.0 / (1.0 + (p / c) ** s)
-
-
-def read_committed_constants() -> dict[str, float]:
-    """Parse the committed constants from player_valuation.py."""
-    text = PLAYER_VALUATION.read_text()
-    out: dict[str, float] = {}
-    for name in CONSTANT_NAMES:
-        # Match lines like ``NAME: float = 0.1100``.
-        m = re.search(
-            rf"^{re.escape(name)}:\s*float\s*=\s*([0-9.]+)\s*$",
-            text,
-            re.MULTILINE,
-        )
-        if not m:
-            raise RuntimeError(
-                f"Could not find constant {name!r} in "
-                f"{PLAYER_VALUATION}.  Did the file format change?"
-            )
-        out[name] = float(m.group(1))
-    return out
+    return 9999.0 / (1.0 + (min(p, 1.0) / c) ** s)
 
 
 def run_fit_with_json() -> dict[str, float]:
-    """Run the fit script, capture JSON output, return constants dict."""
+    """Run the fit script and capture its JSON output."""
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as tmp:
         json_path = Path(tmp.name)
     try:
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(FIT_SCRIPT),
-                "--json-out",
-                str(json_path),
-            ],
+        subprocess.run(
+            [sys.executable, str(FIT_SCRIPT), "--json-out", str(json_path)],
             capture_output=True,
             text=True,
             cwd=str(REPO),
             check=True,
         )
-        data = json.loads(json_path.read_text())
-        return {str(k): float(v) for k, v in data.items()}
+        return {str(k): float(v) for k, v in json.loads(json_path.read_text()).items()}
     finally:
-        try:
-            json_path.unlink()
-        except FileNotFoundError:
-            pass
+        json_path.unlink(missing_ok=True)
 
 
 def compute_scope_drift(committed: dict[str, float], fitted: dict[str, float]) -> dict[str, float]:
-    """Return per-scope RMSE of V_new(p) − V_old(p) over DRIFT_GRID."""
+    """Per-scope RMSE of V_new(p) - V_old(p) over DRIFT_GRID."""
     out: dict[str, float] = {}
     for scope, (c_name, s_name) in SCOPE_TO_CS.items():
         c_old, s_old = committed[c_name], committed[s_name]
         c_new, s_new = fitted[c_name], fitted[s_name]
-        sq_diffs = [(_hill(p, c_new, s_new) - _hill(p, c_old, s_old)) ** 2 for p in DRIFT_GRID]
-        rmse = (sum(sq_diffs) / len(sq_diffs)) ** 0.5
-        out[scope] = rmse
+        sq = [(_hill(p, c_new, s_new) - _hill(p, c_old, s_old)) ** 2 for p in DRIFT_GRID]
+        out[scope] = (sum(sq) / len(sq)) ** 0.5
     return out
-
-
-def rewrite_player_valuation(fitted: dict[str, float]) -> None:
-    """Update the 8 Hill constants in player_valuation.py in place."""
-    text = PLAYER_VALUATION.read_text()
-    for name, new_val in fitted.items():
-        # Preserve formatting — c stays 4 decimals, s stays 3 decimals.
-        if name.endswith("_C"):
-            new_literal = f"{new_val:.4f}"
-        else:
-            new_literal = f"{new_val:.3f}"
-        pattern = rf"^({re.escape(name)}:\s*float\s*=\s*)[0-9.]+(\s*)$"
-        text, n = re.subn(
-            pattern,
-            rf"\g<1>{new_literal}\g<2>",
-            text,
-            flags=re.MULTILINE,
-        )
-        if n != 1:
-            raise RuntimeError(
-                f"Expected exactly 1 match for {name!r} in " f"{PLAYER_VALUATION}, got {n}"
-            )
-    PLAYER_VALUATION.write_text(text)
-
-
-def rebaseline_ktc_reconciliation(fitted: dict[str, float]) -> None:
-    """Recompute PINNED_DELTAS in test_ktc_reconciliation.py from the
-    new OFFENSE master's output at each pinned rank, using the
-    CURRENT KTC CSV as the reference denominator.
-    """
-    import csv
-
-    # Load KTC values (same filter as the test).
-    pick_re = re.compile(r"^\d{4}\s+(Early|Mid|Late)\s+\d", re.IGNORECASE)
-    rows: list[tuple[str, int]] = []
-    with KTC_CSV.open() as f:
-        for r in csv.DictReader(f):
-            name = (r.get("name") or "").strip()
-            val = (r.get("value") or "").strip()
-            if not name or not val or pick_re.match(name):
-                continue
-            try:
-                rows.append((name, int(val)))
-            except ValueError:
-                continue
-    rows.sort(key=lambda t: -t[1])
-
-    # Percentile reference N is read from data_contract.py to stay in
-    # sync.  Parsing inline is cheaper than importing the module.
-    data_contract_text = (REPO / "src" / "api" / "data_contract.py").read_text()
-    ref_n_match = re.search(
-        r"_PERCENTILE_REFERENCE_N:\s*int\s*=\s*(\d+)",
-        data_contract_text,
-    )
-    if not ref_n_match:
-        raise RuntimeError("Could not find _PERCENTILE_REFERENCE_N")
-    ref_n = int(ref_n_match.group(1))
-
-    c_off = fitted["HILL_PERCENTILE_C"]
-    s_off = fitted["HILL_PERCENTILE_S"]
-
-    # Build the new PINNED_DELTAS list.  Preserve the existing
-    # tolerance bands per rank.
-    test_text = KTC_RECONCILIATION_TEST.read_text()
-    existing_tolerances: dict[int, float] = {}
-    for m in re.finditer(
-        r"\(\s*(\d+),\s*\d+,\s*-?\d+\.\d+,\s*(-?\d+\.\d+)\s*\)",
-        test_text,
-    ):
-        rank = int(m.group(1))
-        tol = float(m.group(2))
-        existing_tolerances[rank] = tol
-
-    # Ranks pinned in the test.  Keep the order as-is.
-    new_entries: list[tuple[int, int, float, float]] = []
-    for rank in sorted(existing_tolerances.keys()):
-        if rank - 1 >= len(rows):
-            continue
-        _, ktc = rows[rank - 1]
-        p = (rank - 1) / max(1.0, float(ref_n - 1))
-        p = max(0.0, min(1.0, p))
-        ours = int(round(_hill(p, c_off, s_off)))
-        pct_diff = 100.0 * (ours - ktc) / ktc
-        tol = existing_tolerances[rank]
-        new_entries.append((rank, ours, round(pct_diff, 1), tol))
-
-    # Rewrite PINNED_DELTAS in the test file.
-    new_block_lines = ["PINNED_DELTAS: list[tuple[int, int, float, float]] = ["]
-    for rank, ours, pct, tol in new_entries:
-        sign = "" if pct >= 0 else ""
-        new_block_lines.append(f"    ({rank:>3}, {ours:>4}, {pct:>5}, {tol:>4}),")
-    new_block_lines.append("]")
-    new_block = "\n".join(new_block_lines)
-
-    test_text_new = re.sub(
-        r"PINNED_DELTAS:\s*list\[tuple\[int, int, float, float\]\] = \[[^\]]*\]",
-        new_block,
-        test_text,
-        flags=re.DOTALL,
-        count=1,
-    )
-    if test_text_new == test_text:
-        raise RuntimeError("Failed to rewrite PINNED_DELTAS in test file")
-    KTC_RECONCILIATION_TEST.write_text(test_text_new)
 
 
 def format_drift_report(
@@ -243,87 +136,190 @@ def format_drift_report(
     drift: dict[str, float],
     threshold: float,
 ) -> str:
-    lines: list[str] = []
-    lines.append("Hill scope master drift report")
-    lines.append("=" * 50)
-    lines.append(f"Threshold: {threshold:.1f} RMSE points")
-    lines.append("")
-    lines.append(f"{'scope':<10}{'c_old':>10}{'c_new':>10}{'s_old':>10}{'s_new':>10}{'RMSE':>10}")
+    lines = [
+        "Hill scope master drift report",
+        "=" * 52,
+        f"Threshold: {threshold:.1f} RMSE points",
+        "",
+        f"{'scope':<10}{'c_old':>10}{'c_new':>10}{'s_old':>10}{'s_new':>10}{'RMSE':>10}",
+    ]
     for scope, (c_name, s_name) in SCOPE_TO_CS.items():
-        c_old = committed[c_name]
-        s_old = committed[s_name]
-        c_new = fitted[c_name]
-        s_new = fitted[s_name]
-        rmse = drift[scope]
-        marker = " ★" if rmse > threshold else ""
+        marker = " *" if drift[scope] > threshold else ""
         lines.append(
-            f"{scope:<10}{c_old:>10.4f}{c_new:>10.4f}"
-            f"{s_old:>10.3f}{s_new:>10.3f}{rmse:>10.2f}{marker}"
+            f"{scope:<10}{committed[c_name]:>10.4f}{fitted[c_name]:>10.4f}"
+            f"{committed[s_name]:>10.3f}{fitted[s_name]:>10.3f}{drift[scope]:>10.2f}{marker}"
         )
-    lines.append("")
-    max_scope = max(drift.items(), key=lambda kv: kv[1])
-    lines.append(
-        f"Max drift: {max_scope[0]} @ RMSE={max_scope[1]:.2f} "
-        f"({'APPLY' if max_scope[1] > threshold else 'no-op'})"
-    )
+    top = max(drift.items(), key=lambda kv: kv[1])
+    lines += ["", f"Max drift: {top[0]} @ RMSE={top[1]:.2f}"]
+    return "\n".join(lines)
+
+
+def format_holdout(label: str, result) -> str:
+    lines = [f"{label}: criterion {result.criterion:.1f}  (mean per-source RMSE, lower is better)"]
+    for src, rmse in sorted(result.per_source.items()):
+        lines.append(f"    {src:<20}{rmse:>9.1f}   n={result.per_source_rows[src]}")
+    for src, why in sorted(result.skipped.items()):
+        lines.append(f"    {src:<20}{'skipped':>9}   {why}")
     return "\n".join(lines)
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument(
-        "--threshold",
-        type=float,
-        default=DRIFT_RMSE_THRESHOLD,
-        help="RMSE drift threshold (default: %(default).1f pts).",
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    ap.add_argument("--threshold", type=float, default=DRIFT_RMSE_THRESHOLD)
     ap.add_argument(
         "--dry-run",
         action="store_true",
-        help="Report drift but do not rewrite files.",
+        help="evaluate and report, but do not record the challenger",
+    )
+    ap.add_argument(
+        "--challenger-json",
+        type=Path,
+        help=(
+            "score this parameter set instead of running the fit — used to "
+            "exercise the gate against a known-good or known-bad challenger"
+        ),
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="evaluate even when drift is below the threshold",
     )
     args = ap.parse_args()
 
+    # ── the live constants, and the champion of record ─────────────
     try:
         committed = read_committed_constants()
-    except Exception as exc:
-        print(f"ERROR reading committed constants: {exc}", file=sys.stderr)
-        return 2
+        registry = load_or_seed_registry()
+    except (RegistryError, OSError) as exc:
+        print(f"ERROR resolving champion: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+    champion = registry.champion
 
-    try:
-        fitted = run_fit_with_json()
-    except subprocess.CalledProcessError as exc:
-        print(f"ERROR running fit:\n{exc.stderr}", file=sys.stderr)
-        return 2
-    except Exception as exc:
-        print(f"ERROR running fit: {exc}", file=sys.stderr)
-        return 2
+    # A registry champion that has drifted from what is deployed means
+    # someone hand-edited the constants.  Comparing a challenger to a
+    # champion that is not live yields a correct-looking verdict about
+    # the wrong incumbent.
+    if champion.params != committed:
+        print(
+            f"ERROR: registry champion v{champion.version} does not match the "
+            "constants in player_valuation.py. The registry is not describing "
+            "what is deployed — reconcile with `scripts/model_registry.py status` "
+            "before refitting.",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    # ── the challenger ─────────────────────────────────────────────
+    if args.challenger_json:
+        try:
+            raw = json.loads(args.challenger_json.read_text())
+            fitted = {str(k): float(v) for k, v in raw.items()}
+        except (OSError, ValueError) as exc:
+            print(f"ERROR reading --challenger-json: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+        producer = f"injected via --challenger-json ({args.challenger_json.name})"
+    else:
+        try:
+            fitted = run_fit_with_json()
+        except subprocess.CalledProcessError as exc:
+            print(f"ERROR running fit:\n{exc.stderr}", file=sys.stderr)
+            return EXIT_ERROR
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR running fit: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+        producer = f"scripts/fit_hill_curve_percentile.py @ {git_sha()}"
+
+    missing = [n for n in CONSTANT_NAMES if n not in fitted]
+    if missing:
+        print(f"ERROR: challenger is missing {missing}", file=sys.stderr)
+        return EXIT_ERROR
 
     drift = compute_scope_drift(committed, fitted)
-    report = format_drift_report(committed, fitted, drift, args.threshold)
-    print(report)
+    print(format_drift_report(committed, fitted, drift, args.threshold))
 
-    max_drift = max(drift.values())
-    if max_drift <= args.threshold:
-        print("\nNo drift beyond threshold — no changes made.")
-        return 0
+    if max(drift.values()) <= args.threshold and not args.force:
+        print("\nNo drift beyond threshold — champion stands, nothing to validate.")
+        return EXIT_CHAMPION_STANDS
 
-    if args.dry_run:
-        print("\nDry-run mode — would apply constants but leaving files untouched.")
-        return 1
-
+    # ── the gate ───────────────────────────────────────────────────
+    # Evaluated HERE, not through pytest.  The guard that used to live
+    # in the test suite was auto-marked livedata and deselected by the
+    # workflow's own filter; a gate that depends on a marker policy is
+    # a gate a marker policy can silently switch off.
+    print("\n" + "=" * 52)
+    print("Held-out validation — boards the fit never reads")
+    print("=" * 52)
     try:
-        rewrite_player_valuation(fitted)
-        rebaseline_ktc_reconciliation(fitted)
-    except Exception as exc:
-        print(f"ERROR applying drift: {exc}", file=sys.stderr)
-        return 2
+        champ_eval = evaluate_offense_master(*(champion.params[k] for k in VALIDATED_PARAMS))
+        chal_eval = evaluate_offense_master(*(fitted[k] for k in VALIDATED_PARAMS))
+    except HoldoutError as exc:
+        print(f"ERROR: the gate could not be evaluated: {exc}", file=sys.stderr)
+        print("Refusing to treat an unevaluable gate as a pass.", file=sys.stderr)
+        return EXIT_ERROR
 
-    print("\nApplied new constants to:")
-    print(f"  {PLAYER_VALUATION.relative_to(REPO)}")
-    print(f"  {KTC_RECONCILIATION_TEST.relative_to(REPO)}")
-    print("Run the full test suite to confirm before committing.")
-    return 1
+    print(format_holdout(f"champion v{champion.version}", champ_eval))
+    print(format_holdout("challenger", chal_eval))
+
+    decision = decide_promotion(champ_eval.criterion, chal_eval.criterion)
+    print(f"\nverdict: {'PROMOTABLE' if decision.promote else 'REJECTED'}")
+    print(f"reason:  {decision.reason}")
+    print(
+        f"\nNOTE: only {VALIDATED_PARAMS[0]} / {VALIDATED_PARAMS[1]} (the OFFENSE "
+        "master) are validated out of sample. The other six constants are "
+        "versioned but not gated — see ADR-008."
+    )
+
+    # ── record it, whatever the verdict ────────────────────────────
+    recorded: int | None = None
+    if args.dry_run:
+        print("\nDry-run — challenger not recorded.")
+    else:
+        try:
+            recorded = registry.next_version()
+            registry.add(
+                ModelVersion(
+                    model_id=MODEL_ID,
+                    version=recorded,
+                    params=fitted,
+                    fitted_at=datetime.now(timezone.utc).isoformat(),
+                    producer=producer,
+                    status="challenger",
+                    training_inputs=fingerprint_inputs(training_input_paths()),
+                    holdout=chal_eval.to_dict(),
+                )
+            )
+            if not decision.promote:
+                registry.reject(recorded, reason=decision.reason)
+            registry.save()
+            print(f"\nRecorded challenger v{recorded} in the registry.")
+        except RegistryError as exc:
+            print(f"ERROR recording challenger: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+
+    if decision.alarm:
+        print(
+            "\nALARM: the challenger is far worse than the champion. That is a "
+            "signal about the fit or its inputs, not about the curve — check for "
+            "a collapsed or stale source before refitting.",
+            file=sys.stderr,
+        )
+        return EXIT_ALARM
+
+    if decision.promote:
+        target = recorded if recorded is not None else "<version>"
+        print(
+            "\nA human must promote it — this script cannot. To land it:\n"
+            f"  python3 scripts/model_registry.py validate {target}\n"
+            f'  python3 scripts/model_registry.py promote {target} --reason "held-out win"\n'
+            "  python3 scripts/model_registry.py apply\n"
+            "  # then run the suite and open a PR"
+        )
+        return EXIT_PROMOTABLE
+
+    print("\nChampion stands.")
+    return EXIT_CHAMPION_STANDS
 
 
 if __name__ == "__main__":

--- a/scripts/model_registry.py
+++ b/scripts/model_registry.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -36,6 +34,16 @@ REPO = Path(__file__).resolve().parents[1]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
+from src.model_registry.hill_masters import (  # noqa: E402
+    CONSTANT_NAMES,
+    MODEL_ID,
+    PLAYER_VALUATION,
+    git_sha as _git_sha,
+    load_or_seed_registry as _load_or_seed,
+    read_committed_constants,
+    training_input_paths as _training_input_paths,
+    write_committed_constants,
+)
 from src.model_registry.holdout import (  # noqa: E402
     HoldoutError,
     evaluate_offense_master,
@@ -48,95 +56,6 @@ from src.model_registry.versioning import (  # noqa: E402
     RegistryError,
     fingerprint_inputs,
 )
-
-MODEL_ID = "hill_scope_masters"
-PLAYER_VALUATION = REPO / "src" / "canonical" / "player_valuation.py"
-
-CONSTANT_NAMES: tuple[str, ...] = (
-    "HILL_GLOBAL_PERCENTILE_C",
-    "HILL_GLOBAL_PERCENTILE_S",
-    "HILL_PERCENTILE_C",
-    "HILL_PERCENTILE_S",
-    "IDP_HILL_PERCENTILE_C",
-    "IDP_HILL_PERCENTILE_S",
-    "HILL_ROOKIE_PERCENTILE_C",
-    "HILL_ROOKIE_PERCENTILE_S",
-)
-
-
-def read_committed_constants() -> dict[str, float]:
-    text = PLAYER_VALUATION.read_text()
-    out: dict[str, float] = {}
-    for name in CONSTANT_NAMES:
-        m = re.search(rf"^{re.escape(name)}:\s*float\s*=\s*([0-9.]+)\s*$", text, re.MULTILINE)
-        if not m:
-            raise RegistryError(f"could not find {name!r} in {PLAYER_VALUATION}")
-        out[name] = float(m.group(1))
-    return out
-
-
-def write_committed_constants(params: dict[str, float]) -> None:
-    text = PLAYER_VALUATION.read_text()
-    for name in CONSTANT_NAMES:
-        if name not in params:
-            raise RegistryError(f"champion params missing {name!r}")
-        literal = f"{params[name]:.4f}" if name.endswith("_C") else f"{params[name]:.3f}"
-        text, n = re.subn(
-            rf"^({re.escape(name)}:\s*float\s*=\s*)[0-9.]+(\s*)$",
-            rf"\g<1>{literal}\g<2>",
-            text,
-            flags=re.MULTILINE,
-        )
-        if n != 1:
-            raise RegistryError(f"expected 1 match for {name!r}, got {n}")
-    PLAYER_VALUATION.write_text(text)
-
-
-def _git_sha() -> str:
-    try:
-        return subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            cwd=str(REPO),
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-    except Exception:  # noqa: BLE001
-        return "unknown"
-
-
-def _training_input_paths() -> dict[str, Path]:
-    return {role.label: REPO / role.path for role in source_roles() if role.role == "train"}
-
-
-def _load_or_seed() -> ModelRegistry:
-    """Load the registry, seeding from live constants on first use.
-
-    Seeding records what is ALREADY live as v1 champion.  It is not a
-    claim that those constants won anything — ``qualified`` stays False
-    until someone evaluates them.
-    """
-    try:
-        return ModelRegistry.load(MODEL_ID)
-    except RegistryError:
-        reg = ModelRegistry(MODEL_ID)
-        reg.seed_champion(
-            ModelVersion(
-                model_id=MODEL_ID,
-                version=1,
-                params=read_committed_constants(),
-                fitted_at="unknown",
-                producer="seeded from committed constants in player_valuation.py",
-                training_inputs=fingerprint_inputs(_training_input_paths()),
-                notes=(
-                    "seeded, not validated: these constants were live before the "
-                    "registry existed and carry no out-of-sample score",
-                ),
-            )
-        )
-        reg.save()
-        return reg
-
 
 # ── subcommands ────────────────────────────────────────────────────
 

--- a/src/model_registry/hill_masters.py
+++ b/src/model_registry/hill_masters.py
@@ -1,0 +1,136 @@
+"""Hill scope masters as a registered model — shared by both drivers.
+
+``scripts/model_registry.py`` (the human CLI) and
+``scripts/auto_refit_hill_curves.py`` (the weekly refit) both need to
+read the live constants, resolve the registry, and fingerprint the
+training inputs.  Those helpers live here rather than in either script
+so the two cannot drift into disagreeing about what "the champion" is —
+a refit that resolved the champion differently from the CLI would
+reintroduce the whole problem quietly.
+
+Reading and writing ``player_valuation.py`` are deliberately separate
+functions with very different call sites.  ``read_committed_constants``
+is called freely.  ``write_committed_constants`` is called by exactly
+one place — the CLI's ``apply``, driven by a human — and never by the
+weekly refit.  That asymmetry IS the directive's "do not allow a model
+to autonomously rewrite production code"; if a future change gives the
+refit a path to the writer, the prohibition is gone.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from src.model_registry.holdout import source_roles
+from src.model_registry.versioning import (
+    ModelRegistry,
+    ModelVersion,
+    RegistryError,
+    fingerprint_inputs,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+PLAYER_VALUATION = REPO / "src" / "canonical" / "player_valuation.py"
+
+MODEL_ID = "hill_scope_masters"
+
+CONSTANT_NAMES: tuple[str, ...] = (
+    "HILL_GLOBAL_PERCENTILE_C",
+    "HILL_GLOBAL_PERCENTILE_S",
+    "HILL_PERCENTILE_C",
+    "HILL_PERCENTILE_S",
+    "IDP_HILL_PERCENTILE_C",
+    "IDP_HILL_PERCENTILE_S",
+    "HILL_ROOKIE_PERCENTILE_C",
+    "HILL_ROOKIE_PERCENTILE_S",
+)
+
+# The pair the OFFENSE holdout actually scores.  Named so callers stop
+# assuming "the model" is validated end to end: only these two of the
+# eight have a genuine out-of-sample check today.
+VALIDATED_PARAMS: tuple[str, str] = ("HILL_PERCENTILE_C", "HILL_PERCENTILE_S")
+
+
+def read_committed_constants(path: Path | None = None) -> dict[str, float]:
+    """The eight constants currently live in ``player_valuation.py``."""
+    target = path or PLAYER_VALUATION
+    text = target.read_text()
+    out: dict[str, float] = {}
+    for name in CONSTANT_NAMES:
+        m = re.search(rf"^{re.escape(name)}:\s*float\s*=\s*([0-9.]+)\s*$", text, re.MULTILINE)
+        if not m:
+            raise RegistryError(f"could not find {name!r} in {target}")
+        out[name] = float(m.group(1))
+    return out
+
+
+def write_committed_constants(params: dict[str, float], path: Path | None = None) -> None:
+    """Write the champion's constants into production.
+
+    CALLED BY EXACTLY ONE PLACE: ``scripts/model_registry.py apply``,
+    run by a human.  The weekly refit must never reach this.
+    """
+    target = path or PLAYER_VALUATION
+    text = target.read_text()
+    for name in CONSTANT_NAMES:
+        if name not in params:
+            raise RegistryError(f"champion params missing {name!r}")
+        literal = f"{params[name]:.4f}" if name.endswith("_C") else f"{params[name]:.3f}"
+        text, n = re.subn(
+            rf"^({re.escape(name)}:\s*float\s*=\s*)[0-9.]+(\s*)$",
+            rf"\g<1>{literal}\g<2>",
+            text,
+            flags=re.MULTILINE,
+        )
+        if n != 1:
+            raise RegistryError(f"expected 1 match for {name!r}, got {n}")
+    target.write_text(text)
+
+
+def git_sha() -> str:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(REPO),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def training_input_paths() -> dict[str, Path]:
+    """The CSVs the fit consumes, for provenance fingerprinting."""
+    return {role.label: REPO / role.path for role in source_roles() if role.role == "train"}
+
+
+def load_or_seed_registry(registry_dir: Path | None = None) -> ModelRegistry:
+    """Resolve the registry, seeding from live constants on first use.
+
+    Seeding records what is ALREADY live as v1 champion.  It is not a
+    claim that those constants won anything — ``qualified`` stays False
+    until someone evaluates them.
+    """
+    try:
+        return ModelRegistry.load(MODEL_ID, registry_dir)
+    except RegistryError:
+        reg = ModelRegistry(MODEL_ID)
+        reg.seed_champion(
+            ModelVersion(
+                model_id=MODEL_ID,
+                version=1,
+                params=read_committed_constants(),
+                fitted_at="unknown",
+                producer="seeded from committed constants in player_valuation.py",
+                training_inputs=fingerprint_inputs(training_input_paths()),
+                notes=(
+                    "seeded, not validated: these constants were live before the "
+                    "registry existed and carry no out-of-sample score",
+                ),
+            )
+        )
+        reg.save(registry_dir)
+        return reg

--- a/tests/model_registry/test_refit_driver.py
+++ b/tests/model_registry/test_refit_driver.py
@@ -1,0 +1,178 @@
+"""The refit driver's exit-code contract, exercised as a subprocess.
+
+The workflow branches entirely on this script's exit code, so the
+contract is tested the way the workflow uses it — ``subprocess.run``
+against the real script, real registry and real boards — not by
+importing ``main()`` and inspecting internals.
+
+The point of these tests is the one thing the old guard could not do:
+**come out red.**  A gate observed only passing is indistinguishable
+from a gate that cannot fail, which is the defect this whole path was
+rebuilt to remove.  ``test_a_bad_challenger_is_rejected`` uses the
+exact curve ``(0.300, 2.50)`` that passed every pinned rank under the
+old rebaselined guard.
+
+All are ``--dry-run``: they must not mutate the committed registry.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.model_registry.hill_masters import CONSTANT_NAMES, read_committed_constants
+
+pytestmark = pytest.mark.livedata
+
+REPO = Path(__file__).resolve().parents[2]
+DRIVER = REPO / "scripts" / "auto_refit_hill_curves.py"
+
+EXIT_CHAMPION_STANDS = 0
+EXIT_PROMOTABLE = 1
+EXIT_ERROR = 2
+EXIT_ALARM = 3
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(DRIVER), *args],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _challenger(tmp_path: Path, **overrides: float) -> Path:
+    params = dict(read_committed_constants())
+    params.update(overrides)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / "challenger.json"
+    path.write_text(json.dumps(params, indent=2))
+    return path
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_boards():
+    if not (REPO / "CSVs" / "site_raw" / "fantasyCalc.csv").exists():
+        pytest.skip("holdout boards not present in this checkout")
+
+
+class TestTheGateCanComeOutRed:
+    def test_a_bad_challenger_is_rejected(self, tmp_path):
+        """The curve the OLD guard accepted at every pinned rank."""
+        path = _challenger(tmp_path, HILL_PERCENTILE_C=0.300, HILL_PERCENTILE_S=2.500)
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert r.returncode == EXIT_ALARM, r.stdout + r.stderr
+        assert "REJECTED" in r.stdout
+        assert "ALARM" in r.stderr
+
+    def test_a_mildly_worse_challenger_is_rejected_without_alarm(self, tmp_path):
+        path = _challenger(tmp_path, HILL_PERCENTILE_C=0.124)
+        r = _run("--challenger-json", str(path), "--dry-run", "--force")
+        assert r.returncode == EXIT_CHAMPION_STANDS, r.stdout + r.stderr
+        assert "REJECTED" in r.stdout
+        assert "Champion stands" in r.stdout
+
+    def test_a_good_challenger_is_promotable(self, tmp_path):
+        path = _challenger(tmp_path, HILL_PERCENTILE_C=0.098)
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert r.returncode == EXIT_PROMOTABLE, r.stdout + r.stderr
+        assert "PROMOTABLE" in r.stdout
+
+    def test_both_verdicts_are_reachable_from_the_same_entry_point(self, tmp_path):
+        """MECHANISM TEST. Red and green from one code path, so neither
+        is an artifact of how the test invoked it."""
+        bad = _challenger(tmp_path / "a", HILL_PERCENTILE_C=0.300, HILL_PERCENTILE_S=2.5)
+        good = _challenger(tmp_path / "b", HILL_PERCENTILE_C=0.098)
+        codes = {
+            _run("--challenger-json", str(bad), "--dry-run").returncode,
+            _run("--challenger-json", str(good), "--dry-run").returncode,
+        }
+        assert codes == {EXIT_ALARM, EXIT_PROMOTABLE}
+
+
+class TestItRefusesToGuess:
+    def test_a_malformed_challenger_is_an_error(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("{not json")
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert r.returncode == EXIT_ERROR
+        assert "ERROR" in r.stderr
+
+    def test_an_incomplete_challenger_is_an_error(self, tmp_path):
+        path = tmp_path / "partial.json"
+        path.write_text(json.dumps({"HILL_PERCENTILE_C": 0.1}))
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert r.returncode == EXIT_ERROR
+        assert "missing" in r.stderr
+
+    def test_a_missing_challenger_file_is_an_error(self, tmp_path):
+        r = _run("--challenger-json", str(tmp_path / "nope.json"), "--dry-run")
+        assert r.returncode == EXIT_ERROR
+
+
+class TestItDoesNotTouchProduction:
+    def test_dry_run_leaves_constants_and_registry_untouched(self, tmp_path):
+        before_constants = (REPO / "src/canonical/player_valuation.py").read_bytes()
+        registry_path = REPO / "config" / "model_registry" / "hill_scope_masters.json"
+        before_registry = registry_path.read_bytes()
+
+        path = _challenger(tmp_path, HILL_PERCENTILE_C=0.098)
+        _run("--challenger-json", str(path), "--dry-run")
+
+        assert (REPO / "src/canonical/player_valuation.py").read_bytes() == before_constants
+        assert registry_path.read_bytes() == before_registry
+
+    def test_a_promotable_challenger_still_does_not_self_promote(self, tmp_path):
+        """MECHANISM TEST for the directive. Even the winning path must
+        leave production alone and hand off to a human."""
+        before = (REPO / "src/canonical/player_valuation.py").read_bytes()
+        path = _challenger(tmp_path, HILL_PERCENTILE_C=0.098)
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert r.returncode == EXIT_PROMOTABLE
+        assert (REPO / "src/canonical/player_valuation.py").read_bytes() == before
+        assert "A human must promote it" in r.stdout
+        assert "model_registry.py promote" in r.stdout
+
+
+class TestReportingHonesty:
+    def test_it_names_which_parameters_are_actually_gated(self, tmp_path):
+        """Six of the eight constants are versioned but not validated.
+        The report must not let a reader assume otherwise."""
+        path = _challenger(tmp_path, HILL_PERCENTILE_C=0.098)
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert "only HILL_PERCENTILE_C / HILL_PERCENTILE_S" in r.stdout
+        assert "not gated" in r.stdout
+
+    def test_it_shows_both_sides_of_the_comparison(self, tmp_path):
+        path = _challenger(tmp_path, HILL_PERCENTILE_C=0.098)
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert "champion v" in r.stdout
+        assert "challenger" in r.stdout
+        for board in ("FantasyCalc", "OTCFFB", "PFKDynasty", "FantasyNavigator"):
+            assert board in r.stdout
+
+    def test_no_drift_short_circuits_before_the_gate(self, tmp_path):
+        """An identical challenger is not worth scoring."""
+        params = dict(read_committed_constants())
+        path = tmp_path / "same.json"
+        path.write_text(json.dumps(params))
+        r = _run("--challenger-json", str(path), "--dry-run")
+        assert r.returncode == EXIT_CHAMPION_STANDS
+        assert "No drift beyond threshold" in r.stdout
+        assert "Held-out validation" not in r.stdout
+
+    def test_force_scores_even_without_drift(self, tmp_path):
+        params = dict(read_committed_constants())
+        path = tmp_path / "same.json"
+        path.write_text(json.dumps(params))
+        r = _run("--challenger-json", str(path), "--dry-run", "--force")
+        assert r.returncode == EXIT_CHAMPION_STANDS
+        assert "Held-out validation" in r.stdout
+
+    def test_all_eight_constants_are_required(self):
+        assert len(CONSTANT_NAMES) == 8

--- a/tests/model_registry/test_refit_path_characterisation.py
+++ b/tests/model_registry/test_refit_path_characterisation.py
@@ -1,20 +1,28 @@
-"""Pins the honest characterisation of the EXISTING refit path.
+"""The refit path: what it was, and what it must never become again.
 
-These tests do not assert that the current behaviour is good.  They
-assert that it is what this workstream documented it to be, so that the
-finding cannot rot and so a future change to the refit path shows up
-here rather than in a surprise.
+Until 2026-07-26 the weekly refit rewrote the eight ``HILL_*_C/S``
+constants in ``src/canonical/player_valuation.py``, rewrote the guard
+that was supposed to check them, and pushed to ``main`` — triggering a
+deploy — with nothing verifying the result.  Three independent defects,
+any one sufficient (ADR-008):
 
-The finding, in one sentence: the weekly refit rewrites production
-constants AND rewrites the only test that guards them, from the
-challenger's own output, against a board that is also a training
-source — so the guard cannot fail.
+1. ``rebaseline_ktc_reconciliation`` recomputed the guard's expected
+   values FROM the challenger, so the residual was zero by
+   construction for any curve.
+2. KTC is a TRAINING source for the constants the guard scored, so
+   even honest pins would have been training-set validation.
+3. The guard is auto-marked ``livedata`` and the workflow ran
+   ``pytest -m "not livedata"`` — 13 deselected, 0 run.  It never
+   executed.
 
-Source of truth for the claims:
-  scripts/auto_refit_hill_curves.py
-  .github/workflows/refit-hill-curves.yml
-  tests/canonical/test_ktc_reconciliation.py
-  scripts/fit_hill_curve_percentile.py
+An earlier version of this file pinned those defects so the finding
+could not rot.  They are now fixed, so the assertions are inverted:
+this file pins the FIXES, and fails if any of the three returns.
+
+Reason (2) is deliberately still asserted as TRUE — KTC remains a
+training source.  That is a fact about the fit, not a defect that was
+repaired, and it is precisely why the gate had to move off KTC rather
+than be repaired in place.
 """
 
 from __future__ import annotations
@@ -32,89 +40,156 @@ FIT = REPO / "scripts" / "fit_hill_curve_percentile.py"
 KTC_TEST = REPO / "tests" / "canonical" / "test_ktc_reconciliation.py"
 WORKFLOW = REPO / ".github" / "workflows" / "refit-hill-curves.yml"
 PLAYER_VALUATION = REPO / "src" / "canonical" / "player_valuation.py"
+CONFTEST = REPO / "tests" / "conftest.py"
 
 
 def _strip_comments_and_docstrings(text: str) -> str:
     """Assert on code, not on prose about the code.
 
     ORCHESTRATION.md §2b records a matcher that passed on the CSS
-    *comments* documenting a rule rather than the rule itself.  Same
-    trap applies here: every claim below is about behaviour, and a
-    docstring describing the behaviour must not satisfy it.
+    *comments* documenting a rule rather than the rule itself.  Every
+    claim below is about behaviour, and this file's own docstrings
+    describe the defects at length — without stripping, several of
+    these tests would pass on their own preamble.
     """
     text = re.sub(r'"""(?:.|\n)*?"""', "", text)
     text = re.sub(r"'''(?:.|\n)*?'''", "", text)
     return re.sub(r"(?m)#.*$", "", text)
 
 
-class TestTheRefitRewritesProductionCode:
-    def test_refit_writes_player_valuation(self):
+# ── Defect 1: the refit rewrote production code and its own guard ──
+
+
+class TestTheRefitNoLongerWritesProductionCode:
+    def test_refit_does_not_write_any_file(self):
         code = _strip_comments_and_docstrings(REFIT.read_text())
-        assert "PLAYER_VALUATION.write_text" in code
+        assert "write_text" not in code, "the refit driver writes a file again"
 
-    def test_refit_writes_its_own_guard_test(self):
+    def test_refit_cannot_even_import_the_writer(self):
+        """MECHANISM TEST. Not importing it is stronger than not calling
+        it: a later edit cannot reach the writer by accident."""
         code = _strip_comments_and_docstrings(REFIT.read_text())
-        assert "KTC_RECONCILIATION_TEST.write_text" in code
+        assert "write_committed_constants" not in code
+        import scripts.auto_refit_hill_curves as driver
 
-    def test_workflow_commits_both_files_unreviewed(self):
-        wf = WORKFLOW.read_text()
-        assert "git commit" in wf and "git push" in wf
-        assert "src/canonical/player_valuation.py" in wf
-        assert "tests/canonical/test_ktc_reconciliation.py" in wf
+        assert not hasattr(driver, "write_committed_constants")
 
-
-class TestTheGuardCannotFail:
-    """Two independent reasons, either one sufficient."""
-
-    def test_reason_one_the_pins_are_recomputed_from_the_challenger(self):
-        """``rebaseline_ktc_reconciliation`` derives ``ours`` from the
-        NEW constants and writes it as the expected value, so the
-        test's exact pin has a zero residual by construction."""
+    def test_refit_no_longer_rebaselines_the_guard(self):
         code = _strip_comments_and_docstrings(REFIT.read_text())
-        fn = code.split("def rebaseline_ktc_reconciliation")[1].split("\ndef ")[0]
-        assert 'c_off = fitted["HILL_PERCENTILE_C"]' in fn
-        assert "_hill(p, c_off, s_off)" in fn
-        assert "pct_diff" in fn
-        assert "PINNED_DELTAS" in fn
+        assert "rebaseline" not in code.lower()
+        assert "PINNED_DELTAS" not in code
+        assert "KTC_RECONCILIATION_TEST" not in code
 
-    def test_the_guard_asserts_exactly_what_the_refit_wrote(self):
+    def test_the_guard_still_has_real_assertions_to_make(self):
+        """The guard itself was left intact — only the thing rewriting
+        it was removed. If its pins go stale it should now FAIL, which
+        is the tripwire working rather than a regression."""
         code = _strip_comments_and_docstrings(KTC_TEST.read_text())
         assert "assert ours == pinned_ours" in code
         assert "abs(actual_pct - pinned_pct) <= tolerance_pp" in code
 
-    def test_reason_two_ktc_is_a_training_source(self):
-        """Even with honest pins, scoring the OFFENSE master against KTC
-        is training-set validation — ORCHESTRATION.md §2b."""
-        fit_code = FIT.read_text()
-        offense_block = fit_code.split("OFFENSE_SOURCES")[1].split("}")[0]
+
+class TestTheWorkflowCommitsOnlyTheRegistry:
+    def test_workflow_does_not_commit_production_constants(self):
+        wf = WORKFLOW.read_text()
+        assert "git add config/model_registry/" in wf
+        assert "git add src/canonical/player_valuation.py" not in wf
+        assert "git add tests/canonical/test_ktc_reconciliation.py" not in wf
+
+    def test_no_git_add_targets_anything_but_the_registry(self):
+        """MECHANISM TEST. Catches a second `git add` appended later —
+        the rule is 'only the registry', not 'the registry is among the
+        things committed'."""
+        adds = re.findall(r"^\s*git add (.+)$", WORKFLOW.read_text(), re.MULTILINE)
+        assert adds, "no git add found — did the commit step move?"
+        for target in adds:
+            assert target.strip() == "config/model_registry/", f"unexpected git add: {target}"
+
+
+# ── Defect 3: the gate is invoked directly, not through a marker ────
+
+
+class TestTheGateRunsDirectly:
+    def test_refit_calls_the_holdout_evaluation_itself(self):
+        code = _strip_comments_and_docstrings(REFIT.read_text())
+        assert "evaluate_offense_master" in code
+        assert "decide_promotion" in code
+
+    def test_the_gate_does_not_depend_on_pytest_or_markers(self):
+        """MECHANISM TEST — the fix for reason 3.
+
+        A gate invoked through pytest can be deselected by a filter; a
+        gate invoked as a function call cannot.
+        """
+        code = _strip_comments_and_docstrings(REFIT.read_text())
+        assert "pytest" not in code, "the gate went back through pytest"
+        assert "livedata" not in code
+
+    def test_an_unevaluable_gate_is_an_error_not_a_pass(self):
+        code = _strip_comments_and_docstrings(REFIT.read_text())
+        assert "HoldoutError" in code
+        assert "EXIT_ERROR" in code
+
+    def test_the_workflow_self_tests_the_gate_before_trusting_it(self):
+        assert "pytest tests/model_registry/" in WORKFLOW.read_text()
+
+    def test_the_workflow_no_longer_runs_the_suite_against_rewritten_code(self):
+        """It used to run `pytest -m "not livedata"` over constants it
+        had just rewritten, while that same filter deselected the one
+        test guarding them."""
+        assert 'pytest tests/ -q -m "not livedata"' not in WORKFLOW.read_text()
+
+
+class TestTheLivedataMarkingIsPreserved:
+    """Reason 3 must NOT be solved by un-marking the guard.
+
+    The marking exists because data-coupled failures once stalled every
+    PR (a yahooBoone row-count dip). Removing it would trade one outage
+    class for another. The gate moved instead.
+    """
+
+    def test_the_guard_is_still_marked_livedata(self):
+        block = CONFTEST.read_text().split("_LIVEDATA_MODULES")[1].split(")")[0]
+        assert '"test_ktc_reconciliation.py"' in block, (
+            "the guard was un-marked — that re-introduces the PR-stalling "
+            "failure the marking was added to prevent"
+        )
+
+    def test_the_gate_does_not_rely_on_that_marking_either_way(self):
+        code = _strip_comments_and_docstrings(REFIT.read_text())
+        assert "conftest" not in code
+        assert "_LIVEDATA_MODULES" not in code
+
+
+# ── Defect 2: still true, and still why the gate had to move ────────
+
+
+class TestKtcRemainsATrainingSource:
+    def test_ktc_is_a_training_source(self):
+        offense_block = FIT.read_text().split("OFFENSE_SOURCES")[1].split("}")[0]
         assert "ktc.csv" in offense_block
         assert "KTC" in OFFENSE_TRAINING_SOURCES
 
-    def test_the_guarded_constants_are_the_ones_ktc_trains(self):
-        """Closes the loop: the fit trains HILL_PERCENTILE_C/S from a
-        set containing KTC, and the guard evaluates exactly those."""
-        refit_code = REFIT.read_text()
-        assert '"OFFENSE": ("HILL_PERCENTILE_C", "HILL_PERCENTILE_S")' in refit_code
+    def test_the_guard_scores_the_constants_ktc_trains(self):
         pv = _strip_comments_and_docstrings(PLAYER_VALUATION.read_text())
         sig = pv.split("def percentile_to_value")[1].split(")")[0]
         assert "midpoint: float = HILL_PERCENTILE_C" in sig
         assert "slope: float = HILL_PERCENTILE_S" in sig
 
-    def test_the_workflow_already_admits_the_circularity(self):
-        """The comment is in the repo today. This pins it so the fix
-        cannot be claimed without removing the admission."""
-        wf = WORKFLOW.read_text()
-        assert "circular" in wf.lower()
+    def test_the_new_gate_scores_the_same_constants_on_other_boards(self):
+        """Closes the loop: same parameters, different data."""
+        from src.model_registry.hill_masters import VALIDATED_PARAMS
+
+        assert VALIDATED_PARAMS == ("HILL_PERCENTILE_C", "HILL_PERCENTILE_S")
 
 
 class TestParityWithTheFitSourceList:
-    """The holdout module mirrors OFFENSE_SOURCES as a literal. If the
-    fit gains a source and the mirror does not, a training board
-    silently becomes eligible as holdout."""
+    """``holdout.py`` mirrors OFFENSE_SOURCES as a literal. If the fit
+    gains a source and the mirror does not, a training board silently
+    becomes eligible as holdout."""
 
     def test_training_mirror_matches_the_fit_script(self):
-        fit_code = FIT.read_text()
-        block = fit_code.split("OFFENSE_SOURCES: dict[str, tuple[str, str]] = {")[1]
+        block = FIT.read_text().split("OFFENSE_SOURCES: dict[str, tuple[str, str]] = {")[1]
         block = block.split("}")[0]
         found = set(re.findall(r'^\s*"([A-Za-z]+)":', block, re.MULTILINE))
         assert found == set(OFFENSE_TRAINING_SOURCES), (
@@ -123,21 +198,22 @@ class TestParityWithTheFitSourceList:
         )
 
     def test_mirrored_paths_match_the_fit_script(self):
-        fit_code = FIT.read_text()
-        block = fit_code.split("OFFENSE_SOURCES: dict[str, tuple[str, str]] = {")[1]
+        block = FIT.read_text().split("OFFENSE_SOURCES: dict[str, tuple[str, str]] = {")[1]
         block = block.split("}")[0]
         for label, (path, _) in OFFENSE_TRAINING_SOURCES.items():
             assert path in block, f"{label} path {path} not in the fit script"
 
 
 @pytest.mark.livedata
-class TestTheCircularityIsReal:
-    """Demonstrate it rather than only asserting the code shape."""
+class TestWhyTheOldGuardCouldNotFail:
+    """Retained as the demonstration behind ADR-008.
 
-    def test_rebaselining_drives_the_residual_to_zero(self):
-        """Recompute the pins the way the refit does, then check the
-        guard's own assertion against them: the residual is identically
-        zero, for ANY curve — which is what 'cannot fail' means."""
+    The rebaseline arithmetic is reproduced here — not called, since it
+    no longer exists — to show it passed for ANY curve. That is why the
+    guard was replaced rather than repaired.
+    """
+
+    def test_rebaselining_drove_the_residual_to_zero_for_any_curve(self):
         from src.model_registry.holdout import hill
 
         ktc_csv = REPO / "CSVs" / "site_raw" / "ktc.csv"
@@ -167,50 +243,25 @@ class TestTheCircularityIsReal:
             ).group(1)
         )
 
-        # Two wildly different "challengers". Both must pass the
-        # rebaselined guard, which is the whole problem.
         for c, s in ((0.118, 1.17), (0.300, 2.50)):
             for rank in (1, 12, 50, 150, 400):
                 ktc = rows[rank - 1]
                 p = max(0.0, min(1.0, (rank - 1) / (ref_n - 1)))
                 ours = int(round(hill(p, c, s)))
-                pinned_ours = ours  # what rebaseline writes
+                pinned_ours = ours  # what the rebaseline wrote
                 pinned_pct = round(100.0 * (ours - ktc) / ktc, 1)
                 actual_pct = 100.0 * (ours - ktc) / ktc
-
                 assert ours == pinned_ours
                 assert abs(actual_pct - pinned_pct) <= 10.0
 
+    def test_the_new_gate_rejects_the_curve_the_old_guard_accepted(self):
+        """MECHANISM TEST. (0.300, 2.50) passes every pinned rank above.
+        The replacement must reject it, or the fix is cosmetic."""
+        from src.model_registry.holdout import evaluate_offense_master
+        from src.model_registry.promotion import decide_promotion
 
-class TestTheGuardIsNotEvenRun:
-    """Reason three, independent of the other two.
-
-    ``tests/conftest.py`` auto-marks ``test_ktc_reconciliation.py``
-    ``livedata``, and the refit workflow's regression step runs
-    ``pytest tests/ -q -m "not livedata"``.  So the refit rewrites the
-    guard's expectations and then deselects the guard.
-
-    Each of the three defects is individually sufficient; together they
-    mean the constants reach production with no check of any kind.
-    """
-
-    def test_the_guard_module_is_auto_marked_livedata(self):
-        conftest = (REPO / "tests" / "conftest.py").read_text()
-        block = conftest.split("_LIVEDATA_MODULES")[1].split(")")[0]
-        assert '"test_ktc_reconciliation.py"' in block
-
-    def test_the_refit_workflow_excludes_livedata(self):
-        wf = WORKFLOW.read_text()
-        assert 'pytest tests/ -q -m "not livedata"' in wf
-
-    def test_the_two_combine_to_deselect_the_guard(self):
-        """MECHANISM TEST. Fails if either the marking or the filter
-        changes such that the guard would actually run — at which point
-        the other two defects become load-bearing again."""
-        conftest = (REPO / "tests" / "conftest.py").read_text()
-        marked = '"test_ktc_reconciliation.py"' in conftest.split("_LIVEDATA_MODULES")[1]
-        excluded = 'm "not livedata"' in WORKFLOW.read_text()
-        assert marked and excluded, (
-            "the refit's regression step would now run the KTC guard; "
-            "re-check whether the rebaseline circularity still makes it vacuous"
-        )
+        champion = evaluate_offense_master(0.118, 1.17)
+        absurd = evaluate_offense_master(0.300, 2.50)
+        decision = decide_promotion(champion.criterion, absurd.criterion)
+        assert not decision.promote
+        assert decision.alarm, "a curve this wrong should trip the regression alarm"


### PR DESCRIPTION
> **Scope.** No live player values change. `src/canonical/player_valuation.py` is untouched, and the committed registry is unchanged. This changes **release behaviour**: the weekly refit stops shipping constants.

Lands the wiring ADR-008 deliberately scoped out of #564. Verified still-live on `main` before starting:

```
$ python -m pytest tests/canonical/test_ktc_reconciliation.py -q -m "not livedata"
13 deselected in 0.02s
```

## All three reasons, and what happened to each

**Reason 1 — the refit rewrote its own guard.** `rebaseline_ktc_reconciliation` is gone. The driver no longer writes *any* file, and no longer **imports** `write_committed_constants` at all. Not importing it is stronger than not calling it: a later edit cannot reach the writer by accident. `test_ktc_reconciliation.py` is left intact and un-rewritten, so its pins are a real tripwire again — if constants change and nobody re-baselines by hand, it now fails, which is what its docstring always claimed.

**Reason 2 — KTC is a training source for the constants the guard scored.** Still true, and now irrelevant: validation moved to `src/model_registry/holdout.py`, which scores the OFFENSE master against four value-publishing boards the fit never reads. This is asserted as **still true** rather than deleted, because it is *why* the gate had to move rather than be repaired in place.

**Reason 3 — the guard was never executed.** Fixed by moving the gate out of pytest entirely: the driver calls `evaluate_offense_master` directly. A gate invoked through pytest can be deselected by a filter; a gate invoked as a function call cannot.

**`test_ktc_reconciliation.py` keeps its `livedata` marking.** That marking exists because a yahooBoone row-count dip once stalled every PR, and it is still correct — un-marking it would trade one outage class for another. `TestTheLivedataMarkingIsPreserved` fails if anyone "fixes" it that way.

## The gate comes out red — proven on the real driver path

Not a unit test of `decide_promotion`. This is the script the workflow runs, invoked as a subprocess exactly as the workflow invokes it.

**Known-bad challenger** — `(c=0.300, s=2.500)`, *the exact curve that passed every pinned rank under the old rebaselined guard*:

```
champion v1: criterion 849.8   challenger: criterion 2630.7
    FantasyCalc      852.6  ->  2654.4
    FantasyNavigator 1185.2 ->  2915.4
    OTCFFB           1104.9 ->  2901.1
    PFKDynasty        256.7 ->  2051.9
verdict: REJECTED
reason:  challenger is 1780.9 points WORSE than the champion (alarm threshold 250)
EXIT=3
```

**Known-good challenger** — `(c=0.098, s=1.170)`:

```
champion v1: criterion 849.8   challenger: criterion 648.2
verdict: PROMOTABLE
reason:  challenger improves the held-out criterion by 201.6 points (849.8 -> 648.2),
         clearing the 25-point margin
EXIT=1
```

`tests/model_registry/test_refit_driver.py` runs both as subprocesses, plus `test_both_verdicts_are_reachable_from_the_same_entry_point` — red and green from one code path, so neither is an artifact of how the test invoked it.

## What happens on rejection

| Outcome | Constants | Registry | Workflow | Human notified |
|---|---|---|---|---|
| No drift | untouched | unchanged | green | no |
| Rejected within margin | untouched | recorded as `rejected` | green | no |
| **Promotable** | untouched | recorded | green | **issue opened** |
| **Regression alarm** | untouched | recorded as `rejected` | **red** | **issue opened** |
| Error | untouched | unchanged | **red** | failure email |

Two deliberate choices:

* **Routine rejection does not page.** It is the expected weekly outcome; alerting on it trains people to ignore the alert, which is exactly how a deliberate decision became an invisible hole the first time. It is still *recorded* — every run leaves a dated registry entry.
* **A promotable challenger DOES page.** Otherwise improvements never land and the system quietly becomes a no-op — the same "nothing happened and nobody noticed" shape with the sign flipped.

The registry is the audit trail, and its absence is the signal: a week with no new entry means the workflow did not run.

## Where I diverged from ADR-008's plan

The plan predated the code. Recorded in the ADR too.

* **Steps 1–4 collapsed into one driver** rather than four CLI calls chained in YAML. Every hand-off between shell steps is a place for the gate to be skipped by an `if:` condition; one driver with one exit-code contract has no such seam.
* **Richer exit codes than "0 promotes, 1 rejects"** — `0` champion stands, `1` promotable, `2` error, `3` regression alarm. The binary conflated "no meaningful change" with "the fit broke".
* **Added: the champion must match what is deployed.** The driver refuses to run if the registry champion differs from the constants in `player_valuation.py`. Comparing a challenger against a champion that is not live yields a correct-looking verdict about the wrong incumbent.
* **Added: the workflow self-tests the gate** (`pytest tests/model_registry/`, ~2s) before trusting it.
* **Removed: the weekly full-suite step.** It existed to check code the refit had just rewritten. The refit rewrites nothing now, so there is nothing for a full sweep to regress — and burning 15 minutes weekly to check an unchanged tree is the kind of ritual that makes a real signal easy to ignore.
* **Shared helpers moved to `src/model_registry/hill_masters.py`** so the refit and the human CLI cannot drift into disagreeing about what "the champion" is.

## Environment finding (not fixed here)

`tests/api/test_page_route_coverage.py` **hangs indefinitely** when Playwright browsers are absent, rather than skipping or failing. Each parametrised route starts `server.app`, whose lifespan spawns a Playwright driver; with no browser installed the drivers accumulate and never exit. I lost two suite runs to this before diagnosing it — both looked like slow runs, not hangs (load average 0.06, 46s CPU in 778s elapsed).

Installing `chromium` fixed it locally and the file then passes in 4m28s. CI installs browsers, so this is latent there — but if that install step ever fails, this workflow does not go red, it goes *forever*. Worth a `--timeout` or a skip-if-unavailable guard; out of scope here, flagging it.

## Validation

- Full blocking suite, on the final tree:

```
3763 passed, 325 deselected, 1 warning, 4 subtests passed in 1185.59s (0:19:45)
```

  Zero failures, zero errors. Quoted from the summary line — `grep -cE "FAILED|ERROR|error"` over the log returns `0`. Confirmed **completed, not killed**; two earlier attempts died at 29% and 15% with clean dots and no summary line.
- `tests/model_registry/`: **97 passed** (was 77) — 74 in the blocking gate, 23 `livedata`, both tiers green.
- `ruff check` + `format --check` clean on every file touched, under the repo-pinned 0.6.9 via `python -m ruff`. The pre-existing `scripts/` error count *drops* 15 → 13.
- Branch point `4f9cb05b`; diffed against the **merge base**, not the tip: **8 files, +919 / −536**. `main` has since moved (#563, #566, #567, a data refresh). It touched `src/canonical/player_valuation.py`, but **comment-only** — `git diff | grep -E "^[+-][A-Z_]+.*float"` returns nothing, so all eight constants are byte-identical and every measured number above still holds. No file overlap with this branch; no conflict.

## Not changed

- `src/canonical/player_valuation.py` — byte-identical.
- The ~200-point champion question stays exactly where #564 left it: measured, narrowed to what the four boards support (three improve, PFKDynasty worsens; the mean optimum is a boundary solution), and **unactioned**.
- Only `HILL_PERCENTILE_C`/`_S` are gated. The other six constants are versioned but not validated — the driver prints this on every run so no reader assumes otherwise.

ADR-008 updated with the landed design, the divergences, and the rejection table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_