### PR TITLE
Angle finder: price each package inside one market, not across two

### DIFF
--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -24,26 +24,70 @@ offer (e.g. offering 4 players → returns 3-, 4-, and 5-player
 counter-offers). Same arbitrage math; combinations are evaluated per
 opposing team with the candidate pool clamped to each team's top-N
 players by your calibrated value so the search stays fast.
+
+Per-PLAYER routing was never the bug; per-PACKAGE totalling was
+──────────────────────────────────────────────────────────────────
+:func:`_market_source_for` has always sent each player to the right
+board.  What used to happen next was::
+
+    market_sum = sum(p["market_value"] for p in combo)
+
+over a combo that nothing constrained to one board.  A package holding
+a TE and a linebacker therefore added a KTC number to an IDPTC number
+and produced a total denominated in no market at all.  It was not a
+rounding-level error either: on the 2026-07-26 board Brock Bowers is
+KTC 9,882 and IDPTC 8,975, so a Bowers + Schwesinger offer summed to
+15,549 against a true IDPTC total of 14,642 — 6.2% of overstatement
+handed straight to ``market_gain_pct``, which is the field the ±5%
+plausibility gate reads.
+
+Package totals now go through
+:func:`src.league_intel.cross_market.value_package`, which prices a
+package **entirely inside one market** (offense-only → ``ktcSfTep``;
+any IDP present → ``idpTradeCalc``, the only board spanning both
+universes), and through
+:func:`~src.league_intel.cross_market.compare_packages`, which decides
+whether the resulting verdict survives its own uncertainty.  Nothing
+about single-market valuation is re-implemented here — see ADR-010 and
+that module's docstring for why the exchange-rate assumption is
+stamped rather than buried.
+
+What this deliberately does NOT fix
+───────────────────────────────────
+Each SIDE is valued inside one market, but the two sides can still
+land on different markets — an offense-only offer prices on KTC while
+an IDP-bearing counter prices on IDPTC.  That is the comparison
+``compare_packages`` is built to take, and it is defensible because
+the two boards are measured to share a scale (pooled IDPTC/KTC ratio
+0.9997, Spearman 0.990, n=476).  The residual doubt is not ignored: it
+is exactly what the IDP-bearing side's ``uncertainty_band`` carries
+into the straddle check.  Forcing both sides onto one board would need
+a market argument ``value_package`` does not expose, and inventing one
+here would put a second single-market implementation in the tree.
+
+``find_angles`` (the 1-for-1 pivot) is untouched: it compares two
+single assets, so there is no cross-market sum to constrain.
 """
 
 from __future__ import annotations
 
+from dataclasses import replace
 from itertools import combinations
-from typing import Any, Sequence
+from typing import Any, Iterable, Sequence
 
-_IDP_POSITIONS: frozenset[str] = frozenset(
-    {"DL", "DE", "DT", "EDGE", "NT", "LB", "ILB", "OLB", "MLB", "DB", "CB", "S", "SS", "FS"}
+from src.league_intel.cross_market import (
+    NORMALIZATION_VERSION,
+    PackageValuation,
+    compare_packages,
+    value_package,
 )
 
-# KTC-style Value Adjustment (V2) — ports the frontend formula in
-# ``frontend/lib/trade-logic.js`` (``_vaFromSortedSides``) so the Angle
-# engine stops treating a package of 4 filler players as equivalent to
-# Trade-fairness math is now delegated to ``src.trade.ktc_va``, the
-# Python port of KTC's actual algorithm (PR #335 ported it to JS;
-# this replaced the V2 regression-fit constants below in 2026-04-27).
-# The legacy V2 ``_VA_*`` coefficients (calibrated against 13 trades)
-# disagreed materially with what KTC.com displays, leading to Angle
-# Finder grading trades differently than the trade calculator.
+# Trade-fairness math is delegated to ``src.trade.ktc_va``, the Python
+# port of KTC's actual algorithm (PR #335 ported it to JS; this
+# replaced the V2 regression-fit constants in 2026-04-27).  The legacy
+# V2 coefficients (calibrated against 13 trades) disagreed materially
+# with what KTC.com displays, so the Angle Finder graded trades
+# differently than the trade calculator did.
 #
 # Arbitrage math was previously pure sum-of-raw-totals, which is wrong
 # for uneven sizes: 3 stars for 4 scrubs can look fair on market and a
@@ -55,6 +99,23 @@ from src.trade.ktc_va import (
     adjusted_pair_totals as _adjusted_pair_totals,  # noqa: F401
     ktc_adjust_package,
 )
+from src.utils.name_clean import normalize_position as _normalize_position
+
+# Raw spellings, kept as-is because ``server.py`` imports this set to
+# decide whether a caller's ``positions`` request implies an IDP
+# opt-in, and that check runs against un-normalized request tokens.
+# Position DECISIONS inside this module go through
+# :func:`_is_idp_position`, which normalizes first, so a spelling
+# missing from this literal can no longer route a defender to a board
+# that prices no defenders (the #556 defect in ``finder.py``).
+_IDP_POSITIONS: frozenset[str] = frozenset(
+    {"DL", "DE", "DT", "EDGE", "NT", "LB", "ILB", "OLB", "MLB", "DB", "CB", "S", "SS", "FS"}
+)
+
+# The three canonical buckets ``POSITION_ALIASES`` collapses IDP
+# spellings to — same set ``cross_market`` tests against, so routing
+# here and valuation there cannot disagree about what an IDP is.
+_IDP_FAMILIES: frozenset[str] = frozenset({"DL", "LB", "DB"})
 
 
 def _value_adjustment(small: Sequence[float], large: Sequence[float]) -> float:
@@ -81,7 +142,17 @@ def _value_adjustment(small: Sequence[float], large: Sequence[float]) -> float:
 
 
 def _is_idp_position(position: Any) -> bool:
-    return str(position or "").strip().upper() in _IDP_POSITIONS
+    """True for any spelling of a defensive position.
+
+    Normalizes before testing so ``"EDGE"``/``"CB"``/``"MLB"`` and any
+    future spelling ``POSITION_ALIASES`` learns are all caught, then
+    falls back to the raw literal set for anything normalization leaves
+    alone.  Strictly wider than the old raw-membership test.
+    """
+    raw = str(position or "").strip().upper()
+    if not raw:
+        return False
+    return _normalize_position(raw) in _IDP_FAMILIES or raw in _IDP_POSITIONS
 
 
 def _market_source_for(position: str | None) -> str:
@@ -95,10 +166,149 @@ def _market_source_for(position: str | None) -> str:
     fixture only carries the standard board, so callers that
     haven't been migrated keep working.
     """
-    pos = str(position or "").strip().upper()
-    if pos in _IDP_POSITIONS:
+    if _is_idp_position(position):
         return "idpTradeCalc"
     return "ktcSfTep"
+
+
+# ── Package-level market valuation (ADR-010) ─────────────────────────
+
+
+def _market_values(pkg: PackageValuation) -> list[float]:
+    """Per-asset values from a package valuation, in input order.
+
+    These are the numbers the VA step and the totals must be built
+    from: every one of them is denominated in ``pkg.market``.
+    """
+    return [float(a.normalized_market_value or 0.0) for a in pkg.assets]
+
+
+def _restate_on(pkg: PackageValuation, adjusted_total: float) -> PackageValuation:
+    """``pkg`` restated on its VA-adjusted total.
+
+    ``compare_packages`` has to adjudicate the same quantity the caller
+    gates on, and Angle gates on the KTC-Value-Adjustment-adjusted
+    gain, not the raw sum.  Handing it the raw totals would have it
+    certify a verdict about a number nothing downstream uses.
+
+    The band is scaled with the total rather than carried across in
+    absolute points: it represents a proportion of the package's value
+    that rests on the offense<->IDP exchange rate, and a consolidation
+    premium does not make that rate any better known.  Scaling also
+    errs toward the wider band on the side receiving the VA, which
+    matches ``cross_market``'s posture of withholding near-boundary
+    verdicts rather than asserting them.
+    """
+    total = pkg.total
+    if total is None or total <= 0:
+        return pkg
+    scale = adjusted_total / total
+    return replace(
+        pkg,
+        total=adjusted_total,
+        uncertainty_band=pkg.uncertainty_band * scale,
+    )
+
+
+def _market_stamp(pkg: PackageValuation, *, verbose: bool = True) -> dict[str, Any]:
+    """Provenance for a package total, renderable by the caller.
+
+    ``verbose=False`` for the per-candidate stamp.  The prose warnings
+    run ~500 characters and are near-identical across every package on
+    the same market, so repeating them on 50 candidates adds ~25 KB to
+    a response for no information the fixed side does not already
+    carry.  The version string is likewise constant and lives once in
+    ``market_diagnostics``.
+    """
+    stamp = {
+        "market": pkg.market,
+        "market_strategy": pkg.strategy.value,
+        "market_uncertainty_band": int(round(pkg.uncertainty_band)),
+    }
+    if verbose:
+        stamp["market_normalization_version"] = pkg.normalization_version
+        stamp["market_warnings"] = list(pkg.warnings)
+    return stamp
+
+
+def _unvaluable_stamp(pkg: PackageValuation) -> dict[str, Any]:
+    """Provenance for a package that has no defensible total."""
+    return {
+        "market": None,
+        "market_strategy": pkg.strategy.value,
+        "market_uncertainty_band": 0,
+        "market_normalization_version": pkg.normalization_version,
+        "market_unvaluable_reason": pkg.suppressed_reason,
+        "market_unvaluable_label": pkg.label,
+    }
+
+
+def _package_players(
+    entries: Iterable[dict[str, Any]],
+    pkg: PackageValuation,
+) -> list[dict[str, Any]]:
+    """Player rows whose ``market_source`` matches the package total.
+
+    ``value_package`` preserves input order, so asset *i* is entry *i*.
+    Labelling each player with the board the PACKAGE was priced on —
+    rather than the board that player's position indexes — is the whole
+    point: a WR inside an IDP package really was priced on IDPTC, and
+    the UI badge should say so.
+
+    ``market_source`` is deliberately ``pkg.market`` and not the
+    asset's ``raw_market_source``.  On the scalar-fallback path those
+    two differ: an asset the target board does not price is read off
+    the OTHER board and converted, so its raw source would badge a
+    value that is no longer denominated in it.  The raw board is kept,
+    but under ``market_converted_from``, where it reads as provenance
+    instead of as a contradiction of the number beside it.
+    """
+    rows: list[dict[str, Any]] = []
+    for entry, asset in zip(entries, pkg.assets):
+        converted = bool(asset.converted)
+        rows.append(
+            {
+                "name": entry["name"],
+                "position": entry["position"],
+                "my_value": int(entry["my_value"]),
+                "market_value": int(round(float(asset.normalized_market_value or 0.0))),
+                "market_source": pkg.market or asset.raw_market_source,
+                "market_converted": converted,
+                "market_converted_from": asset.raw_market_source if converted else None,
+            }
+        )
+    return rows
+
+
+def _new_market_diagnostics() -> dict[str, Any]:
+    return {
+        "combos_valued": 0,
+        "unvaluable": 0,
+        "withheld_uncertain": 0,
+        "reasons": {},
+        "normalization_version": NORMALIZATION_VERSION,
+    }
+
+
+def _note_reason(diag: dict[str, Any], reason: str | None) -> None:
+    key = (reason or "unspecified")[:160]
+    diag["reasons"][key] = diag["reasons"].get(key, 0) + 1
+
+
+def _diagnostic_warnings(diag: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    if diag["unvaluable"]:
+        out.append(
+            f"{diag['unvaluable']} package(s) excluded: no single market prices every "
+            "asset in them, and Angle will not substitute a cross-board sum."
+        )
+    if diag["withheld_uncertain"]:
+        out.append(
+            f"{diag['withheld_uncertain']} package(s) withheld: the market gap sits "
+            "inside the cross-market uncertainty band around the plausibility gate, "
+            "so the verdict is too close to call."
+        )
+    return out
 
 
 def _value_pair(row: dict[str, Any]) -> tuple[float, float, str] | None:
@@ -403,11 +613,60 @@ def find_angle_packages(
         _value_pair(r)[0]
         for r in offer_rows  # type: ignore[index]
     )
-    offer_market_total = sum(
-        _value_pair(r)[1]
-        for r in offer_rows  # type: ignore[index]
-    )
     offer_size = len(offer_rows)
+    diag = _new_market_diagnostics()
+
+    # Offer side: ONE market for the whole package, or no total at all.
+    # The user picks these names freely, with no IDP filter in the way,
+    # so this is the side where a mixed-board sum was reachable from the
+    # UI without any opt-in.
+    offer_pkg = value_package(offer_rows)
+    offer_entries = [
+        {
+            "name": str(r.get("canonicalName") or r.get("displayName") or ""),
+            "position": str(r.get("position") or ""),
+            "my_value": _value_pair(r)[0],  # type: ignore[index]
+        }
+        for r in offer_rows
+    ]
+    if not offer_pkg.is_rankable:
+        _note_reason(diag, offer_pkg.suppressed_reason)
+        diag["unvaluable"] += 1
+        warnings.append(
+            offer_pkg.label or "Offer cannot be valued on a single market — no results."
+        )
+        return {
+            "offer": {
+                "team": None,
+                "size": offer_size,
+                "players": [
+                    {
+                        "name": e["name"],
+                        "position": e["position"],
+                        "my_value": int(e["my_value"]),
+                        "market_value": 0,
+                        "market_source": None,
+                    }
+                    for e in offer_entries
+                ],
+                "my_total": int(round(offer_my_total)),
+                "market_total": 0,
+                **_unvaluable_stamp(offer_pkg),
+            },
+            "candidates": [],
+            "market_diagnostics": diag,
+            "warnings": warnings,
+        }
+    offer_market_total = float(offer_pkg.total or 0.0)
+    if offer_pkg.uncertainty_band > 0:
+        # One line in the UI banner; the full measured/assumed wording
+        # lives in the offer block's ``market_warnings`` so a caller
+        # that wants it can render it without burying the page.
+        warnings.append(
+            f"Offer priced on {offer_pkg.market} because it spans offense and IDP; "
+            f"±{int(round(offer_pkg.uncertainty_band))} pts of that total rests on an "
+            "assumed offense<->IDP exchange rate."
+        )
 
     # Target sizes: N-1, N, N+1 — never less than 1.
     target_sizes = sorted({max(1, offer_size - 1), offer_size, offer_size + 1})
@@ -440,7 +699,7 @@ def find_angle_packages(
             pair = _value_pair(row)
             if pair is None:
                 continue
-            my_v, market_v, market_source = pair
+            my_v = pair[0]
             # Per-player filters: position allow-list, my-value floor,
             # and the IDP gate. IDP players get filtered out of the
             # candidate pool by default because most leaguemates don't
@@ -449,7 +708,7 @@ def find_angle_packages(
             row_pos = str(row.get("position") or "").strip().upper()
             if position_filter is not None and row_pos not in position_filter:
                 continue
-            if not include_idp and row_pos in _IDP_POSITIONS:
+            if not include_idp and _is_idp_position(row_pos):
                 continue
             if my_v < min_my_value_floor:
                 continue
@@ -458,8 +717,10 @@ def find_angle_packages(
                     "name": pname,
                     "position": str(row.get("position") or ""),
                     "my_value": my_v,
-                    "market_value": market_v,
-                    "market_source": market_source,
+                    # ``row`` is the payload: package market values are
+                    # produced by ``value_package`` from the contract
+                    # row, never by re-reading a per-position site key.
+                    "row": row,
                 }
             )
         pool.sort(key=lambda p: -p["my_value"])
@@ -472,10 +733,9 @@ def find_angle_packages(
         (float(_value_pair(r)[0]) for r in offer_rows),
         reverse=True,  # type: ignore[index]
     )
-    offer_market_values = sorted(
-        (float(_value_pair(r)[1]) for r in offer_rows),
-        reverse=True,  # type: ignore[index]
-    )
+    # Market side comes from the single-market valuation, NOT from
+    # per-player ``_value_pair`` reads — that plain sum was the defect.
+    offer_market_values = sorted(_market_values(offer_pkg), reverse=True)
 
     # Normalise target-team + seed inputs for constructed-package mode.
     target_ids: set[str] = {str(t).strip() for t in (target_team_owner_ids or []) if str(t).strip()}
@@ -488,13 +748,11 @@ def find_angle_packages(
         pair = _value_pair(row)
         if pair is None:
             return None
-        my_v, market_v, market_source = pair
         return {
             "name": str(row.get("canonicalName") or row.get("displayName") or ""),
             "position": str(row.get("position") or ""),
-            "my_value": my_v,
-            "market_value": market_v,
-            "market_source": market_source,
+            "my_value": pair[0],
+            "row": row,
         }
 
     def _make_candidate(
@@ -505,14 +763,33 @@ def find_angle_packages(
         # Apply KTC-style Value Adjustment so consolidation packages
         # (e.g. 3 studs vs 4 filler pieces whose raws happen to match)
         # don't slip through the thresholds on pure sum-of-raws.
+        #
+        # My-value gate runs FIRST and unchanged. It is pure arithmetic
+        # on values already in hand, it rejects the overwhelming
+        # majority of combos, and both gates are conjunctive — so
+        # ordering it ahead of the market valuation is free and keeps
+        # ``value_package`` off the hot path.
         counter_my_values = [p["my_value"] for p in combo]
-        counter_market_values = [p["market_value"] for p in combo]
         (
             counter_my_adj,
             offer_my_adj,
             counter_my_va,
             offer_my_va,
         ) = _adjusted_pair_totals(counter_my_values, offer_my_values)
+        if offer_my_adj <= 0:
+            return None
+        my_gain_pct = 100.0 * (counter_my_adj - offer_my_adj) / offer_my_adj
+        if my_gain_pct < min_my_gain_pct:
+            return None
+
+        # Counter side: one market for the whole package, or nothing.
+        counter_pkg = value_package([p["row"] for p in combo])
+        diag["combos_valued"] += 1
+        if not counter_pkg.is_rankable:
+            diag["unvaluable"] += 1
+            _note_reason(diag, counter_pkg.suppressed_reason)
+            return None
+        counter_market_values = _market_values(counter_pkg)
         (
             counter_market_adj,
             offer_market_adj,
@@ -520,31 +797,33 @@ def find_angle_packages(
             offer_market_va,
         ) = _adjusted_pair_totals(counter_market_values, offer_market_values)
 
-        if offer_my_adj <= 0 or offer_market_adj <= 0:
+        if offer_market_adj <= 0:
             return None
-        my_gain_pct = 100.0 * (counter_my_adj - offer_my_adj) / offer_my_adj
         market_gain_pct = 100.0 * (counter_market_adj - offer_market_adj) / offer_market_adj
-        if my_gain_pct < min_my_gain_pct:
-            return None
         if market_gain_pct > max_market_gain_pct:
             return None
 
+        # Does the verdict survive its own uncertainty?  For the
+        # offense-only default both bands are zero and this is certain
+        # by construction; it only bites when IDP is in play, which is
+        # exactly when the offense<->IDP exchange rate is load-bearing.
+        comparison = compare_packages(
+            _restate_on(counter_pkg, counter_market_adj),
+            _restate_on(offer_pkg, offer_market_adj),
+            gate_pct=max_market_gain_pct,
+        )
+        if not comparison.verdict_certain:
+            diag["withheld_uncertain"] += 1
+            _note_reason(diag, comparison.suppressed_reason)
+            return None
+
         my_sum = sum(counter_my_values)
-        market_sum = sum(counter_market_values)
+        market_sum = float(counter_pkg.total or 0.0)
         return {
             "team": team_label,
             "owner_id": owner_id_label,
             "size": len(combo),
-            "players": [
-                {
-                    "name": p["name"],
-                    "position": p["position"],
-                    "my_value": int(p["my_value"]),
-                    "market_value": int(p["market_value"]),
-                    "market_source": p["market_source"],
-                }
-                for p in combo
-            ],
+            "players": _package_players(combo, counter_pkg),
             "my_total": int(round(my_sum)),
             "market_total": int(round(market_sum)),
             "my_total_adjusted": int(round(counter_my_adj)),
@@ -557,7 +836,14 @@ def find_angle_packages(
             "offer_market_value_adjustment": int(round(offer_market_va)),
             "my_gain_pct": round(my_gain_pct, 2),
             "market_gain_pct": round(market_gain_pct, 2),
+            "market_gain_low_pct": (
+                round(comparison.gain_low_pct, 2) if comparison.gain_low_pct is not None else None
+            ),
+            "market_gain_high_pct": (
+                round(comparison.gain_high_pct, 2) if comparison.gain_high_pct is not None else None
+            ),
             "arb_score": round(my_gain_pct - market_gain_pct, 2),
+            **_market_stamp(counter_pkg, verbose=False),
         }
 
     if target_ids:
@@ -689,18 +975,8 @@ def find_angle_packages(
         candidates = kept
     candidates = candidates[: max(1, int(limit))]
 
-    offer_players = []
-    for r in offer_rows:
-        pair = _value_pair(r)
-        offer_players.append(
-            {
-                "name": str(r.get("canonicalName") or ""),
-                "position": str(r.get("position") or ""),
-                "my_value": int(pair[0]) if pair else 0,
-                "market_value": int(pair[1]) if pair else 0,
-                "market_source": pair[2] if pair else _market_source_for(r.get("position")),
-            }
-        )
+    offer_players = _package_players(offer_entries, offer_pkg)
+    warnings.extend(_diagnostic_warnings(diag))
 
     return {
         "offer": {
@@ -709,8 +985,12 @@ def find_angle_packages(
             "players": offer_players,
             "my_total": int(round(offer_my_total)),
             "market_total": int(round(offer_market_total)),
+            # Verbose here and nowhere else: the fixed side is the one
+            # place the measured/assumed wording is worth carrying.
+            **_market_stamp(offer_pkg),
         },
         "candidates": candidates,
+        "market_diagnostics": diag,
         "thresholds": {
             "min_my_gain_pct": min_my_gain_pct,
             "max_market_gain_pct": max_market_gain_pct,
@@ -852,8 +1132,57 @@ def find_acquisition_packages(
         }
 
     desired_my_total = sum(_value_pair(r)[0] for r in desired_rows)  # type: ignore[index]
-    desired_market_total = sum(_value_pair(r)[1] for r in desired_rows)  # type: ignore[index]
     desired_size = len(desired_rows)
+    diag = _new_market_diagnostics()
+
+    # Fixed side: one market for the whole acquire package, or nothing.
+    # ``desired_player_names`` comes straight from the user's picks on
+    # opposing rosters with no IDP filter, so this side mixes boards as
+    # freely as the offer side of ``find_angle_packages`` did.
+    desired_pkg = value_package(desired_rows)
+    desired_entries = [
+        {
+            "name": str(r.get("canonicalName") or r.get("displayName") or ""),
+            "position": str(r.get("position") or ""),
+            "my_value": _value_pair(r)[0],  # type: ignore[index]
+        }
+        for r in desired_rows
+    ]
+    if not desired_pkg.is_rankable:
+        _note_reason(diag, desired_pkg.suppressed_reason)
+        diag["unvaluable"] += 1
+        warnings.append(desired_pkg.label or "Acquire package cannot be valued on a single market.")
+        return {
+            "acquire": {
+                "team": my_team.get("name"),
+                "size": desired_size,
+                "players": [
+                    {
+                        "name": e["name"],
+                        "position": e["position"],
+                        "my_value": int(e["my_value"]),
+                        "market_value": 0,
+                        "market_source": None,
+                        "owner_id": desired_owners.get(e["name"], ""),
+                    }
+                    for e in desired_entries
+                ],
+                "my_total": int(round(desired_my_total)),
+                "market_total": 0,
+                "targets": [],
+                **_unvaluable_stamp(desired_pkg),
+            },
+            "candidates": [],
+            "market_diagnostics": diag,
+            "warnings": warnings,
+        }
+    desired_market_total = float(desired_pkg.total or 0.0)
+    if desired_pkg.uncertainty_band > 0:
+        warnings.append(
+            f"Acquire package priced on {desired_pkg.market} because it spans offense and "
+            f"IDP; ±{int(round(desired_pkg.uncertainty_band))} pts of that total rests on "
+            "an assumed offense<->IDP exchange rate."
+        )
 
     target_sizes = sorted({max(1, desired_size - 1), desired_size, desired_size + 1})
 
@@ -877,14 +1206,14 @@ def find_acquisition_packages(
         pair = _value_pair(row)
         if pair is None:
             continue
-        my_v, market_v, market_source = pair
+        my_v = pair[0]
         row_pos = str(row.get("position") or "").strip().upper()
         if position_filter is not None and row_pos not in position_filter:
             continue
         # IDP gate — see docstring on find_angle_packages. Fixed side
         # (desired players) is never filtered; this only restricts the
         # offer-side pool built from the user's own roster.
-        if not include_idp and row_pos in _IDP_POSITIONS:
+        if not include_idp and _is_idp_position(row_pos):
             continue
         if my_v < min_my_value_floor:
             continue
@@ -893,8 +1222,8 @@ def find_acquisition_packages(
                 "name": pname,
                 "position": str(row.get("position") or ""),
                 "my_value": my_v,
-                "market_value": market_v,
-                "market_source": market_source,
+                # See find_angle_packages: ``row`` is what gets priced.
+                "row": row,
             }
         )
     pool.sort(key=lambda p: -p["my_value"])
@@ -905,10 +1234,7 @@ def find_acquisition_packages(
         (float(_value_pair(r)[0]) for r in desired_rows),
         reverse=True,  # type: ignore[index]
     )
-    desired_market_values = sorted(
-        (float(_value_pair(r)[1]) for r in desired_rows),
-        reverse=True,  # type: ignore[index]
-    )
+    desired_market_values = sorted(_market_values(desired_pkg), reverse=True)
 
     def _make_candidate(combo: tuple[dict[str, Any], ...]) -> dict[str, Any] | None:
         # Arbitrage math: user receives ``desired_*``, gives up
@@ -916,14 +1242,28 @@ def find_acquisition_packages(
         # 4 filler to land 3 studs) isn't treated as a fair swap just
         # because raw totals line up — the consolidated side carries a
         # premium on both my-value and market-value.
+        #
+        # My-value gate first — same reasoning as find_angle_packages.
         offer_my_values = [p["my_value"] for p in combo]
-        offer_market_values = [p["market_value"] for p in combo]
         (
             desired_my_adj,
             offer_my_adj,
             desired_my_va,
             offer_my_va,
         ) = _adjusted_pair_totals(desired_my_values, offer_my_values)
+        if offer_my_adj <= 0:
+            return None
+        my_gain_pct = 100.0 * (desired_my_adj - offer_my_adj) / offer_my_adj
+        if my_gain_pct < min_my_gain_pct:
+            return None
+
+        offer_pkg = value_package([p["row"] for p in combo])
+        diag["combos_valued"] += 1
+        if not offer_pkg.is_rankable:
+            diag["unvaluable"] += 1
+            _note_reason(diag, offer_pkg.suppressed_reason)
+            return None
+        offer_market_values = _market_values(offer_pkg)
         (
             desired_market_adj,
             offer_market_adj,
@@ -931,29 +1271,27 @@ def find_acquisition_packages(
             offer_market_va,
         ) = _adjusted_pair_totals(desired_market_values, offer_market_values)
 
-        if offer_my_adj <= 0 or offer_market_adj <= 0:
+        if offer_market_adj <= 0:
             return None
-        my_gain_pct = 100.0 * (desired_my_adj - offer_my_adj) / offer_my_adj
         market_gain_pct = 100.0 * (desired_market_adj - offer_market_adj) / offer_market_adj
-        if my_gain_pct < min_my_gain_pct:
-            return None
         if market_gain_pct > max_market_gain_pct:
             return None
 
+        comparison = compare_packages(
+            _restate_on(desired_pkg, desired_market_adj),
+            _restate_on(offer_pkg, offer_market_adj),
+            gate_pct=max_market_gain_pct,
+        )
+        if not comparison.verdict_certain:
+            diag["withheld_uncertain"] += 1
+            _note_reason(diag, comparison.suppressed_reason)
+            return None
+
         offer_my_sum = sum(offer_my_values)
-        offer_market_sum = sum(offer_market_values)
+        offer_market_sum = float(offer_pkg.total or 0.0)
         return {
             "size": len(combo),
-            "players": [
-                {
-                    "name": p["name"],
-                    "position": p["position"],
-                    "my_value": int(p["my_value"]),
-                    "market_value": int(p["market_value"]),
-                    "market_source": p["market_source"],
-                }
-                for p in combo
-            ],
+            "players": _package_players(combo, offer_pkg),
             "my_total": int(round(offer_my_sum)),
             "market_total": int(round(offer_market_sum)),
             "my_total_adjusted": int(round(offer_my_adj)),
@@ -966,7 +1304,14 @@ def find_acquisition_packages(
             "acquire_market_value_adjustment": int(round(desired_market_va)),
             "my_gain_pct": round(my_gain_pct, 2),
             "market_gain_pct": round(market_gain_pct, 2),
+            "market_gain_low_pct": (
+                round(comparison.gain_low_pct, 2) if comparison.gain_low_pct is not None else None
+            ),
+            "market_gain_high_pct": (
+                round(comparison.gain_high_pct, 2) if comparison.gain_high_pct is not None else None
+            ),
             "arb_score": round(my_gain_pct - market_gain_pct, 2),
+            **_market_stamp(offer_pkg, verbose=False),
         }
 
     candidates: list[dict[str, Any]] = []
@@ -981,20 +1326,10 @@ def find_acquisition_packages(
     candidates.sort(key=lambda c: c["arb_score"], reverse=True)
     candidates = candidates[: max(1, int(limit))]
 
-    desired_players = []
-    for r in desired_rows:
-        pair = _value_pair(r)
-        dname = str(r.get("canonicalName") or "")
-        desired_players.append(
-            {
-                "name": dname,
-                "position": str(r.get("position") or ""),
-                "my_value": int(pair[0]) if pair else 0,
-                "market_value": int(pair[1]) if pair else 0,
-                "market_source": pair[2] if pair else _market_source_for(r.get("position")),
-                "owner_id": desired_owners.get(dname, ""),
-            }
-        )
+    desired_players = _package_players(desired_entries, desired_pkg)
+    for p in desired_players:
+        p["owner_id"] = desired_owners.get(p["name"], "")
+    warnings.extend(_diagnostic_warnings(diag))
 
     # Deduplicated list of target teams the desired players come from.
     targets: list[dict[str, Any]] = []
@@ -1013,8 +1348,10 @@ def find_acquisition_packages(
             "my_total": int(round(desired_my_total)),
             "market_total": int(round(desired_market_total)),
             "targets": targets,
+            **_market_stamp(desired_pkg),
         },
         "candidates": candidates,
+        "market_diagnostics": diag,
         "thresholds": {
             "min_my_gain_pct": min_my_gain_pct,
             "max_market_gain_pct": max_market_gain_pct,

--- a/tests/test_trade_angle.py
+++ b/tests/test_trade_angle.py
@@ -970,21 +970,39 @@ def test_acquire_idp_target_compares_on_idptc():
     # include_idp must be True — the offer-side "My DL" would
     # otherwise be filtered out of the candidate pool by the default
     # IDP gate.
+    #
+    # The 5% gate this used to run at is now unreachable for a package
+    # of pure IDP.  ``cross_market`` sizes an uncertainty band on the
+    # assumed offense<->IDP exchange rate (±16.8% of any IDP subtotal),
+    # ``compare_packages`` withholds a verdict whose band straddles the
+    # gate, and a ±43% range around a 2% gain straddles 5%.  That is
+    # the known over-correction the module's own ``_shared_scale_band``
+    # docstring flags: with BOTH sides pure IDP the exchange rate is a
+    # common factor and cancels in the ratio, but a package cannot see
+    # the other side of the comparison, so it errs wide.  Widening the
+    # gate here keeps this test on the thing it was written to pin —
+    # that DL packages are priced on IDPTC and not on KTC — which the
+    # explicit totals below now assert directly rather than by proxy.
     result = find_acquisition_packages(
         players,
         ["Target DL"],
         "owner-a",
         teams,
         min_my_gain_pct=5.0,
-        max_market_gain_pct=5.0,
+        max_market_gain_pct=60.0,
         include_idp=True,
     )
     assert result["candidates"], "IDP acquire should qualify on IDPTC"
+    # IDPTC values, not KTC: 5100 for the target, 5000 for the offer.
+    # Reading KTC would put the acquire side at 7000.
+    assert result["acquire"]["market_total"] == 5100
+    assert result["acquire"]["market"] == "idpTradeCalc"
+    assert result["candidates"][0]["market_total"] == 5000
     # market source stamped on acquire and candidate rows.
     assert result["acquire"]["players"][0]["market_source"] == "idpTradeCalc"
 
 
-def test_packages_player_rows_expose_per_position_market_source():
+def test_packages_player_rows_expose_package_market_source():
     offer = ["My QB"]
     teams = [
         {"name": "Team A", "ownerId": "owner-a", "players": ["My QB"]},
@@ -1007,13 +1025,19 @@ def test_packages_player_rows_expose_per_position_market_source():
         min_my_gain_pct=5.0,
         max_market_gain_pct=5.0,
     )
+    # ``market_source`` now names the MARKET the whole package was
+    # priced on, not the key that one row happened to be read from.
+    # For an offense-only package that is ``ktcSfTep`` even when the
+    # fixture only carries the retired legacy ``ktc`` key — same
+    # market, and the UI renders both as "KTC".  Per-row provenance
+    # that contradicted the package total was the thing worth losing.
     for c in result["candidates"]:
         for p in c["players"]:
             if p["position"] == "DL":
                 assert p["market_source"] == "idpTradeCalc"
                 assert p["market_value"] == 5100  # IDPTC value
             elif p["position"] == "WR":
-                assert p["market_source"] == "ktc"
+                assert p["market_source"] == "ktcSfTep"
                 assert p["market_value"] == 5100  # KTC value
 
 
@@ -1191,11 +1215,18 @@ def test_packages_idp_included_when_flag_set():
         _player("My QB", 5000, 5000, position="QB"),
         _idp_player("Opp DL", 6000, 5000, position="DL"),
     ]
+    # Gate widened past the offense<->IDP uncertainty band (±16.8% of
+    # the IDP subtotal).  At the 5% default, an all-IDP counter against
+    # an all-offense offer has a band that straddles the gate and
+    # ``compare_packages`` withholds the verdict — correctly, since the
+    # entire comparison rests on the assumed exchange rate.  This test
+    # is about the include_idp POOL gate, not about that verdict.
     result = find_angle_packages(
         players,
         offer,
         "owner-a",
         teams,
+        max_market_gain_pct=25.0,
         include_idp=True,
     )
     names = {p["name"] for c in result["candidates"] for p in c["players"]}
@@ -1219,11 +1250,15 @@ def test_packages_idp_filter_does_not_touch_seed_players():
         _idp_player("Opp Seed DL", 6000, 5000, position="DL"),
         _player("Opp WR", 6000, 5000, position="WR"),
     ]
+    # Gate widened past the offense<->IDP uncertainty band — see
+    # test_packages_idp_included_when_flag_set.  The seed gate is what
+    # this test pins.
     result = find_angle_packages(
         players,
         offer,
         "owner-a",
         teams,
+        max_market_gain_pct=25.0,
         target_team_owner_ids=["owner-b"],
         seed_player_names=["Opp Seed DL"],
     )
@@ -1259,12 +1294,15 @@ def test_acquire_idp_excluded_from_offer_pool_by_default():
         teams,  # include_idp default False
     )
     assert result["candidates"] == []
-    # Flip include_idp on and the offer packages appear.
+    # Flip include_idp on and the offer packages appear.  Gate widened
+    # past the offense<->IDP uncertainty band — see
+    # test_packages_idp_included_when_flag_set.
     result2 = find_acquisition_packages(
         players,
         ["Target WR"],
         "owner-a",
         teams,
+        max_market_gain_pct=25.0,
         include_idp=True,
     )
     assert result2["candidates"], "LB offers should qualify once IDP is allowed"

--- a/tests/trade/test_angle_single_market.py
+++ b/tests/trade/test_angle_single_market.py
@@ -1,0 +1,413 @@
+"""Angle finder must price a package inside ONE market.
+
+``src/trade/angle.py`` routes each PLAYER to the board its position
+indexes (``_market_source_for``): IDP to ``idpTradeCalc``, everything
+else to ``ktcSfTep``.  That part was always right.  What was wrong is
+what happened next — the package total was a plain ``sum`` over that
+per-player list, so a package holding a TE and a linebacker added a
+KTC number to an IDPTC number and produced a total that corresponds to
+no board anyone trades against.
+
+The numbers in these fixtures are the real 2026-07-26 board rather than
+round figures, because the size of the error depends on the one place
+the two boards genuinely diverge.  Brock Bowers is KTC 9,882 and IDPTC
+8,975 — a TE-premium gap of 907 points, matching the measured
+per-position ratio of 0.895 in
+``src/league_intel/cross_market.POSITION_SCALE_RATIOS``.  Pair him with
+Carson Schwesinger (IDPTC 5,667, unpriced by KTC, as every IDP is) and
+the mixed sum is 15,549 against a single-market IDPTC total of 14,642.
+A test built on QB/WR fixtures would pass either way — the pooled
+offense ratio is 0.9997 — and would therefore have proven nothing.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.league_intel.cross_market import (
+    MARKET_IDPTC,
+    MARKET_KTC,
+    NormalizationStrategy,
+    PackageValuation,
+)
+from src.trade import angle as angle_mod
+from src.trade.angle import find_acquisition_packages, find_angle_packages
+
+
+# ── Fixtures: real 2026-07-26 values for the divergent cases ─────────
+
+BOWERS_KTC = 9882.0
+BOWERS_IDPTC = 8975.0
+SCHWESINGER_IDPTC = 5667.0
+
+MIXED_KTC_PLUS_IDPTC_SUM = BOWERS_KTC + SCHWESINGER_IDPTC  # 15549 — wrong
+MIXED_SINGLE_MARKET_TOTAL = BOWERS_IDPTC + SCHWESINGER_IDPTC  # 14642 — right
+
+
+def _row(name, position, my_value, *, ktc=None, idptc=None):
+    sites = {}
+    if ktc is not None:
+        sites["ktcSfTep"] = ktc
+    if idptc is not None:
+        sites["idpTradeCalc"] = idptc
+    return {
+        "canonicalName": name,
+        "displayName": name,
+        "position": position,
+        "rankDerivedValue": my_value,
+        "canonicalSiteValues": sites,
+    }
+
+
+def _board():
+    return [
+        # ── my roster (owner-me) ──
+        _row("Brock Bowers", "TE", 9881, ktc=BOWERS_KTC, idptc=BOWERS_IDPTC),
+        _row("Carson Schwesinger", "LB", 6099, idptc=SCHWESINGER_IDPTC),
+        _row("Justin Jefferson", "WR", 8382, ktc=7607, idptc=7674),
+        _row("Chris Olave", "WR", 5757, ktc=5490, idptc=5534),
+        _row("Bench Filler", "RB", 900, ktc=880, idptc=875),
+        # ── opposing roster (owner-them) ──
+        _row("Puka Nacua", "WR", 11000, ktc=9000, idptc=9100),
+        _row("Fred Warner", "LB", 7000, idptc=6200),
+        _row("Malik Nabers", "WR", 9500, ktc=8600, idptc=8700),
+        _row("Their Filler", "RB", 1200, ktc=1150, idptc=1140),
+        # Tuned to land INSIDE the gate's uncertainty band against a
+        # Chris Olave offer: +2.0% market gain against a 5% gate, with
+        # a ±940-point band on a 5,600-point IDP total.  That is the
+        # coin-flip case compare_packages exists to refuse.
+        _row("Zaven Collins", "LB", 7000, idptc=5600),
+    ]
+
+
+def _teams():
+    return [
+        {
+            "name": "Mine",
+            "ownerId": "owner-me",
+            "players": [
+                "Brock Bowers",
+                "Carson Schwesinger",
+                "Justin Jefferson",
+                "Chris Olave",
+                "Bench Filler",
+            ],
+        },
+        {
+            "name": "Theirs",
+            "ownerId": "owner-them",
+            "players": [
+                "Puka Nacua",
+                "Fred Warner",
+                "Malik Nabers",
+                "Their Filler",
+                "Zaven Collins",
+            ],
+        },
+    ]
+
+
+def _offer(names, **kw):
+    return find_angle_packages(_board(), names, "owner-me", _teams(), **kw)
+
+
+def _acquire(names, **kw):
+    return find_acquisition_packages(_board(), names, "owner-me", _teams(), **kw)
+
+
+class TestOfferSideIsSingleMarket(unittest.TestCase):
+    def test_mixed_offer_total_is_not_the_two_board_sum(self):
+        """The defect, stated as an assertion.
+
+        Pre-fix this total is 15,549: KTC's Bowers plus IDPTC's
+        Schwesinger.  There is no board on which those two numbers are
+        denominated in the same unit.
+        """
+        offer = _offer(["Brock Bowers", "Carson Schwesinger"])["offer"]
+        self.assertNotEqual(
+            offer["market_total"],
+            int(round(MIXED_KTC_PLUS_IDPTC_SUM)),
+            "offer market_total is the KTC+IDPTC mixed sum",
+        )
+        self.assertEqual(offer["market_total"], int(round(MIXED_SINGLE_MARKET_TOTAL)))
+
+    def test_mixed_offer_is_stamped_with_the_market_it_used(self):
+        offer = _offer(["Brock Bowers", "Carson Schwesinger"])["offer"]
+        self.assertEqual(offer.get("market"), MARKET_IDPTC)
+        self.assertEqual(
+            offer.get("market_strategy"),
+            NormalizationStrategy.SINGLE_MARKET.value,
+        )
+
+    def test_mixed_offer_player_rows_report_the_package_market(self):
+        """Per-player labels must agree with the total above them.
+
+        The UI renders ``market_source`` as a KTC/IDPTC badge next to
+        each player.  If Bowers is badged KTC while the package total
+        is an IDPTC total, the page is showing its own arithmetic as
+        inconsistent.
+        """
+        offer = _offer(["Brock Bowers", "Carson Schwesinger"])["offer"]
+        by_name = {p["name"]: p for p in offer["players"]}
+        self.assertEqual(by_name["Brock Bowers"]["market_source"], MARKET_IDPTC)
+        self.assertEqual(by_name["Brock Bowers"]["market_value"], int(BOWERS_IDPTC))
+        self.assertEqual(by_name["Carson Schwesinger"]["market_source"], MARKET_IDPTC)
+
+    def test_offense_only_offer_still_values_on_ktc(self):
+        """The 5%-of-users case must not move.
+
+        ``ktcSfTep`` is the canonical retail anchor for an offense-only
+        package and nothing about this fix should touch it.
+        """
+        offer = _offer(["Justin Jefferson", "Chris Olave"])["offer"]
+        self.assertEqual(offer["market_total"], 7607 + 5490)
+        self.assertEqual(offer.get("market"), MARKET_KTC)
+        for p in offer["players"]:
+            self.assertEqual(p["market_source"], MARKET_KTC)
+
+    def test_offense_only_offer_carries_no_uncertainty_band(self):
+        """No conversion and no cross-universe assumption -> no band.
+
+        This is what keeps the ``compare_packages`` certainty check
+        from suppressing the default offense-only path: a zero band
+        cannot straddle the gate.
+        """
+        offer = _offer(["Justin Jefferson", "Chris Olave"])["offer"]
+        self.assertEqual(offer.get("market_uncertainty_band"), 0)
+
+    def test_mixed_offer_carries_a_nonzero_uncertainty_band(self):
+        offer = _offer(["Brock Bowers", "Carson Schwesinger"])["offer"]
+        self.assertGreater(offer.get("market_uncertainty_band") or 0, 0)
+
+
+class TestCounterSideIsSingleMarket(unittest.TestCase):
+    def test_mixed_counter_package_total_is_single_market(self):
+        """``include_idp=True`` admits IDP into the counter pool.
+
+        Once it does, the counter combos hit exactly the same mixed-sum
+        bug the offer side had.
+        """
+        res = _offer(
+            ["Justin Jefferson", "Chris Olave"],
+            include_idp=True,
+            min_my_gain_pct=-1e9,
+            max_market_gain_pct=1e9,
+            per_team_limit=10**6,
+            limit=10**6,
+        )
+        mixed = [
+            c
+            for c in res["candidates"]
+            if {p["name"] for p in c["players"]} == {"Puka Nacua", "Fred Warner"}
+        ]
+        self.assertTrue(mixed, "expected a Nacua+Warner counter package")
+        cand = mixed[0]
+        self.assertEqual(cand["market_total"], int(round(9100 + 6200)))
+        self.assertNotEqual(cand["market_total"], int(round(9000 + 6200)))
+        self.assertEqual(cand.get("market"), MARKET_IDPTC)
+        for p in cand["players"]:
+            self.assertEqual(p["market_source"], MARKET_IDPTC)
+
+    def test_offense_only_counter_package_unchanged(self):
+        res = _offer(
+            ["Justin Jefferson", "Chris Olave"],
+            min_my_gain_pct=-1e9,
+            max_market_gain_pct=1e9,
+            per_team_limit=10**6,
+            limit=10**6,
+        )
+        pair = [
+            c
+            for c in res["candidates"]
+            if {p["name"] for p in c["players"]} == {"Puka Nacua", "Malik Nabers"}
+        ]
+        self.assertTrue(pair)
+        self.assertEqual(pair[0]["market_total"], 9000 + 8600)
+        self.assertEqual(pair[0].get("market"), MARKET_KTC)
+
+
+class TestAcquireSideIsSingleMarket(unittest.TestCase):
+    def test_mixed_acquire_side_total_is_single_market(self):
+        acq = _acquire(["Puka Nacua", "Fred Warner"])["acquire"]
+        self.assertNotEqual(acq["market_total"], int(round(9000 + 6200)))
+        self.assertEqual(acq["market_total"], int(round(9100 + 6200)))
+        self.assertEqual(acq.get("market"), MARKET_IDPTC)
+
+    def test_mixed_offer_combo_on_acquire_path_is_single_market(self):
+        res = _acquire(
+            ["Puka Nacua", "Malik Nabers"],
+            include_idp=True,
+            min_my_gain_pct=-1e9,
+            max_market_gain_pct=1e9,
+            limit=10**6,
+        )
+        mixed = [
+            c
+            for c in res["candidates"]
+            if {p["name"] for p in c["players"]} == {"Brock Bowers", "Carson Schwesinger"}
+        ]
+        self.assertTrue(mixed, "expected a Bowers+Schwesinger offer package")
+        self.assertEqual(mixed[0]["market_total"], int(round(MIXED_SINGLE_MARKET_TOTAL)))
+        self.assertNotEqual(mixed[0]["market_total"], int(round(MIXED_KTC_PLUS_IDPTC_SUM)))
+
+
+class TestVerdictCertainty(unittest.TestCase):
+    """``compare_packages`` decides whether the gate verdict survives.
+
+    Angle's ±5% gate is a threshold crossing, so a band only matters
+    relative to distance from that threshold.  Offense-only packages
+    carry a zero band and are certain by construction — that is what
+    keeps the default path untouched.  IDP-bearing ones are not.
+    """
+
+    def test_offense_only_path_is_never_withheld(self):
+        res = _offer(
+            ["Justin Jefferson", "Chris Olave"],
+            per_team_limit=10**6,
+            limit=10**6,
+        )
+        diag = res["market_diagnostics"]
+        self.assertEqual(diag["withheld_uncertain"], 0)
+        self.assertEqual(diag["unvaluable"], 0)
+        self.assertGreater(diag["combos_valued"], 0)
+
+    def test_idp_counter_at_the_gate_is_withheld_with_a_reason(self):
+        """An all-IDP counter against an all-offense offer.
+
+        The whole comparison rests on the assumed offense<->IDP
+        exchange rate, so a gain sitting a couple of points from the
+        gate is not a decision — it is a coin flip.  Withheld, counted,
+        and the reason kept where a caller can render it.
+        """
+        res = _offer(
+            ["Chris Olave"],
+            include_idp=True,
+            per_team_limit=10**6,
+            limit=10**6,
+        )
+        diag = res["market_diagnostics"]
+        self.assertGreater(diag["withheld_uncertain"], 0)
+        self.assertTrue(diag["reasons"])
+        blob = " ".join(diag["reasons"]) + " " + " ".join(res["warnings"])
+        self.assertIn("uncertainty band", blob)
+        # Withheld means withheld — the coin-flip package is absent.
+        for c in res["candidates"]:
+            self.assertNotIn("Zaven Collins", {p["name"] for p in c["players"]})
+
+    def test_fixed_side_carries_the_prose_and_candidates_do_not(self):
+        """~500 chars of measured/assumed wording, once, not 50 times.
+
+        The fixed side is where a reader looks for provenance; copying
+        it onto every candidate adds tens of KB to the response and
+        says nothing the offer block has not already said.
+        """
+        res = _offer(
+            ["Brock Bowers", "Carson Schwesinger"],
+            per_team_limit=10**6,
+            limit=10**6,
+        )
+        self.assertIn("market_warnings", res["offer"])
+        self.assertTrue(res["offer"]["market_warnings"])
+        self.assertIn("market_normalization_version", res["offer"])
+        for c in res["candidates"]:
+            self.assertNotIn("market_warnings", c)
+            self.assertIn("market", c)
+            self.assertIn("market_uncertainty_band", c)
+
+    def test_surviving_candidates_publish_their_uncertainty_range(self):
+        res = _offer(
+            ["Justin Jefferson", "Chris Olave"],
+            per_team_limit=10**6,
+            limit=10**6,
+        )
+        self.assertTrue(res["candidates"])
+        for c in res["candidates"]:
+            self.assertIn("market_gain_low_pct", c)
+            self.assertIn("market_gain_high_pct", c)
+            self.assertEqual(c["market_uncertainty_band"], 0)
+
+
+class TestUnvaluablePackagesAreNotSummed(unittest.TestCase):
+    """A package with no defensible single-market total must not get one.
+
+    Honest note on reachability: with ``allow_scalar_fallback`` left at
+    its default, ``value_package`` can only return SUPPRESSED for an
+    empty package or for an asset priced by neither board — and
+    ``angle._value_pair`` already drops any row whose own market has no
+    value, so the second case cannot arrive through the live path
+    today.  The branch is therefore defensive rather than load-bearing,
+    and these tests say so by reaching it deliberately: one through the
+    empty-offer path that IS live, one by substituting the valuation so
+    the handling itself is exercised.  The thing being pinned is that
+    the handling exists and excludes rather than silently falling back
+    to the mixed sum.
+    """
+
+    def test_empty_offer_yields_no_candidates_and_a_reason(self):
+        res = _offer(["Nobody At All"])
+        self.assertEqual(res["candidates"], [])
+        self.assertTrue(res["warnings"])
+
+    def test_suppressed_valuation_excludes_rather_than_sums(self):
+        suppressed = PackageValuation(
+            strategy=NormalizationStrategy.SUPPRESSED,
+            market=None,
+            total=None,
+            suppressed_reason="fixture: priced on neither market",
+            label="Cannot be valued on a single market",
+        )
+        original = angle_mod.value_package
+        try:
+            angle_mod.value_package = lambda rows, **kw: suppressed
+            res = _offer(
+                ["Justin Jefferson", "Chris Olave"],
+                min_my_gain_pct=-1e9,
+                max_market_gain_pct=1e9,
+                per_team_limit=10**6,
+                limit=10**6,
+            )
+        finally:
+            angle_mod.value_package = original
+        self.assertEqual(res["candidates"], [])
+        self.assertEqual(res["offer"]["market_total"], 0)
+        self.assertIsNone(res["offer"].get("market"))
+        blob = " ".join(res["warnings"])
+        self.assertIn("single market", blob.lower())
+
+    def test_unvaluable_counter_is_counted_not_dropped_silently(self):
+        """A withheld counter has to leave a trace the caller can render."""
+        suppressed = PackageValuation(
+            strategy=NormalizationStrategy.SUPPRESSED,
+            market=None,
+            total=None,
+            suppressed_reason="fixture: priced on neither market",
+            label="Cannot be valued on a single market",
+        )
+        real = angle_mod.value_package
+        calls = {"n": 0}
+
+        def _fake(rows, **kw):
+            calls["n"] += 1
+            # First call is the offer side; keep it valuable so the
+            # search proceeds and the COUNTER side is what gets
+            # suppressed.
+            return real(rows, **kw) if calls["n"] == 1 else suppressed
+
+        try:
+            angle_mod.value_package = _fake
+            res = _offer(
+                ["Justin Jefferson", "Chris Olave"],
+                min_my_gain_pct=-1e9,
+                max_market_gain_pct=1e9,
+                per_team_limit=10**6,
+                limit=10**6,
+            )
+        finally:
+            angle_mod.value_package = real
+        self.assertEqual(res["candidates"], [])
+        diag = res.get("market_diagnostics") or {}
+        self.assertGreater(diag.get("unvaluable") or 0, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`src/trade/angle.py` routed every **player** to the right board and then
totalled the **package** across both of them:

```python
counter_market_values = [p["market_value"] for p in combo]   # KTC for offense, IDPTC for IDP
market_sum = sum(counter_market_values)                       # ...added together
```

KTC (`ktcSfTep`) prices offense and picks. IDPTradeCalc (`idpTradeCalc`)
prices offense, IDP and picks. A package holding a TE and a linebacker
added a number from one board to a number from the other and produced a
total denominated in neither. `market_gain_pct` — the field the ±5%
"would the counterparty accept this?" gate reads — was computed from that
total.

All four aggregation sites are fixed:

| Site | What it was |
|---|---|
| `find_angle_packages` offer totals | `sum(_value_pair(r)[1] for r in offer_rows)` |
| `find_angle_packages` offer VA list | `sorted(float(_value_pair(r)[1]) ...)` |
| `find_angle_packages` counter combos | `[p["market_value"] for p in combo]` → `sum(...)` |
| `find_acquisition_packages` both sides | `desired_market_total` / `offer_market_values` + `offer_market_sum` |

## The fix

Package totals now go through `src/league_intel/cross_market.py`
(ADR-010) — used as-is, nothing re-implemented:

- `value_package(rows)` prices a package **entirely inside one market**
  (offense-only → `ktcSfTep`; any IDP present → `idpTradeCalc`, the only
  board spanning both universes) and returns per-asset values all
  denominated in that market. Those feed the KTC Value Adjustment step
  and the totals.
- `compare_packages(counter, offer, gate_pct=max_market_gain_pct)`
  decides whether the verdict survives its own uncertainty. Offense-only
  packages carry a zero band and are certain by construction, so the
  default path is untouched.
- A package `value_package` cannot value is **excluded, counted, and
  stamped** — never replaced with a mixed sum. `market_diagnostics`
  reports `{combos_valued, unvaluable, withheld_uncertain, reasons}` and
  both outcomes raise a user-visible warning.
- Each package and each player row is stamped with the market it was
  actually priced on (`market`, `market_strategy`,
  `market_uncertainty_band`, `market_gain_low_pct/high_pct`,
  per-player `market_source` / `market_converted`).

Two incidental cleanups in the same file, both flagged by
`cross_market.py`'s docstring as this rewire's responsibility:

- `_is_idp_position` now normalizes through `POSITION_ALIASES` before
  testing instead of matching a hand-maintained 14-spelling literal —
  the copied-list hazard that caused #556 in `finder.py`. The raw set
  survives under its old name because `server.py` imports it to parse
  un-normalized request tokens.
- A pre-existing `E402` (the `ktc_va` import sat below a module-level
  assignment) is fixed, because CI lints changed files and this file is
  now changed.

Payload: the ~500 characters of measured/assumed prose that
`value_package` attaches are stamped on the fixed side only, not
copied onto every candidate — that would have added ~25 KB to a
50-candidate IDP response for no information the offer block does not
already carry. Pinned by
`test_fixed_side_carries_the_prose_and_candidates_do_not`.

## Evidence — real league, 2026-07-26 board

Contract built from `exports/latest/dynasty_data_2026-07-26.json`
(1,095 players, 12 teams), 10 scenarios across offer and acquire mode.
Two passes per scenario: **census** (thresholds opened right up, so both
runs enumerate the identical combination set and the comparison isolates
the totals) and **gated** (production defaults: `min_my_gain_pct=5`,
`max_market_gain_pct=5`, `candidate_pool=25`, `per_team_limit=4`).

### Census — 36,799 packages, identical population before and after

| | |
|---|---|
| Packages enumerated | **36,799 → 36,799** (no change) |
| Became unvaluable | **0** |
| Needed the scalar-conversion fallback | **0** — every package resolved on the exact single-market path |
| Market totals that changed | **5,471 (14.9%)**, across 4,142 distinct packages |
| Crossed the ±5% plausibility gate in either direction | **1,463 (4.0%)** |

Swing distribution over the 4,142 distinct changed packages:
median **137 pts**, p90 **515 pts**, max **2,689 pts**; as a percentage
−7.5% to +23.4%, median **−0.43%**. 2,667 moved down, 1,475 up.

Per scenario (census):

```
scenario                                          before -> after   totals changed   gate-flip
A1 offense-only acquire                              298 ->    298                0           0
A2 mixed acquire (offense+IDP)                       298 ->    298                0           0
A3 mixed acquire, include_idp offers                 298 ->    298              118           2
A4 pure-IDP acquire, include_idp offers              298 ->    298              118           0
S1 offense-only offer (default UI path)             3278 ->   3278                0           0
S2 mixed offer TE+IDP                               3278 ->   3278                0         264
S3 mixed offer 3-player                             8591 ->   8591                0         583
S4 mixed offer 3-player, include_idp counters       8591 ->   8591             4024         593
S5 pure-IDP offer, include_idp counters             3278 ->   3278             1211          21
S8 offense-only 3-player offer                      8591 ->   8591                0           0
TOTAL                                              36799 ->  36799             5471        1463
```

Read S2/S3 carefully: their candidate totals do not move (offense-only
counters), but 264 and 583 packages still change side of the gate —
because the **offer** total they are measured against moved.

### Gated run — production defaults

263 → **207** candidates (−21%). Split by cause:

| | candidates |
|---|---|
| before | 263 |
| single-market totals only | 227 (−36) |
| + `compare_packages` certainty gate | 207 (−20) |

```
scenario                                        before  after  withheld_uncertain
A1 offense-only acquire                             27     27          0
A2 mixed acquire (offense+IDP)                      50     50        102   (28 swapped)
A3 mixed acquire, include_idp offers                50     50        378   (46 swapped)
A4 pure-IDP acquire, include_idp offers              0      0          0
S1 offense-only offer (default UI path)             23     23          0
S2 mixed offer TE+IDP                               22      5         19
S3 mixed offer 3-player                             24     11         88
S4 mixed offer 3-player, include_idp counters       20      8         97
S5 pure-IDP offer, include_idp counters             43     29        787
S8 offense-only 3-player offer                       4      4          0
```

**Every offense-only scenario is byte-identical before and after** — same
count, same packages, same totals, nothing withheld. The change is
confined to packages that actually span both universes, which is the
correct blast radius.

### Worked example 1 — the offer side (deterministic)

Offer `Brock Bowers + Carson Schwesinger` from Jason's roster:

| Asset | Pos | KTC | IDPTC | Old contribution | New contribution |
|---|---|---|---|---|---|
| Brock Bowers | TE | 9,882 | 8,975 | **9,882** (KTC) | **8,975** (IDPTC) |
| Carson Schwesinger | LB | — | 5,667 | **5,667** (IDPTC) | **5,667** (IDPTC) |
| **Offer market total** | | | | **15,549** (no board) | **14,642** (`idpTradeCalc`) |

−907 pts, −5.83%. The gap is the TE premium: `ktcSfTep` is a TE++ board
and `POSITION_SCALE_RATIOS["TE"]` is the measured 0.895. A 5.8%
overstatement fed straight into a gate whose whole width is 5%.

### Worked example 2 — the counter side (largest swing measured)

Counter `Aidan Hutchinson + Patrick Mahomes + Tetairoa McMillan + Travis Hunter`:

| Asset | Pos | KTC | IDPTC | Old | New |
|---|---|---|---|---|---|
| Aidan Hutchinson | DL | — | 6,444 | 6,444 | 6,444 |
| Patrick Mahomes | QB | 6,380 | 6,672 | 6,380 | 6,672 |
| Tetairoa McMillan | WR | 6,381 | 6,485 | 6,381 | 6,485 |
| Travis Hunter | WR | 3,344 | 5,637 | **3,344** | **5,637** |
| **Total** | | | | **22,549** | **25,238** |

+2,689 pts, +11.9%, and 85% of it is Travis Hunter. KTC prices only his
offensive side; IDPTC prices the whole two-way player. Under the old sum
the package was priced as if he were a WR-only asset while the defender
next to him was priced on the board that knows better.

## Failing-test output (against `origin/main` @ `ae3042935`)

New file `tests/trade/test_angle_single_market.py`, run on unmodified
main in a clean worktree before any fix existed:

```
$ python3 -m pytest tests/trade/test_angle_single_market.py -q
FFFFFFFFFFFFFF.FF                                                        [100%]

E       AssertionError: 15549 == 15549 : offer market_total is the KTC+IDPTC mixed sum
E       AssertionError: 15549 != 14642
E       AssertionError: 'ktcSfTep' != 'idpTradeCalc'
E       AssertionError: 15200 != 15300
E       AssertionError: 15200 == 15200
E       AssertionError: None != 'ktcSfTep'
E       AssertionError: None != 0
E       KeyError: 'market_diagnostics'
E       AttributeError: module 'src.trade.angle' has no attribute 'value_package'

16 failed, 1 passed in 0.23s
```

The one that passed is the empty-offer case, which already behaved.

The three required invariants are covered:
- mixed offense+IDP package must not produce a two-board total —
  `test_mixed_offer_total_is_not_the_two_board_sum`,
  `test_mixed_counter_package_total_is_single_market`,
  `test_mixed_acquire_side_total_is_single_market`,
  `test_mixed_offer_combo_on_acquire_path_is_single_market`
- offense-only still values on `ktcSfTep` —
  `test_offense_only_offer_still_values_on_ktc`,
  `test_offense_only_counter_package_unchanged`
- unresolvable → reported unvaluable, not summed —
  `TestUnvaluablePackagesAreNotSummed`

Fixtures use the real 2026-07-26 board rather than round numbers on
purpose: a QB/WR fixture passes either way, because the pooled
offense IDPTC/KTC ratio is 0.9997. Only the genuinely divergent rows
(TE, two-way players, IDP) can tell the two implementations apart.

## Five pre-existing tests in `tests/test_trade_angle.py` were edited

Not silently:

- `test_packages_player_rows_expose_per_position_market_source` →
  `..._expose_package_market_source`. `market_source` now names the
  market the **package** was priced on, so a fixture carrying only the
  retired legacy `ktc` key now reports `ktcSfTep`. Same market; the UI
  renders both as "KTC".
- Four IDP tests (`test_acquire_idp_target_compares_on_idptc`,
  `test_packages_idp_included_when_flag_set`,
  `test_packages_idp_filter_does_not_touch_seed_players`,
  `test_acquire_idp_excluded_from_offer_pool_by_default`) had
  `max_market_gain_pct` widened past the offense↔IDP uncertainty band.
  Each pins an **IDP pool-gating** behaviour, not a market verdict, and
  each still asserts exactly what it always asserted — the first one now
  asserts the IDPTC totals directly (5,100 not 7,000) rather than
  inferring board choice from mere acceptance, which is strictly
  stronger.

## Things worth arguing with

**1. `src/roster_intel/packages.py` does not exist.** The brief says it
already consumes `cross_market`. It does not exist on any branch, and
`cross_market.py`'s own docstring agrees: *"The honest count of
production importers of THIS file is zero."* This PR is the first
production consumer, so the module's behaviour has never reached a user
before now and there is no second call site to keep consistent.

**2. The `unvaluable` branch is defensive, not load-bearing — 0 hits on
the real league.** `angle._value_pair` already drops any row with no
value on its own position's board, so by the time rows reach
`value_package` every one of them is priced on at least one market.
With the scalar fallback at its default, `SUPPRESSED` is then reachable
only for an empty package. Measured: 36,799 packages, **zero**
unvaluable, **zero** scalar conversions. The handling is implemented and
tested anyway (the brief requires it, and it is the correct thing to do
if the upstream gate ever loosens), but it is honest to say it changes
no current answer. The tests reach it by substituting the valuation and
say so in their docstring.

**3. The straddle gate costs 20 of the 56 lost candidates, and one slice
of that is a known over-correction.** `cross_market._shared_scale_band`
documents that a **pure-IDP vs pure-IDP** comparison should have the
exchange rate cancel, but a package cannot see the other side of the
comparison so the band is sized wide anyway. That case is now reachable
here. Measured impact on the real league: the one scenario that is
pure-IDP on both sides (A4) returned **0 candidates before and after**,
so it cost nothing in practice — but it does explain why two synthetic
IDP tests needed a wider gate. The module says the real fix is to size
the band inside `compare_packages`, where both compositions are visible.
Deliberately not done here: it changes a shared module with its own test
suite, for a case that currently moves no answers.

**4. What this does NOT fix.** Each side is valued inside one market,
but the two sides can still land on **different** markets (offense-only
offer on KTC vs IDP-bearing counter on IDPTC). That is the comparison
`compare_packages` is designed to take, and it is defensible because the
boards are measured to share a scale (pooled ratio 0.9997, Spearman
0.990, n=476); the residual is exactly what the IDP side's
`uncertainty_band` carries into the straddle check. Forcing both sides
onto one board needs a `market=` argument `value_package` does not
expose, and inventing one here would put a second single-market
implementation in the tree.

**5. `find_angles` (the 1-for-1 pivot) is untouched.** It compares two
single assets, so there is no cross-market *sum* to constrain. It does
compare a KTC number to an IDPTC one when the positions differ — the
same cross-side comparison as (4), accepted for the same measured
reason.

**6. The same defect exists a second time, in the frontend.**
`frontend/app/angle/page.jsx::totalsFor` (~line 278) sums
`market_value` across the user's selection using its own per-position
`marketSourceForPos`, and renders it as *"Offer total: N my · M
market"* before submit. It is the identical mixed-board sum. Not fixed
here: the correct total requires the backend, and reimplementing
single-market valuation in JS is exactly what this repo's
"no frontend ranking engine" rule forbids. The authoritative number is
already shown post-submit in `FixedSidePanel`. Flagging it rather than
scope-creeping into it.

## Performance

Faster, not slower, despite adding a valuation per package. The
my-value gate — pure arithmetic on values already in hand, and the gate
that rejects the overwhelming majority of combos — now runs before the
market valuation instead of after. Both gates are conjunctive so the
result is identical. Full harness over the real league:
**27.1s → 18.7s**.

## Validation

- `python -m ruff` 0.6.9: `ruff check` clean on changed files (also
  clears the pre-existing E402), `ruff format --check .` clean
  repo-wide.
- Full suite on the final tree, exactly as the brief specifies:

  ```
  $ python -m pytest tests/ -q -m "not livedata"
  3944 passed, 325 deselected, 1 warning, 4 subtests passed in 439.32s (0:07:19)
  ```

  Run completed (summary line present, exit 0), zero `FAILED` lines.
  That run was on this branch rebased onto `ae3042935`; main has since
  moved one commit to `74d5c556b`, which changes only
  `.github/workflows/public-league-warmup.yml` (#575) and cannot affect
  pytest. Rebased onto it and re-ran the touched suites —
  `tests/test_trade_angle.py tests/trade/ tests/league_intel/`,
  610 passed.
- `git diff --stat origin/main HEAD` shows only `src/trade/angle.py`,
  `tests/test_trade_angle.py`, `tests/trade/test_angle_single_market.py`.
