### PR TITLE
Domain cutover (B): repoint runtime origins at https://chaseupside.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,7 @@ LOG_FORMAT=text
 
 # Uptime watchdog configuration
 # UPTIME_CHECK_ENABLED=true
-# UPTIME_CHECK_URL=https://riskittogetthebrisket.org/api/health
+# UPTIME_CHECK_URL=https://chaseupside.com/api/health
 # UPTIME_CHECK_INTERVAL_SEC=300
 # UPTIME_CHECK_TIMEOUT_SEC=5
 # UPTIME_ALERT_FAIL_THRESHOLD=2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Risk It To Get The Brisket — Dynasty Trade Calculator
 
 Private repo for the dynasty trade calculator stack powering
-[riskittogetthebrisket.org](https://riskittogetthebrisket.org).
+[chaseupside.com](https://chaseupside.com).
 
 **Architecture at a glance:**
 - **Backend:** Python 3.12 FastAPI + Uvicorn (port 8000).

--- a/deploy/PRODUCTION_BOOTSTRAP.md
+++ b/deploy/PRODUCTION_BOOTSTRAP.md
@@ -8,7 +8,7 @@ Current production target:
 - app path: `/home/dynasty/trade-calculator`
 - venv path: `/home/dynasty/.venvs/trade-calculator`
 - service: `dynasty`
-- domain: `riskittogetthebrisket.org`
+- domain: `chaseupside.com`
 
 ## 1) Repo-managed bootstrap (safe to rerun)
 
@@ -72,18 +72,18 @@ sudo /home/dynasty/.venvs/trade-calculator/bin/python -m playwright install-deps
 
 ## 3) Reverse proxy and TLS
 
-The nginx site config is maintained in `deploy/nginx/riskittogetthebrisket.org.conf`.
+The nginx site config is maintained in `deploy/nginx/chaseupside.com.conf`.
 
 Install or update:
 
 ```bash
-sudo cp deploy/nginx/riskittogetthebrisket.org.conf /etc/nginx/sites-available/riskittogetthebrisket.org
-sudo ln -sf /etc/nginx/sites-available/riskittogetthebrisket.org /etc/nginx/sites-enabled/
+sudo cp deploy/nginx/chaseupside.com.conf /etc/nginx/sites-available/chaseupside.com
+sudo ln -sf /etc/nginx/sites-available/chaseupside.com /etc/nginx/sites-enabled/
 sudo nginx -t && sudo systemctl reload nginx
 ```
 
 Routing:
-1. `riskittogetthebrisket.org` terminates TLS at nginx.
+1. `chaseupside.com` terminates TLS at nginx.
 2. HTTP (`:80`) redirects to HTTPS (`:443`).
 3. `/api/*` → Python backend (`127.0.0.1:8000`).
 4. `/_next/*` → Next.js frontend (`127.0.0.1:3000`) — static assets.
@@ -97,7 +97,7 @@ From server:
 ```bash
 sudo -n /bin/systemctl is-active dynasty
 curl -fsS http://127.0.0.1:8000/api/status | head -c 400
-curl -fsS https://riskittogetthebrisket.org/api/health | head -c 400
+curl -fsS https://chaseupside.com/api/health | head -c 400
 ```
 
 From GitHub:

--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -3,7 +3,7 @@
 ## `public-league-dashboard.json`
 
 One-panel-per-row dashboard that polls
-`https://riskittogetthebrisket.org/api/public/league/metrics` every 30s
+`https://chaseupside.com/api/public/league/metrics` every 30s
 and surfaces the key snapshot-cache signals:
 
 | Panel                          | Target                                   |

--- a/deploy/grafana/public-league-dashboard.json
+++ b/deploy/grafana/public-league-dashboard.json
@@ -2,7 +2,7 @@
   "_comment": [
     "Grafana dashboard for the public /league snapshot-cache metrics.",
     "Data source: Infinity plugin (or any plugin that can poll JSON) against",
-    "http://169.58.50.224/api/public/league/metrics every 30s.",
+    "https://chaseupside.com/api/public/league/metrics every 30s.",
     "Import via: Grafana → Dashboards → Import → upload this JSON.",
     "",
     "Panels:",
@@ -36,10 +36,10 @@
         "type": "constant",
         "current": {
           "selected": true,
-          "text": "http://169.58.50.224/api/public/league/metrics",
-          "value": "http://169.58.50.224/api/public/league/metrics"
+          "text": "https://chaseupside.com/api/public/league/metrics",
+          "value": "https://chaseupside.com/api/public/league/metrics"
         },
-        "query": "http://169.58.50.224/api/public/league/metrics",
+        "query": "https://chaseupside.com/api/public/league/metrics",
         "label": "Metrics endpoint URL"
       }
     ]

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -5,9 +5,9 @@ probe is log-only until the operator opts in to a notification channel.
 
 ## What it checks (every 5 minutes)
 
-1. `https://riskittogetthebrisket.org/api/health` — full external path:
+1. `https://chaseupside.com/api/health` — full external path:
    DNS → TLS → nginx → FastAPI backend.
-2. `https://riskittogetthebrisket.org/` — nginx → Next.js frontend.
+2. `https://chaseupside.com/` — nginx → Next.js frontend.
 3. `http://127.0.0.1:8000/api/health` — backend direct (distinguishes
    "backend down" from "nginx/TLS broken"); disable with
    `CHECK_LOCAL=false`.

--- a/deploy/monitoring/uptime_check.sh
+++ b/deploy/monitoring/uptime_check.sh
@@ -17,7 +17,7 @@
 # deploy/monitoring/README.md; no third-party service is wired in).
 #
 # Env overrides (drop-in on riskit-uptime.service, or cron env):
-#   SITE_URL            default http://169.58.50.224
+#   SITE_URL            default https://chaseupside.com
 #   CHECK_LOCAL         default true   (also probe 127.0.0.1:8000 directly)
 #   LOG_FILE            default /var/log/riskit-uptime.log
 #                        (falls back to stdout if unwritable)
@@ -35,7 +35,7 @@
 
 set -Eeuo pipefail
 
-SITE_URL="${SITE_URL:-http://169.58.50.224}"
+SITE_URL="${SITE_URL:-https://chaseupside.com}"
 CHECK_LOCAL="${CHECK_LOCAL:-true}"
 LOG_FILE="${LOG_FILE:-/var/log/riskit-uptime.log}"
 STATE_FILE="${STATE_FILE:-/var/tmp/riskit-uptime.state}"

--- a/deploy/nginx/chaseupside-proxy.conf
+++ b/deploy/nginx/chaseupside-proxy.conf
@@ -1,0 +1,156 @@
+# chaseupside.com — shared proxy/location snippet
+#
+# Included at SERVER level by both serving blocks in
+# deploy/nginx/chaseupside.com.conf:
+#
+#   * the :443 chaseupside.com / www block (the real site), and
+#   * the transitional :80 169.58.50.224 block (kept until every
+#     monitoring path is repointed — see that block's removal note).
+#
+# It exists so those two cannot drift.  The bare IP and the domain must
+# serve the identical application surface during the cutover window; a
+# location block added to one and forgotten in the other is exactly the
+# failure this file prevents.
+#
+# Install to /etc/nginx/snippets/chaseupside-proxy.conf.
+#
+# ⚠ Do NOT put `add_header` in here.  nginx's add_header inheritance is
+# all-or-nothing per context: a location-level add_header silently drops
+# every server-level security header for that location.  Security
+# headers are declared once per server block in chaseupside.com.conf,
+# which also lets the :443 block send HSTS while the plain-HTTP IP block
+# correctly does not.
+
+# ── Upload ceiling ───────────────────────────────────────────────────
+# 25m, matching the live production config.  The repo's older
+# riskittogetthebrisket.org.conf said 10m; live had been raised to 25m
+# and the live value wins.  Omitting the directive entirely would NOT
+# fall back to 10m — it would fall back to nginx's built-in 1m default
+# and start rejecting uploads that work today.
+client_max_body_size 25m;
+
+# ── Compression (fallback layer) ─────────────────────────────────────
+# The FastAPI backend already gzips responses >= 1 KB (GZipMiddleware)
+# and pre-gzips the /api/data contract.  nginx never re-compresses
+# responses that arrive with Content-Encoding set, so this only picks up
+# what the upstreams leave uncompressed (Next.js pages when its built-in
+# compression is off, JSON error bodies, svg icons).
+gzip on;
+gzip_comp_level 5;
+gzip_min_length 1024;
+gzip_proxied any;
+gzip_vary on;
+gzip_types
+    application/json
+    application/javascript
+    application/manifest+json
+    application/xml
+    image/svg+xml
+    text/css
+    text/plain
+    text/xml;
+
+# ── API routes → Python backend ──────────────────────────────────────
+location /api/ {
+    proxy_pass http://dynasty_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection        "";
+    # 300s, matching live.  A scrape cycle rebuilds the in-memory cache
+    # and can hold /api/data for minutes; live had already been raised
+    # from the repo copy's 120s and that experience is authoritative.
+    proxy_read_timeout 300s;
+    # Fail fast when the backend process is down instead of hanging a
+    # browser tab for the default 60s.  (Not present live; nginx's
+    # default is 60s, so this only shortens the dead-backend case.)
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 30s;
+    # The /api/data contract is MB-scale even after upstream gzip
+    # (~100-400 KB on the wire, up to ~4 MB if a client requests
+    # identity encoding).  Larger in-memory buffers keep nginx from
+    # spilling those responses to disk temp files mid-transfer.
+    proxy_buffers 32 16k;
+    proxy_busy_buffers_size 64k;
+}
+
+# ── Next.js immutable build assets → nginx cache → frontend ─────────
+# NOT present in the live config — this is an intentional addition.
+# Filenames are content-hashed and Next.js serves them with
+# "Cache-Control: public, max-age=31536000, immutable"; nginx honors
+# those upstream headers, so repeated asset hits stop touching the node
+# process.  proxy_cache obeys the upstream Cache-Control for entry
+# lifetime; nothing here adds or overrides Cache-Control.
+#
+# PRIVACY SCOPE: riskit_static is the ONLY shared cache in this config
+# and it is attached ONLY to this location — never to /api/*.
+# tests/api/test_cache_control_privacy.py documents the invariant that
+# auth-gated endpoints must not meet a shared cache.  /api responses
+# pass through uncached with their app-stamped "private"/"no-store"
+# Cache-Control intact, and nginx additionally refuses by default to
+# cache responses carrying Set-Cookie or Cache-Control: private/no-store.
+location /_next/static/ {
+    proxy_pass http://dynasty_frontend;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection        "";
+    proxy_cache riskit_static;
+    proxy_cache_valid 200 7d;
+    proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+    proxy_cache_lock on;
+    proxy_connect_timeout 5s;
+    proxy_read_timeout 30s;
+}
+
+# ── Other Next.js framework routes (/_next/image, /_next/data) ──────
+# Live sets only `Host` here.  The additional headers are deliberate and
+# do not change caching (this location is uncached, and nginx's default
+# cache key is $scheme$proxy_host$request_uri — request headers are not
+# part of it).  X-Forwarded-Proto is the one that matters: without it a
+# Next.js process behind TLS termination can generate http:// absolute
+# URLs, which is a real regression once the site is HTTPS.
+location /_next/ {
+    proxy_pass http://dynasty_frontend;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection        "";
+    proxy_connect_timeout 5s;
+    proxy_read_timeout 60s;
+}
+
+# ── Favicon → frontend ───────────────────────────────────────────────
+location = /favicon.ico {
+    proxy_pass http://dynasty_frontend;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection        "";
+    proxy_connect_timeout 5s;
+}
+
+# ── Everything else → Next.js pages ──────────────────────────────────
+# Live hardcodes `Connection "upgrade"` on every request through this
+# location, websocket or not.  This uses the $connection_upgrade map
+# instead, which sends "upgrade" only when the client actually asked for
+# one and "close" otherwise — the correct spelling, and a no-op for
+# real websocket traffic.
+location / {
+    proxy_pass http://dynasty_frontend;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Connection        $connection_upgrade;
+    proxy_connect_timeout 5s;
+    proxy_read_timeout 75s;
+}

--- a/deploy/nginx/chaseupside.com.conf
+++ b/deploy/nginx/chaseupside.com.conf
@@ -1,0 +1,193 @@
+# chaseupside.com — nginx site config
+# Next.js frontend on :3000, Python backend on :8000
+#
+# Reconciled against the ACTUAL live config
+# (/etc/nginx/sites-enabled/dynasty → sites-available/dynasty), not
+# against the stale deploy/nginx/riskittogetthebrisket.org.conf.  Every
+# live setting is preserved; every deliberate difference is annotated at
+# the point where it occurs.  The full list is in the cutover PR.
+#
+# ⚠ THIS FILE REPLACES THE LIVE `dynasty` SITE.  It does not sit
+# alongside it.  Both declare `upstream dynasty_backend` /
+# `dynasty_frontend`, and since the operator added
+# `chaseupside.com www.chaseupside.com` to the live `server_name`, both
+# would also claim the same hostnames.  Enabling both fails `nginx -t`
+# with a duplicate-upstream error — deliberately, because failing loudly
+# at test time beats two server blocks silently fighting over a name.
+# The swap is atomic: remove the `dynasty` symlink and add this one in
+# the same step, then `nginx -t`, then reload.
+#
+# ⚠ PRECONDITION — the :443 block references
+# /etc/letsencrypt/live/chaseupside.com/{fullchain,privkey}.pem.  Until
+# certbot has issued that certificate those paths do not exist and
+# `nginx -t` fails.  Follow docs/runbooks/domain-cutover-chaseupside.md
+# in order; it is the only supported way to apply this config.
+#
+# Requires deploy/nginx/chaseupside-proxy.conf installed at
+# /etc/nginx/snippets/chaseupside-proxy.conf — that snippet holds the
+# location blocks and is included by both serving blocks below so they
+# cannot drift.
+#
+# Routing (identical to live):
+#   /api/*          → Python backend (127.0.0.1:8000)
+#   /_next/static/* → Next.js (127.0.0.1:3000)  — added: nginx-cached
+#   /_next/*        → Next.js (127.0.0.1:3000)
+#   /favicon.ico    → Next.js (127.0.0.1:3000)
+#   /*              → Next.js (127.0.0.1:3000)  — pages
+#
+# TLS issued with certbot's **webroot** plugin, not --nginx.  The
+# --nginx plugin rewrites the installed config in place; this repo keeps
+# nginx config under version control and deploy/apply_hardening.sh diffs
+# the installed file against the checked-in copy and reinstalls the repo
+# version when they differ.  That script is not wired into any workflow
+# and deploy.sh does not touch nginx at all, so the revert risk is
+# manual-only — it bites if someone runs apply_hardening.sh by hand.
+# Webroot avoids the question entirely by never touching nginx config,
+# which is the reason to prefer it here.
+
+# WebSocket upgrade map (http level, before the server blocks)
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# Local cache for Next.js immutable build assets.  Added relative to
+# live — see the /_next/static/ note in the snippet.  nginx creates the
+# directory at startup if its parent exists; the runbook pre-creates it.
+proxy_cache_path /var/cache/nginx/riskit_static
+                 levels=1:2
+                 keys_zone=riskit_static:10m
+                 max_size=50m
+                 inactive=7d
+                 use_temp_path=off;
+
+# Upstream names match the live config exactly.  Keeping them identical
+# is what makes a double-enable fail at `nginx -t` instead of silently
+# resolving to one of two conflicting server blocks.
+upstream dynasty_backend {
+    server 127.0.0.1:8000;
+    # Not present live.  Idle-connection pooling to the backend; only
+    # used by locations that send `Connection ""` (i.e. /api/).
+    keepalive 8;
+}
+
+upstream dynasty_frontend {
+    server 127.0.0.1:3000;
+    # HTTP/2 multiplexing fans a page load out into many parallel asset
+    # requests; a deeper idle pool avoids TCP handshake churn to node.
+    keepalive 16;
+}
+
+# ── 1. chaseupside.com :80 — ACME + redirect to HTTPS ────────────────
+server {
+    listen 80;
+    listen [::]:80;
+    server_name chaseupside.com www.chaseupside.com;
+
+    # ACME http-01 challenge — MUST precede the catch-all redirect.
+    # Serving it from disk rather than redirecting keeps renewal working
+    # even if the certificate has already lapsed (a redirect to an
+    # untrusted https:// target fails validation).
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# ── 2. chaseupside.com :443 — the real site ──────────────────────────
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name chaseupside.com www.chaseupside.com;
+
+    # TLS — managed by certbot.  These paths exist only after issuance.
+    ssl_certificate     /etc/letsencrypt/live/chaseupside.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/chaseupside.com/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    # ── Security headers ─────────────────────────────────────────────
+    # None of these exist live; all are additions.  `always` so they are
+    # attached to error responses (401/404/5xx) too.
+    #
+    # HSTS: 1 year, no includeSubDomains / no preload.  Add
+    # includeSubDomains only after confirming every current and future
+    # subdomain of chaseupside.com serves valid TLS — HSTS mistakes lock
+    # browsers out for max-age seconds.  Note this header is sent ONLY
+    # here, never from the plain-HTTP IP block below.
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    # frame-ancestors is the modern clickjacking control and is safe to
+    # enforce — it only restricts who may embed this site in a frame and
+    # has no effect on the app's own scripts/styles.  X-Frame-Options is
+    # the legacy fallback for old browsers.
+    add_header Content-Security-Policy "frame-ancestors 'self'" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
+    # A full enforced CSP is intentionally NOT shipped.  Next.js 15 App
+    # Router hydration emits inline <script> chunks (self.__next_f
+    # pushes) without nonces and the app has no nonce plumbing, so an
+    # enforced script-src would need 'unsafe-inline' (defeating the
+    # point) or an app-code change.  To gather violation data before
+    # ever enforcing, uncomment the Report-Only header and watch the
+    # console.  Known external origin: sleepercdn.com headshots
+    # (img-src).  The service worker needs worker-src 'self'.
+    #add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://sleepercdn.com; font-src 'self' data:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+
+    # ACME on :443 — renewals validate over :80, where the real
+    # challenge location lives.  This duplicate only ensures a challenge
+    # arriving here after a redirect resolves to the token on disk
+    # instead of falling through to the page proxy and 404ing.
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+    }
+
+    include /etc/nginx/snippets/chaseupside-proxy.conf;
+}
+
+# ── 3. 169.58.50.224 :80 — TRANSITIONAL, plain HTTP ──────────────────
+# This block preserves the live bare-IP behaviour exactly: plain HTTP,
+# no redirect to HTTPS, no HSTS.
+#
+# It is load-bearing during the cutover.  Monitoring and alerting still
+# point at the IP until the second cutover PR lands: the uptime probe's
+# SITE_URL default, the Grafana metrics_url, and the links in ops /
+# signal / source-health alert emails.  Redirecting the IP to https://
+# would break all of them, because a certificate for chaseupside.com
+# cannot validate for an IP address — every probe would fail the TLS
+# handshake, not merely warn.
+#
+# No `default_server` here on purpose: the live config did not set one
+# either, and claiming it could collide with a Debian default site.
+# Requests to the IP match this block by exact server_name.
+#
+# REMOVAL CRITERION: delete this block once the origin-repointing PR has
+# deployed AND deploy/monitoring/uptime_check.sh, the Grafana
+# dashboard's saved metrics_url, and any external monitor have all been
+# confirmed on https://chaseupside.com.  Verify nothing still calls the
+# IP first:  grep -rn '169\.58\.50\.224' on the repo, and check
+# /var/log/nginx/access.log for requests with Host: 169.58.50.224.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name 169.58.50.224;
+
+    # Same non-HSTS hardening as the TLS block.  Strict-Transport-
+    # Security is deliberately absent: browsers ignore HSTS over plain
+    # HTTP and for IP-address hosts, and sending it here would be
+    # meaningless at best.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Content-Security-Policy "frame-ancestors 'self'" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
+    include /etc/nginx/snippets/chaseupside-proxy.conf;
+}

--- a/deploy/nginx/riskittogetthebrisket.org.conf
+++ b/deploy/nginx/riskittogetthebrisket.org.conf
@@ -1,21 +1,26 @@
-# ⚠ DO NOT APPLY AS-IS — this config is for a domain we no longer own.
+# ⚠ SUPERSEDED — DO NOT APPLY. The live config is
+# deploy/nginx/chaseupside.com.conf.
 #
-# riskittogetthebrisket.org lapsed; the site is served on a bare IP over
-# plain HTTP (no certificate). Applying this file today would break the
-# site twice over: the :80 block 301-redirects everything to https://,
-# which nothing can answer without a cert, and the :443 block points at
+# riskittogetthebrisket.org lapsed and now resolves to a third party; we
+# do not own it. Applying this file would break the site twice over: the
+# :80 block 301-redirects everything to https://, which nothing can
+# answer without a cert, and the :443 block points at
 # /etc/letsencrypt/live/riskittogetthebrisket.org/ paths that no longer
 # exist, so `nginx -t` fails and the reload aborts.
 #
-# Kept verbatim because the proxy rules, cache policy and security
-# headers below are still the intended production shape — only the
-# hostname and TLS wiring are stale. When a new domain is registered:
-#   1. point DNS at the server, 2. run certbot for the new name,
-#   3. replace every riskittogetthebrisket.org occurrence below,
-#   4. `nginx -t` BEFORE reloading.
+# Kept on disk (not deleted) for exactly one reason: it is the reference
+# copy of the proxy rules, cache policy and security headers that
+# chaseupside.com.conf was derived from, so a reviewer can diff the two
+# and confirm nothing was dropped in the port. It is NOT a usable
+# rollback target — rolling back the domain cutover means re-enabling
+# whatever interim HTTP-only config the box was serving before, which is
+# not tracked here. See docs/runbooks/domain-cutover-chaseupside.md.
 #
-# Until then the live server runs an interim HTTP-only config; do not
-# overwrite it with this one.
+# ⚠ MUTUALLY EXCLUSIVE with deploy/nginx/chaseupside.com.conf: both
+# declare the same `$connection_upgrade` map, `riskit_static` cache zone
+# and `backend`/`frontend` upstreams, so enabling both in
+# /etc/nginx/sites-enabled/ fails `nginx -t` with duplicate-object
+# errors.
 #
 # riskittogetthebrisket.org — nginx site config
 # Next.js frontend on :3000, Python backend on :8000

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -83,7 +83,7 @@ for the big picture first.
 
 3. Smoke-test:
    ```
-   curl -s -o /dev/null -w "%{http_code}\n" https://riskittogetthebrisket.org/api/health
+   curl -s -o /dev/null -w "%{http_code}\n" https://chaseupside.com/api/health
    ```
 
 ## How do I add a test?

--- a/docs/PROD-HARDENING.md
+++ b/docs/PROD-HARDENING.md
@@ -14,7 +14,7 @@ Let's Encrypt in front of `dynasty.service` (FastAPI :8000) and
 
 ---
 
-## 1. nginx — `deploy/nginx/riskittogetthebrisket.org.conf`
+## 1. nginx — `deploy/nginx/chaseupside.com.conf`
 
 | Change | Rationale |
 |---|---|
@@ -148,7 +148,7 @@ faults.  So:
 ## 5. Uptime monitoring — `deploy/monitoring/` (new)
 
 `uptime_check.sh` + `riskit-uptime.service`/`.timer` (+ README):
-every 5 minutes probes `https://riskittogetthebrisket.org/api/health`,
+every 5 minutes probes `https://chaseupside.com/api/health`,
 the frontend root, and the local backend port; appends one line per run
 to `/var/log/riskit-uptime.log`.
 
@@ -221,8 +221,8 @@ bash deploy/verify-deploy.sh
 Every step is independently reversible:
 
 - **nginx**: the apply script leaves
-  `/etc/nginx/sites-available/riskittogetthebrisket.org.bak.<timestamp>`.
-  `sudo cp <backup> /etc/nginx/sites-available/riskittogetthebrisket.org
+  `/etc/nginx/sites-available/chaseupside.com.bak.<timestamp>`.
+  `sudo cp <backup> /etc/nginx/sites-available/chaseupside.com
   && sudo nginx -t && sudo systemctl reload nginx`.
 - **Service units**: `git checkout <previous-commit> --
   deploy/systemd/dynasty.service.template

--- a/docs/performance-optimization.md
+++ b/docs/performance-optimization.md
@@ -24,7 +24,7 @@ are elsewhere:
 
 **Deployment note (important):** in production, nginx routes every
 `/api/*` request — including `/api/dynasty-data` — **straight to the
-Python backend** (`deploy/nginx/riskittogetthebrisket.org.conf`), where
+Python backend** (`deploy/nginx/chaseupside.com.conf`), where
 `server.py::get_dynasty_data_alias` → `get_data` already honors the
 caller's `view`/`leagueKey`. The Next.js route at
 `frontend/app/api/dynasty-data/route.js` is therefore **only on the dev

--- a/docs/runbooks/domain-cutover-chaseupside.md
+++ b/docs/runbooks/domain-cutover-chaseupside.md
@@ -1,0 +1,643 @@
+# Domain cutover — `chaseupside.com`
+
+Puts production behind `https://chaseupside.com` with a Let's Encrypt
+certificate. Today the site is served over plain HTTP with **no TLS**,
+so login credentials cross the network in the clear; that is what this
+fixes.
+
+| Tag | Where |
+|---|---|
+| **[VPS]** | shell on the production box, as a user with `sudo` |
+| **[GITHUB]** | github.com → repo → Settings, or the Actions tab |
+| **[LOCAL]** | a shell that is **not** on the VPS — a laptop. Used wherever a check must come from a second vantage point; running it on the box can pass via loopback or NAT hairpin while the public path is broken |
+
+Run the steps in order. Each states its precondition and a checkpoint
+saying what "good" looks like. Paste output back before moving on.
+
+---
+
+## Starting state this runbook assumes
+
+Confirm all four before starting. If any is false, stop — the steps
+below are written against this exact state and not a fresh box.
+
+1. `/etc/nginx/sites-enabled/dynasty` is a **symlink** into
+   `/etc/nginx/sites-available/dynasty`.
+2. That file's `server_name` has already been widened by hand to
+   `169.58.50.224 chaseupside.com www.chaseupside.com`.
+3. `http://chaseupside.com/` therefore already serves the app over
+   plain HTTP.
+4. There is no certificate for `chaseupside.com` yet.
+
+```bash
+ls -l /etc/nginx/sites-enabled/
+grep -n 'server_name' /etc/nginx/sites-available/dynasty
+curl -sS -o /dev/null -w '%{http_code}\n' http://chaseupside.com/api/health
+sudo ls /etc/letsencrypt/live/ 2>/dev/null || echo "(no certs yet)"
+```
+
+> **Checkpoint.** `dynasty` is a symlink; `server_name` lists the IP and
+> both hostnames; the curl returns `200`; no `chaseupside.com` directory
+> under `/etc/letsencrypt/live/`.
+
+### Two PRs, deliberately
+
+`deploy.yml` triggers on **`push` to `main`** — merging *is* deploying.
+That is why the work is split:
+
+* **PR A** (nginx config, this runbook, docs) — safe to merge at any
+  time. Merging it deploys, and that deploy is how the config files
+  reach the box.
+* **PR B** (repoints the uptime probe, alert-email links, Grafana URL,
+  `robots.txt` origin at `https://chaseupside.com`) — **must not merge
+  until the certificate exists**. Merging it early would deploy an
+  uptime probe aimed at a host that cannot answer, and the watchdog
+  would start firing false DOWN alerts during the cutover — exactly
+  when a real alert must not be lost in noise.
+
+---
+
+## Step 0 — [VPS] Record the rollback baseline
+
+**Precondition:** none. Do this first; it is what makes step 12 possible.
+
+```bash
+ls -l /etc/nginx/sites-enabled/
+sudo tar czf "/root/nginx-backup-$(date -u +%Y%m%dT%H%M%SZ).tar.gz" /etc/nginx
+ls -lh /root/nginx-backup-*.tar.gz
+```
+
+> **Checkpoint.** A timestamped tarball exists. Note which site files are
+> enabled — `dynasty` plus possibly Debian's `default`.
+
+---
+
+## Step 0b — [GITHUB] Check `PROD_PUBLIC_URL` **now** (independent of this cutover)
+
+Settings → Secrets and variables → Actions → **Variables** →
+`PROD_PUBLIC_URL`. Just read it; do not change it yet.
+
+This is urgent on its own schedule, not because of the cutover.
+`.github/workflows/intel-refresh.yml` runs on a **cron** and sends
+`Authorization: Bearer ${INTEL_REFRESH_TOKEN}` to whatever host this
+variable names. If it currently holds the lapsed
+`riskittogetthebrisket.org` — which now resolves to a third party — then
+that token is being handed to them on every scheduled run, which is the
+failure that already happened once today.
+
+> **If it names any host we do not control, clear the variable right
+> now.** The workflows fail loudly on an empty value by design; a red
+> workflow is strictly better than a leaked token. Then continue — you
+> will set the real value at step 9.
+
+---
+
+## Step 1 — [LOCAL] Verify DNS for apex **and** `www`
+
+**Precondition:** none.
+
+The domain already answers over HTTP, so the apex clearly resolves. The
+one that has not been proven is `www`, and it matters: the certificate
+requests `www` as a SAN, and Let's Encrypt fails the **whole** issuance
+if any requested name fails validation.
+
+```bash
+dig +short chaseupside.com
+dig +short www.chaseupside.com
+dig +short @1.1.1.1 www.chaseupside.com
+```
+
+> **Checkpoint.** All three print `169.58.50.224`.
+>
+> If `www` prints nothing, either add the DNS record and wait, or drop
+> `www` from the certificate — but decide now, because changing your
+> mind later means re-issuing. To drop it, omit `-d www.chaseupside.com`
+> at step 5 and delete `www.chaseupside.com` from the two `server_name`
+> lines in `chaseupside.com.conf` before step 6.
+
+---
+
+## Step 2 — [GITHUB] Merge PR A
+
+**Precondition:** none.
+
+Merging pushes to `main`, which triggers **Deploy**. That deploy is how
+`deploy/nginx/chaseupside.com.conf` and
+`deploy/nginx/chaseupside-proxy.conf` get onto the box.
+
+PR A touches only nginx config files, docs, and two comment lines in
+`frontend/app/api/*/route.js`. Nothing the running app reads changes.
+The comment change does cause a frontend rebuild, which `deploy.sh`
+performs into a staging directory and swaps atomically — no meaningful
+downtime, but do not be surprised by the rebuild.
+
+> **Checkpoint.** The Deploy workflow is green, and the files are on the
+> box:
+> ```bash
+> ls -l /home/dynasty/trade-calculator/deploy/nginx/chaseupside*.conf
+> ```
+>
+> If Deploy's "Post-deploy smoke test" step is the only thing red, check
+> what `PROD_PUBLIC_URL` points at (step 0b) — that step probes it, and
+> a stale value fails there without affecting the deploy itself.
+
+---
+
+## Step 3 — [VPS] Serve the ACME challenge path
+
+**Precondition:** step 2 green.
+
+We issue with the **webroot** plugin, not `--nginx`. The `--nginx`
+plugin rewrites the installed config in place, and this repo keeps nginx
+config under version control — `deploy/apply_hardening.sh` diffs the
+installed file against the checked-in copy and reinstalls the repo
+version when they differ, which would revert certbot's edits. That
+script is not wired into any workflow and `deploy.sh` does not touch
+nginx, so the risk is **manual-only**: it bites if someone runs
+`apply_hardening.sh` by hand. Webroot sidesteps it by never touching
+nginx config at all.
+
+Create the webroot and the cache directory the new config needs:
+
+```bash
+sudo mkdir -p /var/www/certbot/.well-known/acme-challenge
+sudo mkdir -p /var/cache/nginx
+sudo chown -R www-data:www-data /var/www/certbot
+echo ok | sudo tee /var/www/certbot/.well-known/acme-challenge/ping >/dev/null
+```
+
+The live config proxies `/` to Next.js, so the challenge path would be
+proxied and 404. Add the challenge location to the **live** file. Check
+the anchor first:
+
+```bash
+grep -c 'client_max_body_size 25m;' /etc/nginx/sites-available/dynasty
+```
+
+> **Checkpoint.** Prints `1`. If it prints `0` or more than `1`, stop —
+> insert the location block by hand instead of running the `sed` below.
+
+```bash
+sudo sed -i.bak-acme '/client_max_body_size 25m;/a\
+\
+    location ^~ /.well-known/acme-challenge/ {\
+        root /var/www/certbot;\
+        default_type "text/plain";\
+    }' /etc/nginx/sites-available/dynasty
+
+sed -n '/server_name/,/location \/api\//p' /etc/nginx/sites-available/dynasty
+sudo nginx -t
+```
+
+> **Checkpoint.** The printed excerpt shows the new
+> `location ^~ /.well-known/acme-challenge/` block sitting before
+> `location /api/`, and `nginx -t` prints `test is successful`. A
+> backup of the original is at
+> `/etc/nginx/sites-available/dynasty.bak-acme`.
+>
+> **If `nginx -t` fails, restore and stop:**
+> `sudo cp /etc/nginx/sites-available/dynasty.bak-acme /etc/nginx/sites-available/dynasty`
+
+```bash
+sudo systemctl reload nginx
+```
+
+---
+
+## Step 4 — [LOCAL] Verify the challenge path from outside
+
+**Precondition:** step 3 reloaded cleanly.
+
+Run from a laptop. This is the exact request Let's Encrypt will make.
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://chaseupside.com/.well-known/acme-challenge/ping
+curl -sS http://chaseupside.com/.well-known/acme-challenge/ping
+```
+
+> **Checkpoint.** `200` then `ok`.
+>
+> A `404` means the location did not take effect — re-check step 3. A
+> connection timeout means something upstream of nginx is blocking :80
+> from outside; check the provider's firewall as well as `ufw status`.
+
+---
+
+## Step 5 — [VPS] Issue the certificate
+
+**Precondition:** step 4 checkpoint green.
+
+Dry run first — it exercises the real validation flow without consuming
+the production rate limit (5 failed validations per hostname per hour):
+
+```bash
+sudo certbot certonly --webroot -w /var/www/certbot \
+  -d chaseupside.com -d www.chaseupside.com \
+  --dry-run
+```
+
+> **Checkpoint.** `The dry run was successful.` If it fails, fix the
+> cause and re-run the dry run — do not "try the real one and see".
+
+Issue for real. Replace `you@example.com` with the operator's address
+(it receives expiry warnings):
+
+```bash
+sudo certbot certonly --webroot -w /var/www/certbot \
+  -d chaseupside.com -d www.chaseupside.com \
+  --email you@example.com \
+  --agree-tos --no-eff-email \
+  --deploy-hook "systemctl reload nginx"
+```
+
+`--deploy-hook` matters: with webroot, certbot knows nothing about
+nginx, so without it a renewed certificate would sit on disk unused and
+the site would eventually serve an expired one. The hook is recorded in
+the renewal config and runs on every future renewal.
+
+```bash
+sudo ls -l /etc/letsencrypt/live/chaseupside.com/
+ls -l /etc/letsencrypt/options-ssl-nginx.conf /etc/letsencrypt/ssl-dhparams.pem
+```
+
+> **Checkpoint.** `fullchain.pem` and `privkey.pem` exist, **and** so do
+> the two shared files on the second line — the new config `include`s
+> the first and references the second, so a missing one fails `nginx -t`
+> at step 6. They may be absent on a webroot-only box. Create them with:
+> ```bash
+> sudo curl -fsS -o /etc/letsencrypt/options-ssl-nginx.conf \
+>   https://raw.githubusercontent.com/certbot/certbot/main/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf
+> sudo openssl dhparam -out /etc/letsencrypt/ssl-dhparams.pem 2048
+> ```
+> (the dhparam generation takes a minute or two).
+
+---
+
+## Step 6 — [VPS] Swap in the new config
+
+**Precondition:** step 5 checkpoint green — the certificate exists.
+
+The new config **replaces** the `dynasty` site rather than joining it.
+Both declare `upstream dynasty_backend` / `dynasty_frontend`, and both
+now claim `chaseupside.com`, so having both enabled fails `nginx -t`
+with a duplicate-upstream error. That is intentional: it fails loudly at
+test time instead of silently letting two server blocks fight over a
+hostname. Keep the swap atomic.
+
+```bash
+APPDIR=/home/dynasty/trade-calculator
+
+sudo mkdir -p /etc/nginx/snippets
+sudo install -m 0644 "$APPDIR/deploy/nginx/chaseupside-proxy.conf" \
+     /etc/nginx/snippets/chaseupside-proxy.conf
+sudo install -m 0644 "$APPDIR/deploy/nginx/chaseupside.com.conf" \
+     /etc/nginx/sites-available/chaseupside.com
+
+# Atomic swap: dynasty out, chaseupside.com in.
+sudo rm -f /etc/nginx/sites-enabled/dynasty
+sudo ln -sf /etc/nginx/sites-available/chaseupside.com /etc/nginx/sites-enabled/
+
+ls -l /etc/nginx/sites-enabled/
+sudo nginx -t
+```
+
+> **Checkpoint.** `sites-enabled/` lists `chaseupside.com` and **not**
+> `dynasty`, and `nginx -t` prints `test is successful`.
+>
+> **If `nginx -t` fails, do not reload.** Put the old symlink straight
+> back and paste the error:
+> ```bash
+> sudo rm -f /etc/nginx/sites-enabled/chaseupside.com
+> sudo ln -sf /etc/nginx/sites-available/dynasty /etc/nginx/sites-enabled/
+> sudo nginx -t && sudo systemctl reload nginx
+> ```
+
+```bash
+sudo systemctl reload nginx
+```
+
+`/etc/nginx/sites-available/dynasty` stays on disk. Removing the symlink
+disables it; deleting the file would remove the rollback target.
+
+---
+
+## Step 7 — [LOCAL] Verify TLS, the redirect, and the bare IP
+
+**Precondition:** step 6 reloaded cleanly. Run all of this from a laptop.
+
+Port 80 on the domain must redirect:
+
+```bash
+curl -sI http://chaseupside.com/ | head -5
+curl -sI http://www.chaseupside.com/ | head -5
+```
+
+> **Checkpoint.** `301` with `Location: https://chaseupside.com/`
+> (respectively `https://www.…`).
+
+HTTPS must answer with a valid chain:
+
+```bash
+curl -sI https://chaseupside.com/ | head -8
+curl -sS https://chaseupside.com/api/health | head -c 400; echo
+```
+
+> **Checkpoint.** `HTTP/2 200`, a
+> `strict-transport-security: max-age=31536000` header, and a health
+> body with `"status":"ok"`. `curl` validates the chain by default, so a
+> cert error here is a hard failure, not a warning.
+
+**The bare IP must still work over plain HTTP** — monitoring and the
+alert-email links still point at it until PR B deploys:
+
+```bash
+curl -sI http://169.58.50.224/ | head -3
+curl -sS -o /dev/null -w '%{http_code}\n' http://169.58.50.224/api/health
+```
+
+> **Checkpoint.** `200` on both, and **no `301`**. If the IP redirects to
+> HTTPS, the transitional IP server block is missing or not matching —
+> every monitoring probe would fail the TLS handshake against a
+> certificate that cannot cover an IP address. Stop and fix before
+> continuing.
+
+Certificate contents:
+
+```bash
+echo | openssl s_client -connect chaseupside.com:443 -servername chaseupside.com 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates -ext subjectAltName
+```
+
+> **Checkpoint.** `notAfter` ~90 days out, issuer Let's Encrypt, and
+> `subjectAltName` lists **both** names (unless you deliberately dropped
+> `www` at step 1).
+
+Spot-check the routes with special handling, so a dropped location block
+surfaces now rather than in a user report:
+
+```bash
+for p in / /api/health /api/public/league /favicon.ico; do
+  printf '%-24s %s\n' "$p" "$(curl -sS -o /dev/null -w '%{http_code}' --max-time 45 "https://chaseupside.com$p")"
+done
+```
+
+> **Checkpoint.** All `200`. `/api/public/league` can be slow on a cold
+> snapshot; the 45s timeout covers it.
+
+Confirm a `/_next/static/` asset still serves (this location is new
+relative to the live config, so it is worth one look):
+
+```bash
+ASSET=$(curl -sS https://chaseupside.com/ | grep -o '/_next/static/[^"]*\.js' | head -1)
+echo "asset: $ASSET"
+curl -sI "https://chaseupside.com${ASSET}" | head -6
+```
+
+> **Checkpoint.** `200` with `cache-control: public, max-age=31536000,
+> immutable` passed through from Next.js.
+
+---
+
+## Step 8 — [VPS] Confirm auto-renewal is armed
+
+**Precondition:** step 7 green.
+
+```bash
+systemctl list-timers | grep -i certbot
+```
+
+> **Checkpoint.** A `certbot.timer` line with a `NEXT` time. If nothing
+> prints:
+> ```bash
+> sudo systemctl enable --now certbot.timer
+> systemctl list-timers | grep -i certbot
+> ```
+> Some images use a cron entry instead — check `ls -l /etc/cron.d/certbot`.
+> Either is fine, but one must exist.
+
+```bash
+sudo certbot renew --dry-run
+sudo grep -nE 'renew_hook|webroot_path' /etc/letsencrypt/renewal/chaseupside.com.conf
+```
+
+> **Checkpoint.** `Congratulations, all simulated renewals succeeded`
+> naming `chaseupside.com`, plus
+> `renew_hook = systemctl reload nginx` and
+> `webroot_path = /var/www/certbot`.
+>
+> This is the step that proves renewal works through the **new** config,
+> not just the temporary ACME location the cert was issued under. If
+> `renew_hook` is missing, add it under `[renewalparams]` and re-run the
+> dry run.
+
+---
+
+## Step 9 — [GITHUB] Set `PROD_PUBLIC_URL`
+
+**Precondition:** step 7 green — `https://chaseupside.com/api/health`
+returns 200.
+
+Settings → Secrets and variables → Actions → **Variables**. Set to
+exactly:
+
+```
+https://chaseupside.com
+```
+
+No trailing slash. Six workflows read this — `deploy.yml`,
+`health-check.yml`, `intel-refresh.yml`, `prod-e2e-smoke.yml`,
+`public-league-warmup.yml`, `smoke-test.yml` — and `intel-refresh.yml`
+sends a bearer token to it (see step 0b). Confirm the value resolves to
+`169.58.50.224` before saving.
+
+Verify with a read-only run: Actions → **Health Check** → *Run workflow*.
+
+> **Checkpoint.** Green, and the log shows it probing
+> `https://chaseupside.com`.
+
+---
+
+## Step 10 — [VPS] Update `.env`
+
+**Precondition:** step 7 green — HTTPS actually works.
+
+Edit `/home/dynasty/trade-calculator/.env`.
+
+**10a. `JASON_AUTH_COOKIE_SECURE` — the one that closes the credential
+exposure.**
+
+```bash
+sudo grep '^JASON_AUTH_COOKIE_SECURE=' /home/dynasty/trade-calculator/.env
+```
+
+(prints one non-secret boolean line, not the file). Set it to:
+
+```
+JASON_AUTH_COOKIE_SECURE=true
+```
+
+`server.py` sets the session cookie with `secure=JASON_AUTH_COOKIE_SECURE`.
+A `Secure` cookie is not stored by browsers over plain HTTP, so while
+the site was HTTP-only this had to be `false` for login to work at all —
+which is exactly why credentials have been travelling in the clear.
+
+> Set this **only after** step 7 passed. On plain HTTP it locks everyone
+> out of login: the browser silently discards the cookie and every
+> request comes back unauthenticated.
+
+No `domain` attribute is set on the cookie, so it is host-only for
+`chaseupside.com` — correct, nothing to change. `SameSite=lax` is
+correct for a same-origin app; leave it.
+
+**10b. `PUBLIC_SITE_URL`.**
+
+```
+PUBLIC_SITE_URL=https://chaseupside.com
+```
+
+Use `PUBLIC_SITE_URL`, **not** `NEXT_PUBLIC_SITE_URL`, even though
+`robots.js` / `sitemap.js` check the `NEXT_PUBLIC_` name first.
+`NEXT_PUBLIC_*` is inlined by Next.js at **build** time and
+`deploy/deploy.sh` runs `npm run build` without sourcing `.env`, so a
+value set here would inline as `undefined`. `PUBLIC_SITE_URL` is read
+from the process environment at runtime, which the frontend systemd unit
+supplies via `EnvironmentFile=-…/.env`.
+
+**10c. `UPTIME_CHECK_URL`** — only if the line exists:
+
+```bash
+sudo grep '^UPTIME_CHECK_URL=' /home/dynasty/trade-calculator/.env
+```
+
+```
+UPTIME_CHECK_URL=https://chaseupside.com/api/health
+```
+
+If absent, leave it — PR B updates the code default.
+
+```bash
+sudo systemctl restart dynasty dynasty-frontend
+```
+
+> **Checkpoint.** Log in through a browser at `https://chaseupside.com/`
+> and confirm the session survives a page reload. That is the real test
+> of 10a. If you are bounced back to the login screen, revert 10a to
+> `false`, restart, and investigate before continuing.
+
+---
+
+## Step 11 — [GITHUB] Merge PR B
+
+**Precondition:** steps 7, 9 and 10 all green.
+
+PR B repoints the uptime probe, the alert-email links, the Grafana
+dashboard JSON and the `robots.txt` / `sitemap.xml` origin at
+`https://chaseupside.com`. Merging deploys it.
+
+> **Checkpoint.** Deploy is green, including "Post-deploy smoke test"
+> and "Validate live data contract" — both now exercising the new
+> domain.
+
+```bash
+curl -sS https://chaseupside.com/robots.txt
+```
+
+> **Checkpoint.** The `Sitemap:` line reads
+> `https://chaseupside.com/sitemap.xml`.
+
+```bash
+systemctl cat riskit-uptime.service | grep -i 'SITE_URL' || echo "(no SITE_URL override — code default applies)"
+sudo systemctl start riskit-uptime.service
+sudo tail -n 5 /var/log/riskit-uptime.log
+```
+
+> **Checkpoint.** The probe line shows `https://chaseupside.com` targets
+> returning `200`. If a drop-in pins `SITE_URL` to the old value it wins
+> over the code default — remove it with
+> `sudo systemctl edit riskit-uptime.service`.
+
+---
+
+## Step 12 — Rollback
+
+**12a. [VPS] nginx will not validate, or the site is down.**
+
+```bash
+sudo rm -f /etc/nginx/sites-enabled/chaseupside.com
+sudo ln -sf /etc/nginx/sites-available/dynasty /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+curl -sS -o /dev/null -w '%{http_code}\n' http://169.58.50.224/api/health
+```
+
+> Expect `200`. The site is back exactly as it was, including
+> `http://chaseupside.com` over plain HTTP, because the `dynasty` file
+> still carries the widened `server_name`.
+
+If the config tree itself is in a bad state, restore the tarball from
+step 0:
+
+```bash
+sudo tar xzf /root/nginx-backup-<TIMESTAMP>.tar.gz -C /
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+`deploy/nginx/riskittogetthebrisket.org.conf` is **not** a rollback
+target — we do not own that domain and its `ssl_certificate` paths do
+not exist, so enabling it fails `nginx -t`. It is retained only as the
+historical reference copy.
+
+The issued certificate does no harm after a rollback; leave it and reuse
+it on the next attempt. To remove it:
+`sudo certbot delete --cert-name chaseupside.com`.
+
+**If you already completed step 10a, undo it.** A rollback puts the site
+on plain HTTP, and `JASON_AUTH_COOKIE_SECURE=true` there means browsers
+discard the session cookie and nobody can log in — with a symptom
+(bounced to login, no error) that looks nothing like an nginx rollback:
+
+```bash
+sudo sed -i 's/^JASON_AUTH_COOKIE_SECURE=true$/JASON_AUTH_COOKIE_SECURE=false/' \
+     /home/dynasty/trade-calculator/.env
+sudo grep '^JASON_AUTH_COOKIE_SECURE=' /home/dynasty/trade-calculator/.env
+sudo systemctl restart dynasty
+```
+
+> Set it back to `true` the moment HTTPS works again — it is the setting
+> that has been exposing credentials.
+
+**12b. [GITHUB] A deploy is bad.**
+
+Actions → **Deploy** → *Run workflow* with `deploy_ref` set to the last
+known-good commit and `allow_non_fast_forward=true` (required — the
+workflow blocks backwards deploys by default). Or run
+`deploy/rollback.sh` on the box.
+
+**12c. [GITHUB] Abandoning the cutover.**
+
+Clear `PROD_PUBLIC_URL` rather than pointing it back at the old domain.
+The workflows fail loudly on an empty value; that is intended, and far
+safer than sending a bearer token to a host we do not control.
+
+---
+
+## After the cutover
+
+- **Remove the transitional bare-IP server block** from
+  `chaseupside.com.conf` once nothing calls the IP any more. Check with
+  `grep -rn '169\.58\.50\.224'` on the repo and by looking for
+  `Host: 169.58.50.224` in `/var/log/nginx/access.log`. Removing it
+  earlier breaks monitoring; leaving it forever keeps an unencrypted
+  entrance open.
+- **Grafana**: the dashboard JSON is updated by PR B, but a dashboard
+  already imported keeps its own saved `metrics_url`. Update it in
+  Dashboard settings → Variables, or re-import.
+- **Remove the temporary ACME location** from
+  `/etc/nginx/sites-available/dynasty` if you ever re-enable that file —
+  the new config has its own. The pre-edit backup is at
+  `dynasty.bak-acme`.
+- **HSTS `includeSubDomains` / preload**: deliberately not enabled. Add
+  only after every subdomain of `chaseupside.com` serves valid TLS —
+  mistakes lock browsers out for the full `max-age` (one year).
+- **Product naming**: the app still says "Risk It To Get The Brisket" in
+  titles, the PWA manifest, OG cards and alert copy. Inventoried in
+  PR A's description; a separate change.

--- a/frontend/app/api/dynasty-data/route.js
+++ b/frontend/app/api/dynasty-data/route.js
@@ -17,7 +17,7 @@ const BACKEND_ORIGIN = (() => {
 
 // NOTE ON DEPLOYMENT SCOPE: in production, nginx routes every ``/api/*``
 // request (including ``/api/dynasty-data``) straight to the Python
-// backend — see ``deploy/nginx/riskittogetthebrisket.org.conf`` — where
+// backend — see ``deploy/nginx/chaseupside.com.conf`` — where
 // ``server.py::get_dynasty_data_alias`` already honors the caller's
 // ``view``/``leagueKey``.  This Next route only handles the dev flow
 // (no nginx in front) and any Next-fronted deployment.  The improvements

--- a/frontend/app/api/news/route.js
+++ b/frontend/app/api/news/route.js
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 //
 // DEPLOYMENT SCOPE: in production, nginx routes every ``/api/*``
 // request straight to FastAPI (see
-// ``deploy/nginx/riskittogetthebrisket.org.conf``), so this route is
+// ``deploy/nginx/chaseupside.com.conf``), so this route is
 // never hit there.  It exists for the dev flow (Next dev server on
 // port 3000, no nginx in front) and any Next-fronted deployment —
 // without it, the relative ``/api/news`` fetch in

--- a/frontend/app/robots.js
+++ b/frontend/app/robots.js
@@ -6,7 +6,7 @@ function _origin() {
   return (
     process.env.NEXT_PUBLIC_SITE_URL ||
     process.env.PUBLIC_SITE_URL ||
-    "http://169.58.50.224"
+    "https://chaseupside.com"
   ).replace(/\/$/, "");
 }
 

--- a/frontend/app/sitemap.js
+++ b/frontend/app/sitemap.js
@@ -20,7 +20,7 @@ function _origin() {
   return (
     process.env.NEXT_PUBLIC_SITE_URL ||
     process.env.PUBLIC_SITE_URL ||
-    "http://169.58.50.224"
+    "https://chaseupside.com"
   ).replace(/\/$/, "");
 }
 

--- a/server.py
+++ b/server.py
@@ -141,7 +141,7 @@ SIGNAL_ALERT_CRON_TOKEN = os.getenv("SIGNAL_ALERT_CRON_TOKEN", "").strip()
 UPTIME_CHECK_ENABLED = _env_bool("UPTIME_CHECK_ENABLED", True)
 UPTIME_CHECK_URL = os.getenv(
     "UPTIME_CHECK_URL",
-    "https://riskittogetthebrisket.org/api/health",
+    "https://chaseupside.com/api/health",
 ).strip()
 UPTIME_CHECK_INTERVAL_SEC = int(os.getenv("UPTIME_CHECK_INTERVAL_SEC", "300"))
 UPTIME_CHECK_TIMEOUT_SEC = float(os.getenv("UPTIME_CHECK_TIMEOUT_SEC", "5"))

--- a/src/api/ops_alerts.py
+++ b/src/api/ops_alerts.py
@@ -200,8 +200,8 @@ def format_ops_email(alerts: list[OpsAlert]) -> tuple[str, str]:
             lines.append(f"  • {a.title}")
             lines.append(f"    {a.detail}")
         lines.append("")
-    lines.append("Status: http://169.58.50.224/api/status")
-    lines.append("Health: http://169.58.50.224/api/health")
+    lines.append("Status: https://chaseupside.com/api/status")
+    lines.append("Health: https://chaseupside.com/api/health")
     return subject, "\n".join(lines)
 
 

--- a/src/api/signal_alerts.py
+++ b/src/api/signal_alerts.py
@@ -252,7 +252,7 @@ def format_alert_email(
         if t.get("reason"):
             lines.append(f"    {t['reason']}")
     lines.append("")
-    lines.append("See the terminal:  http://169.58.50.224/")
+    lines.append("See the terminal:  https://chaseupside.com/")
     lines.append("")
     lines.append("To stop receiving these, sign in and dismiss the signal — it'll be")
     lines.append("suppressed for 7 days.  You can change the alert cadence on /settings.")

--- a/src/api/source_health_alerts.py
+++ b/src/api/source_health_alerts.py
@@ -366,5 +366,5 @@ def _format_body(alerts: list[StaleSourceAlert]) -> str:
         for a in recovered:
             lines.append(f"  • {a.source}: back")
         lines.append("")
-    lines.append("See http://169.58.50.224/tools/source-health")
+    lines.append("See https://chaseupside.com/tools/source-health")
     return "\n".join(lines)

--- a/tools/rankings_diff.py
+++ b/tools/rankings_diff.py
@@ -11,7 +11,7 @@ Usage
 
     # Also accepts URL arguments if auth is available:
     python3 tools/rankings_diff.py \\
-        https://riskittogetthebrisket.org/api/data?view=delta \\
+        https://chaseupside.com/api/data?view=delta \\
         https://staging.riskit/api/data?view=delta \\
         --cookie jason_session=...
 


### PR DESCRIPTION
Second half of the `chaseupside.com` cutover. **Stacked on #570** — base is that branch, so this diff shows only the 8 files unique to B. GitHub retargets this to `main` automatically once #570 merges.

## ⛔ Do not merge until the certificate exists

`deploy.yml` triggers on **`push` to `main`**, so merging *is* deploying. Everything in this PR is a value a running process reads.

The two that force the split:

| File | What it drives | If deployed pre-cert |
|---|---|---|
| `deploy/monitoring/uptime_check.sh` | `SITE_URL` default → `riskit-uptime.timer`, every 5 min | probes a host with no TLS listener → **false DOWN alerts** |
| `server.py` | `UPTIME_CHECK_URL` default → in-process watchdog | same, plus alert emails on the `UPTIME_ALERT_FAIL_THRESHOLD` |

False DOWN alerts during a cutover are worse than merely annoying: the cutover is exactly the window where a *real* alert must not be lost in noise. That is the whole reason this is not one PR.

The rest are lower-stakes but belong to the same commit for coherence — they are all "where does a running process say the site lives":

- `src/api/ops_alerts.py`, `src/api/signal_alerts.py`, `src/api/source_health_alerts.py` — links in outbound alert email/push bodies. Pre-cert these would be links that fail to load.
- `frontend/app/robots.js`, `frontend/app/sitemap.js` — the origin advertised to crawlers. `robots.txt` is statically generated at build, so the hardcoded fallback changed here is the effective value (see #570 on why `PUBLIC_SITE_URL` and not `NEXT_PUBLIC_SITE_URL`).
- `deploy/grafana/public-league-dashboard.json` — the metrics endpoint. Note a dashboard **already imported** into Grafana keeps its own saved copy of `metrics_url`; this file change does not reach it. Update in place or re-import.

## Split rule

**Machine-read at runtime → here. Human-read → #570.** That is why prose that also mentions the new origin (`README.md`, `docs/ONBOARDING.md`, `deploy/PRODUCTION_BOOTSTRAP.md`, `.env.example`) stayed in A: a stale sentence in a doc costs a moment's confusion, a stale value in the uptime probe costs a pager. Keeping whole files on one side also avoids splitting any file across both PRs, so there is nothing to reconcile between them.

## When to merge

Step 11 of `docs/runbooks/domain-cutover-chaseupside.md` — after:

1. the certificate is issued (step 5),
2. `curl -sI https://chaseupside.com/` returns 200 with a valid chain (step 7),
3. `PROD_PUBLIC_URL` is set (step 9),
4. `.env` is updated and services restarted (step 10).

## Verification

- `python -m ruff format --check .` → `538 files already formatted` (ruff 0.6.9, matching CI).
- The full suite passed on the combined A+B tree before the split: `4227 passed, 25 skipped, 366 subtests passed`. Every change here is a one-line string literal; no logic is touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_