### PR TITLE
GET /api/gameplan: the first caller the roster intelligence engine has

### DIFF
--- a/server.py
+++ b/server.py
@@ -67,6 +67,7 @@ from src.api.data_contract import (
     normalize_tep_native_multiplier,
     validate_api_data_contract,
 )
+from src.api import gameplan as _gameplan
 from src.api import guest_passes as _guest_passes
 from src.api import rank_history as _rank_history
 from src.api import source_history as _source_history
@@ -4821,6 +4822,135 @@ async def post_waiver_faab_recommend(request: Request):
     rec["resolvedDropValue"] = drop_value
     rec["resolvedAddPosition"] = add_position
     return JSONResponse(content=rec)
+
+
+@app.get("/api/gameplan")
+async def get_gameplan(request: Request):
+    """Roster intelligence for one team: needs, window, targets, partners.
+
+    The API surface over ``src/roster_intel/`` — ``analyze_roster``,
+    the per-position profiles, the five-state competitive window, both
+    target engines, the partner model, and (on request) the Trade
+    Package Generator's Pareto frontier.  Assembly lives in
+    ``src/api/gameplan.py``; this is the transport shell.
+
+    Query parameters::
+
+        leagueKey   optional — standard resolver (explicit key, else the
+                    user's activeLeagueKey, else the registry default)
+        team        optional — ownerId. Defaults to the session's
+                    Sleeper user id, then the league's default_team_map.
+        partner     optional — ownerId from the ``partners`` list. Its
+                    PRESENCE is what turns the package generator on:
+                    packages are per-counterparty and running all
+                    eleven costs ~1.6 s.
+
+    LEAGUE-SCOPED.  Rosters, starter slots, replacement levels, lineup
+    solves, partner fit and packages all resolve through ``leagueKey``;
+    only player ages and market prices follow the scoring profile.  So
+    this endpoint 503s ``data_not_ready`` when the loaded contract is
+    for a different league, matching ``/api/terminal`` and
+    ``/api/trade/*``.
+
+    Cost is real and is reported rather than hidden: a cold league
+    build is ~1.35 s and a cold team view ~1.9 s on the 12-team league.
+    Both are cached on a source stamp (snapshot mtimes + the contract's
+    scrape timestamp) and run in a threadpool; every response stamps
+    ``timing`` so the cost stays measurable in production.
+    """
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        # Echo the requested key so a caller can tell which league the
+        # error is about, the way the other league-scoped routes do.
+        body = {"error": err.code, "message": err.message}
+        requested = (request.query_params.get("leagueKey") or "").strip()
+        if requested:
+            body["leagueKey"] = requested
+        return JSONResponse(status_code=err.status, content=body)
+
+    contract = latest_contract_data
+    if not contract:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": "No data available yet. First scrape may still be running.",
+                "leagueKey": league_cfg.key,
+            },
+        )
+
+    loaded_meta = (contract.get("meta") or {}) if isinstance(contract, dict) else {}
+    loaded_league = loaded_meta.get("leagueKey")
+    if loaded_league and loaded_league != league_cfg.key:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": (
+                    f"No data loaded for league {league_cfg.key!r} yet "
+                    f"(server holds {loaded_league!r})."
+                ),
+                "leagueKey": league_cfg.key,
+            },
+        )
+
+    params = request.query_params
+    owner_id = (params.get("team") or params.get("ownerId") or "").strip()
+    if not owner_id:
+        session = _get_auth_session(request) or {}
+        owner_id = str(session.get("sleeper_user_id") or "").strip()
+        if not owner_id:
+            username = str(session.get("username") or "").strip().lower()
+            mapped = (league_cfg.default_team_map or {}).get(username) or {}
+            owner_id = str(mapped.get("ownerId") or "").strip()
+    if not owner_id:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "team_required",
+                "message": (
+                    "Pass ?team=<ownerId>. It could not be inferred: this session "
+                    "carries no Sleeper user id and the league has no default team "
+                    "mapping for it."
+                ),
+                "leagueKey": league_cfg.key,
+            },
+        )
+
+    partner_owner_id = (params.get("partner") or "").strip() or None
+
+    try:
+        payload = await run_in_threadpool(
+            _gameplan.get_team_gameplan,
+            league_cfg.key,
+            league_cfg.scoring_profile,
+            contract,
+            owner_id,
+            partner_owner_id=partner_owner_id,
+        )
+    except _gameplan.GameplanUnavailable as exc:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "reason": exc.reason,
+                "message": exc.detail,
+                "leagueKey": league_cfg.key,
+            },
+        )
+    except _gameplan.TeamNotInLeague:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error": "team_not_found",
+                "message": f"No roster for owner {owner_id!r} in league {league_cfg.key!r}.",
+                "leagueKey": league_cfg.key,
+            },
+        )
+
+    # Private roster intelligence — never cached by a shared proxy.
+    return JSONResponse(content=payload, headers={"Cache-Control": "no-store"})
 
 
 @app.post("/api/trade/suggestions")

--- a/src/api/gameplan.py
+++ b/src/api/gameplan.py
@@ -1,0 +1,1097 @@
+"""``GET /api/gameplan`` — the API surface over the WS-J roster engines.
+
+Everything in ``src/roster_intel/`` merged with no caller.  ``git grep
+roster_intel`` outside its own package and tests returned zero matches:
+``analyze_roster``, the per-position profiles, the five-state
+competitive window, the target engines, the partner model and the
+Trade Package Generator were all reachable only from a Python REPL.
+This module is the wiring, and the route in ``server.py`` is a thin
+shell over it.
+
+What is league-scoped and what is not
+─────────────────────────────────────
+CLAUDE.md's central rule — *scoring profile controls rankings, league
+key controls context* — decides every input here, and getting it
+backwards is the architectural error that rule exists to prevent.
+
+Resolved by **leagueKey** (one pipeline per league, never collapsed):
+
+* rosters — ``data/ros/team_strength/<key>.json``'s ``fullRoster``
+* starter slots — the registry's per-league ``rosterSettings.starters``
+* replacement levels and scarcity — measured from **this league's own
+  12 rosters**; the league IS its own replacement market
+* the exact lineup solves, the competitive window, partner fit,
+  packages
+* playoff / championship odds — ``data/ros/sims/<key>_playoff.json``
+
+Resolved by **scoring profile** (shared across same-scoring leagues):
+
+* player ages and market site values, read off the live ``/api/data``
+  contract's ``playersArray``.  These are player metadata and rankings,
+  so two leagues on one scoring profile share them and neither one
+  needs its own copy.
+
+Two scales that must never be mixed
+───────────────────────────────────
+``rosValue`` (0-100, rest-of-season points) and ``canonicalSiteValues``
+(0-9999, dynasty market) are different currencies with no validated
+conversion between them.
+
+The target engines take a ``market_values`` / ``market_prices`` map and
+compute ``(ros_value - price) / price`` against it.  Feeding them the
+contract's 0-9999 numbers produces an edge of about -0.99 for every
+player alive — a dead signal that still looks computed.  So those
+inputs are **deliberately not supplied**, the engines report the edge
+as unmeasured, and :func:`_coverage` says so.  ``packages`` is the one
+consumer that does take site values, and it is safe because
+``value_package`` compares market to market and the engine keeps
+lineup points on a separate frontier axis rather than blending them.
+
+Cost, measured not guessed
+──────────────────────────
+On the real 12-team league (57-man rosters, 21 starter slots), one
+core at 2026-07-27::
+
+    measure_endogenous_starters (12 teams)       89 ms
+    compute_replacement_levels (reusing it)       2 ms
+    compute_scarcity                              1 ms
+    optimal_score x12                            52 ms
+    analyze_roster x12                        1,195 ms   <- dominant
+    assess_partners (11 partners)                 0.5 ms
+    rank_target_positions (97 candidates)       277 ms
+    rank_target_players (97 candidates)         271 ms
+    generate_packages (8x8 assets)              146 ms
+
+``analyze_roster`` re-solves the lineup repeatedly — once per position
+for the marginals, once per starter for the absence impacts — so it is
+~91 ms per roster and there is no cheap version of it.  A cold
+league-wide build is therefore ~1.35 s and a cold team view ~1.9 s,
+which is far too slow to run per request on the event loop.
+
+Two caches, both keyed on a **source stamp** rather than a clock:
+:data:`_BUNDLE_CACHE` holds the league-wide build, :data:`_TEAM_CACHE`
+the per-team derivation.  The stamp is the identity of the inputs
+(snapshot mtimes + the contract's scrape timestamp), so a refresh
+invalidates immediately and a quiet hour never serves something newer
+than it claims.  Warm requests are dictionary lookups.  The route runs
+cold builds in a threadpool and stamps ``timing.computeMs`` /
+``timing.cacheHit`` on every response, so the cost stays measurable in
+production instead of being re-guessed.
+
+Honesty stamps are load-bearing
+───────────────────────────────
+Several fields exist because an earlier version presented something as
+stronger than it was.  This module **passes engine ``to_dict()``
+output through unchanged** — it never rebuilds a payload field by
+field, because that is how a caveat gets dropped in a refactor.  In
+particular:
+
+* ``acceptancePlausibility`` ships with the engine's
+  ``acceptanceCaveat`` attached.  It is never renamed to anything
+  containing "probability": rejections are never observed, so no
+  acceptance rate is identifiable from this data.
+* ``winNowWeight`` is ``null`` when candidate ages are missing, and
+  :data:`FIELD_POLICY` declares it non-sortable and non-filterable —
+  its nulls cluster on positions whose obtainable upgrades happen to
+  be un-aged, so ordering by it reorders by data availability.
+* Confidence intervals stay ``null`` rather than collapsing to zero
+  width; zero width reads as certainty.
+* The Pareto frontier is returned wide.  ``value_efficiency`` and
+  ``acceptance_plausibility`` are anti-correlated by construction and
+  no exchange rate exists between market points, lineup points and
+  plausibility, so no blended score is invented to shorten it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.league_intel.cross_market import DEFAULT_GATE_PCT
+from src.league_intel.replacement import (
+    PositionReplacement,
+    ScarcityComponents,
+    compute_replacement_levels,
+    compute_scarcity,
+    measure_endogenous_starters,
+    normalize_base_position,
+)
+from src.roster_intel import packages as _packages
+from src.roster_intel import partner as _partner
+from src.roster_intel import targets as _targets
+from src.roster_intel.engine import RosterIntel, analyze_roster
+from src.roster_intel.marginal import optimal_score, to_roster_players
+from src.ros.lineup import RosterPlayer, load_league_starter_slots
+from src.ros.team_strength import load_team_strength_snapshot
+
+__all__ = [
+    "FIELD_POLICY",
+    "GAMEPLAN_CONTRACT_VERSION",
+    "GameplanUnavailable",
+    "TeamNotInLeague",
+    "LeagueBundle",
+    "LeagueInputs",
+    "TeamInput",
+    "build_gameplan",
+    "build_league_bundle",
+    "get_league_bundle",
+    "invalidate_cache",
+    "load_league_inputs",
+]
+
+GAMEPLAN_CONTRACT_VERSION = "2026-07-27.v1"
+"""Versioned the way ``/api/data`` is.  Bump on any shape change."""
+
+
+# ── Caller-side pre-filters ──────────────────────────────────────────
+# The engines delegate candidate selection to the caller on purpose
+# ("pre-filtering this to genuine surplus is the caller's job and is the
+# single biggest lever on both quality and cost").  These are that
+# choice, made explicitly and stamped into ``coverage.candidatePolicy``
+# rather than left implicit.
+
+MAX_CANDIDATES_PER_POSITION = 12
+"""Cap on acquirable candidates offered to the target engines per
+position, taken in descending ``rosValue``.
+
+A cost guard, and a lossy one: value order is not gain order.  Adding a
+higher-valued player at the same position can never yield a *smaller*
+lineup gain when the two share slot eligibility — but a hybrid IDP
+(``DL`` with ``fantasy_positions=["DL","LB"]``) can out-gain a
+higher-valued pure ``DL`` by filling a slot the other cannot.  So the
+cap can hide a genuinely better target, and that is reported instead of
+being presented as an exhaustive search.
+"""
+
+MAX_PACKAGE_ASSETS_PER_SIDE = 8
+"""Assets offered to the package generator per side.
+
+Measured on the real league: 6x6 costs 81 ms, 8x8 costs 146 ms, 12x12
+costs 513 ms.  Eight keeps a partner view inside a normal request
+budget while still reaching stage 2 and 3 expansion.
+"""
+
+
+class GameplanUnavailable(Exception):
+    """Raised when the inputs for a league are not on disk.
+
+    Carries a machine-readable ``reason`` so the route can answer with
+    the documented ``data_not_ready`` contract instead of a 500.
+    """
+
+    def __init__(self, reason: str, detail: str):
+        self.reason = reason
+        self.detail = detail
+        super().__init__(detail)
+
+
+class TeamNotInLeague(Exception):
+    """The requested owner has no roster in this league.
+
+    A dedicated type rather than ``KeyError``: the route has to turn
+    "unknown team" into a 404, and catching ``KeyError`` there would
+    also swallow one raised deep inside an engine and report a genuine
+    bug as a missing team.
+    """
+
+    def __init__(self, owner_id: str):
+        self.owner_id = owner_id
+        super().__init__(owner_id)
+
+
+# ── Inputs ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TeamInput:
+    """One roster, in both representations the engines need."""
+
+    owner_id: str
+    team_name: str
+    rows: tuple[Mapping[str, Any], ...]
+    pool: tuple[RosterPlayer, ...]
+
+
+@dataclass(frozen=True)
+class LeagueInputs:
+    """Everything loaded from disk for one league, before any solving."""
+
+    league_key: str
+    scoring_profile: str
+    slots: tuple[str, ...]
+    teams: tuple[TeamInput, ...]
+    #: ``{sleeper_player_id: {"age": float}}`` — scoring-profile scoped.
+    player_meta: Mapping[str, Mapping[str, float]]
+    #: ``{sleeper_player_id: {site: value}}`` on the 0-9999 dynasty
+    #: market — scoring-profile scoped, and NEVER mixed with rosValue.
+    site_values: Mapping[str, Mapping[str, float]]
+    #: ``simulate_playoff_odds(...)["playoffOdds"]`` rows, or None.
+    playoff_odds: tuple[Mapping[str, Any], ...] | None
+    source_stamp: str
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LeagueBundle:
+    """The expensive, league-wide build.  Cached on the source stamp."""
+
+    inputs: LeagueInputs
+    replacement: Mapping[str, PositionReplacement]
+    scarcity: Mapping[str, ScarcityComponents]
+    lineup_scores: Mapping[str, float]
+    intel: Mapping[str, RosterIntel]
+    signals: Mapping[str, _partner.RosterSignal]
+    compute_ms: float
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def team(self, owner_id: str) -> TeamInput | None:
+        return next((t for t in self.inputs.teams if t.owner_id == str(owner_id)), None)
+
+
+# ── Loading ──────────────────────────────────────────────────────────
+
+
+def _sim_playoff_path(league_key: str) -> Path:
+    """Per-league playoff-sim cache path.
+
+    Routes through ``src.ros.scrape._sim_paths`` — the writer — so the
+    default league's historical ``latest_playoff.json`` filename and the
+    ``<key>_playoff.json`` namespacing stay defined in exactly one
+    place.  A second copy of that rule here is how the reader and the
+    writer drift apart.
+    """
+    from src.ros.scrape import _sim_paths  # noqa: PLC0415 — avoids a heavy import at module load
+
+    from src.api.league_registry import default_league_key  # noqa: PLC0415
+
+    playoff, _champ = _sim_paths(league_key, default_league_key())
+    return playoff
+
+
+def _file_stamp(path: Path) -> str:
+    try:
+        st = path.stat()
+    except OSError:
+        return f"{path.name}:absent"
+    return f"{path.name}:{st.st_mtime_ns}:{st.st_size}"
+
+
+def _contract_stamp(contract: Mapping[str, Any] | None) -> str:
+    if not isinstance(contract, Mapping):
+        return "contract:none"
+    meta = contract.get("meta") if isinstance(contract.get("meta"), Mapping) else {}
+    for key in ("scrapeTimestamp", "generatedAt", "date"):
+        val = contract.get(key) or (meta or {}).get(key)
+        if val:
+            return f"contract:{val}"
+    return "contract:unstamped"
+
+
+def _index_contract_players(
+    contract: Mapping[str, Any] | None,
+) -> tuple[dict[str, dict[str, float]], dict[str, dict[str, float]]]:
+    """``playersArray`` → ages and market site values, by Sleeper id.
+
+    Keyed by Sleeper id rather than name because the roster snapshot is
+    id-keyed and the identity layer already owns id-grade joins; a
+    second name-normalisation here would be a competing source of
+    truth.
+    """
+    ages: dict[str, dict[str, float]] = {}
+    sites: dict[str, dict[str, float]] = {}
+    if not isinstance(contract, Mapping):
+        return ages, sites
+    rows = contract.get("playersArray")
+    if not isinstance(rows, list):
+        return ages, sites
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        pid = str(row.get("playerId") or "").strip()
+        if not pid:
+            continue
+        age = row.get("age")
+        if isinstance(age, (int, float)) and age > 0:
+            ages[pid] = {"age": float(age)}
+        csv = row.get("canonicalSiteValues")
+        if isinstance(csv, Mapping):
+            priced = {
+                str(k): float(v)
+                for k, v in csv.items()
+                if isinstance(v, (int, float)) and float(v) > 0
+            }
+            if priced:
+                sites[pid] = priced
+    return ages, sites
+
+
+def load_league_inputs(
+    league_key: str,
+    scoring_profile: str,
+    contract: Mapping[str, Any] | None,
+) -> LeagueInputs:
+    """Read every input for one league off disk.
+
+    Raises :class:`GameplanUnavailable` when the roster snapshot the
+    whole surface rests on is missing — that is a
+    ``data_not_ready`` condition, not an empty result.
+    """
+    rows = load_team_strength_snapshot(league_key)
+    if not rows:
+        raise GameplanUnavailable(
+            "roster_snapshot_missing",
+            (
+                f"No team-strength snapshot for league {league_key!r}. "
+                "The gameplan surface reads full rosters from "
+                "data/ros/team_strength/; run the ROS refresh for this league."
+            ),
+        )
+
+    slots = load_league_starter_slots(league_key)
+    if not slots:
+        raise GameplanUnavailable(
+            "starter_slots_missing",
+            (
+                f"League {league_key!r} has no rosterSettings.starters in the "
+                "registry, so there is no lineup to solve."
+            ),
+        )
+
+    notes: list[str] = []
+    teams: list[TeamInput] = []
+    for row in rows:
+        owner_id = str(row.get("ownerId") or "").strip()
+        if not owner_id:
+            continue
+        # ``fullRoster`` and not ``startingLineup + benchDepth``: the
+        # latter is capped at 26 players against real 44-58 man rosters
+        # (ADR-011), which understates depth and overstates fragility in
+        # a known direction.
+        roster = [r for r in (row.get("fullRoster") or []) if isinstance(r, Mapping)]
+        if not roster:
+            notes.append(
+                f"owner {owner_id!r} carries no fullRoster in the snapshot; "
+                "excluded from the league build"
+            )
+            continue
+        teams.append(
+            TeamInput(
+                owner_id=owner_id,
+                team_name=str(row.get("teamName") or ""),
+                rows=tuple(roster),
+                pool=tuple(to_roster_players(roster)),
+            )
+        )
+
+    if not teams:
+        raise GameplanUnavailable(
+            "roster_snapshot_empty",
+            f"Team-strength snapshot for {league_key!r} contains no rosters.",
+        )
+
+    ages, sites = _index_contract_players(contract)
+    if not ages:
+        notes.append(
+            "no player ages reached this build; the competitive window's "
+            "trajectory axis will pin at neutral and the target engines' "
+            "horizon weight will not apply (winNowWeight null)"
+        )
+
+    playoff_odds: tuple[Mapping[str, Any], ...] | None = None
+    sim_path = _sim_playoff_path(league_key)
+    try:
+        if sim_path.exists():
+            payload = json.loads(sim_path.read_text())
+            raw = payload.get("playoffOdds") if isinstance(payload, Mapping) else None
+            if isinstance(raw, list) and raw:
+                playoff_odds = tuple(r for r in raw if isinstance(r, Mapping))
+    except (OSError, json.JSONDecodeError) as exc:
+        notes.append(f"playoff-sim cache unreadable ({exc.__class__.__name__}); odds omitted")
+
+    stamp = hashlib.sha256(
+        "|".join(
+            [
+                league_key,
+                scoring_profile,
+                _file_stamp(_team_strength_stamp_path(league_key)),
+                _file_stamp(sim_path),
+                _contract_stamp(contract),
+                GAMEPLAN_CONTRACT_VERSION,
+            ]
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+
+    return LeagueInputs(
+        league_key=league_key,
+        scoring_profile=scoring_profile,
+        slots=tuple(slots),
+        teams=tuple(teams),
+        player_meta=ages,
+        site_values=sites,
+        playoff_odds=playoff_odds,
+        source_stamp=stamp,
+        notes=tuple(notes),
+    )
+
+
+def _team_strength_stamp_path(league_key: str) -> Path:
+    """Path to the roster snapshot, for stamping only.
+
+    ``load_team_strength_snapshot`` owns reading it; this mirrors its
+    private path rule for the cache key.  Kept narrow — if the two ever
+    disagree the only consequence is a stale-cache miss, never a wrong
+    answer, because the stamp is one input among several.
+    """
+    from src.ros.team_strength import _team_strength_path  # noqa: PLC0415
+
+    return _team_strength_path(league_key)
+
+
+# ── The expensive build ──────────────────────────────────────────────
+
+
+def build_league_bundle(inputs: LeagueInputs) -> LeagueBundle:
+    """Solve everything that is league-wide.  ~1.35 s cold on 12 teams.
+
+    Every optional engine input that CAN be supplied IS supplied.  An
+    absent one does not error — it produces a constant that looks
+    exactly like a broken metric (measured: with no ages the window's
+    trajectory axis reads 0.500 for every roster and
+    ``productive_struggle`` becomes unreachable league-wide).
+    """
+    t0 = time.perf_counter()
+    slots = list(inputs.slots)
+    rep_teams = [{"players": list(t.rows)} for t in inputs.teams]
+
+    # ``measure_endogenous_starters`` is the expensive half of the
+    # replacement build; measure once and hand it to both consumers.
+    endogenous = measure_endogenous_starters(rep_teams, slots)
+    replacement = compute_replacement_levels(rep_teams, slots, endogenous=endogenous)
+    scarcity = compute_scarcity(replacement, rep_teams)
+
+    lineup_scores = {t.owner_id: optimal_score(list(t.pool), slots) for t in inputs.teams}
+
+    odds_rows = list(inputs.playoff_odds) if inputs.playoff_odds else None
+    intel: dict[str, RosterIntel] = {}
+    for t in inputs.teams:
+        intel[t.owner_id] = analyze_roster(
+            t.owner_id,
+            list(t.pool),
+            slots,
+            replacement=replacement,
+            player_meta=inputs.player_meta,
+            playoff_odds=odds_rows,
+            lineup_scores=lineup_scores,
+        )
+
+    starter_levels = {
+        pos: lvl for pos, rep in replacement.items() if (lvl := rep.value("starter")) is not None
+    }
+    signals = {
+        oid: _partner.RosterSignal.from_engine(
+            oid,
+            profile=ri.profile,
+            window=ri.window,
+            starter_levels=starter_levels,
+        )
+        for oid, ri in intel.items()
+    }
+
+    notes = list(inputs.notes)
+    if odds_rows is not None:
+        covered = {str(r.get("ownerId")) for r in odds_rows}
+        missing = [t.owner_id for t in inputs.teams if t.owner_id not in covered]
+        if missing:
+            # This is not cosmetic.  ``league_competitiveness`` takes the
+            # championship-odds percentile across the rows it was GIVEN,
+            # so covered owners are ranked against a pool of
+            # len(odds_rows) while uncovered owners fall back to a
+            # lineup-score percentile across all teams.  Two different
+            # denominators feeding one window axis is a real
+            # incomparability, and each roster's
+            # ``competitiveWindow.inputs.competitivenessSource`` says
+            # which one it got.
+            notes.append(
+                f"playoff sim covers {len(covered)} of {len(inputs.teams)} rosters; "
+                "covered teams take a championship-odds percentile over that "
+                "smaller pool while the rest fall back to a lineup-score "
+                "percentile over the full league — the two competitiveness "
+                "scales are NOT comparable, so do not rank rosters across the "
+                "boundary. Check competitiveWindow.inputs.competitivenessSource "
+                "per roster"
+            )
+
+    return LeagueBundle(
+        inputs=inputs,
+        replacement=replacement,
+        scarcity=scarcity,
+        lineup_scores=lineup_scores,
+        intel=intel,
+        signals=signals,
+        compute_ms=(time.perf_counter() - t0) * 1000.0,
+        notes=tuple(notes),
+    )
+
+
+# ── Caches ───────────────────────────────────────────────────────────
+# Keyed on the source stamp, never on a clock: a refresh invalidates
+# immediately and a quiet hour never serves something newer than it
+# claims.  One live entry per league — the previous stamp's entry is
+# dropped rather than accumulated, matching ``_OVERLAY_RESPONSE_CACHE``
+# in server.py.
+
+_CACHE_LOCK = threading.Lock()
+_BUNDLE_CACHE: dict[str, tuple[str, LeagueBundle]] = {}
+_TEAM_CACHE: "OrderedDict[str, tuple[str, dict[str, Any]]]" = OrderedDict()
+
+_TEAM_CACHE_MAX = 64
+"""Bounded so a caller enumerating every (team, partner) pair cannot
+grow the process heap without limit: 12 teams x 11 partners is 132
+entries at ~90 KB each. Oldest-first eviction, and every entry for a
+league is dropped outright when that league's bundle is rebuilt."""
+
+
+def invalidate_cache(league_key: str | None = None) -> None:
+    """Drop cached builds.  ``None`` clears every league."""
+    with _CACHE_LOCK:
+        if league_key is None:
+            _BUNDLE_CACHE.clear()
+            _TEAM_CACHE.clear()
+            return
+        _BUNDLE_CACHE.pop(league_key, None)
+        for key in [k for k in _TEAM_CACHE if k.startswith(f"{league_key}\x00")]:
+            _TEAM_CACHE.pop(key, None)
+
+
+def get_league_bundle(
+    league_key: str,
+    scoring_profile: str,
+    contract: Mapping[str, Any] | None,
+) -> tuple[LeagueBundle, bool]:
+    """Cached :func:`build_league_bundle`.  Returns ``(bundle, cache_hit)``.
+
+    Loading the inputs is cheap (file stats plus one snapshot read) and
+    happens on every call so the stamp is always current; only the
+    ~1.35 s solve is cached.
+    """
+    inputs = load_league_inputs(league_key, scoring_profile, contract)
+    with _CACHE_LOCK:
+        cached = _BUNDLE_CACHE.get(league_key)
+        if cached is not None and cached[0] == inputs.source_stamp:
+            return cached[1], True
+
+    # The lock is NOT held across the build.  Two concurrent cold
+    # requests for the same league will each solve it and the second
+    # write wins — a wasted 1.35 s, never a wrong answer, since the
+    # build is a pure function of ``inputs``.  Holding the lock instead
+    # would serialise every gameplan request in the process, including
+    # requests for other leagues, behind one solve.
+    bundle = build_league_bundle(inputs)
+    with _CACHE_LOCK:
+        _BUNDLE_CACHE[league_key] = (inputs.source_stamp, bundle)
+        # Team payloads derived from a superseded bundle are stale by
+        # construction; drop them with it.
+        for key in [k for k in _TEAM_CACHE if k.startswith(f"{league_key}\x00")]:
+            _TEAM_CACHE.pop(key, None)
+    return bundle, False
+
+
+# ── Candidate assembly ───────────────────────────────────────────────
+
+
+def _acquirable_candidates(
+    bundle: LeagueBundle, owner_id: str
+) -> tuple[dict[str, list[RosterPlayer]], list[RosterPlayer]]:
+    """Other rosters' tradeable surplus, as target-engine candidates.
+
+    Surplus and not "every rostered player": ``PositionProfile
+    .tradeable_surplus`` is already lineup-derived — priced value that
+    does not enter its owner's optimal lineup and clears a share of the
+    starter replacement level.  Offering the engines all ~600 other
+    rostered players would cost an exact re-solve each and would mostly
+    test players their owner will not move.
+
+    Returns ``(by_position, flat)``.
+    """
+    by_position: dict[str, list[RosterPlayer]] = {}
+    for oid, ri in bundle.intel.items():
+        if oid == owner_id:
+            continue
+        team = bundle.team(oid)
+        if team is None:
+            continue
+        by_name = {(p.canonical_name or p.player_id): p for p in team.pool}
+        for pos, prof in ri.profile.positions.items():
+            for name in prof.surplus_players:
+                player = by_name.get(name)
+                if player is None:
+                    continue
+                by_position.setdefault(normalize_base_position(pos) or pos, []).append(player)
+
+    capped: dict[str, list[RosterPlayer]] = {}
+    for pos, players in by_position.items():
+        players.sort(key=lambda p: (-p.ros_value, p.player_id))
+        capped[pos] = players[:MAX_CANDIDATES_PER_POSITION]
+
+    flat = [p for players in capped.values() for p in players]
+    return capped, flat
+
+
+def _trade_assets(
+    bundle: LeagueBundle, owner_id: str, *, surplus_only: bool
+) -> list[_packages.TradeAsset]:
+    """Package-generator assets for one roster, priced on the dynasty market.
+
+    Only players the contract prices are included — ``value_package``
+    refuses to total a package it cannot value on one market, so an
+    unpriced asset would be generated and then rejected as
+    ``unvaluable``, burning search budget to produce noise.
+    """
+    team = bundle.team(owner_id)
+    if team is None:
+        return []
+    ri = bundle.intel.get(owner_id)
+    wanted: set[str] | None = None
+    if surplus_only and ri is not None:
+        wanted = {name for prof in ri.profile.positions.values() for name in prof.surplus_players}
+
+    out: list[_packages.TradeAsset] = []
+    for player in team.pool:
+        if wanted is not None and (player.canonical_name or player.player_id) not in wanted:
+            continue
+        sites = bundle.inputs.site_values.get(player.player_id)
+        if not sites:
+            continue
+        out.append(_packages.TradeAsset.from_player(player, sites))
+    out.sort(key=lambda a: (-max(a.row["canonicalSiteValues"].values()), a.asset_id))
+    return out
+
+
+# ── Declared consumer constraints ────────────────────────────────────
+
+FIELD_POLICY: dict[str, Any] = {
+    "nonSortable": [
+        {
+            "field": "targetPositions[].winNowWeight",
+            "reason": (
+                "null whenever the position's obtainable candidates have no known "
+                "age, and those nulls are not a random subset — they cluster on "
+                "positions whose upgrades happen to be un-aged. Sorting or "
+                "filtering on it reorders by data availability, not by win-now "
+                "value. It is reported for magnitude context only."
+            ),
+            "alsoNotComparableAcrossRows": (
+                "The field carries two different quantities depending on "
+                "viability, and the engine names them the same thing. On a "
+                "VIABLE row it is horizon_weight — per-position, keyed to the "
+                "age of that position's obtainable upgrades, and the thing that "
+                "can reorder a ranking. On every non-viable row it is the GLOBAL "
+                "win_now_weight scalar, identical across positions, because "
+                "there were no candidates to take a mean age over. So two rows "
+                "can differ on this field purely because one was rankable and "
+                "the other was not. Compare it only within the viable set."
+            ),
+        }
+    ],
+    "nonFilterable": ["targetPositions[].winNowWeight"],
+    "nullIsNotZero": [
+        {
+            "fields": [
+                "roster.playoffOddsCi",
+                "roster.championshipOddsCi",
+                "targetPositions[].winNowWeight",
+                "targetPositions[].marketEfficiency",
+                "targetPlayers[].marketEdge",
+                "needs[].replacementBaseline",
+            ],
+            "reason": (
+                "null means the quantity was not measured. It is never collapsed "
+                "to 0, and an interval is never collapsed to zero width, because "
+                "a zero-width interval reads as certainty."
+            ),
+        }
+    ],
+    "neverRenamed": [
+        {
+            "field": "packages.frontier[].acceptancePlausibility",
+            "reason": (
+                "PLAUSIBILITY, never probability. Rejections are never observed — "
+                "the league snapshot ingests only completed transactions — so an "
+                "acceptance rate is statistically unidentifiable and no rename to "
+                "'probability' is admissible. Ships with acceptanceCaveat attached."
+            ),
+        },
+        {
+            "field": "partners[].tradeAcceptanceEstimate",
+            "reason": (
+                "An ESTIMATE from the same uncalibratable model, capped by "
+                "acceptanceConfidence. Render limitations.partner alongside it."
+            ),
+        },
+    ],
+    "noBlendedFrontierScore": (
+        "packages.frontier is a Pareto set, not a ranking. valueEfficiency and "
+        "acceptancePlausibility are anti-correlated by construction and no "
+        "exchange rate exists between market points, lineup points and "
+        "plausibility. bestBy names which axis each member wins; a caller that "
+        "collapses the set to one pick is expressing a preference, not computing "
+        "an answer."
+    ),
+}
+
+
+# ── Payload assembly ─────────────────────────────────────────────────
+
+
+def _league_summary(bundle: LeagueBundle) -> list[dict[str, Any]]:
+    """Small per-team context row.
+
+    A projection of the same ``RosterIntel`` objects the selected team
+    returns in full — 12 full payloads is ~115 KB and most of it is
+    unread. Any team's complete intel is one ``?team=<ownerId>`` away.
+    """
+    out: list[dict[str, Any]] = []
+    for team in bundle.inputs.teams:
+        ri = bundle.intel[team.owner_id]
+        window = ri.window.to_dict()
+        out.append(
+            {
+                "ownerId": team.owner_id,
+                "teamName": team.team_name,
+                "lineupScore": round(ri.lineup_score, 3),
+                "filledSlots": ri.filled_slots,
+                "totalSlots": ri.total_slots,
+                "competitiveWindow": {
+                    "mostLikely": window["mostLikely"],
+                    "confidence": window["confidence"],
+                    "probabilities": window["probabilities"],
+                    "inputs": window["inputs"],
+                    "stateOrder": window["stateOrder"],
+                    "orderingCaveat": window["orderingCaveat"],
+                },
+                "playoffOdds": ri.playoff_odds,
+                "playoffOddsCi": list(ri.playoff_odds_ci) if ri.playoff_odds_ci else None,
+                "championshipOdds": ri.championship_odds,
+                "championshipOddsCi": (
+                    list(ri.championship_odds_ci) if ri.championship_odds_ci else None
+                ),
+                "oddsSource": ri.odds_source,
+            }
+        )
+    out.sort(key=lambda r: (-r["lineupScore"], r["ownerId"]))
+    return out
+
+
+def _coverage(
+    bundle: LeagueBundle,
+    owner_id: str,
+    candidates: Mapping[str, Sequence[RosterPlayer]],
+    target_players: Sequence[_targets.PlayerTarget],
+) -> dict[str, Any]:
+    """What was measured, what abstained, and why.
+
+    An absent input and a genuinely neutral measurement look identical
+    downstream, so the difference is stated here rather than left for a
+    reader to infer from a suspiciously round number.
+    """
+    inputs = bundle.inputs
+    rostered = [p for t in inputs.teams for p in t.pool]
+    aged = sum(1 for p in rostered if p.player_id in inputs.player_meta)
+    priced = sum(1 for p in rostered if p.player_id in inputs.site_values)
+    odds_rows = inputs.playoff_odds or ()
+    covered = {str(r.get("ownerId")) for r in odds_rows}
+    recommended = sum(1 for t in target_players if t.recommended)
+
+    return {
+        "rosters": len(inputs.teams),
+        "rosteredPlayers": len(rostered),
+        "starterSlots": len(inputs.slots),
+        "ageCoverage": {
+            "withAge": aged,
+            "total": len(rostered),
+            "source": "live contract playersArray (scoring-profile scoped)",
+        },
+        "marketPriceCoverage": {
+            "priced": priced,
+            "total": len(rostered),
+            "scale": "canonicalSiteValues, 0-9999 dynasty market",
+        },
+        "playoffSimCoverage": {
+            "owners": len(covered & {t.owner_id for t in inputs.teams}),
+            "total": len(inputs.teams),
+            "source": "data/ros/sims (league-scoped)",
+        },
+        "candidatePolicy": {
+            "source": "other rosters' tradeable surplus, from PositionProfile.surplusPlayers",
+            "maxPerPosition": MAX_CANDIDATES_PER_POSITION,
+            "offered": sum(len(v) for v in candidates.values()),
+            "byPosition": {k: len(v) for k, v in sorted(candidates.items())},
+            "exhaustive": False,
+            "note": (
+                "Candidates are capped per position in descending rosValue. Value "
+                "order is not gain order for hybrid IDPs — a DL/LB can out-gain a "
+                "higher-valued pure DL by filling a slot the other cannot — so a "
+                "better target can be outside the cap. A position reported "
+                "noCandidates means NOT MEASURED, never 'nothing available'."
+            ),
+        },
+        "marketEdgeUnmeasured": {
+            "reason": (
+                "The target engines compute edge as (rosValue - price) / price. "
+                "rosValue is 0-100 rest-of-season points; the only prices this "
+                "server holds are canonicalSiteValues on the 0-9999 dynasty "
+                "market. No validated conversion exists between them, and feeding "
+                "one to the other yields an edge near -1 for every player — a "
+                "dead signal that still looks computed. So market_values is not "
+                "supplied and marketEdge is null throughout."
+            ),
+            "wouldUnlock": "a rest-of-season-denominated acquisition price per player",
+        },
+        "corroborationYield": {
+            "recommended": recommended,
+            "evaluated": len(target_players),
+            "note": (
+                "A player is never recommended on our own valuation alone. With "
+                "no external role or projection data wired, the only admissible "
+                "corroborators are measured lineup fit and positional scarcity, "
+                "and every rejection carries its own reason. The yield is a "
+                "property of the ROSTER, not a constant: measured on the real "
+                "league it is 1 of 71 for the strongest team (nothing on offer "
+                "improves it) and 40 of 76 for the weakest. A yield near 100% "
+                "would mean a corroborator had been fabricated — supplying a "
+                "plausible-looking availability map moves the strongest team "
+                "from 1 of 97 to 93 of 97, which is the exact failure this gate "
+                "exists to prevent."
+            ),
+        },
+        "ownerId": owner_id,
+    }
+
+
+def build_gameplan(
+    bundle: LeagueBundle,
+    owner_id: str,
+    *,
+    partner_owner_id: str | None = None,
+    cache_hit: bool = False,
+) -> dict[str, Any]:
+    """Assemble one team's gameplan payload.
+
+    Engine ``to_dict()`` output is passed through unchanged rather than
+    re-projected field by field — a hand-rolled projection is how a
+    caveat gets dropped in a refactor.
+    """
+    t0 = time.perf_counter()
+    team = bundle.team(owner_id)
+    if team is None:
+        raise TeamNotInLeague(owner_id)
+    ri = bundle.intel[owner_id]
+    slots = list(bundle.inputs.slots)
+
+    # ── partners ─────────────────────────────────────────────────────
+    partners = _partner.assess_partners(
+        [
+            _partner.PartnerInputs(
+                owner_id=other.owner_id,
+                display_name=other.team_name,
+                our_roster=bundle.signals[owner_id],
+                their_roster=bundle.signals[other.owner_id],
+            )
+            for other in bundle.inputs.teams
+            if other.owner_id != owner_id
+        ]
+    )
+
+    # ── targets ──────────────────────────────────────────────────────
+    candidates, flat = _acquirable_candidates(bundle, owner_id)
+    candidate_ages = {
+        p.player_id: float(bundle.inputs.player_meta[p.player_id]["age"])
+        for p in flat
+        if p.player_id in bundle.inputs.player_meta
+    }
+    target_positions = _targets.rank_target_positions(
+        list(team.pool),
+        slots,
+        profile=ri.profile,
+        candidates=candidates,
+        window=ri.window,
+        scarcity=bundle.scarcity,
+        replacement=bundle.replacement,
+        candidate_ages=candidate_ages,
+        # market_prices deliberately omitted — see coverage.marketEdgeUnmeasured.
+    )
+    target_players = _targets.rank_target_players(
+        list(team.pool),
+        slots,
+        flat,
+        scarcity=bundle.scarcity,
+        # market_values / availability deliberately omitted. Availability
+        # would have to be invented, and an invented corroborator defeats
+        # the exact gate that makes this engine trustworthy: supplying a
+        # plausible-looking one flips the real league from 1 of 97
+        # recommended to 93 of 97.
+    )
+
+    # ── packages (only against a named counterparty) ─────────────────
+    packages_payload: dict[str, Any] | None = None
+    if partner_owner_id:
+        packages_payload = _build_packages(bundle, owner_id, partner_owner_id)
+
+    payload: dict[str, Any] = {
+        "contractVersion": GAMEPLAN_CONTRACT_VERSION,
+        "leagueKey": bundle.inputs.league_key,
+        "scoringProfile": bundle.inputs.scoring_profile,
+        "team": {"ownerId": team.owner_id, "teamName": team.team_name},
+        "roster": ri.to_dict(),
+        "partners": [p.to_dict() for p in partners],
+        "targetPositions": [t.to_dict() for t in target_positions],
+        "targetPlayers": [t.to_dict() for t in target_players],
+        "packages": packages_payload,
+        "league": _league_summary(bundle),
+        "coverage": _coverage(bundle, owner_id, candidates, target_players),
+        "notes": list(bundle.notes),
+        "fieldPolicy": FIELD_POLICY,
+        "limitations": {
+            "targets": _targets.describe_limitations(),
+            "partner": _partner.describe_limitations(),
+            "packages": _packages.describe_limitations(),
+        },
+        "timing": {
+            "leagueBuildMs": round(bundle.compute_ms, 1),
+            "teamBuildMs": round((time.perf_counter() - t0) * 1000.0, 1),
+            "leagueBuildCached": cache_hit,
+            "sourceStamp": bundle.inputs.source_stamp,
+        },
+    }
+    if packages_payload is None:
+        payload["packagesOmitted"] = {
+            "reason": "no partner requested",
+            "howTo": (
+                "pass ?partner=<ownerId> from the partners list. Packages are "
+                "generated against ONE named counterparty because the generator's "
+                "quality and cost both hinge on the caller pre-filtering which "
+                "assets are in play, and running all partners costs ~1.6 s."
+            ),
+        }
+    return payload
+
+
+def _build_packages(bundle: LeagueBundle, owner_id: str, partner_owner_id: str) -> dict[str, Any]:
+    """Trade Package Generator output against one counterparty."""
+    partner_team = bundle.team(partner_owner_id)
+    if partner_team is None:
+        return {
+            "error": "unknown_partner",
+            "message": f"No roster for owner {partner_owner_id!r} in this league.",
+            "frontier": [],
+            "bestBy": {},
+        }
+
+    ours = _trade_assets(bundle, owner_id, surplus_only=True)[:MAX_PACKAGE_ASSETS_PER_SIDE]
+    theirs = _trade_assets(bundle, partner_owner_id, surplus_only=True)[
+        :MAX_PACKAGE_ASSETS_PER_SIDE
+    ]
+    # Cornerstones must come from their FULL roster: derived from the
+    # filtered ask list, every asset looks elite relative to that list
+    # and the premium rule refuses almost every package.
+    their_full = _trade_assets(bundle, partner_owner_id, surplus_only=False)
+
+    roster_settings = _roster_limit(bundle.inputs.league_key)
+    result = _packages.generate_packages(
+        list(bundle.team(owner_id).pool),
+        list(bundle.inputs.slots),
+        our_assets=ours,
+        their_assets=theirs,
+        their_full_roster=their_full,
+        partner_owner_id=partner_owner_id,
+        our_signal=bundle.signals[owner_id],
+        their_signal=bundle.signals[partner_owner_id],
+        roster_limit=roster_settings,
+        gate_pct=DEFAULT_GATE_PCT,
+    )
+    result["partner"] = {
+        "ownerId": partner_owner_id,
+        "teamName": partner_team.team_name,
+    }
+    result["assetPolicy"] = {
+        "ourAssetsOffered": len(ours),
+        "theirAssetsOffered": len(theirs),
+        "maxPerSide": MAX_PACKAGE_ASSETS_PER_SIDE,
+        "filter": "tradeable surplus that the contract prices on the dynasty market",
+        "note": (
+            "Unpriced assets are excluded before generation: value_package "
+            "refuses to total a package it cannot value on one market, so "
+            "including them would spend search budget producing 'unvaluable' "
+            "rejections."
+        ),
+    }
+    return result
+
+
+def _roster_limit(league_key: str) -> int | None:
+    """League roster-size cap for the legality rule, or None."""
+    try:
+        from src.api.league_registry import get_league_by_key  # noqa: PLC0415
+
+        cfg = get_league_by_key(league_key)
+        if cfg is None:
+            return None
+        size = (cfg.roster_settings or {}).get("rosterSize")
+        return int(size) if size else None
+    except Exception:  # noqa: BLE001 — a missing cap disables the rule, never errors
+        return None
+
+
+def get_team_gameplan(
+    league_key: str,
+    scoring_profile: str,
+    contract: Mapping[str, Any] | None,
+    owner_id: str,
+    *,
+    partner_owner_id: str | None = None,
+) -> dict[str, Any]:
+    """Cached end-to-end build for one team.  Runs off the event loop.
+
+    Package payloads are cached under their own key so asking about a
+    second partner does not rebuild the ~550 ms target section.
+    """
+    bundle, cache_hit = get_league_bundle(league_key, scoring_profile, contract)
+    if bundle.team(owner_id) is None:
+        raise TeamNotInLeague(owner_id)
+
+    stamp = bundle.inputs.source_stamp
+    cache_key = "\x00".join([league_key, stamp, owner_id, partner_owner_id or ""])
+    with _CACHE_LOCK:
+        cached = _TEAM_CACHE.get(cache_key)
+        if cached is not None and cached[0] == stamp:
+            _TEAM_CACHE.move_to_end(cache_key)
+            payload = dict(cached[1])
+            # Both flags describe THIS request, not the request that
+            # populated the cache.  Returning the stored payload
+            # verbatim replays the cold build's ``leagueBuildCached:
+            # false`` forever, which makes the timing block lie in the
+            # one direction that matters — it would read as though the
+            # 1.35 s solve ran on every request.
+            payload["timing"] = {
+                **payload["timing"],
+                "teamBuildCached": True,
+                "leagueBuildCached": cache_hit,
+            }
+            return payload
+
+    payload = build_gameplan(
+        bundle, owner_id, partner_owner_id=partner_owner_id, cache_hit=cache_hit
+    )
+    payload["timing"]["teamBuildCached"] = False
+    with _CACHE_LOCK:
+        _TEAM_CACHE[cache_key] = (stamp, payload)
+        _TEAM_CACHE.move_to_end(cache_key)
+        while len(_TEAM_CACHE) > _TEAM_CACHE_MAX:
+            _TEAM_CACHE.popitem(last=False)
+    return payload

--- a/tests/api/test_gameplan_endpoint.py
+++ b/tests/api/test_gameplan_endpoint.py
@@ -1,0 +1,767 @@
+"""Contract tests for ``GET /api/gameplan``.
+
+Three jobs, in order of how loudly they should fail.
+
+1. **The routing contract.**  Every condition in CLAUDE.md's table —
+   400 ``unknown_league``, 400 ``inactive_league``, 503
+   ``data_not_ready``, 404 ``no_leagues_configured`` — plus the
+   ``leagueKey`` stamp every league-scoped route carries.
+
+2. **The honesty stamps survive serialization.**  Several fields exist
+   because a previous version presented something as stronger than it
+   was, and the way those regress is not a rewrite — it is a rename or
+   a "tidy-up" in the API layer.  So there are tests that fail if
+   ``acceptancePlausibility`` ever becomes a probability, if a null
+   confidence interval ever collapses to zero width, if
+   ``winNowWeight``'s nulls ever become zeroes, and if the Pareto
+   frontier ever grows a blended score.
+
+3. **The engines are actually reachable.**  The whole point of the
+   endpoint is that ``git grep roster_intel`` outside its own package
+   returned nothing; a test that only checks status codes would pass
+   against an empty payload.
+
+The fixture builds a small synthetic league rather than reading the
+live snapshots, so these run in the blocking suite.  ``tests/roster_intel
+/test_real_rosters.py`` already guards the engines against the real 12
+rosters under the ``livedata`` marker.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import gameplan, league_registry
+
+# ── Fixture league ───────────────────────────────────────────────────
+# 4 teams x 14 players over 7 starter slots.  Three properties are
+# deliberate, and a fixture missing any of them passes the tests
+# vacuously rather than exercising the engines:
+#
+# * every roster carries more startable RB/WR than it can start, so
+#   ``PositionProfile.tradeable_surplus`` is non-empty and the target
+#   and package engines have real candidates;
+# * two rosters have a genuine HOLE (:data:`_WEAK_POSITION`), so an
+#   acquisition can clear the materiality floor — ``max(3.0, 1% of
+#   lineup score)`` — and ``TargetViability.VIABLE`` is reachable.  A
+#   flat fixture makes every position read ``immaterialGain`` and the
+#   viability branch is never tested;
+# * nobody carries a TE surplus, so TE reports ``noCandidates`` and the
+#   "not measured, never nothing-available" distinction is exercised.
+
+_SLOTS = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1}
+
+_SHAPE = [
+    ("QB", 3),
+    ("RB", 4),
+    ("WR", 5),
+    ("TE", 2),
+]
+
+_WEAK_POSITION = {2: "WR", 3: "WR"}
+"""Owners 2 and 3 field replacement-level receivers.  Their hole is
+what makes an obtainable upgrade material."""
+
+
+def _roster(owner_seed: int) -> list[dict]:
+    """One roster.  Values descend within a position and are offset per
+    team so no two rosters tie on a headline metric."""
+    weak = _WEAK_POSITION.get(owner_seed)
+    rows: list[dict] = []
+    idx = 0
+    for pos, count in _SHAPE:
+        for n in range(count):
+            idx += 1
+            if pos == weak:
+                value = 9.0 - (n * 1.4) - (owner_seed * 0.3)
+            else:
+                value = 90.0 - (n * 9.0) - (owner_seed * 3.5)
+            rows.append(
+                {
+                    "playerId": f"p{owner_seed}{idx:02d}",
+                    "canonicalName": f"{pos.lower()} {owner_seed}-{n}",
+                    "position": pos,
+                    "rosValue": round(max(value, 1.0), 2),
+                    "fantasyPositions": [pos],
+                    "injured": False,
+                    "bye": False,
+                }
+            )
+    return rows
+
+
+def _snapshot() -> list[dict]:
+    return [
+        {
+            "ownerId": f"owner{i}",
+            "teamName": f"Team {i}",
+            "fullRoster": _roster(i),
+        }
+        for i in range(4)
+    ]
+
+
+def _players_array() -> list[dict]:
+    """The scoring-profile-scoped half of the inputs: ages and market
+    prices, keyed by Sleeper id, exactly as ``/api/data`` stamps them."""
+    out: list[dict] = []
+    for i in range(4):
+        for row in _roster(i):
+            n = int(row["playerId"][-2:])
+            out.append(
+                {
+                    "playerId": row["playerId"],
+                    "displayName": row["canonicalName"],
+                    "position": row["position"],
+                    "age": 22 + (n % 11),
+                    "canonicalSiteValues": {
+                        "ktcSfTep": 200.0 + row["rosValue"] * 40.0,
+                    },
+                }
+            )
+    return out
+
+
+def _sim_rows() -> list[dict]:
+    """Playoff-sim rows for SOME owners only, with real intervals on
+    one and none on another — both branches of ``engine._odds_for``
+    matter and the endpoint must carry each through unchanged."""
+    return [
+        {
+            "ownerId": "owner0",
+            "playoffOdds": 0.81,
+            "playoffOddsCi": [0.79, 0.83],
+            "championshipOdds": 0.31,
+            "championshipOddsCi": [0.28, 0.34],
+        },
+        {
+            "ownerId": "owner1",
+            "playoffOdds": 0.42,
+            "championshipOdds": 0.09,
+        },
+    ]
+
+
+@pytest.fixture
+def league(tmp_path, monkeypatch):
+    """Two active leagues plus a retired one, with the gameplan inputs
+    stubbed onto ``main`` only."""
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "L-MAIN",
+                        "scoringProfile": "prof_a",
+                        "active": True,
+                        "aliases": ["primary"],
+                        "rosterSettings": {
+                            "teamCount": 4,
+                            "rosterSize": 14,
+                            "starters": _SLOTS,
+                        },
+                    },
+                    {
+                        "key": "side",
+                        "displayName": "Side",
+                        "sleeperLeagueId": "L-SIDE",
+                        "scoringProfile": "prof_a",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 4, "starters": _SLOTS},
+                    },
+                    {
+                        "key": "retired",
+                        "displayName": "Retired",
+                        "sleeperLeagueId": "L-RET",
+                        "active": False,
+                        "rosterSettings": {},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
+    user_kv._SETUP_DONE.clear()
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+
+    snapshot_path = tmp_path / "team_strength.json"
+    snapshot_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+    sim_path = tmp_path / "sims.json"
+    sim_path.write_text(json.dumps({"playoffOdds": _sim_rows()}), encoding="utf-8")
+
+    monkeypatch.setattr(
+        gameplan,
+        "load_team_strength_snapshot",
+        lambda key=None: _snapshot() if key == "main" else None,
+    )
+    monkeypatch.setattr(gameplan, "_team_strength_stamp_path", lambda key: snapshot_path)
+    monkeypatch.setattr(gameplan, "_sim_playoff_path", lambda key: sim_path)
+    gameplan.invalidate_cache()
+
+    yield {"snapshot": snapshot_path, "sim": sim_path, "tmp": tmp_path}
+
+    gameplan.invalidate_cache()
+    league_registry.reload_registry()
+
+
+def _install_contract(monkeypatch, league_key: str = "main", profile: str = "prof_a"):
+    stub = {
+        "meta": {"leagueKey": league_key, "scoringProfile": profile},
+        "players": {},
+        "playersArray": _players_array(),
+        "sleeper": {"teams": []},
+    }
+    monkeypatch.setattr(server, "latest_contract_data", stub)
+    return stub
+
+
+def _get(client, path: str):
+    return client.get(path)
+
+
+# ── 1. The routing contract ──────────────────────────────────────────
+
+
+def test_happy_path_returns_the_full_surface(league, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/gameplan?team=owner0")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["leagueKey"] == "main"
+    assert body["scoringProfile"] == "prof_a"
+    assert body["contractVersion"] == gameplan.GAMEPLAN_CONTRACT_VERSION
+    assert body["team"]["ownerId"] == "owner0"
+    for key in (
+        "roster",
+        "partners",
+        "targetPositions",
+        "targetPlayers",
+        "league",
+        "coverage",
+        "fieldPolicy",
+        "limitations",
+        "timing",
+    ):
+        assert key in body, f"missing {key}"
+    assert res.headers.get("Cache-Control") == "no-store"
+
+
+def test_unknown_league_key_returns_400(league, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/gameplan?leagueKey=ghost&team=owner0")
+    assert res.status_code == 400
+    body = res.json()
+    assert body["error"] == "unknown_league"
+    assert body["leagueKey"] == "ghost"
+
+
+def test_inactive_league_key_returns_400(league, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/gameplan?leagueKey=retired&team=owner0")
+    assert res.status_code == 400
+    assert res.json()["error"] == "inactive_league"
+
+
+def test_non_loaded_league_returns_503_data_not_ready(league, monkeypatch):
+    """Gameplan is roster intelligence, so it is league-scoped end to
+    end and cannot serve league B off league A's loaded contract —
+    same rule as /api/terminal and /api/trade/*."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, league_key="main")
+        res = _get(c, "/api/gameplan?leagueKey=side&team=owner0")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert body["leagueKey"] == "side"
+
+
+def test_no_leagues_configured_returns_404(tmp_path, monkeypatch):
+    path = tmp_path / "empty.json"
+    path.write_text(json.dumps({"leagues": []}), encoding="utf-8")
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    monkeypatch.delenv("SLEEPER_LEAGUE_ID", raising=False)
+    league_registry.reload_registry()
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+    try:
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            monkeypatch.setattr(server, "latest_contract_data", {"meta": {}})
+            res = _get(c, "/api/gameplan?team=owner0")
+        assert res.status_code == 404
+        assert res.json()["error"] == "no_leagues_configured"
+    finally:
+        league_registry.reload_registry()
+
+
+def test_missing_roster_snapshot_returns_503_with_a_reason(league, monkeypatch):
+    """A league with no team-strength snapshot is data_not_ready, not a
+    500 and not an empty 200 that reads as 'this roster has nothing'."""
+    monkeypatch.setattr(gameplan, "load_team_strength_snapshot", lambda key=None: None)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/gameplan?team=owner0")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert body["reason"] == "roster_snapshot_missing"
+    assert body["leagueKey"] == "main"
+
+
+def test_unknown_team_returns_404(league, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/gameplan?team=nobody")
+    assert res.status_code == 404
+    body = res.json()
+    assert body["error"] == "team_not_found"
+    assert body["leagueKey"] == "main"
+
+
+def test_team_cannot_be_inferred_returns_400(league, monkeypatch):
+    """No ?team, no Sleeper id on the session, no default_team_map —
+    the endpoint must say which input is missing rather than silently
+    picking somebody's roster."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        monkeypatch.setattr(server, "_get_auth_session", lambda request: {"username": "alice"})
+        res = _get(c, "/api/gameplan")
+    assert res.status_code == 400
+    assert res.json()["error"] == "team_required"
+
+
+def test_team_resolves_from_the_session_sleeper_id(league, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        monkeypatch.setattr(
+            server,
+            "_get_auth_session",
+            lambda request: {"username": "alice", "sleeper_user_id": "owner2"},
+        )
+        res = _get(c, "/api/gameplan")
+    assert res.status_code == 200, res.text
+    assert res.json()["team"]["ownerId"] == "owner2"
+
+
+def test_alias_resolves_to_the_canonical_key(league, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/gameplan?leagueKey=primary&team=owner0")
+    assert res.status_code == 200, res.text
+    assert res.json()["leagueKey"] == "main"
+
+
+# ── 2. The honesty stamps ────────────────────────────────────────────
+
+
+def _payload(monkeypatch, query: str = "?team=owner0"):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = c.get(f"/api/gameplan{query}")
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _walk(node, path="$"):
+    """Every (json-path, key, value) in the payload."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield f"{path}.{key}", key, value
+            yield from _walk(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            yield from _walk(value, f"{path}[{i}]")
+
+
+def test_acceptance_plausibility_is_never_renamed_to_a_probability(league, monkeypatch):
+    """MECHANISM TEST.  Fails if the acceptance estimate is ever
+    presented as a calibrated probability.
+
+    Rejections are never observed — the league snapshot ingests only
+    completed transactions — so an acceptance RATE is statistically
+    unidentifiable from this data.  The field names are the last thing
+    standing between that fact and a UI that renders "78% likely to
+    accept", and a rename is exactly how it would be lost.
+    """
+    body = _payload(monkeypatch, "?team=owner3&partner=owner0")
+
+    offenders = [
+        p for p, key, _ in _walk(body) if "probabilit" in key.lower() and "acceptance" in p.lower()
+    ]
+    assert not offenders, f"acceptance quantity renamed to a probability at: {offenders}"
+
+    frontier = (body.get("packages") or {}).get("frontier") or []
+    assert frontier, "fixture produced no packages — this test would pass vacuously"
+    for member in frontier:
+        assert "acceptancePlausibility" in member
+        assert "acceptanceProbability" not in member
+        caveat = member["acceptanceCaveat"]
+        assert "not a calibrated acceptance probability" in caveat
+        assert "Never render as" in caveat
+
+    for row in body["partners"]:
+        assert "tradeAcceptanceEstimate" in row
+        assert not any("probabilit" in k.lower() for k in row)
+
+    # The model's own limitations must ship with the estimate, because
+    # partner.describe_limitations says any surface rendering the
+    # estimate has to render them alongside it.
+    limits = body["limitations"]["partner"]
+    assert limits["keyAssumptions"]["baseAcceptancePriorIsMeasured"] is False
+    assert any("unidentifiable" in c for c in limits["cannotSupport"])
+
+
+def test_null_confidence_intervals_never_collapse_to_zero_width(league, monkeypatch):
+    """MECHANISM TEST.  A zero-width interval reads as certainty.
+
+    ``owner1`` has simulated odds but no intervals; ``owner0`` has
+    both.  The absent pair must stay null rather than becoming
+    ``[0.42, 0.42]`` — or worse ``[0, 0]`` — on the way through the
+    API.
+    """
+    body = _payload(monkeypatch, "?team=owner1")
+    roster = body["roster"]
+    assert roster["playoffOdds"] == pytest.approx(0.42)
+    assert roster["playoffOddsCi"] is None
+    assert roster["championshipOddsCi"] is None
+    assert any("confidence interval" in n for n in roster["notes"])
+
+    # ...and the team that HAS intervals keeps them, so the assertion
+    # above is not just measuring an endpoint that drops all intervals.
+    with_ci = next(r for r in body["league"] if r["ownerId"] == "owner0")
+    assert with_ci["playoffOddsCi"] == [0.79, 0.83]
+    assert with_ci["championshipOddsCi"] == [0.28, 0.34]
+
+    for path, key, value in _walk(body):
+        if not key.endswith("Ci") or not isinstance(value, list) or len(value) != 2:
+            continue
+        assert value[0] != value[1], f"zero-width interval at {path}: {value}"
+
+
+def test_win_now_weight_nulls_survive_and_the_field_is_declared_unsortable(league, monkeypatch):
+    """``winNowWeight`` is null when candidate ages are missing, and its
+    nulls are not a random subset — they cluster on positions whose
+    obtainable upgrades happen to be un-aged.  Sorting on it would
+    reorder by data availability, so the API declares it off-limits.
+    """
+    body = _payload(monkeypatch)
+    policy = body["fieldPolicy"]
+    assert "targetPositions[].winNowWeight" in policy["nonFilterable"]
+    entry = next(e for e in policy["nonSortable"] if e["field"] == "targetPositions[].winNowWeight")
+    # The second reason the field is unsortable: it carries the
+    # per-position horizon weight on viable rows and the GLOBAL win-now
+    # scalar on non-viable ones, under one name.
+    assert "alsoNotComparableAcrossRows" in entry
+
+    for target in body["targetPositions"]:
+        assert "winNowWeight" in target
+        weight = target["winNowWeight"]
+        assert weight is None or isinstance(weight, (int, float))
+
+    # No sort/filter parameter is offered, and passing one must not
+    # silently reorder the list — that is the loophole the declaration
+    # exists to close.
+    plain = [t["position"] for t in body["targetPositions"]]
+    sneaky = _payload(monkeypatch, "?team=owner0&sort=winNowWeight&filter=winNowWeight")
+    assert [t["position"] for t in sneaky["targetPositions"]] == plain
+
+
+def test_win_now_weight_is_null_when_no_ages_reach_the_engines(league, monkeypatch):
+    """MECHANISM TEST for the null branch itself.  Strip ages from the
+    contract and the horizon weight must report that it did not apply,
+    rather than stamping a number that looks applied."""
+    stub = {
+        "meta": {"leagueKey": "main", "scoringProfile": "prof_a"},
+        "players": {},
+        "playersArray": [{**row, "age": None} for row in _players_array()],
+        "sleeper": {"teams": []},
+    }
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        monkeypatch.setattr(server, "latest_contract_data", stub)
+        res = c.get("/api/gameplan?team=owner3")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["coverage"]["ageCoverage"]["withAge"] == 0
+    viable = [t for t in body["targetPositions"] if t["viability"] == "viable"]
+    assert viable, "fixture produced no viable target — this test would pass vacuously"
+    for target in viable:
+        assert target["winNowWeight"] is None
+        assert any("could not be computed" in n for n in target["notes"])
+
+    # ...and the non-viable rows still carry a NUMBER, because the
+    # engine stamps the global win-now scalar there rather than the
+    # per-position horizon weight. Same field name, different quantity —
+    # which is the second reason it must not be sorted on, and is
+    # asserted here so a reader cannot mistake the mixture for a bug in
+    # this endpoint.
+    non_viable = [t for t in body["targetPositions"] if t["viability"] != "viable"]
+    assert non_viable
+    assert all(t["winNowWeight"] is not None for t in non_viable)
+    assert len({t["winNowWeight"] for t in non_viable}) == 1, "global scalar should be uniform"
+
+
+def test_unmeasured_thresholds_are_declared_unmeasured(league, monkeypatch):
+    """Every tunable in these engines is a judgement call, and each
+    module says so in machine-readable form.  That flag must reach the
+    API or the constants read as fitted values."""
+    body = _payload(monkeypatch, "?team=owner3&partner=owner0")
+    assert body["limitations"]["packages"]["keyAssumptions"]["thresholdsAreMeasured"] is False
+    targets = body["limitations"]["targets"]["keyAssumptions"]
+    assert targets["materialityFloorIsMeasured"] is False
+    assert targets["winNowWeightsAreMeasured"] is False
+    assert (
+        body["limitations"]["partner"]["keyAssumptions"]["baseAcceptancePriorIsMeasured"] is False
+    )
+
+
+def test_the_pareto_frontier_is_returned_wide_with_no_blended_score(league, monkeypatch):
+    """No exchange rate exists between market points, lineup points and
+    plausibility, so the frontier is a set of alternatives and must not
+    acquire a single number that ranks them."""
+    body = _payload(monkeypatch, "?team=owner3&partner=owner0")
+    packages = body["packages"]
+    frontier = packages["frontier"]
+    assert frontier
+
+    banned = {"score", "overallScore", "compositeScore", "rank", "blendedScore"}
+    for member in frontier:
+        assert not (banned & set(member)), f"frontier member grew a ranking score: {member.keys()}"
+
+    assert packages["bestBy"], "bestBy must name which axis each member wins"
+    assert "not a ranking" in packages["note"]
+    assert "noBlendedFrontierScore" in body["fieldPolicy"]
+
+    # The frontier really is non-dominated on more than one axis — if
+    # every member won on the same axis, "wide" would be decoration.
+    if len(frontier) > 1:
+        assert len({member["acceptancePlausibility"] for member in frontier}) > 1
+
+
+def test_engine_notes_and_semantics_survive_serialization(league, monkeypatch):
+    """The ``_semantics`` block on each need exists because a consumer
+    derived deficit as ``fragility x marginal`` and got the roster's
+    STRONGEST position reported as its biggest hole.  Stripping it in
+    the API layer re-arms that."""
+    body = _payload(monkeypatch)
+    needs = body["roster"]["needs"]
+    assert needs
+    for need in needs.values():
+        semantics = need["_semantics"]
+        assert "do NOT multiply these" in semantics["warning"]
+        assert need["deficit"] >= 0.0
+        assert 0.0 <= need["concentrationRisk"] <= 1.0
+
+    window = body["roster"]["competitiveWindow"]
+    assert "ordering as soft" in window["orderingCaveat"]
+    assert abs(sum(window["probabilities"].values()) - 1.0) < 1e-9
+
+
+def test_partial_playoff_sim_coverage_is_flagged_not_papered_over(league, monkeypatch):
+    """The sim covers 2 of 4 owners.  Covered teams take a
+    championship-odds percentile over that smaller pool while the rest
+    fall back to a lineup-score percentile over the whole league — two
+    denominators feeding one window axis.  That must be stated."""
+    body = _payload(monkeypatch)
+    coverage = body["coverage"]["playoffSimCoverage"]
+    assert coverage["owners"] == 2
+    assert coverage["total"] == 4
+    assert any("NOT comparable" in n for n in body["notes"])
+
+    sources = {r["competitiveWindow"]["inputs"]["competitivenessSource"] for r in body["league"]}
+    assert sources == {"championshipOdds", "lineupScoreRank"}
+
+    uncovered = next(r for r in body["league"] if r["ownerId"] == "owner3")
+    assert uncovered["oddsSource"] == "owner_not_in_simulation"
+    assert uncovered["playoffOdds"] is None
+
+
+def test_market_edge_is_reported_unmeasured_rather_than_computed_across_scales(league, monkeypatch):
+    """MECHANISM TEST for the scale trap.
+
+    ``rosValue`` is 0-100 rest-of-season points; ``canonicalSiteValues``
+    is the 0-9999 dynasty market.  Feeding one to the other yields an
+    edge near -1 for every player — a dead signal that still looks
+    computed.  The endpoint must decline to supply it and say why.
+    """
+    body = _payload(monkeypatch)
+    assert "rosValue" in body["coverage"]["marketEdgeUnmeasured"]["reason"]
+    for target in body["targetPlayers"]:
+        assert target["marketEdge"] is None
+        assert "marketEdge" not in target["signals"]
+    for target in body["targetPositions"]:
+        assert target["marketEfficiency"] is None
+
+
+# ── 3. The engines are genuinely reachable ───────────────────────────
+
+
+def test_the_roster_payload_carries_real_engine_output(league, monkeypatch):
+    """A status-code-only test would pass against an empty payload.
+    This one fails unless the lineup was actually solved."""
+    body = _payload(monkeypatch)
+    roster = body["roster"]
+    assert roster["lineupScore"] > 0
+    assert roster["totalSlots"] == sum(_SLOTS.values())
+    assert roster["filledSlots"] == roster["totalSlots"]
+    # The optimizer's assignment, not a copy of the whole roster.
+    assert roster["values"]["startersRos"] > 0
+    assert roster["values"]["benchRos"] > 0
+    assert roster["values"]["startersRos"] < roster["values"]["ros"]
+    assert abs(roster["lineupScore"] - roster["values"]["startersRos"]) < 0.01
+
+    positions = roster["positions"]
+    assert {"QB", "RB", "WR", "TE"} <= set(positions)
+    assert any(p["tradeableSurplus"] > 0 for p in positions.values())
+
+    assert len(body["partners"]) == 3
+    assert body["partners"] == sorted(
+        body["partners"], key=lambda p: (-p["tradePartnerFitScore"], p["ownerId"])
+    )
+    assert len(body["league"]) == 4
+
+
+def test_target_positions_report_non_viability_instead_of_omitting_it(league, monkeypatch):
+    """ "No candidates" is 'we could not tell', not 'nothing available',
+    and the distinction is never collapsed — so non-viable positions
+    come back too, unranked."""
+    body = _payload(monkeypatch)
+    targets = body["targetPositions"]
+    assert targets
+    viabilities = {t["viability"] for t in targets}
+    assert viabilities <= {"viable", "noCandidates", "noObtainableUpgrade", "immaterialGain"}
+    for target in targets:
+        assert target["reason"]
+        if target["viability"] != "viable":
+            assert target["priority"] == 0.0
+
+    viable = [t for t in targets if t["viability"] == "viable"]
+    assert viable == sorted(viable, key=lambda t: (-t["priority"], t["position"]))
+
+
+def test_rejected_target_players_carry_their_reason(league, monkeypatch):
+    body = _payload(monkeypatch)
+    players = body["targetPlayers"]
+    assert players
+    for target in players:
+        assert target["reason"]
+        if not target["recommended"]:
+            assert target["corroborating"] == [] or len(target["corroborating"]) >= 0
+    yields = body["coverage"]["corroborationYield"]
+    assert yields["evaluated"] == len(players)
+    assert yields["recommended"] == sum(1 for t in players if t["recommended"])
+
+
+def test_candidate_policy_declares_the_search_non_exhaustive(league, monkeypatch):
+    body = _payload(monkeypatch)
+    policy = body["coverage"]["candidatePolicy"]
+    assert policy["exhaustive"] is False
+    assert policy["maxPerPosition"] == gameplan.MAX_CANDIDATES_PER_POSITION
+    assert "NOT MEASURED" in policy["note"]
+
+
+def test_packages_are_omitted_without_a_named_partner(league, monkeypatch):
+    body = _payload(monkeypatch)
+    assert body["packages"] is None
+    assert "partner=" in body["packagesOmitted"]["howTo"]
+
+
+def test_unknown_partner_is_reported_not_crashed(league, monkeypatch):
+    body = _payload(monkeypatch, "?team=owner0&partner=ghost")
+    assert body["packages"]["error"] == "unknown_partner"
+    assert body["packages"]["frontier"] == []
+
+
+def test_every_package_rejection_is_explained(league, monkeypatch):
+    body = _payload(monkeypatch, "?team=owner3&partner=owner0")
+    packages = body["packages"]
+    assert packages["rejected"]
+    for member in packages["rejected"]:
+        assert member["rejection"] != "none"
+        assert member["rejectionDetail"], member
+    assert packages["stages"]
+    assert packages["partner"]["ownerId"] == "owner0"
+
+
+# ── Caching ──────────────────────────────────────────────────────────
+
+
+def test_second_request_is_served_from_cache(league, monkeypatch):
+    """The league build is ~1.35 s on the real league, so a warm
+    request must not redo it."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        first = c.get("/api/gameplan?team=owner0").json()
+        second = c.get("/api/gameplan?team=owner0").json()
+    assert first["timing"]["leagueBuildCached"] is False
+    assert first["timing"]["teamBuildCached"] is False
+    assert second["timing"]["leagueBuildCached"] is True
+    assert second["timing"]["teamBuildCached"] is True
+    assert first["timing"]["sourceStamp"] == second["timing"]["sourceStamp"]
+    assert second["roster"] == first["roster"]
+
+
+def test_a_new_contract_invalidates_the_cache(league, monkeypatch):
+    """Keyed on the identity of the inputs, not a clock: a refresh must
+    invalidate immediately rather than serving a stale build until a
+    TTL expires."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        stub = _install_contract(monkeypatch)
+        first = c.get("/api/gameplan?team=owner0").json()
+        monkeypatch.setattr(
+            server,
+            "latest_contract_data",
+            {**stub, "scrapeTimestamp": "2026-07-28T00:00:00Z"},
+        )
+        second = c.get("/api/gameplan?team=owner0").json()
+    assert first["timing"]["sourceStamp"] != second["timing"]["sourceStamp"]
+    assert second["timing"]["leagueBuildCached"] is False
+
+
+def test_a_new_roster_snapshot_invalidates_the_cache(league, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        first = c.get("/api/gameplan?team=owner0").json()
+        league["snapshot"].write_text(json.dumps(_snapshot() + [{}]), encoding="utf-8")
+        second = c.get("/api/gameplan?team=owner0").json()
+    assert first["timing"]["sourceStamp"] != second["timing"]["sourceStamp"]
+    assert second["timing"]["leagueBuildCached"] is False
+
+
+# ── The scoring-profile / league-key split ───────────────────────────
+
+
+def test_rosters_follow_the_league_and_ages_follow_the_scoring_profile(league, monkeypatch):
+    """CLAUDE.md's central rule, asserted at the seam.
+
+    Rosters, slots and replacement levels come from the LEAGUE's own
+    snapshot and registry entry; ages and market prices come from the
+    scoring-profile-scoped contract.  If ages were league-scoped, a
+    contract carrying a different profile's players would still have to
+    feed them — and it does, which is the point.
+    """
+    body = _payload(monkeypatch)
+    coverage = body["coverage"]
+    # 4 rosters x 14 players, straight from the league snapshot.
+    assert coverage["rosters"] == 4
+    assert coverage["rosteredPlayers"] == 4 * sum(count for _pos, count in _SHAPE)
+    assert coverage["starterSlots"] == sum(_SLOTS.values())
+    # Ages joined off the contract, not off the roster snapshot (which
+    # carries none).
+    assert coverage["ageCoverage"]["withAge"] == coverage["rosteredPlayers"]
+    assert "scoring-profile scoped" in coverage["ageCoverage"]["source"]
+    assert coverage["marketPriceCoverage"]["priced"] == coverage["rosteredPlayers"]

--- a/tests/api/test_private_auth.py
+++ b/tests/api/test_private_auth.py
@@ -26,6 +26,9 @@ PRIVATE_API_PATHS = [
     "/api/data/rank-history",
     "/api/data/player-source-history",
     "/api/terminal",
+    # Roster intelligence: needs, competitive window, trade targets and
+    # partner fit for a named team. Strictly more private than /api/data.
+    "/api/gameplan",
     "/api/trade/suggestions",
     "/api/trade/finder",
     "/api/trade/simulate",


### PR DESCRIPTION
## The gap this closes

`src/roster_intel/` merged with **no caller**. Before this PR,
`git grep -l roster_intel` excluding `src/roster_intel/`, `tests/` and
`docs/` returned nothing — not `server.py`, not `src/api/`, not
`frontend/`. `analyze_roster`, the per-position profiles, the
five-state competitive window, both target engines, the partner model
and the Trade Package Generator were reachable only from a Python REPL.

`GET /api/gameplan` is the first caller that engine has ever had.
**Backend only** — no frontend work, per the brief.

## Shape

```
GET /api/gameplan?leagueKey=<key>&team=<ownerId>&partner=<ownerId>
```

| Param | Required | Meaning |
|---|---|---|
| `leagueKey` | no | standard resolver: explicit key -> user's `activeLeagueKey` -> registry default |
| `team` | no | ownerId; falls back to the session's Sleeper id, then the league's `default_team_map`, then 400 `team_required` |
| `partner` | no | ownerId. Its **presence** switches the package generator on |

Response (`contractVersion: "2026-07-27.v1"`, versioned like `/api/data`):

```jsonc
{
  "contractVersion": "…", "leagueKey": "…", "scoringProfile": "…",
  "team":            { "ownerId": "…", "teamName": "…" },
  "roster":          { /* analyze_roster().to_dict() verbatim */ },
  "partners":        [ /* assess_partners() */ ],
  "targetPositions": [ /* rank_target_positions() */ ],
  "targetPlayers":   [ /* rank_target_players() */ ],
  "packages":        { /* generate_packages(): frontier, bestBy, rejected, stages */ } | null,
  "league":          [ /* per-team window + odds summary */ ],
  "coverage":        { /* what was measured, what abstained, why */ },
  "notes":           [ … ],
  "fieldPolicy":     { /* what a consumer may NOT do with these fields */ },
  "limitations":     { "targets": …, "partner": …, "packages": … },
  "timing":          { "leagueBuildMs": …, "teamBuildMs": …,
                       "leagueBuildCached": …, "teamBuildCached": …,
                       "sourceStamp": "…" }
}
```

Routing contract is the documented one: 400 `unknown_league`, 400
`inactive_league`, 503 `data_not_ready`, 404 `no_leagues_configured`,
plus 404 `team_not_found` and 400 `team_required`. Every response —
success and error — stamps `leagueKey`. The endpoint is session-gated
by `_private_api_gate` and pinned there by `test_private_auth.py`.

## Scoring profile vs league key

**By `leagueKey`** — rosters (`data/ros/team_strength/<key>.json`'s
`fullRoster`, not the 26-player `startingLineup + benchDepth` view
ADR-011 flagged), starter slots from the registry, replacement levels
and scarcity measured from *this league's own* rosters, every lineup
solve, the window, partner fit, packages, and playoff odds from
`data/ros/sims/<key>_playoff.json`.

**By scoring profile** — player ages and market site values, read off
the live contract's `playersArray`. Player metadata and rankings, so
same-profile leagues share them.

Gameplan is roster/trade intelligence, so it 503s when the loaded
contract's `leagueKey` differs — the rule `/api/terminal` and
`/api/trade/*` follow.

## Timing — measured, not estimated

Real 12-team league, 57-man rosters, 21 starter slots:

| | ms |
|---|---|
| `measure_endogenous_starters` (12 teams) | 89 |
| `compute_replacement_levels` (reusing it) | 2 |
| `compute_scarcity` | 1 |
| `optimal_score` x12 | 52 |
| **`analyze_roster` x12** | **1,195** |
| `assess_partners` (11) | 0.5 |
| `rank_target_positions` (97 candidates) | 277 |
| `rank_target_players` (97 candidates) | 271 |
| `generate_packages` (8x8) | 146 |

`analyze_roster` dominates and there is no cheap version: it re-solves
the lineup once per position for the marginals and once per starter for
the absence impacts, ~91 ms per roster.

End to end through the endpoint:

| | ms |
|---|---|
| cold, no partner | 2,410 |
| **warm, same request** | **10** |
| cold, second team (league bundle cached) | 576 |
| cold, with packages | 684 |
| warm, with packages | 14 |

Payload 90 KB without packages, 124 KB with — **14 KB gzipped**.

Two caches keyed on a **source stamp**, not a clock: snapshot mtimes +
the contract's scrape timestamp + the contract version. A refresh
invalidates immediately; a quiet hour never serves something newer than
it claims. The league bundle is shared across teams; per-team payloads
are LRU-bounded at 64 entries and dropped wholesale when their bundle
is rebuilt. Cold builds run in a threadpool, and `timing` is stamped on
every response so the cost stays measurable in production rather than
re-guessed.

**Follow-up worth doing:** warm the bundle at the end of the ROS
refresh, removing the 1.35 s cold path. Out of scope here — that is a
change to the scrape pipeline, not the API.

## Honesty stamps

Engine `to_dict()` output is passed through **unchanged**. The payload
is never re-projected field by field, because that is how a caveat gets
dropped in a refactor. Carried through and pinned by tests:

- **`acceptancePlausibility`** ships with the engine's
  `acceptanceCaveat`. A test walks the whole payload and fails if any
  key containing "probabilit" appears on an acceptance path. Rejections
  are never observed, so the rate is statistically unidentifiable and
  the rename is inadmissible. `limitations.partner` rides along, as
  `partner.describe_limitations()` requires.
- **Confidence intervals stay `null`.** A test asserts a team with odds
  but no interval keeps `null`, that a team *with* intervals keeps them
  (so the first assertion is not measuring a blanket drop), and that no
  `*Ci` field anywhere in the payload has equal endpoints.
- **`winNowWeight`** is `null` when candidate ages are missing, and
  `fieldPolicy` declares it non-sortable and non-filterable. Passing
  `?sort=winNowWeight` must not reorder anything, which is tested.
- **`thresholdsAreMeasured: false`** and its siblings
  (`materialityFloorIsMeasured`, `winNowWeightsAreMeasured`,
  `baseAcceptancePriorIsMeasured`) reach the API.
- **The Pareto frontier is returned wide.** No blended score is
  invented; `bestBy` names which axis each member wins. A test fails if
  a frontier member grows `score` / `rank` / `compositeScore`.
- The `_semantics` block on each `needs` entry survives — it exists
  because a consumer derived deficit as `fragility x marginal` and got
  the roster's *strongest* position reported as its biggest hole.

Packages are valued through `cross_market.value_package`, i.e. the
single-market path — never the mixed KTC+IDPTC addition.

## What I left out, and why

- **`market_values` / `market_prices` for the target engines.** They
  compute `(rosValue - price) / price`. `rosValue` is 0-100
  rest-of-season points; the only prices this server holds are
  `canonicalSiteValues` on the 0-9999 dynasty market. Feeding one to
  the other yields an edge near -1 for **every player alive** — a dead
  signal that still looks computed. Not supplied;
  `coverage.marketEdgeUnmeasured` says so and `marketEdge` is `null`
  throughout.
- **`availability`** for `rank_target_players`. No measured source
  exists, and a plausible-looking one defeats the corroboration gate:
  supplying "0.6 if their owner has surplus here" moves the strongest
  roster from **1 of 97** recommended to **93 of 97**. That is the exact
  failure the gate exists to prevent, so the input is omitted and the
  measurement is recorded in `coverage.corroborationYield`.
- **Packages for all partners at once.** ~1.6 s, and the module's own
  docs say caller pre-filtering is the single biggest lever on quality.
  One named counterparty per request.
- **Full `RosterIntel` for all 12 teams.** 115 KB, mostly unread. The
  `league` array carries a window + odds summary per team; any team's
  complete intel is one `?team=<ownerId>` away.

## Things in the engines that resisted being surfaced honestly

1. **The playoff sim covers 8 of 12 rosters.**
   `window.league_competitiveness` takes the championship-odds
   percentile across *the rows it was given*, so covered owners are
   ranked against a pool of 8 while uncovered owners fall back to a
   lineup-score percentile across all 12. Two different denominators
   feed one window axis, and the resulting states are not comparable
   across the boundary. Not fixable from the API layer without changing
   an engine, so it is reported: `coverage.playoffSimCoverage` plus a
   top-level note, and each roster's
   `competitiveWindow.inputs.competitivenessSource` already says which
   one it got.

2. **`winNowWeight` carries two different quantities under one name.**
   On a `viable` row it is `horizon_weight` — per-position, keyed to the
   age of that position's obtainable upgrades. On every non-viable row
   the engine stamps the **global** `win_now_weight` scalar instead,
   identical across positions, because there were no candidates to take
   a mean age over. Two rows can therefore differ on this field purely
   because one was rankable. Recorded in `fieldPolicy` as a second,
   independent reason the field must not be sorted on, and pinned by a
   test.

3. **`generate_packages` sorts its frontier by `-value_efficiency`,** so
   in an IDP league the top of the frontier is dominated by
   cross-market artefacts: a DL priced on `idpTradeCalc` against a WR
   priced on `ktcSfTep` reads as a +187% gain while the fairness term is
   correctly suppressed. The engine's own `notes` say so per package and
   they are passed through untouched — but a consumer reading
   `valueEfficiency` alone will be misled. Worth an engine-side look;
   not papered over here.

4. **Defaulting `partner` to the highest-fit counterparty would be
   useless.** On the real league the top-ranked partner has zero
   tradeable surplus the contract prices, so the frontier comes back
   empty. Partner fit ranks structural complementarity; it does not know
   whether the counterparty has anything movable. `partner` is therefore
   explicit, and `assetPolicy.theirAssetsOffered` reports the count so an
   empty frontier is legible rather than mysterious.

5. **`MAX_CANDIDATES_PER_POSITION` is lossy in a way worth naming.**
   Capping by descending `rosValue` is safe for players sharing slot
   eligibility, but a DL/LB hybrid can out-gain a higher-valued pure DL
   by filling a slot the other cannot. `coverage.candidatePolicy` stamps
   `exhaustive: false` and explains it.

## Tests

`tests/api/test_gameplan_endpoint.py` — 30 tests over three jobs: the
routing contract (every error condition plus the `leagueKey` stamp),
the honesty stamps surviving serialization, and proof the engines are
genuinely reachable (a status-code-only test would pass against an
empty payload). Plus `/api/gameplan` added to `test_private_auth.py`'s
gated-endpoint list.

The fixture builds a 4-team synthetic league with a deliberate hole on
two rosters, because a flat fixture makes every position read
`immaterialGain` and never exercises the viability branch — the first
version did exactly that and the assertion caught it.

## Environment note

The container had `pydantic` 1.10.26 installed against `fastapi`
0.140.0, which broke pytest collection for 33 test modules repo-wide
(`cannot import name 'IncEx' from 'pydantic.main'`). Pre-existing, not
introduced here; repaired locally to run the suite. No dependency file
is changed by this PR, but it is worth checking how the pin drifted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_